### PR TITLE
feat(server): daemon integration — session badges + boot wire-up (E-4 parts 3b+3c)

### DIFF
--- a/packages/server/src/orchestration/build-manager.js
+++ b/packages/server/src/orchestration/build-manager.js
@@ -1,0 +1,38 @@
+/**
+ * Boot-time factory for the OrchestrationManager (epic #6691, E-4). Isolated so
+ * the daemon-boot wiring in server-cli.js is testable: it returns a fully-wired
+ * manager when the feature is on, null when it's off, and — critically — null
+ * (never a throw) when construction fails, so the orchestration feature can
+ * NEVER break daemon boot.
+ */
+
+import { join } from 'node:path'
+import { isOrchestrationEnabled } from '../config.js'
+import { validateCwdAllowed } from '../handler-utils.js'
+import { OrchestrationManager } from './orchestration-manager.js'
+import { RunLedger } from './run-ledger.js'
+import { TurnDriver } from './turn-driver.js'
+import { createGitOps } from './git-ops.js'
+import { OrchestrationPermissionGate } from './permission-gate.js'
+
+export function buildOrchestrationManager({ sessionManager, config, chroxyDir, log = null } = {}) {
+  if (!isOrchestrationEnabled(config)) return null
+  try {
+    const manager = new OrchestrationManager({
+      sessionManager,
+      ledger: new RunLedger({ baseDir: join(chroxyDir, 'orchestration') }),
+      turnDriver: new TurnDriver({ sessionManager, log }),
+      gitOps: createGitOps(),
+      config,
+      roles: config?.orchestration?.roles || null,
+      validateCwd: (cwd) => validateCwdAllowed(cwd, config),
+      permissionGateFactory: (opts) => new OrchestrationPermissionGate(opts),
+      log,
+    })
+    log?.info?.('Orchestration engine enabled (features.orchestration)')
+    return manager
+  } catch (err) {
+    log?.warn?.(`Orchestration engine failed to initialize — feature disabled for this boot: ${err?.message || err}`)
+    return null
+  }
+}

