### PR TITLE
feat(dashboard): read-only symbol side-panel for the open file (IDE #6472)

### DIFF
--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -357,13 +357,18 @@ describe('FileBrowserPanel — symbol panel (#6472)', () => {
 
   it('scrolls the viewer to a symbol line on click', async () => {
     const scrollSpy = vi.fn()
+    const prevScrollIntoView = (Element.prototype as any).scrollIntoView
     ;(Element.prototype as any).scrollIntoView = scrollSpy // jsdom lacks it
-    await openFile({ ide: true, symbols: SNAPSHOT })
-    const item = await screen.findByTestId('symbol-item-doThing')
-    fireEvent.click(item)
-    expect(scrollSpy).toHaveBeenCalled()
-    const line = document.querySelector('[data-line="5"]')
-    expect(line?.classList.contains('file-viewer-line--active')).toBe(true)
+    try {
+      await openFile({ ide: true, symbols: SNAPSHOT })
+      const item = await screen.findByTestId('symbol-item-doThing')
+      fireEvent.click(item)
+      expect(scrollSpy).toHaveBeenCalled()
+      const line = document.querySelector('[data-line="5"]')
+      expect(line?.classList.contains('file-viewer-line--active')).toBe(true)
+    } finally {
+      ;(Element.prototype as any).scrollIntoView = prevScrollIntoView
+    }
   })
 
   it('shows no symbol panel and sends no request when the ide capability is off', async () => {

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -9,23 +9,32 @@ import { FileBrowserPanel } from './FileBrowserPanel'
 const mockRequestFileListing = vi.fn()
 const mockRequestFileContent = vi.fn()
 const mockRequestGitStatus = vi.fn()
+const mockRequestSymbols = vi.fn()
 let fileBrowserCallback: ((listing: any) => void) | null = null
 let fileContentCallback: ((content: any) => void) | null = null
 let gitStatusCallback: ((result: any) => void) | null = null
 
 let mockSessionStates: Record<string, any> = {}
 let mockActiveSessionId: string | null = 's1'
+// #6472 symbol-panel store state
+let mockSymbols: any = null
+let mockSymbolsLoading = false
+let mockIdeCapability = false
 
 vi.mock('../store/connection', () => {
   const storeState = () => ({
     requestFileListing: mockRequestFileListing,
     requestFileContent: mockRequestFileContent,
     requestGitStatus: mockRequestGitStatus,
+    requestSymbols: mockRequestSymbols,
     setFileBrowserCallback: (cb: any) => { fileBrowserCallback = cb },
     setFileContentCallback: (cb: any) => { fileContentCallback = cb },
     setGitStatusCallback: (cb: any) => { gitStatusCallback = cb },
     activeSessionId: mockActiveSessionId,
     sessionStates: mockSessionStates,
+    symbols: mockSymbols,
+    symbolsLoading: mockSymbolsLoading,
+    serverCapabilities: { ide: mockIdeCapability },
   })
 
   const useConnectionStore = Object.assign(
@@ -59,6 +68,9 @@ beforeEach(() => {
   gitStatusCallback = null
   mockSessionStates = {}
   mockActiveSessionId = 's1'
+  mockSymbols = null
+  mockSymbolsLoading = false
+  mockIdeCapability = false
 })
 
 describe('FileBrowserPanel', () => {
@@ -285,5 +297,79 @@ describe('FileBrowserPanel', () => {
 
     // Should request file content for the saved path on mount
     expect(mockRequestFileContent).toHaveBeenCalledWith('/home/user/project/index.ts')
+  })
+})
+
+describe('FileBrowserPanel — symbol panel (#6472)', () => {
+  const SNAPSHOT = {
+    path: 'foo.ts',
+    truncated: false,
+    error: null,
+    symbols: [
+      { name: 'doThing', kind: 'function', file: 'foo.ts', line: 5, exported: true },
+      { name: 'helper', kind: 'function', file: 'foo.ts', line: 9, exported: false },
+      { name: 'Widget', kind: 'class', file: 'foo.ts', line: 14, exported: true },
+    ],
+  }
+
+  // Render the panel, load a root listing with one file, click it, and land its
+  // content — so the file viewer (and, when ide is on, the symbol panel) shows.
+  async function openFile(opts: { ide: boolean; symbols?: any }) {
+    mockIdeCapability = opts.ide
+    mockSymbols = opts.symbols ?? null
+    render(<FileBrowserPanel />)
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root',
+        parentPath: null,
+        entries: [{ name: 'foo.ts', isDirectory: false, size: 200 }],
+        error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('foo.ts'))
+    fireEvent.click(screen.getByText('foo.ts'))
+    act(() => {
+      fileContentCallback!({
+        content: Array.from({ length: 20 }, (_, i) => `const v${i} = ${i}`).join('\n'),
+        language: 'typescript',
+        size: 200,
+        truncated: false,
+        error: null,
+      })
+    })
+  }
+
+  it('requests symbols scoped to the file when the ide capability is on', async () => {
+    await openFile({ ide: true, symbols: SNAPSHOT })
+    expect(mockRequestSymbols).toHaveBeenCalledWith('foo.ts')
+  })
+
+  it('renders the open file symbols grouped by kind', async () => {
+    await openFile({ ide: true, symbols: SNAPSHOT })
+    await waitFor(() => {
+      expect(screen.getByTestId('symbol-panel')).toBeTruthy()
+      expect(screen.getByTestId('symbol-group-function')).toBeTruthy()
+      expect(screen.getByTestId('symbol-group-class')).toBeTruthy()
+      expect(screen.getByTestId('symbol-item-doThing')).toBeTruthy()
+      expect(screen.getByTestId('symbol-item-Widget')).toBeTruthy()
+    })
+  })
+
+  it('scrolls the viewer to a symbol line on click', async () => {
+    const scrollSpy = vi.fn()
+    ;(Element.prototype as any).scrollIntoView = scrollSpy // jsdom lacks it
+    await openFile({ ide: true, symbols: SNAPSHOT })
+    const item = await screen.findByTestId('symbol-item-doThing')
+    fireEvent.click(item)
+    expect(scrollSpy).toHaveBeenCalled()
+    const line = document.querySelector('[data-line="5"]')
+    expect(line?.classList.contains('file-viewer-line--active')).toBe(true)
+  })
+
+  it('shows no symbol panel and sends no request when the ide capability is off', async () => {
+    await openFile({ ide: false, symbols: SNAPSHOT })
+    await waitFor(() => screen.getByLabelText('Close file')) // file is open
+    expect(screen.queryByTestId('symbol-panel')).toBeNull()
+    expect(mockRequestSymbols).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useConnectionStore } from '../store/connection'
 import { tokenize } from '@chroxy/store-core'
 import type { FileEntry, FileListing, FileContent, GitStatusResult } from '../store/types'
+import type { SymbolEntry } from '@chroxy/protocol'
 
 /** File icon by extension */
 function fileIcon(name: string, isDirectory: boolean): string {
@@ -121,6 +122,61 @@ function FileTreeItem({ entry, currentPath, rootPath, gitStatusMap, onNavigate, 
   )
 }
 
+/** Single-glyph badge per symbol kind (open string — falls back to a dot). */
+const SYMBOL_KIND_ICON: Record<string, string> = {
+  function: 'ƒ', method: 'ƒ', class: 'C', interface: 'I',
+  type: 'T', enum: 'E', const: 'k', variable: 'v',
+}
+
+interface SymbolsListProps {
+  groups: [string, SymbolEntry[]][]
+  loading: boolean
+  onPick: (line: number) => void
+}
+
+/**
+ * #6472 — read-only symbol list for the open file, grouped by kind. Clicking a
+ * symbol scrolls the viewer to its (1-indexed) line via `onPick`. No per-symbol
+ * backend call — renders the cached `symbols_snapshot` from the store.
+ */
+function SymbolsList({ groups, loading, onPick }: SymbolsListProps) {
+  if (loading && groups.length === 0) {
+    return <div className="symbol-panel-status" data-testid="symbol-panel-loading">Loading symbols…</div>
+  }
+  if (groups.length === 0) {
+    return <div className="symbol-panel-status" data-testid="symbol-panel-empty">No symbols</div>
+  }
+  return (
+    <div className="symbol-panel" data-testid="symbol-panel">
+      {groups.map(([kind, syms]) => (
+        <div key={kind} className="symbol-group">
+          <div className="symbol-group-kind" data-testid={`symbol-group-${kind}`}>
+            {kind}<span className="symbol-group-count">{syms.length}</span>
+          </div>
+          <ul className="symbol-list" role="list">
+            {syms.map((s, i) => (
+              <li key={`${s.name}-${s.line}-${i}`}>
+                <button
+                  type="button"
+                  className="symbol-item"
+                  data-testid={`symbol-item-${s.name}`}
+                  onClick={() => onPick(s.line)}
+                  title={`${s.kind} · line ${s.line}`}
+                >
+                  <span className="symbol-item-icon" aria-hidden="true">{SYMBOL_KIND_ICON[s.kind] ?? '•'}</span>
+                  <span className="symbol-item-name">{s.name}</span>
+                  {s.exported && <span className="symbol-item-exported" title="exported">↗</span>}
+                  <span className="symbol-item-line">{s.line}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function FileBrowserPanel() {
   const requestFileListing = useConnectionStore(s => s.requestFileListing)
   const requestFileContent = useConnectionStore(s => s.requestFileContent)
@@ -128,6 +184,11 @@ export function FileBrowserPanel() {
   const setFileBrowserCallback = useConnectionStore(s => s.setFileBrowserCallback)
   const setFileContentCallback = useConnectionStore(s => s.setFileContentCallback)
   const setGitStatusCallback = useConnectionStore(s => s.setGitStatusCallback)
+  // #6472 — opt-in IDE symbol panel (gated on the server's `ide` capability).
+  const requestSymbols = useConnectionStore(s => s.requestSymbols)
+  const symbolsSnapshot = useConnectionStore(s => s.symbols)
+  const symbolsLoading = useConnectionStore(s => s.symbolsLoading)
+  const ideEnabled = useConnectionStore(s => s.serverCapabilities.ide === true)
   const [currentPath, setCurrentPath] = useState<string | null>(null)
   const [entries, setEntries] = useState<FileEntry[]>([])
   const [parentPath, setParentPath] = useState<string | null>(null)
@@ -163,6 +224,10 @@ export function FileBrowserPanel() {
 
   const [gitStatus, setGitStatus] = useState<GitStatusResult | null>(null)
   const rootPath = useRef<string | null>(null)
+  const viewerRef = useRef<HTMLDivElement>(null)
+  // The workspace-relative path we last asked symbols for; matched against the
+  // snapshot's echoed `path` so we only render symbols for the open file.
+  const [symbolScope, setSymbolScope] = useState<string | null>(null)
 
   // Register callbacks
   useEffect(() => {
@@ -214,6 +279,7 @@ export function FileBrowserPanel() {
     setFileTruncated(false)
     setFileError(null)
     setGitStatus(null)
+    setSymbolScope(null)
     rootPath.current = null
 
     // Restore selected file from session state
@@ -251,7 +317,13 @@ export function FileBrowserPanel() {
     setFileError(null)
     setFileContent(null)
     requestFileContent(path)
-  }, [requestFileContent])
+    // #6472 — also pull the file's symbols (opt-in; the server fail-closes if off).
+    if (ideEnabled && rootPath.current) {
+      const rel = relativePath(path, rootPath.current)
+      setSymbolScope(rel)
+      requestSymbols(rel)
+    }
+  }, [requestFileContent, ideEnabled, requestSymbols])
 
   const handleBack = useCallback(() => {
     if (parentPath) {
@@ -264,6 +336,29 @@ export function FileBrowserPanel() {
     setSelectedFile(null)
     setFileContent(null)
     setFileError(null)
+    setSymbolScope(null)
+  }, [])
+
+  // #6472 — group the open file's symbols by kind for the read-only panel. Only
+  // render when the snapshot's echoed `path` matches the file we asked about.
+  const groupedSymbols = useMemo<[string, SymbolEntry[]][]>(() => {
+    if (!symbolsSnapshot || !symbolScope || symbolsSnapshot.path !== symbolScope) return []
+    const byKind = new Map<string, SymbolEntry[]>()
+    for (const sym of symbolsSnapshot.symbols) {
+      const arr = byKind.get(sym.kind)
+      if (arr) arr.push(sym)
+      else byKind.set(sym.kind, [sym])
+    }
+    return [...byKind.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1))
+  }, [symbolsSnapshot, symbolScope])
+
+  // Scroll the viewer to a 1-indexed line and briefly highlight it.
+  const scrollToLine = useCallback((line: number) => {
+    const el = viewerRef.current?.querySelector<HTMLElement>(`[data-line="${line}"]`)
+    if (!el) return
+    el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    el.classList.add('file-viewer-line--active')
+    window.setTimeout(() => el.classList.remove('file-viewer-line--active'), 1400)
   }, [])
 
   // Breadcrumbs from currentPath relative to root
@@ -378,7 +473,10 @@ export function FileBrowserPanel() {
               &times;
             </button>
           </div>
-          <div className="file-viewer-content">
+          {ideEnabled && fileContent !== null && fileLanguage !== 'image' && (
+            <SymbolsList groups={groupedSymbols} loading={symbolsLoading} onPick={scrollToLine} />
+          )}
+          <div className="file-viewer-content" ref={viewerRef}>
             {fileLoading && <div className="file-viewer-loading">Loading file...</div>}
             {!fileLoading && fileError && <div className="file-viewer-error">{fileError}</div>}
             {!fileLoading && !fileError && fileContent !== null && fileLanguage === 'image' && (
@@ -395,7 +493,7 @@ export function FileBrowserPanel() {
                 <code>
                   {highlightedLines
                     ? highlightedLines.map((tokens, lineIdx) => (
-                        <span key={lineIdx} className="file-viewer-line">
+                        <span key={lineIdx} className="file-viewer-line" data-line={lineIdx + 1}>
                           <span className="file-viewer-line-num">{lineIdx + 1}</span>
                           {tokens.map((tok, tokIdx) => (
                             <span key={tokIdx} className={`syn-${tok.type}`}>{tok.text}</span>

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -228,6 +228,9 @@ export function FileBrowserPanel() {
   // The workspace-relative path we last asked symbols for; matched against the
   // snapshot's echoed `path` so we only render symbols for the open file.
   const [symbolScope, setSymbolScope] = useState<string | null>(null)
+  // Dedup guard so the request effect fires once per open file (not on every
+  // directory navigation), while still covering the restore-on-mount case.
+  const lastSymbolReq = useRef<string | null>(null)
 
   // Register callbacks
   useEffect(() => {
@@ -280,6 +283,7 @@ export function FileBrowserPanel() {
     setFileError(null)
     setGitStatus(null)
     setSymbolScope(null)
+    lastSymbolReq.current = null
     rootPath.current = null
 
     // Restore selected file from session state
@@ -317,13 +321,7 @@ export function FileBrowserPanel() {
     setFileError(null)
     setFileContent(null)
     requestFileContent(path)
-    // #6472 — also pull the file's symbols (opt-in; the server fail-closes if off).
-    if (ideEnabled && rootPath.current) {
-      const rel = relativePath(path, rootPath.current)
-      setSymbolScope(rel)
-      requestSymbols(rel)
-    }
-  }, [requestFileContent, ideEnabled, requestSymbols])
+  }, [requestFileContent])
 
   const handleBack = useCallback(() => {
     if (parentPath) {
@@ -337,7 +335,22 @@ export function FileBrowserPanel() {
     setFileContent(null)
     setFileError(null)
     setSymbolScope(null)
+    lastSymbolReq.current = null
   }, [])
+
+  // #6472 — request the open file's symbols once the workspace root is known.
+  // Single request site: fires when a file is selected AND when the listing lands
+  // (`currentPath`), so a file restored from session state on mount/tab-switch —
+  // where root isn't known at select time — also gets its symbols. Opt-in: the
+  // server fail-closes when features.ide is off, so we gate on ideEnabled.
+  useEffect(() => {
+    if (!selectedFile || !ideEnabled || !rootPath.current) return
+    const rel = relativePath(selectedFile, rootPath.current)
+    if (lastSymbolReq.current === rel) return
+    lastSymbolReq.current = rel
+    setSymbolScope(rel)
+    requestSymbols(rel)
+  }, [selectedFile, currentPath, ideEnabled, requestSymbols])
 
   // #6472 — group the open file's symbols by kind for the read-only panel. Only
   // render when the snapshot's echoed `path` matches the file we asked about.

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3604,6 +3604,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #6472 (epic #6469) — request the opt-in IDE symbol table. The server is
+  // fail-closed when features.ide is off, so the UI gates the affordance on
+  // serverCapabilities.ide (never spin symbolsLoading waiting on a reply that
+  // won't come). `path` scopes the scan to one file/dir; omitted ⇒ whole workspace.
+  requestSymbols: (path?: string) => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ symbolsLoading: true });
+      const msg: Record<string, unknown> = { type: 'list_symbols' };
+      if (path) msg.path = path;
+      if (activeSessionId) msg.sessionId = activeSessionId;
+      wsSend(socket, msg);
+    }
+  },
+
   // Git status
 
   setGitStatusCallback: (cb) => {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1389,6 +1389,9 @@ export interface ConnectionState {
   setFileContentCallback: (cb: ((content: FileContent) => void) | null) => void;
   requestFileListing: (path?: string) => void;
   requestFileContent: (path: string) => void;
+  // #6472 (epic #6469) — request the opt-in IDE symbol table, optionally scoped
+  // to one file/dir. Sets symbolsLoading; the reply lands in `symbols`.
+  requestSymbols: (path?: string) => void;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8094,6 +8094,67 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.5;
 }
 
+/* #6472 — read-only symbol panel (opt-in IDE surface) + scroll-target highlight */
+.file-viewer-line--active {
+  background: var(--accent-subtle, rgba(124, 156, 255, 0.18));
+  transition: background 0.3s ease;
+}
+
+.symbol-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  padding: 6px 12px;
+  max-height: 30%;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  font-size: 12px;
+}
+
+.symbol-panel-status {
+  padding: 6px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.symbol-group { min-width: 0; }
+
+.symbol-group-kind {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  padding: 2px 0;
+}
+.symbol-group-count { margin-left: 4px; opacity: 0.6; }
+
+.symbol-list { list-style: none; margin: 0; padding: 0; }
+
+.symbol-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-align: left;
+}
+.symbol-item:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+
+.symbol-item-icon { width: 14px; text-align: center; color: var(--text-muted); flex-shrink: 0; }
+.symbol-item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.symbol-item-exported { color: var(--success-fg, #4ade80); flex-shrink: 0; }
+.symbol-item-line { margin-left: auto; color: var(--text-muted); opacity: 0.6; flex-shrink: 0; }
+
 /* Syntax token colors */
 .syn-keyword { color: #c4a5ff; }
 .syn-string { color: #4eca6a; }


### PR DESCRIPTION
## Summary

IDE epic (#6469) Phase-1: a read-only **symbol side-panel** that renders the `list_symbols` feed landed in #6471. When a file is open (and the server advertises the opt-in `ide` capability), the file viewer shows the file's symbols grouped by kind; clicking a symbol scrolls the viewer to its line.

Builds directly on #6471 — that PR wired the receive path (`handleSymbolsSnapshot` → `store.symbols`); this adds the **sender** and the **UI**.

## What changed

- **store** (`connection.ts` + `types.ts`) — `requestSymbols(path?)` action: sets `symbolsLoading` and sends `list_symbols` (scoped to the open file). The reply is handled by #6471's `handleSymbolsSnapshot`.
- **`FileBrowserPanel.tsx`** — on file open, requests the file's symbols (workspace-relative path); renders them grouped by kind in a strip above the code; clicking a symbol scrolls the viewer to its 1-indexed line (`data-line` anchors + a transient highlight). Gated on `serverCapabilities.ide` — no affordance and no request when the flag is off (so `symbolsLoading` never spins on a fail-closed server). The snapshot's echoed `path` is matched to the requested scope so a previous file's table never flashes.
- **`components.css`** — `symbol-panel` styles + the scroll-target highlight (reuses existing tokens; grandfathered file, hex-lint clean).

## Acceptance (#6472)
- [x] Side-panel renders symbols grouped by kind
- [x] Click scrolls the file viewer to the symbol line
- [x] New dashboard test

## Validation (this Mac, Node 22)
- Dashboard typecheck: **pass**
- `FileBrowserPanel.test.tsx`: **15 pass** (4 new: scoped request, grouped render, click-scroll, off-when-capability-off)
- **Full dashboard suite: 4092 pass** (no regressions from the store change)
- Production Vite build: **clean**; raw-color hex-lint: **pass**

Closes #6472