### PR TITLE
feat(server): codex app-server driving layer (#6605 phase 1)

### DIFF
--- a/packages/server/src/codex-app-server-client.js
+++ b/packages/server/src/codex-app-server-client.js
@@ -1,0 +1,148 @@
+import { spawn } from 'child_process'
+import { EventEmitter } from 'events'
+import { createLogger } from './logger.js'
+
+const log = createLogger('codex-app-server')
+
+/**
+ * JSON-RPC 2.0 transport for `codex app-server` (newline-delimited over stdio).
+ *
+ * Spawns the app-server child, performs the `initialize` / `initialized`
+ * handshake, correlates client requests to their responses by id, and surfaces:
+ *   - `notification` { method, params } — server → client events (streaming, items)
+ *   - `serverRequest` { id, method, params } — server → client REQUESTS that need a
+ *     reply (approvals / elicitation); the caller answers with respond()/respondError()
+ *   - `exit` { code, signal, error? } — the child went away
+ *
+ * Protocol validated against codex-cli 0.128.0. This is pure transport — it maps
+ * nothing onto Chroxy's session contract; CodexAppServerSession does that.
+ */
+export class CodexAppServerClient extends EventEmitter {
+  constructor({ bin, cwd, env, logger } = {}) {
+    super()
+    this._bin = bin
+    this._cwd = cwd
+    this._env = env
+    this._log = logger || log
+    this._child = null
+    this._buf = ''
+    this._nextId = 1
+    this._pending = new Map() // id -> { resolve, reject }
+    this._closed = false
+  }
+
+  get pid() { return this._child?.pid ?? null }
+
+  /**
+   * Spawn the app-server and complete the handshake. Resolves with the
+   * `initialize` result (userAgent, codexHome, ...). Rejects if the child
+   * dies or the handshake errors.
+   */
+  async initialize(clientInfo = { name: 'chroxy', version: '1' }) {
+    this._child = spawn(this._bin, ['app-server'], { cwd: this._cwd, env: this._env })
+    this._child.stdout.on('data', (d) => this._onData(d))
+    this._child.stderr.on('data', (d) => this._onStderr(d))
+    this._child.on('exit', (code, signal) => this._onExit(code, signal))
+    this._child.on('error', (err) => this._onError(err))
+    const res = await this.request('initialize', { clientInfo })
+    this.notify('initialized')
+    return res
+  }
+
+  /** Send a JSON-RPC request; returns a Promise resolving with the result. */
+  request(method, params) {
+    if (this._closed) return Promise.reject(new Error('codex app-server is closed'))
+    const id = this._nextId++
+    const p = new Promise((resolve, reject) => this._pending.set(id, { resolve, reject }))
+    this._write({ jsonrpc: '2.0', id, method, params })
+    return p
+  }
+
+  /** Send a fire-and-forget JSON-RPC notification. */
+  notify(method, params) {
+    if (this._closed) return
+    this._write({ jsonrpc: '2.0', method, params })
+  }
+
+  /** Answer a server → client request (e.g. an approval) with a result. */
+  respond(id, result) {
+    if (this._closed) return
+    this._write({ jsonrpc: '2.0', id, result })
+  }
+
+  /** Answer a server → client request with a JSON-RPC error. */
+  respondError(id, code, message) {
+    if (this._closed) return
+    this._write({ jsonrpc: '2.0', id, error: { code, message } })
+  }
+
+  _write(msg) {
+    try { this._child?.stdin.write(JSON.stringify(msg) + '\n') }
+    catch (err) { this._log.warn(`codex app-server write failed: ${err.message}`) }
+  }
+
+  _onData(d) {
+    this._buf += String(d)
+    let nl
+    while ((nl = this._buf.indexOf('\n')) >= 0) {
+      const line = this._buf.slice(0, nl)
+      this._buf = this._buf.slice(nl + 1)
+      if (!line.trim()) continue
+      let m
+      try { m = JSON.parse(line) } catch { continue } // ignore non-JSON lines (banners)
+      this._dispatch(m)
+    }
+  }
+
+  /** Route one parsed JSON-RPC message. Exported shape is exercised by tests. */
+  _dispatch(m) {
+    // Response to one of OUR requests: has id + (result|error) and NO method.
+    if (m.id !== undefined && m.method === undefined && (m.result !== undefined || m.error !== undefined)) {
+      const pend = this._pending.get(m.id)
+      if (!pend) return
+      this._pending.delete(m.id)
+      if (m.error) pend.reject(new Error(m.error.message || JSON.stringify(m.error)))
+      else pend.resolve(m.result)
+      return
+    }
+    // Server → client REQUEST (id + method): approvals / elicitation. Needs a reply.
+    if (m.id !== undefined && m.method) {
+      this.emit('serverRequest', { id: m.id, method: m.method, params: m.params || {} })
+      return
+    }
+    // Notification (method, no id): streaming + item events.
+    if (m.method) this.emit('notification', { method: m.method, params: m.params || {} })
+  }
+
+  _onStderr(d) {
+    const s = String(d).trim()
+    if (s) this._log.debug(`codex app-server stderr: ${s.slice(0, 500)}`)
+  }
+
+  _onExit(code, signal) {
+    if (this._closed) return
+    this._closed = true
+    this._rejectAllPending(new Error(`codex app-server exited (code=${code}${signal ? ` signal=${signal}` : ''})`))
+    this.emit('exit', { code, signal })
+  }
+
+  _onError(err) {
+    if (this._closed) return
+    this._log.warn(`codex app-server process error: ${err.message}`)
+    this._closed = true
+    this._rejectAllPending(err)
+    this.emit('exit', { code: null, signal: null, error: err })
+  }
+
+  _rejectAllPending(err) {
+    for (const { reject } of this._pending.values()) reject(err)
+    this._pending.clear()
+  }
+
+  /** Terminate the child and fail any in-flight requests. Idempotent. */
+  kill() {
+    if (!this._closed) this._rejectAllPending(new Error('codex app-server killed'))
+    this._closed = true
+    try { this._child?.kill('SIGKILL') } catch { /* already gone */ }
+  }
+}

--- a/packages/server/src/codex-app-server-client.js
+++ b/packages/server/src/codex-app-server-client.js
@@ -44,6 +44,12 @@ export class CodexAppServerClient extends EventEmitter {
     this._child.stderr.on('data', (d) => this._onStderr(d))
     this._child.on('exit', (code, signal) => this._onExit(code, signal))
     this._child.on('error', (err) => this._onError(err))
+    // #6606 review — a write to a dead child (EPIPE) or an stdout/stderr stream
+    // error would otherwise surface as an UNHANDLED 'error' and crash the daemon.
+    // Route them through the same teardown as a process error (idempotent).
+    for (const s of [this._child.stdin, this._child.stdout, this._child.stderr]) {
+      s?.on('error', (err) => this._onError(err))
+    }
     const res = await this.request('initialize', { clientInfo })
     this.notify('initialized')
     return res
@@ -85,9 +91,11 @@ export class CodexAppServerClient extends EventEmitter {
     this._buf += String(d)
     let nl
     while ((nl = this._buf.indexOf('\n')) >= 0) {
-      const line = this._buf.slice(0, nl)
+      // trim() strips a trailing '\r' too, so CRLF-framed lines parse cleanly
+      // instead of throwing on the stray carriage return (#6606 review).
+      const line = this._buf.slice(0, nl).trim()
       this._buf = this._buf.slice(nl + 1)
-      if (!line.trim()) continue
+      if (!line) continue
       let m
       try { m = JSON.parse(line) } catch { continue } // ignore non-JSON lines (banners)
       this._dispatch(m)

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -1,0 +1,334 @@
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { CodexSession, resolveCodexSandbox } from './codex-session.js'
+import { CodexAppServerClient } from './codex-app-server-client.js'
+import { buildSpawnEnv } from './utils/spawn-env.js'
+import { createLogger, loggerForSession } from './logger.js'
+
+const log = createLogger('codex-app-server')
+
+/**
+ * Codex session driven through the `codex app-server` JSON-RPC protocol
+ * (persistent process) instead of one-shot `codex exec --json` (see
+ * codex-session.js). This is the foundation for surfacing codex's approval
+ * requests through Chroxy's permission pipeline (epic #6605).
+ *
+ * PHASE 1 (this file) is the DRIVING LAYER only: it runs turns and maps the
+ * app-server's streaming notifications onto Chroxy's standard event contract,
+ * at behaviour-parity with the exec path. It uses `approvalPolicy: 'never'`
+ * (codex runs commands within its sandbox without prompting, exactly like
+ * `codex exec`), and does NOT yet surface approvals — `capabilities.permissions`
+ * stays false. Phase 2 flips the policy to `on-request` and wires the
+ * server → client approval RPC into a PermissionManager.
+ *
+ * Selected only when `CHROXY_CODEX_APPSERVER=1` (see providers.js `getProvider`);
+ * otherwise the exec-based CodexSession is used, so this is a no-op by default.
+ *
+ * Architecturally this mirrors SdkSession (persistent backend + streaming),
+ * NOT the JsonlSubprocessSession middle layer (subprocess-per-turn). Codex
+ * provider identity (binary / auth / models / preflight) is delegated to
+ * CodexSession's statics so both paths report identically.
+ */
+export class CodexAppServerSession extends BaseSession {
+  // -- Provider identity (delegated to CodexSession so both paths agree) --
+  static get providerName() { return 'codex' }
+  static get displayLabel() { return 'OpenAI Codex (app-server)' }
+  static get dataDir() { return CodexSession.dataDir }
+  static get messageIdPrefix() { return 'codex' }
+  static get apiKeyEnv() { return CodexSession.apiKeyEnv }
+  static get binaryCandidates() { return CodexSession.binaryCandidates }
+  static get resolvedBinary() { return CodexSession.resolvedBinary }
+  static hasAlternativeCredentials() { return CodexSession.hasAlternativeCredentials() }
+  static resolveAuth(env, helpers) { return CodexSession.resolveAuth(env, helpers) }
+  static get preflight() { return CodexSession.preflight }
+  static getAllowedModels() { return CodexSession.getAllowedModels() }
+  static getFallbackModels() { return CodexSession.getFallbackModels() }
+  static getModelMetadata(id) { return CodexSession.getModelMetadata(id) }
+
+  static get capabilities() {
+    return {
+      // Phase 1 is behaviour-parity with exec: no approval surfacing yet.
+      // Phase 2 flips permissions/inProcessPermissions to true.
+      permissions: false,
+      inProcessPermissions: false,
+      modelSwitch: true,
+      permissionModeSwitch: false,
+      planMode: false,
+      resume: false, // matches exec CodexSession; app-server resume is a follow-up
+      terminal: false,
+      thinkingLevel: false,
+      streaming: true,
+    }
+  }
+
+  constructor(opts = {}) {
+    // #5367 canonical picker — forward every BaseSession opt; codex defaults in
+    // the overrides bag (model omitted → app-server uses ~/.codex/config.toml).
+    super(buildBaseSessionOpts(opts, {
+      provider: opts.provider || 'codex',
+      model: opts.model || null,
+    }))
+    this._client = null
+    this._threadId = null
+    this._activeTurn = null // { messageId, turnId, didStreamStart }
+    this._lastUsage = null
+  }
+
+  _buildChildEnv() { return buildSpawnEnv('codex') }
+
+  // ------------------------------------------------------------------
+  // Lifecycle
+  // ------------------------------------------------------------------
+
+  async start() {
+    const sandbox = resolveCodexSandbox()
+    this._client = new CodexAppServerClient({
+      bin: CodexAppServerSession.resolvedBinary,
+      cwd: this.cwd,
+      env: this._buildChildEnv(),
+      logger: log,
+    })
+    this._client.on('notification', (n) => this._onNotification(n))
+    this._client.on('serverRequest', (r) => this._onServerRequest(r))
+    this._client.on('exit', (e) => this._onClientExit(e))
+
+    await this._client.initialize({ name: 'chroxy', version: '1' })
+    const started = await this._client.request('thread/start', {
+      approvalPolicy: 'never', // Phase 1: sandboxed, no prompts (parity with exec)
+      cwd: this.cwd,
+      sandbox,
+      ...(this.model ? { model: this.model } : {}),
+    })
+    this._threadId = started?.thread?.id || null
+    this.resumeSessionId = this._threadId
+    this._log = loggerForSession('codex-app-server', this._threadId || 'no-thread')
+    this._processReady = true
+    ;(this._log || log).info(`codex app-server ready (thread=${this._threadId} sandbox=${sandbox})`)
+    this.emit('ready', { model: this.model })
+  }
+
+  async sendMessage(prompt, attachments, sendOptions = {}) {
+    if (this._isBusy) {
+      this.enqueueOutgoingMessage({ prompt, attachments, sendOptions })
+      return
+    }
+    if (!this._processReady || !this._client) {
+      this.emit('error', { message: 'Codex app-server session is not started' })
+      return
+    }
+    this._isBusy = true
+    this._messageCounter += 1
+    const messageId = `msg-${this._messageIdPrefix}-${this._messageCounter}`
+    this._currentMessageId = messageId
+    this._activeTurn = { messageId, turnId: null, didStreamStart: false }
+    this._armResultTimeout()
+    ;(this._log || log).info(`codex app-server turn start (msg=${messageId} thread=${this._threadId})`)
+    try {
+      const res = await this._client.request('turn/start', {
+        threadId: this._threadId,
+        approvalPolicy: 'never',
+        input: [{ type: 'text', text: prompt || '' }],
+      })
+      if (this._activeTurn && !this._activeTurn.turnId) this._activeTurn.turnId = res?.turn?.id || null
+    } catch (err) {
+      // turn/start itself failed (dead server, bad thread) — fail this turn.
+      this._failTurn(`Codex turn failed to start: ${err.message}`)
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // app-server notification → Chroxy event mapping
+  // ------------------------------------------------------------------
+
+  _onNotification({ method, params }) {
+    if (!this._activeTurn) {
+      // Between turns: only usage/errors matter; ignore stray item churn.
+      if (method === 'thread/tokenUsage/updated') this._lastUsage = this._mapUsage(params)
+      return
+    }
+    this._resetResultTimeout()
+    const t = this._activeTurn
+    switch (method) {
+      case 'turn/started':
+        if (!t.turnId) t.turnId = params?.turn?.id || params?.turnId || null
+        break
+      case 'item/agentMessage/delta': {
+        const delta = params?.delta ?? params?.text ?? ''
+        if (!delta) break
+        this._ensureStreamStart()
+        this.emit('stream_delta', { messageId: t.messageId, delta })
+        break
+      }
+      case 'item/started':
+        this._onItemStarted(params?.item)
+        break
+      case 'item/completed':
+        this._onItemCompleted(params?.item)
+        break
+      case 'thread/tokenUsage/updated':
+        this._lastUsage = this._mapUsage(params)
+        break
+      case 'turn/completed':
+        this._finishTurn(params?.turn)
+        break
+      case 'error':
+        this._failTurn(`Codex error: ${JSON.stringify(params).slice(0, 200)}`)
+        break
+      default:
+        break // reasoning/plan/other items are ignored in Phase 1
+    }
+  }
+
+  _onItemStarted(item) {
+    if (!item) return
+    // commandExecution / fileChange / mcpToolCall map to Chroxy tools.
+    if (item.type === 'commandExecution') {
+      const toolUseId = item.id
+      this.emit('tool_start', {
+        messageId: this._activeTurn.messageId,
+        toolUseId,
+        tool: 'shell',
+        input: { command: item.command, cwd: item.cwd },
+      })
+      this._trackToolStart(toolUseId, 'shell')
+    } else if (item.type === 'fileChange') {
+      const toolUseId = item.id
+      this.emit('tool_start', {
+        messageId: this._activeTurn.messageId,
+        toolUseId,
+        tool: 'apply_patch',
+        input: { changes: item.changes ?? item.patch ?? null },
+      })
+      this._trackToolStart(toolUseId, 'apply_patch')
+    }
+  }
+
+  _onItemCompleted(item) {
+    if (!item) return
+    if (item.type === 'commandExecution') {
+      this.emit('tool_result', { toolUseId: item.id, result: item.aggregatedOutput ?? '' })
+      this._trackToolResult(item.id)
+    } else if (item.type === 'fileChange') {
+      this.emit('tool_result', { toolUseId: item.id, result: item.status ?? '' })
+      this._trackToolResult(item.id)
+    } else if (item.type === 'agentMessage') {
+      // Fallback: if the final text never arrived as deltas (short replies can
+      // skip the delta stream), emit it once so the message isn't lost.
+      if (!this._activeTurn.didStreamStart && item.text) {
+        this._ensureStreamStart()
+        this.emit('stream_delta', { messageId: this._activeTurn.messageId, delta: item.text })
+      }
+    }
+  }
+
+  _ensureStreamStart() {
+    if (this._activeTurn.didStreamStart) return
+    this._activeTurn.didStreamStart = true
+    this.emit('stream_start', { messageId: this._activeTurn.messageId })
+  }
+
+  _mapUsage(params) {
+    const u = params?.usage || params || {}
+    return {
+      input_tokens: u.inputTokens ?? u.input_tokens ?? 0,
+      output_tokens: u.outputTokens ?? u.output_tokens ?? 0,
+      cached_input_tokens: u.cachedInputTokens ?? u.cached_input_tokens ?? 0,
+    }
+  }
+
+  _finishTurn(turn) {
+    if (!this._activeTurn) return
+    const t = this._activeTurn
+    this._clearResultTimeout()
+    if (t.didStreamStart) this.emit('stream_end', { messageId: t.messageId })
+    this._emitResult(
+      { cost: null, duration: turn?.durationMs ?? null, usage: this._lastUsage, sessionId: this._threadId },
+      'turn_ended_with_orphan_tool_start',
+    )
+    this._activeTurn = null
+    this._clearMessageState()
+    this._maybeDequeue()
+  }
+
+  _failTurn(message) {
+    this._clearResultTimeout()
+    const t = this._activeTurn
+    if (t?.didStreamStart) this.emit('stream_end', { messageId: t.messageId })
+    const wasIntentional = this._consumeIntentionalStop()
+    if (wasIntentional) this.emit('stopped', {})
+    else this.emit('error', { message })
+    this._activeTurn = null
+    this._clearMessageState()
+    this._maybeDequeue()
+  }
+
+  _maybeDequeue() {
+    if (this._outgoingQueue.length && !this._destroying) this.dequeueNextOutgoing()
+  }
+
+  // Basic result-timeout so a wedged turn can't hang busy forever. Reset on
+  // every notification (progress), cleared on turn end.
+  _armResultTimeout() {
+    this._clearResultTimeout()
+    this._resultTimeout = setTimeout(() => {
+      ;(this._log || log).warn(`codex app-server turn result timeout (msg=${this._currentMessageId})`)
+      this._failTurn('Codex turn timed out with no result')
+    }, this._resultTimeoutMs)
+    if (typeof this._resultTimeout.unref === 'function') this._resultTimeout.unref()
+  }
+
+  _resetResultTimeout() {
+    if (this._activeTurn) this._armResultTimeout()
+  }
+
+  _clearResultTimeout() {
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+  }
+
+  // ------------------------------------------------------------------
+  // Server → client requests (approvals). Phase 1: not enabled.
+  // ------------------------------------------------------------------
+
+  _onServerRequest({ id, method }) {
+    // With approvalPolicy:'never' the server should not ask; if it does (future
+    // codex behaviour / a policy we didn't set), decline cleanly rather than
+    // wedge the turn. Phase 2 routes these into the permission pipeline.
+    ;(this._log || log).warn(`codex app-server unexpected serverRequest ${method} — declining (approvals land in Phase 2)`)
+    this._client?.respondError(id, -32601, 'approvals not enabled (Chroxy Phase 1)')
+  }
+
+  _onClientExit({ code, signal, error }) {
+    if (this._destroying) return
+    const detail = error ? error.message : `code=${code}${signal ? ` signal=${signal}` : ''}`
+    ;(this._log || log).warn(`codex app-server exited unexpectedly (${detail})`)
+    this._processReady = false
+    if (this._activeTurn) this._failTurn(`Codex app-server exited (${detail})`)
+    else this.emit('error', { message: `Codex app-server exited (${detail})`, recoverable: true })
+  }
+
+  // ------------------------------------------------------------------
+  // Interrupt / teardown
+  // ------------------------------------------------------------------
+
+  async interrupt() {
+    this.clearOutgoingQueue()
+    this.markIntentionalStop()
+    if (this._client && this._activeTurn?.turnId) {
+      try { await this._client.request('turn/interrupt', { threadId: this._threadId, turnId: this._activeTurn.turnId }) }
+      catch (err) { (this._log || log).debug(`turn/interrupt failed: ${err.message}`) }
+    }
+  }
+
+  async destroy() {
+    this._destroying = true
+    this.clearOutgoingQueue({ emit: false })
+    this._clearIntentionalStop()
+    this._clearResultTimeout()
+    try { this._client?.kill() } catch { /* already gone */ }
+    this._client = null
+    this._activeTurn = null
+    this._clearMessageState()
+    this._destroyPendingBackgroundShells()
+    this._processReady = false
+    this.removeAllListeners()
+  }
+}

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -99,7 +99,11 @@ export class CodexAppServerSession extends BaseSession {
       ...(this.model ? { model: this.model } : {}),
     })
     this._threadId = started?.thread?.id || null
-    this.resumeSessionId = this._threadId
+    // #6608 — do NOT set this.resumeSessionId in Phase 1: capabilities.resume is
+    // false, and SessionManager persists resumeSessionId as the conversationId to
+    // resume on restart. Leaving it null keeps the two consistent. The live thread
+    // id is tracked on this._threadId (used for turn/start + interrupt). Wiring
+    // real app-server resume (thread/resume) is a follow-up.
     this._log = loggerForSession('codex-app-server', this._threadId || 'no-thread')
     this._processReady = true
     ;(this._log || log).info(`codex app-server ready (thread=${this._threadId} sandbox=${sandbox})`)
@@ -127,6 +131,10 @@ export class CodexAppServerSession extends BaseSession {
         threadId: this._threadId,
         approvalPolicy: 'never',
         input: [{ type: 'text', text: prompt || '' }],
+        // #6608 — pass the CURRENT model per turn (turn/start accepts it) so a
+        // mid-session set_model actually takes effect, matching the exec path's
+        // per-turn model. thread/start seeds the initial model; this tracks changes.
+        ...(this.model ? { model: this.model } : {}),
       })
       if (this._activeTurn && !this._activeTurn.turnId) this._activeTurn.turnId = res?.turn?.id || null
     } catch (err) {
@@ -245,6 +253,11 @@ export class CodexAppServerSession extends BaseSession {
       'turn_ended_with_orphan_tool_start',
     )
     this._activeTurn = null
+    // #6606 review — disarm the intentional-stop flag on a NORMAL completion too
+    // (mirrors sdk-session.js). interrupt() arms it; if the turn then completes
+    // cleanly, only _failTurn would otherwise consume it, so a leftover flag
+    // would mis-report a LATER genuine error as a clean `stopped` (#4881 race).
+    this._clearIntentionalStop()
     this._clearMessageState()
     this._maybeDequeue()
   }

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -71,6 +71,7 @@ export class CodexAppServerSession extends BaseSession {
     this._threadId = null
     this._activeTurn = null // { messageId, turnId, didStreamStart }
     this._lastUsage = null
+    this._skillsPrepended = false // #6606 — inject the skills prefix once, on turn 1
   }
 
   _buildChildEnv() { return buildSpawnEnv('codex') }
@@ -125,17 +126,33 @@ export class CodexAppServerSession extends BaseSession {
     this._currentMessageId = messageId
     this._activeTurn = { messageId, turnId: null, didStreamStart: false }
     this._armResultTimeout()
+
+    // #6606 review — mirror the exec path: prepend the combined skills prefix on
+    // the FIRST turn so runtime skills reach codex. The flag flips only AFTER
+    // turn/start succeeds, so a failed first turn still retries with the skills.
+    let text = prompt || ''
+    if (!this._skillsPrepended) {
+      const combined = typeof this._buildCombinedSkillsPrefix === 'function' ? this._buildCombinedSkillsPrefix() : ''
+      if (combined) text = `${combined}\n\n---\n\n${text}`
+    }
+    // #6609 — attachments aren't materialized on the app-server path yet (the
+    // exec path does via JsonlSubprocessSession). Warn rather than silently drop.
+    if (attachments?.length) {
+      ;(this._log || log).warn(`codex app-server: ${attachments.length} attachment(s) ignored — not yet supported (#6609)`)
+    }
+
     ;(this._log || log).info(`codex app-server turn start (msg=${messageId} thread=${this._threadId})`)
     try {
       const res = await this._client.request('turn/start', {
         threadId: this._threadId,
         approvalPolicy: 'never',
-        input: [{ type: 'text', text: prompt || '' }],
+        input: [{ type: 'text', text }],
         // #6608 — pass the CURRENT model per turn (turn/start accepts it) so a
         // mid-session set_model actually takes effect, matching the exec path's
         // per-turn model. thread/start seeds the initial model; this tracks changes.
         ...(this.model ? { model: this.model } : {}),
       })
+      this._skillsPrepended = true
       if (this._activeTurn && !this._activeTurn.turnId) this._activeTurn.turnId = res?.turn?.id || null
     } catch (err) {
       // turn/start itself failed (dead server, bad thread) — fail this turn.

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -22,6 +22,7 @@ import { DeepSeekSession } from './deepseek-session.js'
 import { OllamaSession } from './ollama-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
+import { CodexAppServerSession } from './codex-app-server-session.js'
 import { UserShellSession } from './user-shell-session.js'
 import { registerProviderRegistry } from './models.js'
 import { BILLING_CLASSES } from './billing-class.js'
@@ -52,6 +53,12 @@ const PROVIDERS = {
   'ollama': OllamaSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
+  // #6605 — codex via the app-server JSON-RPC protocol (persistent) instead of
+  // one-shot `codex exec`. Hidden (not a user-selectable provider): it's the
+  // opt-in swap target for the 'codex' key, selected in getProvider() when
+  // CHROXY_CODEX_APPSERVER=1. Registered here so validateProviderClass runs its
+  // contract check at module load.
+  'codex-appserver': CodexAppServerSession,
   // #5983 (epic #5982) — general-purpose user shell ($SHELL via node-pty).
   // Gated OFF by default (userShell.enabled, #5985a) and primary-token-only
   // on create + every terminal_* op (#5985b); excluded from mailbox injection
@@ -73,7 +80,7 @@ export { DEFAULT_PROVIDER, USER_SHELL_PROVIDER }
 // created via a dedicated shell affordance (#5986/#5987), never the chat
 // provider picker. Hiding it keeps it out of listProviders() so it can't be
 // selected as a (fake-ready) chat backend. getProvider/create still resolve it.
-const HIDDEN = new Set([USER_SHELL_PROVIDER])
+const HIDDEN = new Set([USER_SHELL_PROVIDER, 'codex-appserver'])
 
 /** Required methods every provider class prototype must expose. */
 const REQUIRED_METHODS = ['sendMessage', 'interrupt', 'setModel', 'setPermissionMode', 'start', 'destroy']
@@ -163,6 +170,15 @@ export function getRegisteredProviderNames() {
  * @throws {Error} If provider is not registered
  */
 export function getProvider(name) {
+  // #6605 — opt-in: drive codex through the app-server JSON-RPC protocol
+  // (persistent, approval-capable) instead of one-shot `codex exec`. Env-gated
+  // at resolve time (not in the PROVIDERS literal, which is validated at load)
+  // so it's a safe no-op until explicitly enabled. getProvider is the single
+  // chokepoint SessionManager uses to both construct and preflight, so this one
+  // branch covers every path.
+  if (name === 'codex' && process.env.CHROXY_CODEX_APPSERVER === '1') {
+    return CodexAppServerSession
+  }
   const ProviderClass = PROVIDERS[name]
   if (!ProviderClass) {
     const available = Object.keys(PROVIDERS).join(', ')

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -1,0 +1,182 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { CodexAppServerSession } from '../src/codex-app-server-session.js'
+import { CodexAppServerClient } from '../src/codex-app-server-client.js'
+
+// #6605 Phase 1 — the codex app-server DRIVING layer. These pin the JSON-RPC
+// transport routing and the app-server-notification → Chroxy-event mapping
+// WITHOUT spawning a real `codex app-server` (the live end-to-end round-trip is
+// validated separately).
+
+function mkSession() {
+  const sk = mkdtempSync(join(tmpdir(), 'chroxy-cas-'))
+  const s = new CodexAppServerSession({ cwd: '/tmp', skillsDir: sk, repoSkillsDir: null })
+  return { s, cleanup: () => rmSync(sk, { recursive: true, force: true }) }
+}
+function capture(s, events) {
+  const out = []
+  events.forEach((e) => s.on(e, (p) => out.push([e, p])))
+  return out
+}
+
+describe('CodexAppServerClient (JSON-RPC transport)', () => {
+  it('resolves a pending request when its response arrives', async () => {
+    const c = new CodexAppServerClient({})
+    c._child = { stdin: { write: () => {} } } // stub the writer, no real child
+    const p = c.request('initialize', {})
+    c._dispatch({ jsonrpc: '2.0', id: 1, result: { ok: true } })
+    assert.deepEqual(await p, { ok: true })
+  })
+
+  it('rejects a pending request on an error response', async () => {
+    const c = new CodexAppServerClient({})
+    c._child = { stdin: { write: () => {} } }
+    const p = c.request('x', {})
+    c._dispatch({ jsonrpc: '2.0', id: 1, error: { message: 'boom' } })
+    await assert.rejects(p, /boom/)
+  })
+
+  it('emits serverRequest for a server→client request (approval)', () => {
+    const c = new CodexAppServerClient({})
+    let got = null
+    c.on('serverRequest', (r) => (got = r))
+    c._dispatch({ jsonrpc: '2.0', id: 7, method: 'item/commandExecution/requestApproval', params: { reason: 'x' } })
+    assert.equal(got.id, 7)
+    assert.match(got.method, /requestApproval/)
+  })
+
+  it('emits notification for a server notification (no id)', () => {
+    const c = new CodexAppServerClient({})
+    let got = null
+    c.on('notification', (n) => (got = n))
+    c._dispatch({ jsonrpc: '2.0', method: 'turn/started', params: { turn: { id: 't' } } })
+    assert.equal(got.method, 'turn/started')
+  })
+
+  it('buffers newline-delimited JSON split across stdout chunks', () => {
+    const c = new CodexAppServerClient({})
+    const notes = []
+    c.on('notification', (n) => notes.push(n.method))
+    c._onData('{"jsonrpc":"2.0","method":"a"}\n{"jsonrpc":"2.0","meth')
+    c._onData('od":"b"}\n')
+    assert.deepEqual(notes, ['a', 'b'])
+  })
+
+  it('rejects all in-flight requests on kill()', async () => {
+    const c = new CodexAppServerClient({})
+    c._child = { stdin: { write: () => {} } }
+    const p = c.request('x', {})
+    c.kill()
+    await assert.rejects(p, /killed/)
+  })
+})
+
+describe('CodexAppServerSession — app-server → Chroxy event mapping', () => {
+  it('maps agentMessage deltas to a single stream_start + stream_delta stream', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['stream_start', 'stream_delta'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({ method: 'item/agentMessage/delta', params: { delta: 'Hi' } })
+    s._onNotification({ method: 'item/agentMessage/delta', params: { delta: '!' } })
+    assert.deepEqual(ev.map(([e]) => e), ['stream_start', 'stream_delta', 'stream_delta'])
+    assert.equal(ev[1][1].delta, 'Hi')
+    assert.equal(ev[1][1].messageId, 'm1')
+    cleanup()
+  })
+
+  it('maps a commandExecution item to tool_start / tool_result', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['tool_start', 'tool_result'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'commandExecution', id: 'c1', command: 'echo hi', cwd: '/tmp' } } })
+    s._onNotification({ method: 'item/completed', params: { item: { type: 'commandExecution', id: 'c1', aggregatedOutput: 'hi\n' } } })
+    assert.equal(ev[0][0], 'tool_start')
+    assert.equal(ev[0][1].tool, 'shell')
+    assert.equal(ev[0][1].input.command, 'echo hi')
+    assert.equal(ev[1][0], 'tool_result')
+    assert.equal(ev[1][1].result, 'hi\n')
+    assert.equal(ev[1][1].toolUseId, 'c1')
+    cleanup()
+  })
+
+  it('turn/completed emits stream_end + result and clears busy', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['stream_end', 'result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 42 } } })
+    assert.deepEqual(ev.map(([e]) => e), ['stream_end', 'result'])
+    assert.equal(ev[1][1].duration, 42)
+    assert.equal(s._isBusy, false, 'busy cleared after turn')
+    assert.equal(s._activeTurn, null, 'active turn cleared')
+    cleanup()
+  })
+
+  it('a short agentMessage with no prior deltas still emits its text (fallback)', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['stream_start', 'stream_delta'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({ method: 'item/completed', params: { item: { type: 'agentMessage', text: 'short' } } })
+    assert.deepEqual(ev.map(([e, p]) => [e, p.delta]), [['stream_start', undefined], ['stream_delta', 'short']])
+    cleanup()
+  })
+
+  it('ignores the userMessage echo item (no spurious events)', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['stream_start', 'stream_delta', 'tool_start', 'tool_result'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'userMessage', id: 'u1', content: [{ type: 'text', text: 'hi' }] } } })
+    s._onNotification({ method: 'item/completed', params: { item: { type: 'userMessage', id: 'u1' } } })
+    assert.equal(ev.length, 0, 'the input echo produces no Chroxy events')
+    cleanup()
+  })
+})
+
+describe('CodexAppServerSession — lifecycle guards', () => {
+  it('sendMessage while busy enqueues instead of starting a turn', async () => {
+    const { s, cleanup } = mkSession()
+    let queued = null
+    s.on('message_queued', (p) => (queued = p))
+    s._isBusy = true
+    await s.sendMessage('hello')
+    assert.ok(queued, 'busy send was queued')
+    cleanup()
+  })
+
+  it('sendMessage before start() emits a not-started error', async () => {
+    const { s, cleanup } = mkSession()
+    let err = null
+    s.on('error', (e) => (err = e))
+    await s.sendMessage('hello')
+    assert.match(err.message, /not started/)
+    cleanup()
+  })
+
+  it('declines an unexpected server approval request in Phase 1 (no wedge)', () => {
+    const { s, cleanup } = mkSession()
+    let responded = null
+    s._client = { respondError: (id, code, msg) => (responded = { id, code, msg }) }
+    s._onServerRequest({ id: 3, method: 'item/commandExecution/requestApproval', params: {} })
+    assert.equal(responded.id, 3)
+    assert.match(responded.msg, /Phase 1/)
+    cleanup()
+  })
+
+  it('capabilities: permissions off (Phase 1), streaming + modelSwitch on', () => {
+    const c = CodexAppServerSession.capabilities
+    assert.equal(c.permissions, false)
+    assert.equal(c.inProcessPermissions, false)
+    assert.equal(c.streaming, true)
+    assert.equal(c.modelSwitch, true)
+  })
+
+  it('delegates codex provider identity to CodexSession statics', () => {
+    assert.equal(CodexAppServerSession.providerName, 'codex')
+    assert.equal(CodexAppServerSession.apiKeyEnv, 'OPENAI_API_KEY')
+    assert.ok(CodexAppServerSession.resolvedBinary, 'resolvedBinary delegates')
+    assert.ok(Array.isArray(CodexAppServerSession.getAllowedModels()))
+  })
+})

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -65,6 +65,14 @@ describe('CodexAppServerClient (JSON-RPC transport)', () => {
     assert.deepEqual(notes, ['a', 'b'])
   })
 
+  it('parses CRLF-framed lines (a trailing \\r does not break JSON.parse) (#6606)', () => {
+    const c = new CodexAppServerClient({})
+    const notes = []
+    c.on('notification', (n) => notes.push(n.method))
+    c._onData('{"jsonrpc":"2.0","method":"crlf"}\r\n')
+    assert.deepEqual(notes, ['crlf'])
+  })
+
   it('rejects all in-flight requests on kill()', async () => {
     const c = new CodexAppServerClient({})
     c._child = { stdin: { write: () => {} } }
@@ -162,6 +170,24 @@ describe('CodexAppServerSession — lifecycle guards', () => {
     s._onServerRequest({ id: 3, method: 'item/commandExecution/requestApproval', params: {} })
     assert.equal(responded.id, 3)
     assert.match(responded.msg, /Phase 1/)
+    cleanup()
+  })
+
+  it('prepends the skills prefix on the FIRST turn only, and the current model (#6606)', async () => {
+    const { s, cleanup } = mkSession()
+    s._processReady = true
+    s._threadId = 't'
+    s.model = 'gpt-5-codex'
+    const captured = []
+    s._client = { request: async (_m, p) => { captured.push(p); return { turn: { id: 'tt' } } } }
+    s._buildCombinedSkillsPrefix = () => 'SKILLZ'
+    await s.sendMessage('hello')
+    s._isBusy = false // simulate turn completion so the next send isn't queued
+    s._activeTurn = null
+    await s.sendMessage('again')
+    assert.match(captured[0].input[0].text, /SKILLZ[\s\S]*hello/, 'first turn carries the skills prefix')
+    assert.equal(captured[0].model, 'gpt-5-codex', 'turn/start carries the current model')
+    assert.equal(captured[1].input[0].text, 'again', 'second turn has no skills prefix')
     cleanup()
   })
 

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -180,3 +180,68 @@ describe('CodexAppServerSession — lifecycle guards', () => {
     assert.ok(Array.isArray(CodexAppServerSession.getAllowedModels()))
   })
 })
+
+describe('CodexAppServerSession — crash / stop paths (#6607)', () => {
+  it('a NORMAL completion disarms intentional-stop so a LATER failure reports as error (#6606 C1)', () => {
+    const { s, cleanup } = mkSession()
+    // interrupt() armed the intentional-stop flag, but the turn then finished cleanly.
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    s.markIntentionalStop()
+    s._onNotification({ method: 'turn/completed', params: { turn: {} } })
+    // A subsequent GENUINE failure must surface as `error`, not a stale `stopped`.
+    const ev = capture(s, ['error', 'stopped'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm2', turnId: 't2', didStreamStart: false }
+    s._failTurn('genuine failure')
+    assert.deepEqual(ev.map(([e]) => e), ['error'], 'later failure is error, not a stale stopped')
+    cleanup()
+  })
+
+  it('client exit during a turn fails the turn and clears busy', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    s._onClientExit({ code: 1, signal: null })
+    assert.equal(ev[0][0], 'error')
+    assert.match(ev[0][1].message, /exited/)
+    assert.equal(s._isBusy, false, 'busy cleared after client exit mid-turn')
+    assert.equal(s._processReady, false, 'session marked not-ready')
+    cleanup()
+  })
+
+  it('an error notification during a turn fails the turn', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    s._onNotification({ method: 'error', params: { message: 'boom' } })
+    assert.equal(ev[0][0], 'error')
+    assert.equal(s._isBusy, false, 'busy cleared on error')
+    cleanup()
+  })
+
+  it('an intentional interrupt that then fails reports stopped (not error)', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error', 'stopped'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    s.markIntentionalStop()
+    s._failTurn('interrupted')
+    assert.deepEqual(ev.map(([e]) => e), ['stopped'], 'intentional stop surfaces as stopped')
+    cleanup()
+  })
+
+  it('orphan tool_start is swept with a synthetic tool_result at turn end', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['tool_result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    // a tool starts but never completes before the turn ends
+    s._onNotification({ method: 'item/started', params: { item: { type: 'commandExecution', id: 'orphan', command: 'sleep 999', cwd: '/tmp' } } })
+    s._onNotification({ method: 'turn/completed', params: { turn: {} } })
+    assert.ok(ev.some(([, p]) => p.toolUseId === 'orphan'), 'orphan tool_start got a synthetic tool_result')
+    cleanup()
+  })
+})


