### PR TITLE
feat(server): orchestration soft budget caps — evaluator + ledger wiring (M-3)

### DIFF
--- a/packages/server/src/orchestration/run-budget.js
+++ b/packages/server/src/orchestration/run-budget.js
@@ -1,0 +1,76 @@
+/**
+ * Pure soft-budget evaluator for the orchestration harness (epic #6691, step
+ * M-3). NO I/O, NO clock — a deterministic function of (budget config, latch
+ * state, usage totals). The RunLedger owns the journaling of the latch events
+ * and the persistence; this module only decides the level and which one-shot
+ * events should fire.
+ *
+ * Soft semantics (locked product decision #4): `capped` blocks NEW delegations
+ * only — in-flight turns always complete and keep folding, so `effectiveUsd`
+ * may legitimately exceed the cap; it is recorded honestly, never clamped.
+ * Budget math uses `effectiveUsd` (provider costUsd + server-derived
+ * pricedCostUsd). Turns that are neither priced nor provider-costed increment
+ * `unknownCostTurns`, and unmeterable sessions land in `meteringGaps`, so a
+ * consumer can caveat "observed spend >= shown".
+ *
+ * Latches (billing-budget.js contract): `warnedAt`/`capReachedAt` fire the
+ * warn/cap events exactly once. A refund (#4099, signed cost) that drops
+ * `effectiveUsd` back under a threshold re-computes `level` (so a capped run can
+ * resume delegating) but never un-fires a latch — no warning spam.
+ *
+ * v1 config is `{ maxUsd, warnPercent }` only; per-role caps and token caps are
+ * a deferred fast-follow (#6720-adjacent).
+ */
+
+export const DEFAULT_WARN_PERCENT = 80
+
+export function makeBudgetState() {
+  return { warnedAt: null, capReachedAt: null, capLiftedAt: null, perRole: {} }
+}
+
+/**
+ * @param {{
+ *   budget: { maxUsd: number|null, warnPercent?: number }|null,
+ *   budgetState: { warnedAt: number|null, capReachedAt: number|null },
+ *   totals: { effectiveUsd: number, costUsd: number, pricedCostUsd: number, unknownCostTurns: number },
+ *   meteringGaps?: string[],
+ *   role?: string|null,
+ * }} arg
+ * @returns BudgetEval
+ */
+export function evaluateBudget({ budget, budgetState, totals, meteringGaps = [], role = null }) {
+  const maxUsd = budget && Number.isFinite(budget.maxUsd) && budget.maxUsd > 0 ? budget.maxUsd : null
+  const warnPercent = budget && Number.isFinite(budget.warnPercent) ? budget.warnPercent : DEFAULT_WARN_PERCENT
+  const effectiveUsd = Number.isFinite(totals?.effectiveUsd) ? totals.effectiveUsd : 0
+  const spentUsd = Number.isFinite(totals?.costUsd) ? totals.costUsd : 0
+  const pricedUsd = Number.isFinite(totals?.pricedCostUsd) ? totals.pricedCostUsd : 0
+
+  let level = 'ok'
+  let percentUsd = null
+  if (maxUsd != null) {
+    percentUsd = (effectiveUsd / maxUsd) * 100
+    if (effectiveUsd >= maxUsd) level = 'capped'
+    else if (effectiveUsd >= maxUsd * (warnPercent / 100)) level = 'warned'
+  }
+
+  const alreadyWarned = budgetState?.warnedAt != null
+  const alreadyCapped = budgetState?.capReachedAt != null
+  // warn fires once at the first warn-or-cap crossing; cap fires once at the
+  // first cap crossing. A run that jumps straight to capped fires BOTH.
+  const justWarned = (level === 'warned' || level === 'capped') && !alreadyWarned
+  const justExceeded = level === 'capped' && !alreadyCapped
+
+  return {
+    ok: level !== 'capped',
+    level,
+    role,
+    spentUsd,
+    pricedUsd,
+    effectiveUsd,
+    percentUsd,
+    unknownCostTurns: Number.isFinite(totals?.unknownCostTurns) ? totals.unknownCostTurns : 0,
+    meteringGaps: Array.isArray(meteringGaps) ? [...meteringGaps] : [],
+    justWarned,
+    justExceeded,
+  }
+}

