### PR TITLE
fix(server): require E2E encryption for tunneled connections (#6562)

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -247,10 +247,15 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // arrives with socketIp 127.0.0.1 and would be silently downgraded to plaintext,
   // which a paired (identity-pinned) mobile client correctly refuses ("did not
   // negotiate encryption"). Additionally require `client.localPeer` — the
-  // unspoofable upgrade-time locality signal (isLocalOrLanPeer), which is FALSE
-  // when proxy headers (cf-connecting-ip / x-forwarded-for) are present. So a
-  // genuine local dashboard (loopback socket, no proxy headers) is still bypassed,
-  // but a tunneled connection to 127.0.0.1 is not — it does the full key_exchange.
+  // upgrade-time locality CLASSIFICATION (unspoofable socket peer + proxy-header
+  // ABSENCE), which is FALSE when proxy headers (cf-connecting-ip /
+  // x-forwarded-for) are present. So a genuine local dashboard (loopback socket,
+  // no proxy headers) is still bypassed, but a tunneled connection to 127.0.0.1 is
+  // not — it does the full key_exchange. NB: header absence is a WEAK positive
+  // "local" signal (a non-Cloudflare loopback-forwarding proxy that omits these
+  // headers would classify local — see #6564), but an attacker cannot STRIP
+  // cloudflared's edge-stamped cf-connecting-ip to GAIN the bypass, so the
+  // security-relevant direction is safe.
   const isLoopbackSocket = client.socketIp === '127.0.0.1' || client.socketIp === '::1' || client.socketIp === '::ffff:127.0.0.1'
   const isLocalhost = localhostBypass && isLoopbackSocket && client.localPeer === true
   const requireEncryption = encryptionEnabled && !isLocalhost

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -240,8 +240,19 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     sessionInfo.cwd = null
   }
 
