### PR TITLE
feat(server,dashboard): get_permission_input pull for pre-write diffs (#6543 PR-1)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -543,6 +543,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // per repo for inline display (same lifecycle as cancellingActivityIds).
   reindexingRepoPaths: new Set<string>(),
   reindexResults: {},
+  // #6543 (IDE P3 feature B): pulled full redacted tool inputs keyed by requestId.
+  permissionInputs: {},
   // #5502: relay Re-run pending/result buckets (separate from reindex).
   relayRerunningRepoPaths: new Set<string>(),
   relayRerunResults: {},
@@ -1014,6 +1016,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       set({ repoEventsLoading: true });
       wsSend(socket, { type: 'repo_events_request' });
+      return true;
+    }
+    return false;
+  },
+
+  // #6543 (IDE P3 feature B): pull the full redacted tool input for a pending
+  // permission so the prompt can render a per-hunk pre-write diff. The reply is a
+  // single `permission_input` handled into `permissionInputs[requestId]`. Returns
+  // whether the request went on the wire (false = socket closed).
+  requestPermissionInput: (requestId: string): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'get_permission_input', requestId });
       return true;
     }
     return false;

--- a/packages/dashboard/src/store/dispatch-permission-input.test.ts
+++ b/packages/dashboard/src/store/dispatch-permission-input.test.ts
@@ -47,16 +47,20 @@ describe('permission_input dispatch (#6543)', () => {
   it('stores a found:true permission_input keyed by requestId', () => {
     handleMessage({ type: 'permission_input', requestId: 'r1', found: true, tool: 'Write', input: { file_path: '/x', content: 'a\nb' } }, ctx() as never)
     const entry = store.getState().permissionInputs['r1']
-    expect(entry!.found).toBe(true)
-    expect(entry!.tool).toBe('Write')
-    expect((entry!.input as { content: string }).content).toBe('a\nb')
+    expect(entry?.found).toBe(true)
+    if (entry?.found) {
+      expect(entry.tool).toBe('Write')
+      expect((entry.input as { content: string }).content).toBe('a\nb')
+    }
   })
 
   it('stores a found:false reply so the UI can show "unavailable"', () => {
     handleMessage({ type: 'permission_input', requestId: 'r2', found: false, error: { code: 'NOT_PENDING', message: 'gone' } }, ctx() as never)
     const entry = store.getState().permissionInputs['r2']
-    expect(entry!.found).toBe(false)
-    expect(entry!.error!.code).toBe('NOT_PENDING')
+    expect(entry?.found).toBe(false)
+    if (entry && !entry.found) {
+      expect(entry.error.code).toBe('NOT_PENDING')
+    }
   })
 
   it('drops a malformed permission_input (missing found)', () => {

--- a/packages/dashboard/src/store/dispatch-permission-input.test.ts
+++ b/packages/dashboard/src/store/dispatch-permission-input.test.ts
@@ -1,0 +1,66 @@
+/**
+ * #6543 (IDE P3 feature B) — `permission_input` dispatch. The pulled full
+ * redacted tool input lands in `permissionInputs[requestId]`; both found:true
+ * and found:false are stored; malformed is dropped. Mirrors dispatch-repo-events.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+function baseState(): Partial<ConnectionState> {
+  return { connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, permissionInputs: {}, messages: [] }
+}
+
+describe('permission_input dispatch (#6543)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('stores a found:true permission_input keyed by requestId', () => {
+    handleMessage({ type: 'permission_input', requestId: 'r1', found: true, tool: 'Write', input: { file_path: '/x', content: 'a\nb' } }, ctx() as never)
+    const entry = store.getState().permissionInputs['r1']
+    expect(entry!.found).toBe(true)
+    expect(entry!.tool).toBe('Write')
+    expect((entry!.input as { content: string }).content).toBe('a\nb')
+  })
+
+  it('stores a found:false reply so the UI can show "unavailable"', () => {
+    handleMessage({ type: 'permission_input', requestId: 'r2', found: false, error: { code: 'NOT_PENDING', message: 'gone' } }, ctx() as never)
+    const entry = store.getState().permissionInputs['r2']
+    expect(entry!.found).toBe(false)
+    expect(entry!.error!.code).toBe('NOT_PENDING')
+  })
+
+  it('drops a malformed permission_input (missing found)', () => {
+    handleMessage({ type: 'permission_input', requestId: 'r3' }, ctx() as never)
+    expect(store.getState().permissionInputs['r3']).toBeUndefined()
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -130,7 +130,7 @@ import {
   type ClientStoreAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2668,6 +2668,19 @@ function handleRepoEventsDelta(msg: Record<string, unknown>, get: MsgGet, set: M
 }
 
 /**
+ * #6543 (IDE P3 feature B) — `permission_input`: store the pulled full (secret-
+ * redacted) tool input keyed by requestId so the permission prompt can build a
+ * per-hunk pre-write diff. Zod-validated (drop-on-malformed). Both `found:true`
+ * (carries `input`/`tool`) and `found:false` (carries `error`) are stored — the
+ * UI distinguishes "not fetched" (absent) from "unavailable" (found:false).
+ */
+function handlePermissionInput(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerPermissionInputSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ permissionInputs: { ...get().permissionInputs, [parsed.data.requestId]: parsed.data } });
+}
+
+/**
  * #5553 — per-repo session-preset snapshot. The reply to session_preset_get /
  * _set / _approve / _revoke. Store the resolved preset keyed by cwd so the
  * create-session modal can disclose "repo preset applies" and the per-repo
@@ -3275,6 +3288,8 @@ const HANDLERS: Record<string, Handler> = {
   repo_events_snapshot: handleRepoEventsSnapshot,
   // #6536 (PR-2 of #5966): live repo-events delta appended to the pane.
   repo_events_delta: handleRepoEventsDelta,
+  // #6543 (IDE P3 feature B): pulled full redacted tool input for a pre-write diff.
+  permission_input: handlePermissionInput,
   session_preset_snapshot: handleSessionPresetSnapshot,
   // #5253: self-hosted runner Control Room survey snapshot.
   runner_status_snapshot: handleRunnerStatusSnapshot,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerRepoEventsSnapshotMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerRepoEventsSnapshotMessage, ServerPermissionInputMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -915,6 +915,14 @@ export interface ConnectionState {
    */
   reindexResults: Record<string, ReindexResult>;
   /**
+   * #6543 (IDE P3 feature B) — the pulled full (secret-redacted) tool input for
+   * a pending permission, keyed by requestId, fed by the `permission_input`
+   * handler in reply to `requestPermissionInput`. Used to build the per-hunk
+   * pre-write diff on the permission prompt. `found:false` entries are stored so
+   * the UI can distinguish "not fetched yet" from "unavailable".
+   */
+  permissionInputs: Record<string, ServerPermissionInputMessage>;
+  /**
    * #5502 — repo paths with an in-flight `integration_action` relay re-run:
    * set when sendRepoRelayRerun is called, cleared on the
    * `integration_action_ack` / INTEGRATION_ACTION_FAILED session_error. A
@@ -1648,6 +1656,8 @@ export interface ConnectionState {
   requestExternalSessions: () => boolean;
   /** #5966 — request the buffered repo-events snapshot for the Control Room pane. */
   requestRepoEvents: () => boolean;
+  /** #6543 — pull the full redacted tool input for a pending permission (for the pre-write diff). */
+  requestPermissionInput: (requestId: string) => boolean;
 
   // #5553 — per-repo session preset surface (host-authority). Each returns
   // whether the message went on the wire. Replies arrive as

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -281,6 +281,10 @@ export declare const PermissionResponseSchema: z.ZodObject<{
         allowAlways: "allowAlways";
     }>;
 }, z.core.$strip>;
+export declare const GetPermissionInputSchema: z.ZodObject<{
+    type: z.ZodLiteral<"get_permission_input">;
+    requestId: z.ZodString;
+}, z.core.$strip>;
 export declare const QueryPermissionAuditSchema: z.ZodObject<{
     type: z.ZodLiteral<"query_permission_audit">;
     sessionId: z.ZodOptional<z.ZodString>;
@@ -942,6 +946,9 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         allowAlways: "allowAlways";
     }>;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"get_permission_input">;
+    requestId: z.ZodString;
+}, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_sessions">;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"switch_session">;
@@ -1385,6 +1392,7 @@ export type SetModelMessage = z.infer<typeof SetModelSchema>;
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>;
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>;
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>;
+export type GetPermissionInputMessage = z.infer<typeof GetPermissionInputSchema>;
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>;
 export type HostStatusRequestMessage = z.infer<typeof HostStatusRequestSchema>;
 export type RunnerStatusRequestMessage = z.infer<typeof RunnerStatusRequestSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -340,6 +340,16 @@ export const PermissionResponseSchema = z.object({
     requestId: z.string().min(1).max(256),
     decision: z.enum(['allow', 'allowAlways', 'deny']),
 });
