### PR TITLE
fix(server): declare the orchestration config block in CONFIG_SCHEMA

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -1388,6 +1388,10 @@ function envKeyForConfig(key) {
     // warning). Operators should migrate to
     // `CHROXY_DANGEROUSLY_SKIP_PERMISSIONS`.
     skipPermissions: 'CHROXY_SKIP_PERMISSIONS',
+    // #6691 (E-4): explicit mapping so the fallback doesn't become the very
+    // generic `ORCHESTRATION` (key.toUpperCase()), which an unrelated
+    // environment could plausibly set and have silently honored as config.
+    orchestration: 'CHROXY_ORCHESTRATION',
   }
   return envMap[key] || key.toUpperCase()
 }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -110,6 +110,13 @@ const CONFIG_SCHEMA = {
   // CHROXY_ENABLE_IDE=1 env override) reveals the IDE navigation/editing features;
   // off by default so it never risks the core offering. See isIdeFeatureEnabled().
   features: 'object',
+  // #6691 (E-4): the orchestration engine's config block ({ roles, bash, diff,
+  // maxParallelWorkers, ... } — consumed by OrchestrationManager via
+  // buildOrchestrationManager). Declared here so a configured block doesn't
+  // trip the misleading "Unknown config key ... (will be ignored)" warning —
+  // mergeConfig passes unknown file keys through regardless, but the warning
+  // suggested otherwise.
+  orchestration: 'object',
   externalUrl: 'string',
   repos: 'array',
   // #5172 (Control Room v2): filesystem root the Host Status survey scans


### PR DESCRIPTION
One-line schema registration. A configured `orchestration` block ({ roles, bash, diff, … } — consumed by `buildOrchestrationManager` since E-4 #6742) tripped the misleading **"Unknown config key: 'orchestration' (will be ignored)"** warning on every boot. `mergeConfig` passes unknown file keys through regardless (verified — the engine's role config always arrived), but the warning claimed otherwise.

Surfaced by the **flag-on daemon smoke test** run after E-4 merged: boot with `features.orchestration: true` → `Orchestration engine enabled` → `auth_ok` advertises `orchestration: true` → `orchestration_runs_request` round-trips a valid empty snapshot → clean SIGTERM shutdown. All green; this warning was the only wart.

Part of #6691.