### PR TITLE
feat(dashboard): in-session transcript search (Cmd+F) (#6788)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -37,6 +37,7 @@ import { processImageFiles, filterImageFiles } from './utils/image-utils'
 import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
 import { formatTranscript } from './lib/transcript'
+import { extractRowSearchText } from './lib/transcriptSearch'
 import { ActivityIndicator, findInFlightToolUse } from './components/ActivityIndicator'
 import { CheckInChip } from './components/CheckInChip'
 import { EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
@@ -1137,24 +1138,19 @@ export function App() {
     streamingMessageId,
   })
 
-  // #6788 — searchable-text extractor for the ChatView in-session find bar. Most
-  // rows carry their visible text in `content`; a collapsed `tool_group` row
-  // (2+ contiguous tools) has empty `content`, so pull its inner tool summaries
-  // + results from the group payload the pipeline already built. Memoized on the
-  // payload map so ChatView's memoized searchable-row list stays stable.
+  // #6788 — searchable-text extractor for the ChatView in-session find bar.
+  // Delegates to the pure `extractRowSearchText` helper (unit-tested in
+  // lib/transcriptSearch.test.ts): collapsed `tool_group` rows join their inner
+  // tool summaries + results from the group payload, and a SINGLETON `tool_use`
+  // row appends the store message's `toolResult` (#6811 review — a lone tool's
+  // stdout lives on the store message, not in the row's `content`, and must be
+  // just as findable as the same output inside a 2+ group; mobile searches
+  // content || toolResult on every row). Memoized on the two lookup maps so
+  // ChatView's memoized searchable-row list stays stable.
   const chatSearchText = useCallback(
-    (msg: ChatViewMessage): string => {
-      if (msg.type !== 'tool_group') return msg.content
-      const payload = chatToolGroupPayloads.get(msg.id)
-      if (!payload) return msg.content
-      let text = ''
-      for (const m of payload.messages) {
-        if (m.content) text += m.content + ' '
-        if (m.toolResult) text += m.toolResult + ' '
-      }
-      return text
-    },
-    [chatToolGroupPayloads],
+    (msg: ChatViewMessage): string =>
+      extractRowSearchText(msg, chatToolGroupPayloads, storeMsgMap),
+    [chatToolGroupPayloads, storeMsgMap],
   )
 
   // System events for the System tab — uses the same toChatViewMessage

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -26,7 +26,7 @@ import { resolveActivePrimaryClientId } from './components/ViewersIndicator'
 import { type ContextMenuItem } from './components/SessionContextMenu'
 import { buildSidebarContextMenuItems } from './sidebarContextMenuItems'
 import { useCommands, recordMruCommand, getMruCommands } from './store/commands'
-import { ChatView } from './components/ChatView'
+import { ChatView, type ChatViewMessage } from './components/ChatView'
 import { MultiTerminalView } from './components/MultiTerminalView'
 import { InputBar, type FileAttachment, type ImageAttachment } from './components/InputBar'
 import { useVoiceInput } from './hooks/useVoiceInput'
@@ -506,6 +506,10 @@ export function App() {
   // bottom even when the user had scrolled up to read history — see ChatView's
   // scrollToBottomSignal effect.
   const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0)
+  // #6788 — nonce bumped by the Cmd/Ctrl+F shortcut to summon the ChatView's
+  // in-session find bar. A nonce (not a boolean) re-opens it reliably and keeps
+  // ChatView's memo wrapper intact. Only passed to the primary chat panes.
+  const [openSearchSignal, setOpenSearchSignal] = useState(0)
   const evaluateDraft = useConnectionStore(s => s.evaluateDraft)
   const sendPermissionResponse = useConnectionStore(s => s.sendPermissionResponse)
   const switchSession = useConnectionStore(s => s.switchSession)
@@ -1013,6 +1017,11 @@ export function App() {
     // handleShowQr/isConnected are declared below; the ref no-ops when null
     // (disconnected), so the shortcut only opens the modal when there's a server.
     showQr: () => showQrRef.current?.(),
+    // #6788 — Cmd/Ctrl+F summons the in-session find bar. Only intercept the
+    // browser's native find when a chat transcript is on screen (chat view, or a
+    // split whose first pane is chat); elsewhere the event falls through.
+    chatTranscriptVisible: viewMode === 'chat' || splitMode !== null,
+    openTranscriptSearch: () => setOpenSearchSignal(n => n + 1),
   })
 
   const trackedCommands = useMemo(
@@ -1127,6 +1136,26 @@ export function App() {
     storeMessages,
     streamingMessageId,
   })
+
+  // #6788 — searchable-text extractor for the ChatView in-session find bar. Most
+  // rows carry their visible text in `content`; a collapsed `tool_group` row
+  // (2+ contiguous tools) has empty `content`, so pull its inner tool summaries
+  // + results from the group payload the pipeline already built. Memoized on the
+  // payload map so ChatView's memoized searchable-row list stays stable.
+  const chatSearchText = useCallback(
+    (msg: ChatViewMessage): string => {
+      if (msg.type !== 'tool_group') return msg.content
+      const payload = chatToolGroupPayloads.get(msg.id)
+      if (!payload) return msg.content
+      let text = ''
+      for (const m of payload.messages) {
+        if (m.content) text += m.content + ' '
+        if (m.toolResult) text += m.toolResult + ' '
+      }
+      return text
+    },
+    [chatToolGroupPayloads],
+  )
 
   // System events for the System tab — uses the same toChatViewMessage
   // mapping the chat pipeline does so both surfaces present rows in the
