### PR TITLE
feat(server): surface codex approvals through the permission pipeline (#6605 phase 2)

### DIFF
--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -363,8 +363,14 @@ export class CodexAppServerSession extends BaseSession {
       // response is a permission-grant object, not a simple decision — safe-deny
       // (grant nothing) so the turn proceeds without escalating. Full surfacing
       // is tracked in #6610.
+      //
+      // Send ONLY an empty `permissions` object and OMIT `scope`: per the
+      // app-server schema PermissionGrantScope accepts only 'turn'/'session', so
+      // an explicit 'none' is an invalid enum value that errors on deserialize
+      // (the field's serde default only applies when it's ABSENT) — which would
+      // wedge the turn, the opposite of a safe-deny (#6612).
       ;(this._log || log).info('codex app-server: declining permissions-escalation request (grant nothing) — #6610')
-      this._client?.respond(id, { permissions: {}, scope: 'none' })
+      this._client?.respond(id, { permissions: {} })
       return
     }
     ;(this._log || log).warn(`codex app-server: unsupported serverRequest ${method} — declining`)
@@ -406,7 +412,9 @@ export class CodexAppServerSession extends BaseSession {
     // item/commandExecution/requestApproval
     return {
       tool: 'shell',
-      input: { command: params?.command, cwd: params?.cwd, description: params?.reason },
+      // Always give the prompt a non-empty description so a null/blank command
+      // can't render an empty approval prompt (#6611 review nitpick).
+      input: { command: params?.command, cwd: params?.cwd, description: params?.reason || params?.command || 'Run a shell command' },
     }
   }
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -1,6 +1,7 @@
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { CodexSession, resolveCodexSandbox } from './codex-session.js'
 import { CodexAppServerClient } from './codex-app-server-client.js'
+import { PermissionManager, wirePermissionManager } from './permission-manager.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
 import { createLogger, loggerForSession } from './logger.js'
 
@@ -12,13 +13,20 @@ const log = createLogger('codex-app-server')
  * codex-session.js). This is the foundation for surfacing codex's approval
  * requests through Chroxy's permission pipeline (epic #6605).
  *
