### PR TITLE
feat(cli): add `chroxy tokens` to list and revoke paired-device session tokens

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -27,6 +27,7 @@ import { registerProvidersCommand } from './cli/providers-cmd.js'
 import { registerPagesCommands } from './cli/pages-cmd.js'
 import { registerShellApprovalCommand } from './cli/shell-cmd.js'
 import { registerIdentityCommand } from './cli/identity-cmd.js'
+import { registerTokensCommand } from './cli/tokens-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -56,5 +57,6 @@ registerProvidersCommand(program)
 registerPagesCommands(program)
 registerShellApprovalCommand(program)
 registerIdentityCommand(program)
+registerTokensCommand(program)
 
 program.parse()

--- a/packages/server/src/cli/tokens-cmd.js
+++ b/packages/server/src/cli/tokens-cmd.js
@@ -41,6 +41,17 @@ const UNREADABLE_NOTE =
   'permissions, or corrupt). Refusing to touch it so a readable store is never lost. Fix the ' +
   'store access (or stop the daemon and inspect ~/.chroxy/session-tokens.json) and retry.'
 
+// A decoded store SHOULD be `[token, meta]` tuples, but a hand-edited / partially
+// corrupt store could carry a non-tuple element. These accessors never throw on
+// one, so a single bad row can't crash `list`/`revoke` — the bad row shows as
+// malformed and is preserved (not silently dropped) across a targeted revoke.
+function tokenOf(entry) {
+  return Array.isArray(entry) && typeof entry[0] === 'string' ? entry[0] : ''
+}
+function metaOf(entry) {
+  return Array.isArray(entry) && entry[1] && typeof entry[1] === 'object' ? entry[1] : {}
+}
+
 /**
  * List persisted session tokens. Pure aside from the injected store/writer/clock,
  * so a test drives it with an in-memory store.
@@ -63,11 +74,15 @@ export function runTokensList(deps = {}) {
     return { count: 0, tokens: [] }
   }
 
-  const rows = entries.map(([token, meta]) => ({
-    handle: String(token).slice(0, 12),
-    sessionId: (meta && typeof meta.sessionId === 'string' && meta.sessionId) || '(none)',
-    ageMs: meta && typeof meta.createdAt === 'number' ? now - meta.createdAt : null,
-  }))
+  const rows = entries.map((entry) => {
+    const token = tokenOf(entry)
+    const meta = metaOf(entry)
+    return {
+      handle: token ? token.slice(0, 12) : '(malformed)',
+      sessionId: (typeof meta.sessionId === 'string' && meta.sessionId) || '(none)',
+      ageMs: typeof meta.createdAt === 'number' ? now - meta.createdAt : null,
+    }
+  })
 
   out(`${rows.length} paired session token(s):`)
   for (const r of rows) {
@@ -130,7 +145,9 @@ export function runTokensRevoke(target, options = {}, deps = {}) {
     return { revoked: 0, mode: 'one', error: 'no-target' }
   }
 
-  const matches = list.filter(([token]) => String(token).startsWith(target))
+  // target is non-empty here (guarded above), so a malformed row (tokenOf === '')
+  // never matches and is preserved in `remaining`.
+  const matches = list.filter((e) => tokenOf(e).startsWith(target))
   if (matches.length === 0) {
     out(`No session token matches "${target}". Run: chroxy tokens list`)
     return { revoked: 0, mode: 'one', error: 'no-match' }
@@ -141,7 +158,7 @@ export function runTokensRevoke(target, options = {}, deps = {}) {
     return { revoked: 0, mode: 'one', error: 'ambiguous', matches: matches.length }
   }
 
-  const remaining = list.filter(([token]) => !String(token).startsWith(target))
+  const remaining = list.filter((e) => !tokenOf(e).startsWith(target))
   if (!store.save(remaining)) {
     out(`Failed to write the session-token store — nothing revoked. ${UNREADABLE_NOTE}`)
     return { revoked: 0, mode: 'one', error: 'persist-failed' }

--- a/packages/server/src/cli/tokens-cmd.js
+++ b/packages/server/src/cli/tokens-cmd.js
@@ -1,0 +1,158 @@
+// `chroxy tokens` — list and revoke persisted paired-device session tokens
+// (#6599, part of epic #6597). Operates on the on-disk session-token store
+// (`~/.chroxy/session-tokens.json`, #6598) — the same encrypted store the daemon
+// loads at boot.
+//
+// Like `chroxy identity rotate`, this edits the PERSISTED store and takes effect
+// on the daemon's next start: a running daemon keeps its already-issued tokens in
+// memory (and would re-persist them on the next change), so restart the daemon to
+// enforce a revoke. Live revocation against a running daemon is a follow-up.
+//
+// Revoke targets a token by a unique handle PREFIX (from `tokens list`); the full
+// token is never printed. `--all` is the panic button and requires `--yes`.
+
+import { homedir } from 'os'
+import { join } from 'path'
+import { createSessionTokenStore } from '../session-token-store.js'
+
+/** Resolve the chroxy config dir the same way server-cli does. */
+function resolveChroxyDir(env = process.env) {
+  return env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+}
+
+/** Human-readable age; null when the entry has no createdAt. */
+function formatAge(ms) {
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return 'unknown'
+  const sec = Math.floor(ms / 1000)
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h`
+  return `${Math.floor(hr / 24)}d`
+}
+
+const ENFORCE_NOTE =
+  'Restart the daemon to enforce — a running daemon keeps already-issued tokens in memory until restart.'
+
+/**
+ * List persisted session tokens. Pure aside from the injected store/writer/clock,
+ * so a test drives it with an in-memory store.
+ *
+ * @param {object} [deps] - { store, write, now }
+ * @returns {{ count: number, tokens: Array<{ handle: string, sessionId: string, ageMs: number|null }> }}
+ */
+export function runTokensList(deps = {}) {
+  const out = deps.write || console.log
+  const store = deps.store || createSessionTokenStore({ dir: resolveChroxyDir() })
+  const now = typeof deps.now === 'number' ? deps.now : Date.now()
+
+  const entries = store.load()
+  if (!Array.isArray(entries) || entries.length === 0) {
+    out('No paired session tokens. Devices pair via the dashboard QR / pairing code.')
+    return { count: 0, tokens: [] }
+  }
+
+  const rows = entries.map(([token, meta]) => ({
+    handle: String(token).slice(0, 12),
+    sessionId: (meta && typeof meta.sessionId === 'string' && meta.sessionId) || '(none)',
+    ageMs: meta && typeof meta.createdAt === 'number' ? now - meta.createdAt : null,
+  }))
+
+  out(`${rows.length} paired session token(s):`)
+  for (const r of rows) {
+    out(`  ${r.handle}…  session=${r.sessionId}  age=${formatAge(r.ageMs)}`)
+  }
+  out('')
+  out('Revoke one:  chroxy tokens revoke <handle-prefix>')
+  out('Revoke all:  chroxy tokens revoke --all --yes')
+  return { count: rows.length, tokens: rows }
+}
+
+/**
+ * Revoke a session token by handle prefix, or every token with `--all`.
+ *
+ * @param {string|undefined} target - handle prefix (ignored when `options.all`)
+ * @param {{ all?: boolean, yes?: boolean }} [options]
+ * @param {object} [deps] - { store, write }
+ * @returns {{ revoked: number, mode: 'all'|'one', confirmed?: boolean, error?: string, matches?: number }}
+ */
+export function runTokensRevoke(target, options = {}, deps = {}) {
+  const out = deps.write || console.log
+  const store = deps.store || createSessionTokenStore({ dir: resolveChroxyDir() })
+  const entries = store.load()
+  const list = Array.isArray(entries) ? entries : []
+
+  if (options.all) {
+    if (!options.yes) {
+      out(
+        [
+          `chroxy tokens revoke --all — the panic button: revoke ALL ${list.length} paired device token(s).`,
+          '',
+          'Every paired device must re-pair (dashboard QR / pairing code) after this.',
+          `${ENFORCE_NOTE}`,
+          '',
+          'This is consequential — re-run with --yes to proceed:',
+          '  chroxy tokens revoke --all --yes',
+        ].join('\n'),
+      )
+      return { revoked: 0, mode: 'all', confirmed: false }
+    }
+    store.save([])
+    out(`Revoked all ${list.length} session token(s). ${ENFORCE_NOTE}`)
+    return { revoked: list.length, mode: 'all', confirmed: true }
+  }
+
+  if (!target) {
+    out('Specify a token handle prefix (see: chroxy tokens list), or --all to revoke every token.')
+    return { revoked: 0, mode: 'one', error: 'no-target' }
+  }
+
+  const matches = list.filter(([token]) => String(token).startsWith(target))
+  if (matches.length === 0) {
+    out(`No session token matches "${target}". Run: chroxy tokens list`)
+    return { revoked: 0, mode: 'one', error: 'no-match' }
+  }
+  if (matches.length > 1) {
+    // Never guess which token to drop — demand a longer, unambiguous prefix.
+    out(`"${target}" matches ${matches.length} tokens — use a longer handle prefix to disambiguate.`)
+    return { revoked: 0, mode: 'one', error: 'ambiguous', matches: matches.length }
+  }
+
+  const remaining = list.filter(([token]) => !String(token).startsWith(target))
+  store.save(remaining)
+  out(`Revoked 1 session token (${target}…). ${ENFORCE_NOTE}`)
+  return { revoked: 1, mode: 'one', confirmed: true }
+}
+
+export function registerTokensCommand(program) {
+  const tokens = program
+    .command('tokens')
+    .description('List and revoke persisted paired-device session tokens (#6599)')
+
+  tokens
+    .command('list')
+    .description('List paired-device session tokens (handle, session, age)')
+    .action(() => {
+      try {
+        runTokensList()
+      } catch (err) {
+        console.error(`tokens list failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  tokens
+    .command('revoke [handle]')
+    .description('Revoke a session token by handle prefix, or --all to revoke every token')
+    .option('--all', 'Revoke EVERY paired-device token (panic button — all devices re-pair)')
+    .option('--yes', 'Confirm --all (without it, the command only explains what it would do)')
+    .action((handle, options) => {
+      try {
+        runTokensRevoke(handle, options)
+      } catch (err) {
+        console.error(`tokens revoke failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+}

--- a/packages/server/src/cli/tokens-cmd.js
+++ b/packages/server/src/cli/tokens-cmd.js
@@ -20,7 +20,7 @@ function resolveChroxyDir(env = process.env) {
   return env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
 }
 
-/** Human-readable age; null when the entry has no createdAt. */
+/** Human-readable age string; 'unknown' when the caller passes a non-finite age. */
 function formatAge(ms) {
   if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return 'unknown'
   const sec = Math.floor(ms / 1000)
@@ -33,7 +33,13 @@ function formatAge(ms) {
 }
 
 const ENFORCE_NOTE =
-  'Restart the daemon to enforce — a running daemon keeps already-issued tokens in memory until restart.'
+  'Restart the daemon to enforce — a running daemon keeps already-issued tokens in memory ' +
+  'and will re-persist (effectively restoring this token) if it writes before you restart.'
+
+const UNREADABLE_NOTE =
+  'The session-token store exists but could not be read (keychain unavailable, wrong file ' +
+  'permissions, or corrupt). Refusing to touch it so a readable store is never lost. Fix the ' +
+  'store access (or stop the daemon and inspect ~/.chroxy/session-tokens.json) and retry.'
 
 /**
  * List persisted session tokens. Pure aside from the injected store/writer/clock,
@@ -47,7 +53,11 @@ export function runTokensList(deps = {}) {
   const store = deps.store || createSessionTokenStore({ dir: resolveChroxyDir() })
   const now = typeof deps.now === 'number' ? deps.now : Date.now()
 
-  const entries = store.load()
+  const { status, entries } = store.loadResult()
+  if (status === 'unreadable') {
+    out(UNREADABLE_NOTE)
+    return { count: 0, tokens: [], error: 'unreadable' }
+  }
   if (!Array.isArray(entries) || entries.length === 0) {
     out('No paired session tokens. Devices pair via the dashboard QR / pairing code.')
     return { count: 0, tokens: [] }
@@ -80,7 +90,16 @@ export function runTokensList(deps = {}) {
 export function runTokensRevoke(target, options = {}, deps = {}) {
   const out = deps.write || console.log
   const store = deps.store || createSessionTokenStore({ dir: resolveChroxyDir() })
-  const entries = store.load()
+
+  // #6599 — never operate on a store we couldn't read: an 'unreadable' result
+  // (present file, bad perms / no keychain key / corrupt) must NOT be mistaken for
+  // an empty store, or `revoke --all` would silently overwrite real tokens with []
+  // and report "0". Refuse and exit non-zero instead.
+  const { status, entries } = store.loadResult()
+  if (status === 'unreadable') {
+    out(UNREADABLE_NOTE)
+    return { revoked: 0, mode: options.all ? 'all' : 'one', error: 'unreadable' }
+  }
   const list = Array.isArray(entries) ? entries : []
 
   if (options.all) {
@@ -98,7 +117,10 @@ export function runTokensRevoke(target, options = {}, deps = {}) {
       )
       return { revoked: 0, mode: 'all', confirmed: false }
     }
-    store.save([])
+    if (!store.save([])) {
+      out(`Failed to write the session-token store — nothing revoked. ${UNREADABLE_NOTE}`)
+      return { revoked: 0, mode: 'all', error: 'persist-failed' }
+    }
     out(`Revoked all ${list.length} session token(s). ${ENFORCE_NOTE}`)
     return { revoked: list.length, mode: 'all', confirmed: true }
   }
@@ -120,7 +142,10 @@ export function runTokensRevoke(target, options = {}, deps = {}) {
   }
 
   const remaining = list.filter(([token]) => !String(token).startsWith(target))
-  store.save(remaining)
+  if (!store.save(remaining)) {
+    out(`Failed to write the session-token store — nothing revoked. ${UNREADABLE_NOTE}`)
+    return { revoked: 0, mode: 'one', error: 'persist-failed' }
+  }
   out(`Revoked 1 session token (${target}…). ${ENFORCE_NOTE}`)
   return { revoked: 1, mode: 'one', confirmed: true }
 }
@@ -135,7 +160,8 @@ export function registerTokensCommand(program) {
     .description('List paired-device session tokens (handle, session, age)')
     .action(() => {
       try {
-        runTokensList()
+        const res = runTokensList()
+        if (res.error) process.exitCode = 1
       } catch (err) {
         console.error(`tokens list failed: ${err.message}`)
         process.exitCode = 1
@@ -149,7 +175,11 @@ export function registerTokensCommand(program) {
     .option('--yes', 'Confirm --all (without it, the command only explains what it would do)')
     .action((handle, options) => {
       try {
-        runTokensRevoke(handle, options)
+        const res = runTokensRevoke(handle, options)
+        // Exit non-zero on genuine operational failures (a store we couldn't read
+        // or write) so scripts/operators know the revoke did NOT happen. User-input
+        // guidance (no-match / ambiguous / no-target / unconfirmed --all) exits 0.
+        if (res.error === 'unreadable' || res.error === 'persist-failed') process.exitCode = 1
       } catch (err) {
         console.error(`tokens revoke failed: ${err.message}`)
         process.exitCode = 1

--- a/packages/server/src/session-token-store.js
+++ b/packages/server/src/session-token-store.js
@@ -26,45 +26,61 @@ const STORE_FILE = 'session-tokens.json'
  * @param {object} opts
  * @param {string} opts.dir - directory to hold the store (e.g. `~/.chroxy`).
  * @param {object} [opts.keychain] - keychain module (injectable for tests).
- * @returns {{ load: () => Array<[string, object]>, save: (entries: Array<[string, object]>) => void }}
+ * @returns {{
+ *   load: () => Array<[string, object]>,
+ *   loadResult: () => { status: 'absent'|'ok'|'unreadable', entries: Array<[string, object]> },
+ *   exists: () => boolean,
+ *   save: (entries: Array<[string, object]>) => boolean,
+ * }}
  *   `entries` is the `[token, meta]` pair list from the PairingManager map.
  */
 export function createSessionTokenStore({ dir, keychain = realKeychain } = {}) {
   const file = join(dir, STORE_FILE)
 
-  return {
-    load() {
-      try {
-        if (!existsSync(file)) return []
-        // Enforce owner-only 0600 (POSIX) — same boundary as the credential store.
-        // A world/group-readable token file is refused rather than trusted.
-        if (process.platform !== 'win32') {
-          const perms = statSync(file).mode & 0o777
-          if (perms !== 0o600) {
-            log.warn(`${file} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600) — devices will re-pair`)
-            return []
-          }
+  // Read the store, distinguishing the THREE outcomes an interactive caller must
+  // not conflate (#6599): 'absent' (no file), 'ok' (read + decoded), 'unreadable'
+  // (file present but wrong perms / no keychain key / corrupt / undecryptable).
+  // The daemon's `load()` fail-softs all of these to `[]` (a re-pair is harmless);
+  // the tokens CLI uses `loadResult()` so it never overwrites a store it couldn't
+  // read, nor reports "0 tokens" for one it simply failed to decrypt.
+  function read() {
+    try {
+      if (!existsSync(file)) return { status: 'absent', entries: [] }
+      // Enforce owner-only 0600 (POSIX) — same boundary as the credential store.
+      // A world/group-readable token file is refused rather than trusted.
+      if (process.platform !== 'win32') {
+        const perms = statSync(file).mode & 0o777
+        if (perms !== 0o600) {
+          log.warn(`${file} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600) — devices will re-pair`)
+          return { status: 'unreadable', entries: [] }
         }
-        const parsed = JSON.parse(readFileSync(file, 'utf8'))
-        if (isEncryptedEnvelope(parsed)) {
-          const key = getOrCreateMasterKey(keychain)
-          if (!key) {
-            log.warn('session-token store is encrypted but no keychain key is available — devices will re-pair')
-            return []
-          }
-          const data = decryptEnvelope(parsed, key)
-          return Array.isArray(data?.entries) ? data.entries : []
-        }
-        // Plaintext fallback (no-keychain host).
-        return Array.isArray(parsed?.entries) ? parsed.entries : []
-      } catch (err) {
-        // A missing / corrupt / undecryptable store is not fatal: the worst case
-        // is that devices re-pair (the pre-#6598 behaviour). Never throw into the
-        // auth path.
-        log.warn(`could not load persisted session tokens (${err.message}) — devices will re-pair`)
-        return []
       }
-    },
+      const parsed = JSON.parse(readFileSync(file, 'utf8'))
+      if (isEncryptedEnvelope(parsed)) {
+        const key = getOrCreateMasterKey(keychain)
+        if (!key) {
+          log.warn('session-token store is encrypted but no keychain key is available — devices will re-pair')
+          return { status: 'unreadable', entries: [] }
+        }
+        const data = decryptEnvelope(parsed, key)
+        return { status: 'ok', entries: Array.isArray(data?.entries) ? data.entries : [] }
+      }
+      // Plaintext fallback (no-keychain host).
+      return { status: 'ok', entries: Array.isArray(parsed?.entries) ? parsed.entries : [] }
+    } catch (err) {
+      // A missing / corrupt / undecryptable store is not fatal for the daemon: the
+      // worst case is that devices re-pair (the pre-#6598 behaviour). Never throw
+      // into the auth path. Report 'unreadable' so an interactive caller can tell
+      // this apart from a genuinely-empty store.
+      log.warn(`could not load persisted session tokens (${err.message}) — devices will re-pair`)
+      return { status: 'unreadable', entries: [] }
+    }
+  }
+
+  return {
+    load: () => read().entries,
+    loadResult: read,
+    exists: () => existsSync(file),
 
     save(entries) {
       try {
@@ -73,10 +89,13 @@ export function createSessionTokenStore({ dir, keychain = realKeychain } = {}) {
         const key = getOrCreateMasterKey(keychain)
         const body = key ? JSON.stringify(encryptJson(payload, key)) : JSON.stringify(payload)
         writeFileRestricted(file, body)
+        return true
       } catch (err) {
-        // Persistence is best-effort: a failed write just means a restart may
-        // require re-pairing. Don't let it break token issuance.
+        // Persistence is best-effort for the daemon (a failed write just means a
+        // restart may require re-pairing), so we don't throw; but RETURN false so
+        // an interactive caller can report the failure instead of a false success.
         log.warn(`could not persist session tokens (${err.message})`)
+        return false
       }
     },
   }

--- a/packages/server/tests/tokens-cmd.test.js
+++ b/packages/server/tests/tokens-cmd.test.js
@@ -2,12 +2,25 @@ import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { runTokensList, runTokensRevoke } from '../src/cli/tokens-cmd.js'
 
-// In-memory session-token store fake matching the { load, save } adapter shape.
-function fakeStore(initial = []) {
+// In-memory session-token store fake matching the { load, loadResult, exists,
+// save } adapter shape. `opts.status` forces an 'unreadable' result; `opts.saveOk
+// = false` simulates a persist failure.
+function fakeStore(initial = [], opts = {}) {
   let entries = initial.map((e) => [e[0], { ...e[1] }])
+  const status = opts.status || 'ok'
+  const saveOk = opts.saveOk !== false
   return {
     load: () => entries.map((e) => [e[0], { ...e[1] }]),
-    save: (next) => { entries = next.map((e) => [e[0], { ...e[1] }]) },
+    loadResult: () => ({
+      status,
+      entries: status === 'unreadable' ? [] : entries.map((e) => [e[0], { ...e[1] }]),
+    }),
+    exists: () => status !== 'absent',
+    save: (next) => {
+      if (!saveOk) return false
+      entries = next.map((e) => [e[0], { ...e[1] }])
+      return true
+    },
     _current: () => entries,
   }
 }
@@ -56,6 +69,17 @@ describe('chroxy tokens — list (#6599)', () => {
     assert.equal(res.tokens[0].ageMs, null)
     assert.match(w.text(), /age=unknown/)
   })
+
+  it('an UNREADABLE store is reported as an error, never as "empty"', () => {
+    const w = cap()
+    // A present-but-unreadable store (bad perms / no keychain key / corrupt) must
+    // not masquerade as "no tokens".
+    const res = runTokensList({ store: fakeStore([['tok', { createdAt: NOW }]], { status: 'unreadable' }), write: w.write, now: NOW })
+    assert.equal(res.error, 'unreadable')
+    assert.equal(res.count, 0)
+    assert.match(w.text(), /could not be read/)
+    assert.doesNotMatch(w.text(), /No paired session tokens/)
+  })
 })
 
 describe('chroxy tokens — revoke one (#6599)', () => {
@@ -101,6 +125,34 @@ describe('chroxy tokens — revoke one (#6599)', () => {
     assert.equal(res.error, 'no-target')
     assert.equal(store._current().length, 2)
   })
+
+  it('an EMPTY-STRING target is refused (no-target) and never wipes a single-token store', () => {
+    // The `if (!target)` guard is load-bearing: '' would otherwise match every
+    // token via startsWith(''), and on a single-token store revoke exactly one.
+    const single = fakeStore([['only1token', { createdAt: NOW }]])
+    const w = cap()
+    const res = runTokensRevoke('', {}, { store: single, write: w.write })
+    assert.equal(res.error, 'no-target')
+    assert.equal(res.revoked, 0)
+    assert.equal(single._current().length, 1, 'the single token survives an empty target')
+  })
+
+  it('refuses to revoke against an UNREADABLE store (never overwrites it)', () => {
+    const s = fakeStore([[A, { createdAt: NOW }]], { status: 'unreadable' })
+    const w = cap()
+    const res = runTokensRevoke('aaaa', {}, { store: s, write: w.write })
+    assert.equal(res.error, 'unreadable')
+    assert.equal(s._current().length, 1, 'the unreadable store is left intact')
+  })
+
+  it('reports persist-failure instead of a false success', () => {
+    const s = fakeStore([[A, { createdAt: NOW }], [B, { createdAt: NOW }]], { saveOk: false })
+    const w = cap()
+    const res = runTokensRevoke('aaaa1111', {}, { store: s, write: w.write })
+    assert.equal(res.error, 'persist-failed')
+    assert.equal(res.revoked, 0)
+    assert.match(w.text(), /Failed to write/)
+  })
 })
 
 describe('chroxy tokens — revoke --all (#6599)', () => {
@@ -129,5 +181,25 @@ describe('chroxy tokens — revoke --all (#6599)', () => {
     const res = runTokensRevoke(undefined, { all: true, yes: true }, { store, write: w.write })
     assert.equal(res.revoked, 0)
     assert.equal(store._current().length, 0)
+  })
+
+  it('--all --yes REFUSES to overwrite a present-but-unreadable store (the key footgun)', () => {
+    // Two real tokens the CLI can't decrypt. A naive load()->[] + save([]) would
+    // destroy them and report "0". loadResult()==='unreadable' must block the wipe.
+    const s = fakeStore([['t1aaaa', { createdAt: NOW }], ['t2bbbb', { createdAt: NOW }]], { status: 'unreadable' })
+    const w = cap()
+    const res = runTokensRevoke(undefined, { all: true, yes: true }, { store: s, write: w.write })
+    assert.equal(res.error, 'unreadable')
+    assert.equal(res.revoked, 0)
+    assert.equal(s._current().length, 2, 'the unreadable store is NOT overwritten')
+    assert.match(w.text(), /could not be read/)
+  })
+
+  it('--all --yes reports persist-failure instead of a false success', () => {
+    const s = fakeStore([['t1aaaa', { createdAt: NOW }]], { saveOk: false })
+    const w = cap()
+    const res = runTokensRevoke(undefined, { all: true, yes: true }, { store: s, write: w.write })
+    assert.equal(res.error, 'persist-failed')
+    assert.match(w.text(), /Failed to write/)
   })
 })

--- a/packages/server/tests/tokens-cmd.test.js
+++ b/packages/server/tests/tokens-cmd.test.js
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { runTokensList, runTokensRevoke } from '../src/cli/tokens-cmd.js'
+
+// In-memory session-token store fake matching the { load, save } adapter shape.
+function fakeStore(initial = []) {
+  let entries = initial.map((e) => [e[0], { ...e[1] }])
+  return {
+    load: () => entries.map((e) => [e[0], { ...e[1] }]),
+    save: (next) => { entries = next.map((e) => [e[0], { ...e[1] }]) },
+    _current: () => entries,
+  }
+}
+
+// Capture writer.
+function cap() {
+  const lines = []
+  return { write: (s) => lines.push(String(s)), lines, text: () => lines.join('\n') }
+}
+
+const NOW = 1_800_000_000_000
+
+describe('chroxy tokens — list (#6599)', () => {
+  it('reports an empty store without leaking anything', () => {
+    const w = cap()
+    const res = runTokensList({ store: fakeStore([]), write: w.write, now: NOW })
+    assert.equal(res.count, 0)
+    assert.deepEqual(res.tokens, [])
+    assert.match(w.text(), /No paired session tokens/)
+  })
+
+  it('lists entries by 12-char handle, session, and age — never the full token', () => {
+    const token = 'abcdefghijklmNOPQRSTUVWXYZ0123456789fulltoken'
+    const w = cap()
+    const res = runTokensList({
+      store: fakeStore([[token, { createdAt: NOW - 3 * 3600_000, sessionId: 'sess-1' }]]),
+      write: w.write,
+      now: NOW,
+    })
+    assert.equal(res.count, 1)
+    assert.equal(res.tokens[0].handle, 'abcdefghijkl')
+    assert.equal(res.tokens[0].sessionId, 'sess-1')
+    // full token must never appear in the output
+    assert.ok(!w.text().includes(token), 'full token is never printed')
+    assert.match(w.text(), /abcdefghijkl….*session=sess-1.*age=3h/)
+  })
+
+  it('handles a missing sessionId / createdAt gracefully', () => {
+    const w = cap()
+    const res = runTokensList({
+      store: fakeStore([['tok0000000000rest', {}]]),
+      write: w.write,
+      now: NOW,
+    })
+    assert.equal(res.tokens[0].sessionId, '(none)')
+    assert.equal(res.tokens[0].ageMs, null)
+    assert.match(w.text(), /age=unknown/)
+  })
+})
+
+describe('chroxy tokens — revoke one (#6599)', () => {
+  let store
+  const A = 'aaaa1111bbbb2222cccc'
+  const B = 'bbbb3333dddd4444eeee'
+  beforeEach(() => {
+    store = fakeStore([[A, { createdAt: NOW, sessionId: 's-a' }], [B, { createdAt: NOW, sessionId: 's-b' }]])
+  })
+
+  it('revokes exactly the matching token by unique prefix and persists the rest', () => {
+    const w = cap()
+    const res = runTokensRevoke('aaaa1111', {}, { store, write: w.write })
+    assert.deepEqual(res, { revoked: 1, mode: 'one', confirmed: true })
+    const remaining = store._current().map(([t]) => t)
+    assert.deepEqual(remaining, [B], 'only the non-matching token remains')
+    assert.match(w.text(), /Revoked 1 session token/)
+    assert.match(w.text(), /Restart the daemon to enforce/)
+  })
+
+  it('refuses an ambiguous prefix without revoking anything', () => {
+    const s = fakeStore([['pre_a_xxxx', { createdAt: NOW }], ['pre_b_yyyy', { createdAt: NOW }]])
+    const w = cap()
+    const res = runTokensRevoke('pre_', {}, { store: s, write: w.write })
+    assert.equal(res.error, 'ambiguous')
+    assert.equal(res.matches, 2)
+    assert.equal(res.revoked, 0)
+    assert.equal(s._current().length, 2, 'nothing revoked on an ambiguous prefix')
+    assert.match(w.text(), /use a longer handle prefix/)
+  })
+
+  it('reports no-match without touching the store', () => {
+    const w = cap()
+    const res = runTokensRevoke('zzzz', {}, { store, write: w.write })
+    assert.equal(res.error, 'no-match')
+    assert.equal(store._current().length, 2)
+    assert.match(w.text(), /No session token matches/)
+  })
+
+  it('errors when no handle and no --all is given', () => {
+    const w = cap()
+    const res = runTokensRevoke(undefined, {}, { store, write: w.write })
+    assert.equal(res.error, 'no-target')
+    assert.equal(store._current().length, 2)
+  })
+})
+
+describe('chroxy tokens — revoke --all (#6599)', () => {
+  it('requires --yes: explains and changes nothing without it', () => {
+    const store = fakeStore([['t1aaaa', { createdAt: NOW }], ['t2bbbb', { createdAt: NOW }]])
+    const w = cap()
+    const res = runTokensRevoke(undefined, { all: true }, { store, write: w.write })
+    assert.deepEqual(res, { revoked: 0, mode: 'all', confirmed: false })
+    assert.equal(store._current().length, 2, 'no-op without --yes')
+    assert.match(w.text(), /re-run with --yes/)
+    assert.match(w.text(), /panic button/)
+  })
+
+  it('with --yes clears the whole store (panic button)', () => {
+    const store = fakeStore([['t1aaaa', { createdAt: NOW }], ['t2bbbb', { createdAt: NOW }]])
+    const w = cap()
+    const res = runTokensRevoke(undefined, { all: true, yes: true }, { store, write: w.write })
+    assert.deepEqual(res, { revoked: 2, mode: 'all', confirmed: true })
+    assert.equal(store._current().length, 0, 'every token revoked')
+    assert.match(w.text(), /Revoked all 2 session token/)
+  })
+
+  it('--all --yes on an empty store is a safe no-op reporting 0', () => {
+    const store = fakeStore([])
+    const w = cap()
+    const res = runTokensRevoke(undefined, { all: true, yes: true }, { store, write: w.write })
+    assert.equal(res.revoked, 0)
+    assert.equal(store._current().length, 0)
+  })
+})

--- a/packages/server/tests/tokens-cmd.test.js
+++ b/packages/server/tests/tokens-cmd.test.js
@@ -70,6 +70,19 @@ describe('chroxy tokens — list (#6599)', () => {
     assert.match(w.text(), /age=unknown/)
   })
 
+  it('does not crash on a corrupt-but-array store (non-tuple row shown as malformed)', () => {
+    // A hand-edited store could decode to an array containing a non-tuple element.
+    const w = cap()
+    const store = fakeStore([])
+    // Inject malformed rows past the tuple-cloning constructor via loadResult.
+    store.loadResult = () => ({ status: 'ok', entries: [['good00000000_secret', { createdAt: NOW, sessionId: 's' }], 'not-a-tuple', [42]] })
+    const res = runTokensList({ store, write: w.write, now: NOW })
+    assert.equal(res.count, 3)
+    assert.equal(res.tokens[0].handle, 'good00000000')
+    assert.equal(res.tokens[1].handle, '(malformed)')
+    assert.equal(res.tokens[2].handle, '(malformed)')
+  })
+
   it('an UNREADABLE store is reported as an error, never as "empty"', () => {
     const w = cap()
     // A present-but-unreadable store (bad perms / no keychain key / corrupt) must
@@ -152,6 +165,18 @@ describe('chroxy tokens — revoke one (#6599)', () => {
     assert.equal(res.error, 'persist-failed')
     assert.equal(res.revoked, 0)
     assert.match(w.text(), /Failed to write/)
+  })
+
+  it('a targeted revoke preserves a malformed row (never drops or crashes on it)', () => {
+    const store = fakeStore([])
+    let saved = null
+    store.loadResult = () => ({ status: 'ok', entries: [['keepme00_secret', { createdAt: NOW }], 'not-a-tuple', ['dropme00_secret', { createdAt: NOW }]] })
+    store.save = (next) => { saved = next; return true }
+    const w = cap()
+    const res = runTokensRevoke('dropme00', {}, { store, write: w.write })
+    assert.equal(res.revoked, 1)
+    // the real token is dropped; the good one AND the malformed row are preserved
+    assert.deepEqual(saved.map((e) => (Array.isArray(e) ? e[0] : e)), ['keepme00_secret', 'not-a-tuple'])
   })
 })
 


### PR DESCRIPTION
## What

Part of #6599 (epic #6597 — long-lived paired tokens). Operators had no way to see or revoke paired devices; a lost/compromised device could only be cut off by rotating the whole primary token. This adds the **CLI half**: list and revoke paired-device *session* tokens.

- **`chroxy tokens list`** — paired tokens by 12-char **handle**, session id, and age. The full token is **never** printed.
- **`chroxy tokens revoke <handle>`** — revoke one token by a unique handle prefix; an **ambiguous prefix is refused** (never guesses which to drop), a no-match is a safe no-op.
- **`chroxy tokens revoke --all --yes`** — the panic button; clears every token. `--yes` gates it (without it, the command only explains what it would do).

## How

Operates on the persisted session-token store (#6598) — the same encrypted `~/.chroxy/session-tokens.json` the daemon loads at boot — via the existing `createSessionTokenStore({ load, save })` adapter. Mirrors the **`chroxy identity rotate`** precedent: edits the persisted store, and takes effect on the daemon's next start. A running daemon keeps its in-memory tokens until restart, so the output says so plainly (`Restart the daemon to enforce …`).

## Scope / follow-ups

This is the CLI slice. The remaining #6599 scope is tracked:
- **#6678** — desktop/dashboard "Paired devices" UI panel (per-device + revoke-all).
- **#6679** — device-name labels in `list`/`revoke <name>` (needs mint-path plumbing), and **live** revocation against a running daemon (currently restart-to-enforce).

## Tests

`tokens-cmd.test.js` (10) drives the pure action functions with an in-memory store: empty store, list-by-handle (asserts the **full token never appears** in output), missing meta, revoke-by-unique-prefix, **ambiguous-prefix refusal**, no-match, no-target, and `--all` with/without `--yes` + empty-store. 10/10 on Linux CI.

Also verified end-to-end against the **real encrypted DPAPI store** (seed → `list` shows `age=2h` → `revoke <handle>` → empty) and via `tokens --help` wiring.

Part of #6599