### PR TITLE
feat(server): rank find-references results by originating file (#6516)

### DIFF
--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -176,6 +176,12 @@ async function handleFindReferences(ws, client, msg, ctx) {
   if (!isIdeFeatureEnabled(ctx.services?.config)) return
 
   const symbol = typeof msg.symbol === 'string' ? msg.symbol.trim() : ''
+  // The originating file (the symbol was alt+clicked in) — normalized to the
+  // workspace-relative POSIX form findReferences ranks against (#6516), same as
+  // handleResolveSymbol does for its tie-break.
+  const fromFile = typeof msg.file === 'string' && msg.file.trim()
+    ? msg.file.trim().replace(/\\/g, '/')
+    : null
 
   if (!symbol) {
     ctx.transport.send(ws, { type: 'references_result', symbol: '', results: [], truncated: false, error: null })
@@ -196,7 +202,7 @@ async function handleFindReferences(ws, client, msg, ctx) {
   }
 
   try {
-    const { results, truncated } = await findReferences(cwd, symbol)
+    const { results, truncated } = await findReferences(cwd, symbol, { fromFile })
     ctx.transport.send(ws, { type: 'references_result', symbol, results, truncated, error: null })
   } catch (err) {
     log.debug(`find_references failed: ${err?.message}`)

--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -168,8 +168,9 @@ async function handleSearchContent(ws, client, msg, ctx) {
  * `find_references` → `references_result`. Find-all-references (#6477): a
  * word-boundary, case-sensitive grep for a symbol NAME over the same confined
  * walk search_content uses, returning every referencing site. `file` (the
- * originating file) is accepted for symmetry but not used to rank. Dashboard-only
- * consumer for v1 (the references palette).
+ * originating file) ranks that file's references first (#6516), mirroring how
+ * resolveSymbol uses it as a tie-break. Dashboard-only consumer for v1 (the
+ * references palette).
  */
 async function handleFindReferences(ws, client, msg, ctx) {
   // #6481 (epic #6469): fail closed when the IDE surface is not opted in.

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -247,10 +247,10 @@ export async function findReferences(rootDir, symbol, opts = {}) {
   // Rank references in the ORIGINATING file first (#6516) — the file the symbol
   // was alt+clicked in is usually where you want to look, mirroring how
   // resolveSymbol uses `fromFile` as a tie-break. Normalize a Windows-style path
-  // to the forward-slash workspace-relative form collectMatches emits, then stable
-  // -partition origin rows to the front (Array.sort is stable since ES2019, so the
-  // deterministic walk order is preserved within each group). Post-collection, so
-  // it never changes which rows survive the cap — only their order.
+  // to the forward-slash workspace-relative form collectMatches emits, then a
+  // stable partition floats origin rows to the front (Array.sort is stable since
+  // ES2019, so the deterministic walk order is preserved within each group).
+  // Post-collection, so it never changes which rows survive the cap — only order.
   const fromFile = typeof opts.fromFile === 'string' && opts.fromFile.trim()
     ? opts.fromFile.trim().replace(/\\/g, '/')
     : null

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -233,7 +233,7 @@ export async function findReferences(rootDir, symbol, opts = {}) {
   // the `$store` tail inside `my$store`. `(?<![\w$])…(?![\w$])` treats `$` as part
   // of the identifier, so a reference must be flanked by non-identifier chars.
   const re = new RegExp(`(?<![\\w$])${escaped}(?![\\w$])`, 'g')
-  return collectMatches(rootDir, (line) => {
+  const out = await collectMatches(rootDir, (line) => {
     const cols = []
     re.lastIndex = 0
     let m
@@ -243,4 +243,19 @@ export async function findReferences(rootDir, symbol, opts = {}) {
     }
     return cols
   }, opts)
+
+  // Rank references in the ORIGINATING file first (#6516) — the file the symbol
+  // was alt+clicked in is usually where you want to look, mirroring how
+  // resolveSymbol uses `fromFile` as a tie-break. Normalize a Windows-style path
+  // to the forward-slash workspace-relative form collectMatches emits, then stable
+  // -partition origin rows to the front (Array.sort is stable since ES2019, so the
+  // deterministic walk order is preserved within each group). Post-collection, so
+  // it never changes which rows survive the cap — only their order.
+  const fromFile = typeof opts.fromFile === 'string' && opts.fromFile.trim()
+    ? opts.fromFile.trim().replace(/\\/g, '/')
+    : null
+  if (fromFile) {
+    out.results.sort((a, b) => (b.file === fromFile ? 1 : 0) - (a.file === fromFile ? 1 : 0))
+  }
+  return out
 }

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -248,6 +248,20 @@ describe('find_references handler — emission', () => {
     assert.deepEqual(msg.results.map((r) => r.line).sort(), [1, 2])
   })
 
+  it('threads the origin `file` through so its references rank first (#6516)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-h-rank-'))
+    try {
+      writeFileSync(join(dir, 'aa.ts'), 'const a = findMe()\n')
+      writeFileSync(join(dir, 'zz.ts'), 'const z = findMe()\n')
+      const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: dir })
+      await handleFindReferences({}, client, { type: 'find_references', symbol: 'findMe', file: 'zz.ts' }, ctx)
+      // zz.ts is the origin → it floats above aa.ts despite the walk order.
+      assert.deepEqual(sent[0].results.map((r) => r.file), ['zz.ts', 'aa.ts'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('emits an empty result set for a symbol with no references', async () => {
     const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
     await handleFindReferences({}, client, { type: 'find_references', symbol: 'nope' }, ctx)

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -205,8 +205,13 @@ describe('findReferences — word-boundary reverse lookup (#6477)', () => {
 
   it('is unchanged (walk order) when no fromFile is given (#6516)', async () => {
     const { results } = await findReferences(root, 'widget')
-    // Without an origin hint, results stay in the deterministic walk order.
-    assert.deepEqual(results.map((r) => r.line).sort((a, b) => a - b), [1, 2, 5, 5])
+    // Without an origin hint, results keep the deterministic walk order — assert
+    // the ORDER directly (no sort), so an accidental reordering would be caught.
+    // a.ts refs in walk order: line 1, line 2, then the two on line 5.
+    assert.deepEqual(
+      results.map((r) => `${r.file}:${r.line}`),
+      ['a.ts:1', 'a.ts:2', 'a.ts:5', 'a.ts:5'],
+    )
   })
 
   it('returns every occurrence on a line with 1-indexed columns', async () => {

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -172,6 +172,43 @@ describe('findReferences — word-boundary reverse lookup (#6477)', () => {
     }
   })
 
+  it('ranks references in the originating file first (fromFile), stable otherwise (#6516)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-rank-'))
+    try {
+      // widget referenced in three files; alphabetically aa.ts < mm.ts < zz.ts, so
+      // the default walk order is aa, mm, zz. Clicking in mm.ts must float mm first.
+      writeFileSync(join(dir, 'aa.ts'), 'const x = widget()\n')
+      writeFileSync(join(dir, 'mm.ts'), 'const y = widget()\nconst z = widget()\n')
+      writeFileSync(join(dir, 'zz.ts'), 'const w = widget()\n')
+      const { results } = await findReferences(dir, 'widget', { fromFile: 'mm.ts' })
+      // Origin file's rows come first (both of them, in line order), then the rest
+      // in the original deterministic walk order (aa before zz).
+      assert.deepEqual(results.map((r) => `${r.file}:${r.line}`), ['mm.ts:1', 'mm.ts:2', 'aa.ts:1', 'zz.ts:1'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('normalizes a backslash fromFile so a Windows-style origin still ranks (#6516)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-ide-refs-rank-win-'))
+    try {
+      mkdirSync(join(dir, 'src'))
+      writeFileSync(join(dir, 'a.ts'), 'const x = widget()\n')
+      writeFileSync(join(dir, 'src', 'b.ts'), 'const y = widget()\n')
+      // A client that sends a backslash path must still match the POSIX result key.
+      const { results } = await findReferences(dir, 'widget', { fromFile: 'src\\b.ts' })
+      assert.equal(results[0].file, 'src/b.ts')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('is unchanged (walk order) when no fromFile is given (#6516)', async () => {
+    const { results } = await findReferences(root, 'widget')
+    // Without an origin hint, results stay in the deterministic walk order.
+    assert.deepEqual(results.map((r) => r.line).sort((a, b) => a - b), [1, 2, 5, 5])
+  })
+
   it('returns every occurrence on a line with 1-indexed columns', async () => {
     const { results } = await findReferences(root, 'widget')
     const line5 = results.filter((r) => r.line === 5)


### PR DESCRIPTION
## Summary

`find_references` (#6477) accepted a `file` field — the origin the symbol was alt+clicked in — **end-to-end** (client sends it, store threads it, handler receives it), but `findReferences()` in `packages/server/src/ide/search.js` **ignored it** ("accepted for symmetry" with `resolve_symbol`). So the wire carried an input the backend discarded. Follow-up from the review of #6515.

## What changed

Put the origin file to work — rank references **in the originating file first** (the file you clicked in is usually where you want to look), mirroring how `resolveSymbol` uses `fromFile` as a tie-break:

- **`ide/search.js`** — after collecting matches, normalize the origin path to the forward-slash workspace-relative form the results use (so a Windows-style backslash path still matches), then a **stable partition** floats origin rows to the front. `Array.sort` is stable since ES2019, so the deterministic walk order is preserved within each group. Applied **post-collection**, so it never changes which rows survive the result cap — only their order. No `fromFile` ⇒ unchanged walk order.
- **`handlers/ide-handlers.js`** — normalize `msg.file` the same way `handleResolveSymbol` does and forward it as `{ fromFile }`.

**No protocol change** — the `file` field already exists on the wire (this closes the "plumbed-but-unused param" gap the issue flagged, the alternative being to drop the field).

## Testing

- `ide/search.js`: origin-first ranking (stable within groups), backslash-path normalization, and unchanged-without-`fromFile`.
- `handlers/ide-handlers.js`: an **end-to-end** test that a `find_references` carrying `file: 'zz.ts'` floats `zz.ts` above the walk-order-earlier `aa.ts`.
- 45 targeted (ide-search + ide-handlers) tests green; all 5 server custom lints pass; full server suite running (only the known `service.test.js` `:8765` dev-daemon false-positive expected locally).

Closes #6516