### PR TITLE
fix(desktop): resolve the bundled server next to the exe on Windows/Linux

### DIFF
--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -1299,14 +1299,16 @@ impl ServerManager {
     }
 
     /// Resolve the chroxy CLI entry point (cli.js).
-    /// Checks: bundled .app resources, monorepo relative, CHROXY_SERVER_PATH env, `which chroxy`.
+    /// Checks: bundled resources (next-to-exe on Windows/Linux, Contents/Resources
+    /// on macOS), monorepo relative, CHROXY_SERVER_PATH env, `which`/`where chroxy`.
     fn resolve_cli_js() -> Result<PathBuf, String> {
-        // Strategy 1: Bundled inside .app (macOS).
-        // Binary lives at Contents/MacOS/chroxy-desktop,
-        // resources at Contents/Resources/server/src/cli.js.
+        // Strategy 1: Bundled with the installed desktop app. Tauri v2 stages
+        // `bundle.resources` next to the executable on Windows (MSI) and Linux
+        // (AppImage/deb), and under Contents/Resources on macOS. #6640 — the old
+        // code only checked the macOS layout, so the installed Windows/Linux tray
+        // could never find its own bundled server and failed to start the daemon.
         if let Ok(exe) = std::env::current_exe() {
-            if let Some(contents_dir) = exe.parent().and_then(|p| p.parent()) {
-                let bundled = contents_dir.join("Resources/server/src/cli.js");
+            for bundled in bundled_cli_js_candidates(&exe) {
                 if bundled.exists() {
                     return Ok(bundled);
                 }
@@ -1354,7 +1356,16 @@ impl ServerManager {
         #[cfg(windows)]
         let which_cmd = "where";
         if let Ok(output) = Command::new(which_cmd).arg("chroxy").output() {
-            let which_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            // #6640 — `where` on Windows can print multiple matches (one per
+            // line, e.g. chroxy + chroxy.cmd); take only the first. `which`
+            // prints a single path. Without this, a multi-line string becomes a
+            // single nonsensical PathBuf.
+            let which_path = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_string();
             if !which_path.is_empty() {
                 // chroxy bin is a Node script, the actual cli.js should be nearby
                 let p = PathBuf::from(&which_path);
@@ -1371,6 +1382,30 @@ impl ServerManager {
     }
 }
 
+/// Candidate `cli.js` locations for a bundled desktop install, derived from the
+/// desktop binary path and ordered by preference. Existence is checked by the
+/// caller. #6640 — the next-to-exe layout must come first so the installed
+/// Windows MSI (`<install>\server\src\cli.js`) and Linux AppImage/deb resolve;
+/// macOS `.app` places resources under `Contents/Resources` instead.
+fn bundled_cli_js_candidates(exe: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    // Windows (MSI) + Linux (AppImage/deb): resources sit next to the exe.
+    if let Some(dir) = exe.parent() {
+        candidates.push(dir.join("server").join("src").join("cli.js"));
+    }
+    // macOS .app: Contents/MacOS/<bin> -> Contents/Resources/server/src/cli.js
+    if let Some(contents_dir) = exe.parent().and_then(|p| p.parent()) {
+        candidates.push(
+            contents_dir
+                .join("Resources")
+                .join("server")
+                .join("src")
+                .join("cli.js"),
+        );
+    }
+    candidates
+}
+
 impl Drop for ServerManager {
     fn drop(&mut self) {
         self.stop();
@@ -1380,6 +1415,37 @@ impl Drop for ServerManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- resolve_cli_js candidate layout (#6640) --
+    //
+    // The installed desktop app must find its bundled server on every platform.
+    // Tauri v2 stages resources next to the exe on Windows (MSI) / Linux
+    // (AppImage/deb) and under Contents/Resources on macOS. These pin the path
+    // derivation — the actual #6640 bug was that the old code only knew the
+    // macOS layout, so the installed Windows tray never found its own server.
+
+    #[test]
+    fn bundled_cli_js_offers_next_to_exe_first() {
+        let exe = PathBuf::from("C:/Program Files/Chroxy/Chroxy.exe");
+        let cands = bundled_cli_js_candidates(&exe);
+        assert!(cands.len() >= 2, "expected next-to-exe and macOS candidates");
+        // Windows MSI / Linux AppImage/deb layout must be tried first.
+        assert!(cands[0].ends_with("server/src/cli.js"), "got {:?}", cands[0]);
+        assert!(cands[0].starts_with("C:/Program Files/Chroxy"), "got {:?}", cands[0]);
+    }
+
+    #[test]
+    fn bundled_cli_js_still_handles_macos_app_layout() {
+        let exe = PathBuf::from("/Applications/Chroxy.app/Contents/MacOS/chroxy-desktop");
+        let cands = bundled_cli_js_candidates(&exe);
+        assert!(
+            cands
+                .iter()
+                .any(|p| p.ends_with("Contents/Resources/server/src/cli.js")),
+            "macOS Resources layout must still be a candidate: {:?}",
+            cands
+        );
+    }
 
     // -- bind_host_env (#5356) --
     //

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -1376,7 +1376,7 @@ impl ServerManager {
         }
 
         Err(
-            "Could not find chroxy server. Checked: bundled .app resources, monorepo layout, CHROXY_SERVER_PATH env, and PATH (which chroxy)."
+            "Could not find chroxy server. Checked: bundled resources (next-to-exe on Windows/Linux, Contents/Resources on macOS), monorepo layout, CHROXY_SERVER_PATH env, and PATH (which/where chroxy)."
                 .to_string(),
         )
     }


### PR DESCRIPTION
## Summary

Fixes #6640 — the top Phase 0 blocker from the Windows/Linux [swarm audit](https://github.com/blamechris/chroxy/blob/main/docs/audit/windows-linux-support-2026-07-14/00-master-assessment.md).

The installed Windows MSI (and Linux AppImage/deb) **launches but never starts its own daemon**: the tray window opens, but `resolve_cli_js()` can't find the bundled `cli.js`, so `start_server_process` errors out.

**Root cause:** `resolve_cli_js()` (server.rs) Strategy 1 only knew the macOS `.app` layout —
```
exe.parent().parent().join("Resources/server/src/cli.js")
```
On a Windows install `C:\Program Files\Chroxy\Chroxy.exe` that resolves to `C:\Program Files\Resources\server\src\cli.js`, which doesn't exist. The other strategies also miss on a clean end-user box (no monorepo; `CHROXY_SERVER_PATH` is never set by the app; `where chroxy` is empty unless globally npm-installed). Since `auto_start_server` defaults to `true`, this is hit on every launch.

**Fix:** Tauri v2 stages `bundle.resources` **next to the executable** on Windows/Linux (and under `Contents/Resources` on macOS). Add the next-to-exe candidate first, keeping the macOS layout as a fallback. Extracted as a pure, unit-tested helper `bundled_cli_js_candidates()`.

Also hardens Strategy 4: `where chroxy` on Windows can print multiple matches (one per line) — take only the first, or the multi-line string becomes one nonsensical `PathBuf`.

## Testing

- `cargo test --lib bundled_cli_js` on **Windows (x86_64-pc-windows-msvc)** — 2 new tests pass (next-to-exe ordering + macOS layout still handled).
- The bundle staging itself is already Windows-correct (`bundle-server.sh` keeps the win32 node-pty prebuild), so this lookup fix is the last thing between "MSI installs" and "MSI runs."

## Not yet verified (follow-up)

- End-to-end **install-the-MSI-and-launch** confirmation still requires a full `cargo tauri build` (WiX/WebView2) — tracked in the epic (#6653) and the CI item #6651. This PR fixes and unit-tests the path logic that was the blocker; the full MSI smoke is a separate step.
- Related packaging work (no `bundle.windows` block, macOS speech-helper shipped in the MSI) is #6648.