### PR TITLE
fix(ci): make repo-relay notify best-effort + skip when unconfigured

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -30,10 +30,21 @@ jobs:
       github.actor != 'github-actions[bot]' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
+    # The secrets context isn't readable in a job-level `if`, so surface
+    # "are the Discord secrets configured?" through env and gate each step
+    # on it — an unconfigured repo (or fork) skips cleanly instead of
+    # failing every PR with a red notify check
+    env:
+      DISCORD_CONFIGURED: ${{ secrets.DISCORD_BOT_TOKEN != '' && secrets.DISCORD_CHANNEL_PRS != '' }}
     steps:
+      - name: Note missing Discord configuration
+        if: env.DISCORD_CONFIGURED != 'true'
+        run: echo "::notice::DISCORD_BOT_TOKEN / DISCORD_CHANNEL_PRS repo secrets are not set — skipping Discord notification."
+
       # Persist SQLite state between runs. Per-run key: cache entries are
       # immutable, so a constant key would freeze state at the first run.
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        if: env.DISCORD_CONFIGURED == 'true'
         with:
           path: ~/.repo-relay
           key: repo-relay-state-${{ github.repository }}-${{ github.run_id }}
@@ -41,6 +52,7 @@ jobs:
             repo-relay-state-${{ github.repository }}-
 
       - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0
+        if: env.DISCORD_CONFIGURED == 'true'
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}

--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -51,8 +51,12 @@ jobs:
           restore-keys: |
             repo-relay-state-${{ github.repository }}-
 
+      # Best-effort delivery: a failed notification (Discord outage, rate
+      # limit, session budget) must not red-X the PR — the step's own failure
+      # annotation stays visible in the run for debugging
       - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0
         if: env.DISCORD_CONFIGURED == 'true'
+        continue-on-error: true
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}


### PR DESCRIPTION
## Summary

The `notify` job (`blamechris/repo-relay`) has been failing on every PR tonight, leaving a persistent red X (non-required check → PRs merge `UNSTABLE`; #6737 and #6738 both merged that way).

## Root cause (corrected during investigation)

The initial diagnosis — missing `DISCORD_BOT_TOKEN` / `DISCORD_CHANNEL_PRS` secrets — was **wrong**. Both secrets are set and pass the action's input validation (`Inputs validated successfully` in every run log); the `discord_bot_token is required` strings in the logs are just the echoed source of the validation script, not triggered errors.

The actual failure is `[repo-relay] ERROR: Internal Server Error` during Discord login. Repo Relay was green all day on 2026-07-16 and started failing at 01:35Z on 2026-07-17 — matching Discord's **active status-page incident** ("API Errors", investigating since 17:49 PDT, still unresolved). It will recover on its own; the durable problem is that any Discord hiccup red-Xes PRs.

## Fix (two layers, both in `.github/workflows/repo-relay.yml`)

1. **Best-effort delivery** — `continue-on-error: true` on the relay step. A failed notification (Discord outage, rate limit, session budget) keeps its failure annotation inside the run but no longer fails the check, so PRs stop showing UNSTABLE.
2. **Skip when unconfigured** — the `secrets` context isn't readable in a job-level `if`, so a `DISCORD_CONFIGURED` boolean is exposed via job `env` and gates the cache + relay steps. Unconfigured clones/forks skip with a `::notice::` instead of erroring. (Not the cause here, but correct hardening.)

Related to #6691 (surfaced during the orchestration epic).

## Verification

- `actionlint` clean.
- This PR's own `pull_request` event runs the modified workflow, **during the ongoing Discord incident** — the notify check going green while delivery still fails is a live demonstration of the fix.