### PR TITLE
perf(server): cache the workspace symbol index across resolve/list calls (#6499)

### DIFF
--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -12,7 +12,7 @@
  */
 import { resolveSession } from '../handler-utils.js'
 import { isIdeFeatureEnabled } from '../config.js'
-import { collectWorkspaceSymbols, resolveSymbol } from '../ide/symbols.js'
+import { collectWorkspaceSymbols, getWorkspaceSymbolIndex, resolveSymbol } from '../ide/symbols.js'
 import { searchContent, findReferences } from '../ide/search.js'
 import { createLogger } from '../logger.js'
 
@@ -43,7 +43,11 @@ async function handleListSymbols(ws, client, msg, ctx) {
   }
 
   try {
-    const { symbols, truncated } = await collectWorkspaceSymbols(cwd, { path })
+    // Whole-workspace list_symbols (no path) shares the TTL symbol-index cache
+    // (#6499) with resolve_symbol; a scoped path re-scans that sub-tree fresh.
+    const { symbols, truncated } = path
+      ? await collectWorkspaceSymbols(cwd, { path })
+      : await getWorkspaceSymbolIndex(cwd)
     ctx.transport.send(ws, { type: 'symbols_snapshot', path, symbols, truncated, error: null })
   } catch (err) {
     log.debug(`list_symbols failed: ${err?.message}`)

--- a/packages/server/src/ide/symbols.js
+++ b/packages/server/src/ide/symbols.js
@@ -297,6 +297,88 @@ export async function collectWorkspaceSymbols(rootDir, opts = {}) {
   return { symbols, truncated }
 }
 
+// ---------------------------------------------------------------------------
+// Workspace symbol-index cache (#6499)
+// ---------------------------------------------------------------------------
+//
+// resolveSymbol and the whole-workspace list_symbols both do a FULL bounded walk
+// on every call — a burst of cmd/ctrl+clicks over a tunnel re-parses the whole
+// tree each time. This short-lived, invalidatable cache holds the full-walk
+// result (`collectWorkspaceSymbols(rootDir)` with no `path`) keyed by the REAL
+// (symlink-resolved) workspace root, so a second lookup within the TTL filters
+// the cached table instead of re-walking. Scoped (`path`-bearing) scans are NOT
+// cached — they are cheap and varied; only the expensive no-path full walk is.
+//
+// Invalidation is TTL-based (a newly-added declaration resolves once the entry
+// expires); `invalidateWorkspaceSymbolIndex()` clears everything for a future
+// file-change signal or test teardown. The cached object is treated as READ-ONLY
+// by every consumer (resolveSymbol reads, the handler serializes) — do not mutate
+// it, or you corrupt the shared entry.
+const DEFAULT_INDEX_TTL_MS = 5000
+const MAX_INDEX_CACHE_ENTRIES = 16
+const _indexCache = new Map() // realpath(root) → { result, expires }
+let _indexHits = 0
+let _indexMisses = 0
+
+/**
+ * Full-workspace symbol index with a short TTL cache (#6499). Same return shape
+ * as `collectWorkspaceSymbols(rootDir)` (no path). Keyed by the realpath of the
+ * root so two workspaces never share an entry, and so an in-workspace symlink
+ * can't poison another root's key.
+ *
+ * @param {string} rootDir          Absolute workspace root (session cwd).
+ * @param {object} [opts]
+ * @param {number} [opts.ttlMs]     Entry lifetime (default 5000ms).
+ * @param {number} [opts.now]       Injectable clock for deterministic tests.
+ * @returns {Promise<{symbols: SymbolEntry[], truncated: boolean}>}
+ */
+export async function getWorkspaceSymbolIndex(rootDir, opts = {}) {
+  const { ttlMs = DEFAULT_INDEX_TTL_MS, now = Date.now() } = opts
+  // Key by the REAL root — same base collectWorkspaceSymbols confines against. An
+  // unresolvable root can't be cached safely; fall back to the (also-guarded,
+  // empty-on-error) uncached walk.
+  let key
+  try {
+    key = await realpath(resolve(rootDir))
+  } catch {
+    return collectWorkspaceSymbols(rootDir)
+  }
+
+  const hit = _indexCache.get(key)
+  if (hit && hit.expires > now) {
+    _indexHits++
+    return hit.result
+  }
+
+  _indexMisses++
+  const result = await collectWorkspaceSymbols(rootDir)
+  // Bounded FIFO eviction — the daemon usually has one workspace, but never let a
+  // long-lived process accumulate unbounded entries.
+  _indexCache.delete(key) // drop any stale entry so re-insert lands as newest
+  if (_indexCache.size >= MAX_INDEX_CACHE_ENTRIES) {
+    const oldest = _indexCache.keys().next().value
+    if (oldest !== undefined) _indexCache.delete(oldest)
+  }
+  _indexCache.set(key, { result, expires: now + ttlMs })
+  return result
+}
+
+/**
+ * Clear the workspace symbol-index cache (#6499) — every entry and the hit/miss
+ * counters. No-arg / coarse by design: a hook for a future file-change signal or
+ * a test teardown. TTL expiry is the routine invalidation path.
+ */
+export function invalidateWorkspaceSymbolIndex() {
+  _indexCache.clear()
+  _indexHits = 0
+  _indexMisses = 0
+}
+
+/** Cache hit/miss/size counters (#6499) — for tests and diagnostics. */
+export function _symbolIndexCacheStats() {
+  return { hits: _indexHits, misses: _indexMisses, size: _indexCache.size }
+}
+
 /**
  * Resolve a symbol NAME to a single declaration location — the backbone of
  * go-to-definition (#6475, epic #6469). Reuses collectWorkspaceSymbols so the
@@ -322,7 +404,9 @@ export async function resolveSymbol(rootDir, symbolName, opts = {}) {
   const name = typeof symbolName === 'string' ? symbolName.trim() : ''
   if (!name) return null
   const { fromFile = null } = opts
-  const { symbols } = await collectWorkspaceSymbols(rootDir)
+  // Route through the TTL cache (#6499) so a burst of clicks doesn't re-walk the
+  // tree each time; ttlMs/now (if present) are forwarded for deterministic tests.
+  const { symbols } = await getWorkspaceSymbolIndex(rootDir, opts)
   let best = null
   let bestScore = -1
   for (const s of symbols) {

--- a/packages/server/src/ide/symbols.js
+++ b/packages/server/src/ide/symbols.js
@@ -405,8 +405,10 @@ export async function resolveSymbol(rootDir, symbolName, opts = {}) {
   if (!name) return null
   const { fromFile = null } = opts
   // Route through the TTL cache (#6499) so a burst of clicks doesn't re-walk the
-  // tree each time; ttlMs/now (if present) are forwarded for deterministic tests.
-  const { symbols } = await getWorkspaceSymbolIndex(rootDir, opts)
+  // tree each time. Forward ONLY the cache knobs explicitly (not the whole opts
+  // bag) — `fromFile` is a resolveSymbol-only ranking hint the index ignores, so
+  // passing it through would be silent coupling.
+  const { symbols } = await getWorkspaceSymbolIndex(rootDir, { ttlMs: opts.ttlMs, now: opts.now })
   let best = null
   let bestScore = -1
   for (const s of symbols) {

--- a/packages/server/tests/ide-symbols.test.js
+++ b/packages/server/tests/ide-symbols.test.js
@@ -292,26 +292,43 @@ describe('getWorkspaceSymbolIndex — TTL cache (#6499)', () => {
 
   it('serves a second call within the TTL from cache (does NOT re-walk)', async () => {
     invalidateWorkspaceSymbolIndex()
-    // Miss populates the cache at now=1000 (expires 1000+5000).
-    const first = await getWorkspaceSymbolIndex(root, { now: 1000, ttlMs: 5000 })
-    assert.deepEqual(first.symbols.map((s) => s.name), ['alpha'])
-    // A new declaration lands on disk...
-    writeFileSync(join(root, 'b.ts'), 'export const beta = 2\n')
-    // ...but a within-TTL call must NOT observe it — the stale table is the proof
-    // the tree was not re-walked (acceptance: no re-walk within the TTL).
-    const second = await getWorkspaceSymbolIndex(root, { now: 3000, ttlMs: 5000 })
-    assert.deepEqual(second.symbols.map((s) => s.name), ['alpha'])
-    const stats = _symbolIndexCacheStats()
-    assert.equal(stats.hits, 1)
-    assert.equal(stats.misses, 1)
+    // Self-contained temp dir so the scenario doesn't depend on sibling tests.
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-ide-idxcache-ttl-'))
+    try {
+      writeFileSync(join(dir, 'a.ts'), 'export const alpha = 1\n')
+      // Miss populates the cache at now=1000 (expires 1000+5000).
+      const firstCall = await getWorkspaceSymbolIndex(dir, { now: 1000, ttlMs: 5000 })
+      assert.deepEqual(firstCall.symbols.map((s) => s.name), ['alpha'])
+      // A new declaration lands on disk...
+      writeFileSync(join(dir, 'b.ts'), 'export const beta = 2\n')
+      // ...but a within-TTL call must NOT observe it — the stale table is the proof
+      // the tree was not re-walked (acceptance: no re-walk within the TTL).
+      const second = await getWorkspaceSymbolIndex(dir, { now: 3000, ttlMs: 5000 })
+      assert.deepEqual(second.symbols.map((s) => s.name), ['alpha'])
+      const stats = _symbolIndexCacheStats()
+      assert.equal(stats.hits, 1)
+      assert.equal(stats.misses, 1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('re-walks after the TTL expires so a newly-added declaration resolves', async () => {
     invalidateWorkspaceSymbolIndex()
-    await getWorkspaceSymbolIndex(root, { now: 1000, ttlMs: 5000 }) // populate
-    // Past expiry (1000 + 5000 = 6000) → re-walk picks up b.ts written above.
-    const after = await getWorkspaceSymbolIndex(root, { now: 7000, ttlMs: 5000 })
-    assert.deepEqual(after.symbols.map((s) => s.name).sort(), ['alpha', 'beta'])
+    // Self-contained — create + mutate this dir within the test so it isn't
+    // order-dependent on a file written by a sibling test.
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-ide-idxcache-exp-'))
+    try {
+      writeFileSync(join(dir, 'a.ts'), 'export const alpha = 1\n')
+      await getWorkspaceSymbolIndex(dir, { now: 1000, ttlMs: 5000 }) // populate (expires 6000)
+      // A new declaration lands AFTER the cache was populated...
+      writeFileSync(join(dir, 'b.ts'), 'export const beta = 2\n')
+      // ...invisible within the TTL, but a post-expiry call re-walks and picks it up.
+      const after = await getWorkspaceSymbolIndex(dir, { now: 7000, ttlMs: 5000 })
+      assert.deepEqual(after.symbols.map((s) => s.name).sort(), ['alpha', 'beta'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('invalidate() forces the next call to re-walk (and resets stats)', async () => {
@@ -348,7 +365,8 @@ describe('getWorkspaceSymbolIndex — TTL cache (#6499)', () => {
       writeFileSync(join(r, 'a.ts'), 'export const widget = 1\n')
       const first = await resolveSymbol(r, 'widget', { now: 1000, ttlMs: 5000 })
       assert.deepEqual(first, { file: 'a.ts', line: 1 })
-      // Add a competing exported decl; a within-TTL resolve must not see it.
+      // A NEW exported decl lands after the cache was populated; a within-TTL
+      // resolve works off the stale index, so it must not see it yet (not-found).
       writeFileSync(join(r, 'later.ts'), 'export const gadget = 2\n')
       assert.equal(await resolveSymbol(r, 'gadget', { now: 2000, ttlMs: 5000 }), null) // stale cache
       assert.equal(_symbolIndexCacheStats().hits, 1) // second resolve hit the cache

--- a/packages/server/tests/ide-symbols.test.js
+++ b/packages/server/tests/ide-symbols.test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'node:test'
+import { describe, it, before, beforeEach, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -235,6 +235,9 @@ describe('resolveSymbol — go-to-definition (#6475)', () => {
     writeFileSync(join(outside, 'secret.js'), 'export function TOP_SECRET() {}\n')
     symlinkSync(join(outside, 'secret.js'), join(root, 'linkfile.js'))
   })
+  // resolveSymbol now routes through the #6499 TTL cache; start each test with a
+  // clean index so a future mid-block file mutation can't get a stale hit.
+  beforeEach(() => invalidateWorkspaceSymbolIndex())
   after(() => {
     rmSync(root, { recursive: true, force: true })
     rmSync(outside, { recursive: true, force: true })

--- a/packages/server/tests/ide-symbols.test.js
+++ b/packages/server/tests/ide-symbols.test.js
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { parseSymbols, collectWorkspaceSymbols, resolveSymbol } from '../src/ide/symbols.js'
+import {
+  parseSymbols,
+  collectWorkspaceSymbols,
+  resolveSymbol,
+  getWorkspaceSymbolIndex,
+  invalidateWorkspaceSymbolIndex,
+  _symbolIndexCacheStats,
+} from '../src/ide/symbols.js'
 
 /**
  * Unit tests for the self-contained IDE symbol parser (#6471, epic #6469).
@@ -261,5 +268,89 @@ describe('resolveSymbol — go-to-definition (#6475)', () => {
 
   it('never resolves a symbol reachable only through an out-of-workspace symlink', async () => {
     assert.equal(await resolveSymbol(root, 'TOP_SECRET'), null)
+  })
+})
+
+describe('getWorkspaceSymbolIndex — TTL cache (#6499)', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-idxcache-'))
+    writeFileSync(join(root, 'a.ts'), 'export const alpha = 1\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('returns the same shape as an uncached full walk', async () => {
+    invalidateWorkspaceSymbolIndex()
+    const cached = await getWorkspaceSymbolIndex(root, { now: 1000 })
+    const fresh = await collectWorkspaceSymbols(root)
+    assert.deepEqual(cached.symbols.map((s) => s.name).sort(), fresh.symbols.map((s) => s.name).sort())
+    assert.equal(cached.truncated, fresh.truncated)
+  })
+
+  it('serves a second call within the TTL from cache (does NOT re-walk)', async () => {
+    invalidateWorkspaceSymbolIndex()
+    // Miss populates the cache at now=1000 (expires 1000+5000).
+    const first = await getWorkspaceSymbolIndex(root, { now: 1000, ttlMs: 5000 })
+    assert.deepEqual(first.symbols.map((s) => s.name), ['alpha'])
+    // A new declaration lands on disk...
+    writeFileSync(join(root, 'b.ts'), 'export const beta = 2\n')
+    // ...but a within-TTL call must NOT observe it — the stale table is the proof
+    // the tree was not re-walked (acceptance: no re-walk within the TTL).
+    const second = await getWorkspaceSymbolIndex(root, { now: 3000, ttlMs: 5000 })
+    assert.deepEqual(second.symbols.map((s) => s.name), ['alpha'])
+    const stats = _symbolIndexCacheStats()
+    assert.equal(stats.hits, 1)
+    assert.equal(stats.misses, 1)
+  })
+
+  it('re-walks after the TTL expires so a newly-added declaration resolves', async () => {
+    invalidateWorkspaceSymbolIndex()
+    await getWorkspaceSymbolIndex(root, { now: 1000, ttlMs: 5000 }) // populate
+    // Past expiry (1000 + 5000 = 6000) → re-walk picks up b.ts written above.
+    const after = await getWorkspaceSymbolIndex(root, { now: 7000, ttlMs: 5000 })
+    assert.deepEqual(after.symbols.map((s) => s.name).sort(), ['alpha', 'beta'])
+  })
+
+  it('invalidate() forces the next call to re-walk (and resets stats)', async () => {
+    invalidateWorkspaceSymbolIndex()
+    await getWorkspaceSymbolIndex(root, { now: 1000 })
+    assert.equal(_symbolIndexCacheStats().misses, 1)
+    invalidateWorkspaceSymbolIndex()
+    assert.equal(_symbolIndexCacheStats().misses, 0) // counters reset
+    const again = await getWorkspaceSymbolIndex(root, { now: 1000 })
+    assert.equal(_symbolIndexCacheStats().misses, 1) // a fresh miss, not a hit
+    assert.ok(again.symbols.length >= 1)
+  })
+
+  it('is confined per-workspace — a second root does not share the first cache', async () => {
+    invalidateWorkspaceSymbolIndex()
+    const root2 = mkdtempSync(join(tmpdir(), 'chroxy-ide-idxcache2-'))
+    try {
+      writeFileSync(join(root2, 'z.ts'), 'export function zeta() {}\n')
+      const a = await getWorkspaceSymbolIndex(root, { now: 1000 })
+      const b = await getWorkspaceSymbolIndex(root2, { now: 1000 })
+      assert.ok(a.symbols.some((s) => s.name === 'alpha'))
+      assert.ok(b.symbols.some((s) => s.name === 'zeta'))
+      assert.ok(!b.symbols.some((s) => s.name === 'alpha')) // no bleed between workspaces
+      assert.equal(_symbolIndexCacheStats().misses, 2) // two distinct roots → two walks
+    } finally {
+      rmSync(root2, { recursive: true, force: true })
+    }
+  })
+
+  it('resolveSymbol reuses the cache — a second resolve within the TTL does not re-walk', async () => {
+    invalidateWorkspaceSymbolIndex()
+    const r = mkdtempSync(join(tmpdir(), 'chroxy-ide-idxcache3-'))
+    try {
+      writeFileSync(join(r, 'a.ts'), 'export const widget = 1\n')
+      const first = await resolveSymbol(r, 'widget', { now: 1000, ttlMs: 5000 })
+      assert.deepEqual(first, { file: 'a.ts', line: 1 })
+      // Add a competing exported decl; a within-TTL resolve must not see it.
+      writeFileSync(join(r, 'later.ts'), 'export const gadget = 2\n')
+      assert.equal(await resolveSymbol(r, 'gadget', { now: 2000, ttlMs: 5000 }), null) // stale cache
+      assert.equal(_symbolIndexCacheStats().hits, 1) // second resolve hit the cache
+    } finally {
+      rmSync(r, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

`resolveSymbol` (go-to-definition, #6498) and the whole-workspace `list_symbols` (#6471) both did a **full bounded tree walk + re-parse on every call** — `collectWorkspaceSymbols(cwd)` with no `path`. A burst of cmd/ctrl+clicks over a Cloudflare tunnel on a large repo repeated the entire walk each time: wasted CPU/IO on the daemon and added latency before each jump. Follow-up from the review of #6498.

## What changed — `packages/server/src/ide/symbols.js`

A short-lived, invalidatable **workspace symbol-index cache**:

- **`getWorkspaceSymbolIndex(rootDir, {ttlMs, now})`** wraps the no-path `collectWorkspaceSymbols` and caches its result keyed by **`realpath(root)`** (TTL default 5s). A second lookup within the TTL filters the cached table instead of re-walking.
  - Keyed by the **real** root so two workspaces never share an entry and an in-workspace symlink can't poison another key.
  - **Bounded FIFO eviction** (16 entries) so a long-lived daemon can't grow unbounded.
- **`invalidateWorkspaceSymbolIndex()`** clears everything (a hook for a future file-change signal / test teardown). TTL expiry is the routine invalidation path — a newly-added declaration resolves once the entry ages out.
- **`_symbolIndexCacheStats()`** — hit/miss/size counters for tests + diagnostics.
- `resolveSymbol` and the **no-path** `list_symbols` handler route through it; a **scoped** (`path`-bearing) `list_symbols` still scans that sub-tree fresh.

`collectWorkspaceSymbols` stays **pure/uncached** — scoped scans and existing callers are unchanged, so the cache is opt-in at the wrapper (lower risk). **Caps and realpath confinement are untouched.**

## Acceptance (#6499)
- ✅ A second `resolve_symbol` within the TTL does not re-walk (proven by a within-TTL call returning the stale table + a cache-hit counter).
- ✅ Cache is confined per-workspace (realpath key) and invalidates (TTL/`invalidate()`) so a newly-added declaration still resolves.
- ✅ Caps + realpath confinement unchanged.

## Testing

- **6 new deterministic cache tests** (injectable clock — no sleeps) in `ide-symbols.test.js`: same shape as an uncached walk; within-TTL serves stale (no re-walk); post-TTL re-walk picks up a new declaration; `invalidate()` forces a re-walk; per-workspace confinement (no bleed between roots); `resolveSymbol` reuses the cache.
- ide-symbols (28) + ide-handlers (21) targeted green; all 5 server custom lints pass.
- Full server suite: 10,799 pass. The only 2 "failures" locally are the documented `service.test.js` `getFullServiceStatus` health-check assertions that expect **no** server on :8765 — a false positive from my dev daemon being live on :8765 for dogfooding (unrelated to this change; green in CI, which has no live daemon).

Closes #6499