### PR TITLE
test(store-core): lock both clients to the result queue-reconcile via SWITCH_FIXTUREs (#6707)

### DIFF
--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1786,6 +1786,41 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
+    // #6627/#6707 — status-aware parity: with an interleaved queue
+    // [confirmed-orphan, pending, confirmed] and queueLength 1, both clients must
+    // reap ONLY the oldest CONFIRMED orphan (a dropped dequeue) and preserve the
+    // optimistic pending entry (a live, not-yet-confirmed send) plus the newest
+    // confirmed one. This is the strong removal-guard fixture: seed length 3 →
+    // expect length 2, so a deleted/stripped reconcile fails it, and a client
+    // that trims the pending entry (the #5950-class regression) fails too.
+    name: 'result reap keeps an interleaved pending entry while trimming a confirmed orphan',
+    type: 'result',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'done' } as unknown as ChatMessage],
+          queuedMessages: [
+            { clientMessageId: 'uin-0', text: 'orphan', queuedAt: 9, status: 'confirmed' },
+            { clientMessageId: 'uin-1', text: 'live', queuedAt: 10, status: 'pending' },
+            { clientMessageId: 'uin-2', text: 'a', queuedAt: 11, status: 'confirmed' },
+          ],
+        },
+      },
+    },
+    message: { type: 'result', sessionId: 's1', cost: 0.01, duration: 1200, queueLength: 1 },
+    expect: {
+      sessions: {
+        s1: {
+          queuedMessages: [
+            { clientMessageId: 'uin-1', text: 'live', queuedAt: 10, status: 'pending' },
+            { clientMessageId: 'uin-2', text: 'a', queuedAt: 11, status: 'confirmed' },
+          ],
+        },
+      },
+    },
+  },
+  {
     // stream_end is the asymmetric teardown gap (stream_start IS pinned above):
     // both clients clear `streamingMessageId` and refresh the messages REFERENCE
     // but leave the transcript untouched. Seed the in-flight response bubble and

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1726,6 +1726,66 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     },
   },
   {
+    // #6627/#6707 — a turn-complete `result` carries the server's authoritative
+    // outgoing-queue length. When a `message_dequeued` was dropped/late the
+    // client still shows a flushed message as "Queued"; both clients self-heal on
+    // the result by trimming the stale CONFIRMED orphan (oldest-first, FIFO) down
+    // to queueLength. The transcript is untouched. This fixture locks app +
+    // dashboard to the same outcome — the reconcile lives in each client's REAL
+    // `case 'result'`, not the shared dispatch table, so only the both-clients
+    // SWITCH harness enforces parity (the #6705 review's deferred gap).
+    name: 'result reconciles a stale queued orphan against queueLength (self-heal)',
+    type: 'result',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'done' } as unknown as ChatMessage],
+          queuedMessages: [
+            { clientMessageId: 'uin-1', text: 'a', queuedAt: 10, status: 'confirmed' },
+            { clientMessageId: 'uin-2', text: 'b', queuedAt: 11, status: 'confirmed' },
+          ],
+        },
+      },
+    },
+    message: { type: 'result', sessionId: 's1', cost: 0.01, duration: 1200, queueLength: 1 },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'done' }],
+          // The oldest confirmed orphan (uin-1) is trimmed; the newest survives.
+          queuedMessages: [{ clientMessageId: 'uin-2', text: 'b', queuedAt: 11, status: 'confirmed' }],
+        },
+      },
+    },
+  },
+  {
+    // #6627/#6707 — when the client queue already matches the result's
+    // queueLength, the reconcile is a referential no-op: the genuinely-queued
+    // entry survives untouched. Guards against an over-eager trim clobbering a
+    // live queued message on every turn boundary.
+    name: 'result leaves the queue intact when queueLength already matches',
+    type: 'result',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'done' } as unknown as ChatMessage],
+          queuedMessages: [{ clientMessageId: 'uin-1', text: 'still queued', queuedAt: 10, status: 'confirmed' }],
+        },
+      },
+    },
+    message: { type: 'result', sessionId: 's1', cost: 0.01, duration: 1200, queueLength: 1 },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [{ id: 'resp-1', type: 'response', content: 'done' }],
+          queuedMessages: [{ clientMessageId: 'uin-1', text: 'still queued', queuedAt: 10, status: 'confirmed' }],
+        },
+      },
+    },
+  },
+  {
     // stream_end is the asymmetric teardown gap (stream_start IS pinned above):
     // both clients clear `streamingMessageId` and refresh the messages REFERENCE
     // but leave the transcript untouched. Seed the in-flight response bubble and


### PR DESCRIPTION
## Summary

Closes #6707.

The #6627 turn-boundary queue reconcile (a stale **"Queued"** bubble self-heals when a `result` carries a lower `queueLength` than the client's queue) lives in **each client's real `case 'result'`** (`app` + `dashboard` message-handler), **not** the shared dispatch table. So the store-core dispatch contract never enforced that both clients reconcile identically — the deferred gap flagged in the #6705 review (and why the app-vs-dashboard gating divergence found there was unenforced until it was hand-fixed).

`SWITCH_FIXTURES` is the *only* suite that drives **both** clients' production `handleMessage`. This adds two `result` fixtures there:

| Fixture | Seed | Message | Both clients expect |
|---|---|---|---|
| **self-heal** | `queuedMessages: [uin-1(confirmed), uin-2(confirmed)]` | `result … queueLength: 1` | `queuedMessages: [uin-2]` (oldest orphan trimmed), transcript untouched |
| **no-op** | `queuedMessages: [uin-1(confirmed)]` | `result … queueLength: 1` | `queuedMessages: [uin-1]` (genuinely-queued entry survives) |

## Why this is a real regression guard

The self-heal fixture asserts a **trimmed** `queuedMessages` (length 1) from a seeded length-2 queue. If `queueLength` were ever stripped before `case 'result'`, or the reconcile removed/disabled, both clients would leave the queue at length 2 and the fixture fails on the `toMatchObject` length mismatch. A future app/dashboard divergence (one trims, one doesn't) also fails.

## Verification

- `packages/app` (jest) contract-switch: **44/44** — `√ result reconciles a stale queued orphan` + `√ result leaves the queue intact`.
- `packages/dashboard` (vitest) contract-switch: **44/44**.
- `packages/store-core` contract + coverage-lints: **119** (no coverage-lint trip — `result` was already a covered type).
- store-core `typecheck` clean.

Test-only; no runtime change. Completes the second of the two #6705 review follow-ups (the first, #6706, landed in #6709).