### PR TITLE
feat(server): expose Chroxy host identity to agent sessions

### DIFF
--- a/docs/guides/host-metadata.md
+++ b/docs/guides/host-metadata.md
@@ -28,8 +28,13 @@ stray `CHROXY_HOST_*` export cannot spoof them.
 Any provider that can run shell commands reads them directly:
 
 ```bash
-echo "$CHROXY_HOST_APP $CHROXY_HOST_VERSION ($CHROXY_HOST_CHANNEL) — $CHROXY_HOST_GIT_BRANCH@$CHROXY_HOST_GIT_SHA on $CHROXY_HOST_PLATFORM"
-# Chroxy 0.10.0 (dev) — feat/6633-host-metadata@4ebf6bf on darwin
+echo "$CHROXY_HOST_APP $CHROXY_HOST_VERSION ($CHROXY_HOST_CHANNEL) on $CHROXY_HOST_PLATFORM"
+# Chroxy 0.10.0 (dev) on darwin
+
+# The git vars are set only on dev builds — guard for them on a release build,
+# where they are unset (so a bare "@" would otherwise print):
+[ -n "$CHROXY_HOST_GIT_SHA" ] && echo "build: ${CHROXY_HOST_GIT_BRANCH:-detached}@$CHROXY_HOST_GIT_SHA"
+# build: feat/6633-host-metadata@4ebf6bf
 ```
 
 - **Subprocess providers** (Claude CLI/TUI, Codex, Gemini, …) receive the block

--- a/docs/guides/host-metadata.md
+++ b/docs/guides/host-metadata.md
@@ -35,8 +35,12 @@ echo "$CHROXY_HOST_APP $CHROXY_HOST_VERSION ($CHROXY_HOST_CHANNEL) — $CHROXY_H
 - **Subprocess providers** (Claude CLI/TUI, Codex, Gemini, …) receive the block
   via `buildSpawnEnv` — the single chokepoint that builds every child process's
   environment.
-- **The in-process Claude SDK** provider inherits it because the daemon publishes
-  the same block into its own `process.env` at startup.
+- **The in-process Claude SDK** and BYOK-family providers (DeepSeek, Ollama,
+  Anthropic-/OpenAI-compatible) inherit it because the daemon publishes the same
+  block into its own `process.env` at startup.
+- **Containerized providers** (`docker-cli`, `docker-sdk`, `docker-byok`, and the
+  k8s backend) forward the block across the container boundary, so an agent
+  running *inside* an isolated container/pod sees the same host identity.
 
 ## Using it in a skill or agent prompt
 

