### PR TITLE
fix(app,dashboard): prune permissionInputs on prompt resolution (#6559)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
+++ b/packages/app/src/__tests__/store/message-handler-permission-input.test.ts
@@ -34,9 +34,18 @@ jest.mock('../../store/persistence', () => ({
   _resetForTesting: jest.fn(),
 }));
 
-/** Minimal mock Zustand store seeding `permissionInputs` with an empty map. */
+/** Minimal mock Zustand store seeding `permissionInputs` with an empty map.
+ *  Also seeds the flat fields the permission_resolved / _expired / _timeout
+ *  handlers read (sessionStates for the all-sessions prompt search, plus the
+ *  notification/error lists) so dispatching those events doesn't crash. */
 function createMockStore(initialInputs: Record<string, unknown> = {}) {
-  let state = { permissionInputs: initialInputs } as unknown as ConnectionState;
+  let state = {
+    permissionInputs: initialInputs,
+    sessionStates: {},
+    sessionNotifications: [],
+    serverErrors: [],
+    activeSessionId: null,
+  } as unknown as ConnectionState;
   return {
     store: {
       getState: () => state,
@@ -158,5 +167,47 @@ describe('permission_input feeder (#6543 PR-4)', () => {
     // No-op: the seeded map reference is untouched (parse failed before any set).
     expect(current().permissionInputs).toBe(seeded);
     expect(current().permissionInputs.r3).toBeUndefined();
+  });
+
+  it('#6559 — prunes the pulled input when the prompt resolves (unrelated keys survive)', () => {
+    const { store, current } = createMockStore({
+      r1: { type: 'permission_input', requestId: 'r1', found: true, tool: 'Write', input: { file_path: '/x' } },
+      keep: { type: 'permission_input', requestId: 'keep', found: true, tool: 'Edit', input: { file_path: '/y' } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'permission_resolved', requestId: 'r1', decision: 'allow' });
+
+    expect(current().permissionInputs.r1).toBeUndefined();
+    expect(current().permissionInputs.keep).toBeDefined();
+  });
+
+  it('#6559 — prunes on permission_expired and permission_timeout too', () => {
+    const { store, current } = createMockStore({
+      re: { type: 'permission_input', requestId: 're', found: true, tool: 'Write', input: {} },
+      rt: { type: 'permission_input', requestId: 'rt', found: true, tool: 'Write', input: {} },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'permission_expired', requestId: 're', message: 'expired' });
+    _testMessageHandler.handle({ type: 'permission_timeout', requestId: 'rt', message: 'timed out' });
+
+    expect(current().permissionInputs.re).toBeUndefined();
+    expect(current().permissionInputs.rt).toBeUndefined();
+  });
+
+  it('#6559 — leaves a live (unresolved) prompt input in place (AC #3)', () => {
+    const { store, current } = createMockStore({
+      live: { type: 'permission_input', requestId: 'live', found: true, tool: 'Write', input: {} },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Resolving a DIFFERENT request must not touch the still-live prompt's input.
+    _testMessageHandler.handle({ type: 'permission_resolved', requestId: 'other', decision: 'allow' });
+
+    expect(current().permissionInputs.live).toBeDefined();
   });
 });

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1557,6 +1557,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       restartEtaMs: null,
       restartingSince: null,
       pendingPermissionConfirm: null,
+      // #6559 — drop any pulled pre-write-diff inputs on disconnect (they're
+      // per-connection; a resolved prompt already self-prunes, this clears the
+      // tail if we disconnect mid-prompt).
+      permissionInputs: {},
       timeoutWarning: null,
       // #4542: clear the cached prefs snapshot on disconnect so the next
       // connect refetches from the actual server (snapshots are host-specific).

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3052,7 +3052,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // over a long session. Guard the copy-delete so a prompt that never
         // pulled input (the common case) doesn't churn a new object.
         set((s) => {
-          if (!s.permissionInputs || !(resolvedRequestId in s.permissionInputs)) return {};
+          if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, resolvedRequestId)) return {};
           const next = { ...s.permissionInputs };
           delete next[resolvedRequestId];
           return { permissionInputs: next };
@@ -3084,7 +3084,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
         // #6559 — prune the pulled input for an expired prompt too.
         set((s) => {
-          if (!s.permissionInputs || !(expiredRequestId in s.permissionInputs)) return {};
+          if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, expiredRequestId)) return {};
           const next = { ...s.permissionInputs };
           delete next[expiredRequestId];
           return { permissionInputs: next };
@@ -3125,7 +3125,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           .forEach((n) => notifState.dismissSessionNotification(n.id));
         // #6559 — prune the pulled input for a timed-out prompt too.
         set((s) => {
-          if (!s.permissionInputs || !(timeoutRequestId in s.permissionInputs)) return {};
+          if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, timeoutRequestId)) return {};
           const next = { ...s.permissionInputs };
           delete next[timeoutRequestId];
           return { permissionInputs: next };

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3047,6 +3047,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             (n) => n.requestId !== resolvedRequestId
           ),
         }));
+        // #6559 — prune the pulled pre-write-diff input for this now-resolved
+        // prompt. permissionInputs is append-only otherwise and grows unbounded
+        // over a long session. Guard the copy-delete so a prompt that never
+        // pulled input (the common case) doesn't churn a new object.
+        set((s) => {
+          if (!s.permissionInputs || !(resolvedRequestId in s.permissionInputs)) return {};
+          const next = { ...s.permissionInputs };
+          delete next[resolvedRequestId];
+          return { permissionInputs: next };
+        });
       }
       break;
     }
