### PR TITLE
feat(dashboard): device-pairing QR in the overflow menu + Cmd+Shift+L shortcut

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -972,6 +972,12 @@ export function App() {
     setImageAttachments(prev => [...prev, ...attachments])
   }, [])
 
+  // Latest-handler ref for the Cmd+Shift+L device-pairing shortcut. `handleShowQr`
+  // (from useQrModal) and `isConnected` are declared BELOW this dispatch call, so
+  // the shortcut reads them through a ref rather than forcing a hook reorder. The
+  // ref is assigned once both are in scope (search: showQrRef.current =).
+  const showQrRef = useRef<(() => void) | null>(null)
+
   // #4770: keydown dispatch (Backspace prevention + Tauri Ctrl+V image
   // paste + registry-routed shortcuts) lives in useShortcutDispatch so
   // App stays under the SRP threshold and the dispatch ladder is
@@ -1002,6 +1008,10 @@ export function App() {
     openFilePalette: () => { if (ideEnabled) setFileOpenPaletteOpen(true) },
     openSymbolSearch: () => { if (ideEnabled) setSymbolSearchOpen(true) },
     openCodeSearch: () => { if (ideEnabled) setCodeSearchOpen(true) },
+    // Cmd+Shift+L → device-pairing QR. Stable closure over a ref, since
+    // handleShowQr/isConnected are declared below; the ref no-ops when null
+    // (disconnected), so the shortcut only opens the modal when there's a server.
+    showQr: () => showQrRef.current?.(),
   })
 
   const trackedCommands = useMemo(
@@ -1885,6 +1895,11 @@ export function App() {
   }, [activeModel, availableModels])
 
   const isConnected = connectionPhase === 'connected'
+  // Point the Cmd+Shift+L shortcut at the live QR handler, gated on connection
+  // (mirrors the footer/overflow `onShowQr={isConnected ? handleShowQr : undefined}`
+  // surfaces). Assigning a ref during render is the standard latest-callback idiom
+  // — no state update, no re-render.
+  showQrRef.current = isConnected ? handleShowQr : null
   const isReconnecting = connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting'
   // #5698 — the reconnect ladder gave up; terminal state, manual reconnect only.
   const isServerDown = connectionPhase === 'server_down'
@@ -2021,6 +2036,7 @@ export function App() {
             return next
           })
         }}
