### PR TITLE
feat(dashboard,app): per-code-block copy button in chat markdown (#6793)

### DIFF
--- a/packages/app/src/__tests__/utils/markdown.test.ts
+++ b/packages/app/src/__tests__/utils/markdown.test.ts
@@ -18,7 +18,10 @@ describe('splitContentBlocks', () => {
     const blocks = splitContentBlocks(input);
     expect(blocks).toHaveLength(3);
     expect(blocks[0]).toEqual({ kind: 'text', content: 'Before' });
-    expect(blocks[1]).toEqual({ kind: 'code', lang: 'js', content: 'const x = 1;' });
+    // #6813: `content` is the display text (trimmed); `copyText` carries the
+    // exact original bytes (incl. the newline ending the last code line) so
+    // the copy action matches the dashboard byte-for-byte.
+    expect(blocks[1]).toEqual({ kind: 'code', lang: 'js', content: 'const x = 1;', copyText: 'const x = 1;\n' });
     expect(blocks[2]).toEqual({ kind: 'text', content: 'After' });
   });
 
@@ -26,7 +29,14 @@ describe('splitContentBlocks', () => {
     const input = '```\nhello\n```';
     const blocks = splitContentBlocks(input);
     expect(blocks).toHaveLength(1);
-    expect(blocks[0]).toEqual({ kind: 'code', lang: '', content: 'hello' });
+    expect(blocks[0]).toEqual({ kind: 'code', lang: '', content: 'hello', copyText: 'hello\n' });
+  });
+
+  it('copyText preserves interior trailing blank lines that content trims for display (#6813)', () => {
+    const input = '```\nfoo  \n\n```';
+    const blocks = splitContentBlocks(input);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ kind: 'code', lang: '', content: 'foo', copyText: 'foo  \n\n' });
   });
 
   it('normalizes CRLF to LF', () => {
@@ -40,8 +50,8 @@ describe('splitContentBlocks', () => {
     const input = '```js\na\n```\n```py\nb\n```';
     const blocks = splitContentBlocks(input);
     expect(blocks).toHaveLength(2);
-    expect(blocks[0]).toEqual({ kind: 'code', lang: 'js', content: 'a' });
-    expect(blocks[1]).toEqual({ kind: 'code', lang: 'py', content: 'b' });
+    expect(blocks[0]).toEqual({ kind: 'code', lang: 'js', content: 'a', copyText: 'a\n' });
+    expect(blocks[1]).toEqual({ kind: 'code', lang: 'py', content: 'b', copyText: 'b\n' });
   });
 
   it('does not treat inline backticks as fences', () => {

--- a/packages/app/src/components/Icon.tsx
+++ b/packages/app/src/components/Icon.tsx
@@ -21,6 +21,7 @@ export const iconMap = {
   download: 'download-outline',
   export: 'share-outline',
   edit: 'create-outline',
+  copy: 'copy-outline',
 
   // Content & Files
   folder: 'folder-outline',

--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -1,9 +1,14 @@
-import React, { useMemo } from 'react';
-import { View, Text, StyleSheet, Platform, Linking, Alert, StyleProp, TextStyle, ScrollView } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { View, Text, StyleSheet, Platform, Linking, Alert, StyleProp, TextStyle, ScrollView, TouchableOpacity } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
 import { ICON_BULLET, ICON_CHECKBOX_CHECKED, ICON_CHECKBOX_UNCHECKED } from '../constants/icons';
 import { COLORS } from '../constants/colors';
 import { tokenize, SYNTAX_COLORS } from '../utils/syntax';
 import type { TokenType } from '../utils/syntax';
+import { Icon } from './Icon';
+
+/** How long the ✓ "copied" confirmation stays up before reverting to the copy icon. */
+const CODE_COPY_RESET_MS = 1500;
 
 
 // -- Constants --
@@ -589,6 +594,55 @@ const HighlightedCode = React.memo(({ code, language }: { code: string; language
 });
 HighlightedCode.displayName = 'HighlightedCode';
 
+/**
+ * #6793 — per-fenced-code-block copy button (mobile). Copies exactly this
+ * block's raw source (the same `block.content` string `HighlightedCode`
+ * renders — pre-tokenization, so no syntax-highlighting artifacts) via the
+ * same `expo-clipboard` API the multi-select transcript copy already uses
+ * (`SessionScreen.tsx`'s `handleCopy` → `Clipboard.setStringAsync`), and
+ * flashes a brief checkmark confirmation. Unlike the dashboard's hover-only
+ * `.code-copy-btn` (#6793, no hover on touch devices), this renders as an
+ * always-visible small icon in a header row above the code, so it's
+ * discoverable and tappable without a long-press gesture.
+ */
+const CodeCopyButton = React.memo(({ code }: { code: string }) => {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+  }, []);
+
+  const handlePress = useCallback(() => {
+    if (resetTimer.current) {
+      clearTimeout(resetTimer.current);
+      resetTimer.current = null;
+    }
+    Clipboard.setStringAsync(code)
+      .then(() => {
+        setCopied(true);
+        resetTimer.current = setTimeout(() => setCopied(false), CODE_COPY_RESET_MS);
+      })
+      .catch((error) => {
+        console.error('Failed to copy code block to clipboard', error);
+      });
+  }, [code]);
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      style={md.codeCopyButton}
+      hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+      accessibilityRole="button"
+      accessibilityLabel={copied ? 'Copied' : 'Copy code'}
+      testID="code-copy-button"
+    >
+      <Icon name={copied ? 'check' : 'copy'} size={14} color={copied ? COLORS.accentGreen : COLORS.textDim} />
+    </TouchableOpacity>
+  );
+});
+CodeCopyButton.displayName = 'CodeCopyButton';
+
 /** Formatted response -- renders Claude's markdown as styled blocks.
  *
  *  `messageTextStyle` is threaded through to FormattedTextBlock so the
@@ -604,7 +658,14 @@ function FormattedResponseImpl({ content, messageTextStyle }: { content: string;
         if (block.kind === 'code') {
           return (
             <View key={`b${i}`} style={md.codeBlock}>
-              {block.lang ? <Text style={md.codeLang}>{block.lang}</Text> : null}
+              {/* #6793 — header row: language label (if any) on the left, the
+                  per-block copy button on the right. Always rendered (even
+                  language-less blocks) so the copy affordance is consistent
+                  across every fenced block. */}
+              <View style={md.codeBlockHeader}>
+                {block.lang ? <Text style={md.codeLang}>{block.lang}</Text> : <View />}
+                <CodeCopyButton code={block.content} />
+              </View>
               <HighlightedCode code={block.content} language={block.lang} />
             </View>
           );
@@ -674,12 +735,24 @@ export const md = StyleSheet.create({
     borderWidth: 1,
     borderColor: COLORS.borderPrimary,
   },
+  // #6793 — language label + copy button share a row so the copy icon never
+  // overlaps the label text, and so language-less blocks still get a
+  // (empty-left) row with just the button.
+  codeBlockHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
   codeLang: {
     color: COLORS.textDim,
     fontSize: 10,
-    marginBottom: 4,
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     textTransform: 'uppercase',
+  },
+  codeCopyButton: {
+    padding: 4,
+    borderRadius: 4,
   },
   codeText: {
     color: COLORS.textCodeBlock,

--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -640,6 +640,10 @@ const CodeCopyButton = React.memo(({ code }: { code: string }) => {
       })
       .catch((error) => {
         console.error('Failed to copy code block to clipboard', error);
+        // #6813 review: surface the failure the same way the app's other copy
+        // flow does (SessionScreen.handleCopy) — a silent console.error leaves
+        // the user with no feedback and an empty clipboard.
+        Alert.alert('Copy failed', 'Unable to copy code to clipboard. Please try again.');
       });
   }, [code]);
 

--- a/packages/app/src/components/MarkdownRenderer.tsx
+++ b/packages/app/src/components/MarkdownRenderer.tsx
@@ -38,7 +38,10 @@ const DEEP_NEST_BULLET = '\u25E6'; // White bullet ◦
 // -- Content Block Types --
 
 type ContentBlock =
-  | { kind: 'code'; lang: string; content: string }
+  /** `content` is display text (trailing whitespace trimmed so the code card
+   *  doesn't render dangling blank lines); `copyText` is the block's EXACT
+   *  original bytes for the #6793 copy action — see splitContentBlocks. */
+  | { kind: 'code'; lang: string; content: string; copyText: string }
   | { kind: 'text'; content: string };
 
 /** Split content into alternating text and fenced code blocks.
@@ -50,7 +53,9 @@ export function splitContentBlocks(rawContent: string): ContentBlock[] {
   const blocks: ContentBlock[] = [];
   // Require ``` at line start (or string start), followed by optional language + newline.
   // Closing fence uses lookahead so the \n isn't consumed -- allows consecutive code blocks.
-  const regex = /(?:^|\n)```(\w*)\n([\s\S]*?)(?:\n```(?=\s*\n|$)|$)/g;
+  // The closing fence is a CAPTURE group (match[3]) so copyText below can tell a closed
+  // fence apart from an unterminated one (the `|$` alternative captures '').
+  const regex = /(?:^|\n)```(\w*)\n([\s\S]*?)(\n```(?=\s*\n|$)|$)/g;
   let lastIndex = 0;
   let match;
 
@@ -61,8 +66,18 @@ export function splitContentBlocks(rawContent: string): ContentBlock[] {
       const text = content.slice(lastIndex, fenceStart).trim();
       if (text) blocks.push({ kind: 'text', content: text });
     }
+    // #6813 review: the copy action must place the SAME bytes on the clipboard
+    // as the dashboard, whose renderMarkdown captures everything between the
+    // opening fence's newline and the closing ``` — INCLUDING the newline that
+    // ends the last code line. Here that final newline is consumed by the
+    // closing-fence group (match[3]), and `trimEnd()` additionally drops any
+    // interior trailing blank lines/spaces. So: keep the trim for DISPLAY
+    // (`content` — no dangling blank lines in the code card), but build
+    // `copyText` from the untrimmed body + the consumed newline (when the
+    // fence was actually closed; an unterminated block has no such newline).
+    const copyText = match[3] ? `${match[2]}\n` : match[2];
     const code = match[2].trimEnd();
-    if (code) blocks.push({ kind: 'code', lang: match[1] || '', content: code });
+    if (code) blocks.push({ kind: 'code', lang: match[1] || '', content: code, copyText });
     lastIndex = match.index + match[0].length;
   }
 
@@ -632,7 +647,10 @@ const CodeCopyButton = React.memo(({ code }: { code: string }) => {
     <TouchableOpacity
       onPress={handlePress}
       style={md.codeCopyButton}
-      hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+      // #6813 review: 14pt icon + 2×5 padding = 24pt visual; 2×11 hitSlop
+      // extends the effective touch target to 46pt — above the repo's 44pt
+      // accessibility minimum — without inflating the visual footprint.
+      hitSlop={{ top: 11, right: 11, bottom: 11, left: 11 }}
       accessibilityRole="button"
       accessibilityLabel={copied ? 'Copied' : 'Copy code'}
       testID="code-copy-button"
@@ -664,7 +682,7 @@ function FormattedResponseImpl({ content, messageTextStyle }: { content: string;
                   across every fenced block. */}
               <View style={md.codeBlockHeader}>
                 {block.lang ? <Text style={md.codeLang}>{block.lang}</Text> : <View />}
