### PR TITLE
feat(ide): go-to-definition — resolve_symbol + cmd/ctrl+click jump (#6475)

### DIFF
--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -10,6 +10,10 @@ const mockRequestFileListing = vi.fn()
 const mockRequestFileContent = vi.fn()
 const mockRequestGitStatus = vi.fn()
 const mockRequestSymbols = vi.fn()
+// #6475 go-to-definition
+const mockRequestResolveSymbol = vi.fn()
+const mockOpenFileInBrowser = vi.fn()
+let mockSymbolLocation: any = null
 let fileBrowserCallback: ((listing: any) => void) | null = null
 let fileContentCallback: ((content: any) => void) | null = null
 let gitStatusCallback: ((result: any) => void) | null = null
@@ -37,6 +41,9 @@ vi.mock('../store/connection', () => {
     symbolsLoading: mockSymbolsLoading,
     serverCapabilities: { ide: mockIdeCapability },
     fileBrowserPendingOpen: mockFileBrowserPendingOpen,
+    requestResolveSymbol: mockRequestResolveSymbol,
+    openFileInBrowser: mockOpenFileInBrowser,
+    symbolLocation: mockSymbolLocation,
   })
 
   const useConnectionStore = Object.assign(
@@ -74,6 +81,7 @@ beforeEach(() => {
   mockSymbolsLoading = false
   mockIdeCapability = false
   mockFileBrowserPendingOpen = null
+  mockSymbolLocation = null
 })
 
 describe('FileBrowserPanel', () => {
@@ -408,5 +416,75 @@ describe('FileBrowserPanel — external open (#6473 Cmd+P)', () => {
     } finally {
       ;(Element.prototype as any).scrollIntoView = prev
     }
+  })
+})
+
+describe('FileBrowserPanel — go-to-definition (#6475)', () => {
+  // Open a file whose content is a single bare identifier, so the tokenizer emits
+  // one clickable `syn-plain` token we can cmd/ctrl+click.
+  async function openIdentifierFile(ide: boolean) {
+    mockIdeCapability = ide
+    render(<FileBrowserPanel />)
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root',
+        parentPath: null,
+        entries: [{ name: 'foo.ts', isDirectory: false, size: 20 }],
+        error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('foo.ts'))
+    fireEvent.click(screen.getByText('foo.ts'))
+    act(() => {
+      fileContentCallback!({
+        content: 'widget', language: 'typescript', size: 20, truncated: false, error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('widget'))
+  }
+
+  it('cmd/ctrl+click on a token resolves the symbol, passing the open file as a hint', async () => {
+    await openIdentifierFile(true)
+    fireEvent.click(screen.getByText('widget'), { metaKey: true })
+    expect(mockRequestResolveSymbol).toHaveBeenCalledWith('widget', 'foo.ts')
+  })
+
+  it('a plain click (no modifier) does NOT resolve', async () => {
+    await openIdentifierFile(true)
+    fireEvent.click(screen.getByText('widget'))
+    expect(mockRequestResolveSymbol).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on cmd+click when the ide capability is off', async () => {
+    await openIdentifierFile(false)
+    fireEvent.click(screen.getByText('widget'), { metaKey: true })
+    expect(mockRequestResolveSymbol).not.toHaveBeenCalled()
+  })
+
+  it('jumps to the definition on a resolve hit (opens target file + line)', () => {
+    mockSymbolLocation = { symbol: 'widget', file: 'src/widget.ts', line: 12, error: null, nonce: 1 }
+    render(<FileBrowserPanel />)
+    // The go-to-def effect fires on mount → opens the target via the store.
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/widget.ts', 12)
+  })
+
+  it('shows a transient "not found" pill on a resolve miss', async () => {
+    mockSymbolLocation = { symbol: 'ghost', file: null, line: null, error: 'Definition not found', nonce: 1 }
+    render(<FileBrowserPanel />)
+    // Open a file so the viewer (which hosts the pill) is mounted.
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root', parentPath: null,
+        entries: [{ name: 'foo.ts', isDirectory: false, size: 20 }], error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('foo.ts'))
+    fireEvent.click(screen.getByText('foo.ts'))
+    act(() => {
+      fileContentCallback!({ content: 'x', language: 'typescript', size: 1, truncated: false, error: null })
+    })
+    const pill = await screen.findByTestId('def-not-found')
+    expect(pill.textContent).toContain('ghost')
+    expect(mockOpenFileInBrowser).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -190,6 +190,10 @@ export function FileBrowserPanel() {
   const symbolsLoading = useConnectionStore(s => s.symbolsLoading)
   const ideEnabled = useConnectionStore(s => s.serverCapabilities.ide === true)
   const fileBrowserPendingOpen = useConnectionStore(s => s.fileBrowserPendingOpen)
+  // #6475 — go-to-definition: cmd/ctrl+click a token → resolve → jump.
+  const requestResolveSymbol = useConnectionStore(s => s.requestResolveSymbol)
+  const symbolLocation = useConnectionStore(s => s.symbolLocation)
+  const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
   const [currentPath, setCurrentPath] = useState<string | null>(null)
   const [entries, setEntries] = useState<FileEntry[]>([])
   const [parentPath, setParentPath] = useState<string | null>(null)
@@ -229,6 +233,11 @@ export function FileBrowserPanel() {
   // #6476 — a 1-indexed line to scroll to once the externally-opened file's
   // content has rendered (symbol-search "jump to definition").
   const pendingScrollLine = useRef<number | null>(null)
+  // #6475 — the last go-to-definition nonce we acted on, so a persisted
+  // `symbolLocation` doesn't re-fire a jump on remount / tab-switch.
+  const lastDefNonce = useRef<number | null>(null)
+  // #6475 — transient "Definition not found for X" pill (cleared after a beat).
+  const [defNotFound, setDefNotFound] = useState<string | null>(null)
   // The workspace-relative path we last asked symbols for; matched against the
   // snapshot's echoed `path` so we only render symbols for the open file.
   const [symbolScope, setSymbolScope] = useState<string | null>(null)
@@ -327,6 +336,25 @@ export function FileBrowserPanel() {
     requestFileContent(path)
   }, [requestFileContent])
 
+  // #6475 — cmd/ctrl+click a token in the viewer to jump to its definition.
+  // Event-delegated on the <pre>: read the clicked token's text; if it's an
+  // identifier-ish token (not a keyword/string/comment/punctuation), resolve it,
+  // passing the open file as a ranking tie-break hint. Opt-in: gated on ideEnabled.
+  const handleCodeClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    if (!ideEnabled || !(e.metaKey || e.ctrlKey)) return
+    const target = e.target as HTMLElement
+    const cls = typeof target.className === 'string' ? target.className : ''
+    const m = cls.match(/(?:^|\s)syn-(\w+)/)
+    if (!m || !['plain', 'function', 'type', 'property'].includes(m[1]!)) return
+    const text = (target.textContent || '').trim()
+    if (!/^[A-Za-z_$][\w$]*$/.test(text)) return
+    e.preventDefault()
+    const fromFile = selectedFile && rootPath.current
+      ? relativePath(selectedFile, rootPath.current)
+      : undefined
+    requestResolveSymbol(text, fromFile)
+  }, [ideEnabled, selectedFile, requestResolveSymbol])
+
   // #6473 — open a file requested externally (Cmd+P quick-open); reuse the click
   // path so it persists the selection, loads content, and triggers the symbols
   // request. Keyed on the nonce object so repeated opens of the same path fire.
@@ -398,6 +426,24 @@ export function FileBrowserPanel() {
     const id = window.setTimeout(() => scrollToLine(line), 0)
     return () => window.clearTimeout(id)
   }, [fileContent, scrollToLine])
+
+  // #6475 — react to a go-to-definition result: on a hit, open the target file
+  // at the declaration line (reusing the Cmd+P open plumbing); on a miss, flash a
+  // transient "not found" pill. Deduped by nonce so a persisted result doesn't
+  // re-jump on remount / tab-switch.
+  useEffect(() => {
+    if (!symbolLocation) return
+    if (lastDefNonce.current === symbolLocation.nonce) return
+    lastDefNonce.current = symbolLocation.nonce
+    if (symbolLocation.file && symbolLocation.line != null) {
+      openFileInBrowser(symbolLocation.file, symbolLocation.line)
+      setDefNotFound(null)
+      return
+    }
+    setDefNotFound(symbolLocation.symbol || 'symbol')
+    const id = window.setTimeout(() => setDefNotFound(null), 2200)
+    return () => window.clearTimeout(id)
+  }, [symbolLocation, openFileInBrowser])
 
   // Breadcrumbs from currentPath relative to root
   const breadcrumbs = useMemo(() => {
@@ -515,6 +561,12 @@ export function FileBrowserPanel() {
             <SymbolsList groups={groupedSymbols} loading={symbolsLoading} onPick={scrollToLine} />
           )}
           <div className="file-viewer-content" ref={viewerRef}>
+            {/* #6475 — transient go-to-definition "not found" feedback. */}
+            {defNotFound && (
+              <div className="file-viewer-def-notfound" data-testid="def-not-found" role="status">
+                Definition not found for <code>{defNotFound}</code>
+              </div>
+            )}
             {fileLoading && <div className="file-viewer-loading">Loading file...</div>}
             {!fileLoading && fileError && <div className="file-viewer-error">{fileError}</div>}
             {!fileLoading && !fileError && fileContent !== null && fileLanguage === 'image' && (
@@ -527,7 +579,11 @@ export function FileBrowserPanel() {
               </div>
             )}
             {!fileLoading && !fileError && fileContent !== null && fileLanguage !== 'image' && (
-              <pre className="file-viewer-code">
+              <pre
+                className={ideEnabled ? 'file-viewer-code file-viewer-code--ide' : 'file-viewer-code'}
+                onClick={handleCodeClick}
+                title={ideEnabled ? 'Cmd/Ctrl+click a symbol to jump to its definition' : undefined}
+              >
                 <code>
                   {highlightedLines
                     ? highlightedLines.map((tokens, lineIdx) => (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -657,6 +657,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   fileBrowserPendingOpen: null,
   workspaceSymbols: null,
   workspaceSymbolsLoading: false,
+  symbolLocation: null,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2487,6 +2488,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   fileBrowserPendingOpen: null,
   workspaceSymbols: null,
   workspaceSymbolsLoading: false,
+  symbolLocation: null,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3650,6 +3652,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       set({ workspaceSymbolsLoading: true });
       const msg: Record<string, unknown> = { type: 'list_symbols' };
+      if (activeSessionId) msg.sessionId = activeSessionId;
+      wsSend(socket, msg);
+    }
+  },
+
+  // #6475 — go-to-definition: resolve a clicked symbol name to its declaration.
+  // The reply (`symbol_location`) lands in `symbolLocation`; FileBrowserPanel
+  // reacts to jump there or surface a transient 'not found'.
+  requestResolveSymbol: (symbol: string, file?: string) => {
+    const trimmed = typeof symbol === 'string' ? symbol.trim() : '';
+    if (!trimmed) return;
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const msg: Record<string, unknown> = { type: 'resolve_symbol', symbol: trimmed };
+      if (file) msg.file = file;
       if (activeSessionId) msg.sessionId = activeSessionId;
       wsSend(socket, msg);
     }

--- a/packages/dashboard/src/store/dispatch-symbol-location.test.ts
+++ b/packages/dashboard/src/store/dispatch-symbol-location.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Dispatch test for go-to-definition (#6475, epic #6469).
+ *
+ * Guards the wire path between the dashboard message handler and the store for
+ * `symbol_location`:
+ *   - a valid result is stored in `symbolLocation` with a FRESH, monotonically
+ *     increasing nonce (so a repeat resolve of the same symbol re-fires the
+ *     FileBrowserPanel jump effect even when file/line are unchanged).
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerSymbolLocationMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function loc(over: Partial<ServerSymbolLocationMessage> = {}): ServerSymbolLocationMessage {
+  return {
+    type: 'symbol_location',
+    symbol: 'doThing',
+    file: 'src/foo.ts',
+    line: 12,
+    error: null,
+    ...over,
+  }
+}
+
+describe('symbol_location dispatch (#6475)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore({
+      connectionPhase: 'connected',
+      socket: null,
+      sessions: [],
+      activeSessionId: null,
+      sessionStates: {},
+      symbolLocation: null,
+      messages: [],
+    })
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('stores a resolve hit with a nonce', () => {
+    handleMessage(loc(), ctx() as never)
+    const s = store.getState().symbolLocation
+    expect(s).not.toBeNull()
+    expect(s!.symbol).toBe('doThing')
+    expect(s!.file).toBe('src/foo.ts')
+    expect(s!.line).toBe(12)
+    expect(s!.error).toBeNull()
+    expect(s!.nonce).toBe(1)
+  })
+
+  it('stores a not-found miss (null file/line + error)', () => {
+    handleMessage(loc({ symbol: 'ghost', file: null, line: null, error: 'Definition not found' }), ctx() as never)
+    const s = store.getState().symbolLocation
+    expect(s!.file).toBeNull()
+    expect(s!.line).toBeNull()
+    expect(s!.error).toMatch(/not found/i)
+  })
+
+  it('increments the nonce on each result so an identical re-resolve re-fires', () => {
+    handleMessage(loc(), ctx() as never)
+    handleMessage(loc(), ctx() as never)
+    expect(store.getState().symbolLocation!.nonce).toBe(2)
+  })
+
+  it('drops a malformed payload without mutating state', () => {
+    const before = store.getState().symbolLocation
+    // Missing the required `symbol` field.
+    handleMessage({ type: 'symbol_location', file: 'x', line: 1, error: null } as never, ctx() as never)
+    expect(store.getState().symbolLocation).toBe(before)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -130,7 +130,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2562,6 +2562,21 @@ function handleSymbolsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: 
 }
 
 /**
+ * Go-to-definition (#6475, epic #6469) — `symbol_location`: store the resolve
+ * result (with a fresh nonce so a repeat resolve of the same symbol re-fires the
+ * jump effect). FileBrowserPanel reacts to `symbolLocation`: on a hit it opens
+ * the target file at the line; on a miss it shows a transient 'not found' pill.
+ * The wire shape is Zod-validated (drop malformed payloads rather than crash).
+ * Dashboard-only for v1 (the mobile app has no symbol surface yet).
+ */
+function handleSymbolLocation(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerSymbolLocationSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const prev = get().symbolLocation;
+  set({ symbolLocation: { ...parsed.data, nonce: (prev?.nonce ?? 0) + 1 } });
+}
+
+/**
  * Mailbox (#5914 follow-up) — Control Room "Mailbox" tab `mailbox_status_snapshot`:
  * REPLACE the stored snapshot with the carried one and clear the in-flight
  * loading flag. Same defensive pattern as the host/runner snapshots — the wire
@@ -3180,6 +3195,8 @@ const HANDLERS: Record<string, Handler> = {
   pair_resolved: handlePairResolved,
   // #6471 (epic #6469): opt-in IDE workspace symbol table snapshot.
   symbols_snapshot: handleSymbolsSnapshot,
+  // #6475 (epic #6469): opt-in IDE go-to-definition result.
+  symbol_location: handleSymbolLocation,
   // #5175 (epic #5170): Host/Repo Status Control Room survey snapshot.
   host_status_snapshot: handleHostStatusSnapshot,
   // Mailbox (#5914 follow-up): Control Room "Mailbox" tab survey snapshot.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2572,8 +2572,11 @@ function handleSymbolsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: 
 function handleSymbolLocation(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerSymbolLocationSchema.safeParse(msg);
   if (!parsed.success) return;
+  // Store only the fields the state shape declares — drop the wire `type` so
+  // ConnectionState.symbolLocation can't drift or grow an accidental dependency.
+  const { symbol, file, line, error } = parsed.data;
   const prev = get().symbolLocation;
-  set({ symbolLocation: { ...parsed.data, nonce: (prev?.nonce ?? 0) + 1 } });
+  set({ symbolLocation: { symbol, file, line, error, nonce: (prev?.nonce ?? 0) + 1 } });
 }
 
 /**

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1200,6 +1200,11 @@ export interface ConnectionState {
   // snapshot). Separate from the per-file `symbols` (#6472) so they don't clobber.
   workspaceSymbols: ServerSymbolsSnapshotMessage | null;
   workspaceSymbolsLoading: boolean;
+  // #6475 — the latest go-to-definition result (a `symbol_location` reply). On a
+  // hit `file`/`line` point at the declaration and FileBrowserPanel jumps there;
+  // on a miss `error` is set and the viewer shows a transient 'not found' pill.
+  // The nonce lets a repeated resolve of the same symbol re-fire the jump effect.
+  symbolLocation: { symbol: string; file: string | null; line: number | null; error: string | null; nonce: number } | null;
 
   // Custom agents from server
   customAgents: CustomAgent[];
@@ -1406,6 +1411,10 @@ export interface ConnectionState {
   openFileInBrowser: (path: string, line?: number) => void;
   // #6476 — request the whole-workspace symbol table for the symbol-search modal.
   requestWorkspaceSymbols: () => void;
+  // #6475 — resolve a clicked symbol NAME to its definition (go-to-definition).
+  // `file` is the originating file (a ranking tie-break hint). The reply lands in
+  // `symbolLocation`; FileBrowserPanel reacts to jump there or show 'not found'.
+  requestResolveSymbol: (symbol: string, file?: string) => void;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8164,6 +8164,32 @@ button.sidebar-token-view-session-row:hover {
   transition: background 0.3s ease;
 }
 
+/* #6475 — go-to-definition: cmd/ctrl+hover a token shows a link cursor so the
+   affordance is discoverable; the transient "not found" pill flags a miss. */
+.file-viewer-code--ide .syn-plain,
+.file-viewer-code--ide .syn-function,
+.file-viewer-code--ide .syn-type,
+.file-viewer-code--ide .syn-property {
+  cursor: text;
+}
+.file-viewer-code--ide:hover .syn-function {
+  text-decoration: underline dotted rgba(124, 156, 255, 0.4);
+  text-underline-offset: 2px;
+}
+.file-viewer-def-notfound {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 6px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.file-viewer-def-notfound code {
+  color: var(--text-error, #f87171);
+}
+
 .symbol-panel {
   display: flex;
   flex-wrap: wrap;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -467,6 +467,12 @@ export declare const ListSymbolsSchema: z.ZodObject<{
     path: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
+export declare const ResolveSymbolSchema: z.ZodObject<{
+    type: z.ZodLiteral<"resolve_symbol">;
+    symbol: z.ZodString;
+    file: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ListSlashCommandsSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_slash_commands">;
 }, z.core.$loose>;
@@ -1020,6 +1026,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_symbols">;
     path: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"resolve_symbol">;
+    symbol: z.ZodString;
+    file: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_slash_commands">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -607,6 +607,17 @@ export const ListSymbolsSchema = z.object({
     path: z.string().max(4096).optional(),
     sessionId: z.string().max(256).optional(),
 }).passthrough();
+// #6475 (epic #6469): resolve a clicked symbol NAME to its declaration for
+// go-to-definition (server → `symbol_location`). `file` is the file the click
+// came from — used only to break ranking ties, so a local helper resolves in
+// place while an imported symbol jumps to its exported definition. Gated behind
+// the opt-in `features.ide` flag — handled only when enabled.
+export const ResolveSymbolSchema = z.object({
+    type: z.literal('resolve_symbol'),
+    symbol: z.string().min(1).max(256),
+    file: z.string().max(4096).optional(),
+    sessionId: z.string().max(256).optional(),
+}).passthrough();
 export const ListSlashCommandsSchema = z.object({
     type: z.literal('list_slash_commands'),
 }).passthrough();
@@ -1239,6 +1250,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     WriteFileSchema,
     ListFilesSchema,
     ListSymbolsSchema,
+    ResolveSymbolSchema,
     ListSlashCommandsSchema,
     ListAgentsSchema,
     RequestFullHistorySchema,

--- a/packages/protocol/dist/schemas/server/ide.d.ts
+++ b/packages/protocol/dist/schemas/server/ide.d.ts
@@ -33,3 +33,11 @@ export declare const ServerSymbolsSnapshotSchema: z.ZodObject<{
 }, z.core.$strip>;
 export type SymbolEntry = z.infer<typeof SymbolEntrySchema>;
 export type ServerSymbolsSnapshotMessage = z.infer<typeof ServerSymbolsSnapshotSchema>;
+export declare const ServerSymbolLocationSchema: z.ZodObject<{
+    type: z.ZodLiteral<"symbol_location">;
+    symbol: z.ZodString;
+    file: z.ZodNullable<z.ZodString>;
+    line: z.ZodNullable<z.ZodNumber>;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+export type ServerSymbolLocationMessage = z.infer<typeof ServerSymbolLocationSchema>;

--- a/packages/protocol/dist/schemas/server/ide.js
+++ b/packages/protocol/dist/schemas/server/ide.js
@@ -32,3 +32,14 @@ export const ServerSymbolsSnapshotSchema = z.object({
     truncated: z.boolean(),
     error: z.string().nullable(),
 });
+// `resolve_symbol` response (#6475) — go-to-definition. `symbol` echoes the
+// queried name (correlation). On a hit, `file` (workspace-relative POSIX path)
+// and `line` (1-indexed) point at the declaration and `error` is null; on a
+// miss both are null and `error` explains (e.g. 'Definition not found').
+export const ServerSymbolLocationSchema = z.object({
+    type: z.literal('symbol_location'),
+    symbol: z.string(),
+    file: z.string().nullable(),
+    line: z.number().nullable(),
+    error: z.string().nullable(),
+});

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -683,6 +683,18 @@ export const ListSymbolsSchema = z.object({
   sessionId: z.string().max(256).optional(),
 }).passthrough()
 
+// #6475 (epic #6469): resolve a clicked symbol NAME to its declaration for
+// go-to-definition (server → `symbol_location`). `file` is the file the click
+// came from — used only to break ranking ties, so a local helper resolves in
+// place while an imported symbol jumps to its exported definition. Gated behind
+// the opt-in `features.ide` flag — handled only when enabled.
+export const ResolveSymbolSchema = z.object({
+  type: z.literal('resolve_symbol'),
+  symbol: z.string().min(1).max(256),
+  file: z.string().max(4096).optional(),
+  sessionId: z.string().max(256).optional(),
+}).passthrough()
+
 export const ListSlashCommandsSchema = z.object({
   type: z.literal('list_slash_commands'),
 }).passthrough()
@@ -1397,6 +1409,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   WriteFileSchema,
   ListFilesSchema,
   ListSymbolsSchema,
+  ResolveSymbolSchema,
   ListSlashCommandsSchema,
   ListAgentsSchema,
   RequestFullHistorySchema,

--- a/packages/protocol/src/schemas/server/ide.ts
+++ b/packages/protocol/src/schemas/server/ide.ts
@@ -37,3 +37,17 @@ export const ServerSymbolsSnapshotSchema = z.object({
 
 export type SymbolEntry = z.infer<typeof SymbolEntrySchema>
 export type ServerSymbolsSnapshotMessage = z.infer<typeof ServerSymbolsSnapshotSchema>
+
+// `resolve_symbol` response (#6475) — go-to-definition. `symbol` echoes the
+// queried name (correlation). On a hit, `file` (workspace-relative POSIX path)
+// and `line` (1-indexed) point at the declaration and `error` is null; on a
+// miss both are null and `error` explains (e.g. 'Definition not found').
+export const ServerSymbolLocationSchema = z.object({
+  type: z.literal('symbol_location'),
+  symbol: z.string(),
+  file: z.string().nullable(),
+  line: z.number().nullable(),
+  error: z.string().nullable(),
+})
+
+export type ServerSymbolLocationMessage = z.infer<typeof ServerSymbolLocationSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -119,6 +119,7 @@ const PLATFORM_SPECIFIC = {
   'log_entry': 'dashboard',          // console page is dashboard-only
   'file_list': 'dashboard',          // file explorer sidebar is dashboard-only
   'symbols_snapshot': 'dashboard',   // #6471 (epic #6469) opt-in IDE symbol table — dashboard symbol panel (#6472) is dashboard-only for v1; mobile parity is a tracked fast-follow
+  'symbol_location': 'dashboard',    // #6475 (epic #6469) opt-in IDE go-to-definition result — dashboard file viewer cmd/ctrl+click jump; dashboard-only for v1, mobile parity deferred
   'environment_created': 'dashboard', // environment panel is dashboard-only
   'environment_list': 'dashboard',    // environment panel is dashboard-only
   'environment_destroyed': 'dashboard', // environment panel is dashboard-only

--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -68,7 +68,13 @@ async function handleResolveSymbol(ws, client, msg, ctx) {
   if (!isIdeFeatureEnabled(ctx.services?.config)) return
 
   const symbol = typeof msg.symbol === 'string' ? msg.symbol.trim() : ''
-  const fromFile = typeof msg.file === 'string' && msg.file ? msg.file : null
+  // Normalize the tie-break hint to the workspace-relative POSIX form
+  // collectWorkspaceSymbols emits (forward slashes), so a Windows-style path or
+  // stray whitespace from any client still matches `s.file`. Pure string compare
+  // — no security impact (#6498 review, cross-platform determinism).
+  const fromFile = typeof msg.file === 'string' && msg.file.trim()
+    ? msg.file.trim().replace(/\\/g, '/')
+    : null
 
   if (!symbol) {
     ctx.transport.send(ws, { type: 'symbol_location', symbol: '', file: null, line: null, error: 'No symbol to resolve' })

--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -7,11 +7,11 @@
  * the operator opts in, so clients won't send these messages, and the handler
  * additionally returns early as defence-in-depth. Off ⇒ zero IDE behaviour.
  *
- * Handles: list_symbols (#6471).
+ * Handles: list_symbols (#6471), resolve_symbol (#6475).
  */
 import { resolveSession } from '../handler-utils.js'
 import { isIdeFeatureEnabled } from '../config.js'
-import { collectWorkspaceSymbols } from '../ide/symbols.js'
+import { collectWorkspaceSymbols, resolveSymbol } from '../ide/symbols.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ide')
@@ -55,6 +55,57 @@ async function handleListSymbols(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * `resolve_symbol` → `symbol_location`. Go-to-definition (#6475): resolves a
+ * clicked symbol NAME to a single declaration over the same regex index
+ * list_symbols uses. `file` (the originating file) only breaks ranking ties.
+ * A hit sends `{ file, line, error: null }`; a miss sends `{ file: null,
+ * line: null, error }` so the client can show a graceful 'definition not found'.
+ * Dashboard-only consumer for v1.
+ */
+async function handleResolveSymbol(ws, client, msg, ctx) {
+  // #6481 (epic #6469): fail closed when the IDE surface is not opted in.
+  if (!isIdeFeatureEnabled(ctx.services?.config)) return
+
+  const symbol = typeof msg.symbol === 'string' ? msg.symbol.trim() : ''
+  const fromFile = typeof msg.file === 'string' && msg.file ? msg.file : null
+
+  if (!symbol) {
+    ctx.transport.send(ws, { type: 'symbol_location', symbol: '', file: null, line: null, error: 'No symbol to resolve' })
+    return
+  }
+
+  const entry = resolveSession(ctx, msg, client)
+  const cwd = entry?.cwd || null
+  if (!cwd) {
+    ctx.transport.send(ws, {
+      type: 'symbol_location',
+      symbol,
+      file: null,
+      line: null,
+      error: 'No workspace directory for this session',
+    })
+    return
+  }
+
+  try {
+    const loc = await resolveSymbol(cwd, symbol, { fromFile })
+    ctx.transport.send(ws, loc
+      ? { type: 'symbol_location', symbol, file: loc.file, line: loc.line, error: null }
+      : { type: 'symbol_location', symbol, file: null, line: null, error: 'Definition not found' })
+  } catch (err) {
+    log.debug(`resolve_symbol failed: ${err?.message}`)
+    ctx.transport.send(ws, {
+      type: 'symbol_location',
+      symbol,
+      file: null,
+      line: null,
+      error: err?.message || 'Failed to resolve symbol',
+    })
+  }
+}
+
 export const ideHandlers = {
   list_symbols: handleListSymbols,
+  resolve_symbol: handleResolveSymbol,
 }

--- a/packages/server/src/ide/symbols.js
+++ b/packages/server/src/ide/symbols.js
@@ -296,3 +296,42 @@ export async function collectWorkspaceSymbols(rootDir, opts = {}) {
 
   return { symbols, truncated }
 }
+
+/**
+ * Resolve a symbol NAME to a single declaration location — the backbone of
+ * go-to-definition (#6475, epic #6469). Reuses collectWorkspaceSymbols so the
+ * same realpath confinement + bounded walk apply, filters the table to
+ * declarations whose name matches exactly, and ranks the candidates:
+ *   - an exported declaration outranks a local one (+2), so a cmd/ctrl+click on
+ *     an imported symbol lands on its public definition, and
+ *   - a declaration in the originating file outranks one elsewhere (+1), so a
+ *     click on a locally-declared helper resolves in place.
+ * Regex-parsed, so ~80% accurate with zero new deps — a genuine miss (name not
+ * found, or only a usage exists) returns null and the caller reports a graceful
+ * 'not found'. On a score tie the FIRST (walk-order-earliest, deterministic)
+ * candidate wins.
+ *
+ * @param {string} rootDir           Absolute workspace root (session cwd).
+ * @param {string} symbolName        Exact declared identifier to resolve.
+ * @param {object} [opts]
+ * @param {string|null} [opts.fromFile]  Workspace-relative POSIX path the click
+ *                                       came from; used only to break ranking ties.
+ * @returns {Promise<{file: string, line: number}|null>}
+ */
+export async function resolveSymbol(rootDir, symbolName, opts = {}) {
+  const name = typeof symbolName === 'string' ? symbolName.trim() : ''
+  if (!name) return null
+  const { fromFile = null } = opts
+  const { symbols } = await collectWorkspaceSymbols(rootDir)
+  let best = null
+  let bestScore = -1
+  for (const s of symbols) {
+    if (s.name !== name) continue
+    const score = (s.exported ? 2 : 0) + (fromFile && s.file === fromFile ? 1 : 0)
+    if (score > bestScore) {
+      best = s
+      bestScore = score
+    }
+  }
+  return best ? { file: best.file, line: best.line } : null
+}

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -292,6 +292,7 @@ function _isSecureRequest(req) {
  *   { type: 'list_conversations' }                      — request saved conversation list
  *   { type: 'list_files', path? }                       — request file listing for a path
  *   { type: 'list_symbols', path? }                     — request workspace symbol table (#6471, opt-in IDE — features.ide)
+ *   { type: 'resolve_symbol', symbol, file? }           — resolve a symbol name to its definition (#6475, opt-in IDE — features.ide)
  *   { type: 'list_providers' }                          — request available provider list
  *   { type: 'list_repos' }                              — request workspace repository list
  *   { type: 'list_skills' }                             — request active skills list
@@ -380,6 +381,7 @@ function _isSecureRequest(req) {
  *   { type: 'file_listing', path, parentPath, entries, error } — file browser listing response
  *   { type: 'file_content', path, content, language, size, truncated, error } — file content response
  *   { type: 'symbols_snapshot', path, symbols: [{ name, kind, file, line, exported }], truncated, error } — #6471 workspace symbol table (opt-in IDE, features.ide; dashboard-only v1)
+ *   { type: 'symbol_location', symbol, file, line, error } — #6475 go-to-definition result (opt-in IDE, features.ide; dashboard-only v1)
  *   { type: 'slash_commands', commands: [{ name, description, source }] } — available slash commands
  *   { type: 'agent_list', agents: [{ name, description, source }] } — available custom agents
  *   { type: 'client_joined', client: { clientId, deviceName, deviceType, platform } } — new client connected

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ideHandlers } from '../src/handlers/ide-handlers.js'
@@ -134,5 +134,32 @@ describe('resolve_symbol handler — emission', () => {
     assert.equal(sent[0].type, 'symbol_location')
     assert.equal(sent[0].file, null)
     assert.match(sent[0].error, /No workspace/)
+  })
+})
+
+describe('resolve_symbol handler — cross-platform file hint (#6498)', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-resolve-win-'))
+    // Two same-named non-exported decls: only the same-file tie-break disambiguates.
+    // Walk order (sorted) parses `other.ts` before `sub/`, so without a matching
+    // fromFile the miss falls to other.ts.
+    mkdirSync(join(root, 'sub'))
+    writeFileSync(join(root, 'sub', 'local.ts'), 'const target = 1\n')
+    writeFileSync(join(root, 'other.ts'), 'const target = 2\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('normalizes a Windows-style backslash file hint so the same-file tie-break still applies', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'target', file: 'sub\\local.ts' }, ctx)
+    assert.equal(sent[0].file, 'sub/local.ts')
+    assert.equal(sent[0].line, 1)
+  })
+
+  it('trims whitespace from the file hint', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'target', file: '  sub/local.ts  ' }, ctx)
+    assert.equal(sent[0].file, 'sub/local.ts')
   })
 })

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -4,15 +4,17 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ideHandlers } from '../src/handlers/ide-handlers.js'
-import { ServerSymbolsSnapshotSchema } from '@chroxy/protocol'
+import { ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema } from '@chroxy/protocol'
 import { nsCtx } from './test-helpers.js'
 
 /**
- * Handler tests for list_symbols (#6471, epic #6469): the opt-in `features.ide`
- * gate (fail-closed when off) and the symbols_snapshot emission shape.
+ * Handler tests for list_symbols (#6471) and resolve_symbol (#6475, epic #6469):
+ * the opt-in `features.ide` gate (fail-closed when off) and the
+ * symbols_snapshot / symbol_location emission shapes.
  */
 
 const handleListSymbols = ideHandlers.list_symbols
+const handleResolveSymbol = ideHandlers.resolve_symbol
 
 /** Build a handler ctx with a send-capturing transport, a config (for the flag
  *  gate), and a sessionManager resolving the given cwd. */
@@ -72,6 +74,65 @@ describe('list_symbols handler — emission', () => {
     assert.equal(sent.length, 1)
     assert.equal(sent[0].type, 'symbols_snapshot')
     assert.deepEqual(sent[0].symbols, [])
+    assert.match(sent[0].error, /No workspace/)
+  })
+})
+
+describe('resolve_symbol handler — feature gate', () => {
+  it('is a no-op (no send) when features.ide is off', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: false, cwd: '/tmp' })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'exported' }, ctx)
+    assert.equal(sent.length, 0)
+  })
+})
+
+describe('resolve_symbol handler — emission', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-resolve-h-'))
+    writeFileSync(join(root, 'mod.ts'), 'export function exported() {}\nclass Local {}\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('emits a schema-valid symbol_location with file + line on a hit', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'exported' }, ctx)
+    assert.equal(sent.length, 1)
+    const msg = sent[0]
+    const parsed = ServerSymbolLocationSchema.safeParse(msg)
+    assert.ok(parsed.success, 'emitted message must satisfy ServerSymbolLocationSchema')
+    assert.equal(msg.symbol, 'exported')
+    assert.equal(msg.file, 'mod.ts')
+    assert.equal(msg.line, 1)
+    assert.equal(msg.error, null)
+  })
+
+  it('emits a not-found symbol_location (null file/line + error) on a miss', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'nope' }, ctx)
+    assert.equal(sent.length, 1)
+    const msg = sent[0]
+    assert.ok(ServerSymbolLocationSchema.safeParse(msg).success)
+    assert.equal(msg.file, null)
+    assert.equal(msg.line, null)
+    assert.match(msg.error, /not found/i)
+  })
+
+  it('emits an error location when the symbol is empty', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: '   ' }, ctx)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].type, 'symbol_location')
+    assert.equal(sent[0].file, null)
+    assert.match(sent[0].error, /No symbol/)
+  })
+
+  it('emits an error location when the session has no cwd', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: null })
+    await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'exported' }, ctx)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].type, 'symbol_location')
+    assert.equal(sent[0].file, null)
     assert.match(sent[0].error, /No workspace/)
   })
 })

