### PR TITLE
feat(dashboard): orchestration Runs data layer + coverage-guard moves (S-3a)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -507,6 +507,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // repo_events_snapshot handler. Null until the first survey lands.
   repoEventsSnapshot: null,
   repoEventsLoading: false,
+  // #6691 (S-3): orchestration Runs tab state (dashboard-only v1).
+  orchestrationRuns: null,
+  orchestrationRunsLoading: false,
+  orchestrationRunDetails: {},
+  orchestrationRunDetailLoading: new Set<string>(),
+  orchestrationRunDetailErrors: {},
+  orchestrationRunDetailStale: {},
+  orchestrationPendingActions: {},
+  orchestrationActionResults: {},
+  selectedRunId: null,
   // #5553: per-repo session presets keyed by cwd, fed by session_preset_snapshot.
   sessionPresetSnapshots: {},
   // #5553: server-provided composer seeds keyed by sessionId (drained by App).
@@ -1019,6 +1029,43 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return true;
     }
     return false;
+  },
+
+  // #6691 (S-3): request the orchestration runs-list snapshot for the Runs tab.
+  // Mirrors requestRepoEvents — wire-or-nothing (loading flips only when the
+  // socket is OPEN).
+  requestOrchestrationRuns: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ orchestrationRunsLoading: true });
+      wsSend(socket, { type: 'orchestration_runs_request' });
+      return true;
+    }
+    return false;
+  },
+
+  // #6691 (S-3): request one run's full detail snapshot. Also the resync path
+  // when a delta seq gap marks the held detail stale. Clears the run's stale
+  // flag/error on dispatch so the panel shows a clean loading state.
+  requestOrchestrationRunDetail: (runId: string): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const loading = new Set(get().orchestrationRunDetailLoading);
+      loading.add(runId);
+      const stale = { ...get().orchestrationRunDetailStale };
+      delete stale[runId];
+      const errors = { ...get().orchestrationRunDetailErrors };
+      delete errors[runId];
+      set({ orchestrationRunDetailLoading: loading, orchestrationRunDetailStale: stale, orchestrationRunDetailErrors: errors });
+      wsSend(socket, { type: 'orchestration_run_detail_request', runId });
+      return true;
+    }
+    return false;
+  },
+
+  // #6691 (S-3): select a run in the Runs tab.
+  selectRun: (runId: string | null): void => {
+    set({ selectedRunId: runId });
   },
 
   // #6543 (IDE P3 feature B): pull the full redacted tool input for a pending
@@ -2284,6 +2331,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().wslActioningIds.size > 0) {
         set({ wslActioningIds: new Set<string>() });
       }
+      // #6691 (S-3): ditto for in-flight orchestration detail requests + pending
+      // mutating actions — a reply can never arrive on the dead socket.
+      if (get().orchestrationRunDetailLoading.size > 0) {
+        set({ orchestrationRunDetailLoading: new Set<string>() });
+      }
+      if (Object.keys(get().orchestrationPendingActions).length > 0) {
+        set({ orchestrationPendingActions: {} });
+      }
       // #6153: reset every Control Room survey *Loading flag that's still true on
       // a socket drop. Each survey section computes refreshDisabled = loading ||
       // !connected, so a refresh in flight when the socket dies would leave
@@ -2297,7 +2352,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         'repoRuntimeConfigLoading', 'byokPoolStatusLoading', 'hostPruneStatusLoading',
         'simulatorStatusLoading', 'emulatorStatusLoading', 'wslStatusLoading', 'integrationStatusLoading',
         'skillsInventoryLoading', 'mailboxStatusLoading', 'externalSessionsLoading',
-        'repoEventsLoading',
+        'repoEventsLoading', 'orchestrationRunsLoading',
       ] as const;
       const loadingReset: Partial<Record<(typeof surveyLoadingKeys)[number], boolean>> = {};
       for (const key of surveyLoadingKeys) {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1052,12 +1052,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       const loading = new Set(get().orchestrationRunDetailLoading);
       loading.add(runId);
-      const stale = { ...get().orchestrationRunDetailStale };
-      delete stale[runId];
+      // NOTE: the stale flag is NOT cleared here — it marks a seq gap and must
+      // persist (visible as "resyncing…") until a VALID snapshot lands (the
+      // snapshot handler clears it). A previous error IS cleared: this is a
+      // fresh attempt.
       const errors = { ...get().orchestrationRunDetailErrors };
       delete errors[runId];
-      set({ orchestrationRunDetailLoading: loading, orchestrationRunDetailStale: stale, orchestrationRunDetailErrors: errors });
-      wsSend(socket, { type: 'orchestration_run_detail_request', runId });
+      set({ orchestrationRunDetailLoading: loading, orchestrationRunDetailErrors: errors });
+      // requestId encodes the target run so the degraded `run: null` reply can
+      // be routed back to the right per-run error/loading slots.
+      wsSend(socket, { type: 'orchestration_run_detail_request', runId, requestId: `detail:${runId}` });
       return true;
     }
     return false;

