### PR TITLE
feat(server): orchestration engine read path — committee loop, roles, permission gate (E-2)

### DIFF
--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -143,6 +143,7 @@ export class OrchestrationManager extends EventEmitter {
 
   async startRun(runId) {
     const run = this._get(runId)
+    if (run.phase !== 'created') throw new Error(`run ${runId} already started (phase ${run.phase})`)
     run.phase = 'planning'
     this._ledger.setStatus(runId, 'planning')
     let plan
@@ -174,6 +175,12 @@ export class OrchestrationManager extends EventEmitter {
     const sessionId = this._spawnSession(run, { role: 'architect' })
     run.architectSessionId = sessionId
     run.ownedSessions.set(sessionId, { role: 'architect', subtaskId: null })
+    // The architect reads/greps the repo to plan and review; it never edits.
+    // Give it the same read-only rules as workers so its Read/Glob/Grep are
+    // settled without prompting (else — with no rules and the gate deliberately
+    // deny-only for it — a read request would wedge until the turn watchdog
+    // fires and fails the run). Anything else it emits (Bash) hits the gate.
+    this._applyReadOnlyRules(sessionId)
     const repoMap = ''
     const prompt = buildPlanPrompt({ goal: run.goal, repoMap, maxSubtasks: 8 })
     const { decision } = await this._driveDecision(run, sessionId, prompt, 'epic_plan', 'plan', null)
@@ -238,37 +245,42 @@ export class OrchestrationManager extends EventEmitter {
 
   async _runSubtask(run, subtaskId) {
     const st = run.subtasks.get(subtaskId)
-    const sessionId = this._spawnSession(run, { role: 'audit', subtaskId })
-    run.ownedSessions.set(sessionId, { role: 'audit', subtaskId })
-    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
-    this._ledger.attachSession(run.runId, subtaskId, { sessionId, provider: run.roleModels.worker.provider, model: run.roleModels.worker.model, meterable: true })
-
-    // read-only rules for audit workers (write-deny; reads allowed)
-    this._applyAuditRules(sessionId)
+    let sessionId = this._spawnWorker(run, subtaskId)
 
     let feedback = null
     // committee loop for this subtask
     while (true) {
-      if (st.iterations > this._cfg.maxCommitteeIterations) {
+      // Bail if the run was cancelled/torn down while an await was in flight —
+      // don't drive more turns or write status on a dead run.
+      if (run.cancelled || !this._runs.has(run.runId)) return null
+      // `iterations` counts committee round-trips already spent; at the cap we
+      // stop and escalate rather than looping forever on a stubborn subtask.
+      if (st.iterations >= this._cfg.maxCommitteeIterations) {
         return this._escalateSubtask(run, subtaskId, 'committee iteration cap exceeded')
       }
       // 1) plan-of-attack
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
       const poa = await this._driveDecision(run, sessionId, buildPoaPrompt({ subtask: st.spec }), 'plan_of_attack', 'poa', subtaskId).then((r) => r.decision)
       st.poa = poa
-      // 2) architect reviews the PoA
+      // 2) architect reviews the PoA (usage attributed to architect.review, NOT
+      // the subtask cell — see _architectReview)
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'poa_review' })
-      const poaReview = await this._architectReview(run, buildPoaReviewPrompt({ subtask: st.spec, poa }), 'poa_review', subtaskId)
+      const poaReview = await this._architectReview(run, buildPoaReviewPrompt({ subtask: st.spec, poa }), 'poa_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'plan', verdict: poaReview.verdict, reviewerSessionId: run.architectSessionId, notes: poaReview.feedback ?? '' })
       if (poaReview.verdict === 'escalate') return this._escalateSubtask(run, subtaskId, poaReview.feedback || 'architect escalated the plan')
-      if (poaReview.verdict === 'revise' || poaReview.verdict === 'redelegate') { st.iterations += 1; feedback = poaReview.feedback ?? null; continue }
+      if (poaReview.verdict === 'revise' || poaReview.verdict === 'redelegate') {
+        st.iterations += 1
+        feedback = poaReview.feedback ?? null
+        if (poaReview.verdict === 'redelegate') sessionId = this._respawnWorker(run, subtaskId, sessionId)
+        continue
+      }
       // 3) execute
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'executing' })
       const result = await this._driveDecision(run, sessionId, buildExecutePrompt({ subtask: st.spec, feedback }), 'work_result', 'execute', subtaskId).then((r) => r.decision)
       st.result = result
       // 4) architect reviews the result
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'result_review' })
-      const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result }), 'result_review', subtaskId)
+      const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result }), 'result_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'result', verdict: resultReview.verdict, reviewerSessionId: run.architectSessionId, notes: resultReview.feedback ?? '' })
       if (resultReview.verdict === 'approve') {
         run.results.push({ title: st.spec.title, summary: result.summary })
@@ -276,13 +288,32 @@ export class OrchestrationManager extends EventEmitter {
         return this._finishSubtask(run, subtaskId, 'done')
       }
       if (resultReview.verdict === 'escalate') return this._escalateSubtask(run, subtaskId, resultReview.feedback || 'architect escalated the result')
-      // revise / redelegate → loop with feedback
+      // revise / redelegate → loop with feedback (redelegate gets a fresh worker)
       st.iterations += 1
       feedback = resultReview.feedback ?? null
+      if (resultReview.verdict === 'redelegate') sessionId = this._respawnWorker(run, subtaskId, sessionId)
     }
   }
 
