### PR TITLE
fix(server): make the embedded user-shell launch on Windows

### DIFF
--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -21,9 +21,15 @@ export function cloudflaredInstallHint() {
   return 'see https://pkg.cloudflare.com/ for installation'
 }
 
-export function defaultShell() {
-  if (isWindows) return process.env.COMSPEC || 'cmd.exe'
-  return process.env.SHELL || '/bin/zsh'
+/**
+ * The OS default shell: Windows → `COMSPEC` (cmd.exe), POSIX → `$SHELL`
+ * (falling back to zsh). `platform`/`env` are injectable so callers that resolve
+ * a shell for a spawn (e.g. the embedded user-shell, #6646) can unit-test both
+ * platform branches on any CI host; production calls pass no args.
+ */
+export function defaultShell({ platform = process.platform, env = process.env } = {}) {
+  if (platform === 'win32') return env.COMSPEC || 'cmd.exe'
+  return env.SHELL || '/bin/zsh'
 }
 
 /**

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -18,6 +18,7 @@ import { realpathSync, existsSync } from 'fs'
 import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
+import { isWindows, defaultShell, killProcessTree } from './platform.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 
 const log = createLogger('user-shell-session')
@@ -31,17 +32,43 @@ const MIRROR_FLUSH_MS = 50
 // SIGTERM → grace → SIGKILL the process group on destroy.
 const DESTROY_GRACE_MS = 3000
 
+// Windows PowerShell 5.1 ships in-box at this fixed System32 path on every
+// Windows install (the `v1.0` dir name is a historical constant, not the PS
+// version). Preferred over cmd.exe for a real interactive terminal.
+const WIN_POWERSHELL_RELATIVE = 'System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
 /**
- * Resolve the shell to spawn: `$SHELL` if it exists, then common fallbacks.
- * Returns the first path that exists; if none do (a truly unusual host), falls
- * back to `/bin/sh` as a last resort — start() then surfaces a clean spawn error
- * if that path is also missing.
+ * Resolve the interactive shell to spawn.
+ *
+ * POSIX: `$SHELL` if it exists, then `/bin/zsh|bash|sh`, then `/bin/sh` as a
+ * last resort (start() surfaces a clean spawn error if even that is missing).
+ *
+ * Windows (#6646): the POSIX candidates never exist, so the old code returned
+ * `/bin/sh` and node-pty's spawn always failed — the embedded shell never
+ * launched. Prefer a real interactive shell instead: an explicit `$SHELL` that
+ * exists wins (lets a user pin e.g. `pwsh.exe`), then Windows PowerShell 5.1 at
+ * its fixed System32 path, then `defaultShell()` (COMSPEC/cmd.exe).
+ *
+ * `platform`/`env`/`exists` are injectable so both platform branches are
+ * unit-testable on any CI host — the Windows path can't rely on a Windows
+ * runner being present. Production callers pass no args.
  */
-function resolveShell() {
-  const shell = process.env.SHELL
-  if (typeof shell === 'string' && shell && existsSync(shell)) return shell
+export function resolveShell({
+  platform = process.platform,
+  env = process.env,
+  exists = existsSync,
+} = {}) {
+  const shell = env.SHELL
+  if (platform === 'win32') {
+    if (typeof shell === 'string' && shell && exists(shell)) return shell
+    const systemRoot = env.SystemRoot || env.windir || 'C:\\Windows'
+    const winPowerShell = `${systemRoot}\\${WIN_POWERSHELL_RELATIVE}`
+    if (exists(winPowerShell)) return winPowerShell
+    return defaultShell({ platform, env })
+  }
+  if (typeof shell === 'string' && shell && exists(shell)) return shell
   for (const cand of ['/bin/zsh', '/bin/bash', '/bin/sh']) {
-    if (existsSync(cand)) return cand
+    if (exists(cand)) return cand
   }
   return '/bin/sh'
 }
@@ -99,6 +126,9 @@ export class UserShellSession extends BaseSession {
     this._mirrorTimer = null
     this._terminalMirrorActive = false
     this._killTimer = null
+    // Windows tree-reaper for destroy() (taskkill /T /F). Injectable so a test
+    // can assert the Windows branch without spawning a real taskkill (#6646).
+    this._killProcessTree = killProcessTree
   }
 
   /**
@@ -351,10 +381,19 @@ export class UserShellSession extends BaseSession {
   }
 
   /**
-   * Kill the PTY (no respawn) and clear all timers. SIGTERM, then after a grace
-   * window SIGKILL the whole process group so backgrounded jobs die too. The
-   * liveness probe + _ptyExited latch narrow escalation to a genuinely-hung
-   * shell (never a recycled pid).
+   * Kill the PTY (no respawn) and clear all timers.
+   *
+   * POSIX: SIGTERM, then after a grace window SIGKILL the whole process GROUP so
+   * backgrounded jobs die too. The liveness probe + `_ptyExited` latch narrow
+   * escalation to a genuinely-hung shell (never a recycled pid).
+   *
+   * Windows (#6646): there is no graceful SIGTERM (node-pty maps `kill()` to
+   * `TerminateProcess` on the direct pid) and no process groups, so a direct
+   * kill would orphan the shell's children — acute here because a shell often
+   * launches `.cmd`/`.bat` wrappers whose real process is a grandchild. Reap the
+   * whole descendant tree at once with `taskkill /PID <pid> /T /F` (via
+   * killProcessTree); no grace window, since the shell can't run a SIGTERM
+   * handler on Windows anyway.
    */
   destroy() {
     // Idempotent: a second destroy() (or a destroy racing the exit path) is a
@@ -370,27 +409,32 @@ export class UserShellSession extends BaseSession {
     }
     this._mirrorBuffer = ''
 
+    const onWindows = this._isWindowsOverride ?? isWindows
     const term = this._term
     const pid = term?.pid
     if (term && !this._ptyExited) {
-      try { term.kill('SIGTERM') } catch { /* already gone */ }
-      if (Number.isInteger(pid) && pid > 0) {
-        this._killTimer = setTimeout(() => {
-          this._killTimer = null
-          if (this._ptyExited) return
-          try { process.kill(pid, 0) } catch { return /* already exited */ }
-          log.warn(`user-shell PTY (pid=${pid}) did not exit ${DESTROY_GRACE_MS}ms after SIGTERM — escalating to SIGKILL`)
-          let killed = false
-          if (process.platform !== 'win32') {
-            try { process.kill(-pid, 'SIGKILL'); killed = true } catch { /* group gone */ }
-          }
-          if (!killed) {
-            try { term.kill('SIGKILL') } catch {
-              try { process.kill(pid, 'SIGKILL') } catch { /* already gone */ }
+      if (onWindows) {
+        this._killProcessTree(term, { force: true })
+      } else {
+        try { term.kill('SIGTERM') } catch { /* already gone */ }
+        if (Number.isInteger(pid) && pid > 0) {
+          this._killTimer = setTimeout(() => {
+            this._killTimer = null
+            if (this._ptyExited) return
+            try { process.kill(pid, 0) } catch { return /* already exited */ }
+            log.warn(`user-shell PTY (pid=${pid}) did not exit ${DESTROY_GRACE_MS}ms after SIGTERM — escalating to SIGKILL`)
+            // SIGKILL the whole process group so backgrounded jobs die too; fall
+            // back to the direct pid if the group is already gone.
+            try {
+              process.kill(-pid, 'SIGKILL')
+            } catch {
+              try { term.kill('SIGKILL') } catch {
+                try { process.kill(pid, 'SIGKILL') } catch { /* already gone */ }
+              }
             }
-          }
-        }, DESTROY_GRACE_MS)
-        if (typeof this._killTimer.unref === 'function') this._killTimer.unref()
+          }, DESTROY_GRACE_MS)
+          if (typeof this._killTimer.unref === 'function') this._killTimer.unref()
+        }
       }
     }
     this._term = null

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -198,9 +198,11 @@ export class UserShellSession extends BaseSession {
     }
 
     // destroy() can race the spawn (it set _destroying while we awaited the
-    // import): kill the fresh PTY so it isn't orphaned, then bail.
+    // import): reap the fresh PTY so it isn't orphaned, then bail. Uses the same
+    // Windows tree-kill as destroy() (#6646) — a shell rc/profile can spawn a
+    // child immediately, so a direct kill on Windows would orphan it here too.
     if (this._destroying) {
-      try { this._term.kill('SIGTERM') } catch { /* already gone */ }
+      this._reapTerm(this._term)
       this._term = null
       return
     }
@@ -450,6 +452,24 @@ export class UserShellSession extends BaseSession {
     if (this._killTimer) {
       clearTimeout(this._killTimer)
       this._killTimer = null
+    }
+  }
+
+  /**
+   * One-shot teardown of a term with no grace window — used by the start()
+   * destroy-race path where the shell was just spawned. POSIX: a direct SIGTERM
+   * (nothing is running in the fresh shell to gracefully save). Windows (#6646):
+   * the whole descendant tree via taskkill /T /F (a shell rc/profile may already
+   * have spawned a child, and node-pty's kill() would orphan it). destroy()'s
+   * own kill path stays separate because it adds the POSIX grace-escalation.
+   */
+  _reapTerm(term) {
+    if (!term) return
+    const onWindows = this._isWindowsOverride ?? isWindows
+    if (onWindows) {
+      this._killProcessTree(term, { force: true })
+    } else {
+      try { term.kill('SIGTERM') } catch { /* already gone */ }
     }
   }
 }

--- a/packages/server/src/user-shell-session.js
+++ b/packages/server/src/user-shell-session.js
@@ -29,7 +29,9 @@ const DEFAULT_COLS = 120
 const DEFAULT_ROWS = 30
 // Coalesce PTY bytes into one terminal_output per tick (bounds broadcast churn).
 const MIRROR_FLUSH_MS = 50
-// SIGTERM → grace → SIGKILL the process group on destroy.
+// POSIX destroy() escalation window: SIGTERM → grace → SIGKILL the process
+// group. Windows has no grace — destroy() reaps the whole tree at once via
+// taskkill (#6646), so this constant is POSIX-only.
 const DESTROY_GRACE_MS = 3000
 
 // Windows PowerShell 5.1 ships in-box at this fixed System32 path on every

--- a/packages/server/tests/user-shell-session.test.js
+++ b/packages/server/tests/user-shell-session.test.js
@@ -223,6 +223,29 @@ describe('UserShellSession — lifecycle (#5983)', () => {
     assert.equal(s._shellAlive, false)
   })
 
+  it('_reapTerm (start destroy-race): POSIX SIGTERMs, Windows tree-kills (#6646)', () => {
+    // POSIX branch — direct SIGTERM, no tree-kill.
+    const posix = makeLiveShell()
+    posix._isWindowsOverride = false
+    const posixTree = []
+    posix._killProcessTree = (t) => posixTree.push(t.pid)
+    posix._reapTerm(posix._term)
+    assert.deepEqual(posix._term._calls.kill, ['SIGTERM'])
+    assert.equal(posixTree.length, 0, 'POSIX never tree-kills')
+
+    // Windows branch — tree-kill, no direct signal.
+    const win = makeLiveShell()
+    win._isWindowsOverride = true
+    const winTree = []
+    win._killProcessTree = (t, opts) => winTree.push({ pid: t.pid, opts })
+    win._reapTerm(win._term)
+    assert.deepEqual(winTree, [{ pid: 4242, opts: { force: true } }])
+    assert.deepEqual(win._term._calls.kill, [], 'Windows reaps the tree, no direct kill')
+
+    // null term is a no-op (never reached in practice, but defensive).
+    assert.doesNotThrow(() => posix._reapTerm(null))
+  })
+
   it('destroy after exit does not double-kill (either platform)', () => {
     for (const onWindows of [false, true]) {
       const s = makeLiveShell()

--- a/packages/server/tests/user-shell-session.test.js
+++ b/packages/server/tests/user-shell-session.test.js
@@ -100,6 +100,13 @@ describe('resolveShell (#6646)', () => {
     )
   })
 
+  it('Windows: $SHELL set but non-existent falls through to PowerShell (not honoured)', () => {
+    assert.equal(
+      resolveShell({ platform: 'win32', env: { SHELL: 'C:\\nope\\bad.exe', SystemRoot: 'C:\\Windows' }, exists: (p) => p === WIN_PS }),
+      WIN_PS,
+    )
+  })
+
   it('Windows: falls back to COMSPEC/cmd.exe (defaultShell) when PowerShell is absent', () => {
     const cmd = 'C:\\Windows\\System32\\cmd.exe'
     assert.equal(

--- a/packages/server/tests/user-shell-session.test.js
+++ b/packages/server/tests/user-shell-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { UserShellSession } from '../src/user-shell-session.js'
+import { UserShellSession, resolveShell } from '../src/user-shell-session.js'
 import { getProvider, validateProviderClass } from '../src/providers.js'
 
 /**
@@ -61,6 +61,61 @@ describe('UserShellSession — class contract (#5983)', () => {
     const s = new UserShellSession({ cwd: '/tmp' })
     assert.equal(s.sendMessage('hi'), false)
     assert.equal(s.interrupt(), false)
+  })
+})
+
+describe('resolveShell (#6646)', () => {
+  const WIN_PS = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
+  it('POSIX: honours $SHELL when it exists', () => {
+    assert.equal(
+      resolveShell({ platform: 'linux', env: { SHELL: '/usr/bin/fish' }, exists: (p) => p === '/usr/bin/fish' }),
+      '/usr/bin/fish',
+    )
+  })
+
+  it('POSIX: falls back through zsh/bash/sh, then /bin/sh as last resort', () => {
+    assert.equal(
+      resolveShell({ platform: 'linux', env: {}, exists: (p) => p === '/bin/bash' }),
+      '/bin/bash',
+    )
+    assert.equal(
+      resolveShell({ platform: 'linux', env: {}, exists: () => false }),
+      '/bin/sh',
+    )
+  })
+
+  it('Windows: prefers Windows PowerShell 5.1 at the fixed System32 path', () => {
+    assert.equal(
+      resolveShell({ platform: 'win32', env: { SystemRoot: 'C:\\Windows' }, exists: (p) => p === WIN_PS }),
+      WIN_PS,
+    )
+  })
+
+  it('Windows: an explicit $SHELL that exists wins (pin pwsh.exe)', () => {
+    const pwsh = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+    assert.equal(
+      resolveShell({ platform: 'win32', env: { SHELL: pwsh, SystemRoot: 'C:\\Windows' }, exists: (p) => p === pwsh }),
+      pwsh,
+    )
+  })
+
+  it('Windows: falls back to COMSPEC/cmd.exe (defaultShell) when PowerShell is absent', () => {
+    const cmd = 'C:\\Windows\\System32\\cmd.exe'
+    assert.equal(
+      resolveShell({ platform: 'win32', env: { SystemRoot: 'C:\\Windows', COMSPEC: cmd }, exists: () => false }),
+      cmd,
+    )
+    assert.equal(
+      resolveShell({ platform: 'win32', env: {}, exists: () => false }),
+      'cmd.exe',
+      'bare cmd.exe when COMSPEC is unset',
+    )
+  })
+
+  it('never returns a POSIX /bin path on Windows (the #6646 spawn-failure regression)', () => {
+    const resolved = resolveShell({ platform: 'win32', env: { SystemRoot: 'C:\\Windows' }, exists: (p) => p === WIN_PS })
+    assert.doesNotMatch(resolved, /^\/bin\//, 'a /bin/* shell would fail node-pty spawn on Windows')
   })
 })
 
@@ -141,8 +196,9 @@ describe('UserShellSession — lifecycle (#5983)', () => {
     assert.equal(typeof s.start, 'function')
   })
 
-  it('destroy SIGTERMs the live PTY, clears timers, and stops being runnable', () => {
+  it('destroy (POSIX) SIGTERMs the live PTY, clears timers, and stops being runnable', () => {
     const s = makeLiveShell()
+    s._isWindowsOverride = false // force the POSIX branch regardless of test host
     const term = s._term
     s.destroy()
     assert.deepEqual(term._calls.kill, ['SIGTERM'])
@@ -152,12 +208,33 @@ describe('UserShellSession — lifecycle (#5983)', () => {
     assert.equal(s._mirrorTimer, null)
   })
 
-  it('destroy after exit does not double-kill', () => {
+  it('destroy (Windows) reaps the whole tree via taskkill, no SIGTERM/grace timer (#6646)', () => {
     const s = makeLiveShell()
+    s._isWindowsOverride = true // force the Windows branch regardless of test host
+    const treeKills = []
+    s._killProcessTree = (t, opts) => treeKills.push({ pid: t.pid, opts })
     const term = s._term
-    s._onShellExit({ exitCode: 0 }, 'exit')
     s.destroy()
-    assert.equal(term._calls.kill.length, 0, 'no SIGTERM — PTY already exited')
+    assert.deepEqual(treeKills, [{ pid: 4242, opts: { force: true } }],
+      'the whole descendant tree is force-reaped in one taskkill /T /F')
+    assert.deepEqual(term._calls.kill, [], 'no direct SIGTERM/SIGKILL — the tree-kill is the teardown')
+    assert.equal(s._killTimer, null, 'no POSIX grace-escalation timer on Windows')
+    assert.equal(s._term, null)
+    assert.equal(s._shellAlive, false)
+  })
+
+  it('destroy after exit does not double-kill (either platform)', () => {
+    for (const onWindows of [false, true]) {
+      const s = makeLiveShell()
+      s._isWindowsOverride = onWindows
+      const treeKills = []
+      s._killProcessTree = (t) => treeKills.push(t.pid)
+      const term = s._term
+      s._onShellExit({ exitCode: 0 }, 'exit')
+      s.destroy()
+      assert.equal(term._calls.kill.length, 0, 'no signal — PTY already exited')
+      assert.equal(treeKills.length, 0, 'no taskkill — PTY already exited')
+    }
   })
 
   describe('_buildShellEnv secret stripping (#6311)', () => {


### PR DESCRIPTION
## Problem
`resolveShell()` in `user-shell-session.js` only knew POSIX shells (`$SHELL`, `/bin/zsh|bash|sh`) and returned `/bin/sh` as a last resort. On Windows none of those exist, so node-pty's spawn always failed and the embedded user-shell (epic #5982) **never launched**. Ironically `platform.js` already exported a correct `defaultShell()` (COMSPEC/cmd.exe) that this code ignored. The `destroy()` path also skipped tree-kill on Windows.

## Fix
- **`resolveShell()`** — Windows branch: honour an explicit `$SHELL` that exists (lets a user pin `pwsh.exe`), then **Windows PowerShell 5.1** at its fixed System32 path, then **`defaultShell()`** (COMSPEC/cmd.exe). POSIX path unchanged.
- **`defaultShell()`** — gains injectable `platform`/`env` (backward-compatible defaults) so both resolvers are unit-testable on any CI host. It had **no callers** before this.
- **`destroy()`** — Windows now reaps the whole descendant tree with `taskkill /PID <pid> /T /F` (via the existing tested `killProcessTree`), since node-pty maps `kill()` to `TerminateProcess` on the direct pid and a shell's `.cmd`/`.bat` wrapper grandchildren would otherwise be orphaned. POSIX keeps its SIGTERM → grace → **group**-SIGKILL escalation.

## Tests
- New `resolveShell` DI tests cover **both** platform branches deterministically on the Linux runner (PowerShell-preferred, `$SHELL` pin, COMSPEC fallback, and a guard that it never returns a `/bin/*` path on Windows).
- `destroy` tests split into a forced-POSIX case (`['SIGTERM']`) and a forced-Windows case (asserts the tree-kill fires, no SIGTERM, no grace timer); double-kill-after-exit covered on both platforms.

## Verified on Windows 11 (this host)
Real node-pty spawn of the resolved shell — the PTY opens and executes a command in both cases:
- `$SHELL` unset (daemon case) → `C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe` → **PASS**
- `$SHELL` set → honoured shell → **PASS**

Closes #6646