### PR TITLE
feat(desktop): add bundle.windows config + drop the macOS speech-helper from Win/Linux bundles

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -37,14 +37,21 @@
       "icons/icon.png"
     ],
     "resources": {
-      "server-bundle": "server",
-      "swift/speech-helper": "speech-helper"
+      "server-bundle": "server"
     },
     "createUpdaterArtifacts": true,
     "macOS": {
       "signingIdentity": "$APPLE_SIGNING_IDENTITY",
       "infoPlist": "Info.plist",
       "entitlements": "entitlements.plist"
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper"
+      },
+      "nsis": {
+        "installMode": "currentUser"
+      }
     }
   },
   "plugins": {

--- a/packages/desktop/src-tauri/tauri.macos.conf.json
+++ b/packages/desktop/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,8 @@
+{
+  "bundle": {
+    "resources": {
+      "server-bundle": "server",
+      "swift/speech-helper": "speech-helper"
+    }
+  }
+}


### PR DESCRIPTION
## Problem
`tauri.conf.json` had a `bundle.macOS` block but **no `bundle.windows`**, so:
- WebView2 was online-bootstrap-only.
- The WiX MSI was per-machine/admin with no per-user option.
- The macOS `swift/speech-helper` (208KB Mach-O) shipped as a **shared** resource inside every Windows MSI and Linux bundle as dead weight.

## Fix (config only — CI-verifiable)
- **Scope the speech-helper out of Win/Linux**: moved `swift/speech-helper` from the shared `bundle.resources` into a new `tauri.macos.conf.json` overlay, which Tauri v2 **auto-merges only on macOS builds**. Windows/Linux bundles no longer carry the Mach-O.
- **`bundle.windows.webviewInstallMode = embedBootstrapper`**: the WebView2 bootstrapper ships inside the installer (no online-only bootstrap). On the Win11 target (WebView2 preinstalled) no download occurs; the embedded bootstrapper is the offline fallback. (Chose `embedBootstrapper` over `offlineInstaller` to avoid ~150 MB of runtime bloat that Win11 never needs.)
- **`bundle.windows.nsis.installMode = currentUser`**: a per-user, non-elevated NSIS install target alongside the per-machine WiX MSI.

## Verification
- **JSON valid**; the per-PR **Desktop Rust Tests** jobs (all 3 platforms) parse the config via `build.rs`, so an invalid `bundle.windows` key fails CI.
- **Per-platform merge simulated** (replicating Tauri's deep merge of `tauri.macos.conf.json`):
  | platform | `bundle.resources` |
  |---|---|
  | windows | `["server-bundle"]` |
  | linux | `["server-bundle"]` |
  | macos | `["server-bundle", "swift/speech-helper"]` |
  Since Tauri bundles **exactly** the declared resources, the Mach-O can no longer land in the Windows MSI or Linux bundle (**AC #4**), while macOS keeps it (no voice-to-text regression).

## Scope / follow-up
This PR is the **config** half. Actually building + signing + uploading the NSIS installer in the release pipeline (`--bundles msi,nsis`) is untestable outside a tagged release build and touches critical release infra, so it's tracked separately in #6667. A literal MSI-content inspection likewise needs a real release build.

Closes #6648