### PR TITLE
feat(server): orchestration git-ops primitives for the write path (E-3 part 1)

### DIFF
--- a/packages/server/src/orchestration/git-ops.js
+++ b/packages/server/src/orchestration/git-ops.js
@@ -26,7 +26,7 @@
 
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
-import { join } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
 import { rmSync, mkdirSync, existsSync } from 'node:fs'
 import { GIT } from '../git.js'
@@ -34,7 +34,30 @@ import { GIT } from '../git.js'
 const execFileAsync = promisify(execFileCb)
 
 const DEFAULT_TIMEOUT_MS = 30_000
-const DEFAULT_MAX_BUFFER = 4 * 1024 * 1024 // git diff of a large subtask can be big; we cap what we KEEP separately
+const DEFAULT_MAX_BUFFER = 8 * 1024 * 1024
+// A raw `git diff`/`status` can be far larger than what we KEEP; buffer
+// generously so a big real change is never misread as empty (we cap the KEPT
+// bytes separately in computeCappedDiff).
+const DIFF_MAX_BUFFER = 64 * 1024 * 1024
+
+// Reject a ref/path that git would parse as an OPTION (leading '-') or that
+// carries a NUL/newline — defense-in-depth so a caller can never turn a branch
+// name into a git flag. execFile already blocks SHELL injection; this blocks
+// ARGUMENT injection.
+function assertSafeRef(name, kind = 'ref') {
+  if (typeof name !== 'string' || name.length === 0) throw new GitOpsError(`empty ${kind}`)
+  if (name.startsWith('-') || /[\0\n\r]/.test(name)) throw new GitOpsError(`unsafe ${kind}: ${JSON.stringify(name)}`)
+}
+
+// Byte-accurate UTF-8 truncation that drops an incomplete trailing multibyte
+// char (String.slice counts UTF-16 code units, so it can overshoot a byte
+// budget ~3x on CJK content and split surrogate pairs into U+FFFD).
+function byteSliceUtf8(str, maxBytes) {
+  const buf = Buffer.from(str, 'utf8')
+  if (buf.length <= maxBytes) return str
+  // stream:true holds back an incomplete trailing sequence instead of emitting U+FFFD.
+  return new TextDecoder('utf-8').decode(buf.subarray(0, maxBytes), { stream: true })
+}
 
 // Orchestrator commit identity — the daemon env has no configured git identity,
 // so a bare `git commit` would fail. Passed per-invocation via `-c`, never
@@ -100,18 +123,21 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
 
   // A worker worktree is created DETACHED at HEAD; put it on a named branch.
   const createBranch = async (worktreePath, branchName) => {
+    assertSafeRef(branchName, 'branch')
     const base = await captureHead(worktreePath)
     await runOrThrow(['-C', worktreePath, 'switch', '-c', branchName])
     return { branch: branchName, baseSha: base.sha }
   }
 
   const branchExists = async (repoDir, branchName) => {
+    assertSafeRef(branchName, 'branch')
     const r = await run(['-C', repoDir, 'rev-parse', '--verify', '--quiet', `refs/heads/${branchName}`])
     return { exists: r.ok }
   }
 
   const deleteBranch = async (repoDir, branchName) => {
-    const r = await run(['-C', repoDir, 'branch', '-D', branchName])
+    assertSafeRef(branchName, 'branch')
+    const r = await run(['-C', repoDir, 'branch', '-D', '--', branchName])
     return { deleted: r.ok }
   }
 
@@ -121,10 +147,23 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
   // and total byte caps with explicit truncation markers so a small worker
   // model isn't handed a 2MB patch.
   const computeCappedDiff = async ({ repoDir, baseSha, headRef = 'HEAD', maxBytes = 65_536, maxFileBytes = 8_192 }) => {
-    const statR = await run(['-C', repoDir, 'diff', '--stat', `${baseSha}..${headRef}`])
-    const patchR = await run(['-C', repoDir, 'diff', `${baseSha}..${headRef}`])
+    const statR = await run(['-C', repoDir, 'diff', '--stat', `${baseSha}..${headRef}`], { maxBuffer: DIFF_MAX_BUFFER })
+    const patchR = await run(['-C', repoDir, 'diff', `${baseSha}..${headRef}`], { maxBuffer: DIFF_MAX_BUFFER })
     const stat = statR.ok ? statR.stdout : ''
-    const fullPatch = patchR.ok ? patchR.stdout : ''
+    // If the raw diff couldn't be produced/buffered, NEVER return an empty patch
+    // as if clean — that would let a huge unreviewed change look like no change.
+    // Report it honestly as truncated with an explicit marker.
+    if (!patchR.ok) {
+      return {
+        stat,
+        patch: `// diff unavailable (${patchR.stderr || 'exceeded buffer'})\n`,
+        truncated: true,
+        omittedFiles: [],
+        includedFiles: [],
+        error: patchR.stderr || 'diff_unavailable',
+      }
+    }
+    const fullPatch = patchR.stdout
 
     // Split into per-file sections on the `diff --git` boundary.
     const sections = []
@@ -158,10 +197,11 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
       }
       let piece = section
       if (Buffer.byteLength(piece, 'utf8') > maxFileBytes) {
-        // Truncate on a char boundary at/below the byte budget.
-        piece = piece.slice(0, maxFileBytes)
-        const omittedBytes = Buffer.byteLength(section, 'utf8') - Buffer.byteLength(piece, 'utf8')
-        piece += `\n// … ${omittedBytes} bytes omitted (file diff truncated)\n`
+        // Byte-accurate truncation (not String.slice, which counts UTF-16 units
+        // and overshoots the byte budget on multibyte content).
+        const kept = byteSliceUtf8(piece, maxFileBytes)
+        const omittedBytes = Buffer.byteLength(section, 'utf8') - Buffer.byteLength(kept, 'utf8')
+        piece = `${kept}\n// … ${omittedBytes} bytes omitted (file diff truncated)\n`
         truncated = true
       }
       // Total-budget check after per-file truncation.
@@ -180,20 +220,27 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
 
   // --- auto-commit (the load-bearing safety primitive) ---------------------
 
+  // THROWS on a git-status failure rather than reporting clean — a false "clean"
+  // would make autoCommit a no-op and let teardown delete uncommitted work. A
+  // caller must treat an indeterminate tree as "do not destroy".
   const isDirty = async (worktreePath) => {
-    const r = await run(['-C', worktreePath, 'status', '--porcelain'])
-    return { dirty: r.ok ? r.stdout.trim().length > 0 : false }
+    const r = await runOrThrow(['-C', worktreePath, 'status', '--porcelain'], { maxBuffer: DIFF_MAX_BUFFER })
+    return { dirty: r.stdout.trim().length > 0 }
   }
 
   // Commit everything in a worker worktree. Called ALWAYS before destroying an
   // implement worker (destroySession removes the worktree, deleting uncommitted
-  // work). A clean tree is a no-op, not an error.
+  // work). A clean tree is a no-op, not an error. --no-verify / --no-gpg-sign:
+  // these are the daemon's OWN bookkeeping commits — they must not run the
+  // user's pre-commit/commit-msg hooks (a rejecting hook would throw here and
+  // lose the worker's output) or require a GPG key the daemon doesn't have.
   const autoCommit = async ({ worktreePath, subtaskId, message = null, identity: id = identity }) => {
     const { dirty } = await isDirty(worktreePath)
     if (!dirty) return { committed: false }
     await runOrThrow(['-C', worktreePath, 'add', '-A'])
     const msg = message || `chroxy-orch(${subtaskId}): auto-commit`
-    await runOrThrow(['-C', worktreePath, '-c', `user.name=${id.name}`, '-c', `user.email=${id.email}`, 'commit', '-m', msg])
+    await runOrThrow(['-C', worktreePath, '-c', `user.name=${id.name}`, '-c', `user.email=${id.email}`,
+      'commit', '--no-verify', '--no-gpg-sign', '-m', msg])
     const head = await captureHead(worktreePath)
     return { committed: true, sha: head.sha }
   }