+  // Spawn + register + rule-gate + attach a worker session for a subtask.
+  _spawnWorker(run, subtaskId) {
+    const sessionId = this._spawnSession(run, { role: 'audit', subtaskId })
+    run.ownedSessions.set(sessionId, { role: 'audit', subtaskId })
+    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
+    this._applyReadOnlyRules(sessionId)
+    this._ledger.attachSession(run.runId, subtaskId, { sessionId, provider: run.roleModels.worker.provider, model: run.roleModels.worker.model, meterable: true })
+    return sessionId
+  }
+
+  // redelegate: tear down the current worker and hand the subtask to a fresh one.
+  _respawnWorker(run, subtaskId, oldSessionId) {
+    this._destroySession(run, oldSessionId)
+    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'respawning' })
+    return this._spawnWorker(run, subtaskId)
+  }
+
   _finishSubtask(run, subtaskId, status) {
+    if (run.cancelled || !this._runs.has(run.runId)) return
     const st = run.subtasks.get(subtaskId)
     if (st) st.state = status
     this._ledger.updateSubtask(run.runId, subtaskId, { status })
@@ -337,8 +368,13 @@ export class OrchestrationManager extends EventEmitter {
 
   // --- turn driving + decisions -------------------------------------------
 
-  async _architectReview(run, prompt, kind, subtaskId) {
-    const { decision } = await this._driveDecision(run, run.architectSessionId, prompt, kind, kind, subtaskId)
+  async _architectReview(run, prompt, kind) {
+    // subtaskId is intentionally null: the review turn's tokens belong to the
+    // architect.review role, NOT the subtask's own usage cell (which tracks the
+    // worker's cost). Folding it in would price the architect's turn with the
+    // worker's provider and spuriously flip the subtask's modelDrift flag. The
+    // review's LINK to the subtask is recorded separately via recordCommitteeReview.
+    const { decision } = await this._driveDecision(run, run.architectSessionId, prompt, kind, kind, null)
     return decision
   }
 
@@ -388,7 +424,7 @@ export class OrchestrationManager extends EventEmitter {
     return sessionId
   }
 
-  _applyAuditRules(sessionId) {
+  _applyReadOnlyRules(sessionId) {
     const session = this._sm.getSession?.(sessionId)?.session
     if (session && typeof session.setPermissionRules === 'function') {
       session.setPermissionRules([
@@ -425,6 +461,10 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   _failRun(run, code, err) {
+    // A cancel that already tore the run down wins: don't overwrite the
+    // terminal 'cancelled' status with 'failed' (or double-emit lifecycle
+    // events) when an in-flight turn rejects SESSION_GONE on the next tick.
+    if (run.cancelled || !this._runs.has(run.runId)) return { runId: run.runId, phase: run.phase }
     run.phase = 'failed'
     this._ledger.setStatus(run.runId, 'failed', code)
     // tear down any owned sessions
@@ -458,9 +498,14 @@ export class OrchestrationManager extends EventEmitter {
     return false
   }
   _roleClassForSession(sessionId) {
+    // The architect is read-only too (it plans/reviews, never edits), so it maps
+    // to the 'audit' policy: reads are rule-allowed and never reach the gate;
+    // anything else (Bash) is denied. Returning null here would make the gate
+    // IGNORE the architect, wedging any non-rule tool it emits until the turn
+    // watchdog fires and fails the run.
     for (const run of this._runs.values()) {
       const meta = run.ownedSessions.get(sessionId)
-      if (meta) return meta.role === 'audit' ? 'audit' : null // architect never gets gated tool prompts
+      if (meta) return 'audit'
     }
     return null
   }

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -1,0 +1,501 @@
+/**
+ * OrchestrationManager (engine, epic #6691, step E-2) — the committee engine.
+ * Owns run lifecycle for the READ/audit path: an architect session plans the
+ * epic, worker sessions execute audit subtasks, the architect reviews each
+ * plan-of-attack and result, and a synthesis turn produces the report. Write-
+ * capable workers + merge-back are E-3; the wire projection is E-4.
+ *
+ * Wires the merged foundations: RunLedger (M-2) for durable state + usage,
+ * run-budget (M-3) for soft caps, TurnDriver (E-1) to drive sessions,
+ * decision-contract (E-1) for the structured committee decisions, run-model
+ * (E-1) for the gate registry, role-prompts (this step), and the permission
+ * gate. Sessions are real SessionManager sessions (one model per session).
+ *
+ * The manager is event-driven and async; each subtask advances through the
+ * committee loop as its turns resolve. All external collaborators are injected,
+ * so the whole loop is testable against a scripted fake provider.
+ */
+
+import { EventEmitter } from 'node:events'
+import { randomBytes } from 'node:crypto'
+import { extractDecision, DecisionParseError, buildRepairPrompt } from './decision-contract.js'
+import { makeGate, resolveGate as resolveGateModel, nextGateId } from './run-model.js'
+import {
+  architectPreamble, auditWorkerPreamble, presetFor,
+  buildPlanPrompt, buildPoaPrompt, buildPoaReviewPrompt,
+  buildExecutePrompt, buildResultReviewPrompt, buildSynthesisPrompt,
+} from './role-prompts.js'
+
+const DEFAULTS = {
+  maxParallelWorkers: 2,
+  reserveSessions: 1,
+  maxCommitteeIterations: 4,
+  maxParseRetries: 2,
+  turnTimeoutMs: 30 * 60 * 1000,
+}
+
+// Providers whose sessions can be metered AND permission-gated read-only (S-2
+// design matrix). audit workers must be one of these.
+const AUDIT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
+
+// Engine-side subtask states that end scheduling. 'escalated' is deliberately
+// excluded — it awaits a user gate, so it must block synthesis.
+const TERMINAL_SUBTASK_STATES = new Set(['done', 'failed', 'skipped'])
+function isTerminalSubtaskState(state) { return TERMINAL_SUBTASK_STATES.has(state) }
+
+export class OrchestrationManager extends EventEmitter {
+  /**
+   * @param {{
+   *   sessionManager: any, ledger: any, turnDriver: any, permissionGateFactory?: Function,
+   *   config?: object, roles?: object, validateCwd?: (cwd: string) => (string|null),
+   *   now?: () => number, log?: object,
+   * }} opts
+   */
+  constructor({ sessionManager, ledger, turnDriver, permissionGateFactory = null, config = {}, roles = null, validateCwd = null, now = () => Date.now(), log = null }) {
+    super()
+    if (!sessionManager) throw new Error('OrchestrationManager requires a sessionManager')
+    if (!ledger) throw new Error('OrchestrationManager requires a ledger')
+    if (!turnDriver) throw new Error('OrchestrationManager requires a turnDriver')
+    this._sm = sessionManager
+    this._ledger = ledger
+    this._driver = turnDriver
+    this._cfg = { ...DEFAULTS, ...(config.orchestration || config || {}) }
+    this._roles = roles || (config.orchestration && config.orchestration.roles) || null
+    this._validateCwd = validateCwd
+    this._now = now
+    this._log = log
+    this._runs = new Map() // runId -> engine state
+    this._reports = new Map() // runId -> reportMarkdown (in-memory until M-4 persists report.md)
+    this._maxReports = 32
+    this._maxSessions = Number.isFinite(config.maxSessions) ? config.maxSessions : 5
+
+    // Owned-session registry drives the permission gate (answers ONLY our sessions).
+    if (permissionGateFactory) {
+      this._gate = permissionGateFactory({
+        sessionManager,
+        isOwnedSession: (sid) => this._isOwnedSession(sid),
+        policyForSession: (sid) => this._roleClassForSession(sid),
+        emitEscalation: (info) => this._onPermissionEscalation(info),
+        log,
+      })
+    }
+  }
+
+  dispose() {
+    this._gate?.dispose?.()
+  }
+
+  // --- run creation --------------------------------------------------------
+
+  createRun({ title = '', goal = null, cwd, preset = null, budgetUsd = null, autoApprovePlan = false, roleOverrides = null } = {}) {
+    if (!cwd || typeof cwd !== 'string') throw new Error('createRun requires a cwd')
+    if (this._validateCwd) {
+      const cwdError = this._validateCwd(cwd)
+      if (cwdError) throw new Error(`invalid cwd: ${cwdError}`)
+    }
+    if (this._runs.size > 0) throw new Error('a run is already active (one run at a time in v1)')
+
+    const presetDef = preset ? presetFor(preset) : null
+    const effectiveGoal = goal || presetDef?.goalTemplate || null
+    if (!effectiveGoal) throw new Error('createRun requires a goal or a preset that provides one')
+
+    const roleModels = this._resolveRoles(roleOverrides)
+    const configSnapshot = {
+      cwd,
+      roleModels,
+      budget: { maxUsd: Number.isFinite(budgetUsd) ? budgetUsd : null, warnPercent: 80 },
+    }
+    const record = this._ledger.createRun({ title: title || (presetDef?.name ?? 'orchestration run'), preset, configSnapshot })
+    const runId = record.runId
+
+    this._runs.set(runId, {
+      runId,
+      cwd,
+      goal: effectiveGoal,
+      preset: presetDef,
+      autoApprovePlan: autoApprovePlan === true,
+      roleModels,
+      architectSessionId: null,
+      ownedSessions: new Map(), // sessionId -> { role: 'architect'|'audit', subtaskId }
+      gates: new Map(), // gateId -> gate
+      subtasks: new Map(), // subtaskId -> { iterations, poa, result, state }
+      results: [], // accepted { title, summary }
+      phase: 'created',
+      cancelled: false,
+    })
+    return record
+  }
+
+  _resolveRoles(overrides) {
+    const base = this._roles || {}
+    const merged = { ...base, ...(overrides || {}) }
+    const architect = merged.architect
+    const worker = merged.auditWorker || merged.worker
+    if (!architect?.provider || !architect?.model) throw new Error('orchestration roles.architect must set { provider, model }')
+    if (!worker?.provider || !worker?.model) throw new Error('orchestration roles.worker/auditWorker must set { provider, model }')
+    if (!AUDIT_ELIGIBLE_PROVIDERS.has(worker.provider)) {
+      throw new Error(`audit worker provider '${worker.provider}' cannot be permission-gated read-only (use ${[...AUDIT_ELIGIBLE_PROVIDERS].join('/')})`)
+    }
+    return { architect, worker }
+  }
+
+  // --- lifecycle -----------------------------------------------------------
+
+  async startRun(runId) {
+    const run = this._get(runId)
+    run.phase = 'planning'
+    this._ledger.setStatus(runId, 'planning')
+    let plan
+    try {
+      plan = await this._plan(run)
+    } catch (err) {
+      return this._failRun(run, `PLAN_${err instanceof DecisionParseError ? 'PARSE' : 'FAILED'}`, err)
+    }
+    // materialize subtasks (audit preset coerces every subtask to role:'audit')
+    for (const spec of plan.subtasks) {
+      const subtaskId = `st_${randomBytes(4).toString('hex')}`
+      const role = run.preset?.forceRole === 'audit' ? 'audit' : spec.role
+      this._ledger.createSubtask(runId, { subtaskId, role: `worker.${role}`, title: spec.title })
+      run.subtasks.set(subtaskId, { iterations: 0, spec: { ...spec, role }, state: 'pending', poa: null, result: null })
+    }
+
+    if (run.autoApprovePlan) {
+      return this._beginExecuting(run)
+    }
+    // open the epic_plan user gate — the spend gate
+    const gate = this._openGate(run, { kind: 'epic_plan', summary: `Approve the ${run.subtasks.size}-subtask audit plan`, detail: plan.summary ?? null })
+    run.phase = 'plan_review'
+    this._ledger.setStatus(runId, 'plan_review')
+    this.emit('gate_opened', { runId, gate })
+    return { runId, phase: 'plan_review', gateId: gate.gateId }
+  }
+
+  async _plan(run) {
+    const sessionId = this._spawnSession(run, { role: 'architect' })
+    run.architectSessionId = sessionId
+    run.ownedSessions.set(sessionId, { role: 'architect', subtaskId: null })
+    const repoMap = ''
+    const prompt = buildPlanPrompt({ goal: run.goal, repoMap, maxSubtasks: 8 })
+    const { decision } = await this._driveDecision(run, sessionId, prompt, 'epic_plan', 'plan', null)
+    return decision
+  }
+
+  async resolveGate(runId, gateId, { decision, note = null, budgetUsd = null } = {}) {
+    const run = this._get(runId)
+    const gate = run.gates.get(gateId)
+    if (!gate) {
+      const err = new Error(`gate ${gateId} not found`)
+      err.code = 'GATE_NOT_FOUND'
+      throw err
+    }
+    const resolved = resolveGateModel(gate, { decision, note, budgetUsd, resolvedAt: this._now() })
+    run.gates.set(gateId, resolved)
+    this.emit('gate_resolved', { runId, gate: resolved })
+
+    if (gate.kind === 'epic_plan') {
+      if (decision === 'approve') return this._beginExecuting(run)
+      return this._failRun(run, 'PLAN_REJECTED', new Error(note || 'epic plan rejected'))
+    }
+    if (gate.kind === 'escalation') {
+      return this._resolveEscalation(run, gate, decision, note)
+    }
+    return { runId, gateId, decision }
+  }
+
+  _beginExecuting(run) {
+    run.phase = 'executing'
+    this._ledger.setStatus(run.runId, 'executing')
+    this._schedule(run)
+    return { runId: run.runId, phase: 'executing' }
+  }
+
+  // --- scheduler -----------------------------------------------------------
+
+  _schedule(run) {
+    if (run.cancelled || run.phase !== 'executing') return
+    const all = [...run.subtasks.values()]
+    // Ready to synthesize only when EVERY subtask is terminal. 'escalated' is
+    // NOT terminal — it blocks synthesis until the user resolves its gate, so a
+    // sibling escalation can't let the run synthesize with a hole in it.
+    if (all.every((s) => isTerminalSubtaskState(s.state))) {
+      this._synthesize(run).catch((err) => this._failRun(run, 'SYNTHESIS_FAILED', err))
+      return
+    }
+    const pending = [...run.subtasks.entries()].filter(([, s]) => s.state === 'pending')
+    for (const [subtaskId] of pending) {
+      if (this._activeWorkerCount(run) >= this._cfg.maxParallelWorkers) break
+      if (!this._sessionHeadroom()) break
+      const budget = this._ledger.evaluateBudget(run.runId, { role: 'worker.audit' })
+      if (budget && budget.ok === false) { this._pauseForBudget(run); break }
+      const st = run.subtasks.get(subtaskId)
+      st.state = 'active'
+      this._runSubtask(run, subtaskId).catch((err) => {
+        this._log?.warn?.(`subtask ${subtaskId} crashed: ${err?.message || err}`)
+        this._finishSubtask(run, subtaskId, 'failed')
+      })
+    }
+  }
+
+  async _runSubtask(run, subtaskId) {
+    const st = run.subtasks.get(subtaskId)
+    const sessionId = this._spawnSession(run, { role: 'audit', subtaskId })
+    run.ownedSessions.set(sessionId, { role: 'audit', subtaskId })
+    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
+    this._ledger.attachSession(run.runId, subtaskId, { sessionId, provider: run.roleModels.worker.provider, model: run.roleModels.worker.model, meterable: true })
+
+    // read-only rules for audit workers (write-deny; reads allowed)
+    this._applyAuditRules(sessionId)
+
+    let feedback = null
+    // committee loop for this subtask
+    while (true) {
+      if (st.iterations > this._cfg.maxCommitteeIterations) {
+        return this._escalateSubtask(run, subtaskId, 'committee iteration cap exceeded')
+      }
+      // 1) plan-of-attack
+      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
+      const poa = await this._driveDecision(run, sessionId, buildPoaPrompt({ subtask: st.spec }), 'plan_of_attack', 'poa', subtaskId).then((r) => r.decision)
+      st.poa = poa
+      // 2) architect reviews the PoA
+      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'poa_review' })
+      const poaReview = await this._architectReview(run, buildPoaReviewPrompt({ subtask: st.spec, poa }), 'poa_review', subtaskId)
+      this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'plan', verdict: poaReview.verdict, reviewerSessionId: run.architectSessionId, notes: poaReview.feedback ?? '' })
+      if (poaReview.verdict === 'escalate') return this._escalateSubtask(run, subtaskId, poaReview.feedback || 'architect escalated the plan')
+      if (poaReview.verdict === 'revise' || poaReview.verdict === 'redelegate') { st.iterations += 1; feedback = poaReview.feedback ?? null; continue }
+      // 3) execute
+      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'executing' })
+      const result = await this._driveDecision(run, sessionId, buildExecutePrompt({ subtask: st.spec, feedback }), 'work_result', 'execute', subtaskId).then((r) => r.decision)
+      st.result = result
+      // 4) architect reviews the result
+      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'result_review' })
+      const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result }), 'result_review', subtaskId)
+      this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'result', verdict: resultReview.verdict, reviewerSessionId: run.architectSessionId, notes: resultReview.feedback ?? '' })
+      if (resultReview.verdict === 'approve') {
+        run.results.push({ title: st.spec.title, summary: result.summary })
+        this._destroySession(run, sessionId)
+        return this._finishSubtask(run, subtaskId, 'done')
+      }
+      if (resultReview.verdict === 'escalate') return this._escalateSubtask(run, subtaskId, resultReview.feedback || 'architect escalated the result')
+      // revise / redelegate → loop with feedback
+      st.iterations += 1
+      feedback = resultReview.feedback ?? null
+    }
+  }
+
+  _finishSubtask(run, subtaskId, status) {
+    const st = run.subtasks.get(subtaskId)
+    if (st) st.state = status
+    this._ledger.updateSubtask(run.runId, subtaskId, { status })
+    // release the worker if still owned
+    for (const [sid, meta] of run.ownedSessions) {
+      if (meta.subtaskId === subtaskId && meta.role === 'audit') this._destroySession(run, sid)
+    }
+    this._schedule(run)
+  }
+
+  _escalateSubtask(run, subtaskId, reason) {
+    const st = run.subtasks.get(subtaskId)
+    if (st) st.state = 'escalated'
+    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'escalated' })
+    // Free this subtask's worker so a pending sibling can take the slot while
+    // the user resolves the escalation gate.
+    for (const [sid, meta] of [...run.ownedSessions]) {
+      if (meta.subtaskId === subtaskId && meta.role === 'audit') this._destroySession(run, sid)
+    }
+    const gate = this._openGate(run, { kind: 'escalation', nodeId: subtaskId, summary: `Subtask "${st?.spec?.title ?? subtaskId}" escalated`, detail: reason })
+    this.emit('gate_opened', { runId: run.runId, gate })
+    this._schedule(run)
+    return { runId: run.runId, subtaskId, escalated: true, gateId: gate.gateId }
+  }
+
+  _resolveEscalation(run, gate, decision, note) {
+    const subtaskId = gate.nodeId
+    const st = subtaskId ? run.subtasks.get(subtaskId) : null
+    if (!st) return { runId: run.runId, resolved: true }
+    if (decision === 'skip') { this._finishSubtask(run, subtaskId, 'skipped'); return { runId: run.runId, subtaskId, skipped: true } }
+    if (decision === 'reject') return this._failRun(run, 'ESCALATION_REJECTED', new Error(note || 'user failed the run'))
+    // approve / revise → re-drive the subtask (iteration reset via a fresh worker)
+    st.state = 'pending'
+    st.iterations = 0
+    this._schedule(run)
+    return { runId: run.runId, subtaskId, retrying: true }
+  }
+
+  async _synthesize(run) {
+    run.phase = 'synthesizing'
+    this._ledger.setStatus(run.runId, 'synthesizing')
+    const { decision } = await this._driveDecision(run, run.architectSessionId, buildSynthesisPrompt({ goal: run.goal, results: run.results }), 'synthesis', 'synthesis', null)
+    // The report lives in memory until M-4 (run-report.js) persists report.{json,md}.
+    this._rememberReport(run.runId, decision.reportMarkdown)
+    this._destroySession(run, run.architectSessionId)
+    run.phase = 'completed'
+    this._ledger.setStatus(run.runId, 'completed')
+    this.emit('run_completed', { runId: run.runId, reportMarkdown: decision.reportMarkdown })
+    this._runs.delete(run.runId)
+    return { runId: run.runId, phase: 'completed', reportMarkdown: decision.reportMarkdown }
+  }
+
+  // --- turn driving + decisions -------------------------------------------
+
+  async _architectReview(run, prompt, kind, subtaskId) {
+    const { decision } = await this._driveDecision(run, run.architectSessionId, prompt, kind, kind, subtaskId)
+    return decision
+  }
+
+  // Drive one turn and extract its decision, with a repair-reprompt ladder.
+  async _driveDecision(run, sessionId, prompt, kind, turnLabel, subtaskId) {
+    let attempt = 0
+    let currentPrompt = prompt
+    let lastError = null
+    while (attempt <= this._cfg.maxParseRetries) {
+      const { text, result } = await this._driver.driveTurn(sessionId, currentPrompt, { label: turnLabel, timeoutMs: this._cfg.turnTimeoutMs })
+      const roleClass = run.ownedSessions.get(sessionId)?.role ?? null
+      // dotted ledger role: architect plan/synthesis vs architect.review, worker.audit
+      const ledgerRole = roleClass === 'architect'
+        ? (turnLabel === 'poa_review' || turnLabel === 'result_review' ? 'architect.review' : 'architect')
+        : `worker.${roleClass}`
+      this._ledger.recordTurnUsage(run.runId, {
+        subtaskId, sessionId, role: ledgerRole, turnLabel, terminalEvent: 'result', data: result,
+      })
+      try {
+        return { decision: extractDecision(text, kind).decision }
+      } catch (err) {
+        lastError = err
+        attempt += 1
+        if (attempt > this._cfg.maxParseRetries) break
+        currentPrompt = buildRepairPrompt(kind, err) // cheap: context is cached
+      }
+    }
+    throw lastError || new DecisionParseError('no_block', 'exhausted parse retries')
+  }
+
+  // --- session spawn/teardown ---------------------------------------------
+
+  _spawnSession(run, { role, subtaskId = null }) {
+    const spec = role === 'architect' ? run.roleModels.architect : run.roleModels.worker
+    const opts = {
+      name: `orch:${run.runId}:${role}${subtaskId ? `:${subtaskId}` : ''}`,
+      cwd: run.cwd,
+      provider: spec.provider,
+      model: spec.model,
+      permissionMode: 'approve',
+      sessionPreamble: role === 'architect' ? architectPreamble() : auditWorkerPreamble(),
+      metadata: { orchestrationRunId: run.runId, orchestrationRole: role === 'architect' ? 'architect' : `worker.${role}` },
+    }
+    // codex audit workers get the read-only sandbox (#6690).
+    if (spec.provider === 'codex') opts.codexSandbox = 'read-only'
+    const sessionId = this._sm.createSession(opts)
+    return sessionId
+  }
+
+  _applyAuditRules(sessionId) {
+    const session = this._sm.getSession?.(sessionId)?.session
+    if (session && typeof session.setPermissionRules === 'function') {
+      session.setPermissionRules([
+        { tool: 'Read', decision: 'allow' }, { tool: 'Glob', decision: 'allow' }, { tool: 'Grep', decision: 'allow' },
+        { tool: 'Write', decision: 'deny' }, { tool: 'Edit', decision: 'deny' }, { tool: 'NotebookEdit', decision: 'deny' }, { tool: 'apply_patch', decision: 'deny' },
+      ])
+    }
+  }
+
+  _destroySession(run, sessionId) {
+    if (!sessionId) return
+    run.ownedSessions.delete(sessionId)
+    try { this._sm.destroySession?.(sessionId) } catch { /* best-effort */ }
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  _openGate(run, { kind, nodeId = null, summary, detail = null, budgetUsd = null }) {
+    const gate = makeGate({ gateId: nextGateId(run.runId), runId: run.runId, kind, nodeId, summary, detail, budgetUsd, openedAt: this._now() })
+    run.gates.set(gate.gateId, gate)
+    return gate
+  }
+
+  _pauseForBudget(run) {
+    run.phase = 'budget_paused'
+    this._ledger.setStatus(run.runId, 'budget_paused')
+    this.emit('run_budget_paused', { runId: run.runId })
+  }
+
+  _onPermissionEscalation(info) {
+    const run = this._runForSession(info.sessionId)
+    if (!run) return
+    this.emit('permission_escalation', { runId: run.runId, ...info })
+  }
+
+  _failRun(run, code, err) {
+    run.phase = 'failed'
+    this._ledger.setStatus(run.runId, 'failed', code)
+    // tear down any owned sessions
+    for (const sid of [...run.ownedSessions.keys()]) this._destroySession(run, sid)
+    this.emit('run_failed', { runId: run.runId, code, message: err?.message || String(err) })
+    this._runs.delete(run.runId)
+    return { runId: run.runId, phase: 'failed', code }
+  }
+
+  cancelRun(runId, { reason = 'user' } = {}) {
+    const run = this._runs.get(runId)
+    if (!run) return null
+    run.cancelled = true
+    for (const sid of [...run.ownedSessions.keys()]) {
+      try { this._sm.getSession?.(sid)?.session?.interrupt?.() } catch { /* ignore */ }
+      this._destroySession(run, sid)
+    }
+    this._ledger.setStatus(runId, 'cancelled', reason)
+    this.emit('run_cancelled', { runId, reason })
+    this._runs.delete(runId)
+    return { runId, phase: 'cancelled' }
+  }
+
+  _get(runId) {
+    const run = this._runs.get(runId)
+    if (!run) throw new Error(`run ${runId} not found`)
+    return run
+  }
+  _isOwnedSession(sessionId) {
+    for (const run of this._runs.values()) if (run.ownedSessions.has(sessionId)) return true
+    return false
+  }
+  _roleClassForSession(sessionId) {
+    for (const run of this._runs.values()) {
+      const meta = run.ownedSessions.get(sessionId)
+      if (meta) return meta.role === 'audit' ? 'audit' : null // architect never gets gated tool prompts
+    }
+    return null
+  }
+  _runForSession(sessionId) {
+    for (const run of this._runs.values()) if (run.ownedSessions.has(sessionId)) return run
+    return null
+  }
+  _activeWorkerCount(run) {
+    let n = 0
+    for (const s of run.subtasks.values()) if (s.state === 'active') n += 1
+    return n
+  }
+  _sessionHeadroom() {
+    const size = typeof this._sm.listSessions === 'function' ? this._sm.listSessions().length : this._sm._sessions?.size ?? 0
+    return size <= (this._maxSessions - this._cfg.reserveSessions)
+  }
+
+  // --- read API (consumed by the S-2 handlers; wire projection is E-4) -----
+
+  listRuns() {
+    return this._ledger.listRuns()
+  }
+  getRunSnapshot(runId) {
+    const record = this._ledger.getRun(runId)
+    if (!record) return null
+    // E-4 projects this into the wire RunDetail; for now hand back the record
+    // plus the in-memory report (M-4 will persist + project it).
+    return { seq: 0, run: record, reportMarkdown: this._reports.get(runId) ?? null }
+  }
+
+  _rememberReport(runId, markdown) {
+    this._reports.set(runId, markdown)
+    while (this._reports.size > this._maxReports) {
+      const oldest = this._reports.keys().next().value
+      this._reports.delete(oldest)
+    }
+  }
+}

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -152,10 +152,17 @@ export class OrchestrationManager extends EventEmitter {
     } catch (err) {
       return this._failRun(run, `PLAN_${err instanceof DecisionParseError ? 'PARSE' : 'FAILED'}`, err)
     }
