### PR TITLE
feat: exact remote-based repo-events scoping (replace basename matching) (#6539)

### DIFF
--- a/packages/dashboard/src/components/RepoEventsSection.test.tsx
+++ b/packages/dashboard/src/components/RepoEventsSection.test.tsx
@@ -126,6 +126,24 @@ describe('RepoEventsSection pure helpers (#5966)', () => {
     expect(groups.map((g) => g.repo)).toEqual(['blamechris/chroxy'])
   })
 
+  it('scopeAndGroupEvents matches exactRepos case-insensitively (canonical full_name vs git remote casing)', () => {
+    const events = [ev({ repo: 'blamechris/chroxy' })]
+    // The server lowercases activeRepos; the event's canonical full_name matches
+    // regardless of the git remote's original casing.
+    const scope = { exactRepos: new Set(['blamechris/chroxy']), basenames: new Set<string>() }
+    expect(scopeAndGroupEvents(events, scope, false).groups.map((g) => g.repo)).toEqual(['blamechris/chroxy'])
+  })
+
+  it('scopeAndGroupEvents hides an event with a null/bare repo under exact scoping (revealed by Show all)', () => {
+    const events = [ev({ repo: null }), ev({ repo: 'blamechris/chroxy' })]
+    const scope = { exactRepos: new Set(['blamechris/chroxy']), basenames: new Set<string>() }
+    const { groups, hiddenCount } = scopeAndGroupEvents(events, scope, false)
+    expect(groups.map((g) => g.repo)).toEqual(['blamechris/chroxy'])
+    expect(hiddenCount).toBe(1)
+    // Show all reveals it, grouped under the unknown-repo bucket.
+    expect(scopeAndGroupEvents(events, scope, true).groups.length).toBe(2)
+  })
+
   it('formatAgo renders a relative label or a dash', () => {
     expect(formatAgo('2026-07-02T12:00:00.000Z', NOW)).toBe('5m ago')
     expect(formatAgo('2026-07-02T12:05:00.000Z', NOW)).toBe('just now')

--- a/packages/dashboard/src/components/RepoEventsSection.test.tsx
+++ b/packages/dashboard/src/components/RepoEventsSection.test.tsx
@@ -72,30 +72,58 @@ describe('RepoEventsSection pure helpers (#5966)', () => {
     expect([...set].sort()).toEqual(['chroxy', 'widget'])
   })
 
+  // Backward-compat basename fallback (older daemon: exactRepos null).
+  const basenameScope = (bases: string[]) => ({ exactRepos: null, basenames: new Set(bases) })
+
   it('scopeAndGroupEvents reverses to newest-first and groups by repo', () => {
     const events = [
       ev({ repo: 'a/one', at: '2026-07-02T10:00:00.000Z', summary: 'old' }),
       ev({ repo: 'a/two', at: '2026-07-02T11:00:00.000Z', summary: 'mid' }),
       ev({ repo: 'a/one', at: '2026-07-02T12:00:00.000Z', summary: 'new' }),
     ]
-    const { groups, hiddenCount } = scopeAndGroupEvents(events, new Set(), false)
+    const { groups, hiddenCount } = scopeAndGroupEvents(events, basenameScope([]), false)
     // newest event (a/one 'new') ranks its group first
     expect(groups.map((g) => g.repo)).toEqual(['one', 'two'].map((x) => `a/${x}`))
     expect(groups[0]!.events.map((e) => e.summary)).toEqual(['new', 'old'])
     expect(hiddenCount).toBe(0)
   })
 
-  it('scopeAndGroupEvents filters to active repos and counts the hidden', () => {
+  it('scopeAndGroupEvents filters by basename fallback when exactRepos is null', () => {
     const events = [ev({ repo: 'blamechris/chroxy' }), ev({ repo: 'someone/other' })]
-    const { groups, hiddenCount } = scopeAndGroupEvents(events, new Set(['chroxy']), false)
+    const { groups, hiddenCount } = scopeAndGroupEvents(events, basenameScope(['chroxy']), false)
     expect(groups.map((g) => g.repo)).toEqual(['blamechris/chroxy'])
     expect(hiddenCount).toBe(1)
   })
 
-  it('scopeAndGroupEvents shows everything when showAll is true or no active repos', () => {
+  it('scopeAndGroupEvents shows everything when showAll is true or the active set is empty', () => {
     const events = [ev({ repo: 'blamechris/chroxy' }), ev({ repo: 'someone/other' })]
-    expect(scopeAndGroupEvents(events, new Set(['chroxy']), true).hiddenCount).toBe(0)
-    expect(scopeAndGroupEvents(events, new Set(), false).groups.length).toBe(2)
+    expect(scopeAndGroupEvents(events, basenameScope(['chroxy']), true).hiddenCount).toBe(0)
+    expect(scopeAndGroupEvents(events, basenameScope([]), false).groups.length).toBe(2)
+  })
+
+  // #6539: exact owner/repo scoping (the server-provided set takes precedence).
+  it('scopeAndGroupEvents matches by EXACT owner/repo when exactRepos is provided', () => {
+    const events = [ev({ repo: 'blamechris/chroxy' }), ev({ repo: 'someone/chroxy' })]
+    // Both share basename "chroxy", but exact scoping keeps only the right owner.
+    const scope = { exactRepos: new Set(['blamechris/chroxy']), basenames: new Set(['chroxy']) }
+    const { groups, hiddenCount } = scopeAndGroupEvents(events, scope, false)
+    expect(groups.map((g) => g.repo)).toEqual(['blamechris/chroxy'])
+    expect(hiddenCount).toBe(1)
+  })
+
+  it('scopeAndGroupEvents with an empty exact set (no GitHub-remote sessions) shows all, not none', () => {
+    const events = [ev({ repo: 'blamechris/chroxy' }), ev({ repo: 'someone/other' })]
+    const scope = { exactRepos: new Set<string>(), basenames: new Set(['chroxy']) }
+    // exactRepos is provided-but-empty ⇒ no scoping (don't erroneously hide all).
+    expect(scopeAndGroupEvents(events, scope, false).groups.length).toBe(2)
+  })
+
+  it('scopeAndGroupEvents prefers exactRepos over the basename fallback', () => {
+    const events = [ev({ repo: 'blamechris/chroxy' }), ev({ repo: 'someone/other' })]
+    // basenames would keep 'other'; exact set does not — exact wins.
+    const scope = { exactRepos: new Set(['blamechris/chroxy']), basenames: new Set(['chroxy', 'other']) }
+    const { groups } = scopeAndGroupEvents(events, scope, false)
+    expect(groups.map((g) => g.repo)).toEqual(['blamechris/chroxy'])
   })
 
   it('formatAgo renders a relative label or a dash', () => {

--- a/packages/dashboard/src/components/RepoEventsSection.tsx
+++ b/packages/dashboard/src/components/RepoEventsSection.tsx
@@ -128,9 +128,11 @@ export function scopeAndGroupEvents(
   const byRepo = new Map<string, RepoEvent[]>()
   for (const ev of newestFirst) {
     if (scoped) {
-      // Exact: the event's `owner/repo` must be in the set. Fallback: its basename.
-      const key = useExact ? ev.repo ?? null : repoBasename(ev.repo)
-      if (!key || !activeSet.has(key)) {
+      // Exact: the event's `owner/repo` must be in the set (case-insensitive —
+      // GitHub names are, and a git-config remote can differ in case from the
+      // canonical `full_name` the webhook stamps). Fallback: its cwd basename.
+      const filterKey = useExact ? (ev.repo ? ev.repo.toLowerCase() : null) : repoBasename(ev.repo)
+      if (!filterKey || !activeSet.has(filterKey)) {
         hiddenCount++
         continue
       }
@@ -230,7 +232,10 @@ export function RepoEventsSection({
   const events = snapshot?.events ?? []
   // #6539: prefer the server's exact `owner/repo` set; fall back to cwd basenames
   // when an older daemon omits it. `exactRepos: null` ⇒ use the basename guess.
-  const exactRepos = Array.isArray(snapshot?.activeRepos) ? new Set(snapshot.activeRepos) : null
+  // Lowercased for case-insensitive matching (GitHub names are case-insensitive).
+  const exactRepos = Array.isArray(snapshot?.activeRepos)
+    ? new Set(snapshot.activeRepos.map((r) => r.toLowerCase()))
+    : null
   const basenames = activeRepoBasenames(sessions ?? [])
   const { groups, hiddenCount } = scopeAndGroupEvents(events, { exactRepos, basenames }, showAll)
   const activeScopeSize = exactRepos !== null ? exactRepos.size : basenames.size

--- a/packages/dashboard/src/components/RepoEventsSection.tsx
+++ b/packages/dashboard/src/components/RepoEventsSection.tsx
@@ -95,25 +95,42 @@ export interface RepoEventGroup {
 }
 
 /**
+ * The active-repo scope to filter events against. `#6539`: prefer the server's
+ * EXACT `owner/repo` set (`exactRepos`, resolved from each session's git remote);
+ * fall back to the best-effort cwd-`basenames` guess only when the server didn't
+ * send it (older daemon, `exactRepos: null`).
+ */
+export interface RepoEventsScope {
+  /** Exact `owner/repo` set from the snapshot's `activeRepos`, or null if absent. */
+  exactRepos: ReadonlySet<string> | null
+  /** Fallback: cwd basenames derived client-side. Used only when `exactRepos` is null. */
+  basenames: ReadonlySet<string>
+}
+
+/**
  * Scope + group events for display. The store feed is most-recent-LAST, so we
- * reverse to newest-first. When `showAll` is false and there's a non-empty set
- * of active-repo basenames, events are filtered to those repos; otherwise all
- * events pass. Returns the visible groups (ordered by their newest event) plus
- * how many events were hidden by scoping (0 when unscoped).
+ * reverse to newest-first. When `showAll` is false and the active set is
+ * non-empty, events are filtered to those repos; otherwise all events pass.
+ * `#6539`: matches by EXACT `owner/repo` when the server sent `activeRepos`,
+ * else by cwd basename (backward-compatible fallback). Returns the visible
+ * groups (ordered by their newest event) plus how many events were hidden.
  */
 export function scopeAndGroupEvents(
   events: readonly RepoEvent[],
-  activeBasenames: Set<string>,
+  scope: RepoEventsScope,
   showAll: boolean,
 ): { groups: RepoEventGroup[]; hiddenCount: number } {
   const newestFirst = events.slice().reverse()
-  const scoped = !showAll && activeBasenames.size > 0
+  const useExact = scope.exactRepos !== null
+  const activeSet = useExact ? scope.exactRepos! : scope.basenames
+  const scoped = !showAll && activeSet.size > 0
   let hiddenCount = 0
   const byRepo = new Map<string, RepoEvent[]>()
   for (const ev of newestFirst) {
     if (scoped) {
-      const base = repoBasename(ev.repo)
-      if (!base || !activeBasenames.has(base)) {
+      // Exact: the event's `owner/repo` must be in the set. Fallback: its basename.
+      const key = useExact ? ev.repo ?? null : repoBasename(ev.repo)
+      if (!key || !activeSet.has(key)) {
         hiddenCount++
         continue
       }
@@ -211,9 +228,13 @@ export function RepoEventsSection({
   const generatedAtMs = snapshot ? Date.parse(snapshot.generatedAt) : NaN
 
   const events = snapshot?.events ?? []
-  const activeBasenames = activeRepoBasenames(sessions ?? [])
-  const { groups, hiddenCount } = scopeAndGroupEvents(events, activeBasenames, showAll)
-  const scopingActive = !showAll && activeBasenames.size > 0
+  // #6539: prefer the server's exact `owner/repo` set; fall back to cwd basenames
+  // when an older daemon omits it. `exactRepos: null` ⇒ use the basename guess.
+  const exactRepos = Array.isArray(snapshot?.activeRepos) ? new Set(snapshot.activeRepos) : null
+  const basenames = activeRepoBasenames(sessions ?? [])
+  const { groups, hiddenCount } = scopeAndGroupEvents(events, { exactRepos, basenames }, showAll)
+  const activeScopeSize = exactRepos !== null ? exactRepos.size : basenames.size
+  const scopingActive = !showAll && activeScopeSize > 0
 
   return (
     <div className="cr-section" data-testid="repo-events-section">
@@ -289,7 +310,7 @@ export function RepoEventsSection({
             <span className="cr-chip" data-testid="repo-events-chip-repos">
               Repos: <b data-testid="repo-events-chip-count-repos">{new Set(events.map((e) => e.repo ?? '(unknown repo)')).size}</b>
             </span>
-            {activeBasenames.size > 0 && (
+            {activeScopeSize > 0 && (
               <label className="cr-chip" data-testid="repo-events-show-all">
                 <input
                   type="checkbox"

--- a/packages/protocol/dist/schemas/server/control-room/repo-events.d.ts
+++ b/packages/protocol/dist/schemas/server/control-room/repo-events.d.ts
@@ -89,6 +89,7 @@ export declare const ServerRepoEventsSnapshotSchema: z.ZodObject<{
         url: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         summary: z.ZodString;
     }, z.core.$loose>>;
+    activeRepos: z.ZodOptional<z.ZodArray<z.ZodString>>;
     error: z.ZodOptional<z.ZodObject<{
         code: z.ZodString;
         message: z.ZodString;

--- a/packages/protocol/dist/schemas/server/control-room/repo-events.js
+++ b/packages/protocol/dist/schemas/server/control-room/repo-events.js
@@ -71,6 +71,15 @@ export const ServerRepoEventsSnapshotSchema = z.object({
     requestId: z.string().nullable().optional(),
     generatedAt: z.string().datetime(),
     events: z.array(RepoEventSchema),
+    /**
+     * #6539 — the EXACT `owner/repo` set the live sessions are working in, resolved
+     * server-side from each active session's git `origin` remote. The dashboard
+     * scopes events to this set (exact `owner/repo` match), replacing the
+     * best-effort cwd-basename guess. Additive + optional: an older server omits it,
+     * and the dashboard falls back to basename scoping. Sessions with no
+     * recognizable GitHub remote are simply absent (not scoped out erroneously).
+     */
+    activeRepos: z.array(z.string()).optional(),
     /** Present only on a refusal (e.g. a session-bound token surveying the host). */
     error: z.object({ code: z.string(), message: z.string() }).optional(),
 });

--- a/packages/protocol/src/schemas/server/control-room/repo-events.ts
+++ b/packages/protocol/src/schemas/server/control-room/repo-events.ts
@@ -74,6 +74,15 @@ export const ServerRepoEventsSnapshotSchema = z.object({
   requestId: z.string().nullable().optional(),
   generatedAt: z.string().datetime(),
   events: z.array(RepoEventSchema),
+  /**
+   * #6539 — the EXACT `owner/repo` set the live sessions are working in, resolved
+   * server-side from each active session's git `origin` remote. The dashboard
+   * scopes events to this set (exact `owner/repo` match), replacing the
+   * best-effort cwd-basename guess. Additive + optional: an older server omits it,
+   * and the dashboard falls back to basename scoping. Sessions with no
+   * recognizable GitHub remote are simply absent (not scoped out erroneously).
+   */
+  activeRepos: z.array(z.string()).optional(),
   /** Present only on a refusal (e.g. a session-bound token surveying the host). */
   error: z.object({ code: z.string(), message: z.string() }).optional(),
 })

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -202,6 +202,34 @@ export function parseGithubPrsUrl(remote) {
 }
 
 /**
+ * #6539 — resolve the EXACT active-repo set for repo-events scoping. For each
+ * distinct active-session cwd, read its `origin` remote (`git remote get-url
+ * origin`, failure-tolerant) and map it to `owner/repo` via
+ * {@link parseGithubOwnerRepo}. A cwd that isn't a git repo, has no origin, or
+ * has a non-GitHub remote resolves to null and is dropped — so a session without
+ * a recognizable GitHub remote is simply absent from the set (the dashboard
+ * degrades to "show all" for it rather than scoping it out). Deduped + sorted so
+ * the snapshot field is deterministic.
+ *
+ * @param {string[]} cwds - active-session working directories.
+ * @param {object} [opts]
+ * @param {Function} [opts.execFn] - promisified execFile seam (tests inject a stub).
+ * @param {number} [opts.concurrency]
+ * @returns {Promise<string[]>} sorted, deduped `owner/repo` full names.
+ */
+export async function resolveActiveRepos(cwds, { execFn = execFileAsync, concurrency = 4 } = {}) {
+  const distinct = [...new Set((Array.isArray(cwds) ? cwds : []).filter((c) => typeof c === 'string' && c.length > 0))]
+  if (distinct.length === 0) return []
+  const tasks = distinct.map((cwd) => async () => {
+    const remote = await tryExec(execFn, 'git', ['remote', 'get-url', 'origin'], cwd)
+    const parsed = parseGithubOwnerRepo(remote)
+    return parsed ? `${parsed.owner}/${parsed.repo}` : null
+  })
+  const names = await mapWithCap(tasks, concurrency)
+  return [...new Set(names.filter(Boolean))].sort()
+}
+
+/**
  * Conclusions/states from a `gh` statusCheckRollup entry that count as a failed
  * check. `gh pr list --json statusCheckRollup` mixes two node shapes: CheckRun
  * (GitHub Actions etc., carries `status` + `conclusion`) and StatusContext

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -223,7 +223,11 @@ export async function resolveActiveRepos(cwds, { execFn = execFileAsync, concurr
   const tasks = distinct.map((cwd) => async () => {
     const remote = await tryExec(execFn, 'git', ['remote', 'get-url', 'origin'], cwd)
     const parsed = parseGithubOwnerRepo(remote)
-    return parsed ? `${parsed.owner}/${parsed.repo}` : null
+    // Lowercase: GitHub owner/repo are case-insensitive, but a manually-edited
+    // remote ('BlameChris/Chroxy') can differ in case from the canonical
+    // `full_name` the webhook stamps on `ev.repo` ('blamechris/chroxy'). Normalize
+    // so the dashboard's exact match doesn't erroneously hide events (#6539).
+    return parsed ? `${parsed.owner}/${parsed.repo}`.toLowerCase() : null
   })
   const names = await mapWithCap(tasks, concurrency)
   return [...new Set(names.filter(Boolean))].sort()

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -32,7 +32,7 @@ import { realpathSync } from 'fs'
 import { resolve } from 'path'
 import { createLogger } from '../logger.js'
 import { resolveRepoSet, DEFAULT_CONTROL_ROOM_ROOT } from '../control-room/repo-set.js'
-import { surveyRepos } from '../control-room/survey.js'
+import { surveyRepos, resolveActiveRepos } from '../control-room/survey.js'
 import { surveyRunners, DEFAULT_RUNNER_ROOT } from '../control-room/runners.js'
 import { surveyContainers } from '../control-room/containers.js'
 import { surveyRepoRuntimeConfig, hostRuntimeDefaults } from '../control-room/repo-runtime-config.js'
@@ -74,6 +74,9 @@ const simulatorInFlight = new WeakSet()
 const emulatorInFlight = new WeakSet()
 // #6138: same again for the WSL distro survey — independent of all above.
 const wslInFlight = new WeakSet()
+// #6539: repo-events became an async survey (it now resolves active sessions'
+// git remotes for exact scoping), so it gains an in-flight guard like the rest.
+const repoEventsInFlight = new WeakSet()
 
 /**
  * #5377 — shared builder for the survey error-snapshots. The error reply is a
@@ -1894,29 +1897,56 @@ const handleExternalSessionsRequest = makeSyncHostSurvey({
 })
 
 /**
+ * #6539 — build a schema-valid `repo_events_snapshot`. `events`/`activeRepos`
+ * default empty (the FORBIDDEN / in-progress / failed replies), overwritten by
+ * the success path. `generatedAt` is stamped fresh per reply.
+ */
+function repoEventsSnapshot(requestId, fields = {}) {
+  return {
+    type: 'repo_events_snapshot',
+    requestId: requestId ?? null,
+    generatedAt: new Date().toISOString(),
+    events: [],
+    activeRepos: [],
+    ...fields,
+  }
+}
+
+/**
  * #5966 (epic #5422 phase 5) — reply to a `repo_events_request` with a
  * point-in-time snapshot of the GitHub-webhook repo events the daemon buffered
  * in its bounded RepoEventStore (github-webhook.js, HMAC-verified ingest #6468).
- * Reads the in-memory store only (no git/gh survey), so — like the mailbox /
- * external-session surveys — it is synchronous and has no in-flight guard. The
- * store is lazily created on the first webhook delivery, so a null store is the
- * valid "nothing buffered yet" state and yields an empty (schema-valid) feed.
  *
- * A bounded tail (`limit: 50`) keeps the snapshot small even though the store
- * caps at 200 — the pane shows recent activity, not the whole ring. Host-level
- * survey: a pairing-bound (share-a-session) token is rejected, like
- * `host_status_request`, still with a schema-valid empty snapshot carrying an
- * additive `error` so the pane renders the refusal rather than spinning.
+ * #6539: the reply now also carries `activeRepos` — the EXACT `owner/repo` set
+ * the live sessions are working in, resolved server-side from each active
+ * session's git `origin` remote — so the dashboard scopes events by exact match
+ * rather than guessing from cwd basenames. Resolving remotes is async git I/O, so
+ * this moved from a synchronous store read to the async survey factory (gaining
+ * the shared host-authority gate + in-flight guard). A bounded tail (`limit: 50`)
+ * keeps the events small even though the store caps at 200. `ctx.resolveActiveRepos`
+ * is a test seam; production falls through to the real implementation.
  */
-const handleRepoEventsRequest = makeSyncHostSurvey({
-  type: 'repo_events_snapshot',
-  emptyFields: { events: [] },
-  forbiddenMessage: 'repo_events_request requires host-level authority (a session-bound token cannot survey the host)',
-  resolve: (ctx) => {
+const handleRepoEventsRequest = makeSurveyHandler({
+  inFlight: repoEventsInFlight,
+  logName: 'repo events survey',
+  forbidden: ({ requestId }) => repoEventsSnapshot(requestId, {
+    error: {
+      code: 'FORBIDDEN',
+      message: 'repo_events_request requires host-level authority (a session-bound token cannot survey the host)',
+    },
+  }),
+  inProgress: ({ requestId }) => repoEventsSnapshot(requestId, {
+    error: { code: 'SURVEY_IN_PROGRESS', message: 'A repo events survey is already in progress for this client' },
+  }),
+  failed: ({ requestId, err }) => repoEventsSnapshot(requestId, {
+    error: { code: 'SURVEY_FAILED', message: getErrorMessage(err, 'repo events survey failed') },
+  }),
+  run: async ({ ctx, requestId }) => {
     const store = ctx?.services?.repoEventStore
-    return {
-      events: typeof store?.list === 'function' ? store.list({ limit: 50 }) : [],
-    }
+    const events = typeof store?.list === 'function' ? store.list({ limit: 50 }) : []
+    const resolveFn = typeof ctx?.resolveActiveRepos === 'function' ? ctx.resolveActiveRepos : resolveActiveRepos
+    const activeRepos = await resolveFn(activeSessionCwds(ctx?.sessions?.sessionManager))
+    return repoEventsSnapshot(requestId, { events, activeRepos })
   },
 })
 

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -1928,7 +1928,7 @@ function repoEventsSnapshot(requestId, fields = {}) {
  */
 const handleRepoEventsRequest = makeSurveyHandler({
   inFlight: repoEventsInFlight,
-  logName: 'repo events survey',
+  logName: 'repo_events_request',
   forbidden: ({ requestId }) => repoEventsSnapshot(requestId, {
     error: {
       code: 'FORBIDDEN',

--- a/packages/server/tests/control-room-repo-events.test.js
+++ b/packages/server/tests/control-room-repo-events.test.js
@@ -24,6 +24,9 @@ function makeCtx(overrides = {}) {
   return nsCtx({
     send: sendSpy,
     repoEventStore: { list: ({ limit } = {}) => (typeof limit === 'number' ? SAMPLE.slice(-limit) : SAMPLE.slice()) },
+    // #6539: the handler resolves active-session git remotes (async). Inject a
+    // deterministic stub so tests don't spawn git; overridable per test.
+    resolveActiveRepos: async () => ['blamechris/chroxy'],
     ...overrides,
     _send: sendSpy,
   })
@@ -33,55 +36,92 @@ function lastSent(ctx) {
   return ctx.transport.send.lastCall[1]
 }
 
-describe('repo_events_request handler (#5966)', () => {
+describe('repo_events_request handler (#5966, #6539)', () => {
   it('is registered in the controlRoomHandlers map', () => {
     assert.equal(typeof controlRoomHandlers.repo_events_request, 'function')
   })
 
-  it('replies with a schema-valid snapshot carrying the buffered events', () => {
+  it('replies with a schema-valid snapshot carrying the buffered events + exact activeRepos', async () => {
     const ctx = makeCtx()
-    controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request', requestId: 'r1' }, ctx)
+    await controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request', requestId: 'r1' }, ctx)
     const msg = lastSent(ctx)
     assert.equal(msg.type, 'repo_events_snapshot')
     assert.equal(msg.requestId, 'r1')
     assert.equal(msg.events.length, 2)
     assert.equal(msg.events[1].number, 42)
+    // #6539: the exact active-repo set from the resolver
+    assert.deepEqual(msg.activeRepos, ['blamechris/chroxy'])
     assert.equal(msg.error, undefined)
     assert.ok(ServerRepoEventsSnapshotSchema.safeParse(msg).success)
   })
 
-  it('requests a bounded tail (limit 50) from the store', () => {
+  it('requests a bounded tail (limit 50) from the store', async () => {
     let seen = null
     const ctx = makeCtx({ repoEventStore: { list: (opts) => { seen = opts; return SAMPLE } } })
-    controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
+    await controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
     assert.deepEqual(seen, { limit: 50 })
   })
 
-  it('echoes a null requestId when none is provided', () => {
+  it('echoes a null requestId when none is provided', async () => {
     const ctx = makeCtx()
-    controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
+    await controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
     const msg = lastSent(ctx)
     assert.equal(msg.requestId, null)
     assert.ok(ServerRepoEventsSnapshotSchema.safeParse(msg).success)
   })
 
-  it('refuses a session-bound (pairing) token with an error + empty events', () => {
+  it('carries an empty activeRepos when no session has a recognizable remote', async () => {
+    const ctx = makeCtx({ resolveActiveRepos: async () => [] })
+    await controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
+    const msg = lastSent(ctx)
+    assert.deepEqual(msg.activeRepos, [])
+    assert.equal(msg.events.length, 2, 'events still flow when scoping is empty')
+    assert.ok(ServerRepoEventsSnapshotSchema.safeParse(msg).success)
+  })
+
+  it('refuses a session-bound (pairing) token with an error + empty events', async () => {
     const ctx = makeCtx()
-    controlRoomHandlers.repo_events_request({}, { boundSessionId: 'sess-1' }, { type: 'repo_events_request', requestId: 'r2' }, ctx)
+    await controlRoomHandlers.repo_events_request({}, { boundSessionId: 'sess-1' }, { type: 'repo_events_request', requestId: 'r2' }, ctx)
     const msg = lastSent(ctx)
     assert.equal(msg.type, 'repo_events_snapshot')
     assert.equal(msg.requestId, 'r2')
     assert.deepEqual(msg.events, [])
+    assert.deepEqual(msg.activeRepos, [])
     assert.equal(msg.error.code, 'FORBIDDEN')
     assert.ok(ServerRepoEventsSnapshotSchema.safeParse(msg).success)
   })
 
-  it('degrades to an empty snapshot when the store is absent (no webhook delivered yet)', () => {
+  it('degrades to an empty snapshot when the store is absent (no webhook delivered yet)', async () => {
     const ctx = makeCtx({ repoEventStore: null })
-    controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
+    await controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request' }, ctx)
     const msg = lastSent(ctx)
     assert.deepEqual(msg.events, [])
     assert.ok(ServerRepoEventsSnapshotSchema.safeParse(msg).success)
+  })
+
+  it('replies SURVEY_FAILED when remote resolution throws (does not crash)', async () => {
+    const ctx = makeCtx({ resolveActiveRepos: async () => { throw new Error('git exploded') } })
+    await controlRoomHandlers.repo_events_request({}, {}, { type: 'repo_events_request', requestId: 'r3' }, ctx)
+    const msg = lastSent(ctx)
+    assert.equal(msg.requestId, 'r3')
+    assert.equal(msg.error.code, 'SURVEY_FAILED')
+    assert.ok(ServerRepoEventsSnapshotSchema.safeParse(msg).success)
+  })
+
+  it('rejects a concurrent survey for the same client with SURVEY_IN_PROGRESS', async () => {
+    // A resolver that never settles until we release it keeps the first survey
+    // in-flight while the second arrives.
+    let release
+    const gate = new Promise((r) => { release = r })
+    const client = {}
+    const ctx = makeCtx({ resolveActiveRepos: async () => { await gate; return ['blamechris/chroxy'] } })
+    const first = controlRoomHandlers.repo_events_request({}, client, { type: 'repo_events_request', requestId: 'a' }, ctx)
+    await controlRoomHandlers.repo_events_request({}, client, { type: 'repo_events_request', requestId: 'b' }, ctx)
+    const inProgressMsg = lastSent(ctx)
+    assert.equal(inProgressMsg.requestId, 'b')
+    assert.equal(inProgressMsg.error.code, 'SURVEY_IN_PROGRESS')
+    release()
+    await first
   })
 })
 

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -240,6 +240,14 @@ describe('resolveActiveRepos (#6539 exact repo-events scoping)', () => {
     const out = await resolveActiveRepos(['/x', '/y'], { execFn: exec })
     assert.deepEqual(out, ['alice/app', 'bob/app'], 'same basename "app", distinct owner/repo')
   })
+
+  it('lowercases the owner/repo so a case-mismatched git remote still matches the canonical full_name', async () => {
+    // A manually-edited remote can carry non-canonical casing; the webhook always
+    // stamps GitHub's canonical (lowercased-here) full_name on ev.repo.
+    const exec = makeExec({ '/a': 'git@github.com:BlameChris/Chroxy.git' })
+    const out = await resolveActiveRepos(['/a'], { execFn: exec })
+    assert.deepEqual(out, ['blamechris/chroxy'])
+  })
 })
 
 describe('parseGithubPrsUrl', () => {

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -28,6 +28,7 @@ import {
   parseGithubPrsUrl,
   parseAheadBehind,
   detectAttribution,
+  resolveActiveRepos,
   DEFAULT_THRESHOLDS,
 } from '../src/control-room/survey.js'
 
@@ -191,6 +192,53 @@ describe('parseGithubOwnerRepo (#5501 shared derivation)', () => {
     assert.equal(parseGithubOwnerRepo('git@gitlab.com:owner/repo.git'), null)
     assert.equal(parseGithubOwnerRepo('git@github.com:owner/repo/extra.git'), null)
     assert.equal(parseGithubOwnerRepo(null), null)
+  })
+})
+
+describe('resolveActiveRepos (#6539 exact repo-events scoping)', () => {
+  // Stub the promisified execFile: map cwd → origin remote stdout, or throw for
+  // a non-repo / no-origin cwd (matching real `git remote get-url` failure).
+  const makeExec = (byCwd) => async (_file, _args, opts) => {
+    const remote = byCwd[opts?.cwd]
+    if (remote === undefined) throw new Error('not a git repository')
+    return { stdout: remote }
+  }
+
+  it('resolves each active cwd to its exact owner/repo (deduped + sorted)', async () => {
+    const exec = makeExec({
+      '/a': 'git@github.com:blamechris/chroxy.git',
+      '/b': 'https://github.com/octocat/hello.git',
+      '/c': 'git@github.com:blamechris/chroxy.git', // dup remote, different cwd (worktree)
+    })
+    const out = await resolveActiveRepos(['/a', '/b', '/c'], { execFn: exec })
+    assert.deepEqual(out, ['blamechris/chroxy', 'octocat/hello'])
+  })
+
+  it('drops cwds with no repo / no origin / a non-GitHub remote (graceful degrade)', async () => {
+    const exec = makeExec({
+      '/gh': 'https://github.com/o/r.git',
+      '/gitlab': 'git@gitlab.com:o/r.git', // non-GitHub → dropped
+      // '/bare' is absent from the map → exec throws → dropped
+    })
+    const out = await resolveActiveRepos(['/gh', '/gitlab', '/bare'], { execFn: exec })
+    assert.deepEqual(out, ['o/r'])
+  })
+
+  it('returns [] for an empty / non-array cwd list without spawning git', async () => {
+    let called = false
+    const exec = async () => { called = true; return { stdout: '' } }
+    assert.deepEqual(await resolveActiveRepos([], { execFn: exec }), [])
+    assert.deepEqual(await resolveActiveRepos(undefined, { execFn: exec }), [])
+    assert.equal(called, false)
+  })
+
+  it('distinguishes two repos that share a basename across owners (the bug #6539 fixes)', async () => {
+    const exec = makeExec({
+      '/x': 'git@github.com:alice/app.git',
+      '/y': 'git@github.com:bob/app.git',
+    })
+    const out = await resolveActiveRepos(['/x', '/y'], { execFn: exec })
+    assert.deepEqual(out, ['alice/app', 'bob/app'], 'same basename "app", distinct owner/repo')
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #6539 (item 2 of #6536, feature #5966, epic #5422).

Control Room repo-events were scoped to active sessions **best-effort** by comparing an event's `owner/REPO` **basename** against each session's **cwd basename** (PR-1, #6535). That misfires on:
- a worktree dir named differently from the repo,
- **two repos sharing a basename across different owners** (e.g. `alice/app` vs `bob/app`),
- monorepo subdir cwds.

This resolves each active session's **actual git remote** server-side and scopes on the full `owner/repo`.

## Changes

- **server `survey.js`** — new `resolveActiveRepos(cwds)`: for each distinct active-session cwd, read its `origin` remote (`git remote get-url origin`, failure-tolerant via the existing `tryExec`) and map to `owner/repo` via `parseGithubOwnerRepo`. Non-repo / non-GitHub / no-origin cwds drop out (deduped + sorted). Concurrency-capped.
- **server `control-room-handlers.js`** — `repo_events_request` moves from the sync store-read factory to the **async `makeSurveyHandler`** (remote resolution is async I/O), gaining the shared host-authority gate + in-flight guard, and carries the exact `activeRepos` set. `ctx.resolveActiveRepos` is a test seam.
- **protocol** — `ServerRepoEventsSnapshotSchema` gains an **additive, optional** `activeRepos: string[]`. An older daemon omits it and the dashboard falls back to basenames — fully backward-compatible.
- **dashboard `RepoEventsSection`** — scope by **exact `owner/repo`** when the snapshot carries `activeRepos`, else the basename fallback. Crucially, an **empty exact set** (no session has a recognizable GitHub remote) shows **all** events rather than erroneously hiding everything. The "Show all repos" toggle is preserved.

## Acceptance criteria

- [x] Server resolves active sessions' git remotes → `owner/repo` set (reuses `parseGithubOwnerRepo`)
- [x] `repo_events_snapshot` carries the exact active-repo set (additive, backward-compatible)
- [x] Dashboard scopes by exact `owner/repo` (not basename); "Show all repos" preserved
- [x] Sessions with no / non-GitHub remote degrade gracefully (absent from the set, not scoped out)
- [x] Full protocol + store-core + dashboard + server suites green; coverage guards unaffected (additive field)

## Verification

- protocol **358**, store-core **1939** (coverage guards clean — additive field trips none), all 16 control-room server suites (`survey` 62 incl. 4 new `resolveActiveRepos` cases + the same-basename-across-owners guard, `repo-events` 11 incl. async + activeRepos + SURVEY_IN_PROGRESS/FAILED, `handlers` 163), full dashboard **4264** (incl. new exact-scoping + empty-set + exact-over-basename cases). Server eslint clean.

## Design note

The design doc offered sync-with-cache vs async handler; I chose the **async survey factory** (it exists, is battle-tested for exactly this git/gh async-survey shape, and avoids a cold-cache first-request scoping gap). `git remote get-url` is a ~10ms local probe, so no cache is needed.