### PR TITLE
fix(store-core): self-heal stale "Queued" bubble on the turn boundary (#6627)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2825,13 +2825,26 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (effectiveId && get().sessionStates[effectiveId]) {
           // Force a new messages array reference so selectors detect the change,
           // even when flushPendingDeltas() was a no-op (timer already flushed).
-          updateSession(effectiveId, (ss) => ({
-            ...resultPatch,
-            messages: [...ss.messages],
-            // #6627 — LIVE results only: a REPLAYED result (on switch_session)
-            // carries a stale queueLength that must not trim the current queue.
-            ...(queueReconcile && !_ctx.replayingSessions.has(effectiveId) ? queueReconcile.applyTo(ss.queuedMessages ?? []) : {}),
-          }));
+          updateSession(effectiveId, (ss) => {
+            // #6627 — reconcile the queue on the turn boundary so a stale "Queued"
+            // bubble (dropped/late message_dequeued) self-heals. Apply only for a
+            // LIVE, OWN-session result: skip during replay (stale queueLength) and
+            // when effectiveId fell back to the active session (effectiveId !==
+            // targetId → the queueLength is from a different session) — matching
+            // the dashboard's targetId-scoped gate. Only patch queuedMessages when
+            // the reconcile actually trimmed an orphan (referential no-op otherwise
+            // → no needless write/rerender every turn).
+            const currentQueue = ss.queuedMessages ?? [];
+            const reconciledQueue =
+              queueReconcile && effectiveId === targetId && !_ctx.replayingSessions.has(effectiveId)
+                ? queueReconcile.applyTo(currentQueue).queuedMessages
+                : currentQueue;
+            return {
+              ...resultPatch,
+              messages: [...ss.messages],
+              ...(reconciledQueue !== currentQueue ? { queuedMessages: reconciledQueue } : {}),
+            };
+          });
         }
       }
       break;

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -91,6 +91,7 @@ import {
   // mcp_servers / session_usage / web_task_list / web_feature_status migrated
   // to the shared dispatch table (#5556 slice 2)
   handleResultUsage as sharedResultUsage,
+  handleResultQueueReconcile,
   handleServerError as sharedServerError,
   handleServerStatusLegacy as sharedServerStatusLegacy,
   // web_task_created / web_task_updated — migrated to the shared dispatch table
@@ -2811,6 +2812,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         lastResultDuration: normalized.lastResultDuration,
       };
       const targetId = normalized.sessionId;
+      // #6627 — reconcile the queue against the result's authoritative queueLength
+      // so a stale "Queued" bubble (from a dropped/late message_dequeued) self-heals
+      // on this turn boundary. Null when the server sent no queueLength (older).
+      const queueReconcile = handleResultQueueReconcile(msg, get().activeSessionId);
       // Notify if a background session just finished (was streaming)
       if (targetId && get().sessionStates[targetId]?.streamingMessageId) {
         pushSessionNotification(targetId, 'completed', 'Task completed');
@@ -2823,6 +2828,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           updateSession(effectiveId, (ss) => ({
             ...resultPatch,
             messages: [...ss.messages],
+            // #6627 — LIVE results only: a REPLAYED result (on switch_session)
+            // carries a stale queueLength that must not trim the current queue.
+            ...(queueReconcile && !_ctx.replayingSessions.has(effectiveId) ? queueReconcile.applyTo(ss.queuedMessages ?? []) : {}),
           }));
         }
       }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -86,6 +86,7 @@ import {
   handleEnvironmentError as sharedEnvironmentError,
   // mcp_servers / session_usage migrated to the shared dispatch table (#5556 slice 2)
   handleResultUsage as sharedResultUsage,
+  handleResultQueueReconcile,
   handleServerError as sharedServerError,
   handleServerStatusLegacy as sharedServerStatusLegacy,
   // web_task_created / web_task_updated — migrated to the shared dispatch table
@@ -4404,6 +4405,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         lastResultCost: resolvedCost,
         lastResultDuration: normalized.lastResultDuration,
       };