@@ -3072,6 +3082,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             (n) => n.requestId !== expiredRequestId
           ),
         }));
+        // #6559 — prune the pulled input for an expired prompt too.
+        set((s) => {
+          if (!s.permissionInputs || !(expiredRequestId in s.permissionInputs)) return {};
+          const next = { ...s.permissionInputs };
+          delete next[expiredRequestId];
+          return { permissionInputs: next };
+        });
       }
       break;
     }
@@ -3106,6 +3123,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         notifState.sessionNotifications
           .filter((n) => n.requestId === timeoutRequestId)
           .forEach((n) => notifState.dismissSessionNotification(n.id));
+        // #6559 — prune the pulled input for a timed-out prompt too.
+        set((s) => {
+          if (!s.permissionInputs || !(timeoutRequestId in s.permissionInputs)) return {};
+          const next = { ...s.permissionInputs };
+          delete next[timeoutRequestId];
+          return { permissionInputs: next };
+        });
       }
       // Show a dismissible server error banner so users know the permission was auto-denied
       // (system message text comes from the shared handler so wording stays in sync)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2515,6 +2515,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       serverErrors: [],
       sessionNotifications: [],
       resolvedPermissions: {},
+      // #6559 — drop any pulled pre-write-diff inputs on disconnect (per-connection
+      // state; mirrors the app disconnect reset so both clients clear the tail if
+      // we disconnect mid-prompt). A resolved/expired/timed-out prompt already
+      // self-prunes above.
+      permissionInputs: {},
       serverPhase: null,
       tunnelProgress: null,
       // #5356: clear exposure on disconnect so a reconnect against a

