### PR TITLE
feat(server): orchestration engine foundations — run model, decision contract, turn driver (E-1)

### DIFF
--- a/packages/server/src/orchestration/decision-contract.js
+++ b/packages/server/src/orchestration/decision-contract.js
@@ -1,0 +1,217 @@
+/**
+ * Committee decision contract (engine foundations, epic #6691, step E-1) — the
+ * highest-risk piece. Models end each committee turn with a fenced JSON block
+ * (```chroxy-decision); this module extracts and validates it. Fail-closed:
+ * absence of a valid block is NEVER an approval — extractDecision throws, and
+ * the engine's policy (repair re-prompt → architect salvage → escalate) decides
+ * what to do. It never guesses a verdict.
+ *
+ * Pure — no I/O, no clock, no session. zod (server package ^4.3.6) validates
+ * per-kind; unknown keys are stripped, not fatal.
+ */
+
+import { z } from 'zod'
+
+export const DECISION_KINDS = [
+  'epic_plan', 'plan_of_attack', 'poa_review', 'work_result', 'result_review', 'synthesis',
+]
+
+const VERDICT = z.enum(['approve', 'revise', 'redelegate', 'escalate'])
+
+// Per-kind schemas. `kind` is a z.literal discriminator; unknown keys stripped.
+const SubtaskSpec = z.object({
+  title: z.string().min(1).max(300),
+  goal: z.string().min(1).max(8000),
+  role: z.enum(['audit', 'implement']),
+  dependsOn: z.array(z.string().max(128)).max(50).optional(),
+  successCriteria: z.string().max(4000).optional(),
+  filesHint: z.array(z.string().max(1024)).max(200).optional(),
+})
+
+export const DECISION_SCHEMAS = {
+  epic_plan: z.object({
+    kind: z.literal('epic_plan'),
+    summary: z.string().max(8000).optional(),
+    subtasks: z.array(SubtaskSpec).min(1).max(100),
+  }),
+  plan_of_attack: z.object({
+    kind: z.literal('plan_of_attack'),
+    plan: z.string().min(1).max(20000),
+    summary: z.string().min(1).max(4000),
+  }),
+  poa_review: z.object({
+    kind: z.literal('poa_review'),
+    verdict: VERDICT,
+    feedback: z.string().max(8000).optional(),
+  }),
+  work_result: z.object({
+    kind: z.literal('work_result'),
+    summary: z.string().min(1).max(20000),
+    filesChanged: z.array(z.string().max(1024)).max(500).optional(),
+    notes: z.string().max(8000).optional(),
+  }),
+  result_review: z.object({
+    kind: z.literal('result_review'),
+    verdict: VERDICT,
+    feedback: z.string().max(8000).optional(),
+  }),
+  synthesis: z.object({
+    kind: z.literal('synthesis'),
+    reportMarkdown: z.string().min(1).max(200000),
+    summary: z.string().max(8000).optional(),
+  }),
+}
+
+export class DecisionParseError extends Error {
+  constructor(stage, detail) {
+    super(`decision parse failed at ${stage}: ${detail}`)
+    this.name = 'DecisionParseError'
+    this.code = 'DECISION_PARSE_ERROR'
+    this.stage = stage // 'no_block' | 'parse' | 'kind' | 'schema'
+    this.detail = detail
+  }
+}
+
+const TAIL_SCAN_LIMIT = 32 * 1024
+
+function findFencedBlocks(text) {
+  // ```tag\n ... ``` — capture tag + body. Tolerates a trailing space after the
+  // tag and CRLF. Non-greedy body so adjacent fences don't merge.
+  const re = /```([a-zA-Z0-9_-]*)[ \t]*\r?\n([\s\S]*?)```/g
+  const blocks = []
+  let m
+  while ((m = re.exec(text)) !== null) blocks.push({ tag: m[1].toLowerCase(), body: m[2].trim() })
+  return blocks
+}
+
+// Last balanced {...} object in the final TAIL_SCAN_LIMIT chars, string-aware so
+// braces inside JSON strings don't confuse the depth count.
+function braceScanFromTail(text) {
+  const tail = text.length > TAIL_SCAN_LIMIT ? text.slice(text.length - TAIL_SCAN_LIMIT) : text
+  const end = tail.lastIndexOf('}')
+  if (end === -1) return null
+  let depth = 0
+  let inStr = false
+  for (let i = end; i >= 0; i--) {
+    const ch = tail[i]
+    if (inStr) {
+      // walking backwards: a quote closes the string unless it's escaped. We
+      // approximate escape handling by checking the preceding backslash run.
+      if (ch === '"') {
+        let bs = 0
+        let j = i - 1
+        while (j >= 0 && tail[j] === '\\') { bs++; j-- }
+        if (bs % 2 === 0) inStr = false
+      }
+      continue
+    }
+    if (ch === '"') { inStr = true; continue }
+    if (ch === '}') depth++
+    else if (ch === '{') {
+      depth--
+      if (depth === 0) return tail.slice(i, end + 1)
+    }
+  }
+  return null
+}
+
+/** Pick the decision block text from model output, scanning from the end. */
+function extractBlockText(text) {
+  const blocks = findFencedBlocks(text)
+  const byTag = (tag) => {
+    for (let i = blocks.length - 1; i >= 0; i--) if (blocks[i].tag === tag) return blocks[i].body
+    return null
+  }
+  return (
+    byTag('chroxy-decision')
+    || byTag('json')
+    || (blocks.length ? blocks[blocks.length - 1].body : null)
+    || braceScanFromTail(text)
+  )
+}
+
+function tolerantParse(raw) {
+  try { return JSON.parse(raw) } catch { /* fall through to tolerant pass */ }
+  const cleaned = raw
+    .replace(/\/\/[^\n\r]*/g, '') // line comments
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/[“”]/g, '"') // smart double quotes
+    .replace(/[‘’]/g, "'") // smart single quotes
+    .replace(/,(\s*[}\]])/g, '$1') // trailing commas
+  return JSON.parse(cleaned) // may throw — caller wraps
+}
+
+function zodErrorSummary(error) {
+  return error.issues
+    .slice(0, 8)
+    .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+    .join('; ')
+}
+
+/**
+ * Extract + validate the committee decision of `expectedKind` from model text.
+ * @returns {{ decision: object, warnings: string[] }}
+ * @throws {DecisionParseError}
+ */
+export function extractDecision(text, expectedKind) {
+  const schema = DECISION_SCHEMAS[expectedKind]
+  if (!schema) throw new DecisionParseError('kind', `unknown expectedKind '${expectedKind}'`)
+  const warnings = []
+  const raw = typeof text === 'string' ? extractBlockText(text) : null
+  if (raw == null || raw.length === 0) {
+    throw new DecisionParseError('no_block', 'no fenced chroxy-decision block, json block, or JSON object found')
+  }
+
+  let obj
+  try {
+    obj = tolerantParse(raw)
+  } catch (err) {
+    throw new DecisionParseError('parse', (err && err.message) || 'invalid JSON')
+  }
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    throw new DecisionParseError('parse', 'decision is not a JSON object')
+  }
+  // Distinguish a kind mismatch from a schema failure for clearer repair prompts.
+  if (obj.kind !== expectedKind) {
+    throw new DecisionParseError('kind', `expected kind '${expectedKind}', got '${obj.kind ?? '(absent)'}'`)
+  }
+  const parsed = schema.safeParse(obj)
+  if (!parsed.success) {
+    throw new DecisionParseError('schema', zodErrorSummary(parsed.error))
+  }
+  return { decision: parsed.data, warnings }
+}
+
+const EXAMPLES = {
+  epic_plan: '{ "kind": "epic_plan", "subtasks": [ { "title": "...", "goal": "...", "role": "audit" } ] }',
+  plan_of_attack: '{ "kind": "plan_of_attack", "plan": "...", "summary": "..." }',
+  poa_review: '{ "kind": "poa_review", "verdict": "approve", "feedback": "..." }',
+  work_result: '{ "kind": "work_result", "summary": "..." }',
+  result_review: '{ "kind": "result_review", "verdict": "approve" }',
+  synthesis: '{ "kind": "synthesis", "reportMarkdown": "# ..." }',
+}
+
+/** The per-turn instruction appended to a role prompt (NOT the capped preamble). */
+export function decisionInstruction(expectedKind) {
+  return [
+    `End your reply with exactly one fenced code block tagged \`chroxy-decision\` containing ONLY`,
+    `JSON of kind "${expectedKind}", matching:`,
+    '```chroxy-decision',
+    EXAMPLES[expectedKind] ?? '{ "kind": "..." }',
+    '```',
+    'The block must be the last thing in your message. Do not wrap it in prose.',
+  ].join('\n')
+}
+
+/** The corrective re-prompt sent to the same session on a parse failure. */
+export function buildRepairPrompt(expectedKind, parseError) {
+  const stage = parseError instanceof DecisionParseError ? parseError.stage : 'unknown'
+  const detail = parseError instanceof DecisionParseError ? parseError.detail : String(parseError)
+  return [
+    `Your previous reply's chroxy-decision block could not be used (${stage}: ${detail}).`,
+    `Reply with ONLY the corrected block — nothing else:`,
+    '```chroxy-decision',
+    EXAMPLES[expectedKind] ?? '{ "kind": "..." }',
+    '```',
+  ].join('\n')
+}

