### PR TITLE
feat(app): mobile pre-write-diff review for Write/Edit permission prompts (#6543)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the mobile `permission_input` feeder (#6543 PR-4, IDE P3 feature B).
+ *
+ * The dashboard shipped the editable pre-write-diff first: a permission prompt
+ * pulls the FULL (secret-redacted) tool input via `get_permission_input`, and the
+ * server replies with a single `permission_input` message that lands in
+ * `permissionInputs[requestId]`. PR-4 brings the mobile app to parity — its
+ * `handleMessage` switch gains a `case 'permission_input':` that mirrors the
+ * dashboard handler exactly: Zod-validate → `set({ permissionInputs: { ...prev,
+ * [requestId]: data } })`, dropping malformed messages.
+ *
+ * These tests exercise the production wire path: dispatch a message through
+ * `_testMessageHandler.handle` and assert on the resulting `state.permissionInputs`
+ * map — the same slice the mobile pre-write-diff UI reads. Mirrors the dashboard's
+ * dispatch-permission-input.test.ts so both clients are behaviour-verified.
+ */
+import {
+  _testMessageHandler,
+  _testResetStore,
+  setStore,
+} from '../../store/message-handler';
+import type { ConnectionState } from '../../store/types';
+
+// Mock persistence so the handler's imports resolve without touching disk.
+jest.mock('../../store/persistence', () => ({
+  clearPersistedSession: jest.fn(() => Promise.resolve()),
+  persistSessionMessages: jest.fn(),
+  persistViewMode: jest.fn(),
+  persistActiveSession: jest.fn(),
+  persistTerminalBuffer: jest.fn(),
+  loadPersistedState: jest.fn(),
+  loadSessionMessages: jest.fn(),
+  clearPersistedState: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+/** Minimal mock Zustand store seeding `permissionInputs` with an empty map. */
+function createMockStore(initialInputs: Record<string, unknown> = {}) {
+  let state = { permissionInputs: initialInputs } as unknown as ConnectionState;
+  return {
+    store: {
+      getState: () => state,
+      setState: (
+        updater: Partial<ConnectionState> | ((s: ConnectionState) => Partial<ConnectionState>),
+      ) => {
+        state = typeof updater === 'function'
+          ? { ...state, ...updater(state) }
+          : { ...state, ...updater };
+      },
+      subscribe: () => () => {},
+      destroy: () => {},
+    },
+    current: () => state,
+  };
+}
+
+function createMockContext() {
+  return {
+    socket: { readyState: 1, send: jest.fn() } as any,
+    serverUrl: 'wss://test.example.com',
+    apiToken: 'test-token',
+    connectionId: 'test-conn-1',
+    reconnecting: false,
+    connectedAt: Date.now(),
+    isSessionSwitchReplay: false,
+    activeSessionIdAtConnect: null,
+    replayingSessions: new Set<string>(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// Clear BOTH the module-level store + context refs after each test so this suite
+// can't leak state into other test files (order-dependent failures) — same
+// hygiene as the #6247 activity feeder suite.
+afterEach(() => {
+  _testResetStore();
+  _testMessageHandler.setContext(null as never);
+});
+
+describe('permission_input feeder (#6543 PR-4)', () => {
+  it('stores a found:true permission_input keyed by requestId', () => {
+    const { store, current } = createMockStore();
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_input',
+      requestId: 'r1',
+      found: true,
+      tool: 'Write',
+      input: { file_path: '/x', content: 'a\nb' },
+    });
+
+    const pulled = current().permissionInputs.r1 as Record<string, unknown>;
+    expect(pulled).toBeDefined();
+    expect(pulled.found).toBe(true);
+    expect(pulled.tool).toBe('Write');
+    expect(pulled.input).toEqual({ file_path: '/x', content: 'a\nb' });
+  });
+
+  it('stores a found:false permission_input (unavailable, carries error)', () => {
+    const { store, current } = createMockStore();
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_input',
+      requestId: 'r2',
+      found: false,
+      error: { code: 'NOT_PENDING', message: 'gone' },
+    });
+
+    const pulled = current().permissionInputs.r2 as Record<string, unknown>;
+    expect(pulled).toBeDefined();
+    expect(pulled.found).toBe(false);
+    expect(pulled.error).toEqual({ code: 'NOT_PENDING', message: 'gone' });
+  });
+
+  it('does not clobber a prior entry for a different requestId', () => {
+    const { store, current } = createMockStore();
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'permission_input',
+      requestId: 'r1',
+      found: true,
+      tool: 'Write',
+      input: { file_path: '/a', content: 'first' },
+    });
+    _testMessageHandler.handle({
+      type: 'permission_input',
+      requestId: 'r2',
+      found: true,
+      tool: 'Edit',
+      input: { file_path: '/b', old_string: 'x', new_string: 'y' },
+    });
+
+    expect(current().permissionInputs.r1).toBeDefined();
+    expect(current().permissionInputs.r2).toBeDefined();
+    expect((current().permissionInputs.r1 as Record<string, unknown>).tool).toBe('Write');
+    expect((current().permissionInputs.r2 as Record<string, unknown>).tool).toBe('Edit');
+  });
+
+  it('drops a malformed permission_input (missing found) without throwing or mutating', () => {
+    const seeded = {};
+    const { store, current } = createMockStore(seeded);
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    expect(() =>
+      _testMessageHandler.handle({ type: 'permission_input', requestId: 'r3' }),
+    ).not.toThrow();
+
+    // No-op: the seeded map reference is untouched (parse failed before any set).
+    expect(current().permissionInputs).toBe(seeded);
+    expect(current().permissionInputs.r3).toBeUndefined();
+  });
+});

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -48,7 +48,10 @@ export interface ChatViewProps {
    * (`answer: <otherLabel>, freeformText`). See
    * `MessageBubble.SelectOptionValue` for the union type.
    */
-  onSelectOption: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
+  // #6543 (feature B): the optional 5th `editedInput` carries a Write/Edit
+  // pre-write-diff narrowing straight through to SessionScreen's handler (ChatView
+  // forwards the ref unchanged); null/omitted for every other prompt.
+  onSelectOption: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string, editedInput?: Record<string, string> | null) => void;
   /**
    * #4973 — submit handler for the multi-question AskUserQuestion form.
    * Fires with the per-question answers map; SessionScreen forwards it to

--- a/packages/app/src/components/PreWriteDiffReview.tsx
+++ b/packages/app/src/components/PreWriteDiffReview.tsx
@@ -1,0 +1,120 @@
+/**
+ * PreWriteDiffReview (#6543 PR-4, IDE P3 feature B) — the mobile per-hunk
+ * pre-write review rendered inside a Write/Edit permission prompt. It turns the
+ * agent's proposed edit into a diff, lets the operator drop individual hunks, and
+ * hands the narrowed content back as an `editedInput` the prompt sends on Approve.
+ * The React-Native mirror of the dashboard's PreWriteDiffReview.
+ *
+ * Wires the feature-B stack together on mobile:
+ *   - the pulled tool input (#6550 `get_permission_input` → `permissionInputs`),
+ *   - the client differ (#6546 `computeHunks`/`applyHunks`),
+ *   - the selectable hunk component (#6548 `DiffHunkView`),
+ *   - the server merge whitelist (#6552) — which is why we only ever emit the ONE
+ *     content field per tool (Write→`content`, Edit→`new_string`); the server
+ *     ignores anything else, so the path can't be redirected here either.
+ *
+ * The diff base: Edit is self-contained (`old_string → new_string`); Write is
+ * `'' → content` (review the whole proposed body; a disk-diff base is a
+ * follow-up). Emits `null` when every hunk is kept (no edit → a plain Allow).
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { computeHunks, applyHunks } from '@chroxy/store-core';
+import { DiffHunkView } from './DiffViewer';
+import { COLORS } from '../constants/colors';
+
+type ToolInput = Record<string, unknown>;
+
+/** Per-tool: the substitutable content field + how to derive the diff sides. */
+const TOOL_DIFF: Record<string, { field: string; base: (i: ToolInput) => string; proposed: (i: ToolInput) => string }> = {
+  Write: { field: 'content', base: () => '', proposed: (i) => String(i.content ?? '') },
+  Edit: { field: 'new_string', base: (i) => String(i.old_string ?? ''), proposed: (i) => String(i.new_string ?? '') },
+};
+
+/** Whether a tool has a per-hunk pre-write review (drives the prompt's gate). */
+export function isReviewableTool(tool: string | undefined | null): boolean {
+  return !!tool && Object.prototype.hasOwnProperty.call(TOOL_DIFF, tool);
+}
+
+export interface PreWriteDiffReviewProps {
+  tool: string;
+  input: ToolInput;
+  /** Called with the narrowed `editedInput` (or `null` when all hunks are kept). */
+  onEditedInputChange: (editedInput: Record<string, string> | null) => void;
+}
+
+export function PreWriteDiffReview({ tool, input, onEditedInputChange }: PreWriteDiffReviewProps) {
+  const spec = TOOL_DIFF[tool];
+  const { base, hunks } = useMemo(() => {
+    if (!spec) return { base: '', hunks: [] };
+    const b = spec.base(input);
+    return { base: b, hunks: computeHunks(b, spec.proposed(input)) };
+  }, [spec, input]);
+
+  // All hunks kept by default. Reset when the diff changes (new prompt/input).
+  const [selected, setSelected] = useState<Set<number>>(() => new Set(hunks.map((_, i) => i)));
+  useEffect(() => {
+    setSelected(new Set(hunks.map((_, i) => i)));
+    onEditedInputChange(null); // fresh prompt → no edit until the operator drops a hunk
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hunks]);
+
+  // Emit on toggle (NOT in a render effect) so a non-memoized parent callback
+  // can't cause a render loop. The new set is derived from the updater's `prev`
+  // (always authoritative, even under React batching) — not the render closure —
+  // so rapid toggles can't compute from a stale selection.
+  function toggle(i: number) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      const allKept = next.size === hunks.length;
+      onEditedInputChange(allKept ? null : { [spec!.field]: applyHunks(base, hunks, next) });
+      return next;
+    });
+  }
+
+  if (!spec || hunks.length === 0) return null;
+
+  const droppedCount = hunks.length - selected.size;
+  const allDropped = selected.size === 0;
+  // #6555: dropping EVERY hunk means an empty result (an empty file for Write / a
+  // no-op for Edit) — call that out clearly rather than the generic "narrowed" copy.
+  const hint = allDropped
+    ? `All hunks dropped — Approve writes ${tool === 'Write' ? 'an empty file' : 'no change'}.`
+    : droppedCount === 0
+      ? 'Review the proposed change — uncheck a hunk to drop it from the write.'
+      : `${droppedCount} hunk${droppedCount === 1 ? '' : 's'} dropped — Approve writes the narrowed content.`;
+
+  return (
+    <View style={styles.container} testID="prewrite-diff-review">
+      <Text style={[styles.hint, allDropped && styles.hintWarn]} testID="prewrite-diff-hint">
+        {hint}
+      </Text>
+      {hunks.map((hunk, i) => (
+        <DiffHunkView
+          key={i}
+          hunk={hunk}
+          selectable
+          selected={selected.has(i)}
+          onToggle={() => toggle(i)}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 8,
+    gap: 6,
+  },
+  hint: {
+    fontSize: 12,
+    color: COLORS.textSecondary,
+    marginBottom: 4,
+  },
+  hintWarn: {
+    color: COLORS.accentOrange,
+  },
+});

--- a/packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx
@@ -202,6 +202,9 @@ describe('MessageBubble Other / freeform answer (#4755)', () => {
       'q-1',
       undefined,
       'toolu_other_freeform',
+      // #6543 (feature B): the option-button path now forwards `editedInput` —
+      // `null` here (this prompt isn't a Write/Edit pre-write-diff review).
+      null,
     );
   });
 });

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -561,7 +561,7 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
           on (serverCapabilities.ide), the tool is reviewable (Write/Edit), and the
           pulled input has landed. Dropped hunks become `editedInput` sent on
           Approve. A refusal / not-yet-pulled state renders nothing (plain Allow). */}