-                <CodeCopyButton code={block.content} />
+                <CodeCopyButton code={block.copyText} />
               </View>
               <HighlightedCode code={block.content} language={block.lang} />
             </View>
@@ -751,7 +769,9 @@ export const md = StyleSheet.create({
     textTransform: 'uppercase',
   },
   codeCopyButton: {
-    padding: 4,
+    // 5 (not 4) so visual size + hitSlop clears the 44pt touch-target
+    // minimum — see the hitSlop comment on the TouchableOpacity.
+    padding: 5,
     borderRadius: 4,
   },
   codeText: {

--- a/packages/app/src/components/__tests__/MarkdownRenderer.copyCodeBlock.test.tsx
+++ b/packages/app/src/components/__tests__/MarkdownRenderer.copyCodeBlock.test.tsx
@@ -11,6 +11,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { StyleSheet } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { FormattedResponse } from '../MarkdownRenderer';
 import { flushMicrotasks } from '../../test-utils/test-helpers';
@@ -100,10 +101,10 @@ describe('MarkdownRenderer per-code-block copy button (#6793)', () => {
     });
 
     expect(mockSetStringAsync).toHaveBeenCalledTimes(1);
-    expect(mockSetStringAsync).toHaveBeenCalledWith('const second = 2');
+    expect(mockSetStringAsync).toHaveBeenCalledWith('const second = 2\n');
     // Never the whole markdown source, and never the OTHER block's text.
     expect(mockSetStringAsync).not.toHaveBeenCalledWith(content);
-    expect(mockSetStringAsync).not.toHaveBeenCalledWith('const first = 1');
+    expect(mockSetStringAsync).not.toHaveBeenCalledWith('const first = 1\n');
   });
 
   it('tapping the first block\'s button does not copy the second block\'s text', async () => {
@@ -116,8 +117,41 @@ describe('MarkdownRenderer per-code-block copy button (#6793)', () => {
       await flushMicrotasks();
     });
 
-    expect(mockSetStringAsync).toHaveBeenCalledWith('block one');
-    expect(mockSetStringAsync).not.toHaveBeenCalledWith('block two');
+    expect(mockSetStringAsync).toHaveBeenCalledWith('block one\n');
+    expect(mockSetStringAsync).not.toHaveBeenCalledWith('block two\n');
+  });
+
+  it('preserves the trailing newline in the copied text — byte parity with the dashboard (#6813 review)', async () => {
+    // The dashboard's renderMarkdown captures the newline that ends the last
+    // code line, so its copy button copies 'const x = 1\n'. The mobile fence
+    // regex consumes that newline into the closing-fence match and the display
+    // path additionally trimEnd()s — the copy action must reconstruct the
+    // exact original bytes, not the display text.
+    const tree = renderResponse('```js\nconst x = 1\n```');
+
+    await act(async () => {
+      copyButtons(tree.root)[0]!.props.onPress();
+      await flushMicrotasks();
+    });
+
+    expect(mockSetStringAsync).toHaveBeenCalledTimes(1);
+    const copied = mockSetStringAsync.mock.calls[0]![0] as string;
+    expect(copied).toBe('const x = 1\n');
+    expect(copied.endsWith('\n')).toBe(true);
+  });
+
+  it('exposes a ≥44pt effective touch target (icon + padding + hitSlop) (#6813 review)', () => {
+    const tree = renderResponse('```\nx\n```');
+    const button = copyButtons(tree.root)[0]!;
+    const style = StyleSheet.flatten(button.props.style) as { padding?: number };
+    const hitSlop = button.props.hitSlop as { top: number; right: number; bottom: number; left: number };
+    // The Icon renders at 14pt (see CodeCopyButton); visual size is icon +
+    // padding, and hitSlop extends the touchable area beyond the visual
+    // bounds. Both axes must clear the repo's 44pt accessibility minimum
+    // (same convention as DiffHunkView's ≥44pt toggle test).
+    const visual = 14 + 2 * (style.padding ?? 0);
+    expect(visual + hitSlop.top + hitSlop.bottom).toBeGreaterThanOrEqual(44);
+    expect(visual + hitSlop.left + hitSlop.right).toBeGreaterThanOrEqual(44);
   });
 
   it('shows a transient "Copied" accessibility state after a successful copy, then reverts', async () => {

--- a/packages/app/src/components/__tests__/MarkdownRenderer.copyCodeBlock.test.tsx
+++ b/packages/app/src/components/__tests__/MarkdownRenderer.copyCodeBlock.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * #6793 — per-fenced-code-block copy button (mobile).
+ *
+ * Mirrors `MarkdownRenderer.openURL.test.ts`'s harness conventions for this
+ * file (`react-test-renderer` + `act` — `@testing-library/react-native` is
+ * NOT installed in this repo, see `src/test-utils/test-helpers.ts`). Covers:
+ * one button per fenced code block, each scoped to its own block's raw text
+ * (not the whole message / not a sibling block), wired to the SAME
+ * `expo-clipboard` API the multi-select transcript copy already uses
+ * (`SessionScreen.tsx`'s `handleCopy`), and the transient "Copied" state.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import * as Clipboard from 'expo-clipboard';
+import { FormattedResponse } from '../MarkdownRenderer';
+import { flushMicrotasks } from '../../test-utils/test-helpers';
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(() => Promise.resolve(true)),
+}));
+
+const mockSetStringAsync = Clipboard.setStringAsync as jest.Mock;
+
+// A successful copy schedules a REAL 1500ms setTimeout (CODE_COPY_RESET_MS)
+// to revert the "Copied" state. Several tests below press a button without
+// advancing/asserting on that reset — unmounting after each test runs
+// CodeCopyButton's cleanup effect (clearTimeout), so the timer never fires
+// against a Jest environment that's already torn down (which otherwise spams
+// "update not wrapped in act" / "import after teardown" noise).
+let activeTree: renderer.ReactTestRenderer | null = null;
+
+afterEach(() => {
+  if (activeTree) {
+    act(() => activeTree!.unmount());
+    activeTree = null;
+  }
+});
+
+function renderResponse(content: string): renderer.ReactTestRenderer {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<FormattedResponse content={content} messageTextStyle={undefined} />);
+  });
+  activeTree = tree;
+  return tree;
+}
+
+/**
+ * `TouchableOpacity` forwards `testID` through several internal composition
+ * layers (its own forwardRef alias, an `Animated.View`, nested host `View`s)
+ * — `findAllByProps({ testID: ... })` matches EVERY one of those layers, not
+ * one-per-logical-button (verified empirically: a single `CodeCopyButton`
+ * yields 5 matches). Keep only the outermost match per subtree — the one
+ * whose nearest identically-tagged ancestor doesn't exist — so the count
+ * reflects actual rendered buttons, one per fenced code block.
+ */
+function copyButtons(root: ReactTestInstance): ReactTestInstance[] {
+  const all = root.findAll((node) => node.props.testID === 'code-copy-button');
+  return all.filter((node) => {
+    let parent = node.parent;
+    while (parent) {
+      if (parent.props?.testID === 'code-copy-button') return false;
+      parent = parent.parent;
+    }
+    return true;
+  });
+}
+
+describe('MarkdownRenderer per-code-block copy button (#6793)', () => {
+  beforeEach(() => {
+    mockSetStringAsync.mockClear();
+    mockSetStringAsync.mockResolvedValue(true);
+  });
+
+  it('renders one copy button per fenced code block', () => {
+    const content = 'intro\n\n```js\nconst a = 1\n```\n\nmiddle\n\n```py\ndef b(): pass\n```';
+    const tree = renderResponse(content);
+    expect(copyButtons(tree.root)).toHaveLength(2);
+  });
+
+  it('renders a copy button even for a language-less fenced block', () => {
+    const tree = renderResponse('```\nplain block\n```');
+    expect(copyButtons(tree.root)).toHaveLength(1);
+  });
+
+  it('renders NO copy button when there is no fenced code block', () => {
+    const tree = renderResponse('just some prose, no code here');
+    expect(copyButtons(tree.root)).toHaveLength(0);
+  });
+
+  it('tapping a block\'s copy button copies via expo-clipboard.setStringAsync with ONLY that block\'s text', async () => {
+    const content = 'before\n\n```js\nconst first = 1\n```\n\nbetween\n\n```js\nconst second = 2\n```';
+    const tree = renderResponse(content);
+    const buttons = copyButtons(tree.root);
+    expect(buttons).toHaveLength(2);
+
+    await act(async () => {
+      buttons[1]!.props.onPress();
+      await flushMicrotasks();
+    });
+
+    expect(mockSetStringAsync).toHaveBeenCalledTimes(1);
+    expect(mockSetStringAsync).toHaveBeenCalledWith('const second = 2');
+    // Never the whole markdown source, and never the OTHER block's text.
+    expect(mockSetStringAsync).not.toHaveBeenCalledWith(content);
+    expect(mockSetStringAsync).not.toHaveBeenCalledWith('const first = 1');
+  });
+
+  it('tapping the first block\'s button does not copy the second block\'s text', async () => {
+    const content = '```\nblock one\n```\n\n```\nblock two\n```';
+    const tree = renderResponse(content);
+    const buttons = copyButtons(tree.root);
+
+    await act(async () => {
+      buttons[0]!.props.onPress();
+      await flushMicrotasks();
+    });
+
+    expect(mockSetStringAsync).toHaveBeenCalledWith('block one');
+    expect(mockSetStringAsync).not.toHaveBeenCalledWith('block two');
+  });
+
+  it('shows a transient "Copied" accessibility state after a successful copy, then reverts', async () => {
+    jest.useFakeTimers();
+    try {
+      const tree = renderResponse('```\nconst x = 1\n```');
+      const button = copyButtons(tree.root)[0]!;
+      expect(button.props.accessibilityLabel).toBe('Copy code');
+
+      await act(async () => {
+        button.props.onPress();
+        await flushMicrotasks();
+      });
+      expect(copyButtons(tree.root)[0]!.props.accessibilityLabel).toBe('Copied');
+
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+      expect(copyButtons(tree.root)[0]!.props.accessibilityLabel).toBe('Copy code');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not show "Copied" when the clipboard write rejects', async () => {
+    mockSetStringAsync.mockRejectedValueOnce(new Error('clipboard unavailable'));
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tree = renderResponse('```\nconst x = 1\n```');
+    const button = copyButtons(tree.root)[0]!;
+
+    await act(async () => {
+      button.props.onPress();
+      await flushMicrotasks();
+    });
+
+    expect(copyButtons(tree.root)[0]!.props.accessibilityLabel).toBe('Copy code');
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/app/src/components/__tests__/MarkdownRenderer.copyCodeBlock.test.tsx
+++ b/packages/app/src/components/__tests__/MarkdownRenderer.copyCodeBlock.test.tsx
@@ -11,7 +11,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { StyleSheet } from 'react-native';
+import { Alert, StyleSheet } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { FormattedResponse } from '../MarkdownRenderer';
 import { flushMicrotasks } from '../../test-utils/test-helpers';
@@ -176,9 +176,10 @@ describe('MarkdownRenderer per-code-block copy button (#6793)', () => {
     }
   });
 
-  it('does not show "Copied" when the clipboard write rejects', async () => {
+  it('surfaces an Alert (not just console.error) and does not show "Copied" when the clipboard write rejects', async () => {
     mockSetStringAsync.mockRejectedValueOnce(new Error('clipboard unavailable'));
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
     const tree = renderResponse('```\nconst x = 1\n```');
     const button = copyButtons(tree.root)[0]!;
 
@@ -189,6 +190,26 @@ describe('MarkdownRenderer per-code-block copy button (#6793)', () => {
 
     expect(copyButtons(tree.root)[0]!.props.accessibilityLabel).toBe('Copy code');
     expect(consoleErrorSpy).toHaveBeenCalled();
+    // #6813 review: the failure must be USER-visible, matching the app's other
+    // copy flow (SessionScreen.handleCopy) — a silent console.error leaves the
+    // user with an empty clipboard and no idea why.
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith('Copy failed', expect.stringContaining('Unable to copy code'));
     consoleErrorSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  it('does not alert on a successful copy', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const tree = renderResponse('```\nconst x = 1\n```');
+
+    await act(async () => {
+      copyButtons(tree.root)[0]!.props.onPress();
+      await flushMicrotasks();
+    });
+
+    expect(mockSetStringAsync).toHaveBeenCalledTimes(1);
+    expect(alertSpy).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
   });
 });

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -2,15 +2,22 @@
  * ChatView + ThinkingDots tests (#1156)
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, act, waitFor } from '@testing-library/react'
 import { ChatView, type ChatViewMessage } from './ChatView'
 import { ThinkingDots } from './ThinkingDots'
+import { writeText } from '../utils/clipboard'
 import * as fs from 'fs'
 import * as path from 'path'
 
+vi.mock('../utils/clipboard', () => ({ writeText: vi.fn() }))
+const mockWriteText = vi.mocked(writeText)
+
 const componentsCss = fs.readFileSync(path.resolve(__dirname, '../theme/components.css'), 'utf-8')
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  mockWriteText.mockReset()
+})
 
 function makeMessages(count: number): ChatViewMessage[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -43,6 +50,72 @@ describe('ChatView', () => {
     // Exactly one — the finished, non-empty response. A regression that dropped
     // the `!isStreaming` / `type === 'response'` / non-empty gate would fail here.
     expect(screen.queryAllByTestId('msg-copy-button')).toHaveLength(1)
+  })
+
+  describe('per-code-block copy button (#6793)', () => {
+    it('renders one copy button per fenced code block, independent of the whole-message copy control', () => {
+      const messages: ChatViewMessage[] = [
+        {
+          id: 'r1',
+          type: 'response',
+          content: 'here are two snippets\n\n```js\nconst a = 1\n```\n\nand\n\n```py\ndef b(): pass\n```',
+          timestamp: 1,
+        },
+      ]
+      render(<ChatView messages={messages} isStreaming={false} />)
+      expect(screen.getAllByTestId('code-copy-button')).toHaveLength(2)
+      // The whole-message CopyButton still renders alongside them.
+      expect(screen.getAllByTestId('msg-copy-button')).toHaveLength(1)
+    })
+
+    it('clicking a code block\'s copy button copies ONLY that block\'s text, not the whole message', async () => {
+      mockWriteText.mockResolvedValue(true)
+      const messages: ChatViewMessage[] = [
+        {
+          id: 'r1',
+          type: 'response',
+          content: 'intro text\n\n```js\nconst first = 1\n```\n\nmiddle text\n\n```js\nconst second = 2\n```',
+          timestamp: 1,
+        },
+      ]
+      render(<ChatView messages={messages} isStreaming={false} />)
+      const buttons = screen.getAllByTestId('code-copy-button')
+      expect(buttons).toHaveLength(2)
+      fireEvent.click(buttons[1]!)
+      await waitFor(() => expect(mockWriteText).toHaveBeenCalledTimes(1))
+      expect(mockWriteText).toHaveBeenCalledWith('const second = 2\n')
+      // Never called with the raw markdown source or the other block's text.
+      expect(mockWriteText).not.toHaveBeenCalledWith(messages[0]!.content)
+      expect(mockWriteText).not.toHaveBeenCalledWith('const first = 1\n')
+    })
+
+    it('shows a transient copied indicator on the clicked button without affecting the others', async () => {
+      mockWriteText.mockResolvedValue(true)
+      const messages: ChatViewMessage[] = [
+        { id: 'r1', type: 'response', content: '```\nblock one\n```\n\n```\nblock two\n```', timestamp: 1 },
+      ]
+      render(<ChatView messages={messages} isStreaming={false} />)
+      const codeCopyButtons = screen.getAllByTestId('code-copy-button')
+      const first = codeCopyButtons[0]!
+      const second = codeCopyButtons[1]!
+      fireEvent.click(first)
+      await waitFor(() => expect(first).toHaveAttribute('data-copied', 'true'))
+      expect(second).not.toHaveAttribute('data-copied')
+    })
+
+    it('clicking the copy button does not trigger the #6625 markdown link-click handler on the same container', () => {
+      // A code block sits in the same dangerouslySetInnerHTML container as any
+      // rendered links; the copy click must not fall through to link handling.
+      mockWriteText.mockResolvedValue(true)
+      const messages: ChatViewMessage[] = [
+        { id: 'r1', type: 'response', content: 'see https://example.com\n\n```\nsnippet\n```', timestamp: 1 },
+      ]
+      render(<ChatView messages={messages} isStreaming={false} />)
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      fireEvent.click(screen.getByTestId('code-copy-button'), { metaKey: true })
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
   })
 
   it('previews image + document attachments on a sent user message (#6632)', () => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -20,7 +20,7 @@ import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMem
 import { bumpRenderCount, type ChatActivityState, type MessageAttachment } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
-import { handleMarkdownLinkClick } from '../lib/links'
+import { handleMarkdownBodyClick } from '../lib/codeCopy'
 import { CopyButton } from './CopyButton'
 import { isRenderableImageUri } from '../utils/attachment-preview'
 import { MessageRowShell } from './MeasuredRow'
@@ -331,7 +331,8 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   const body =
     type === 'response' || type === 'tool_use'
       // #6625: modifier-click opens a rendered link; plain click keeps selection.
-      ? <div onClick={handleMarkdownLinkClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+      // #6793: same container also owns the per-code-block copy button click.
+      ? <div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
       : type === 'thinking'
         ? <ThinkingBody content={content} streaming={!!isStreaming} />
         : content

--- a/packages/dashboard/src/components/OrchestrationRunsSection.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.tsx
@@ -25,7 +25,7 @@ import { useConnectionStore } from '../store/connection'
 import type { RunSummary, RunDetail, RunGate, RunNode, RunTimelineEntry, RunUsage } from '@chroxy/protocol'
 import { formatGeneratedAgo } from './ControlRoomSection'
 import { renderMarkdown } from '../lib/markdown'
-import { handleMarkdownLinkClick } from '../lib/links'
+import { handleMarkdownBodyClick } from '../lib/codeCopy'
 import { Modal } from './Modal'
 
 /** Server-authored spend figure — never computed client-side (AC-3). */
@@ -271,7 +271,7 @@ function DetailPanel({ runId, onOpenSession }: { runId: string; onOpenSession: (
           <div
             className="cr-orch-report markdown-content"
             data-testid="orch-report-markdown"
-            onClick={handleMarkdownLinkClick}
+            onClick={handleMarkdownBodyClick}
             dangerouslySetInnerHTML={{ __html: renderMarkdown(run.report.markdown) }}
           />
           <details>

--- a/packages/dashboard/src/lib/codeCopy.test.ts
+++ b/packages/dashboard/src/lib/codeCopy.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { handleCodeCopyClick, handleMarkdownBodyClick, CODE_BLOCK_CLASS, CODE_COPY_BTN_CLASS } from './codeCopy'
+import { useConnectionStore } from '../store/connection'
+
+/**
+ * Builds a `.code-block` DOM fragment matching what `renderMarkdown`
+ * (lib/markdown.ts) emits: `<div class="code-block"><button class="code-copy-btn">…</button><pre><code>…</code></pre></div>`.
+ */
+function codeBlock(text: string): { container: HTMLDivElement; button: HTMLButtonElement } {
+  const container = document.createElement('div')
+  container.innerHTML =
+    `<div class="${CODE_BLOCK_CLASS}"><button type="button" class="${CODE_COPY_BTN_CLASS}" aria-label="Copy code" title="Copy code">⧉</button><pre><code>${text}</code></pre></div>`
+  document.body.appendChild(container)
+  return { container, button: container.querySelector<HTMLButtonElement>(`.${CODE_COPY_BTN_CLASS}`)! }
+}
+
+// NOTE: no explicit return-type annotation — `vi.fn()`'s default generic
+// (`Procedure`) is what's assignable to a plain `() => void` signature; a
+// `ReturnType<typeof vi.fn>` annotation instead resolves the generic to its
+// *constraint* (`Procedure | Constructable`), which is NOT assignable and
+// breaks the `CodeCopyClickEvent` parameter type at every call site below
+// (mirrors the unannotated `mouse()` helper in lib/links.test.ts).
+function click(target: EventTarget | null) {
+  return { target, stopPropagation: vi.fn() }
+}
+
+describe('handleCodeCopyClick (#6793)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('copies the code block textContent (not the button glyph) when clicking the button', () => {
+    const { button } = codeBlock('const x = 1')
+    const writeText = vi.fn().mockResolvedValue(true)
+    const handled = handleCodeCopyClick(click(button), writeText)
+    expect(handled).toBe(true)
+    expect(writeText).toHaveBeenCalledWith('const x = 1')
+    expect(writeText).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves the button when the click target is a descendant (e.g. the glyph text node)', () => {
+    const { button } = codeBlock('const y = 2')
+    const glyphText = button.firstChild! // the "⧉" text node
+    const writeText = vi.fn().mockResolvedValue(true)
+    handleCodeCopyClick(click(glyphText), writeText)
+    expect(writeText).toHaveBeenCalledWith('const y = 2')
+  })
+
+  it('copies only the CLICKED block\'s text when multiple code blocks are present', () => {
+    const container = document.createElement('div')
+    container.innerHTML =
+      `<div class="${CODE_BLOCK_CLASS}"><button class="${CODE_COPY_BTN_CLASS}" data-testid="btn-a">⧉</button><pre><code>first block</code></pre></div>` +
+      `<div class="${CODE_BLOCK_CLASS}"><button class="${CODE_COPY_BTN_CLASS}" data-testid="btn-b">⧉</button><pre><code>second block</code></pre></div>`
+    document.body.appendChild(container)
+    const btnB = container.querySelector('[data-testid="btn-b"]')!
+    const writeText = vi.fn().mockResolvedValue(true)
+    handleCodeCopyClick(click(btnB), writeText)
+    expect(writeText).toHaveBeenCalledWith('second block')
+    expect(writeText).not.toHaveBeenCalledWith('first block')
+  })
+
+  it('stops propagation when the click is on the copy button', () => {
+    const { button } = codeBlock('x')
+    const writeText = vi.fn().mockResolvedValue(true)
+    const e = click(button)
+    handleCodeCopyClick(e, writeText)
+    expect(e.stopPropagation).toHaveBeenCalledOnce()
+  })
+
+  it('returns false and does NOT stop propagation for a click outside any copy button', () => {
+    const div = document.createElement('div')
+    div.textContent = 'plain text'
+    const writeText = vi.fn()
+    const e = click(div)
+    const handled = handleCodeCopyClick(e, writeText)
+    expect(handled).toBe(false)
+    expect(e.stopPropagation).not.toHaveBeenCalled()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('flashes a ✓ confirmation directly on the button DOM node, then resets after 1500ms', async () => {
+    vi.useFakeTimers()
+    try {
+      const { button } = codeBlock('x')
+      const writeText = vi.fn().mockResolvedValue(true)
+      handleCodeCopyClick(click(button), writeText)
+      await vi.waitFor(() => expect(button).toHaveAttribute('data-copied', 'true'))
+      expect(button.textContent).toBe('✓')
+      expect(button.getAttribute('aria-label')).toBe('Copied')
+
+      vi.advanceTimersByTime(1500)
+      expect(button).not.toHaveAttribute('data-copied')
+      expect(button.textContent).toBe('⧉')
+      expect(button.getAttribute('aria-label')).toBe('Copy code')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces a warning toast and does NOT show copied when the clipboard write fails', async () => {
+    const { button } = codeBlock('x')
+    const writeText = vi.fn().mockResolvedValue(false)
+    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError').mockImplementation(() => {})
+    handleCodeCopyClick(click(button), writeText)
+    await vi.waitFor(() => expect(addServerError).toHaveBeenCalledWith(expect.stringContaining('Failed to copy'), undefined, 'warning'))
+    expect(button).not.toHaveAttribute('data-copied')
+  })
+
+  it('does nothing (still handled) when the block has no text content', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `<div class="${CODE_BLOCK_CLASS}"><button class="${CODE_COPY_BTN_CLASS}">⧉</button><pre><code></code></pre></div>`
+    document.body.appendChild(container)
+    const button = container.querySelector<HTMLButtonElement>(`.${CODE_COPY_BTN_CLASS}`)!
+    const writeText = vi.fn()
+    const handled = handleCodeCopyClick(click(button), writeText)
+    expect(handled).toBe(true)
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleMarkdownBodyClick (#6793)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('handles a code-copy-button click without falling through to link handling', () => {
+    const { container, button } = codeBlock('some code')
+    const anchor = document.createElement('a')
+    anchor.href = 'https://example.com'
+    container.appendChild(anchor)
+    const open = vi.fn()
+    // handleMarkdownBodyClick only takes the event; we can't inject `open`
+    // directly, so just assert it doesn't throw and the click is treated as
+    // handled (no navigation side effect possible since target is the button).
+    expect(() =>
+      handleMarkdownBodyClick({ target: button, stopPropagation: vi.fn(), metaKey: true, ctrlKey: false, detail: 1, preventDefault: vi.fn() }),
+    ).not.toThrow()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('falls through to link handling when the click is not on a copy button', () => {
+    const anchor = document.createElement('a')
+    anchor.setAttribute('href', 'https://example.com')
+    document.body.appendChild(anchor)
+    const preventDefault = vi.fn()
+    // A plain mouse click on a link (detail >= 1, no modifier) is suppressed
+    // by handleMarkdownLinkClick — preventDefault fires, proving the click
+    // fell through past the (non-matching) copy-button check.
+    handleMarkdownBodyClick({ target: anchor, stopPropagation: vi.fn(), metaKey: false, ctrlKey: false, detail: 1, preventDefault })
+    expect(preventDefault).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/dashboard/src/lib/codeCopy.test.ts
+++ b/packages/dashboard/src/lib/codeCopy.test.ts
@@ -125,18 +125,31 @@ describe('handleMarkdownBodyClick (#6793)', () => {
   })
 
   it('handles a code-copy-button click without falling through to link handling', () => {
+    // #6813 review: only handleMarkdownLinkClick calls preventDefault (its
+    // open AND suppress branches both do) — the copy path must short-circuit
+    // before the link handler runs. To make the not-called assertion actually
+    // falsifiable, wrap the code block in an anchor: if the copy click ever
+    // fell through, `closest('a[href]')` would find this ancestor and the
+    // suppress branch would fire preventDefault, failing the test. The test
+    // below is the positive control: the identical click shape on a bare
+    // anchor DOES preventDefault.
     const { container, button } = codeBlock('some code')
     const anchor = document.createElement('a')
-    anchor.href = 'https://example.com'
+    anchor.setAttribute('href', 'https://example.com')
+    const block = container.firstElementChild!
+    anchor.appendChild(block)
     container.appendChild(anchor)
-    const open = vi.fn()
-    // handleMarkdownBodyClick only takes the event; we can't inject `open`
-    // directly, so just assert it doesn't throw and the click is treated as
-    // handled (no navigation side effect possible since target is the button).
-    expect(() =>
-      handleMarkdownBodyClick({ target: button, stopPropagation: vi.fn(), metaKey: true, ctrlKey: false, detail: 1, preventDefault: vi.fn() }),
-    ).not.toThrow()
-    expect(open).not.toHaveBeenCalled()
+    // This test exercises the REAL writeText default (handleMarkdownBodyClick
+    // has no injection point); jsdom has no clipboard, so the write resolves
+    // false and would push a warning into the real store — silence it.
+    const addServerError = vi.spyOn(useConnectionStore.getState(), 'addServerError').mockImplementation(() => {})
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+    handleMarkdownBodyClick({ target: button, stopPropagation, metaKey: false, ctrlKey: false, detail: 1, preventDefault })
+    expect(preventDefault).not.toHaveBeenCalled()
+    // …and the copy path DID claim the event (stopPropagation is its marker).
+    expect(stopPropagation).toHaveBeenCalledOnce()
+    addServerError.mockRestore()
   })
 
   it('falls through to link handling when the click is not on a copy button', () => {
@@ -146,7 +159,8 @@ describe('handleMarkdownBodyClick (#6793)', () => {
     const preventDefault = vi.fn()
     // A plain mouse click on a link (detail >= 1, no modifier) is suppressed
     // by handleMarkdownLinkClick — preventDefault fires, proving the click
-    // fell through past the (non-matching) copy-button check.
+    // fell through past the (non-matching) copy-button check. Positive control
+    // for the preventDefault-NOT-called assertion above.
     handleMarkdownBodyClick({ target: anchor, stopPropagation: vi.fn(), metaKey: false, ctrlKey: false, detail: 1, preventDefault })
     expect(preventDefault).toHaveBeenCalledOnce()
   })

--- a/packages/dashboard/src/lib/codeCopy.ts
+++ b/packages/dashboard/src/lib/codeCopy.ts
@@ -1,0 +1,115 @@
+import { writeText as defaultWriteText } from '../utils/clipboard'
+import { useConnectionStore } from '../store/connection'
+import { handleMarkdownLinkClick, type LinkClickEvent } from './links'
+
+/**
+ * #6793 — per-fenced-code-block copy button.
+ *
+ * `renderMarkdown` (lib/markdown.ts) wraps every fenced code block in a
+ * `.code-block` container carrying a `.code-copy-btn` button, but that
+ * markup is a plain HTML string rendered via `dangerouslySetInnerHTML` — the
+ * button can't carry a React `onClick`, and it must NOT carry an inline
+ * `onclick="…"` attribute (this repo's dashboard CSP is `script-src 'self'`
+ * with no `'unsafe-inline'`, and DOMPurify strips `on*` attributes anyway).
+ * Instead, this is a single delegated `onClick` on the markdown container —
+ * the same pattern #6625's `handleMarkdownLinkClick` (lib/links.ts) already
+ * established for link clicks inside the same `dangerouslySetInnerHTML`
+ * body. ChatView.tsx wires both handlers into one `onClick`.
+ */
+
+const COPIED_LABEL = 'Copied'
+const COPIED_GLYPH = '✓'
+const DEFAULT_LABEL = 'Copy code'
+const DEFAULT_GLYPH = '⧉'
+const COPIED_RESET_MS = 1500
+
+export const CODE_COPY_BTN_CLASS = 'code-copy-btn'
+export const CODE_BLOCK_CLASS = 'code-block'
+
+/** Minimal click-event shape this handler reads (test-friendly subset, mirrors LinkClickEvent). */
+export interface CodeCopyClickEvent {
+  target: EventTarget | null
+  stopPropagation: () => void
+}
+
+// Pending "copied ✓" reset timers, keyed by the button element so a rapid
+// re-click resets cleanly (clears the old timer) instead of two timers
+// racing to reset the glyph — mirrors CopyButton's per-click timer reset
+// (#6631), just done imperatively since these buttons aren't React state.
+const resetTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>()
+
+function showCopied(button: HTMLElement): void {
+  const pending = resetTimers.get(button)
+  if (pending) clearTimeout(pending)
+  button.textContent = COPIED_GLYPH
+  button.setAttribute('aria-label', COPIED_LABEL)
+  button.setAttribute('title', COPIED_LABEL)
+  button.setAttribute('data-copied', 'true')
+  const timer = setTimeout(() => {
+    resetTimers.delete(button)
+    button.textContent = DEFAULT_GLYPH
+    button.setAttribute('aria-label', DEFAULT_LABEL)
+    button.setAttribute('title', DEFAULT_LABEL)
+    button.removeAttribute('data-copied')
+  }, COPIED_RESET_MS)
+  resetTimers.set(button, timer)
+}
+
+/**
+ * `onClick` handler for a container of rendered markdown. A click on a
+ * `.code-copy-btn` copies its fenced code block's text to the clipboard and
+ * flashes a transient ✓ confirmation directly on the button.
+ *
+ * The copied text is read from the rendered `<code>` element's
+ * `textContent` at click time — NOT a `data-*` attribute stashed on the
+ * button. See the comment in `lib/markdown.ts` for why: DOMPurify's
+ * SAFE_FOR_XML guard silently strips an ENTIRE attribute whose value
+ * contains a `</script>`-shaped substring or a `-->`/`]>` comment closer,
+ * which real code snippets can easily contain. `textContent` has no such
+ * failure mode and always reconstructs the exact fenced source, since
+ * `renderMarkdown` only ever wraps/escapes each character — never drops or
+ * reorders it.
+ *
+ * Returns `true` when the click was on a copy button (handled), so a caller
+ * chaining this with `handleMarkdownLinkClick` in the same `onClick` can
+ * short-circuit and skip the link-click logic for the same event.
+ */
+export function handleCodeCopyClick(
+  e: CodeCopyClickEvent,
+  writeText: (text: string) => Promise<boolean> = defaultWriteText,
+): boolean {
+  const node = e.target
+  const el = node instanceof Element ? node : (node as { parentElement?: Element | null } | null)?.parentElement ?? null
+  const button = el && typeof el.closest === 'function' ? (el.closest(`.${CODE_COPY_BTN_CLASS}`) as HTMLElement | null) : null
+  if (!button) return false // click wasn't on a copy button — leave other handlers alone
+  e.stopPropagation()
+  const block = button.closest(`.${CODE_BLOCK_CLASS}`)
+  const codeEl = block?.querySelector('pre code')
+  const text = codeEl?.textContent ?? ''
+  if (!text) return true // nothing to copy (shouldn't happen — button only renders alongside a block)
+  void writeText(text).then((ok) => {
+    if (!ok) {
+      useConnectionStore.getState().addServerError('Failed to copy code to clipboard. Please try again.', undefined, 'warning')
+      return
+    }
+    showCopied(button)
+  })
+  return true
+}
+
+/** Combined click-event shape needed by both delegated handlers below. */
+export type MarkdownBodyClickEvent = CodeCopyClickEvent & LinkClickEvent
+
+/**
+ * Single delegated `onClick` for any `dangerouslySetInnerHTML` markdown body
+ * (ChatView.tsx's response/tool_use rows, OrchestrationRunsSection.tsx's run
+ * reports — anywhere `renderMarkdown`'s output is mounted). Tries the
+ * per-fenced-code-block copy button first (#6793) — a handled click
+ * short-circuits before reaching the link handler — then falls through to
+ * the #6625 `handleMarkdownLinkClick`, so both behaviors share one container
+ * without stepping on each other.
+ */
+export function handleMarkdownBodyClick(e: MarkdownBodyClickEvent): void {
+  if (handleCodeCopyClick(e)) return
+  handleMarkdownLinkClick(e)
+}

--- a/packages/dashboard/src/lib/markdown.test.ts
+++ b/packages/dashboard/src/lib/markdown.test.ts
@@ -286,6 +286,61 @@ describe('renderMarkdown', () => {
     })
   })
 
+  // Per-code-block copy button (#6793)
+  describe('per-code-block copy button (#6793)', () => {
+    it('wraps a fenced code block in a .code-block container with a .code-copy-btn', () => {
+      const html = renderMarkdown('```js\nconst x = 5\n```')
+      expect(html).toContain('class="code-block"')
+      expect(html).toMatch(/<div class="code-block"><button[^>]*class="code-copy-btn"[^>]*>.*?<\/button><pre>/)
+    })
+
+    it('gives the button an accessible label and testid, distinct from the whole-message copy button', () => {
+      const html = renderMarkdown('```\nx\n```')
+      expect(html).toContain('aria-label="Copy code"')
+      expect(html).toContain('data-testid="code-copy-button"')
+    })
+
+    it('renders one .code-block per fenced block, each scoped to its own snippet', () => {
+      const html = renderMarkdown('```js\nfirst\n```\n\ntext between\n\n```py\nsecond\n```')
+      expect((html.match(/class="code-block"/g) || []).length).toBe(2)
+      expect((html.match(/class="code-copy-btn"/g) || []).length).toBe(2)
+      // Each block's own <pre><code> immediately follows its own button — not
+      // one giant wrapper around both snippets.
+      const div = document.createElement('div')
+      div.innerHTML = html
+      const blocks = div.querySelectorAll('.code-block')
+      expect(blocks).toHaveLength(2)
+      expect(blocks[0]!.querySelector('pre code')!.textContent).toBe('first\n')
+      expect(blocks[1]!.querySelector('pre code')!.textContent).toBe('second\n')
+    })
+
+    it('does NOT add a copy button to inline code spans', () => {
+      const html = renderMarkdown('use `npm install` here')
+      expect(html).not.toContain('code-copy-btn')
+      expect(html).not.toContain('code-block')
+    })
+
+    it('the rendered <code> textContent reconstructs the exact original block, even with characters DOMPurify treats specially in attributes', () => {
+      // A `data-*`-attribute-based copy affordance would lose this content —
+      // DOMPurify's SAFE_FOR_XML guard strips an entire attribute whose value
+      // contains a `</script>`-shaped substring or a `-->`/`]>` closer. The
+      // textContent-based approach has no such failure mode.
+      const tricky = 'const s = "</script>"\n// comment --> end\nconst arr = []> // typo'
+      const html = renderMarkdown('```\n' + tricky + '\n```')
+      const div = document.createElement('div')
+      div.innerHTML = html
+      expect(div.querySelector('pre code')!.textContent).toBe(tricky + '\n')
+    })
+
+    it('reconstructs the exact block through the syntax-highlighted (language) path too', () => {
+      const code = 'const x = "<b>&amp;</b>" // & < >'
+      const html = renderMarkdown('```js\n' + code + '\n```')
+      const div = document.createElement('div')
+      div.innerHTML = html
+      expect(div.querySelector('pre code')!.textContent).toBe(code + '\n')
+    })
+  })
+
   it('sanitizes XSS payloads via DOMPurify defense-in-depth', () => {
     // Verify no raw <script> or event handler attributes survive in output.
     // Input is escaped by escapeHtml first; DOMPurify catches anything that

--- a/packages/dashboard/src/lib/markdown.ts
+++ b/packages/dashboard/src/lib/markdown.ts
@@ -25,7 +25,25 @@ export function renderMarkdown(text: string): string {
     const lang = rawLang ? rawLang.trim().split(/\s+/)[0] : ''
     const cls = lang ? ` class="language-${lang}"` : ''
     const highlighted = lang ? highlightCode(code, lang) : escapeHtml(code)
-    codeBlocks.push(`<pre><code${cls}>${highlighted}</code></pre>`)
+    // #6793 — wrap each fenced block in a `.code-block` container carrying a
+    // hover-revealed copy button. The button does NOT carry the block's raw
+    // text as a `data-*` attribute: DOMPurify's SAFE_FOR_XML guard strips any
+    // attribute whose value contains a comment/CDATA closer or a
+    // `</script|style|title|...>` substring (verified against this repo's
+    // DOMPurify version — it silently drops the whole attribute, not just the
+    // dangerous part), which real code snippets can easily contain (e.g. a
+    // block demonstrating `</script>` or a `-->` comment). Instead, the copy
+    // handler reads the rendered block's `textContent` at click time —
+    // `highlightCode`/`escapeHtml` above only wrap each character in
+    // `<span>`/entity-escape it, never drop or reorder text, so `<code>`'s
+    // `textContent` reconstructs the exact original block. This string
+    // pipeline is rendered via `dangerouslySetInnerHTML` (CSP `script-src
+    // 'self'`, no inline handlers), so the click is wired up via event
+    // delegation in the consuming component (ChatView.tsx), NOT an inline
+    // `onclick="…"` attribute.
+    codeBlocks.push(
+      `<div class="code-block"><button type="button" class="code-copy-btn" data-testid="code-copy-button" aria-label="Copy code" title="Copy code">⧉</button><pre><code${cls}>${highlighted}</code></pre></div>`,
+    )
     return placeholder
   })
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3018,6 +3018,58 @@ button.sidebar-token-view-session-row:hover {
   overflow-wrap: normal;
 }
 
+/* #6793 — per-fenced-code-block copy button. `.code-block` is emitted
+   exclusively by `renderMarkdown` (lib/markdown.ts) as the wrapper around
+   every fenced `<pre><code>`, so this is intentionally unscoped (not
+   `.msg .code-block`) — it also covers OrchestrationRunsSection.tsx's run
+   reports, the other live consumer of the shared markdown pipeline. */
+.code-block {
+  position: relative;
+}
+
+.code-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--text-muted);
+  /* theme-neutral fallbacks (matches .msg-copy-btn, #6631) so the control
+     reads correctly in both light and dark. */
+  background: var(--surface-raised, rgba(127, 127, 127, 0.12));
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+  opacity: 0;
+  /* Hidden ⇒ not a click target, so an invisible top-right hotspot can't eat
+     a selection click over the code below; re-enabled below when shown. */
+  pointer-events: none;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.code-block:hover .code-copy-btn,
+.code-copy-btn:focus-visible,
+.code-copy-btn[data-copied='true'] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.code-copy-btn:hover {
+  color: var(--text-heading);
+}
+
+.code-copy-btn[data-copied='true'] {
+  opacity: 1;
+  color: var(--accent-green, #22c55e);
+}
+
 .msg code {
   font-family: var(--font-mono);
   background: var(--bg-code-block);


### PR DESCRIPTION
## Summary

Adds a per-fenced-code-block copy affordance to chat markdown on both the dashboard and the mobile app — previously the only copy control was whole-message (`CopyButton` / multi-select transcript copy).

**Dashboard** (`packages/dashboard/src/lib/markdown.ts`): `renderMarkdown` wraps each fenced code block in a `.code-block` container with a hover-revealed `.code-copy-btn`. Since the markdown renders through a `dangerouslySetInnerHTML` string pipeline (CSP `script-src 'self'`, no inline handlers), the click is wired up via a single delegated `onClick` in the consuming components (`ChatView.tsx`, and `OrchestrationRunsSection.tsx` for parity — it shares the same `renderMarkdown` pipeline) rather than an inline `onclick` attribute — mirroring the existing `#6625` link-click delegation pattern.

The copy handler (`packages/dashboard/src/lib/codeCopy.ts`) reads the block's rendered `<code>` `textContent` at click time instead of stashing the raw text on a `data-*` attribute. Verified empirically that DOMPurify's `SAFE_FOR_XML` guard silently strips an entire attribute whose value contains a `</script>`-shaped substring or a `-->`/`]>` closer — real code snippets can easily contain these — so `textContent` (which has no such failure mode, since `highlightCode`/`escapeHtml` only ever wrap/escape each character, never drop it) is the robust choice.

**Mobile** (`packages/app/src/components/MarkdownRenderer.tsx`): each fenced code block gets a header row with the language label and a tap-to-copy icon button, wired to the same `expo-clipboard` API the multi-select transcript copy (`SessionScreen.tsx`'s `handleCopy`) already uses.

Both platforms show a transient "copied" confirmation and keep the copy icon out of the copied text.

## Test plan
- [x] `packages/dashboard`: `vitest run` — 254 test files / 4370 tests passing (includes new `codeCopy.test.ts`, `markdown.test.ts` additions, `ChatView.test.tsx` integration tests)
- [x] `packages/dashboard`: `tsc --noEmit` clean
- [x] `packages/app`: full `jest` suite — 166 test suites / 2169 tests passing (includes new `MarkdownRenderer.copyCodeBlock.test.tsx`)
- [x] `packages/app`: `tsc --noEmit` clean