### PR TITLE
feat(dashboard): Cmd+Shift+O fuzzy symbol search + jump-to-definition (IDE #6476)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -68,6 +68,7 @@ import { usePermissionNotification, type PermissionPromptInfo } from './hooks/us
 import { useInterventionPing } from './hooks/useInterventionPing'
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { FileOpenPalette } from './components/FileOpenPalette'
+import { SymbolSearchPalette } from './components/SymbolSearchPalette'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { useTunnelReady } from './hooks/useTunnelReady'
 import { useQrModal } from './hooks/useQrModal'
@@ -607,6 +608,7 @@ export function App() {
   const commands = useCommands(isPtyProvider)
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [fileOpenPaletteOpen, setFileOpenPaletteOpen] = useState(false)
+  const [symbolSearchOpen, setSymbolSearchOpen] = useState(false)
 
   // Local state
   const [showCreateSession, setShowCreateSession] = useState(false)
@@ -993,6 +995,7 @@ export function App() {
     setPermissionMode,
     appendImageAttachments,
     openFilePalette: () => { if (ideEnabled) setFileOpenPaletteOpen(true) },
+    openSymbolSearch: () => { if (ideEnabled) setSymbolSearchOpen(true) },
   })
 
   const trackedCommands = useMemo(
@@ -2604,6 +2607,10 @@ export function App() {
       <FileOpenPalette
         isOpen={fileOpenPaletteOpen}
         onClose={() => setFileOpenPaletteOpen(false)}
+      />
+      <SymbolSearchPalette
+        isOpen={symbolSearchOpen}
+        onClose={() => setSymbolSearchOpen(false)}
       />
     </div>
   )

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -390,4 +390,23 @@ describe('FileBrowserPanel — external open (#6473 Cmd+P)', () => {
     expect(mockRequestFileContent).toHaveBeenCalledWith('/root/deep/thing.ts')
     expect(screen.getByLabelText('Close file')).toBeTruthy()
   })
+
+  it('scrolls to the requested line after the file loads (#6476 jump-to-def)', async () => {
+    const scrollSpy = vi.fn()
+    const prev = (Element.prototype as any).scrollIntoView
+    ;(Element.prototype as any).scrollIntoView = scrollSpy // jsdom lacks it
+    try {
+      mockFileBrowserPendingOpen = { path: '/root/x.ts', line: 3, nonce: 1 }
+      render(<FileBrowserPanel />)
+      // Content lands → lines render with data-line anchors → deferred scroll fires.
+      act(() => {
+        fileContentCallback!({
+          content: 'l1\nl2\nl3\nl4\nl5', language: 'typescript', size: 10, truncated: false, error: null,
+        })
+      })
+      await waitFor(() => expect(scrollSpy).toHaveBeenCalled())
+    } finally {
+      ;(Element.prototype as any).scrollIntoView = prev
+    }
+  })
 })

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -226,6 +226,9 @@ export function FileBrowserPanel() {
   const [gitStatus, setGitStatus] = useState<GitStatusResult | null>(null)
   const rootPath = useRef<string | null>(null)
   const viewerRef = useRef<HTMLDivElement>(null)
+  // #6476 — a 1-indexed line to scroll to once the externally-opened file's
+  // content has rendered (symbol-search "jump to definition").
+  const pendingScrollLine = useRef<number | null>(null)
   // The workspace-relative path we last asked symbols for; matched against the
   // snapshot's echoed `path` so we only render symbols for the open file.
   const [symbolScope, setSymbolScope] = useState<string | null>(null)
@@ -328,7 +331,10 @@ export function FileBrowserPanel() {
   // path so it persists the selection, loads content, and triggers the symbols
   // request. Keyed on the nonce object so repeated opens of the same path fire.
   useEffect(() => {
-    if (fileBrowserPendingOpen) handleFileClick(fileBrowserPendingOpen.path)
+    if (!fileBrowserPendingOpen) return
+    handleFileClick(fileBrowserPendingOpen.path)
+    // #6476 — remember the jump-to line; the scroll fires once content renders.
+    pendingScrollLine.current = fileBrowserPendingOpen.line ?? null
   }, [fileBrowserPendingOpen, handleFileClick])
 
   const handleBack = useCallback(() => {
@@ -381,6 +387,17 @@ export function FileBrowserPanel() {
     el.classList.add('file-viewer-line--active')
     window.setTimeout(() => el.classList.remove('file-viewer-line--active'), 1400)
   }, [])
+
+  // #6476 — once an externally-opened file's content has rendered, scroll to the
+  // requested jump-to line (symbol-search "jump to definition"). Deferred a tick
+  // so the freshly-rendered `data-line` rows are in the DOM.
+  useEffect(() => {
+    if (pendingScrollLine.current == null || fileContent == null) return
+    const line = pendingScrollLine.current
+    pendingScrollLine.current = null
+    const id = window.setTimeout(() => scrollToLine(line), 0)
+    return () => window.clearTimeout(id)
+  }, [fileContent, scrollToLine])
 
   // Breadcrumbs from currentPath relative to root
   const breadcrumbs = useMemo(() => {

--- a/packages/dashboard/src/components/SymbolSearchPalette.test.tsx
+++ b/packages/dashboard/src/components/SymbolSearchPalette.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../store/connection', () => {
   const storeState = () => ({
     requestWorkspaceSymbols: mockRequestWorkspaceSymbols,
     workspaceSymbols: mockWorkspaceSymbols,
+    workspaceSymbolsLoading: false,
     openFileInBrowser: mockOpenFileInBrowser,
   })
   const useConnectionStore = Object.assign(

--- a/packages/dashboard/src/components/SymbolSearchPalette.test.tsx
+++ b/packages/dashboard/src/components/SymbolSearchPalette.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * SymbolSearchPalette — tests for the Cmd+Shift+O fuzzy symbol search (#6476).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { SymbolSearchPalette } from './SymbolSearchPalette'
+
+const mockRequestWorkspaceSymbols = vi.fn()
+const mockOpenFileInBrowser = vi.fn()
+let mockWorkspaceSymbols: any = null
+
+vi.mock('../store/connection', () => {
+  const storeState = () => ({
+    requestWorkspaceSymbols: mockRequestWorkspaceSymbols,
+    workspaceSymbols: mockWorkspaceSymbols,
+    openFileInBrowser: mockOpenFileInBrowser,
+  })
+  const useConnectionStore = Object.assign(
+    (selector: any) => selector(storeState()),
+    { getState: () => storeState(), setState: () => {} },
+  )
+  return { useConnectionStore }
+})
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockWorkspaceSymbols = {
+    path: null, truncated: false, error: null,
+    symbols: [
+      { name: 'parseSymbols', kind: 'function', file: 'src/ide/symbols.js', line: 42, exported: true },
+      { name: 'Widget', kind: 'class', file: 'src/ui/Widget.tsx', line: 10, exported: true },
+      { name: 'helper', kind: 'function', file: 'src/util.ts', line: 5, exported: false },
+    ],
+  }
+})
+
+describe('SymbolSearchPalette (#6476)', () => {
+  it('does not render when closed', () => {
+    render(<SymbolSearchPalette isOpen={false} onClose={() => {}} />)
+    expect(screen.queryByTestId('symbol-search-palette')).toBeNull()
+    expect(mockRequestWorkspaceSymbols).not.toHaveBeenCalled()
+  })
+
+  it('requests the workspace symbols and renders them when opened', async () => {
+    render(<SymbolSearchPalette isOpen={true} onClose={() => {}} />)
+    expect(mockRequestWorkspaceSymbols).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getByTestId('symbol-search-item-parseSymbols')).toBeTruthy()
+      expect(screen.getByTestId('symbol-search-item-Widget')).toBeTruthy()
+    })
+  })
+
+  it('filters symbols by the typed query', async () => {
+    render(<SymbolSearchPalette isOpen={true} onClose={() => {}} />)
+    const input = await screen.findByTestId('symbol-search-input')
+    fireEvent.change(input, { target: { value: 'widget' } })
+    await waitFor(() => {
+      expect(screen.getByTestId('symbol-search-item-Widget')).toBeTruthy()
+      expect(screen.queryByTestId('symbol-search-item-parseSymbols')).toBeNull()
+    })
+  })
+
+  it('jumps to file:line on Enter (opens the file at the symbol line)', async () => {
+    const onClose = vi.fn()
+    render(<SymbolSearchPalette isOpen={true} onClose={onClose} />)
+    const input = await screen.findByTestId('symbol-search-input')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/ide/symbols.js', 42)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('arrow-down then Enter jumps to the second symbol', async () => {
+    render(<SymbolSearchPalette isOpen={true} onClose={() => {}} />)
+    const input = await screen.findByTestId('symbol-search-input')
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/ui/Widget.tsx', 10)
+  })
+
+  it('jumps on click', async () => {
+    const onClose = vi.fn()
+    render(<SymbolSearchPalette isOpen={true} onClose={onClose} />)
+    const item = await screen.findByTestId('symbol-search-item-helper')
+    fireEvent.mouseDown(item)
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/util.ts', 5)
+  })
+
+  it('closes on Escape without jumping', async () => {
+    const onClose = vi.fn()
+    render(<SymbolSearchPalette isOpen={true} onClose={onClose} />)
+    const input = await screen.findByTestId('symbol-search-input')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+    expect(mockOpenFileInBrowser).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/SymbolSearchPalette.tsx
+++ b/packages/dashboard/src/components/SymbolSearchPalette.tsx
@@ -28,6 +28,7 @@ const SYMBOL_KIND_ICON: Record<string, string> = {
 export function SymbolSearchPalette({ isOpen, onClose }: SymbolSearchPaletteProps) {
   const requestWorkspaceSymbols = useConnectionStore(s => s.requestWorkspaceSymbols)
   const snapshot = useConnectionStore(s => s.workspaceSymbols)
+  const loading = useConnectionStore(s => s.workspaceSymbolsLoading)
   const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -53,7 +54,7 @@ export function SymbolSearchPalette({ isOpen, onClose }: SymbolSearchPaletteProp
   }, [symbols, query])
 
   useEffect(() => {
-    setSelectedIndex(i => (filtered.length === 0 ? 0 : Math.min(i, filtered.length - 1)))
+    setSelectedIndex(i => (filtered.length === 0 ? 0 : Math.min(i, Math.min(filtered.length, DISPLAY_CAP) - 1)))
   }, [filtered.length])
 
   useEffect(() => {
@@ -72,7 +73,7 @@ export function SymbolSearchPalette({ isOpen, onClose }: SymbolSearchPaletteProp
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') { e.preventDefault(); onClose() }
-    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, filtered.length - 1)) }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, Math.min(filtered.length, DISPLAY_CAP) - 1)) }
     else if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIndex(i => Math.max(i - 1, 0)) }
     else if (e.key === 'Enter') { e.preventDefault(); openAt(selectedIndex) }
   }, [filtered.length, selectedIndex, openAt, onClose])
@@ -81,7 +82,10 @@ export function SymbolSearchPalette({ isOpen, onClose }: SymbolSearchPaletteProp
 
   const overflow = filtered.length > DISPLAY_CAP ? filtered.length - DISPLAY_CAP : 0
   const display = overflow > 0 ? filtered.slice(0, DISPLAY_CAP) : filtered
-  const isLoading = symbols === null
+  // #6476 review — show "Indexing…" while a (re)scan is in flight so a reopen never
+  // renders the previous scan's table as if it were fresh (workspaceSymbolsLoading
+  // is set on request, cleared on snapshot).
+  const isLoading = loading || symbols === null
 
   return (
     <div

--- a/packages/dashboard/src/components/SymbolSearchPalette.tsx
+++ b/packages/dashboard/src/components/SymbolSearchPalette.tsx
@@ -1,0 +1,130 @@
+/**
+ * SymbolSearchPalette — Cmd+Shift+O fuzzy symbol search (#6476, IDE epic #6469).
+ *
+ * Opening it requests the whole-workspace symbol table (a path-less `list_symbols`
+ * scan, landing in `workspaceSymbols`); the input fuzzy-filters by symbol name and
+ * Enter jumps to the symbol's file:line — `openFileInBrowser(file, line)` opens the
+ * file in the viewer and scrolls to the line.
+ *
+ * Gated by the caller on the opt-in `ide` capability. Reuses the file-open-palette
+ * chrome (CSS) + the symbol-item glyph/line styles.
+ */
+import { useState, useEffect, useMemo, useRef, useCallback, type KeyboardEvent } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { SymbolEntry } from '@chroxy/protocol'
+
+export interface SymbolSearchPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const DISPLAY_CAP = 200
+
+const SYMBOL_KIND_ICON: Record<string, string> = {
+  function: 'ƒ', method: 'ƒ', class: 'C', interface: 'I',
+  type: 'T', enum: 'E', const: 'k', variable: 'v',
+}
+
+export function SymbolSearchPalette({ isOpen, onClose }: SymbolSearchPaletteProps) {
+  const requestWorkspaceSymbols = useConnectionStore(s => s.requestWorkspaceSymbols)
+  const snapshot = useConnectionStore(s => s.workspaceSymbols)
+  const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    requestWorkspaceSymbols()
+    setQuery('')
+    setSelectedIndex(0)
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0)
+    return () => window.clearTimeout(id)
+  }, [isOpen, requestWorkspaceSymbols])
+
+  const symbols = snapshot?.symbols ?? null
+
+  const filtered = useMemo<SymbolEntry[]>(() => {
+    if (!symbols) return []
+    if (!query) return symbols
+    const lower = query.toLowerCase()
+    return symbols.filter(s => s.name.toLowerCase().includes(lower))
+  }, [symbols, query])
+
+  useEffect(() => {
+    setSelectedIndex(i => (filtered.length === 0 ? 0 : Math.min(i, filtered.length - 1)))
+  }, [filtered.length])
+
+  useEffect(() => {
+    const items = listRef.current?.querySelectorAll('[role="option"]')
+    const el = items?.[selectedIndex] as HTMLElement | undefined
+    el?.scrollIntoView?.({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const openAt = useCallback((idx: number) => {
+    const s = filtered[idx]
+    if (s) {
+      openFileInBrowser(s.file, s.line)
+      onClose()
+    }
+  }, [filtered, openFileInBrowser, onClose])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, filtered.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIndex(i => Math.max(i - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); openAt(selectedIndex) }
+  }, [filtered.length, selectedIndex, openAt, onClose])
+
+  if (!isOpen) return null
+
+  const overflow = filtered.length > DISPLAY_CAP ? filtered.length - DISPLAY_CAP : 0
+  const display = overflow > 0 ? filtered.slice(0, DISPLAY_CAP) : filtered
+  const isLoading = symbols === null
+
+  return (
+    <div
+      className="file-open-palette-overlay"
+      data-modal-overlay
+      data-testid="symbol-search-palette"
+      onKeyDown={handleKeyDown}
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="file-open-palette" role="dialog" aria-label="Search symbols">
+        <input
+          ref={inputRef}
+          className="file-open-palette-input"
+          type="text"
+          placeholder="Search symbols…"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0) }}
+          data-testid="symbol-search-input"
+          aria-label="Search symbols"
+        />
+        <div ref={listRef} className="file-open-palette-list" role="listbox" aria-label="Symbols">
+          {isLoading && <div className="file-open-palette-status">Indexing symbols…</div>}
+          {!isLoading && filtered.length === 0 && (
+            <div className="file-open-palette-status" data-testid="symbol-search-empty">No symbols</div>
+          )}
+          {display.map((s, i) => (
+            <div
+              key={`${s.file}:${s.line}:${s.name}:${i}`}
+              role="option"
+              aria-selected={i === selectedIndex}
+              className={`file-open-palette-item${i === selectedIndex ? ' selected' : ''}`}
+              data-testid={`symbol-search-item-${s.name}`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onMouseDown={(e) => { e.preventDefault(); openAt(i) }}
+            >
+              <span className="symbol-item-icon" aria-hidden="true">{SYMBOL_KIND_ICON[s.kind] ?? '•'}</span>
+              <span className="file-open-palette-path">{s.name}</span>
+              <span className="symbol-item-line">{s.file.split('/').pop()}:{s.line}</span>
+            </div>
+          ))}
+          {overflow > 0 && <div className="file-open-palette-status">{overflow} more…</div>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -72,6 +72,8 @@ export interface ShortcutDispatchProps {
   // #6473 — open the Cmd+P quick-open file palette (the caller gates it on the
   // `ide` capability). Optional so existing call sites / tests keep working.
   openFilePalette?: () => void
+  // #6476 — open the Cmd+Shift+O symbol-search palette (caller gates on `ide`).
+  openSymbolSearch?: () => void
 }
 
 export function useShortcutDispatch(props: ShortcutDispatchProps): void {
@@ -96,6 +98,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     setPermissionMode,
     appendImageAttachments,
     openFilePalette,
+    openSymbolSearch,
   } = props
 
   useEffect(() => {
@@ -207,6 +210,9 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
             break
           case 'file.openPalette':
             openFilePalette?.()
+            break
+          case 'symbol.search':
+            openSymbolSearch?.()
             break
           case 'sidebar.toggle':
             setSidebarOpen(prev => !prev)

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -64,6 +64,14 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
     scope: 'global',
   },
   {
+    // #6476 (IDE epic #6469) — Cmd+Shift+O fuzzy symbol search. Gated on `ide` in App.
+    id: 'symbol.search',
+    defaultBinding: 'cmd+shift+o',
+    description: 'Search symbols',
+    category: 'navigation',
+    scope: 'global',
+  },
+  {
     id: 'sidebar.toggle',
     defaultBinding: 'cmd+b',
     description: 'Toggle sidebar',

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -655,6 +655,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   slashCommands: [],
   filePickerFiles: null,
   fileBrowserPendingOpen: null,
+  workspaceSymbols: null,
+  workspaceSymbolsLoading: false,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2483,6 +2485,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       slashCommands: [],
       filePickerFiles: null,
   fileBrowserPendingOpen: null,
+  workspaceSymbols: null,
+  workspaceSymbolsLoading: false,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3624,7 +3628,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #6473 — open a file in the FileBrowserPanel viewer. Persist the selection,
   // switch to the Files view, and bump fileBrowserPendingOpen so the panel opens
   // it even when the view is already mounted. Used by Cmd+P quick-open.
-  openFileInBrowser: (path: string) => {
+  openFileInBrowser: (path: string, line?: number) => {
     const { activeSessionId, sessionStates, setViewMode } = get();
     if (activeSessionId && sessionStates[activeSessionId]) {
       set({
@@ -3634,8 +3638,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         },
       });
     }
-    set((s) => ({ fileBrowserPendingOpen: { path, nonce: (s.fileBrowserPendingOpen?.nonce ?? 0) + 1 } }));
+    set((s) => ({ fileBrowserPendingOpen: { path, line, nonce: (s.fileBrowserPendingOpen?.nonce ?? 0) + 1 } }));
     setViewMode('files');
+  },
+
+  // #6476 — request the whole-workspace symbol table (no path scope) for the
+  // symbol-search modal. Fail-closed server-side when features.ide is off; the UI
+  // gates the affordance on serverCapabilities.ide.
+  requestWorkspaceSymbols: () => {
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ workspaceSymbolsLoading: true });
+      const msg: Record<string, unknown> = { type: 'list_symbols' };
+      if (activeSessionId) msg.sessionId = activeSessionId;
+      wsSend(socket, msg);
+    }
   },
 
   // Git status

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2549,7 +2549,14 @@ function handleHostStatusSnapshot(msg: Record<string, unknown>, _get: MsgGet, se
 function handleSymbolsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerSymbolsSnapshotSchema.safeParse(msg);
   if (!parsed.success) return;
-  set({ symbols: parsed.data, symbolsLoading: false });
+  // #6476 — a whole-workspace scan (path === null) feeds the symbol-search modal;
+  // a file-scoped scan feeds the per-file symbol panel (#6472). Route accordingly
+  // so the two symbol surfaces never clobber each other's table.
+  if (parsed.data.path === null) {
+    set({ workspaceSymbols: parsed.data, workspaceSymbolsLoading: false });
+  } else {
+    set({ symbols: parsed.data, symbolsLoading: false });
+  }
 }
 
 /**

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2551,11 +2551,13 @@ function handleSymbolsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: 
   if (!parsed.success) return;
   // #6476 — a whole-workspace scan (path === null) feeds the symbol-search modal;
   // a file-scoped scan feeds the per-file symbol panel (#6472). Route accordingly
-  // so the two symbol surfaces never clobber each other's table.
+  // so the two symbol surfaces never clobber each other's table. Clear BOTH loading
+  // flags in either branch so a mis-routed request (e.g. a path-less requestSymbols)
+  // can never leave the other surface's loading flag stuck on.
   if (parsed.data.path === null) {
-    set({ workspaceSymbols: parsed.data, workspaceSymbolsLoading: false });
+    set({ workspaceSymbols: parsed.data, workspaceSymbolsLoading: false, symbolsLoading: false });
   } else {
-    set({ symbols: parsed.data, symbolsLoading: false });
+    set({ symbols: parsed.data, symbolsLoading: false, workspaceSymbolsLoading: false });
   }
 }
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1396,8 +1396,9 @@ export interface ConnectionState {
   setFileContentCallback: (cb: ((content: FileContent) => void) | null) => void;
   requestFileListing: (path?: string) => void;
   requestFileContent: (path: string) => void;
-  // #6472 (epic #6469) — request the opt-in IDE symbol table, optionally scoped
-  // to one file/dir. Sets symbolsLoading; the reply lands in `symbols`.
+  // #6472 (epic #6469) — request the per-file/dir IDE symbol table (pass a `path`).
+  // Sets symbolsLoading; the reply lands in `symbols`. NOTE: a path-less scan routes
+  // to `workspaceSymbols` instead (#6476) — use requestWorkspaceSymbols for that.
   requestSymbols: (path?: string) => void;
   // #6473 — open a file in the FileBrowserPanel viewer (switches to the Files view
   // and signals the panel via fileBrowserPendingOpen). Used by Cmd+P quick-open.

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1195,7 +1195,11 @@ export interface ConnectionState {
   filePickerFiles: FilePickerItem[] | null;
   // #6473 — a Cmd+P quick-open request the FileBrowserPanel watches: open this
   // path in the viewer. The nonce lets repeated opens of the same path re-fire.
-  fileBrowserPendingOpen: { path: string; nonce: number } | null;
+  fileBrowserPendingOpen: { path: string; line?: number; nonce: number } | null;
+  // #6476 — whole-workspace symbol table for the symbol-search modal (a path===null
+  // snapshot). Separate from the per-file `symbols` (#6472) so they don't clobber.
+  workspaceSymbols: ServerSymbolsSnapshotMessage | null;
+  workspaceSymbolsLoading: boolean;
 
   // Custom agents from server
   customAgents: CustomAgent[];
@@ -1397,7 +1401,10 @@ export interface ConnectionState {
   requestSymbols: (path?: string) => void;
   // #6473 — open a file in the FileBrowserPanel viewer (switches to the Files view
   // and signals the panel via fileBrowserPendingOpen). Used by Cmd+P quick-open.
-  openFileInBrowser: (path: string) => void;
+  // #6476 — optional `line` scrolls the viewer to that 1-indexed line after load.
+  openFileInBrowser: (path: string, line?: number) => void;
+  // #6476 — request the whole-workspace symbol table for the symbol-search modal.
+  requestWorkspaceSymbols: () => void;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;


### PR DESCRIPTION
## Summary

IDE epic (#6469) Phase-2: a global **Cmd+Shift+O** modal that fuzzy-searches the **whole-workspace symbol table** and **jumps to the symbol's file:line**. Gated on the opt-in `ide` capability. Reuses the #6473 palette chrome + `openFileInBrowser`.

## What changed

- **store** — `requestWorkspaceSymbols()` sends a path-less `list_symbols`; `handleSymbolsSnapshot` routes a `path===null` snapshot to a new **`workspaceSymbols`** field so the modal never clobbers the per-file symbol panel's `symbols` (#6472). `openFileInBrowser(path, line?)` gained an optional line, and FileBrowserPanel scrolls to it once the file's content renders (a deferred `data-line` lookup + the existing highlight).
- **`SymbolSearchPalette.tsx`** (new) — overlay + client-side fuzzy filter by symbol name + keyboard nav (arrows / Enter / Esc), reusing the `file-open-palette` CSS + symbol-item glyph/line styles. Enter/click → `openFileInBrowser(file, line)`.
- **shortcut** — `symbol.search` (`cmd+shift+o`) in `shortcuts/defaults.ts` + a dispatch case; `App.tsx` gates it on `serverCapabilities.ide` and mounts the modal.

## Acceptance (#6476)
- [x] Modal fuzzy-searches the workspace symbol table
- [x] Enter jumps to the symbol's file:line

## Validation (this Mac, Node 22)
- Dashboard typecheck: **pass**
- New tests: `SymbolSearchPalette.test.tsx` (7) + a FileBrowserPanel jump-to-line scroll test → **all pass**
- **Full dashboard suite: 4109 pass** (no regressions)
- Production Vite build: **clean** (reused CSS — no new styles)

Closes #6476