### PR TITLE
fix(ide): correlate file_content replies by request nonce (#6502)

### DIFF
--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -26,6 +26,8 @@ let mockSymbols: any = null
 let mockSymbolsLoading = false
 let mockIdeCapability = false
 let mockFileBrowserPendingOpen: any = null
+// #6502 — the latest read_file nonce the store recorded
+let mockLastFileContentRequestId: string | null = null
 
 vi.mock('../store/connection', () => {
   const storeState = () => ({
@@ -46,6 +48,7 @@ vi.mock('../store/connection', () => {
     requestFindReferences: mockRequestFindReferences,
     openFileInBrowser: mockOpenFileInBrowser,
     symbolLocation: mockSymbolLocation,
+    lastFileContentRequestId: mockLastFileContentRequestId,
   })
 
   const useConnectionStore = Object.assign(
@@ -84,6 +87,7 @@ beforeEach(() => {
   mockIdeCapability = false
   mockFileBrowserPendingOpen = null
   mockSymbolLocation = null
+  mockLastFileContentRequestId = null
 })
 
 describe('FileBrowserPanel', () => {
@@ -561,5 +565,54 @@ describe('FileBrowserPanel — stale content guard (#6497)', () => {
       fileContentCallback!({ path: '/root/a.ts', content: 'CORRECT', language: 'typescript', size: 7, truncated: false, error: null })
     })
     await waitFor(() => screen.getByText('CORRECT'))
+  })
+})
+
+describe('FileBrowserPanel — nonce correlation guard (#6502)', () => {
+  it('drops a reply whose requestId is not the latest, even when the path matches', async () => {
+    render(<FileBrowserPanel />)
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root', parentPath: null,
+        entries: [{ name: 'a.ts', isDirectory: false, size: 10 }], error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('a.ts'))
+    fireEvent.click(screen.getByText('a.ts')) // selectedFile = /root/a.ts
+    // The store's latest in-flight read is nonce '2'.
+    mockLastFileContentRequestId = '2'
+    // A reply carrying an OLDER nonce for the SAME path must be dropped — this is
+    // the case path-matching alone (#6497) would have wrongly accepted.
+    act(() => {
+      fileContentCallback!({ path: '/root/a.ts', content: 'SUPERSEDED', language: 'typescript', size: 5, truncated: false, error: null, requestId: '1' })
+    })
+    expect(screen.queryByText('SUPERSEDED')).toBeNull()
+    // The reply matching the latest nonce renders.
+    act(() => {
+      fileContentCallback!({ path: '/root/a.ts', content: 'LATEST', language: 'typescript', size: 6, truncated: false, error: null, requestId: '2' })
+    })
+    await waitFor(() => screen.getByText('LATEST'))
+  })
+
+  it('falls back to path-matching for a nonce-less reply from an older server', async () => {
+    render(<FileBrowserPanel />)
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root', parentPath: null,
+        entries: [{ name: 'a.ts', isDirectory: false, size: 10 }], error: null,
+      })
+    })
+    await waitFor(() => screen.getByText('a.ts'))
+    fireEvent.click(screen.getByText('a.ts')) // selectedFile = /root/a.ts
+    mockLastFileContentRequestId = '2'
+    // No requestId on the reply → nonce guard is skipped, path-match (#6497) applies.
+    act(() => {
+      fileContentCallback!({ path: '/root/other.ts', content: 'STALE', language: 'typescript', size: 5, truncated: false, error: null })
+    })
+    expect(screen.queryByText('STALE')).toBeNull()
+    act(() => {
+      fileContentCallback!({ path: '/root/a.ts', content: 'OK', language: 'typescript', size: 6, truncated: false, error: null })
+    })
+    await waitFor(() => screen.getByText('OK'))
   })
 })

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -305,10 +305,18 @@ export function FileBrowserPanel() {
 
   useEffect(() => {
     const handleContent = (content: FileContent) => {
-      // #6497 — drop a reply that belongs to a since-deselected file: closes the
-      // wrong-content flash and the jump-to-line scroll-target bleed under a rapid
-      // A→B open where A's reply lands after B was selected.
-      if (!contentReplyMatchesSelection(content.path, selectedFileRef.current)) return
+      // #6502 — nonce correlation is authoritative: drop any reply whose echoed
+      // requestId isn't the latest read_file we issued (a superseded request).
+      // This subsumes the #6497 case (a since-deselected file's reply carries an
+      // older nonce) without depending on echoed-path shape. The path-match
+      // (#6497) stays as the fallback for replies from an older server that
+      // doesn't echo a requestId at all.
+      if (content.requestId != null) {
+        const latest = useConnectionStore.getState().lastFileContentRequestId
+        if (latest != null && content.requestId !== latest) return
+      } else if (!contentReplyMatchesSelection(content.path, selectedFileRef.current)) {
+        return
+      }
       setFileContent(content.content)
       setFileLanguage(content.language)
       setFileSize(content.size)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -372,6 +372,11 @@ export const selectShowSession = (s: ConnectionState): boolean =>
 let searchNonce = 0;
 let searchTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
+// #6502 — monotonic read_file request nonce. The server echoes it back on the
+// `file_content` reply so the file browser can drop replies from superseded
+// requests (path-agnostic correlation), instead of tail-matching the path.
+let fileContentRequestNonce = 0;
+
 // #5281 ③ PR 2 — one-shot pairing id for the next socket open. When set, the
 // auth handshake sends `{type:'pair', pairingId}` instead of `{type:'auth',
 // token}`; it's cleared right after that first send so a later reconnect uses
@@ -669,6 +674,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   _directoryListingCallback: null,
   _fileBrowserCallback: null,
   _fileContentCallback: null,
+  lastFileContentRequestId: null,
   _gitStatusCallback: null,
   _diffCallback: null,
   conversationHistory: [],
@@ -3620,7 +3626,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   requestFileContent: (path: string) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'read_file', path });
+      // #6502 — stamp each request with a fresh nonce and record it as the
+      // latest in-flight read. The file_content handler drops any reply whose
+      // echoed requestId isn't this one (a superseded read).
+      const requestId = String(++fileContentRequestNonce);
+      set({ lastFileContentRequestId: requestId });
+      wsSend(socket, { type: 'read_file', path, requestId });
     }
   },
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -236,6 +236,9 @@ export interface FileContent {
   size: number | null;
   truncated: boolean;
   error: string | null;
+  // #6502 — the request nonce echoed from the originating `read_file`, used to
+  // drop replies from superseded requests. Null when the server didn't echo one.
+  requestId: string | null;
 }
 
 // #3181: GitStatusEntry was structurally identical to @chroxy/store-core's