--- a/packages/server/tests/ide-symbols.test.js
+++ b/packages/server/tests/ide-symbols.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { parseSymbols, collectWorkspaceSymbols } from '../src/ide/symbols.js'
+import { parseSymbols, collectWorkspaceSymbols, resolveSymbol } from '../src/ide/symbols.js'
 
 /**
  * Unit tests for the self-contained IDE symbol parser (#6471, epic #6469).
@@ -207,5 +207,59 @@ describe('collectWorkspaceSymbols', () => {
     const { symbols, truncated } = await collectWorkspaceSymbols(root, { maxSymbols: 1 })
     assert.equal(symbols.length, 1)
     assert.equal(truncated, true)
+  })
+})
+
+describe('resolveSymbol — go-to-definition (#6475)', () => {
+  let root
+  let outside
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-resolve-'))
+    // An exported declaration in one file...
+    writeFileSync(join(root, 'mod.ts'), 'export const widget = () => {}\n')
+    // ...and a same-named LOCAL (non-exported) declaration in another.
+    writeFileSync(join(root, 'local.ts'), 'const widget = 1\nexport function only() {}\n')
+    // Two same-named non-exported decls, to exercise the fromFile tiebreak.
+    writeFileSync(join(root, 'a.ts'), 'const dup = 1\n')
+    writeFileSync(join(root, 'b.ts'), 'const dup = 2\n')
+    // A symbol reachable only via an in-workspace symlink pointing OUTSIDE —
+    // the whole-tree walk skips symlinks, so it must never resolve.
+    outside = mkdtempSync(join(tmpdir(), 'chroxy-ide-resolve-out-'))
+    writeFileSync(join(outside, 'secret.js'), 'export function TOP_SECRET() {}\n')
+    symlinkSync(join(outside, 'secret.js'), join(root, 'linkfile.js'))
+  })
+  after(() => {
+    rmSync(root, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('resolves a unique symbol to its declaration file + 1-indexed line', async () => {
+    assert.deepEqual(await resolveSymbol(root, 'only'), { file: 'local.ts', line: 2 })
+  })
+
+  it('prefers the EXPORTED declaration when the same name is declared twice', async () => {
+    // widget is exported in mod.ts (+2) and a local const in local.ts (+0).
+    assert.deepEqual(await resolveSymbol(root, 'widget'), { file: 'mod.ts', line: 1 })
+  })
+
+  it('breaks a tie toward the originating file (fromFile)', async () => {
+    // dup is a non-exported const in both a.ts and b.ts; fromFile decides.
+    assert.deepEqual(await resolveSymbol(root, 'dup', { fromFile: 'b.ts' }), { file: 'b.ts', line: 1 })
+    // Without a fromFile hint, walk-order (a before b) wins deterministically.
+    assert.deepEqual(await resolveSymbol(root, 'dup'), { file: 'a.ts', line: 1 })
+  })
+
+  it('returns null for a name with no declaration (graceful not-found)', async () => {
+    assert.equal(await resolveSymbol(root, 'doesNotExist'), null)
+  })
+
+  it('returns null for an empty / whitespace / non-string name', async () => {
+    assert.equal(await resolveSymbol(root, ''), null)
+    assert.equal(await resolveSymbol(root, '   '), null)
+    assert.equal(await resolveSymbol(root, null), null)
+  })
+
+  it('never resolves a symbol reachable only through an out-of-workspace symlink', async () => {
+    assert.equal(await resolveSymbol(root, 'TOP_SECRET'), null)
   })
 })

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -157,6 +157,7 @@ const DASHBOARD_ONLY = new Set<string>([
   // introduced here; the schema just made the lint see them.
   'session_activity',           // per-session busy/idle + cost ping — dashboard activity tree only
   'symbols_snapshot',           // #6471 (epic #6469) opt-in IDE workspace symbol table — dashboard symbol panel (#6472) only for v1; mobile parity is a tracked fast-follow
+  'symbol_location',            // #6475 (epic #6469) opt-in IDE go-to-definition result — dashboard file viewer cmd/ctrl+click jump; dashboard-only for v1, mobile parity deferred
   'terminal_size',              // authoritative PTY grid for letterboxing — app terminal parity is still partial (#5987)
   // #6332 (batch 2b of #6314): the container/worktree environment lifecycle —
   // dashboard-only by design (the app has no environment surface). Schemaing


### PR DESCRIPTION
## Summary

The first genuinely differentiated IDE capability (#6469 Phase 2): **go-to-definition**. Cmd/Ctrl+click a symbol in the dashboard file viewer and jump to its declaration, resolved server-side over the same regex symbol index `list_symbols` (#6471) already builds — **zero new deps**, ~80% accurate, all behind the opt-in `features.ide` flag.

Builds directly on #6471 (list_symbols backbone) and #6476 (symbol search), reusing their confinement, parser, and file-open/jump plumbing.

## What changed

**Server**
- `resolveSymbol(rootDir, name, { fromFile })` in `ide/symbols.js` — reuses `collectWorkspaceSymbols` (so the same realpath confinement + bounded walk apply), filters to exact-name declarations, and ranks candidates: **exported (+2)** so an imported symbol lands on its public definition, **same-file (+1)** so a local helper resolves in place. Deterministic on ties. A miss (or usage-only) returns `null`.
- `resolve_symbol` handler in `ide-handlers.js` — fail-closed on `features.ide`; emits `symbol_location { symbol, file, line, error }`. A miss sends null `file`/`line` + `'Definition not found'`.

**Protocol**
- `ResolveSymbolSchema` (client) + `ServerSymbolLocationSchema` (server/ide), registered in the client discriminated union, the `ws-server.js` Client→Server / Server→Client doc comments, and **both coverage guards** (handler-coverage `PLATFORM_SPECIFIC` + protocol-type-coverage `DASHBOARD_ONLY`) as dashboard-only for v1.

**Dashboard**
- `requestResolveSymbol` sender + nonce-tagged `symbolLocation` store field + `handleSymbolLocation` dispatch.
- `FileBrowserPanel`: cmd/ctrl+click a token → resolve → on a **hit**, reuse the Cmd+P open plumbing to jump to file+line (verified: the server resolves the workspace-relative path against cwd); on a **miss**, a transient "Definition not found" pill. A link-cursor hint appears on cmd-hover. All gated on the server's `ide` capability.

## Acceptance (from #6475)
- [x] Cmd/Ctrl+click a symbol jumps to its definition
- [x] `resolve_symbol` returns a location from the repo-memory-style index
- [x] Graceful 'not found' when the regex can't resolve

## Testing
- **Server:** `resolveSymbol` ranking (exported > local, fromFile tie-break), out-of-workspace-symlink confinement, empty/miss → null; handler emission shape + feature gate + no-cwd path.
- **Dashboard:** `symbol_location` dispatch (nonce increment + Zod drop); `FileBrowserPanel` click→resolve (passes open file as hint), plain-click no-op, ide-off no-op, jump-on-hit, not-found pill.
- Full suites green locally: dashboard **4118**, store-core **1919**, protocol **347**, server ide **31**; both server custom lints pass; all typechecks clean.

> Note: the end-to-end DOM jump shares #6476's already-shipped path-resolution; unit-tested here via the store/effect wiring. A live dashboard smoke (cmd+click in a real session) is a nice follow-up but not required for the logic.

Closes #6475