- * PHASE 1 (this file) is the DRIVING LAYER only: it runs turns and maps the
- * app-server's streaming notifications onto Chroxy's standard event contract,
- * at behaviour-parity with the exec path. It uses `approvalPolicy: 'never'`
- * (codex runs commands within its sandbox without prompting, exactly like
- * `codex exec`), and does NOT yet surface approvals — `capabilities.permissions`
- * stays false. Phase 2 flips the policy to `on-request` and wires the
- * server → client approval RPC into a PermissionManager.
+ * PHASE 1 was the DRIVING LAYER: run turns + map the app-server's streaming
+ * notifications onto Chroxy's standard event contract.
+ *
+ * PHASE 2 (#6605) surfaces codex's APPROVALS through Chroxy's permission
+ * pipeline. `approvalPolicy` is derived from the session's permission mode
+ * (`auto` → `never`, else `on-request`), so codex asks before running a command
+ * or editing a file; the server → client approval RPC
+ * (`item/commandExecution/requestApproval` / `item/fileChange/requestApproval`)
+ * is routed into a PermissionManager exactly like SdkSession's `canUseTool`
+ * bridge — it emits `permission_request`, waits for the user's
+ * `permission_response`, and answers codex with the correct per-method decision
+ * enum (CommandExecutionApprovalDecision vs ReviewDecision). `capabilities`
+ * therefore advertises `permissions` / `inProcessPermissions` /
+ * `permissionModeSwitch`.
  *
  * Selected only when `CHROXY_CODEX_APPSERVER=1` (see providers.js `getProvider`);
  * otherwise the exec-based CodexSession is used, so this is a no-op by default.
@@ -46,12 +54,11 @@ export class CodexAppServerSession extends BaseSession {
 
   static get capabilities() {
     return {
-      // Phase 1 is behaviour-parity with exec: no approval surfacing yet.
-      // Phase 2 flips permissions/inProcessPermissions to true.
-      permissions: false,
-      inProcessPermissions: false,
+      // Phase 2 (#6605): approvals are surfaced through the permission pipeline.
+      permissions: true,
+      inProcessPermissions: true, // requires respondToPermission + respondToQuestion
       modelSwitch: true,
-      permissionModeSwitch: false,
+      permissionModeSwitch: true, // mode drives approvalPolicy + PermissionManager
       planMode: false,
       resume: false, // matches exec CodexSession; app-server resume is a follow-up
       terminal: false,
@@ -72,6 +79,17 @@ export class CodexAppServerSession extends BaseSession {
     this._activeTurn = null // { messageId, turnId, didStreamStart }
     this._lastUsage = null
     this._skillsPrepended = false // #6606 — inject the skills prefix once, on turn 1
+    this._turnAbort = null // per-turn AbortController — cancels pending approvals
+
+    // #6605 Phase 2 — surface codex approvals through the same PermissionManager
+    // bridge SdkSession uses. wirePermissionManager re-emits permission_request /
+    // permission_resolved / user_question on THIS session and back-links
+    // _pendingPermissions/_lastPermissionData for ws-permissions.js.
+    this._permissions = new PermissionManager({ log })
+    wirePermissionManager(this, this._permissions, {
+      onRequest: () => this._pauseResultTimeoutForPermission(),
+      onResolved: () => this._resumeResultTimeoutForPermission(),
+    })
   }
 
   _buildChildEnv() { return buildSpawnEnv('codex') }
@@ -94,7 +112,7 @@ export class CodexAppServerSession extends BaseSession {
 
     await this._client.initialize({ name: 'chroxy', version: '1' })
     const started = await this._client.request('thread/start', {
-      approvalPolicy: 'never', // Phase 1: sandboxed, no prompts (parity with exec)
+      approvalPolicy: this._approvalPolicy(), // #6605 P2 — derived from permission mode
       cwd: this.cwd,
       sandbox,
       ...(this.model ? { model: this.model } : {}),
@@ -125,6 +143,9 @@ export class CodexAppServerSession extends BaseSession {
     const messageId = `msg-${this._messageIdPrefix}-${this._messageCounter}`
     this._currentMessageId = messageId
     this._activeTurn = { messageId, turnId: null, didStreamStart: false }
+    // Fresh abort scope for this turn's approvals — interrupt()/destroy() abort it
+    // so a pending permission_request resolves (deny) instead of hanging the turn.
+    this._turnAbort = new AbortController()
     this._armResultTimeout()
 
     // #6606 review — mirror the exec path: prepend the combined skills prefix on
@@ -145,7 +166,7 @@ export class CodexAppServerSession extends BaseSession {
     try {
       const res = await this._client.request('turn/start', {
         threadId: this._threadId,
-        approvalPolicy: 'never',
+        approvalPolicy: this._approvalPolicy(), // #6605 P2 — per-turn, tracks mode changes
         input: [{ type: 'text', text }],
         // #6608 — pass the CURRENT model per turn (turn/start accepts it) so a
         // mid-session set_model actually takes effect, matching the exec path's
@@ -270,6 +291,7 @@ export class CodexAppServerSession extends BaseSession {
       'turn_ended_with_orphan_tool_start',
     )
     this._activeTurn = null
+    this._endTurnAbort()
     // #6606 review — disarm the intentional-stop flag on a NORMAL completion too
     // (mirrors sdk-session.js). interrupt() arms it; if the turn then completes
     // cleanly, only _failTurn would otherwise consume it, so a leftover flag
@@ -287,8 +309,18 @@ export class CodexAppServerSession extends BaseSession {
     if (wasIntentional) this.emit('stopped', {})
     else this.emit('error', { message })
     this._activeTurn = null
+    this._endTurnAbort()
     this._clearMessageState()
     this._maybeDequeue()
+  }
+
+  // Abort this turn's approval scope (any pending permission_request resolves as
+  // a deny) and drop the controller. Safe to call with no active turn.
+  _endTurnAbort() {
+    if (this._turnAbort) {
+      try { this._turnAbort.abort() } catch { /* noop */ }
+      this._turnAbort = null
+    }
   }
 
   _maybeDequeue() {
@@ -315,16 +347,102 @@ export class CodexAppServerSession extends BaseSession {
   }
 
   // ------------------------------------------------------------------
-  // Server → client requests (approvals). Phase 1: not enabled.
+  // Server → client requests (approvals) — routed into the permission pipeline
   // ------------------------------------------------------------------
 
-  _onServerRequest({ id, method }) {
-    // With approvalPolicy:'never' the server should not ask; if it does (future
-    // codex behaviour / a policy we didn't set), decline cleanly rather than
-    // wedge the turn. Phase 2 routes these into the permission pipeline.
-    ;(this._log || log).warn(`codex app-server unexpected serverRequest ${method} — declining (approvals land in Phase 2)`)
-    this._client?.respondError(id, -32601, 'approvals not enabled (Chroxy Phase 1)')
+  // Codex asks before running a command / editing a file (approvalPolicy
+  // 'on-request'). Route the two clean approval families through the
+  // PermissionManager; safe-decline the scope-escalation variant (#6610).
+  _onServerRequest({ id, method, params }) {
+    if (method === 'item/commandExecution/requestApproval' || method === 'item/fileChange/requestApproval') {
+      this._routeApproval(id, method, params)
+      return
+    }
+    if (method === 'item/permissions/requestApproval') {
+      // Scope-escalation (codex wants BROADER permissions than its sandbox). The
+      // response is a permission-grant object, not a simple decision — safe-deny
+      // (grant nothing) so the turn proceeds without escalating. Full surfacing
+      // is tracked in #6610.
+      ;(this._log || log).info('codex app-server: declining permissions-escalation request (grant nothing) — #6610')
+      this._client?.respond(id, { permissions: {}, scope: 'none' })
+      return
+    }
+    ;(this._log || log).warn(`codex app-server: unsupported serverRequest ${method} — declining`)
+    this._client?.respondError(id, -32601, 'unsupported request')
   }
+
+  // Bridge one codex approval RPC → a Chroxy permission_request and back. Mirrors
+  // SdkSession's canUseTool: handlePermission emits permission_request, resolves
+  // when the user answers (or on rule/mode short-circuit, timeout, or abort), and
+  // we answer codex with the decision enum that matches THIS approval family.
+  async _routeApproval(rpcId, method, params) {
+    const { tool, input } = this._describeApproval(method, params)
+    let result
+    try {
+      // Pass a sentinel `suggestions` entry so an "Allow always" response sets
+      // `updatedPermissions` on the result (respondToPermission only echoes it
+      // when suggestions were provided) — that's how we detect a SESSION grant
+      // and answer codex with acceptForSession/approved_for_session. The sentinel
+      // is never persisted (no SDK behind this path); it's a local marker only.
+      const suggestions = [{ codexApproval: method }]
+      result = await this._permissions.handlePermission(tool, input, this._turnAbort?.signal, this.permissionMode, suggestions)
+    } catch (err) {
+      result = { behavior: 'deny', message: err?.message || 'permission error' }
+    }
+    const allow = result?.behavior === 'allow'
+    const session = allow && !!result?.updatedPermissions // "always allow" → session grant
+    this._client?.respond(rpcId, this._codexDecision(method, allow, session))
+  }
+
+  // Map a codex approval request into the (tool, input) shape PermissionManager
+  // renders. `description`/`command`/`file_path` drive the human-facing prompt.
+  _describeApproval(method, params) {
+    if (method === 'item/fileChange/requestApproval') {
+      return {
+        tool: 'apply_patch',
+        input: { description: params?.reason || 'Apply file changes', file_path: params?.grantRoot },
+      }
+    }
+    // item/commandExecution/requestApproval
+    return {
+      tool: 'shell',
+      input: { command: params?.command, cwd: params?.cwd, description: params?.reason },
+    }
+  }
+
+  // The two approval families use DIFFERENT decision vocabularies (from the
+  // app-server JSON schema): fileChange → ReviewDecision, commandExecution →
+  // CommandExecutionApprovalDecision.
+  _codexDecision(method, allow, session) {
+    if (method === 'item/fileChange/requestApproval') {
+      if (!allow) return { decision: 'denied' }
+      return { decision: session ? 'approved_for_session' : 'approved' }
+    }
+    if (!allow) return { decision: 'decline' }
+    return { decision: session ? 'acceptForSession' : 'accept' }
+  }
+
+  // 'auto' (skip all prompts) → codex runs without asking. Every other mode →
+  // 'on-request': codex asks per action and the PermissionManager applies the
+  // mode/rules (auto-allow for acceptEdits/rules, prompt for 'approve').
+  _approvalPolicy() {
+    return this.permissionMode === 'auto' ? 'never' : 'on-request'
+  }
+
+  // In-process permission responses (capabilities.inProcessPermissions) — thin
+  // delegators to the PermissionManager, mirroring SdkSession.
+  respondToPermission(requestId, decision, editedInput) {
+    return this._permissions.respondToPermission(requestId, decision, editedInput)
+  }
+
+  respondToQuestion(text, answers) {
+    return this._permissions.respondToQuestion(text, answers)
+  }
+
+  // A permission prompt can outlast the result timeout while it waits on a human;
+  // pause the timer on request, re-arm it once the decision lands (#3920 pattern).
+  _pauseResultTimeoutForPermission() { this._clearResultTimeout() }
+  _resumeResultTimeoutForPermission() { if (this._activeTurn) this._armResultTimeout() }
 
   _onClientExit({ code, signal, error }) {
     if (this._destroying) return
@@ -353,6 +471,8 @@ export class CodexAppServerSession extends BaseSession {
     this.clearOutgoingQueue({ emit: false })
     this._clearIntentionalStop()
     this._clearResultTimeout()
+    this._endTurnAbort() // resolve any in-flight approval as a deny before teardown
+    try { this._permissions?.destroy() } catch { /* noop */ }
     try { this._client?.kill() } catch { /* already gone */ }
     this._client = null
     this._activeTurn = null

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -468,10 +468,22 @@ export class CodexAppServerSession extends BaseSession {
   async interrupt() {
     this.clearOutgoingQueue()
     this.markIntentionalStop()
+    // Stop must not wait on a prompt: abort this turn's approval scope so a
+    // pending permission_request resolves (deny → decline) immediately, instead
+    // of leaving the turn wedged until the 5-min timeout (#6611 review).
+    this._endTurnAbort()
     if (this._client && this._activeTurn?.turnId) {
       try { await this._client.request('turn/interrupt', { threadId: this._threadId, turnId: this._activeTurn.turnId }) }
       catch (err) { (this._log || log).debug(`turn/interrupt failed: ${err.message}`) }
     }
+  }
+
+  // Panic-button parity with SdkSession (#3729): switching TO auto drains any
+  // already-emitted approval prompts (they resolve as allow → we answer codex
+  // accept), so the user isn't left staring at a prompt after choosing "approve
+  // everything". approvalPolicy for the NEXT turn is derived from the new mode.
+  _onPermissionModeChanged(mode) {
+    if (mode === 'auto') this._permissions.autoAllowPending()
   }
 
   async destroy() {

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -163,16 +163,6 @@ describe('CodexAppServerSession — lifecycle guards', () => {
     cleanup()
   })
 
-  it('declines an unexpected server approval request in Phase 1 (no wedge)', () => {
-    const { s, cleanup } = mkSession()
-    let responded = null
-    s._client = { respondError: (id, code, msg) => (responded = { id, code, msg }) }
-    s._onServerRequest({ id: 3, method: 'item/commandExecution/requestApproval', params: {} })
-    assert.equal(responded.id, 3)
-    assert.match(responded.msg, /Phase 1/)
-    cleanup()
-  })
-
   it('prepends the skills prefix on the FIRST turn only, and the current model (#6606)', async () => {
     const { s, cleanup } = mkSession()
     s._processReady = true
@@ -191,10 +181,10 @@ describe('CodexAppServerSession — lifecycle guards', () => {
     cleanup()
   })
 
-  it('capabilities: permissions off (Phase 1), streaming + modelSwitch on', () => {
+  it('capabilities: streaming + modelSwitch on, approvals surfaced (Phase 2)', () => {
     const c = CodexAppServerSession.capabilities
-    assert.equal(c.permissions, false)
-    assert.equal(c.inProcessPermissions, false)
+    assert.equal(c.permissions, true)
+    assert.equal(c.inProcessPermissions, true)
     assert.equal(c.streaming, true)
     assert.equal(c.modelSwitch, true)
   })
@@ -268,6 +258,127 @@ describe('CodexAppServerSession — crash / stop paths (#6607)', () => {
     s._onNotification({ method: 'item/started', params: { item: { type: 'commandExecution', id: 'orphan', command: 'sleep 999', cwd: '/tmp' } } })
     s._onNotification({ method: 'turn/completed', params: { turn: {} } })
     assert.ok(ev.some(([, p]) => p.toolUseId === 'orphan'), 'orphan tool_start got a synthetic tool_result')
+    cleanup()
+  })
+})
+
+describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
+  const tick = () => new Promise((r) => setImmediate(r))
+  function mkApprovalSession(mode = 'approve') {
+    const { s, cleanup } = mkSession()
+    const responded = []
+    s._processReady = true
+    s.permissionMode = mode
+    s._turnAbort = new AbortController()
+    s._client = {
+      respond: (id, r) => responded.push([id, r]),
+      respondError: (id, code, message) => responded.push([id, { error: { code, message } }]),
+    }
+    return { s, cleanup, responded }
+  }
+
+  it('capabilities advertise permissions + inProcessPermissions + permissionModeSwitch', () => {
+    const c = CodexAppServerSession.capabilities
+    assert.equal(c.permissions, true)
+    assert.equal(c.inProcessPermissions, true)
+    assert.equal(c.permissionModeSwitch, true)
+  })
+
+  it('exposes the in-process permission responders', () => {
+    const { s, cleanup } = mkSession()
+    assert.equal(typeof s.respondToPermission, 'function')
+    assert.equal(typeof s.respondToQuestion, 'function')
+    cleanup()
+  })
+
+  it('approvalPolicy: auto → never, every other mode → on-request', () => {
+    const { s, cleanup } = mkSession()
+    s.permissionMode = 'auto'; assert.equal(s._approvalPolicy(), 'never')
+    s.permissionMode = 'approve'; assert.equal(s._approvalPolicy(), 'on-request')
+    s.permissionMode = 'acceptEdits'; assert.equal(s._approvalPolicy(), 'on-request')
+    cleanup()
+  })
+
+  it('commandExecution approval → permission_request; allow → {decision:accept}', async () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 5, method: 'item/commandExecution/requestApproval', params: { command: 'rm x', cwd: '/tmp', reason: 'Delete x?' } })
+    assert.equal(reqs.length, 1, 'emitted a permission_request')
+    assert.equal(reqs[0][1].tool, 'shell')
+    s.respondToPermission(reqs[0][1].requestId, 'allow')
+    await tick()
+    assert.deepEqual(responded, [[5, { decision: 'accept' }]])
+    cleanup()
+  })
+
+  it('commandExecution deny → {decision:decline}', async () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 6, method: 'item/commandExecution/requestApproval', params: { command: 'rm -rf /', reason: 'nope' } })
+    s.respondToPermission(reqs[0][1].requestId, 'deny')
+    await tick()
+    assert.deepEqual(responded, [[6, { decision: 'decline' }]])
+    cleanup()
+  })
+
+  it('commandExecution allowAlways → {decision:acceptForSession}', async () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 7, method: 'item/commandExecution/requestApproval', params: { command: 'ls', reason: 'list' } })
+    s.respondToPermission(reqs[0][1].requestId, 'allowAlways')
+    await tick()
+    assert.deepEqual(responded, [[7, { decision: 'acceptForSession' }]])
+    cleanup()
+  })
+
+  it('fileChange approval uses ReviewDecision (allow→approved, deny→denied, session→approved_for_session)', async () => {
+    for (const [decision, expected] of [['allow', 'approved'], ['deny', 'denied'], ['allowAlways', 'approved_for_session']]) {
+      const { s, cleanup, responded } = mkApprovalSession()
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 9, method: 'item/fileChange/requestApproval', params: { grantRoot: '/repo', reason: 'edit files' } })
+      assert.equal(reqs[0][1].tool, 'apply_patch')
+      s.respondToPermission(reqs[0][1].requestId, decision)
+      await tick()
+      assert.deepEqual(responded, [[9, { decision: expected }]], `fileChange ${decision} → ${expected}`)
+      cleanup()
+    }
+  })
+
+  it('auto mode auto-allows without emitting a prompt (accept)', async () => {
+    const { s, cleanup, responded } = mkApprovalSession('auto')
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 10, method: 'item/commandExecution/requestApproval', params: { command: 'echo hi' } })
+    await tick()
+    assert.equal(reqs.length, 0, 'auto mode does not prompt')
+    assert.deepEqual(responded, [[10, { decision: 'accept' }]])
+    cleanup()
+  })
+
+  it('permissions-escalation request is safe-denied (grant nothing) without a prompt', () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 11, method: 'item/permissions/requestApproval', params: { scope: 'disk-full-access' } })
+    assert.equal(reqs.length, 0, 'escalation is not surfaced as a normal prompt in Phase 2')
+    assert.deepEqual(responded, [[11, { permissions: {}, scope: 'none' }]])
+    cleanup()
+  })
+
+  it('an unsupported serverRequest is declined with a JSON-RPC error', () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    s._onServerRequest({ id: 12, method: 'some/futureRequest', params: {} })
+    assert.equal(responded[0][0], 12)
+    assert.ok(responded[0][1].error, 'answered with an error')
+    cleanup()
+  })
+
+  it('an aborted turn scope resolves a pending approval as deny (decline)', async () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 13, method: 'item/commandExecution/requestApproval', params: { command: 'sleep 999' } })
+    assert.equal(reqs.length, 1)
+    s._endTurnAbort() // interrupt()/turn-end aborts the scope
+    await tick()
+    assert.deepEqual(responded, [[13, { decision: 'decline' }]], 'abort → decline')
     cleanup()
   })
 })

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -354,12 +354,24 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     cleanup()
   })
 