### PR DESCRIPTION
## What

Phase 1 of [epic #6605](https://github.com/blamechris/chroxy/issues/6605) — surfacing codex approvals in Chroxy. This lands the **driving layer**: run codex through its `app-server` JSON-RPC protocol (persistent process) instead of one-shot `codex exec --json`.

**Flag-gated + off by default** (`CHROXY_CODEX_APPSERVER=1`) → a complete no-op for everyone until explicitly enabled. `getProvider('codex')` returns the exec-based `CodexSession` unless the flag is set.

## Why this shape

`codex exec` is sandbox-only and cannot emit approval round-trips (verified — it rejects `--ask-for-approval`). The `app-server` protocol *can* (POC-validated: it sends `item/commandExecution/requestApproval` and honours the reply). Phase 1 stands up the persistent driving layer at **behaviour-parity** with exec (`approvalPolicy: 'never'` — codex runs within its sandbox without prompting); **Phase 2** flips to `on-request` and wires the approval RPC into a `PermissionManager`.

## Changes

- **`codex-app-server-client.js`** — JSON-RPC/stdio transport: `initialize`/`initialized` handshake, request↔response correlation by id, and `notification` / `serverRequest` events. Pure transport (maps nothing onto the session contract).
- **`codex-app-server-session.js`** — `CodexAppServerSession extends BaseSession` (persistent, mirrors `SdkSession`, **not** the subprocess-per-turn middle layer). `start()` handshake → `thread/start` → `emit('ready')`; `sendMessage()` → `turn/start` + queue-while-processing; maps notifications (`item/agentMessage/delta`, `commandExecution`/`fileChange` items, `turn/completed`, `tokenUsage`) onto `stream_start`/`stream_delta`/`stream_end` + `tool_start`/`tool_result` + `result`. Codex identity (binary/auth/models/preflight) delegated to `CodexSession` statics.
- **`providers.js`** — `getProvider` flag branch (the single construct+preflight chokepoint); `codex-appserver` registered **hidden** so `validateProviderClass` runs its contract check at load.

## Validation

- **Live** (daemon on this branch, flag on): session create + streaming turn + reply via the app-server path — `codex app-server ready (thread=… sandbox=workspace-write)` → `turn start` → reply in ~8s. Confirms the handshake, `thread/start` with `approvalPolicy:'never'`, `turn/start`, and the full event mapping.
- **16 new unit tests** (transport routing + framing; notification→event mapping; lifecycle guards) — all green.
- Existing exec `CodexSession` path unchanged (132 codex tests pass); all 5 server custom lints green.

## Not in this PR (Phase 2+)
Approval surfacing (`capabilities.permissions` stays false here), permission-mode ↔ approvalPolicy mapping, and app-server thread resume.

Part of #6605.