### PR TITLE
fix(ide): guard FileBrowserPanel content callback on reply path (#6497)

### DIFF
--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -510,6 +510,13 @@ describe('contentReplyMatchesSelection (#6497)', () => {
     // '/root/barfoo.ts' must NOT match selection 'foo.ts' (segment boundary).
     expect(contentReplyMatchesSelection('/root/barfoo.ts', 'foo.ts')).toBe(false)
   })
+  it('requires an EXACT match for an absolute selection (no tail-match) (#6501 review)', () => {
+    // A different root that happens to end with the same absolute string must not match.
+    expect(contentReplyMatchesSelection('/other/root/a.ts', '/root/a.ts')).toBe(false)
+    expect(contentReplyMatchesSelection('/root/a.ts', '/root/a.ts')).toBe(true)
+    // Windows absolute selection: exact only.
+    expect(contentReplyMatchesSelection('D:/x/root/a.ts', 'C:/root/a.ts')).toBe(false)
+  })
   it('keeps a reply that cannot be correlated (null path)', () => {
     expect(contentReplyMatchesSelection(null, '/root/a.ts')).toBe(true)
     expect(contentReplyMatchesSelection('/root/a.ts', null)).toBe(true)

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'
-import { FileBrowserPanel } from './FileBrowserPanel'
+import { FileBrowserPanel, contentReplyMatchesSelection } from './FileBrowserPanel'
 
 // Mock the connection store
 const mockRequestFileListing = vi.fn()
@@ -481,10 +481,61 @@ describe('FileBrowserPanel — go-to-definition (#6475)', () => {
     await waitFor(() => screen.getByText('foo.ts'))
     fireEvent.click(screen.getByText('foo.ts'))
     act(() => {
-      fileContentCallback!({ content: 'x', language: 'typescript', size: 1, truncated: false, error: null })
+      fileContentCallback!({ path: '/root/foo.ts', content: 'x', language: 'typescript', size: 1, truncated: false, error: null })
     })
     const pill = await screen.findByTestId('def-not-found')
     expect(pill.textContent).toContain('ghost')
     expect(mockOpenFileInBrowser).not.toHaveBeenCalled()
+  })
+})
+
+describe('contentReplyMatchesSelection (#6497)', () => {
+  it('matches an exact absolute path (tree click)', () => {
+    expect(contentReplyMatchesSelection('/root/a.ts', '/root/a.ts')).toBe(true)
+  })
+  it('matches a resolved absolute reply against a workspace-relative selection (symbol jump)', () => {
+    // The server echoes the absolute path; a #6475/#6476 jump selected 'src/util.ts'.
+    expect(contentReplyMatchesSelection('/root/src/util.ts', 'src/util.ts')).toBe(true)
+    expect(contentReplyMatchesSelection('/root/src/util.ts', './src/util.ts')).toBe(true)
+  })
+  it('normalizes Windows separators on both sides', () => {
+    expect(contentReplyMatchesSelection('C:\\root\\a.ts', 'C:\\root\\a.ts')).toBe(true)
+    expect(contentReplyMatchesSelection('C:\\root\\src\\util.ts', 'src/util.ts')).toBe(true)
+  })
+  it('rejects a reply for a different file', () => {
+    expect(contentReplyMatchesSelection('/root/other.ts', '/root/a.ts')).toBe(false)
+    expect(contentReplyMatchesSelection('/root/other.ts', 'src/util.ts')).toBe(false)
+  })
+  it('does not partial-match a different file that shares a suffix substring', () => {
+    // '/root/barfoo.ts' must NOT match selection 'foo.ts' (segment boundary).
+    expect(contentReplyMatchesSelection('/root/barfoo.ts', 'foo.ts')).toBe(false)
+  })
+  it('keeps a reply that cannot be correlated (null path)', () => {
+    expect(contentReplyMatchesSelection(null, '/root/a.ts')).toBe(true)
+    expect(contentReplyMatchesSelection('/root/a.ts', null)).toBe(true)
+  })
+})
+
+describe('FileBrowserPanel — stale content guard (#6497)', () => {
+  it('ignores a file_content reply for a since-deselected file', async () => {
+    render(<FileBrowserPanel />)
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root', parentPath: null,
+        entries: [{ name: 'a.ts', isDirectory: false, size: 10 }], error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('a.ts'))
+    fireEvent.click(screen.getByText('a.ts')) // selectedFile = /root/a.ts
+    // A late reply for a DIFFERENT file must not flash into the viewer.
+    act(() => {
+      fileContentCallback!({ path: '/root/other.ts', content: 'STALE', language: 'typescript', size: 5, truncated: false, error: null })
+    })
+    expect(screen.queryByText('STALE')).toBeNull()
+    // The correct reply lands and renders.
+    act(() => {
+      fileContentCallback!({ path: '/root/a.ts', content: 'CORRECT', language: 'typescript', size: 7, truncated: false, error: null })
+    })
+    await waitFor(() => screen.getByText('CORRECT'))
   })
 })

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -55,6 +55,25 @@ function formatSize(bytes: number | null): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
+/**
+ * #6497 — does a `file_content` reply belong to the currently-selected file?
+ * The server echoes the resolved ABSOLUTE path (ws-file-ops/reader.js), while the
+ * selection may be absolute (a file-tree click) OR workspace-relative (a #6475/
+ * #6476 symbol jump). Compare tolerantly: an exact match, or the reply's absolute
+ * path ending on the selected (relative) path. It NEVER drops a correct reply —
+ * for the selected file the reply's abs path always equals or tail-matches it —
+ * so a late/out-of-order reply for a *different* file is discarded instead of
+ * flashing into the current viewer or stealing its jump-to-line target. A reply
+ * with no path (an empty/invalid request) can't be correlated, so it's kept.
+ */
+export function contentReplyMatchesSelection(replyPath: string | null, selected: string | null): boolean {
+  if (!replyPath || !selected) return true
+  const rp = replyPath.replace(/\\/g, '/')
+  const sel = selected.replace(/\\/g, '/')
+  if (rp === sel) return true
+  return rp.endsWith('/' + sel.replace(/^\.?\//, ''))
+}
+
 /** Build a lookup of relative paths to their git status */
 function buildGitStatusMap(
   gitStatus: GitStatusResult | null,
@@ -220,6 +239,10 @@ export function FileBrowserPanel() {
       }
     }
   }, [])
