### PR TITLE
feat(dashboard): Markdown syntax highlighting in the IDE file viewer (#6508)

### DIFF
--- a/packages/dashboard/src/lib/syntax.test.ts
+++ b/packages/dashboard/src/lib/syntax.test.ts
@@ -118,6 +118,59 @@ describe('tokenize', () => {
   })
 })
 
+describe('markdown highlighting (#6508)', () => {
+  it('resolves md / markdown / mdx (server sends the bare extension as the id)', () => {
+    // reader.js sends `extname` verbatim — `.md` → 'md', `.markdown` → 'markdown'.
+    // Without a Markdown LanguageDef these fall through to all-`plain` (no colours).
+    expect(getSyntaxRules('md')).not.toBeNull()
+    expect(getSyntaxRules('markdown')).not.toBeNull()
+    expect(getSyntaxRules('mdx')).not.toBeNull()
+  })
+
+  it('colours an ATX heading line as a single non-plain token', () => {
+    const tokens = tokenize('## Getting started', 'md')
+    expect(tokens).toEqual([{ text: '## Getting started', type: 'keyword' }])
+  })
+
+  it('does NOT treat a mid-line or spaceless # as a heading', () => {
+    // `#6508` and `C#` are not headings — an ATX heading needs a space/EOL after
+    // the hashes, so these must stay plain (no keyword token).
+    expect(tokenize('see issue #6508 for details', 'md').some(t => t.type === 'keyword')).toBe(false)
+    expect(tokenize('#hashtag', 'md').some(t => t.type === 'keyword')).toBe(false)
+  })
+
+  it('tokenizes a mixed inline line (code, link, bold) into several token types', () => {
+    const kinds = new Set(
+      tokenize('Use `npm run` and see [docs](http://x) for **details**.', 'md').map(t => t.type),
+    )
+    expect(kinds.has('string')).toBe(true) // `npm run`
+    expect(kinds.has('function')).toBe(true) // [docs](…)
+    expect(kinds.has('number')).toBe(true) // **details**
+    expect(kinds.size).toBeGreaterThan(2)
+  })
+
+  it('colours a list marker but leaves the item text plain', () => {
+    const tokens = tokenize('- first item', 'md')
+    expect(tokens[0]).toEqual({ text: '- ', type: 'operator' })
+    expect(tokens.some(t => t.type === 'plain')).toBe(true)
+    // An ordered marker too — but a version like `1.2.3` (no space) is not a marker.
+    expect(tokenize('1. step one', 'md')[0]).toEqual({ text: '1. ', type: 'operator' })
+    expect(tokenize('1.2.3 released', 'md').some(t => t.type === 'operator')).toBe(false)
+  })
+
+  it('does NOT emphasise snake_case identifiers (underscore emphasis is omitted)', () => {
+    // This repo's docs are full of snake_case names — `_`/`__` emphasis would
+    // mangle far more than it highlights, so it is deliberately unsupported.
+    const tokens = tokenize('the feedback_test_state_contamination file', 'md')
+    expect(tokens.every(t => t.type === 'plain')).toBe(true)
+  })
+
+  it('colours a bare URL and a blockquote marker', () => {
+    expect(tokenize('visit https://example.com/x now', 'md').some(t => t.type === 'function')).toBe(true)
+    expect(tokenize('> quoted line', 'md')[0]?.type).toBe('comment')
+  })
+})
+
 describe('highlightCode', () => {
   it('wraps tokens in colored spans', () => {
     const html = highlightCode('const x = 5', 'javascript')

--- a/packages/dashboard/src/lib/syntax.test.ts
+++ b/packages/dashboard/src/lib/syntax.test.ts
@@ -169,6 +169,19 @@ describe('markdown highlighting (#6508)', () => {
     expect(tokenize('visit https://example.com/x now', 'md').some(t => t.type === 'function')).toBe(true)
     expect(tokenize('> quoted line', 'md')[0]?.type).toBe('comment')
   })
+
+  it('highlights block constructs on EVERY line of a whole-file input (mobile path, #6518)', () => {
+    // The dashboard tokenizes per-line, but the mobile viewer (FileBrowser.tsx)
+    // passes the whole file to tokenize(). The block rules carry the `m` flag so
+    // `^`/`$` match every line boundary — without it, only line 1 would highlight.
+    const file = ['intro text', '', '## Heading on line 3', '- a list item', '> a quote'].join('\n')
+    const tokens = tokenize(file, 'md')
+    const byType = (type: string) => tokens.filter(t => t.type === type)
+    // The heading is on line 3, not line 1 — it must still be a keyword token.
+    expect(byType('keyword').some(t => t.text.includes('Heading on line 3'))).toBe(true)
+    expect(byType('operator').some(t => t.text === '- ')).toBe(true) // list marker below line 1
+    expect(byType('comment').some(t => t.text.startsWith('>'))).toBe(true) // blockquote below line 1
+  })
 })
 
 describe('highlightCode', () => {

--- a/packages/store-core/src/syntax.ts
+++ b/packages/store-core/src/syntax.ts
@@ -267,6 +267,35 @@ const sql: LanguageDef = [
   { pattern: s(/[();,.]/), type: 'punctuation' },
 ]
 
+// Markdown (#6508) — a lightweight, LINE-oriented highlighter. The dashboard
+// viewer tokenizes each line independently (FileBrowserPanel), so every rule is
+// single-line: block constructs (headings, list/quote markers, fences, thematic
+// breaks) are `^`-anchored so they only fire at column 0, and inline spans
+// (code, links, emphasis) match anywhere on the line. Two deliberate scope cuts:
+// (1) `_`/`__` emphasis is omitted — this repo's docs are full of snake_case
+// identifiers and file names, so underscore emphasis would mangle far more than
+// it highlights; (2) a fenced block's *content* isn't tracked across lines (the
+// tokenizer is stateless per-line), so only the ``` fence delimiter line is
+// coloured, not the code inside it. Bold, italic, and strikethrough share the
+// `number` (warm) colour — output is colour-only spans, so weight/slant can't be
+// shown; unifying emphasis to one hue keeps them distinct from body text.
+const markdown: LanguageDef = [
+  // Block-level, line-start anchored — listed first so they win at column 0.
+  { pattern: s(/^ {0,3}#{1,6}(?=\s|$)[^\n]*/), type: 'keyword' }, // ATX heading (whole line)
+  { pattern: s(/^ {0,3}(?:```|~~~)[^\n]*/), type: 'string' }, // fenced-code delimiter line
+  { pattern: s(/^ {0,3}(?:-{3,}|\*{3,}|_{3,})[ \t]*$/), type: 'comment' }, // thematic break (HR)
+  { pattern: s(/^ {0,3}>+ ?/), type: 'comment' }, // blockquote marker
+  { pattern: s(/^ {0,3}(?:[-*+]|\d{1,9}[.)]) +/), type: 'operator' }, // list marker
+  // Inline spans — matched anywhere on the line.
+  { pattern: s(/`[^`\n]+`/), type: 'string' }, // inline code
+  { pattern: s(/!\[[^\]\n]*\]\([^)\n]*\)/), type: 'function' }, // image
+  { pattern: s(/\[[^\]\n]+\]\([^)\n]*\)/), type: 'function' }, // link
+  { pattern: s(/https?:\/\/[^\s)]+/), type: 'function' }, // bare URL
+  { pattern: s(/\*\*[^\n]+?\*\*/), type: 'number' }, // bold (before italic)
+  { pattern: s(/~~[^\n]+?~~/), type: 'number' }, // strikethrough
+  { pattern: s(/\*[^*\n]+?\*/), type: 'number' }, // italic
+]
+
 // ---------------------------------------------------------------------------
 // Language registry
 // ---------------------------------------------------------------------------
@@ -291,6 +320,7 @@ const LANGUAGES: Record<string, LanguageDef> = {
   c,
   cpp: c,
   sql,
+  markdown,
 }
 
 /** Aliases map short names to canonical names.
@@ -338,6 +368,11 @@ const ALIASES: Record<string, string> = {
   jsonc: 'json',
   json5: 'json',
   toml: 'yaml',
+  // Markdown (#6508) — the server sends the bare extension as the id (reader.js
+  // sends `extname` without a leading dot). `.markdown` hits the LANGUAGES key
+  // directly; `.md`/`.mdx` need an alias, or the viewer renders them all-`plain`.
+  md: 'markdown',
+  mdx: 'markdown',
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/syntax.ts
+++ b/packages/store-core/src/syntax.ts
@@ -280,12 +280,17 @@ const sql: LanguageDef = [
 // `number` (warm) colour — output is colour-only spans, so weight/slant can't be
 // shown; unifying emphasis to one hue keeps them distinct from body text.
 const markdown: LanguageDef = [
-  // Block-level, line-start anchored — listed first so they win at column 0.
-  { pattern: s(/^ {0,3}#{1,6}(?=\s|$)[^\n]*/), type: 'keyword' }, // ATX heading (whole line)
-  { pattern: s(/^ {0,3}(?:```|~~~)[^\n]*/), type: 'string' }, // fenced-code delimiter line
-  { pattern: s(/^ {0,3}(?:-{3,}|\*{3,}|_{3,})[ \t]*$/), type: 'comment' }, // thematic break (HR)
-  { pattern: s(/^ {0,3}>+ ?/), type: 'comment' }, // blockquote marker
-  { pattern: s(/^ {0,3}(?:[-*+]|\d{1,9}[.)]) +/), type: 'operator' }, // list marker
+  // Block-level, line-start anchored — listed first so they win at column 0. The
+  // `m` flag makes `^`/`$` match every line boundary, not just string index 0:
+  // the dashboard tokenizes per-line so it's a no-op there, but the mobile viewer
+  // (FileBrowser.tsx) passes the WHOLE file to tokenize(), so without `m` these
+  // block constructs would only highlight on line 1 (#6518). `s()` keeps `m` and
+  // adds the sticky `y` the scanner needs — same as the `diff` LanguageDef.
+  { pattern: s(/^ {0,3}#{1,6}(?=\s|$)[^\n]*/m), type: 'keyword' }, // ATX heading (whole line)
+  { pattern: s(/^ {0,3}(?:```|~~~)[^\n]*/m), type: 'string' }, // fenced-code delimiter line
+  { pattern: s(/^ {0,3}(?:-{3,}|\*{3,}|_{3,})[ \t]*$/m), type: 'comment' }, // thematic break (HR)
+  { pattern: s(/^ {0,3}>+ ?/m), type: 'comment' }, // blockquote marker
+  { pattern: s(/^ {0,3}(?:[-*+]|\d{1,9}[.)]) +/m), type: 'operator' }, // list marker
   // Inline spans — matched anywhere on the line.
   { pattern: s(/`[^`\n]+`/), type: 'string' }, // inline code
   { pattern: s(/!\[[^\]\n]*\]\([^)\n]*\)/), type: 'function' }, // image


### PR DESCRIPTION
## Summary

The opt-in IDE file viewer (#6469) rendered `.md`/`.markdown` files with **no syntax highlighting** — every line one `plain` colour — because those extensions were neither a `LANGUAGES` key nor an `ALIASES` entry in the shared tokenizer (`packages/store-core/src/syntax.ts`). Markdown is the **4th-most-common extension in this repo (113 files)** — `CLAUDE.md`, docs, guides — so it's one of the most-viewed file types in the viewer.

Same **bug class** as #6507 (`.mjs/.cjs/.mts/.cts`), but Markdown needs a real grammar, not a one-line alias.

## What changed

- **`packages/store-core/src/syntax.ts`** — a lightweight, line-oriented Markdown `LanguageDef`, registered as the `markdown` key + `md`/`mdx` aliases (`.markdown` hits the key directly; the server sends the bare extension as the language id).

The viewer tokenizes **each line independently** (`FileBrowserPanel` — `lines.map(line => tokenize(line, lang))`), so every rule is single-line:
- **Block constructs** (ATX headings, list/quote markers, fenced-code delimiter lines, thematic breaks) are `^`-anchored so they fire only at column 0.
- **Inline spans** (inline code, links, images, bare URLs, bold/italic/strikethrough) match anywhere on the line.

### Colour mapping
| Construct | Token type | Colour |
|-----------|-----------|--------|
| Heading | `keyword` | purple |
| Inline code + fence delimiter | `string` | green |
| Link / image / bare URL | `function` | blue |
| Bold / italic / strikethrough | `number` | warm |
| Blockquote / thematic break | `comment` | grey |
| List marker | `operator` | — |

### Two deliberate scope cuts (documented inline)
1. **`_`/`__` emphasis is omitted** — this repo's docs are full of `snake_case` identifiers and file names (`feedback_test_state_contamination.md`), so underscore emphasis would mangle far more than it highlights.
2. **A fenced block's *content* isn't tracked across lines** (the tokenizer is stateless per-line), so only the ` ``` ` delimiter line is coloured, not the code inside it.

Bold/italic/strikethrough share the warm `number` colour because output is colour-only spans (weight/slant can't be shown) — unifying emphasis to one hue keeps it distinct from body text. No new token types or CSS: it reuses the existing `.syn-*` classes every other language uses.

## Testing

- **7 new cases** in `packages/dashboard/src/lib/syntax.test.ts` (mirroring the #6507 pattern): `md`/`markdown`/`mdx` resolve; a heading is one non-plain token; a mid-line/spaceless `#` is **not** a heading; a mixed inline line yields code+link+bold token types; list markers colour but text stays plain (and `1.2.3` is not a marker); `snake_case` stays all-plain; bare URLs + blockquote markers colour.
- Full **store-core** (1919) and **dashboard** (4176) suites green.
- **Live-verified** against the running daemon: a `README.md` renders headings purple (`syn-keyword`), inline code green (`syn-string`), links blue (`syn-function`), and `_underscored_` prose stays `syn-plain`.

Closes #6508