### PR TITLE
feat(dashboard): the Control Room Runs tab — read-only observer UI (S-3b)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomView.runs-gating.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.runs-gating.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * ControlRoomView capability gating for the Runs tab (#6691 S-3b).
+ *
+ * The `runs` descriptor is capability-gated: it renders in the strip (and
+ * deep-links/persistence resolve to it) ONLY while the daemon advertises
+ * `orchestration` in auth_ok. Fail-closed — a feature-off daemon shows no dead
+ * chrome, and a persisted/deep-linked 'runs' tab degrades to 'repos'.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+let storeState: Record<string, unknown> = {}
+
+function resetStore(over: Record<string, unknown> = {}) {
+  storeState = {
+    connectionPhase: 'connected',
+    hostStatus: null, runnerStatus: null, integrationStatus: null,
+    hostStatusLoading: false, runnerStatusLoading: false, integrationStatusLoading: false,
+    requestHostStatus: vi.fn(() => true), requestRunnerStatus: vi.fn(() => true), requestIntegrationStatus: vi.fn(() => true),
+    sessions: [], activity: { bySession: {} },
+    externalSessionsSnapshot: null, requestExternalSessions: vi.fn(() => true),
+    orchestrationRuns: null, orchestrationRunsLoading: false,
+    requestOrchestrationRuns: vi.fn(() => true),
+    serverCapabilities: {},
+    ...over,
+  }
+}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector?: (s: Record<string, unknown>) => unknown) =>
+    typeof selector === 'function' ? selector(storeState) : storeState,
+}))
+
+vi.mock('./ControlRoomSection', () => ({
+  ControlRoomSection: () => <div data-testid="stub-repos">repos</div>,
+  formatGeneratedAgo: () => 'just now',
+}))
+vi.mock('./OrchestrationRunsSection', () => ({
+  OrchestrationRunsSection: () => <div data-testid="stub-runs">runs</div>,
+}))
+vi.mock('./SettingsPanel', () => ({
+  SettingsContent: () => <div data-testid="stub-settings">settings</div>,
+}))
+
+import { ControlRoomView } from './ControlRoomView'
+
+beforeEach(() => { resetStore(); localStorage.clear() })
+afterEach(() => cleanup())
+
+describe('Runs tab capability gating (#6691 S-3b)', () => {
+  it('hides the Runs tab when the orchestration capability is absent', () => {
+    render(<ControlRoomView />)
+    expect(screen.queryByRole('tab', { name: 'Runs' })).toBeNull()
+  })
+
+  it('a persisted "runs" tab falls back to repos when the capability is off (fail-closed)', () => {
+    localStorage.setItem('chroxy_cr_tab', 'runs')
+    render(<ControlRoomView />)
+    expect(screen.queryByTestId('stub-runs')).toBeNull()
+    expect(screen.getByTestId('stub-repos')).toBeTruthy()
+  })
+
+  it('shows + renders the Runs tab when the capability is advertised', () => {
+    resetStore({ serverCapabilities: { orchestration: true } })
+    localStorage.setItem('chroxy_cr_tab', 'runs')
+    render(<ControlRoomView />)
+    expect(screen.getByRole('tab', { name: 'Runs' })).toBeTruthy()
+    expect(screen.getByTestId('stub-runs')).toBeTruthy()
+  })
+
+  it('every ungated tab still renders in the strip (no over-filtering)', () => {
+    render(<ControlRoomView />)
+    expect(screen.getByRole('tab', { name: 'Project status' })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: 'Settings' })).toBeTruthy()
+  })
+})

