### PR TITLE
fix(dashboard): repair file-viewer CSS nesting + tokenizer extension coverage (IDE #6469)

### DIFF
--- a/packages/dashboard/src/components/css-audit.test.ts
+++ b/packages/dashboard/src/components/css-audit.test.ts
@@ -53,12 +53,20 @@ describe('CSS structure — file viewer rules are not accidentally nested', () =
     expect((css.match(/{/g) || []).length).toBe((css.match(/}/g) || []).length)
   })
 
-  it('.file-tree-btn opens with a declaration body, not a comment or nested selector', () => {
+  it('.file-tree-btn opens with a declaration body, not a nested selector', () => {
     const css = readCss()
     const idx = css.search(/^\.file-tree-btn\s*\{/m)
     expect(idx).toBeGreaterThan(-1)
-    const firstBodyLine = (css.slice(idx).split('\n')[1] ?? '').trim()
-    // A real property (`display: flex;`), NOT `/* … */` or `.some-selector {`.
-    expect(firstBodyLine).toMatch(/^[a-z-]+\s*:/)
+    // Take everything after the opening brace, strip block comments, and find the
+    // first non-blank line — so a harmless leading comment or blank line doesn't
+    // trip the guard. It must be a declaration (`prop: value`); a nested selector
+    // (`.foo {`) or stray `}` there signals the unclosed-rule corruption.
+    const afterBrace = css.slice(idx + css.slice(idx).indexOf('{') + 1)
+    const firstMeaningful = afterBrace
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? ''
+    expect(firstMeaningful).toMatch(/^[a-z-]+\s*:/)
   })
 })

--- a/packages/dashboard/src/components/css-audit.test.ts
+++ b/packages/dashboard/src/components/css-audit.test.ts
@@ -37,3 +37,28 @@ describe('CSS audit — no dead rules', () => {
     expect(matches).toHaveLength(1)
   })
 })
