### PR TITLE
fix(server): recover a restore ghost-resume inline in start() (#6576, follow-up to #6579)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1254,6 +1254,20 @@ export class ClaudeTuiSession extends BaseSession {
       throw err
     }
     if (this._ptyExited) {
+      // #6576 (Option A) — the dying warmup already went through _onPtyGone →
+      // _scheduleRespawn. If claude's own tail CONFIRMED the resume id is unknown,
+      // that path armed a retry-FRESH (`_freshRetryPending`) + scheduled a respawn
+      // on a brand-new conversation. Do NOT reject start() in that case: a restore
+      // start() rejection makes SessionManager (`_handleAsyncStartFailure`) tear
+      // down the provider, which cancels the scheduled respawn — the exact
+      // restore-on-restart wedge #6576 is about (the background retry never runs).
+      // Return quietly instead; the scheduled respawn spawns the fresh conversation
+      // and emits `ready` when it warms up, so the session recovers in place with no
+      // `session_restore_failed` and no teardown. A genuinely unrecoverable death
+      // (no retry armed) still rejects below.
+      if (this._freshRetryPending) {
+        return
+      }
       const message = `claude PTY exited during warmup (code=${this._ptyExitInfo?.exitCode ?? 'unknown'})`
       this.emit('error', { message })
       throw new Error(message)

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1303,8 +1303,10 @@ describe('ClaudeTuiSession', () => {
           // spawnCalls === 2 (the scheduled fresh retry) leaves a live _term → survives.
         }
         const readies = []
+        // Swallow the session-scoped 'error' emits (the PTY-exit + the
+        // `code: 'resume_unknown'` "starting fresh" signal both ride the 'error'
+        // event) so EventEmitter doesn't throw on an unhandled 'error'.
         session.on('error', () => {})
-        session.on('resume_unknown', () => {})
         session.on('ready', (d) => readies.push(d))
 
         // The fix: start() RESOLVES (pre-fix it threw → session_restore_failed + teardown).

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1274,6 +1274,56 @@ describe('ClaudeTuiSession', () => {
     // plus adjacent-line pairs (the TUI line-wraps and box-pads its output,
     // so a pattern can straddle ONE rendered line break — but the `.*` in the
     // #4950 co-occurrence patterns must never span unrelated lines).
+    // #6576 (Option A) — the ACTUAL restore-on-restart fix. start() must NOT reject
+    // when the dying warmup armed a retry-FRESH, because SessionManager tears down
+    // the provider on a restore start() rejection (`_handleAsyncStartFailure`),
+    // which cancels the scheduled respawn — the wedge #6576 is about. This exercises
+    // the FULL start() path (not `_onPtyGone` directly), covering the teardown race
+    // the `_scheduleRespawn`-only tests could not see.
+    it('start() does NOT reject a restore whose --resume ghost dies during warmup — recovers via the scheduled retry-FRESH and emits ready (#6576)', async () => {
+      let spawnCalls = 0
+      const prevHome = process.env.HOME
+      const fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-6576a-'))
+      writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
+      process.env.HOME = fakeHome
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: emptySkillsDir, repoSkillsDir: null, resumeSessionId: 'ghost-uuid-0001' })
+        session._spawnPty = async function () {
+          spawnCalls++
+          this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {}, on: () => {} }
+          if (spawnCalls === 1) {
+            // The doomed --resume dies during warmup with claude's own rejection in
+            // the tail — this arms the retry-FRESH (and pre-fix made start() throw →
+            // SessionManager teardown → the restore-on-restart wedge).
+            this._outputTail = ''
+            this._outputTailRaw = Buffer.alloc(0)
+            this._appendToOutputTail(`No conversation found with session ID: ${this._sessionId}`)
+            this._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+          }
+          // spawnCalls === 2 (the scheduled fresh retry) leaves a live _term → survives.
+        }
+        const readies = []
+        session.on('error', () => {})
+        session.on('resume_unknown', () => {})
+        session.on('ready', (d) => readies.push(d))
+
+        // The fix: start() RESOLVES (pre-fix it threw → session_restore_failed + teardown).
+        await session.start()
+        assert.equal(session._freshRetryPending, true, 'the first death armed a retry-FRESH that start() deferred to instead of rejecting')
+        assert.equal(readies.length, 0, 'ready not emitted yet — the fresh conversation is still scheduled to spawn')
+
+        for (const d of [1000, 2000]) { mock.timers.tick(d); await new Promise((r) => setImmediate(r)) }
+
+        assert.equal(spawnCalls, 2, 'one doomed --resume + one fresh retry spawn')
+        assert.equal(readies.length, 1, 'the fresh retry survived warmup and emitted ready — session recovered IN PLACE (no restore_failed / no teardown)')
+        assert.notEqual(readies[0].sessionId, 'ghost-uuid-0001', 'ready carries the new fresh conversation uuid')
+        assert.equal(session._processReady, true, 'session ready after inline recovery')
+      } finally {
+        if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome
+        try { rmSync(fakeHome, { recursive: true, force: true }) } catch { /* best effort */ }
+      }
+    })
+
     describe('_scanOutputForUnknownResume (#5417)', () => {
       it('matches claude\'s resume rejection through ANSI codes and line wrapping', () => {
         session = makeSession()


### PR DESCRIPTION
## Why (follow-up to #6579)
#6579 fired the retry-FRESH on the first confirmed unknown-resume death — but it was **incomplete for the primary restore-on-restart scenario**, caught by live-restarting the daemon:

- On a **restore**, the ghost `--resume` dies during `start()`'s warmup → `start()` throws → `SessionManager._handleAsyncStartFailure` **tears down the dead provider** → that `destroy()` sets `_destroying`, which **cancels the scheduled retry-FRESH respawn**. The fresh conversation never spawned; the session stayed `session_restore_failed` (the wedge #6576 is about).
- #6579's unit tests called `_onPtyGone` directly, bypassing the `start()`→SessionManager teardown path — which is why the gap slipped through.

## Fix
In `start()`'s warmup-death branch ([claude-tui-session.js](packages/server/src/claude-tui-session.js)): if `_onPtyGone` already armed a retry-FRESH (`_freshRetryPending`), **return quietly instead of rejecting**. `start()` resolving means SessionManager doesn't tear down the provider, so the scheduled respawn runs → spawns the fresh conversation → emits `ready`. The session recovers **in place**, no `session_restore_failed`. A genuinely unrecoverable death (no retry armed) still rejects as before.

```js
if (this._ptyExited) {
  if (this._freshRetryPending) { return }   // #6576 Option A — don't reject; let the scheduled retry recover
  ... throw ...
}
```

## Validation (both ways this time)
- **Unit test** drives the **full `start()` path** (not `_onPtyGone`): a restored session whose `--resume` ghost dies during warmup must have `start()` RESOLVE and then recover to `ready` via the scheduled retry. **Verified it FAILS with the fix disabled** (proves it exercises the real path).
- **Live**: planted a ghost Default state, restarted the daemon on this branch — watched the fresh retry spawn (`spawn claude TUI uuid=6cdbf110`) and reach ready (`Session … ready: 6cdbf110`), client snapshot **`claude_ready:1 / restore_failed:0`**. The exact scenario the merged fix wedged on.
- 383/383 claude-tui + cli-session; opt-forwarding lint + eslint green. #6579's early-gate change stays (helps mid-session deaths); this closes the restore-on-restart case.

Closes #6576