### PR TITLE
feat(server): provider-aware permission-mode copy for codex

### DIFF
--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -16,14 +16,48 @@ const log = createLogger('handler-utils')
 // `description` is a short, plain-English sentence the dashboard
 // surfaces as a tooltip / inline hint (#4013). Keep terse — the picker
 // space is limited and screen readers re-narrate the whole string.
-// The auto-mode description deliberately names `--dangerously-skip-permissions`
-// so users searching for that Claude CLI flag find the chroxy equivalent.
-export const PERMISSION_MODES = [
-  { id: 'approve', label: 'Approve', description: 'Default. Every tool call gates on your approval in the dashboard or mobile app.' },
-  { id: 'acceptEdits', label: 'Accept Edits', description: 'Auto-approve Read/Write/Edit/NotebookEdit/Glob/Grep. Bash, MCP, and other tools still gate on approval.' },
-  { id: 'auto', label: 'Auto (skip all prompts)', description: 'Auto-approve every tool call without prompting. Equivalent to `claude --dangerously-skip-permissions`.' },
-  { id: 'plan', label: 'Plan', description: 'Plan mode — Claude is asked to plan before acting; each tool call still gates on approval.' },
-]
+// The default (Claude) auto-mode description deliberately names
+// `--dangerously-skip-permissions` so users searching for that Claude CLI flag
+// find the chroxy equivalent.
+//
+// #6638: the mode IDs are provider-independent, but the descriptions are NOT —
+// the default copy is Claude-oriented (Read/Write/Edit tool names, the
+// `--dangerously-skip-permissions` flag, real plan mode). Codex has different
+// tools (apply_patch / shell / connectors) and no plan enforcement, so
+// `getPermissionModes('codex')` returns codex-tuned copy. Callers pass the active
+// session's provider; a switch re-sends `available_permission_modes` (session-handlers).
+const MODE_LABELS = { approve: 'Approve', acceptEdits: 'Accept Edits', auto: 'Auto (skip all prompts)', plan: 'Plan' }
+const MODE_DESCRIPTIONS = {
+  default: {
+    approve: 'Default. Every tool call gates on your approval in the dashboard or mobile app.',
+    acceptEdits: 'Auto-approve Read/Write/Edit/NotebookEdit/Glob/Grep. Bash, MCP, and other tools still gate on approval.',
+    auto: 'Auto-approve every tool call without prompting. Equivalent to `claude --dangerously-skip-permissions`.',
+    plan: 'Plan mode — Claude is asked to plan before acting; each tool call still gates on approval.',
+  },
+  codex: {
+    approve: 'Default. Every codex command, file edit, and connector action gates on your approval.',
+    acceptEdits: 'Auto-approve codex file edits (apply_patch). Shell commands, connector actions, and permission escalations still gate on approval.',
+    auto: 'Auto-approve every codex action without prompting (codex runs with approvalPolicy `never`).',
+    plan: 'Not a distinct codex mode — behaves like Approve (codex has no plan enforcement).',
+  },
+}
+const MODE_IDS = ['approve', 'acceptEdits', 'auto', 'plan']
+const buildModes = (desc) => MODE_IDS.map((id) => ({ id, label: MODE_LABELS[id], description: desc[id] }))
+
+// The default (Claude) mode list. Kept as a named export for back-compat.
+export const PERMISSION_MODES = buildModes(MODE_DESCRIPTIONS.default)
+
+/**
+ * The permission-mode list with descriptions tuned to the given provider (#6638).
+ * Codex gets codex-specific copy; everything else gets the default. The mode IDs
+ * are identical across providers, so validation (ALLOWED_PERMISSION_MODE_IDS) is
+ * provider-independent.
+ * @param {string|null|undefined} provider
+ */
+export function getPermissionModes(provider) {
+  return provider === 'codex' ? buildModes(MODE_DESCRIPTIONS.codex) : PERMISSION_MODES
+}
+
 export const ALLOWED_PERMISSION_MODE_IDS = new Set(PERMISSION_MODES.map((m) => m.id))
 
 // -- Attachment validation constants --

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -6,7 +6,7 @@
  */
 import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { auditShellCreate } from '../shell-audit.js'
-import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer, isUserShellSession, ALLOWED_PERMISSION_MODE_IDS } from '../handler-utils.js'
+import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer, isUserShellSession, ALLOWED_PERMISSION_MODE_IDS, getPermissionModes } from '../handler-utils.js'
 import { getRegistryForProvider } from '../models.js'
 import { isUserShellEnabled, isUserShellApprovalRequired } from '../config.js'
 import { createLogger, loggerForSession } from '../logger.js'
