### PR TITLE
feat(server,protocol,dashboard,app): stream thinking content end-to-end (#6756)

### DIFF
--- a/packages/app/src/components/__tests__/MessageBubble.thinking.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.thinking.test.tsx
@@ -7,7 +7,7 @@
  * generic ThinkingIndicator animation.
  */
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 // The real ThinkingIndicator drives a native-driver Animated loop that crashes
 // react-test-renderer (findNodeHandle is undefined off-device). Stub it so the
@@ -71,7 +71,8 @@ describe('MessageBubble thinking content (#6756)', () => {
     // Expand.
     act(() => { tree.root.findByProps({ testID: 'thinking-toggle' }).props.onPress(); });
     const content = tree.root.findByProps({ testID: 'thinking-content' });
-    expect(content.props.children).toBe('weighing the trade-offs');
+    const text = (Array.isArray(content.props.children) ? content.props.children : [content.props.children]).join('');
+    expect(text).toBe('weighing the trade-offs');
   });
 
   it('labels "Thinking…" while thinkingStreaming is true', () => {
@@ -85,5 +86,32 @@ describe('MessageBubble thinking content (#6756)', () => {
     expect(tree.root.findAllByProps({ testID: 'thinking-bubble' })).toHaveLength(0);
     // …instead the generic (stubbed) thinking indicator.
     expect(tree.root.findAllByProps({ testID: 'thinking-indicator-stub' }).length).toBeGreaterThan(0);
+  });
+
+  it('appends a "[thinking truncated]" marker when the content hit the size cap (#6756 review)', () => {
+    const tree = render(makeThinking({ thinkingStreaming: false, thinkingTruncated: true }));
+    act(() => { tree.root.findByProps({ testID: 'thinking-toggle' }).props.onPress(); });
+    const content = tree.root.findByProps({ testID: 'thinking-content' });
+    const text = (Array.isArray(content.props.children) ? content.props.children : [content.props.children]).join('');
+    expect(text).toContain('weighing the trade-offs');
+    expect(text).toContain('[thinking truncated]');
+  });
+
+  it('omits the truncation marker when the flag is absent (#6756 review)', () => {
+    const tree = render(makeThinking({ thinkingStreaming: false }));
+    act(() => { tree.root.findByProps({ testID: 'thinking-toggle' }).props.onPress(); });
+    const content = tree.root.findByProps({ testID: 'thinking-content' });
+    const text = (Array.isArray(content.props.children) ? content.props.children : [content.props.children]).join('');
+    expect(text).not.toContain('[thinking truncated]');
+  });
+
+  it('exposes a ≥44pt effective touch target on the toggle, both axes (#6756 review)', () => {
+    // Same convention as DiffHunkView's ≥44pt toggle test / the MarkdownRenderer
+    // copy-button test: min dimensions carried by the style, both axes asserted.
+    const tree = render(makeThinking({ thinkingStreaming: false }));
+    const toggle = tree.root.findByProps({ testID: 'thinking-toggle' });
+    const style = StyleSheet.flatten(toggle.props.style) as { minHeight?: number; minWidth?: number };
+    expect(style.minHeight).toBeGreaterThanOrEqual(44);
+    expect(style.minWidth).toBeGreaterThanOrEqual(44);
   });
 });

--- a/packages/app/src/components/__tests__/MessageBubble.thinking.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.thinking.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * #6756 — mobile content-capable thinking view.
+ *
+ * A `type: 'thinking'` bubble that carries real reasoning content renders the
+ * expandable ThinkingBubble disclosure (parity with the dashboard's
+ * ThinkingBody); an empty thinking bubble (the ephemeral placeholder) keeps the
+ * generic ThinkingIndicator animation.
+ */
+import React from 'react';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+// The real ThinkingIndicator drives a native-driver Animated loop that crashes
+// react-test-renderer (findNodeHandle is undefined off-device). Stub it so the
+// empty-content fallback branch is still assertable without the animation.
+jest.mock('../chat/ThinkingIndicator', () => ({
+  ThinkingIndicator: () => {
+    const { Text: RNText } = require('react-native');
+    return <RNText testID="thinking-indicator-stub">indicator</RNText>;
+  },
+}));
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+beforeEach(() => {
+  useConnectionLifecycleStore.setState({ connectionPhase: 'connected' });
+});
+
+function makeThinking(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1-thinking-0',
+    type: 'thinking',
+    content: 'weighing the trade-offs',
+    timestamp: Date.now(),
+    ...overrides,
+  } as ChatMessage;
+}
+
+function render(message: ChatMessage) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onSelectOption={jest.fn()}
+      />,
+    );
+  });
+  return tree;
+}
+
+/** Concatenated text of the toggle line (e.g. "▸ Thought"). */
+function toggleLabel(tree: renderer.ReactTestRenderer): string {
+  const toggle = tree.root.findByProps({ testID: 'thinking-toggle' });
+  const label = toggle.findByType(Text).props.children;
+  return (Array.isArray(label) ? label : [label]).join('');
+}
+
+describe('MessageBubble thinking content (#6756)', () => {
+  it('renders an expandable disclosure with the reasoning content', () => {
+    const tree = render(makeThinking({ thinkingStreaming: false }));
+    // Label reads "Thought" once streaming has ended.
+    expect(toggleLabel(tree)).toContain('Thought');
+    // Collapsed by default — no content node yet.
+    expect(tree.root.findAllByProps({ testID: 'thinking-content' })).toHaveLength(0);
+    // Expand.
+    act(() => { tree.root.findByProps({ testID: 'thinking-toggle' }).props.onPress(); });
+    const content = tree.root.findByProps({ testID: 'thinking-content' });
+    expect(content.props.children).toBe('weighing the trade-offs');
+  });
+
+  it('labels "Thinking…" while thinkingStreaming is true', () => {
+    const tree = render(makeThinking({ thinkingStreaming: true }));
+    expect(toggleLabel(tree)).toContain('Thinking…');
+  });
+
+  it('falls back to the ThinkingIndicator animation when there is no content', () => {
+    const tree = render(makeThinking({ content: '' }));
+    // No disclosure bubble…
+    expect(tree.root.findAllByProps({ testID: 'thinking-bubble' })).toHaveLength(0);
+    // …instead the generic (stubbed) thinking indicator.
+    expect(tree.root.findAllByProps({ testID: 'thinking-indicator-stub' }).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -82,7 +82,7 @@ export function buildPromptSessionLabel(
  * thinking bubble (the ephemeral placeholder) keeps the `ThinkingIndicator`
  * animation.
  */
-function ThinkingBubble({ content, streaming }: { content: string; streaming: boolean }) {
+function ThinkingBubble({ content, streaming, truncated }: { content: string; streaming: boolean; truncated?: boolean }) {
   const [expanded, setExpanded] = useState(false);
   return (
     <View style={styles.thinkingBubble} testID="thinking-bubble">
@@ -94,6 +94,11 @@ function ThinkingBubble({ content, streaming }: { content: string; streaming: bo
         testID="thinking-toggle"
         accessibilityRole="button"
         accessibilityLabel={streaming ? 'Thinking' : 'Thought'}
+        // Small horizontal hitSlop for comfort past the text's visual bounds;
+        // the ≥44pt minimum on both axes is carried by the style's
+        // minHeight/minWidth (see thinkingToggleTouchable).
+        hitSlop={{ top: 0, right: 8, bottom: 0, left: 8 }}
+        style={styles.thinkingToggleTouchable}
       >
         <Text style={styles.thinkingToggle}>
           {expanded ? '▾' : '▸'} {streaming ? 'Thinking…' : 'Thought'}
@@ -102,6 +107,9 @@ function ThinkingBubble({ content, streaming }: { content: string; streaming: bo
       {expanded && (
         <Text style={styles.thinkingContent} testID="thinking-content" selectable>
           {content}
+          {/* #6756 — the store bounded this bubble at MAX_THINKING_CONTENT_LEN
+              and dropped further deltas; say so instead of cutting silently. */}
+          {truncated ? '\n… [thinking truncated]' : ''}
         </Text>
       )}
     </View>
@@ -369,7 +377,11 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
     const thinkingContent = typeof message.content === 'string' ? message.content : '';
     if (thinkingContent.trim().length > 0) {
       return (
-        <ThinkingBubble content={thinkingContent} streaming={message.thinkingStreaming === true} />
+        <ThinkingBubble
+          content={thinkingContent}
+          streaming={message.thinkingStreaming === true}
+          truncated={message.thinkingTruncated === true}
+        />
       );
     }
     return <ThinkingIndicator />;
@@ -836,6 +848,17 @@ const styles = StyleSheet.create({
   thinkingBubble: {
     marginBottom: 12,
     maxWidth: '90%',
+  },
+  // ≥44pt effective touch target on BOTH axes (repo accessibility minimum —
+  // same convention as DiffHunkView's toggle row): the 13pt text line alone is
+  // far short of 44pt, so the touchable carries explicit min dimensions and
+  // centers the label vertically. alignSelf keeps the target hugging the label
+  // instead of stretching the full row width.
+  thinkingToggleTouchable: {
+    minHeight: 44,
+    minWidth: 44,
+    justifyContent: 'center',
+    alignSelf: 'flex-start',
   },
   thinkingToggle: {
     color: COLORS.textMuted,

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -74,6 +74,40 @@ export function buildPromptSessionLabel(
   return provider ? `${name} · ${provider}` : name;
 }
 
+/**
+ * #6756 — content-capable thinking view. The mobile parity of the dashboard's
+ * `ThinkingBody`: a quiet collapsible disclosure ("▸ Thinking…" while streaming,
+ * "▸ Thought" once done) that reveals the model's reasoning text on tap. Used
+ * only when a thinking bubble actually carries reasoning content; an empty
+ * thinking bubble (the ephemeral placeholder) keeps the `ThinkingIndicator`
+ * animation.
+ */
+function ThinkingBubble({ content, streaming }: { content: string; streaming: boolean }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <View style={styles.thinkingBubble} testID="thinking-bubble">
+      <TouchableOpacity
+        onPress={() => {
+          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+          setExpanded((v) => !v);
+        }}
+        testID="thinking-toggle"
+        accessibilityRole="button"
+        accessibilityLabel={streaming ? 'Thinking' : 'Thought'}
+      >
+        <Text style={styles.thinkingToggle}>
+          {expanded ? '▾' : '▸'} {streaming ? 'Thinking…' : 'Thought'}
+        </Text>
+      </TouchableOpacity>
+      {expanded && (
+        <Text style={styles.thinkingContent} testID="thinking-content" selectable>
+          {content}
+        </Text>
+      )}
+    </View>
+  );
+}
+
 function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, allowSingleMultiSelect, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
   /**
@@ -329,6 +363,15 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
   };
 
   if (isThinking) {
+    // #6756 — render the model's reasoning content as an expandable disclosure
+    // when present; fall back to the generic animation for the contentless
+    // placeholder (or a thinking block that hasn't streamed any text yet).
+    const thinkingContent = typeof message.content === 'string' ? message.content : '';
+    if (thinkingContent.trim().length > 0) {
+      return (
+        <ThinkingBubble content={thinkingContent} streaming={message.thinkingStreaming === true} />
+      );
+    }
     return <ThinkingIndicator />;
   }
 
@@ -786,6 +829,24 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     marginBottom: 12,
     maxWidth: '85%',
+  },
+  // #6756 — content-capable thinking disclosure (mobile parity with the
+  // dashboard's ThinkingBody). Deliberately low-noise: a muted toggle line and,
+  // when expanded, the reasoning text. No card chrome.
+  thinkingBubble: {
+    marginBottom: 12,
+    maxWidth: '90%',
+  },
+  thinkingToggle: {
+    color: COLORS.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  thinkingContent: {
+    marginTop: 6,
+    color: COLORS.textSecondary,
+    fontSize: 13,
+    lineHeight: 19,
   },
   // Chat redesign #6391 (mobile no-bubble): bare assistant response — no card,
   // flush, so a long turn reads like a document. User/prompt/tool keep cards.

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -44,6 +44,7 @@ import {
   handleThinkingStreamStart as sharedThinkingStart,
   handleThinkingDelta as sharedThinkingDelta,
   handleThinkingStreamEnd as sharedThinkingEnd,
+  finalizeThinkingStreams,
   handleAuthOk as sharedAuthOk,
   parseConnectedClients as sharedParseConnectedClients,
   handleAuthFail as sharedAuthFail,
@@ -2747,12 +2748,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (targetId && get().sessionStates[targetId]) {
           // Force a new messages array reference so selectors detect the change,
           // even when flushPendingDeltas() was a no-op (timer already flushed).
+          // #6756 — turn-boundary backstop: finalise any thinking bubble whose
+          // own thinking stream_end was dropped so it can't be stuck on
+          // "Thinking…".
           updateSession(targetId, (ss) => ({
             streamingMessageId: null,
-            messages: [...ss.messages],
+            messages: finalizeThinkingStreams([...ss.messages]),
           }));
         } else {
-          updateActiveSession((ss) => ({ streamingMessageId: null, messages: [...ss.messages] }));
+          updateActiveSession((ss) => ({
+            streamingMessageId: null,
+            messages: finalizeThinkingStreams([...ss.messages]),
+          }));
         }
       }
       break;
@@ -2887,7 +2894,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
                 : currentQueue;
             return {
               ...resultPatch,
-              messages: [...ss.messages],
+              // #6756 — `result` is the guaranteed turn boundary; finalise any
+              // thinking bubble whose own stream_end was dropped.
+              messages: finalizeThinkingStreams([...ss.messages]),
               ...(reconciledQueue !== currentQueue ? { queuedMessages: reconciledQueue } : {}),
             };
           });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -40,6 +40,10 @@ import {
   handleStreamStart as sharedStreamStart,
   sharedStreamDelta,
   handleStreamEnd as sharedStreamEnd,
+  // #6756 — extended-thinking (reasoning) content stream.
+  handleThinkingStreamStart as sharedThinkingStart,
+  handleThinkingDelta as sharedThinkingDelta,
+  handleThinkingStreamEnd as sharedThinkingEnd,
   handleAuthOk as sharedAuthOk,
   parseConnectedClients as sharedParseConnectedClients,
   handleAuthFail as sharedAuthFail,
@@ -2563,6 +2567,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_start': {
+      // #6756 — a thinking stream_start opens a reasoning bubble on a distinct
+      // id. Route to the thinking handler (does NOT touch streamingMessageId —
+      // the 'pending' sentinel / response stream own the turn's busy state).
+      if (msg.thinking === true) {
+        const thinkingTargetId = (msg.sessionId as string) || get().activeSessionId;
+        if (thinkingTargetId && get().sessionStates[thinkingTargetId]) {
+          updateSession(thinkingTargetId, (ss) => {
+            const out = sharedThinkingStart(msg, get().activeSessionId, ss.messages);
+            if (!out.isNewMessage || !out.newMessage) return {};
+            return { messages: [...filterThinking(ss.messages), out.newMessage] };
+          });
+        }
+        break;
+      }
       const targetId = (msg.sessionId as string) || get().activeSessionId;
       if (targetId && get().sessionStates[targetId]) {
         updateSession(targetId, (ss) => {
@@ -2603,6 +2621,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_delta': {
+      // #6756 — a thinking stream_delta accumulates reasoning content onto the
+      // thinking bubble (lazy-created if its stream_start was missed).
+      if (msg.thinking === true) {
+        const payload = sharedThinkingDelta(msg, get().activeSessionId);
+        if (payload) {
+          const thinkingTargetId = payload.sessionId;
+          if (thinkingTargetId && get().sessionStates[thinkingTargetId]) {
+            updateSession(thinkingTargetId, (ss) => {
+              const next = payload.applyTo(ss.messages);
+              return next === ss.messages ? {} : { messages: next };
+            });
+          }
+        }
+        break;
+      }
       // #5515 (epic #5514): record the server-stamped serverTs and the local
       // recv time of the OLDEST un-rendered delta for this messageId, so
       // flushPendingDeltas can measure token-to-render. First-write-wins until
@@ -2687,6 +2720,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_end':
+      // #6756 — a thinking stream_end finalises the reasoning bubble's label
+      // ("Thinking…" → "Thought") without touching the response stream state.
+      if (msg.thinking === true) {
+        const payload = sharedThinkingEnd(msg, get().activeSessionId);
+        const thinkingTargetId = payload.sessionId;
+        if (thinkingTargetId && get().sessionStates[thinkingTargetId]) {
+          updateSession(thinkingTargetId, (ss) => {
+            const next = payload.applyTo(ss.messages);
+            return next === ss.messages ? {} : { messages: next };
+          });
+        }
+        break;
+      }
       // Flush any buffered deltas immediately before clearing streaming state
       _ctx.deltaFlusher.flushNow();
       {

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -184,6 +184,25 @@ describe('ChatView', () => {
     expect(screen.getByTestId('thinking-toggle')).toHaveTextContent('Thought')
   })
 
+  it('surfaces a "[thinking truncated]" marker when the content hit the size cap (#6756)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'msg-1-thinking-0', type: 'thinking', content: 'capped reasoning', thinkingStreaming: false, thinkingTruncated: true, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    fireEvent.click(screen.getByTestId('thinking-toggle'))
+    expect(screen.getByTestId('thinking-truncated')).toHaveTextContent('[thinking truncated]')
+    // …and no marker without the flag.
+    cleanup()
+    render(
+      <ChatView
+        messages={[{ id: 't2', type: 'thinking', content: 'full reasoning', thinkingStreaming: false, timestamp: Date.now() }]}
+        isStreaming={false}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('thinking-toggle'))
+    expect(screen.queryByTestId('thinking-truncated')).not.toBeInTheDocument()
+  })
+
   it('renders empty state when no messages', () => {
     render(<ChatView messages={[]} isStreaming={false} />)
     expect(screen.getByTestId('chat-view')).toBeInTheDocument()

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -162,6 +162,28 @@ describe('ChatView', () => {
     expect(screen.getByText('deep-secret-reasoning')).toBeInTheDocument()
   })
 
+  // #6756 — real streamed reasoning content feeds ThinkingBody, with the
+  // "Thinking…" vs "Thought" label driven by the `thinkingStreaming` flag
+  // (distinct from the response `isStreaming`).
+  it('labels ThinkingBody "Thinking…" while thinkingStreaming and reveals real content (#6756)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'msg-1-thinking-0', type: 'thinking', content: 'weighing the options', thinkingStreaming: true, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    const toggle = screen.getByTestId('thinking-toggle')
+    expect(toggle).toHaveTextContent('Thinking…')
+    fireEvent.click(toggle)
+    expect(screen.getByText('weighing the options')).toBeInTheDocument()
+  })
+
+  it('flips ThinkingBody to "Thought" once thinkingStreaming is false (#6756)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 'msg-1-thinking-0', type: 'thinking', content: 'settled reasoning', thinkingStreaming: false, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    expect(screen.getByTestId('thinking-toggle')).toHaveTextContent('Thought')
+  })
+
   it('renders empty state when no messages', () => {
     render(<ChatView messages={[]} isStreaming={false} />)
     expect(screen.getByTestId('chat-view')).toBeInTheDocument()

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -111,6 +111,12 @@ export interface ChatViewMessage {
   timestamp: number
   isStreaming?: boolean
   /**
+   * #6756: on a `thinking` row, whether reasoning content is still streaming
+   * (drives ThinkingBody's "Thinking…" vs "Thought" label). Mirrored from the
+   * store ChatMessage; distinct from `isStreaming` (the response text stream).
+   */
+  thinkingStreaming?: boolean
+  /**
    * #4476: structured error code mirrored from the store ChatMessage.
    * Renderers may switch on this to surface a distinct variant for known
    * error categories (e.g. `'stream_stall'` → chip + retry). Undefined
@@ -327,6 +333,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   content,
   timestamp,
   isStreaming,
+  thinkingStreaming,
   attachments,
   queued,
   onCancelQueued,
@@ -337,6 +344,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   content: string
   timestamp: number
   isStreaming?: boolean
+  /** #6756: on a `thinking` row, whether reasoning content is still streaming
+   *  (drives the ThinkingBody "Thinking…" vs "Thought" label). */
+  thinkingStreaming?: boolean
   /** #6632: user-message attachments (images/documents) to preview. */
   attachments?: ChatViewMessage['attachments']
   /** #5939: this user_input is held in the server's outgoing queue. */
@@ -367,7 +377,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
       // #6793: same container also owns the per-code-block copy button click.
       ? <div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
       : type === 'thinking'
-        ? <ThinkingBody content={content} streaming={!!isStreaming} />
+        ? <ThinkingBody content={content} streaming={!!thinkingStreaming} />
         : content
 
   return (
@@ -970,6 +980,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   content={msg.content}
                   timestamp={msg.timestamp}
                   isStreaming={msg.isStreaming}
+                  thinkingStreaming={msg.thinkingStreaming}
                   attachments={msg.attachments}
                   queued={queuedIds?.has(msg.id) ?? false}
                   queuePosition={queuePositions?.get(msg.id)}

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -117,6 +117,12 @@ export interface ChatViewMessage {
    */
   thinkingStreaming?: boolean
   /**
+   * #6756: on a `thinking` row, the accumulated reasoning hit the size cap and
+   * further deltas were dropped — ThinkingBody appends a "[thinking truncated]"
+   * marker so the cut is never silent.
+   */
+  thinkingTruncated?: boolean
+  /**
    * #4476: structured error code mirrored from the store ChatMessage.
    * Renderers may switch on this to surface a distinct variant for known
    * error categories (e.g. `'stream_stall'` → chip + retry). Undefined
@@ -306,7 +312,7 @@ function rowClassFor(type: string, hasIcon: boolean): string {
  * start/end the client doesn't carry yet.) The row's MeasuredRow ResizeObserver
  * re-measures on toggle, so the virtualized list stays correct.
  */
-function ThinkingBody({ content, streaming }: { content: string; streaming: boolean }) {
+function ThinkingBody({ content, streaming, truncated }: { content: string; streaming: boolean; truncated?: boolean }) {
   const [expanded, setExpanded] = useState(false)
   return (
     <div className="thinking-body">
@@ -322,7 +328,18 @@ function ThinkingBody({ content, streaming }: { content: string; streaming: bool
       >
         {expanded ? '▾' : '▸'} {streaming ? 'Thinking…' : 'Thought'}
       </button>
-      {expanded && <div className="thinking-full">{content}</div>}
+      {expanded && (
+        <div className="thinking-full">
+          {content}
+          {/* #6756 — the store bounded this bubble at MAX_THINKING_CONTENT_LEN
+              and dropped further deltas; say so instead of cutting silently. */}
+          {truncated && (
+            <div className="thinking-truncated" data-testid="thinking-truncated">
+              … [thinking truncated]
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }
@@ -334,6 +351,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   timestamp,
   isStreaming,
   thinkingStreaming,
+  thinkingTruncated,
   attachments,
   queued,
   onCancelQueued,
@@ -347,6 +365,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   /** #6756: on a `thinking` row, whether reasoning content is still streaming
    *  (drives the ThinkingBody "Thinking…" vs "Thought" label). */
   thinkingStreaming?: boolean
+  /** #6756: on a `thinking` row, the reasoning content hit the size cap —
+   *  ThinkingBody appends a "[thinking truncated]" marker. */
+  thinkingTruncated?: boolean
   /** #6632: user-message attachments (images/documents) to preview. */
   attachments?: ChatViewMessage['attachments']
   /** #5939: this user_input is held in the server's outgoing queue. */
@@ -377,7 +398,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
       // #6793: same container also owns the per-code-block copy button click.
       ? <div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
       : type === 'thinking'
-        ? <ThinkingBody content={content} streaming={!!thinkingStreaming} />
+        ? <ThinkingBody content={content} streaming={!!thinkingStreaming} truncated={thinkingTruncated} />
         : content
 
   return (
@@ -981,6 +1002,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   timestamp={msg.timestamp}
                   isStreaming={msg.isStreaming}
                   thinkingStreaming={msg.thinkingStreaming}
+                  thinkingTruncated={msg.thinkingTruncated}
                   attachments={msg.attachments}
                   queued={queuedIds?.has(msg.id) ?? false}
                   queuePosition={queuePositions?.get(msg.id)}

--- a/packages/dashboard/src/hooks/useChatMessages.test.ts
+++ b/packages/dashboard/src/hooks/useChatMessages.test.ts
@@ -71,11 +71,11 @@ describe('useChatMessages', () => {
     expect(result.current.chatToolGroupPayloads.size).toBe(0)
   })
 
-  it('collapses a run of 2+ tool_use/thinking into a single tool_group row', () => {
+  it('collapses a run of 2+ tool_use into a tool_group; thinking stays standalone (#6756)', () => {
     const messages = [
       msg({ id: 'u1', type: 'user_input', content: 'do many things' }),
-      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
       msg({ id: 'th1', type: 'thinking', content: 'planning' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
       msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
       msg({ id: 'r1', type: 'response', content: 'done' }),
     ]
@@ -83,7 +83,9 @@ describe('useChatMessages', () => {
       useChatMessages({ storeMessages: messages, streamingMessageId: null }),
     )
     const types = result.current.chatMessages.map(m => m.type)
-    expect(types).toEqual(['user_input', 'tool_group', 'response'])
+    // #6756 — the thinking bubble renders as its own row (reaching ThinkingBody),
+    // and only the two contiguous tool_use bubbles collapse into a tool_group.
+    expect(types).toEqual(['user_input', 'thinking', 'tool_group', 'response'])
 
     // The group id is the synthetic key `activity-<firstId>`.
     const groupRow = result.current.chatMessages.find(m => m.type === 'tool_group')!
@@ -92,7 +94,7 @@ describe('useChatMessages', () => {
     // Payload map must contain the same key.
     const payload = result.current.chatToolGroupPayloads.get('activity-t1')
     expect(payload).toBeDefined()
-    expect(payload!.messages.map(m => m.id)).toEqual(['t1', 'th1', 't2'])
+    expect(payload!.messages.map(m => m.id)).toEqual(['t1', 't2'])
     expect(payload!.isActive).toBe(false)
   })
 

--- a/packages/dashboard/src/hooks/useChatMessages.ts
+++ b/packages/dashboard/src/hooks/useChatMessages.ts
@@ -11,8 +11,9 @@
  *     -> filter(m => m.type !== 'system')   // System events render on the
  *                                           //   System tab, not in chat.
  *     -> groupMessages                      // (#3747) collapse contiguous
- *                                           //   tool_use / thinking runs
- *                                           //   into ActivityGroups.
+ *                                           //   tool_use runs into
+ *                                           //   ActivityGroups (#6756:
+ *                                           //   thinking stays standalone).
  *     -> applyStreamingOverlay              // mark trailing activity group
  *                                           //   as active during streaming.
  *     -> ChatViewMessage[]                  // flatten to chat-view rows.

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -35,6 +35,7 @@ import {
   handleThinkingStreamStart as sharedThinkingStart,
   handleThinkingDelta as sharedThinkingDelta,
   handleThinkingStreamEnd as sharedThinkingEnd,
+  finalizeThinkingStreams,
   handleAuthOk as sharedAuthOk,
   parseConnectedClients as sharedParseConnectedClients,
   handleAuthFail as sharedAuthFail,
@@ -2079,12 +2080,14 @@ function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet,
   if (targetId && get().sessionStates[targetId]) {
     // Force a new messages array reference so selectors detect the change,
     // even when flushPendingDeltas() was a no-op (timer already flushed).
+    // #6756 — turn-boundary backstop: finalise any thinking bubble whose own
+    // thinking stream_end was dropped so it can't be stuck on "Thinking…".
     updateSession(targetId, (ss) => ({
       streamingMessageId: null,
-      messages: [...ss.messages],
+      messages: finalizeThinkingStreams([...ss.messages]),
     }));
   } else {
-    set((s) => ({ streamingMessageId: null, messages: [...s.messages] }));
+    set((s) => ({ streamingMessageId: null, messages: finalizeThinkingStreams([...s.messages]) }));
   }
 }
 
@@ -4632,7 +4635,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
               : currentQueue;
           const patch: Partial<SessionState> = {
             ...resultPatch,
-            messages: [...ss.messages],
+            // #6756 — `result` is the guaranteed turn boundary; finalise any
+            // thinking bubble whose own stream_end was dropped (mirrors the
+            // activeTools orphan sweep below).
+            messages: finalizeThinkingStreams([...ss.messages]),
             ...(reconciledQueue !== currentQueue ? { queuedMessages: reconciledQueue } : {}),
           };
           // #4493 — gate per target session id. A live `result` for
@@ -4641,7 +4647,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           return patch;
         });
       } else {
-        set((s) => ({ ...resultPatch, messages: [...s.messages] }));
+        set((s) => ({ ...resultPatch, messages: finalizeThinkingStreams([...s.messages]) }));
       }
       break;
     }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -31,6 +31,10 @@ import {
   handleStreamStart as sharedStreamStart,
   sharedStreamDelta,
   handleStreamEnd as sharedStreamEnd,
+  // #6756 — extended-thinking (reasoning) content stream.
+  handleThinkingStreamStart as sharedThinkingStart,
+  handleThinkingDelta as sharedThinkingDelta,
+  handleThinkingStreamEnd as sharedThinkingEnd,
   handleAuthOk as sharedAuthOk,
   parseConnectedClients as sharedParseConnectedClients,
   handleAuthFail as sharedAuthFail,
@@ -1843,6 +1847,21 @@ function handleClaudeReady(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 // agent_busy migrated to the shared store-core dispatch table (#5556)
 
 function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  // #6756 — a thinking stream_start opens a reasoning bubble on a distinct id.
+  // Route to the thinking handler BEFORE the response-stream machinery (it does
+  // NOT touch streamingMessageId — the turn's busy state stays owned by the
+  // 'pending' sentinel / response stream).
+  if (msg.thinking === true) {
+    const thinkingTargetId = (msg.sessionId as string) || get().activeSessionId;
+    if (thinkingTargetId && get().sessionStates[thinkingTargetId]) {
+      updateSession(thinkingTargetId, (ss) => {
+        const out = sharedThinkingStart(msg, get().activeSessionId, ss.messages);
+        if (!out.isNewMessage || !out.newMessage) return {};
+        return { messages: [...filterThinking(ss.messages), out.newMessage] };
+      });
+    }
+    return;
+  }
   const targetId = (msg.sessionId as string) || get().activeSessionId;
   if (targetId && get().sessionStates[targetId]) {
     updateSession(targetId, (ss) => {
@@ -1881,6 +1900,21 @@ function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 }
 
 function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  // #6756 — a thinking stream_delta accumulates reasoning content onto the
+  // thinking bubble (lazy-created if its stream_start was missed). Handled
+  // separately from the response-stream coalescing hot path.
+  if (msg.thinking === true) {
+    const payload = sharedThinkingDelta(msg, get().activeSessionId);
+    if (!payload) return;
+    const thinkingTargetId = payload.sessionId;
+    if (thinkingTargetId && get().sessionStates[thinkingTargetId]) {
+      updateSession(thinkingTargetId, (ss) => {
+        const next = payload.applyTo(ss.messages);
+        return next === ss.messages ? {} : { messages: next };
+      });
+    }
+    return;
+  }
   // #5515 (epic #5514): record the server-stamped serverTs and local recv time
   // of the OLDEST un-rendered delta for this messageId so flushPendingDeltas
   // can measure token-to-render. First-write-wins until the next flush clears
@@ -2016,6 +2050,20 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 }
 
 function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  // #6756 — a thinking stream_end finalises the reasoning bubble's label
+  // ("Thinking…" → "Thought") without touching the response stream state
+  // (no delta flush, no streamingMessageId clear).
+  if (msg.thinking === true) {
+    const payload = sharedThinkingEnd(msg, get().activeSessionId);
+    const thinkingTargetId = payload.sessionId;
+    if (thinkingTargetId && get().sessionStates[thinkingTargetId]) {
+      updateSession(thinkingTargetId, (ss) => {
+        const next = payload.applyTo(ss.messages);
+        return next === ss.messages ? {} : { messages: next };
+      });
+    }
+    return;
+  }
   // Flush any buffered deltas immediately before clearing streaming state
   deltaFlusher.flushNow();
   // Add newline separator after response ends for Output view readability

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -10,17 +10,20 @@ export declare const ServerStreamStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_start">;
     messageId: z.ZodString;
     serverTs: z.ZodOptional<z.ZodNumber>;
+    thinking: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const ServerStreamDeltaSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_delta">;
     messageId: z.ZodString;
     delta: z.ZodString;
     serverTs: z.ZodOptional<z.ZodNumber>;
+    thinking: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const ServerStreamEndSchema: z.ZodObject<{
     type: z.ZodLiteral<"stream_end">;
     messageId: z.ZodString;
     serverTs: z.ZodOptional<z.ZodNumber>;
+    thinking: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$strip>;
 export declare const ServerMessageSchema: z.ZodObject<{
     type: z.ZodLiteral<"message">;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -14,21 +14,34 @@ import { MAX_SANE_DURATION_MS } from "./connection.js";
 // one-way numbers from the RTT-split method instead (see app/dashboard
 // latency-stats). Always optional so older servers/clients interop unchanged.
 const ServerTsSchema = z.number().int().nonnegative().finite().optional();
+// #6756: an optional flag marking a stream_start/delta/end as carrying the
+// model's extended-thinking (reasoning) content rather than the visible
+// response text. Providers that surface thinking (claude SDK, BYOK) emit these
+// with a DISTINCT `messageId` (e.g. `<turnId>-thinking-<n>`) so a thinking
+// stream never collides with the response stream, and clients route them to a
+// `type: 'thinking'` chat bubble instead of the response slot. Always optional
+// so older servers/clients interop unchanged (absent === not thinking). Because
+// the id is distinct from the ephemeral placeholder id `'thinking'`, the
+// client's `filterThinking` still only strips the placeholder.
+const ThinkingFlagSchema = z.boolean().optional();
 export const ServerStreamStartSchema = z.object({
     type: z.literal('stream_start'),
     messageId: z.string(),
     serverTs: ServerTsSchema,
+    thinking: ThinkingFlagSchema,
 });
 export const ServerStreamDeltaSchema = z.object({
     type: z.literal('stream_delta'),
     messageId: z.string(),
     delta: z.string(),
     serverTs: ServerTsSchema,
+    thinking: ThinkingFlagSchema,
 });
 export const ServerStreamEndSchema = z.object({
     type: z.literal('stream_end'),
     messageId: z.string(),
     serverTs: ServerTsSchema,
+    thinking: ThinkingFlagSchema,
 });
 export const ServerMessageSchema = z.object({
     type: z.literal('message'),

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -19,10 +19,22 @@ import type { ServerPermissionRequestMessage } from './messages.ts'
 // latency-stats). Always optional so older servers/clients interop unchanged.
 const ServerTsSchema = z.number().int().nonnegative().finite().optional()
 
+// #6756: an optional flag marking a stream_start/delta/end as carrying the
+// model's extended-thinking (reasoning) content rather than the visible
+// response text. Providers that surface thinking (claude SDK, BYOK) emit these
+// with a DISTINCT `messageId` (e.g. `<turnId>-thinking-<n>`) so a thinking
+// stream never collides with the response stream, and clients route them to a
+// `type: 'thinking'` chat bubble instead of the response slot. Always optional
+// so older servers/clients interop unchanged (absent === not thinking). Because
+// the id is distinct from the ephemeral placeholder id `'thinking'`, the
+// client's `filterThinking` still only strips the placeholder.
+const ThinkingFlagSchema = z.boolean().optional()
+
 export const ServerStreamStartSchema = z.object({
   type: z.literal('stream_start'),
   messageId: z.string(),
   serverTs: ServerTsSchema,
+  thinking: ThinkingFlagSchema,
 })
 
 export const ServerStreamDeltaSchema = z.object({
@@ -30,12 +42,14 @@ export const ServerStreamDeltaSchema = z.object({
   messageId: z.string(),
   delta: z.string(),
   serverTs: ServerTsSchema,
+  thinking: ThinkingFlagSchema,
 })
 
 export const ServerStreamEndSchema = z.object({
   type: z.literal('stream_end'),
   messageId: z.string(),
   serverTs: ServerTsSchema,
+  thinking: ThinkingFlagSchema,
 })
 
 export const ServerMessageSchema = z.object({

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -284,6 +284,13 @@ export class ClaudeByokSession extends BaseSession {
     // here.
     this._streamingIndexToToolUseId = new Map()
 
+    // #6756: per-stream index → thinking messageId, mirroring the toolUseId map
+    // above. The translated `thinking_delta` events carry only the block index;
+    // this maps each thinking block's index to the distinct thinking id we open
+    // on its first delta so subsequent deltas + the content_block_stop route
+    // correctly. Cleared alongside `_streamingIndexToToolUseId`.
+    this._streamingIndexToThinkingId = new Map()
+
     // #4080: toolUseIds whose permission_request is currently pending.
     // Populated when this session re-emits permission_request (line
     // ~165), drained on permission_resolved (line ~167). Consulted on
@@ -594,6 +601,22 @@ export class ClaudeByokSession extends BaseSession {
             case 'stream_delta':
               this.emit('stream_delta', { messageId, delta: t.text })
               break
+            case 'thinking_delta': {
+              // #6756 — extended-thinking (reasoning) delta. The translator
+              // already recognises `thinking_delta` (byok-event-translator.js);
+              // previously it hit `default: break` and was dropped. Route it to
+              // a distinct thinking id (opened lazily on the block's first
+              // delta) so it streams into a `type: 'thinking'` bubble.
+              const idx = typeof t.index === 'number' ? t.index : 0
+              let thinkingId = this._streamingIndexToThinkingId.get(idx)
+              if (!thinkingId) {
+                thinkingId = `${messageId}-thinking-${idx}`
+                this._streamingIndexToThinkingId.set(idx, thinkingId)
+                this.emit('stream_start', { messageId: thinkingId, thinking: true })
+              }
+              this.emit('stream_delta', { messageId: thinkingId, delta: t.text, thinking: true })
+              break
+            }
             case 'tool_start': {
               // Surface the tool_use opening to the dashboard so it can
               // render a tool-call bubble. Matches sdk-session.js /
@@ -674,10 +697,17 @@ export class ClaudeByokSession extends BaseSession {
               // #4080: free the per-index slot as soon as the block
               // finishes so a long turn's map doesn't grow unbounded.
               // Safe to delete even if index isn't in the map — that
-              // just means we never tracked this block (text /
-              // thinking) and the lookup is a no-op.
+              // just means we never tracked this block (text) and the
+              // lookup is a no-op.
               if (typeof t.index === 'number') {
                 this._streamingIndexToToolUseId.delete(t.index)
+                // #6756 — close the thinking stream for this block so the
+                // client finalises its "Thinking… → Thought" label.
+                const thinkingId = this._streamingIndexToThinkingId.get(t.index)
+                if (thinkingId) {
+                  this._streamingIndexToThinkingId.delete(t.index)
+                  this.emit('stream_end', { messageId: thinkingId, thinking: true })
+                }
               }
               break
             case 'message_delta':
@@ -704,6 +734,7 @@ export class ClaudeByokSession extends BaseSession {
         // toolUseId from the previous round. Clear here so each round
         // starts with an empty per-stream map.
         this._streamingIndexToToolUseId.clear()
+        this._streamingIndexToThinkingId.clear()
         lastStopReason = final.stop_reason
         const roundUsage = final.usage || {}
         turnUsage.input_tokens += Number(roundUsage.input_tokens) || 0
@@ -965,6 +996,7 @@ export class ClaudeByokSession extends BaseSession {
       // them on every exit path — success, error, abort, hard timeout.
       // Safe to call when already empty.
       this._streamingIndexToToolUseId.clear()
+      this._streamingIndexToThinkingId.clear()
       this._finishTurn()
     }
   }
@@ -1997,6 +2029,7 @@ export class ClaudeByokSession extends BaseSession {
     // active stream / outstanding permission count, but any external
     // reference (test capture, future export) would keep them alive.
     this._streamingIndexToToolUseId.clear()
+    this._streamingIndexToThinkingId.clear()
     this._pendingPermissionToolUseIds.clear()
     // #5056: drop any outstanding subagent permission-routing pointers so
     // the destroyed parent doesn't retain references to its children.

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -140,6 +140,16 @@ Object.assign(EVENT_MAP, {
   },
 
   stream_start: (data, ctx) => {
+    // #6756 — a thinking stream_start opens a reasoning bubble on a distinct id.
+    // Tag the wire message so the client routes it to a `type: 'thinking'`
+    // bubble, and skip the agent_busy / session_list churn: the turn's busy
+    // state is already owned by the response stream / the client's 'pending'
+    // sentinel, so a per-thinking-block session_list refresh would be noise.
+    if (data.thinking) {
+      return {
+        messages: [{ msg: { type: 'stream_start', messageId: data.messageId, thinking: true } }],
+      }
+    }
     const messages = [
       { msg: { type: 'stream_start', messageId: data.messageId } },
       { msg: { type: 'agent_busy' } },
@@ -154,6 +164,17 @@ Object.assign(EVENT_MAP, {
   },
 
   stream_delta: (data, _ctx) => {
+    // #6756 — thinking deltas broadcast IMMEDIATELY (no coalescing). The delta
+    // buffer keys only on sessionId:messageId and reconstructs a bare
+    // {messageId, delta} on flush, so it can't carry the `thinking` flag; and a
+    // thinking bubble uses a distinct messageId anyway, so it never shares a
+    // buffer key with the response text. Returning no `buffer` flag sends it
+    // straight through with the flag intact.
+    if (data.thinking) {
+      return {
+        messages: [{ msg: { type: 'stream_delta', messageId: data.messageId, delta: data.delta, thinking: true } }],
+      }
+    }
     // Delta buffering is handled externally — normalizer returns the raw delta
     // and the caller decides whether to buffer or flush.
     return {
@@ -163,6 +184,14 @@ Object.assign(EVENT_MAP, {
   },
 
   stream_end: (data, ctx) => {
+    // #6756 — a thinking stream_end finalises the reasoning bubble's label. No
+    // flush_deltas: thinking deltas were never buffered, and flushing here would
+    // prematurely emit the response text buffer.
+    if (data.thinking) {
+      return {
+        messages: [{ msg: { type: 'stream_end', messageId: data.messageId, thinking: true } }],
+      }
+    }
     return {
       messages: [{ msg: { type: 'stream_end', messageId: data.messageId } }],
       sideEffects: [

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -901,9 +901,16 @@ export class SdkSession extends BaseSession {
                   // #6756 — extended-thinking block opened. Open a thinking
                   // stream on a distinct id so reasoning content streams into a
                   // `type: 'thinking'` bubble (not the response slot).
-                  const thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
-                  thinkingBlocks.set(event.index, thinkingId)
-                  this.emit('stream_start', { messageId: thinkingId, thinking: true })
+                  // Copilot review on #6817: if a reordered thinking_delta for
+                  // this block index already lazily opened the stream, REUSE its
+                  // id and don't re-emit stream_start — one block must never
+                  // produce two streams.
+                  let thinkingId = thinkingBlocks.get(event.index)
+                  if (!thinkingId) {
+                    thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
+                    thinkingBlocks.set(event.index, thinkingId)
+                    this.emit('stream_start', { messageId: thinkingId, thinking: true })
+                  }
                   didStreamThinking = true
                   if (blockType === 'redacted_thinking') {
                     // Redacted thinking carries encrypted `data`, never readable

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -625,6 +625,14 @@ export class SdkSession extends BaseSession {
     // false, but the turn may have streamed before the timeout landed).
     const streamState = { hasStreamStarted: false }
     let didStreamText = false
+    // #6756 — extended-thinking forwarding. Each thinking / redacted_thinking
+    // content block gets a DISTINCT thinking messageId (`<turnId>-thinking-<n>`)
+    // so its stream never collides with the response text stream. `thinkingBlocks`
+    // maps the SDK stream event `index` → that thinking id so the thinking_delta
+    // and content_block_stop events (which carry only the index) route correctly.
+    const thinkingBlocks = new Map()
+    let thinkingBlockCount = 0
+    let didStreamThinking = false
 
     const sdkPermMode = this._sdkPermissionMode()
     // Skills MVP (#2957) — append shared skills via SDK systemPrompt.append.
@@ -889,6 +897,24 @@ export class SdkSession extends BaseSession {
                   // #4628: defense-in-depth — track so _emitResult sweep
                   // catches any orphan if the API ever drops a tool_result.
                   this._trackToolStart(toolStartData.toolUseId, event.content_block.name)
+                } else if (blockType === 'thinking' || blockType === 'redacted_thinking') {
+                  // #6756 — extended-thinking block opened. Open a thinking
+                  // stream on a distinct id so reasoning content streams into a
+                  // `type: 'thinking'` bubble (not the response slot).
+                  const thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
+                  thinkingBlocks.set(event.index, thinkingId)
+                  this.emit('stream_start', { messageId: thinkingId, thinking: true })
+                  didStreamThinking = true
+                  if (blockType === 'redacted_thinking') {
+                    // Redacted thinking carries encrypted `data`, never readable
+                    // text — forward a marker so the block is never silently
+                    // dropped (its content_block_stop still closes the stream).
+                    this.emit('stream_delta', {
+                      messageId: thinkingId,
+                      delta: '[redacted thinking]',
+                      thinking: true,
+                    })
+                  }
                 }
                 break
               }
@@ -908,6 +934,31 @@ export class SdkSession extends BaseSession {
                   // because both ends are this same process; it's a true
                   // elapsed duration, unlike the cross-machine serverTs field.
                   this.emit('stream_delta', { messageId, delta: delta.text, _emitMonoMs: Number(process.hrtime.bigint() / 1_000_000n) })
+                } else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+                  // #6756 — reasoning delta. Route to the thinking id opened on
+                  // this block's content_block_start; lazy-open if the start was
+                  // reordered/dropped so a delta is never lost. `signature_delta`
+                  // (the block's signature, not content) falls through untouched.
+                  let thinkingId = thinkingBlocks.get(event.index)
+                  if (!thinkingId) {
+                    thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
+                    thinkingBlocks.set(event.index, thinkingId)
+                    this.emit('stream_start', { messageId: thinkingId, thinking: true })
+                  }
+                  didStreamThinking = true
+                  this.emit('stream_delta', { messageId: thinkingId, delta: delta.thinking, thinking: true })
+                }
+                break
+              }
+
+              case 'content_block_stop': {
+                // #6756 — close the thinking stream for this block so the client
+                // finalises its "Thinking… → Thought" label. Only thinking
+                // blocks are tracked here; text/tool_use blocks are a no-op.
+                const thinkingId = thinkingBlocks.get(event.index)
+                if (thinkingId) {
+                  thinkingBlocks.delete(event.index)
+                  this.emit('stream_end', { messageId: thinkingId, thinking: true })
                 }
                 break
               }
@@ -933,6 +984,20 @@ export class SdkSession extends BaseSession {
                   content: block.text,
                   timestamp: Date.now(),
                 })
+              }
+
+              // #6756 — fallback for thinking delivered only on the full
+              // assistant message (partial-message streaming off, or a block the
+              // stream_event path never surfaced). Only fires when NOTHING was
+              // streamed this turn, so the streaming path is never double-emitted.
+              if ((block.type === 'thinking' || block.type === 'redacted_thinking') && !didStreamThinking) {
+                const thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
+                const text = block.type === 'redacted_thinking'
+                  ? '[redacted thinking]'
+                  : (typeof block.thinking === 'string' ? block.thinking : '')
+                this.emit('stream_start', { messageId: thinkingId, thinking: true })
+                if (text) this.emit('stream_delta', { messageId: thinkingId, delta: text, thinking: true })
+                this.emit('stream_end', { messageId: thinkingId, thinking: true })
               }
 
               if (block.type === 'tool_use') {

--- a/packages/server/tests/byok-session-thinking.test.js
+++ b/packages/server/tests/byok-session-thinking.test.js
@@ -1,0 +1,109 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ClaudeByokSession } from '../src/byok-session.js'
+
+/**
+ * #6756 — ClaudeByokSession forwards the already-translated `thinking_delta`
+ * instead of dropping it at `default: break`.
+ *
+ * The `@anthropic-ai/sdk` stream is stubbed via `session._client`. Raw
+ * `thinking_delta` / `content_block_stop` events flow through
+ * `translateSdkEvent`; the session opens a thinking stream on a distinct id
+ * (`<turnId>-thinking-<index>`) and closes it on the block's stop.
+ */
+
+function fakeStream(events, finalMessage) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const e of events) yield e
+    },
+    async finalMessage() {
+      return (
+        finalMessage || {
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: 'ok' }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }
+      )
+    },
+  }
+}
+
+function capture(session) {
+  const captured = []
+  for (const name of ['stream_start', 'stream_delta', 'stream_end', 'result', 'error']) {
+    session.on(name, (payload) => captured.push({ name, ...payload }))
+  }
+  return captured
+}
+
+describe('ClaudeByokSession — thinking content forwarding (#6756)', () => {
+  let tmpHome
+  let originalHome
+  let originalApiKey
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-byok-thinking-'))
+    originalHome = process.env.HOME
+    originalApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.HOME = tmpHome
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
+  })
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
+    else delete process.env.ANTHROPIC_API_KEY
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('wires thinking_delta through as a thinking stream on a distinct id', async () => {
+    const session = new ClaudeByokSession({ cwd: '/tmp' })
+    session._client = {
+      messages: {
+        stream: () =>
+          fakeStream([
+            { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
+            { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } },
+            { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Reasoning A. ' } },
+            { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Reasoning B.' } },
+            { type: 'content_block_stop', index: 0 },
+            { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+            { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hi' } },
+            { type: 'content_block_stop', index: 1 },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 5, output_tokens: 4 } },
+            { type: 'message_stop' },
+          ], {
+            stop_reason: 'end_turn',
+            content: [{ type: 'thinking', thinking: 'Reasoning A. Reasoning B.' }, { type: 'text', text: 'Hi' }],
+            usage: { input_tokens: 5, output_tokens: 4 },
+          }),
+      },
+    }
+    const captured = capture(session)
+    await session.start()
+    await session.sendMessage('hi')
+
+    const thinkingStarts = captured.filter((e) => e.name === 'stream_start' && e.thinking === true)
+    assert.equal(thinkingStarts.length, 1, 'one thinking stream opened')
+    const thinkingId = thinkingStarts[0].messageId
+    assert.match(thinkingId, /-thinking-0$/)
+
+    const thinkingDeltas = captured.filter((e) => e.name === 'stream_delta' && e.thinking === true)
+    assert.deepEqual(thinkingDeltas.map((e) => e.delta), ['Reasoning A. ', 'Reasoning B.'])
+    assert.ok(thinkingDeltas.every((e) => e.messageId === thinkingId))
+
+    const thinkingEnds = captured.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    assert.equal(thinkingEnds[0].messageId, thinkingId)
+
+    // Response text is untagged and on a different id.
+    const textDeltas = captured.filter((e) => e.name === 'stream_delta' && !e.thinking)
+    assert.deepEqual(textDeltas.map((e) => e.delta), ['Hi'])
+    assert.notEqual(textDeltas[0].messageId, thinkingId)
+  })
+})

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -261,6 +261,16 @@ describe('EventNormalizer', () => {
       assert.ok(result.sideEffects.some(se => se.type === 'session_list'))
       assert.ok(result.sideEffects.some(se => se.type === 'log'))
     })
+
+    // #6756 — a thinking stream_start carries the flag and skips the
+    // agent_busy / session_list churn.
+    it('tags thinking:true and omits agent_busy / session_list', () => {
+      const result = normalizer.normalize('stream_start', { messageId: 'msg-1-thinking-0', thinking: true }, makeCtx())
+      assert.equal(result.messages.length, 1)
+      assert.equal(result.messages[0].msg.type, 'stream_start')
+      assert.equal(result.messages[0].msg.thinking, true)
+      assert.ok(!result.sideEffects, 'no session_list churn per thinking block')
+    })
   })
 
   // ---- EVENT_MAP: stream_delta ----
@@ -270,6 +280,16 @@ describe('EventNormalizer', () => {
       const result = normalizer.normalize('stream_delta', { messageId: 'msg-1', delta: 'hello' }, makeCtx())
       assert.equal(result.buffer, true)
       assert.equal(result.messages[0].msg.delta, 'hello')
+    })
+
+    // #6756 — thinking deltas broadcast immediately (no buffering) with the flag
+    // intact; the coalescing buffer can't carry the flag.
+    it('thinking delta is NOT buffered and carries thinking:true', () => {
+      const result = normalizer.normalize('stream_delta', { messageId: 'msg-1-thinking-0', delta: 'reason', thinking: true }, makeCtx())
+      assert.ok(!result.buffer, 'thinking deltas bypass the coalescing buffer')
+      assert.equal(result.messages[0].msg.type, 'stream_delta')
+      assert.equal(result.messages[0].msg.delta, 'reason')
+      assert.equal(result.messages[0].msg.thinking, true)
     })
   })
 
@@ -281,6 +301,15 @@ describe('EventNormalizer', () => {
       assert.equal(result.messages[0].msg.type, 'stream_end')
       assert.equal(result.messages[0].msg.messageId, 'msg-1')
       assert.ok(result.sideEffects.some(se => se.type === 'flush_deltas'))
+    })
+
+    // #6756 — a thinking stream_end carries the flag and does NOT flush the
+    // response-text buffer.
+    it('tags thinking:true and omits flush_deltas', () => {
+      const result = normalizer.normalize('stream_end', { messageId: 'msg-1-thinking-0', thinking: true }, makeCtx())
+      assert.equal(result.messages[0].msg.type, 'stream_end')
+      assert.equal(result.messages[0].msg.thinking, true)
+      assert.ok(!result.sideEffects, 'thinking end does not flush the text buffer')
     })
   })
 

--- a/packages/server/tests/sdk-session-thinking.test.js
+++ b/packages/server/tests/sdk-session-thinking.test.js
@@ -112,6 +112,35 @@ describe('SdkSession — thinking content forwarding (#6756)', () => {
     assert.ok(events.some((e) => e.name === 'stream_end' && e.thinking === true))
   })
 
+  it('delta-before-start ordering produces exactly ONE thinking stream (Copilot review on #6817)', async () => {
+    // A reordered/missed content_block_start: the first thinking_delta lazily
+    // opens the stream; the late content_block_start for the SAME block index
+    // must reuse that id and must NOT emit a second stream_start.
+    session._callQuery = () => asyncStream([
+      initMsg,
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'early ' } } },
+      { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'late' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'early late' }] } },
+      resultMsg,
+    ])
+    const events = capture(session)
+    await session.sendMessage('hi')
+
+    const thinkingStarts = events.filter((e) => e.name === 'stream_start' && e.thinking === true)
+    assert.equal(thinkingStarts.length, 1, 'exactly one thinking stream_start for the block')
+    const thinkingId = thinkingStarts[0].messageId
+
+    const thinkingDeltas = events.filter((e) => e.name === 'stream_delta' && e.thinking === true)
+    assert.deepEqual(thinkingDeltas.map((e) => e.delta), ['early ', 'late'])
+    assert.ok(thinkingDeltas.every((e) => e.messageId === thinkingId), 'both deltas ride the lazily-opened id')
+
+    const thinkingEnds = events.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    assert.equal(thinkingEnds[0].messageId, thinkingId)
+  })
+
   it('falls back to the full assistant message when the thinking block never streamed', async () => {
     // No thinking stream_event partials — only the final assistant message
     // carries the thinking block (partial streaming off / block not surfaced).

--- a/packages/server/tests/sdk-session-thinking.test.js
+++ b/packages/server/tests/sdk-session-thinking.test.js
@@ -1,0 +1,132 @@
+import { describe, it, beforeEach, afterEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { SdkSession } from '../src/sdk-session.js'
+
+/**
+ * #6756 — SdkSession forwards extended-thinking (reasoning) content.
+ *
+ * Drives `sendMessage` with a mocked `_callQuery` async stream that yields the
+ * Agent SDK's partial `stream_event` messages (content_block_start /
+ * content_block_delta / content_block_stop) for a thinking block, then a text
+ * block. Captures the emitted stream_start / stream_delta / stream_end events
+ * and asserts the thinking ones carry `thinking: true` on a DISTINCT messageId,
+ * while the response text stream is untagged.
+ */
+
+let _tmp
+function tmpStateFile() {
+  if (!_tmp) _tmp = mkdtempSync(join(tmpdir(), 'sdk-thinking-test-'))
+  return join(_tmp, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+after(() => {
+  if (_tmp) rmSync(_tmp, { recursive: true, force: true })
+})
+
+function createSession(opts = {}) {
+  const session = new SdkSession({ cwd: '/tmp', stateFilePath: tmpStateFile(), ...opts })
+  // Non-blocking model refresh would otherwise fire real network work.
+  session._fetchSupportedModels = () => {}
+  return session
+}
+
+function asyncStream(messages) {
+  return (async function* () {
+    for (const m of messages) yield m
+  })()
+}
+
+function capture(session) {
+  const events = []
+  for (const name of ['stream_start', 'stream_delta', 'stream_end', 'message', 'tool_start']) {
+    session.on(name, (d) => events.push({ name, ...d }))
+  }
+  session.on('error', () => {})
+  return events
+}
+
+const initMsg = { type: 'system', subtype: 'init', session_id: 'sdk-1', model: 'claude-x', tools: [] }
+const resultMsg = { type: 'result', session_id: 'sdk-1', total_cost_usd: 0.01, duration_ms: 10, usage: {} }
+
+describe('SdkSession — thinking content forwarding (#6756)', () => {
+  let session
+  beforeEach(() => { session = createSession() })
+  afterEach(() => { session.destroy() })
+
+  it('streams a thinking block on a distinct id tagged thinking:true, then response text untagged', async () => {
+    session._callQuery = () => asyncStream([
+      initMsg,
+      { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Let me think. ' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Step two.' } } },
+      // signature_delta must be ignored (it is not reasoning content).
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'sig' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'stream_event', event: { type: 'content_block_start', index: 1, content_block: { type: 'text' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hello' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 1 } },
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'Let me think. Step two.' }, { type: 'text', text: 'Hello' }] } },
+      resultMsg,
+    ])
+    const events = capture(session)
+    await session.sendMessage('hi')
+
+    const thinkingStarts = events.filter((e) => e.name === 'stream_start' && e.thinking === true)
+    assert.equal(thinkingStarts.length, 1, 'one thinking stream_start')
+    const thinkingId = thinkingStarts[0].messageId
+    assert.match(thinkingId, /-thinking-0$/, 'thinking id is turn-scoped + block-indexed')
+
+    const thinkingDeltas = events.filter((e) => e.name === 'stream_delta' && e.thinking === true)
+    assert.deepEqual(thinkingDeltas.map((e) => e.delta), ['Let me think. ', 'Step two.'])
+    assert.ok(thinkingDeltas.every((e) => e.messageId === thinkingId), 'all thinking deltas share the id')
+
+    const thinkingEnds = events.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    assert.equal(thinkingEnds[0].messageId, thinkingId)
+
+    // The response text stream is untagged and uses a DIFFERENT id.
+    const textDeltas = events.filter((e) => e.name === 'stream_delta' && !e.thinking)
+    assert.deepEqual(textDeltas.map((e) => e.delta), ['Hello'])
+    assert.notEqual(textDeltas[0].messageId, thinkingId)
+  })
+
+  it('forwards a redacted_thinking block as a marker (never silently dropped)', async () => {
+    session._callQuery = () => asyncStream([
+      initMsg,
+      { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'redacted_thinking', data: 'ENCRYPTED' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'stream_event', event: { type: 'content_block_start', index: 1, content_block: { type: 'text' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Done' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 1 } },
+      { type: 'assistant', message: { content: [{ type: 'redacted_thinking', data: 'ENCRYPTED' }, { type: 'text', text: 'Done' }] } },
+      resultMsg,
+    ])
+    const events = capture(session)
+    await session.sendMessage('hi')
+
+    const redactedDeltas = events.filter((e) => e.name === 'stream_delta' && e.thinking === true)
+    assert.equal(redactedDeltas.length, 1)
+    assert.equal(redactedDeltas[0].delta, '[redacted thinking]')
+    assert.ok(events.some((e) => e.name === 'stream_end' && e.thinking === true))
+  })
+
+  it('falls back to the full assistant message when the thinking block never streamed', async () => {
+    // No thinking stream_event partials — only the final assistant message
+    // carries the thinking block (partial streaming off / block not surfaced).
+    session._callQuery = () => asyncStream([
+      initMsg,
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'Whole-message reasoning.' }, { type: 'text', text: 'Answer' }] } },
+      resultMsg,
+    ])
+    const events = capture(session)
+    await session.sendMessage('hi')
+
+    const thinkingDeltas = events.filter((e) => e.name === 'stream_delta' && e.thinking === true)
+    assert.equal(thinkingDeltas.length, 1)
+    assert.equal(thinkingDeltas[0].delta, 'Whole-message reasoning.')
+    assert.ok(events.some((e) => e.name === 'stream_start' && e.thinking === true))
+    assert.ok(events.some((e) => e.name === 'stream_end' && e.thinking === true))
+  })
+})

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -61,24 +61,26 @@ describe('buildChatViewMessages', () => {
     expect(out.chatToolGroupPayloads.size).toBe(0)
   })
 
-  it('collapses a run of 2+ tool_use/thinking into a single tool_group row', () => {
+  it('collapses a run of 2+ tool_use into a tool_group; thinking stays standalone (#6756)', () => {
     const messages = [
       msg({ id: 'u1', type: 'user_input', content: 'do many things' }),
-      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
       msg({ id: 'th1', type: 'thinking', content: 'planning' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
       msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
       msg({ id: 'r1', type: 'response', content: 'done' }),
     ]
     const out = buildChatViewMessages(messages, null)
     const types = out.chatMessages.map(m => m.type)
-    expect(types).toEqual(['user_input', 'tool_group', 'response'])
+    // #6756 — the thinking bubble renders as its own row (reaching ThinkingBody),
+    // and only the two contiguous tool_use bubbles collapse into a tool_group.
+    expect(types).toEqual(['user_input', 'thinking', 'tool_group', 'response'])
 
     const groupRow = out.chatMessages.find(m => m.type === 'tool_group')!
     expect(groupRow.id).toBe('activity-t1')
 
     const payload = out.chatToolGroupPayloads.get('activity-t1')
     expect(payload).toBeDefined()
-    expect(payload!.messages.map(m => m.id)).toEqual(['t1', 'th1', 't2'])
+    expect(payload!.messages.map(m => m.id)).toEqual(['t1', 't2'])
     expect(payload!.isActive).toBe(false)
   })
 

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -62,6 +62,13 @@ export interface ChatViewMessage {
   timestamp: number
   isStreaming?: boolean
   /**
+   * #6756 — mirrored from the store ChatMessage on `thinking` rows: `true`
+   * while reasoning content is still streaming (label "Thinking…"), `false`
+   * once the thinking block ended (label "Thought"). Distinct from
+   * `isStreaming` (which tracks the response text via `streamingMessageId`).
+   */
+  thinkingStreaming?: boolean
+  /**
    * #4476 — structured error code mirrored from the store ChatMessage so
    * renderers can switch on it (e.g. `'stream_stall'` → chip + retry).
    */
@@ -110,6 +117,12 @@ export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
     // renderMessage path can switch error bubbles into the
     // StreamStallChip variant.
     ...(msg.code ? { code: msg.code } : {}),
+    // #6756: carry the thinking streaming flag through on thinking rows so the
+    // ThinkingBody disclosure can label "Thinking…" vs "Thought". Gated to
+    // `thinking` to match the contract (the field lives only on thinking bubbles).
+    ...(msg.type === 'thinking' && msg.thinkingStreaming !== undefined
+      ? { thinkingStreaming: msg.thinkingStreaming }
+      : {}),
     // #6632: carry user-message attachments through so the transcript can
     // preview them (dropped previously → no thumbnail on the sent message).
     // Gated to `user_input` to match the contract (attachments live only on user

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -13,14 +13,15 @@
  *     -> filter(m => m.type !== 'system')   // System events render on
  *                                           //   the System tab.
  *     -> groupMessages                      // (#3747) collapse contiguous
- *                                           //   tool_use / thinking runs
- *                                           //   into ActivityGroups.
+ *                                           //   tool_use runs into
+ *                                           //   ActivityGroups (#6756:
+ *                                           //   thinking stays standalone).
  *     -> applyStreamingOverlay              // mark trailing activity group
  *                                           //   as active during streaming.
  *     -> ChatViewMessage[]                  // flatten to chat-view rows.
  *
  * Singleton activity groups (1 message) pass through as the original
- * `tool_use` / `thinking` row so the existing ToolBubble path stays
+ * `tool_use` row so the existing ToolBubble path stays
  * reachable. Runs of 2+ messages collapse to a synthetic `tool_group`
  * row whose `id` is the group key `activity-<firstId>`. The full payload
  * is exposed via `chatToolGroupPayloads: Map<groupId, { messages, isActive }>`
@@ -68,6 +69,13 @@ export interface ChatViewMessage {
    * `isStreaming` (which tracks the response text via `streamingMessageId`).
    */
   thinkingStreaming?: boolean
+  /**
+   * #6756 — mirrored from the store ChatMessage on `thinking` rows: the
+   * accumulated reasoning content hit MAX_THINKING_CONTENT_LEN and further
+   * deltas were dropped. Renderers append a small "[thinking truncated]"
+   * marker so the cut is never silent.
+   */
+  thinkingTruncated?: boolean
   /**
    * #4476 — structured error code mirrored from the store ChatMessage so
    * renderers can switch on it (e.g. `'stream_stall'` → chip + retry).
@@ -123,6 +131,11 @@ export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
     ...(msg.type === 'thinking' && msg.thinkingStreaming !== undefined
       ? { thinkingStreaming: msg.thinkingStreaming }
       : {}),
+    // #6756: surface a hit size cap — renderers append a "[thinking truncated]"
+    // marker so the cut is never silent. Same thinking-row gate as above.
+    ...(msg.type === 'thinking' && msg.thinkingTruncated
+      ? { thinkingTruncated: true }
+      : {}),
     // #6632: carry user-message attachments through so the transcript can
     // preview them (dropped previously → no thumbnail on the sent message).
     // Gated to `user_input` to match the contract (attachments live only on user
@@ -148,8 +161,9 @@ export function buildChatViewMessages(
   // Filter out `system` events — they belong on the System tab.
   const chatFilteredMessages = storeMessages.filter(m => m.type !== 'system')
 
-  // Group contiguous tool_use / thinking runs, then apply the streaming
-  // overlay so the trailing group flips to isActive while streaming.
+  // Group contiguous tool_use runs (#6756: thinking stays standalone), then
+  // apply the streaming overlay so the trailing group flips to isActive while
+  // streaming.
   const baseGroups = groupMessages(chatFilteredMessages)
   const displayGroups = applyStreamingOverlay(
     baseGroups,
@@ -159,8 +173,8 @@ export function buildChatViewMessages(
 
   // Map of synthetic group id -> original messages + isActive. Only
   // populated for runs of 2+ messages (#3794 review) — singleton activity
-  // groups render as the original `tool_use` / `thinking` row through
-  // ToolBubble, so they don't need a payload lookup.
+  // groups render as the original `tool_use` row through ToolBubble, so
+  // they don't need a payload lookup.
   const chatToolGroupPayloads = new Map<
     string,
     { messages: ChatMessage[]; isActive: boolean }
@@ -172,12 +186,12 @@ export function buildChatViewMessages(
   }
 
   // Flatten to ChatViewMessage[] — singleton activity groups (1 msg)
-  // pass through as `tool_use` / `thinking`; runs of 2+ collapse to a
-  // single synthetic `tool_group` row keyed by the group key.
+  // pass through as `tool_use`; runs of 2+ collapse to a single
+  // synthetic `tool_group` row keyed by the group key.
   const chatMessages: ChatViewMessage[] = displayGroups.map((g) => {
     if (g.type === 'single') return toChatViewMessage(g.message)
     if (g.messages.length < 2) {
-      // Singleton — emit as the original tool_use / thinking row.
+      // Singleton — emit as the original tool_use row.
       return toChatViewMessage(g.messages[0]!)
     }
     const last = g.messages[g.messages.length - 1]

--- a/packages/store-core/src/group-messages.test.ts
+++ b/packages/store-core/src/group-messages.test.ts
@@ -60,14 +60,20 @@ describe('groupMessages', () => {
     }
   })
 
-  it('groups tool_use and thinking together (both contribute to activity)', () => {
+  it('keeps thinking standalone, breaking a tool run (#6756)', () => {
+    // Thinking now carries real reasoning content, so each thinking bubble is
+    // its own `single` row (reaching the content-capable disclosure) instead of
+    // collapsing into the tool activity group.
     const t1 = msg('1', 'thinking')
     const u = msg('2', 'tool_use', { tool: 'Bash' })
     const t2 = msg('3', 'thinking')
     const groups = groupMessages([t1, u, t2])
-    expect(groups).toHaveLength(1)
-    if (groups[0].type === 'activity') {
-      expect(groups[0].messages).toHaveLength(3)
+    expect(groups).toHaveLength(3)
+    expect(groups[0].type).toBe('single')
+    expect(groups[1].type).toBe('activity')
+    expect(groups[2].type).toBe('single')
+    if (groups[1].type === 'activity') {
+      expect(groups[1].messages).toHaveLength(1)
     }
   })
 
@@ -170,7 +176,7 @@ describe('applyStreamingOverlay', () => {
       msg('1', 'tool_use', { tool: 'Bash' }),
       msg('2', 'response', { content: 'ok' }),
       msg('3', 'tool_use', { tool: 'Read' }),
-      msg('4', 'thinking'),
+      msg('4', 'tool_use', { tool: 'Grep' }),
     ]
     const base = groupMessages(messages)
     expect(base).toHaveLength(3)

--- a/packages/store-core/src/group-messages.ts
+++ b/packages/store-core/src/group-messages.ts
@@ -1,16 +1,26 @@
 /**
  * Shared message grouping selector (#3747).
  *
- * Groups consecutive tool_use and thinking messages into a single activity
- * group so chat surfaces can render them as one collapsible block instead
- * of a wall of individual bubbles. Pure structural grouping with no React
- * or platform dependencies — both the mobile app and the desktop dashboard
- * consume the same DisplayGroup output.
+ * Groups consecutive tool_use messages into a single activity group so chat
+ * surfaces can render them as one collapsible block instead of a wall of
+ * individual bubbles. Pure structural grouping with no React or platform
+ * dependencies — both the mobile app and the desktop dashboard consume the
+ * same DisplayGroup output.
  *
- * Boundary rule: any non-tool, non-thinking message (assistant text, user
- * input, prompts, errors, system events) ends the current group. Permission
- * prompts and question prompts are `type: 'prompt'`, so they break runs and
- * stay as standalone rows.
+ * Boundary rule: any non-tool message (assistant text, user input, prompts,
+ * errors, system events) ends the current group. Permission prompts and
+ * question prompts are `type: 'prompt'`, so they break runs and stay as
+ * standalone rows.
+ *
+ * #6756 — `thinking` bubbles are NOT absorbed into activity groups. Now that
+ * extended-thinking carries real reasoning content (not just the old empty
+ * placeholder), each thinking bubble renders as its own standalone
+ * `single` row so it reaches the content-capable disclosure (dashboard
+ * `ThinkingBody` / mobile MessageBubble) instead of collapsing into a bare
+ * "Thinking" label inside a tool group. This breaks a tool run: a thinking
+ * bubble between two tool_use bubbles yields three rows. `countToolUses` /
+ * `summarizeToolCounts` already excluded thinking, so tool counts are
+ * unaffected.
  */
 import type { ChatMessage } from './types'
 
@@ -18,8 +28,9 @@ export type DisplayGroup =
   | { type: 'single'; message: ChatMessage }
   | { type: 'activity'; messages: ChatMessage[]; isActive: boolean; key: string }
 
-/** Group consecutive tool_use and thinking messages into ActivityGroups.
- *  Pure structural grouping — does not depend on streaming state. */
+/** Group consecutive tool_use messages into ActivityGroups.
+ *  Pure structural grouping — does not depend on streaming state.
+ *  #6756 — thinking bubbles break a run and stay standalone (see file header). */
 export function groupMessages(messages: ChatMessage[]): DisplayGroup[] {
   const groups: DisplayGroup[] = []
   let activityBuf: ChatMessage[] = []
@@ -37,7 +48,7 @@ export function groupMessages(messages: ChatMessage[]): DisplayGroup[] {
   }
 
   for (const msg of messages) {
-    if (msg.type === 'tool_use' || msg.type === 'thinking') {
+    if (msg.type === 'tool_use') {
       activityBuf.push(msg)
     } else {
       flushActivity()

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -1333,7 +1333,12 @@ export function handleThinkingStreamStart(
       ? msg.messageId
       : nextMessageId('thinking')
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
-  const existing = existingMessages.find((m) => m.id === thinkingMessageId)
+  // Type-guarded like the sibling handlers (handleThinkingDelta / -StreamEnd):
+  // only an existing THINKING bubble dedups; a non-thinking message that
+  // somehow occupies the id must not silently swallow the start.
+  const existing = existingMessages.find(
+    (m) => m.id === thinkingMessageId && m.type === 'thinking',
+  )
   if (existing) {
     return { sessionId, thinkingMessageId, isNewMessage: false, newMessage: null }
   }
@@ -1430,6 +1435,29 @@ export function handleThinkingDelta(
       return updated
     },
   }
+}
+
+/**
+ * #6756 — orphan sweep: finalise any thinking bubble still marked streaming.
+ *
+ * A thinking bubble normally finalises on its own `stream_end` (the block's
+ * `content_block_stop`), but if that message is dropped (server crash, missed
+ * broadcast) the bubble would be stuck on "Thinking…" forever. The turn
+ * boundary is a guaranteed backstop: callers run this on the RESPONSE stream's
+ * `stream_end` and on `result` — by then every thinking block of the turn is
+ * over. Returns the same array reference when nothing was streaming (no-op),
+ * so callers can compose it with their force-new-reference spread without an
+ * extra clone in the common case. Mirrors the #4308 activeTools orphan sweep.
+ */
+export function finalizeThinkingStreams(messages: ChatMessage[]): ChatMessage[] {
+  if (!messages.some((m) => m.type === 'thinking' && m.thinkingStreaming === true)) {
+    return messages
+  }
+  return messages.map((m) =>
+    m.type === 'thinking' && m.thinkingStreaming === true
+      ? { ...m, thinkingStreaming: false }
+      : m,
+  )
 }
 
 /** Result returned from {@link handleThinkingStreamEnd}. */

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -1270,6 +1270,212 @@ export function handleStreamEnd(
 }
 
 // ---------------------------------------------------------------------------
+// thinking stream (#6756)
+//
+// Extended-thinking / reasoning content forwarded by the providers that
+// produce it (claude SDK, BYOK) arrives on the SAME wire messages as the
+// visible response text (stream_start / stream_delta / stream_end) but tagged
+// with `thinking: true` and a DISTINCT `messageId` (`<turnId>-thinking-<n>`).
+// The caller diverts those to these handlers BEFORE the response-stream
+// machinery (pendingDeltas / continuation-split / etc.), so the two streams
+// never share the buffered-append hot path. A thinking message is a plain
+// `type: 'thinking'` ChatMessage whose `content` accumulates the reasoning
+// text — feeding the dashboard's ThinkingBody disclosure and the mobile
+// content-capable thinking view. Its id is distinct from the ephemeral
+// placeholder id `'thinking'`, so `filterThinking` still strips only the
+// placeholder.
+// ---------------------------------------------------------------------------
+
+/**
+ * Upper bound (UTF-16 code units, matching {@link MAX_TOOL_INPUT_PARTIAL_LEN})
+ * on a thinking bubble's accumulated `content`. Reasoning can be long; this is
+ * the same defence-in-depth ceiling the streaming tool-input accumulator uses
+ * so a runaway/adversarial thinking stream can't balloon client `messages`
+ * state. On truncation the buffer is sliced to exactly this length and the
+ * `thinkingTruncated` boolean is set; further deltas drop idempotently.
+ */
+export const MAX_THINKING_CONTENT_LEN = MAX_TOOL_INPUT_PARTIAL_LEN
+
+/** Result returned from {@link handleThinkingStreamStart}. */
+export interface ThinkingStreamStartPayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** Stable id of the thinking bubble (the server-stamped `messageId`). */
+  thinkingMessageId: string
+  /**
+   * Whether the caller should append a new thinking message. False when a
+   * thinking bubble with this id already exists (duplicate/replayed start) —
+   * the caller then leaves the messages array untouched.
+   */
+  isNewMessage: boolean
+  /** Pre-built `type: 'thinking'` ChatMessage when `isNewMessage` is true. */
+  newMessage: ChatMessage | null
+}
+
+/**
+ * Resolve a thinking `stream_start` (a `stream_start` with `thinking: true`).
+ *
+ * Builds a fresh `{ type: 'thinking', content: '', thinkingStreaming: true }`
+ * bubble at the server-stamped id unless one already exists (dedup on
+ * reconnect/replay). The caller drops the ephemeral `'thinking'` placeholder
+ * via `filterThinking` and appends `newMessage`. Does NOT touch
+ * `streamingMessageId` — the turn's `'pending'` sentinel (set at send) keeps
+ * the busy/stop state correct across the whole turn; the thinking label is
+ * driven by the bubble's own `thinkingStreaming` field.
+ */
+export function handleThinkingStreamStart(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+  existingMessages: readonly ChatMessage[],
+): ThinkingStreamStartPayload {
+  const thinkingMessageId =
+    typeof msg.messageId === 'string' && msg.messageId
+      ? msg.messageId
+      : nextMessageId('thinking')
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
+  const existing = existingMessages.find((m) => m.id === thinkingMessageId)
+  if (existing) {
+    return { sessionId, thinkingMessageId, isNewMessage: false, newMessage: null }
+  }
+  const newMessage: ChatMessage = {
+    id: thinkingMessageId,
+    type: 'thinking',
+    content: '',
+    thinkingStreaming: true,
+    timestamp: Date.now(),
+  }
+  return { sessionId, thinkingMessageId, isNewMessage: true, newMessage }
+}
+
+/** Result returned from {@link handleThinkingDelta} when the message is well-formed. */
+export interface ThinkingDeltaPayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** The thinking bubble id the delta accumulates onto. */
+  thinkingMessageId: string
+  /**
+   * Apply the delta to a session's `messages` array: locate the `thinking`
+   * bubble by id and append `delta` to its `content` (bounded at
+   * {@link MAX_THINKING_CONTENT_LEN}). If no bubble exists yet (a delta beat
+   * its `stream_start`, or the provider emits deltas only), one is lazily
+   * created — the ephemeral `'thinking'` placeholder is dropped in that case.
+   * Returns the same reference (no-op) only when the bubble is already
+   * truncated.
+   */
+  applyTo: (messages: ChatMessage[]) => ChatMessage[]
+}
+
+/**
+ * Validate and build an accumulator for a thinking `stream_delta` (a
+ * `stream_delta` with `thinking: true`). Returns `null` when `messageId` or
+ * `delta` is missing/non-string — both required by the wire shape; malformed
+ * payloads drop silently rather than throw.
+ */
+export function handleThinkingDelta(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): ThinkingDeltaPayload | null {
+  if (typeof msg.messageId !== 'string' || !msg.messageId) return null
+  if (typeof msg.delta !== 'string') return null
+  const thinkingMessageId = msg.messageId
+  const delta = msg.delta
+  const sessionId = parseRawStringField(msg, 'sessionId') || activeSessionId
+
+  return {
+    sessionId,
+    thinkingMessageId,
+    applyTo: (messages) => {
+      const idx = messages.findIndex(
+        (m) => m.id === thinkingMessageId && m.type === 'thinking',
+      )
+      if (idx === -1) {
+        // Lazy-create: a delta arrived before (or without) its stream_start.
+        // Drop the ephemeral placeholder and seed a fresh thinking bubble.
+        let seed = delta
+        let truncated = false
+        if (seed.length > MAX_THINKING_CONTENT_LEN) {
+          seed = seed.slice(0, MAX_THINKING_CONTENT_LEN)
+          truncated = true
+        }
+        const created: ChatMessage = {
+          id: thinkingMessageId,
+          type: 'thinking',
+          content: seed,
+          thinkingStreaming: true,
+          ...(truncated ? { thinkingTruncated: true } : null),
+          timestamp: Date.now(),
+        }
+        return [...messages.filter((m) => m.id !== 'thinking'), created]
+      }
+      const existing = messages[idx]!
+      // Idempotent terminal state: once truncated, drop further deltas.
+      if (existing.thinkingTruncated) return messages
+      const prev = existing.content || ''
+      let next: string
+      let truncated = false
+      if (prev.length + delta.length > MAX_THINKING_CONTENT_LEN) {
+        const headroom = MAX_THINKING_CONTENT_LEN - prev.length
+        next = prev + delta.slice(0, Math.max(0, headroom))
+        truncated = true
+      } else {
+        next = prev + delta
+      }
+      const updated = [...messages]
+      updated[idx] = {
+        ...existing,
+        content: next,
+        thinkingStreaming: true,
+        ...(truncated ? { thinkingTruncated: true } : null),
+      }
+      return updated
+    },
+  }
+}
+
+/** Result returned from {@link handleThinkingStreamEnd}. */
+export interface ThinkingStreamEndPayload {
+  /** Resolved target session, or null when no session context exists. */
+  sessionId: string | null
+  /** The thinking bubble id whose streaming label should finalise. */
+  thinkingMessageId: string | null
+  /**
+   * Apply the finalisation to a session's `messages` array: flip the matching
+   * `thinking` bubble's `thinkingStreaming` to `false` (label → "Thought").
+   * Returns the same reference (no-op) when no matching bubble is present, so
+   * callers can skip the state write.
+   */
+  applyTo: (messages: ChatMessage[]) => ChatMessage[]
+}
+
+/**
+ * Resolve a thinking `stream_end` (a `stream_end` with `thinking: true`).
+ * Finalises the bubble's streaming label without touching `streamingMessageId`.
+ */
+export function handleThinkingStreamEnd(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): ThinkingStreamEndPayload {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
+  const thinkingMessageId = parseRawStringField(msg, 'messageId')
+  return {
+    sessionId,
+    thinkingMessageId,
+    applyTo: (messages) => {
+      if (!thinkingMessageId) return messages
+      const idx = messages.findIndex(
+        (m) => m.id === thinkingMessageId && m.type === 'thinking',
+      )
+      if (idx === -1) return messages
+      const existing = messages[idx]!
+      if (existing.thinkingStreaming !== true) return messages
+      const updated = [...messages]
+      updated[idx] = { ...existing, thinkingStreaming: false }
+      return updated
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
 // result — payload-normalization parts only
 //
 // Streaming-state cleanup (`flushPendingDeltas`, `clearTimeout(deltaFlushTimer)`,

--- a/packages/store-core/src/handlers/thinking.test.ts
+++ b/packages/store-core/src/handlers/thinking.test.ts
@@ -9,6 +9,7 @@ import {
   handleThinkingStreamStart,
   handleThinkingDelta,
   handleThinkingStreamEnd,
+  finalizeThinkingStreams,
   MAX_THINKING_CONTENT_LEN,
 } from './stream'
 import type { ChatMessage } from '../types'
@@ -46,6 +47,44 @@ describe('handleThinkingStreamStart (#6756)', () => {
     )
     expect(out.isNewMessage).toBe(false)
     expect(out.newMessage).toBeNull()
+  })
+
+  it('does NOT dedup against a non-thinking message occupying the id (type guard)', () => {
+    // Stream-ID discipline consistency with the sibling handlers: a tool_use
+    // (or any non-thinking) message on the same id must not swallow the start.
+    const collider: ChatMessage = { id: 'msg-1-thinking-0', type: 'tool_use', content: '', timestamp: 1 }
+    const out = handleThinkingStreamStart(
+      { type: 'stream_start', messageId: 'msg-1-thinking-0', thinking: true },
+      SESSION,
+      [collider],
+    )
+    expect(out.isNewMessage).toBe(true)
+    expect(out.newMessage).toMatchObject({ type: 'thinking', thinkingStreaming: true })
+  })
+})
+
+describe('finalizeThinkingStreams (#6756 orphan sweep)', () => {
+  it('flips every still-streaming thinking bubble to finalised', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'a', thinkingStreaming: true, timestamp: 0 },
+      { id: 'r1', type: 'response', content: 'x', timestamp: 1 },
+      { id: 't1', type: 'thinking', content: 'b', thinkingStreaming: true, timestamp: 2 },
+    ]
+    const next = finalizeThinkingStreams(messages)
+    expect(next).not.toBe(messages)
+    expect(next.filter((m) => m.type === 'thinking').map((m) => m.thinkingStreaming)).toEqual([false, false])
+    // Non-thinking rows keep identity (map only clones the flipped ones).
+    expect(next[1]).toBe(messages[1])
+  })
+
+  it('is a same-reference no-op when nothing is streaming', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'a', thinkingStreaming: false, timestamp: 0 },
+      { id: 'r1', type: 'response', content: 'x', timestamp: 1 },
+    ]
+    expect(finalizeThinkingStreams(messages)).toBe(messages)
+    const empty: ChatMessage[] = []
+    expect(finalizeThinkingStreams(empty)).toBe(empty)
   })
 })
 

--- a/packages/store-core/src/handlers/thinking.test.ts
+++ b/packages/store-core/src/handlers/thinking.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #6756 — shared thinking-stream handlers: a `stream_start`/`stream_delta`/
+ * `stream_end` tagged `thinking: true` accumulates reasoning content onto a
+ * `type: 'thinking'` bubble (distinct id) that feeds the content-capable
+ * disclosure, separate from the response-text stream.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  handleThinkingStreamStart,
+  handleThinkingDelta,
+  handleThinkingStreamEnd,
+  MAX_THINKING_CONTENT_LEN,
+} from './stream'
+import type { ChatMessage } from '../types'
+
+const SESSION = 's1'
+
+function placeholder(): ChatMessage {
+  return { id: 'thinking', type: 'thinking', content: '', timestamp: 0 }
+}
+
+describe('handleThinkingStreamStart (#6756)', () => {
+  it('builds a fresh streaming thinking bubble at the server-stamped id', () => {
+    const out = handleThinkingStreamStart(
+      { type: 'stream_start', messageId: 'msg-1-thinking-0', thinking: true, sessionId: SESSION },
+      null,
+      [],
+    )
+    expect(out.sessionId).toBe(SESSION)
+    expect(out.thinkingMessageId).toBe('msg-1-thinking-0')
+    expect(out.isNewMessage).toBe(true)
+    expect(out.newMessage).toMatchObject({
+      id: 'msg-1-thinking-0',
+      type: 'thinking',
+      content: '',
+      thinkingStreaming: true,
+    })
+  })
+
+  it('dedups when a bubble with the id already exists (replay/dup start)', () => {
+    const existing: ChatMessage = { id: 'msg-1-thinking-0', type: 'thinking', content: 'x', timestamp: 1 }
+    const out = handleThinkingStreamStart(
+      { type: 'stream_start', messageId: 'msg-1-thinking-0', thinking: true },
+      SESSION,
+      [existing],
+    )
+    expect(out.isNewMessage).toBe(false)
+    expect(out.newMessage).toBeNull()
+  })
+})
+
+describe('handleThinkingDelta (#6756)', () => {
+  it('appends onto an existing thinking bubble', () => {
+    const messages: ChatMessage[] = [
+      { id: 'msg-1-thinking-0', type: 'thinking', content: 'Let me ', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const p = handleThinkingDelta(
+      { type: 'stream_delta', messageId: 'msg-1-thinking-0', delta: 'think.', thinking: true },
+      SESSION,
+    )!
+    const next = p.applyTo(messages)
+    expect(next[0]!.content).toBe('Let me think.')
+    expect(next[0]!.thinkingStreaming).toBe(true)
+    expect(next).not.toBe(messages)
+  })
+
+  it('lazy-creates the bubble (dropping the placeholder) when start was missed', () => {
+    const messages: ChatMessage[] = [placeholder()]
+    const p = handleThinkingDelta(
+      { type: 'stream_delta', messageId: 'msg-1-thinking-0', delta: 'Reasoning…', thinking: true },
+      SESSION,
+    )!
+    const next = p.applyTo(messages)
+    // placeholder ('thinking') dropped, real thinking bubble appended
+    expect(next.map((m) => m.id)).toEqual(['msg-1-thinking-0'])
+    expect(next[0]!.content).toBe('Reasoning…')
+    expect(next[0]!.thinkingStreaming).toBe(true)
+  })
+
+  it('bounds content at MAX_THINKING_CONTENT_LEN and flags truncation', () => {
+    const near = 'a'.repeat(MAX_THINKING_CONTENT_LEN - 3)
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: near, thinkingStreaming: true, timestamp: 0 },
+    ]
+    const p = handleThinkingDelta(
+      { type: 'stream_delta', messageId: 't0', delta: 'bbbbbb', thinking: true },
+      SESSION,
+    )!
+    const next = p.applyTo(messages)
+    expect(next[0]!.content.length).toBe(MAX_THINKING_CONTENT_LEN)
+    expect(next[0]!.thinkingTruncated).toBe(true)
+    // further deltas drop idempotently (same reference)
+    const again = handleThinkingDelta(
+      { type: 'stream_delta', messageId: 't0', delta: 'more', thinking: true },
+      SESSION,
+    )!.applyTo(next)
+    expect(again).toBe(next)
+  })
+
+  it('rejects malformed payloads (missing id/delta)', () => {
+    expect(handleThinkingDelta({ type: 'stream_delta', thinking: true }, SESSION)).toBeNull()
+    expect(
+      handleThinkingDelta({ type: 'stream_delta', messageId: 't0', thinking: true }, SESSION),
+    ).toBeNull()
+  })
+})
+
+describe('handleThinkingStreamEnd (#6756)', () => {
+  it('flips thinkingStreaming to false on the matching bubble', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done reasoning', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const p = handleThinkingStreamEnd({ type: 'stream_end', messageId: 't0', thinking: true }, SESSION)
+    const next = p.applyTo(messages)
+    expect(next[0]!.thinkingStreaming).toBe(false)
+    expect(next[0]!.content).toBe('done reasoning')
+  })
+
+  it('is a no-op (same reference) when the bubble is absent or already finalised', () => {
+    const finalised: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'x', thinkingStreaming: false, timestamp: 0 },
+    ]
+    const p = handleThinkingStreamEnd({ type: 'stream_end', messageId: 't0', thinking: true }, SESSION)
+    expect(p.applyTo(finalised)).toBe(finalised)
+    expect(p.applyTo([])).toEqual([])
+  })
+})

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -506,6 +506,10 @@ export type {
   StreamEndPayload,
   StreamDeltaContext,
   PendingDelta,
+  // #6756 — thinking-stream handler payload shapes.
+  ThinkingStreamStartPayload,
+  ThinkingDeltaPayload,
+  ThinkingStreamEndPayload,
   ResultUsagePayload,
   // #5454 — remaining both-sides duplicates extracted into store-core
   PairFailPayload,
@@ -640,6 +644,11 @@ export {
   handleStreamStart,
   sharedStreamDelta,
   handleStreamEnd,
+  // #6756 — extended-thinking (reasoning) stream handlers.
+  handleThinkingStreamStart,
+  handleThinkingDelta,
+  handleThinkingStreamEnd,
+  MAX_THINKING_CONTENT_LEN,
   handleResultUsage,
   // #5454 — remaining both-sides duplicates extracted into store-core
   handleRawOutput,

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -648,6 +648,7 @@ export {
   handleThinkingStreamStart,
   handleThinkingDelta,
   handleThinkingStreamEnd,
+  finalizeThinkingStreams,
   MAX_THINKING_CONTENT_LEN,
   handleResultUsage,
   // #5454 — remaining both-sides duplicates extracted into store-core

--- a/packages/store-core/src/types/chat.ts
+++ b/packages/store-core/src/types/chat.ts
@@ -160,6 +160,26 @@ export interface ChatMessage {
    * only for backwards compatibility with rehydrated state.
    */
   toolInputPartialTruncated?: boolean;
+  /**
+   * #6756 — set on a `type: 'thinking'` bubble while its reasoning content is
+   * still streaming from the provider (extended-thinking `thinking_delta`
+   * chunks are arriving). Flipped to `false` on the thinking block's
+   * `stream_end`. Renderers show a "Thinking…" label while `true` and "Thought"
+   * once `false`. Distinct from the connection-wide `streamingMessageId` (which
+   * tracks the visible response text), so a thinking bubble finalises its label
+   * independently of the response stream. Undefined on non-thinking bubbles and
+   * on the ephemeral `'thinking'` placeholder.
+   */
+  thinkingStreaming?: boolean;
+  /**
+   * #6756 — set to `true` once a thinking bubble's accumulated reasoning
+   * content hits {@link MAX_THINKING_CONTENT_LEN} and subsequent
+   * `thinking_delta` chunks are dropped. Mirrors `toolInputPartialTruncated`;
+   * a defence-in-depth bound so a runaway/adversarial thinking stream can't
+   * balloon client `messages` state. Renderers MAY surface a "truncated"
+   * affordance.
+   */
+  thinkingTruncated?: boolean;
   answered?: string;
   /**
    * #4973 — structured per-question answers map recorded when the user


### PR DESCRIPTION
## Problem

The model's extended-thinking / reasoning content was never surfaced in chat on any Chroxy client. The gap was in the data plane, not just display: **no provider forwarded thinking blocks over the wire**, so neither client had reasoning text to render.

- The dashboard's `ThinkingBody` disclosure was content-capable but unfed — the only `thinking`-typed message it ever got was the empty optimistic placeholder.
- Mobile's `MessageBubble` rendered a fixed animation for any thinking message and discarded `message.content`.
- `sdk-session.js` handled only `text` blocks/`text_delta`; a thinking `content_block_start` / `thinking_delta` was silently dropped.
- `byok-session.js` had no case for the already-translated `thinking_delta` kind — it fell to `default: break`.
- The protocol had no server→client channel carrying reasoning text.

Closes #6756.

## Approach

**Wire design — extend an existing message, no new type.** Added an optional `thinking?: boolean` flag to the existing `stream_start` / `stream_delta` / `stream_end` schemas rather than inventing a new server message type. A new type would have tripped the three coverage guards (ws-server `Server -> Client:` doc-block roster, protocol handler-coverage, store-core coverage-lint) and protocol-type-coverage; extending existing messages trips none of them (no new `z.literal`, no new `case`). Thinking uses a **distinct** `messageId` (`<turnId>-thinking-<n>`) so a thinking stream never collides with the response text stream, and the client's `filterThinking` still strips only the ephemeral placeholder (id `'thinking'`).

- **Streaming, block-scoped:** each thinking / `redacted_thinking` content block opens its own thinking stream and closes on `content_block_stop`, so interleaved thinking blocks stay ordered.
- **Redacted thinking** is forwarded as a `[redacted thinking]` marker — never silently dropped.
- **Label:** a per-message `thinkingStreaming` field (not the connection-wide `streamingMessageId`) drives the "Thinking…" → "Thought" label, so a thinking bubble finalises independently of the response stream and the turn's `'pending'` busy sentinel is untouched.
- **De-grouping:** `groupMessages` no longer absorbs `thinking` into tool activity groups. Now that thinking carries real content, each bubble renders standalone through the content-capable disclosure (dashboard `ThinkingBody` / mobile) instead of collapsing to a bare "Thinking" label inside a tool group. `countToolUses` / `summarizeToolCounts` already excluded thinking, so tool counts are unaffected.
- **Size guard:** thinking content is bounded at `MAX_THINKING_CONTENT_LEN` (= the existing 1 MiB `MAX_TOOL_INPUT_PARTIAL_LEN`) with a `thinkingTruncated` flag and idempotent drop — the same policy the streaming tool-input accumulator uses.

## Provider coverage

| Provider | Status |
|---|---|
| **claude SDK** (`sdk-session.js`) | ✅ forwards thinking / redacted_thinking content blocks + `thinking_delta` from the Agent SDK stream; full-assistant-message fallback for non-streamed thinking |
| **BYOK** (`byok-session.js`) | ✅ wires the translated `thinking_delta` through (was `default: break`) |
| **TUI / CLI / codex / gemini** | ⬜ out of scope — unchanged. codex's `reasoning/plan` items remain "Phase 1 ignored"; a follow-up can lift them onto the same wire flag |

Server-side coalescing of thinking deltas is a possible follow-up (thinking currently broadcasts per-token since the delta buffer can't carry the flag; it is collapsed-by-default so the frame cost is low).

## Testing

All in the isolated worktree, Node 22:

- **Protocol:** `npm run build` + full suite — 362 pass; dist staged.
- **store-core:** typecheck clean; full vitest — **1963 pass** (54 files), incl. new `handlers/thinking.test.ts` (8) + updated grouping tests + coverage-lint + protocol-type-coverage-lint.
- **dashboard:** typecheck clean; full vitest — **4455 pass** (260 files), incl. new `ChatView` ThinkingBody content/label tests + updated `useChatMessages` grouping test.
- **app:** `tsc --noEmit` clean; full jest — **2176 pass** (167 suites), incl. new `MessageBubble.thinking.test.tsx`.
- **server:** targeted `node --test` (sdk-session, byok-session, event-normalizer + 2 new thinking driver suites) — **413 pass**; both required custom lints (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`) OK; eslint clean on the changed server files.

New tests: SDK/BYOK driver tests mock the provider stream with thinking blocks and assert the distinct-id + `thinking:true` forwarding (incl. redacted marker + full-message fallback); store-core handler tests cover accumulate/lazy-create/bound/finalise; dashboard + mobile renderer tests cover the content disclosure and the streaming-vs-done label.
