### PR TITLE
fix(server): protected-path floor for permission auto-approve (#6794)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -245,7 +245,9 @@ export class ClaudeByokSession extends BaseSession {
     // PermissionManager + event re-emission via the shared wiring (P2-9) so the
     // dashboard / mobile permission UI and the audit log work uniformly across
     // providers. ByokSession passes no pause/resume hooks (no result-timeout).
-    this._permissions = new PermissionManager({ log })
+    // #6794 — pass cwd so the protected-path floor can resolve relative tool
+    // targets (.git/.claude/.env…) against this session's working directory.
+    this._permissions = new PermissionManager({ log, cwd: this.cwd })
     wirePermissionManager(this, this._permissions)
 
     // Realpath cache used by the tool executor's path-safety check. One

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -111,7 +111,9 @@ export class CodexAppServerSession extends BaseSession {
     // bridge SdkSession uses. wirePermissionManager re-emits permission_request /
     // permission_resolved / user_question on THIS session and back-links
     // _pendingPermissions/_lastPermissionData for ws-permissions.js.
-    this._permissions = new PermissionManager({ log })
+    // #6794 — pass cwd so the protected-path floor can resolve relative tool
+    // targets (.git/.claude/.env…) against this session's working directory.
+    this._permissions = new PermissionManager({ log, cwd: this.cwd })
     wirePermissionManager(this, this._permissions, {
       onRequest: () => this._pauseResultTimeoutForPermission(),
       onResolved: () => this._resumeResultTimeoutForPermission(),

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -108,7 +108,9 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
  * worktree that itself lives under a real `.claude/` dir writing to
  * `packages/…` is NOT floored, because the `.claude` segment is above cwd.
  *
- * Segment rules (a match on ANY segment floors the write):
+ * Segment rules (a match on ANY segment floors the write; segments are
+ * lowercased first so `.GIT`/`.Env.local` can't evade the floor on the
+ * case-insensitive filesystems where they alias the real paths):
  *   - a segment in {@link PROTECTED_DIR_SEGMENTS} (`.git` / `.claude` / `.vscode`)
  *   - a `.config` segment immediately followed by `git` (the XDG git-config dir)
  *   - a segment that is `.env` or starts with `.env.` (`.env` / `.env.local` / …)
@@ -138,7 +140,14 @@ export function isProtectedPathTarget(input, cwd) {
   // resolve() absorbs absolute paths, a leading `./`, and `..` traversal; the
   // relative path is what we segment-match so cwd's own name can't false-match.
   const rel = relative(base, resolve(base, target))
-  const segments = rel.split(sep).filter((s) => s.length > 0 && s !== '..')
+  // Lowercase every segment before matching: on case-insensitive filesystems
+  // (macOS APFS, Windows) `.GIT/config` IS `.git/config`, so a case-sensitive
+  // match would let case variants evade the floor. Over-flooring a genuinely
+  // distinct `.GIT` on case-sensitive Linux is fine — the floor only forces a
+  // prompt, never denies.
+  const segments = rel.split(sep)
+    .filter((s) => s.length > 0 && s !== '..')
+    .map((s) => s.toLowerCase())
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i]
     if (PROTECTED_DIR_SEGMENTS.has(seg)) return true

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -98,10 +98,12 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
 }
 
 /**
- * #6794 — does this tool input target a protected path? Extracts the first
- * present {@link PROTECTED_PATH_INPUT_FIELDS} value, resolves it against the
- * session cwd (so absolute paths, a leading `./`, and `..` traversal all
- * normalize), then tests the path RELATIVE to cwd segment-by-segment.
+ * #6794 — does this tool input target a protected path? Inspects EVERY present
+ * {@link PROTECTED_PATH_INPUT_FIELDS} value (a benign `file_path` must not
+ * shadow a protected `path`), resolves each against the session cwd (so
+ * absolute paths, a leading `./`, and `..` traversal all normalize), then
+ * tests the path RELATIVE to cwd segment-by-segment. ANY protected field
+ * floors the input.
  *
  * Matching relative-to-cwd (not the raw absolute path) is deliberate: the
  * session's OWN location can never trigger a false positive — e.g. a git
@@ -128,31 +130,26 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
  */
 export function isProtectedPathTarget(input, cwd) {
   if (!input || typeof input !== 'object') return false
-  let target
-  for (const field of PROTECTED_PATH_INPUT_FIELDS) {
-    if (typeof input[field] === 'string' && input[field].length > 0) {
-      target = input[field]
-      break
-    }
-  }
-  if (!target) return false
   const base = (typeof cwd === 'string' && cwd.length > 0) ? cwd : process.cwd()
-  // resolve() absorbs absolute paths, a leading `./`, and `..` traversal; the
-  // relative path is what we segment-match so cwd's own name can't false-match.
-  const rel = relative(base, resolve(base, target))
-  // Lowercase every segment before matching: on case-insensitive filesystems
-  // (macOS APFS, Windows) `.GIT/config` IS `.git/config`, so a case-sensitive
-  // match would let case variants evade the floor. Over-flooring a genuinely
-  // distinct `.GIT` on case-sensitive Linux is fine — the floor only forces a
-  // prompt, never denies.
-  const segments = rel.split(sep)
-    .filter((s) => s.length > 0 && s !== '..')
-    .map((s) => s.toLowerCase())
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i]
-    if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
-    if (seg === '.env' || seg.startsWith('.env.')) return true
-    if (seg === '.config' && segments[i + 1] === 'git') return true
+  for (const field of PROTECTED_PATH_INPUT_FIELDS) {
+    if (typeof input[field] !== 'string' || input[field].length === 0) continue
+    // resolve() absorbs absolute paths, a leading `./`, and `..` traversal; the
+    // relative path is what we segment-match so cwd's own name can't false-match.
+    const rel = relative(base, resolve(base, input[field]))
+    // Lowercase every segment before matching: on case-insensitive filesystems
+    // (macOS APFS, Windows) `.GIT/config` IS `.git/config`, so a case-sensitive
+    // match would let case variants evade the floor. Over-flooring a genuinely
+    // distinct `.GIT` on case-sensitive Linux is fine — the floor only forces a
+    // prompt, never denies.
+    const segments = rel.split(sep)
+      .filter((s) => s.length > 0 && s !== '..')
+      .map((s) => s.toLowerCase())
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i]
+      if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
+      if (seg === '.env' || seg.startsWith('.env.')) return true
+      if (seg === '.config' && segments[i + 1] === 'git') return true
+    }
   }
   return false
 }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
