### PR TITLE
feat(server): per-model token usage capture across providers (M-1)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -18,6 +18,7 @@ import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
 import { join } from 'path'
 import { homedir } from 'os'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { synthesizeModelUsage } from './usage-normalize.js'
 import { PermissionManager, wirePermissionManager } from './permission-manager.js'
 import { createLogger } from './logger.js'
 import { isOperatorTimeoutInRange } from './duration.js'
@@ -893,6 +894,16 @@ export class ClaudeByokSession extends BaseSession {
         // #5630: emit null when no round produced a known cost so the UI
         // shows "n/a" instead of a misleading $0.00.
         cost: turnCostKnown ? turnCost : null,
+        // #6692: single-model split. Task-subagent usage is folded into
+        // turnUsage under the parent's model, which is CORRECT today because
+        // children hard-inherit the parent model (see _executeTaskTool). If a
+        // per-profile model override ever lands (#5018's deferred AC), that
+        // change must split this map by actual child model (#5020).
+        modelUsage: synthesizeModelUsage(
+          this.model || this._defaultModel,
+          turnUsage,
+          turnCostKnown ? turnCost : null,
+        ),
       })
     } catch (err) {
       // #4118: extend the synchronous stream-init rollback (#4109) to
@@ -935,6 +946,13 @@ export class ClaudeByokSession extends BaseSession {
         // #5630: null when no priced round committed before the error so the
         // partial-cost line shows "n/a" rather than $0.00.
         cost: turnCostKnown ? turnCost : null,
+        // #6692: partial-spend turns get the same single-model split as the
+        // success path so per-model accounting survives errored turns.
+        modelUsage: synthesizeModelUsage(
+          this.model || this._defaultModel,
+          turnUsage,
+          turnCostKnown ? turnCost : null,
+        ),
       })
     } finally {
       // #4080: per-turn isolation guarantee. The per-round clear after
@@ -1798,7 +1816,7 @@ export class ClaudeByokSession extends BaseSession {
         messageId,
         message: 'Interrupted by user',
         code: 'ABORT',
-        ...(partials ? { usage: partials.usage, cost: partials.cost } : {}),
+        ...(partials ? { usage: partials.usage, cost: partials.cost, modelUsage: partials.modelUsage ?? null } : {}),
       })
       return
     }
@@ -1808,7 +1826,7 @@ export class ClaudeByokSession extends BaseSession {
       messageId,
       message,
       code,
-      ...(partials ? { usage: partials.usage, cost: partials.cost } : {}),
+      ...(partials ? { usage: partials.usage, cost: partials.cost, modelUsage: partials.modelUsage ?? null } : {}),
     })
   }
 

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
 import { randomBytes } from 'crypto'
+import { normalizeSdkModelUsage } from './usage-normalize.js'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createPermissionHookManager } from './permission-hook.js'
@@ -1212,6 +1213,13 @@ export class CliSession extends BaseSession {
           cost: data.total_cost_usd,
           duration: data.duration_ms,
           usage: data.usage,
+          // #6692: the CLI's stream-json result is produced by the same
+          // runtime as the SDK's; when it carries modelUsage/num_turns/
+          // duration_api_ms, forward them — all three degrade to null on
+          // older CLI builds that omit them.
+          numTurns: Number.isFinite(data.num_turns) ? data.num_turns : null,
+          apiDurationMs: Number.isFinite(data.duration_api_ms) ? data.duration_api_ms : null,
+          modelUsage: normalizeSdkModelUsage(data.modelUsage),
         })
 
         // Message complete — ready for next message

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, basename, extname } from 'path'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { nonNegInt, synthesizeModelUsage } from './usage-normalize.js'
 import { CodexSession, resolveCodexSandbox } from './codex-session.js'
 import { CodexAppServerClient } from './codex-app-server-client.js'
 import { PermissionManager, wirePermissionManager } from './permission-manager.js'
