### PR TITLE
docs: WSL2 story + explicit .sh LF guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
 * text=auto eol=lf
 
+# Shell scripts MUST stay LF even on a Windows checkout with core.autocrlf=true —
+# CRLF breaks direct execution under WSL/Linux (`./script.sh` -> `bash\r: not
+# found`). Explicit over the `* eol=lf` rule above so it can never fall back to
+# content auto-detection (#6652).
+*.sh text eol=lf
+
 *.png binary
 *.jpg binary
 *.jpeg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 * text=auto eol=lf
 
 # Shell scripts MUST stay LF even on a Windows checkout with core.autocrlf=true —
-# CRLF breaks direct execution under WSL/Linux (`./script.sh` -> `bash\r: not
-# found`). Explicit over the `* eol=lf` rule above so it can never fall back to
-# content auto-detection (#6652).
+# CRLF breaks direct execution under WSL/Linux (`./script.sh` fails with
+# `bash\r: not found`). Explicit over the `* text=auto eol=lf` rule above so a
+# .sh can never fall back to content auto-detection (#6652).
 *.sh text eol=lf
 
 *.png binary

--- a/README.md
+++ b/README.md
@@ -377,6 +377,21 @@ cargo tauri build
 
 The MSI lands at `packages\desktop\src-tauri\target\release\bundle\msi\Chroxy_<version>_x64_en-US.msi`.
 
+### Running the Linux server under WSL2
+
+If you want the exact Linux runtime, run the daemon inside WSL2 instead of the native-Windows server. Verified on Ubuntu:
+
+```bash
+# Inside WSL2 (Ubuntu) — clone NATIVELY (not under /mnt/c; see the note below)
+git clone https://github.com/blamechris/chroxy && cd chroxy
+npm install                       # a native Linux install — node-pty needs its Linux prebuild
+npx chroxy start --host 0.0.0.0   # 0.0.0.0 is required to reach it from Windows
+```
+
+- **Reaching it from Windows:** WSL2's localhost-forwarding only forwards to a **`0.0.0.0`-bound** server, so `http://localhost:8765` works from a Windows browser. A `--host 127.0.0.1` bind is **not** forwarded and silently isolates the daemon inside WSL — use `--host 0.0.0.0` (chroxy's default) here.
+- **Phone / remote access:** WSL2 sits behind NAT, so run the Cloudflare tunnel **inside** WSL2 (its outbound connection traverses the NAT cleanly): install `cloudflared` in the distro, then plain `npx chroxy start`. Exposing a WSL2 port inbound instead would need a Windows-side `netsh interface portproxy` rule.
+- **Clone natively, not from `/mnt/c`:** a Windows checkout mounted at `/mnt/c` carries two hazards — node-pty's Windows prebuilds don't load under Linux (hence the native `npm install`), and `.sh` scripts a Windows checkout wrote with `core.autocrlf` have CRLF endings that break `./script.sh` (`bash script.sh` tolerates it). The repo stores every script LF (`.gitattributes`), so a native WSL clone is clean.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
Closes #6652.

**WSL2 docs** (new README subsection under Running on Windows): run the Linux daemon inside WSL2 — native clone (not `/mnt/c`), native `npm install` (node-pty needs its Linux prebuild), bind `--host 0.0.0.0` (WSL2 localhost-forwarding only forwards 0.0.0.0; `127.0.0.1` silently isolates it), and run `cloudflared` **inside** WSL2 for phone access (WSL2 NAT — outbound tunnel traverses it; inbound would need `netsh portproxy`). All verified on Ubuntu during the audit.

**CRLF:** investigation shows the repo already stores every `.sh` as LF (`git ls-files --eol` → `i/lf`), so a fresh/native clone is clean and CI (Linux) is unaffected — the CRLF the audit observed is a local `core.autocrlf=true` working-tree artifact that only breaks `./script.sh` run directly from a `/mnt/c` Windows checkout (`bash script.sh` tolerates it). Added an explicit `*.sh text eol=lf` rule (over the broad `* eol=lf`) as a belt-and-suspenders guard, mirroring the repo's existing explicit-attribute pattern. Docs-only + one gitattributes line.