### PR TITLE
feat(server): env-overridable claude-tui READY_QUIESCENCE_MS + pin the per-spawn reset

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1232,8 +1232,12 @@ export class ClaudeTuiSession extends BaseSession {
   // early the #5794 first-turn nudge (a bare `\r` re-send) is the backstop that
   // recovers the composer — an early fire is a brief wedge at worst (#6603).
   static get READY_QUIESCENCE_MS() {
-    const override = parseInt(process.env.CHROXY_TUI_READY_QUIESCENCE_MS || '', 10)
-    return Number.isFinite(override) && override > 0 ? override : 400
+    // Strict digits-only (after trim) so a partial-numeric value like "1200ms"
+    // is rejected → 400, matching the documented "positive integer" contract
+    // (parseInt alone would silently accept "1200ms" as 1200).
+    const raw = (process.env.CHROXY_TUI_READY_QUIESCENCE_MS || '').trim()
+    const override = /^\d+$/.test(raw) ? parseInt(raw, 10) : NaN
+    return override > 0 ? override : 400
   }
   // #5317 (WP-2.3) — grace window between destroy()'s SIGTERM and the SIGKILL
   // escalation. Long enough for claude to flush its Stop hook + reap its own

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2144,6 +2144,19 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
+   * #6601: reset the output-quiescence readiness state for a fresh (re)spawn —
+   * clear the "saw first output" gate and re-stamp `_lastOutputMs` to now, so a
+   * leftover `_lastOutputMs` from the prior process can't read as "ready" the
+   * instant we respawn. The counterpart to `_appendToOutputTail` (which SETS
+   * these). Extracted from `_spawnPty` so the guard is unit-testable without a
+   * real PTY (#6604).
+   */
+  _resetQuiescenceForSpawn() {
+    this._sawFirstOutput = false
+    this._lastOutputMs = this._nowMonotonic()
+  }
+
+  /**
    * Append a PTY onData chunk to the recent-output tails (#3919).
    *
    * Maintains two tails:
@@ -2161,19 +2174,6 @@ export class ClaudeTuiSession extends BaseSession {
    * visual-render the PTY, so the colors aren't useful. Strip pattern
    * covers CSI / OSC / SS3 / single-char terminal-mode codes (#4031).
    */
-  /**
-   * #6601: reset the output-quiescence readiness state for a fresh (re)spawn —
-   * clear the "saw first output" gate and re-stamp `_lastOutputMs` to now, so a
-   * leftover `_lastOutputMs` from the prior process can't read as "ready" the
-   * instant we respawn. The counterpart to `_appendToOutputTail` (which SETS
-   * these). Extracted from `_spawnPty` so the guard is unit-testable without a
-   * real PTY (#6604).
-   */
-  _resetQuiescenceForSpawn() {
-    this._sawFirstOutput = false
-    this._lastOutputMs = this._nowMonotonic()
-  }
-
   _appendToOutputTail(data) {
     // #6601: output-quiescence readiness — stamp the recency of PTY output so
     // checkReady can detect a settled composer (see READY_QUIESCENCE_MS) when no

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1223,7 +1223,18 @@ export class ClaudeTuiSession extends BaseSession {
   // redraw sub-second (vs the 5s per-turn ceiling). Comfortably above the observed
   // intra-render gaps (~270ms) so it can't false-trigger mid-render; the
   // warmup/turn ceilings still backstop a genuinely-stuck TUI.
-  static get READY_QUIESCENCE_MS() { return 400 }
+  //
+  // Override with CHROXY_TUI_READY_QUIESCENCE_MS (positive integer ms) to widen
+  // the window on a flaky/slow host — a genuine mid-warmup pause (MCP enumeration,
+  // a slow skills-dir read, a loaded host) exceeding 400ms would fire quiescence
+  // early and land the throttled prompt on a not-yet-ready composer. In the
+  // no-session-file case quiescence is the only readiness signal, so if it fires
+  // early the #5794 first-turn nudge (a bare `\r` re-send) is the backstop that
+  // recovers the composer — an early fire is a brief wedge at worst (#6603).
+  static get READY_QUIESCENCE_MS() {
+    const override = parseInt(process.env.CHROXY_TUI_READY_QUIESCENCE_MS || '', 10)
+    return Number.isFinite(override) && override > 0 ? override : 400
+  }
   // #5317 (WP-2.3) — grace window between destroy()'s SIGTERM and the SIGKILL
   // escalation. Long enough for claude to flush its Stop hook + reap its own
   // tool children on a clean SIGTERM, short enough that a hung claude (or a
@@ -1900,9 +1911,8 @@ export class ClaudeTuiSession extends BaseSession {
     this._outputTailRaw = Buffer.alloc(0)
     // #6601: re-evaluate output-quiescence readiness for THIS spawn — require
     // fresh output before trusting a quiet stretch, so a leftover _lastOutputMs
-    // from the prior process can't read as "ready" the instant we respawn.
-    this._sawFirstOutput = false
-    this._lastOutputMs = this._nowMonotonic()
+    // from the prior process can't read as "ready" the instant we respawn (#6604).
+    this._resetQuiescenceForSpawn()
 
     // #5794: a fresh PTY can swallow the first submit again, so re-arm the
     // first-turn submit nudge for the first message on THIS spawn. Reset after
@@ -2151,6 +2161,19 @@ export class ClaudeTuiSession extends BaseSession {
    * visual-render the PTY, so the colors aren't useful. Strip pattern
    * covers CSI / OSC / SS3 / single-char terminal-mode codes (#4031).
    */
+  /**
+   * #6601: reset the output-quiescence readiness state for a fresh (re)spawn —
+   * clear the "saw first output" gate and re-stamp `_lastOutputMs` to now, so a
+   * leftover `_lastOutputMs` from the prior process can't read as "ready" the
+   * instant we respawn. The counterpart to `_appendToOutputTail` (which SETS
+   * these). Extracted from `_spawnPty` so the guard is unit-testable without a
+   * real PTY (#6604).
+   */
+  _resetQuiescenceForSpawn() {
+    this._sawFirstOutput = false
+    this._lastOutputMs = this._nowMonotonic()
+  }
+
   _appendToOutputTail(data) {
     // #6601: output-quiescence readiness — stamp the recency of PTY output so
     // checkReady can detect a settled composer (see READY_QUIESCENCE_MS) when no

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1761,6 +1761,46 @@ describe('ClaudeTuiSession', () => {
       assert.equal(ready, false, 'status=busy file wins over quiescence')
     })
 
+    it('#6604 the per-spawn reset drops a previously-quiesced session back to not-ready until fresh output', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {}, pid: fakePid }
+
+      // A session that HAD rendered and quiesced reads ready...
+      session._sawFirstOutput = true
+      session._lastOutputMs = session._nowMonotonic() - (ClaudeTuiSession.READY_QUIESCENCE_MS + 200)
+      assert.equal(await session._waitForPrompt(100), true, 'sanity: a quiesced session reads ready')
+
+      // ...but the per-spawn reset (run by _spawnPty on every respawn) must drop it
+      // back to not-ready — the stale _lastOutputMs can't count until fresh output.
+      session._resetQuiescenceForSpawn()
+      assert.equal(session._sawFirstOutput, false, 'reset clears the saw-first-output gate')
+      assert.equal(await session._waitForPrompt(50), false,
+        'respawn reset reads not-ready despite the leftover (stale) _lastOutputMs')
+
+      // Fresh output on the new spawn re-arms the gate; once it quiesces, ready again.
+      session._appendToOutputTail('composer render')
+      assert.equal(session._sawFirstOutput, true, 'fresh output re-arms the gate')
+      session._lastOutputMs = session._nowMonotonic() - (ClaudeTuiSession.READY_QUIESCENCE_MS + 200)
+      assert.equal(await session._waitForPrompt(100), true, 'ready again after fresh output quiesces')
+    })
+
+    it('#6603 READY_QUIESCENCE_MS honours CHROXY_TUI_READY_QUIESCENCE_MS (positive int, else 400)', () => {
+      const prev = process.env.CHROXY_TUI_READY_QUIESCENCE_MS
+      try {
+        process.env.CHROXY_TUI_READY_QUIESCENCE_MS = '1200'
+        assert.equal(ClaudeTuiSession.READY_QUIESCENCE_MS, 1200, 'a positive override is applied')
+        for (const bad of ['0', '-50', 'abc', '']) {
+          process.env.CHROXY_TUI_READY_QUIESCENCE_MS = bad
+          assert.equal(ClaudeTuiSession.READY_QUIESCENCE_MS, 400, `invalid "${bad}" falls back to 400`)
+        }
+        delete process.env.CHROXY_TUI_READY_QUIESCENCE_MS
+        assert.equal(ClaudeTuiSession.READY_QUIESCENCE_MS, 400, 'unset falls back to 400')
+      } finally {
+        if (prev === undefined) delete process.env.CHROXY_TUI_READY_QUIESCENCE_MS
+        else process.env.CHROXY_TUI_READY_QUIESCENCE_MS = prev
+      }
+    })
+
     it('_waitForPrompt returns false when pid is missing or invalid (Copilot review on #4040)', async () => {
       // Returning true on a missing/invalid pid would silently disable
       // readiness gating on any platform/runtime where node-pty fails to

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1789,7 +1789,11 @@ describe('ClaudeTuiSession', () => {
       try {
         process.env.CHROXY_TUI_READY_QUIESCENCE_MS = '1200'
         assert.equal(ClaudeTuiSession.READY_QUIESCENCE_MS, 1200, 'a positive override is applied')
-        for (const bad of ['0', '-50', 'abc', '']) {
+        process.env.CHROXY_TUI_READY_QUIESCENCE_MS = '  700  '
+        assert.equal(ClaudeTuiSession.READY_QUIESCENCE_MS, 700, 'surrounding whitespace is trimmed')
+        // Strict digits-only: partial-numeric / non-integer strings are rejected
+        // (not silently truncated by parseInt), matching the documented contract.
+        for (const bad of ['0', '-50', 'abc', '', '1200ms', '3.9', '1e3', '0x10', ' ']) {
           process.env.CHROXY_TUI_READY_QUIESCENCE_MS = bad
           assert.equal(ClaudeTuiSession.READY_QUIESCENCE_MS, 400, `invalid "${bad}" falls back to 400`)
         }


### PR DESCRIPTION
Two from-review follow-ups on #6602's PTY output-quiescence readiness fallback (the no-session-file path for current claude's interactive TUI).

## #6603 — make `READY_QUIESCENCE_MS` env-overridable
400ms leaves only ~130ms of headroom over the observed ~270ms max intra-render gap. On a slow cold start (MCP enumeration, a loaded host) a genuine mid-warmup pause could exceed 400ms → quiescence fires early → the throttled prompt lands on a not-yet-ready composer.
- `READY_QUIESCENCE_MS` now reads `CHROXY_TUI_READY_QUIESCENCE_MS` (positive integer ms; `0`/negative/non-numeric/unset → `400`), so a flaky host can widen the window without a rebuild.
- Documented that the #5794 first-turn nudge (a bare `\r` re-send) is the backstop if quiescence fires early — so an early fire is a brief wedge at worst.

## #6604 — pin the per-spawn quiescence reset
`_spawnPty` resets `_sawFirstOutput=false` + `_lastOutputMs=now` on every (re)spawn so a leftover `_lastOutputMs` can't read as ready the instant we respawn. The 4 existing tests didn't cover the **respawn** case.
- Extracted the reset into `_resetQuiescenceForSpawn()` so the guard is unit-testable without a real PTY (the block was buried in `_spawnPty`, which tests fully stub).
- Added a test: a previously-quiesced session (`_sawFirstOutput=true` + a stale `_lastOutputMs`) reads ready → after the reset reads **not-ready** despite the stale timestamp → reads ready again only once fresh `_appendToOutputTail` output quiesces.

## Verified
All **313** `claude-tui-session.test.js` tests pass on Linux (WSL2). eslint + the server opt-forwarding / state-file-path lints are green. (The file's `~/.claude/sessions` session-file tests are blocked by the test sandbox on a real Windows home, so verification was on WSL2 — the CI Server-Tests platform.)

Closes #6603
Closes #6604