### PR TITLE
feat(server): surface codex MCP connector elicitations as approvals (#6635)

### DIFF
--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -80,8 +80,11 @@ Each family answers Codex in **its own** vocabulary — the `PermissionManager`
 | `mcpServer/elicitation/request` (#6635) | `{ action: 'accept' }` | (no session grant) | `{ action: 'decline' }` |
 
 The elicitation response also permits structured `content` (for `form`-mode) and
-`{ action: 'cancel' }`; the current implementation answers with the action only —
-see §8.
+`{ action: 'cancel' }`. The current implementation answers action-only: a
+confirmation-style (no required fields) or `url`-mode elicitation accepts; a
+`form`/`openai/form` elicitation that **requires fields** is *declined even on
+allow* (a safe status quo — an action-only accept could make the connector act on
+empty params the user never saw), until #6684 collects content. See §8.
 
 The escalation grant is reconstructed from the two `GrantedPermissionProfile`
 fields (`fileSystem`, `network`) the request carried — never an echo of the raw

--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -16,9 +16,9 @@ Everything under **Current state** is grounded in the code as of this writing;
 ## TL;DR
 
 - The **app-server driver** (`CodexAppServerSession`) is the canonical, approval-capable Codex path and the default. The legacy `codex exec` path (`CHROXY_CODEX_APPSERVER=0`) has **no** Chroxy approval surface — treat it as a fallback only.
-- Codex surfaces **three** approval families through the same `PermissionManager` the Claude providers use: shell commands, file edits, and (since #6610) sandbox scope-escalations.
+- Codex surfaces its approvals through the same `PermissionManager` the Claude providers use: shell commands, file edits, sandbox scope-escalations (#6610), and connector elicitations (#6635).
 - Codex **does not** support Chroxy session rules ("Allow for Session" persisted per-tool). "Always allow" maps to Codex's *own* per-turn/per-session grant vocabulary, not a Chroxy rule.
-- **MCP / connector tool calls are not surfaced** in the permission pipeline (the gap behind the missed-GitHub-connector-approval report, #6635).
+- **MCP connector elicitations** (e.g. a GitHub write approval) now surface as accept/decline (#6635); structured form-content / url-mode / execution-item rendering remain (#6684).
 - The **sandbox** (`read-only` / `workspace-write` / `danger-full-access`) is env-only (`CHROXY_CODEX_SANDBOX`), not per-session in the UI/API.
 
 ---
@@ -52,17 +52,18 @@ Codex maps them to a Codex `approvalPolicy` per turn: `auto → never` (Codex ne
 asks), every other mode → `on-request`. `plan` is **not** a real Codex mode
 (Codex has no plan enforcement) — it behaves like `approve`.
 
-| Request class → | `shell` (command exec) | `apply_patch` (file edit) | `request_permissions` (scope-escalation) | MCP / connector call |
+| Request class → | `shell` (command exec) | `apply_patch` (file edit) | `request_permissions` (scope-escalation) | `mcp_elicitation` (connector) |
 |---|---|---|---|---|
-| **approve** (default) | Prompt | Prompt | Prompt | **Not surfaced** |
-| **acceptEdits** | Prompt | **Auto-approve** | Prompt | **Not surfaced** |
-| **auto** | No prompt (Codex `never`) | No prompt | No prompt | Not surfaced |
-| **plan** | Prompt (= approve) | Prompt | Prompt | **Not surfaced** |
+| **approve** (default) | Prompt | Prompt | Prompt | Prompt |
+| **acceptEdits** | Prompt | **Auto-approve** | Prompt | Prompt |
+| **auto** | No prompt (Codex `never`) | No prompt | No prompt | Auto-allow |
+| **plan** | Prompt (= approve) | Prompt | Prompt | Prompt |
 
 Why the cells are what they are:
 - `apply_patch` is in `ACCEPT_EDITS_TOOLS`, so `acceptEdits` auto-approves Codex edits (the analogue of auto-approving Claude Write/Edit).
-- `shell` and `request_permissions` are in `NEVER_AUTO_ALLOW` — they always prompt (except under `auto`, where Codex's `approvalPolicy: never` means it doesn't send an approval request at all).
-- Under `auto`, `PermissionManager.handlePermission` also short-circuits to allow, so even a stray request is drained without a prompt.
+- `shell`, `request_permissions`, and `mcp_elicitation` are in `NEVER_AUTO_ALLOW` — they always prompt (except under `auto`).
+- Under `auto`, `PermissionManager.handlePermission` short-circuits to allow, so requests are drained without a prompt. (`shell`/`apply_patch`/`request_permissions` also don't get *sent* under `auto` since Codex's `approvalPolicy` is `never`; a connector `mcp_elicitation` is a standalone MCP request that can still arrive, and is auto-allowed.)
+- **`mcp_elicitation`** = a connector eliciting the user (#6635), surfaced as accept/decline — the confirmation case. See §8 for what's still open (form `content`, url-mode, execution-item rendering).
 
 ---
 
@@ -76,6 +77,11 @@ Each family answers Codex in **its own** vocabulary — the `PermissionManager`
 | `item/commandExecution/requestApproval` | `accept` | `acceptForSession` | `decline` |
 | `item/fileChange/requestApproval` | `approved` | `approved_for_session` | `denied` |
 | `item/permissions/requestApproval` (#6610) | `{ permissions: <requested>, scope: 'turn' }` | `{ permissions: <requested>, scope: 'session' }` | `{ permissions: {} }` (scope omitted) |
+| `mcpServer/elicitation/request` (#6635) | `{ action: 'accept' }` | (no session grant) | `{ action: 'decline' }` |
+
+The elicitation response also permits structured `content` (for `form`-mode) and
+`{ action: 'cancel' }`; the current implementation answers with the action only —
+see §8.
 
 The escalation grant is reconstructed from the two `GrantedPermissionProfile`
 fields (`fileSystem`, `network`) the request carried — never an echo of the raw
@@ -154,7 +160,7 @@ Both clients render these via the existing `PermissionPrompt` (`<tool>:
 
 | Gap | Detail | Related |
 |---|---|---|
-| **MCP / connector approvals unsurfaced** | `mcpToolCall` items are not mapped to a `tool_start` or an approval — only `commandExecution` + `fileChange` are. Connector calls (e.g. GitHub) run under Codex's sandbox/`approvalPolicy` and never reach Chroxy's prompt. | #6635 |
+| **MCP connector elicitation — partially addressed (#6635)** | A connector eliciting the user (`mcpServer/elicitation/request`, e.g. a GitHub write approval) is now surfaced as an **accept/decline** prompt (previously `-32601`-declined, so the approval was "missed"). Still open: structured `content` collection for `form`/`openai/form` modes and interactive `url`-mode flows (accept currently answers action-only), and rendering the `mcpToolCall` execution item itself as a `tool_start` (#6684). | #6635 |
 | **No session rules** | "Allow for Session" persists a rule for Claude SDK/BYOK; for Codex it's a Codex-side grant only (§4). | — |
 | **Provider-generic mode copy** | Mode labels/descriptions and `skipPermissions` (= `--dangerously-skip-permissions`) are Claude/TUI-oriented; `skipPermissions` is a no-op for Codex, and `plan` is a no-op alias for `approve`. | — |
 | **Sandbox not per-session** | `CHROXY_CODEX_SANDBOX` is env-only; a per-session selector would need protocol + UI. | — |
@@ -180,8 +186,8 @@ Each carries a recommendation, but the call is yours.
 5. **Required approval-UI detail for Codex** (full command, cwd, env, patch/diff preview, redaction, drilldown)?
    *Recommendation:* command + cwd ship today; add a **diff/patch preview** for `apply_patch` (currently only `reason` + `grantRoot`) and a scope drilldown for escalations. Env is sensitive — keep redacted/omitted by default.
 
-6. **MCP / connector approval path (the #6635 gap).**
-   *Recommendation:* the highest-value fix here — map `mcpToolCall` items to a `tool_start` and, where Codex requests approval for them, into the permission pipeline (a `mcp`/connector tool class). Needs confirming which Codex app-server events carry connector approvals. Track as a dedicated issue.
+6. **MCP / connector approval path (the #6635 gap) — the elicitation approval shipped.**
+   Connector elicitations (`mcpServer/elicitation/request`) now surface as an accept/decline prompt via the `mcp_elicitation` tool (`NEVER_AUTO_ALLOW`), fixing the "missed approval → rejected tool call" case. *Remaining:* structured `content` collection for `form`/`openai/form` elicitations and interactive `url`-mode flows, plus rendering the `mcpToolCall` execution item as a `tool_start` — tracked in #6684.
 
 7. **How should timeout/interrupt/auto-switch appear to the user?**
    *Recommendation:* surface a resolved state on the prompt (timed-out / cancelled / auto-approved) rather than silently dropping it — same UX work as #6627 (queued/permission resolved-state rendering).

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -433,6 +433,16 @@ export class CodexAppServerSession extends BaseSession {
       this._routePermissionsApproval(id, params)
       return
     }
+    if (method === 'mcpServer/elicitation/request') {
+      // A codex MCP server (connector, e.g. GitHub) is eliciting the user — most
+      // commonly a write/action confirmation. Previously this fell through to the
+      // -32601 decline below, so the connector approval was silently rejected and
+      // "missed" (#6635). Surface it as an accept/decline prompt. NOTE: structured
+      // form-content collection and interactive url-mode flows are a follow-up —
+      // accept currently answers with the action only, no `content`.
+      this._routeMcpElicitation(id, params)
+      return
+    }
     ;(this._log || log).warn(`codex app-server: unsupported serverRequest ${method} — declining`)
     this._client?.respondError(id, -32601, 'unsupported request')
   }
@@ -567,6 +577,47 @@ export class CodexAppServerSession extends BaseSession {
       ? ` — ${params.reason.trim()}`
       : ''
     return `Codex is requesting to broaden its sandbox permissions${reason}: ${scope}`
+  }
+
+  // #6635: an MCP server (connector) is eliciting the user. Surface it as an
+  // accept/decline prompt through the permission pipeline (was silently declined
+  // with -32601, so a GitHub-connector write approval was "missed" and the tool
+  // call rejected). The elicitation response is { action: accept|decline|cancel,
+  // content? }; we answer with the action only — structured `content` collection
+  // (form / openai/form modes) and interactive url-mode flows are a follow-up.
+  async _routeMcpElicitation(rpcId, params) {
+    let result
+    try {
+      const input = {
+        description: this._describeMcpElicitation(params),
+        serverName: params?.serverName ?? null,
+        mode: params?.mode ?? null,
+        // Surfaced so the client can show a url-mode elicitation's link.
+        url: typeof params?.url === 'string' ? params.url : null,
+        message: typeof params?.message === 'string' ? params.message : null,
+      }
+      const suggestions = [{ codexApproval: 'mcpServer/elicitation/request' }]
+      result = await this._permissions.handlePermission('mcp_elicitation', input, this._turnAbort?.signal, this.permissionMode, suggestions)
+    } catch (err) {
+      result = { behavior: 'deny', message: err?.message || 'permission error' }
+    }
+    // accept on allow; decline otherwise (a user deny, timeout, or abort). We never
+    // synthesize `content`, so a form-mode elicitation gets an action-only accept.
+    const action = result?.behavior === 'allow' ? 'accept' : 'decline'
+    this._client?.respond(rpcId, { action })
+  }
+
+  // Human-readable elicitation prompt: which connector is asking, and what for.
+  _describeMcpElicitation(params) {
+    const server = typeof params?.serverName === 'string' && params.serverName.trim()
+      ? params.serverName.trim()
+      : 'an MCP connector'
+    const msg = typeof params?.message === 'string' && params.message.trim() ? params.message.trim() : ''
+    const url = params?.mode === 'url' && typeof params?.url === 'string' && params.url.trim()
+      ? ` (opens ${params.url.trim()})`
+      : ''
+    const ask = msg || 'is requesting your input'
+    return `Codex connector "${server}" ${msg ? 'asks' : ''}: ${ask}${url}`.replace(/\s+:/, ':')
   }
 
   // 'auto' (skip all prompts) → codex runs without asking. Every other mode →

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -596,15 +596,33 @@ export class CodexAppServerSession extends BaseSession {
         url: typeof params?.url === 'string' ? params.url : null,
         message: typeof params?.message === 'string' ? params.message : null,
       }
+      // The sentinel is inert for this tool (unlike command/file/escalation, we
+      // don't read updatedPermissions): an elicitation "allow" is a one-shot
+      // accept, never a persisted rule — kept only for handlePermission symmetry.
       const suggestions = [{ codexApproval: 'mcpServer/elicitation/request' }]
       result = await this._permissions.handlePermission('mcp_elicitation', input, this._turnAbort?.signal, this.permissionMode, suggestions)
     } catch (err) {
       result = { behavior: 'deny', message: err?.message || 'permission error' }
     }
-    // accept on allow; decline otherwise (a user deny, timeout, or abort). We never
-    // synthesize `content`, so a form-mode elicitation gets an action-only accept.
-    const action = result?.behavior === 'allow' ? 'accept' : 'decline'
+    const allow = result?.behavior === 'allow'
+    // #6635: we can't collect structured `content` yet (#6684), so a form-mode
+    // elicitation that REQUIRES fields is DECLINED even on allow — an action-only
+    // accept could make the connector act on empty/default params the user never
+    // saw. Confirmation-style (no required fields) + url-mode accept normally; a
+    // decline is always the safe status quo (matches the pre-#6635 -32601 outcome).
+    const action = allow && !this._elicitationRequiresContent(params) ? 'accept' : 'decline'
     this._client?.respond(rpcId, { action })
+  }
+
+  // True when accepting would need structured `content` we can't yet collect:
+  // `openai/form` (freeform content) or a `form` whose schema declares required
+  // properties. `url`-mode and content-less confirmation forms return false.
+  _elicitationRequiresContent(params) {
+    const mode = params?.mode
+    if (mode === 'openai/form') return true
+    if (mode !== 'form') return false
+    const required = params?.requestedSchema?.required
+    return Array.isArray(required) && required.length > 0
   }
 
   // Human-readable elicitation prompt: which connector is asking, and what for.
@@ -616,8 +634,11 @@ export class CodexAppServerSession extends BaseSession {
     const url = params?.mode === 'url' && typeof params?.url === 'string' && params.url.trim()
       ? ` (opens ${params.url.trim()})`
       : ''
-    const ask = msg || 'is requesting your input'
-    return `Codex connector "${server}" ${msg ? 'asks' : ''}: ${ask}${url}`.replace(/\s+:/, ':')
+    // Build the two shapes explicitly rather than post-cleaning whitespace: with a
+    // message → `connector "x" asks: <msg>`, without → `connector "x": is requesting…`.
+    return msg
+      ? `Codex connector "${server}" asks: ${msg}${url}`
+      : `Codex connector "${server}": is requesting your input${url}`
   }
 
   // 'auto' (skip all prompts) → codex runs without asking. Every other mode →

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -21,7 +21,9 @@ export const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 
 // arbitrary codex command execution can't be rule-whitelisted either (#6605).
 // `request_permissions` is codex's sandbox-escalation approval (#6610) — broadening
 // filesystem/network scope must always prompt, never be silently rule-whitelisted.
-export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions'])
+// `mcp_elicitation` is a codex MCP connector eliciting the user (#6635, e.g. a
+// GitHub connector write approval) — a connector action must always prompt too.
+export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions', 'mcp_elicitation'])
 
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -525,6 +525,7 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
       assert.match(reqs[0][1].description, /github/)
       assert.match(reqs[0][1].description, /issue #42/)
       s.respondToPermission(reqs[0][1].requestId, 'deny')
+      cleanup()
     })
 
     it('accept → { action: accept }', async () => {

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -566,6 +566,47 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
       s.respondToPermission(reqs[0][1].requestId, 'deny')
       cleanup()
     })
+
+    it('a REQUIRED-field form is declined even on allow (no incomplete accept until #6684)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      // form-mode with a required property → we can't collect content yet, so an
+      // action-only accept could write empty/default params → decline instead.
+      s._onServerRequest({ id: 35, method: 'mcpServer/elicitation/request', params: { serverName: 'github', threadId: 't1', mode: 'form', message: 'Fill the release notes', requestedSchema: { required: ['notes'] } } })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      assert.deepEqual(responded, [[35, { action: 'decline' }]], 'required-field form → decline even on allow')
+      cleanup()
+    })
+
+    it('openai/form is declined even on allow (freeform content not yet collectable)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 36, method: 'mcpServer/elicitation/request', params: { serverName: 'x', threadId: 't1', mode: 'openai/form', message: 'give feedback', requestedSchema: true } })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      assert.deepEqual(responded, [[36, { action: 'decline' }]])
+      cleanup()
+    })
+
+    it('auto mode auto-accepts a connector elicitation (bypass) without prompting', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('auto')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 37, method: 'mcpServer/elicitation/request', params: elicitParams })
+      await tick()
+      assert.equal(reqs.length, 0, 'auto mode does not prompt')
+      assert.deepEqual(responded, [[37, { action: 'accept' }]])
+      cleanup()
+    })
+
+    it('a missing serverName falls back to a generic connector label', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 38, method: 'mcpServer/elicitation/request', params: { threadId: 't1', mode: 'form', message: 'proceed?', requestedSchema: {} } })
+      assert.match(reqs[0][1].description, /an MCP connector/)
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
+      cleanup()
+    })
   })
 
   it('interrupt() aborts a pending approval → Stop unblocks the turn (decline)', async () => {

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -513,6 +513,61 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     })
   })
 
+  describe('MCP connector elicitation surfacing (#6635)', () => {
+    const elicitParams = { serverName: 'github', threadId: 't1', mode: 'form', message: 'Allow writing a comment to issue #42?', requestedSchema: {} }
+
+    it('surfaces the elicitation as a prompt naming the connector + message (was -32601 declined)', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 30, method: 'mcpServer/elicitation/request', params: elicitParams })
+      assert.equal(reqs.length, 1, 'connector elicitation is surfaced, not silently declined')
+      assert.equal(reqs[0][1].tool, 'mcp_elicitation')
+      assert.match(reqs[0][1].description, /github/)
+      assert.match(reqs[0][1].description, /issue #42/)
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
+    })
+
+    it('accept → { action: accept }', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 31, method: 'mcpServer/elicitation/request', params: elicitParams })
+      s.respondToPermission(reqs[0][1].requestId, 'allow')
+      await tick()
+      assert.deepEqual(responded, [[31, { action: 'accept' }]])
+      cleanup()
+    })
+
+    it('deny → { action: decline } (a missed connector approval is now an explicit decline)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 32, method: 'mcpServer/elicitation/request', params: elicitParams })
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
+      await tick()
+      assert.deepEqual(responded, [[32, { action: 'decline' }]])
+      cleanup()
+    })
+
+    it('abort mid-elicitation → { action: decline } (answers codex, no wedge)', async () => {
+      const { s, cleanup, responded } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 33, method: 'mcpServer/elicitation/request', params: elicitParams })
+      assert.equal(reqs.length, 1)
+      s._endTurnAbort()
+      await tick()
+      assert.deepEqual(responded, [[33, { action: 'decline' }]])
+      cleanup()
+    })
+
+    it('url-mode surfaces the link in the prompt', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 34, method: 'mcpServer/elicitation/request', params: { serverName: 'github', threadId: 't1', mode: 'url', elicitationId: 'e1', message: 'Authorize access', url: 'https://example.com/oauth' } })
+      assert.match(reqs[0][1].description, /https:\/\/example\.com\/oauth/)
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
+      cleanup()
+    })
+  })
+
   it('interrupt() aborts a pending approval → Stop unblocks the turn (decline)', async () => {
     const { s, cleanup, responded } = mkApprovalSession()
     capture(s, ['permission_request'])

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -736,7 +736,9 @@ describe('PermissionManager', () => {
       // shell = codex's command-execution tool (#6605), never-whitelistable like Bash.
       // request_permissions = codex's sandbox-escalation tool (#6610) — broadening
       // filesystem/network scope must always prompt, never be rule-whitelisted.
-      const expected = ['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions']
+      // mcp_elicitation = a codex MCP connector eliciting the user (#6635) — a
+      // connector action (e.g. a GitHub write approval) must always prompt too.
+      const expected = ['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions', 'mcp_elicitation']
       for (const tool of expected) {
         assert.ok(NEVER_AUTO_ALLOW.has(tool), `Expected NEVER_AUTO_ALLOW to contain ${tool}`)
       }


### PR DESCRIPTION
## What

A codex MCP server (connector, e.g. GitHub) elicits the user via `mcpServer/elicitation/request` — most commonly a **write/action confirmation**. That method fell through to `_onServerRequest`'s `-32601` "unsupported request" decline, so the connector approval was **silently rejected and "missed"**: the write never happened and the tool call failed. That's #6635 ("GitHub connector write approval prompt can be missed while tool call is rejected").

The scoping spike (`codex app-server generate-json-schema`) confirmed the mechanism: codex has **five** server→client request methods; we handled three, and `mcpServer/elicitation/request` (+ the experimental `item/tool/requestUserInput`) were hard-declined.

## How

Route `mcpServer/elicitation/request` through the permission pipeline as a new **`mcp_elicitation`** tool (in `NEVER_AUTO_ALLOW` — a connector action always prompts, like `shell`/`request_permissions`):

- the prompt names the connector (`serverName`) + message, and surfaces a `url`-mode link;
- **accept → `{ action: 'accept' }`**, **deny / timeout / abort → `{ action: 'decline' }`** (never left waiting → no turn wedge).

Renders via the existing `PermissionPrompt` on both clients — no client change.

## Scope (deliberately the confirmation case)

The elicitation response also allows structured `content` (for `form`/`openai/form` modes) and interactive `url`-mode flows. This PR answers **action-only**, which is correct for the confirmation case (the #6635 bug) but incomplete for form-mode elicitations that require fields. Those, plus rendering the `mcpToolCall` *execution* item as a `tool_start`, are tracked in **#6684**.

## Tests

`codex-app-server-session.test.js` — new `describe('MCP connector elicitation surfacing (#6635)')`: surfaced-as-prompt (naming connector + message), accept→`{action:'accept'}`, deny→`{action:'decline'}`, abort→decline (no wedge), url-mode surfaces the link. `permission-manager.test.js` NEVER_AUTO_ALLOW list updated. Affected suites (codex + permission-manager + settings-handlers + whitelist) **176/176 on Linux**; eslint + lints clean.

Doc updated: `docs/design/codex-permission-model.md` (matrix, §3, §8, §9.6).

Closes #6635