-    // materialize subtasks (audit preset coerces every subtask to role:'audit')
+    // Materialize subtasks. E-2 is the READ/audit path: every subtask runs
+    // read-only regardless of the role the architect proposed, so coerce all of
+    // them to 'audit' — labeling a subtask worker.implement while it actually
+    // runs through the read-only worker path would make the run record lie. The
+    // implement path (respecting spec.role for non-audit runs) is E-3.
     for (const spec of plan.subtasks) {
       const subtaskId = `st_${randomBytes(4).toString('hex')}`
-      const role = run.preset?.forceRole === 'audit' ? 'audit' : spec.role
+      if (spec.role && spec.role !== 'audit') {
+        this._log?.warn?.(`orchestration: subtask "${spec.title}" requested role '${spec.role}'; coerced to audit (read path only)`)
+      }
+      const role = 'audit'
       this._ledger.createSubtask(runId, { subtaskId, role: `worker.${role}`, title: spec.title })
       run.subtasks.set(subtaskId, { iterations: 0, spec: { ...spec, role }, state: 'pending', poa: null, result: null })
     }
@@ -520,7 +527,9 @@ export class OrchestrationManager extends EventEmitter {
   }
   _sessionHeadroom() {
     const size = typeof this._sm.listSessions === 'function' ? this._sm.listSessions().length : this._sm._sessions?.size ?? 0
-    return size <= (this._maxSessions - this._cfg.reserveSessions)
+    // Room to spawn ONE more session while still leaving reserveSessions slots
+    // free — strict, so the reserve is preserved AFTER the new session exists.
+    return size + 1 <= this._maxSessions - this._cfg.reserveSessions
   }
 
   // --- read API (consumed by the S-2 handlers; wire projection is E-4) -----

