### PR TITLE
fix(server): detect claude-tui readiness via PTY output quiescence (#6601)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -434,6 +434,13 @@ export class ClaudeTuiSession extends BaseSession {
     // UTF-8 strings already decoded, but the relevant control bytes
     // are 7-bit ASCII and survive the decode unchanged.
     this._outputTailRaw = Buffer.alloc(0)
+    // #6601: PTY output-quiescence readiness signal. `_lastOutputMs` is the
+    // monotonic time of the most recent onData chunk; `_sawFirstOutput` gates the
+    // signal until claude has actually rendered something on THIS spawn (so the
+    // `now - 0` at init doesn't read as "already quiescent"). Together (checkReady)
+    // they detect a settled composer when no ~/.claude/sessions file exists.
+    this._lastOutputMs = 0
+    this._sawFirstOutput = false
     // #5835 Phase 1: live remote-viewer mirror. PTY onData fires very frequently
     // during a TUI redraw, so coalesce bytes into a buffer and flush one
     // `terminal_output` event per tick (MIRROR_FLUSH_MS) — bounding the broadcast
@@ -1207,6 +1214,16 @@ export class ClaudeTuiSession extends BaseSession {
   // transitions are sub-second once the session is up.
   static get SPAWN_WARMUP_MAX_MS() { return 15_000 }
   static get TURN_PROMPT_WAIT_MAX_MS() { return 5_000 }
+  // #6601: how long PTY output must be quiet before the composer counts as ready
+  // when no session file resolves (current claude's INTERACTIVE TUI writes none,
+  // so the file probe never resolves and the caller used to burn the full
+  // warmup/turn ceiling then "write anyway"). The composer's render burst settles
+  // well within this window; the idle TUI then stays silent for seconds. Validated
+  // live: cold composer ready ~1.1s (vs the 15s warmup ceiling), between-turn
+  // redraw sub-second (vs the 5s per-turn ceiling). Comfortably above the observed
+  // intra-render gaps (~270ms) so it can't false-trigger mid-render; the
+  // warmup/turn ceilings still backstop a genuinely-stuck TUI.
+  static get READY_QUIESCENCE_MS() { return 400 }
   // #5317 (WP-2.3) — grace window between destroy()'s SIGTERM and the SIGKILL
   // escalation. Long enough for claude to flush its Stop hook + reap its own
   // tool children on a clean SIGTERM, short enough that a hung claude (or a
@@ -1881,6 +1898,11 @@ export class ClaudeTuiSession extends BaseSession {
     // the first spawn; this covers every subsequent _respawnPty.
     this._outputTail = ''
     this._outputTailRaw = Buffer.alloc(0)
+    // #6601: re-evaluate output-quiescence readiness for THIS spawn — require
+    // fresh output before trusting a quiet stretch, so a leftover _lastOutputMs
+    // from the prior process can't read as "ready" the instant we respawn.
+    this._sawFirstOutput = false
+    this._lastOutputMs = this._nowMonotonic()
 
     // #5794: a fresh PTY can swallow the first submit again, so re-arm the
     // first-turn submit nudge for the first message on THIS spawn. Reset after
@@ -2061,7 +2083,22 @@ export class ClaudeTuiSession extends BaseSession {
         sessFile = ClaudeTuiSession.resolveSessionFile(this._sessionId, pid, { allowDirScan })
         this._resolvedSessionFile = sessFile
       }
-      if (!sessFile) return false
+      if (!sessFile) {
+        // #6601: no session file resolved. Current claude's INTERACTIVE TUI
+        // writes no ~/.claude/sessions/<pid>.json at all, so the file probe
+        // never resolves and the caller used to burn the full warmup/turn
+        // ceiling then "write anyway" (the degraded path). Fall back to PTY
+        // OUTPUT QUIESCENCE: once claude has rendered on this spawn and output
+        // has been quiet for READY_QUIESCENCE_MS, the composer's render burst has
+        // settled and it is ready for input. Validated live (cold ready ~1.1s,
+        // between-turn redraw sub-second). The file path below is UNCHANGED for
+        // -p / claude-desktop / any version that DOES write a file; the
+        // warmup/turn ceilings still backstop a genuinely-stuck TUI, and the
+        // auth-failure scan (poll loop, above this) still runs first so a
+        // logged-out banner can't be mistaken for a settled composer.
+        return this._sawFirstOutput &&
+          (this._nowMonotonic() - this._lastOutputMs) >= ClaudeTuiSession.READY_QUIESCENCE_MS
+      }
       // A matching file was resolved → we have this session's readiness signal.
       sawStatus = true
       const status = ClaudeTuiSession.readSessionStatus(sessFile)
@@ -2115,6 +2152,11 @@ export class ClaudeTuiSession extends BaseSession {
    * covers CSI / OSC / SS3 / single-char terminal-mode codes (#4031).
    */
   _appendToOutputTail(data) {
+    // #6601: output-quiescence readiness — stamp the recency of PTY output so
+    // checkReady can detect a settled composer (see READY_QUIESCENCE_MS) when no
+    // session file exists. Two cheap field writes on a hot (per-redraw) path.
+    this._lastOutputMs = this._nowMonotonic()
+    this._sawFirstOutput = true
     const rawStr = String(data)
     const chunk = Buffer.from(rawStr, 'utf8')
     // #5794/#5809: monotonic total — never capped, so the nudge's progress check

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1716,6 +1716,51 @@ describe('ClaudeTuiSession', () => {
       assert.equal(ready, false, 'absent session file is treated as not-ready')
     })
 
+    // #6601: current claude's INTERACTIVE TUI writes no ~/.claude/sessions file,
+    // so the file probe never resolves. The probe then falls back to PTY output
+    // QUIESCENCE — once claude has rendered on this spawn and output has been
+    // quiet for READY_QUIESCENCE_MS, the composer has settled and is ready. These
+    // pin that fallback and its guards (no false-ready before render / while busy).
+    it('#6601 _waitForPrompt resolves true when no session file but output has quiesced', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      // no session file written; simulate a rendered-then-settled composer
+      session._sawFirstOutput = true
+      session._lastOutputMs = session._nowMonotonic() - (ClaudeTuiSession.READY_QUIESCENCE_MS + 200)
+      const ready = await session._waitForPrompt(100)
+      assert.equal(ready, true, 'quiescent output (no file) counts as ready')
+    })
+
+    it('#6601 _waitForPrompt stays not-ready while output is still flowing (not yet quiesced)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      session._sawFirstOutput = true
+      session._lastOutputMs = session._nowMonotonic() // just now — 0ms quiet
+      const ready = await session._waitForPrompt(50) // well under READY_QUIESCENCE_MS
+      assert.equal(ready, false, 'output still flowing (not quiescent) is not ready')
+    })
+
+    it('#6601 _waitForPrompt stays not-ready before ANY output (cold, pre-render — quiet-by-default trap)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      // _sawFirstOutput defaults false; _lastOutputMs defaults 0 (so now-0 LOOKS
+      // quiescent) — the _sawFirstOutput guard is what prevents a false-ready.
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'no output yet must NOT count as ready')
+    })
+
+    it('#6601 a busy session file overrides output quiescence (no false-ready)', async () => {
+      // Precedence: when a file DOES resolve and says busy, quiescence must not
+      // override it — the file path returns before the quiescence fallback.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+      writeSessionFile(fakePid, 'busy')
+      session._sawFirstOutput = true
+      session._lastOutputMs = session._nowMonotonic() - 10_000 // very quiescent
+      const ready = await session._waitForPrompt(50)
+      assert.equal(ready, false, 'status=busy file wins over quiescence')
+    })
+
     it('_waitForPrompt returns false when pid is missing or invalid (Copilot review on #4040)', async () => {
       // Returning true on a missing/invalid pid would silently disable
       // readiness gating on any platform/runtime where node-pty fails to


### PR DESCRIPTION
## Problem

Current claude (2.1.186/187) writes **no** `~/.claude/sessions/<pid>.json` for its **interactive** TUI (only `-p`/SDK mode and the Claude Desktop app do). chroxy's readiness probe keys on that file, so for every claude-tui session it never resolves — the probe burns the full `SPAWN_WARMUP_MAX_MS` (15s) on cold start and `TURN_PROMPT_WAIT_MAX_MS` (5s) on **every** turn, then falls through to "write anyway" (degraded). It works in a trusted cwd but wastes ~13s/session + ~5s/message.

Root-caused live for #6601 (see the issue for the full investigation — including why string-scraping the TUI is too fragile).

## Fix

Fall back to **PTY output quiescence** when no session file resolves: once claude has rendered on this spawn (`_sawFirstOutput`) and output has been quiet for `READY_QUIESCENCE_MS` (400ms), the composer's render burst has settled and it's ready. This is a robust, version-independent signal (no glyph/text scraping) that works for both cold-start and between-turns (bridges the post-Stop-hook redraw).

Surgical: only `checkReady`'s **no-file** branch changes (`return false` → the quiescence check). The session-file path is untouched for `-p` / claude-desktop / any version that writes a file, the warmup/turn ceilings still backstop a genuinely-stuck TUI, and the auth-failure scan still runs first in the poll loop so a logged-out banner can't read as ready.

## Validated live (daemon on this branch)

| Metric | Before (main) | After |
|---|---|---|
| Cold-start `claude_ready` | ~15.1s | **~1.2s** |
| Per-turn `waitForPrompt` | ~5.0s | **~0ms** |
| First message end-to-end | ~15s+ | **~2.3s** |

Daemon log confirms the quiescence path firing: `waitForPrompt (elapsedMs=1137 sawStatus=false ready=true)` — ready via quiescence (no file), and the "readiness gating disabled / may stall" warnings are gone.

## Tests

All 311 claude-tui-session tests pass, incl. 4 new ones pinning the fallback + its guards: quiescent→ready, still-flowing→not-ready, **no-output-yet→not-ready** (the `now - 0` quiet-by-default trap the `_sawFirstOutput` guard closes), and busy-file-overrides-quiescence.

## Scope / follow-up

An interstitial (trust/onboarding) is also quiescent, so this doesn't add interstitial *detection* — but it doesn't make it worse: chroxy already pre-trusts the cwd (so the trust dialog is pre-empted), and current claude's notices render inline (non-blocking). A dedicated interstitial guard can be a follow-up if a real case surfaces; adding a fragile token matcher now would risk its own false-negative wedges.

Closes #6601