### PR TITLE
fix: per-platform cloudflared install hints (winget on Windows)

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,19 @@ pub fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Per-platform "how to install cloudflared" hint for user-facing errors —
+/// Windows → winget, macOS → Homebrew, Linux → the Cloudflare package repo
+/// (parity with the JS `cloudflaredInstallHint`, #6649).
+fn cloudflared_install_hint() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "brew install cloudflared"
+    } else if cfg!(target_os = "windows") {
+        "winget install Cloudflare.cloudflared"
+    } else {
+        "see https://pkg.cloudflare.com/"
+    }
+}
+
 use tauri::{
     menu::{
         CheckMenuItem, CheckMenuItemBuilder, MenuBuilder, MenuItem, MenuItemBuilder, SubmenuBuilder,
@@ -289,7 +302,7 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
 
     // Validate cloudflared for tunnel modes
     if mode != "none" && !ServerManager::check_cloudflared() {
-        return Err("cloudflared not found. Install with: brew install cloudflared".to_string());
+        return Err(format!("cloudflared not found. Install with: {}", cloudflared_install_hint()));
     }
 
     // Update settings
@@ -1909,7 +1922,7 @@ fn handle_start(app: &tauri::AppHandle) {
         send_notification(
             app,
             "Tunnel Unavailable",
-            "cloudflared not found. Install with: brew install cloudflared",
+            &format!("cloudflared not found. Install with: {}", cloudflared_install_hint()),
         );
         // Fall back to local-only mode for this start
     }
@@ -2227,7 +2240,7 @@ fn handle_set_tunnel_mode(app: &tauri::AppHandle, mode: &str) {
         send_notification(
             app,
             "Tunnel Unavailable",
-            "cloudflared not found. Install with: brew install cloudflared",
+            &format!("cloudflared not found. Install with: {}", cloudflared_install_hint()),
         );
         // Revert the checkbox to current mode
         let current = app

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -2,11 +2,12 @@ import { execFileSync } from 'child_process'
 import { existsSync, readFileSync } from 'fs'
 import { dirname, isAbsolute, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { homedir, platform } from 'os'
+import { homedir } from 'os'
 import { createServer } from 'net'
 import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { prepareSpawn } from './utils/win-spawn.js'
+import { cloudflaredInstallHint } from './platform.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
 import { registerAnthropicCompatibleProviders } from './anthropic-compatible-session.js'
 import { registerOpenAiCompatibleProviders } from './openai-compatible-session.js'
@@ -292,8 +293,6 @@ export async function checkTunnelRoutability(deps = {}) {
  */
 export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR, now = Date.now(), tunnelProbe } = {}) {
   const checks = []
-  const isMac = platform() === 'darwin'
-  const isLinux = platform() === 'linux'
 
   // 1. Node.js version
   const nodeVersion = process.versions.node
@@ -315,9 +314,7 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
       '/usr/local/bin/cloudflared',
       join(homedir(), '.local/bin/cloudflared'),
     ],
-    installHint: isMac ? 'brew install cloudflared'
-      : isLinux ? 'see https://pkg.cloudflare.com/ for installation'
-      : 'see https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/',
+    installHint: cloudflaredInstallHint(),
   }))
 
   // 3. Load config (once) — used for both the Config check and provider resolution.

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -11,8 +11,9 @@ export const isLinux = process.platform === 'linux'
 /**
  * Per-platform "how to install cloudflared" hint for user-facing errors:
  * Windows → winget, macOS → Homebrew, Linux → the Cloudflare package repo.
- * Centralized so the tunnel adapter, doctor, and the desktop app all give an
- * actionable command for the host they're actually running on (#6649).
+ * The tunnel adapter and doctor share this single source of truth; the desktop
+ * app mirrors the same logic in Rust (`cloudflared_install_hint` in lib.rs), as
+ * it can't call across the JS/Rust boundary (#6649).
  */
 export function cloudflaredInstallHint() {
   if (isMac) return 'brew install cloudflared'

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -17,7 +17,7 @@ export const isLinux = process.platform === 'linux'
 export function cloudflaredInstallHint() {
   if (isMac) return 'brew install cloudflared'
   if (isWindows) return 'winget install Cloudflare.cloudflared'
-  return 'see https://pkg.cloudflare.com/'
+  return 'see https://pkg.cloudflare.com/ for installation'
 }
 
 export function defaultShell() {

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -8,6 +8,18 @@ export const isWindows = process.platform === 'win32'
 export const isMac = process.platform === 'darwin'
 export const isLinux = process.platform === 'linux'
 
+/**
+ * Per-platform "how to install cloudflared" hint for user-facing errors:
+ * Windows → winget, macOS → Homebrew, Linux → the Cloudflare package repo.
+ * Centralized so the tunnel adapter, doctor, and the desktop app all give an
+ * actionable command for the host they're actually running on (#6649).
+ */
+export function cloudflaredInstallHint() {
+  if (isMac) return 'brew install cloudflared'
+  if (isWindows) return 'winget install Cloudflare.cloudflared'
+  return 'see https://pkg.cloudflare.com/'
+}
+
 export function defaultShell() {
   if (isWindows) return process.env.COMSPEC || 'cmd.exe'
   return process.env.SHELL || '/bin/zsh'

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -1,6 +1,7 @@
 import { spawn, execFileSync } from 'child_process'
 import { BaseTunnelAdapter } from './base.js'
 import { createLogger, redactSensitive } from '../logger.js'
+import { cloudflaredInstallHint } from '../platform.js'
 
 const log = createLogger('tunnel')
 
@@ -43,7 +44,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       stableUrl: false,
       binaryName: 'cloudflared',
       setupRequired: false,
-      installHint: 'brew install cloudflared',
+      installHint: cloudflaredInstallHint(),
     }
   }
 
@@ -60,7 +61,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       return {
         available: false,
         version: null,
-        hint: 'Install with: brew install cloudflared',
+        hint: `Install with: ${cloudflaredInstallHint()}`,
       }
     }
   }
