### PR TITLE
feat(server): surface codex sandbox-escalation approvals in the permission pipeline

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -380,8 +380,13 @@ vision + file references), with no regression (resume is unsupported on *both*
 paths). The only thing that kept it opt-in was a soak period; it now ships on by
 default, with the exec path one env var away (`CHROXY_CODEX_APPSERVER=0`) as a
 fallback. Codex's own scope-escalation requests
-(`item/permissions/requestApproval`) are currently safe-denied — full surfacing
-is tracked in #6610.
+(`item/permissions/requestApproval`) are surfaced through the normal permission
+prompt (#6610): when codex asks to broaden its sandbox (new filesystem write
+scopes or network access), you get a distinctly-worded approval prompt describing
+the requested scope. Approve grants exactly that scope for the current turn,
+"always allow" grants it for the session, and deny grants nothing. Like `shell`,
+sandbox escalations can never be permanently rule-whitelisted — they always
+prompt.
 
 ## Gemini
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -514,32 +514,49 @@ export class CodexAppServerSession extends BaseSession {
     this._client?.respond(rpcId, this._codexPermissionsGrant(allow, session, params?.permissions))
   }
 
-  // Build the PermissionsRequestApprovalResponse. Approve → grant EXACTLY what
-  // codex requested (RequestPermissionProfile and GrantedPermissionProfile share
-  // the same {fileSystem?, network?} shape, so echoing the request is schema-valid
-  // by construction) with scope 'session' for an "always allow" else 'turn'. Deny →
-  // an empty `permissions` object with `scope` OMITTED (an explicit 'none' is an
-  // invalid PermissionGrantScope enum and wedges the turn — #6612).
+  // Build the PermissionsRequestApprovalResponse. Approve → grant EXACTLY what codex
+  // requested. RequestPermissionProfile and GrantedPermissionProfile share the same
+  // {fileSystem?, network?} shape (the request is even additionalProperties:false), so
+  // we reconstruct the grant from those two known fields rather than echoing the raw
+  // request object: that grants precisely the requested scope while making a malformed
+  // frame (an array — typeof [] === 'object' — or any unexpected key) structurally
+  // unable to reach the wire and wedge the turn (#6612). Scope 'session' for an
+  // "always allow" else 'turn'. Deny → an empty `permissions` object with `scope`
+  // OMITTED (an explicit 'none' is an invalid PermissionGrantScope enum and wedges
+  // the turn — #6612).
   _codexPermissionsGrant(allow, session, requestedPermissions) {
     if (!allow) return { permissions: {} }
-    const permissions = requestedPermissions && typeof requestedPermissions === 'object'
+    const src = requestedPermissions && typeof requestedPermissions === 'object' && !Array.isArray(requestedPermissions)
       ? requestedPermissions
       : {}
+    const permissions = {}
+    if (src.fileSystem !== undefined) permissions.fileSystem = src.fileSystem
+    if (src.network !== undefined) permissions.network = src.network
     return { permissions, scope: session ? 'session' : 'turn' }
   }
 
   // Human-readable summary of the requested scope for the approval prompt, so the
