### PR TITLE
fix(app): stop the reconnect loop after lock/unlock — latch server_down on probe give-up (#6583)

### DIFF
--- a/packages/app/src/__tests__/store/connection-connect.test.ts
+++ b/packages/app/src/__tests__/store/connection-connect.test.ts
@@ -143,7 +143,11 @@ describe('connect() health check', () => {
 });
 
 describe('connect() retry exhaustion', () => {
-  it('sets disconnected + final error after all retries fail', async () => {
+  // #6583 — the probe give-up now latches the STICKY terminal `server_down`, NOT
+  // `disconnected`. `disconnected` remounts ConnectScreen (App.tsx gates it on that
+  // phase) whose mount effect auto-connects → an endless reconnect loop after
+  // lock/unlock over a dead server. `server_down` shows a stable Retry banner.
+  it('sets server_down (terminal) + final error after all retries fail (#6583)', async () => {
     global.fetch = jest.fn().mockRejectedValue(new TypeError('Network request failed'));
 
     useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
@@ -158,7 +162,7 @@ describe('connect() retry exhaustion', () => {
     }
 
     const lifecycleState = useConnectionLifecycleStore.getState();
-    expect(lifecycleState.connectionPhase).toBe('disconnected');
+    expect(lifecycleState.connectionPhase).toBe('server_down');
     expect(lifecycleState.connectionError).toBe('Could not reach server');
   });
 

--- a/packages/app/src/__tests__/store/connection-connect.test.ts
+++ b/packages/app/src/__tests__/store/connection-connect.test.ts
@@ -143,12 +143,17 @@ describe('connect() health check', () => {
 });
 
 describe('connect() retry exhaustion', () => {
-  // #6583 — the probe give-up now latches the STICKY terminal `server_down`, NOT
-  // `disconnected`. `disconnected` remounts ConnectScreen (App.tsx gates it on that
-  // phase) whose mount effect auto-connects → an endless reconnect loop after
-  // lock/unlock over a dead server. `server_down` shows a stable Retry banner.
-  it('sets server_down (terminal) + final error after all retries fail (#6583)', async () => {
+  // #6583 — the probe give-up latches the STICKY terminal `server_down` ONLY when
+  // there's a saved record to reconnect to (covered in connection-server-down.test.ts).
+  // For a FIRST-TIME connect with no saved record — this test — it falls back to
+  // `disconnected` → the connect form. That's loop-safe (ConnectScreen's mount
+  // auto-connect no-ops without a saved record) and avoids stranding the user on
+  // SessionScreen's server_down UI, whose Reconnect (retryConnection) no-ops with no
+  // saved record.
+  it('sets disconnected (no saved record) + final error after all retries fail (#6583)', async () => {
     global.fetch = jest.fn().mockRejectedValue(new TypeError('Network request failed'));
+    // Explicit: no saved record → the first-time-connect branch of the give-up gate.
+    useConnectionLifecycleStore.setState({ savedConnection: null });
 
     useConnectionStore.getState().connect('wss://example.com', 'tok', { silent: true });
 
@@ -162,7 +167,7 @@ describe('connect() retry exhaustion', () => {
     }
 
     const lifecycleState = useConnectionLifecycleStore.getState();
-    expect(lifecycleState.connectionPhase).toBe('server_down');
+    expect(lifecycleState.connectionPhase).toBe('disconnected');
     expect(lifecycleState.connectionError).toBe('Could not reach server');
   });
 

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -229,6 +229,14 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
   // unmounted and shows a stable Retry banner instead.
   it('#6583 — a health-probe give-up latches server_down (not disconnected → remount loop)', async () => {
     const ws = installMockWebSocket();
+    // The observed repro is a RECONNECT: a saved record exists (from a prior
+    // auth_ok), the phone locks/unlocks over a dead server, and the probe ladder
+    // exhausts. With a saved record the give-up must latch the sticky terminal
+    // 'server_down' — 'disconnected' would remount ConnectScreen (App.tsx gate)
+    // whose mount effect auto-connects the saved record → give up → the loop.
+    useConnectionLifecycleStore.setState({
+      savedConnection: { url: 'wss://10.0.0.71:8765', token: 'tok' },
+    });
     // The /health check fails every attempt → the probe retry ladder exhausts
     // CONNECT_MAX_RETRIES → onProbeGaveUp (the give-up path this fix corrects).
     (global.fetch as jest.Mock).mockRejectedValue(new Error('network unreachable'));
@@ -254,6 +262,34 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     jest.advanceTimersByTime(60_000);
     await flushPromises();
     expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+    expect(ws.instances.length).toBe(0);
+
+    ws.restore();
+  });
+
+  // #6583 review — the give-up gate is SAVED-RECORD-conditional. With NO saved
+  // record (a first-time connect that never authenticated), the give-up falls back
+  // to 'disconnected' → the connect form, NOT 'server_down'. That's correct on both
+  // counts: ConnectScreen's mount auto-connect no-ops without a saved record (so
+  // 'disconnected' can't loop), and 'server_down' would strand the user on
+  // SessionScreen's server_down UI whose Reconnect (retryConnection) no-ops here.
+  it('#6583 — a give-up with NO saved record falls back to disconnected (not server_down)', async () => {
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.setState({ savedConnection: null });
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('network unreachable'));
+
+    useConnectionStore.getState().connect('wss://10.0.0.71:8765', 'tok', { silent: true });
+    await flushPromises();
+    for (let i = 0; i < 12; i++) {
+      const phase = useConnectionLifecycleStore.getState().connectionPhase;
+      if (phase === 'disconnected' || phase === 'server_down') break;
+      jest.advanceTimersByTime(30_000);
+      await flushPromises();
+    }
+
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('disconnected');
+    expect(useConnectionLifecycleStore.getState().connectionPhase).not.toBe('server_down');
+    // Still no socket — the probe never passed.
     expect(ws.instances.length).toBe(0);
 
     ws.restore();

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -247,6 +247,15 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     // The probe never passed, so no WebSocket was ever built.
     expect(ws.instances.length).toBe(0);
 
+    // #6583 — the terminal state must be STICKY: after give-up, advancing time must
+    // NOT kick a fresh probe/socket. Pre-fix, landing in 'disconnected' would remount
+    // ConnectScreen (App.tsx gate) → mount auto-connect → new probe → the loop. Here
+    // it must stay put with no new connection attempts.
+    jest.advanceTimersByTime(60_000);
+    await flushPromises();
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+    expect(ws.instances.length).toBe(0);
+
     ws.restore();
   });
 });

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -219,4 +219,34 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     expect(ws.instances.length).toBe(before); // nothing to dial
     ws.restore();
   });
+
+  // #6583 — the health-probe give-up (onProbeGaveUp) must latch the STICKY terminal
+  // `server_down`, NOT `disconnected`. App.tsx mounts ConnectScreen only while phase
+  // === 'disconnected', and ConnectScreen's mount effect auto-connects on mount — so
+  // a probe give-up landing in `disconnected` remounts ConnectScreen → auto-connect →
+  // give up → `disconnected` → remount → an endless reconnect loop (observed on a real
+  // device after lock/unlock over a dead tunnel). `server_down` keeps ConnectScreen
+  // unmounted and shows a stable Retry banner instead.
+  it('#6583 — a health-probe give-up latches server_down (not disconnected → remount loop)', async () => {
+    const ws = installMockWebSocket();
+    // The /health check fails every attempt → the probe retry ladder exhausts
+    // CONNECT_MAX_RETRIES → onProbeGaveUp (the give-up path this fix corrects).
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('network unreachable'));
+
+    useConnectionStore.getState().connect('wss://10.0.0.71:8765', 'tok', { silent: true });
+    await flushPromises();
+    for (let i = 0; i < 12; i++) {
+      if (useConnectionLifecycleStore.getState().connectionPhase === 'server_down') break;
+      jest.advanceTimersByTime(30_000);
+      await flushPromises();
+    }
+
+    // Pre-fix this was 'disconnected' (→ ConnectScreen remount → auto-connect loop).
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+    expect(useConnectionLifecycleStore.getState().connectionPhase).not.toBe('disconnected');
+    // The probe never passed, so no WebSocket was ever built.
+    expect(ws.instances.length).toBe(0);
+
+    ws.restore();
+  });
 });

--- a/packages/app/src/__tests__/store/connection-server-down.test.ts
+++ b/packages/app/src/__tests__/store/connection-server-down.test.ts
@@ -255,10 +255,12 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     // The probe never passed, so no WebSocket was ever built.
     expect(ws.instances.length).toBe(0);
 
-    // #6583 — the terminal state must be STICKY: after give-up, advancing time must
-    // NOT kick a fresh probe/socket. Pre-fix, landing in 'disconnected' would remount
-    // ConnectScreen (App.tsx gate) → mount auto-connect → new probe → the loop. Here
-    // it must stay put with no new connection attempts.
+    // #6583 — the store half of stickiness: after give-up the ladder arms no timer,
+    // so advancing time kicks no fresh probe/socket. (This alone doesn't distinguish
+    // the fix from the pre-fix 'disconnected' — the ladder is quiescent either way;
+    // the phase assertion above is the load-bearing one. The end-to-end remount loop
+    // — 'disconnected' → ConnectScreen remount → mount auto-connect — lives in the
+    // ConnectScreen mount path and is tracked for a render-based regression test.)
     jest.advanceTimersByTime(60_000);
     await flushPromises();
     expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
@@ -290,6 +292,57 @@ describe('#5725 terminal server_down after the reconnect ladder is exhausted', (
     expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('disconnected');
     expect(useConnectionLifecycleStore.getState().connectionPhase).not.toBe('server_down');
     // Still no socket — the probe never passed.
+    expect(ws.instances.length).toBe(0);
+
+    ws.restore();
+  });
+
+  // #6583 — the SAME saved-record-conditional latch applies to onRestartGaveUp
+  // (the /health probe answers {status:'restarting'} every attempt and the server
+  // never comes back → the restart-wait ladder exhausts). A phone unlocking over a
+  // server stuck mid-restart is a plausible real-world #6583 trigger, so this branch
+  // must be latched too — without these tests a revert to unconditional
+  // 'disconnected' would ship green.
+  it('#6583 — a restart give-up WITH a saved record latches server_down', async () => {
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.setState({
+      savedConnection: { url: 'wss://tunnel.example.com', token: 'tok' },
+    });
+    // 200 { status: 'restarting' } on every attempt → onRestarting each rung →
+    // onRestartGaveUp once the ladder exhausts CONNECT_MAX_RETRIES.
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { status: 'restarting', restartEtaMs: 5000 }),
+    );
+
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    // Initial + 5 retries; 15_000ms > max jittered delay (8000 * 1.5 = 12_000ms).
+    for (let attempt = 0; attempt <= 5; attempt++) {
+      await flushPromises();
+      if (attempt < 5) jest.advanceTimersByTime(15_000);
+    }
+
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('server_down');
+    // The probe never returned ok, so no WebSocket was built.
+    expect(ws.instances.length).toBe(0);
+
+    ws.restore();
+  });
+
+  it('#6583 — a restart give-up with NO saved record falls back to disconnected', async () => {
+    const ws = installMockWebSocket();
+    useConnectionLifecycleStore.setState({ savedConnection: null });
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { status: 'restarting', restartEtaMs: 5000 }),
+    );
+
+    useConnectionStore.getState().connect('wss://tunnel.example.com', 'tok', { silent: true });
+    for (let attempt = 0; attempt <= 5; attempt++) {
+      await flushPromises();
+      if (attempt < 5) jest.advanceTimersByTime(15_000);
+    }
+
+    expect(useConnectionLifecycleStore.getState().connectionPhase).toBe('disconnected');
+    expect(useConnectionLifecycleStore.getState().connectionPhase).not.toBe('server_down');
     expect(ws.instances.length).toBe(0);
 
     ws.restore();

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -41,6 +41,12 @@ const LAN_TROUBLESHOOTING_URL =
 const MOUNT_AUTOCONNECT_COOLDOWN_MS = 5000;
 let _lastMountAutoConnectAtMs = 0;
 
+/** Test-only — reset the module-level mount-auto-connect cooldown so suites that
+ *  mount ConnectScreen don't couple through it (#6583 review). */
+export function __resetMountAutoConnectForTests(): void {
+  _lastMountAutoConnectAtMs = 0;
+}
+
 
 type ParseResult =
   | { ok: true; wsUrl: string; token: string; pairingId?: undefined; identityKey?: string }

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -41,12 +41,6 @@ const LAN_TROUBLESHOOTING_URL =
 const MOUNT_AUTOCONNECT_COOLDOWN_MS = 5000;
 let _lastMountAutoConnectAtMs = 0;
 
-/** Test-only — reset the module-level mount-auto-connect cooldown so suites that
- *  mount ConnectScreen don't couple through it (#6583 review). */
-export function __resetMountAutoConnectForTests(): void {
-  _lastMountAutoConnectAtMs = 0;
-}
-
 
 type ParseResult =
   | { ok: true; wsUrl: string; token: string; pairingId?: undefined; identityKey?: string }

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -36,8 +36,8 @@ const LAN_TROUBLESHOOTING_URL =
 // mounts it ONLY while connectionPhase === 'disconnected', so any give-up path that
 // lands the FSM there remounts this screen) can't machine-gun the mount auto-connect
 // into a reconnect loop. connectAuto runs its own reconnect ladder, so one kick per
-// short window is enough; a genuine gap — or a user Connect/Disconnect — lets it
-// fire again. Module-scope so it survives remounts.
+// short window is enough; the guard is purely time-based — once the window elapses a
+// later mount can kick again. Module-scope so it survives remounts.
 const MOUNT_AUTOCONNECT_COOLDOWN_MS = 5000;
 let _lastMountAutoConnectAtMs = 0;
 

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -32,6 +32,15 @@ const DEFAULT_PORT = 8765;
 const LAN_TROUBLESHOOTING_URL =
   'https://github.com/blamechris/chroxy/blob/main/docs/troubleshooting/lan-discovery.md';
 
+// #6583 — a module-level guard so a phase-driven REMOUNT of ConnectScreen (App.tsx
+// mounts it ONLY while connectionPhase === 'disconnected', so any give-up path that
+// lands the FSM there remounts this screen) can't machine-gun the mount auto-connect
+// into a reconnect loop. connectAuto runs its own reconnect ladder, so one kick per
+// short window is enough; a genuine gap — or a user Connect/Disconnect — lets it
+// fire again. Module-scope so it survives remounts.
+const MOUNT_AUTOCONNECT_COOLDOWN_MS = 5000;
+let _lastMountAutoConnectAtMs = 0;
+
 
 type ParseResult =
   | { ok: true; wsUrl: string; token: string; pairingId?: undefined; identityKey?: string }
@@ -148,6 +157,12 @@ export function ConnectScreen() {
       if (!mounted || userDisconnected) return;
       const saved = useConnectionLifecycleStore.getState().savedConnection;
       if (saved) {
+        // #6583 — skip if a recent mount already kicked off auto-connect, so a
+        // give-up → 'disconnected' → ConnectScreen-remount cycle can't machine-gun
+        // into a reconnect loop. connectAuto runs its own reconnect ladder.
+        const now = Date.now();
+        if (now - _lastMountAutoConnectAtMs < MOUNT_AUTOCONNECT_COOLDOWN_MS) return;
+        _lastMountAutoConnectAtMs = now;
         setAutoConnecting(true);
         // #5518 — auto-select LAN vs tunnel for the saved record on reconnect.
         void useConnectionStore.getState().connectAuto(saved, { silent: true });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1127,7 +1127,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         }, delayMs);
       },
       onRestartGaveUp: () => {
-        useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
+        // #6583 — latch the sticky terminal 'server_down' (like onProbeGaveUp /
+        // onTerminalDown), NOT 'disconnected'. A restart that never completes would
+        // otherwise remount ConnectScreen (App.tsx gates it on phase === 'disconnected')
+        // → mount auto-connect → 'server_restarting' → give up → 'disconnected' →
+        // remount → the same endless reconnect loop. The attempt-id guard prevents a
+        // stale callback clobbering a fresh 'connecting'.
+        if (myAttemptId !== connectionAttemptId) return;
+        useConnectionLifecycleStore.getState().setConnectionPhase('server_down');
         useConnectionLifecycleStore.getState().setConnectionError('Server restart timed out', _retryCount);
         if (!silent) {
           Alert.alert(

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1128,13 +1128,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       },
       onRestartGaveUp: () => {
         // #6583 — latch the sticky terminal 'server_down' (like onProbeGaveUp /
-        // onTerminalDown), NOT 'disconnected'. A restart that never completes would
-        // otherwise remount ConnectScreen (App.tsx gates it on phase === 'disconnected')
-        // → mount auto-connect → 'server_restarting' → give up → 'disconnected' →
-        // remount → the same endless reconnect loop. The attempt-id guard prevents a
-        // stale callback clobbering a fresh 'connecting'.
+        // onTerminalDown) when there's a saved record to reconnect to. A restart that
+        // never completes would otherwise fall to 'disconnected' → ConnectScreen
+        // remount → mount auto-connect → 'server_restarting' → give up → the same loop.
+        // Without a saved record (a first-time connect to a restarting server), fall
+        // back to 'disconnected' → the connect form: mount auto-connect no-ops with no
+        // saved record (so no loop), and server_down's Reconnect would no-op anyway.
+        // The attempt-id guard prevents a stale callback clobbering a fresh 'connecting'.
         if (myAttemptId !== connectionAttemptId) return;
-        useConnectionLifecycleStore.getState().setConnectionPhase('server_down');
+        const hasSaved = !!useConnectionLifecycleStore.getState().savedConnection?.token;
+        useConnectionLifecycleStore.getState().setConnectionPhase(hasSaved ? 'server_down' : 'disconnected');
         useConnectionLifecycleStore.getState().setConnectionError('Server restart timed out', _retryCount);
         if (!silent) {
           Alert.alert(
@@ -1148,16 +1151,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         }
       },
       onProbeGaveUp: () => {
-        // #6583 — latch the STICKY terminal 'server_down' (like onGaveUp/onTerminalDown),
-        // NOT 'disconnected'. App.tsx gates ConnectScreen on phase === 'disconnected',
-        // and ConnectScreen's mount effect auto-connects on every mount — so setting
-        // 'disconnected' here remounts ConnectScreen → auto-connect → 'connecting'
+        // #6583 — a give-up must NOT land in 'disconnected' when there's a saved
+        // record. App.tsx gates ConnectScreen on phase === 'disconnected', and
+        // ConnectScreen's mount effect auto-connects whenever a saved record exists
+        // — so 'disconnected' remounts ConnectScreen → auto-connect → 'connecting'
         // (unmount) → give up → 'disconnected' → remount → an endless reconnect loop
-        // after lock/unlock over a dead server. 'server_down' keeps ConnectScreen
-        // unmounted and shows a stable Retry banner; recovery comes from the
+        // after lock/unlock over a dead server. Latch the STICKY terminal
+        // 'server_down' instead (like onGaveUp/onTerminalDown): ConnectScreen stays
+        // unmounted and a stable Retry banner shows; recovery comes from the
         // cooldown-gated resume / network-change / user-retry paths.
+        //   For a first-time connect that never authenticated there is NO saved
+        // record (savedConnection is only set on auth_ok). Mount auto-connect no-ops
+        // without one, so 'disconnected' can't loop there — and 'server_down' would
+        // strand the user on SessionScreen's server_down UI whose Reconnect
+        // (retryConnection) no-ops with no saved record. So fall back to
+        // 'disconnected' (→ the connect form) when there's nothing to reconnect to.
         if (myAttemptId !== connectionAttemptId) return;
-        useConnectionLifecycleStore.getState().setConnectionPhase('server_down');
+        const hasSaved = !!useConnectionLifecycleStore.getState().savedConnection?.token;
+        useConnectionLifecycleStore.getState().setConnectionPhase(hasSaved ? 'server_down' : 'disconnected');
         useConnectionLifecycleStore.getState().setConnectionError('Could not reach server', _retryCount);
         if (!silent) {
           Alert.alert(

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1141,7 +1141,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         }
       },
       onProbeGaveUp: () => {
-        useConnectionLifecycleStore.getState().setConnectionPhase('disconnected');
+        // #6583 — latch the STICKY terminal 'server_down' (like onGaveUp/onTerminalDown),
+        // NOT 'disconnected'. App.tsx gates ConnectScreen on phase === 'disconnected',
+        // and ConnectScreen's mount effect auto-connects on every mount — so setting
+        // 'disconnected' here remounts ConnectScreen → auto-connect → 'connecting'
+        // (unmount) → give up → 'disconnected' → remount → an endless reconnect loop
+        // after lock/unlock over a dead server. 'server_down' keeps ConnectScreen
+        // unmounted and shows a stable Retry banner; recovery comes from the
+        // cooldown-gated resume / network-change / user-retry paths.
+        if (myAttemptId !== connectionAttemptId) return;
+        useConnectionLifecycleStore.getState().setConnectionPhase('server_down');
         useConnectionLifecycleStore.getState().setConnectionError('Could not reach server', _retryCount);
         if (!silent) {
           Alert.alert(


### PR DESCRIPTION
## Symptom (real device, P1)
Lock → unlock over a dead server → **reconnecting → timeout → connect screen → instant reconnect → repeat**, forever.

## Not a credential bug — the token persists (no re-scan by design)
Verified: the QR's one-time code is exchanged **once** for a persistent `sessionToken` (SecureStore); reconnect always sends `auth` with the stored token (never `pair`). The E2E `key_exchange` re-runs per connection automatically. So a lock/unlock is *supposed* to reconnect silently.

## Root cause
`App.tsx` mounts ConnectScreen **only** while `connectionPhase === 'disconnected'`, and ConnectScreen's `[]`-deps mount effect **auto-connects on every mount**. The health-probe reconnect ladder's give-up (`onProbeGaveUp`) set phase = **`disconnected`** — unlike the socket-drop `onGaveUp`, which latches the sticky terminal **`server_down`**. So: give-up → `disconnected` → ConnectScreen remounts → auto-connect → `connecting` (unmount) → give up → `disconnected` → remount → endless loop.

## Fix
- **(B)** `onProbeGaveUp` latches the sticky `server_down` (with the attempt-id guard, mirroring `onTerminalDown`) → ConnectScreen stays unmounted, stable "Server appears down / Retry" banner shows.
- **(A)** a module-level cooldown on ConnectScreen's mount auto-connect so *any* remount can't machine-gun a reconnect loop.

## Validation
- New real-store behavior test drives the probe ladder to give-up and asserts `server_down` — **verified it fails with the fix reverted** (`Received: "disconnected"`).
- Updated the prior retry-exhaustion test (`connection-connect.test.ts`) to expect `server_down`.
- **Full app suite: 2140/2140**, tsc + eslint clean.

Follow-ups (in #6583, not this PR): AppState timer-cancel hygiene (C), empty-token persist guard (D). Requires an APK rebuild to reach devices.

Closes #6583