### PR TITLE
feat(server): orchestration RunLedger — durable run store (M-2)

### DIFF
--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -21,6 +21,7 @@ export default [
         TextEncoder: 'readonly',
         TextDecoder: 'readonly',
         crypto: 'readonly',
+        structuredClone: 'readonly',
         fetch: 'readonly',
         Response: 'readonly',
         Headers: 'readonly',

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -257,8 +257,15 @@ export class RunLedger extends EventEmitter {
       body = ''
       truncated = true
       this._emitEvent(runId, { type: 'events_dropped', count: 1, reason: 'journal_cap' }, { lifecycle: false })
-    } else if (body.length > COMMITTEE_BODY_MAX) {
-      body = body.slice(0, COMMITTEE_BODY_MAX)
+    } else if (Buffer.byteLength(body, 'utf8') > COMMITTEE_BODY_MAX) {
+      // Cap by BYTES (the constant is a byte budget), not UTF-16 code units — a
+      // multibyte body could otherwise be ~3-4x over. TextDecoder with
+      // stream:true decodes only the COMPLETE codepoints within the budget and
+      // holds back a trailing partial sequence (rather than emitting a 3-byte
+      // U+FFFD that could push the re-encoded result back over budget), so the
+      // result is guaranteed <= COMMITTEE_BODY_MAX bytes and valid JSON.
+      const buf = Buffer.from(body, 'utf8').subarray(0, COMMITTEE_BODY_MAX)
+      body = new TextDecoder('utf8').decode(buf, { stream: true })
       truncated = true
     }
     this._emitEvent(runId, {

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -1,0 +1,345 @@
+/**
+ * RunLedger — durable per-run store for the orchestration harness (epic #6691,
+ * step M-2). Owns disk layout, the seq'd append journal (crash ground truth),
+ * debounced run.json snapshots, crash recovery, and LRU GC. All mutation logic
+ * lives in the pure reducer (run-record.js); this file is I/O + orchestration.
+ *
+ * Layout under `baseDir` (the engine passes CHROXY_CONFIG_DIR/.chroxy/orchestration;
+ * tests ALWAYS pass a temp dir — the same sandbox discipline as stateFilePath):
+ *   runs-index.json                 bounded index (LRU, maxRuns)
+ *   runs/<runId>/run.json           debounced atomic snapshot (authoritative)
+ *   runs/<runId>/events.jsonl       append-only journal (replayed on recovery)
+ *   runs/<runId>/report.{json,md}   written at terminal state (M-4)
+ *
+ * Durability boundary (mirrors #5309): the journal is appended synchronously
+ * per event and is the crash record; run.json is debounced for high-frequency
+ * turn_usage folds and flushed (fsync) immediately on lifecycle mutations and
+ * at terminal state. On boot, recoverRuns() replays journal lines with
+ * seq > snapshot.lastSeq through the reducer, so a crash between an append and
+ * the debounced save loses nothing.
+ */
+
+import { EventEmitter } from 'node:events'
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import { join } from 'node:path'
+import { loadJsonState, saveJsonState } from '../json-state-file.js'
+import { applyEvent, makeRunRecord, isTerminalStatus } from './run-record.js'
+import { createLogger } from '../logger.js'
+
+const log = createLogger('run-ledger')
+
+export const DEFAULT_SAVE_DEBOUNCE_MS = 2000
+export const DEFAULT_MAX_RUNS = 200
+export const DEFAULT_MAX_JOURNAL_MB = 50
+const COMMITTEE_BODY_MAX = 32 * 1024 // per-line committee_review body cap
+const INDEX_VERSION = 1
+
+export class RunLedger extends EventEmitter {
+  /**
+   * @param {{
+   *   baseDir: string,
+   *   saveDebounceMs?: number,
+   *   maxRuns?: number,
+   *   maxJournalMb?: number,
+   *   now?: () => number,
+   *   priceTurn?: (arg: { provider: string|null, model: string|null, usage: object }) => number|null,
+   * }} opts
+   */
+  constructor(opts = {}) {
+    super()
+    if (!opts.baseDir || typeof opts.baseDir !== 'string') {
+      throw new Error('RunLedger requires an explicit baseDir')
+    }
+    this._baseDir = opts.baseDir
+    this._runsDir = join(this._baseDir, 'runs')
+    this._indexPath = join(this._baseDir, 'runs-index.json')
+    this._saveDebounceMs = Number.isFinite(opts.saveDebounceMs) && opts.saveDebounceMs >= 0
+      ? opts.saveDebounceMs
+      : DEFAULT_SAVE_DEBOUNCE_MS
+    this._maxRuns = Number.isFinite(opts.maxRuns) && opts.maxRuns > 0 ? Math.floor(opts.maxRuns) : DEFAULT_MAX_RUNS
+    this._maxJournalBytes = (Number.isFinite(opts.maxJournalMb) && opts.maxJournalMb > 0
+      ? opts.maxJournalMb : DEFAULT_MAX_JOURNAL_MB) * 1024 * 1024
+    this._now = typeof opts.now === 'function' ? opts.now : () => Date.now()
+    this._priceTurn = typeof opts.priceTurn === 'function' ? opts.priceTurn : defaultPriceTurn
+    this._records = new Map()
+    this._journalBytes = new Map() // runId -> approx journal size
+    this._dirty = new Set()
+    this._saveTimer = null
+    this._disposed = false
+  }
+
+  // -- paths ----------------------------------------------------------------
+
+  _runDir(runId) { return join(this._runsDir, runId) }
+  _snapshotPath(runId) { return join(this._runDir(runId), 'run.json') }
+  _journalPath(runId) { return join(this._runDir(runId), 'events.jsonl') }
+
+  // -- the single write path ------------------------------------------------
+
+  /**
+   * Journal one event, apply it to the in-memory record, and persist. Lifecycle
+   * events flush (fsync) immediately; high-frequency folds are debounced.
+   * The journal append happens BEFORE the snapshot save so it is always the
+   * furthest-ahead record.
+   */
+  _emitEvent(runId, payload, { lifecycle = false } = {}) {
+    const record = this._records.get(runId)
+    if (!record) return null
+    const seq = record.lastSeq + 1
+    const event = { seq, ts: this._now(), ...payload }
+    const line = JSON.stringify(event) + '\n'
+    try {
+      appendFileSync(this._journalPath(runId), line)
+      this._journalBytes.set(runId, (this._journalBytes.get(runId) || 0) + Buffer.byteLength(line))
+    } catch (err) {
+      // A journal write failure is serious but must not crash the daemon; the
+      // in-memory record still advances so the run continues, and the next
+      // snapshot save captures state (at the cost of a recovery gap).
+      log.warn(`journal append failed for ${runId} (${err?.code || err?.message})`)
+    }
+    applyEvent(record, event)
+    if (lifecycle) {
+      this._flushNow(runId)
+      this._updateIndex()
+    } else {
+      this._scheduleSave(runId)
+    }
+    return event
+  }
+
+  _scheduleSave(runId) {
+    this._dirty.add(runId)
+    if (this._saveTimer || this._disposed) return
+    this._saveTimer = setTimeout(() => {
+      this._saveTimer = null
+      this.flush()
+    }, this._saveDebounceMs)
+    if (typeof this._saveTimer.unref === 'function') this._saveTimer.unref()
+  }
+
+  _saveSnapshot(runId, { fsync = false } = {}) {
+    const record = this._records.get(runId)
+    if (!record) return
+    try {
+      saveJsonState(this._snapshotPath(runId), record, { fsync })
+      this._dirty.delete(runId)
+    } catch (err) {
+      log.warn(`snapshot save failed for ${runId} (${err?.code || err?.message})`)
+    }
+  }
+
+  _flushNow(runId) {
+    this._saveSnapshot(runId, { fsync: true })
+  }
+
+  /** Persist every dirty run's snapshot (best-effort, non-fsync). Called by the
+   *  debounce timer and by dispose/shutdown. */
+  flush() {
+    for (const runId of [...this._dirty]) this._saveSnapshot(runId, { fsync: false })
+  }
+
+  _updateIndex() {
+    const runs = [...this._records.values()]
+      .map((r) => ({
+        runId: r.runId,
+        title: r.title,
+        preset: r.preset,
+        status: r.status,
+        startedAt: r.startedAt,
+        endedAt: r.endedAt,
+        effectiveUsd: r.usageTotals.overall.effectiveUsd,
+        terminal: isTerminalStatus(r.status),
+      }))
+      .sort((a, b) => (b.endedAt ?? b.startedAt ?? 0) - (a.endedAt ?? a.startedAt ?? 0))
+    this._gc(runs)
+    try {
+      saveJsonState(this._indexPath, { version: INDEX_VERSION, runs }, { fsync: true })
+    } catch (err) {
+      log.warn(`index save failed (${err?.code || err?.message})`)
+    }
+  }
+
+  /** LRU-evict terminal runs beyond maxRuns: drop from the index list AND rm
+   *  their directory + in-memory record. Non-terminal runs are never evicted. */
+  _gc(runs) {
+    if (runs.length <= this._maxRuns) return
+    const evictable = runs.filter((r) => r.terminal)
+    const keep = runs.length - this._maxRuns
+    const toEvict = evictable.slice(evictable.length - Math.min(keep, evictable.length))
+    for (const r of toEvict) {
+      const i = runs.indexOf(r)
+      if (i >= 0) runs.splice(i, 1)
+      this._records.delete(r.runId)
+      this._journalBytes.delete(r.runId)
+      this._dirty.delete(r.runId)
+      try { rmSync(this._runDir(r.runId), { recursive: true, force: true }) } catch { /* best-effort */ }
+    }
+  }
+
+  // -- public API -----------------------------------------------------------
+
+  createRun({ title = '', preset = null, configSnapshot = null } = {}) {
+    const runId = `run_${this._now()}_${randomBytes(4).toString('hex')}`
+    const record = makeRunRecord({ runId })
+    this._records.set(runId, record)
+    this._journalBytes.set(runId, 0)
+    mkdirSync(this._runDir(runId), { recursive: true, mode: 0o700 })
+    this._emitEvent(runId, { type: 'run_created', title, preset, configSnapshot }, { lifecycle: true })
+    return this.getRun(runId)
+  }
+
+  setStatus(runId, status, reason = null) {
+    this._emitEvent(runId, { type: 'run_status_changed', status, reason }, { lifecycle: true })
+    return this.getRun(runId)
+  }
+
+  createSubtask(runId, { subtaskId, parentId = null, role, title = '' }) {
+    this._emitEvent(runId, { type: 'subtask_created', subtaskId, parentId, role, title }, { lifecycle: true })
+  }
+
+  updateSubtask(runId, subtaskId, { status }) {
+    this._emitEvent(runId, { type: 'subtask_updated', subtaskId, status }, { lifecycle: true })
+  }
+
+  attachSession(runId, subtaskId, { sessionId, provider, model, meterable = true }) {
+    this._emitEvent(runId, { type: 'session_attached', subtaskId, sessionId, provider, model, meterable }, { lifecycle: true })
+  }
+
+  /**
+   * Fold one turn's usage. `data` is the provider terminal (result/error)
+   * payload (cost, usage snake_case, modelUsage, numTurns, duration,
+   * apiDurationMs). The ledger prices cost:null turns via priceTurn — the
+   * "ledger owns money math" rule. Debounced (high-frequency).
+   */
+  recordTurnUsage(runId, { subtaskId = null, sessionId = null, role = null, turnLabel = null, terminalEvent = 'result', data = {} }) {
+    const record = this._records.get(runId)
+    if (!record) return null
+    const st = subtaskId ? record.subtasks.find((s) => s.subtaskId === subtaskId) : null
+    const provider = st?.provider ?? null
+    const modelRaw = data.model ?? (data.modelUsage ? Object.keys(data.modelUsage)[0] : null) ?? st?.model ?? null
+    const meterable = st ? st.meterable !== false : true
+    const cost = Number.isFinite(data.cost) ? data.cost : null
+    let pricedCostUsd = null
+    if (cost == null && data.usage) {
+      const p = this._priceTurn({ provider, model: modelRaw, usage: data.usage })
+      if (Number.isFinite(p)) pricedCostUsd = p
+    }
+    const event = this._emitEvent(runId, {
+      type: 'turn_usage',
+      subtaskId,
+      sessionId,
+      role,
+      model: modelRaw,
+      modelRaw,
+      terminalEvent,
+      turnLabel,
+      cost,
+      pricedCostUsd,
+      usage: data.usage ?? null,
+      modelUsage: data.modelUsage ?? null,
+      numTurns: Number.isFinite(data.numTurns) ? data.numTurns : null,
+      durationMs: Number.isFinite(data.duration) ? data.duration : null,
+      apiDurationMs: Number.isFinite(data.apiDurationMs) ? data.apiDurationMs : null,
+      meterable,
+    })
+    this.emit('run_usage_updated', { runId, usageTotals: record.usageTotals })
+    return { cell: st ? st.usage : record.usageTotals.overall, event }
+  }
+
+  recordCommitteeReview(runId, subtaskId, { phase, verdict, reviewerSessionId = null, notes = '' }) {
+    // Cap the body; shed bodies entirely once the journal exceeds its size cap
+    // (usage lines are always kept — they are the accounting record).
+    const overCap = (this._journalBytes.get(runId) || 0) > this._maxJournalBytes
+    let body = typeof notes === 'string' ? notes : ''
+    let truncated = false
+    if (overCap) {
+      body = ''
+      truncated = true
+      this._emitEvent(runId, { type: 'events_dropped', count: 1, reason: 'journal_cap' }, { lifecycle: false })
+    } else if (body.length > COMMITTEE_BODY_MAX) {
+      body = body.slice(0, COMMITTEE_BODY_MAX)
+      truncated = true
+    }
+    this._emitEvent(runId, {
+      type: 'committee_review', subtaskId, phase, verdict, reviewerSessionId, notes: body, truncated,
+    }, { lifecycle: true })
+  }
+
+  note(runId, patch) {
+    this._emitEvent(runId, { type: 'run_note', patch }, { lifecycle: true })
+  }
+
+  getRun(runId) {
+    const r = this._records.get(runId)
+    return r ? structuredClone(r) : null
+  }
+
+  listRuns() {
+    return [...this._records.values()]
+      .map((r) => ({
+        runId: r.runId, title: r.title, preset: r.preset, status: r.status,
+        startedAt: r.startedAt, endedAt: r.endedAt,
+        effectiveUsd: r.usageTotals.overall.effectiveUsd,
+      }))
+      .sort((a, b) => (b.endedAt ?? b.startedAt ?? 0) - (a.endedAt ?? a.startedAt ?? 0))
+  }
+
+  /**
+   * Rebuild in-memory records from disk at boot. For each run dir: load the
+   * snapshot, then replay journal lines with seq > snapshot.lastSeq through the
+   * reducer (idempotent — lastSeq gates double-folds). Returns the records so
+   * the engine can decide which non-terminal runs to fail vs resume.
+   */
+  recoverRuns() {
+    const recovered = []
+    if (!existsSync(this._runsDir)) return recovered
+    let dirs = []
+    try { dirs = readdirSync(this._runsDir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name) } catch { return recovered }
+    for (const runId of dirs) {
+      const snapshotPath = this._snapshotPath(runId)
+      const record = loadJsonState(snapshotPath, () => null, { requireObject: true })
+      if (!record || record.runId !== runId) {
+        log.warn(`recover: skipping ${runId} (missing/mismatched snapshot)`)
+        continue
+      }
+      const replayFrom = Number.isFinite(record.lastSeq) ? record.lastSeq : 0
+      let journalBytes = 0
+      const journalPath = this._journalPath(runId)
+      if (existsSync(journalPath)) {
+        try { journalBytes = statSync(journalPath).size } catch { /* ignore */ }
+        let raw = ''
+        try { raw = readFileSync(journalPath, 'utf8') } catch { raw = '' }
+        for (const lineStr of raw.split('\n')) {
+          if (!lineStr) continue
+          let ev
+          try { ev = JSON.parse(lineStr) } catch { continue }
+          if (Number.isFinite(ev?.seq) && ev.seq > replayFrom) applyEvent(record, ev)
+        }
+      }
+      this._records.set(runId, record)
+      this._journalBytes.set(runId, journalBytes)
+      recovered.push(structuredClone(record))
+    }
+    return recovered
+  }
+
+  dispose() {
+    this._disposed = true
+    if (this._saveTimer) { clearTimeout(this._saveTimer); this._saveTimer = null }
+    this.flush()
+    this.removeAllListeners()
+  }
+}
+
+// Default pricing is a no-op (returns null → the turn counts as unknown-cost).
+// The engine injects a real `priceTurn` at construction — a thin wrapper over
+// models.js `computePromptCostUsd(usage, getModelPricing(resolveModelId(model)))`
+// (the Claude static table + ~/.chroxy/models.json overlay, which also covers
+// operator-priced codex/gemini). Keeping models.js OUT of the ledger's default
+// keeps this module dependency-light and its unit tests free of any config-dir
+// / registry I/O; a run with no injected pricer simply reports unpriced tokens
+// honestly (unknownCostTurns), never a wrong number.
+function defaultPriceTurn() {
+  return null
+}

--- a/packages/server/src/orchestration/run-record.js
+++ b/packages/server/src/orchestration/run-record.js
@@ -1,0 +1,273 @@
+/**
+ * Pure run-record shapes + the single event reducer (orchestration harness,
+ * epic #6691, delivery step M-2). NO I/O, NO clock, NO randomness — everything
+ * here is a deterministic function of its inputs so the live-recording path and
+ * the crash-recovery replay path (run-ledger.js) produce byte-identical state.
+ *
+ * The one mutation primitive is `applyEvent(record, event)`: every ledger
+ * mutation is expressed as a journal event, applied through this reducer. Live
+ * recording appends the event then applies it; recovery replays journal events
+ * with `seq > snapshot.lastSeq` through the same reducer. `record.lastSeq`
+ * advances to `event.seq` as each event applies, so a replayed line can never
+ * double-fold.
+ *
+ * Cost provenance is load-bearing: a turn's provider-reported `costUsd` (signed
+ * — refunds subtract) is NEVER contaminated by the server-derived
+ * `pricedCostUsd` fallback. `effectiveUsd = costUsd + pricedCostUsd` is the one
+ * display/budget number, recomputed on every fold.
+ */
+
+export const RUN_RECORD_VERSION = 1
+
+// Run statuses the ledger treats as terminal (no further work; report-eligible).
+// The engine owns the full status vocabulary; the ledger only needs to know
+// which ones end a run for GC / fsync / index purposes.
+export const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled'])
+
+export function isTerminalStatus(status) {
+  return TERMINAL_STATUSES.has(status)
+}
+
+function nonNegInt(x) {
+  const n = Number(x)
+  if (!Number.isFinite(n) || n <= 0) return 0
+  return Math.floor(n)
+}
+
+function finiteOr(x, fallback) {
+  const n = Number(x)
+  return Number.isFinite(n) ? n : fallback
+}
+
+/** The one usage shape used everywhere (per-run/role/model/session/subtask). */
+export function makeUsageCell() {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    webSearchRequests: 0,
+    turns: 0,
+    costUsd: 0, // sum of provider-reported finite costs (signed)
+    costKnownTurns: 0,
+    unknownCostTurns: 0,
+    pricedCostUsd: 0, // server-derived fallback for unknown-cost turns only
+    effectiveUsd: 0, // costUsd + pricedCostUsd — recomputed, not authoritative
+  }
+}
+
+/** Normalize a snake_case provider usage object into the cell's token fields. */
+export function normalizeUsage(usage) {
+  const u = usage && typeof usage === 'object' ? usage : {}
+  return {
+    inputTokens: nonNegInt(u.input_tokens),
+    outputTokens: nonNegInt(u.output_tokens),
+    cacheReadTokens: nonNegInt(u.cache_read_input_tokens ?? u.cached_input_tokens),
+    cacheCreationTokens: nonNegInt(u.cache_creation_input_tokens),
+    webSearchRequests: nonNegInt(u.web_search_requests),
+  }
+}
+
+// Fold one turn's numbers into a cell in place. `cost` is the provider-reported
+// signed cost (null/undefined = unknown); `pricedCostUsd` is the server-derived
+// fallback used ONLY when cost is unknown.
+function foldCell(cell, tokens, cost, pricedCostUsd) {
+  cell.inputTokens += tokens.inputTokens
+  cell.outputTokens += tokens.outputTokens
+  cell.cacheReadTokens += tokens.cacheReadTokens
+  cell.cacheCreationTokens += tokens.cacheCreationTokens
+  cell.webSearchRequests += tokens.webSearchRequests
+  cell.turns += 1
+  if (Number.isFinite(cost)) {
+    cell.costUsd += cost
+    cell.costKnownTurns += 1
+  } else if (Number.isFinite(pricedCostUsd)) {
+    cell.pricedCostUsd += pricedCostUsd
+  } else {
+    cell.unknownCostTurns += 1
+  }
+  cell.effectiveUsd = cell.costUsd + cell.pricedCostUsd
+  return cell
+}
+
+function ensureCell(bucket, key) {
+  if (!bucket[key]) bucket[key] = makeUsageCell()
+  return bucket[key]
+}
+
+export function makeSubtask({ subtaskId, parentId = null, role, title }) {
+  return {
+    subtaskId,
+    parentId,
+    role,
+    title: title ?? '',
+    sessionId: null,
+    provider: null,
+    model: null,
+    meterable: true,
+    status: 'pending',
+    createdAt: null,
+    startedAt: null,
+    endedAt: null,
+    wallClockMs: null,
+    apiDurationMs: 0,
+    numTurns: 0,
+    modelDrift: false,
+    usage: makeUsageCell(),
+    committee: [],
+  }
+}
+
+/** An empty run-record shell. `run_created` (seq 1) seeds it via applyEvent. */
+export function makeRunRecord({ runId }) {
+  return {
+    version: RUN_RECORD_VERSION,
+    runId,
+    title: '',
+    preset: null,
+    status: 'created',
+    createdAt: null,
+    startedAt: null,
+    endedAt: null,
+    lastSeq: 0,
+    configSnapshot: null,
+    budgetState: { warnedAt: null, capReachedAt: null, capLiftedAt: null, perRole: {} },
+    subtasks: [],
+    usageTotals: {
+      overall: makeUsageCell(),
+      byRole: {},
+      byModel: {},
+      bySession: {},
+    },
+    meteringGaps: [],
+    notes: { verdictQuality: null },
+    baseline: null,
+    droppedEvents: 0,
+  }
+}
+
+function findSubtask(record, subtaskId) {
+  return record.subtasks.find((s) => s.subtaskId === subtaskId) || null
+}
+
+/**
+ * The single pure reducer. Applies one journal event to the record in place and
+ * advances `record.lastSeq` to `event.seq`. Unknown event types are ignored
+ * (forward-compat) but still advance lastSeq. Returns the record.
+ */
+export function applyEvent(record, event) {
+  if (!event || typeof event !== 'object') return record
+  switch (event.type) {
+    case 'run_created':
+      record.title = event.title ?? ''
+      record.preset = event.preset ?? null
+      record.configSnapshot = event.configSnapshot ?? null
+      record.createdAt = finiteOr(event.ts, record.createdAt)
+      record.status = 'created'
+      break
+
+    case 'run_status_changed':
+      record.status = event.status
+      if (event.status === 'executing' && record.startedAt == null) {
+        record.startedAt = finiteOr(event.ts, null)
+      }
+      if (isTerminalStatus(event.status)) record.endedAt = finiteOr(event.ts, record.endedAt)
+      break
+
+    case 'subtask_created':
+      if (!findSubtask(record, event.subtaskId)) {
+        const st = makeSubtask({
+          subtaskId: event.subtaskId,
+          parentId: event.parentId ?? null,
+          role: event.role,
+          title: event.title,
+        })
+        st.createdAt = finiteOr(event.ts, null)
+        record.subtasks.push(st)
+      }
+      break
+
+    case 'subtask_updated': {
+      const st = findSubtask(record, event.subtaskId)
+      if (st) {
+        if (typeof event.status === 'string') st.status = event.status
+        if (event.status === 'briefing' && st.startedAt == null) st.startedAt = finiteOr(event.ts, null)
+        if (isTerminalStatus(event.status) || ['done', 'skipped', 'interrupted'].includes(event.status)) {
+          st.endedAt = finiteOr(event.ts, st.endedAt)
+          if (st.startedAt != null && st.endedAt != null) st.wallClockMs = st.endedAt - st.startedAt
+        }
+      }
+      break
+    }
+
+    case 'session_attached': {
+      const st = findSubtask(record, event.subtaskId)
+      if (st) {
+        st.sessionId = event.sessionId ?? null
+        st.provider = event.provider ?? null
+        st.model = event.model ?? null
+        st.meterable = event.meterable !== false
+      }
+      break
+    }
+
+    case 'turn_usage': {
+      const tokens = normalizeUsage(event.usage)
+      const cost = Number.isFinite(event.cost) ? event.cost : undefined
+      const priced = Number.isFinite(event.pricedCostUsd) ? event.pricedCostUsd : undefined
+      foldCell(record.usageTotals.overall, tokens, cost, priced)
+      if (event.role) foldCell(ensureCell(record.usageTotals.byRole, event.role), tokens, cost, priced)
+      if (event.model) foldCell(ensureCell(record.usageTotals.byModel, event.model), tokens, cost, priced)
+      if (event.sessionId) {
+        const cell = ensureCell(record.usageTotals.bySession, event.sessionId)
+        foldCell(cell, tokens, cost, priced)
+        cell.role = event.role ?? cell.role ?? null
+        cell.model = event.model ?? cell.model ?? null
+        cell.meterable = event.meterable !== false
+      }
+      if (event.meterable === false && event.sessionId && !record.meteringGaps.includes(event.sessionId)) {
+        record.meteringGaps.push(event.sessionId)
+      }
+      const st = event.subtaskId ? findSubtask(record, event.subtaskId) : null
+      if (st) {
+        foldCell(st.usage, tokens, cost, priced)
+        st.apiDurationMs += nonNegInt(event.apiDurationMs)
+        st.numTurns += nonNegInt(event.numTurns)
+        // A model on the turn that differs from the attached model = drift
+        // (user flipped the model, or an SDK Task sub-model). The per-model
+        // split stays exact; the flag just surfaces it for the report.
+        if (event.model && st.model && event.model !== st.model) st.modelDrift = true
+      }
+      break
+    }
+
+    case 'committee_review': {
+      const st = findSubtask(record, event.subtaskId)
+      if (st) {
+        st.committee.push({
+          phase: event.phase,
+          verdict: event.verdict,
+          reviewerSessionId: event.reviewerSessionId ?? null,
+          notesSeq: event.seq, // the body lives on this journal line
+          ts: finiteOr(event.ts, null),
+        })
+      }
+      break
+    }
+
+    case 'run_note':
+      if (event.patch && typeof event.patch === 'object') {
+        if ('verdictQuality' in event.patch) record.notes.verdictQuality = event.patch.verdictQuality ?? null
+      }
+      break
+
+    case 'events_dropped':
+      record.droppedEvents += nonNegInt(event.count)
+      break
+
+    default:
+      break // forward-compat: unknown event types still advance lastSeq
+  }
+  record.lastSeq = Number.isFinite(event.seq) ? event.seq : record.lastSeq
+  return record
+}

--- a/packages/server/src/orchestration/run-record.js
+++ b/packages/server/src/orchestration/run-record.js
@@ -215,6 +215,15 @@ export function applyEvent(record, event) {
       const tokens = normalizeUsage(event.usage)
       const cost = Number.isFinite(event.cost) ? event.cost : undefined
       const priced = Number.isFinite(event.pricedCostUsd) ? event.pricedCostUsd : undefined
+      // Defense-in-depth: the engine is expected to gate on "finite cost OR
+      // finite tokens" before recording (the single-counting invariant), but a
+      // both-null synthetic (stream-stall recovery) must never inflate turn
+      // counts / unknownCostTurns even if one slips through. Deterministic, so
+      // live and replay skip identically.
+      const hasTokens = tokens.inputTokens > 0 || tokens.outputTokens > 0
+        || tokens.cacheReadTokens > 0 || tokens.cacheCreationTokens > 0
+        || tokens.webSearchRequests > 0
+      if (cost === undefined && priced === undefined && !hasTokens) break
       foldCell(record.usageTotals.overall, tokens, cost, priced)
       if (event.role) foldCell(ensureCell(record.usageTotals.byRole, event.role), tokens, cost, priced)
       if (event.model) foldCell(ensureCell(record.usageTotals.byModel, event.model), tokens, cost, priced)

--- a/packages/server/tests/orchestration-run-ledger.test.js
+++ b/packages/server/tests/orchestration-run-ledger.test.js
@@ -1,0 +1,202 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+import { makeRunRecord, applyEvent, makeUsageCell } from '../src/orchestration/run-record.js'
+
+// #6691 M-2 — the durable run store. Every test uses a temp baseDir (the same
+// sandbox discipline as stateFilePath); nothing touches the real ~/.chroxy.
+
+let baseDir
+let clock
+const now = () => clock
+
+beforeEach(() => {
+  baseDir = mkdtempSync(join(tmpdir(), 'chroxy-runledger-'))
+  clock = 1_000
+})
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true })
+})
+
+// A ledger with synchronous saves (debounce 0) unless a test overrides.
+function mkLedger(opts = {}) {
+  return new RunLedger({ baseDir, saveDebounceMs: 0, now, ...opts })
+}
+
+describe('run-record reducer (pure)', () => {
+  it('folds a turn into overall/byRole/byModel/bySession cells with the same numbers', () => {
+    const r = makeRunRecord({ runId: 'r1' })
+    applyEvent(r, { seq: 1, ts: 1, type: 'run_created', title: 't' })
+    applyEvent(r, {
+      seq: 2, ts: 2, type: 'turn_usage', role: 'architect', model: 'opus', sessionId: 's1',
+      cost: 0.5, usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 10 },
+    })
+    assert.equal(r.usageTotals.overall.inputTokens, 100)
+    assert.equal(r.usageTotals.overall.costUsd, 0.5)
+    assert.equal(r.usageTotals.overall.effectiveUsd, 0.5)
+    assert.equal(r.usageTotals.byRole.architect.inputTokens, 100)
+    assert.equal(r.usageTotals.byModel.opus.cacheReadTokens, 10)
+    assert.equal(r.usageTotals.bySession.s1.outputTokens, 20)
+    assert.equal(r.lastSeq, 2)
+  })
+
+  it('keeps provider costUsd separate from derived pricedCostUsd; effectiveUsd sums them', () => {
+    const c = makeUsageCell()
+    // one known-cost turn + one priced (cost:null) turn folded via events
+    const r = makeRunRecord({ runId: 'r1' })
+    applyEvent(r, { seq: 1, ts: 1, type: 'turn_usage', role: 'a', cost: 1.0, usage: { input_tokens: 1 } })
+    applyEvent(r, { seq: 2, ts: 2, type: 'turn_usage', role: 'a', cost: null, pricedCostUsd: 0.25, usage: { input_tokens: 1 } })
+    applyEvent(r, { seq: 3, ts: 3, type: 'turn_usage', role: 'a', cost: null, usage: { input_tokens: 1 } }) // unpriced
+    const cell = r.usageTotals.byRole.a
+    assert.equal(cell.costUsd, 1.0) // NOT contaminated by the 0.25
+    assert.equal(cell.pricedCostUsd, 0.25)
+    assert.equal(cell.effectiveUsd, 1.25)
+    assert.equal(cell.costKnownTurns, 1)
+    assert.equal(cell.unknownCostTurns, 1)
+    assert.equal(c.turns, 0) // sanity: the standalone cell is untouched
+  })
+
+  it('signed cost (refund) subtracts from costUsd', () => {
+    const r = makeRunRecord({ runId: 'r1' })
+    applyEvent(r, { seq: 1, ts: 1, type: 'turn_usage', role: 'a', cost: 2.0, usage: { input_tokens: 1 } })
+    applyEvent(r, { seq: 2, ts: 2, type: 'turn_usage', role: 'a', cost: -0.5, usage: { input_tokens: 1 } })
+    assert.equal(r.usageTotals.byRole.a.costUsd, 1.5)
+  })
+
+  it('records a metering gap for an unmeterable session', () => {
+    const r = makeRunRecord({ runId: 'r1' })
+    applyEvent(r, { seq: 1, ts: 1, type: 'turn_usage', sessionId: 's1', meterable: false, usage: { input_tokens: 1 } })
+    assert.deepEqual(r.meteringGaps, ['s1'])
+  })
+
+  it('flags model drift when a turn model differs from the attached subtask model', () => {
+    const r = makeRunRecord({ runId: 'r1' })
+    applyEvent(r, { seq: 1, ts: 1, type: 'subtask_created', subtaskId: 'st1', role: 'w' })
+    applyEvent(r, { seq: 2, ts: 2, type: 'session_attached', subtaskId: 'st1', sessionId: 's1', provider: 'p', model: 'sonnet' })
+    applyEvent(r, { seq: 3, ts: 3, type: 'turn_usage', subtaskId: 'st1', model: 'haiku', usage: { input_tokens: 1 } })
+    assert.equal(r.subtasks[0].modelDrift, true)
+  })
+})
+
+describe('RunLedger persistence + folding', () => {
+  it('createRun writes a snapshot + index + journal', () => {
+    const led = mkLedger()
+    const run = led.createRun({ title: 'audit', preset: 'repo-audit' })
+    assert.match(run.runId, /^run_\d+_[0-9a-f]{8}$/)
+    assert.equal(run.status, 'created')
+    assert.ok(existsSync(join(baseDir, 'runs', run.runId, 'run.json')))
+    assert.ok(existsSync(join(baseDir, 'runs', run.runId, 'events.jsonl')))
+    assert.ok(existsSync(join(baseDir, 'runs-index.json')))
+    const idx = JSON.parse(readFileSync(join(baseDir, 'runs-index.json'), 'utf8'))
+    assert.equal(idx.runs[0].runId, run.runId)
+    led.dispose()
+  })
+
+  it('recordTurnUsage prices a cost:null turn via the injected priceTurn', () => {
+    const led = mkLedger({ priceTurn: ({ usage }) => (usage.input_tokens || 0) * 0.001 })
+    const run = led.createRun({})
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'worker.audit' })
+    led.attachSession(run.runId, 'st1', { sessionId: 's1', provider: 'codex', model: 'gpt-5.1', meterable: true })
+    const { cell } = led.recordTurnUsage(run.runId, {
+      subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', terminalEvent: 'result',
+      data: { cost: null, usage: { input_tokens: 1000, output_tokens: 10 } },
+    })
+    assert.equal(cell.costUsd, 0) // no provider cost
+    assert.equal(cell.pricedCostUsd, 1) // 1000 * 0.001
+    assert.equal(cell.effectiveUsd, 1)
+    led.dispose()
+  })
+
+  it('an unpriced cost:null turn counts as unknown-cost, never a wrong number', () => {
+    const led = mkLedger() // default priceTurn returns null
+    const run = led.createRun({})
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'w' })
+    led.attachSession(run.runId, 'st1', { sessionId: 's1', provider: 'gemini', model: 'g', meterable: true })
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'w', data: { cost: null, usage: { input_tokens: 5 } } })
+    const r = led.getRun(run.runId)
+    assert.equal(r.usageTotals.overall.effectiveUsd, 0)
+    assert.equal(r.usageTotals.overall.unknownCostTurns, 1)
+    led.dispose()
+  })
+})
+
+describe('RunLedger crash recovery', () => {
+  it('replays journal lines ahead of a stale snapshot (lastSeq gate) to reconstruct state', () => {
+    // Simulate a crash: build a run, then hand-truncate run.json's lastSeq back
+    // so the journal is "ahead", then recover with a fresh ledger.
+    const led = mkLedger()
+    const run = led.createRun({ title: 'x' })
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' })
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'a', data: { cost: 0.4, usage: { input_tokens: 10 } } })
+    led.flush()
+    led.dispose()
+
+    // Roll the snapshot back to BEFORE the turn_usage fold (as a crash between
+    // journal append and the debounced save would leave it).
+    const snapPath = join(baseDir, 'runs', run.runId, 'run.json')
+    const snap = JSON.parse(readFileSync(snapPath, 'utf8'))
+    const staleSeq = 2 // run_created(1) + subtask_created(2); turn_usage(3) not yet in snapshot
+    snap.lastSeq = staleSeq
+    snap.usageTotals = makeRunRecord({ runId: run.runId }).usageTotals // zeroed
+    writeFileSync(snapPath, JSON.stringify(snap))
+
+    const led2 = mkLedger()
+    const recovered = led2.recoverRuns()
+    assert.equal(recovered.length, 1)
+    const r = led2.getRun(run.runId)
+    assert.equal(r.usageTotals.overall.costUsd, 0.4, 'turn_usage(3) replayed from journal')
+    assert.equal(r.lastSeq, 3)
+    led2.dispose()
+  })
+
+  it('recovers zero runs from an empty base dir', () => {
+    const led = mkLedger()
+    assert.deepEqual(led.recoverRuns(), [])
+    led.dispose()
+  })
+})
+
+describe('RunLedger GC', () => {
+  it('LRU-evicts terminal runs beyond maxRuns and removes their directory', () => {
+    const led = mkLedger({ maxRuns: 2 })
+    const ids = []
+    for (let i = 0; i < 3; i++) {
+      clock = 1000 + i
+      const run = led.createRun({ title: `r${i}` })
+      ids.push(run.runId)
+      led.setStatus(run.runId, 'completed') // terminal → eligible for eviction
+    }
+    // 3 terminal runs, cap 2 → oldest evicted
+    const remaining = led.listRuns().map((r) => r.runId)
+    assert.equal(remaining.length, 2)
+    assert.ok(!remaining.includes(ids[0]), 'oldest run evicted')
+    assert.ok(!existsSync(join(baseDir, 'runs', ids[0])), 'evicted run dir removed')
+    assert.ok(existsSync(join(baseDir, 'runs', ids[2])), 'newest run dir kept')
+    led.dispose()
+  })
+
+  it('never evicts a non-terminal run even over the cap', () => {
+    const led = mkLedger({ maxRuns: 1 })
+    clock = 2000; led.createRun({}) // non-terminal
+    clock = 2001; led.createRun({}) // non-terminal
+    assert.equal(led.listRuns().length, 2, 'both kept — neither is terminal')
+    led.dispose()
+  })
+})
+
+describe('RunLedger committee body cap', () => {
+  it('truncates a committee-review body over 32KB', () => {
+    const led = mkLedger()
+    const run = led.createRun({})
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' })
+    led.recordCommitteeReview(run.runId, 'st1', { phase: 'plan', verdict: 'approve', notes: 'x'.repeat(40 * 1024) })
+    const journal = readFileSync(join(baseDir, 'runs', run.runId, 'events.jsonl'), 'utf8')
+    const line = journal.trim().split('\n').map((l) => JSON.parse(l)).find((e) => e.type === 'committee_review')
+    assert.equal(line.truncated, true)
+    assert.ok(line.notes.length <= 32 * 1024)
+    led.dispose()
+  })
+})

