### PR TITLE
docs: add the verified Windows quick-start (local/LAN, no tunnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,21 @@ winget install Git.Git
 # Restart PowerShell so the new tools land on PATH, then:
 git clone https://github.com/blamechris/chroxy
 cd chroxy
-npm install
+npm install          # no Visual Studio / node-gyp needed — node-pty ships prebuilt Windows binaries
+npx chroxy doctor    # verify Node, cloudflared, and the port are ready
 npx chroxy init
 npx chroxy start
 ```
 
 Same QR-code / manual-entry connection flow as macOS. All session features (model switching, files, git, plan mode, agents) work identically.
+
+**Quickest start — local/LAN, no Cloudflare account, no tunnel:**
+
+```powershell
+npx chroxy start --tunnel none --host 127.0.0.1
+```
+
+This binds the server locally and prints a token-gated dashboard URL — open it in any Windows browser for the full chat/terminal UI without installing the desktop app. Drop `--host 127.0.0.1` (the default is `0.0.0.0`) to also reach it from your phone over the LAN. Plain `npx chroxy start` (a Cloudflare Quick Tunnel) works too; if the edge isn't routable yet it degrades to local/LAN instead of aborting, so the daemon always comes up — pass `--tunnel named` for a stable remote URL.
 
 **Run at startup:** native Windows service install is not supported by the CLI. Pick one of:
 - **Task Scheduler** — schedule `node <chroxy-path> start` at logon

--- a/README.md
+++ b/README.md
@@ -339,10 +339,10 @@ Same QR-code / manual-entry connection flow as macOS. All session features (mode
 **Quickest start — local/LAN, no Cloudflare account, no tunnel:**
 
 ```powershell
-npx chroxy start --tunnel none --host 127.0.0.1
+npx chroxy start --tunnel none --host 127.0.0.1 --show-token
 ```
 
-This binds the server locally and prints a token-gated dashboard URL — open it in any Windows browser for the full chat/terminal UI without installing the desktop app. Drop `--host 127.0.0.1` (the default is `0.0.0.0`) to also reach it from your phone over the LAN. Plain `npx chroxy start` (a Cloudflare Quick Tunnel) works too; if the edge isn't routable yet it degrades to local/LAN instead of aborting, so the daemon always comes up — pass `--tunnel named` for a stable remote URL.
+This binds the server locally and prints a **token-gated dashboard URL**. With `--show-token` the printed URL includes the `?token=…`, so you can open it directly in any Windows browser for the full chat/terminal UI — no desktop app needed. (Without the flag the URL and token are masked in the output; add `--show-token`, or append the token yourself.) Drop `--host 127.0.0.1` (the default is `0.0.0.0`) to also reach it from your phone over the LAN. Plain `npx chroxy start` (a Cloudflare Quick Tunnel) works too; if the edge isn't routable yet it degrades to local/LAN instead of aborting — pass `--tunnel named` for a stable remote URL.
 
 **Run at startup:** native Windows service install is not supported by the CLI. Pick one of:
 - **Task Scheduler** — schedule `node <chroxy-path> start` at logon


### PR DESCRIPTION
Closes #6642.

The README's "Running on Windows" section jumped straight to `npx chroxy start` (a Cloudflare Quick Tunnel) and skipped the minimal path that works today with zero setup friction. Adds:

- **Quickest start** — `npx chroxy start --tunnel none --host 127.0.0.1` → token-gated browser dashboard, no desktop app, no Cloudflare account. `0.0.0.0` default reaches it over the LAN from a phone.
- **No build toolchain** — calls out that `npm install` needs no Visual Studio / node-gyp (node-pty ships prebuilt Windows binaries), which the audit verified.
- **`npx chroxy doctor`** as the first-run smoke check.
- Notes the #6641 tunnel **degrade-to-local** behavior so the daemon always comes up, and points at `--tunnel named` for a stable remote URL.

Docs-only. All commands were verified on Windows 11 during the swarm audit (PR #6656).