### PR TITLE
feat(ide): Cmd+Shift+F find-in-project content search (#6474)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -69,6 +69,7 @@ import { useInterventionPing } from './hooks/useInterventionPing'
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { FileOpenPalette } from './components/FileOpenPalette'
 import { SymbolSearchPalette } from './components/SymbolSearchPalette'
+import { CodeSearchPalette } from './components/CodeSearchPalette'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { useTunnelReady } from './hooks/useTunnelReady'
 import { useQrModal } from './hooks/useQrModal'
@@ -609,6 +610,7 @@ export function App() {
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [fileOpenPaletteOpen, setFileOpenPaletteOpen] = useState(false)
   const [symbolSearchOpen, setSymbolSearchOpen] = useState(false)
+  const [codeSearchOpen, setCodeSearchOpen] = useState(false)
 
   // Local state
   const [showCreateSession, setShowCreateSession] = useState(false)
@@ -996,6 +998,7 @@ export function App() {
     appendImageAttachments,
     openFilePalette: () => { if (ideEnabled) setFileOpenPaletteOpen(true) },
     openSymbolSearch: () => { if (ideEnabled) setSymbolSearchOpen(true) },
+    openCodeSearch: () => { if (ideEnabled) setCodeSearchOpen(true) },
   })
 
   const trackedCommands = useMemo(
@@ -2611,6 +2614,10 @@ export function App() {
       <SymbolSearchPalette
         isOpen={symbolSearchOpen}
         onClose={() => setSymbolSearchOpen(false)}
+      />
+      <CodeSearchPalette
+        isOpen={codeSearchOpen}
+        onClose={() => setCodeSearchOpen(false)}
       />
     </div>
   )

--- a/packages/dashboard/src/components/CodeSearchPalette.test.tsx
+++ b/packages/dashboard/src/components/CodeSearchPalette.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * CodeSearchPalette — tests for the Cmd+Shift+F find-in-project palette (#6474).
+ * Unlike the symbol palette, matching happens server-side, so typing dispatches a
+ * (debounced) `requestSearchContent` and results come from `codeSearchResults`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { CodeSearchPalette } from './CodeSearchPalette'
+
+const mockRequestSearchContent = vi.fn()
+const mockOpenFileInBrowser = vi.fn()
+let mockCodeSearchResults: any = null
+let mockCodeSearchLoading = false
+
+vi.mock('../store/connection', () => {
+  const storeState = () => ({
+    requestSearchContent: mockRequestSearchContent,
+    codeSearchResults: mockCodeSearchResults,
+    codeSearchLoading: mockCodeSearchLoading,
+    openFileInBrowser: mockOpenFileInBrowser,
+  })
+  const useConnectionStore = Object.assign(
+    (selector: any) => selector(storeState()),
+    { getState: () => storeState(), setState: () => {} },
+  )
+  return { useConnectionStore }
+})
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCodeSearchLoading = false
+  mockCodeSearchResults = {
+    query: 'target', truncated: false, error: null,
+    results: [
+      { file: 'src/a.ts', line: 3, column: 7, text: 'const target = 1' },
+      { file: 'src/b.ts', line: 9, column: 1, text: 'target()' },
+    ],
+  }
+})
+
+describe('CodeSearchPalette (#6474)', () => {
+  it('does not render when closed', () => {
+    render(<CodeSearchPalette isOpen={false} onClose={() => {}} />)
+    expect(screen.queryByTestId('code-search-palette')).toBeNull()
+  })
+
+  it('shows the 2+ char hint on open (empty query) and does not search', () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    expect(screen.getByTestId('code-search-hint')).toBeTruthy()
+    expect(mockRequestSearchContent).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a debounced search once the query is 2+ chars', async () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    const input = await screen.findByTestId('code-search-input')
+    fireEvent.change(input, { target: { value: 'target' } })
+    await waitFor(() => expect(mockRequestSearchContent).toHaveBeenCalledWith('target'), { timeout: 1000 })
+  })
+
+  it('does not search for a single character', () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    const input = screen.getByTestId('code-search-input')
+    fireEvent.change(input, { target: { value: 't' } })
+    expect(mockRequestSearchContent).not.toHaveBeenCalled()
+    expect(screen.getByTestId('code-search-hint')).toBeTruthy()
+  })
+
+  it('renders the result rows for the current query', async () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    fireEvent.change(screen.getByTestId('code-search-input'), { target: { value: 'target' } })
+    await waitFor(() => {
+      expect(screen.getByTestId('code-search-item-0')).toBeTruthy()
+      expect(screen.getByTestId('code-search-item-1')).toBeTruthy()
+    })
+  })
+
+  it('ignores stale results whose echoed query does not match the input', () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    // Type a query the (mock) stored results are NOT for → shows "Searching…", no rows.
+    fireEvent.change(screen.getByTestId('code-search-input'), { target: { value: 'different' } })
+    expect(screen.queryByTestId('code-search-item-0')).toBeNull()
+  })
+
+  it('opens the file at the match line on Enter, then closes', async () => {
+    const onClose = vi.fn()
+    render(<CodeSearchPalette isOpen={true} onClose={onClose} />)
+    const input = screen.getByTestId('code-search-input')
+    fireEvent.change(input, { target: { value: 'target' } })
+    await waitFor(() => screen.getByTestId('code-search-item-0'))
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/a.ts', 3)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('arrow-down then Enter opens the second match', async () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    const input = screen.getByTestId('code-search-input')
+    fireEvent.change(input, { target: { value: 'target' } })
+    await waitFor(() => screen.getByTestId('code-search-item-1'))
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/b.ts', 9)
+  })
+
+  it('opens a match on click', async () => {
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    fireEvent.change(screen.getByTestId('code-search-input'), { target: { value: 'target' } })
+    const row = await screen.findByTestId('code-search-item-1')
+    fireEvent.mouseDown(row)
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/b.ts', 9)
+  })
+
+  it('closes on Escape without opening anything', () => {
+    const onClose = vi.fn()
+    render(<CodeSearchPalette isOpen={true} onClose={onClose} />)
+    fireEvent.keyDown(screen.getByTestId('code-search-input'), { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+    expect(mockOpenFileInBrowser).not.toHaveBeenCalled()
+  })
+
+  it('shows "No matches" when the current query has an empty result set', async () => {
+    mockCodeSearchResults = { query: 'zzz', truncated: false, error: null, results: [] }
+    render(<CodeSearchPalette isOpen={true} onClose={() => {}} />)
+    fireEvent.change(screen.getByTestId('code-search-input'), { target: { value: 'zzz' } })
+    await waitFor(() => expect(screen.getByTestId('code-search-empty')).toBeTruthy())
+  })
+})