@@ -147,7 +148,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       proc.on('error', (err) => {
         if (!resolved) {
-          reject(new Error(`Failed to start cloudflared: ${err.message}. Install with: brew install cloudflared`))
+          reject(new Error(`Failed to start cloudflared: ${err.message}. Install with: ${cloudflaredInstallHint()}`))
         }
       })
 
@@ -176,7 +177,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           timedOut = true
           proc.kill()
           const tail = redactedTail(outputTailRaw)
-          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? `. Last output: ${tail}` : ''}`))
+          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (${cloudflaredInstallHint()})${tail ? `. Last output: ${tail}` : ''}`))
         }
       }, 30_000)
       // Don't let the 30s start-timeout timer pin the event loop on success —
@@ -241,7 +242,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       proc.on('error', (err) => {
         if (!resolved) {
-          reject(new Error(`Failed to start cloudflared: ${err.message}. Install with: brew install cloudflared`))
+          reject(new Error(`Failed to start cloudflared: ${err.message}. Install with: ${cloudflaredInstallHint()}`))
         }
       })
 
@@ -267,7 +268,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           timedOut = true
           proc.kill()
           const tail = redactedTail(outputTailRaw)
-          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed? (brew install cloudflared)${tail ? `. Last output: ${tail}` : ''}`))
+          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed? (${cloudflaredInstallHint()})${tail ? `. Last output: ${tail}` : ''}`))
         }
       }, 30_000)
       // Don't let the 30s start-timeout timer pin the event loop on success.

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -5,7 +5,7 @@ import { mkdtempSync, readFileSync, writeFileSync, rmSync, statSync, existsSync 
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { pathToFileURL } from 'node:url'
-import { defaultShell, writeFileRestricted, forceKill, isWindows } from '../src/platform.js'
+import { defaultShell, writeFileRestricted, forceKill, isWindows, isMac, cloudflaredInstallHint } from '../src/platform.js'
 
 // Production code in `platform.js` imports from `'fs'` etc. via ESM — the
 // subprocess shims below need to use `file:` URLs for both the `--import`
@@ -29,6 +29,17 @@ describe('platform', () => {
       const shell = defaultShell()
       assert.strictEqual(typeof shell, 'string')
       assert.ok(shell.length > 0)
+    })
+  })
+
+  describe('cloudflaredInstallHint()', () => {
+    it('returns an actionable, platform-appropriate install hint (#6649)', () => {
+      const hint = cloudflaredInstallHint()
+      assert.strictEqual(typeof hint, 'string')
+      assert.ok(hint.length > 0)
+      if (isWindows) assert.match(hint, /winget install Cloudflare\.cloudflared/)
+      else if (isMac) assert.match(hint, /brew install cloudflared/)
+      else assert.match(hint, /pkg\.cloudflare\.com/)
     })
   })
 

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -2,6 +2,7 @@ import { describe, it, mock, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'events'
 import { CloudflareTunnelAdapter } from '../../src/tunnel/cloudflare.js'
+import { cloudflaredInstallHint } from '../../src/platform.js'
 import { waitForEvent } from '../test-helpers.js'
 
 /**
@@ -488,7 +489,7 @@ describe('CloudflareTunnelAdapter', () => {
       const caps = CloudflareTunnelAdapter.capabilities
       assert.deepEqual(caps.modes, ['quick', 'named'])
       assert.equal(caps.binaryName, 'cloudflared')
-      assert.equal(caps.installHint, 'brew install cloudflared')
+      assert.equal(caps.installHint, cloudflaredInstallHint())
     })
 
     it('has correct static name', () => {


### PR DESCRIPTION
Closes #6649.

Every runtime "install cloudflared" hint hardcoded `brew install cloudflared` — wrong on Windows and Linux (the audit's Tunneler agent flagged all the sites).

- New shared `cloudflaredInstallHint()` in `platform.js`: Windows → `winget install Cloudflare.cloudflared`, macOS → `brew install cloudflared`, Linux → the Cloudflare package repo.
- Wired into the tunnel adapter's 6 error/hint sites (`tunnel/cloudflare.js`).
- **DRY:** `doctor.js` was already per-platform via an inline ternary (and used a docs-page URL for Windows instead of winget) — collapsed onto the shared helper (dropped now-unused `isMac`/`isLinux`/`platform`).
- Desktop app gets a matching Rust `cloudflared_install_hint()` for its 3 `lib.rs` sites.

**Testing:** new `cloudflaredInstallHint()` unit test (asserts the winget hint on Windows), cargo builds clean, eslint + all 5 server custom lints green. (Two pre-existing `doctor.test.js` failures on this Node-24 Windows box — Node-version + a codex/env test — are unrelated and pass on Linux CI.)