### PR TITLE
fix(server): three provider/token bugs — init provider picker, Codex OAuth runtime, --show-token under supervisor

### DIFF
--- a/packages/server/src/cli/init-cmd.js
+++ b/packages/server/src/cli/init-cmd.js
@@ -153,8 +153,16 @@ export async function runInitCmd(deps = {}) {
   const providersInput = await promptFn('   Providers: ')
   const providers = parseProviderSelection(providersInput)
 
+  // #6565: the daemon's provider SELECTOR reads the singular `provider` key
+  // (server-cli.js `config.provider || DEFAULT_PROVIDER`), NOT this `providers[]`
+  // list — that array is informational only (providers-cmd.js). Write the primary
+  // choice (providers[0]) as `provider` so the picker actually takes effect;
+  // otherwise a non-default selection is silently ignored and the daemon falls
+  // back to DEFAULT_PROVIDER (claude-tui). PROVIDER_CHOICES ids are already valid
+  // selector ids ('claude-tui', 'codex', …), so no mapping is needed.
   const config = {
     port,
+    ...(providers.length > 0 ? { provider: providers[0] } : {}),
     providers,
   }
 

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -10,6 +10,7 @@ import {
   maybeRatchetContextWindow,
 } from './utils/context-window-learn.js'
 import { BILLING_CLASSES } from './billing-class.js'
+import { hasCodexOAuthCreds } from './auth-probes.js'
 
 /**
  * Manages a Codex CLI session using `codex exec --json`.
@@ -308,6 +309,17 @@ export class CodexSession extends JsonlSubprocessSession {
     return 'OPENAI_API_KEY'
   }
 
+  /**
+   * #6563 — Codex authenticates via OPENAI_API_KEY OR OAuth tokens cached in
+   * ~/.codex/auth.json by `codex login`. Reuse the SAME probe resolveAuth() and
+   * the preflight use so all three layers (display, runtime, preflight) agree
+   * that a `codex login`-only user is authenticated — start() must not throw for
+   * them just because the env key is unset.
+   */
+  static hasAlternativeCredentials() {
+    return hasCodexOAuthCreds()
+  }
+
   static get providerName() {
     return 'codex'
   }
@@ -408,7 +420,11 @@ export class CodexSession extends JsonlSubprocessSession {
       credentials: {
         envVars: ['OPENAI_API_KEY'],
         hint: 'set OPENAI_API_KEY',
-        optional: false,
+        // #6563: the env var is OPTIONAL when OAuth creds exist (`codex login`),
+        // so `chroxy doctor` agrees with resolveAuth() (ready on OAuth) instead of
+        // reporting a false credentials failure. Same probe as resolveAuth() +
+        // hasAlternativeCredentials() → one definition of "authenticated".
+        optional: hasCodexOAuthCreds(),
       },
     }
   }

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -421,9 +421,11 @@ export class CodexSession extends JsonlSubprocessSession {
         envVars: ['OPENAI_API_KEY'],
         hint: 'set OPENAI_API_KEY',
         // #6563: the env var is OPTIONAL when OAuth creds exist (`codex login`),
-        // so `chroxy doctor` agrees with resolveAuth() (ready on OAuth) instead of
-        // reporting a false credentials failure. Same probe as resolveAuth() +
-        // hasAlternativeCredentials() → one definition of "authenticated".
+        // so `chroxy doctor` downgrades the missing env var from fail→warn instead
+        // of a hard credentials failure — doctor can't read the OAuth token, but it
+        // must not report a false failure when resolveAuth() is ready on OAuth. Same
+        // probe as resolveAuth() + hasAlternativeCredentials() → one definition of
+        // "has a usable credential".
         optional: hasCodexOAuthCreds(),
       },
     }

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -241,9 +241,11 @@ export class GeminiSession extends JsonlSubprocessSession {
         envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
         hint: 'set GEMINI_API_KEY or GOOGLE_API_KEY',
         // #6563: the env var is OPTIONAL when OAuth creds exist (`gemini login`),
-        // so `chroxy doctor` agrees with resolveAuth() (ready on OAuth) instead
-        // of reporting a false credentials failure. Same probe as resolveAuth()
-        // + hasAlternativeCredentials() → one definition of "authenticated".
+        // so `chroxy doctor` downgrades the missing env var from fail→warn instead
+        // of a hard credentials failure — doctor can't read the OAuth token, but it
+        // must not report a false failure when resolveAuth() is ready on OAuth. Same
+        // probe as resolveAuth() + hasAlternativeCredentials() → one definition of
+        // "has a usable credential".
         optional: hasGeminiOAuthCreds(),
       },
     }

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
+import { hasGeminiOAuthCreds } from './auth-probes.js'
 import {
   CONTEXT_WINDOW_HEADROOM,
   getRatchetCap,
@@ -127,6 +128,17 @@ export class GeminiSession extends JsonlSubprocessSession {
     return 'GEMINI_API_KEY'
   }
 
+  /**
+   * #6563 — Gemini authenticates via GEMINI_API_KEY / GOOGLE_API_KEY OR OAuth
+   * tokens cached under ~/.gemini by `gemini login`. Reuse the SAME probe
+   * resolveAuth() and the preflight use so all three layers (display, runtime,
+   * preflight) agree that a `gemini login`-only user is authenticated — start()
+   * must not throw for them just because the env key is unset.
+   */
+  static hasAlternativeCredentials() {
+    return hasGeminiOAuthCreds()
+  }
+
   static get providerName() {
     return 'gemini'
   }
@@ -228,7 +240,11 @@ export class GeminiSession extends JsonlSubprocessSession {
         // preflight + #3404 audit auth surface match what the spawn allows.
         envVars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
         hint: 'set GEMINI_API_KEY or GOOGLE_API_KEY',
-        optional: false,
+        // #6563: the env var is OPTIONAL when OAuth creds exist (`gemini login`),
+        // so `chroxy doctor` agrees with resolveAuth() (ready on OAuth) instead
+        // of reporting a false credentials failure. Same probe as resolveAuth()
+        // + hasAlternativeCredentials() → one definition of "authenticated".
+        optional: hasGeminiOAuthCreds(),
       },
     }
   }

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -72,6 +72,18 @@ export class JsonlSubprocessSession extends BaseSession {
     throw new Error(`${this.name}.apiKeyEnv must be overridden`)
   }
 
