### PR TITLE
fix(server): resolve the claude-tui session file by sessionId so readiness works on current claude (#6578)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,5 @@
 import { randomBytes, randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
+import { mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
 // #6132 (HOL fix from #5337): the per-turn hook-drain hot path uses async fs so a
 // slow/stuck sink (FUSE/NFS, full disk, tmpwatch race) can't block the shared
 // event loop — which would freeze EVERY claude-tui session (the default provider).
@@ -550,6 +550,12 @@ export class ClaudeTuiSession extends BaseSession {
     // recur on the fresh PTY. Reset to false in _spawnPty (every successful
     // (re)spawn), flipped true the first time sendMessage arms the nudge.
     this._firstTurnNudgedForSpawn = false
+    // #6578: cache the session-file path resolved by resolveSessionFile so the
+    // per-turn readiness probe doesn't re-scan ~/.claude/sessions every turn.
+    // Invalidated on every (re)spawn (reset in _spawnPty alongside the nudge
+    // latch) because a respawn under a wrapper shim can land on a new pid, and a
+    // retry-FRESH fallback mints a new sessionId → the old path no longer maps.
+    this._resolvedSessionFile = null
     // #5431: incremental transcript scanner for outstanding background work
     // (run_in_background Bash/Agent, Monitor, ScheduleWakeup). Created
     // lazily by getBackgroundTaskSnapshot() once the per-PID session file
@@ -956,6 +962,76 @@ export class ClaudeTuiSession extends BaseSession {
       return typeof data.status === 'string' ? data.status : null
     } catch {
       return null
+    }
+  }
+
+  /**
+   * #6578: resolve the on-disk session file for THIS session, keyed on the
+   * deterministic `sessionId` (passed to claude as `--session-id`/`--resume`)
+   * rather than only the pty pid. Two breakages on current claude (2.1.186+)
+   * made the pid-only path unreliable:
+   *   - MODE A: under a wrapper-shim install the real claude pid != pty pid,
+   *     so `~/.claude/sessions/<pty-pid>.json` never appears.
+   *   - MODE B: the session file carries NO `status` field at all, so the old
+   *     status-only signal returned null even when the file WAS found.
+   * Since claude writes this file at startup with a matching `sessionId`, the
+   * file is resolvable by directory scan regardless of pid, and its mere
+   * existence (with a matching sessionId) is itself a startup-readiness signal.
+   *
+   * Resolution order:
+   *   1. Fast path — `sessionFilePath(ptyPid)`; verify its parsed `sessionId`
+   *      matches (or accept it verbatim when `sessionId` is falsy, preserving
+   *      the legacy pid-keyed behaviour for callers without a known id).
+   *   2. Dir-scan — read `~/.claude/sessions` and return the first `*.json`
+   *      whose parsed `sessionId === sessionId`.
+   *
+   * Swallows ALL I/O/parse errors (returns null) — this feeds the readiness
+   * path and must NEVER throw. Returns the absolute path or null.
+   *
+   * @param {string|null} sessionId  the upstream claude conversation uuid
+   * @param {number} ptyPid          the pty child pid (fast-path filename)
+   * @returns {string|null}
+   */
+  static resolveSessionFile(sessionId, ptyPid) {
+    // Fast path: the pty-pid-named file. When we have no sessionId to match on
+    // (older callers), accept it verbatim if it exists — matches the legacy
+    // pid-keyed behaviour. With a sessionId, only accept it on a match.
+    if (Number.isInteger(ptyPid) && ptyPid > 0) {
+      const fast = this.sessionFilePath(ptyPid)
+      try {
+        const data = JSON.parse(readFileSync(fast, 'utf8'))
+        if (!sessionId || data.sessionId === sessionId) return fast
+      } catch { /* not written yet / mid-write race / wrong pid — fall through */ }
+    }
+    // Dir-scan fallback keyed on sessionId. Nothing to scan for without an id.
+    if (!sessionId) return null
+    try {
+      const dir = join(homedir(), '.claude', 'sessions')
+      for (const name of readdirSync(dir)) {
+        if (!name.endsWith('.json')) continue
+        const full = join(dir, name)
+        try {
+          const data = JSON.parse(readFileSync(full, 'utf8'))
+          if (data.sessionId === sessionId) return full
+        } catch { /* skip unreadable/half-written sibling files */ }
+      }
+    } catch { /* sessions dir missing / unreadable — degrade to null */ }
+    return null
+  }
+
+  /**
+   * #6578: does `filePath` still map to `sessionId`? Used to validate a cached
+   * `_resolvedSessionFile` before reusing it — the file could be deleted or
+   * (after a retry-FRESH fallback) now carry a different id. When `sessionId`
+   * is falsy the check reduces to "the file still exists" (legacy pid-keyed
+   * callers). Swallows errors → false, so a stale cache forces a re-resolve.
+   */
+  static _sessionFileMatches(filePath, sessionId) {
+    try {
+      const data = JSON.parse(readFileSync(filePath, 'utf8'))
+      return sessionId ? data.sessionId === sessionId : true
+    } catch {
+      return false
     }
   }
 
@@ -1801,6 +1877,10 @@ export class ClaudeTuiSession extends BaseSession {
     // first-turn submit nudge for the first message on THIS spawn. Reset after
     // the destroy-race guard above so an aborted (re)spawn doesn't clear it.
     this._firstTurnNudgedForSpawn = false
+    // #6578: a (re)spawn can land on a new pid (wrapper shim) or a new sessionId
+    // (retry-FRESH fallback), so the cached session-file path is stale — force
+    // the next readiness probe to re-resolve.
+    this._resolvedSessionFile = null
 
     this._term.onData((data) => {
       this._appendToOutputTail(data)
@@ -1858,27 +1938,24 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
-   * #5328 (WP-5.6): build the diagnostic suffix for a readiness-probe timeout.
-   * When the probe degraded (never saw a `status` field — `_lastProbeSawStatus`
-   * is false), distinguish the two root causes by checking whether the per-pid
-   * session file exists on disk, so the swallowed degradation names its likely
-   * cause instead of just "not ready":
-   *   - file MISSING → claude is likely running under a DIFFERENT pid than the
-   *     PTY child (a wrapper shim that forks node without `exec`); the probe
-   *     reads ~/.claude/sessions/<pty-pid>.json, which the real claude never
-   *     writes, so readiness gating is effectively disabled for this session.
-   *   - file PRESENT but statusless → a non-cli entrypoint or an upstream
-   *     file-format change; the file exists but carries no `status` field.
-   * Returns '' when the probe was healthy (saw status but never idle = real busy).
+   * #5328 (WP-5.6) / #6578: build the diagnostic suffix for a readiness-probe
+   * timeout. Since #6578 the probe resolves the session file by matching
+   * `sessionId` (resolveSessionFile) and treats existence-with-matching-id as
+   * ready even when the file carries no `status`, so `_lastProbeSawStatus` now
+   * means "resolved a matching session file". That collapses the degraded case
+   * to ONE: no session file carrying this session's `sessionId` was found
+   * anywhere under ~/.claude/sessions — neither at the pty pid nor via the
+   * dir-scan. Likely causes: a wrapper shim whose real claude writes to a
+   * DIFFERENT ~/.claude (so no matching file is reachable), or claude never
+   * wrote the file. Returns '' when the probe resolved a matching file (found
+   * but busy = healthy, real busy).
    */
   _degradedProbeSuffix() {
     if (this._lastProbeSawStatus !== false) return ''
     const pid = this._term && this._term.pid
-    const sessFile = Number.isInteger(pid) && pid > 0 ? ClaudeTuiSession.sessionFilePath(pid) : null
-    if (sessFile && !existsSync(sessFile)) {
-      return ` — no session file at ${sessFile} (pty pid ${pid}); claude may be running under a different pid (a wrapper shim that forks node without exec), so the readiness probe can never see its status and readiness gating is effectively disabled for this session`
-    }
-    return ' — session file never appeared with a `status` field; if claude was spawned via a non-cli entrypoint or upstream changed the file format, the probe has degraded and will never see ready'
+    const pidNote = Number.isInteger(pid) && pid > 0 ? ` (pty pid ${pid})` : ''
+    const idNote = this._sessionId ? ` sessionId ${this._sessionId}` : ' (no sessionId)'
+    return ` — no session file for${idNote} found under ~/.claude/sessions${pidNote}; claude may be running under a different pid or a different ~/.claude (a wrapper shim that forks node without exec, or a redirected HOME), so the readiness probe can't resolve its state and readiness gating is effectively disabled for this session`
   }
 
   /**
@@ -1949,17 +2026,31 @@ export class ClaudeTuiSession extends BaseSession {
       this._lastProbeSawStatus = false
       return finish(false)
     }
-    const sessFile = ClaudeTuiSession.sessionFilePath(pid)
-    // Track whether we ever read a non-null status. Distinguishes
-    // "claude wrote status but never reached idle" (real busy/stuck)
-    // from "status field never appeared" (probe degraded — see the
-    // entrypoint:cli note on sessionFilePath). The warn sites read
-    // `_lastProbeSawStatus` to surface the difference in logs.
+    // #6578: resolve the session file by matching `sessionId` (not just the pty
+    // pid) so a wrapper-shim install (real claude pid != pty pid, MODE A) still
+    // finds the file, and treat the file's EXISTENCE-with-matching-sessionId as
+    // a readiness signal because current claude session files carry no `status`
+    // field at all (MODE B). `_lastProbeSawStatus` now means "resolved a
+    // matching session file this poll" (not "read a non-null status string").
     let sawStatus = false
     const checkReady = () => {
+      // Reuse the cached path when it still resolves to this session's file;
+      // re-resolve (dir-scan) when the cache is cold or has gone stale (file
+      // deleted / sessionId changed). Caching keeps the per-turn probe from
+      // scanning ~/.claude/sessions every poll.
+      let sessFile = this._resolvedSessionFile
+      if (!sessFile || !ClaudeTuiSession._sessionFileMatches(sessFile, this._sessionId)) {
+        sessFile = ClaudeTuiSession.resolveSessionFile(this._sessionId, pid)
+        this._resolvedSessionFile = sessFile
+      }
+      if (!sessFile) return false
+      // A matching file was resolved → we have this session's readiness signal.
+      sawStatus = true
       const status = ClaudeTuiSession.readSessionStatus(sessFile)
-      if (status !== null) sawStatus = true
-      return status !== null && status !== 'busy'
+      // Ready = a status is present and it's not 'busy' (versions that still
+      // write status keep between-turn gating), OR the file exists with no
+      // status field at all (current claude — existence IS the ready signal).
+      return status === null ? true : status !== 'busy'
     }
     while (this._nowMonotonic() - startMs < timeoutMs) {
       if (this._ptyExited) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -556,6 +556,10 @@ export class ClaudeTuiSession extends BaseSession {
     // latch) because a respawn under a wrapper shim can land on a new pid, and a
     // retry-FRESH fallback mints a new sessionId → the old path no longer maps.
     this._resolvedSessionFile = null
+    // #6578: last time the readiness probe ran the (readdir-heavy) session-file
+    // dir-scan, so it can be throttled to ~2/sec during warmup. -Infinity so the
+    // first cold-resolve scans immediately; reset on each (re)spawn.
+    this._lastSessionDirScanMs = -Infinity
     // #5431: incremental transcript scanner for outstanding background work
     // (run_in_background Bash/Agent, Monitor, ScheduleWakeup). Created
     // lazily by getBackgroundTaskSnapshot() once the per-PID session file
@@ -992,10 +996,12 @@ export class ClaudeTuiSession extends BaseSession {
    * @param {number} ptyPid          the pty child pid (fast-path filename)
    * @returns {string|null}
    */
-  static resolveSessionFile(sessionId, ptyPid) {
+  static resolveSessionFile(sessionId, ptyPid, { allowDirScan = true } = {}) {
     // Fast path: the pty-pid-named file. When we have no sessionId to match on
     // (older callers), accept it verbatim if it exists — matches the legacy
-    // pid-keyed behaviour. With a sessionId, only accept it on a match.
+    // pid-keyed behaviour. With a sessionId, only accept it on a match. This is a
+    // single stat+read and runs on every poll; the dir-scan below is the costly
+    // part and the caller throttles it via `allowDirScan`.
     if (Number.isInteger(ptyPid) && ptyPid > 0) {
       const fast = this.sessionFilePath(ptyPid)
       try {
@@ -1003,8 +1009,10 @@ export class ClaudeTuiSession extends BaseSession {
         if (!sessionId || data.sessionId === sessionId) return fast
       } catch { /* not written yet / mid-write race / wrong pid — fall through */ }
     }
-    // Dir-scan fallback keyed on sessionId. Nothing to scan for without an id.
-    if (!sessionId) return null
+    // Dir-scan fallback keyed on sessionId. Nothing to scan for without an id, and
+    // callers can suppress the scan (allowDirScan=false) to throttle its per-poll
+    // cost during the warmup window — the cheap fast-path above still runs.
+    if (!sessionId || !allowDirScan) return null
     try {
       const dir = join(homedir(), '.claude', 'sessions')
       for (const name of readdirSync(dir)) {
@@ -1023,8 +1031,9 @@ export class ClaudeTuiSession extends BaseSession {
    * #6578: does `filePath` still map to `sessionId`? Used to validate a cached
    * `_resolvedSessionFile` before reusing it — the file could be deleted or
    * (after a retry-FRESH fallback) now carry a different id. When `sessionId`
-   * is falsy the check reduces to "the file still exists" (legacy pid-keyed
-   * callers). Swallows errors → false, so a stale cache forces a re-resolve.
+   * is falsy the check reduces to "the file still exists AND parses as JSON"
+   * (legacy pid-keyed callers). Swallows errors → false (a missing OR
+   * unreadable/corrupt file), so a stale cache forces a re-resolve.
    */
   static _sessionFileMatches(filePath, sessionId) {
     try {
@@ -1879,8 +1888,9 @@ export class ClaudeTuiSession extends BaseSession {
     this._firstTurnNudgedForSpawn = false
     // #6578: a (re)spawn can land on a new pid (wrapper shim) or a new sessionId
     // (retry-FRESH fallback), so the cached session-file path is stale — force
-    // the next readiness probe to re-resolve.
+    // the next readiness probe to re-resolve (and scan immediately).
     this._resolvedSessionFile = null
+    this._lastSessionDirScanMs = -Infinity
 
     this._term.onData((data) => {
       this._appendToOutputTail(data)
@@ -2040,7 +2050,15 @@ export class ClaudeTuiSession extends BaseSession {
       // scanning ~/.claude/sessions every poll.
       let sessFile = this._resolvedSessionFile
       if (!sessFile || !ClaudeTuiSession._sessionFileMatches(sessFile, this._sessionId)) {
-        sessFile = ClaudeTuiSession.resolveSessionFile(this._sessionId, pid)
+        // Throttle the readdir-heavy dir-scan to ~2/sec during the cold-resolve
+        // warmup window. The cheap fast-path (pty-pid file read) still runs every
+        // 100ms poll; only the fallback scan is rate-limited — so a MODE-A file
+        // (real pid != pty pid) is still detected within ~500ms of appearing,
+        // negligible against the multi-second warmup.
+        const now = this._nowMonotonic()
+        const allowDirScan = (now - this._lastSessionDirScanMs) >= 500
+        if (allowDirScan) this._lastSessionDirScanMs = now
+        sessFile = ClaudeTuiSession.resolveSessionFile(this._sessionId, pid, { allowDirScan })
         this._resolvedSessionFile = sessFile
       }
       if (!sessFile) return false

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1677,6 +1677,19 @@ describe('ClaudeTuiSession', () => {
       return path
     }
 
+    // #6578: write a session file carrying an explicit `sessionId` and,
+    // when `status` is undefined, OMIT the `status` field entirely (current
+    // claude 2.1.186+ session files carry no `status` at all). The resolver
+    // keys on `sessionId`, not the pid, so the FILE name pid may differ from
+    // the pty pid (wrapper-shim MODE A).
+    function writeSessionFileV2(pid, sessionId, status) {
+      const path = join(fakeHome, '.claude', 'sessions', `${pid}.json`)
+      const body = { pid, sessionId, cwd: '/tmp', startedAt: Date.now() }
+      if (status !== undefined) body.status = status
+      writeFileSync(path, JSON.stringify(body))
+      return path
+    }
+
     it('_waitForPrompt resolves true when session file reports status=idle', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._term = { write: () => {}, kill: () => {}, pid: fakePid }
@@ -1802,6 +1815,87 @@ describe('ClaudeTuiSession', () => {
       assert.equal(ready, true, 'probe survives JSON.parse errors and resolves once the file is sane')
     })
 
+    // #6578 — the readiness signal is now resolved by matching `sessionId`,
+    // not by the pty pid alone, and file-existence-with-matching-sessionId is
+    // itself a startup readiness signal (claude writes the file at startup and
+    // current versions carry NO `status` field). These lock in the four
+    // resolution/gating cases plus the multi-session false-positive guard.
+
+    it('_waitForPrompt resolves a session file under a DIFFERENT pid via matching sessionId (#6578 MODE A)', async () => {
+      // Wrapper-shim install: real claude pid != pty pid, so the fast-path
+      // ~/.claude/sessions/<pty-pid>.json never appears — but the real file
+      // (named by claude's own pid) carries a matching sessionId. The dir-scan
+      // must find it and treat file-existence as ready.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      session._sessionId = 'uuid-mode-a'
+      // No file at fakePid; a file under a DIFFERENT pid with the matching id.
+      writeSessionFileV2(fakePid + 7, 'uuid-mode-a', undefined)
+      const ready = await session._waitForPrompt(200)
+      assert.equal(ready, true, 'resolved by sessionId under a different pid → ready')
+      assert.equal(session._lastProbeSawStatus, true,
+        'resolving a matching session file counts as "saw status" (not degraded)')
+    })
+
+    it('_waitForPrompt treats a matching statusless session file as ready (#6578 MODE B)', async () => {
+      // Current claude session files carry NO `status` field. File at the pty
+      // pid, matching sessionId, no status → ready (not degraded).
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      session._sessionId = 'uuid-mode-b'
+      writeSessionFileV2(fakePid, 'uuid-mode-b', undefined)
+      const ready = await session._waitForPrompt(200)
+      assert.equal(ready, true, 'statusless-but-present matching file → ready')
+      assert.equal(session._lastProbeSawStatus, true,
+        'a resolved matching file is not a degraded probe')
+    })
+
+    it('_waitForPrompt still gates on status=busy when the file carries a status (#6578 back-compat)', async () => {
+      // Claude versions that still write `status` must keep between-turn
+      // gating: a matching file with status:busy is NOT ready.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      session._sessionId = 'uuid-busy'
+      writeSessionFileV2(fakePid, 'uuid-busy', 'busy')
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'status=busy on a matching file must still gate')
+    })
+
+    it('_waitForPrompt ignores a session file whose sessionId does not match (#6578 multi-session guard)', async () => {
+      // A sibling session's file (different sessionId) must not be read as
+      // THIS session's readiness — otherwise two concurrent TUIs false-positive
+      // off each other.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      session._sessionId = 'uuid-mine'
+      // Only a foreign file exists (statusless, would otherwise read as ready).
+      writeSessionFileV2(fakePid + 3, 'uuid-someone-else', undefined)
+      const ready = await session._waitForPrompt(60)
+      assert.equal(ready, false, 'non-matching sessionId must not be treated as ready')
+      assert.equal(session._lastProbeSawStatus, false,
+        'no matching file resolved → degraded/no-file signal')
+    })
+
+    it('resolveSessionFile returns the pid path on the fast path and null on no match (#6578)', () => {
+      // Fast path: file at the pty pid with a matching sessionId → returned.
+      const p = writeSessionFileV2(fakePid, 'uuid-fast', undefined)
+      assert.equal(
+        ClaudeTuiSession.resolveSessionFile('uuid-fast', fakePid), p,
+        'fast path returns the pty-pid file when its sessionId matches',
+      )
+      // No file anywhere with the id → null (swallowed I/O, never throws).
+      assert.equal(
+        ClaudeTuiSession.resolveSessionFile('uuid-absent', fakePid), null,
+        'no matching file anywhere → null',
+      )
+      // Dir-scan fallback: fast path misses, another file matches.
+      const q = writeSessionFileV2(fakePid + 11, 'uuid-scan', undefined)
+      assert.equal(
+        ClaudeTuiSession.resolveSessionFile('uuid-scan', fakePid), q,
+        'dir-scan finds the matching file under a different pid',
+      )
+    })
+
     it('readSessionStatus returns null for missing/invalid files', () => {
       // Static helper isolation: covers the file-absent, JSON-invalid,
       // and missing-field branches without going through the polling
@@ -1882,60 +1976,58 @@ describe('ClaudeTuiSession', () => {
       })
     })
 
-    describe('_degradedProbeSuffix (#5328, WP-5.6)', () => {
-      // Surfaces WHY the readiness probe degraded: a missing session file for
-      // the pty pid points at claude running under a different pid (wrapper
-      // shim); a statusless-but-present file points at a wrong entrypoint.
-      //
-      // #5366 review: stub the static sessionFilePath onto a temp dir so the
-      // file-existence branches are HERMETIC (no reliance on the real ~/.claude)
-      // and BOTH branches (missing vs present) are exercised deterministically.
-      let probeTmp
-      let origSessionFilePath
+    describe('_degradedProbeSuffix (#5328, WP-5.6; #6578)', () => {
+      // #6578: readiness is now resolved by matching `sessionId` (via
+      // resolveSessionFile), and `_lastProbeSawStatus` means "resolved a
+      // matching session file". So the suffix collapses to a single degraded
+      // case: NO session file for this sessionId was found anywhere (wrapper
+      // shim under a fully different install, or claude never wrote it). The
+      // found-but-busy case is healthy (`_lastProbeSawStatus === true` →
+      // empty). The stub is on resolveSessionFile now, not sessionFilePath.
+      let origResolve
       beforeEach(() => {
-        probeTmp = mkdtempSync(join(tmpdir(), 'chroxy-tui-probe-'))
-        origSessionFilePath = ClaudeTuiSession.sessionFilePath
-        ClaudeTuiSession.sessionFilePath = (pid) => join(probeTmp, `${pid}.json`)
+        origResolve = ClaudeTuiSession.resolveSessionFile
       })
       afterEach(() => {
-        ClaudeTuiSession.sessionFilePath = origSessionFilePath
-        if (probeTmp) rmSync(probeTmp, { recursive: true, force: true })
-        probeTmp = null
+        ClaudeTuiSession.resolveSessionFile = origResolve
       })
 
-      it('returns empty when the probe saw a status (healthy / real busy)', () => {
+      it('returns empty when the probe resolved a matching file (healthy / real busy)', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
         session._lastProbeSawStatus = true
         assert.equal(session._degradedProbeSuffix(), '')
       })
 
-      it('names the wrong-pid cause when the per-pid session file is MISSING', () => {
-        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
-        session._lastProbeSawStatus = false
-        session._term = { pid: 4242 } // no file written for it → missing
-        const suffix = session._degradedProbeSuffix()
-        assert.match(suffix, /no session file at .*4242\.json/, `got: ${suffix}`)
-        assert.match(suffix, /different pid/)
-        assert.match(suffix, /readiness gating is effectively disabled/)
-      })
-
-      it('names the statusless-file cause when the session file is PRESENT (#5366 review)', () => {
+      it('names the no-matching-file cause when no session file for this sessionId resolved (#6578)', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
         session._lastProbeSawStatus = false
         session._term = { pid: 4242 }
-        // File exists but carries no `status` field → wrong-entrypoint cause.
-        writeFileSync(join(probeTmp, '4242.json'), '{}')
+        session._sessionId = 'uuid-gone'
+        ClaudeTuiSession.resolveSessionFile = () => null // nothing resolved
         const suffix = session._degradedProbeSuffix()
-        assert.match(suffix, /session file never appeared with a `status` field/, `got: ${suffix}`)
-        assert.doesNotMatch(suffix, /different pid/)
+        assert.match(suffix, /no session file/, `got: ${suffix}`)
+        assert.match(suffix, /uuid-gone/, `should name the sessionId, got: ${suffix}`)
+        assert.match(suffix, /readiness gating is effectively disabled/)
       })
 
-      it('falls back to the statusless-file message when there is no usable pid', () => {
+      it('does not claim a missing pid-file when the dir-scan DID resolve one (no misleading wrapper-shim wording) (#6578)', () => {
+        // If a matching file was found (even under a different pid), the probe
+        // is NOT degraded — the suffix must be empty, not the wrapper-shim note.
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._lastProbeSawStatus = true // resolved a matching file
+        session._term = { pid: 4242 }
+        session._sessionId = 'uuid-found'
+        assert.equal(session._degradedProbeSuffix(), '',
+          'a resolved matching file is not a degraded probe')
+      })
+
+      it('still degrades gracefully when there is no usable pid or sessionId (#6578)', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
         session._lastProbeSawStatus = false
         session._term = null
+        session._sessionId = null
         const suffix = session._degradedProbeSuffix()
-        assert.match(suffix, /session file never appeared with a `status` field/, `got: ${suffix}`)
+        assert.match(suffix, /no session file/, `got: ${suffix}`)
       })
     })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1894,6 +1894,12 @@ describe('ClaudeTuiSession', () => {
         ClaudeTuiSession.resolveSessionFile('uuid-scan', fakePid), q,
         'dir-scan finds the matching file under a different pid',
       )
+      // #6578 throttle: allowDirScan:false suppresses the (readdir-heavy) fallback,
+      // so the same under-a-different-pid file is NOT found — only the fast path runs.
+      assert.equal(
+        ClaudeTuiSession.resolveSessionFile('uuid-scan', fakePid, { allowDirScan: false }), null,
+        'allowDirScan:false skips the dir-scan (fast-path miss → null)',
+      )
     })
 
     it('readSessionStatus returns null for missing/invalid files', () => {


### PR DESCRIPTION
## Summary

The **first message after a fresh claude-tui spawn stalled** to the ~5-minute "no response" watchdog because the readiness probe couldn't detect readiness. `_waitForPrompt` built **one** path from the pty pid (`~/.claude/sessions/<pty-pid>.json`) and required a `status` **string** — both signals are broken on current claude (**verified live on 2.1.186/187**):

- **MODE A** — under a wrapper-shim install (`~/.local/bin/claude` forks node without exec), the real claude pid ≠ pty pid, so the `<pty-pid>.json` file never appears.
- **MODE B** — current claude session files carry **no `status` field at all** (keys: pid, sessionId, cwd, startedAt, …), so `readSessionStatus` returns null even when the file *is* found.

Either way the probe silently degraded (`_lastProbeSawStatus=false`), the first `\r` was sent **blind**, and the freshly-spawned composer swallowed it.

## Fix

`this._sessionId` is deterministic at spawn (passed as `--session-id`/`--resume <uuid>`) and the session file carries a matching `sessionId`. So:

- **New `resolveSessionFile(sessionId, ptyPid)`** — fast-path the pty-pid file (verified by `sessionId` match), else **dir-scan** `~/.claude/sessions` for the file whose `sessionId` matches. Resolves the real file **regardless of pid** (MODE A). All I/O/parse errors swallowed → null (never throws into readiness). Cached per spawn, invalidated on respawn.
- **Readiness rework** — ready = (`status` present AND `!== 'busy'`) **OR** (a matching-`sessionId` file exists with no `status`) — the file is the process's own startup registration (MODE B). Still gates on `busy` for older claude that writes status. Pty-pid guard, auth-failure short-circuit, and exit guard all intact.
- **`_degradedProbeSuffix`** now distinguishes "no matching file anywhere" from "found but busy"; keeps a wrapper-shim note only for the genuine no-match case.
- The **first-turn submit nudge** stays as the composer-swallow backstop.

## Testing

`claude-tui-session.test.js` (extended the `readiness probe (#4040)` harness): **MODE A** (different pid, matching sessionId → ready), **MODE B** (statusless matching file → ready), **busy-with-status still gates**, **non-matching sessionId ignored** (multi-session false-positive guard), + a direct `resolveSessionFile` fast-path/no-match/dir-scan test. → **307 pass / 0 fail**. All 5 custom server lints green.

## ⚠️ Manual verification needed

File-existence-with-matching-sessionId is a **startup** readiness signal, not proof the composer is fully interactive — a residual not coverable by unit tests. Please do a **live claude-tui smoke**: spawn a fresh session and confirm the **first** message processes within a few seconds (no watchdog wedge), ideally on both a normal install and a wrapper-shim install (MODE A). The first-turn nudge remains as the backstop if the composer still swallows the first `\r`.

Closes #6578