### PR TITLE
feat(server): orchestration WS surface — handlers, feature flag, delta broadcast (S-2)

### DIFF
--- a/packages/protocol/dist/schemas/server/orchestration.d.ts
+++ b/packages/protocol/dist/schemas/server/orchestration.d.ts
@@ -465,7 +465,7 @@ export declare const ServerOrchestrationRunSnapshotSchema: z.ZodObject<{
     requestId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     generatedAt: z.ZodString;
     seq: z.ZodNumber;
-    run: z.ZodObject<{
+    run: z.ZodNullable<z.ZodObject<{
         runId: z.ZodString;
         title: z.ZodString;
         preset: z.ZodNullable<z.ZodString>;
@@ -645,7 +645,7 @@ export declare const ServerOrchestrationRunSnapshotSchema: z.ZodObject<{
             json: z.ZodString;
             markdown: z.ZodString;
         }, z.core.$strip>>;
-    }, z.core.$loose>;
+    }, z.core.$loose>>;
     error: z.ZodOptional<z.ZodObject<{
         code: z.ZodString;
         message: z.ZodString;

--- a/packages/protocol/dist/schemas/server/orchestration.js
+++ b/packages/protocol/dist/schemas/server/orchestration.js
@@ -167,7 +167,10 @@ export const ServerOrchestrationRunSnapshotSchema = z.object({
     requestId: z.string().max(128).nullable().optional(),
     generatedAt: z.string().datetime(),
     seq: z.number().int().nonnegative(),
-    run: RunDetailSchema,
+    // nullable: a degraded reply (not_found / a survey failure / a session-bound
+    // refusal) carries `run: null` + `error`, mirroring the runs-snapshot's empty
+    // `runs` + `error` degraded shape.
+    run: RunDetailSchema.nullable(),
     error: z.object({ code: z.string(), message: z.string() }).optional(),
 }).passthrough();
 // Server-initiated push (no request). Broadcast to unbound clients only. A

--- a/packages/protocol/src/schemas/server/orchestration.ts
+++ b/packages/protocol/src/schemas/server/orchestration.ts
@@ -187,7 +187,10 @@ export const ServerOrchestrationRunSnapshotSchema = z.object({
   requestId: z.string().max(128).nullable().optional(),
   generatedAt: z.string().datetime(),
   seq: z.number().int().nonnegative(),
-  run: RunDetailSchema,
+  // nullable: a degraded reply (not_found / a survey failure / a session-bound
+  // refusal) carries `run: null` + `error`, mirroring the runs-snapshot's empty
+  // `runs` + `error` degraded shape.
+  run: RunDetailSchema.nullable(),
   error: z.object({ code: z.string(), message: z.string() }).optional(),
 }).passthrough()
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -673,6 +673,16 @@ export function isIdeFeatureEnabled(config) {
   return config?.features?.ide === true
 }
 
+// #6691 — the opt-in orchestration/delegation harness ("committee"). Fail-closed
+// like isIdeFeatureEnabled: only an explicit env=1 or `features.orchestration
+// === true` enables it. Gates the WS handler surface AND the `orchestration`
+// capability advertised in auth_ok, so a client only reveals the Runs surface
+// when the operator has opted in.
+export function isOrchestrationEnabled(config) {
+  if (process.env.CHROXY_ENABLE_ORCHESTRATION === '1') return true
+  return config?.features?.orchestration === true
+}
+
 // #6277: single source of truth for "does a user-shell spawn need host-local
 // approval first?". Fail-closed — only an explicit `userShell.requireApproval
 // === true` enables the gate. Independent of `enabled`: the gate only bites when

--- a/packages/server/src/handlers/orchestration-handlers.js
+++ b/packages/server/src/handlers/orchestration-handlers.js
@@ -167,7 +167,15 @@ function orchestration_run_start(ws, client, msg, ctx) {
       autoApprovePlan: msg.autoApprovePlan === true,
       roleOverrides: msg.roles ?? null,
     }))
