### PR TITLE
fix(server): route byok-mcp-client spawn through prepareSpawn on Windows (#6504)

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { createLogger } from './logger.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
+import { prepareSpawn } from './utils/win-spawn.js'
 
 // #4453: exponential restart backoff. The first restart still fires at ~1s
 // after the death (no regression on the existing acceptance test); the
@@ -186,9 +187,16 @@ export class MCPClient extends EventEmitter {
     this._setState(MCP_STATES.STARTING)
     let child
     try {
-      child = spawn(this._config.command, this._config.args, {
+      // #6504 — route a user-configured .cmd/.bat MCP command through cmd.exe on
+      // Windows (Node 24 rejects spawning a .cmd shim directly with EINVAL, e.g.
+      // an npx-style shim). prepareSpawn is a no-op for .exe/POSIX, so non-Windows
+      // behaviour is unchanged; its cross-spawn escaping passes the user-supplied
+      // args verbatim through cmd.exe (round-tripped in win-spawn.test.js).
+      const spawnSpec = prepareSpawn(this._config.command, this._config.args)
+      child = spawn(spawnSpec.command, spawnSpec.args, {
         env: this._buildChildEnv(),
         stdio: ['pipe', 'pipe', 'pipe'],
+        ...spawnSpec.options,
       })
     } catch (err) {
       this._log.warn(`MCP server ${this.name}: spawn threw: ${err?.message || err}`)

--- a/packages/server/tests/windows-cmd-routing.test.js
+++ b/packages/server/tests/windows-cmd-routing.test.js
@@ -81,4 +81,15 @@ describe('Windows .cmd routing — call sites invoke prepareSpawn (#6484)', () =
     // checkBinary.
     assert.match(s, /prepareSpawn\(resolved, args\)[\s\S]*?execFileSync\(spawnSpec\.command, spawnSpec\.args/, 'checkBinary routed')
   })
+
+  // #6504 — the MCP server command comes from USER config (not resolve-binary), so
+  // a .cmd/.bat shim (common for npm-installed MCP servers on Windows) hits the same
+  // Node-24 EINVAL. Route it through prepareSpawn like the provider spawn sites.
+  it('byok-mcp-client routes the user-configured MCP command through prepareSpawn', () => {
+    const s = src('byok-mcp-client.js')
+    assert.match(s, /import \{ prepareSpawn \} from '\.\/utils\/win-spawn\.js'/, 'imports prepareSpawn')
+    assert.match(s, /prepareSpawn\(this\._config\.command, this\._config\.args\)/, 'routes the configured command/args')
+    assert.match(s, /spawn\(spawnSpec\.command, spawnSpec\.args/, 'spawns spawnSpec.command/.args')
+    assert.match(s, /\.\.\.spawnSpec\.options/, 'spreads spawnSpec.options')
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up from the review of #6503, which routed the provider-subprocess + doctor spawn sites through `prepareSpawn` for Windows `.cmd` shims (Node 24 `.cmd` EINVAL). One more spawn site had the **same** exposure but was out of scope:

`packages/server/src/byok-mcp-client.js` — `spawn(this._config.command, this._config.args, …)`.

Unlike the provider binaries (resolved via `resolve-binary.js`), this command comes from **user-configured MCP-server config**. If a user points an MCP server at a `.cmd`/`.bat` shim (common for npm-installed MCP servers on Windows, e.g. an `npx`-style `.cmd`), spawning it directly throws `EINVAL` on Node 24 — the exact failure `prepareSpawn` was built to fix.

## Changes

- **`byok-mcp-client.js`** — route the spawn through `prepareSpawn(this._config.command, this._config.args)` and spawn `spawnSpec.command`/`.args` with `...spawnSpec.options`, mirroring the idiom in `cli-session.js` / `jsonl-subprocess-session.js` / `doctor.js`. `prepareSpawn` is a no-op for `.exe`/POSIX, so non-Windows behaviour is unchanged. The args are user-supplied, but `prepareSpawn`'s cross-spawn escaping passes arbitrary args through cmd.exe verbatim (round-tripped against adversarial input in `win-spawn.test.js`).
- **`windows-cmd-routing.test.js`** — a source-guard for the byok call site, mirroring the existing jsonl/doctor guards. **No `child_process` mock** — per the #6503 lesson, `mock.module` of a global leaks across `node --test`'s concurrent files. The routing is proved by the source guard + `prepareSpawn`'s own transform tests; the existing `byok-mcp-client.test.js` (which spawns a real MCP stub) proves the POSIX wiring stays intact.

## Tests

`windows-cmd-routing` + `win-spawn` + `byok-mcp-client` suites — 46 tests green. All 5 server custom lints pass.

## Acceptance (from #6504)
- [x] `byok-mcp-client.js` routes a `.cmd`/`.bat`-configured MCP server through cmd.exe on Windows (source-guarded + prepareSpawn transform covered)
- [x] No change to POSIX / `.exe` behaviour (prepareSpawn no-op; existing byok spawn test green)
- [ ] Verified on a native Windows host with an npm-installed (`.cmd`) MCP server — **needs a Windows host; flagged for dogfood follow-up**

Closes #6504