### PR TITLE
feat: carry isError end-to-end for failed tool_result styling (#6712)

### DIFF
--- a/packages/app/__tests__/contract-switch.test.ts
+++ b/packages/app/__tests__/contract-switch.test.ts
@@ -181,6 +181,11 @@ function normalize(messages: unknown[]): Array<Record<string, unknown>> {
     // fixture can assert streamed tool input. toMatchObject is partial, so
     // existing fixtures that don't assert it are unaffected.
     toolInputPartial: m.toolInputPartial,
+    // #6712: the tool_result patch fields, so a fixture can assert a result was
+    // attached (and flagged truncated / isError) onto its tool_use bubble.
+    toolResult: m.toolResult,
+    toolResultTruncated: m.toolResultTruncated,
+    toolResultIsError: m.toolResultIsError,
   }));
 }
 

--- a/packages/app/src/components/Icon.tsx
+++ b/packages/app/src/components/Icon.tsx
@@ -79,11 +79,20 @@ interface IconProps {
   size?: number;
   color?: string;
   testID?: string;
+  accessibilityLabel?: string;
 }
 
 /** Render a vector icon by semantic name */
-export function Icon({ name, size = 20, color = COLORS.textMuted, testID }: IconProps) {
+export function Icon({ name, size = 20, color = COLORS.textMuted, testID, accessibilityLabel }: IconProps) {
   const glyphName = iconMap[name];
   if (!glyphName) return null;
-  return <Ionicons name={glyphName as keyof typeof Ionicons.glyphMap} size={size} color={color} testID={testID} />;
+  return (
+    <Ionicons
+      name={glyphName as keyof typeof Ionicons.glyphMap}
+      size={size}
+      color={color}
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
+    />
+  );
 }

--- a/packages/app/src/components/Icon.tsx
+++ b/packages/app/src/components/Icon.tsx
@@ -78,11 +78,12 @@ interface IconProps {
   name: IconName;
   size?: number;
   color?: string;
+  testID?: string;
 }
 
 /** Render a vector icon by semantic name */
-export function Icon({ name, size = 20, color = COLORS.textMuted }: IconProps) {
+export function Icon({ name, size = 20, color = COLORS.textMuted, testID }: IconProps) {
   const glyphName = iconMap[name];
   if (!glyphName) return null;
-  return <Ionicons name={glyphName as keyof typeof Ionicons.glyphMap} size={size} color={color} />;
+  return <Ionicons name={glyphName as keyof typeof Ionicons.glyphMap} size={size} color={color} testID={testID} />;
 }

--- a/packages/app/src/components/__tests__/ActivityGroup.test.tsx
+++ b/packages/app/src/components/__tests__/ActivityGroup.test.tsx
@@ -90,6 +90,16 @@ describe('ActivityGroup / ActivityEntry — structured-renderer wiring (#4201)',
     expect(findByTestId(root, 'todo-list-header')).toHaveLength(0);
   });
 
+  it('shows the error icon for a failed tool_result and not for a successful one (#6712)', () => {
+    const errored = renderGroup([makeToolMessage({ id: 'm1', tool: 'db/query', toolResult: 'boom', toolResultIsError: true })]);
+    expandGroup(errored);
+    expect(findByTestId(errored, 'activity-entry-error-m1')[0]).toBeTruthy();
+
+    const ok = renderGroup([makeToolMessage({ id: 'm2', toolResult: 'ok' })]);
+    expandGroup(ok);
+    expect(findByTestId(ok, 'activity-entry-error-m2')).toHaveLength(0);
+  });
+
   it('does not render the TodoList when only the group is expanded but the entry is not', () => {
     const root = renderGroup([makeToolMessage({ id: 'm1' })]);
     expandGroup(root);

--- a/packages/app/src/components/__tests__/ActivityGroup.test.tsx
+++ b/packages/app/src/components/__tests__/ActivityGroup.test.tsx
@@ -98,6 +98,11 @@ describe('ActivityGroup / ActivityEntry — structured-renderer wiring (#4201)',
     const ok = renderGroup([makeToolMessage({ id: 'm2', toolResult: 'ok' })]);
     expandGroup(ok);
     expect(findByTestId(ok, 'activity-entry-error-m2')).toHaveLength(0);
+
+    // Pending (no result yet) also shows no error icon.
+    const pending = renderGroup([makeToolMessage({ id: 'm3', toolResult: undefined })]);
+    expandGroup(pending);
+    expect(findByTestId(pending, 'activity-entry-error-m3')).toHaveLength(0);
   });
 
   it('does not render the TodoList when only the group is expanded but the entry is not', () => {

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -110,7 +110,17 @@ function ActivityEntry({
       testID={`activity-entry-${message.id}`}
     >
       <View style={styles.activityEntryRow}>
-        {hasResult ? <Icon name="check" size={12} color={COLORS.accentGreen} /> : <Icon name="chevronRight" size={12} color={COLORS.textMuted} />}
+        {/* #6712: a failed tool_result (codex mcpToolCall / orphan sweep) shows a
+            red alert icon instead of the green check. */}
+        {hasResult ? (
+          message.toolResultIsError ? (
+            <Icon name="alertCircle" size={12} color={COLORS.accentRed} testID={`activity-entry-error-${message.id}`} />
+          ) : (
+            <Icon name="check" size={12} color={COLORS.accentGreen} />
+          )
+        ) : (
+          <Icon name="chevronRight" size={12} color={COLORS.textMuted} />
+        )}
         <Text style={styles.activityEntryTool}>{displayTool}</Text>
         {imageCount > 0 && (
           <Text style={styles.activityImageBadge}>{imageCount === 1 ? '1 image' : `${imageCount} images`}</Text>

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -114,7 +114,7 @@ function ActivityEntry({
             red alert icon instead of the green check. */}
         {hasResult ? (
           message.toolResultIsError ? (
-            <Icon name="alertCircle" size={12} color={COLORS.accentRed} testID={`activity-entry-error-${message.id}`} />
+            <Icon name="alertCircle" size={12} color={COLORS.accentRed} testID={`activity-entry-error-${message.id}`} accessibilityLabel="tool failed" />
           ) : (
             <Icon name="check" size={12} color={COLORS.accentGreen} />
           )

--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -109,6 +109,22 @@ describe('ToolGroup', () => {
     expect(screen.getByTestId('tool-group-entry-2')).toHaveTextContent('›')
   })
 
+  it('renders an error marker (✕) + error attribute for a failed tool_result (#6712)', () => {
+    const messages = [
+      tool('1', 'db/query', { toolResult: 'connection refused', toolResultIsError: true }),
+      tool('2', 'Bash', { toolResult: 'ok' }),
+    ]
+    render(<ToolGroup messages={messages} isActive={true} />)
+    const errored = screen.getByTestId('tool-group-entry-1')
+    expect(errored).toHaveTextContent('✕')
+    expect(errored).toHaveAttribute('data-error', 'true')
+    expect(errored).toHaveClass('tool-group-entry--error')
+    // A successful result is unaffected — still the check marker, no error attr.
+    const ok = screen.getByTestId('tool-group-entry-2')
+    expect(ok).toHaveTextContent('✓')
+    expect(ok).not.toHaveAttribute('data-error')
+  })
+
   it('counts an empty toolResult as complete (server may emit "")', () => {
     const messages = [
       tool('1', 'Bash', { toolResult: '' }),

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -181,6 +181,8 @@ function ToolGroupEntry({
         <span className={markerClass} aria-hidden="true">
           {resultIsError ? '✕' : hasResult ? '✓' : '›'}
         </span>
+        {/* #6712: the marker is aria-hidden, so surface the failure to AT. */}
+        {resultIsError && <span className="sr-only">tool failed</span>}
         <span className="tool-group-entry-name">{toolName}</span>
         {summary && <span className="tool-group-entry-input">{summary}</span>}
         <span className="tool-group-entry-toggle" aria-hidden="true">

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -107,7 +107,11 @@ function ToolGroupEntry({
   const hasResult =
     message.toolResult !== undefined ||
     (message.toolResultImages?.length ?? 0) > 0
-  const markerClass = `tool-group-entry-marker tool-group-entry-marker--${hasResult ? 'complete' : 'pending'}`
+  // #6712: a failed tool_result (codex mcpToolCall / orphan sweep) gets an error
+  // marker + entry class so the renderer can tint it distinctly from a success.
+  const resultIsError = hasResult && message.toolResultIsError === true
+  const markerState = resultIsError ? 'error' : hasResult ? 'complete' : 'pending'
+  const markerClass = `tool-group-entry-marker tool-group-entry-marker--${markerState}`
 
   // #4279 / #4282: the parent group's toggle now lives on a dedicated
   // header <button> that is a SIBLING of the entry list — not an ancestor
@@ -152,8 +156,9 @@ function ToolGroupEntry({
 
   return (
     <div
-      className={`tool-group-entry${expanded ? ' tool-group-entry--expanded' : ''}`}
+      className={`tool-group-entry${expanded ? ' tool-group-entry--expanded' : ''}${resultIsError ? ' tool-group-entry--error' : ''}`}
       data-testid={`tool-group-entry-${message.id}`}
+      data-error={resultIsError ? 'true' : undefined}
     >
       {/*
         #4281: the click target is the ROW, not the outer entry container.
@@ -174,7 +179,7 @@ function ToolGroupEntry({
         onKeyDown={handleKeyDown}
       >
         <span className={markerClass} aria-hidden="true">
-          {hasResult ? '✓' : '›'}
+          {resultIsError ? '✕' : hasResult ? '✓' : '›'}
         </span>
         <span className="tool-group-entry-name">{toolName}</span>
         {summary && <span className="tool-group-entry-input">{summary}</span>}

--- a/packages/dashboard/src/store/contract-switch.test.ts
+++ b/packages/dashboard/src/store/contract-switch.test.ts
@@ -99,6 +99,11 @@ function normalize(messages: unknown[]): Array<Record<string, unknown>> {
     // fixture can assert streamed tool input. toMatchObject is partial, so
     // existing fixtures that don't assert it are unaffected.
     toolInputPartial: m.toolInputPartial,
+    // #6712: the tool_result patch fields, so a fixture can assert a result was
+    // attached (and flagged truncated / isError) onto its tool_use bubble.
+    toolResult: m.toolResult,
+    toolResultTruncated: m.toolResultTruncated,
+    toolResultIsError: m.toolResultIsError,
   }))
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3274,6 +3274,16 @@ button.sidebar-token-view-session-row:hover {
   color: var(--text-muted);
 }
 
+/* #6712 — a failed tool_result (codex mcpToolCall / orphan sweep). */
+.tool-group-entry-marker--error {
+  color: var(--accent-red, #d6685f);
+}
+
+.tool-group-entry--error {
+  background: var(--accent-red-light);
+  border-left: 2px solid var(--accent-red, #d6685f);
+}
+
 .tool-group-entry-name {
   color: var(--accent-purple);
   font-weight: 500;

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -47,6 +47,7 @@ export declare const ServerToolResultSchema: z.ZodObject<{
     toolUseId: z.ZodString;
     result: z.ZodAny;
     truncated: z.ZodOptional<z.ZodBoolean>;
+    isError: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const ServerToolInputDeltaSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_input_delta">;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -88,6 +88,11 @@ export const ServerToolResultSchema = z.object({
     toolUseId: z.string(),
     result: z.any(),
     truncated: z.boolean().optional(),
+    // #6712: the result represents a FAILED tool execution (a failed codex
+    // mcpToolCall, or a synthetic orphan-sweep result), so clients can render an
+    // error affordance instead of a plain result. Additive/optional — absent on
+    // older servers and for successful results.
+    isError: z.boolean().optional(),
 });
 // #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use
 // `input`. Emitted between `tool_start` and `tool_result` while the

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -88,10 +88,11 @@ export const ServerToolResultSchema = z.object({
     toolUseId: z.string(),
     result: z.any(),
     truncated: z.boolean().optional(),
-    // #6712: the result represents a FAILED tool execution (a failed codex
+    // #6712: whether the result represents a FAILED tool execution (a failed codex
     // mcpToolCall, or a synthetic orphan-sweep result), so clients can render an
-    // error affordance instead of a plain result. Additive/optional — absent on
-    // older servers and for successful results.
+    // error affordance. Optional: only `true` is meaningful — clients treat a
+    // missing value as false. Older servers and non-mcp tools omit it; codex
+    // mcpToolCall emits it explicitly (`false` on success).
     isError: z.boolean().optional(),
 });
 // #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -98,6 +98,11 @@ export const ServerToolResultSchema = z.object({
   toolUseId: z.string(),
   result: z.any(),
   truncated: z.boolean().optional(),
+  // #6712: the result represents a FAILED tool execution (a failed codex
+  // mcpToolCall, or a synthetic orphan-sweep result), so clients can render an
+  // error affordance instead of a plain result. Additive/optional — absent on
+  // older servers and for successful results.
+  isError: z.boolean().optional(),
 })
 
 // #4080 / #4081: incremental partial-JSON chunk for a streaming tool_use

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -98,10 +98,11 @@ export const ServerToolResultSchema = z.object({
   toolUseId: z.string(),
   result: z.any(),
   truncated: z.boolean().optional(),
-  // #6712: the result represents a FAILED tool execution (a failed codex
+  // #6712: whether the result represents a FAILED tool execution (a failed codex
   // mcpToolCall, or a synthetic orphan-sweep result), so clients can render an
-  // error affordance instead of a plain result. Additive/optional — absent on
-  // older servers and for successful results.
+  // error affordance. Optional: only `true` is meaningful — clients treat a
+  // missing value as false. Older servers and non-mcp tools omit it; codex
+  // mcpToolCall emits it explicitly (`false` on success).
   isError: z.boolean().optional(),
 })
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -370,12 +370,13 @@ export class CodexAppServerSession extends BaseSession {
       this._trackToolResult(item.id)
       if (item.id != null) this._pendingFileChanges.delete(item.id) // #6638: done — release the cached diff
     } else if (item.type === 'mcpToolCall') {
-      // #6684: emit the connector tool's output as a tool_result. A failed call
-      // surfaces error.message as the result TEXT — the wire tool_result carries
-      // no isError field (ServerToolResultSchema is {toolUseId, result,
-      // truncated}), so error styling is out of scope here (tracked in #6712).
+      // #6684/#6712: emit the connector tool's output as a tool_result. A failed
+      // call surfaces error.message as the result text AND flags `isError` (which
+      // now round-trips the wire → clients style the error). Large output is
+      // capped and flagged `truncated`.
       const { result, truncated } = this._summarizeMcpResult(item)
-      this.emit('tool_result', { toolUseId: item.id, result, truncated })
+      const isError = item.status === 'failed' || item.error != null
+      this.emit('tool_result', { toolUseId: item.id, result, truncated, isError })
       this._trackToolResult(item.id)
     } else if (item.type === 'agentMessage') {
       // Fallback: if the final text never arrived as deltas (short replies can
@@ -396,11 +397,11 @@ export class CodexAppServerSession extends BaseSession {
     return tool || server || 'mcp'
   }
 
-  // #6684: reduce an mcpToolCall completion to a { result, truncated } tool_result.
-  // Prefers the connector's error message (failed calls convey failure via this
-  // text, not styling — #6712), then the MCP content array (text parts inline,
-  // non-text parts as a `[type]` marker), then structuredContent, then the bare
-  // status so the card is never blank. Text is bounded by MAX_MCP_RESULT_CHARS.
+  // #6684: reduce an mcpToolCall completion to a { result, truncated } tool_result
+  // (the caller adds `isError` from the item status). Prefers the connector's
+  // error message, then the MCP content array (text parts inline, non-text parts
+  // as a `[type]` marker), then structuredContent, then the bare status so the
+  // card is never blank. Text is bounded by MAX_MCP_RESULT_CHARS.
   _summarizeMcpResult(item) {
     if (item?.error && typeof item.error.message === 'string' && item.error.message) {
       return this._capMcpResult(item.error.message)

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -210,6 +210,11 @@ Object.assign(EVENT_MAP, {
   tool_result: (data) => {
     const msg = { type: 'tool_result', toolUseId: data.toolUseId, result: data.result, truncated: data.truncated }
     if (data.images?.length) msg.images = data.images
+    // #6712: forward the failed-tool flag onto the LIVE wire (this normalizer is
+    // the serialization choke point for both backends). Without it a failed
+    // codex mcpToolCall / orphan-sweep result would render plain live but
+    // error-styled after a history replay (which sends the entry raw).
+    if (typeof data.isError === 'boolean') msg.isError = data.isError
     return { messages: [{ msg }] }
   },
 

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -221,15 +221,16 @@ export class SessionMessageHistory extends EventEmitter {
         const baseTs = typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp)
           ? entry.timestamp
           : Date.now()
-        // `synthetic` / `interrupted` / `isError` / `reason` are diagnostic
-        // hints only — no client code branches on them today, and the wire
-        // schema (`ServerToolResultSchema` in packages/protocol) strips
-        // unknown fields on parse. The behaviour that clears the dashboard's
-        // activeTools entry is driven purely by the `tool_result` type +
-        // matching `toolUseId` going through `handleToolResult.applyToActiveTools`
-        // (store-core/handlers/index.ts). Keep these fields anyway so the
-        // synthetic stays grep-able on disk and a future renderer can show
-        // a distinct "interrupted" badge without a protocol change.
+        // #6712: `isError` is now a first-class wire field
+        // (`ServerToolResultSchema`) that BOTH clients branch on to style a
+        // failed result (a red alert icon / ✕ marker) — so a replayed synthetic
+        // sweep entry surfaces the error affordance too (replay sends the entry
+        // raw). `synthetic` / `interrupted` / `reason` remain diagnostic hints
+        // that no client branches on and the schema strips on parse; kept so the
+        // synthetic stays grep-able on disk and a future renderer can show a
+        // distinct "interrupted" badge without a protocol change. The activeTools
+        // clear is driven purely by the `tool_result` type + matching `toolUseId`
+        // through `handleToolResult.applyToActiveTools`.
         out.push({
           type: 'tool_result',
           toolUseId: entry.toolUseId,

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -344,7 +344,7 @@ function _isSecureRequest(req) {
  *   { type: 'terminal_size', sessionId, cols, rows }   — #5835 Phase 2 authoritative live-PTY grid size; sent to a client on terminal_subscribe and broadcast to all terminal subscribers on a primary-driven terminal_resize so observers re-letterbox to the same grid
  *   { type: 'tool_start',   messageId, toolUseId, tool, input, serverName? } — tool invocation (serverName present for MCP tools)
  *   { type: 'tool_input_delta', messageId, toolUseId, partialJson } — #4080/#4081: incremental partial JSON for the streaming tool_use `input`; concatenate per-toolUseId for the live bubble preview
- *   { type: 'tool_result',  toolUseId, result, truncated, images? }  — tool result (images: [{mediaType, data}])
+ *   { type: 'tool_result',  toolUseId, result, truncated, images?, isError? }  — tool result (images: [{mediaType, data}]; #6712 isError flags a failed tool for the error affordance)
  *   { type: 'mcp_servers',  servers: [{ name, status }] }     — connected MCP servers
  *   { type: 'result',       ... }                     — query stats
  *   { type: 'status',       connected: true }         — connection status

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -144,7 +144,7 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
     cleanup()
   })
 
-  it('a failed mcpToolCall surfaces the error message as the result text (#6712 tracks styling)', () => {
+  it('a failed mcpToolCall surfaces the error message as the result text AND flags isError (#6712)', () => {
     const { s, cleanup } = mkSession()
     const ev = capture(s, ['tool_result'])
     s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
@@ -153,10 +153,22 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
       method: 'item/completed',
       params: { item: { type: 'mcpToolCall', id: 't2', status: 'failed', error: { message: 'connection refused' } } },
     })
-    // The wire tool_result carries no isError (ServerToolResultSchema strips it),
-    // so the failure is conveyed by the error TEXT — assert that, not a flag.
+    // #6712: isError now round-trips the wire so clients can style the failure.
     assert.equal(ev[0][1].result, 'connection refused')
-    assert.equal('isError' in ev[0][1], false, 'no dead isError field on the wire payload')
+    assert.equal(ev[0][1].isError, true)
+    cleanup()
+  })
+
+  it('a successful mcpToolCall flags isError false', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['tool_result'])
+    s._activeTurn = { messageId: 'm1', turnId: null, didStreamStart: false }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'mcpToolCall', id: 't3', server: 'db', tool: 'query' } } })
+    s._onNotification({
+      method: 'item/completed',
+      params: { item: { type: 'mcpToolCall', id: 't3', status: 'completed', result: { content: [{ type: 'text', text: 'ok' }] } } },
+    })
+    assert.equal(ev[0][1].isError, false)
     cleanup()
   })
 

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -365,6 +365,17 @@ describe('EventNormalizer', () => {
       assert.deepEqual(msg.images, images)
     })
 
+    it('forwards isError onto the wire so a failed result round-trips (#6712)', () => {
+      const data = { toolUseId: 'tu1', result: 'connection refused', truncated: false, isError: true }
+      const msg = normalizer.normalize('tool_result', data, makeCtx()).messages[0].msg
+      assert.equal(msg.isError, true)
+    })
+
+    it('omits isError when not a boolean (successful/legacy results carry no flag)', () => {
+      const msg = normalizer.normalize('tool_result', { toolUseId: 'tu1', result: 'ok', truncated: false }, makeCtx()).messages[0].msg
+      assert.equal('isError' in msg, false)
+    })
+
     it('omits images when not present', () => {
       const data = { toolUseId: 'tu1', result: 'text only', truncated: false }
       const result = normalizer.normalize('tool_result', data, makeCtx())

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1614,7 +1614,42 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
     expect: {
       // Both clients attach the result onto the same bubble; assert the bubble
       // is still a single tool_use entry carrying the result text.
-      sessions: { s1: { messages: [{ type: 'tool_use', toolUseId: 'tu-1' }] } },
+      sessions: { s1: { messages: [{ type: 'tool_use', toolUseId: 'tu-1', toolResult: 'file contents here' }] } },
+    },
+  },
+  {
+    // #6712 — a FAILED tool_result (codex mcpToolCall failure / orphan sweep)
+    // flags `isError` on the wire; both clients must attach `toolResultIsError`
+    // (+ the error text) onto the tool_use bubble so the renderers can style it.
+    name: 'tool_result flags isError + truncated onto the tool_use bubble',
+    type: 'tool_result',
+    init: {
+      activeSessionId: 's1',
+      sessions: {
+        s1: {
+          messages: [
+            { id: 'tool-tu-2', type: 'tool_use', tool: 'db/query', toolUseId: 'tu-2', content: '' } as unknown as ChatMessage,
+          ],
+          activeTools: [{ toolUseId: 'tu-2', tool: 'db/query', startedAt: 1 }],
+        },
+      },
+    },
+    message: {
+      type: 'tool_result',
+      sessionId: 's1',
+      toolUseId: 'tu-2',
+      result: 'connection refused',
+      isError: true,
+      truncated: false,
+    },
+    expect: {
+      sessions: {
+        s1: {
+          messages: [
+            { type: 'tool_use', toolUseId: 'tu-2', toolResult: 'connection refused', toolResultIsError: true, toolResultTruncated: false },
+          ],
+        },
+      },
     },
   },
   {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -7243,6 +7243,19 @@ describe('handleToolResult', () => {
     expect(out!.resultText).toBe('visible-text')
   })
 
+  // #6712 — carry isError so a failed tool_result (codex mcpToolCall / orphan
+  // sweep) can be styled by the renderers.
+  it('patches toolResultIsError from a boolean msg.isError', () => {
+    expect(handleToolResult({ toolUseId: 'tu-1', result: 'boom', isError: true }, 's')!.patch.toolResultIsError).toBe(true)
+    expect(handleToolResult({ toolUseId: 'tu-1', result: 'ok', isError: false }, 's')!.patch.toolResultIsError).toBe(false)
+  })
+
+  it('defaults toolResultIsError to false when isError is absent or non-boolean', () => {
+    expect(handleToolResult({ toolUseId: 'tu-1', result: 'ok' }, 's')!.patch.toolResultIsError).toBe(false)
+    // non-boolean coerces to the safe default (matches the truncated guard)
+    expect(handleToolResult({ toolUseId: 'tu-1', result: 'ok', isError: 'true' as unknown as boolean }, 's')!.patch.toolResultIsError).toBe(false)
+  })
+
   it('resolves sessionId from message when present', () => {
     const out = handleToolResult(
       { toolUseId: 'tu-1', sessionId: 'sess-1', result: 'ok' },

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -408,8 +408,8 @@ export interface ToolResultPayload {
  * Otherwise returns a payload with:
  * - `sessionId`: resolved from string-typed `msg.sessionId` falling back to
  *   `activeSessionId`. Non-string values are ignored.
- * - `patch`: `{ toolResult, toolResultTruncated }`, plus `toolResultImages`
- *   only when `msg.images` is a non-empty array.
+ * - `patch`: `{ toolResult, toolResultTruncated, toolResultIsError }`, plus
+ *   `toolResultImages` only when `msg.images` is a non-empty array.
  * - `resultText`: the raw result string (string-validated) for the caller's
  *   terminal preview.
  * - `applyTo(messages)`: locates the matching `tool_use` entry by
@@ -432,6 +432,7 @@ export function handleToolResult(
   const sessionId = msgSessionId || activeSessionId
   const resultText = typeof msg.result === 'string' ? msg.result : ''
   const truncated = typeof msg.truncated === 'boolean' ? msg.truncated : false
+  const isError = typeof msg.isError === 'boolean' ? msg.isError : false
   const images = Array.isArray(msg.images)
     ? (msg.images as ToolResultImage[])
     : undefined
@@ -439,6 +440,7 @@ export function handleToolResult(
   const patch: Partial<ChatMessage> = {
     toolResult: resultText,
     toolResultTruncated: truncated,
+    toolResultIsError: isError,
   }
   if (images?.length) patch.toolResultImages = images
 

--- a/packages/store-core/src/types/chat.ts
+++ b/packages/store-core/src/types/chat.ts
@@ -90,10 +90,11 @@ export interface ChatMessage {
   toolResult?: string;
   toolResultTruncated?: boolean;
   /**
-   * #6712: the tool_result represents a FAILED tool execution (a failed codex
-   * `mcpToolCall`, or a synthetic orphan-sweep result). Renderers can surface an
-   * error affordance (e.g. a red tint / warning icon on the result) instead of a
-   * plain result. Additive: absent on older servers / non-error results.
+   * #6712: whether the tool_result represents a FAILED tool execution (a failed
+   * codex `mcpToolCall`, or a synthetic orphan-sweep result). Renderers surface
+   * an error affordance (red tint / warning icon) when `true`. Optional: only
+   * `true` is meaningful — a missing/`false` value is a normal result. store-core
+   * defaults a missing wire `isError` to `false`.
    */
   toolResultIsError?: boolean;
   /**

--- a/packages/store-core/src/types/chat.ts
+++ b/packages/store-core/src/types/chat.ts
@@ -90,6 +90,13 @@ export interface ChatMessage {
   toolResult?: string;
   toolResultTruncated?: boolean;
   /**
+   * #6712: the tool_result represents a FAILED tool execution (a failed codex
+   * `mcpToolCall`, or a synthetic orphan-sweep result). Renderers can surface an
+   * error affordance (e.g. a red tint / warning icon on the result) instead of a
+   * plain result. Additive: absent on older servers / non-error results.
+   */
+  toolResultIsError?: boolean;
+  /**
    * #4476: structured error code for `type: 'error'` bubbles. Mirrors the
    * `code` field on `ServerMessageSchema` — populated when the server tags
    * an error with a known machine-readable identifier (e.g. `'stream_stall'`


### PR DESCRIPTION
## Summary

Closes #6712 (follow-up from the #6711 / #6684 review).

`ServerToolResultSchema` was `{ toolUseId, result, truncated }` and Zod strips unknown keys, so an `isError` set on a `tool_result` — the orphan-sweep synthetic result, and (originally) the codex `mcpToolCall` failed path — **never reached clients**. A failed tool result was indistinguishable from a success in the UI. This carries `isError` through the whole pipeline.

## Changes

- **protocol** — `ServerToolResultSchema` gains an additive optional `isError`.
- **store-core** — `handleToolResult` reads `msg.isError` → `toolResultIsError` on the tool_use bubble patch (mirrors `toolResultTruncated`); `ChatMessage` type + unit tests. A `tool_result`-with-`isError` **SWITCH_FIXTURE** + both clients' `normalize()` whitelist extended (`toolResult` / `toolResultTruncated` / `toolResultIsError`) so the both-clients patch is now contract-locked (it wasn't before — a pre-existing gap).
- **server** — the codex `mcpToolCall` failed path re-adds `isError` (now that the wire carries it); the existing **orphan-sweep** `isError` now round-trips too.
- **app** (`ActivityGroup`) — a failed result shows a red **alert icon** instead of the green check (`Icon` gains an optional `testID`).
- **dashboard** (`ToolGroup`) — a failed result shows a **✕** marker + a `--error` tint (`data-error` attr for testability).

## Verification (fully covered — no visual-QA-only tail)

Both client renders are verified by **component tests**, not just flagged:
- protocol **358**, store-core **1941** (+ contract-fixture + coverage guards), codex **77** (failed → isError:true, success → false), dashboard **4268** (incl. new `ToolGroup` ✕/`data-error` test), app `ActivityGroup` **15** (error-icon present/absent) + `contract-switch`.

The only non-automated aspect is the exact visual polish (icon glyph / red shade) — the render *logic* (which affordance shows when `toolResultIsError`) is deterministic and unit-tested on both clients.