-  // operator sees WHAT codex wants to broaden before granting it.
+  // operator sees WHAT codex wants to broaden before granting it. The prompt is
+  // truncated to 200 chars downstream, so cap each list to a few entries + a
+  // "+N more" tail (keeps the most-load-bearing detail — including the trailing
+  // "network access" — from being sliced off) and stringify every path defensively.
   _describePermissionsRequest(params) {
+    const MAX_ENTRIES = 3
+    const summarize = (arr, render) => {
+      const shown = arr.slice(0, MAX_ENTRIES).map(render)
+      const extra = arr.length - shown.length
+      return extra > 0 ? [...shown, `+${extra} more`] : shown
+    }
     const parts = []
     const fs = params?.permissions?.fileSystem
-    if (fs) {
-      for (const e of Array.isArray(fs.entries) ? fs.entries : []) {
+    if (fs && typeof fs === 'object') {
+      const entries = Array.isArray(fs.entries) ? fs.entries : []
+      for (const p of summarize(entries, (e) => {
         const path = e?.path?.path ?? e?.path?.pattern ?? e?.path?.value?.kind ?? 'a path'
-        parts.push(`filesystem ${e?.access ?? 'access'} → ${path}`)
-      }
-      if (Array.isArray(fs.read) && fs.read.length) parts.push(`filesystem read: ${fs.read.join(', ')}`)
-      if (Array.isArray(fs.write) && fs.write.length) parts.push(`filesystem write: ${fs.write.join(', ')}`)
+        return `filesystem ${e?.access ?? 'access'} → ${String(path)}`
+      })) parts.push(p)
+      if (Array.isArray(fs.read) && fs.read.length) parts.push(`filesystem read: ${summarize(fs.read, String).join(', ')}`)
+      if (Array.isArray(fs.write) && fs.write.length) parts.push(`filesystem write: ${summarize(fs.write, String).join(', ')}`)
     }
     if (params?.permissions?.network?.enabled) parts.push('network access')
     const scope = parts.length ? parts.join('; ') : 'broader permissions'

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -425,18 +425,9 @@ export class CodexAppServerSession extends BaseSession {
       return
     }
     if (method === 'item/permissions/requestApproval') {
-      // Scope-escalation (codex wants BROADER permissions than its sandbox). The
-      // response is a permission-grant object, not a simple decision — safe-deny
-      // (grant nothing) so the turn proceeds without escalating. Full surfacing
-      // is tracked in #6610.
-      //
-      // Send ONLY an empty `permissions` object and OMIT `scope`: per the
-      // app-server schema PermissionGrantScope accepts only 'turn'/'session', so
-      // an explicit 'none' is an invalid enum value that errors on deserialize
-      // (the field's serde default only applies when it's ABSENT) — which would
-      // wedge the turn, the opposite of a safe-deny (#6612).
-      ;(this._log || log).info('codex app-server: declining permissions-escalation request (grant nothing) — #6610')
-      this._client?.respond(id, { permissions: {} })
+      // Scope-escalation: codex wants BROADER permissions than its sandbox. Surface
+      // it through the permission pipeline as a distinctly-worded prompt (#6610).
+      this._routePermissionsApproval(id, params)
       return
     }
     ;(this._log || log).warn(`codex app-server: unsupported serverRequest ${method} — declining`)
@@ -494,6 +485,68 @@ export class CodexAppServerSession extends BaseSession {
     }
     if (!allow) return { decision: 'decline' }
     return { decision: session ? 'acceptForSession' : 'accept' }
+  }
+
+  // #6610: codex's THIRD approval family — item/permissions/requestApproval — is a
+  // scope-escalation (it wants broader filesystem/network access than its sandbox).
+  // Unlike the command/file families the response is a permission-GRANT object
+  // (PermissionsRequestApprovalResponse: { permissions, scope?, strictAutoReview? }),
+  // not a decision enum, so it needs its own routing + response mapping. It still
+  // flows through the same PermissionManager prompt (a distinctly-worded request),
+  // so existing clients render + answer it with the normal allow/deny UI.
+  async _routePermissionsApproval(rpcId, params) {
+    let result
+    try {
+      const input = {
+        description: this._describePermissionsRequest(params),
+        // Structured detail for any client that wants to render the exact scope.
+        requestedPermissions: params?.permissions ?? null,
+      }
+      // Sentinel suggestion → respondToPermission echoes updatedPermissions on an
+      // "always allow", which we read as a SESSION-scoped grant (mirrors _routeApproval).
+      const suggestions = [{ codexApproval: 'item/permissions/requestApproval' }]
+      result = await this._permissions.handlePermission('request_permissions', input, this._turnAbort?.signal, this.permissionMode, suggestions)
+    } catch (err) {
+      result = { behavior: 'deny', message: err?.message || 'permission error' }
+    }
+    const allow = result?.behavior === 'allow'
+    const session = allow && !!result?.updatedPermissions
+    this._client?.respond(rpcId, this._codexPermissionsGrant(allow, session, params?.permissions))
+  }
+
+  // Build the PermissionsRequestApprovalResponse. Approve → grant EXACTLY what
+  // codex requested (RequestPermissionProfile and GrantedPermissionProfile share
+  // the same {fileSystem?, network?} shape, so echoing the request is schema-valid
+  // by construction) with scope 'session' for an "always allow" else 'turn'. Deny →
+  // an empty `permissions` object with `scope` OMITTED (an explicit 'none' is an
+  // invalid PermissionGrantScope enum and wedges the turn — #6612).
+  _codexPermissionsGrant(allow, session, requestedPermissions) {
+    if (!allow) return { permissions: {} }
+    const permissions = requestedPermissions && typeof requestedPermissions === 'object'
+      ? requestedPermissions
+      : {}
+    return { permissions, scope: session ? 'session' : 'turn' }
+  }
+
+  // Human-readable summary of the requested scope for the approval prompt, so the
+  // operator sees WHAT codex wants to broaden before granting it.
+  _describePermissionsRequest(params) {
+    const parts = []
+    const fs = params?.permissions?.fileSystem
+    if (fs) {
+      for (const e of Array.isArray(fs.entries) ? fs.entries : []) {
+        const path = e?.path?.path ?? e?.path?.pattern ?? e?.path?.value?.kind ?? 'a path'
+        parts.push(`filesystem ${e?.access ?? 'access'} → ${path}`)
+      }
+      if (Array.isArray(fs.read) && fs.read.length) parts.push(`filesystem read: ${fs.read.join(', ')}`)
+      if (Array.isArray(fs.write) && fs.write.length) parts.push(`filesystem write: ${fs.write.join(', ')}`)
+    }
+    if (params?.permissions?.network?.enabled) parts.push('network access')
+    const scope = parts.length ? parts.join('; ') : 'broader permissions'
+    const reason = typeof params?.reason === 'string' && params.reason.trim()
+      ? ` — ${params.reason.trim()}`
+      : ''
+    return `Codex is requesting to broaden its sandbox permissions${reason}: ${scope}`
   }
 
   // 'auto' (skip all prompts) → codex runs without asking. Every other mode →

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -19,7 +19,9 @@ export const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 
 // Tools that can never be auto-allowed by rules (too dangerous to whitelist).
 // `shell` is codex's command-execution approval — the codex analogue of Bash, so
 // arbitrary codex command execution can't be rule-whitelisted either (#6605).
-export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell'])
+// `request_permissions` is codex's sandbox-escalation approval (#6610) — broadening
+// filesystem/network scope must always prompt, never be silently rule-whitelisted.
+export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions'])
 
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -399,6 +399,7 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
       assert.match(req.description, /network access/)
       // structured detail passed through for any client that wants to render it
       assert.deepEqual(req.input.requestedPermissions, escalationParams.permissions)
+      s.respondToPermission(req.requestId, 'deny') // resolve so no pending timeout timer leaks past cleanup
       cleanup()
     })
 