@@ -2304,6 +2333,8 @@ export function App() {
                         onCancelQueued={onCancelQueued}
                         workingLabel={workingLabel}
                         inFlightToolColor={inFlightToolColor}
+                        openSearchSignal={openSearchSignal}
+                        getSearchText={chatSearchText}
                       />
                     }
                     second={
@@ -2351,6 +2382,8 @@ export function App() {
                         onCancelQueued={onCancelQueued}
                         workingLabel={workingLabel}
                         inFlightToolColor={inFlightToolColor}
+                        openSearchSignal={openSearchSignal}
+                        getSearchText={chatSearchText}
                       />
                     </div>
                     <div

--- a/packages/dashboard/src/components/ChatView.search.test.tsx
+++ b/packages/dashboard/src/components/ChatView.search.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * ChatView in-session find — #6788
+ *
+ * Covers the find bar wired into the virtualized dashboard ChatView:
+ *   1. Summoning (the openSearchSignal nonce) opens + focuses the bar.
+ *   2. Typing shows an N/M counter and message-row-level highlight.
+ *   3. Next / previous navigation cycles the active match (wrap-around).
+ *   4. A non-matching query shows the "No results" state.
+ *   5. Escape and the close button dismiss the bar (and clear the query).
+ *   6. Jumping to a match works against the virtualized list — an off-screen
+ *      (windowed-out) match is scrolled to and mounted without a manual scroll.
+ *
+ * jsdom reports 0 for layout geometry, so test 6 stubs offsetHeight / clientHeight
+ * / scrollHeight the same way ChatView.virtualization.test.tsx does.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { useState } from 'react'
+import { ChatView, type ChatViewMessage } from './ChatView'
+
+afterEach(cleanup)
+
+function makeMessages(count: number): ChatViewMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `msg-${i}`,
+    type: 'response' as const,
+    content: `Message ${i}`,
+    timestamp: 1000 + i,
+  }))
+}
+
+/** Render ChatView with a button that bumps the openSearchSignal nonce. */
+function Harness({ messages }: { messages: ChatViewMessage[] }) {
+  const [sig, setSig] = useState(0)
+  return (
+    <>
+      <button data-testid="summon" onClick={() => setSig((n) => n + 1)}>
+        summon
+      </button>
+      <ChatView messages={messages} isStreaming={false} openSearchSignal={sig} />
+    </>
+  )
+}
+
+function summon() {
+  fireEvent.click(screen.getByTestId('summon'))
+}
+
+function type(value: string) {
+  fireEvent.change(screen.getByTestId('transcript-search-input'), { target: { value } })
+}
+
+describe('ChatView in-session find (#6788)', () => {
+  it('is hidden until summoned, then opens and focuses the input', () => {
+    render(<Harness messages={makeMessages(5)} />)
+    expect(screen.queryByTestId('transcript-search-bar')).not.toBeInTheDocument()
+    summon()
+    const input = screen.getByTestId('transcript-search-input')
+    expect(input).toBeInTheDocument()
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('shows an N/M counter and highlights matching rows', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'm0', type: 'response', content: 'alpha match one', timestamp: 1 },
+      { id: 'm1', type: 'response', content: 'beta', timestamp: 2 },
+      { id: 'm2', type: 'response', content: 'gamma match two', timestamp: 3 },
+      { id: 'm3', type: 'response', content: 'delta', timestamp: 4 },
+      { id: 'm4', type: 'response', content: 'epsilon match three', timestamp: 5 },
+    ]
+    render(<Harness messages={messages} />)
+    summon()
+    type('match')
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/3')
+    // Every hit is tinted; the first is the active match.
+    expect(document.querySelectorAll('[data-search-match]').length).toBe(3)
+    const active = document.querySelector('[data-search-active]')
+    expect(active?.getAttribute('data-row-key')).toBe('m0')
+  })
+
+  it('next / previous cycle the active match with wrap-around', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'm0', type: 'response', content: 'alpha match', timestamp: 1 },
+      { id: 'm1', type: 'response', content: 'beta match', timestamp: 2 },
+      { id: 'm2', type: 'response', content: 'gamma match', timestamp: 3 },
+    ]
+    render(<Harness messages={messages} />)
+    summon()
+    type('match')
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/3')
+
+    fireEvent.click(screen.getByTestId('transcript-search-next'))
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('2/3')
+    expect(document.querySelector('[data-search-active]')?.getAttribute('data-row-key')).toBe('m1')
+
+    // Wrap forward past the end back to the first match.
+    fireEvent.click(screen.getByTestId('transcript-search-next'))
+    fireEvent.click(screen.getByTestId('transcript-search-next'))
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/3')
+
+    // Wrap backward from the first to the last.
+    fireEvent.click(screen.getByTestId('transcript-search-prev'))
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('3/3')
+    expect(document.querySelector('[data-search-active]')?.getAttribute('data-row-key')).toBe('m2')
+  })
+
+  it('Enter advances and Shift+Enter steps back', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'm0', type: 'response', content: 'match a', timestamp: 1 },
+      { id: 'm1', type: 'response', content: 'match b', timestamp: 2 },
+    ]
+    render(<Harness messages={messages} />)
+    summon()
+    type('match')
+    const input = screen.getByTestId('transcript-search-input')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('2/2')
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/2')
+  })
+
+  it('shows "No results" for a non-matching query', () => {
+    render(<Harness messages={makeMessages(5)} />)
+    summon()
+    type('zzz-nope')
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('No results')
+    expect(document.querySelector('[data-search-active]')).toBeNull()
+  })
+
+  it('Escape closes the bar and clears the query', () => {
+    render(<Harness messages={makeMessages(5)} />)
+    summon()
+    type('Message')
+    fireEvent.keyDown(screen.getByTestId('transcript-search-input'), { key: 'Escape' })
+    expect(screen.queryByTestId('transcript-search-bar')).not.toBeInTheDocument()
+    // Re-summon: the query was cleared, so no active match lingers.
+    summon()
+    expect(screen.getByTestId('transcript-search-input')).toHaveValue('')
+    expect(document.querySelector('[data-search-active]')).toBeNull()
+  })
+
+  it('the close button dismisses the bar', () => {
+    render(<Harness messages={makeMessages(5)} />)
+    summon()
+    expect(screen.getByTestId('transcript-search-bar')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('transcript-search-close'))
+    expect(screen.queryByTestId('transcript-search-bar')).not.toBeInTheDocument()
+  })
+
+  it('jumps the virtualized list to an off-screen match and mounts it', async () => {
+    const ROW_HEIGHT = 80
+    const VIEWPORT = 400
+    const offsetHeight = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(ROW_HEIGHT)
+    const clientHeight = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(VIEWPORT)
+    const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(200 * ROW_HEIGHT)
+    try {
+      // 200 rows (well past the windowing threshold); only row 150 has "needle".
+      const messages = makeMessages(200)
+      messages[150] = { id: 'msg-150', type: 'response', content: 'the needle in the haystack', timestamp: 2000 }
+
+      render(<Harness messages={messages} />)
+      // Off-screen precondition: row 150 is windowed out (not in the DOM).
+      expect(screen.queryByTestId('msg-msg-150')).not.toBeInTheDocument()
+
+      summon()
+      await act(async () => {
+        type('needle')
+        // Flush the scroll-to-match effect + its next-frame correction pass.
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null))))
+      })
+
+      // The windowed list scrolled to the match and mounted it — no manual
+      // scrolling required (the AC the issue calls out for the virtualized list).
+      const row = screen.getByTestId('msg-msg-150')
+      expect(row).toBeInTheDocument()
+      expect(row).toHaveAttribute('data-search-active')
+      expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/1')
+    } finally {
+      offsetHeight.mockRestore()
+      clientHeight.mockRestore()
+      scrollHeight.mockRestore()
+    }
+  })
+})

--- a/packages/dashboard/src/components/ChatView.search.test.tsx
+++ b/packages/dashboard/src/components/ChatView.search.test.tsx
@@ -158,6 +158,27 @@ describe('ChatView in-session find (#6788)', () => {
     expect(screen.queryByTestId('transcript-search-bar')).not.toBeInTheDocument()
   })
 