+  // #6497 — the file-content callback is registered once, so it can't close over
+  // the live `selectedFile` state. Mirror it into a ref (synced below) so the
+  // callback can drop replies that belong to a since-deselected file.
+  const selectedFileRef = useRef<string | null>(selectedFile)
   const [fileContent, setFileContent] = useState<string | null>(null)
   const [fileLanguage, setFileLanguage] = useState<string | null>(null)
   const [fileSize, setFileSize] = useState<number | null>(null)
@@ -261,8 +284,17 @@ export function FileBrowserPanel() {
     return () => setFileBrowserCallback(null)
   }, [setFileBrowserCallback])
 
+  // #6497 — keep the ref in sync with the live selection for the content guard.
+  useEffect(() => {
+    selectedFileRef.current = selectedFile
+  }, [selectedFile])
+
   useEffect(() => {
     const handleContent = (content: FileContent) => {
+      // #6497 — drop a reply that belongs to a since-deselected file: closes the
+      // wrong-content flash and the jump-to-line scroll-target bleed under a rapid
+      // A→B open where A's reply lands after B was selected.
+      if (!contentReplyMatchesSelection(content.path, selectedFileRef.current)) return
       setFileContent(content.content)
       setFileLanguage(content.language)
       setFileSize(content.size)

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -5,7 +5,7 @@
  * Clicking a file loads its content with syntax highlighting.
  * Displays git status decorations on modified/untracked files.
  */
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react'
 import { useConnectionStore } from '../store/connection'
 import { tokenize } from '@chroxy/store-core'
 import type { FileEntry, FileListing, FileContent, GitStatusResult } from '../store/types'
@@ -71,6 +71,11 @@ export function contentReplyMatchesSelection(replyPath: string | null, selected:
   const rp = replyPath.replace(/\\/g, '/')
   const sel = selected.replace(/\\/g, '/')
   if (rp === sel) return true
+  // An ABSOLUTE selection (file-tree click) must match exactly — never tail-match,
+  // or an unrelated abs reply that happens to end with the same string would slip
+  // through. Only a workspace-relative selection (a #6475/#6476 symbol jump) is
+  // tail-matched against the server's resolved absolute reply path.
+  if (sel.startsWith('/') || /^[A-Za-z]:\//.test(sel)) return false
   return rp.endsWith('/' + sel.replace(/^\.?\//, ''))
 }
 
@@ -225,7 +230,15 @@ export function FileBrowserPanel() {
     activeSessionId ? s.sessionStates[activeSessionId]?.selectedFilePath ?? null : null
   )
   const [selectedFile, _setSelectedFile] = useState<string | null>(savedFilePath)
+  // #6497 — the file-content callback is registered once, so it can't close over
+  // the live `selectedFile` state. Mirror it into a ref (updated synchronously at
+  // every selection site + a layout-effect backstop) so the callback can drop
+  // replies that belong to a since-deselected file.
+  const selectedFileRef = useRef<string | null>(savedFilePath)
   const setSelectedFile = useCallback((path: string | null) => {
+    // #6497 — update the guard ref synchronously at the primary selection site so
+    // no reply can slip through before the sync effect runs.
+    selectedFileRef.current = path
     _setSelectedFile(path)
     // Persist to session state
     const sid = useConnectionStore.getState().activeSessionId
@@ -239,10 +252,6 @@ export function FileBrowserPanel() {
       }
     }
   }, [])
-  // #6497 — the file-content callback is registered once, so it can't close over
-  // the live `selectedFile` state. Mirror it into a ref (synced below) so the
-  // callback can drop replies that belong to a since-deselected file.
-  const selectedFileRef = useRef<string | null>(selectedFile)
   const [fileContent, setFileContent] = useState<string | null>(null)
   const [fileLanguage, setFileLanguage] = useState<string | null>(null)
   const [fileSize, setFileSize] = useState<number | null>(null)
@@ -284,8 +293,11 @@ export function FileBrowserPanel() {
     return () => setFileBrowserCallback(null)
   }, [setFileBrowserCallback])
 
-  // #6497 — keep the ref in sync with the live selection for the content guard.
-  useEffect(() => {
+  // #6497 — backstop: keep the ref in sync for selection changes that bypass
+  // setSelectedFile (session-switch restore, StrictMode). A layout effect runs
+  // synchronously after commit — before the browser yields to the next macrotask
+  // (a file_content WS message) — so the ref can't be briefly stale.
+  useLayoutEffect(() => {
     selectedFileRef.current = selectedFile
   }, [selectedFile])
 


### PR DESCRIPTION
## Summary

Closes a narrow correctness race in the dashboard file viewer surfaced by the #6496 review (root cause pre-dates it, #6473). `FileBrowserPanel`'s `read_file` callback applied **whatever reply arrived** to the currently-open file, ignoring `content.path`. Two consequences:

1. **Scroll-target bleed** — with the #6476 jump-to-line, opening file A (line 5) then B (line 9) before A's content lands, with A's reply arriving first, scrolled A's content to B's line (9) and B never scrolled.
2. **Wrong-content flash** — a late reply for a previously-selected file briefly rendered into the current viewer.

Sequential replies over one socket usually arrive in order, so the common path was already fine — hence Minor.

## Fix

Drop a `file_content` reply whose path doesn't match the current selection.

The subtlety: the server echoes the **resolved absolute** path (`ws-file-ops/reader.js:81`), while the selection can be **absolute** (file-tree click) or **workspace-relative** (a #6475/#6476 symbol jump — `openFileInBrowser('src/util.ts', …)`). A naive `content.path !== selectedFile` compare would drop every symbol-jump reply and break go-to-definition. So `contentReplyMatchesSelection()` is normalization-tolerant: an exact match, or the absolute reply tail-matching the relative selection (segment-boundary aware, Windows-separator normalized). It **never drops a correct reply** — only late replies for a different file.

A once-registered callback can't close over live `selectedFile` state, so the selection is mirrored into a ref that a small sync effect keeps current.

## Acceptance (from #6497)
- [x] `handleContent` ignores a `file_content` reply for a non-selected file
- [x] Jump-to-line scrolls the correct file even under a rapid A→B open (the dropped stale reply never reaches the scroll effect)

## Testing
- **Pure helper** `contentReplyMatchesSelection`: exact abs match, abs-reply vs relative selection (symbol jump), Windows separators, different-file rejection, segment-boundary (no `/barfoo.ts` ↔ `foo.ts` partial match), null-path kept.
- **Component**: a stale reply for a since-deselected file is dropped (no flash); the correct reply then renders.
- Full dashboard suite green locally: **4125** (+7); typecheck clean.

Closes #6497