--- a/packages/dashboard/src/store/dispatch-orchestration.test.ts
+++ b/packages/dashboard/src/store/dispatch-orchestration.test.ts
@@ -110,10 +110,28 @@ describe('orchestration dispatch (#6691 S-3)', () => {
     expect(s.orchestrationRunDetails.run_1!.seq).toBe(5)
     expect(s.orchestrationRunDetails.run_1!.detail.epicPrompt).toBe('Audit the repo thoroughly')
     expect(s.orchestrationRunDetailLoading.has('run_1')).toBe(false)
-    // degraded run:null
-    store.setState({ orchestrationRunDetailLoading: new Set(['run_x']) })
-    handleMessage({ type: 'orchestration_run_snapshot', requestId: 'req-1', generatedAt: '2026-07-17T00:00:00.000Z', seq: 0, run: null, error: { code: 'RUN_NOT_FOUND', message: 'nope' } }, ctx() as never)
+    // degraded run:null with the `detail:<runId>` echo routes to THAT run only
+    store.setState({ orchestrationRunDetailLoading: new Set(['run_x', 'run_y']) })
+    handleMessage({ type: 'orchestration_run_snapshot', requestId: 'detail:run_x', generatedAt: '2026-07-17T00:00:00.000Z', seq: 0, run: null, error: { code: 'RUN_NOT_FOUND', message: 'nope' } }, ctx() as never)
+    const s2 = store.getState()
+    expect(s2.orchestrationRunDetailLoading.has('run_x')).toBe(false)
+    expect(s2.orchestrationRunDetailLoading.has('run_y')).toBe(true, )
+    expect(s2.orchestrationRunDetailErrors.run_x!.code).toBe('RUN_NOT_FOUND')
+    // no parseable echo → fall back to clearing ALL loading (nothing spins forever)
+    handleMessage({ type: 'orchestration_run_snapshot', generatedAt: '2026-07-17T00:00:00.000Z', seq: 0, run: null, error: { code: 'UNAVAILABLE', message: 'engine off' } }, ctx() as never)
     expect(store.getState().orchestrationRunDetailLoading.size).toBe(0)
+  })
+
+  it('a resync request preserves the stale flag until a valid snapshot lands', () => {
+    // simulate: gap marked the run stale, resync issued, snapshot arrives
+    store.setState({
+      orchestrationRunDetailStale: { run_1: true },
+      orchestrationRunDetailLoading: new Set(['run_1']),
+    })
+    handleMessage({ type: 'orchestration_run_snapshot', generatedAt: '2026-07-17T00:02:00.000Z', seq: 7, run: runDetail(), requestId: 'detail:run_1' }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationRunDetailStale.run_1).toBeUndefined()
+    expect(s.orchestrationRunDetails.run_1!.seq).toBe(7)
   })
 
   it('in-order delta applies via the reducer (gate upsert + header update)', () => {

--- a/packages/dashboard/src/store/dispatch-orchestration.test.ts
+++ b/packages/dashboard/src/store/dispatch-orchestration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration test for the orchestration Runs-tab data wiring (#6691, S-3
+ * #6702). Guards: list snapshot REPLACES + clears loading (degraded shape
+ * valid; malformed dropped without clearing loading); run detail seeds the
+ * store-core HeldRunDetail; deltas apply via the shared reducer under the
+ * seq===held+1 contract (gap → stale + one resync re-request); action ack and
+ * session_error{ORCHESTRATION_ACTION_FAILED} both clear the pending entry.
+ * Mirrors dispatch-repo-events.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({ clearPersistedSession: vi.fn() }))
+
+import { handleMessage, setStore, clearDeltaBuffers, clearPermissionSplits, stopHeartbeat, resetReplayFlags } from './message-handler'
+import type { ConnectionState } from './types'
+import type { RunSummary, RunDetail } from '@chroxy/protocol'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      state = { ...state, ...(typeof s === 'function' ? s(state) : s) }
+    },
+  }
+}
+function createMockSocket(): WebSocket {
+  return { send: vi.fn(), close: vi.fn(), readyState: WebSocket.OPEN, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+}
+
+const USAGE = { inputTokens: 100, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0.1, pricedCostUsd: 0, effectiveUsd: 0.1, unknownCostTurns: 0 }
+const BUDGET = { capUsd: null, spentUsd: 0.1, state: 'ok' as const }
+
+function runSummary(over: Partial<RunSummary> = {}): RunSummary {
+  return {
+    runId: 'run_1', title: 'Audit', preset: 'repo-audit', status: 'executing', cwd: '/repo',
+    epicPromptPreview: 'Audit the repo', architect: { provider: 'claude-sdk', model: 'fable' },
+    budget: BUDGET, usage: USAGE,
+    nodeCounts: { total: 2, running: 1, done: 1, failed: 0 },
+    pendingUserGates: 0, createdAt: 1000, updatedAt: 2000,
+    ...over,
+  } as RunSummary
+}
+function runDetail(over: Partial<RunDetail> = {}): RunDetail {
+  return {
+    ...runSummary(), epicPrompt: 'Audit the repo thoroughly',
+    nodes: [], gates: [], timeline: [],
+    usageRollup: { total: USAGE, byRole: {}, byModel: {} },
+    meteringGaps: [],
+    ...over,
+  } as RunDetail
+}
+const GATE = { gateId: 'g1', runId: 'run_1', nodeId: null, kind: 'epic_plan' as const, status: 'pending' as const, summary: 'Approve the plan', openedAt: 1000, resolvedAt: null, resolvedBy: null }
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected', socket: null, sessions: [], activeSessionId: null, sessionStates: {}, messages: [],
+    orchestrationRuns: null, orchestrationRunsLoading: true,
+    orchestrationRunDetails: {}, orchestrationRunDetailLoading: new Set<string>(),
+    orchestrationRunDetailErrors: {}, orchestrationRunDetailStale: {},
+    orchestrationPendingActions: {}, orchestrationActionResults: {},
+    selectedRunId: null,
+    requestOrchestrationRuns: vi.fn(() => true) as never,
+    requestOrchestrationRunDetail: vi.fn(() => true) as never,
+    // the generic session_error fall-through raises the server-error banner
+    addServerError: vi.fn() as never,
+  }
+}
+
+describe('orchestration dispatch (#6691 S-3)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.clearAllMocks(); localStorage.clear(); clearDeltaBuffers(); clearPermissionSplits()
+    mockSocket = createMockSocket(); store = createMockStore(baseState()); setStore(store)
+  })
+  afterEach(() => { stopHeartbeat(); clearDeltaBuffers(); clearPermissionSplits(); resetReplayFlags() })
+
+  it('runs_snapshot REPLACES the list and clears loading; degraded shape is valid', () => {
+    handleMessage({ type: 'orchestration_runs_snapshot', generatedAt: '2026-07-17T00:00:00.000Z', runs: [runSummary()] }, ctx() as never)
+    let s = store.getState()
+    expect(s.orchestrationRuns!.runs).toHaveLength(1)
+    expect(s.orchestrationRunsLoading).toBe(false)
+    // degraded: empty + error — still stored (the section renders the error)
+    handleMessage({ type: 'orchestration_runs_snapshot', generatedAt: '2026-07-17T00:01:00.000Z', runs: [], error: { code: 'UNAVAILABLE', message: 'engine off' } }, ctx() as never)
+    s = store.getState()
+    expect(s.orchestrationRuns!.runs).toHaveLength(0)
+    expect(s.orchestrationRuns!.error!.code).toBe('UNAVAILABLE')
+  })
+
+  it('malformed runs_snapshot is dropped WITHOUT clearing loading', () => {
+    handleMessage({ type: 'orchestration_runs_snapshot', runs: 'nope' }, ctx() as never)
+    expect(store.getState().orchestrationRunsLoading).toBe(true)
+    expect(store.getState().orchestrationRuns).toBeNull()
+  })
+
+  it('run_snapshot seeds { detail, seq }; run:null degraded reply clears loading', () => {
+    store.setState({ orchestrationRunDetailLoading: new Set(['run_1']) })
+    handleMessage({ type: 'orchestration_run_snapshot', generatedAt: '2026-07-17T00:00:00.000Z', seq: 5, run: runDetail() }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationRunDetails.run_1!.seq).toBe(5)
+    expect(s.orchestrationRunDetails.run_1!.detail.epicPrompt).toBe('Audit the repo thoroughly')
+    expect(s.orchestrationRunDetailLoading.has('run_1')).toBe(false)
+    // degraded run:null
+    store.setState({ orchestrationRunDetailLoading: new Set(['run_x']) })
+    handleMessage({ type: 'orchestration_run_snapshot', requestId: 'req-1', generatedAt: '2026-07-17T00:00:00.000Z', seq: 0, run: null, error: { code: 'RUN_NOT_FOUND', message: 'nope' } }, ctx() as never)
+    expect(store.getState().orchestrationRunDetailLoading.size).toBe(0)
+  })
+
+  it('in-order delta applies via the reducer (gate upsert + header update)', () => {
+    store.setState({
+      orchestrationRuns: { type: 'orchestration_runs_snapshot', generatedAt: '2026-07-17T00:00:00.000Z', runs: [runSummary()] } as never,
+      orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 1 } },
+    })
+    handleMessage({
+      type: 'orchestration_run_delta', runId: 'run_1', seq: 2, generatedAt: '2026-07-17T00:01:00.000Z',
+      run: runSummary({ status: 'plan_review', pendingUserGates: 1 }), gate: GATE,
+    }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationRunDetails.run_1!.seq).toBe(2)
+    expect(s.orchestrationRunDetails.run_1!.detail.gates).toHaveLength(1)
+    expect(s.orchestrationRunDetails.run_1!.detail.status).toBe('plan_review')
+    // list row upserted too
+    expect(s.orchestrationRuns!.runs[0]!.pendingUserGates).toBe(1)
+  })
+
+  it('a seq gap marks the run stale and issues exactly one resync re-request', () => {
+    store.setState({ orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 1 } } })
+    handleMessage({ type: 'orchestration_run_delta', runId: 'run_1', seq: 5, generatedAt: '2026-07-17T00:01:00.000Z', run: runSummary() }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationRunDetailStale.run_1).toBe(true)
+    expect(s.orchestrationRunDetails.run_1!.seq).toBe(1, )
+    expect(s.requestOrchestrationRunDetail).toHaveBeenCalledTimes(1)
+    expect(s.requestOrchestrationRunDetail).toHaveBeenCalledWith('run_1')
+  })
+
+  it('a stale/duplicate seq is ignored (no state change, no re-request)', () => {
+    store.setState({ orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 3 } } })
+    handleMessage({ type: 'orchestration_run_delta', runId: 'run_1', seq: 2, generatedAt: '2026-07-17T00:01:00.000Z', gate: GATE }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationRunDetails.run_1!.seq).toBe(3)
+    expect(s.orchestrationRunDetails.run_1!.detail.gates).toHaveLength(0)
+    expect(s.requestOrchestrationRunDetail).not.toHaveBeenCalled()
+  })
+
+  it('a delta with no list held and pendingUserGates>0 triggers one list fetch', () => {
+    store.setState({ orchestrationRunsLoading: false })
+    handleMessage({ type: 'orchestration_run_delta', runId: 'run_1', seq: 1, generatedAt: '2026-07-17T00:01:00.000Z', run: runSummary({ pendingUserGates: 1 }) }, ctx() as never)
+    expect(store.getState().requestOrchestrationRuns).toHaveBeenCalledTimes(1)
+  })
+
+  it('action_ack clears the pending entry and records success', () => {
+    store.setState({ orchestrationPendingActions: { 'orch-1': { kind: 'gate_response', runId: 'run_1', gateId: 'g1', at: 1 } } })
+    handleMessage({ type: 'orchestration_action_ack', requestId: 'orch-1', action: 'gate_response', runId: 'run_1', gateId: 'g1' }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationPendingActions['orch-1']).toBeUndefined()
+    expect(s.orchestrationActionResults['orch-1']!.ok).toBe(true)
+  })
+
+  it('session_error{ORCHESTRATION_ACTION_FAILED} clears pending and records the reason', () => {
+    store.setState({ orchestrationPendingActions: { 'orch-2': { kind: 'start', runId: 'run_1', at: 1 } } })
+    handleMessage({ type: 'session_error', code: 'ORCHESTRATION_ACTION_FAILED', message: 'gate already resolved', requestId: 'orch-2' }, ctx() as never)
+    const s = store.getState()
+    expect(s.orchestrationPendingActions['orch-2']).toBeUndefined()
+    expect(s.orchestrationActionResults['orch-2']!.ok).toBe(false)
+    expect(s.orchestrationActionResults['orch-2']!.error).toMatch(/already resolved/)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2715,13 +2715,23 @@ function handleOrchestrationRunSnapshot(msg: Record<string, unknown>, get: MsgGe
     set({ orchestrationRunDetails: details, orchestrationRunDetailLoading: loading, orchestrationRunDetailStale: stale, orchestrationRunDetailErrors: errors });
     return;
   }
-  // degraded: no run — we can't know which runId without echo, so clear ALL
-  // in-flight detail loading and record the error under the requestId when
-  // present (the panel keys its error banner off the selected run's absence).
-  const loading = new Set<string>();
-  const errors = { ...get().orchestrationRunDetailErrors };
-  if (typeof parsed.data.requestId === 'string' && error) errors[parsed.data.requestId] = error;
-  set({ orchestrationRunDetailLoading: loading, ...(error ? { orchestrationRunDetailErrors: errors } : {}) });
+  // degraded: no run — route back to the requesting run via the echoed
+  // requestId (`detail:<runId>`, set by requestOrchestrationRunDetail): clear
+  // ONLY that run's loading and record its error keyed by runId. A reply with
+  // no parseable echo (foreign requester) falls back to clearing all in-flight
+  // detail loading so nothing spins forever.
+  const echoed = typeof parsed.data.requestId === 'string' && parsed.data.requestId.startsWith('detail:')
+    ? parsed.data.requestId.slice('detail:'.length)
+    : null;
+  if (echoed) {
+    const loading = new Set(get().orchestrationRunDetailLoading);
+    loading.delete(echoed);
+    const errors = { ...get().orchestrationRunDetailErrors };
+    if (error) errors[echoed] = error;
+    set({ orchestrationRunDetailLoading: loading, ...(error ? { orchestrationRunDetailErrors: errors } : {}) });
+    return;
+  }
+  set({ orchestrationRunDetailLoading: new Set<string>() });
 }
 
 /**

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -129,9 +129,13 @@ import {
   createDispatchTable,
   runDispatch,
   type ClientStoreAdapter,
+  // #6691 (S-3): orchestration list/detail reducers — the handlers below are
+  // thin wrappers over these (never reimplement the merge/seq logic here).
+  upsertRunSummary,
+  applyRunDelta,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2679,6 +2683,108 @@ function handleRepoEventsDelta(msg: Record<string, unknown>, get: MsgGet, set: M
 }
 
 /**
+ * #6691 (S-3) — `orchestration_runs_snapshot`: the Runs-tab list survey.
+ * REPLACES the held snapshot wholesale (survey posture; delta.run upserts rows
+ * between surveys). The degraded `runs: [] + error` shape is schema-valid and
+ * stored as-is (the section renders the error). Malformed → drop WITHOUT
+ * clearing loading (matches the survey-family convention).
+ */
+function handleOrchestrationRunsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerOrchestrationRunsSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ orchestrationRuns: parsed.data, orchestrationRunsLoading: false });
+}
+
+/**
+ * #6691 (S-3) — `orchestration_run_snapshot`: one run's full detail (pull-only —
+ * issued on selection or as the seq-gap resync). `run: null` is the degraded
+ * not-found/unavailable reply: store the error per-run and clear loading.
+ */
+function handleOrchestrationRunSnapshot(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerOrchestrationRunSnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const { run, seq, error } = parsed.data;
+  if (run) {
+    const details = { ...get().orchestrationRunDetails, [run.runId]: { detail: run, seq } };
+    const loading = new Set(get().orchestrationRunDetailLoading);
+    loading.delete(run.runId);
+    const stale = { ...get().orchestrationRunDetailStale };
+    delete stale[run.runId];
+    const errors = { ...get().orchestrationRunDetailErrors };
+    delete errors[run.runId];
+    set({ orchestrationRunDetails: details, orchestrationRunDetailLoading: loading, orchestrationRunDetailStale: stale, orchestrationRunDetailErrors: errors });
+    return;
+  }
+  // degraded: no run — we can't know which runId without echo, so clear ALL
+  // in-flight detail loading and record the error under the requestId when
+  // present (the panel keys its error banner off the selected run's absence).
+  const loading = new Set<string>();
+  const errors = { ...get().orchestrationRunDetailErrors };
+  if (typeof parsed.data.requestId === 'string' && error) errors[parsed.data.requestId] = error;
+  set({ orchestrationRunDetailLoading: loading, ...(error ? { orchestrationRunDetailErrors: errors } : {}) });
+}
+
+/**
+ * #6691 (S-3) — `orchestration_run_delta`: live run update pushed to host-level
+ * clients. Two independent applications:
+ *  - list row: `delta.run` (a RunSummary) upserts into the held runs snapshot
+ *    via the store-core reducer; a delta before the first survey with pending
+ *    user gates triggers one list fetch (so the gate badge can appear).
+ *  - held detail: applied via applyRunDelta under the strict seq===held+1
+ *    contract; a gap marks the run stale and issues ONE resync re-request.
+ */
+function handleOrchestrationRunDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerOrchestrationRunDeltaSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const delta = parsed.data;
+
+  // list row upsert (or a one-shot list fetch when nothing is held yet)
+  const list = get().orchestrationRuns;
+  if (list && delta.run) {
+    set({ orchestrationRuns: { ...list, runs: upsertRunSummary(list.runs, delta.run), generatedAt: delta.generatedAt } });
+  } else if (!list && delta.run && delta.run.pendingUserGates > 0 && !get().orchestrationRunsLoading) {
+    // no survey yet but a gate needs the user — fetch the list so the badge shows
+    get().requestOrchestrationRuns();
+  }
+
+  // held-detail application via the shared reducer
+  const held = get().orchestrationRunDetails[delta.runId] ?? null;
+  if (!held) return;
+  const { held: next, resync } = applyRunDelta(held, delta);
+  if (resync) {
+    // seq gap: mark stale; issue exactly one re-request (the request action
+    // no-ops into `false` when the socket is closed, and the loading Set guards
+    // duplicate resyncs while one is already in flight)
+    const stale = { ...get().orchestrationRunDetailStale, [delta.runId]: true };
+    set({ orchestrationRunDetailStale: stale });
+    if (!get().orchestrationRunDetailLoading.has(delta.runId)) {
+      get().requestOrchestrationRunDetail(delta.runId);
+    }
+    return;
+  }
+  if (next && next !== held) {
+    set({ orchestrationRunDetails: { ...get().orchestrationRunDetails, [delta.runId]: next } });
+  }
+}
+
+/**
+ * #6691 (S-3) — `orchestration_action_ack`: terminal success echo for a mutating
+ * orchestration action (start/gate_response/cancel/pause/resume/annotate).
+ * Clears the pending entry and records the result keyed by requestId. The
+ * failure path arrives as `session_error{ORCHESTRATION_ACTION_FAILED}` instead.
+ */
+function handleOrchestrationActionAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerOrchestrationActionAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const requestId = parsed.data.requestId ?? null;
+  if (!requestId) return;
+  const pending = { ...get().orchestrationPendingActions };
+  delete pending[requestId];
+  const results = { ...get().orchestrationActionResults, [requestId]: { ok: true, error: null, at: Date.now() } };
+  set({ orchestrationPendingActions: pending, orchestrationActionResults: results });
+}
+
+/**
  * #6543 (IDE P3 feature B) — `permission_input`: store the pulled full (secret-
  * redacted) tool input keyed by requestId so the permission prompt can build a
  * per-hunk pre-write diff. Zod-validated (drop-on-malformed). Both `found:true`
@@ -3299,6 +3405,12 @@ const HANDLERS: Record<string, Handler> = {
   repo_events_snapshot: handleRepoEventsSnapshot,
   // #6536 (PR-2 of #5966): live repo-events delta appended to the pane.
   repo_events_delta: handleRepoEventsDelta,
+  // #6691 (S-3): orchestration Runs tab (dashboard-only v1) — list survey,
+  // pull-only run detail, live run delta (store-core reducers), action ack.
+  orchestration_runs_snapshot: handleOrchestrationRunsSnapshot,
+  orchestration_run_snapshot: handleOrchestrationRunSnapshot,
+  orchestration_run_delta: handleOrchestrationRunDelta,
+  orchestration_action_ack: handleOrchestrationActionAck,
   // #6543 (IDE P3 feature B): pulled full redacted tool input for a pre-write diff.
   permission_input: handlePermissionInput,
   session_preset_snapshot: handleSessionPresetSnapshot,
@@ -4048,6 +4160,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           resolveReindex(get, set, msg.repoPath, {
             counts: null,
             error: parsed.message || 'Reindex failed.',
+          });
+        }
+      } else if (parsed.code === 'ORCHESTRATION_ACTION_FAILED' && typeof msg.requestId === 'string') {
+        // #6691 (S-3): a failed orchestration action echoes the requestId —
+        // clear the pending entry and record the failure inline (the generic
+        // toast below still fires, matching the INTEGRATION_ACTION_FAILED
+        // precedent).
+        const orchPending = { ...get().orchestrationPendingActions };
+        if (msg.requestId in orchPending) {
+          delete orchPending[msg.requestId];
+          set({
+            orchestrationPendingActions: orchPending,
+            orchestrationActionResults: {
+              ...get().orchestrationActionResults,
+              [msg.requestId]: { ok: false, error: parsed.message || 'Orchestration action failed.', at: Date.now() },
+            },
           });
         }
       } else if (parsed.code === 'CONTAINER_ACTION_FAILED' && typeof msg.environmentId === 'string') {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,8 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerRepoEventsSnapshotMessage, ServerPermissionInputMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerRepoEventsSnapshotMessage, ServerPermissionInputMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment, ServerOrchestrationRunsSnapshot } from '@chroxy/protocol'
+import type { HeldRunDetail } from '@chroxy/store-core'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
 // for its state slot, and avoids importing a `.tsx` component here.
@@ -1049,6 +1050,35 @@ export interface ConnectionState {
   /** #5966 — true between dispatching a `repo_events_request` and its snapshot. */
   repoEventsLoading: boolean;
   /**
+   * #6691 (S-3) — the orchestration runs-list snapshot (wire shape, replaced
+   * wholesale per survey; delta.run upserts rows between surveys), or null
+   * before the first one lands.
+   */
+  orchestrationRuns: ServerOrchestrationRunsSnapshot | null;
+  /** #6691 — true between dispatching `orchestration_runs_request` and its snapshot. */
+  orchestrationRunsLoading: boolean;
+  /**
+   * #6691 — per-run held detail (store-core HeldRunDetail: the RunDetail plus
+   * the wire-seq high-water mark it was last consistent at). Deltas apply via
+   * the store-core reducer under the strict seq===held+1 contract.
+   */
+  orchestrationRunDetails: Record<string, HeldRunDetail>;
+  /** #6691 — runIds with an in-flight `orchestration_run_detail_request`. */
+  orchestrationRunDetailLoading: Set<string>;
+  /** #6691 — degraded `run: null` replies, keyed by runId. */
+  orchestrationRunDetailErrors: Record<string, { code: string; message: string }>;
+  /** #6691 — runIds whose held detail hit a delta seq gap (resync pending). */
+  orchestrationRunDetailStale: Record<string, boolean>;
+  /**
+   * #6691 — outstanding mutating actions keyed by requestId; cleared by the
+   * matching `orchestration_action_ack` or `session_error{ORCHESTRATION_ACTION_FAILED}`.
+   */
+  orchestrationPendingActions: Record<string, { kind: string; runId: string; gateId?: string; at: number }>;
+  /** #6691 — terminal results for recent orchestration actions, keyed by requestId. */
+  orchestrationActionResults: Record<string, { ok: boolean; error: string | null; at: number }>;
+  /** #6691 — the run selected in the Runs tab (detail panel target). */
+  selectedRunId: string | null;
+  /**
    * #6138 — true between dispatching a `wsl_status_request` and the matching
    * snapshot arriving (Refresh spinner). Cleared when a VALID snapshot lands (a
    * malformed payload is dropped and leaves this true).
@@ -1656,6 +1686,12 @@ export interface ConnectionState {
   requestExternalSessions: () => boolean;
   /** #5966 — request the buffered repo-events snapshot for the Control Room pane. */
   requestRepoEvents: () => boolean;