@@ -201,6 +248,7 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
   // --- integration worktree + sequential merge -----------------------------
 
   const createIntegrationWorktree = async ({ repoDir, runId, branchName, baseSha }) => {
+    assertSafeRef(branchName, 'branch')
     const worktreePath = integrationWorktreePath(runId)
     fs.mkdirSync(runWorktreesDir(runId), { recursive: true })
     await runOrThrow(['-C', repoDir, 'worktree', 'add', '-b', branchName, worktreePath, baseSha])
@@ -213,8 +261,13 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
   }
 
   const mergeNoFf = async ({ integrationWorktree, branch, subtaskId, identity: id = identity }) => {
+    assertSafeRef(branch, 'branch')
+    // --no-verify / --no-gpg-sign for the same reason as autoCommit: the merge
+    // commit is the daemon's bookkeeping, so a user commit-msg/pre-merge-commit
+    // hook must not be able to reject it (that would look like a non-conflict
+    // failure and wedge the integration worktree with MERGE_HEAD set).
     const r = await run(['-C', integrationWorktree, '-c', `user.name=${id.name}`, '-c', `user.email=${id.email}`,
-      'merge', '--no-ff', branch, '-m', `chroxy-orch: merge ${subtaskId}`])
+      'merge', '--no-ff', '--no-verify', '--no-gpg-sign', '-m', `chroxy-orch: merge ${subtaskId}`, branch])
     if (r.ok) return { ok: true }
     const files = await conflictFiles(integrationWorktree)
     if (files.length > 0 || /conflict/i.test(r.stderr) || /conflict/i.test(r.stdout)) {
@@ -231,14 +284,21 @@ export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot 
 
   // --- teardown + reconcile ------------------------------------------------
 
-  // Remove an ORCHESTRATOR-OWNED worktree. --force is safe here BECAUSE the
-  // path is one we created under the worktrees root; the rm fallback covers a
-  // git that refuses (locked/partial). NEVER call this on a user worktree.
+  // Remove an ORCHESTRATOR-OWNED worktree. --force + the rm fallback are safe
+  // ONLY under the worktrees root — this guard ENFORCES that invariant so a
+  // corrupted ledger record or a buggy caller can never `rm -rf` the user's
+  // repo, the ledger's runs/ dir, or any path outside the root. The root itself
+  // is also refused (we only ever remove `<root>/<runId>/…`).
   const removeWorktree = async ({ repoDir, worktreePath }) => {
-    const r = await run(['-C', repoDir, 'worktree', 'remove', '--force', worktreePath])
+    const base = resolve(rootDir())
+    const target = resolve(String(worktreePath || ''))
+    if (target === base || !target.startsWith(base + sep)) {
+      throw new GitOpsError(`refusing to remove a path outside the worktrees root: ${worktreePath}`)
+    }
+    const r = await run(['-C', repoDir, 'worktree', 'remove', '--force', target])
     if (r.ok) return { removed: true, method: 'git' }
-    if (fs.existsSync(worktreePath)) {
-      try { fs.rmSync(worktreePath, { recursive: true, force: true }) } catch { /* best-effort */ }
+    if (fs.existsSync(target)) {
+      try { fs.rmSync(target, { recursive: true, force: true }) } catch { /* best-effort */ }
     }
     return { removed: true, method: 'rm' }
   }

--- a/packages/server/src/orchestration/git-ops.js
+++ b/packages/server/src/orchestration/git-ops.js
@@ -1,0 +1,287 @@
+/**
+ * Git operations for the orchestration write path (epic #6691, step E-3).
+ *
+ * The safety primitives behind write-capable workers: create a per-subtask
+ * branch in a worker's worktree, compute a capped review diff, auto-commit
+ * before any teardown (so uncommitted work is never lost), and merge accepted
+ * branches sequentially into a run-owned integration worktree. Landing the
+ * result (into the user's branch, or a push) is ALWAYS a human action — this
+ * module never touches the user's working tree, never checks out or merges into
+ * the user's branch, and never contacts a remote.
+ *
+ * Hard rules baked in here:
+ *  - Every git call is `execFile(GIT, [...args])` — never a shell string, so a
+ *    branch name / path / conflict-file list can never inject a command.
+ *  - `GIT` is the resolved binary (a bare 'git' is ENOENT under launchd's
+ *    minimal PATH).
+ *  - `worktree remove --force` + an rm fallback are used ONLY on orchestrator-
+ *    owned worktrees under the injected worktrees root; user-adjacent
+ *    reclamation is the GC reaper's job, not this module's.
+ *  - Expected git failure modes (a merge conflict, a clean tree, a missing
+ *    branch) are returned as structured results, not thrown.
+ *
+ * All collaborators (git binary, clock, fs, worktrees root) are injected via
+ * `createGitOps(...)` so the suite can drive it against temp repos.
+ */
+
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { rmSync, mkdirSync, existsSync } from 'node:fs'
+import { GIT } from '../git.js'
+
+const execFileAsync = promisify(execFileCb)
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_BUFFER = 4 * 1024 * 1024 // git diff of a large subtask can be big; we cap what we KEEP separately
+
+// Orchestrator commit identity — the daemon env has no configured git identity,
+// so a bare `git commit` would fail. Passed per-invocation via `-c`, never
+// written to any user config.
+const ORCH_IDENTITY = { name: 'chroxy-orch', email: 'orch@chroxy.local' }
+
+/** ~/.chroxy (honoring CHROXY_CONFIG_DIR), matching the rest of the daemon. */
+export function configDir() {
+  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+}
+
+/** The root the orphan sweep and the provisioner MUST agree on. Never `runs/`. */
+export function defaultWorktreesRoot() {
+  return join(configDir(), 'orchestration', 'worktrees')
+}
+
+export class GitOpsError extends Error {
+  constructor(message, { args = null, stderr = null } = {}) {
+    super(message)
+    this.name = 'GitOpsError'
+    this.code = 'GIT_OP_FAILED'
+    this.args = args
+    this.stderr = stderr
+  }
+}
+
+export function createGitOps({ git = GIT, now = () => Date.now(), worktreesRoot = null, identity = ORCH_IDENTITY, fs = { rmSync, mkdirSync, existsSync } } = {}) {
+  const gitBin = () => git
+  const rootDir = () => worktreesRoot || defaultWorktreesRoot()
+
+  const errText = (err) => (err?.stderr?.trim?.() || err?.message || String(err))
+
+  // Run git; resolve { stdout, stderr } on success. On failure, resolve a
+  // structured { failed:true, stderr, code } so callers can branch on expected
+  // failure modes instead of try/catch everywhere.
+  const run = async (args, { timeout = DEFAULT_TIMEOUT_MS, maxBuffer = DEFAULT_MAX_BUFFER } = {}) => {
+    try {
+      const { stdout, stderr } = await execFileAsync(gitBin(), args, { timeout, maxBuffer })
+      return { ok: true, stdout: stdout ?? '', stderr: stderr ?? '' }
+    } catch (err) {
+      return { ok: false, stdout: err?.stdout ?? '', stderr: errText(err), code: err?.code ?? null }
+    }
+  }
+  // Run git; THROW on failure. For ops where a failure is genuinely unexpected.
+  const runOrThrow = async (args, opts) => {
+    const r = await run(args, opts)
+    if (!r.ok) throw new GitOpsError(`git ${args.join(' ')} failed: ${r.stderr}`, { args, stderr: r.stderr })
+    return r
+  }
+
+  // --- path single-source-of-truth ----------------------------------------
+
+  const orchestrationWorktreesRoot = () => rootDir()
+  const runWorktreesDir = (runId) => join(rootDir(), String(runId))
+  const integrationWorktreePath = (runId) => join(rootDir(), String(runId), 'integration')
+
+  // --- branch + HEAD -------------------------------------------------------
+
+  const captureHead = async (dir) => {
+    const r = await runOrThrow(['-C', dir, 'rev-parse', 'HEAD'])
+    return { sha: r.stdout.trim() }
+  }
+
+  // A worker worktree is created DETACHED at HEAD; put it on a named branch.
+  const createBranch = async (worktreePath, branchName) => {
+    const base = await captureHead(worktreePath)
+    await runOrThrow(['-C', worktreePath, 'switch', '-c', branchName])
+    return { branch: branchName, baseSha: base.sha }
+  }
+
+  const branchExists = async (repoDir, branchName) => {
+    const r = await run(['-C', repoDir, 'rev-parse', '--verify', '--quiet', `refs/heads/${branchName}`])
+    return { exists: r.ok }
+  }
+
+  const deleteBranch = async (repoDir, branchName) => {
+    const r = await run(['-C', repoDir, 'branch', '-D', branchName])
+    return { deleted: r.ok }
+  }
+
+  // --- capped diff ---------------------------------------------------------
+
+  // A reproducible, size-bounded review artifact: baseSha..headRef, per-file
+  // and total byte caps with explicit truncation markers so a small worker
+  // model isn't handed a 2MB patch.
+  const computeCappedDiff = async ({ repoDir, baseSha, headRef = 'HEAD', maxBytes = 65_536, maxFileBytes = 8_192 }) => {
+    const statR = await run(['-C', repoDir, 'diff', '--stat', `${baseSha}..${headRef}`])
+    const patchR = await run(['-C', repoDir, 'diff', `${baseSha}..${headRef}`])
+    const stat = statR.ok ? statR.stdout : ''
+    const fullPatch = patchR.ok ? patchR.stdout : ''
+
+    // Split into per-file sections on the `diff --git` boundary.
+    const sections = []
+    const re = /(^|\n)(diff --git [^\n]*\n)/g
+    const indices = []
+    let m
+    while ((m = re.exec(fullPatch)) !== null) indices.push(m.index + (m[1] ? 1 : 0))
+    if (indices.length === 0 && fullPatch) sections.push(fullPatch)
+    for (let i = 0; i < indices.length; i += 1) {
+      const start = indices[i]
+      const end = i + 1 < indices.length ? indices[i + 1] : fullPatch.length
+      sections.push(fullPatch.slice(start, end))
+    }
+
+    const fileNameOf = (section) => {
+      const fm = section.match(/^diff --git a\/(.+?) b\/(.+?)\n/)
+      return fm ? fm[2] : (section.split('\n', 1)[0] || 'unknown').slice(0, 200)
+    }
+
+    let out = ''
+    let truncated = false
+    const includedFiles = []
+    const omittedFiles = []
+    for (const section of sections) {
+      const name = fileNameOf(section)
+      // Whole-file omission once the total budget is exhausted.
+      if (Buffer.byteLength(out, 'utf8') >= maxBytes) {
+        truncated = true
+        omittedFiles.push(name)
+        continue
+      }
+      let piece = section
+      if (Buffer.byteLength(piece, 'utf8') > maxFileBytes) {
+        // Truncate on a char boundary at/below the byte budget.
+        piece = piece.slice(0, maxFileBytes)
+        const omittedBytes = Buffer.byteLength(section, 'utf8') - Buffer.byteLength(piece, 'utf8')
+        piece += `\n// … ${omittedBytes} bytes omitted (file diff truncated)\n`
+        truncated = true
+      }
+      // Total-budget check after per-file truncation.
+      if (Buffer.byteLength(out + piece, 'utf8') > maxBytes) {
+        truncated = true
+        omittedFiles.push(name)
+        continue
+      }
+      out += piece
+      includedFiles.push(name)
+    }
+    if (omittedFiles.length) out += `\n// omitted files (diff too large): ${omittedFiles.join(', ')}\n`
+
+    return { stat, patch: out, truncated, omittedFiles, includedFiles }
+  }
+
+  // --- auto-commit (the load-bearing safety primitive) ---------------------
+
+  const isDirty = async (worktreePath) => {
+    const r = await run(['-C', worktreePath, 'status', '--porcelain'])
+    return { dirty: r.ok ? r.stdout.trim().length > 0 : false }
+  }
+
+  // Commit everything in a worker worktree. Called ALWAYS before destroying an
+  // implement worker (destroySession removes the worktree, deleting uncommitted
+  // work). A clean tree is a no-op, not an error.
+  const autoCommit = async ({ worktreePath, subtaskId, message = null, identity: id = identity }) => {
+    const { dirty } = await isDirty(worktreePath)
+    if (!dirty) return { committed: false }
+    await runOrThrow(['-C', worktreePath, 'add', '-A'])
+    const msg = message || `chroxy-orch(${subtaskId}): auto-commit`
+    await runOrThrow(['-C', worktreePath, '-c', `user.name=${id.name}`, '-c', `user.email=${id.email}`, 'commit', '-m', msg])
+    const head = await captureHead(worktreePath)
+    return { committed: true, sha: head.sha }
+  }
+
+  // --- integration worktree + sequential merge -----------------------------
+
+  const createIntegrationWorktree = async ({ repoDir, runId, branchName, baseSha }) => {
+    const worktreePath = integrationWorktreePath(runId)
+    fs.mkdirSync(runWorktreesDir(runId), { recursive: true })
+    await runOrThrow(['-C', repoDir, 'worktree', 'add', '-b', branchName, worktreePath, baseSha])
+    return { worktreePath, branch: branchName }
+  }
+
+  const conflictFiles = async (integrationWorktree) => {
+    const r = await run(['-C', integrationWorktree, 'diff', '--name-only', '--diff-filter=U'])
+    return r.ok ? r.stdout.split('\n').map((s) => s.trim()).filter(Boolean) : []
+  }
+
+  const mergeNoFf = async ({ integrationWorktree, branch, subtaskId, identity: id = identity }) => {
+    const r = await run(['-C', integrationWorktree, '-c', `user.name=${id.name}`, '-c', `user.email=${id.email}`,
+      'merge', '--no-ff', branch, '-m', `chroxy-orch: merge ${subtaskId}`])
+    if (r.ok) return { ok: true }
+    const files = await conflictFiles(integrationWorktree)
+    if (files.length > 0 || /conflict/i.test(r.stderr) || /conflict/i.test(r.stdout)) {
+      return { ok: false, conflict: true, conflictFiles: files, stderr: r.stderr }
+    }
+    // A non-conflict merge failure is genuinely unexpected.
+    throw new GitOpsError(`merge ${branch} failed: ${r.stderr}`, { stderr: r.stderr })
+  }
+
+  const abortMerge = async (integrationWorktree) => {
+    const r = await run(['-C', integrationWorktree, 'merge', '--abort'])
+    return { aborted: r.ok }
+  }
+
+  // --- teardown + reconcile ------------------------------------------------
+
+  // Remove an ORCHESTRATOR-OWNED worktree. --force is safe here BECAUSE the
+  // path is one we created under the worktrees root; the rm fallback covers a
+  // git that refuses (locked/partial). NEVER call this on a user worktree.
+  const removeWorktree = async ({ repoDir, worktreePath }) => {
+    const r = await run(['-C', repoDir, 'worktree', 'remove', '--force', worktreePath])
+    if (r.ok) return { removed: true, method: 'git' }
+    if (fs.existsSync(worktreePath)) {
+      try { fs.rmSync(worktreePath, { recursive: true, force: true }) } catch { /* best-effort */ }
+    }
+    return { removed: true, method: 'rm' }
+  }
+
+  const pruneWorktrees = async (repoDir) => {
+    const r = await run(['-C', repoDir, 'worktree', 'prune'])
+    return { pruned: r.ok }
+  }
+
+  // Parse `worktree list --porcelain` into { path, head, branch, detached }.
+  const listWorktrees = async (repoDir) => {
+    const r = await run(['-C', repoDir, 'worktree', 'list', '--porcelain'])
+    if (!r.ok) return []
+    const entries = []
+    let cur = null
+    for (const line of r.stdout.split('\n')) {
+      if (line.startsWith('worktree ')) { cur = { path: line.slice('worktree '.length).trim(), head: null, branch: null, detached: false }; entries.push(cur) }
+      else if (cur && line.startsWith('HEAD ')) cur.head = line.slice('HEAD '.length).trim()
+      else if (cur && line.startsWith('branch ')) cur.branch = line.slice('branch '.length).trim()
+      else if (cur && line.trim() === 'detached') cur.detached = true
+    }
+    return entries
+  }
+
+  return {
+    now,
+    identity,
+    configDir,
+    orchestrationWorktreesRoot,
+    runWorktreesDir,
+    integrationWorktreePath,
+    captureHead,
+    createBranch,
+    branchExists,
+    deleteBranch,
+    computeCappedDiff,
+    isDirty,
+    autoCommit,
+    createIntegrationWorktree,
+    mergeNoFf,
+    abortMerge,
+    removeWorktree,
+    pruneWorktrees,
+    listWorktrees,
+  }
+}

--- a/packages/server/tests/orchestration-git-ops.test.js
+++ b/packages/server/tests/orchestration-git-ops.test.js
@@ -2,29 +2,39 @@
 // temp git repositories. Named distinctly from the pre-existing git-ops.test.js
 // (which covers the ws-file-ops git handler).
 //
-// The load-bearing assertion in several cases: the source repo's HEAD sha AND
-// current branch are byte-identical before/after every write-path cycle — the
-// engine must never touch the user's working tree or branch.
+// The load-bearing assertions:
+//  - the source repo's HEAD + current branch + working tree are byte-identical
+//    before/after every write-path cycle (the engine never touches the user's tree);
+//  - removeWorktree REFUSES any path outside the injected worktrees root;
+//  - autoCommit / mergeNoFf use the orch identity, skip user hooks/signing, and
+//    never lose work.
+//
+// Each test gets its OWN worktrees root (via createGitOps({ worktreesRoot })) so
+// gitOps.removeWorktree only ever operates on paths under that root — matching
+// production, where worker worktrees are SessionManager's (removed by it) and
+// gitOps.removeWorktree handles only the run's integration worktree.
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { GIT } from '../src/git.js'
-import { createGitOps, defaultWorktreesRoot, configDir } from '../src/orchestration/git-ops.js'
+import { createGitOps, defaultWorktreesRoot, configDir, GitOpsError } from '../src/orchestration/git-ops.js'
 import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
 
-const gitOps = createGitOps() // real GIT
+const cleanupDirs = []
+function track(dir) { cleanupDirs.push(dir); return dir }
+process.on('exit', () => { for (const d of cleanupDirs) { try { rmSync(d, RM_RETRY) } catch { /* best effort */ } } })
 
 function g(dir, ...args) {
   return execFileSync(GIT, ['-C', dir, ...args], { encoding: 'utf8' }).trim()
 }
 
 // A temp repo with a configured identity + one initial commit on `main`.
-function mkRepo() {
-  const dir = mkdtempSync(join(tmpdir(), 'orch-git-repo-'))
+function mkRepo({ withIdentity = true } = {}) {
+  const dir = track(mkdtempSync(join(tmpdir(), 'orch-git-repo-')))
   execFileSync(GIT, ['-C', dir, 'init', '-q', '-b', 'main'])
   disableRepoAutoGc(dir)
   g(dir, 'config', 'user.name', 'Test User')
@@ -32,43 +42,48 @@ function mkRepo() {
   writeFileSync(join(dir, 'README.md'), 'hello\n')
   g(dir, 'add', '-A')
   g(dir, 'commit', '-q', '-m', 'initial')
+  if (!withIdentity) { g(dir, 'config', '--unset', 'user.name'); g(dir, 'config', '--unset', 'user.email') }
   return dir
 }
 
-// Add a DETACHED worker worktree at HEAD (mimicking SessionManager's provisioning).
-function addWorkerWorktree(repoDir, name) {
-  const wt = join(mkdtempSync(join(tmpdir(), 'orch-git-wt-')), name)
+// A gitOps whose worktrees root is a fresh temp dir, so removeWorktree's
+// containment guard operates against a real, isolated root.
+function mkGitOps() {
+  const wtRoot = track(mkdtempSync(join(tmpdir(), 'orch-wt-root-')))
+  return { gitOps: createGitOps({ worktreesRoot: wtRoot }), wtRoot }
+}
+
+let wtSeq = 0
+// A DETACHED worker worktree UNDER the given root (mimics SessionManager's
+// provisioning). Worker worktrees are removed via rawRemoveWorktree (as
+// SessionManager would); gitOps.removeWorktree is reserved for integration ones.
+function addWorkerWorktree(repoDir, wtRoot, name) {
+  const wt = join(wtRoot, `worker_${++wtSeq}_${name}`)
   execFileSync(GIT, ['-C', repoDir, 'worktree', 'add', '--detach', wt, 'HEAD'])
   return wt
 }
-
-const cleanupDirs = []
-function track(dir) { cleanupDirs.push(dir); return dir }
-process.on('exit', () => { for (const d of cleanupDirs) { try { rmSync(d, RM_RETRY) } catch { /* best effort */ } } })
+function rawRemoveWorktree(repoDir, wt) {
+  execFileSync(GIT, ['-C', repoDir, 'worktree', 'remove', '--force', wt])
+}
 
 // --- path helpers ----------------------------------------------------------
 
 test('path helpers live under orchestration/worktrees, never runs/', () => {
   const root = defaultWorktreesRoot()
   assert.ok(root.endsWith(join('orchestration', 'worktrees')), 'worktrees root')
-  assert.ok(!root.includes(`${join('orchestration', 'runs')}`), 'never under runs/')
-  assert.equal(gitOps.integrationWorktreePath('run_1'), join(root, 'run_1', 'integration'))
-  // CHROXY_CONFIG_DIR is honored via configDir()
-  assert.ok(defaultWorktreesRoot().startsWith(configDir()))
-})
-
-test('injected worktreesRoot is the single source of truth', () => {
+  assert.ok(!root.includes(join('orchestration', 'runs')), 'never under runs/')
   const ops = createGitOps({ worktreesRoot: '/tmp/wt-root' })
   assert.equal(ops.integrationWorktreePath('run_x'), '/tmp/wt-root/run_x/integration')
   assert.equal(ops.runWorktreesDir('run_x'), '/tmp/wt-root/run_x')
+  assert.ok(defaultWorktreesRoot().startsWith(configDir()))
 })
 
 // --- branch + HEAD ---------------------------------------------------------
 
 test('createBranch names a detached worker worktree and captures baseSha', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
-  // freshly added worktree is detached
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
   assert.equal(g(wt, 'rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD', 'detached before')
   const baseHead = g(repo, 'rev-parse', 'HEAD')
   const { branch, baseSha } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
@@ -78,36 +93,78 @@ test('createBranch names a detached worker worktree and captures baseSha', async
 })
 
 test('branchExists / deleteBranch', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
   await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
   assert.equal((await gitOps.branchExists(repo, 'chroxy/orch/run_1/st_a')).exists, true)
-  assert.equal((await gitOps.branchExists(repo, 'nope')).exists, false)
-  // can't delete a checked-out branch; remove the worktree first
-  await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  assert.equal((await gitOps.branchExists(repo, 'chroxy/orch/run_1/nope')).exists, false)
+  rawRemoveWorktree(repo, wt) // free the checked-out branch
   assert.equal((await gitOps.deleteBranch(repo, 'chroxy/orch/run_1/st_a')).deleted, true)
   assert.equal((await gitOps.branchExists(repo, 'chroxy/orch/run_1/st_a')).exists, false)
 })
 
+test('createBranch / mergeNoFf / deleteBranch reject an option-injecting ref name', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
+  await assert.rejects(() => gitOps.createBranch(wt, '--force'), GitOpsError)
+  await assert.rejects(() => gitOps.createBranch(wt, '-x'), /unsafe branch/)
+  await assert.rejects(() => gitOps.deleteBranch(repo, '-D'), /unsafe branch/)
+  await assert.rejects(() => gitOps.mergeNoFf({ integrationWorktree: repo, branch: '--evil', subtaskId: 's' }), /unsafe branch/)
+  await assert.rejects(() => gitOps.createBranch(wt, 'bad\nname'), /unsafe branch/)
+})
+
 // --- auto-commit -----------------------------------------------------------
 
-test('autoCommit commits a dirty worktree; work survives worktree removal', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
+test('autoCommit uses the orch identity, does not leak to config, and survives removal', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
   const { branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
   writeFileSync(join(wt, 'finding.md'), 'a bug\n')
   const res = await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
   assert.equal(res.committed, true)
   assert.ok(res.sha)
-  // remove the worktree; the branch (and its commit) must survive
-  await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  // commit author is the orch identity, NOT the repo identity
+  assert.equal(g(wt, 'log', '-1', '--format=%an'), 'chroxy-orch')
+  assert.equal(g(wt, 'log', '-1', '--format=%ae'), 'orch@chroxy.local')
+  // the -c override did not persist into the repo config (no leak)
+  assert.equal(g(repo, 'config', 'user.name'), 'Test User')
+  // committed work survives worker-worktree removal
+  rawRemoveWorktree(repo, wt)
   assert.equal((await gitOps.branchExists(repo, branch)).exists, true)
-  assert.equal(g(repo, 'show', `${branch}:finding.md`), 'a bug', 'committed content survives')
+  assert.equal(g(repo, 'show', `${branch}:finding.md`), 'a bug')
+})
+
+test('autoCommit commits even when the repo has NO configured identity', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo({ withIdentity: false })
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
+  await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  writeFileSync(join(wt, 'finding.md'), 'a bug\n')
+  const res = await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  assert.equal(res.committed, true, 'orch identity provided via -c, so a bare-identity repo still commits')
+})
+
+test('autoCommit skips a rejecting pre-commit hook (--no-verify)', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  // a pre-commit hook that always fails
+  const hook = join(repo, '.git', 'hooks', 'pre-commit')
+  writeFileSync(hook, '#!/bin/sh\nexit 1\n')
+  chmodSync(hook, 0o755)
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
+  await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  writeFileSync(join(wt, 'finding.md'), 'a bug\n')
+  const res = await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  assert.equal(res.committed, true, 'orch bookkeeping commit bypasses the user pre-commit hook')
 })
 
 test('autoCommit on a clean tree is a no-op', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
   await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
   const res = await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
   assert.equal(res.committed, false)
@@ -116,28 +173,42 @@ test('autoCommit on a clean tree is a no-op', async () => {
 // --- capped diff -----------------------------------------------------------
 
 test('computeCappedDiff truncates oversized files + omits overflow, with markers', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
   const { baseSha, branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
-  // one huge file (sorts FIRST so it's the per-file-truncation case) + several
-  // small files (the later ones overflow the total budget → omitted).
-  writeFileSync(join(wt, 'aaa_huge.txt'), 'x'.repeat(20_000) + '\n')
+  writeFileSync(join(wt, 'aaa_huge.txt'), 'x'.repeat(20_000) + '\n') // sorts first → per-file truncation path
   for (let i = 0; i < 6; i += 1) writeFileSync(join(wt, `f${i}.txt`), `content ${i}\n`.repeat(50))
   await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
 
   const diff = await gitOps.computeCappedDiff({ repoDir: repo, baseSha, headRef: branch, maxBytes: 4_000, maxFileBytes: 1_000 })
-  assert.equal(diff.truncated, true, 'flagged truncated')
+  assert.equal(diff.truncated, true)
   assert.match(diff.patch, /bytes omitted \(file diff truncated\)/, 'per-file truncation marker')
   assert.ok(diff.omittedFiles.length > 0, 'some files omitted for total budget')
   assert.match(diff.patch, /omitted files \(diff too large\)/, 'omitted-files trailer')
   assert.ok(diff.stat.length > 0, 'stat present')
-  // total kept patch respects the byte budget within a small overshoot for markers
   assert.ok(Buffer.byteLength(diff.patch, 'utf8') <= 4_000 + 500)
 })
 
+test('computeCappedDiff byte-truncates multibyte content without overshooting ~3x', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
+  const { baseSha, branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  // CJK content: each char is 3 UTF-8 bytes. A code-unit slice would keep ~3x maxFileBytes.
+  writeFileSync(join(wt, 'cjk.txt'), '中'.repeat(4000) + '\n')
+  await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  const diff = await gitOps.computeCappedDiff({ repoDir: repo, baseSha, headRef: branch, maxBytes: 100_000, maxFileBytes: 2_000 })
+  assert.equal(diff.truncated, true)
+  // kept single-file section must be within the byte budget + a small marker allowance
+  assert.ok(Buffer.byteLength(diff.patch, 'utf8') <= 2_000 + 200, `byte-bounded, got ${Buffer.byteLength(diff.patch, 'utf8')}`)
+  assert.ok(!diff.patch.includes('�'), 'no split-surrogate replacement char')
+})
+
 test('computeCappedDiff returns a full untruncated diff when under caps', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
   const { baseSha, branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
   writeFileSync(join(wt, 'small.txt'), 'one line\n')
   await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
@@ -147,108 +218,141 @@ test('computeCappedDiff returns a full untruncated diff when under caps', async 
   assert.match(diff.patch, /\+one line/)
 })
 
+test('computeCappedDiff on a no-op range returns an empty, non-truncated patch', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const wt = addWorkerWorktree(repo, wtRoot, 'w1')
+  const { baseSha, branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  // no changes committed on the branch
+  const diff = await gitOps.computeCappedDiff({ repoDir: repo, baseSha, headRef: branch })
+  assert.equal(diff.patch, '')
+  assert.equal(diff.truncated, false)
+  assert.deepEqual(diff.omittedFiles, [])
+  assert.deepEqual(diff.includedFiles, [])
+})
+
 // --- integration worktree + sequential merge -------------------------------
 
 test('sequential --no-ff merge of two non-conflicting branches', async () => {
-  const repo = track(mkRepo())
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
   const base = g(repo, 'rev-parse', 'HEAD')
-  // two workers touch different files
   const branches = []
   for (const [i, name] of ['st_a', 'st_b'].entries()) {
-    const wt = track(addWorkerWorktree(repo, name))
+    const wt = addWorkerWorktree(repo, wtRoot, name)
     const { branch } = await gitOps.createBranch(wt, `chroxy/orch/run_1/${name}`)
     writeFileSync(join(wt, `file_${i}.txt`), `work ${i}\n`)
     await gitOps.autoCommit({ worktreePath: wt, subtaskId: name })
-    await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+    rawRemoveWorktree(repo, wt)
     branches.push(branch)
   }
   const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_1', branchName: 'chroxy/orch/run_1/integration', baseSha: base })
-  track(worktreePath)
   for (const [i, branch] of branches.entries()) {
     const res = await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch, subtaskId: `st_${i}` })
     assert.equal(res.ok, true, `merge ${branch} clean`)
   }
-  // both files present on the integration branch
   assert.equal(readFileSync(join(worktreePath, 'file_0.txt'), 'utf8'), 'work 0\n')
   assert.equal(readFileSync(join(worktreePath, 'file_1.txt'), 'utf8'), 'work 1\n')
 })
 
 test('conflicting merge returns conflict + conflictFiles; abortMerge cleans up', async () => {
-  const repo = track(mkRepo())
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
   const base = g(repo, 'rev-parse', 'HEAD')
   const branches = []
   for (const [i, name] of ['st_a', 'st_b'].entries()) {
-    const wt = track(addWorkerWorktree(repo, name))
+    const wt = addWorkerWorktree(repo, wtRoot, name)
     const { branch } = await gitOps.createBranch(wt, `chroxy/orch/run_2/${name}`)
-    writeFileSync(join(wt, 'README.md'), `conflicting change ${i}\n`) // SAME file
+    writeFileSync(join(wt, 'README.md'), `conflicting change ${i}\n`)
     await gitOps.autoCommit({ worktreePath: wt, subtaskId: name })
-    await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+    rawRemoveWorktree(repo, wt)
     branches.push(branch)
   }
   const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_2', branchName: 'chroxy/orch/run_2/integration', baseSha: base })
-  track(worktreePath)
-  const first = await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch: branches[0], subtaskId: 'st_a' })
-  assert.equal(first.ok, true)
+  assert.equal((await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch: branches[0], subtaskId: 'st_a' })).ok, true)
   const second = await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch: branches[1], subtaskId: 'st_b' })
   assert.equal(second.ok, false)
   assert.equal(second.conflict, true)
-  assert.ok(second.conflictFiles.includes('README.md'), 'conflict file reported')
-  const aborted = await gitOps.abortMerge(worktreePath)
-  assert.equal(aborted.aborted, true)
-  // after abort the integration tree is clean (first merge intact)
+  assert.ok(second.conflictFiles.includes('README.md'))
+  assert.equal((await gitOps.abortMerge(worktreePath)).aborted, true)
   assert.equal((await gitOps.isDirty(worktreePath)).dirty, false)
 })
 