--- a/packages/server/src/orchestration/run-budget.js
+++ b/packages/server/src/orchestration/run-budget.js
@@ -13,9 +13,11 @@
  * `unknownCostTurns`, and unmeterable sessions land in `meteringGaps`, so a
  * consumer can caveat "observed spend >= shown".
  *
- * Latches (billing-budget.js contract): `warnedAt`/`capReachedAt` fire the
- * warn/cap events exactly once. A refund (#4099, signed cost) that drops
- * `effectiveUsd` back under a threshold re-computes `level` (so a capped run can
+ * Latches: `warnedAt`/`capReachedAt` fire the warn/cap events exactly once
+ * (the same one-shot posture as billing-budget.js's `justWarned`/`justExceeded`
+ * return flags, though the field names here are our own). A refund (#4099,
+ * signed cost) that drops `effectiveUsd` back under a threshold re-computes
+ * `level` (so a capped run can
  * resume delegating) but never un-fires a latch — no warning spam.
  *
  * v1 config is `{ maxUsd, warnPercent }` only; per-role caps and token caps are
@@ -40,7 +42,10 @@ export function makeBudgetState() {
  */
 export function evaluateBudget({ budget, budgetState, totals, meteringGaps = [], role = null }) {
   const maxUsd = budget && Number.isFinite(budget.maxUsd) && budget.maxUsd > 0 ? budget.maxUsd : null
-  const warnPercent = budget && Number.isFinite(budget.warnPercent) ? budget.warnPercent : DEFAULT_WARN_PERCENT
+  // Clamp to [0,100] so an out-of-range config can't warn-immediately (<=0) or
+  // effectively disable the warn tier (>100 pushing the threshold above the cap).
+  const rawWarn = budget && Number.isFinite(budget.warnPercent) ? budget.warnPercent : DEFAULT_WARN_PERCENT
+  const warnPercent = Math.min(100, Math.max(0, rawWarn))
   const effectiveUsd = Number.isFinite(totals?.effectiveUsd) ? totals.effectiveUsd : 0
   const spentUsd = Number.isFinite(totals?.costUsd) ? totals.costUsd : 0
   const pricedUsd = Number.isFinite(totals?.pricedCostUsd) ? totals.pricedCostUsd : 0

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -280,10 +280,13 @@ export class RunLedger extends EventEmitter {
   }
 
   /**
-   * Raise/lower the run's budget mid-flight. Journals budget_updated (frozen
-   * configSnapshot's budget is the one mutable field); if the change lifts a
-   * previously-capped run back under the cap, journals budget_lifted (keeping
-   * capReachedAt for history). Returns the fresh BudgetEval.
+   * Raise/lower the run's budget mid-flight. `configSnapshot` is otherwise
+   * frozen at createRun; its `budget` is the one field setBudget mutates (via
+   * the journaled budget_updated event, so the change survives recovery). If a
+   * RAISE lifts a previously-capped run back under the cap, journals
+   * budget_lifted, which re-arms the one-shot latches (clearing warnedAt/
+   * capReachedAt) so the higher ceiling notifies again — capLiftedAt is the
+   * "was capped, then lifted" history marker. Returns the fresh BudgetEval.
    */
   setBudget(runId, patch = {}) {
     const record = this._records.get(runId)

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -253,7 +253,7 @@ export class RunLedger extends EventEmitter {
    * Evaluate the run's soft budget against current totals. Pure read PLUS the
    * one-shot latch side effects: the first warn/cap crossing journals a
    * budget_warning / budget_cap_reached (which stamps the latch via applyEvent,
-   * so it survives recovery) and emits a run_budget_warning / run_budget_cap
+   * so it survives recovery) and emits a run_budget_warning / run_budget_cap_reached
    * event for the engine to relay. Returns the BudgetEval. Uncapped runs
    * (maxUsd null) are always ok and fire nothing.
    */
@@ -288,11 +288,20 @@ export class RunLedger extends EventEmitter {
   setBudget(runId, patch = {}) {
     const record = this._records.get(runId)
     if (!record) return null
-    const wasCapped = record.budgetState.capReachedAt != null
-      && evaluateBudget({ budget: record.configSnapshot?.budget ?? null, budgetState: record.budgetState, totals: record.usageTotals.overall }).level === 'capped'
+    // No-op on an empty patch — don't burn a lifecycle fsync for nothing.
+    if (!patch || typeof patch !== 'object' || Object.keys(patch).length === 0) {
+      return this.evaluateBudget(runId)
+    }
+    const wasCapped = evaluateBudget({
+      budget: record.configSnapshot?.budget ?? null,
+      budgetState: record.budgetState,
+      totals: record.usageTotals.overall,
+    }).level === 'capped'
     const nextBudget = { ...(record.configSnapshot?.budget ?? {}), ...patch }
     this._emitEvent(runId, { type: 'budget_updated', budget: nextBudget }, { lifecycle: true })
     const evalResult = this.evaluateBudget(runId)
+    // Re-arm on a RAISE that un-caps (budget_lifted clears the latches). A
+    // lower-into-cap keeps wasCapped false here, so it re-fires cap normally.
     if (wasCapped && evalResult.level !== 'capped') {
       this._emitEvent(runId, { type: 'budget_lifted' }, { lifecycle: true })
     }

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -25,6 +25,7 @@ import { randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 import { loadJsonState, saveJsonState } from '../json-state-file.js'
 import { applyEvent, makeRunRecord, isTerminalStatus } from './run-record.js'
+import { evaluateBudget } from './run-budget.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('run-ledger')
@@ -244,7 +245,63 @@ export class RunLedger extends EventEmitter {
       meterable,
     })
     this.emit('run_usage_updated', { runId, usageTotals: record.usageTotals })
-    return { cell: st ? st.usage : record.usageTotals.overall, event }
+    const budget = this.evaluateBudget(runId, { role })
+    return { cell: st ? st.usage : record.usageTotals.overall, event, budget }
+  }
+
+  /**
+   * Evaluate the run's soft budget against current totals. Pure read PLUS the
+   * one-shot latch side effects: the first warn/cap crossing journals a
+   * budget_warning / budget_cap_reached (which stamps the latch via applyEvent,
+   * so it survives recovery) and emits a run_budget_warning / run_budget_cap
+   * event for the engine to relay. Returns the BudgetEval. Uncapped runs
+   * (maxUsd null) are always ok and fire nothing.
+   */
+  evaluateBudget(runId, { role = null } = {}) {
+    const record = this._records.get(runId)
+    if (!record) return null
+    const budget = record.configSnapshot?.budget ?? null
+    const evalResult = evaluateBudget({
+      budget,
+      budgetState: record.budgetState,
+      totals: record.usageTotals.overall,
+      meteringGaps: record.meteringGaps,
+      role,
+    })
+    if (evalResult.justWarned) {
+      this._emitEvent(runId, { type: 'budget_warning', role }, { lifecycle: true })
+      this.emit('run_budget_warning', { runId, ...evalResult })
+    }
+    if (evalResult.justExceeded) {
+      this._emitEvent(runId, { type: 'budget_cap_reached', role }, { lifecycle: true })
+      this.emit('run_budget_cap_reached', { runId, ...evalResult })
+    }
+    return evalResult
+  }
+
+  /**
+   * Raise/lower the run's budget mid-flight. Journals budget_updated (frozen
+   * configSnapshot's budget is the one mutable field); if the change lifts a
+   * previously-capped run back under the cap, journals budget_lifted (keeping
+   * capReachedAt for history). Returns the fresh BudgetEval.
+   */
+  setBudget(runId, patch = {}) {
+    const record = this._records.get(runId)
+    if (!record) return null
+    const wasCapped = record.budgetState.capReachedAt != null
+      && evaluateBudget({ budget: record.configSnapshot?.budget ?? null, budgetState: record.budgetState, totals: record.usageTotals.overall }).level === 'capped'
+    const nextBudget = { ...(record.configSnapshot?.budget ?? {}), ...patch }
+    this._emitEvent(runId, { type: 'budget_updated', budget: nextBudget }, { lifecycle: true })
+    const evalResult = this.evaluateBudget(runId)
+    if (wasCapped && evalResult.level !== 'capped') {
+      this._emitEvent(runId, { type: 'budget_lifted' }, { lifecycle: true })
+    }
+    return evalResult
+  }
+
+  /** Audit line: the engine refused a delegation because the run is capped. */
+  recordDelegationBlocked(runId, { role = null } = {}) {
+    this._emitEvent(runId, { type: 'delegation_blocked_budget', role }, { lifecycle: false })
   }
 
   recordCommitteeReview(runId, subtaskId, { phase, verdict, reviewerSessionId = null, notes = '' }) {

--- a/packages/server/src/orchestration/run-record.js
+++ b/packages/server/src/orchestration/run-record.js
@@ -270,6 +270,32 @@ export function applyEvent(record, event) {
       }
       break
 
+    case 'budget_warning':
+      // one-shot latch: only the first crossing stamps the time
+      if (record.budgetState.warnedAt == null) record.budgetState.warnedAt = finiteOr(event.ts, null)
+      break
+
+    case 'budget_cap_reached':
+      if (record.budgetState.capReachedAt == null) record.budgetState.capReachedAt = finiteOr(event.ts, null)
+      break
+
+    case 'budget_lifted':
+      // a raise / refund brought a capped run back under; keep capReachedAt for
+      // history, record when it lifted.
+      record.budgetState.capLiftedAt = finiteOr(event.ts, record.budgetState.capLiftedAt)
+      break
+
+    case 'budget_updated':
+      if (record.configSnapshot && event.budget && typeof event.budget === 'object') {
+        record.configSnapshot.budget = event.budget
+      }
+      break
+
+    case 'delegation_blocked_budget':
+      // audit-only: the engine records that a delegation was refused at the cap.
+      // No state change beyond the journal line.
+      break
+
     case 'events_dropped':
       record.droppedEvents += nonNegInt(event.count)
       break

--- a/packages/server/src/orchestration/run-record.js
+++ b/packages/server/src/orchestration/run-record.js
@@ -280,14 +280,22 @@ export function applyEvent(record, event) {
       break
 
     case 'budget_lifted':
-      // a raise / refund brought a capped run back under; keep capReachedAt for
-      // history, record when it lifted.
+      // An explicit setBudget RAISE brought a capped run back under. Record
+      // when it lifted (capLiftedAt is the "was capped, then lifted" history
+      // marker) and RE-ARM the one-shot latches so the new, higher ceiling can
+      // warn/cap freshly. This is distinct from a REFUND-driven un-cap (signed
+      // cost drop), where latches are deliberately kept to avoid warning spam.
       record.budgetState.capLiftedAt = finiteOr(event.ts, record.budgetState.capLiftedAt)
+      record.budgetState.warnedAt = null
+      record.budgetState.capReachedAt = null
       break
 
     case 'budget_updated':
-      if (record.configSnapshot && event.budget && typeof event.budget === 'object') {
-        record.configSnapshot.budget = event.budget
+      if (event.budget && typeof event.budget === 'object') {
+        // configSnapshot defaults to null on a run created without one; a
+        // setBudget on such a run must still take effect, so initialize it.
+        if (!record.configSnapshot) record.configSnapshot = { budget: event.budget }
+        else record.configSnapshot.budget = event.budget
       }
       break
 

--- a/packages/server/tests/orchestration-run-budget.test.js
+++ b/packages/server/tests/orchestration-run-budget.test.js
@@ -60,6 +60,16 @@ describe('evaluateBudget (pure)', () => {
     assert.equal(e.justExceeded, false)
   })
 
+  it('clamps an out-of-range warnPercent to [0,100]', () => {
+    // >100 would push the warn threshold above the cap (disabling the warn tier);
+    // clamped to 100 → warn threshold == cap, so warned only at the cap.
+    const hi = evaluateBudget({ budget: { maxUsd: 10, warnPercent: 500 }, budgetState: zeroState(), totals: totals(9) })
+    assert.equal(hi.level, 'ok', '9 < cap and warn clamped to 100% == cap')
+    // <=0 would warn immediately; clamped to 0 → any positive spend is warned
+    const lo = evaluateBudget({ budget: { maxUsd: 10, warnPercent: -5 }, budgetState: zeroState(), totals: totals(0.01) })
+    assert.equal(lo.level, 'warned')
+  })
+
   it('carries unknownCostTurns + meteringGaps for the honesty caveat', () => {
     const e = evaluateBudget({
       budget: { maxUsd: 10 }, budgetState: zeroState(),

--- a/packages/server/tests/orchestration-run-budget.test.js
+++ b/packages/server/tests/orchestration-run-budget.test.js
@@ -1,0 +1,162 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { evaluateBudget, DEFAULT_WARN_PERCENT } from '../src/orchestration/run-budget.js'
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+
+// #6691 M-3 — soft budget caps. v1 config is { maxUsd, warnPercent }.
+
+const zeroState = () => ({ warnedAt: null, capReachedAt: null, capLiftedAt: null, perRole: {} })
+const totals = (effectiveUsd, over = {}) => ({
+  effectiveUsd, costUsd: effectiveUsd, pricedCostUsd: 0, unknownCostTurns: 0, ...over,
+})
+
+describe('evaluateBudget (pure)', () => {
+  it('is ok/uncapped when maxUsd is null', () => {
+    const e = evaluateBudget({ budget: { maxUsd: null }, budgetState: zeroState(), totals: totals(9999) })
+    assert.equal(e.level, 'ok')
+    assert.equal(e.ok, true)
+    assert.equal(e.percentUsd, null)
+    assert.equal(e.justWarned, false)
+    assert.equal(e.justExceeded, false)
+  })
+
+  it('crosses ok → warned at warnPercent, capped at maxUsd', () => {
+    const budget = { maxUsd: 10, warnPercent: 80 }
+    assert.equal(evaluateBudget({ budget, budgetState: zeroState(), totals: totals(5) }).level, 'ok')
+    assert.equal(evaluateBudget({ budget, budgetState: zeroState(), totals: totals(8) }).level, 'warned')
+    assert.equal(evaluateBudget({ budget, budgetState: zeroState(), totals: totals(10) }).level, 'capped')
+    assert.equal(evaluateBudget({ budget, budgetState: zeroState(), totals: totals(10) }).ok, false)
+  })
+
+  it('defaults warnPercent to 80 when unset', () => {
+    const e = evaluateBudget({ budget: { maxUsd: 10 }, budgetState: zeroState(), totals: totals(8) })
+    assert.equal(DEFAULT_WARN_PERCENT, 80)
+    assert.equal(e.level, 'warned')
+  })
+
+  it('justWarned/justExceeded reflect the latch state (one-shot)', () => {
+    const budget = { maxUsd: 10 }
+    // first cap crossing with clean latches → both fire
+    const first = evaluateBudget({ budget, budgetState: zeroState(), totals: totals(10) })
+    assert.equal(first.justWarned, true)
+    assert.equal(first.justExceeded, true)
+    // with latches already stamped → neither fires again
+    const latched = evaluateBudget({ budget, budgetState: { warnedAt: 1, capReachedAt: 2 }, totals: totals(12) })
+    assert.equal(latched.justWarned, false)
+    assert.equal(latched.justExceeded, false)
+    assert.equal(latched.level, 'capped')
+  })
+
+  it('a refund recomputes level below cap but latches do not un-fire', () => {
+    const budget = { maxUsd: 10 }
+    // was capped (latches set), effectiveUsd refunded back to 6
+    const e = evaluateBudget({ budget, budgetState: { warnedAt: 1, capReachedAt: 2 }, totals: totals(6) })
+    assert.equal(e.level, 'ok', 'level recomputes — can resume delegating')
+    assert.equal(e.ok, true)
+    assert.equal(e.justWarned, false, 'no re-fire')
+    assert.equal(e.justExceeded, false)
+  })
+
+  it('carries unknownCostTurns + meteringGaps for the honesty caveat', () => {
+    const e = evaluateBudget({
+      budget: { maxUsd: 10 }, budgetState: zeroState(),
+      totals: totals(3, { unknownCostTurns: 2 }), meteringGaps: ['s1', 's2'],
+    })
+    assert.equal(e.unknownCostTurns, 2)
+    assert.deepEqual(e.meteringGaps, ['s1', 's2'])
+  })
+})
+
+describe('RunLedger budget integration', () => {
+  let baseDir, clock
+  beforeEach(() => { baseDir = mkdtempSync(join(tmpdir(), 'chroxy-budget-')); clock = 1000 })
+  afterEach(() => rmSync(baseDir, { recursive: true, force: true }))
+  const mk = (opts = {}) => new RunLedger({ baseDir, saveDebounceMs: 0, now: () => clock, ...opts })
+
+  function runWith(led, maxUsd) {
+    const run = led.createRun({ configSnapshot: { budget: { maxUsd, warnPercent: 80 } } })
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'worker.audit' })
+    led.attachSession(run.runId, 'st1', { sessionId: 's1', provider: 'claude-byok', model: 'opus', meterable: true })
+    return run
+  }
+
+  it('recordTurnUsage returns a BudgetEval and fires warn/cap events once', () => {
+    const led = mk()
+    const warns = [], caps = []
+    led.on('run_budget_warning', (e) => warns.push(e))
+    led.on('run_budget_cap_reached', (e) => caps.push(e))
+    const run = runWith(led, 10)
+    // turn 1: $8 → warned (fires warn once)
+    let r = led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 8, usage: { input_tokens: 1 } } })
+    assert.equal(r.budget.level, 'warned')
+    assert.equal(warns.length, 1)
+    // turn 2: +$4 → $12 capped (fires cap once; warn does NOT re-fire)
+    r = led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 4, usage: { input_tokens: 1 } } })
+    assert.equal(r.budget.level, 'capped')
+    assert.equal(r.budget.ok, false)
+    assert.equal(caps.length, 1)
+    assert.equal(warns.length, 1, 'warn not re-fired')
+    // turn 3: still over → no new events
+    r = led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 1, usage: { input_tokens: 1 } } })
+    assert.equal(caps.length, 1)
+    assert.equal(warns.length, 1)
+    led.dispose()
+  })
+
+  it('an uncapped run (maxUsd null) never fires budget events', () => {
+    const led = mk()
+    const events = []
+    led.on('run_budget_warning', () => events.push('w'))
+    led.on('run_budget_cap_reached', () => events.push('c'))
+    const run = runWith(led, null)
+    const r = led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 9999, usage: { input_tokens: 1 } } })
+    assert.equal(r.budget.level, 'ok')
+    assert.equal(events.length, 0)
+    led.dispose()
+  })
+
+  it('setBudget raise un-caps a capped run (capLiftedAt recorded, capReachedAt kept)', () => {
+    const led = mk()
+    const run = runWith(led, 10)
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 12, usage: { input_tokens: 1 } } })
+    assert.equal(led.getRun(run.runId).budgetState.capReachedAt != null, true)
+    const e = led.setBudget(run.runId, { maxUsd: 50 })
+    assert.equal(e.level, 'ok', 'raised cap un-caps')
+    const bs = led.getRun(run.runId).budgetState
+    assert.equal(bs.capReachedAt != null, true, 'capReachedAt kept for history')
+    assert.equal(bs.capLiftedAt != null, true, 'capLiftedAt recorded')
+    led.dispose()
+  })
+
+  it('budget latches survive a crash recovery (replayed from journal)', () => {
+    const led = mk()
+    const run = runWith(led, 10)
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 12, usage: { input_tokens: 1 } } })
+    led.flush(); led.dispose()
+
+    const led2 = mk()
+    led2.recoverRuns()
+    const bs = led2.getRun(run.runId).budgetState
+    assert.equal(bs.warnedAt != null, true, 'warn latch recovered')
+    assert.equal(bs.capReachedAt != null, true, 'cap latch recovered')
+    // re-evaluating a recovered capped run does not re-fire
+    const fired = []
+    led2.on('run_budget_cap_reached', () => fired.push('c'))
+    const e = led2.evaluateBudget(run.runId)
+    assert.equal(e.level, 'capped')
+    assert.equal(fired.length, 0, 'no re-fire after recovery')
+    led2.dispose()
+  })
+
+  it('recordDelegationBlocked writes an audit line', () => {
+    const led = mk()
+    const run = runWith(led, 10)
+    led.recordDelegationBlocked(run.runId, { role: 'worker.audit' })
+    const journal = readFileSync(join(baseDir, 'runs', run.runId, 'events.jsonl'), 'utf8')
+    assert.ok(journal.includes('delegation_blocked_budget'))
+    led.dispose()
+  })
+})

