### PR TITLE
fix(server): reap the whole process tree on Windows teardown

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -9,7 +9,7 @@ import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
-import { forceKill } from './platform.js'
+import { forceKill, killProcessTree } from './platform.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
 import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
@@ -1478,7 +1478,12 @@ export class CliSession extends BaseSession {
       // tests with a mock child that never emits 'close').
       if (typeof forceKillTimer.unref === 'function') forceKillTimer.unref()
 
-      oldChild.kill('SIGTERM')
+      // #6643 — on Windows a plain SIGTERM only TerminateProcess-es the cmd.exe
+      // shim wrapping a `.cmd` provider (claude/codex/…); the real node
+      // grandchild is orphaned and the wrapper's `close` above then cancels the
+      // forceKill escalation before it can fire. killProcessTree reaps the whole
+      // tree (POSIX behaviour is an identical graceful SIGTERM).
+      killProcessTree(oldChild)
     } else {
       this._respawning = false
       this._respawnCount = 0

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -5,6 +5,7 @@ import { createLogger } from './logger.js'
 import { guardChildStreams } from './child-stream-guard.js'
 import { getErrorMessage } from './utils/error-message.js'
 import { prepareSpawn } from './utils/win-spawn.js'
+import { killProcessTree } from './platform.js'
 
 const log = createLogger('jsonl-subprocess-session')
 
@@ -159,9 +160,11 @@ export class JsonlSubprocessSession extends BaseSession {
     // this session instance. Mirrors CliSession.destroy() (#4602).
     this._clearIntentionalStop()
     if (this._process) {
-      try {
-        this._process.kill('SIGTERM')
-      } catch { /* already dead */ }
+      // #6643 — on Windows SIGTERM only TerminateProcess-es the cmd.exe shim
+      // wrapping a `.cmd` provider (codex/gemini/…), orphaning the real node
+      // grandchild (there is no forceKill escalation on this path). Reap the
+      // whole tree; POSIX behaviour is an identical graceful SIGTERM.
+      killProcessTree(this._process)
       this._process = null
     }
     this.removeAllListeners()

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -132,7 +132,9 @@ export function writeFileRestricted(
 }
 
 /**
- * Terminate `child` AND its entire descendant tree.
+ * Terminate `child` — its whole descendant TREE on Windows (taskkill /T), or
+ * just the DIRECT process on POSIX (see the per-platform notes below; callers
+ * that need the whole POSIX group spawn `detached` and signal the negative pid).
  *
  * POSIX: `child.kill(force ? 'SIGKILL' : 'SIGTERM')` on the direct process —
  * the long-standing behaviour (callers that need the whole group spawn
@@ -163,6 +165,10 @@ export function killProcessTree(child, { force = false } = {}) {
         execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
           stdio: 'ignore',
           windowsHide: true,
+          // Bound the teardown path: a wedged taskkill must not hang stop /
+          // respawn. On timeout execFileSync throws and we fall back to the
+          // direct child.kill() below (#6657 review).
+          timeout: 5000,
         })
         return
       } catch {

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -1,4 +1,5 @@
 import { writeFileSync, chmodSync, renameSync, unlinkSync } from 'fs'
+import { execFileSync } from 'child_process'
 import { createLogger } from './logger.js'
 
 const log = createLogger('platform')
@@ -130,10 +131,56 @@ export function writeFileRestricted(
   }
 }
 
-export function forceKill(child) {
+/**
+ * Terminate `child` AND its entire descendant tree.
+ *
+ * POSIX: `child.kill(force ? 'SIGKILL' : 'SIGTERM')` on the direct process —
+ * the long-standing behaviour (callers that need the whole group spawn
+ * `detached` and signal the negative pid themselves). `force:false` stays a
+ * graceful SIGTERM so a caller's existing SIGTERM→SIGKILL escalation is
+ * unchanged.
+ *
+ * Windows: there is no process-group signal and no graceful console-tree
+ * termination — Node maps BOTH `SIGTERM` and `SIGKILL` to `TerminateProcess`
+ * on the DIRECT pid, so descendants are orphaned. This is acute for Chroxy:
+ * `.cmd`/`.bat` provider shims (claude, codex, gemini, …) run under
+ * `cmd.exe /d /s /c`, so the real agent/node process is a GRANDCHILD of the
+ * tracked pid. `cmd /c` waits for its child, so actively killing the wrapper
+ * (respawn / model-switch / destroy) leaves node running — still editing files
+ * and burning tokens — after Stop/teardown (#6643). Reap the whole tree with
+ * `taskkill /PID <pid> /T /F`. The `force` flag is POSIX-only; on Windows the
+ * kill is always forced (matching Node's existing TerminateProcess semantics,
+ * where SIGTERM was never graceful anyway). Best-effort: an already-exited pid
+ * or a taskkill failure falls back to a direct `child.kill()` — this never
+ * throws, so it is safe to call from a teardown path.
+ */
+export function killProcessTree(child, { force = false } = {}) {
+  if (!child) return
   if (isWindows) {
-    child.kill('SIGKILL')
-  } else {
-    child.kill('SIGKILL')
+    const pid = child.pid
+    if (pid) {
+      try {
+        execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+          stdio: 'ignore',
+          windowsHide: true,
+        })
+        return
+      } catch {
+        // pid already gone, or taskkill unavailable/failed — fall through to a
+        // direct kill so teardown still makes progress.
+      }
+    }
+    try { child.kill('SIGKILL') } catch { /* already gone */ }
+    return
   }
+  try { child.kill(force ? 'SIGKILL' : 'SIGTERM') } catch { /* already gone */ }
+}
+
+/**
+ * Force-kill `child` and its whole descendant tree (#6643). POSIX sends
+ * SIGKILL to the process; Windows reaps the tree via taskkill. See
+ * {@link killProcessTree}.
+ */
+export function forceKill(child) {
+  killProcessTree(child, { force: true })
 }

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -983,6 +983,10 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
   it('setModel kills old child and respawns after close', async () => {
     const session = createReadySession({ model: 'sonnet' })
     const oldChild = session._child
+    // #6643: null the mock pid so killProcessTree takes its deterministic
+    // no-pid fallback (a direct kill) on Windows instead of shelling out to
+    // `taskkill /PID <mock>` against a real bystander process on a local run.
+    oldChild.pid = null
 
     // Stub start() to prevent actual process spawning
     let startCalled = false
@@ -1284,6 +1288,9 @@ describe('CliSession setPermissionMode panic-button mid-turn (#3735)', () => {
     const session = createReadySession({ permissionMode: 'approve' })
     sessions.push(session)
     const oldChild = session._child
+    // #6643: null the mock pid so killProcessTree takes its deterministic
+    // no-pid fallback on Windows (see the setModel respawn test).
+    oldChild.pid = null
 
     // Simulate the user being mid-turn: claude -p is running, _isBusy=true,
     // a messageId+ctx are set, and the result timer is armed.

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -6,6 +6,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'no
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { CliSession } from '../src/cli-session.js'
+import { isWindows } from '../src/platform.js'
 import { SessionStatePersistence } from '../src/session-state-persistence.js'
 
 /**
@@ -996,7 +997,9 @@ describe('_killAndRespawn behavioral tests (#1009)', () => {
     assert.equal(session._processReady, false)
     assert.equal(session._child, null, 'Old child should be detached')
     assert.equal(oldChild.kill.mock.calls.length, 1, 'kill() should be called on old child')
-    assert.equal(oldChild.kill.mock.calls[0].arguments[0], 'SIGTERM')
+    // #6643 — respawn routes through killProcessTree: POSIX still sends a
+    // graceful SIGTERM; on Windows the pid-less mock falls back to a direct kill.
+    if (!isWindows) assert.equal(oldChild.kill.mock.calls[0].arguments[0], 'SIGTERM')
 
     // start() not called yet (waiting for close)
     assert.equal(startCalled, false)
@@ -1308,8 +1311,9 @@ describe('CliSession setPermissionMode panic-button mid-turn (#3735)', () => {
     assert.equal(session._respawning, true)
     assert.equal(session._processReady, false)
     assert.equal(session._child, null, 'old child detached during respawn')
-    assert.equal(oldChild.kill.mock.calls.length, 1, 'SIGTERM sent to in-flight process')
-    assert.equal(oldChild.kill.mock.calls[0].arguments[0], 'SIGTERM')
+    assert.equal(oldChild.kill.mock.calls.length, 1, 'kill sent to in-flight process')
+    // #6643 — see killProcessTree note above; POSIX still uses a graceful SIGTERM.
+    if (!isWindows) assert.equal(oldChild.kill.mock.calls[0].arguments[0], 'SIGTERM')
 
     // start() is deferred until the old child's 'close' event fires.
     assert.equal(startCalled, 0, 'start() waits for old child to close')

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -4,6 +4,7 @@ import { writeFileSync, unlinkSync, existsSync, chmodSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { JsonlSubprocessSession } from '../src/jsonl-subprocess-session.js'
+import { isWindows } from '../src/platform.js'
 import { addLogListener, removeLogListener } from '../src/logger.js'
 import { waitFor } from './test-helpers.js'
 
@@ -251,10 +252,17 @@ describe('JsonlSubprocessSession (base)', () => {
       s.start()
       await waitFor(() => s.isReady, { label: 'isReady' })
 
+      // #6643 — destroy() now routes through killProcessTree so a `.cmd`-shim
+      // provider's node grandchild is reaped on Windows, not just the wrapper.
+      // For this pid-less mock: POSIX still sends a graceful SIGTERM; on Windows
+      // (no real pid to taskkill) it falls back to a direct kill. Either way the
+      // child is terminated and state is cleared. The real Windows tree-kill is
+      // covered by platform.test.js.
       let killed = null
       s._process = { kill: (sig) => { killed = sig } }
       s.destroy()
-      assert.equal(killed, 'SIGTERM')
+      assert.ok(killed, 'destroy() should terminate the child process')
+      if (!isWindows) assert.equal(killed, 'SIGTERM', 'POSIX destroy uses a graceful SIGTERM')
       assert.equal(s._process, null)
       assert.equal(s.isReady, false)
       assert.equal(s.isRunning, false)

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, statSync, existsSync } from 'fs'
+import { spawn, spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, statSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { pathToFileURL } from 'node:url'
@@ -514,6 +514,60 @@ try {
       forceKill(fakeChild)
       assert.ok(killed)
       assert.strictEqual(signal, 'SIGKILL')
+    })
+
+    // #6643 — on Windows, forceKill must reap the WHOLE descendant tree, not
+    // just the tracked pid. `.cmd` provider shims run under `cmd.exe /d /s /c`,
+    // so the real node process is a GRANDCHILD; a naive TerminateProcess on the
+    // cmd wrapper orphans it (still editing files / burning tokens after Stop).
+    // Only validatable on a real Windows runner — spawn cmd.exe -> node, kill
+    // the cmd wrapper, and assert the node grandchild dies too.
+    it('reaps the whole child -> grandchild process tree on Windows (#6643)', { skip: !isWindows }, async () => {
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+      const isAlive = (pid) => {
+        try { process.kill(pid, 0); return true } catch (e) { return e.code === 'EPERM' }
+      }
+      const stamp = `${process.pid}-${Date.now()}`
+      const pidFile = join(tmpdir(), `chroxy-treekill-${stamp}.pid`)
+      const script = join(tmpdir(), `chroxy-treekill-${stamp}.cjs`)
+      // Grandchild: record its own pid to a file, then stay alive.
+      writeFileSync(
+        script,
+        `require('fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setInterval(() => {}, 1e9)`,
+      )
+      // cmd.exe is the tracked child; `node <script>` is the grandchild — the
+      // same shape as `cmd /c claude.cmd` -> node.
+      const child = spawn('cmd.exe', ['/d', '/s', '/c', 'node', script], {
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+      try {
+        // Wait (<=15s) for the grandchild to report its pid.
+        let grandPid = null
+        for (let i = 0; i < 150 && grandPid === null; i++) {
+          try {
+            const raw = readFileSync(pidFile, 'utf-8').trim()
+            if (raw) grandPid = parseInt(raw, 10)
+          } catch { /* not written yet */ }
+          if (grandPid === null) await sleep(100)
+        }
+        assert.ok(Number.isInteger(grandPid) && grandPid > 0, 'grandchild should report a pid')
+        assert.ok(isAlive(grandPid), 'grandchild should be alive before forceKill')
+
+        // Kill the tracked cmd wrapper — the node grandchild must die too.
+        forceKill(child)
+
+        let dead = false
+        for (let i = 0; i < 80 && !dead; i++) {
+          if (!isAlive(grandPid)) { dead = true; break }
+          await sleep(100)
+        }
+        assert.ok(dead, 'forceKill must reap the node grandchild, not just the cmd wrapper')
+      } finally {
+        try { forceKill(child) } catch {}
+        try { rmSync(script, { force: true }) } catch {}
+        try { rmSync(pidFile, { force: true }) } catch {}
+      }
     })
   })
 })

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -541,9 +541,9 @@ try {
         stdio: 'ignore',
         windowsHide: true,
       })
