### PR TITLE
feat(skills): add a `pi` compile target to compile-skill-targets.mjs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,12 +127,18 @@ custom-command format, so the same skill is first-party under whichever model yo
   not version-controlled). Codex CLI still supports `~/.codex/prompts/` (recent versions also ship
   a `~/.codex/skills/` dir); the emitter targets the stable prompts path. Off by default — the
   compiler prints a hint if `~/.codex` exists but `codex` isn't a selected target.
+- **pi** *(opt-in)* → `~/.pi/agent/skills/<name>/SKILL.md` (Pi Coding Agent, `earendil-works/pi`;
+  invoked `/skill:<name>`; user-global, not version-controlled). Markdown + YAML frontmatter
+  (`name` + `description`) like the claude target, but Pi **appends** invocation args as
+  `User: <args>` rather than substituting inline — so `$ARGUMENTS`/`$N` in the body pass through
+  literally and the compiler `warn`s if a body uses them. Off by default — the compiler prints a
+  hint if `~/.pi` exists but `pi` isn't a selected target. (#6573)
 
 The active target list is the `targets:` line in `.claude/skill-profile.md` (this repo:
-`claude, gemini` — both in-repo/version-controlled; codex is per-machine opt-in via
-`--targets codex`, kept out of the committed default so a clone never writes to an unaware
-machine's `~/.codex`). With no `targets:` line the compiler falls back to `claude` only and
-`/skill` prompts you. After editing a skill's generic source by hand, recompile:
+`claude, gemini` — both in-repo/version-controlled; codex and pi are per-machine opt-in via
+`--targets codex` / `--targets pi`, kept out of the committed default so a clone never writes to an
+unaware machine's `~/.codex` or `~/.pi`). With no `targets:` line the compiler falls back to
+`claude` only and `/skill` prompts you. After editing a skill's generic source by hand, recompile:
 `node scripts/compile-skill-targets.mjs --name <name>` (`--dry-run` to preview).
 
 This repo carries `.claude/skill-profile.md` (the customization profile + `targets:`) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,12 +108,18 @@ custom-command format, so the same skill is first-party under whichever model yo
   not version-controlled). Codex CLI still supports `~/.codex/prompts/` (recent versions also ship
   a `~/.codex/skills/` dir); the emitter targets the stable prompts path. Off by default — the
   compiler prints a hint if `~/.codex` exists but `codex` isn't a selected target.
