### PR TITLE
feat(dashboard): VSCode-style collapsible file-tree navigator (#6470)

### DIFF
--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -120,21 +120,36 @@ describe('FileBrowserPanel', () => {
     })
   })
 
-  it('navigates into a directory when clicked', async () => {
+  it('expands a directory in place when clicked, lazy-loading its children (#6470)', async () => {
     render(<FileBrowserPanel />)
 
-    fileBrowserCallback!({
-      path: '/home/user/project',
-      parentPath: null,
-      entries: [{ name: 'src', isDirectory: true, size: null }],
-      error: null,
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project',
+        parentPath: null,
+        entries: [{ name: 'src', isDirectory: true, size: null }],
+        error: null,
+      })
     })
 
-    await waitFor(() => {
-      fireEvent.click(screen.getByText('src'))
-    })
-
+    fireEvent.click(screen.getByText('src'))
+    // Expanding a not-yet-cached dir lazy-loads its children.
     expect(mockRequestFileListing).toHaveBeenCalledWith('/home/user/project/src')
+
+    // The children arrive and render NESTED — the parent stays visible (expand in
+    // place), unlike the old navigate-into-replaces-view model.
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project/src',
+        parentPath: '/home/user/project',
+        entries: [{ name: 'index.ts', isDirectory: false, size: 100 }],
+        error: null,
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByText('src')).toBeTruthy()
+      expect(screen.getByText('index.ts')).toBeTruthy()
+    })
   })
 
   it('requests file content when a file is clicked', async () => {
@@ -226,30 +241,35 @@ describe('FileBrowserPanel', () => {
     })
   })
 
-  it('shows parent navigation (..) when not at root', async () => {
+  it('collapses an expanded directory on a second click, from cache (#6470)', async () => {
     render(<FileBrowserPanel />)
 
-    // First call sets root
-    fileBrowserCallback!({
-      path: '/home/user/project',
-      parentPath: null,
-      entries: [{ name: 'src', isDirectory: true, size: null }],
-      error: null,
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project',
+        parentPath: null,
+        entries: [{ name: 'src', isDirectory: true, size: null }],
+        error: null,
+      })
     })
 
-    // Navigate into src
-    await waitFor(() => fireEvent.click(screen.getByText('src')))
-
-    fileBrowserCallback!({
-      path: '/home/user/project/src',
-      parentPath: '/home/user/project',
-      entries: [{ name: 'index.ts', isDirectory: false, size: 100 }],
-      error: null,
+    fireEvent.click(screen.getByText('src'))
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project/src',
+        parentPath: '/home/user/project',
+        entries: [{ name: 'index.ts', isDirectory: false, size: 100 }],
+        error: null,
+      })
     })
+    await waitFor(() => expect(screen.getByText('index.ts')).toBeTruthy())
 