+      let grandPid = null
       try {
         // Wait (<=15s) for the grandchild to report its pid.
-        let grandPid = null
         for (let i = 0; i < 150 && grandPid === null; i++) {
           try {
             const raw = readFileSync(pidFile, 'utf-8').trim()
@@ -565,6 +565,9 @@ try {
         assert.ok(dead, 'forceKill must reap the node grandchild, not just the cmd wrapper')
       } finally {
         try { forceKill(child) } catch {}
+        // Defensive: if the fix regressed and the grandchild survived, don't
+        // leak a live node orphan on the runner.
+        try { if (grandPid) process.kill(grandPid, 'SIGKILL') } catch {}
         try { rmSync(script, { force: true }) } catch {}
         try { rmSync(pidFile, { force: true }) } catch {}
       }


### PR DESCRIPTION
## Summary

Fixes #6643 — a Phase 1 safety finding from the Windows/Linux [swarm audit](https://github.com/blamechris/chroxy/blob/main/docs/audit/windows-linux-support-2026-07-14/00-master-assessment.md), reproduced live by the Windows Expert agent.

On Windows, **"Stop" is advisory**: `child.kill()` only `TerminateProcess`es the direct pid, and Node maps *both* `SIGTERM` and `SIGKILL` to that. Because `.cmd`/`.bat` provider shims (claude, codex, gemini, …) run under `cmd.exe /d /s /c`, the real agent/node process is a **grandchild** of the tracked pid. So Stop / model-switch / destroy killed only the `cmd` wrapper and left node running — still editing files and burning tokens after the UI reported "stopped."

Two compounding defects:
- `forceKill` was a **no-op branch** — identical Windows/POSIX arms (`child.kill('SIGKILL')`).
- The graceful `SIGTERM` teardown paths orphaned the tree too: `TerminateProcess`-ing the wrapper fires its `close`, which **cancels the `forceKill` escalation timer** before it can run. `jsonl-subprocess` destroy had no escalation at all.

## Fix

- Add `killProcessTree(child, { force })` in `platform.js`:
  - **Windows:** reap the whole tree via `taskkill /PID <pid> /T /F` (best-effort; falls back to a direct kill if the pid is already gone).
  - **POSIX:** unchanged — `child.kill(force ? 'SIGKILL' : 'SIGTERM')`.
- `forceKill` delegates to it (`force: true`) — so every existing `forceKill` call site (supervisor, cli-session respawn/destroy escalation) now tree-kills on Windows for free.
- Route the two orphaning graceful teardown paths through it: `cli-session` respawn (`SIGTERM`) and `jsonl-subprocess` destroy (`SIGTERM`, which had no escalation).

**POSIX behaviour is byte-for-byte unchanged** (graceful `SIGTERM` → forced `SIGKILL` escalation preserved).

## Testing

- New **real-Windows** test in `platform.test.js`: spawns `cmd.exe → node`, `forceKill`s the `cmd` wrapper, and asserts the node **grandchild** is reaped (not just the wrapper). Gated `{ skip: !isWindows }`; runs on the `windows-latest` CI job.
- Full affected suite green on this Windows box: `platform` + `cli-session*` + `jsonl-subprocess*` = **305/305**, `supervisor*` = **60/60**.
- Test assertions that pinned the exact signal were made platform-aware (POSIX still asserts the graceful `SIGTERM`).

## Follow-up (not in this PR)

- Making **interrupt** (Stop mid-turn, `SIGINT`) actually interrupt on Windows needs `CTRL_BREAK` via `GenerateConsoleCtrlEvent` — a distinct change from termination (tracked in the epic #6653).
- A Windows **Job Object** (`KILL_ON_JOB_CLOSE`) would be the race-free "do it properly" version but needs a native addon.