### PR TITLE
feat(dashboard): Cmd+P quick-open file palette (IDE #6473)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -67,6 +67,7 @@ import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
 import { useInterventionPing } from './hooks/useInterventionPing'
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
+import { FileOpenPalette } from './components/FileOpenPalette'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { useTunnelReady } from './hooks/useTunnelReady'
 import { useQrModal } from './hooks/useQrModal'
@@ -158,6 +159,8 @@ export function App() {
   // shell" affordance on it means paired devices / disabled hosts never see a
   // dead button.
   const userShellSupported = useConnectionStore(s => s.serverCapabilities?.userShell === true)
+  // #6473 — gate the Cmd+P quick-open palette on the opt-in `ide` capability.
+  const ideEnabled = useConnectionStore(s => s.serverCapabilities?.ide === true)
   // #6006 — the operator panic button (Revoke token) is available only when the
   // server has a rotating TokenManager (auth on) AND this client holds the
   // primary token, both reflected in the `tokenRevoke` capability. Gating on it
@@ -603,6 +606,7 @@ export function App() {
   // Command palette
   const commands = useCommands(isPtyProvider)
   const [paletteOpen, setPaletteOpen] = useState(false)
+  const [fileOpenPaletteOpen, setFileOpenPaletteOpen] = useState(false)
 
   // Local state
   const [showCreateSession, setShowCreateSession] = useState(false)
@@ -988,6 +992,7 @@ export function App() {
     sendInterrupt,
     setPermissionMode,
     appendImageAttachments,
+    openFilePalette: () => { if (ideEnabled) setFileOpenPaletteOpen(true) },
   })
 
   const trackedCommands = useMemo(
@@ -2595,6 +2600,10 @@ export function App() {
         paletteOpen={paletteOpen}
         onPaletteClose={() => setPaletteOpen(false)}
         mruList={paletteOpen ? getMruCommands() : undefined}
+      />
+      <FileOpenPalette
+        isOpen={fileOpenPaletteOpen}
+        onClose={() => setFileOpenPaletteOpen(false)}
       />
     </div>
   )

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -20,6 +20,7 @@ let mockActiveSessionId: string | null = 's1'
 let mockSymbols: any = null
 let mockSymbolsLoading = false
 let mockIdeCapability = false
+let mockFileBrowserPendingOpen: any = null
 
 vi.mock('../store/connection', () => {
   const storeState = () => ({
@@ -35,6 +36,7 @@ vi.mock('../store/connection', () => {
     symbols: mockSymbols,
     symbolsLoading: mockSymbolsLoading,
     serverCapabilities: { ide: mockIdeCapability },
+    fileBrowserPendingOpen: mockFileBrowserPendingOpen,
   })
 
   const useConnectionStore = Object.assign(
@@ -71,6 +73,7 @@ beforeEach(() => {
   mockSymbols = null
   mockSymbolsLoading = false
   mockIdeCapability = false
+  mockFileBrowserPendingOpen = null
 })
 
 describe('FileBrowserPanel', () => {
@@ -376,5 +379,15 @@ describe('FileBrowserPanel — symbol panel (#6472)', () => {
     await waitFor(() => screen.getByLabelText('Close file')) // file is open
     expect(screen.queryByTestId('symbol-panel')).toBeNull()
     expect(mockRequestSymbols).not.toHaveBeenCalled()
+  })
+})
+
+describe('FileBrowserPanel — external open (#6473 Cmd+P)', () => {
+  it('opens a file requested via fileBrowserPendingOpen', () => {
+    mockFileBrowserPendingOpen = { path: '/root/deep/thing.ts', nonce: 1 }
+    render(<FileBrowserPanel />)
+    // The pending-open effect fires on mount → loads the file into the viewer.
+    expect(mockRequestFileContent).toHaveBeenCalledWith('/root/deep/thing.ts')
+    expect(screen.getByLabelText('Close file')).toBeTruthy()
   })
 })

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -189,6 +189,7 @@ export function FileBrowserPanel() {
   const symbolsSnapshot = useConnectionStore(s => s.symbols)
   const symbolsLoading = useConnectionStore(s => s.symbolsLoading)
   const ideEnabled = useConnectionStore(s => s.serverCapabilities.ide === true)
+  const fileBrowserPendingOpen = useConnectionStore(s => s.fileBrowserPendingOpen)
   const [currentPath, setCurrentPath] = useState<string | null>(null)
   const [entries, setEntries] = useState<FileEntry[]>([])
   const [parentPath, setParentPath] = useState<string | null>(null)
@@ -322,6 +323,13 @@ export function FileBrowserPanel() {
     setFileContent(null)
     requestFileContent(path)
   }, [requestFileContent])
+
+  // #6473 — open a file requested externally (Cmd+P quick-open); reuse the click
+  // path so it persists the selection, loads content, and triggers the symbols
+  // request. Keyed on the nonce object so repeated opens of the same path fire.
+  useEffect(() => {
+    if (fileBrowserPendingOpen) handleFileClick(fileBrowserPendingOpen.path)
+  }, [fileBrowserPendingOpen, handleFileClick])
 
   const handleBack = useCallback(() => {
     if (parentPath) {

--- a/packages/dashboard/src/components/FileOpenPalette.test.tsx
+++ b/packages/dashboard/src/components/FileOpenPalette.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * FileOpenPalette — tests for the Cmd+P quick-open file palette (#6473).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { FileOpenPalette } from './FileOpenPalette'
+
+const mockFetchFileList = vi.fn()
+const mockOpenFileInBrowser = vi.fn()
+let mockFiles: any = null
+
+vi.mock('../store/connection', () => {
+  const storeState = () => ({
+    fetchFileList: mockFetchFileList,
+    filePickerFiles: mockFiles,
+    openFileInBrowser: mockOpenFileInBrowser,
+  })
+  const useConnectionStore = Object.assign(
+    (selector: any) => selector(storeState()),
+    { getState: () => storeState(), setState: () => {} },
+  )
+  return { useConnectionStore }
+})
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFiles = [
+    { path: 'src/index.ts', type: 'file', size: 100 },
+    { path: 'src/App.tsx', type: 'file', size: 200 },
+    { path: 'README.md', type: 'file', size: 50 },
+  ]
+})
+
+describe('FileOpenPalette (#6473)', () => {
+  it('does not render when closed', () => {
+    render(<FileOpenPalette isOpen={false} onClose={() => {}} />)
+    expect(screen.queryByTestId('file-open-palette')).toBeNull()
+    expect(mockFetchFileList).not.toHaveBeenCalled()
+  })
+
+  it('fetches the file list and renders files when opened', async () => {
+    render(<FileOpenPalette isOpen={true} onClose={() => {}} />)
+    expect(mockFetchFileList).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getByTestId('file-open-palette-input')).toBeTruthy()
+      expect(screen.getByTestId('file-open-item-src/index.ts')).toBeTruthy()
+      expect(screen.getByTestId('file-open-item-README.md')).toBeTruthy()
+    })
+  })
+
+  it('filters files by the typed query', async () => {
+    render(<FileOpenPalette isOpen={true} onClose={() => {}} />)
+    const input = await screen.findByTestId('file-open-palette-input')
+    fireEvent.change(input, { target: { value: 'readme' } })
+    await waitFor(() => {
+      expect(screen.getByTestId('file-open-item-README.md')).toBeTruthy()
+      expect(screen.queryByTestId('file-open-item-src/index.ts')).toBeNull()
+    })
+  })
+
+  it('opens the first file on Enter and closes', async () => {
+    const onClose = vi.fn()
+    render(<FileOpenPalette isOpen={true} onClose={onClose} />)
+    const input = await screen.findByTestId('file-open-palette-input')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/index.ts')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('arrow-down then Enter opens the second file', async () => {
+    const onClose = vi.fn()
+    render(<FileOpenPalette isOpen={true} onClose={onClose} />)
+    const input = await screen.findByTestId('file-open-palette-input')
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/App.tsx')
+  })
+
+  it('opens a file on click', async () => {
+    const onClose = vi.fn()
+    render(<FileOpenPalette isOpen={true} onClose={onClose} />)
+    const item = await screen.findByTestId('file-open-item-README.md')
+    fireEvent.mouseDown(item)
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('README.md')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on Escape without opening a file', async () => {
+    const onClose = vi.fn()
+    render(<FileOpenPalette isOpen={true} onClose={onClose} />)
+    const input = await screen.findByTestId('file-open-palette-input')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+    expect(mockOpenFileInBrowser).not.toHaveBeenCalled()
+  })
+
+  it('shows an empty state when the filter matches nothing', async () => {
+    render(<FileOpenPalette isOpen={true} onClose={() => {}} />)
+    const input = await screen.findByTestId('file-open-palette-input')
+    fireEvent.change(input, { target: { value: 'zzz-no-match' } })
+    await waitFor(() => expect(screen.getByTestId('file-open-palette-empty')).toBeTruthy())
+  })
+})

--- a/packages/dashboard/src/components/FileOpenPalette.tsx
+++ b/packages/dashboard/src/components/FileOpenPalette.tsx
@@ -1,0 +1,123 @@
+/**
+ * FileOpenPalette — Cmd+P quick-open (#6473, IDE epic #6469).
+ *
+ * A fuzzy file palette over the existing `list_files` backend: opening it fetches
+ * the workspace file list (bounded, server-side), the input filters by path
+ * substring, and Enter opens the selected file in the FileBrowserPanel viewer
+ * (via the `openFileInBrowser` store action, which switches to the Files view).
+ *
+ * Gated by the caller on the opt-in `ide` capability — App only opens it when the
+ * server advertises `features.ide`.
+ */
+import { useState, useEffect, useMemo, useRef, useCallback, type KeyboardEvent } from 'react'
+import { useConnectionStore } from '../store/connection'
+
+export interface FileOpenPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const DISPLAY_CAP = 200
+
+export function FileOpenPalette({ isOpen, onClose }: FileOpenPaletteProps) {
+  const fetchFileList = useConnectionStore(s => s.fetchFileList)
+  const files = useConnectionStore(s => s.filePickerFiles)
+  const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // On open: pull the (bounded) workspace file list, reset, and focus the input.
+  useEffect(() => {
+    if (!isOpen) return
+    fetchFileList()
+    setQuery('')
+    setSelectedIndex(0)
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0)
+    return () => window.clearTimeout(id)
+  }, [isOpen, fetchFileList])
+
+  const filtered = useMemo(() => {
+    if (!files) return []
+    if (!query) return files
+    const lower = query.toLowerCase()
+    return files.filter(f => f.path.toLowerCase().includes(lower))
+  }, [files, query])
+
+  // Keep the selection in range as the filter narrows.
+  useEffect(() => {
+    setSelectedIndex(i => (filtered.length === 0 ? 0 : Math.min(i, filtered.length - 1)))
+  }, [filtered.length])
+
+  // Keep the highlighted row in view.
+  useEffect(() => {
+    const items = listRef.current?.querySelectorAll('[role="option"]')
+    const el = items?.[selectedIndex] as HTMLElement | undefined
+    el?.scrollIntoView?.({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const openAt = useCallback((idx: number) => {
+    const f = filtered[idx]
+    if (f) {
+      openFileInBrowser(f.path)
+      onClose()
+    }
+  }, [filtered, openFileInBrowser, onClose])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, filtered.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIndex(i => Math.max(i - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); openAt(selectedIndex) }
+  }, [filtered.length, selectedIndex, openAt, onClose])
+
+  if (!isOpen) return null
+
+  const overflow = filtered.length > DISPLAY_CAP ? filtered.length - DISPLAY_CAP : 0
+  const display = overflow > 0 ? filtered.slice(0, DISPLAY_CAP) : filtered
+  const loading = files === null
+
+  return (
+    <div
+      className="file-open-palette-overlay"
+      data-modal-overlay
+      data-testid="file-open-palette"
+      onKeyDown={handleKeyDown}
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="file-open-palette" role="dialog" aria-label="Go to file">
+        <input
+          ref={inputRef}
+          className="file-open-palette-input"
+          type="text"
+          placeholder="Go to file…"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0) }}
+          data-testid="file-open-palette-input"
+          aria-label="Go to file"
+        />
+        <div ref={listRef} className="file-open-palette-list" role="listbox" aria-label="Files">
+          {loading && <div className="file-open-palette-status">Loading files…</div>}
+          {!loading && filtered.length === 0 && (
+            <div className="file-open-palette-status" data-testid="file-open-palette-empty">No files found</div>
+          )}
+          {display.map((file, i) => (
+            <div
+              key={file.path}
+              role="option"
+              aria-selected={i === selectedIndex}
+              className={`file-open-palette-item${i === selectedIndex ? ' selected' : ''}`}
+              data-testid={`file-open-item-${file.path}`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onMouseDown={(e) => { e.preventDefault(); openAt(i) }}
+            >
+              <span className="file-open-palette-path">{file.path}</span>
+            </div>
+          ))}
+          {overflow > 0 && <div className="file-open-palette-status">{overflow} more…</div>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -69,6 +69,9 @@ export interface ShortcutDispatchProps {
   sendInterrupt: () => void
   setPermissionMode: (mode: string) => void
   appendImageAttachments: (attachments: ImageAttachment[]) => void
+  // #6473 — open the Cmd+P quick-open file palette (the caller gates it on the
+  // `ide` capability). Optional so existing call sites / tests keep working.
+  openFilePalette?: () => void
 }
 
 export function useShortcutDispatch(props: ShortcutDispatchProps): void {
@@ -92,6 +95,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     sendInterrupt,
     setPermissionMode,
     appendImageAttachments,
+    openFilePalette,
   } = props
 
   useEffect(() => {
@@ -200,6 +204,9 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
           case 'palette.toggle':
           case 'palette.toggle.vscode':
             setPaletteOpen(prev => !prev)
+            break
+          case 'file.openPalette':
+            openFilePalette?.()
             break
           case 'sidebar.toggle':
             setSidebarOpen(prev => !prev)

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -55,6 +55,15 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
     scope: 'global',
   },
   {
+    // #6473 (IDE epic #6469) — Cmd+P fuzzy file quick-open. Opens only when the
+    // server advertises the opt-in `ide` capability (gated in App).
+    id: 'file.openPalette',
+    defaultBinding: 'cmd+p',
+    description: 'Quick open file',
+    category: 'navigation',
+    scope: 'global',
+  },
+  {
     id: 'sidebar.toggle',
     defaultBinding: 'cmd+b',
     description: 'Toggle sidebar',

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -654,6 +654,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   pendingPermissionConfirm: null,
   slashCommands: [],
   filePickerFiles: null,
+  fileBrowserPendingOpen: null,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2481,6 +2482,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       pendingPermissionConfirm: null,
       slashCommands: [],
       filePickerFiles: null,
+  fileBrowserPendingOpen: null,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3617,6 +3619,23 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (activeSessionId) msg.sessionId = activeSessionId;
       wsSend(socket, msg);
     }
+  },
+
+  // #6473 — open a file in the FileBrowserPanel viewer. Persist the selection,
+  // switch to the Files view, and bump fileBrowserPendingOpen so the panel opens
+  // it even when the view is already mounted. Used by Cmd+P quick-open.
+  openFileInBrowser: (path: string) => {
+    const { activeSessionId, sessionStates, setViewMode } = get();
+    if (activeSessionId && sessionStates[activeSessionId]) {
+      set({
+        sessionStates: {
+          ...sessionStates,
+          [activeSessionId]: { ...sessionStates[activeSessionId], selectedFilePath: path },
+        },
+      });
+    }
+    set((s) => ({ fileBrowserPendingOpen: { path, nonce: (s.fileBrowserPendingOpen?.nonce ?? 0) + 1 } }));
+    setViewMode('files');
   },
 
   // Git status

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1193,6 +1193,9 @@ export interface ConnectionState {
 
   // File picker items from list_files
   filePickerFiles: FilePickerItem[] | null;
+  // #6473 — a Cmd+P quick-open request the FileBrowserPanel watches: open this
+  // path in the viewer. The nonce lets repeated opens of the same path re-fire.
+  fileBrowserPendingOpen: { path: string; nonce: number } | null;
 
   // Custom agents from server
   customAgents: CustomAgent[];
@@ -1392,6 +1395,9 @@ export interface ConnectionState {
   // #6472 (epic #6469) — request the opt-in IDE symbol table, optionally scoped
   // to one file/dir. Sets symbolsLoading; the reply lands in `symbols`.
   requestSymbols: (path?: string) => void;
+  // #6473 — open a file in the FileBrowserPanel viewer (switches to the Files view
+  // and signals the panel via fileBrowserPendingOpen). Used by Cmd+P quick-open.
+  openFileInBrowser: (path: string) => void;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4672,6 +4672,70 @@ button.sidebar-token-view-session-row:hover {
   border-top: 1px solid var(--banner-border-subtle);
 }
 
+/* #6473 — Cmd+P quick-open file palette (mirrors the command-palette overlay) */
+.file-open-palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  justify-content: center;
+  padding-top: 15vh;
+  background: rgba(15, 15, 26, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.file-open-palette {
+  width: min(640px, 92vw);
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.file-open-palette-input {
+  border: none;
+  border-bottom: 1px solid var(--border-primary);
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  padding: 12px 14px;
+  outline: none;
+}
+.file-open-palette-input::placeholder { color: var(--text-muted); }
+
+.file-open-palette-list {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.file-open-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.file-open-palette-item.selected,
+.file-open-palette-item:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+
+.file-open-palette-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.file-open-palette-status {
+  padding: 12px 14px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
 /* Attachment chips row */
 .attachment-chips {
   display: flex;


### PR DESCRIPTION
## Summary

IDE epic (#6469) Phase-1: a global **Cmd+P** fuzzy file quick-open palette, over the **existing `list_files` backend** (no new backend). Type to filter by path; Enter (or click) opens the file in the FileBrowserPanel viewer. Gated on the opt-in `ide` capability — no palette when the flag is off.

## What changed

- **store** (`connection.ts` + `types.ts`) — `openFileInBrowser(path)` action + `fileBrowserPendingOpen` field. It persists the selection, `setViewMode('files')`, and bumps a nonce so the panel opens the file even when the Files view is already mounted.
- **`FileBrowserPanel.tsx`** — a reactive effect on `fileBrowserPendingOpen` that reuses the click path (loads content + triggers the #6472 symbol request).
- **shortcut** — `file.openPalette` (`cmd+p`) registered in `shortcuts/defaults.ts` + a dispatch case in `useShortcutDispatch.ts`; `App.tsx` gates it on `serverCapabilities.ide` and mounts the palette. `e.preventDefault()` in the dispatcher suppresses the browser print dialog.
- **`FileOpenPalette.tsx`** (new) — overlay + input + client-side fuzzy filter + keyboard nav (arrows / Enter / Esc), reading `filePickerFiles` from the existing `list_files` → `file_list` flow.
- **`components.css`** — palette styles mirroring the command-palette overlay (existing tokens; hex-lint clean).

## Acceptance (#6473)
- [x] Cmd+P opens a fuzzy file palette; Enter opens the file
- [x] Backed by the existing `list_files` query param (no new backend)

## Validation (this Mac, Node 22)
- Dashboard typecheck: **pass**
- New tests: `FileOpenPalette.test.tsx` (8) + a `FileBrowserPanel` reactive-open test → **9 new, all pass**
- **Full dashboard suite: 4101 pass** (no regressions from the shortcut-hook change)
- Production Vite build: **clean**; raw-color hex-lint: **pass**

Note: found that #6474 (Cmd+Shift+F grep) is NOT a "quick win" as the roadmap gauge claimed — there's no content-search backend, so it needs one. Filed as context for that issue.

Closes #6473