### PR TITLE
feat(server): wire the manager read API to the projection layer (E-4 part 2)

### DIFF
--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -766,7 +766,11 @@ export class OrchestrationManager extends EventEmitter {
       const run = this._runs.get(row.runId)
       if (run) return recordToRunSummary(record, this._snapshotExtras(run))
       const cached = this._completedSnapshots.get(row.runId)
-      return cached ? cached.run : recordToRunSummary(record, { report: this._reportExtra(row.runId) })
+      // cached.summary (a lean RunSummary) — NOT cached.run (a fat RunDetail):
+      // the runs list must stay lightweight (RunSummarySchema is .passthrough(),
+      // so a RunDetail would silently balloon every terminal row with its
+      // nodes/timeline/rollup).
+      return cached ? cached.summary : recordToRunSummary(record, { report: this._reportExtra(row.runId) })
     }).filter(Boolean)
   }
 
@@ -812,14 +816,26 @@ export class OrchestrationManager extends EventEmitter {
     return md ? { json: '', markdown: md } : null
   }
 
-  // On terminal, freeze the final wire projection so the snapshot survives the
-  // run's engine state being deleted from _runs.
+  // On terminal, freeze BOTH the detail (for getRunSnapshot) and the summary
+  // (for the lightweight runs list) so the snapshot survives the run's engine
+  // state being deleted from _runs. Never throws: a projection failure must not
+  // skip the caller's _runs.delete (a leaked run wedges createRun's one-run-at-
+  // a-time guard for the process lifetime).
   _cacheCompletedSnapshot(run) {
-    const record = this._ledger.getRun(run.runId)
-    if (!record) return
-    this._completedSnapshots.set(run.runId, { seq: run.wireSeq, run: recordToRunDetail(record, this._snapshotExtras(run)) })
-    while (this._completedSnapshots.size > this._maxCompletedSnapshots) {
-      this._completedSnapshots.delete(this._completedSnapshots.keys().next().value)
+    try {
+      const record = this._ledger.getRun(run.runId)
+      if (!record) return
+      const extras = this._snapshotExtras(run)
+      this._completedSnapshots.set(run.runId, {
+        seq: run.wireSeq,
+        run: recordToRunDetail(record, extras),
+        summary: recordToRunSummary(record, extras),
+      })
+      while (this._completedSnapshots.size > this._maxCompletedSnapshots) {
+        this._completedSnapshots.delete(this._completedSnapshots.keys().next().value)
+      }
+    } catch (err) {
+      this._log?.warn?.(`orchestration: caching terminal snapshot failed for ${run.runId}: ${err?.message || err}`)
     }
   }
 

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -36,6 +36,7 @@ import {
   buildExecutePrompt, buildResultReviewPrompt, buildSynthesisPrompt,
 } from './role-prompts.js'
 import { createGitOps } from './git-ops.js'
+import { recordToRunSummary, recordToRunDetail } from './to-wire.js'
 
 const DEFAULTS = {
   maxParallelWorkers: 2,
@@ -94,6 +95,10 @@ export class OrchestrationManager extends EventEmitter {
     this._runs = new Map() // runId -> engine state
     this._reports = new Map() // runId -> reportMarkdown (in-memory until M-4 persists report.md)
     this._maxReports = 32
+    // Final wire-projected snapshots for terminal runs (their engine state is
+    // deleted from _runs, so gates/timeline would otherwise be gone). Bounded.
+    this._completedSnapshots = new Map() // runId -> { seq, run: RunDetail }
+    this._maxCompletedSnapshots = 32
     this._maxSessions = Number.isFinite(config.maxSessions) ? config.maxSessions : 5
 
     // Owned-session registry drives the permission gate (answers ONLY our sessions).
@@ -152,6 +157,9 @@ export class OrchestrationManager extends EventEmitter {
       results: [], // accepted { title, summary }
       integration: null, // { worktreePath, branch, merged: [] } — lazily created on first accepted implement subtask
       mergeChain: Promise.resolve(), // per-run mutex serializing integration-worktree ops (create/merge/abort)
+      timeline: [], // [RunTimelineEntry] activity feed (gate opens/resolves + committee reviews)
+      timelineSeq: 0, // monotonic per-run seq for timeline entries
+      wireSeq: 0, // per-run wire delta seq (bumped on successful broadcast in E-4 part 3)
       phase: 'created',
       cancelled: false,
     })
@@ -237,6 +245,7 @@ export class OrchestrationManager extends EventEmitter {
     }
     const resolved = resolveGateModel(gate, { decision, note, budgetUsd, resolvedAt: this._now() })
     run.gates.set(gateId, resolved)
+    this._appendTimeline(run, { kind: 'gate_resolved', gateId, nodeId: gate.nodeId ?? null, summary: `${gate.kind} gate ${decision}`, detail: note })
     this.emit('gate_resolved', { runId, gate: resolved })
 
     if (gate.kind === 'epic_plan') {
@@ -307,6 +316,7 @@ export class OrchestrationManager extends EventEmitter {
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'poa_review' })
       const poaReview = await this._architectReview(run, buildPoaReviewPrompt({ subtask: st.spec, poa }), 'poa_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'plan', verdict: poaReview.verdict, reviewerSessionId: run.architectSessionId, notes: poaReview.feedback ?? '' })
+      this._appendTimeline(run, { kind: 'committee_review', nodeId: subtaskId, verdict: poaReview.verdict, summary: `plan-of-attack ${poaReview.verdict}`, detail: poaReview.feedback ?? null })
       if (poaReview.verdict === 'escalate') return this._escalateSubtask(run, subtaskId, poaReview.feedback || 'architect escalated the plan')
       if (poaReview.verdict === 'revise' || poaReview.verdict === 'redelegate') {
         st.iterations += 1
@@ -325,6 +335,7 @@ export class OrchestrationManager extends EventEmitter {
       this._ledger.updateSubtask(run.runId, subtaskId, { status: 'result_review' })
       const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result, diff }), 'result_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'result', verdict: resultReview.verdict, reviewerSessionId: run.architectSessionId, notes: resultReview.feedback ?? '' })
+      this._appendTimeline(run, { kind: 'committee_review', nodeId: subtaskId, verdict: resultReview.verdict, summary: `result ${resultReview.verdict}`, detail: resultReview.feedback ?? null })
       if (resultReview.verdict === 'approve') {
         if (st.spec.role === 'implement') return await this._acceptImplement(run, subtaskId, sessionId, result)
         run.results.push({ title: st.spec.title, summary: result.summary })
@@ -436,6 +447,7 @@ export class OrchestrationManager extends EventEmitter {
     run.phase = 'completed'
     this._ledger.setStatus(run.runId, 'completed')
     this.emit('run_completed', { runId: run.runId, reportMarkdown: decision.reportMarkdown, integrationBranch })
+    this._cacheCompletedSnapshot(run)
     this._runs.delete(run.runId)
     return { runId: run.runId, phase: 'completed', reportMarkdown: decision.reportMarkdown, integrationBranch }
   }
@@ -634,7 +646,15 @@ export class OrchestrationManager extends EventEmitter {
   _openGate(run, { kind, nodeId = null, summary, detail = null, budgetUsd = null }) {
     const gate = makeGate({ gateId: nextGateId(run.runId), runId: run.runId, kind, nodeId, summary, detail, budgetUsd, openedAt: this._now() })
     run.gates.set(gate.gateId, gate)
+    this._appendTimeline(run, { kind: 'gate_opened', gateId: gate.gateId, nodeId, summary })
     return gate
+  }
+
+  // Append a bounded activity-feed entry (projected to RunTimelineEntry by to-wire).
+  _appendTimeline(run, { kind, summary, nodeId = null, gateId = null, verdict = null, detail = null }) {
+    run.timelineSeq += 1
+    run.timeline.push({ seq: run.timelineSeq, at: this._now(), kind, summary, nodeId, gateId, verdict, detail })
+    if (run.timeline.length > 500) run.timeline.splice(0, run.timeline.length - 500)
   }
 
   _pauseForBudget(run) {
@@ -660,6 +680,7 @@ export class OrchestrationManager extends EventEmitter {
     for (const sid of [...run.ownedSessions.keys()]) await this._destroySession(run, sid)
     await this._cleanupIntegration(run)
     this.emit('run_failed', { runId: run.runId, code, message: err?.message || String(err) })
+    this._cacheCompletedSnapshot(run)
     this._runs.delete(run.runId)
     return { runId: run.runId, phase: 'failed', code }
   }
@@ -677,6 +698,7 @@ export class OrchestrationManager extends EventEmitter {
     await this._cleanupIntegration(run)
     this._ledger.setStatus(runId, 'cancelled', reason)
     this.emit('run_cancelled', { runId, reason })
+    this._cacheCompletedSnapshot(run)
     this._runs.delete(runId)
     return { runId, phase: 'cancelled' }
   }
@@ -730,17 +752,75 @@ export class OrchestrationManager extends EventEmitter {
     return size + 1 <= this._maxSessions - this._cfg.reserveSessions
   }
 
-  // --- read API (consumed by the S-2 handlers; wire projection is E-4) -----
+  // --- read API (consumed by the S-2 handlers) — wire-projected via to-wire ---
 
+  // RunSummary[] for the runs list. Active runs use their live engine extras (so
+  // pendingUserGates is accurate); a terminal run whose engine state is gone
+  // uses its cached final snapshot, else projects from the record alone.
   listRuns() {
-    return this._ledger.listRuns()
+    // The ledger index gives ordering (newest first) + the run ids; project each
+    // from its full record so the summary is complete.
+    return this._ledger.listRuns().map((row) => {
+      const record = this._ledger.getRun(row.runId)
+      if (!record) return null
+      const run = this._runs.get(row.runId)
+      if (run) return recordToRunSummary(record, this._snapshotExtras(run))
+      const cached = this._completedSnapshots.get(row.runId)
+      return cached ? cached.run : recordToRunSummary(record, { report: this._reportExtra(row.runId) })
+    }).filter(Boolean)
   }
+
+  // { seq, run: RunDetail } for one run.
   getRunSnapshot(runId) {
+    const run = this._runs.get(runId)
+    if (run) {
+      const record = this._ledger.getRun(runId)
+      if (!record) return null
+      return { seq: run.wireSeq, run: recordToRunDetail(record, this._snapshotExtras(run)) }
+    }
+    const cached = this._completedSnapshots.get(runId)
+    if (cached) return cached
     const record = this._ledger.getRun(runId)
     if (!record) return null
-    // E-4 projects this into the wire RunDetail; for now hand back the record
-    // plus the in-memory report (M-4 will persist + project it).
-    return { seq: 0, run: record, reportMarkdown: this._reports.get(runId) ?? null }
+    return { seq: 0, run: recordToRunDetail(record, { report: this._reportExtra(runId) }) }
+  }
+
+  // Assemble the projection `extras` bag from a run's live engine state.
+  _snapshotExtras(run) {
+    const nodeExtras = {}
+    for (const [subtaskId, st] of run.subtasks) {
+      nodeExtras[subtaskId] = {
+        branch: st.branch ?? null,
+        worktreePath: st.worktreePath ?? null,
+        planSummary: st.poa?.plan ?? null,
+        resultSummary: st.result?.summary ?? null,
+        attempt: st.iterations ?? 0,
+        committeeIterations: st.iterations ?? 0,
+      }
+    }
+    return {
+      epicPrompt: run.goal ?? '',
+      gates: [...run.gates.values()],
+      timeline: run.timeline,
+      nodeExtras,
+      report: this._reportExtra(run.runId),
+    }
+  }
+
+  _reportExtra(runId) {
+    const md = this._reports.get(runId)
+    return md ? { json: '', markdown: md } : null
+  }
+
+  // On terminal, freeze the final wire projection so the snapshot survives the
+  // run's engine state being deleted from _runs.
+  _cacheCompletedSnapshot(run) {
+    const record = this._ledger.getRun(run.runId)
+    if (!record) return
+    this._completedSnapshots.set(run.runId, { seq: run.wireSeq, run: recordToRunDetail(record, this._snapshotExtras(run)) })
+    while (this._completedSnapshots.size > this._maxCompletedSnapshots) {
+      this._completedSnapshots.delete(this._completedSnapshots.keys().next().value)
+    }
   }
 
   _rememberReport(runId, markdown) {

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { EventEmitter } from 'node:events'
 
+import { RunSummarySchema, RunDetailSchema } from '@chroxy/protocol'
 import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
 import { TurnDriver } from '../src/orchestration/turn-driver.js'
@@ -156,6 +157,39 @@ function implementDecider(planRole = 'implement') {
 }
 
 // --- tests -----------------------------------------------------------------
+
+test('read API (getRunSnapshot/listRuns) returns schema-valid wire shapes, live and terminal', async () => {
+  const { mgr, cleanup } = harness(implementDecider())
+  try {
+    const rec = mgr.createRun({ goal: 'Implement it well', cwd: '/repo', autoApprovePlan: false })
+    // gate open → the run is live in _runs; project a live RunDetail
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    const live = mgr.getRunSnapshot(rec.runId)
+    assert.equal(RunDetailSchema.safeParse(live.run).success, true, 'live RunDetail is schema-valid')
+    assert.ok(live.run.gates.length >= 1, 'the epic_plan gate is in the snapshot')
+    assert.ok(live.run.timeline.some((t) => t.kind === 'gate_opened'), 'timeline has the gate_opened entry')
+    assert.equal(live.run.pendingUserGates, 1)
+    // listRuns projects RunSummary[]
+    const list = mgr.listRuns()
+    assert.equal(list.length, 1)
+    assert.equal(RunSummarySchema.safeParse(list[0]).success, true, 'RunSummary is schema-valid')
+
+    // run to completion → snapshot survives from the terminal cache
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'approve' })
+    await done
+    const terminal = mgr.getRunSnapshot(rec.runId)
+    assert.equal(RunDetailSchema.safeParse(terminal.run).success, true, 'terminal RunDetail is schema-valid (from cache)')
+    assert.equal(terminal.run.status, 'completed')
+    assert.ok(terminal.run.timeline.some((t) => t.kind === 'gate_resolved'), 'timeline has the gate_resolved entry')
+    assert.ok(terminal.run.timeline.some((t) => t.kind === 'committee_review'), 'timeline has committee reviews')
+    assert.equal(RunSummarySchema.safeParse(mgr.listRuns()[0]).success, true)
+  } finally {
+    cleanup()
+  }
+})
 
 test('full implement run: branch → commit → diff review → merge → done → completed', async () => {
   const { sm, ledger, gitOps, mgr, cleanup } = harness(implementDecider())

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -185,7 +185,40 @@ test('read API (getRunSnapshot/listRuns) returns schema-valid wire shapes, live 
     assert.equal(terminal.run.status, 'completed')
     assert.ok(terminal.run.timeline.some((t) => t.kind === 'gate_resolved'), 'timeline has the gate_resolved entry')
     assert.ok(terminal.run.timeline.some((t) => t.kind === 'committee_review'), 'timeline has committee reviews')
+    // the terminal LIST row must be a lean RunSummary, NOT a fat RunDetail
+    const listRow = mgr.listRuns()[0]
+    assert.equal(RunSummarySchema.safeParse(listRow).success, true)
+    assert.equal(listRow.timeline, undefined, 'list row is summary-shaped (no detail timeline)')
+    assert.equal(listRow.nodes, undefined, 'list row is summary-shaped (no detail nodes)')
+    assert.equal(listRow.usageRollup, undefined, 'list row is summary-shaped (no detail rollup)')
+    // an unknown run → null snapshot, and absent from the list
+    assert.equal(mgr.getRunSnapshot('nope'), null)
+    assert.ok(!mgr.listRuns().some((r) => r.runId === 'nope'))
+  } finally {
+    cleanup()
+  }
+})
+
+test('a cancelled run is cached and served from the terminal snapshot', async () => {
+  // hang at the plan gate so the run is live, then cancel it.
+  const decide = ({ role, kind, n }) => {
+    if (role === 'architect' && kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'implement' }] }
+    if (role === 'architect' && kind === 'poa_review') return null // hang
+    return implementDecider()({ role, kind, n })
+  }
+  const { mgr, cleanup } = harness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const startP = mgr.startRun(rec.runId)
+    await new Promise((r) => setTimeout(r, 20))
+    await mgr.cancelRun(rec.runId)
+    await startP
+    const snap = mgr.getRunSnapshot(rec.runId)
+    assert.ok(snap, 'cancelled run still served from cache')
+    assert.equal(RunDetailSchema.safeParse(snap.run).success, true)
+    assert.equal(snap.run.status, 'cancelled')
     assert.equal(RunSummarySchema.safeParse(mgr.listRuns()[0]).success, true)
+    assert.equal(mgr.listRuns()[0].timeline, undefined, 'cancelled list row is summary-shaped')
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary

Step **E-4 part 2**: the engine's read API now returns wire shapes (via the `to-wire` projection merged in part 1, #6737) instead of raw ledger records — so the S-2 handlers can serve `orchestration_runs_snapshot` / `orchestration_run_snapshot` directly.

## What's here

- `listRuns()` → **`RunSummary[]`** (projected per-run via `recordToRunSummary`)
- `getRunSnapshot(runId)` → **`{ seq, run: RunDetail }`** via `recordToRunDetail`
- **Per-run activity timeline**: gate opens/resolves + committee reviews are appended (bounded to 500) and projected into `RunDetail.timeline`
- `_snapshotExtras` assembles the projection bag from live engine state (gates, timeline, epicPrompt, per-node branch/worktree/plan/result, report)
- **Terminal snapshot cache**: a terminal run is deleted from `_runs`, so its final wire projection is frozen into a bounded `_completedSnapshots` cache on complete/fail/cancel — `getRunSnapshot`/`listRuns` fall back to it (else project from the record alone)
- `wireSeq` counter added to run state (bumped on broadcast in part 3)

## Testing

New end-to-end test drives a run and asserts the read API returns **schema-valid** `RunDetail` **live AND terminal-from-cache** + schema-valid `RunSummary[]`, with the timeline carrying `gate_opened` / `gate_resolved` / `committee_review` entries.

41 orchestration tests pass (manager + implement + to-wire) — **no regression** to the committee loop · `eslint src/` clean · custom lints pass.

Part of #6700 (E-4). Part 3 (daemon wire-up: server-cli instantiation + ws-server delta broadcast + session badges) makes the engine reachable end-to-end.