### PR TITLE
fix(server): bound get_permission_input pull amplification (#6551)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -783,8 +783,15 @@ function handleGetPermissionInput(ws, client, msg, ctx) {
   if (!pending) return notFound('NOT_PENDING', 'That permission is no longer pending (resolved or expired).')
 
   const tool = sess?._lastPermissionData?.get(requestId)?.tool
-  const input = sanitizeToolInput(pending.input, { maxChars: PULL_MAX_INPUT_CHARS })
-  return send({ found: true, tool, input })
+  // #6551 — memoize the redacted pull on the pending entry so repeated pulls for
+  // the same requestId don't re-run the full redactDeep tree-walk + JSON.stringify
+  // per call. The pending entry is deleted at every resolve/timeout/abort site, so
+  // the memo auto-invalidates with it (no separate cache-invalidation wiring). The
+  // input is treated as immutable once pending, so the cached value stays correct.
+  if (pending._redactedPull === undefined) {
+    pending._redactedPull = sanitizeToolInput(pending.input, { maxChars: PULL_MAX_INPUT_CHARS })
+  }
+  return send({ found: true, tool, input: pending._redactedPull })
 }
 
 export const settingsHandlers = {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -583,6 +583,13 @@ export class WsServer {
     this._rateLimiter = new RateLimiter({ name: 'ws' })
     // Separate, relaxed limiter for permission/question responses (60 per minute, no burst)
     this._permissionRateLimiter = new RateLimiter({ name: 'permission', windowMs: 60_000, maxMessages: 60, burst: 0 })
+    // #6551: dedicated limiter for get_permission_input (the pre-write-diff pull).
+    // Each pull can return up to 512K, so it's TIGHTER than the general limiter
+    // (30/min + 10 burst vs 100 + 20) to bound cost/egress amplification — a
+    // legit diff-review UI pulls at most once per permission prompt, so 40
+    // effective/min is generous while capping a self-DoS from one client hammering
+    // one requestId.
+    this._permissionInputRateLimiter = new RateLimiter({ name: 'permission-input', windowMs: 60_000, maxMessages: 30, burst: 10 })
     // #3737: per-IP limiter for GET /diagnostics. Default 12 req/min + 4 burst
     // — half of /permission since the cost (FS read + session iteration) is
     // comparable but legitimate use is diagnostic, not interactive. Override
@@ -2157,6 +2164,14 @@ export class WsServer {
       if (!allowed) {
         const label = msg.type === 'user_question_response' ? 'question responses' : 'permission responses'
         this._send(ws, { type: 'rate_limited', retryAfterMs, message: `Too many ${label}. Please slow down.` })
+        return
+      }
+    } else if (msg.type === 'get_permission_input') {
+      // #6551: the pre-write-diff pull has its own tight limiter (each call can
+      // return up to 512K), so it can't burn the general budget or self-DoS.
+      const { allowed, retryAfterMs } = this._permissionInputRateLimiter.check(client.rateLimitKey)
+      if (!allowed) {
+        this._send(ws, { type: 'rate_limited', retryAfterMs, message: 'Too many permission-input pulls. Please slow down.' })
         return
       }
     } else {

--- a/packages/server/tests/get-permission-input.test.js
+++ b/packages/server/tests/get-permission-input.test.js
@@ -107,4 +107,35 @@ describe('get_permission_input handler (#6543)', () => {
     assert.equal(msg.found, false)
     assert.equal(msg.error.code, 'NOT_PENDING')
   })
+
+  it('#6551 — memoizes the redacted pull on the pending entry (no re-serialization per repeat pull)', () => {
+    // A STABLE session (getSession returns the SAME object) so the memo stored on
+    // the pending entry survives across calls — makeCtx() rebuilds the session per
+    // call, which would defeat the memo.
+    const { session } = makeSession()
+    const send = createSpy()
+    const ctx = nsCtx({
+      send,
+      permissionSessionMap: new Map([['req-1', 'sess-1']]),
+      sessionManager: { getSession: (sid) => (sid === 'sess-1' ? { session } : undefined) },
+      _send: send,
+    })
+    const pull = () => {
+      settingsHandlers.get_permission_input({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+      return ctx.transport.send.lastCall[1].input
+    }
+
+    const first = pull()
+    const second = pull()
+
+    // Reference-identical → the second pull reused the memoized redaction instead
+    // of a fresh redactDeep tree-walk + JSON.stringify. (Without the memo,
+    // sanitizeToolInput returns a NEW object each call.)
+    assert.strictEqual(first, second, 'repeated pulls return the SAME redacted object (memoized)')
+    // The memo lives on the pending entry, so it auto-invalidates when the entry
+    // is deleted on resolve/timeout/abort.
+    assert.ok(session._pendingPermissions.get('req-1')._redactedPull !== undefined, 'redacted pull cached on the pending entry')
+    // Security is unaffected — the cached value is still fully redacted.
+    assert.ok(!JSON.stringify(first).includes(SECRET), 'the memoized pull is still redacted')
+  })
 })

--- a/packages/server/tests/get-permission-input.test.js
+++ b/packages/server/tests/get-permission-input.test.js
@@ -138,4 +138,28 @@ describe('get_permission_input handler (#6543)', () => {
     // Security is unaffected — the cached value is still fully redacted.
     assert.ok(!JSON.stringify(first).includes(SECRET), 'the memoized pull is still redacted')
   })
+
+  it('#6551 — a WARM memo is still authorization-gated (the cache never bypasses the viewer/owner check)', () => {
+    const { session } = makeSession()
+    const send = createSpy()
+    const ctx = nsCtx({
+      send,
+      permissionSessionMap: new Map([['req-1', 'sess-1']]),
+      sessionManager: { getSession: (sid) => (sid === 'sess-1' ? { session } : undefined) },
+      _send: send,
+    })
+
+    // An authorized viewer pulls first → the memo is populated.
+    settingsHandlers.get_permission_input({}, { id: 'c1', activeSessionId: 'sess-1' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    assert.equal(ctx.transport.send.lastCall[1].found, true)
+    assert.ok(session._pendingPermissions.get('req-1')._redactedPull !== undefined, 'memo is warm')
+
+    // A DIFFERENT client bound to another session pulls the SAME requestId. The
+    // authority gate must reject it BEFORE the memo is served — the warm cache
+    // must not leak the input to an unauthorized client.
+    settingsHandlers.get_permission_input({}, { id: 'c2', boundSessionId: 'other-session' }, { type: 'get_permission_input', requestId: 'req-1' }, ctx)
+    const msg = ctx.transport.send.lastCall[1]
+    assert.equal(msg.found, false, 'unauthorized client gets found:false even with a warm memo')
+    assert.equal(msg.input, undefined, 'no cached input leaks to the unauthorized client')
+  })
 })

--- a/packages/server/tests/ws-server-rate-limit.test.js
+++ b/packages/server/tests/ws-server-rate-limit.test.js
@@ -209,7 +209,17 @@ describe('WsServer permission_response rate limiting (#2324)', () => {
     for (let i = 0; i < 5; i++) {
       send(ws, { type: 'get_permission_input', requestId: `req-${i}` })
     }
-    await new Promise(resolve => setTimeout(resolve, 150))
+    // Deterministic (not a fixed sleep): wait for the LAST pull's reply. Messages
+    // are processed in order, so req-4's permission_input arriving proves all 5
+    // were handled. If get_permission_input shared the general limiter (2), req-4
+    // would be rate-limited instead and this wait would TIME OUT — so the wait
+    // itself asserts the separation; the check below is belt-and-suspenders.
+    await waitForMessage(
+      messages,
+      m => m.type === 'permission_input' && m.requestId === 'req-4',
+      2000,
+      'permission_input reply for the last pull'
+    )
 
     const rateLimited = messages.find(m => m.type === 'rate_limited')
     assert.equal(rateLimited, undefined, 'get_permission_input uses its own limiter, not the general one')

--- a/packages/server/tests/ws-server-rate-limit.test.js
+++ b/packages/server/tests/ws-server-rate-limit.test.js
@@ -152,6 +152,71 @@ describe('WsServer permission_response rate limiting (#2324)', () => {
     ws.close()
   })
 
+  it('#6551 — rate-limits get_permission_input with its own tight limiter', async () => {
+    const mockSession = createMockSession()
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: mockSession,
+      authRequired: false,
+    })
+
+    // Tight dedicated limiter so we don't need to send 30 pulls.
+    server._permissionInputRateLimiter = new RateLimiter({ windowMs: 60_000, maxMessages: 3, burst: 0 })
+
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    // 3 pulls are allowed (they resolve to found:false — no pending — but are NOT rate-limited).
+    for (let i = 0; i < 3; i++) {
+      send(ws, { type: 'get_permission_input', requestId: `req-${i}` })
+    }
+    // The 4th pull trips the dedicated limiter.
+    send(ws, { type: 'get_permission_input', requestId: 'req-overflow' })
+
+    const rateLimited = await waitForMessage(
+      messages,
+      m => m.type === 'rate_limited',
+      2000,
+      'rate_limited for get_permission_input'
+    )
+
+    assert.ok(rateLimited, 'Should receive rate_limited message')
+    assert.ok(rateLimited.retryAfterMs > 0, 'retryAfterMs should be positive')
+    assert.match(rateLimited.message, /permission-input pulls/i, 'Message should mention permission-input pulls')
+
+    ws.close()
+  })
+
+  it('#6551 — get_permission_input does not consume the general rate limiter bucket', async () => {
+    const mockSession = createMockSession()
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: mockSession,
+      authRequired: false,
+    })
+
+    // General limiter is tighter than the number of pulls; dedicated limiter is generous.
+    server._rateLimiter = new RateLimiter({ windowMs: 60_000, maxMessages: 2, burst: 0 })
+    server._permissionInputRateLimiter = new RateLimiter({ windowMs: 60_000, maxMessages: 100, burst: 0 })
+
+    const port = await startServerAndGetPort(server)
+    const { ws, messages } = await createClient(port)
+
+    // 5 pulls — would trip the general limiter (2) if they shared it; the dedicated
+    // limiter (100) leaves them all under budget.
+    for (let i = 0; i < 5; i++) {
+      send(ws, { type: 'get_permission_input', requestId: `req-${i}` })
+    }
+    await new Promise(resolve => setTimeout(resolve, 150))
+
+    const rateLimited = messages.find(m => m.type === 'rate_limited')
+    assert.equal(rateLimited, undefined, 'get_permission_input uses its own limiter, not the general one')
+
+    ws.close()
+  })
+
   it('rate-limits user_question_response after the relaxed threshold is exceeded', async () => {
     const mockSession = createMockSession()
     server = new WsServer({


### PR DESCRIPTION
## Summary

The authorized pre-write-diff pull (`get_permission_input`, #6543) had a cost/egress amplification: a ~30-byte request could yield up to a 512K response **and** forced a full re-redaction (`redactDeep` tree-walk + `JSON.stringify`) on **every** call, while sharing the general 100/min limiter. One client hammering one `requestId` could burn ~61MB/min + ~120 redaction scans/min.

This is a low-severity **self-DoS** (only an authorized viewer/owner can pull), not a privilege/leak issue — but worth bounding.

## Mitigations

**1. Memoize the redacted pull** (`settings-handlers.js`)
Cache the sanitized result on the pending entry (`pending._redactedPull`), so repeated pulls for the same `requestId` reuse the redaction instead of recomputing it. The pending entry is deleted at every resolve/timeout/abort site (`permission-manager.js`), so the memo **auto-invalidates** with it — no separate cache-invalidation wiring.

**2. Dedicated rate limiter** (`ws-server.js`)
`get_permission_input` gets its own limiter — **30/min + 10 burst**, tighter than the general 100+20 since each pull is expensive. It no longer consumes the general budget, and egress is capped (~15MB/min worst case vs ~61MB/min).

## Testing

- `get-permission-input.test.js`: memoization returns a **reference-identical** redacted object across repeat pulls for the same pending entry (proving no re-serialization), the memo is stored on the pending entry, and the value is still fully redacted. All existing security assertions (secret redaction, un-truncated content, cross-session leak-nothing) unchanged → **8 passed**.
- `ws-server-rate-limit.test.js`: the dedicated limiter trips a `rate_limited` reply after its threshold, and `get_permission_input` does **not** consume the general limiter bucket → **9 passed**.
- All 5 server custom lints pass; `ws-permissions.test.js` **65 passed**.

No new `BaseSession` opt, no new wire message type. Server style (ES modules, no semicolons, single quotes) followed.

Closes #6551