### PR TITLE
fix(ide): single-flight in-flight find-in-project content greps (#6506)

### DIFF
--- a/packages/server/src/handlers/ide-handlers.js
+++ b/packages/server/src/handlers/ide-handlers.js
@@ -128,6 +128,15 @@ async function handleSearchContent(ws, client, msg, ctx) {
   // #6481 (epic #6469): fail closed when the IDE surface is not opted in.
   if (!isIdeFeatureEnabled(ctx.services?.config)) return
 
+  // #6506 — single-flight per connection: a newer search_content supersedes any
+  // in-flight walk. Stamp a monotonic token; the walk polls isCancelled() and
+  // aborts once the token moves, and we skip emitting a superseded reply — so the
+  // daemon runs at most one workspace walk per client at a time under fast typing.
+  // Stamped before the empty-query branch so clearing the box also cancels a walk.
+  const token = (client._ideSearchToken || 0) + 1
+  client._ideSearchToken = token
+  const superseded = () => client._ideSearchToken !== token
+
   const query = typeof msg.query === 'string' ? msg.query.trim() : ''
   const path = typeof msg.path === 'string' && msg.path ? msg.path : null
 
@@ -150,9 +159,13 @@ async function handleSearchContent(ws, client, msg, ctx) {
   }
 
   try {
-    const { results, truncated } = await searchContent(cwd, query, { path })
+    const { results, truncated } = await searchContent(cwd, query, { path, isCancelled: superseded })
+    // A newer search landed while this walk ran — it emits its own results; stay
+    // silent so a stale reply can't clobber the fresher one.
+    if (superseded()) return
     ctx.transport.send(ws, { type: 'code_search_results', query, results, truncated, error: null })
   } catch (err) {
+    if (superseded()) return
     log.debug(`search_content failed: ${err?.message}`)
     ctx.transport.send(ws, {
       type: 'code_search_results',

--- a/packages/server/src/ide/search.js
+++ b/packages/server/src/ide/search.js
@@ -61,7 +61,10 @@ const TEXT_BASENAMES = new Set([
  * @param {string} rootDir            Absolute workspace root (session cwd).
  * @param {(line: string) => number[]} matchLine  Per-line matcher → 1-indexed columns.
  * @param {object} [opts]  path, maxFiles(2000), maxResults(500), maxFileSize(512KB),
- *                         maxDepth(12), maxLineLength(1000).
+ *                         maxDepth(12), maxLineLength(1000), isCancelled.
+ * @param {() => boolean} [opts.isCancelled]  #6506 — polled at each walk boundary
+ *   (dir entry, per-dirent, file entry); when it returns true the walk aborts
+ *   promptly. Lets a caller supersede an in-flight walk (single-flight search).
  * @returns {Promise<{results: Array<{file:string,line:number,column:number,text:string}>, truncated: boolean}>}
  */
 async function collectMatches(rootDir, matchLine, opts = {}) {
@@ -72,6 +75,7 @@ async function collectMatches(rootDir, matchLine, opts = {}) {
     maxFileSize = 512 * 1024,
     maxDepth = 12,
     maxLineLength = 1000,
+    isCancelled = null,
   } = opts
 
   // Realpath-confine the root (symlink-safe base) — see the security note above.
@@ -106,6 +110,7 @@ async function collectMatches(rootDir, matchLine, opts = {}) {
 
   /** Grep one file into the accumulator, honouring the caps. */
   async function grepFile(absPath) {
+    if (isCancelled && isCancelled()) return
     if (filesRead >= maxFiles) { truncated = true; return }
     const base = absPath.split(sep).pop().toLowerCase()
     const ext = extname(base)
@@ -146,6 +151,7 @@ async function collectMatches(rootDir, matchLine, opts = {}) {
 
   /** Recursively walk a directory. */
   async function walk(dir, depth) {
+    if (isCancelled && isCancelled()) return
     if (depth > maxDepth || filesRead >= maxFiles || results.length >= maxResults) {
       if (filesRead >= maxFiles || results.length >= maxResults) truncated = true
       return
@@ -156,6 +162,7 @@ async function collectMatches(rootDir, matchLine, opts = {}) {
     } catch { return }
     dirents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
     for (const ent of dirents) {
+      if (isCancelled && isCancelled()) break
       if (filesRead >= maxFiles || results.length >= maxResults) { truncated = true; break }
       const abs = join(dir, ent.name)
       if (ent.isDirectory()) {

--- a/packages/server/tests/ide-handlers.test.js
+++ b/packages/server/tests/ide-handlers.test.js
@@ -220,6 +220,31 @@ describe('search_content handler — emission', () => {
   })
 })
 
+describe('search_content handler — single-flight (#6506)', () => {
+  let root
+  before(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-ide-search-sf-'))
+    // Several files so a full walk yields real matches across a few awaits.
+    for (let i = 0; i < 12; i++) writeFileSync(join(root, `f${i}.ts`), 'const findMe = 1\n')
+  })
+  after(() => rmSync(root, { recursive: true, force: true }))
+
+  it('supersedes an in-flight walk — two rapid searches emit only the latest', async () => {
+    const { ctx, sent } = makeCtx({ ideEnabled: true, cwd: root })
+    // A per-connection client whose _ideSearchToken the handler bumps per request.
+    const sfClient = { activeSessionId: 'sess-1' }
+    // Fire two WITHOUT awaiting the first: the second stamps a newer token
+    // synchronously before either walk's async body runs, so the first walk
+    // aborts via isCancelled and skips its emit.
+    const p1 = handleSearchContent({}, sfClient, { type: 'search_content', query: 'findMe' }, ctx)
+    const p2 = handleSearchContent({}, sfClient, { type: 'search_content', query: 'findMe' }, ctx)
+    await Promise.all([p1, p2])
+    const emitted = sent.filter((m) => m.type === 'code_search_results')
+    assert.equal(emitted.length, 1, 'only the latest search emits; the superseded one stays silent')
+    assert.ok(emitted[0].results.length > 0, 'the surviving search returns real matches')
+  })
+})
+
 describe('find_references handler — feature gate', () => {
   it('is a no-op (no send) when features.ide is off', async () => {
     const { ctx, sent } = makeCtx({ ideEnabled: false, cwd: '/tmp' })

--- a/packages/server/tests/ide-search.test.js
+++ b/packages/server/tests/ide-search.test.js
@@ -78,6 +78,27 @@ describe('searchContent — grep behaviour', () => {
     const { results } = await searchContent(root, 'target', { path: 'src' })
     assert.deepEqual(results.map((r) => r.file), ['src/b.ts'])
   })
+
+  // #6506 — the walk polls isCancelled() at each boundary so a caller can
+  // supersede an in-flight search (single-flight — the handler wires this up).
+  it('aborts the directory walk immediately when isCancelled() is true', async () => {
+    const { results, truncated } = await searchContent(root, 'target', { isCancelled: () => true })
+    assert.deepEqual(results, [])
+    assert.equal(truncated, false)
+  })
+
+  it('aborts a single-file grep when isCancelled() is true', async () => {
+    // path→a.js takes the tstat.isFile() branch (grepFile directly, not walk),
+    // so this proves the grepFile-entry poll independently of the walk poll.
+    const { results } = await searchContent(root, 'target', { path: 'a.js', isCancelled: () => true })
+    assert.deepEqual(results, [])
+  })
+
+  it('is a no-op change when isCancelled() never fires (no regression)', async () => {
+    const withGuard = await searchContent(root, 'target', { isCancelled: () => false })
+    const without = await searchContent(root, 'target')
+    assert.deepEqual(withGuard, without)
+  })
 })
 
 describe('searchContent — confinement (security)', () => {


### PR DESCRIPTION
## Summary

Follow-up hardening from the review of #6505 (Cmd+Shift+F find-in-project, #6474). Under fast typing on a large repo, a slow grep for a short needle (`ab`) could still be walking the tree when the next debounced `search_content` (`abcd`) arrived — so the daemon ran N overlapping full-tree walks for one search intent. The dashboard already drops stale *renders* (echoed-`query` guard), but the server never cancelled the superseded walk.

Each walk is cap-bounded (`maxFiles` 2000 / `maxResults` 500 / `maxDepth` 12) behind an authenticated, opted-in `features.ide` operator, so this is a mild amplification, not a DoS — hence a hardening follow-up.

## Changes (server-only, no protocol change)

- **`ide/search.js`** — `collectMatches` accepts an optional `isCancelled()` and polls it at each walk boundary (dir entry, per-dirent loop, file entry); when it returns true the walk aborts promptly. No-op when the opt is absent, so `searchContent`/`findReferences` behaviour is unchanged (they pass `opts` straight through).
- **`handlers/ide-handlers.js`** — `handleSearchContent` stamps a monotonic per-connection token (`client._ideSearchToken`) at entry, passes `isCancelled: () => superseded` into the walk, and skips emitting once a newer token has landed. Result: at most one active workspace walk per client at a time; an older walk aborts as soon as the next request lands. The `code_search_results` contract and the `ide-search.test.js` confinement suite are untouched.

## Tests

- **`ide-search.test.js`** — `isCancelled: () => true` aborts both the directory walk and a single-file grep (empty results); `isCancelled: () => false` is byte-identical to no-opt (no regression).
- **`ide-handlers.test.js`** — a deterministic single-flight test: two rapid `handleSearchContent` calls sharing one client emit **only the latest** result set (the superseded walk aborts and stays silent), and the survivor returns real matches.

Local: server IDE suite (search + handlers + symbols + feature-flag) 82 tests green; all 5 server custom lints pass.

## Acceptance (from #6506)
- [x] A rapid sequence of `search_content` requests from one client results in at most one active workspace walk at a time (older walks abort promptly).
- [x] No behavioural regression to the `code_search_results` contract or the `ide-search.test.js` confinement suite.

Closes #6506