### PR TITLE
refactor(dashboard): file-tree rootPath→state + ARIA depth (#6531, #6532)

### DIFF
--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -226,6 +226,57 @@ describe('FileBrowserPanel', () => {
     })
   })
 
+  it('renders git decorations even when git_status arrives before the listing (#6532)', async () => {
+    render(<FileBrowserPanel />)
+    // Git status lands FIRST — before rootPath is known.
+    act(() => {
+      gitStatusCallback!({
+        branch: 'main',
+        staged: [],
+        unstaged: [{ path: 'a.js', status: 'modified' }],
+        untracked: [],
+        error: null,
+      })
+    })
+    // Then the listing lands and sets rootPath — the git map must recompute so the
+    // badge appears (regression: with rootPath as a ref it did not).
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root',
+        parentPath: null,
+        entries: [{ name: 'a.js', isDirectory: false, size: 10 }],
+        error: null,
+      })
+    })
+    await waitFor(() => expect(screen.getByText('M')).toBeTruthy())
+  })
+
+  it('sets aria-level on tree items reflecting nesting depth (#6531)', async () => {
+    render(<FileBrowserPanel />)
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root',
+        parentPath: null,
+        entries: [{ name: 'src', isDirectory: true, size: null }],
+        error: null,
+      })
+    })
+    expect(screen.getByText('src').closest('[role="treeitem"]')?.getAttribute('aria-level')).toBe('1')
+
+    fireEvent.click(screen.getByText('src'))
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root/src',
+        parentPath: '/root',
+        entries: [{ name: 'index.ts', isDirectory: false, size: 10 }],
+        error: null,
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByText('index.ts').closest('[role="treeitem"]')?.getAttribute('aria-level')).toBe('2')
+    })
+  })
+
   it('shows error state', async () => {
     render(<FileBrowserPanel />)
 

--- a/packages/dashboard/src/components/FileBrowserPanel.test.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.test.tsx
@@ -251,6 +251,31 @@ describe('FileBrowserPanel', () => {
     await waitFor(() => expect(screen.getByText('M')).toBeTruthy())
   })
 
+  it('sets the tree root only from the root listing (parentPath null), not a stray subdir', async () => {
+    render(<FileBrowserPanel />)
+    // A subdir listing arrives first (hypothetical race) — must NOT become root.
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root/src',
+        parentPath: '/root',
+        entries: [{ name: 'stray.ts', isDirectory: false, size: 10 }],
+        error: null,
+      })
+    })
+    expect(screen.queryByText('stray.ts')).toBeNull() // root unknown → nothing renders
+
+    // The real root listing (parentPath null) lands and the tree renders.
+    act(() => {
+      fileBrowserCallback!({
+        path: '/root',
+        parentPath: null,
+        entries: [{ name: 'index.ts', isDirectory: false, size: 20 }],
+        error: null,
+      })
+    })
+    await waitFor(() => expect(screen.getByText('index.ts')).toBeTruthy())
+  })
+
   it('sets aria-level on tree items reflecting nesting depth (#6531)', async () => {
     render(<FileBrowserPanel />)
     act(() => {

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -136,6 +136,7 @@ function FileTreeRow({ item, rootPath, gitStatusMap, selected, onToggle, onFileC
       <button
         type="button"
         role="treeitem"
+        aria-level={depth + 1}
         aria-expanded={entry.isDirectory ? expanded : undefined}
         aria-selected={selected || undefined}
         className={`file-tree-btn${entry.isDirectory ? ' is-directory' : ''}${selected ? ' is-selected' : ''}`}
@@ -239,7 +240,7 @@ export function FileBrowserPanel() {
   const openFileInBrowser = useConnectionStore(s => s.openFileInBrowser)
   // #6470 — VSCode-style collapsible tree state: children cached per directory
   // (the root + each expanded subdir), the set of expanded dirs, and dirs with an
-  // in-flight browse_files. rootPath (the ref below) bounds the tree.
+  // in-flight browse_files. rootPath (state, below) bounds the tree.
   const [dirChildren, setDirChildren] = useState<Map<string, FileEntry[]>>(new Map())
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set())
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set())
@@ -282,7 +283,10 @@ export function FileBrowserPanel() {
   const [fileError, setFileError] = useState<string | null>(null)
 
   const [gitStatus, setGitStatus] = useState<GitStatusResult | null>(null)
-  const rootPath = useRef<string | null>(null)
+  // #6532 — rootPath is state (not a ref) so the memos/effects that read it list
+  // it as an explicit dep, and git decorations recompute regardless of whether
+  // the listing or the git_status reply lands first.
+  const [rootPath, setRootPath] = useState<string | null>(null)
   const viewerRef = useRef<HTMLDivElement>(null)
   // #6476 — a 1-indexed line to scroll to once the externally-opened file's
   // content has rendered (symbol-search "jump to definition").
@@ -305,7 +309,9 @@ export function FileBrowserPanel() {
       setLoading(false)
       setError(listing.error)
       if (!listing.path) return
-      if (!rootPath.current) rootPath.current = listing.path
+      // Functional update — this callback is registered once and can't close
+      // over the live rootPath state.
+      setRootPath(prev => prev || listing.path)
       // Route the children under the directory they belong to (the root, or a
       // subdir being expanded) — never replace the whole tree. #6470.
       setDirChildren(prev => {
@@ -380,7 +386,7 @@ export function FileBrowserPanel() {
     setGitStatus(null)
     setSymbolScope(null)
     lastSymbolReq.current = null
-    rootPath.current = null
+    setRootPath(null)
 
     // Restore selected file from session state
     const state = useConnectionStore.getState()
@@ -401,8 +407,8 @@ export function FileBrowserPanel() {
   }, [activeSessionId, requestFileListing, requestGitStatus, requestFileContent])
 
   const gitStatusMap = useMemo(
-    () => buildGitStatusMap(gitStatus, rootPath.current),
-    [gitStatus],
+    () => buildGitStatusMap(gitStatus, rootPath),
+    [gitStatus, rootPath],
   )
 
   // #6470 — expand/collapse a directory in place; lazy-load its children on the
@@ -419,7 +425,7 @@ export function FileBrowserPanel() {
   // #6470 — reveal a directory (breadcrumb click): expand it and every ancestor,
   // lazy-loading any whose children aren't cached yet.
   const handleRevealDir = useCallback((path: string) => {
-    const chain = ancestorDirs(joinPath(path, 'x'), rootPath.current || '')
+    const chain = ancestorDirs(joinPath(path, 'x'), rootPath || '')
     for (const d of chain) {
       if (!dirChildren.has(d) && !loadingDirs.has(d)) {
         setLoadingDirs(l => new Set(l).add(d))
@@ -431,7 +437,7 @@ export function FileBrowserPanel() {
       chain.forEach(d => next.add(d))
       return next
     })
-  }, [dirChildren, loadingDirs, requestFileListing])
+  }, [dirChildren, loadingDirs, requestFileListing, rootPath])
 
   const handleFileClick = useCallback((path: string) => {
     setSelectedFile(path)
@@ -457,13 +463,13 @@ export function FileBrowserPanel() {
     const text = (target.textContent || '').trim()
     if (!/^[A-Za-z_$][\w$]*$/.test(text)) return
     e.preventDefault()
-    const fromFile = selectedFile && rootPath.current
-      ? relativePath(selectedFile, rootPath.current)
+    const fromFile = selectedFile && rootPath
+      ? relativePath(selectedFile, rootPath)
       : undefined
     // cmd/ctrl wins if both modifiers are held (definition is the primary gesture).
     if (goToDef) requestResolveSymbol(text, fromFile)
     else requestFindReferences(text, fromFile)
-  }, [ideEnabled, selectedFile, requestResolveSymbol, requestFindReferences])
+  }, [ideEnabled, selectedFile, rootPath, requestResolveSymbol, requestFindReferences])
 
   // #6473 — open a file requested externally (Cmd+P quick-open); reuse the click
   // path so it persists the selection, loads content, and triggers the symbols
@@ -489,16 +495,15 @@ export function FileBrowserPanel() {
   // where root isn't known at select time — also gets its symbols. Opt-in: the
   // server fail-closes when features.ide is off, so we gate on ideEnabled.
   useEffect(() => {
-    if (!selectedFile || !ideEnabled || !rootPath.current) return
-    const rel = relativePath(selectedFile, rootPath.current)
+    if (!selectedFile || !ideEnabled || !rootPath) return
+    const rel = relativePath(selectedFile, rootPath)
     if (lastSymbolReq.current === rel) return
     lastSymbolReq.current = rel
     setSymbolScope(rel)
     requestSymbols(rel)
-    // dirChildren stands in for the old `currentPath` dep: it changes when the
-    // root listing lands, so a file restored on mount (root not yet known at
-    // select time) still requests its symbols once rootPath is set.
-  }, [selectedFile, dirChildren, ideEnabled, requestSymbols])
+    // rootPath is a dep so a file restored on mount (root not yet known at select
+    // time) still requests its symbols once the root listing lands.
+  }, [selectedFile, rootPath, ideEnabled, requestSymbols])
 
   // #6472 — group the open file's symbols by kind for the read-only panel. Only
   // render when the snapshot's echoed `path` matches the file we asked about.
@@ -552,16 +557,15 @@ export function FileBrowserPanel() {
   }, [symbolLocation, openFileInBrowser])
 
   // #6470 — breadcrumbs for the selected file (VSCode-style: root → dirs → file).
-  // dirChildren is a dep so it recomputes once rootPath.current is first known.
   const breadcrumbs = useMemo(
-    () => buildBreadcrumbs(selectedFile, rootPath.current || ''),
-    [selectedFile, dirChildren],
+    () => buildBreadcrumbs(selectedFile, rootPath || ''),
+    [selectedFile, rootPath],
   )
 
   // #6470 — the flattened visible tree: root children + expanded subtrees.
   const visibleEntries = useMemo(
-    () => rootPath.current ? computeVisibleEntries(rootPath.current, dirChildren, expandedDirs, loadingDirs) : [],
-    [dirChildren, expandedDirs, loadingDirs],
+    () => rootPath ? computeVisibleEntries(rootPath, dirChildren, expandedDirs, loadingDirs) : [],
+    [rootPath, dirChildren, expandedDirs, loadingDirs],
   )
 
   // Syntax-highlighted lines for the file viewer
@@ -615,7 +619,7 @@ export function FileBrowserPanel() {
                 <FileTreeRow
                   key={item.path}
                   item={item}
-                  rootPath={rootPath.current || ''}
+                  rootPath={rootPath || ''}
                   gitStatusMap={gitStatusMap}
                   selected={selectedFile === item.path}
                   onToggle={handleToggleDir}

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -309,9 +309,10 @@ export function FileBrowserPanel() {
       setLoading(false)
       setError(listing.error)
       if (!listing.path) return
-      // Functional update — this callback is registered once and can't close
-      // over the live rootPath state.
-      setRootPath(prev => prev || listing.path)
+      // Set the tree root only from the ROOT listing — the server marks it with
+      // parentPath null (the CWD caps navigation), so a subdir reply that somehow
+      // arrived first can't be mistaken for the root.
+      if (listing.parentPath === null) setRootPath(listing.path)
       // Route the children under the directory they belong to (the root, or a
       // subdir being expanded) — never replace the whole tree. #6470.
       setDirChildren(prev => {


### PR DESCRIPTION
## Summary

Two small follow-ups from the #6470 (PR #6530) review, folded together since both touch the file-tree component. **No visual change** — internal robustness + a11y.

## #6532 — `rootPath` ref → state
The workspace root was a ref (`rootPath.current`) read by the `visibleEntries`/`breadcrumbs`/`gitStatusMap` memos and the symbol/code-click effects, which listed `dirChildren` as a stand-in dep. Correct only because `handleListing` set the ref before `setDirChildren` — an implicit ordering coupling.

Now it's state, listed as an explicit dep everywhere it's read. This also fixes a **latent timing bug**: `gitStatusMap` (dep was `[gitStatus]`) reads the root, so if a `git_status` reply landed before the first listing, git decorations could be absent until the next status change. With `rootPath` as a dep, the map recomputes when the root lands.

## #6531 — ARIA depth
The tree is rendered flat with CSS indentation (all `treeitem`s are siblings). Added `aria-level` (= depth + 1) to each treeitem so screen readers convey nesting depth — the correct cue for a flattened tree, rather than nested `role="group"`.

## Tests
- Git decorations render when `git_status` arrives **before** the listing (proves #6532).
- `aria-level` reflects depth (root = 1, nested = 2).
- Full dashboard suite **4203 green**; typecheck clean; re-dogfooded live (expand/collapse intact, no regression from the extra re-renders).

Closes #6531
Closes #6532