### PR TITLE
fix(server): recover a ghost-resume claude-tui session on the first confirmed death (#6576)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1384,7 +1384,18 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     this._respawnCount++
-    if (this._respawnCount > 5) {
+    // #6576 — fire the retry-FRESH as soon as the dying tail CONFIRMS the resume id
+    // is unknown (the `_scanOutputForUnknownResume()` disjunct), not only at the
+    // 5-respawn cap. Retrying a `--resume` claude has ALREADY rejected is pointless,
+    // and the cap-gated ~30s of backoff exceeds a client's readiness timeout — a
+    // ghost resume otherwise broadcast `session_restore_failed` and wedged every
+    // real client into a reconnect loop (daemon restarts also reset `_respawnCount`,
+    // so the cap was never reached). The one-shot `_didFallbackFromUnknownResume`
+    // latch (the `|| this._didFallbackFromUnknownResume` disjunct) keeps a fresh
+    // attempt that ALSO dies routing to exhaustion instead of looping; the
+    // `_respawnCount > 5` disjunct still governs UNCONFIRMED crash loops (#5417) so a
+    // real conversation is never abandoned without claude's own rejection.
+    if (this._scanOutputForUnknownResume() || this._didFallbackFromUnknownResume || this._respawnCount > 5) {
       // #5348 — drop-and-retry-FRESH fallback. A FRESH session (spawned with
       // `--session-id`) that died before claude persisted its conversation
       // makes every `--resume` respawn doomed: claude can't find the

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1453,7 +1453,13 @@ export class ClaudeTuiSession extends BaseSession {
         })
         // Fall through to the scheduling below — this IS the extra attempt.
       } else {
-        ;(this._log || log).error(`Max PTY respawn attempts reached (${this._respawnCount - 1}), giving up`)
+        // #6576 — with the early retry-FRESH firing, this else can be reached via
+        // the `_didFallbackFromUnknownResume` latch (fresh fallback also died) BEFORE
+        // the 5-respawn cap, so log the real reason instead of a misleading
+        // "Max PTY respawn attempts reached" when the count never hit the cap.
+        ;(this._log || log).error(this._didFallbackFromUnknownResume
+          ? `Fresh-conversation retry also died during warmup after the resume id was rejected — giving up (${this._respawnCount - 1} attempt(s))`
+          : `Max PTY respawn attempts reached (${this._respawnCount - 1}), giving up`)
         const tail = this._outputTailDiagnostic()
         // When the retry-FRESH fallback itself failed, escalate with the same
         // terminal code CliSession uses (resume_unknown_exhausted, #5004) —

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1124,7 +1124,7 @@ describe('ClaudeTuiSession', () => {
     // CONFIRM the resume id is unknown (claude's own "No conversation found"
     // rejection), so the doomed resumes here die with that diagnostic in the
     // tail, exactly as the real claude TUI renders it before exiting.
-    it('an originally-fresh session gets ONE retry-FRESH attempt at the cap when the tail confirms resume_unknown (#5348/#5417)', async () => {
+    it('an originally-fresh session retries FRESH on the FIRST confirmed unknown-resume death, then exhausts if the fresh attempt also dies (#6576/#5348/#5417)', async () => {
       const spawns = []
       session = makeSession((self) => {
         spawns.push({ resumed: self._resumedFromPersisted, id: self._sessionId })
@@ -1138,18 +1138,19 @@ describe('ClaudeTuiSession', () => {
       session.on('respawn_exhausted', (d) => exhausted.push(d))
 
       session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
-      // 5 doomed --resume attempts, then the fresh fallback (also 15s backoff).
-      for (const d of [1000, 2000, 4000, 8000, 15000, 15000]) {
+      // #6576: the FIRST respawn dies with claude's "No conversation found" tail →
+      // retry FRESH immediately (no 5-respawn cap wait). The fresh attempt here also
+      // dies (null tail) → one-shot latch → exhaust. Two spawns total, not six.
+      for (const d of [1000, 2000, 4000]) {
         mock.timers.tick(d)
         await new Promise((r) => setImmediate(r))
       }
-      mock.timers.tick(15000)
-      await new Promise((r) => setImmediate(r))
 
-      assert.equal(spawns.length, 6, '5 resume attempts + exactly one fresh fallback attempt')
-      assert.ok(spawns.slice(0, 5).every((s) => s.resumed && s.id === 'conv-uuid-1234'), 'first 5 attempts --resume the original conversation')
-      assert.equal(spawns[5].resumed, false, 'the fallback attempt spawns FRESH (--session-id, not --resume)')
-      assert.notEqual(spawns[5].id, 'conv-uuid-1234', 'the fallback attempt mints a brand-new conversation uuid')
+      assert.equal(spawns.length, 2, 'one doomed --resume attempt + exactly one fresh fallback attempt (no 5-respawn cap wait)')
+      assert.equal(spawns[0].resumed, true, 'first respawn --resumes the original conversation')
+      assert.equal(spawns[0].id, 'conv-uuid-1234')
+      assert.equal(spawns[1].resumed, false, 'the fallback attempt spawns FRESH (--session-id, not --resume)')
+      assert.notEqual(spawns[1].id, 'conv-uuid-1234', 'the fallback attempt mints a brand-new conversation uuid')
       const resumeUnknown = errors.filter((e) => e.code === 'resume_unknown')
       assert.equal(resumeUnknown.length, 1, 'one loud resume_unknown error so the dashboard can render "starting fresh"')
       assert.equal(resumeUnknown[0].attemptedResumeId, 'conv-uuid-1234', 'the error carries the abandoned conversation id')
@@ -1163,25 +1164,25 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._respawnScheduled, false, 'no further respawn after exhaustion')
     })
 
-    it('a retry-FRESH attempt that survives warmup re-emits ready with the new uuid and re-arms the latch (#5348)', async () => {
+    it('a retry-FRESH attempt that survives warmup re-emits ready with the new uuid and re-arms the latch (#6576/#5348)', async () => {
       let spawnCalls = 0
-      // First 5 spawns die during warmup (doomed resumes, each leaving claude's
-      // resume rejection in the tail, #5417); the 6th — the fresh fallback —
-      // survives.
+      // #6576: the FIRST respawn dies during warmup with claude's resume rejection
+      // in the tail (#5417) → retry FRESH immediately; the fresh fallback (spawn #2)
+      // survives. No 5-respawn cap wait.
       session = makeSession((self) => {
         spawnCalls++
-        if (spawnCalls <= 5) dieWithTail(self, `No conversation found with session ID: ${self._sessionId}`)
+        if (spawnCalls === 1) dieWithTail(self, `No conversation found with session ID: ${self._sessionId}`)
       })
       const readies = []
       session.on('ready', (d) => readies.push(d))
 
       session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
-      for (const d of [1000, 2000, 4000, 8000, 15000, 15000]) {
+      for (const d of [1000, 2000, 4000]) {
         mock.timers.tick(d)
         await new Promise((r) => setImmediate(r))
       }
 
-      assert.equal(spawnCalls, 6)
+      assert.equal(spawnCalls, 2, 'one doomed --resume respawn + one fresh fallback that survives (no 5-respawn cap wait)')
       assert.equal(readies.length, 1, 'ready re-emitted once the fresh attempt survives warmup')
       assert.notEqual(readies[0].sessionId, 'conv-uuid-1234', 'ready carries the NEW conversation uuid (persistence picks it up via the resumeSessionId getter)')
       assert.equal(readies[0].sessionId, session._sessionId, 'emitted id matches the live session id')
@@ -1245,18 +1246,18 @@ describe('ClaudeTuiSession', () => {
       session.on('respawn_exhausted', (d) => exhausted.push(d))
 
       session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
-      // 5 doomed --resume attempts, then the fresh fallback (also 15s backoff).
-      for (const d of [1000, 2000, 4000, 8000, 15000, 15000]) {
+      // #6576: the FIRST respawn dies with claude's "No conversation found" tail →
+      // retry FRESH immediately; the fresh attempt also dies (null tail) → exhaust.
+      for (const d of [1000, 2000, 4000]) {
         mock.timers.tick(d)
         await new Promise((r) => setImmediate(r))
       }
-      mock.timers.tick(15000)
-      await new Promise((r) => setImmediate(r))
 
-      assert.equal(spawns.length, 6, '5 resume attempts + exactly one fresh fallback attempt')
-      assert.ok(spawns.slice(0, 5).every((s) => s.resumed && s.id === 'restored-uuid-9999'), 'first 5 attempts --resume the restored conversation')
-      assert.equal(spawns[5].resumed, false, 'the fallback attempt spawns FRESH (--session-id, not --resume)')
-      assert.notEqual(spawns[5].id, 'restored-uuid-9999', 'the fallback attempt mints a brand-new conversation uuid')
+      assert.equal(spawns.length, 2, 'one doomed --resume attempt + exactly one fresh fallback attempt (no 5-respawn cap wait)')
+      assert.equal(spawns[0].resumed, true, 'first respawn --resumes the restored conversation')
+      assert.equal(spawns[0].id, 'restored-uuid-9999')
+      assert.equal(spawns[1].resumed, false, 'the fallback attempt spawns FRESH (--session-id, not --resume)')
+      assert.notEqual(spawns[1].id, 'restored-uuid-9999', 'the fallback attempt mints a brand-new conversation uuid')
       const resumeUnknown = errors.filter((e) => e.code === 'resume_unknown')
       assert.equal(resumeUnknown.length, 1, 'one loud resume_unknown error so the dashboard can render "starting fresh"')
       assert.equal(resumeUnknown[0].attemptedResumeId, 'restored-uuid-9999', 'the error carries the abandoned conversation id')


### PR DESCRIPTION
## Problem (root-caused live this session)
A claude-tui session that persists a conversation id claude can't resume — never persisted before the PTY died, or wiped from `~/.claude/projects/` — runs `claude --resume <ghost>` on every boot. `claude` prints **"No conversation found with session ID: …"** and exits code=1 **during warmup**. `start()` rejects immediately → `SessionManager` broadcasts `session_restore_failed` → real clients (dashboard/desktop/mobile, whose FSM waits for `claude_ready`) reconnect-loop.

The existing drop-and-retry-FRESH fallback (#5348/#5417) *does* recover it — but only at the **5-respawn cap** (~30s of backoff), which is **past the client readiness timeout**, and every daemon restart **resets `_respawnCount`**, so a ghost resume could wedge the session indefinitely (observed this session across repeated restarts).

## Fix
Fire the existing, tested retry-FRESH as soon as the dying PTY tail **CONFIRMS** the resume id is unknown, not only at the cap. One-line change to the `_scheduleRespawn` gate:

```js
// before
if (this._respawnCount > 5) {
// after
if (this._scanOutputForUnknownResume() || this._didFallbackFromUnknownResume || this._respawnCount > 5) {
```

The inner `_scanOutputForUnknownResume() && !_didFallbackFromUnknownResume` still routes retry-vs-exhaust, so:
- **first confirmed unknown-resume death → retry FRESH** (~1-2s, well inside the client readiness window)
- **fresh attempt also dies → exhaust** (one-shot latch, no loop)
- **fresh attempt survives → `ready`** on the new uuid
- **unrelated crash loop (no tail match) → cap-governed exhaustion** unchanged (#5417 — a real conversation is never abandoned without claude's own rejection)

## Tests
- The three cap-timing tests (`#5348/#5417`) now assert the **first-death** timing (2 spawns, not 6) — retitled to reference #6576.
- The unrelated-crash (`#5417`) and restored-no-tail exhaustion tests are **unchanged and still green** — the safety gate (claude's own rejection required) is intact.
- Full `claude-tui-session` suite: **301/301**. `cli-session` (parallel resume machinery, untouched): 81/81. Server opt-forwarding + state-file lints green.

Closes #6576