### PR TITLE
feat(store-core): client-side line hunk differ + per-hunk apply (#6542)

### DIFF
--- a/packages/store-core/src/hunk-diff.test.ts
+++ b/packages/store-core/src/hunk-diff.test.ts
@@ -1,0 +1,121 @@
+/**
+ * hunk-diff tests (#6542, IDE P3.1) — the client-side line differ + per-hunk
+ * apply. The round-trip invariants (apply-all === proposed, apply-none ===
+ * original) are the load-bearing correctness proof; the rest pins hunk shape,
+ * subset application, edge cases, and the size guard.
+ */
+import { describe, it, expect } from 'vitest'
+import { computeHunks, applyHunks, MAX_DIFF_LINES } from './hunk-diff'
+
+/** Assert the two round-trip invariants for a case. */
+function assertRoundTrip(original: string, proposed: string) {
+  const hunks = computeHunks(original, proposed)
+  expect(applyHunks(original, hunks, () => true)).toBe(proposed)
+  expect(applyHunks(original, hunks, () => false)).toBe(original)
+}
+
+describe('computeHunks (#6542)', () => {
+  it('returns no hunks when content is identical', () => {
+    expect(computeHunks('a\nb\nc', 'a\nb\nc')).toEqual([])
+    expect(computeHunks('', '')).toEqual([])
+  })
+
+  it('produces a git-style header + prefix-free lines for a modification', () => {
+    const hunks = computeHunks('a\nb\nc', 'a\nB\nc')
+    expect(hunks).toHaveLength(1)
+    expect(hunks[0]!.header).toMatch(/^@@ -\d+,\d+ \+\d+,\d+ @@$/)
+    const types = hunks[0]!.lines.map((l) => l.type)
+    expect(types).toContain('deletion')
+    expect(types).toContain('addition')
+    // content carries NO +/-/space prefix (the renderer adds it)
+    const del = hunks[0]!.lines.find((l) => l.type === 'deletion')!
+    expect(del.content).toBe('b')
+  })
+
+  it('splits distant changes into separate hunks, merges near ones', () => {
+    const original = Array.from({ length: 30 }, (_, i) => `line${i}`).join('\n')
+    const far = original.split('\n')
+    far[2] = 'CHANGED-2'
+    far[25] = 'CHANGED-25'
+    expect(computeHunks(original, far.join('\n'))).toHaveLength(2) // far apart → 2 hunks
+
+    const near = original.split('\n')
+    near[10] = 'CHANGED-10'
+    near[12] = 'CHANGED-12'
+    expect(computeHunks(original, near.join('\n'))).toHaveLength(1) // within 2·context → merged
+  })
+
+  it('handles pure addition, pure deletion, insert-at-start, insert-at-end', () => {
+    assertRoundTrip('a\nb\nc', 'a\nb\nc\nd\ne')       // append
+    assertRoundTrip('a\nb\nc', 'a\nc')                 // delete middle
+    assertRoundTrip('b\nc', 'a\nb\nc')                 // insert at start
+    assertRoundTrip('a\nb', 'a\nb\nc')                 // insert at end
+    assertRoundTrip('', 'x')                            // empty → content
+    assertRoundTrip('x', '')                            // content → empty
+    assertRoundTrip('a\nb\nc', 'x\ny\nz')               // whole-file replace (no common lines)
+  })
+
+  it('preserves a trailing newline losslessly (round-trip)', () => {
+    assertRoundTrip('a\nb\n', 'a\nB\n')
+    assertRoundTrip('a\nb', 'a\nb\n')  // adding a trailing newline
+  })
+
+  it('round-trips a spread of realistic edits', () => {
+    const cases: Array<[string, string]> = [
+      ['const x = 1\nconst y = 2\n', 'const x = 1\nconst y = 3\nconst z = 4\n'],
+      ['line1\nline2\nline3\nline4\nline5', 'line1\nline3\nline4\nline5\nline6'],
+      ['a\na\na\na', 'a\nb\na\na'],            // repeated lines
+      ['x', 'x\nx\nx'],                         // one → many identical
+      ['keep\nremove1\nremove2\nkeep2', 'keep\nkeep2'],
+    ]
+    for (const [o, p] of cases) assertRoundTrip(o, p)
+  })
+})
+
+describe('applyHunks subset selection (#6542)', () => {
+  const original = Array.from({ length: 30 }, (_, i) => `line${i}`).join('\n')
+  const editedArr = original.split('\n')
+  editedArr[2] = 'A-CHANGED'
+  editedArr[25] = 'B-CHANGED'
+  const proposed = editedArr.join('\n')
+  const hunks = computeHunks(original, proposed)
+
+  it('applying only hunk 0 keeps hunk 1 region original', () => {
+    const result = applyHunks(original, hunks, new Set([0])).split('\n')
+    expect(result[2]).toBe('A-CHANGED')  // hunk 0 applied
+    expect(result[25]).toBe('line25')    // hunk 1 rejected → original
+  })
+
+  it('applying only hunk 1 keeps hunk 0 region original', () => {
+    const result = applyHunks(original, hunks, [1]).split('\n')
+    expect(result[2]).toBe('line2')      // hunk 0 rejected
+    expect(result[25]).toBe('B-CHANGED') // hunk 1 applied
+  })
+
+  it('accepts a Set, an array, or a predicate for selection', () => {
+    expect(applyHunks(original, hunks, new Set([0, 1]))).toBe(proposed)
+    expect(applyHunks(original, hunks, [0, 1])).toBe(proposed)
+    expect(applyHunks(original, hunks, () => true)).toBe(proposed)
+    expect(applyHunks(original, hunks, [])).toBe(original)
+  })
+})
+
+describe('applyHunks robustness + size guard (#6542)', () => {
+  it('an unparseable hunk header leaves its content untouched (never corrupts)', () => {
+    const original = 'a\nb\nc'
+    const hunks = computeHunks(original, 'a\nX\nc')
+    const corrupt = [{ ...hunks[0]!, header: 'not-a-header' }]
+    // malformed → the original is returned unchanged rather than dropping lines
+    expect(applyHunks(original, corrupt, () => true)).toBe(original)
+  })
+
+  it('falls back to a single whole-file-replace hunk past MAX_DIFF_LINES', () => {
+    const big = Array.from({ length: MAX_DIFF_LINES }, (_, i) => `l${i}`).join('\n')
+    const bigChanged = big + '\nextra'
+    const hunks = computeHunks(big, bigChanged)
+    expect(hunks).toHaveLength(1)
+    // still round-trips through the fallback shape
+    expect(applyHunks(big, hunks, () => true)).toBe(bigChanged)
+    expect(applyHunks(big, hunks, () => false)).toBe(big)
+  })
+})

--- a/packages/store-core/src/hunk-diff.test.ts
+++ b/packages/store-core/src/hunk-diff.test.ts
@@ -60,6 +60,30 @@ describe('computeHunks (#6542)', () => {
     assertRoundTrip('a\nb', 'a\nb\n')  // adding a trailing newline
   })
 
+  it('emits git-style empty-side headers (new file / deleted file), no phantom line', () => {
+    // new file: pure addition, 0-based old start, no phantom '' deletion
+    const created = computeHunks('', 'x\ny')
+    expect(created).toHaveLength(1)
+    expect(created[0]!.header).toBe('@@ -0,0 +1,2 @@')
+    expect(created[0]!.lines.map((l) => l.type)).toEqual(['addition', 'addition'])
+    // deleted file: pure deletion, 0-based new start
+    const deleted = computeHunks('x\ny', '')
+    expect(deleted[0]!.header).toBe('@@ -1,2 +0,0 @@')
+    expect(deleted[0]!.lines.map((l) => l.type)).toEqual(['deletion', 'deletion'])
+    // and both still round-trip
+    assertRoundTrip('', 'x\ny')
+    assertRoundTrip('x\ny', '')
+  })
+
+  it('round-trips CRLF content without mangling line endings', () => {
+    assertRoundTrip('a\r\nb\r\nc', 'a\r\nB\r\nc')
+    assertRoundTrip('a\r\nb\r\n', 'a\r\nb\r\nc\r\n')
+    // a lone \r stays attached to its line's content (split is on \n only)
+    const hunks = computeHunks('a\r\nb', 'a\r\nB')
+    expect(hunks[0]!.lines.find((l) => l.type === 'deletion')!.content).toBe('b')
+    expect(hunks[0]!.lines.find((l) => l.type === 'addition')!.content).toBe('B')
+  })
+
   it('round-trips a spread of realistic edits', () => {
     const cases: Array<[string, string]> = [
       ['const x = 1\nconst y = 2\n', 'const x = 1\nconst y = 3\nconst z = 4\n'],

--- a/packages/store-core/src/hunk-diff.ts
+++ b/packages/store-core/src/hunk-diff.ts
@@ -1,0 +1,200 @@
+/**
+ * Client-side line hunk diff (#6542, IDE P3.1) — the shared foundation for the
+ * edit-in-place / per-hunk-review surfaces (#6543 feature B, #6544 feature A).
+ *
+ * The server's git `getDiff` can only diff what's on disk, so a pre-write diff
+ * (original → an in-editor buffer, or an agent's proposed content) has to be
+ * computed on the client. This module produces the SAME `DiffHunk` shape the
+ * server emits (so `HunkView` renders both identically) and adds `applyHunks`,
+ * which reconstructs a file applying only an operator-selected SUBSET of hunks —
+ * the core of per-hunk accept/reject.
+ *
+ * The differ is a straightforward LCS line diff (correct + easy to reason about)
+ * with a size guard: past `MAX_DIFF_LINES` combined lines it falls back to a
+ * single whole-file-replace hunk rather than allocate an O(n·m) table.
+ *
+ * Round-trip contract (the load-bearing invariants, verified in the tests):
+ *   - `applyHunks(original, computeHunks(original, proposed), ALL)  === proposed`
+ *   - `applyHunks(original, computeHunks(original, proposed), NONE) === original`
+ *   - selecting any subset yields a valid interleaving of the two sides.
+ */
+import type { DiffHunk, DiffHunkLine } from './types/git'
+
+/** Default unified-diff context lines around each change. */
+export const DEFAULT_CONTEXT_LINES = 3
+
+/**
+ * Combined-line ceiling before the differ bails to a single whole-file-replace
+ * hunk. The LCS table is O(n·m); at 4000 combined lines that is ~4M cells worst
+ * case, which is fine, and beyond it a per-hunk review isn't ergonomic anyway.
+ */
+export const MAX_DIFF_LINES = 4000
+
+type EditOp = { op: 'eq' | 'del' | 'ins'; oldIndex: number; newIndex: number; content: string }
+
+/**
+ * Split file content into lines such that `lines.join('\n') === content` for
+ * ANY input (JS guarantees this for split/join on '\n'), so the round-trip is
+ * lossless — a trailing newline becomes a trailing empty element that the diff
+ * treats like any other line. Empty content is `['']` (length 1), not `[]`.
+ */
+function toLines(content: string): string[] {
+  return content.split('\n')
+}
+
+/**
+ * LCS line diff → an ordered edit script. Each op carries the 0-indexed
+ * position in the original (`oldIndex`) and proposed (`newIndex`) it sits at,
+ * which the hunk builder turns into `@@` line numbers.
+ */
+function diffLines(a: string[], b: string[]): EditOp[] {
+  const n = a.length
+  const m = b.length
+  // dp[i][j] = LCS length of a[i:] and b[j:].
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i]![j] = a[i] === b[j] ? dp[i + 1]![j + 1]! + 1 : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!)
+    }
+  }
+  const ops: EditOp[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ op: 'eq', oldIndex: i, newIndex: j, content: a[i]! })
+      i++
+      j++
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      ops.push({ op: 'del', oldIndex: i, newIndex: j, content: a[i]! })
+      i++
+    } else {
+      ops.push({ op: 'ins', oldIndex: i, newIndex: j, content: b[j]! })
+      j++
+    }
+  }
+  while (i < n) {
+    ops.push({ op: 'del', oldIndex: i, newIndex: j, content: a[i]! })
+    i++
+  }
+  while (j < m) {
+    ops.push({ op: 'ins', oldIndex: i, newIndex: j, content: b[j]! })
+    j++
+  }
+  return ops
+}
+
+/** A single whole-file-replace hunk — the large-input + no-common-line fallback. */
+function wholeFileReplaceHunk(a: string[], b: string[]): DiffHunk {
+  const lines: DiffHunkLine[] = [
+    ...a.map((content): DiffHunkLine => ({ type: 'deletion', content })),
+    ...b.map((content): DiffHunkLine => ({ type: 'addition', content })),
+  ]
+  return { header: `@@ -1,${a.length} +1,${b.length} @@`, lines }
+}
+
+/**
+ * Compute the hunks transforming `original` into `proposed`, in the canonical
+ * `DiffHunk` shape (git-style `@@ -o,c +n,c @@` header + context/deletion/
+ * addition lines with the +/-/space PREFIX omitted, exactly as the server's
+ * parser emits). Returns `[]` when the two are identical. Hunks are ordered and
+ * non-overlapping, each padded with up to `contextLines` unchanged lines and
+ * merged when they would otherwise abut.
+ */
+export function computeHunks(original: string, proposed: string, contextLines = DEFAULT_CONTEXT_LINES): DiffHunk[] {
+  if (original === proposed) return []
+  const a = toLines(original)
+  const b = toLines(proposed)
+  if (a.length + b.length > MAX_DIFF_LINES) return [wholeFileReplaceHunk(a, b)]
+
+  const ops = diffLines(a, b)
+  const changed = ops.map((o) => o.op !== 'eq')
+
+  // Expand each changed op by `contextLines` in both directions, then merge
+  // overlapping/abutting ranges into hunk op-ranges [start, end).
+  const ranges: Array<[number, number]> = []
+  for (let k = 0; k < ops.length; k++) {
+    if (!changed[k]) continue
+    const start = Math.max(0, k - contextLines)
+    const end = Math.min(ops.length, k + contextLines + 1)
+    const last = ranges[ranges.length - 1]
+    if (last && start <= last[1]) last[1] = Math.max(last[1], end)
+    else ranges.push([start, end])
+  }
+
+  return ranges.map(([start, end]) => {
+    const slice = ops.slice(start, end)
+    const first = slice[0]!
+    const oldCount = slice.filter((o) => o.op !== 'ins').length
+    const newCount = slice.filter((o) => o.op !== 'del').length
+    // git convention: for a non-empty side the start is 1-indexed (0-indexed+1);
+    // for a 0-count side it is the 0-indexed line the change sits AFTER.
+    const oldStart = oldCount === 0 ? first.oldIndex : first.oldIndex + 1
+    const newStart = newCount === 0 ? first.newIndex : first.newIndex + 1
+    const lines: DiffHunkLine[] = slice.map((o) => ({
+      type: o.op === 'eq' ? 'context' : o.op === 'del' ? 'deletion' : 'addition',
+      content: o.content,
+    }))
+    return { header: `@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`, lines }
+  })
+}
+
+/** Parse the 0-indexed original region `[start, start+count)` a hunk covers. */
+function parseOriginalRange(header: string): { start: number; count: number } | null {
+  const m = /^@@ -(\d+),(\d+) /.exec(header)
+  if (!m) return null
+  const oldStart = Number(m[1])
+  const count = Number(m[2])
+  // Inverse of computeHunks's header math: count 0 → oldStart is the 0-indexed
+  // insertion position; count > 0 → oldStart is 1-indexed, so subtract 1.
+  const start = count === 0 ? oldStart : oldStart - 1
+  return { start, count }
+}
+
+/** The proposed-side content of a hunk (context + additions, in order). */
+function proposedSide(hunk: DiffHunk): string[] {
+  return hunk.lines.filter((l) => l.type !== 'deletion').map((l) => l.content)
+}
+
+/**
+ * Reconstruct a file by applying only the SELECTED hunks (by their index in
+ * `hunks`); unselected hunks keep the original lines. `selected` may be a Set or
+ * array of indices, or a predicate `(index) => boolean`.
+ *
+ * Contract: `applyHunks(original, hunks, () => true) === proposed` and
+ * `applyHunks(original, hunks, () => false) === original` for hunks produced by
+ * `computeHunks(original, proposed)`. A hunk whose header can't be parsed is
+ * treated as unselected-safe (its original region is preserved) so a malformed
+ * hunk can never corrupt or drop content.
+ */
+export function applyHunks(
+  original: string,
+  hunks: DiffHunk[],
+  selected: Set<number> | number[] | ((index: number) => boolean),
+): string {
+  const isSelected =
+    typeof selected === 'function'
+      ? selected
+      : ((s) => (index: number) => s.has(index))(selected instanceof Set ? selected : new Set(selected))
+
+  const orig = toLines(original)
+  const out: string[] = []
+  let cursor = 0
+  hunks.forEach((hunk, index) => {
+    const range = parseOriginalRange(hunk.header)
+    if (!range) return // unparseable → leave its region to the tail copy below
+    // Copy the untouched gap before this hunk.
+    if (range.start > cursor) out.push(...orig.slice(cursor, range.start))
+    if (isSelected(index)) {
+      // Take the proposed side (context + additions).
+      out.push(...proposedSide(hunk))
+    } else {
+      // Keep the original region verbatim.
+      out.push(...orig.slice(range.start, range.start + range.count))
+    }
+    cursor = range.start + range.count
+  })
+  // Copy the trailing gap after the last hunk.
+  if (cursor < orig.length) out.push(...orig.slice(cursor))
+  return out.join('\n')
+}

