### PR TITLE
feat(server): codex permission-mode mapping + app-server docs (#6605 phase 3+4)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -39,7 +39,7 @@ The registry lives in [`packages/server/src/providers.js`](../packages/server/sr
 | `claude-tui` *(default)* | `claude` (Claude Code CLI, interactive TUI) | `claude` CLI login (rejects `ANTHROPIC_API_KEY` — strips it from spawn env) | Deferred to `claude` TUI | Subscription login only | Persistent PTY, one warmup per session; permission hook via HTTP; deliver-on-complete (no live streaming); bills as interactive subscription. The zero-config default (see #5819), to keep setups off the metered programmatic-credit pool. |
 | `claude-channel` *(research preview)* | `claude --channels` (Claude Code CLI, MCP channel transport) | `claude` CLI login (rejects `ANTHROPIC_API_KEY`). Requires `claude` ≥ 2.1.80 + `--dangerously-load-development-channels` | Deferred to `claude` | Subscription login only | **Scaffold — not yet runnable** (`start()` throws; bridge in #3954). Documented MCP contract instead of TUI scrape; live streaming; first-party permission relay; bills as interactive subscription |
 | `gemini` | `gemini` (Gemini CLI) | `GEMINI_API_KEY` / `GOOGLE_API_KEY`, **or** `gemini login` OAuth | `gemini-2.5-pro` | Google AI Studio API key or a `gemini login` session | No permissions, no plan mode, no resume, no attachments |
-| `codex` | `codex` (OpenAI Codex CLI) | `OPENAI_API_KEY`, **or** `codex login` OAuth | CLI default (`~/.codex/config.toml`) | OpenAI API key or a `codex login` session | No permissions, no plan mode, no resume, no attachments |
+| `codex` | `codex` (OpenAI Codex CLI) | `OPENAI_API_KEY`, **or** `codex login` OAuth | CLI default (`~/.codex/config.toml`) | OpenAI API key or a `codex login` session | Default (`codex exec`): no permissions, no plan mode, no resume, no attachments. Opt-in `CHROXY_CODEX_APPSERVER=1` (app-server): **approvals + permission-mode switching** surfaced in Chroxy (still no attachments/resume — see the "Codex app-server + approvals" section below) |
 | `claude-byok` | `@anthropic-ai/sdk` (npm) → Anthropic Messages API | `ANTHROPIC_API_KEY` (or `anthropicApiKey` in `~/.chroxy/credentials.json`) | `claude-opus-4-8` | Anthropic API key (per-token billing) | No `claude` binary — Chroxy's own in-process agent loop (streaming, tools, in-process permissions, MCP); no cross-restart resume (#4047) |
 | `deepseek` | `@anthropic-ai/sdk` → DeepSeek's Anthropic-compatible endpoint | `DEEPSEEK_API_KEY` (or `deepseekApiKey` in `~/.chroxy/credentials.json`); `DEEPSEEK_BASE_URL` (optional endpoint override) | `deepseek-chat` | DeepSeek API key (per-token billing) | Subclass of `claude-byok` — same agent loop with DeepSeek credentials, endpoint, and pricing |
 | `ollama` | `@anthropic-ai/sdk` → local Ollama daemon (v0.14+) | `CHROXY_OLLAMA_BASE_URL` / `OLLAMA_HOST` (optional endpoint overrides) | `qwen3-coder` | None — local inference | Local models via Ollama's Anthropic-compatible API; full BYOK agent loop (tools, permissions, MCP); cost always $0; any `ollama pull`ed model id accepted |
@@ -339,6 +339,40 @@ The public Codex config reference at developers.openai.com/codex
 documents the override keys (`exclude_slash_tmp`, `exclude_tmpdir_env_var`,
 `writable_roots`) but not the full default policy — re-verify against
 the source if Codex versions change.
+
+### Codex app-server + approvals (`CHROXY_CODEX_APPSERVER`, opt-in) — #6605
+
+By default the codex provider drives `codex exec --json` (one subprocess per
+turn), which has **no approval surface** — codex runs whatever its sandbox
+allows without asking. Setting `CHROXY_CODEX_APPSERVER=1` on the server switches
+the codex provider to a persistent **`codex app-server`** (JSON-RPC) session that
+surfaces codex's approval requests through Chroxy's **permission pipeline** — so
+you approve/deny codex's commands and file edits the same way you do Claude, and
+can switch permission modes mid-session. It is a no-op unless the flag is set.
+
+Codex's `approvalPolicy` is derived from the session's permission mode, and
+Chroxy's `PermissionManager` decides whether to prompt or auto-resolve:
+
+| Permission mode | codex `approvalPolicy` | Behaviour |
+|---|---|---|
+| `approve` (default) | `on-request` | Every codex command / file edit prompts for your approval. |
+| `acceptEdits` | `on-request` | Codex **file edits auto-approve**; **commands still prompt**. |
+| `auto` | `never` | Codex runs without asking (bypass). Switching *to* `auto` also drains any pending prompts. |
+| `plan` | `on-request` | Not a real codex mode (codex has no plan enforcement) — behaves like `approve`. |
+
+The `CHROXY_CODEX_SANDBOX` override still applies: codex asks before any action
+its sandbox would block (e.g. a write under `read-only`), and an approval
+escalates that single action. `apply_patch` (codex's file edit) is treated like
+`Write`/`Edit`, and `shell` (codex's command execution) like `Bash` — so
+arbitrary codex command execution can't be permanently rule-whitelisted.
+
+**Still opt-in (not the default) because** the app-server path does not yet
+materialize attachments (#6609) that the exec path supports, and it wants
+broader real-world validation first. Enable it per-host when you want approval
+control over codex; the exec path remains the default until parity + a
+validation period. Codex's own scope-escalation requests
+(`item/permissions/requestApproval`) are currently safe-denied — full surfacing
+is tracked in #6610.
 
 ## Gemini
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -28,14 +28,13 @@ import {
 } from '../per-session-settings.js'
 import { createPermissionResolver, resolveOriginSessionId } from '../permission-resolver.js'
 import { sanitizeToolInput, PULL_MAX_INPUT_CHARS } from '../redaction.js'
-
-// Tools that are eligible to be whitelisted via set_permission_rules.
-// These are safe file-operation tools that don't execute code or make network requests.
-const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep'])
-
-
-// Tools that must never be auto-allowed regardless of user rules.
-const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'])
+// #6605 — SINGLE source of truth for the rule-eligibility sets. These used to be
+// a duplicate hard-coded copy here, which silently drifted from
+// permission-manager's when codex's `apply_patch` (rule-eligible, like Write) and
+// `shell` (never-auto-allow, like Bash) were added — so set_permission_rules
+// validation and PermissionManager's enforcement could disagree. Import the
+// exported sets so the two layers can never diverge again.
+import { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../permission-manager.js'
 
 const log = createLogger('ws')
 

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -8,14 +8,18 @@ import { sanitizeToolInput, redactValue } from './redaction.js'
 
 const _fallbackLog = createLogger('permission-manager')
 
-// Tools that acceptEdits mode auto-approves
-const ACCEPT_EDITS_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep'])
+// Tools that acceptEdits mode auto-approves. `apply_patch` is codex's file-edit
+// approval (item/fileChange/requestApproval, #6605) — the codex analogue of
+// Write/Edit, so acceptEdits auto-approves codex edits too.
+const ACCEPT_EDITS_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep', 'apply_patch'])
 
-// Tools eligible for session-scoped auto-allow rules
-export const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep'])
+// Tools eligible for session-scoped auto-allow rules (`apply_patch` = codex edits).
+export const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep', 'apply_patch'])
 
-// Tools that can never be auto-allowed by rules (too dangerous to whitelist)
-export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'])
+// Tools that can never be auto-allowed by rules (too dangerous to whitelist).
+// `shell` is codex's command-execution approval — the codex analogue of Bash, so
+// arbitrary codex command execution can't be rule-whitelisted either (#6605).
+export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell'])
 
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -344,6 +344,28 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     }
   })
 
+  it('acceptEdits auto-approves a codex file edit (fileChange) without a prompt', async () => {
+    const { s, cleanup, responded } = mkApprovalSession('acceptEdits')
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 30, method: 'item/fileChange/requestApproval', params: { grantRoot: '/repo', reason: 'edit' } })
+    await tick()
+    assert.equal(reqs.length, 0, 'acceptEdits does not prompt for a codex edit')
+    assert.deepEqual(responded, [[30, { decision: 'approved' }]])
+    cleanup()
+  })
+
+  it('acceptEdits still PROMPTS for a codex shell command (not an edit)', async () => {
+    const { s, cleanup, responded } = mkApprovalSession('acceptEdits')
+    const reqs = capture(s, ['permission_request'])
+    s._onServerRequest({ id: 31, method: 'item/commandExecution/requestApproval', params: { command: 'rm x' } })
+    assert.equal(reqs.length, 1, 'acceptEdits prompts for a shell command')
+    assert.equal(responded.length, 0, 'no decision until the user answers')
+    s.respondToPermission(reqs[0][1].requestId, 'deny')
+    await tick()
+    assert.deepEqual(responded, [[31, { decision: 'decline' }]])
+    cleanup()
+  })
+
   it('auto mode auto-allows without emitting a prompt (accept)', async () => {
     const { s, cleanup, responded } = mkApprovalSession('auto')
     const reqs = capture(s, ['permission_request'])

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -724,7 +724,8 @@ describe('PermissionManager', () => {
 
   describe('ELIGIBLE_TOOLS and NEVER_AUTO_ALLOW constants', () => {
     it('ELIGIBLE_TOOLS contains the expected file operation tools', () => {
-      const expected = ['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep']
+      // apply_patch = codex's file-edit tool (#6605), eligible like Write/Edit.
+      const expected = ['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep', 'apply_patch']
       for (const tool of expected) {
         assert.ok(ELIGIBLE_TOOLS.has(tool), `Expected ELIGIBLE_TOOLS to contain ${tool}`)
       }
@@ -732,7 +733,8 @@ describe('PermissionManager', () => {
     })
 
     it('NEVER_AUTO_ALLOW contains the expected dangerous tools', () => {
-      const expected = ['Bash', 'Task', 'WebFetch', 'WebSearch']
+      // shell = codex's command-execution tool (#6605), never-whitelistable like Bash.
+      const expected = ['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell']
       for (const tool of expected) {
         assert.ok(NEVER_AUTO_ALLOW.has(tool), `Expected NEVER_AUTO_ALLOW to contain ${tool}`)
       }

--- a/packages/server/tests/settings-handlers-permission-rules.test.js
+++ b/packages/server/tests/settings-handlers-permission-rules.test.js
@@ -13,6 +13,7 @@
 import { describe, it, beforeEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { settingsHandlers, ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../src/handlers/settings-handlers.js'
+import { ELIGIBLE_TOOLS as PM_ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW as PM_NEVER_AUTO_ALLOW } from '../src/permission-manager.js'
 import { sendSessionInfo } from '../src/ws-history.js'
 import { PermissionAuditLog } from '../src/permission-audit.js'
 import { nsCtx } from './test-helpers.js'
@@ -129,6 +130,21 @@ describe('handleSetPermissionRules — valid rules', () => {
     // Should not throw
     handler(WS, client, { type: 'set_permission_rules', rules }, ctx)
     assert.equal(ctx.transport.broadcastToSession.mock.callCount(), 1)
+  })
+})
+
+describe('rule-eligibility sets share ONE source of truth (#6605/#6613)', () => {
+  it('settings-handlers re-exports the SAME sets as permission-manager (no drift)', () => {
+    // A duplicate hard-coded copy here silently drifted from permission-manager's
+    // when codex tool names were added (Copilot, PR #6613). Same-reference asserts
+    // the single source of truth so validation + enforcement can never disagree.
+    assert.equal(ELIGIBLE_TOOLS, PM_ELIGIBLE_TOOLS, 'ELIGIBLE_TOOLS is permission-manager\'s set')
+    assert.equal(NEVER_AUTO_ALLOW, PM_NEVER_AUTO_ALLOW, 'NEVER_AUTO_ALLOW is permission-manager\'s set')
+  })
+
+  it('codex tool names are governed: apply_patch eligible, shell never-auto-allow', () => {
+    assert.ok(ELIGIBLE_TOOLS.has('apply_patch'), 'codex file edits are session-rule eligible')
+    assert.ok(NEVER_AUTO_ALLOW.has('shell'), 'codex command execution can never be rule-whitelisted')
   })
 })
 


### PR DESCRIPTION
## What

Completes the codex approval epic (#6605): **Phase 3** refines the permission-mode ↔ approval mapping so the modes behave correctly for the app-server path, and **Phase 4** documents it and records the flag-default decision. Builds on Phase 2 (#6611). Still flag-gated behind `CHROXY_CODEX_APPSERVER=1`.

## Phase 3 — mode mapping

Codex's approval tool names are now first-class in the permission model, mapped to their Claude equivalents:

| codex tool | ~ Claude | Set change | Effect |
|---|---|---|---|
| `apply_patch` (file edit) | Write/Edit | + `ACCEPT_EDITS_TOOLS`, + `ELIGIBLE_TOOLS` | **`acceptEdits` auto-approves codex edits**; edits are session-rule eligible |
| `shell` (command exec) | Bash | + `NEVER_AUTO_ALLOW` | arbitrary codex command execution **can't be permanently rule-whitelisted** |

Result — the per-mode behaviour (all handled by the existing `PermissionManager`, no codex-local mode logic):

| Mode | Behaviour |
|---|---|
| `approve` | prompt for every command + edit |
| `acceptEdits` | **auto-approve edits, prompt commands** |
| `auto` | run without asking (+ drains pending prompts on switch) |
| `plan` | behaves like `approve` (codex has no plan enforcement) |

Tests: `acceptEdits` auto-approves a codex `fileChange` but still prompts for a `shell` command; the pinned `ELIGIBLE_TOOLS`/`NEVER_AUTO_ALLOW` contract tests updated (sets stay disjoint).

## Phase 4 — docs + flag default

- `docs/providers.md`: new **"Codex app-server + approvals"** section (the flag, the per-mode `approvalPolicy` table, sandbox interaction, tool-name mapping, and the escalation safe-deny) + updated the capability matrix row.
- **Decision: keep the flag opt-in (not default).** Documented reason: the app-server path doesn't yet materialize attachments (#6609) that the exec path supports, and wants broader real-world validation. The exec path stays the default until parity; flip is a later call.

## Validation
Full `permission-manager` (83) + `codex-app-server-session` (38) suites pass; opt-forwarding / logger-scoping / tests-state lints green. (The approval round-trip itself was live-validated in #6611.)

Closes #6605.