@@ -366,10 +367,25 @@ export class CodexAppServerSession extends BaseSession {
 
   _mapUsage(params) {
     const u = params?.usage || params || {}
+    const rawInput = nonNegInt(u.inputTokens ?? u.input_tokens)
+    const cached = nonNegInt(u.cachedInputTokens ?? u.cached_input_tokens)
     return {
-      input_tokens: u.inputTokens ?? u.input_tokens ?? 0,
-      output_tokens: u.outputTokens ?? u.output_tokens ?? 0,
-      cached_input_tokens: u.cachedInputTokens ?? u.cached_input_tokens ?? 0,
+      // #6692: codex reports cached tokens as a SUBSET of input (OpenAI's
+      // prompt_tokens_details convention; corroborated in-repo by the exec
+      // path's context ratchet treating input_tokens as the full prompt —
+      // codex-session.js). Chroxy's accounting keys are ADDITIVE (Anthropic
+      // shape: input excludes cache reads), so split into uncached input +
+      // cache_read. The subtraction is clamped, so a future codex build that
+      // switched to additive reporting would undercount input rather than
+      // go negative. Before this fix the cache count was emitted only under
+      // `cached_input_tokens`, a key `_trackUsage` never reads — codex cache
+      // tokens were silently dropped from cumulativeUsage.
+      input_tokens: nonNegInt(rawInput - cached),
+      output_tokens: nonNegInt(u.outputTokens ?? u.output_tokens),
+      cache_read_input_tokens: cached,
+      // Deprecated duplicate of cache_read_input_tokens — kept one release
+      // for any external reader of the raw result payload (#6692).
+      cached_input_tokens: cached,
     }
   }
 
@@ -379,7 +395,15 @@ export class CodexAppServerSession extends BaseSession {
     this._clearResultTimeout()
     if (t.didStreamStart) this.emit('stream_end', { messageId: t.messageId })
     this._emitResult(
-      { cost: null, duration: turn?.durationMs ?? null, usage: this._lastUsage, sessionId: this._threadId },
+      {
+        cost: null,
+        duration: turn?.durationMs ?? null,
+        usage: this._lastUsage,
+        // #6692: single-model split (codex runs one model per session; cost
+        // is unknown at the source — pricing happens downstream).
+        modelUsage: synthesizeModelUsage(this.model, this._lastUsage),
+        sessionId: this._threadId,
+      },
       'turn_ended_with_orphan_tool_start',
     )
     this._activeTurn = null

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -1,5 +1,6 @@
 import { JsonlSubprocessSession } from './jsonl-subprocess-session.js'
 import { buildBaseSessionOpts } from './base-session.js'
+import { synthesizeModelUsage } from './usage-normalize.js'
 import { homedir } from 'os'
 import { join } from 'path'
 import { resolveBinary } from './utils/resolve-binary.js'
@@ -418,6 +419,11 @@ export class GeminiSession extends JsonlSubprocessSession {
             input_tokens: inputTokens,
             output_tokens: outputTokens,
           },
+          // #6692: single-model split (gemini reports no cache/cost fields)
+          modelUsage: synthesizeModelUsage(this.model, {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+          }),
           sessionId: null,
         })
         break
@@ -485,6 +491,11 @@ export class GeminiSession extends JsonlSubprocessSession {
             input_tokens: usage.input_tokens || 0,
             output_tokens: usage.output_tokens || 0,
           },
+          // #6692: keep the legacy/test path shape-identical to production
+          modelUsage: synthesizeModelUsage(this.model, {
+            input_tokens: usage.input_tokens || 0,
+            output_tokens: usage.output_tokens || 0,
+          }),
           sessionId: null,
         })
         break

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 import { updateModels, saveModelsCache, updateContextWindow, getModels, ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { normalizeSdkModelUsage } from './usage-normalize.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
@@ -931,6 +932,12 @@ export class SdkSession extends BaseSession {
               cost: msg.total_cost_usd,
               duration: msg.duration_ms,
               usage: msg.usage,
+              // #6692: surface the per-model split + turn metadata the SDK
+              // already reports instead of discarding them. Additive — every
+              // existing result consumer ignores unknown fields.
+              numTurns: Number.isFinite(msg.num_turns) ? msg.num_turns : null,
+              apiDurationMs: Number.isFinite(msg.duration_api_ms) ? msg.duration_api_ms : null,
+              modelUsage: normalizeSdkModelUsage(msg.modelUsage),
             }, 'turn_ended_with_orphan_tool_start')
 
             this._clearMessageState()

--- a/packages/server/src/usage-normalize.js
+++ b/packages/server/src/usage-normalize.js
@@ -38,11 +38,16 @@ export function nonNegInt(x) {
  * entries) into the wire contract above. Returns null when the input is
  * absent, not an object, or normalizes to zero entries.
  */
