### PR TITLE
fix(desktop): reap orphaned cloudflared on stop so the public tunnel dies with the app

### DIFF
--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -1106,7 +1106,23 @@ impl ServerManager {
     pub fn stop(&mut self) {
         self.user_stopped.store(true, Ordering::Relaxed);
         self.auto_restart_pending.store(false, Ordering::Relaxed);
+        // #6645 — the node server owns cloudflared as a GRANDCHILD. kill_child
+        // only signals the direct child (TerminateProcess on Windows gives it no
+        // cleanup window), so the server's own tunnel.stop() never runs and
+        // cloudflared is orphaned — the public *.trycloudflare.com URL then
+        // outlives the app. kill_orphan_cloudflared previously ran ONLY on
+        // start(), so an orphaned tunnel stayed live between quit and next
+        // launch. Reap it here too (this covers user-stop, window close/exit,
+        // and Drop, which all route through stop()). Only when a child actually
+        // existed — a childless stop() (e.g. unit tests, or stop with no server
+        // running) must NOT spawn a process scan or risk killing an unrelated
+        // cloudflared. No-op when the server already stopped its own tunnel
+        // (graceful POSIX shutdown).
+        let had_child = self.child.is_some();
         self.stop_process();
+        if had_child {
+            Self::kill_orphan_cloudflared(self.config.port, &self.log_buffer);
+        }
     }
 
     /// Restart: stop then start (resets auto-restart state via start()).


### PR DESCRIPTION
## Summary

Fixes #6645 — a Phase 1 safety finding from the Windows/Linux [swarm audit](https://github.com/blamechris/chroxy/blob/main/docs/audit/windows-linux-support-2026-07-14/00-master-assessment.md) (Tunneler F3 / Guardian F5).

The desktop app's node server owns `cloudflared` as a **grandchild**. `kill_child()` only signals the direct child — on Windows `child.kill()` is `TerminateProcess`, which gives the server no cleanup window, so its own `tunnel.stop()` never runs and `cloudflared` is orphaned. `kill_orphan_cloudflared` previously ran **only on `start()`**, so between quit and the next launch the public `*.trycloudflare.com` URL stayed **live and reachable** (fingerprintable via `/health`, open to pairing attempts) with no local UI to stop it.

## Fix

Call `kill_orphan_cloudflared` in `stop()` as well. All the app-exit paths route through `stop()`:
- `WindowEvent::CloseRequested` (lib.rs:1493)
- `RunEvent::ExitRequested` (lib.rs:1517)
- tray "Quit" (lib.rs:1660) and shutdown (lib.rs:2064)
- `Drop for ServerManager` (server.rs)

So user-stop, window close, tray quit, and app exit now tear the public tunnel down immediately.

**Guarded on `had_child`:** a childless `stop()` (unit tests, or stopping when no server is running) must not spawn a `ps`/`wmic` process scan or risk killing an unrelated `cloudflared`. It's also a no-op when the server already stopped its own tunnel (graceful POSIX shutdown).

## Testing

- `cargo test --lib` on Windows: **126/127 pass**, and all `stop*` tests are green. The single failure — `set_node_path_stores_existing_path` — is **pre-existing and unrelated**: it hardcodes the unix path `/usr` ("exists on all systems"), which doesn't exist on Windows, so it fails on a Windows-local run but passes on the macOS CI runner. (This is exactly the kind of Windows-portability gap the audit flagged; folding it into the CI-hardening work under #6651.)

## Not covered (follow-up)

- A **hard app crash** (tray process killed) can't run any cleanup, so `Drop`/`stop()` won't fire. The race-free fix there is a Windows **Job Object** (`KILL_ON_JOB_CLOSE`) tying cloudflared's lifetime to the app — needs a native addon; tracked in the epic (#6653). The `start()`-time `kill_orphan_cloudflared` remains the backstop for that case.