--- a/packages/server/tests/orchestration-run-ledger.test.js
+++ b/packages/server/tests/orchestration-run-ledger.test.js
@@ -141,13 +141,22 @@ describe('RunLedger crash recovery', () => {
     const staleSeq = 2 // run_created(1) + subtask_created(2); turn_usage(3) not yet in snapshot
     snap.lastSeq = staleSeq
     snap.usageTotals = makeRunRecord({ runId: run.runId }).usageTotals // zeroed
+    // Also zero the per-subtask fold so replay must reconstruct it too, not just
+    // the run totals — proves the reducer folds subtask cells on replay.
+    if (snap.subtasks[0]) {
+      snap.subtasks[0].usage = makeUsageCell()
+      snap.subtasks[0].numTurns = 0
+      snap.subtasks[0].apiDurationMs = 0
+    }
     writeFileSync(snapPath, JSON.stringify(snap))
 
     const led2 = mkLedger()
     const recovered = led2.recoverRuns()
     assert.equal(recovered.length, 1)
     const r = led2.getRun(run.runId)
-    assert.equal(r.usageTotals.overall.costUsd, 0.4, 'turn_usage(3) replayed from journal')
+    assert.equal(r.usageTotals.overall.costUsd, 0.4, 'turn_usage(3) replayed into run totals')
+    assert.equal(r.subtasks[0].usage.costUsd, 0.4, 'turn_usage(3) replayed into the subtask cell')
+    assert.equal(r.subtasks[0].usage.inputTokens, 10)
     assert.equal(r.lastSeq, 3)
     led2.dispose()
   })