+        onShowQr={isConnected ? handleShowQr : undefined}
         showCopyTranscript={viewMode === 'chat' && storeMessages.length > 0}
         transcriptCopied={transcriptCopied}
         onCopyTranscript={handleCopyTranscript}

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -62,6 +62,10 @@ export interface AppHeaderProps {
   // holds the primary token), which filters the "Revoke token" row out entirely.
   onRevokeToken?: () => void
   onToggleSkillsPanel: () => void
+  // Show the device-pairing QR (same action as the footer "QR" button + the
+  // Cmd+Shift+L shortcut). Undefined when disconnected, which filters the
+  // "Pair a device" row out of the overflow menu entirely.
+  onShowQr?: () => void
   showCopyTranscript: boolean
   transcriptCopied: boolean
   onCopyTranscript: () => void
@@ -225,6 +229,17 @@ export function AppHeader(props: AppHeaderProps) {
               icon: '\u{1F9E9}',
               title: 'Skills',
               onClick: props.onToggleSkillsPanel,
+            },
+            // Pair a device — surfaces the linking QR in the discoverable "..."
+            // menu (parity with the footer "QR" button). `onShowQr` is undefined
+            // when disconnected, so the menu filters this row out (no server to
+            // pair against). Mirrors the Cmd+Shift+L shortcut.
+            {
+              id: 'pair-device',
+              label: 'Pair a device',
+              icon: '\u{1F4F1}',
+              title: `Pair a device — scan the QR with the Chroxy mobile app (${formatShortcutKeys('Cmd+Shift+L')})`,
+              onClick: props.onShowQr,
             },
             props.showCopyTranscript
               ? {

--- a/packages/dashboard/src/hooks/useShortcutDispatch.test.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.test.ts
@@ -49,6 +49,7 @@ const TEST_DEFS: ShortcutDef[] = [
   { id: 'view.cycleSplit', defaultBinding: 'cmd+\\', description: 'Cycle split', category: 'view', scope: 'global' },
   { id: 'help.toggle', defaultBinding: '?', description: 'Help', category: 'other', scope: 'global' },
   { id: 'palette.toggle.vscode', defaultBinding: 'cmd+shift+p', description: 'Palette (VS Code)', category: 'navigation', scope: 'global' },
+  { id: 'device.pairQr', defaultBinding: 'cmd+shift+l', description: 'Pair a device', category: 'navigation', scope: 'global' },
 ]
 
 function fireKey(opts: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
@@ -155,6 +156,20 @@ describe('useShortcutDispatch', () => {
     renderHook(() => useShortcutDispatch(props))
     fireKey({ key: ',', metaKey: true })
     expect(props.setSettingsOpen).toHaveBeenCalledOnce()
+  })
+
+  it('dispatches device.pairQr → showQr on Cmd+Shift+L', () => {
+    const showQr = vi.fn()
+    const props = makeProps({ showQr })
+    renderHook(() => useShortcutDispatch(props))
+    fireKey({ key: 'l', metaKey: true, shiftKey: true })
+    expect(showQr).toHaveBeenCalledOnce()
+  })
+
+  it('device.pairQr no-ops when showQr is undefined (disconnected — no throw)', () => {
+    const props = makeProps({ showQr: undefined })
+    renderHook(() => useShortcutDispatch(props))
+    expect(() => fireKey({ key: 'l', metaKey: true, shiftKey: true })).not.toThrow()
   })
 
   it('dispatches session.new on Cmd+N', () => {

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -76,6 +76,10 @@ export interface ShortcutDispatchProps {
   openSymbolSearch?: () => void
   // #6474 — open the Cmd+Shift+F find-in-project palette (caller gates on `ide`).
   openCodeSearch?: () => void
+  // Show the device-pairing QR modal (Cmd+Shift+L). Optional + undefined when
+  // disconnected (the caller gates on `isConnected`), so the shortcut no-ops
+  // rather than opening an empty modal with no server to pair against.
+  showQr?: () => void
 }
 
 export function useShortcutDispatch(props: ShortcutDispatchProps): void {
@@ -102,6 +106,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     openFilePalette,
     openSymbolSearch,
     openCodeSearch,
+    showQr,
   } = props
 
   useEffect(() => {
@@ -228,6 +233,12 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
             // to the legacy modal toggle when the redirect isn't wired.
             if (openSettings) openSettings()
             else setSettingsOpen(prev => !prev)
+            break
+          case 'device.pairQr':
+            // Open the linking QR modal (same action as the footer "QR" button
+            // + the overflow "Pair a device" row). `showQr` is undefined when
+            // disconnected, so this no-ops rather than opening an empty modal.
+            showQr?.()
             break
           case 'session.new':
             setShowCreateSession(true)

--- a/packages/dashboard/src/shortcuts/defaults.test.ts
+++ b/packages/dashboard/src/shortcuts/defaults.test.ts
@@ -38,4 +38,24 @@ describe('DEFAULT_SHORTCUTS', () => {
       expect(entry?.category).toBe('session')
     })
   })
+
+  describe('device.pairQr entry (pair-a-device QR shortcut)', () => {
+    const entry = DEFAULT_SHORTCUTS.find(s => s.id === 'device.pairQr')
+
+    it('exists in the registry', () => {
+      expect(entry, 'missing device.pairQr entry').toBeDefined()
+    })
+
+    it('binds to Cmd+Shift+L by default (NOT Cmd+Shift+Q, which macOS reserves for Log Out)', () => {
+      expect(entry?.defaultBinding.toLowerCase()).toBe('cmd+shift+l')
+    })
+
+    it('is a global shortcut so the dispatch ladder routes it', () => {
+      expect(entry?.scope).toBe('global')
+    })
+
+    it('groups under navigation (with the palette / settings / quick-open entries)', () => {
+      expect(entry?.category).toBe('navigation')
+    })
+  })
 })

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -94,6 +94,18 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
     scope: 'global',
   },
   {
+    // Pair a device — opens the linking QR modal (the same action as the
+    // footer "QR" button + the header overflow "Pair a device" row). Default
+    // Cmd+Shift+L ("L" = link a device); deliberately NOT Cmd+Shift+Q, which
+    // macOS reserves for Log Out. No-op when disconnected (App gates the
+    // handler on `isConnected`, mirroring the footer/overflow surfaces).
+    id: 'device.pairQr',
+    defaultBinding: 'cmd+shift+l',
+    description: 'Pair a device (show QR)',
+    category: 'navigation',
+    scope: 'global',
+  },
+  {
     id: 'session.new',
     defaultBinding: 'cmd+n',
     description: 'New session',


### PR DESCRIPTION
## Summary

The linking QR (pair a phone) was only reachable via the small footer **"QR"** button — not discoverable. This adds it to the two conventional surfaces a user would look for a common action:

- **"📱 Pair a device"** row in the header **"…" overflow menu** (next to Skills / Settings). Filtered out when disconnected, mirroring the footer's `isConnected` gate.
- A **rebindable global shortcut** `device.pairQr` — default **Cmd+Shift+L** ("L" for *link a device*; deliberately **not** Cmd+Shift+Q, which macOS reserves for Log Out). Because it routes through the shortcut registry, it also appears in the **`?` cheat sheet** and the **Settings rebind list** for free.

All three surfaces (footer button, overflow row, shortcut) call the same `handleShowQr`.

## Why a ref for the shortcut

`handleShowQr` (from `useQrModal`) and `isConnected` are declared *below* the `useShortcutDispatch` call in `App.tsx`. Rather than reorder hooks in a large component, the shortcut reads the handler through a `showQrRef` assigned once both are in scope (the standard latest-callback idiom — a ref write during render, no state update). It no-ops when null (disconnected).

## Changes
- `shortcuts/defaults.ts` — new `device.pairQr` entry (`cmd+shift+l`, navigation category).
- `hooks/useShortcutDispatch.ts` — `showQr?` prop + `case 'device.pairQr'`.
- `App.tsx` — `showQrRef` + wire `showQr` into the dispatch + `onShowQr` into `<AppHeader>`.
- `components/AppHeader.tsx` — `onShowQr?` prop + the "Pair a device" overflow row.

## Tests
- `defaults.test.ts` — asserts the `device.pairQr` entry (binding `cmd+shift+l`, global, navigation).
- `useShortcutDispatch.test.ts` — Cmd+Shift+L → `showQr`; and the disconnected no-op (no throw).
- ✅ Full dashboard suite green: **245 files / 4247 tests**; `tsc --noEmit` clean.

## Note
The macOS-native Tauri menu bar (File > …) is a separate Rust surface and is intentionally out of scope here; this covers the in-app overflow menu + keyboard shortcut. Verified live in the running desktop app.