### PR TITLE
feat(dashboard): orchestration run controls — gates, actions, annotate, new-run (S-3c)

### DIFF
--- a/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
@@ -13,10 +13,15 @@ const requestRunsMock = vi.fn(() => true)
 const requestDetailMock = vi.fn(() => true)
 const selectRunMock = vi.fn()
 const switchSessionMock = vi.fn()
+const startRunMock = vi.fn(() => 'orch-start-1')
+const gateResponseMock = vi.fn(() => 'orch-gate-1')
+const runActionMock = vi.fn(() => 'orch-action-1')
+const annotateMock = vi.fn(() => 'orch-annotate-1')
 let storeState: Record<string, unknown> = {}
 
 function resetStore(over: Record<string, unknown> = {}) {
   requestRunsMock.mockClear(); requestDetailMock.mockClear(); selectRunMock.mockClear(); switchSessionMock.mockClear()
+  startRunMock.mockClear(); gateResponseMock.mockClear(); runActionMock.mockClear(); annotateMock.mockClear()
   storeState = {
     connectionPhase: 'connected',
     orchestrationRuns: null,
@@ -25,11 +30,17 @@ function resetStore(over: Record<string, unknown> = {}) {
     orchestrationRunDetailLoading: new Set<string>(),
     orchestrationRunDetailErrors: {},
     orchestrationRunDetailStale: {},
+    orchestrationPendingActions: {},
+    orchestrationActionResults: {},
     selectedRunId: null,
     requestOrchestrationRuns: requestRunsMock,
     requestOrchestrationRunDetail: requestDetailMock,
     selectRun: selectRunMock,
     switchSession: switchSessionMock,
+    startOrchestrationRun: startRunMock,
+    sendOrchestrationGateResponse: gateResponseMock,
+    sendOrchestrationRunAction: runActionMock,
+    sendOrchestrationRunAnnotate: annotateMock,
     ...over,
   }
 }
@@ -167,5 +178,108 @@ describe('OrchestrationRunsSection (#6691 S-3b)', () => {
     resetStore({ orchestrationRuns: snapshot([]), orchestrationRunsLoading: true })
     rerender(<OrchestrationRunsSection />)
     expect((screen.getByTestId('orch-refresh') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  // ---- S-3c mutating affordances ----
+
+  it('GateBanner: approve sends a gate response; request-changes requires a note', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 3 } },
+    })
+    render(<OrchestrationRunsSection />)
+    // request-changes disabled until a note is typed
+    expect((screen.getByTestId('orch-gate-revise') as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(screen.getByTestId('orch-gate-approve'))
+    expect(gateResponseMock).toHaveBeenCalledWith('run_1', 'g1', 'approve', undefined, undefined)
+    // typing a note enables revise
+    fireEvent.change(screen.getByTestId('orch-gate-note'), { target: { value: 'tighten scope' } })
+    fireEvent.click(screen.getByTestId('orch-gate-revise'))
+    expect(gateResponseMock).toHaveBeenCalledWith('run_1', 'g1', 'revise', 'tighten scope', undefined)
+  })
+
+  it('GateBanner: a budget_overrun gate exposes the new-cap input on approve', () => {
+    const gate = { gateId: 'g2', runId: 'run_1', nodeId: null, kind: 'budget_overrun', status: 'pending', summary: 'Raise the cap?', openedAt: 1, resolvedAt: null, resolvedBy: null, budgetUsd: 10 }
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ gates: [gate] }), seq: 3 } },
+    })
+    render(<OrchestrationRunsSection />)
+    fireEvent.change(screen.getByTestId('orch-gate-budget-input'), { target: { value: '12.5' } })
+    fireEvent.click(screen.getByTestId('orch-gate-approve'))
+    expect(gateResponseMock).toHaveBeenCalledWith('run_1', 'g2', 'approve', undefined, 12.5)
+  })
+
+  it('RunControls: cancel confirms then sends; pause shown for an executing run', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'executing' }), seq: 3 } },
+    })
+    render(<OrchestrationRunsSection />)
+    expect(screen.getByTestId('orch-action-pause')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('orch-action-cancel'))
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(runActionMock).toHaveBeenCalledWith('run_1', 'cancel')
+    confirmSpy.mockRestore()
+  })
+
+  it('RunControls: resume shown for a paused run, hidden at terminal state', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary({ status: 'paused' })]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'paused' }), seq: 3 } },
+    })
+    const { rerender } = render(<OrchestrationRunsSection />)
+    fireEvent.click(screen.getByTestId('orch-action-resume'))
+    expect(runActionMock).toHaveBeenCalledWith('run_1', 'resume')
+    // terminal → no controls at all
+    resetStore({
+      orchestrationRuns: snapshot([runSummary({ status: 'completed' })]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'completed' }), seq: 9 } },
+    })
+    rerender(<OrchestrationRunsSection />)
+    expect(screen.queryByTestId('orch-run-controls')).toBeNull()
+  })
+
+  it('AnnotateForm: submits baseline + verdict quality at terminal state', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary({ status: 'completed' })]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'completed' }), seq: 9 } },
+    })
+    render(<OrchestrationRunsSection />)
+    fireEvent.change(screen.getByTestId('orch-annotate-baseline'), { target: { value: 'sess_mono' } })
+    fireEvent.change(screen.getByTestId('orch-annotate-quality'), { target: { value: 'excellent' } })
+    fireEvent.click(screen.getByTestId('orch-annotate-submit'))
+    expect(annotateMock).toHaveBeenCalledWith('run_1', { baselineSessionId: 'sess_mono', verdictQuality: 'excellent' })
+  })
+
+  it('NewRunModal: opens, requires cwd, and starts a preset run', () => {
+    resetStore({ orchestrationRuns: snapshot([]) })
+    render(<OrchestrationRunsSection />)
+    fireEvent.click(screen.getByTestId('orch-new-run'))
+    expect(screen.getByTestId('orch-new-run-modal')).toBeTruthy()
+    // submit disabled until cwd is provided
+    expect((screen.getByTestId('orch-new-submit') as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.change(screen.getByTestId('orch-new-cwd'), { target: { value: '/repo' } })
+    fireEvent.click(screen.getByTestId('orch-new-autoapprove'))
+    fireEvent.click(screen.getByTestId('orch-new-submit'))
+    expect(startRunMock).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/repo', preset: 'repo-audit', autoApprovePlan: true }))
+  })
+
+  it('NewRunModal: custom epic prompt path (no preset)', () => {
+    resetStore({ orchestrationRuns: snapshot([]) })
+    render(<OrchestrationRunsSection />)
+    fireEvent.click(screen.getByTestId('orch-new-run'))
+    fireEvent.change(screen.getByTestId('orch-new-preset'), { target: { value: '' } })
+    fireEvent.change(screen.getByTestId('orch-new-cwd'), { target: { value: '/repo' } })
+    fireEvent.change(screen.getByTestId('orch-new-epic'), { target: { value: 'Refactor the auth module' } })
+    fireEvent.click(screen.getByTestId('orch-new-submit'))
+    expect(startRunMock).toHaveBeenCalledWith(expect.objectContaining({ cwd: '/repo', epicPrompt: 'Refactor the auth module', preset: undefined }))
   })
 })