@@ -196,7 +205,21 @@ describe('RunLedger committee body cap', () => {
     const journal = readFileSync(join(baseDir, 'runs', run.runId, 'events.jsonl'), 'utf8')
     const line = journal.trim().split('\n').map((l) => JSON.parse(l)).find((e) => e.type === 'committee_review')
     assert.equal(line.truncated, true)
-    assert.ok(line.notes.length <= 32 * 1024)
+    assert.ok(Buffer.byteLength(line.notes, 'utf8') <= 32 * 1024, 'body capped by bytes')
+    led.dispose()
+  })
+
+  it('caps a multibyte committee body by BYTES, not UTF-16 code units', () => {
+    const led = mkLedger()
+    const run = led.createRun({})
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' })
+    // '你' is 3 bytes / 1 code unit — 20k code units ≈ 60KB, well over the 32KB
+    // byte cap despite being under it in .length terms.
+    led.recordCommitteeReview(run.runId, 'st1', { phase: 'plan', verdict: 'approve', notes: '你'.repeat(20 * 1024) })
+    const journal = readFileSync(join(baseDir, 'runs', run.runId, 'events.jsonl'), 'utf8')
+    const line = journal.trim().split('\n').map((l) => JSON.parse(l)).find((e) => e.type === 'committee_review')
+    assert.equal(line.truncated, true)
+    assert.ok(Buffer.byteLength(line.notes, 'utf8') <= 32 * 1024, 'multibyte body capped by bytes')
     led.dispose()
   })
 })