-    .then((run) => sendAck(ws, ctx, msg, 'start', run?.runId ?? null))
+    .then((run) => {
+      // The ack's runId is a required string on the wire; a manager that
+      // resolved without one is a bug — surface it as an error, not a null ack.
+      if (!run || typeof run.runId !== 'string') {
+        orchestrationActionError(ws, ctx, msg, 'start-failed', 'run started but no runId was returned')
+        return
+      }
+      sendAck(ws, ctx, msg, 'start', run.runId)
+    })
     .catch((err) => {
       log.warn(`orchestration_run_start failed: ${getErrorMessage(err, 'unknown')}`)
       orchestrationActionError(ws, ctx, msg, 'start-failed', getErrorMessage(err, 'failed to start run'))
@@ -179,7 +187,12 @@ function orchestration_gate_response(ws, client, msg, ctx) {
   if (!guardAction(ws, client, msg, ctx, { requirePrimary: gateNeedsPrimary(msg) })) return
   Promise.resolve()
     .then(() => manager(ctx).resolveGate(msg.runId, msg.gateId, {
-      decision: msg.decision, note: msg.note ?? null, budgetUsd: msg.budgetUsd ?? null,
+      decision: msg.decision,
+      note: msg.note ?? null,
+      // budgetUsd is a raise, valid ONLY on an approve (of a budget_overrun gate)
+      // — it is what strict-primary gates. Forwarding it on reject/revise/skip
+      // would decouple the raise from the primary-token check, so drop it there.
+      budgetUsd: msg.decision === 'approve' ? (msg.budgetUsd ?? null) : null,
     }))
     .then(() => sendAck(ws, ctx, msg, 'gate_response', msg.runId, msg.gateId))
     .catch((err) => orchestrationActionError(ws, ctx, msg, 'gate-failed', getErrorMessage(err, 'failed to resolve gate')))

--- a/packages/server/src/handlers/orchestration-handlers.js
+++ b/packages/server/src/handlers/orchestration-handlers.js
@@ -1,0 +1,215 @@
+/**
+ * WS handlers for the orchestration/delegation harness ("committee", epic
+ * #6691, delivery step S-2). This is the SERVER SURFACE: it routes the six
+ * client->server messages to the engine (`ctx.services.orchestrationManager`,
+ * wired for real in E-4) and enforces the auth posture. The engine is driven
+ * through a small interface so this layer is testable against a stub.
+ *
+ * Auth posture (docs/security/bearer-token-authority.md):
+ *  - Every handler is FLAG-gated: a silent no-op when the orchestration feature
+ *    is off (fail-closed; the IDE-handlers pattern, so a runtime flag flip needs
+ *    no re-registration).
+ *  - Host authority: runs are host-wide cross-session objects, so a
+ *    session-bound (share-a-session) token is rejected — unbound clients only.
+ *  - Strict-primary (`client.isPrimaryToken`) for `orchestration_run_start` and
+ *    for a spend-unblocking gate approval (approve on epic_plan / budget_overrun):
+ *    these spawn write-capable worker sessions, the same escalation class as
+ *    user-shell creation.
+ *  - `orchestration_run_start` validates its cwd against the allowlist —
+ *    SessionManager.createSession does NOT, so an in-process orchestrator must.
+ */
+
+import { createLogger } from '../logger.js'
+import { isOrchestrationEnabled } from '../config.js'
+import { validateCwdAllowed } from '../handler-utils.js'
+import { makeSurveyHandler, makeActionError } from '../control-room/handler-factory.js'
+import { getErrorMessage } from '../utils/error-message.js'
+
+const log = createLogger('ws')
+
+// Per-client in-flight guards (WeakSet — GC'd with the client, no cleanup path).
+const runsInFlight = new WeakSet()
+const detailInFlight = new WeakSet()
+
+const orchestrationActionError = makeActionError('ORCHESTRATION_ACTION_FAILED', (msg) => ({
+  runId: msg.runId ?? null,
+  gateId: msg.gateId ?? null,
+  action: msg.action ?? msg.decision ?? null,
+}))
+
+const nowIso = () => new Date().toISOString()
+const enabled = (ctx) => isOrchestrationEnabled(ctx?.services?.config)
+const manager = (ctx) => ctx?.services?.orchestrationManager || null
+
+function requestIdOf(msg) {
+  return typeof msg?.requestId === 'string' ? msg.requestId : undefined
+}
+
+// -- surveys (pull snapshots) ----------------------------------------------
+
+const runsSurvey = makeSurveyHandler({
+  inFlight: runsInFlight,
+  logName: 'orchestration_runs_request',
+  forbidden: ({ requestId }) => ({
+    type: 'orchestration_runs_snapshot', generatedAt: nowIso(), runs: [],
+    error: { code: 'host_authority_required', message: 'orchestration is host-level; a session-bound token cannot list runs' },
+    requestId: requestId ?? null,
+  }),
+  inProgress: ({ requestId }) => ({
+    type: 'orchestration_runs_snapshot', generatedAt: nowIso(), runs: [],
+    error: { code: 'in_progress', message: 'a runs request is already in flight' }, requestId: requestId ?? null,
+  }),
+  failed: ({ requestId, err }) => ({
+    type: 'orchestration_runs_snapshot', generatedAt: nowIso(), runs: [],
+    error: { code: 'survey_failed', message: getErrorMessage(err, 'unknown error') }, requestId: requestId ?? null,
+  }),
+  run: async ({ ctx, requestId }) => {
+    const mgr = manager(ctx)
+    const runs = mgr ? await mgr.listRuns() : []
+    return { type: 'orchestration_runs_snapshot', generatedAt: nowIso(), runs, requestId: requestId ?? null }
+  },
+})
+
+const detailSurvey = makeSurveyHandler({
+  inFlight: detailInFlight,
+  logName: 'orchestration_run_detail_request',
+  forbidden: ({ requestId }) => ({
+    type: 'orchestration_run_snapshot', generatedAt: nowIso(), seq: 0, run: null,
+    error: { code: 'host_authority_required', message: 'orchestration is host-level; a session-bound token cannot read a run' },
+    requestId: requestId ?? null,
+  }),
+  inProgress: ({ requestId }) => ({
+    type: 'orchestration_run_snapshot', generatedAt: nowIso(), seq: 0, run: null,
+    error: { code: 'in_progress', message: 'a run-detail request is already in flight' }, requestId: requestId ?? null,
+  }),
+  failed: ({ requestId, err }) => ({
+    type: 'orchestration_run_snapshot', generatedAt: nowIso(), seq: 0, run: null,
+    error: { code: 'survey_failed', message: getErrorMessage(err, 'unknown error') }, requestId: requestId ?? null,
+  }),
+  run: async ({ ctx, msg, requestId }) => {
+    const mgr = manager(ctx)
+    const snap = mgr ? await mgr.getRunSnapshot(msg.runId) : null
+    if (!snap || !snap.run) {
+      return {
+        type: 'orchestration_run_snapshot', generatedAt: nowIso(), seq: 0, run: null,
+        error: { code: 'not_found', message: `run ${msg.runId} not found` }, requestId: requestId ?? null,
+      }
+    }
+    return { type: 'orchestration_run_snapshot', generatedAt: nowIso(), seq: snap.seq ?? 0, run: snap.run, requestId: requestId ?? null }
+  },
+})
+
+function orchestration_runs_request(ws, client, msg, ctx) {
+  if (!enabled(ctx)) return // silent no-op when the feature is off
+  return runsSurvey(ws, client, msg, ctx)
+}
+
+function orchestration_run_detail_request(ws, client, msg, ctx) {
+  if (!enabled(ctx)) return
+  return detailSurvey(ws, client, msg, ctx)
+}
+
+// -- action helpers --------------------------------------------------------
+
+// Host-authority + optional strict-primary gate. Returns true if the request
+// may proceed; otherwise sends a session_error and returns false.
+function guardAction(ws, client, msg, ctx, { requirePrimary = false } = {}) {
+  if (client?.boundSessionId) {
+    orchestrationActionError(ws, ctx, msg, 'forbidden', 'orchestration is host-level; a session-bound token cannot drive runs')
+    return false
+  }
+  if (requirePrimary && client?.isPrimaryToken !== true) {
+    orchestrationActionError(ws, ctx, msg, 'primary_token_required', 'this action requires the primary token (it can spawn write-capable worker sessions)')
+    return false
+  }
+  const mgr = manager(ctx)
+  if (!mgr) {
+    orchestrationActionError(ws, ctx, msg, 'unavailable', 'the orchestration engine is not running on this server')
+    return false
+  }
+  return true
+}
+
+function sendAck(ws, ctx, msg, action, runId, gateId) {
+  ctx.transport.send(ws, {
+    type: 'orchestration_action_ack',
+    action,
+    runId,
+    ...(gateId ? { gateId } : {}),
+    requestId: requestIdOf(msg) ?? null,
+  })
+}
+
+// A gate approval that unblocks spend requires the primary token.
+function gateNeedsPrimary(msg) {
+  return msg?.decision === 'approve'
+}
+
+// -- actions ----------------------------------------------------------------
+
+function orchestration_run_start(ws, client, msg, ctx) {
+  if (!enabled(ctx)) return
+  if (!guardAction(ws, client, msg, ctx, { requirePrimary: true })) return
+  // cwd allowlist — createSession does NOT enforce it, so the surface must.
+  // validateCwdAllowed RETURNS an error string (falsy = allowed), it does not throw.
+  const cwdError = validateCwdAllowed(msg.cwd, ctx.services.config)
+  if (cwdError) {
+    orchestrationActionError(ws, ctx, msg, 'invalid-cwd', cwdError)
+    return
+  }
+  Promise.resolve()
+    .then(() => manager(ctx).startRun({
+      title: msg.title ?? null,
+      goal: msg.epicPrompt ?? null,
+      preset: msg.preset ?? null,
+      cwd: msg.cwd,
+      budgetUsd: msg.budgetUsd ?? null,
+      autoApprovePlan: msg.autoApprovePlan === true,
+      roleOverrides: msg.roles ?? null,
+    }))
+    .then((run) => sendAck(ws, ctx, msg, 'start', run?.runId ?? null))
+    .catch((err) => {
+      log.warn(`orchestration_run_start failed: ${getErrorMessage(err, 'unknown')}`)
+      orchestrationActionError(ws, ctx, msg, 'start-failed', getErrorMessage(err, 'failed to start run'))
+    })
+}
+
+function orchestration_gate_response(ws, client, msg, ctx) {
+  if (!enabled(ctx)) return
+  if (!guardAction(ws, client, msg, ctx, { requirePrimary: gateNeedsPrimary(msg) })) return
+  Promise.resolve()
+    .then(() => manager(ctx).resolveGate(msg.runId, msg.gateId, {
+      decision: msg.decision, note: msg.note ?? null, budgetUsd: msg.budgetUsd ?? null,
+    }))
+    .then(() => sendAck(ws, ctx, msg, 'gate_response', msg.runId, msg.gateId))
+    .catch((err) => orchestrationActionError(ws, ctx, msg, 'gate-failed', getErrorMessage(err, 'failed to resolve gate')))
+}
+
+function orchestration_run_action(ws, client, msg, ctx) {
+  if (!enabled(ctx)) return
+  if (!guardAction(ws, client, msg, ctx)) return
+  Promise.resolve()
+    .then(() => manager(ctx).runAction(msg.runId, msg.action))
+    .then(() => sendAck(ws, ctx, msg, msg.action, msg.runId))
+    .catch((err) => orchestrationActionError(ws, ctx, msg, 'action-failed', getErrorMessage(err, `failed to ${msg.action} run`)))
+}
+
+function orchestration_run_annotate(ws, client, msg, ctx) {
+  if (!enabled(ctx)) return
+  if (!guardAction(ws, client, msg, ctx)) return
+  Promise.resolve()
+    .then(() => manager(ctx).annotate(msg.runId, {
+      baselineSessionId: msg.baselineSessionId ?? null, verdictQuality: msg.verdictQuality ?? undefined,
+    }))
+    .then(() => sendAck(ws, ctx, msg, 'annotate', msg.runId))
+    .catch((err) => orchestrationActionError(ws, ctx, msg, 'annotate-failed', getErrorMessage(err, 'failed to annotate run')))
+}
+
+export const orchestrationHandlers = {
+  orchestration_runs_request,
+  orchestration_run_detail_request,
+  orchestration_run_start,
+  orchestration_gate_response,
+  orchestration_run_action,
+  orchestration_run_annotate,
+}

--- a/packages/server/src/ws-handler-context.js
+++ b/packages/server/src/ws-handler-context.js
@@ -142,6 +142,10 @@ export const CTX_NAMESPACES = {
     // #5966: bounded RepoEventStore drained by the Control Room repo-events
     // survey. Null until the first GitHub-webhook delivery lazily creates it.
     'repoEventStore',
+    // #6691: the OrchestrationManager (delegation harness). Present only when
+    // the orchestration feature is enabled and the engine is wired (E-4); the
+    // handlers (S-2) treat an absent manager as "engine not running".
+    'orchestrationManager',
   ],
   runtime: [
     'draining',

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -186,6 +186,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // so clients reveal IDE navigation/editing UI. Optional — absent → false
     // (fail-closed) for old servers / callers.
     ideEnabled,
+    // #6691: whether the orchestration harness is enabled on this server,
+    // surfaced as the `orchestration` capability so the dashboard reveals the
+    // Runs surface. Optional — absent → false (fail-closed) for old servers.
+    orchestrationEnabled,
     // #6006: whether the server has a rotating TokenManager (i.e. auth is on),
     // so the operator panic button (`revoke_token`) can fire. Surfaced as the
     // `tokenRevoke` capability, gated to primary-token clients below. Optional —
@@ -408,6 +412,11 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // (fail-closed). A server-wide feature gate, not token-scoped — available to
     // every client when the operator opts in.
     ide: ideEnabled === true,
+    // #6691: the opt-in orchestration/delegation harness ("committee") is
+    // enabled on THIS server (features.orchestration / CHROXY_ENABLE_ORCHESTRATION).
+    // Clients gate the Runs surface on this flag; absent/false (default, or older
+    // servers) → no orchestration chrome (fail-closed).
+    orchestration: orchestrationEnabled === true,
     // #5986 (epic #5982) — the embedded user-shell terminal is available to THIS
     // client: the server has it enabled (userShell.enabled) AND this connection
     // holds the primary token. Both conditions of the create gate are reflected

--- a/packages/server/src/ws-message-handlers.js
+++ b/packages/server/src/ws-message-handlers.js
@@ -22,6 +22,7 @@ import { controlRoomHandlers } from './handlers/control-room-handlers.js'
 import { summarizeHandlers } from './handlers/summarize-handlers.js'
 import { pairingHandlers } from './handlers/pairing-handlers.js'
 import { tokenHandlers } from './handlers/token-handlers.js'
+import { orchestrationHandlers } from './handlers/orchestration-handlers.js'
 
 const log = createLogger('ws')
 
@@ -41,6 +42,7 @@ const handlerRegistry = new Map([
   ...Object.entries(summarizeHandlers),
   ...Object.entries(pairingHandlers),
   ...Object.entries(tokenHandlers),
+  ...Object.entries(orchestrationHandlers),
 ])
 
 /**

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -22,7 +22,7 @@ import { handleAuthMessage, handlePairMessage, handlePairRequestMessage, handleK
 import { postPairLinkToDiscord } from './discord-pair-delivery.js'
 import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } from './ws-history.js'
 import { createDevicePreferences } from './device-preferences.js'
-import { isUserShellEnabled, isIdeFeatureEnabled } from './config.js'
+import { isUserShellEnabled, isIdeFeatureEnabled, isOrchestrationEnabled } from './config.js'
 import { createHttpHandler } from './http-routes.js'
 import { CheckpointManager } from './checkpoint-manager.js'
 import { DevPreviewManager } from './dev-preview.js'
@@ -884,6 +884,10 @@ export class WsServer {
         // Lazily created on the first webhook delivery, so null until then —
         // the survey handler treats a null store as an empty (schema-valid) feed.
         get repoEventStore() { return self._repoEventStore ?? null },
+        // #6691: the OrchestrationManager, wired for real in E-4. Null until then
+        // (and whenever the feature is off) — the handlers treat a null manager
+        // as "engine not running" and reply with an unavailable error.
+        get orchestrationManager() { return self._orchestrationManager ?? null },
       },
       runtime: {
         get draining() { return self._draining },
@@ -964,6 +968,10 @@ export class WsServer {
       // `ide` capability so clients gate IDE UI. Late-bound getter so a test
       // mutating self.config is seen.
       get ideEnabled() { return isIdeFeatureEnabled(self.config) },
+      // #6691: whether the orchestration harness is enabled on THIS server,
+      // surfaced as the `orchestration` capability so the dashboard reveals the
+      // Runs surface. Server-wide gate, not token-scoped; fail-closed.
+      get orchestrationEnabled() { return isOrchestrationEnabled(self.config) },
       // #6006: whether the operator panic button (revoke_token) can fire — true
       // iff a usable rotating TokenManager exists (i.e. auth is on). Mirrors the
       // token-handlers availability check (`typeof revoke === 'function'`) so the
@@ -2289,6 +2297,15 @@ export class WsServer {
       { type: 'repo_events_delta', generatedAt: new Date().toISOString(), event },
       (client) => !client.boundSessionId,
     )
+  }
+
+  // #6691: push a single orchestration run delta to host-level (unbound) clients
+  // only — runs are host-wide cross-session objects; a session-bound token never
+  // receives them. Called by the OrchestrationManager (E-4); the `delta`
+  // already carries its own type/runId/seq (schemas/server/orchestration.ts).
+  _broadcastOrchestrationDelta(delta) {
+    if (!delta) return
+    this._broadcast(delta, (client) => !client.boundSessionId)
   }
 
   /**

--- a/packages/server/tests/orchestration-handlers.test.js
+++ b/packages/server/tests/orchestration-handlers.test.js
@@ -31,15 +31,14 @@ function mkManager(overrides = {}) {
   }
 }
 
-function mkCtx({ enabled = true, manager = mkManager(), cwdAllowlist = null } = {}) {
+function mkCtx({ enabled = true, manager = mkManager() } = {}) {
   const sent = []
   const ctx = {
     transport: { send: (_ws, msg) => sent.push(msg) },
     services: {
       config: {
         features: { orchestration: enabled },
-        homeOverride: REAL_HOME,
-        ...(cwdAllowlist ? { allowedCwds: cwdAllowlist } : {}),
+        homeOverride: REAL_HOME, // scopes validateCwdAllowed's "within home" check to the temp home
       },
       orchestrationManager: manager,
     },

--- a/packages/server/tests/orchestration-handlers.test.js
+++ b/packages/server/tests/orchestration-handlers.test.js
@@ -1,0 +1,146 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { orchestrationHandlers } from '../src/handlers/orchestration-handlers.js'
+
+// run_start's validateCwdAllowed requires the cwd to be within $HOME. Use a
+// temp "home" (config.homeOverride) with the cwd under it — hermetic, no writes
+// under the real home / ~/.chroxy (sandbox-guard safe).
+const REAL_HOME = mkdtempSync(join(tmpdir(), 'chroxy-orch-home-'))
+const REAL_CWD = join(REAL_HOME, 'repo')
+mkdirSync(REAL_CWD, { recursive: true })
+process.on('exit', () => { try { rmSync(REAL_HOME, { recursive: true, force: true }) } catch { /* ignore */ } })
+
+// #6691 S-2 — the WS surface. Flag-gated, host-authority + strict-primary,
+// driven against a stub OrchestrationManager. No real sessions / ~/.chroxy.
+
+const WS = {} // opaque handle passed to ctx.transport.send
+
+function mkManager(overrides = {}) {
+  return {
+    listRuns: async () => [{ runId: 'r1', title: 't', status: 'executing' }],
+    getRunSnapshot: async (runId) => (runId === 'r1' ? { seq: 3, run: { runId: 'r1' } } : null),
+    startRun: async () => ({ runId: 'run_new' }),
+    resolveGate: async () => ({ ok: true }),
+    runAction: async () => ({ ok: true }),
+    annotate: async () => ({ ok: true }),
+    ...overrides,
+  }
+}
+
+function mkCtx({ enabled = true, manager = mkManager(), cwdAllowlist = null } = {}) {
+  const sent = []
+  const ctx = {
+    transport: { send: (_ws, msg) => sent.push(msg) },
+    services: {
+      config: {
+        features: { orchestration: enabled },
+        homeOverride: REAL_HOME,
+        ...(cwdAllowlist ? { allowedCwds: cwdAllowlist } : {}),
+      },
+      orchestrationManager: manager,
+    },
+  }
+  return { ctx, sent }
+}
+
+const hostClient = { isPrimaryToken: true, boundSessionId: null }
+const boundClient = { isPrimaryToken: true, boundSessionId: 's-bound' }
+const nonPrimaryClient = { isPrimaryToken: false, boundSessionId: null }
+
+const tick = () => new Promise((r) => setTimeout(r, 0))
+
+describe('orchestration handlers — flag gate', () => {
+  it('every handler is a silent no-op when the feature is off', async () => {
+    const { ctx, sent } = mkCtx({ enabled: false })
+    for (const [type, fn] of Object.entries(orchestrationHandlers)) {
+      await fn(WS, hostClient, { type, runId: 'r1', gateId: 'g1', decision: 'approve', action: 'cancel', cwd: '/x' }, ctx)
+    }
+    await tick()
+    assert.equal(sent.length, 0, 'nothing sent when disabled')
+  })
+})
+
+describe('orchestration handlers — surveys', () => {
+  it('runs_request replies with a snapshot from the manager', async () => {
+    const { ctx, sent } = mkCtx()
+    await orchestrationHandlers.orchestration_runs_request(WS, hostClient, { type: 'orchestration_runs_request', requestId: 'q1' }, ctx)
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].type, 'orchestration_runs_snapshot')
+    assert.equal(sent[0].runs.length, 1)
+    assert.equal(sent[0].requestId, 'q1')
+  })
+
+  it('run_detail_request replies with seq + run; not_found for a missing run', async () => {
+    const { ctx, sent } = mkCtx()
+    await orchestrationHandlers.orchestration_run_detail_request(WS, hostClient, { type: 'orchestration_run_detail_request', runId: 'r1' }, ctx)
+    assert.equal(sent[0].seq, 3)
+    assert.equal(sent[0].run.runId, 'r1')
+    await orchestrationHandlers.orchestration_run_detail_request(WS, hostClient, { type: 'orchestration_run_detail_request', runId: 'missing' }, ctx)
+    assert.equal(sent[1].run, null)
+    assert.equal(sent[1].error.code, 'not_found')
+  })
+
+  it('a session-bound client is refused (host authority)', async () => {
+    const { ctx, sent } = mkCtx()
+    await orchestrationHandlers.orchestration_runs_request(WS, boundClient, { type: 'orchestration_runs_request' }, ctx)
+    assert.equal(sent[0].error.code, 'host_authority_required')
+  })
+})
+
+describe('orchestration handlers — actions', () => {
+  it('run_start acks with the new runId (host + primary)', async () => {
+    const { ctx, sent } = mkCtx()
+    orchestrationHandlers.orchestration_run_start(WS, hostClient, { type: 'orchestration_run_start', preset: 'repo-audit', cwd: REAL_CWD }, ctx)
+    await tick()
+    assert.equal(sent[0].type, 'orchestration_action_ack')
+    assert.equal(sent[0].action, 'start')
+    assert.equal(sent[0].runId, 'run_new')
+  })
+
+  it('run_start requires the primary token', async () => {
+    const { ctx, sent } = mkCtx()
+    orchestrationHandlers.orchestration_run_start(WS, nonPrimaryClient, { type: 'orchestration_run_start', preset: 'repo-audit', cwd: REAL_CWD }, ctx)
+    await tick()
+    assert.equal(sent[0].code, 'ORCHESTRATION_ACTION_FAILED')
+    assert.equal(sent[0].reason, 'primary_token_required')
+  })
+
+  it('gate_response approve requires primary; reject/revise do not', async () => {
+    const a = mkCtx()
+    orchestrationHandlers.orchestration_gate_response(WS, nonPrimaryClient, { type: 'orchestration_gate_response', runId: 'r1', gateId: 'g1', decision: 'approve' }, a.ctx)
+    await tick()
+    assert.equal(a.sent[0].reason, 'primary_token_required')
+    const b = mkCtx()
+    orchestrationHandlers.orchestration_gate_response(WS, nonPrimaryClient, { type: 'orchestration_gate_response', runId: 'r1', gateId: 'g1', decision: 'reject' }, b.ctx)
+    await tick()
+    assert.equal(b.sent[0].type, 'orchestration_action_ack') // reject allowed for non-primary host client
+    assert.equal(b.sent[0].action, 'gate_response')
+  })
+
+  it('run_action acks cancel/pause/resume', async () => {
+    const { ctx, sent } = mkCtx()
+    orchestrationHandlers.orchestration_run_action(WS, hostClient, { type: 'orchestration_run_action', runId: 'r1', action: 'cancel' }, ctx)
+    await tick()
+    assert.equal(sent[0].action, 'cancel')
+    assert.equal(sent[0].runId, 'r1')
+  })
+
+  it('surfaces ORCHESTRATION_ACTION_FAILED when the manager throws', async () => {
+    const { ctx, sent } = mkCtx({ manager: mkManager({ runAction: async () => { throw new Error('boom') } }) })
+    orchestrationHandlers.orchestration_run_action(WS, hostClient, { type: 'orchestration_run_action', runId: 'r1', action: 'cancel' }, ctx)
+    await tick()
+    assert.equal(sent[0].code, 'ORCHESTRATION_ACTION_FAILED')
+    assert.equal(sent[0].reason, 'action-failed')
+  })
+
+  it('reports "unavailable" when the engine is not wired', async () => {
+    const { ctx, sent } = mkCtx({ manager: null })
+    orchestrationHandlers.orchestration_run_action(WS, hostClient, { type: 'orchestration_run_action', runId: 'r1', action: 'cancel' }, ctx)
+    await tick()
+    assert.equal(sent[0].code, 'ORCHESTRATION_ACTION_FAILED')
+    assert.equal(sent[0].reason, 'unavailable')
+  })
+})