+import { resolve, relative, sep } from 'node:path'
 import { createLogger } from './logger.js'
 // #6038: the SDK/TUI permission path broadcasts to clients too, so it must apply
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
@@ -24,6 +25,25 @@ export const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 
 // `mcp_elicitation` is a codex MCP connector eliciting the user (#6635, e.g. a
 // GitHub connector write approval) — a connector action must always prompt too.
 export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch', 'shell', 'request_permissions', 'mcp_elicitation'])
+
+// #6794 — hardcoded protected-path floor. Even under lenient settings (auto /
+// acceptEdits / a broad `allow` rule) Chroxy must not SILENTLY auto-approve a
+// path-carrying tool aimed at a repo-control / agent-config directory or a
+// secret file. This mirrors Claude Code's own "always ask" floor (desktop
+// parity): the target simply falls through to the interactive prompt instead
+// of short-circuiting — a floor, never a hard deny.
+//
+// Protected DIRECTORY segment names, matched at any depth relative to the
+// session cwd. `.config/git` (the XDG git-config dir) is a two-segment
+// sequence handled separately in isProtectedPathTarget, not a bare segment.
+const PROTECTED_DIR_SEGMENTS = new Set(['.git', '.claude', '.vscode'])
+
+// Tool-input fields that name a filesystem target. Presence of one is what
+// makes a tool "path-carrying" for the floor (Write/Edit → file_path,
+// NotebookEdit → notebook_path, Read/Glob/Grep → file_path/path). A tool with
+// none of these (Bash, Task, WebFetch, WebSearch) cannot be floored here —
+// command-shaped access is out of scope for a path floor.
+const PROTECTED_PATH_INPUT_FIELDS = ['file_path', 'path', 'notebook_path']
 
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000
@@ -78,6 +98,57 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
 }
 
 /**
+ * #6794 — does this tool input target a protected path? Extracts the first
+ * present {@link PROTECTED_PATH_INPUT_FIELDS} value, resolves it against the
+ * session cwd (so absolute paths, a leading `./`, and `..` traversal all
+ * normalize), then tests the path RELATIVE to cwd segment-by-segment.
+ *
+ * Matching relative-to-cwd (not the raw absolute path) is deliberate: the
+ * session's OWN location can never trigger a false positive — e.g. a git
+ * worktree that itself lives under a real `.claude/` dir writing to
+ * `packages/…` is NOT floored, because the `.claude` segment is above cwd.
+ *
+ * Segment rules (a match on ANY segment floors the write):
+ *   - a segment in {@link PROTECTED_DIR_SEGMENTS} (`.git` / `.claude` / `.vscode`)
+ *   - a `.config` segment immediately followed by `git` (the XDG git-config dir)
+ *   - a segment that is `.env` or starts with `.env.` (`.env` / `.env.local` / …)
+ *
+ * A target ABOVE cwd yields leading `..` segments; those are dropped before the
+ * scan, so the real names beyond them are still checked (an out-of-cwd `.git`
+ * still floors — conservative, and the floor only forces a prompt). Returns
+ * false for any missing / non-string path field, so a command-shaped tool
+ * (Bash, WebFetch) is never floored. Pure + side-effect-free (string ops only —
+ * no regex, so the `.env.*` match can't be mangled by later edits).
+ *
+ * @param {object} input  the tool input
+ * @param {string} [cwd]  the session cwd (falls back to process.cwd())
+ * @returns {boolean}
+ */
+export function isProtectedPathTarget(input, cwd) {
+  if (!input || typeof input !== 'object') return false
+  let target
+  for (const field of PROTECTED_PATH_INPUT_FIELDS) {
+    if (typeof input[field] === 'string' && input[field].length > 0) {
+      target = input[field]
+      break
+    }
+  }
+  if (!target) return false
+  const base = (typeof cwd === 'string' && cwd.length > 0) ? cwd : process.cwd()
+  // resolve() absorbs absolute paths, a leading `./`, and `..` traversal; the
+  // relative path is what we segment-match so cwd's own name can't false-match.
+  const rel = relative(base, resolve(base, target))
+  const segments = rel.split(sep).filter((s) => s.length > 0 && s !== '..')
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
+    if (seg === '.env' || seg.startsWith('.env.')) return true
+    if (seg === '.config' && segments[i + 1] === 'git') return true
+  }
+  return false
+}
+
+/**
  * Manages in-process permission requests for SDK-style sessions.
  *
  * Handles the lifecycle of permission prompts:
@@ -93,13 +164,17 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
  *   user_question       { toolUseId, questions }
  */
 export class PermissionManager extends EventEmitter {
-  constructor({ timeoutMs, log, maxPendingPermissions } = {}) {
+  constructor({ timeoutMs, log, maxPendingPermissions, cwd } = {}) {
     super()
     this._timeoutMs = timeoutMs || DEFAULT_TIMEOUT_MS
     this._log = log || console
     // #6448 — bound on concurrent pending permissions; injectable so the cap is
     // testable without minting 1000 real requests.
     this._maxPendingPermissions = maxPendingPermissions || MAX_PENDING_PERMISSIONS
+    // #6794 — session cwd anchors the protected-path floor (see
+    // isProtectedPathTarget). Optional: when unset the floor resolves targets
+    // against process.cwd(), which still catches relative protected paths.
+    this._cwd = (typeof cwd === 'string' && cwd.length > 0) ? cwd : null
 
     this._pendingPermissions = new Map() // requestId -> { resolve, input }
     this._permissionTimers = new Map()   // requestId -> timer
@@ -214,20 +289,33 @@ export class PermissionManager extends EventEmitter {
       return this._handleAskUserQuestion(input, signal)
     }
 
+    // #6794 — protected-path floor. A path-carrying tool aimed at a protected
+    // path (.git/.claude/.vscode/.config/git/.env*) must NOT be silently
+    // auto-approved by auto mode, a broad `allow` rule, or acceptEdits — mirror
+    // Claude Code's "always ask" floor and let it fall through to the prompt.
+    // This is a FLOOR, not a hard deny: a lenient mode simply stops
+    // short-circuiting for these paths. A `deny` rule still denies (the floor
+    // never widens access), and if the prompt path then auto-denies on
+    // no-client/timeout, that is the existing fail-closed behavior.
+    const protectedTarget = isProtectedPathTarget(input, this._cwd)
+
     // 'auto' (= SDK bypassPermissions) short-circuit: approve every tool
     // call without consulting rules or emitting a prompt. SdkSession also
     // skips canUseTool registration when starting a turn in auto mode, but
     // a turn that started in another mode keeps its callback alive for the
     // whole turn — without this guard, flipping to auto mid-turn (#3729)
     // still emits prompts because session rules and the prompt path run
-    // before any mode check.
-    if (permissionMode === 'auto') {
+    // before any mode check. #6794: the floor takes precedence — a protected
+    // target still prompts even under auto.
+    if (permissionMode === 'auto' && !protectedTarget) {
       return Promise.resolve({ behavior: 'allow', updatedInput: input || {} })
     }
 
-    // Session rules: check before acceptEdits and the prompt path
+    // Session rules: check before acceptEdits and the prompt path. #6794: a
+    // protected target skips the `allow` branch (fall through to the prompt);
+    // a `deny` rule still denies.
     const ruleDecision = this._matchesRule(toolName)
-    if (ruleDecision !== null) {
+    if (ruleDecision !== null && !(protectedTarget && ruleDecision === 'allow')) {
       this._logInfo(`Permission rule matched for ${toolName}: ${ruleDecision}`)
       if (ruleDecision === 'allow') {
         return Promise.resolve({ behavior: 'allow', updatedInput: input || {} })
@@ -235,8 +323,9 @@ export class PermissionManager extends EventEmitter {
       return Promise.resolve({ behavior: 'deny', message: 'Denied by session rule' })
     }
 
-    // acceptEdits: auto-approve file operations, prompt for everything else
-    if (permissionMode === 'acceptEdits' && ACCEPT_EDITS_TOOLS.has(toolName)) {
+    // acceptEdits: auto-approve file operations, prompt for everything else.
+    // #6794: the floor takes precedence — a protected target still prompts.
+    if (permissionMode === 'acceptEdits' && ACCEPT_EDITS_TOOLS.has(toolName) && !protectedTarget) {
       return Promise.resolve({ behavior: 'allow', updatedInput: input || {} })
     }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -367,7 +367,9 @@ export class SdkSession extends BaseSession {
     // a pending prompt silently goes unresponsive after 5 min (#2831). The
     // pause uses a reference count so concurrent prompts keep the timer
     // suspended until the last one resolves. (Shared wiring extracted in P2-9.)
-    this._permissions = new PermissionManager({ log })
+    // #6794 — pass cwd so the protected-path floor can resolve relative tool
+    // targets (.git/.claude/.env…) against this session's working directory.
+    this._permissions = new PermissionManager({ log, cwd: this.cwd })
     wirePermissionManager(this, this._permissions, {
       onRequest: () => this._pauseResultTimeoutForPermission(),
       onResolved: () => this._resumeResultTimeoutForPermission(),

--- a/packages/server/tests/permission-manager-protected-path-floor.test.js
+++ b/packages/server/tests/permission-manager-protected-path-floor.test.js
@@ -236,6 +236,16 @@ describe('isProtectedPathTarget (#6794)', () => {
     { notebook_path: '.git/x.ipynb' },
     { path: '.claude/foo' },
     { file_path: `${cwd}/.git/HEAD` },
+    // Case variants — on case-insensitive filesystems (macOS APFS, Windows)
+    // these resolve to the SAME protected paths, so matching must be
+    // case-insensitive. Over-flooring a genuinely-distinct `.GIT` on
+    // case-sensitive Linux is acceptable: the floor only forces a prompt.
+    { file_path: '.GIT/config' },
+    { file_path: '.CLAUDE/x' },
+    { file_path: '.VSCode/x' },
+    { file_path: '.ENV' },
+    { file_path: '.Env.local' },
+    { file_path: '.Config/Git/config' },
   ]
   for (const input of floored) {
     it(`floors ${JSON.stringify(input)}`, () => {

--- a/packages/server/tests/permission-manager-protected-path-floor.test.js
+++ b/packages/server/tests/permission-manager-protected-path-floor.test.js
@@ -1,0 +1,276 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { PermissionManager, isProtectedPathTarget } from '../src/permission-manager.js'
+
+/**
+ * #6794 — hardcoded protected-path floor.
+ *
+ * Chroxy's in-process permission engine scoped auto-approve by tool NAME only,
+ * so a broad `allow Write` rule / acceptEdits / auto mode would silently write
+ * to .git/, .claude/, .vscode/, .config/git/, or .env*. The floor mirrors
+ * Claude Code's "always ask" floor: a path-carrying tool aimed at a protected
+ * path skips every auto-approve short-circuit and falls through to the normal
+ * interactive prompt (a floor, NOT a hard deny — a `deny` rule still denies).
+ *
+ * These tests exercise handlePermission (the shared entry every in-process
+ * provider — SDK / BYOK / Codex — routes through) and the exported pure
+ * matcher directly. Paths are synthetic (string ops only — no fs), so a fixed
+ * cwd needs no on-disk directory.
+ */
+
+const silentLog = { info() {}, warn() {} }
+const CWD = '/work/project'
+
+function createManager(opts = {}) {
+  return new PermissionManager({ log: silentLog, cwd: CWD, ...opts })
+}
+
+describe('protected-path floor (#6794)', () => {
+  let pm
+
+  beforeEach(() => {
+    pm = createManager()
+  })
+
+  afterEach(() => {
+    pm.destroy()
+  })
+
+  // -- Acceptance criteria: broad settings must NOT auto-approve protected paths --
+
+  describe('does not auto-approve protected paths under lenient settings', () => {
+    it('(a) allow Write rule + write to .git/config falls through to the prompt', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.setRules([{ tool: 'Write', decision: 'allow' }])
+
+      const promise = pm.handlePermission('Write', { file_path: '.git/config' }, null, 'approve')
+      assert.equal(events.length, 1, 'protected write must emit a prompt, not auto-allow')
+      assert.equal(events[0].tool, 'Write')
+
+      // Resolve so the pending promise/timer drains for a clean teardown.
+      pm.respondToPermission(events[0].requestId, 'deny')
+      const result = await promise
+      assert.equal(result.behavior, 'deny')
+    })
+
+    it('(b) acceptEdits + Edit to .claude/settings.local.json falls through to the prompt', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission(
+        'Edit',
+        { file_path: '.claude/settings.local.json' },
+        null,
+        'acceptEdits',
+      )
+      assert.equal(events.length, 1, 'protected edit must prompt even in acceptEdits')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+
+    it('(c) auto mode + Write to .env falls through to the prompt', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission('Write', { file_path: '.env' }, null, 'auto')
+      assert.equal(events.length, 1, 'protected write must prompt even in auto/bypass mode')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+  })
+
+  // -- Negative controls: benign paths keep short-circuiting --
+
+  describe('still auto-approves non-protected paths', () => {
+    it('(d) allow Write rule + write to src/foo.js is auto-approved (no prompt)', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.setRules([{ tool: 'Write', decision: 'allow' }])
+
+      const result = await pm.handlePermission('Write', { file_path: 'src/foo.js' }, null, 'approve')
+      assert.equal(result.behavior, 'allow')
+      assert.equal(events.length, 0, 'benign write must not prompt')
+    })
+
+    it('(d) .github/workflows/x.yml must NOT match .git/ (auto-approved)', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.setRules([{ tool: 'Write', decision: 'allow' }])
+
+      const result = await pm.handlePermission(
+        'Write',
+        { file_path: '.github/workflows/x.yml' },
+        null,
+        'approve',
+      )
+      assert.equal(result.behavior, 'allow', '.github must not be confused with .git')
+      assert.equal(events.length, 0)
+    })
+
+    it('acceptEdits still auto-approves a benign Edit', async () => {
+      const result = await pm.handlePermission('Edit', { file_path: 'src/app/main.js' }, null, 'acceptEdits')
+      assert.equal(result.behavior, 'allow')
+    })
+
+    it('auto mode still auto-approves a benign Write', async () => {
+      const result = await pm.handlePermission('Write', { file_path: 'docs/readme.md' }, null, 'auto')
+      assert.equal(result.behavior, 'allow')
+    })
+  })
+
+  // -- Traversal + absolute paths --
+
+  describe('normalization / traversal', () => {
+    it('(e) sub/../.git/config is floored (traversal collapses to .git/config)', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.setRules([{ tool: 'Write', decision: 'allow' }])
+
+      const promise = pm.handlePermission('Write', { file_path: 'sub/../.git/config' }, null, 'approve')
+      assert.equal(events.length, 1, 'traversal into .git must be floored')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+
+    it('a leading ./ into .claude is floored', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission('Write', { file_path: './.claude/x.json' }, null, 'auto')
+      assert.equal(events.length, 1)
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+
+    it('an absolute path INSIDE cwd targeting .claude is floored', async () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission(
+        'Write',
+        { file_path: `${CWD}/.claude/settings.local.json` },
+        null,
+        'auto',
+      )
+      assert.equal(events.length, 1)
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+  })
+
+  // -- deny rules still deny (the floor never widens access) --
+
+  it('a deny rule on a protected path still denies (floor does not turn deny into a prompt)', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+    pm.setRules([{ tool: 'Write', decision: 'deny' }])
+
+    const result = await pm.handlePermission('Write', { file_path: '.git/config' }, null, 'approve')
+    assert.equal(result.behavior, 'deny')
+    assert.equal(result.message, 'Denied by session rule')
+    assert.equal(events.length, 0, 'a deny rule short-circuits without a prompt')
+  })
+
+  // -- NotebookEdit (notebook_path) + generic path-field coverage --
+
+  it('NotebookEdit targeting .git via notebook_path is floored', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const promise = pm.handlePermission('NotebookEdit', { notebook_path: '.git/nb.ipynb' }, null, 'acceptEdits')
+    assert.equal(events.length, 1)
+    pm.respondToPermission(events[0].requestId, 'deny')
+    await promise
+  })
+
+  it('a read of .env (auto-read secret parity) is floored under acceptEdits', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const promise = pm.handlePermission('Read', { file_path: '.env.production' }, null, 'acceptEdits')
+    assert.equal(events.length, 1, '.env.production read must prompt, not auto-approve')
+    pm.respondToPermission(events[0].requestId, 'deny')
+    await promise
+  })
+
+  // -- The worktree false-positive guard (relative-to-cwd matching) --
+
+  it('a session whose OWN cwd lives under a .claude/ dir does not false-match benign writes', async () => {
+    // e.g. an agent git worktree at /home/me/.claude/worktrees/agent-x — a
+    // write to packages/server/foo.js must NOT be floored just because the
+    // session's cwd contains a `.claude` segment (matched relative to cwd).
+    const worktreePm = createManager({ cwd: '/home/me/.claude/worktrees/agent-x' })
+    try {
+      const result = await worktreePm.handlePermission(
+        'Write',
+        { file_path: 'packages/server/foo.js' },
+        null,
+        'auto',
+      )
+      assert.equal(result.behavior, 'allow', 'cwd-internal .claude must not floor a benign write')
+    } finally {
+      worktreePm.destroy()
+    }
+  })
+})
+
+// -- The exported pure matcher, exercised directly --
+
+describe('isProtectedPathTarget (#6794)', () => {
+  const cwd = '/work/project'
+
+  const floored = [
+    { file_path: '.git/config' },
+    { file_path: 'sub/dir/.git/config' },
+    { file_path: '.claude/settings.local.json' },
+    { file_path: '.vscode/settings.json' },
+    { file_path: '.config/git/config' },
+    { file_path: '.env' },
+    { file_path: '.env.local' },
+    { file_path: '.env.production' },
+    { file_path: 'sub/../.git/config' },
+    { notebook_path: '.git/x.ipynb' },
+    { path: '.claude/foo' },
+    { file_path: `${cwd}/.git/HEAD` },
+  ]
+  for (const input of floored) {
+    it(`floors ${JSON.stringify(input)}`, () => {
+      assert.equal(isProtectedPathTarget(input, cwd), true)
+    })
+  }
+
+  const notFloored = [
+    { file_path: 'src/foo.js' },
+    { file_path: '.github/workflows/ci.yml' }, // .github != .git
+    { file_path: '.config/other/settings' }, // .config/git only, not all of .config
+    { file_path: 'foo.env' }, // trailing .env is not a .env file
+    { file_path: '.environment/config' }, // .env* prefix must be exactly .env or .env.
+    { file_path: '.gitignore' }, // a file named .gitignore is not the .git dir
+    { file_path: 'docs/readme.md' },
+    { command: 'rm -rf /' }, // no path field → never floored (command-shaped)
+    {}, // empty input
+    null, // non-object
+    { file_path: '' }, // empty path
+  ]
+  for (const input of notFloored) {
+    it(`does not floor ${JSON.stringify(input)}`, () => {
+      assert.equal(isProtectedPathTarget(input, cwd), false)
+    })
+  }
+
+  it('resolves relative to the given cwd, not the process cwd', () => {
+    // Same relative target; cwd only affects absolute-path resolution + the
+    // relative-segment framing, so `.git/config` floors under any cwd.
+    assert.equal(isProtectedPathTarget({ file_path: '.git/config' }, '/a/b'), true)
+    assert.equal(isProtectedPathTarget({ file_path: '.git/config' }, '/x/y/z'), true)
+  })
+
+  it('a cwd that itself sits under a protected segment does not false-match', () => {
+    // cwd = .../.claude/... ; a benign relative write stays unfloored.
+    assert.equal(isProtectedPathTarget({ file_path: 'src/a.js' }, '/home/me/.claude/wt/agent'), false)
+  })
+})

--- a/packages/server/tests/permission-manager-protected-path-floor.test.js
+++ b/packages/server/tests/permission-manager-protected-path-floor.test.js
@@ -246,6 +246,11 @@ describe('isProtectedPathTarget (#6794)', () => {
     { file_path: '.ENV' },
     { file_path: '.Env.local' },
     { file_path: '.Config/Git/config' },
+    // Multi-field inputs — EVERY present path field is inspected, so a benign
+    // field can't shadow a protected one (and order doesn't matter).
+    { file_path: 'src/ok.js', path: '.git/config' },
+    { file_path: '.git/config', path: 'src/ok.js' },
+    { file_path: 'src/ok.js', notebook_path: '.env' },
   ]
   for (const input of floored) {
     it(`floors ${JSON.stringify(input)}`, () => {
@@ -261,6 +266,7 @@ describe('isProtectedPathTarget (#6794)', () => {
     { file_path: '.environment/config' }, // .env* prefix must be exactly .env or .env.
     { file_path: '.gitignore' }, // a file named .gitignore is not the .git dir
     { file_path: 'docs/readme.md' },
+    { file_path: 'src/a.js', path: 'src/b.js', notebook_path: 'nb/c.ipynb' }, // all-benign multi-field
     { command: 'rm -rf /' }, // no path field → never floored (command-shaped)
     {}, // empty input
     null, // non-object


### PR DESCRIPTION
## Problem

Chroxy's in-process permission engine scoped auto-approve by **tool name only** — it never inspected the tool's target path. A session rule like `{ tool: 'Write', decision: 'allow' }` (or `acceptEdits` / `auto` mode) therefore auto-approved writes to **any** in-workspace path, including sensitive ones like `.git/`, `.claude/`, `.vscode/`, `.config/git/`, and `.env*`. There was no hardcoded protected-path floor these lenient settings couldn't cross (`permission-manager.js` `_matchesRule` compared `rule.tool === toolName` only; `acceptEdits`/`auto` approved any path).

## Approach

Add a hardcoded **protected-path floor** in `PermissionManager.handlePermission`, checked **before** the auto-mode, session-rule, and acceptEdits short-circuits. It mirrors Claude Code's own "always ask" floor (desktop parity): a path-carrying tool aimed at a protected path skips every auto-approve short-circuit and falls through to the normal interactive prompt.

- **Floor, not a hard deny.** A lenient mode simply stops short-circuiting for these paths. A `deny` rule still denies (the floor never widens access). If the prompt path then auto-denies on no-client/timeout, that is the existing fail-closed behavior.
- **`isProtectedPathTarget(input, cwd)`** — pure, exported matcher. Extracts the first present `file_path` / `path` / `notebook_path`, resolves it against the session cwd (absolute paths, a leading `./`, and `..` traversal all normalize via `path.resolve`), then segment-matches the path **relative to cwd**. Matching relative-to-cwd (not the raw absolute path) means a session whose **own** cwd lives under a real `.claude/` dir (e.g. an agent git worktree at `…/.claude/worktrees/agent-x`) never false-matches benign writes. String ops only — no regex — so the `.env*` match can't be mangled by a later edit.
- **Segment rules:** any `.git` / `.claude` / `.vscode` segment at any depth; a `.config` segment immediately followed by `git` (the XDG git-config dir); a segment that is `.env` or starts with `.env.`. `.github` does **not** match `.git`; `.config/other/…` is not floored; `foo.env` and `.gitignore` are not floored.
- **Provider wiring:** the three in-process providers that route through `handlePermission` — SDK (`sdk-session.js`), BYOK (`byok-session.js`), and Codex app-server (`codex-app-server-session.js`) — now pass `cwd: this.cwd` into the `PermissionManager` constructor's new `cwd` opt so the floor can resolve relative targets.

### Provider coverage / uniformity

- **SDK / BYOK / Codex app-server** — route their `canUseTool` / tool-gate through the shared `handlePermission`, so the floor covers all three. BYOK's post-approval executor still applies its own `validatePathWithinCwd` confinement on top.
- **CLI / TUI** — run the real Claude Code binary and make their own permission decisions, calling Chroxy's HTTP hook only when they need a prompt. Chroxy's rule/acceptEdits/auto short-circuits in `permission-manager.js` **do not run** for them, and Claude Code already layers its own native protected-path floor — so no server-side change is needed there. (No schema change: `packages/protocol` untouched; path-scoped rules remain a follow-up.)
- **Codex `apply_patch` nuance:** its approval input carries `file_path = grantRoot` (a directory, which the floor inspects) plus a `changes[]` array of per-file paths. The generic floor inspects the top-level `file_path`/`path`/`notebook_path` fields; it does not walk `changes[].path`. Per-change-path inspection for codex `apply_patch` is a reasonable follow-up.

## Testing

New `packages/server/tests/permission-manager-protected-path-floor.test.js` (39 assertions):

- **Acceptance:** `allow Write` rule + `.git/config`; `acceptEdits` + `.claude/settings.local.json`; `auto` + `.env` — all emit a prompt instead of auto-approving.
- **Negative controls:** `allow Write` + `src/foo.js` and `.github/workflows/x.yml` still auto-approve; benign `acceptEdits`/`auto` writes still auto-approve.
- **Traversal / absolute:** `sub/../.git/config`, `./.claude/x.json`, and an absolute path inside cwd targeting `.claude` are floored.
- `deny` rule on a protected path still denies (no prompt); `NotebookEdit` via `notebook_path`; `.env.production` read floored; **worktree false-positive guard** (cwd under `.claude/`, benign write not floored).
- The exported pure matcher exercised directly across a floored / not-floored table.

Verification (Node 22):
- New file: **39/39 pass**.
- All permission-related test files (30 files): **489/489 pass**.
- Provider suites (sdk/byok/codex-app-server, 8 files): **424/424 pass**.
- `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `lint-claude-family-explicit.sh`, `lint-logger-session-scoping.sh`, `lint-ws-index-mutations.sh` — all green. `eslint src/` clean on changed files.

Closes #6794