### PR TITLE
feat(server): emit orchestration run deltas on lifecycle transitions (E-4 part 3a)

### DIFF
--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -36,7 +36,7 @@ import {
   buildExecutePrompt, buildResultReviewPrompt, buildSynthesisPrompt,
 } from './role-prompts.js'
 import { createGitOps } from './git-ops.js'
-import { recordToRunSummary, recordToRunDetail } from './to-wire.js'
+import { recordToRunSummary, recordToRunDetail, gateToWire } from './to-wire.js'
 
 const DEFAULTS = {
   maxParallelWorkers: 2,
@@ -216,6 +216,7 @@ export class OrchestrationManager extends EventEmitter {
     run.phase = 'plan_review'
     this._ledger.setStatus(runId, 'plan_review')
     this.emit('gate_opened', { runId, gate })
+    this._emitRunDelta(run, { gate })
     return { runId, phase: 'plan_review', gateId: gate.gateId }
   }
 
@@ -247,6 +248,7 @@ export class OrchestrationManager extends EventEmitter {
     run.gates.set(gateId, resolved)
     this._appendTimeline(run, { kind: 'gate_resolved', gateId, nodeId: gate.nodeId ?? null, summary: `${gate.kind} gate ${decision}`, detail: note })
     this.emit('gate_resolved', { runId, gate: resolved })
+    this._emitRunDelta(run, { gate: resolved })
 
     if (gate.kind === 'epic_plan') {
       if (decision === 'approve') return this._beginExecuting(run)
@@ -417,6 +419,7 @@ export class OrchestrationManager extends EventEmitter {
     await this._releaseSubtaskSessions(run, subtaskId)
     const gate = this._openGate(run, { kind: 'escalation', nodeId: subtaskId, summary: `Subtask "${st?.spec?.title ?? subtaskId}" escalated`, detail: reason })
     this.emit('gate_opened', { runId: run.runId, gate })
+    this._emitRunDelta(run, { gate })
     this._schedule(run)
     return { runId: run.runId, subtaskId, escalated: true, gateId: gate.gateId }
   }
@@ -447,6 +450,7 @@ export class OrchestrationManager extends EventEmitter {
     run.phase = 'completed'
     this._ledger.setStatus(run.runId, 'completed')
     this.emit('run_completed', { runId: run.runId, reportMarkdown: decision.reportMarkdown, integrationBranch })
+    this._emitRunDelta(run)
     this._cacheCompletedSnapshot(run)
     this._runs.delete(run.runId)
     return { runId: run.runId, phase: 'completed', reportMarkdown: decision.reportMarkdown, integrationBranch }
@@ -657,10 +661,31 @@ export class OrchestrationManager extends EventEmitter {
     if (run.timeline.length > 500) run.timeline.splice(0, run.timeline.length - 500)
   }
 
+  // Build + emit a wire `orchestration_run_delta` for host-level clients (the
+  // daemon forwards it to WsServer._broadcastOrchestrationDelta). Carries the
+  // updated run header (RunSummary) + the changed gate. `wireSeq` is bumped per
+  // emit; a gap self-heals via the client re-requesting the full snapshot (the
+  // reducer applies a delta only when seq === held + 1). No-op for a gone run.
+  _emitRunDelta(run, { gate = null } = {}) {
+    const record = this._ledger.getRun(run.runId)
+    if (!record) return
+    run.wireSeq += 1
+    const delta = {
+      type: 'orchestration_run_delta',
+      runId: run.runId,
+      seq: run.wireSeq,
+      generatedAt: new Date(this._now()).toISOString(),
+      run: recordToRunSummary(record, this._snapshotExtras(run)),
+    }
+    if (gate) delta.gate = gateToWire(gate)
+    this.emit('run_delta', delta)
+  }
+
   _pauseForBudget(run) {
     run.phase = 'budget_paused'
     this._ledger.setStatus(run.runId, 'budget_paused')
     this.emit('run_budget_paused', { runId: run.runId })
+    this._emitRunDelta(run)
   }
 
   _onPermissionEscalation(info) {
@@ -680,6 +705,7 @@ export class OrchestrationManager extends EventEmitter {
     for (const sid of [...run.ownedSessions.keys()]) await this._destroySession(run, sid)
     await this._cleanupIntegration(run)
     this.emit('run_failed', { runId: run.runId, code, message: err?.message || String(err) })
+    this._emitRunDelta(run)
     this._cacheCompletedSnapshot(run)
     this._runs.delete(run.runId)
     return { runId: run.runId, phase: 'failed', code }
@@ -698,6 +724,7 @@ export class OrchestrationManager extends EventEmitter {
     await this._cleanupIntegration(run)
     this._ledger.setStatus(runId, 'cancelled', reason)
     this.emit('run_cancelled', { runId, reason })
+    this._emitRunDelta(run)
     this._cacheCompletedSnapshot(run)
     this._runs.delete(runId)
     return { runId, phase: 'cancelled' }

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -11,7 +11,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { EventEmitter } from 'node:events'
 
-import { RunSummarySchema, RunDetailSchema } from '@chroxy/protocol'
+import { RunSummarySchema, RunDetailSchema, ServerOrchestrationRunDeltaSchema } from '@chroxy/protocol'
 import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
 import { TurnDriver } from '../src/orchestration/turn-driver.js'
@@ -194,6 +194,40 @@ test('read API (getRunSnapshot/listRuns) returns schema-valid wire shapes, live 
     // an unknown run → null snapshot, and absent from the list
     assert.equal(mgr.getRunSnapshot('nope'), null)
     assert.ok(!mgr.listRuns().some((r) => r.runId === 'nope'))
+  } finally {
+    cleanup()
+  }
+})
+
+test('emits schema-valid run_delta events with monotonic seq across the run lifecycle', async () => {
+  const { mgr, cleanup } = harness(implementDecider())
+  try {
+    const deltas = []
+    mgr.on('run_delta', (d) => deltas.push(d))
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    // gate_opened produced a delta carrying the gate
+    assert.ok(deltas.length >= 1)
+    const g = deltas[deltas.length - 1]
+    assert.equal(ServerOrchestrationRunDeltaSchema.safeParse(g).success, true, 'gate delta is schema-valid')
+    assert.equal(g.runId, rec.runId)
+    assert.ok(g.gate, 'gate delta carries the gate')
+    assert.equal(g.run.status, 'plan_review')
+
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'approve' })
+    await done
+    // every delta is schema-valid and seq is strictly monotonic
+    let prev = 0
+    for (const d of deltas) {
+      assert.equal(ServerOrchestrationRunDeltaSchema.safeParse(d).success, true)
+      assert.ok(d.seq > prev, `seq strictly increasing (${d.seq} > ${prev})`)
+      prev = d.seq
+    }
+    // a terminal delta reflects the completed status
+    assert.equal(deltas[deltas.length - 1].run.status, 'completed')
   } finally {
     cleanup()
   }


### PR DESCRIPTION
## Summary

Step **E-4 part 3a**: the engine now emits a wire-shaped `orchestration_run_delta` on each run lifecycle transition, so host-level dashboard clients get live updates. The daemon will forward these to `WsServer._broadcastOrchestrationDelta` in **part 3c** (the boot glue); this PR is the pure engine-side contract, testable in isolation.

## What's here

- `_emitRunDelta(run, { gate })` projects the current record → `RunSummary` (via `to-wire`), attaches the changed gate, bumps the per-run `wireSeq`, and emits a `run_delta` event.
- Wired at all 7 lifecycle emit sites: `gate_opened` (×2), `gate_resolved`, `run_budget_paused`, `run_completed`, `run_failed`, `run_cancelled` — firing **before** `_runs.delete` on terminal paths so the terminal delta reflects the final status.
- `wireSeq` bumps per emit; a gap self-heals via the client re-requesting the full snapshot (the reducer applies a delta only when `seq === held + 1`), so bump-on-emit is safe even with no client connected.

Node/timeline-granular deltas are a follow-up; v1 pushes the run header + gate (the load-bearing live signals), and the client fetches full `RunDetail` on demand via `getRunSnapshot`.

## Testing

A full run's `run_delta` stream is all schema-valid (`ServerOrchestrationRunDeltaSchema`) with **strictly monotonic seq**; the gate delta carries the gate; the terminal delta reflects `completed`. 30 orchestration-manager tests pass · `eslint src/` clean · custom lints pass.

Part of #6700 (E-4). Remaining: **3b** session badges (SessionManager metadata → `ServerSessionListEntry`), **3c** daemon glue (server-cli instantiation + ws-server forward), then a running-daemon smoke test.