-// --- teardown + listing ----------------------------------------------------
-
-test('removeWorktree + pruneWorktrees + listWorktrees', async () => {
-  const repo = track(mkRepo())
-  const wt = track(addWorkerWorktree(repo, 'w1'))
-  await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
-  let list = await gitOps.listWorktrees(repo)
-  assert.ok(list.some((e) => e.path === wt || e.path.endsWith('w1')), 'worktree listed')
-  const rm = await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
-  assert.equal(rm.removed, true)
-  assert.ok(!existsSync(wt), 'worktree dir gone')
-  await gitOps.pruneWorktrees(repo)
-  list = await gitOps.listWorktrees(repo)
-  assert.ok(!list.some((e) => e.path === wt), 'removed worktree no longer listed')
+test('createIntegrationWorktree throws on a colliding runId/branch (retry is the caller\'s job)', async () => {
+  const { gitOps } = mkGitOps()
+  const repo = mkRepo()
+  const base = g(repo, 'rev-parse', 'HEAD')
+  await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_3', branchName: 'chroxy/orch/run_3/integration', baseSha: base })
+  // second call for the same runId/branch fails SAFE (no overwrite) via a typed error
+  await assert.rejects(
+    () => gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_3', branchName: 'chroxy/orch/run_3/integration', baseSha: base }),
+    GitOpsError,
+  )
 })
 
-test('removeWorktree falls back to rm when git refuses', async () => {
-  // point at a path git does not know as a worktree → git fails → rm fallback
-  const repo = track(mkRepo())
-  const orphan = track(mkdtempSync(join(tmpdir(), 'orch-git-orphan-')))
-  mkdirSync(join(orphan, 'sub'), { recursive: true })
-  writeFileSync(join(orphan, 'sub', 'x'), 'y')
-  const rm = await gitOps.removeWorktree({ repoDir: repo, worktreePath: orphan })
+// --- teardown + containment ------------------------------------------------
+
+test('removeWorktree removes an integration worktree under the root; prune + list reflect it', async () => {
+  const { gitOps } = mkGitOps()
+  const repo = mkRepo()
+  const base = g(repo, 'rev-parse', 'HEAD')
+  const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_1', branchName: 'chroxy/orch/run_1/integration', baseSha: base })
+  // match by suffix — git may report a symlink-resolved path (/private/var vs /var on macOS)
+  const leaf = join('run_1', 'integration')
+  assert.ok((await gitOps.listWorktrees(repo)).some((e) => e.path.endsWith(leaf)), 'integration worktree listed')
+  const rm = await gitOps.removeWorktree({ repoDir: repo, worktreePath })
+  assert.equal(rm.removed, true)
+  assert.ok(!existsSync(worktreePath))
+  await gitOps.pruneWorktrees(repo)
+  assert.ok(!(await gitOps.listWorktrees(repo)).some((e) => e.path.endsWith(leaf)), 'not listed after removal')
+})
+
+test('removeWorktree falls back to rm for a stale dir UNDER the root', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  // a dir under the root that git does not know as a worktree → git fails → rm
+  const stale = join(wtRoot, 'run_x', 'integration')
+  mkdirSync(join(stale, 'sub'), { recursive: true })
+  writeFileSync(join(stale, 'sub', 'x'), 'y')
+  const rm = await gitOps.removeWorktree({ repoDir: repo, worktreePath: stale })
   assert.equal(rm.removed, true)
   assert.equal(rm.method, 'rm')
-  assert.ok(!existsSync(orphan), 'rm fallback removed the dir')
+  assert.ok(!existsSync(stale))
+})
+
+test('removeWorktree REFUSES a path outside the worktrees root (and the root itself)', async () => {
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
+  const outside = track(mkdtempSync(join(tmpdir(), 'orch-outside-')))
+  writeFileSync(join(outside, 'keep.txt'), 'precious\n')
+  await assert.rejects(() => gitOps.removeWorktree({ repoDir: repo, worktreePath: outside }), /outside the worktrees root/)
+  assert.ok(existsSync(join(outside, 'keep.txt')), 'out-of-root path NOT deleted')
+  // the source repo itself is refused
+  await assert.rejects(() => gitOps.removeWorktree({ repoDir: repo, worktreePath: repo }), /outside the worktrees root/)
+  assert.ok(existsSync(join(repo, 'README.md')), 'user repo NOT deleted')
+  // the root itself is refused (we only remove <root>/<runId>/…)
+  await assert.rejects(() => gitOps.removeWorktree({ repoDir: repo, worktreePath: wtRoot }), /outside the worktrees root/)
 })
 
 // --- HARD BOUNDARY: user repo untouched ------------------------------------
 
 test('a full write-path cycle never changes the source repo HEAD or branch', async () => {
-  const repo = track(mkRepo())
+  const { gitOps, wtRoot } = mkGitOps()
+  const repo = mkRepo()
   const headBefore = g(repo, 'rev-parse', 'HEAD')
   const branchBefore = g(repo, 'rev-parse', '--abbrev-ref', 'HEAD')
   const statusBefore = g(repo, 'status', '--porcelain')
 
-  // worker → branch → commit → integration → merge
-  const wt = track(addWorkerWorktree(repo, 'st_a'))
+  const wt = addWorkerWorktree(repo, wtRoot, 'st_a')
   const { branch, baseSha } = await gitOps.createBranch(wt, 'chroxy/orch/run_9/st_a')
   writeFileSync(join(wt, 'audit.md'), 'finding\n')
   await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
-  await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  rawRemoveWorktree(repo, wt)
   const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_9', branchName: 'chroxy/orch/run_9/integration', baseSha })
-  track(worktreePath)
   await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch, subtaskId: 'st_a' })
 
-  // the user's checkout is byte-identical
   assert.equal(g(repo, 'rev-parse', 'HEAD'), headBefore, 'HEAD unchanged')
   assert.equal(g(repo, 'rev-parse', '--abbrev-ref', 'HEAD'), branchBefore, 'branch unchanged')
   assert.equal(g(repo, 'status', '--porcelain'), statusBefore, 'working tree unchanged')
-  // no remote was ever added
   assert.equal(g(repo, 'remote'), '', 'no remote contacted')
 })

--- a/packages/server/tests/orchestration-git-ops.test.js
+++ b/packages/server/tests/orchestration-git-ops.test.js
@@ -1,0 +1,254 @@
+// Tests for the orchestration git-ops primitives (E-3 write path) against REAL
+// temp git repositories. Named distinctly from the pre-existing git-ops.test.js
+// (which covers the ws-file-ops git handler).
+//
+// The load-bearing assertion in several cases: the source repo's HEAD sha AND
+// current branch are byte-identical before/after every write-path cycle — the
+// engine must never touch the user's working tree or branch.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { GIT } from '../src/git.js'
+import { createGitOps, defaultWorktreesRoot, configDir } from '../src/orchestration/git-ops.js'
+import { disableRepoAutoGc, RM_RETRY } from './test-helpers.js'
+
+const gitOps = createGitOps() // real GIT
+
+function g(dir, ...args) {
+  return execFileSync(GIT, ['-C', dir, ...args], { encoding: 'utf8' }).trim()
+}
+
+// A temp repo with a configured identity + one initial commit on `main`.
+function mkRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'orch-git-repo-'))
+  execFileSync(GIT, ['-C', dir, 'init', '-q', '-b', 'main'])
+  disableRepoAutoGc(dir)
+  g(dir, 'config', 'user.name', 'Test User')
+  g(dir, 'config', 'user.email', 'test@example.com')
+  writeFileSync(join(dir, 'README.md'), 'hello\n')
+  g(dir, 'add', '-A')
+  g(dir, 'commit', '-q', '-m', 'initial')
+  return dir
+}
+
+// Add a DETACHED worker worktree at HEAD (mimicking SessionManager's provisioning).
+function addWorkerWorktree(repoDir, name) {
+  const wt = join(mkdtempSync(join(tmpdir(), 'orch-git-wt-')), name)
+  execFileSync(GIT, ['-C', repoDir, 'worktree', 'add', '--detach', wt, 'HEAD'])
+  return wt
+}
+
+const cleanupDirs = []
+function track(dir) { cleanupDirs.push(dir); return dir }
+process.on('exit', () => { for (const d of cleanupDirs) { try { rmSync(d, RM_RETRY) } catch { /* best effort */ } } })
+
+// --- path helpers ----------------------------------------------------------
+
+test('path helpers live under orchestration/worktrees, never runs/', () => {
+  const root = defaultWorktreesRoot()
+  assert.ok(root.endsWith(join('orchestration', 'worktrees')), 'worktrees root')
+  assert.ok(!root.includes(`${join('orchestration', 'runs')}`), 'never under runs/')
+  assert.equal(gitOps.integrationWorktreePath('run_1'), join(root, 'run_1', 'integration'))
+  // CHROXY_CONFIG_DIR is honored via configDir()
+  assert.ok(defaultWorktreesRoot().startsWith(configDir()))
+})
+
+test('injected worktreesRoot is the single source of truth', () => {
+  const ops = createGitOps({ worktreesRoot: '/tmp/wt-root' })
+  assert.equal(ops.integrationWorktreePath('run_x'), '/tmp/wt-root/run_x/integration')
+  assert.equal(ops.runWorktreesDir('run_x'), '/tmp/wt-root/run_x')
+})
+
+// --- branch + HEAD ---------------------------------------------------------
+
+test('createBranch names a detached worker worktree and captures baseSha', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  // freshly added worktree is detached
+  assert.equal(g(wt, 'rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD', 'detached before')
+  const baseHead = g(repo, 'rev-parse', 'HEAD')
+  const { branch, baseSha } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  assert.equal(branch, 'chroxy/orch/run_1/st_a')
+  assert.equal(baseSha, baseHead)
+  assert.equal(g(wt, 'rev-parse', '--abbrev-ref', 'HEAD'), 'chroxy/orch/run_1/st_a', 'on branch after')
+})
+
+test('branchExists / deleteBranch', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  assert.equal((await gitOps.branchExists(repo, 'chroxy/orch/run_1/st_a')).exists, true)
+  assert.equal((await gitOps.branchExists(repo, 'nope')).exists, false)
+  // can't delete a checked-out branch; remove the worktree first
+  await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  assert.equal((await gitOps.deleteBranch(repo, 'chroxy/orch/run_1/st_a')).deleted, true)
+  assert.equal((await gitOps.branchExists(repo, 'chroxy/orch/run_1/st_a')).exists, false)
+})
+
+// --- auto-commit -----------------------------------------------------------
+
+test('autoCommit commits a dirty worktree; work survives worktree removal', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  writeFileSync(join(wt, 'finding.md'), 'a bug\n')
+  const res = await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  assert.equal(res.committed, true)
+  assert.ok(res.sha)
+  // remove the worktree; the branch (and its commit) must survive
+  await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  assert.equal((await gitOps.branchExists(repo, branch)).exists, true)
+  assert.equal(g(repo, 'show', `${branch}:finding.md`), 'a bug', 'committed content survives')
+})
+
+test('autoCommit on a clean tree is a no-op', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  const res = await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  assert.equal(res.committed, false)
+})
+
+// --- capped diff -----------------------------------------------------------
+
+test('computeCappedDiff truncates oversized files + omits overflow, with markers', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { baseSha, branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  // one huge file (sorts FIRST so it's the per-file-truncation case) + several
+  // small files (the later ones overflow the total budget → omitted).
+  writeFileSync(join(wt, 'aaa_huge.txt'), 'x'.repeat(20_000) + '\n')
+  for (let i = 0; i < 6; i += 1) writeFileSync(join(wt, `f${i}.txt`), `content ${i}\n`.repeat(50))
+  await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+
+  const diff = await gitOps.computeCappedDiff({ repoDir: repo, baseSha, headRef: branch, maxBytes: 4_000, maxFileBytes: 1_000 })
+  assert.equal(diff.truncated, true, 'flagged truncated')
+  assert.match(diff.patch, /bytes omitted \(file diff truncated\)/, 'per-file truncation marker')
+  assert.ok(diff.omittedFiles.length > 0, 'some files omitted for total budget')
+  assert.match(diff.patch, /omitted files \(diff too large\)/, 'omitted-files trailer')
+  assert.ok(diff.stat.length > 0, 'stat present')
+  // total kept patch respects the byte budget within a small overshoot for markers
+  assert.ok(Buffer.byteLength(diff.patch, 'utf8') <= 4_000 + 500)
+})
+
+test('computeCappedDiff returns a full untruncated diff when under caps', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  const { baseSha, branch } = await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  writeFileSync(join(wt, 'small.txt'), 'one line\n')
+  await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  const diff = await gitOps.computeCappedDiff({ repoDir: repo, baseSha, headRef: branch })
+  assert.equal(diff.truncated, false)
+  assert.equal(diff.omittedFiles.length, 0)
+  assert.match(diff.patch, /\+one line/)
+})
+
+// --- integration worktree + sequential merge -------------------------------
+
+test('sequential --no-ff merge of two non-conflicting branches', async () => {
+  const repo = track(mkRepo())
+  const base = g(repo, 'rev-parse', 'HEAD')
+  // two workers touch different files
+  const branches = []
+  for (const [i, name] of ['st_a', 'st_b'].entries()) {
+    const wt = track(addWorkerWorktree(repo, name))
+    const { branch } = await gitOps.createBranch(wt, `chroxy/orch/run_1/${name}`)
+    writeFileSync(join(wt, `file_${i}.txt`), `work ${i}\n`)
+    await gitOps.autoCommit({ worktreePath: wt, subtaskId: name })
+    await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+    branches.push(branch)
+  }
+  const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_1', branchName: 'chroxy/orch/run_1/integration', baseSha: base })
+  track(worktreePath)
+  for (const [i, branch] of branches.entries()) {
+    const res = await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch, subtaskId: `st_${i}` })
+    assert.equal(res.ok, true, `merge ${branch} clean`)
+  }
+  // both files present on the integration branch
+  assert.equal(readFileSync(join(worktreePath, 'file_0.txt'), 'utf8'), 'work 0\n')
+  assert.equal(readFileSync(join(worktreePath, 'file_1.txt'), 'utf8'), 'work 1\n')
+})
+
+test('conflicting merge returns conflict + conflictFiles; abortMerge cleans up', async () => {
+  const repo = track(mkRepo())
+  const base = g(repo, 'rev-parse', 'HEAD')
+  const branches = []
+  for (const [i, name] of ['st_a', 'st_b'].entries()) {
+    const wt = track(addWorkerWorktree(repo, name))
+    const { branch } = await gitOps.createBranch(wt, `chroxy/orch/run_2/${name}`)
+    writeFileSync(join(wt, 'README.md'), `conflicting change ${i}\n`) // SAME file
+    await gitOps.autoCommit({ worktreePath: wt, subtaskId: name })
+    await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+    branches.push(branch)
+  }
+  const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_2', branchName: 'chroxy/orch/run_2/integration', baseSha: base })
+  track(worktreePath)
+  const first = await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch: branches[0], subtaskId: 'st_a' })
+  assert.equal(first.ok, true)
+  const second = await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch: branches[1], subtaskId: 'st_b' })
+  assert.equal(second.ok, false)
+  assert.equal(second.conflict, true)
+  assert.ok(second.conflictFiles.includes('README.md'), 'conflict file reported')
+  const aborted = await gitOps.abortMerge(worktreePath)
+  assert.equal(aborted.aborted, true)
+  // after abort the integration tree is clean (first merge intact)
+  assert.equal((await gitOps.isDirty(worktreePath)).dirty, false)
+})
+
+// --- teardown + listing ----------------------------------------------------
+
+test('removeWorktree + pruneWorktrees + listWorktrees', async () => {
+  const repo = track(mkRepo())
+  const wt = track(addWorkerWorktree(repo, 'w1'))
+  await gitOps.createBranch(wt, 'chroxy/orch/run_1/st_a')
+  let list = await gitOps.listWorktrees(repo)
+  assert.ok(list.some((e) => e.path === wt || e.path.endsWith('w1')), 'worktree listed')
+  const rm = await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  assert.equal(rm.removed, true)
+  assert.ok(!existsSync(wt), 'worktree dir gone')
+  await gitOps.pruneWorktrees(repo)
+  list = await gitOps.listWorktrees(repo)
+  assert.ok(!list.some((e) => e.path === wt), 'removed worktree no longer listed')
+})
+
+test('removeWorktree falls back to rm when git refuses', async () => {
+  // point at a path git does not know as a worktree → git fails → rm fallback
+  const repo = track(mkRepo())
+  const orphan = track(mkdtempSync(join(tmpdir(), 'orch-git-orphan-')))
+  mkdirSync(join(orphan, 'sub'), { recursive: true })
+  writeFileSync(join(orphan, 'sub', 'x'), 'y')
+  const rm = await gitOps.removeWorktree({ repoDir: repo, worktreePath: orphan })
+  assert.equal(rm.removed, true)
+  assert.equal(rm.method, 'rm')
+  assert.ok(!existsSync(orphan), 'rm fallback removed the dir')
+})
+
+// --- HARD BOUNDARY: user repo untouched ------------------------------------
+
+test('a full write-path cycle never changes the source repo HEAD or branch', async () => {
+  const repo = track(mkRepo())
+  const headBefore = g(repo, 'rev-parse', 'HEAD')
+  const branchBefore = g(repo, 'rev-parse', '--abbrev-ref', 'HEAD')
+  const statusBefore = g(repo, 'status', '--porcelain')
+
+  // worker → branch → commit → integration → merge
+  const wt = track(addWorkerWorktree(repo, 'st_a'))
+  const { branch, baseSha } = await gitOps.createBranch(wt, 'chroxy/orch/run_9/st_a')
+  writeFileSync(join(wt, 'audit.md'), 'finding\n')
+  await gitOps.autoCommit({ worktreePath: wt, subtaskId: 'st_a' })
+  await gitOps.removeWorktree({ repoDir: repo, worktreePath: wt })
+  const { worktreePath } = await gitOps.createIntegrationWorktree({ repoDir: repo, runId: 'run_9', branchName: 'chroxy/orch/run_9/integration', baseSha })
+  track(worktreePath)
+  await gitOps.mergeNoFf({ integrationWorktree: worktreePath, branch, subtaskId: 'st_a' })
+
+  // the user's checkout is byte-identical
+  assert.equal(g(repo, 'rev-parse', 'HEAD'), headBefore, 'HEAD unchanged')
+  assert.equal(g(repo, 'rev-parse', '--abbrev-ref', 'HEAD'), branchBefore, 'branch unchanged')
+  assert.equal(g(repo, 'status', '--porcelain'), statusBefore, 'working tree unchanged')
+  // no remote was ever added
+  assert.equal(g(repo, 'remote'), '', 'no remote contacted')
+})