+// model ids come from provider output (untrusted). Reject the keys that could
+// pollute a plain object so a hostile/buggy id can't reach `out[id] = …`.
+const UNSAFE_KEY = new Set(['__proto__', 'constructor', 'prototype'])
+const isSafeModelId = (id) => typeof id === 'string' && id.length > 0 && !UNSAFE_KEY.has(id)
+
 export function normalizeSdkModelUsage(raw) {
   if (!raw || typeof raw !== 'object') return null
   const out = {}
   for (const [modelId, u] of Object.entries(raw)) {
-    if (!modelId || !u || typeof u !== 'object') continue
+    if (!isSafeModelId(modelId) || !u || typeof u !== 'object') continue
     out[modelId] = {
       input_tokens: nonNegInt(u.inputTokens ?? u.input_tokens),
       output_tokens: nonNegInt(u.outputTokens ?? u.output_tokens),
@@ -73,13 +78,17 @@ export function normalizeSdkModelUsage(raw) {
  * synthesize a row `_trackUsage` skips.
  */
 export function synthesizeModelUsage(model, usage, costUsd = null) {
-  if (!model || typeof model !== 'string') return null
+  if (!isSafeModelId(model)) return null
   if (!usage || typeof usage !== 'object') return null
+  // A real numeric token field is the signal. Test `typeof === 'number'` (not
+  // Number(v)) so a provider's explicit null for a missing field is NOT read
+  // as 0 — `Number(null) === 0` is finite and would fabricate an all-zero row
+  // for a genuinely-empty turn. An explicit numeric 0 still counts as signal.
   const anyTokenSignal = [
     usage.input_tokens, usage.output_tokens,
     usage.cache_read_input_tokens, usage.cached_input_tokens,
     usage.cache_creation_input_tokens,
-  ].some((v) => Number.isFinite(Number(v)))
+  ].some((v) => typeof v === 'number' && Number.isFinite(v))
   if (!anyTokenSignal) return null
   return {
     [model]: {

--- a/packages/server/src/usage-normalize.js
+++ b/packages/server/src/usage-normalize.js
@@ -60,8 +60,17 @@ export function normalizeSdkModelUsage(raw) {
  * model per session (byok family, codex, gemini). `usage` is the provider's
  * flat snake_case turn usage; absent fields clamp to 0. Returns null when
  * the model id is unknown or the usage object carries no token signal at
- * all (mirrors `_trackUsage`'s finite-tokens gate so a both-null synthetic
- * result never fabricates an all-zero per-model row).
+ * all, so a both-null synthetic result (stream-stall recovery) never
+ * fabricates an all-zero per-model row.
+ *
+ * Note the gate is BROADER than `_trackUsage`'s (session-manager.js), which
+ * keys only on a finite `input_tokens`: this returns a row when ANY of the 5
+ * token fields is finite. They coincide today because every provider call
+ * site emits a finite `input_tokens` (0 or positive) whenever `usage` is an
+ * object, so the sole divergence (an output-or-cache-only turn) can't arise.
+ * A future consumer that sums these rows against `cumulativeUsage` should not
+ * assume literal parity — if an output-only provider ever appears, this would
+ * synthesize a row `_trackUsage` skips.
  */
 export function synthesizeModelUsage(model, usage, costUsd = null) {
   if (!model || typeof model !== 'string') return null

--- a/packages/server/src/usage-normalize.js
+++ b/packages/server/src/usage-normalize.js
@@ -1,0 +1,100 @@
+/**
+ * Cross-provider per-model usage normalization (#6692).
+ *
+ * Every provider session emits a terminal `result` event whose flat `usage`
+ * object feeds the per-session accumulator (session-manager `_trackUsage`).
+ * What that flat shape cannot carry is a per-model split — the Agent SDK
+ * reports one (`msg.modelUsage`, camelCase keys) and single-model providers
+ * can synthesize one — so the result payload gains an ADDITIVE `modelUsage`
+ * field in the shape below. Token keys stay snake_case so any cell can be
+ * passed straight to `computePromptCostUsd` (models.js) unchanged.
+ *
+ *   modelUsage: {
+ *     [modelId]: {
+ *       input_tokens, output_tokens,
+ *       cache_read_input_tokens, cache_creation_input_tokens,
+ *       web_search_requests,
+ *       cost_usd,            // provider-reported; null when unknown
+ *     }
+ *   } | null                 // null = provider produced nothing this turn
+ *
+ * Consumers must treat `modelUsage` as optional — `_trackUsage` and every
+ * existing subscriber ignore unknown result fields by design.
+ */
+
+/**
+ * Clamp to a non-negative finite integer — mirrors `_trackUsage`'s
+ * tokenDelta coercion so a poisoned provider value can never drive an
+ * accumulator negative or NaN.
+ */
+export function nonNegInt(x) {
+  const n = Number(x)
+  if (!Number.isFinite(n) || n <= 0) return 0
+  return Math.floor(n)
+}
+
+/**
+ * Normalize the Agent SDK's per-model usage map (camelCase ModelUsage
+ * entries) into the wire contract above. Returns null when the input is
+ * absent, not an object, or normalizes to zero entries.
+ */
+export function normalizeSdkModelUsage(raw) {
+  if (!raw || typeof raw !== 'object') return null
+  const out = {}
+  for (const [modelId, u] of Object.entries(raw)) {
+    if (!modelId || !u || typeof u !== 'object') continue
+    out[modelId] = {
+      input_tokens: nonNegInt(u.inputTokens ?? u.input_tokens),
+      output_tokens: nonNegInt(u.outputTokens ?? u.output_tokens),
+      cache_read_input_tokens: nonNegInt(u.cacheReadInputTokens ?? u.cache_read_input_tokens),
+      cache_creation_input_tokens: nonNegInt(u.cacheCreationInputTokens ?? u.cache_creation_input_tokens),
+      web_search_requests: nonNegInt(u.webSearchRequests ?? u.web_search_requests),
+      cost_usd: Number.isFinite(u.costUSD) ? u.costUSD : (Number.isFinite(u.cost_usd) ? u.cost_usd : null),
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+/**
+ * Build a single-entry modelUsage map for providers that run exactly one
+ * model per session (byok family, codex, gemini). `usage` is the provider's
+ * flat snake_case turn usage; absent fields clamp to 0. Returns null when
+ * the model id is unknown or the usage object carries no token signal at
+ * all (mirrors `_trackUsage`'s finite-tokens gate so a both-null synthetic
+ * result never fabricates an all-zero per-model row).
+ */
+export function synthesizeModelUsage(model, usage, costUsd = null) {
+  if (!model || typeof model !== 'string') return null
+  if (!usage || typeof usage !== 'object') return null
+  const anyTokenSignal = [
+    usage.input_tokens, usage.output_tokens,
+    usage.cache_read_input_tokens, usage.cached_input_tokens,
+    usage.cache_creation_input_tokens,
+  ].some((v) => Number.isFinite(Number(v)))
+  if (!anyTokenSignal) return null
+  return {
+    [model]: {
+      input_tokens: nonNegInt(usage.input_tokens),
+      output_tokens: nonNegInt(usage.output_tokens),
+      // codex historically emitted `cached_input_tokens`; accept both so a
+      // caller can hand this the raw pre-#6692 shape without dropping cache.
+      cache_read_input_tokens: nonNegInt(usage.cache_read_input_tokens ?? usage.cached_input_tokens),
+      cache_creation_input_tokens: nonNegInt(usage.cache_creation_input_tokens),
+      web_search_requests: nonNegInt(usage.web_search_requests),
+      cost_usd: Number.isFinite(costUsd) ? costUsd : null,
+    },
+  }
+}
+
+/**
+ * Whether a provider's sessions produce token telemetry at all. claude-tui
+ * and claude-channel emit `usage:null, cost:null` on every turn (Stop-hook
+ * limitation), so anything that needs metering — orchestration runs (#6691),
+ * cost comparisons — must refuse or caveat them. user-shell runs no model.
+ */
+const UNMETERABLE_PROVIDERS = new Set(['claude-tui', 'claude-channel', 'user-shell'])
+
+export function isMeterableProvider(provider) {
+  if (!provider || typeof provider !== 'string') return false
+  return !UNMETERABLE_PROVIDERS.has(provider)
+}

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -4705,3 +4705,54 @@ describe('ClaudeByokSession', () => {
     })
   })
 })
+
+// #6692 — byok runs one model per session; the result (and partial-spend
+// error) payloads gain a synthesized single-model split carrying the same
+// cost the flat payload reports.
+describe('per-model usage on result (#6692)', () => {
+  it('synthesizes a single-model modelUsage with the turn cost', async () => {
+    const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-8' })
+    session._client = {
+      messages: {
+        stream: () =>
+          fakeStream([], {
+            stop_reason: 'end_turn',
+            content: [{ type: 'text', text: 'hi' }],
+            usage: { input_tokens: 100, output_tokens: 50 },
+          }),
+      },
+    }
+    const captured = captureEvents(session)
+    await session.start()
+    await session.sendMessage('q')
+    const result = captured.find((e) => e.name === 'result')
+    assert.ok(result, 'result event must fire')
+    const mu = result.payload.modelUsage['claude-opus-4-8']
+    assert.ok(mu, 'modelUsage entry for the session model')
+    assert.equal(mu.input_tokens, 100)
+    assert.equal(mu.output_tokens, 50)
+    assert.equal(mu.cost_usd, result.payload.cost)
+    assert.ok(Number.isFinite(result.payload.cost), 'known-pricing model yields finite cost')
+    await session.destroy()
+  })
+
+  it('cost_usd is null in modelUsage when pricing is unknown (#5630 parity)', async () => {
+    const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-future-model-9-9' })
+    session._client = {
+      messages: {
+        stream: () =>
+          fakeStream([], {
+            stop_reason: 'end_turn',
+            content: [{ type: 'text', text: 'hi' }],
+            usage: { input_tokens: 100, output_tokens: 50 },
+          }),
+      },
+    }
+    const captured = captureEvents(session)
+    await session.start()
+    await session.sendMessage('q')
+    const result = captured.find((e) => e.name === 'result')
+    assert.equal(result.payload.modelUsage['claude-future-model-9-9'].cost_usd, null)
+    await session.destroy()
+  })
+})

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -1166,3 +1166,60 @@ describe('CliSession stream-event handling', () => {
     })
   })
 })
+
+// #6692 — the CLI's stream-json result line carries the same modelUsage /
+// num_turns / duration_api_ms fields as the SDK (shared runtime); forward
+// them normalized, degrading to null on older CLI builds.
+describe('per-model usage forwarding (#6692)', () => {
+  it('forwards modelUsage/num_turns/duration_api_ms from the result line', () => {
+    const session = createSession()
+    const results = []
+    session.on('result', (r) => results.push(r))
+    session._handleEvent({
+      type: 'result',
+      session_id: 's1',
+      subtype: 'success',
+      result: 'ok',
+      total_cost_usd: 0.01,
+      duration_ms: 5,
+      duration_api_ms: 3,
+      num_turns: 2,
+      usage: { input_tokens: 1, output_tokens: 1 },
+      modelUsage: {
+        'claude-opus-4-8': { inputTokens: 1, outputTokens: 1, costUSD: 0.01 },
+      },
+    })
+    assert.equal(results.length, 1)
+    assert.equal(results[0].numTurns, 2)
+    assert.equal(results[0].apiDurationMs, 3)
+    assert.deepEqual(results[0].modelUsage, {
+      'claude-opus-4-8': {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        web_search_requests: 0,
+        cost_usd: 0.01,
+      },
+    })
+  })
+
+  it('degrades all three fields to null on an older CLI result line', () => {
+    const session = createSession()
+    const results = []
+    session.on('result', (r) => results.push(r))
+    session._handleEvent({
+      type: 'result',
+      session_id: 's1',
+      subtype: 'success',
+      result: 'ok',
+      total_cost_usd: 0,
+      duration_ms: 5,
+      usage: {},
+    })
+    assert.equal(results.length, 1)
+    assert.equal(results[0].numTurns, null)
+    assert.equal(results[0].apiDurationMs, null)
+    assert.equal(results[0].modelUsage, null)
+  })
+})

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -813,3 +813,60 @@ describe('CodexAppServerSession — attachments (#6609)', () => {
     cleanup()
   })
 })
+
+// #6692 — codex reports cached input as a SUBSET of inputTokens (OpenAI
+// convention). Chroxy's accounting keys are additive, so _mapUsage must split
+// into uncached input + cache_read (previously the cache count lived only
+// under `cached_input_tokens`, a key _trackUsage never reads — dropped).
+describe('usage mapping (#6692)', () => {
+  it('splits subset-cached input into uncached input + cache_read and synthesizes modelUsage', () => {
+    const { s, cleanup } = mkSession({ model: 'gpt-5.1-codex' })
+    const ev = capture(s, ['result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    s._onNotification({
+      method: 'thread/tokenUsage/updated',
+      params: { usage: { inputTokens: 1000, cachedInputTokens: 600, outputTokens: 42 } },
+    })
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 7 } } })
+    assert.equal(ev.length, 1)
+    const r = ev[0][1]
+    assert.deepEqual(r.usage, {
+      input_tokens: 400,
+      output_tokens: 42,
+      cache_read_input_tokens: 600,
+      cached_input_tokens: 600, // deprecated duplicate, one release
+    })
+    assert.deepEqual(r.modelUsage, {
+      'gpt-5.1-codex': {
+        input_tokens: 400,
+        output_tokens: 42,
+        cache_read_input_tokens: 600,
+        cache_creation_input_tokens: 0,
+        web_search_requests: 0,
+        cost_usd: null,
+      },
+    })
+    cleanup()
+  })
+
+  it('a turn with no tokenUsage notification emits usage null and no fabricated modelUsage', () => {
+    const { s, cleanup } = mkSession({ model: 'gpt-5.1-codex' })
+    const ev = capture(s, ['result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 7 } } })
+    assert.equal(ev[0][1].usage, null)
+    assert.equal(ev[0][1].modelUsage, null)
+    cleanup()
+  })
+
+  it('clamps an additive-reporting future build instead of going negative', () => {
+    const { s, cleanup } = mkSession({ model: 'gpt-5.1-codex' })
+    // cached > input: impossible under subset semantics; the split clamps to 0
+    const mapped = s._mapUsage({ usage: { inputTokens: 100, cachedInputTokens: 600, outputTokens: 1 } })
+    assert.equal(mapped.input_tokens, 0)
+    assert.equal(mapped.cache_read_input_tokens, 600)
+    cleanup()
+  })
+})

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -812,3 +812,26 @@ describe('GeminiSession', () => {
     })
   })
 })
