### PR TITLE
fix(ci): replace notify continue-on-error with repo-relay best_effort

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -51,14 +51,17 @@ jobs:
           restore-keys: |
             repo-relay-state-${{ github.repository }}-
 
-      # Best-effort delivery: a failed notification (Discord outage, rate
-      # limit, session budget) must not red-X the PR — the step's own failure
-      # annotation stays visible in the run for debugging
-      - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0
+      # best_effort replaces the old blanket continue-on-error: transient
+      # infra failures (Discord 5xx, timeouts, session budget) exit 0 with a
+      # warning annotation, while definitive config errors (revoked token,
+      # deleted channel, missing permissions) still fail loudly. Note the
+      # cache post-step saves on job success, so relay state persists across
+      # tolerated-failure runs — intended (state writes are incremental).
+      - uses: blamechris/repo-relay@3fa58908bfb9e6f69fed5236ddae4ff2180a1d54 # v1.2.0
         if: env.DISCORD_CONFIGURED == 'true'
-        continue-on-error: true
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}
           channel_issues: ${{ secrets.DISCORD_CHANNEL_ISSUES || secrets.DISCORD_CHANNEL_PRS }}
           channel_releases: ${{ secrets.DISCORD_CHANNEL_RELEASES || secrets.DISCORD_CHANNEL_PRS }}
+          best_effort: 'true'


### PR DESCRIPTION
## Summary

Completes the durable half of the notify-job fix: bumps the `blamechris/repo-relay` pin to **v1.2.0** (`3fa58908b`) and replaces the blanket `continue-on-error: true` from #6739 with the action's new `best_effort: 'true'` input ([repo-relay#172](https://github.com/blamechris/repo-relay/pull/172)).

Closes #6741

## Behavior

| Failure | Before (#6739) | Now |
|---|---|---|
| Discord 5xx / timeout / network / session budget | green (annotation) | green (`::warning::` annotation) |
| Revoked token / deleted channel / missing permissions | **green (masked!)** | **red — fails loudly** |
| Secrets unset (forks / fresh clones) | skipped with notice | skipped with notice (unchanged) |

Classification happens inside the action (`isConfigError`): `DiscordjsError` TokenInvalid, REST 400/401/403, Unknown Channel (10003), missing-permission `ConfigError`, plus message fallbacks for gateway-level auth failures. The config-fatal set is a closed enumeration so an unclassified transient error can never re-create the every-PR red X that motivated this (#6737 / #6738 merged UNSTABLE during the 2026-07-17 Discord incident).

## Verification

- `actionlint` clean.
- repo-relay side: 400/400 vitest tests incl. spawn-based integration tests of all four flag × outcome quadrants against the committed `dist/cli.js`; E2E smoke: invalid token + `best_effort` → exit 1; dead network + `best_effort` → exit 0 + warning.
- This PR's own notify run executes the new pin via the merge ref — check should be green.