### PR TITLE
feat(dashboard): copy control on assistant response bubbles (#6631)

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -30,6 +30,21 @@ describe('ChatView', () => {
     expect(screen.getByText('Message 2')).toBeInTheDocument()
   })
 
+  it('shows the copy control only on finished, non-empty response bubbles (#6631)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'r-done', type: 'response', content: 'finished answer', timestamp: 1 },
+      { id: 'r-stream', type: 'response', content: 'partial…', timestamp: 2, isStreaming: true },
+      { id: 'r-empty', type: 'response', content: '   ', timestamp: 3 },
+      { id: 'tool', type: 'tool_use', content: 'tool text', timestamp: 4 },
+      { id: 'sys', type: 'system', content: 'system note', timestamp: 5 },
+      { id: 'usr', type: 'user_input', content: 'my question', timestamp: 6 },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    // Exactly one — the finished, non-empty response. A regression that dropped
+    // the `!isStreaming` / `type === 'response'` / non-empty gate would fail here.
+    expect(screen.queryAllByTestId('msg-copy-button')).toHaveLength(1)
+  })
+
   it('renders thinking as a collapsed disclosure (chat redesign #6391)', () => {
     const messages: ChatViewMessage[] = [
       { id: 't1', type: 'thinking', content: 'deep-secret-reasoning', timestamp: Date.now() },

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -21,6 +21,7 @@ import { bumpRenderCount, type ChatActivityState } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
 import { handleMarkdownLinkClick } from '../lib/links'
+import { CopyButton } from './CopyButton'
 import { MessageRowShell } from './MeasuredRow'
 import { ChatExpandContext, type ChatExpandRegistry } from './chatExpandRegistry'
 import { useWindowedRange } from './useWindowedRange'
@@ -333,6 +334,10 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
     <>
       {type !== 'user_input' && icon}
       <div className={`msg ${TYPE_CLASS[type] || 'assistant'}${isStreaming ? ' streaming' : ''}${queued ? ' queued' : ''}`}>
+        {/* #6631: a subtle copy control on assistant responses (not while still
+            streaming — copy the finished text). Room for future per-response
+            actions alongside it. */}
+        {type === 'response' && !isStreaming && content.trim() !== '' && <CopyButton content={content} />}
         {body}
         {queued && (
           <span className="msg-queued" data-testid={`msg-queued-${id}`}>

--- a/packages/dashboard/src/components/CopyButton.test.tsx
+++ b/packages/dashboard/src/components/CopyButton.test.tsx
@@ -43,6 +43,20 @@ describe('CopyButton (#6631)', () => {
     addServerError.mockRestore()
   })
 
+  it('resets the copied ✓ when a re-click fails (latest attempt wins)', async () => {
+    mockWriteText.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError').mockImplementation(() => {})
+    render(<CopyButton content="x" />)
+    const btn = screen.getByTestId('msg-copy-button')
+    fireEvent.click(btn)
+    await waitFor(() => expect(btn).toHaveAttribute('data-copied', 'true'))
+    // Second click fails — the stale ✓ must clear rather than linger.
+    fireEvent.click(btn)
+    await waitFor(() => expect(addServerError).toHaveBeenCalled())
+    expect(btn).not.toHaveAttribute('data-copied')
+    addServerError.mockRestore()
+  })
+
   it('stops the click from propagating to parent handlers', () => {
     mockWriteText.mockResolvedValue(true)
     const parentClick = vi.fn()

--- a/packages/dashboard/src/components/CopyButton.test.tsx
+++ b/packages/dashboard/src/components/CopyButton.test.tsx
@@ -29,11 +29,13 @@ describe('CopyButton (#6631)', () => {
     expect(mockWriteText).toHaveBeenCalledWith('the full response text')
     await waitFor(() => expect(screen.getByTestId('msg-copy-button')).toHaveAttribute('data-copied', 'true'))
     expect(screen.getByTestId('msg-copy-button')).toHaveAttribute('aria-label', 'Copied')
+    // a11y: the success is announced through a polite live region
+    expect(screen.getByRole('status')).toHaveTextContent('Copied')
   })
 
   it('surfaces a warning toast and does NOT show copied when the clipboard write fails', async () => {
     mockWriteText.mockResolvedValue(false)
-    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError')
+    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError').mockImplementation(() => {})
     render(<CopyButton content="x" />)
     fireEvent.click(screen.getByTestId('msg-copy-button'))
     await waitFor(() => expect(addServerError).toHaveBeenCalledWith(expect.stringContaining('Failed to copy'), undefined, 'warning'))

--- a/packages/dashboard/src/components/CopyButton.test.tsx
+++ b/packages/dashboard/src/components/CopyButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { CopyButton } from './CopyButton'
+import { writeText } from '../utils/clipboard'
+import { useConnectionStore } from '../store/connection'
+
+vi.mock('../utils/clipboard', () => ({ writeText: vi.fn() }))
+const mockWriteText = vi.mocked(writeText)
+
+describe('CopyButton (#6631)', () => {
+  beforeEach(() => {
+    mockWriteText.mockReset()
+  })
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders an accessible copy button', () => {
+    render(<CopyButton content="hello world" />)
+    const btn = screen.getByTestId('msg-copy-button')
+    expect(btn).toHaveAttribute('aria-label', 'Copy response')
+    expect(btn).not.toHaveAttribute('data-copied')
+  })
+
+  it('copies the content to the clipboard on click and shows the copied state', async () => {
+    mockWriteText.mockResolvedValue(true)
+    render(<CopyButton content="the full response text" />)
+    fireEvent.click(screen.getByTestId('msg-copy-button'))
+    expect(mockWriteText).toHaveBeenCalledWith('the full response text')
+    await waitFor(() => expect(screen.getByTestId('msg-copy-button')).toHaveAttribute('data-copied', 'true'))
+    expect(screen.getByTestId('msg-copy-button')).toHaveAttribute('aria-label', 'Copied')
+  })
+
+  it('surfaces a warning toast and does NOT show copied when the clipboard write fails', async () => {
+    mockWriteText.mockResolvedValue(false)
+    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError')
+    render(<CopyButton content="x" />)
+    fireEvent.click(screen.getByTestId('msg-copy-button'))
+    await waitFor(() => expect(addServerError).toHaveBeenCalledWith(expect.stringContaining('Failed to copy'), undefined, 'warning'))
+    expect(screen.getByTestId('msg-copy-button')).not.toHaveAttribute('data-copied')
+    addServerError.mockRestore()
+  })
+
+  it('stops the click from propagating to parent handlers', () => {
+    mockWriteText.mockResolvedValue(true)
+    const parentClick = vi.fn()
+    render(
+      <div onClick={parentClick}>
+        <CopyButton content="x" />
+      </div>,
+    )
+    fireEvent.click(screen.getByTestId('msg-copy-button'))
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/CopyButton.tsx
+++ b/packages/dashboard/src/components/CopyButton.tsx
@@ -13,7 +13,11 @@ import { useConnectionStore } from '../store/connection'
 export function CopyButton({ content, label = 'Copy response' }: { content: string; label?: string }) {
   const [copied, setCopied] = useState(false)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => () => { if (timer.current) clearTimeout(timer.current) }, [])
+  const mounted = useRef(true)
+  useEffect(() => () => {
+    mounted.current = false
+    if (timer.current) clearTimeout(timer.current)
+  }, [])
 
   const onCopy = useCallback(
     (e: MouseEvent) => {
@@ -21,29 +25,35 @@ export function CopyButton({ content, label = 'Copy response' }: { content: stri
       // (e.g. the #6625 link handler or a future select-message gesture).
       e.stopPropagation()
       void writeText(content).then((ok) => {
+        if (!mounted.current) return // row windowed-out mid-write — don't touch state
         if (!ok) {
           useConnectionStore.getState().addServerError('Failed to copy to clipboard. Please try again.', undefined, 'warning')
           return
         }
         setCopied(true)
         if (timer.current) clearTimeout(timer.current)
-        timer.current = setTimeout(() => setCopied(false), 1500)
+        timer.current = setTimeout(() => { if (mounted.current) setCopied(false) }, 1500)
       })
     },
     [content],
   )
 
   return (
-    <button
-      type="button"
-      className="msg-copy-btn"
-      aria-label={copied ? 'Copied' : label}
-      title={copied ? 'Copied' : label}
-      data-testid="msg-copy-button"
-      data-copied={copied ? 'true' : undefined}
-      onClick={onCopy}
-    >
-      {copied ? '✓' : '⧉'}
-    </button>
+    <>
+      <button
+        type="button"
+        className="msg-copy-btn"
+        aria-label={copied ? 'Copied' : label}
+        title={copied ? 'Copied' : label}
+        data-testid="msg-copy-button"
+        data-copied={copied ? 'true' : undefined}
+        onClick={onCopy}
+      >
+        {copied ? '✓' : '⧉'}
+      </button>
+      {/* #6631: announce the success to AT — an aria-label flip on an already-
+          focused control isn't reliably re-announced across screen readers. */}
+      <span className="sr-only" role="status" aria-live="polite">{copied ? 'Copied' : ''}</span>
+    </>
   )
 }

--- a/packages/dashboard/src/components/CopyButton.tsx
+++ b/packages/dashboard/src/components/CopyButton.tsx
@@ -24,6 +24,11 @@ export function CopyButton({ content, label = 'Copy response' }: { content: stri
       // Don't let the copy click also trigger the bubble/row click handlers
       // (e.g. the #6625 link handler or a future select-message gesture).
       e.stopPropagation()
+      // Reset the confirmation at the start of every attempt so the visual
+      // state always reflects the LATEST click — a re-click whose write then
+      // fails must not keep showing a stale ✓ until the old timer expires.
+      if (timer.current) { clearTimeout(timer.current); timer.current = null }
+      setCopied(false)
       void writeText(content).then((ok) => {
         if (!mounted.current) return // row windowed-out mid-write — don't touch state
         if (!ok) {
@@ -31,7 +36,6 @@ export function CopyButton({ content, label = 'Copy response' }: { content: stri
           return
         }
         setCopied(true)
-        if (timer.current) clearTimeout(timer.current)
         timer.current = setTimeout(() => { if (mounted.current) setCopied(false) }, 1500)
       })
     },

--- a/packages/dashboard/src/components/CopyButton.tsx
+++ b/packages/dashboard/src/components/CopyButton.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
+import { writeText } from '../utils/clipboard'
+import { useConnectionStore } from '../store/connection'
+
+/**
+ * #6631 — a subtle "copy" control for a response bubble. Copies `content` to the
+ * OS clipboard via the shared clipboard helper (Tauri native plugin in
+ * WKWebView, `navigator.clipboard` otherwise — see utils/clipboard), showing a
+ * brief ✓ confirmation. A failed write surfaces a non-destructive `warning`
+ * toast, mirroring App.tsx's `copyToClipboard`. The layout leaves room for
+ * future per-response actions alongside it.
+ */
+export function CopyButton({ content, label = 'Copy response' }: { content: string; label?: string }) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current) }, [])
+
+  const onCopy = useCallback(
+    (e: MouseEvent) => {
+      // Don't let the copy click also trigger the bubble/row click handlers
+      // (e.g. the #6625 link handler or a future select-message gesture).
+      e.stopPropagation()
+      void writeText(content).then((ok) => {
+        if (!ok) {
+          useConnectionStore.getState().addServerError('Failed to copy to clipboard. Please try again.', undefined, 'warning')
+          return
+        }
+        setCopied(true)
+        if (timer.current) clearTimeout(timer.current)
+        timer.current = setTimeout(() => setCopied(false), 1500)
+      })
+    },
+    [content],
+  )
+
+  return (
+    <button
+      type="button"
+      className="msg-copy-btn"
+      aria-label={copied ? 'Copied' : label}
+      title={copied ? 'Copied' : label}
+      data-testid="msg-copy-button"
+      data-copied={copied ? 'true' : undefined}
+      onClick={onCopy}
+    >
+      {copied ? '✓' : '⧉'}
+    </button>
+  )
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2671,6 +2671,8 @@ button.sidebar-token-view-session-row:hover {
 }
 
 .msg {
+  /* #6631: anchor the absolutely-positioned copy control to the bubble. */
+  position: relative;
   max-width: 85%;
   /* #4757: flex/grid child needs min-width: 0 so a long <pre> or wide
      inline-code line can't push the bubble past its 85% cap. Without
@@ -2907,6 +2909,44 @@ button.sidebar-token-view-session-row:hover {
 }
 
 /* ---- Markdown in messages ---- */
+/* #6631 — subtle per-response copy control. Hidden until the bubble is hovered
+   or focused (keyboard), so it doesn't clutter the transcript. */
+.msg-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--text-muted);
+  background: var(--surface-raised, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.msg:hover .msg-copy-btn,
+.msg-copy-btn:focus-visible {
+  opacity: 1;
+}
+
+.msg-copy-btn:hover {
+  color: var(--text-heading);
+}
+
+.msg-copy-btn[data-copied='true'] {
+  opacity: 1;
+  color: var(--accent-green, #4ade80);
+}
+
 .msg pre {
   background: var(--bg-code-block);
   border-radius: 6px;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2925,8 +2925,10 @@ button.sidebar-token-view-session-row:hover {
   font-size: 12px;
   line-height: 1;
   color: var(--text-muted);
-  background: var(--surface-raised, rgba(0, 0, 0, 0.25));
-  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
+  /* theme-neutral fallbacks (match the repo's --surface-raised fallback at
+     .cr-* usage) so the control reads correctly in BOTH light and dark. */
+  background: var(--surface-raised, rgba(127, 127, 127, 0.12));
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
   border-radius: var(--radius-sm, 6px);
   cursor: pointer;
   opacity: 0;
@@ -2944,7 +2946,7 @@ button.sidebar-token-view-session-row:hover {
 
 .msg-copy-btn[data-copied='true'] {
   opacity: 1;
-  color: var(--accent-green, #4ade80);
+  color: var(--accent-green, #22c55e);
 }
 
 .msg pre {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2932,12 +2932,17 @@ button.sidebar-token-view-session-row:hover {
   border-radius: var(--radius-sm, 6px);
   cursor: pointer;
   opacity: 0;
+  /* Hidden ⇒ not a click target, so an invisible top-right hotspot can't eat a
+     selection/link click; re-enabled below when the control is actually shown. */
+  pointer-events: none;
   transition: opacity 0.12s ease, color 0.12s ease;
 }
 
 .msg:hover .msg-copy-btn,
-.msg-copy-btn:focus-visible {
+.msg-copy-btn:focus-visible,
+.msg-copy-btn[data-copied='true'] {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .msg-copy-btn:hover {


### PR DESCRIPTION
## Summary

Closes #6631 (initial scope: `Copy`).

Adds a subtle one-click **Copy** control to each finished assistant/agent response bubble, so the response text can be copied to the clipboard without manual selection.

## Changes

- **new `CopyButton.tsx`** — copies `content` via the shared clipboard helper (`utils/clipboard.writeText`: Tauri native plugin in WKWebView, `navigator.clipboard` fallback), shows a brief **✓** confirmation, and on failure surfaces a non-destructive `warning` toast (mirrors App.tsx's `copyToClipboard`, #4871/#4870). `stopPropagation` so the copy click doesn't also trigger the bubble/row handlers (e.g. the #6625 link gate). Timer cleaned up on unmount.
- **`ChatView.tsx`** — render the button on `response` bubbles only (skipped while still streaming / for empty content).
- **CSS** — the button is hidden until the bubble is hovered **or** the button is keyboard-focused (`:focus-visible`), so it stays subtle; `.msg` gets `position: relative` to anchor it top-right. The `data-copied` state stays visible + green briefly. Layout leaves room for future per-response actions alongside it.

## Verification

- **4 CopyButton tests**: renders an accessible button; click copies `content` + flips to the copied state + `aria-label="Copied"`; a failed write surfaces the `warning` toast and does NOT show copied; `stopPropagation` keeps a parent `onClick` from firing.
- Full dashboard suite green (**4289**), typecheck clean.

## ⚠️ Flagged for live QA

The copy **logic** (clipboard write, toast on failure, copied state, propagation) is fully unit-tested. The on-screen **placement/appearance** needs a live check: the button is unobtrusive (hover/focus-reveal, top-right) and doesn't overlap long content or the timestamp. On the Tauri desktop build, confirm the native clipboard plugin path actually writes (the reason `writeText` exists).

**Out of scope (future):** the bottom action-area for additional per-response actions (the issue's "eventually"), and the mobile app.