### PR TITLE
fix(server): replace Google-API-key-format test fixture flagged by secret scanning

### DIFF
--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -191,10 +191,12 @@ describe('anthropic-compatible config validation', () => {
     })
 
     it('never echoes an apiKeyEnv value that evades the secret heuristic', () => {
-      // Real keys without a recognized prefix (AIza…-style, short vendor
-      // hex tokens) slip past looksLikeInlineSecret; the invalid-NAME
-      // warning must still not print the value.
-      const evading = 'AIzaSyD-9tSrke72PouQMnMX-a7eZSW0jkFMBWY'
+      // Real keys without a recognized prefix (e.g. Google AIza… keys or
+      // short vendor hex tokens) slip past looksLikeInlineSecret; the
+      // invalid-NAME warning must still not print the value. The fixture
+      // below is a SYNTHETIC non-NAME that evades the heuristic — it is
+      // deliberately NOT in any real key format so secret scanners ignore it.
+      const evading = 'deadbeef-cafef00d-not-a-real-key'
       const { entries, warnings } = validateAnthropicCompatibleProviders([
         makeEntry({ apiKeyEnv: evading }),
       ])


### PR DESCRIPTION
## What

Replace the `apiKeyEnv` test fixture in `anthropic-compatible.test.js` that was in real Google-API-key format (`AIza` + 35 chars) with a synthetic value (`deadbeef-cafef00d-not-a-real-key`) that carries no recognizable secret format.

## Why

GitHub secret scanning flagged the literal (public-leak alert #2, `secret_type=google_api_key`). The value is not a Chroxy credential — it's the canonical **Google Charts GeoChart `mapsApiKey` example** published verbatim in Google's own developer docs, copy-pasted into the test as a realistic-looking placeholder. GitHub's own validity check reports `validity=unknown` (not `active`), and the string is used only as a rejected fixture — never a runtime value. So there is nothing to revoke.

The test itself only needs "a string that slips past `looksLikeInlineSecret` and isn't a valid env-var NAME" to verify the validator doesn't echo secret-like values. The specific literal is irrelevant to the assertions — but the real-key *format* means format-based scanners (trufflehog, gitleaks, pre-commit hooks, fork-level GitHub scanning) will re-flag it indefinitely. Swapping to a non-matching synthetic value stops that recurring noise at zero test-coverage cost.

## Changes

- `packages/server/tests/anthropic-compatible.test.js`: swap the `evading` fixture value; clarify the comment to note the fixture is deliberately not in any real key format. Test intent and all assertions unchanged.

## Verification

- The target test (`never echoes an apiKeyEnv value that evades the secret heuristic`) passes.
- File pass/fail count is unchanged by this edit (verified against the pre-edit file); the pre-existing unrelated failures are environment-specific and not touched by this change.

## Notes

- Resolves the working-tree source of secret-scanning alert #2. The historical commit blob still contains the string, so the alert should be dispositioned as **"used in tests"** — a full history rewrite is out of proportion for a public example placeholder.