@@ -81,6 +81,9 @@ function handleSwitchSession(ws, client, msg, ctx) {
   const switchProvider = entry.provider || null
   const switchRegistry = getRegistryForProvider(switchProvider)
   ctx.transport.send(ws, { type: 'available_models', models: switchRegistry.getModels(), defaultModel: switchRegistry.getDefaultModelId(), provider: switchProvider })
+  // #6638: also re-send the permission-mode copy so switching to/from a Codex
+  // session updates the mode descriptions (Codex has different tools + no plan mode).
+  ctx.transport.send(ws, { type: 'available_permission_modes', modes: getPermissionModes(switchProvider) })
   broadcastFocusChanged(client, targetId, ctx)
 }
 

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -5,7 +5,7 @@
  * handshake and history replay concerns from core server orchestration.
  */
 import { toShortModelId, getRegistryForProvider } from './models.js'
-import { PERMISSION_MODES } from './handler-utils.js'
+import { getPermissionModes } from './handler-utils.js'
 import { listProviders, getProvider } from './providers.js'
 import { createLogger } from './logger.js'
 import { createKeyPair, deriveSharedKey, deriveConnectionKey, signExchangeKey } from '@chroxy/store-core/crypto'
@@ -213,6 +213,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
 
   // Get initial session info for auth_ok payload
   let sessionInfo = {}
+  // #6638: the active session's provider, captured for the auth_ok permission-mode
+  // copy (Codex gets codex-tuned descriptions). `entry` below is block-scoped, so
+  // hoist the provider to function scope.
+  let authOkProvider = null
   if (sessionManager) {
     let activeId = defaultSessionId
     let entry = activeId ? sessionManager.getSession(activeId) : null
@@ -232,6 +236,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     }
     if (entry) {
       sessionInfo.cwd = entry.cwd
+      authOkProvider = entry.provider || null
     }
   } else if (cliSession) {
     sessionInfo.cwd = cliSession.cwd
@@ -467,7 +472,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // client never has to wait for (or react to) the discrete
     // `available_permission_modes` burst frame. The discrete frame is still
     // sent below for older clients that read the enum only from it.
-    availablePermissionModes: PERMISSION_MODES,
+    availablePermissionModes: getPermissionModes(authOkProvider),
     resultTimeoutMs: effectiveResultTimeoutMs,
     hardTimeoutMs: effectiveHardTimeoutMs,
     streamStallTimeoutMs: effectiveStreamStallTimeoutMs,
@@ -691,7 +696,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // schedule. With no active session activeProvider is null and there is nothing
     // to refresh (scheduleProviderModelsRefresh no-ops on a null provider).
     scheduleProviderModelsRefresh(ctx, ws, activeProvider)
-    send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
+    send(ws, { type: 'available_permission_modes', modes: getPermissionModes(activeProvider) })
     permissions.resendPendingPermissions(ws, client)
     // #5555: fire the connect-time bootstrap burst (providers + slash commands
     // + agents) so a new client never sends its 3-request list_* round trip.
@@ -730,7 +735,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       type: 'permission_mode_changed',
       mode: cliSession.permissionMode || 'approve',
     })
