### PR TITLE
feat(server): per-session codex sandbox mode via create_session

### DIFF
--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -128,8 +128,11 @@ a new thread.
 This is a **Codex-only concept** with no Claude equivalent. The env var is the
 server-wide default; since #6638 a session can **override it at creation** via the
 `create_session` `codexSandbox` field (one of the three modes), which wins over
-the env/default and is applied at that session's thread start. A client **selector
-UI** to set it is a follow-up — the API + server wiring ship here.
+the env/default on **both** the app-server and legacy-exec paths, applied at that
+session's thread start. A client **selector UI** to set it is a follow-up (#6689)
+— the API + server wiring ship here. (The per-session choice isn't persisted, so a
+session restored after a daemon restart reverts to the env/default — harmless
+today since codex `resume` is unsupported and a restore starts a fresh thread.)
 Scope-escalation (`request_permissions`) is how Codex asks, mid-turn, to broaden
 beyond its sandbox; approving it grants the requested filesystem/network scope
 for the turn or session (§3).

--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -125,8 +125,11 @@ can edit files). Applied **once at thread start** — the per-turn parameter is 
 `approvalPolicy` (§2), not the sandbox, so a mid-session sandbox change would need
 a new thread.
 
-This is a **Codex-only concept** with no Claude equivalent, and it is
-**env-only** — not exposed per-session in the UI or the `create_session` API.
+This is a **Codex-only concept** with no Claude equivalent. The env var is the
+server-wide default; since #6638 a session can **override it at creation** via the
+`create_session` `codexSandbox` field (one of the three modes), which wins over
+the env/default and is applied at that session's thread start. A client **selector
+UI** to set it is a follow-up — the API + server wiring ship here.
 Scope-escalation (`request_permissions`) is how Codex asks, mid-turn, to broaden
 beyond its sandbox; approving it grants the requested filesystem/network scope
 for the turn or session (§3).
@@ -178,7 +181,7 @@ Each carries a recommendation, but the call is yours.
    *Recommendation:* yes, low-effort — make the mode copy provider-aware so Codex doesn't show `--dangerously-skip-permissions`/plan-mode language that doesn't apply. At minimum, note in the copy that `plan` ≈ `approve` and `skipPermissions` is a no-op for Codex.
 
 2. **Expose sandbox mode per session (UI/API) instead of env-only?**