+- **pi** *(opt-in)* → `~/.pi/agent/skills/<name>/SKILL.md` (Pi Coding Agent, `earendil-works/pi`;
+  invoked `/skill:<name>`; user-global, not version-controlled). Markdown + YAML frontmatter
+  (`name` + `description`) like the claude target, but Pi **appends** invocation args as
+  `User: <args>` rather than substituting inline — so `$ARGUMENTS`/`$N` in the body pass through
+  literally and the compiler `warn`s if a body uses them. Off by default — the compiler prints a
+  hint if `~/.pi` exists but `pi` isn't a selected target. (#6573)
 
 The active target list is the `targets:` line in `.claude/skill-profile.md` (this repo:
-`claude, gemini` — both in-repo/version-controlled; codex is per-machine opt-in via
-`--targets codex`, kept out of the committed default so a clone never writes to an unaware
-machine's `~/.codex`). With no `targets:` line the compiler falls back to `claude` only and
-`/skill` prompts you. After editing a skill's generic source by hand, recompile:
+`claude, gemini` — both in-repo/version-controlled; codex and pi are per-machine opt-in via
+`--targets codex` / `--targets pi`, kept out of the committed default so a clone never writes to an
+unaware machine's `~/.codex` or `~/.pi`). With no `targets:` line the compiler falls back to
+`claude` only and `/skill` prompts you. After editing a skill's generic source by hand, recompile:
 `node scripts/compile-skill-targets.mjs --name <name>` (`--dry-run` to preview).
 
 This repo carries `.claude/skill-profile.md` (the customization profile + `targets:`) and

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -20,7 +20,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const helperPath = resolve(__dirname, '..', 'compile-skill-targets.mjs')
 
-const { deriveDescription, detectUncompiledAgents } = await import(helperPath)
+const { deriveDescription, detectUncompiledAgents, emitPi, ALL_TARGETS } = await import(helperPath)
 
 let pass = 0
 let fail = 0
@@ -184,6 +184,44 @@ await test('detectUncompiledAgents returns nothing when no agent home dirs exist
   try {
     const out = detectUncompiledAgents(['claude'], home)
     assert(out.length === 0, `no agent dirs present, expected [], got ${JSON.stringify(out)}`)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+// --- Pi target (#6573) ----------------------------------------------------
+
+await test('pi is a known compile target', () => {
+  assert(ALL_TARGETS.includes('pi'), `expected 'pi' in ALL_TARGETS, got ${JSON.stringify(ALL_TARGETS)}`)
+})
+
+await test('emitPi writes ~/.pi/agent/skills/<name>/SKILL.md with name + description frontmatter', () => {
+  const out = emitPi('demo-skill', '# Body\nDo the thing.\n', 'Does the thing.')
+  assert(/[/\\]\.pi[/\\]agent[/\\]skills[/\\]demo-skill[/\\]SKILL\.md$/.test(out.path), `unexpected path: ${out.path}`)
+  // Pi REQUIRES a `name` field matching the parent dir (unlike the claude emitter).
+  assert(out.content.startsWith('---\nname: demo-skill\ndescription: '), `missing name/description frontmatter:\n${out.content}`)
+  assert(out.content.includes('# Body\nDo the thing.'), 'body must pass through verbatim')
+  assert(/\/skill:demo-skill/.test(out.note), `note should document /skill: invocation, got: ${out.note}`)
+})
+
+await test('emitPi warns when the body uses arg tokens Pi will not substitute', () => {
+  const withArgs = emitPi('a', 'Summarize $ARGUMENTS please\n', 'x')
+  assert(withArgs.warn && /not substituted/i.test(withArgs.warn), `expected an arg-token warning, got: ${withArgs.warn}`)
+  const noArgs = emitPi('b', 'No args here\n', 'x')
+  assert(!noArgs.warn, `expected no warning for an arg-free body, got: ${noArgs.warn}`)
+})
+
+await test('emitPi does not warn for a shell positional inside a fenced code block', () => {
+  const out = emitPi('c', 'Run it:\n```bash\necho "${1:-default}"\n```\n', 'x')
+  assert(!out.warn, `a shell positional in a code fence must not warn, got: ${out.warn}`)
+})
+
+await test('detectUncompiledAgents flags an installed-but-unselected pi (~/.pi)', () => {
+  const home = mkdtempSync(pjoin(tmpdir(), 'skill-home-'))
+  try {
+    mkdirSync(pjoin(home, '.pi'))
+    const out = detectUncompiledAgents(['claude', 'gemini'], home)
+    assert(out.includes('pi'), `expected pi flagged, got ${JSON.stringify(out)}`)
   } finally {
     rmSync(home, { recursive: true, force: true })
   }

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -198,8 +198,9 @@ await test('pi is a known compile target', () => {
 await test('emitPi writes ~/.pi/agent/skills/<name>/SKILL.md with name + description frontmatter', () => {
   const out = emitPi('demo-skill', '# Body\nDo the thing.\n', 'Does the thing.')
   assert(/[/\\]\.pi[/\\]agent[/\\]skills[/\\]demo-skill[/\\]SKILL\.md$/.test(out.path), `unexpected path: ${out.path}`)
-  // Pi REQUIRES a `name` field matching the parent dir (unlike the claude emitter).
-  assert(out.content.startsWith('---\nname: demo-skill\ndescription: '), `missing name/description frontmatter:\n${out.content}`)
+  // Pi REQUIRES a `name` field matching the parent dir (unlike the claude emitter);
+  // it's quoted so a YAML-significant char in a filename can't break the frontmatter.
+  assert(out.content.startsWith('---\nname: "demo-skill"\ndescription: '), `missing name/description frontmatter:\n${out.content}`)
   assert(out.content.includes('# Body\nDo the thing.'), 'body must pass through verbatim')
   assert(/\/skill:demo-skill/.test(out.note), `note should document /skill: invocation, got: ${out.note}`)
 })
@@ -218,6 +219,12 @@ await test('emitPi does not warn for an arg token inside a fenced code block (bu
   assert(!fenced.warn, `a bare $1 inside a code fence must not warn, got: ${fenced.warn}`)
   const prose = emitPi('c', 'Pass echo $1 to the tool\n', 'x')
   assert(prose.warn && /not substituted/i.test(prose.warn), `a bare $1 in prose must warn, got: ${prose.warn}`)
+})
+
+await test('emitPi quotes the name so a YAML-significant char in a filename stays valid YAML', () => {
+  // A Linux filename could carry `:` — unquoted `name: weird:name` would misparse.
+  const out = emitPi('weird:name', 'body\n', 'x')
+  assert(out.content.startsWith('---\nname: "weird:name"\n'), `name must be quoted, got:\n${out.content}`)
 })
 
 await test('emitPi warns on a non-Pi-valid skill name (Pi rejects it at load)', () => {

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -211,9 +211,22 @@ await test('emitPi warns when the body uses arg tokens Pi will not substitute', 
   assert(!noArgs.warn, `expected no warning for an arg-free body, got: ${noArgs.warn}`)
 })
 
-await test('emitPi does not warn for a shell positional inside a fenced code block', () => {
-  const out = emitPi('c', 'Run it:\n```bash\necho "${1:-default}"\n```\n', 'x')
-  assert(!out.warn, `a shell positional in a code fence must not warn, got: ${out.warn}`)
+await test('emitPi does not warn for an arg token inside a fenced code block (but does in prose)', () => {
+  // Use `$1` — a token that DOES match the warn regex — so the test actually
+  // exercises the code-fence stripping rather than passing trivially.
+  const fenced = emitPi('c', 'Run it:\n```bash\necho $1\n```\n', 'x')
+  assert(!fenced.warn, `a bare $1 inside a code fence must not warn, got: ${fenced.warn}`)
+  const prose = emitPi('c', 'Pass echo $1 to the tool\n', 'x')
+  assert(prose.warn && /not substituted/i.test(prose.warn), `a bare $1 in prose must warn, got: ${prose.warn}`)
+})
+
+await test('emitPi warns on a non-Pi-valid skill name (Pi rejects it at load)', () => {
+  for (const bad of ['My_Skill', 'has space', '-leading', 'trailing-', 'double--hyphen', 'UPPER']) {
+    const out = emitPi(bad, 'body\n', 'x')
+    assert(out.warn && /not Pi-valid/.test(out.warn), `expected a name-format warning for "${bad}", got: ${out.warn}`)
+  }
+  const ok = emitPi('good-name-123', 'body\n', 'x')
+  assert(!ok.warn || !/not Pi-valid/.test(ok.warn), `a valid kebab name must not warn, got: ${ok.warn}`)
 })
 
 await test('detectUncompiledAgents flags an installed-but-unselected pi (~/.pi)', () => {

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -9,10 +9,11 @@
 //   claude -> .claude/skills/<name>/SKILL.md        (md + YAML frontmatter; v2.1.x "skills")
 //   gemini -> .gemini/commands/<name>.toml          (TOML: prompt + description; {{args}})
 //   codex  -> ~/.codex/prompts/<name>.md            (md; $ARGUMENTS; user-global, /prompts:<name>)
+//   pi     -> ~/.pi/agent/skills/<name>/SKILL.md    (md + YAML frontmatter; user-global, /skill:<name>)
 //
 // Targets come from `.claude/skill-profile.md` (a `targets:` line) unless
-// overridden with --targets. Codex is opt-in (user-global; still supported by
-// codex-cli via ~/.codex/prompts/).
+// overridden with --targets. Codex and Pi are opt-in (user-global home dirs:
+// ~/.codex/prompts/ and ~/.pi/agent/skills/).
 //
 // Usage:
 //   node scripts/compile-skill-targets.mjs [--name <name>] [--targets claude,gemini]
@@ -24,16 +25,20 @@ import { join, dirname, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
-const ALL_TARGETS = ['claude', 'gemini', 'codex']
+export const ALL_TARGETS = ['claude', 'gemini', 'codex', 'pi']
 
 // #6571 — home-dir marker(s) for coding agents whose skills are USER-GLOBAL and
-// OPT-IN. Only `codex` qualifies: its skills land in `~/.codex/prompts/` (a home
-// dir, not the repo) and it is deliberately off the committed default target list,
-// so a Codex contributor can silently miss the dev-workflow skills. `gemini` is
-// NOT here — it's in the default `targets:` and compiles into the repo's
-// `.gemini/commands/` (version-controlled), so a missing Gemini skill is visible
-// in the repo and its home dir (`~/.gemini`) says nothing about compile coverage.
-const AGENT_HOME_MARKERS = { codex: '.codex' }
+// OPT-IN. `codex` (`~/.codex/prompts/`) and `pi` (`~/.pi/agent/skills/`, #6573)
+// qualify: their skills land in a home dir, not the repo, and both are deliberately
+// off the committed default target list, so a Codex/Pi contributor can silently miss
+// the dev-workflow skills. `gemini` is NOT here — it's in the default `targets:` and
+// compiles into the repo's `.gemini/commands/` (version-controlled), so a missing
+// Gemini skill is visible in the repo and its home dir (`~/.gemini`) says nothing
+// about compile coverage.
+const AGENT_HOME_MARKERS = { codex: '.codex', pi: '.pi' }
+
+// User-global skill dir per opt-in target, for the "installed but not selected" hint.
+const AGENT_SKILL_DIRS = { codex: '~/.codex/prompts/', pi: '~/.pi/agent/skills/' }
 
 /**
  * #6571 — detect coding agents that are installed on this machine (their home dir
@@ -203,7 +208,27 @@ function emitCodex(name, body, description) {
   }
 }
 
-const EMITTERS = { claude: emitClaude, gemini: emitGemini, codex: emitCodex }
+// #6573 — Pi Coding Agent (earendil-works/pi) skills. Format is Markdown +
+// YAML frontmatter in `<name>/SKILL.md` (nearly identical to the claude target),
+// but user-global at ~/.pi/agent/skills/ and OPT-IN (like codex). Pi REQUIRES a
+// `name` field that matches the parent directory. Invoked as /skill:<name>; Pi
+// appends invocation args as `User: <args>` rather than substituting inline, so
+// $ARGUMENTS (the neutral arg token) has no in-body Pi equivalent — the body
+// passes through literally and a `warn` flags any arg token the author used.
+export function emitPi(name, body, description) {
+  // Warn on arg tokens only OUTSIDE fenced code blocks (a shell `${1:-…}` in a
+  // ```code``` block is a positional, not a skill-arg concern) — mirrors emitGemini.
+  const prose = body.replace(/```[\s\S]*?```/g, '')
+  const usesArgs = /\$ARGUMENTS\b/.test(prose) || /\$[1-9]\b/.test(prose)
+  return {
+    path: join(homedir(), '.pi/agent/skills', name, 'SKILL.md'),
+    content: `---\nname: ${name}\ndescription: ${yamlDq(description)}\n---\n\n${body}`,
+    note: `pi: invoke as /skill:${name} (user-global ~/.pi/agent/skills/)`,
+    warn: usesArgs ? `pi: appends args as "User: <args>" — inline arg tokens ($ARGUMENTS / $N) are NOT substituted` : null,
+  }
+}
+
+const EMITTERS = { claude: emitClaude, gemini: emitGemini, codex: emitCodex, pi: emitPi }
 
 function compileOne(name, srcPath, targets, repo, dryRun) {
   const raw = readFileSync(srcPath, 'utf8')
@@ -256,9 +281,11 @@ function main() {
   const uncompiled = detectUncompiledAgents(targets)
   if (uncompiled.length) {
     const dirs = uncompiled.map((t) => `~/${AGENT_HOME_MARKERS[t]}`).join(', ')
-    // Codex prompts write to ~/.codex/prompts/ (user-global); name that so the hint
-    // can't be misread as compiling into the home dir for a repo-local target.
-    console.log(`Hint: ${dirs} present but ${uncompiled.join(', ')} not a selected target — pass --targets ${[...targets, ...uncompiled].join(',')} to also compile into ~/.codex/prompts/ (see docs/dev-workflow-skills.md).`)
+    // Name each target's actual user-global skill dir (codex → ~/.codex/prompts/,
+    // pi → ~/.pi/agent/skills/) so the hint can't be misread as compiling into the
+    // home dir for a repo-local target.
+    const skillDirs = uncompiled.map((t) => AGENT_SKILL_DIRS[t] || `~/${AGENT_HOME_MARKERS[t]}`).join(', ')
+    console.log(`Hint: ${dirs} present but ${uncompiled.join(', ')} not a selected target — pass --targets ${[...targets, ...uncompiled].join(',')} to also compile into ${skillDirs} (see docs/dev-workflow-skills.md).`)
   }
 
   const names = args.name ? [args.name] : readdirSync(cmdDir).filter((f) => f.endsWith('.md')).map((f) => f.replace(/\.md$/, ''))

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -216,15 +216,28 @@ function emitCodex(name, body, description) {
 // $ARGUMENTS (the neutral arg token) has no in-body Pi equivalent — the body
 // passes through literally and a `warn` flags any arg token the author used.
 export function emitPi(name, body, description) {
-  // Warn on arg tokens only OUTSIDE fenced code blocks (a shell `${1:-…}` in a
+  const warns = []
+  // Warn on arg tokens only OUTSIDE fenced code blocks (a shell `echo $1` in a
   // ```code``` block is a positional, not a skill-arg concern) — mirrors emitGemini.
   const prose = body.replace(/```[\s\S]*?```/g, '')
-  const usesArgs = /\$ARGUMENTS\b/.test(prose) || /\$[1-9]\b/.test(prose)
+  if (/\$ARGUMENTS\b/.test(prose) || /\$[1-9]\b/.test(prose)) {
+    warns.push('pi: appends args as "User: <args>" — inline arg tokens ($ARGUMENTS / $N) are NOT substituted')
+  }
+  // Pi REJECTS a non-conforming name at load (lowercase a-z / 0-9 / single hyphens,
+  // ≤64 chars, matching the parent dir) — unlike claude/gemini/codex, which accept
+  // anything. Warn rather than silently emit a SKILL.md Pi won't load. (All current
+  // skill names conform; this guards a future one.)
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name) || name.length > 64) {
+    warns.push(`pi: skill name "${name}" is not Pi-valid (lowercase a-z, 0-9, single hyphens, ≤64 chars) — Pi will reject it at load`)
+  }
+  // `name` is kept UNQUOTED: every valid Pi name is a YAML-safe plain scalar, and
+  // Pi matches it against the parent directory name — quoting risks a raw-string
+  // mismatch. A non-conforming name is surfaced by the warn above instead.
   return {
     path: join(homedir(), '.pi/agent/skills', name, 'SKILL.md'),
     content: `---\nname: ${name}\ndescription: ${yamlDq(description)}\n---\n\n${body}`,
     note: `pi: invoke as /skill:${name} (user-global ~/.pi/agent/skills/)`,
-    warn: usesArgs ? `pi: appends args as "User: <args>" — inline arg tokens ($ARGUMENTS / $N) are NOT substituted` : null,
+    warn: warns.length ? warns.join('; ') : null,
   }
 }
 

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -230,12 +230,14 @@ export function emitPi(name, body, description) {
   if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name) || name.length > 64) {
     warns.push(`pi: skill name "${name}" is not Pi-valid (lowercase a-z, 0-9, single hyphens, ≤64 chars) — Pi will reject it at load`)
   }
-  // `name` is kept UNQUOTED: every valid Pi name is a YAML-safe plain scalar, and
-  // Pi matches it against the parent directory name — quoting risks a raw-string
-  // mismatch. A non-conforming name is surfaced by the warn above instead.
+  // Quote `name` (like `description`) so the frontmatter is ALWAYS valid YAML even
+  // if a source filename carried a YAML-significant char (`:`, `#`, `"`) — an
+  // unquoted `name: weird:name` would misparse. A quoted scalar YAML-parses back to
+  // the exact string, so Pi's match against the parent directory name still holds
+  // (any charset violation is separately surfaced by the warn above).
   return {
     path: join(homedir(), '.pi/agent/skills', name, 'SKILL.md'),
-    content: `---\nname: ${name}\ndescription: ${yamlDq(description)}\n---\n\n${body}`,
+    content: `---\nname: ${yamlDq(name)}\ndescription: ${yamlDq(description)}\n---\n\n${body}`,
     note: `pi: invoke as /skill:${name} (user-global ~/.pi/agent/skills/)`,
     warn: warns.length ? warns.join('; ') : null,
   }


### PR DESCRIPTION
## What

Chroxy's dev-workflow skills (the `.claude/commands/*.md` neutral sources) now compile into **Pi Coding Agent** (`earendil-works/pi`) native skills — so a user driving chroxy who also uses Pi gets the same first-party skills there. Closes #6573.

## Spike — Pi's skill format (per the [Pi docs](https://hochej.github.io/pi-mono/coding-agent/skills/))

- **File:** `<name>/SKILL.md` — Markdown + YAML frontmatter, **`name`** (must match the parent dir) + **`description`** required.
- **Location:** user-global `~/.pi/agent/skills/` (also supports project `.pi/skills/`).
- **Invocation:** `/skill:<name>` (e.g. `/skill:full-review`).
- **Args:** Pi **appends** invocation args as `User: <args>` — it does **not** substitute inline. So `$ARGUMENTS`/`$N` in a body have no in-body Pi equivalent.

## How

`emitPi(name, body, description)` mirrors the `claude` emitter (SKILL.md + frontmatter) but:
- writes to `~/.pi/agent/skills/<name>/SKILL.md` (user-global);
- includes the **`name`** field Pi requires (the claude emitter omits it);
- `warn`s when the body uses `$ARGUMENTS`/`$N` (outside code fences), since Pi won't substitute them.

Wiring: `pi` added to `ALL_TARGETS` + `EMITTERS`; **opt-in** like codex (`--targets pi`), kept out of the committed default `targets:` so a clone never writes to an unaware machine's `~/.pi`. `AGENT_HOME_MARKERS` gains `pi: '.pi'` so the "installed-but-unselected" hint fires — and that hint now names each target's real skill dir (`~/.codex/prompts/`, `~/.pi/agent/skills/`) instead of hardcoding codex's.

## Tests

`scripts/__tests__/compile-skill-targets.test.mjs` (+5): `pi` is a known target; `emitPi` path + `name`/`description` frontmatter + body passthrough + `/skill:` note; the arg-token warning (with a fenced-code-block false-positive guard); and `~/.pi` detection in `detectUncompiledAgents`. 16/16 on Linux. Also compiled a real skill (`full-review`) to `--targets pi` end-to-end (correct path, warn, note emitted).

> The Windows dev host can't run this harness (pre-existing `ERR_UNSUPPORTED_ESM_URL_SCHEME` — the test `import()`s a `C:\…` path); green on the Linux CI runner.

## Verification note for @blamechris

Acceptance criterion #4 — *"at least one compiled skill verified loading + invoking in a real Pi session"* — needs a live Pi install, which isn't available here. The emitter is implemented to Pi's published format and unit-tested, but **please load one compiled `~/.pi/agent/skills/<name>/SKILL.md` in a real Pi session and confirm `/skill:<name>` works** before relying on it.

Closes #6573