-  it('permissions-escalation request is safe-denied (grant nothing) without a prompt', () => {
+  it('permissions-escalation request is safe-denied (grant nothing, no scope) without a prompt', () => {
     const { s, cleanup, responded } = mkApprovalSession()
     const reqs = capture(s, ['permission_request'])
     s._onServerRequest({ id: 11, method: 'item/permissions/requestApproval', params: { scope: 'disk-full-access' } })
     assert.equal(reqs.length, 0, 'escalation is not surfaced as a normal prompt in Phase 2')
-    assert.deepEqual(responded, [[11, { permissions: {}, scope: 'none' }]])
+    // grant nothing: empty permissions, scope OMITTED (an explicit 'none' is an
+    // invalid PermissionGrantScope enum value and would wedge the turn — #6612).
+    assert.deepEqual(responded, [[11, { permissions: {} }]])
+    cleanup()
+  })
+
+  it('destroy() clears a pending approval without hanging (no leak)', async () => {
+    const { s, cleanup } = mkApprovalSession()
+    capture(s, ['permission_request'])
+    s._onServerRequest({ id: 14, method: 'item/commandExecution/requestApproval', params: { command: 'x' } })
+    assert.equal(s._permissions._pendingPermissions.size, 1, 'one pending approval before destroy')
+    await s.destroy()
+    assert.equal(s._permissions._pendingPermissions.size, 0, 'destroy cleared the pending approval (no hang/leak)')
     cleanup()
   })
 

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -365,6 +365,26 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     cleanup()
   })
 