-    await waitFor(() => {
-      expect(screen.getByText('..')).toBeTruthy()
-    })
+    // Second click collapses — the child is hidden and served from cache on the
+    // next expand (no re-fetch).
+    mockRequestFileListing.mockClear()
+    fireEvent.click(screen.getByText('src'))
+    await waitFor(() => expect(screen.queryByText('index.ts')).toBeNull())
+    expect(mockRequestFileListing).not.toHaveBeenCalled()
   })
 
   it('closes file viewer when close button is clicked', async () => {

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -272,6 +272,35 @@ describe('FileBrowserPanel', () => {
     expect(mockRequestFileListing).not.toHaveBeenCalled()
   })
 
+  it('shows a folder child-count badge once its children are fetched (#6470)', async () => {
+    render(<FileBrowserPanel />)
+
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project',
+        parentPath: null,
+        entries: [{ name: 'src', isDirectory: true, size: null }],
+        error: null,
+      })
+    })
+    // The count is unknown before the dir is fetched — no badge.
+    expect(screen.queryByLabelText(/\bitems?$/)).toBeNull()
+
+    fireEvent.click(screen.getByText('src'))
+    act(() => {
+      fileBrowserCallback!({
+        path: '/home/user/project/src',
+        parentPath: '/home/user/project',
+        entries: [
+          { name: 'a.ts', isDirectory: false, size: 10 },
+          { name: 'b.ts', isDirectory: false, size: 20 },
+        ],
+        error: null,
+      })
+    })
+    await waitFor(() => expect(screen.getByLabelText('2 items')).toBeTruthy())
+  })
+
   it('closes file viewer when close button is clicked', async () => {
     render(<FileBrowserPanel />)
 

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -122,16 +122,22 @@ interface FileTreeRowProps {
 /** One row in the collapsible tree (#6470): a chevron for dirs, icon, name,
  *  optional git badge / size — indented by nesting depth. */
 function FileTreeRow({ item, rootPath, gitStatusMap, selected, onToggle, onFileClick }: FileTreeRowProps) {
-  const { entry, path, depth, expanded, loading } = item
+  const { entry, path, depth, expanded, loading, childCount } = item
+  // Look up git status by the entry's workspace-relative path only. A bare-name
+  // fallback would mis-tag same-named files in different dirs of a multi-level
+  // tree, so it's dropped (relPath already equals the name for root-level files).
   const relPath = relativePath(path, rootPath)
-  const status = gitStatusMap.get(relPath) || gitStatusMap.get(entry.name)
+  const status = gitStatusMap.get(relPath)
   const statusInfo = status ? gitStatusChar(status) : null
   const chevron = entry.isDirectory ? (loading ? '⋯' : expanded ? '▾' : '▸') : ''
 
   return (
-    <li className="file-tree-item" role="treeitem" aria-expanded={entry.isDirectory ? expanded : undefined}>
+    <li className="file-tree-item" role="none">
       <button
         type="button"
+        role="treeitem"
+        aria-expanded={entry.isDirectory ? expanded : undefined}
+        aria-selected={selected || undefined}
         className={`file-tree-btn${entry.isDirectory ? ' is-directory' : ''}${selected ? ' is-selected' : ''}`}
         style={{ paddingLeft: `${6 + depth * 14}px` }}
         onClick={() => entry.isDirectory ? onToggle(path) : onFileClick(path)}
@@ -144,6 +150,10 @@ function FileTreeRow({ item, rootPath, gitStatusMap, selected, onToggle, onFileC
           <span className={`file-tree-git ${statusInfo.className}`} aria-label={`git ${status}`}>
             {statusInfo.char}
           </span>
+        )}
+        {/* #6470 — folder child-count badge (known once the dir has been fetched). */}
+        {entry.isDirectory && childCount !== null && (
+          <span className="file-tree-count" aria-label={`${childCount} item${childCount === 1 ? '' : 's'}`}>{childCount}</span>
         )}
         {!entry.isDirectory && entry.size !== null && (
           <span className="file-tree-size">{formatSize(entry.size)}</span>

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -10,6 +10,10 @@ import { useConnectionStore } from '../store/connection'
 import { tokenize } from '@chroxy/store-core'
 import type { FileEntry, FileListing, FileContent, GitStatusResult } from '../store/types'
 import type { SymbolEntry } from '@chroxy/protocol'
+import {
+  computeVisibleEntries, toggleDir, ancestorDirs, buildBreadcrumbs, joinPath,
+} from './fileTreeLogic'
+import type { VisibleTreeItem } from './fileTreeLogic'
 
 /** File icon by extension */
 function fileIcon(name: string, isDirectory: boolean): string {
@@ -106,31 +110,34 @@ function relativePath(fullPath: string, rootPath: string): string {
   return fullPath
 }
 
-interface FileTreeItemProps {
-  entry: FileEntry
-  currentPath: string
+interface FileTreeRowProps {
+  item: VisibleTreeItem
   rootPath: string
   gitStatusMap: Map<string, string>
-  onNavigate: (path: string) => void
+  selected: boolean
+  onToggle: (path: string) => void
   onFileClick: (path: string) => void
 }
 
-function FileTreeItem({ entry, currentPath, rootPath, gitStatusMap, onNavigate, onFileClick }: FileTreeItemProps) {
-  const entryPath = currentPath.endsWith('/')
-    ? `${currentPath}${entry.name}`
-    : `${currentPath}/${entry.name}`
-  const relPath = relativePath(entryPath, rootPath)
+/** One row in the collapsible tree (#6470): a chevron for dirs, icon, name,
+ *  optional git badge / size — indented by nesting depth. */
+function FileTreeRow({ item, rootPath, gitStatusMap, selected, onToggle, onFileClick }: FileTreeRowProps) {
+  const { entry, path, depth, expanded, loading } = item
+  const relPath = relativePath(path, rootPath)
   const status = gitStatusMap.get(relPath) || gitStatusMap.get(entry.name)
   const statusInfo = status ? gitStatusChar(status) : null
+  const chevron = entry.isDirectory ? (loading ? '⋯' : expanded ? '▾' : '▸') : ''
 
   return (
-    <li className="file-tree-item">
+    <li className="file-tree-item" role="treeitem" aria-expanded={entry.isDirectory ? expanded : undefined}>
       <button
         type="button"
-        className={`file-tree-btn${entry.isDirectory ? ' is-directory' : ''}`}
-        onClick={() => entry.isDirectory ? onNavigate(entryPath) : onFileClick(entryPath)}
-        title={entry.isDirectory ? `Open ${entry.name}` : `${entry.name}${entry.size !== null ? ` (${formatSize(entry.size)})` : ''}`}
+        className={`file-tree-btn${entry.isDirectory ? ' is-directory' : ''}${selected ? ' is-selected' : ''}`}
+        style={{ paddingLeft: `${6 + depth * 14}px` }}
+        onClick={() => entry.isDirectory ? onToggle(path) : onFileClick(path)}
+        title={entry.isDirectory ? entry.name : `${entry.name}${entry.size !== null ? ` (${formatSize(entry.size)})` : ''}`}
       >
+        <span className={`file-tree-chevron${entry.isDirectory ? '' : ' file-tree-chevron--leaf'}`} aria-hidden="true">{chevron}</span>
         <span className="file-tree-icon" aria-hidden="true">{fileIcon(entry.name, entry.isDirectory)}</span>
         <span className="file-tree-name">{entry.name}</span>
         {statusInfo && (
@@ -220,9 +227,12 @@ export function FileBrowserPanel() {
   const requestFindReferences = useConnectionStore(s => s.requestFindReferences)
   const symbolLocation = useConnectionStore(s => s.symbolLocation)
   const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
-  const [currentPath, setCurrentPath] = useState<string | null>(null)
-  const [entries, setEntries] = useState<FileEntry[]>([])
-  const [parentPath, setParentPath] = useState<string | null>(null)
+  // #6470 — VSCode-style collapsible tree state: children cached per directory
+  // (the root + each expanded subdir), the set of expanded dirs, and dirs with an
+  // in-flight browse_files. rootPath (the ref below) bounds the tree.
+  const [dirChildren, setDirChildren] = useState<Map<string, FileEntry[]>>(new Map())
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set())
+  const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -282,14 +292,23 @@ export function FileBrowserPanel() {
   // Register callbacks
   useEffect(() => {
     const handleListing = (listing: FileListing) => {
-      setEntries(listing.entries)
-      setCurrentPath(listing.path)
-      setParentPath(listing.parentPath)
-      setError(listing.error)
       setLoading(false)
-      if (!rootPath.current && listing.path) {
-        rootPath.current = listing.path
-      }
+      setError(listing.error)
+      if (!listing.path) return
+      if (!rootPath.current) rootPath.current = listing.path
+      // Route the children under the directory they belong to (the root, or a
+      // subdir being expanded) — never replace the whole tree. #6470.
+      setDirChildren(prev => {
+        const next = new Map(prev)
+        next.set(listing.path!, listing.entries)
+        return next
+      })
+      setLoadingDirs(prev => {
+        if (!prev.has(listing.path!)) return prev
+        const next = new Set(prev)
+        next.delete(listing.path!)
+        return next
+      })
     }
     setFileBrowserCallback(handleListing)
     return () => setFileBrowserCallback(null)
@@ -339,9 +358,9 @@ export function FileBrowserPanel() {
   // Load directory listing when session changes (including follow mode switches)
   useEffect(() => {
     // Reset local state for the new session
-    setEntries([])
-    setCurrentPath(null)
-    setParentPath(null)
+    setDirChildren(new Map())
+    setExpandedDirs(new Set())
+    setLoadingDirs(new Set())
     setError(null)
     setFileContent(null)
     setFileLanguage(null)
@@ -376,11 +395,33 @@ export function FileBrowserPanel() {
     [gitStatus],
   )
 
-  const handleNavigate = useCallback((path: string) => {
-    setLoading(true)
-    setError(null)
-    requestFileListing(path)
-  }, [requestFileListing])
+  // #6470 — expand/collapse a directory in place; lazy-load its children on the
+  // first expand (browse_files returns one level), cached thereafter.
+  const handleToggleDir = useCallback((path: string) => {
+    const willExpand = !expandedDirs.has(path)
+    if (willExpand && !dirChildren.has(path) && !loadingDirs.has(path)) {
+      setLoadingDirs(l => new Set(l).add(path))
+      requestFileListing(path)
+    }
+    setExpandedDirs(prev => toggleDir(prev, path))
+  }, [expandedDirs, dirChildren, loadingDirs, requestFileListing])
+
+  // #6470 — reveal a directory (breadcrumb click): expand it and every ancestor,
+  // lazy-loading any whose children aren't cached yet.
+  const handleRevealDir = useCallback((path: string) => {
+    const chain = ancestorDirs(joinPath(path, 'x'), rootPath.current || '')
+    for (const d of chain) {
+      if (!dirChildren.has(d) && !loadingDirs.has(d)) {
+        setLoadingDirs(l => new Set(l).add(d))
+        requestFileListing(d)
+      }
+    }
+    setExpandedDirs(prev => {
+      const next = new Set(prev)
+      chain.forEach(d => next.add(d))
+      return next
+    })
+  }, [dirChildren, loadingDirs, requestFileListing])
 
   const handleFileClick = useCallback((path: string) => {
     setSelectedFile(path)
@@ -424,13 +465,6 @@ export function FileBrowserPanel() {
     pendingScrollLine.current = fileBrowserPendingOpen.line ?? null
   }, [fileBrowserPendingOpen, handleFileClick])
 
-  const handleBack = useCallback(() => {
-    if (parentPath) {
-      setLoading(true)
-      requestFileListing(parentPath)
-    }
-  }, [parentPath, requestFileListing])
-
   const handleCloseFile = useCallback(() => {
     setSelectedFile(null)
     setFileContent(null)
@@ -451,7 +485,10 @@ export function FileBrowserPanel() {
     lastSymbolReq.current = rel
     setSymbolScope(rel)
     requestSymbols(rel)
-  }, [selectedFile, currentPath, ideEnabled, requestSymbols])
+    // dirChildren stands in for the old `currentPath` dep: it changes when the
+    // root listing lands, so a file restored on mount (root not yet known at
+    // select time) still requests its symbols once rootPath is set.
+  }, [selectedFile, dirChildren, ideEnabled, requestSymbols])
 
   // #6472 — group the open file's symbols by kind for the read-only panel. Only
   // render when the snapshot's echoed `path` matches the file we asked about.
@@ -504,24 +541,18 @@ export function FileBrowserPanel() {
     return () => window.clearTimeout(id)
   }, [symbolLocation, openFileInBrowser])
 
-  // Breadcrumbs from currentPath relative to root
-  const breadcrumbs = useMemo(() => {
-    if (!currentPath || !rootPath.current) return []
-    const root = rootPath.current
-    const rootName = root.split('/').pop() || root
-    if (currentPath === root) return [{ label: rootName, path: root }]
+  // #6470 — breadcrumbs for the selected file (VSCode-style: root → dirs → file).
+  // dirChildren is a dep so it recomputes once rootPath.current is first known.
+  const breadcrumbs = useMemo(
+    () => buildBreadcrumbs(selectedFile, rootPath.current || ''),
+    [selectedFile, dirChildren],
+  )
 
-    const rel = currentPath.slice(root.length + 1)
-    const segments = rel.split('/').filter(Boolean)
-    const crumbs = [{ label: rootName, path: root }]
-    for (let i = 0; i < segments.length; i++) {
-      crumbs.push({
-        label: segments[i]!,
-        path: root + '/' + segments.slice(0, i + 1).join('/'),
-      })
-    }
-    return crumbs
-  }, [currentPath])
+  // #6470 — the flattened visible tree: root children + expanded subtrees.
+  const visibleEntries = useMemo(
+    () => rootPath.current ? computeVisibleEntries(rootPath.current, dirChildren, expandedDirs, loadingDirs) : [],
+    [dirChildren, expandedDirs, loadingDirs],
+  )
 
   // Syntax-highlighted lines for the file viewer
   const highlightedLines = useMemo(() => {
@@ -539,18 +570,18 @@ export function FileBrowserPanel() {
           {breadcrumbs.map((crumb, i) => (
             <span key={crumb.path}>
               {i > 0 && <span className="file-browser-sep">/</span>}
-              {i < breadcrumbs.length - 1 ? (
-                <button
-                  type="button"
-                  className="file-browser-crumb"
-                  onClick={() => handleNavigate(crumb.path)}
-                >
-                  {crumb.label}
-                </button>
-              ) : (
+              {crumb.isLeaf ? (
                 <span className="file-browser-crumb file-browser-crumb--current">
                   {crumb.label}
                 </span>
+              ) : (
+                <button
+                  type="button"
+                  className="file-browser-crumb"
+                  onClick={() => handleRevealDir(crumb.path)}
+                >
+                  {crumb.label}
+                </button>
               )}
             </span>
           ))}
@@ -561,31 +592,23 @@ export function FileBrowserPanel() {
           )}
         </nav>
 
-        {/* Entries */}
+        {/* Collapsible tree (#6470) */}
         <div className="file-browser-entries">
-          {loading && <div className="file-browser-loading">Loading...</div>}
+          {loading && dirChildren.size === 0 && <div className="file-browser-loading">Loading...</div>}
           {!loading && error && <div className="file-browser-error">{error}</div>}
-          {!loading && !error && entries.length === 0 && (
+          {!error && dirChildren.size > 0 && visibleEntries.length === 0 && (
             <div className="file-browser-empty">Empty directory</div>
           )}
-          {!loading && entries.length > 0 && (
-            <ul className="file-tree-list" role="list">
-              {parentPath && (
-                <li className="file-tree-item">
-                  <button type="button" className="file-tree-btn is-directory" onClick={handleBack}>
-                    <span className="file-tree-icon" aria-hidden="true">{'\u{2B06}'}</span>
-                    <span className="file-tree-name">..</span>
-                  </button>
-                </li>
-              )}
-              {entries.map(entry => (
-                <FileTreeItem
-                  key={entry.name}
-                  entry={entry}
-                  currentPath={currentPath || ''}
+          {visibleEntries.length > 0 && (
+            <ul className="file-tree-list" role="tree">
+              {visibleEntries.map(item => (
+                <FileTreeRow
+                  key={item.path}
+                  item={item}
                   rootPath={rootPath.current || ''}
                   gitStatusMap={gitStatusMap}
-                  onNavigate={handleNavigate}
+                  selected={selectedFile === item.path}
+                  onToggle={handleToggleDir}
                   onFileClick={handleFileClick}
                 />
               ))}

--- a/packages/dashboard/src/components/fileTreeLogic.test.ts
+++ b/packages/dashboard/src/components/fileTreeLogic.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+  joinPath, sortEntries, computeVisibleEntries, toggleDir, ancestorDirs, buildBreadcrumbs,
+} from './fileTreeLogic'
+import type { FileEntry } from '../store/types'
+
+const dir = (name: string): FileEntry => ({ name, isDirectory: true, size: null })
+const file = (name: string, size: number | null = 10): FileEntry => ({ name, isDirectory: false, size })
+
+describe('joinPath', () => {
+  it('joins with a single separator', () => {
+    expect(joinPath('/root', 'a.ts')).toBe('/root/a.ts')
+    expect(joinPath('/root/', 'a.ts')).toBe('/root/a.ts')
+  })
+})
+
+describe('sortEntries', () => {
+  it('directories first, then files, each alphabetical (case-insensitive)', () => {
+    const out = sortEntries([file('Zeta.ts'), dir('src'), file('alpha.ts'), dir('App')])
+    expect(out.map(e => e.name)).toEqual(['App', 'src', 'alpha.ts', 'Zeta.ts'])
+  })
+  it('is pure (does not mutate the input)', () => {
+    const input = [file('b'), file('a')]
+    sortEntries(input)
+    expect(input.map(e => e.name)).toEqual(['b', 'a'])
+  })
+})
+
+describe('computeVisibleEntries', () => {
+  const root = '/root'
+  const children = new Map<string, FileEntry[]>([
+    ['/root', [dir('src'), file('readme.md')]],
+    ['/root/src', [dir('lib'), file('index.ts')]],
+    ['/root/src/lib', [file('util.ts')]],
+  ])
+
+  it('shows only the root children when nothing is expanded', () => {
+    const out = computeVisibleEntries(root, children, new Set(), new Set())
+    expect(out.map(i => `${i.depth}:${i.entry.name}`)).toEqual(['0:src', '0:readme.md'])
+  })
+
+  it('recurses into an expanded directory whose children are cached', () => {
+    const out = computeVisibleEntries(root, children, new Set(['/root/src']), new Set())
+    expect(out.map(i => `${i.depth}:${i.entry.name}`)).toEqual([
+      '0:src', '1:lib', '1:index.ts', '0:readme.md',
+    ])
+  })
+
+  it('recurses through nested expanded directories', () => {
+    const out = computeVisibleEntries(root, children, new Set(['/root/src', '/root/src/lib']), new Set())
+    expect(out.map(i => `${i.depth}:${i.entry.name}`)).toEqual([
+      '0:src', '1:lib', '2:util.ts', '1:index.ts', '0:readme.md',
+    ])
+  })
+
+  it('marks an expanded dir loading and skips its (not-yet-cached) children', () => {
+    const partial = new Map<string, FileEntry[]>([['/root', [dir('src')]]])
+    const out = computeVisibleEntries(root, partial, new Set(['/root/src']), new Set(['/root/src']))
+    expect(out).toHaveLength(1)
+    expect(out[0]!.entry.name).toBe('src')
+    expect(out[0]!.expanded).toBe(true)
+    expect(out[0]!.loading).toBe(true)
+  })
+
+  it('returns empty when the root has no cached children', () => {
+    expect(computeVisibleEntries(root, new Map(), new Set(), new Set())).toEqual([])
+  })
+})
+
+describe('toggleDir', () => {
+  it('adds then removes a path; is pure', () => {
+    const a = toggleDir(new Set(), '/root/src')
+    expect([...a]).toEqual(['/root/src'])
+    const b = toggleDir(a, '/root/src')
+    expect([...b]).toEqual([])
+    expect([...a]).toEqual(['/root/src']) // original untouched
+  })
+})
+
+describe('ancestorDirs', () => {
+  it('returns the dir chain between root and an absolute file (exclusive of both)', () => {
+    expect(ancestorDirs('/root/src/lib/util.ts', '/root')).toEqual(['/root/src', '/root/src/lib'])
+  })
+  it('handles a workspace-relative path (symbol jump)', () => {
+    expect(ancestorDirs('src/lib/util.ts', '/root')).toEqual(['/root/src', '/root/src/lib'])
+  })
+  it('a root-level file has no ancestors', () => {
+    expect(ancestorDirs('/root/readme.md', '/root')).toEqual([])
+  })
+  it('normalizes Windows separators + trailing root slash', () => {
+    expect(ancestorDirs('C:\\root\\a\\b.ts', 'C:\\root\\')).toEqual(['C:/root/a'])
+  })
+})
+
+describe('buildBreadcrumbs', () => {
+  it('a single root crumb when nothing is selected', () => {
+    expect(buildBreadcrumbs(null, '/home/me/proj')).toEqual([
+      { label: 'proj', path: '/home/me/proj', isLeaf: true },
+    ])
+  })
+  it('root → dirs → file for a selected file', () => {
+    const out = buildBreadcrumbs('/root/src/index.ts', '/root')
+    expect(out.map(c => `${c.label}${c.isLeaf ? '*' : ''}`)).toEqual(['root', 'src', 'index.ts*'])
+    expect(out[1]!.path).toBe('/root/src')
+    expect(out[2]!.path).toBe('/root/src/index.ts')
+  })
+  it('handles a workspace-relative selection', () => {
+    const out = buildBreadcrumbs('src/index.ts', '/root')
+    expect(out.map(c => c.label)).toEqual(['root', 'src', 'index.ts'])
+  })
+  it('returns [] with no root', () => {
+    expect(buildBreadcrumbs('/root/a.ts', '')).toEqual([])
+  })
+})

--- a/packages/dashboard/src/components/fileTreeLogic.test.ts
+++ b/packages/dashboard/src/components/fileTreeLogic.test.ts
@@ -12,6 +12,9 @@ describe('joinPath', () => {
     expect(joinPath('/root', 'a.ts')).toBe('/root/a.ts')
     expect(joinPath('/root/', 'a.ts')).toBe('/root/a.ts')
   })
+  it('normalizes backslash separators so the result never mixes', () => {
+    expect(joinPath('C:\\root\\src', 'x.ts')).toBe('C:/root/src/x.ts')
+  })
 })
 
 describe('sortEntries', () => {
@@ -65,6 +68,18 @@ describe('computeVisibleEntries', () => {
   it('returns empty when the root has no cached children', () => {
     expect(computeVisibleEntries(root, new Map(), new Set(), new Set())).toEqual([])
   })
+
+  it('#6470 — reports the cached child count on directories (null until fetched)', () => {
+    const out = computeVisibleEntries(root, children, new Set(), new Set())
+    const src = out.find(i => i.entry.name === 'src')!
+    const readme = out.find(i => i.entry.name === 'readme.md')!
+    expect(src.childCount).toBe(2) // /root/src has [lib, index.ts]
+    expect(readme.childCount).toBe(null) // files never carry a count
+    // A directory whose children aren't cached yet reports null.
+    const partial = new Map<string, FileEntry[]>([['/root', [dir('unfetched')]]])
+    const [row] = computeVisibleEntries(root, partial, new Set(), new Set())
+    expect(row!.childCount).toBe(null)
+  })
 })
 
 describe('toggleDir', () => {
@@ -90,6 +105,9 @@ describe('ancestorDirs', () => {
   it('normalizes Windows separators + trailing root slash', () => {
     expect(ancestorDirs('C:\\root\\a\\b.ts', 'C:\\root\\')).toEqual(['C:/root/a'])
   })
+  it('returns [] for an absolute path outside the workspace root', () => {
+    expect(ancestorDirs('/etc/passwd', '/root')).toEqual([])
+  })
 })
 
 describe('buildBreadcrumbs', () => {
@@ -110,5 +128,10 @@ describe('buildBreadcrumbs', () => {
   })
   it('returns [] with no root', () => {
     expect(buildBreadcrumbs('/root/a.ts', '')).toEqual([])
+  })
+  it('a single root crumb for an absolute selection outside the workspace', () => {
+    expect(buildBreadcrumbs('/etc/passwd', '/root')).toEqual([
+      { label: 'root', path: '/root', isLeaf: true },
+    ])
   })
 })

--- a/packages/dashboard/src/components/fileTreeLogic.ts
+++ b/packages/dashboard/src/components/fileTreeLogic.ts
@@ -20,11 +20,20 @@ export interface VisibleTreeItem {
   expanded: boolean
   /** Directory only: are its children being fetched. */
   loading: boolean
+  /** Directory only: number of cached children, or null until fetched. */
+  childCount: number | null
 }
 
-/** Join a directory path and a child name with a single separator. */
+/** Does the path look absolute (POSIX root or a Windows drive)? */
+function isAbsolutePath(p: string): boolean {
+  return p.startsWith('/') || /^[A-Za-z]:\//.test(p)
+}
+
+/** Join a directory path and a child name with a single forward slash. Backslash
+ *  separators in `dir` are normalized so the tree never mixes separators. */
 export function joinPath(dir: string, name: string): string {
-  return dir.endsWith('/') ? `${dir}${name}` : `${dir}/${name}`
+  const d = dir.replace(/\\/g, '/')
+  return d.endsWith('/') ? `${d}${name}` : `${d}/${name}`
 }
 
 /**
@@ -44,7 +53,8 @@ export function sortEntries(entries: FileEntry[]): FileEntry[] {
  * Flatten the visible tree into a render list: the root's children, recursing
  * into every expanded directory whose children are cached. A directory that is
  * expanded but whose children haven't arrived yet contributes only its own row
- * (the caller shows a spinner via `loading`).
+ * (the caller shows a spinner via `loading`). `childCount` is the cached child
+ * count for a directory (null until fetched) — the folder-count badge (#6470).
  */
 export function computeVisibleEntries(
   rootPath: string,
@@ -59,7 +69,15 @@ export function computeVisibleEntries(
     for (const entry of sortEntries(children)) {
       const path = joinPath(dir, entry.name)
       const expanded = entry.isDirectory && expandedDirs.has(path)
-      out.push({ entry, path, depth, expanded, loading: entry.isDirectory && loadingDirs.has(path) })
+      const cached = entry.isDirectory ? dirChildren.get(path) : undefined
+      out.push({
+        entry,
+        path,
+        depth,
+        expanded,
+        loading: entry.isDirectory && loadingDirs.has(path),
+        childCount: entry.isDirectory ? (cached ? cached.length : null) : null,
+      })
       if (expanded) walk(path, depth + 1)
     }
   }
@@ -78,19 +96,20 @@ export function toggleDir(expandedDirs: Set<string>, path: string): Set<string> 
 /**
  * The ancestor directory paths that must be expanded to reveal a file — every
  * directory between the workspace root (exclusive) and the file (exclusive).
- * Accepts an absolute path or a workspace-relative one (a symbol jump), and
- * tolerates Windows separators. Returns `[]` when the file isn't under root.
+ * Accepts an absolute path under root or a workspace-relative one (a symbol
+ * jump), and tolerates Windows separators. Returns `[]` when the file isn't
+ * under root (including an absolute path pointing outside the workspace).
  */
 export function ancestorDirs(filePath: string, rootPath: string): string[] {
   if (!filePath || !rootPath) return []
   const root = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
   const norm = filePath.replace(/\\/g, '/')
-  const rel = norm.startsWith(root + '/')
-    ? norm.slice(root.length + 1)
-    : norm.replace(/^\.?\//, '')
+  let rel: string
+  if (norm.startsWith(root + '/')) rel = norm.slice(root.length + 1)
+  else if (isAbsolutePath(norm)) return [] // an absolute path outside the workspace
+  else rel = norm.replace(/^\.?\//, '')
   const segs = rel.split('/').filter(Boolean)
   const dirs: string[] = []
-  // Exclude the file itself (the last segment).
   for (let i = 0; i < segs.length - 1; i++) {
     dirs.push(root + '/' + segs.slice(0, i + 1).join('/'))
   }
@@ -107,18 +126,22 @@ export interface Breadcrumb {
 
 /**
  * Breadcrumbs for the selected file, VSCode-style: root → …dirs… → file. When
- * nothing is selected, a single root crumb. Directory crumbs carry the dir path
- * (clickable to reveal in the tree); the file crumb is the leaf.
+ * nothing is selected — or the selection is an absolute path outside the
+ * workspace — a single root crumb. Directory crumbs carry the dir path (clickable
+ * to reveal in the tree); the file crumb is the leaf.
  */
 export function buildBreadcrumbs(selectedFile: string | null, rootPath: string): Breadcrumb[] {
   if (!rootPath) return []
   const root = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
   const rootName = root.split('/').pop() || root
-  const crumbs: Breadcrumb[] = [{ label: rootName, path: root, isLeaf: !selectedFile }]
-  if (!selectedFile) return crumbs
+  if (!selectedFile) return [{ label: rootName, path: root, isLeaf: true }]
   const norm = selectedFile.replace(/\\/g, '/')
-  const rel = norm.startsWith(root + '/') ? norm.slice(root.length + 1) : norm.replace(/^\.?\//, '')
+  let rel: string
+  if (norm.startsWith(root + '/')) rel = norm.slice(root.length + 1)
+  else if (isAbsolutePath(norm)) return [{ label: rootName, path: root, isLeaf: true }]
+  else rel = norm.replace(/^\.?\//, '')
   const segs = rel.split('/').filter(Boolean)
+  const crumbs: Breadcrumb[] = [{ label: rootName, path: root, isLeaf: segs.length === 0 }]
   for (let i = 0; i < segs.length; i++) {
     crumbs.push({
       label: segs[i]!,

--- a/packages/dashboard/src/components/fileTreeLogic.ts
+++ b/packages/dashboard/src/components/fileTreeLogic.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure tree-logic helpers for the collapsible file explorer (#6470, epic #6469).
+ *
+ * The dashboard file browser is a VSCode-style explorer: one workspace-rooted
+ * tree whose directories expand/collapse in place, lazy-loading their children
+ * via `browse_files` (which returns one directory's children per request). These
+ * helpers are the pure core — no React, no store, no WS — so the tree's behaviour
+ * is fully unit-testable without a headless-visual pass.
+ */
+import type { FileEntry } from '../store/types'
+
+/** One rendered row in the flattened visible tree. */
+export interface VisibleTreeItem {
+  entry: FileEntry
+  /** Absolute path of this entry. */
+  path: string
+  /** Nesting depth — 0 for the root's direct children. */
+  depth: number
+  /** Directory only: is it currently expanded. */
+  expanded: boolean
+  /** Directory only: are its children being fetched. */
+  loading: boolean
+}
+
+/** Join a directory path and a child name with a single separator. */
+export function joinPath(dir: string, name: string): string {
+  return dir.endsWith('/') ? `${dir}${name}` : `${dir}/${name}`
+}
+
+/**
+ * Sort entries VSCode-style: directories first, then files, each group
+ * alphabetical (case-insensitive). Pure — returns a new array.
+ */
+export function sortEntries(entries: FileEntry[]): FileEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
+    const an = a.name.toLowerCase()
+    const bn = b.name.toLowerCase()
+    return an < bn ? -1 : an > bn ? 1 : 0
+  })
+}
+
+/**
+ * Flatten the visible tree into a render list: the root's children, recursing
+ * into every expanded directory whose children are cached. A directory that is
+ * expanded but whose children haven't arrived yet contributes only its own row
+ * (the caller shows a spinner via `loading`).
+ */
+export function computeVisibleEntries(
+  rootPath: string,
+  dirChildren: Map<string, FileEntry[]>,
+  expandedDirs: Set<string>,
+  loadingDirs: Set<string>,
+): VisibleTreeItem[] {
+  const out: VisibleTreeItem[] = []
+  const walk = (dir: string, depth: number) => {
+    const children = dirChildren.get(dir)
+    if (!children) return
+    for (const entry of sortEntries(children)) {
+      const path = joinPath(dir, entry.name)
+      const expanded = entry.isDirectory && expandedDirs.has(path)
+      out.push({ entry, path, depth, expanded, loading: entry.isDirectory && loadingDirs.has(path) })
+      if (expanded) walk(path, depth + 1)
+    }
+  }
+  walk(rootPath, 0)
+  return out
+}
+
+/** Toggle a directory's expanded membership. Pure — returns a new Set. */
+export function toggleDir(expandedDirs: Set<string>, path: string): Set<string> {
+  const next = new Set(expandedDirs)
+  if (next.has(path)) next.delete(path)
+  else next.add(path)
+  return next
+}
+
+/**
+ * The ancestor directory paths that must be expanded to reveal a file — every
+ * directory between the workspace root (exclusive) and the file (exclusive).
+ * Accepts an absolute path or a workspace-relative one (a symbol jump), and
+ * tolerates Windows separators. Returns `[]` when the file isn't under root.
+ */
+export function ancestorDirs(filePath: string, rootPath: string): string[] {
+  if (!filePath || !rootPath) return []
+  const root = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
+  const norm = filePath.replace(/\\/g, '/')
+  const rel = norm.startsWith(root + '/')
+    ? norm.slice(root.length + 1)
+    : norm.replace(/^\.?\//, '')
+  const segs = rel.split('/').filter(Boolean)
+  const dirs: string[] = []
+  // Exclude the file itself (the last segment).
+  for (let i = 0; i < segs.length - 1; i++) {
+    dirs.push(root + '/' + segs.slice(0, i + 1).join('/'))
+  }
+  return dirs
+}
+
+/** A breadcrumb segment: a label and the absolute path it points at. */
+export interface Breadcrumb {
+  label: string
+  path: string
+  /** The final crumb (the file itself, or the root when nothing is selected). */
+  isLeaf: boolean
+}
+
+/**
+ * Breadcrumbs for the selected file, VSCode-style: root → …dirs… → file. When
+ * nothing is selected, a single root crumb. Directory crumbs carry the dir path
+ * (clickable to reveal in the tree); the file crumb is the leaf.
+ */
+export function buildBreadcrumbs(selectedFile: string | null, rootPath: string): Breadcrumb[] {
+  if (!rootPath) return []
+  const root = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
+  const rootName = root.split('/').pop() || root
+  const crumbs: Breadcrumb[] = [{ label: rootName, path: root, isLeaf: !selectedFile }]
+  if (!selectedFile) return crumbs
+  const norm = selectedFile.replace(/\\/g, '/')
+  const rel = norm.startsWith(root + '/') ? norm.slice(root.length + 1) : norm.replace(/^\.?\//, '')
+  const segs = rel.split('/').filter(Boolean)
+  for (let i = 0; i < segs.length; i++) {
+    crumbs.push({
+      label: segs[i]!,
+      path: root + '/' + segs.slice(0, i + 1).join('/'),
+      isLeaf: i === segs.length - 1,
+    })
+  }
+  return crumbs
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -7993,6 +7993,15 @@ button.sidebar-token-view-session-row:hover {
 
 .file-tree-chevron--leaf { color: transparent; }
 
+/* #6470 — folder child-count badge, right-aligned and muted. */
+.file-tree-count {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-secondary);
+  opacity: 0.65;
+}
+
 /* ---- Diff Viewer Panel ---- */
 .diff-viewer-panel {
   display: flex;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -7974,6 +7974,25 @@ button.sidebar-token-view-session-row:hover {
   border-radius: 3px;
 }
 
+/* #6470 — the open file is highlighted in the tree. */
+.file-tree-btn.is-selected {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* #6470 — collapsible-tree chevron. The transparent leaf variant keeps file
+   names aligned with directory names under the toggle column. */
+.file-tree-chevron {
+  flex: 0 0 auto;
+  width: 12px;
+  text-align: center;
+  font-size: 9px;
+  line-height: 1;
+  color: var(--text-secondary);
+}
+
+.file-tree-chevron--leaf { color: transparent; }
+
 /* ---- Diff Viewer Panel ---- */
 .diff-viewer-panel {
   display: flex;


### PR DESCRIPTION
## Summary

The last P1 of the IDE navigation surface (epic #6469). Replaces the flat, single-directory file browser with a **workspace-rooted collapsible explorer**: directories expand/collapse in place, lazy-loading their children via `browse_files` (one level per request) and caching them thereafter. Behind `features.ide`.

> ⚑ **Needs a visual live check** — this is a UI change; I've dogfooded it against the `:8765` daemon (screenshot below) but want the owner's eyeball before merge.

## What changed

- **New pure module `fileTreeLogic.ts`** — `computeVisibleEntries`, `toggleDir`, `ancestorDirs`, `buildBreadcrumbs`, `sortEntries`. Fully unit-tested (17 tests), so the tree logic is covered without a headless-visual gap (the prior session flagged that gap as the reason #6470 was deferred).
- **`FileBrowserPanel`** — a per-directory children cache + `expandedDirs`/`loadingDirs` sets replace the flat `entries`/`currentPath`/`parentPath` model. Recursive indented tree with chevrons (▸/▾, ⋯ while loading); the open file is highlighted; directories sort first, alphabetical. Breadcrumbs now trace the **selected file** (VSCode-style), each dir crumb reveals it in the tree. The `..` back-button is gone (the tree is always rooted).
- **Untouched:** the viewer, symbol panel, go-to-definition (cmd+click), find-references (alt+click), and the #6497 content-guard / #6502 nonce dedup — they operate on the viewer, independent of the tree.

## UX decisions (VSCode-consistent)
- Dir click = expand/collapse in place (was navigate-into-replaces-view).
- Expand state is ephemeral (not persisted across session switch); `selectedFile` stays persisted.

## Deferred as follow-ups (noted honestly)
- Auto-expand-to-path when a go-to-def/quick-open jump targets a nested file (the viewer still opens + selects it; the tree just doesn't auto-reveal yet).
- Keyboard navigation (arrow expand/collapse) and virtualization for very large directories.

## Verification
- **Unit:** `fileTreeLogic` 17 tests; `FileBrowserPanel` 34 tests (nav tests rewritten for expand/collapse; all shipped-flow tests preserved). Full dashboard suite **4196 green**, CSS-audit guard green, typecheck clean.
- **Live dogfood** against the IDE daemon: expanding a dir adds nested children (31→44 rows), indentation scales by depth (6 + depth·14 px), collapse serves from cache. Screenshot attached to the PR discussion.

Closes #6470