--- a/packages/server/tests/orchestration-handlers.test.js
+++ b/packages/server/tests/orchestration-handlers.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { orchestrationHandlers } from '../src/handlers/orchestration-handlers.js'
+import { ServerOrchestrationRunSnapshotSchema } from '@chroxy/protocol'
 
 // run_start's validateCwdAllowed requires the cwd to be within $HOME. Use a
 // temp "home" (config.homeOverride) with the cwd under it — hermetic, no writes
@@ -81,6 +82,8 @@ describe('orchestration handlers — surveys', () => {
     await orchestrationHandlers.orchestration_run_detail_request(WS, hostClient, { type: 'orchestration_run_detail_request', runId: 'missing' }, ctx)
     assert.equal(sent[1].run, null)
     assert.equal(sent[1].error.code, 'not_found')
+    // the degraded run:null reply must still validate against the wire schema
+    assert.equal(ServerOrchestrationRunSnapshotSchema.safeParse(sent[1]).success, true)
   })
 
   it('a session-bound client is refused (host authority)', async () => {

--- a/packages/server/tests/ws-schema-coverage.test.js
+++ b/packages/server/tests/ws-schema-coverage.test.js
@@ -100,16 +100,11 @@ describe('WS protocol schema coverage', () => {
       // schema-coverage check and no longer belongs in KNOWN_PRE_REGISTRY.
       // #5271 (Control Room Phase 2a): cancel_activity likewise now has a real
       // handler (input-handlers.js), so its temporary entry was removed here.
-      // #6691 orchestration harness (S-1): the client->server contract lands
-      // in @chroxy/protocol first; the server handlers register in S-2 (#6697),
-      // at which point these are removed from KNOWN_PRE_REGISTRY (as
-      // host_status_request / cancel_activity were above).
-      'orchestration_runs_request',
-      'orchestration_run_detail_request',
-      'orchestration_run_start',
-      'orchestration_gate_response',
-      'orchestration_run_action',
-      'orchestration_run_annotate',
+      // #6691 orchestration harness (S-2, #6697): the six orchestration_* client
+      // types now have real handlers (orchestration-handlers.js), so they are
+      // covered by the forward schema-coverage check and were removed from
+      // KNOWN_PRE_REGISTRY here (they were parked here by S-1 while only the
+      // protocol contract existed — as host_status_request / cancel_activity were).
     ])
 
     const unexplained = schemaOnly.filter((t) => !KNOWN_PRE_REGISTRY.has(t))


### PR DESCRIPTION
## Summary

PR-6 (step S-2) of the orchestration epic (#6691): the **server WS surface**. Routes the six client→server messages to the engine (`ctx.services.orchestrationManager`, wired for real in E-4) and enforces the auth posture. Driven against a stub manager so it's testable now.

- **`config.js`** — `isOrchestrationEnabled` (`features.orchestration` / `CHROXY_ENABLE_ORCHESTRATION=1`, fail-closed, copies `isIdeFeatureEnabled`).
- **`handlers/orchestration-handlers.js`** (new) — the 6 handlers. Each is **flag-gated** (silent no-op when off — the IDE-handlers pattern), **host-authority** (a session-bound token is refused — runs are host-wide cross-session objects), and **strict-primary** (`client.isPrimaryToken`) for `orchestration_run_start` and a spend-unblocking gate approval (they spawn write-capable workers). `run_start` validates its cwd via `validateCwdAllowed` (createSession does **not**). Surveys use `makeSurveyHandler`; failures use `makeActionError('ORCHESTRATION_ACTION_FAILED')`. An absent manager → an `unavailable` error (before E-4 lands).
- **`ws-message-handlers.js`** — register `orchestrationHandlers`. This also lets the 6 client types be **removed from `ws-schema-coverage` `KNOWN_PRE_REGISTRY`** (they're handled now, no longer schema-only).
- **`ws-handler-context.js` + `ws-server.js`** — `orchestrationManager` ctx getter (null until E-4), `_broadcastOrchestrationDelta` (a clone of `_broadcastRepoEvent` — broadcast to **unbound clients only**), and the `orchestration` capability in `auth_ok` (so the dashboard can gate the Runs surface, fail-closed).

## Deliberate sequencing note
The ws-server.js `Server -> Client:` **doc-block lines** for the 4 server types (which put them into guard-1's universe) and the guard-1/guard-2 allowlist moves land in **S-3 (#6702)** together with the dashboard handlers — so the doc block and its coverage guard stay in sync in one PR rather than parking then un-parking across two. guard-1 is unaffected here (universe unchanged); the broadcast works regardless (guard-1 scans the doc block, not emit sites).

## Tests
10 tests (`orchestration-handlers.test.js`): flag-off silent no-op across all 6; survey snapshots + `not_found` + host-authority refusal; `run_start`/gate-approve strict-primary; action ack; manager-throw → `ORCHESTRATION_ACTION_FAILED`; `unavailable` when the engine isn't wired. guard tests (ws-schema-coverage, handler-coverage) + deep-ctx tests (test-helpers, ws-server) stay green; all 5 custom shell lints + eslint clean.

Closes #6697. Part of #6691.