--- a/packages/server/src/orchestration/permission-gate.js
+++ b/packages/server/src/orchestration/permission-gate.js
@@ -1,0 +1,97 @@
+/**
+ * Orchestration permission gate (engine, epic #6691, step E-2) — a scoped
+ * headless approver for the sessions a run OWNS. The engine spawns workers with
+ * a permission posture (audit workers get read-allow / write-deny rules via
+ * setPermissionRules, so file tools are settled before they ever prompt); this
+ * gate handles what's left — chiefly Bash, which can NEVER be rule-allowed
+ * (permission-manager NEVER_AUTO_ALLOW). It answers ONLY for owned sessions,
+ * never a user's session.
+ *
+ * Security posture:
+ *  - Scope: acts only when `isOwnedSession(sessionId)` is true.
+ *  - Same trust position as a human clicking Allow — it answers each request
+ *    individually via `session.respondToPermission`, so there is no standing
+ *    Bash whitelist (the NEVER_AUTO_ALLOW invariant is preserved).
+ *  - Fail-closed: any tool with no explicit allow decision is denied (audit
+ *    workers) or escalated to the user (implement workers, a later step).
+ *  - Never uses permissionMode:'auto' / skipPermissions for workers.
+ */
+
+// Tools a worker must never be allowed to use headlessly: sub-delegation and
+// network fetches (the committee owns the delegation tree; keeps cost flat).
+const ALWAYS_DENY = new Set(['Task', 'WebFetch', 'WebSearch'])
+
+export class OrchestrationPermissionGate {
+  /**
+   * @param {{
+   *   sessionManager: import('node:events').EventEmitter,
+   *   isOwnedSession: (sessionId: string) => boolean,
+   *   policyForSession: (sessionId: string) => ('audit'|'implement'|null),
+   *   emitEscalation?: (info: object) => void,
+   *   log?: object,
+   * }} opts
+   */
+  constructor({ sessionManager, isOwnedSession, policyForSession, emitEscalation = null, log = null }) {
+    if (!sessionManager || typeof sessionManager.on !== 'function') {
+      throw new Error('OrchestrationPermissionGate requires a sessionManager EventEmitter')
+    }
+    if (typeof isOwnedSession !== 'function') throw new Error('isOwnedSession is required')
+    if (typeof policyForSession !== 'function') throw new Error('policyForSession is required')
+    this._sm = sessionManager
+    this._isOwned = isOwnedSession
+    this._policyForSession = policyForSession
+    this._emitEscalation = emitEscalation
+    this._log = log
+    this._onEvent = this._handleSessionEvent.bind(this)
+    this._sm.on('session_event', this._onEvent)
+  }
+
+  dispose() {
+    this._sm.off?.('session_event', this._onEvent)
+  }
+
+  _handleSessionEvent({ sessionId, event, data } = {}) {
+    if (event !== 'permission_request') return
+    if (!this._isOwned(sessionId)) return // never answer a user's session
+    const role = this._policyForSession(sessionId)
+    if (!role) return
+    const toolName = data?.toolName ?? data?.tool ?? ''
+    const requestId = data?.requestId ?? data?.id ?? null
+    if (requestId == null) return
+    const decision = this._decide(role, toolName, data?.input ?? {})
+    if (decision === 'escalate') {
+      // Implement-worker Bash that isn't allowlisted: surface to the user. Until
+      // the run's escalation UX resolves it, deny so the worker never blocks
+      // indefinitely (a later step wires a real hold + user response).
+      this._emitEscalation?.({ sessionId, toolName, input: data?.input ?? null, requestId })
+      this._respond(sessionId, requestId, 'deny')
+      return
+    }
+    this._respond(sessionId, requestId, decision)
+  }
+
+  _decide(role, toolName, _input) {
+    if (ALWAYS_DENY.has(toolName)) return 'deny'
+    // Audit workers are read-only: file reads are already allowed via session
+    // rules, so anything reaching the gate (Bash, shell) is denied.
+    if (role === 'audit') return 'deny'
+    // Implement workers: Bash isn't rule-eligible → escalate to the user.
+    // (The allowlist match is a later step; default-escalate is fail-closed.)
+    if (toolName === 'Bash' || toolName === 'shell') return 'escalate'
+    return 'deny'
+  }
+
+  _respond(sessionId, requestId, decision) {
+    const entry = this._sm.getSession?.(sessionId)
+    const session = entry?.session
+    if (!session || typeof session.respondToPermission !== 'function') {
+      this._log?.warn?.(`permission-gate: cannot answer ${sessionId} (no respondToPermission)`)
+      return
+    }
+    try {
+      session.respondToPermission(requestId, decision === 'allow' ? 'allow' : 'deny')
+    } catch (err) {
+      this._log?.warn?.(`permission-gate: respond failed for ${sessionId}: ${err?.message || err}`)
+    }
+  }
+}