+
+// #6692 — gemini reports input/output only; the result payload gains a
+// synthesized single-model split so per-model accounting works uniformly.
+describe('per-model usage on result (#6692)', () => {
+  it('production _processJsonlLine result carries synthesized modelUsage', () => {
+    const session = new GeminiSession({ cwd: '/tmp', model: 'gemini-2.5-pro' })
+    const results = []
+    session.on('result', (r) => results.push(r))
+    const ctx = { messageId: 'g1', didStreamStart: false, didEmitResult: false }
+    session._processJsonlLine({ type: 'result', usage: { input_tokens: 10, output_tokens: 5 } }, ctx)
+    assert.equal(results.length, 1)
+    assert.deepEqual(results[0].modelUsage, {
+      'gemini-2.5-pro': {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        web_search_requests: 0,
+        cost_usd: null,
+      },
+    })
+  })
+})

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -2998,3 +2998,79 @@ describe('SdkSession state-persistence roundtrip (#4700)', () => {
       'Map insertion order must round-trip so "most-recent" semantics survive a restart')
   })
 })
+
+// #6692 — per-model usage forwarding: the result payload must surface the
+// SDK's modelUsage split (normalized to snake_case) plus num_turns /
+// duration_api_ms instead of discarding them.
+describe('per-model usage forwarding (#6692)', () => {
+  it('forwards normalized modelUsage + numTurns + apiDurationMs on result', async () => {
+    const s = createSession()
+    s._processReady = true
+    const results = []
+    s.on('result', (r) => results.push(r))
+    s._callQuery = () => {
+      return (async function* () {
+        yield {
+          type: 'result',
+          session_id: 'usage-test',
+          total_cost_usd: 0.05,
+          duration_ms: 1234,
+          duration_api_ms: 987,
+          num_turns: 3,
+          usage: { input_tokens: 100, output_tokens: 50 },
+          modelUsage: {
+            'claude-opus-4-8': {
+              inputTokens: 100,
+              outputTokens: 50,
+              cacheReadInputTokens: 25,
+              cacheCreationInputTokens: 5,
+              webSearchRequests: 0,
+              costUSD: 0.05,
+              contextWindow: 200000,
+            },
+          },
+        }
+      })()
+    }
+    await s.sendMessage('hello')
+    assert.equal(results.length, 1)
+    const r = results[0]
+    assert.equal(r.numTurns, 3)
+    assert.equal(r.apiDurationMs, 987)
+    assert.deepEqual(r.modelUsage, {
+      'claude-opus-4-8': {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 25,
+        cache_creation_input_tokens: 5,
+        web_search_requests: 0,
+        cost_usd: 0.05,
+      },
+    })
+    s.destroy()
+  })
+
+  it('degrades numTurns/apiDurationMs/modelUsage to null when the result omits them', async () => {
+    const s = createSession()
+    s._processReady = true
+    const results = []
+    s.on('result', (r) => results.push(r))
+    s._callQuery = () => {
+      return (async function* () {
+        yield {
+          type: 'result',
+          session_id: 'usage-test-2',
+          total_cost_usd: 0,
+          duration_ms: 1,
+          usage: {},
+        }
+      })()
+    }
+    await s.sendMessage('hello')
+    assert.equal(results.length, 1)
+    assert.equal(results[0].numTurns, null)
+    assert.equal(results[0].apiDurationMs, null)
+    assert.equal(results[0].modelUsage, null)
+    s.destroy()
+  })
+})

