### PR TITLE
fix(server): stamp queueLength on every result via a central emit() override (#6706)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1454,12 +1454,44 @@ export class BaseSession extends EventEmitter {
    */
   _emitResult(payload, sweepReason = 'stream_completed_without_result') {
     this._sweepUnresolvedToolStarts(sweepReason)
-    // #6627: stamp every turn-complete result with the authoritative outgoing-queue
-    // length so clients reconcile any stale "Queued" bubble on a turn boundary — a
-    // dropped/late `message_dequeued` no longer leaves a stale badge until the next
-    // queue event. The count is pre-flush (the imminent dequeue emits its own
-    // event); reconcileQueueLength only trims confirmed orphans, never a live entry.
-    this.emit('result', { ...payload, queueLength: this._outgoingQueue.length })
+    // queueLength is stamped centrally in the emit() override below (#6627/#6706).
+    this.emit('result', payload)
+  }
+
+  /**
+   * #6627 / #6706: single choke point for the turn-boundary queue-length stamp.
+   *
+   * Every `result` event carries the session's authoritative outgoing-queue
+   * length so clients reconcile a stale "Queued" bubble on a turn boundary — a
+   * dropped/late `message_dequeued` no longer leaves a stale badge until the
+   * next queue event. The count is pre-flush (the imminent dequeue emits its own
+   * event); `reconcileQueueLength` only trims confirmed orphans, never a live
+   * entry, so it is safe to stamp on every result.
+   *
+   * Stamping here (rather than at each call site) is deliberate: `_emitResult`
+   * is NOT the only emitter — several providers emit `result` directly (CLI /
+   * exec-codex / gemini / byok / stall fallbacks) because they don't want the
+   * orphan sweep, and the #6705 review missed 3 of the 8 sites. Centralizing on
+   * the one method every `result` passes through makes the self-heal uniform
+   * and un-forgettable for future emit sites too.
+   *
+   * Idempotent: a payload that already carries `queueLength` (none today, but a
+   * caller could pre-stamp) is left untouched. `_outgoingQueue` is a BaseSession
+   * field initialized before any subclass method can run; the `?` guard is
+   * belt-and-braces and yields 0 for the impossible early-emit case.
+   *
+   * @param {string} event
+   * @param {...any} args
+   * @returns {boolean} whether the event had listeners (EventEmitter contract)
+   */
+  emit(event, ...args) {
+    if (event === 'result') {
+      const payload = args[0]
+      if (payload && typeof payload === 'object' && payload.queueLength === undefined) {
+        args[0] = { ...payload, queueLength: this._outgoingQueue ? this._outgoingQueue.length : 0 }
+      }
+    }
+    return super.emit(event, ...args)
   }
 
   _clearMessageState() {

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1442,12 +1442,13 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
-   * #4628: emit `result` after sweeping any in-flight tool_starts. All
-   * provider sessions should route through this rather than calling
-   * `this.emit('result', ...)` directly, so orphan tool_starts get
-   * paired with a synthetic tool_result BEFORE the result fires (and
-   * BEFORE state is persisted, since session-message-history listens
-   * for both events).
+   * #4628: emit `result` after sweeping any in-flight tool_starts. Provider
+   * sessions should route through this WHEN they need the orphan sweep, so
+   * orphan tool_starts get paired with a synthetic tool_result BEFORE the
+   * result fires (and BEFORE state is persisted, since session-message-history
+   * listens for both events). Some providers deliberately emit `this.emit(
+   * 'result', ...)` directly (they don't want the sweep); the queueLength stamp
+   * is applied to those too via the emit() override below.
    *
    * @param {object} payload — the result event payload ({cost, duration, usage, sessionId})
    * @param {string} [sweepReason] — optional override for the sweep reason
@@ -1478,7 +1479,8 @@ export class BaseSession extends EventEmitter {
    * Idempotent: a payload that already carries `queueLength` (none today, but a
    * caller could pre-stamp) is left untouched. `_outgoingQueue` is a BaseSession
    * field initialized before any subclass method can run; the `?` guard is
-   * belt-and-braces and yields 0 for the impossible early-emit case.
+   * belt-and-braces and yields 0 for the should-never-happen case of a subclass
+   * emitting `result` inside `super()` before the field is set.
    *
    * @param {string} event
    * @param {...any} args

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1696,6 +1696,27 @@ describe('BaseSession', () => {
       s.emit('result', payload)
       assert.equal('queueLength' in payload, false, 'original payload is not mutated')
     })
+
+    it("preserves the EventEmitter 'error' contract through the override", () => {
+      // The override must NOT swallow or reshape 'error': an unhandled 'error'
+      // still throws (Node's default), and a handled one is delivered verbatim
+      // (never queueLength-stamped). This is the override's highest-risk path.
+      assert.throws(() => s.emit('error', new Error('boom')), /boom/)
+      let received = null
+      s.on('error', (e) => { received = e })
+      const errPayload = { message: 'handled', queueLength: undefined }
+      s.emit('error', errPayload)
+      assert.equal(received, errPayload, 'error payload delivered by identity, unstamped')
+      assert.equal('queueLength' in received && received.queueLength !== undefined, false)
+    })
+
+    it('forwards all args for non-result events (multi-arg pass-through)', () => {
+      const seen = []
+      s.on('foo', (a, b, c) => seen.push(a, b, c))
+      const had = s.emit('foo', 1, 'two', { three: true })
+      assert.equal(had, true)
+      assert.deepStrictEqual(seen, [1, 'two', { three: true }])
+    })
   })
 })
 

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1637,6 +1637,66 @@ describe('BaseSession', () => {
       assert.equal(s._inFlightToolStarts.size, 0)
     })
   })
