### PR TITLE
docs: document the desktop app's Node 22 prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ This binds the server locally and prints a **token-gated dashboard URL**. With `
 
 Download the latest MSI from the [Releases page](https://github.com/blamechris/chroxy/releases/latest) and double-click to install. WebView2 is preinstalled on Windows 11; on Windows 10, install it once from https://developer.microsoft.com/microsoft-edge/webview2/.
 
+**Prerequisite — Node.js 22.** The MSI bundles the Chroxy server but **not** a Node runtime, so the tray launches the server with your **system Node** (discovered from `%ProgramFiles%\nodejs`, nvm-windows, or `PATH`). Install it first — `winget install OpenJS.NodeJS.LTS` — otherwise the tray window opens but the server won't start (you'll see a "Node not found" message; install Node 22+ and use the tray's Start/Restart).
+
 ### Desktop tray app — build from source
 
 Only needed if you want to compile locally:

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ This binds the server locally and prints a **token-gated dashboard URL**. With `
 
 Download the latest MSI from the [Releases page](https://github.com/blamechris/chroxy/releases/latest) and double-click to install. WebView2 is preinstalled on Windows 11; on Windows 10, install it once from https://developer.microsoft.com/microsoft-edge/webview2/.
 
-**Prerequisite — Node.js 22.** The MSI bundles the Chroxy server but **not** a Node runtime, so the tray launches the server with your **system Node** (discovered from `%ProgramFiles%\nodejs`, nvm-windows, or `PATH`). Install it first — `winget install OpenJS.NodeJS.LTS` — otherwise the tray window opens but the server won't start (you'll see a "Node not found" message; install Node 22+ and use the tray's Start/Restart).
+**Prerequisite — Node.js 22.** The MSI bundles the Chroxy server but **not** a Node runtime, so the tray launches the server with your **system Node** (discovered from `%ProgramFiles%\nodejs`, nvm-windows, or `PATH`). Install it first — `winget install OpenJS.NodeJS.LTS` — otherwise the tray window opens but the server won't start, failing with a "Could not find Node.js >= 22" error (the in-app hint points to nodejs.org / nvm-windows). Install Node 22+, then use the tray's Start/Restart.
 
 ### Desktop tray app — build from source
 


### PR DESCRIPTION
Closes #6650.

The Windows MSI bundles the Chroxy server JS but **not** a Node runtime — the tray spawns the server with the user's **system Node** (`node.rs` `resolve_node22` discovers `%ProgramFiles%\nodejs`, nvm-windows, or `PATH`; requires >=22). This wasn't documented, so a clean box with no Node gets a tray window that opens but can't start the server. Adds a **Prerequisite — Node.js 22** note to the Desktop tray section with the winget command and the failure symptom. Docs-only.