### PR TITLE
feat(server): editedInput execution seam for per-hunk write review (#6543 PR-2)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -280,6 +280,7 @@ export declare const PermissionResponseSchema: z.ZodObject<{
         deny: "deny";
         allowAlways: "allowAlways";
     }>;
+    editedInput: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
 }, z.core.$strip>;
 export declare const GetPermissionInputSchema: z.ZodObject<{
     type: z.ZodLiteral<"get_permission_input">;
@@ -945,6 +946,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         deny: "deny";
         allowAlways: "allowAlways";
     }>;
+    editedInput: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"get_permission_input">;
     requestId: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -339,6 +339,15 @@ export const PermissionResponseSchema = z.object({
     type: z.literal('permission_response'),
     requestId: z.string().min(1).max(256),
     decision: z.enum(['allow', 'allowAlways', 'deny']),
+    // #6543 (IDE P3 feature B): optional per-hunk-review edits for an `allow` —
+    // a client that reviewed the agent's proposed Write/Edit and dropped some
+    // hunks sends the reduced CONTENT here. The server merges ONLY the whitelisted
+    // content field(s) per tool (Write→content, Edit→new_string) and NEVER the
+    // path/anchor fields, so an edit can narrow the write but can't redirect where
+    // it lands. Ignored on deny, and for tools with no editable content field. A
+    // loose object — the server-side whitelist (permission-manager.js) is the
+    // enforcement point.
+    editedInput: z.record(z.string(), z.unknown()).optional(),
 });
 // #6543 (IDE P3 feature B): pull the FULL secret-redacted tool input for a
 // pending permission, so a client can build a per-hunk pre-write diff. The

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -384,6 +384,15 @@ export const PermissionResponseSchema = z.object({
   type: z.literal('permission_response'),
   requestId: z.string().min(1).max(256),
   decision: z.enum(['allow', 'allowAlways', 'deny']),
+  // #6543 (IDE P3 feature B): optional per-hunk-review edits for an `allow` —
+  // a client that reviewed the agent's proposed Write/Edit and dropped some
+  // hunks sends the reduced CONTENT here. The server merges ONLY the whitelisted
+  // content field(s) per tool (Write→content, Edit→new_string) and NEVER the
+  // path/anchor fields, so an edit can narrow the write but can't redirect where
+  // it lands. Ignored on deny, and for tools with no editable content field. A
+  // loose object — the server-side whitelist (permission-manager.js) is the
+  // enforcement point.
+  editedInput: z.record(z.string(), z.unknown()).optional(),
 })
 
 // #6543 (IDE P3 feature B): pull the FULL secret-redacted tool input for a

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1730,7 +1730,7 @@ export class ClaudeByokSession extends BaseSession {
    * PermissionManager which resolves the pending Promise in
    * handlePermission() above.
    */
-  respondToPermission(requestId, decision) {
+  respondToPermission(requestId, decision, editedInput) {
     // #5056: if this requestId belongs to a Task subagent (its pending
     // entry lives in the CHILD's PermissionManager, not ours), forward
     // the decision to that child. ws-permissions only ever calls the
@@ -1746,9 +1746,10 @@ export class ClaudeByokSession extends BaseSession {
       // which our relay listener uses to clear the same entry — deleting
       // here too is idempotent and closes the lifetime tightly.
       this._subagentPermissionRouting.delete(requestId)
-      return child.respondToPermission(requestId, decision)
+      // #6543: forward the operator's per-hunk editedInput to the child too.
+      return child.respondToPermission(requestId, decision, editedInput)
     }
-    return this._permissions.respondToPermission(requestId, decision)
+    return this._permissions.respondToPermission(requestId, decision, editedInput)
   }
 
   /**

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -459,6 +459,11 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   const result = resolver.resolve(requestId, decision, client.boundSessionId, {
     clientId: client.id,
     dispatchFallbackSessionId: client.activeSessionId,
+    // #6543 (feature B): the operator's per-hunk edits for an approve. The server
+    // whitelists which fields may be substituted (permission-manager.js
+    // mergeEditedInput) — a client can narrow the content but not redirect the
+    // path. Only present when the client reviewed + edited the proposed write.
+    editedInput: msg.editedInput,
   })
 
   if (result.kind === 'binding_mismatch') {

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -44,10 +44,12 @@ const EDITABLE_INPUT_FIELDS = {
 
 /**
  * Merge a client's `editedInput` into the agent's original tool input under the
- * strict {@link EDITABLE_INPUT_FIELDS} whitelist. Returns the original unchanged
- * when there's no editedInput, the tool isn't editable, or the edited value
- * isn't a string. Never mutates the inputs. This is the load-bearing "narrow-
- * only, no path redirect" control for feature B — keep it dumb + auditable.
+ * strict {@link EDITABLE_INPUT_FIELDS} whitelist. Returns the original REFERENCE
+ * when there's no editedInput, it isn't a plain object, or the tool isn't
+ * editable; otherwise returns a shallow clone with only the whitelisted STRING
+ * fields substituted (a non-string edited value is skipped, so the clone equals
+ * the original by value). Never mutates the inputs. This is the load-bearing
+ * "narrow-only, no path redirect" control for feature B — keep it dumb + auditable.
  *
  * @param {object} originalInput  the agent's proposed tool input
  * @param {*} editedInput         the client-supplied override (untrusted)

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -28,6 +28,46 @@ const MAX_SESSION_RULES = 100         // session-scoped auto-allow rules
 const MAX_RAW_DESCRIPTION_LEN = 8192  // raw tool field length fed to redactValue (far above the 200-char shown window)
 
 /**
+ * #6543 (IDE P3 feature B) — per-tool whitelist of the CONTENT field(s) a client
+ * may substitute via `editedInput` on an `allow` (the per-hunk pre-write review).
+ * ONLY these content fields can come from the client; the path/anchor fields
+ * (`file_path`, `old_string`, `command`, …) are always taken from the ORIGINAL
+ * input. So an operator can narrow/edit the shown content but can NEVER redirect
+ * where the write lands or what runs. A tool absent from this map ignores
+ * `editedInput` entirely (accept/reject-the-whole-tool). `old_string` is
+ * deliberately NOT editable — it is the Edit's match anchor, not shown content.
+ */
+const EDITABLE_INPUT_FIELDS = {
+  Write: ['content'],
+  Edit: ['new_string'],
+}
+
+/**
+ * Merge a client's `editedInput` into the agent's original tool input under the
+ * strict {@link EDITABLE_INPUT_FIELDS} whitelist. Returns the original unchanged
+ * when there's no editedInput, the tool isn't editable, or the edited value
+ * isn't a string. Never mutates the inputs. This is the load-bearing "narrow-
+ * only, no path redirect" control for feature B — keep it dumb + auditable.
+ *
+ * @param {object} originalInput  the agent's proposed tool input
+ * @param {*} editedInput         the client-supplied override (untrusted)
+ * @param {string} toolName       the tool the permission is for
+ * @returns {object}
+ */
+export function mergeEditedInput(originalInput, editedInput, toolName) {
+  if (!editedInput || typeof editedInput !== 'object' || Array.isArray(editedInput)) return originalInput
+  const allowed = EDITABLE_INPUT_FIELDS[toolName]
+  if (!allowed) return originalInput
+  const merged = { ...originalInput }
+  for (const field of allowed) {
+    if (Object.prototype.hasOwnProperty.call(editedInput, field) && typeof editedInput[field] === 'string') {
+      merged[field] = editedInput[field]
+    }
+  }
+  return merged
+}
+
+/**
  * Manages in-process permission requests for SDK-style sessions.
  *
  * Handles the lifecycle of permission prompts:
@@ -336,12 +376,15 @@ export class PermissionManager extends EventEmitter {
    * @returns {boolean} true if a pending permission was found and resolved,
    *   false if the requestId was unknown (already resolved or expired).
    */
-  respondToPermission(requestId, decision) {
+  respondToPermission(requestId, decision, editedInput) {
     const pending = this._pendingPermissions.get(requestId)
     if (!pending) {
       this._logWarn(`No pending permission for ${requestId}`)
       return false
     }
+    // #6543: capture the tool name BEFORE deleting the last-permission data, so
+    // the editedInput whitelist knows which content field(s) are substitutable.
+    const toolName = this._lastPermissionData.get(requestId)?.tool
     this._pendingPermissions.delete(requestId)
     this._lastPermissionData.delete(requestId)
     this._clearPermissionTimer(requestId)
@@ -352,8 +395,14 @@ export class PermissionManager extends EventEmitter {
     // before any follow-on work runs synchronously.
     this.emit('permission_resolved', { requestId, decision, reason: 'user' })
 
+    // #6543 (feature B): on an approve, an operator who reviewed the proposed
+    // Write/Edit per-hunk may substitute the CONTENT (never the path — see
+    // mergeEditedInput). Ignored on deny. The merged input flows to the agent's
+    // tool executor as `updatedInput`, which still path-confines the write.
+    const approvedInput = mergeEditedInput(pending.input, editedInput, toolName)
+
     if (decision === 'allow') {
-      pending.resolve({ behavior: 'allow', updatedInput: pending.input })
+      pending.resolve({ behavior: 'allow', updatedInput: approvedInput })
     } else if (decision === 'allowAlways') {
       // Per the Agent SDK type contract (PermissionResult in
       // @anthropic-ai/claude-agent-sdk coreTypes.d.ts), behavior is
@@ -371,7 +420,7 @@ export class PermissionManager extends EventEmitter {
       // by Skeptic in the 2026-04-11 production readiness audit.
       const result = {
         behavior: 'allow',
-        updatedInput: pending.input,
+        updatedInput: approvedInput,
       }
       if (pending.suggestions && pending.suggestions.length > 0) {
         result.updatedPermissions = pending.suggestions

--- a/packages/server/src/permission-resolver.js
+++ b/packages/server/src/permission-resolver.js
@@ -89,7 +89,7 @@ export function createPermissionResolver({
    * @returns {{ kind: string, [k: string]: any }} ResolveResult
    */
   function resolve(requestId, decision, callerBoundSessionId, opts = {}) {
-    const { clientId = null, dispatchFallbackSessionId = null } = opts
+    const { clientId = null, dispatchFallbackSessionId = null, editedInput = undefined } = opts
 
     // Invariant B (#2806 residual): the binding check reads the RAW map entry —
     // never an activeSessionId fallback. For a bound caller the request MUST be
@@ -117,7 +117,9 @@ export function createPermissionResolver({
     if (originSessionId && sm) {
       const entry = sm.getSession(originSessionId)
       if (entry && typeof entry.session.respondToPermission === 'function') {
-        const resolved = entry.session.respondToPermission(requestId, decision)
+        // #6543 (feature B): editedInput flows ONLY to the in-process (SDK/BYOK)
+        // path — the legacy HTTP path below ignores it (CLI tool executes as-is).
+        const resolved = entry.session.respondToPermission(requestId, decision, editedInput)
         consumeRoute(requestId)
         if (resolved) {
           audit(clientId, originSessionId, requestId, decision)

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1292,8 +1292,8 @@ export class SdkSession extends BaseSession {
    * Resolve a pending permission request (called by WsServer when
    * the app sends permission_response).
    */
-  respondToPermission(requestId, decision) {
-    return this._permissions.respondToPermission(requestId, decision)
+  respondToPermission(requestId, decision, editedInput) {
+    return this._permissions.respondToPermission(requestId, decision, editedInput)
   }
 
   /**

--- a/packages/server/tests/edited-input-merge.test.js
+++ b/packages/server/tests/edited-input-merge.test.js
@@ -52,6 +52,20 @@ describe('mergeEditedInput whitelist (#6543)', () => {
     mergeEditedInput(orig, { content: 'edited' }, 'Write')
     assert.equal(orig.content, 'orig')
   })
+
+  it('#6553 — is prototype-pollution resistant (iterates the whitelist, not client keys)', () => {
+    // Attack: a `__proto__` / `constructor` payload can't reach the assignment
+    // because the merge loops over EDITABLE_INPUT_FIELDS, never editedInput's own
+    // keys. Assert Object.prototype stays clean and no polluted key appears.
+    const before = { ...Object.prototype }
+    const r1 = mergeEditedInput({ file_path: '/a', content: 'orig' }, JSON.parse('{"__proto__":{"polluted":"yes"},"content":"edited"}'), 'Write')
+    const r2 = mergeEditedInput({ file_path: '/a', content: 'orig' }, { constructor: { prototype: { polluted: 'yes' } }, content: 'edited' }, 'Write')
+    assert.equal(({}).polluted, undefined, 'Object.prototype must not be polluted')
+    assert.equal(r1.polluted, undefined)
+    assert.equal(r2.polluted, undefined)
+    assert.equal(r1.content, 'edited') // the legit whitelisted field still applies
+    assert.deepEqual(Object.prototype, before)
+  })
 })
 
 describe('respondToPermission editedInput integration (#6543)', () => {

--- a/packages/server/tests/edited-input-merge.test.js
+++ b/packages/server/tests/edited-input-merge.test.js
@@ -1,0 +1,100 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { PermissionManager, mergeEditedInput } from '../src/permission-manager.js'
+
+/**
+ * #6543 (IDE P3 feature B) — the editedInput execution seam. The load-bearing
+ * security control: a client that reviewed the agent's proposed Write/Edit
+ * per-hunk may substitute the CONTENT, but can NEVER redirect the path (or
+ * change a non-content field / a non-editable tool). Covers the pure
+ * `mergeEditedInput` whitelist + the `respondToPermission` integration.
+ */
+
+describe('mergeEditedInput whitelist (#6543)', () => {
+  it('Write: substitutes content, PRESERVES file_path (path redirect blocked)', () => {
+    const r = mergeEditedInput({ file_path: '/repo/a.js', content: 'orig' }, { content: 'edited', file_path: '/etc/passwd' }, 'Write')
+    assert.equal(r.content, 'edited')
+    assert.equal(r.file_path, '/repo/a.js') // the attacker's /etc/passwd is ignored
+  })
+
+  it('Edit: substitutes new_string, PRESERVES file_path AND old_string (anchor)', () => {
+    const r = mergeEditedInput(
+      { file_path: '/repo/a.js', old_string: 'foo', new_string: 'bar' },
+      { new_string: 'BAZ', old_string: 'HIJACK', file_path: '/evil' },
+      'Edit',
+    )
+    assert.equal(r.new_string, 'BAZ')
+    assert.equal(r.old_string, 'foo')       // anchor not editable
+    assert.equal(r.file_path, '/repo/a.js') // path not editable
+  })
+
+  it('a non-editable tool (Bash) ignores editedInput ENTIRELY (no command change)', () => {
+    const r = mergeEditedInput({ command: 'ls' }, { command: 'rm -rf /', content: 'x' }, 'Bash')
+    assert.deepEqual(r, { command: 'ls' })
+  })
+
+  it('ignores non-whitelisted fields, non-string values, and cannot ADD fields', () => {
+    const r = mergeEditedInput({ file_path: '/a', content: 'orig' }, { content: 42, extra: 'nope', file_path: '/evil' }, 'Write')
+    assert.equal(r.content, 'orig')  // 42 is not a string → ignored
+    assert.equal(r.extra, undefined) // cannot inject a new field
+    assert.equal(r.file_path, '/a')
+  })
+
+  it('returns the ORIGINAL for missing / null / array editedInput', () => {
+    const orig = { file_path: '/a', content: 'orig' }
+    assert.strictEqual(mergeEditedInput(orig, undefined, 'Write'), orig)
+    assert.strictEqual(mergeEditedInput(orig, null, 'Write'), orig)
+    assert.strictEqual(mergeEditedInput(orig, ['x'], 'Write'), orig)
+  })
+
+  it('does not mutate the original input', () => {
+    const orig = { file_path: '/a', content: 'orig' }
+    mergeEditedInput(orig, { content: 'edited' }, 'Write')
+    assert.equal(orig.content, 'orig')
+  })
+})
+
+describe('respondToPermission editedInput integration (#6543)', () => {
+  function seed(tool, input) {
+    const pm = new PermissionManager({ log: { info() {}, warn() {}, error() {} } })
+    let resolved
+    pm._pendingPermissions.set('req-1', { resolve: (r) => { resolved = r }, input, suggestions: [] })
+    pm._lastPermissionData.set('req-1', { tool })
+    return { pm, resolved: () => resolved }
+  }
+
+  it('allow + editedInput ⇒ updatedInput has the edited content, original path', () => {
+    const { pm, resolved } = seed('Write', { file_path: '/repo/a.js', content: 'orig' })
+    pm.respondToPermission('req-1', 'allow', { content: 'edited', file_path: '/evil' })
+    assert.equal(resolved().behavior, 'allow')
+    assert.equal(resolved().updatedInput.content, 'edited')
+    assert.equal(resolved().updatedInput.file_path, '/repo/a.js')
+  })
+
+  it('allow WITHOUT editedInput ⇒ original input executes unchanged', () => {
+    const { pm, resolved } = seed('Write', { file_path: '/repo/a.js', content: 'orig' })
+    pm.respondToPermission('req-1', 'allow')
+    assert.equal(resolved().updatedInput.content, 'orig')
+  })
+
+  it('deny + editedInput ⇒ denied, editedInput ignored (no execution)', () => {
+    const { pm, resolved } = seed('Write', { file_path: '/repo/a.js', content: 'orig' })
+    pm.respondToPermission('req-1', 'deny', { content: 'edited' })
+    assert.equal(resolved().behavior, 'deny')
+    assert.equal(resolved().updatedInput, undefined)
+  })
+
+  it('allowAlways + editedInput ⇒ current execution uses the edit', () => {
+    const { pm, resolved } = seed('Edit', { file_path: '/repo/a.js', old_string: 'a', new_string: 'b' })
+    pm.respondToPermission('req-1', 'allowAlways', { new_string: 'EDITED' })
+    assert.equal(resolved().behavior, 'allow')
+    assert.equal(resolved().updatedInput.new_string, 'EDITED')
+    assert.equal(resolved().updatedInput.file_path, '/repo/a.js')
+  })
+
+  it('an unknown requestId returns false and resolves nothing', () => {
+    const { pm, resolved } = seed('Write', { file_path: '/a', content: 'x' })
+    assert.equal(pm.respondToPermission('nope', 'allow', { content: 'y' }), false)
+    assert.equal(resolved(), undefined)
+  })
+})

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -556,7 +556,7 @@ describe('settings-handlers', () => {
       settingsHandlers.permission_response(makeWs(), client, { requestId: 'req-1', decision: 'allow' }, ctx)
 
       assert.equal(session.respondToPermission.callCount, 1)
-      assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow'])
+      assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow', undefined]) // #6543: editedInput 3rd arg (absent here)
     })
 
     // Issue #2912: permission_response rejection for a bound-client must use
@@ -752,7 +752,7 @@ describe('settings-handlers', () => {
 
         assert.equal(sessionA.respondToPermission.callCount, 1,
           'unbound client with matching activeSessionId must route normally')
-        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-active', 'allow'])
+        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-active', 'allow', undefined])
         assert.equal(ctx.permissions.permissionSessionMap.has('perm-ok-active'), false,
           'mapping must be consumed when the decision is routed')
       })
@@ -782,7 +782,7 @@ describe('settings-handlers', () => {
 
         assert.equal(sessionA.respondToPermission.callCount, 1,
           'subscribed unbound client must route normally — matches _broadcastToSession filter')
-        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-sub', 'allow'])
+        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-sub', 'allow', undefined])
       })
 
       it('leaves the bound-client guard unchanged (different code path)', () => {
@@ -848,7 +848,7 @@ describe('settings-handlers', () => {
 
         assert.equal(sessionA.respondToPermission.callCount, 1,
           'after-switch decision must route to the originating session A')
-        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-after-switch', 'allow'])
+        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-after-switch', 'allow', undefined])
         assert.equal(sessionB.respondToPermission.callCount, 0,
           'must not bleed onto the now-active session B')
         assert.equal(ctx.permissions.permissionSessionMap.has('perm-after-switch'), false,

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -493,7 +493,7 @@ describe('handleSessionMessage', () => {
         decision: 'allow',
       }, ctx)
       assert.equal(entry.session.respondToPermission.callCount, 1)
-      assert.deepStrictEqual(entry.session.respondToPermission.lastCall, ['req-broadcast', 'allow'])
+      assert.deepStrictEqual(entry.session.respondToPermission.lastCall, ['req-broadcast', 'allow', undefined]) // #6543: editedInput 3rd arg (absent here)
       assert.equal(ctx.transport.broadcast.mock.calls.length, 0,
         'SDK path must NOT broadcast inline — the unified pipeline handles it (#3048)')
     })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -961,7 +961,7 @@ describe('createPermissionHandler', () => {
       assert.equal(res.statusCode, 200)
       assert.equal(respondToPermission.mock.calls.length, 1,
         'SDK session.respondToPermission must be invoked')
-      assert.deepStrictEqual(respondToPermission.mock.calls[0].arguments, ['sdk-req', 'allow'])
+      assert.deepStrictEqual(respondToPermission.mock.calls[0].arguments, ['sdk-req', 'allow', undefined]) // #6543: editedInput 3rd arg (HTTP path never sets it)
       assert.equal(opts.broadcastFn.mock.calls.length, 0,
         'SDK path must NOT broadcast inline — the unified pipeline handles it (#3048)')
     })


### PR DESCRIPTION
## What — the security-critical core of feature B

A client that reviewed the agent's proposed Write/Edit **per-hunk** (via the #6550 input pull + the #6546/#6548 diff infra) can now approve a **narrowed** write. The reduced content rides on `permission_response`'s new optional **`editedInput`** and is merged into the input the agent's tool executor runs — which still path-confines the write.

## The load-bearing security control — `mergeEditedInput` (strict per-tool whitelist)
| Tool | Substitutable field(s) | Never editable |
|---|---|---|
| `Write` | `content` | `file_path` |
| `Edit` | `new_string` | `file_path`, `old_string` (the match anchor) |
| _(any other)_ | — (editedInput ignored entirely) | everything |

`editedInput` **cannot**: change the path, add a new field, pass a non-string value, or touch a non-whitelisted field — all of those always come from the agent's **original** input. So an operator can **narrow/edit the shown content but can never redirect where the write lands or what runs.** Ignored on `deny`. The merge is dumb + auditable by design.

## Plumbing
`handlePermissionResponse` reads `msg.editedInput` → resolver → `sdk/byok respondToPermission` → the **one** merge in `PermissionManager.respondToPermission` (applied on allow/allowAlways). SDK executes `updatedInput`; BYOK executes `effectiveInput = updatedInput || input`. The legacy HTTP/CLI path ignores it. `editedInput` is **additive-optional** — existing `permission_response` senders are unaffected. **Server-only** — the dashboard *sends* editedInput in PR-3 (the UI).

## Tests (the security proof)
- **Path-redirect blocked:** `Write` with `file_path:'/etc/passwd'` and `Edit` with a hijacked `old_string` are rejected — path/anchor preserved.
- Non-editable tool (`Bash`) ignores editedInput; non-string / extra-field / mutation guards; `respondToPermission` allow-with-edit / allow-without / **deny-ignores** / allowAlways / unknown-id.
- Permission + session regression **190 green**; protocol **358**; 5 custom lints; eslint 0 errors.

⚠️ This is the sensitive seam — flagging for a **dedicated security review**.

Part of #6543 · epic #6469 · design basis #6529