### PR TITLE
feat(server): show WHAT changes in a codex apply_patch approval

### DIFF
--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -138,7 +138,7 @@ for the turn or session (§3).
 | Family | `tool` | prompt input |
 |---|---|---|
 | command exec | `shell` | `{ command, cwd, description: reason \|\| command \|\| 'Run a shell command' }` |
-| file edit | `apply_patch` | `{ description: reason + files summary, file_path: grantRoot, changes }` — the approval params carry no diff, so the `changes` (`FileUpdateChange[]` = `{path,kind,diff}`) are correlated from the fileChange item by `itemId` (#6638); the description names the files (`"reason — 2 files: a.js, b.js"`) and `changes` carries the raw diff for a client that renders it |
+| file edit | `apply_patch` | `{ description: reason + files summary, file_path: grantRoot, changes }` — the approval params carry no diff, so the `changes` (`FileUpdateChange[]` = `{path,kind,diff}`) are correlated from the fileChange item by `itemId` (#6638); the description always names the files (`"reason — 2 files: a.js, b.js"`), and `changes` carries the raw diff for a client that renders it (subject to the permission broadcast's `sanitizeToolInput` ~10K cap — a very large patch collapses to a truncation marker, so the file summary is the guaranteed-visible part) |
 | escalation | `request_permissions` | `{ description: <human-readable scope summary>, requestedPermissions }` |
 
 Descriptions are redacted and capped at ≤200 chars downstream. The escalation
@@ -187,7 +187,7 @@ Each carries a recommendation, but the call is yours.
    *Recommendation:* keep current semantics — `allowAlways` maps to Codex's session grant per family; `shell`/`request_permissions` never auto-allow (always prompt). Document this so the "Allow for Session" button's meaning on a Codex `shell` prompt is clear (it's a Codex session grant, not a Chroxy rule) — or hide "Allow for Session" on never-auto-allow Codex tools to avoid implying a persisted rule.
 
 5. **Required approval-UI detail for Codex** (full command, cwd, env, patch/diff preview, redaction, drilldown)?
-   *Update:* command + cwd ship today, and the **`apply_patch` diff preview shipped** (#6638) — the fileChange item's `changes` are correlated into the approval by `itemId`: the prompt names the files, and the raw `changes` ride along for a client that renders a diff. Still open: a scope drilldown for escalations. Env is sensitive — keep redacted/omitted by default.
+   *Update:* command + cwd ship today, and the **`apply_patch` diff preview shipped** (#6638) — the fileChange item's `changes` are correlated into the approval by `itemId`: the prompt always names the files, and the raw `changes` ride along for a client that renders a diff (bounded by the broadcast `sanitizeToolInput` ~10K cap; a very large patch truncates, so the file summary is the guaranteed part). Still open: a scope drilldown for escalations. Env is sensitive — keep redacted/omitted by default.
 
 6. **MCP / connector approval path (the #6635 gap) — the elicitation approval shipped.**
    Connector elicitations (`mcpServer/elicitation/request`) now surface as an accept/decline prompt via the `mcp_elicitation` tool (`NEVER_AUTO_ALLOW`), fixing the "missed approval → rejected tool call" case. *Remaining:* structured `content` collection for `form`/`openai/form` elicitations and interactive `url`-mode flows, plus rendering the `mcpToolCall` execution item as a `tool_start` — tracked in #6684.

--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -138,7 +138,7 @@ for the turn or session (§3).
 | Family | `tool` | prompt input |
 |---|---|---|
 | command exec | `shell` | `{ command, cwd, description: reason \|\| command \|\| 'Run a shell command' }` |
-| file edit | `apply_patch` | `{ description: reason \|\| 'Apply file changes', file_path: grantRoot }` |
+| file edit | `apply_patch` | `{ description: reason + files summary, file_path: grantRoot, changes }` — the approval params carry no diff, so the `changes` (`FileUpdateChange[]` = `{path,kind,diff}`) are correlated from the fileChange item by `itemId` (#6638); the description names the files (`"reason — 2 files: a.js, b.js"`) and `changes` carries the raw diff for a client that renders it |
 | escalation | `request_permissions` | `{ description: <human-readable scope summary>, requestedPermissions }` |
 
 Descriptions are redacted and capped at ≤200 chars downstream. The escalation
@@ -187,7 +187,7 @@ Each carries a recommendation, but the call is yours.
    *Recommendation:* keep current semantics — `allowAlways` maps to Codex's session grant per family; `shell`/`request_permissions` never auto-allow (always prompt). Document this so the "Allow for Session" button's meaning on a Codex `shell` prompt is clear (it's a Codex session grant, not a Chroxy rule) — or hide "Allow for Session" on never-auto-allow Codex tools to avoid implying a persisted rule.
 
 5. **Required approval-UI detail for Codex** (full command, cwd, env, patch/diff preview, redaction, drilldown)?
-   *Recommendation:* command + cwd ship today; add a **diff/patch preview** for `apply_patch` (currently only `reason` + `grantRoot`) and a scope drilldown for escalations. Env is sensitive — keep redacted/omitted by default.
+   *Update:* command + cwd ship today, and the **`apply_patch` diff preview shipped** (#6638) — the fileChange item's `changes` are correlated into the approval by `itemId`: the prompt names the files, and the raw `changes` ride along for a client that renders a diff. Still open: a scope drilldown for escalations. Env is sensitive — keep redacted/omitted by default.
 
 6. **MCP / connector approval path (the #6635 gap) — the elicitation approval shipped.**
    Connector elicitations (`mcpServer/elicitation/request`) now surface as an accept/decline prompt via the `mcp_elicitation` tool (`NEVER_AUTO_ALLOW`), fixing the "missed approval → rejected tool call" case. *Remaining:* structured `content` collection for `form`/`openai/form` elicitations and interactive `url`-mode flows, plus rendering the `mcpToolCall` execution item as a `tool_start` — tracked in #6684.

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -12,6 +12,11 @@ import { createLogger, loggerForSession } from './logger.js'
 // Image extensions codex can attach for VISION via a `localImage` input item.
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'])
 
+// #6638: cap on cached fileChange diffs (itemId → changes). A turn deletes each on
+// completion and clears the map at turn end, so this only bites a pathological
+// flood of un-completed fileChange items.
+const MAX_PENDING_FILE_CHANGES = 500
+
 const log = createLogger('codex-app-server')
 
 /**
@@ -88,6 +93,9 @@ export class CodexAppServerSession extends BaseSession {
     this._lastUsage = null
     this._skillsPrepended = false // #6606 — inject the skills prefix once, on turn 1
     this._turnAbort = null // per-turn AbortController — cancels pending approvals
+    // #6638: fileChange item.changes cached by itemId, so a fileChange approval
+    // (whose params carry NO diff) can surface WHAT will change. Cleared per turn.
+    this._pendingFileChanges = new Map()
     this._attachDir = null // #6609 — lazily-created temp dir for materialized attachments
 
     // #6605 Phase 2 — surface codex approvals through the same PermissionManager
@@ -306,13 +314,23 @@ export class CodexAppServerSession extends BaseSession {
       this._trackToolStart(toolUseId, 'shell')
     } else if (item.type === 'fileChange') {
       const toolUseId = item.id
+      const changes = item.changes ?? item.patch ?? null
       this.emit('tool_start', {
         messageId: this._activeTurn.messageId,
         toolUseId,
         tool: 'apply_patch',
-        input: { changes: item.changes ?? item.patch ?? null },
+        input: { changes },
       })
       this._trackToolStart(toolUseId, 'apply_patch')
+      // #6638: remember the changes so a later fileChange approval (keyed by the
+      // same itemId, but carrying no diff) can show what will change. Bounded —
+      // deleted on item completion / cleared per turn; evict oldest at the cap.
+      if (toolUseId != null) {
+        if (this._pendingFileChanges.size >= MAX_PENDING_FILE_CHANGES) {
+          this._pendingFileChanges.delete(this._pendingFileChanges.keys().next().value)
+        }
+        this._pendingFileChanges.set(toolUseId, changes)
+      }
     }
   }
 
@@ -324,6 +342,7 @@ export class CodexAppServerSession extends BaseSession {
     } else if (item.type === 'fileChange') {
       this.emit('tool_result', { toolUseId: item.id, result: item.status ?? '' })
       this._trackToolResult(item.id)
+      if (item.id != null) this._pendingFileChanges.delete(item.id) // #6638: done — release the cached diff
     } else if (item.type === 'agentMessage') {
       // Fallback: if the final text never arrived as deltas (short replies can
       // skip the delta stream), emit it once so the message isn't lost.
@@ -380,6 +399,13 @@ export class CodexAppServerSession extends BaseSession {
     this._endTurnAbort()
     this._clearMessageState()
     this._maybeDequeue()
+  }
+
+  // #6638: also release cached fileChange diffs when per-turn state is cleared
+  // (turn end / fail / destroy), so a diff can't outlive its turn.
+  _clearMessageState() {
+    super._clearMessageState()
+    this._pendingFileChanges.clear()
   }
 
   // Abort this turn's approval scope (any pending permission_request resolves as
@@ -474,9 +500,18 @@ export class CodexAppServerSession extends BaseSession {
   // renders. `description`/`command`/`file_path` drive the human-facing prompt.
   _describeApproval(method, params) {
     if (method === 'item/fileChange/requestApproval') {
+      // #6638: the approval params carry no diff, so correlate to the fileChange
+      // item's cached changes (same itemId) and surface WHAT changes — a paths
+      // summary in the description (visible with no client change) + the raw
+      // changes for a client that renders a diff.
+      const changes = params?.itemId != null ? this._pendingFileChanges.get(params.itemId) ?? null : null
+      const summary = this._summarizeFileChanges(changes)
+      const description = summary
+        ? (params?.reason ? `${params.reason} — ${summary}` : `Apply changes: ${summary}`)
+        : (params?.reason || 'Apply file changes')
       return {
         tool: 'apply_patch',
-        input: { description: params?.reason || 'Apply file changes', file_path: params?.grantRoot },
+        input: { description, file_path: params?.grantRoot, changes },
       }
     }
     // item/commandExecution/requestApproval
@@ -486,6 +521,21 @@ export class CodexAppServerSession extends BaseSession {
       // can't render an empty approval prompt (#6611 review nitpick).
       input: { command: params?.command, cwd: params?.cwd, description: params?.reason || params?.command || 'Run a shell command' },
     }
+  }
+
+  // #6638: summarize a fileChange `changes` array (FileUpdateChange[] =
+  // { path, kind, diff }) into a paths line for the approval prompt, e.g.
+  // "2 files: src/a.js, src/b.js". Caps the list (+N more) so it stays bounded
+  // for the ≤200-char prompt. Returns null when there's nothing to summarize.
+  _summarizeFileChanges(changes) {
+    if (!Array.isArray(changes) || changes.length === 0) return null
+    const MAX = 3
+    const paths = changes.map((c) => (c && typeof c.path === 'string' ? c.path : null)).filter(Boolean)
+    if (paths.length === 0) return `${changes.length} file change(s)`
+    const shown = paths.slice(0, MAX)
+    const extra = paths.length - shown.length
+    const list = shown.join(', ') + (extra > 0 ? `, +${extra} more` : '')
+    return `${paths.length} file${paths.length === 1 ? '' : 's'}: ${list}`
   }
 
   // The two approval families use DIFFERENT decision vocabularies (from the

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -323,9 +323,11 @@ export class CodexAppServerSession extends BaseSession {
       })
       this._trackToolStart(toolUseId, 'apply_patch')
       // #6638: remember the changes so a later fileChange approval (keyed by the
-      // same itemId, but carrying no diff) can show what will change. Bounded —
-      // deleted on item completion / cleared per turn; evict oldest at the cap.
-      if (toolUseId != null) {
+      // same itemId, but carrying no diff) can show what will change. Only cache a
+      // non-null diff — a null-change item would just waste a slot and evict a real
+      // diff earlier. Bounded: deleted on item completion / cleared per turn; evict
+      // oldest at the cap.
+      if (toolUseId != null && changes != null) {
         if (this._pendingFileChanges.size >= MAX_PENDING_FILE_CHANGES) {
           this._pendingFileChanges.delete(this._pendingFileChanges.keys().next().value)
         }

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -400,6 +400,25 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
       assert.equal(s._summarizeFileChanges(null), null)
       cleanup()
     })
+
+    it('clears the cached diffs when the turn ends (leak prevention)', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      s.on('error', () => {}) // _failTurn emits 'error'; swallow so EventEmitter doesn't throw
+      s._activeTurn = { messageId: 'm1', didStreamStart: false }
+      s._onItemStarted(fcItem())
+      assert.equal(s._pendingFileChanges.size, 1, 'cached during the turn')
+      s._failTurn('boom') // a turn-teardown path → _clearMessageState → clears the cache
+      assert.equal(s._pendingFileChanges.size, 0, 'released at turn end')
+      cleanup()
+    })
+
+    it('_summarizeFileChanges tolerates a string patch and path-less entries', () => {
+      const { s, cleanup } = mkApprovalSession()
+      // #6638: item.changes ?? item.patch — patch can be a unified-diff STRING.
+      assert.equal(s._summarizeFileChanges('a-unified-diff-string'), null, 'a string patch → null, no throw')
+      assert.match(s._summarizeFileChanges([{ kind: 'update', diff: 'd' }, null]), /file change\(s\)/, 'entries without a path → count only')
+      cleanup()
+    })
   })
 
   it('acceptEdits auto-approves a codex file edit (fileChange) without a prompt', async () => {

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -344,6 +344,64 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     }
   })
 
+  describe('apply_patch diff preview (#6638)', () => {
+    const fcItem = () => ({
+      type: 'fileChange',
+      id: 'fc-1',
+      changes: [
+        { path: 'src/a.js', kind: 'update', diff: '@@ -1 +1 @@\n-a\n+b' },
+        { path: 'src/b.js', kind: 'add', diff: '+new' },
+      ],
+    })
+
+    it('correlates the fileChange item changes into the approval (paths summary + raw changes)', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+      const reqs = capture(s, ['permission_request'])
+      const item = fcItem()
+      s._onItemStarted(item) // caches changes keyed by itemId 'fc-1'
+      s._onServerRequest({ id: 40, method: 'item/fileChange/requestApproval', params: { itemId: 'fc-1', grantRoot: '/repo', reason: 'edit' } })
+      const req = reqs[0][1]
+      assert.equal(req.tool, 'apply_patch')
+      assert.match(req.description, /2 files: src\/a\.js, src\/b\.js/, 'description names the files being changed')
+      assert.deepEqual(req.input.changes, item.changes, 'raw diff passed through for client rendering')
+      s.respondToPermission(req.requestId, 'deny')
+      cleanup()
+    })
+
+    it('gracefully omits the diff when no matching item was seen (no regression)', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      const reqs = capture(s, ['permission_request'])
+      s._onServerRequest({ id: 41, method: 'item/fileChange/requestApproval', params: { itemId: 'unseen', grantRoot: '/repo', reason: 'edit files' } })
+      const req = reqs[0][1]
+      assert.equal(req.description, 'edit files', 'falls back to the reason')
+      assert.equal(req.input.changes, null)
+      s.respondToPermission(req.requestId, 'deny')
+      cleanup()
+    })
+
+    it('releases the cached diff on item completion', () => {
+      const { s, cleanup } = mkApprovalSession('approve')
+      s._activeTurn = { messageId: 'm1', didStreamStart: true }
+      const reqs = capture(s, ['permission_request'])
+      s._onItemStarted(fcItem())
+      s._onItemCompleted({ type: 'fileChange', id: 'fc-1', status: 'ok' })
+      s._onServerRequest({ id: 42, method: 'item/fileChange/requestApproval', params: { itemId: 'fc-1', grantRoot: '/repo', reason: 'edit' } })
+      assert.equal(reqs[0][1].input.changes, null, 'a completed item is no longer cached')
+      s.respondToPermission(reqs[0][1].requestId, 'deny')
+      cleanup()
+    })
+
+    it('_summarizeFileChanges caps the path list with a +N more tail', () => {
+      const { s, cleanup } = mkApprovalSession()
+      const many = Array.from({ length: 6 }, (_, i) => ({ path: `f${i}.js`, kind: 'update', diff: 'd' }))
+      assert.match(s._summarizeFileChanges(many), /6 files: f0\.js, f1\.js, f2\.js, \+3 more/)
+      assert.equal(s._summarizeFileChanges([]), null)
+      assert.equal(s._summarizeFileChanges(null), null)
+      cleanup()
+    })
+  })
+
   it('acceptEdits auto-approves a codex file edit (fileChange) without a prompt', async () => {
     const { s, cleanup, responded } = mkApprovalSession('acceptEdits')
     const reqs = capture(s, ['permission_request'])


### PR DESCRIPTION
## What

Follow-on from the codex permission scoping (#6638 §9.5). A codex file-edit approval (`item/fileChange/requestApproval`) could only say **"Apply file changes"** — its params carry no diff (only `itemId`, `reason`, `grantRoot`). So an operator approving a codex edit couldn't see *what* would change from the prompt.

The actual diff arrives earlier, on the fileChange **item.started** event (`item.changes` = `FileUpdateChange[]` = `{ path, kind, diff }`), keyed by the **same `itemId`**.

## How

Correlate them: cache the item's `changes` by `itemId` when the item starts, then on the approval (same `itemId`):
- **description names the files** — `"reason — 2 files: src/a.js, src/b.js"` (capped `+N more`) — visible **with no client change**, since the prompt already renders `<tool>: <description>`;
- the raw **`changes`** ride along in the approval `input` for a client that renders an inline diff.

Falls back gracefully (reason / generic description, `changes: null`) when no matching item was seen — **no regression**. The cache is bounded: evict-at-cap (500), delete on item completion, and cleared per turn via a `_clearMessageState` override (a diff can't outlive its turn).

## Verification notes for @blamechris

- The **file-name summary in the prompt** works server-side today (no client change).
- The **inline diff rendering** of the raw `changes` in the permission prompt is a client concern — the data is now in the approval `input`; please confirm/extend the app/dashboard `apply_patch` permission prompt to render it.
- The correlation assumes the fileChange item.started (with `changes`) arrives **before** the approval (codex's item-then-approve flow). If a live codex session ever ordered them differently, it gracefully no-ops (the diff is still visible in the separate apply_patch tool card). Worth a quick live check that the summary populates.

## Tests

`codex-app-server-session.test.js` — new `describe('apply_patch diff preview (#6638)')`: correlation (paths summary + raw changes), graceful fallback (no matching item → reason + null), per-completion cache release, and the `_summarizeFileChanges` `+N more` cap. Full codex suite **67/67 on Linux**; eslint clean. Doc updated (§6, §9.5).

Addresses #6638 open decision 5.