--- a/packages/server/src/orchestration/role-prompts.js
+++ b/packages/server/src/orchestration/role-prompts.js
@@ -1,0 +1,109 @@
+/**
+ * Role preambles + per-turn prompt builders + the repo-audit preset for the
+ * orchestration harness (engine, epic #6691, step E-2).
+ *
+ * The PREAMBLE (role framing) goes in the session preamble, which is silently
+ * capped at SESSION_PREAMBLE_MAX_LENGTH (4000) — so preambles stay short and
+ * the structured-output CONTRACT travels in the per-turn prompts (which are not
+ * capped), appended via decision-contract's `decisionInstruction`.
+ */
+
+import { decisionInstruction } from './decision-contract.js'
+
+export const ARCHITECT_PREAMBLE = [
+  'You are the ARCHITECT of a code-audit committee. You decompose an audit goal',
+  'into independent subtasks, review each worker\'s plan-of-attack before it runs,',
+  'review each worker\'s result after, and finally synthesize a report.',
+  'You never edit files yourself. Be concrete and terse. Every turn ends with a',
+  'single fenced `chroxy-decision` JSON block, exactly as the turn instructs —',
+  'no prose after it. Absence of a valid block is treated as a failure, never as',
+  'approval, so always emit one.',
+].join(' ')
+
+export const AUDIT_WORKER_PREAMBLE = [
+  'You are an AUDIT WORKER on a code-audit committee. You investigate one subtask',
+  'READ-ONLY: read and search the codebase, reason about it, and report findings.',
+  'You do NOT edit files, run mutating commands, or fetch the network. First you',
+  'propose a short plan-of-attack for the architect to approve; then you execute',
+  'and report a result summary. Every turn ends with a single fenced',
+  '`chroxy-decision` JSON block, exactly as the turn instructs — no prose after it.',
+].join(' ')
+
+export function architectPreamble() { return ARCHITECT_PREAMBLE }
+export function auditWorkerPreamble() { return AUDIT_WORKER_PREAMBLE }
+
+const join = (...parts) => parts.filter((p) => p != null && p !== '').join('\n\n')
+
+/** Architect: decompose the epic goal into subtasks. */
+export function buildPlanPrompt({ goal, repoMap = '', maxSubtasks = 8 }) {
+  return join(
+    `Decompose this audit goal into at most ${maxSubtasks} INDEPENDENT subtasks, each a distinct area of the repo. Each subtask has role "audit".`,
+    `GOAL:\n${goal}`,
+    repoMap ? `REPO MAP (partial):\n${repoMap}` : null,
+    decisionInstruction('epic_plan'),
+  )
+}
+
+/** Worker: propose a plan-of-attack for one subtask. */
+export function buildPoaPrompt({ subtask }) {
+  return join(
+    `Propose a brief plan-of-attack for this audit subtask, then wait for approval.`,
+    `SUBTASK: ${subtask.title}\nGOAL: ${subtask.goal}`,
+    subtask.successCriteria ? `SUCCESS CRITERIA: ${subtask.successCriteria}` : null,
+    decisionInstruction('plan_of_attack'),
+  )
+}
+
+/** Architect: review a worker's plan-of-attack. */
+export function buildPoaReviewPrompt({ subtask, poa }) {
+  return join(
+    `Review this worker's plan-of-attack for subtask "${subtask.title}".`,
+    `PLAN:\n${poa.plan}`,
+    `Verdict: approve (proceed), revise (send feedback, same worker retries), redelegate (fresh worker), or escalate (to the user).`,
+    decisionInstruction('poa_review'),
+  )
+}
+
+/** Worker: execute the (approved) subtask and report a result. */
+export function buildExecutePrompt({ subtask, feedback = null }) {
+  return join(
+    `Carry out the audit for subtask "${subtask.title}" and report your findings.`,
+    feedback ? `ARCHITECT FEEDBACK to address:\n${feedback}` : null,
+    decisionInstruction('work_result'),
+  )
+}
+
+/** Architect: review a worker's result. */
+export function buildResultReviewPrompt({ subtask, result }) {
+  return join(
+    `Review this worker's audit result for subtask "${subtask.title}".`,
+    `RESULT:\n${result.summary}`,
+    `Verdict: approve (accept), revise (send feedback, same worker retries), redelegate (fresh worker), or escalate.`,
+    decisionInstruction('result_review'),
+  )
+}
+
+/** Architect: synthesize the accepted results into a report. */
+export function buildSynthesisPrompt({ goal, results = [] }) {
+  const body = results.map((r, i) => `## ${i + 1}. ${r.title}\n${r.summary}`).join('\n\n')
+  return join(
+    `Synthesize the committee's audit results into one markdown report for this goal.`,
+    `GOAL:\n${goal}`,
+    `RESULTS:\n${body || '(none)'}`,
+    decisionInstruction('synthesis'),
+  )
+}
+
+export const REPO_AUDIT_PRESET = Object.freeze({
+  name: 'repo-audit',
+  goalTemplate:
+    'Perform a full self-audit of this repository: correctness bugs, security issues, '
+    + 'dead code, missing test coverage, and documentation drift. Decompose the work by area.',
+  // Every subtask in an audit run is read-only, regardless of what the architect
+  // proposes — the engine coerces role:'implement' to 'audit' with a warning.
+  forceRole: 'audit',
+})
+
+export function presetFor(name) {
+  return name === 'repo-audit' ? REPO_AUDIT_PRESET : null
+}

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -89,7 +89,7 @@ export class TurnDriver {
    * free, so no event can arrive before the accumulator exists (a fast provider
    * can emit before the returned promise is even awaited). Contended turns queue
    * FIFO and start synchronously when the prior turn releases.
-   * @returns {Promise<{ text: string, result: { cost, duration, usage } }>}
+   * @returns {Promise<{ text: string, result: { cost, duration, usage, modelUsage, model, numTurns, apiDurationMs } }>}
    * @throws {TurnError}
    */
   driveTurn(sessionId, prompt, { label = null, timeoutMs = null } = {}) {
@@ -200,10 +200,18 @@ export class TurnDriver {
         break
       }
       case 'result': {
+        // Forward the FULL terminal usage payload, not just cost/duration/usage:
+        // the ledger's recordTurnUsage keys off modelUsage/model/numTurns/
+        // apiDurationMs for per-model attribution (#6692). Dropping them here
+        // would silently collapse every metered run to a single unknown model.
         const result = {
           cost: data?.cost ?? null,
           duration: data?.duration ?? null,
           usage: data?.usage ?? null,
+          modelUsage: data?.modelUsage ?? null,
+          model: data?.model ?? null,
+          numTurns: Number.isFinite(data?.numTurns) ? data.numTurns : null,
+          apiDurationMs: Number.isFinite(data?.apiDurationMs) ? data.apiDurationMs : null,
         }
         const text = this._assembleText(ctx)
         this._finishTurn(ctx, () => ctx.resolve({ text, result }))

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -1,0 +1,408 @@
+// Tests for the OrchestrationManager committee engine (read/audit path, E-2).
+// Drives full audit runs against a fake SessionManager whose sessions detect the
+// expected decision kind from each prompt and emit scripted `chroxy-decision`
+// blocks — exercising the same TurnDriver → RunLedger → decision-contract wire
+// path production uses, with no real provider.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
+import { OrchestrationPermissionGate } from '../src/orchestration/permission-gate.js'
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+import { TurnDriver } from '../src/orchestration/turn-driver.js'
+
+// --- fakes -----------------------------------------------------------------
+
+const KIND_RE = /kind "([a-z_]+)"/
+
+function fenced(obj) {
+  return 'Here is my decision.\n\n```chroxy-decision\n' + JSON.stringify(obj) + '\n```'
+}
+
+class FakeSession extends EventEmitter {
+  constructor(sessionId, sm, opts, decide, model) {
+    super()
+    this.sessionId = sessionId
+    this._sm = sm
+    this.opts = opts
+    this._decide = decide
+    this._model = model
+    this.role = opts.metadata?.orchestrationRole ?? null
+    this.permissionRules = null
+    this.destroyed = false
+    this.interrupted = 0
+    this.lastKind = null
+    this.kindCalls = Object.create(null)
+    this.permissionResponses = []
+  }
+  setPermissionRules(rules) { this.permissionRules = rules }
+  interrupt() { this.interrupted += 1 }
+  respondToPermission(requestId, decision) { this.permissionResponses.push({ requestId, decision }) }
+  sendMessage(prompt) {
+    const m = String(prompt).match(KIND_RE)
+    const kind = m ? m[1] : this.lastKind
+    this.lastKind = kind
+    this.kindCalls[kind] = (this.kindCalls[kind] || 0) + 1
+    queueMicrotask(() => {
+      if (this.destroyed) return
+      const out = this._decide({ role: this.role, kind, prompt: String(prompt), n: this.kindCalls[kind], model: this._model })
+      const text = typeof out === 'string' ? out : fenced(out)
+      this._sm.emit('session_event', { sessionId: this.sessionId, event: 'stream_delta', data: { messageId: 'm1', delta: text } })
+      this._sm.emit('session_event', {
+        sessionId: this.sessionId,
+        event: 'result',
+        data: {
+          model: this._model,
+          cost: 0.01,
+          duration: 500,
+          apiDurationMs: 400,
+          numTurns: 1,
+          usage: { input_tokens: 100, output_tokens: 40, cache_read_input_tokens: 10 },
+          modelUsage: { [this._model]: { input_tokens: 100, output_tokens: 40, cache_read_input_tokens: 10 } },
+        },
+      })
+    })
+    return Promise.resolve()
+  }
+}
+
+class FakeSM extends EventEmitter {
+  constructor(decide, { architectModel = 'fable-hi', workerModel = 'haiku' } = {}) {
+    super()
+    this.setMaxListeners(0)
+    this._decide = decide
+    this._models = { architect: architectModel, worker: workerModel }
+    this._sessions = new Map()
+    this._n = 0
+    this.created = []
+    this.destroyedIds = []
+  }
+  createSession(opts) {
+    const sessionId = `sess_${++this._n}`
+    const isArch = opts.metadata?.orchestrationRole === 'architect'
+    const model = isArch ? this._models.architect : this._models.worker
+    const session = new FakeSession(sessionId, this, opts, this._decide, model)
+    this._sessions.set(sessionId, session)
+    this.created.push({ sessionId, opts, session })
+    return sessionId
+  }
+  getSession(id) { const s = this._sessions.get(id); return s ? { session: s } : null }
+  destroySession(id) {
+    const s = this._sessions.get(id)
+    if (!s) return
+    s.destroyed = true
+    this._sessions.delete(id)
+    this.destroyedIds.push(id)
+    this.emit('session_destroyed', { sessionId: id })
+  }
+  listSessions() { return [...this._sessions.keys()] }
+}
+
+// Default happy-path decider: architect plans 2 subtasks, approves every review,
+// synthesizes; workers propose a PoA and report a result.
+function happyDecider({ role, kind }) {
+  if (role === 'architect') {
+    if (kind === 'epic_plan') {
+      return {
+        kind: 'epic_plan',
+        summary: 'Two-area audit',
+        subtasks: [
+          { title: 'Audit server auth', goal: 'Review auth for bugs', role: 'audit' },
+          { title: 'Audit tunnel', goal: 'Review tunnel for bugs', role: 'audit' },
+        ],
+      }
+    }
+    if (kind === 'poa_review') return { kind: 'poa_review', verdict: 'approve' }
+    if (kind === 'result_review') return { kind: 'result_review', verdict: 'approve' }
+    if (kind === 'synthesis') return { kind: 'synthesis', reportMarkdown: '# Audit Report\n\nAll clear.' }
+  }
+  if (kind === 'plan_of_attack') return { kind: 'plan_of_attack', plan: 'Read the files and grep.', summary: 'PoA' }
+  if (kind === 'work_result') return { kind: 'work_result', summary: 'Found 2 issues in the area.' }
+  throw new Error(`unexpected turn role=${role} kind=${kind}`)
+}
+
+const ROLES = {
+  architect: { provider: 'claude-sdk', model: 'fable-hi' },
+  auditWorker: { provider: 'claude-sdk', model: 'haiku' },
+}
+
+function makeHarness(decide, { roles = ROLES, config = {}, permissionGate = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'orch-mgr-'))
+  const sm = new FakeSM(decide)
+  const ledger = new RunLedger({ baseDir: dir })
+  const driver = new TurnDriver({ sessionManager: sm })
+  const mgr = new OrchestrationManager({
+    sessionManager: sm,
+    ledger,
+    turnDriver: driver,
+    roles,
+    config,
+    permissionGateFactory: permissionGate ? (o) => new OrchestrationPermissionGate(o) : null,
+  })
+  const cleanup = () => {
+    mgr.dispose()
+    driver.dispose()
+    ledger.dispose?.()
+    rmSync(dir, { recursive: true, force: true })
+  }
+  return { dir, sm, ledger, driver, mgr, cleanup }
+}
+
+// Resolve on the first of the named manager events; reject on run_failed unless
+// it is one of the awaited events.
+function waitFor(mgr, events, { timeoutMs = 5000 } = {}) {
+  const wanted = new Set(events)
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error(`timeout waiting for ${events.join('/')}`)) }, timeoutMs)
+    const handlers = new Map()
+    const cleanup = () => { clearTimeout(timer); for (const [ev, h] of handlers) mgr.off(ev, h) }
+    const allEvents = new Set([...wanted, 'run_failed'])
+    for (const ev of allEvents) {
+      const h = (payload) => { cleanup(); resolve({ event: ev, payload }) }
+      handlers.set(ev, h)
+      mgr.on(ev, h)
+    }
+  })
+}
+
+// --- tests -----------------------------------------------------------------
+
+test('full audit run: plan → committee → synthesis → completed', async () => {
+  const { sm, ledger, mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit the repo', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    const { event, payload } = await done
+    assert.equal(event, 'run_completed')
+    assert.match(payload.reportMarkdown, /Audit Report/)
+
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.equal(record.subtasks.length, 2)
+    assert.ok(record.subtasks.every((s) => s.status === 'done'), 'all subtasks done')
+
+    // per-role + per-model attribution survived the turn-driver
+    assert.ok(record.usageTotals.byRole.architect, 'architect role recorded')
+    assert.ok(record.usageTotals.byRole['architect.review'], 'architect.review role recorded')
+    assert.ok(record.usageTotals.byRole['worker.audit'], 'worker.audit role recorded')
+    assert.ok(record.usageTotals.byModel['fable-hi'], 'architect model recorded')
+    assert.ok(record.usageTotals.byModel.haiku, 'worker model recorded')
+
+    // audit workers got read-allow / write-deny rules and were torn down
+    const workerSessions = sm.created.filter((c) => c.opts.metadata?.orchestrationRole === 'worker.audit')
+    assert.equal(workerSessions.length, 2)
+    for (const w of workerSessions) {
+      const rules = w.session.permissionRules
+      assert.ok(rules.some((r) => r.tool === 'Write' && r.decision === 'deny'), 'Write denied')
+      assert.ok(rules.some((r) => r.tool === 'Read' && r.decision === 'allow'), 'Read allowed')
+    }
+    // every spawned session destroyed by the end
+    assert.equal(sm.listSessions().length, 0, 'no leaked sessions')
+  } finally {
+    cleanup()
+  }
+})
+
+test('plan gate: startRun opens epic_plan gate; approve runs it to completion', async () => {
+  const { ledger, mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    const res = await mgr.startRun(rec.runId)
+    assert.equal(res.phase, 'plan_review')
+    const { payload } = await gated
+    assert.equal(payload.gate.kind, 'epic_plan')
+    assert.equal(ledger.getRun(rec.runId).status, 'plan_review')
+
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'approve' })
+    await done
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
+  } finally {
+    cleanup()
+  }
+})
+
+test('plan gate: reject fails the run', async () => {
+  const { ledger, mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    const failed = waitFor(mgr, ['run_failed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'reject', note: 'no' })
+    const { payload: fp } = await failed
+    assert.equal(fp.code, 'PLAN_REJECTED')
+    assert.equal(ledger.getRun(rec.runId).status, 'failed')
+  } finally {
+    cleanup()
+  }
+})
+
+test('revise verdict loops the subtask, then approves', async () => {
+  // architect revises the first PoA of each subtask once, approves after.
+  const decide = (ctx) => {
+    if (ctx.role === 'architect' && ctx.kind === 'poa_review') {
+      return { kind: 'poa_review', verdict: ctx.n === 1 ? 'revise' : 'approve', feedback: 'tighten scope' }
+    }
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.ok(record.subtasks.every((s) => s.status === 'done'))
+    // at least one poa committee review with a revise verdict was recorded
+    const reviews = record.subtasks.flatMap((s) => s.committee)
+    assert.ok(reviews.some((r) => r.phase === 'plan' && r.verdict === 'revise'), 'revise review recorded')
+  } finally {
+    cleanup()
+  }
+})
+
+test('iteration cap escalates the subtask; skip lets the run finish', async () => {
+  // architect always revises → subtask A can never pass poa_review → escalates.
+  const decide = (ctx) => {
+    if (ctx.role === 'architect' && ctx.kind === 'poa_review') return { kind: 'poa_review', verdict: 'revise', feedback: 'again' }
+    if (ctx.role === 'architect' && ctx.kind === 'epic_plan') {
+      return { kind: 'epic_plan', subtasks: [{ title: 'Only area', goal: 'g', role: 'audit' }] }
+    }
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide, { config: { maxCommitteeIterations: 2 } })
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const escalated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await escalated
+    assert.equal(payload.gate.kind, 'escalation')
+
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'skip' })
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.equal(record.subtasks[0].status, 'skipped')
+  } finally {
+    cleanup()
+  }
+})
+
+test('worker parse failure is repaired on retry', async () => {
+  // worker emits garbage on the first work_result turn, valid on the repair.
+  const decide = (ctx) => {
+    if (ctx.kind === 'work_result' && ctx.n === 1) return 'I could not comply. No block here.'
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
+  } finally {
+    cleanup()
+  }
+})
+
+test('unrecoverable parse failure fails the subtask', async () => {
+  // one subtask's worker never emits a valid work_result → subtask fails, run
+  // still synthesizes the rest.
+  const decide = (ctx) => {
+    if (ctx.kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'audit' }] }
+    if (ctx.kind === 'work_result') return 'never a valid block'
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide, { config: { maxParseRetries: 1 } })
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.equal(record.subtasks[0].status, 'failed')
+  } finally {
+    cleanup()
+  }
+})
+
+test('budget cap pauses the run before spawning workers', async () => {
+  // maxUsd below the plan-turn cost → evaluateBudget caps before the first
+  // worker delegation → budget_paused.
+  const { ledger, mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true, budgetUsd: 0.005 })
+    const paused = waitFor(mgr, ['run_budget_paused'])
+    await mgr.startRun(rec.runId)
+    await paused
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'budget_paused')
+    // no worker subtask ran to done
+    assert.ok(record.subtasks.every((s) => s.status !== 'done'))
+  } finally {
+    cleanup()
+  }
+})
+
+test('rejects an ineligible worker provider at createRun', () => {
+  const { mgr, cleanup } = makeHarness(happyDecider, {
+    roles: { architect: ROLES.architect, auditWorker: { provider: 'gemini', model: 'g' } },
+  })
+  try {
+    assert.throws(() => mgr.createRun({ goal: 'x', cwd: '/repo' }), /cannot be permission-gated read-only/)
+  } finally {
+    cleanup()
+  }
+})
+
+test('rejects a cwd that fails validation', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'orch-cwd-'))
+  const sm = new FakeSM(happyDecider)
+  const ledger = new RunLedger({ baseDir: dir })
+  const driver = new TurnDriver({ sessionManager: sm })
+  const mgr = new OrchestrationManager({
+    sessionManager: sm, ledger, turnDriver: driver, roles: ROLES,
+    validateCwd: (cwd) => (cwd === '/ok' ? null : 'outside allowed roots'),
+  })
+  try {
+    assert.throws(() => mgr.createRun({ goal: 'x', cwd: '/nope' }), /invalid cwd/)
+    assert.doesNotThrow(() => mgr.createRun({ goal: 'x', cwd: '/ok' }))
+  } finally {
+    mgr.dispose(); driver.dispose(); rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('repo-audit preset supplies the goal and forces audit role', async () => {
+  // architect proposes an implement subtask; preset coerces it to audit.
+  const decide = (ctx) => {
+    if (ctx.kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'implement' }] }
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ cwd: '/repo', preset: 'repo-audit', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.equal(record.subtasks[0].role, 'worker.audit', 'implement coerced to audit')
+    // the run was created with no explicit goal — the preset supplied it
+    assert.equal(record.preset, 'repo-audit')
+  } finally {
+    cleanup()
+  }
+})

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -499,6 +499,27 @@ test('cancel during a turn keeps status cancelled (no failed overwrite)', async 
   }
 })
 
