### PR TITLE
fix(app): honest LAN-scan empty state + unicast sweep hardening (#6561)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ npx chroxy tunnel setup
 ### Triage Runbooks
 
 - [`docs/troubleshooting/session-token-mismatch.md`](docs/troubleshooting/session-token-mismatch.md) — how to enable the `[session-binding-*]` debug logs and correlate a `SESSION_TOKEN_MISMATCH` failure by `requestId` (runbook from the resolved #2832 investigation).
+- [`docs/troubleshooting/lan-discovery.md`](docs/troubleshooting/lan-discovery.md) — why the mobile app's "Scan Local Network" finds nothing on the same Wi-Fi (it's a **unicast /24 sweep**, not mDNS — router client/AP isolation blocks it) and the router-side fixes + manual/QR fallbacks (#6561).
 
 ## Session Start Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ npx chroxy tunnel setup
 ### Triage Runbooks
 
 - [`docs/troubleshooting/session-token-mismatch.md`](docs/troubleshooting/session-token-mismatch.md) — how to enable the `[session-binding-*]` debug logs and correlate a `SESSION_TOKEN_MISMATCH` failure by `requestId` (runbook from the resolved #2832 investigation).
+- [`docs/troubleshooting/lan-discovery.md`](docs/troubleshooting/lan-discovery.md) — why the mobile app's "Scan Local Network" finds nothing on the same Wi-Fi (it's a **unicast /24 sweep**, not mDNS — router client/AP isolation blocks it) and the router-side fixes + manual/QR fallbacks (#6561).
 
 ## Session Start Protocol
 

--- a/docs/troubleshooting/lan-discovery.md
+++ b/docs/troubleshooting/lan-discovery.md
@@ -1,0 +1,159 @@
+# LAN discovery: "Scan Local Network" finds no server
+
+**Symptom:** On the mobile app's **Connect** screen you tap **Scan Local Network**,
+the scan completes, and it shows *"No servers found"* — even though the Chroxy
+daemon is running on your computer and both devices are on the same Wi-Fi.
+
+This guide explains how the scan actually works, why it can come up empty, how to
+fix it at the router, and the fallbacks that work **regardless** of your router.
+
+> **TL;DR — the reliable way in:** on the Connect screen tap **Enter manually** and
+> type your computer's LAN IP and port (e.g. `10.0.0.71` : `8765`), or **Scan QR
+> Code**. Discovery is a convenience; the connection itself does not need it.
+
+---
+
+## How the scan actually works (it is *not* mDNS/Bonjour)
+
+The app does **not** use mDNS/Bonjour/multicast to find the daemon. It does a
+**unicast subnet sweep**:
+
+1. It reads the phone's own Wi-Fi IP (e.g. `10.0.0.42`).
+2. It assumes a `/24` network and derives the subnet prefix (`10.0.0`).
+3. It sends a plain HTTP `GET /health` to **every** address in that subnet
+   (`10.0.0.1` … `10.0.0.254`) on the scan port.
+4. Any address that answers `{"status":"ok"}` is listed as a discovered server.
+
+Two consequences follow directly from this design:
+
+- **`dns-sd` / Bonjour advertising is irrelevant.** The daemon advertising
+  `_chroxy._tcp` over mDNS (and any router multicast/IGMP filtering) does **not**
+  affect this scan — the app never listens for mDNS. If a scan finds nothing, the
+  cause is that the phone could not open a **unicast** HTTP connection to the
+  daemon's address, or the daemon isn't on the scanned `/24`.
+- **The daemon must be listening on your LAN IP, not loopback.** Start it exposed
+  on all interfaces (`0.0.0.0`), which is what `chroxy start` does by default in
+  the current builds. If it is bound to `127.0.0.1`, no other device can reach it.
+  Confirm on the computer:
+
+  ```bash
+  lsof -iTCP:8765 -sTCP:LISTEN -n -P
+  # want: node ... TCP *:8765 (LISTEN)   — the "*" means all interfaces
+  # NOT:  node ... TCP 127.0.0.1:8765 (LISTEN)
+  ```
+
+---
+
+## Step 0 — the one test that tells you where the problem is
+
+From the **phone**, with **Wi-Fi ON and cellular data OFF**, open a browser and go
+to your computer's health endpoint:
+
+```
+http://<your-computer-LAN-IP>:8765/health
+```
+
+(Find the IP on the computer with `ipconfig getifaddr en0` on macOS, or `hostname -I`
+on Linux.)
+
+- **It loads `{"status":"ok",…}`** → the phone **can** reach the daemon over
+  unicast. Discovery *should* work; re-run the scan, and if it still comes up empty
+  see [Same subnet, still not found](#same-subnet-still-not-found). Either way,
+  **Enter manually** with that same IP + port will connect.
+- **It hangs / "cannot connect"** → the phone **cannot** reach the daemon's IP at
+  all. That is your router isolating devices from each other (or the phone being on
+  a different network/subnet). Continue to [Router-side fixes](#router-side-fixes).
+
+Turning cellular data **off** during this test matters: with it on, the phone may
+route the request over the cellular network instead of Wi-Fi and give a misleading
+result.
+
+---
+
+## Router-side fixes
+
+These are the common consumer-router / mesh settings that block **unicast**
+device-to-device traffic on the same Wi-Fi. You usually only need one of them.
+
+### 1. Client / AP isolation ("device isolation", "wireless isolation")
+
+The single most common cause. When enabled, the router forwards each Wi-Fi client's
+traffic **only** to the internet, not to other devices on the same network — so the
+phone cannot reach the computer even though both are "on the same Wi-Fi".
+
+Find it under **Wireless → Advanced**, or in a mesh app under the network/security
+settings, named one of:
+
+| Vendor / app | Setting to turn **off** |
+| --- | --- |
+| eero | *(no direct toggle; ensure devices are **not** on a "guest" or "isolated" profile)* |
+| Google/Nest Wifi | "Device / client isolation" is off by default; check per-device "Guest" assignment |
+| Netgear Orbi | Wireless → Advanced → **Enable Wireless Isolation** → off |
+| ASUS | Wireless → Professional → **Set AP Isolated** → No |
+| TP-Link / Deco | Advanced → Wireless → **AP Isolation** → off (Deco app: More → Advanced) |
+| ISP-supplied routers | Often labelled "AP isolation", "client isolation", or "guest" — off |
+
+### 2. Guest network
+
+If the phone (or the computer) is joined to a **Guest** SSID, most routers isolate
+guest clients from the main LAN by design. Put **both** devices on your **main**
+Wi-Fi network.
+
+### 3. Separate 2.4 GHz / 5 GHz SSIDs, or band/AP steering
+
+If your router exposes the two radio bands as **different SSIDs** (e.g.
+`MyWifi` and `MyWifi-5G`), and the phone and computer are on different ones, they
+can land on different subnets and won't see each other. Either join both devices to
+the **same** SSID, or (if the router uses one SSID with band steering) this is
+usually fine — verify with [Step 0](#step-0--the-one-test-that-tells-you-where-the-problem-is).
+
+### 4. Mesh "device isolation" / IoT segments
+
+Mesh systems (eero, Deco, Orbi, Google/Nest) sometimes put devices into isolated
+profiles or a separate IoT network. In the mesh app, make sure the phone and the
+computer are on the **same** network/profile with device-to-device access allowed.
+
+> **A note on multicast / IGMP snooping:** you may see advice to "enable multicast"
+> or "turn on IGMP snooping" for Bonjour/mDNS discovery. That advice is for
+> *multicast* discovery — **Chroxy's scan is unicast, so it does not apply here.**
+> Fix client/AP isolation instead.
+
+---
+
+## Same subnet, still not found
+
+If [Step 0](#step-0--the-one-test-that-tells-you-where-the-problem-is) loads the
+health page (the phone *can* reach the daemon) but the scan still lists nothing:
+
+- **Check the subnet the app scanned.** The empty state shows the range it swept
+  (e.g. *"Scanned `10.0.0.1-254`"*). If that prefix does **not** match your
+  computer's IP prefix, your network isn't a simple `/24` or the two devices are on
+  different subnets — use **Enter manually**.
+- **Check the port.** The scan uses the port in the box next to the button (default
+  `8765`). If you started the daemon on a different port, set it here.
+- **Re-run once.** A single sweep can miss a host under momentary Wi-Fi contention;
+  the scan probes ~254 addresses with a short timeout each.
+
+---
+
+## Reliable fallbacks (no discovery required)
+
+These always work as long as the phone can reach the daemon's IP:
+
+1. **Enter manually** — Connect screen → **Enter manually** → type
+   `host:port` (e.g. `10.0.0.71:8765`) and your token. This bypasses discovery
+   entirely.
+2. **Scan QR Code** — the QR shown by `chroxy start` encodes the host **and** the
+   token, so a scan connects in one step.
+3. **Reconnect** — once you've connected successfully, the app remembers the host
+   and shows a one-tap **Reconnect** on the Connect screen next time.
+
+---
+
+## Related
+
+- [`docs/security/bearer-token-authority.md`](../security/bearer-token-authority.md)
+  — §10 documents the unauthenticated `GET /health` fingerprint endpoint the scan
+  probes.
+- Tracking issue:
+  [#6561](https://github.com/blamechris/chroxy/issues/6561).

--- a/packages/app/__tests__/ConnectScreen.test.ts
+++ b/packages/app/__tests__/ConnectScreen.test.ts
@@ -88,11 +88,32 @@ describe('ConnectScreen component structure', () => {
 
   test('shows actionable empty-state guidance after scan finds nothing', () => {
     expect(src).toMatch(/No servers found on port/)
-    expect(src).toMatch(/loopback by default/)
-    expect(src).toMatch(/Expose on local network/)
+    // Honest root-cause guidance for a unicast sweep (client/AP isolation),
+    // replacing the old false "binds to loopback" claim (#6561).
+    expect(src).toMatch(/client\/AP isolation/)
     expect(src).toMatch(/testID="lan-scan-empty-state"/)
     expect(src).toMatch(/testID="lan-scan-empty-title"/)
     expect(src).toMatch(/testID="lan-scan-empty-hint"/)
+  })
+
+  test('empty state offers discovery-independent fallbacks (manual entry + troubleshooting)', () => {
+    expect(src).toMatch(/testID="lan-scan-manual-cta"/)
+    expect(src).toMatch(/testID="lan-scan-troubleshooting-link"/)
+    expect(src).toMatch(/lan-discovery\.md/)
+  })
+
+  test('does not claim the daemon binds to loopback (false when bound to 0.0.0.0)', () => {
+    // Regression guard for #6561: the old copy misdirected users to enable an
+    // already-on setting. These strings must stay out of the empty state.
+    expect(src).not.toMatch(/loopback by default/)
+    expect(src).not.toMatch(/Expose on local network/)
+  })
+
+  test('shows a distinct "no local network" empty state (cellular / no usable IPv4)', () => {
+    expect(src).toMatch(/scanNoWifi/)
+    expect(src).toMatch(/testID="lan-scan-nowifi-title"/)
+    expect(src).toMatch(/testID="lan-scan-nowifi-hint"/)
+    expect(src).toMatch(/No local network to scan/)
   })
 
   test('shows error guidance when scan throws', () => {

--- a/packages/app/src/__tests__/utils/lan-scanner.test.ts
+++ b/packages/app/src/__tests__/utils/lan-scanner.test.ts
@@ -1,0 +1,65 @@
+import {
+  validatePort,
+  isScannableIpv4,
+  deriveSubnet24,
+} from '../../utils/lan-scanner';
+
+describe('validatePort', () => {
+  it('accepts valid ports in range', () => {
+    expect(validatePort('8765')).toBe(8765);
+    expect(validatePort('1')).toBe(1);
+    expect(validatePort('65535')).toBe(65535);
+  });
+
+  it('rejects out-of-range, non-numeric, and empty input', () => {
+    expect(validatePort('0')).toBeNull();
+    expect(validatePort('65536')).toBeNull();
+    expect(validatePort('')).toBeNull();
+    expect(validatePort('80a')).toBeNull();
+    expect(validatePort('-1')).toBeNull();
+    expect(validatePort('12.5')).toBeNull();
+  });
+});
+
+describe('isScannableIpv4', () => {
+  it('accepts real host addresses on private and other ranges', () => {
+    expect(isScannableIpv4('10.0.0.71')).toBe(true);
+    expect(isScannableIpv4('192.168.1.5')).toBe(true);
+    expect(isScannableIpv4('172.16.4.2')).toBe(true);
+    // We intentionally do not restrict to RFC1918 — some networks hand out others.
+    expect(isScannableIpv4('100.64.1.1')).toBe(true);
+  });
+
+  it('rejects unspecified, loopback, and link-local addresses (no LAN to sweep)', () => {
+    expect(isScannableIpv4('0.0.0.0')).toBe(false);
+    expect(isScannableIpv4('127.0.0.1')).toBe(false);
+    expect(isScannableIpv4('169.254.10.20')).toBe(false); // APIPA — no DHCP lease
+  });
+
+  it('rejects non-IPv4 / malformed input', () => {
+    expect(isScannableIpv4('')).toBe(false);
+    expect(isScannableIpv4(null)).toBe(false);
+    expect(isScannableIpv4(undefined)).toBe(false);
+    expect(isScannableIpv4('not-an-ip')).toBe(false);
+    expect(isScannableIpv4('10.0.0')).toBe(false);
+    expect(isScannableIpv4('10.0.0.256')).toBe(false); // octet > 255
+    expect(isScannableIpv4('fe80::1')).toBe(false); // IPv6
+    expect(isScannableIpv4('10.0.0.1.5')).toBe(false);
+  });
+});
+
+describe('deriveSubnet24', () => {
+  it('returns the /24 prefix for a scannable IP', () => {
+    expect(deriveSubnet24('10.0.0.71')).toBe('10.0.0');
+    expect(deriveSubnet24('192.168.1.200')).toBe('192.168.1');
+  });
+
+  it('returns null for any address we cannot scan from', () => {
+    expect(deriveSubnet24('0.0.0.0')).toBeNull();
+    expect(deriveSubnet24('127.0.0.1')).toBeNull();
+    expect(deriveSubnet24('169.254.1.1')).toBeNull();
+    expect(deriveSubnet24('')).toBeNull();
+    expect(deriveSubnet24(null)).toBeNull();
+    expect(deriveSubnet24('garbage')).toBeNull();
+  });
+});

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -10,6 +10,7 @@ import {
   Keyboard,
   ActivityIndicator,
   Platform,
+  Linking,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { CameraView, useCameraPermissions, BarcodeScanningResult } from 'expo-camera';
@@ -21,10 +22,15 @@ import { setPendingPairingId, setPendingPairingIdentityKey } from '../store/mess
 import { Icon } from '../components/Icon';
 import { ICON_TRIANGLE_DOWN, ICON_TRIANGLE_RIGHT, ICON_BULLET } from '../constants/icons';
 import { COLORS } from '../constants/colors';
-import { validatePort, scanSubnet } from '../utils/lan-scanner';
+import { validatePort, scanSubnet, deriveSubnet24 } from '../utils/lan-scanner';
 import type { DiscoveredServer } from '../utils/lan-scanner';
 
 const DEFAULT_PORT = 8765;
+
+// Troubleshooting guide linked from the LAN-scan empty state (#6561). Points at
+// the docs on `main` so it stays valid without an app release.
+const LAN_TROUBLESHOOTING_URL =
+  'https://github.com/blamechris/chroxy/blob/main/docs/troubleshooting/lan-discovery.md';
 
 
 type ParseResult =
@@ -107,6 +113,13 @@ export function ConnectScreen() {
   const [scanning, setScanning] = useState(false);
   const [scanCompleted, setScanCompleted] = useState(false);
   const [scanError, setScanError] = useState(false);
+  // Set when the scan couldn't start because the phone isn't on Wi-Fi (or has no
+  // usable LAN IP) — distinct from a completed scan that simply found nothing, so
+  // the empty state can give the right advice.
+  const [scanNoWifi, setScanNoWifi] = useState(false);
+  // The /24 prefix we actually swept (e.g. "10.0.0"), surfaced in the UI so a
+  // subnet mismatch between phone and daemon is visible (#6561).
+  const [scannedSubnet, setScannedSubnet] = useState<string | null>(null);
   const [discoveredServers, setDiscoveredServers] = useState<DiscoveredServer[]>([]);
   const [scanProgress, setScanProgress] = useState(0);
   const [scanPort, setScanPort] = useState(String(DEFAULT_PORT));
@@ -288,27 +301,48 @@ export function ConnectScreen() {
     setScanning(true);
     setScanCompleted(false);
     setScanError(false);
+    setScanNoWifi(false);
+    setScannedSubnet(null);
     setDiscoveredServers([]);
     setScanProgress(0);
 
     const abort = new AbortController();
     scanAbortRef.current = abort;
 
+    // Drive every terminal outcome through one helper so `scanCompleted` (the E2E
+    // anchor) and the spinner state stay in sync regardless of which branch we hit.
+    const finalizeScan = (patch?: { error?: boolean; noWifi?: boolean }) => {
+      if (abort.signal.aborted) return;
+      if (patch?.error) setScanError(true);
+      if (patch?.noWifi) setScanNoWifi(true);
+      setScanProgress(1);
+      setScanning(false);
+      setScanCompleted(true);
+    };
+
+    const port = validatePort(scanPort);
+    if (port === null) {
+      Alert.alert('Invalid Port', `Port must be between 1 and 65535. Using default (${DEFAULT_PORT}).`);
+      setScanPort(String(DEFAULT_PORT));
+      setScanning(false);
+      return;
+    }
+
     try {
       const deviceIp = await Network.getIpAddressAsync();
-      if (!deviceIp || abort.signal.aborted) {
+      if (abort.signal.aborted) {
         setScanning(false);
         return;
       }
 
-      const subnet = deviceIp.split('.').slice(0, 3).join('.');
-      const port = validatePort(scanPort);
-      if (port === null) {
-        Alert.alert('Invalid Port', `Port must be between 1 and 65535. Using default (${DEFAULT_PORT}).`);
-        setScanPort(String(DEFAULT_PORT));
-        setScanning(false);
+      const subnet = deriveSubnet24(deviceIp);
+      if (!subnet) {
+        // No usable private IPv4 (0.0.0.0 / loopback / link-local / cellular-only)
+        // → the phone has no LAN to sweep. Almost always "not connected to Wi-Fi".
+        finalizeScan({ noWifi: true });
         return;
       }
+      setScannedSubnet(subnet);
 
       await scanSubnet(subnet, port, abort.signal, {
         onProgress: (p) => setScanProgress(p),
@@ -316,14 +350,11 @@ export function ConnectScreen() {
       });
     } catch (err) {
       console.warn('[LAN scan] scan threw unexpectedly:', err);
-      setScanError(true);
+      finalizeScan({ error: true });
+      return;
     }
 
-    if (!abort.signal.aborted) {
-      setScanProgress(1);
-      setScanning(false);
-      setScanCompleted(true);
-    }
+    finalizeScan();
   }, [scanning, scanPort]);
 
   const handleSelectDiscovered = (server: DiscoveredServer) => {
@@ -334,6 +365,20 @@ export function ConnectScreen() {
     // require auth, and connecting with an empty token causes auth failures + rate limiting.
     setShowManual(true);
     scrollToInput();
+  };
+
+  // Reliable, discovery-independent fallback: reveal + scroll to the manual
+  // host+port form. Surfaced from the empty state so a blocked scan has an
+  // obvious next step (#6561).
+  const jumpToManualEntry = () => {
+    setShowManual(true);
+    scrollToInput();
+  };
+
+  const openTroubleshooting = () => {
+    Linking.openURL(LAN_TROUBLESHOOTING_URL).catch(() => {
+      Alert.alert('Could not open link', LAN_TROUBLESHOOTING_URL);
+    });
   };
 
   if (autoConnecting) {
@@ -518,17 +563,32 @@ export function ConnectScreen() {
         <View
           style={styles.discoveredSection}
           testID="lan-scan-empty-state"
-          accessibilityLabel={scanError ? 'LAN scan result: scan failed' : 'LAN scan result: no servers found'}
+          accessibilityLabel={
+            scanNoWifi
+              ? 'LAN scan result: not on Wi-Fi'
+              : scanError
+                ? 'LAN scan result: scan failed'
+                : 'LAN scan result: no servers found'
+          }
         >
-          {scanError ? (
+          {scanNoWifi ? (
+            <>
+              <Text style={styles.scanEmptyTitle} testID="lan-scan-nowifi-title">
+                Not connected to Wi-Fi
+              </Text>
+              <Text style={styles.scanEmptyHint} testID="lan-scan-nowifi-hint">
+                A local network scan needs Wi-Fi. Connect your phone to the same Wi-Fi
+                network as your computer and scan again — or enter the address manually below.
+              </Text>
+            </>
+          ) : scanError ? (
             <>
               <Text style={styles.scanEmptyTitle} testID="lan-scan-error-title">
                 Scan failed (port {scanPort})
               </Text>
               <Text style={styles.scanEmptyHint} testID="lan-scan-error-hint">
-                Could not scan the network. Make sure WiFi is on and your phone and computer are on the same network.{'\n'}
-                If Chroxy is running but not visible, open Chroxy on your computer, go to Settings, and enable{' '}
-                <Text style={styles.scanEmptyHighlight}>"Expose on local network"</Text>, then scan again.
+                Couldn't scan the network. Make sure Wi-Fi is on and your phone is on the
+                same network as your computer, then try again.
               </Text>
             </>
           ) : (
@@ -537,12 +597,41 @@ export function ConnectScreen() {
                 No servers found on port {scanPort}
               </Text>
               <Text style={styles.scanEmptyHint} testID="lan-scan-empty-hint">
-                Chroxy binds to loopback by default and won't appear in a LAN scan.{'\n'}
-                On your computer, open Chroxy {'→'} Settings and enable{' '}
-                <Text style={styles.scanEmptyHighlight}>"Expose on local network"</Text>, then scan again.
+                Scanned{' '}
+                <Text style={styles.scanEmptyHighlight}>
+                  {scannedSubnet ? `${scannedSubnet}.1-254` : 'your Wi-Fi'}
+                </Text>{' '}
+                and found no Chroxy daemon.{'\n\n'}
+                If Chroxy is running and reachable at your computer's LAN IP, your Wi-Fi
+                router may be blocking device-to-device connections (client/AP isolation) —
+                common on mesh and guest networks.{'\n\n'}
+                The reliable way in: <Text style={styles.scanEmptyHighlight}>Enter manually</Text>{' '}
+                with your computer's IP and port, or{' '}
+                <Text style={styles.scanEmptyHighlight}>Scan QR Code</Text>.
               </Text>
             </>
           )}
+
+          <View style={styles.scanEmptyActions}>
+            <TouchableOpacity
+              onPress={jumpToManualEntry}
+              accessibilityRole="button"
+              accessibilityLabel="Enter server address manually"
+              testID="lan-scan-manual-cta"
+            >
+              <Text style={styles.scanEmptyLink}>{ICON_TRIANGLE_RIGHT} Enter address manually</Text>
+            </TouchableOpacity>
+            {!scanNoWifi && (
+              <TouchableOpacity
+                onPress={openTroubleshooting}
+                accessibilityRole="button"
+                accessibilityLabel="Open LAN discovery troubleshooting guide"
+                testID="lan-scan-troubleshooting-link"
+              >
+                <Text style={styles.scanEmptyLink}>{ICON_TRIANGLE_RIGHT} Troubleshooting: LAN discovery</Text>
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
       )}
 
@@ -852,6 +941,17 @@ const styles = StyleSheet.create({
   scanEmptyHighlight: {
     color: COLORS.textMuted,
     fontWeight: '600',
+  },
+  scanEmptyActions: {
+    marginTop: 14,
+    alignItems: 'center',
+    gap: 10,
+  },
+  scanEmptyLink: {
+    color: COLORS.accentBlue,
+    fontSize: 13,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   discoveredItem: {
     flexDirection: 'row',

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -584,7 +584,7 @@ export function ConnectScreen() {
           testID="lan-scan-empty-state"
           accessibilityLabel={
             scanNoWifi
-              ? 'LAN scan result: not on Wi-Fi'
+              ? 'LAN scan result: no local network to scan'
               : scanError
                 ? 'LAN scan result: scan failed'
                 : 'LAN scan result: no servers found'
@@ -593,11 +593,12 @@ export function ConnectScreen() {
           {scanNoWifi ? (
             <>
               <Text style={styles.scanEmptyTitle} testID="lan-scan-nowifi-title">
-                Not connected to Wi-Fi
+                No local network to scan
               </Text>
               <Text style={styles.scanEmptyHint} testID="lan-scan-nowifi-hint">
-                A local network scan needs Wi-Fi. Connect your phone to the same Wi-Fi
-                network as your computer and scan again — or enter the address manually below.
+                Your phone isn't on a Wi-Fi network with a usable local address — it may be
+                on cellular, or on Wi-Fi that hasn't assigned an IPv4 address. Connect to the
+                same Wi-Fi as your computer and scan again — or enter the address manually below.
               </Text>
             </>
           ) : scanError ? (
@@ -634,6 +635,7 @@ export function ConnectScreen() {
           <View style={styles.scanEmptyActions}>
             <TouchableOpacity
               style={styles.scanEmptyLinkButton}
+              activeOpacity={0.7}
               onPress={jumpToManualEntry}
               accessibilityRole="button"
               accessibilityLabel="Enter server address manually"
@@ -644,6 +646,7 @@ export function ConnectScreen() {
             {!scanNoWifi && (
               <TouchableOpacity
                 style={styles.scanEmptyLinkButton}
+                activeOpacity={0.7}
                 onPress={openTroubleshooting}
                 accessibilityRole="link"
                 accessibilityLabel="Open LAN discovery troubleshooting guide"

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -329,6 +329,24 @@ export function ConnectScreen() {
     }
 
     try {
+      // Best-effort transport check: a cellular-only phone can still return a
+      // *scannable* IP (e.g. CGNAT 100.64.x), so IP shape alone can't tell Wi-Fi
+      // from cellular. getNetworkStateAsync makes the "not on Wi-Fi" state
+      // authoritative for cellular; if it throws/undefined we fall back to the IP
+      // heuristic below. We only treat an *explicit* CELLULAR type as no-LAN —
+      // WIFI/ETHERNET/UNKNOWN still proceed to the IP-based subnet check.
+      let onCellular = false;
+      try {
+        const netState = await Network.getNetworkStateAsync();
+        onCellular = netState?.type === Network.NetworkStateType.CELLULAR;
+      } catch {
+        // Older/unsupported platform — rely on the IP check below.
+      }
+      if (abort.signal.aborted) {
+        setScanning(false);
+        return;
+      }
+
       const deviceIp = await Network.getIpAddressAsync();
       if (abort.signal.aborted) {
         setScanning(false);
@@ -336,9 +354,10 @@ export function ConnectScreen() {
       }
 
       const subnet = deriveSubnet24(deviceIp);
-      if (!subnet) {
-        // No usable private IPv4 (0.0.0.0 / loopback / link-local / cellular-only)
-        // → the phone has no LAN to sweep. Almost always "not connected to Wi-Fi".
+      if (!subnet || onCellular) {
+        // No usable LAN IP (0.0.0.0 / loopback / link-local) or an explicitly
+        // cellular transport → the phone has no LAN to sweep. Almost always
+        // "not connected to Wi-Fi".
         finalizeScan({ noWifi: true });
         return;
       }
@@ -614,6 +633,7 @@ export function ConnectScreen() {
 
           <View style={styles.scanEmptyActions}>
             <TouchableOpacity
+              style={styles.scanEmptyLinkButton}
               onPress={jumpToManualEntry}
               accessibilityRole="button"
               accessibilityLabel="Enter server address manually"
@@ -623,8 +643,9 @@ export function ConnectScreen() {
             </TouchableOpacity>
             {!scanNoWifi && (
               <TouchableOpacity
+                style={styles.scanEmptyLinkButton}
                 onPress={openTroubleshooting}
-                accessibilityRole="button"
+                accessibilityRole="link"
                 accessibilityLabel="Open LAN discovery troubleshooting guide"
                 testID="lan-scan-troubleshooting-link"
               >
@@ -943,9 +964,15 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   scanEmptyActions: {
-    marginTop: 14,
+    marginTop: 8,
     alignItems: 'center',
-    gap: 10,
+  },
+  // Wrapper gives each link a >=44pt tap target (Apple HIG); the visible Text
+  // stays 13pt. Matches the `manualToggle` pattern used elsewhere on this screen.
+  scanEmptyLinkButton: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 8,
   },
   scanEmptyLink: {
     color: COLORS.accentBlue,

--- a/packages/app/src/utils/lan-scanner.ts
+++ b/packages/app/src/utils/lan-scanner.ts
@@ -22,7 +22,18 @@ export interface ScanResult {
 }
 
 const BATCH_SIZE = 30;
-const PROBE_TIMEOUT_MS = 1500;
+// Per-probe timeout. On a LAN, a live daemon answers `/health` in a few ms, so a
+// short timeout would be plenty for the *found* case. The timeout only bites on
+// dead IPs — and only on networks that silently DROP packets to unused addresses
+// (many consumer routers) rather than sending a fast RST. On such a network every
+// probe waits the full timeout, so if the live daemon's probe happens to be
+// queued behind a batch of dropped-packet connections (iOS caps concurrent
+// sockets), too-short a timeout can miss a reachable daemon. 2s gives the live
+// probe headroom to answer on a DROP network while keeping the whole sweep
+// (~ceil(254/BATCH_SIZE) batches) inside the E2E flow's 30s budget. On a network
+// that RSTs dead IPs fast (the common case) this value is irrelevant — dead
+// probes reject immediately regardless — so the found-case latency is unchanged.
+const PROBE_TIMEOUT_MS = 2000;
 
 /**
  * Validate a port string and return the numeric port, or null if invalid.
@@ -32,6 +43,46 @@ export function validatePort(portStr: string): number | null {
   const parsed = Number(portStr);
   if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) return null;
   return parsed;
+}
+
+/**
+ * True when `ip` is a dotted-quad IPv4 we can actually derive a scannable /24
+ * from — i.e. a real host address on some network, not a placeholder or an
+ * address whose peers we could never reach.
+ *
+ * Rejects: non-IPv4 (empty, IPv6, junk), the unspecified `0.0.0.0`, loopback
+ * `127/8`, and link-local `169.254/16` (APIPA — the phone has no real DHCP lease,
+ * so there is no LAN to sweep). Everything else, including any RFC1918 private
+ * range, is accepted; we intentionally do NOT hard-code "must be 10/192.168/172"
+ * because some networks hand out other ranges.
+ */
+export function isScannableIpv4(ip: string | null | undefined): boolean {
+  if (!ip || typeof ip !== 'string') return false;
+  const m = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const octets = m.slice(1, 5).map(Number);
+  if (octets.some((o) => o > 255)) return false;
+  const [a, b] = octets;
+  if (a === 0) return false; // 0.0.0.0 / 0/8 — unspecified
+  if (a === 127) return false; // loopback
+  if (a === 169 && b === 254) return false; // link-local (no DHCP lease)
+  return true;
+}
+
+/**
+ * Derive the /24 subnet prefix (e.g. `"10.0.0"`) we sweep for a given device IP,
+ * or `null` when the IP isn't scannable (see {@link isScannableIpv4}).
+ *
+ * We assume a /24 because that is what the vast majority of home/office Wi-Fi
+ * networks use and expo-network does not expose the interface netmask. If the
+ * daemon lives on a wider network (e.g. a /16) or a different subnet than the
+ * phone, this sweep will not reach it — hence the UI surfaces the exact subnet
+ * scanned so a subnet mismatch is visible, and always offers manual entry / QR
+ * as the reliable, discovery-independent fallback.
+ */
+export function deriveSubnet24(ip: string | null | undefined): string | null {
+  if (!isScannableIpv4(ip)) return null;
+  return (ip as string).split('.').slice(0, 3).join('.');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the mobile app's **"Scan Local Network"** empty state and hardens the scan itself, for [#6561](https://github.com/blamechris/chroxy/issues/6561).

**Key reframing:** the app's "Scan Local Network" is **not mDNS/Bonjour** — there is no zeroconf library. It's a **unicast `/24` subnet sweep**: it takes the phone's Wi-Fi IP, derives the `/24`, and HTTP-probes `GET /health` on every address (`.1`–`.254`). So:

- `dns-sd`/Bonjour advertising and router **multicast/IGMP** filtering are **irrelevant** to this scan — the app never listens for mDNS.
- The old empty-state copy — *"Chroxy binds to loopback by default and won't appear in a LAN scan"* — was **false** (the daemon was on `0.0.0.0`) and told the user to enable a setting that was already on.
- When a unicast sweep finds nothing on the same Wi-Fi, the real culprit is almost always **client/AP isolation** (blocks unicast device-to-device), a guest network, or a subnet mismatch — not multicast.

## What changed

**`packages/app/src/utils/lan-scanner.ts`**
- New pure, unit-tested helpers `isScannableIpv4()` / `deriveSubnet24()` — reject `0.0.0.0`, loopback, link-local (APIPA) and non-IPv4 before sweeping.
- Probe timeout `1500ms → 2000ms`: more headroom for a reachable daemon whose probe gets queued behind dropped-packet connections on routers that silently DROP (not RST) to dead IPs. On the common RST-fast network this value is irrelevant, so found-case latency is unchanged; the whole sweep still fits the E2E flow's 30s budget.

**`packages/app/src/screens/ConnectScreen.tsx`**
- Distinct **"Not connected to Wi-Fi"** empty state when the phone has no usable LAN IP.
- **Surfaces the exact `/24` swept** (e.g. *"Scanned `10.0.0.1-254`"*) so a subnet mismatch between phone and daemon is visible.
- Replaces the false loopback copy with honest **client/AP-isolation** guidance.
- Adds tappable **"Enter address manually"** (jumps to the host+port form) and **"Troubleshooting: LAN discovery"** (opens the new doc) — the reliable, discovery-independent fallbacks.
- Preserves the `lan-scan-complete` E2E anchor and all existing testIDs.

**`docs/troubleshooting/lan-discovery.md`** (new)
- Explains the unicast-not-mDNS design, the **one bisecting test** (from the phone, open `http://<mac-ip>:8765/health` with cellular off — loads ⇒ sweep-side, hangs ⇒ router isolation), vendor-by-vendor router fixes (client/AP isolation, guest network, band/SSID split, mesh device-isolation), and the manual/QR fallbacks. Linked from the empty state and `CLAUDE.md` runbooks.

## Testing

- `npx jest` — new `lan-scanner.test.ts` (helpers) + existing `endpoint-selector` / `connection-audit-phase1` / `connection-persistence-lan` suites: **green**.
- `npx tsc --noEmit` — clean on the touched files (only the pre-existing, gitignored `xterm-bundle.generated` artifact error remains, which CI builds).

## Not closing #6561 yet

The code + docs address asks 2–4 and reframe ask 1. The **root cause on the maintainer's specific network** (router client-isolation vs. a sweep-side miss) still needs the on-device bisecting test in the doc's *Step 0*. Once @blamechris confirms the reachability test result, we close the loop (and, if it's a sweep-side miss, follow up with any further tuning).

Related to #6561