### PR TITLE
fix(server): make the provider picker report codex's runtime driver capabilities

### DIFF
--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -256,8 +256,16 @@ export function getProviderDataDirs() {
  */
 export function listProviders() {
   const list = []
-  for (const [name, ProviderClass] of Object.entries(PROVIDERS)) {
+  for (const name of Object.keys(PROVIDERS)) {
     if (HIDDEN.has(name)) continue
+    // #6618 — resolve to the class that will ACTUALLY be instantiated for this
+    // provider id. getProvider honors CHROXY_CODEX_APPSERVER for codex (app-server
+    // by default, exec on opt-out), so the picker's advertised capabilities match
+    // what a live session reports in session_info. For every other provider
+    // getProvider is just PROVIDERS[name], so this is a no-op. codex's app-server
+    // class delegates dataDir/resolveAuth/preflight to the exec class, so `auth` is
+    // unchanged — only the capability shape follows the runtime driver.
+    const ProviderClass = getProvider(name)
     list.push({
       name,
       capabilities: {

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -183,6 +183,40 @@ describe('Provider Registry', () => {
     }
   })
 
+  // #6618: the picker (listProviders) advertised codex's EXEC capability shape
+  // (from the static PROVIDERS literal) while a live codex session is the
+  // app-server driver (getProvider default), so the two disagreed on
+  // permissions/inProcessPermissions/permissionModeSwitch. listProviders now
+  // resolves through getProvider so the picker tracks the runtime driver,
+  // honoring CHROXY_CODEX_APPSERVER.
+  it('listProviders codex caps match the runtime driver, honoring CHROXY_CODEX_APPSERVER (#6618)', () => {
+    const orig = process.env.CHROXY_CODEX_APPSERVER
+    const CAP_KEYS = ['permissions', 'inProcessPermissions', 'permissionModeSwitch']
+    try {
+      for (const [label, val] of [['default (app-server)', undefined], ['opt-out (=0)', '0']]) {
+        if (val === undefined) delete process.env.CHROXY_CODEX_APPSERVER
+        else process.env.CHROXY_CODEX_APPSERVER = val
+        const codexEntry = listProviders().find(p => p.name === 'codex')
+        assert.ok(codexEntry, `codex provider registered (${label})`)
+        const runtimeCaps = getProvider('codex').capabilities
+        for (const k of CAP_KEYS) {
+          assert.equal(codexEntry.capabilities[k], runtimeCaps[k],
+            `picker codex.${k} must match the runtime driver in ${label}`)
+        }
+      }
+      // Concretely: default = app-server (approval-capable), =0 = exec (no approvals).
+      delete process.env.CHROXY_CODEX_APPSERVER
+      assert.equal(listProviders().find(p => p.name === 'codex').capabilities.permissions, true,
+        'codex default (app-server) advertises approvals in the picker')
+      process.env.CHROXY_CODEX_APPSERVER = '0'
+      assert.equal(listProviders().find(p => p.name === 'codex').capabilities.permissions, false,
+        'codex exec opt-out advertises no approvals in the picker')
+    } finally {
+      if (orig === undefined) delete process.env.CHROXY_CODEX_APPSERVER
+      else process.env.CHROXY_CODEX_APPSERVER = orig
+    }
+  })
+
   // #3404 audit (F1+F5): listProviders must surface auth/credentials state
   // so the dashboard can grey-out unusable providers and show a billing-
   // identity confidence panel without making the user run `chroxy doctor`.

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -206,11 +206,22 @@ describe('Provider Registry', () => {
       }
       // Concretely: default = app-server (approval-capable), =0 = exec (no approvals).
       delete process.env.CHROXY_CODEX_APPSERVER
-      assert.equal(listProviders().find(p => p.name === 'codex').capabilities.permissions, true,
+      const defaultList = listProviders()
+      assert.equal(defaultList.find(p => p.name === 'codex').capabilities.permissions, true,
         'codex default (app-server) advertises approvals in the picker')
       process.env.CHROXY_CODEX_APPSERVER = '0'
-      assert.equal(listProviders().find(p => p.name === 'codex').capabilities.permissions, false,
+      const optOutList = listProviders()
+      assert.equal(optOutList.find(p => p.name === 'codex').capabilities.permissions, false,
         'codex exec opt-out advertises no approvals in the picker')
+
+      // No-op for every OTHER provider: resolving through getProvider only swaps
+      // codex, so a non-codex entry's caps must be identical across the env flip.
+      for (const name of ['claude-sdk', 'claude-cli']) {
+        const a = defaultList.find(p => p.name === name)
+        const b = optOutList.find(p => p.name === name)
+        if (a && b) assert.deepEqual(a.capabilities, b.capabilities,
+          `${name} caps must not change with CHROXY_CODEX_APPSERVER (only codex is resolved)`)
+      }
     } finally {
       if (orig === undefined) delete process.env.CHROXY_CODEX_APPSERVER
       else process.env.CHROXY_CODEX_APPSERVER = orig


### PR DESCRIPTION
## What

`listProviders()` (the pre-session provider picker) iterated the static `PROVIDERS` literal, where `'codex' → CodexSession` (the exec class). So the picker advertised codex's **exec** capability shape — `permissions:false`, `inProcessPermissions:false`, `permissionModeSwitch:false`.

But a live codex session is `CodexAppServerSession` (the #6616 default), and `session_info` sources capabilities from the session's constructor — so it reports `permissions:true`, `inProcessPermissions:true`, `permissionModeSwitch:true`. **The picker and a live session disagreed on codex's capability surface** (latent today — the only picker-driven gate, `sessionRules`, is `false` for both codex classes — but wrong for any future affordance keying off the picker's `permissions`/`permissionModeSwitch`).

## How

`listProviders()` now resolves each entry through `getProvider(name)`, the same chokepoint `SessionManager` uses to construct sessions. `getProvider` honors `CHROXY_CODEX_APPSERVER` for codex (app-server by default, exec on `=0` opt-out); for every other provider it's just `PROVIDERS[name]`, so this is a no-op.

**No blast radius on `auth`:** `CodexAppServerSession` delegates `dataDir`/`resolveAuth`/`preflight` to `CodexSession`, so `getProviderAuthInfo` returns the identical shape — only the capability surface now follows the runtime driver.

## Tests

New test (`providers.test.js`) asserts the picker's codex `permissions`/`inProcessPermissions`/`permissionModeSwitch` match `getProvider('codex').capabilities` for **both** the default (app-server → approval-capable) and the `CHROXY_CODEX_APPSERVER=0` opt-out (exec → no approvals). Full `providers.test.js` suite: **96/96 on Linux**.

> Note: ~10 pre-existing `credential-file caching (#4658/#4656)` tests fail on a Windows dev host (they rely on Unix file-mode/mtime semantics — `chmod` is a no-op on Windows) and are green on the Linux CI runner; unrelated to this change (they fail on `main` too).

Satisfies both acceptance boxes in the issue.

Closes #6618