### PR TITLE
feat(desktop): wire the first-run setup wizard to the existing Tauri commands (#6787)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -95,6 +95,7 @@ import { type RepoInvestigateRequest, type RepoOpenSessionRequest } from './comp
 import { ControlRoomView } from './components/ControlRoomView'
 import { AppModals } from './components/AppModals'
 import { AppHeader } from './components/AppHeader'
+import { SetupWizard } from './components/SetupWizard'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -1946,6 +1947,10 @@ export function App() {
 
   return (
     <div id="app" className={sidebarRepos.length > 0 ? 'with-sidebar' : ''}>
+      {/* #6787 — desktop first-run setup wizard. Self-contained: resolves
+          get_setup_state itself and renders null outside Tauri or once
+          setup is complete, so it can sit unconditionally at the root. */}
+      <SetupWizard />
       {/* #4873 — single page-level live region that announces only the
           SETTLED connection phase after a debounce. Replaces the
           per-status-dot role=status announcements that flooded SR

--- a/packages/dashboard/src/components/SetupWizard.css
+++ b/packages/dashboard/src/components/SetupWizard.css
@@ -1,7 +1,12 @@
 /* SetupWizard — desktop first-run setup panel (#6787).
    Overlay/content/title chrome comes from the shared Modal component
    (.modal-overlay / .modal-content / .modal-title in theme/components.css);
-   only the wizard-internal styles live here. */
+   only the wizard-internal styles live here.
+
+   Tokens-only (lint-no-raw-color-literals): every color is a bare
+   var(--token) from the generated theme.css — no hex literals, no
+   fallbacks (the lint flags hex anywhere outside comments, including
+   inside var() fallbacks). */
 
 .setup-wizard {
   max-height: 75vh;
@@ -9,7 +14,7 @@
 }
 
 .setup-wizard-subtitle {
-  color: var(--text-secondary, #cccccc);
+  color: var(--text-secondary);
   font-size: 0.9rem;
   margin: 0 0 20px;
 }
@@ -19,7 +24,7 @@
 }
 
 .setup-wizard-section h3 {
-  color: var(--text-primary, #ffffff);
+  color: var(--text-primary);
   font-size: 1rem;
   margin: 0 0 10px;
 }
@@ -37,16 +42,16 @@
 
 .setup-wizard-recheck-btn {
   background: transparent;
-  color: var(--accent-blue, #4a9eff);
-  border: 1px solid var(--accent-blue-border, #4a9eff44);
-  border-radius: 6px;
+  color: var(--accent-blue);
+  border: 1px solid var(--accent-blue-border);
+  border-radius: var(--radius-sm);
   padding: 4px 10px;
   font-size: 0.8rem;
   cursor: pointer;
 }
 
 .setup-wizard-recheck-btn:hover:not(:disabled) {
-  background: var(--accent-blue-subtle, #4a9eff33);
+  background: var(--accent-blue-subtle);
 }
 
 .setup-wizard-recheck-btn:disabled {
@@ -69,8 +74,10 @@
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  border-radius: 6px;
-  background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border-radius: var(--radius-sm);
+  /* --bg-card, not --bg-secondary: the latter equals --bg-modal, which
+     would make the rows invisible against the modal surface. */
+  background: var(--bg-card);
   font-size: 0.9rem;
 }
 
@@ -83,33 +90,33 @@
 }
 
 .setup-wizard-dep-row--pass .setup-wizard-dep-icon {
-  color: var(--status-connected, #22c55e);
+  color: var(--status-connected);
 }
 
 .setup-wizard-dep-row--fail .setup-wizard-dep-icon {
-  color: var(--error, #e74c3c);
+  color: var(--accent-red);
 }
 
 .setup-wizard-dep-row--unknown .setup-wizard-dep-icon,
 .setup-wizard-dep-row--checking .setup-wizard-dep-icon {
-  color: var(--warning-fg, #fbbf24);
+  color: var(--warning-fg);
 }
 
 .setup-wizard-dep-label {
-  color: var(--text-primary, #ffffff);
+  color: var(--text-primary);
   flex: 1;
 }
 
 .setup-wizard-dep-detail {
-  color: var(--text-muted, #888888);
+  color: var(--text-muted);
   font-size: 0.85em;
 }
 
 .setup-wizard-dep-hint {
   flex-basis: 100%;
-  color: var(--text-muted, #888888);
+  color: var(--text-muted);
   font-size: 0.8rem;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
 }
 
 .setup-wizard-field {
@@ -117,16 +124,16 @@
   flex-direction: column;
   gap: 4px;
   margin-bottom: 12px;
-  color: var(--text-secondary, #cccccc);
+  color: var(--text-secondary);
   font-size: 0.85rem;
 }
 
 .setup-wizard-field input,
 .setup-wizard-field select {
-  background: var(--bg-session-bar, #14142a);
-  color: var(--text-primary, #ffffff);
-  border: 1px solid var(--scrollbar-thumb, #333355);
-  border-radius: 6px;
+  background: var(--bg-session-bar);
+  color: var(--text-primary);
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: var(--radius-sm);
   padding: 8px 10px;
   font-size: 0.9rem;
 }
@@ -134,13 +141,13 @@
 .setup-wizard-field input:focus,
 .setup-wizard-field select:focus {
   outline: none;
-  border-color: var(--accent-blue, #4a9eff);
+  border-color: var(--accent-blue);
 }
 
 .setup-wizard-error {
-  color: var(--error, #e74c3c);
-  background: var(--warning-bg-subtle, #fbbf2422);
-  border-radius: 6px;
+  color: var(--text-error);
+  background: var(--accent-red-light);
+  border-radius: var(--radius-sm);
   padding: 8px 10px;
   font-size: 0.85rem;
   margin-bottom: 16px;
@@ -152,10 +159,10 @@
 }
 
 .setup-wizard-finish-btn {
-  background: var(--accent-blue, #4a9eff);
-  color: #ffffff;
+  background: var(--accent-blue);
+  color: var(--text-primary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 10px 20px;
   font-size: 0.9rem;
   font-weight: 600;

--- a/packages/dashboard/src/components/SetupWizard.css
+++ b/packages/dashboard/src/components/SetupWizard.css
@@ -1,31 +1,11 @@
-/* SetupWizard — desktop first-run setup panel (#6787). */
+/* SetupWizard — desktop first-run setup panel (#6787).
+   Overlay/content/title chrome comes from the shared Modal component
+   (.modal-overlay / .modal-content / .modal-title in theme/components.css);
+   only the wizard-internal styles live here. */
 
-.setup-wizard-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2000;
-}
-
-.setup-wizard-content {
-  position: relative;
-  background: var(--bg-modal, #1a1a2e);
-  border: 1px solid var(--scrollbar-thumb, #333355);
-  border-radius: 12px;
-  padding: 28px;
-  width: 100%;
-  max-width: 480px;
-  max-height: 85vh;
+.setup-wizard {
+  max-height: 75vh;
   overflow-y: auto;
-}
-
-.setup-wizard-title {
-  color: var(--text-primary, #ffffff);
-  font-size: 1.3rem;
-  margin: 0 0 4px;
 }
 
 .setup-wizard-subtitle {

--- a/packages/dashboard/src/components/SetupWizard.css
+++ b/packages/dashboard/src/components/SetupWizard.css
@@ -1,0 +1,192 @@
+/* SetupWizard — desktop first-run setup panel (#6787). */
+
+.setup-wizard-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.setup-wizard-content {
+  position: relative;
+  background: var(--bg-modal, #1a1a2e);
+  border: 1px solid var(--scrollbar-thumb, #333355);
+  border-radius: 12px;
+  padding: 28px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.setup-wizard-title {
+  color: var(--text-primary, #ffffff);
+  font-size: 1.3rem;
+  margin: 0 0 4px;
+}
+
+.setup-wizard-subtitle {
+  color: var(--text-secondary, #cccccc);
+  font-size: 0.9rem;
+  margin: 0 0 20px;
+}
+
+.setup-wizard-section {
+  margin-bottom: 20px;
+}
+
+.setup-wizard-section h3 {
+  color: var(--text-primary, #ffffff);
+  font-size: 1rem;
+  margin: 0 0 10px;
+}
+
+.setup-wizard-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.setup-wizard-section-header h3 {
+  margin: 0;
+}
+
+.setup-wizard-recheck-btn {
+  background: transparent;
+  color: var(--accent-blue, #4a9eff);
+  border: 1px solid var(--accent-blue-border, #4a9eff44);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.setup-wizard-recheck-btn:hover:not(:disabled) {
+  background: var(--accent-blue-subtle, #4a9eff33);
+}
+
+.setup-wizard-recheck-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.setup-wizard-dep-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.setup-wizard-dep-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  font-size: 0.9rem;
+}
+
+.setup-wizard-dep-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25em;
+  font-weight: 700;
+}
+
+.setup-wizard-dep-row--pass .setup-wizard-dep-icon {
+  color: var(--status-connected, #22c55e);
+}
+
+.setup-wizard-dep-row--fail .setup-wizard-dep-icon {
+  color: var(--error, #e74c3c);
+}
+
+.setup-wizard-dep-row--unknown .setup-wizard-dep-icon,
+.setup-wizard-dep-row--checking .setup-wizard-dep-icon {
+  color: var(--warning-fg, #fbbf24);
+}
+
+.setup-wizard-dep-label {
+  color: var(--text-primary, #ffffff);
+  flex: 1;
+}
+
+.setup-wizard-dep-detail {
+  color: var(--text-muted, #888888);
+  font-size: 0.85em;
+}
+
+.setup-wizard-dep-hint {
+  flex-basis: 100%;
+  color: var(--text-muted, #888888);
+  font-size: 0.8rem;
+  font-family: var(--font-mono, monospace);
+}
+
+.setup-wizard-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  color: var(--text-secondary, #cccccc);
+  font-size: 0.85rem;
+}
+
+.setup-wizard-field input,
+.setup-wizard-field select {
+  background: var(--bg-session-bar, #14142a);
+  color: var(--text-primary, #ffffff);
+  border: 1px solid var(--scrollbar-thumb, #333355);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 0.9rem;
+}
+
+.setup-wizard-field input:focus,
+.setup-wizard-field select:focus {
+  outline: none;
+  border-color: var(--accent-blue, #4a9eff);
+}
+
+.setup-wizard-error {
+  color: var(--error, #e74c3c);
+  background: var(--warning-bg-subtle, #fbbf2422);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 0.85rem;
+  margin-bottom: 16px;
+}
+
+.setup-wizard-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.setup-wizard-finish-btn {
+  background: var(--accent-blue, #4a9eff);
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.setup-wizard-finish-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.setup-wizard-finish-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/packages/dashboard/src/components/SetupWizard.test.tsx
+++ b/packages/dashboard/src/components/SetupWizard.test.tsx
@@ -91,6 +91,11 @@ describe('SetupWizard', () => {
       expect(screen.getByTestId('setup-wizard-dep-cloudflared')).toHaveClass('setup-wizard-dep-row--fail')
       expect(screen.getByTestId('setup-wizard-dep-claude')).toHaveClass('setup-wizard-dep-row--fail')
     })
+    // #6814 review — the fail state is conveyed by color + glyph visually,
+    // so each row must also carry the state as (visually-hidden) text.
+    expect(screen.getByTestId('setup-wizard-dep-node')).toHaveTextContent('Node 22: missing')
+    expect(screen.getByTestId('setup-wizard-dep-cloudflared')).toHaveTextContent('cloudflared: missing')
+    expect(screen.getByTestId('setup-wizard-dep-claude')).toHaveTextContent('Claude CLI: missing')
   })
 
   it('shows passing dependency rows when all tools are found', async () => {
@@ -108,6 +113,27 @@ describe('SetupWizard', () => {
       expect(screen.getByTestId('setup-wizard-dep-claude')).toHaveClass('setup-wizard-dep-row--pass')
     })
     expect(screen.getByText(/v22\.1\.0/)).toBeInTheDocument()
+    // #6814 review — accessible state text for the pass state.
+    expect(screen.getByTestId('setup-wizard-dep-node')).toHaveTextContent('Node 22: found')
+    expect(screen.getByTestId('setup-wizard-dep-cloudflared')).toHaveTextContent('cloudflared: found')
+    expect(screen.getByTestId('setup-wizard-dep-claude')).toHaveTextContent('Claude CLI: found')
+  })
+
+  it('moves focus into the dialog when the wizard appears (#6814 review)', async () => {
+    setupTauriMock({
+      setupState: { isFirstRun: true, port: 8765, tunnelMode: 'none', isRunning: false },
+      dependencies: PASSING_DEPS,
+    })
+    render(<SetupWizard />)
+
+    await screen.findByTestId('setup-wizard')
+
+    // The shared Modal focuses the first focusable control on open and traps
+    // Tab inside; assert focus actually landed within the dialog.
+    const dialog = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
   })
 
   it('re-check button re-invokes check_dependencies', async () => {

--- a/packages/dashboard/src/components/SetupWizard.test.tsx
+++ b/packages/dashboard/src/components/SetupWizard.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Tests for SetupWizard (#6787) — wires get_setup_state / check_dependencies
+ * / save_setup_config to a first-run onboarding panel.
+ *
+ * Mocks `window.__TAURI_INTERNALS__.invoke` the same way useVoiceInput.test.ts
+ * does, since SetupWizard talks to Tauri commands directly rather than
+ * through a WS-driven store.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { SetupWizard } from './SetupWizard'
+
+type InvokeResponses = {
+  setupState?: unknown
+  dependencies?: unknown
+  saveSetupConfigImpl?: (args: Record<string, unknown>) => unknown
+}
+
+let mockInvoke: ReturnType<typeof vi.fn>
+
+function setupTauriMock(responses: InvokeResponses) {
+  mockInvoke = vi.fn(async (cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === 'get_setup_state') return responses.setupState
+    if (cmd === 'check_dependencies') return responses.dependencies
+    if (cmd === 'save_setup_config') {
+      if (responses.saveSetupConfigImpl) return responses.saveSetupConfigImpl(args || {})
+      return undefined
+    }
+    if (cmd === 'start_server') return undefined
+    return undefined
+  })
+
+  Object.defineProperty(window, '__TAURI_INTERNALS__', {
+    value: { invoke: mockInvoke },
+    writable: true,
+    configurable: true,
+  })
+}
+
+function clearTauriMock() {
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+}
+
+const PASSING_DEPS = {
+  node22: { found: true, path: '/usr/local/bin/node', version: 'v22.1.0' },
+  cloudflared: { found: true },
+  claude: { found: true, version: '1.0.0' },
+}
+
+const FAILING_DEPS = {
+  node22: { found: false, path: null, version: null },
+  cloudflared: { found: false },
+  claude: { found: false, version: null },
+}
+
+afterEach(() => {
+  cleanup()
+  clearTauriMock()
+})
+
+describe('SetupWizard', () => {
+  it('renders nothing outside Tauri (plain web dashboard, #6787)', async () => {
+    // No __TAURI_INTERNALS__ defined at all.
+    render(<SetupWizard />)
+    expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
+    // Give any stray effects a tick to settle before asserting stability.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when setup is already complete (isFirstRun: false)', async () => {
+    setupTauriMock({ setupState: { isFirstRun: false, port: 8765, tunnelMode: 'none', isRunning: true } })
+    render(<SetupWizard />)
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith('get_setup_state', undefined))
+    expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
+    // check_dependencies must never be called when the wizard doesn't show.
+    expect(mockInvoke).not.toHaveBeenCalledWith('check_dependencies', undefined)
+  })
+
+  it('renders the wizard on first run and shows pass/fail dependency rows', async () => {
+    setupTauriMock({
+      setupState: { isFirstRun: true, port: 8765, tunnelMode: 'none', isRunning: false },
+      dependencies: FAILING_DEPS,
+    })
+    render(<SetupWizard />)
+
+    await screen.findByTestId('setup-wizard')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('setup-wizard-dep-node')).toHaveClass('setup-wizard-dep-row--fail')
+      expect(screen.getByTestId('setup-wizard-dep-cloudflared')).toHaveClass('setup-wizard-dep-row--fail')
+      expect(screen.getByTestId('setup-wizard-dep-claude')).toHaveClass('setup-wizard-dep-row--fail')
+    })
+  })
+
+  it('shows passing dependency rows when all tools are found', async () => {
+    setupTauriMock({
+      setupState: { isFirstRun: true, port: 8765, tunnelMode: 'none', isRunning: false },
+      dependencies: PASSING_DEPS,
+    })
+    render(<SetupWizard />)
+
+    await screen.findByTestId('setup-wizard')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('setup-wizard-dep-node')).toHaveClass('setup-wizard-dep-row--pass')
+      expect(screen.getByTestId('setup-wizard-dep-cloudflared')).toHaveClass('setup-wizard-dep-row--pass')
+      expect(screen.getByTestId('setup-wizard-dep-claude')).toHaveClass('setup-wizard-dep-row--pass')
+    })
+    expect(screen.getByText(/v22\.1\.0/)).toBeInTheDocument()
+  })
+
+  it('re-check button re-invokes check_dependencies', async () => {
+    setupTauriMock({
+      setupState: { isFirstRun: true, port: 8765, tunnelMode: 'none', isRunning: false },
+      dependencies: FAILING_DEPS,
+    })
+    render(<SetupWizard />)
+    await screen.findByTestId('setup-wizard')
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith('check_dependencies', undefined))
+
+    const callsBefore = mockInvoke.mock.calls.filter(([cmd]) => cmd === 'check_dependencies').length
+    fireEvent.click(screen.getByTestId('setup-wizard-recheck'))
+
+    await waitFor(() => {
+      const callsAfter = mockInvoke.mock.calls.filter(([cmd]) => cmd === 'check_dependencies').length
+      expect(callsAfter).toBeGreaterThan(callsBefore)
+    })
+  })
+
+  it('finish calls save_setup_config with the chosen port + tunnel mode, then hides', async () => {
+    setupTauriMock({
+      setupState: { isFirstRun: true, port: 8765, tunnelMode: 'none', isRunning: false },
+      dependencies: PASSING_DEPS,
+    })
+    render(<SetupWizard />)
+    await screen.findByTestId('setup-wizard')
+
+    fireEvent.change(screen.getByTestId('setup-wizard-port'), { target: { value: '9090' } })
+    fireEvent.change(screen.getByTestId('setup-wizard-tunnel-mode'), { target: { value: 'quick' } })
+    fireEvent.click(screen.getByTestId('setup-wizard-finish'))
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('save_setup_config', { port: 9090, tunnelMode: 'quick' })
+    })
+    await waitFor(() => expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument())
+    // Finishing also starts the embedded server, mirroring the existing
+    // "Start Server" affordance.
+    expect(mockInvoke).toHaveBeenCalledWith('start_server', undefined)
+  })
+
+  it('surfaces a save error and keeps the wizard open on failure', async () => {
+    setupTauriMock({
+      setupState: { isFirstRun: true, port: 8765, tunnelMode: 'none', isRunning: false },
+      dependencies: PASSING_DEPS,
+      saveSetupConfigImpl: () => {
+        throw new Error('disk full')
+      },
+    })
+    render(<SetupWizard />)
+    await screen.findByTestId('setup-wizard')
+
+    fireEvent.click(screen.getByTestId('setup-wizard-finish'))
+
+    await screen.findByTestId('setup-wizard-error')
+    expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/SetupWizard.tsx
+++ b/packages/dashboard/src/components/SetupWizard.tsx
@@ -1,0 +1,228 @@
+/**
+ * SetupWizard — desktop first-run setup panel (#6787).
+ *
+ * Wires the three orphaned Tauri commands (`get_setup_state`,
+ * `check_dependencies`, `save_setup_config`) to a minimal onboarding UI. On
+ * mount inside the Tauri shell, checks whether this is a first run; if so,
+ * shows a blocking panel with a dependency checklist (Node 22 / cloudflared
+ * / claude CLI) and the port + tunnel-mode choices `save_setup_config`
+ * expects. Finishing saves the config (which clears the Rust-side
+ * `IS_FIRST_RUN` flag so the panel never shows again) and starts the
+ * embedded server, same as the existing "Start Server" affordance.
+ *
+ * Entirely self-contained: renders `null` outside Tauri (zero behavior
+ * change for the plain web dashboard) and `null` once setup is complete, so
+ * it can be mounted unconditionally at the top of <App/>.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { isTauri } from '../utils/tauri'
+import {
+  checkDependencies,
+  getSetupState,
+  saveSetupConfig,
+  startServer,
+  type DependencyCheckResult,
+} from '../hooks/useTauriIPC'
+import './SetupWizard.css'
+
+const TUNNEL_MODE_OPTIONS: { value: string; label: string }[] = [
+  { value: 'none', label: 'None — local network only' },
+  { value: 'quick', label: 'Quick — random public URL, no account needed' },
+  { value: 'named', label: 'Named — stable URL, requires a Cloudflare account' },
+]
+
+type DepStatus = 'checking' | 'unknown' | 'pass' | 'fail'
+
+interface DependencyRowProps {
+  testId: string
+  label: string
+  found?: boolean
+  detail?: string | null
+  hint: string
+  checking: boolean
+}
+
+function DependencyRow({ testId, label, found, detail, hint, checking }: DependencyRowProps) {
+  const status: DepStatus = checking
+    ? 'checking'
+    : found === undefined
+      ? 'unknown'
+      : found
+        ? 'pass'
+        : 'fail'
+  const icon = status === 'checking' ? '…' : status === 'pass' ? '✓' : status === 'unknown' ? '?' : '✕'
+  return (
+    <li className={`setup-wizard-dep-row setup-wizard-dep-row--${status}`} data-testid={testId}>
+      <span className="setup-wizard-dep-icon" aria-hidden="true">{icon}</span>
+      <span className="setup-wizard-dep-label">
+        {label}
+        {detail ? <span className="setup-wizard-dep-detail"> ({detail})</span> : null}
+      </span>
+      {(status === 'fail' || status === 'unknown') && (
+        <span className="setup-wizard-dep-hint">{hint}</span>
+      )}
+    </li>
+  )
+}
+
+export function SetupWizard() {
+  // Whether we've resolved get_setup_state yet — avoids a flash of the
+  // panel (or of nothing) before we know if this is actually a first run.
+  const [resolved, setResolved] = useState(false)
+  const [visible, setVisible] = useState(false)
+  const [port, setPort] = useState(8765)
+  const [tunnelMode, setTunnelMode] = useState('none')
+  const [deps, setDeps] = useState<DependencyCheckResult | null>(null)
+  const [depsChecking, setDepsChecking] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const runDependencyCheck = useCallback(() => {
+    setDepsChecking(true)
+    checkDependencies()
+      .then((result) => setDeps(result))
+      .finally(() => setDepsChecking(false))
+  }, [])
+
+  useEffect(() => {
+    if (!isTauri()) {
+      setResolved(true)
+      return
+    }
+    let cancelled = false
+    getSetupState().then((state) => {
+      if (cancelled) return
+      setResolved(true)
+      if (state?.isFirstRun) {
+        setVisible(true)
+        setPort(state.port || 8765)
+        setTunnelMode(state.tunnelMode || 'none')
+        runDependencyCheck()
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [runDependencyCheck])
+
+  const handleFinish = useCallback(() => {
+    if (saving) return
+    setSaving(true)
+    setSaveError(null)
+    saveSetupConfig(port, tunnelMode)
+      .then(() => {
+        setVisible(false)
+        // Mirrors App's handleStartServer — fire-and-forget; useTauriEvents
+        // already listens for server_ready/server_error and reconciles the
+        // connection store once the embedded server actually comes up.
+        startServer()
+      })
+      .catch((err: unknown) => {
+        setSaveError(err instanceof Error ? err.message : 'Failed to save setup configuration.')
+      })
+      .finally(() => setSaving(false))
+  }, [port, tunnelMode, saving])
+
+  if (!isTauri() || !resolved || !visible) return null
+
+  return (
+    <div className="setup-wizard-overlay" data-testid="setup-wizard">
+      <div
+        className="setup-wizard-content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="setup-wizard-title"
+      >
+        <h2 id="setup-wizard-title" className="setup-wizard-title">Welcome to Chroxy</h2>
+        <p className="setup-wizard-subtitle">
+          Let&apos;s check your setup before the daemon starts.
+        </p>
+
+        <section className="setup-wizard-section">
+          <div className="setup-wizard-section-header">
+            <h3>Dependencies</h3>
+            <button
+              type="button"
+              className="setup-wizard-recheck-btn"
+              onClick={runDependencyCheck}
+              disabled={depsChecking}
+              data-testid="setup-wizard-recheck"
+            >
+              {depsChecking ? 'Checking…' : 'Re-check'}
+            </button>
+          </div>
+          <ul className="setup-wizard-dep-list">
+            <DependencyRow
+              testId="setup-wizard-dep-node"
+              label="Node 22"
+              found={deps?.node22.found}
+              detail={deps?.node22.version}
+              hint="Install Node 22 from nodejs.org, nvm, or Homebrew."
+              checking={depsChecking}
+            />
+            <DependencyRow
+              testId="setup-wizard-dep-cloudflared"
+              label="cloudflared"
+              found={deps?.cloudflared.found}
+              hint="Install with: brew install cloudflared"
+              checking={depsChecking}
+            />
+            <DependencyRow
+              testId="setup-wizard-dep-claude"
+              label="Claude CLI"
+              found={deps?.claude.found}
+              detail={deps?.claude.version}
+              hint="Install with: npm install -g @anthropic-ai/claude-code"
+              checking={depsChecking}
+            />
+          </ul>
+        </section>
+
+        <section className="setup-wizard-section">
+          <h3>Configuration</h3>
+          <label className="setup-wizard-field">
+            <span>Port</span>
+            <input
+              type="number"
+              min={1}
+              max={65535}
+              value={port}
+              onChange={(e) => setPort(Number(e.target.value) || 0)}
+              data-testid="setup-wizard-port"
+            />
+          </label>
+          <label className="setup-wizard-field">
+            <span>Tunnel mode</span>
+            <select
+              value={tunnelMode}
+              onChange={(e) => setTunnelMode(e.target.value)}
+              data-testid="setup-wizard-tunnel-mode"
+            >
+              {TUNNEL_MODE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </label>
+        </section>
+
+        {saveError && (
+          <div className="setup-wizard-error" role="alert" data-testid="setup-wizard-error">
+            {saveError}
+          </div>
+        )}
+
+        <div className="setup-wizard-actions">
+          <button
+            type="button"
+            className="setup-wizard-finish-btn"
+            onClick={handleFinish}
+            disabled={saving || port < 1 || port > 65535}
+            data-testid="setup-wizard-finish"
+          >
+            {saving ? 'Saving…' : 'Finish setup'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/SetupWizard.tsx
+++ b/packages/dashboard/src/components/SetupWizard.tsx
@@ -10,12 +10,20 @@
  * `IS_FIRST_RUN` flag so the panel never shows again) and starts the
  * embedded server, same as the existing "Start Server" affordance.
  *
+ * Composes the shared <Modal> so focus management matches every other
+ * dashboard dialog (#6814 review): focus moves into the dialog on open,
+ * Tab is trapped inside while visible, and focus is restored on close. The
+ * wizard is non-dismissible — `onClose` is a no-op (Escape does nothing)
+ * and backdrop clicks are disabled — because a first run has nothing
+ * useful behind the dialog until setup completes.
+ *
  * Entirely self-contained: renders `null` outside Tauri (zero behavior
  * change for the plain web dashboard) and `null` once setup is complete, so
  * it can be mounted unconditionally at the top of <App/>.
  */
 import { useCallback, useEffect, useState } from 'react'
 import { isTauri } from '../utils/tauri'
+import { Modal } from './Modal'
 import {
   checkDependencies,
   getSetupState,
@@ -32,6 +40,18 @@ const TUNNEL_MODE_OPTIONS: { value: string; label: string }[] = [
 ]
 
 type DepStatus = 'checking' | 'unknown' | 'pass' | 'fail'
+
+/**
+ * Spoken state for a dependency row (#6814 review). The visual pass/fail
+ * state is conveyed by color + glyph only, so the same information is
+ * appended as visually-hidden (`.sr-only`) text for screen readers.
+ */
+const DEP_STATUS_TEXT: Record<DepStatus, string> = {
+  checking: 'checking',
+  unknown: 'not checked',
+  pass: 'found',
+  fail: 'missing',
+}
 
 interface DependencyRowProps {
   testId: string
@@ -56,6 +76,7 @@ function DependencyRow({ testId, label, found, detail, hint, checking }: Depende
       <span className="setup-wizard-dep-icon" aria-hidden="true">{icon}</span>
       <span className="setup-wizard-dep-label">
         {label}
+        <span className="sr-only">{`: ${DEP_STATUS_TEXT[status]}`}</span>
         {detail ? <span className="setup-wizard-dep-detail"> ({detail})</span> : null}
       </span>
       {(status === 'fail' || status === 'unknown') && (
@@ -66,9 +87,6 @@ function DependencyRow({ testId, label, found, detail, hint, checking }: Depende
 }
 
 export function SetupWizard() {
-  // Whether we've resolved get_setup_state yet — avoids a flash of the
-  // panel (or of nothing) before we know if this is actually a first run.
-  const [resolved, setResolved] = useState(false)
   const [visible, setVisible] = useState(false)
   const [port, setPort] = useState(8765)
   const [tunnelMode, setTunnelMode] = useState('none')
@@ -85,14 +103,10 @@ export function SetupWizard() {
   }, [])
 
   useEffect(() => {
-    if (!isTauri()) {
-      setResolved(true)
-      return
-    }
+    if (!isTauri()) return
     let cancelled = false
     getSetupState().then((state) => {
       if (cancelled) return
-      setResolved(true)
       if (state?.isFirstRun) {
         setVisible(true)
         setPort(state.port || 8765)
@@ -123,17 +137,22 @@ export function SetupWizard() {
       .finally(() => setSaving(false))
   }, [port, tunnelMode, saving])
 
-  if (!isTauri() || !resolved || !visible) return null
+  // The wizard is non-dismissible: setup either completes (handleFinish
+  // hides it and clears the Rust-side first-run flag) or stays up. Escape
+  // and backdrop clicks are intentionally inert.
+  const handleClose = useCallback(() => {}, [])
+
+  if (!isTauri() || !visible) return null
 
   return (
-    <div className="setup-wizard-overlay" data-testid="setup-wizard">
-      <div
-        className="setup-wizard-content"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="setup-wizard-title"
-      >
-        <h2 id="setup-wizard-title" className="setup-wizard-title">Welcome to Chroxy</h2>
+    <Modal
+      open
+      onClose={handleClose}
+      title="Welcome to Chroxy"
+      maxWidth="480px"
+      closeOnBackdrop={false}
+    >
+      <div className="setup-wizard" data-testid="setup-wizard">
         <p className="setup-wizard-subtitle">
           Let&apos;s check your setup before the daemon starts.
         </p>
@@ -223,6 +242,6 @@ export function SetupWizard() {
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/packages/dashboard/src/components/SetupWizard.tsx
+++ b/packages/dashboard/src/components/SetupWizard.tsx
@@ -23,6 +23,7 @@
  */
 import { useCallback, useEffect, useState } from 'react'
 import { isTauri } from '../utils/tauri'
+import { isMacPlatform } from '../utils/platform'
 import { Modal } from './Modal'
 import {
   checkDependencies,
@@ -183,7 +184,13 @@ export function SetupWizard() {
               testId="setup-wizard-dep-cloudflared"
               label="cloudflared"
               found={deps?.cloudflared.found}
-              hint="Install with: brew install cloudflared"
+              // #6814 review — the app is cross-platform, so a Homebrew-only
+              // hint is wrong off-Mac. Uses the dashboard's shared platform
+              // detection; the non-Mac pointer matches the Rust side's
+              // cloudflared_install_hint() fallback (pkg.cloudflare.com).
+              hint={isMacPlatform()
+                ? 'Install with: brew install cloudflared'
+                : 'See the cloudflared install docs: https://pkg.cloudflare.com/'}
               checking={depsChecking}
             />
             <DependencyRow

--- a/packages/dashboard/src/hooks/TauriIPC.test.ts
+++ b/packages/dashboard/src/hooks/TauriIPC.test.ts
@@ -95,4 +95,35 @@ describe('Tauri IPC commands (#1108)', () => {
   test('TypeScript hook exports setSummonHotkey', () => {
     expect(hookSrc).toMatch(/export async function setSummonHotkey/)
   })
+
+  // #6787 — first-run setup wizard wiring.
+  test('Rust has check_dependencies command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn check_dependencies/)
+  })
+
+  test('Rust has get_setup_state command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn get_setup_state/)
+  })
+
+  test('Rust has save_setup_config command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn save_setup_config/)
+  })
+
+  test('setup wizard commands registered in generate_handler', () => {
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?check_dependencies/)
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?get_setup_state/)
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?save_setup_config/)
+  })
+
+  test('TypeScript hook exports checkDependencies', () => {
+    expect(hookSrc).toMatch(/export async function checkDependencies/)
+  })
+
+  test('TypeScript hook exports getSetupState', () => {
+    expect(hookSrc).toMatch(/export async function getSetupState/)
+  })
+
+  test('TypeScript hook exports saveSetupConfig', () => {
+    expect(hookSrc).toMatch(/export async function saveSetupConfig/)
+  })
 })

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -206,9 +206,12 @@ export async function checkDependencies(): Promise<DependencyCheckResult | null>
  * Persist the first-run wizard's chosen port + tunnel mode (#6787) and clear
  * the Rust-side `IS_FIRST_RUN` flag so the wizard never shows again. No-ops
  * outside Tauri. Throws when invoke is unavailable inside Tauri, or when the
- * Rust side rejects the config write (bad tunnel mode, IO/parse error) — the
- * wizard keeps its fields and surfaces the failure rather than silently
- * closing on a save that didn't actually persist.
+ * Rust side fails to persist — a settings save failure, or a read/parse/write
+ * error on `~/.chroxy/config.json` — so the wizard keeps its fields and
+ * surfaces the failure rather than silently closing on a save that didn't
+ * actually persist. Note the tunnel mode is persisted as-is: unlike
+ * `set_tunnel_mode`, the Rust `save_setup_config` does not validate the
+ * enum, so callers must only pass 'none' | 'quick' | 'named'.
  */
 export async function saveSetupConfig(port: number, tunnelMode: string): Promise<void> {
   if (!isTauri()) return

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -16,6 +16,29 @@ interface ServerInfo {
   isRunning: boolean
 }
 
+/** Payload returned by the Rust `get_setup_state` command (#6787). */
+export interface SetupState {
+  /** True when the desktop config was just created (no prior `~/.chroxy/config.json`). */
+  isFirstRun: boolean
+  port: number
+  tunnelMode: string
+  isRunning: boolean
+}
+
+/** One dependency's found/version probe, as returned by `check_dependencies` (#6787). */
+export interface DependencyStatus {
+  found: boolean
+  path?: string | null
+  version?: string | null
+}
+
+/** Payload returned by the Rust `check_dependencies` command (#6787). */
+export interface DependencyCheckResult {
+  node22: DependencyStatus
+  cloudflared: DependencyStatus
+  claude: DependencyStatus
+}
+
 /** Invoke a Tauri command (returns null if not in Tauri context) */
 async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T | null> {
   const invoke = getTauriInvoke()
@@ -159,4 +182,39 @@ export async function revealInFinder(path: string): Promise<void> {
     throw new Error('Tauri invoke is unavailable')
   }
   await invoke('reveal_in_finder', { path })
+}
+
+/**
+ * Read first-run wizard state (#6787): whether setup has never completed,
+ * plus the current port / tunnel mode / server-running snapshot so the
+ * wizard can pre-fill its fields. Returns `null` outside Tauri.
+ */
+export async function getSetupState(): Promise<SetupState | null> {
+  return tauriInvoke<SetupState>('get_setup_state')
+}
+
+/**
+ * Probe for Node 22, cloudflared, and the `claude` CLI on PATH (#6787).
+ * Used by the first-run wizard's dependency checklist (initial check + the
+ * "Re-check" button). Returns `null` outside Tauri.
+ */
+export async function checkDependencies(): Promise<DependencyCheckResult | null> {
+  return tauriInvoke<DependencyCheckResult>('check_dependencies')
+}
+
+/**
+ * Persist the first-run wizard's chosen port + tunnel mode (#6787) and clear
+ * the Rust-side `IS_FIRST_RUN` flag so the wizard never shows again. No-ops
+ * outside Tauri. Throws when invoke is unavailable inside Tauri, or when the
+ * Rust side rejects the config write (bad tunnel mode, IO/parse error) — the
+ * wizard keeps its fields and surfaces the failure rather than silently
+ * closing on a save that didn't actually persist.
+ */
+export async function saveSetupConfig(port: number, tunnelMode: string): Promise<void> {
+  if (!isTauri()) return
+  const invoke = getTauriInvoke()
+  if (!invoke) {
+    throw new Error('Tauri invoke is unavailable')
+  }
+  await invoke('save_setup_config', { port, tunnelMode })
 }


### PR DESCRIPTION
## Summary

The Rust side of the desktop first-run setup wizard was already fully built — `get_setup_state`, `check_dependencies`, and `save_setup_config` are defined, registered in `build.rs`, permissioned in `capabilities/default.json`, and covered by Rust integration tests — but nothing under `packages/dashboard/src` ever called them. `docs/feature-matrix.md` claimed Desktop "Y" for Setup Wizard / Dependency Check while the flow was entirely unreachable.

This wires a new `SetupWizard` dashboard component to the existing commands:

- `useTauriIPC.ts` gains `getSetupState` / `checkDependencies` / `saveSetupConfig`, following the file's existing conventions (`null` outside Tauri, throws on save failure so the UI can surface it).
- `SetupWizard` is self-contained and mounts unconditionally at the root of `<App/>`. It resolves `get_setup_state` on mount and renders `null` outside Tauri or once setup is already complete — **zero behavior change for the plain web dashboard**. On a genuine first run it shows a blocking panel with:
  - a dependency checklist (Node 22 / cloudflared / claude CLI) with pass/fail rows and a re-check button, backed by `check_dependencies`
  - the port + tunnel-mode fields `save_setup_config` actually expects (no invented fields)
  - a Finish button that saves the config (which clears the Rust-side `IS_FIRST_RUN` flag, so the panel never shows again) and starts the embedded server, mirroring the existing "Start Server" affordance already used elsewhere in `App.tsx`.

**No Rust changes.** The desktop backend was already correct — verified command signatures, `build.rs` registration, capability grants, and the existing `command_integration.rs` suite before writing any dashboard code.

`docs/feature-matrix.md` already read "Y" for Desktop Setup Wizard / Dependency Check; that claim is now actually true, so no doc edit was needed (the instruction was to update it only if the "Y" newly became true).

## Test plan
- [x] `npx vitest run` — full dashboard suite: 254 files / 4364 tests passed
- [x] `npx tsc --noEmit` — clean
- [x] New `SetupWizard.test.tsx`: hidden outside Tauri, hidden when setup already complete, dependency pass/fail rendering, re-check button, finish → `save_setup_config` + `start_server`, save-error surfaced without closing the panel
- [x] `TauriIPC.test.ts` extended with the same Rust-command-exists / registered-in-generate_handler / TS-hook-exports checks used for the other commands in that suite

Closes #6787
