### PR TITLE
fix(server): resolveProviderLabel reports codex's runtime driver label

### DIFF
--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -202,12 +202,23 @@ export function getProvider(name) {
  * the server still boots with a readable banner even if someone registers a
  * custom provider without a label, and returns `'unknown'` for empty input.
  *
+ * #6676 — resolves through `getProvider(name)` (not the static `PROVIDERS[name]`),
+ * so codex reports the label of its RUNTIME driver (app-server by default →
+ * "OpenAI Codex (app-server)", exec on `CHROXY_CODEX_APPSERVER=0` → "OpenAI
+ * Codex"), matching what a live session's `constructor.displayLabel` reports.
+ * `getProvider` throws for an unknown name, so those fall back to the raw name.
+ *
  * @param {string | undefined | null} name - Provider identifier
  * @returns {string} Human-readable label
  */
 export function resolveProviderLabel(name) {
   if (!name || typeof name !== 'string') return 'unknown'
-  const ProviderClass = PROVIDERS[name]
+  let ProviderClass
+  try {
+    ProviderClass = getProvider(name)
+  } catch {
+    ProviderClass = PROVIDERS[name]
+  }
   if (ProviderClass && typeof ProviderClass.displayLabel === 'string' && ProviderClass.displayLabel.length > 0) {
     return ProviderClass.displayLabel
   }

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -862,6 +862,32 @@ describe('claude-channel provider scaffold (#3953)', () => {
     assert.match(label, /channel/i)
   })
 
+  // #6676 — resolveProviderLabel('codex') must report the RUNTIME driver's label
+  // (matching a live session), not the static exec label, honoring the opt-out.
+  it('resolveProviderLabel(codex) tracks the runtime driver, honoring CHROXY_CODEX_APPSERVER', async () => {
+    const { resolveProviderLabel, getProvider } = await import('../src/providers.js')
+    const orig = process.env.CHROXY_CODEX_APPSERVER
+    try {
+      delete process.env.CHROXY_CODEX_APPSERVER
+      assert.equal(resolveProviderLabel('codex'), getProvider('codex').displayLabel, 'default: matches the app-server driver')
+      assert.match(resolveProviderLabel('codex'), /app-server/, 'default codex label names the app-server driver')
+      process.env.CHROXY_CODEX_APPSERVER = '0'
+      assert.equal(resolveProviderLabel('codex'), getProvider('codex').displayLabel, 'opt-out: matches the exec driver')
+      assert.equal(resolveProviderLabel('codex'), 'OpenAI Codex', 'exec opt-out label has no app-server suffix')
+    } finally {
+      if (orig === undefined) delete process.env.CHROXY_CODEX_APPSERVER
+      else process.env.CHROXY_CODEX_APPSERVER = orig
+    }
+  })
+
+  it('resolveProviderLabel falls back to the raw name for an unknown provider', async () => {
+    const { resolveProviderLabel } = await import('../src/providers.js')
+    // getProvider throws for an unknown name; the label must degrade to the id.
+    assert.equal(resolveProviderLabel('totally-unknown-provider'), 'totally-unknown-provider')
+    assert.equal(resolveProviderLabel(''), 'unknown')
+    assert.equal(resolveProviderLabel(null), 'unknown')
+  })
+
   it('shares the ~/.claude dataDir without duplicating it in getProviderDataDirs', async () => {
     const { getProviderDataDirs } = await import('../src/providers.js')
     const { homedir } = await import('node:os')
@@ -1138,7 +1164,9 @@ describe('resolveProviderLabel helper (#2953)', () => {
     const { resolveProviderLabel } = await import('../src/providers.js')
     assert.equal(resolveProviderLabel('claude-cli'), 'Claude Code (CLI)')
     assert.equal(resolveProviderLabel('claude-sdk'), 'Claude Code (SDK)')
-    assert.equal(resolveProviderLabel('codex'), 'OpenAI Codex')
+    // #6676: codex now resolves to its runtime driver's label — app-server by
+    // default (dedicated env-honoring coverage in the #6676 test above).
+    assert.equal(resolveProviderLabel('codex'), 'OpenAI Codex (app-server)')
     assert.equal(resolveProviderLabel('gemini'), 'Google Gemini')
   })
 

--- a/packages/server/tests/server-cli-banner.test.js
+++ b/packages/server/tests/server-cli-banner.test.js
@@ -24,7 +24,8 @@ describe('buildServerBanner (#2953)', () => {
 
   it('uses the OpenAI Codex label for codex (no fallthrough to raw id)', () => {
     const line = buildServerBanner({ version: '1.2.3', provider: 'codex' })
-    assert.match(line, /Chroxy Server v1\.2\.3 \(OpenAI Codex\)/)
+    // #6676: the banner now names the active codex driver — app-server by default.
+    assert.match(line, /Chroxy Server v1\.2\.3 \(OpenAI Codex \(app-server\)\)/)
     assert.doesNotMatch(line, /\(codex\)/)
   })
 


### PR DESCRIPTION
## What

Sibling of #6618 (which fixed the same picker-vs-live split for *capabilities*). `resolveProviderLabel('codex')` read the static `PROVIDERS['codex']` (exec) label — `"OpenAI Codex"` — while a live codex session is `CodexAppServerSession` (the #6616 default), whose `displayLabel` is `"OpenAI Codex (app-server)"`. So the startup banner and any label surface disagreed with the running driver.

## How

Resolve through `getProvider(name)` (mirrors the #6618 `listProviders` fix), which honors `CHROXY_CODEX_APPSERVER` (app-server by default, exec on `=0`). `getProvider` throws for an unknown name, so a `try/catch` falls back to the raw id — preserving the "unknown provider → readable banner" behavior exactly.

Effect: the startup banner now names the **active** codex driver, e.g. `Chroxy Server v… (OpenAI Codex (app-server))`, which is strictly more informative for an operator.

## Tests

- New: `resolveProviderLabel('codex')` matches `getProvider('codex').displayLabel` for **both** default (app-server) and `CHROXY_CODEX_APPSERVER=0` (exec); unknown-name → raw id; empty/null → `'unknown'`.
- Updated the existing label + banner tests to the runtime-driver label.
- `providers.test.js` + `server-cli-banner.test.js`: **104/104 on Linux**. eslint + lints clean.

Closes #6676