@@ -446,6 +447,68 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
         [],
         'no fields outside the schema',
       )
+      cleanup()
+    })
+
+    it('abort mid-escalation → responds { permissions: {} } (answers codex, no turn wedge #6612)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 16, method: 'item/permissions/requestApproval', params: escalationParams })
+      assert.equal(reqs.length, 1, 'escalation prompted')
+      s._endTurnAbort() // Stop / turn-end aborts the pending escalation
+      await tick()
+      assert.deepEqual(responded, [[16, { permissions: {} }]], 'abort grants nothing but still answers codex')
+      cleanup()
+    })
+
+    it('malformed permissions (an array) is coerced to an empty grant, never echoed (no wedge)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      // typeof [] === 'object': a naive echo would put an array on the wire where codex
+      // expects a {fileSystem?, network?} object → deserialize failure → wedged turn (#6612).
+      s._onServerRequest({ id: 17, method: 'item/permissions/requestApproval', params: { ...escalationParams, permissions: [] } })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      assert.deepEqual(responded, [[17, { permissions: {}, scope: 'turn' }]], 'array dropped, grants an empty (valid) profile')
+      cleanup()
+    })
+
+    it('grants ONLY fileSystem/network — an unexpected requested field never reaches the wire', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      const params = { ...escalationParams, permissions: { ...escalationParams.permissions, bogus: 'x' } }
+      s._onServerRequest({ id: 18, method: 'item/permissions/requestApproval', params })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      assert.deepEqual(
+        responded[0][1],
+        { permissions: { fileSystem: escalationParams.permissions.fileSystem, network: escalationParams.permissions.network }, scope: 'turn' },
+        'only the two GrantedPermissionProfile fields are granted; a request-only key is dropped',
+      )
+      cleanup()
+    })
+
+    it('describes the legacy read/write filesystem shape (not just entries)', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      const params = { ...escalationParams, reason: null, permissions: { fileSystem: { read: ['/etc/hosts'], write: ['/var/log'] } } }
+      s._onServerRequest({ id: 19, method: 'item/permissions/requestApproval', params })
+      assert.match(reqs[0][1].description, /filesystem read: \/etc\/hosts/)
+      assert.match(reqs[0][1].description, /filesystem write: \/var\/log/)
+      s.respondToPermission(reqs[0][1].requestId, 'deny') // resolve so no pending timeout timer leaks past cleanup
+      cleanup()
+    })
+
+    it('caps a huge filesystem scope with a "+N more" tail so the prompt stays bounded and keeps network access', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      const entries = Array.from({ length: 10 }, (_, i) => ({ access: 'write', path: { type: 'path', path: `/p/${i}` } }))
+      const params = { ...escalationParams, reason: null, permissions: { fileSystem: { entries }, network: { enabled: true } } }
+      s._onServerRequest({ id: 22, method: 'item/permissions/requestApproval', params })
+      const desc = reqs[0][1].description
+      assert.match(desc, /\+7 more/, 'summarizes the tail instead of listing all 10 entries')
+      assert.match(desc, /network access/, 'the trailing network scope survives the cap')
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
       cleanup()
     })
   })

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -376,15 +376,78 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     cleanup()
   })
 
