### PR TITLE
fix(dashboard): link Environment hint + dim disabled worktree row (#6512, #6513)

### DIFF
--- a/packages/dashboard/src/components/AdvancedSectionCss.test.ts
+++ b/packages/dashboard/src/components/AdvancedSectionCss.test.ts
@@ -40,4 +40,9 @@ describe('Advanced-section toggle layout (#6509)', () => {
     expect(rule).toMatch(/min-width:\s*0/)
     expect(rule).toMatch(/overflow-wrap:/)
   })
+
+  test('#6513: a disabled toggle row is dimmed via :has(input:disabled)', () => {
+    const rule = css.match(/\.advanced-section \.checkbox-label:has\(input:disabled\)\s*\{[^}]*\}/)?.[0] ?? ''
+    expect(rule).toMatch(/opacity:/)
+  })
 })

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -970,13 +970,14 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 id="env-select"
                 value={environmentId}
                 onChange={e => setEnvironmentId(e.target.value)}
+                aria-describedby="env-hint"
               >
                 <option value="">None (ephemeral container)</option>
                 {environments.filter(e => e.status === 'running').map(e => (
                   <option key={e.id} value={e.id}>{e.name} ({e.image})</option>
                 ))}
               </select>
-              <span className="form-hint">
+              <span id="env-hint" className="form-hint">
                 Connect to a persistent environment container
               </span>
             </div>

--- a/packages/dashboard/src/components/CreateSessionModalAdvancedLayout.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalAdvancedLayout.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../hooks/usePathAutocomplete', () => ({
 
 const TUI_PROVIDER = { name: 'claude-tui', capabilities: {}, auth: { ready: true, source: 'static', detail: '' } }
 
-function mockStore() {
+function mockStore(environments: unknown[] = []) {
   vi.doMock('../store/connection', () => ({
     useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
       selector({
@@ -30,7 +30,7 @@ function mockStore() {
         availableModelsProvider: null,
         availableProviders: [TUI_PROVIDER],
         availablePermissionModes: [],
-        environments: [],
+        environments,
         requestDirectoryListing: () => {},
         setDirectoryListingCallback: () => {},
         defaultCwd: null,
@@ -106,5 +106,17 @@ describe('CreateSessionModal Advanced-section layout (#6509)', () => {
     expect(group.getAttribute('role')).toBe('radiogroup')
     expect(group.getAttribute('aria-labelledby')).toBe('skip-permissions-legend')
     expect(group.getAttribute('aria-describedby')).toBe('skip-permissions-hint')
+  })
+
+  it('#6512: links the Environment select to its hint via aria-describedby', async () => {
+    mockStore([{ id: 'env-1', name: 'dev', image: 'node:22', status: 'running' }])
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} />)
+    openAdvanced()
+    const select = document.getElementById('env-select')
+    expect(select).not.toBeNull()
+    expect(select!.getAttribute('aria-describedby')).toBe('env-hint')
+    // The hint carries the matching id so the association resolves.
+    expect(document.getElementById('env-hint')?.classList.contains('form-hint')).toBe(true)
   })
 })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5926,6 +5926,12 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.5;
   cursor: not-allowed;
 }
+/* The input keeps `cursor: pointer` above; override it when disabled so the whole
+   row (label + box) reads consistently inert on hover (#6514 review). */
+.advanced-section .checkbox-label input:disabled,
+.advanced-section .radio-label input:disabled {
+  cursor: not-allowed;
+}
 
 .advanced-section .form-field-label {
   display: block;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5919,6 +5919,14 @@ button.sidebar-token-view-session-row:hover {
   margin-top: 2px;
 }
 
+/* #6513: the worktree checkbox is disabled until a CWD is set. Dim the whole row
+   so it reads as inert (the browser only greys the box itself). `:has()` tracks
+   the input's live :disabled state, so this needs no reactive class. */
+.advanced-section .checkbox-label:has(input:disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .advanced-section .form-field-label {
   display: block;
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary

Two Advanced-section polish nits surfaced by the #6510 review, both in the New Session modal.

- **#6512** — the **Environment** select had no programmatic hint association. Added `id="env-hint"` to its `.form-hint` + `aria-describedby="env-hint"` on the select, matching how the permission-mode and worktree hints are already wired.
- **#6513** — the worktree checkbox is `disabled` until a CWD is set, but only the box itself greyed (the label read as live). Dim the whole row via `.advanced-section .checkbox-label:has(input:disabled) { opacity: 0.5; cursor: not-allowed }`. `:has()` tracks the input's live `:disabled` state, so no reactive class is needed.

## Verification
- Live (Playwright, against the running dashboard): with the modal open and no CWD set, the worktree row's `<input>` is `disabled` and the label computes `opacity: 0.5` — dimmed as intended.
- `:has()` is browser-native and reactive; the repo's "Style Lint" job is grep-based (color-literals + undefined-vars), which this passes — no selector linter to object.

## Tests
- `CreateSessionModalAdvancedLayout.test.tsx`: the Environment select carries `aria-describedby="env-hint"` and the hint carries the matching `id`.
- `AdvancedSectionCss.test.ts`: a guard for the `:has(input:disabled)` dim rule.
- Full dashboard suite green: **4154**; both style-lint scripts + typecheck clean.

Closes #6512, closes #6513