+test('coerces an implement subtask to audit even without a preset (E-2 read path)', async () => {
+  const decide = (ctx) => {
+    if (ctx.kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'implement' }] }
+    return happyDecider(ctx)
+  }
+  const { sm, ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true }) // NO preset
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.subtasks[0].role, 'worker.audit', 'ledger role coerced to audit')
+    // and the actual session was spawned read-only, matching the label
+    const worker = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'worker.audit')
+    assert.ok(worker, 'worker spawned as worker.audit (not worker.implement)')
+  } finally {
+    cleanup()
+  }
+})
+
 test('repo-audit preset supplies the goal and forces audit role', async () => {
   // architect proposes an implement subtask; preset coerces it to audit.
   const decide = (ctx) => {

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -51,6 +51,7 @@ class FakeSession extends EventEmitter {
     queueMicrotask(() => {
       if (this.destroyed) return
       const out = this._decide({ role: this.role, kind, prompt: String(prompt), n: this.kindCalls[kind], model: this._model })
+      if (out == null) return // sentinel: hang this turn (no result emitted)
       const text = typeof out === 'string' ? out : fenced(out)
       this._sm.emit('session_event', { sessionId: this.sessionId, event: 'stream_delta', data: { messageId: 'm1', delta: text } })
       this._sm.emit('session_event', {
@@ -382,6 +383,119 @@ test('rejects a cwd that fails validation', () => {
     assert.doesNotThrow(() => mgr.createRun({ goal: 'x', cwd: '/ok' }))
   } finally {
     mgr.dispose(); driver.dispose(); rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('architect session is spawned read-only', async () => {
+  const { sm, mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const arch = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'architect')
+    assert.ok(arch, 'architect session created')
+    const rules = arch.session.permissionRules
+    assert.ok(Array.isArray(rules), 'architect got permission rules')
+    assert.ok(rules.some((r) => r.tool === 'Read' && r.decision === 'allow'), 'architect Read allowed')
+    assert.ok(rules.some((r) => r.tool === 'Write' && r.decision === 'deny'), 'architect Write denied')
+  } finally {
+    cleanup()
+  }
+})
+
+test('gate denies an architect Bash request (never ignores it)', async () => {
+  // C2: with a permission gate, an owned architect session that emits Bash is
+  // answered (deny), not left to wedge.
+  const { sm, mgr, cleanup } = makeHarness(happyDecider, { permissionGate: true })
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    await gated // plan done; architect session still owned (destroyed at synthesis)
+    const arch = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'architect').session
+    sm.emit('session_event', { sessionId: arch.sessionId, event: 'permission_request', data: { requestId: 'rq', tool: 'Bash', input: { command: 'ls' } } })
+    assert.deepEqual(arch.permissionResponses, [{ requestId: 'rq', decision: 'deny' }])
+  } finally {
+    cleanup()
+  }
+})
+
+test('redelegate spawns a fresh worker session', async () => {
+  const decide = (ctx) => {
+    if (ctx.kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'audit' }] }
+    if (ctx.role === 'architect' && ctx.kind === 'poa_review') {
+      return { kind: 'poa_review', verdict: ctx.n === 1 ? 'redelegate' : 'approve' }
+    }
+    return happyDecider(ctx)
+  }
+  const { sm, ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
+    // one subtask, redelegated once → TWO worker sessions were created for it
+    const workers = sm.created.filter((c) => c.opts.metadata?.orchestrationRole === 'worker.audit')
+    assert.equal(workers.length, 2, 'redelegate created a fresh worker')
+  } finally {
+    cleanup()
+  }
+})
+
+test('architect review usage lands in architect.review, not the subtask cell', async () => {
+  const { ledger, mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    // architect: plan + synthesis = 2 turns; architect.review: 2 subtasks × 2 reviews = 4
+    assert.equal(record.usageTotals.byRole.architect.turns, 2)
+    assert.equal(record.usageTotals.byRole['architect.review'].turns, 4)
+    // each subtask cell holds only its worker's 2 turns (poa + execute), and the
+    // architect's review turns did NOT flip modelDrift on it
+    for (const st of record.subtasks) {
+      assert.equal(st.usage.turns, 2, 'subtask cell = worker turns only')
+      assert.notEqual(st.modelDrift, true, 'no spurious modelDrift from the review turn')
+    }
+  } finally {
+    cleanup()
+  }
+})
+
+test('startRun is rejected if the run already started', async () => {
+  const { mgr, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    await gated
+    await assert.rejects(() => mgr.startRun(rec.runId), /already started/)
+  } finally {
+    cleanup()
+  }
+})
+
+test('cancel during a turn keeps status cancelled (no failed overwrite)', async () => {
+  // architect plan turn hangs; cancel mid-turn destroys it → the turn rejects
+  // SESSION_GONE → _plan throws → _failRun must NOT overwrite cancelled.
+  const decide = (ctx) => (ctx.kind === 'epic_plan' ? null : happyDecider(ctx))
+  const { ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    let failed = false
+    mgr.on('run_failed', () => { failed = true })
+    const startP = mgr.startRun(rec.runId)
+    await new Promise((r) => setTimeout(r, 10)) // let the plan turn start + hang
+    mgr.cancelRun(rec.runId)
+    await startP
+    assert.equal(ledger.getRun(rec.runId).status, 'cancelled')
+    assert.equal(failed, false, 'no run_failed emitted after cancel')
+  } finally {
+    cleanup()
   }
 })
 

--- a/packages/server/tests/orchestration-permission-gate.test.js
+++ b/packages/server/tests/orchestration-permission-gate.test.js
@@ -1,0 +1,108 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { OrchestrationPermissionGate } from '../src/orchestration/permission-gate.js'
+
+// #6691 E-2 — the scoped headless approver. It answers permission_request ONLY
+// for sessions the run owns, and never grants a standing Bash whitelist.
+
+function mkStub() {
+  const sm = new EventEmitter()
+  const sessions = new Map()
+  sm.getSession = (id) => sessions.get(id) || null
+  const add = (id) => {
+    const session = { responses: [], respondToPermission(requestId, decision) { this.responses.push({ requestId, decision }) } }
+    sessions.set(id, { session })
+    return session
+  }
+  sm.req = (id, data) => sm.emit('session_event', { sessionId: id, event: 'permission_request', data })
+  return { sm, add, sessions }
+}
+
+let gate
+afterEach(() => { gate?.dispose(); gate = null })
+
+describe('OrchestrationPermissionGate', () => {
+  it('ignores permission requests for sessions it does not own', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => false, // owns nothing
+      policyForSession: () => 'audit',
+    })
+    sm.req('s1', { requestId: 'r1', toolName: 'Bash', input: { command: 'ls' } })
+    assert.equal(s.responses.length, 0, 'never answers a non-owned session')
+  })
+
+  it('denies Bash for an owned audit session', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: (id) => id === 's1',
+      policyForSession: () => 'audit',
+    })
+    sm.req('s1', { requestId: 'r1', toolName: 'Bash', input: { command: 'rm -rf /' } })
+    assert.deepEqual(s.responses, [{ requestId: 'r1', decision: 'deny' }])
+  })
+
+  it('always denies Task/WebFetch/WebSearch regardless of role', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => true,
+      policyForSession: () => 'implement',
+    })
+    for (const [i, tool] of ['Task', 'WebFetch', 'WebSearch'].entries()) {
+      sm.req('s1', { requestId: `r${i}`, toolName: tool, input: {} })
+    }
+    assert.deepEqual(s.responses.map((r) => r.decision), ['deny', 'deny', 'deny'])
+  })
+
+  it('escalates then denies Bash for an implement worker, emitting an escalation', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    const escalations = []
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => true,
+      policyForSession: () => 'implement',
+      emitEscalation: (info) => escalations.push(info),
+    })
+    sm.req('s1', { requestId: 'r1', toolName: 'Bash', input: { command: 'npm test' } })
+    // deny keeps the worker unblocked until the user resolves the escalation
+    assert.deepEqual(s.responses, [{ requestId: 'r1', decision: 'deny' }])
+    assert.equal(escalations.length, 1)
+    assert.equal(escalations[0].toolName, 'Bash')
+    assert.equal(escalations[0].requestId, 'r1')
+  })
+
+  it('ignores non-permission session events and requests with no requestId', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => true,
+      policyForSession: () => 'audit',
+    })
+    sm.emit('session_event', { sessionId: 's1', event: 'result', data: { cost: 1 } })
+    sm.req('s1', { toolName: 'Bash' }) // no requestId
+    assert.equal(s.responses.length, 0)
+  })
+
+  it('unsubscribes on dispose', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => true,
+      policyForSession: () => 'audit',
+    })
+    gate.dispose()
+    gate = null
+    sm.req('s1', { requestId: 'r1', toolName: 'Bash' })
+    assert.equal(s.responses.length, 0, 'no longer listening after dispose')
+  })
+})