+
+  // #6706 — the turn-boundary queue-length stamp (#6627) is applied centrally in
+  // the emit() override, so EVERY `result` carries queueLength regardless of
+  // which provider emits it (the direct-emit providers — CLI/exec-codex/gemini/
+  // byok/stall fallbacks — bypass _emitResult but still pass through emit()).
+  describe('result queueLength stamping via emit() override (#6627/#6706)', () => {
+    let s
+    beforeEach(() => {
+      s = new BaseSession({ cwd: '/tmp', repoSkillsDir: null })
+    })
+
+    it('stamps queueLength: 0 on a direct emit when the outgoing queue is empty', () => {
+      let received = null
+      s.on('result', (ev) => { received = ev })
+      // Simulate a direct-emit provider (e.g. cli-session) bypassing _emitResult.
+      s.emit('result', { cost: null, duration: 5, usage: null, sessionId: 'sess_1' })
+      assert.equal(received.queueLength, 0)
+      assert.equal(received.sessionId, 'sess_1', 'original fields preserved')
+    })
+
+    it('stamps queueLength reflecting the current outgoing-queue length', () => {
+      s._outgoingQueue.push({ clientMessageId: 'uin-1' }, { clientMessageId: 'uin-2' })
+      let received = null
+      s.on('result', (ev) => { received = ev })
+      s.emit('result', { cost: 1, duration: 5, usage: null, sessionId: 'sess_1' })
+      assert.equal(received.queueLength, 2)
+    })
+
+    it('_emitResult results also carry queueLength (regression for #6627)', () => {
+      s._outgoingQueue.push({ clientMessageId: 'uin-1' })
+      let received = null
+      s.on('result', (ev) => { received = ev })
+      s._emitResult({ cost: null, duration: 100, usage: null, sessionId: 'sess_1' }, 'turn_end')
+      assert.equal(received.queueLength, 1)
+    })
+
+    it('does not overwrite a queueLength already present on the payload (idempotent)', () => {
+      s._outgoingQueue.push({ clientMessageId: 'uin-1' }, { clientMessageId: 'uin-2' })
+      let received = null
+      s.on('result', (ev) => { received = ev })
+      s.emit('result', { sessionId: 'sess_1', queueLength: 7 })
+      assert.equal(received.queueLength, 7, 'pre-stamped value is preserved')
+    })
+
+    it('leaves non-result events untouched and preserves the has-listeners return', () => {
+      let received = null
+      s.on('stream', (ev) => { received = ev })
+      const hadListeners = s.emit('stream', { chunk: 'x' })
+      assert.equal(hadListeners, true)
+      assert.deepStrictEqual(received, { chunk: 'x' }, 'no queueLength added to non-result events')
+      assert.equal(s.emit('result', { sessionId: 'n' }), false, 'returns false when result has no listener')
+    })
+
+    it('does not mutate the caller-supplied payload object (spreads a copy)', () => {
+      const payload = { cost: null, sessionId: 'sess_1' }
+      s.on('result', () => {})
+      s.emit('result', payload)
+      assert.equal('queueLength' in payload, false, 'original payload is not mutated')
+    })
+  })
 })
 
 // #4509: BaseSession's three per-session inactivity timeouts must also clamp


### PR DESCRIPTION
## Summary

Closes #6706.

PR #6705 (#6627) added a turn-boundary self-heal for a stale **"Queued"** bubble by stamping each turn-complete `result` with the session's authoritative outgoing-queue length. But it stamped only in `_emitResult`, so the self-heal reached the **codex-app-server default** + SDK main path and *not* the providers that emit `result` **directly**:

| Site | Provider |
|---|---|
| `cli-session.js` (×2) | legacy `claude -p` |
| `codex-session.js` | legacy `codex exec` |
| `gemini-session.js` (×2) | Gemini |
| `byok-session.js` | BYOK |
| `jsonl-subprocess-session.js` | middle-layer fallback |
| `sdk-session.js` | stall fallback |

**8 sites** — the #6705 review only spotted 5, which is itself the argument against wrapping each call site.

## Approach

Rather than wrap 8 fragile multi-line object literals (and hope no future emit site forgets), **centralize the stamp in a BaseSession `emit()` override** — the single method every `result` passes through. This mirrors how this repo guards other "must not forget" invariants (the opt-forwarding lint, etc.): make it structurally un-forgettable.

- `emit()` stamps `queueLength: this._outgoingQueue.length` onto any `result` payload lacking it. **Idempotent** (a pre-stamped payload is untouched), **non-mutating** (spreads a copy), other events pass straight through, and the EventEmitter has-listeners return value is preserved.
- `_emitResult` drops its inline stamp and defers to the override.
- `_outgoingQueue` is a BaseSession field → safe on every subclass, `queueLength: 0` for non-queue sessions (no behavior change when the queue is empty).

## Tests

6 new base-session cases: direct-emit stamp (empty + populated queue), `_emitResult` regression, idempotency, non-result pass-through, and no-mutation of the caller payload.

## Verification

All `result`-listening server suites green (WSL2 / CI platform) — no test asserted an exact result payload that the additive field would break:

`base-session` 154 · `cli-session` 81 · `cli-session-events` 44 · `gemini-session` 52 · `codex-session` 119 · `byok-session` 132 · `jsonl-subprocess-session` 43 · `jsonl-subprocess-intentional-stop` 15 · `sdk-session` 148 · `claude-tui-session` 313 · `activity-registry` 35 · `docker-session` 35.

## Follow-up context

This completes the provider-coverage half of the #6705 review's deferred items; #6707 (a `result` SWITCH_FIXTURE locking both clients to the same reconcile) is the remaining one.