### PR DESCRIPTION
## Summary

PR-3 (step M-2) of the orchestration epic (#6691): the **durable per-run store** the harness records into. Two new server modules under `packages/server/src/orchestration/` + tests. No protocol/wire changes; budget evaluation (M-3) and report rendering (M-4) are deliberately separate PRs.

- **`run-record.js`** — pure shapes + the single event reducer `applyEvent(record, event)`. Every mutation is a journal event applied through this one reducer, so the **live-recording path and the crash-recovery replay path produce byte-identical state**. Cost provenance is load-bearing: a turn's provider-reported `costUsd` (signed — refunds subtract) is **never** contaminated by the server-derived `pricedCostUsd` fallback; `effectiveUsd = costUsd + pricedCostUsd` is the one display/budget number, recomputed on fold. Folds each turn into overall / byRole / byModel / bySession / subtask cells; tracks `meteringGaps` (unmeterable sessions) and `modelDrift`.
- **`run-ledger.js`** — `RunLedger` (EventEmitter). **Journal-first**: synchronous `events.jsonl` append is the crash ground truth; `run.json` is a debounced atomic snapshot (fsync **immediately** on lifecycle/terminal mutations, debounced for high-frequency `turn_usage` folds) via the shared `json-state-file.js`. `recoverRuns()` replays journal lines with `seq > snapshot.lastSeq` — the `lastSeq` gate makes replay idempotent (no double-fold), so a crash between an append and the debounced save loses nothing. LRU GC evicts **terminal** runs beyond `maxRuns` (never a live run) and `rmSync`s their dir; 32KB committee-body cap + journal-size body shedding (usage lines always kept). Pricing is **injected** by the engine (a thin `models.js` wrapper); the default reports unpriced tokens honestly (`unknownCostTurns`) rather than a wrong number.

## Layout
```
<CHROXY_CONFIG_DIR>/.chroxy/orchestration/
  runs-index.json                 bounded LRU index
  runs/<runId>/run.json           debounced atomic snapshot (authoritative)
  runs/<runId>/events.jsonl       append-only journal (replayed on recovery)
```

## Tests
13 tests (`orchestration-run-ledger.test.js`): fold correctness across all cell buckets, cost-vs-priced provenance, signed refunds, metering gaps, model drift, **crash-recovery replay** (roll snapshot back, replay journal, assert reconstructed), **LRU GC** (terminal-only eviction + dir removal), committee body cap. Every test uses a temp `baseDir` (the sandbox discipline). All 5 server custom shell lints green.

### ⚠️ CI note — 2 pre-existing LOCAL failures, unrelated to this PR
The full local run shows the same 2 codex **integration** failures as #6713 (`Codex spawn-and-assert #3873`, `runDoctorChecks #2951`) — environmental fallout from security incident **#6708** (XProtect removed the codex native binary from this machine). This PR adds only new files under `orchestration/`; it touches nothing near doctor/spawn. They pass on CI's clean runners.

Closes #6694. Part of #6691.