+
+/**
+ * Structural guard (IDE #6469 viewer regression).
+ *
+ * `.file-tree-btn {` once lost its body + closing brace, so native CSS nesting
+ * swallowed the whole file-viewer + symbol-panel + diff-viewer section into
+ * `.file-tree-btn { … }` — those rules then only matched elements INSIDE a tree
+ * button (i.e. never), so the viewer rendered with browser defaults (no
+ * syntax-highlight colours, no line-number gutter, jammed symbol panel).
+ */
+describe('CSS structure — file viewer rules are not accidentally nested', () => {
+  it('components.css has balanced braces', () => {
+    const css = readCss()
+    expect((css.match(/{/g) || []).length).toBe((css.match(/}/g) || []).length)
+  })
+
+  it('.file-tree-btn opens with a declaration body, not a comment or nested selector', () => {
+    const css = readCss()
+    const idx = css.search(/^\.file-tree-btn\s*\{/m)
+    expect(idx).toBeGreaterThan(-1)
+    const firstBodyLine = (css.slice(idx).split('\n')[1] ?? '').trim()
+    // A real property (`display: flex;`), NOT `/* … */` or `.some-selector {`.
+    expect(firstBodyLine).toMatch(/^[a-z-]+\s*:/)
+  })
+})

--- a/packages/dashboard/src/lib/syntax.test.ts
+++ b/packages/dashboard/src/lib/syntax.test.ts
@@ -32,6 +32,21 @@ describe('getSyntaxRules', () => {
     expect(getSyntaxRules('rs')).not.toBeNull()
   })
 
+  it('resolves the JS/TS family extensions the server sends verbatim (mjs/cjs/mts/cts)', () => {
+    // reader.js sends the bare extension as the language id — these must resolve
+    // or a `.mjs`/`.cjs`/`.mts`/`.cts` file renders all-`plain` (no colours).
+    expect(getSyntaxRules('mjs')).not.toBeNull()
+    expect(getSyntaxRules('cjs')).not.toBeNull()
+    expect(getSyntaxRules('mts')).not.toBeNull()
+    expect(getSyntaxRules('cts')).not.toBeNull()
+  })
+
+  it('actually tokenizes a .mjs line into multiple token types (not all plain)', () => {
+    const kinds = new Set(tokenize('const deleteCount = go(1) // note', 'mjs').map(t => t.type))
+    expect(kinds.size).toBeGreaterThan(1)
+    expect(kinds.has('keyword')).toBe(true)
+  })
+
   it('returns null for unknown language', () => {
     expect(getSyntaxRules('brainfuck')).toBeNull()
     expect(getSyntaxRules('')).toBeNull()

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -7933,6 +7933,21 @@ button.sidebar-token-view-session-row:hover {
 .file-tree-item { margin: 0; }
 
 .file-tree-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 3px 8px;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  text-align: left;
+  border-radius: 3px;
+}
+
 /* ---- Diff Viewer Panel ---- */
 .diff-viewer-panel {
   display: flex;
@@ -8270,14 +8285,6 @@ button.sidebar-token-view-session-row:hover {
 .syn-plain { color: #a0d0ff; }
 .syn-diff_add { color: #4eca6a; }
 .syn-diff_remove { color: #ff5b5b; }
-  padding: 6px 12px;
-  font-size: var(--text-sm);
-  background: none;
-  border: none;
-  color: var(--text-primary);
-  cursor: pointer;
-  text-align: left;
-}
 
 .diff-sidebar-item:hover { background: var(--bg-card); }
 .diff-sidebar-item.active { background: var(--bg-card); border-left: 2px solid var(--accent-blue); }

--- a/packages/store-core/src/syntax.ts
+++ b/packages/store-core/src/syntax.ts
@@ -300,6 +300,13 @@ const LANGUAGES: Record<string, LanguageDef> = {
 const ALIASES: Record<string, string> = {
   js: 'javascript',
   ts: 'typescript',
+  // JS/TS family extensions the server sends verbatim as the language id
+  // (reader.js sends `extname` without a leading dot). Without these, a `.mjs`/
+  // `.cjs`/`.mts`/`.cts` file falls through to all-`plain` (no syntax colours).
+  mjs: 'javascript',
+  cjs: 'javascript',
+  mts: 'typescript',
+  cts: 'typescript',
   py: 'python',
   sh: 'bash',
   shell: 'bash',


### PR DESCRIPTION
## Summary

Two **pre-existing** bugs made the opt-in IDE file viewer (#6469) render wrong — found during live verification of the shipped IDE features (symbol search / go-to-def / find-in-project all worked; the file viewer looked "wonky": no colours, jammed line numbers, jammed symbol panel).

### 1. CSS nesting corruption (`components.css`)
`.file-tree-btn {` had lost its body **and** closing brace; an orphaned property block 345 lines below was erroneously closing it. With native CSS nesting, that swallowed the **entire file-viewer + symbol-panel + diff-viewer** section into `.file-tree-btn { … }` — so `.file-viewer-line-num`, `.symbol-item`, `.syn-*`, etc. compiled to `.file-tree-btn .file-viewer-line-num` and only matched elements *inside a tree button* (never). The viewer fell back to browser defaults:
- `.file-viewer-line-num` → `width:auto; display:inline` (gutter collapsed)
- `.symbol-item` → `display:inline-block; gap:normal` (`vdeleteCount931` jammed)
- `.syn-*` colours never applied

Fix: restored `.file-tree-btn`'s body + closing brace and removed the orphaned block. Braces re-balanced (1567/1567).

### 2. Tokenizer extension gap (`syntax.ts`)
`ws-file-ops/reader.js` sends the **bare extension** as the language id, but the tokenizer only aliased `js`/`ts` — so `.mjs`/`.cjs`/`.mts`/`.cts` files (all over this repo) fell through to all-`plain` (one colour). Added the JS/TS-family aliases → `javascript`/`typescript`.

## Verification
Headless DOM inspection against a live daemon, before → after:
| | before | after |
|---|---|---|
| distinct `syn-*` token classes on a `.mjs` | **1** (all plain) | **9** (keyword/string/comment/…) |
| `.file-viewer-line-num` | `width:auto, display:inline` | `width:48px, display:inline-block, text-align:right` |
| `.symbol-item` | `display:inline-block, gap:normal` | `display:flex, gap:6px` |

Confirmed visually in the running dashboard by the maintainer.

## Tests
- `lib/syntax.test.ts`: `getSyntaxRules`/`tokenize` resolve `mjs/cjs/mts/cts` and a `.mjs` line tokenizes into multiple types (not all plain).
- `css-audit.test.ts`: a structural guard — components.css has balanced braces, and `.file-tree-btn` opens with a declaration body (not a comment/nested selector) — catches this exact corruption class going forward.
- Full suites green: dashboard **4145**, store-core **1919**; typecheck clean.

Related to #6469 (surfaced during IDE-surface verification; not a regression from any single PR — the CSS corruption predates 40+ commits).