### PR TITLE
test(app): render-based regression test for ConnectScreen mount-auto-connect cooldown (#6585)

### DIFF
--- a/packages/app/src/__tests__/screens/ConnectScreenMountCooldown.test.tsx
+++ b/packages/app/src/__tests__/screens/ConnectScreenMountCooldown.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Render-based regression test for ConnectScreen's #6583 mount-auto-connect
+ * cooldown (#6585). The store-level #6583 latch is covered in
+ * store/connection-server-down.test.ts; this exercises the OTHER half of the
+ * fix — the end-to-end remount path — by actually mounting ConnectScreen:
+ *
+ *   - a first mount with a saved record fires connectAuto once,
+ *   - a REMOUNT within MOUNT_AUTOCONNECT_COOLDOWN_MS (5s) does NOT re-fire
+ *     (this is the loop-breaker: a give-up → 'disconnected' → remount cycle
+ *     can't machine-gun connectAuto),
+ *   - a remount after the window re-fires (the guard is purely time-based, not
+ *     a permanent latch).
+ *
+ * Uses the repo's react-test-renderer harness (no @testing-library/react-native
+ * here) + fake timers to drive Date.now() across the cooldown window. The mount
+ * effect awaits loadSavedConnection().then(...), so each mount flushes microtasks
+ * before asserting.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+// ConnectScreen pulls in native modules jest.setup.js does not cover. The mount
+// auto-connect effect touches none of them, but the imports must resolve.
+jest.mock('expo-camera', () => ({
+  CameraView: () => null,
+  useCameraPermissions: () => [{ granted: true }, jest.fn()],
+}));
+// expo-network is left to the jest-expo default mock (the connection store
+// subscribes via Network.addNetworkStateListener at module load; the mount
+// auto-connect effect touches no network API).
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { ConnectScreen, __resetMountAutoConnectForTests } from '../../screens/ConnectScreen';
+import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+const SAVED = { url: 'wss://tunnel.example.com', token: 'tok' };
+
+let connectAuto: jest.Mock;
+let loadSavedConnection: jest.Mock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  __resetMountAutoConnectForTests();
+  connectAuto = jest.fn().mockResolvedValue(undefined);
+  loadSavedConnection = jest.fn().mockResolvedValue(undefined);
+  // Override the two store actions the mount effect calls; seed a saved record.
+  useConnectionStore.setState({ connectAuto, loadSavedConnection } as never);
+  useConnectionLifecycleStore.setState({ savedConnection: SAVED, userDisconnected: false } as never);
+});
+
+afterEach(() => {
+  act(() => {
+    useConnectionLifecycleStore.setState({ savedConnection: null } as never);
+  });
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+/** Mount ConnectScreen and flush the async loadSavedConnection().then() chain. */
+async function mountFlush(): Promise<renderer.ReactTestRenderer> {
+  let tree!: renderer.ReactTestRenderer;
+  await act(async () => {
+    tree = renderer.create(<ConnectScreen />);
+    // loadSavedConnection() resolves on the microtask queue; flush it so the
+    // .then() (which decides whether to call connectAuto) runs before we assert.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return tree;
+}
+
+describe('ConnectScreen mount auto-connect cooldown (#6585 / #6583)', () => {
+  it('a first mount with a saved record fires connectAuto once', async () => {
+    const tree = await mountFlush();
+    expect(connectAuto).toHaveBeenCalledTimes(1);
+    expect(connectAuto).toHaveBeenCalledWith(SAVED, { silent: true });
+    act(() => tree.unmount());
+  });
+
+  it('a remount WITHIN the cooldown window does not re-fire connectAuto (loop-breaker)', async () => {
+    const t1 = await mountFlush();
+    expect(connectAuto).toHaveBeenCalledTimes(1);
+    act(() => t1.unmount());
+
+    connectAuto.mockClear();
+    jest.advanceTimersByTime(2000); // < 5000ms window
+    const t2 = await mountFlush();
+
+    // Pre-fix, every remount re-kicked auto-connect → the reconnect loop. The
+    // cooldown must swallow this one.
+    expect(connectAuto).not.toHaveBeenCalled();
+    act(() => t2.unmount());
+  });
+
+  it('a remount AFTER the cooldown window re-fires connectAuto (purely time-based)', async () => {
+    const t1 = await mountFlush();
+    expect(connectAuto).toHaveBeenCalledTimes(1);
+    act(() => t1.unmount());
+
+    connectAuto.mockClear();
+    jest.advanceTimersByTime(5001); // > 5000ms window
+    const t2 = await mountFlush();
+
+    expect(connectAuto).toHaveBeenCalledTimes(1);
+    act(() => t2.unmount());
+  });
+});

--- a/packages/app/src/__tests__/screens/ConnectScreenMountCooldown.test.tsx
+++ b/packages/app/src/__tests__/screens/ConnectScreenMountCooldown.test.tsx
@@ -41,9 +41,27 @@ const SAVED = { url: 'wss://tunnel.example.com', token: 'tok' };
 let connectAuto: jest.Mock;
 let loadSavedConnection: jest.Mock;
 
+// These Zustand stores are singletons shared across every test file in the same
+// Jest worker. We override two store actions + two lifecycle fields below, so we
+// capture their originals and RESTORE them in afterEach — otherwise the mocks
+// leak into later suites and cause order-dependent flakiness (#6588 review).
+type ConnStore = ReturnType<typeof useConnectionStore.getState>;
+type LifecycleStore = ReturnType<typeof useConnectionLifecycleStore.getState>;
+let origConnectAuto: ConnStore['connectAuto'];
+let origLoadSavedConnection: ConnStore['loadSavedConnection'];
+let origSavedConnection: LifecycleStore['savedConnection'];
+let origUserDisconnected: LifecycleStore['userDisconnected'];
+
 beforeEach(() => {
   jest.useFakeTimers();
   __resetMountAutoConnectForTests();
+  const cs = useConnectionStore.getState();
+  origConnectAuto = cs.connectAuto;
+  origLoadSavedConnection = cs.loadSavedConnection;
+  const ls = useConnectionLifecycleStore.getState();
+  origSavedConnection = ls.savedConnection;
+  origUserDisconnected = ls.userDisconnected;
+
   connectAuto = jest.fn().mockResolvedValue(undefined);
   loadSavedConnection = jest.fn().mockResolvedValue(undefined);
   // Override the two store actions the mount effect calls; seed a saved record.
@@ -52,9 +70,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  act(() => {
-    useConnectionLifecycleStore.setState({ savedConnection: null } as never);
-  });
+  // Restore the singleton store actions + lifecycle fields we overrode.
+  useConnectionStore.setState({
+    connectAuto: origConnectAuto,
+    loadSavedConnection: origLoadSavedConnection,
+  } as never);
+  useConnectionLifecycleStore.setState({
+    savedConnection: origSavedConnection,
+    userDisconnected: origUserDisconnected,
+  } as never);
   jest.useRealTimers();
   jest.clearAllMocks();
 });

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -41,6 +41,12 @@ const LAN_TROUBLESHOOTING_URL =
 const MOUNT_AUTOCONNECT_COOLDOWN_MS = 5000;
 let _lastMountAutoConnectAtMs = 0;
 
+/** Test-only — reset the module-level mount-auto-connect cooldown between renders
+ *  so a render-based suite can exercise the window deterministically (#6585). */
+export function __resetMountAutoConnectForTests(): void {
+  _lastMountAutoConnectAtMs = 0;
+}
+
 
 type ParseResult =
   | { ok: true; wsUrl: string; token: string; pairingId?: undefined; identityKey?: string }


### PR DESCRIPTION
## Summary

The #6583 fix has two halves: a store-level `server_down` latch (covered in `connection-server-down.test.ts`) **and** a module-level 5s mount-auto-connect cooldown in `ConnectScreen`. The cooldown had no render-based coverage — the end-to-end remount loop (`disconnected` → `App.tsx` remounts `ConnectScreen` → mount effect auto-connects) was only proven at the store layer. This adds the render-based regression test.

## What it verifies

Mounts the real `ConnectScreen` with `react-test-renderer` + fake timers:

1. **first mount** with a saved record → `connectAuto` fires once with `{ silent: true }`.
2. **remount within the 5s window** → `connectAuto` does **not** re-fire (the loop-breaker — pre-fix, every remount re-kicked auto-connect).
3. **remount after the window** → `connectAuto` fires again (the guard is purely time-based, not a permanent latch).

## Notes

- Re-adds the test-only `__resetMountAutoConnectForTests()` export to `ConnectScreen.tsx`. It was dropped in #6584 as dead code *because no consumer existed*; this test is that consumer (tracked as this issue). No runtime behaviour change.
- Uses the repo's `react-test-renderer` harness (no `@testing-library/react-native` here). Mocks `expo-camera` + `react-native-safe-area-context` for a full-screen render; `expo-network` is left to the jest-expo default (the connection store subscribes to `addNetworkStateListener` at module load; the mount effect touches no network API). The async mount effect's `loadSavedConnection().then()` chain is flushed before each assertion.

## Testing

- `npx jest src/__tests__/screens/ConnectScreenMountCooldown.test.tsx` → **3 passed**.
- Full app suite → **2146 passed** (164 suites).
- `tsc --noEmit` → clean.

Closes #6585