### PR TITLE
feat(dashboard): per-hunk pre-write diff review on the permission prompt (#6543 PR-3)

### DIFF
--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -283,7 +283,7 @@ describe('PermissionPrompt', () => {
       />
     )
     fireEvent.click(screen.getByText('Allow'))
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', null) // #6543: editedInput 3rd arg (null — no review active)
   })
 
   it('calls onRespond with deny when Deny clicked', () => {
@@ -298,7 +298,7 @@ describe('PermissionPrompt', () => {
       />
     )
     fireEvent.click(screen.getByText('Deny'))
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny')
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny', null) // #6543: editedInput 3rd arg (null on deny)
   })
 
   it('shows answered state after response (#2833 — driven by store)', () => {
@@ -366,7 +366,7 @@ describe('PermissionPrompt', () => {
     fireEvent.click(screen.getByText('Allow'))
     fireEvent.click(screen.getByText('Deny'))
     expect(onRespond).toHaveBeenCalledTimes(1)
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', null) // #6543: editedInput 3rd arg (null — no review active)
   })
 
   it('disables all action buttons after first click (#2852)', () => {
@@ -640,7 +640,7 @@ describe('PermissionPrompt — Allow for Session button (#2834)', () => {
       />
     )
     fireEvent.click(screen.getByTestId('btn-allow-session'))
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession')
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowSession', null) // #6543: editedInput 3rd arg
   })
 
   it('hides the button once the prompt is resolved', () => {
@@ -718,7 +718,7 @@ describe('PermissionPrompt — provider capability gate (#3072)', () => {
     // The allow button is still here; the session-rule button is not rendered,
     // but verify the silent coerce path: a programmatic 'allow' click works.
     fireEvent.click(screen.getByText('Allow'))
-    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow')
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', null) // #6543: editedInput 3rd arg (null — no review active)
   })
 })
 

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -22,13 +22,19 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider } from '../store/connection'
 import type { PermissionDecision } from '../store/types'
 import { isMacPlatform } from '../utils/platform'
+import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
 
 export interface PermissionPromptProps {
   requestId: string
   tool: string
   description: string
   remainingMs: number
-  onRespond: (requestId: string, decision: PermissionDecision) => void
+  /**
+   * #6543 (feature B): `editedInput` carries the operator's per-hunk narrowing
+   * for an approve (omitted for a plain Allow / a Deny). The server whitelists
+   * which fields it merges.
+   */
+  onRespond: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null) => void
   /**
    * #5667 — human label for the session that asked (e.g. "ltl · CLI"),
    * derived by the renderer from the message's `originSessionId`. Rendered as
@@ -91,6 +97,23 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   const availableProviders = useConnectionStore((s) => s.availableProviders)
   const providerSupportsRules = isRuleEligibleProvider(activeProvider, availableProviders)
 
+  // #6543 (feature B): per-hunk pre-write review. Gated on the server's `ide`
+  // capability (features.ide) + a reviewable tool (Write/Edit). When eligible we
+  // PULL the full redacted tool input (the broadcast one is truncated), then
+  // render a diff whose dropped hunks become `editedInput` on Approve.
+  const ideEnabled = useConnectionStore((s) => Boolean(s.serverCapabilities?.ide))
+  const requestPermissionInput = useConnectionStore((s) => s.requestPermissionInput)
+  const pulledInput = useConnectionStore((s) => s.permissionInputs?.[requestId])
+  const reviewEligible = ideEnabled && isReviewableTool(tool)
+  const [editedInput, setEditedInput] = useState<Record<string, string> | null>(null)
+
+  // Pull the input once when a reviewable prompt appears (before it's answered).
+  useEffect(() => {
+    if (reviewEligible && !answered && pulledInput === undefined) {
+      requestPermissionInput(requestId)
+    }
+  }, [reviewEligible, answered, pulledInput, requestPermissionInput, requestId])
+
   useEffect(() => {
     if (intervalRef.current) clearInterval(intervalRef.current)
     setRemaining(remainingMs)
@@ -139,8 +162,9 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     const effective: PermissionDecision =
       decision === 'allowSession' && !allowSessionOk ? 'allow' : decision
     if (intervalRef.current) clearInterval(intervalRef.current)
-    onRespond(requestId, effective)
-  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules, connected])
+    // #6543: carry the per-hunk edits on an approve only (never on deny).
+    onRespond(requestId, effective, effective === 'deny' ? null : editedInput)
+  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules, connected, editedInput])
 
   // #6287 — the Cmd/Ctrl+Y, Cmd/Ctrl+Shift+Y and Escape keyboard shortcuts moved
   // to a SINGLE document-level listener (useChatKeyboard, wired in App.tsx) that
@@ -187,6 +211,18 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
       <div className="perm-desc" id={`perm-desc-${requestId}`}>
         <span className="perm-tool">{tool}</span>: {description || 'Permission requested'}
       </div>
+
+      {/* #6543 (feature B): per-hunk pre-write review for a Write/Edit when
+          features.ide is on. Renders once the pulled input lands; dropped hunks
+          become `editedInput` sent on Approve. A refusal / not-yet-pulled state
+          simply shows no review (the plain Allow/Deny still work). */}
+      {reviewEligible && showButtons && pulledInput?.found && pulledInput.input && (
+        <PreWriteDiffReview
+          tool={tool}
+          input={pulledInput.input as Record<string, unknown>}
+          onEditedInputChange={setEditedInput}
+        />
+      )}
 
       {!answered && (
         <div

--- a/packages/dashboard/src/components/PreWriteDiffReview.test.tsx
+++ b/packages/dashboard/src/components/PreWriteDiffReview.test.tsx
@@ -45,6 +45,15 @@ describe('PreWriteDiffReview (#6543)', () => {
     expect(onChange).toHaveBeenLastCalledWith(null)
   })
 
+  it('#6555: warns clearly when ALL hunks are dropped (empty write)', () => {
+    render(<PreWriteDiffReview tool="Write" input={{ content: 'x\ny\nz' }} onEditedInputChange={vi.fn()} />)
+    const toggles = screen.getAllByTestId('hunk-toggle')
+    toggles.forEach((t) => fireEvent.click(t)) // drop every hunk
+    const hint = screen.getByTestId('prewrite-diff-hint')
+    expect(hint.textContent).toContain('empty file')
+    expect(hint.className).toContain('prewrite-diff-hint-warn')
+  })
+
   it('renders nothing for a non-reviewable tool', () => {
     const { container } = render(<PreWriteDiffReview tool="Bash" input={{ command: 'ls' }} onEditedInputChange={vi.fn()} />)
     expect(container.querySelector('[data-testid="prewrite-diff-review"]')).toBeNull()

--- a/packages/dashboard/src/components/PreWriteDiffReview.test.tsx
+++ b/packages/dashboard/src/components/PreWriteDiffReview.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * PreWriteDiffReview (#6543 PR-3) — the per-hunk pre-write review. Covers the
+ * diff derivation per tool, that dropping a hunk emits the narrowed content on
+ * the ONE whitelisted field, all-kept emits null, and non-reviewable tools
+ * render nothing.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
+
+afterEach(cleanup)
+
+describe('PreWriteDiffReview (#6543)', () => {
+  it('isReviewableTool: Write/Edit are reviewable, others are not', () => {
+    expect(isReviewableTool('Write')).toBe(true)
+    expect(isReviewableTool('Edit')).toBe(true)
+    expect(isReviewableTool('Bash')).toBe(false)
+    expect(isReviewableTool('Read')).toBe(false)
+  })
+
+  it('Edit: diffs old→new; dropping the hunk emits the reduced new_string', () => {
+    const onChange = vi.fn()
+    render(<PreWriteDiffReview tool="Edit" input={{ old_string: 'a\nb\nc', new_string: 'a\nB\nc' }} onEditedInputChange={onChange} />)
+    expect(screen.getByTestId('prewrite-diff-review')).toBeTruthy()
+    const toggles = screen.getAllByTestId('hunk-toggle')
+    expect(toggles.length).toBeGreaterThan(0)
+    fireEvent.click(toggles[0]!) // drop the only hunk → result is the original old_string
+    expect(onChange).toHaveBeenLastCalledWith({ new_string: 'a\nb\nc' })
+  })
+
+  it('Write: diffs ""→content; dropping the hunk emits reduced content', () => {
+    const onChange = vi.fn()
+    render(<PreWriteDiffReview tool="Write" input={{ content: 'x\ny\nz' }} onEditedInputChange={onChange} />)
+    const toggles = screen.getAllByTestId('hunk-toggle')
+    fireEvent.click(toggles[0]!) // drop the all-additions hunk → empty content
+    expect(onChange).toHaveBeenLastCalledWith({ content: '' })
+  })
+
+  it('emits null when every hunk is kept (a plain Allow)', () => {
+    const onChange = vi.fn()
+    render(<PreWriteDiffReview tool="Edit" input={{ old_string: 'a\nb', new_string: 'a\nB' }} onEditedInputChange={onChange} />)
+    const toggle = screen.getAllByTestId('hunk-toggle')[0]!
+    fireEvent.click(toggle) // drop
+    fireEvent.click(toggle) // re-add → all kept again
+    expect(onChange).toHaveBeenLastCalledWith(null)
+  })
+
+  it('renders nothing for a non-reviewable tool', () => {
+    const { container } = render(<PreWriteDiffReview tool="Bash" input={{ command: 'ls' }} onEditedInputChange={vi.fn()} />)
+    expect(container.querySelector('[data-testid="prewrite-diff-review"]')).toBeNull()
+  })
+
+  it('renders nothing when there is no diff (proposed === base)', () => {
+    const { container } = render(<PreWriteDiffReview tool="Write" input={{ content: '' }} onEditedInputChange={vi.fn()} />)
+    expect(container.querySelector('[data-testid="prewrite-diff-review"]')).toBeNull()
+  })
+
+  it('shows a "dropped" hint once a hunk is unchecked', () => {
+    // Changes 12 lines apart → two separate hunks (beyond the 2·context merge window).
+    const lines = Array.from({ length: 13 }, (_, i) => `line${i}`)
+    const edited = [...lines]
+    edited[0] = 'CHANGED0'
+    edited[12] = 'CHANGED12'
+    render(<PreWriteDiffReview tool="Edit" input={{ old_string: lines.join('\n'), new_string: edited.join('\n') }} onEditedInputChange={vi.fn()} />)
+    const toggles = screen.getAllByTestId('hunk-toggle')
+    expect(toggles.length).toBe(2)
+    fireEvent.click(toggles[0]!)
+    expect(screen.getByTestId('prewrite-diff-hint').textContent).toContain('1 hunk dropped')
+  })
+})

--- a/packages/dashboard/src/components/PreWriteDiffReview.tsx
+++ b/packages/dashboard/src/components/PreWriteDiffReview.tsx
@@ -71,12 +71,18 @@ export function PreWriteDiffReview({ tool, input, onEditedInputChange }: PreWrit
   if (!spec || hunks.length === 0) return null
 
   const droppedCount = hunks.length - selected.size
+  const allDropped = selected.size === 0
+  // #6555: dropping EVERY hunk means an empty result (an empty file for Write / a
+  // no-op for Edit) — call that out clearly rather than the generic "narrowed" copy.
+  const hint = allDropped
+    ? `All hunks dropped — Approve writes ${tool === 'Write' ? 'an empty file' : 'no change'}.`
+    : droppedCount === 0
+      ? 'Review the proposed change — uncheck a hunk to drop it from the write.'
+      : `${droppedCount} hunk${droppedCount === 1 ? '' : 's'} dropped — Approve writes the narrowed content.`
   return (
     <div className="prewrite-diff-review" data-testid="prewrite-diff-review">
-      <div className="prewrite-diff-hint" data-testid="prewrite-diff-hint">
-        {droppedCount === 0
-          ? 'Review the proposed change — uncheck a hunk to drop it from the write.'
-          : `${droppedCount} hunk${droppedCount === 1 ? '' : 's'} dropped — Approve writes the narrowed content.`}
+      <div className={`prewrite-diff-hint${allDropped ? ' prewrite-diff-hint-warn' : ''}`} data-testid="prewrite-diff-hint">
+        {hint}
       </div>
       {hunks.map((hunk, i) => (
         <HunkView

--- a/packages/dashboard/src/components/PreWriteDiffReview.tsx
+++ b/packages/dashboard/src/components/PreWriteDiffReview.tsx
@@ -57,15 +57,19 @@ export function PreWriteDiffReview({ tool, input, onEditedInputChange }: PreWrit
   }, [hunks])
 
   // Emit on toggle (NOT in a render effect) so a non-memoized parent callback
-  // can't cause a render loop. `selected` is read from the closure — fine for a
-  // human clicking one hunk at a time.
+  // can't cause a render loop. The new set is derived from the updater's `prev`
+  // (always authoritative, even under React batching) — not the render closure —
+  // so rapid toggles can't compute from a stale selection.
   function toggle(i: number) {
-    const next = new Set(selected)
-    if (next.has(i)) next.delete(i)
-    else next.add(i)
-    setSelected(next)
-    const allKept = next.size === hunks.length
-    onEditedInputChange(allKept ? null : { [spec!.field]: applyHunks(base, hunks, next) })
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(i)) next.delete(i)
+      else next.add(i)
+      const allKept = next.size === hunks.length
+      // Idempotent (parent setState); StrictMode's dev double-invoke is harmless.
+      onEditedInputChange(allKept ? null : { [spec!.field]: applyHunks(base, hunks, next) })
+      return next
+    })
   }
 
   if (!spec || hunks.length === 0) return null

--- a/packages/dashboard/src/components/PreWriteDiffReview.tsx
+++ b/packages/dashboard/src/components/PreWriteDiffReview.tsx
@@ -1,0 +1,93 @@
+/**
+ * PreWriteDiffReview (#6543 PR-3, IDE P3 feature B) — the per-hunk pre-write
+ * review rendered inside a Write/Edit permission prompt. It turns the agent's
+ * proposed edit into a diff, lets the operator drop individual hunks, and hands
+ * the narrowed content back as an `editedInput` the prompt sends on Approve.
+ *
+ * Wires the whole feature-B stack together:
+ *   - the pulled tool input (#6550 `get_permission_input`),
+ *   - the client differ (#6546 `computeHunks`/`applyHunks`),
+ *   - the selectable hunk component (#6548 `HunkView`),
+ *   - the server merge whitelist (#6552) — which is why we only ever emit the
+ *     ONE content field per tool (Write→`content`, Edit→`new_string`); the
+ *     server ignores anything else, so the path can't be redirected here either.
+ *
+ * The diff base: Edit is self-contained (`old_string → new_string`); Write is
+ * `'' → content` (review the whole proposed body; a disk-diff base is a
+ * follow-up). Emits `null` when every hunk is kept (no edit → a plain Allow).
+ */
+import { useEffect, useMemo, useState } from 'react'
+import { computeHunks, applyHunks } from '@chroxy/store-core'
+import { HunkView } from './DiffViewerPanel'
+
+type ToolInput = Record<string, unknown>
+
+/** Per-tool: the substitutable content field + how to derive the diff sides. */
+const TOOL_DIFF: Record<string, { field: string; base: (i: ToolInput) => string; proposed: (i: ToolInput) => string }> = {
+  Write: { field: 'content', base: () => '', proposed: (i) => String(i.content ?? '') },
+  Edit: { field: 'new_string', base: (i) => String(i.old_string ?? ''), proposed: (i) => String(i.new_string ?? '') },
+}
+
+/** Whether a tool has a per-hunk pre-write review (drives the prompt's gate). */
+export function isReviewableTool(tool: string): boolean {
+  return Object.prototype.hasOwnProperty.call(TOOL_DIFF, tool)
+}
+
+export interface PreWriteDiffReviewProps {
+  tool: string
+  input: ToolInput
+  /** Called with the narrowed `editedInput` (or `null` when all hunks are kept). */
+  onEditedInputChange: (editedInput: Record<string, string> | null) => void
+}
+
+export function PreWriteDiffReview({ tool, input, onEditedInputChange }: PreWriteDiffReviewProps) {
+  const spec = TOOL_DIFF[tool]
+  const { base, hunks } = useMemo(() => {
+    if (!spec) return { base: '', hunks: [] }
+    const b = spec.base(input)
+    return { base: b, hunks: computeHunks(b, spec.proposed(input)) }
+  }, [spec, input])
+
+  // All hunks kept by default. Reset when the diff changes (new prompt/input).
+  const [selected, setSelected] = useState<Set<number>>(() => new Set(hunks.map((_, i) => i)))
+  useEffect(() => {
+    setSelected(new Set(hunks.map((_, i) => i)))
+    onEditedInputChange(null) // fresh prompt → no edit until the operator drops a hunk
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hunks])
+
+  // Emit on toggle (NOT in a render effect) so a non-memoized parent callback
+  // can't cause a render loop. `selected` is read from the closure — fine for a
+  // human clicking one hunk at a time.
+  function toggle(i: number) {
+    const next = new Set(selected)
+    if (next.has(i)) next.delete(i)
+    else next.add(i)
+    setSelected(next)
+    const allKept = next.size === hunks.length
+    onEditedInputChange(allKept ? null : { [spec!.field]: applyHunks(base, hunks, next) })
+  }
+
+  if (!spec || hunks.length === 0) return null
+
+  const droppedCount = hunks.length - selected.size
+  return (
+    <div className="prewrite-diff-review" data-testid="prewrite-diff-review">
+      <div className="prewrite-diff-hint" data-testid="prewrite-diff-hint">
+        {droppedCount === 0
+          ? 'Review the proposed change — uncheck a hunk to drop it from the write.'
+          : `${droppedCount} hunk${droppedCount === 1 ? '' : 's'} dropped — Approve writes the narrowed content.`}
+      </div>
+      {hunks.map((hunk, i) => (
+        <HunkView
+          key={i}
+          hunk={hunk}
+          viewMode="unified"
+          selectable
+          selected={selected.has(i)}
+          onToggle={() => toggle(i)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -126,7 +126,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           tool={storeMsg.tool || 'Unknown'}
           description={storeMsg.content}
           remainingMs={remainingMs}
-          onRespond={(reqId, decision) => sendPermissionResponse(reqId, decision)}
+          onRespond={(reqId, decision, editedInput) => sendPermissionResponse(reqId, decision, editedInput)}
           sessionLabel={buildSessionLabel(storeMsg.originSessionId, sessions)}
         />
       )

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -189,6 +189,34 @@ describe('#6308 — dashboard sendPermissionResponse', () => {
     const prompt = ss.messages.find((m) => m.requestId === 'req-1')
     expect(prompt?.answered).toBe('allow')
   })
+
+  it('#6543: an approve carries editedInput on the wire; plain allow / deny omit it', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          messages: [{ id: 'p1', type: 'prompt', requestId: 'req-1', tool: 'Write', timestamp: 1 }],
+        } as unknown as SessionState,
+      },
+      sessionNotifications: [],
+      socket,
+    } as never)
+    const last = () => sent[sent.length - 1] as { decision?: string; editedInput?: unknown }
+
+    useConnectionStore.getState().sendPermissionResponse('req-1', 'allow', { content: 'edited' })
+    expect(last().decision).toBe('allow')
+    expect(last().editedInput).toEqual({ content: 'edited' })
+
+    useConnectionStore.getState().sendPermissionResponse('req-1', 'allow') // plain Allow
+    expect(last().editedInput).toBeUndefined()
+
+    useConnectionStore.getState().sendPermissionResponse('req-1', 'deny', { content: 'x' }) // deny drops it
+    expect(last().editedInput).toBeUndefined()
+  })
 })
 
 describe('#6308 — dashboard sendInterrupt / sendUserQuestionResponse', () => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3075,7 +3075,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       type: 'permission_response',
       requestId,
       decision: wireDecision,
-      ...(editedInput && wireDecision !== 'deny' ? { editedInput } : {}),
+      ...(editedInput && Object.keys(editedInput).length > 0 && wireDecision !== 'deny' ? { editedInput } : {}),
     };
     // #6308: the socket can flip OPEN → CLOSING before this synchronous send (wsSend
     // → false). Bail BEFORE markPermissionResolved/markPromptAnswered — otherwise the

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3048,7 +3048,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
-  sendPermissionResponse: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {
+  sendPermissionResponse: (requestId: string, decision: 'allow' | 'deny' | 'allowSession', editedInput?: Record<string, string> | null) => {
     const { socket } = get();
     // #5699 — refuse to answer a permission prompt while disconnected. A
     // permission request is NOT safely queueable: the server expires the pending
@@ -3068,7 +3068,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // is implemented client-side via a follow-up set_permission_rules message
     // (the schema only accepts 'allow' | 'allowAlways' | 'deny').
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
-    const payload = { type: 'permission_response', requestId, decision: wireDecision };
+    // #6543 (feature B): the operator's per-hunk edits ride along on an approve.
+    // Only sent when present (a plain Allow omits it); the server whitelists
+    // which fields it can substitute (permission-manager.js mergeEditedInput).
+    const payload = {
+      type: 'permission_response',
+      requestId,
+      decision: wireDecision,
+      ...(editedInput && wireDecision !== 'deny' ? { editedInput } : {}),
+    };
     // #6308: the socket can flip OPEN → CLOSING before this synchronous send (wsSend
     // → false). Bail BEFORE markPermissionResolved/markPromptAnswered — otherwise the
     // bubble flips to "answered" while the server never saw the frame and auto-denies

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1356,7 +1356,7 @@ export interface ConnectionState {
    * payload, or rejects on disconnect / 60s timeout. Errors from the server
    * arrive as the `error` field on the resolved value, not as a Promise reject. */
   evaluateDraft: (draft: string) => Promise<EvaluatorResultPayload>;
-  sendPermissionResponse: (requestId: string, decision: PermissionDecision) => 'sent' | 'queued' | false;
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null) => 'sent' | 'queued' | false;
   /** Mark a permission request as resolved in the store (separate from the
    * wire-level response). Used by PermissionPrompt to render its answered
    * state across remounts (#2833). Safe to call for an already-resolved

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3356,6 +3356,11 @@ button.sidebar-token-view-session-row:hover {
   background: var(--bg-header);
 }
 
+/* #6555: all-hunks-dropped writes an empty/no-op result — flag it. */
+.prewrite-diff-hint-warn {
+  color: var(--accent-orange);
+}
+
 .perm-buttons {
   display: flex;
   gap: 8px;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3335,6 +3335,27 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-purple);
 }
 
+/* #6543 (feature B): per-hunk pre-write review inside a Write/Edit permission
+ * prompt — a bounded, scrollable diff whose hunk toggles narrow the write. */
+.prewrite-diff-review {
+  margin: 8px 0;
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.prewrite-diff-hint {
+  padding: 6px 12px;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  position: sticky;
+  top: 0;
+  background: var(--bg-header);
+}
+
 .perm-buttons {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## What — the capstone that makes feature B usable

When a **Write/Edit** permission prompt arrives and **`features.ide`** is on, the prompt now shows a **per-hunk pre-write diff**. The operator can uncheck hunks to drop them, and **Approve** writes the narrowed content. This wires the whole edit-in-place stack into one UI:

- pulls the full tool input (#6550 `get_permission_input`),
- diffs the proposed change (#6546 `computeHunks`/`applyHunks`),
- renders selectable hunks (#6548 `HunkView`),
- sends the narrowed content as `editedInput` (#6552 server merge — which whitelists the fields, so a dropped hunk narrows the write but **never** redirects the path).

## Pieces
| File | Change |
|---|---|
| `PreWriteDiffReview.tsx` (new) | per-tool diff (Edit: `old_string→new_string`; Write: `''→content`), selectable hunks, `applyHunks` → `editedInput` on the ONE whitelisted content field. Emits `null` when all hunks are kept (a plain Allow). |
| `PermissionPrompt.tsx` | gated on `serverCapabilities.ide` + a reviewable tool; pulls the input on appearance; threads `editedInput` through `onRespond` on approve (null on deny). |
| `connection.ts` / `types.ts` | `sendPermissionResponse` gains an optional `editedInput` that rides the wire **only** on an approve; `useMessageRenderer` forwards it. |

## Tests
- `PreWriteDiffReview`: diff derivation per tool, dropping a hunk emits the reduced content, all-kept emits `null`, non-reviewable tool / no-diff render nothing.
- `PermissionPrompt`: `onRespond` arg threading (editedInput 3rd arg).
- Store **wire test**: an approve carries `editedInput`; a plain allow / a deny omit it.
- Full dashboard suite **4239 green** + typecheck + CSS style-lints. No protocol/server change (`editedInput` landed in #6552).

## ⚠️ Needs your eye (visual)
The diff-in-prompt **look and feel** can't be verified by tests — flagging for your live check (needs a daemon on this branch + `features.ide` + a Write/Edit prompt). **PR-4 (mobile)** is the last slice of feature B.

Part of #6543 · epic #6469 · design basis #6529