--- a/packages/server/src/orchestration/decision-contract.js
+++ b/packages/server/src/orchestration/decision-contract.js
@@ -130,15 +130,43 @@ function extractBlockText(text) {
   )
 }
 
+// Strip //, /* */ comments and trailing commas that are OUTSIDE JSON strings,
+// so a `//` (e.g. a URL) or a `, }` inside a string value is never mangled.
+// Smart quotes are normalized everywhere (they only ever appear as a typo for
+// real quotes, and a smart quote inside a value is still not valid JSON).
+function stripNoise(s) {
+  let out = ''
+  let inStr = false
+  let esc = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (inStr) {
+      out += ch
+      if (esc) esc = false
+      else if (ch === '\\') esc = true
+      else if (ch === '"') inStr = false
+      continue
+    }
+    if (ch === '"') { inStr = true; out += ch; continue }
+    // line comment
+    if (ch === '/' && s[i + 1] === '/') { while (i < s.length && s[i] !== '\n' && s[i] !== '\r') i++; i--; continue }
+    // block comment
+    if (ch === '/' && s[i + 1] === '*') { i += 2; while (i < s.length && !(s[i] === '*' && s[i + 1] === '/')) i++; i++; continue }
+    // trailing comma: a comma followed (after whitespace) by } or ]
+    if (ch === ',') {
+      let j = i + 1
+      while (j < s.length && /\s/.test(s[j])) j++
+      if (s[j] === '}' || s[j] === ']') continue // drop the comma
+    }
+    out += ch
+  }
+  return out
+}
+
 function tolerantParse(raw) {
   try { return JSON.parse(raw) } catch { /* fall through to tolerant pass */ }
-  const cleaned = raw
-    .replace(/\/\/[^\n\r]*/g, '') // line comments
-    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
-    .replace(/[“”]/g, '"') // smart double quotes
-    .replace(/[‘’]/g, "'") // smart single quotes
-    .replace(/,(\s*[}\]])/g, '$1') // trailing commas
-  return JSON.parse(cleaned) // may throw — caller wraps
+  const normalized = raw.replace(/[“”]/g, '"').replace(/[‘’]/g, "'")
+  return JSON.parse(stripNoise(normalized)) // may throw — caller wraps
 }
 
 function zodErrorSummary(error) {

--- a/packages/server/src/orchestration/run-model.js
+++ b/packages/server/src/orchestration/run-model.js
@@ -83,6 +83,7 @@ export class TransitionError extends Error {
 /** Throw unless `from -> to` is a legal RUN transition. cancelling/suspended are
  *  reachable from any non-terminal state; a self-loop on executing is allowed. */
 export function assertRunTransition(from, to) {
+  if (!RUN_STATUSES.has(from)) throw new TransitionError('run', `${from} (unknown state)`, to)
   if (!RUN_STATUSES.has(to)) throw new TransitionError('run', from, `${to} (unknown state)`)
   if (from === to && to === 'executing') return true
   if ((to === 'cancelling' || to === 'suspended') && !TERMINAL_RUN_STATUSES.has(from)) return true
@@ -94,6 +95,7 @@ export function assertRunTransition(from, to) {
 /** Throw unless `from -> to` is a legal SUBTASK transition. cancelled/interrupted
  *  are reachable from any non-terminal state (run cancel / restart). */
 export function assertNodeTransition(from, to) {
+  if (!NODE_STATUSES.has(from)) throw new TransitionError('node', `${from} (unknown state)`, to)
   if (!NODE_STATUSES.has(to)) throw new TransitionError('node', from, `${to} (unknown state)`)
   if ((to === 'cancelled' || to === 'interrupted') && !TERMINAL_NODE_STATUSES.has(from)) return true
   const allowed = NODE_TRANSITIONS[from]
@@ -124,6 +126,9 @@ export function nextGateId(runId) {
  */
 export function makeGate({ gateId, runId, kind, nodeId = null, summary, detail = null, budgetUsd = null, openedAt }) {
   if (!RUN_GATE_KIND_VALUES.includes(kind)) throw new Error(`unknown gate kind: ${kind}`)
+  // openedAt is a REQUIRED number on the wire (RunGateSchema); run-model is
+  // clock-free, so the caller (which has the clock) must stamp it.
+  if (!Number.isFinite(openedAt)) throw new Error('makeGate requires a numeric openedAt')
   return {
     gateId,
     runId,
@@ -133,7 +138,7 @@ export function makeGate({ gateId, runId, kind, nodeId = null, summary, detail =
     summary: summary ?? '',
     detail,
     budgetUsd,
-    openedAt: openedAt ?? null,
+    openedAt,
     resolvedAt: null,
     resolvedBy: null,
     note: null,

--- a/packages/server/src/orchestration/run-model.js
+++ b/packages/server/src/orchestration/run-model.js
@@ -1,0 +1,177 @@
+/**
+ * Orchestration state machines + gate registry (engine foundations, epic
+ * #6691, step E-1). Pure — no I/O, no clock. The canonical state/verdict
+ * vocabularies come from @chroxy/protocol (the wire contract is the single
+ * source of truth); this module adds the LEGAL-TRANSITION guards and the
+ * user-gate registry model the engine (E-2) drives.
+ *
+ * Distinct from run-record.js (M-2), which is the durable-persistence reducer.
+ * run-model owns "is this transition legal?"; run-record owns "fold this event
+ * into the stored record".
+ */
+
+import {
+  RUN_STATUS_VALUES,
+  RUN_NODE_STATUS_VALUES,
+  RUN_GATE_KIND_VALUES,
+  RUN_GATE_STATUS_VALUES,
+  COMMITTEE_VERDICT_VALUES,
+} from '@chroxy/protocol'
+
+export {
+  RUN_STATUS_VALUES,
+  RUN_NODE_STATUS_VALUES,
+  RUN_GATE_KIND_VALUES,
+  RUN_GATE_STATUS_VALUES,
+  COMMITTEE_VERDICT_VALUES,
+}
+
+const RUN_STATUSES = new Set(RUN_STATUS_VALUES)
+const NODE_STATUSES = new Set(RUN_NODE_STATUS_VALUES)
+
+export const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'cancelled'])
+export const TERMINAL_NODE_STATUSES = new Set(['done', 'skipped', 'failed', 'cancelled', 'interrupted'])
+
+// Legal run-state transitions. `cancelling` and `suspended` are reachable from
+// any non-terminal state (cancel request / daemon restart), handled specially
+// in assertRunTransition rather than enumerated on every row.
+const RUN_TRANSITIONS = {
+  created: ['planning'],
+  planning: ['plan_review', 'executing', 'failed'], // executing when autoApprovePlan skips the gate
+  plan_review: ['executing', 'cancelled'],
+  executing: ['plan_review', 'paused', 'budget_paused', 'synthesizing', 'executing', 'failed'],
+  paused: ['executing', 'cancelling'],
+  budget_paused: ['executing', 'synthesizing', 'cancelling'],
+  synthesizing: ['completed', 'failed'],
+  suspended: ['planning', 'plan_review', 'executing', 'budget_paused', 'paused', 'synthesizing', 'cancelled', 'failed'],
+  cancelling: ['cancelled'],
+  completed: [],
+  failed: [],
+  cancelled: [],
+}
+
+// Legal subtask transitions (the committee loop). `respawning` re-enters
+// `briefing`; a revise loops back to `briefing` (poa) or `executing` (result).
+const NODE_TRANSITIONS = {
+  pending: ['spawning', 'skipped', 'cancelled'],
+  spawning: ['briefing', 'failed', 'respawning'],
+  briefing: ['poa_review', 'failed'],
+  poa_review: ['executing', 'briefing', 'respawning', 'escalated', 'failed'],
+  executing: ['result_review', 'failed'],
+  result_review: ['merging', 'done', 'executing', 'respawning', 'escalated', 'failed'],
+  respawning: ['briefing', 'spawning', 'failed'],
+  merging: ['done', 'conflict_fixup', 'escalated', 'failed'],
+  conflict_fixup: ['merging', 'escalated', 'failed'],
+  escalated: ['briefing', 'done', 'skipped', 'failed'],
+  done: [],
+  skipped: [],
+  failed: [],
+  cancelled: [],
+  interrupted: ['briefing', 'cancelled', 'failed'], // resume re-drives; else cancelled
+}
+
+export class TransitionError extends Error {
+  constructor(kind, from, to) {
+    super(`illegal ${kind} transition: ${from} -> ${to}`)
+    this.name = 'TransitionError'
+    this.code = 'ILLEGAL_TRANSITION'
+    this.from = from
+    this.to = to
+  }
+}
+
+/** Throw unless `from -> to` is a legal RUN transition. cancelling/suspended are
+ *  reachable from any non-terminal state; a self-loop on executing is allowed. */
+export function assertRunTransition(from, to) {
+  if (!RUN_STATUSES.has(to)) throw new TransitionError('run', from, `${to} (unknown state)`)
+  if (from === to && to === 'executing') return true
+  if ((to === 'cancelling' || to === 'suspended') && !TERMINAL_RUN_STATUSES.has(from)) return true
+  const allowed = RUN_TRANSITIONS[from]
+  if (!allowed || !allowed.includes(to)) throw new TransitionError('run', from, to)
+  return true
+}
+
+/** Throw unless `from -> to` is a legal SUBTASK transition. cancelled/interrupted
+ *  are reachable from any non-terminal state (run cancel / restart). */
+export function assertNodeTransition(from, to) {
+  if (!NODE_STATUSES.has(to)) throw new TransitionError('node', from, `${to} (unknown state)`)
+  if ((to === 'cancelled' || to === 'interrupted') && !TERMINAL_NODE_STATUSES.has(from)) return true
+  const allowed = NODE_TRANSITIONS[from]
+  if (!allowed || !allowed.includes(to)) throw new TransitionError('node', from, to)
+  return true
+}
+
+export function isTerminalRunStatus(s) { return TERMINAL_RUN_STATUSES.has(s) }
+export function isTerminalNodeStatus(s) { return TERMINAL_NODE_STATUSES.has(s) }
+
+// --- Gate registry --------------------------------------------------------
+
+// Which committee verdict maps to which user-facing gate resolution. Architect
+// reviews that come back `approve` need no user gate; only the escalating
+// verdicts open a gate.
+export const GATE_DECISIONS = ['approve', 'reject', 'revise', 'skip']
+
+let _gateSeq = 0
+/** Deterministic-per-process gate id. `now`-free (the caller stamps openedAt). */
+export function nextGateId(runId) {
+  _gateSeq += 1
+  return `gate_${runId}_${_gateSeq}`
+}
+
+/**
+ * Build a user gate. Only the four RUN_GATE_KIND_VALUES kinds are user gates;
+ * architect-internal reviews are timeline entries, not gates (see design).
+ */
+export function makeGate({ gateId, runId, kind, nodeId = null, summary, detail = null, budgetUsd = null, openedAt }) {
+  if (!RUN_GATE_KIND_VALUES.includes(kind)) throw new Error(`unknown gate kind: ${kind}`)
+  return {
+    gateId,
+    runId,
+    nodeId,
+    kind,
+    status: 'pending',
+    summary: summary ?? '',
+    detail,
+    budgetUsd,
+    openedAt: openedAt ?? null,
+    resolvedAt: null,
+    resolvedBy: null,
+    note: null,
+  }
+}
+
+const GATE_STATUS_FOR_DECISION = {
+  approve: 'approved',
+  reject: 'rejected',
+  revise: 'revise_requested',
+  skip: 'skipped',
+}
+
+/**
+ * Resolve a pending gate. Returns a NEW gate object (pure). Throws if the gate
+ * is already resolved (idempotency is the caller's concern — a double-resolve
+ * is a real error worth surfacing) or the decision is unknown.
+ */
+export function resolveGate(gate, { decision, note = null, budgetUsd = null, resolvedBy = 'user', resolvedAt }) {
+  if (!GATE_DECISIONS.includes(decision)) throw new Error(`unknown gate decision: ${decision}`)
+  if (gate.status !== 'pending') {
+    const err = new Error(`gate ${gate.gateId} already resolved (${gate.status})`)
+    err.code = 'GATE_ALREADY_RESOLVED'
+    throw err
+  }
+  return {
+    ...gate,
+    status: GATE_STATUS_FOR_DECISION[decision],
+    resolvedAt: resolvedAt ?? null,
+    resolvedBy,
+    note,
+    // an approve-with-raise on a budget_overrun gate carries the new cap
+    budgetUsd: budgetUsd != null ? budgetUsd : gate.budgetUsd,
+  }
+}
+
+/** Expire a pending gate (timeout). Resolved gates are returned unchanged. */
+export function expireGate(gate, { resolvedAt } = {}) {
+  if (gate.status !== 'pending') return gate
+  return { ...gate, status: 'expired', resolvedAt: resolvedAt ?? null, resolvedBy: 'policy' }
+}

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -98,7 +98,7 @@ export class TurnDriver {
     if (!entry || !entry.session) return Promise.reject(new TurnError('SESSION_GONE', `session ${sessionId} not found`))
 
     return new Promise((resolve, reject) => {
-      const start = () => this._beginTurn(sessionId, entry, prompt, { label, timeoutMs }, resolve, reject)
+      const start = () => this._beginTurn(sessionId, prompt, { label, timeoutMs }, resolve, reject)
       if (!this._occupied.has(sessionId)) {
         this._occupied.add(sessionId)
         start()
@@ -110,7 +110,15 @@ export class TurnDriver {
     })
   }
 
-  _beginTurn(sessionId, entry, prompt, { label, timeoutMs }, resolve, reject) {
+  _beginTurn(sessionId, prompt, { label, timeoutMs }, resolve, reject) {
+    // Re-fetch the session at START time, not at driveTurn() time: a queued turn
+    // may have waited behind the mutex while its session was destroyed/replaced.
+    const entry = this._sm.getSession?.(sessionId)
+    if (!entry || !entry.session) {
+      reject(new TurnError('SESSION_GONE', `session ${sessionId} gone before its turn started`))
+      this._startNext(sessionId)
+      return
+    }
     const ctx = {
       sessionId,
       label,

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -1,0 +1,233 @@
+/**
+ * TurnDriver (engine foundations, epic #6691, step E-1) — the single primitive
+ * for driving one turn of a Chroxy session and getting its final text back.
+ * The orchestration engine never touches sessions directly; it drives them
+ * through here.
+ *
+ * Mechanics (design §4.2):
+ * - One `session_event` listener on the SessionManager; per-session FIFO mutex
+ *   so at most one driven turn runs per session (committee reviews serialize on
+ *   the architect session).
+ * - Epoch guard: events that arrive before our send, or a stray `result` with
+ *   no active turn, are ignored.
+ * - Text is accumulated live from `stream_delta` (per messageId) + non-streamed
+ *   `message {type:'response'}` events, bounded to MAX_ACCUM_BYTES with an
+ *   explicit truncation marker (the decision parser scans from the tail).
+ * - Completion keys ONLY off the `result` event (isRunning can stay true on
+ *   pending background shells). `error` is turn-terminal → TurnError.
+ * - Watchdog: on timeout, interrupt() the session and reject TURN_TIMEOUT.
+ * - `session_destroyed` mid-turn → SESSION_GONE.
+ */
+
+export const MAX_ACCUM_BYTES = 2 * 1024 * 1024
+export const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000
+const TRUNCATION_MARKER = '\n…[chroxy-orch: output truncated at 2MB]…\n'
+
+export class TurnError extends Error {
+  constructor(code, message, { partialText = '' } = {}) {
+    super(message || code)
+    this.name = 'TurnError'
+    this.code = code // TURN_ERROR | TURN_TIMEOUT | SESSION_GONE | SEND_FAILED
+    this.partialText = partialText
+  }
+}
+
+export class TurnDriver {
+  /**
+   * @param {{ sessionManager: import('node:events').EventEmitter, log?: object,
+   *   defaultTimeoutMs?: number }} opts
+   */
+  constructor({ sessionManager, log = null, defaultTimeoutMs = DEFAULT_TURN_TIMEOUT_MS }) {
+    if (!sessionManager || typeof sessionManager.on !== 'function') {
+      throw new Error('TurnDriver requires a sessionManager EventEmitter')
+    }
+    this._sm = sessionManager
+    this._log = log
+    this._defaultTimeoutMs = defaultTimeoutMs
+    this._active = new Map() // sessionId -> active turn context
+    this._occupied = new Set() // sessionId -> has a turn running or reserved
+    this._waiters = new Map() // sessionId -> FIFO array of start thunks
+    this._onSessionEvent = this._handleSessionEvent.bind(this)
+    this._onSessionDestroyed = this._handleSessionDestroyed.bind(this)
+    this._sm.on('session_event', this._onSessionEvent)
+    this._sm.on('session_destroyed', this._onSessionDestroyed)
+    this._disposed = false
+  }
+
+  dispose() {
+    this._disposed = true
+    this._sm.off?.('session_event', this._onSessionEvent)
+    this._sm.off?.('session_destroyed', this._onSessionDestroyed)
+    // Drop queued (never-started) turns first so rejecting in-flight ones can't
+    // start a waiter mid-teardown. Snapshot before mutating.
+    this._waiters.clear()
+    const active = [...this._active.values()]
+    this._active.clear()
+    this._occupied.clear()
+    for (const ctx of active) {
+      if (ctx.settled) continue
+      ctx.settled = true
+      if (ctx.timer) { clearTimeout(ctx.timer); ctx.timer = null }
+      ctx.reject(new TurnError('SESSION_GONE', 'TurnDriver disposed', { partialText: ctx.text() }))
+    }
+  }
+
+  /**
+   * Drive one turn: send `prompt`, accumulate output, resolve on `result`.
+   * The turn's context is registered SYNCHRONOUSLY when the per-session mutex is
+   * free, so no event can arrive before the accumulator exists (a fast provider
+   * can emit before the returned promise is even awaited). Contended turns queue
+   * FIFO and start synchronously when the prior turn releases.
+   * @returns {Promise<{ text: string, result: { cost, duration, usage } }>}
+   * @throws {TurnError}
+   */
+  driveTurn(sessionId, prompt, { label = null, timeoutMs = null } = {}) {
+    if (this._disposed) return Promise.reject(new TurnError('SESSION_GONE', 'TurnDriver disposed'))
+    const entry = this._sm.getSession?.(sessionId)
+    if (!entry || !entry.session) return Promise.reject(new TurnError('SESSION_GONE', `session ${sessionId} not found`))
+
+    return new Promise((resolve, reject) => {
+      const start = () => this._beginTurn(sessionId, entry, prompt, { label, timeoutMs }, resolve, reject)
+      if (!this._occupied.has(sessionId)) {
+        this._occupied.add(sessionId)
+        start()
+      } else {
+        const q = this._waiters.get(sessionId) || []
+        q.push(start)
+        this._waiters.set(sessionId, q)
+      }
+    })
+  }
+
+  _beginTurn(sessionId, entry, prompt, { label, timeoutMs }, resolve, reject) {
+    const ctx = {
+      sessionId,
+      label,
+      buffers: new Map(), // messageId -> streamed text
+      order: [], // {kind:'buf',mid} | {kind:'resp',text} in arrival order
+      bytes: 0,
+      truncated: false,
+      settled: false,
+      timer: null,
+      resolve,
+      reject,
+    }
+    ctx.text = () => this._assembleText(ctx)
+    this._active.set(sessionId, ctx)
+
+    const ms = Number.isFinite(timeoutMs) ? timeoutMs : this._defaultTimeoutMs
+    // NOT unref'd: an in-flight orchestration turn is real work that should hold
+    // the process open, and the timer is always cleared on turn completion /
+    // dispose (so it never leaks — cf. the #6027 leaked-handle family).
+    ctx.timer = setTimeout(() => {
+      try { entry.session.interrupt?.() } catch { /* best-effort */ }
+      this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_TIMEOUT', `turn timed out after ${ms}ms`, { partialText: ctx.text() })))
+    }, ms)
+
+    // Fire-and-forget send; a rejection (closing socket, etc.) is SEND_FAILED —
+    // NEVER leave it unhandled (an unhandled rejection crashes the daemon).
+    try {
+      const ret = entry.session.sendMessage(prompt, [], { clientMessageId: `orch-${label || 'turn'}` })
+      if (ret && typeof ret.then === 'function') {
+        ret.catch((err) => {
+          this._finishTurn(ctx, () => ctx.reject(new TurnError('SEND_FAILED', (err && err.message) || 'sendMessage rejected', { partialText: ctx.text() })))
+        })
+      }
+    } catch (err) {
+      this._finishTurn(ctx, () => ctx.reject(new TurnError('SEND_FAILED', (err && err.message) || 'sendMessage threw', { partialText: ctx.text() })))
+    }
+  }
+
+  _startNext(sessionId) {
+    const q = this._waiters.get(sessionId)
+    if (q && q.length > 0) {
+      const start = q.shift() // stays occupied — hand the slot to the next turn
+      start()
+    } else {
+      this._occupied.delete(sessionId)
+      this._waiters.delete(sessionId)
+    }
+  }
+
+  _handleSessionEvent({ sessionId, event, data } = {}) {
+    const ctx = this._active.get(sessionId)
+    if (!ctx || ctx.settled) return // epoch guard: no active turn → drop
+    switch (event) {
+      case 'stream_delta': {
+        const mid = data?.messageId ?? '_'
+        const delta = typeof data?.delta === 'string' ? data.delta : ''
+        if (!delta) break
+        if (!ctx.buffers.has(mid)) { ctx.buffers.set(mid, ''); ctx.order.push({ kind: 'buf', mid }) }
+        ctx.buffers.set(mid, ctx.buffers.get(mid) + this._boundedAccept(ctx, delta))
+        break
+      }
+      case 'message': {
+        if (data?.type === 'response' && typeof data.content === 'string' && data.content.length) {
+          const accepted = this._boundedAccept(ctx, data.content)
+          if (accepted.length) ctx.order.push({ kind: 'resp', text: accepted })
+        }
+        break
+      }
+      case 'result': {
+        const result = {
+          cost: data?.cost ?? null,
+          duration: data?.duration ?? null,
+          usage: data?.usage ?? null,
+        }
+        const text = this._assembleText(ctx)
+        this._finishTurn(ctx, () => ctx.resolve({ text, result }))
+        break
+      }
+      case 'error': {
+        this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_ERROR', (data && data.message) || 'session error', { partialText: this._assembleText(ctx) })))
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  _handleSessionDestroyed({ sessionId } = {}) {
+    const ctx = this._active.get(sessionId)
+    if (!ctx || ctx.settled) return
+    this._finishTurn(ctx, () => ctx.reject(new TurnError('SESSION_GONE', `session ${sessionId} destroyed mid-turn`, { partialText: this._assembleText(ctx) })))
+  }
+
+  // Accept as much of `str` as fits under the 2MB accumulator budget; returns
+  // the accepted text (with a truncation marker appended once, on the crossing).
+  // Pure w.r.t. `order` — the caller decides where the accepted text lands.
+  _boundedAccept(ctx, str) {
+    if (ctx.truncated) return ''
+    const room = MAX_ACCUM_BYTES - ctx.bytes
+    const bytes = Buffer.byteLength(str, 'utf8')
+    if (bytes <= room) {
+      ctx.bytes += bytes
+      return str
+    }
+    // over budget — take the codepoints that fit (stream decode drops a trailing
+    // partial sequence), then mark truncated so later output is ignored.
+    const slice = new TextDecoder('utf8').decode(Buffer.from(str, 'utf8').subarray(0, Math.max(0, room)), { stream: true })
+    ctx.bytes = MAX_ACCUM_BYTES
+    ctx.truncated = true
+    return slice + TRUNCATION_MARKER
+  }
+
+  _assembleText(ctx) {
+    // Concatenate in arrival order: streamed buffers by messageId + inline
+    // response strings. Falls back to nothing if empty (caller may read history).
+    const parts = []
+    for (const item of ctx.order) {
+      if (item.kind === 'buf') parts.push(ctx.buffers.get(item.mid) || '')
+      else parts.push(item.text)
+    }
+    return parts.join('')
+  }
+
+  _finishTurn(ctx, settle) {
+    if (ctx.settled) return
+    ctx.settled = true
+    if (ctx.timer) { clearTimeout(ctx.timer); ctx.timer = null }
+    this._active.delete(ctx.sessionId)
+    try { settle() } finally { this._startNext(ctx.sessionId) }
+  }
+}

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -21,6 +21,11 @@
 
 export const MAX_ACCUM_BYTES = 2 * 1024 * 1024
 export const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000
+// After a timeout+interrupt the mutex is held in a "draining" state until the
+// session confirms it stopped (a trailing result/error/stopped), so a late
+// event from the interrupted turn can't be misattributed to the next turn.
+// This bounds how long we wait for that confirmation before releasing anyway.
+export const DEFAULT_DRAIN_TIMEOUT_MS = 10 * 1000
 const TRUNCATION_MARKER = '\n…[chroxy-orch: output truncated at 2MB]…\n'
 
 export class TurnError extends Error {
@@ -37,16 +42,17 @@ export class TurnDriver {
    * @param {{ sessionManager: import('node:events').EventEmitter, log?: object,
    *   defaultTimeoutMs?: number }} opts
    */
-  constructor({ sessionManager, log = null, defaultTimeoutMs = DEFAULT_TURN_TIMEOUT_MS }) {
+  constructor({ sessionManager, log = null, defaultTimeoutMs = DEFAULT_TURN_TIMEOUT_MS, drainTimeoutMs = DEFAULT_DRAIN_TIMEOUT_MS }) {
     if (!sessionManager || typeof sessionManager.on !== 'function') {
       throw new Error('TurnDriver requires a sessionManager EventEmitter')
     }
     this._sm = sessionManager
     this._log = log
     this._defaultTimeoutMs = defaultTimeoutMs
+    this._drainTimeoutMs = drainTimeoutMs
     this._active = new Map() // sessionId -> active turn context
     this._occupied = new Set() // sessionId -> has a turn running or reserved
-    this._waiters = new Map() // sessionId -> FIFO array of start thunks
+    this._waiters = new Map() // sessionId -> FIFO array of { start, reject }
     this._onSessionEvent = this._handleSessionEvent.bind(this)
     this._onSessionDestroyed = this._handleSessionDestroyed.bind(this)
     this._sm.on('session_event', this._onSessionEvent)
@@ -58,13 +64,18 @@ export class TurnDriver {
     this._disposed = true
     this._sm.off?.('session_event', this._onSessionEvent)
     this._sm.off?.('session_destroyed', this._onSessionDestroyed)
-    // Drop queued (never-started) turns first so rejecting in-flight ones can't
-    // start a waiter mid-teardown. Snapshot before mutating.
-    this._waiters.clear()
+    // Reject queued (never-started) turns so their promises settle instead of
+    // hanging forever, then reject in-flight ones. Snapshot before mutating.
+    const waiters = [...this._waiters.values()].flat()
     const active = [...this._active.values()]
+    this._waiters.clear()
     this._active.clear()
     this._occupied.clear()
+    for (const w of waiters) {
+      try { w.reject(new TurnError('SESSION_GONE', 'TurnDriver disposed')) } catch { /* ignore */ }
+    }
     for (const ctx of active) {
+      if (ctx.drainTimer) { clearTimeout(ctx.drainTimer); ctx.drainTimer = null }
       if (ctx.settled) continue
       ctx.settled = true
       if (ctx.timer) { clearTimeout(ctx.timer); ctx.timer = null }
@@ -93,7 +104,7 @@ export class TurnDriver {
         start()
       } else {
         const q = this._waiters.get(sessionId) || []
-        q.push(start)
+        q.push({ start, reject })
         this._waiters.set(sessionId, q)
       }
     })
@@ -121,7 +132,10 @@ export class TurnDriver {
     // dispose (so it never leaks — cf. the #6027 leaked-handle family).
     ctx.timer = setTimeout(() => {
       try { entry.session.interrupt?.() } catch { /* best-effort */ }
-      this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_TIMEOUT', `turn timed out after ${ms}ms`, { partialText: ctx.text() })))
+      // Drain: settle the caller now, but HOLD the mutex until the interrupted
+      // session confirms it stopped, so its trailing events don't leak into the
+      // next turn (finding #6723).
+      this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_TIMEOUT', `turn timed out after ${ms}ms`, { partialText: ctx.text() })), { drain: true })
     }, ms)
 
     // Fire-and-forget send; a rejection (closing socket, etc.) is SEND_FAILED —
@@ -141,8 +155,8 @@ export class TurnDriver {
   _startNext(sessionId) {
     const q = this._waiters.get(sessionId)
     if (q && q.length > 0) {
-      const start = q.shift() // stays occupied — hand the slot to the next turn
-      start()
+      const next = q.shift() // stays occupied — hand the slot to the next turn
+      next.start()
     } else {
       this._occupied.delete(sessionId)
       this._waiters.delete(sessionId)
@@ -151,7 +165,16 @@ export class TurnDriver {
 
   _handleSessionEvent({ sessionId, event, data } = {}) {
     const ctx = this._active.get(sessionId)
-    if (!ctx || ctx.settled) return // epoch guard: no active turn → drop
+    if (!ctx) return // epoch guard: no active/draining turn for this session → drop
+    if (ctx.draining) {
+      // A settled-but-draining turn (post-timeout). Swallow its trailing output;
+      // a terminal event confirms the session stopped → release the mutex.
+      if (event === 'result' || event === 'error' || event === 'stopped' || event === 'stream_end') {
+        this._endDrain(ctx)
+      }
+      return
+    }
+    if (ctx.settled) return
     switch (event) {
       case 'stream_delta': {
         const mid = data?.messageId ?? '_'
@@ -223,11 +246,34 @@ export class TurnDriver {
     return parts.join('')
   }
 
-  _finishTurn(ctx, settle) {
+  _finishTurn(ctx, settle, { drain = false } = {}) {
     if (ctx.settled) return
     ctx.settled = true
     if (ctx.timer) { clearTimeout(ctx.timer); ctx.timer = null }
-    this._active.delete(ctx.sessionId)
-    try { settle() } finally { this._startNext(ctx.sessionId) }
+    // Settle the caller's promise immediately either way.
+    try { settle() } catch { /* settle should not throw */ }
+    if (drain) {
+      // Keep the ctx in _active (marked draining) so the mutex stays held and
+      // this session's trailing events are swallowed until it confirms it
+      // stopped or the drain watchdog fires.
+      ctx.draining = true
+      // unref'd: the caller's promise is already settled, so nothing awaited
+      // depends on this; it's just a grace period before releasing the mutex,
+      // and the process shouldn't stay alive for it. Normally a trailing
+      // terminal event ends the drain well before this fires.
+      ctx.drainTimer = setTimeout(() => this._endDrain(ctx), this._drainTimeoutMs)
+      if (typeof ctx.drainTimer.unref === 'function') ctx.drainTimer.unref()
+    } else {
+      this._active.delete(ctx.sessionId)
+      this._startNext(ctx.sessionId)
+    }
+  }
+
+  _endDrain(ctx) {
+    if (ctx.drainTimer) { clearTimeout(ctx.drainTimer); ctx.drainTimer = null }
+    if (this._active.get(ctx.sessionId) === ctx) {
+      this._active.delete(ctx.sessionId)
+      this._startNext(ctx.sessionId)
+    }
   }
 }

--- a/packages/server/tests/orchestration-decision-contract.test.js
+++ b/packages/server/tests/orchestration-decision-contract.test.js
@@ -64,6 +64,14 @@ describe('extractDecision — happy paths', () => {
     const text = 'note: {"kind":"work_result","summary":"contains } and { in text"}'
     assert.equal(extractDecision(text, 'work_result').decision.summary, 'contains } and { in text')
   })
+
+  it('tolerant parse does NOT mangle // or commas inside string values (fallback string-aware)', () => {
+    // trailing comma → strict parse fails → tolerant pass; the URL "//" and the
+    // in-string ", " must survive untouched.
+    const raw = '```chroxy-decision\n{"kind":"work_result","summary":"see http://example.com/a, and /* not a comment */ more",}\n```'
+    const { decision } = extractDecision(raw, 'work_result')
+    assert.equal(decision.summary, 'see http://example.com/a, and /* not a comment */ more')
+  })
 })
 
 describe('extractDecision — fail-closed', () => {

--- a/packages/server/tests/orchestration-decision-contract.test.js
+++ b/packages/server/tests/orchestration-decision-contract.test.js
@@ -1,0 +1,117 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+function grab(fn) { try { fn(); return null } catch (e) { return e } }
+import {
+  extractDecision,
+  DecisionParseError,
+  decisionInstruction,
+  buildRepairPrompt,
+} from '../src/orchestration/decision-contract.js'
+
+// #6691 E-1 — the committee decision contract. Fail-closed: absence of a valid
+// block THROWS; it is never read as an approval.
+
+const block = (obj) => '```chroxy-decision\n' + JSON.stringify(obj, null, 2) + '\n```'
+
+describe('extractDecision — happy paths', () => {
+  it('parses a chroxy-decision block at the end of prose', () => {
+    const text = 'Here is my review.\n\n' + block({ kind: 'poa_review', verdict: 'approve', feedback: 'lgtm' })
+    const { decision } = extractDecision(text, 'poa_review')
+    assert.equal(decision.verdict, 'approve')
+    assert.equal(decision.feedback, 'lgtm')
+  })
+
+  it('parses an epic_plan with subtasks', () => {
+    const { decision } = extractDecision(block({
+      kind: 'epic_plan',
+      subtasks: [{ title: 'audit auth', goal: 'find authz bugs', role: 'audit' }],
+    }), 'epic_plan')
+    assert.equal(decision.subtasks.length, 1)
+    assert.equal(decision.subtasks[0].role, 'audit')
+  })
+
+  it('strips unknown keys, keeps the schema fields', () => {
+    const { decision } = extractDecision(block({ kind: 'result_review', verdict: 'revise', extra: 'ignored', feedback: 'x' }), 'result_review')
+    assert.equal(decision.verdict, 'revise')
+    assert.equal('extra' in decision, false)
+  })
+
+  it('takes the LAST chroxy-decision block when several fences exist', () => {
+    const text = [
+      '```json\n{"kind":"poa_review","verdict":"escalate"}\n```',
+      'then reconsidered:',
+      block({ kind: 'poa_review', verdict: 'approve' }),
+    ].join('\n')
+    assert.equal(extractDecision(text, 'poa_review').decision.verdict, 'approve')
+  })
+
+  it('falls back to a json-tagged fence, then an untagged fence, then a tail brace-scan', () => {
+    // json-tagged fence
+    assert.equal(extractDecision('```json\n{"kind":"poa_review","verdict":"revise"}\n```', 'poa_review').decision.verdict, 'revise')
+    // untagged fence
+    assert.equal(extractDecision('```\n{"kind":"poa_review","verdict":"escalate"}\n```', 'poa_review').decision.verdict, 'escalate')
+    // bare object, no fence — tail brace-scan
+    assert.equal(extractDecision('final answer: {"kind":"poa_review","verdict":"approve"}', 'poa_review').decision.verdict, 'approve')
+  })
+
+  it('tolerant parse: comments, trailing commas, smart quotes', () => {
+    const raw = '```chroxy-decision\n{\n  // my verdict\n  “kind”: “poa_review”,\n  “verdict”: “approve”,\n}\n```'
+    assert.equal(extractDecision(raw, 'poa_review').decision.verdict, 'approve')
+  })
+
+  it('brace-scan ignores braces inside JSON strings', () => {
+    const text = 'note: {"kind":"work_result","summary":"contains } and { in text"}'
+    assert.equal(extractDecision(text, 'work_result').decision.summary, 'contains } and { in text')
+  })
+})
+
+describe('extractDecision — fail-closed', () => {
+  it('throws no_block when there is no block or object', () => {
+    const e = grab(() => extractDecision('I approve. lgtm!', 'poa_review'))
+    assert.equal(e.stage, 'no_block')
+  })
+
+  it('throws parse on unfixable JSON', () => {
+    const e = grab(() => extractDecision('```chroxy-decision\n{kind: poa_review, verdict}\n```', 'poa_review'))
+    assert.equal(e.stage, 'parse')
+  })
+
+  it('throws kind on a kind mismatch (distinct from schema failure)', () => {
+    const e = grab(() => extractDecision(block({ kind: 'result_review', verdict: 'approve' }), 'poa_review'))
+    assert.equal(e.stage, 'kind')
+  })
+
+  it('throws schema on a bad verdict enum / missing required field', () => {
+    const e1 = grab(() => extractDecision(block({ kind: 'poa_review', verdict: 'yes' }), 'poa_review'))
+    assert.equal(e1.stage, 'schema')
+    const e2 = grab(() => extractDecision(block({ kind: 'plan_of_attack', plan: 'x' }), 'plan_of_attack'))
+    assert.equal(e2.stage, 'schema') // missing summary
+  })
+
+  it('a quoted-JSON tail with the WRONG kind is not accepted (negative fixture)', () => {
+    // a config sample the worker merely quoted, not a real decision
+    const text = 'example config: {"kind":"some_config","value":42}\n(no decision follows)'
+    const e = grab(() => extractDecision(text, 'poa_review'))
+    assert.equal(e.stage, 'kind')
+  })
+
+  it('an empty string throws no_block, never returns a decision', () => {
+    assert.throws(() => extractDecision('', 'poa_review'), (e) => e instanceof DecisionParseError && e.stage === 'no_block')
+  })
+})
+
+describe('prompt helpers', () => {
+  it('decisionInstruction embeds the kind + a tagged example', () => {
+    const p = decisionInstruction('epic_plan')
+    assert.match(p, /chroxy-decision/)
+    assert.match(p, /epic_plan/)
+  })
+  it('buildRepairPrompt surfaces the failure stage + detail', () => {
+    let caught
+    try { extractDecision('nope', 'poa_review') } catch (e) { caught = e }
+    const p = buildRepairPrompt('poa_review', caught)
+    assert.match(p, /no_block/)
+    assert.match(p, /corrected block/)
+  })
+})

--- a/packages/server/tests/orchestration-run-model.test.js
+++ b/packages/server/tests/orchestration-run-model.test.js
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+function grab(fn) { try { fn(); return null } catch (e) { return e } }
+import {
+  assertRunTransition,
+  assertNodeTransition,
+  TransitionError,
+  makeGate,
+  resolveGate,
+  expireGate,
+  nextGateId,
+  isTerminalRunStatus,
+  isTerminalNodeStatus,
+} from '../src/orchestration/run-model.js'
+
+// #6691 E-1 — state-machine guards + gate registry.
+
+describe('run transitions', () => {
+  it('allows the canonical happy path', () => {
+    assert.equal(assertRunTransition('created', 'planning'), true)
+    assert.equal(assertRunTransition('planning', 'plan_review'), true)
+    assert.equal(assertRunTransition('plan_review', 'executing'), true)
+    assert.equal(assertRunTransition('executing', 'synthesizing'), true)
+    assert.equal(assertRunTransition('synthesizing', 'completed'), true)
+  })
+  it('allows cancelling/suspended from any non-terminal state', () => {
+    assert.equal(assertRunTransition('executing', 'cancelling'), true)
+    assert.equal(assertRunTransition('planning', 'suspended'), true)
+  })
+  it('rejects illegal + terminal-source transitions', () => {
+    assert.throws(() => assertRunTransition('created', 'completed'), TransitionError)
+    assert.throws(() => assertRunTransition('completed', 'executing'), TransitionError)
+    assert.throws(() => assertRunTransition('executing', 'nonsense'), TransitionError)
+    assert.throws(() => assertRunTransition('completed', 'cancelling'), TransitionError) // terminal source
+  })
+  it('isTerminalRunStatus', () => {
+    assert.equal(isTerminalRunStatus('completed'), true)
+    assert.equal(isTerminalRunStatus('executing'), false)
+  })
+})
+
+describe('node (subtask) transitions', () => {
+  it('allows the committee loop', () => {
+    assert.equal(assertNodeTransition('pending', 'spawning'), true)
+    assert.equal(assertNodeTransition('spawning', 'briefing'), true)
+    assert.equal(assertNodeTransition('briefing', 'poa_review'), true)
+    assert.equal(assertNodeTransition('poa_review', 'executing'), true) // approve
+    assert.equal(assertNodeTransition('poa_review', 'briefing'), true) // revise
+    assert.equal(assertNodeTransition('result_review', 'merging'), true)
+    assert.equal(assertNodeTransition('merging', 'conflict_fixup'), true)
+    assert.equal(assertNodeTransition('conflict_fixup', 'merging'), true)
+    assert.equal(assertNodeTransition('result_review', 'escalated'), true)
+  })
+  it('allows cancelled/interrupted from any non-terminal state', () => {
+    assert.equal(assertNodeTransition('executing', 'interrupted'), true)
+    assert.equal(assertNodeTransition('briefing', 'cancelled'), true)
+  })
+  it('rejects illegal transitions', () => {
+    assert.throws(() => assertNodeTransition('pending', 'merging'), TransitionError)
+    assert.throws(() => assertNodeTransition('done', 'executing'), TransitionError)
+    assert.throws(() => assertNodeTransition('done', 'interrupted'), TransitionError) // terminal source
+  })
+  it('isTerminalNodeStatus', () => {
+    assert.equal(isTerminalNodeStatus('done'), true)
+    assert.equal(isTerminalNodeStatus('escalated'), false)
+  })
+})
+
+describe('gate registry', () => {
+  it('nextGateId is unique per call', () => {
+    const a = nextGateId('r1'), b = nextGateId('r1')
+    assert.notEqual(a, b)
+  })
+  it('makeGate rejects an unknown kind', () => {
+    assert.throws(() => makeGate({ gateId: 'g', runId: 'r', kind: 'bogus', summary: 's' }))
+  })
+  it('resolveGate maps decisions to statuses and is a pure copy', () => {
+    const g = makeGate({ gateId: 'g1', runId: 'r1', kind: 'epic_plan', summary: 'approve plan', openedAt: 1 })
+    const approved = resolveGate(g, { decision: 'approve', resolvedAt: 2 })
+    assert.equal(approved.status, 'approved')
+    assert.equal(approved.resolvedBy, 'user')
+    assert.equal(g.status, 'pending', 'original not mutated')
+    assert.equal(resolveGate(g, { decision: 'reject', resolvedAt: 2 }).status, 'rejected')
+    assert.equal(resolveGate(g, { decision: 'revise', resolvedAt: 2 }).status, 'revise_requested')
+    assert.equal(resolveGate(g, { decision: 'skip', resolvedAt: 2 }).status, 'skipped')
+  })
+  it('resolveGate carries budgetUsd on an approve-with-raise', () => {
+    const g = makeGate({ gateId: 'g1', runId: 'r1', kind: 'budget_overrun', summary: 'over', openedAt: 1 })
+    const r = resolveGate(g, { decision: 'approve', budgetUsd: 50, resolvedAt: 2 })
+    assert.equal(r.budgetUsd, 50)
+  })
+  it('resolveGate throws on a double-resolve and on an unknown decision', () => {
+    const g = makeGate({ gateId: 'g1', runId: 'r1', kind: 'epic_plan', summary: 's', openedAt: 1 })
+    const done = resolveGate(g, { decision: 'approve', resolvedAt: 2 })
+    const e = grab(() => resolveGate(done, { decision: 'approve', resolvedAt: 3 }))
+    assert.equal(e.code, 'GATE_ALREADY_RESOLVED')
+    assert.throws(() => resolveGate(g, { decision: 'bogus' }))
+  })
+  it('expireGate marks a pending gate expired by policy; resolved gates unchanged', () => {
+    const g = makeGate({ gateId: 'g1', runId: 'r1', kind: 'escalation', summary: 's', openedAt: 1 })
+    const ex = expireGate(g, { resolvedAt: 9 })
+    assert.equal(ex.status, 'expired')
+    assert.equal(ex.resolvedBy, 'policy')
+    const done = resolveGate(g, { decision: 'approve', resolvedAt: 2 })
+    assert.equal(expireGate(done), done, 'already-resolved gate returned unchanged')
+  })
+})

--- a/packages/server/tests/orchestration-run-model.test.js
+++ b/packages/server/tests/orchestration-run-model.test.js
@@ -33,6 +33,7 @@ describe('run transitions', () => {
     assert.throws(() => assertRunTransition('completed', 'executing'), TransitionError)
     assert.throws(() => assertRunTransition('executing', 'nonsense'), TransitionError)
     assert.throws(() => assertRunTransition('completed', 'cancelling'), TransitionError) // terminal source
+    assert.throws(() => assertRunTransition('bogus_from', 'cancelling'), TransitionError) // unknown source
   })
   it('isTerminalRunStatus', () => {
     assert.equal(isTerminalRunStatus('completed'), true)
@@ -60,6 +61,7 @@ describe('node (subtask) transitions', () => {
     assert.throws(() => assertNodeTransition('pending', 'merging'), TransitionError)
     assert.throws(() => assertNodeTransition('done', 'executing'), TransitionError)
     assert.throws(() => assertNodeTransition('done', 'interrupted'), TransitionError) // terminal source
+    assert.throws(() => assertNodeTransition('bogus_from', 'cancelled'), TransitionError) // unknown source
   })
   it('isTerminalNodeStatus', () => {
     assert.equal(isTerminalNodeStatus('done'), true)
@@ -74,6 +76,10 @@ describe('gate registry', () => {
   })
   it('makeGate rejects an unknown kind', () => {
     assert.throws(() => makeGate({ gateId: 'g', runId: 'r', kind: 'bogus', summary: 's' }))
+  })
+  it('makeGate requires a numeric openedAt (wire contract)', () => {
+    assert.throws(() => makeGate({ gateId: 'g', runId: 'r', kind: 'epic_plan', summary: 's' }))
+    assert.equal(makeGate({ gateId: 'g', runId: 'r', kind: 'epic_plan', summary: 's', openedAt: 5 }).openedAt, 5)
   })
   it('resolveGate maps decisions to statuses and is a pure copy', () => {
     const g = makeGate({ gateId: 'g1', runId: 'r1', kind: 'epic_plan', summary: 'approve plan', openedAt: 1 })

--- a/packages/server/tests/orchestration-turn-driver.test.js
+++ b/packages/server/tests/orchestration-turn-driver.test.js
@@ -143,4 +143,41 @@ describe('TurnDriver — failure modes', () => {
     const e = await driver.driveTurn('nope', 'go').then(() => null, (err) => err)
     assert.equal(e.code, 'SESSION_GONE')
   })
+
+  it('dispose() rejects a turn queued behind the mutex (no hang)', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first')
+    const p2 = driver.driveTurn('s1', 'second') // queued behind the mutex
+    driver.dispose()
+    driver = null // afterEach won't double-dispose
+    const e1 = await p1.then(() => null, (err) => err)
+    const e2 = await p2.then(() => null, (err) => err)
+    assert.equal(e1.code, 'SESSION_GONE')
+    assert.equal(e2.code, 'SESSION_GONE', 'queued turn settled, not left hanging')
+  })
+})
+
+describe('TurnDriver — post-timeout drain (no cross-turn misattribution)', () => {
+  it('swallows a timed-out turn\'s trailing events; the next turn keeps its own', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    // turn-1 times out fast → interrupt + drain (mutex held)
+    const p1 = driver.driveTurn('s1', 'first', { timeoutMs: 10 })
+    const p2 = driver.driveTurn('s1', 'second') // queued behind the drain
+    const e1 = await p1.then(() => null, (err) => err)
+    assert.equal(e1.code, 'TURN_TIMEOUT')
+    // turn-1's LATE trailing output arrives after the timeout — must be swallowed
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'STALE-from-turn-1' })
+    sm.ev('s1', 'result', { cost: 99, duration: 99, usage: { input_tokens: 999 } }) // ends the drain
+    // now turn-2 runs and gets ITS output
+    await Promise.resolve()
+    sm.ev('s1', 'stream_delta', { messageId: 'm2', delta: 'fresh-turn-2' })
+    sm.ev('s1', 'result', { cost: 2, duration: 2, usage: { input_tokens: 2 } })
+    const r2 = await p2
+    assert.equal(r2.text, 'fresh-turn-2', 'turn-2 did not absorb turn-1 stale delta')
+    assert.equal(r2.result.cost, 2, 'turn-2 did not absorb turn-1 stale result')
+  })
 })

--- a/packages/server/tests/orchestration-turn-driver.test.js
+++ b/packages/server/tests/orchestration-turn-driver.test.js
@@ -25,7 +25,8 @@ function mkStub() {
   }
   // emit a session_event for a session
   sm.ev = (id, event, data) => sm.emit('session_event', { sessionId: id, event, data })
-  sm.destroy = (id) => sm.emit('session_destroyed', { sessionId: id })
+  // destroy: remove from the map (so getSession re-fetch fails) AND emit the event
+  sm.destroy = (id) => { sessions.delete(id); sm.emit('session_destroyed', { sessionId: id }) }
   return { sm, addSession }
 }
 
@@ -142,6 +143,20 @@ describe('TurnDriver — failure modes', () => {
     driver = new TurnDriver({ sessionManager: sm })
     const e = await driver.driveTurn('nope', 'go').then(() => null, (err) => err)
     assert.equal(e.code, 'SESSION_GONE')
+  })
+
+  it('a queued turn rejects SESSION_GONE if its session is destroyed while waiting', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first')
+    const p2 = driver.driveTurn('s1', 'second') // queued behind the mutex
+    // destroy the session — turn-1 rejects; turn-2 re-fetches at start and finds it gone
+    sm.destroy('s1')
+    const e1 = await p1.then(() => null, (err) => err)
+    const e2 = await p2.then(() => null, (err) => err)
+    assert.equal(e1.code, 'SESSION_GONE')
+    assert.equal(e2.code, 'SESSION_GONE', 'queued turn re-validates the session at start time')
   })
 
   it('dispose() rejects a turn queued behind the mutex (no hang)', async () => {

--- a/packages/server/tests/orchestration-turn-driver.test.js
+++ b/packages/server/tests/orchestration-turn-driver.test.js
@@ -1,0 +1,146 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { TurnDriver, TurnError } from '../src/orchestration/turn-driver.js'
+
+// #6691 E-1 — the driven-turn primitive, tested against a stub SessionManager
+// that mimics the real session_event / session_destroyed surface. No real
+// sessions, no ~/.chroxy.
+
+// A fake SessionManager: EventEmitter + getSession returning a fake session
+// whose sendMessage/interrupt we can observe. We drive events manually.
+function mkStub() {
+  const sm = new EventEmitter()
+  const sessions = new Map()
+  sm.getSession = (id) => sessions.get(id) || null
+  const addSession = (id, { sendImpl } = {}) => {
+    const session = {
+      sent: [],
+      interrupted: 0,
+      sendMessage(prompt, _atts, opts) { this.sent.push({ prompt, opts }); return sendImpl ? sendImpl() : undefined },
+      interrupt() { this.interrupted++ },
+    }
+    sessions.set(id, { session })
+    return session
+  }
+  // emit a session_event for a session
+  sm.ev = (id, event, data) => sm.emit('session_event', { sessionId: id, event, data })
+  sm.destroy = (id) => sm.emit('session_destroyed', { sessionId: id })
+  return { sm, addSession }
+}
+
+let driver
+afterEach(() => { driver?.dispose(); driver = null })
+
+describe('TurnDriver — happy path', () => {
+  it('accumulates streamed deltas and resolves on result', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'hello', { label: 'plan' })
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'Hel' })
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'lo world' })
+    sm.ev('s1', 'result', { cost: 0.1, duration: 5, usage: { input_tokens: 3 } })
+    const { text, result } = await p
+    assert.equal(text, 'Hello world')
+    assert.equal(result.cost, 0.1)
+    assert.deepEqual(result.usage, { input_tokens: 3 })
+  })
+
+  it('captures non-streamed message{response} fallback text', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'hi')
+    sm.ev('s1', 'message', { type: 'response', content: 'compact summary' })
+    sm.ev('s1', 'result', { cost: 0, duration: 1, usage: {} })
+    assert.equal((await p).text, 'compact summary')
+  })
+})
+
+describe('TurnDriver — epoch guard + mutex', () => {
+  it('ignores stray events with no active turn', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    // events before any driveTurn are dropped
+    sm.ev('s1', 'stream_delta', { messageId: 'm0', delta: 'ghost' })
+    sm.ev('s1', 'result', { cost: 9, duration: 9, usage: {} })
+    const p = driver.driveTurn('s1', 'go')
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'real' })
+    sm.ev('s1', 'result', { cost: 1, duration: 1, usage: {} })
+    const { text, result } = await p
+    assert.equal(text, 'real', 'ghost delta from before the turn ignored')
+    assert.equal(result.cost, 1)
+  })
+
+  it('serializes two turns on the same session (FIFO mutex)', async () => {
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first')
+    const p2 = driver.driveTurn('s1', 'second')
+    // only the first turn's send has happened; second is queued behind the mutex
+    assert.equal(s.sent.length, 1)
+    assert.equal(s.sent[0].prompt, 'first')
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'A' })
+    sm.ev('s1', 'result', { cost: 0, duration: 0, usage: {} })
+    assert.equal((await p1).text, 'A')
+    // now the second turn runs
+    await Promise.resolve()
+    assert.equal(s.sent.length, 2)
+    assert.equal(s.sent[1].prompt, 'second')
+    sm.ev('s1', 'stream_delta', { messageId: 'm2', delta: 'B' })
+    sm.ev('s1', 'result', { cost: 0, duration: 0, usage: {} })
+    assert.equal((await p2).text, 'B')
+  })
+})
+
+describe('TurnDriver — failure modes', () => {
+  it('rejects TURN_ERROR on a session error event (with partialText)', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'go')
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'partial' })
+    sm.ev('s1', 'error', { message: 'boom' })
+    const e = await p.then(() => null, (err) => err)
+    assert.ok(e instanceof TurnError)
+    assert.equal(e.code, 'TURN_ERROR')
+    assert.equal(e.partialText, 'partial')
+  })
+
+  it('rejects SESSION_GONE when the session is destroyed mid-turn', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'go')
+    sm.destroy('s1')
+    const e = await p.then(() => null, (err) => err)
+    assert.equal(e.code, 'SESSION_GONE')
+  })
+
+  it('rejects SEND_FAILED when sendMessage rejects', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1', { sendImpl: () => Promise.reject(new Error('socket closing')) })
+    driver = new TurnDriver({ sessionManager: sm })
+    const e = await driver.driveTurn('s1', 'go').then(() => null, (err) => err)
+    assert.equal(e.code, 'SEND_FAILED')
+  })
+
+  it('rejects TURN_TIMEOUT and interrupts the session', async () => {
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const e = await driver.driveTurn('s1', 'go', { timeoutMs: 10 }).then(() => null, (err) => err)
+    assert.equal(e.code, 'TURN_TIMEOUT')
+    assert.equal(s.interrupted, 1)
+  })
+
+  it('throws SESSION_GONE synchronously for an unknown session', async () => {
+    const { sm } = mkStub()
+    driver = new TurnDriver({ sessionManager: sm })
+    const e = await driver.driveTurn('nope', 'go').then(() => null, (err) => err)
+    assert.equal(e.code, 'SESSION_GONE')
+  })
+})


### PR DESCRIPTION
## Summary

PR-5 (step E-1) of the orchestration epic (#6691): the three pure, independently-testable foundations the committee engine (E-2) is built on. No engine/SessionManager wiring yet — these are the primitives.

- **`run-model.js`** — run + subtask state-machine transition guards (`assertRunTransition`/`assertNodeTransition`; `cancelling`/`suspended` and `cancelled`/`interrupted` reachable from any non-terminal state) and the **user-gate registry** (`makeGate`/`resolveGate`/`expireGate`; decision→status map; a double-resolve throws `GATE_ALREADY_RESOLVED`). Imports the canonical enums from `@chroxy/protocol` — the wire contract is the single source of truth, so the engine and the wire can't drift.
- **`decision-contract.js`** (highest-risk) — the committee JSON contract. `extractDecision` scans **from the tail** (`chroxy-decision` fence → `json` fence → any fence → **string-aware brace-scan** of the final 32KB), tolerant-parses (`//`/`/* */` comments, trailing commas, smart quotes), and validates a **per-kind zod schema**. **Fail-closed**: no valid block → `DecisionParseError {stage: no_block|parse|kind|schema}`, **never** an approval. `decisionInstruction`/`buildRepairPrompt` generate the per-turn contract instruction and the repair re-prompt.
- **`turn-driver.js`** — the single driven-turn primitive. Per-session **FIFO mutex with synchronous context registration** (a fast provider can emit before the returned promise is even awaited — the turn context must exist first), **epoch guard** (events before the turn / stray results dropped), live text accumulation (`stream_delta` + non-streamed `message{response}`) bounded to 2MB with a truncation marker, watchdog → `interrupt()`, resolves on `result`, rejects `TurnError {TURN_ERROR|TURN_TIMEOUT|SESSION_GONE|SEND_FAILED}` (the fire-and-forget `sendMessage` rejection is caught — an unhandled rejection would crash the daemon).

## Tests
38 tests across the three modules: the fail-closed **negative fixtures** (a quoted-JSON tail with the wrong kind is rejected, not accepted; empty/prose → `no_block`), tolerant-parse cases, brace-scan string-awareness, transition-guard tables, the full gate lifecycle, and every TurnDriver failure mode + mutex serialization + epoch guard against a stub SessionManager. eslint + all 5 custom shell lints green.

Two design notes verified during implementation: the mutex must register the turn context **synchronously** (an `await` before registration drops synchronously-emitted events), and the watchdog timer is **not** `unref`'d (an in-flight turn is real work that should hold the process open; it's always cleared on completion, so no leak).

Closes #6696. Part of #6691.

_(2 codex integration failures locally = the known #6708 XProtect-incident env failures; this diff only adds orchestration/ files.)_