### PR TITLE
feat(dashboard): preview image/document attachments on sent user messages (#6632)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -31,6 +31,7 @@ import { MultiTerminalView } from './components/MultiTerminalView'
 import { InputBar, type FileAttachment, type ImageAttachment } from './components/InputBar'
 import { useVoiceInput } from './hooks/useVoiceInput'
 import { toWireAttachments } from './utils/attachment-utils'
+import { toMessageAttachments } from './utils/attachment-preview'
 import { derivePendingPermissionCounts, totalPendingPermissions, selectNextPendingSession } from './utils/pendingPermissions'
 import { processImageFiles, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
@@ -1579,7 +1580,17 @@ export function App() {
     const blocks = sid ? pastedTextBlocksRef.current.get(sid) ?? [] : []
     const blockMap = new Map(blocks.map(b => [b.id, b.content]))
     const expanded = blockMap.size > 0 ? expandPasteMarkers(text, blockMap) : text
-    const sendResult = sendInput(expanded, wire.length > 0 ? wire : undefined)
+    // #6632: build transcript previews (composer images → data: URIs, files →
+    // chips) so the sent bubble shows what was attached.
+    const previews = toMessageAttachments(
+      imageAttachments.length > 0 ? imageAttachments : undefined,
+      allFiles.length > 0 ? allFiles : undefined,
+    )
+    const sendResult = sendInput(
+      expanded,
+      wire.length > 0 ? wire : undefined,
+      previews.length > 0 ? { previewAttachments: previews } : undefined,
+    )
     // #6295 — parity with the mobile app (SessionScreen handleSend): when the
     // socket is closed the send falls through to the offline queue and returns
     // 'queued'. Surface a transient info notice so the operator knows the

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -55,6 +55,9 @@ describe('ChatView', () => {
         attachments: [
           { id: 'img-1', type: 'image', uri: 'data:image/png;base64,abc', name: 'shot.png', mediaType: 'image/png', size: 10 },
           { id: 'doc-1', type: 'document', uri: 'blob:x', name: 'notes.pdf', mediaType: 'application/pdf', size: 20 },
+          // #6632: a resumed-session image whose data: URI was stripped by
+          // persistence → renders a filename chip, NOT a broken <img>.
+          { id: 'img-stripped', type: 'image', uri: '[data stripped]', name: 'old.png', mediaType: 'image/png', size: 0 },
         ],
       },
     ]
@@ -63,6 +66,9 @@ describe('ChatView', () => {
     expect(img).toHaveAttribute('src', 'data:image/png;base64,abc')
     expect(img).toHaveAttribute('alt', 'shot.png')
     expect(screen.getByTestId('msg-attachment-doc-doc-1')).toHaveTextContent('notes.pdf')
+    // stripped image → chip fallback (filename shown), no broken <img>
+    expect(screen.queryByTestId('msg-attachment-image-img-stripped')).not.toBeInTheDocument()
+    expect(screen.getByTestId('msg-attachment-doc-img-stripped')).toHaveTextContent('old.png')
   })
 
   it('renders no attachment container on a message without attachments (#6632)', () => {

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -45,6 +45,31 @@ describe('ChatView', () => {
     expect(screen.queryAllByTestId('msg-copy-button')).toHaveLength(1)
   })
 
+  it('previews image + document attachments on a sent user message (#6632)', () => {
+    const messages: ChatViewMessage[] = [
+      {
+        id: 'u1',
+        type: 'user_input',
+        content: 'here you go',
+        timestamp: 1,
+        attachments: [
+          { id: 'img-1', type: 'image', uri: 'data:image/png;base64,abc', name: 'shot.png', mediaType: 'image/png', size: 10 },
+          { id: 'doc-1', type: 'document', uri: 'blob:x', name: 'notes.pdf', mediaType: 'application/pdf', size: 20 },
+        ],
+      },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    const img = screen.getByTestId('msg-attachment-image-img-1')
+    expect(img).toHaveAttribute('src', 'data:image/png;base64,abc')
+    expect(img).toHaveAttribute('alt', 'shot.png')
+    expect(screen.getByTestId('msg-attachment-doc-doc-1')).toHaveTextContent('notes.pdf')
+  })
+
+  it('renders no attachment container on a message without attachments (#6632)', () => {
+    render(<ChatView messages={[{ id: 'u2', type: 'user_input', content: 'plain', timestamp: 1 }]} isStreaming={false} />)
+    expect(screen.queryByTestId('msg-attachments-u2')).not.toBeInTheDocument()
+  })
+
   it('renders thinking as a collapsed disclosure (chat redesign #6391)', () => {
     const messages: ChatViewMessage[] = [
       { id: 't1', type: 'thinking', content: 'deep-secret-reasoning', timestamp: Date.now() },

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -359,6 +359,8 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
                   src={att.uri}
                   alt={att.name}
                   title={att.name}
+                  loading="lazy"
+                  decoding="async"
                   data-testid={`msg-attachment-image-${att.id}`}
                 />
               ) : (

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -17,7 +17,7 @@
  * survives a row scrolling out of and back into the window.
  */
 import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
-import { bumpRenderCount, type ChatActivityState } from '@chroxy/store-core'
+import { bumpRenderCount, type ChatActivityState, type MessageAttachment } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
 import { handleMarkdownLinkClick } from '../lib/links'
@@ -113,6 +113,8 @@ export interface ChatViewMessage {
    * for legacy errors without a structured code.
    */
   code?: string
+  /** #6632: attachments on a user_input message, for transcript previews. */
+  attachments?: MessageAttachment[]
 }
 
 export interface ChatViewProps {
@@ -291,6 +293,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   content,
   timestamp,
   isStreaming,
+  attachments,
   queued,
   onCancelQueued,
   queuePosition,
@@ -300,6 +303,8 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   content: string
   timestamp: number
   isStreaming?: boolean
+  /** #6632: user-message attachments (images/documents) to preview. */
+  attachments?: ChatViewMessage['attachments']
   /** #5939: this user_input is held in the server's outgoing queue. */
   queued?: boolean
   /** #5939: cancel this queued follow-up (stable callback from ChatView). */
@@ -339,6 +344,28 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
             actions alongside it. */}
         {type === 'response' && !isStreaming && content.trim() !== '' && <CopyButton content={content} />}
         {body}
+        {/* #6632: preview what the user attached to their message — image
+            thumbnails, and a compact chip for non-image documents. */}
+        {type === 'user_input' && attachments && attachments.length > 0 && (
+          <div className="msg-attachments" data-testid={`msg-attachments-${id}`}>
+            {attachments.map((att) =>
+              att.type === 'image' ? (
+                <img
+                  key={att.id}
+                  className="msg-attachment-image"
+                  src={att.uri}
+                  alt={att.name}
+                  title={att.name}
+                  data-testid={`msg-attachment-image-${att.id}`}
+                />
+              ) : (
+                <span key={att.id} className="msg-attachment-doc" title={att.name} data-testid={`msg-attachment-doc-${att.id}`}>
+                  <span aria-hidden="true">📄</span> {att.name}
+                </span>
+              ),
+            )}
+          </div>
+        )}
         {queued && (
           <span className="msg-queued" data-testid={`msg-queued-${id}`}>
             <span className="msg-queued-label">Queued</span>
@@ -793,6 +820,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   content={msg.content}
                   timestamp={msg.timestamp}
                   isStreaming={msg.isStreaming}
+                  attachments={msg.attachments}
                   queued={queuedIds?.has(msg.id) ?? false}
                   queuePosition={queuePositions?.get(msg.id)}
                   onCancelQueued={onCancelQueued}

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -22,6 +22,7 @@ import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
 import { handleMarkdownLinkClick } from '../lib/links'
 import { CopyButton } from './CopyButton'
+import { isRenderableImageUri } from '../utils/attachment-preview'
 import { MessageRowShell } from './MeasuredRow'
 import { ChatExpandContext, type ChatExpandRegistry } from './chatExpandRegistry'
 import { useWindowedRange } from './useWindowedRange'
@@ -344,12 +345,14 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
             actions alongside it. */}
         {type === 'response' && !isStreaming && content.trim() !== '' && <CopyButton content={content} />}
         {body}
-        {/* #6632: preview what the user attached to their message — image
-            thumbnails, and a compact chip for non-image documents. */}
+        {/* #6632: preview what the user attached — image thumbnails (only for a
+            renderable, safe image URI), otherwise a filename chip. A resumed
+            session's stripped `data:` URI, or a non-image document, falls back to
+            the chip so the user still sees WHAT was attached. */}
         {type === 'user_input' && attachments && attachments.length > 0 && (
           <div className="msg-attachments" data-testid={`msg-attachments-${id}`}>
             {attachments.map((att) =>
-              att.type === 'image' ? (
+              att.type === 'image' && isRenderableImageUri(att.uri) ? (
                 <img
                   key={att.id}
                   className="msg-attachment-image"
@@ -360,7 +363,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
                 />
               ) : (
                 <span key={att.id} className="msg-attachment-doc" title={att.name} data-testid={`msg-attachment-doc-${att.id}`}>
-                  <span aria-hidden="true">📄</span> {att.name}
+                  <span aria-hidden="true">{att.type === 'image' ? '🖼' : '📄'}</span> {att.name}
                 </span>
               ),
             )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2877,9 +2877,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const busy = active.streamingMessageId !== null || active.isIdle === false;
 
     // Show user message immediately (optimistic update + thinking indicator, or
-    // a queued badge when busy). Wire attachments use a different shape than
-    // MessageAttachment — pass text only for now.
-    get().addUserMessage(input, undefined, { clientMessageId, queued: busy });
+    // a queued badge when busy). #6632: carry the caller-built MessageAttachment
+    // previews (composer images → data: URIs, files → chips) onto the optimistic
+    // bubble so the transcript shows what was attached.
+    get().addUserMessage(input, options?.previewAttachments, { clientMessageId, queued: busy });
 
     const payload: Record<string, unknown> = { type: 'input', data: input, clientMessageId };
     if (activeSessionId) payload.sessionId = activeSessionId;

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -418,6 +418,25 @@ describe('useConnectionStore', () => {
       expect(payload.clientMessageId).toBe(bubble!.id);
     });
 
+    it('carries previewAttachments onto the optimistic user bubble (#6632)', async () => {
+      const { useConnectionStore, createEmptySessionState } = await import('./connection');
+      const send = vi.fn();
+      const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+      useConnectionStore.setState({
+        socket: openSocket,
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), streamingMessageId: null, isIdle: true, messages: [], queuedMessages: [] } },
+      });
+      const previewAttachments = [
+        { id: 'img-0', type: 'image' as const, uri: 'data:image/png;base64,abc', name: 'shot.png', mediaType: 'image/png', size: 3 },
+      ];
+      useConnectionStore.getState().sendInput('look at this', undefined, { previewAttachments });
+      const bubble = useConnectionStore.getState().sessionStates.s1!.messages.find(m => m.type === 'user_input');
+      // The real send path (sendInput → addUserMessage) surfaces the previews so
+      // the transcript can render them — guards the wiring that was dead before.
+      expect(bubble?.attachments).toEqual(previewAttachments);
+    });
+
     it('preserves the in-progress turn thinking indicator when queueing a follow-up', async () => {
       const { useConnectionStore, createEmptySessionState } = await import('./connection');
       const send = vi.fn();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1327,7 +1327,7 @@ export interface ConnectionState {
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   // #6453 — canonical WIRE attachment type (was an inline loose shape with a
   // `[key: string]: string` index); the dashboard sends both file_ref + image.
-  sendInput: (input: string, wireAttachments?: Attachment[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
+  sendInput: (input: string, wireAttachments?: Attachment[], options?: { isVoice?: boolean; previewAttachments?: MessageAttachment[] }) => 'sent' | 'queued' | false;
   /**
    * Interrupt the current turn. Defaults to the active session; pass an explicit
    * `sessionId` to interrupt a specific session (e.g. the Control Room

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2954,6 +2954,38 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-green, #22c55e);
 }
 
+/* #6632 — attachment previews on a sent user message. */
+.msg-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.msg-attachment-image {
+  max-width: 160px;
+  max-height: 160px;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  object-fit: cover;
+}
+
+.msg-attachment-doc {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 220px;
+  padding: 2px 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--surface-raised, rgba(127, 127, 127, 0.12));
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  border-radius: var(--radius-sm, 6px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .msg pre {
   background: var(--bg-code-block);
   border-radius: 6px;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2963,6 +2963,7 @@ button.sidebar-token-view-session-row:hover {
 }
 
 .msg-attachment-image {
+  display: block; /* avoid the inline-image baseline gap inside the grid */
   max-width: 160px;
   max-height: 160px;
   border-radius: var(--radius-sm, 6px);

--- a/packages/dashboard/src/utils/attachment-preview.test.ts
+++ b/packages/dashboard/src/utils/attachment-preview.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { toMessageAttachments, isRenderableImageUri } from './attachment-preview'
+
+describe('toMessageAttachments (#6632)', () => {
+  it('builds a data: URI image attachment from a composer image', () => {
+    const out = toMessageAttachments([{ data: 'AAAA', mediaType: 'image/png', name: 'shot.png' }], undefined)
+    expect(out).toEqual([
+      { id: 'img-0', type: 'image', uri: 'data:image/png;base64,AAAA', name: 'shot.png', mediaType: 'image/png', size: 4 },
+    ])
+  })
+
+  it('builds a document attachment from a composer file (path → uri, no data)', () => {
+    const out = toMessageAttachments(undefined, [{ path: '/tmp/notes.pdf', name: 'notes.pdf' }])
+    expect(out).toEqual([{ id: 'doc-0', type: 'document', uri: '/tmp/notes.pdf', name: 'notes.pdf', mediaType: '', size: 0 }])
+  })
+
+  it('combines images then files with unique ids', () => {
+    const out = toMessageAttachments(
+      [{ data: 'x', mediaType: 'image/jpeg', name: 'a.jpg' }],
+      [{ path: '/p/b.txt', name: 'b.txt' }],
+    )
+    expect(out.map((a) => [a.id, a.type])).toEqual([['img-0', 'image'], ['doc-0', 'document']])
+  })
+
+  it('returns [] for no attachments', () => {
+    expect(toMessageAttachments()).toEqual([])
+    expect(toMessageAttachments([], [])).toEqual([])
+  })
+})
+
+describe('isRenderableImageUri (#6632)', () => {
+  it('accepts renderable image schemes', () => {
+    expect(isRenderableImageUri('data:image/png;base64,x')).toBe(true)
+    expect(isRenderableImageUri('blob:https://app/abc')).toBe(true)
+    expect(isRenderableImageUri('https://cdn/x.png')).toBe(true)
+  })
+
+  it('rejects the persistence "[data stripped]" sentinel (resumed session)', () => {
+    expect(isRenderableImageUri('[data stripped]')).toBe(false)
+  })
+
+  it('rejects non-image / unsafe / relative schemes', () => {
+    expect(isRenderableImageUri('http://cdn/x.png')).toBe(false) // no plaintext peer fetch
+    expect(isRenderableImageUri('javascript:alert(1)')).toBe(false)
+    expect(isRenderableImageUri('data:text/html,x')).toBe(false)
+    expect(isRenderableImageUri('/local/path')).toBe(false)
+    expect(isRenderableImageUri(null)).toBe(false)
+    expect(isRenderableImageUri(undefined)).toBe(false)
+  })
+})

--- a/packages/dashboard/src/utils/attachment-preview.ts
+++ b/packages/dashboard/src/utils/attachment-preview.ts
@@ -1,0 +1,44 @@
+import type { MessageAttachment } from '@chroxy/store-core'
+import type { ImageAttachment, FileAttachment } from '../components/InputBar'
+
+/**
+ * #6632 — build the `MessageAttachment[]` for a sent user message's optimistic
+ * transcript preview from the composer's pending attachments. Images carry
+ * base64 → a `data:` URI thumbnail; files carry only a path/name → a document
+ * chip. Ids are index-scoped (unique within the one message's list, which is
+ * all React keys need).
+ */
+export function toMessageAttachments(
+  images?: ImageAttachment[],
+  files?: FileAttachment[],
+): MessageAttachment[] {
+  const out: MessageAttachment[] = []
+  ;(images ?? []).forEach((img, i) => {
+    out.push({
+      id: `img-${i}`,
+      type: 'image',
+      uri: `data:${img.mediaType};base64,${img.data}`,
+      name: img.name,
+      mediaType: img.mediaType,
+      size: img.data.length,
+    })
+  })
+  ;(files ?? []).forEach((f, i) => {
+    out.push({ id: `doc-${i}`, type: 'document', uri: f.path, name: f.name, mediaType: '', size: 0 })
+  })
+  return out
+}
+
+const RENDERABLE_IMAGE_SCHEME = /^(data:image\/|blob:|https:\/\/)/i
+
+/**
+ * Whether an image attachment's `uri` can safely render as an `<img>`: a
+ * renderable image scheme (`data:image/…`, `blob:`, `https:`) — which also
+ * excludes the persistence `'[data stripped]'` sentinel that `stripLargeData`
+ * writes for a resumed session. When false the caller falls back to a filename
+ * chip so a resumed message shows WHAT was attached instead of a broken image.
+ * Doubles as a scheme allowlist (no `javascript:`/`http:` fetch from a peer uri).
+ */
+export function isRenderableImageUri(uri: string | null | undefined): boolean {
+  return typeof uri === 'string' && RENDERABLE_IMAGE_SCHEME.test(uri.trim())
+}

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -301,5 +301,18 @@ describe('buildChatViewMessages', () => {
       const v = toChatViewMessage(m)
       expect('code' in v).toBe(false)
     })
+
+    it('propagates user-message attachments so the transcript can preview them (#6632)', () => {
+      const attachments = [
+        { id: 'a1', type: 'image' as const, uri: 'data:image/png;base64,xxx', name: 'shot.png', mediaType: 'image/png', size: 12 },
+      ]
+      const v = toChatViewMessage(msg({ id: 'u1', type: 'user_input', content: 'see this', attachments }))
+      expect(v.attachments).toEqual(attachments)
+    })
+
+    it('omits `attachments` when absent or empty', () => {
+      expect('attachments' in toChatViewMessage(msg({ id: 'u1', type: 'user_input', content: 'no files' }))).toBe(false)
+      expect('attachments' in toChatViewMessage(msg({ id: 'u2', type: 'user_input', content: 'empty', attachments: [] }))).toBe(false)
+    })
   })
 })

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -314,5 +314,10 @@ describe('buildChatViewMessages', () => {
       expect('attachments' in toChatViewMessage(msg({ id: 'u1', type: 'user_input', content: 'no files' }))).toBe(false)
       expect('attachments' in toChatViewMessage(msg({ id: 'u2', type: 'user_input', content: 'empty', attachments: [] }))).toBe(false)
     })
+
+    it('does NOT propagate attachments for a non-user_input message (contract: user messages only)', () => {
+      const attachments = [{ id: 'a1', type: 'image' as const, uri: 'data:image/png;base64,x', name: 'x.png', mediaType: 'image/png', size: 1 }]
+      expect('attachments' in toChatViewMessage(msg({ id: 'r1', type: 'response', content: 'hi', attachments }))).toBe(false)
+    })
   })
 })

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -112,7 +112,9 @@ export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
     ...(msg.code ? { code: msg.code } : {}),
     // #6632: carry user-message attachments through so the transcript can
     // preview them (dropped previously → no thumbnail on the sent message).
-    ...(msg.attachments?.length ? { attachments: msg.attachments } : {}),
+    // Gated to `user_input` to match the contract (attachments live only on user
+    // messages) — don't thread attachment data onto non-user bubbles.
+    ...(msg.type === 'user_input' && msg.attachments?.length ? { attachments: msg.attachments } : {}),
   }
 }
 

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -46,7 +46,7 @@ import {
   type DisplayGroup,
 } from './group-messages'
 import { isRetryableAskUserQuestionError } from './ask-user-question-errors'
-import type { ChatMessage } from './types'
+import type { ChatMessage, MessageAttachment } from './types'
 
 /**
  * Flattened chat-view row.
@@ -66,6 +66,12 @@ export interface ChatViewMessage {
    * renderers can switch on it (e.g. `'stream_stall'` → chip + retry).
    */
   code?: string
+  /**
+   * #6632 — attachments on a `user_input` message (images / documents), mirrored
+   * from the store ChatMessage so the transcript can render a thumbnail/chip of
+   * what the user sent (confirming the attachment after submit / on resume).
+   */
+  attachments?: MessageAttachment[]
 }
 
 export interface ChatViewPipelineResult {
@@ -104,6 +110,9 @@ export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
     // renderMessage path can switch error bubbles into the
     // StreamStallChip variant.
     ...(msg.code ? { code: msg.code } : {}),
+    // #6632: carry user-message attachments through so the transcript can
+    // preview them (dropped previously → no thumbnail on the sent message).
+    ...(msg.attachments?.length ? { attachments: msg.attachments } : {}),
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #6632.

A sent user message showed **no thumbnail** of what the user attached, so they couldn't confirm what they sent (especially after submit or on a resumed session). The attachment data was already on the store `ChatMessage` (`attachments: MessageAttachment[]`, populated by `addUserMessage`), but the shared `toChatViewMessage` mapping **dropped it** — so the chat view never received it.

## Changes

- **store-core** — `ChatViewMessage` gains an additive `attachments?: MessageAttachment[]`, and `toChatViewMessage` propagates it (only when non-empty). Shared, so both clients get the data. Unit tests.
- **dashboard `ChatView`** — thread `attachments` to the memoized message row (the store's array is reference-stable, so the render-skip memo isn't defeated) and render, on `user_input` bubbles: **image thumbnails** (`<img src={att.uri}>`, bounded 160px) and a compact **chip** for non-image documents. Component tests.
- **CSS** — bounded thumbnails (`object-fit: cover`) + a truncating doc chip, theme-neutral tokens.

## Verification

- store-core **1951** (incl. new `toChatViewMessage` attachment propagation + omit-when-empty tests; coverage guards unaffected — additive view-type field).
- dashboard **4293** (incl. new ChatView tests: image `src`/`alt` + doc chip render; no container when there are no attachments).
- Both typechecks clean.

## ⚠️ Flagged for live QA

The data plumbing and render **presence** are fully unit-tested; the on-screen **appearance** needs a live check: the thumbnail actually loads from `att.uri`, sizing/wrapping looks right alongside the message text, and — importantly — **whether the `uri` survives a resumed session** (a `blob:` URL dies on reload; a `data:` URI persists). If resumed-session previews are blank, persisting a `data:` URI (or a server-fetchable ref) for attachments is a follow-up.

**Out of scope:** the mobile app render (its message rendering is separate; store-core now carries the data for it when that lands).