+  it('re-summoning while already open refocuses the input and preserves + selects the query (#6811 review)', () => {
+    render(<Harness messages={makeMessages(5)} />)
+    summon()
+    type('Message 3')
+    const before = screen.getByTestId('transcript-search-input') as HTMLInputElement
+    // Simulate focus wandering off to the transcript / app chrome.
+    act(() => before.blur())
+    expect(document.activeElement).not.toBe(before)
+
+    // Cmd+F again (the parent bumps the nonce) — the bar must refocus with the
+    // existing query preserved and selected, ready to be retyped or reused.
+    summon()
+    const after = screen.getByTestId('transcript-search-input') as HTMLInputElement
+    expect(document.activeElement).toBe(after)
+    expect(after).toHaveValue('Message 3')
+    expect(after.selectionStart).toBe(0)
+    expect(after.selectionEnd).toBe('Message 3'.length)
+    // Match state carried through untouched.
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/1')
+  })
+
   it('does not run the searchable-text extractor until first summoned (#6811 review minor)', () => {
     const getSearchText = vi.fn((m: ChatViewMessage) => m.content)
     render(<Harness messages={makeMessages(5)} getSearchText={getSearchText} />)

--- a/packages/dashboard/src/components/ChatView.search.test.tsx
+++ b/packages/dashboard/src/components/ChatView.search.test.tsx
@@ -30,14 +30,25 @@ function makeMessages(count: number): ChatViewMessage[] {
 }
 
 /** Render ChatView with a button that bumps the openSearchSignal nonce. */
-function Harness({ messages }: { messages: ChatViewMessage[] }) {
+function Harness({
+  messages,
+  getSearchText,
+}: {
+  messages: ChatViewMessage[]
+  getSearchText?: (msg: ChatViewMessage) => string
+}) {
   const [sig, setSig] = useState(0)
   return (
     <>
       <button data-testid="summon" onClick={() => setSig((n) => n + 1)}>
         summon
       </button>
-      <ChatView messages={messages} isStreaming={false} openSearchSignal={sig} />
+      <ChatView
+        messages={messages}
+        isStreaming={false}
+        openSearchSignal={sig}
+        getSearchText={getSearchText}
+      />
     </>
   )
 }
@@ -145,6 +156,18 @@ describe('ChatView in-session find (#6788)', () => {
     expect(screen.getByTestId('transcript-search-bar')).toBeInTheDocument()
     fireEvent.click(screen.getByTestId('transcript-search-close'))
     expect(screen.queryByTestId('transcript-search-bar')).not.toBeInTheDocument()
+  })
+
+  it('does not run the searchable-text extractor until first summoned (#6811 review minor)', () => {
+    const getSearchText = vi.fn((m: ChatViewMessage) => m.content)
+    render(<Harness messages={makeMessages(5)} getSearchText={getSearchText} />)
+    // No summon yet — the O(N) per-row extraction must not have run.
+    expect(getSearchText).not.toHaveBeenCalled()
+    summon()
+    // First summon unlocks the scan; matches still work.
+    expect(getSearchText).toHaveBeenCalled()
+    type('Message 2')
+    expect(screen.getByTestId('transcript-search-count').textContent).toBe('1/1')
   })
 
   it('jumps the virtualized list to an off-screen match and mounts it', async () => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -991,9 +991,14 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
 
       {/* #6788 — in-session find bar, overlaid on the (non-scrolling) .chat-view
           parent so it stays pinned while the .chat-messages list scrolls under
-          it. Mounted only while open; its own mount effect grabs focus. */}
+          it. Mounted only while open; its own mount effect grabs focus.
+          Keyed by the summon nonce (#6811 review): a repeat Cmd+F while the bar
+          is already open remounts it, re-running the mount focus+select so
+          every summon lands the caret in the field with the query selected —
+          the query itself lives in the hook, so the text survives the remount. */}
       {searchOpen && (
         <TranscriptSearchBar
+          key={openSearchSignal}
           query={search.query}
           currentIndex={search.currentIndex}
           matchCount={search.matchCount}

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -230,6 +230,13 @@ const SCROLL_THRESHOLD = 100
 const SEARCH_SCROLL_HEADROOM = 80
 
 /**
+ * #6788 — stable empty searchable-row list handed to the search hook until the
+ * find bar is first summoned, so the per-row text extraction never runs (and
+ * never churns memo identity) for sessions that never open find.
+ */
+const NO_SEARCH_ROWS: SearchableRow[] = []
+
+/**
  * #5561 — fallback `gap` between rows in `.chat-messages` (theme/components.css).
  * Folded into the windowing height math so the spacer heights match the real
  * scroll geometry. The live value is read from `getComputedStyle().rowGap` at
@@ -525,16 +532,25 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   // #6788 — in-session find. Build the searchable-row list from the deduped
   // messages (the same rows the windowed list renders, so a match maps 1:1 to a
   // scroll target). `getSearchText` lets the parent surface collapsed tool-group
-  // text; otherwise we match on the row's own `content`. Only recomputed when
-  // the messages or the extractor identity change.
+  // text; otherwise we match on the row's own `content`.
+  //
+  // Gated behind the bar having been summoned at least once (#6811 review):
+  // the map is O(N) and invokes `getSearchText` per row on every
+  // dedupedMessages change — i.e. every streaming flush — which is avoidable
+  // work on multi-thousand-message sessions that never open find. Until the
+  // first summon we hand the hook a stable empty list (query is '' anyway, so
+  // no matches are lost); after that it stays live so close → reopen is instant.
+  const [searchEverOpened, setSearchEverOpened] = useState(false)
   const searchRows = useMemo<SearchableRow[]>(
-    () =>
-      dedupedMessages.map((m) => ({
+    () => {
+      if (!searchEverOpened) return NO_SEARCH_ROWS
+      return dedupedMessages.map((m) => ({
         id: m.id,
         type: m.type,
         text: getSearchText ? getSearchText(m) : m.content,
-      })),
-    [dedupedMessages, getSearchText],
+      }))
+    },
+    [dedupedMessages, getSearchText, searchEverOpened],
   )
   const search = useTranscriptSearch(searchRows)
   const { open: searchOpen, currentMatchId: searchMatchId, matchIdSet: searchMatchIdSet, openSearch, closeSearch } = search
@@ -807,6 +823,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   useEffect(() => {
     if (openSearchSignal === lastOpenSearchSignalRef.current) return
     lastOpenSearchSignalRef.current = openSearchSignal
+    // First summon unlocks the searchable-row scan (see the searchRows gate).
+    setSearchEverOpened(true)
     openSearch()
   }, [openSearchSignal, openSearch])
 
@@ -818,6 +836,11 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
   // user scrolling first. Writing `scrollTop` (and re-seeding the windowing
   // state) mounts the target row in the same commit. Flagged programmatic so the
   // resulting scroll event isn't misread as a user scroll-up.
+  // #6811 review — the programmatic-flag-clear RAF is tracked in a ref so a
+  // superseding jump (fast typing / rapid next-next) cancels the stale clear
+  // before scheduling its own, and the scroll-to-match effect's cleanup can
+  // cancel + flush it on unmount/match-change instead of leaking it.
+  const searchFlagClearRafRef = useRef<number | null>(null)
   const scrollToRowIndex = useCallback((index: number) => {
     const el = containerRef.current
     if (!el || index < 0) return
@@ -826,7 +849,11 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     el.scrollTop = target
     setScrollTop(target)
     setViewportHeight(el.clientHeight)
-    requestAnimationFrame(() => { programmaticScrollRef.current = false })
+    if (searchFlagClearRafRef.current !== null) cancelAnimationFrame(searchFlagClearRafRef.current)
+    searchFlagClearRafRef.current = requestAnimationFrame(() => {
+      searchFlagClearRafRef.current = null
+      programmaticScrollRef.current = false
+    })
   }, [])
 
   // #6788 — keep the active find match in view. On each match change: mark the
@@ -845,7 +872,16 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
       const idx2 = dedupRef.current.findIndex((m) => m.id === searchMatchId)
       if (idx2 >= 0) scrollToRowIndex(idx2)
     })
-    return () => cancelAnimationFrame(raf)
+    return () => {
+      cancelAnimationFrame(raf)
+      // Cancel + flush any pending flag-clear so the programmatic-scroll flag
+      // can't be left stuck true past this effect's lifetime (#6811 review).
+      if (searchFlagClearRafRef.current !== null) {
+        cancelAnimationFrame(searchFlagClearRafRef.current)
+        searchFlagClearRafRef.current = null
+        programmaticScrollRef.current = false
+      }
+    }
   }, [searchMatchId, scrollToRowIndex])
 
   // #5561 — the windowed slice. Only rows in [startIndex, endIndex) mount; the

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -26,6 +26,9 @@ import { isRenderableImageUri } from '../utils/attachment-preview'
 import { MessageRowShell } from './MeasuredRow'
 import { ChatExpandContext, type ChatExpandRegistry } from './chatExpandRegistry'
 import { useWindowedRange } from './useWindowedRange'
+import { TranscriptSearchBar } from './TranscriptSearchBar'
+import { useTranscriptSearch } from '../hooks/useTranscriptSearch'
+import type { SearchableRow } from '../lib/transcriptSearch'
 
 /* ---- Sender Icons ---- */
 
@@ -183,6 +186,22 @@ export interface ChatViewProps {
    * ("Claude is working…"). A stable string so it doesn't churn per token.
    */
   workingLabel?: string
+  /**
+   * #6788 — monotonically-increasing nonce the parent bumps to summon the
+   * in-session find bar (Cmd/Ctrl+F). A nonce (rather than a boolean) keeps
+   * ChatView's memo wrapper intact and re-opens the bar reliably even if it
+   * was already open. The initial value is ignored; only changes open it.
+   * Undefined → the find affordance is never summoned (e.g. the System tab).
+   */
+  openSearchSignal?: number
+  /**
+   * #6788 — optional per-row searchable-text extractor for in-session find.
+   * The parent supplies it so collapsed `tool_group` rows (whose ChatViewMessage
+   * `content` is empty) still match on their inner tool summaries + results.
+   * When omitted, find matches against each row's `content`. Must be stable
+   * (memoized) — it feeds a memoized searchable-row list.
+   */
+  getSearchText?: (msg: ChatViewMessage) => string
 }
 
 const TYPE_CLASS: Record<string, string> = {
@@ -202,6 +221,13 @@ const TYPE_CLASS: Record<string, string> = {
  * very bottom still counts as "following the conversation").
  */
 const SCROLL_THRESHOLD = 100
+
+/**
+ * #6788 — headroom (px) left above a search match when the list scrolls to it,
+ * so the matched row lands just below the top edge rather than flush against it
+ * (mirrors the mobile `y - 80` headroom / `viewPosition: 0` landing).
+ */
+const SEARCH_SCROLL_HEADROOM = 80
 
 /**
  * #5561 — fallback `gap` between rows in `.chat-messages` (theme/components.css).
@@ -398,7 +424,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel, openSearchSignal, getSearchText }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
   // #6392 — 1-based send position for each queued follow-up, derived from the
@@ -495,6 +521,31 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     rowGap,
     keyAt,
   })
+
+  // #6788 — in-session find. Build the searchable-row list from the deduped
+  // messages (the same rows the windowed list renders, so a match maps 1:1 to a
+  // scroll target). `getSearchText` lets the parent surface collapsed tool-group
+  // text; otherwise we match on the row's own `content`. Only recomputed when
+  // the messages or the extractor identity change.
+  const searchRows = useMemo<SearchableRow[]>(
+    () =>
+      dedupedMessages.map((m) => ({
+        id: m.id,
+        type: m.type,
+        text: getSearchText ? getSearchText(m) : m.content,
+      })),
+    [dedupedMessages, getSearchText],
+  )
+  const search = useTranscriptSearch(searchRows)
+  const { open: searchOpen, currentMatchId: searchMatchId, matchIdSet: searchMatchIdSet, openSearch, closeSearch } = search
+
+  // Latest windowed range + deduped list read imperatively by the scroll-to-match
+  // effect (both change identity across renders; a ref keeps the effect keyed on
+  // just the active match id rather than re-firing on every windowing recompute).
+  const rangeRef = useRef(range)
+  rangeRef.current = range
+  const dedupRef = useRef(dedupedMessages)
+  dedupRef.current = dedupedMessages
 
   const syncGeometry = useCallback(() => {
     const el = containerRef.current
@@ -749,6 +800,54 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
     return () => cancelAnimationFrame(rafId)
   }, [isStreaming, userScrolledUp, scrollToBottomNow])
 
+  // #6788 — summon the find bar when the parent bumps the nonce. Seeded with the
+  // initial value so mount is a no-op; only a genuine bump opens (mirrors the
+  // scrollToBottomSignal pattern). Undefined nonce → never fires (System tab).
+  const lastOpenSearchSignalRef = useRef(openSearchSignal)
+  useEffect(() => {
+    if (openSearchSignal === lastOpenSearchSignalRef.current) return
+    lastOpenSearchSignalRef.current = openSearchSignal
+    openSearch()
+  }, [openSearchSignal, openSearch])
+
+  // #6788 — scroll the (virtualized) list to a row by index. Uses the windowing
+  // hook's `offsetAt` to compute the row's content-space top edge — which works
+  // for rows currently WINDOWED OUT (off-screen), the case the issue calls out:
+  // native browser find can't reach an unmounted row, but `offsetAt` sums the
+  // cached/estimated heights above it, so we can jump straight there without the
+  // user scrolling first. Writing `scrollTop` (and re-seeding the windowing
+  // state) mounts the target row in the same commit. Flagged programmatic so the
+  // resulting scroll event isn't misread as a user scroll-up.
+  const scrollToRowIndex = useCallback((index: number) => {
+    const el = containerRef.current
+    if (!el || index < 0) return
+    const target = Math.max(0, rangeRef.current.offsetAt(index) - SEARCH_SCROLL_HEADROOM)
+    programmaticScrollRef.current = true
+    el.scrollTop = target
+    setScrollTop(target)
+    setViewportHeight(el.clientHeight)
+    requestAnimationFrame(() => { programmaticScrollRef.current = false })
+  }, [])
+
+  // #6788 — keep the active find match in view. On each match change: mark the
+  // reader as scrolled-up (so the streaming/count auto-follow doesn't yank them
+  // off the match), jump to the match's estimated offset (mounting it if it was
+  // windowed out), then re-run on the next frame once the row + its neighbours
+  // have measured so the landing is corrected from estimates to real heights.
+  useEffect(() => {
+    if (!searchMatchId) return
+    if (!containerRef.current) return
+    setUserScrolledUp(true)
+    const index = dedupRef.current.findIndex((m) => m.id === searchMatchId)
+    if (index < 0) return
+    scrollToRowIndex(index)
+    const raf = requestAnimationFrame(() => {
+      const idx2 = dedupRef.current.findIndex((m) => m.id === searchMatchId)
+      if (idx2 >= 0) scrollToRowIndex(idx2)
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [searchMatchId, scrollToRowIndex])
+
   // #5561 — the windowed slice. Only rows in [startIndex, endIndex) mount; the
   // top/bottom spacers reserve the height of the skipped rows so the scrollbar
   // geometry (and therefore scroll position when content appends above the
@@ -796,6 +895,11 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
             const icon = senderIconFor(msg.type)
             const rowClass = rowClassFor(msg.type, icon !== null)
             const custom = renderMessage?.(msg)
+            // #6788 — per-row find highlight. `searchMatch` tints every hit;
+            // `searchActive` marks the one the list is scrolled to. Passing
+            // primitives keeps the row memo skipping unaffected rows.
+            const searchMatch = searchMatchIdSet.has(msg.id)
+            const searchActive = searchMatchId === msg.id
             if (custom !== undefined && custom !== null) {
               return (
                 <MessageRowShell
@@ -804,6 +908,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   measureRow={range.measureRow}
                   className={rowClass}
                   testId={`msg-${msg.id}`}
+                  searchMatch={searchMatch}
+                  searchActive={searchActive}
                 >
                   {msg.type !== 'user_input' && icon}
                   <div style={{ display: 'contents' }}>{custom}</div>
@@ -818,6 +924,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                 measureRow={range.measureRow}
                 className={rowClass}
                 testId={`msg-${msg.id}`}
+                searchMatch={searchMatch}
+                searchActive={searchActive}
               >
                 <DefaultMessageRow
                   id={msg.id}
@@ -844,6 +952,21 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
           {(isStreaming || isBusy) && <WorkingIndicator label={workingLabel} />}
         </div>
       </ChatExpandContext.Provider>
+
+      {/* #6788 — in-session find bar, overlaid on the (non-scrolling) .chat-view
+          parent so it stays pinned while the .chat-messages list scrolls under
+          it. Mounted only while open; its own mount effect grabs focus. */}
+      {searchOpen && (
+        <TranscriptSearchBar
+          query={search.query}
+          currentIndex={search.currentIndex}
+          matchCount={search.matchCount}
+          onQueryChange={search.setQuery}
+          onNext={search.next}
+          onPrev={search.prev}
+          onClose={closeSearch}
+        />
+      )}
 
       {userScrolledUp && (
         <button

--- a/packages/dashboard/src/components/MeasuredRow.tsx
+++ b/packages/dashboard/src/components/MeasuredRow.tsx
@@ -26,10 +26,21 @@ export interface MessageRowShellProps {
   className: string
   /** Test id for the row container (kept identical to the pre-#5561 `msg-<id>`). */
   testId: string
+  /**
+   * #6788 — this row matches the active in-session find query. Stamped as a
+   * `data-search-match` attribute so the transcript can tint every hit. A
+   * plain boolean so the row memo still skips unaffected rows.
+   */
+  searchMatch?: boolean
+  /**
+   * #6788 — this row is the CURRENT (focused) find match — the one the list is
+   * scrolled to. Stamped as `data-search-active` for a stronger highlight.
+   */
+  searchActive?: boolean
   children: ReactNode
 }
 
-function MessageRowShellImpl({ rowKey, measureRow, className, testId, children }: MessageRowShellProps) {
+function MessageRowShellImpl({ rowKey, measureRow, className, testId, searchMatch, searchActive, children }: MessageRowShellProps) {
   const ref = useRef<HTMLDivElement>(null)
 
   const report = useCallback(() => {
@@ -51,7 +62,14 @@ function MessageRowShellImpl({ rowKey, measureRow, className, testId, children }
   }, [report])
 
   return (
-    <div ref={ref} className={className || undefined} data-testid={testId} data-row-key={rowKey}>
+    <div
+      ref={ref}
+      className={className || undefined}
+      data-testid={testId}
+      data-row-key={rowKey}
+      data-search-match={searchMatch ? '' : undefined}
+      data-search-active={searchActive ? '' : undefined}
+    >
       {children}
     </div>
   )

--- a/packages/dashboard/src/components/TranscriptSearchBar.tsx
+++ b/packages/dashboard/src/components/TranscriptSearchBar.tsx
@@ -1,0 +1,129 @@
+/**
+ * TranscriptSearchBar — the in-session find bar overlaid on the dashboard
+ * ChatView (#6788).
+ *
+ * A compact Cmd/Ctrl+F-style bar: a text input, an "N/M" match counter (or a
+ * "No results" state), previous / next navigation, and a close button. It is
+ * purely presentational — all match state lives in `useTranscriptSearch` and
+ * the scroll-to-match wiring lives in ChatView. Keyboard: Enter → next,
+ * Shift+Enter → previous, Escape → close (mirrors the browser find idiom and
+ * the mobile app's search controls).
+ */
+import { useEffect, useRef } from 'react'
+
+export interface TranscriptSearchBarProps {
+  /** Current query text. */
+  query: string
+  /** 0-based index of the active match. */
+  currentIndex: number
+  /** Total number of matches. */
+  matchCount: number
+  /** Update the query. */
+  onQueryChange: (q: string) => void
+  /** Advance to the next match. */
+  onNext: () => void
+  /** Step to the previous match. */
+  onPrev: () => void
+  /** Close the find bar. */
+  onClose: () => void
+}
+
+export function TranscriptSearchBar({
+  query,
+  currentIndex,
+  matchCount,
+  onQueryChange,
+  onNext,
+  onPrev,
+  onClose,
+}: TranscriptSearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Focus + select the field when the bar mounts (it mounts on open) so the
+  // user can type immediately, and a re-summon over an existing query replaces it.
+  useEffect(() => {
+    const el = inputRef.current
+    if (!el) return
+    el.focus()
+    el.select()
+  }, [])
+
+  const hasQuery = query.trim().length > 0
+  const hasMatches = matchCount > 0
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (!hasMatches) return
+      if (e.shiftKey) onPrev()
+      else onNext()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      // Keep the Escape scoped to the find bar so it doesn't bubble up to
+      // modal/overlay Escape handlers.
+      e.stopPropagation()
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      className="transcript-search"
+      data-testid="transcript-search-bar"
+      role="search"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        className="transcript-search-input"
+        data-testid="transcript-search-input"
+        placeholder="Find in conversation"
+        aria-label="Find in conversation"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <span
+        className="transcript-search-count"
+        data-testid="transcript-search-count"
+        aria-live="polite"
+      >
+        {!hasQuery ? '' : hasMatches ? `${currentIndex + 1}/${matchCount}` : 'No results'}
+      </span>
+      <div className="transcript-search-nav">
+        <button
+          type="button"
+          className="transcript-search-btn"
+          data-testid="transcript-search-prev"
+          aria-label="Previous match"
+          title="Previous match (Shift+Enter)"
+          disabled={!hasMatches}
+          onClick={onPrev}
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          className="transcript-search-btn"
+          data-testid="transcript-search-next"
+          aria-label="Next match"
+          title="Next match (Enter)"
+          disabled={!hasMatches}
+          onClick={onNext}
+        >
+          ↓
+        </button>
+        <button
+          type="button"
+          className="transcript-search-btn transcript-search-close"
+          data-testid="transcript-search-close"
+          aria-label="Close find"
+          title="Close (Escape)"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/hooks/useShortcutDispatch.test.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.test.ts
@@ -50,6 +50,7 @@ const TEST_DEFS: ShortcutDef[] = [
   { id: 'help.toggle', defaultBinding: '?', description: 'Help', category: 'other', scope: 'global' },
   { id: 'palette.toggle.vscode', defaultBinding: 'cmd+shift+p', description: 'Palette (VS Code)', category: 'navigation', scope: 'global' },
   { id: 'device.pairQr', defaultBinding: 'cmd+shift+l', description: 'Pair a device', category: 'navigation', scope: 'global' },
+  { id: 'transcript.search', defaultBinding: 'cmd+f', description: 'Find in conversation', category: 'navigation', scope: 'global', disabledInTextInput: true },
 ]
 
 function fireKey(opts: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
@@ -327,5 +328,39 @@ describe('useShortcutDispatch', () => {
     renderHook(() => useShortcutDispatch(props))
     fireKey({ key: 'p', metaKey: true, shiftKey: true })
     expect(props.setPaletteOpen).toHaveBeenCalledOnce()
+  })
+
+  it('transcript.search (Cmd+F) opens the find bar + preventDefaults when a chat transcript is visible', () => {
+    const openTranscriptSearch = vi.fn()
+    const props = makeProps({ chatTranscriptVisible: true, openTranscriptSearch })
+    renderHook(() => useShortcutDispatch(props))
+    const event = fireKey({ key: 'f', metaKey: true })
+    expect(openTranscriptSearch).toHaveBeenCalledOnce()
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('transcript.search (Cmd+F) falls through to native find when no chat transcript is visible', () => {
+    const openTranscriptSearch = vi.fn()
+    // e.g. the Files / System / Control Room tab — no transcript to search.
+    const props = makeProps({ chatTranscriptVisible: false, openTranscriptSearch })
+    renderHook(() => useShortcutDispatch(props))
+    const event = fireKey({ key: 'f', metaKey: true })
+    expect(openTranscriptSearch).not.toHaveBeenCalled()
+    // Not swallowed — the browser's native Cmd+F still runs on non-chat surfaces.
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('transcript.search (Cmd+F) does NOT fire inside a text input (native find keeps working)', () => {
+    const openTranscriptSearch = vi.fn()
+    const props = makeProps({ chatTranscriptVisible: true, openTranscriptSearch })
+    renderHook(() => useShortcutDispatch(props))
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    const event = new KeyboardEvent('keydown', { key: 'f', metaKey: true, bubbles: true, cancelable: true })
+    input.dispatchEvent(event)
+    expect(openTranscriptSearch).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    document.body.removeChild(input)
   })
 })

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -80,6 +80,18 @@ export interface ShortcutDispatchProps {
   // disconnected (the caller gates on `isConnected`), so the shortcut no-ops
   // rather than opening an empty modal with no server to pair against.
   showQr?: () => void
+  /**
+   * #6788 — true when a chat transcript is on screen (chat view active, or a
+   * split with a chat pane). Cmd+F only intercepts the browser's native find
+   * when this holds; on non-chat surfaces the event falls through so the
+   * browser's find still works (there's no transcript for our find bar to reach).
+   */
+  chatTranscriptVisible?: boolean
+  /**
+   * #6788 — summon the in-session find bar (bumps the ChatView open nonce).
+   * Only called when `chatTranscriptVisible` is true.
+   */
+  openTranscriptSearch?: () => void
 }
 
 export function useShortcutDispatch(props: ShortcutDispatchProps): void {
@@ -107,6 +119,8 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     openSymbolSearch,
     openCodeSearch,
     showQr,
+    chatTranscriptVisible,
+    openTranscriptSearch,
   } = props
 
   useEffect(() => {
@@ -207,6 +221,20 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
           if (overlays.length === 0 || onlyShortcutHelp) {
             e.preventDefault()
             setShortcutHelpOpen(prev => !prev)
+          }
+          return
+        }
+        // #6788 — Cmd/Ctrl+F in-conversation find. Only intercept (and suppress
+        // the browser's native find) when a chat transcript is actually on
+        // screen; otherwise let the event through so native find still works on
+        // non-chat surfaces. Handled BEFORE the generic preventDefault so a
+        // non-chat Cmd+F is never swallowed. The registry's `disabledInTextInput`
+        // already lets native find run while a text input (composer / other
+        // search field) has focus.
+        if (matchedId === 'transcript.search') {
+          if (chatTranscriptVisible && openTranscriptSearch) {
+            e.preventDefault()
+            openTranscriptSearch()
           }
           return
         }
@@ -323,5 +351,7 @@ export function useShortcutDispatch(props: ShortcutDispatchProps): void {
     openSettings,
     setShowCreateSession,
     setShortcutHelpOpen,
+    chatTranscriptVisible,
+    openTranscriptSearch,
   ])
 }

--- a/packages/dashboard/src/hooks/useTranscriptSearch.test.ts
+++ b/packages/dashboard/src/hooks/useTranscriptSearch.test.ts
@@ -1,0 +1,81 @@
+/**
+ * useTranscriptSearch — hook-level tests (#6788 / #6811 review).
+ *
+ * Pins the stable-empty-reference contract: when the query is blank (the
+ * steady state for every session that opened find and closed it, and for the
+ * bar sitting open with no text) or when nothing matches, `matchIds` and
+ * `matchIdSet` must keep the SAME references across `rows` changes — the rows
+ * churn on every streaming flush, and fresh [] / new Set() allocations per
+ * render would defeat downstream identity-based memos.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTranscriptSearch } from './useTranscriptSearch'
+import type { SearchableRow } from '../lib/transcriptSearch'
+
+function rowsOf(count: number): SearchableRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `r${i}`,
+    type: 'response',
+    text: `row ${i}`,
+  }))
+}
+
+describe('useTranscriptSearch stable empty references (#6811 review)', () => {
+  it('keeps matchIds / matchIdSet identities across rows changes while the query is blank', () => {
+    const { result, rerender } = renderHook(
+      ({ rows }: { rows: SearchableRow[] }) => useTranscriptSearch(rows),
+      { initialProps: { rows: rowsOf(3) } },
+    )
+    const ids1 = result.current.matchIds
+    const set1 = result.current.matchIdSet
+    expect(ids1).toEqual([])
+    expect(set1.size).toBe(0)
+
+    // Streaming appends new rows — the blank-query empties must not churn.
+    rerender({ rows: rowsOf(4) })
+    expect(result.current.matchIds).toBe(ids1)
+    expect(result.current.matchIdSet).toBe(set1)
+
+    rerender({ rows: rowsOf(50) })
+    expect(result.current.matchIds).toBe(ids1)
+    expect(result.current.matchIdSet).toBe(set1)
+  })
+
+  it('keeps stable empty identities across rows changes for a no-match query', () => {
+    const { result, rerender } = renderHook(
+      ({ rows }: { rows: SearchableRow[] }) => useTranscriptSearch(rows),
+      { initialProps: { rows: rowsOf(3) } },
+    )
+    act(() => result.current.setQuery('zzz-no-hit'))
+    const ids1 = result.current.matchIds
+    const set1 = result.current.matchIdSet
+    expect(ids1).toEqual([])
+
+    rerender({ rows: rowsOf(4) })
+    expect(result.current.matchIds).toBe(ids1)
+    expect(result.current.matchIdSet).toBe(set1)
+  })
+
+  it('shares one frozen empty across the blank and no-match cases', () => {
+    const { result } = renderHook(
+      ({ rows }: { rows: SearchableRow[] }) => useTranscriptSearch(rows),
+      { initialProps: { rows: rowsOf(3) } },
+    )
+    const blankIds = result.current.matchIds
+    act(() => result.current.setQuery('zzz-no-hit'))
+    expect(result.current.matchIds).toBe(blankIds)
+    expect(Object.isFrozen(blankIds)).toBe(true)
+  })
+
+  it('still produces real (non-empty) matches when the query hits', () => {
+    const { result } = renderHook(
+      ({ rows }: { rows: SearchableRow[] }) => useTranscriptSearch(rows),
+      { initialProps: { rows: rowsOf(3) } },
+    )
+    act(() => result.current.setQuery('row 1'))
+    expect(result.current.matchIds).toEqual(['r1'])
+    expect(result.current.matchIdSet.has('r1')).toBe(true)
+    expect(result.current.currentMatchId).toBe('r1')
+  })
+})

--- a/packages/dashboard/src/hooks/useTranscriptSearch.ts
+++ b/packages/dashboard/src/hooks/useTranscriptSearch.ts
@@ -1,0 +1,107 @@
+/**
+ * useTranscriptSearch — in-session find state for the dashboard ChatView (#6788).
+ *
+ * Owns the find bar's open/query/active-match state and derives the ordered
+ * match list from the pure `computeTranscriptMatches` helper. React-free match
+ * logic lives in `../lib/transcriptSearch`; this hook is only the state shell
+ * (mirrors the mobile SessionScreen search state, lifted into a hook so the
+ * dashboard ChatView stays lean and the behaviour is testable in isolation).
+ */
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import {
+  computeTranscriptMatches,
+  stepMatchIndex,
+  type SearchableRow,
+} from '../lib/transcriptSearch'
+
+export interface UseTranscriptSearchResult {
+  /** Whether the find bar is showing. */
+  open: boolean
+  /** Current query text. */
+  query: string
+  /** Update the query (resets the active match to the first hit). */
+  setQuery: (q: string) => void
+  /** Ordered ids of matching rows. */
+  matchIds: string[]
+  /** Set form of `matchIds` for O(1) per-row highlight checks. */
+  matchIdSet: ReadonlySet<string>
+  /** Number of matches for the "N/M" counter. */
+  matchCount: number
+  /** 0-based index of the active match within `matchIds`. */
+  currentIndex: number
+  /** Id of the active match row, or null when there are none. */
+  currentMatchId: string | null
+  /** Advance to the next match (wraps). */
+  next: () => void
+  /** Step to the previous match (wraps). */
+  prev: () => void
+  /** Show the find bar. */
+  openSearch: () => void
+  /** Hide the find bar and clear the query + active match. */
+  closeSearch: () => void
+}
+
+export function useTranscriptSearch(
+  rows: ReadonlyArray<SearchableRow>,
+): UseTranscriptSearchResult {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  const matchIds = useMemo(
+    () => computeTranscriptMatches(rows, query),
+    [rows, query],
+  )
+  const matchIdSet = useMemo(() => new Set(matchIds), [matchIds])
+
+  // Reset the active match to the first hit whenever the query changes.
+  // Keyed on the query string (not the match count) so an equal-count query
+  // change still resets — the same guard mobile uses (#6788 parity).
+  useEffect(() => {
+    setCurrentIndex(0)
+  }, [query])
+
+  // Clamp the active index if the match list shrinks under it — the transcript
+  // can grow/shrink while a query is live (streaming appends, a tool group
+  // collapsing), which would otherwise leave `currentIndex` pointing past the
+  // end.
+  useEffect(() => {
+    if (currentIndex > 0 && currentIndex >= matchIds.length) {
+      setCurrentIndex(matchIds.length > 0 ? matchIds.length - 1 : 0)
+    }
+  }, [matchIds.length, currentIndex])
+
+  const currentMatchId =
+    matchIds.length > 0 ? matchIds[currentIndex] ?? null : null
+
+  const next = useCallback(() => {
+    setCurrentIndex((i) => stepMatchIndex(i, matchIds.length, 1))
+  }, [matchIds.length])
+
+  const prev = useCallback(() => {
+    setCurrentIndex((i) => stepMatchIndex(i, matchIds.length, -1))
+  }, [matchIds.length])
+
+  const openSearch = useCallback(() => setOpen(true), [])
+
+  const closeSearch = useCallback(() => {
+    setOpen(false)
+    setQuery('')
+    setCurrentIndex(0)
+  }, [])
+
+  return {
+    open,
+    query,
+    setQuery,
+    matchIds,
+    matchIdSet,
+    matchCount: matchIds.length,
+    currentIndex,
+    currentMatchId,
+    next,
+    prev,
+    openSearch,
+    closeSearch,
+  }
+}

--- a/packages/dashboard/src/hooks/useTranscriptSearch.ts
+++ b/packages/dashboard/src/hooks/useTranscriptSearch.ts
@@ -14,6 +14,16 @@ import {
   type SearchableRow,
 } from '../lib/transcriptSearch'
 
+/**
+ * #6811 review — stable empty references returned whenever the query is blank
+ * or nothing matches. The match memo recomputes on every `rows` change (every
+ * streaming flush once search has been opened); handing downstream
+ * identity-based memos the SAME frozen array / set in the no-match case keeps
+ * them from churning on fresh `[]` / `new Set()` allocations per render.
+ */
+const EMPTY_MATCHES: readonly string[] = Object.freeze([])
+const EMPTY_MATCH_SET: ReadonlySet<string> = new Set()
+
 export interface UseTranscriptSearchResult {
   /** Whether the find bar is showing. */
   open: boolean
@@ -22,7 +32,7 @@ export interface UseTranscriptSearchResult {
   /** Update the query (resets the active match to the first hit). */
   setQuery: (q: string) => void
   /** Ordered ids of matching rows. */
-  matchIds: string[]
+  matchIds: readonly string[]
   /** Set form of `matchIds` for O(1) per-row highlight checks. */
   matchIdSet: ReadonlySet<string>
   /** Number of matches for the "N/M" counter. */
@@ -48,11 +58,20 @@ export function useTranscriptSearch(
   const [query, setQuery] = useState('')
   const [currentIndex, setCurrentIndex] = useState(0)
 
-  const matchIds = useMemo(
-    () => computeTranscriptMatches(rows, query),
-    [rows, query],
+  // #6811 review — return the module-level stable empties when the query is
+  // blank or nothing matches, so a rows change (every streaming flush once
+  // search has been opened) hands downstream identity-based memos the SAME
+  // references instead of fresh [] / new Set() allocations. With `matchIds`
+  // identity-stable in the no-match case, the `matchIdSet` memo doesn't even
+  // recompute across rows churn.
+  const matchIds = useMemo<readonly string[]>(() => {
+    const ids = computeTranscriptMatches(rows, query)
+    return ids.length === 0 ? EMPTY_MATCHES : ids
+  }, [rows, query])
+  const matchIdSet = useMemo<ReadonlySet<string>>(
+    () => (matchIds.length === 0 ? EMPTY_MATCH_SET : new Set(matchIds)),
+    [matchIds],
   )
-  const matchIdSet = useMemo(() => new Set(matchIds), [matchIds])
 
   // Reset the active match to the first hit whenever the query changes.
   // Keyed on the query string (not the match count) so an equal-count query

--- a/packages/dashboard/src/lib/transcriptSearch.test.ts
+++ b/packages/dashboard/src/lib/transcriptSearch.test.ts
@@ -6,7 +6,13 @@
  * independent of React and the virtualized ChatView.
  */
 import { describe, it, expect } from 'vitest'
-import { computeTranscriptMatches, stepMatchIndex, type SearchableRow } from './transcriptSearch'
+import {
+  computeTranscriptMatches,
+  extractRowSearchText,
+  stepMatchIndex,
+  type SearchableRow,
+  type SearchTextSourceMessage,
+} from './transcriptSearch'
 
 const rows: SearchableRow[] = [
   { id: 'a', type: 'user_input', text: 'Please refactor the Auth module' },
@@ -50,6 +56,78 @@ describe('computeTranscriptMatches', () => {
 
   it('trims surrounding whitespace before matching', () => {
     expect(computeTranscriptMatches(rows, '  refactor  ')).toEqual(['a'])
+  })
+})
+
+describe('extractRowSearchText', () => {
+  const NO_GROUPS = new Map<string, { messages: SearchTextSourceMessage[] }>()
+  const NO_STORE = new Map<string, SearchTextSourceMessage>()
+
+  it('includes a singleton tool row result from the store message (#6811 review Major)', () => {
+    // The common shape: assistant → ONE tool → assistant. The tool's stdout
+    // lives on the store message's toolResult, NOT in the row's content.
+    const storeMsgMap = new Map<string, SearchTextSourceMessage>([
+      ['t1', { content: 'Bash: npm test', toolResult: '742 passing needle-in-stdout' }],
+    ])
+    const row = { id: 't1', type: 'tool_use', content: 'Bash: npm test' }
+
+    // Precondition the fix exists for: the needle is absent from content alone.
+    expect(row.content.includes('needle-in-stdout')).toBe(false)
+
+    const text = extractRowSearchText(row, NO_GROUPS, storeMsgMap)
+    expect(text).toContain('needle-in-stdout')
+    expect(text).toContain('Bash: npm test')
+
+    // End-to-end with the matcher: the singleton tool's result text matches…
+    const withResult: SearchableRow[] = [{ id: 't1', type: 'tool_use', text }]
+    expect(computeTranscriptMatches(withResult, 'needle-in-stdout')).toEqual(['t1'])
+    // …while matching content alone (the pre-fix behaviour) finds nothing.
+    const contentOnly: SearchableRow[] = [{ id: 't1', type: 'tool_use', text: row.content }]
+    expect(computeTranscriptMatches(contentOnly, 'needle-in-stdout')).toEqual([])
+  })
+
+  it('falls back to the row content when a singleton tool has no result yet', () => {
+    // In-flight tool (no toolResult), or a row missing from the store map.
+    const storeMsgMap = new Map<string, SearchTextSourceMessage>([
+      ['t1', { content: 'Bash: sleep 5' }],
+    ])
+    expect(
+      extractRowSearchText({ id: 't1', type: 'tool_use', content: 'Bash: sleep 5' }, NO_GROUPS, storeMsgMap),
+    ).toBe('Bash: sleep 5')
+    expect(
+      extractRowSearchText({ id: 'missing', type: 'tool_use', content: 'Read foo.ts' }, NO_GROUPS, NO_STORE),
+    ).toBe('Read foo.ts')
+  })
+
+  it('joins inner tool summaries + results for a collapsed tool_group', () => {
+    const groups = new Map<string, { messages: SearchTextSourceMessage[] }>([
+      ['activity-a', {
+        messages: [
+          { content: 'Read src/a.ts', toolResult: 'const alpha = 1' },
+          { content: 'Grep beta', toolResult: 'src/b.ts: beta-hit' },
+        ],
+      }],
+    ])
+    const text = extractRowSearchText(
+      { id: 'activity-a', type: 'tool_group', content: '' },
+      groups,
+      NO_STORE,
+    )
+    expect(text).toContain('Read src/a.ts')
+    expect(text).toContain('const alpha = 1')
+    expect(text).toContain('beta-hit')
+  })
+
+  it('falls back to row content for a tool_group with no payload', () => {
+    expect(
+      extractRowSearchText({ id: 'activity-x', type: 'tool_group', content: '' }, NO_GROUPS, NO_STORE),
+    ).toBe('')
+  })
+
+  it('returns plain content for non-tool rows', () => {
+    expect(
+      extractRowSearchText({ id: 'r1', type: 'response', content: 'hello world' }, NO_GROUPS, NO_STORE),
+    ).toBe('hello world')
   })
 })
 

--- a/packages/dashboard/src/lib/transcriptSearch.test.ts
+++ b/packages/dashboard/src/lib/transcriptSearch.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the pure transcript-search helpers (#6788).
+ *
+ * These pin the match semantics the mobile app already ships (case-insensitive
+ * substring, document order, thinking excluded) and the wrap-around navigation,
+ * independent of React and the virtualized ChatView.
+ */
+import { describe, it, expect } from 'vitest'
+import { computeTranscriptMatches, stepMatchIndex, type SearchableRow } from './transcriptSearch'
+
+const rows: SearchableRow[] = [
+  { id: 'a', type: 'user_input', text: 'Please refactor the Auth module' },
+  { id: 'b', type: 'response', text: 'Sure — I updated the authentication flow' },
+  { id: 'c', type: 'thinking', text: 'the user wants auth changes' },
+  { id: 'd', type: 'tool_use', text: 'Read src/auth.ts' },
+  { id: 'e', type: 'response', text: 'Done. No auth left to touch.' },
+]
+
+describe('computeTranscriptMatches', () => {
+  it('returns [] for a blank query', () => {
+    expect(computeTranscriptMatches(rows, '')).toEqual([])
+  })
+
+  it('returns [] for a whitespace-only query', () => {
+    expect(computeTranscriptMatches(rows, '   ')).toEqual([])
+  })
+
+  it('matches case-insensitively', () => {
+    // "auth" appears in a (Auth), b (authentication), d (auth.ts), e (auth).
+    // c is a thinking row and is excluded even though it contains "auth".
+    expect(computeTranscriptMatches(rows, 'AUTH')).toEqual(['a', 'b', 'd', 'e'])
+  })
+
+  it('matches an arbitrary substring, not just word boundaries', () => {
+    expect(computeTranscriptMatches(rows, 'hentica')).toEqual(['b'])
+  })
+
+  it('preserves document order', () => {
+    expect(computeTranscriptMatches(rows, 'o')).toEqual(['a', 'b', 'e'])
+  })
+
+  it('excludes thinking rows from matches', () => {
+    // Only the thinking row contains "wants"; it must not match.
+    expect(computeTranscriptMatches(rows, 'wants')).toEqual([])
+  })
+
+  it('returns [] when nothing matches', () => {
+    expect(computeTranscriptMatches(rows, 'zzz-nope')).toEqual([])
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(computeTranscriptMatches(rows, '  refactor  ')).toEqual(['a'])
+  })
+})
+
+describe('stepMatchIndex', () => {
+  it('advances forward', () => {
+    expect(stepMatchIndex(0, 3, 1)).toBe(1)
+    expect(stepMatchIndex(1, 3, 1)).toBe(2)
+  })
+
+  it('wraps forward past the end back to 0', () => {
+    expect(stepMatchIndex(2, 3, 1)).toBe(0)
+  })
+
+  it('steps backward', () => {
+    expect(stepMatchIndex(2, 3, -1)).toBe(1)
+  })
+
+  it('wraps backward from 0 to the last index', () => {
+    expect(stepMatchIndex(0, 3, -1)).toBe(2)
+  })
+
+  it('returns 0 for an empty list', () => {
+    expect(stepMatchIndex(0, 0, 1)).toBe(0)
+    expect(stepMatchIndex(0, 0, -1)).toBe(0)
+  })
+
+  it('stays at 0 for a single-match list', () => {
+    expect(stepMatchIndex(0, 1, 1)).toBe(0)
+    expect(stepMatchIndex(0, 1, -1)).toBe(0)
+  })
+})

--- a/packages/dashboard/src/lib/transcriptSearch.ts
+++ b/packages/dashboard/src/lib/transcriptSearch.ts
@@ -51,3 +51,49 @@ export function stepMatchIndex(current: number, count: number, dir: 1 | -1): num
   if (count <= 0) return 0
   return (((current + dir) % count) + count) % count
 }
+
+/**
+ * Minimal structural view of a store ChatMessage for search-text extraction —
+ * only the fields the extractor reads, so this module stays dependency-free
+ * (`@chroxy/store-core`'s ChatMessage satisfies it structurally).
+ */
+export interface SearchTextSourceMessage {
+  content?: string
+  toolResult?: string
+}
+
+/**
+ * Build the searchable text for one chat-view row (#6788 review fix).
+ *
+ * Tool output does NOT live in `ChatViewMessage.content` — it lives on the
+ * store message's `toolResult`. Mobile searches `content || toolResult` on
+ * every row; the dashboard must do the same for BOTH tool shapes:
+ *
+ * - `tool_group` (2+ contiguous tools collapsed): `content` is empty — join
+ *   every inner tool's summary + result from the group payload.
+ * - singleton `tool_use` (the common case: assistant → one tool → assistant):
+ *   append the store message's `toolResult` so a lone tool's stdout / file
+ *   contents are just as findable as the same output inside a group.
+ * - everything else: the row's own rendered `content`.
+ */
+export function extractRowSearchText(
+  row: { id: string; type: string; content: string },
+  toolGroupPayloads: ReadonlyMap<string, { messages: readonly SearchTextSourceMessage[] }>,
+  storeMsgMap: ReadonlyMap<string, SearchTextSourceMessage>,
+): string {
+  if (row.type === 'tool_group') {
+    const payload = toolGroupPayloads.get(row.id)
+    if (!payload) return row.content
+    let text = ''
+    for (const m of payload.messages) {
+      if (m.content) text += m.content + ' '
+      if (m.toolResult) text += m.toolResult + ' '
+    }
+    return text
+  }
+  if (row.type === 'tool_use') {
+    const result = storeMsgMap.get(row.id)?.toolResult
+    return result ? `${row.content} ${result}` : row.content
+  }
+  return row.content
+}

--- a/packages/dashboard/src/lib/transcriptSearch.ts
+++ b/packages/dashboard/src/lib/transcriptSearch.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure match-index helpers for in-session transcript search (#6788).
+ *
+ * The web dashboard's ChatView is virtualized (#5561) so the browser's
+ * native find can't reach rows that are windowed out while off-screen.
+ * This module holds the pure, side-effect-free matching + navigation
+ * logic the find bar builds on — extracted so it can be unit-tested
+ * independently of React and the windowing hook. It mirrors the mobile
+ * `searchMatchArray` / `currentMatchIndex` pattern
+ * (packages/app/src/screens/SessionScreen.tsx): case-insensitive substring
+ * matching, `thinking` rows excluded, wrap-around prev/next navigation.
+ */
+
+/** One row of the currently loaded transcript, in document order. */
+export interface SearchableRow {
+  /** Stable row id — matches the ChatView row key / message id. */
+  id: string
+  /** Rendered text to match against (case-insensitive substring). */
+  text: string
+  /**
+   * Row discriminator. `thinking` rows are excluded from matches, mirroring
+   * mobile which skips reasoning bubbles from find.
+   */
+  type: string
+}
+
+/**
+ * Return the ids of rows whose `text` contains `query` (case-insensitive
+ * substring), in document order. A blank / whitespace-only query yields no
+ * matches. `thinking` rows are never matched.
+ */
+export function computeTranscriptMatches(
+  rows: ReadonlyArray<SearchableRow>,
+  query: string,
+): string[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+  const ids: string[] = []
+  for (const row of rows) {
+    if (row.type === 'thinking') continue
+    if (row.text.toLowerCase().includes(q)) ids.push(row.id)
+  }
+  return ids
+}
+
+/**
+ * Step over a match list with wrap-around. `dir` is +1 (next) or -1 (prev).
+ * Returns 0 for an empty list. Mirrors mobile's handleSearchNext / handleSearchPrev.
+ */
+export function stepMatchIndex(current: number, count: number, dir: 1 | -1): number {
+  if (count <= 0) return 0
+  return (((current + dir) % count) + count) % count
+}

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -80,6 +80,21 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
     scope: 'global',
   },
   {
+    // #6788 — Cmd/Ctrl+F in-conversation find. `disabledInTextInput` keeps the
+    // browser's native find working whenever focus is in a text input (the
+    // composer, another search field): we only intercept Cmd+F when focus is on
+    // the transcript / app chrome, and only when a chat pane is actually on
+    // screen (gated in useShortcutDispatch). The dashboard chat list is
+    // virtualized (#5561) so native find can't reach off-screen rows — this
+    // find bar can. Joins Shift+Tab / `?` as a text-input-gated shortcut.
+    id: 'transcript.search',
+    defaultBinding: 'cmd+f',
+    description: 'Find in conversation',
+    category: 'navigation',
+    scope: 'global',
+    disabledInTextInput: true,
+  },
+  {
     id: 'sidebar.toggle',
     defaultBinding: 'cmd+b',
     description: 'Toggle sidebar',

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2908,6 +2908,96 @@ button.sidebar-token-view-session-row:hover {
   border-color: var(--accent-blue);
 }
 
+/* ---- #6788 in-session transcript find ---- */
+/* Overlaid on the non-scrolling .chat-view parent so it stays pinned while the
+   .chat-messages list scrolls under it. z-index sits above the presence rail (2)
+   and the scroll-to-bottom FAB (10). */
+.transcript-search {
+  position: absolute;
+  top: 8px;
+  right: 16px;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md, 10px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+}
+
+.transcript-search-input {
+  width: 180px;
+  padding: 4px 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-input, var(--bg-secondary));
+  border: 1px solid var(--border-subtle, var(--border-primary));
+  border-radius: var(--radius-sm, 6px);
+  outline: none;
+}
+
+.transcript-search-input:focus {
+  border-color: var(--accent-blue);
+}
+
+.transcript-search-count {
+  min-width: 44px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.transcript-search-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.transcript-search-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+}
+
+.transcript-search-btn:hover:not(:disabled) {
+  background: var(--surface-raised, rgba(127, 127, 127, 0.12));
+  color: var(--text-primary);
+}
+
+.transcript-search-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Message-row-level find highlight — keyed on the data attributes MeasuredRow
+   stamps (#6788). Scoped to the scroll container so they never leak into other
+   lists. `data-search-match` tints every hit; `data-search-active` is the one
+   the list is scrolled to. */
+.chat-messages [data-search-match] {
+  background: var(--search-match-bg, rgba(250, 204, 21, 0.14));
+  border-radius: var(--radius-sm, 6px);
+}
+
+.chat-messages [data-search-active] {
+  background: var(--search-active-bg, rgba(250, 204, 21, 0.30));
+  box-shadow: 0 0 0 1px var(--accent-orange, rgba(250, 204, 21, 0.6));
+  border-radius: var(--radius-sm, 6px);
+}
+
 /* ---- Markdown in messages ---- */
 /* #6631 — subtle per-response copy control. Hidden until the bubble is hovered
    or focused (keyboard), so it doesn't clutter the transcript. */


### PR DESCRIPTION
## Summary

Adds a keyboard-summoned **in-conversation find** to the dashboard `ChatView`, so a specific turn or tool call can be located in a long, virtualized transcript without manual scrolling. The existing `ConversationSearch` only searches archived sessions for the resume-sidebar flow; this searches the **currently open session** — the parity gap the issue calls out (mobile already ships this).

## What it does

- **Cmd/Ctrl+F** opens a compact find bar with an **N/M match counter**, previous/next navigation (Enter / Shift+Enter and buttons), and **Escape to dismiss**.
- **Match semantics mirror mobile**: case-insensitive substring against each row's rendered text (user + assistant + tool summaries), `thinking` rows excluded. Collapsed `tool_group` rows (whose `ChatViewMessage.content` is empty) match on their inner tool summaries + results via a parent-supplied searchable-text extractor.
- **Works against the `#5561` windowed list**: jumping to a match uses the match's content-space offset (`useWindowedRange.offsetAt`) to scroll to and mount an **off-screen (windowed-out)** row, with a next-frame correction once it measures. Native browser find can't reach an unmounted row — this can.
- **Message-row-level highlight**: every hit is tinted (`data-search-match`); the active match is stronger (`data-search-active`).

## Shortcut-scoping decision

`transcript.search` is registered in the shortcut registry with `disabledInTextInput: true` (joining `Shift+Tab` / `?`). So:

- **In a text input** (composer, another search field): Cmd+F is **not** intercepted — the browser's native find keeps working (honors "do not hijack browser find if an input has focus").
- **Focus on the transcript / app chrome, chat pane visible**: Cmd+F opens the in-session find bar and preventDefaults.
- **Non-chat surface** (Files / System / Control Room): Cmd+F **falls through** to native find rather than being swallowed (the dispatcher only intercepts when `chatTranscriptVisible`).

## Virtualization handling

The dashboard chat list is windowed via `useWindowedRange` — only rows intersecting the viewport (+ overscan) mount. Scroll-to-match computes the target row's offset with `range.offsetAt(index)`, writes `scrollTop` and re-seeds the windowing state so the row mounts in the same commit, then re-runs on the next frame once the row + neighbours measure to correct the landing. Reader is flagged scrolled-up so the streaming auto-follow doesn't yank them off the match.

## Tests

- `lib/transcriptSearch.test.ts` — pure match/navigation helper (case-insensitivity, order, thinking-excluded, wrap-around).
- `components/ChatView.search.test.tsx` — open/focus, N/M counter + highlight, next/prev wrap-around, Enter/Shift+Enter, no-results, Escape + close, and the **off-screen virtualized jump** (a windowed-out match is scrolled to and mounted).
- `hooks/useShortcutDispatch.test.ts` — Cmd+F opens + preventDefaults when a transcript is visible, falls through otherwise, and is suppressed inside a text input.

Full dashboard `vitest run` (255 files / 4375 tests) and `tsc --noEmit` are green.

Closes #6788