--- a/packages/server/tests/orchestration-permission-gate.test.js
+++ b/packages/server/tests/orchestration-permission-gate.test.js
@@ -47,6 +47,20 @@ describe('OrchestrationPermissionGate', () => {
     assert.deepEqual(s.responses, [{ requestId: 'r1', decision: 'deny' }])
   })
 
+  it('reads the production `tool` key (not just toolName)', () => {
+    // the real permission_request payload carries `tool`; the gate falls back to
+    // it. Exercise that key explicitly so a rename of the fallback is caught.
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => true,
+      policyForSession: () => 'audit',
+    })
+    sm.req('s1', { requestId: 'r1', tool: 'Bash', input: { command: 'ls' } })
+    assert.deepEqual(s.responses, [{ requestId: 'r1', decision: 'deny' }])
+  })
+
   it('always denies Task/WebFetch/WebSearch regardless of role', () => {
     const { sm, add } = mkStub()
     const s = add('s1')

--- a/packages/server/tests/orchestration-turn-driver.test.js
+++ b/packages/server/tests/orchestration-turn-driver.test.js
@@ -57,6 +57,43 @@ describe('TurnDriver — happy path', () => {
     sm.ev('s1', 'result', { cost: 0, duration: 1, usage: {} })
     assert.equal((await p).text, 'compact summary')
   })
+
+  it('forwards the full terminal usage payload (modelUsage/model/numTurns/apiDurationMs)', async () => {
+    // #6692: per-model attribution must survive the turn-driver, or the ledger
+    // collapses every metered run to a single unknown model.
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'go')
+    sm.ev('s1', 'result', {
+      cost: 0.2,
+      duration: 10,
+      usage: { input_tokens: 5 },
+      model: 'haiku',
+      modelUsage: { haiku: { input_tokens: 5, output_tokens: 2 } },
+      num_turns: 3, // snake_case from the wire — driver reads camelCase numTurns
+      numTurns: 3,
+      apiDurationMs: 8,
+    })
+    const { result } = await p
+    assert.equal(result.model, 'haiku')
+    assert.deepEqual(result.modelUsage, { haiku: { input_tokens: 5, output_tokens: 2 } })
+    assert.equal(result.numTurns, 3)
+    assert.equal(result.apiDurationMs, 8)
+  })
+
+  it('coerces missing/non-finite metadata fields to null', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'go')
+    sm.ev('s1', 'result', { cost: 0, duration: 1, usage: {} }) // no model/modelUsage/turns
+    const { result } = await p
+    assert.equal(result.model, null)
+    assert.equal(result.modelUsage, null)
+    assert.equal(result.numTurns, null)
+    assert.equal(result.apiDurationMs, null)
+  })
 })
 
 describe('TurnDriver — epoch guard + mutex', () => {


### PR DESCRIPTION
## Summary

Step **E-2** of the orchestration/committee epic (#6691): the `OrchestrationManager` committee engine for the **read/audit path**. Wires the merged foundations — RunLedger (M-2), run-budget (M-3), TurnDriver + decision-contract + run-model (E-1) — into the run/subtask lifecycle.

Read/audit path only. Write-capable workers, git-ops merge-back, restart reconcile, and gate timeouts are **E-3 (#6699)**; the wire projection into `RunDetail`/`RunSummary` is **E-4 (#6700)**.

## What's here

**New modules (`packages/server/src/orchestration/`):**

- **`orchestration-manager.js`** — run lifecycle (`created → planning → plan_review gate → executing → synthesizing → completed/failed`), a headroom- and budget-aware scheduler, and the per-subtask committee loop:
  worker plan-of-attack → architect `poa_review` → worker execute → architect `result_review`, with `approve/revise/redelegate/escalate` verdicts. A per-subtask iteration cap (`maxCommitteeIterations`, default 4) escalates to a user gate; escalated subtasks block synthesis until resolved (`skip`/`retry`/`reject`). Decision parses go through a repair-reprompt ladder. Audit workers are spawned read-only (write-deny `setPermissionRules`; codex `sandbox: 'read-only'`) and torn down when their subtask ends. Exposes `createRun/startRun/resolveGate/cancelRun` + `listRuns/getRunSnapshot` for the S-2 handlers.
- **`role-prompts.js`** — architect + audit-worker preambles (kept under the 4000-char session-preamble cap; the structured-output contract travels in the per-turn prompts via `decisionInstruction`), per-turn prompt builders, and the `repo-audit` preset (coerces every subtask to `audit`).
- **`permission-gate.js`** — a scoped headless approver answering `permission_request` **only** for run-owned sessions: `Task`/`WebFetch`/`WebSearch` always denied; audit workers deny-by-default; implement-worker `Bash` escalates to the user (deny until resolved). No standing Bash whitelist — the `NEVER_AUTO_ALLOW` invariant holds.

**Modified:**

- **`turn-driver.js`** — forward the **full** terminal usage payload (`modelUsage` / `model` / `numTurns` / `apiDurationMs`) on `result`, not just `cost/duration/usage`. Without this the ledger's per-model attribution (#6692) silently collapses every metered run to one unknown model.

## Testing

New `orchestration-manager.test.js` drives full audit runs against a fake `SessionManager` whose sessions detect the expected decision kind from each prompt and emit scripted `chroxy-decision` blocks — the same TurnDriver → RunLedger → decision-contract wire path production uses, no real provider:

- full audit run → `completed`, with per-role (`architect` / `architect.review` / `worker.audit`) **and** per-model usage attribution assertions, read-only rules applied, no leaked sessions
- plan-gate approve → completion; plan-gate reject → `failed`
- `revise` loop; iteration-cap → escalation gate → `skip` → run finishes
- worker parse-failure repaired on retry; unrecoverable parse-failure fails just that subtask
- budget cap pauses before spawning workers (`budget_paused`)
- ineligible worker provider + failing cwd rejected at `createRun`; preset role coercion

Plus `orchestration-permission-gate.test.js` (6 cases) and two `turn-driver` passthrough cases.

**Gates:** 101/101 orchestration tests pass · `eslint src/` clean (0 errors) · `lint-session-opt-forwarding.sh` + `lint-tests-state-file-path.sh` pass.

Closes #6698