-      {reviewEligible && showOptionButtons && pulledInput?.found && pulledInput.input && (
+      {reviewEligible && showOptionButtons && message.answered == null && !isExpired && pulledInput?.found && pulledInput.input && (
         <PreWriteDiffReview
           tool={message.tool ?? ''}
           input={pulledInput.input as Record<string, unknown>}

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -22,6 +22,7 @@ import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { FormattedResponse } from '../MarkdownRenderer';
 import { PermissionDetailOrFallback, PermissionCountdown, PermissionPill, permissionStyles } from '../PermissionDetail';
+import { PreWriteDiffReview, isReviewableTool } from '../PreWriteDiffReview';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { ToolBubble } from './ToolBubble';
 import { StreamStallChip } from '../StreamStallChip';
@@ -83,7 +84,11 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
   queued?: boolean;
   /** #5938 — cancel this queued follow-up by its message id before it flushes. */
   onCancelQueued?: (id: string) => void;
-  onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
+  // #6543 (feature B): `editedInput` carries the operator's per-hunk narrowing
+  // from a Write/Edit pre-write-diff review — sent on an Approve so the server
+  // writes only the kept hunks. `null`/omitted = no narrowing (a plain response);
+  // the store's sendPermissionResponse drops it for a deny regardless.
+  onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string, editedInput?: Record<string, string> | null) => void;
   /**
    * #4973 — submit handler for the multi-question form. Fires with the
    * per-question answers map (`Record<string, string | string[]>`) plus
@@ -196,6 +201,27 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
   const promptSessionLabel = useConnectionStore((s) =>
     buildPromptSessionLabel(message.originSessionId, s.sessions),
   );
+
+  // #6543 (feature B): per-hunk pre-write review. Gated on the server's `ide`
+  // capability (features.ide) + a reviewable tool (Write/Edit), mirroring the
+  // dashboard's PermissionPrompt. When eligible, pull the full (secret-redacted)
+  // tool input via `get_permission_input` and render a diff whose dropped hunks
+  // become `editedInput` on Approve.
+  const ideEnabled = useConnectionStore((s) => Boolean(s.serverCapabilities?.ide));
+  const requestPermissionInput = useConnectionStore((s) => s.requestPermissionInput);
+  const pulledInput = useConnectionStore((s) =>
+    message.requestId ? s.permissionInputs?.[message.requestId] : undefined,
+  );
+  const reviewEligible = isPrompt && ideEnabled && isReviewableTool(message.tool);
+  const [editedInput, setEditedInput] = useState<Record<string, string> | null>(null);
+
+  // Pull the full tool input once per eligible, unanswered prompt (idempotent —
+  // gated on `pulledInput === undefined` so a re-render doesn't re-request).
+  useEffect(() => {
+    if (reviewEligible && message.requestId && message.answered == null && pulledInput === undefined) {
+      requestPermissionInput(message.requestId);
+    }
+  }, [reviewEligible, message.requestId, message.answered, pulledInput, requestPermissionInput]);
 
   // Reset "Other" UI mode when the prompt becomes answered (#3746 review).
   // Without this, otherActive would stay true after an answer arrives from
@@ -530,6 +556,18 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
           </View>
         </View>
       )}
+      {/* #6543 (feature B): the per-hunk pre-write diff review — rendered between
+          the permission detail and the option buttons, only when features.ide is
+          on (serverCapabilities.ide), the tool is reviewable (Write/Edit), and the
+          pulled input has landed. Dropped hunks become `editedInput` sent on
+          Approve. A refusal / not-yet-pulled state renders nothing (plain Allow). */}
+      {reviewEligible && showOptionButtons && pulledInput?.found && pulledInput.input && (
+        <PreWriteDiffReview
+          tool={message.tool ?? ''}
+          input={pulledInput.input as Record<string, unknown>}
+          onEditedInputChange={setEditedInput}
+        />
+      )}
       {showOptionButtons && (
         <View style={styles.promptOptions}>
           {message.options!.map((opt, i) => {
@@ -583,7 +621,11 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
                   // tunnel) fires two user_question_response messages.
                   if (submittedRef.current) return;
                   submittedRef.current = true;
-                  onSelectOption?.(opt.value, message.id, message.requestId, message.toolUseId);
+                  // #6543 (feature B): forward the per-hunk narrowing on an
+                  // Approve. `editedInput` is null for non-reviewable prompts and
+                  // when every hunk is kept; the store's sendPermissionResponse
+                  // drops it for a deny, so passing it unconditionally is safe.
+                  onSelectOption?.(opt.value, message.id, message.requestId, message.toolUseId, editedInput);
                 }}
               >
                 <Text style={[

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -913,6 +913,10 @@ export function SessionScreen() {
     messageId: string,
     requestId?: string,
     toolUseId?: string,
+    // #6543 (feature B): the operator's per-hunk narrowing from a Write/Edit
+    // pre-write-diff review, forwarded to sendPermissionResponse (which drops it
+    // for a deny). Null/omitted for every non-reviewable prompt.
+    editedInput?: Record<string, string> | null,
   ) => {
     // #4875: shared `isFreeformAnswer` guard from @chroxy/store-core
     // narrows `value` to `OtherFreeformAnswer` in the true branch, so the
@@ -929,7 +933,9 @@ export function SessionScreen() {
       // Permission responses are decision strings ('allow' / 'deny' / etc.)
       // and never carry an Other / freeform payload — the freeform branch
       // is defence-in-depth only; in practice this site sees `string`.
-      sent = sendPermissionResponse(requestId, freeform ? value.freeformText : value);
+      // #6543 (feature B): forward the pre-write-diff narrowing (null for
+      // non-reviewable prompts; the store drops it for a deny).
+      sent = sendPermissionResponse(requestId, freeform ? value.freeformText : value, editedInput);
     } else {
       const literal = freeform ? value.freeformText : value;
       sent = sendInput(hasTerminal ? literal + '\r' : literal);

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -513,6 +513,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   sessions: [],
   activeSessionId: null,
   sessionStates: {},
+  // #6543 (feature B): pulled full redacted tool inputs keyed by requestId.
+  permissionInputs: {},
+  // #6543 (feature B): server capability map from auth_ok; gates the pre-write diff.
+  serverCapabilities: {},
   activity: createEmptyActivityState(),
   availableModels: [],
   defaultModelId: null,
@@ -1861,7 +1865,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  sendPermissionResponse: (requestId: string, decision: string) => {
+  sendPermissionResponse: (requestId: string, decision: string, editedInput?: Record<string, string> | null) => {
     const { socket } = get();
     // #5699 — refuse to answer a permission prompt while disconnected, rather
     // than queuing it. The server EXPIRES the pending request the moment the
@@ -1873,7 +1877,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (!socket || socket.readyState !== WebSocket.OPEN) return false;
     // allowSession: send immediate 'allow' unblock + register a session rule for auto-approval
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
-    const payload = { type: 'permission_response', requestId, decision: wireDecision };
+    // #6543 (feature B): the operator's per-hunk edits ride on an approve only,
+    // and only when non-empty. The server whitelists which fields it substitutes.
+    const payload = {
+      type: 'permission_response',
+      requestId,
+      decision: wireDecision,
+      ...(editedInput && Object.keys(editedInput).length > 0 && wireDecision !== 'deny' ? { editedInput } : {}),
+    };
     if (wireDecision === 'deny') hapticWarning(); else hapticMedium();
     // #6308: the socket can flip OPEN → CLOSING before this synchronous send, so
     // wsSend can throw and return false. Bail BEFORE marking the prompt answered —
@@ -1925,6 +1936,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       }
     }
     return result;
+  },
+
+  // #6543 (feature B): pull the full redacted tool input for a pending permission
+  // so the mobile prompt can render a per-hunk pre-write diff. The reply is a
+  // single `permission_input` handled into `permissionInputs[requestId]`.
+  requestPermissionInput: (requestId: string): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'get_permission_input', requestId });
+      return true;
+    }
+    return false;
   },
 
   sendUserQuestionResponse: (

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -143,7 +143,7 @@ import { PROTOCOL_VERSION } from '@chroxy/protocol';
 // store-core reducer so a malformed payload is dropped, not crashed on (same
 // pattern the dashboard feeder uses). Resolved via the jest moduleNameMapper
 // `^@chroxy/protocol/schemas$` and the protocol package's `./schemas` export.
-import { ServerActivitySnapshotSchema, ServerActivityDeltaSchema } from '@chroxy/protocol/schemas';
+import { ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerPermissionInputSchema } from '@chroxy/protocol/schemas';
 import { hapticSuccess } from '../utils/haptics';
 import type {
   ChatMessage,
@@ -1869,6 +1869,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         restartEtaMs: null,
         restartingSince: null,
         webFeatures: auth.webFeatures,
+        // #6543 (feature B): the server's advertised capability map (`{ ide, … }`),
+        // parsed from `msg.capabilities` by the shared handleAuthOk. Gates the
+        // mobile pre-write-diff review, mirroring the dashboard's serverCapabilities.
+        serverCapabilities: auth.serverCapabilities,
       };
       if (ctx.isReconnect) {
         set(connectedState);
@@ -3540,6 +3544,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // live short-circuit for activity_delta, whose reducer returns the SAME ref
     // on a no-op); kept for symmetry with the delta case + the dashboard feeder.
     // This makes #6245's read-only MissionControlScreen go live.
+    // #6543 (IDE P3 feature B) — `permission_input`: store the pulled full
+    // (secret-redacted) tool input keyed by requestId so the mobile permission
+    // prompt can build a per-hunk pre-write diff. Zod-validated (drop-on-
+    // malformed). Both `found:true` (carries `input`/`tool`) and `found:false`
+    // (carries `error`) are stored — the UI distinguishes "not fetched" (absent)
+    // from "unavailable" (found:false). Mirrors the dashboard handler.
+    case 'permission_input': {
+      const parsed = ServerPermissionInputSchema.safeParse(msg);
+      if (!parsed.success) return;
+      set({ permissionInputs: { ...get().permissionInputs, [parsed.data.requestId]: parsed.data } });
+      return;
+    }
+
     case 'activity_snapshot': {
       const parsed = ServerActivitySnapshotSchema.safeParse(msg);
       if (!parsed.success) return;

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -297,6 +297,15 @@ export interface ModelsAndPermissionsData {
   availableProviders: ProviderInfo[];
   // Pending auto permission mode confirmation from server
   pendingPermissionConfirm: PendingPermissionConfirm | null;
+  // #6543 (feature B): pulled full (secret-redacted) tool inputs for pre-write
+  // diffs, keyed by requestId. Fed by the `permission_input` reply to a
+  // `get_permission_input` pull (see requestPermissionInput).
+  permissionInputs: Record<string, ServerPermissionInputMessage>;
+  // #6543 (feature B): the server's advertised capability map from `auth_ok`
+  // (`{ ide: true, … }`). Gates the mobile pre-write-diff review to servers with
+  // `features.ide` on, mirroring the dashboard's `serverCapabilities?.ide` gate.
+  // Absent/non-object capabilities parse to `{}` (no advertised capabilities).
+  serverCapabilities: Record<string, boolean>;
 }
 
 /**
@@ -496,17 +505,8 @@ export interface MessageInputActions {
   // (no server confirm/dequeue will arrive), so it can't linger forever.
   clearOptimisticQueuedMessage: (clientMessageId: string, sessionId?: string) => void;
   sendPermissionResponse: (requestId: string, decision: string, editedInput?: Record<string, string> | null) => 'sent' | 'queued' | false;
-  /** #6543 (feature B): pulled full redacted tool inputs for pre-write diffs, keyed by requestId. */
-  permissionInputs: Record<string, ServerPermissionInputMessage>;
-  /** #6543: pull the full redacted tool input for a pending permission. */
+  /** #6543: pull the full redacted tool input for a pending permission (a `permission_input` reply lands in `permissionInputs`). */
   requestPermissionInput: (requestId: string) => boolean;
-  /**
-   * #6543 (feature B): the server's advertised capability map from `auth_ok`
-   * (`{ ide: true, … }`). Gates the mobile pre-write-diff review to servers with
-   * `features.ide` on, mirroring the dashboard's `serverCapabilities?.ide` gate.
-   * Absent/non-object capabilities parse to `{}` (no advertised capabilities).
-   */
-  serverCapabilities: Record<string, boolean>;
   /**
    * Send a `user_question_response` answer to the server.
    *

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -11,7 +11,7 @@
 
 // #6453 — canonical WIRE attachment type for the sendInput signature (was an
 // inline `{ type; mediaType; data; name }[]`; the app only sends binary).
-import type { BinaryAttachment } from '@chroxy/protocol';
+import type { BinaryAttachment, ServerPermissionInputMessage } from '@chroxy/protocol';
 
 // Re-export shared protocol types from store-core
 export type {
@@ -495,7 +495,18 @@ export interface MessageInputActions {
   // #6451 — locally drop an optimistic 'Queued' badge whose send failed outright
   // (no server confirm/dequeue will arrive), so it can't linger forever.
   clearOptimisticQueuedMessage: (clientMessageId: string, sessionId?: string) => void;
-  sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
+  sendPermissionResponse: (requestId: string, decision: string, editedInput?: Record<string, string> | null) => 'sent' | 'queued' | false;
+  /** #6543 (feature B): pulled full redacted tool inputs for pre-write diffs, keyed by requestId. */
+  permissionInputs: Record<string, ServerPermissionInputMessage>;
+  /** #6543: pull the full redacted tool input for a pending permission. */
+  requestPermissionInput: (requestId: string) => boolean;
+  /**
+   * #6543 (feature B): the server's advertised capability map from `auth_ok`
+   * (`{ ide: true, … }`). Gates the mobile pre-write-diff review to servers with
+   * `features.ide` on, mirroring the dashboard's `serverCapabilities?.ide` gate.
+   * Absent/non-object capabilities parse to `{}` (no advertised capabilities).
+   */
+  serverCapabilities: Record<string, boolean>;
   /**
    * Send a `user_question_response` answer to the server.
    *

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -159,7 +159,11 @@ const PLATFORM_SPECIFIC = {
   // fast-follow per epic #5159), so they are BOTH-CLIENTS and the coverage test
   // passes because each handler has a `case 'activity_snapshot'/'activity_delta':`.
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
-  'permission_input': 'dashboard', // #6543 (IDE P3 feature B) reply to a get_permission_input pull — full redacted tool input for the pre-write diff; dashboard-only for the first cut (the pre-write-diff UI lands dashboard-first), mobile parity is PR-4 of #6543
+  // 'permission_input' removed from PLATFORM_SPECIFIC — the mobile app now
+  // handles it too (#6543 PR-4, the pre-write-diff mobile parity fast-follow),
+  // so it is BOTH-CLIENTS. Coverage passes because the dashboard has a
+  // `permission_input: handlePermissionInput` HANDLERS-map entry and the mobile
+  // app has a `case 'permission_input':` clause.
   'repo_events_snapshot': 'dashboard', // Control Room repo-events survey reply (#5966, epic #5422 phase 5) — GitHub-webhook activity buffered by the daemon (#6468); host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'repo_events_delta': 'dashboard', // Control Room repo-events LIVE delta (#6536, PR-2 of #5966) — host-broadcast of a new webhook event so the pane updates without a Refresh; host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow
   'runner_status_snapshot': 'dashboard', // Control Room self-hosted runner survey reply (#5253) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity would be a fast-follow

--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -91,13 +91,25 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // close comment for the full rationale.
 // ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
-  // EMPTY — the both-clients SWITCH_FIXTURES backlog is fully drained. Every
-  // both-clients switch type now has a behaviour-verified fixture (incl. the last
-  // two via the #6344 multi-message prelude: history_replay_end resolves against a
-  // history_replay_start baseline; key_exchange_ok runs after an encryption auth_ok
-  // stashes the pending key pair) OR is a documented NO_SWITCH_CONTRACT_BY_DESIGN
-  // exemption. Re-add a type here ONLY when retro-fitting a pre-existing case that
-  // genuinely can't be fixtured yet, with a note — prefer a real fixture.
+  // permission_input (#6543 PR-4) — the pre-write-diff pull reply became
+  // both-clients when the mobile app gained a `case 'permission_input':` (dashboard
+  // handles it via its HANDLERS map). Its reducer is a one-line flat-state write
+  // (`set({ permissionInputs: { ...get().permissionInputs, [requestId]: data } })`)
+  // that is byte-identical on both clients, and each side is behaviour-verified by
+  // a dedicated dispatch test (dashboard: dispatch-permission-input.test.ts; app:
+  // message-handler-permission-input.test.ts). A shared SWITCH_FIXTURES entry is a
+  // tracked follow-up (the flat `permissionInputs` map is trivially assertable once
+  // the per-client SWITCH runner seeds it); listed here until then.
+  'permission_input',
+  // ------------------------------------------------------------------
+  // Below WAS empty — the both-clients SWITCH_FIXTURES backlog is otherwise fully
+  // drained. Every other both-clients switch type has a behaviour-verified fixture
+  // (incl. the last two via the #6344 multi-message prelude: history_replay_end
+  // resolves against a history_replay_start baseline; key_exchange_ok runs after an
+  // encryption auth_ok stashes the pending key pair) OR is a documented
+  // NO_SWITCH_CONTRACT_BY_DESIGN exemption. Re-add a type here ONLY when retro-
+  // fitting a pre-existing case that genuinely can't be fixtured yet, with a note —
+  // prefer a real fixture.
   // agent_idle — now has a SWITCH_FIXTURES entry (#6325); the contract-switch
   // harness was extended to assert session-scalar fields (isIdle, …).
   // activity_snapshot / activity_delta — both clients now feed them through the

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -192,7 +192,9 @@ const DASHBOARD_ONLY = new Set<string>([
   'evaluator_clarify',          // auto-evaluator clarify banner (#3188) — dashboard-only
   'evaluator_rewrite',          // auto-evaluator rewrite banner (#3188) — dashboard-only
   'host_status_snapshot',       // Control Room Host/Repo Status (#5170) — dashboard-only for v1
-  'permission_input',           // #6543 (IDE P3 feature B) get_permission_input reply — full redacted tool input for the pre-write diff; dashboard-only for the first cut, mobile parity is PR-4 of #6543
+  // permission_input removed — the mobile app now handles it too (#6543 PR-4,
+  // the pre-write-diff mobile parity fast-follow), so it is no longer
+  // dashboard-only. Both clients dispatch it into `permissionInputs[requestId]`.
   'integration_action_ack',     // Control Room Integrations action ack (#5500) — dashboard-only
   'integration_status_snapshot',// Control Room Integrations survey (#5499) — dashboard-only
   'mailbox_status_snapshot',    // Control Room Mailbox tab survey (#5914) — dashboard-only


### PR DESCRIPTION
## Summary

Brings the **mobile app** to parity with the dashboard's editable pre-write-diff (feature B, IDE P3, epic #6469). A Write/Edit permission prompt now pulls the full (secret-redacted) tool input, renders a **per-hunk diff**, and lets the operator drop individual hunks — the narrowed content rides back as `editedInput` on **Approve**. This is **PR-4** of #6543 (the mobile fast-follow after the dashboard shipped #6545/#6546/#6548/#6550/#6552/#6554).

## What's in it

**Store parity — unit + contract verified**
- `sendPermissionResponse` forwards an optional `editedInput` (the store already drops it for a `deny`).
- `permissionInputs` map + `requestPermissionInput` action (the `get_permission_input` pull).
- `permission_input` handler stores the pulled input keyed by `requestId` (mirrors the dashboard `handlePermissionInput`).
- `serverCapabilities` tracked from `auth_ok` (already computed by the shared `handleAuthOk`, previously discarded on mobile) — gates the review on `features.ide`, mirroring the dashboard's `serverCapabilities?.ide`.

**UI — typecheck-clean**
- `PreWriteDiffReview` RN component, a faithful port of the dashboard component, composed over the already-tested `computeHunks`/`applyHunks` (#6546) + the selectable `DiffHunkView` (#6548).
- `MessageBubble` pulls the input on an eligible prompt (features.ide + Write/Edit), renders the diff, and threads `editedInput` through `onSelectOption` → `ChatView` → `SessionScreen` → `sendPermissionResponse`.

**Coverage guards** — `permission_input` flipped **dashboard-only → both-clients**:
- removed from protocol `handler-coverage` `PLATFORM_SPECIFIC`,
- removed from store-core `DASHBOARD_ONLY`,
- added to `PENDING_CONTRACT_TYPES` (the reducer is a one-line flat write, byte-identical on both clients; a shared SWITCH_FIXTURES entry is a tracked follow-up).

## Verification

- ✅ `app` `tsc --noEmit` clean
- ✅ New mobile dispatch test (`message-handler-permission-input.test.ts`) — `found:true` / `found:false` / no-clobber / malformed-drop (4 tests), mirroring the dashboard's `dispatch-permission-input.test.ts`
- ✅ Mobile jest (auth-ok, message-handler, activity, contract-switch, permission-input): 108 pass
- ✅ store-core full `vitest run`: 1934 pass
- ✅ protocol full `npm test`: 358 pass

## ⚠️ Needs on-device verification

The **UI rendering + tap-to-drop-hunk interaction** cannot be component-tested (no React-Native testing-library in this workspace). The store/reducer path is fully unit + contract verified; the **visual render and gesture flow are not** and need an on-device pass (Write/Edit prompt on a `features.ide` server → diff renders → uncheck a hunk → Approve writes the narrowed content). Filing a follow-up to track that.

Closes #6543