### PR TITLE
feat(server,dashboard,app): selective checkpoint restore — files / conversation / both (#6767)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -896,6 +896,39 @@ describe('checkpoint_restored handler', () => {
 
     expect(switchSession).not.toHaveBeenCalled();
   });
+
+  // #6767/#6827 — a 'files'-mode restore keeps the current session, so instead
+  // of re-homing the client renders a visible system confirmation in the active
+  // session's transcript (a silent files-only rewind looked like nothing happened).
+  it("appends a files-restored system message (and does not switch) for a 'files'-mode restore", () => {
+    const switchSession = jest.fn();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+
+      switchSession,
+    } as any);
+
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'checkpoint_restored',
+      checkpointId: 'cp-1',
+      mode: 'files',
+      filesOnly: true,
+      name: 'Before refactor',
+    });
+
+    expect(switchSession).not.toHaveBeenCalled();
+    const messages = store.getState().sessionStates.s1.messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      type: 'system',
+      content: 'Files restored to checkpoint "Before refactor"',
+    });
+  });
 });
 
 describe('session_updated handler (#1381)', () => {

--- a/packages/app/src/components/CheckpointView.tsx
+++ b/packages/app/src/components/CheckpointView.tsx
@@ -11,13 +11,43 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { useConnectionStore } from '../store/connection';
-import type { Checkpoint } from '../store/types';
+import type { Checkpoint, RestoreCheckpointMode } from '../store/types';
 import { COLORS } from '../constants/colors';
 import { Icon } from './Icon';
 
 interface CheckpointViewProps {
   visible: boolean;
   onClose: () => void;
+}
+
+// #6767: selective restore-mode picker (default first).
+const RESTORE_MODES: RestoreCheckpointMode[] = ['both', 'files', 'conversation'];
+const RESTORE_MODE_LABEL: Record<RestoreCheckpointMode, string> = {
+  both: 'Both',
+  files: 'Files',
+  conversation: 'Conversation',
+};
+
+// Honest per-mode confirm copy — only 'files' keeps the current session.
+function restoreConfirmCopy(mode: RestoreCheckpointMode, name?: string): { title: string; message: string } {
+  const cp = name || 'checkpoint';
+  switch (mode) {
+    case 'files':
+      return {
+        title: 'Restore Files',
+        message: `Revert your working files to "${cp}"? Your conversation and session stay as they are.`,
+      };
+    case 'conversation':
+      return {
+        title: 'Restore Conversation',
+        message: `Branch the conversation from "${cp}" into a new session? Your working files stay as they are.`,
+      };
+    default:
+      return {
+        title: 'Restore Checkpoint',
+        message: `Revert your working files to "${cp}" and branch the conversation into a new session?`,
+      };
+  }
 }
 
 /** Format a timestamp into a readable date/time string */
@@ -117,7 +147,13 @@ export function CheckpointView({ visible, onClose }: CheckpointViewProps) {
   const listCheckpoints = useConnectionStore((s) => s.listCheckpoints);
   const deleteCheckpoint = useConnectionStore((s) => s.deleteCheckpoint);
   const restoreCheckpoint = useConnectionStore((s) => s.restoreCheckpoint);
+  // #6767: gate the "Conversation" restore-mode option on the active session's
+  // provider being able to fork/branch a resumed transcript.
+  const activeSessionId = useConnectionStore((s) => s.activeSessionId);
+  const sessions = useConnectionStore((s) => s.sessions);
+  const availableProviders = useConnectionStore((s) => s.availableProviders);
 
+  const [restoreMode, setRestoreMode] = useState<RestoreCheckpointMode>('both');
   const [showCreateInput, setShowCreateInput] = useState(false);
   const [newCheckpointName, setNewCheckpointName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
@@ -163,6 +199,18 @@ export function CheckpointView({ visible, onClose }: CheckpointViewProps) {
     }
   }, [visible, listCheckpoints]);
 
+  const canForkConversation = React.useMemo(() => {
+    const active = activeSessionId ? sessions.find((s) => s.sessionId === activeSessionId) : undefined;
+    const provider = active?.provider ?? null;
+    return availableProviders.find((p) => p.name === provider)?.capabilities?.conversationFork === true;
+  }, [activeSessionId, sessions, availableProviders]);
+
+  // #6767: if the picker is on 'conversation' but the active session can't fork
+  // (session switch, provider changed), fall back to the always-available 'both'.
+  useEffect(() => {
+    if (!canForkConversation && restoreMode === 'conversation') setRestoreMode('both');
+  }, [canForkConversation, restoreMode]);
+
   // Sort checkpoints in reverse chronological order
   const sortedCheckpoints = React.useMemo(
     () => [...checkpoints].sort((a, b) => b.createdAt - a.createdAt),
@@ -203,22 +251,19 @@ export function CheckpointView({ visible, onClose }: CheckpointViewProps) {
   const handleRestore = useCallback(
     (id: string) => {
       const cp = checkpoints.find((c) => c.id === id);
-      Alert.alert(
-        'Restore Checkpoint',
-        `Restore files to "${cp?.name || 'checkpoint'}"? Your working files will be reverted to this checkpoint and a new session will open.`,
-        [
-          { text: 'Cancel', style: 'cancel' },
-          {
-            text: 'Restore',
-            onPress: () => {
-              restoreCheckpoint(id);
-              onClose();
-            },
+      const { title, message } = restoreConfirmCopy(restoreMode, cp?.name);
+      Alert.alert(title, message, [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Restore',
+          onPress: () => {
+            restoreCheckpoint(id, restoreMode);
+            onClose();
           },
-        ],
-      );
+        },
+      ]);
     },
-    [checkpoints, restoreCheckpoint, onClose],
+    [checkpoints, restoreCheckpoint, restoreMode, onClose],
   );
 
   const renderItem = useCallback(
@@ -249,6 +294,43 @@ export function CheckpointView({ visible, onClose }: CheckpointViewProps) {
             >
               <Icon name="close" size={20} color={COLORS.textSecondary} />
             </TouchableOpacity>
+          </View>
+
+          {/* #6767: restore-mode picker — applies to the next Restore tap.
+              "Conversation" is disabled when the active session's provider can't
+              branch a resumed transcript. */}
+          <View style={styles.modePicker} testID="checkpoint-restore-mode">
+            <Text style={styles.modeLabel}>Restore:</Text>
+            {RESTORE_MODES.map((m) => {
+              const disabled = m === 'conversation' && !canForkConversation;
+              const active = restoreMode === m;
+              return (
+                <TouchableOpacity
+                  key={m}
+                  style={[
+                    styles.modeButton,
+                    active && styles.modeButtonActive,
+                    disabled && styles.modeButtonDisabled,
+                  ]}
+                  onPress={() => setRestoreMode(m)}
+                  disabled={disabled}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active, disabled }}
+                  accessibilityLabel={`Restore mode ${RESTORE_MODE_LABEL[m]}`}
+                  testID={`checkpoint-mode-${m}`}
+                >
+                  <Text
+                    style={[
+                      styles.modeButtonText,
+                      active && styles.modeButtonTextActive,
+                      disabled && styles.modeButtonTextDisabled,
+                    ]}
+                  >
+                    {RESTORE_MODE_LABEL[m]}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
           </View>
 
           {/* Create checkpoint area */}
@@ -360,6 +442,48 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
     color: COLORS.textPrimary,
+  },
+  // #6767: selective-restore mode picker
+  modePicker: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.borderPrimary,
+  },
+  modeLabel: {
+    fontSize: 13,
+    color: COLORS.textDim,
+    marginRight: 2,
+  },
+  modeButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: COLORS.borderPrimary,
+    backgroundColor: COLORS.backgroundCard,
+  },
+  modeButtonActive: {
+    backgroundColor: COLORS.accentBlueLight,
+    borderColor: COLORS.accentBlueBorder,
+  },
+  modeButtonDisabled: {
+    opacity: 0.4,
+  },
+  modeButtonText: {
+    fontSize: 13,
+    color: COLORS.textSecondary,
+    fontWeight: '500',
+  },
+  modeButtonTextActive: {
+    color: COLORS.accentBlue,
+  },
+  modeButtonTextDisabled: {
+    color: COLORS.textDim,
   },
   closeButton: {
     padding: 8,

--- a/packages/app/src/components/CheckpointView.tsx
+++ b/packages/app/src/components/CheckpointView.tsx
@@ -466,6 +466,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: COLORS.borderPrimary,
     backgroundColor: COLORS.backgroundCard,
+    // 44pt minimum touch target on both axes — matches the component's other
+    // controls (closeButton / deleteButton / createConfirmButton).
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   modeButtonActive: {
     backgroundColor: COLORS.accentBlueLight,

--- a/packages/app/src/components/__tests__/CheckpointView.test.tsx
+++ b/packages/app/src/components/__tests__/CheckpointView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Alert, Text } from 'react-native';
+import { Alert, StyleSheet, Text } from 'react-native';
 import { CheckpointView } from '../CheckpointView';
 import { useConnectionStore } from '../../store/connection';
 
@@ -261,6 +261,23 @@ describe('CheckpointView', () => {
       const conv = findByTestID(root!.root, 'checkpoint-mode-conversation');
       expect(conv.props.disabled).toBe(true);
       expect(conv.props.accessibilityState?.disabled).toBe(true);
+    });
+
+    // Copilot review on #6825: the picker buttons must meet the 44pt minimum
+    // touch target on BOTH axes, like the component's other controls
+    // (DiffHunkView convention: assert the flattened style's floor).
+    it('exposes ≥44pt touch targets on all mode buttons (accessibility min size)', () => {
+      setupStore(sampleCheckpoints, { canFork: true });
+      let root: renderer.ReactTestRenderer;
+      act(() => {
+        root = renderer.create(<CheckpointView visible={true} onClose={onClose} />);
+      });
+      for (const m of ['both', 'files', 'conversation']) {
+        const btn = findByTestID(root!.root, `checkpoint-mode-${m}`);
+        const flat = StyleSheet.flatten(btn.props.style);
+        expect(flat.minWidth).toBeGreaterThanOrEqual(44);
+        expect(flat.minHeight).toBeGreaterThanOrEqual(44);
+      }
     });
 
     it('enables Conversation and restores with it when the provider can fork', () => {

--- a/packages/app/src/components/__tests__/CheckpointView.test.tsx
+++ b/packages/app/src/components/__tests__/CheckpointView.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../store/connection', () => ({
 
 const mockUseConnectionStore = useConnectionStore as unknown as jest.Mock;
 
-function setupStore(checkpoints: any[] = []) {
+function setupStore(checkpoints: any[] = [], opts: { canFork?: boolean } = {}) {
   mockUseConnectionStore.mockImplementation((selector: any) => {
     const state = {
       checkpoints,
@@ -24,6 +24,14 @@ function setupStore(checkpoints: any[] = []) {
       restoreCheckpoint: mockRestoreCheckpoint,
       deleteCheckpoint: mockDeleteCheckpoint,
       createCheckpoint: mockCreateCheckpoint,
+      // #6767: restore-mode picker capability lookup. Default provider is a
+      // non-fork one (claude-tui) so 'Conversation' is disabled unless canFork.
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', provider: opts.canFork ? 'claude-sdk' : 'claude-tui' }],
+      availableProviders: [
+        { name: 'claude-sdk', capabilities: { conversationFork: true } },
+        { name: 'claude-tui', capabilities: {} },
+      ],
     };
     return selector(state);
   });
@@ -70,6 +78,11 @@ function findTextNodes(root: ReactTestInstance, text: string): ReactTestInstance
 /** Find a touchable by accessibilityLabel */
 function findByLabel(root: ReactTestInstance, label: string): ReactTestInstance {
   return root.findByProps({ accessibilityLabel: label });
+}
+
+/** Find an element by testID */
+function findByTestID(root: ReactTestInstance, id: string): ReactTestInstance {
+  return root.findByProps({ testID: id });
 }
 
 describe('CheckpointView', () => {
@@ -153,9 +166,10 @@ describe('CheckpointView', () => {
       findByLabel(root!.root, 'Restore checkpoint Initial setup').props.onPress();
     });
 
+    // #6767: default mode is 'both' — copy reflects files revert + conversation branch.
     expect(alertSpy).toHaveBeenCalledWith(
       'Restore Checkpoint',
-      'Restore files to "Initial setup"? Your working files will be reverted to this checkpoint and a new session will open.',
+      'Revert your working files to "Initial setup" and branch the conversation into a new session?',
       expect.arrayContaining([
         expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
         expect.objectContaining({ text: 'Restore' }),
@@ -182,7 +196,8 @@ describe('CheckpointView', () => {
     );
     restoreBtn?.onPress?.();
 
-    expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-2');
+    // #6767: default restore mode is 'both'.
+    expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-2', 'both');
     expect(onClose).toHaveBeenCalled();
   });
 
@@ -206,6 +221,68 @@ describe('CheckpointView', () => {
     expect(cancelBtn?.style).toBe('cancel');
     expect(mockRestoreCheckpoint).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // #6767 — selective restore-mode picker.
+  describe('restore-mode picker (#6767)', () => {
+    it("restores with 'files' mode when Files is picked (keeps the current session)", () => {
+      const alertSpy = jest.spyOn(Alert, 'alert');
+      setupStore(sampleCheckpoints);
+      let root: renderer.ReactTestRenderer;
+      act(() => {
+        root = renderer.create(<CheckpointView visible={true} onClose={onClose} />);
+      });
+
+      // Pick 'Files' mode, then tap Restore on cp-1.
+      act(() => {
+        findByTestID(root!.root, 'checkpoint-mode-files').props.onPress();
+      });
+      act(() => {
+        findByLabel(root!.root, 'Restore checkpoint Initial setup').props.onPress();
+      });
+
+      // Copy must be the files-only variant (no "new session" claim).
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Restore Files',
+        'Revert your working files to "Initial setup"? Your conversation and session stay as they are.',
+        expect.anything(),
+      );
+      const restoreBtn = alertSpy.mock.calls[0][2]?.find((b: any) => b.text === 'Restore');
+      restoreBtn?.onPress?.();
+      expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-1', 'files');
+    });
+
+    it('disables the Conversation option when the active provider cannot fork', () => {
+      setupStore(sampleCheckpoints, { canFork: false });
+      let root: renderer.ReactTestRenderer;
+      act(() => {
+        root = renderer.create(<CheckpointView visible={true} onClose={onClose} />);
+      });
+      const conv = findByTestID(root!.root, 'checkpoint-mode-conversation');
+      expect(conv.props.disabled).toBe(true);
+      expect(conv.props.accessibilityState?.disabled).toBe(true);
+    });
+
+    it('enables Conversation and restores with it when the provider can fork', () => {
+      const alertSpy = jest.spyOn(Alert, 'alert');
+      setupStore(sampleCheckpoints, { canFork: true });
+      let root: renderer.ReactTestRenderer;
+      act(() => {
+        root = renderer.create(<CheckpointView visible={true} onClose={onClose} />);
+      });
+      const conv = findByTestID(root!.root, 'checkpoint-mode-conversation');
+      expect(conv.props.disabled).toBe(false);
+
+      act(() => {
+        conv.props.onPress();
+      });
+      act(() => {
+        findByLabel(root!.root, 'Restore checkpoint Added auth').props.onPress();
+      });
+      const restoreBtn = alertSpy.mock.calls[0][2]?.find((b: any) => b.text === 'Restore');
+      restoreBtn?.onPress?.();
+      expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-2', 'conversation');
+    });
   });
 
   it('shows delete confirmation via Alert on delete press', () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -85,6 +85,7 @@ import type {
   ContextUsage,
   ContextOccupancy,
   MessageAttachment,
+  RestoreCheckpointMode,
   SavedConnection,
   SessionInfo,
   SessionState,
@@ -2467,8 +2468,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     sendIfOpen({ type: 'list_checkpoints' });
   },
 
-  restoreCheckpoint: (checkpointId: string) => {
-    sendIfOpen({ type: 'restore_checkpoint', checkpointId });
+  restoreCheckpoint: (checkpointId: string, mode?: RestoreCheckpointMode) => {
+    // #6767: only send `mode` for a non-default choice so the wire matches
+    // pre-#6767 for the common 'both' path.
+    sendIfOpen(
+      mode && mode !== 'both'
+        ? { type: 'restore_checkpoint', checkpointId, mode }
+        : { type: 'restore_checkpoint', checkpointId },
+    );
   },
 
   deleteCheckpoint: (checkpointId: string) => {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -202,7 +202,16 @@ export interface ProviderCapabilities {
   // Gates the multi-select checkbox affordance so the client doesn't offer a
   // form the server refuses.
   multiSelectReinject?: boolean;
+  // #6767: true when the provider can fork/branch a resumed conversation at a
+  // message boundary (SDK provider). Gates the checkpoint restore-mode picker's
+  // "Conversation" option — providers that can't fork omit it / report false.
+  conversationFork?: boolean;
 }
+
+// #6767: selective checkpoint-restore mode. 'files' reverts only the working
+// tree (current session/conversation continue), 'conversation' branches the
+// conversation at the checkpoint (working tree kept), 'both' does both (default).
+export type RestoreCheckpointMode = 'files' | 'conversation' | 'both';
 
 // #3404 audit (F1+F5): per-provider auth state for grey-out + billing detail.
 export interface ProviderAuth {
@@ -581,7 +590,10 @@ export interface DiscoveryActions {
 export interface CheckpointAndPlanActions {
   createCheckpoint: (name?: string) => void;
   listCheckpoints: () => void;
-  restoreCheckpoint: (checkpointId: string) => void;
+  // #6767: selective restore — 'files' reverts only the working tree (current
+  // session continues), 'conversation' branches the conversation (files kept),
+  // 'both' (default) does both. Omitted → server default 'both'.
+  restoreCheckpoint: (checkpointId: string, mode?: RestoreCheckpointMode) => void;
   deleteCheckpoint: (checkpointId: string) => void;
   clearPlanState: () => void;
   sendPlanResponse: (sessionId: string, approve: boolean) => void;

--- a/packages/dashboard/src/components/CheckpointTimeline.edge.test.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.edge.test.tsx
@@ -28,6 +28,10 @@ vi.mock('../store/connection', () => ({
       restoreCheckpoint: mockRestoreCheckpoint,
       deleteCheckpoint: mockDeleteCheckpoint,
       connectionPhase: storeState.connectionPhase ?? 'connected',
+      // #6767: restore-mode picker capability lookup.
+      activeSessionId: storeState.activeSessionId ?? null,
+      sessions: storeState.sessions ?? [],
+      availableProviders: storeState.availableProviders ?? [],
     }
     return selector(store)
   },

--- a/packages/dashboard/src/components/CheckpointTimeline.test.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.test.tsx
@@ -21,10 +21,27 @@ vi.mock('../store/connection', () => ({
       restoreCheckpoint: mockRestoreCheckpoint,
       deleteCheckpoint: mockDeleteCheckpoint,
       connectionPhase: storeState.connectionPhase ?? 'connected',
+      // #6767: restore-mode picker capability lookup.
+      activeSessionId: storeState.activeSessionId ?? null,
+      sessions: storeState.sessions ?? [],
+      availableProviders: storeState.availableProviders ?? [],
     }
     return selector(store)
   },
 }))
+
+// #6767: an active session whose provider CAN branch the conversation.
+const FORK_CAPABLE = {
+  activeSessionId: 's1',
+  sessions: [{ sessionId: 's1', provider: 'claude-sdk' }],
+  availableProviders: [{ name: 'claude-sdk', capabilities: { conversationFork: true } }],
+}
+// A provider that CANNOT fork (the default when nothing is set, made explicit).
+const NON_FORK = {
+  activeSessionId: 's1',
+  sessions: [{ sessionId: 's1', provider: 'claude-tui' }],
+  availableProviders: [{ name: 'claude-tui', capabilities: {} }],
+}
 
 afterEach(() => cleanup())
 
@@ -88,12 +105,49 @@ describe('CheckpointTimeline', () => {
     expect(screen.getByText('85 msgs')).toBeTruthy()
   })
 
-  it('calls restoreCheckpoint when Restore is clicked', () => {
+  it('calls restoreCheckpoint with the default mode (both) when Restore is clicked', () => {
     storeState.checkpoints = [CHECKPOINTS[0]!]
     render(<CheckpointTimeline />)
 
     fireEvent.click(screen.getByText('Restore'))
-    expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-1')
+    // #6767: default restore mode is 'both'.
+    expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-1', 'both')
+  })
+
+  // #6767 — selective restore-mode picker.
+  describe('restore-mode picker (#6767)', () => {
+    it('renders the three restore modes with Both selected by default', () => {
+      storeState.checkpoints = [CHECKPOINTS[0]!]
+      render(<CheckpointTimeline />)
+      expect(screen.getByTestId('checkpoint-mode-both').getAttribute('aria-pressed')).toBe('true')
+      expect(screen.getByTestId('checkpoint-mode-files').getAttribute('aria-pressed')).toBe('false')
+      expect(screen.getByTestId('checkpoint-mode-conversation').getAttribute('aria-pressed')).toBe('false')
+    })
+
+    it('restores with the chosen mode (files) — keeps the current session', () => {
+      storeState.checkpoints = [CHECKPOINTS[0]!]
+      render(<CheckpointTimeline />)
+      fireEvent.click(screen.getByTestId('checkpoint-mode-files'))
+      fireEvent.click(screen.getByText('Restore'))
+      expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-1', 'files')
+    })
+
+    it('disables Conversation when the active session provider cannot fork', () => {
+      Object.assign(storeState, NON_FORK, { checkpoints: [CHECKPOINTS[0]!] })
+      render(<CheckpointTimeline />)
+      const conv = screen.getByTestId('checkpoint-mode-conversation') as HTMLButtonElement
+      expect(conv.disabled).toBe(true)
+    })
+
+    it('enables Conversation and restores with it when the provider can fork', () => {
+      Object.assign(storeState, FORK_CAPABLE, { checkpoints: [CHECKPOINTS[0]!] })
+      render(<CheckpointTimeline />)
+      const conv = screen.getByTestId('checkpoint-mode-conversation') as HTMLButtonElement
+      expect(conv.disabled).toBe(false)
+      fireEvent.click(conv)
+      fireEvent.click(screen.getByText('Restore'))
+      expect(mockRestoreCheckpoint).toHaveBeenCalledWith('cp-1', 'conversation')
+    })
   })
 
   it('shows delete confirmation on Delete click', () => {

--- a/packages/dashboard/src/components/CheckpointTimeline.tsx
+++ b/packages/dashboard/src/components/CheckpointTimeline.tsx
@@ -9,7 +9,26 @@
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useConnectionStore } from '../store/connection'
-import type { Checkpoint } from '../store/types'
+import type { Checkpoint, RestoreCheckpointMode } from '../store/types'
+
+// #6767: selective restore-mode picker. Order = display order (default first).
+const RESTORE_MODES: RestoreCheckpointMode[] = ['both', 'files', 'conversation']
+const RESTORE_MODE_LABEL: Record<RestoreCheckpointMode, string> = {
+  both: 'Both',
+  files: 'Files',
+  conversation: 'Conversation',
+}
+const RESTORE_MODE_TITLE: Record<RestoreCheckpointMode, string> = {
+  both: 'Revert the working files and branch the conversation into a new session',
+  files: 'Revert only the working files — this conversation and session continue',
+  conversation: 'Branch the conversation into a new session — the working files are left as they are',
+}
+// Honest per-mode Restore-button tooltip (only 'files' keeps the current session).
+const RESTORE_BUTTON_TITLE: Record<RestoreCheckpointMode, string> = {
+  both: 'Restore files and branch the conversation (opens a new session)',
+  files: 'Restore files only (keeps this conversation and session)',
+  conversation: 'Branch the conversation to this checkpoint (opens a new session)',
+}
 
 function formatTimestamp(ms: number): string {
   const d = new Date(ms)
@@ -47,10 +66,12 @@ interface CheckpointNodeProps {
   onDelete: (id: string) => void
   confirmingDelete: string | null
   setConfirmingDelete: (id: string | null) => void
+  // #6767: tooltip reflecting the currently-selected restore mode.
+  restoreButtonTitle: string
 }
 
 function CheckpointNode({
-  checkpoint, isLatest, onRestore, onDelete, confirmingDelete, setConfirmingDelete,
+  checkpoint, isLatest, onRestore, onDelete, confirmingDelete, setConfirmingDelete, restoreButtonTitle,
 }: CheckpointNodeProps) {
   const isConfirming = confirmingDelete === checkpoint.id
   // #3484: trim guard on the name fallback. A whitespace-only
@@ -102,7 +123,7 @@ function CheckpointNode({
             type="button"
             className="cp-btn cp-restore"
             onClick={() => onRestore(checkpoint.id)}
-            title="Restore files to this checkpoint (opens a new session)"
+            title={restoreButtonTitle}
           >
             Restore
           </button>
@@ -146,10 +167,30 @@ export function CheckpointTimeline() {
   const restoreCheckpoint = useConnectionStore(s => s.restoreCheckpoint)
   const deleteCheckpoint = useConnectionStore(s => s.deleteCheckpoint)
   const connectionPhase = useConnectionStore(s => s.connectionPhase)
+  // #6767: gate the "Conversation" restore-mode option on the active session's
+  // provider being able to fork/branch a resumed transcript. Mirrors the
+  // sessionRules / auto-mode-confirm capability lookups elsewhere in the store.
+  const activeSessionId = useConnectionStore(s => s.activeSessionId)
+  const sessions = useConnectionStore(s => s.sessions)
+  const availableProviders = useConnectionStore(s => s.availableProviders)
 
   const [newName, setNewName] = useState('')
   const [creating, setCreating] = useState(false)
   const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null)
+  const [restoreMode, setRestoreMode] = useState<RestoreCheckpointMode>('both')
+
+  const canForkConversation = useMemo(() => {
+    const active = activeSessionId ? sessions.find(s => s.sessionId === activeSessionId) : undefined
+    const provider = active?.provider ?? null
+    return availableProviders.find(p => p.name === provider)?.capabilities?.conversationFork === true
+  }, [activeSessionId, sessions, availableProviders])
+
+  // #6767: if the picker lands on 'conversation' but the active session can't
+  // fork (session switch, or a fork-capable provider that just went away), fall
+  // back to the always-available 'both'.
+  useEffect(() => {
+    if (!canForkConversation && restoreMode === 'conversation') setRestoreMode('both')
+  }, [canForkConversation, restoreMode])
 
   // Load checkpoints on mount
   useEffect(() => {
@@ -172,8 +213,8 @@ export function CheckpointTimeline() {
   }, [newName, createCheckpoint])
 
   const handleRestore = useCallback((id: string) => {
-    restoreCheckpoint(id)
-  }, [restoreCheckpoint])
+    restoreCheckpoint(id, restoreMode)
+  }, [restoreCheckpoint, restoreMode])
 
   const handleDelete = useCallback((id: string) => {
     deleteCheckpoint(id)
@@ -181,6 +222,32 @@ export function CheckpointTimeline() {
 
   return (
     <div className="checkpoint-timeline" data-testid="checkpoint-timeline">
+      {/* #6767: restore-mode picker — applied to whichever checkpoint's Restore
+          button is clicked. 'Conversation' is disabled when the active session's
+          provider can't branch a resumed transcript. */}
+      <div className="cp-mode-picker" data-testid="checkpoint-restore-mode" role="group" aria-label="Restore mode">
+        <span className="cp-mode-label">Restore:</span>
+        {RESTORE_MODES.map((m) => {
+          const disabled = m === 'conversation' && !canForkConversation
+          return (
+            <button
+              key={m}
+              type="button"
+              className={`cp-btn cp-mode-btn${restoreMode === m ? ' cp-mode-active' : ''}`}
+              data-testid={`checkpoint-mode-${m}`}
+              aria-pressed={restoreMode === m}
+              disabled={disabled}
+              title={disabled
+                ? "This session's provider can't branch the conversation — use Files or Both"
+                : RESTORE_MODE_TITLE[m]}
+              onClick={() => setRestoreMode(m)}
+            >
+              {RESTORE_MODE_LABEL[m]}
+            </button>
+          )
+        })}
+      </div>
+
       {/* Create checkpoint */}
       <div className="cp-create-section">
         {creating ? (
@@ -228,6 +295,7 @@ export function CheckpointTimeline() {
               onDelete={handleDelete}
               confirmingDelete={confirmingDelete}
               setConfirmingDelete={setConfirmingDelete}
+              restoreButtonTitle={RESTORE_BUTTON_TITLE[restoreMode]}
             />
           ))}
         </div>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -48,6 +48,7 @@ export type {
   ConversationSummary,
   SearchResult,
   ConnectionState,
+  RestoreCheckpointMode,
 } from './types';
 
 // Re-export utility functions for backward compatibility
@@ -62,6 +63,7 @@ import type {
   ConnectionContext,
   ConnectionState,
   InputSettings,
+  RestoreCheckpointMode,
   ServerEntry,
   SessionInfo,
   SessionState,
@@ -4223,10 +4225,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
-  restoreCheckpoint: (checkpointId: string) => {
+  restoreCheckpoint: (checkpointId: string, mode?: RestoreCheckpointMode) => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
-      wsSend(socket, { type: 'restore_checkpoint', checkpointId });
+      // #6767: only send `mode` when the caller picked a non-default one, so the
+      // wire stays identical to pre-#6767 for the common 'both' path.
+      const msg: { type: 'restore_checkpoint'; checkpointId: string; mode?: RestoreCheckpointMode } = {
+        type: 'restore_checkpoint',
+        checkpointId,
+      };
+      if (mode && mode !== 'both') msg.mode = mode;
+      wsSend(socket, msg);
     }
   },
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -6435,3 +6435,56 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 })
+
+// #6767/#6827 — a 'files'-mode checkpoint restore keeps the CURRENT session, so
+// the dispatch renders a visible system confirmation in the active session's
+// transcript instead of re-homing (a silent files-only rewind looked like
+// nothing happened client-side).
+describe("checkpoint_restored (mode 'files') confirmation (#6827)", () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSocket = createMockSocket()
+  })
+
+  it('appends a files-restored system message to the active session and does not switch', () => {
+    const switchSession = vi.fn()
+    store = createMockStore(
+      baseState({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        switchSession,
+      } as any),
+    )
+    setStore(store)
+
+    handleMessage(
+      {
+        type: 'checkpoint_restored',
+        checkpointId: 'cp-1',
+        mode: 'files',
+        filesOnly: true,
+        name: 'Before refactor',
+      } as any,
+      ctx() as any,
+    )
+
+    expect(switchSession).not.toHaveBeenCalled()
+    const ss = (store.getState() as any).sessionStates.s1
+    expect(ss.messages).toHaveLength(1)
+    expect(ss.messages[0]).toMatchObject({
+      type: 'system',
+      content: 'Files restored to checkpoint "Before refactor"',
+    })
+  })
+})

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -131,6 +131,11 @@ export interface EnvironmentInfo {
   cpuLimit: string;
 }
 
+// #6767: selective checkpoint-restore mode. 'files' reverts only the working
+// tree (current session/conversation continue), 'conversation' branches the
+// conversation at the checkpoint (working tree kept), 'both' does both (default).
+export type RestoreCheckpointMode = 'files' | 'conversation' | 'both';
+
 export interface ProviderCapabilities {
   permissions: boolean;
   inProcessPermissions: boolean;
@@ -166,6 +171,11 @@ export interface ProviderCapabilities {
   // Gates the multi-select checkbox affordance so the client doesn't offer a
   // form the server refuses.
   multiSelectReinject?: boolean;
+  // #6767: true when the provider can fork/branch a resumed conversation at a
+  // message boundary (SDK provider). Gates the checkpoint restore-mode picker's
+  // "Conversation" option — providers that can't fork (CLI/TUI/BYOK/Gemini/Codex
+  // and containerized SDK) omit it / report false, so the option is disabled.
+  conversationFork?: boolean;
 }
 
 // #3404 audit (F1+F5): per-provider auth state for grey-out + billing panel.
@@ -1549,7 +1559,10 @@ export interface ConnectionState {
   // Checkpoint actions
   createCheckpoint: (name?: string) => void;
   listCheckpoints: () => void;
-  restoreCheckpoint: (checkpointId: string) => void;
+  // #6767: selective restore — 'files' reverts only the working tree (current
+  // session continues), 'conversation' branches the conversation (files kept),
+  // 'both' (default) does both. Omitted → server default 'both'.
+  restoreCheckpoint: (checkpointId: string, mode?: RestoreCheckpointMode) => void;
   deleteCheckpoint: (checkpointId: string) => void;
 
   // Plan mode actions

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2494,6 +2494,40 @@ button.sidebar-token-view-session-row:hover {
 
 .cp-create-btn:hover { background: #2563eb; }
 
+/* #6767: selective-restore mode picker */
+.cp-mode-picker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.cp-mode-label {
+  font-size: var(--text-sm);
+  color: var(--text-dim);
+  margin-right: 2px;
+}
+
+.cp-mode-btn {
+  padding: 3px 9px;
+}
+
+.cp-mode-active {
+  background: var(--accent-blue);
+  color: #fff;
+  border-color: var(--accent-blue);
+}
+
+.cp-mode-active:hover { background: #2563eb; }
+
+.cp-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.cp-btn:disabled:hover { background: var(--bg-primary); }
+
 .cp-empty {
   text-align: center;
   color: var(--text-dim);

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -550,6 +550,11 @@ export declare const ListCheckpointsSchema: z.ZodObject<{
 export declare const RestoreCheckpointSchema: z.ZodObject<{
     type: z.ZodLiteral<"restore_checkpoint">;
     checkpointId: z.ZodString;
+    mode: z.ZodOptional<z.ZodEnum<{
+        files: "files";
+        conversation: "conversation";
+        both: "both";
+    }>>;
 }, z.core.$strip>;
 export declare const CreateCheckpointSchema: z.ZodObject<{
     type: z.ZodLiteral<"create_checkpoint">;
@@ -1167,6 +1172,11 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"restore_checkpoint">;
     checkpointId: z.ZodString;
+    mode: z.ZodOptional<z.ZodEnum<{
+        files: "files";
+        conversation: "conversation";
+        both: "both";
+    }>>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"create_checkpoint">;
     name: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -728,6 +728,12 @@ export const ListCheckpointsSchema = z.object({
 export const RestoreCheckpointSchema = z.object({
     type: z.literal('restore_checkpoint'),
     checkpointId: z.string().max(256),
+    // #6767: selective restore. 'files' reverts only the working tree (current
+    // session/conversation continue — no new session); 'conversation' branches
+    // the conversation at the checkpoint (working tree untouched — fork-capable
+    // providers only, else rejected); 'both' (default, and the pre-#6767
+    // behaviour) does both. Optional so older clients that omit it get 'both'.
+    mode: z.enum(['files', 'conversation', 'both']).optional(),
 });
 export const CreateCheckpointSchema = z.object({
     type: z.literal('create_checkpoint'),

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -429,9 +429,14 @@ export declare const ServerCheckpointListSchema: z.ZodObject<{
 export declare const ServerCheckpointRestoredSchema: z.ZodObject<{
     type: z.ZodLiteral<"checkpoint_restored">;
     checkpointId: z.ZodString;
-    newSessionId: z.ZodString;
-    name: z.ZodString;
+    newSessionId: z.ZodOptional<z.ZodString>;
+    name: z.ZodOptional<z.ZodString>;
     filesOnly: z.ZodOptional<z.ZodBoolean>;
+    mode: z.ZodOptional<z.ZodEnum<{
+        files: "files";
+        conversation: "conversation";
+        both: "both";
+    }>>;
 }, z.core.$strip>;
 export declare const ServerSessionWarningSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_warning">;

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -542,20 +542,28 @@ export const ServerCheckpointListSchema = z.object({
     sessionId: z.string().nullable(),
     checkpoints: z.array(CheckpointSchema),
 });
-// NOTE: checkpoint_restored keys are exactly { type, checkpointId,
-// newSessionId, name, filesOnly? } — no `sessionId`. `newSessionId` is the
-// fresh session the restore created; the client re-homes to it via
-// switchSession. `filesOnly` (#6766) is true when only the working tree was
-// restored and the conversation was NOT branched (the provider can't fork /
-// truncate a resumed transcript); false when the conversation was forked and
-// truncated to the checkpoint. Optional for back-compat with older servers
-// that never branched — a missing value is treated as files-only.
+// NOTE: checkpoint_restored keys are { type, checkpointId, newSessionId?,
+// name?, filesOnly?, mode? } — no `sessionId`. `newSessionId` is the fresh
+// session a restore created; the client re-homes to it via switchSession.
+// `filesOnly` (#6766) is true when only the working tree was restored and the
+// conversation was NOT branched (the provider can't fork / truncate a resumed
+// transcript); false when the conversation was forked and truncated to the
+// checkpoint. Optional for back-compat with older servers that never branched
+// — a missing value is treated as files-only.
+//
+// #6767: `mode` echoes the selective-restore mode the server ran ('files' |
+// 'conversation' | 'both'). `newSessionId`/`name` are now OPTIONAL: a 'files'
+// restore reverts only the working tree and keeps the CURRENT session (no new
+// session, no re-home), so it omits both — 'conversation' and 'both' still
+// create and re-home to a rewound session and carry them. Optional so older
+// servers (which always created a new session) round-trip unchanged.
 export const ServerCheckpointRestoredSchema = z.object({
     type: z.literal('checkpoint_restored'),
     checkpointId: z.string(),
-    newSessionId: z.string(),
-    name: z.string(),
+    newSessionId: z.string().optional(),
+    name: z.string().optional(),
     filesOnly: z.boolean().optional(),
+    mode: z.enum(['files', 'conversation', 'both']).optional(),
 });
 // #6332 (batch 2b of #6314): idle-timeout lifecycle. `session_warning` is the
 // pre-timeout notice; `session_timeout` fires at close. NOTE the time field

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -554,9 +554,12 @@ export const ServerCheckpointListSchema = z.object({
 // #6767: `mode` echoes the selective-restore mode the server ran ('files' |
 // 'conversation' | 'both'). `newSessionId`/`name` are now OPTIONAL: a 'files'
 // restore reverts only the working tree and keeps the CURRENT session (no new
-// session, no re-home), so it omits both — 'conversation' and 'both' still
-// create and re-home to a rewound session and carry them. Optional so older
-// servers (which always created a new session) round-trip unchanged.
+// session, no re-home), so it omits `newSessionId` — but carries `name` as the
+// CHECKPOINT's name so the client can render a visible "files restored"
+// confirmation (#6827). 'conversation' and 'both' still create and re-home to
+// a rewound session and carry both (`name` = the new session's name there).
+// Optional so older servers (which always created a new session) round-trip
+// unchanged.
 export const ServerCheckpointRestoredSchema = z.object({
     type: z.literal('checkpoint_restored'),
     checkpointId: z.string(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -822,6 +822,12 @@ export const ListCheckpointsSchema = z.object({
 export const RestoreCheckpointSchema = z.object({
   type: z.literal('restore_checkpoint'),
   checkpointId: z.string().max(256),
+  // #6767: selective restore. 'files' reverts only the working tree (current
+  // session/conversation continue — no new session); 'conversation' branches
+  // the conversation at the checkpoint (working tree untouched — fork-capable
+  // providers only, else rejected); 'both' (default, and the pre-#6767
+  // behaviour) does both. Optional so older clients that omit it get 'both'.
+  mode: z.enum(['files', 'conversation', 'both']).optional(),
 })
 
 export const CreateCheckpointSchema = z.object({

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -577,20 +577,28 @@ export const ServerCheckpointListSchema = z.object({
   checkpoints: z.array(CheckpointSchema),
 })
 
-// NOTE: checkpoint_restored keys are exactly { type, checkpointId,
-// newSessionId, name, filesOnly? } — no `sessionId`. `newSessionId` is the
-// fresh session the restore created; the client re-homes to it via
-// switchSession. `filesOnly` (#6766) is true when only the working tree was
-// restored and the conversation was NOT branched (the provider can't fork /
-// truncate a resumed transcript); false when the conversation was forked and
-// truncated to the checkpoint. Optional for back-compat with older servers
-// that never branched — a missing value is treated as files-only.
+// NOTE: checkpoint_restored keys are { type, checkpointId, newSessionId?,
+// name?, filesOnly?, mode? } — no `sessionId`. `newSessionId` is the fresh
+// session a restore created; the client re-homes to it via switchSession.
+// `filesOnly` (#6766) is true when only the working tree was restored and the
+// conversation was NOT branched (the provider can't fork / truncate a resumed
+// transcript); false when the conversation was forked and truncated to the
+// checkpoint. Optional for back-compat with older servers that never branched
+// — a missing value is treated as files-only.
+//
+// #6767: `mode` echoes the selective-restore mode the server ran ('files' |
+// 'conversation' | 'both'). `newSessionId`/`name` are now OPTIONAL: a 'files'
+// restore reverts only the working tree and keeps the CURRENT session (no new
+// session, no re-home), so it omits both — 'conversation' and 'both' still
+// create and re-home to a rewound session and carry them. Optional so older
+// servers (which always created a new session) round-trip unchanged.
 export const ServerCheckpointRestoredSchema = z.object({
   type: z.literal('checkpoint_restored'),
   checkpointId: z.string(),
-  newSessionId: z.string(),
-  name: z.string(),
+  newSessionId: z.string().optional(),
+  name: z.string().optional(),
   filesOnly: z.boolean().optional(),
+  mode: z.enum(['files', 'conversation', 'both']).optional(),
 })
 
 // #6332 (batch 2b of #6314): idle-timeout lifecycle. `session_warning` is the

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -589,9 +589,12 @@ export const ServerCheckpointListSchema = z.object({
 // #6767: `mode` echoes the selective-restore mode the server ran ('files' |
 // 'conversation' | 'both'). `newSessionId`/`name` are now OPTIONAL: a 'files'
 // restore reverts only the working tree and keeps the CURRENT session (no new
-// session, no re-home), so it omits both — 'conversation' and 'both' still
-// create and re-home to a rewound session and carry them. Optional so older
-// servers (which always created a new session) round-trip unchanged.
+// session, no re-home), so it omits `newSessionId` — but carries `name` as the
+// CHECKPOINT's name so the client can render a visible "files restored"
+// confirmation (#6827). 'conversation' and 'both' still create and re-home to
+// a rewound session and carry both (`name` = the new session's name there).
+// Optional so older servers (which always created a new session) round-trip
+// unchanged.
 export const ServerCheckpointRestoredSchema = z.object({
   type: z.literal('checkpoint_restored'),
   checkpointId: z.string(),

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -70,6 +70,13 @@ async function acquireCwdLock(cwd) {
  * rewound session's transcript stops at the checkpoint. For providers that
  * cannot truncate a resumed transcript the restore is files-only. The
  * `boundaryMessageId` captured here is what makes that truncation possible.
+ *
+ * #6767: selective restore (files / conversation / both) is orchestrated by the
+ * WS handler, not this manager. `restoreCheckpoint` always performs the git
+ * restore (used for the 'files' and 'both' modes); the 'conversation'-only mode
+ * reads the checkpoint via `getCheckpoint` instead so the working tree is left
+ * untouched. Either way the returned record carries `resumeSessionId` +
+ * `boundaryMessageId` for the handler's fork decision.
  */
 export class CheckpointManager extends EventEmitter {
   /**

--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -32,7 +32,12 @@ const log = createLogger('docker-sdk')
  */
 export class DockerSdkSession extends SdkSession {
   static get capabilities() {
-    return { ...SdkSession.capabilities, containerized: true }
+    // #6767: the transcript for a containerized session lives inside the
+    // container, so the host-side conversation fork can't reach it — restore
+    // degrades to files-only here (mirrors the instance-level
+    // `supportsConversationFork` getter below). Advertise conversationFork:false
+    // so the checkpoint UI disables the "Conversation" restore-mode option.
+    return { ...SdkSession.capabilities, containerized: true, conversationFork: false }
   }
 
   /**

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -92,11 +92,34 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
     sendSessionError(ws, ctx, 'Missing checkpointId')
     return
   }
+  // #6767: selective restore mode. 'files' reverts only the working tree and
+  // keeps the CURRENT session/conversation (no fork, no new session); 'conversation'
+  // branches the conversation at the checkpoint and leaves the working tree
+  // untouched (fork-capable providers only); 'both' (the default and the pre-#6767
+  // behaviour) does both. Any unknown value falls back to 'both'.
+  const mode = msg.mode === 'files' || msg.mode === 'conversation' || msg.mode === 'both' ? msg.mode : 'both'
   const currentEntry = ctx.sessions.sessionManager.getSession(sid)
   if (currentEntry?.session?.isRunning) {
     sendSessionError(ws, ctx, 'Cannot restore checkpoint while session is busy. Wait for the current task to finish or interrupt first.')
     return
   }
+  // #6767: whether the ORIGINAL session's provider can branch the conversation.
+  const origSession = currentEntry?.session
+  const forkCapable = !!(
+    origSession &&
+    origSession.supportsConversationFork === true &&
+    typeof origSession.forkConversation === 'function'
+  )
+  // #6767: 'conversation' mode is meaningless on a provider that can't fork a
+  // resumed transcript — reject clearly rather than silently doing nothing (or
+  // a misleading full-transcript resume). 'files'/'both' still work everywhere.
+  if (mode === 'conversation' && !forkCapable) {
+    sendSessionError(ws, ctx, "This session's provider can't restore the conversation only — it can't branch a resumed transcript. Use \"Files\" or \"Both\" instead.")
+    return
+  }
+  // #6767: only 'files'/'both' hard-reset the working tree. 'conversation' leaves
+  // it untouched, so it neither needs the shared-cwd guard below nor the git restore.
+  const restoreFiles = mode !== 'conversation'
   // #5731 T8 (confirms deferred #5700): restoring hard-resets the working tree
   // at the checkpoint's cwd. If ANOTHER non-destroying session shares that cwd
   // (the default for non-worktree sessions) and is mid-turn, the reset yanks
@@ -110,48 +133,63 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
   // and the whole scan is wrapped so an unexpected accessor failure (throw or a
   // non-array return) fails OPEN — the guard is defense-in-depth, so on its own
   // error we fall through to the normal restore (the pre-#5731 behaviour) rather
-  // than crashing the WS message handler.
-  try {
-    const checkpointMgr = ctx.services.checkpointManager
-    const sessionMgr = ctx.sessions.sessionManager
-    if (typeof checkpointMgr.getCheckpoint === 'function' && typeof sessionMgr.listSessions === 'function') {
-      const cp = checkpointMgr.getCheckpoint(sid, msg.checkpointId)
-      const liveSessions = sessionMgr.listSessions()
-      if (cp?.cwd && Array.isArray(liveSessions)) {
-        const targetCwd = normalizeCwd(cp.cwd)
-        const busyShare = liveSessions.find(
-          (s) => s && s.sessionId !== sid && s.isBusy && normalizeCwd(s.cwd) === targetCwd,
-        )
-        if (busyShare) {
-          sendSessionError(ws, ctx, `Cannot restore checkpoint: another session ("${busyShare.name}") is busy in the same working directory and would lose its in-progress changes. Wait for it to finish or interrupt it first.`)
-          return
+  // than crashing the WS message handler. Skipped entirely for 'conversation'
+  // mode (#6767), which never touches the working tree.
+  if (restoreFiles) {
+    try {
+      const checkpointMgr = ctx.services.checkpointManager
+      const sessionMgr = ctx.sessions.sessionManager
+      if (typeof checkpointMgr.getCheckpoint === 'function' && typeof sessionMgr.listSessions === 'function') {
+        const cp = checkpointMgr.getCheckpoint(sid, msg.checkpointId)
+        const liveSessions = sessionMgr.listSessions()
+        if (cp?.cwd && Array.isArray(liveSessions)) {
+          const targetCwd = normalizeCwd(cp.cwd)
+          const busyShare = liveSessions.find(
+            (s) => s && s.sessionId !== sid && s.isBusy && normalizeCwd(s.cwd) === targetCwd,
+          )
+          if (busyShare) {
+            sendSessionError(ws, ctx, `Cannot restore checkpoint: another session ("${busyShare.name}") is busy in the same working directory and would lose its in-progress changes. Wait for it to finish or interrupt it first.`)
+            return
+          }
         }
       }
+    } catch (err) {
+      log.warn(`Shared-cwd restore guard skipped (accessor error, failing open): ${err?.message || err}`)
     }
-  } catch (err) {
-    log.warn(`Shared-cwd restore guard skipped (accessor error, failing open): ${err?.message || err}`)
   }
   try {
-    const checkpoint = await ctx.services.checkpointManager.restoreCheckpoint(sid, msg.checkpointId)
+    // #6767: 'files'/'both' restore the git snapshot; 'conversation' reads the
+    // checkpoint WITHOUT touching the working tree.
+    let checkpoint
+    if (restoreFiles) {
+      checkpoint = await ctx.services.checkpointManager.restoreCheckpoint(sid, msg.checkpointId)
+    } else {
+      checkpoint = ctx.services.checkpointManager.getCheckpoint(sid, msg.checkpointId)
+      if (!checkpoint) throw new Error(`Checkpoint not found: ${msg.checkpointId}`)
+    }
 
-    // #6766: decide whether this rewind can truly branch the conversation or is
-    // files-only. A real branch needs (a) a fork-capable provider on the ORIGINAL
-    // session and (b) a captured fork boundary. When both hold, fork the
+    // #6766/#6767: decide whether this rewind branches the conversation. A real
+    // branch needs (a) a fork-capable provider on the ORIGINAL session, (b) a
+    // captured fork boundary, and (c) a mode that includes the conversation
+    // ('conversation'/'both'; 'files' never forks). When they hold, fork the
     // conversation truncated to the boundary so the rewound session resumes AT
     // the checkpoint's point (not the full latest transcript); otherwise resume
     // the checkpoint's conversation id unchanged and report the restore as
     // files-only so the UI never claims a conversation rewind it didn't do.
-    const origSession = currentEntry?.session
     const boundaryMessageId = checkpoint.boundaryMessageId
+    const hasBoundary = typeof boundaryMessageId === 'string' && boundaryMessageId.length > 0
+    // #6767: a 'conversation'-only rewind has no file restore to fall back on, so
+    // a checkpoint with no branch point (created before fork support) can't be
+    // honored — reject instead of resuming the full latest transcript with no
+    // change. 'both' still degrades to files-only in that case (below).
+    if (mode === 'conversation' && !hasBoundary) {
+      sendSessionError(ws, ctx, 'This checkpoint has no conversation branch point (it predates conversation-fork support). Use "Files" or "Both" instead.')
+      return
+    }
+    const branchConversation = mode !== 'files'
     let resumeSessionId = checkpoint.resumeSessionId
     let filesOnly = true
-    if (
-      origSession &&
-      origSession.supportsConversationFork === true &&
-      typeof origSession.forkConversation === 'function' &&
-      typeof boundaryMessageId === 'string' &&
-      boundaryMessageId.length > 0
-    ) {
+    if (branchConversation && forkCapable && hasBoundary) {
       try {
         const forkedId = await origSession.forkConversation({
           sessionId: checkpoint.resumeSessionId,
@@ -166,6 +204,27 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       } catch (err) {
         log.warn(`Checkpoint conversation fork failed, restoring files only: ${err.message}`)
       }
+    }
+    // #6767: a 'conversation'-only rewind that failed to branch would create a
+    // misleading full-transcript session with no file change — surface the
+    // failure instead. (Verified fork-capable + boundary above, so this only
+    // fires when forkConversation itself throws or returns no id.)
+    if (mode === 'conversation' && filesOnly) {
+      sendSessionError(ws, ctx, 'Failed to branch the conversation for this checkpoint. The working tree was left unchanged.')
+      return
+    }
+
+    // #6767: 'files' mode reverts only the working tree — the current session and
+    // conversation continue, so there is no new session and nothing to re-home.
+    if (mode === 'files') {
+      ctx.transport.send(ws, {
+        type: 'checkpoint_restored',
+        checkpointId: checkpoint.id,
+        // No newSessionId/name: the client stays on the current session.
+        filesOnly: true,
+        mode,
+      })
+      return
     }
 
     const newSessionId = await ctx.sessions.sessionManager.createSession({
@@ -186,6 +245,9 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       // branched); false when the conversation was forked/truncated to the
       // checkpoint. Lets clients describe what actually happened truthfully.
       filesOnly,
+      // #6767: echo the selective-restore mode ('conversation' | 'both') so the
+      // client can word the outcome precisely.
+      mode,
     })
     // The initiator's active session moved to the rewound session above; announce
     // it to presence/Control-Room observers (the loop below does the same for the

--- a/packages/server/src/handlers/checkpoint-handlers.js
+++ b/packages/server/src/handlers/checkpoint-handlers.js
@@ -220,7 +220,10 @@ async function handleRestoreCheckpoint(ws, client, msg, ctx) {
       ctx.transport.send(ws, {
         type: 'checkpoint_restored',
         checkpointId: checkpoint.id,
-        // No newSessionId/name: the client stays on the current session.
+        // No newSessionId: the client stays on the current session. `name` here
+        // is the CHECKPOINT's name (there is no new session to name) so clients
+        // can confirm "Files restored to checkpoint <name>" visibly (#6827).
+        name: checkpoint.name,
         filesOnly: true,
         mode,
       })

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -146,6 +146,14 @@ export class SdkSession extends BaseSession {
       // user message. Subprocess providers don't get this for free —
       // they snapshot the skills text at session start.
       skillToggle: true,
+      // #6767: the SDK can fork/truncate a resumed conversation to a message
+      // boundary (`forkSession({ upToMessageId })`), so a checkpoint restore
+      // can branch the conversation ('conversation' / 'both' modes), not just
+      // the files. Advertised so the checkpoint UI enables the "Conversation"
+      // restore-mode option only where the server can actually honor it.
+      // DockerSdkSession overrides this to false — see the instance-level
+      // `supportsConversationFork` getter (transcript lives in-container).
+      conversationFork: true,
     }
   }
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -394,7 +394,7 @@ function _isSecureRequest(req) {
  *   { type: 'client_focus_changed', clientId, sessionId, timestamp } — another client changed session focus
  *   { type: 'checkpoint_created', sessionId, checkpoint } — checkpoint created (auto or manual)
  *   { type: 'checkpoint_list', sessionId, checkpoints }   — list of checkpoints
- *   { type: 'checkpoint_restored', checkpointId, newSessionId, name, filesOnly? } — checkpoint restored (new session created; filesOnly true = working tree only, conversation NOT branched — #6766)
+ *   { type: 'checkpoint_restored', checkpointId, mode, newSessionId?, name?, filesOnly? } — checkpoint restored (#6766/#6767: mode 'files' keeps the current session — no newSessionId, name = the checkpoint's name; 'conversation'/'both' create + re-home to a rewound session, name = its name; filesOnly true = working tree only, conversation NOT branched)
  *   { type: 'primary_changed', sessionId, clientId } — last-writer-wins primary changed (null on disconnect)
  *   { type: 'session_role', sessionId, primaryClientId } — #5589/#5281: explicit primary-ownership; client derives its role (primary iff primaryClientId === own clientId, observer if another holds it, null = unclaimed)
  *   { type: 'pong' }                                    — heartbeat response

--- a/packages/server/tests/docker-sdk-session.test.js
+++ b/packages/server/tests/docker-sdk-session.test.js
@@ -1107,10 +1107,24 @@ describe('DockerSdkSession real import (capabilities only)', () => {
     const { SdkSession } = await import('../src/sdk-session.js')
     const dockerCaps = DockerSdkSession.capabilities
     const sdkCaps = SdkSession.capabilities
+    // #6767: conversationFork is DELIBERATELY overridden false on Docker (the
+    // in-container transcript is unreachable by the host-side fork), so it is
+    // excluded from the "matches SdkSession" spread check and asserted below.
     for (const [key, value] of Object.entries(sdkCaps)) {
+      if (key === 'conversationFork') continue
       assert.equal(dockerCaps[key], value, `capability ${key} should match SdkSession`)
     }
     assert.equal(dockerCaps.containerized, true, 'should also have containerized')
+  })
+
+  // #6767: the checkpoint restore-mode picker gates the "Conversation" option on
+  // this advertised capability. SdkSession can fork; DockerSdkSession can't (the
+  // transcript lives in-container) — so it overrides the inherited value to false.
+  it('DockerSdkSession.capabilities.conversationFork is false; SdkSession is true (#6767)', async () => {
+    const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+    const { SdkSession } = await import('../src/sdk-session.js')
+    assert.equal(SdkSession.capabilities.conversationFork, true)
+    assert.equal(DockerSdkSession.capabilities.conversationFork, false)
   })
 
   it('exports FORWARDED_ENV_KEYS and DEFAULT_CONTAINER_CLI_PATH', async () => {

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -362,6 +362,9 @@ describe('checkpoint-handlers', () => {
         assert.equal(restored.mode, 'files')
         assert.equal(restored.filesOnly, true)
         assert.equal(restored.newSessionId, undefined, 'no newSessionId in files mode')
+        // #6827: the CHECKPOINT's name rides along so clients can render the
+        // visible "Files restored to checkpoint <name>" confirmation.
+        assert.equal(restored.name, 'Checkpoint 1', 'files mode carries the checkpoint name')
       })
 
       it("'files' works on a non-fork provider (no fork attempted, current session kept)", async () => {

--- a/packages/server/tests/handlers/checkpoint-handlers.test.js
+++ b/packages/server/tests/handlers/checkpoint-handlers.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { checkpointHandlers } from '../../src/handlers/checkpoint-handlers.js'
@@ -318,6 +319,268 @@ describe('checkpoint-handlers', () => {
         assert.equal(createArgs.resumeSessionId, 'conv-1', 'falls back to the raw resume id on fork failure')
         const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
         assert.equal(restored.filesOnly, true)
+      })
+    })
+
+    // #6767 — selective restore: 'files' (git only, no fork, no new session),
+    // 'conversation' (fork only, working tree untouched, fork-capable providers),
+    // 'both' (the pre-#6767 default). The matrix below covers mode × capability
+    // including the two rejection paths; two real-git tests assert the working
+    // tree is untouched (conversation) / reverted (files) end-to-end.
+    describe('selective restore modes (#6767)', () => {
+      function makeModeCtx({ forkCapable = false, boundaryMessageId = 'uuid-b1' } = {}) {
+        const sessions = new Map()
+        const orig = createMockSession()
+        orig.isRunning = false
+        orig.resumeSessionId = 'conv-1'
+        if (forkCapable) {
+          orig.supportsConversationFork = true
+          orig.forkConversation = createSpy(async () => 'forked-conv-id')
+        }
+        sessions.set('s1', { session: orig, name: 'S', cwd: '/tmp' })
+        sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: Checkpoint 1', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+        const cp = { id: 'cp-1', name: 'Checkpoint 1', cwd: '/tmp', resumeSessionId: 'conv-1', boundaryMessageId }
+        ctx.services.checkpointManager.getCheckpoint = createSpy(() => cp)
+        ctx.services.checkpointManager.restoreCheckpoint = createSpy(async () => cp)
+        return { ctx, orig }
+      }
+
+      it("'files' restores the git snapshot but does NOT fork or create a new session", async () => {
+        const { ctx, orig } = makeModeCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1' })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'files' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1, 'files mode restores the git snapshot')
+        assert.equal(orig.forkConversation.callCount, 0, 'files mode never forks the conversation')
+        assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0, 'files mode keeps the current session (no new session)')
+        assert.equal(client.activeSessionId, 's1', 'files mode leaves the client on the current session')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.ok(restored, 'checkpoint_restored sent')
+        assert.equal(restored.mode, 'files')
+        assert.equal(restored.filesOnly, true)
+        assert.equal(restored.newSessionId, undefined, 'no newSessionId in files mode')
+      })
+
+      it("'files' works on a non-fork provider (no fork attempted, current session kept)", async () => {
+        const { ctx } = makeModeCtx({ forkCapable: false })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'files' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1)
+        assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.mode, 'files')
+        assert.equal(restored.filesOnly, true)
+      })
+
+      it("'conversation' forks WITHOUT restoring files and re-homes to the rewound session", async () => {
+        const { ctx, orig } = makeModeCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1' })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'conversation' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 0, 'conversation mode never runs the git restore')
+        assert.ok(ctx.services.checkpointManager.getCheckpoint.callCount >= 1, 'conversation mode reads the checkpoint without restoring files')
+        assert.equal(orig.forkConversation.callCount, 1, 'conversation mode forks the transcript')
+        const [forkArgs] = orig.forkConversation.calls[0]
+        assert.equal(forkArgs.upToMessageId, 'uuid-b1')
+        const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+        assert.equal(createArgs.resumeSessionId, 'forked-conv-id', 'rewound session resumes the truncated fork')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.mode, 'conversation')
+        assert.equal(restored.filesOnly, false)
+        assert.equal(restored.newSessionId, 'restored-session-id')
+      })
+
+      it("'conversation' is REJECTED on a non-fork provider (no restore, no new session)", async () => {
+        const { ctx } = makeModeCtx({ forkCapable: false })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'conversation' }, ctx)
+
+        const err = ctx._sent.find(m => m.type === 'session_error')
+        assert.ok(err, 'must reject conversation mode on a non-fork provider')
+        assert.match(err.message, /can't restore the conversation only/i)
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 0, 'must not touch the working tree')
+        assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0, 'must not create a session')
+        assert.equal(ctx._sent.find(m => m.type === 'checkpoint_restored'), undefined)
+      })
+
+      it("'conversation' is REJECTED when the checkpoint has no fork boundary", async () => {
+        const { ctx, orig } = makeModeCtx({ forkCapable: true, boundaryMessageId: null })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'conversation' }, ctx)
+
+        const err = ctx._sent.find(m => m.type === 'session_error')
+        assert.ok(err, 'must reject when there is no branch point')
+        assert.match(err.message, /no conversation branch point/i)
+        assert.equal(orig.forkConversation.callCount, 0)
+        assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+      })
+
+      it("'conversation' surfaces a fork failure instead of a misleading full-transcript session", async () => {
+        const { ctx, orig } = makeModeCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1' })
+        orig.forkConversation = createSpy(async () => { throw new Error('fork boom') })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'conversation' }, ctx)
+
+        const err = ctx._sent.find(m => m.type === 'session_error')
+        assert.ok(err, 'a failed conversation-only fork must surface an error')
+        assert.match(err.message, /Failed to branch the conversation/)
+        assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0, 'no misleading session created')
+      })
+
+      it("'both' restores files AND forks the conversation (filesOnly:false)", async () => {
+        const { ctx, orig } = makeModeCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1' })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'both' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1, 'both mode restores files')
+        assert.equal(orig.forkConversation.callCount, 1, 'both mode forks the conversation')
+        const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+        assert.equal(createArgs.resumeSessionId, 'forked-conv-id')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.mode, 'both')
+        assert.equal(restored.filesOnly, false)
+        assert.equal(restored.newSessionId, 'restored-session-id')
+      })
+
+      it("'both' on a non-fork provider restores files + new session, degrades to filesOnly:true", async () => {
+        const { ctx } = makeModeCtx({ forkCapable: false })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'both' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1)
+        const [createArgs] = ctx.sessions.sessionManager.createSession.calls[0]
+        assert.equal(createArgs.resumeSessionId, 'conv-1', 'resumes the raw id when it cannot fork')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.mode, 'both')
+        assert.equal(restored.filesOnly, true)
+      })
+
+      it("defaults to 'both' when mode is omitted (pre-#6767 behaviour)", async () => {
+        const { ctx, orig } = makeModeCtx({ forkCapable: true, boundaryMessageId: 'uuid-b1' })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1, 'default restores files')
+        assert.equal(orig.forkConversation.callCount, 1, 'default forks the conversation')
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.mode, 'both')
+        assert.equal(restored.newSessionId, 'restored-session-id')
+      })
+
+      it("an unknown mode falls back to 'both'", async () => {
+        const { ctx } = makeModeCtx({ forkCapable: false })
+        const client = makeClient({ activeSessionId: 's1' })
+
+        await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: 'cp-1', mode: 'bogus' }, ctx)
+
+        assert.equal(ctx.services.checkpointManager.restoreCheckpoint.callCount, 1)
+        const restored = ctx._sent.find(m => m.type === 'checkpoint_restored')
+        assert.equal(restored.mode, 'both')
+      })
+
+      it("'conversation' leaves the REAL working tree untouched (git status unchanged)", async () => {
+        // Real git repo + real CheckpointManager: checkpoint at state A, change
+        // the file to state B (dirty), restore in 'conversation' mode → the tree
+        // must STILL be at state B. Conversation mode never reverts files.
+        const checkpointsDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-conv-state-'))
+        const repo = mkdtempSync(join(tmpdir(), 'chroxy-cp-conv-repo-'))
+        try {
+          const git = (...args) => execFileSync('git', args, { cwd: repo, stdio: 'pipe' })
+          git('init', '-q')
+          git('config', 'user.email', 'test@example.com')
+          git('config', 'user.name', 'Test')
+          writeFileSync(join(repo, 'file.txt'), 'state-A\n')
+          git('add', '-A')
+          git('commit', '-q', '-m', 'init')
+
+          const manager = new CheckpointManager({ checkpointsDir })
+          await manager.createCheckpoint({ sessionId: 's1', resumeSessionId: 'conv-1', cwd: repo, name: 'A', boundaryMessageId: 'uuid-a' })
+
+          // Dirty the working tree to state B (uncommitted).
+          writeFileSync(join(repo, 'file.txt'), 'state-B\n')
+          const statusBefore = execFileSync('git', ['status', '--porcelain'], { cwd: repo }).toString()
+
+          const sessions = new Map()
+          const orig = createMockSession()
+          orig.isRunning = false
+          orig.resumeSessionId = 'conv-1'
+          orig.supportsConversationFork = true
+          orig.forkConversation = createSpy(async () => 'forked-conv-id')
+          sessions.set('s1', { session: orig, name: 'S', cwd: repo })
+          sessions.set('restored-session-id', { session: createMockSession(), name: 'Rewind: A', cwd: repo })
+          const ctx = makeCtx(sessions)
+          ctx.services.checkpointManager = manager
+          ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+          const client = makeClient({ activeSessionId: 's1' })
+          const [cpMeta] = manager.listCheckpoints('s1')
+
+          await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: cpMeta.id, mode: 'conversation' }, ctx)
+
+          assert.equal(readFileSync(join(repo, 'file.txt'), 'utf8'), 'state-B\n', 'conversation mode must not revert the file')
+          const statusAfter = execFileSync('git', ['status', '--porcelain'], { cwd: repo }).toString()
+          assert.equal(statusAfter, statusBefore, 'conversation mode leaves git status unchanged')
+          assert.equal(orig.forkConversation.callCount, 1, 'the conversation WAS forked')
+        } finally {
+          rmSync(checkpointsDir, { recursive: true, force: true })
+          rmSync(repo, { recursive: true, force: true })
+        }
+      })
+
+      it("'files' reverts the REAL working tree and keeps the current session", async () => {
+        // Mirror of the conversation test: checkpoint at state A, change to state
+        // B, restore in 'files' mode → the tree must be back at state A, with NO
+        // new session created (the conversation continues).
+        const checkpointsDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-files-state-'))
+        const repo = mkdtempSync(join(tmpdir(), 'chroxy-cp-files-repo-'))
+        try {
+          const git = (...args) => execFileSync('git', args, { cwd: repo, stdio: 'pipe' })
+          git('init', '-q')
+          git('config', 'user.email', 'test@example.com')
+          git('config', 'user.name', 'Test')
+          writeFileSync(join(repo, 'file.txt'), 'state-A\n')
+          git('add', '-A')
+          git('commit', '-q', '-m', 'init')
+
+          const manager = new CheckpointManager({ checkpointsDir })
+          await manager.createCheckpoint({ sessionId: 's1', resumeSessionId: 'conv-1', cwd: repo, name: 'A', boundaryMessageId: 'uuid-a' })
+
+          writeFileSync(join(repo, 'file.txt'), 'state-B\n')
+
+          const sessions = new Map()
+          const orig = createMockSession()
+          orig.isRunning = false
+          orig.resumeSessionId = 'conv-1'
+          orig.supportsConversationFork = true
+          orig.forkConversation = createSpy(async () => 'forked-conv-id')
+          sessions.set('s1', { session: orig, name: 'S', cwd: repo })
+          const ctx = makeCtx(sessions)
+          ctx.services.checkpointManager = manager
+          ctx.sessions.sessionManager.createSession = createSpy(async () => 'restored-session-id')
+          const client = makeClient({ activeSessionId: 's1' })
+          const [cpMeta] = manager.listCheckpoints('s1')
+
+          await checkpointHandlers.restore_checkpoint(makeWs(), client, { checkpointId: cpMeta.id, mode: 'files' }, ctx)
+
+          assert.equal(readFileSync(join(repo, 'file.txt'), 'utf8'), 'state-A\n', 'files mode reverts the working tree to the checkpoint')
+          assert.equal(orig.forkConversation.callCount, 0, 'files mode does not fork')
+          assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0, 'files mode keeps the current session')
+          assert.equal(client.activeSessionId, 's1')
+        } finally {
+          rmSync(checkpointsDir, { recursive: true, force: true })
+          rmSync(repo, { recursive: true, force: true })
+        }
       })
     })
 

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -1430,6 +1430,24 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { flat: { activeSessionId: 'cp-new-sid' } },
   },
   {
+    // #6767/#6827 — a 'files'-mode restore keeps the CURRENT session (no
+    // newSessionId, nothing to re-home), so both clients confirm the revert with
+    // a system message on the active session's transcript instead — a files-only
+    // rewind must never be silent. `name` here is the CHECKPOINT's name.
+    name: "checkpoint_restored (mode 'files') appends a files-restored confirmation without re-homing (both clients)",
+    type: 'checkpoint_restored',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'checkpoint_restored', checkpointId: 'cp-1', mode: 'files', filesOnly: true, name: 'Before refactor' },
+    // No flat.activeSessionId assert here: the model adapter records WRITES, and
+    // files mode's whole point is that nothing re-homes (no write happens). The
+    // per-client no-switch asserts live in each client's message-handler tests.
+    expect: {
+      sessions: {
+        s1: { messages: [{ type: 'system', content: 'Files restored to checkpoint "Before refactor"' }] },
+      },
+    },
+  },
+  {
     // #5618 — conversations_list migrated SWITCH→DISPATCH. Both clients write the flat
     // conversationHistory from the parsed array (the app's error-clear + secondary-store
     // mirror ride the optional applyConversationsListExtras hook, not asserted here).

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -641,6 +641,9 @@ export interface DispatchMessageMap {
     newSessionId?: string
     // #6766: true when only files were restored (conversation NOT branched).
     filesOnly?: boolean
+    // #6767: selective-restore mode the server ran. 'files' omits newSessionId
+    // (current session kept — no switch); 'conversation'/'both' carry it.
+    mode?: 'files' | 'conversation' | 'both'
   }
   search_results: {
     type: 'search_results'

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -137,6 +137,7 @@ import {
   // --- checkpoint cases (#5618 Batch 6) ---
   handleCheckpointCreated,
   handleCheckpointRestored,
+  handleCheckpointFilesRestored,
   handleConversationsList,
   handleSearchResults,
   handleCheckpointList,
@@ -644,6 +645,9 @@ export interface DispatchMessageMap {
     // #6767: selective-restore mode the server ran. 'files' omits newSessionId
     // (current session kept — no switch); 'conversation'/'both' carry it.
     mode?: 'files' | 'conversation' | 'both'
+    // #6827: the rewound session's name ('conversation'/'both') or the
+    // CHECKPOINT's name ('files' — used in the files-restored confirmation).
+    name?: string
   }
   search_results: {
     type: 'search_results'
@@ -1183,6 +1187,12 @@ function dispatchConversationsList<S extends DispatchSessionBase>(
  * checkpoint and re-homed this client onto it; auto-switch to it. Both clients
  * switch via the required {@link ClientStoreAdapter.switchToRestoredSession} hook
  * (the app passes its no-notify/no-haptic options, the dashboard plain).
+ *
+ * #6767/#6827: a 'files'-mode restore keeps the CURRENT session — no
+ * `newSessionId`, so the re-home path is a no-op. Confirm the revert visibly
+ * instead with a `system` message on the active session's transcript (the
+ * `budget_resumed` pattern; byte-identical across both clients) so a files-only
+ * rewind is never silent.
  */
 function dispatchCheckpointRestored<S extends DispatchSessionBase>(
   msg: DispatchMessageMap['checkpoint_restored'],
@@ -1191,6 +1201,18 @@ function dispatchCheckpointRestored<S extends DispatchSessionBase>(
   const restored = handleCheckpointRestored(msg as Record<string, unknown>)
   if (restored) {
     adapter.switchToRestoredSession(restored.newSessionId)
+    return
+  }
+  const filesRestored = handleCheckpointFilesRestored(msg as Record<string, unknown>)
+  if (!filesRestored) return
+  const activeId = adapter.getActiveSessionId()
+  if (activeId && adapter.hasSession(activeId)) {
+    adapter.updateSession(
+      activeId,
+      (ss) => ({ messages: [...ss.messages, filesRestored.systemMessage] } as Partial<S>),
+    )
+  } else {
+    adapter.addMessage(filesRestored.systemMessage)
   }
 }
 

--- a/packages/store-core/src/handlers/checkpoint.ts
+++ b/packages/store-core/src/handlers/checkpoint.ts
@@ -64,6 +64,9 @@ export function handleCheckpointList(
 // checkpoint_restored
 // ---------------------------------------------------------------------------
 
+/** #6767: which parts a checkpoint restore reverted. */
+export type RestoreMode = 'files' | 'conversation' | 'both'
+
 /** Parsed payload from a `checkpoint_restored` message. */
 export interface CheckpointRestoredPayload {
   newSessionId: string
@@ -75,6 +78,14 @@ export interface CheckpointRestoredPayload {
    * never branched), so callers never over-claim a conversation rewind.
    */
   filesOnly: boolean
+  /**
+   * #6767: the selective-restore mode the server ran. 'conversation'/'both'
+   * create + re-home to a new session (so this payload carries a newSessionId);
+   * 'files' keeps the current session and omits newSessionId, so this handler
+   * returns null for it (no switch) and `mode` is only ever present here for the
+   * session-creating modes. Absent when talking to a pre-#6767 server.
+   */
+  mode?: RestoreMode
 }
 
 /**
@@ -99,5 +110,11 @@ export function handleCheckpointRestored(
   // #6766: default to files-only unless the server explicitly says otherwise, so
   // a missing/legacy flag never lets a client claim a conversation rewind.
   const filesOnly = typeof msg.filesOnly === 'boolean' ? msg.filesOnly : true
-  return { newSessionId: trimmed, filesOnly }
+  // #6767: echo the restore mode when the server supplied a valid one (a 'files'
+  // restore never reaches here — it carries no newSessionId and returns null above).
+  const mode =
+    msg.mode === 'files' || msg.mode === 'conversation' || msg.mode === 'both'
+      ? (msg.mode as RestoreMode)
+      : undefined
+  return { newSessionId: trimmed, filesOnly, ...(mode ? { mode } : {}) }
 }

--- a/packages/store-core/src/handlers/checkpoint.ts
+++ b/packages/store-core/src/handlers/checkpoint.ts
@@ -7,7 +7,8 @@
  * ./index.ts for the stateless-handler contract.
  */
 
-import type { Checkpoint } from '../types'
+import type { ChatMessage, Checkpoint } from '../types'
+import { nextMessageId } from '../utils'
 import { resolveSessionId } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -117,4 +118,35 @@ export function handleCheckpointRestored(
       ? (msg.mode as RestoreMode)
       : undefined
   return { newSessionId: trimmed, filesOnly, ...(mode ? { mode } : {}) }
+}
+
+// ---------------------------------------------------------------------------
+// checkpoint_restored — 'files'-mode confirmation (#6767 / #6827)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the transcript confirmation for a 'files'-mode `checkpoint_restored`.
+ *
+ * #6827: a files-only restore keeps the current session — the payload carries
+ * no `newSessionId`, so {@link handleCheckpointRestored} returns null and
+ * nothing re-homes. Without this the revert would be invisible client-side.
+ * Returns a `system` ChatMessage for the active session's transcript (the
+ * `budget_resumed` pattern — rendered identically by both clients), naming the
+ * checkpoint when the server supplied `name` (the CHECKPOINT's name here; in
+ * the session-creating modes `name` is the new session's name instead).
+ * Returns null for any non-'files' payload — the re-home path owns those.
+ */
+export function handleCheckpointFilesRestored(
+  msg: Record<string, unknown>,
+): { systemMessage: ChatMessage } | null {
+  if (msg.mode !== 'files') return null
+  const name = typeof msg.name === 'string' && msg.name.trim().length > 0 ? msg.name.trim() : null
+  return {
+    systemMessage: {
+      id: nextMessageId('system'),
+      type: 'system',
+      content: name ? `Files restored to checkpoint "${name}"` : 'Files restored to checkpoint',
+      timestamp: Date.now(),
+    },
+  }
 }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -31,6 +31,7 @@ import {
   handleCheckpointCreated,
   handleCheckpointList,
   handleCheckpointRestored,
+  handleCheckpointFilesRestored,
   handleError,
   handleSessionError,
   handleSessionStopped,
@@ -2008,6 +2009,47 @@ describe('handleCheckpointRestored', () => {
       newSessionId: 'sess-new',
       filesOnly: true,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleCheckpointFilesRestored (#6767 / #6827)
+// ---------------------------------------------------------------------------
+describe('handleCheckpointFilesRestored', () => {
+  it('builds a system confirmation naming the checkpoint for a files-mode payload', () => {
+    const result = handleCheckpointFilesRestored({
+      type: 'checkpoint_restored',
+      checkpointId: 'cp-1',
+      mode: 'files',
+      filesOnly: true,
+      name: 'Before refactor',
+    })
+    expect(result).not.toBeNull()
+    expect(result!.systemMessage).toMatchObject({
+      type: 'system',
+      content: 'Files restored to checkpoint "Before refactor"',
+    })
+    expect(typeof result!.systemMessage.id).toBe('string')
+    expect(typeof result!.systemMessage.timestamp).toBe('number')
+  })
+
+  it('falls back to a generic confirmation when name is absent or blank', () => {
+    expect(
+      handleCheckpointFilesRestored({ mode: 'files', checkpointId: 'cp-1' })!.systemMessage.content,
+    ).toBe('Files restored to checkpoint')
+    expect(
+      handleCheckpointFilesRestored({ mode: 'files', name: '   ' })!.systemMessage.content,
+    ).toBe('Files restored to checkpoint')
+    expect(
+      handleCheckpointFilesRestored({ mode: 'files', name: 42 })!.systemMessage.content,
+    ).toBe('Files restored to checkpoint')
+  })
+
+  it('returns null for non-files modes and legacy payloads (the re-home path owns those)', () => {
+    expect(handleCheckpointFilesRestored({ mode: 'both', newSessionId: 's2' })).toBeNull()
+    expect(handleCheckpointFilesRestored({ mode: 'conversation', newSessionId: 's2' })).toBeNull()
+    expect(handleCheckpointFilesRestored({ newSessionId: 's2' })).toBeNull()
+    expect(handleCheckpointFilesRestored({})).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1988,6 +1988,27 @@ describe('handleCheckpointRestored', () => {
   it('returns null when newSessionId is whitespace only', () => {
     expect(handleCheckpointRestored({ newSessionId: '   ' })).toBeNull()
   })
+
+  // #6767: selective-restore mode echo. 'conversation'/'both' carry a
+  // newSessionId (session-creating), 'files' never reaches here (no newSessionId).
+  it('carries mode when the server echoes a valid selective-restore mode', () => {
+    expect(
+      handleCheckpointRestored({ newSessionId: 'sess-new', filesOnly: false, mode: 'conversation' }),
+    ).toEqual({ newSessionId: 'sess-new', filesOnly: false, mode: 'conversation' })
+    expect(
+      handleCheckpointRestored({ newSessionId: 'sess-new', filesOnly: false, mode: 'both' }),
+    ).toEqual({ newSessionId: 'sess-new', filesOnly: false, mode: 'both' })
+  })
+
+  it('omits mode when the server sends an unknown/absent mode (pre-#6767 shape)', () => {
+    expect(
+      handleCheckpointRestored({ newSessionId: 'sess-new', mode: 'bogus' }),
+    ).toEqual({ newSessionId: 'sess-new', filesOnly: true })
+    expect(handleCheckpointRestored({ newSessionId: 'sess-new' })).toEqual({
+      newSessionId: 'sess-new',
+      filesOnly: true,
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -575,6 +575,7 @@ export {
   handleCheckpointCreated,
   handleCheckpointList,
   handleCheckpointRestored,
+  handleCheckpointFilesRestored,
   handleError,
   handleSessionError,
   // #4879: quiet "user-initiated Stop" confirmation handler — flips


### PR DESCRIPTION
## Problem

Checkpoint restore had exactly one mode: revert the working tree **and** branch the conversation into a new session — no way to restore code only or conversation only. This builds on the conversation-fork infrastructure #6807 (merged) added for #6766.

## Approach

### Server
- `restore_checkpoint` gains a `mode`: `'files' | 'conversation' | 'both'` (default `'both'` — the pre-#6767 behaviour).
  - **`files`** — git restore only. The current session and conversation continue: **no fork, no new session, no re-home**. The shared-cwd busy guard still applies (it hard-resets the tree).
  - **`conversation`** — fork/truncate the transcript only; the **working tree is untouched** (no git restore, shared-cwd guard skipped). Requires a fork-capable provider **and** a checkpoint branch point — otherwise rejected with a clear error. A conversation-only fork failure surfaces an error rather than a misleading full-transcript session.
  - **`both`** — today's behaviour (git restore + fork when possible + new session + re-home).
- `'conversation'`/`'both'` create and re-home to a rewound session; `'files'` does not — reflected honestly in client copy.

### Wire
- `mode` on `restore_checkpoint`; echoed on `checkpoint_restored`. `newSessionId`/`name` are now **optional** on `checkpoint_restored` (a `files` restore omits them so the client stays put). Protocol `dist` rebuilt + committed.

### Capability signal
- `SdkSession.capabilities.conversationFork = true`; `DockerSdkSession` overrides it **false** (the in-container transcript is unreachable by the host-side fork). Flows through `listProviders()` so the clients gate the picker's **Conversation** option on the active session's provider — mirroring the existing `sessionRules` / auto-mode-confirm capability lookups. The server's instance-level `supportsConversationFork` remains the enforcement authority (rejects `conversation` when it can't fork), so the picker gate is a best-effort UX hint.

### Clients
- **Dashboard** `CheckpointTimeline` and **mobile** `CheckpointView` get a restore-mode picker (default **Both**; **Conversation** disabled when the provider can't fork). Per-mode copy is honest — only `files` keeps the current session.

## Tests
- **Server** (`checkpoint-handlers`, all green): mode × provider-capability matrix incl. **both rejection paths** (non-fork provider, no branch point), plus two **real-git** tests — `conversation` leaves the working tree unchanged (git status untouched) and `files` reverts it while keeping the current session. `docker-sdk-session` asserts the `conversationFork` override. Temp `checkpointsDir` + temp repos throughout.
- **store-core** (`vitest run`, 1992 passed): `checkpoint_restored` `mode` parsing.
- **dashboard** (`vitest run`, 4471 passed) + **app** (`jest`, 2185 passed): picker rendering, mode selection, disabled-Conversation state.
- **protocol** (362) · **tsc** store-core/dashboard/app clean · all 5 server `lint-*.sh` green · server eslint clean on touched source.

## Scope

Per-edit-tool-call checkpoint **granularity** (the issue's second slice — rewind between edits within a single turn) is **out of this PR**: it requires reworking checkpoint *creation*, not just restore. This PR implements **selective restore** only. The genuine settings-vs-history conversation-fork action from the issue is likewise a separate follow-up.

Closes #6767
Closes #6827

## Review follow-ups (second commit)

- **M1 (#6827):** a `files`-mode restore is no longer silent client-side — the shared dispatch appends a `system` transcript message ("Files restored to checkpoint \<name\>") to the active session on **both** clients (the `budget_resumed` pattern); the server's files-mode payload now carries the checkpoint's `name`. Tests: store-core handler units + a files-mode DISPATCH contract fixture + explicit dashboard and app message-handler asserts (message appended, no session switch).
- **M2:** `ws-server.js` Server→Client doc roster updated to the current `checkpoint_restored` shape `{ type, checkpointId, mode, newSessionId?, name?, filesOnly? }`.