--- a/packages/dashboard/src/store/dispatch-permission-input.test.ts
+++ b/packages/dashboard/src/store/dispatch-permission-input.test.ts
@@ -30,7 +30,15 @@ function createMockSocket(): WebSocket {
   return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
 }
 function baseState(): Partial<ConnectionState> {
-  return { connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, permissionInputs: {}, messages: [] }
+  // Mirror the real store's init for the fields the permission_resolved / _expired
+  // / _timeout handlers touch (sessionNotifications banner-drain + the error/info
+  // notification actions), so dispatching those events doesn't crash the mock.
+  return {
+    connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null,
+    sessionStates: {}, permissionInputs: {}, messages: [],
+    sessionNotifications: [], resolvedPermissions: {},
+    addServerError: vi.fn(), addInfoNotification: vi.fn(),
+  } as Partial<ConnectionState>
 }
 
 describe('permission_input dispatch (#6543)', () => {
@@ -66,5 +74,27 @@ describe('permission_input dispatch (#6543)', () => {
   it('drops a malformed permission_input (missing found)', () => {
     handleMessage({ type: 'permission_input', requestId: 'r3' }, ctx() as never)
     expect(store.getState().permissionInputs['r3']).toBeUndefined()
+  })
+
+  it('#6559 — prunes the pulled input when the prompt resolves (unrelated keys survive)', () => {
+    handleMessage({ type: 'permission_input', requestId: 'r1', found: true, tool: 'Write', input: { file_path: '/x', content: 'a' } }, ctx() as never)
+    handleMessage({ type: 'permission_input', requestId: 'keep', found: true, tool: 'Edit', input: { file_path: '/y', content: 'b' } }, ctx() as never)
+    expect(store.getState().permissionInputs['r1']).toBeDefined()
+
+    handleMessage({ type: 'permission_resolved', requestId: 'r1', decision: 'allow' }, ctx() as never)
+
+    expect(store.getState().permissionInputs['r1']).toBeUndefined()
+    expect(store.getState().permissionInputs['keep']).toBeDefined()
+  })
+
+  it('#6559 — prunes on permission_expired and permission_timeout too', () => {
+    handleMessage({ type: 'permission_input', requestId: 're', found: true, tool: 'Write', input: { file_path: '/e' } }, ctx() as never)
+    handleMessage({ type: 'permission_input', requestId: 'rt', found: true, tool: 'Write', input: { file_path: '/t' } }, ctx() as never)
+
+    handleMessage({ type: 'permission_expired', requestId: 're', message: 'expired' }, ctx() as never)
+    handleMessage({ type: 'permission_timeout', requestId: 'rt', message: 'timed out' }, ctx() as never)
+
+    expect(store.getState().permissionInputs['re']).toBeUndefined()
+    expect(store.getState().permissionInputs['rt']).toBeUndefined()
   })
 })

--- a/packages/dashboard/src/store/dispatch-permission-input.test.ts
+++ b/packages/dashboard/src/store/dispatch-permission-input.test.ts
@@ -97,4 +97,13 @@ describe('permission_input dispatch (#6543)', () => {
     expect(store.getState().permissionInputs['re']).toBeUndefined()
     expect(store.getState().permissionInputs['rt']).toBeUndefined()
   })
+
+  it('#6559 — leaves a live (unresolved) prompt input in place (AC #3)', () => {
+    handleMessage({ type: 'permission_input', requestId: 'live', found: true, tool: 'Write', input: { file_path: '/l' } }, ctx() as never)
+
+    // Resolving a DIFFERENT request must not touch the still-live prompt's input.
+    handleMessage({ type: 'permission_resolved', requestId: 'other', decision: 'allow' }, ctx() as never)
+
+    expect(store.getState().permissionInputs['live']).toBeDefined()
+  })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2339,7 +2339,7 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
     // session. Guard the copy-delete so a prompt that never pulled input (the
     // common case) doesn't churn a new object. Mirrors the app handler.
     set((s) => {
-      if (!s.permissionInputs || !(resolvedRequestId in s.permissionInputs)) return {};
+      if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, resolvedRequestId)) return {};
       const next = { ...s.permissionInputs };
       delete next[resolvedRequestId];
       return { permissionInputs: next };
@@ -4465,7 +4465,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // #6559 — prune the pulled input for an expired prompt. Hoisted above the
         // alreadyResolved early-return so both branches drop it (guarded copy-delete).
         set((s) => {
-          if (!s.permissionInputs || !(expiredRequestId in s.permissionInputs)) return {};
+          if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, expiredRequestId)) return {};
           const next = { ...s.permissionInputs };
           delete next[expiredRequestId];
           return { permissionInputs: next };
@@ -4569,7 +4569,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
         // #6559 — prune the pulled input for a timed-out prompt too.
         set((s) => {
-          if (!s.permissionInputs || !(timeoutRequestId in s.permissionInputs)) return {};
+          if (!s.permissionInputs || !Object.prototype.hasOwnProperty.call(s.permissionInputs, timeoutRequestId)) return {};
           const next = { ...s.permissionInputs };
           delete next[timeoutRequestId];
           return { permissionInputs: next };

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2334,6 +2334,16 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
           : n
       ),
     }));