-   *Recommendation:* yes, but as its own slice — add `sandbox` to `create_session` for Codex + a session control, defaulting to `workspace-write`. It's the most operator-visible Codex-specific lever. Bigger than a copy tweak (protocol + both clients).
+   *Update:* the **API + server wiring shipped** (#6638) — `create_session` takes a `codexSandbox` mode that overrides the env/default for that session. Still open: the client **session control** (app/dashboard selector) to set it. Default stays `workspace-write`.
 
 3. **Should scope-escalation requests remain prompts (post-#6610), and be visible in history?**
    *Recommendation:* keep the prompt (shipped in #6610). Separately decide whether a *resolved* escalation leaves a compact audit line in the transcript — recommend yes, for auditability, tracked with the resolved-permissions-in-history UX (#6627).

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -342,6 +342,11 @@ export declare const CreateSessionSchema: z.ZodObject<{
         }, z.core.$loose>>;
         autoAllowBashIfSandboxed: z.ZodOptional<z.ZodBoolean>;
     }, z.core.$loose>>;
+    codexSandbox: z.ZodOptional<z.ZodEnum<{
+        "read-only": "read-only";
+        "workspace-write": "workspace-write";
+        "danger-full-access": "danger-full-access";
+    }>>;
     isolation: z.ZodOptional<z.ZodEnum<{
         worktree: "worktree";
         sandbox: "sandbox";
@@ -981,6 +986,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         }, z.core.$loose>>;
         autoAllowBashIfSandboxed: z.ZodOptional<z.ZodBoolean>;
     }, z.core.$loose>>;
+    codexSandbox: z.ZodOptional<z.ZodEnum<{
+        "read-only": "read-only";
+        "workspace-write": "workspace-write";
+        "danger-full-access": "danger-full-access";
+    }>>;
     isolation: z.ZodOptional<z.ZodEnum<{
         worktree: "worktree";
         sandbox: "sandbox";

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -398,6 +398,9 @@ export const CreateSessionSchema = z.object({
     permissionMode: z.enum(['approve', 'acceptEdits', 'auto', 'plan']).optional(),
     worktree: z.boolean().optional(),
     sandbox: SandboxSchema.optional(),
+    // #6638: per-session Codex sandbox mode (codex provider only; ignored by
+    // others). Overrides the server-wide CHROXY_CODEX_SANDBOX / the default.
+    codexSandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
     isolation: z.enum(['none', 'worktree', 'sandbox', 'container']).optional(),
     environmentId: z.string().max(256).optional(),
     // #4208: opt-in to spawning the claude TUI with

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -449,6 +449,9 @@ export const CreateSessionSchema = z.object({
   permissionMode: z.enum(['approve', 'acceptEdits', 'auto', 'plan']).optional(),
   worktree: z.boolean().optional(),
   sandbox: SandboxSchema.optional(),
+  // #6638: per-session Codex sandbox mode (codex provider only; ignored by
+  // others). Overrides the server-wide CHROXY_CODEX_SANDBOX / the default.
+  codexSandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
   isolation: z.enum(['none', 'worktree', 'sandbox', 'container']).optional(),
   environmentId: z.string().max(256).optional(),
   // #4208: opt-in to spawning the claude TUI with

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -93,6 +93,9 @@ export class CodexAppServerSession extends BaseSession {
     this._lastUsage = null
     this._skillsPrepended = false // #6606 — inject the skills prefix once, on turn 1
     this._turnAbort = null // per-turn AbortController — cancels pending approvals
+    // #6638: per-session sandbox override (create_session `codexSandbox`) — wins
+    // over CHROXY_CODEX_SANDBOX / the default. Applied at thread start.
+    this._codexSandbox = opts.codexSandbox || null
     // #6638: fileChange item.changes cached by itemId, so a fileChange approval
     // (whose params carry NO diff) can surface WHAT will change. Cleared per turn.
     this._pendingFileChanges = new Map()
@@ -116,7 +119,7 @@ export class CodexAppServerSession extends BaseSession {
   // ------------------------------------------------------------------
 
   async start() {
-    const sandbox = resolveCodexSandbox()
+    const sandbox = resolveCodexSandbox(this._codexSandbox)
     this._client = new CodexAppServerClient({
       bin: CodexAppServerSession.resolvedBinary,
       cwd: this.cwd,

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -202,15 +202,17 @@ export function resolveCodexSandbox(override) {
  *                                 form so the CLI replays prior conversation
  *                                 state instead of treating each message as
  *                                 a fresh thread (#3865).
+ * @param {string} [sandboxOverride]  #6638 — per-session sandbox mode; wins over
+ *                                 the CHROXY_CODEX_SANDBOX env / default if valid.
  * @returns {string[]}
  */
-export function buildCodexArgs(text, model, threadId = null) {
+export function buildCodexArgs(text, model, threadId = null, sandboxOverride = undefined) {
   // INVARIANT: --sandbox must be passed to the parent `exec`, not to the
   // `resume` subcommand. `codex exec resume --sandbox ...` errors out with
   // `unexpected argument '--sandbox' found` (verified against codex-cli
   // 0.128.0) because --sandbox is only declared on the parent `exec` command.
   // Keep --sandbox BEFORE the `resume` subcommand on the resume path.
-  const sandbox = resolveCodexSandbox()
+  const sandbox = resolveCodexSandbox(sandboxOverride)
   const args = threadId
     ? ['exec', '--sandbox', sandbox, 'resume', threadId, text, '--json', '--skip-git-repo-check']
     : ['exec', text, '--json', '--skip-git-repo-check', '--sandbox', sandbox]
@@ -512,6 +514,9 @@ export class CodexSession extends JsonlSubprocessSession {
       model: opts.model || DEFAULT_MODEL,
       resumeSessionId: opts.resumeSessionId,
     }))
+    // #6638: per-session sandbox override — honored on the exec path too, so a
+    // read-only/full-access session isn't a silent no-op under CHROXY_CODEX_APPSERVER=0.
+    this._codexSandbox = opts.codexSandbox || null
   }
 
   // ------------------------------------------------------------------
@@ -519,7 +524,7 @@ export class CodexSession extends JsonlSubprocessSession {
   // ------------------------------------------------------------------
 
   _buildArgs(text) {
-    return buildCodexArgs(text, this.model, this.resumeSessionId)
+    return buildCodexArgs(text, this.model, this.resumeSessionId, this._codexSandbox)
   }
 
   _buildChildEnv() {

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -109,9 +109,19 @@ const _warnedSandboxValues = new Set()
  * Read at call time (not module-load time) so the override responds to test
  * harnesses, hot reload, and in-process env changes.
  *
+ * #6638: a per-session `override` (from create_session `codexSandbox`) wins over
+ * the env when it is a valid mode — so a session can pick read-only / full-access
+ * without changing the server-wide env. An invalid override is ignored and the
+ * env → default resolution proceeds (the schema already gates the wire value, so
+ * this only bites an internal caller passing garbage).
+ *
+ * @param {string} [override] - per-session sandbox mode, wins over the env if valid
  * @returns {'read-only'|'workspace-write'|'danger-full-access'}
  */
-export function resolveCodexSandbox() {
+export function resolveCodexSandbox(override) {
+  if (typeof override === 'string' && CODEX_SANDBOX_MODES.includes(override.trim())) {
+    return override.trim()
+  }
   const raw = process.env.CHROXY_CODEX_SANDBOX
   if (typeof raw !== 'string' || raw.length === 0) return CODEX_DEFAULT_SANDBOX
   const trimmed = raw.trim()

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -8,6 +8,7 @@ import { USER_SHELL_PROVIDER } from '@chroxy/protocol'
 import { auditShellCreate } from '../shell-audit.js'
 import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError, isSessionViewer, isUserShellSession, ALLOWED_PERMISSION_MODE_IDS, getPermissionModes } from '../handler-utils.js'
 import { getRegistryForProvider } from '../models.js'
+import { CODEX_SANDBOX_MODES } from '../codex-session.js'
 import { isUserShellEnabled, isUserShellApprovalRequired } from '../config.js'
 import { createLogger, loggerForSession } from '../logger.js'
 
@@ -115,6 +116,10 @@ function handleCreateSession(ws, client, msg, ctx) {
   const permissionMode = rawPermMode && ALLOWED_PERMISSION_MODE_IDS.has(rawPermMode) ? rawPermMode : undefined
   const worktree = msg.worktree === true ? true : undefined
   const sandbox = (msg.sandbox && typeof msg.sandbox === 'object' && !Array.isArray(msg.sandbox)) ? msg.sandbox : undefined
+  // #6638: per-session codex sandbox mode. Schema-gated to the valid enum; the
+  // guard keeps an unexpected value from reaching the session (→ env/default).
+  const rawCodexSandbox = (typeof msg.codexSandbox === 'string' && msg.codexSandbox.trim()) ? msg.codexSandbox.trim() : undefined
+  const codexSandbox = rawCodexSandbox && CODEX_SANDBOX_MODES.includes(rawCodexSandbox) ? rawCodexSandbox : undefined
   const environmentId = (typeof msg.environmentId === 'string' && msg.environmentId.trim()) ? msg.environmentId.trim() : undefined
   // #4208: opt-in TUI flag — preserve strict booleans so an explicit `false`
   // can override a server-wide `defaultSkipPermissions: true` on a per-session
@@ -209,7 +214,7 @@ function handleCreateSession(ws, client, msg, ctx) {
 
   // #6277 — build the create options + audit identity ONCE; both the synchronous
   // path and the host-approval deferred path replay the identical create.
-  const createOptions = { name, cwd, provider, model, permissionMode, worktree, sandbox, skipPermissions, agentCommId, ...envOpts }
+  const createOptions = { name, cwd, provider, model, permissionMode, worktree, sandbox, codexSandbox, skipPermissions, agentCommId, ...envOpts }
   const isUserShell = provider === USER_SHELL_PROVIDER
   // Capture the audit identity at REQUEST time: the deferred (approved) path may
   // run after the requesting socket is gone, so it can't read a live `client`.

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1110,7 +1110,7 @@ export class SessionManager extends EventEmitter {
    *   full-destroy path on start failure.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, skipPersist = false, preserveId, isRestore = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, codexSandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, skipPersist = false, preserveId, isRestore = false } = {}) {
     // #6036 — front-half SRP extraction: preflight + isolation + provider/preset
     // resolution (incl. the limit guard, cwd check, id/name, #2962 preflight,
     // #5985 user-shell gate, #3403 model fallback, worktree create/restore, and
@@ -1160,6 +1160,10 @@ export class SessionManager extends EventEmitter {
       // ProviderClass via getProvider() — the registry key.
       provider: resolvedProvider,
     }
+    // #6638: per-session codex sandbox mode (read-only / workspace-write /
+    // danger-full-access). Codex-specific opt read directly by CodexAppServerSession;
+    // ignored by other providers.
+    if (codexSandbox) providerOpts.codexSandbox = codexSandbox
     if (this._maxToolInput) providerOpts.maxToolInput = this._maxToolInput
     if (this._resultTimeoutMs != null) providerOpts.resultTimeoutMs = this._resultTimeoutMs
     if (this._hardTimeoutMs != null) providerOpts.hardTimeoutMs = this._hardTimeoutMs

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -11,9 +11,9 @@ import { CodexAppServerClient } from '../src/codex-app-server-client.js'
 // WITHOUT spawning a real `codex app-server` (the live end-to-end round-trip is
 // validated separately).
 
-function mkSession() {
+function mkSession(extraOpts = {}) {
   const sk = mkdtempSync(join(tmpdir(), 'chroxy-cas-'))
-  const s = new CodexAppServerSession({ cwd: '/tmp', skillsDir: sk, repoSkillsDir: null })
+  const s = new CodexAppServerSession({ cwd: '/tmp', skillsDir: sk, repoSkillsDir: null, ...extraOpts })
   return { s, cleanup: () => rmSync(sk, { recursive: true, force: true }) }
 }
 function capture(s, events) {
@@ -297,6 +297,15 @@ describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
     s.permissionMode = 'approve'; assert.equal(s._approvalPolicy(), 'on-request')
     s.permissionMode = 'acceptEdits'; assert.equal(s._approvalPolicy(), 'on-request')
     cleanup()
+  })
+
+  it('stores a per-session codexSandbox opt for start() to apply (#6638)', () => {
+    const withOverride = mkSession({ codexSandbox: 'read-only' })
+    assert.equal(withOverride.s._codexSandbox, 'read-only', 'the per-session sandbox override is captured')
+    withOverride.cleanup()
+    const without = mkSession()
+    assert.equal(without.s._codexSandbox, null, 'no opt → null (start() falls back to env/default)')
+    without.cleanup()
   })
 
   it('commandExecution approval → permission_request; allow → {decision:accept}', async () => {

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -979,6 +979,19 @@ describe('CodexSession', () => {
       assert.equal(withModel[idxModel + 1], 'workspace-write')
     })
 
+    it('honors a per-session sandbox override on the exec path (#6638)', () => {
+      // Not a silent no-op under CHROXY_CODEX_APPSERVER=0: a valid override wins
+      // regardless of env (invalid-override → env/default precedence is covered
+      // by the resolveCodexSandbox tests).
+      const args = buildCodexArgs('hi', null, null, 'read-only')
+      assert.equal(args[args.indexOf('--sandbox') + 1], 'read-only')
+      // On the resume path too, --sandbox stays before the resume subcommand.
+      const resume = buildCodexArgs('hi', null, 'thr-1', 'danger-full-access')
+      const ri = resume.indexOf('--sandbox')
+      assert.equal(resume[ri + 1], 'danger-full-access')
+      assert.ok(ri < resume.indexOf('resume'), '--sandbox stays before the resume subcommand')
+    })
+
     // #3865: multi-turn context loss. Without a threadId, every sendMessage
     // spawns `codex exec "<prompt>"` as a fresh thread and Codex has no
     // memory of prior turns. When a threadId is supplied, argv switches to

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -1128,6 +1128,22 @@ describe('CodexSession', () => {
         }
       })
 
+      it('resolveCodexSandbox(override) — a valid per-session override wins over env/default (#6638)', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+        assert.equal(resolveCodexSandbox('danger-full-access'), 'danger-full-access', 'override beats env')
+        delete process.env.CHROXY_CODEX_SANDBOX
+        assert.equal(resolveCodexSandbox('read-only'), 'read-only', 'override beats the default')
+        assert.equal(resolveCodexSandbox('  workspace-write  '), 'workspace-write', 'override is trimmed')
+      })
+
+      it('resolveCodexSandbox(override) — an invalid/absent override falls through to env/default (#6638)', () => {
+        process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+        assert.equal(resolveCodexSandbox('gimme-root'), 'read-only', 'invalid override → env resolution')
+        delete process.env.CHROXY_CODEX_SANDBOX
+        assert.equal(resolveCodexSandbox('bogus'), 'workspace-write', 'invalid override + no env → default')
+        assert.equal(resolveCodexSandbox(undefined), 'workspace-write', 'no override → default')
+      })
+
       // #3981: resolveCodexSandbox() runs on every sendMessage(). Without
       // a per-value warn cache, a single typo in an operator's environment
       // would spam console.warn for every turn for the lifetime of the

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -253,6 +253,20 @@ describe('session-handlers', () => {
       assert.equal(sent.sessionId, 'new-id')
     })
 
+    it('threads a valid codexSandbox to createSession and drops an invalid one (#6638)', () => {
+      const ctx = makeCtx()
+      const session = createMockSession()
+      const spy = createSpy(() => 'new-id')
+      ctx.sessions.sessionManager.createSession = spy
+      ctx._sessions.set('new-id', { session, name: 'New', cwd: '/tmp' })
+
+      sessionHandlers.create_session(makeWs(), makeClient(), { name: 'A', codexSandbox: 'read-only' }, ctx)
+      assert.equal(spy.lastCall[0].codexSandbox, 'read-only', 'a valid codexSandbox is threaded to createSession')
+
+      sessionHandlers.create_session(makeWs(), makeClient(), { name: 'B', codexSandbox: 'gimme-root' }, ctx)
+      assert.equal(spy.lastCall[0].codexSandbox, undefined, 'an invalid codexSandbox is dropped (→ env/default)')
+    })
+
     it('sends session_error when worktree requested without cwd', () => {
       const ctx = makeCtx()
       sessionHandlers.create_session(makeWs(), makeClient(), { worktree: true }, ctx)

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -263,6 +263,9 @@ describe('session-handlers', () => {
       sessionHandlers.create_session(makeWs(), makeClient(), { name: 'A', codexSandbox: 'read-only' }, ctx)
       assert.equal(spy.lastCall[0].codexSandbox, 'read-only', 'a valid codexSandbox is threaded to createSession')
 
+      // NB: over the wire an invalid codexSandbox is rejected by the schema
+      // (ClientMessageSchema) before reaching here; this asserts the handler's
+      // defense-in-depth for an internal caller that bypasses the schema.
       sessionHandlers.create_session(makeWs(), makeClient(), { name: 'B', codexSandbox: 'gimme-root' }, ctx)
       assert.equal(spy.lastCall[0].codexSandbox, undefined, 'an invalid codexSandbox is dropped (→ env/default)')
     })


### PR DESCRIPTION
## What

Follow-on from the codex permission scoping (#6638 §9.2). Codex's sandbox mode (`read-only` / `workspace-write` / `danger-full-access`) was **env-only** (`CHROXY_CODEX_SANDBOX`, server-wide). A session couldn't run in a tighter (read-only exploration) or looser (trusted full-access) sandbox without changing the whole server's env.

This lets a session **pick its own sandbox at creation**.

## How

- **protocol**: `create_session` gains an optional `codexSandbox` enum (codex-only; ignored by other providers) — dist rebuilt.
- **`resolveCodexSandbox(override)`**: a valid per-session override wins over `CHROXY_CODEX_SANDBOX` and the default; an invalid one falls through to the existing env/default resolution (the schema already gates the wire value).
- **`CodexAppServerSession`** reads `opts.codexSandbox` and applies it at `thread/start` (codex applies the sandbox once at thread start — see the design doc §5).
- **threading**: `create_session` handler (schema-gated + guarded) → `createSession` → `providerOpts` (a codex-specific opt read directly by the session — not a `BaseSession` opt, so no opt-forwarding concern).

Default stays `workspace-write`. The client **selector UI** is tracked in **#6689** — this ships the API + server wiring.

## Tests

- `codex-session.test.js`: `resolveCodexSandbox(override)` precedence — a valid override beats env/default (and is trimmed); an invalid/absent override falls through to env → default.
- `codex-app-server-session.test.js`: the session captures `_codexSandbox` from the opt (start() applies it).
- `session-handlers.test.js`: `create_session` threads a valid `codexSandbox` to `createSession` and drops an invalid one.

Protocol schemas **260/260**; the touched server suites green on Linux; eslint + opt-forwarding + state-file lints clean.

Addresses #6638 open decision 2.