@@ -1241,6 +1244,9 @@ export interface ConnectionState {
   // File browser callbacks
   _fileBrowserCallback: ((listing: FileListing) => void) | null;
   _fileContentCallback: ((content: FileContent) => void) | null;
+  // #6502 — nonce of the most recent read_file request. A file_content reply
+  // whose echoed requestId differs is from a superseded request and is dropped.
+  lastFileContentRequestId: string | null;
 
   // Git status callback
   _gitStatusCallback: ((result: GitStatusResult) => void) | null;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -452,6 +452,7 @@ export declare const BrowseFilesSchema: z.ZodObject<{
 export declare const ReadFileSchema: z.ZodObject<{
     type: z.ZodLiteral<"read_file">;
     path: z.ZodString;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 export declare const WriteFileSchema: z.ZodObject<{
     type: z.ZodLiteral<"write_file">;
@@ -1028,6 +1029,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"read_file">;
     path: z.ZodString;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"write_file">;
     path: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -588,6 +588,10 @@ export const BrowseFilesSchema = z.object({
 export const ReadFileSchema = z.object({
     type: z.literal('read_file'),
     path: z.string().max(4096),
+    // #6502 — optional monotonic request nonce. The server echoes it back on the
+    // `file_content` reply so the dashboard can correlate replies to the latest
+    // in-flight request (path-agnostic), instead of relying on path tail-matching.
+    requestId: z.string().max(200).optional(),
 }).passthrough();
 export const WriteFileSchema = z.object({
     type: z.literal('write_file'),

--- a/packages/protocol/dist/schemas/server/file-ops.d.ts
+++ b/packages/protocol/dist/schemas/server/file-ops.d.ts
@@ -82,6 +82,7 @@ export declare const ServerFileContentSchema: z.ZodObject<{
     size: z.ZodNullable<z.ZodNumber>;
     truncated: z.ZodBoolean;
     error: z.ZodNullable<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ServerDirectoryListingSchema: z.ZodObject<{
     type: z.ZodLiteral<"directory_listing">;

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -59,9 +59,11 @@ export const ServerDiffResultSchema = z.object({
     })),
     error: z.string().nullable(),
 });
-// `read_file` response. All 7 keys are always present (present-and-nullable, not
-// optional). For images, `content` is a base64 data URL and `language` is the
-// literal 'image'; `content` is sliced to 100KB with `truncated` true past that.
+// `read_file` response. The 7 core keys are always present (present-and-nullable,
+// not optional); `requestId` (#6502) is the one optional field — echoed back only
+// when the originating `read_file` carried a nonce, so the dashboard can drop a
+// superseded reply. For images, `content` is a base64 data URL and `language` is
+// the literal 'image'; `content` is sliced to 100KB with `truncated` true past that.
 export const ServerFileContentSchema = z.object({
     type: z.literal('file_content'),
     path: z.string().nullable(),

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -70,6 +70,10 @@ export const ServerFileContentSchema = z.object({
     size: z.number().nullable(),
     truncated: z.boolean(),
     error: z.string().nullable(),
+    // #6502 — echoes the `read_file` request nonce when the client supplied one,
+    // so the dashboard can drop replies from superseded requests without relying
+    // on echoed-path matching. Absent when the request carried no nonce.
+    requestId: z.string().max(200).optional(),
 });
 // `browse_files` response (HOME-dir restricted). `entries` are directories only
 // ({ name, isDirectory: true }); `parentPath` is legitimately null at the root

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -660,6 +660,10 @@ export const BrowseFilesSchema = z.object({
 export const ReadFileSchema = z.object({
   type: z.literal('read_file'),
   path: z.string().max(4096),
+  // #6502 — optional monotonic request nonce. The server echoes it back on the
+  // `file_content` reply so the dashboard can correlate replies to the latest
+  // in-flight request (path-agnostic), instead of relying on path tail-matching.
+  requestId: z.string().max(200).optional(),
 }).passthrough()
 
 export const WriteFileSchema = z.object({

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -64,9 +64,11 @@ export const ServerDiffResultSchema = z.object({
   error: z.string().nullable(),
 })
 
-// `read_file` response. All 7 keys are always present (present-and-nullable, not
-// optional). For images, `content` is a base64 data URL and `language` is the
-// literal 'image'; `content` is sliced to 100KB with `truncated` true past that.
+// `read_file` response. The 7 core keys are always present (present-and-nullable,
+// not optional); `requestId` (#6502) is the one optional field — echoed back only
+// when the originating `read_file` carried a nonce, so the dashboard can drop a
+// superseded reply. For images, `content` is a base64 data URL and `language` is
+// the literal 'image'; `content` is sliced to 100KB with `truncated` true past that.
 export const ServerFileContentSchema = z.object({
   type: z.literal('file_content'),
   path: z.string().nullable(),

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -75,6 +75,10 @@ export const ServerFileContentSchema = z.object({
   size: z.number().nullable(),
   truncated: z.boolean(),
   error: z.string().nullable(),
+  // #6502 — echoes the `read_file` request nonce when the client supplied one,
+  // so the dashboard can drop replies from superseded requests without relying
+  // on echoed-path matching. Absent when the request carried no nonce.
+  requestId: z.string().max(200).optional(),
 })
 
 // `browse_files` response (HOME-dir restricted). `entries` are directories only

--- a/packages/server/src/handlers/file-handlers.js
+++ b/packages/server/src/handlers/file-handlers.js
@@ -24,7 +24,9 @@ function handleListFiles(ws, client, msg, ctx) {
 
 function handleReadFile(ws, client, msg, ctx) {
   const entry = resolveSession(ctx, msg, client)
-  ctx.services.fileOps.readFile(ws, msg.path, entry?.cwd || null)
+  // #6502 — forward the optional request nonce so the file_content reply echoes
+  // it, letting the dashboard drop superseded replies without path-matching.
+  ctx.services.fileOps.readFile(ws, msg.path, entry?.cwd || null, msg.requestId)
 }
 
 function handleWriteFile(ws, client, msg, ctx) {

--- a/packages/server/src/ws-file-ops/reader.js
+++ b/packages/server/src/ws-file-ops/reader.js
@@ -29,10 +29,21 @@ const IMAGE_MIME = {
  */
 export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd) {
 
-  /** Read file content at a given path within the session CWD */
-  async function readFileContent(ws, requestedPath, sessionCwd) {
+  /**
+   * Read file content at a given path within the session CWD.
+   *
+   * @param {string} [requestId] - #6502: optional request nonce echoed back on
+   *   every `file_content` reply so the dashboard can correlate replies to the
+   *   latest in-flight request. Omitted from the payload when not provided.
+   */
+  async function readFileContent(ws, requestedPath, sessionCwd, requestId) {
+    // Attach the request nonce (when present) to every file_content reply so a
+    // superseded read can be dropped client-side without echoed-path matching.
+    const send = requestId === undefined
+      ? (payload) => sendFn(ws, payload)
+      : (payload) => sendFn(ws, { ...payload, requestId })
     if (!sessionCwd) {
-      sendFn(ws, {
+      send({
         type: 'file_content',
         path: null,
         content: null,
@@ -45,7 +56,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
     }
 
     if (!requestedPath || typeof requestedPath !== 'string' || !requestedPath.trim()) {
-      sendFn(ws, {
+      send({
         type: 'file_content',
         path: null,
         content: null,
@@ -76,7 +87,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
           const cwdReal = await resolveSessionCwd(sessionCwd)
           const lexicallyWithinCwd = absPath.startsWith(cwdReal + '/') || absPath === cwdReal
           if (!lexicallyWithinCwd) {
-            sendFn(ws, {
+            send({
               type: 'file_content',
               path: absPath,
               content: null,
@@ -87,7 +98,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
             })
             return
           }
-          sendFn(ws, {
+          send({
             type: 'file_content',
             path: absPath,
             content: null,
@@ -103,7 +114,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
 
       const { valid } = await validatePathWithinCwd(resolvedAbsPath, sessionCwd)
       if (!valid) {
-        sendFn(ws, {
+        send({
           type: 'file_content',
           path: absPath,
           content: null,
@@ -117,7 +128,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
 
       const fileStat = await stat(resolvedAbsPath)
       if (fileStat.isDirectory()) {
-        sendFn(ws, {
+        send({
           type: 'file_content',
           path: absPath,
           content: null,
@@ -130,7 +141,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       }
 
       if (fileStat.size > 512 * 1024) {
-        sendFn(ws, {
+        send({
           type: 'file_content',
           path: absPath,
           content: null,
@@ -154,7 +165,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
         } catch (openErr) {
           if (openErr.code === 'ELOOP') {
             // Symlink appeared at the canonical path after validation — reject
-            sendFn(ws, {
+            send({
               type: 'file_content',
               path: absPath,
               content: null,
@@ -176,7 +187,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       // SVG excluded — it's an active document format (scripts/external refs); render as text instead
       if (IMAGE_MIME[ext]) {
         const dataUrl = `data:${IMAGE_MIME[ext]};base64,${buf.toString('base64')}`
-        sendFn(ws, {
+        send({
           type: 'file_content',
           path: absPath,
           content: dataUrl,
@@ -192,7 +203,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       const checkLen = Math.min(buf.length, 8192)
       for (let i = 0; i < checkLen; i++) {
         if (buf[i] === 0) {
-          sendFn(ws, {
+          send({
             type: 'file_content',
             path: absPath,
             content: null,
@@ -212,7 +223,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
         truncated = true
       }
 
-      sendFn(ws, {
+      send({
         type: 'file_content',
         path: absPath,
         content,
@@ -227,7 +238,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       else if (err.code === 'EACCES') errorMessage = 'Permission denied'
       else errorMessage = err.message || 'Unknown error'
 
-      sendFn(ws, {
+      send({
         type: 'file_content',
         path: absPath || requestedPath || null,
         content: null,

--- a/packages/server/tests/ws-file-ops-error-paths.test.js
+++ b/packages/server/tests/ws-file-ops-error-paths.test.js
@@ -83,6 +83,34 @@ describe('ws-file-ops error paths', () => {
     assert.equal(sent[0].content, 'hello world')
   })
 
+  // #6502 — the request nonce is echoed on every file_content reply so the
+  // dashboard can drop replies from superseded requests.
+  it('readFile echoes the request nonce on a successful reply', async () => {
+    writeFileSync(join(tmp, 'hello.txt'), 'hello world')
+
+    await ops.readFile(ws, 'hello.txt', tmp, 'nonce-7')
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].type, 'file_content')
+    assert.equal(sent[0].requestId, 'nonce-7')
+  })
+
+  it('readFile echoes the request nonce on an error reply', async () => {
+    await ops.readFile(ws, 'does-not-exist.txt', tmp, 'nonce-err')
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].type, 'file_content')
+    assert.equal(sent[0].error, 'File not found')
+    assert.equal(sent[0].requestId, 'nonce-err')
+  })
+
+  it('readFile omits requestId when the request carried no nonce', async () => {
+    writeFileSync(join(tmp, 'hello.txt'), 'hello world')
+
+    await ops.readFile(ws, 'hello.txt', tmp)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].type, 'file_content')
+    assert.ok(!('requestId' in sent[0]), 'no requestId key when none supplied')
+  })
+
   it('readFile rejects a symlink pointing outside the workspace root', async () => {
     // Create a file outside the workspace
     const outsideDir = realpathSync(mkdtempSync(join(tmpdir(), 'fileops-outside-')))

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1104,7 +1104,7 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
         callbacks: [
           {
             name: 'fileContent',
-            payload: { path: '/f.ts', content: 'x', language: 'typescript', size: 1, truncated: true, error: null },
+            payload: { path: '/f.ts', content: 'x', language: 'typescript', size: 1, truncated: true, error: null, requestId: null },
           },
         ],
       },

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -1526,7 +1526,7 @@ describe('shared dispatch table', () => {
         truncated: true,
       })
       expect(seen).toEqual([
-        { path: '/f.ts', content: 'x', language: 'typescript', size: 1, truncated: true, error: null },
+        { path: '/f.ts', content: 'x', language: 'typescript', size: 1, truncated: true, error: null, requestId: null },
       ])
     })
 

--- a/packages/store-core/src/handlers/file.ts
+++ b/packages/store-core/src/handlers/file.ts
@@ -117,6 +117,12 @@ export interface FileContentPayload {
   truncated: boolean
   /** Error string from the server, if any. Null when missing/non-string. */
   error: string | null
+  /**
+   * #6502 — the request nonce the server echoed from the originating
+   * `read_file`. Lets a client drop a reply belonging to a superseded request
+   * (path-agnostic correlation). Null when missing/non-string (older servers).
+   */
+  requestId: string | null
 }
 
 /**
@@ -134,6 +140,7 @@ export function handleFileContent(msg: Record<string, unknown>): FileContentPayl
     size: typeof msg.size === 'number' ? msg.size : null,
     truncated: msg.truncated === true,
     error: parseRawStringField(msg, 'error'),
+    requestId: parseRawStringField(msg, 'requestId'),
   }
 }
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -3529,6 +3529,7 @@ describe('handleFileContent', () => {
       size: 9,
       truncated: false,
       error: null,
+      requestId: null,
     })
   })
 
@@ -3540,6 +3541,7 @@ describe('handleFileContent', () => {
       size: null,
       truncated: false,
       error: null,
+      requestId: null,
     })
   })
 
@@ -3558,6 +3560,7 @@ describe('handleFileContent', () => {
       size: null,
       truncated: false,
       error: null,
+      requestId: null,
     })
   })
 
@@ -3569,6 +3572,7 @@ describe('handleFileContent', () => {
       size: null,
       truncated: false,
       error: null,
+      requestId: null,
     })
   })
 
@@ -3596,12 +3600,23 @@ describe('handleFileContent', () => {
       size: null,
       truncated: false,
       error: 'too big',
+      requestId: null,
     })
   })
 
   it('preserves empty-string content verbatim', () => {
     // Empty string is still a string and passes through (matches inline guard).
     expect(handleFileContent({ content: '' }).content).toBe('')
+  })
+
+  it('#6502 — echoes the request nonce when present', () => {
+    expect(handleFileContent({ path: '/f.ts', content: 'x', requestId: '42' }).requestId).toBe('42')
+  })
+
+  it('#6502 — coerces a missing/non-string requestId to null', () => {
+    expect(handleFileContent({}).requestId).toBe(null)
+    expect(handleFileContent({ requestId: 7 }).requestId).toBe(null)
+    expect(handleFileContent({ requestId: null }).requestId).toBe(null)
   })
 
   it('preserves zero size verbatim', () => {


### PR DESCRIPTION
## Summary

Follow-up hardening from the review of #6501 (which closed #6497). Threads an optional monotonic **request nonce** through `read_file` → `file_content` so the dashboard drops replies from superseded requests by **exact correlation**, replacing reliance on the tolerant echoed-path tail-match.

The prior path-based guard (#6497) is correct for today's flows but carries two structural fragilities a nonce eliminates: relative-tail ambiguity (a relative selection tail-matches any absolute reply) and path-normalization coupling (silently drops correct replies if the server ever canonicalizes the echoed path). See #6502 for the full rationale.

## Changes

- **protocol** — optional `requestId` on `ReadFileSchema` + `ServerFileContentSchema`. Backward-compatible: absent on the wire when the client sends no nonce; older clients/servers ignore the field. Dist rebuilt + staged.
- **server** — `readFileContent` echoes the nonce on **every** `file_content` reply (success + all error paths) via a local `send` helper; `handleReadFile` forwards `msg.requestId`. Write/diff replies untouched.
- **store-core** — `handleFileContent` parses `requestId` into `FileContentPayload` (null when missing/non-string).
- **dashboard** — `requestFileContent` stamps a fresh monotonic nonce and records it as the latest in-flight read (`lastFileContentRequestId`). `FileBrowserPanel` treats the nonce as the **authoritative** correlation — dropping a superseded reply *even when its path matches* — and keeps the #6497 path-match as the fallback for nonce-less replies from older servers.

## Tests

- **server** (`ws-file-ops-error-paths`): nonce echoed on success + error replies; omitted when no nonce supplied.
- **store-core** (`handlers.test`, `dispatch-table.test`, `fixtures`): `requestId` parsed when present, coerced to null otherwise; fixtures updated.
- **dashboard** (`FileBrowserPanel.test`): a stale-nonce reply for the **same path** is dropped (the case path-matching alone would wrongly accept); latest-nonce reply renders; nonce-less reply falls back to path-match.

Local: protocol 347 · store-core 1921 · dashboard 4179 · server file-ops 126 — all green. Server custom lints pass; all typechecks clean; dashboard builds.

Non-visual robustness change (no UI surface change); covered by unit tests end-to-end across the wire path.

Closes #6502