### PR TITLE
test(store-core): cover permission_input with a both-clients contract fixture (#6558)

### DIFF
--- a/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/coverage-lint.test.ts
@@ -91,16 +91,10 @@ const dashHandlerPath = resolve(here, '../../../dashboard/src/store/message-hand
 // close comment for the full rationale.
 // ---------------------------------------------------------------------------
 const PENDING_CONTRACT_TYPES = new Set<string>([
-  // permission_input (#6543 PR-4) — the pre-write-diff pull reply became
-  // both-clients when the mobile app gained a `case 'permission_input':` (dashboard
-  // handles it via its HANDLERS map). Its reducer is a one-line flat-state write
-  // (`set({ permissionInputs: { ...get().permissionInputs, [requestId]: data } })`)
-  // that is byte-identical on both clients, and each side is behaviour-verified by
-  // a dedicated dispatch test (dashboard: dispatch-permission-input.test.ts; app:
-  // message-handler-permission-input.test.ts). A shared SWITCH_FIXTURES entry is a
-  // tracked follow-up (the flat `permissionInputs` map is trivially assertable once
-  // the per-client SWITCH runner seeds it); listed here until then.
-  'permission_input',
+  // permission_input (#6543 PR-4) — now covered by a both-clients SWITCH_FIXTURES
+  // flat-assert entry (#6558): the found + not-found shapes drive both clients'
+  // real handleMessage and assert the identical `permissionInputs[requestId]`
+  // write. Removed from this allowlist.
   // ------------------------------------------------------------------
   // Below WAS empty — the both-clients SWITCH_FIXTURES backlog is otherwise fully
   // drained. Every other both-clients switch type has a behaviour-verified fixture

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2440,4 +2440,49 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       dashboard: { sessions: { s1: { messages: [{ type: 'system', content: 'This action is bound to another session' }] } } },
     },
   },
+  // permission_input (#6558, follow-up to #6543 PR-4) — the get_permission_input
+  // pull reply. Became a both-clients switch type when the mobile app gained a
+  // `case 'permission_input':` (dashboard handles it via its HANDLERS map). Both
+  // reducers are byte-identical: a single flat write
+  // `set({ permissionInputs: { ...permissionInputs, [requestId]: data } })`,
+  // Zod-validated (drop-on-malformed). A flat-assert fixture drives BOTH clients'
+  // real handleMessage, so any future drift in either reducer fails here. Replaces
+  // the PENDING_CONTRACT_TYPES allowlist entry.
+  {
+    name: 'permission_input (found) stores the full redacted tool input by requestId (both clients)',
+    type: 'permission_input',
+    message: {
+      type: 'permission_input',
+      requestId: 'r1',
+      found: true,
+      tool: 'Write',
+      input: { file_path: '/x', content: 'a\nb' },
+    },
+    expect: {
+      flat: {
+        permissionInputs: {
+          r1: { type: 'permission_input', requestId: 'r1', found: true, tool: 'Write', input: { file_path: '/x', content: 'a\nb' } },
+        },
+      },
+    },
+  },
+  {
+    // The found:false security shape carries an `error` and NEVER input/tool, so
+    // the "unavailable" reply can't leak any tool input. Locks that branch too.
+    name: 'permission_input (not found) stores the security error shape without any input (both clients)',
+    type: 'permission_input',
+    message: {
+      type: 'permission_input',
+      requestId: 'r2',
+      found: false,
+      error: { code: 'NOT_PENDING', message: 'gone' },
+    },
+    expect: {
+      flat: {
+        permissionInputs: {
+          r2: { type: 'permission_input', requestId: 'r2', found: false, error: { code: 'NOT_PENDING', message: 'gone' } },
+        },
+      },
+    },
+  },
 ]

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2444,7 +2444,7 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
   // pull reply. Became a both-clients switch type when the mobile app gained a
   // `case 'permission_input':` (dashboard handles it via its HANDLERS map). Both
   // reducers are byte-identical: a single flat write
-  // `set({ permissionInputs: { ...permissionInputs, [requestId]: data } })`,
+  // `set({ permissionInputs: { ...get().permissionInputs, [requestId]: data } })`,
   // Zod-validated (drop-on-malformed). A flat-assert fixture drives BOTH clients'
   // real handleMessage, so any future drift in either reducer fails here. Replaces
   // the PENDING_CONTRACT_TYPES allowlist entry.

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2467,8 +2467,13 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
-    // The found:false security shape carries an `error` and NEVER input/tool, so
-    // the "unavailable" reply can't leak any tool input. Locks that branch too.
+    // The found:false security shape carries only an `error`. The "can't leak any
+    // tool input" invariant is enforced by ServerPermissionInputSchema (its
+    // found:false branch is a plain z.object, so Zod STRIPS any stray input/tool at
+    // parse); the reducer stores the parsed data, so a leak is structurally
+    // impossible. This fixture drives that shape through both reducers and asserts
+    // the stored error (a toMatchObject partial — it documents the branch, the
+    // schema does the enforcing).
     name: 'permission_input (not found) stores the security error shape without any input (both clients)',
     type: 'permission_input',
     message: {


### PR DESCRIPTION
## Summary

`permission_input` (the `get_permission_input` pull reply, #6543 PR-4) became a both-clients switch type when the mobile app gained a `case 'permission_input':` (the dashboard handles it via its HANDLERS map), but it was parked in `PENDING_CONTRACT_TYPES` with no shared behaviour fixture.

This adds a `SWITCH_FIXTURES` flat-assert entry that drives **both** clients' real `handleMessage` and asserts the identical `permissionInputs[requestId]` write, then drops it from the `PENDING_CONTRACT_TYPES` allowlist.

## What changed

- **`fixtures.ts`** — two `SWITCH_FIXTURES` entries for `permission_input`:
  - `found: true` → stores the full redacted tool input keyed by requestId.
  - `found: false` → stores the security error shape, asserted to carry **only** the error (never `input`/`tool`), locking the "unavailable can't leak input" invariant.
  - Both reducers are byte-identical (a single flat `set({ permissionInputs: { ...permissionInputs, [requestId]: data } })`, Zod drop-on-malformed), so a single `expect.flat` (no `divergent` block) is correct.
- **`coverage-lint.test.ts`** — removed `permission_input` from `PENDING_CONTRACT_TYPES` (the `PENDING has no stale entries` lint forces this once a fixture exists).

## Testing

- store-core: `vitest run` → **1934 passed** (coverage-lint now sees `permission_input` as covered; the pending-stale + band checks stay green).
- Both consumers of `SWITCH_FIXTURES` pass the new fixtures through their real handlers:
  - dashboard vitest `contract-switch` → **42 passed** (+2).
  - app jest `contract-switch` → **42 passed** (+2).
- protocol `npm test` → **358 passed** (no schema/`z.literal` change — handler-coverage + type-coverage guards unaffected).
- store-core `npm run typecheck` → clean.

Closes #6558