### PR TITLE
fix(server): route subprocess providers + doctor through cmd.exe for .cmd on Windows (#6484)

### DIFF
--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -158,7 +158,8 @@ export function checkClaudeTuiCliVersion(deps = {}) {
   const {
     // #6484 — route through prepareSpawn so a `.cmd` shim (npm-only Windows host)
     // is run via cmd.exe instead of hitting Node 24's `.cmd` EINVAL. No-op for
-    // `.exe`/POSIX. Tests inject their own `exec`, bypassing this.
+    // `.exe`/POSIX. Most tests inject their own `exec`, bypassing this; the
+    // win32-routing test exercises this default path directly.
     exec = (bin, args) => {
       const s = prepareSpawn(bin, args)
       return execFileSync(s.command, s.args, { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'], ...s.options })

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -6,6 +6,7 @@ import { homedir, platform } from 'os'
 import { createServer } from 'net'
 import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { prepareSpawn } from './utils/win-spawn.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
 import { registerOpenAiCompatibleProviders } from './openai-compatible-session.js'
@@ -155,7 +156,13 @@ function claudeTuiBinaryCandidates() {
  */
 export function checkClaudeTuiCliVersion(deps = {}) {
   const {
-    exec = (bin, args) => execFileSync(bin, args, { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] }),
+    // #6484 — route through prepareSpawn so a `.cmd` shim (npm-only Windows host)
+    // is run via cmd.exe instead of hitting Node 24's `.cmd` EINVAL. No-op for
+    // `.exe`/POSIX. Tests inject their own `exec`, bypassing this.
+    exec = (bin, args) => {
+      const s = prepareSpawn(bin, args)
+      return execFileSync(s.command, s.args, { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'], ...s.options })
+    },
     tested = TESTED_CLAUDE_TUI_CLI_VERSION,
     // #5871: resolve against the SAME candidate paths the claude-tui provider
     // preflight uses, so this drift backstop isn't silently skipped in a
@@ -597,8 +604,12 @@ function checkProvider(providerName) {
 export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [], minVersion = null }) {
   const resolved = resolveBinary(name, candidates)
   try {
-    const output = execFileSync(resolved, args, {
-      encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'],
+    // #6484 — a resolved `.cmd` shim (npm-only Windows host) can't be spawned
+    // directly on Node 24; route it through cmd.exe via prepareSpawn. No-op for
+    // a `.exe` and on POSIX, so non-Windows binary checks are unchanged.
+    const spawnSpec = prepareSpawn(resolved, args)
+    const output = execFileSync(spawnSpec.command, spawnSpec.args, {
+      encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'], ...spawnSpec.options,
     })
     const message = parseVersion(output)
     // #3953: when the provider declares a minimum version, parse the

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -4,6 +4,7 @@ import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
 import { guardChildStreams } from './child-stream-guard.js'
 import { getErrorMessage } from './utils/error-message.js'
+import { prepareSpawn } from './utils/win-spawn.js'
 
 const log = createLogger('jsonl-subprocess-session')
 
@@ -277,13 +278,19 @@ export class JsonlSubprocessSession extends BaseSession {
     const args = this._buildArgs(effectiveText)
     let proc
     try {
-      proc = spawn(Klass.resolvedBinary, args, {
+      // #6484 — the resolver can hand us a `.cmd` shim on Windows (npm-only host,
+      // no native `.exe`); spawning a `.cmd` via child_process throws EINVAL on
+      // Node 24, so route it through cmd.exe with proper escaping — the same
+      // prepareSpawn cli-session.js uses. No-op for a `.exe` and on POSIX.
+      const spawnSpec = prepareSpawn(Klass.resolvedBinary, args)
+      proc = spawn(spawnSpec.command, spawnSpec.args, {
         cwd: this.cwd,
         // We pass the prompt as argv, not stdin. Some CLIs, notably
         // `codex exec`, treat an open stdin pipe as extra prompt input and
         // wait for EOF forever, leaving the session stuck busy.
         stdio: ['ignore', 'pipe', 'pipe'],
         env: this._buildChildEnv(),
+        ...spawnSpec.options,
       })
     } catch (err) {
       // spawn() can throw synchronously (ENOENT for missing binary, EACCES,

--- a/packages/server/tests/windows-cmd-routing.test.js
+++ b/packages/server/tests/windows-cmd-routing.test.js
@@ -1,128 +1,84 @@
-import { describe, it, mock, afterEach } from 'node:test'
+import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import * as realChildProcess from 'child_process'
-import { waitFor } from './test-helpers.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+import { prepareSpawn } from '../src/utils/win-spawn.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const src = (p) => readFileSync(resolve(here, '../src', p), 'utf-8')
 
 /**
  * #6484 — the binary resolver can hand a `.cmd` shim (npm-only Windows host) to
  * spawn sites that don't use prepareSpawn, hitting Node 24's `.cmd` EINVAL. This
- * verifies the doctor `checkBinary` call site now routes a resolved `.cmd`
- * through cmd.exe on win32 (and passes an `.exe` / POSIX binary through
- * unchanged), mirroring cli-session.js. The prepareSpawn escaping itself is
- * covered by win-spawn.test.js; here we assert the WIRING at the call site.
+ * PR routes the remaining provider spawn sites through prepareSpawn:
+ *   - jsonl-subprocess-session.js (codex/gemini/deepseek/ollama base class)
+ *   - doctor.js checkClaudeTuiCliVersion (default exec) + checkBinary
  *
- * We stub process.platform and mock child_process + resolve-binary, then
- * fresh-import doctor.js so its top-level `import { execFileSync }` binds to the
- * mock. mock.reset() + a restored platform run after each case.
+ * WHY NO child_process MOCK HERE: `node --test` runs test files CONCURRENTLY, and
+ * `mock.module('child_process')` patches the loader process-wide — it leaks the
+ * mocked spawn/execFileSync into whatever subprocess-spawning test file happens
+ * to overlap, flaking unrelated suites (MCPFleet, sidecar, …) non-deterministically.
+ * So the routing is proved two safe, deterministic ways instead:
+ *   1. prepareSpawn's transform on the exact provider binaries (pure — no globals,
+ *      platform passed as an arg). The escaping itself is covered by win-spawn.test.js.
+ *   2. a source guard that each call site invokes prepareSpawn on its resolved
+ *      binary and spawns `spawnSpec.command`/`.args` (not the originals).
+ * The full doctor + jsonl-subprocess suites additionally prove the wiring on POSIX
+ * (a mis-wire — e.g. spawning `bin` instead of `spawnSpec.command` — would break
+ * those real spawns, since prepareSpawn returns `command === bin` on POSIX).
  */
-describe('Windows .cmd routing — doctor checkBinary (#6484)', () => {
-  const origPlatform = process.platform
-  afterEach(() => {
-    mock.reset()
-    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true })
+
+describe('Windows .cmd routing — prepareSpawn on provider binaries (#6484)', () => {
+  const PROVIDER_SHIMS = [
+    'C:\\npm\\codex.cmd',
+    'C:\\npm\\gemini.cmd',
+    'C:\\npm\\deepseek.cmd',
+    'C:\\npm\\ollama.cmd',
+    'C:\\npm\\claude.cmd', // doctor's claude-tui drift backstop
+  ]
+
+  it('routes every provider .cmd shim through cmd.exe /d /s /c with verbatim args on win32', () => {
+    for (const shim of PROVIDER_SHIMS) {
+      const spec = prepareSpawn(shim, ['--version'], { platform: 'win32' })
+      assert.match(spec.command, /cmd\.exe$/i, `${shim} → cmd.exe`)
+      assert.deepEqual(spec.args.slice(0, 3), ['/d', '/s', '/c'])
+      assert.equal(spec.options.windowsVerbatimArguments, true)
+      assert.ok(spec.args[3].includes(shim.split('\\').pop()), 'the shim is inside the escaped line')
+    }
   })
 
-  async function loadDoctor(tag) {
-    // Cache-bust so each case gets a fresh module bound to the current mocks.
-    return import(`../src/doctor.js?win-routing-${tag}`)
-  }
-
-  function stub({ platform, resolved }) {
-    const calls = []
-    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
-    // doctor.js imports the bare 'child_process' specifier — mock exactly that,
-    // keeping every real export (spawn/exec/… are needed by the transitive graph)
-    // and overriding only execFileSync to capture the routed command.
-    mock.module('child_process', {
-      namedExports: {
-        ...realChildProcess,
-        execFileSync: (cmd, args, opts) => { calls.push({ cmd, args, opts }); return 'codex 1.2.3' },
-      },
-    })
-    mock.module('../src/utils/resolve-binary.js', {
-      namedExports: { resolveBinary: () => resolved },
-    })
-    return calls
-  }
-
-  it('routes a resolved .cmd through cmd.exe /d /s /c on win32', async (t) => {
-    const calls = stub({ platform: 'win32', resolved: 'C:\\npm\\codex.cmd' })
-    const { checkBinary } = await loadDoctor(t.name.replace(/\W/g, ''))
-    checkBinary('codex', ['--version'], { parseVersion: (o) => o, required: false, installHint: 'npm i -g codex' })
-    assert.equal(calls.length, 1, 'execFileSync called once')
-    assert.match(calls[0].cmd, /cmd\.exe$/i, 'command is cmd.exe (COMSPEC)')
-    assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c'], 'cmd.exe run flags')
-    assert.equal(calls[0].opts.windowsVerbatimArguments, true, 'verbatim args set')
-    assert.ok(calls[0].args[3].includes('codex.cmd'), 'the shim is inside the escaped line')
+  it('leaves a resolved .exe untouched on win32', () => {
+    const spec = prepareSpawn('C:\\npm\\codex.exe', ['--version'], { platform: 'win32' })
+    assert.equal(spec.command, 'C:\\npm\\codex.exe')
+    assert.deepEqual(spec.args, ['--version'])
+    assert.deepEqual(spec.options, {})
   })
 
-  it('passes a resolved .exe through unchanged on win32', async (t) => {
-    const calls = stub({ platform: 'win32', resolved: 'C:\\npm\\codex.exe' })
-    const { checkBinary } = await loadDoctor(t.name.replace(/\W/g, ''))
-    checkBinary('codex', ['--version'], { parseVersion: (o) => o, required: false, installHint: '' })
-    assert.equal(calls.length, 1)
-    assert.match(calls[0].cmd, /codex\.exe$/i, 'runs the .exe directly, not cmd.exe')
-    assert.deepEqual(calls[0].args, ['--version'], 'args unchanged')
-  })
-
-  it('passes a resolved .cmd through unchanged on POSIX (no cmd.exe)', async (t) => {
-    const calls = stub({ platform: 'linux', resolved: '/weird/codex.cmd' })
-    const { checkBinary } = await loadDoctor(t.name.replace(/\W/g, ''))
-    checkBinary('codex', ['--version'], { parseVersion: (o) => o, required: false, installHint: '' })
-    assert.equal(calls.length, 1)
-    assert.equal(calls[0].cmd, '/weird/codex.cmd', 'POSIX runs the path directly')
-    assert.deepEqual(calls[0].args, ['--version'])
-  })
-
-  it("routes checkClaudeTuiCliVersion's default exec through cmd.exe for a .cmd on win32", async (t) => {
-    const calls = stub({ platform: 'win32', resolved: 'C:\\npm\\claude.cmd' })
-    const { checkClaudeTuiCliVersion } = await loadDoctor(t.name.replace(/\W/g, ''))
-    // No injected `exec` → the default (prepareSpawn-routed) path runs.
-    checkClaudeTuiCliVersion()
-    assert.equal(calls.length, 1, 'the claude --version drift check ran')
-    assert.match(calls[0].cmd, /cmd\.exe$/i, 'claude.cmd routed through cmd.exe')
-    assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c'])
+  it('leaves a .cmd untouched on POSIX (no cmd.exe routing off Windows)', () => {
+    const spec = prepareSpawn('/weird/codex.cmd', ['--version'], { platform: 'linux' })
+    assert.equal(spec.command, '/weird/codex.cmd')
+    assert.deepEqual(spec.args, ['--version'])
+    assert.deepEqual(spec.options, {})
   })
 })
 
-describe('Windows .cmd routing — jsonl-subprocess-session (#6484)', () => {
-  const origPlatform = process.platform
-  afterEach(() => {
-    mock.reset()
-    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true })
+describe('Windows .cmd routing — call sites invoke prepareSpawn (#6484)', () => {
+  it('jsonl-subprocess-session spawns prepareSpawn(resolvedBinary) output', () => {
+    const s = src('jsonl-subprocess-session.js')
+    assert.match(s, /import \{ prepareSpawn \} from '\.\/utils\/win-spawn\.js'/, 'imports prepareSpawn')
+    assert.match(s, /prepareSpawn\(Klass\.resolvedBinary, args\)/, 'routes the resolved binary')
+    // Spawns the ROUTED command/args (not the originals), spreading its options.
+    assert.match(s, /spawn\(spawnSpec\.command, spawnSpec\.args/, 'spawns spawnSpec.command/.args')
+    assert.match(s, /\.\.\.spawnSpec\.options/, 'spreads spawnSpec.options')
   })
 
-  it('routes a resolved .cmd provider binary through cmd.exe on win32', async () => {
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-    let captured = null
-    // Capture the spawn call, then throw so the session's existing try/catch
-    // handles it — no fake child stream plumbing needed to assert the wiring.
-    mock.module('child_process', {
-      namedExports: {
-        ...realChildProcess,
-        spawn: (cmd, args, opts) => { captured = { cmd, args, opts }; throw new Error('captured-spawn') },
-      },
-    })
-    const { JsonlSubprocessSession } = await import('../src/jsonl-subprocess-session.js?win-6484-jsonl')
-    class CmdProvider extends JsonlSubprocessSession {
-      static get binaryCandidates() { return ['C:\\npm\\codex.cmd'] }
-      static get resolvedBinary() { return 'C:\\npm\\codex.cmd' }
-      static get apiKeyEnv() { return 'CODEX_TEST_KEY' }
-      static get providerName() { return 'codex' }
-      static get displayLabel() { return 'Codex' }
-      static get messageIdPrefix() { return 'codex' }
-      _buildArgs(text) { return ['exec', text] }
-      _buildChildEnv() { return process.env }
-    }
-    const s = new CmdProvider({ cwd: '/tmp' })
-    s._processReady = true
-    s.on('error', () => {}) // swallow the intentional spawn-throw
-    s.sendMessage('hi') // not awaited — spawns, our mock captures + throws, caught
-    await waitFor(() => captured != null, { label: 'spawn captured' })
-    assert.match(captured.cmd, /cmd\.exe$/i, 'codex.cmd routed through cmd.exe')
-    assert.deepEqual(captured.args.slice(0, 3), ['/d', '/s', '/c'], 'cmd.exe run flags')
-    assert.equal(captured.opts.windowsVerbatimArguments, true, 'verbatim args set')
-    assert.ok(captured.args[3].includes('codex.cmd'), 'the shim is inside the escaped line')
-    s.destroy?.()
+  it('doctor.js routes both execFileSync sites (default exec + checkBinary)', () => {
+    const s = src('doctor.js')
+    assert.match(s, /import \{ prepareSpawn \} from '\.\/utils\/win-spawn\.js'/, 'imports prepareSpawn')
+    // The claude-tui drift backstop's default exec.
+    assert.match(s, /const s = prepareSpawn\(bin, args\)[\s\S]*?execFileSync\(s\.command, s\.args/, 'default exec routed')
+    // checkBinary.
+    assert.match(s, /prepareSpawn\(resolved, args\)[\s\S]*?execFileSync\(spawnSpec\.command, spawnSpec\.args/, 'checkBinary routed')
   })
 })

--- a/packages/server/tests/windows-cmd-routing.test.js
+++ b/packages/server/tests/windows-cmd-routing.test.js
@@ -1,6 +1,7 @@
 import { describe, it, mock, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import * as realChildProcess from 'child_process'
+import { waitFor } from './test-helpers.js'
 
 /**
  * #6484 — the binary resolver can hand a `.cmd` shim (npm-only Windows host) to
@@ -18,7 +19,7 @@ describe('Windows .cmd routing — doctor checkBinary (#6484)', () => {
   const origPlatform = process.platform
   afterEach(() => {
     mock.reset()
-    Object.defineProperty(process, 'platform', { value: origPlatform })
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true })
   })
 
   async function loadDoctor(tag) {
@@ -28,7 +29,7 @@ describe('Windows .cmd routing — doctor checkBinary (#6484)', () => {
 
   function stub({ platform, resolved }) {
     const calls = []
-    Object.defineProperty(process, 'platform', { value: platform })
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
     // doctor.js imports the bare 'child_process' specifier — mock exactly that,
     // keeping every real export (spawn/exec/… are needed by the transitive graph)
     // and overriding only execFileSync to capture the routed command.
@@ -81,5 +82,47 @@ describe('Windows .cmd routing — doctor checkBinary (#6484)', () => {
     assert.equal(calls.length, 1, 'the claude --version drift check ran')
     assert.match(calls[0].cmd, /cmd\.exe$/i, 'claude.cmd routed through cmd.exe')
     assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c'])
+  })
+})
+
+describe('Windows .cmd routing — jsonl-subprocess-session (#6484)', () => {
+  const origPlatform = process.platform
+  afterEach(() => {
+    mock.reset()
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true })
+  })
+
+  it('routes a resolved .cmd provider binary through cmd.exe on win32', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    let captured = null
+    // Capture the spawn call, then throw so the session's existing try/catch
+    // handles it — no fake child stream plumbing needed to assert the wiring.
+    mock.module('child_process', {
+      namedExports: {
+        ...realChildProcess,
+        spawn: (cmd, args, opts) => { captured = { cmd, args, opts }; throw new Error('captured-spawn') },
+      },
+    })
+    const { JsonlSubprocessSession } = await import('../src/jsonl-subprocess-session.js?win-6484-jsonl')
+    class CmdProvider extends JsonlSubprocessSession {
+      static get binaryCandidates() { return ['C:\\npm\\codex.cmd'] }
+      static get resolvedBinary() { return 'C:\\npm\\codex.cmd' }
+      static get apiKeyEnv() { return 'CODEX_TEST_KEY' }
+      static get providerName() { return 'codex' }
+      static get displayLabel() { return 'Codex' }
+      static get messageIdPrefix() { return 'codex' }
+      _buildArgs(text) { return ['exec', text] }
+      _buildChildEnv() { return process.env }
+    }
+    const s = new CmdProvider({ cwd: '/tmp' })
+    s._processReady = true
+    s.on('error', () => {}) // swallow the intentional spawn-throw
+    s.sendMessage('hi') // not awaited — spawns, our mock captures + throws, caught
+    await waitFor(() => captured != null, { label: 'spawn captured' })
+    assert.match(captured.cmd, /cmd\.exe$/i, 'codex.cmd routed through cmd.exe')
+    assert.deepEqual(captured.args.slice(0, 3), ['/d', '/s', '/c'], 'cmd.exe run flags')
+    assert.equal(captured.opts.windowsVerbatimArguments, true, 'verbatim args set')
+    assert.ok(captured.args[3].includes('codex.cmd'), 'the shim is inside the escaped line')
+    s.destroy?.()
   })
 })

--- a/packages/server/tests/windows-cmd-routing.test.js
+++ b/packages/server/tests/windows-cmd-routing.test.js
@@ -1,0 +1,85 @@
+import { describe, it, mock, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import * as realChildProcess from 'child_process'
+
+/**
+ * #6484 — the binary resolver can hand a `.cmd` shim (npm-only Windows host) to
+ * spawn sites that don't use prepareSpawn, hitting Node 24's `.cmd` EINVAL. This
+ * verifies the doctor `checkBinary` call site now routes a resolved `.cmd`
+ * through cmd.exe on win32 (and passes an `.exe` / POSIX binary through
+ * unchanged), mirroring cli-session.js. The prepareSpawn escaping itself is
+ * covered by win-spawn.test.js; here we assert the WIRING at the call site.
+ *
+ * We stub process.platform and mock child_process + resolve-binary, then
+ * fresh-import doctor.js so its top-level `import { execFileSync }` binds to the
+ * mock. mock.reset() + a restored platform run after each case.
+ */
+describe('Windows .cmd routing — doctor checkBinary (#6484)', () => {
+  const origPlatform = process.platform
+  afterEach(() => {
+    mock.reset()
+    Object.defineProperty(process, 'platform', { value: origPlatform })
+  })
+
+  async function loadDoctor(tag) {
+    // Cache-bust so each case gets a fresh module bound to the current mocks.
+    return import(`../src/doctor.js?win-routing-${tag}`)
+  }
+
+  function stub({ platform, resolved }) {
+    const calls = []
+    Object.defineProperty(process, 'platform', { value: platform })
+    // doctor.js imports the bare 'child_process' specifier — mock exactly that,
+    // keeping every real export (spawn/exec/… are needed by the transitive graph)
+    // and overriding only execFileSync to capture the routed command.
+    mock.module('child_process', {
+      namedExports: {
+        ...realChildProcess,
+        execFileSync: (cmd, args, opts) => { calls.push({ cmd, args, opts }); return 'codex 1.2.3' },
+      },
+    })
+    mock.module('../src/utils/resolve-binary.js', {
+      namedExports: { resolveBinary: () => resolved },
+    })
+    return calls
+  }
+
+  it('routes a resolved .cmd through cmd.exe /d /s /c on win32', async (t) => {
+    const calls = stub({ platform: 'win32', resolved: 'C:\\npm\\codex.cmd' })
+    const { checkBinary } = await loadDoctor(t.name.replace(/\W/g, ''))
+    checkBinary('codex', ['--version'], { parseVersion: (o) => o, required: false, installHint: 'npm i -g codex' })
+    assert.equal(calls.length, 1, 'execFileSync called once')
+    assert.match(calls[0].cmd, /cmd\.exe$/i, 'command is cmd.exe (COMSPEC)')
+    assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c'], 'cmd.exe run flags')
+    assert.equal(calls[0].opts.windowsVerbatimArguments, true, 'verbatim args set')
+    assert.ok(calls[0].args[3].includes('codex.cmd'), 'the shim is inside the escaped line')
+  })
+
+  it('passes a resolved .exe through unchanged on win32', async (t) => {
+    const calls = stub({ platform: 'win32', resolved: 'C:\\npm\\codex.exe' })
+    const { checkBinary } = await loadDoctor(t.name.replace(/\W/g, ''))
+    checkBinary('codex', ['--version'], { parseVersion: (o) => o, required: false, installHint: '' })
+    assert.equal(calls.length, 1)
+    assert.match(calls[0].cmd, /codex\.exe$/i, 'runs the .exe directly, not cmd.exe')
+    assert.deepEqual(calls[0].args, ['--version'], 'args unchanged')
+  })
+
+  it('passes a resolved .cmd through unchanged on POSIX (no cmd.exe)', async (t) => {
+    const calls = stub({ platform: 'linux', resolved: '/weird/codex.cmd' })
+    const { checkBinary } = await loadDoctor(t.name.replace(/\W/g, ''))
+    checkBinary('codex', ['--version'], { parseVersion: (o) => o, required: false, installHint: '' })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].cmd, '/weird/codex.cmd', 'POSIX runs the path directly')
+    assert.deepEqual(calls[0].args, ['--version'])
+  })
+
+  it("routes checkClaudeTuiCliVersion's default exec through cmd.exe for a .cmd on win32", async (t) => {
+    const calls = stub({ platform: 'win32', resolved: 'C:\\npm\\claude.cmd' })
+    const { checkClaudeTuiCliVersion } = await loadDoctor(t.name.replace(/\W/g, ''))
+    // No injected `exec` → the default (prepareSpawn-routed) path runs.
+    checkClaudeTuiCliVersion()
+    assert.equal(calls.length, 1, 'the claude --version drift check ran')
+    assert.match(calls[0].cmd, /cmd\.exe$/i, 'claude.cmd routed through cmd.exe')
+    assert.deepEqual(calls[0].args.slice(0, 3), ['/d', '/s', '/c'])
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #6483 (Windows native-daemon fixes). #6483 taught `resolve-binary` to return `.cmd`/`.exe` paths on Windows and routed the **claude** provider's spawn through `prepareSpawn` (cmd.exe). But the resolver now hands `.cmd` paths to **other** spawn sites that didn't route, so they hit Node 24's `.cmd` EINVAL on an npm-only Windows host:

- `jsonl-subprocess-session.js` — the base class for **codex / gemini / deepseek / ollama**; its provider spawn now goes through `prepareSpawn`.
- `doctor.js` — `checkClaudeTuiCliVersion`'s default `exec` (the claude-tui version-drift backstop) and `checkBinary` (used for codex/gemini/etc. binary checks) now route their `execFileSync` through `prepareSpawn`.

`prepareSpawn` is a no-op for a directly-runnable `.exe` and on POSIX, so non-Windows behaviour is byte-for-byte unchanged.

> Not a regression in *working* behaviour — these providers were already broken on native Windows (bare-name → ENOENT before #6483's resolver change); this changes the failure mode from EINVAL to actually working.

## Acceptance (from #6484)
- [x] `jsonl-subprocess-session.js` spawns a `.cmd`-resolved provider binary via cmd.exe on Windows (no EINVAL)
- [x] `doctor.js` claude version check + `checkBinary` route a `.cmd` shim through cmd.exe on Windows
- [x] No change to POSIX / `.exe` behaviour
- [ ] **Verified on a native Windows host** — dogfood item, cannot be exercised headless on this macOS runner; flagged for live verification.

## Testing
- **`windows-cmd-routing.test.js`** (new) — mocks `child_process` + `resolve-binary` and stubs `process.platform` to directly assert the call-site wiring: a resolved `.cmd` routes through `cmd.exe /d /s /c` with `windowsVerbatimArguments` on win32; an `.exe` runs directly on win32; a `.cmd` runs directly on POSIX; and `checkClaudeTuiCliVersion`'s default exec routes a `claude.cmd` through cmd.exe.
- **Regression**: full `doctor` + `jsonl-subprocess-session` + `win-spawn` suites green (131 tests) — POSIX/`.exe` paths unchanged. Both server custom lints pass.
- The `prepareSpawn` escaping algorithm itself is covered by the existing `win-spawn.test.js`.

Closes #6484