-    send(ws, { type: 'available_permission_modes', modes: PERMISSION_MODES })
+    send(ws, { type: 'available_permission_modes', modes: getPermissionModes(legacyProvider) })
   }
 
   permissions.resendPendingPermissions(ws)

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -218,8 +218,28 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // hoist the provider to function scope.
   let authOkProvider = null
   if (sessionManager) {
-    let activeId = defaultSessionId
-    let entry = activeId ? sessionManager.getSession(activeId) : null
+    // #6687: resolve the active session with the SAME precedence block 2 uses to
+    // restore the client — the per-device persisted active session (#4835) first,
+    // then defaultSessionId → firstSessionId, then the bound-session override — so
+    // auth_ok's cwd + permission-mode copy describe the session the client is
+    // actually switched to, not the server default.
+    let activeId = null
+    let entry = null
+    const persistedDeviceId = client.deviceInfo?.deviceId
+    if (devicePreferences && persistedDeviceId) {
+      const persistedId = devicePreferences.getActiveSessionId(persistedDeviceId)
+      if (persistedId) {
+        const persistedEntry = sessionManager.getSession(persistedId)
+        if (persistedEntry) {
+          activeId = persistedId
+          entry = persistedEntry
+        }
+      }
+    }
+    if (!entry) {
+      activeId = defaultSessionId
+      entry = activeId ? sessionManager.getSession(activeId) : null
+    }
     if (!entry) {
       activeId = sessionManager.firstSessionId
       entry = activeId ? sessionManager.getSession(activeId) : null

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -23,6 +23,7 @@ import {
   validateCwdAllowed,
   FORBIDDEN_HOME_SUBDIRS,
   PERMISSION_MODES,
+  getPermissionModes,
   ALLOWED_PERMISSION_MODE_IDS,
   MAX_ATTACHMENT_COUNT,
   MAX_IMAGE_SIZE,
@@ -1562,5 +1563,36 @@ describe('sendError fail-safe send guard (#5702 8a)', () => {
     sendError(ws, 'r3', 'CODE', 'message')
     assert.strictEqual(sent.length, 1)
     assert.strictEqual(sent[0].code, 'CODE')
+  })
+})
+
+describe('getPermissionModes provider-aware copy (#6638)', () => {
+  const idsOf = (modes) => modes.map((m) => m.id)
+  const byId = (modes, id) => modes.find((m) => m.id === id)
+
+  it('non-codex providers get the default (Claude) modes', () => {
+    for (const p of [null, undefined, 'claude-sdk', 'gemini', 'unknown']) {
+      assert.deepEqual(getPermissionModes(p), PERMISSION_MODES, `provider ${p} → default modes`)
+    }
+  })
+
+  it('codex gets codex-tuned descriptions with the SAME mode ids', () => {
+    const codex = getPermissionModes('codex')
+    // ids are provider-independent (validation must stay uniform)
+    assert.deepEqual(idsOf(codex), idsOf(PERMISSION_MODES))
+    // but the descriptions are codex-specific — no Claude-only copy
+    const joined = codex.map((m) => m.description).join(' ')
+    assert.doesNotMatch(joined, /dangerously-skip-permissions/, 'no Claude CLI flag')
+    assert.doesNotMatch(joined, /Read\/Write\/Edit/, 'no Claude tool names')
+    assert.match(byId(codex, 'acceptEdits').description, /apply_patch/, 'names the codex edit tool')
+    assert.match(byId(codex, 'plan').description, /no plan enforcement|behaves like Approve/i, 'plan ≈ approve for codex')
+    assert.match(byId(codex, 'auto').description, /approvalPolicy/, 'names the codex bypass mechanism')
+  })
+
+  it('every codex mode has a non-empty label + description', () => {
+    for (const m of getPermissionModes('codex')) {
+      assert.ok(m.label && m.label.length > 0, `${m.id} has a label`)
+      assert.ok(m.description && m.description.length > 0, `${m.id} has a description`)
+    }
   })
 })

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -117,6 +117,17 @@ describe('session-handlers', () => {
       assert.equal(sent.conversationId, 'conv-1')
     })
 
+    it('re-sends provider-scoped permission modes on switch (codex → codex copy) (#6638)', () => {
+      const ctx = makeCtx()
+      const session = createMockSession()
+      ctx._sessions.set('sess-cx', { session, name: 'Codex', cwd: '/tmp', provider: 'codex' })
+      sessionHandlers.switch_session(makeWs(), makeClient(), { sessionId: 'sess-cx' }, ctx)
+      const modesMsg = ctx._sent.find(m => m.type === 'available_permission_modes')
+      assert.ok(modesMsg, 'available_permission_modes re-sent on switch')
+      const acceptEdits = modesMsg.modes.find(m => m.id === 'acceptEdits')
+      assert.match(acceptEdits.description, /apply_patch/, 'switch to codex → codex-tuned mode copy')
+    })
+
     it('sends session_error when session not found', () => {
       const ctx = makeCtx()
       sessionHandlers.switch_session(makeWs(), makeClient(), { sessionId: 'missing' }, ctx)

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -356,6 +356,8 @@ export function createMockSessionManager(sessions = [], overrides = {}) {
       cwd: s.cwd || '/tmp',
       type: s.type || 'cli',
       isBusy: s.isRunning || false,
+      // Real entries carry the provider; needed for provider-scoped models/modes.
+      ...(s.provider !== undefined ? { provider: s.provider } : {}),
     })
   }
 

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1292,6 +1292,26 @@ describe('sendPostAuthInfo — auth_bootstrap (#5555)', () => {
     assert.deepEqual(permModes.modes, PERMISSION_MODES)
   })
 
+  it('a codex active session at connect gets codex-tuned mode copy (#6638)', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-cx', name: 'Codex', cwd: '/repo', provider: 'codex' },
+    ])
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-cx' })
+    registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    // Both the folded auth_ok list (new clients) and the discrete frame (old
+    // clients) should carry codex copy — same ids, codex-specific descriptions.
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    const frame = ctx._sends.find(m => m.type === 'available_permission_modes')
+    for (const modes of [authOk.availablePermissionModes, frame.modes]) {
+      assert.deepEqual(modes.map(m => m.id), PERMISSION_MODES.map(m => m.id), 'ids unchanged')
+      assert.match(modes.find(m => m.id === 'acceptEdits').description, /apply_patch/, 'codex copy')
+      assert.doesNotMatch(modes.find(m => m.id === 'auto').description, /dangerously-skip-permissions/, 'no Claude flag')
+    }
+  })
+
   it('multi-session: emits an auth_bootstrap burst with providers + slashCommands + agents', async () => {
     const { manager } = createMockSessionManager([
       { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
@@ -2840,6 +2860,29 @@ describe('sendPostAuthInfo — per-device active session restore (#4835)', () =>
     assert.ok(switchMsg, 'session_switched not sent')
     assert.equal(switchMsg.sessionId, 'sess-big')
     assert.equal(switchMsg.name, 'Ltl')
+  })
+
+  it('auth_ok cwd + permission-mode copy follow the DEVICE-PERSISTED session, not the default (#6687)', () => {
+    // Default is a Claude session; the device previously switched to a codex one.
+    // auth_ok (which new clients read directly) must describe the restored codex
+    // session — block 1 now uses the same device-preference precedence as block 2.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-default', name: 'Claude', cwd: '/claude', provider: 'claude-sdk' },
+      { id: 'sess-codex', name: 'Codex', cwd: '/codex', provider: 'codex' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'laptop': 'sess-codex' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager, defaultSessionId: 'sess-default', devicePreferences: devicePrefs })
+    registerClient(ctx, ws, { deviceInfo: { deviceId: 'laptop', deviceName: 'Laptop', deviceType: 'desktop', platform: 'darwin' } })
+
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends.find(m => m.type === 'auth_ok')
+    assert.equal(authOk.cwd, '/codex', 'auth_ok.cwd follows the device-persisted session, not the default')
+    assert.match(
+      authOk.availablePermissionModes.find(m => m.id === 'acceptEdits').description,
+      /apply_patch/,
+      'auth_ok mode copy is codex-tuned for the device-persisted codex session',
+    )
   })
 
   it('falls back to firstSessionId when the deviceId has no recorded preference', () => {


### PR DESCRIPTION
## What

Follow-on from the codex permission scoping (#6638 §9.1). The permission-mode **descriptions** were Claude-oriented and mislead codex users:
- `acceptEdits`: "Auto-approve **Read/Write/Edit/NotebookEdit/Glob/Grep**…" (Claude tool names)
- `auto`: "Equivalent to `claude --dangerously-skip-permissions`" (a Claude CLI flag)
- `plan`: "Plan mode — **Claude** is asked to plan…" (codex has no plan enforcement)

Codex has different tools (`apply_patch`/`shell`/connectors) and treats `plan` like `approve`.

## How

`getPermissionModes(provider)` — the mode **IDs stay provider-independent** (validation via `ALLOWED_PERMISSION_MODE_IDS` is unchanged), but codex sessions get codex-tuned descriptions:
- `acceptEdits` → "Auto-approve codex file edits (**apply_patch**). Shell commands, connector actions, and permission escalations still gate on approval."
- `auto` → "…codex runs with **approvalPolicy `never`**."
- `plan` → "**Not a distinct codex mode** — behaves like Approve (codex has no plan enforcement)."

Threaded through:
- **connect handshake** (`sendPostAuthInfo`): both `auth_ok.availablePermissionModes` (new clients) and the discrete `available_permission_modes` frame (old clients), scoped to the active session's provider — via a function-scoped `authOkProvider` since the `entry` var is block-scoped;
- **session switch** (`session-handlers`): re-sends `available_permission_modes` scoped to the switched provider, right alongside the existing `available_models` re-send — so switching to/from a codex session updates the copy immediately.

No behavior change to modes themselves — copy only.

## Tests

`handler-utils.test.js` — `getPermissionModes`: non-codex → default, codex → same ids + codex-specific copy (no `dangerously-skip-permissions` / `Read/Write/Edit`, names `apply_patch`, `plan ≈ approve`). `session-handlers.test.js` — switch to codex re-sends codex-tuned modes. Affected suites (handler-utils + ws-history + session-handlers) **376/376 on Linux**; eslint + lints clean.

Addresses #6638 open decision 1.