-  it('permissions-escalation request is safe-denied (grant nothing, no scope) without a prompt', () => {
-    const { s, cleanup, responded } = mkApprovalSession()
-    const reqs = capture(s, ['permission_request'])
-    s._onServerRequest({ id: 11, method: 'item/permissions/requestApproval', params: { scope: 'disk-full-access' } })
-    assert.equal(reqs.length, 0, 'escalation is not surfaced as a normal prompt in Phase 2')
-    // grant nothing: empty permissions, scope OMITTED (an explicit 'none' is an
-    // invalid PermissionGrantScope enum value and would wedge the turn — #6612).
-    assert.deepEqual(responded, [[11, { permissions: {} }]])
-    cleanup()
+  describe('permissions-escalation surfacing (#6610)', () => {
+    // A real PermissionsRequestApprovalParams (codex asks to broaden its sandbox).
+    const escalationParams = {
+      cwd: '/repo', itemId: 'i1', threadId: 't1', turnId: 'turn1', startedAtMs: 0,
+      reason: 'install deps',
+      permissions: {
+        fileSystem: { entries: [{ access: 'write', path: { type: 'path', path: '/repo/node_modules' } }] },
+        network: { enabled: true },
+      },
+    }
+
+    it('surfaces the escalation as a distinctly-worded prompt describing the requested scope', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 11, method: 'item/permissions/requestApproval', params: escalationParams })
+      assert.equal(reqs.length, 1, 'escalation is surfaced (no longer safe-denied silently)')
+      const req = reqs[0][1]
+      assert.match(req.description, /broaden its sandbox permissions/)
+      assert.match(req.description, /install deps/)
+      assert.match(req.description, /filesystem write/)
+      assert.match(req.description, /network access/)
+      // structured detail passed through for any client that wants to render it
+      assert.deepEqual(req.input.requestedPermissions, escalationParams.permissions)
+      cleanup()
+    })
+
+    it('approve → grants EXACTLY the requested permissions for this turn', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 12, method: 'item/permissions/requestApproval', params: escalationParams })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      assert.deepEqual(responded, [[12, { permissions: escalationParams.permissions, scope: 'turn' }]])
+      cleanup()
+    })
+
+    it('approve-always → grants the requested permissions for the SESSION', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 13, method: 'item/permissions/requestApproval', params: escalationParams })
+      s.respondToPermission(reqs[0][1].requestId, 'allowAlways')
+      await tick()
+      assert.deepEqual(responded, [[13, { permissions: escalationParams.permissions, scope: 'session' }]])
+      cleanup()
+    })
+
+    it('deny → grants NOTHING (empty permissions, scope omitted per #6612)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 14, method: 'item/permissions/requestApproval', params: escalationParams })
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
+      await tick()
+      assert.deepEqual(responded, [[14, { permissions: {} }]])
+      cleanup()
+    })
+
+    it('the grant response conforms to PermissionsRequestApprovalResponse (schema shape)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 15, method: 'item/permissions/requestApproval', params: escalationParams })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      const resp = responded[0][1]
+      assert.equal(typeof resp.permissions, 'object', 'permissions is the required GrantedPermissionProfile object')
+      assert.ok(['turn', 'session'].includes(resp.scope), 'scope is a valid PermissionGrantScope enum')
+      assert.deepEqual(
+        Object.keys(resp).filter((k) => !['permissions', 'scope', 'strictAutoReview'].includes(k)),
+        [],
+        'no fields outside the schema',
+      )
+      cleanup()
+    })
   })
 
   it('interrupt() aborts a pending approval → Stop unblocks the turn (decline)', async () => {

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -734,7 +734,9 @@ describe('PermissionManager', () => {
 
     it('NEVER_AUTO_ALLOW contains the expected dangerous tools', () => {
       // shell = codex's command-execution tool (#6605), never-whitelistable like Bash.
-      const expected = ['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell']
+      // request_permissions = codex's sandbox-escalation tool (#6610) — broadening
+      // filesystem/network scope must always prompt, never be rule-whitelisted.
+      const expected = ['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions']
       for (const tool of expected) {
         assert.ok(NEVER_AUTO_ALLOW.has(tool), `Expected NEVER_AUTO_ALLOW to contain ${tool}`)
       }


### PR DESCRIPTION
## What

The codex app-server emits `item/permissions/requestApproval` when the model wants to **broaden its sandbox** mid-turn — new filesystem write scopes or network access. The app-server driver previously **safe-denied every such request**, so a codex session could never be granted broader permissions through Chroxy: the escalation was silently refused and never surfaced to the operator.

This routes the request through Chroxy's **existing permission pipeline** so it appears in the standard permission prompt on both clients, with **no client code change**.

## How

`_onServerRequest` now calls `_routePermissionsApproval` for `item/permissions/requestApproval`, which:

1. Builds a synthetic `request_permissions` tool call with a human-readable description of the requested scope (`_describePermissionsRequest` — e.g. _"Codex is requesting to broaden its sandbox permissions — &lt;reason&gt;: filesystem write → …; network access"_).
2. Hands it to `this._permissions.handlePermission(...)` — the same path command/file approvals already use — so the dashboard/app render it via the existing `PermissionPrompt` (`<tool>: <description>`).
3. Maps the decision back to a `PermissionsRequestApprovalResponse`:
   - **approve** → grant **exactly** the requested permission profile, scope `turn`
   - **approve-always** → same profile, scope `session`
   - **deny** → `{ permissions: {} }` (scope omitted)

### Why echoing the request is safe

The codex `RequestPermissionProfile` (request `permissions`) and `GrantedPermissionProfile` (response `permissions`) share the same `{ fileSystem?, network? }` shape. Echoing the model's own requested `permissions` back on approve is therefore **schema-valid by construction** (verified against the authoritative schema from `codex app-server generate-json-schema`), which matters because a malformed approval response **wedges the turn** (cf. #6612).

## Tests

`packages/server/tests/codex-app-server-session.test.js` — the old safe-deny test is replaced by `describe('permissions-escalation surfacing (#6610)')` with 5 cases:

- surfaces the escalation as a distinctly-worded permission prompt describing the requested scope
- approve → grants exactly the requested profile with scope `turn`
- approve-always → grants the profile with scope `session`
- deny → grants nothing (`{ permissions: {} }`)
- the emitted grant conforms to the `PermissionsRequestApprovalResponse` shape

Full `codex-app-server-session.test.js` suite green on Linux (WSL2, the CI Server-Tests platform); eslint + the server opt-forwarding / state-file-path lints clean.

## Verification note for @blamechris

Server-side logic is complete and unit-tested. The operator-facing rendering reuses the **existing** permission prompt UI (no client change), so it can't be exercised by the server test suite — **please eyeball one live codex escalation prompt** (dashboard/app) to confirm the description reads well end-to-end.

Closes #6610