### PR TITLE
feat(server): render codex mcpToolCall executions as tool_start/tool_result (#6684 part 4)

### DIFF
--- a/docs/design/codex-permission-model.md
+++ b/docs/design/codex-permission-model.md
@@ -63,7 +63,7 @@ Why the cells are what they are:
 - `apply_patch` is in `ACCEPT_EDITS_TOOLS`, so `acceptEdits` auto-approves Codex edits (the analogue of auto-approving Claude Write/Edit).
 - `shell`, `request_permissions`, and `mcp_elicitation` are in `NEVER_AUTO_ALLOW` — they always prompt (except under `auto`).
 - Under `auto`, `PermissionManager.handlePermission` short-circuits to allow, so requests are drained without a prompt. (`shell`/`apply_patch`/`request_permissions` also don't get *sent* under `auto` since Codex's `approvalPolicy` is `never`; a connector `mcp_elicitation` is a standalone MCP request that can still arrive, and is auto-allowed.)
-- **`mcp_elicitation`** = a connector eliciting the user (#6635), surfaced as accept/decline — the confirmation case. See §8 for what's still open (form `content`, url-mode, execution-item rendering).
+- **`mcp_elicitation`** = a connector eliciting the user (#6635), surfaced as accept/decline — the confirmation case. See §8 for what's still open (form `content`, url-mode). The connector tool *execution* (`mcpToolCall`) now renders as a `tool_start`/`tool_result` (#6684 part 4).
 
 ---
 
@@ -169,7 +169,7 @@ Both clients render these via the existing `PermissionPrompt` (`<tool>:
 
 | Gap | Detail | Related |
 |---|---|---|
-| **MCP connector elicitation — partially addressed (#6635)** | A connector eliciting the user (`mcpServer/elicitation/request`, e.g. a GitHub write approval) is now surfaced as an **accept/decline** prompt (previously `-32601`-declined, so the approval was "missed"). Still open: structured `content` collection for `form`/`openai/form` modes and interactive `url`-mode flows (accept currently answers action-only), and rendering the `mcpToolCall` execution item itself as a `tool_start` (#6684). | #6635 |
+| **MCP connector elicitation — partially addressed (#6635)** | A connector eliciting the user (`mcpServer/elicitation/request`, e.g. a GitHub write approval) is now surfaced as an **accept/decline** prompt (previously `-32601`-declined, so the approval was "missed"). The `mcpToolCall` execution item itself is now surfaced as a `tool_start`/`tool_result` too (#6684 part 4 — labelled `server/tool`, failures flagged `isError`). Still open: structured `content` collection for `form`/`openai/form` modes and interactive `url`-mode flows (accept currently answers action-only), and the experimental `item/tool/requestUserInput`. | #6635, #6684 |
 | **No session rules** | "Allow for Session" persists a rule for Claude SDK/BYOK; for Codex it's a Codex-side grant only (§4). | — |
 | **Provider-generic mode copy** | Mode labels/descriptions and `skipPermissions` (= `--dangerously-skip-permissions`) are Claude/TUI-oriented; `skipPermissions` is a no-op for Codex, and `plan` is a no-op alias for `approve`. | — |
 | **Sandbox not per-session** | `CHROXY_CODEX_SANDBOX` is env-only; a per-session selector would need protocol + UI. | — |
@@ -196,7 +196,7 @@ Each carries a recommendation, but the call is yours.
    *Update:* command + cwd ship today, and the **`apply_patch` diff preview shipped** (#6638) — the fileChange item's `changes` are correlated into the approval by `itemId`: the prompt always names the files, and the raw `changes` ride along for a client that renders a diff (bounded by the broadcast `sanitizeToolInput` ~10K cap; a very large patch truncates, so the file summary is the guaranteed part). Still open: a scope drilldown for escalations. Env is sensitive — keep redacted/omitted by default.
 
 6. **MCP / connector approval path (the #6635 gap) — the elicitation approval shipped.**
-   Connector elicitations (`mcpServer/elicitation/request`) now surface as an accept/decline prompt via the `mcp_elicitation` tool (`NEVER_AUTO_ALLOW`), fixing the "missed approval → rejected tool call" case. *Remaining:* structured `content` collection for `form`/`openai/form` elicitations and interactive `url`-mode flows, plus rendering the `mcpToolCall` execution item as a `tool_start` — tracked in #6684.
+   Connector elicitations (`mcpServer/elicitation/request`) now surface as an accept/decline prompt via the `mcp_elicitation` tool (`NEVER_AUTO_ALLOW`), fixing the "missed approval → rejected tool call" case. The `mcpToolCall` execution item now renders as a `tool_start`/`tool_result` (#6684 part 4). *Remaining:* structured `content` collection for `form`/`openai/form` elicitations, interactive `url`-mode flows, and the experimental `item/tool/requestUserInput` — tracked in #6684.
 
 7. **How should timeout/interrupt/auto-switch appear to the user?**
    *Recommendation:* surface a resolved state on the prompt (timed-out / cancelled / auto-approved) rather than silently dropping it — same UX work as #6627 (queued/permission resolved-state rendering).

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -17,6 +17,11 @@ const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.
 // flood of un-completed fileChange items.
 const MAX_PENDING_FILE_CHANGES = 500
 
+// #6684: cap the rendered mcpToolCall result text. A connector tool can return an
+// arbitrarily large content array / structuredContent blob; bound it so a single
+// tool_result can't balloon the transcript or the persisted history ring.
+const MAX_MCP_RESULT_CHARS = 10_000
+
 const log = createLogger('codex-app-server')
 
 /**
@@ -303,9 +308,12 @@ export class CodexAppServerSession extends BaseSession {
 
   _onItemStarted(item) {
     if (!item) return
-    // commandExecution / fileChange map to Chroxy tools. mcpToolCall items are
-    // NOT surfaced (no tool_start, no approval) — the connector-approval gap
-    // documented in docs/design/codex-permission-model.md §8 (#6635).
+    // commandExecution / fileChange / mcpToolCall map to Chroxy tools. The
+    // mcpToolCall EXECUTION is surfaced as a tool_start/tool_result so connector
+    // tool calls are visible in the transcript (#6684 part 4). Note this is
+    // transcript visibility only — a connector tool execution does not itself go
+    // through the approval pipeline (that is the separate mcpServer/elicitation
+    // request, #6635); see docs/design/codex-permission-model.md §8.
     if (item.type === 'commandExecution') {
       const toolUseId = item.id
       this.emit('tool_start', {
@@ -336,6 +344,19 @@ export class CodexAppServerSession extends BaseSession {
         }
         this._pendingFileChanges.set(toolUseId, changes)
       }
+    } else if (item.type === 'mcpToolCall') {
+      // #6684: surface a connector tool EXECUTION in the transcript, labelled
+      // `server/tool` (e.g. `github/create_issue`) so the source connector is
+      // clear, with the call arguments as the input.
+      const toolUseId = item.id
+      const tool = this._mcpToolLabel(item)
+      this.emit('tool_start', {
+        messageId: this._activeTurn.messageId,
+        toolUseId,
+        tool,
+        input: { server: item.server, tool: item.tool, arguments: item.arguments },
+      })
+      this._trackToolStart(toolUseId, tool)
     }
   }
 
@@ -348,6 +369,12 @@ export class CodexAppServerSession extends BaseSession {
       this.emit('tool_result', { toolUseId: item.id, result: item.status ?? '' })
       this._trackToolResult(item.id)
       if (item.id != null) this._pendingFileChanges.delete(item.id) // #6638: done — release the cached diff
+    } else if (item.type === 'mcpToolCall') {
+      // #6684: emit the connector tool's output as a tool_result. A failed call
+      // surfaces the error message flagged isError so the client can style it.
+      const { result, isError } = this._summarizeMcpResult(item)
+      this.emit('tool_result', { toolUseId: item.id, result, isError })
+      this._trackToolResult(item.id)
     } else if (item.type === 'agentMessage') {
       // Fallback: if the final text never arrived as deltas (short replies can
       // skip the delta stream), emit it once so the message isn't lost.
@@ -356,6 +383,44 @@ export class CodexAppServerSession extends BaseSession {
         this.emit('stream_delta', { messageId: this._activeTurn.messageId, delta: item.text })
       }
     }
+  }
+
+  // #6684: `server/tool` label for an mcpToolCall (e.g. `github/create_issue`),
+  // degrading to whichever of the two is present, else a generic `mcp`.
+  _mcpToolLabel(item) {
+    const server = typeof item?.server === 'string' ? item.server.trim() : ''
+    const tool = typeof item?.tool === 'string' ? item.tool.trim() : ''
+    if (server && tool) return `${server}/${tool}`
+    return tool || server || 'mcp'
+  }
+
+  // #6684: reduce an mcpToolCall completion to a { result, isError } tool_result.
+  // Prefers the connector's error message (failed), then the MCP content array
+  // (text parts inline, non-text parts as a `[type]` marker), then
+  // structuredContent, then the bare status so the card is never blank. Bounded
+  // by MAX_MCP_RESULT_CHARS.
+  _summarizeMcpResult(item) {
+    if (item?.error && typeof item.error.message === 'string' && item.error.message) {
+      return { result: this._capMcpText(item.error.message), isError: true }
+    }
+    const isError = item?.status === 'failed'
+    const content = item?.result?.content
+    if (Array.isArray(content) && content.length > 0) {
+      const text = content
+        .map((c) => (c && typeof c.text === 'string' ? c.text : c && typeof c.type === 'string' ? `[${c.type}]` : null))
+        .filter(Boolean)
+        .join('\n')
+      if (text) return { result: this._capMcpText(text), isError }
+    }
+    if (item?.result?.structuredContent != null) {
+      return { result: this._capMcpText(JSON.stringify(item.result.structuredContent)), isError }
+    }
+    return { result: item?.status ?? '', isError }
+  }
+
+  _capMcpText(text) {
+    const s = String(text)
+    return s.length > MAX_MCP_RESULT_CHARS ? `${s.slice(0, MAX_MCP_RESULT_CHARS)}\n… (truncated)` : s
   }
 
   _ensureStreamStart() {

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -371,9 +371,11 @@ export class CodexAppServerSession extends BaseSession {
       if (item.id != null) this._pendingFileChanges.delete(item.id) // #6638: done — release the cached diff
     } else if (item.type === 'mcpToolCall') {
       // #6684: emit the connector tool's output as a tool_result. A failed call
-      // surfaces the error message flagged isError so the client can style it.
-      const { result, isError } = this._summarizeMcpResult(item)
-      this.emit('tool_result', { toolUseId: item.id, result, isError })
+      // surfaces error.message as the result TEXT — the wire tool_result carries
+      // no isError field (ServerToolResultSchema is {toolUseId, result,
+      // truncated}), so error styling is out of scope here (tracked in #6712).
+      const { result, truncated } = this._summarizeMcpResult(item)
+      this.emit('tool_result', { toolUseId: item.id, result, truncated })
       this._trackToolResult(item.id)
     } else if (item.type === 'agentMessage') {
       // Fallback: if the final text never arrived as deltas (short replies can
@@ -394,33 +396,38 @@ export class CodexAppServerSession extends BaseSession {
     return tool || server || 'mcp'
   }
 
-  // #6684: reduce an mcpToolCall completion to a { result, isError } tool_result.
-  // Prefers the connector's error message (failed), then the MCP content array
-  // (text parts inline, non-text parts as a `[type]` marker), then
-  // structuredContent, then the bare status so the card is never blank. Bounded
-  // by MAX_MCP_RESULT_CHARS.
+  // #6684: reduce an mcpToolCall completion to a { result, truncated } tool_result.
+  // Prefers the connector's error message (failed calls convey failure via this
+  // text, not styling — #6712), then the MCP content array (text parts inline,
+  // non-text parts as a `[type]` marker), then structuredContent, then the bare
+  // status so the card is never blank. Text is bounded by MAX_MCP_RESULT_CHARS.
   _summarizeMcpResult(item) {
     if (item?.error && typeof item.error.message === 'string' && item.error.message) {
-      return { result: this._capMcpText(item.error.message), isError: true }
+      return this._capMcpResult(item.error.message)
     }
-    const isError = item?.status === 'failed'
     const content = item?.result?.content
     if (Array.isArray(content) && content.length > 0) {
       const text = content
         .map((c) => (c && typeof c.text === 'string' ? c.text : c && typeof c.type === 'string' ? `[${c.type}]` : null))
         .filter(Boolean)
         .join('\n')
-      if (text) return { result: this._capMcpText(text), isError }
+      if (text) return this._capMcpResult(text)
     }
     if (item?.result?.structuredContent != null) {
-      return { result: this._capMcpText(JSON.stringify(item.result.structuredContent)), isError }
+      return this._capMcpResult(JSON.stringify(item.result.structuredContent))
     }
-    return { result: item?.status ?? '', isError }
+    return { result: item?.status ?? '', truncated: false }
   }
 
-  _capMcpText(text) {
+  // Cap the rendered text at MAX_MCP_RESULT_CHARS, signalling an over-cap slice via
+  // the wire `truncated` flag (ServerToolResultSchema.truncated → store-core's
+  // toolResultTruncated) rather than an in-band marker.
+  _capMcpResult(text) {
     const s = String(text)
-    return s.length > MAX_MCP_RESULT_CHARS ? `${s.slice(0, MAX_MCP_RESULT_CHARS)}\n… (truncated)` : s
+    if (s.length > MAX_MCP_RESULT_CHARS) {
+      return { result: s.slice(0, MAX_MCP_RESULT_CHARS), truncated: true }
+    }
+    return { result: s, truncated: false }
   }
 
   _ensureStreamStart() {

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -134,6 +134,8 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
     assert.equal(ev[0][0], 'tool_start')
     assert.equal(ev[0][1].tool, 'github/create_issue')
     assert.equal(ev[0][1].toolUseId, 't1')
+    assert.equal(ev[0][1].input.server, 'github')
+    assert.equal(ev[0][1].input.tool, 'create_issue')
     assert.deepEqual(ev[0][1].input.arguments, { title: 'x' })
     assert.equal(ev[1][0], 'tool_result')
     assert.equal(ev[1][1].toolUseId, 't1')
@@ -181,8 +183,9 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
     // structuredContent fallback when there is no content array
     const structured = s._summarizeMcpResult({ status: 'completed', result: { structuredContent: { ok: true } } })
     assert.equal(structured.result, '{"ok":true}')
-    // status fallback when there is nothing renderable
+    // status fallback when there is nothing renderable (result {} or null)
     assert.equal(s._summarizeMcpResult({ status: 'completed', result: {} }).result, 'completed')
+    assert.equal(s._summarizeMcpResult({ status: 'completed', result: null }).result, 'completed')
     // cap: a >10k text result is truncated with a marker
     const huge = 'x'.repeat(20_000)
     const capped = s._summarizeMcpResult({ status: 'completed', result: { content: [{ type: 'text', text: huge }] } })

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -140,11 +140,11 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
     assert.equal(ev[1][0], 'tool_result')
     assert.equal(ev[1][1].toolUseId, 't1')
     assert.equal(ev[1][1].result, 'issue #42 created')
-    assert.equal(ev[1][1].isError, false)
+    assert.equal(ev[1][1].truncated, false)
     cleanup()
   })
 
-  it('a failed mcpToolCall surfaces the error message flagged isError', () => {
+  it('a failed mcpToolCall surfaces the error message as the result text (#6712 tracks styling)', () => {
     const { s, cleanup } = mkSession()
     const ev = capture(s, ['tool_result'])
     s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
@@ -153,8 +153,10 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
       method: 'item/completed',
       params: { item: { type: 'mcpToolCall', id: 't2', status: 'failed', error: { message: 'connection refused' } } },
     })
+    // The wire tool_result carries no isError (ServerToolResultSchema strips it),
+    // so the failure is conveyed by the error TEXT — assert that, not a flag.
     assert.equal(ev[0][1].result, 'connection refused')
-    assert.equal(ev[0][1].isError, true)
+    assert.equal('isError' in ev[0][1], false, 'no dead isError field on the wire payload')
     cleanup()
   })
 
@@ -169,28 +171,30 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
 
   it('mcpToolCall result joins multiple content parts and marks non-text parts', () => {
     const { s, cleanup } = mkSession()
-    const { result, isError } = s._summarizeMcpResult({
+    const { result, truncated } = s._summarizeMcpResult({
       status: 'completed',
       result: { content: [{ type: 'text', text: 'line one' }, { type: 'image', data: '…' }, { type: 'text', text: 'line two' }] },
     })
     assert.equal(result, 'line one\n[image]\nline two')
-    assert.equal(isError, false)
+    assert.equal(truncated, false)
     cleanup()
   })
 
-  it('mcpToolCall falls back to structuredContent, then status, and caps huge output', () => {
+  it('mcpToolCall falls back to structuredContent, then status, and caps huge output via the truncated flag', () => {
     const { s, cleanup } = mkSession()
     // structuredContent fallback when there is no content array
     const structured = s._summarizeMcpResult({ status: 'completed', result: { structuredContent: { ok: true } } })
     assert.equal(structured.result, '{"ok":true}')
+    assert.equal(structured.truncated, false)
     // status fallback when there is nothing renderable (result {} or null)
     assert.equal(s._summarizeMcpResult({ status: 'completed', result: {} }).result, 'completed')
     assert.equal(s._summarizeMcpResult({ status: 'completed', result: null }).result, 'completed')
-    // cap: a >10k text result is truncated with a marker
+    // cap: a >10k text result is sliced to the cap and flagged truncated (no
+    // in-band marker — the wire `truncated` field carries the signal, #6684).
     const huge = 'x'.repeat(20_000)
     const capped = s._summarizeMcpResult({ status: 'completed', result: { content: [{ type: 'text', text: huge }] } })
-    assert.ok(capped.result.length < huge.length, 'capped')
-    assert.ok(capped.result.endsWith('… (truncated)'), 'truncation marker appended')
+    assert.equal(capped.result.length, 10_000, 'sliced to MAX_MCP_RESULT_CHARS')
+    assert.equal(capped.truncated, true, 'truncated flag set')
     cleanup()
   })
 

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -110,6 +110,98 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
     cleanup()
   })
 
+  // #6684 part 4 — connector tool EXECUTIONS (mcpToolCall items) surface in the
+  // transcript as tool_start/tool_result, like commandExecution/fileChange.
+  it('maps an mcpToolCall item to tool_start / tool_result (server/tool label + content)', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['tool_start', 'tool_result'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({
+      method: 'item/started',
+      params: { item: { type: 'mcpToolCall', id: 't1', server: 'github', tool: 'create_issue', arguments: { title: 'x' } } },
+    })
+    s._onNotification({
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'mcpToolCall',
+          id: 't1',
+          status: 'completed',
+          result: { content: [{ type: 'text', text: 'issue #42 created' }] },
+        },
+      },
+    })
+    assert.equal(ev[0][0], 'tool_start')
+    assert.equal(ev[0][1].tool, 'github/create_issue')
+    assert.equal(ev[0][1].toolUseId, 't1')
+    assert.deepEqual(ev[0][1].input.arguments, { title: 'x' })
+    assert.equal(ev[1][0], 'tool_result')
+    assert.equal(ev[1][1].toolUseId, 't1')
+    assert.equal(ev[1][1].result, 'issue #42 created')
+    assert.equal(ev[1][1].isError, false)
+    cleanup()
+  })
+
+  it('a failed mcpToolCall surfaces the error message flagged isError', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['tool_result'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'mcpToolCall', id: 't2', server: 'db', tool: 'query' } } })
+    s._onNotification({
+      method: 'item/completed',
+      params: { item: { type: 'mcpToolCall', id: 't2', status: 'failed', error: { message: 'connection refused' } } },
+    })
+    assert.equal(ev[0][1].result, 'connection refused')
+    assert.equal(ev[0][1].isError, true)
+    cleanup()
+  })
+
+  it('mcpToolCall label degrades gracefully (tool-only, then generic mcp)', () => {
+    const { s, cleanup } = mkSession()
+    assert.equal(s._mcpToolLabel({ tool: 'lonely_tool' }), 'lonely_tool')
+    assert.equal(s._mcpToolLabel({ server: 'srv' }), 'srv')
+    assert.equal(s._mcpToolLabel({}), 'mcp')
+    assert.equal(s._mcpToolLabel({ server: ' gh ', tool: ' t ' }), 'gh/t')
+    cleanup()
+  })
+
+  it('mcpToolCall result joins multiple content parts and marks non-text parts', () => {
+    const { s, cleanup } = mkSession()
+    const { result, isError } = s._summarizeMcpResult({
+      status: 'completed',
+      result: { content: [{ type: 'text', text: 'line one' }, { type: 'image', data: '…' }, { type: 'text', text: 'line two' }] },
+    })
+    assert.equal(result, 'line one\n[image]\nline two')
+    assert.equal(isError, false)
+    cleanup()
+  })
+
+  it('mcpToolCall falls back to structuredContent, then status, and caps huge output', () => {
+    const { s, cleanup } = mkSession()
+    // structuredContent fallback when there is no content array
+    const structured = s._summarizeMcpResult({ status: 'completed', result: { structuredContent: { ok: true } } })
+    assert.equal(structured.result, '{"ok":true}')
+    // status fallback when there is nothing renderable
+    assert.equal(s._summarizeMcpResult({ status: 'completed', result: {} }).result, 'completed')
+    // cap: a >10k text result is truncated with a marker
+    const huge = 'x'.repeat(20_000)
+    const capped = s._summarizeMcpResult({ status: 'completed', result: { content: [{ type: 'text', text: huge }] } })
+    assert.ok(capped.result.length < huge.length, 'capped')
+    assert.ok(capped.result.endsWith('… (truncated)'), 'truncation marker appended')
+    cleanup()
+  })
+
+  it('an orphan mcpToolCall tool_start is swept with a synthetic tool_result at turn end', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['tool_result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'mcpToolCall', id: 'orphan-mcp', server: 'x', tool: 'y' } } })
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 1 } } })
+    assert.ok(ev.some(([, p]) => p.toolUseId === 'orphan-mcp'), 'orphan mcpToolCall got a synthetic tool_result')
+    cleanup()
+  })
+
   it('turn/completed emits stream_end + result and clears busy', () => {
     const { s, cleanup } = mkSession()
     const ev = capture(s, ['stream_end', 'result'])


### PR DESCRIPTION
## Summary

Addresses **part 4 of #6684** (does **not** close it — parts 1–3 remain, see below).

Codex connector tool **executions** (`mcpToolCall` thread items) were dropped on the floor — only their *approvals* (`mcpServer/elicitation`, #6635) surfaced, so a connector tool call (e.g. a GitHub or DB MCP tool) was invisible in the transcript. This maps them exactly like `commandExecution` / `fileChange`:

- **`item/started` mcpToolCall → `tool_start`**, labelled `server/tool` (e.g. `github/create_issue`, degrading to tool-only / server-only / `mcp`), with `{ server, tool, arguments }` as input.
- **`item/completed` → `tool_result`**: the MCP `content` array flattened (text parts inline, non-text parts as `[type]` markers), falling back to `structuredContent`, then the bare `status` so the card is never blank. A **failed** call surfaces `error.message` as the result **text** (visible). Output over `MAX_MCP_RESULT_CHARS` (10k) is sliced and flagged via the wire `truncated` field (which store-core reads → `toolResultTruncated`).

Item shape taken from the authoritative `codex app-server generate-json-schema` dump (`McpToolCallThreadItem`: `server`, `tool`, `arguments`, `status`, `result.content`, `error.message`).

### Scope note

Transcript **visibility** only — a connector tool execution does not go through the approval pipeline (that's the separate elicitation request), and `tool_start` creates no `serverRequest`, so no spurious permission card. Orphan `mcpToolCall` `tool_start`s are swept at turn end by the existing `_sweepUnresolvedToolStarts` path.

**No `isError` on the wire:** `ServerToolResultSchema` is `{ toolUseId, result, truncated }` and strips unknown keys, and no client reads `isError` on a tool_result — so a failed call is conveyed by its error **text**, not styling. End-to-end error styling (which would also fix the existing orphan-sweep's dead `isError`) is tracked in **#6712**.

## Tests

`codex-app-server-session.test.js` (suite 70 → **76**): happy-path tool_start/tool_result with `server/tool` label + `{server,tool,arguments}` input, a failed call (error text surfaced, no dead `isError` on the payload), label degradation, multi-part content flattening, structuredContent/status/null fallbacks, the 10k cap flagged `truncated: true`, and orphan-sweep at turn end.

## Remaining (#6684 stays open)

- Part 1 — structured `content` collection for `form`/`openai/form` elicitations (needs form UI + protocol).
- Part 2 — interactive `url`-mode affordance.
- Part 3 — `item/tool/requestUserInput` (still `-32601`-declined).

Follow-up: **#6712** (carry `isError` end-to-end for failed tool_result styling). Design doc `docs/design/codex-permission-model.md` §8/§9.6 updated.