+  it('interrupt() aborts a pending approval → Stop unblocks the turn (decline)', async () => {
+    const { s, cleanup, responded } = mkApprovalSession()
+    capture(s, ['permission_request'])
+    s._onServerRequest({ id: 20, method: 'item/commandExecution/requestApproval', params: { command: 'x' } })
+    await s.interrupt()
+    await tick()
+    assert.deepEqual(responded, [[20, { decision: 'decline' }]], 'Stop declined the pending approval')
+    cleanup()
+  })
+
+  it('switching to auto drains a pending approval (autoAllowPending → accept)', async () => {
+    const { s, cleanup, responded } = mkApprovalSession('approve')
+    capture(s, ['permission_request'])
+    s._onServerRequest({ id: 21, method: 'item/commandExecution/requestApproval', params: { command: 'x' } })
+    s.setPermissionMode('auto') // panic button — must drain the pending prompt
+    await tick()
+    assert.deepEqual(responded, [[21, { decision: 'accept' }]], 'auto drained the pending prompt as accept')
+    cleanup()
+  })
+
   it('destroy() clears a pending approval without hanging (no leak)', async () => {
     const { s, cleanup } = mkApprovalSession()
     capture(s, ['permission_request'])


### PR DESCRIPTION
## What

Phase 2 of the codex approval epic (#6605): **surface codex's approval requests through Chroxy's permission pipeline**, so a user approves/denies codex exactly the way they approve Claude. Builds on the Phase 1 driving layer (#6606). Still **flag-gated** behind `CHROXY_CODEX_APPSERVER=1` — a no-op by default.

## How

- **`approvalPolicy` derived from permission mode** — `auto` → `never` (codex self-runs), every other mode → `on-request` (codex asks per action; the PermissionManager then applies mode/rules: auto-allow for `acceptEdits`/rules, prompt for `approve`).
- **Approval RPCs bridged into `PermissionManager`** exactly like `SdkSession`'s `canUseTool`: `item/commandExecution/requestApproval` + `item/fileChange/requestApproval` → `handlePermission()` → emits `permission_request`, waits for the user's `permission_response`, and answers codex with the decision enum that matches **that** approval family:
  - commandExecution → `CommandExecutionApprovalDecision` (`accept` / `acceptForSession` / `decline`)
  - fileChange → `ReviewDecision` (`approved` / `approved_for_session` / `denied`)
  - session-grant ("Allow always") is detected via a sentinel `suggestions` marker → `updatedPermissions`.
- **`item/permissions/requestApproval`** (scope escalation, complex `{permissions, scope}` response) is **safe-denied** (grant nothing) so it never wedges a turn — full surfacing tracked in #6610.
- **capabilities** now advertise `permissions` / `inProcessPermissions` / `permissionModeSwitch`; `respondToPermission` / `respondToQuestion` delegate to the manager.
- A **per-turn `AbortController`** cancels a pending approval on `interrupt()`/`destroy()` so an unanswered prompt resolves as a **deny** rather than hanging the turn.

The decision enums + approval methods were taken from the app-server's own `generate-json-schema` output and confirmed empirically.

## Validation

- **Live end-to-end over the production WS path:** a fresh codex app-server session (read-only sandbox) was asked to write a file → a `permission_request` surfaced over WS (`"Do you want to write the requested marker file to /tmp?"`) → approved via `permission_response` → codex ran the command and the file was actually created. Deny/interrupt paths exercised via unit tests.
- **33 unit tests** cover the decision mapping (both enums, allow/deny/session), mode→policy derivation, the escalation safe-deny, abort→deny, and the capability/contract surface. Server custom lints green (opt-forwarding, logger-scoping, provider-contract).

## Follow-ups
- #6610 — full `item/permissions/requestApproval` (scope-escalation) surfacing.
- #6609 — attachments on the app-server path.

Related to #6605.