### PR TITLE
feat(server): orchestration wire projection layer (E-4 part 1)

### DIFF
--- a/packages/server/src/orchestration/to-wire.js
+++ b/packages/server/src/orchestration/to-wire.js
@@ -16,6 +16,8 @@
  * resultSummary, attempt, committeeIterations } } }.
  */
 
+import { RUN_GATE_KIND_VALUES, COMMITTEE_VERDICT_VALUES } from './run-model.js'
+
 const num = (v, d = 0) => (Number.isFinite(v) ? v : d)
 const str = (v, d = '') => (typeof v === 'string' ? v : d)
 const nstr = (v) => (typeof v === 'string' ? v : null)
@@ -83,9 +85,19 @@ export function timelineEntryToWire(entryArg) {
   }
   if (entry.nodeId != null) out.nodeId = String(entry.nodeId)
   if (entry.gateId != null) out.gateId = String(entry.gateId)
-  if (entry.verdict != null) out.verdict = entry.verdict
+  // verdict is optional AND enum-constrained — only pass a valid one through, else
+  // omit it (an out-of-enum string would make safeParse reject the whole entry).
+  if (COMMITTEE_VERDICT_VALUES.includes(entry.verdict)) out.verdict = entry.verdict
   if (entry.detail != null) out.detail = String(entry.detail)
   return out
+}
+
+// A gate is projectable only with a schema-valid `kind` (a required enum with no
+// safe default). A malformed gate is dropped from a run's gate list rather than
+// emitted as an invalid RunGate — from the real path makeGate guarantees a valid
+// kind, so this only guards a corrupted/hand-built gate.
+function isProjectableGate(gate) {
+  return gate && RUN_GATE_KIND_VALUES.includes(gate.kind)
 }
 
 /** A ledger subtask record (+ per-node extras) → RunNode. Null-safe. */
