### PR TITLE
feat(ide): find-all-references — alt/option+click a symbol (#6477)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -70,6 +70,7 @@ import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { FileOpenPalette } from './components/FileOpenPalette'
 import { SymbolSearchPalette } from './components/SymbolSearchPalette'
 import { CodeSearchPalette } from './components/CodeSearchPalette'
+import { ReferencesPalette } from './components/ReferencesPalette'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { useTunnelReady } from './hooks/useTunnelReady'
 import { useQrModal } from './hooks/useQrModal'
@@ -611,6 +612,8 @@ export function App() {
   const [fileOpenPaletteOpen, setFileOpenPaletteOpen] = useState(false)
   const [symbolSearchOpen, setSymbolSearchOpen] = useState(false)
   const [codeSearchOpen, setCodeSearchOpen] = useState(false)
+  // #6477 — the references palette is opened by alt+click (store-driven), not a shortcut.
+  const referencesOpen = useConnectionStore(s => s.referencesOpen)
 
   // Local state
   const [showCreateSession, setShowCreateSession] = useState(false)
@@ -2618,6 +2621,10 @@ export function App() {
       <CodeSearchPalette
         isOpen={codeSearchOpen}
         onClose={() => setCodeSearchOpen(false)}
+      />
+      <ReferencesPalette
+        isOpen={ideEnabled && referencesOpen}
+        onClose={() => useConnectionStore.setState({ referencesOpen: false })}
       />
     </div>
   )

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -12,6 +12,7 @@ const mockRequestGitStatus = vi.fn()
 const mockRequestSymbols = vi.fn()
 // #6475 go-to-definition
 const mockRequestResolveSymbol = vi.fn()
+const mockRequestFindReferences = vi.fn()
 const mockOpenFileInBrowser = vi.fn()
 let mockSymbolLocation: any = null
 let fileBrowserCallback: ((listing: any) => void) | null = null
@@ -42,6 +43,7 @@ vi.mock('../store/connection', () => {
     serverCapabilities: { ide: mockIdeCapability },
     fileBrowserPendingOpen: mockFileBrowserPendingOpen,
     requestResolveSymbol: mockRequestResolveSymbol,
+    requestFindReferences: mockRequestFindReferences,
     openFileInBrowser: mockOpenFileInBrowser,
     symbolLocation: mockSymbolLocation,
   })
@@ -453,6 +455,21 @@ describe('FileBrowserPanel — go-to-definition (#6475)', () => {
     await openIdentifierFile(true)
     fireEvent.click(screen.getByText('widget'))
     expect(mockRequestResolveSymbol).not.toHaveBeenCalled()
+    expect(mockRequestFindReferences).not.toHaveBeenCalled()
+  })
+
+  it('alt/option+click on a token finds references (#6477), passing the open file', async () => {
+    await openIdentifierFile(true)
+    fireEvent.click(screen.getByText('widget'), { altKey: true })
+    expect(mockRequestFindReferences).toHaveBeenCalledWith('widget', 'foo.ts')
+    expect(mockRequestResolveSymbol).not.toHaveBeenCalled()
+  })
+
+  it('cmd wins over alt when both are held (definition is primary)', async () => {
+    await openIdentifierFile(true)
+    fireEvent.click(screen.getByText('widget'), { metaKey: true, altKey: true })
+    expect(mockRequestResolveSymbol).toHaveBeenCalledWith('widget', 'foo.ts')
+    expect(mockRequestFindReferences).not.toHaveBeenCalled()
   })
 
   it('does nothing on cmd+click when the ide capability is off', async () => {

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -216,6 +216,8 @@ export function FileBrowserPanel() {
   const fileBrowserPendingOpen = useConnectionStore(s => s.fileBrowserPendingOpen)
   // #6475 — go-to-definition: cmd/ctrl+click a token → resolve → jump.
   const requestResolveSymbol = useConnectionStore(s => s.requestResolveSymbol)
+  // #6477 — find-all-references: alt/option+click a token → references palette.
+  const requestFindReferences = useConnectionStore(s => s.requestFindReferences)
   const symbolLocation = useConnectionStore(s => s.symbolLocation)
   const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
   const [currentPath, setCurrentPath] = useState<string | null>(null)
@@ -380,12 +382,15 @@ export function FileBrowserPanel() {
     requestFileContent(path)
   }, [requestFileContent])
 
-  // #6475 — cmd/ctrl+click a token in the viewer to jump to its definition.
-  // Event-delegated on the <pre>: read the clicked token's text; if it's an
-  // identifier-ish token (not a keyword/string/comment/punctuation), resolve it,
-  // passing the open file as a ranking tie-break hint. Opt-in: gated on ideEnabled.
+  // #6475 / #6477 — modifier+click a token in the viewer: cmd/ctrl+click jumps to
+  // its definition (go-to-definition); alt/option+click finds all references.
+  // Event-delegated on the <pre>: read the clicked token's text; only act on an
+  // identifier-ish token (not a keyword/string/comment/punctuation). Opt-in.
   const handleCodeClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
-    if (!ideEnabled || !(e.metaKey || e.ctrlKey)) return
+    if (!ideEnabled) return
+    const goToDef = e.metaKey || e.ctrlKey
+    const findRefs = e.altKey
+    if (!goToDef && !findRefs) return
     const target = e.target as HTMLElement
     const cls = typeof target.className === 'string' ? target.className : ''
     const m = cls.match(/(?:^|\s)syn-(\w+)/)
@@ -396,8 +401,10 @@ export function FileBrowserPanel() {
     const fromFile = selectedFile && rootPath.current
       ? relativePath(selectedFile, rootPath.current)
       : undefined
-    requestResolveSymbol(text, fromFile)
-  }, [ideEnabled, selectedFile, requestResolveSymbol])
+    // cmd/ctrl wins if both modifiers are held (definition is the primary gesture).
+    if (goToDef) requestResolveSymbol(text, fromFile)
+    else requestFindReferences(text, fromFile)
+  }, [ideEnabled, selectedFile, requestResolveSymbol, requestFindReferences])
 
   // #6473 — open a file requested externally (Cmd+P quick-open); reuse the click
   // path so it persists the selection, loads content, and triggers the symbols

--- a/packages/dashboard/src/components/ReferencesPalette.test.tsx
+++ b/packages/dashboard/src/components/ReferencesPalette.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * ReferencesPalette — tests for the find-all-references result list (#6477).
+ * Opened by alt+click; no query input — the symbol is fixed by the click.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ReferencesPalette } from './ReferencesPalette'
+
+const mockOpenFileInBrowser = vi.fn()
+let mockReferencesResult: any = null
+let mockReferencesLoading = false
+let mockReferencesSymbol = ''
+
+vi.mock('../store/connection', () => {
+  const storeState = () => ({
+    referencesResult: mockReferencesResult,
+    referencesLoading: mockReferencesLoading,
+    referencesSymbol: mockReferencesSymbol,
+    openFileInBrowser: mockOpenFileInBrowser,
+  })
+  const useConnectionStore = Object.assign(
+    (selector: any) => selector(storeState()),
+    { getState: () => storeState(), setState: () => {} },
+  )
+  return { useConnectionStore }
+})
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockReferencesLoading = false
+  mockReferencesSymbol = 'widget'
+  mockReferencesResult = {
+    symbol: 'widget', truncated: false, error: null,
+    results: [
+      { file: 'src/a.ts', line: 3, column: 7, text: 'const widget = 1' },
+      { file: 'src/b.ts', line: 9, column: 1, text: 'widget()' },
+    ],
+  }
+})
+
+describe('ReferencesPalette (#6477)', () => {
+  it('does not render when closed', () => {
+    render(<ReferencesPalette isOpen={false} onClose={() => {}} />)
+    expect(screen.queryByTestId('references-palette')).toBeNull()
+  })
+
+  it('shows the queried symbol in the header + the result count', () => {
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    const header = screen.getByTestId('references-header')
+    expect(header.textContent).toContain('widget')
+    expect(header.textContent).toContain('2')
+  })
+
+  it('renders a row per referencing site', () => {
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    expect(screen.getByTestId('references-item-0')).toBeTruthy()
+    expect(screen.getByTestId('references-item-1')).toBeTruthy()
+  })
+
+  it('shows "Searching…" while loading', () => {
+    mockReferencesLoading = true
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    expect(screen.getByText('Searching…')).toBeTruthy()
+    expect(screen.queryByTestId('references-item-0')).toBeNull()
+  })
+
+  it('ignores a stale result whose symbol does not match the requested one', () => {
+    mockReferencesSymbol = 'somethingElse'
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    // The stored result is for `widget`, not `somethingElse` → treated as not-current.
+    expect(screen.queryByTestId('references-item-0')).toBeNull()
+  })
+
+  it('shows "No references found" for a current empty result', () => {
+    mockReferencesResult = { symbol: 'widget', truncated: false, error: null, results: [] }
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    expect(screen.getByTestId('references-empty')).toBeTruthy()
+  })
+
+  it('opens the file at the site on Enter, then closes', async () => {
+    const onClose = vi.fn()
+    render(<ReferencesPalette isOpen={true} onClose={onClose} />)
+    const list = await screen.findByRole('listbox')
+    fireEvent.keyDown(list, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/a.ts', 3)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('arrow-down then Enter opens the second site', async () => {
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    const list = screen.getByRole('listbox')
+    fireEvent.keyDown(list, { key: 'ArrowDown' })
+    fireEvent.keyDown(list, { key: 'Enter' })
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/b.ts', 9)
+  })
+
+  it('opens a site on click', async () => {
+    render(<ReferencesPalette isOpen={true} onClose={() => {}} />)
+    fireEvent.mouseDown(await screen.findByTestId('references-item-1'))
+    expect(mockOpenFileInBrowser).toHaveBeenCalledWith('src/b.ts', 9)
+  })
+
+  it('closes on Escape without opening anything', () => {
+    const onClose = vi.fn()
+    render(<ReferencesPalette isOpen={true} onClose={onClose} />)
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+    expect(mockOpenFileInBrowser).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/ReferencesPalette.tsx
+++ b/packages/dashboard/src/components/ReferencesPalette.tsx
@@ -1,0 +1,121 @@
+/**
+ * ReferencesPalette — find-all-references result list (#6477, IDE epic #6469).
+ *
+ * Opened by alt/ctrl+click on a token in the file viewer (FileBrowserPanel),
+ * which dispatches `requestFindReferences` and flips `referencesOpen`. Unlike the
+ * Cmd+Shift+F palette there's no query input — the symbol is fixed by the click;
+ * this just lists the referencing sites (`references_result`). Enter / click jumps
+ * to a site via `openFileInBrowser(file, line)`.
+ *
+ * Gated by the caller on the opt-in `ide` capability. Reuses the file-open-palette
+ * chrome + the code-search preview row.
+ */
+import { useState, useEffect, useMemo, useRef, useCallback, type KeyboardEvent } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { SearchResultEntry } from '@chroxy/protocol'
+
+export interface ReferencesPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const DISPLAY_CAP = 200
+
+export function ReferencesPalette({ isOpen, onClose }: ReferencesPaletteProps) {
+  const snapshot = useConnectionStore(s => s.referencesResult)
+  const loading = useConnectionStore(s => s.referencesLoading)
+  const symbol = useConnectionStore(s => s.referencesSymbol)
+  const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    setSelectedIndex(0)
+    const id = window.setTimeout(() => listRef.current?.focus(), 0)
+    return () => window.clearTimeout(id)
+  }, [isOpen])
+
+  // Trust the stored result only when it's for the CURRENT symbol (a stale reply
+  // for a previous click is ignored until the new one lands).
+  const isCurrent = !!snapshot && snapshot.symbol === symbol
+  const results = useMemo<SearchResultEntry[]>(() => (isCurrent ? snapshot!.results : []), [snapshot, isCurrent])
+
+  useEffect(() => {
+    setSelectedIndex(i => (results.length === 0 ? 0 : Math.min(i, Math.min(results.length, DISPLAY_CAP) - 1)))
+  }, [results.length])
+
+  useEffect(() => {
+    const items = listRef.current?.querySelectorAll('[role="option"]')
+    const el = items?.[selectedIndex] as HTMLElement | undefined
+    el?.scrollIntoView?.({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const openAt = useCallback((idx: number) => {
+    const r = results[idx]
+    if (r) {
+      openFileInBrowser(r.file, r.line)
+      onClose()
+    }
+  }, [results, openFileInBrowser, onClose])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); setSelectedIndex(i => Math.min(i + 1, Math.min(results.length, DISPLAY_CAP) - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setSelectedIndex(i => Math.max(i - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); openAt(selectedIndex) }
+  }, [results.length, selectedIndex, openAt, onClose])
+
+  if (!isOpen) return null
+
+  const overflow = results.length > DISPLAY_CAP ? results.length - DISPLAY_CAP : 0
+  const display = overflow > 0 ? results.slice(0, DISPLAY_CAP) : results
+  const searching = loading || !isCurrent
+
+  return (
+    <div
+      className="file-open-palette-overlay"
+      data-modal-overlay
+      data-testid="references-palette"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="file-open-palette" role="dialog" aria-label="References">
+        <div className="file-open-palette-header" data-testid="references-header">
+          References to <code>{symbol}</code>
+          {isCurrent && !searching && <span className="references-count"> · {results.length}</span>}
+        </div>
+        <div
+          ref={listRef}
+          className="file-open-palette-list"
+          role="listbox"
+          aria-label="References"
+          tabIndex={0}
+          onKeyDown={handleKeyDown}
+        >
+          {searching && <div className="file-open-palette-status">Searching…</div>}
+          {!searching && results.length === 0 && (
+            <div className="file-open-palette-status" data-testid="references-empty">No references found</div>
+          )}
+          {!searching && display.map((r, i) => (
+            <div
+              key={`${r.file}:${r.line}:${r.column}:${i}`}
+              role="option"
+              aria-selected={i === selectedIndex}
+              className={`file-open-palette-item${i === selectedIndex ? ' selected' : ''}`}
+              data-testid={`references-item-${i}`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onMouseDown={(e) => { e.preventDefault(); openAt(i) }}
+            >
+              <span className="code-search-preview" title={r.text}>{r.text.trim() || ' '}</span>
+              <span className="symbol-item-line">{r.file.split('/').pop()}:{r.line}</span>
+            </div>
+          ))}
+          {overflow > 0 && <div className="file-open-palette-status">{overflow} more…</div>}
+          {isCurrent && snapshot!.truncated && display.length > 0 && (
+            <div className="file-open-palette-status" data-testid="references-truncated">Results truncated</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ReferencesPalette.tsx
+++ b/packages/dashboard/src/components/ReferencesPalette.tsx
@@ -1,7 +1,7 @@
 /**
  * ReferencesPalette — find-all-references result list (#6477, IDE epic #6469).
  *
- * Opened by alt/ctrl+click on a token in the file viewer (FileBrowserPanel),
+ * Opened by alt/option+click on a token in the file viewer (FileBrowserPanel),
  * which dispatches `requestFindReferences` and flips `referencesOpen`. Unlike the
  * Cmd+Shift+F palette there's no query input — the symbol is fixed by the click;
  * this just lists the referencing sites (`references_result`). Enter / click jumps

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -660,6 +660,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   symbolLocation: null,
   codeSearchResults: null,
   codeSearchLoading: false,
+  referencesResult: null,
+  referencesSymbol: '',
+  referencesOpen: false,
+  referencesLoading: false,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2493,6 +2497,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   symbolLocation: null,
   codeSearchResults: null,
   codeSearchLoading: false,
+  referencesResult: null,
+  referencesSymbol: '',
+  referencesOpen: false,
+  referencesLoading: false,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3685,6 +3693,22 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       set({ codeSearchLoading: true });
       const msg: Record<string, unknown> = { type: 'search_content', query: trimmed };
+      if (activeSessionId) msg.sessionId = activeSessionId;
+      wsSend(socket, msg);
+    }
+  },
+
+  // #6477 — find-all-references for a clicked symbol. Opens the references palette
+  // and clears any stale result; the reply (`references_result`) lands in
+  // `referencesResult`.
+  requestFindReferences: (symbol: string, file?: string) => {
+    const trimmed = typeof symbol === 'string' ? symbol.trim() : '';
+    if (!trimmed) return;
+    const { socket, activeSessionId } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ referencesSymbol: trimmed, referencesOpen: true, referencesLoading: true, referencesResult: null });
+      const msg: Record<string, unknown> = { type: 'find_references', symbol: trimmed };
+      if (file) msg.file = file;
       if (activeSessionId) msg.sessionId = activeSessionId;
       wsSend(socket, msg);
     }

--- a/packages/dashboard/src/store/dispatch-references-result.test.ts
+++ b/packages/dashboard/src/store/dispatch-references-result.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Dispatch test for find-all-references (#6477, epic #6469).
+ *
+ * Guards the wire path between the dashboard message handler and the store for
+ * `references_result`:
+ *   - a valid reply REPLACES `referencesResult` and clears `referencesLoading`.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState } from './types'
+import type { ServerReferencesResultMessage } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function refs(over: Partial<ServerReferencesResultMessage> = {}): ServerReferencesResultMessage {
+  return {
+    type: 'references_result',
+    symbol: 'widget',
+    results: [{ file: 'src/a.ts', line: 3, column: 7, text: 'const widget = 1' }],
+    truncated: false,
+    error: null,
+    ...over,
+  }
+}
+
+describe('references_result dispatch (#6477)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore({
+      connectionPhase: 'connected',
+      socket: null,
+      sessions: [],
+      activeSessionId: null,
+      sessionStates: {},
+      referencesResult: null,
+      referencesLoading: true,
+      messages: [],
+    } as unknown as Partial<ConnectionState>)
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('stores the reference set and clears the loading flag', () => {
+    handleMessage(refs(), ctx() as never)
+    const s = store.getState()
+    expect(s.referencesResult).not.toBeNull()
+    expect(s.referencesResult!.symbol).toBe('widget')
+    expect(s.referencesResult!.results[0]?.file).toBe('src/a.ts')
+    expect(s.referencesLoading).toBe(false)
+  })
+
+  it('replaces a prior reference set wholesale', () => {
+    handleMessage(refs(), ctx() as never)
+    handleMessage(refs({ symbol: 'other', results: [] }), ctx() as never)
+    expect(store.getState().referencesResult!.symbol).toBe('other')
+    expect(store.getState().referencesResult!.results).toEqual([])
+  })
+
+  it('drops a malformed payload without mutating state or clearing loading', () => {
+    const before = store.getState().referencesResult
+    handleMessage({ type: 'references_result', symbol: 'x', truncated: false, error: null } as never, ctx() as never)
+    expect(store.getState().referencesResult).toBe(before)
+    expect(store.getState().referencesLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -130,7 +130,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2592,6 +2592,18 @@ function handleSearchResults(msg: Record<string, unknown>, _get: MsgGet, set: Ms
 }
 
 /**
+ * Find-all-references (#6477, epic #6469) — `references_result`: REPLACE the
+ * stored result set with the carried one and clear the loading flag. Same
+ * defensive Zod-validated pattern as code_search_results; drives the references
+ * palette (opened by alt/ctrl+click). Dashboard-only for v1.
+ */
+function handleReferencesResult(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerReferencesResultSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ referencesResult: parsed.data, referencesLoading: false });
+}
+
+/**
  * Mailbox (#5914 follow-up) — Control Room "Mailbox" tab `mailbox_status_snapshot`:
  * REPLACE the stored snapshot with the carried one and clear the in-flight
  * loading flag. Same defensive pattern as the host/runner snapshots — the wire
@@ -3215,6 +3227,8 @@ const HANDLERS: Record<string, Handler> = {
   // #6474 (epic #6469): opt-in IDE find-in-project results (distinct wire type
   // from the cross-session `search_results` handled by the shared dispatch table).
   code_search_results: handleSearchResults,
+  // #6477 (epic #6469): opt-in IDE find-all-references result.
+  references_result: handleReferencesResult,
   // #5175 (epic #5170): Host/Repo Status Control Room survey snapshot.
   host_status_snapshot: handleHostStatusSnapshot,
   // Mailbox (#5914 follow-up): Control Room "Mailbox" tab survey snapshot.

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1211,7 +1211,7 @@ export interface ConnectionState {
   codeSearchResults: ServerSearchResultsMessage | null;
   // #6474 — true between dispatching a `search_content` request and its reply.
   codeSearchLoading: boolean;
-  // #6477 — find-all-references (alt/ctrl+click a token). `referencesResult` is
+  // #6477 — find-all-references (alt/option+click a token). `referencesResult` is
   // the latest `references_result` reply; `referencesSymbol` is the requested name
   // (for the modal title while the reply is in flight); `referencesOpen` controls
   // the references palette; `referencesLoading` is true between request and reply.

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -1211,6 +1211,14 @@ export interface ConnectionState {
   codeSearchResults: ServerSearchResultsMessage | null;
   // #6474 — true between dispatching a `search_content` request and its reply.
   codeSearchLoading: boolean;
+  // #6477 — find-all-references (alt/ctrl+click a token). `referencesResult` is
+  // the latest `references_result` reply; `referencesSymbol` is the requested name
+  // (for the modal title while the reply is in flight); `referencesOpen` controls
+  // the references palette; `referencesLoading` is true between request and reply.
+  referencesResult: ServerReferencesResultMessage | null;
+  referencesSymbol: string;
+  referencesOpen: boolean;
+  referencesLoading: boolean;
 
   // Custom agents from server
   customAgents: CustomAgent[];
@@ -1424,6 +1432,9 @@ export interface ConnectionState {
   // #6474 — find-in-project: grep the workspace for `query` (2+ chars). Sets
   // codeSearchLoading; the reply lands in `codeSearchResults` (Cmd+Shift+F palette).
   requestSearchContent: (query: string) => void;
+  // #6477 — find-all-references for a clicked symbol. Opens the references palette
+  // (referencesOpen) + sets referencesLoading; the reply lands in referencesResult.
+  requestFindReferences: (symbol: string, file?: string) => void;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4709,6 +4709,22 @@ button.sidebar-token-view-session-row:hover {
 }
 .file-open-palette-input::placeholder { color: var(--text-muted); }
 
+/* #6477 — references palette header (no input; the symbol is fixed by the click). */
+.file-open-palette-header {
+  border-bottom: 1px solid var(--border-primary);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 12px 14px;
+}
+.file-open-palette-header code {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.references-count { color: var(--text-muted); }
+
 .file-open-palette-list {
   overflow-y: auto;
   padding: 4px 0;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -479,6 +479,12 @@ export declare const SearchContentSchema: z.ZodObject<{
     path: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
+export declare const FindReferencesSchema: z.ZodObject<{
+    type: z.ZodLiteral<"find_references">;
+    symbol: z.ZodString;
+    file: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ListSlashCommandsSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_slash_commands">;
 }, z.core.$loose>;
@@ -1042,6 +1048,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"search_content">;
     query: z.ZodString;
     path: z.ZodOptional<z.ZodString>;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"find_references">;
+    symbol: z.ZodString;
+    file: z.ZodOptional<z.ZodString>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_slash_commands">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -628,9 +628,9 @@ export const SearchContentSchema = z.object({
     sessionId: z.string().max(256).optional(),
 }).passthrough();
 // #6477 (epic #6469): find-all-references (server → `references_result`). Whole-
-// word, case-sensitive grep for a symbol name (alt/ctrl+click a token in the file
-// viewer). `file` is the originating file (accepted for symmetry). Gated behind
-// the opt-in `features.ide` flag.
+// word, case-sensitive grep for a symbol name (alt/option+click a token in the
+// file viewer; cmd/ctrl+click is go-to-definition). `file` is the originating file
+// (accepted for symmetry). Gated behind the opt-in `features.ide` flag.
 export const FindReferencesSchema = z.object({
     type: z.literal('find_references'),
     symbol: z.string().min(1).max(256),

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -627,6 +627,16 @@ export const SearchContentSchema = z.object({
     path: z.string().max(4096).optional(),
     sessionId: z.string().max(256).optional(),
 }).passthrough();
+// #6477 (epic #6469): find-all-references (server → `references_result`). Whole-
+// word, case-sensitive grep for a symbol name (alt/ctrl+click a token in the file
+// viewer). `file` is the originating file (accepted for symmetry). Gated behind
+// the opt-in `features.ide` flag.
+export const FindReferencesSchema = z.object({
+    type: z.literal('find_references'),
+    symbol: z.string().min(1).max(256),
+    file: z.string().max(4096).optional(),
+    sessionId: z.string().max(256).optional(),
+}).passthrough();
 export const ListSlashCommandsSchema = z.object({
     type: z.literal('list_slash_commands'),
 }).passthrough();
@@ -1261,6 +1271,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     ListSymbolsSchema,
     ResolveSymbolSchema,
     SearchContentSchema,
+    FindReferencesSchema,
     ListSlashCommandsSchema,
     ListAgentsSchema,
     RequestFullHistorySchema,

--- a/packages/protocol/dist/schemas/server/ide.d.ts
+++ b/packages/protocol/dist/schemas/server/ide.d.ts
@@ -61,3 +61,16 @@ export declare const ServerSearchResultsSchema: z.ZodObject<{
 }, z.core.$strip>;
 export type SearchResultEntry = z.infer<typeof SearchResultEntrySchema>;
 export type ServerSearchResultsMessage = z.infer<typeof ServerSearchResultsSchema>;
+export declare const ServerReferencesResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"references_result">;
+    symbol: z.ZodString;
+    results: z.ZodArray<z.ZodObject<{
+        file: z.ZodString;
+        line: z.ZodNumber;
+        column: z.ZodNumber;
+        text: z.ZodString;
+    }, z.core.$strip>>;
+    truncated: z.ZodBoolean;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
+export type ServerReferencesResultMessage = z.infer<typeof ServerReferencesResultSchema>;

--- a/packages/protocol/dist/schemas/server/ide.js
+++ b/packages/protocol/dist/schemas/server/ide.js
@@ -64,3 +64,13 @@ export const ServerSearchResultsSchema = z.object({
     truncated: z.boolean(),
     error: z.string().nullable(),
 });
+// `find_references` response (#6477) — find-all-references. `symbol` echoes the
+// queried name (correlation); `results` reuses the search-match shape (one row
+// per referencing site); `truncated` on cap; `error` non-null only on failure.
+export const ServerReferencesResultSchema = z.object({
+    type: z.literal('references_result'),
+    symbol: z.string(),
+    results: z.array(SearchResultEntrySchema),
+    truncated: z.boolean(),
+    error: z.string().nullable(),
+});

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -705,6 +705,17 @@ export const SearchContentSchema = z.object({
   sessionId: z.string().max(256).optional(),
 }).passthrough()
 
+// #6477 (epic #6469): find-all-references (server → `references_result`). Whole-
+// word, case-sensitive grep for a symbol name (alt/ctrl+click a token in the file
+// viewer). `file` is the originating file (accepted for symmetry). Gated behind
+// the opt-in `features.ide` flag.
+export const FindReferencesSchema = z.object({
+  type: z.literal('find_references'),
+  symbol: z.string().min(1).max(256),
+  file: z.string().max(4096).optional(),
+  sessionId: z.string().max(256).optional(),
+}).passthrough()
+
 export const ListSlashCommandsSchema = z.object({
   type: z.literal('list_slash_commands'),
 }).passthrough()
@@ -1421,6 +1432,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   ListSymbolsSchema,
   ResolveSymbolSchema,
   SearchContentSchema,
+  FindReferencesSchema,
   ListSlashCommandsSchema,
   ListAgentsSchema,
   RequestFullHistorySchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -706,9 +706,9 @@ export const SearchContentSchema = z.object({
 }).passthrough()
 
 // #6477 (epic #6469): find-all-references (server → `references_result`). Whole-
-// word, case-sensitive grep for a symbol name (alt/ctrl+click a token in the file
-// viewer). `file` is the originating file (accepted for symmetry). Gated behind
-// the opt-in `features.ide` flag.
+// word, case-sensitive grep for a symbol name (alt/option+click a token in the
+// file viewer; cmd/ctrl+click is go-to-definition). `file` is the originating file
+// (accepted for symmetry). Gated behind the opt-in `features.ide` flag.
 export const FindReferencesSchema = z.object({
   type: z.literal('find_references'),
   symbol: z.string().min(1).max(256),

--- a/packages/protocol/src/schemas/server/ide.ts
+++ b/packages/protocol/src/schemas/server/ide.ts
@@ -77,3 +77,16 @@ export const ServerSearchResultsSchema = z.object({
 
 export type SearchResultEntry = z.infer<typeof SearchResultEntrySchema>
 export type ServerSearchResultsMessage = z.infer<typeof ServerSearchResultsSchema>
+
+// `find_references` response (#6477) — find-all-references. `symbol` echoes the
+// queried name (correlation); `results` reuses the search-match shape (one row
+// per referencing site); `truncated` on cap; `error` non-null only on failure.
+export const ServerReferencesResultSchema = z.object({
+  type: z.literal('references_result'),
+  symbol: z.string(),
+  results: z.array(SearchResultEntrySchema),
+  truncated: z.boolean(),
+  error: z.string().nullable(),
+})
+
+export type ServerReferencesResultMessage = z.infer<typeof ServerReferencesResultSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -121,6 +121,7 @@ const PLATFORM_SPECIFIC = {
   'symbols_snapshot': 'dashboard',   // #6471 (epic #6469) opt-in IDE symbol table — dashboard symbol panel (#6472) is dashboard-only for v1; mobile parity is a tracked fast-follow
   'symbol_location': 'dashboard',    // #6475 (epic #6469) opt-in IDE go-to-definition result — dashboard file viewer cmd/ctrl+click jump; dashboard-only for v1, mobile parity deferred
   'code_search_results': 'dashboard', // #6474 (epic #6469) opt-in IDE find-in-project results — dashboard Cmd+Shift+F palette; distinct from cross-session `search_results`; dashboard-only for v1
+  'references_result': 'dashboard',   // #6477 (epic #6469) opt-in IDE find-all-references — dashboard references palette (alt+click); dashboard-only for v1
   'environment_created': 'dashboard', // environment panel is dashboard-only
   'environment_list': 'dashboard',    // environment panel is dashboard-only
   'environment_destroyed': 'dashboard', // environment panel is dashboard-only

--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -7,12 +7,13 @@
  * the operator opts in, so clients won't send these messages, and the handler
  * additionally returns early as defence-in-depth. Off ⇒ zero IDE behaviour.
  *
- * Handles: list_symbols (#6471), resolve_symbol (#6475), search_content (#6474).
+ * Handles: list_symbols (#6471), resolve_symbol (#6475), search_content (#6474),
+ * find_references (#6477).
  */
 import { resolveSession } from '../handler-utils.js'
 import { isIdeFeatureEnabled } from '../config.js'
 import { collectWorkspaceSymbols, resolveSymbol } from '../ide/symbols.js'
-import { searchContent } from '../ide/search.js'
+import { searchContent, findReferences } from '../ide/search.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('ide')
@@ -159,8 +160,55 @@ async function handleSearchContent(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * `find_references` → `references_result`. Find-all-references (#6477): a
+ * word-boundary, case-sensitive grep for a symbol NAME over the same confined
+ * walk search_content uses, returning every referencing site. `file` (the
+ * originating file) is accepted for symmetry but not used to rank. Dashboard-only
+ * consumer for v1 (the references palette).
+ */
+async function handleFindReferences(ws, client, msg, ctx) {
+  // #6481 (epic #6469): fail closed when the IDE surface is not opted in.
+  if (!isIdeFeatureEnabled(ctx.services?.config)) return
+
+  const symbol = typeof msg.symbol === 'string' ? msg.symbol.trim() : ''
+
+  if (!symbol) {
+    ctx.transport.send(ws, { type: 'references_result', symbol: '', results: [], truncated: false, error: null })
+    return
+  }
+
+  const entry = resolveSession(ctx, msg, client)
+  const cwd = entry?.cwd || null
+  if (!cwd) {
+    ctx.transport.send(ws, {
+      type: 'references_result',
+      symbol,
+      results: [],
+      truncated: false,
+      error: 'No workspace directory for this session',
+    })
+    return
+  }
+
+  try {
+    const { results, truncated } = await findReferences(cwd, symbol)
+    ctx.transport.send(ws, { type: 'references_result', symbol, results, truncated, error: null })
+  } catch (err) {
+    log.debug(`find_references failed: ${err?.message}`)
+    ctx.transport.send(ws, {
+      type: 'references_result',
+      symbol,
+      results: [],
+      truncated: false,
+      error: err?.message || 'Failed to find references',
+    })
+  }
+}
+
 export const ideHandlers = {
   list_symbols: handleListSymbols,
   resolve_symbol: handleResolveSymbol,
   search_content: handleSearchContent,
+  find_references: handleFindReferences,
 }

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -46,21 +46,25 @@ const TEXT_BASENAMES = new Set([
 ])
 
 /**
- * Search the workspace (or a confined sub-path) for a case-insensitive substring.
+ * Shared confined walk (#6474 search + #6477 find-references). Walks `rootDir`
+ * (or a confined sub-path), reads each text file, and calls `matchLine(text)` per
+ * line; `matchLine` returns an array of 1-indexed column positions where a match
+ * starts. Each match becomes a `{file,line,column,text}` row, honouring the caps.
+ *
+ * SECURITY — this is the single confinement boundary for BOTH callers: the root
+ * is realpath-resolved, an optional scope `path` is REAL-path confined (a
+ * `..`-escape, an absolute path, or a symlink whose real target lands outside is
+ * refused), ignored/dot dirs are skipped, and files are lstat'd so a symlink is
+ * never followed. The regression tests in ide-search.test.js assert the
+ * symlink-escape cases for both entry points.
  *
  * @param {string} rootDir            Absolute workspace root (session cwd).
- * @param {string} query             Needle (min 2 chars after trim; else no-op).
- * @param {object} [opts]
- * @param {string|null} [opts.path]   Workspace-relative file/dir to scope to.
- * @param {number} [opts.maxFiles]    Cap on files read (default 2000).
- * @param {number} [opts.maxResults]  Cap on match rows returned (default 500).
- * @param {number} [opts.maxFileSize] Skip files larger than this (default 512KB).
- * @param {number} [opts.maxDepth]    Directory recursion depth (default 12).
- * @param {number} [opts.maxLineLength] Preview cap so a minified line can't bloat
- *                                       a result (default 1000).
+ * @param {(line: string) => number[]} matchLine  Per-line matcher → 1-indexed columns.
+ * @param {object} [opts]  path, maxFiles(2000), maxResults(500), maxFileSize(512KB),
+ *                         maxDepth(12), maxLineLength(1000).
  * @returns {Promise<{results: Array<{file:string,line:number,column:number,text:string}>, truncated: boolean}>}
  */
-export async function searchContent(rootDir, query, opts = {}) {
+async function collectMatches(rootDir, matchLine, opts = {}) {
   const {
     path = null,
     maxFiles = 2000,
@@ -69,12 +73,6 @@ export async function searchContent(rootDir, query, opts = {}) {
     maxDepth = 12,
     maxLineLength = 1000,
   } = opts
-
-  const needle = typeof query === 'string' ? query.trim() : ''
-  // A 1-char search would match almost everything and swamp the result cap; the
-  // dashboard also requires 2+ chars, so this is a cheap server-side guard too.
-  if (needle.length < 2) return { results: [], truncated: false }
-  const lowerNeedle = needle.toLowerCase()
 
   // Realpath-confine the root (symlink-safe base) — see the security note above.
   let root
@@ -133,15 +131,16 @@ export async function searchContent(rootDir, query, opts = {}) {
     const rel = relative(root, absPath).split(sep).join('/')
     const lines = content.split('\n')
     for (let i = 0; i < lines.length; i++) {
-      const idx = lines[i].toLowerCase().indexOf(lowerNeedle)
-      if (idx === -1) continue
-      if (results.length >= maxResults) { truncated = true; return }
-      results.push({
-        file: rel,
-        line: i + 1,
-        column: idx + 1,
-        text: lines[i].length > maxLineLength ? lines[i].slice(0, maxLineLength) : lines[i],
-      })
+      const cols = matchLine(lines[i])
+      for (let c = 0; c < cols.length; c++) {
+        if (results.length >= maxResults) { truncated = true; return }
+        results.push({
+          file: rel,
+          line: i + 1,
+          column: cols[c],
+          text: lines[i].length > maxLineLength ? lines[i].slice(0, maxLineLength) : lines[i],
+        })
+      }
     }
   }
 
@@ -181,4 +180,63 @@ export async function searchContent(rootDir, query, opts = {}) {
   }
 
   return { results, truncated }
+}
+
+/**
+ * Search the workspace (or a confined sub-path) for a case-insensitive substring
+ * (#6474). One result per matching line (the first occurrence), matching the
+ * find-in-project palette's expectation.
+ *
+ * @param {string} rootDir  Absolute workspace root (session cwd).
+ * @param {string} query    Needle (min 2 chars after trim; else no-op).
+ * @param {object} [opts]   See collectMatches.
+ * @returns {Promise<{results: Array<{file:string,line:number,column:number,text:string}>, truncated: boolean}>}
+ */
+export async function searchContent(rootDir, query, opts = {}) {
+  const needle = typeof query === 'string' ? query.trim() : ''
+  // A 1-char search would match almost everything and swamp the result cap; the
+  // dashboard also requires 2+ chars, so this is a cheap server-side guard too.
+  if (needle.length < 2) return { results: [], truncated: false }
+  const lowerNeedle = needle.toLowerCase()
+  return collectMatches(rootDir, (line) => {
+    const idx = line.toLowerCase().indexOf(lowerNeedle)
+    return idx === -1 ? EMPTY_COLS : [idx + 1]
+  }, opts)
+}
+
+const EMPTY_COLS = []
+
+/**
+ * Find all references to a symbol NAME (#6477) — reverse-lookup for the
+ * find-all-references panel. Unlike searchContent this is a WORD-BOUNDARY,
+ * case-SENSITIVE match (an identifier reference is exact + whole-word: `go`
+ * matches `go()` but not `goHome` or `Cargo`), and it returns EVERY occurrence on
+ * a line, not just the first. Regex-based over the same confined walk — ~80%
+ * accurate with zero new deps (no scope/type analysis; a string literal or
+ * comment mentioning the name is still a "reference").
+ *
+ * @param {string} rootDir  Absolute workspace root (session cwd).
+ * @param {string} symbol   Identifier to find references to.
+ * @param {object} [opts]   See collectMatches.
+ * @returns {Promise<{results: Array<{file:string,line:number,column:number,text:string}>, truncated: boolean}>}
+ */
+export async function findReferences(rootDir, symbol, opts = {}) {
+  const name = typeof symbol === 'string' ? symbol.trim() : ''
+  // Only real identifiers — a non-identifier can't be word-boundary-matched
+  // meaningfully and would risk a runaway regex.
+  if (!/^[A-Za-z_$][\w$]*$/.test(name)) return { results: [], truncated: false }
+  // Escape `$` (the only regex-special an identifier can contain) so a
+  // `$`-prefixed name doesn't turn into an end-of-line anchor.
+  const escaped = name.replace(/\$/g, '\\$&')
+  const re = new RegExp(`\\b${escaped}\\b`, 'g')
+  return collectMatches(rootDir, (line) => {
+    const cols = []
+    re.lastIndex = 0
+    let m
+    while ((m = re.exec(line)) !== null) {
+      cols.push(m.index + 1)
+      if (m.index === re.lastIndex) re.lastIndex++ // zero-width guard (defensive)
+    }
+    return cols
+  }, opts)
 }

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -228,7 +228,11 @@ export async function findReferences(rootDir, symbol, opts = {}) {
   // Escape `$` (the only regex-special an identifier can contain) so a
   // `$`-prefixed name doesn't turn into an end-of-line anchor.
   const escaped = name.replace(/\$/g, '\\$&')
-  const re = new RegExp(`\\b${escaped}\\b`, 'g')
+  // Explicit identifier boundaries — a plain `\b` is `\w`-relative and mishandles
+  // `$`-names (`$` isn't a `\w` char): it MISSES a real `$store` and FALSE-matches
+  // the `$store` tail inside `my$store`. `(?<![\w$])…(?![\w$])` treats `$` as part
+  // of the identifier, so a reference must be flanked by non-identifier chars.
+  const re = new RegExp(`(?<![\\w$])${escaped}(?![\\w$])`, 'g')
   return collectMatches(rootDir, (line) => {
     const cols = []
     re.lastIndex = 0

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -294,6 +294,7 @@ function _isSecureRequest(req) {
  *   { type: 'list_symbols', path? }                     — request workspace symbol table (#6471, opt-in IDE — features.ide)
  *   { type: 'resolve_symbol', symbol, file? }           — resolve a symbol name to its definition (#6475, opt-in IDE — features.ide)
  *   { type: 'search_content', query, path? }            — find-in-project content grep (#6474, opt-in IDE — features.ide)
+ *   { type: 'find_references', symbol, file? }           — find-all-references word-boundary grep (#6477, opt-in IDE — features.ide)
  *   { type: 'list_providers' }                          — request available provider list
  *   { type: 'list_repos' }                              — request workspace repository list
  *   { type: 'list_skills' }                             — request active skills list
@@ -384,6 +385,7 @@ function _isSecureRequest(req) {
  *   { type: 'symbols_snapshot', path, symbols: [{ name, kind, file, line, exported }], truncated, error } — #6471 workspace symbol table (opt-in IDE, features.ide; dashboard-only v1)
  *   { type: 'symbol_location', symbol, file, line, error } — #6475 go-to-definition result (opt-in IDE, features.ide; dashboard-only v1)
  *   { type: 'code_search_results', query, results: [{ file, line, column, text }], truncated, error } — #6474 find-in-project results (opt-in IDE, features.ide; dashboard-only v1)
+ *   { type: 'references_result', symbol, results: [{ file, line, column, text }], truncated, error } — #6477 find-all-references results (opt-in IDE, features.ide; dashboard-only v1)
  *   { type: 'slash_commands', commands: [{ name, description, source }] } — available slash commands
  *   { type: 'agent_list', agents: [{ name, description, source }] } — available custom agents
  *   { type: 'client_joined', client: { clientId, deviceName, deviceType, platform } } — new client connected

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ideHandlers } from '../src/handlers/ide-handlers.js'
-import { ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema } from '@chroxy/protocol'
+import { ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema } from '@chroxy/protocol'
 import { nsCtx } from './test-helpers.js'
 
 /**
@@ -16,6 +16,7 @@ import { nsCtx } from './test-helpers.js'
 const handleListSymbols = ideHandlers.list_symbols
 const handleResolveSymbol = ideHandlers.resolve_symbol
 const handleSearchContent = ideHandlers.search_content
+const handleFindReferences = ideHandlers.find_references
 
 /** Build a handler ctx with a send-capturing transport, a config (for the flag
  *  gate), and a sessionManager resolving the given cwd. */
@@ -214,6 +215,58 @@ describe('search_content handler — emission', () => {
     const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: null })
     await handleSearchContent({}, client, { type: 'search_content', query: 'findMe' }, ctx)
     assert.equal(sent[0].type, 'code_search_results')
+    assert.deepEqual(sent[0].results, [])
+    assert.match(sent[0].error, /No workspace/)
+  })
+})
+
+describe('find_references handler — feature gate', () => {
+  it('is a no-op (no send) when features.ide is off', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: false, cwd: '/tmp' })
+    await handleFindReferences({}, client, { type: 'find_references', symbol: 'x' }, ctx)
+    assert.equal(sent.length, 0)
+  })
+})
+
+describe('find_references handler — emission', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-h-'))
+    writeFileSync(join(root, 'mod.ts'), 'const findMe = 1\nconst x = findMe + findMeToo\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('emits a schema-valid references_result with whole-word hits', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleFindReferences({}, client, { type: 'find_references', symbol: 'findMe' }, ctx)
+    assert.equal(sent.length, 1)
+    const msg = sent[0]
+    assert.ok(ServerReferencesResultSchema.safeParse(msg).success, 'emitted message must satisfy ServerReferencesResultSchema')
+    assert.equal(msg.symbol, 'findMe')
+    assert.equal(msg.error, null)
+    // line 1 (decl) + line 2 (usage) — NOT `findMeToo` (word boundary).
+    assert.deepEqual(msg.results.map((r) => r.line).sort(), [1, 2])
+  })
+
+  it('emits an empty result set for a symbol with no references', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleFindReferences({}, client, { type: 'find_references', symbol: 'nope' }, ctx)
+    assert.ok(ServerReferencesResultSchema.safeParse(sent[0]).success)
+    assert.deepEqual(sent[0].results, [])
+    assert.equal(sent[0].error, null)
+  })
+
+  it('emits an empty result set for an empty symbol (no crash)', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    await handleFindReferences({}, client, { type: 'find_references', symbol: '   ' }, ctx)
+    assert.equal(sent[0].type, 'references_result')
+    assert.deepEqual(sent[0].results, [])
+  })
+
+  it('emits an error result when the session has no cwd', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: null })
+    await handleFindReferences({}, client, { type: 'find_references', symbol: 'findMe' }, ctx)
+    assert.equal(sent[0].type, 'references_result')
     assert.deepEqual(sent[0].results, [])
     assert.match(sent[0].error, /No workspace/)
   })

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { searchContent } from '../src/ide/search.js'
+import { searchContent, findReferences } from '../src/ide/search.js'
 
 /**
  * Unit tests for the IDE content-search backend (#6474, epic #6469). Grep
@@ -120,5 +120,65 @@ describe('searchContent — confinement (security)', () => {
 
   it('refuses traversal THROUGH an in-workspace symlink to an outside file', async () => {
     assert.deepEqual((await searchContent(root, 'DEEP_SECRET', { path: 'linkdir/sub/deep.js' })).results, [])
+  })
+})
+
+describe('findReferences — word-boundary reverse lookup (#6477)', () => {
+  let root
+  let outside
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-'))
+    writeFileSync(join(root, 'a.ts'), [
+      'import { widget } from "./w"',   // 1 — reference
+      'const x = widget()',             // 2 — reference
+      'const y = widgetFactory()',      // 3 — NOT a ref (widgetFactory)
+      'const z = superwidget',          // 4 — NOT a ref (superwidget)
+      'widget; widget // twice',        // 5 — TWO references on one line
+      'const Widget = 1',               // 6 — NOT a ref (case-sensitive)
+    ].join('\n') + '\n')
+    // Symbol reachable only via an out-of-workspace symlink — must never appear.
+    outside = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-out-'))
+    writeFileSync(join(outside, 'secret.js'), 'const widget = "SECRET"\n')
+    symlinkSync(join(outside, 'secret.js'), join(root, 'linkfile.js'))
+  })
+  after(() => {
+    rmSync(root, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('matches whole-word references only (not substrings)', async () => {
+    const { results } = await findReferences(root, 'widget')
+    const lines = results.map((r) => r.line).sort((a, b) => a - b)
+    // lines 1, 2, and two on 5 — NOT 3 (widgetFactory), 4 (superwidget), 6 (Widget).
+    assert.deepEqual(lines, [1, 2, 5, 5])
+  })
+
+  it('is case-sensitive (an identifier reference is exact)', async () => {
+    assert.deepEqual((await findReferences(root, 'Widget')).results.map((r) => r.line), [6])
+  })
+
+  it('returns every occurrence on a line with 1-indexed columns', async () => {
+    const { results } = await findReferences(root, 'widget')
+    const line5 = results.filter((r) => r.line === 5)
+    assert.equal(line5.length, 2)
+    assert.equal(line5[0].column, 1)      // "widget; widget" — first at col 1
+    assert.equal(line5[1].column, 9)      // second at col 9
+    assert.equal(line5[0].file, 'a.ts')
+  })
+
+  it('returns nothing for a non-identifier or empty name', async () => {
+    assert.deepEqual((await findReferences(root, '')).results, [])
+    assert.deepEqual((await findReferences(root, 'a b')).results, [])
+    assert.deepEqual((await findReferences(root, '(){}')).results, [])
+  })
+
+  it('never surfaces a reference reachable only through an out-of-workspace symlink', async () => {
+    assert.deepEqual((await findReferences(root, 'widget', { path: 'linkfile.js' })).results, [])
+  })
+
+  it('sets truncated when the result cap is hit', async () => {
+    const { results, truncated } = await findReferences(root, 'widget', { maxResults: 1 })
+    assert.equal(results.length, 1)
+    assert.equal(truncated, true)
   })
 })

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -157,6 +157,21 @@ describe('findReferences — word-boundary reverse lookup (#6477)', () => {
     assert.deepEqual((await findReferences(root, 'Widget')).results.map((r) => r.line), [6])
   })
 
+  it('handles a $-containing identifier without \\b mishandling ($store, not my$store)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-dollar-'))
+    try {
+      writeFileSync(join(dir, 's.js'), [
+        'const $store = create()',   // 1 — reference
+        'return $store.value',        // 2 — reference
+        'const my$store = other()',   // 3 — NOT a ref (the $store here is a tail of my$store)
+      ].join('\n') + '\n')
+      const { results } = await findReferences(dir, '$store')
+      assert.deepEqual(results.map((r) => r.line).sort((a, b) => a - b), [1, 2])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('returns every occurrence on a line with 1-indexed columns', async () => {
     const { results } = await findReferences(root, 'widget')
     const line5 = results.filter((r) => r.line === 5)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -159,6 +159,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'symbols_snapshot',           // #6471 (epic #6469) opt-in IDE workspace symbol table — dashboard symbol panel (#6472) only for v1; mobile parity is a tracked fast-follow
   'symbol_location',            // #6475 (epic #6469) opt-in IDE go-to-definition result — dashboard file viewer cmd/ctrl+click jump; dashboard-only for v1, mobile parity deferred
   'code_search_results',        // #6474 (epic #6469) opt-in IDE find-in-project results — dashboard Cmd+Shift+F palette; distinct from cross-session `search_results`; dashboard-only for v1
+  'references_result',          // #6477 (epic #6469) opt-in IDE find-all-references — dashboard references palette (alt+click); dashboard-only for v1
   'terminal_size',              // authoritative PTY grid for letterboxing — app terminal parity is still partial (#5987)
   // #6332 (batch 2b of #6314): the container/worktree environment lifecycle —
   // dashboard-only by design (the app has no environment surface). Schemaing


### PR DESCRIPTION
## Summary

Adds **find-all-references** to the opt-in IDE surface (#6469 Phase 3), pairing with go-to-definition (#6475): **alt/option+click** a token in the dashboard file viewer to list every referencing site. Builds on #6474's `searchContent` walk.

## What changed

**Server**
- `ide/search.js` — extracted the confined walk into a shared `collectMatches(rootDir, matchLine, opts)` (the **single realpath-confinement boundary** for both callers), and added `findReferences(rootDir, symbol)` as a **word-boundary, case-sensitive** matcher over it (`\bsymbol\b`; every occurrence per line, not just the first). `searchContent` is now a thin substring wrapper — behaviour preserved (its 13 tests still pass). `$`-in-identifier is escaped so it can't become an end-of-line anchor.
- `find_references` handler — fail-closed on `features.ide`; emits `references_result`.

**Protocol**
- `FindReferencesSchema` (client) + `ServerReferencesResultSchema` (`references_result`, reusing the search-match entry shape), registered in the client union, the `ws-server.js` doc comments, and **both coverage guards** as dashboard-only v1.

**Dashboard**
- `requestFindReferences` sender + `referencesResult`/`referencesSymbol`/`referencesOpen`/`referencesLoading` store fields + `handleReferencesResult` dispatch.
- `FileBrowserPanel` — the existing cmd/ctrl+click go-to-definition handler now **also** takes **alt+click → find references** (cmd/ctrl wins if both modifiers are held, since definition is the primary gesture).
- `ReferencesPalette` — a modal (no query input; the symbol is fixed by the click) titled **"References to `<symbol>`"**, listing `file:line` + a line preview, arrow/Enter/click → `openFileInBrowser`. Opened reactively from `referencesOpen`, with a stale-symbol guard on the echoed `symbol`.

## Acceptance (from #6477)
- [x] `find_references` returns referencing sites for a symbol (word-boundary over the confined walk)
- [x] Results panel links each to `file:line`

## Verified live
Alt+click a token in the viewer opens the references palette titled for that symbol (screenshotted). The confinement is shared with `searchContent` and re-tested (symlink-escape refused for both entry points).

## Tests
- **Server:** `findReferences` — whole-word (not substring), case-sensitivity, all-occurrences-per-line with 1-indexed columns, non-identifier → empty, out-of-workspace symlink refused, truncation; handler emission + `features.ide` gate + no-cwd. Server ide suite **62** pass; both server lints pass.
- **Dashboard:** `references_result` dispatch (stores + clears loading + drops malformed); `ReferencesPalette` render/header/jump/arrow-nav/stale-guard/empty/escape; `FileBrowserPanel` alt+click → find-references (+ cmd-wins-over-alt, + plain-click no-op). Full dashboard **4169**, store-core **1919**, protocol **347**; both coverage guards green; all typechecks clean.

> Note: over a very large workspace the grep is naturally slower (the same bound-but-unbatched concern tracked in #6506); fast at repo scale.

Closes #6477