--- a/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
@@ -199,6 +199,40 @@ describe('OrchestrationRunsSection (#6691 S-3b)', () => {
     expect(gateResponseMock).toHaveBeenCalledWith('run_1', 'g1', 'revise', 'tighten scope', undefined)
   })
 
+  it('GateBanner: after a success ack the buttons lock and show "Response sent" (no duplicate response)', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail(), seq: 3 } },
+      // the ack already landed: pending cleared, result ok — the delta hasn't
+      // yet flipped gate.status off 'pending' (the banner is still mounted)
+      orchestrationPendingActions: {},
+      orchestrationActionResults: { 'orch-gate-1': { ok: true, error: null, at: 1 } },
+    })
+    gateResponseMock.mockReturnValue('orch-gate-1')
+    render(<OrchestrationRunsSection />)
+    fireEvent.click(screen.getByTestId('orch-gate-approve'))
+    expect(gateResponseMock).toHaveBeenCalledTimes(1)
+    // its result is now ok → buttons lock, "Response sent" shows, re-click is a no-op
+    expect(screen.getByTestId('orch-gate-sent')).toBeTruthy()
+    expect((screen.getByTestId('orch-gate-approve') as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(screen.getByTestId('orch-gate-approve'))
+    expect(gateResponseMock).toHaveBeenCalledTimes(1) // still 1 — locked
+  })
+
+  it('GateBanner: a 0 or empty budget is not sent as a cap', () => {
+    const gate = { gateId: 'g2', runId: 'run_1', nodeId: null, kind: 'budget_overrun', status: 'pending', summary: 'Raise?', openedAt: 1, resolvedAt: null, resolvedBy: null, budgetUsd: 10 }
+    resetStore({
+      orchestrationRuns: snapshot([runSummary()]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ gates: [gate] }), seq: 3 } },
+    })
+    render(<OrchestrationRunsSection />)
+    fireEvent.change(screen.getByTestId('orch-gate-budget-input'), { target: { value: '0' } })
+    fireEvent.click(screen.getByTestId('orch-gate-approve'))
+    expect(gateResponseMock).toHaveBeenCalledWith('run_1', 'g2', 'approve', undefined, undefined)
+  })
+
   it('GateBanner: a budget_overrun gate exposes the new-cap input on approve', () => {
     const gate = { gateId: 'g2', runId: 'run_1', nodeId: null, kind: 'budget_overrun', status: 'pending', summary: 'Raise the cap?', openedAt: 1, resolvedAt: null, resolvedBy: null, budgetUsd: 10 }
     resetStore({

--- a/packages/dashboard/src/components/OrchestrationRunsSection.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.tsx
@@ -20,7 +20,7 @@
  * ControlRoomView strip/deep-link layer — this component assumes it only
  * renders when the engine is enabled.
  */
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { RunSummary, RunDetail, RunGate, RunNode, RunTimelineEntry, RunUsage } from '@chroxy/protocol'
 import { formatGeneratedAgo } from './ControlRoomSection'
@@ -111,14 +111,79 @@ function NodeRow({ node, onOpenSession }: { node: RunNode; onOpenSession: (sessi
   )
 }
 
-/** Pending gates render display-only in S-3b; approve/deny controls are S-3c. */
+/** A resolved gate (or the summary line of a pending one) — display only. */
 function GateRow({ gate }: { gate: RunGate }) {
   return (
     <li className="cr-orch-gate" data-testid="orch-gate-row" data-gate-status={gate.status}>
       <span className="cr-tag" data-accent={gate.status === 'pending' ? 'warn' : 'neutral'}>{gate.kind.replace(/_/g, ' ')}</span>
       <span data-testid="orch-gate-summary">{gate.summary}</span>
       {gate.status !== 'pending' && <span className="cr-dim"> · {gate.status}{gate.resolvedBy ? ` by ${gate.resolvedBy}` : ''}</span>}
-      {gate.status === 'pending' && <span className="cr-dim" data-testid="orch-gate-pending-hint"> · awaiting your decision (respond in S-3c)</span>}
+    </li>
+  )
+}
+
+/**
+ * GateBanner (#6691 S-3c) — an actionable pending gate. Approve / Request
+ * changes (→ revise, requires a note) / Reject / Skip; a budget_overrun gate
+ * additionally takes a new-cap input on approve. The request is correlated by
+ * requestId; the row shows a pending → ack/error state inline.
+ */
+function GateBanner({ runId, gate }: { runId: string; gate: RunGate }) {
+  const send = useConnectionStore((s) => s.sendOrchestrationGateResponse)
+  const pending = useConnectionStore((s) => s.orchestrationPendingActions)
+  const results = useConnectionStore((s) => s.orchestrationActionResults)
+  const [note, setNote] = useState('')
+  const [budget, setBudget] = useState('')
+  const [reqId, setReqId] = useState<string | null>(null)
+
+  const inFlight = reqId != null && reqId in pending
+  const result = reqId != null ? results[reqId] : undefined
+  const isBudget = gate.kind === 'budget_overrun'
+
+  const respond = (decision: 'approve' | 'reject' | 'revise' | 'skip') => {
+    if (decision === 'revise' && !note.trim()) return // require a note to request changes
+    const budgetUsd = isBudget && decision === 'approve' && budget.trim() ? Number(budget) : undefined
+    const id = send(runId, gate.gateId, decision, note.trim() || undefined, Number.isFinite(budgetUsd) ? budgetUsd : undefined)
+    if (id) setReqId(id)
+  }
+
+  return (
+    <li className="cr-orch-gate-banner" data-testid="orch-gate-banner" data-gate-kind={gate.kind}>
+      <div className="cr-orch-gate-head">
+        <span className="cr-tag" data-accent="warn">{gate.kind.replace(/_/g, ' ')}</span>
+        <span data-testid="orch-gate-summary">{gate.summary}</span>
+      </div>
+      {gate.detail && <p className="cr-dim cr-orch-gate-detail">{gate.detail}</p>}
+      <textarea
+        className="cr-orch-gate-note"
+        data-testid="orch-gate-note"
+        placeholder="Note (required to request changes)"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        rows={2}
+        disabled={inFlight}
+      />
+      {isBudget && (
+        <input
+          className="cr-orch-gate-budget"
+          data-testid="orch-gate-budget-input"
+          type="number"
+          min="0"
+          step="0.01"
+          placeholder="New budget cap (USD) — optional"
+          value={budget}
+          onChange={(e) => setBudget(e.target.value)}
+          disabled={inFlight}
+        />
+      )}
+      <div className="cr-orch-gate-actions">
+        <button type="button" data-testid="orch-gate-approve" disabled={inFlight} onClick={() => respond('approve')}>Approve</button>
+        <button type="button" data-testid="orch-gate-revise" disabled={inFlight || !note.trim()} onClick={() => respond('revise')}>Request changes</button>
+        <button type="button" data-testid="orch-gate-reject" disabled={inFlight} onClick={() => respond('reject')}>Reject</button>
+        <button type="button" data-testid="orch-gate-skip" disabled={inFlight} onClick={() => respond('skip')}>Skip</button>
+      </div>
+      {inFlight && <span className="cr-dim" data-testid="orch-gate-pending">Sending…</span>}
+      {result && !result.ok && <span className="cr-error" data-testid="orch-gate-error">{result.error}</span>}
     </li>
   )
 }
@@ -158,10 +223,12 @@ function DetailPanel({ runId, onOpenSession }: { runId: string; onOpenSession: (
       </div>
       {run.epicPrompt && <p className="cr-dim cr-orch-epic" data-testid="orch-detail-epic">{run.epicPrompt}</p>}
 
+      <RunControls run={run} />
+
       {pendingGates.length > 0 && (
         <>
           <h5>Gates awaiting you</h5>
-          <ul className="cr-orch-gates" data-testid="orch-pending-gates">{pendingGates.map((g) => <GateRow key={g.gateId} gate={g} />)}</ul>
+          <ul className="cr-orch-gates" data-testid="orch-pending-gates">{pendingGates.map((g) => <GateBanner key={g.gateId} runId={run.runId} gate={g} />)}</ul>
         </>
       )}
 
@@ -203,6 +270,169 @@ function DetailPanel({ runId, onOpenSession }: { runId: string; onOpenSession: (
           </details>
         </>
       )}
+
+      {TERMINAL_STATUSES.has(run.status) && <AnnotateForm runId={run.runId} />}
+    </div>
+  )
+}
+
+/** Cancel/pause/resume controls, gated by the run's current status. */
+function RunControls({ run }: { run: RunDetail }) {
+  const send = useConnectionStore((s) => s.sendOrchestrationRunAction)
+  const pending = useConnectionStore((s) => s.orchestrationPendingActions)
+  const [reqId, setReqId] = useState<string | null>(null)
+  const inFlight = reqId != null && reqId in pending
+
+  if (TERMINAL_STATUSES.has(run.status)) return null
+  const act = (action: 'cancel' | 'pause' | 'resume') => {
+    if (action === 'cancel' && !window.confirm('Cancel this run? In-flight workers are stopped and their work auto-committed to their branches.')) return
+    const id = send(run.runId, action)
+    if (id) setReqId(id)
+  }
+  const canPause = run.status === 'executing'
+  const canResume = run.status === 'paused' || run.status === 'budget_paused' || run.status === 'suspended'
+  return (
+    <div className="cr-orch-run-controls" data-testid="orch-run-controls">
+      {canPause && <button type="button" data-testid="orch-action-pause" disabled={inFlight} onClick={() => act('pause')}>Pause</button>}
+      {canResume && <button type="button" data-testid="orch-action-resume" disabled={inFlight} onClick={() => act('resume')}>Resume</button>}
+      <button type="button" className="cr-danger-btn" data-testid="orch-action-cancel" disabled={inFlight} onClick={() => act('cancel')}>Cancel run</button>
+      {inFlight && <span className="cr-dim" data-testid="orch-action-pending">Sending…</span>}
+    </div>
+  )
+}
+
+/**
+ * AnnotateForm (#6691 S-3c) — the dogfood measurement affordance: attach a
+ * monolithic-baseline session id and/or a verdict-quality note to a terminal
+ * run. The report's delegated-vs-baseline comparison reads these.
+ */
+function AnnotateForm({ runId }: { runId: string }) {
+  const send = useConnectionStore((s) => s.sendOrchestrationRunAnnotate)
+  const pending = useConnectionStore((s) => s.orchestrationPendingActions)
+  const results = useConnectionStore((s) => s.orchestrationActionResults)
+  const [baseline, setBaseline] = useState('')
+  const [quality, setQuality] = useState('')
+  const [reqId, setReqId] = useState<string | null>(null)
+  const inFlight = reqId != null && reqId in pending
+  const result = reqId != null ? results[reqId] : undefined
+
+  const submit = () => {
+    if (!baseline.trim() && !quality.trim()) return
+    const id = send(runId, { baselineSessionId: baseline.trim() || undefined, verdictQuality: quality.trim() || undefined })
+    if (id) setReqId(id)
+  }
+  return (
+    <details className="cr-orch-annotate" data-testid="orch-annotate">
+      <summary className="cr-dim">Annotate for the cost comparison</summary>
+      <input
+        className="cr-orch-annotate-baseline"
+        data-testid="orch-annotate-baseline"
+        placeholder="Monolithic baseline session id"
+        value={baseline}
+        onChange={(e) => setBaseline(e.target.value)}
+        disabled={inFlight}
+      />
+      <textarea
+        className="cr-orch-annotate-quality"
+        data-testid="orch-annotate-quality"
+        placeholder="Verdict quality note (optional)"
+        value={quality}
+        onChange={(e) => setQuality(e.target.value)}
+        rows={2}
+        disabled={inFlight}
+      />
+      <button type="button" data-testid="orch-annotate-submit" disabled={inFlight || (!baseline.trim() && !quality.trim())} onClick={submit}>Save annotation</button>
+      {inFlight && <span className="cr-dim" data-testid="orch-annotate-pending">Saving…</span>}
+      {result && (result.ok
+        ? <span className="cr-ok" data-testid="orch-annotate-ok">Saved</span>
+        : <span className="cr-error" data-testid="orch-annotate-error">{result.error}</span>)}
+    </details>
+  )
+}
+
+/**
+ * NewRunModal (#6691 S-3c) — start an orchestration run. v1 exposes the
+ * repo-audit preset (or a free-form epic prompt), the working directory (cwd,
+ * re-validated server-side against the allowlist), an optional budget cap, and
+ * the auto-approve-plan opt-out. Role/model overrides use the daemon's
+ * configured defaults unless supplied.
+ */
+function NewRunModal({ onClose }: { onClose: () => void }) {
+  const start = useConnectionStore((s) => s.startOrchestrationRun)
+  const pending = useConnectionStore((s) => s.orchestrationPendingActions)
+  const results = useConnectionStore((s) => s.orchestrationActionResults)
+  const [preset, setPreset] = useState('repo-audit')
+  const [epicPrompt, setEpicPrompt] = useState('')
+  const [cwd, setCwd] = useState('')
+  const [title, setTitle] = useState('')
+  const [budget, setBudget] = useState('')
+  const [autoApprove, setAutoApprove] = useState(false)
+  const [reqId, setReqId] = useState<string | null>(null)
+
+  const inFlight = reqId != null && reqId in pending
+  const result = reqId != null ? results[reqId] : undefined
+  const usePreset = preset !== ''
+  const canSubmit = Boolean(cwd.trim()) && (usePreset || Boolean(epicPrompt.trim())) && !inFlight
+
+  // Close the modal once the start action succeeds (its ack cleared the pending
+  // entry and recorded ok:true); the list delta brings the new run in.
+  useEffect(() => {
+    if (result?.ok) onClose()
+  }, [result, onClose])
+
+  const submit = () => {
+    if (!canSubmit) return
+    const budgetUsd = budget.trim() ? Number(budget) : undefined
+    const id = start({
+      cwd: cwd.trim(),
+      preset: usePreset ? preset : undefined,
+      epicPrompt: !usePreset ? epicPrompt.trim() : undefined,
+      title: title.trim() || undefined,
+      budgetUsd: Number.isFinite(budgetUsd) ? budgetUsd : undefined,
+      autoApprovePlan: autoApprove,
+    })
+    if (id) setReqId(id)
+  }
+
+  return (
+    <div className="cr-orch-modal-backdrop" data-testid="orch-new-run-modal" role="dialog" aria-modal="true">
+      <div className="cr-orch-modal">
+        <h4>Start an orchestration run</h4>
+        <label className="cr-orch-field">
+          <span>Preset</span>
+          <select data-testid="orch-new-preset" value={preset} onChange={(e) => setPreset(e.target.value)} disabled={inFlight}>
+            <option value="repo-audit">repo-audit</option>
+            <option value="">Custom epic prompt…</option>
+          </select>
+        </label>
+        {!usePreset && (
+          <label className="cr-orch-field">
+            <span>Epic prompt</span>
+            <textarea data-testid="orch-new-epic" rows={3} value={epicPrompt} onChange={(e) => setEpicPrompt(e.target.value)} placeholder="Describe the epic to decompose…" disabled={inFlight} />
+          </label>
+        )}
+        <label className="cr-orch-field">
+          <span>Working directory</span>
+          <input data-testid="orch-new-cwd" value={cwd} onChange={(e) => setCwd(e.target.value)} placeholder="/path/to/repo" disabled={inFlight} />
+        </label>
+        <label className="cr-orch-field">
+          <span>Title (optional)</span>
+          <input data-testid="orch-new-title" value={title} onChange={(e) => setTitle(e.target.value)} disabled={inFlight} />
+        </label>
+        <label className="cr-orch-field">
+          <span>Budget cap USD (optional)</span>
+          <input data-testid="orch-new-budget" type="number" min="0" step="0.01" value={budget} onChange={(e) => setBudget(e.target.value)} disabled={inFlight} />
+        </label>
+        <label className="cr-orch-check">
+          <input type="checkbox" data-testid="orch-new-autoapprove" checked={autoApprove} onChange={(e) => setAutoApprove(e.target.checked)} disabled={inFlight} />
+          <span>Auto-approve plan (skips the epic-plan gate)</span>
+        </label>
+        {result && !result.ok && <p className="cr-error" data-testid="orch-new-error">{result.error}</p>}
+        <div className="cr-orch-modal-actions">
+          <button type="button" data-testid="orch-new-cancel" onClick={onClose} disabled={inFlight}>Cancel</button>
+          <button type="button" data-testid="orch-new-submit" onClick={submit} disabled={!canSubmit}>{inFlight ? 'Starting…' : 'Start run'}</button>
+        </div>
+      </div>
     </div>
   )
 }
@@ -221,6 +451,7 @@ export function OrchestrationRunsSection({ now = Date.now }: OrchestrationRunsSe
   const selectedRunId = useConnectionStore((s) => s.selectedRunId)
   const selectRun = useConnectionStore((s) => s.selectRun)
   const switchSession = useConnectionStore((s) => s.switchSession)
+  const [showNewRun, setShowNewRun] = useState(false)
 
   // Pull the selected run's detail when it isn't held yet (selection persists
   // across tab flips; the delta stream keeps a held detail current).
@@ -241,16 +472,29 @@ export function OrchestrationRunsSection({ now = Date.now }: OrchestrationRunsSe
           <h3>Runs</h3>
           {snapshot && <span className="cr-dim" data-testid="orch-generated-ago">{formatGeneratedAgo(Date.parse(snapshot.generatedAt), now())}</span>}
         </div>
-        <button
-          type="button"
-          className="cr-refresh-btn"
-          data-testid="orch-refresh"
-          disabled={!connected || loading}
-          onClick={() => requestRuns()}
-        >
-          {loading ? 'Refreshing…' : 'Refresh'}
-        </button>
+        <div className="cr-orch-header-actions">
+          <button
+            type="button"
+            className="cr-primary-btn"
+            data-testid="orch-new-run"
+            disabled={!connected}
+            onClick={() => setShowNewRun(true)}
+          >
+            New run
+          </button>
+          <button
+            type="button"
+            className="cr-refresh-btn"
+            data-testid="orch-refresh"
+            disabled={!connected || loading}
+            onClick={() => requestRuns()}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
       </header>
+
+      {showNewRun && <NewRunModal onClose={() => setShowNewRun(false)} />}
 
       {snapshot?.error && (
         <p className="cr-error" data-testid="orch-runs-error">{snapshot.error.code}: {snapshot.error.message}</p>

--- a/packages/dashboard/src/components/OrchestrationRunsSection.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.tsx
@@ -26,6 +26,7 @@ import type { RunSummary, RunDetail, RunGate, RunNode, RunTimelineEntry, RunUsag
 import { formatGeneratedAgo } from './ControlRoomSection'
 import { renderMarkdown } from '../lib/markdown'
 import { handleMarkdownLinkClick } from '../lib/links'
+import { Modal } from './Modal'
 
 /** Server-authored spend figure — never computed client-side (AC-3). */
 function usd(usage: RunUsage | undefined | null): string {
@@ -139,11 +140,19 @@ function GateBanner({ runId, gate }: { runId: string; gate: RunGate }) {
   const inFlight = reqId != null && reqId in pending
   const result = reqId != null ? results[reqId] : undefined
   const isBudget = gate.kind === 'budget_overrun'
+  // Lock once we've sent — inFlight OR a recorded success. Prevents a duplicate
+  // gate response in the ack→delta window (the ack clears `pending` and flips
+  // inFlight false BEFORE the run-detail delta flips gate.status and unmounts
+  // this banner, briefly re-enabling the buttons otherwise).
+  const locked = inFlight || result?.ok === true
 
   const respond = (decision: 'approve' | 'reject' | 'revise' | 'skip') => {
+    if (locked) return
     if (decision === 'revise' && !note.trim()) return // require a note to request changes
-    const budgetUsd = isBudget && decision === 'approve' && budget.trim() ? Number(budget) : undefined
-    const id = send(runId, gate.gateId, decision, note.trim() || undefined, Number.isFinite(budgetUsd) ? budgetUsd : undefined)
+    // budget_overrun raise: only a positive, finite figure is a real cap
+    const parsed = isBudget && decision === 'approve' && budget.trim() ? Number(budget) : undefined
+    const budgetUsd = Number.isFinite(parsed) && (parsed as number) > 0 ? parsed : undefined
+    const id = send(runId, gate.gateId, decision, note.trim() || undefined, budgetUsd)
     if (id) setReqId(id)
   }
 
@@ -168,7 +177,7 @@ function GateBanner({ runId, gate }: { runId: string; gate: RunGate }) {
           className="cr-orch-gate-budget"
           data-testid="orch-gate-budget-input"
           type="number"
-          min="0"
+          min="0.01"
           step="0.01"
           placeholder="New budget cap (USD) — optional"
           value={budget}
@@ -177,12 +186,13 @@ function GateBanner({ runId, gate }: { runId: string; gate: RunGate }) {
         />
       )}
       <div className="cr-orch-gate-actions">
-        <button type="button" data-testid="orch-gate-approve" disabled={inFlight} onClick={() => respond('approve')}>Approve</button>
-        <button type="button" data-testid="orch-gate-revise" disabled={inFlight || !note.trim()} onClick={() => respond('revise')}>Request changes</button>
-        <button type="button" data-testid="orch-gate-reject" disabled={inFlight} onClick={() => respond('reject')}>Reject</button>
-        <button type="button" data-testid="orch-gate-skip" disabled={inFlight} onClick={() => respond('skip')}>Skip</button>
+        <button type="button" data-testid="orch-gate-approve" disabled={locked} onClick={() => respond('approve')}>Approve</button>
+        <button type="button" data-testid="orch-gate-revise" disabled={locked || !note.trim()} onClick={() => respond('revise')}>Request changes</button>
+        <button type="button" data-testid="orch-gate-reject" disabled={locked} onClick={() => respond('reject')}>Reject</button>
+        <button type="button" data-testid="orch-gate-skip" disabled={locked} onClick={() => respond('skip')}>Skip</button>
       </div>
       {inFlight && <span className="cr-dim" data-testid="orch-gate-pending">Sending…</span>}
+      {result?.ok && <span className="cr-ok" data-testid="orch-gate-sent">Response sent</span>}
       {result && !result.ok && <span className="cr-error" data-testid="orch-gate-error">{result.error}</span>}
     </li>
   )
@@ -283,7 +293,9 @@ function RunControls({ run }: { run: RunDetail }) {
   const [reqId, setReqId] = useState<string | null>(null)
   const inFlight = reqId != null && reqId in pending
 
-  if (TERMINAL_STATUSES.has(run.status)) return null
+  // hidden at terminal state AND while already cancelling (the cancel is
+  // in-flight server-side — re-clicking is pointless)
+  if (TERMINAL_STATUSES.has(run.status) || run.status === 'cancelling') return null
   const act = (action: 'cancel' | 'pause' | 'resume') => {
     if (action === 'cancel' && !window.confirm('Cancel this run? In-flight workers are stopped and their work auto-committed to their branches.')) return
     const id = send(run.runId, action)
@@ -354,8 +366,10 @@ function AnnotateForm({ runId }: { runId: string }) {
  * NewRunModal (#6691 S-3c) — start an orchestration run. v1 exposes the
  * repo-audit preset (or a free-form epic prompt), the working directory (cwd,
  * re-validated server-side against the allowlist), an optional budget cap, and
- * the auto-approve-plan opt-out. Role/model overrides use the daemon's
- * configured defaults unless supplied.
+ * an auto-approve-plan toggle (off by default, so the user reviews the epic
+ * plan gate unless they opt in). Role/model overrides use the daemon's
+ * configured defaults unless supplied. Uses the shared Modal for focus-trap +
+ * Escape + accessible naming; closeOnBackdrop is false since it holds form input.
  */
 function NewRunModal({ onClose }: { onClose: () => void }) {
   const start = useConnectionStore((s) => s.startOrchestrationRun)
@@ -382,22 +396,23 @@ function NewRunModal({ onClose }: { onClose: () => void }) {
 
   const submit = () => {
     if (!canSubmit) return
-    const budgetUsd = budget.trim() ? Number(budget) : undefined
+    // only a positive, finite figure is a real cap (schema is z.number().positive())
+    const parsed = budget.trim() ? Number(budget) : undefined
+    const budgetUsd = Number.isFinite(parsed) && (parsed as number) > 0 ? parsed : undefined
     const id = start({
       cwd: cwd.trim(),
       preset: usePreset ? preset : undefined,
       epicPrompt: !usePreset ? epicPrompt.trim() : undefined,
       title: title.trim() || undefined,
-      budgetUsd: Number.isFinite(budgetUsd) ? budgetUsd : undefined,
+      budgetUsd,
       autoApprovePlan: autoApprove,
     })
     if (id) setReqId(id)
   }
 
   return (
-    <div className="cr-orch-modal-backdrop" data-testid="orch-new-run-modal" role="dialog" aria-modal="true">
-      <div className="cr-orch-modal">
-        <h4>Start an orchestration run</h4>
+    <Modal open onClose={onClose} title="Start an orchestration run" closeOnBackdrop={false}>
+      <div className="cr-orch-modal" data-testid="orch-new-run-modal">
         <label className="cr-orch-field">
           <span>Preset</span>
           <select data-testid="orch-new-preset" value={preset} onChange={(e) => setPreset(e.target.value)} disabled={inFlight}>
@@ -421,7 +436,7 @@ function NewRunModal({ onClose }: { onClose: () => void }) {
         </label>
         <label className="cr-orch-field">
           <span>Budget cap USD (optional)</span>
-          <input data-testid="orch-new-budget" type="number" min="0" step="0.01" value={budget} onChange={(e) => setBudget(e.target.value)} disabled={inFlight} />
+          <input data-testid="orch-new-budget" type="number" min="0.01" step="0.01" value={budget} onChange={(e) => setBudget(e.target.value)} disabled={inFlight} />
         </label>
         <label className="cr-orch-check">
           <input type="checkbox" data-testid="orch-new-autoapprove" checked={autoApprove} onChange={(e) => setAutoApprove(e.target.checked)} disabled={inFlight} />
@@ -433,7 +448,7 @@ function NewRunModal({ onClose }: { onClose: () => void }) {
           <button type="button" data-testid="orch-new-submit" onClick={submit} disabled={!canSubmit}>{inFlight ? 'Starting…' : 'Start run'}</button>
         </div>
       </div>
-    </div>
+    </Modal>
   )
 }
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1072,6 +1072,67 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ selectedRunId: runId });
   },
 
+  // #6691 (S-3c): the mutating orchestration actions. All wire-or-nothing —
+  // the pending entry is written ONLY after wsSend genuinely puts the message on
+  // the wire (never queued offline), keyed by the requestId the server echoes on
+  // the orchestration_action_ack / ORCHESTRATION_ACTION_FAILED session_error.
+  startOrchestrationRun: (opts: {
+    preset?: string; epicPrompt?: string; cwd: string; title?: string;
+    budgetUsd?: number; autoApprovePlan?: boolean;
+    roles?: Record<string, { provider: string; model: string }>;
+  }): string | null => {
+    const { socket } = get();
+    if (!opts.cwd || (!opts.preset && !opts.epicPrompt)) return null;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return null;
+    const requestId = `orch-start-${nextMessageId()}`;
+    const msg: Record<string, unknown> = { type: 'orchestration_run_start', cwd: opts.cwd, requestId };
+    if (opts.preset) msg.preset = opts.preset;
+    if (opts.epicPrompt) msg.epicPrompt = opts.epicPrompt;
+    if (opts.title) msg.title = opts.title;
+    if (typeof opts.budgetUsd === 'number') msg.budgetUsd = opts.budgetUsd;
+    if (typeof opts.autoApprovePlan === 'boolean') msg.autoApprovePlan = opts.autoApprovePlan;
+    if (opts.roles && Object.keys(opts.roles).length > 0) msg.roles = opts.roles;
+    if (!wsSend(socket, msg)) return null;
+    set({ orchestrationPendingActions: { ...get().orchestrationPendingActions, [requestId]: { kind: 'start', runId: '', at: Date.now() } } });
+    return requestId;
+  },
+
+  sendOrchestrationGateResponse: (runId: string, gateId: string, decision: 'approve' | 'reject' | 'revise' | 'skip', note?: string, budgetUsd?: number): string | null => {
+    const { socket } = get();
+    if (!runId || !gateId) return null;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return null;
+    const requestId = `orch-gate-${nextMessageId()}`;
+    const msg: Record<string, unknown> = { type: 'orchestration_gate_response', runId, gateId, decision, requestId };
+    if (note) msg.note = note;
+    if (typeof budgetUsd === 'number') msg.budgetUsd = budgetUsd;
+    if (!wsSend(socket, msg)) return null;
+    set({ orchestrationPendingActions: { ...get().orchestrationPendingActions, [requestId]: { kind: 'gate_response', runId, gateId, at: Date.now() } } });
+    return requestId;
+  },
+
+  sendOrchestrationRunAction: (runId: string, action: 'cancel' | 'pause' | 'resume'): string | null => {
+    const { socket } = get();
+    if (!runId) return null;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return null;
+    const requestId = `orch-action-${nextMessageId()}`;
+    if (!wsSend(socket, { type: 'orchestration_run_action', runId, action, requestId })) return null;
+    set({ orchestrationPendingActions: { ...get().orchestrationPendingActions, [requestId]: { kind: action, runId, at: Date.now() } } });
+    return requestId;
+  },
+
+  sendOrchestrationRunAnnotate: (runId: string, opts: { baselineSessionId?: string; verdictQuality?: string }): string | null => {
+    const { socket } = get();
+    if (!runId || (!opts.baselineSessionId && opts.verdictQuality === undefined)) return null;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return null;
+    const requestId = `orch-annotate-${nextMessageId()}`;
+    const msg: Record<string, unknown> = { type: 'orchestration_run_annotate', runId, requestId };
+    if (opts.baselineSessionId) msg.baselineSessionId = opts.baselineSessionId;
+    if (opts.verdictQuality !== undefined) msg.verdictQuality = opts.verdictQuality;
+    if (!wsSend(socket, msg)) return null;
+    set({ orchestrationPendingActions: { ...get().orchestrationPendingActions, [requestId]: { kind: 'annotate', runId, at: Date.now() } } });
+    return requestId;
+  },
+
   // #6543 (IDE P3 feature B): pull the full redacted tool input for a pending
   // permission so the prompt can render a per-hunk pre-write diff. The reply is a
   // single `permission_input` handled into `permissionInputs[requestId]`. Returns

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1089,7 +1089,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (opts.preset) msg.preset = opts.preset;
     if (opts.epicPrompt) msg.epicPrompt = opts.epicPrompt;
     if (opts.title) msg.title = opts.title;
-    if (typeof opts.budgetUsd === 'number') msg.budgetUsd = opts.budgetUsd;
+    // the wire schema is z.number().positive().finite() — only forward a real cap
+    if (typeof opts.budgetUsd === 'number' && Number.isFinite(opts.budgetUsd) && opts.budgetUsd > 0) msg.budgetUsd = opts.budgetUsd;
     if (typeof opts.autoApprovePlan === 'boolean') msg.autoApprovePlan = opts.autoApprovePlan;
     if (opts.roles && Object.keys(opts.roles).length > 0) msg.roles = opts.roles;
     if (!wsSend(socket, msg)) return null;
@@ -1104,7 +1105,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const requestId = `orch-gate-${nextMessageId()}`;
     const msg: Record<string, unknown> = { type: 'orchestration_gate_response', runId, gateId, decision, requestId };
     if (note) msg.note = note;
-    if (typeof budgetUsd === 'number') msg.budgetUsd = budgetUsd;
+    // wire schema is z.number().positive().finite() — only forward a real cap
+    if (typeof budgetUsd === 'number' && Number.isFinite(budgetUsd) && budgetUsd > 0) msg.budgetUsd = budgetUsd;
     if (!wsSend(socket, msg)) return null;
     set({ orchestrationPendingActions: { ...get().orchestrationPendingActions, [requestId]: { kind: 'gate_response', runId, gateId, at: Date.now() } } });
     return requestId;

--- a/packages/dashboard/src/store/orchestration-actions.test.ts
+++ b/packages/dashboard/src/store/orchestration-actions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Store-level tests for the S-3c mutating orchestration senders (#6691). The
+ * load-bearing contract: wire-or-nothing — nothing is put on the wire (and no
+ * pending entry is written) unless the socket is OPEN; each send tags a
+ * requestId and records a pending action keyed by it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'p', secretKey: 's' })),
+  deriveSharedKey: vi.fn(), encrypt: vi.fn(), decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'salt'), deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0, DIRECTION_SERVER: 1,
+}))
+vi.mock('./persistence', () => ({
+  loadPersistedState: vi.fn(() => null), loadSessionList: vi.fn(() => []),
+  loadAllSessionMessages: vi.fn(() => ({})), persistSessionMessages: vi.fn(),
+  persistViewMode: vi.fn(), persistActiveSession: vi.fn(), persistTerminalBuffer: vi.fn(),
+  persistSessionList: vi.fn(), persistActiveServer: vi.fn(), loadPersistedActiveServer: vi.fn(() => null),
+  clearPersistedState: vi.fn(), clearPersistedTerminalBuffer: vi.fn(), setServerScope: vi.fn(),
+  clearPersistedSession: vi.fn(),
+}))
+
+import { useConnectionStore } from './connection'
+
+function openSocket() {
+  const sent: unknown[] = []
+  const socket = { send: (d: string) => sent.push(JSON.parse(d)), readyState: WebSocket.OPEN, close: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as WebSocket
+  return { socket, sent }
+}
+
+describe('orchestration mutating senders (#6691 S-3c)', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({ socket: null, orchestrationPendingActions: {} })
+  })
+
+  it('returns null and sends nothing when the socket is closed', () => {
+    const s = useConnectionStore.getState()
+    expect(s.startOrchestrationRun({ cwd: '/repo', preset: 'repo-audit' })).toBeNull()
+    expect(s.sendOrchestrationGateResponse('r', 'g', 'approve')).toBeNull()
+    expect(s.sendOrchestrationRunAction('r', 'cancel')).toBeNull()
+    expect(s.sendOrchestrationRunAnnotate('r', { verdictQuality: 'x' })).toBeNull()
+    expect(Object.keys(useConnectionStore.getState().orchestrationPendingActions)).toHaveLength(0)
+  })
+
+  it('startOrchestrationRun needs a cwd AND (preset OR epicPrompt)', () => {
+    const { socket } = openSocket()
+    useConnectionStore.setState({ socket })
+    const s = useConnectionStore.getState()
+    expect(s.startOrchestrationRun({ cwd: '', preset: 'repo-audit' })).toBeNull()
+    expect(s.startOrchestrationRun({ cwd: '/repo' })).toBeNull() // neither preset nor epic
+  })
+
+  it('a successful start puts the message on the wire and records a pending entry', () => {
+    const { socket, sent } = openSocket()
+    useConnectionStore.setState({ socket })
+    const reqId = useConnectionStore.getState().startOrchestrationRun({ cwd: '/repo', preset: 'repo-audit', budgetUsd: 5, autoApprovePlan: true })
+    expect(reqId).toMatch(/^orch-start-/)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toMatchObject({ type: 'orchestration_run_start', cwd: '/repo', preset: 'repo-audit', budgetUsd: 5, autoApprovePlan: true, requestId: reqId })
+    const pending = useConnectionStore.getState().orchestrationPendingActions[reqId!]
+    expect(pending).toMatchObject({ kind: 'start' })
+  })
+
+  it('gate response / run action / annotate all tag a requestId + pending entry', () => {
+    const { socket, sent } = openSocket()
+    useConnectionStore.setState({ socket })
+    const s = useConnectionStore.getState()
+    const g = s.sendOrchestrationGateResponse('run_1', 'g1', 'approve', undefined, 12)
+    const a = s.sendOrchestrationRunAction('run_1', 'pause')
+    const n = s.sendOrchestrationRunAnnotate('run_1', { baselineSessionId: 'sess_x' })
+    expect(sent.map((m) => (m as { type: string }).type)).toEqual([
+      'orchestration_gate_response', 'orchestration_run_action', 'orchestration_run_annotate',
+    ])
+    expect(sent[0]).toMatchObject({ runId: 'run_1', gateId: 'g1', decision: 'approve', budgetUsd: 12 })
+    expect(sent[1]).toMatchObject({ runId: 'run_1', action: 'pause' })
+    expect(sent[2]).toMatchObject({ runId: 'run_1', baselineSessionId: 'sess_x' })
+    const pend = useConnectionStore.getState().orchestrationPendingActions
+    expect(pend[g!]).toMatchObject({ kind: 'gate_response' })
+    expect(pend[a!]).toMatchObject({ kind: 'pause' })
+    expect(pend[n!]).toMatchObject({ kind: 'annotate' })
+  })
+
+  it('annotate needs at least one of baseline / verdictQuality', () => {
+    const { socket } = openSocket()
+    useConnectionStore.setState({ socket })
+    expect(useConnectionStore.getState().sendOrchestrationRunAnnotate('run_1', {})).toBeNull()
+  })
+})

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1692,6 +1692,14 @@ export interface ConnectionState {
   requestOrchestrationRunDetail: (runId: string) => boolean;
   /** #6691 — select a run in the Runs tab (detail panel target). */
   selectRun: (runId: string | null) => void;
+  /** #6691 (S-3c) — start an orchestration run. Returns the requestId (or null if not sent). */
+  startOrchestrationRun: (opts: { preset?: string; epicPrompt?: string; cwd: string; title?: string; budgetUsd?: number; autoApprovePlan?: boolean; roles?: Record<string, { provider: string; model: string }> }) => string | null;
+  /** #6691 (S-3c) — respond to a run gate. Returns the requestId (or null if not sent). */
+  sendOrchestrationGateResponse: (runId: string, gateId: string, decision: 'approve' | 'reject' | 'revise' | 'skip', note?: string, budgetUsd?: number) => string | null;
+  /** #6691 (S-3c) — cancel/pause/resume a run. Returns the requestId (or null if not sent). */
+  sendOrchestrationRunAction: (runId: string, action: 'cancel' | 'pause' | 'resume') => string | null;
+  /** #6691 (S-3c) — annotate a run (baseline session + verdict quality). Returns the requestId (or null if not sent). */
+  sendOrchestrationRunAnnotate: (runId: string, opts: { baselineSessionId?: string; verdictQuality?: string }) => string | null;
   /** #6543 — pull the full redacted tool input for a pending permission (for the pre-write diff). */
   requestPermissionInput: (requestId: string) => boolean;
 


### PR DESCRIPTION
## Summary

The mutating half of S-3 (#6702) — the Runs tab becomes **actionable**, completing the epic's dashboard surface. Everything the S-4 dogfood needs to drive a run from the browser now exists.

## What's here

- **Store senders** (wire-or-nothing — the pending entry is written only after `wsSend` genuinely puts the message on the wire, keyed by the requestId the server echoes on the ack / `ORCHESTRATION_ACTION_FAILED`): `startOrchestrationRun`, `sendOrchestrationGateResponse`, `sendOrchestrationRunAction` (cancel/pause/resume), `sendOrchestrationRunAnnotate`.
- **GateBanner**: an actionable pending gate — **Approve** / **Request changes** (→ revise, requires a note) / **Reject** / **Skip**; a `budget_overrun` gate exposes a new-cap input on approve; inline pending → ack/error correlated by requestId.
- **RunControls**: cancel (with a confirm) / pause (executing) / resume (paused | budget_paused | suspended); hidden at terminal state.
- **AnnotateForm**: the dogfood measurement affordance — attach a monolithic **baseline session id** + verdict-quality note to a terminal run (the report's delegated-vs-baseline comparison reads these).
- **NewRunModal**: start a run — repo-audit preset **or** a custom epic prompt, cwd (re-validated server-side), title, budget cap, and the auto-approve-plan opt-out; closes on the success ack.

## Testing

8 new component RTL cases (gate approve / revise-needs-note / budget-cap, cancel-confirm, resume, terminal-hides-controls, annotate submit, new-run preset + custom-epic) + 5 store-sender cases (wire-or-nothing, requestId + pending-entry, validation). **Full dashboard suite 4339/4339** · typecheck + production build clean.

## Deferred

The Control Room tab **gate count badge** (Σ pendingUserGates on the tab button) → #6750. The run list already shows per-run "N gates awaiting you" chips and the detail panel has the actionable banner, so this is polish, and it touches `App.tsx`/`SessionBar.tsx` (separate surface).

Completes S-3. With this + M-4, the **S-4 dogfood** is fully drivable from the dashboard: New run → approve the plan gate → watch the committee → read the report → annotate with a baseline.