### PR TITLE
feat(dashboard): surface dev-server preview tunnels (#6790)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -278,6 +278,8 @@ export function App() {
     // multi-question AskUserQuestion deny shipped in #4648) in the
     // FooterBar counter chip so users can tell when chroxy intervened.
     interventions,
+    // #6790: active dev-server preview tunnels for the header DevPreviewChip.
+    devPreviews,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
 
   // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
@@ -594,6 +596,8 @@ export function App() {
   // re-render unrelated chrome.
   const markSessionNotificationRead = useConnectionStore(s => s.markSessionNotificationRead)
   const markAllSessionNotificationsRead = useConnectionStore(s => s.markAllSessionNotificationsRead)
+  // #6790 — dismiss an active dev-server preview tunnel from the header chip.
+  const closeDevPreview = useConnectionStore(s => s.closeDevPreview)
   const conversationHistory = useConnectionStore(s => s.conversationHistory)
   const fetchConversationHistory = useConnectionStore(s => s.fetchConversationHistory)
   const resumeConversation = useConnectionStore(s => s.resumeConversation)
@@ -2063,6 +2067,8 @@ export function App() {
         provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
         modelLabel={activeModelLabel}
         costBadgeMode={costBadgeMode}
+        devPreviews={devPreviews}
+        onCloseDevPreview={closeDevPreview}
       />
 
       {/* Sidebar */}

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -3,8 +3,10 @@ import { ChatSettingsDropdown } from './ChatSettingsDropdown'
 import { NotificationsWidget } from './NotificationsWidget'
 import { HeaderOverflowMenu, type HeaderOverflowItem } from './HeaderOverflowMenu'
 import { StatusBar } from './StatusBar'
+import { DevPreviewChip } from './DevPreviewChip'
 import { formatShortcutKeys } from '../utils/platform'
 import type { ChatActivityState } from '@chroxy/store-core'
+import type { DevPreview } from '../store/types'
 
 declare const __APP_VERSION__: string
 
@@ -82,6 +84,11 @@ export interface AppHeaderProps {
   provider?: string
   modelLabel?: string
   costBadgeMode: ComponentProps<typeof StatusBar>['costBadgeMode']
+  // Dev-server preview tunnels (#6790) — active session's live devPreviews
+  // (server-detected localhost dev server, auto-tunneled). Empty array
+  // renders nothing; DevPreviewChip self-gates.
+  devPreviews: DevPreview[]
+  onCloseDevPreview: (port: number) => void
 }
 
 export function AppHeader(props: AppHeaderProps) {
@@ -168,6 +175,12 @@ export function AppHeader(props: AppHeaderProps) {
         />
       </div>
       <div className="header-right">
+        {/* #6790 — active dev-server preview tunnels for this session. The
+            server auto-detects a localhost dev server and opens a Cloudflare
+            tunnel; this chip is the only dashboard surface that makes the
+            resulting URL discoverable (previously only visible by scrolling
+            raw tool output). Self-gates on an empty devPreviews array. */}
+        <DevPreviewChip previews={props.devPreviews} onClose={props.onCloseDevPreview} />
         {/* #4890 — Slack-style intervention notifications widget. Bell
             with unread badge → dropdown listing every intervention alert
             (read + unread) so the operator gets a durable "do I have

--- a/packages/dashboard/src/components/CopyButton.test.tsx
+++ b/packages/dashboard/src/components/CopyButton.test.tsx
@@ -68,4 +68,12 @@ describe('CopyButton (#6631)', () => {
     fireEvent.click(screen.getByTestId('msg-copy-button'))
     expect(parentClick).not.toHaveBeenCalled()
   })
+
+  it('honours className/testId overrides for non-bubble hosts (#6790)', () => {
+    render(<CopyButton content="x" className="dev-preview-chip__copy" testId="custom-copy" />)
+    const btn = screen.getByTestId('custom-copy')
+    expect(btn).toHaveClass('dev-preview-chip__copy')
+    expect(btn).not.toHaveClass('msg-copy-btn')
+    expect(screen.queryByTestId('msg-copy-button')).toBeNull()
+  })
 })

--- a/packages/dashboard/src/components/CopyButton.tsx
+++ b/packages/dashboard/src/components/CopyButton.tsx
@@ -9,8 +9,24 @@ import { useConnectionStore } from '../store/connection'
  * brief ✓ confirmation. A failed write surfaces a non-destructive `warning`
  * toast, mirroring App.tsx's `copyToClipboard`. The layout leaves room for
  * future per-response actions alongside it.
+ *
+ * #6790 — `className` / `testId` are overridable so non-bubble hosts (the
+ * dev-preview chip) can reuse the full copy behaviour (clipboard write,
+ * failure toast, ✓ state, sr-only announcement) without inheriting
+ * `.msg-copy-btn`'s bubble-specific CSS (absolute top-right positioning,
+ * hidden until `.msg:hover`). Defaults preserve the original bubble usage.
  */
-export function CopyButton({ content, label = 'Copy response' }: { content: string; label?: string }) {
+export function CopyButton({
+  content,
+  label = 'Copy response',
+  className = 'msg-copy-btn',
+  testId = 'msg-copy-button',
+}: {
+  content: string
+  label?: string
+  className?: string
+  testId?: string
+}) {
   const [copied, setCopied] = useState(false)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const mounted = useRef(true)
@@ -46,10 +62,10 @@ export function CopyButton({ content, label = 'Copy response' }: { content: stri
     <>
       <button
         type="button"
-        className="msg-copy-btn"
+        className={className}
         aria-label={copied ? 'Copied' : label}
         title={copied ? 'Copied' : label}
-        data-testid="msg-copy-button"
+        data-testid={testId}
         data-copied={copied ? 'true' : undefined}
         onClick={onCopy}
       >

--- a/packages/dashboard/src/components/DevPreviewChip.test.tsx
+++ b/packages/dashboard/src/components/DevPreviewChip.test.tsx
@@ -4,8 +4,9 @@
  *
  * Covers: hidden when devPreviews is empty, renders a chip per active
  * preview with the port + a link to the tunnel URL, the close control
- * invokes onClose with the right port, and the copy control writes the
- * exact tunnel URL to the clipboard.
+ * invokes onClose with the right port (including selecting the right chip
+ * among several), and the copy control (the shared CopyButton, #6631)
+ * writes the exact tunnel URL to the clipboard.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
@@ -42,15 +43,22 @@ describe('DevPreviewChip', () => {
     expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
   })
 
-  it('renders one chip per active preview, deduped by port', () => {
+  it('renders one chip per active preview and dismissing one closes only that port', () => {
     const previews: DevPreview[] = [
       { port: 3000, url: 'https://foo.trycloudflare.com' },
       { port: 4000, url: 'https://bar.trycloudflare.com' },
     ]
-    render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+    const onClose = vi.fn()
+    render(<DevPreviewChip previews={previews} onClose={onClose} />)
 
     expect(screen.getByTestId('dev-preview-chip-3000')).toBeInTheDocument()
     expect(screen.getByTestId('dev-preview-chip-4000')).toBeInTheDocument()
+
+    // Dismissing the SECOND chip must close its own port — not the first
+    // entry's — so the per-chip close binding is verified, not just render.
+    fireEvent.click(screen.getByTestId('dev-preview-chip-close-4000'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith(4000)
   })
 
   it('calls onClose with the matching port when the dismiss control is clicked', () => {

--- a/packages/dashboard/src/components/DevPreviewChip.test.tsx
+++ b/packages/dashboard/src/components/DevPreviewChip.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for DevPreviewChip (#6790) — header surface for active dev-server
+ * preview tunnels sourced from the session's `devPreviews` store state.
+ *
+ * Covers: hidden when devPreviews is empty, renders a chip per active
+ * preview with the port + a link to the tunnel URL, the close control
+ * invokes onClose with the right port, and the copy control writes the
+ * exact tunnel URL to the clipboard.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { DevPreviewChip } from './DevPreviewChip'
+import { writeText } from '../utils/clipboard'
+import { useConnectionStore } from '../store/connection'
+import type { DevPreview } from '../store/types'
+
+vi.mock('../utils/clipboard', () => ({ writeText: vi.fn() }))
+const mockWriteText = vi.mocked(writeText)
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  mockWriteText.mockReset()
+})
+
+describe('DevPreviewChip', () => {
+  it('renders nothing when devPreviews is empty', () => {
+    const { container } = render(<DevPreviewChip previews={[]} onClose={() => {}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a chip for a single active preview with port + link to the tunnel URL', () => {
+    const previews: DevPreview[] = [{ port: 3000, url: 'https://foo.trycloudflare.com' }]
+    render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+
+    expect(screen.getByTestId('dev-preview-chip-3000')).toBeInTheDocument()
+    expect(screen.getByText(':3000')).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /open dev preview on port 3000/i })
+    expect(link).toHaveAttribute('href', 'https://foo.trycloudflare.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('renders one chip per active preview, deduped by port', () => {
+    const previews: DevPreview[] = [
+      { port: 3000, url: 'https://foo.trycloudflare.com' },
+      { port: 4000, url: 'https://bar.trycloudflare.com' },
+    ]
+    render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+
+    expect(screen.getByTestId('dev-preview-chip-3000')).toBeInTheDocument()
+    expect(screen.getByTestId('dev-preview-chip-4000')).toBeInTheDocument()
+  })
+
+  it('calls onClose with the matching port when the dismiss control is clicked', () => {
+    const previews: DevPreview[] = [{ port: 5173, url: 'https://baz.trycloudflare.com' }]
+    const onClose = vi.fn()
+    render(<DevPreviewChip previews={previews} onClose={onClose} />)
+
+    fireEvent.click(screen.getByTestId('dev-preview-chip-close-5173'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith(5173)
+  })
+
+  it('copies the exact tunnel URL to the clipboard and shows the copied state', async () => {
+    mockWriteText.mockResolvedValue(true)
+    const previews: DevPreview[] = [{ port: 8080, url: 'https://qux.trycloudflare.com/app' }]
+    render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+
+    fireEvent.click(screen.getByTestId('dev-preview-chip-copy-8080'))
+    expect(mockWriteText).toHaveBeenCalledWith('https://qux.trycloudflare.com/app')
+    await waitFor(() =>
+      expect(screen.getByTestId('dev-preview-chip-copy-8080')).toHaveAttribute('data-copied', 'true'),
+    )
+  })
+
+  it('surfaces a warning toast and does not show copied when the clipboard write fails', async () => {
+    mockWriteText.mockResolvedValue(false)
+    const previews: DevPreview[] = [{ port: 9000, url: 'https://fail.trycloudflare.com' }]
+    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError').mockImplementation(() => {})
+    render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+
+    fireEvent.click(screen.getByTestId('dev-preview-chip-copy-9000'))
+    await waitFor(() =>
+      expect(addServerError).toHaveBeenCalledWith(expect.stringContaining('Failed to copy'), undefined, 'warning'),
+    )
+    expect(screen.getByTestId('dev-preview-chip-copy-9000')).not.toHaveAttribute('data-copied')
+    addServerError.mockRestore()
+  })
+})

--- a/packages/dashboard/src/components/DevPreviewChip.test.tsx
+++ b/packages/dashboard/src/components/DevPreviewChip.test.tsx
@@ -83,6 +83,30 @@ describe('DevPreviewChip', () => {
     )
   })
 
+  it('renders a clickable anchor for an https:// tunnel URL (scheme guard positive case)', () => {
+    const previews: DevPreview[] = [{ port: 3000, url: 'https://ok.trycloudflare.com' }]
+    render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+
+    const link = screen.getByRole('link', { name: /open dev preview on port 3000/i })
+    expect(link.tagName).toBe('A')
+    expect(link).toHaveAttribute('href', 'https://ok.trycloudflare.com')
+  })
+
+  it('renders NO anchor (and no href anywhere) for a javascript: URL, keeping the chip + dismiss', () => {
+    const previews: DevPreview[] = [{ port: 3000, url: 'javascript:alert(1)' }]
+    const { container } = render(<DevPreviewChip previews={previews} onClose={() => {}} />)
+
+    // Chip still renders, with the port label and its dismiss control...
+    expect(screen.getByTestId('dev-preview-chip-3000')).toBeInTheDocument()
+    expect(screen.getByText(':3000')).toBeInTheDocument()
+    expect(screen.getByTestId('dev-preview-chip-close-3000')).toBeInTheDocument()
+
+    // ...but nothing is navigable: no anchor, no href attribute anywhere.
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelector('[href]')).toBeNull()
+  })
+
   it('surfaces a warning toast and does not show copied when the clipboard write fails', async () => {
     mockWriteText.mockResolvedValue(false)
     const previews: DevPreview[] = [{ port: 9000, url: 'https://fail.trycloudflare.com' }]

--- a/packages/dashboard/src/components/DevPreviewChip.tsx
+++ b/packages/dashboard/src/components/DevPreviewChip.tsx
@@ -1,0 +1,115 @@
+/**
+ * DevPreviewChip — dashboard surface for active dev-server preview tunnels (#6790).
+ *
+ * The server auto-detects a localhost dev server started inside a session,
+ * opens an ephemeral Cloudflare tunnel, and pushes the resulting
+ * `{ port, url }` pair into the session's `devPreviews` array (see
+ * `packages/store-core/src/handlers/dev-preview.ts`). The dashboard store
+ * has tracked this state and exposed a `closeDevPreview` action
+ * (`connection.ts`) since #614, but no dashboard component ever read it —
+ * this is the first UI consumer, mirroring the mobile app's
+ * `DevPreviewBanner` (`packages/app/src/components/DevPreviewBanner.tsx`),
+ * which opens the URL via `Linking.openURL` (OS browser) on tap.
+ *
+ * Renders one small chip per active preview: a link that opens the tunnel
+ * URL in a new tab, a copy-URL button, and a dismiss control that calls
+ * `closeDevPreview`. Renders nothing when there are no active previews, and
+ * updates live as `devPreviews` changes (the caller feeds this from the
+ * active session's store state, so a `dev_preview` / `dev_preview_stopped`
+ * dispatch re-renders it automatically).
+ *
+ * Does NOT embed the preview — that's #6789's scope (an inline iframe /
+ * webview pane). This is deliberately the minimal "so the URL is
+ * discoverable" fix: the server already does the hard part (detection +
+ * tunnel), the dashboard just needed to show it.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { writeText } from '../utils/clipboard'
+import { useConnectionStore } from '../store/connection'
+import type { DevPreview } from '../store/types'
+
+export interface DevPreviewChipProps {
+  previews: DevPreview[]
+  onClose: (port: number) => void
+}
+
+/** A single chip: open link + copy + dismiss for one active dev preview. */
+function DevPreviewChipItem({ preview, onClose }: { preview: DevPreview; onClose: (port: number) => void }) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mounted = useRef(true)
+  useEffect(() => () => {
+    mounted.current = false
+    if (timer.current) clearTimeout(timer.current)
+  }, [])
+
+  const onCopy = useCallback(() => {
+    if (timer.current) { clearTimeout(timer.current); timer.current = null }
+    setCopied(false)
+    void writeText(preview.url).then((ok) => {
+      if (!mounted.current) return
+      if (!ok) {
+        useConnectionStore.getState().addServerError('Failed to copy dev preview URL. Please try again.', undefined, 'warning')
+        return
+      }
+      setCopied(true)
+      timer.current = setTimeout(() => { if (mounted.current) setCopied(false) }, 1500)
+    })
+  }, [preview.url])
+
+  return (
+    <span
+      className="dev-preview-chip"
+      data-testid={`dev-preview-chip-${preview.port}`}
+      title={preview.url}
+    >
+      <a
+        className="dev-preview-chip__link"
+        href={preview.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Open dev preview on port ${preview.port}: ${preview.url}`}
+      >
+        <span className="dev-preview-chip__icon" aria-hidden="true">{'\u{1F310}'}</span>
+        <span className="dev-preview-chip__port">:{preview.port}</span>
+      </a>
+      <button
+        type="button"
+        className="dev-preview-chip__copy"
+        data-testid={`dev-preview-chip-copy-${preview.port}`}
+        data-copied={copied ? 'true' : undefined}
+        onClick={onCopy}
+        aria-label={copied ? 'Copied' : `Copy dev preview URL: ${preview.url}`}
+        title={copied ? 'Copied' : 'Copy URL'}
+      >
+        {copied ? '✓' : '⧉'}
+      </button>
+      <button
+        type="button"
+        className="dev-preview-chip__close"
+        data-testid={`dev-preview-chip-close-${preview.port}`}
+        onClick={() => onClose(preview.port)}
+        aria-label={`Dismiss dev preview on port ${preview.port}`}
+        title="Dismiss dev preview"
+      >
+        &times;
+      </button>
+    </span>
+  )
+}
+
+export function DevPreviewChip({ previews, onClose }: DevPreviewChipProps) {
+  // Defensive: several App-level test fixtures mock `getActiveSessionState()`
+  // with a partial shape that predates this field (App.test.tsx), so
+  // `previews` can arrive `undefined` at runtime despite the required prop
+  // type. Treat that the same as "no active previews" rather than crashing.
+  if (!previews || previews.length === 0) return null
+
+  return (
+    <div className="dev-preview-chips" data-testid="dev-preview-chips">
+      {previews.map(preview => (
+        <DevPreviewChipItem key={preview.port} preview={preview} onClose={onClose} />
+      ))}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/DevPreviewChip.tsx
+++ b/packages/dashboard/src/components/DevPreviewChip.tsx
@@ -12,51 +12,35 @@
  * which opens the URL via `Linking.openURL` (OS browser) on tap.
  *
  * Renders one small chip per active preview: a link that opens the tunnel
- * URL in a new tab, a copy-URL button, and a dismiss control that calls
- * `closeDevPreview`. Renders nothing when there are no active previews, and
- * updates live as `devPreviews` changes (the caller feeds this from the
- * active session's store state, so a `dev_preview` / `dev_preview_stopped`
- * dispatch re-renders it automatically).
+ * URL in a new tab, a copy-URL button (the shared `CopyButton`, #6631 —
+ * clipboard write, failure toast, ✓ state, and the sr-only "Copied"
+ * announcement all come from it), and a dismiss control that calls
+ * `closeDevPreview`. Renders nothing when there are no active previews,
+ * and updates live as `devPreviews` changes (the caller feeds this from
+ * the active session's store state, so a `dev_preview` /
+ * `dev_preview_stopped` dispatch re-renders it automatically).
  *
  * Does NOT embed the preview — that's #6789's scope (an inline iframe /
  * webview pane). This is deliberately the minimal "so the URL is
  * discoverable" fix: the server already does the hard part (detection +
  * tunnel), the dashboard just needed to show it.
  */
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { writeText } from '../utils/clipboard'
-import { useConnectionStore } from '../store/connection'
+import { CopyButton } from './CopyButton'
 import type { DevPreview } from '../store/types'
 
 export interface DevPreviewChipProps {
-  previews: DevPreview[]
+  /**
+   * Active previews for the session. Optional because several App-level
+   * test fixtures mock `getActiveSessionState()` with partial shapes that
+   * predate this field (App.test.tsx), so the value can genuinely arrive
+   * `undefined` at runtime — treated the same as "no active previews".
+   */
+  previews?: DevPreview[]
   onClose: (port: number) => void
 }
 
 /** A single chip: open link + copy + dismiss for one active dev preview. */
 function DevPreviewChipItem({ preview, onClose }: { preview: DevPreview; onClose: (port: number) => void }) {
-  const [copied, setCopied] = useState(false)
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const mounted = useRef(true)
-  useEffect(() => () => {
-    mounted.current = false
-    if (timer.current) clearTimeout(timer.current)
-  }, [])
-
-  const onCopy = useCallback(() => {
-    if (timer.current) { clearTimeout(timer.current); timer.current = null }
-    setCopied(false)
-    void writeText(preview.url).then((ok) => {
-      if (!mounted.current) return
-      if (!ok) {
-        useConnectionStore.getState().addServerError('Failed to copy dev preview URL. Please try again.', undefined, 'warning')
-        return
-      }
-      setCopied(true)
-      timer.current = setTimeout(() => { if (mounted.current) setCopied(false) }, 1500)
-    })
-  }, [preview.url])
-
   return (
     <span
       className="dev-preview-chip"
@@ -73,17 +57,12 @@ function DevPreviewChipItem({ preview, onClose }: { preview: DevPreview; onClose
         <span className="dev-preview-chip__icon" aria-hidden="true">{'\u{1F310}'}</span>
         <span className="dev-preview-chip__port">:{preview.port}</span>
       </a>
-      <button
-        type="button"
+      <CopyButton
+        content={preview.url}
+        label={`Copy dev preview URL: ${preview.url}`}
         className="dev-preview-chip__copy"
-        data-testid={`dev-preview-chip-copy-${preview.port}`}
-        data-copied={copied ? 'true' : undefined}
-        onClick={onCopy}
-        aria-label={copied ? 'Copied' : `Copy dev preview URL: ${preview.url}`}
-        title={copied ? 'Copied' : 'Copy URL'}
-      >
-        {copied ? '✓' : '⧉'}
-      </button>
+        testId={`dev-preview-chip-copy-${preview.port}`}
+      />
       <button
         type="button"
         className="dev-preview-chip__close"
@@ -99,10 +78,6 @@ function DevPreviewChipItem({ preview, onClose }: { preview: DevPreview; onClose
 }
 
 export function DevPreviewChip({ previews, onClose }: DevPreviewChipProps) {
-  // Defensive: several App-level test fixtures mock `getActiveSessionState()`
-  // with a partial shape that predates this field (App.test.tsx), so
-  // `previews` can arrive `undefined` at runtime despite the required prop
-  // type. Treat that the same as "no active previews" rather than crashing.
   if (!previews || previews.length === 0) return null
 
   return (

--- a/packages/dashboard/src/components/DevPreviewChip.tsx
+++ b/packages/dashboard/src/components/DevPreviewChip.tsx
@@ -39,24 +39,57 @@ export interface DevPreviewChipProps {
   onClose: (port: number) => void
 }
 
+/**
+ * Defensive scheme guard (#6812 review): only URLs that parse with an
+ * http: or https: scheme may become a clickable anchor. The server only
+ * ever emits Cloudflare tunnel https URLs here, but the value crosses the
+ * wire — a malicious/compromised sender must not be able to smuggle a
+ * `javascript:` (or other active-scheme) href into the header.
+ */
+function isHttpUrl(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 /** A single chip: open link + copy + dismiss for one active dev preview. */
 function DevPreviewChipItem({ preview, onClose }: { preview: DevPreview; onClose: (port: number) => void }) {
+  const label = (
+    <>
+      <span className="dev-preview-chip__icon" aria-hidden="true">{'\u{1F310}'}</span>
+      <span className="dev-preview-chip__port">:{preview.port}</span>
+    </>
+  )
   return (
     <span
       className="dev-preview-chip"
       data-testid={`dev-preview-chip-${preview.port}`}
       title={preview.url}
     >
-      <a
-        className="dev-preview-chip__link"
-        href={preview.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={`Open dev preview on port ${preview.port}: ${preview.url}`}
-      >
-        <span className="dev-preview-chip__icon" aria-hidden="true">{'\u{1F310}'}</span>
-        <span className="dev-preview-chip__port">:{preview.port}</span>
-      </a>
+      {isHttpUrl(preview.url) ? (
+        <a
+          className="dev-preview-chip__link"
+          href={preview.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`Open dev preview on port ${preview.port}: ${preview.url}`}
+        >
+          {label}
+        </a>
+      ) : (
+        // Non-http(s) scheme: render the same label as plain text — the
+        // chip (and its dismiss control) stays visible, but nothing is
+        // navigable.
+        <span
+          className="dev-preview-chip__link"
+          aria-label={`Dev preview on port ${preview.port}`}
+        >
+          {label}
+        </span>
+      )}
       <CopyButton
         content={preview.url}
         label={`Copy dev preview URL: ${preview.url}`}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -506,8 +506,11 @@
   font-family: var(--font-mono);
 }
 
-.dev-preview-chip__link:hover,
-.dev-preview-chip__link:focus-visible {
+/* Underline is an anchor-only affordance — the scheme-guard fallback renders
+   the same class on a plain (non-navigable) span, which must not imply
+   clickability on hover. */
+a.dev-preview-chip__link:hover,
+a.dev-preview-chip__link:focus-visible {
   text-decoration: underline;
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -537,7 +537,10 @@
 .dev-preview-chip__copy:hover,
 .dev-preview-chip__close:hover {
   color: var(--text-heading);
-  background: rgba(127, 127, 127, 0.15);
+  /* Same token-with-neutral-fallback idiom as .msg-copy-btn — the token is
+     theme-provided where defined; the fallback reads correctly in both
+     light and dark. */
+  background: var(--surface-raised, rgba(127, 127, 127, 0.15));
 }
 
 .dev-preview-chip__copy[data-copied='true'] {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -475,6 +475,75 @@
   flex-shrink: 0;
 }
 
+/* #6790 — active dev-server preview tunnel chip(s). One chip per entry in
+   the active session's `devPreviews`; renders nothing when the array is
+   empty (DevPreviewChip self-gates). */
+.dev-preview-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dev-preview-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--accent-green-light);
+  border: 1px solid var(--accent-green-border);
+  border-radius: var(--radius-sm);
+  padding: 2px 4px 2px 8px;
+  font-size: 11px;
+  color: var(--accent-green);
+}
+
+.dev-preview-chip__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+
+.dev-preview-chip__link:hover,
+.dev-preview-chip__link:focus-visible {
+  text-decoration: underline;
+}
+
+.dev-preview-chip__icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.dev-preview-chip__copy,
+.dev-preview-chip__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  margin-left: 2px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.dev-preview-chip__copy:hover,
+.dev-preview-chip__close:hover {
+  color: var(--text-heading);
+  background: rgba(127, 127, 127, 0.15);
+}
+
+.dev-preview-chip__copy[data-copied='true'] {
+  color: var(--accent-green);
+}
+
 /* #5200/#5203: the status bar lives on its own row (.header-meta) and spans
    the FULL header width, space-betweening two groups — identity (type badge +
    model) on the left, metrics (configurable cost badge + token meter) on the


### PR DESCRIPTION
## Summary

- `devPreviews` (per-session store state tracking server-detected localhost dev servers + their auto-opened Cloudflare tunnels) has been wired end-to-end since #614 but had zero dashboard consumers — no banner, no link, no way to discover the tunnel URL short of scrolling raw tool output.
- Adds `DevPreviewChip`, a new dashboard component rendered in the header's right zone: one chip per active `devPreviews` entry, showing the port with a link that opens the tunnel URL in a new tab (`target=_blank rel=noopener noreferrer`), a copy-URL button, and a dismiss control wired to the existing `closeDevPreview` action.
- Mirrors the mobile app's `DevPreviewBanner` pattern (`packages/app/src/components/DevPreviewBanner.tsx`), which already opens the tunnel URL via `Linking.openURL`.
- State updates live: `devPreviews` is sourced from the same `getActiveSessionState()` selector App.tsx already uses for `activeAgents`/`sessionCost`/etc., so `dev_preview` / `dev_preview_stopped` dispatches re-render the chip automatically.
- Does **not** add an embedded iframe/webview preview pane — that's #6789's scope. This is the minimal "make the URL discoverable" fix.

## `DevPreview` shape (verified against store-core)

```ts
// packages/store-core/src/types/session.ts:212
export interface DevPreview {
  port: number;
  url: string;
}
```

No framework/label field exists in the wire state, so the chip labels each entry by port only (`:3000`) with the full URL as the link title/tooltip and aria-label.

## Files changed

- `packages/dashboard/src/components/DevPreviewChip.tsx` (new) — the chip component
- `packages/dashboard/src/components/DevPreviewChip.test.tsx` (new) — component tests
- `packages/dashboard/src/components/AppHeader.tsx` — mounts `DevPreviewChip` in `header-right`, threads `devPreviews` + `onCloseDevPreview` props
- `packages/dashboard/src/App.tsx` — selects `devPreviews` from `getActiveSessionState()` and `closeDevPreview` from the store, passes both to `AppHeader`
- `packages/dashboard/src/theme/components.css` — `.dev-preview-chip*` styles (hand-authored file, not the generated `theme.css`)

## Test plan

- [x] `packages/dashboard`: `vitest run` — 254 files / 4356 tests passing (full suite, not just the new file)
- [x] `packages/dashboard`: `tsc --noEmit` — clean
- [x] New `DevPreviewChip.test.tsx`: renders nothing when `devPreviews` is empty, renders a chip per active preview with correct port/link/href/target/rel, dismiss calls `onClose(port)`, copy writes the exact tunnel URL to the clipboard (success + failure-toast paths)

Closes #6790