+      // #6627 — reconcile the queue against the result's authoritative queueLength
+      // so a stale "Queued" bubble (from a dropped/late message_dequeued) self-heals
+      // on this turn boundary. Null when the server sent no queueLength (older).
+      const queueReconcile = handleResultQueueReconcile(msg, get().activeSessionId);
       // Notify if a background session just finished (was streaming)
       if (targetId && get().sessionStates[targetId]?.streamingMessageId) {
         pushSessionNotification(targetId, 'completed', 'Task completed');
@@ -4430,6 +4435,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           const patch: Partial<SessionState> = {
             ...resultPatch,
             messages: [...ss.messages],
+            // #6627 — self-heal a stale "Queued" bubble on the turn boundary.
+            // LIVE results only: a REPLAYED result (on switch_session) carries a
+            // stale queueLength that must not trim the current queue (mirrors the
+            // activeTools replay guard below).
+            ...(queueReconcile && !_replayingSessions.has(targetId) ? queueReconcile.applyTo(ss.queuedMessages ?? []) : {}),
           };
           // #4493 — gate per target session id. A live `result` for
           // session B during A's replay must still sweep B's activeTools.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -4432,14 +4432,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // replayed in-flight tool_start then re-adds the entry with a
           // fresh Date.now() startedAt, restoring the exact "Running X · 1s"
           // clock-reset symptom #4466 set out to fix.
+          // #6627 — self-heal a stale "Queued" bubble on the turn boundary.
+          // LIVE results only: a REPLAYED result (on switch_session) carries a
+          // stale queueLength that must not trim the current queue (mirrors the
+          // activeTools replay guard below). Only patch queuedMessages when the
+          // reconcile actually trimmed an orphan — reconcileQueueLength returns
+          // the same array reference in the common in-sync case, so gating on
+          // referential inequality avoids a needless write/rerender every turn.
+          const currentQueue = ss.queuedMessages ?? [];
+          const reconciledQueue =
+            queueReconcile && !_replayingSessions.has(targetId)
+              ? queueReconcile.applyTo(currentQueue).queuedMessages
+              : currentQueue;
           const patch: Partial<SessionState> = {
             ...resultPatch,
             messages: [...ss.messages],
-            // #6627 — self-heal a stale "Queued" bubble on the turn boundary.
-            // LIVE results only: a REPLAYED result (on switch_session) carries a
-            // stale queueLength that must not trim the current queue (mirrors the
-            // activeTools replay guard below).
-            ...(queueReconcile && !_replayingSessions.has(targetId) ? queueReconcile.applyTo(ss.queuedMessages ?? []) : {}),
+            ...(reconciledQueue !== currentQueue ? { queuedMessages: reconciledQueue } : {}),
           };
           // #4493 — gate per target session id. A live `result` for
           // session B during A's replay must still sweep B's activeTools.

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -60,6 +60,7 @@ export declare const ServerResultSchema: z.ZodObject<{
     duration: z.ZodOptional<z.ZodNumber>;
     usage: z.ZodOptional<z.ZodAny>;
     sessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    queueLength: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerModelChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"model_changed">;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -111,6 +111,10 @@ export const ServerResultSchema = z.object({
     duration: z.number().optional(),
     usage: z.any().optional(),
     sessionId: z.string().nullable().optional(),
+    // #6627: the session's authoritative outgoing-queue length at turn end, so
+    // clients reconcile a stale "Queued" bubble on the turn boundary (self-heals a
+    // dropped/late message_dequeued). Absent from older servers.
+    queueLength: z.number().int().nonnegative().optional(),
 });
 export const ServerModelChangedSchema = z.object({
     type: z.literal('model_changed'),

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -123,6 +123,10 @@ export const ServerResultSchema = z.object({
   duration: z.number().optional(),
   usage: z.any().optional(),
   sessionId: z.string().nullable().optional(),
+  // #6627: the session's authoritative outgoing-queue length at turn end, so
+  // clients reconcile a stale "Queued" bubble on the turn boundary (self-heals a
+  // dropped/late message_dequeued). Absent from older servers.
+  queueLength: z.number().int().nonnegative().optional(),
 })
 
 export const ServerModelChangedSchema = z.object({

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1454,7 +1454,12 @@ export class BaseSession extends EventEmitter {
    */
   _emitResult(payload, sweepReason = 'stream_completed_without_result') {
     this._sweepUnresolvedToolStarts(sweepReason)
-    this.emit('result', payload)
+    // #6627: stamp every turn-complete result with the authoritative outgoing-queue
+    // length so clients reconcile any stale "Queued" bubble on a turn boundary — a
+    // dropped/late `message_dequeued` no longer leaves a stale badge until the next
+    // queue event. The count is pre-flush (the imminent dequeue emits its own
+    // event); reconcileQueueLength only trims confirmed orphans, never a live entry.
+    this.emit('result', { ...payload, queueLength: this._outgoingQueue.length })
   }
 
   _clearMessageState() {

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   handleMessageQueued,
   handleMessageDequeued,
+  handleResultQueueReconcile,
   enqueueOptimisticQueuedMessage,
   removeQueuedMessage,
   reconcileQueueLength,
@@ -355,5 +356,41 @@ describe('handleMessageDequeued', () => {
     const current = [confirmed('uin-1', 'a')]
     const builder = handleMessageDequeued({ sessionId: 's1', clientMessageId: 'uin-9', reason: 'flush' }, null)
     expect(builder.applyTo(current).queuedMessages).toBe(current)
+  })
+})
+
+describe('handleResultQueueReconcile (#6627 — self-heal a stale queued bubble on turn boundary)', () => {
+  it('returns null when the result carries no queueLength (older server) — caller skips', () => {
+    expect(handleResultQueueReconcile({ sessionId: 's1' }, null)).toBeNull()
+    expect(handleResultQueueReconcile({ sessionId: 's1', queueLength: undefined }, null)).toBeNull()
+  })
+
+  it('trims a stale CONFIRMED orphan down to the result queueLength (dropped message_dequeued)', () => {
+    // Client still shows 2 confirmed, but the server flushed one and the
+    // message_dequeued was lost — the next result carries queueLength: 1.
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
+    const builder = handleResultQueueReconcile({ sessionId: 's1', queueLength: 1 }, null)!
+    const next = builder.applyTo(current).queuedMessages
+    expect(next.map((m) => m.clientMessageId)).toEqual(['uin-2'])
+  })
+
+  it('is a referential no-op when already in sync (React skips the re-render)', () => {
+    const current = [confirmed('uin-1', 'a')]
+    const builder = handleResultQueueReconcile({ sessionId: 's1', queueLength: 1 }, null)!
+    expect(builder.applyTo(current).queuedMessages).toBe(current)
+  })
+
+  it('never trims a PENDING (unconfirmed) entry — only confirmed orphans', () => {
+    // A just-sent optimistic entry legitimately makes the local queue longer than
+    // the server's confirmed count; it must survive a result reconcile.
+    const current = [confirmed('uin-1', 'a'), pending('uin-2', 'b')]
+    const builder = handleResultQueueReconcile({ sessionId: 's1', queueLength: 0 }, null)!
+    const next = builder.applyTo(current).queuedMessages
+    expect(next.map((m) => m.clientMessageId)).toEqual(['uin-2'])
+  })
+
+  it('resolves the target session from the result msg', () => {
+    const builder = handleResultQueueReconcile({ sessionId: 'sess-x', queueLength: 0 }, 'active')!
+    expect(builder.sessionId).toBe('sess-x')
   })
 })

--- a/packages/store-core/src/handlers/outgoing-queue.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.ts
@@ -331,3 +331,28 @@ export function handleMessageDequeued(
     }),
   }
 }
+
+/**
+ * #6627 — reconcile the queued list against a turn-complete `result`'s
+ * authoritative `queueLength`. `message_dequeued` self-heals only on queue events;
+ * if that frame is dropped/late, a stale "Queued" bubble would otherwise persist
+ * until the next queue event (or a reconnect). Stamping every `result` with the
+ * server's queue length gives a self-heal point on every turn boundary.
+ *
+ * Returns null when the result carries no finite `queueLength` (older server), so
+ * the caller skips the state write entirely. `reconcileQueueLength` only trims
+ * CONFIRMED orphans down to the server's count — it never drops a `'pending'`
+ * (unconfirmed) entry or a genuinely-still-queued message, so this is safe to run
+ * on every result.
+ */
+export function handleResultQueueReconcile(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): QueuedMessagesBuilder | null {
+  const queueLength = optionalNumber(msg, 'queueLength')
+  if (queueLength === undefined) return null
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => ({ queuedMessages: reconcileQueueLength(current, queueLength) }),
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -545,6 +545,9 @@ export {
   // #5950 — orphan-badge safety net: reconcile local queue length to the
   // server's authoritative count so a dropped message_dequeued self-heals.
   reconcileQueueLength,
+  // #6627 — reconcile the queue on a turn-complete result too, so a stale
+  // "Queued" bubble self-heals on the next turn boundary (not only queue events).
+  handleResultQueueReconcile,
   handleDevPreview,
   handleDevPreviewStopped,
   handleAuthOk,


### PR DESCRIPTION
## Summary

Closes #6627.

A queued outgoing message can keep its **"Queued"** styling *after* it has already flushed to Claude, if the `message_dequeued` frame is dropped or arrives late. The badge only self-heals on a **queue event** (`message_queued`/`message_dequeued`), so a missed frame leaves the stale styling until the *next* queue event — or a reconnect snapshot.

This adds a second self-heal point: the **turn boundary**. Each `_emitResult`-routed turn-complete `result` is stamped with the session's authoritative outgoing-queue length, and the clients reconcile against it.

### Reach (accurate scope)

The stamp is applied in `BaseSession._emitResult`, so it covers the providers that route their turn-complete result through it: the **codex-app-server driver (the current default)**, the SDK main path, and the TUI/form drivers. Providers that emit `result` **directly** (legacy `cli-session`/`codex exec`, `gemini`, `byok`, the SDK stall fallback) do not yet carry `queueLength` and keep their existing `message_dequeued`-only self-heal — tracked in #6706. The field is optional/additive, so those paths simply no-op (never regress).

## Changes

- **`base-session.js`** — `_emitResult` emits `{ ...payload, queueLength: this._outgoingQueue.length }`. The count is **pre-flush** (the imminent dequeue emits its own `message_dequeued`); `reconcileQueueLength` only trims *confirmed* orphans, never a pending/live entry, so a still-queued message stamps N (no-op) and only the next turn stamps N-1.
- **`protocol` (`ServerResultSchema`)** — optional `queueLength: z.number().int().nonnegative().optional()`. Absent from older servers → clients no-op.
- **`store-core`** — new `handleResultQueueReconcile(msg, activeSessionId)` builder: returns `null` when no `queueLength`, else reconciles via the existing `reconcileQueueLength`. Re-exported from `index.ts`. 5 new unit tests.
- **`app` + `dashboard` message-handlers** — apply the reconcile in `case 'result'`, gated to **LIVE, own-session** results (skipped during `switch_session` replay, and — app-side — when `effectiveId !== targetId`). Only patches `queuedMessages` when the reconcile actually trims an orphan (referential no-op otherwise → no needless rerender).

## Why it's safe to reconcile on every result

`reconcileQueueLength` is status-aware: it trims the oldest **confirmed** orphans down to the server's count and **never** removes a `'pending'` (optimistic) entry, nor pads when local is shorter. In the common in-sync case it returns the same array reference, and the call site only writes when that reference changes — so this is a pure safety net.

## Verification

- store-core: **1939** tests green (incl. 5 new `handleResultQueueReconcile` cases + dispatch/contract coverage guards).
- protocol: **358** schema tests green (native Windows).
- server: `base-session` **148** + `cli-session-pending-queue` **17** green (WSL2 / CI platform).
- app `tsc --noEmit` + dashboard `typecheck` clean.
- Full CI green on the first commit; re-run pending on the review-fix commit.

## ⚠️ Flagged for live QA — client render not verified end-to-end by me

Per the agreed approach, the **server + store-core reconcile logic is unit-verified**, but the **on-screen client render (does the stale "Queued" card actually clear)** has **not** been verified against a live codex session — that path needs a real dropped/late `message_dequeued`, which unit tests can't reproduce.

**Suggested QA:** queue a codex follow-up message behind an in-flight one, let the first turn complete and the second flush, and confirm the queued card's styling clears on the turn boundary (not only when the next queue event happens to arrive). Both mobile and dashboard.

## Follow-ups

- #6706 — extend `queueLength` stamping to the direct-emit providers (CLI/exec-codex/gemini/byok/sdk-stall).
- #6707 — lock both clients to the same turn-boundary reconcile via a `result` SWITCH_FIXTURE contract test.