### PR TITLE
fix(server): checkpoint restore honesty — fork when possible, files-only labeling otherwise (#6766)

### DIFF
--- a/packages/app/src/components/CheckpointView.tsx
+++ b/packages/app/src/components/CheckpointView.tsx
@@ -205,7 +205,7 @@ export function CheckpointView({ visible, onClose }: CheckpointViewProps) {
       const cp = checkpoints.find((c) => c.id === id);
       Alert.alert(
         'Restore Checkpoint',
-        `Restore files to "${cp?.name || 'checkpoint'}"? Your working files will be reverted to this checkpoint.`,
+        `Restore files to "${cp?.name || 'checkpoint'}"? Your working files will be reverted to this checkpoint and a new session will open.`,
         [
           { text: 'Cancel', style: 'cancel' },
           {

--- a/packages/app/src/components/CheckpointView.tsx
+++ b/packages/app/src/components/CheckpointView.tsx
@@ -205,7 +205,7 @@ export function CheckpointView({ visible, onClose }: CheckpointViewProps) {
       const cp = checkpoints.find((c) => c.id === id);
       Alert.alert(
         'Restore Checkpoint',
-        `Restore to "${cp?.name || 'checkpoint'}"? This will create a new session from this point.`,
+        `Restore files to "${cp?.name || 'checkpoint'}"? Your working files will be reverted to this checkpoint.`,
         [
           { text: 'Cancel', style: 'cancel' },
           {

--- a/packages/app/src/components/__tests__/CheckpointView.test.tsx
+++ b/packages/app/src/components/__tests__/CheckpointView.test.tsx
@@ -155,7 +155,7 @@ describe('CheckpointView', () => {
 
     expect(alertSpy).toHaveBeenCalledWith(
       'Restore Checkpoint',
-      expect.stringContaining('Restore to "Initial setup"'),
+      expect.stringContaining('Restore files to "Initial setup"'),
       expect.arrayContaining([
         expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
         expect.objectContaining({ text: 'Restore' }),

--- a/packages/app/src/components/__tests__/CheckpointView.test.tsx
+++ b/packages/app/src/components/__tests__/CheckpointView.test.tsx
@@ -155,7 +155,7 @@ describe('CheckpointView', () => {
 
     expect(alertSpy).toHaveBeenCalledWith(
       'Restore Checkpoint',
-      expect.stringContaining('Restore files to "Initial setup"'),
+      'Restore files to "Initial setup"? Your working files will be reverted to this checkpoint and a new session will open.',
       expect.arrayContaining([
         expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
         expect.objectContaining({ text: 'Restore' }),

--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -102,7 +102,7 @@ function CheckpointNode({
             type="button"
             className="cp-btn cp-restore"
             onClick={() => onRestore(checkpoint.id)}
-            title="Restore files to this checkpoint"
+            title="Restore files to this checkpoint (opens a new session)"
           >
             Restore
           </button>

--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -4,7 +4,7 @@
  * Shows checkpoints as nodes on a vertical timeline with:
  * - Name, description, and timestamp
  * - Message count and git snapshot badge
- * - Restore (branch from any point) and delete actions
+ * - Restore files to a checkpoint and delete actions
  * - Create checkpoint button
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
@@ -102,7 +102,7 @@ function CheckpointNode({
             type="button"
             className="cp-btn cp-restore"
             onClick={() => onRestore(checkpoint.id)}
-            title="Restore to this checkpoint (creates new session)"
+            title="Restore files to this checkpoint"
           >
             Restore
           </button>

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -431,6 +431,7 @@ export declare const ServerCheckpointRestoredSchema: z.ZodObject<{
     checkpointId: z.ZodString;
     newSessionId: z.ZodString;
     name: z.ZodString;
+    filesOnly: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const ServerSessionWarningSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_warning">;

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -542,14 +542,20 @@ export const ServerCheckpointListSchema = z.object({
     sessionId: z.string().nullable(),
     checkpoints: z.array(CheckpointSchema),
 });
-// NOTE: checkpoint_restored does NOT carry a `sessionId` — keys are exactly
-// { type, checkpointId, newSessionId, name }. `newSessionId` is the fresh
-// session the restore created; the client re-homes to it via switchSession.
+// NOTE: checkpoint_restored keys are exactly { type, checkpointId,
+// newSessionId, name, filesOnly? } — no `sessionId`. `newSessionId` is the
+// fresh session the restore created; the client re-homes to it via
+// switchSession. `filesOnly` (#6766) is true when only the working tree was
+// restored and the conversation was NOT branched (the provider can't fork /
+// truncate a resumed transcript); false when the conversation was forked and
+// truncated to the checkpoint. Optional for back-compat with older servers
+// that never branched — a missing value is treated as files-only.
 export const ServerCheckpointRestoredSchema = z.object({
     type: z.literal('checkpoint_restored'),
     checkpointId: z.string(),
     newSessionId: z.string(),
     name: z.string(),
+    filesOnly: z.boolean().optional(),
 });
 // #6332 (batch 2b of #6314): idle-timeout lifecycle. `session_warning` is the
 // pre-timeout notice; `session_timeout` fires at close. NOTE the time field

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -577,14 +577,20 @@ export const ServerCheckpointListSchema = z.object({
   checkpoints: z.array(CheckpointSchema),
 })
 
-// NOTE: checkpoint_restored does NOT carry a `sessionId` — keys are exactly
-// { type, checkpointId, newSessionId, name }. `newSessionId` is the fresh
-// session the restore created; the client re-homes to it via switchSession.
+// NOTE: checkpoint_restored keys are exactly { type, checkpointId,
+// newSessionId, name, filesOnly? } — no `sessionId`. `newSessionId` is the
+// fresh session the restore created; the client re-homes to it via
+// switchSession. `filesOnly` (#6766) is true when only the working tree was
+// restored and the conversation was NOT branched (the provider can't fork /
+// truncate a resumed transcript); false when the conversation was forked and
+// truncated to the checkpoint. Optional for back-compat with older servers
+// that never branched — a missing value is treated as files-only.
 export const ServerCheckpointRestoredSchema = z.object({
   type: z.literal('checkpoint_restored'),
   checkpointId: z.string(),
   newSessionId: z.string(),
   name: z.string(),
+  filesOnly: z.boolean().optional(),
 })
 
 // #6332 (batch 2b of #6314): idle-timeout lifecycle. `session_warning` is the

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -62,8 +62,14 @@ async function acquireCwdLock(cwd) {
  * This avoids touching the shared stash stack, making concurrent sessions
  * in the same repository safe.
  *
- * Rewind creates a new session that resumes from the checkpoint's
- * conversation ID, effectively branching the conversation.
+ * The manager owns the git snapshot and the checkpoint metadata only. It does
+ * NOT branch the conversation itself — that is decided at restore time by the
+ * WS handler based on the session's provider (#6766): for a fork-capable
+ * provider (the SDK, via `forkSession`/`upToMessageId`) restore forks the
+ * conversation truncated to the checkpoint's `boundaryMessageId`, so the
+ * rewound session's transcript stops at the checkpoint. For providers that
+ * cannot truncate a resumed transcript the restore is files-only. The
+ * `boundaryMessageId` captured here is what makes that truncation possible.
  */
 export class CheckpointManager extends EventEmitter {
   /**
@@ -103,9 +109,13 @@ export class CheckpointManager extends EventEmitter {
    * @param {string} [params.name] - User-provided checkpoint name
    * @param {string} [params.description] - Auto-generated description (e.g., last message)
    * @param {number} [params.messageCount] - Number of messages at checkpoint time
+   * @param {string} [params.boundaryMessageId] - #6766: the SDK transcript UUID
+   *   marking this checkpoint's conversation boundary. When present (SDK
+   *   provider), restore forks the conversation truncated up to and including
+   *   this message; absent → the restore is files-only for this checkpoint.
    * @returns {Promise<object>} The created checkpoint
    */
-  async createCheckpoint({ sessionId, resumeSessionId, cwd, name, description, messageCount }) {
+  async createCheckpoint({ sessionId, resumeSessionId, cwd, name, description, messageCount, boundaryMessageId }) {
     const checkpoints = this._getCheckpoints(sessionId)
 
     // Enforce max checkpoints — remove oldest if at limit
@@ -126,6 +136,10 @@ export class CheckpointManager extends EventEmitter {
       name: name || `Checkpoint ${(this._counters.get(sessionId) || 0) + 1}`,
       description: description || '',
       messageCount: messageCount || 0,
+      // #6766: fork boundary for a true conversation rewind at restore. Stored
+      // as null when the provider can't supply one (subprocess providers) so a
+      // restore of that checkpoint honestly degrades to files-only.
+      boundaryMessageId: typeof boundaryMessageId === 'string' && boundaryMessageId ? boundaryMessageId : null,
       createdAt: Date.now(),
       gitRef: null,
     }
@@ -193,11 +207,17 @@ export class CheckpointManager extends EventEmitter {
 
   /**
    * Restore file state from a checkpoint's git snapshot.
-   * Does NOT restore conversation state — that requires creating a new session
-   * with the checkpoint's resumeSessionId (handled by session-manager).
+   *
+   * This restores the working tree only. The conversation side of a rewind is
+   * the WS restore handler's responsibility (#6766): it reads the returned
+   * `resumeSessionId` + `boundaryMessageId` and, for a fork-capable provider,
+   * forks the conversation truncated to the boundary; otherwise it resumes
+   * files-only. Kept here so the git snapshot and the conversation decision stay
+   * decoupled across providers.
    * @param {string} sessionId
    * @param {string} checkpointId
-   * @returns {Promise<object>} The checkpoint data (including resumeSessionId)
+   * @returns {Promise<object>} The checkpoint data (including resumeSessionId
+   *   and boundaryMessageId)
    */
   async restoreCheckpoint(sessionId, checkpointId) {
     const checkpoint = this.getCheckpoint(sessionId, checkpointId)

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -36,6 +36,16 @@ export class DockerSdkSession extends SdkSession {
   }
 
   /**
+   * #6766: the SDK transcript for a containerized session lives inside the
+   * container (`~/.claude/projects` in the container's filesystem), not on the
+   * host where the standalone `forkSession` reads. So a host-side conversation
+   * fork can't reach it — restore degrades to a files-only rewind here.
+   */
+  get supportsConversationFork() {
+    return false
+  }
+
+  /**
    * Preflight credentials block — overrides SdkSession's host-side spec (#4780).
    *
    * Mirror of DockerSession.preflight — see that class for the full rationale.

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -51,6 +51,9 @@ async function handleCreateCheckpoint(ws, client, msg, ctx) {
       name: typeof msg.name === 'string' ? msg.name.slice(0, 100) : undefined,
       description: typeof msg.description === 'string' ? msg.description.slice(0, 500) : undefined,
       messageCount: ctx.sessions.sessionManager.getHistoryCount(sid),
+      // #6766: capture the conversation fork boundary so a later restore can
+      // truncate the transcript to this point (SDK provider only; others → null).
+      boundaryMessageId: entry.session.lastMessageUuid,
     })
     ctx.transport.send(ws, {
       type: 'checkpoint_created',
@@ -130,8 +133,43 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
   }
   try {
     const checkpoint = await ctx.services.checkpointManager.restoreCheckpoint(sid, msg.checkpointId)
+
+    // #6766: decide whether this rewind can truly branch the conversation or is
+    // files-only. A real branch needs (a) a fork-capable provider on the ORIGINAL
+    // session and (b) a captured fork boundary. When both hold, fork the
+    // conversation truncated to the boundary so the rewound session resumes AT
+    // the checkpoint's point (not the full latest transcript); otherwise resume
+    // the checkpoint's conversation id unchanged and report the restore as
+    // files-only so the UI never claims a conversation rewind it didn't do.
+    const origSession = currentEntry?.session
+    const boundaryMessageId = checkpoint.boundaryMessageId
+    let resumeSessionId = checkpoint.resumeSessionId
+    let filesOnly = true
+    if (
+      origSession &&
+      origSession.supportsConversationFork === true &&
+      typeof origSession.forkConversation === 'function' &&
+      typeof boundaryMessageId === 'string' &&
+      boundaryMessageId.length > 0
+    ) {
+      try {
+        const forkedId = await origSession.forkConversation({
+          sessionId: checkpoint.resumeSessionId,
+          upToMessageId: boundaryMessageId,
+        })
+        if (forkedId) {
+          resumeSessionId = forkedId
+          filesOnly = false
+        } else {
+          log.warn('Checkpoint conversation fork returned no id — restoring files only')
+        }
+      } catch (err) {
+        log.warn(`Checkpoint conversation fork failed, restoring files only: ${err.message}`)
+      }
+    }
+
     const newSessionId = await ctx.sessions.sessionManager.createSession({
-      resumeSessionId: checkpoint.resumeSessionId,
+      resumeSessionId,
       cwd: checkpoint.cwd,
       name: `Rewind: ${checkpoint.name}`,
     })
@@ -144,6 +182,10 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       checkpointId: checkpoint.id,
       newSessionId,
       name: newEntry?.name || `Rewind: ${checkpoint.name}`,
+      // #6766: true when only the working tree was restored (conversation NOT
+      // branched); false when the conversation was forked/truncated to the
+      // checkpoint. Lets clients describe what actually happened truthfully.
+      filesOnly,
     })
     // The initiator's active session moved to the rewound session above; announce
     // it to presence/Control-Room observers (the loop below does the same for the

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -323,6 +323,10 @@ async function handleInput(ws, client, msg, ctx) {
       cwd: entry.cwd,
       description: trimmed.slice(0, 100),
       messageCount: ctx.sessions.sessionManager.getHistoryCount(targetSessionId),
+      // #6766: capture the fork boundary (last assistant transcript UUID of the
+      // turn that just ended) so restoring this pre-turn checkpoint can truncate
+      // the conversation to here. Undefined on providers that don't track it.
+      boundaryMessageId: entry.session.lastMessageUuid,
     }).catch((err) => log.warn(`Auto-checkpoint failed: ${err.message}`))
   }
   // Adopt the sender's clientMessageId if present and well-formed; otherwise

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,4 +1,4 @@
-import { query } from '@anthropic-ai/claude-agent-sdk'
+import { query, forkSession } from '@anthropic-ai/claude-agent-sdk'
 import { join } from 'path'
 import { homedir } from 'os'
 import { updateModels, saveModelsCache, updateContextWindow, getModels, ALLOWED_MODEL_IDS } from './models.js'
@@ -352,6 +352,18 @@ export class SdkSession extends BaseSession {
     this._query = null
     this._thinkingLevel = null
 
+    // #6766: last SDK transcript message UUID seen this session. Captured from
+    // each full `assistant` message in the query loop and used as the fork
+    // boundary (`upToMessageId`) when a checkpoint created just after this
+    // point is later restored — so rewind truncates the conversation to the
+    // checkpoint instead of resuming the full latest transcript. Only the SDK
+    // provider tracks this; subprocess providers leave `lastMessageUuid` null.
+    this._lastMessageUuid = null
+    // #6766: injectable handle for the SDK's standalone `forkSession` so tests
+    // can stub the on-disk transcript fork without a live session (mirrors the
+    // instance-level `_query` injection the rest of the suite uses).
+    this._forkSessionImpl = forkSession
+
     // #5269 (Control Room Phase 2a): map a Task subagent's tool_use_id (the id
     // chroxy keys activity/agent nodes by) → the SDK's separate `task_id`,
     // captured from `task_started` system messages. cancelActivity() needs the
@@ -429,6 +441,69 @@ export class SdkSession extends BaseSession {
   /** Public accessor for the SDK session ID used to resume conversations. */
   get resumeSessionId() {
     return this._sdkSessionId
+  }
+
+  /**
+   * #6766: the transcript UUID of the last full assistant message seen this
+   * session, or null before the first turn completes. Checkpoint creation reads
+   * this to record a fork boundary; `null` on providers that don't track it.
+   * @returns {string|null}
+   */
+  get lastMessageUuid() {
+    return this._lastMessageUuid || null
+  }
+
+  /**
+   * #6766: whether this provider can fork/truncate a resumed conversation to a
+   * message boundary. True for the SDK provider (the Agent SDK exposes
+   * `forkSession({ upToMessageId })`); overridden false where the transcript is
+   * not reachable by the host-side fork (see DockerSdkSession — the transcript
+   * lives inside the container). The checkpoint restore path gates the real
+   * conversation rewind on this; when false it degrades to a files-only restore.
+   * @returns {boolean}
+   */
+  get supportsConversationFork() {
+    return true
+  }
+
+  /**
+   * #6766: record the fork boundary from a full SDK message. Guarded so a
+   * message without a string `uuid` leaves the previous boundary intact.
+   * Extracted from the query loop so it can be unit-tested directly.
+   * @param {object} msg - An SDK stream message (expects a `uuid` field).
+   */
+  _captureBoundaryMessage(msg) {
+    if (msg && typeof msg.uuid === 'string' && msg.uuid) {
+      this._lastMessageUuid = msg.uuid
+    }
+  }
+
+  /**
+   * #6766: fork a conversation into a new, independent SDK session truncated to
+   * a message boundary. Wraps the Agent SDK's standalone `forkSession`, which
+   * copies the source transcript (remapping UUIDs) up to and including
+   * `upToMessageId`, then returns the new session's id — resumable like any
+   * other conversation id. This is what makes checkpoint "Rewind" actually
+   * branch the conversation (not just the files) for the SDK provider.
+   *
+   * @param {object} params
+   * @param {string} [params.sessionId] - Source conversation id to fork.
+   *   Defaults to this session's current SDK id.
+   * @param {string} [params.upToMessageId] - Fork boundary (inclusive). Omitted
+   *   → full copy.
+   * @returns {Promise<string|null>} The forked conversation id, or null if the
+   *   SDK returned no id.
+   */
+  async forkConversation({ sessionId, upToMessageId } = {}) {
+    const source = sessionId || this._sdkSessionId
+    if (!source) throw new Error('Cannot fork conversation: no source session id')
+    const opts = {}
+    if (typeof upToMessageId === 'string' && upToMessageId) opts.upToMessageId = upToMessageId
+    // Scope the transcript search to this session's project dir when known; the
+    // SDK falls back to searching all project dirs when `dir` is omitted.
+    if (this.cwd) opts.dir = this.cwd
+    const result = await this._forkSessionImpl(source, opts)
+    return result?.sessionId || null
   }
 
   /**
@@ -839,6 +914,11 @@ export class SdkSession extends BaseSession {
           }
 
           case 'assistant': {
+            // #6766: remember this message's transcript UUID as the fork
+            // boundary. A checkpoint auto-created at the start of the NEXT turn
+            // captures this as its boundary, so restoring that checkpoint can
+            // fork the conversation truncated to exactly this point.
+            this._captureBoundaryMessage(msg)
             // Full assistant message — process content blocks for tool detection
             const content = msg.message?.content
             if (!Array.isArray(content)) break

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -394,7 +394,7 @@ function _isSecureRequest(req) {
  *   { type: 'client_focus_changed', clientId, sessionId, timestamp } — another client changed session focus
  *   { type: 'checkpoint_created', sessionId, checkpoint } — checkpoint created (auto or manual)
  *   { type: 'checkpoint_list', sessionId, checkpoints }   — list of checkpoints
- *   { type: 'checkpoint_restored', checkpointId, newSessionId, name } — checkpoint restored (new session created)
+ *   { type: 'checkpoint_restored', checkpointId, newSessionId, name, filesOnly? } — checkpoint restored (new session created; filesOnly true = working tree only, conversation NOT branched — #6766)
  *   { type: 'primary_changed', sessionId, clientId } — last-writer-wins primary changed (null on disconnect)
  *   { type: 'session_role', sessionId, primaryClientId } — #5589/#5281: explicit primary-ownership; client derives its role (primary iff primaryClientId === own clientId, observer if another holds it, null = unclaimed)
  *   { type: 'pong' }                                    — heartbeat response

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -61,6 +61,36 @@ describe('CheckpointManager', () => {
     assert.ok(cp.gitRef) // should have a git tag
   })
 
+  // #6766: the fork boundary must round-trip through create → restore so the
+  // restore handler can truncate the conversation to the checkpoint's point.
+  it('stores the boundaryMessageId and returns it on restore (#6766)', async () => {
+    const cp = await manager.createCheckpoint({
+      sessionId: 'sess-1',
+      resumeSessionId: 'sdk-abc',
+      cwd: gitDir,
+      name: 'Before query',
+      messageCount: 3,
+      boundaryMessageId: 'uuid-boundary-1',
+    })
+    assert.equal(cp.boundaryMessageId, 'uuid-boundary-1')
+
+    const restored = await manager.restoreCheckpoint('sess-1', cp.id)
+    assert.equal(restored.boundaryMessageId, 'uuid-boundary-1', 'restore returns the fork boundary')
+  })
+
+  // #6766: providers that can't supply a boundary (subprocess providers) must
+  // land as an explicit null so restore honestly degrades to files-only.
+  it('defaults boundaryMessageId to null when absent (#6766)', async () => {
+    const cp = await manager.createCheckpoint({
+      sessionId: 'sess-1',
+      resumeSessionId: 'sdk-abc',
+      cwd: gitDir,
+      name: 'No boundary',
+      messageCount: 1,
+    })
+    assert.equal(cp.boundaryMessageId, null)
+  })
+
   it('#5731 (T3): emits checkpoint_persist_failed when the disk write fails, but still returns the checkpoint', async () => {
     // Root bypasses DAC permission checks, so the read-only-dir trick can't force
     // a write failure when run as uid 0 (Docker/devcontainer) — skip there, mirroring

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1118,6 +1118,18 @@ describe('DockerSdkSession real import (capabilities only)', () => {
     assert.ok(Array.isArray(mod.FORWARDED_ENV_KEYS))
     assert.equal(typeof mod.DEFAULT_CONTAINER_CLI_PATH, 'string')
   })
+
+  // #6766: the SDK provider forks conversations, but a containerized session's
+  // transcript lives inside the container where the host-side fork can't reach
+  // it — so DockerSdkSession must opt out and let restore degrade to files-only.
+  it('DockerSdkSession.supportsConversationFork is false; SdkSession is true (#6766)', async () => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    const { SdkSession } = await import('../src/sdk-session.js')
+    const docker = Object.create(DockerSdkSession.prototype)
+    const sdk = Object.create(SdkSession.prototype)
+    assert.equal(docker.supportsConversationFork, false, 'container transcript is unreachable by host-side fork')
+    assert.equal(sdk.supportsConversationFork, true)
+  })
 })
 
 describe('DockerSdkSession._augmentQueryOptions hook in SdkSession', () => {

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -1,6 +1,10 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { checkpointHandlers } from '../../src/handlers/checkpoint-handlers.js'
+import { CheckpointManager } from '../../src/checkpoint-manager.js'
 import { createSpy, createMockSession, makeSessionIndexCtx, nsCtx } from '../test-helpers.js'
 
 function makeCtx(sessions = new Map(), overrides = {}) {
@@ -220,22 +224,63 @@ describe('checkpoint-handlers', () => {
         assert.equal(restored.filesOnly, false, 'a real conversation branch is not files-only')
       })
 
-      it('restoring the EARLIER of two checkpoints truncates to the earlier boundary', async () => {
-        // Two checkpoints in one session; restore the earlier one → fork must
-        // use the earlier boundary, so the rewound history stops there (not the
-        // later checkpoint / full transcript). This is the issue's core AC.
-        const { ctx, orig } = makeForkCtx({ forkCapable: true, boundaryMessageId: 'uuid-early' })
-        // Model "two checkpoints": the manager returns the EARLIER checkpoint's
-        // boundary for the id we restore.
-        const earlier = { id: 'cp-early', name: 'Checkpoint 1', cwd: '/tmp', resumeSessionId: 'conv-1', boundaryMessageId: 'uuid-early' }
-        ctx.services.checkpointManager.getCheckpoint = createSpy(() => earlier)
-        ctx.services.checkpointManager.restoreCheckpoint = createSpy(async () => earlier)
-        const client = makeClient({ activeSessionId: 's1' })
+      it('restoring the EARLIER of two REAL checkpoints truncates to the earlier boundary', async () => {
+        // The issue's core AC, end-to-end through a REAL CheckpointManager (no
+        // mocked boundary lookup): two checkpoints created in one session with
+        // DISTINCT fork boundaries, restore the earlier by its real id → the
+        // fork must receive the EARLIER checkpoint's upToMessageId, so the
+        // rewound history stops at that checkpoint, not the later one / the
+        // full latest transcript. Temp checkpointsDir + non-git cwd (#4633; a
+        // non-git dir skips the snapshot machinery, which is irrelevant here).
+        const checkpointsDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-handler-state-'))
+        const workDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-handler-cwd-'))
+        try {
+          const manager = new CheckpointManager({ checkpointsDir })
+          const early = await manager.createCheckpoint({
+            sessionId: 's1',
+            resumeSessionId: 'conv-1',
+            cwd: workDir,
+            name: 'Early',
+            messageCount: 2,
+            boundaryMessageId: 'uuid-early',
+          })
+          const late = await manager.createCheckpoint({
+            sessionId: 's1',
+            resumeSessionId: 'conv-1',
+            cwd: workDir,
+            name: 'Late',
+            messageCount: 6,
+            boundaryMessageId: 'uuid-late',
+          })
+          assert.notEqual(early.boundaryMessageId, late.boundaryMessageId, 'precondition: distinct boundaries')
 
-        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-early' }, ctx)
+          const sessions = new Map()
+          const orig = createMockSession()
+          orig.isRunning = false
+          orig.resumeSessionId = 'conv-1'
+          orig.supportsConversationFork = true
+          orig.forkConversation = createSpy(async () => 'forked-early-id')
+          sessions.set('s1', { session: orig, name: 'S', cwd: workDir })
+          sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: Early', cwd: workDir })
+          const ctx = makeCtx(sessions)
+          ctx.services.checkpointManager = manager // the REAL manager, not the default mock
+          ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+          const client = makeClient({ activeSessionId: 's1' })
 
-        const [forkArgs] = orig.forkConversation.calls[0]
-        assert.equal(forkArgs.upToMessageId, 'uuid-early', 'truncates to the earlier checkpoint, not the latest state')
+          await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: early.id }, ctx)
+
+          assert.equal(orig.forkConversation.callCount, 1, 'must fork exactly once')
+          const [forkArgs] = orig.forkConversation.calls[0]
+          assert.equal(forkArgs.upToMessageId, 'uuid-early', 'forks at the EARLIER checkpoint boundary, not uuid-late / latest state')
+          assert.equal(forkArgs.sessionId, 'conv-1')
+          const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+          assert.equal(createArgs.resumeSessionId, 'forked-early-id', 'rewound session resumes the truncated fork')
+          const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+          assert.equal(restored.filesOnly, false)
+        } finally {
+          rmSync(checkpointsDir, { recursive: true, force: true })
+          rmSync(workDir, { recursive: true, force: true })
+        }
       })
 
       it('degrades to files-only (filesOnly:true, raw resume) for a non-fork provider', async () => {

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -175,6 +175,107 @@ describe('checkpoint-handlers', () => {
       assert.equal(restored.newSessionId, 'restored-session-id')
     })
 
+    // #6766 — truthfulness: a fork-capable provider (the SDK) rewinds the
+    // conversation truncated to the checkpoint boundary; every other provider
+    // degrades to a files-only restore and says so. These tests mock the SDK
+    // fork at the session's `forkConversation` seam (the same instance-level
+    // injection the SdkSession suite uses for `_query`).
+    describe('conversation fork vs files-only degradation (#6766)', () => {
+      function makeForkCtx({ forkCapable = false, boundaryMessageId = null, forkReturns = 'forked-conv-id', forkThrows = false } = {}) {
+        const sessions = new Map()
+        const orig = createMockSession()
+        orig.isRunning = false
+        orig.resumeSessionId = 'conv-1'
+        if (forkCapable) {
+          orig.supportsConversationFork = true
+          orig.forkConversation = createSpy(async () => {
+            if (forkThrows) throw new Error('fork boom')
+            return forkReturns
+          })
+        }
+        sessions.set('s1', { session: orig, name: 'S', cwd: '/tmp' })
+        sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: Checkpoint 1', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+        const cp = { id: 'cp-1', name: 'Checkpoint 1', cwd: '/tmp', resumeSessionId: 'conv-1', boundaryMessageId }
+        ctx.services.checkpointManager.getCheckpoint = createSpy(() => cp)
+        ctx.services.checkpointManager.restoreCheckpoint = createSpy(async () => cp)
+        return { ctx, orig }
+      }
+
+      it('forks the conversation truncated to the boundary and reports filesOnly:false', async () => {
+        const { ctx, orig } = makeForkCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1' })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(orig.forkConversation.callCount, 1, 'must fork the conversation')
+        const [forkArgs] = orig.forkConversation.calls[0]
+        assert.equal(forkArgs.sessionId, 'conv-1')
+        assert.equal(forkArgs.upToMessageId, 'uuid-b1', 'forks truncated to the checkpoint boundary')
+        // The rewound session resumes the FORKED (truncated) id, not the raw one.
+        const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+        assert.equal(createArgs.resumeSessionId, 'forked-conv-id')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.filesOnly, false, 'a real conversation branch is not files-only')
+      })
+
+      it('restoring the EARLIER of two checkpoints truncates to the earlier boundary', async () => {
+        // Two checkpoints in one session; restore the earlier one → fork must
+        // use the earlier boundary, so the rewound history stops there (not the
+        // later checkpoint / full transcript). This is the issue's core AC.
+        const { ctx, orig } = makeForkCtx({ forkCapable: true, boundaryMessageId: 'uuid-early' })
+        // Model "two checkpoints": the manager returns the EARLIER checkpoint's
+        // boundary for the id we restore.
+        const earlier = { id: 'cp-early', name: 'Checkpoint 1', cwd: '/tmp', resumeSessionId: 'conv-1', boundaryMessageId: 'uuid-early' }
+        ctx.services.checkpointManager.getCheckpoint = createSpy(() => earlier)
+        ctx.services.checkpointManager.restoreCheckpoint = createSpy(async () => earlier)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-early' }, ctx)
+
+        const [forkArgs] = orig.forkConversation.calls[0]
+        assert.equal(forkArgs.upToMessageId, 'uuid-early', 'truncates to the earlier checkpoint, not the latest state')
+      })
+
+      it('degrades to files-only (filesOnly:true, raw resume) for a non-fork provider', async () => {
+        const { ctx, orig } = makeForkCtx({ forkCapable: false, boundaryMessageId: 'uuid-b1' })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(orig.forkConversation, undefined, 'non-fork provider has no fork method')
+        const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+        assert.equal(createArgs.resumeSessionId, 'conv-1', 'resumes the checkpoint id unchanged')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.filesOnly, true, 'no conversation branch claimed')
+      })
+
+      it('degrades to files-only when a fork-capable provider has no boundary', async () => {
+        const { ctx, orig } = makeForkCtx({ forkCapable: true, boundaryMessageId: null })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(orig.forkConversation.callCount, 0, 'no boundary → no fork attempted')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.filesOnly, true)
+      })
+
+      it('degrades to files-only when the fork itself throws', async () => {
+        const { ctx, orig } = makeForkCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1', forkThrows: true })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(orig.forkConversation.callCount, 1)
+        const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+        assert.equal(createArgs.resumeSessionId, 'conv-1', 'falls back to the raw resume id on fork failure')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.filesOnly, true)
+      })
+    })
+
     it('re-homes OTHER clients viewing the original session onto the rewound session (#5700)', async () => {
       const sessions = new Map()
       const orig = createMockSession()

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -3074,3 +3074,72 @@ describe('per-model usage forwarding (#6692)', () => {
     s.destroy()
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #6766 — conversation fork boundary + fork wrapper. These make checkpoint
+// "Rewind" actually branch the conversation truncated to the checkpoint (for the
+// SDK provider) rather than resuming the full latest transcript.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('SdkSession conversation fork (#6766)', () => {
+  it('captures the latest assistant transcript uuid as the fork boundary during a turn', async () => {
+    const s = createSession()
+    s._processReady = true
+    assert.equal(s.lastMessageUuid, null, 'null before any turn')
+    s._callQuery = () => (async function* () {
+      yield { type: 'assistant', uuid: 'asst-1', message: { content: [{ type: 'text', text: 'hi' }] } }
+      yield { type: 'assistant', uuid: 'asst-2', message: { content: [{ type: 'text', text: 'more' }] } }
+      yield { type: 'result', session_id: 'conv-x', total_cost_usd: 0, duration_ms: 1, usage: {} }
+    })()
+    await s.sendMessage('hello')
+    assert.equal(s.lastMessageUuid, 'asst-2', 'boundary tracks the latest assistant message of the turn')
+    s.destroy()
+  })
+
+  it('_captureBoundaryMessage ignores messages without a string uuid', () => {
+    const s = createSession()
+    s._captureBoundaryMessage({ uuid: 'm-1' })
+    assert.equal(s.lastMessageUuid, 'm-1')
+    s._captureBoundaryMessage({}) // no uuid — keep previous
+    assert.equal(s.lastMessageUuid, 'm-1')
+    s._captureBoundaryMessage({ uuid: 42 }) // non-string — keep previous
+    assert.equal(s.lastMessageUuid, 'm-1')
+    s._captureBoundaryMessage({ uuid: 'm-2' })
+    assert.equal(s.lastMessageUuid, 'm-2')
+    s.destroy()
+  })
+
+  it('supportsConversationFork is true for the SDK provider', () => {
+    const s = createSession()
+    assert.equal(s.supportsConversationFork, true)
+    s.destroy()
+  })
+
+  it('forkConversation wraps the SDK forkSession with the boundary + project dir', async () => {
+    const s = createSession({ cwd: '/repo' })
+    const calls = []
+    s._forkSessionImpl = async (id, opts) => { calls.push([id, opts]); return { sessionId: 'forked-xyz' } }
+    const forked = await s.forkConversation({ sessionId: 'conv-1', upToMessageId: 'm-2' })
+    assert.equal(forked, 'forked-xyz')
+    assert.deepEqual(calls, [['conv-1', { upToMessageId: 'm-2', dir: '/repo' }]])
+    s.destroy()
+  })
+
+  it('forkConversation defaults the source to the live session and returns null when the SDK gives no id', async () => {
+    const s = createSession({ cwd: '/repo' })
+    s._sdkSessionId = 'live-conv'
+    let seen = null
+    s._forkSessionImpl = async (id) => { seen = id; return {} } // no sessionId
+    const forked = await s.forkConversation({ upToMessageId: 'm-9' })
+    assert.equal(seen, 'live-conv', 'defaults to the live SDK session id')
+    assert.equal(forked, null)
+    s.destroy()
+  })
+
+  it('forkConversation throws when there is no source conversation', async () => {
+    const s = createSession()
+    s._sdkSessionId = null
+    await assert.rejects(() => s.forkConversation({}), /no source session id/)
+    s.destroy()
+  })
+})

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -639,6 +639,8 @@ export interface DispatchMessageMap {
   checkpoint_restored: {
     type: 'checkpoint_restored'
     newSessionId?: string
+    // #6766: true when only files were restored (conversation NOT branched).
+    filesOnly?: boolean
   }
   search_results: {
     type: 'search_results'

--- a/packages/store-core/src/handlers/checkpoint.ts
+++ b/packages/store-core/src/handlers/checkpoint.ts
@@ -67,10 +67,19 @@ export function handleCheckpointList(
 /** Parsed payload from a `checkpoint_restored` message. */
 export interface CheckpointRestoredPayload {
   newSessionId: string
+  /**
+   * #6766: true when the restore reverted only the working tree and did NOT
+   * branch the conversation (the provider can't fork/truncate a resumed
+   * transcript); false when the conversation was forked/truncated to the
+   * checkpoint. Defaults to true when the server omits the field (older servers
+   * never branched), so callers never over-claim a conversation rewind.
+   */
+  filesOnly: boolean
 }
 
 /**
- * Extract and trim the new session ID from a `checkpoint_restored` message.
+ * Extract the new session ID (and the files-only flag) from a
+ * `checkpoint_restored` message.
  *
  * App-only handler today (the dashboard's `checkpoint_restored` is a no-op);
  * extracted here so dashboard can adopt the same handler later if/when it
@@ -87,5 +96,8 @@ export function handleCheckpointRestored(
   if (typeof raw !== 'string') return null
   const trimmed = raw.trim()
   if (trimmed.length === 0) return null
-  return { newSessionId: trimmed }
+  // #6766: default to files-only unless the server explicitly says otherwise, so
+  // a missing/legacy flag never lets a client claim a conversation rewind.
+  const filesOnly = typeof msg.filesOnly === 'boolean' ? msg.filesOnly : true
+  return { newSessionId: trimmed, filesOnly }
 }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1941,16 +1941,36 @@ describe('handleServerMode', () => {
 // handleCheckpointRestored
 // ---------------------------------------------------------------------------
 describe('handleCheckpointRestored', () => {
-  it('extracts trimmed newSessionId', () => {
+  it('extracts trimmed newSessionId (defaults filesOnly true)', () => {
     expect(handleCheckpointRestored({ newSessionId: 'sess-new' })).toEqual({
       newSessionId: 'sess-new',
+      filesOnly: true,
     })
   })
 
   it('trims whitespace from newSessionId', () => {
     expect(
       handleCheckpointRestored({ newSessionId: '  sess-trim  ' }),
-    ).toEqual({ newSessionId: 'sess-trim' })
+    ).toEqual({ newSessionId: 'sess-trim', filesOnly: true })
+  })
+
+  // #6766: the flag lets the client describe the restore truthfully.
+  it('carries filesOnly:false when the server branched the conversation', () => {
+    expect(
+      handleCheckpointRestored({ newSessionId: 'sess-new', filesOnly: false }),
+    ).toEqual({ newSessionId: 'sess-new', filesOnly: false })
+  })
+
+  it('carries filesOnly:true when the server reports a files-only restore', () => {
+    expect(
+      handleCheckpointRestored({ newSessionId: 'sess-new', filesOnly: true }),
+    ).toEqual({ newSessionId: 'sess-new', filesOnly: true })
+  })
+
+  it('defaults filesOnly to true when the field is a non-boolean', () => {
+    expect(
+      handleCheckpointRestored({ newSessionId: 'sess-new', filesOnly: 'yes' }),
+    ).toEqual({ newSessionId: 'sess-new', filesOnly: true })
   })
 
   it('returns null when newSessionId is missing', () => {


### PR DESCRIPTION
## Problem

Checkpoint **"Rewind"** restored the working tree but reopened the conversation at its **latest** state — contradicting the "branch from any point" / "effectively branching the conversation" promise. A checkpoint stored only the SDK conversation id (`resumeSessionId`) plus a display-only `messageCount`, with no per-message offset. Chroxy resumes the *same* conversation id every turn and never forked it, so every checkpoint captured the same id; restore created a new session resuming that id — i.e. the full, latest transcript. Files reverted; the chat did not.

Evidence in the issue: `checkpoint-manager.js` docstrings (53-67 "effectively branching", 194-201 "Does NOT restore conversation state"), `checkpoint-handlers.js:131-137` (creates session with no transcript offset), `sdk-session.js:651-652` (resume appends to the same id, `forkSession` absent), and the UI copy in `CheckpointTimeline.tsx` / `CheckpointView.tsx`.

## Approach

**The SDK can fork+truncate — verified, not assumed.** The installed `@anthropic-ai/claude-agent-sdk@0.2.114` exports `forkSession(sessionId, { upToMessageId })` (copies the transcript, remapping UUIDs, sliced inclusive to a message boundary → new resumable id) and `Options.forkSession`. Confirmed at runtime (`typeof forkSession === 'function'`) and that SDK stream messages carry `uuid`. So this ships the **fork-when-possible** path, not degradation-only.

**Per-provider honesty:**

- **SDK provider (default):** `SdkSession` now captures the last full assistant message's transcript UUID per turn (`lastMessageUuid`). The auto-checkpoint (created at the *start* of the next turn) stores it as the checkpoint's `boundaryMessageId`. On restore, the handler forks the conversation via `forkConversation({ upToMessageId })`, and the rewound session resumes the **forked, truncated** id — transcript stops at the checkpoint. Result reports `filesOnly: false`.
- **Every other provider** (CLI / TUI / BYOK / Gemini / Codex, and containerized SDK where the transcript lives in-container and the host-side fork can't reach it — `DockerSdkSession.supportsConversationFork = false`): no boundary / not fork-capable → restore **degrades honestly** to a files-only rewind (`filesOnly: true`), falling back to the raw resume id. If a fork is attempted but errors or returns no id, it also degrades.
- **Copy:** dashboard tooltip + docstring and the mobile confirm dialog now say "Restore files to this checkpoint" — no "branch the conversation" / "creates new session" wording.
- **Docstrings:** the overpromising `CheckpointManager` class + `restoreCheckpoint` docblocks are corrected.

**Wire:** added optional `filesOnly` to `checkpoint_restored` (protocol dist rebuilt); `store-core`'s `handleCheckpointRestored` parses it and defaults to `true` for legacy/absent servers so a client never over-claims a rewind. `boundaryMessageId` is server-internal (not added to the client-facing checkpoint list).

Scope note: this is the truthfulness slice of #6766. Selective restore modes (code/conversation/both), a restore-mode picker, and a settings-only-vs-history fork action remain in the larger follow-up #6767.

## Testing

- **server** (`node --test`, all green): `checkpoint-manager` (boundary stored + round-trips on restore; null when absent), `checkpoint-handlers` (fork truncates to the boundary + `filesOnly:false`; **restoring the earlier of two checkpoints truncates to the earlier boundary**; degrades to `filesOnly:true` for non-fork provider / no boundary / fork-throws), `sdk-session` (uuid capture driving a real turn, `forkConversation` wraps the SDK with `{ upToMessageId, dir }`, defaults + error paths), `docker-sdk-session` (`supportsConversationFork` false vs SDK true), plus `input-handlers`, `ws-message-handlers`, `ws-handler-coverage`, `ws-schemas`, `input-conflict` — 700+ tests green.
- **store-core** `vitest run`: 1955 passed (incl. new `filesOnly` parsing + contract fixtures).
- **protocol** `npm test`: 362 passed.
- **Typecheck:** store-core / dashboard / app `tsc --noEmit` clean.
- **Lints:** `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`, `lint-claude-family-explicit.sh`, `lint-ws-index-mutations.sh` and eslint on touched files — all clean.

Residual note: the mocked tests exercise Chroxy's fork wiring; the real on-disk SDK transcript slice (`forkSession` UUID matching / project-dir resolution) can only be fully validated against a live Claude session.

Closes #6766