+  /** #6691 (S-3) — request the orchestration runs-list snapshot for the Runs tab. */
+  requestOrchestrationRuns: () => boolean;
+  /** #6691 — request one run's full detail snapshot (also the seq-gap resync path). */
+  requestOrchestrationRunDetail: (runId: string) => boolean;
+  /** #6691 — select a run in the Runs tab (detail panel target). */
+  selectRun: (runId: string | null) => void;
   /** #6543 — pull the full redacted tool input for a pending permission (for the pre-write diff). */
   requestPermissionInput: (requestId: string) => boolean;
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -187,6 +187,10 @@ const PLATFORM_SPECIFIC = {
   'external_sessions_snapshot': 'dashboard', // Control Room mission-control external-session survey reply (#5969, epic #5422) — host-level surface, dashboard-only (the mobile app has no Control Room); mobile parity is tracked by #5968
   'summarize_session_result': 'dashboard', // sidebar "Summarize & start new session" reply (#5547) — the sidebar context-menu idiom is dashboard-only; the mobile app is out of scope for v1 (the server endpoint is client-agnostic so the app can adopt later)
   'session_preset_snapshot': 'dashboard', // Control Room per-repo session-preset reply (#5553, epic #5159) — host-level surface (gear drawer + create-modal disclosure), dashboard-only; the server applies the preamble universally, so the mobile app needs no handler for v1 (explicitly out of scope per the issue)
+  'orchestration_runs_snapshot': 'dashboard', // Control Room "Runs" tab list survey (#6691 S-3, epic #6702) — host-level surface, dashboard-only v1; mobile parity is an explicit fast-follow per the design's locked decisions
+  'orchestration_run_snapshot': 'dashboard',  // one run's full detail (pull-only) for the Runs tab detail panel (#6691 S-3) — dashboard-only v1
+  'orchestration_run_delta': 'dashboard',     // live run update for the Runs tab (seq===held+1 contract via store-core applyRunDelta) (#6691 S-3) — dashboard-only v1
+  'orchestration_action_ack': 'dashboard',    // terminal success echo for mutating orchestration actions (#6691 S-3) — dashboard-only v1
   // 'agent_event' (#5016) is now handled by both dashboard and mobile
   // app (#5060 — mobile renders the same nested sub-bubbles inside the
   // parent Task tool_call). No PLATFORM_SPECIFIC entry needed; the

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -502,6 +502,10 @@ function _isSecureRequest(req) {
  *   { type: 'evaluator_rewrite', sessionId, originalDraft, rewritten, reasoning, evaluatorIterationId } — auto-evaluator rewrite verdict broadcast (#3208 schema, #3186 emit, #3188 dashboard handler)
  *   { type: 'evaluator_clarify', sessionId, originalDraft, clarification, reasoning, evaluatorIterationId, evaluatorIteration } — auto-evaluator clarify verdict broadcast (#3208 schema, #3186 emit, #3188 dashboard handler)
  *   { type: 'stdin_dropped_totals', sessionId, bytes, count, reason, escalated } — cumulative SidecarProcess pre-dial-cap drop totals (#3544, transient)
+ *   { type: 'orchestration_runs_snapshot', requestId?, generatedAt, runs: [RunSummary], error? } — orchestration runs-list survey (#6691, dashboard-only v1)
+ *   { type: 'orchestration_run_snapshot', requestId?, generatedAt, seq, run: RunDetail|null, error? } — one run's full detail (pull-only; run:null = degraded reply) (#6691)
+ *   { type: 'orchestration_run_delta', runId, seq, generatedAt, run?, node?, gate?, timeline? } — live run update pushed to host-level clients; client applies iff seq===held+1 (#6691)
+ *   { type: 'orchestration_action_ack', requestId?, action, runId, gateId? } — terminal success echo for a mutating orchestration action (#6691)
  *
  * Encrypted envelope (bidirectional, wraps any message above after key exchange):
  *   { type: 'encrypted', d: '<base64 ciphertext>', n: <nonce counter> }

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -218,6 +218,14 @@ const DASHBOARD_ONLY = new Set<string>([
   'skills_inventory_snapshot',  // Control Room Skills inventory survey (#5554) — dashboard-only
   'skills_list',                // skills list response (#3209) — dashboard-only for v1
   'summarize_session_result',   // sidebar "Summarize & start new session" reply (#5547) — dashboard-only
+  // Orchestration harness (#6691, S-3 #6702): the Control Room Runs tab —
+  // dashboard-only v1 per the design's locked decisions; mobile parity is an
+  // explicit fast-follow. Moved here from UNHANDLED_BY_DESIGN when the
+  // dashboard handlers landed.
+  'orchestration_runs_snapshot', // Runs tab list survey
+  'orchestration_run_snapshot',  // one run's full detail (pull-only)
+  'orchestration_run_delta',     // live run update (store-core applyRunDelta, seq contract)
+  'orchestration_action_ack',    // mutating-action success echo
 ])
 
 // Handled by the APP only — no dashboard surface by design.
@@ -242,14 +250,6 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  // Orchestration harness (#6691, S-1): the protocol contract + shared store-core
-  // reducers land first (this PR); the dashboard client handlers that consume
-  // them are the next step (S-3, #6702), which will MOVE these to DASHBOARD_ONLY
-  // (dashboard-only v1 — the mobile app is a later fast-follow).
-  'orchestration_runs_snapshot',
-  'orchestration_run_snapshot',
-  'orchestration_run_delta',
-  'orchestration_action_ack',
 ])
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -512,6 +512,8 @@ export type {
   SessionCostThresholdCrossedPayload,
   NotificationPrefsState,
   NotificationPrefsPayload,
+  // #6691 (S-3): orchestration held-detail shape consumed by the dashboard store
+  HeldRunDetail,
 } from './handlers'
 
 export {
@@ -648,6 +650,12 @@ export {
   handleNotificationPrefs,
   // #5454 — pure core of the #554 stream-split block (permission_request)
   resolvePermissionStreamSplit,
+  // #6691 (S-3): orchestration list/detail reducers (dashboard-only v1) — the
+  // dashboard message handlers are thin wrappers over these; never reimplement
+  // the merge/seq logic client-side.
+  upsertRunSummary,
+  applyRunDelta,
+  RUN_TIMELINE_MAX,
 } from './handlers'
 
 // #4591: shared device-list formatters. Eliminates duplicated copies of


### PR DESCRIPTION
## Summary

The first S-3 slice (#6702): the dashboard consumes the orchestration wire family. **Data-only** — state populates invisibly; the Runs tab UI (S-3b) and mutating affordances (S-3c) follow. Handlers + ws-server doc-block lines + both guard moves land **atomically** (any intermediate state is CI-red by design).

## What's here

- **store-core barrel**: `upsertRunSummary` / `applyRunDelta` / `RUN_TIMELINE_MAX` / `HeldRunDetail` exported from the root index.
- **dashboard store**: orchestration state (runs snapshot, per-run `HeldRunDetail`, loading/errors/stale tracking, pending mutating actions, `selectedRunId`) + `requestOrchestrationRuns` / `requestOrchestrationRunDetail` (wire-or-nothing) + disconnect sweep.
- **message handlers** — thin wrappers over the store-core reducers (merge/seq logic never reimplemented client-side):
  - `runs_snapshot`: survey posture (replace; degraded stored as-is; malformed dropped without clearing loading)
  - `run_snapshot`: pull-only detail → `{ detail, seq }`; `run: null` degraded path
  - `run_delta`: list-row upsert + held-detail application under the strict `seq === held + 1` contract — a gap marks the run stale and issues **exactly one** resync re-request
  - `action_ack` + `session_error{ORCHESTRATION_ACTION_FAILED}`: clear pending by `requestId`, record result
- **guards**: ws-server `Server -> Client:` +4 lines (guard-1 universe) · `PLATFORM_SPECIFIC` +4 dashboard entries (guard-1) · `UNHANDLED_BY_DESIGN` → `DASHBOARD_ONLY` move (guard-2) · guard-3 needed nothing (S-2 registered the client handlers).

## Testing

New `dispatch-orchestration.test.ts` (9 cases incl. the seq-gap resync contract). Full sweeps: **dashboard 4312/4312 · store-core 1952/1952 (guard-2) · protocol 362/362 (guard-1)** · dashboard typecheck + production build clean.

Part of #6702. Next: S-3b (the Runs tab UI, capability-gated) and S-3c (gate approve/deny, new-run modal, annotate).