@@ -141,7 +153,7 @@ function updatedAtOf(record) {
 export function recordToRunSummary(record = {}, extras = {}) {
   const cfg = record.configSnapshot || {}
   const architect = cfg.roleModels?.architect || {}
-  const gates = (extras.gates || []).filter(Boolean)
+  const gates = (extras.gates || []).filter(isProjectableGate)
   return {
     runId: str(record.runId),
     title: str(record.title),
@@ -172,7 +184,7 @@ export function recordToRunDetail(record = {}, extras = {}) {
     epicPrompt: str(extras.epicPrompt),
     // filter falsy elements — a null in a manager-supplied array must not throw.
     nodes: (record.subtasks || []).filter(Boolean).map((s) => nodeToWire(s, record.runId, nodeExtras[s.subtaskId] || {})),
-    gates: (extras.gates || []).filter(Boolean).map(gateToWire),
+    gates: (extras.gates || []).filter(isProjectableGate).map(gateToWire),
     timeline: (extras.timeline || []).filter(Boolean).slice(-500).map(timelineEntryToWire),
     usageRollup: rollup,
     meteringGaps: Array.isArray(record.meteringGaps) ? record.meteringGaps.slice() : [],

--- a/packages/server/src/orchestration/to-wire.js
+++ b/packages/server/src/orchestration/to-wire.js
@@ -1,0 +1,173 @@
+/**
+ * Wire projection layer (epic #6691, step E-4). Pure functions that project a
+ * durable RunLedger record + the manager's live engine extras (gates, timeline,
+ * epic prompt, per-node worktree/branch/plan/result) into the @chroxy/protocol
+ * wire shapes (RunSummary / RunDetail / RunNode / RunGate / RunUsage / ...).
+ *
+ * Kept OUT of the manager and the ledger so it can be unit-tested against the
+ * protocol schemas in isolation: every projection here must satisfy
+ * `<Schema>.safeParse(...)`. Projections are defensive — a missing/degraded
+ * field defaults to a schema-valid zero rather than throwing, so a snapshot
+ * request can never crash on a half-built run.
+ *
+ * The `extras` bag carries what the ledger record does not hold (the manager
+ * owns it live): { epicPrompt, gates: [RunGate], timeline: [RunTimelineEntry],
+ * report, nodeExtras: { [subtaskId]: { branch, worktreePath, planSummary,
+ * resultSummary, attempt, committeeIterations } } }.
+ */
+
+const num = (v, d = 0) => (Number.isFinite(v) ? v : d)
+const str = (v, d = '') => (typeof v === 'string' ? v : d)
+const nstr = (v) => (typeof v === 'string' ? v : null)
+
+// Subtask statuses that end the node's life, split for nodeCounts buckets.
+const NODE_DONE = new Set(['done'])
+const NODE_FAILED = new Set(['failed', 'cancelled', 'interrupted'])
+const NODE_OTHER_TERMINAL = new Set(['skipped'])
+
+/** A ledger usage cell → RunUsage. */
+export function usageToWire(cell = {}) {
+  return {
+    inputTokens: num(cell.inputTokens),
+    outputTokens: num(cell.outputTokens),
+    cacheReadTokens: num(cell.cacheReadTokens),
+    cacheCreationTokens: num(cell.cacheCreationTokens),
+    costUsd: num(cell.costUsd),
+    pricedCostUsd: num(cell.pricedCostUsd),
+    effectiveUsd: num(cell.effectiveUsd),
+    unknownCostTurns: num(cell.unknownCostTurns),
+  }
+}
+
+/** record.budgetState + configSnapshot.budget + overall usage → RunBudget. */
+export function budgetToWire(record) {
+  const cap = record?.configSnapshot?.budget?.maxUsd
+  const bs = record?.budgetState || {}
+  const state = bs.capReachedAt != null ? 'capped' : bs.warnedAt != null ? 'warned' : 'ok'
+  return {
+    capUsd: Number.isFinite(cap) && cap > 0 ? cap : null,
+    spentUsd: num(record?.usageTotals?.overall?.effectiveUsd),
+    state,
+  }
+}
+
+/** A manager gate object → RunGate (mostly passthrough with schema-safe defaults). */
+export function gateToWire(gate = {}) {
+  const out = {
+    gateId: str(gate.gateId),
+    runId: str(gate.runId),
+    nodeId: nstr(gate.nodeId),
+    kind: str(gate.kind),
+    status: str(gate.status, 'pending'),
+    summary: str(gate.summary),
+    openedAt: num(gate.openedAt),
+    resolvedAt: Number.isFinite(gate.resolvedAt) ? gate.resolvedAt : null,
+    resolvedBy: gate.resolvedBy === 'user' || gate.resolvedBy === 'policy' ? gate.resolvedBy : null,
+  }
+  if (gate.detail != null) out.detail = String(gate.detail)
+  if (Number.isFinite(gate.budgetUsd) && gate.budgetUsd > 0) out.budgetUsd = gate.budgetUsd
+  if (gate.note != null) out.note = String(gate.note)
+  return out
+}
+
+/** A manager timeline entry → RunTimelineEntry. */
+export function timelineEntryToWire(entry = {}) {
+  const out = {
+    seq: num(entry.seq),
+    at: num(entry.at),
+    kind: str(entry.kind),
+    summary: str(entry.summary),
+  }
+  if (entry.nodeId != null) out.nodeId = String(entry.nodeId)
+  if (entry.gateId != null) out.gateId = String(entry.gateId)
+  if (entry.verdict != null) out.verdict = entry.verdict
+  if (entry.detail != null) out.detail = String(entry.detail)
+  return out
+}
+
+/** A ledger subtask record (+ per-node extras) → RunNode. */
+export function nodeToWire(subtask, runId, nodeExtra = {}) {
+  const created = num(subtask.createdAt)
+  return {
+    nodeId: str(subtask.subtaskId),
+    runId: str(runId),
+    title: str(subtask.title),
+    role: str(subtask.role),
+    provider: nstr(subtask.provider),
+    model: nstr(subtask.model),
+    status: str(subtask.status, 'pending'),
+    attempt: num(nodeExtra.attempt),
+    committeeIterations: num(nodeExtra.committeeIterations ?? (Array.isArray(subtask.committee) ? subtask.committee.length : 0)),
+    sessionId: nstr(subtask.sessionId),
+    worktreePath: nstr(nodeExtra.worktreePath),
+    branch: nstr(nodeExtra.branch),
+    planSummary: nstr(nodeExtra.planSummary),
+    resultSummary: nstr(nodeExtra.resultSummary),
+    usage: usageToWire(subtask.usage),
+    createdAt: created,
+    updatedAt: num(subtask.endedAt ?? subtask.startedAt ?? subtask.createdAt),
+  }
+}
+
+function nodeCounts(subtasks = []) {
+  let done = 0; let failed = 0; let other = 0
+  for (const s of subtasks) {
+    if (NODE_DONE.has(s.status)) done += 1
+    else if (NODE_FAILED.has(s.status)) failed += 1
+    else if (NODE_OTHER_TERMINAL.has(s.status)) other += 1
+  }
+  const total = subtasks.length
+  return { total, done, failed, running: Math.max(0, total - done - failed - other) }
+}
+
+function updatedAtOf(record) {
+  return num(record.endedAt ?? record.startedAt ?? record.createdAt)
+}
+
+/** A ledger record (+ extras) → RunSummary. */
+export function recordToRunSummary(record, extras = {}) {
+  const cfg = record.configSnapshot || {}
+  const architect = cfg.roleModels?.architect || {}
+  const gates = extras.gates || []
+  return {
+    runId: str(record.runId),
+    title: str(record.title),
+    preset: nstr(record.preset),
+    status: str(record.status, 'created'),
+    cwd: str(cfg.cwd),
+    epicPromptPreview: str(extras.epicPrompt).slice(0, 280),
+    architect: { provider: str(architect.provider), model: str(architect.model) },
+    budget: budgetToWire(record),
+    usage: usageToWire(record.usageTotals?.overall),
+    nodeCounts: nodeCounts(record.subtasks),
+    pendingUserGates: gates.filter((g) => g.status === 'pending').length,
+    createdAt: num(record.createdAt),
+    updatedAt: updatedAtOf(record),
+  }
+}
+
+/** A ledger record (+ extras) → RunDetail. */
+export function recordToRunDetail(record, extras = {}) {
+  const nodeExtras = extras.nodeExtras || {}
+  const rollup = {
+    total: usageToWire(record.usageTotals?.overall),
+    byRole: Object.fromEntries(Object.entries(record.usageTotals?.byRole || {}).map(([k, v]) => [k, usageToWire(v)])),
+    byModel: Object.fromEntries(Object.entries(record.usageTotals?.byModel || {}).map(([k, v]) => [k, usageToWire(v)])),
+  }
+  const detail = {
+    ...recordToRunSummary(record, extras),
+    epicPrompt: str(extras.epicPrompt),
+    nodes: (record.subtasks || []).map((s) => nodeToWire(s, record.runId, nodeExtras[s.subtaskId] || {})),
+    gates: (extras.gates || []).map(gateToWire),
+    timeline: (extras.timeline || []).slice(-500).map(timelineEntryToWire),
+    usageRollup: rollup,
+    meteringGaps: Array.isArray(record.meteringGaps) ? record.meteringGaps.slice() : [],
+  }
+  const baseline = record.baseline?.effectiveUsd
+  if (Number.isFinite(baseline)) detail.baselineEffectiveUsd = baseline
+  if (record.notes?.verdictQuality != null) detail.verdictQuality = String(record.notes.verdictQuality)
+  if (extras.report && typeof extras.report === 'object') {
+    detail.report = { json: str(extras.report.json), markdown: str(extras.report.markdown) }
+  }
+  return detail
+}

--- a/packages/server/src/orchestration/to-wire.js
+++ b/packages/server/src/orchestration/to-wire.js
@@ -25,8 +25,9 @@ const NODE_DONE = new Set(['done'])
 const NODE_FAILED = new Set(['failed', 'cancelled', 'interrupted'])
 const NODE_OTHER_TERMINAL = new Set(['skipped'])
 
-/** A ledger usage cell → RunUsage. */
-export function usageToWire(cell = {}) {
+/** A ledger usage cell → RunUsage. Null-safe (a null element must not throw). */
+export function usageToWire(cellArg) {
+  const cell = cellArg || {}
   return {
     inputTokens: num(cell.inputTokens),
     outputTokens: num(cell.outputTokens),
@@ -52,7 +53,8 @@ export function budgetToWire(record) {
 }
 
 /** A manager gate object → RunGate (mostly passthrough with schema-safe defaults). */
-export function gateToWire(gate = {}) {
+export function gateToWire(gateArg) {
+  const gate = gateArg || {}
   const out = {
     gateId: str(gate.gateId),
     runId: str(gate.runId),
@@ -71,7 +73,8 @@ export function gateToWire(gate = {}) {
 }
 
 /** A manager timeline entry → RunTimelineEntry. */
-export function timelineEntryToWire(entry = {}) {
+export function timelineEntryToWire(entryArg) {
+  const entry = entryArg || {}
   const out = {
     seq: num(entry.seq),
     at: num(entry.at),
@@ -85,8 +88,10 @@ export function timelineEntryToWire(entry = {}) {
   return out
 }
 
-/** A ledger subtask record (+ per-node extras) → RunNode. */
-export function nodeToWire(subtask, runId, nodeExtra = {}) {
+/** A ledger subtask record (+ per-node extras) → RunNode. Null-safe. */
+export function nodeToWire(subtaskArg, runId, nodeExtraArg) {
+  const subtask = subtaskArg || {}
+  const nodeExtra = nodeExtraArg || {}
   const created = num(subtask.createdAt)
   return {
     nodeId: str(subtask.subtaskId),
@@ -109,12 +114,20 @@ export function nodeToWire(subtask, runId, nodeExtra = {}) {
   }
 }
 
-function nodeCounts(subtasks = []) {
-  let done = 0; let failed = 0; let other = 0
+// nodeCounts semantics for the UI consumer: 'skipped' is terminal-but-neither
+// (subtracted from running, counted in none of done/failed) so the three buckets
+// do NOT sum to total when skipped nodes exist; 'interrupted' counts as failed
+// (it shows failed until a resume moves it back to briefing).
+function nodeCounts(subtasksArg) {
+  const subtasks = subtasksArg || []
+  let done = 0
+  let failed = 0
+  let other = 0
   for (const s of subtasks) {
-    if (NODE_DONE.has(s.status)) done += 1
-    else if (NODE_FAILED.has(s.status)) failed += 1
-    else if (NODE_OTHER_TERMINAL.has(s.status)) other += 1
+    const status = s?.status
+    if (NODE_DONE.has(status)) done += 1
+    else if (NODE_FAILED.has(status)) failed += 1
+    else if (NODE_OTHER_TERMINAL.has(status)) other += 1
   }
   const total = subtasks.length
   return { total, done, failed, running: Math.max(0, total - done - failed - other) }
@@ -125,10 +138,10 @@ function updatedAtOf(record) {
 }
 
 /** A ledger record (+ extras) → RunSummary. */
-export function recordToRunSummary(record, extras = {}) {
+export function recordToRunSummary(record = {}, extras = {}) {
   const cfg = record.configSnapshot || {}
   const architect = cfg.roleModels?.architect || {}
-  const gates = extras.gates || []
+  const gates = (extras.gates || []).filter(Boolean)
   return {
     runId: str(record.runId),
     title: str(record.title),
@@ -147,7 +160,7 @@ export function recordToRunSummary(record, extras = {}) {
 }
 
 /** A ledger record (+ extras) → RunDetail. */
-export function recordToRunDetail(record, extras = {}) {
+export function recordToRunDetail(record = {}, extras = {}) {
   const nodeExtras = extras.nodeExtras || {}
   const rollup = {
     total: usageToWire(record.usageTotals?.overall),
@@ -157,9 +170,10 @@ export function recordToRunDetail(record, extras = {}) {
   const detail = {
     ...recordToRunSummary(record, extras),
     epicPrompt: str(extras.epicPrompt),
-    nodes: (record.subtasks || []).map((s) => nodeToWire(s, record.runId, nodeExtras[s.subtaskId] || {})),
-    gates: (extras.gates || []).map(gateToWire),
-    timeline: (extras.timeline || []).slice(-500).map(timelineEntryToWire),
+    // filter falsy elements — a null in a manager-supplied array must not throw.
+    nodes: (record.subtasks || []).filter(Boolean).map((s) => nodeToWire(s, record.runId, nodeExtras[s.subtaskId] || {})),
+    gates: (extras.gates || []).filter(Boolean).map(gateToWire),
+    timeline: (extras.timeline || []).filter(Boolean).slice(-500).map(timelineEntryToWire),
     usageRollup: rollup,
     meteringGaps: Array.isArray(record.meteringGaps) ? record.meteringGaps.slice() : [],
   }

--- a/packages/server/tests/orchestration-to-wire.test.js
+++ b/packages/server/tests/orchestration-to-wire.test.js
@@ -8,9 +8,9 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { RunSummarySchema, RunDetailSchema, RunNodeSchema, RunGateSchema, RunUsageSchema } from '@chroxy/protocol'
+import { RunSummarySchema, RunDetailSchema, RunNodeSchema, RunGateSchema, RunUsageSchema, RunTimelineEntrySchema } from '@chroxy/protocol'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
-import { makeGate, resolveGate, nextGateId } from '../src/orchestration/run-model.js'
+import { makeGate, resolveGate, expireGate, nextGateId } from '../src/orchestration/run-model.js'
 import {
   usageToWire, budgetToWire, gateToWire, nodeToWire, timelineEntryToWire,
   recordToRunSummary, recordToRunDetail,
@@ -148,6 +148,70 @@ test('recordToRunDetail satisfies RunDetailSchema with nodes/gates/timeline/roll
     assert.ok(detail.usageRollup.byRole['worker.implement'], 'worker role in rollup')
     assert.equal(detail.verdictQuality ?? null, null)
     assert.deepEqual(detail.report, { json: '{"ok":true}', markdown: '# Report' })
+  } finally {
+    cleanup()
+  }
+})
+
+test('nodeCounts: skipped is excluded from all three buckets; interrupted counts as failed', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const rec = ledger.createRun({ title: 't', preset: null, configSnapshot: { cwd: '/r', roleModels: { architect: { provider: 'a', model: 'm' } }, budget: { maxUsd: null } } })
+    const id = rec.runId
+    for (const [sid, status] of [['s1', 'done'], ['s2', 'failed'], ['s3', 'skipped'], ['s4', 'interrupted'], ['s5', 'executing']]) {
+      ledger.createSubtask(id, { subtaskId: sid, role: 'worker.audit', title: sid })
+      ledger.updateSubtask(id, sid, { status })
+    }
+    const nc = recordToRunSummary(ledger.getRun(id), {}).nodeCounts
+    assert.deepEqual(nc, { total: 5, done: 1, failed: 2, running: 1 }, 'interrupted→failed, skipped excluded, executing→running')
+    assert.equal(nc.running + nc.done + nc.failed, nc.total - 1, 'buckets sum to total MINUS the skipped node')
+  } finally {
+    cleanup()
+  }
+})
+
+test('gateToWire handles an expired (policy-resolved) gate and a budget_overrun gate', () => {
+  const runId = 'run_1'
+  const expired = expireGate(makeGate({ gateId: 'g1', runId, kind: 'escalation', nodeId: 'st', summary: 's', openedAt: 1 }), { resolvedAt: 99 })
+  const w = gateToWire(expired)
+  assert.equal(RunGateSchema.safeParse(w).success, true)
+  assert.equal(w.status, 'expired')
+  assert.equal(w.resolvedBy, 'policy')
+  const overrun = gateToWire(makeGate({ gateId: 'g2', runId, kind: 'budget_overrun', nodeId: null, summary: 'raise?', budgetUsd: 10, openedAt: 2 }))
+  assert.equal(RunGateSchema.safeParse(overrun).success, true)
+  assert.equal(overrun.budgetUsd, 10)
+})
+
+test('timeline longer than 500 is sliced to the last 500', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    const timeline = Array.from({ length: 700 }, (_, i) => ({ seq: i + 1, at: i, kind: 'k', summary: `e${i}` }))
+    const detail = recordToRunDetail(record, { epicPrompt: '', gates: [], timeline })
+    assert.equal(detail.timeline.length, 500)
+    assert.equal(detail.timeline[0].summary, 'e200', 'kept the LAST 500')
+    assert.equal(RunDetailSchema.safeParse(detail).success, true)
+  } finally {
+    cleanup()
+  }
+})
+
+test('null elements in manager arrays degrade gracefully (never throw, still schema-valid)', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    // manager arrays with null holes + a null in the record subtasks
+    record.subtasks.push(null)
+    const detail = recordToRunDetail(record, {
+      epicPrompt: 'x', gates: [null, makeGate({ gateId: 'g', runId: record.runId, kind: 'epic_plan', nodeId: null, summary: 's', openedAt: 1 })],
+      timeline: [null, { seq: 1, at: 1, kind: 'k', summary: 's' }],
+    })
+    assert.equal(RunDetailSchema.safeParse(detail).success, true, 'null holes filtered, still valid')
+    assert.equal(detail.gates.length, 1)
+    assert.equal(detail.timeline.length, 1)
+    assert.equal(detail.nodes.length, 1, 'null subtask filtered out')
+    // direct helper calls on null must not throw either
+    assert.equal(RunTimelineEntrySchema.safeParse(timelineEntryToWire(null)).success, true)
   } finally {
     cleanup()
   }

--- a/packages/server/tests/orchestration-to-wire.test.js
+++ b/packages/server/tests/orchestration-to-wire.test.js
@@ -1,0 +1,166 @@
+// Tests for the wire projection layer (E-4). The load-bearing assertion: every
+// projection satisfies the real @chroxy/protocol schema (safeParse), so the
+// server can never broadcast a shape the client reducer will reject.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { RunSummarySchema, RunDetailSchema, RunNodeSchema, RunGateSchema, RunUsageSchema } from '@chroxy/protocol'
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+import { makeGate, resolveGate, nextGateId } from '../src/orchestration/run-model.js'
+import {
+  usageToWire, budgetToWire, gateToWire, nodeToWire, timelineEntryToWire,
+  recordToRunSummary, recordToRunDetail,
+} from '../src/orchestration/to-wire.js'
+
+function mkLedger() {
+  const dir = mkdtempSync(join(tmpdir(), 'towire-'))
+  const ledger = new RunLedger({ baseDir: dir })
+  return { ledger, cleanup: () => { ledger.dispose?.(); rmSync(dir, { recursive: true, force: true }) } }
+}
+
+// Build a realistic run record via the REAL ledger write path.
+function buildRecord(ledger, { status = 'executing', budgetUsd = 5 } = {}) {
+  const configSnapshot = {
+    cwd: '/repo',
+    roleModels: { architect: { provider: 'claude-sdk', model: 'fable' }, worker: { provider: 'codex', model: 'codex-m' } },
+    budget: { maxUsd: budgetUsd, warnPercent: 80 },
+  }
+  const rec = ledger.createRun({ title: 'Audit run', preset: 'repo-audit', configSnapshot })
+  const runId = rec.runId
+  ledger.setStatus(runId, 'planning')
+  ledger.createSubtask(runId, { subtaskId: 'st_a', role: 'worker.implement', title: 'Add helper' })
+  ledger.attachSession(runId, 'st_a', { sessionId: 'sess_1', provider: 'codex', model: 'codex-m', meterable: true })
+  ledger.recordTurnUsage(runId, { subtaskId: 'st_a', sessionId: 'sess_1', role: 'worker.implement', turnLabel: 'execute', terminalEvent: 'result', data: { model: 'codex-m', cost: 0.02, usage: { input_tokens: 100, output_tokens: 40 } } })
+  ledger.recordTurnUsage(runId, { subtaskId: null, sessionId: 'arch', role: 'architect', turnLabel: 'plan', terminalEvent: 'result', data: { model: 'fable', cost: 0.5, usage: { input_tokens: 500, output_tokens: 200 } } })
+  ledger.updateSubtask(runId, 'st_a', { status: 'done' })
+  ledger.recordCommitteeReview(runId, 'st_a', { phase: 'result', verdict: 'approve', reviewerSessionId: 'arch', notes: 'lgtm' })
+  ledger.setStatus(runId, status)
+  return ledger.getRun(runId)
+}
+
+function extrasFor(record) {
+  const runId = record.runId
+  const openGate = makeGate({ gateId: nextGateId(runId), runId, kind: 'epic_plan', nodeId: null, summary: 'Approve the plan', detail: '2 subtasks', openedAt: 1000 })
+  const resolvedGate = resolveGate(
+    makeGate({ gateId: nextGateId(runId), runId, kind: 'escalation', nodeId: 'st_a', summary: 'conflict', openedAt: 900 }),
+    { decision: 'skip', resolvedAt: 950 },
+  )
+  return {
+    epicPrompt: 'Perform a full self-audit of this repository. '.repeat(20), // > 280 chars → preview truncates
+    gates: [openGate, resolvedGate],
+    timeline: [
+      { seq: 1, at: 1000, kind: 'gate_opened', gateId: openGate.gateId, summary: 'plan gate opened' },
+      { seq: 2, at: 1100, kind: 'committee_review', nodeId: 'st_a', verdict: 'approve', summary: 'result approved' },
+    ],
+    nodeExtras: { st_a: { branch: 'chroxy/orch/x/st_a', worktreePath: '/wt/st_a', planSummary: 'edit f', resultSummary: 'edited f', attempt: 1, committeeIterations: 2 } },
+    report: { json: '{"ok":true}', markdown: '# Report' },
+  }
+}
+
+// --- unit projections ------------------------------------------------------
+
+test('usageToWire produces a schema-valid RunUsage', () => {
+  const u = usageToWire({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheCreationTokens: 0, costUsd: 0.1, pricedCostUsd: 0, effectiveUsd: 0.1, unknownCostTurns: 0 })
+  assert.equal(RunUsageSchema.safeParse(u).success, true)
+  // missing/garbage input → schema-valid zeros, never throws
+  assert.equal(RunUsageSchema.safeParse(usageToWire(undefined)).success, true)
+  assert.equal(usageToWire({ inputTokens: NaN }).inputTokens, 0)
+})
+
+test('budgetToWire maps cap/spent/state', () => {
+  const capped = budgetToWire({ configSnapshot: { budget: { maxUsd: 5 } }, budgetState: { capReachedAt: 123 }, usageTotals: { overall: { effectiveUsd: 6 } } })
+  assert.deepEqual(capped, { capUsd: 5, spentUsd: 6, state: 'capped' })
+  const warned = budgetToWire({ configSnapshot: { budget: { maxUsd: 5 } }, budgetState: { warnedAt: 1 }, usageTotals: { overall: { effectiveUsd: 4 } } })
+  assert.equal(warned.state, 'warned')
+  const uncapped = budgetToWire({ configSnapshot: { budget: { maxUsd: null } }, budgetState: {}, usageTotals: { overall: { effectiveUsd: 1 } } })
+  assert.equal(uncapped.capUsd, null)
+  assert.equal(uncapped.state, 'ok')
+})
+
+test('gateToWire produces schema-valid RunGate for open + resolved gates', () => {
+  const runId = 'run_1'
+  const open = makeGate({ gateId: 'g1', runId, kind: 'epic_plan', nodeId: null, summary: 's', openedAt: 1 })
+  const resolved = resolveGate(makeGate({ gateId: 'g2', runId, kind: 'escalation', nodeId: 'st', summary: 's', openedAt: 1 }), { decision: 'approve', note: 'ok', resolvedAt: 2 })
+  assert.equal(RunGateSchema.safeParse(gateToWire(open)).success, true)
+  const w = gateToWire(resolved)
+  assert.equal(RunGateSchema.safeParse(w).success, true)
+  assert.equal(w.resolvedBy, 'user')
+  assert.equal(w.note, 'ok')
+})
+
+test('nodeToWire produces schema-valid RunNode, pulling branch/plan from extras', () => {
+  const st = { subtaskId: 'st_a', role: 'worker.implement', title: 'T', provider: 'codex', model: 'm', status: 'done', sessionId: 'sess', usage: {}, committee: [{}, {}], createdAt: 10, endedAt: 20 }
+  const node = nodeToWire(st, 'run_1', { branch: 'b', worktreePath: '/w', planSummary: 'p', resultSummary: 'r', attempt: 1, committeeIterations: 2 })
+  assert.equal(RunNodeSchema.safeParse(node).success, true)
+  assert.equal(node.branch, 'b')
+  assert.equal(node.committeeIterations, 2)
+  assert.equal(node.updatedAt, 20)
+  // no extras → nullable fields are null, still schema-valid
+  assert.equal(RunNodeSchema.safeParse(nodeToWire(st, 'run_1')).success, true)
+  assert.equal(nodeToWire(st, 'run_1').branch, null)
+})
+
+test('timelineEntryToWire is schema-valid', () => {
+  const e = timelineEntryToWire({ seq: 3, at: 100, kind: 'committee_review', nodeId: 'st', verdict: 'revise', summary: 's' })
+  assert.equal(e.verdict, 'revise')
+  assert.equal(e.nodeId, 'st')
+})
+
+// --- full record projections against the real schemas ----------------------
+
+test('recordToRunSummary satisfies RunSummarySchema', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    const summary = recordToRunSummary(record, extrasFor(record))
+    const parsed = RunSummarySchema.safeParse(summary)
+    assert.equal(parsed.success, true, parsed.success ? '' : JSON.stringify(parsed.error.issues))
+    assert.equal(summary.preset, 'repo-audit')
+    assert.equal(summary.cwd, '/repo')
+    assert.deepEqual(summary.architect, { provider: 'claude-sdk', model: 'fable' })
+    assert.equal(summary.nodeCounts.total, 1)
+    assert.equal(summary.nodeCounts.done, 1)
+    assert.equal(summary.pendingUserGates, 1, 'one open gate, one resolved')
+    assert.ok(summary.epicPromptPreview.length <= 280)
+    assert.ok(summary.usage.inputTokens > 0)
+  } finally {
+    cleanup()
+  }
+})
+
+test('recordToRunDetail satisfies RunDetailSchema with nodes/gates/timeline/rollup', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    const detail = recordToRunDetail(record, extrasFor(record))
+    const parsed = RunDetailSchema.safeParse(detail)
+    assert.equal(parsed.success, true, parsed.success ? '' : JSON.stringify(parsed.error.issues))
+    assert.equal(detail.nodes.length, 1)
+    assert.equal(detail.nodes[0].branch, 'chroxy/orch/x/st_a')
+    assert.equal(detail.gates.length, 2)
+    assert.equal(detail.timeline.length, 2)
+    // usageRollup carries per-role attribution
+    assert.ok(detail.usageRollup.byRole.architect, 'architect role in rollup')
+    assert.ok(detail.usageRollup.byRole['worker.implement'], 'worker role in rollup')
+    assert.equal(detail.verdictQuality ?? null, null)
+    assert.deepEqual(detail.report, { json: '{"ok":true}', markdown: '# Report' })
+  } finally {
+    cleanup()
+  }
+})
+
+test('a degraded/empty record still projects to a schema-valid summary + detail', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const rec = ledger.createRun({ title: '', preset: null, configSnapshot: null })
+    const record = ledger.getRun(rec.runId)
+    assert.equal(RunSummarySchema.safeParse(recordToRunSummary(record, {})).success, true)
+    assert.equal(RunDetailSchema.safeParse(recordToRunDetail(record, {})).success, true)
+  } finally {
+    cleanup()
+  }
+})

--- a/packages/server/tests/orchestration-to-wire.test.js
+++ b/packages/server/tests/orchestration-to-wire.test.js
@@ -217,6 +217,25 @@ test('null elements in manager arrays degrade gracefully (never throw, still sch
   }
 })
 
+test('a gate with an invalid kind is dropped; an out-of-enum verdict is omitted (never emitted invalid)', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    const good = makeGate({ gateId: 'g', runId: record.runId, kind: 'epic_plan', nodeId: null, summary: 's', openedAt: 1 })
+    const detail = recordToRunDetail(record, {
+      epicPrompt: 'x',
+      gates: [good, { gateId: 'bad', runId: record.runId, kind: 'not_a_kind', summary: 's', openedAt: 1, status: 'pending' }],
+      timeline: [{ seq: 1, at: 1, kind: 'k', summary: 's', verdict: 'bogus_verdict' }],
+    })
+    assert.equal(detail.gates.length, 1, 'malformed-kind gate dropped')
+    assert.equal(detail.gates[0].gateId, 'g')
+    assert.equal(detail.timeline[0].verdict, undefined, 'out-of-enum verdict omitted')
+    assert.equal(RunDetailSchema.safeParse(detail).success, true)
+  } finally {
+    cleanup()
+  }
+})
+
 test('a degraded/empty record still projects to a schema-valid summary + detail', () => {
   const { ledger, cleanup } = mkLedger()
   try {


### PR DESCRIPTION
## Summary

Step **E-4 part 1** of the orchestration epic (#6691): the pure projection layer that maps a durable `RunLedger` record + the manager's live engine extras into the `@chroxy/protocol` wire shapes. Split out so the wire contract is reviewable + testable in isolation — **nothing calls it yet**; the manager read-API wiring + the daemon delta broadcast are E-4 parts 2/3.

## `to-wire.js`

- `usageToWire` (cell → `RunUsage`), `budgetToWire` (record → `RunBudget`, ok/warned/capped), `gateToWire`, `timelineEntryToWire`, `nodeToWire`
- `recordToRunSummary` / `recordToRunDetail` — the full projections

The `extras` bag carries what the ledger record does **not** hold (the manager owns it live): `epicPrompt`, `gates[]`, `timeline[]`, `report`, and per-node `{branch, worktreePath, planSummary, resultSummary, attempt, committeeIterations}`.

**Defensive by design**: a missing/degraded field defaults to a schema-valid zero rather than throwing, so a snapshot request can never crash on a half-built run.

## Testing

Every projection is validated against the **real protocol schemas** via `safeParse` — `RunSummarySchema` / `RunDetailSchema` / `RunNodeSchema` / `RunGateSchema` / `RunUsageSchema` — from records driven through the **actual `RunLedger` write path** (8 cases incl. per-role usage rollup, open + resolved gates, node extras from the bag, and a degraded/empty record). The point: the server can never broadcast a shape the client reducer will reject.

`eslint src/` clean · custom lint passes · 8/8 tests green.

Part of #6700 (E-4).