### PR TITLE
feat(dashboard): render tool-produced images in chat (#6755)

### DIFF
--- a/packages/dashboard/src/components/ImageLightbox.test.tsx
+++ b/packages/dashboard/src/components/ImageLightbox.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * ImageLightbox component tests (#6755).
+ *
+ * The component is a thin wrapper around the generic `Modal` — these tests
+ * cover the parts specific to ImageLightbox (null-when-closed, the image
+ * itself, the explicit close button, and the click-swallowing wrapper that
+ * keeps a dismiss from bubbling into a parent ToolBubble/ToolGroup toggle).
+ * Escape-key and backdrop-close behavior are already covered by
+ * Modal.test.tsx.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ImageLightbox } from './ImageLightbox'
+
+afterEach(cleanup)
+
+describe('ImageLightbox', () => {
+  it('renders nothing when uri is null', () => {
+    render(<ImageLightbox uri={null} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('image-lightbox-img')).not.toBeInTheDocument()
+  })
+
+  it('renders the image at the given data URI when open', () => {
+    const uri = 'data:image/png;base64,iVBORw0KGgo='
+    render(<ImageLightbox uri={uri} onClose={vi.fn()} />)
+    expect(screen.getByTestId('image-lightbox-img')).toHaveAttribute('src', uri)
+  })
+
+  it('defaults the accessible title to "Image" when no label is given', () => {
+    render(<ImageLightbox uri="data:image/png;base64,x" onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Image')
+  })
+
+  it('uses a custom label for the accessible title', () => {
+    render(<ImageLightbox uri="data:image/png;base64,x" onClose={vi.fn()} label="Image 2 of 3" />)
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Image 2 of 3')
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<ImageLightbox uri="data:image/png;base64,x" onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close image' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows the click so it does not bubble to an ancestor onClick', () => {
+    const outerClick = vi.fn()
+    render(
+      <div onClick={outerClick}>
+        <ImageLightbox uri="data:image/png;base64,x" onClose={vi.fn()} />
+      </div>,
+    )
+    fireEvent.click(screen.getByTestId('image-lightbox-img'))
+    expect(outerClick).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/ImageLightbox.tsx
+++ b/packages/dashboard/src/components/ImageLightbox.tsx
@@ -1,0 +1,48 @@
+/**
+ * ImageLightbox — full-resolution click-to-zoom overlay for tool-result
+ * images (#6755: computer-use screenshots, browser tools returning base64
+ * PNGs). Composes the generic `Modal` for consistent Escape-key,
+ * backdrop-close, and focus-trap behavior — the "content" is just the
+ * full-size image plus an explicit close button. Shared by ToolBubble's
+ * expanded body and ToolGroup's per-entry detail panel so both surfaces
+ * present identically, mirroring the mobile app's ImageViewer.
+ */
+import { Modal } from './Modal'
+
+export interface ImageLightboxProps {
+  /** data: URI of the image to show full-size. Null/undefined = closed. */
+  uri: string | null
+  onClose: () => void
+  /** Accessible modal title — also shown as a small caption above the image. */
+  label?: string
+}
+
+export function ImageLightbox({ uri, onClose, label = 'Image' }: ImageLightboxProps) {
+  if (!uri) return null
+  return (
+    // #6755: the lightbox is rendered from inside ToolBubble / ToolGroup's
+    // ToolGroupEntry, both of which have their own ancestor onClick that
+    // toggles expand/collapse. The Modal's own content stops propagation,
+    // but its backdrop-close click does not — swallow the click here so
+    // opening or dismissing the lightbox never also collapses the parent
+    // bubble/entry.
+    <div onClick={(e) => e.stopPropagation()}>
+      <Modal open onClose={onClose} title={label} maxWidth="min(92vw, 1100px)">
+        <button
+          type="button"
+          className="image-lightbox-close"
+          onClick={onClose}
+          aria-label="Close image"
+        >
+          &times;
+        </button>
+        <img
+          src={uri}
+          alt=""
+          className="image-lightbox-img"
+          data-testid="image-lightbox-img"
+        />
+      </Modal>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -422,6 +422,9 @@ describe('ToolBubble', () => {
       const thumbBtn = screen.getByTestId('tool-result-image-tu-img-1-0')
       const img = thumbBtn.querySelector('img')
       expect(img).toHaveAttribute('src', `data:${images[0].mediaType};base64,${images[0].data}`)
+      // The thumbnail opens the ImageLightbox modal — announce that to AT
+      // (matches the dashboard's modal-trigger pattern).
+      expect(thumbBtn).toHaveAttribute('aria-haspopup', 'dialog')
     })
 
     it('renders one thumbnail per image for a multi-image result (grid)', () => {
@@ -435,6 +438,9 @@ describe('ToolBubble', () => {
       fireEvent.click(screen.getByRole('button'))
       expect(screen.getByTestId('tool-result-image-tu-img-2-0')).toBeInTheDocument()
       expect(screen.getByTestId('tool-result-image-tu-img-2-1')).toBeInTheDocument()
+      // Every thumbnail in the grid is a modal trigger.
+      expect(screen.getByTestId('tool-result-image-tu-img-2-0')).toHaveAttribute('aria-haspopup', 'dialog')
+      expect(screen.getByTestId('tool-result-image-tu-img-2-1')).toHaveAttribute('aria-haspopup', 'dialog')
     })
 
     it('does not render an image grid when resultImages is absent', () => {

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ToolResultImage } from '@chroxy/store-core'
 import { ToolBubble } from './ToolBubble'
 
 afterEach(() => {
@@ -389,6 +390,148 @@ describe('ToolBubble', () => {
         />,
       )
       expect(screen.getByTestId('tool-bubble-pulse-tu-5')).toBeInTheDocument()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // #6755 — tool-result images (computer-use screenshots, browser tools
+  // returning base64 PNGs) render as thumbnails in the expanded body, with
+  // click-to-zoom into a full-resolution lightbox. Mirrors the mobile
+  // ToolDetailModal image grid + ImageViewer.
+  // ---------------------------------------------------------------------------
+  describe('tool-result image rendering (#6755)', () => {
+    // Fixed-length tuple (not a bare array) so indexed access stays typed as
+    // `ToolResultImage`, not `ToolResultImage | undefined`, under the
+    // dashboard's `noUncheckedIndexedAccess` tsconfig.
+    const image1: ToolResultImage = { mediaType: 'image/png', data: 'iVBORw0KGgoAAAANSUhEUg==' }
+    const image2: ToolResultImage = { mediaType: 'image/png', data: 'ZmFrZS1zZWNvbmQtaW1hZ2U=' }
+    const images: [ToolResultImage, ToolResultImage] = [image1, image2]
+
+    it('renders a thumbnail for an images-only result (result === undefined)', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-img-1"
+          input={{ url: 'https://example.com' }}
+          resultImages={[images[0]]}
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      const grid = screen.getByTestId('tool-result-images-tu-img-1')
+      expect(grid).toBeInTheDocument()
+      const thumbBtn = screen.getByTestId('tool-result-image-tu-img-1-0')
+      const img = thumbBtn.querySelector('img')
+      expect(img).toHaveAttribute('src', `data:${images[0].mediaType};base64,${images[0].data}`)
+    })
+
+    it('renders one thumbnail per image for a multi-image result (grid)', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-img-2"
+          resultImages={images}
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByTestId('tool-result-image-tu-img-2-0')).toBeInTheDocument()
+      expect(screen.getByTestId('tool-result-image-tu-img-2-1')).toBeInTheDocument()
+    })
+
+    it('does not render an image grid when resultImages is absent', () => {
+      render(<ToolBubble toolName="Read" toolUseId="tu-img-3" input="/f" result="contents" />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByTestId('tool-result-images-tu-img-3')).not.toBeInTheDocument()
+    })
+
+    it('renders both the text result and the image grid when a tool resolves with both', () => {
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-img-4"
+          input={{ command: 'screenshot.sh' }}
+          result="saved to /tmp/out.png"
+          resultImages={[images[0]]}
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.getByText('saved to /tmp/out.png')).toBeInTheDocument()
+      expect(screen.getByTestId('tool-result-images-tu-img-4')).toBeInTheDocument()
+    })
+
+    it('opens the full-resolution lightbox on thumbnail click', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-img-5"
+          resultImages={[images[0]]}
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByTestId('image-lightbox-img')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('tool-result-image-tu-img-5-0'))
+      const lightboxImg = screen.getByTestId('image-lightbox-img')
+      expect(lightboxImg).toHaveAttribute('src', `data:${images[0].mediaType};base64,${images[0].data}`)
+    })
+
+    it('dismisses the lightbox via its close button without collapsing the parent bubble', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-img-6"
+          resultImages={[images[0]]}
+        />,
+      )
+      const toggle = screen.getByRole('button')
+      fireEvent.click(toggle)
+      fireEvent.click(screen.getByTestId('tool-result-image-tu-img-6-0'))
+      expect(screen.getByTestId('image-lightbox-img')).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: 'Close image' }))
+      expect(screen.queryByTestId('image-lightbox-img')).not.toBeInTheDocument()
+      // The bubble itself must still be expanded — dismissing the lightbox
+      // must not bubble into the outer toggle.
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('dismisses the lightbox on Escape', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-img-7"
+          resultImages={[images[0]]}
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      fireEvent.click(screen.getByTestId('tool-result-image-tu-img-7-0'))
+      expect(screen.getByTestId('image-lightbox-img')).toBeInTheDocument()
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(screen.queryByTestId('image-lightbox-img')).not.toBeInTheDocument()
+    })
+
+    it('labels the lightbox with position among multiple images', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-img-8"
+          resultImages={images}
+        />,
+      )
+      fireEvent.click(screen.getByRole('button'))
+      fireEvent.click(screen.getByTestId('tool-result-image-tu-img-8-1'))
+      expect(screen.getByText('Image 2 of 2')).toBeInTheDocument()
+    })
+
+    it('sets aria-controls when the tool resolved with images only (no text)', () => {
+      render(<ToolBubble toolName="screenshot" toolUseId="tu-img-9" resultImages={[images[0]]} />)
+      const toggle = screen.getByRole('button')
+      expect(toggle).not.toHaveAttribute('aria-controls')
+      fireEvent.click(toggle)
+      expect(toggle).toHaveAttribute('aria-controls', 'tool-result-tu-img-9')
+    })
+
+    it('does not render the images-only panel when resultImages is an empty array', () => {
+      render(<ToolBubble toolName="screenshot" toolUseId="tu-img-10" resultImages={[]} />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByTestId('tool-result-images-tu-img-10')).not.toBeInTheDocument()
     })
   })
 

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -35,6 +35,7 @@ import {
 import type { ChildAgentEvent, ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 import { ChildAgentEventList } from './ChildAgentEventList'
+import { ImageLightbox } from './ImageLightbox'
 import { useInitialExpanded } from './chatExpandRegistry'
 
 export interface ToolBubbleProps {
@@ -141,6 +142,25 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // ActivityIndicator's in-flight predicate. Without this the header
   // pulses forever for computer-use / screenshot tools.
   const hasResult = result !== undefined || (resultImages?.length ?? 0) > 0
+  // #6755 — split `hasResult` into its two constituents so the expanded
+  // body can render text and images independently (a tool can resolve
+  // with either, both, or neither). `hasTextResult` excludes the empty
+  // string on purpose: an empty-string result renders nothing (matches
+  // the pre-#6755 behavior where the whole panel was gated on `result`
+  // being truthy), while an images-only result must still show the
+  // image grid instead of a blank/missing panel.
+  const hasTextResult = result !== undefined && result !== ''
+  const hasImages = (resultImages?.length ?? 0) > 0
+  // #6755 — full-resolution click-to-zoom. Stores the INDEX into
+  // `resultImages` (not the data URI) so the lightbox label can read
+  // "Image N of M" without a second lookup.
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+  const lightboxImage = lightboxIndex != null ? resultImages?.[lightboxIndex] : undefined
+  const lightboxUri = lightboxImage ? `data:${lightboxImage.mediaType};base64,${lightboxImage.data}` : null
+  const lightboxLabel =
+    resultImages && resultImages.length > 1 && lightboxIndex != null
+      ? `Image ${lightboxIndex + 1} of ${resultImages.length}`
+      : 'Image'
   // #4667 — internal-shape tools (currently AskUserQuestion) must never
   // surface raw `tool_input` JSON in the chat surface; the structured
   // render path owns the display. Gate computed once so both the
@@ -240,7 +260,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
       role="button"
       tabIndex={0}
       aria-expanded={expanded}
-      aria-controls={expanded && result ? resultId : undefined}
+      aria-controls={expanded && (hasTextResult || hasImages) ? resultId : undefined}
       onClick={toggle}
       onKeyDown={handleKeyDown}
     >
@@ -266,7 +286,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
           {summary}
         </span>
       )}
-      {expanded && result && (
+      {expanded && (hasTextResult || hasImages) && (
         // #4139: click inside the result area must not bubble up to the
         // outer onClick that collapses the bubble — otherwise selecting
         // text or interacting with the checklist accidentally re-toggles.
@@ -277,7 +297,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
         >
           {todoParsed ? (
             <TodoList parsed={todoParsed} />
-          ) : isLongResult && !resultExpanded ? (
+          ) : hasTextResult && isLongResult && !resultExpanded ? (
             <>
               <pre>{result!.split('\n').slice(0, TOOL_OUTPUT_COLLAPSE_HEAD_LINES).join('\n')}</pre>
               <button
@@ -289,7 +309,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
                 Show {resultLineCount - TOOL_OUTPUT_COLLAPSE_HEAD_LINES} more lines
               </button>
             </>
-          ) : (
+          ) : hasTextResult ? (
             <>
               <pre>{result}</pre>
               {isLongResult && (
@@ -303,6 +323,37 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
                 </button>
               )}
             </>
+          ) : null}
+          {/* #6755 — tools that resolve with images-only (computer-use
+              screenshots, browser tools returning base64 PNGs) leave
+              `result === undefined`; render the thumbnail grid instead of
+              a blank panel. Click a thumbnail to open the full-resolution
+              lightbox. Mirrors the mobile ToolDetailModal image grid. */}
+          {hasImages && (
+            <div className="tool-result-images" data-testid={`tool-result-images-${toolUseId}`}>
+              {resultImages!.map((img, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  className="tool-result-image-btn"
+                  data-testid={`tool-result-image-${toolUseId}-${i}`}
+                  onClick={() => setLightboxIndex(i)}
+                  aria-label={
+                    resultImages!.length > 1
+                      ? `View image ${i + 1} of ${resultImages!.length}`
+                      : 'View image'
+                  }
+                >
+                  <img
+                    src={`data:${img.mediaType};base64,${img.data}`}
+                    alt=""
+                    className="tool-result-image-thumb"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </button>
+              ))}
+            </div>
           )}
         </div>
       )}
@@ -343,6 +394,9 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
           <pre>{partialPreview.text}</pre>
         </div>
       )}
+      {/* #6755 — full-resolution click-to-zoom for a tool-result thumbnail.
+          Renders nothing while lightboxUri is null. */}
+      <ImageLightbox uri={lightboxUri} onClose={() => setLightboxIndex(null)} label={lightboxLabel} />
     </div>
   )
 }

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -338,6 +338,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
                   className="tool-result-image-btn"
                   data-testid={`tool-result-image-${toolUseId}-${i}`}
                   onClick={() => setLightboxIndex(i)}
+                  aria-haspopup="dialog"
                   aria-label={
                     resultImages!.length > 1
                       ? `View image ${i + 1} of ${resultImages!.length}`

--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -10,7 +10,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import * as fs from 'fs'
 import * as path from 'path'
-import type { ChatMessage } from '@chroxy/store-core'
+import type { ChatMessage, ToolResultImage } from '@chroxy/store-core'
 import { ToolGroup } from './ToolGroup'
 
 const componentsCss = fs.readFileSync(path.resolve(__dirname, '../theme/components.css'), 'utf-8')
@@ -525,6 +525,96 @@ describe('ToolGroup', () => {
       // panel must NOT toggle the entry — only the row is the click target.
       fireEvent.click(detail)
       expect(screen.getByTestId('tool-group-entry-detail-1')).toBeInTheDocument()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // #6755 — tool-result images (computer-use screenshots, browser tools
+  // returning base64 PNGs) render as thumbnails in the grouped entry's
+  // detail panel, replacing the previous "Result: (no result)" placeholder
+  // for the images-only case, with click-to-zoom into a full-resolution
+  // lightbox. Mirrors the ToolBubble behavior (#6755) for the 2+-tool
+  // grouped path.
+  // ---------------------------------------------------------------------------
+  describe('tool-result image rendering in the grouped entry detail (#6755)', () => {
+    // Fixed-length tuple (not a bare array) so indexed access stays typed as
+    // `ToolResultImage`, not `ToolResultImage | undefined`, under the
+    // dashboard's `noUncheckedIndexedAccess` tsconfig.
+    const image1: ToolResultImage = { mediaType: 'image/png', data: 'iVBORw0KGgoAAAANSUhEUg==' }
+    const image2: ToolResultImage = { mediaType: 'image/png', data: 'ZmFrZS1zZWNvbmQtaW1hZ2U=' }
+    const images: [ToolResultImage, ToolResultImage] = [image1, image2]
+
+    it('renders an image thumbnail for an images-only result instead of "(no result)"', () => {
+      const messages = [
+        tool('1', 'screenshot', { toolResultImages: [image1] }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      const detail = screen.getByTestId('tool-group-entry-detail-1')
+      expect(detail).not.toHaveTextContent('(no result)')
+      const grid = screen.getByTestId('tool-group-entry-images-1')
+      expect(grid).toBeInTheDocument()
+      const thumbBtn = screen.getByTestId('tool-group-entry-image-1-0')
+      expect(thumbBtn.querySelector('img')).toHaveAttribute(
+        'src',
+        `data:${images[0].mediaType};base64,${images[0].data}`,
+      )
+    })
+
+    it('renders one thumbnail per image for a multi-image result', () => {
+      const messages = [tool('1', 'screenshot', { toolResultImages: images })]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      expect(screen.getByTestId('tool-group-entry-image-1-0')).toBeInTheDocument()
+      expect(screen.getByTestId('tool-group-entry-image-1-1')).toBeInTheDocument()
+    })
+
+    it('still shows the Result text section when a tool has both text and images', () => {
+      const messages = [
+        tool('1', 'Bash', { toolResult: 'saved screenshot', toolResultImages: [images[0]] }),
+      ]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      const detail = screen.getByTestId('tool-group-entry-detail-1')
+      expect(detail).toHaveTextContent('saved screenshot')
+      expect(screen.getByTestId('tool-group-entry-images-1')).toBeInTheDocument()
+    })
+
+    it('still shows "(no result)" for a resolved empty-string result with no images (regression guard)', () => {
+      const messages = [tool('1', 'Bash', { toolResult: '' })]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toHaveTextContent('(no result)')
+    })
+
+    it('still shows "(no result yet)" for a pending tool with no images (regression guard)', () => {
+      const messages = [tool('1', 'Bash', { toolInput: { command: 'sleep 5' } })]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toHaveTextContent('(no result yet)')
+    })
+
+    it('opens the full-resolution lightbox on thumbnail click without collapsing the entry or group', () => {
+      const messages = [tool('1', 'screenshot', { toolResultImages: [images[0]] })]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      expect(screen.queryByTestId('image-lightbox-img')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('tool-group-entry-image-1-0'))
+      const lightboxImg = screen.getByTestId('image-lightbox-img')
+      expect(lightboxImg).toHaveAttribute('src', `data:${images[0].mediaType};base64,${images[0].data}`)
+      // Neither the entry nor the parent group collapsed.
+      expect(screen.getByTestId('tool-group-entry-detail-1')).toBeInTheDocument()
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('dismisses the lightbox via its close button', () => {
+      const messages = [tool('1', 'screenshot', { toolResultImages: [images[0]] })]
+      render(<ToolGroup messages={messages} isActive={true} />)
+      fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+      fireEvent.click(screen.getByTestId('tool-group-entry-image-1-0'))
+      expect(screen.getByTestId('image-lightbox-img')).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: 'Close image' }))
+      expect(screen.queryByTestId('image-lightbox-img')).not.toBeInTheDocument()
     })
   })
 

--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -559,6 +559,9 @@ describe('ToolGroup', () => {
         'src',
         `data:${images[0].mediaType};base64,${images[0].data}`,
       )
+      // The thumbnail opens the ImageLightbox modal — announce that to AT
+      // (matches the dashboard's modal-trigger pattern).
+      expect(thumbBtn).toHaveAttribute('aria-haspopup', 'dialog')
     })
 
     it('renders one thumbnail per image for a multi-image result', () => {
@@ -567,6 +570,9 @@ describe('ToolGroup', () => {
       fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
       expect(screen.getByTestId('tool-group-entry-image-1-0')).toBeInTheDocument()
       expect(screen.getByTestId('tool-group-entry-image-1-1')).toBeInTheDocument()
+      // Every thumbnail in the grid is a modal trigger.
+      expect(screen.getByTestId('tool-group-entry-image-1-0')).toHaveAttribute('aria-haspopup', 'dialog')
+      expect(screen.getByTestId('tool-group-entry-image-1-1')).toHaveAttribute('aria-haspopup', 'dialog')
     })
 
     it('still shows the Result text section when a tool has both text and images', () => {

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -19,6 +19,7 @@ import {
   shouldSuppressRawToolInput,
 } from '@chroxy/store-core'
 import { ChildAgentEventList } from './ChildAgentEventList'
+import { ImageLightbox } from './ImageLightbox'
 import { ChatExpandContext, useInitialExpanded } from './chatExpandRegistry'
 
 export interface ToolGroupProps {
@@ -153,6 +154,26 @@ function ToolGroupEntry({
   // Distinguish "tool finished with empty output" from "tool still running".
   // hasResult covers both toolResult presence and image results.
   const resultPlaceholder = hasResult ? '(no result)' : '(no result yet)'
+  // #6755 — images-only tool results (computer-use screenshots, browser
+  // tools returning base64 PNGs) previously rendered "Result: (no result)"
+  // in this panel because `resultDetail` was empty and there was nowhere
+  // else for the image data to go. `hasImages` drives a dedicated Images
+  // section below; `showResultText` suppresses the now-redundant "(no
+  // result)" placeholder specifically for the images-only case (pending
+  // and text-bearing results still show the Result section as before).
+  const hasImages = (message.toolResultImages?.length ?? 0) > 0
+  const hasTextResult = message.toolResult !== undefined && message.toolResult !== ''
+  const showResultText = !hasResult || hasTextResult || !hasImages
+  // #6755 — full-resolution click-to-zoom, same pattern as ToolBubble:
+  // store the INDEX (not the data URI) so the lightbox label can read
+  // "Image N of M".
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+  const lightboxImage = lightboxIndex != null ? message.toolResultImages?.[lightboxIndex] : undefined
+  const lightboxUri = lightboxImage ? `data:${lightboxImage.mediaType};base64,${lightboxImage.data}` : null
+  const lightboxLabel =
+    message.toolResultImages && message.toolResultImages.length > 1 && lightboxIndex != null
+      ? `Image ${lightboxIndex + 1} of ${message.toolResultImages.length}`
+      : 'Image'
 
   return (
     <div
@@ -211,12 +232,50 @@ function ToolGroupEntry({
               {inputDetail || '(no input)'}
             </pre>
           </div>
-          <div className="tool-group-entry-detail-section">
-            <div className="tool-group-entry-detail-label">Result</div>
-            <pre className="tool-group-entry-detail-content">
-              {resultDetail || resultPlaceholder}
-            </pre>
-          </div>
+          {showResultText && (
+            <div className="tool-group-entry-detail-section">
+              <div className="tool-group-entry-detail-label">Result</div>
+              <pre className="tool-group-entry-detail-content">
+                {resultDetail || resultPlaceholder}
+              </pre>
+            </div>
+          )}
+          {/* #6755 — images-only tool results (computer-use screenshots,
+              browser tools returning base64 PNGs) render a thumbnail grid
+              here instead of the "Result: (no result)" placeholder above
+              (suppressed via `showResultText`). Click a thumbnail to open
+              the full-resolution lightbox. */}
+          {hasImages && (
+            <div className="tool-group-entry-detail-section">
+              <div className="tool-group-entry-detail-label">
+                {message.toolResultImages!.length === 1 ? 'Image' : `Images (${message.toolResultImages!.length})`}
+              </div>
+              <div className="tool-result-images" data-testid={`tool-group-entry-images-${message.id}`}>
+                {message.toolResultImages!.map((img, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    className="tool-result-image-btn"
+                    data-testid={`tool-group-entry-image-${message.id}-${i}`}
+                    onClick={() => setLightboxIndex(i)}
+                    aria-label={
+                      message.toolResultImages!.length > 1
+                        ? `View image ${i + 1} of ${message.toolResultImages!.length}`
+                        : 'View image'
+                    }
+                  >
+                    <img
+                      src={`data:${img.mediaType};base64,${img.data}`}
+                      alt=""
+                      className="tool-result-image-thumb"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
           {/* #5016 — Task subagent nested progress in grouped-entry view.
               When this entry is a Task tool_use whose subagent emitted
               intermediate events, surface them here so the user sees the
@@ -232,6 +291,7 @@ function ToolGroupEntry({
           )}
         </div>
       )}
+      <ImageLightbox uri={lightboxUri} onClose={() => setLightboxIndex(null)} label={lightboxLabel} />
     </div>
   )
 }

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -258,6 +258,7 @@ function ToolGroupEntry({
                     className="tool-result-image-btn"
                     data-testid={`tool-group-entry-image-${message.id}-${i}`}
                     onClick={() => setLightboxIndex(i)}
+                    aria-haspopup="dialog"
                     aria-label={
                       message.toolResultImages!.length > 1
                         ? `View image ${i + 1} of ${message.toolResultImages!.length}`

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3158,6 +3158,74 @@ button.sidebar-token-view-session-row:hover {
   display: block;
 }
 
+/* #6755 — tool-result image thumbnails (computer-use screenshots, browser
+   PNGs). Mirrors `.msg-attachments`/`.msg-attachment-image` (#6632) so
+   image previews read consistently whether they came from a user
+   attachment or a tool result. Shared by ToolBubble's expanded body and
+   ToolGroup's per-entry detail panel. */
+.tool-result-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.tool-result-image-btn {
+  display: block;
+  padding: 0;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  border-radius: var(--radius-sm, 6px);
+  background: none;
+  cursor: pointer;
+  overflow: hidden;
+  line-height: 0;
+}
+
+.tool-result-image-btn:hover,
+.tool-result-image-btn:focus-visible {
+  border-color: var(--accent-blue);
+}
+
+.tool-result-image-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 1px;
+}
+
+.tool-result-image-thumb {
+  display: block;
+  width: 140px;
+  height: 100px;
+  object-fit: cover;
+  background: var(--bg-elevated, var(--bg-input));
+}
+
+/* #6755 — ImageLightbox: the full-resolution click-to-zoom overlay,
+   composed from the generic `.modal-overlay`/`.modal-content` (above). */
+.image-lightbox-close {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.image-lightbox-close:hover {
+  color: var(--text-primary);
+}
+
+.image-lightbox-img {
+  display: block;
+  max-width: 100%;
+  max-height: 80vh;
+  margin: 0 auto;
+  border-radius: 8px;
+}
+
 /* ---- Tool Group (#3747) ----
  *
  * Wraps a contiguous run of tool calls under a single collapsible block.


### PR DESCRIPTION
## Problem

Tools that resolve with images (computer-use screenshots, browser tools returning base64 PNGs) never displayed those images in the web dashboard's chat, even though the server forwards them and the dashboard store holds them (`tool-result.js` -> `handleToolResult` -> `ChatMessage.toolResultImages` -> `useMessageRenderer` -> `resultImages` prop). The data was fully plumbed into `ToolBubble`/`ToolGroup` but only consumed by the "is this tool resolved?" pulse predicate — never rendered. A screenshot-only tool result showed up as an empty/collapsed bubble, or `Result: (no result)` in the grouped path. Mobile already renders this data as a thumbnail grid with a full-screen viewer (`ToolDetailModal` + `ImageViewer`); the dashboard was the only surface missing it.

## Approach

Mirrored mobile's data path (`data:${mediaType};base64,${data}` thumbnails, tap-to-zoom) using the dashboard's existing component patterns rather than mobile's exact UI:

- **`ToolBubble`**: renders `resultImages` as a thumbnail grid in the expanded body, independent of whether a text result is also present. Split the existing `hasResult` predicate into `hasTextResult`/`hasImages` so an images-only result (`result === undefined`) still shows a panel instead of nothing — previously the whole result `<div>` was gated on `result` being truthy.
- **`ToolGroup`**: same thumbnail grid in the per-entry detail panel. Added `showResultText` to suppress the now-redundant `(no result)` placeholder specifically for the images-only case; pending (`(no result yet)`) and text-bearing results are unaffected (regression-guarded by tests).
- **New `ImageLightbox` component**: composes the existing generic `Modal` (Escape key, backdrop-close, focus trap already built in) for the full-resolution click-to-zoom overlay, plus an explicit close button. Shared by both `ToolBubble` and `ToolGroup` so the two surfaces present identically. The lightbox swallows its own click events so opening/dismissing it never bubbles into the parent bubble/entry's own expand-collapse toggle.
- New CSS: `.tool-result-images` / `.tool-result-image-btn` / `.tool-result-image-thumb` (mirrors the existing `.msg-attachments` / `.msg-attachment-image` styling used for user-sent image attachments) plus `.image-lightbox-close` / `.image-lightbox-img`.

**No protocol or store-core changes.** Verified the issue's file:line claims against current `main` before starting — `toolResultImages` was already threaded end-to-end (`packages/server/src/tool-result.js` -> `packages/store-core/src/handlers/stream.ts` -> `packages/dashboard/src/hooks/useMessageRenderer.tsx`); only the dashboard render path was missing. This PR touches dashboard components/styles/tests only.

## Testing

- New vitest coverage: `ToolBubble.test.tsx` (images-only result, multi-image grid, text+images together, lightbox open/close/Escape, aria-controls for images-only, empty-array no-op), `ToolGroup.test.tsx` (grouped entry images-only replacing the `(no result)` placeholder, multi-image grid, text+images together, pending/empty-string regression guards, lightbox open/close without collapsing the entry or group), and a new `ImageLightbox.test.tsx`.
- `cd packages/dashboard && npx vitest run` — full suite green: 254 test files, 4373 tests passing (0 regressions).
- `cd packages/dashboard && npx tsc --noEmit` — clean.

Closes #6755