### PR TITLE
fix(server): prune permissionInputs on the legacy-unmapped resolve path

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -522,9 +522,13 @@ function handlePermissionResponse(ws, client, msg, ctx) {
     // client.id` exclusion). The resolving client needs its own
     // `permission_resolved` to prune `permissionInputs[requestId]` (#6559) —
     // append-only otherwise, so on this legacy path the entry used to linger
-    // until disconnect. The client handler is idempotent (guarded copy-delete
-    // prune; the notification re-stamp only touches not-yet-acked rows), and
-    // this matches the SDK path, which broadcasts session events to every
+    // until disconnect. Echoing to the resolver is SAFE to re-apply: the
+    // `permissionInputs` prune is a guarded copy-delete, the notification
+    // read-stamp only touches not-yet-acked rows, and re-marking the
+    // already-answered prompt is functionally inert (its label reads from
+    // `resolvedPermissions`, and the pending-count only checks that `answered`
+    // is truthy — only `answeredAt` is refreshed to the server-confirmed time).
+    // This also matches the SDK path, which broadcasts session events to every
     // subscriber without excluding the origin client.
     ctx.transport.broadcast({ type: 'permission_resolved', requestId, decision })
   }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -518,10 +518,15 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   // broadcast). Legacy non-SDK sessions (no PermissionManager) keep an inline
   // broadcast for the unmapped case only — mirrors the prior `!originSessionId`.
   if (!result.sessionId) {
-    ctx.transport.broadcast(
-      { type: 'permission_resolved', requestId, decision },
-      (c) => c.id !== client.id
-    )
+    // #6590: broadcast to ALL clients INCLUDING the resolver (no `c.id !==
+    // client.id` exclusion). The resolving client needs its own
+    // `permission_resolved` to prune `permissionInputs[requestId]` (#6559) —
+    // append-only otherwise, so on this legacy path the entry used to linger
+    // until disconnect. The client handler is idempotent (guarded copy-delete
+    // prune; the notification re-stamp only touches not-yet-acked rows), and
+    // this matches the SDK path, which broadcasts session events to every
+    // subscriber without excluding the origin client.
+    ctx.transport.broadcast({ type: 'permission_resolved', requestId, decision })
   }
 }
 

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -558,6 +558,31 @@ describe('settings-handlers', () => {
       assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow', undefined]) // #6543: editedInput 3rd arg (absent here)
     })
 
+    it('#6590 legacy-unmapped resolve broadcasts permission_resolved to ALL clients incl. the resolver', () => {
+      // Legacy-unmapped path: the request is in the global pendingPermissions but
+      // NOT mapped to a session, so the resolver returns sessionId=null and the
+      // inline legacy broadcast fires. The resolving client must receive its own
+      // permission_resolved so it prunes permissionInputs[requestId] promptly (not
+      // only at disconnect) — i.e. the broadcast must NOT exclude it (#6590).
+      const ctx = makeCtx()
+      ctx.permissions.pendingPermissions = new Map([['req-legacy', { data: {} }]])
+      ctx.permissions.permissions = { resolvePermission: createSpy(() => true) }
+      // Unbound + no active session → originSessionId is null → result.sessionId null.
+      const client = makeClient({ id: 'client-resolver', activeSessionId: null, boundSessionId: null })
+
+      settingsHandlers.permission_response(makeWs(), client, { requestId: 'req-legacy', decision: 'allow' }, ctx)
+
+      assert.equal(ctx.permissions.permissions.resolvePermission.callCount, 1, 'legacy resolve invoked')
+      const call = ctx.transport.broadcast.calls.find(
+        (args) => args[0]?.type === 'permission_resolved' && args[0]?.requestId === 'req-legacy',
+      )
+      assert.ok(call, 'permission_resolved was broadcast on the legacy path')
+      assert.equal(call[0].decision, 'allow')
+      // The whole point of #6590: NO second (exclusion filter) argument, so the
+      // broadcast reaches every client including the resolver.
+      assert.equal(call.length, 1, 'broadcast has no client-exclusion filter (resolver included)')
+    })
+
     // Issue #2912: permission_response rejection for a bound-client must use
     // the same unified SESSION_TOKEN_MISMATCH payload (code + message +
     // boundSessionId + boundSessionName) as every other emit site. The only

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -519,8 +519,11 @@ describe('handleSessionMessage', () => {
       assert.equal(msg.decision, 'deny')
       assert.equal(Object.prototype.hasOwnProperty.call(msg, 'sessionId'), false,
         'unmapped legacy resolutions must not carry a sessionId')
-      assert.equal(filter({ id: 'responder' }), false)
-      assert.equal(filter({ id: 'other-client' }), true)
+      // #6590: the broadcast no longer excludes the resolving client (no filter
+      // arg) — the resolver needs its own permission_resolved to prune
+      // permissionInputs[requestId], and this matches the SDK path.
+      assert.equal(filter, undefined,
+        'legacy broadcast reaches ALL clients incl. the resolver (no exclusion filter, #6590)')
     })
   })
 


### PR DESCRIPTION
## Problem
Identified during review of #6589 (#6559). #6559 prunes `permissionInputs[requestId]` when a prompt terminates via `permission_resolved`/`permission_expired`/`permission_timeout` on both clients. One narrow gap: the **legacy-unmapped WS resolve path** (`handlers/settings-handlers.js`) broadcast `permission_resolved` to everyone **except** the resolving client (`c.id !== client.id`). So on that path the client that answered the prompt never received a `permission_resolved` for its own request and never pruned that entry until it disconnected — a single stale (already-redacted) entry per self-resolved-via-legacy prompt.

## Fix
Broadcast to **all** clients including the resolver (drop the exclusion filter), matching the SDK path — which routes session events through the unified pipeline and broadcasts to every subscriber without excluding the origin client.

**Safe because the client `permission_resolved` handler is idempotent:** the `permissionInputs` prune is a guarded copy-delete, and the notification re-stamp explicitly only touches not-yet-acked rows (it was built for exactly "a server-driven resolution arriving after the operator already acted"). So the resolver receiving its own resolution just prunes + no-ops.

## Test
Added `#6590`: drives a legacy-unmapped resolve (request in `pendingPermissions`, no session map entry → `result.sessionId` null) and asserts the `permission_resolved` broadcast carries **no** client-exclusion filter (`broadcast.calls[…].length === 1`), so the resolver is included.

Verified: 121/121 `settings-handlers` + `permission-resolved-broadcast` tests pass on Linux (WSL2); eslint + state-file-path lint green.

Closes #6590