### PR TITLE
fix(server): degrade to local/LAN when the tunnel isn't routable at boot

### DIFF
--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -91,6 +91,10 @@ export class Supervisor extends EventEmitter {
     this._tunnel = null
     this._heartbeatInterval = null
     this._currentWsUrl = null
+    // #6641: true while the tunnel is up but not routable — the server runs
+    // local/LAN-only and advertises no remote/QR access. Read by the degrade
+    // test; a natural gate for a future auto-reverify.
+    this._tunnelDegraded = false
     this._signalsRegistered = false
     this._restartScheduledAt = null
     this._restartDelayMs = null
@@ -325,15 +329,22 @@ export class Supervisor extends EventEmitter {
     // must NOT abort the whole daemon. The default `chroxy start` used to
     // exit(1) here whenever a warming quick-tunnel edge answered with a status
     // outside {502,530} (e.g. a bare 404 during route propagation), taking down
-    // local + LAN access with it. Instead, degrade to local/LAN: keep
-    // cloudflared alive (so the tunnel_recovered handler can advertise remote
-    // access if it becomes routable) and start the child anyway.
+    // local + LAN access with it. Instead, degrade to local/LAN: start the
+    // child anyway so the server is usable right now.
     //
-    // #5314 (WP-1.4) note: the no-orphan guarantee is preserved a different way.
-    // Previously a tunnel-verify throw meant "stop cloudflared, then exit" so it
-    // couldn't leak. Now cloudflared stays up but the child is forked and
-    // supervised, so BOTH are torn down together in shutdown() — no orphan.
-    // A NON-routability error (an unexpected throw) still takes the old
+    // Degraded mode does NOT auto-recover to remote: `tunnel_recovered` only
+    // fires when the cloudflared PROCESS flaps (tunnel/base.js), not when an
+    // alive-but-unroutable tunnel finishes propagating, and there is no
+    // routability re-poll. So we advertise NO remote/QR access and tell the
+    // operator to restart (or use --tunnel named) once the tunnel is routable,
+    // rather than promising a QR that would never appear. (An auto re-verify in
+    // degraded mode is a possible follow-up — see #6641.)
+    //
+    // #5314 (WP-1.4) note: on the SIGINT/SIGTERM path the no-orphan guarantee
+    // still holds — shutdown() stops the tunnel and the supervised child
+    // together. (The crash-loop give-up path, _serveTerminalDown(), does not
+    // stop the tunnel — a pre-existing gap, not introduced here.) A
+    // NON-routability error (an unexpected throw) still takes the old
     // stop-cloudflared-then-exit cleanup path via _failBoot().
     let tunnelRoutable = true
     try {
@@ -346,8 +357,9 @@ export class Supervisor extends EventEmitter {
       tunnelRoutable = false
       this._tunnelDegraded = true
       this._log.warn(
-        'Tunnel not routable yet — starting in local/LAN mode. Remote (QR) access ' +
-        `will be advertised if the tunnel becomes routable. ${err.message}`
+        'Tunnel not routable — starting in local/LAN mode; remote access is ' +
+        'unavailable. Restart once your network/tunnel is ready, or use ' +
+        `--tunnel named for a stable URL. ${err.message}`
       )
     }
 
@@ -370,24 +382,30 @@ export class Supervisor extends EventEmitter {
         process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard\n`)
         process.stdout.write('\n')
       } else {
-        // 3a. Degraded: local/LAN only, no QR to a dead endpoint.
-        process.stdout.write('\n⚠️  Tunnel not routable yet — serving on local/LAN only.\n')
+        // 3a. Degraded: local/LAN only, no QR to a dead endpoint, and no false
+        // promise of auto-recovery (#6641 review).
+        process.stdout.write('\n⚠️  Tunnel not routable — serving on local/LAN only (no remote/QR access).\n')
         process.stdout.write(`   Dashboard: http://localhost:${this._port}/dashboard\n`)
+        process.stdout.write(`   LAN:       http://<this-machine-ip>:${this._port}/dashboard\n`)
         process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
-        process.stdout.write('   Remote (phone) access will be advertised here if the tunnel becomes routable.\n\n')
+        process.stdout.write('   For remote (phone) access, restart once the tunnel is routable, or use --tunnel named.\n\n')
       }
 
-      // 3b. Write connection info file for programmatic access
+      // 3b. Write connection info file for programmatic access. In degraded mode
+      // OMIT the public wsUrl/httpUrl/connectionUrl (they're not routable) so no
+      // consumer advertises a dead endpoint — notably the dashboard /qr route
+      // falls back to connectionUrl, which would otherwise resurface the exact
+      // dead QR #6641 kills, just in the dashboard modal (#6641 review). The
+      // local `port` is still written so loopback CLIs (chroxy publish / pages)
+      // hit the right port even in tunnel mode (#5683).
       writeConnectionInfo({
-        wsUrl,
-        httpUrl,
-        // #5683: the LOCAL listen port, so loopback CLIs (chroxy publish / pages)
-        // hit the right port even in tunnel mode, where httpUrl is the public
-        // trycloudflare URL with no :port to parse.
+        wsUrl: tunnelRoutable ? wsUrl : null,
+        httpUrl: tunnelRoutable ? httpUrl : null,
         port: this._port,
         apiToken: this._apiToken,
-        connectionUrl,
+        connectionUrl: tunnelRoutable ? connectionUrl : null,
         tunnelMode: this._modeLabel,
+        tunnelDegraded: !tunnelRoutable,
         startedAt: new Date().toISOString(),
         pid: process.pid,
       })

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -321,29 +321,61 @@ export class Supervisor extends EventEmitter {
       this._log.error(message)
     })
 
-    // 2-3. Wait for the tunnel to be routable, then display + persist connection
-    // info. #5314 (WP-1.4) — every step here runs while cloudflared is already
-    // up (this._tunnel.start() above) but BEFORE the child is forked, so ANY
-    // throw must stop cloudflared first or it leaks as an orphan. waitForTunnel
-    // THROWS on a routine DNS-settle failure; _displayQr (QR encode) and
-    // writeConnectionInfo (disk) can also throw. _failBoot() is the single
-    // cleanup path. (The PID write below has its own non-fatal guard, and the
-    // child fork is past the no-leak boundary.)
+    // 2. Wait for the tunnel to be routable. #6641 — a not-yet-routable tunnel
+    // must NOT abort the whole daemon. The default `chroxy start` used to
+    // exit(1) here whenever a warming quick-tunnel edge answered with a status
+    // outside {502,530} (e.g. a bare 404 during route propagation), taking down
+    // local + LAN access with it. Instead, degrade to local/LAN: keep
+    // cloudflared alive (so the tunnel_recovered handler can advertise remote
+    // access if it becomes routable) and start the child anyway.
+    //
+    // #5314 (WP-1.4) note: the no-orphan guarantee is preserved a different way.
+    // Previously a tunnel-verify throw meant "stop cloudflared, then exit" so it
+    // couldn't leak. Now cloudflared stays up but the child is forked and
+    // supervised, so BOTH are torn down together in shutdown() — no orphan.
+    // A NON-routability error (an unexpected throw) still takes the old
+    // stop-cloudflared-then-exit cleanup path via _failBoot().
+    let tunnelRoutable = true
     try {
       await this._waitForTunnel(httpUrl)
+    } catch (err) {
+      if (err?.code !== 'TUNNEL_NOT_ROUTABLE') {
+        await this._failBoot(err)
+        return
+      }
+      tunnelRoutable = false
+      this._tunnelDegraded = true
+      this._log.warn(
+        'Tunnel not routable yet — starting in local/LAN mode. Remote (QR) access ' +
+        `will be advertised if the tunnel becomes routable. ${err.message}`
+      )
+    }
 
-      // 3. Display connection info
+    // 3. Display + persist connection info. The QR is shown ONLY for a routable
+    // tunnel — a QR to a not-yet-routable endpoint just hangs the app (the exact
+    // failure #6641 addresses), so in degraded mode we advertise local/LAN only.
+    // A throw in this block (QR encode / disk write) still routes to _failBoot().
+    try {
       const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${this._apiToken}`
 
-      this._log.info(`${this._modeLabel} ready`)
-      process.stdout.write('📱 Scan this QR code with the Chroxy app:\n\n')
-      await this._displayQr(connectionUrl)
-      process.stdout.write('\nOr connect manually:\n')
-      process.stdout.write(`   URL:   ${wsUrl}\n`)
-      process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
-      const dashboardBase = httpUrl || `http://localhost:${this._port}`
-      process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard\n`)
-      process.stdout.write('\n')
+      if (tunnelRoutable) {
+        // 3a. Display connection info
+        this._log.info(`${this._modeLabel} ready`)
+        process.stdout.write('📱 Scan this QR code with the Chroxy app:\n\n')
+        await this._displayQr(connectionUrl)
+        process.stdout.write('\nOr connect manually:\n')
+        process.stdout.write(`   URL:   ${wsUrl}\n`)
+        process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
+        const dashboardBase = httpUrl || `http://localhost:${this._port}`
+        process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard\n`)
+        process.stdout.write('\n')
+      } else {
+        // 3a. Degraded: local/LAN only, no QR to a dead endpoint.
+        process.stdout.write('\n⚠️  Tunnel not routable yet — serving on local/LAN only.\n')
+        process.stdout.write(`   Dashboard: http://localhost:${this._port}/dashboard\n`)
+        process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
+        process.stdout.write('   Remote (phone) access will be advertised here if the tunnel becomes routable.\n\n')
+      }
 
       // 3b. Write connection info file for programmatic access
       writeConnectionInfo({

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -211,6 +211,48 @@ describe('Supervisor', () => {
       clearInterval(supervisor._heartbeatInterval)
     })
 
+    it('#6641: degrades to local/LAN instead of exiting when the tunnel is not routable', async () => {
+      const { supervisor } = setup()
+      const err = new Error('Tunnel failed to become routable after 20 attempts (108s). Last failure: HTTP 404.')
+      err.code = 'TUNNEL_NOT_ROUTABLE'
+      supervisor._waitForTunnel = () => Promise.reject(err)
+
+      const chunks = []
+      mock.method(process.stdout, 'write', (chunk) => { chunks.push(String(chunk)); return true })
+      try {
+        await supervisor.start()
+      } finally {
+        mock.restoreAll()
+        supervisor._shuttingDown = true
+        if (supervisor._heartbeatInterval) clearInterval(supervisor._heartbeatInterval)
+      }
+      const output = chunks.join('')
+
+      // The daemon must NOT exit and MUST fork the child so local + LAN work.
+      assert.equal(supervisor._exitCalled, null, 'should not exit on a not-routable tunnel')
+      assert.equal(supervisor._mockChildren.length, 1, 'child (local server) should still start')
+      // cloudflared is kept alive so it can recover — NOT stopped here.
+      assert.equal(supervisor._mockTunnel.stop.mock.callCount(), 0, 'cloudflared should stay up')
+      assert.equal(supervisor._tunnelDegraded, true)
+      // No QR to a dead endpoint; degraded local/LAN banner instead.
+      assert.doesNotMatch(output, /Scan this QR/, 'no QR when the tunnel is not routable')
+      assert.match(output, /local\/LAN only/, 'shows the degraded local/LAN banner')
+    })
+
+    it('#6641: still aborts (stops cloudflared + exits) on a non-routability tunnel error', async () => {
+      const { supervisor } = setup()
+      supervisor._waitForTunnel = () => Promise.reject(new Error('boom: unexpected tunnel failure'))
+
+      await supervisor.start()
+
+      assert.equal(supervisor._exitCalled, 1, 'a non-TUNNEL_NOT_ROUTABLE error still fails boot')
+      assert.equal(supervisor._mockTunnel.stop.mock.callCount(), 1, 'cloudflared is stopped on hard boot failure')
+      assert.equal(supervisor._mockChildren.length, 0, 'no child forked on hard boot failure')
+
+      supervisor._shuttingDown = true
+      if (supervisor._heartbeatInterval) clearInterval(supervisor._heartbeatInterval)
+    })
+
     it('writes PID file on start', async () => {
       const { supervisor, config } = setup()
       await supervisor.start()

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -237,6 +237,18 @@ describe('Supervisor', () => {
       // No QR to a dead endpoint; degraded local/LAN banner instead.
       assert.doesNotMatch(output, /Scan this QR/, 'no QR when the tunnel is not routable')
       assert.match(output, /local\/LAN only/, 'shows the degraded local/LAN banner')
+      // #6641 review: must NOT promise auto-advertised remote access (it never
+      // happens for an alive-but-unroutable tunnel) — give actionable guidance.
+      assert.doesNotMatch(output, /will be advertised/i, 'no false auto-advertise promise')
+      assert.match(output, /--tunnel named|restart/i, 'gives actionable remote-access guidance')
+      // Degraded connection.json must NOT carry a dead public URL — the dashboard
+      // /qr route falls back to connectionUrl and would otherwise resurface a
+      // dead QR in the modal.
+      const connInfo = JSON.parse(readFileSync(join(process.env.CHROXY_CONFIG_DIR, 'connection.json'), 'utf-8'))
+      assert.equal(connInfo.connectionUrl, null, 'degraded connection.json omits the public connectionUrl')
+      assert.equal(connInfo.wsUrl, null, 'degraded connection.json omits the public wsUrl')
+      assert.equal(connInfo.tunnelDegraded, true)
+      assert.equal(connInfo.port, supervisor._port, 'local port is still written for loopback CLIs')
     })
 
     it('#6641: still aborts (stops cloudflared + exits) on a non-routability tunnel error', async () => {


### PR DESCRIPTION
## Summary

Fixes #6641 — a Phase 0 blocker from the Windows/Linux [swarm audit](https://github.com/blamechris/chroxy/blob/main/docs/audit/windows-linux-support-2026-07-14/00-master-assessment.md).

The default `chroxy start` (quick tunnel) aborted with `exit(1)` **before the server ever bound** whenever the supervisor's pre-fork routability check failed — e.g. when a warming `trycloudflare.com` edge answered with a status outside `{502,530}` (a bare **404** during route propagation, reproduced on Windows). That took **local and LAN** access down along with the tunnel.

Now `TUNNEL_NOT_ROUTABLE` is treated as **non-fatal**:
- keep `cloudflared` alive (so the existing `tunnel_recovered` path can advertise remote access if it becomes routable),
- fork the child so **local/LAN work immediately**,
- **withhold the QR** in degraded mode (a QR to a not-yet-routable endpoint just hangs the app).

A non-routability boot error (unexpected throw) still takes the original stop-cloudflared-then-`exit(1)` cleanup path.

## Why not just widen the 502/530 allowlist

The audit's Tunneler agent reproduced a `trycloudflare` edge returning **404 for ~6 minutes even with a healthy origin** — so a 404 is *not* proof of routability. Adding it to the success set would declare a dead tunnel "routable" and hand the user a QR to a dead endpoint. The safe fix is to **decouple daemon boot from tunnel routability**, not to loosen the classifier.

## No-orphan guarantee (#5314) preserved

Previously a tunnel-verify throw meant "stop cloudflared, then exit" so it couldn't leak. Now cloudflared stays up but the child is forked and supervised, so **both are torn down together in `shutdown()`** (`supervisor.js:943-949`) — no orphan.

## Testing

- `supervisor.js` + tunnel suites: **84/84 pass** (added 2 supervisor tests — the degrade path and the hard-fail path).
- ESLint clean.

## Follow-up (not in this PR)

- Background re-verification to advertise the QR once a *previously-degraded* quick tunnel becomes routable without a drop/recover cycle (today it relies on the existing `tunnel_recovered` machinery).