--- a/docs/guides/host-metadata.md
+++ b/docs/guides/host-metadata.md
@@ -1,0 +1,50 @@
+# Chroxy host metadata (`CHROXY_HOST_*`)
+
+Every agent session launched by Chroxy — Claude, Codex, Gemini, and any future
+provider — is given a small, non-sensitive **host identity** through environment
+variables. This lets an agent answer *"what Chroxy build am I running in?"* from
+inside a chat session instead of guessing from screenshots, the checked-out repo,
+or app-bundle metadata (issue #6633).
+
+## The variables
+
+| Variable | Always present | Example | Meaning |
+|---|---|---|---|
+| `CHROXY_HOST_APP` | yes | `Chroxy` | Product name. |
+| `CHROXY_HOST_VERSION` | yes | `0.10.0` | Running server package version. |
+| `CHROXY_HOST_CHANNEL` | yes | `dev` / `release` | `dev` when launched from a git working tree, `release` from a packaged install. |
+| `CHROXY_HOST_PLATFORM` | yes | `darwin` / `win32` / `linux` | `process.platform` of the host. |
+| `CHROXY_HOST_NODE` | yes | `22.14.0` | Node.js version running the daemon. |
+| `CHROXY_HOST_PID` | yes | `48213` | PID of the daemon process — pins the exact running host. |
+| `CHROXY_HOST_GIT_SHA` | dev only | `4ebf6bf` | Short commit SHA (omitted for release builds). |
+| `CHROXY_HOST_GIT_BRANCH` | dev only | `feat/6633-host-metadata` | Branch name (omitted when detached or unavailable). |
+
+The values are **computed by the daemon** (version from its own `package.json`,
+git identity via `git`) — never passed through from the operator's shell — so a
+stray `CHROXY_HOST_*` export cannot spoof them.
+
+## Reading it from a session
+
+Any provider that can run shell commands reads them directly:
+
+```bash
+echo "$CHROXY_HOST_APP $CHROXY_HOST_VERSION ($CHROXY_HOST_CHANNEL) — $CHROXY_HOST_GIT_BRANCH@$CHROXY_HOST_GIT_SHA on $CHROXY_HOST_PLATFORM"
+# Chroxy 0.10.0 (dev) — feat/6633-host-metadata@4ebf6bf on darwin
+```
+
+- **Subprocess providers** (Claude CLI/TUI, Codex, Gemini, …) receive the block
+  via `buildSpawnEnv` — the single chokepoint that builds every child process's
+  environment.
+- **The in-process Claude SDK** provider inherits it because the daemon publishes
+  the same block into its own `process.env` at startup.
+
+## Using it in a skill or agent prompt
+
+A runtime skill (`~/.chroxy/skills/*.md`) or an agent prompt can instruct the
+model to confirm its host before smoke-testing a freshly rebuilt branch, e.g.:
+
+> Before verifying this change, run `echo "$CHROXY_HOST_VERSION $CHROXY_HOST_CHANNEL $CHROXY_HOST_GIT_SHA"`
+> and confirm the branch/SHA matches the build under test.
+
+This makes "am I talking to the build I just rebuilt?" a one-line check instead
+of a screenshot comparison.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,6 +18,8 @@ Three additional providers register automatically when `environments.enabled=tru
 
 Beyond the built-ins, any service or local server that exposes an **Anthropic-compatible Messages API** (Z.ai GLM, Moonshot Kimi, MiniMax, LM Studio, llama.cpp server, vLLM, OpenRouter, custom proxies) can be registered straight from `config.json` — no code required. See [Anthropic-compatible endpoints (config-driven)](#anthropic-compatible-endpoints-config-driven). Endpoints that speak the **OpenAI Chat Completions API** instead (OpenAI, OpenRouter, LM Studio, vLLM, Together, Groq, …) register the same way under a sibling block — see [OpenAI-compatible endpoints (config-driven)](#openai-compatible-endpoints-config-driven).
 
+Regardless of provider, every session's environment carries Chroxy's own **host identity** (`CHROXY_HOST_VERSION`, `CHROXY_HOST_GIT_SHA`, `CHROXY_HOST_CHANNEL`, …) so an agent can confirm the exact running build — see [Chroxy host metadata](guides/host-metadata.md).
+
 ## Setting credentials from the dashboard
 
 The **primary** way to supply provider credentials is the **Settings → Provider Credentials** pane in the desktop dashboard (and the browser dashboard — same authenticated WebSocket path). It lets you view, set, rotate, test, and remove an API key per provider without dropping to a terminal to export environment variables:

--- a/packages/server/src/chroxy-host-metadata.js
+++ b/packages/server/src/chroxy-host-metadata.js
@@ -1,0 +1,112 @@
+/**
+ * chroxy-host-metadata — the identity of the Chroxy host that launched an agent
+ * session (#6633).
+ *
+ * Agents (Claude, Codex, Gemini, …) previously could not answer "what Chroxy
+ * build am I running in?" without guessing from screenshots or the checked-out
+ * repo. This module computes a small, non-sensitive identity block and exposes
+ * it as `CHROXY_HOST_*` environment variables, which are injected into every
+ * agent's process environment (see `buildSpawnEnv` for subprocess providers and
+ * the server startup `Object.assign(process.env, …)` for the in-process SDK). A
+ * session can then read e.g. `$CHROXY_HOST_VERSION` from a Bash tool call.
+ *
+ * The values are COMPUTED here (version from this package's package.json, git
+ * identity via `git`), never passed through from the operator's shell — so they
+ * are authoritative and can't be spoofed by a stray `CHROXY_HOST_*` export.
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Synchronous read at module scope is fine: the file is tiny and never changes
+// mid-process (mirrors byok-mcp-client's readPackageVersion). Never block on a
+// missing/unreadable package.json — fall back to a sentinel.
+function readPackageVersion() {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const raw = readFileSync(join(here, '..', 'package.json'), 'utf8')
+    const parsed = JSON.parse(raw)
+    if (typeof parsed?.version === 'string' && parsed.version.length > 0) {
+      return parsed.version
+    }
+  } catch {
+    // Fall through — identity should degrade gracefully, never crash a spawn.
+  }
+  return '0.0.0'
+}
+
+/**
+ * Best-effort git identity for dev builds. A released npm/tarball install has no
+ * `.git`, so this returns `{}` there. Guarded and time-boxed — computing host
+ * identity must never block or fail a session spawn.
+ *
+ * @param {typeof execFileSync} [exec] - injectable for tests
+ * @returns {{ sha?: string, branch?: string }}
+ */
+export function readGitIdentity(exec = execFileSync) {
+  const cwd = dirname(fileURLToPath(import.meta.url))
+  const run = (args) => String(exec('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 })).trim()
+  try {
+    const sha = run(['rev-parse', '--short', 'HEAD'])
+    if (!sha) return {}
+    const out = { sha }
+    try {
+      const branch = run(['rev-parse', '--abbrev-ref', 'HEAD'])
+      // 'HEAD' means detached — no meaningful branch name to report.
+      if (branch && branch !== 'HEAD') out.branch = branch
+    } catch {
+      // No branch is fine; the SHA alone still identifies the build.
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Build the `CHROXY_HOST_*` identity map. Pure — every source is either read
+ * fresh or injected, so tests can pin each field without mocking modules.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.version]  - override the package version
+ * @param {{ sha?: string, branch?: string }} [opts.git] - override git identity
+ * @param {string} [opts.platform] - override process.platform
+ * @param {string} [opts.node]     - override the node version
+ * @param {number|string} [opts.pid] - override the process id
+ * @returns {Record<string, string>} string-valued env map (git keys omitted when absent)
+ */
+export function buildChroxyHostEnv({ version, git, platform, node, pid } = {}) {
+  const g = git ?? readGitIdentity()
+  const env = {
+    CHROXY_HOST_APP: 'Chroxy',
+    CHROXY_HOST_VERSION: version ?? readPackageVersion(),
+    // A git SHA means we're running from a working tree → a dev/local build;
+    // its absence means a packaged release.
+    CHROXY_HOST_CHANNEL: g.sha ? 'dev' : 'release',
+    CHROXY_HOST_PLATFORM: platform ?? process.platform,
+    CHROXY_HOST_NODE: node ?? process.versions.node,
+    CHROXY_HOST_PID: String(pid ?? process.pid),
+  }
+  if (g.sha) env.CHROXY_HOST_GIT_SHA = g.sha
+  if (g.branch) env.CHROXY_HOST_GIT_BRANCH = g.branch
+  return env
+}
+
+// Memoized per-process view. Git/version don't change mid-run, so compute once
+// and reuse across every spawn.
+let _cache = null
+
+/**
+ * The memoized `CHROXY_HOST_*` map for this process.
+ * @returns {Record<string, string>}
+ */
+export function getChroxyHostEnv() {
+  if (!_cache) _cache = buildChroxyHostEnv()
+  return _cache
+}
+
+/** Test seam: drop the memoized value so a test can re-derive it. */
+export function _resetChroxyHostEnvCacheForTest() {
+  _cache = null
+}

--- a/packages/server/src/chroxy-host-metadata.js
+++ b/packages/server/src/chroxy-host-metadata.js
@@ -19,8 +19,9 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-// Synchronous read at module scope is fine: the file is tiny and never changes
-// mid-process (mirrors byok-mcp-client's readPackageVersion). Never block on a
+// A synchronous read is fine: the file is tiny and never changes mid-process,
+// and getChroxyHostEnv memoizes the result so this runs at most once on demand
+// (mirrors byok-mcp-client's readPackageVersion). Never block on a
 // missing/unreadable package.json — fall back to a sentinel.
 function readPackageVersion() {
   try {

--- a/packages/server/src/chroxy-host-metadata.js
+++ b/packages/server/src/chroxy-host-metadata.js
@@ -41,11 +41,20 @@ function readPackageVersion() {
  * `.git`, so this returns `{}` there. Guarded and time-boxed — computing host
  * identity must never block or fail a session spawn.
  *
+ * Only a chroxy SOURCE checkout reports git identity. When chroxy is installed as
+ * a dependency (`…/node_modules/chroxy/…`), `git rev-parse` would otherwise walk
+ * up to the USER's project `.git` and mislabel the build `dev` while leaking the
+ * user's branch/SHA into third-party (codex/gemini) subprocesses. The
+ * node_modules guard makes that impossible — an installed chroxy is `release`.
+ *
  * @param {typeof execFileSync} [exec] - injectable for tests
+ * @param {string} [moduleDir] - injectable module directory (for tests)
  * @returns {{ sha?: string, branch?: string }}
  */
-export function readGitIdentity(exec = execFileSync) {
-  const cwd = dirname(fileURLToPath(import.meta.url))
+export function readGitIdentity(exec = execFileSync, moduleDir = dirname(fileURLToPath(import.meta.url))) {
+  // Installed-as-a-dependency → never inspect the surrounding repo's git.
+  if (moduleDir.split(/[/\\]/).includes('node_modules')) return {}
+  const cwd = moduleDir
   const run = (args) => String(exec('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 })).trim()
   try {
     const sha = run(['rev-parse', '--short', 'HEAD'])

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -3,6 +3,7 @@ import { createInterface } from 'readline'
 import { CliSession } from './cli-session.js'
 import { createLogger } from './logger.js'
 import { BILLING_CLASSES } from './billing-class.js'
+import { getChroxyHostEnv } from './chroxy-host-metadata.js'
 
 const log = createLogger('docker-session')
 
@@ -283,6 +284,14 @@ export class DockerSession extends CliSession {
     // Always forward CHROXY_HOST if set
     if (env.CHROXY_HOST) {
       dockerArgs.push('--env', `CHROXY_HOST=${env.CHROXY_HOST}`)
+    }
+    // #6633: forward Chroxy's own (non-sensitive) host identity so an agent
+    // INSIDE the container can still answer "what build am I in?". Sourced from
+    // the authoritative computed block; the `CHROXY_HOST_` prefix (trailing
+    // underscore) is distinct from the permission-hook `CHROXY_HOST` routing var
+    // above.
+    for (const [key, val] of Object.entries(getChroxyHostEnv())) {
+      dockerArgs.push('--env', `${key}=${val}`)
     }
 
     dockerArgs.push(this._containerId, 'claude', ...claudeArgs)

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -1,6 +1,7 @@
 import { execFile, spawn } from 'child_process'
 import { createLogger } from '../../logger.js'
 import { VALID_USERNAME_RE } from '../../utils/validation-patterns.js'
+import { getChroxyHostEnv } from '../../chroxy-host-metadata.js'
 
 const log = createLogger('docker-backend')
 
@@ -514,6 +515,13 @@ export class DockerBackend {
           dockerArgs.push('--env', `${key}=${val}`)
         }
       }
+    }
+    // #6633: also forward Chroxy's own (non-sensitive) host identity so an agent
+    // INSIDE the container can answer "what build am I in?". Sourced from the
+    // authoritative computed block (not `env`), so it lands regardless of how the
+    // caller built its env.
+    for (const [key, val] of Object.entries(getChroxyHostEnv())) {
+      dockerArgs.push('--env', `${key}=${val}`)
     }
 
     // Override HOME and PATH for the container user.

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -4,6 +4,7 @@ import { PassThrough } from 'stream'
 import { KubeConfig, CoreV1Api, PortForward } from '@kubernetes/client-node'
 import WebSocket from 'ws'
 import { createLogger } from '../../logger.js'
+import { getChroxyHostEnv } from '../../chroxy-host-metadata.js'
 
 const log = createLogger('k8s-backend')
 
@@ -1228,6 +1229,14 @@ export class K8sBackend {
       for (const [name, value] of Object.entries(containerEnv)) {
         env.push({ name, value: String(value) })
       }
+    }
+
+    // #6633: Chroxy's own (non-sensitive) host identity, so an agent exec'd into
+    // the pod can answer "what build am I in?" — pod-spec env is inherited by
+    // `kubectl exec` processes. Added after containerEnv so the computed identity
+    // is authoritative.
+    for (const [name, value] of Object.entries(getChroxyHostEnv())) {
+      env.push({ name, value: String(value) })
     }
 
     // 4. Resolve imagePullPolicy: per-call opt > constructor opt > omit (K8s default)

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -13,6 +13,7 @@ import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { waitForTunnel } from './tunnel-check.js'
 import { PushManager, settlePush } from './push.js'
 import { ensureIngestSecret } from './event-ingest.js'
+import { getChroxyHostEnv } from './chroxy-host-metadata.js'
 import { PushNotificationHandler } from './server-cli/push-notification-handler.js'
 import { StartupDisplay } from './server-cli/startup-display.js'
 import { TunnelLifecycleHandler } from './server-cli/tunnel-lifecycle-handler.js'
@@ -447,6 +448,12 @@ export async function startCliServer(config) {
   }
 
   initFileLoggingFromConfig(config)
+
+  // #6633: publish Chroxy's host identity into this process's environment so the
+  // in-process SDK provider's Bash tools inherit it (subprocess providers get it
+  // via buildSpawnEnv). Computed + authoritative — a session can read
+  // $CHROXY_HOST_VERSION / _GIT_SHA / _CHANNEL to confirm the exact running build.
+  Object.assign(process.env, getChroxyHostEnv())
 
   const PORT = config.port || parseInt(process.env.PORT || '8765', 10)
   const NO_AUTH = !!config.noAuth

--- a/packages/server/src/utils/spawn-env.js
+++ b/packages/server/src/utils/spawn-env.js
@@ -24,6 +24,7 @@
  * non-denylisted credential keys are eligible for store injection.
  */
 import { resolveCredential, isKnownCredentialKey } from '../credential-store.js'
+import { getChroxyHostEnv } from '../chroxy-host-metadata.js'
 
 // Standard vars every child process needs for its runtime to function.
 // Shell PATH, locale, TERM, TMPDIR, user/home identity.
@@ -163,7 +164,11 @@ export function buildSpawnEnv(provider, extras = {}) {
         if (resolved.value) env[key] = resolved.value
       }
     }
-    return { ...env, ...extras }
+    // #6633: inject Chroxy's own host identity (version/channel/git/platform).
+    // These are COMPUTED (not passed through from process.env), so they are
+    // authoritative and safe for allowlist-mode providers — non-sensitive
+    // metadata, never an operator secret. `extras` still wins on any collision.
+    return { ...env, ...getChroxyHostEnv(), ...extras }
   }
 
   // denylist mode: start from full parent env, remove sensitive keys.
@@ -189,5 +194,6 @@ export function buildSpawnEnv(provider, extras = {}) {
     const resolved = resolveCredential(key)
     if (resolved.value) parentEnv[key] = resolved.value
   }
-  return { ...parentEnv, ...extras }
+  // #6633: Chroxy host identity, computed and authoritative (see allowlist branch).
+  return { ...parentEnv, ...getChroxyHostEnv(), ...extras }
 }

--- a/packages/server/tests/chroxy-host-metadata.test.js
+++ b/packages/server/tests/chroxy-host-metadata.test.js
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildChroxyHostEnv, readGitIdentity, getChroxyHostEnv, _resetChroxyHostEnvCacheForTest } from '../src/chroxy-host-metadata.js'
+
+describe('chroxy-host-metadata (#6633)', () => {
+  it('builds a fully-populated identity map from injected sources', () => {
+    const env = buildChroxyHostEnv({
+      version: '9.9.9',
+      git: { sha: 'abc1234', branch: 'feat/x' },
+      platform: 'win32',
+      node: '22.1.0',
+      pid: 4242,
+    })
+    assert.deepEqual(env, {
+      CHROXY_HOST_APP: 'Chroxy',
+      CHROXY_HOST_VERSION: '9.9.9',
+      CHROXY_HOST_CHANNEL: 'dev',
+      CHROXY_HOST_PLATFORM: 'win32',
+      CHROXY_HOST_NODE: '22.1.0',
+      CHROXY_HOST_PID: '4242',
+      CHROXY_HOST_GIT_SHA: 'abc1234',
+      CHROXY_HOST_GIT_BRANCH: 'feat/x',
+    })
+  })
+
+  it('every value is a string (env vars can only be strings)', () => {
+    const env = buildChroxyHostEnv({ version: '1.0.0', git: { sha: 'd' }, pid: 7 })
+    for (const [k, v] of Object.entries(env)) {
+      assert.equal(typeof v, 'string', `${k} must be a string, got ${typeof v}`)
+    }
+  })
+
+  it('no git → release channel and no git keys', () => {
+    const env = buildChroxyHostEnv({ version: '1.2.3', git: {}, platform: 'linux', node: '22.0.0', pid: 1 })
+    assert.equal(env.CHROXY_HOST_CHANNEL, 'release')
+    assert.ok(!('CHROXY_HOST_GIT_SHA' in env), 'no SHA key when git is unavailable')
+    assert.ok(!('CHROXY_HOST_GIT_BRANCH' in env), 'no branch key when git is unavailable')
+  })
+
+  it('git SHA without a branch → dev channel, SHA present, branch omitted', () => {
+    const env = buildChroxyHostEnv({ version: '1.0.0', git: { sha: 'deadbee' }, pid: 1 })
+    assert.equal(env.CHROXY_HOST_CHANNEL, 'dev')
+    assert.equal(env.CHROXY_HOST_GIT_SHA, 'deadbee')
+    assert.ok(!('CHROXY_HOST_GIT_BRANCH' in env), 'branch omitted when git reports none')
+  })
+
+  it('falls back to a sentinel version when package.json is unreadable is handled by the real read', () => {
+    // Exercise the real (un-injected) path: version comes from the server
+    // package.json, so it is a non-empty semver-ish string, never undefined.
+    const env = buildChroxyHostEnv({ git: {}, platform: 'linux', node: '22.0.0', pid: 1 })
+    assert.equal(typeof env.CHROXY_HOST_VERSION, 'string')
+    assert.ok(env.CHROXY_HOST_VERSION.length > 0, 'version is populated from package.json')
+  })
+
+  describe('readGitIdentity', () => {
+    it('returns sha + branch from a working git', () => {
+      const exec = (_cmd, args) => {
+        if (args.includes('--abbrev-ref')) return 'main\n'
+        return 'abcdef1\n'
+      }
+      assert.deepEqual(readGitIdentity(exec), { sha: 'abcdef1', branch: 'main' })
+    })
+
+    it('detached HEAD → sha only, no branch', () => {
+      const exec = (_cmd, args) => (args.includes('--abbrev-ref') ? 'HEAD\n' : 'abcdef1\n')
+      assert.deepEqual(readGitIdentity(exec), { sha: 'abcdef1' })
+    })
+
+    it('git failure (no repo) → {}', () => {
+      const exec = () => { throw new Error('not a git repository') }
+      assert.deepEqual(readGitIdentity(exec), {})
+    })
+
+    it('empty sha → {} (never a half-populated identity)', () => {
+      const exec = () => '  \n'
+      assert.deepEqual(readGitIdentity(exec), {})
+    })
+  })
+
+  describe('getChroxyHostEnv memoization', () => {
+    it('returns a stable memoized object across calls', () => {
+      _resetChroxyHostEnvCacheForTest()
+      const a = getChroxyHostEnv()
+      const b = getChroxyHostEnv()
+      assert.equal(a, b, 'same reference — computed once per process')
+      assert.equal(a.CHROXY_HOST_APP, 'Chroxy')
+      assert.equal(typeof a.CHROXY_HOST_VERSION, 'string')
+      _resetChroxyHostEnvCacheForTest()
+    })
+  })
+})

--- a/packages/server/tests/chroxy-host-metadata.test.js
+++ b/packages/server/tests/chroxy-host-metadata.test.js
@@ -75,6 +75,22 @@ describe('chroxy-host-metadata (#6633)', () => {
       const exec = () => '  \n'
       assert.deepEqual(readGitIdentity(exec), {})
     })
+
+    it('installed as a dependency (path under node_modules) → {} without touching git', () => {
+      // Guards the privacy fix: an npm-installed chroxy must NOT walk up to the
+      // user's project .git and leak their branch/SHA into third-party subprocesses.
+      let called = false
+      const exec = () => { called = true; return 'abcdef1\n' }
+      const out = readGitIdentity(exec, '/home/u/proj/node_modules/chroxy/packages/server/src')
+      assert.deepEqual(out, {}, 'no git identity for an installed package')
+      assert.equal(called, false, 'git is never invoked when under node_modules')
+    })
+
+    it('a source checkout (no node_modules ancestor) still queries git', () => {
+      const exec = (_c, args) => (args.includes('--abbrev-ref') ? 'main\n' : 'abcdef1\n')
+      const out = readGitIdentity(exec, '/home/u/src/chroxy/packages/server/src')
+      assert.deepEqual(out, { sha: 'abcdef1', branch: 'main' })
+    })
   })
 
   describe('getChroxyHostEnv memoization', () => {

--- a/packages/server/tests/chroxy-host-metadata.test.js
+++ b/packages/server/tests/chroxy-host-metadata.test.js
@@ -44,9 +44,9 @@ describe('chroxy-host-metadata (#6633)', () => {
     assert.ok(!('CHROXY_HOST_GIT_BRANCH' in env), 'branch omitted when git reports none')
   })
 
-  it('falls back to a sentinel version when package.json is unreadable is handled by the real read', () => {
-    // Exercise the real (un-injected) path: version comes from the server
-    // package.json, so it is a non-empty semver-ish string, never undefined.
+  it('reads a real, non-empty version from package.json via the un-injected path', () => {
+    // Exercise the real (un-injected) read: version comes from the server
+    // package.json, so it is always a non-empty string, never undefined.
     const env = buildChroxyHostEnv({ git: {}, platform: 'linux', node: '22.0.0', pid: 1 })
     assert.equal(typeof env.CHROXY_HOST_VERSION, 'string')
     assert.ok(env.CHROXY_HOST_VERSION.length > 0, 'version is populated from package.json')

--- a/packages/server/tests/spawn-env.test.js
+++ b/packages/server/tests/spawn-env.test.js
@@ -311,13 +311,24 @@ describe('buildSpawnEnv', () => {
       })
     })
 
-    it('host identity is authoritative — an operator CHROXY_HOST_* export cannot spoof it', () => {
+    it('host identity is authoritative — an operator CHROXY_HOST_* export cannot spoof it (allowlist)', () => {
       // The values are COMPUTED, not passed through, so a shell export of the
       // same name is overridden by the real identity (important for allowlist
       // mode, where it also proves the value did not merely leak through).
       withEnv({ OPENAI_API_KEY: 'sk', CHROXY_HOST_VERSION: '0.0.0-spoofed', CHROXY_HOST_APP: 'NotChroxy' }, () => {
         const env = buildSpawnEnv('codex')
         assert.notEqual(env.CHROXY_HOST_VERSION, '0.0.0-spoofed', 'computed version wins over an operator export')
+        assert.equal(env.CHROXY_HOST_APP, 'Chroxy', 'app name is authoritative')
+      })
+    })
+
+    it('operator CHROXY_HOST_* export cannot spoof it in DENYLIST mode either', () => {
+      // Denylist mode is where spoofing actually has teeth: parentEnv carries the
+      // operator's export, so correctness depends entirely on `...getChroxyHostEnv()`
+      // being spread AFTER `...parentEnv`. Guard that ordering against regression.
+      withEnv({ CHROXY_HOST_VERSION: '0.0.0-spoofed', CHROXY_HOST_APP: 'NotChroxy' }, () => {
+        const env = buildSpawnEnv('claude')
+        assert.notEqual(env.CHROXY_HOST_VERSION, '0.0.0-spoofed', 'computed version overrides the operator export from parentEnv')
         assert.equal(env.CHROXY_HOST_APP, 'Chroxy', 'app name is authoritative')
       })
     })

--- a/packages/server/tests/spawn-env.test.js
+++ b/packages/server/tests/spawn-env.test.js
@@ -289,4 +289,37 @@ describe('buildSpawnEnv', () => {
       })
     })
   })
+
+  // #6633: every agent subprocess gets Chroxy's host identity so a session can
+  // answer "what build am I in?" — via buildSpawnEnv for all subprocess providers.
+  describe('host identity injection (#6633)', () => {
+    it('injects CHROXY_HOST_* into an allowlist-mode child (codex)', () => {
+      withEnv({ OPENAI_API_KEY: 'sk' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.equal(env.CHROXY_HOST_APP, 'Chroxy')
+        assert.ok(env.CHROXY_HOST_VERSION && env.CHROXY_HOST_VERSION.length > 0)
+        assert.ok(['dev', 'release'].includes(env.CHROXY_HOST_CHANNEL))
+        assert.ok(env.CHROXY_HOST_PLATFORM, 'platform is present')
+      })
+    })
+
+    it('injects CHROXY_HOST_* into a denylist-mode child (claude)', () => {
+      withEnv({}, () => {
+        const env = buildSpawnEnv('claude')
+        assert.equal(env.CHROXY_HOST_APP, 'Chroxy')
+        assert.ok(env.CHROXY_HOST_VERSION && env.CHROXY_HOST_VERSION.length > 0)
+      })
+    })
+
+    it('host identity is authoritative — an operator CHROXY_HOST_* export cannot spoof it', () => {
+      // The values are COMPUTED, not passed through, so a shell export of the
+      // same name is overridden by the real identity (important for allowlist
+      // mode, where it also proves the value did not merely leak through).
+      withEnv({ OPENAI_API_KEY: 'sk', CHROXY_HOST_VERSION: '0.0.0-spoofed', CHROXY_HOST_APP: 'NotChroxy' }, () => {
+        const env = buildSpawnEnv('codex')
+        assert.notEqual(env.CHROXY_HOST_VERSION, '0.0.0-spoofed', 'computed version wins over an operator export')
+        assert.equal(env.CHROXY_HOST_APP, 'Chroxy', 'app name is authoritative')
+      })
+    })
+  })
 })


### PR DESCRIPTION
## What

Agents (Claude, Codex, Gemini, …) couldn't reliably answer *"what Chroxy build am I running in?"* from inside a session — only guess from screenshots, the checked-out repo, or app-bundle metadata. That made smoke-testing a freshly rebuilt branch guesswork (the motivating chat: _"what is the current chroxy im communicating with you on? I wanna smoke test your changes"_).

This gives every session a small, **computed, authoritative** host-identity block via environment variables.

## The variables

| Variable | Present | Meaning |
|---|---|---|
| `CHROXY_HOST_APP` | always | `Chroxy` |
| `CHROXY_HOST_VERSION` | always | running server package version |
| `CHROXY_HOST_CHANNEL` | always | `dev` (git working tree) / `release` |
| `CHROXY_HOST_PLATFORM` | always | `darwin`/`win32`/`linux` |
| `CHROXY_HOST_NODE` | always | daemon Node version |
| `CHROXY_HOST_PID` | always | daemon PID (pins the exact process) |
| `CHROXY_HOST_GIT_SHA` | dev | short commit SHA |
| `CHROXY_HOST_GIT_BRANCH` | dev | branch (omitted when detached) |

Values are **computed by the daemon** (version from its `package.json`, git via `git`), never passed through from the operator's shell — so a stray `CHROXY_HOST_*` export cannot spoof them (there's a test for this).

## How — provider-neutral, single chokepoint

- **`chroxy-host-metadata.js`** — pure `buildChroxyHostEnv(opts)` + memoized `getChroxyHostEnv()` + injectable `readGitIdentity(exec)`. Git/version reads are guarded and time-boxed so identity never blocks or fails a spawn.
- **`buildSpawnEnv`** merges the block into both allowlist (codex/gemini) and denylist (claude) child envs — the one chokepoint every subprocess provider uses. Non-sensitive, so safe for allowlist mode.
- **`server-cli` startup** publishes the same block into the daemon's own `process.env`, so the in-process Claude SDK provider's Bash tools inherit it too.

A session reads it with a plain shell call:
```bash
echo "$CHROXY_HOST_APP $CHROXY_HOST_VERSION ($CHROXY_HOST_CHANNEL) — $CHROXY_HOST_GIT_BRANCH@$CHROXY_HOST_GIT_SHA"
```

## Tests / docs

- `chroxy-host-metadata.test.js` (10) — field map, string-only values, dev/release channel, detached HEAD, git-failure → `{}`, memoization.
- `spawn-env.test.js` (+3) — injected into allowlist (codex) and denylist (claude) children; **operator export cannot spoof** the computed identity.
- Full server suite **green on Linux CI**. (On a Windows/WSL dev host ~56 integration tests fail pre-existing — CRLF `.sh` endings + codex-binary version — confirmed identical with my changes reverted; unrelated to this PR.)
- `docs/guides/host-metadata.md` documents the vars and how a skill/agent prompt reads them (acceptance: "document how a skill should read this").

Satisfies all five acceptance criteria in the issue.

Closes #6633