### PR TITLE
feat(server): make the codex app-server path the default (#6616)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -39,7 +39,7 @@ The registry lives in [`packages/server/src/providers.js`](../packages/server/sr
 | `claude-tui` *(default)* | `claude` (Claude Code CLI, interactive TUI) | `claude` CLI login (rejects `ANTHROPIC_API_KEY` — strips it from spawn env) | Deferred to `claude` TUI | Subscription login only | Persistent PTY, one warmup per session; permission hook via HTTP; deliver-on-complete (no live streaming); bills as interactive subscription. The zero-config default (see #5819), to keep setups off the metered programmatic-credit pool. |
 | `claude-channel` *(research preview)* | `claude --channels` (Claude Code CLI, MCP channel transport) | `claude` CLI login (rejects `ANTHROPIC_API_KEY`). Requires `claude` ≥ 2.1.80 + `--dangerously-load-development-channels` | Deferred to `claude` | Subscription login only | **Scaffold — not yet runnable** (`start()` throws; bridge in #3954). Documented MCP contract instead of TUI scrape; live streaming; first-party permission relay; bills as interactive subscription |
 | `gemini` | `gemini` (Gemini CLI) | `GEMINI_API_KEY` / `GOOGLE_API_KEY`, **or** `gemini login` OAuth | `gemini-2.5-pro` | Google AI Studio API key or a `gemini login` session | No permissions, no plan mode, no resume, no attachments |
-| `codex` | `codex` (OpenAI Codex CLI) | `OPENAI_API_KEY`, **or** `codex login` OAuth | CLI default (`~/.codex/config.toml`) | OpenAI API key or a `codex login` session | Default (`codex exec`): no permissions, no plan mode, no resume, no attachments. Opt-in `CHROXY_CODEX_APPSERVER=1` (app-server): **approvals + permission-mode switching + attachments** (image vision + document/file references) surfaced in Chroxy (no resume yet — see the "Codex app-server + approvals" section below) |
+| `codex` | `codex` (OpenAI Codex CLI) | `OPENAI_API_KEY`, **or** `codex login` OAuth | CLI default (`~/.codex/config.toml`) | OpenAI API key or a `codex login` session | **Default (app-server, #6616):** approvals + permission-mode switching + attachments (image vision + document/file references) + intra-session memory; no plan mode, no resume yet. Opt out with `CHROXY_CODEX_APPSERVER=0` → legacy `codex exec` (no permissions, no attachments) |
 | `claude-byok` | `@anthropic-ai/sdk` (npm) → Anthropic Messages API | `ANTHROPIC_API_KEY` (or `anthropicApiKey` in `~/.chroxy/credentials.json`) | `claude-opus-4-8` | Anthropic API key (per-token billing) | No `claude` binary — Chroxy's own in-process agent loop (streaming, tools, in-process permissions, MCP); no cross-restart resume (#4047) |
 | `deepseek` | `@anthropic-ai/sdk` → DeepSeek's Anthropic-compatible endpoint | `DEEPSEEK_API_KEY` (or `deepseekApiKey` in `~/.chroxy/credentials.json`); `DEEPSEEK_BASE_URL` (optional endpoint override) | `deepseek-chat` | DeepSeek API key (per-token billing) | Subclass of `claude-byok` — same agent loop with DeepSeek credentials, endpoint, and pricing |
 | `ollama` | `@anthropic-ai/sdk` → local Ollama daemon (v0.14+) | `CHROXY_OLLAMA_BASE_URL` / `OLLAMA_HOST` (optional endpoint overrides) | `qwen3-coder` | None — local inference | Local models via Ollama's Anthropic-compatible API; full BYOK agent loop (tools, permissions, MCP); cost always $0; any `ollama pull`ed model id accepted |
@@ -340,15 +340,17 @@ documents the override keys (`exclude_slash_tmp`, `exclude_tmpdir_env_var`,
 `writable_roots`) but not the full default policy — re-verify against
 the source if Codex versions change.
 
-### Codex app-server + approvals (`CHROXY_CODEX_APPSERVER`, opt-in) — #6605
+### Codex app-server + approvals (`CHROXY_CODEX_APPSERVER`) — #6605 / #6616
 
-By default the codex provider drives `codex exec --json` (one subprocess per
-turn), which has **no approval surface** — codex runs whatever its sandbox
-allows without asking. Setting `CHROXY_CODEX_APPSERVER=1` on the server switches
-the codex provider to a persistent **`codex app-server`** (JSON-RPC) session that
-surfaces codex's approval requests through Chroxy's **permission pipeline** — so
-you approve/deny codex's commands and file edits the same way you do Claude, and
-can switch permission modes mid-session. It is a no-op unless the flag is set.
+The codex provider drives a persistent **`codex app-server`** (JSON-RPC) session
+**by default** (#6616). It surfaces codex's approval requests through Chroxy's
+**permission pipeline** — so you approve/deny codex's commands and file edits the
+same way you do Claude, and can switch permission modes mid-session — and it
+carries intra-session conversation memory + attachments (below).
+
+To fall back to the legacy `codex exec --json` path (one subprocess per turn, **no
+approval surface** — codex runs whatever its sandbox allows without asking, and no
+attachments), set `CHROXY_CODEX_APPSERVER=0` (also accepts `false`/`no`/`off`).
 
 Codex's `approvalPolicy` is derived from the session's permission mode, and
 Chroxy's `PermissionManager` decides whether to prompt or auto-resolve:
@@ -372,12 +374,12 @@ rejects them outright). Image attachments become codex `localImage` input items
 materialized and named in a text suffix codex can read. So on attachments the
 app-server path is a strict improvement over exec, not a regression.
 
-**Still opt-in (not the default)** — purely to bank a broader real-world
-validation period; there is no longer a feature gap versus the exec path (it's a
-strict superset: approvals, intra-session conversation memory, and attachments,
-with no attachment/resume regression). Enable it per-host today when you want
-approval control over codex; flipping it on by default is a follow-up once it has
-soaked. Codex's own scope-escalation requests
+**Why it's the default (#6616).** The app-server path is a strict superset of
+exec — approvals, intra-session conversation memory, and attachments (image
+vision + file references), with no regression (resume is unsupported on *both*
+paths). The only thing that kept it opt-in was a soak period; it now ships on by
+default, with the exec path one env var away (`CHROXY_CODEX_APPSERVER=0`) as a
+fallback. Codex's own scope-escalation requests
 (`item/permissions/requestApproval`) are currently safe-denied — full surfacing
 is tracked in #6610.
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -35,8 +35,9 @@ const log = createLogger('codex-app-server')
  * therefore advertises `permissions` / `inProcessPermissions` /
  * `permissionModeSwitch`.
  *
- * Selected only when `CHROXY_CODEX_APPSERVER=1` (see providers.js `getProvider`);
- * otherwise the exec-based CodexSession is used, so this is a no-op by default.
+ * This is the DEFAULT driver for the `codex` provider (#6616, see providers.js
+ * `getProvider`); set `CHROXY_CODEX_APPSERVER=0` to fall back to the legacy
+ * exec-based CodexSession.
  *
  * Architecturally this mirrors SdkSession (persistent backend + streaming),
  * NOT the JsonlSubprocessSession middle layer (subprocess-per-turn). Codex

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -35,6 +35,10 @@ import {
   resetCachesForTest,
 } from './auth-probes.js'
 
+// #6616 — values of CHROXY_CODEX_APPSERVER that opt the codex provider OUT of the
+// (now-default) app-server path and back to the legacy `codex exec` path.
+const CODEX_EXEC_OPT_OUT = new Set(['0', 'false', 'no', 'off'])
+
 const PROVIDERS = {
   'claude-cli': CliSession,
   'claude-sdk': SdkSession,
@@ -53,11 +57,11 @@ const PROVIDERS = {
   'ollama': OllamaSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
-  // #6605 — codex via the app-server JSON-RPC protocol (persistent) instead of
-  // one-shot `codex exec`. Hidden (not a user-selectable provider): it's the
-  // opt-in swap target for the 'codex' key, selected in getProvider() when
-  // CHROXY_CODEX_APPSERVER=1. Registered here so validateProviderClass runs its
-  // contract check at module load.
+  // #6605/#6616 — codex via the app-server JSON-RPC protocol (persistent) instead
+  // of one-shot `codex exec`. Hidden (not a user-selectable provider): it's the
+  // swap target for the 'codex' key and is now the DEFAULT, selected in
+  // getProvider() unless CHROXY_CODEX_APPSERVER opts out (=0). Registered here so
+  // validateProviderClass runs its contract check at module load.
   'codex-appserver': CodexAppServerSession,
   // #5983 (epic #5982) — general-purpose user shell ($SHELL via node-pty).
   // Gated OFF by default (userShell.enabled, #5985a) and primary-token-only
@@ -170,13 +174,16 @@ export function getRegisteredProviderNames() {
  * @throws {Error} If provider is not registered
  */
 export function getProvider(name) {
-  // #6605 — opt-in: drive codex through the app-server JSON-RPC protocol
-  // (persistent, approval-capable) instead of one-shot `codex exec`. Env-gated
-  // at resolve time (not in the PROVIDERS literal, which is validated at load)
-  // so it's a safe no-op until explicitly enabled. getProvider is the single
-  // chokepoint SessionManager uses to both construct and preflight, so this one
-  // branch covers every path.
-  if (name === 'codex' && process.env.CHROXY_CODEX_APPSERVER === '1') {
+  // #6616 — codex is driven through the app-server JSON-RPC protocol (persistent,
+  // approval-capable) BY DEFAULT. It's a strict superset of one-shot `codex exec`:
+  // approvals surfaced in Chroxy (#6611), permission-mode mapping (#6613),
+  // intra-session conversation memory, and attachments incl. image vision (#6609)
+  // — where exec rejects attachments and has no approval surface. Opt OUT to the
+  // legacy exec path with CHROXY_CODEX_APPSERVER=0 (or false/no/off). Resolved
+  // here (not in the load-validated PROVIDERS literal) because getProvider is the
+  // single chokepoint SessionManager uses to both construct and preflight, so
+  // this one branch covers every path.
+  if (name === 'codex' && !CODEX_EXEC_OPT_OUT.has((process.env.CHROXY_CODEX_APPSERVER || '').trim().toLowerCase())) {
     return CodexAppServerSession
   }
   const ProviderClass = PROVIDERS[name]

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -320,7 +320,10 @@ describe('settings-handlers', () => {
         assert.match(err.message, /gemini/i)
       })
 
-      it('rejects set_permission_mode on a Codex session with CAPABILITY_NOT_SUPPORTED', () => {
+      it('accepts set_permission_mode on a Codex session (app-server is the default, #6616)', () => {
+        // Since #6616 the codex provider drives the app-server path by default,
+        // which advertises permissionModeSwitch:true — so the capability gate now
+        // ALLOWS set_permission_mode for codex (it used to reject under exec).
         const sessions = new Map()
         const session = createMockSession()
         sessions.set('s1', { session, name: 'Cx', cwd: '/tmp', provider: 'codex' })
@@ -330,12 +333,8 @@ describe('settings-handlers', () => {
 
         settingsHandlers.set_permission_mode(ws, client, { mode: 'approve', requestId: 'r2' }, ctx)
 
-        assert.equal(session.setPermissionMode.callCount, 0)
-        assert.equal(ws._messages.length, 1)
-        const err = ws._messages[0]
-        assert.equal(err.type, 'error')
-        assert.equal(err.code, 'CAPABILITY_NOT_SUPPORTED')
-        assert.match(err.message, /codex/i)
+        assert.equal(session.setPermissionMode.callCount, 1)
+        assert.equal(ws._messages.length, 0, 'no CAPABILITY_NOT_SUPPORTED error for codex now')
       })
 
       it('accepts set_permission_mode on a claude-sdk session', () => {

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1551,31 +1551,28 @@ describe('validateProviderClass — inProcessPermissions guard (#5379)', () => {
 describe('codex provider default — app-server (#6616)', () => {
   const KEY = 'CHROXY_CODEX_APPSERVER'
   const orig = process.env[KEY]
-  const restore = () => { if (orig === undefined) delete process.env[KEY]; else process.env[KEY] = orig }
+  // try/finally so a failed assertion can't leave CHROXY_CODEX_APPSERVER mutated
+  // and leak into later tests (Copilot #6617 review).
+  const withEnv = (val, fn) => {
+    if (val === undefined) delete process.env[KEY]; else process.env[KEY] = val
+    try { fn() } finally { if (orig === undefined) delete process.env[KEY]; else process.env[KEY] = orig }
+  }
 
   it('defaults to the app-server driver when the env is unset', () => {
-    delete process.env[KEY]
-    assert.equal(getProvider('codex'), CodexAppServerSession)
-    restore()
+    withEnv(undefined, () => assert.equal(getProvider('codex'), CodexAppServerSession))
   })
 
   it('any non-opt-out value keeps the app-server driver (e.g. "1")', () => {
-    process.env[KEY] = '1'
-    assert.equal(getProvider('codex'), CodexAppServerSession)
-    restore()
+    withEnv('1', () => assert.equal(getProvider('codex'), CodexAppServerSession))
   })
 
   it('opts out to the exec CodexSession for 0/false/no/off (case-insensitive)', () => {
     for (const v of ['0', 'false', 'no', 'off', 'OFF', ' false ']) {
-      process.env[KEY] = v
-      assert.equal(getProvider('codex'), CodexSession, `opt-out value: "${v}"`)
+      withEnv(v, () => assert.equal(getProvider('codex'), CodexSession, `opt-out value: "${v}"`))
     }
-    restore()
   })
 
   it('the opt-out never affects non-codex providers', () => {
-    process.env[KEY] = '0'
-    assert.equal(getProvider('claude-cli'), CliSession)
-    restore()
+    withEnv('0', () => assert.equal(getProvider('claude-cli'), CliSession))
   })
 })

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -7,6 +7,7 @@ import { registerProvider, getProvider, listProviders, registerDockerProvider, _
 import { CliSession } from '../src/cli-session.js'
 import { SdkSession } from '../src/sdk-session.js'
 import { CodexSession } from '../src/codex-session.js'
+import { CodexAppServerSession } from '../src/codex-app-server-session.js'
 import { GeminiSession } from '../src/gemini-session.js'
 
 describe('Provider Registry', () => {
@@ -1544,5 +1545,37 @@ describe('validateProviderClass — inProcessPermissions guard (#5379)', () => {
       assert.deepEqual([...DOCKER_PROVIDER_IDS].sort(), ['docker', 'docker-byok', 'docker-cli', 'docker-sdk'],
         'a docker provider changed — keep DOCKER_PROVIDER_IDS in sync with store-core CLAUDE_BACKED_DOCKER_IDS; a NON-Claude docker-* must NOT be added to the store-core allowlist (it would get a fabricated 200k context-window meter)')
     })
+  })
+})
+
+describe('codex provider default — app-server (#6616)', () => {
+  const KEY = 'CHROXY_CODEX_APPSERVER'
+  const orig = process.env[KEY]
+  const restore = () => { if (orig === undefined) delete process.env[KEY]; else process.env[KEY] = orig }
+
+  it('defaults to the app-server driver when the env is unset', () => {
+    delete process.env[KEY]
+    assert.equal(getProvider('codex'), CodexAppServerSession)
+    restore()
+  })
+
+  it('any non-opt-out value keeps the app-server driver (e.g. "1")', () => {
+    process.env[KEY] = '1'
+    assert.equal(getProvider('codex'), CodexAppServerSession)
+    restore()
+  })
+
+  it('opts out to the exec CodexSession for 0/false/no/off (case-insensitive)', () => {
+    for (const v of ['0', 'false', 'no', 'off', 'OFF', ' false ']) {
+      process.env[KEY] = v
+      assert.equal(getProvider('codex'), CodexSession, `opt-out value: "${v}"`)
+    }
+    restore()
+  })
+
+  it('the opt-out never affects non-codex providers', () => {
+    process.env[KEY] = '0'
+    assert.equal(getProvider('claude-cli'), CliSession)
+    restore()
   })
 })


### PR DESCRIPTION
## What

Flips `CHROXY_CODEX_APPSERVER` from **opt-in** to **default-on**: the `codex` provider now drives the persistent `codex app-server` (JSON-RPC) path by default, with the legacy `codex exec` path one env var away.

This is the final step of the codex approval epic (#6605). The app-server path is now a **strict superset** of exec:
- approvals surfaced through the permission pipeline (#6611)
- permission-mode → approvalPolicy mapping (#6613)
- intra-session conversation memory (persistent thread vs stateless `codex exec`)
- attachments incl. **image vision** (#6609) — exec *rejects* attachments and has no approval surface

No feature gap remains, so it ships on by default.

## How

`getProvider('codex')` now returns `CodexAppServerSession` **unless** `CHROXY_CODEX_APPSERVER` is an opt-out value (`0` / `false` / `no` / `off`, case-insensitive + trimmed) → legacy `CodexSession`. The flag thus inverts from "opt in" to "opt out"; `=1` (and any non-opt-out value) keeps the app-server path.

- `providers.js`: default-select in the single `getProvider` chokepoint (used for both construct + preflight) + a `CODEX_EXEC_OPT_OUT` set; registration/getProvider comments + class doc updated.
- `docs/providers.md`: capability matrix row + the "Codex app-server + approvals" section rewritten for default-on with the exec fallback.

## Validation

- **Runtime-verified** the selection matrix: unset → `CodexAppServerSession`; `=0`/`=false`/`no`/`off` → `CodexSession`; `=1` → `CodexAppServerSession`.
- **+4 providers tests** (default, non-opt-out, opt-out set case-insensitive, non-codex unaffected). Full suites green: providers (78), codex-app-server (45), **codex-session (116 — exec path unaffected)**, codex-ratchet (8); opt-forwarding + logger lints green.
- The app-server path itself was live-validated across the epic (approval round-trip #6611, image vision #6609).

## Rollback
`CHROXY_CODEX_APPSERVER=0` restores the exec path instantly — no code change needed.

Closes #6616.