--- a/packages/dashboard/src/components/CodeSearchPalette.tsx
+++ b/packages/dashboard/src/components/CodeSearchPalette.tsx
@@ -1,0 +1,150 @@
+/**
+ * CodeSearchPalette — Cmd+Shift+F find-in-project content grep (#6474, IDE epic
+ * #6469).
+ *
+ * Unlike the symbol palette (#6476), the match can't happen client-side — the
+ * browser has no file contents — so the query is sent to the server (debounced,
+ * 2+ chars) via `requestSearchContent`, and the `search_results` reply lands in
+ * `codeSearchResults`. Each row is a file:line match with the matched line as a
+ * preview; Enter / click opens the file at that line via `openFileInBrowser`.
+ *
+ * Gated by the caller on the opt-in `ide` capability. Reuses the file-open-palette
+ * chrome (CSS).
+ */
+import { useState, useEffect, useMemo, useRef, useCallback, type KeyboardEvent } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { SearchResultEntry } from '@chroxy/protocol'
+
+export interface CodeSearchPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const DISPLAY_CAP = 200
+const DEBOUNCE_MS = 200
+const MIN_QUERY = 2
+
+export function CodeSearchPalette({ isOpen, onClose }: CodeSearchPaletteProps) {
+  const requestSearchContent = useConnectionStore(s => s.requestSearchContent)
+  const snapshot = useConnectionStore(s => s.codeSearchResults)
+  const loading = useConnectionStore(s => s.codeSearchLoading)
+  const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    setQuery('')
+    setSelectedIndex(0)
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0)
+    return () => window.clearTimeout(id)
+  }, [isOpen])
+
+  // Debounced server-side search on query change (content grep can't run client-side).
+  useEffect(() => {
+    if (!isOpen) return
+    if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    const q = query.trim()
+    if (q.length < MIN_QUERY) return
+    debounceRef.current = window.setTimeout(() => requestSearchContent(q), DEBOUNCE_MS)
+    return () => { if (debounceRef.current) window.clearTimeout(debounceRef.current) }
+  }, [query, isOpen, requestSearchContent])
+
+  const trimmed = query.trim()
+  // Only trust the stored results if they're for the CURRENT query — the server
+  // echoes `query`, so a reply for a stale (shorter) query is ignored while the
+  // user keeps typing.
+  const isCurrent = !!snapshot && snapshot.query === trimmed
+  const results = useMemo<SearchResultEntry[]>(() => {
+    if (trimmed.length < MIN_QUERY || !isCurrent) return []
+    return snapshot!.results
+  }, [snapshot, isCurrent, trimmed])
+
+  useEffect(() => {
+    setSelectedIndex(i => (results.length === 0 ? 0 : Math.min(i, Math.min(results.length, DISPLAY_CAP) - 1)))
+  }, [results.length])
+
+  useEffect(() => {
+    const items = listRef.current?.querySelectorAll('[role="option"]')
+    const el = items?.[selectedIndex] as HTMLElement | undefined
+    el?.scrollIntoView?.({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const openAt = useCallback((idx: number) => {
+    const r = results[idx]
+    if (r) {
+      openFileInBrowser(r.file, r.line)
+      onClose()
+    }
+  }, [results, openFileInBrowser, onClose])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, Math.min(results.length, DISPLAY_CAP) - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIndex(i => Math.max(i - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); openAt(selectedIndex) }
+  }, [results.length, selectedIndex, openAt, onClose])
+
+  if (!isOpen) return null
+
+  const overflow = results.length > DISPLAY_CAP ? results.length - DISPLAY_CAP : 0
+  const display = overflow > 0 ? results.slice(0, DISPLAY_CAP) : results
+  // "Searching…" while a query is in flight OR results haven't caught up to the
+  // current query yet, so a stale set never renders as if it were fresh.
+  const searching = trimmed.length >= MIN_QUERY && (loading || !isCurrent)
+
+  return (
+    <div
+      className="file-open-palette-overlay"
+      data-modal-overlay
+      data-testid="code-search-palette"
+      onKeyDown={handleKeyDown}
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="file-open-palette" role="dialog" aria-label="Search in files">
+        <input
+          ref={inputRef}
+          className="file-open-palette-input"
+          type="text"
+          placeholder="Search in files…"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0) }}
+          data-testid="code-search-input"
+          aria-label="Search in files"
+        />
+        <div ref={listRef} className="file-open-palette-list" role="listbox" aria-label="Search results">
+          {trimmed.length < MIN_QUERY && (
+            <div className="file-open-palette-status" data-testid="code-search-hint">Type 2+ characters to search</div>
+          )}
+          {trimmed.length >= MIN_QUERY && searching && (
+            <div className="file-open-palette-status">Searching…</div>
+          )}
+          {trimmed.length >= MIN_QUERY && !searching && results.length === 0 && (
+            <div className="file-open-palette-status" data-testid="code-search-empty">No matches</div>
+          )}
+          {display.map((r, i) => (
+            <div
+              key={`${r.file}:${r.line}:${r.column}:${i}`}
+              role="option"
+              aria-selected={i === selectedIndex}
+              className={`file-open-palette-item${i === selectedIndex ? ' selected' : ''}`}
+              data-testid={`code-search-item-${i}`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onMouseDown={(e) => { e.preventDefault(); openAt(i) }}
+            >
+              <span className="code-search-preview" title={r.text}>{r.text.trim() || ' '}</span>
+              <span className="symbol-item-line">{r.file.split('/').pop()}:{r.line}</span>
+            </div>
+          ))}
+          {overflow > 0 && <div className="file-open-palette-status">{overflow} more…</div>}
+          {isCurrent && snapshot!.truncated && display.length > 0 && (
+            <div className="file-open-palette-status" data-testid="code-search-truncated">Results truncated — refine your search</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/CodeSearchPalette.tsx
+++ b/packages/dashboard/src/components/CodeSearchPalette.tsx
@@ -4,7 +4,7 @@
  *
  * Unlike the symbol palette (#6476), the match can't happen client-side — the
  * browser has no file contents — so the query is sent to the server (debounced,
- * 2+ chars) via `requestSearchContent`, and the `search_results` reply lands in
+ * 2+ chars) via `requestSearchContent`, and the `code_search_results` reply lands in
  * `codeSearchResults`. Each row is a file:line match with the matched line as a
  * preview; Enter / click opens the file at that line via `openFileInBrowser`.
  *

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -74,6 +74,8 @@ export interface ShortcutDispatchProps {
   openFilePalette?: () => void
   // #6476 — open the Cmd+Shift+O symbol-search palette (caller gates on `ide`).
   openSymbolSearch?: () => void
+  // #6474 — open the Cmd+Shift+F find-in-project palette (caller gates on `ide`).
+  openCodeSearch?: () => void
 }
 
 export function useShortcutDispatch(props: ShortcutDispatchProps): void {
@@ -99,6 +101,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     appendImageAttachments,
     openFilePalette,
     openSymbolSearch,
+    openCodeSearch,
   } = props
 
   useEffect(() => {
@@ -210,6 +213,9 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
             break
           case 'file.openPalette':
             openFilePalette?.()
+            break
+          case 'search.inProject':
+            openCodeSearch?.()
             break
           case 'symbol.search':
             openSymbolSearch?.()

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -72,6 +72,14 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
     scope: 'global',
   },
   {
+    // #6474 (IDE epic #6469) — Cmd+Shift+F find-in-project content grep. Gated on `ide` in App.
+    id: 'search.inProject',
+    defaultBinding: 'cmd+shift+f',
+    description: 'Search in files',
+    category: 'navigation',
+    scope: 'global',
+  },
+  {
     id: 'sidebar.toggle',
     defaultBinding: 'cmd+b',
     description: 'Toggle sidebar',

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -658,6 +658,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   workspaceSymbols: null,
   workspaceSymbolsLoading: false,
   symbolLocation: null,
+  codeSearchResults: null,
+  codeSearchLoading: false,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2489,6 +2491,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   workspaceSymbols: null,
   workspaceSymbolsLoading: false,
   symbolLocation: null,
+  codeSearchResults: null,
+  codeSearchLoading: false,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3667,6 +3671,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, unknown> = { type: 'resolve_symbol', symbol: trimmed };
       if (file) msg.file = file;
+      if (activeSessionId) msg.sessionId = activeSessionId;
+      wsSend(socket, msg);
+    }
+  },
+
+  // #6474 — find-in-project content grep. The reply (`search_results`) lands in
+  // `codeSearchResults`; the Cmd+Shift+F palette renders it.
+  requestSearchContent: (query: string) => {
+    const trimmed = typeof query === 'string' ? query.trim() : '';
+    if (trimmed.length < 2) return;
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ codeSearchLoading: true });
+      const msg: Record<string, unknown> = { type: 'search_content', query: trimmed };
       if (activeSessionId) msg.sessionId = activeSessionId;
       wsSend(socket, msg);
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3676,7 +3676,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  // #6474 — find-in-project content grep. The reply (`search_results`) lands in
+  // #6474 — find-in-project content grep. The reply (`code_search_results`) lands in
   // `codeSearchResults`; the Cmd+Shift+F palette renders it.
   requestSearchContent: (query: string) => {
     const trimmed = typeof query === 'string' ? query.trim() : '';

--- a/packages/dashboard/src/store/dispatch-search-results.test.ts
+++ b/packages/dashboard/src/store/dispatch-search-results.test.ts
@@ -2,7 +2,7 @@
  * Dispatch test for find-in-project (#6474, epic #6469).
  *
  * Guards the wire path between the dashboard message handler and the store for
- * `search_results`:
+ * `code_search_results`:
  *   - a valid reply REPLACES `codeSearchResults` and clears `codeSearchLoading`.
  *   - a malformed payload is dropped (Zod safeParse) without mutating state.
  *   - it does NOT touch the unrelated cross-session `searchResults` field.
@@ -65,7 +65,7 @@ function results(over: Partial<ServerSearchResultsMessage> = {}): ServerSearchRe
   }
 }
 
-describe('search_results dispatch (#6474)', () => {
+describe('code_search_results dispatch (#6474)', () => {
   let store: ReturnType<typeof createMockStore>
   let mockSocket: WebSocket
 

--- a/packages/dashboard/src/store/dispatch-search-results.test.ts
+++ b/packages/dashboard/src/store/dispatch-search-results.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Dispatch test for find-in-project (#6474, epic #6469).
+ *
+ * Guards the wire path between the dashboard message handler and the store for
+ * `search_results`:
+ *   - a valid reply REPLACES `codeSearchResults` and clears `codeSearchLoading`.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state.
+ *   - it does NOT touch the unrelated cross-session `searchResults` field.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerSearchResultsMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function results(over: Partial<ServerSearchResultsMessage> = {}): ServerSearchResultsMessage {
+  return {
+    type: 'code_search_results',
+    query: 'target',
+    results: [{ file: 'src/a.ts', line: 3, column: 7, text: 'const target = 1' }],
+    truncated: false,
+    error: null,
+    ...over,
+  }
+}
+
+describe('search_results dispatch (#6474)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore({
+      connectionPhase: 'connected',
+      socket: null,
+      sessions: [],
+      activeSessionId: null,
+      sessionStates: {},
+      codeSearchResults: null,
+      codeSearchLoading: true,
+      // The unrelated cross-session search field must be untouched.
+      searchResults: [],
+      messages: [],
+    } as unknown as Partial<ConnectionState>)
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('stores the result set and clears the loading flag', () => {
+    handleMessage(results(), ctx() as never)
+    const s = store.getState()
+    expect(s.codeSearchResults).not.toBeNull()
+    expect(s.codeSearchResults!.query).toBe('target')
+    expect(s.codeSearchResults!.results[0]?.file).toBe('src/a.ts')
+    expect(s.codeSearchLoading).toBe(false)
+  })
+
+  it('does not touch the unrelated cross-session searchResults field', () => {
+    handleMessage(results(), ctx() as never)
+    // Cross-session `searchResults` (a different feature) stays as it was.
+    expect(Array.isArray(store.getState().searchResults)).toBe(true)
+    expect(store.getState().searchResults.length).toBe(0)
+  })
+
+  it('replaces a prior result set wholesale', () => {
+    handleMessage(results(), ctx() as never)
+    handleMessage(results({ query: 'other', results: [] }), ctx() as never)
+    expect(store.getState().codeSearchResults!.query).toBe('other')
+    expect(store.getState().codeSearchResults!.results).toEqual([])
+  })
+
+  it('drops a malformed payload without mutating state or clearing loading', () => {
+    const before = store.getState().codeSearchResults
+    // Missing the required `results` array.
+    handleMessage({ type: 'code_search_results', query: 'x', truncated: false, error: null } as never, ctx() as never)
+    expect(store.getState().codeSearchResults).toBe(before)
+    expect(store.getState().codeSearchLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2580,7 +2580,7 @@ function handleSymbolLocation(msg: Record<string, unknown>, get: MsgGet, set: Ms
 }
 
 /**
- * Find-in-project (#6474, epic #6469) — `search_results`: REPLACE the stored
+ * Find-in-project (#6474, epic #6469) — `code_search_results`: REPLACE the stored
  * result set with the carried one and clear the in-flight loading flag. Each
  * reply is a full picture (no delta). Zod-validated so a malformed payload is
  * dropped rather than crashing the Cmd+Shift+F palette. Dashboard-only for v1.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -130,7 +130,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2580,6 +2580,18 @@ function handleSymbolLocation(msg: Record<string, unknown>, get: MsgGet, set: Ms
 }
 
 /**
+ * Find-in-project (#6474, epic #6469) — `search_results`: REPLACE the stored
+ * result set with the carried one and clear the in-flight loading flag. Each
+ * reply is a full picture (no delta). Zod-validated so a malformed payload is
+ * dropped rather than crashing the Cmd+Shift+F palette. Dashboard-only for v1.
+ */
+function handleSearchResults(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerSearchResultsSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ codeSearchResults: parsed.data, codeSearchLoading: false });
+}
+
+/**
  * Mailbox (#5914 follow-up) — Control Room "Mailbox" tab `mailbox_status_snapshot`:
  * REPLACE the stored snapshot with the carried one and clear the in-flight
  * loading flag. Same defensive pattern as the host/runner snapshots — the wire
@@ -3200,6 +3212,9 @@ const HANDLERS: Record<string, Handler> = {
   symbols_snapshot: handleSymbolsSnapshot,
   // #6475 (epic #6469): opt-in IDE go-to-definition result.
   symbol_location: handleSymbolLocation,
+  // #6474 (epic #6469): opt-in IDE find-in-project results (distinct wire type
+  // from the cross-session `search_results` handled by the shared dispatch table).
+  code_search_results: handleSearchResults,
   // #5175 (epic #5170): Host/Repo Status Control Room survey snapshot.
   host_status_snapshot: handleHostStatusSnapshot,
   // Mailbox (#5914 follow-up): Control Room "Mailbox" tab survey snapshot.

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerSymbolsSnapshotMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -1205,6 +1205,12 @@ export interface ConnectionState {
   // on a miss `error` is set and the viewer shows a transient 'not found' pill.
   // The nonce lets a repeated resolve of the same symbol re-fire the jump effect.
   symbolLocation: { symbol: string; file: string | null; line: number | null; error: string | null; nonce: number } | null;
+  // #6474 — the latest find-in-project result set (a `search_results` reply) that
+  // feeds the Cmd+Shift+F palette. Named `codeSearch*` to avoid colliding with the
+  // cross-session `searchResults` below. Null until the first search this session.
+  codeSearchResults: ServerSearchResultsMessage | null;
+  // #6474 — true between dispatching a `search_content` request and its reply.
+  codeSearchLoading: boolean;
 
   // Custom agents from server
   customAgents: CustomAgent[];
@@ -1415,6 +1421,9 @@ export interface ConnectionState {
   // `file` is the originating file (a ranking tie-break hint). The reply lands in
   // `symbolLocation`; FileBrowserPanel reacts to jump there or show 'not found'.
   requestResolveSymbol: (symbol: string, file?: string) => void;
+  // #6474 — find-in-project: grep the workspace for `query` (2+ chars). Sets
+  // codeSearchLoading; the reply lands in `codeSearchResults` (Cmd+Shift+F palette).
+  requestSearchContent: (query: string) => void;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8245,6 +8245,18 @@ button.sidebar-token-view-session-row:hover {
 .symbol-item-exported { color: var(--success-fg, #4ade80); flex-shrink: 0; }
 .symbol-item-line { margin-left: auto; color: var(--text-muted); opacity: 0.6; flex-shrink: 0; }
 
+/* #6474 — Cmd+Shift+F find-in-project result row: the matched line as a preview,
+   monospace + truncated, with the file:line pushed to the right by symbol-item-line. */
+.code-search-preview {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
 /* Syntax token colors */
 .syn-keyword { color: #c4a5ff; }
 .syn-string { color: #4eca6a; }

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -473,6 +473,12 @@ export declare const ResolveSymbolSchema: z.ZodObject<{
     file: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
+export declare const SearchContentSchema: z.ZodObject<{
+    type: z.ZodLiteral<"search_content">;
+    query: z.ZodString;
+    path: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ListSlashCommandsSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_slash_commands">;
 }, z.core.$loose>;
@@ -1031,6 +1037,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"resolve_symbol">;
     symbol: z.ZodString;
     file: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"search_content">;
+    query: z.ZodString;
+    path: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_slash_commands">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -618,6 +618,15 @@ export const ResolveSymbolSchema = z.object({
     file: z.string().max(4096).optional(),
     sessionId: z.string().max(256).optional(),
 }).passthrough();
+// #6474 (epic #6469): find-in-project content grep (server → `search_results`).
+// `query` is the case-insensitive needle (2+ chars); `path` optionally scopes the
+// search to a sub-dir/file. Gated behind the opt-in `features.ide` flag.
+export const SearchContentSchema = z.object({
+    type: z.literal('search_content'),
+    query: z.string().min(1).max(1024),
+    path: z.string().max(4096).optional(),
+    sessionId: z.string().max(256).optional(),
+}).passthrough();
 export const ListSlashCommandsSchema = z.object({
     type: z.literal('list_slash_commands'),
 }).passthrough();
@@ -1251,6 +1260,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     ListFilesSchema,
     ListSymbolsSchema,
     ResolveSymbolSchema,
+    SearchContentSchema,
     ListSlashCommandsSchema,
     ListAgentsSchema,
     RequestFullHistorySchema,

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -618,7 +618,7 @@ export const ResolveSymbolSchema = z.object({
     file: z.string().max(4096).optional(),
     sessionId: z.string().max(256).optional(),
 }).passthrough();
-// #6474 (epic #6469): find-in-project content grep (server → `search_results`).
+// #6474 (epic #6469): find-in-project content grep (server → `code_search_results`).
 // `query` is the case-insensitive needle (2+ chars); `path` optionally scopes the
 // search to a sub-dir/file. Gated behind the opt-in `features.ide` flag.
 export const SearchContentSchema = z.object({

--- a/packages/protocol/dist/schemas/server/ide.d.ts
+++ b/packages/protocol/dist/schemas/server/ide.d.ts
@@ -41,3 +41,23 @@ export declare const ServerSymbolLocationSchema: z.ZodObject<{
     error: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
 export type ServerSymbolLocationMessage = z.infer<typeof ServerSymbolLocationSchema>;
+export declare const SearchResultEntrySchema: z.ZodObject<{
+    file: z.ZodString;
+    line: z.ZodNumber;
+    column: z.ZodNumber;
+    text: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerSearchResultsSchema: z.ZodObject<{
+    type: z.ZodLiteral<"code_search_results">;
+    query: z.ZodString;
+    results: z.ZodArray<z.ZodObject<{
+        file: z.ZodString;
+        line: z.ZodNumber;
+        column: z.ZodNumber;
+        text: z.ZodString;
+    }, z.core.$strip>>;
+    truncated: z.ZodBoolean;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+export type SearchResultEntry = z.infer<typeof SearchResultEntrySchema>;
+export type ServerSearchResultsMessage = z.infer<typeof ServerSearchResultsSchema>;

--- a/packages/protocol/dist/schemas/server/ide.js
+++ b/packages/protocol/dist/schemas/server/ide.js
@@ -43,3 +43,24 @@ export const ServerSymbolLocationSchema = z.object({
     line: z.number().nullable(),
     error: z.string().nullable(),
 });
+// One content-search match (#6474). `file` is the workspace-relative POSIX path,
+// `line`/`column` are 1-indexed, `text` is the matched line (server-capped) for
+// a preview snippet.
+export const SearchResultEntrySchema = z.object({
+    file: z.string(),
+    line: z.number(),
+    column: z.number(),
+    text: z.string(),
+});
+// `search_content` response (#6474) — find-in-project. The wire type is
+// `code_search_results` (NOT `search_results`, which the cross-session
+// conversation search already owns in the shared dispatch table). `query` echoes
+// the needle (correlation), `truncated` is true when the result/file cap was hit,
+// `error` is non-null only on failure (results then empty).
+export const ServerSearchResultsSchema = z.object({
+    type: z.literal('code_search_results'),
+    query: z.string(),
+    results: z.array(SearchResultEntrySchema),
+    truncated: z.boolean(),
+    error: z.string().nullable(),
+});

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -695,6 +695,16 @@ export const ResolveSymbolSchema = z.object({
   sessionId: z.string().max(256).optional(),
 }).passthrough()
 
+// #6474 (epic #6469): find-in-project content grep (server → `search_results`).
+// `query` is the case-insensitive needle (2+ chars); `path` optionally scopes the
+// search to a sub-dir/file. Gated behind the opt-in `features.ide` flag.
+export const SearchContentSchema = z.object({
+  type: z.literal('search_content'),
+  query: z.string().min(1).max(1024),
+  path: z.string().max(4096).optional(),
+  sessionId: z.string().max(256).optional(),
+}).passthrough()
+
 export const ListSlashCommandsSchema = z.object({
   type: z.literal('list_slash_commands'),
 }).passthrough()
@@ -1410,6 +1420,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   ListFilesSchema,
   ListSymbolsSchema,
   ResolveSymbolSchema,
+  SearchContentSchema,
   ListSlashCommandsSchema,
   ListAgentsSchema,
   RequestFullHistorySchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -695,7 +695,7 @@ export const ResolveSymbolSchema = z.object({
   sessionId: z.string().max(256).optional(),
 }).passthrough()
 
-// #6474 (epic #6469): find-in-project content grep (server → `search_results`).
+// #6474 (epic #6469): find-in-project content grep (server → `code_search_results`).
 // `query` is the case-insensitive needle (2+ chars); `path` optionally scopes the
 // search to a sub-dir/file. Gated behind the opt-in `features.ide` flag.
 export const SearchContentSchema = z.object({

--- a/packages/protocol/src/schemas/server/ide.ts
+++ b/packages/protocol/src/schemas/server/ide.ts
@@ -51,3 +51,29 @@ export const ServerSymbolLocationSchema = z.object({
 })
 
 export type ServerSymbolLocationMessage = z.infer<typeof ServerSymbolLocationSchema>
+
+// One content-search match (#6474). `file` is the workspace-relative POSIX path,
+// `line`/`column` are 1-indexed, `text` is the matched line (server-capped) for
+// a preview snippet.
+export const SearchResultEntrySchema = z.object({
+  file: z.string(),
+  line: z.number(),
+  column: z.number(),
+  text: z.string(),
+})
+
+// `search_content` response (#6474) — find-in-project. The wire type is
+// `code_search_results` (NOT `search_results`, which the cross-session
+// conversation search already owns in the shared dispatch table). `query` echoes
+// the needle (correlation), `truncated` is true when the result/file cap was hit,
+// `error` is non-null only on failure (results then empty).
+export const ServerSearchResultsSchema = z.object({
+  type: z.literal('code_search_results'),
+  query: z.string(),
+  results: z.array(SearchResultEntrySchema),
+  truncated: z.boolean(),
+  error: z.string().nullable(),
+})
+
+export type SearchResultEntry = z.infer<typeof SearchResultEntrySchema>
+export type ServerSearchResultsMessage = z.infer<typeof ServerSearchResultsSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -120,6 +120,7 @@ const PLATFORM_SPECIFIC = {
   'file_list': 'dashboard',          // file explorer sidebar is dashboard-only
   'symbols_snapshot': 'dashboard',   // #6471 (epic #6469) opt-in IDE symbol table — dashboard symbol panel (#6472) is dashboard-only for v1; mobile parity is a tracked fast-follow
   'symbol_location': 'dashboard',    // #6475 (epic #6469) opt-in IDE go-to-definition result — dashboard file viewer cmd/ctrl+click jump; dashboard-only for v1, mobile parity deferred
+  'code_search_results': 'dashboard', // #6474 (epic #6469) opt-in IDE find-in-project results — dashboard Cmd+Shift+F palette; distinct from cross-session `search_results`; dashboard-only for v1
   'environment_created': 'dashboard', // environment panel is dashboard-only
   'environment_list': 'dashboard',    // environment panel is dashboard-only
   'environment_destroyed': 'dashboard', // environment panel is dashboard-only

--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -7,11 +7,12 @@
  * the operator opts in, so clients won't send these messages, and the handler
  * additionally returns early as defence-in-depth. Off ⇒ zero IDE behaviour.
  *
- * Handles: list_symbols (#6471), resolve_symbol (#6475).
+ * Handles: list_symbols (#6471), resolve_symbol (#6475), search_content (#6474).
  */
 import { resolveSession } from '../handler-utils.js'
 import { isIdeFeatureEnabled } from '../config.js'
 import { collectWorkspaceSymbols, resolveSymbol } from '../ide/symbols.js'
+import { searchContent } from '../ide/search.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ide')
@@ -111,7 +112,55 @@ async function handleResolveSymbol(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * `search_content` → `code_search_results`. Find-in-project (#6474):
+ * case-insensitive substring grep over the session workspace (or an optional
+ * sub-path), returning file/line/column + the matched line for preview. The
+ * response type is `code_search_results` (NOT `search_results`, owned by the
+ * cross-session conversation search). Dashboard-only consumer (Cmd+Shift+F).
+ */
+async function handleSearchContent(ws, client, msg, ctx) {
+  // #6481 (epic #6469): fail closed when the IDE surface is not opted in.
+  if (!isIdeFeatureEnabled(ctx.services?.config)) return
+
+  const query = typeof msg.query === 'string' ? msg.query.trim() : ''
+  const path = typeof msg.path === 'string' && msg.path ? msg.path : null
+
+  if (!query) {
+    ctx.transport.send(ws, { type: 'code_search_results', query: '', results: [], truncated: false, error: null })
+    return
+  }
+
+  const entry = resolveSession(ctx, msg, client)
+  const cwd = entry?.cwd || null
+  if (!cwd) {
+    ctx.transport.send(ws, {
+      type: 'code_search_results',
+      query,
+      results: [],
+      truncated: false,
+      error: 'No workspace directory for this session',
+    })
+    return
+  }
+
+  try {
+    const { results, truncated } = await searchContent(cwd, query, { path })
+    ctx.transport.send(ws, { type: 'code_search_results', query, results, truncated, error: null })
+  } catch (err) {
+    log.debug(`search_content failed: ${err?.message}`)
+    ctx.transport.send(ws, {
+      type: 'code_search_results',
+      query,
+      results: [],
+      truncated: false,
+      error: err?.message || 'Failed to search',
+    })
+  }
+}
+
 export const ideHandlers = {
   list_symbols: handleListSymbols,
   resolve_symbol: handleResolveSymbol,
+  search_content: handleSearchContent,
 }

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -1,0 +1,174 @@
+/**
+ * IDE content search (#6474, epic #6469) — find-in-project / codebase grep.
+ *
+ * A self-contained, dependency-free recursive content search over the session
+ * workspace: case-insensitive substring match, returning file/line/column plus
+ * the matched line as a preview. Powers the dashboard Cmd+Shift+F palette; it
+ * also gives find-references (#6477) a reverse-lookup primitive.
+ *
+ * SECURITY — the walk mirrors collectWorkspaceSymbols (ide/symbols.js): the root
+ * is realpath-resolved and an optional scope `path` is REAL-path confined to it
+ * (a `..`-escape, an absolute path, or a symlink whose real target lands outside
+ * is refused), ignored/dot dirs are skipped, and files are lstat'd so a symlink
+ * is never followed. Keep the two confinement blocks in sync — both are the
+ * attacker-reachable WS surface's boundary; the regression tests
+ * (ide-search.test.js) assert the symlink-escape cases on both.
+ */
+import { readdir, readFile, stat, realpath, lstat } from 'fs/promises'
+import { join, resolve, relative, extname, sep } from 'path'
+
+// Directories never worth walking (mirrors symbols.js IGNORED_DIRS).
+const IGNORED_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', 'target', 'coverage',
+  '.next', '.nuxt', '.expo', '.turbo', '.cache', 'vendor', '__pycache__',
+  '.venv', 'venv', '.tox', '.gradle', '.idea', '.vscode-test',
+])
+
+// Text file extensions we grep. Broader than symbols' EXT_LANG (which only
+// parses js/py) — a codebase search should cover configs, docs, and other
+// source languages — but still an allowlist so binaries/assets are skipped
+// without a read.
+const TEXT_EXT = new Set([
+  '.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx', '.mts', '.cts',
+  '.py', '.pyi', '.rb', '.go', '.rs', '.java', '.kt', '.swift', '.c', '.h',
+  '.cc', '.cpp', '.hpp', '.cs', '.php', '.lua', '.sh', '.bash', '.zsh',
+  '.json', '.jsonc', '.yml', '.yaml', '.toml', '.ini', '.env', '.xml',
+  '.html', '.htm', '.css', '.scss', '.less', '.svg', '.vue', '.svelte',
+  '.md', '.mdx', '.txt', '.rst', '.sql', '.graphql', '.gql', '.proto',
+  '.dockerfile', '.gitignore', '.editorconfig',
+])
+
+/**
+ * Search the workspace (or a confined sub-path) for a case-insensitive substring.
+ *
+ * @param {string} rootDir            Absolute workspace root (session cwd).
+ * @param {string} query             Needle (min 2 chars after trim; else no-op).
+ * @param {object} [opts]
+ * @param {string|null} [opts.path]   Workspace-relative file/dir to scope to.
+ * @param {number} [opts.maxFiles]    Cap on files read (default 2000).
+ * @param {number} [opts.maxResults]  Cap on match rows returned (default 500).
+ * @param {number} [opts.maxFileSize] Skip files larger than this (default 512KB).
+ * @param {number} [opts.maxDepth]    Directory recursion depth (default 12).
+ * @param {number} [opts.maxLineLength] Preview cap so a minified line can't bloat
+ *                                       a result (default 1000).
+ * @returns {Promise<{results: Array<{file:string,line:number,column:number,text:string}>, truncated: boolean}>}
+ */
+export async function searchContent(rootDir, query, opts = {}) {
+  const {
+    path = null,
+    maxFiles = 2000,
+    maxResults = 500,
+    maxFileSize = 512 * 1024,
+    maxDepth = 12,
+    maxLineLength = 1000,
+  } = opts
+
+  const needle = typeof query === 'string' ? query.trim() : ''
+  // A 1-char search would match almost everything and swamp the result cap; the
+  // dashboard also requires 2+ chars, so this is a cheap server-side guard too.
+  if (needle.length < 2) return { results: [], truncated: false }
+  const lowerNeedle = needle.toLowerCase()
+
+  // Realpath-confine the root (symlink-safe base) — see the security note above.
+  let root
+  try {
+    root = await realpath(resolve(rootDir))
+  } catch {
+    return { results: [], truncated: false }
+  }
+
+  let target = root
+  if (path) {
+    let realTarget
+    try {
+      realTarget = await realpath(resolve(root, path))
+    } catch {
+      return { results: [], truncated: false }
+    }
+    const rel = relative(root, realTarget)
+    if (rel === '..' || rel.startsWith('..' + sep) || resolve(root, rel) !== realTarget) {
+      return { results: [], truncated: false }
+    }
+    if (rel.split(sep).some((s) => IGNORED_DIRS.has(s) || s.startsWith('.'))) {
+      return { results: [], truncated: false }
+    }
+    target = realTarget
+  }
+
+  const results = []
+  let filesRead = 0
+  let truncated = false
+
+  /** Grep one file into the accumulator, honouring the caps. */
+  async function grepFile(absPath) {
+    if (filesRead >= maxFiles) { truncated = true; return }
+    const ext = extname(absPath).toLowerCase()
+    // Match extensionless well-known files (Dockerfile, Makefile) by basename too.
+    if (!TEXT_EXT.has(ext) && !TEXT_EXT.has(`.${absPath.split(sep).pop().toLowerCase()}`)) return
+    let st
+    try {
+      // lstat (not stat) so a symlink is never followed — defence-in-depth; the
+      // scoped target is realpath-confined and walk() skips symlink dirents.
+      st = await lstat(absPath)
+    } catch { return }
+    if (!st.isFile()) return
+    if (st.size > maxFileSize) return
+    filesRead++
+    let content
+    try {
+      content = await readFile(absPath, 'utf-8')
+    } catch { return }
+    // Skip a file that looks binary (a NUL in the first chunk) despite its ext.
+    if (content.indexOf(String.fromCharCode(0)) !== -1) return
+    const rel = relative(root, absPath).split(sep).join('/')
+    const lines = content.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const idx = lines[i].toLowerCase().indexOf(lowerNeedle)
+      if (idx === -1) continue
+      if (results.length >= maxResults) { truncated = true; return }
+      results.push({
+        file: rel,
+        line: i + 1,
+        column: idx + 1,
+        text: lines[i].length > maxLineLength ? lines[i].slice(0, maxLineLength) : lines[i],
+      })
+    }
+  }
+
+  /** Recursively walk a directory. */
+  async function walk(dir, depth) {
+    if (depth > maxDepth || filesRead >= maxFiles || results.length >= maxResults) {
+      if (filesRead >= maxFiles || results.length >= maxResults) truncated = true
+      return
+    }
+    let dirents
+    try {
+      dirents = await readdir(dir, { withFileTypes: true })
+    } catch { return }
+    dirents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    for (const ent of dirents) {
+      if (filesRead >= maxFiles || results.length >= maxResults) { truncated = true; break }
+      const abs = join(dir, ent.name)
+      if (ent.isDirectory()) {
+        if (IGNORED_DIRS.has(ent.name) || ent.name.startsWith('.')) continue
+        await walk(abs, depth + 1)
+      } else if (ent.isFile()) {
+        await grepFile(abs)
+      }
+    }
+  }
+
+  let tstat
+  try {
+    tstat = await stat(target)
+  } catch {
+    return { results, truncated }
+  }
+  if (tstat.isFile()) {
+    await grepFile(target)
+  } else if (tstat.isDirectory()) {
+    await walk(target, 0)
+  }
+
+  return { results, truncated }
+}

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -35,7 +35,14 @@ const TEXT_EXT = new Set([
   '.json', '.jsonc', '.yml', '.yaml', '.toml', '.ini', '.env', '.xml',
   '.html', '.htm', '.css', '.scss', '.less', '.svg', '.vue', '.svelte',
   '.md', '.mdx', '.txt', '.rst', '.sql', '.graphql', '.gql', '.proto',
-  '.dockerfile', '.gitignore', '.editorconfig',
+])
+
+// Extensionless / dotfile basenames worth grepping. Matched by FULL basename
+// (lowercased) — `extname()` returns '' for a leading-dot file like `.env`, so
+// these can't be caught by TEXT_EXT.
+const TEXT_BASENAMES = new Set([
+  '.env', '.gitignore', '.editorconfig', '.npmrc', '.nvmrc', '.babelrc',
+  '.prettierrc', '.eslintrc', 'dockerfile', 'makefile', 'procfile', 'gemfile',
 ])
 
 /**
@@ -102,9 +109,12 @@ export async function searchContent(rootDir, query, opts = {}) {
   /** Grep one file into the accumulator, honouring the caps. */
   async function grepFile(absPath) {
     if (filesRead >= maxFiles) { truncated = true; return }
-    const ext = extname(absPath).toLowerCase()
-    // Match extensionless well-known files (Dockerfile, Makefile) by basename too.
-    if (!TEXT_EXT.has(ext) && !TEXT_EXT.has(`.${absPath.split(sep).pop().toLowerCase()}`)) return
+    const base = absPath.split(sep).pop().toLowerCase()
+    const ext = extname(base)
+    // Match by extension (foo.ts) OR by full basename for dotfiles / extensionless
+    // well-known files (.env, .gitignore, Dockerfile, Makefile) — extname() is ''
+    // for those, so the TEXT_EXT check alone would miss them.
+    if (!TEXT_EXT.has(ext) && !TEXT_BASENAMES.has(base)) return
     let st
     try {
       // lstat (not stat) so a symlink is never followed — defence-in-depth; the

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -293,6 +293,7 @@ function _isSecureRequest(req) {
  *   { type: 'list_files', path? }                       — request file listing for a path
  *   { type: 'list_symbols', path? }                     — request workspace symbol table (#6471, opt-in IDE — features.ide)
  *   { type: 'resolve_symbol', symbol, file? }           — resolve a symbol name to its definition (#6475, opt-in IDE — features.ide)
+ *   { type: 'search_content', query, path? }            — find-in-project content grep (#6474, opt-in IDE — features.ide)
  *   { type: 'list_providers' }                          — request available provider list
  *   { type: 'list_repos' }                              — request workspace repository list
  *   { type: 'list_skills' }                             — request active skills list
@@ -382,6 +383,7 @@ function _isSecureRequest(req) {
  *   { type: 'file_content', path, content, language, size, truncated, error } — file content response
  *   { type: 'symbols_snapshot', path, symbols: [{ name, kind, file, line, exported }], truncated, error } — #6471 workspace symbol table (opt-in IDE, features.ide; dashboard-only v1)
  *   { type: 'symbol_location', symbol, file, line, error } — #6475 go-to-definition result (opt-in IDE, features.ide; dashboard-only v1)
+ *   { type: 'code_search_results', query, results: [{ file, line, column, text }], truncated, error } — #6474 find-in-project results (opt-in IDE, features.ide; dashboard-only v1)
  *   { type: 'slash_commands', commands: [{ name, description, source }] } — available slash commands
  *   { type: 'agent_list', agents: [{ name, description, source }] } — available custom agents
  *   { type: 'client_joined', client: { clientId, deviceName, deviceType, platform } } — new client connected

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -181,7 +181,7 @@ describe('search_content handler — emission', () => {
   })
   after(() => rmSync(root, { recursive: true, force: true }))
 
-  it('emits a schema-valid search_results with file/line/column/text on a hit', async () => {
+  it('emits a schema-valid code_search_results with file/line/column/text on a hit', async () => {
     const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
     await handleSearchContent({}, client, { type: 'search_content', query: 'findMe' }, ctx)
     assert.equal(sent.length, 1)

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ideHandlers } from '../src/handlers/ide-handlers.js'
-import { ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema } from '@chroxy/protocol'
+import { ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema } from '@chroxy/protocol'
 import { nsCtx } from './test-helpers.js'
 
 /**
@@ -15,6 +15,7 @@ import { nsCtx } from './test-helpers.js'
 
 const handleListSymbols = ideHandlers.list_symbols
 const handleResolveSymbol = ideHandlers.resolve_symbol
+const handleSearchContent = ideHandlers.search_content
 
 /** Build a handler ctx with a send-capturing transport, a config (for the flag
  *  gate), and a sessionManager resolving the given cwd. */
@@ -161,5 +162,59 @@ describe('resolve_symbol handler — cross-platform file hint (#6498)', () => {
     const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
     await handleResolveSymbol({}, client, { type: 'resolve_symbol', symbol: 'target', file: '  sub/local.ts  ' }, ctx)
     assert.equal(sent[0].file, 'sub/local.ts')
+  })
+})
+
+describe('search_content handler — feature gate', () => {
+  it('is a no-op (no send) when features.ide is off', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: false, cwd: '/tmp' })
+    await handleSearchContent({}, client, { type: 'search_content', query: 'x' }, ctx)
+    assert.equal(sent.length, 0)
+  })
+})
+
+describe('search_content handler — emission', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-search-h-'))
+    writeFileSync(join(root, 'mod.ts'), 'export function findMe() {}\nconst other = 1\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('emits a schema-valid search_results with file/line/column/text on a hit', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleSearchContent({}, client, { type: 'search_content', query: 'findMe' }, ctx)
+    assert.equal(sent.length, 1)
+    const msg = sent[0]
+    assert.ok(ServerSearchResultsSchema.safeParse(msg).success, 'emitted message must satisfy ServerSearchResultsSchema')
+    assert.equal(msg.query, 'findMe')
+    assert.equal(msg.error, null)
+    assert.equal(msg.results.length, 1)
+    assert.equal(msg.results[0].file, 'mod.ts')
+    assert.equal(msg.results[0].line, 1)
+    assert.ok(msg.results[0].text.includes('findMe'))
+  })
+
+  it('emits an empty schema-valid result set for a miss', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleSearchContent({}, client, { type: 'search_content', query: 'zzznope' }, ctx)
+    assert.ok(ServerSearchResultsSchema.safeParse(sent[0]).success)
+    assert.deepEqual(sent[0].results, [])
+    assert.equal(sent[0].error, null)
+  })
+
+  it('emits an empty result set for an empty query (no crash)', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleSearchContent({}, client, { type: 'search_content', query: '   ' }, ctx)
+    assert.equal(sent[0].type, 'code_search_results')
+    assert.deepEqual(sent[0].results, [])
+  })
+
+  it('emits an error result when the session has no cwd', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: null })
+    await handleSearchContent({}, client, { type: 'search_content', query: 'findMe' }, ctx)
+    assert.equal(sent[0].type, 'code_search_results')
+    assert.deepEqual(sent[0].results, [])
+    assert.match(sent[0].error, /No workspace/)
   })
 })

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -19,6 +19,8 @@ describe('searchContent — grep behaviour', () => {
     mkdirSync(join(root, 'src'))
     writeFileSync(join(root, 'src', 'b.ts'), 'export const target = go()\n')
     writeFileSync(join(root, 'readme.md'), '# targeting the docs\n')
+    // A dotfile — extname('.env') is '', so it must match via the basename allowlist.
+    writeFileSync(join(root, '.env'), 'API_KEY=findme_env\n')
     // Ignored dirs must not be searched.
     mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true })
     writeFileSync(join(root, 'node_modules', 'pkg', 'index.js'), 'const target = "hidden"\n')
@@ -35,6 +37,13 @@ describe('searchContent — grep behaviour', () => {
     assert.deepEqual(keys, ['a.js:1:7', 'a.js:3:1', 'readme.md:1:3', 'src/b.ts:1:14'])
     const a1 = results.find((r) => r.file === 'a.js' && r.line === 1)
     assert.equal(a1.text, 'const target = 1')
+  })
+
+  it('greps dotfiles / extensionless files via the basename allowlist (#6505 review)', async () => {
+    const { results } = await searchContent(root, 'findme_env')
+    assert.equal(results.length, 1)
+    assert.equal(results[0].file, '.env')
+    assert.equal(results[0].line, 1)
   })
 
   it('uses forward-slash workspace-relative paths', async () => {

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -1,0 +1,115 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { searchContent } from '../src/ide/search.js'
+
+/**
+ * Unit tests for the IDE content-search backend (#6474, epic #6469). Grep
+ * behaviour + the realpath confinement (mirrors ide-symbols.test.js) against a
+ * real temp workspace — the symlink-escape cases are the security regression.
+ */
+
+describe('searchContent — grep behaviour', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-search-'))
+    writeFileSync(join(root, 'a.js'), 'const target = 1\nconst other = 2\nTARGET again\n')
+    mkdirSync(join(root, 'src'))
+    writeFileSync(join(root, 'src', 'b.ts'), 'export const target = go()\n')
+    writeFileSync(join(root, 'readme.md'), '# targeting the docs\n')
+    // Ignored dirs must not be searched.
+    mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true })
+    writeFileSync(join(root, 'node_modules', 'pkg', 'index.js'), 'const target = "hidden"\n')
+    // Non-text asset ignored.
+    writeFileSync(join(root, 'logo.png'), 'target-not-searched-binary-ext\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('finds a case-insensitive substring with file / 1-indexed line / 1-indexed column', async () => {
+    const { results, truncated } = await searchContent(root, 'target')
+    assert.equal(truncated, false)
+    // a.js line 1 (col 7) + line 3 (col 1, "TARGET"), src/b.ts line 1, readme.md line 1.
+    const keys = results.map((r) => `${r.file}:${r.line}:${r.column}`).sort()
+    assert.deepEqual(keys, ['a.js:1:7', 'a.js:3:1', 'readme.md:1:3', 'src/b.ts:1:14'])
+    const a1 = results.find((r) => r.file === 'a.js' && r.line === 1)
+    assert.equal(a1.text, 'const target = 1')
+  })
+
+  it('uses forward-slash workspace-relative paths', async () => {
+    const { results } = await searchContent(root, 'go()')
+    assert.equal(results.length, 1)
+    assert.equal(results[0].file, 'src/b.ts')
+  })
+
+  it('skips node_modules / ignored dirs and non-text extensions', async () => {
+    const { results } = await searchContent(root, 'target')
+    assert.ok(!results.some((r) => r.file.includes('node_modules')), 'node_modules excluded')
+    assert.ok(!results.some((r) => r.file.endsWith('.png')), 'binary-ext asset excluded')
+  })
+
+  it('is a no-op for a query shorter than 2 chars', async () => {
+    assert.deepEqual((await searchContent(root, 't')).results, [])
+    assert.deepEqual((await searchContent(root, '')).results, [])
+    assert.deepEqual((await searchContent(root, '  ')).results, [])
+  })
+
+  it('returns nothing for a needle with no match', async () => {
+    assert.deepEqual((await searchContent(root, 'zzznomatch')).results, [])
+  })
+
+  it('sets truncated when the result cap is hit', async () => {
+    const { results, truncated } = await searchContent(root, 'target', { maxResults: 1 })
+    assert.equal(results.length, 1)
+    assert.equal(truncated, true)
+  })
+
+  it('scopes to a sub-path when path is given', async () => {
+    const { results } = await searchContent(root, 'target', { path: 'src' })
+    assert.deepEqual(results.map((r) => r.file), ['src/b.ts'])
+  })
+})
+
+describe('searchContent — confinement (security)', () => {
+  let root
+  let outside
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-search-conf-'))
+    writeFileSync(join(root, 'in.js'), 'const inside = 1\n')
+    // A sibling tree OUTSIDE the workspace, reachable only via symlinks planted
+    // inside it — the arbitrary-file-read vector the confinement must block.
+    outside = mkdtempSync(join(tmpdir(), 'chroxy-ide-search-out-'))
+    writeFileSync(join(outside, 'secret.js'), 'const TOP_SECRET = 1\n')
+    mkdirSync(join(outside, 'sub'))
+    writeFileSync(join(outside, 'sub', 'deep.js'), 'const DEEP_SECRET = 1\n')
+    symlinkSync(join(outside, 'secret.js'), join(root, 'linkfile.js'))
+    symlinkSync(outside, join(root, 'linkdir'))
+  })
+  after(() => {
+    rmSync(root, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('never surfaces a symbol reachable only through an out-of-workspace symlink', async () => {
+    // A full-tree search skips symlink dirents, so the secret never appears.
+    assert.deepEqual((await searchContent(root, 'TOP_SECRET')).results, [])
+    assert.deepEqual((await searchContent(root, 'DEEP_SECRET')).results, [])
+  })
+
+  it('refuses a path that escapes the workspace root', async () => {
+    assert.deepEqual((await searchContent(root, 'anything', { path: '../../../etc' })).results, [])
+  })
+
+  it('refuses a symlinked FILE whose real target is outside the workspace', async () => {
+    assert.deepEqual((await searchContent(root, 'TOP_SECRET', { path: 'linkfile.js' })).results, [])
+  })
+
+  it('refuses a symlinked DIRECTORY whose real target is outside the workspace', async () => {
+    assert.deepEqual((await searchContent(root, 'DEEP_SECRET', { path: 'linkdir' })).results, [])
+  })
+
+  it('refuses traversal THROUGH an in-workspace symlink to an outside file', async () => {
+    assert.deepEqual((await searchContent(root, 'DEEP_SECRET', { path: 'linkdir/sub/deep.js' })).results, [])
+  })
+})

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -158,6 +158,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'session_activity',           // per-session busy/idle + cost ping — dashboard activity tree only
   'symbols_snapshot',           // #6471 (epic #6469) opt-in IDE workspace symbol table — dashboard symbol panel (#6472) only for v1; mobile parity is a tracked fast-follow
   'symbol_location',            // #6475 (epic #6469) opt-in IDE go-to-definition result — dashboard file viewer cmd/ctrl+click jump; dashboard-only for v1, mobile parity deferred
+  'code_search_results',        // #6474 (epic #6469) opt-in IDE find-in-project results — dashboard Cmd+Shift+F palette; distinct from cross-session `search_results`; dashboard-only for v1
   'terminal_size',              // authoritative PTY grid for letterboxing — app terminal parity is still partial (#5987)
   // #6332 (batch 2b of #6314): the container/worktree environment lifecycle —
   // dashboard-only by design (the app has no environment surface). Schemaing


### PR DESCRIPTION
## Summary

Adds a codebase grep to the opt-in IDE surface (#6469 Phase 1): a `search_content` WS backend + a **Cmd+Shift+F** dashboard palette. The `list_files` backend the issue mentioned is a *filename* fuzzy-picker (Cmd+P), so a true find-in-project with `file:line` results needs a real content-search backend — built here. Its reverse-lookup primitive also unblocks find-references (#6477).

## What changed

**Server**
- `ide/search.js` `searchContent(rootDir, query, opts)` — case-insensitive substring grep over the workspace, returning `{file, line, column, text}` (the matched line as a preview). Reuses `collectWorkspaceSymbols`' **realpath confinement + bounded walk** (out-of-workspace symlink refused, ignored/dot dirs skipped, `lstat` symlink-blind), with a broader text-extension allowlist, a NUL-byte binary skip, and caps (`maxFiles`/`maxResults`/`maxFileSize`/`maxDepth`).
- `search_content` handler in `ide-handlers.js` — fail-closed on `features.ide`; emits `code_search_results`.

**Protocol**
- `SearchContentSchema` (client) + `ServerSearchResultsSchema` (server/ide), registered in the client union, the `ws-server.js` doc comments, and both coverage guards.
- ⚠️ The **response wire type is `code_search_results`**, NOT `search_results` — the cross-session *conversation* search already owns `search_results` in the shared dispatch table (`runDispatch` handles it before the per-client HANDLERS map, so reusing the name would have silently shadowed this handler). Caught during implementation via a dispatch test; renamed.

**Dashboard**
- `requestSearchContent` sender + `codeSearchResults`/`codeSearchLoading` store fields (named `codeSearch*` to avoid the existing cross-session `searchResults` field) + `handleSearchResults` dispatch.
- `CodeSearchPalette`: **debounced** server-side search (2+ chars, since content match can't run client-side), results rendered as `file:line` + a monospace line preview, arrow/Enter/click → `openFileInBrowser(file, line)`, and a stale-query guard keyed on the echoed `query`. Cmd+Shift+F shortcut, gated on the `ide` capability.

## Acceptance (from #6474)
- [x] Cmd+Shift+F searches the workspace; results link to `file:line`
- [x] Reuses existing backend search *pattern* (the confined walk from #6471) — a filename picker can't return line-level matches, so a content backend was required

## Testing
- **Server:** `searchContent` grep/case-insensitivity/caps/scope + the confinement suite (out-of-workspace symlink file/dir/traversal refused); handler emission + `features.ide` gate + no-cwd. Server ide suite: **50** pass.
- **Dashboard:** `code_search_results` dispatch (stores + clears loading + **leaves the cross-session `searchResults` untouched** + drops malformed); `CodeSearchPalette` debounce, results, jump, arrow-nav, stale-query guard, empty/hint states. Full dashboard suite **4141**, store-core **1919**, protocol **347**; both coverage guards + server lints green; all typechecks clean.

> The palette's visual polish (layout/theming) is a nice follow-up to eyeball live; the search/results/jump **logic** is unit-tested end-to-end.

Closes #6474