### PR TITLE
feat(server): run report + baseline annotation (M-4)

### DIFF
--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -846,11 +846,17 @@ export class OrchestrationManager extends EventEmitter {
   // The report artifacts for a run, in preference order: the in-memory docs
   // (built at completion / re-annotation), then the persisted report.{json,md}
   // (a restarted daemon), then the bare synthesis narrative (legacy fallback).
+  // The disk read is SKIPPED for live runs: a report only exists at terminal
+  // state, and _snapshotExtras runs on hot paths (every delta emit, listRuns) —
+  // probing the filesystem per delta for a file that can't exist yet would be
+  // pure waste.
   _reportExtra(runId) {
     const docs = this._reportDocs.get(runId)
     if (docs) return docs
-    const persisted = this._ledger.readReport?.(runId)
-    if (persisted) return persisted
+    if (!this._runs.has(runId)) {
+      const persisted = this._ledger.readReport?.(runId)
+      if (persisted) return persisted
+    }
     const md = this._reports.get(runId)
     return md ? { json: '', markdown: md } : null
   }
@@ -917,21 +923,22 @@ export class OrchestrationManager extends EventEmitter {
         err.code = 'BASELINE_SESSION_NOT_FOUND'
         throw err
       }
-      const u = entry.cumulativeUsage || {}
-      const costUsd = Number.isFinite(u.costUsd) ? u.costUsd : 0
+      const u = entry.cumulativeUsage || null
+      const costUsd = Number.isFinite(u?.costUsd) ? u.costUsd : 0
       // A subscription-billed baseline (claude-tui, the default provider) keeps
       // costUsd at 0 forever while doing real work — recording it as a $0
       // baseline would render "delegation cost MORE than the monolithic run",
-      // the exact inversion the honesty rules exist to prevent. Flag it
+      // the exact inversion the honesty rules exist to prevent. Same for a
+      // session with NO usage accumulator at all: no signal ≠ $0. Flag both
       // unmetered so the report suppresses the money delta and surfaces the gap.
-      const hadActivity = (u.turnsBilled ?? 0) > 0 || (u.inputTokens ?? 0) > 0 || (u.outputTokens ?? 0) > 0
+      const hadActivity = (u?.turnsBilled ?? 0) > 0 || (u?.inputTokens ?? 0) > 0 || (u?.outputTokens ?? 0) > 0
       this._ledger.setBaseline(runId, {
         sessionId: baselineSessionId,
         // a plain session's spend signal is its provider-reported cumulative cost
         effectiveUsd: costUsd,
-        unmetered: costUsd === 0 && hadActivity,
-        inputTokens: u.inputTokens, outputTokens: u.outputTokens,
-        cacheReadTokens: u.cacheReadTokens, cacheCreationTokens: u.cacheCreationTokens,
+        unmetered: !u || (costUsd === 0 && hadActivity),
+        inputTokens: u?.inputTokens, outputTokens: u?.outputTokens,
+        cacheReadTokens: u?.cacheReadTokens, cacheCreationTokens: u?.cacheCreationTokens,
       })
     }
     // refresh derived artifacts for a terminal run (a live run rebuilds at completion)

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -863,7 +863,12 @@ export class OrchestrationManager extends EventEmitter {
     try {
       const record = this._ledger.getRun(runId)
       if (!record) return null
-      const narrative = this._reports.get(runId) ?? null
+      // The synthesis narrative's only durable copy is the persisted report's
+      // `synthesis` field — after a restart (or _reports LRU eviction) the
+      // in-memory copy is gone, and overwriting report.{json,md} without this
+      // fallback would DESTROY the narrative (a re-annotated old run would lose
+      // its audit findings forever).
+      const narrative = this._reports.get(runId) ?? this._persistedNarrative(runId)
       const report = buildRunReport(record)
       report.synthesis = narrative
       const markdown = (narrative ? `${narrative}\n\n---\n\n` : '') + renderReportMarkdown(report)
@@ -876,6 +881,19 @@ export class OrchestrationManager extends EventEmitter {
       return { json, markdown }
     } catch (err) {
       this._log?.warn?.(`orchestration: report generation failed for ${runId}: ${err?.message || err}`)
+      return null
+    }
+  }
+
+  // Recover the synthesis narrative from the persisted report.json (a restarted
+  // daemon / evicted in-memory copy). Null when absent or unparseable.
+  _persistedNarrative(runId) {
+    try {
+      const persisted = this._ledger.readReport?.(runId)
+      if (!persisted?.json) return null
+      const parsed = JSON.parse(persisted.json)
+      return typeof parsed?.synthesis === 'string' ? parsed.synthesis : null
+    } catch {
       return null
     }
   }
@@ -900,10 +918,18 @@ export class OrchestrationManager extends EventEmitter {
         throw err
       }
       const u = entry.cumulativeUsage || {}
+      const costUsd = Number.isFinite(u.costUsd) ? u.costUsd : 0
+      // A subscription-billed baseline (claude-tui, the default provider) keeps
+      // costUsd at 0 forever while doing real work — recording it as a $0
+      // baseline would render "delegation cost MORE than the monolithic run",
+      // the exact inversion the honesty rules exist to prevent. Flag it
+      // unmetered so the report suppresses the money delta and surfaces the gap.
+      const hadActivity = (u.turnsBilled ?? 0) > 0 || (u.inputTokens ?? 0) > 0 || (u.outputTokens ?? 0) > 0
       this._ledger.setBaseline(runId, {
         sessionId: baselineSessionId,
         // a plain session's spend signal is its provider-reported cumulative cost
-        effectiveUsd: Number.isFinite(u.costUsd) ? u.costUsd : 0,
+        effectiveUsd: costUsd,
+        unmetered: costUsd === 0 && hadActivity,
         inputTokens: u.inputTokens, outputTokens: u.outputTokens,
         cacheReadTokens: u.cacheReadTokens, cacheCreationTokens: u.cacheCreationTokens,
       })
@@ -914,8 +940,9 @@ export class OrchestrationManager extends EventEmitter {
       const cached = this._completedSnapshots.get(runId)
       if (cached) {
         const fresh = this._ledger.getRun(runId)
-        if (Number.isFinite(fresh?.baseline?.effectiveUsd)) cached.run.baselineEffectiveUsd = fresh.baseline.effectiveUsd
-        if (fresh?.notes?.verdictQuality != null) cached.run.verdictQuality = fresh.notes.verdictQuality
+        // suppress the money figure for an unmetered baseline (matches the report)
+        if (Number.isFinite(fresh?.baseline?.effectiveUsd) && fresh?.baseline?.unmetered !== true) cached.run.baselineEffectiveUsd = fresh.baseline.effectiveUsd
+        if (fresh?.notes?.verdictQuality != null) cached.run.verdictQuality = String(fresh.notes.verdictQuality)
         if (docs) cached.run.report = docs
       }
     }

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -37,6 +37,7 @@ import {
 } from './role-prompts.js'
 import { createGitOps } from './git-ops.js'
 import { recordToRunSummary, recordToRunDetail, gateToWire } from './to-wire.js'
+import { buildRunReport, renderReportMarkdown } from './run-report.js'
 
 const DEFAULTS = {
   maxParallelWorkers: 2,
@@ -93,7 +94,8 @@ export class OrchestrationManager extends EventEmitter {
     this._now = now
     this._log = log
     this._runs = new Map() // runId -> engine state
-    this._reports = new Map() // runId -> reportMarkdown (in-memory until M-4 persists report.md)
+    this._reports = new Map() // runId -> the architect's synthesis narrative markdown
+    this._reportDocs = new Map() // runId -> { json, markdown } — the persisted M-4 report artifacts
     this._maxReports = 32
     // Final wire-projected snapshots for terminal runs (their engine state is
     // deleted from _runs, so gates/timeline would otherwise be gone). Bounded.
@@ -441,7 +443,7 @@ export class OrchestrationManager extends EventEmitter {
     run.phase = 'synthesizing'
     this._ledger.setStatus(run.runId, 'synthesizing')
     const { decision } = await this._driveDecision(run, run.architectSessionId, buildSynthesisPrompt({ goal: run.goal, results: run.results }), 'synthesis', 'synthesis', null)
-    // The report lives in memory until M-4 (run-report.js) persists report.{json,md}.
+    // Keep the architect's narrative in memory (it feeds the persisted report).
     this._rememberReport(run.runId, decision.reportMarkdown)
     await this._destroySession(run, run.architectSessionId)
     // Remove the integration worktree; its branch (the run's output) is kept.
@@ -449,6 +451,9 @@ export class OrchestrationManager extends EventEmitter {
     await this._cleanupIntegration(run)
     run.phase = 'completed'
     this._ledger.setStatus(run.runId, 'completed')
+    // M-4: derive + persist report.{json,md} (metrics report with the synthesis
+    // narrative prepended) so the artifact survives restarts.
+    this._buildAndPersistReport(run.runId)
     this.emit('run_completed', { runId: run.runId, reportMarkdown: decision.reportMarkdown, integrationBranch })
     this._emitRunDelta(run)
     this._cacheCompletedSnapshot(run)
@@ -838,9 +843,83 @@ export class OrchestrationManager extends EventEmitter {
     }
   }
 
+  // The report artifacts for a run, in preference order: the in-memory docs
+  // (built at completion / re-annotation), then the persisted report.{json,md}
+  // (a restarted daemon), then the bare synthesis narrative (legacy fallback).
   _reportExtra(runId) {
+    const docs = this._reportDocs.get(runId)
+    if (docs) return docs
+    const persisted = this._ledger.readReport?.(runId)
+    if (persisted) return persisted
     const md = this._reports.get(runId)
     return md ? { json: '', markdown: md } : null
+  }
+
+  // M-4: derive the metrics report from the ledger record, prepend the
+  // architect's synthesis narrative, persist report.{json,md}, and keep the
+  // docs in memory for snapshots. Never throws (derived state; the journal is
+  // ground truth and the report can be regenerated).
+  _buildAndPersistReport(runId) {
+    try {
+      const record = this._ledger.getRun(runId)
+      if (!record) return null
+      const narrative = this._reports.get(runId) ?? null
+      const report = buildRunReport(record)
+      report.synthesis = narrative
+      const markdown = (narrative ? `${narrative}\n\n---\n\n` : '') + renderReportMarkdown(report)
+      const json = JSON.stringify(report, null, 2)
+      this._ledger.writeReport(runId, { json, markdown })
+      this._reportDocs.set(runId, { json, markdown })
+      while (this._reportDocs.size > this._maxReports) {
+        this._reportDocs.delete(this._reportDocs.keys().next().value)
+      }
+      return { json, markdown }
+    } catch (err) {
+      this._log?.warn?.(`orchestration: report generation failed for ${runId}: ${err?.message || err}`)
+      return null
+    }
+  }
+
+  // M-4 (#6701): annotate a run for the dogfood measurement — attach the
+  // monolithic-baseline session's usage and/or a verdict-quality note. Works on
+  // live AND terminal runs (operates via the ledger, not engine state); on a
+  // terminal run the persisted report + frozen snapshot are refreshed.
+  async annotate(runId, { baselineSessionId = null, verdictQuality = undefined } = {}) {
+    const record = this._ledger.getRun(runId)
+    if (!record) {
+      const err = new Error(`run ${runId} not found`)
+      err.code = 'RUN_NOT_FOUND'
+      throw err
+    }
+    if (verdictQuality !== undefined) this._ledger.note(runId, { verdictQuality })
+    if (baselineSessionId) {
+      const entry = this._sm.getSession?.(baselineSessionId)
+      if (!entry) {
+        const err = new Error(`baseline session ${baselineSessionId} not found`)
+        err.code = 'BASELINE_SESSION_NOT_FOUND'
+        throw err
+      }
+      const u = entry.cumulativeUsage || {}
+      this._ledger.setBaseline(runId, {
+        sessionId: baselineSessionId,
+        // a plain session's spend signal is its provider-reported cumulative cost
+        effectiveUsd: Number.isFinite(u.costUsd) ? u.costUsd : 0,
+        inputTokens: u.inputTokens, outputTokens: u.outputTokens,
+        cacheReadTokens: u.cacheReadTokens, cacheCreationTokens: u.cacheCreationTokens,
+      })
+    }
+    // refresh derived artifacts for a terminal run (a live run rebuilds at completion)
+    if (!this._runs.has(runId)) {
+      const docs = this._buildAndPersistReport(runId)
+      const cached = this._completedSnapshots.get(runId)
+      if (cached) {
+        const fresh = this._ledger.getRun(runId)
+        if (Number.isFinite(fresh?.baseline?.effectiveUsd)) cached.run.baselineEffectiveUsd = fresh.baseline.effectiveUsd
+        if (fresh?.notes?.verdictQuality != null) cached.run.verdictQuality = fresh.notes.verdictQuality
+        if (docs) cached.run.report = docs
+      }
+    }
+    return { runId, annotated: true }
   }
 
   // On terminal, freeze BOTH the detail (for getRunSnapshot) and the summary

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -20,7 +20,7 @@
  */
 
 import { EventEmitter } from 'node:events'
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 import { loadJsonState, saveJsonState } from '../json-state-file.js'
@@ -359,8 +359,14 @@ export class RunLedger extends EventEmitter {
     const dir = this._runDir(runId)
     try {
       mkdirSync(dir, { recursive: true })
-      writeFileSync(join(dir, 'report.json'), json)
-      writeFileSync(join(dir, 'report.md'), markdown)
+      // tmp+rename per file so a crash never leaves a HALF-WRITTEN artifact; a
+      // crash between the two renames can leave json/md from different builds,
+      // which is acceptable for derived state (regenerated on re-annotation).
+      for (const [name, content] of [['report.json', json], ['report.md', markdown]]) {
+        const tmp = join(dir, `${name}.tmp`)
+        writeFileSync(tmp, content)
+        renameSync(tmp, join(dir, name))
+      }
       return true
     } catch (err) {
       log.warn(`writeReport failed for ${runId}: ${err?.message || err}`)

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -20,7 +20,7 @@
  */
 
 import { EventEmitter } from 'node:events'
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 import { loadJsonState, saveJsonState } from '../json-state-file.js'
@@ -344,6 +344,41 @@ export class RunLedger extends EventEmitter {
 
   note(runId, patch) {
     this._emitEvent(runId, { type: 'run_note', patch }, { lifecycle: true })
+  }
+
+  // M-4 (#6701): set the monolithic-baseline comparison anchor (journaled, so
+  // it survives restart + replay). Last write wins.
+  setBaseline(runId, baseline) {
+    this._emitEvent(runId, { type: 'baseline_set', baseline }, { lifecycle: true })
+    return this.getRun(runId)
+  }
+
+  // M-4: persist the final report artifacts next to run.json. Overwrites on
+  // re-annotation (the report is derived state — the journal is ground truth).
+  writeReport(runId, { json = '', markdown = '' } = {}) {
+    const dir = this._runDir(runId)
+    try {
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'report.json'), json)
+      writeFileSync(join(dir, 'report.md'), markdown)
+      return true
+    } catch (err) {
+      log.warn(`writeReport failed for ${runId}: ${err?.message || err}`)
+      return false
+    }
+  }
+
+  // M-4: read persisted report artifacts (null when absent) — lets a restarted
+  // daemon serve a terminal run's report without the in-memory copy.
+  readReport(runId) {
+    const dir = this._runDir(runId)
+    try {
+      const json = readFileSync(join(dir, 'report.json'), 'utf8')
+      const markdown = readFileSync(join(dir, 'report.md'), 'utf8')
+      return { json, markdown }
+    } catch {
+      return null
+    }
   }
 
   getRun(runId) {

--- a/packages/server/src/orchestration/run-record.js
+++ b/packages/server/src/orchestration/run-record.js
@@ -270,6 +270,23 @@ export function applyEvent(record, event) {
       }
       break
 
+    // M-4 (#6701): the monolithic-session comparison anchor set via
+    // orchestration_run_annotate. Idempotent (last write wins) so the user can
+    // re-annotate with a different baseline session.
+    case 'baseline_set':
+      if (event.baseline && typeof event.baseline === 'object') {
+        record.baseline = {
+          sessionId: typeof event.baseline.sessionId === 'string' ? event.baseline.sessionId : null,
+          effectiveUsd: finiteOr(event.baseline.effectiveUsd, 0),
+          inputTokens: nonNegInt(event.baseline.inputTokens),
+          outputTokens: nonNegInt(event.baseline.outputTokens),
+          cacheReadTokens: nonNegInt(event.baseline.cacheReadTokens),
+          cacheCreationTokens: nonNegInt(event.baseline.cacheCreationTokens),
+          annotatedAt: finiteOr(event.ts, null),
+        }
+      }
+      break
+
     case 'budget_warning':
       // one-shot latch: only the first crossing stamps the time
       if (record.budgetState.warnedAt == null) record.budgetState.warnedAt = finiteOr(event.ts, null)

--- a/packages/server/src/orchestration/run-record.js
+++ b/packages/server/src/orchestration/run-record.js
@@ -278,6 +278,9 @@ export function applyEvent(record, event) {
         record.baseline = {
           sessionId: typeof event.baseline.sessionId === 'string' ? event.baseline.sessionId : null,
           effectiveUsd: finiteOr(event.baseline.effectiveUsd, 0),
+          // subscription-billed baseline: cost signal is 0 despite real work —
+          // the report must not render a money delta against it
+          unmetered: event.baseline.unmetered === true,
           inputTokens: nonNegInt(event.baseline.inputTokens),
           outputTokens: nonNegInt(event.baseline.outputTokens),
           cacheReadTokens: nonNegInt(event.baseline.cacheReadTokens),

--- a/packages/server/src/orchestration/run-report.js
+++ b/packages/server/src/orchestration/run-report.js
@@ -1,0 +1,172 @@
+/**
+ * Run report generation (epic #6691, step M-4). Pure functions deriving the
+ * dogfood-measurement report from a run's ledger record: per-role /
+ * per-model / per-subtask effective spend, cache-hit ratios, committee
+ * overhead, and the delegated-vs-monolithic baseline comparison.
+ *
+ * Honesty rules: `effectiveUsd` is the one spend number (provider-reported
+ * signed cost + server-priced fallback); `unknownCostTurns` and `meteringGaps`
+ * are surfaced, never hidden — observed spend >= shown. The report is DERIVED
+ * state (the journal is ground truth) and safe to regenerate at any time.
+ */
+
+const nz = (v) => (Number.isFinite(v) ? v : 0)
+const usd = (v) => `$${nz(v).toFixed(4)}`
+const pct = (v) => `${(nz(v) * 100).toFixed(1)}%`
+
+// Cache-hit ratio: what fraction of prompt-side tokens were cache reads.
+function cacheHitRatio(cell = {}) {
+  const read = nz(cell.cacheReadTokens)
+  const denom = nz(cell.inputTokens) + read
+  return denom > 0 ? read / denom : 0
+}
+
+function cellSummary(cell = {}) {
+  return {
+    inputTokens: nz(cell.inputTokens),
+    outputTokens: nz(cell.outputTokens),
+    cacheReadTokens: nz(cell.cacheReadTokens),
+    cacheCreationTokens: nz(cell.cacheCreationTokens),
+    turns: nz(cell.turns),
+    costUsd: nz(cell.costUsd),
+    pricedCostUsd: nz(cell.pricedCostUsd),
+    effectiveUsd: nz(cell.effectiveUsd),
+    unknownCostTurns: nz(cell.unknownCostTurns),
+    cacheHitRatio: cacheHitRatio(cell),
+  }
+}
+
+/** Build the structured report object from a ledger record. */
+export function buildRunReport(record) {
+  const totals = record?.usageTotals || {}
+  const overall = cellSummary(totals.overall)
+  const byRole = Object.fromEntries(Object.entries(totals.byRole || {}).map(([k, v]) => [k, cellSummary(v)]))
+  const byModel = Object.fromEntries(Object.entries(totals.byModel || {}).map(([k, v]) => [k, cellSummary(v)]))
+
+  // Committee overhead: what the architect's REVIEW turns cost, on top of the
+  // work itself (plan/synthesis are counted as architect, not overhead).
+  const reviewUsd = nz(byRole['architect.review']?.effectiveUsd)
+  const committeeOverhead = {
+    effectiveUsd: reviewUsd,
+    shareOfTotal: overall.effectiveUsd > 0 ? reviewUsd / overall.effectiveUsd : 0,
+    reviewTurns: nz(byRole['architect.review']?.turns),
+  }
+
+  const subtasks = (record?.subtasks || []).map((st) => ({
+    subtaskId: st.subtaskId,
+    title: st.title,
+    role: st.role,
+    status: st.status,
+    provider: st.provider ?? null,
+    model: st.model ?? null,
+    committeeIterations: Array.isArray(st.committee) ? st.committee.length : 0,
+    verdicts: Array.isArray(st.committee) ? st.committee.map((c) => c.verdict) : [],
+    numTurns: nz(st.numTurns),
+    apiDurationMs: nz(st.apiDurationMs),
+    modelDrift: st.modelDrift === true,
+    usage: cellSummary(st.usage),
+  }))
+
+  // Baseline comparison (set via orchestration_run_annotate): the same epic run
+  // as a single monolithic frontier session.
+  let baseline = null
+  if (record?.baseline && Number.isFinite(record.baseline.effectiveUsd)) {
+    const b = record.baseline
+    const delegated = overall.effectiveUsd
+    baseline = {
+      sessionId: b.sessionId ?? null,
+      effectiveUsd: nz(b.effectiveUsd),
+      deltaUsd: delegated - nz(b.effectiveUsd),
+      // <1 = delegation was cheaper than the monolithic baseline
+      ratio: nz(b.effectiveUsd) > 0 ? delegated / nz(b.effectiveUsd) : null,
+      annotatedAt: b.annotatedAt ?? null,
+    }
+  }
+
+  return {
+    version: 1,
+    runId: record?.runId ?? null,
+    title: record?.title ?? '',
+    preset: record?.preset ?? null,
+    status: record?.status ?? null,
+    createdAt: record?.createdAt ?? null,
+    endedAt: record?.endedAt ?? null,
+    totals: overall,
+    byRole,
+    byModel,
+    committeeOverhead,
+    subtasks,
+    baseline,
+    verdictQuality: record?.notes?.verdictQuality ?? null,
+    // honesty surfaces
+    unknownCostTurns: overall.unknownCostTurns,
+    meteringGaps: Array.isArray(record?.meteringGaps) ? record.meteringGaps.slice() : [],
+    droppedEvents: nz(record?.droppedEvents),
+  }
+}
+
+/** Render the report object as a human-readable markdown document. */
+export function renderReportMarkdown(report) {
+  const lines = []
+  lines.push(`# Orchestration run report — ${report.title || report.runId}`)
+  lines.push('')
+  lines.push(`- **Run**: \`${report.runId}\`${report.preset ? ` (preset: ${report.preset})` : ''}`)
+  lines.push(`- **Status**: ${report.status}`)
+  lines.push(`- **Total effective spend**: ${usd(report.totals.effectiveUsd)} across ${report.totals.turns} turns`)
+  lines.push(`- **Cache-hit ratio (overall)**: ${pct(report.totals.cacheHitRatio)}`)
+  if (report.verdictQuality != null) lines.push(`- **Verdict quality**: ${report.verdictQuality}`)
+  lines.push('')
+
+  if (report.baseline) {
+    lines.push('## Delegated vs monolithic baseline')
+    lines.push('')
+    lines.push('| | Effective USD |')
+    lines.push('|---|---|')
+    lines.push(`| Delegated (this run) | ${usd(report.totals.effectiveUsd)} |`)
+    lines.push(`| Monolithic baseline | ${usd(report.baseline.effectiveUsd)} |`)
+    lines.push(`| **Delta** | **${usd(report.baseline.deltaUsd)}** ${report.baseline.ratio != null ? `(${(report.baseline.ratio * 100).toFixed(0)}% of baseline)` : ''} |`)
+    lines.push('')
+  }
+
+  lines.push('## Spend by role')
+  lines.push('')
+  lines.push('| Role | Effective USD | Turns | Cache-hit |')
+  lines.push('|---|---|---|---|')
+  for (const [role, cell] of Object.entries(report.byRole)) {
+    lines.push(`| ${role} | ${usd(cell.effectiveUsd)} | ${cell.turns} | ${pct(cell.cacheHitRatio)} |`)
+  }
+  lines.push('')
+  lines.push(`Committee overhead (architect.review): ${usd(report.committeeOverhead.effectiveUsd)} — ${pct(report.committeeOverhead.shareOfTotal)} of total, ${report.committeeOverhead.reviewTurns} review turns.`)
+  lines.push('')
+
+  lines.push('## Spend by model')
+  lines.push('')
+  lines.push('| Model | Effective USD | Turns | Cache-hit |')
+  lines.push('|---|---|---|---|')
+  for (const [model, cell] of Object.entries(report.byModel)) {
+    lines.push(`| ${model} | ${usd(cell.effectiveUsd)} | ${cell.turns} | ${pct(cell.cacheHitRatio)} |`)
+  }
+  lines.push('')
+
+  lines.push('## Subtasks')
+  lines.push('')
+  lines.push('| Subtask | Role | Status | Iterations | Effective USD | Drift |')
+  lines.push('|---|---|---|---|---|---|')
+  for (const st of report.subtasks) {
+    lines.push(`| ${st.title || st.subtaskId} | ${st.role} | ${st.status} | ${st.committeeIterations} | ${usd(st.usage.effectiveUsd)} | ${st.modelDrift ? '⚠ model drift' : '—'} |`)
+  }
+  lines.push('')
+
+  const gaps = []
+  if (report.unknownCostTurns > 0) gaps.push(`${report.unknownCostTurns} turn(s) with unknown cost`)
+  if (report.meteringGaps.length > 0) gaps.push(`unmetered sessions: ${report.meteringGaps.join(', ')}`)
+  if (report.droppedEvents > 0) gaps.push(`${report.droppedEvents} journal event(s) dropped`)
+  if (gaps.length) {
+    lines.push('## Metering gaps (observed spend ≥ shown)')
+    lines.push('')
+    for (const g of gaps) lines.push(`- ${g}`)
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}

--- a/packages/server/src/orchestration/run-report.js
+++ b/packages/server/src/orchestration/run-report.js
@@ -13,6 +13,9 @@
 const nz = (v) => (Number.isFinite(v) ? v : 0)
 const usd = (v) => `$${nz(v).toFixed(4)}`
 const pct = (v) => `${(nz(v) * 100).toFixed(1)}%`
+// Titles come from user goals / architect-model output — escape the two things
+// that corrupt a markdown table cell (pipes and newlines).
+const cell = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' ')
 
 // Cache-hit ratio: what fraction of prompt-side tokens were cache reads.
 function cacheHitRatio(cell = {}) {
@@ -73,12 +76,19 @@ export function buildRunReport(record) {
   if (record?.baseline && Number.isFinite(record.baseline.effectiveUsd)) {
     const b = record.baseline
     const delegated = overall.effectiveUsd
+    const unmetered = b.unmetered === true
     baseline = {
       sessionId: b.sessionId ?? null,
       effectiveUsd: nz(b.effectiveUsd),
-      deltaUsd: delegated - nz(b.effectiveUsd),
+      // A subscription-billed baseline has NO cost signal — a money delta
+      // against $0 would falsely read "delegation cost more". Token counts
+      // still compare honestly.
+      unmetered,
+      deltaUsd: unmetered ? null : delegated - nz(b.effectiveUsd),
       // <1 = delegation was cheaper than the monolithic baseline
-      ratio: nz(b.effectiveUsd) > 0 ? delegated / nz(b.effectiveUsd) : null,
+      ratio: !unmetered && nz(b.effectiveUsd) > 0 ? delegated / nz(b.effectiveUsd) : null,
+      inputTokens: nz(b.inputTokens),
+      outputTokens: nz(b.outputTokens),
       annotatedAt: b.annotatedAt ?? null,
     }
   }
@@ -120,11 +130,22 @@ export function renderReportMarkdown(report) {
   if (report.baseline) {
     lines.push('## Delegated vs monolithic baseline')
     lines.push('')
-    lines.push('| | Effective USD |')
-    lines.push('|---|---|')
-    lines.push(`| Delegated (this run) | ${usd(report.totals.effectiveUsd)} |`)
-    lines.push(`| Monolithic baseline | ${usd(report.baseline.effectiveUsd)} |`)
-    lines.push(`| **Delta** | **${usd(report.baseline.deltaUsd)}** ${report.baseline.ratio != null ? `(${(report.baseline.ratio * 100).toFixed(0)}% of baseline)` : ''} |`)
+    if (report.baseline.unmetered) {
+      // No cost signal on the baseline (subscription-billed) — a money delta
+      // against $0 would falsely read "delegation cost more". Compare tokens.
+      lines.push(`> ⚠ The baseline session (\`${report.baseline.sessionId ?? 'unknown'}\`) is **unmetered** (subscription-billed — no cost signal). Money comparison suppressed; token comparison below.`)
+      lines.push('')
+      lines.push('| | Input tokens | Output tokens |')
+      lines.push('|---|---|---|')
+      lines.push(`| Delegated (this run) | ${report.totals.inputTokens + report.totals.cacheReadTokens} | ${report.totals.outputTokens} |`)
+      lines.push(`| Monolithic baseline | ${report.baseline.inputTokens} | ${report.baseline.outputTokens} |`)
+    } else {
+      lines.push('| | Effective USD |')
+      lines.push('|---|---|')
+      lines.push(`| Delegated (this run) | ${usd(report.totals.effectiveUsd)} |`)
+      lines.push(`| Monolithic baseline | ${usd(report.baseline.effectiveUsd)} |`)
+      lines.push(`| **Delta** | **${usd(report.baseline.deltaUsd)}** ${report.baseline.ratio != null ? `(${(report.baseline.ratio * 100).toFixed(0)}% of baseline)` : ''} |`)
+    }
     lines.push('')
   }
 
@@ -153,13 +174,14 @@ export function renderReportMarkdown(report) {
   lines.push('| Subtask | Role | Status | Iterations | Effective USD | Drift |')
   lines.push('|---|---|---|---|---|---|')
   for (const st of report.subtasks) {
-    lines.push(`| ${st.title || st.subtaskId} | ${st.role} | ${st.status} | ${st.committeeIterations} | ${usd(st.usage.effectiveUsd)} | ${st.modelDrift ? '⚠ model drift' : '—'} |`)
+    lines.push(`| ${cell(st.title || st.subtaskId)} | ${st.role} | ${st.status} | ${st.committeeIterations} | ${usd(st.usage.effectiveUsd)} | ${st.modelDrift ? '⚠ model drift' : '—'} |`)
   }
   lines.push('')
 
   const gaps = []
   if (report.unknownCostTurns > 0) gaps.push(`${report.unknownCostTurns} turn(s) with unknown cost`)
   if (report.meteringGaps.length > 0) gaps.push(`unmetered sessions: ${report.meteringGaps.join(', ')}`)
+  if (report.baseline?.unmetered) gaps.push('the baseline session is unmetered (subscription-billed) — no money comparison possible')
   if (report.droppedEvents > 0) gaps.push(`${report.droppedEvents} journal event(s) dropped`)
   if (gaps.length) {
     lines.push('## Metering gaps (observed spend ≥ shown)')

--- a/packages/server/src/orchestration/to-wire.js
+++ b/packages/server/src/orchestration/to-wire.js
@@ -189,8 +189,10 @@ export function recordToRunDetail(record = {}, extras = {}) {
     usageRollup: rollup,
     meteringGaps: Array.isArray(record.meteringGaps) ? record.meteringGaps.slice() : [],
   }
+  // An unmetered (subscription-billed) baseline has no cost signal — omitting
+  // the figure beats projecting a misleading $0 (matches run-report.js).
   const baseline = record.baseline?.effectiveUsd
-  if (Number.isFinite(baseline)) detail.baselineEffectiveUsd = baseline
+  if (Number.isFinite(baseline) && record.baseline?.unmetered !== true) detail.baselineEffectiveUsd = baseline
   if (record.notes?.verdictQuality != null) detail.verdictQuality = String(record.notes.verdictQuality)
   if (extras.report && typeof extras.report === 'object') {
     detail.report = { json: str(extras.report.json), markdown: str(extras.report.markdown) }

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -274,6 +274,70 @@ test('completion persists report.{json,md}; annotate attaches the baseline to a 
   }
 })
 
+test('annotate after a restart preserves the synthesis narrative (does not clobber report.md)', async () => {
+  // boot 1: complete a run (report.md persisted with the narrative)
+  const dir = mkdtempSync(join(tmpdir(), 'impl-restart-'))
+  const sm1 = new FakeSM(implementDecider())
+  const ledger1 = new RunLedger({ baseDir: dir })
+  const driver1 = new TurnDriver({ sessionManager: sm1 })
+  const mgr1 = new OrchestrationManager({ sessionManager: sm1, ledger: ledger1, turnDriver: driver1, gitOps: makeFakeGitOps(), roles: ROLES_CODEX })
+  let runId
+  try {
+    const rec = mgr1.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    runId = rec.runId
+    const done = waitFor(mgr1, ['run_completed'])
+    await mgr1.startRun(runId)
+    await done
+    assert.match(ledger1.readReport(runId).markdown, /# Done/, 'narrative persisted at completion')
+  } finally {
+    mgr1.dispose(); driver1.dispose(); ledger1.dispose?.()
+  }
+
+  // boot 2: fresh manager over the same baseDir (in-memory narrative GONE)
+  const sm2 = new FakeSM(implementDecider())
+  const ledger2 = new RunLedger({ baseDir: dir })
+  ledger2.recoverRuns()
+  const driver2 = new TurnDriver({ sessionManager: sm2 })
+  const mgr2 = new OrchestrationManager({ sessionManager: sm2, ledger: ledger2, turnDriver: driver2, gitOps: makeFakeGitOps(), roles: ROLES_CODEX })
+  try {
+    const baseId = sm2.createSession({ cwd: '/repo' })
+    sm2._sessions.get(baseId).cumulativeUsage = { inputTokens: 100, outputTokens: 10, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 1.25, turnsBilled: 2 }
+    await mgr2.annotate(runId, { baselineSessionId: baseId })
+    const after = ledger2.readReport(runId)
+    assert.match(after.markdown, /# Done/, 'narrative SURVIVED the post-restart annotate')
+    const parsed = JSON.parse(after.json)
+    assert.equal(parsed.synthesis, '# Done', 'synthesis field preserved in report.json')
+    assert.equal(parsed.baseline.effectiveUsd, 1.25, 'baseline attached')
+  } finally {
+    mgr2.dispose(); driver2.dispose(); ledger2.dispose?.()
+    rmSync(dir, { recursive: true, force: true })
+    rmSync(sm1._wtRoot, { recursive: true, force: true })
+    rmSync(sm2._wtRoot, { recursive: true, force: true })
+  }
+})
+
+test('an unmetered (subscription) baseline never projects a $0 comparison', async () => {
+  const { sm, ledger, mgr, cleanup } = harness(implementDecider())
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    // a subscription-billed baseline: real activity, zero cost signal
+    const baseId = sm.createSession({ cwd: '/repo' })
+    sm._sessions.get(baseId).cumulativeUsage = { inputTokens: 90000, outputTokens: 12000, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0, turnsBilled: 12 }
+    await mgr.annotate(rec.runId, { baselineSessionId: baseId })
+    const snap = mgr.getRunSnapshot(rec.runId)
+    assert.equal(snap.run.baselineEffectiveUsd, undefined, 'no misleading $0 baseline on the wire')
+    const report = JSON.parse(ledger.readReport(rec.runId).json)
+    assert.equal(report.baseline.unmetered, true)
+    assert.equal(report.baseline.deltaUsd, null)
+    assert.match(ledger.readReport(rec.runId).markdown, /unmetered/i)
+  } finally {
+    cleanup()
+  }
+})
+
 test('a cancelled run is cached and served from the terminal snapshot', async () => {
   // hang at the plan gate so the run is live, then cancel it.
   const decide = ({ role, kind, n }) => {

--- a/packages/server/tests/orchestration-manager-implement.test.js
+++ b/packages/server/tests/orchestration-manager-implement.test.js
@@ -81,7 +81,10 @@ class FakeSM extends EventEmitter {
     this.created.push({ sessionId, opts, session })
     return sessionId
   }
-  getSession(id) { const s = this._sessions.get(id); return s ? { session: s, worktreePath: s.worktreePath } : null }
+  getSession(id) {
+    const s = this._sessions.get(id)
+    return s ? { session: s, worktreePath: s.worktreePath, cumulativeUsage: s.cumulativeUsage ?? null } : null
+  }
   destroySession(id) { const s = this._sessions.get(id); if (s) { s.destroyed = true; this._sessions.delete(id); this.destroyedIds.push(id) } }
   listSessions() { return [...this._sessions.keys()] }
 }
@@ -228,6 +231,44 @@ test('emits schema-valid run_delta events with monotonic seq across the run life
     }
     // a terminal delta reflects the completed status
     assert.equal(deltas[deltas.length - 1].run.status, 'completed')
+  } finally {
+    cleanup()
+  }
+})
+
+test('completion persists report.{json,md}; annotate attaches the baseline to a terminal run', async () => {
+  const { sm, ledger, mgr, cleanup } = harness(implementDecider())
+  try {
+    const rec = mgr.createRun({ goal: 'Implement', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+
+    // report persisted at completion, carried in the snapshot, narrative first
+    const snap = mgr.getRunSnapshot(rec.runId)
+    assert.ok(snap.run.report, 'terminal snapshot carries the report')
+    assert.match(snap.run.report.markdown, /# Done[\s\S]*Orchestration run report/, 'synthesis narrative + metrics report')
+    const persisted = ledger.readReport(rec.runId)
+    assert.ok(persisted, 'report.{json,md} persisted')
+    assert.equal(JSON.parse(persisted.json).status, 'completed')
+
+    // a "monolithic baseline" session with cumulative usage
+    const baseId = sm.createSession({ cwd: '/repo', metadata: null })
+    sm._sessions.get(baseId).cumulativeUsage = { inputTokens: 9000, outputTokens: 1500, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 2.5, turnsBilled: 4 }
+    await mgr.annotate(rec.runId, { baselineSessionId: baseId, verdictQuality: 'good' })
+
+    // the terminal snapshot + persisted report reflect the annotation
+    const snap2 = mgr.getRunSnapshot(rec.runId)
+    assert.equal(snap2.run.baselineEffectiveUsd, 2.5)
+    assert.equal(snap2.run.verdictQuality, 'good')
+    const report2 = JSON.parse(ledger.readReport(rec.runId).json)
+    assert.equal(report2.baseline.effectiveUsd, 2.5)
+    assert.equal(report2.verdictQuality, 'good')
+    assert.ok(report2.baseline.ratio > 0, 'delegated/baseline ratio computed')
+
+    // unknown run / unknown baseline session → typed errors
+    await assert.rejects(() => mgr.annotate('run_nope', { verdictQuality: 'x' }), /not found/)
+    await assert.rejects(() => mgr.annotate(rec.runId, { baselineSessionId: 'sess_nope' }), /baseline session/)
   } finally {
     cleanup()
   }

--- a/packages/server/tests/orchestration-run-report.test.js
+++ b/packages/server/tests/orchestration-run-report.test.js
@@ -1,0 +1,156 @@
+// Tests for M-4 (#6701): report generation + baseline annotation. The report is
+// derived from records driven through the REAL RunLedger write path, and the
+// manager's annotate() is exercised live and terminal.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+import { buildRunReport, renderReportMarkdown } from '../src/orchestration/run-report.js'
+
+function mkLedger() {
+  const dir = mkdtempSync(join(tmpdir(), 'runreport-'))
+  const ledger = new RunLedger({ baseDir: dir })
+  return { dir, ledger, cleanup: () => { ledger.dispose?.(); rmSync(dir, { recursive: true, force: true }) } }
+}
+
+// Drive a realistic 2-subtask run through the real ledger.
+function buildRecord(ledger) {
+  const rec = ledger.createRun({
+    title: 'Audit run', preset: 'repo-audit',
+    configSnapshot: { cwd: '/repo', roleModels: { architect: { provider: 'claude-sdk', model: 'fable' }, worker: { provider: 'codex', model: 'codex-m' } }, budget: { maxUsd: null } },
+  })
+  const id = rec.runId
+  ledger.setStatus(id, 'executing')
+  for (const [st, cost] of [['st_a', 0.05], ['st_b', 0.03]]) {
+    ledger.createSubtask(id, { subtaskId: st, role: 'worker.audit', title: `Task ${st}` })
+    ledger.attachSession(id, st, { sessionId: `sess_${st}`, provider: 'codex', model: 'codex-m', meterable: true })
+    ledger.recordTurnUsage(id, { subtaskId: st, sessionId: `sess_${st}`, role: 'worker.audit', turnLabel: 'execute', terminalEvent: 'result', data: { model: 'codex-m', cost, usage: { input_tokens: 1000, output_tokens: 200, cache_read_input_tokens: 3000 } } })
+    ledger.recordCommitteeReview(id, st, { phase: 'result', verdict: 'approve', reviewerSessionId: 'arch', notes: 'ok' })
+    ledger.updateSubtask(id, st, { status: 'done' })
+  }
+  // architect: plan + synthesis (role architect) and 2 reviews (architect.review)
+  ledger.recordTurnUsage(id, { subtaskId: null, sessionId: 'arch', role: 'architect', turnLabel: 'plan', terminalEvent: 'result', data: { model: 'fable', cost: 0.5, usage: { input_tokens: 5000, output_tokens: 800 } } })
+  ledger.recordTurnUsage(id, { subtaskId: null, sessionId: 'arch', role: 'architect.review', turnLabel: 'result_review', terminalEvent: 'result', data: { model: 'fable', cost: 0.2, usage: { input_tokens: 2000, output_tokens: 100, cache_read_input_tokens: 6000 } } })
+  ledger.recordTurnUsage(id, { subtaskId: null, sessionId: 'arch', role: 'architect.review', turnLabel: 'result_review', terminalEvent: 'result', data: { model: 'fable', cost: 0.2, usage: { input_tokens: 2000, output_tokens: 100, cache_read_input_tokens: 6000 } } })
+  ledger.setStatus(id, 'completed')
+  return ledger.getRun(id)
+}
+
+test('buildRunReport derives totals, roles, models, committee overhead, cache-hit', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    const r = buildRunReport(record)
+    // totals: 0.05+0.03+0.5+0.2+0.2 = 0.98 across 5 turns
+    assert.ok(Math.abs(r.totals.effectiveUsd - 0.98) < 1e-9, `total ${r.totals.effectiveUsd}`)
+    assert.equal(r.totals.turns, 5)
+    // committee overhead = the two review turns
+    assert.ok(Math.abs(r.committeeOverhead.effectiveUsd - 0.4) < 1e-9)
+    assert.equal(r.committeeOverhead.reviewTurns, 2)
+    assert.ok(Math.abs(r.committeeOverhead.shareOfTotal - 0.4 / 0.98) < 1e-9)
+    // per-role + per-model splits
+    assert.ok(Math.abs(r.byRole['worker.audit'].effectiveUsd - 0.08) < 1e-9)
+    assert.ok(Math.abs(r.byModel.fable.effectiveUsd - 0.9) < 1e-9)
+    assert.ok(Math.abs(r.byModel['codex-m'].effectiveUsd - 0.08) < 1e-9)
+    // cache-hit ratio for a worker cell: 3000/(1000+3000) = 0.75
+    assert.ok(Math.abs(r.byRole['worker.audit'].cacheHitRatio - 0.75) < 1e-9)
+    // subtasks carried through with verdicts
+    assert.equal(r.subtasks.length, 2)
+    assert.deepEqual(r.subtasks[0].verdicts, ['approve'])
+    // no baseline annotated yet
+    assert.equal(r.baseline, null)
+    assert.equal(r.unknownCostTurns, 0)
+  } finally {
+    cleanup()
+  }
+})
+
+test('baseline_set flows into the report with delta + ratio', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record0 = buildRecord(ledger)
+    ledger.setBaseline(record0.runId, { sessionId: 'mono', effectiveUsd: 2.0, inputTokens: 9000, outputTokens: 1500 })
+    const r = buildRunReport(ledger.getRun(record0.runId))
+    assert.equal(r.baseline.sessionId, 'mono')
+    assert.equal(r.baseline.effectiveUsd, 2.0)
+    assert.ok(Math.abs(r.baseline.deltaUsd - (0.98 - 2.0)) < 1e-9, 'delta = delegated - baseline')
+    assert.ok(Math.abs(r.baseline.ratio - 0.98 / 2.0) < 1e-9, 'ratio < 1 = delegation cheaper')
+  } finally {
+    cleanup()
+  }
+})
+
+test('baseline survives journal replay (recoverRuns)', () => {
+  const { dir, ledger, cleanup } = mkLedger()
+  try {
+    const record0 = buildRecord(ledger)
+    ledger.setBaseline(record0.runId, { sessionId: 'mono', effectiveUsd: 3.5 })
+    ledger.dispose()
+    const ledger2 = new RunLedger({ baseDir: dir })
+    ledger2.recoverRuns()
+    const rec = ledger2.getRun(record0.runId)
+    assert.equal(rec.baseline.effectiveUsd, 3.5, 'baseline recovered from journal')
+    ledger2.dispose()
+  } finally {
+    try { cleanup() } catch { /* ledger already disposed */ }
+  }
+})
+
+test('renderReportMarkdown produces the tables + honesty section', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record0 = buildRecord(ledger)
+    ledger.setBaseline(record0.runId, { sessionId: 'mono', effectiveUsd: 2.0 })
+    // an unmetered session → meteringGaps
+    ledger.createSubtask(record0.runId, { subtaskId: 'st_c', role: 'worker.audit', title: 'unmetered' })
+    ledger.attachSession(record0.runId, 'st_c', { sessionId: 'sess_c', provider: 'codex', model: 'codex-m', meterable: false })
+    ledger.recordTurnUsage(record0.runId, { subtaskId: 'st_c', sessionId: 'sess_c', role: 'worker.audit', turnLabel: 'execute', terminalEvent: 'result', data: { usage: { input_tokens: 10 } } })
+    const report = buildRunReport(ledger.getRun(record0.runId))
+    const md = renderReportMarkdown(report)
+    assert.match(md, /# Orchestration run report — Audit run/)
+    assert.match(md, /## Delegated vs monolithic baseline/)
+    assert.match(md, /\| Delegated \(this run\) \| \$0\.98\d* \|/)
+    assert.match(md, /## Spend by role/)
+    assert.match(md, /architect\.review/)
+    assert.match(md, /Committee overhead \(architect\.review\): \$0\.4000/)
+    assert.match(md, /## Spend by model/)
+    assert.match(md, /## Subtasks/)
+    assert.match(md, /## Metering gaps/)
+    assert.match(md, /unmetered sessions: sess_c/)
+  } finally {
+    cleanup()
+  }
+})
+
+test('writeReport/readReport round-trip persists report.{json,md}', () => {
+  const { dir, ledger, cleanup } = mkLedger()
+  try {
+    const record = buildRecord(ledger)
+    const report = buildRunReport(record)
+    const json = JSON.stringify(report)
+    const markdown = renderReportMarkdown(report)
+    assert.equal(ledger.writeReport(record.runId, { json, markdown }), true)
+    assert.ok(existsSync(join(dir, 'runs', record.runId, 'report.json')))
+    assert.ok(existsSync(join(dir, 'runs', record.runId, 'report.md')))
+    const back = ledger.readReport(record.runId)
+    assert.equal(back.json, json)
+    assert.equal(back.markdown, markdown)
+    assert.equal(JSON.parse(back.json).totals.turns, 5)
+    // absent run → null
+    assert.equal(ledger.readReport('run_nope'), null)
+  } finally {
+    cleanup()
+  }
+})
+
+test('a report from a degraded/empty record never throws', () => {
+  const r = buildRunReport({})
+  assert.equal(r.totals.effectiveUsd, 0)
+  const md = renderReportMarkdown(r)
+  assert.match(md, /# Orchestration run report/)
+  assert.match(md, /Total effective spend/)
+})

--- a/packages/server/tests/orchestration-run-report.test.js
+++ b/packages/server/tests/orchestration-run-report.test.js
@@ -147,6 +147,38 @@ test('writeReport/readReport round-trip persists report.{json,md}', () => {
   }
 })
 
+test('an unmetered baseline suppresses the money delta and surfaces the gap', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const record0 = buildRecord(ledger)
+    ledger.setBaseline(record0.runId, { sessionId: 'tui', effectiveUsd: 0, unmetered: true, inputTokens: 90000, outputTokens: 12000 })
+    const r = buildRunReport(ledger.getRun(record0.runId))
+    assert.equal(r.baseline.unmetered, true)
+    assert.equal(r.baseline.deltaUsd, null, 'no money delta against a $0 subscription baseline')
+    assert.equal(r.baseline.ratio, null)
+    const md = renderReportMarkdown(r)
+    assert.match(md, /unmetered.*subscription-billed/i, 'warning surfaced')
+    assert.ok(!md.includes('| **Delta** |'), 'delta row suppressed')
+    assert.match(md, /\| Monolithic baseline \| 90000 \| 12000 \|/, 'token comparison shown instead')
+    assert.match(md, /## Metering gaps/, 'gap section present')
+  } finally {
+    cleanup()
+  }
+})
+
+test('markdown table cells escape pipes/newlines in titles', () => {
+  const { ledger, cleanup } = mkLedger()
+  try {
+    const rec = ledger.createRun({ title: 't', preset: null, configSnapshot: { cwd: '/r', roleModels: { architect: { provider: 'a', model: 'm' } }, budget: { maxUsd: null } } })
+    ledger.createSubtask(rec.runId, { subtaskId: 's1', role: 'worker.audit', title: 'evil | title\nwith newline' })
+    ledger.updateSubtask(rec.runId, 's1', { status: 'done' })
+    const md = renderReportMarkdown(buildRunReport(ledger.getRun(rec.runId)))
+    assert.match(md, /evil \\\| title with newline/, 'pipe escaped, newline flattened')
+  } finally {
+    cleanup()
+  }
+})
+
 test('a report from a degraded/empty record never throws', () => {
   const r = buildRunReport({})
   assert.equal(r.totals.effectiveUsd, 0)


### PR DESCRIPTION
## Summary

Step **M-4** of the orchestration epic (#6691): the dogfood-measurement layer. Closes #6701.

## What's here

- **`run-report.js`** (new, pure): `buildRunReport(record)` derives the structured report from a run's ledger record — totals, by-role / by-model splits with **cache-hit ratios**, **committee overhead** (architect.review spend + share of total), per-subtask verdicts/iterations/model-drift, the **delegated-vs-monolithic baseline delta + ratio**, and the honesty surfaces (`unknownCostTurns`, `meteringGaps`, `droppedEvents` — observed spend ≥ shown). `renderReportMarkdown` renders the human document. Never throws on a degraded record.
- **`baseline_set`** reducer case + `ledger.setBaseline` — journaled, so the baseline survives restart/replay (tested).
- **`ledger.writeReport`/`readReport`** — `report.{json,md}` persisted next to `run.json` at completion (derived state; the journal stays ground truth).
- **`manager.annotate(runId, { baselineSessionId, verdictQuality })`** — the method the S-2 `orchestration_run_annotate` handler has been calling since #6725: pulls the baseline session's `cumulativeUsage`, journals it; works on **live and terminal** runs (terminal → the persisted report + frozen snapshot are refreshed in place). Typed errors (`RUN_NOT_FOUND`, `BASELINE_SESSION_NOT_FOUND`).
- At completion the report (synthesis narrative + metrics) is persisted and carried in `RunDetail.report` (`RunReportSchema` shape); a restarted daemon serves it from disk.

## Testing

Report math (totals `0.98` across 5 turns; committee overhead `0.4` = 40.8% share; cache-hit `0.75`; per-role/per-model splits), baseline delta/ratio, journal-replay survival, markdown tables + metering-gaps section, write/read round-trip, degraded-record safety; end-to-end via the fake-provider harness: completion persists narrative+metrics, terminal annotate refreshes snapshot + report, error paths.

**80/80** orchestration tests pass · `eslint src/` clean · custom lints pass.

With this, everything the **S-4 dogfood** needs on the server side exists: run the audit, annotate with the baseline session, read `report.md`. Remaining epic step: S-3 (dashboard Runs UI).