--- a/packages/server/tests/usage-normalize.test.js
+++ b/packages/server/tests/usage-normalize.test.js
@@ -85,6 +85,17 @@ describe('normalizeSdkModelUsage', () => {
     assert.equal(normalizeSdkModelUsage({ m: null, n: 3 }), null)
   })
 
+  it('skips unsafe model ids (prototype-pollution guard) and keeps real entries', () => {
+    // JSON.parse gives '__proto__'/'constructor' as real OWN keys (a provider's
+    // usage comes from parsed JSON), unlike an object literal where `__proto__:`
+    // sets the proto. Unsafe ids are dropped; safe ones pass through.
+    const raw = JSON.parse('{"__proto__": {"inputTokens": 1}, "constructor": {"inputTokens": 9}, "real": {"inputTokens": 2}}')
+    const out = normalizeSdkModelUsage(raw)
+    assert.equal(Object.prototype.inputTokens, undefined)
+    assert.deepEqual(Object.keys(out), ['real'])
+    assert.equal(out.real.input_tokens, 2)
+  })
+
   it('accepts already-snake_case entries (CLI stream-json forward-compat)', () => {
     const out = normalizeSdkModelUsage({
       m: { input_tokens: 5, output_tokens: 2, cache_read_input_tokens: 1, cost_usd: 0.5 },
@@ -142,12 +153,24 @@ describe('synthesizeModelUsage', () => {
   })
 
   it('returns null when the usage object carries no token signal (both-null synthetic results)', () => {
-    // Mirrors _trackUsage's finite-tokens gate: a stream-stall synthetic
-    // result must not fabricate an all-zero per-model row.
+    // A stream-stall synthetic result must not fabricate an all-zero per-model row.
     assert.equal(synthesizeModelUsage('m', {}), null)
     assert.equal(synthesizeModelUsage('m', { foo: 1 }), null)
     // an explicit zero IS a signal (finite number) — zero-token turns exist
     assert.notEqual(synthesizeModelUsage('m', { input_tokens: 0 }), null)
+  })
+
+  it('treats explicit null token fields as no-signal (Number(null)===0 must not fabricate a row)', () => {
+    assert.equal(synthesizeModelUsage('m', { input_tokens: null, output_tokens: null }), null)
+    // a real number alongside nulls still synthesizes
+    assert.notEqual(synthesizeModelUsage('m', { input_tokens: null, output_tokens: 5 }), null)
+  })
+
+  it('rejects unsafe model ids (prototype-pollution guard)', () => {
+    for (const id of ['__proto__', 'constructor', 'prototype']) {
+      assert.equal(synthesizeModelUsage(id, { input_tokens: 1 }), null, id)
+    }
+    assert.equal(Object.prototype.input_tokens, undefined)
   })
 })
 

--- a/packages/server/tests/usage-normalize.test.js
+++ b/packages/server/tests/usage-normalize.test.js
@@ -1,0 +1,166 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  nonNegInt,
+  normalizeSdkModelUsage,
+  synthesizeModelUsage,
+  isMeterableProvider,
+} from '../src/usage-normalize.js'
+
+// #6692 — cross-provider per-model usage normalization. These pin the module
+// contract every provider emit site relies on: snake_case token keys, nonneg
+// clamps mirroring _trackUsage's coercions, and null (never {}) when a turn
+// produced no per-model signal.
+
+describe('nonNegInt', () => {
+  it('clamps negatives, NaN, Infinity, and non-numbers to 0', () => {
+    for (const bad of [-1, -0.5, NaN, Infinity, -Infinity, 'x', null, undefined, {}]) {
+      assert.equal(nonNegInt(bad), 0, `expected 0 for ${String(bad)}`)
+    }
+  })
+
+  it('floors positive floats and passes integers through', () => {
+    assert.equal(nonNegInt(3.9), 3)
+    assert.equal(nonNegInt(42), 42)
+    assert.equal(nonNegInt('7'), 7)
+  })
+})
+
+describe('normalizeSdkModelUsage', () => {
+  it('maps SDK camelCase ModelUsage entries to snake_case cells', () => {
+    const out = normalizeSdkModelUsage({
+      'claude-opus-4-8': {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 30,
+        cacheCreationInputTokens: 10,
+        webSearchRequests: 2,
+        costUSD: 0.0123,
+        contextWindow: 200000, // dropped — context ratchet owns this field
+        maxOutputTokens: 8192, // dropped
+      },
+    })
+    assert.deepEqual(out, {
+      'claude-opus-4-8': {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 10,
+        web_search_requests: 2,
+        cost_usd: 0.0123,
+      },
+    })
+  })
+
+  it('keeps every model of a multi-model turn (Task subagents)', () => {
+    const out = normalizeSdkModelUsage({
+      'claude-opus-4-8': { inputTokens: 10, outputTokens: 1, costUSD: 0.01 },
+      'claude-haiku-4-5': { inputTokens: 999, outputTokens: 5, costUSD: 0.001 },
+    })
+    assert.deepEqual(Object.keys(out).sort(), ['claude-haiku-4-5', 'claude-opus-4-8'])
+    assert.equal(out['claude-haiku-4-5'].input_tokens, 999)
+  })
+
+  it('cost_usd degrades to null when costUSD is missing or non-finite', () => {
+    const out = normalizeSdkModelUsage({
+      m1: { inputTokens: 1 },
+      m2: { inputTokens: 1, costUSD: NaN },
+    })
+    assert.equal(out.m1.cost_usd, null)
+    assert.equal(out.m2.cost_usd, null)
+  })
+
+  it('clamps poisoned token values instead of propagating them', () => {
+    const out = normalizeSdkModelUsage({ m: { inputTokens: -5, outputTokens: NaN } })
+    assert.equal(out.m.input_tokens, 0)
+    assert.equal(out.m.output_tokens, 0)
+  })
+
+  it('returns null for absent, non-object, or empty input', () => {
+    assert.equal(normalizeSdkModelUsage(undefined), null)
+    assert.equal(normalizeSdkModelUsage(null), null)
+    assert.equal(normalizeSdkModelUsage('nope'), null)
+    assert.equal(normalizeSdkModelUsage({}), null)
+    // entries that are not objects are skipped; all-skipped → null
+    assert.equal(normalizeSdkModelUsage({ m: null, n: 3 }), null)
+  })
+
+  it('accepts already-snake_case entries (CLI stream-json forward-compat)', () => {
+    const out = normalizeSdkModelUsage({
+      m: { input_tokens: 5, output_tokens: 2, cache_read_input_tokens: 1, cost_usd: 0.5 },
+    })
+    assert.deepEqual(out.m, {
+      input_tokens: 5,
+      output_tokens: 2,
+      cache_read_input_tokens: 1,
+      cache_creation_input_tokens: 0,
+      web_search_requests: 0,
+      cost_usd: 0.5,
+    })
+  })
+})
+
+describe('synthesizeModelUsage', () => {
+  it('builds a single-entry map from flat snake_case turn usage', () => {
+    const out = synthesizeModelUsage(
+      'claude-opus-4-8',
+      { input_tokens: 17, output_tokens: 23, cache_read_input_tokens: 4, cache_creation_input_tokens: 1 },
+      0.00198,
+    )
+    assert.deepEqual(out, {
+      'claude-opus-4-8': {
+        input_tokens: 17,
+        output_tokens: 23,
+        cache_read_input_tokens: 4,
+        cache_creation_input_tokens: 1,
+        web_search_requests: 0,
+        cost_usd: 0.00198,
+      },
+    })
+  })
+
+  it('accepts the legacy codex cached_input_tokens key', () => {
+    const out = synthesizeModelUsage('gpt-5.1-codex', {
+      input_tokens: 400,
+      output_tokens: 42,
+      cached_input_tokens: 600,
+    })
+    assert.equal(out['gpt-5.1-codex'].cache_read_input_tokens, 600)
+  })
+
+  it('cost defaults to null and non-finite cost degrades to null', () => {
+    const out = synthesizeModelUsage('m', { input_tokens: 1 })
+    assert.equal(out.m.cost_usd, null)
+    const out2 = synthesizeModelUsage('m', { input_tokens: 1 }, NaN)
+    assert.equal(out2.m.cost_usd, null)
+  })
+
+  it('returns null without a model id or usage object', () => {
+    assert.equal(synthesizeModelUsage(null, { input_tokens: 1 }), null)
+    assert.equal(synthesizeModelUsage('', { input_tokens: 1 }), null)
+    assert.equal(synthesizeModelUsage('m', null), null)
+  })
+
+  it('returns null when the usage object carries no token signal (both-null synthetic results)', () => {
+    // Mirrors _trackUsage's finite-tokens gate: a stream-stall synthetic
+    // result must not fabricate an all-zero per-model row.
+    assert.equal(synthesizeModelUsage('m', {}), null)
+    assert.equal(synthesizeModelUsage('m', { foo: 1 }), null)
+    // an explicit zero IS a signal (finite number) — zero-token turns exist
+    assert.notEqual(synthesizeModelUsage('m', { input_tokens: 0 }), null)
+  })
+})
+
+describe('isMeterableProvider', () => {
+  it('is true for token-reporting providers', () => {
+    for (const p of ['claude-sdk', 'claude-cli', 'claude-byok', 'codex', 'gemini', 'deepseek', 'ollama']) {
+      assert.equal(isMeterableProvider(p), true, p)
+    }
+  })
+
+  it('is false for telemetry-null providers and junk', () => {
+    for (const p of ['claude-tui', 'claude-channel', 'user-shell', '', null, undefined, 42]) {
+      assert.equal(isMeterableProvider(p), false, String(p))
+    }
+  })
+})


### PR DESCRIPTION
## Summary

PR-1 (step M-1) of the orchestration epic (#6691), and independently valuable — this ships **ungated** and improves usage telemetry for **all** sessions, not just orchestration.

Chroxy discards per-model usage today. This surfaces it:

- **`usage-normalize.js`** (new): `normalizeSdkModelUsage` (SDK camelCase `ModelUsage` → snake_case cells, so a cell drops straight into `computePromptCostUsd`), `synthesizeModelUsage` (single-model providers), `isMeterableProvider` (claude-tui/channel/user-shell report no usage). Nonneg clamps mirror `_trackUsage`'s coercions.
- **sdk-session / cli-session**: forward `modelUsage` + `numTurns` + `apiDurationMs` on the `result` payload. Additive — verified the existing `_trackUsage` and the `event-normalizer` result allowlist ignore unknown fields, so this is **non-breaking** and stays in-process (no wire/protocol change in this PR).
- **codex** (`_mapUsage`): emit `cache_read_input_tokens`. Codex reports cached tokens as a **subset** of `input_tokens` (OpenAI `prompt_tokens_details` convention — independently confirmed in the codex turn log: `input=65835, cached=6528, non_cached=59307`), while Chroxy's keys are additive, so the fix **splits** into uncached input + cache_read (clamped, so a hypothetical additive-reporting future build undercounts rather than goes negative). Previously the cache count lived only under `cached_input_tokens`, a key `_trackUsage` never reads — **codex cache tokens were silently dropped from `cumulativeUsage`**.
- **byok / gemini / codex**: synthesize a single-model `modelUsage` (byok also on the partial-spend error path).

## Phase-0 verification (before writing the fix)
- Codex cache **inclusivity** (subset vs additive): confirmed **subset** from the exec-path context ratchet + OpenAI convention + the codex turn log arithmetic.
- CLI `modelUsage` presence: the CLI stream-json result shares the SDK runtime type — forwarded, degrading to `null` on older builds.

## Tests
- New `usage-normalize.test.js` (contract: key mapping, nonneg clamps, null-on-empty, subset handling).
- Per-provider result-emit assertions added to sdk / cli / byok / gemini / codex-app-server suites.
- All 6 directly-affected files green (471 tests); full server suite **11089 pass / 13 skip**.

## ⚠️ CI note — 2 pre-existing LOCAL failures, unrelated to this PR
The full local run shows 2 codex **integration** failures (`Codex spawn-and-assert #3873`, `runDoctorChecks provider awareness #2951`). Both are environmental fallout from security incident **#6708**: macOS XProtect removed the OpenAI codex native binary from this machine mid-session, so those tests `ENOENT` on `…/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex`. This PR's diff touches only the 5 provider result-emit paths + the new module — **nothing** near doctor/spawn/argv (`git diff` confirms). They will pass on CI's clean runners.

Closes #6692. Part of #6691.