-  // Skip encryption for localhost connections
-  const isLocalhost = localhostBypass && (client.socketIp === '127.0.0.1' || client.socketIp === '::1' || client.socketIp === '::ffff:127.0.0.1')
+  // Skip encryption for localhost connections.
+  //
+  // #6562: the loopback socket-IP check alone is NOT sufficient — cloudflared
+  // forwards tunnel traffic to 127.0.0.1, so a REMOTE client over a Quick Tunnel
+  // arrives with socketIp 127.0.0.1 and would be silently downgraded to plaintext,
+  // which a paired (identity-pinned) mobile client correctly refuses ("did not
+  // negotiate encryption"). Additionally require `client.localPeer` — the
+  // unspoofable upgrade-time locality signal (isLocalOrLanPeer), which is FALSE
+  // when proxy headers (cf-connecting-ip / x-forwarded-for) are present. So a
+  // genuine local dashboard (loopback socket, no proxy headers) is still bypassed,
+  // but a tunneled connection to 127.0.0.1 is not — it does the full key_exchange.
+  const isLoopbackSocket = client.socketIp === '127.0.0.1' || client.socketIp === '::1' || client.socketIp === '::ffff:127.0.0.1'
+  const isLocalhost = localhostBypass && isLoopbackSocket && client.localPeer === true
   const requireEncryption = encryptionEnabled && !isLocalhost
 
   // #5555 (eager key exchange) — if the client supplied its ephemeral public

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1743,6 +1743,13 @@ export class WsServer {
       // socket peer, identical to the strip decision — they can never diverge.
       const localPeer = isLocalOrLanPeer(req)
       req._chroxyUsesDeflate = !localPeer
+      // #6562: carry the same UNSPOOFABLE locality signal to the encryption
+      // decision. isLocalOrLanPeer is false when proxy headers are present, so a
+      // cloudflared-tunneled connection (which arrives at socketIp 127.0.0.1 but
+      // carries cf-connecting-ip) is NOT a local peer — the loopback encryption
+      // bypass (ws-history.js) must consult this so tunneled clients still do the
+      // key_exchange instead of being silently downgraded to plaintext.
+      req._chroxyLocalPeer = localPeer
       if (localPeer) {
         delete req.headers['sec-websocket-extensions']
       }
@@ -1800,6 +1807,11 @@ export class WsServer {
         // — see EventNormalizer._resolveFlushIntervalMs. Set from the
         // unspoofable upgrade-time locality decision (req._chroxyUsesDeflate).
         usesDeflate: req._chroxyUsesDeflate === true,
+        // #6562: true only for a genuine loopback/LAN peer with NO proxy headers
+        // — i.e. NOT a cloudflared-tunneled connection. Gates the loopback
+        // encryption bypass so a tunneled (proxied) connection to socketIp
+        // 127.0.0.1 is not treated as trusted-local and still requires E2E.
+        localPeer: req._chroxyLocalPeer === true,
         // #3404: visible defaults to true; mobile flips to false on backgrounding
         // so completion push notifications fire instead of being suppressed by
         // a still-alive but invisible WS connection.

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1743,12 +1743,16 @@ export class WsServer {
       // socket peer, identical to the strip decision — they can never diverge.
       const localPeer = isLocalOrLanPeer(req)
       req._chroxyUsesDeflate = !localPeer
-      // #6562: carry the same UNSPOOFABLE locality signal to the encryption
-      // decision. isLocalOrLanPeer is false when proxy headers are present, so a
+      // #6562: carry the same upgrade-time locality CLASSIFICATION (unspoofable
+      // socket peer + proxy-header ABSENCE) to the encryption decision.
+      // isLocalOrLanPeer is false when proxy headers are present, so a
       // cloudflared-tunneled connection (which arrives at socketIp 127.0.0.1 but
-      // carries cf-connecting-ip) is NOT a local peer — the loopback encryption
-      // bypass (ws-history.js) must consult this so tunneled clients still do the
-      // key_exchange instead of being silently downgraded to plaintext.
+      // carries cf-connecting-ip) is NOT classified local — the loopback
+      // encryption bypass (ws-history.js) must consult this so tunneled clients
+      // still do the key_exchange instead of a plaintext downgrade. Header absence
+      // is a weak positive signal (see #6564), but the security-relevant direction
+      // is safe: an attacker can't strip cloudflared's edge-stamped header to gain
+      // the bypass.
       req._chroxyLocalPeer = localPeer
       if (localPeer) {
         delete req.headers['sec-websocket-extensions']

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -846,10 +846,14 @@ describe('sendPostAuthInfo — encryption', () => {
     if (client._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
   })
 
+  // The bypass cases model a GENUINE local dashboard: a loopback socketIp AND
+  // localPeer:true (isLocalOrLanPeer saw no proxy headers). #6562 additionally
+  // requires localPeer so a tunneled connection to 127.0.0.1 is NOT bypassed —
+  // see the proxied-loopback regression test below.
   it('bypasses encryption requirement for 127.0.0.1 when localhostBypass enabled', () => {
     const ws = makeFakeWs()
     const ctx = makeCtx({ encryptionEnabled: true, localhostBypass: true })
-    registerClient(ctx, ws, { socketIp: '127.0.0.1' })
+    registerClient(ctx, ws, { socketIp: '127.0.0.1', localPeer: true })
 
     sendPostAuthInfo(ctx, ws)
     const authOk = ctx._sends.find(m => m.type === 'auth_ok')
@@ -859,7 +863,7 @@ describe('sendPostAuthInfo — encryption', () => {
   it('bypasses encryption requirement for ::1 when localhostBypass enabled', () => {
     const ws = makeFakeWs()
     const ctx = makeCtx({ encryptionEnabled: true, localhostBypass: true })
-    registerClient(ctx, ws, { socketIp: '::1' })
+    registerClient(ctx, ws, { socketIp: '::1', localPeer: true })
 
     sendPostAuthInfo(ctx, ws)
     const authOk = ctx._sends.find(m => m.type === 'auth_ok')
@@ -869,11 +873,40 @@ describe('sendPostAuthInfo — encryption', () => {
   it('bypasses encryption requirement for ::ffff:127.0.0.1 when localhostBypass enabled', () => {
     const ws = makeFakeWs()
     const ctx = makeCtx({ encryptionEnabled: true, localhostBypass: true })
-    registerClient(ctx, ws, { socketIp: '::ffff:127.0.0.1' })
+    registerClient(ctx, ws, { socketIp: '::ffff:127.0.0.1', localPeer: true })
 
     sendPostAuthInfo(ctx, ws)
     const authOk = ctx._sends.find(m => m.type === 'auth_ok')
     assert.equal(authOk.encryption, 'disabled')
+  })
+
+  it('#6562: does NOT bypass encryption for a loopback socketIp that is a PROXIED (tunneled) peer', () => {
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ encryptionEnabled: true, localhostBypass: true, keyExchangeTimeoutMs: 60000 })
+    // cloudflared forwards tunnel traffic to 127.0.0.1, so socketIp is loopback —
+    // but the upgrade-time isLocalOrLanPeer check set localPeer=false because
+    // cf-connecting-ip / x-forwarded-for were present. A paired mobile client over
+    // a Quick Tunnel MUST still get the encrypted handshake, not a plaintext bypass.
+    const client = registerClient(ctx, ws, { socketIp: '127.0.0.1', localPeer: false })
+
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.encryption, 'required')
+    if (client._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
+  })
+
+  it('#6562: a genuine LAN peer (RFC1918 socket, localPeer:true) still REQUIRES encryption (bypass is loopback-only)', () => {
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ encryptionEnabled: true, localhostBypass: true, keyExchangeTimeoutMs: 60000 })
+    // A real LAN device: socketIp is RFC1918 (not loopback), localPeer:true (no
+    // proxy headers). The bypass stays loopback-ONLY, so this must still encrypt —
+    // this locks the "added condition is stricter, never wider" property.
+    const client = registerClient(ctx, ws, { socketIp: '10.0.0.5', localPeer: true })
+
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.encryption, 'required')
+    if (client._keyExchangeTimeout) clearTimeout(client._keyExchangeTimeout)
   })
 
   it('does NOT bypass encryption for localhost IP when localhostBypass is false', () => {


### PR DESCRIPTION
## Summary

**Closes #6562.** A paired (identity-pinned) mobile client could not connect over a Cloudflare Quick Tunnel — it refused with *"Server Identity Changed — did not negotiate encryption."* The daemon was serving tunneled clients **plaintext**.

**Root cause:** the loopback E2E-encryption bypass (`ws-history.js`) keyed only on a loopback socket IP. `cloudflared tunnel --url http://localhost:8765` forwards tunnel traffic to `127.0.0.1`, so a **remote** tunneled client arrives with `socketIp === '127.0.0.1'` → the bypass triggered → no `key_exchange` → plaintext. Same class as #6277 (cloudflared-loopback trap).

## Fix

Additionally require the **unspoofable** upgrade-time locality signal. The WS upgrade handler already computes `isLocalOrLanPeer(req)` for the deflate decision — it's `false` when proxy headers (`cf-connecting-ip` / `x-forwarded-for`) are present. Carry it onto the client as `localPeer` and require it for the bypass:

```js
isLocalhost = localhostBypass && isLoopbackSocket && client.localPeer === true
```

- **Real local dashboard** (loopback socket, no proxy headers) → `localPeer=true` → bypass preserved.
- **Tunneled connection** (loopback socket + `cf-connecting-ip`) → `localPeer=false` → full `key_exchange`.
- **LAN** → unchanged (bypass stays loopback-only).

The change is **strictly stricter** (an added `&&` term), **fails closed** (undefined `localPeer` → encryption required), and adds **no new header trust** to the bypass — `socketIp` stays kernel-supplied (`req.socket.remoteAddress`).

## Why no client is locked out
Both clients already implement the handshake — `packages/dashboard/src/store/connection.ts` and `packages/app/src/store/connection.ts` handle `key_exchange_ok` + eager key exchange (#5555). So tunneled links are **upgraded from plaintext to encrypted**, not broken.

## Verification
- ✅ **Live end-to-end:** phone over a Quick Tunnel now logs `E2E encryption established` and connects (previously: refused). Confirmed by the reporter.
- ✅ **155 ws-history tests pass**, incl. two new regressions:
  - proxied-loopback (tunneled) → `encryption: required`
  - genuine LAN peer (`localPeer:true`, RFC1918 socket) → still `required` (bypass stays loopback-only)
- ✅ ws-history / ws-server / ws-auth / ws-exposure: **374 pass**; server custom lints green.
- ✅ **Adversarial security review: SAFE** — a remote attacker can't regain the bypass (cloudflared stamps `cf-connecting-ip` at the edge; a client can't strip it); no fail-open path; no new spoofable-header trust.

## Follow-up
- #6564 — harden against a **non-Cloudflare** loopback-forwarding proxy that omits proxy headers (header-absence is a weak "local" signal; pre-existing, out of scope here).

Closes #6562