### PR TITLE
fix(server): stop losing codex cache tokens (field-name mismatch + double-count) (#6692)

### DIFF
--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -439,7 +439,7 @@ export class CodexAppServerSession extends BaseSession {
 
   _mapUsage(params) {
     const u = params?.usage || params || {}
-    const num = (x) => (Number.isFinite(Number(x)) && Number(x) >= 0 ? Number(x) : 0)
+    const num = (x) => { const n = Number(x); return Number.isFinite(n) && n >= 0 ? n : 0 }
     const totalInput = num(u.inputTokens ?? u.input_tokens)
     // #6692: codex/OpenAI reports cached tokens as a SUBSET of the input count,
     // but chroxy's usage model (`session-manager._trackUsage`) accumulates

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -439,10 +439,24 @@ export class CodexAppServerSession extends BaseSession {
 
   _mapUsage(params) {
     const u = params?.usage || params || {}
+    const num = (x) => (Number.isFinite(Number(x)) && Number(x) >= 0 ? Number(x) : 0)
+    const totalInput = num(u.inputTokens ?? u.input_tokens)
+    // #6692: codex/OpenAI reports cached tokens as a SUBSET of the input count,
+    // but chroxy's usage model (`session-manager._trackUsage`) accumulates
+    // input_tokens and cache_read_input_tokens as DISJOINT counters (the
+    // Anthropic convention). Two bugs followed: (1) the cached value was emitted
+    // under `cached_input_tokens`, but `_trackUsage` reads `cache_read_input_tokens`
+    // — so codex cache tokens were silently dropped; (2) had they matched, the
+    // cached portion would double-count (it's already inside input). Fix both:
+    // emit under the key `_trackUsage` reads, and subtract the cached subset from
+    // input so the two counters stay disjoint. `cached_input_tokens` is kept as a
+    // legacy alias for one release for any consumer of the old key.
+    const cacheRead = Math.min(num(u.cachedInputTokens ?? u.cached_input_tokens), totalInput)
     return {
-      input_tokens: u.inputTokens ?? u.input_tokens ?? 0,
-      output_tokens: u.outputTokens ?? u.output_tokens ?? 0,
-      cached_input_tokens: u.cachedInputTokens ?? u.cached_input_tokens ?? 0,
+      input_tokens: Math.max(0, totalInput - cacheRead),
+      output_tokens: num(u.outputTokens ?? u.output_tokens),
+      cache_read_input_tokens: cacheRead,
+      cached_input_tokens: cacheRead,
     }
   }
 

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -234,6 +234,51 @@ describe('CodexAppServerSession — app-server → Chroxy event mapping', () => 
     cleanup()
   })
 
+  // #6692 — codex token usage: emit under the key `_trackUsage` reads
+  // (`cache_read_input_tokens`, not `cached_input_tokens`) and keep input
+  // DISJOINT from the cached subset (OpenAI reports cached inside input).
+  describe('_mapUsage (#6692 codex cache-token fix)', () => {
+    it('emits cache_read_input_tokens and subtracts the cached subset from input', () => {
+      const { s, cleanup } = mkSession()
+      const u = s._mapUsage({ usage: { inputTokens: 1000, outputTokens: 200, cachedInputTokens: 300 } })
+      assert.equal(u.cache_read_input_tokens, 300, 'cached maps to the key _trackUsage reads')
+      assert.equal(u.input_tokens, 700, 'input excludes the cached subset (no double-count)')
+      assert.equal(u.output_tokens, 200)
+      assert.equal(u.cached_input_tokens, 300, 'legacy alias kept one release')
+      cleanup()
+    })
+
+    it('accepts snake_case fields and clamps a cached value larger than input', () => {
+      const { s, cleanup } = mkSession()
+      const u = s._mapUsage({ usage: { input_tokens: 50, output_tokens: 10, cached_input_tokens: 999 } })
+      assert.equal(u.cache_read_input_tokens, 50, 'cached clamped to input')
+      assert.equal(u.input_tokens, 0, 'input never goes negative')
+      cleanup()
+    })
+
+    it('defaults missing / non-finite usage fields to 0', () => {
+      const { s, cleanup } = mkSession()
+      const u = s._mapUsage({})
+      assert.deepEqual(u, { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cached_input_tokens: 0 })
+      const bad = s._mapUsage({ usage: { inputTokens: -5, outputTokens: Infinity, cachedInputTokens: 'x' } })
+      assert.deepEqual(bad, { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cached_input_tokens: 0 })
+      cleanup()
+    })
+
+    it('flows the corrected usage through thread/tokenUsage/updated → turn/completed result', () => {
+      const { s, cleanup } = mkSession()
+      const ev = capture(s, ['result'])
+      s._isBusy = true
+      s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+      s._onNotification({ method: 'thread/tokenUsage/updated', params: { usage: { inputTokens: 800, outputTokens: 100, cachedInputTokens: 200 } } })
+      s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 5 } } })
+      const usage = ev[0][1].usage
+      assert.equal(usage.cache_read_input_tokens, 200)
+      assert.equal(usage.input_tokens, 600)
+      cleanup()
+    })
+  })
+
   it('a short agentMessage with no prior deltas still emits its text (fallback)', () => {
     const { s, cleanup } = mkSession()
     const ev = capture(s, ['stream_start', 'stream_delta'])

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2953,6 +2953,19 @@ describe('SessionManager._trackUsage (#4072)', () => {
     assert.equal(got.turnsBilled, 2)
   })
 
+  it('accumulates codex cache_read_input_tokens into cumulativeUsage (field-name contract, #6692)', () => {
+    // The exact usage shape codex `_mapUsage` now emits after #6692 (input
+    // DISJOINT from the cache_read subset, under the key `_trackUsage` reads).
+    // Guards the cross-module field-name contract that silently dropped codex
+    // cache tokens when the two sides disagreed (`cached_input_tokens` vs
+    // `cache_read_input_tokens`).
+    const { mgr } = makeWiredManager()
+    mgr._trackUsage('s1', { usage: { input_tokens: 700, output_tokens: 100, cache_read_input_tokens: 300 }, cost: null })
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.inputTokens, 700)
+    assert.equal(got.cacheReadTokens, 300, 'codex cache tokens now land in cumulativeUsage')
+  })
+
   it('emits session_usage on every priced result event', () => {
     const { mgr, session } = makeWiredManager()
     const events = captureSessionUsage(mgr)


### PR DESCRIPTION
## Summary

The M-1 "ships first, ungated" slice of #6692 — a concrete usage-accounting **bug fix** (does not close #6692; the per-model foundation remains, see below).

Codex token usage had two bugs feeding `session-manager._trackUsage`:

1. **Field-name mismatch** — `codex-app-server-session.js` `_mapUsage` emitted the cached count under **`cached_input_tokens`**, but `_trackUsage` reads **`cache_read_input_tokens`** (`session-manager.js:3036`). So every codex session's cache tokens were **silently dropped** from `cumulativeUsage`.
2. **Double-count risk** — codex/OpenAI reports cached tokens as a **subset** of the input count, while chroxy's usage model accumulates `input_tokens` and `cache_read_input_tokens` as **disjoint** counters (the Anthropic convention — see `_trackUsage`). Had the keys matched, the cached portion would have double-counted.

## Fix

`_mapUsage` now emits under `cache_read_input_tokens` **and** subtracts the cached subset from input so the two counters stay disjoint: `input = max(0, total_input − cached)`, `cache_read = min(cached, total_input)`. `cached_input_tokens` is kept as a legacy alias for one release.

### Phase-0 (a) — resolved by analysis, not a live capture

The "is cached inclusive of input?" question is answered authoritatively from two documented conventions: (i) chroxy's `_trackUsage` accumulates `inputTokens` and `cacheReadTokens` as **separate** counters (Anthropic: input excludes cache); (ii) OpenAI's usage schema reports `cached_tokens` as a **subset** of `prompt_tokens`. So codex's input includes cached → subtract to make them disjoint and consistent with every other provider. (A real payload would confirm, but this is the correct default under both conventions, not a guess.)

## Tests

`codex-app-server-session.test.js` (77 → **81**): direct `_mapUsage` (cache→`cache_read`, input disjoint, legacy alias); snake_case + cached-larger-than-input clamp; missing/non-finite → 0; and the wire path `thread/tokenUsage/updated → turn/completed` result carrying the corrected usage. eslint clean.

## Remaining on #6692 (per-model foundation — no consumer until the orchestration ledger)

`usage-normalize.js` (`normalizeSdkModelUsage`/`synthesizeModelUsage`/`isMeterableProvider`) + additive per-model `modelUsage`/`numTurns`/`apiDurationMs` on all five providers' result payloads. Deferred because it has no visible effect until the ledger (later #6691 steps) consumes it, whereas this cache-token fix is immediately correct-ing live usage accounting.