### PR TITLE
feat(dashboard): modifier-click rendered links to open in the browser (#6625)

### DIFF
--- a/packages/dashboard/src/components/ChatMessage.tsx
+++ b/packages/dashboard/src/components/ChatMessage.tsx
@@ -6,6 +6,7 @@
  */
 import { useMemo } from 'react'
 import { renderMarkdown } from '../lib/markdown'
+import { handleMarkdownLinkClick } from '../lib/links'
 
 export interface ChatMessageProps {
   id: string
@@ -46,7 +47,9 @@ export function ChatMessage({ id, type, content, isStreaming }: ChatMessageProps
       data-muted={type === 'system' ? 'true' : undefined}
     >
       {html !== null ? (
-        <div dangerouslySetInnerHTML={{ __html: html }} />
+        // #6625: modifier-click a rendered link to open it in the browser; a
+        // plain click keeps the text selectable (handler suppresses navigation).
+        <div onClick={handleMarkdownLinkClick} dangerouslySetInnerHTML={{ __html: html }} />
       ) : (
         content
       )}

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -20,6 +20,7 @@ import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMem
 import { bumpRenderCount, type ChatActivityState } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
+import { handleMarkdownLinkClick } from '../lib/links'
 import { MessageRowShell } from './MeasuredRow'
 import { ChatExpandContext, type ChatExpandRegistry } from './chatExpandRegistry'
 import { useWindowedRange } from './useWindowedRange'
@@ -322,7 +323,8 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
 
   const body =
     type === 'response' || type === 'tool_use'
-      ? <div dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+      // #6625: modifier-click opens a rendered link; plain click keeps selection.
+      ? <div onClick={handleMarkdownLinkClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
       : type === 'thinking'
         ? <ThinkingBody content={content} streaming={!!isStreaming} />
         : content

--- a/packages/dashboard/src/lib/links.test.ts
+++ b/packages/dashboard/src/lib/links.test.ts
@@ -82,6 +82,16 @@ describe('handleMarkdownLinkClick (#6625)', () => {
     expect(open).toHaveBeenCalledWith('https://example.com')
   })
 
+  it('resolves the anchor when the click target is a Text node inside the link', () => {
+    // Defensive: DOM click targets are normally Elements, but a Text node must
+    // still resolve to its parent anchor so navigation stays gated.
+    const a = anchor('https://example.com')
+    const textNode = a.firstChild! // the "link" text node
+    const open = vi.fn()
+    handleMarkdownLinkClick(mouse({ target: textNode, metaKey: true }), open)
+    expect(open).toHaveBeenCalledWith('https://example.com')
+  })
+
   it('resolves the anchor when the click lands on a child of the link', () => {
     const a = anchor('https://example.com')
     const span = document.createElement('span')

--- a/packages/dashboard/src/lib/links.test.ts
+++ b/packages/dashboard/src/lib/links.test.ts
@@ -1,32 +1,48 @@
 import { describe, it, expect, vi } from 'vitest'
-import { resolveModifierLinkOpen, handleMarkdownLinkClick } from './links'
+import { resolveLinkOpen, handleMarkdownLinkClick } from './links'
 
-describe('resolveModifierLinkOpen (#6625)', () => {
+describe('resolveLinkOpen (#6625)', () => {
   it('returns the URL for a modifier-click on an http(s) link', () => {
-    expect(resolveModifierLinkOpen('https://example.com', { metaKey: true })).toBe('https://example.com')
-    expect(resolveModifierLinkOpen('http://example.com/x', { ctrlKey: true })).toBe('http://example.com/x')
+    expect(resolveLinkOpen('https://example.com', { metaKey: true })).toBe('https://example.com')
+    expect(resolveLinkOpen('http://example.com/x', { ctrlKey: true })).toBe('http://example.com/x')
   })
 
-  it('returns null for a plain click (no modifier)', () => {
-    expect(resolveModifierLinkOpen('https://example.com', {})).toBeNull()
-    expect(resolveModifierLinkOpen('https://example.com', { metaKey: false, ctrlKey: false })).toBeNull()
+  it('opens on keyboard activation (Enter → synthesized click, detail 0) with no modifier', () => {
+    expect(resolveLinkOpen('https://example.com', { detail: 0 })).toBe('https://example.com')
   })
 
-  it('returns null for an unsafe / non-http scheme even with a modifier held', () => {
-    expect(resolveModifierLinkOpen('javascript:alert(1)', { metaKey: true })).toBeNull()
-    expect(resolveModifierLinkOpen('data:text/html,x', { ctrlKey: true })).toBeNull()
-    expect(resolveModifierLinkOpen('mailto:a@b.com', { metaKey: true })).toBeNull()
-    expect(resolveModifierLinkOpen('/relative/path', { metaKey: true })).toBeNull()
+  it('returns null for a plain MOUSE click (detail ≥ 1, no modifier)', () => {
+    expect(resolveLinkOpen('https://example.com', { detail: 1 })).toBeNull()
+    expect(resolveLinkOpen('https://example.com', {})).toBeNull()
+    expect(resolveLinkOpen('https://example.com', { metaKey: false, ctrlKey: false, detail: 1 })).toBeNull()
+  })
+
+  it('is case-insensitive on the scheme', () => {
+    expect(resolveLinkOpen('HTTPS://Example.com', { metaKey: true })).toBe('HTTPS://Example.com')
+  })
+
+  it('returns null for an unsafe / non-http scheme even with a modifier or keyboard', () => {
+    expect(resolveLinkOpen('javascript:alert(1)', { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen('javascript:alert(1)//x', { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen('data:text/html,x', { ctrlKey: true })).toBeNull()
+    expect(resolveLinkOpen('mailto:a@b.com', { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen('http:/single-slash', { detail: 0 })).toBeNull()
+  })
+
+  it('returns null for relative / protocol-relative hrefs (raw attribute, not resolved)', () => {
+    expect(resolveLinkOpen('/relative/path', { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen('//evil.com', { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen('#anchor', { metaKey: true })).toBeNull()
   })
 
   it('returns null for a missing/blank href', () => {
-    expect(resolveModifierLinkOpen(null, { metaKey: true })).toBeNull()
-    expect(resolveModifierLinkOpen(undefined, { metaKey: true })).toBeNull()
-    expect(resolveModifierLinkOpen('   ', { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen(null, { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen(undefined, { metaKey: true })).toBeNull()
+    expect(resolveLinkOpen('   ', { metaKey: true })).toBeNull()
   })
 
   it('trims surrounding whitespace', () => {
-    expect(resolveModifierLinkOpen('  https://example.com  ', { metaKey: true })).toBe('https://example.com')
+    expect(resolveLinkOpen('  https://example.com  ', { metaKey: true })).toBe('https://example.com')
   })
 })
 
@@ -37,14 +53,33 @@ describe('handleMarkdownLinkClick (#6625)', () => {
     a.textContent = 'link'
     return a
   }
+  const mouse = (over: Partial<{ target: EventTarget; metaKey: boolean; ctrlKey: boolean }>) => ({
+    target: null,
+    metaKey: false,
+    ctrlKey: false,
+    detail: 1, // a real mouse click
+    preventDefault: vi.fn(),
+    ...over,
+  })
 
-  it('opens an http(s) link on a modifier-click and suppresses navigation', () => {
-    const a = anchor('https://example.com')
+  it('opens an http(s) link on a Cmd(meta)-click and suppresses navigation', () => {
+    const e = { ...mouse({ target: anchor('https://example.com'), metaKey: true }) }
     const open = vi.fn()
-    const preventDefault = vi.fn()
-    handleMarkdownLinkClick({ target: a, metaKey: true, ctrlKey: false, preventDefault }, open)
+    handleMarkdownLinkClick(e, open)
     expect(open).toHaveBeenCalledWith('https://example.com')
-    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(e.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('opens on a Ctrl-click (Windows/Linux modifier)', () => {
+    const open = vi.fn()
+    handleMarkdownLinkClick(mouse({ target: anchor('https://example.com'), ctrlKey: true }), open)
+    expect(open).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('opens on keyboard activation (detail 0) even without a modifier', () => {
+    const open = vi.fn()
+    handleMarkdownLinkClick({ target: anchor('https://example.com'), metaKey: false, ctrlKey: false, detail: 0, preventDefault: vi.fn() }, open)
+    expect(open).toHaveBeenCalledWith('https://example.com')
   })
 
   it('resolves the anchor when the click lands on a child of the link', () => {
@@ -52,35 +87,40 @@ describe('handleMarkdownLinkClick (#6625)', () => {
     const span = document.createElement('span')
     a.appendChild(span)
     const open = vi.fn()
-    handleMarkdownLinkClick({ target: span, metaKey: true, ctrlKey: false, preventDefault: vi.fn() }, open)
+    handleMarkdownLinkClick(mouse({ target: span, metaKey: true }), open)
     expect(open).toHaveBeenCalledWith('https://example.com')
   })
 
-  it('does NOT open on a plain click, but suppresses navigation (keeps selection)', () => {
-    const a = anchor('https://example.com')
+  it('does NOT open on a plain mouse click, but suppresses navigation (keeps selection)', () => {
+    const e = mouse({ target: anchor('https://example.com') })
     const open = vi.fn()
-    const preventDefault = vi.fn()
-    handleMarkdownLinkClick({ target: a, metaKey: false, ctrlKey: false, preventDefault }, open)
+    handleMarkdownLinkClick(e, open)
     expect(open).not.toHaveBeenCalled()
-    expect(preventDefault).toHaveBeenCalledOnce() // native target=_blank open is suppressed
+    expect(e.preventDefault).toHaveBeenCalledOnce()
   })
 
   it('does NOT open an unsafe scheme even with a modifier, and suppresses navigation', () => {
-    const a = anchor('javascript:alert(1)')
+    const e = mouse({ target: anchor('javascript:alert(1)'), metaKey: true })
     const open = vi.fn()
-    const preventDefault = vi.fn()
-    handleMarkdownLinkClick({ target: a, metaKey: true, ctrlKey: false, preventDefault }, open)
+    handleMarkdownLinkClick(e, open)
     expect(open).not.toHaveBeenCalled()
-    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(e.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('reads the RAW href attribute — a relative href does NOT open (no origin resolution)', () => {
+    const e = mouse({ target: anchor('/relative/path'), metaKey: true })
+    const open = vi.fn()
+    handleMarkdownLinkClick(e, open)
+    expect(open).not.toHaveBeenCalled()
   })
 
   it('leaves a non-link click completely untouched (no preventDefault, no open)', () => {
     const div = document.createElement('div')
     div.textContent = 'plain text'
+    const e = mouse({ target: div, metaKey: true })
     const open = vi.fn()
-    const preventDefault = vi.fn()
-    handleMarkdownLinkClick({ target: div, metaKey: true, ctrlKey: false, preventDefault }, open)
+    handleMarkdownLinkClick(e, open)
     expect(open).not.toHaveBeenCalled()
-    expect(preventDefault).not.toHaveBeenCalled()
+    expect(e.preventDefault).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/lib/links.test.ts
+++ b/packages/dashboard/src/lib/links.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveModifierLinkOpen, handleMarkdownLinkClick } from './links'
+
+describe('resolveModifierLinkOpen (#6625)', () => {
+  it('returns the URL for a modifier-click on an http(s) link', () => {
+    expect(resolveModifierLinkOpen('https://example.com', { metaKey: true })).toBe('https://example.com')
+    expect(resolveModifierLinkOpen('http://example.com/x', { ctrlKey: true })).toBe('http://example.com/x')
+  })
+
+  it('returns null for a plain click (no modifier)', () => {
+    expect(resolveModifierLinkOpen('https://example.com', {})).toBeNull()
+    expect(resolveModifierLinkOpen('https://example.com', { metaKey: false, ctrlKey: false })).toBeNull()
+  })
+
+  it('returns null for an unsafe / non-http scheme even with a modifier held', () => {
+    expect(resolveModifierLinkOpen('javascript:alert(1)', { metaKey: true })).toBeNull()
+    expect(resolveModifierLinkOpen('data:text/html,x', { ctrlKey: true })).toBeNull()
+    expect(resolveModifierLinkOpen('mailto:a@b.com', { metaKey: true })).toBeNull()
+    expect(resolveModifierLinkOpen('/relative/path', { metaKey: true })).toBeNull()
+  })
+
+  it('returns null for a missing/blank href', () => {
+    expect(resolveModifierLinkOpen(null, { metaKey: true })).toBeNull()
+    expect(resolveModifierLinkOpen(undefined, { metaKey: true })).toBeNull()
+    expect(resolveModifierLinkOpen('   ', { metaKey: true })).toBeNull()
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(resolveModifierLinkOpen('  https://example.com  ', { metaKey: true })).toBe('https://example.com')
+  })
+})
+
+describe('handleMarkdownLinkClick (#6625)', () => {
+  function anchor(href: string): HTMLAnchorElement {
+    const a = document.createElement('a')
+    a.setAttribute('href', href)
+    a.textContent = 'link'
+    return a
+  }
+
+  it('opens an http(s) link on a modifier-click and suppresses navigation', () => {
+    const a = anchor('https://example.com')
+    const open = vi.fn()
+    const preventDefault = vi.fn()
+    handleMarkdownLinkClick({ target: a, metaKey: true, ctrlKey: false, preventDefault }, open)
+    expect(open).toHaveBeenCalledWith('https://example.com')
+    expect(preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('resolves the anchor when the click lands on a child of the link', () => {
+    const a = anchor('https://example.com')
+    const span = document.createElement('span')
+    a.appendChild(span)
+    const open = vi.fn()
+    handleMarkdownLinkClick({ target: span, metaKey: true, ctrlKey: false, preventDefault: vi.fn() }, open)
+    expect(open).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('does NOT open on a plain click, but suppresses navigation (keeps selection)', () => {
+    const a = anchor('https://example.com')
+    const open = vi.fn()
+    const preventDefault = vi.fn()
+    handleMarkdownLinkClick({ target: a, metaKey: false, ctrlKey: false, preventDefault }, open)
+    expect(open).not.toHaveBeenCalled()
+    expect(preventDefault).toHaveBeenCalledOnce() // native target=_blank open is suppressed
+  })
+
+  it('does NOT open an unsafe scheme even with a modifier, and suppresses navigation', () => {
+    const a = anchor('javascript:alert(1)')
+    const open = vi.fn()
+    const preventDefault = vi.fn()
+    handleMarkdownLinkClick({ target: a, metaKey: true, ctrlKey: false, preventDefault }, open)
+    expect(open).not.toHaveBeenCalled()
+    expect(preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('leaves a non-link click completely untouched (no preventDefault, no open)', () => {
+    const div = document.createElement('div')
+    div.textContent = 'plain text'
+    const open = vi.fn()
+    const preventDefault = vi.fn()
+    handleMarkdownLinkClick({ target: div, metaKey: true, ctrlKey: false, preventDefault }, open)
+    expect(open).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/lib/links.ts
+++ b/packages/dashboard/src/lib/links.ts
@@ -63,7 +63,11 @@ export function handleMarkdownLinkClick(
     window.open(url, '_blank', 'noopener,noreferrer')
   },
 ): void {
-  const el = e.target as HTMLElement | null
+  // A click target is normally the deepest Element, but resolve a Text node to
+  // its parent (defensive) so `closest` can still reach the anchor and the
+  // native `target="_blank"` navigation stays gated.
+  const node = e.target
+  const el = node instanceof Element ? node : (node as { parentElement?: Element | null } | null)?.parentElement ?? null
   const anchor = el && typeof el.closest === 'function' ? el.closest('a[href]') : null
   if (!anchor) return // click wasn't on a link — leave selection/other handlers alone
   const url = resolveLinkOpen(anchor.getAttribute('href'), e)

--- a/packages/dashboard/src/lib/links.ts
+++ b/packages/dashboard/src/lib/links.ts
@@ -2,8 +2,13 @@
  * #6625 — modifier-click a rendered link to open it in the user's default
  * browser (Cmd on macOS, Ctrl on Windows/Linux), while a plain click leaves the
  * chat text selectable. Rendered markdown links are real `<a target="_blank">`
- * anchors (see lib/markdown.ts); this gates their navigation on a modifier so a
- * plain click/drag can select the surrounding text instead of navigating away.
+ * anchors (see lib/markdown.ts); this gates their navigation so a plain
+ * click/drag can select the surrounding text instead of navigating away.
+ *
+ * Keyboard activation is preserved: pressing Enter on a focused link dispatches
+ * a synthesized click with `detail === 0`, which we treat as an open (so the
+ * link stays operable by keyboard — WCAG 2.1.1). Only a plain MOUSE click
+ * (detail ≥ 1, no modifier) is suppressed.
  *
  * Safety: only `http:`/`https:` schemes open — the markdown renderer already
  * strips `javascript:`/`data:`/`vbscript:`, and this is a second gate at the
@@ -12,33 +17,42 @@
 
 const OPENABLE_SCHEME = /^https?:\/\//i
 
+/** Activation state read off a click event (test-friendly subset). */
+export interface LinkActivation {
+  metaKey?: boolean
+  ctrlKey?: boolean
+  /** `UIEvent.detail` — 0 for a keyboard-synthesized click (Enter), ≥1 for mouse. */
+  detail?: number
+}
+
 /**
- * The URL to open for a modifier-click, or `null` when it should NOT open
- * (plain click, or an unsafe/relative scheme). Pure — no DOM.
+ * The URL to open for this activation, or `null` when it should NOT open (a
+ * plain mouse click, or an unsafe/relative scheme). Opens on a modifier-click
+ * OR a keyboard activation (Enter). Pure — no DOM.
+ *
+ * NOTE: `href` must be the RAW attribute value (not a resolved `.href` DOM
+ * property) — resolving would turn `//evil.com` or `/rel` into an absolute URL
+ * that passes the http(s) gate. Callers use `getAttribute('href')`.
  */
-export function resolveModifierLinkOpen(
-  href: string | null | undefined,
-  mods: { metaKey?: boolean; ctrlKey?: boolean },
-): string | null {
+export function resolveLinkOpen(href: string | null | undefined, act: LinkActivation): string | null {
   if (!href) return null
-  if (!(mods.metaKey || mods.ctrlKey)) return null
+  const activate = act.metaKey || act.ctrlKey || act.detail === 0
+  if (!activate) return null
   const url = href.trim()
   return OPENABLE_SCHEME.test(url) ? url : null
 }
 
 /** Minimal shape of the click event fields this handler reads (test-friendly). */
-export interface LinkClickEvent {
+export interface LinkClickEvent extends LinkActivation {
   target: EventTarget | null
-  metaKey: boolean
-  ctrlKey: boolean
   preventDefault: () => void
 }
 
 /**
- * `onClick` handler for a container of rendered markdown. A modifier-click on an
- * `<a>` opens its (http/https) href in the browser; a plain click on an `<a>` is
- * suppressed so it does not navigate away, keeping the text selectable. A click
- * that isn't on a link is left completely untouched.
+ * `onClick` handler for a container of rendered markdown. A modifier-click (or
+ * keyboard Enter) on an `<a>` opens its (http/https) href in the browser; a
+ * plain mouse click on an `<a>` is suppressed so it does not navigate away,
+ * keeping the text selectable. A click that isn't on a link is left untouched.
  *
  * `open` is injectable so the behavior is unit-testable without a real
  * `window.open`; it defaults to a `noopener,noreferrer` new-tab open.
@@ -52,13 +66,13 @@ export function handleMarkdownLinkClick(
   const el = e.target as HTMLElement | null
   const anchor = el && typeof el.closest === 'function' ? el.closest('a[href]') : null
   if (!anchor) return // click wasn't on a link — leave selection/other handlers alone
-  const url = resolveModifierLinkOpen(anchor.getAttribute('href'), e)
+  const url = resolveLinkOpen(anchor.getAttribute('href'), e)
   if (url) {
     e.preventDefault()
     open(url)
     return
   }
-  // Plain click (or an unsafe scheme) ON a link: suppress the native
+  // Plain mouse click (or an unsafe scheme) ON a link: suppress the native
   // `target="_blank"` navigation so a click/drag selects text instead.
   e.preventDefault()
 }

--- a/packages/dashboard/src/lib/links.ts
+++ b/packages/dashboard/src/lib/links.ts
@@ -1,0 +1,64 @@
+/**
+ * #6625 — modifier-click a rendered link to open it in the user's default
+ * browser (Cmd on macOS, Ctrl on Windows/Linux), while a plain click leaves the
+ * chat text selectable. Rendered markdown links are real `<a target="_blank">`
+ * anchors (see lib/markdown.ts); this gates their navigation on a modifier so a
+ * plain click/drag can select the surrounding text instead of navigating away.
+ *
+ * Safety: only `http:`/`https:` schemes open — the markdown renderer already
+ * strips `javascript:`/`data:`/`vbscript:`, and this is a second gate at the
+ * click boundary so a crafted href can't open a dangerous scheme.
+ */
+
+const OPENABLE_SCHEME = /^https?:\/\//i
+
+/**
+ * The URL to open for a modifier-click, or `null` when it should NOT open
+ * (plain click, or an unsafe/relative scheme). Pure — no DOM.
+ */
+export function resolveModifierLinkOpen(
+  href: string | null | undefined,
+  mods: { metaKey?: boolean; ctrlKey?: boolean },
+): string | null {
+  if (!href) return null
+  if (!(mods.metaKey || mods.ctrlKey)) return null
+  const url = href.trim()
+  return OPENABLE_SCHEME.test(url) ? url : null
+}
+
+/** Minimal shape of the click event fields this handler reads (test-friendly). */
+export interface LinkClickEvent {
+  target: EventTarget | null
+  metaKey: boolean
+  ctrlKey: boolean
+  preventDefault: () => void
+}
+
+/**
+ * `onClick` handler for a container of rendered markdown. A modifier-click on an
+ * `<a>` opens its (http/https) href in the browser; a plain click on an `<a>` is
+ * suppressed so it does not navigate away, keeping the text selectable. A click
+ * that isn't on a link is left completely untouched.
+ *
+ * `open` is injectable so the behavior is unit-testable without a real
+ * `window.open`; it defaults to a `noopener,noreferrer` new-tab open.
+ */
+export function handleMarkdownLinkClick(
+  e: LinkClickEvent,
+  open: (url: string) => void = (url) => {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  },
+): void {
+  const el = e.target as HTMLElement | null
+  const anchor = el && typeof el.closest === 'function' ? el.closest('a[href]') : null
+  if (!anchor) return // click wasn't on a link — leave selection/other handlers alone
+  const url = resolveModifierLinkOpen(anchor.getAttribute('href'), e)
+  if (url) {
+    e.preventDefault()
+    open(url)
+    return
+  }
+  // Plain click (or an unsafe scheme) ON a link: suppress the native
+  // `target="_blank"` navigation so a click/drag selects text instead.
+  e.preventDefault()
+}


### PR DESCRIPTION
## Summary

Closes #6625.

Rendered markdown links in the dashboard chat are real `<a target="_blank">` anchors (`lib/markdown.ts`), so **any** click opened them — which fought text selection (you couldn't click into or select link text without navigating away). This gates opening on a **modifier-click** (Cmd on macOS, Ctrl on Windows/Linux) and leaves a plain click free to select text.

## Changes

- **new `lib/links.ts`:**
  - `resolveModifierLinkOpen(href, { metaKey, ctrlKey })` — pure: returns the URL to open only when a modifier is held **and** the scheme is `http`/`https`, else `null`.
  - `handleMarkdownLinkClick(e, open?)` — resolves the clicked `<a>` (via `closest`), opens on a modifier-click (`window.open(url, '_blank', 'noopener,noreferrer')`), else `preventDefault`s so the native `target="_blank"` navigation doesn't fire and a click/drag selects text. A click off a link is left untouched. `open` is injected for testing.
- **wire** the handler onto both markdown render surfaces: `ChatMessage.tsx` and `ChatView.tsx` (response / tool_use bodies).

## Safety & fallbacks

- **Scheme allowlist** — only `http`/`https` open, a second gate at the click boundary on top of the renderer's `javascript:`/`data:`/`vbscript:` strip.
- **Context menu** still works — only left-click is intercepted, so right-click → "Open in new tab" is intact.

## Verification

- **10 unit tests** (`links.test.ts`): the pure helper (modifier gate, scheme allowlist, blank/relative/unsafe hrefs, whitespace trim) + the DOM handler (opens on modifier-click, resolves an anchor from a child target, plain click suppresses without opening, unsafe scheme blocked, non-link click untouched).
- Full dashboard suite green (**4278**), typecheck clean.

## ⚠️ Flagged for live QA

The click **logic** is fully unit-tested, but the on-screen interaction needs a live check: (1) Cmd/Ctrl-click a link in a chat message actually opens your browser; (2) a plain click/drag now selects the link text instead of navigating; (3) right-click still offers "Open in new tab". This intentionally **changes** existing behavior (plain-click no longer opens) per the issue's "preserve text selection" requirement.

**Out of scope:** mobile app (modifier-click is a desktop gesture; tap-to-open is a separate concern). Keyboard `Enter`-to-open is preserved (opens on the keyboard-synthesized `detail === 0` click) — WCAG 2.1.1.