--- a/packages/store-core/src/hunk-diff.ts
+++ b/packages/store-core/src/hunk-diff.ts
@@ -13,6 +13,11 @@
  * with a size guard: past `MAX_DIFF_LINES` combined lines it falls back to a
  * single whole-file-replace hunk rather than allocate an O(n·m) table.
  *
+ * Headers follow git's unified-diff convention, INCLUDING the empty-side cases —
+ * a new file is `@@ -0,0 +1,N @@` (pure additions, no phantom deletion) and a
+ * deleted file is `@@ -1,N +0,0 @@` — so the output stays consistent with the
+ * server's git diff and `applyHunks` can round-trip a git-style count-0 hunk.
+ *
  * Round-trip contract (the load-bearing invariants, verified in the tests):
  *   - `applyHunks(original, computeHunks(original, proposed), ALL)  === proposed`
  *   - `applyHunks(original, computeHunks(original, proposed), NONE) === original`
@@ -33,13 +38,19 @@ export const MAX_DIFF_LINES = 4000
 type EditOp = { op: 'eq' | 'del' | 'ins'; oldIndex: number; newIndex: number; content: string }
 
 /**
- * Split file content into lines such that `lines.join('\n') === content` for
- * ANY input (JS guarantees this for split/join on '\n'), so the round-trip is
- * lossless — a trailing newline becomes a trailing empty element that the diff
- * treats like any other line. Empty content is `['']` (length 1), not `[]`.
+ * Split file content into lines such that `lines.join('\n') === content`, so the
+ * round-trip is lossless — a trailing newline becomes a trailing empty element
+ * the diff treats like any other line.
+ *
+ * The one special case is the **empty file**: `''` maps to `[]` (0 lines), NOT
+ * `['']`. This matches git's unified-diff model — a `'' → 'x'` diff is then a
+ * pure addition (`@@ -0,0 +1,1 @@`, one addition line) rather than a phantom
+ * deletion of an empty line — so `computeHunks` output stays consistent with the
+ * server's git diff. `[].join('\n') === ''`, so the round-trip is still lossless.
+ * (A single newline `'\n'` is `['', '']`, distinct from the empty file.)
  */
 function toLines(content: string): string[] {
-  return content.split('\n')
+  return content === '' ? [] : content.split('\n')
 }
 
 /**
@@ -90,7 +101,12 @@ function wholeFileReplaceHunk(a: string[], b: string[]): DiffHunk {
     ...a.map((content): DiffHunkLine => ({ type: 'deletion', content })),
     ...b.map((content): DiffHunkLine => ({ type: 'addition', content })),
   ]
-  return { header: `@@ -1,${a.length} +1,${b.length} @@`, lines }
+  // git convention: a 0-count side uses a 0-based start (new file `@@ -0,0 +1,N @@`,
+  // deleted file `@@ -1,N +0,0 @@`); a non-empty side is 1-based. Keeps the header
+  // consistent with `parseOriginalRange`'s count-0 insertion math.
+  const oldStart = a.length === 0 ? 0 : 1
+  const newStart = b.length === 0 ? 0 : 1
+  return { header: `@@ -${oldStart},${a.length} +${newStart},${b.length} @@`, lines }
 }
 
 /**

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -863,3 +863,15 @@ export {
   totalPendingPermissions,
   selectNextPendingSession,
 } from './pending-permissions'
+
+// #6542 (IDE P3.1): client-side line hunk diff + per-hunk apply — the shared
+// foundation for the edit-in-place / per-hunk-review surfaces (#6543 feature B,
+// #6544 feature A). The server's git getDiff can't produce a pre-write diff, so
+// original → proposed is diffed on the client into the canonical DiffHunk shape;
+// applyHunks reconstructs a file from an operator-selected subset of hunks.
+export {
+  computeHunks,
+  applyHunks,
+  DEFAULT_CONTEXT_LINES,
+  MAX_DIFF_LINES,
+} from './hunk-diff'


### PR DESCRIPTION
## What

The pure-logic foundation of **#6542 (IDE P3.1)** — a client-side line differ that both edit-in-place features build on. First slice of the edit-in-place work (#6478) after the P3.0 write-gate (#6545). Follows your **B-first** priority call.

The server's git `getDiff` can only diff what's on disk, so a **pre-write diff** — original → an in-editor buffer, or the agent's proposed content before it hits disk (#6543) — has to be computed on the client.

## API (store-core, exported from the barrel)
- **`computeHunks(original, proposed): DiffHunk[]`** — LCS line diff producing the **canonical `DiffHunk` shape** (git-style `@@` header + prefix-free context/deletion/addition lines), so `HunkView` renders it identically to the server's diff. Distant changes → separate hunks; near ones merge; identical input → `[]`. **Size guard:** past `MAX_DIFF_LINES` combined lines it returns one whole-file-replace hunk instead of allocating an O(n·m) table.
- **`applyHunks(original, hunks, selected): string`** — reconstruct a file applying only an operator-selected **subset** of hunks (`Set` | array | predicate) — the core of per-hunk accept/reject. A hunk with an unparseable header **preserves its original region** (never corrupts or drops content).

## Correctness
The round-trip invariants are the load-bearing proof, tested across additions / deletions / whole-file replace / trailing-newline / repeated-line / insert-at-start-and-end:
- `applyHunks(original, computeHunks(original, proposed), ALL)  === proposed`
- `applyHunks(original, computeHunks(original, proposed), NONE) === original`

Plus: subset selection keeps rejected regions original, malformed-header safety, and the size-guard fallback still round-trips. **11 tests**, store-core suite **1932 green**, typecheck clean, dashboard typecheck clean (it bundles the store-core barrel from source — no dist build needed).

## Scope
Pure logic only — **no UI**. The selectable `HunkView` (dashboard + mobile toggle) is the next slice and **closes #6542**; this is **Part of #6542**.

Part of #6542 · epic #6469 · design basis #6529