+  /**
+   * #6563 — whether this provider can authenticate WITHOUT `apiKeyEnv` set
+   * (e.g. Codex OAuth tokens in ~/.codex/auth.json from `codex login`). When
+   * true, start() does NOT throw on a missing env var. Base default: false
+   * (env-var-only). A subclass with a non-env credential source overrides this
+   * to reuse the SAME probe its resolveAuth()/preflight use, so display, runtime,
+   * and preflight share one definition of "authenticated".
+   */
+  static hasAlternativeCredentials() {
+    return false
+  }
+
   static get providerName() {
     throw new Error(`${this.name}.providerName must be overridden`)
   }
@@ -125,7 +137,12 @@ export class JsonlSubprocessSession extends BaseSession {
 
   start() {
     const envVar = this.constructor.apiKeyEnv
-    if (!process.env[envVar]) {
+    // #6563: OAuth-only providers (Codex via `codex login`) have no env key — the
+    // child authenticates from its OAuth file (e.g. ~/.codex/auth.json; HOME is
+    // forwarded to the child). Only throw when there is NEITHER the env var NOR an
+    // alternative credential source, so a `codex login`-only user isn't rejected
+    // by the runtime despite resolveAuth() reporting ready.
+    if (!process.env[envVar] && !this.constructor.hasAlternativeCredentials()) {
       throw new Error(`${envVar} environment variable is not set`)
     }
     this._processReady = true

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -258,7 +258,7 @@ export function getLogLevel() {
  * @returns {{ debug: Function, info: Function, warn: Function, error: Function, audit: Function, log: Function, withSession: Function }}
  */
 export function createLogger(component, context = {}) {
-  const write = (level, msg, { always = false } = {}) => {
+  const write = (level, msg, { always = false, toConsole = true } = {}) => {
     // `always` bypasses the configured level gate (#6001) so an audit trail is
     // never dropped by LOG_LEVEL. Everything else (redaction, console routing,
     // listener broadcast, file write) is identical to a normal line.
@@ -270,10 +270,15 @@ export function createLogger(component, context = {}) {
       ? JSON.stringify({ ts: timestamp, level, component, msg: safeMsg })
       : `${timestamp} [${level.toUpperCase()}] [${component}] ${safeMsg}`
 
-    // Always write to console (for foreground mode)
-    if (level === 'error') console.error(line)
-    else if (level === 'warn') console.warn(line)
-    else console.log(line)
+    // Write to console (for foreground mode). #6566: `toConsole:false` suppresses
+    // the console write while keeping the file + listener paths — used by the
+    // supervisor to log a REDACTED connect-block line to disk while printing the
+    // un-redacted line to the operator's terminal separately under --show-token.
+    if (toConsole) {
+      if (level === 'error') console.error(line)
+      else if (level === 'warn') console.warn(line)
+      else console.log(line)
+    }
 
     // Notify listeners (for WS broadcast to dashboard)
     if (_logListeners.size > 0) {
@@ -305,9 +310,9 @@ export function createLogger(component, context = {}) {
 
   return {
     debug(msg) { write('debug', msg) },
-    info(msg) { write('info', msg) },
-    warn(msg) { write('warn', msg) },
-    error(msg) { write('error', msg) },
+    info(msg, opts) { write('info', msg, opts) },
+    warn(msg, opts) { write('warn', msg, opts) },
+    error(msg, opts) { write('error', msg, opts) },
     /**
      * Always-on audit line (#6001) — bypasses the configured LOG_LEVEL so a
      * security audit trail (e.g. shell-audit) is never suppressed by a quiet

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -20,6 +20,16 @@ function maskToken(token) {
   return `${token.slice(0, 4)}...${token.slice(-4)}`
 }
 
+// #6566: the StartupDisplay connect-block lines that carry the API token —
+// `   Token: <token>` and `   Dashboard: …?token=<token>`. Under --show-token the
+// supervisor prints these RAW to the operator's terminal instead of letting the
+// redacting logger scrub them back to [REDACTED] (the child's stdout is re-logged
+// through that logger). Deliberately narrow — only the startup banner, never an
+// arbitrary log line that happens to mention a token. Exported for the test.
+export function isConnectBlockTokenLine(line) {
+  return /^\s*Token:\s/.test(line) || /Dashboard:\s.*\?token=/.test(line)
+}
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'))
@@ -432,6 +442,17 @@ export class Supervisor extends EventEmitter {
     if (this._child.stdout) {
       stdoutRl = createInterface({ input: this._child.stdout })
       stdoutRl.on('line', (line) => {
+        // #6566: honour --show-token through the supervisor pipe. The child prints
+        // the real token in the connect-block when --show-token is set, but the
+        // logger's secret-redaction scrubs it on the way to the terminal. When the
+        // operator explicitly asked to see it, print those lines RAW to the
+        // terminal and log a REDACTED copy to the FILE only (toConsole:false), so
+        // the token reaches the operator's terminal but never lands on disk.
+        if (this.config.showToken && isConnectBlockTokenLine(line)) {
+          process.stdout.write(`${line}\n`)
+          this._log.info(`[child:out] ${line}`, { toConsole: false })
+          return
+        }
         this._log.info(`[child:out] ${line}`)
       })
     }

--- a/packages/server/tests/cli-init-cmd.test.js
+++ b/packages/server/tests/cli-init-cmd.test.js
@@ -111,6 +111,37 @@ describe('chroxy init provider picker', () => {
     assert.deepEqual(parsed.providers, ['gemini'])
   })
 
+  // #6565: the daemon's provider SELECTOR reads the singular `provider` key
+  // (server-cli.js `config.provider || DEFAULT_PROVIDER`), NOT `providers[]`.
+  // init must write `provider = providers[0]` so a picked provider actually runs.
+  it('#6565: writes the singular `provider` key = primary choice (default → claude-tui)', async () => {
+    const mock = makePrompt(['', ''])
+    const env = makeEnv()
+    await runInitCmd({
+      force: true, promptFn: mock.fn, logFn: env.log, writeFileFn: env.writeFile,
+      ensureDirFn: () => {}, configFilePath: '/tmp/fake-config.json', configDirPath: '/tmp/fake-dir',
+      existsFn: () => false, isKeychainAvailableFn: () => false, setTokenFn: () => {},
+    })
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.equal(parsed.provider, 'claude-tui', 'singular `provider` written for the selector')
+    assert.deepEqual(parsed.providers, ['claude-tui'])
+  })
+
+  it('#6565: a non-default pick (codex) writes provider=codex → start resolves codex', async () => {
+    const mock = makePrompt(['', '3']) // 3 = codex
+    const env = makeEnv()
+    await runInitCmd({
+      force: true, promptFn: mock.fn, logFn: env.log, writeFileFn: env.writeFile,
+      ensureDirFn: () => {}, configFilePath: '/tmp/fake-config.json', configDirPath: '/tmp/fake-dir',
+      existsFn: () => false, isKeychainAvailableFn: () => false, setTokenFn: () => {},
+    })
+    const parsed = JSON.parse(env.getWritten().contents)
+    assert.equal(parsed.provider, 'codex')
+    assert.deepEqual(parsed.providers, ['codex'])
+    // Mirrors the selector in server-cli.js — the daemon would now run codex.
+    assert.equal(parsed.provider || 'claude-tui', 'codex')
+  })
+
   it('shows next-step hint for codex (OPENAI_API_KEY)', async () => {
     const mock = makePrompt(['', '3'])
     const env = makeEnv()

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -895,8 +895,9 @@ describe('CodexSession', () => {
 
     // #6563: a `codex login`-only user (OAuth tokens in ~/.codex/auth.json, no
     // OPENAI_API_KEY) must be runtime-ready — start() must NOT throw (matching
-    // resolveAuth()'s ready:true), and preflight must mark the env var optional so
-    // `chroxy doctor` agrees. All three layers share the hasCodexOAuthCreds probe.
+    // resolveAuth()'s ready:true), and preflight marks the env var optional so
+    // `chroxy doctor` downgrades the missing key from fail→warn (not a hard
+    // failure). All three layers share the hasCodexOAuthCreds probe.
     it('#6563: OAuth-only (auth.json present, no env var) — start() does not throw + preflight optional', () => {
       const oauthDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-oauth-'))
       writeFileSync(join(oauthDir, 'auth.json'), JSON.stringify({ tokens: { access_token: 'tok-abc' } }))
@@ -905,7 +906,7 @@ describe('CodexSession', () => {
       delete process.env.OPENAI_API_KEY
       try {
         assert.equal(CodexSession.hasAlternativeCredentials(), true)
-        assert.equal(CodexSession.preflight.credentials.optional, true, 'doctor agrees Codex is authenticated via OAuth')
+        assert.equal(CodexSession.preflight.credentials.optional, true, 'preflight marks the key optional so doctor downgrades a missing key fail→warn, not a hard failure')
         const session = new CodexSession({ cwd: '/tmp' })
         assert.doesNotThrow(() => session.start(), 'OAuth-only user is not rejected at runtime')
         assert.equal(session._processReady, true)

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -862,11 +862,23 @@ describe('CodexSession', () => {
   })
 
   describe('start() API key validation', () => {
+    let savedCodexHome, noOauthDir
+    beforeEach(() => {
+      // #6563: isolate the OAuth probe from the test machine's ~/.codex so the
+      // "no creds → throws" expectation is deterministic regardless of whether the
+      // dev has run `codex login`. Point CHROXY_CODEX_HOME at an empty dir.
+      savedCodexHome = process.env.CHROXY_CODEX_HOME
+      noOauthDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-noauth-'))
+      process.env.CHROXY_CODEX_HOME = noOauthDir
+    })
     afterEach(() => {
       process.env.OPENAI_API_KEY = 'test-key'
+      if (savedCodexHome === undefined) delete process.env.CHROXY_CODEX_HOME
+      else process.env.CHROXY_CODEX_HOME = savedCodexHome
+      try { rmSync(noOauthDir, { recursive: true, force: true }) } catch { /* best effort */ }
     })
 
-    it('throws when OPENAI_API_KEY is not set', () => {
+    it('throws when OPENAI_API_KEY is not set and no OAuth creds', () => {
       const session = new CodexSession({ cwd: '/tmp' })
       delete process.env.OPENAI_API_KEY
       assert.throws(() => session.start(), {
@@ -879,6 +891,30 @@ describe('CodexSession', () => {
       session.start()
       assert.equal(session._processReady, true)
       session.destroy()
+    })
+
+    // #6563: a `codex login`-only user (OAuth tokens in ~/.codex/auth.json, no
+    // OPENAI_API_KEY) must be runtime-ready — start() must NOT throw (matching
+    // resolveAuth()'s ready:true), and preflight must mark the env var optional so
+    // `chroxy doctor` agrees. All three layers share the hasCodexOAuthCreds probe.
+    it('#6563: OAuth-only (auth.json present, no env var) — start() does not throw + preflight optional', () => {
+      const oauthDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-oauth-'))
+      writeFileSync(join(oauthDir, 'auth.json'), JSON.stringify({ tokens: { access_token: 'tok-abc' } }))
+      const savedHome = process.env.CHROXY_CODEX_HOME
+      process.env.CHROXY_CODEX_HOME = oauthDir
+      delete process.env.OPENAI_API_KEY
+      try {
+        assert.equal(CodexSession.hasAlternativeCredentials(), true)
+        assert.equal(CodexSession.preflight.credentials.optional, true, 'doctor agrees Codex is authenticated via OAuth')
+        const session = new CodexSession({ cwd: '/tmp' })
+        assert.doesNotThrow(() => session.start(), 'OAuth-only user is not rejected at runtime')
+        assert.equal(session._processReady, true)
+        session.destroy()
+      } finally {
+        if (savedHome === undefined) delete process.env.CHROXY_CODEX_HOME
+        else process.env.CHROXY_CODEX_HOME = savedHome
+        try { rmSync(oauthDir, { recursive: true, force: true }) } catch { /* best effort */ }
+      }
     })
   })
 

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -91,7 +91,7 @@ describe('GeminiSession', () => {
       let session = null
       try {
         assert.equal(GeminiSession.hasAlternativeCredentials(), true)
-        assert.equal(GeminiSession.preflight.credentials.optional, true, 'doctor agrees Gemini is authenticated via OAuth')
+        assert.equal(GeminiSession.preflight.credentials.optional, true, 'preflight marks the key optional so doctor downgrades a missing key fail→warn, not a hard failure')
         session = new GeminiSession({ cwd: '/tmp' })
         // The base JsonlSubprocessSession.start() throws the API-key error ONLY when
         // no env var AND no alt creds; with OAuth present that throw must be skipped.

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -54,6 +54,61 @@ describe('GeminiSession', () => {
     assert.equal(session.model, 'gemini-2.5-pro')
   })
 
+  // #6563: parity with the Codex fix — a `gemini login`-only user (OAuth tokens
+  // under ~/.gemini, no GEMINI_API_KEY) must be runtime-ready. hasAlternativeCredentials()
+  // reuses the same hasGeminiOAuthCreds() probe resolveAuth() + preflight use, so all
+  // three layers (display, runtime, preflight) agree — start() must not throw for the
+  // missing env key and `chroxy doctor` marks the credential optional.
+  describe('start() OAuth-awareness (#6563)', () => {
+    let savedGeminiHome, noOauthDir
+    beforeEach(() => {
+      // Isolate the OAuth probe from the test machine's real ~/.gemini so the
+      // "no creds" expectation is deterministic regardless of a real `gemini login`.
+      savedGeminiHome = process.env.CHROXY_GEMINI_HOME
+      noOauthDir = mkdtempSync(join(tmpdir(), 'chroxy-gemini-noauth-'))
+      process.env.CHROXY_GEMINI_HOME = noOauthDir
+    })
+    afterEach(() => {
+      if (savedGeminiHome === undefined) delete process.env.CHROXY_GEMINI_HOME
+      else process.env.CHROXY_GEMINI_HOME = savedGeminiHome
+      try { rmSync(noOauthDir, { recursive: true, force: true }) } catch { /* best effort */ }
+    })
+
+    it('no env var and no OAuth creds → hasAlternativeCredentials() false + preflight credential required', () => {
+      delete process.env.GEMINI_API_KEY
+      assert.equal(GeminiSession.hasAlternativeCredentials(), false)
+      assert.equal(GeminiSession.preflight.credentials.optional, false)
+    })
+
+    it('OAuth-only (oauth_creds.json present, no env var) — hasAlternativeCredentials() + preflight optional + start() not rejected for the missing key', () => {
+      // Different temp dir than noOauthDir — the OAuth probe is cache-keyed on
+      // CHROXY_GEMINI_HOME, so reusing the dir would risk a stale cached false.
+      const oauthDir = mkdtempSync(join(tmpdir(), 'chroxy-gemini-oauth-'))
+      writeFileSync(join(oauthDir, 'oauth_creds.json'), JSON.stringify({ access_token: 'tok-abc' }))
+      const savedHome = process.env.CHROXY_GEMINI_HOME
+      process.env.CHROXY_GEMINI_HOME = oauthDir
+      delete process.env.GEMINI_API_KEY
+      let session = null
+      try {
+        assert.equal(GeminiSession.hasAlternativeCredentials(), true)
+        assert.equal(GeminiSession.preflight.credentials.optional, true, 'doctor agrees Gemini is authenticated via OAuth')
+        session = new GeminiSession({ cwd: '/tmp' })
+        // The base JsonlSubprocessSession.start() throws the API-key error ONLY when
+        // no env var AND no alt creds; with OAuth present that throw must be skipped.
+        // A binary-not-found error (gemini CLI absent in CI) is unrelated — only the
+        // GEMINI_API_KEY rejection is asserted against.
+        let apiKeyError = null
+        try { session.start() } catch (e) { if (/GEMINI_API_KEY/.test(e?.message ?? '')) apiKeyError = e }
+        assert.equal(apiKeyError, null, 'OAuth-only user is not rejected at runtime for a missing API key')
+      } finally {
+        if (session) { try { session.destroy() } catch { /* best effort */ } }
+        if (savedHome === undefined) delete process.env.CHROXY_GEMINI_HOME
+        else process.env.CHROXY_GEMINI_HOME = savedHome
+        try { rmSync(oauthDir, { recursive: true, force: true }) } catch { /* best effort */ }
+      }
+    })
+  })
+
   // ---------------------------------------------------------------------
   // #3225: JsonlSubprocessSession previously dropped these constructor
   // opts at the middle layer, so providers gating and manual activation
@@ -322,6 +377,22 @@ describe('GeminiSession', () => {
   })
 
   describe('start() API key validation', () => {
+    // #6563: isolate the OAuth probe from the test machine's real ~/.gemini so the
+    // "no key → throws" expectation is deterministic regardless of a real `gemini
+    // login` (hasAlternativeCredentials() now gates the throw). Point CHROXY_GEMINI_HOME
+    // at an empty dir so hasGeminiOAuthCreds() is false here.
+    let savedGeminiHome, noOauthDir
+    beforeEach(() => {
+      savedGeminiHome = process.env.CHROXY_GEMINI_HOME
+      noOauthDir = mkdtempSync(join(tmpdir(), 'chroxy-gemini-akv-'))
+      process.env.CHROXY_GEMINI_HOME = noOauthDir
+    })
+    afterEach(() => {
+      if (savedGeminiHome === undefined) delete process.env.CHROXY_GEMINI_HOME
+      else process.env.CHROXY_GEMINI_HOME = savedGeminiHome
+      try { rmSync(noOauthDir, { recursive: true, force: true }) } catch { /* best effort */ }
+    })
+
     it('throws when GEMINI_API_KEY is not set', () => {
       const session = new GeminiSession({ cwd: '/tmp' })
       delete process.env.GEMINI_API_KEY

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { Readable } from 'stream'
 import { createServer as createNetServer } from 'net'
-import { Supervisor } from '../src/supervisor.js'
+import { Supervisor, isConnectBlockTokenLine } from '../src/supervisor.js'
 
 // Bind without a host arg so these probes match how the supervisor's standby
 // server binds (`listen(port)` → the unspecified address), otherwise an
@@ -247,6 +247,53 @@ describe('Supervisor', () => {
 
       supervisor._shuttingDown = true
       clearInterval(supervisor._heartbeatInterval)
+    })
+
+    // #6566: under supervision the child prints the real token in its connect-block
+    // when --show-token is set, but that stdout line is re-logged through the
+    // redacting logger — scrubbing it back to [REDACTED] on the way to the
+    // operator's terminal. Push a connect-block line through the child's stdout
+    // (a distinct token so the supervisor's own masked banner can't interfere) and
+    // inspect what reaches process.stdout.
+    async function driveChildLine(showToken, line) {
+      const { supervisor } = setup(showToken ? { showToken: true } : {})
+      const chunks = []
+      mock.method(process.stdout, 'write', (chunk) => { chunks.push(String(chunk)); return true })
+      try {
+        await supervisor.start()
+        supervisor.lastChild.stdout.push(line + '\n')
+        await new Promise((r) => setImmediate(r))
+        await new Promise((r) => setImmediate(r))
+      } finally {
+        mock.restoreAll()
+        supervisor._shuttingDown = true
+        if (supervisor._heartbeatInterval) clearInterval(supervisor._heartbeatInterval)
+      }
+      return chunks.join('')
+    }
+
+    it('#6566: --show-token reveals the real token in the terminal under supervision', async () => {
+      const out = await driveChildLine(true, '   Token: SHOWTOKEN-SECRET-123')
+      assert.match(out, /SHOWTOKEN-SECRET-123/, 'the real token reaches the terminal under --show-token')
+      assert.doesNotMatch(out, /Token: \[REDACTED\]/, 'the connect-block Token line is not scrubbed')
+    })
+
+    it('#6566: --show-token reveals the full ?token= dashboard URL under supervision', async () => {
+      const out = await driveChildLine(true, '   Dashboard: http://host:8765/dashboard?token=SHOWTOKEN-SECRET-123')
+      assert.match(out, /\?token=SHOWTOKEN-SECRET-123/, 'the full ?token= URL reaches the terminal')
+    })
+
+    it('#6566: still redacts the token WITHOUT --show-token (default supervised path)', async () => {
+      const out = await driveChildLine(false, '   Token: SHOWTOKEN-SECRET-123')
+      assert.doesNotMatch(out, /SHOWTOKEN-SECRET-123/, 'the token is redacted when the flag is off')
+      assert.match(out, /\[REDACTED\]/, 'the redacting logger still scrubs the token to disk + terminal')
+    })
+
+    it('#6566: isConnectBlockTokenLine matches only the connect-block token lines', () => {
+      assert.equal(isConnectBlockTokenLine('   Token: abc123'), true)
+      assert.equal(isConnectBlockTokenLine('   Dashboard: http://h/dashboard?token=abc123'), true)
+      assert.equal(isConnectBlockTokenLine('some log line mentioning a token in prose'), false)
+      assert.equal(isConnectBlockTokenLine('   URL:   ws://host:8765'), false)
     })
 
     it('exits when no API token configured', async () => {


### PR DESCRIPTION
Three related provider/token bugs, one commit each. Each was filed with full root-cause analysis.

## #6565 — `chroxy init` provider picker ignored (root cause)
init persisted the picked provider as the informational `providers[]` array, but selection reads only the singular `config.provider`. A non-default pick (e.g. Codex) was silently ignored → daemon ran claude-tui → TUI timeout (a "no response" that was really "wrong provider"). **Fix:** init writes `provider = providers[0]` (ids are already valid selector ids). `d5950f8de`

## #6563 — Codex reports ready via OAuth but runtime hard-fails (Option A)
`resolveAuth()` accepted `codex login` OAuth as ready, but `start()` threw when `OPENAI_API_KEY` was unset and the preflight declared it non-optional → subscription users saw ready then got a silent no-response. **Fix (runtime OAuth-aware):** a shared `hasCodexOAuthCreds` probe now drives all three layers — `JsonlSubprocessSession.start()` skips the env-var throw when `hasAlternativeCredentials()` is true (Codex overrides it to the OAuth probe), and `preflight.credentials.optional = hasCodexOAuthCreds()` so `chroxy doctor` agrees. `8333da406`

## #6566 — `--show-token` defeated by supervisor log redaction
Under supervision the child's connect-block stdout is re-logged through the redacting logger → `Token: [REDACTED]` even with `--show-token`. **Fix:** the supervisor prints the connect-block raw to the terminal under `--show-token` and logs a redacted copy to the file only (new logger `toConsole:false`), so the operator sees the real token + full `?token=` URL while `~/.chroxy/logs` never gets the raw token. `0ed8ddb54`

## Verification
- ✅ Targeted sweep over the full blast radius: init, codex, `JsonlSubprocessSession` base + both subclasses (codex, gemini), logger (`toConsole`), supervisor — **431 tests, 0 fail**.
- ✅ New tests per issue: init provider-key (default + codex pick); Codex OAuth-only path through `start()` + preflight; supervised `--show-token` reveal + default-redact + `isConnectBlockTokenLine`.
- ✅ All 5 server custom lints green (incl. `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`).

Closes #6565
Closes #6563
Closes #6566