--- a/packages/server/src/orchestration/build-manager.js
+++ b/packages/server/src/orchestration/build-manager.js
@@ -18,10 +18,20 @@ import { OrchestrationPermissionGate } from './permission-gate.js'
 export function buildOrchestrationManager({ sessionManager, config, chroxyDir, log = null } = {}) {
   if (!isOrchestrationEnabled(config)) return null
   try {
+    const ledger = new RunLedger({ baseDir: join(chroxyDir, 'orchestration') })
+    // Load prior runs from disk BEFORE anything writes: without this, the first
+    // post-restart createRun would rewrite runs-index.json from the empty
+    // in-memory map, clobbering the durable index. Pure load + journal replay —
+    // no run is auto-resumed (in-flight runs stay at their last persisted
+    // status; full restart-reconcile — suspend/interrupted marking, orphan
+    // worktree sweep — is tracked in #6743).
+    const recovered = ledger.recoverRuns()
+    if (recovered.length) log?.info?.(`Orchestration: recovered ${recovered.length} run record(s) from disk`)
+    const turnDriver = new TurnDriver({ sessionManager, log })
     const manager = new OrchestrationManager({
       sessionManager,
-      ledger: new RunLedger({ baseDir: join(chroxyDir, 'orchestration') }),
-      turnDriver: new TurnDriver({ sessionManager, log }),
+      ledger,
+      turnDriver,
       gitOps: createGitOps(),
       config,
       roles: config?.orchestration?.roles || null,
@@ -29,6 +39,14 @@ export function buildOrchestrationManager({ sessionManager, config, chroxyDir, l
       permissionGateFactory: (opts) => new OrchestrationPermissionGate(opts),
       log,
     })
+    // The factory owns construction, so it owns teardown: extend dispose() to
+    // also stop the turn driver (SessionManager listeners) and flush the ledger.
+    const managerDispose = manager.dispose.bind(manager)
+    manager.dispose = () => {
+      managerDispose()
+      try { turnDriver.dispose() } catch { /* idempotent best-effort */ }
+      try { ledger.dispose() } catch { /* flushes pending snapshot writes */ }
+    }
     log?.info?.('Orchestration engine enabled (features.orchestration)')
     return manager
   } catch (err) {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1230,6 +1230,7 @@ export async function startCliServer(config) {
     pairingManager,
     pushManager,
     billingCanaryMonitor,
+    orchestrationManager,
     modelsOverlayWatcher,
     getWorktreeReapTimer: () => worktreeReapTimer,
     emergencyCleanupSync,

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -48,6 +48,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
 import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders } from './config.js'
+import { buildOrchestrationManager } from './orchestration/build-manager.js'
 import { parseDuration } from './duration.js'
 import { createSessionTokenStore } from './session-token-store.js'
 
@@ -934,10 +935,15 @@ export async function startCliServer(config) {
     sessionTokenStore: createSessionTokenStore({ dir: chroxyDir }),
   })
 
+  // #6691 (E-4): the orchestration engine (null when the feature is off or if
+  // construction fails — never a throw, so it can't break daemon boot).
+  const orchestrationManager = buildOrchestrationManager({ sessionManager, config, chroxyDir, log })
+
   wsServer = new WsServer({
     port: PORT,
     apiToken: API_TOKEN,
     sessionManager,
+    orchestrationManager,
     defaultSessionId,
     authRequired: !NO_AUTH,
     pushManager,
@@ -962,6 +968,15 @@ export async function startCliServer(config) {
   // Resolve the bind address. --no-auth forces loopback; otherwise an explicit
   // config.host (e.g. --host 127.0.0.1) binds that interface with auth still
   // on, and the default (undefined) binds 0.0.0.0 as before.
+  // #6691 (E-4): forward engine run deltas to host-level (unbound) dashboard
+  // clients. The manager already projects each delta to the wire shape; the
+  // WsServer only routes it. Guarded so a broadcast error never bubbles.
+  if (orchestrationManager) {
+    orchestrationManager.on('run_delta', (delta) => {
+      try { wsServer._broadcastOrchestrationDelta(delta) } catch (err) { log.warn(`orchestration delta broadcast failed: ${err?.message || err}`) }
+    })
+  }
+
   const bindHost = resolveBindHost({ noAuth: NO_AUTH, host: config.host })
   // #5356 (visibility layer): one warning when binding non-loopback (the
   // default 0.0.0.0 included) — LAN peers can reach the unauthenticated

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -33,6 +33,7 @@ export class ServerOrchestrator {
     pairingManager,
     pushManager = null,
     billingCanaryMonitor = null,
+    orchestrationManager = null,
     modelsOverlayWatcher = null,
     getWorktreeReapTimer,
     emergencyCleanupSync,
@@ -52,6 +53,10 @@ export class ServerOrchestrator {
     this._pairingManager = pairingManager
     this._pushManager = pushManager
     this._billingCanaryMonitor = billingCanaryMonitor
+    // #6691 (E-4): the orchestration engine (null when the feature is off).
+    // Disposed on shutdown: unhooks its SessionManager listeners (permission
+    // gate + turn driver) and flushes the run ledger's pending snapshot writes.
+    this._orchestrationManager = orchestrationManager
     // #5932: the models.json overlay fs-watcher handle (or null when watching
     // couldn't be established). Closed on shutdown so the watch doesn't outlive
     // the daemon.
@@ -108,6 +113,14 @@ export class ServerOrchestrator {
     // wouldn't block exit, but clearing it avoids a recompute racing shutdown.
     if (this._billingCanaryMonitor) {
       try { this._billingCanaryMonitor.stop() } catch {}
+    }
+    // #6691 (E-4): tear down the orchestration engine BEFORE destroying the
+    // sessions it may own — dispose unhooks its listeners and flushes the run
+    // ledger, so the subsequent destroyAll can't race a debounced snapshot write.
+    if (this._orchestrationManager) {
+      try { this._orchestrationManager.dispose() } catch (err) {
+        log.warn(`Orchestration engine dispose failed: ${err?.message || err}`)
+      }
     }
     // Persist sessions before destroying (enables restore on restart)
     try { this._sessionManager.serializeState() } catch (err) {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1108,6 +1108,12 @@ export class SessionManager extends EventEmitter {
    *   handler preserves the restored history + worktree (registers a failed-restore)
    *   instead of fully destroying the session. Fresh sessions omit it and take the
    *   full-destroy path on start failure.
+   * @param {object|null} [options.metadata] - #6691 (E-4): opaque per-session annotations
+   *   set by an in-process caller (the orchestration engine tags its sessions with
+   *   `{ orchestrationRunId, orchestrationRole }`, surfaced as optional session-list badge
+   *   fields). NOT settable over the wire (the create_session handler whitelists its
+   *   fields), and NOT persisted — in-memory only in v1; restart-reconcile re-establishes
+   *   it (#6743).
    * @returns {string} sessionId
    */
   createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, codexSandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, metadata = null, skipPersist = false, preserveId, isRestore = false } = {}) {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1110,7 +1110,7 @@ export class SessionManager extends EventEmitter {
    *   full-destroy path on start failure.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, codexSandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, skipPersist = false, preserveId, isRestore = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, codexSandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, metadata = null, skipPersist = false, preserveId, isRestore = false } = {}) {
     // #6036 — front-half SRP extraction: preflight + isolation + provider/preset
     // resolution (incl. the limit guard, cwd check, id/name, #2962 preflight,
     // #5985 user-shell gate, #3403 model fallback, worktree create/restore, and
@@ -1312,6 +1312,11 @@ export class SessionManager extends EventEmitter {
       // editable into the new session's composer. Not persisted — it is
       // re-resolved from disk on every fresh create, and restores skip folding.
       sessionPreset: presetDescriptor,
+      // #6691 (E-4): opaque per-session annotations set by the caller (the
+      // orchestration engine tags its sessions with { orchestrationRunId,
+      // orchestrationRole } for the session-list badges). In-memory only in v1 —
+      // not persisted; a restart-reconcile re-establishes it (E-3 part 3).
+      metadata: metadata || null,
     }
 
     this._sessions.set(sessionId, entry)
@@ -1673,6 +1678,11 @@ export class SessionManager extends EventEmitter {
         worktree: entry.worktreePath != null,
         repoCwd: entry.worktreeRepoDir || null,
         isolation: entry.isolation || 'none',
+        // #6691 (E-4): orchestration badges — present only for engine-owned
+        // sessions (architect / worker.*), absent otherwise. Optional on the wire
+        // (ServerSessionListEntry), so a plain session omits them entirely.
+        ...(entry.metadata?.orchestrationRunId ? { orchestrationRunId: entry.metadata.orchestrationRunId } : {}),
+        ...(entry.metadata?.orchestrationRole ? { orchestrationRole: entry.metadata.orchestrationRole } : {}),
         // #4664: per-session toggle/string settings (promptEvaluator,
         // chroxyContextHint, sessionPreamble) surface through the
         // registry so the dashboard can hydrate every knob's current

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -543,7 +543,7 @@ function _isSecureRequest(req) {
  *   - A session operation failed in an expected, user-facing way → `session_error`
  */
 export class WsServer {
-  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null, pagesRateLimiter } = {}) {
+  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, serverIdentity = null, maxPendingConnections, backpressureThreshold, environmentManager, orchestrationManager = null, config = null, diagnosticsRateLimit = null, devicePreferences = null, pagesStore = null, pagesRateLimiter } = {}) {
     this.port = port
     this.apiToken = apiToken
     this._tokenManager = tokenManager || null
@@ -1068,6 +1068,10 @@ export class WsServer {
     // Multi-session support: prefer sessionManager, fall back to single cliSession
     this.sessionManager = sessionManager || null
     this.environmentManager = environmentManager || null
+    // #6691 (E-4): the OrchestrationManager (null when the feature is off). Its
+    // run_delta events are forwarded to host-level clients by server-cli via
+    // _broadcastOrchestrationDelta; the handlers read it off ctx.services.
+    this._orchestrationManager = orchestrationManager || null
     this.defaultSessionId = defaultSessionId || null
     this._checkpointManager = new CheckpointManager()
 

--- a/packages/server/tests/orchestration-build-manager.test.js
+++ b/packages/server/tests/orchestration-build-manager.test.js
@@ -4,7 +4,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { EventEmitter } from 'node:events'
@@ -12,13 +12,18 @@ import { EventEmitter } from 'node:events'
 import { buildOrchestrationManager } from '../src/orchestration/build-manager.js'
 import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
 
-function tmp() { return mkdtempSync(join(tmpdir(), 'buildmgr-')) }
+const tmpDirs = []
+function tmp() { const d = mkdtempSync(join(tmpdir(), 'buildmgr-')); tmpDirs.push(d); return d }
+process.on('exit', () => { for (const d of tmpDirs) { try { rmSync(d, { recursive: true, force: true }) } catch { /* best effort */ } } })
 
 test('returns null when the feature is off (fail-closed default)', () => {
   const sm = new EventEmitter()
-  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: {}, chroxyDir: tmp() }), null)
-  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: { features: {} }, chroxyDir: tmp() }), null)
-  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: { features: { orchestration: false } }, chroxyDir: tmp() }), null)
+  // flag-off never touches the dir at all
+  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: {}, chroxyDir: '/nonexistent' }), null)
+  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: { features: {} }, chroxyDir: '/nonexistent' }), null)
+  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: { features: { orchestration: false } }, chroxyDir: '/nonexistent' }), null)
+  // and attaches ZERO listeners to the session manager (total no-op)
+  assert.equal(sm.eventNames().length, 0, 'flag-off attaches no listeners')
 })
 
 test('constructs a wired manager when features.orchestration is on', () => {
@@ -50,6 +55,45 @@ test('returns null (never throws) when construction fails', () => {
   })
   assert.equal(mgr, null)
   assert.ok(warnings.some((w) => /failed to initialize/i.test(w)), 'logged a warning')
+})
+
+test('recovers prior run records from disk at boot (index not clobbered)', () => {
+  const dir = tmp()
+  // cwd must be a REAL directory within (a fake) $HOME — the factory wires
+  // validateCwdAllowed, which stats it and enforces the within-home rule.
+  const fakeHome = tmp()
+  const cwd = join(fakeHome, 'repo')
+  mkdirSync(cwd, { recursive: true })
+  const cfg = {
+    features: { orchestration: true }, homeOverride: fakeHome,
+    orchestration: { roles: { architect: { provider: 'claude-sdk', model: 'm' }, worker: { provider: 'codex', model: 'm' } } },
+  }
+  const mkSm = () => { const sm = new EventEmitter(); sm.listSessions = () => []; return sm }
+  // boot 1: create a run and dispose (flushes run.json)
+  const mgr1 = buildOrchestrationManager({ sessionManager: mkSm(), config: cfg, chroxyDir: dir })
+  const rec = mgr1.createRun({ goal: 'g', cwd })
+  mgr1.dispose()
+  // boot 2: the prior run is recovered — listRuns sees it (no empty-map clobber)
+  const mgr2 = buildOrchestrationManager({ sessionManager: mkSm(), config: cfg, chroxyDir: dir })
+  const runs = mgr2.listRuns()
+  assert.equal(runs.length, 1, 'prior run recovered at boot')
+  assert.equal(runs[0].runId, rec.runId)
+  mgr2.dispose()
+})
+
+test('dispose() unhooks the engine listeners from the session manager', () => {
+  const dir = tmp()
+  const sm = new EventEmitter()
+  sm.listSessions = () => []
+  const before = sm.eventNames().length
+  const mgr = buildOrchestrationManager({
+    sessionManager: sm,
+    config: { features: { orchestration: true }, orchestration: { roles: { architect: { provider: 'claude-sdk', model: 'm' }, worker: { provider: 'codex', model: 'm' } } } },
+    chroxyDir: dir,
+  })
+  assert.ok(sm.eventNames().length > before, 'engine attached listeners (turn driver)')
+  mgr.dispose()
+  assert.equal(sm.eventNames().length, before, 'dispose removed every engine listener')
 })
 
 test('honors the CHROXY_ENABLE_ORCHESTRATION=1 env override', () => {

--- a/packages/server/tests/orchestration-build-manager.test.js
+++ b/packages/server/tests/orchestration-build-manager.test.js
@@ -1,0 +1,70 @@
+// Tests for the boot-time OrchestrationManager factory (E-4 part 3c). The
+// load-bearing property: it NEVER throws — a disabled feature or a construction
+// error returns null so the orchestration engine can't break daemon boot.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+import { buildOrchestrationManager } from '../src/orchestration/build-manager.js'
+import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
+
+function tmp() { return mkdtempSync(join(tmpdir(), 'buildmgr-')) }
+
+test('returns null when the feature is off (fail-closed default)', () => {
+  const sm = new EventEmitter()
+  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: {}, chroxyDir: tmp() }), null)
+  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: { features: {} }, chroxyDir: tmp() }), null)
+  assert.equal(buildOrchestrationManager({ sessionManager: sm, config: { features: { orchestration: false } }, chroxyDir: tmp() }), null)
+})
+
+test('constructs a wired manager when features.orchestration is on', () => {
+  const dir = tmp()
+  const sm = new EventEmitter() // TurnDriver only needs .on
+  sm.listSessions = () => []
+  try {
+    const mgr = buildOrchestrationManager({
+      sessionManager: sm,
+      config: { features: { orchestration: true }, orchestration: { roles: { architect: { provider: 'claude-sdk', model: 'm' }, worker: { provider: 'codex', model: 'm' } } } },
+      chroxyDir: dir,
+      log: null,
+    })
+    assert.ok(mgr instanceof OrchestrationManager, 'returns an OrchestrationManager')
+    // it can serve its read API without a run (empty list)
+    assert.deepEqual(mgr.listRuns(), [])
+    mgr.dispose?.()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('returns null (never throws) when construction fails', () => {
+  const warnings = []
+  const log = { info: () => {}, warn: (m) => warnings.push(m) }
+  // sessionManager without .on → TurnDriver constructor throws → caught → null
+  const mgr = buildOrchestrationManager({
+    sessionManager: {}, config: { features: { orchestration: true } }, chroxyDir: tmp(), log,
+  })
+  assert.equal(mgr, null)
+  assert.ok(warnings.some((w) => /failed to initialize/i.test(w)), 'logged a warning')
+})
+
+test('honors the CHROXY_ENABLE_ORCHESTRATION=1 env override', () => {
+  const prev = process.env.CHROXY_ENABLE_ORCHESTRATION
+  process.env.CHROXY_ENABLE_ORCHESTRATION = '1'
+  const dir = tmp()
+  const sm = new EventEmitter()
+  sm.listSessions = () => []
+  try {
+    const mgr = buildOrchestrationManager({ sessionManager: sm, config: {}, chroxyDir: dir })
+    assert.ok(mgr instanceof OrchestrationManager, 'env override enables the engine even with no config')
+    mgr.dispose?.()
+  } finally {
+    if (prev === undefined) delete process.env.CHROXY_ENABLE_ORCHESTRATION
+    else process.env.CHROXY_ENABLE_ORCHESTRATION = prev
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/packages/server/tests/session-manager-orchestration-badges.test.js
+++ b/packages/server/tests/session-manager-orchestration-badges.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { EventEmitter } from 'events'
@@ -81,6 +81,35 @@ describe('session-list orchestration badges (#6691 E-4)', () => {
       })
       const entry = mgr.listSessions().find((s) => s.sessionId === id)
       assert.equal(entry.orchestrationRole, 'architect')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('metadata is NOT persisted: a serialize→restore round-trip yields no badges', () => {
+    const mgr = makeMgr()
+    const stateFile = join(mgr._tmpDir, 'state.json')
+    try {
+      mgr.createSession({
+        cwd: '/tmp', provider: 'test-noop-badge',
+        metadata: { orchestrationRunId: 'run_abc', orchestrationRole: 'worker.audit' },
+      })
+      mgr.serializeState()
+      // the persisted state carries NO metadata (engine ownership is in-memory;
+      // restart-reconcile re-establishes it — #6743)
+      const raw = JSON.parse(readFileSync(stateFile, 'utf8'))
+      assert.ok(!JSON.stringify(raw).includes('orchestrationRunId'), 'metadata absent from persisted state')
+      // a fresh manager restoring that state lists the session WITHOUT badges
+      const mgr2 = new SessionManager({ skipPreflight: true, maxSessions: 10, defaultCwd: '/tmp', stateFilePath: stateFile })
+      mgr2._tmpDir = mkdtempSync(join(tmpdir(), 'sm-badge-r-'))
+      try {
+        mgr2.restoreState()
+        for (const s of mgr2.listSessions()) {
+          assert.equal('orchestrationRunId' in s, false, 'restored session has no badge')
+        }
+      } finally {
+        cleanup(mgr2)
+      }
     } finally {
       cleanup(mgr)
     }

--- a/packages/server/tests/session-manager-orchestration-badges.test.js
+++ b/packages/server/tests/session-manager-orchestration-badges.test.js
@@ -1,0 +1,88 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { EventEmitter } from 'events'
+import { SessionManager } from '../src/session-manager.js'
+
+// #6691 (E-4 part 3b): createSession accepts an opaque `metadata` annotation and
+// listSessions() surfaces the orchestration badges (orchestrationRunId /
+// orchestrationRole) for engine-owned sessions — absent for plain sessions.
+
+let registerProvider
+
+before(async () => {
+  ({ registerProvider } = await import('../src/providers.js'))
+  class NoopProvider extends EventEmitter {
+    constructor(opts) {
+      super()
+      this.cwd = opts.cwd
+      this.model = opts.model || null
+      this.permissionMode = opts.permissionMode || 'approve'
+      this.isRunning = false
+      this.resumeSessionId = null
+    }
+    static get capabilities() { return {} }
+    start() {}
+    destroy() {}
+    sendMessage() {}
+    interrupt() {}
+    setModel() {}
+    setPermissionMode() {}
+  }
+  registerProvider('test-noop-badge', NoopProvider)
+})
+
+function makeMgr() {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'sm-badge-'))
+  const mgr = new SessionManager({ skipPreflight: true, maxSessions: 10, defaultCwd: '/tmp', stateFilePath: join(tmpDir, 'state.json') })
+  mgr._tmpDir = tmpDir
+  return mgr
+}
+function cleanup(mgr) { mgr.destroyAll(); rmSync(mgr._tmpDir, { recursive: true, force: true }) }
+
+describe('session-list orchestration badges (#6691 E-4)', () => {
+  it('surfaces orchestrationRunId/orchestrationRole from createSession metadata', () => {
+    const mgr = makeMgr()
+    try {
+      const id = mgr.createSession({
+        cwd: '/tmp', provider: 'test-noop-badge',
+        metadata: { orchestrationRunId: 'run_abc', orchestrationRole: 'worker.audit' },
+      })
+      const entry = mgr.listSessions().find((s) => s.sessionId === id)
+      assert.ok(entry, 'session listed')
+      assert.equal(entry.orchestrationRunId, 'run_abc')
+      assert.equal(entry.orchestrationRole, 'worker.audit')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('omits the badge fields entirely for a plain (non-orchestration) session', () => {
+    const mgr = makeMgr()
+    try {
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'test-noop-badge' })
+      const entry = mgr.listSessions().find((s) => s.sessionId === id)
+      assert.ok(entry)
+      assert.equal('orchestrationRunId' in entry, false, 'no badge key on a plain session')
+      assert.equal('orchestrationRole' in entry, false)
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('carries the architect badge too', () => {
+    const mgr = makeMgr()
+    try {
+      const id = mgr.createSession({
+        cwd: '/tmp', provider: 'test-noop-badge',
+        metadata: { orchestrationRunId: 'run_x', orchestrationRole: 'architect' },
+      })
+      const entry = mgr.listSessions().find((s) => s.sessionId === id)
+      assert.equal(entry.orchestrationRole, 'architect')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The final E-4 slice: the orchestration engine becomes **reachable end-to-end** (flag-gated, default off). Closes #6700.

## Part 3b — session badges

- `SessionManager.createSession` accepts an opaque `metadata` annotation (stored on the entry; **in-memory only in v1**, not persisted — restart-reconcile re-establishes it in E-3 part 3).
- `listSessions()` surfaces the optional `orchestrationRunId` / `orchestrationRole` badges for engine-owned sessions and **omits them entirely** for plain sessions — populating the optional `ServerSessionListEntry` fields added in S-1, so the dashboard can badge architect/worker sessions and deep-link to their run.

## Part 3c — daemon boot glue (fail-safe by construction)

- **`orchestration/build-manager.js`**: `buildOrchestrationManager({ sessionManager, config, chroxyDir, log })` wires the full engine (RunLedger at `<chroxyDir>/orchestration`, TurnDriver, gitOps, permission-gate factory, roles from `config.orchestration.roles`, `validateCwdAllowed`). Returns **null when the feature is off**, and **null (never throws) on any construction error** — the engine can NEVER break daemon boot.
- **`server-cli.js`**: builds the manager after `restoreState()`, passes it to `WsServer`, and forwards the manager's `run_delta` events to `_broadcastOrchestrationDelta` (host-level clients), guarded so a broadcast error never bubbles.
- **`ws-server.js`**: accepts the `orchestrationManager` constructor opt (the `ctx.services` getter was already in place from S-2).

**The flag-off path is a provable no-op**: `buildOrchestrationManager` → null → handlers reply "engine not running" → delta wiring skipped.

## Testing

- build-manager: off → null (fail-closed); on → a wired `OrchestrationManager` (config flag AND the `CHROXY_ENABLE_ORCHESTRATION=1` env override); construction failure → null + a logged warning, never a throw.
- badges: surface for worker + architect sessions, absent (key not present) for plain sessions.
- 29 orchestration/session tests pass on the branch · `eslint src/` clean · custom lints pass.

## Remaining verification

A **running-daemon smoke test** (boot with the flag on, start a real audit run from the dashboard) — deliberately not automated here since it spends real tokens; will be run per the `headless_ws_smoke` runbook before the dogfood (S-4).