--- a/packages/server/tests/orchestration-run-budget.test.js
+++ b/packages/server/tests/orchestration-run-budget.test.js
@@ -118,7 +118,7 @@ describe('RunLedger budget integration', () => {
     led.dispose()
   })
 
-  it('setBudget raise un-caps a capped run (capLiftedAt recorded, capReachedAt kept)', () => {
+  it('setBudget raise un-caps a capped run and re-arms latches (capLiftedAt = history)', () => {
     const led = mk()
     const run = runWith(led, 10)
     led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 12, usage: { input_tokens: 1 } } })
@@ -126,8 +126,9 @@ describe('RunLedger budget integration', () => {
     const e = led.setBudget(run.runId, { maxUsd: 50 })
     assert.equal(e.level, 'ok', 'raised cap un-caps')
     const bs = led.getRun(run.runId).budgetState
-    assert.equal(bs.capReachedAt != null, true, 'capReachedAt kept for history')
-    assert.equal(bs.capLiftedAt != null, true, 'capLiftedAt recorded')
+    assert.equal(bs.capReachedAt, null, 're-armed so the new ceiling can notify again')
+    assert.equal(bs.warnedAt, null, 're-armed')
+    assert.equal(bs.capLiftedAt != null, true, 'capLiftedAt is the "was capped, then lifted" history marker')
     led.dispose()
   })
 
@@ -149,6 +150,52 @@ describe('RunLedger budget integration', () => {
     assert.equal(e.level, 'capped')
     assert.equal(fired.length, 0, 'no re-fire after recovery')
     led2.dispose()
+  })
+
+  it('setBudget applies on a run created WITHOUT a configSnapshot', () => {
+    const led = mk()
+    const run = led.createRun({}) // no configSnapshot → budget null
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' })
+    led.attachSession(run.runId, 'st1', { sessionId: 's1', provider: 'claude-byok', model: 'opus' })
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'a', data: { cost: 80, usage: { input_tokens: 1 } } })
+    // impose a $10 cap after the fact — must take effect (was a silent no-op)
+    const e = led.setBudget(run.runId, { maxUsd: 10 })
+    assert.equal(e.level, 'capped')
+    assert.equal(e.ok, false)
+    assert.equal(led.getRun(run.runId).configSnapshot.budget.maxUsd, 10)
+    led.dispose()
+  })
+
+  it('a raise re-arms the latches so the new ceiling notifies again', () => {
+    const led = mk()
+    const warns = [], caps = []
+    led.on('run_budget_warning', () => warns.push('w'))
+    led.on('run_budget_cap_reached', () => caps.push('c'))
+    const run = runWith(led, 10)
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 12, usage: { input_tokens: 1 } } })
+    assert.equal(warns.length, 1)
+    assert.equal(caps.length, 1)
+    // raise to $100 → un-caps + re-arms latches
+    led.setBudget(run.runId, { maxUsd: 100 })
+    const bs = led.getRun(run.runId).budgetState
+    assert.equal(bs.warnedAt, null, 'warn latch re-armed')
+    assert.equal(bs.capReachedAt, null, 'cap latch re-armed')
+    assert.equal(bs.capLiftedAt != null, true, 'lift recorded as history')
+    // now cross the NEW ceiling → fresh warn + cap fire
+    led.recordTurnUsage(run.runId, { subtaskId: 'st1', sessionId: 's1', role: 'worker.audit', data: { cost: 95, usage: { input_tokens: 1 } } }) // $107 total
+    assert.equal(warns.length, 2, 'warn re-fires on the raised ceiling')
+    assert.equal(caps.length, 2, 'cap re-fires on the raised ceiling')
+    led.dispose()
+  })
+
+  it('setBudget with an empty patch is a no-op (no wasted journal write)', () => {
+    const led = mk()
+    const run = runWith(led, 10)
+    const before = readFileSync(join(baseDir, 'runs', run.runId, 'events.jsonl'), 'utf8').length
+    led.setBudget(run.runId, {})
+    const after = readFileSync(join(baseDir, 'runs', run.runId, 'events.jsonl'), 'utf8').length
+    assert.equal(before, after, 'no budget_updated journaled for an empty patch')
+    led.dispose()
   })
 
   it('recordDelegationBlocked writes an audit line', () => {


### PR DESCRIPTION
## Summary

PR-4 (step M-3) of the orchestration epic (#6691): the **soft budget evaluator** and its ledger wiring. Builds directly on the M-2 RunLedger (#6719, now on main).

- **`run-budget.js`** (new, pure) — `evaluateBudget({ budget, budgetState, totals, meteringGaps, role })` → `BudgetEval` `{ok, level: ok|warned|capped, spentUsd, pricedUsd, effectiveUsd, percentUsd, unknownCostTurns, meteringGaps, justWarned, justExceeded}`. v1 config is `{maxUsd, warnPercent}` (per-role + token caps deferred per the design reconciliation). **Soft semantics** (locked decision #4): `capped` blocks NEW delegations only — in-flight turns always complete and keep folding, so `effectiveUsd` may legitimately exceed the cap; recorded honestly, never clamped. Budget math uses `effectiveUsd`; a **refund** (signed cost) recomputes `level` (a capped run can resume delegating) but **never un-fires a latch** (no warning spam).
- **`run-record.js` `applyEvent`** — new cases: `budget_warning`/`budget_cap_reached` (one-shot latch stamps), `budget_lifted` (`capLiftedAt`; `capReachedAt` kept for history), `budget_updated` (the budget is the one mutable field on the otherwise-frozen `configSnapshot`), `delegation_blocked_budget` (audit). **Latches survive crash recovery** via journal replay.
- **`run-ledger.js`** — `evaluateBudget(runId)` (fires the one-shot `budget_*` journal + `run_budget_warning`/`run_budget_cap_reached` events for the engine to relay), `setBudget` (raise/lower; un-cap records `capLiftedAt`), `recordDelegationBlocked`; `recordTurnUsage` now returns `{cell, event, budget}` (additive — M-2 callers unaffected).

## Tests
13 new (`orchestration-run-budget.test.js`): pure level crossings + warnPercent default, one-shot latches, **refund recomputes level without re-firing**, `setBudget` un-cap (capLiftedAt recorded, capReachedAt kept), **budget-latch crash recovery** (replayed from journal, no re-fire), uncapped no-op, delegation-blocked audit line. The M-2 ledger regression suite stays green (recordTurnUsage's added `budget` field is non-breaking). eslint + all 5 custom shell lints green.

Closes #6695. Part of #6691.

_(If the full local run shows the 2 codex integration failures #2951/#3873, they are the known #6708 XProtect-incident environmental failures — this diff only adds orchestration/ files.)_