### PR TITLE
fix(app): enable Android cleartext for release builds so LAN ws:// connects (#6581)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8020,6 +8020,53 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-1.0.10.tgz",
+      "integrity": "sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-camera": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.10.tgz",
@@ -16959,6 +17006,7 @@
         "@xterm/addon-fit": "0.10.0",
         "@xterm/xterm": "5.5.0",
         "expo": "^54.0.0",
+        "expo-build-properties": "~1.0.10",
         "expo-camera": "~17.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -100,6 +100,14 @@
         {
           "faceIDPermission": "Allow Chroxy to use Face ID to unlock the app."
         }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
       ]
     ],
     "extra": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,6 +51,7 @@
     "@xterm/addon-fit": "0.10.0",
     "@xterm/xterm": "5.5.0",
     "expo": "^54.0.0",
+    "expo-build-properties": "~1.0.10",
     "expo-camera": "~17.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",


### PR DESCRIPTION
## Problem (root-caused live, P0)
Release Android builds of the app have **no cleartext-traffic permission**, so Android 9+ silently drops every plaintext `ws://` / `http://` the app makes. Chroxy over LAN is `ws://<lan-ip>:8765` (plaintext transport; the E2E encryption is application-layer *on top*), so **LAN pairing is impossible on a release APK** — it only worked in dev builds (debug manifest sets `usesCleartextTraffic`) or over a tunnel (`wss://`).

**Live evidence:** the phone's browser reached `http://<lan-ip>:8765/health` fine, but the release APK produced **zero** WS connections at the daemon (Android dropped them before they left the phone); the same phone connected over the Cloudflare tunnel (`wss://`).

## Fix
Add the `expo-build-properties` config plugin with `android.usesCleartextTraffic: true`. Safe here — Chroxy's LAN traffic is already E2E-encrypted at the app layer, so the plaintext *transport* carries an encrypted payload.

**Verified via `expo prebuild -p android`:** the base `android/app/src/main/AndroidManifest.xml` now sets `android:usesCleartextTraffic="true"` on the `<application>` (applies to release, not just debug — previously only the debug variant had it).

## Notes
- **Config-only** (app.json + expo-build-properties dep); no JS changes.
- **Requires an APK rebuild** (EAS) to take effect on device.

Closes #6581