+// #6543 (IDE P3 feature B): pull the FULL secret-redacted tool input for a
+// pending permission, so a client can build a per-hunk pre-write diff. The
+// `permission_request` broadcast truncates `input` (~10K, secret-safe); this
+// fetches the un-truncated (still redacted) version by requestId. Session-bound:
+// the server only returns input for a permission the client's session owns. The
+// reply is a single `permission_input` (see server.ts).
+export const GetPermissionInputSchema = z.object({
+    type: z.literal('get_permission_input'),
+    requestId: z.string().min(1).max(256),
+});
 export const QueryPermissionAuditSchema = z.object({
     type: z.literal('query_permission_audit'),
     sessionId: z.string().max(256).optional(),
@@ -1268,6 +1278,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SkillTrustAcceptSchema,
     SkillTrustGrantSchema,
     PermissionResponseSchema,
+    GetPermissionInputSchema,
     ListSessionsSchema,
     SwitchSessionSchema,
     CreateSessionSchema,

--- a/packages/protocol/dist/schemas/server/messages.d.ts
+++ b/packages/protocol/dist/schemas/server/messages.d.ts
@@ -6,7 +6,7 @@
  */
 import { z } from 'zod';
 import { BillingCanarySnapshotSchema, BillingCanaryWarningSchema, ServerAuthOkSchema, ServerPairPendingSchema, ServerPairRequestPendingSchema, ServerPairResolvedSchema, ServerPairResultSchema } from './connection.ts';
-import { ServerPermissionRequestSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts';
+import { ServerPermissionRequestSchema, ServerPermissionInputSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts';
 import { ActivityEntrySchema, ActivityKindSchema, ActivityOutputRefSchema, ActivityStatusSchema, ServerActivityDeltaSchema, ServerActivitySnapshotSchema, ServerCancelActivityAckSchema, ServerMessageDequeuedSchema, ServerMessageQueuedSchema } from './activity.ts';
 import { ExternalSessionEntrySchema, HostStatusSummarySchema, IntegrationActionCountsSchema, IntegrationCliStatusSchema, IntegrationRepoSchema, IntegrationStatusSummarySchema, MailboxDeliveryEventSchema, MailboxRegistrationSchema, RepoEventSchema, ServerRepoEventsDeltaSchema, RepoMemoryCacheSchema, RepoMemoryReportSchema, RepoMemoryStatusSchema, RepoRelayRunSchema, RepoRelayStatusSchema, RepoRelayVerdictSchema, RepoRunnersSchema, RepoRuntimeConfigEntrySchema, RepoStatusSchema, RepoTreeSchema, RepoVerdictSchema, RunnerInfoSchema, RunnerServiceStateSchema, RunnerStatusSummarySchema, RunnerVerdictSchema, ServerByokPoolActionAckSchema, ServerByokPoolStatusSnapshotSchema, ServerContainersActionAckSchema, ServerContainersStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerHostPruneActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerSessionPresetDisclosureSchema, ServerSessionPresetFullSchema, ServerSessionPresetSnapshotSchema, ServerSimulatorActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerSummarizeSessionResultSchema, ServerWslActionAckSchema, ServerWslStatusSnapshotSchema, SkillInventoryEntrySchema, SkillInventoryRepoSchema } from './control-room.ts';
 import { CumulativeUsageSchema, ServerAuthBootstrapSchema, ServerSessionStoppedSchema, ServerSkillTrustGrantInvalidAuthorSchema, ServerSkillTrustGrantOkSchema, ServerSkillsListSchema, ServerTunnelUrlChangedSchema } from './session.ts';
@@ -22,6 +22,7 @@ export type ServerPairResolvedMessage = z.infer<typeof ServerPairResolvedSchema>
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerShellPendingApprovalMessage = z.infer<typeof ServerShellPendingApprovalSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
+export type ServerPermissionInputMessage = z.infer<typeof ServerPermissionInputSchema>;
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;
 export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchema>;
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>;

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -135,17 +135,21 @@ export declare const ServerPermissionRequestSchema: z.ZodObject<{
  * `input`/`tool` are present only when `found`. Session-bound: the server only
  * returns input for a permission the requesting client's session owns.
  */
-export declare const ServerPermissionInputSchema: z.ZodObject<{
+export declare const ServerPermissionInputSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"permission_input">;
     requestId: z.ZodString;
-    found: z.ZodBoolean;
+    found: z.ZodLiteral<true>;
     tool: z.ZodOptional<z.ZodString>;
-    input: z.ZodOptional<z.ZodAny>;
-    error: z.ZodOptional<z.ZodObject<{
+    input: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"permission_input">;
+    requestId: z.ZodString;
+    found: z.ZodLiteral<false>;
+    error: z.ZodObject<{
         code: z.ZodString;
         message: z.ZodString;
-    }, z.core.$strip>>;
-}, z.core.$strip>;
+    }, z.core.$strip>;
+}, z.core.$strip>], "found">;
 /**
  * Single validated builder for the `permission_request` wire message (#6031).
  *

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -127,6 +127,26 @@ export declare const ServerPermissionRequestSchema: z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 /**
+ * #6543 (IDE P3, feature B) — reply to a `get_permission_input`. The
+ * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a
+ * client building a per-hunk pre-write diff PULLS the full (still
+ * secret-redacted) tool input by requestId. `found` is false when the request
+ * is unknown, already resolved, or belongs to another session (with `error`);
+ * `input`/`tool` are present only when `found`. Session-bound: the server only
+ * returns input for a permission the requesting client's session owns.
+ */
+export declare const ServerPermissionInputSchema: z.ZodObject<{
+    type: z.ZodLiteral<"permission_input">;
+    requestId: z.ZodString;
+    found: z.ZodBoolean;
+    tool: z.ZodOptional<z.ZodString>;
+    input: z.ZodOptional<z.ZodAny>;
+    error: z.ZodOptional<z.ZodObject<{
+        code: z.ZodString;
+        message: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+/**
  * Single validated builder for the `permission_request` wire message (#6031).
  *
  * `permission_request` is the most security-relevant message on the wire — a

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -219,17 +219,27 @@ export const ServerPermissionRequestSchema = z.object({
  * `input`/`tool` are present only when `found`. Session-bound: the server only
  * returns input for a permission the requesting client's session owns.
  */
-export const ServerPermissionInputSchema = z.object({
-    type: z.literal('permission_input'),
-    requestId: z.string(),
-    found: z.boolean(),
-    /** The tool name (e.g. 'Write' / 'Edit'), present only when `found`. */
-    tool: z.string().optional(),
-    /** The full secret-redacted tool input, present only when `found`. */
-    input: z.any().optional(),
-    /** Present when `found` is false (unknown / resolved / cross-session). */
-    error: z.object({ code: z.string(), message: z.string() }).optional(),
-});
+export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
+    // found:true carries the redacted input (a string-keyed object) + tool name,
+    // and NEVER an `error`.
+    z.object({
+        type: z.literal('permission_input'),
+        requestId: z.string(),
+        found: z.literal(true),
+        /** The tool name (e.g. 'Write' / 'Edit'). */
+        tool: z.string().optional(),
+        /** The full secret-redacted tool input. */
+        input: z.record(z.string(), z.unknown()),
+    }),
+    // found:false carries an `error` and NEVER `input`/`tool` — a security message,
+    // so the "unavailable" shape can't accidentally ship any tool input.
+    z.object({
+        type: z.literal('permission_input'),
+        requestId: z.string(),
+        found: z.literal(false),
+        error: z.object({ code: z.string(), message: z.string() }),
+    }),
+]);
 /**
  * Single validated builder for the `permission_request` wire message (#6031).
  *

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -211,6 +211,26 @@ export const ServerPermissionRequestSchema = z.object({
     sessionId: z.string().optional(),
 });
 /**
+ * #6543 (IDE P3, feature B) — reply to a `get_permission_input`. The
+ * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a
+ * client building a per-hunk pre-write diff PULLS the full (still
+ * secret-redacted) tool input by requestId. `found` is false when the request
+ * is unknown, already resolved, or belongs to another session (with `error`);
+ * `input`/`tool` are present only when `found`. Session-bound: the server only
+ * returns input for a permission the requesting client's session owns.
+ */
+export const ServerPermissionInputSchema = z.object({
+    type: z.literal('permission_input'),
+    requestId: z.string(),
+    found: z.boolean(),
+    /** The tool name (e.g. 'Write' / 'Edit'), present only when `found`. */
+    tool: z.string().optional(),
+    /** The full secret-redacted tool input, present only when `found`. */
+    input: z.any().optional(),
+    /** Present when `found` is false (unknown / resolved / cross-session). */
+    error: z.object({ code: z.string(), message: z.string() }).optional(),
+});
+/**
  * Single validated builder for the `permission_request` wire message (#6031).
  *
  * `permission_request` is the most security-relevant message on the wire — a

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -386,6 +386,17 @@ export const PermissionResponseSchema = z.object({
   decision: z.enum(['allow', 'allowAlways', 'deny']),
 })
 
+// #6543 (IDE P3 feature B): pull the FULL secret-redacted tool input for a
+// pending permission, so a client can build a per-hunk pre-write diff. The
+// `permission_request` broadcast truncates `input` (~10K, secret-safe); this
+// fetches the un-truncated (still redacted) version by requestId. Session-bound:
+// the server only returns input for a permission the client's session owns. The
+// reply is a single `permission_input` (see server.ts).
+export const GetPermissionInputSchema = z.object({
+  type: z.literal('get_permission_input'),
+  requestId: z.string().min(1).max(256),
+})
+
 export const QueryPermissionAuditSchema = z.object({
   type: z.literal('query_permission_audit'),
   sessionId: z.string().max(256).optional(),
@@ -1430,6 +1441,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SkillTrustAcceptSchema,
   SkillTrustGrantSchema,
   PermissionResponseSchema,
+  GetPermissionInputSchema,
   ListSessionsSchema,
   SwitchSessionSchema,
   CreateSessionSchema,
@@ -1545,6 +1557,7 @@ export type SetModelMessage = z.infer<typeof SetModelSchema>
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>
+export type GetPermissionInputMessage = z.infer<typeof GetPermissionInputSchema>
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>
 export type HostStatusRequestMessage = z.infer<typeof HostStatusRequestSchema>
 export type RunnerStatusRequestMessage = z.infer<typeof RunnerStatusRequestSchema>

--- a/packages/protocol/src/schemas/server/messages.ts
+++ b/packages/protocol/src/schemas/server/messages.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod'
 
 import { BillingCanarySnapshotSchema, BillingCanaryWarningSchema, ServerAuthOkSchema, ServerPairPendingSchema, ServerPairRequestPendingSchema, ServerPairResolvedSchema, ServerPairResultSchema } from './connection.ts'
-import { ServerPermissionRequestSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts'
+import { ServerPermissionRequestSchema, ServerPermissionInputSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts'
 import { ActivityEntrySchema, ActivityKindSchema, ActivityOutputRefSchema, ActivityStatusSchema, ServerActivityDeltaSchema, ServerActivitySnapshotSchema, ServerCancelActivityAckSchema, ServerMessageDequeuedSchema, ServerMessageQueuedSchema } from './activity.ts'
 import { ExternalSessionEntrySchema, HostStatusSummarySchema, IntegrationActionCountsSchema, IntegrationCliStatusSchema, IntegrationRepoSchema, IntegrationStatusSummarySchema, MailboxDeliveryEventSchema, MailboxRegistrationSchema, RepoEventSchema, ServerRepoEventsDeltaSchema, RepoMemoryCacheSchema, RepoMemoryReportSchema, RepoMemoryStatusSchema, RepoRelayRunSchema, RepoRelayStatusSchema, RepoRelayVerdictSchema, RepoRunnersSchema, RepoRuntimeConfigEntrySchema, RepoStatusSchema, RepoTreeSchema, RepoVerdictSchema, RunnerInfoSchema, RunnerServiceStateSchema, RunnerStatusSummarySchema, RunnerVerdictSchema, ServerByokPoolActionAckSchema, ServerByokPoolStatusSnapshotSchema, ServerContainersActionAckSchema, ServerContainersStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerHostPruneActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerSessionPresetDisclosureSchema, ServerSessionPresetFullSchema, ServerSessionPresetSnapshotSchema, ServerSimulatorActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerSummarizeSessionResultSchema, ServerWslActionAckSchema, ServerWslStatusSnapshotSchema, SkillInventoryEntrySchema, SkillInventoryRepoSchema } from './control-room.ts'
 import { CumulativeUsageSchema, ServerAuthBootstrapSchema, ServerSessionStoppedSchema, ServerSkillTrustGrantInvalidAuthorSchema, ServerSkillTrustGrantOkSchema, ServerSkillsListSchema, ServerTunnelUrlChangedSchema } from './session.ts'
@@ -28,6 +28,9 @@ export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>
 // #6277 — host-local user-shell approval pending notice (dashboard-only v1).
 export type ServerShellPendingApprovalMessage = z.infer<typeof ServerShellPendingApprovalSchema>
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>
+// #6543 (IDE P3 feature B): reply to a get_permission_input pull — the full
+// secret-redacted tool input for building a pre-write diff.
+export type ServerPermissionInputMessage = z.infer<typeof ServerPermissionInputSchema>
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>
 // #4192: typed alias for the generic `type: 'error'` envelope added in #4178.
 // Downstream consumers (store-core handleError, dashboard message-handler,

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -241,17 +241,27 @@ export const ServerPermissionRequestSchema = z.object({
  * `input`/`tool` are present only when `found`. Session-bound: the server only
  * returns input for a permission the requesting client's session owns.
  */
-export const ServerPermissionInputSchema = z.object({
-  type: z.literal('permission_input'),
-  requestId: z.string(),
-  found: z.boolean(),
-  /** The tool name (e.g. 'Write' / 'Edit'), present only when `found`. */
-  tool: z.string().optional(),
-  /** The full secret-redacted tool input, present only when `found`. */
-  input: z.any().optional(),
-  /** Present when `found` is false (unknown / resolved / cross-session). */
-  error: z.object({ code: z.string(), message: z.string() }).optional(),
-})
+export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
+  // found:true carries the redacted input (a string-keyed object) + tool name,
+  // and NEVER an `error`.
+  z.object({
+    type: z.literal('permission_input'),
+    requestId: z.string(),
+    found: z.literal(true),
+    /** The tool name (e.g. 'Write' / 'Edit'). */
+    tool: z.string().optional(),
+    /** The full secret-redacted tool input. */
+    input: z.record(z.string(), z.unknown()),
+  }),
+  // found:false carries an `error` and NEVER `input`/`tool` — a security message,
+  // so the "unavailable" shape can't accidentally ship any tool input.
+  z.object({
+    type: z.literal('permission_input'),
+    requestId: z.string(),
+    found: z.literal(false),
+    error: z.object({ code: z.string(), message: z.string() }),
+  }),
+])
 
 /**
  * Single validated builder for the `permission_request` wire message (#6031).

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -233,6 +233,27 @@ export const ServerPermissionRequestSchema = z.object({
 })
 
 /**
+ * #6543 (IDE P3, feature B) — reply to a `get_permission_input`. The
+ * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a
+ * client building a per-hunk pre-write diff PULLS the full (still
+ * secret-redacted) tool input by requestId. `found` is false when the request
+ * is unknown, already resolved, or belongs to another session (with `error`);
+ * `input`/`tool` are present only when `found`. Session-bound: the server only
+ * returns input for a permission the requesting client's session owns.
+ */
+export const ServerPermissionInputSchema = z.object({
+  type: z.literal('permission_input'),
+  requestId: z.string(),
+  found: z.boolean(),
+  /** The tool name (e.g. 'Write' / 'Edit'), present only when `found`. */
+  tool: z.string().optional(),
+  /** The full secret-redacted tool input, present only when `found`. */
+  input: z.any().optional(),
+  /** Present when `found` is false (unknown / resolved / cross-session). */
+  error: z.object({ code: z.string(), message: z.string() }).optional(),
+})
+
+/**
  * Single validated builder for the `permission_request` wire message (#6031).
  *
  * `permission_request` is the most security-relevant message on the wire — a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -159,6 +159,7 @@ const PLATFORM_SPECIFIC = {
   // fast-follow per epic #5159), so they are BOTH-CLIENTS and the coverage test
   // passes because each handler has a `case 'activity_snapshot'/'activity_delta':`.
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
+  'permission_input': 'dashboard', // #6543 (IDE P3 feature B) reply to a get_permission_input pull — full redacted tool input for the pre-write diff; dashboard-only for the first cut (the pre-write-diff UI lands dashboard-first), mobile parity is PR-4 of #6543
   'repo_events_snapshot': 'dashboard', // Control Room repo-events survey reply (#5966, epic #5422 phase 5) — GitHub-webhook activity buffered by the daemon (#6468); host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'repo_events_delta': 'dashboard', // Control Room repo-events LIVE delta (#6536, PR-2 of #5966) — host-broadcast of a new webhook event so the pane updates without a Refresh; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'runner_status_snapshot': 'dashboard', // Control Room self-hosted runner survey reply (#5253) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3221,4 +3221,27 @@ describe('@chroxy/protocol schemas', () => {
       }).success)
     })
   })
+
+  describe('#6543 — get_permission_input / permission_input', () => {
+    it('ClientMessageSchema accepts get_permission_input (union membership)', async () => {
+      const { ClientMessageSchema } = await import('../src/schemas/client.ts')
+      assert.ok(ClientMessageSchema.safeParse({ type: 'get_permission_input', requestId: 'r1' }).success)
+      assert.ok(!ClientMessageSchema.safeParse({ type: 'get_permission_input' }).success, 'requestId required')
+    })
+
+    it('ServerPermissionInputSchema round-trips a found reply + a not-found reply', async () => {
+      const { ServerPermissionInputSchema } = await import('../src/schemas/server/stream.ts')
+      const found = ServerPermissionInputSchema.safeParse({
+        type: 'permission_input', requestId: 'r1', found: true, tool: 'Write',
+        input: { file_path: '/x', content: 'a\nb' },
+      })
+      assert.ok(found.success)
+      assert.equal(found.data.tool, 'Write')
+      const missing = ServerPermissionInputSchema.safeParse({
+        type: 'permission_input', requestId: 'r1', found: false, error: { code: 'NOT_PENDING', message: 'gone' },
+      })
+      assert.ok(missing.success)
+      assert.equal(missing.data.input, undefined)
+    })
+  })
 })

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -753,8 +753,9 @@ for (const settingDef of PER_SESSION_SETTINGS) {
  *      `found:false` with NO input — it can never read another session's input.
  *   3. The raw input (`session._pendingPermissions`, the back-compat accessor
  *      onto the session's PermissionManager) is re-run through `sanitizeToolInput`
- *      with the larger `PULL_MAX_INPUT_CHARS` cap — the KEY-NAME + VALUE-SHAPE
- *      secret passes ALWAYS run, so a higher cap never weakens redaction.
+ *      with the larger `PULL_MAX_INPUT_CHARS` cap — for the tool_input object the
+ *      KEY-NAME + VALUE-SHAPE secret passes run on every value regardless of the
+ *      cap, so a higher cap never weakens redaction, only the truncation point.
  */
 function handleGetPermissionInput(ws, client, msg, ctx) {
   const requestId = msg.requestId

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -27,6 +27,7 @@ import {
   buildPerSessionSettingHandler,
 } from '../per-session-settings.js'
 import { createPermissionResolver, resolveOriginSessionId } from '../permission-resolver.js'
+import { sanitizeToolInput, PULL_MAX_INPUT_CHARS } from '../redaction.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
 // These are safe file-operation tools that don't execute code or make network requests.
@@ -737,10 +738,55 @@ for (const settingDef of PER_SESSION_SETTINGS) {
   perSessionSettingHandlers[settingDef.requestType] = buildPerSessionSettingHandler(settingDef)
 }
 
+/**
+ * #6543 (IDE P3 feature B) — reply to a `get_permission_input` pull. The
+ * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a
+ * client building a per-hunk pre-write diff pulls the FULL (still secret-
+ * redacted) tool input by requestId.
+ *
+ * SECURITY — session-bound, read-only, redacted:
+ *   1. The requestId → session mapping (`permissionSessionMap`, populated for
+ *      both the SDK and hook dispatch paths) locates the owning session.
+ *   2. Authorization is IDENTICAL to `permission_response`: a bound client must
+ *      own that session; an unbound client must be a viewer of it
+ *      (`isSessionViewer`). An unauthorized (or unknown) request gets
+ *      `found:false` with NO input — it can never read another session's input.
+ *   3. The raw input (`session._pendingPermissions`, the back-compat accessor
+ *      onto the session's PermissionManager) is re-run through `sanitizeToolInput`
+ *      with the larger `PULL_MAX_INPUT_CHARS` cap — the KEY-NAME + VALUE-SHAPE
+ *      secret passes ALWAYS run, so a higher cap never weakens redaction.
+ */
+function handleGetPermissionInput(ws, client, msg, ctx) {
+  const requestId = msg.requestId
+  const send = (fields) => ctx.transport.send(ws, { type: 'permission_input', requestId, ...fields })
+  const notFound = (code, message) => send({ found: false, error: { code, message } })
+
+  const sessionId = ctx.permissions.permissionSessionMap.get(requestId)
+  if (!sessionId) return notFound('NOT_FOUND', 'No pending permission for that request.')
+
+  // Same authority gate as permission_response — a client may only read the
+  // input for a permission it could itself answer.
+  if (client.boundSessionId) {
+    if (client.boundSessionId !== sessionId) return notFound('NOT_FOUND', 'No pending permission for that request.')
+  } else if (!isSessionViewer(client, sessionId)) {
+    return notFound('NOT_FOUND', 'No pending permission for that request.')
+  }
+
+  const sess = ctx.sessions.sessionManager?.getSession?.(sessionId)?.session
+  const pending = sess?._pendingPermissions?.get(requestId)
+  if (!pending) return notFound('NOT_PENDING', 'That permission is no longer pending (resolved or expired).')
+
+  const tool = sess?._lastPermissionData?.get(requestId)?.tool
+  const input = sanitizeToolInput(pending.input, { maxChars: PULL_MAX_INPUT_CHARS })
+  return send({ found: true, tool, input })
+}
+
 export const settingsHandlers = {
   set_model: handleSetModel,
   set_permission_mode: handleSetPermissionMode,
   permission_response: handlePermissionResponse,
+  // #6543 (IDE P3 feature B): pull the full redacted tool input for a pre-write diff.
+  get_permission_input: handleGetPermissionInput,
   query_permission_audit: handleQueryPermissionAudit,
   list_providers: handleListProviders,
   set_thinking_level: handleSetThinkingLevel,

--- a/packages/server/src/redaction.js
+++ b/packages/server/src/redaction.js
@@ -124,11 +124,11 @@ const MAX_SANITIZE_DEPTH = 8
  * @param {WeakSet} seen
  * @returns {*}
  */
-function redactDeep(value, depth, seen) {
+function redactDeep(value, depth, seen, maxChars = MAX_INPUT_CHARS) {
   if (typeof value === 'string') {
     const redacted = redactValue(value)
-    return redacted.length > MAX_INPUT_CHARS
-      ? redacted.slice(0, MAX_INPUT_CHARS) + '... [truncated]'
+    return redacted.length > maxChars
+      ? redacted.slice(0, maxChars) + '... [truncated]'
       : redacted
   }
   if (!value || typeof value !== 'object') return value
@@ -137,13 +137,13 @@ function redactDeep(value, depth, seen) {
   seen.add(value)
   let out
   if (Array.isArray(value)) {
-    out = value.map((item) => redactDeep(item, depth + 1, seen))
+    out = value.map((item) => redactDeep(item, depth + 1, seen, maxChars))
   } else {
     out = {}
     for (const [key, child] of Object.entries(value)) {
       out[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
         ? '[REDACTED]'
-        : redactDeep(child, depth + 1, seen)
+        : redactDeep(child, depth + 1, seen, maxChars)
     }
   }
   seen.delete(value)
@@ -160,10 +160,19 @@ function redactDeep(value, depth, seen) {
  * — is redacted before it reaches any client. Both passes recurse through nested
  * objects and arrays.
  *
+ * The `maxChars` cap governs BOTH the per-string truncation and the whole-object
+ * summary fallback. It defaults to `MAX_INPUT_CHARS` (the ~10K broadcast cap), so
+ * every existing broadcast caller is byte-for-byte unchanged. The pull path
+ * (#6543 `get_permission_input`, which needs the FULL content to build a
+ * pre-write diff) passes a larger `maxChars` (`PULL_MAX_INPUT_CHARS`) — the
+ * secret-stripping passes (KEY-NAME + VALUE-SHAPE) ALWAYS run regardless of the
+ * cap, so a higher cap never weakens redaction, only the truncation threshold.
+ *
  * @param {object} input
+ * @param {{ maxChars?: number }} [opts]
  * @returns {object}
  */
-function sanitizeToolInput(input) {
+function sanitizeToolInput(input, { maxChars = MAX_INPUT_CHARS } = {}) {
   if (!input || typeof input !== 'object') return input
 
   const seen = new WeakSet()
@@ -171,15 +180,24 @@ function sanitizeToolInput(input) {
   for (const [key, value] of Object.entries(input)) {
     result[key] = SENSITIVE_KEY_NAMES.has(key.toLowerCase())
       ? '[REDACTED]'
-      : redactDeep(value, 1, seen)
+      : redactDeep(value, 1, seen, maxChars)
   }
 
   // Final size check on the whole object
   const serialized = JSON.stringify(result)
-  if (serialized.length > MAX_INPUT_CHARS) {
-    return { _truncated: true, summary: serialized.slice(0, MAX_INPUT_CHARS) + '... [truncated]' }
+  if (serialized.length > maxChars) {
+    return { _truncated: true, summary: serialized.slice(0, maxChars) + '... [truncated]' }
   }
   return result
 }
 
-export { SENSITIVE_PATTERNS, API_KEY_PATTERNS, SENSITIVE_KEY_NAMES, sanitizeToolInput }
+/**
+ * #6543: the truncation cap for the `get_permission_input` PULL path — the
+ * client needs the un-broadcast-truncated (but still secret-redacted) tool input
+ * to build a full pre-write diff. Generous enough for any realistic file edit,
+ * bounded so a pathological input can't blast the wire (the diff falls back to a
+ * whole-file view past `computeHunks`'s own line guard anyway).
+ */
+const PULL_MAX_INPUT_CHARS = 512 * 1024 // 512K chars
+
+export { SENSITIVE_PATTERNS, API_KEY_PATTERNS, SENSITIVE_KEY_NAMES, sanitizeToolInput, PULL_MAX_INPUT_CHARS, MAX_INPUT_CHARS }

--- a/packages/server/src/redaction.js
+++ b/packages/server/src/redaction.js
@@ -164,9 +164,12 @@ function redactDeep(value, depth, seen, maxChars = MAX_INPUT_CHARS) {
  * summary fallback. It defaults to `MAX_INPUT_CHARS` (the ~10K broadcast cap), so
  * every existing broadcast caller is byte-for-byte unchanged. The pull path
  * (#6543 `get_permission_input`, which needs the FULL content to build a
- * pre-write diff) passes a larger `maxChars` (`PULL_MAX_INPUT_CHARS`) — the
- * secret-stripping passes (KEY-NAME + VALUE-SHAPE) ALWAYS run regardless of the
- * cap, so a higher cap never weakens redaction, only the truncation threshold.
+ * pre-write diff) passes a larger `maxChars` (`PULL_MAX_INPUT_CHARS`) — for an
+ * object input (which every real tool_input is), the secret-stripping passes
+ * (KEY-NAME + VALUE-SHAPE) run on every value regardless of the cap, so a higher
+ * cap never weakens redaction, only the truncation threshold. A non-object input
+ * is returned as-is (there is nothing to key/redact); callers always pass the
+ * tool_input object.
  *
  * @param {object} input
  * @param {{ maxChars?: number }} [opts]

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -351,6 +351,7 @@ function _isSecureRequest(req) {
  *   { type: 'claude_ready' }                          — Claude Code ready for input
  *   { type: 'model_changed', model: '...' }          — active model updated
  *   { type: 'available_models', models: [...], provider?, defaultModel? } — models the active provider accepts
+ *   { type: 'permission_input', requestId, found, tool?, input?, error? } — #6543 (IDE P3 feature B) reply to a `get_permission_input` pull: the FULL secret-redacted tool input for a pending permission (the `permission_request` broadcast truncates `input` at ~10K), so a client can build a per-hunk pre-write diff. `found:false` (+ `error`) when the request is unknown / already resolved / owned by another session — the handler is session-bound (a client only gets input for a permission its session owns).
  *   { type: 'permission_request', requestId, tool, description, input, remainingMs } — permission prompt
  *   { type: 'confirm_permission_mode', mode, warning } — server challenges auto mode (client must re-send with confirmed: true)
  *   { type: 'permission_mode_changed', mode: '...' } — permission mode updated

--- a/packages/server/tests/get-permission-input.test.js
+++ b/packages/server/tests/get-permission-input.test.js
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { settingsHandlers } from '../src/handlers/settings-handlers.js'
+import { createSpy, nsCtx } from './test-helpers.js'
+import { ServerPermissionInputSchema } from '@chroxy/protocol'
+
+/**
+ * #6543 (IDE P3 feature B) — `get_permission_input` handler. The security-
+ * critical contract: it returns the FULL secret-redacted tool input ONLY to a
+ * client authorized for the owning session (same gate as permission_response),
+ * and NEVER leaks another session's input. Un-truncated (larger cap) so a
+ * pre-write diff is complete; secrets are still stripped.
+ */
+
+const SECRET = 'sk-ant-api03-' + 'x'.repeat(95)
+const BIG_CONTENT = 'const line = 1\n'.repeat(1500) // ~22K chars — exceeds the 10K broadcast cap
+
+// A session whose PermissionManager (back-compat accessors) holds a pending
+// Write permission for `req-1`, with a secret embedded in the content.
+function makeSession() {
+  return {
+    session: {
+      _pendingPermissions: new Map([
+        ['req-1', { input: { file_path: '/repo/x.js', content: `${BIG_CONTENT}\n// token=${SECRET}` }, resolve: () => {} }],
+      ]),
+      _lastPermissionData: new Map([['req-1', { tool: 'Write' }]]),
+    },
+  }
+}
+
+function makeCtx({ mapEntry = ['req-1', 'sess-1'] } = {}) {
+  const send = createSpy()
+  return nsCtx({
+    send,
+    permissionSessionMap: new Map(mapEntry ? [mapEntry] : []),
+    sessionManager: { getSession: (sid) => (sid === 'sess-1' ? makeSession() : undefined) },
+    _send: send,
+  })
+}
+
+function lastSent(ctx) {
+  return ctx.transport.send.lastCall[1]
+}
+
+describe('get_permission_input handler (#6543)', () => {
+  it('is registered in settingsHandlers', () => {
+    assert.equal(typeof settingsHandlers.get_permission_input, 'function')
+  })
+
+  it('returns the FULL redacted input to a viewer of the owning session', () => {
+    const ctx = makeCtx()
+    // unbound client actively viewing sess-1 (isSessionViewer)
+    settingsHandlers.get_permission_input({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    const msg = lastSent(ctx)
+    assert.equal(msg.type, 'permission_input')
+    assert.equal(msg.found, true)
+    assert.equal(msg.tool, 'Write')
+    // secret stripped
+    assert.ok(!JSON.stringify(msg.input).includes(SECRET), 'the API key must be redacted out')
+    assert.ok(JSON.stringify(msg.input).includes('[REDACTED'), 'redaction marker present')
+    // NOT truncated at the 10K broadcast cap — the big content survives for the diff
+    assert.ok(msg.input.content.length > 15000, 'content is not truncated at the broadcast cap')
+    assert.equal(msg.input.file_path, '/repo/x.js')
+    assert.ok(ServerPermissionInputSchema.safeParse(msg).success)
+  })
+
+  it('returns found:true for a bound client that OWNS the session', () => {
+    const ctx = makeCtx()
+    settingsHandlers.get_permission_input({}, { id: 'c1', boundSessionId: 'sess-1' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    assert.equal(lastSent(ctx).found, true)
+  })
+
+  it('LEAKS NOTHING to a bound client of a DIFFERENT session', () => {
+    const ctx = makeCtx()
+    settingsHandlers.get_permission_input({}, { id: 'c2', boundSessionId: 'other-session' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    const msg = lastSent(ctx)
+    assert.equal(msg.found, false)
+    assert.equal(msg.input, undefined, 'no input for a cross-session client')
+    assert.ok(ServerPermissionInputSchema.safeParse(msg).success)
+  })
+
+  it('LEAKS NOTHING to an unbound client that is not a viewer of the session', () => {
+    const ctx = makeCtx()
+    settingsHandlers.get_permission_input({}, { id: 'c3', activeSessionId: 'unrelated', subscribedSessionIds: new Set() }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    const msg = lastSent(ctx)
+    assert.equal(msg.found, false)
+    assert.equal(msg.input, undefined)
+  })
+
+  it('found:false for an unknown requestId (no session mapping)', () => {
+    const ctx = makeCtx({ mapEntry: null })
+    settingsHandlers.get_permission_input({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'get_permission_input', requestId: 'nope' }, ctx)
+    assert.equal(lastSent(ctx).found, false)
+  })
+
+  it('found:false (NOT_PENDING) when the session no longer holds the request', () => {
+    const send = createSpy()
+    const ctx = nsCtx({
+      send,
+      permissionSessionMap: new Map([['req-1', 'sess-1']]),
+      // session exists but its pending map is empty (resolved/expired)
+      sessionManager: { getSession: () => ({ session: { _pendingPermissions: new Map(), _lastPermissionData: new Map() } }) },
+      _send: send,
+    })
+    settingsHandlers.get_permission_input({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    const msg = ctx.transport.send.lastCall[1]
+    assert.equal(msg.found, false)
+    assert.equal(msg.error.code, 'NOT_PENDING')
+  })
+})

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -192,6 +192,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'evaluator_clarify',          // auto-evaluator clarify banner (#3188) — dashboard-only
   'evaluator_rewrite',          // auto-evaluator rewrite banner (#3188) — dashboard-only
   'host_status_snapshot',       // Control Room Host/Repo Status (#5170) — dashboard-only for v1
+  'permission_input',           // #6543 (IDE P3 feature B) get_permission_input reply — full redacted tool input for the pre-write diff; dashboard-only for the first cut, mobile parity is PR-4 of #6543
   'integration_action_ack',     // Control Room Integrations action ack (#5500) — dashboard-only
   'integration_status_snapshot',// Control Room Integrations survey (#5499) — dashboard-only
   'mailbox_status_snapshot',    // Control Room Mailbox tab survey (#5914) — dashboard-only


### PR DESCRIPTION
## What

**PR-1 of feature B** (#6543 — per-hunk review of the agent's proposed writes). The `permission_request` broadcast truncates the tool input at ~10K (secret-safe), so a client building a per-hunk pre-write diff **pulls** the full (still secret-redacted) input by requestId. **Read-only — no execution-path change** (the `editedInput` merge is the security-sensitive PR-2).

## Layers
| Layer | Change |
|---|---|
| **redaction** (`redaction.js`) | `sanitizeToolInput`/`redactDeep` take an optional `maxChars`, **defaulting to the ~10K broadcast cap so every existing broadcast caller is byte-for-byte unchanged** (86 redaction tests green). The secret-stripping passes (KEY-NAME + VALUE-SHAPE) **always** run — a higher cap never weakens redaction, only the truncation threshold. New `PULL_MAX_INPUT_CHARS` (512K) for the pull. |
| **protocol** | client `GetPermissionInputSchema`; server `ServerPermissionInputSchema` (`permission_input`: `found` + `tool?`/`input?` when found, `error?` when not). Coverage guards (handler-coverage PLATFORM_SPECIFIC + store-core DASHBOARD_ONLY) — dashboard-only for the first cut, mobile parity is PR-4. Dist rebuilt + staged. |
| **server** (`handleGetPermissionInput`) | **Session-bound**, same authority gate as `permission_response`: a bound client must own the session; an unbound client must be a viewer (`isSessionViewer`). Unknown/unauthorized → `found:false` with **NO input** — never reads another session's input. Reads the raw input off the session's PermissionManager (back-compat accessor) and re-redacts with the larger cap. |
| **dashboard** | `permissionInputs[requestId]` store field + `requestPermissionInput` action + `permission_input` handler. |

## Security tests (the load-bearing part)
`get-permission-input.test.js`: **leaks nothing** to a bound client of a different session / an unbound non-viewer / an unknown requestId / a no-longer-pending request; returns the **full redacted** input to a viewer (secret `sk-ant-…` stripped, ~22K content **not** truncated at the broadcast cap). Plus protocol round-trips + dashboard dispatch.

## Green
Redaction regression 86 · protocol 358 · store-core 1934 · dashboard 4232 + typecheck · server permission/ws-server suites 233 · 5 custom lints · server eslint 0 errors.

Part of #6543 · epic #6469 · design basis #6529