### PR DESCRIPTION
## Summary

Step **E-3 part 1** of the orchestration epic (#6691): the pure git safety primitives behind write-capable workers, split out from the engine wiring so this load-bearing layer can be reviewed **in isolation**. No engine behavior changes — nothing calls `git-ops.js` until part 2 wires the implement lifecycle.

This split exists because git-ops is the module where a bug could touch the user's repo. Reviewing it alone, against the invariant checklist below, is the point.

## API — `createGitOps({ git, now, worktreesRoot, identity, fs })`

- **Path single-source-of-truth**: `orchestrationWorktreesRoot` / `runWorktreesDir` / `integrationWorktreePath` — everything under `~/.chroxy/orchestration/worktrees/<runId>/`, **never** under `runs/` (the RunLedger owns that). `worktreesRoot` is injected so the provisioner and the orphan sweep agree by construction and tests can redirect it.
- `captureHead` / `createBranch` (names a detached worker worktree, returns `baseSha`) / `branchExists` / `deleteBranch`
- `computeCappedDiff` — reproducible `baseSha..headRef` review artifact with per-file + total byte caps and explicit truncation markers
- `isDirty` / `autoCommit` — the load-bearing safety primitive: commit a worker worktree before any teardown so uncommitted work is never lost (clean tree = no-op)
- `createIntegrationWorktree` / `mergeNoFf` (structured conflict result + `conflictFiles`) / `abortMerge`
- `removeWorktree` (`--force` + rm fallback, **orchestrator-owned paths only**) / `pruneWorktrees` / `listWorktrees`

## Safety invariants baked in (reviewer checklist)

- [x] Every git call is `execFile(GIT, [...args])` — **never a shell string**, so branch names / paths / conflict-file lists can't inject a command
- [x] `GIT` is the resolved binary (bare `'git'` is ENOENT under launchd's minimal PATH)
- [x] Expected git failures (merge conflict, clean tree, missing branch) return **structured results**, not throws
- [x] Orchestrator commits pass `-c user.name/email` per-call (daemon has no git identity) and **never write user config**
- [x] `--force` worktree removal only on paths under the injected worktrees root
- [x] Paths are `worktrees/<runId>/…`, never `runs/`

## Testing

13 cases against **real temp git repos** (`disableRepoAutoGc` + `RM_RETRY` for the runner gc-race): detached-worktree branch naming; capped-diff truncation markers + omitted-files trailer; auto-commit survives worktree removal; clean-tree no-op; sequential `--no-ff` merge; conflict → structured `conflictFiles` → abort; removeWorktree + rm fallback + prune + list.

**The hard boundary case**: a full worktree → branch → commit → integration → merge cycle leaves the source repo's HEAD, current branch, and working tree **byte-identical**, and asserts no remote was ever contacted.

`eslint src/` clean (0 errors) · custom lints pass · 13/13 git-ops tests pass.

Part of #6699. The implement-worker lifecycle + robustness (reconcile, cancel, orphan sweep, gate timeouts) follow in **part 2**, which closes #6699.