--- a/packages/dashboard/src/components/ControlRoomView.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.test.tsx
@@ -140,6 +140,11 @@ describe('ControlRoomView', () => {
     // mock omits; the per-tab routing is covered by the targeted tab tests above
     // + the mission-control test, and ControlRoomView.registry.test.ts covers the
     // derived-set consistency.)
+    // #6691 (S-3): capability-gated tabs (runs) render only while the server
+    // advertises the capability — grant them all here so the drift guard still
+    // covers every descriptor. The gated-OFF behaviour has its own suite
+    // (ControlRoomView.runs-gating.test.tsx).
+    resetStore({ serverCapabilities: { orchestration: true } })
     render(<ControlRoomView />)
     for (const t of CONTROL_ROOM_TABS) {
       expect(screen.getByTestId(`cr-tab-${t.key}`)).toBeTruthy()

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -47,6 +47,7 @@ import { HostPruneSection } from './HostPruneSection'
 import { DeviceRuntimesSection } from './DeviceRuntimesSection'
 import { IntegrationsSection } from './IntegrationsSection'
 import { RepoEventsSection } from './RepoEventsSection'
+import { OrchestrationRunsSection } from './OrchestrationRunsSection'
 import { SkillsInventorySection } from './SkillsInventorySection'
 import { MailboxPanel } from './MailboxPanel'
 import { CrossSessionMissionControl } from './CrossSessionMissionControl'
@@ -95,11 +96,19 @@ type SurveyTabDescriptor = {
   readonly loadingKey: LoadingKey
   /** Store action that dispatches the survey request. */
   readonly requestKey: RequestKey
+  /**
+   * #6691 (S-3): optional server-capability gate. When set, the tab renders in
+   * the strip (and deep-links/persistence resolve to it) ONLY while
+   * `serverCapabilities[capability] === true` — fail-closed, so a feature-off
+   * daemon shows no dead chrome.
+   */
+  readonly capability?: string
 }
 type StaticTabDescriptor = {
   readonly key: string
   readonly label: string
   readonly survey: false
+  readonly capability?: string
 }
 type ControlRoomTabDescriptor = SurveyTabDescriptor | StaticTabDescriptor
 
@@ -247,6 +256,22 @@ export const CONTROL_ROOM_TABS = [
     key: 'mission-control',
     label: 'Mission control',
     survey: false,
+  },
+  // #6691 (S-3, epic #6702): the orchestration "Runs" tab — the committee
+  // engine's runs list + per-run detail (nodes, gates, timeline, report). Same
+  // survey:true request/snapshot flow as the others; ADDITIONALLY live
+  // `orchestration_run_delta` messages upsert between surveys. Capability-gated:
+  // hidden entirely unless the daemon advertises `orchestration` in auth_ok
+  // (feature-flagged engine, off by default).
+  {
+    key: 'runs',
+    label: 'Runs',
+    survey: true,
+    requestType: 'orchestration_runs_request',
+    snapshotKey: 'orchestrationRuns',
+    loadingKey: 'orchestrationRunsLoading',
+    requestKey: 'requestOrchestrationRuns',
+    capability: 'orchestration',
   },
   // #5544: the Settings tab converges the scattered preference surfaces
   // (notification categories, appearance, session defaults, BYOK, Tauri desktop
@@ -408,7 +433,19 @@ export function ControlRoomView({
   interventionPingEnabled,
   onToggleInterventionPing,
 }: ControlRoomViewProps = {}) {
-  const [tab, setTab] = useState<ControlRoomTab>(() => initialTab ?? loadPersistedTab())
+  const [rawTab, setTab] = useState<ControlRoomTab>(() => initialTab ?? loadPersistedTab())
+
+  // #6691 (S-3): capability gate — a tab whose descriptor names a capability is
+  // visible only while the server advertises it (auth_ok). Fail-closed: a
+  // deep-linked/persisted gated tab resolves to 'repos' instead of rendering
+  // dead chrome for a feature the daemon doesn't run.
+  const serverCapabilities = useConnectionStore((s) => s.serverCapabilities)
+  const isTabVisible = useCallback((key: ControlRoomTab): boolean => {
+    const d = CONTROL_ROOM_TABS.find((t) => t.key === key)
+    const cap = d && 'capability' in d ? d.capability : undefined
+    return !cap || serverCapabilities?.[cap] === true
+  }, [serverCapabilities])
+  const tab: ControlRoomTab = isTabVisible(rawTab) ? rawTab : 'repos'
 
   const selectTab = useCallback((next: ControlRoomTab) => {
     setTab(next)
@@ -640,7 +677,7 @@ export function ControlRoomView({
           onPointerCancel={endStripDrag}
           onPointerLeave={endStripDrag}
         >
-        {CONTROL_ROOM_TABS.map((t, i) => {
+        {CONTROL_ROOM_TABS.filter((t) => isTabVisible(t.key)).map((t, i) => {
           const active = tab === t.key
           return (
             <button
@@ -722,6 +759,8 @@ export function ControlRoomView({
         <MailboxPanel />
       ) : tab === 'repo-events' ? (
         <RepoEventsSection />
+      ) : tab === 'runs' ? (
+        <OrchestrationRunsSection />
       ) : tab === 'mission-control' ? (
         <MissionControlTab />
       ) : (

--- a/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * OrchestrationRunsSection (#6691 S-3b) — the Runs tab component.
+ *
+ * Covers: empty/error/list states, selection pulls the detail (effect), the
+ * detail panel renders nodes/gates/timeline, "Open session" jumps via
+ * switchSession, the stale (resyncing) chip, and the terminal report render.
+ * The store is mocked (codebase convention) so the test drives plain state.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+const requestRunsMock = vi.fn(() => true)
+const requestDetailMock = vi.fn(() => true)
+const selectRunMock = vi.fn()
+const switchSessionMock = vi.fn()
+let storeState: Record<string, unknown> = {}
+
+function resetStore(over: Record<string, unknown> = {}) {
+  requestRunsMock.mockClear(); requestDetailMock.mockClear(); selectRunMock.mockClear(); switchSessionMock.mockClear()
+  storeState = {
+    connectionPhase: 'connected',
+    orchestrationRuns: null,
+    orchestrationRunsLoading: false,
+    orchestrationRunDetails: {},
+    orchestrationRunDetailLoading: new Set<string>(),
+    orchestrationRunDetailErrors: {},
+    orchestrationRunDetailStale: {},
+    selectedRunId: null,
+    requestOrchestrationRuns: requestRunsMock,
+    requestOrchestrationRunDetail: requestDetailMock,
+    selectRun: selectRunMock,
+    switchSession: switchSessionMock,
+    ...over,
+  }
+}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector?: (s: Record<string, unknown>) => unknown) =>
+    typeof selector === 'function' ? selector(storeState) : storeState,
+}))
+
+import { OrchestrationRunsSection } from './OrchestrationRunsSection'
+
+const USAGE = { inputTokens: 100, outputTokens: 20, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0.1, pricedCostUsd: 0, effectiveUsd: 0.1234, unknownCostTurns: 0 }
+const BUDGET = { capUsd: 5, spentUsd: 0.1234, state: 'ok' }
+
+function runSummary(over: Record<string, unknown> = {}) {
+  return {
+    runId: 'run_1', title: 'Repo audit', preset: 'repo-audit', status: 'executing', cwd: '/repo',
+    epicPromptPreview: 'Audit', architect: { provider: 'claude-sdk', model: 'fable' },
+    budget: BUDGET, usage: USAGE, nodeCounts: { total: 2, running: 1, done: 1, failed: 0 },
+    pendingUserGates: 1, createdAt: 1000, updatedAt: 2000, ...over,
+  }
+}
+function runDetail(over: Record<string, unknown> = {}) {
+  return {
+    ...runSummary(), epicPrompt: 'Audit the repo thoroughly',
+    nodes: [{
+      nodeId: 'st_a', runId: 'run_1', title: 'Audit auth', role: 'worker.audit', provider: 'codex', model: 'm',
+      status: 'executing', attempt: 0, committeeIterations: 1, sessionId: 'sess_9', worktreePath: null,
+      branch: null, planSummary: null, resultSummary: null, usage: USAGE, createdAt: 1000, updatedAt: 1500,
+    }],
+    gates: [{ gateId: 'g1', runId: 'run_1', nodeId: null, kind: 'epic_plan', status: 'pending', summary: 'Approve the 2-subtask plan', openedAt: 900, resolvedAt: null, resolvedBy: null }],
+    timeline: [{ seq: 1, at: 950, kind: 'gate_opened', summary: 'plan gate opened' }],
+    usageRollup: { total: USAGE, byRole: {}, byModel: {} },
+    meteringGaps: [], ...over,
+  }
+}
+
+const snapshot = (runs: unknown[]) => ({ type: 'orchestration_runs_snapshot', generatedAt: '2026-07-17T00:00:00.000Z', runs })
+
+beforeEach(() => resetStore())
+afterEach(() => cleanup())
+
+describe('OrchestrationRunsSection (#6691 S-3b)', () => {
+  it('renders the not-loaded and empty states', () => {
+    const { rerender } = render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-runs-empty').textContent).toMatch(/Not loaded yet/)
+    resetStore({ orchestrationRuns: snapshot([]) })
+    rerender(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-runs-empty').textContent).toMatch(/No orchestration runs yet/)
+  })
+
+  it('renders the degraded snapshot error', () => {
+    resetStore({ orchestrationRuns: { ...snapshot([]), error: { code: 'UNAVAILABLE', message: 'engine off' } } })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-runs-error').textContent).toMatch(/UNAVAILABLE/)
+  })
+
+  it('renders run rows with status, gate chip, and server-authored spend', () => {
+    resetStore({ orchestrationRuns: snapshot([runSummary()]) })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-run-title').textContent).toBe('Repo audit')
+    expect(screen.getByTestId('orch-run-gate-chip').textContent).toMatch(/1 gate awaiting you/)
+    expect(screen.getByTestId('orch-run-spend').textContent).toContain('$0.1234')
+  })
+
+  it('clicking a run selects it; an unheld selection pulls the detail via the effect', () => {
+    resetStore({ orchestrationRuns: snapshot([runSummary()]) })
+    render(<OrchestrationRunsSection />)
+    fireEvent.click(screen.getByTestId('orch-run-row'))
+    expect(selectRunMock).toHaveBeenCalledWith('run_1')
+    // selection held in store → rerender with selectedRunId set but detail absent
+    resetStore({ orchestrationRuns: snapshot([runSummary()]), selectedRunId: 'run_1' })
+    render(<OrchestrationRunsSection />)
+    expect(requestDetailMock).toHaveBeenCalledWith('run_1')
+  })
+
+  it('renders the detail panel: nodes, pending gate, timeline; Open session jumps', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 3 } },
+    })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-detail-title').textContent).toBe('Repo audit')
+    expect(screen.getByTestId('orch-node-row').textContent).toContain('Audit auth')
+    expect(screen.getByTestId('orch-gate-summary').textContent).toMatch(/Approve the 2-subtask plan/)
+    expect(screen.getByTestId('orch-timeline-entry').textContent).toContain('plan gate opened')
+    fireEvent.click(screen.getByTestId('orch-node-open-session'))
+    expect(switchSessionMock).toHaveBeenCalledWith('sess_9')
+  })
+
+  it('shows the resyncing chip while the held detail is stale', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 3 } },
+      orchestrationRunDetailStale: { run_1: true },
+    })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-detail-stale')).toBeTruthy()
+  })
+
+  it('renders the per-run detail error state', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetailErrors: { run_1: { code: 'RUN_NOT_FOUND', message: 'gone' } },
+    })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-detail-error').textContent).toMatch(/RUN_NOT_FOUND/)
+  })
+
+  it('renders the report markdown (and raw JSON) at terminal state', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary({ status: 'completed' })]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'completed', report: { json: '{"ok":true}', markdown: '# Audit report' } }), seq: 9 } },
+    })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-report-markdown').textContent).toContain('# Audit report')
+    expect(screen.getByTestId('orch-report-json').textContent).toContain('"ok"')
+  })
+
+  it('Refresh dispatches the runs request and disables while loading', () => {
+    resetStore({ orchestrationRuns: snapshot([]) })
+    const { rerender } = render(<OrchestrationRunsSection />)
+    fireEvent.click(screen.getByTestId('orch-refresh'))
+    expect(requestRunsMock).toHaveBeenCalledTimes(1)
+    resetStore({ orchestrationRuns: snapshot([]), orchestrationRunsLoading: true })
+    rerender(<OrchestrationRunsSection />)
+    expect((screen.getByTestId('orch-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
@@ -95,15 +95,18 @@ describe('OrchestrationRunsSection (#6691 S-3b)', () => {
     expect(screen.getByTestId('orch-run-spend').textContent).toContain('$0.1234')
   })
 
-  it('clicking a run selects it; an unheld selection pulls the detail via the effect', () => {
+  it('clicking a run selects it', () => {
     resetStore({ orchestrationRuns: snapshot([runSummary()]) })
     render(<OrchestrationRunsSection />)
     fireEvent.click(screen.getByTestId('orch-run-row'))
     expect(selectRunMock).toHaveBeenCalledWith('run_1')
-    // selection held in store → rerender with selectedRunId set but detail absent
+  })
+
+  it('an unheld selection pulls the detail via the effect', () => {
     resetStore({ orchestrationRuns: snapshot([runSummary()]), selectedRunId: 'run_1' })
     render(<OrchestrationRunsSection />)
     expect(requestDetailMock).toHaveBeenCalledWith('run_1')
+    expect(requestDetailMock).toHaveBeenCalledTimes(1)
   })
 
   it('renders the detail panel: nodes, pending gate, timeline; Open session jumps', () => {
@@ -149,7 +152,10 @@ describe('OrchestrationRunsSection (#6691 S-3b)', () => {
       orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'completed', report: { json: '{"ok":true}', markdown: '# Audit report' } }), seq: 9 } },
     })
     render(<OrchestrationRunsSection />)
-    expect(screen.getByTestId('orch-report-markdown').textContent).toContain('# Audit report')
+    // rendered through the sanitized markdown pipeline → an <h1>, so the '#' is
+    // gone from textContent but the heading text remains
+    expect(screen.getByTestId('orch-report-markdown').textContent).toContain('Audit report')
+    expect(screen.getByTestId('orch-report-markdown').querySelector('h1')).toBeTruthy()
     expect(screen.getByTestId('orch-report-json').textContent).toContain('"ok"')
   })
 

--- a/packages/dashboard/src/components/OrchestrationRunsSection.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.tsx
@@ -24,6 +24,8 @@ import { useEffect } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { RunSummary, RunDetail, RunGate, RunNode, RunTimelineEntry, RunUsage } from '@chroxy/protocol'
 import { formatGeneratedAgo } from './ControlRoomSection'
+import { renderMarkdown } from '../lib/markdown'
+import { handleMarkdownLinkClick } from '../lib/links'
 
 /** Server-authored spend figure — never computed client-side (AC-3). */
 function usd(usage: RunUsage | undefined | null): string {
@@ -187,7 +189,14 @@ function DetailPanel({ runId, onOpenSession }: { runId: string; onOpenSession: (
       {TERMINAL_STATUSES.has(run.status) && run.report && (
         <>
           <h5>Report</h5>
-          <pre className="cr-orch-report" data-testid="orch-report-markdown">{run.report.markdown}</pre>
+          {/* the shared sanitized markdown pipeline (same as ChatMessage) — the
+              report is model-authored, so it must never render unsanitized */}
+          <div
+            className="cr-orch-report markdown-content"
+            data-testid="orch-report-markdown"
+            onClick={handleMarkdownLinkClick}
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(run.report.markdown) }}
+          />
           <details>
             <summary className="cr-dim">Raw report JSON</summary>
             <pre className="cr-orch-report-json" data-testid="orch-report-json">{run.report.json}</pre>

--- a/packages/dashboard/src/components/OrchestrationRunsSection.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.tsx
@@ -1,0 +1,266 @@
+/**
+ * OrchestrationRunsSection (#6691 S-3b, epic #6702) — the "Runs" Control Room tab.
+ *
+ * Read-only observer surface for the orchestration/committee engine: a runs
+ * list (left) and, on selection, the run's full detail — status/budget header,
+ * the node (subtask) tree with per-node role/status/spend + "Open session"
+ * jump, pending gates (display-only in S-3b; approve/deny lands in S-3c), the
+ * bounded activity timeline, and the persisted report markdown at terminal
+ * state (JSON behind a collapsed <details>).
+ *
+ * Data flow: the tab is `survey: true` in the CONTROL_ROOM_TABS registry, so
+ * activation auto-fetches `orchestration_runs_request` (staleness-guarded);
+ * selecting a run pulls its detail via `requestOrchestrationRunDetail`. Live
+ * `orchestration_run_delta` messages upsert list rows and apply to the held
+ * detail under the store-core seq contract (a gap shows "resyncing…" until the
+ * resync snapshot lands). No client-side pricing math — costs render the
+ * server's effectiveUsd via the shared formatters (issue AC-3).
+ *
+ * The tab is capability-gated (`serverCapabilities.orchestration`) at the
+ * ControlRoomView strip/deep-link layer — this component assumes it only
+ * renders when the engine is enabled.
+ */
+import { useEffect } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { RunSummary, RunDetail, RunGate, RunNode, RunTimelineEntry, RunUsage } from '@chroxy/protocol'
+import { formatGeneratedAgo } from './ControlRoomSection'
+
+/** Server-authored spend figure — never computed client-side (AC-3). */
+function usd(usage: RunUsage | undefined | null): string {
+  if (!usage || !Number.isFinite(usage.effectiveUsd)) return '—'
+  return `$${usage.effectiveUsd.toFixed(4)}`
+}
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled'])
+
+/** Status chip accent: terminal-good, terminal-bad, gated, or in-flight. */
+function statusAccent(status: string): string {
+  if (status === 'completed') return 'ok'
+  if (status === 'failed' || status === 'cancelled') return 'bad'
+  if (status === 'plan_review' || status === 'budget_paused' || status === 'paused' || status === 'suspended') return 'warn'
+  return 'neutral'
+}
+
+function StatusChip({ status }: { status: string }) {
+  return (
+    <span className="cr-tag" data-accent={statusAccent(status)} data-testid="orch-run-status">
+      {status.replace(/_/g, ' ')}
+    </span>
+  )
+}
+
+/** Budget meter: spent vs cap (or uncapped), warned/capped accent. */
+function BudgetMeter({ run }: { run: RunSummary }) {
+  const { capUsd, spentUsd, state } = run.budget
+  const label = capUsd == null
+    ? `$${spentUsd.toFixed(4)} spent (no cap)`
+    : `$${spentUsd.toFixed(4)} / $${capUsd.toFixed(2)}`
+  return (
+    <span
+      className="cr-tag"
+      data-accent={state === 'capped' ? 'bad' : state === 'warned' ? 'warn' : 'neutral'}
+      data-testid="orch-budget-meter"
+      title={`budget state: ${state}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+function RunRow({ run, selected, onSelect }: { run: RunSummary; selected: boolean; onSelect: (id: string) => void }) {
+  return (
+    <li>
+      <button
+        type="button"
+        className={`cr-orch-run-row${selected ? ' is-selected' : ''}`}
+        data-testid="orch-run-row"
+        aria-pressed={selected}
+        onClick={() => onSelect(run.runId)}
+      >
+        <span className="cr-orch-run-title" data-testid="orch-run-title">{run.title || run.runId}</span>
+        <StatusChip status={run.status} />
+        {run.pendingUserGates > 0 && (
+          <span className="cr-tag" data-accent="warn" data-testid="orch-run-gate-chip">
+            {run.pendingUserGates} gate{run.pendingUserGates === 1 ? '' : 's'} awaiting you
+          </span>
+        )}
+        <span className="cr-dim" data-testid="orch-run-spend"> · {usd(run.usage)}</span>
+        <span className="cr-dim"> · {run.nodeCounts.done}/{run.nodeCounts.total} done</span>
+      </button>
+    </li>
+  )
+}
+
+function NodeRow({ node, onOpenSession }: { node: RunNode; onOpenSession: (sessionId: string) => void }) {
+  return (
+    <li className="cr-orch-node" data-testid="orch-node-row">
+      <span className="cr-orch-node-title">{node.title || node.nodeId}</span>
+      <span className="cr-tag" data-accent="neutral" data-testid="orch-node-role">{node.role}</span>
+      <StatusChip status={node.status} />
+      <span className="cr-dim"> · {usd(node.usage ?? null)}</span>
+      {node.committeeIterations > 0 && <span className="cr-dim"> · {node.committeeIterations} committee round{node.committeeIterations === 1 ? '' : 's'}</span>}
+      {node.branch && <code className="cr-dim" data-testid="orch-node-branch">{node.branch}</code>}
+      {node.sessionId && (
+        <button type="button" className="cr-link-btn" data-testid="orch-node-open-session" onClick={() => onOpenSession(node.sessionId!)}>
+          Open session
+        </button>
+      )}
+    </li>
+  )
+}
+
+/** Pending gates render display-only in S-3b; approve/deny controls are S-3c. */
+function GateRow({ gate }: { gate: RunGate }) {
+  return (
+    <li className="cr-orch-gate" data-testid="orch-gate-row" data-gate-status={gate.status}>
+      <span className="cr-tag" data-accent={gate.status === 'pending' ? 'warn' : 'neutral'}>{gate.kind.replace(/_/g, ' ')}</span>
+      <span data-testid="orch-gate-summary">{gate.summary}</span>
+      {gate.status !== 'pending' && <span className="cr-dim"> · {gate.status}{gate.resolvedBy ? ` by ${gate.resolvedBy}` : ''}</span>}
+      {gate.status === 'pending' && <span className="cr-dim" data-testid="orch-gate-pending-hint"> · awaiting your decision (respond in S-3c)</span>}
+    </li>
+  )
+}
+
+function TimelineRow({ entry }: { entry: RunTimelineEntry }) {
+  return (
+    <li className="cr-orch-timeline-entry" data-testid="orch-timeline-entry">
+      <span className="cr-dim">#{entry.seq}</span> {entry.summary}
+      {entry.verdict && <span className="cr-tag" data-accent="neutral">{entry.verdict}</span>}
+    </li>
+  )
+}
+
+function DetailPanel({ runId, onOpenSession }: { runId: string; onOpenSession: (sessionId: string) => void }) {
+  const held = useConnectionStore((s) => s.orchestrationRunDetails[runId] ?? null)
+  const loading = useConnectionStore((s) => s.orchestrationRunDetailLoading.has(runId))
+  const stale = useConnectionStore((s) => s.orchestrationRunDetailStale[runId] === true)
+  const error = useConnectionStore((s) => s.orchestrationRunDetailErrors[runId] ?? null)
+
+  if (error) {
+    return <p className="cr-error" data-testid="orch-detail-error">{error.code}: {error.message}</p>
+  }
+  if (!held) {
+    return <p className="cr-dim" data-testid="orch-detail-loading">{loading ? 'Loading run detail…' : 'Select a run to inspect it.'}</p>
+  }
+  const run: RunDetail = held.detail
+  const pendingGates = run.gates.filter((g) => g.status === 'pending')
+  const resolvedGates = run.gates.filter((g) => g.status !== 'pending')
+  return (
+    <div className="cr-orch-detail" data-testid="orch-detail-panel">
+      <div className="cr-orch-detail-header">
+        <h4 data-testid="orch-detail-title">{run.title || run.runId}</h4>
+        <StatusChip status={run.status} />
+        <BudgetMeter run={run} />
+        <span className="cr-dim" data-testid="orch-detail-spend">{usd(run.usage)} · {run.nodeCounts.done}/{run.nodeCounts.total} subtasks done</span>
+        {stale && <span className="cr-tag" data-accent="warn" data-testid="orch-detail-stale">resyncing…</span>}
+      </div>
+      {run.epicPrompt && <p className="cr-dim cr-orch-epic" data-testid="orch-detail-epic">{run.epicPrompt}</p>}
+
+      {pendingGates.length > 0 && (
+        <>
+          <h5>Gates awaiting you</h5>
+          <ul className="cr-orch-gates" data-testid="orch-pending-gates">{pendingGates.map((g) => <GateRow key={g.gateId} gate={g} />)}</ul>
+        </>
+      )}
+
+      <h5>Subtasks</h5>
+      {run.nodes.length === 0
+        ? <p className="cr-dim" data-testid="orch-nodes-empty">No subtasks yet (planning).</p>
+        : <ul className="cr-orch-nodes">{run.nodes.map((n) => <NodeRow key={n.nodeId} node={n} onOpenSession={onOpenSession} />)}</ul>}
+
+      {run.timeline.length > 0 && (
+        <>
+          <h5>Activity</h5>
+          <ul className="cr-orch-timeline" data-testid="orch-timeline">
+            {run.timeline.slice(-20).map((e) => <TimelineRow key={e.seq} entry={e} />)}
+          </ul>
+        </>
+      )}
+
+      {resolvedGates.length > 0 && (
+        <details>
+          <summary className="cr-dim">Resolved gates ({resolvedGates.length})</summary>
+          <ul className="cr-orch-gates">{resolvedGates.map((g) => <GateRow key={g.gateId} gate={g} />)}</ul>
+        </details>
+      )}
+
+      {TERMINAL_STATUSES.has(run.status) && run.report && (
+        <>
+          <h5>Report</h5>
+          <pre className="cr-orch-report" data-testid="orch-report-markdown">{run.report.markdown}</pre>
+          <details>
+            <summary className="cr-dim">Raw report JSON</summary>
+            <pre className="cr-orch-report-json" data-testid="orch-report-json">{run.report.json}</pre>
+          </details>
+        </>
+      )}
+    </div>
+  )
+}
+
+export interface OrchestrationRunsSectionProps {
+  /** Injectable clock for the "generated Nm ago" line. */
+  now?: () => number
+}
+
+export function OrchestrationRunsSection({ now = Date.now }: OrchestrationRunsSectionProps = {}) {
+  const snapshot = useConnectionStore((s) => s.orchestrationRuns)
+  const loading = useConnectionStore((s) => s.orchestrationRunsLoading)
+  const connected = useConnectionStore((s) => s.connectionPhase === 'connected')
+  const requestRuns = useConnectionStore((s) => s.requestOrchestrationRuns)
+  const requestDetail = useConnectionStore((s) => s.requestOrchestrationRunDetail)
+  const selectedRunId = useConnectionStore((s) => s.selectedRunId)
+  const selectRun = useConnectionStore((s) => s.selectRun)
+  const switchSession = useConnectionStore((s) => s.switchSession)
+
+  // Pull the selected run's detail when it isn't held yet (selection persists
+  // across tab flips; the delta stream keeps a held detail current).
+  const heldSelected = useConnectionStore((s) => (selectedRunId ? s.orchestrationRunDetails[selectedRunId] ?? null : null))
+  const selectedLoading = useConnectionStore((s) => (selectedRunId ? s.orchestrationRunDetailLoading.has(selectedRunId) : false))
+  useEffect(() => {
+    if (selectedRunId && !heldSelected && !selectedLoading && connected) {
+      requestDetail(selectedRunId)
+    }
+  }, [selectedRunId, heldSelected, selectedLoading, connected, requestDetail])
+
+  const runs = snapshot?.runs ?? []
+  return (
+    <section className="cr-section" data-testid="orch-runs-section">
+      <header className="cr-section-header">
+        <div>
+          <div className="cr-eyebrow">Orchestration</div>
+          <h3>Runs</h3>
+          {snapshot && <span className="cr-dim" data-testid="orch-generated-ago">{formatGeneratedAgo(Date.parse(snapshot.generatedAt), now())}</span>}
+        </div>
+        <button
+          type="button"
+          className="cr-refresh-btn"
+          data-testid="orch-refresh"
+          disabled={!connected || loading}
+          onClick={() => requestRuns()}
+        >
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </header>
+
+      {snapshot?.error && (
+        <p className="cr-error" data-testid="orch-runs-error">{snapshot.error.code}: {snapshot.error.message}</p>
+      )}
+
+      {runs.length === 0 && !snapshot?.error ? (
+        <p className="cr-dim" data-testid="orch-runs-empty">
+          {snapshot ? 'No orchestration runs yet. Start one to see the committee at work (S-3c adds the button; the WS API works today).' : loading ? 'Loading…' : 'Not loaded yet.'}
+        </p>
+      ) : (
+        <div className="cr-orch-layout">
+          <ul className="cr-orch-run-list" data-testid="orch-run-list">
+            {runs.map((r) => (
+              <RunRow key={r.runId} run={r} selected={r.runId === selectedRunId} onSelect={(id) => selectRun(id)} />
+            ))}
+          </ul>
+          {selectedRunId && <DetailPanel runId={selectedRunId} onOpenSession={(sessionId) => switchSession(sessionId)} />}
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

The visible half of S-3 (#6702): a **capability-gated "Runs" Control Room tab** consuming the S-3a data layer (#6747). Read-only observer surface — the mutating affordances (gate approve/deny, new-run modal, annotate) are **S-3c**.

## What's here

- **Registry**: the `runs` descriptor (`survey: true` — activation auto-fetches with the standard staleness guard) + a new optional `capability` field on the descriptor types.
- **Capability gating, fail-closed**: the tab renders in the strip (and deep-links/persisted tabs resolve to it) **only** while `serverCapabilities.orchestration === true` (auth_ok). A persisted `runs` tab on a feature-off daemon degrades to `repos` — no dead chrome. Implemented as a rawTab shadow + strip filter, so the registry stays static and the drift tests hold.
- **`OrchestrationRunsSection`**: runs list (status chip, pending-gate chip, server-authored spend — no client-side pricing math, AC-3) + detail panel:
  - status / budget meter / spend header + epic prompt
  - pending gates (display-only, S-3c hint) + resolved gates collapsed
  - subtask tree — role, status, spend, committee rounds, branch, per-node **Open session** (`switchSession`)
  - last-20 activity timeline, `resyncing…` chip during a seq-gap resync
  - **report markdown** + raw-JSON `<details>` at terminal state (the S-4 headline, visible in-product)

## Testing

13 new RTL cases (component states + capability gating incl. the persisted-tab fallback). The descriptor drift guard now grants all capabilities so it still covers every descriptor; gated-off behaviour has its own suite. **Full dashboard suite 4326/4326** · typecheck + production build clean.

Part of #6702. Next: S-3c (GateBanner approve/deny, NewRunModal, run actions, annotate, CR-tab gate badge).