+    // #6559 — prune the pulled pre-write-diff input for this now-resolved prompt.
+    // permissionInputs is append-only otherwise and grows unbounded over a long
+    // session. Guard the copy-delete so a prompt that never pulled input (the
+    // common case) doesn't churn a new object. Mirrors the app handler.
+    set((s) => {
+      if (!s.permissionInputs || !(resolvedRequestId in s.permissionInputs)) return {};
+      const next = { ...s.permissionInputs };
+      delete next[resolvedRequestId];
+      return { permissionInputs: next };
+    });
   }
 }
 
@@ -4452,6 +4462,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const { requestId: expiredRequestId, systemMessage: expiredSystemMsg } =
         sharedPermissionExpired(msg);
       if (expiredRequestId) {
+        // #6559 — prune the pulled input for an expired prompt. Hoisted above the
+        // alreadyResolved early-return so both branches drop it (guarded copy-delete).
+        set((s) => {
+          if (!s.permissionInputs || !(expiredRequestId in s.permissionInputs)) return {};
+          const next = { ...s.permissionInputs };
+          delete next[expiredRequestId];
+          return { permissionInputs: next };
+        });
         // If the user already resolved this request (via Allow/Deny/AllowSession),
         // this is the race condition from #2833 — the server expired the prompt
         // after we answered. Suppress the "Expired — already handled" message
@@ -4549,6 +4567,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
               : n
           ),
         }));
+        // #6559 — prune the pulled input for a timed-out prompt too.
+        set((s) => {
+          if (!s.permissionInputs || !(timeoutRequestId in s.permissionInputs)) return {};
+          const next = { ...s.permissionInputs };
+          delete next[timeoutRequestId];
+          return { permissionInputs: next };
+        });
       }
       // Surface a dismissible error toast so the operator knows the
       // permission was auto-denied (wording comes from the shared handler so


### PR DESCRIPTION
## Summary

`permissionInputs` — the full (redacted) tool inputs pulled for the #6543 pre-write-diff review, keyed by requestId — was **append-only**: written on `permission_input` and never deleted. Over a long session it grows unbounded. This prunes each entry when its prompt terminates, on **both** clients.

## What changed

Prune (guarded copy-delete) at every prompt-ending path, on both the app and the dashboard:
- **`permission_resolved`** (primary), **`permission_expired`**, **`permission_timeout`**
- app **`disconnect()`** also clears the whole map (it's per-connection state)

The guard skips allocating a new map both when the prompt never pulled input (the common case) **and** when `permissionInputs` is `undefined` — the real store inits it to `{}`, but under-seeded test mocks don't, so the guard keeps the prune a safe no-op there.

## Why it's safe

- requestIds are globally unique → no stale-collision risk (this is pure memory hygiene, not a correctness fix).
- Consumers (`MessageBubble` / `PermissionPrompt`) read `permissionInputs[requestId]` only for a **live** prompt, so pruning at resolution can't affect an in-flight prompt (AC #3 — covered by a dedicated test).

## Testing

Extended both clients' dispatch tests with resolved / expired / timeout prune assertions + an AC-3 "live prompt untouched" case:
- app jest `message-handler-permission-input` → **7 passed**; dashboard vitest `dispatch-permission-input` → **5 passed**.
- Full suites: app **2154**, dashboard **4251**, store-core **1934**, protocol **358** — all green (the guard fixes a regression where dispatching these events against mocks that don't seed `permissionInputs` would have thrown on `in undefined`).
- app + dashboard `tsc --noEmit` → clean.

Closes #6559