### PR TITLE
feat(server,dashboard,app): persistent allow-always permission rules (#6771)

### DIFF
--- a/packages/app/__tests__/message-handler.test.ts
+++ b/packages/app/__tests__/message-handler.test.ts
@@ -350,6 +350,8 @@ describe('message-handler', () => {
         { label: 'Allow', value: 'allow' },
         { label: 'Deny', value: 'deny' },
         { label: 'Allow for Session', value: 'allowSession' },
+        // #6771: a rule-supporting provider also gets "Always allow (project)".
+        { label: 'Always allow (project)', value: 'allowAlways' },
       ]);
     });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -3726,8 +3726,9 @@ describe('permission_request message handler', () => {
     expect(msgs).toHaveLength(1);
     expect(msgs[0].type).toBe('prompt');
     expect(msgs[0].requestId).toBe('perm-1');
-    expect(msgs[0].options).toHaveLength(3);
-    expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny', 'allowSession']);
+    // #6771: a rule-supporting provider also gets the "Always allow (project)" option.
+    expect(msgs[0].options).toHaveLength(4);
+    expect(msgs[0].options!.map((o: any) => o.value)).toEqual(['allow', 'deny', 'allowSession', 'allowAlways']);
   });
 
   // #3072: when the active session's provider does not declare the

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -72,6 +72,7 @@ export function SettingsScreen() {
     clearSavedConnection,
     requestFullHistory,
     setPermissionRules,
+    setProjectPermissionRules,
   } = useConnectionStore();
 
   const activeSessionId = useConnectionStore((s) => s.activeSessionId);
@@ -79,6 +80,12 @@ export function SettingsScreen() {
     const id = s.activeSessionId;
     if (!id || !s.sessionStates[id]) return EMPTY_RULES;
     return s.sessionStates[id].sessionRules ?? EMPTY_RULES;
+  });
+  // #6771 — durable per-project ("always allow") rules for the active session.
+  const persistentRules = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    if (!id || !s.sessionStates[id]) return EMPTY_RULES;
+    return s.sessionStates[id].persistentRules ?? EMPTY_RULES;
   });
 
   // Use the connection store as source of truth — same store SessionScreen and
@@ -376,6 +383,56 @@ export function SettingsScreen() {
                 </TouchableOpacity>
               </>
             )}
+          </View>
+        </>
+      )}
+
+      {/* PROJECT RULES (#6771) — durable "always allow" grants that survive a
+          daemon restart. Removing one sends the reduced set as projectRules. */}
+      {activeSessionId != null && persistentRules.length > 0 && (
+        <>
+          <Text style={styles.sectionHeader} testID="project-rules-header">PROJECT RULES (ALWAYS ALLOW)</Text>
+          <View style={styles.section}>
+            <View style={styles.rulesContainer}>
+              {persistentRules.map((rule: PermissionRule, index: number) => (
+                <TouchableOpacity
+                  key={`persist-${rule.tool}-${rule.decision}-${index}`}
+                  testID={`project-rule-${rule.tool}`}
+                  style={[
+                    styles.ruleChip,
+                    rule.decision === 'allow' ? styles.ruleChipAllow : styles.ruleChipDeny,
+                  ]}
+                  onPress={() => {
+                    const updated = persistentRules.filter((_: PermissionRule, i: number) => i !== index);
+                    setProjectPermissionRules(updated);
+                  }}
+                >
+                  <Text
+                    style={[
+                      styles.ruleChipText,
+                      rule.decision === 'allow' ? styles.ruleChipTextAllow : styles.ruleChipTextDeny,
+                    ]}
+                  >
+                    {rule.tool} — {rule.decision === 'allow' ? 'always allow' : 'always deny'}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.ruleChipRemove,
+                      rule.decision === 'allow' ? styles.ruleChipTextAllow : styles.ruleChipTextDeny,
+                    ]}
+                  >
+                    {' ×'}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <View style={styles.separator} />
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => setProjectPermissionRules([])}
+            >
+              <Text style={styles.destructiveText}>Clear All Project Rules</Text>
+            </TouchableOpacity>
           </View>
         </>
       )}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -85,6 +85,7 @@ import type {
   ContextUsage,
   ContextOccupancy,
   MessageAttachment,
+  PermissionRule,
   SavedConnection,
   SessionInfo,
   SessionState,
@@ -2134,6 +2135,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setPermissionRules: (rules) => {
     const { activeSessionId } = get();
     const payload: Record<string, unknown> = { type: 'set_permission_rules', rules };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    sendIfOpen(payload);
+  },
+
+  // #6771 — replace the durable per-project ("always allow") rule set for the
+  // active session's project cwd. Used by the SessionRules screen to REMOVE a
+  // persistent rule (send the reduced list). Session rules are left untouched:
+  // we resend the current sessionRules alongside so the server's single
+  // set_permission_rules handler doesn't clobber them.
+  setProjectPermissionRules: (projectRules) => {
+    const { activeSessionId, sessionStates } = get();
+    const ss = activeSessionId ? sessionStates[activeSessionId] : null;
+    // Strip the client-only `persist` marker before echoing rules back — the
+    // server's schema (PermissionRuleSchema) accepts only { tool, decision }.
+    const bare = (rs?: PermissionRule[]) =>
+      (rs ?? []).map((r) => ({ tool: r.tool, decision: r.decision }));
+    const payload: Record<string, unknown> = {
+      type: 'set_permission_rules',
+      rules: bare(ss?.sessionRules),
+      projectRules: bare(projectRules),
+    };
     if (activeSessionId) payload.sessionId = activeSessionId;
     sendIfOpen(payload);
   },

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -3030,6 +3030,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         { label: 'Allow', value: 'allow' },
         { label: 'Deny', value: 'deny' },
         ...(providerSupportsRules ? [{ label: 'Allow for Session', value: 'allowSession' }] : []),
+        // #6771 — "Always allow (project)" persists a durable per-project rule
+        // (server-side), gated on the same session-rule provider support.
+        ...(providerSupportsRules ? [{ label: 'Always allow (project)', value: 'allowAlways' }] : []),
       ];
       const newExpiresAt = permPayload.remainingMs !== null ? Date.now() + permPayload.remainingMs : undefined;
 

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -171,6 +171,9 @@ export interface PermissionRule {
   tool: string;
   decision: 'allow' | 'deny';
   pattern?: string;
+  // #6771: set to 'project' on a DURABLE rule (backed by the daemon's per-project
+  // rule store — survives restarts). Absent on a session-scoped rule.
+  persist?: 'project';
 }
 
 export interface ProviderCapabilities {
@@ -227,6 +230,10 @@ export interface ProviderInfo {
 export interface SessionState extends BaseSessionState {
   activityState: SessionActivity;
   sessionRules?: PermissionRule[];
+  // #6771: durable per-project rules ("always allow / deny"), tagged
+  // `persist:'project'`. Written by permission_rules_updated (persistentRules
+  // field via the shared dispatch table). Surfaced in the SessionRules screen.
+  persistentRules?: PermissionRule[];
 }
 
 export interface SessionNotification {
@@ -553,6 +560,9 @@ export interface ModelsAndPermissionsActions {
   confirmPermissionMode: (mode: string) => void;
   cancelPermissionConfirm: () => void;
   setPermissionRules: (rules: PermissionRule[]) => void;
+  // #6771 — replace the durable per-project ("always allow") rule set for the
+  // active session's project cwd (SessionRules screen removal path).
+  setProjectPermissionRules: (projectRules: PermissionRule[]) => void;
 }
 
 /**

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -390,12 +390,13 @@ export function App() {
       if (!m.requestId) continue
       if (m.tool !== 'AskUserQuestion') continue
       // Per-message `answered` is set by `handlePermissionResolved` on
-      // BOTH allow and deny — gate only flips off for allow variants.
-      if (m.answered === 'allow' || m.answered === 'allowSession') continue
+      // BOTH allow and deny — gate only flips off for allow variants
+      // (#6771: allowAlways is an allow variant too).
+      if (m.answered === 'allow' || m.answered === 'allowSession' || m.answered === 'allowAlways') continue
       // Cross-client decision via `resolvedPermissions[requestId]` —
       // same allow-only rule.
       const decision = resolvedPermissions?.[m.requestId]
-      if (decision === 'allow' || decision === 'allowSession') continue
+      if (decision === 'allow' || decision === 'allowSession' || decision === 'allowAlways') continue
       return true
     }
     return false

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -660,6 +660,84 @@ describe('PermissionPrompt — Allow for Session button (#2834)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Always allow (this project) — durable rule button (#6771)
+// ---------------------------------------------------------------------------
+describe('PermissionPrompt — Always allow (project) button (#6771)', () => {
+  beforeEach(() => {
+    resetMockStore()
+  })
+
+  it('renders the Always allow button for a rule-eligible tool + supporting provider', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="Write file"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('btn-allow-always')).toHaveTextContent('Always allow')
+  })
+
+  it('calls onRespond with allowAlways when clicked', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="Write file"
+        remainingMs={60000}
+        onRespond={onRespond}
+      />
+    )
+    fireEvent.click(screen.getByTestId('btn-allow-always'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allowAlways', null)
+  })
+
+  it('does NOT render for a non-rule-eligible tool (Bash)', () => {
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Bash"
+        description="rm -rf"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('btn-allow-always')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render when the provider lacks the sessionRules capability', () => {
+    mockStoreState.availableProviders = [{ name: 'claude-sdk', capabilities: { sessionRules: false } }]
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="Write file"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('btn-allow-always')).not.toBeInTheDocument()
+  })
+
+  it('shows "Always allowed (project)" once the store records allowAlways', () => {
+    mockStoreState.resolvedPermissions = { 'req-1': 'allowAlways' }
+    render(
+      <PermissionPrompt
+        requestId="req-1"
+        tool="Write"
+        description="Write file"
+        remainingMs={60000}
+        onRespond={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('perm-answer')).toHaveTextContent('Always allowed (project)')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Allow for Session — provider capability gate (#3072)
 // ---------------------------------------------------------------------------
 describe('PermissionPrompt — provider capability gate (#3072)', () => {

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -152,15 +152,14 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     if (submittingRef.current || answered || remaining <= 0 || !connected) return
     submittingRef.current = true
     setSubmitting(true)
-    // 'allowSession' is only meaningful when both the tool is rule-eligible
-    // (#2834) AND the active provider supports session rules (#3072). Either
-    // gate failing means the server would reject the follow-up
-    // set_permission_rules; silently coerce to a plain 'allow' so keyboard
-    // shortcut users on an ineligible prompt still get an Allow-equivalent
-    // decision.
-    const allowSessionOk = isRuleEligibleTool(tool) && providerSupportsRules
+    // 'allowSession' / 'allowAlways' (#6771) are only meaningful when both the
+    // tool is rule-eligible (#2834) AND the active provider supports session
+    // rules (#3072). Either gate failing means the server would reject the rule;
+    // silently coerce to a plain 'allow' so keyboard shortcut users on an
+    // ineligible prompt still get an Allow-equivalent decision.
+    const ruleOk = isRuleEligibleTool(tool) && providerSupportsRules
     const effective: PermissionDecision =
-      decision === 'allowSession' && !allowSessionOk ? 'allow' : decision
+      (decision === 'allowSession' || decision === 'allowAlways') && !ruleOk ? 'allow' : decision
     if (intervalRef.current) clearInterval(intervalRef.current)
     // #6543: carry the per-hunk edits on an approve only (never on deny).
     onRespond(requestId, effective, effective === 'deny' ? null : editedInput)
@@ -178,6 +177,9 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   const isUrgent = remaining > 0 && remaining <= 30000
   const showButtons = !answered && !isExpired
   const showAllowSession = showButtons && isRuleEligibleTool(tool) && providerSupportsRules
+  // #6771 — "Always allow (this project)" shares the same eligibility gate as
+  // "Allow for Session" (rule-eligible tool + provider that supports rules).
+  const showAllowAlways = showAllowSession
   const [dismissed, setDismissed] = useState(false)
 
   // #2840: keyboard hint labels near the Allow / Allow-for-Session buttons
@@ -266,6 +268,19 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
                 Allow for Session
               </button>
             )}
+            {showAllowAlways && (
+              <button
+                className="btn-allow-always"
+                onClick={() => respond('allowAlways')}
+                type="button"
+                aria-label={`Always allow ${tool} for this project`}
+                data-testid="btn-allow-always"
+                title="Always allow this tool for this project (persists across restarts)"
+                disabled={submitting || !connected}
+              >
+                Always allow
+              </button>
+            )}
             <button
               className="btn-deny"
               onClick={() => respond('deny')}
@@ -309,7 +324,13 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
 
       {answered && (
         <div className="perm-answer" data-testid="perm-answer">
-          {answered === 'deny' ? 'Denied' : answered === 'allowSession' ? 'Allowed for session' : 'Allowed'}
+          {answered === 'deny'
+            ? 'Denied'
+            : answered === 'allowSession'
+              ? 'Allowed for session'
+              : answered === 'allowAlways'
+                ? 'Always allowed (project)'
+                : 'Allowed'}
         </div>
       )}
     </div>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -62,6 +62,7 @@ import type {
   ConnectionContext,
   ConnectionState,
   InputSettings,
+  PermissionDecision,
   ServerEntry,
   SessionInfo,
   SessionState,
@@ -3179,7 +3180,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
-  sendPermissionResponse: (requestId: string, decision: 'allow' | 'deny' | 'allowSession', editedInput?: Record<string, string> | null) => {
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null) => {
     const { socket } = get();
     // #5699 — refuse to answer a permission prompt while disconnected. A
     // permission request is NOT safely queueable: the server expires the pending
@@ -3196,8 +3197,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       return false;
     }
     // allowSession: wire decision is still 'allow' — session-scoped behaviour
-    // is implemented client-side via a follow-up set_permission_rules message
-    // (the schema only accepts 'allow' | 'allowAlways' | 'deny').
+    // is implemented client-side via a follow-up set_permission_rules message.
+    // #6771 allowAlways: sent VERBATIM — the server persists a durable
+    // per-project rule (permission-manager.js), no follow-up needed. (The schema
+    // accepts 'allow' | 'allowAlways' | 'deny'.)
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
     // #6543 (feature B): the operator's per-hunk edits ride along on an approve.
     // Only sent when present (a plain Allow omits it); the server whitelists
@@ -3264,7 +3267,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return result;
   },
 
-  markPermissionResolved: (requestId: string, decision: 'allow' | 'deny' | 'allowSession') => {
+  markPermissionResolved: (requestId: string, decision: PermissionDecision) => {
     set((state) => ({
       // #2838: cap map size to prevent unbounded growth across long sessions.
       resolvedPermissions: capResolvedPermissions(state.resolvedPermissions, requestId, decision),

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -275,6 +275,9 @@ export interface PermissionRule {
   tool: string;
   decision: 'allow' | 'deny';
   pattern?: string;
+  // #6771: set to 'project' on a DURABLE rule (backed by the daemon's per-project
+  // rule store — survives restarts). Absent on a session-scoped rule.
+  persist?: 'project';
 }
 
 /**
@@ -285,8 +288,12 @@ export interface PermissionRule {
  * `'allowSession'` means the user clicked "Allow for Session" — the wire
  * decision sent to the server is `'allow'`, and a follow-up
  * `set_permission_rules` message registers a rule for the tool.
+ *
+ * #6771: `'allowAlways'` means the user clicked "Always allow (this project)".
+ * Unlike `allowSession`, the wire decision `'allowAlways'` is sent VERBATIM —
+ * the server persists a durable per-project rule (no follow-up needed).
  */
-export type PermissionDecision = 'allow' | 'deny' | 'allowSession';
+export type PermissionDecision = 'allow' | 'deny' | 'allowSession' | 'allowAlways';
 
 // #3188: auto-evaluator clarify-pending state. Populated by the
 // `evaluator_clarify` handler when the auto-evaluator hook (#3186) lands
@@ -494,6 +501,11 @@ export interface SessionState extends BaseSessionState {
   // append new rules without losing existing ones. Optional: undefined until
   // the server confirms rules for this session.
   sessionRules?: PermissionRule[];
+  // #6771: durable per-project rules ("always allow / deny"), each tagged
+  // `persist:'project'`. Written by permission_rules_updated (persistentRules
+  // field). Distinct from sessionRules so standing project grants aren't
+  // conflated with the session-scoped set. Optional until the server reports.
+  persistentRules?: PermissionRule[];
   // #3209: cached skills list for the active session. Populated by
   // list_skills response, mutated in-place by skill_activated /
   // skill_deactivated broadcasts. Optional — undefined until the

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3788,6 +3788,20 @@ button.sidebar-token-view-session-row:hover {
   background: #16a34a;
 }
 
+/* Always allow for this project (#6771) — the widest-scope allow (persists
+   across daemon restarts), so it reads as the most deliberate of the three
+   allow actions: outlined rather than solid-filled. */
+.btn-allow-always {
+  background: transparent;
+  color: var(--accent-green);
+  border: 1px solid var(--accent-green);
+}
+
+.btn-allow-always:hover {
+  background: var(--accent-green);
+  color: #fff;
+}
+
 .btn-deny {
   background: var(--accent-red);
   color: #fff;
@@ -3797,6 +3811,7 @@ button.sidebar-token-view-session-row:hover {
 
 .btn-allow:focus-visible,
 .btn-allow-session:focus-visible,
+.btn-allow-always:focus-visible,
 .btn-deny:focus-visible {
   outline: 2px solid #fff;
   outline-offset: 2px;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -226,6 +226,13 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
             deny: "deny";
         }>;
     }, z.core.$strip>>;
+    projectRules: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        tool: z.ZodString;
+        decision: z.ZodEnum<{
+            allow: "allow";
+            deny: "deny";
+        }>;
+    }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const SetPromptEvaluatorSchema: z.ZodObject<{
@@ -960,6 +967,13 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             deny: "deny";
         }>;
     }, z.core.$strip>>;
+    projectRules: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        tool: z.ZodString;
+        decision: z.ZodEnum<{
+            allow: "allow";
+            deny: "deny";
+        }>;
+    }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"set_prompt_evaluator">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -252,6 +252,11 @@ export const TestCredentialSchema = z.object({
 export const SetPermissionRulesSchema = z.object({
     type: z.literal('set_permission_rules'),
     rules: z.array(PermissionRuleSchema).max(1000),
+    // #6771: optional durable per-project rule set. When present it FULLY REPLACES
+    // the persisted "always allow / deny" rules for the target session's project
+    // cwd (the client "manage / remove persistent rule" path — send the reduced
+    // list to drop one). Absent → session rules only, unchanged behaviour.
+    projectRules: z.array(PermissionRuleSchema).max(1000).optional(),
     sessionId: z.string().max(256).optional(),
 });
 // #3185: per-session promptEvaluator toggle. Strict boolean — the server

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -288,6 +288,11 @@ export const TestCredentialSchema = z.object({
 export const SetPermissionRulesSchema = z.object({
   type: z.literal('set_permission_rules'),
   rules: z.array(PermissionRuleSchema).max(1000),
+  // #6771: optional durable per-project rule set. When present it FULLY REPLACES
+  // the persisted "always allow / deny" rules for the target session's project
+  // cwd (the client "manage / remove persistent rule" path — send the reduced
+  // list to drop one). Absent → session rules only, unchanged behaviour.
+  projectRules: z.array(PermissionRuleSchema).max(1000).optional(),
   sessionId: z.string().max(256).optional(),
 })
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -134,6 +134,7 @@ export const BASE_SESSION_OPT_KEYS = [
   'hardTimeoutMs',
   'streamStallTimeoutMs',
   'backgroundShellHardQuiesceMs',
+  'permissionRuleStore',
 ]
 
 // #5367: pick the BaseSession opts out of a subclass's full opts bag and merge
@@ -287,9 +288,19 @@ export class BaseSession extends EventEmitter {
     // BACKGROUND_SHELL_HARD_QUIESCE_MS (4h); 0 disables hard-reaping (revert
     // to #5247 advisory-only). Forwarded from config via SessionManager.
     backgroundShellHardQuiesceMs,
+    // #6771 — the daemon-wide durable PermissionRuleStore (persistent per-project
+    // "always allow / deny"). A runtime handle (not serialized), forwarded from
+    // SessionManager; the in-process permission providers (SDK / BYOK / codex)
+    // hand it to their PermissionManager so an `allowAlways` decision persists a
+    // project-scoped rule and new sessions in the same cwd seed from it.
+    permissionRuleStore,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
+    // #6771 — durable per-project permission rule store (see the opt doc above).
+    // Read by the in-process permission providers when they build their
+    // PermissionManager; null on providers/tests that don't wire it.
+    this._permissionRuleStore = permissionRuleStore || null
     this.model = model || null
     // Actual model the underlying CLI/SDK reports at init time. May differ
     // from `this.model` (the user's requested override) when no override

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -284,7 +284,8 @@ export class ClaudeByokSession extends BaseSession {
     // providers. ByokSession passes no pause/resume hooks (no result-timeout).
     // #6794 — pass cwd so the protected-path floor can resolve relative tool
     // targets (.git/.claude/.env…) against this session's working directory.
-    this._permissions = new PermissionManager({ log, cwd: this.cwd })
+    // #6771 — pass the durable rule store (persistent per-project allow-always).
+    this._permissions = new PermissionManager({ log, cwd: this.cwd, ruleStore: this._permissionRuleStore })
     wirePermissionManager(this, this._permissions)
 
     // Realpath cache used by the tool executor's path-safety check. One
@@ -1880,6 +1881,33 @@ export class ClaudeByokSession extends BaseSession {
   setPermissionRules(rules) {
     if (typeof this._permissions.setRules === 'function') {
       this._permissions.setRules(rules)
+    }
+  }
+
+  /** Current session-scoped permission rules (#3072 parity with SdkSession). */
+  getPermissionRules() {
+    if (typeof this._permissions.getRules === 'function') {
+      return this._permissions.getRules()
+    }
+    return []
+  }
+
+  /**
+   * #6771 — durable (project-scoped) permission rules applied to this session.
+   */
+  getPersistentPermissionRules() {
+    if (typeof this._permissions.getPersistentRules === 'function') {
+      return this._permissions.getPersistentRules()
+    }
+    return []
+  }
+
+  /**
+   * #6771 — re-seed this session's in-memory durable rule set (no persist).
+   */
+  setPersistentPermissionRules(rules) {
+    if (typeof this._permissions.setPersistentRules === 'function') {
+      this._permissions.setPersistentRules(rules)
     }
   }
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -113,7 +113,8 @@ export class CodexAppServerSession extends BaseSession {
     // _pendingPermissions/_lastPermissionData for ws-permissions.js.
     // #6794 — pass cwd so the protected-path floor can resolve relative tool
     // targets (.git/.claude/.env…) against this session's working directory.
-    this._permissions = new PermissionManager({ log, cwd: this.cwd })
+    // #6771 — pass the durable rule store (persistent per-project allow-always).
+    this._permissions = new PermissionManager({ log, cwd: this.cwd, ruleStore: this._permissionRuleStore })
     wirePermissionManager(this, this._permissions, {
       onRequest: () => this._pauseResultTimeoutForPermission(),
       onResolved: () => this._resumeResultTimeoutForPermission(),

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -532,6 +532,25 @@ function handlePermissionResponse(ws, client, msg, ctx) {
     // subscriber without excluding the origin client.
     ctx.transport.broadcast({ type: 'permission_resolved', requestId, decision })
   }
+
+  // #6771 — an `allowAlways` that resolved on an in-process session just
+  // persisted a durable project rule (permission-manager.js). Broadcast the
+  // updated rule sets so every client's rules surface (mobile SessionRules,
+  // etc.) reflects the new standing grant without a reconnect. The manager
+  // updated its in-memory persistent set synchronously during respondToPermission,
+  // so getPersistentPermissionRules() already includes it.
+  if (decision === 'allowAlways' && result.sessionId) {
+    const rulesEntry = ctx.sessions.sessionManager?.getSession?.(result.sessionId)
+    const rulesSession = rulesEntry?.session
+    if (rulesSession && typeof rulesSession.getPersistentPermissionRules === 'function') {
+      ctx.transport.broadcastToSession(result.sessionId, {
+        type: 'permission_rules_updated',
+        sessionId: result.sessionId,
+        rules: typeof rulesSession.getPermissionRules === 'function' ? rulesSession.getPermissionRules() : [],
+        persistentRules: rulesSession.getPersistentPermissionRules(),
+      })
+    }
+  }
 }
 
 function handleQueryPermissionAudit(ws, client, msg, ctx) {
@@ -713,6 +732,41 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
     }
   }
 
+  // #6771 — optional durable (project-scoped) rule set. When present, it FULLY
+  // REPLACES the persisted rules for this session's project cwd — the client
+  // "manage / remove persistent rule" path (send the reduced list to drop one).
+  // Validated with the same eligibility floor as session rules.
+  const projectRules = msg.projectRules
+  if (projectRules !== undefined) {
+    if (!Array.isArray(projectRules)) {
+      sendSessionError(ws, ctx, 'projectRules must be an array')
+      return
+    }
+    for (let i = 0; i < projectRules.length; i++) {
+      const rule = projectRules[i]
+      if (!rule || typeof rule !== 'object') {
+        sendSessionError(ws, ctx, `projectRules[${i}]: not an object`)
+        return
+      }
+      if (typeof rule.tool !== 'string' || !rule.tool.trim()) {
+        sendSessionError(ws, ctx, `projectRules[${i}]: missing tool name`)
+        return
+      }
+      if (rule.decision !== 'allow' && rule.decision !== 'deny') {
+        sendSessionError(ws, ctx, `projectRules[${i}]: decision must be 'allow' or 'deny'`)
+        return
+      }
+      if (rule.decision === 'allow' && NEVER_AUTO_ALLOW.has(rule.tool)) {
+        sendSessionError(ws, ctx, `projectRules[${i}]: tool '${rule.tool}' cannot be auto-allowed`)
+        return
+      }
+      if (rule.decision === 'allow' && !ELIGIBLE_TOOLS.has(rule.tool)) {
+        sendSessionError(ws, ctx, `projectRules[${i}]: tool '${rule.tool}' is not eligible for permission rules`)
+        return
+      }
+    }
+  }
+
   const sessionId = msg.sessionId || client.activeSessionId
   const entry = resolveSessionOrError(ws, ctx, msg, client)
   if (!entry) return
@@ -723,6 +777,17 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
 
   entry.session.setPermissionRules(rules)
 
+  // #6771 — apply the durable project-rule replacement (if any) to the store,
+  // then re-seed THIS session's in-memory persistent set so it takes effect
+  // immediately. The store is keyed by the session's cwd.
+  const ruleStore = ctx.sessions.sessionManager?.permissionRuleStore
+  if (projectRules !== undefined && ruleStore && typeof ruleStore.setRules === 'function') {
+    const stored = ruleStore.setRules(entry.session.cwd, projectRules)
+    if (typeof entry.session.setPersistentPermissionRules === 'function') {
+      entry.session.setPersistentPermissionRules(stored)
+    }
+  }
+
   // Audit the whitelist change
   if (ctx.permissions.permissionAudit) {
     ctx.permissions.permissionAudit.logWhitelistChange({
@@ -732,11 +797,15 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
     })
   }
 
-  // Broadcast updated rules to all session clients
+  // Broadcast updated rules to all session clients. #6771 — include the durable
+  // persistentRules so the rules surfaces show session AND project grants.
   const currentRules = entry.session.getPermissionRules ? entry.session.getPermissionRules() : rules
-  ctx.transport.broadcastToSession(sessionId, { type: 'permission_rules_updated', rules: currentRules, sessionId })
+  const persistentRules = typeof entry.session.getPersistentPermissionRules === 'function'
+    ? entry.session.getPersistentPermissionRules()
+    : []
+  ctx.transport.broadcastToSession(sessionId, { type: 'permission_rules_updated', rules: currentRules, persistentRules, sessionId })
   // #4828: session-scoped.
-  loggerForSession('ws', sessionId).info(`Permission rules updated by ${client.id} on session ${sessionId}: ${rules.length} rule(s)`)
+  loggerForSession('ws', sessionId).info(`Permission rules updated by ${client.id} on session ${sessionId}: ${rules.length} session rule(s)${projectRules !== undefined ? `, ${projectRules.length} project rule(s)` : ''}`)
 }
 
 // #4664: assemble the per-session-setting WS handlers from the registry.

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -98,6 +98,32 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
 }
 
 /**
+ * #6794 — is a single path value protected, resolved against `base`?
+ * `resolve()` absorbs absolute paths, a leading `./`, and `..` traversal; the
+ * relative path is what we segment-match so cwd's own name can't false-match.
+ * Segments are lowercased first: on case-insensitive filesystems (macOS APFS,
+ * Windows) `.GIT/config` IS `.git/config`, so a case-sensitive match would let
+ * case variants evade the floor. Over-flooring a genuinely distinct `.GIT` on
+ * case-sensitive Linux is fine — the floor only forces a prompt, never denies.
+ * @param {string} target  a path value from a tool input
+ * @param {string} base    the resolution base (session cwd)
+ * @returns {boolean}
+ */
+function isProtectedPathValue(target, base) {
+  const rel = relative(base, resolve(base, target))
+  const segments = rel.split(sep)
+    .filter((s) => s.length > 0 && s !== '..')
+    .map((s) => s.toLowerCase())
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
+    if (seg === '.env' || seg.startsWith('.env.')) return true
+    if (seg === '.config' && segments[i + 1] === 'git') return true
+  }
+  return false
+}
+
+/**
  * #6794 — does this tool input target a protected path? Inspects EVERY present
  * {@link PROTECTED_PATH_INPUT_FIELDS} value (a benign `file_path` must not
  * shadow a protected `path`), resolves each against the session cwd (so
@@ -105,14 +131,25 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
  * tests the path RELATIVE to cwd segment-by-segment. ANY protected field
  * floors the input.
  *
+ * #6805/#6828 — codex `apply_patch` carries its per-file targets in an ARRAY:
+ * `input.changes` is `FileUpdateChange[] = { path, kind, diff }` (see
+ * codex-app-server-session.js `_describeApproval`), with the top-level
+ * `file_path` set to the approval's `grantRoot` — typically the benign repo
+ * root. Scanning only the flat fields therefore let a member edit under
+ * `.git/`/`.env*` escape the floor (and, with a persisted `{apply_patch,
+ * allow}` rule from #6771, be durably auto-approved). Every array entry's
+ * `path` is now checked with the same matcher — ANY protected member floors
+ * the WHOLE request. A string-shaped `changes` (codex's legacy unified-diff
+ * `item.patch` passthrough) carries no parseable paths and is skipped, same
+ * as any other non-array field.
+ *
  * Matching relative-to-cwd (not the raw absolute path) is deliberate: the
  * session's OWN location can never trigger a false positive — e.g. a git
  * worktree that itself lives under a real `.claude/` dir writing to
  * `packages/…` is NOT floored, because the `.claude` segment is above cwd.
  *
- * Segment rules (a match on ANY segment floors the write; segments are
- * lowercased first so `.GIT`/`.Env.local` can't evade the floor on the
- * case-insensitive filesystems where they alias the real paths):
+ * Segment rules (a match on ANY segment floors the write; see
+ * {@link isProtectedPathValue} for the lowercase rationale):
  *   - a segment in {@link PROTECTED_DIR_SEGMENTS} (`.git` / `.claude` / `.vscode`)
  *   - a `.config` segment immediately followed by `git` (the XDG git-config dir)
  *   - a segment that is `.env` or starts with `.env.` (`.env` / `.env.local` / …)
@@ -133,22 +170,13 @@ export function isProtectedPathTarget(input, cwd) {
   const base = (typeof cwd === 'string' && cwd.length > 0) ? cwd : process.cwd()
   for (const field of PROTECTED_PATH_INPUT_FIELDS) {
     if (typeof input[field] !== 'string' || input[field].length === 0) continue
-    // resolve() absorbs absolute paths, a leading `./`, and `..` traversal; the
-    // relative path is what we segment-match so cwd's own name can't false-match.
-    const rel = relative(base, resolve(base, input[field]))
-    // Lowercase every segment before matching: on case-insensitive filesystems
-    // (macOS APFS, Windows) `.GIT/config` IS `.git/config`, so a case-sensitive
-    // match would let case variants evade the floor. Over-flooring a genuinely
-    // distinct `.GIT` on case-sensitive Linux is fine — the floor only forces a
-    // prompt, never denies.
-    const segments = rel.split(sep)
-      .filter((s) => s.length > 0 && s !== '..')
-      .map((s) => s.toLowerCase())
-    for (let i = 0; i < segments.length; i++) {
-      const seg = segments[i]
-      if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
-      if (seg === '.env' || seg.startsWith('.env.')) return true
-      if (seg === '.config' && segments[i + 1] === 'git') return true
+    if (isProtectedPathValue(input[field], base)) return true
+  }
+  // #6805/#6828 — walk the array-shaped per-file targets (codex apply_patch).
+  if (Array.isArray(input.changes)) {
+    for (const change of input.changes) {
+      if (!change || typeof change.path !== 'string' || change.path.length === 0) continue
+      if (isProtectedPathValue(change.path, base)) return true
     }
   }
   return false

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -170,7 +170,7 @@ export function isProtectedPathTarget(input, cwd) {
  *   user_question       { toolUseId, questions }
  */
 export class PermissionManager extends EventEmitter {
-  constructor({ timeoutMs, log, maxPendingPermissions, cwd } = {}) {
+  constructor({ timeoutMs, log, maxPendingPermissions, cwd, ruleStore } = {}) {
     super()
     this._timeoutMs = timeoutMs || DEFAULT_TIMEOUT_MS
     this._log = log || console
@@ -181,6 +181,12 @@ export class PermissionManager extends EventEmitter {
     // isProtectedPathTarget). Optional: when unset the floor resolves targets
     // against process.cwd(), which still catches relative protected paths.
     this._cwd = (typeof cwd === 'string' && cwd.length > 0) ? cwd : null
+    // #6771 — durable per-project rule store (PermissionRuleStore). Optional:
+    // when present, an `allowAlways` decision persists a rule keyed by this
+    // session's cwd, and this session seeds its persistent rules from the store
+    // on construction (below) so a prior grant takes effect without re-prompting
+    // after a daemon restart.
+    this._ruleStore = ruleStore || null
 
     this._pendingPermissions = new Map() // requestId -> { resolve, input }
     this._permissionTimers = new Map()   // requestId -> timer
@@ -200,6 +206,15 @@ export class PermissionManager extends EventEmitter {
 
     // Session-scoped permission rules
     this._sessionRules = [] // [{ tool, decision }]
+
+    // #6771 — durable per-project rules seeded from the store for THIS
+    // session's cwd. Kept SEPARATE from `_sessionRules` so `setRules`/
+    // `clearRules` (the session-scoped `set_permission_rules` path, and the
+    // clearRules() on a permission-mode switch) never wipe a project-level
+    // "always allow", and vice-versa. `_matchesRule` consults both.
+    this._persistentRules = (this._ruleStore && this._cwd)
+      ? this._ruleStore.getRules(this._cwd)
+      : []
 
     // AskUserQuestion handling
     this._pendingUserAnswer = null // { resolve, input, toolUseId } when waiting for user answer
@@ -250,20 +265,55 @@ export class PermissionManager extends EventEmitter {
   }
 
   /**
-   * Clear all session-scoped permission rules.
+   * Clear all session-scoped permission rules. Persistent (project-scoped)
+   * rules are UNTOUCHED — a mode switch or a `set_permission_rules []` must not
+   * silently revoke a durable "always allow" (#6771).
    */
   clearRules() {
     this._sessionRules = []
   }
 
   /**
-   * Check whether a toolName matches a session rule.
+   * Return a copy of the durable (project-scoped) rules currently applied to
+   * this session, each tagged `persist: 'project'` so a client can render them
+   * distinctly from session rules (#6771).
+   *
+   * @returns {Array<{tool: string, decision: string, persist: 'project'}>}
+   */
+  getPersistentRules() {
+    return this._persistentRules.map((r) => ({ tool: r.tool, decision: r.decision, persist: 'project' }))
+  }
+
+  /**
+   * Replace this session's durable rule set in memory (does NOT persist —
+   * callers that own the store persist separately). Used to re-seed after the
+   * store changes out-of-band (e.g. a client edited the project's rules).
+   *
+   * @param {Array<{tool: string, decision: string}>} rules
+   */
+  setPersistentRules(rules) {
+    this._persistentRules = Array.isArray(rules)
+      ? rules
+        .filter((r) => r && typeof r.tool === 'string' && (r.decision === 'allow' || r.decision === 'deny'))
+        .map((r) => ({ tool: r.tool, decision: r.decision }))
+      : []
+  }
+
+  /**
+   * Check whether a toolName matches a session or persistent rule. Session
+   * rules are consulted FIRST (a live, intentional session decision wins over a
+   * standing project grant), then the durable project rules (#6771).
    *
    * @param {string} toolName
    * @returns {'allow'|'deny'|null} null if no rule matches
    */
   _matchesRule(toolName) {
     for (const rule of this._sessionRules) {
+      if (rule.tool === toolName) {
+        return rule.decision
+      }
+    }
+    for (const rule of this._persistentRules) {
       if (rule.tool === toolName) {
         return rule.decision
       }
@@ -529,6 +579,23 @@ export class PermissionManager extends EventEmitter {
       }
       if (pending.suggestions && pending.suggestions.length > 0) {
         result.updatedPermissions = pending.suggestions
+      }
+      // #6771 — persist a DURABLE project-scoped rule so this grant survives a
+      // daemon restart (the SDK `updatedPermissions` above only persists within
+      // the SDK's own session). Only for rule-eligible tools: the store rejects
+      // NEVER_AUTO_ALLOW / non-ELIGIBLE tools, so an `allowAlways` on Bash (or a
+      // codex `shell`) degrades to a one-shot allow and is NEVER durably
+      // whitelisted. Seed the in-memory persistent set too so the very next tool
+      // call in THIS session auto-allows without re-prompting.
+      if (toolName && this._ruleStore && this._cwd) {
+        const persisted = this._ruleStore.addRule(this._cwd, { tool: toolName, decision: 'allow' })
+        if (persisted) {
+          // Re-seed the in-memory set so the very next tool call in THIS session
+          // auto-allows. The client-facing `permission_rules_updated` broadcast
+          // is emitted by the WS response handler (settings-handlers.js) after
+          // this resolves — getPersistentRules() reflects the update synchronously.
+          this.setPersistentRules(this._ruleStore.getRules(this._cwd))
+        }
       }
       pending.resolve(result)
     } else {

--- a/packages/server/src/permission-rule-store.js
+++ b/packages/server/src/permission-rule-store.js
@@ -89,14 +89,26 @@ export class PermissionRuleStore {
   }
 
   /**
-   * Load rules from disk. Idempotent — safe to call once at daemon start. A
-   * missing file is treated as an empty store; an unparseable / malformed file
-   * is logged and skipped (fail-open to "no persisted rules" rather than
-   * crashing daemon start over a corrupt sidecar).
+   * Load rules from disk, REPLACING any in-memory state — load() is a true
+   * snapshot of the file, so a second load() (or a load after the file was
+   * deleted or corrupted) can never keep stale in-memory rules alive and
+   * re-persist them on the next write. A missing file is treated as an empty
+   * store; an unparseable / malformed / unknown-version file is logged and
+   * skipped whole (fail-open to "no persisted rules", never a partial read).
+   *
+   * Project keys are re-normalized through {@link normalizeProjectKey} on load
+   * (the same function every read/write path uses), so a hand-edited
+   * non-normalized key (trailing slash, `..` segments) can't create a shadow
+   * entry that a session's normalized cwd never matches. Two file keys that
+   * normalize to the same cwd merge (first key's rule wins per tool, matching
+   * the per-project dedupe).
    * @returns {this}
    */
   load() {
     this._loaded = true
+    // Reset FIRST — see the doc block: every early return below must leave the
+    // store EMPTY, not holding the previous load's (now unbacked) rules.
+    this._projects.clear()
     let raw
     try {
       raw = fs.readFileSync(this._filePath, 'utf-8')
@@ -113,11 +125,24 @@ export class PermissionRuleStore {
       this._log.warn(`Failed to parse permission rules at ${this._filePath}: ${err.message} — ignoring`)
       return this
     }
-    const projects = parsed && typeof parsed === 'object' ? parsed.projects : null
+    if (!parsed || typeof parsed !== 'object') return this
+    // Version gate: an unknown (future / hand-mangled) version is skipped WHOLE
+    // rather than partially read against the wrong shape assumptions.
+    if (parsed.version !== STORE_VERSION) {
+      this._log.warn(`Unsupported permission-rules version ${JSON.stringify(parsed.version)} at ${this._filePath} (expected ${STORE_VERSION}) — ignoring`)
+      return this
+    }
+    const projects = parsed.projects
     if (!projects || typeof projects !== 'object') return this
-    for (const [key, entry] of Object.entries(projects)) {
+    for (const [rawKey, entry] of Object.entries(projects)) {
+      // Re-normalize the file key so non-normalized spellings can't shadow the
+      // normalized key every runtime read/write uses. An unkeyable entry is dropped.
+      const key = normalizeProjectKey(rawKey)
+      if (!key) continue
       const rules = entry && Array.isArray(entry.rules) ? entry.rules : []
-      const clean = []
+      // Merge base: rules already loaded under the same NORMALIZED key from an
+      // earlier (differently-spelled) file key — dedupe by tool, first key wins.
+      const clean = this._projects.get(key)?.slice() ?? []
       for (const rule of rules) {
         if (!rule || typeof rule.tool !== 'string') continue
         if (rule.decision !== 'allow' && rule.decision !== 'deny') continue

--- a/packages/server/src/permission-rule-store.js
+++ b/packages/server/src/permission-rule-store.js
@@ -1,0 +1,270 @@
+import fs from 'fs'
+import { dirname, resolve } from 'path'
+import { writeFileRestricted } from './platform.js'
+import { createLogger } from './logger.js'
+import { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from './permission-manager.js'
+
+const log = createLogger('permission-rule-store')
+
+// Current on-disk schema version. Bumped only on a breaking shape change so a
+// future loader can migrate (or discard) an older file rather than silently
+// mis-reading it.
+const STORE_VERSION = 1
+
+// Hard cap on persisted rules PER PROJECT (mirrors MAX_SESSION_RULES in
+// permission-manager.js — the persistent set is matched on every tool call the
+// same way the session set is). A normal project has a handful; this only bites
+// a hand-edited or runaway file.
+const MAX_RULES_PER_PROJECT = 100
+
+/**
+ * Normalize a project key from a session cwd. `path.resolve` collapses `.`/`..`
+ * and makes the key absolute so two spellings of the same directory
+ * (`/x/proj`, `/x/proj/`, `/x/proj/.`) share one entry. Deliberately NOT
+ * case-folded: the session cwd is stored verbatim elsewhere, and folding here
+ * would let a case-insensitive filesystem alias two genuinely distinct keys on
+ * the rare case-sensitive host. A non-string / empty cwd yields null (the
+ * caller then skips persistence — an unkeyable session can't own a rule).
+ * @param {string} cwd
+ * @returns {string|null}
+ */
+export function normalizeProjectKey(cwd) {
+  if (typeof cwd !== 'string' || cwd.length === 0) return null
+  try {
+    return resolve(cwd)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether a tool may be PERMANENTLY auto-approved. Same floor the session-rule
+ * path enforces (settings-handlers.js / permission-manager.setRules): a tool
+ * must be in ELIGIBLE_TOOLS and NOT in NEVER_AUTO_ALLOW. This keeps
+ * execution/network tools (Bash, Task, WebFetch, WebSearch, codex shell, …) out
+ * of the durable store even if a client somehow requests allowAlways for one.
+ * @param {string} tool
+ * @returns {boolean}
+ */
+export function isPersistableTool(tool) {
+  return typeof tool === 'string'
+    && ELIGIBLE_TOOLS.has(tool)
+    && !NEVER_AUTO_ALLOW.has(tool)
+}
+
+/**
+ * Durable, per-project permission rule store — the "always allow / always deny"
+ * decisions that must survive a daemon restart (issue #6771). Persists to a
+ * single JSON file (a sibling of `session-state.json`, e.g.
+ * `~/.chroxy/permission-rules.json`) keyed by NORMALIZED project cwd, distinct
+ * from PermissionManager's ephemeral in-memory `_sessionRules`.
+ *
+ * Shape:
+ *   {
+ *     "version": 1,
+ *     "projects": {
+ *       "/abs/project/cwd": {
+ *         "rules": [ { "tool": "Write", "decision": "allow", "createdAt": 123 } ]
+ *       }
+ *     }
+ *   }
+ *
+ * Loaded once on daemon start; a new session with a matching cwd seeds its
+ * PermissionManager from `getRules(cwd)`. Writes are atomic (temp + rename via
+ * writeFileRestricted, mode 0600) so a crash mid-write can't corrupt the file.
+ */
+export class PermissionRuleStore {
+  /**
+   * @param {object} options
+   * @param {string} options.filePath - Path to the rules JSON file.
+   * @param {object} [options.logger] - Optional logger (defaults to module logger).
+   */
+  constructor({ filePath, logger } = {}) {
+    if (!filePath) throw new Error('PermissionRuleStore requires a filePath')
+    this._filePath = filePath
+    this._log = logger || log
+    // projectKey -> [{ tool, decision, createdAt }]
+    this._projects = new Map()
+    this._loaded = false
+  }
+
+  /**
+   * Load rules from disk. Idempotent — safe to call once at daemon start. A
+   * missing file is treated as an empty store; an unparseable / malformed file
+   * is logged and skipped (fail-open to "no persisted rules" rather than
+   * crashing daemon start over a corrupt sidecar).
+   * @returns {this}
+   */
+  load() {
+    this._loaded = true
+    let raw
+    try {
+      raw = fs.readFileSync(this._filePath, 'utf-8')
+    } catch (err) {
+      if (err && err.code !== 'ENOENT') {
+        this._log.warn(`Failed to read permission rules at ${this._filePath}: ${err.message}`)
+      }
+      return this
+    }
+    let parsed
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      this._log.warn(`Failed to parse permission rules at ${this._filePath}: ${err.message} — ignoring`)
+      return this
+    }
+    const projects = parsed && typeof parsed === 'object' ? parsed.projects : null
+    if (!projects || typeof projects !== 'object') return this
+    for (const [key, entry] of Object.entries(projects)) {
+      const rules = entry && Array.isArray(entry.rules) ? entry.rules : []
+      const clean = []
+      for (const rule of rules) {
+        if (!rule || typeof rule.tool !== 'string') continue
+        if (rule.decision !== 'allow' && rule.decision !== 'deny') continue
+        // Enforce the same durable-eligibility floor on LOAD as on write, so a
+        // hand-edited file can't smuggle a Bash allow past NEVER_AUTO_ALLOW.
+        if (rule.decision === 'allow' && !isPersistableTool(rule.tool)) continue
+        if (clean.some((r) => r.tool === rule.tool)) continue
+        clean.push({
+          tool: rule.tool,
+          decision: rule.decision,
+          createdAt: typeof rule.createdAt === 'number' ? rule.createdAt : Date.now(),
+        })
+        if (clean.length >= MAX_RULES_PER_PROJECT) break
+      }
+      if (clean.length > 0) this._projects.set(key, clean)
+    }
+    const count = Array.from(this._projects.values()).reduce((n, r) => n + r.length, 0)
+    if (count > 0) this._log.info(`Loaded ${count} persistent permission rule(s) across ${this._projects.size} project(s)`)
+    return this
+  }
+
+  /**
+   * Return the persisted rules for a project cwd as `[{ tool, decision }]`
+   * (metadata stripped — the shape PermissionManager's `_matchesRule` consumes).
+   * Empty array when the cwd has no persisted rules.
+   * @param {string} cwd
+   * @returns {Array<{tool: string, decision: string}>}
+   */
+  getRules(cwd) {
+    const key = normalizeProjectKey(cwd)
+    if (!key) return []
+    const rules = this._projects.get(key)
+    if (!rules) return []
+    return rules.map((r) => ({ tool: r.tool, decision: r.decision }))
+  }
+
+  /**
+   * Add (or replace) a durable rule for a project cwd and persist. An `allow`
+   * rule for a non-persistable tool (NEVER_AUTO_ALLOW / not ELIGIBLE) is
+   * rejected — returns false without writing. A rule for the same tool is
+   * replaced (last-writer-wins) rather than duplicated. Returns true when the
+   * store changed and was persisted.
+   * @param {string} cwd
+   * @param {{tool: string, decision: string}} rule
+   * @returns {boolean}
+   */
+  addRule(cwd, rule) {
+    const key = normalizeProjectKey(cwd)
+    if (!key) return false
+    if (!rule || typeof rule.tool !== 'string') return false
+    if (rule.decision !== 'allow' && rule.decision !== 'deny') return false
+    if (rule.decision === 'allow' && !isPersistableTool(rule.tool)) {
+      this._log.warn(`Refusing to persist allow rule for non-persistable tool '${rule.tool}'`)
+      return false
+    }
+    const existing = this._projects.get(key) || []
+    if (existing.length >= MAX_RULES_PER_PROJECT && !existing.some((r) => r.tool === rule.tool)) {
+      this._log.warn(`Project ${key} at persistent-rule cap (${MAX_RULES_PER_PROJECT}) — not adding '${rule.tool}'`)
+      return false
+    }
+    const next = existing.filter((r) => r.tool !== rule.tool)
+    next.push({ tool: rule.tool, decision: rule.decision, createdAt: Date.now() })
+    this._projects.set(key, next)
+    this._persist()
+    return true
+  }
+
+  /**
+   * Replace the ENTIRE persistent rule set for a project cwd (used by the
+   * client-driven "manage / remove" path). Invalid rules and non-persistable
+   * `allow` rules are filtered out; duplicates by tool are collapsed
+   * (last-writer-wins). An empty result removes the project entry. Persists.
+   * @param {string} cwd
+   * @param {Array<{tool: string, decision: string}>} rules
+   * @returns {Array<{tool: string, decision: string}>} the stored rules
+   */
+  setRules(cwd, rules) {
+    const key = normalizeProjectKey(cwd)
+    if (!key) return []
+    const clean = []
+    if (Array.isArray(rules)) {
+      for (const rule of rules) {
+        if (!rule || typeof rule.tool !== 'string') continue
+        if (rule.decision !== 'allow' && rule.decision !== 'deny') continue
+        if (rule.decision === 'allow' && !isPersistableTool(rule.tool)) continue
+        const idx = clean.findIndex((r) => r.tool === rule.tool)
+        const record = { tool: rule.tool, decision: rule.decision, createdAt: Date.now() }
+        if (idx >= 0) clean[idx] = record
+        else clean.push(record)
+        if (clean.length >= MAX_RULES_PER_PROJECT) break
+      }
+    }
+    if (clean.length === 0) this._projects.delete(key)
+    else this._projects.set(key, clean)
+    this._persist()
+    return clean.map((r) => ({ tool: r.tool, decision: r.decision }))
+  }
+
+  /**
+   * Remove a single durable rule (by tool) for a project cwd and persist.
+   * Returns true when a rule was actually removed.
+   * @param {string} cwd
+   * @param {string} tool
+   * @returns {boolean}
+   */
+  removeRule(cwd, tool) {
+    const key = normalizeProjectKey(cwd)
+    if (!key) return false
+    const existing = this._projects.get(key)
+    if (!existing) return false
+    const next = existing.filter((r) => r.tool !== tool)
+    if (next.length === existing.length) return false
+    if (next.length === 0) this._projects.delete(key)
+    else this._projects.set(key, next)
+    this._persist()
+    return true
+  }
+
+  /**
+   * Snapshot of every project's rules — `{ [projectKey]: [{tool, decision}] }`.
+   * For diagnostics / a future management surface.
+   * @returns {Record<string, Array<{tool: string, decision: string}>>}
+   */
+  listProjects() {
+    const out = {}
+    for (const [key, rules] of this._projects) {
+      out[key] = rules.map((r) => ({ tool: r.tool, decision: r.decision }))
+    }
+    return out
+  }
+
+  /** @private — atomic write of the whole store. */
+  _persist() {
+    try {
+      const dir = dirname(this._filePath)
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+      const projects = {}
+      for (const [key, rules] of this._projects) {
+        projects[key] = { rules }
+      }
+      const state = { version: STORE_VERSION, projects }
+      writeFileRestricted(this._filePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
+    } catch (err) {
+      // Best-effort: a failed persist leaves the in-memory set intact for this
+      // process; the prior good file (if any) survives (atomic write). Surface
+      // it so an operator can see the durable grant won't survive a restart.
+      this._log.error(`Failed to persist permission rules to ${this._filePath}: ${err?.stack || err}`)
+    }
+  }
+}

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -387,7 +387,9 @@ export class SdkSession extends BaseSession {
     // suspended until the last one resolves. (Shared wiring extracted in P2-9.)
     // #6794 — pass cwd so the protected-path floor can resolve relative tool
     // targets (.git/.claude/.env…) against this session's working directory.
-    this._permissions = new PermissionManager({ log, cwd: this.cwd })
+    // #6771 — pass the durable rule store so an `allowAlways` decision persists
+    // a project-scoped rule and this session seeds from prior grants for its cwd.
+    this._permissions = new PermissionManager({ log, cwd: this.cwd, ruleStore: this._permissionRuleStore })
     wirePermissionManager(this, this._permissions, {
       onRequest: () => this._pauseResultTimeoutForPermission(),
       onResolved: () => this._resumeResultTimeoutForPermission(),
@@ -1594,6 +1596,29 @@ export class SdkSession extends BaseSession {
   clearPermissionRules() {
     if (typeof this._permissions.clearRules === 'function') {
       this._permissions.clearRules()
+    }
+  }
+
+  /**
+   * #6771 — durable (project-scoped) permission rules currently applied to this
+   * session, tagged `persist:'project'`. Delegates to PermissionManager.
+   * @returns {Array<{tool: string, decision: string, persist: 'project'}>}
+   */
+  getPersistentPermissionRules() {
+    if (typeof this._permissions.getPersistentRules === 'function') {
+      return this._permissions.getPersistentRules()
+    }
+    return []
+  }
+
+  /**
+   * #6771 — re-seed this session's in-memory durable rule set (does NOT persist;
+   * the caller owns the store write). Delegates to PermissionManager.
+   * @param {Array<{tool: string, decision: string}>} rules
+   */
+  setPersistentPermissionRules(rules) {
+    if (typeof this._permissions.setPersistentRules === 'function') {
+      this._permissions.setPersistentRules(rules)
     }
   }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -22,6 +22,7 @@ import { SessionMessageHistory } from './session-message-history.js'
 import { SkillsUsageRecorder } from './skills-usage.js'
 import { resolveSessionPreset, foldPreamble } from './session-preset.js'
 import { SessionPresetTrustStore } from './session-preset-trust.js'
+import { PermissionRuleStore } from './permission-rule-store.js'
 import { createLogger } from './logger.js'
 import { ExternalSessionRegistry } from './external-session-registry.js'
 import { metrics } from './metrics.js'
@@ -327,6 +328,11 @@ export class SessionManager extends EventEmitter {
     // #5553: config path for the daemon-side preset override map. Tests point
     // this at a temp config.json; production uses the default ~/.chroxy/config.json.
     presetConfigPath,
+    // #6771: durable per-project permission rule store (persistent "always
+    // allow / deny"). Tests pass their own temp-pathed store; production wires a
+    // default whose file (permission-rules.json) sits next to the session-state
+    // file so a temp stateFilePath keeps it out of the real ~/.chroxy.
+    permissionRuleStore,
 
     // Message history
     maxMessages,
@@ -510,6 +516,18 @@ export class SessionManager extends EventEmitter {
     // Config path the preset resolver reads the daemon override map from.
     // Defaults to undefined → resolveSessionPreset uses its own DEFAULT_CONFIG_PATH.
     this.presetConfigPath = typeof presetConfigPath === 'string' ? presetConfigPath : null
+    // #6771: durable per-project permission rule store. Same temp-redirect logic
+    // as the sidecars above — the default file sits next to the session-state
+    // file so a test's temp stateFilePath keeps the rules out of the real home.
+    // Only the DEFAULT store is loaded here (so restored + newly-created sessions
+    // in a known cwd seed their persistent rules from prior grants); a
+    // caller-supplied store owns its own load() lifecycle.
+    if (permissionRuleStore) {
+      this.permissionRuleStore = permissionRuleStore
+    } else {
+      this.permissionRuleStore = new PermissionRuleStore({ filePath: join(dirname(this._stateFilePath), 'permission-rules.json') })
+      this.permissionRuleStore.load()
+    }
     Object.defineProperty(this, '_persistTimer', {
       get: () => this._persistence._persistTimer,
       set: (v) => { this._persistence._persistTimer = v },
@@ -1263,6 +1281,11 @@ export class SessionManager extends EventEmitter {
     if (containerId) providerOpts.containerId = containerId
     if (containerUser) providerOpts.containerUser = containerUser
     if (containerCliPath) providerOpts.containerCliPath = containerCliPath
+    // #6771: hand the durable per-project permission rule store to the session so
+    // its PermissionManager (SDK / BYOK / codex-app-server) can seed persistent
+    // rules for this cwd and persist an `allowAlways` decision. A runtime handle,
+    // forwarded via BASE_SESSION_OPT_KEYS.
+    providerOpts.permissionRuleStore = this.permissionRuleStore
     const session = new ProviderClass(providerOpts)
     // Pre-seed `bootedModel` from a restored snapshot so the dashboard can
     // surface the session's actual model immediately on reconnect, without

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -971,11 +971,17 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
       sessionId,
     })
   }
-  // Replay permission rules so reconnecting clients have current whitelist
+  // Replay permission rules so reconnecting clients have current whitelist.
+  // #6771 — also replay durable per-project rules (persistentRules) so the
+  // rules surfaces show standing "always allow" grants on session load, not
+  // only after a fresh allowAlways in the current session.
   if (typeof session.getPermissionRules === 'function') {
     const rules = session.getPermissionRules()
-    if (rules.length > 0) {
-      send(ws, { type: 'permission_rules_updated', rules, sessionId })
+    const persistentRules = typeof session.getPersistentPermissionRules === 'function'
+      ? session.getPersistentPermissionRules()
+      : []
+    if (rules.length > 0 || persistentRules.length > 0) {
+      send(ws, { type: 'permission_rules_updated', rules, persistentRules, sessionId })
     }
   }
 

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -453,6 +453,21 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
               ...(result.sessionId ? { sessionId: result.sessionId } : {}),
             })
           }
+          // #6771 — an allowAlways over the HTTP fallback (iOS notification
+          // action) just persisted a durable project rule on the in-process
+          // session. Broadcast the updated rule sets so clients' rules surfaces
+          // refresh, mirroring the WS handler (settings-handlers.js).
+          if (decision === 'allowAlways' && result.via === 'sdk' && result.sessionId) {
+            const rulesSession = getSessionManager()?.getSession?.(result.sessionId)?.session
+            if (rulesSession && typeof rulesSession.getPersistentPermissionRules === 'function') {
+              broadcastFn({
+                type: 'permission_rules_updated',
+                sessionId: result.sessionId,
+                rules: typeof rulesSession.getPermissionRules === 'function' ? rulesSession.getPermissionRules() : [],
+                persistentRules: rulesSession.getPersistentPermissionRules(),
+              })
+            }
+          }
           log.info(`Permission ${requestId} resolved via HTTP: ${decision} (${result.via})`)
           sendJson(res, 200, { ok: true })
           return

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1847,6 +1847,8 @@ describe('buildBaseSessionOpts (#5367)', () => {
 describe('subclass opt forwarding — no opt dropped (#5367)', () => {
   let tmpDir
   let trustStore
+  // #6771 — an opaque runtime handle checked by identity (no file I/O needed).
+  const sentinelRuleStore = { addRule() { return false }, getRules() { return [] } }
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-opt-fwd-'))
     trustStore = new SkillsTrustStore({ filePath: join(tmpDir, 'trust.json'), mode: 'warn' })
@@ -1883,6 +1885,9 @@ describe('subclass opt forwarding — no opt dropped (#5367)', () => {
       hardTimeoutMs: 33 * 60 * 1000,
       streamStallTimeoutMs: 7 * 60 * 1000,
       backgroundShellHardQuiesceMs: 0, // explicit 0 — the falsy-preservation case
+      // #6771 — durable per-project rule store (runtime handle). A truthy
+      // sentinel object survives BaseSession's `|| null`, so it lands verbatim.
+      permissionRuleStore: sentinelRuleStore,
     }
   }
 
@@ -1915,6 +1920,8 @@ describe('subclass opt forwarding — no opt dropped (#5367)', () => {
     hardTimeoutMs: (s, o) => assert.equal(s._hardTimeoutMs, o.hardTimeoutMs),
     streamStallTimeoutMs: (s, o) => assert.equal(s._streamStallTimeoutMs, o.streamStallTimeoutMs),
     backgroundShellHardQuiesceMs: (s) => assert.equal(s._backgroundShellHardQuiesceMs, 0),
+    // #6771 — the durable rule store handle lands on _permissionRuleStore.
+    permissionRuleStore: (s) => assert.equal(s._permissionRuleStore, sentinelRuleStore),
   }
 
   // Guard: the assertion table must cover exactly the canonical opt set, so a

--- a/packages/server/tests/permission-manager-protected-path-floor.test.js
+++ b/packages/server/tests/permission-manager-protected-path-floor.test.js
@@ -289,4 +289,131 @@ describe('isProtectedPathTarget (#6794)', () => {
     // cwd = .../.claude/... ; a benign relative write stays unfloored.
     assert.equal(isProtectedPathTarget({ file_path: 'src/a.js' }, '/home/me/.claude/wt/agent'), false)
   })
+
+  // #6805/#6828 — codex apply_patch carries per-file targets in an ARRAY
+  // (input.changes = FileUpdateChange[] = { path, kind, diff }); the flat
+  // file_path is the approval's grantRoot (typically the benign repo root).
+  // ANY protected member must floor the whole request.
+  describe('array-shaped changes[] (codex apply_patch, #6805/#6828)', () => {
+    it('floors when a changes[] member targets .git/ even with a benign grantRoot file_path', () => {
+      assert.equal(isProtectedPathTarget({
+        file_path: cwd, // grantRoot — benign
+        changes: [
+          { path: 'src/ok.js', kind: 'update', diff: 'd' },
+          { path: '.git/config', kind: 'update', diff: 'd' },
+        ],
+      }, cwd), true)
+    })
+
+    it('floors on .env* / .claude / .config-git members too', () => {
+      for (const path of ['.env', '.env.local', '.claude/settings.local.json', '.config/git/config', 'sub/.git/HEAD']) {
+        assert.equal(isProtectedPathTarget({ file_path: cwd, changes: [{ path, kind: 'update', diff: 'd' }] }, cwd), true, path)
+      }
+    })
+
+    it('applies the same case-insensitive segment matching to members', () => {
+      assert.equal(isProtectedPathTarget({ changes: [{ path: '.GIT/config', kind: 'update', diff: 'd' }] }, cwd), true)
+    })
+
+    it('does NOT floor when every member is benign (negative control)', () => {
+      assert.equal(isProtectedPathTarget({
+        file_path: cwd,
+        changes: [
+          { path: 'src/a.js', kind: 'update', diff: 'd' },
+          { path: 'src/b.js', kind: 'add', diff: 'd' },
+        ],
+      }, cwd), false)
+    })
+
+    it('tolerates a string patch, path-less entries, and null members (no throw, no floor)', () => {
+      // #6638: item.changes ?? item.patch — patch can be a unified-diff STRING.
+      assert.equal(isProtectedPathTarget({ file_path: cwd, changes: 'a-unified-diff-string' }, cwd), false)
+      assert.equal(isProtectedPathTarget({ changes: [{ kind: 'update', diff: 'd' }, null, { path: '' }] }, cwd), false)
+      assert.equal(isProtectedPathTarget({ changes: [] }, cwd), false)
+    })
+  })
+})
+
+// #6805/#6828 — end-to-end: the lenient-settings short-circuits must not
+// auto-approve an apply_patch whose changes[] contains a protected member.
+describe('protected-path floor walks apply_patch changes[] (#6805/#6828)', () => {
+  let pm
+
+  beforeEach(() => {
+    pm = createManager()
+  })
+
+  afterEach(() => {
+    pm.destroy()
+  })
+
+  const protectedInput = () => ({
+    file_path: CWD, // grantRoot — benign on its own
+    changes: [
+      { path: 'src/ok.js', kind: 'update', diff: 'd' },
+      { path: '.git/config', kind: 'update', diff: 'd' },
+    ],
+  })
+
+  const benignInput = () => ({
+    file_path: CWD,
+    changes: [
+      { path: 'src/a.js', kind: 'update', diff: 'd' },
+      { path: 'src/b.js', kind: 'add', diff: 'd' },
+    ],
+  })
+
+  it('(a) allow apply_patch rule + a .git/ member falls through to the prompt', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+    pm.setRules([{ tool: 'apply_patch', decision: 'allow' }])
+
+    const promise = pm.handlePermission('apply_patch', protectedInput(), null, 'approve')
+    assert.equal(events.length, 1, 'protected member must emit a prompt, not auto-allow')
+
+    pm.respondToPermission(events[0].requestId, 'deny')
+    const result = await promise
+    assert.equal(result.behavior, 'deny')
+  })
+
+  it('acceptEdits + a .git/ member falls through to the prompt', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const promise = pm.handlePermission('apply_patch', protectedInput(), null, 'acceptEdits')
+    assert.equal(events.length, 1, 'protected member must prompt even in acceptEdits')
+
+    pm.respondToPermission(events[0].requestId, 'deny')
+    await promise
+  })
+
+  it('auto mode + a .git/ member falls through to the prompt', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const promise = pm.handlePermission('apply_patch', protectedInput(), null, 'auto')
+    assert.equal(events.length, 1, 'protected member must prompt even in auto/bypass mode')
+
+    pm.respondToPermission(events[0].requestId, 'deny')
+    await promise
+  })
+
+  it('(b) negative control: all-benign changes[] still short-circuits under an allow rule', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+    pm.setRules([{ tool: 'apply_patch', decision: 'allow' }])
+
+    const result = await pm.handlePermission('apply_patch', benignInput(), null, 'approve')
+    assert.equal(result.behavior, 'allow')
+    assert.equal(events.length, 0, 'benign apply_patch stays auto-approved (no over-flooring)')
+  })
+
+  it('negative control: all-benign changes[] still short-circuits under acceptEdits', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const result = await pm.handlePermission('apply_patch', benignInput(), null, 'acceptEdits')
+    assert.equal(result.behavior, 'allow')
+    assert.equal(events.length, 0)
+  })
 })

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -1,0 +1,313 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { PermissionRuleStore, normalizeProjectKey, isPersistableTool } from '../src/permission-rule-store.js'
+import { PermissionManager } from '../src/permission-manager.js'
+
+/**
+ * #6771 — durable "always allow" permission rules.
+ *
+ * Covers the PermissionRuleStore (per-project persistence keyed by normalized
+ * cwd, atomic write, restart survival, NEVER_AUTO_ALLOW floor) and its
+ * integration with PermissionManager (seeding, allowAlways persistence, the
+ * #6794 protected-path floor interaction, and per-cwd scoping).
+ *
+ * Every store here writes to a temp dir (never the real ~/.chroxy) so the
+ * #4633 sandbox guard is satisfied.
+ */
+
+const silentLog = { info() {}, warn() {}, error() {} }
+
+describe('#6771 PermissionRuleStore', () => {
+  let dir
+  let filePath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-rule-store-'))
+    filePath = join(dir, 'permission-rules.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('normalizeProjectKey collapses spellings and rejects empties', () => {
+    assert.equal(normalizeProjectKey('/a/b'), '/a/b')
+    assert.equal(normalizeProjectKey('/a/b/'), '/a/b')
+    assert.equal(normalizeProjectKey('/a/b/.'), '/a/b')
+    assert.equal(normalizeProjectKey('/a/c/../b'), '/a/b')
+    assert.equal(normalizeProjectKey(''), null)
+    assert.equal(normalizeProjectKey(undefined), null)
+    assert.equal(normalizeProjectKey(42), null)
+  })
+
+  it('isPersistableTool only accepts ELIGIBLE, non-NEVER_AUTO_ALLOW tools', () => {
+    assert.equal(isPersistableTool('Write'), true)
+    assert.equal(isPersistableTool('Read'), true)
+    assert.equal(isPersistableTool('Bash'), false)      // NEVER_AUTO_ALLOW
+    assert.equal(isPersistableTool('WebFetch'), false)  // NEVER_AUTO_ALLOW
+    assert.equal(isPersistableTool('Task'), false)      // NEVER_AUTO_ALLOW
+    assert.equal(isPersistableTool('Frobnicate'), false) // not ELIGIBLE
+  })
+
+  it('addRule persists and getRules reads it back (metadata stripped)', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    assert.equal(store.addRule('/proj/a', { tool: 'Write', decision: 'allow' }), true)
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+    assert.ok(existsSync(filePath), 'store file written')
+  })
+
+  it('survives a simulated restart: a NEW store instance reads persisted rules', () => {
+    const store1 = new PermissionRuleStore({ filePath, logger: silentLog })
+    store1.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    store1.addRule('/proj/a', { tool: 'Edit', decision: 'allow' })
+
+    // New process → new store reading the same file.
+    const store2 = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(
+      store2.getRules('/proj/a').sort((x, y) => x.tool.localeCompare(y.tool)),
+      [{ tool: 'Edit', decision: 'allow' }, { tool: 'Write', decision: 'allow' }],
+    )
+  })
+
+  it('scopes rules per project cwd — a different cwd does not inherit', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+    assert.deepEqual(store.getRules('/proj/b'), [])
+  })
+
+  it('addRule replaces (does not duplicate) a rule for the same tool', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'deny' })
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'deny' }])
+  })
+
+  it('refuses to persist an allow rule for a NEVER_AUTO_ALLOW tool', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    assert.equal(store.addRule('/proj/a', { tool: 'Bash', decision: 'allow' }), false)
+    assert.deepEqual(store.getRules('/proj/a'), [])
+  })
+
+  it('load() enforces the eligibility floor on a hand-edited file', () => {
+    // A hand-tampered file that smuggles a Bash allow must be dropped on load.
+    const tampered = {
+      version: 1,
+      projects: {
+        '/proj/a': { rules: [
+          { tool: 'Bash', decision: 'allow' },   // dropped (NEVER_AUTO_ALLOW)
+          { tool: 'Write', decision: 'allow' },  // kept
+        ] },
+      },
+    }
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    // Persist a placeholder then overwrite the file directly to simulate tamper.
+    store.addRule('/proj/z', { tool: 'Read', decision: 'allow' })
+    writeFileSync(filePath, JSON.stringify(tampered))
+    const store2 = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store2.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+  })
+
+  it('setRules replaces the whole project set and removeRule drops one', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.setRules('/proj/a', [
+      { tool: 'Write', decision: 'allow' },
+      { tool: 'Read', decision: 'allow' },
+    ])
+    assert.equal(store.getRules('/proj/a').length, 2)
+    assert.equal(store.removeRule('/proj/a', 'Write'), true)
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Read', decision: 'allow' }])
+    // Removing the last rule deletes the project entry.
+    store.removeRule('/proj/a', 'Read')
+    assert.deepEqual(store.getRules('/proj/a'), [])
+  })
+
+  it('load() tolerates a missing file and a corrupt file (fail-open to empty)', () => {
+    const missing = new PermissionRuleStore({ filePath: join(dir, 'nope.json'), logger: silentLog }).load()
+    assert.deepEqual(missing.getRules('/proj/a'), [])
+
+    const corruptPath = join(dir, 'corrupt.json')
+    writeFileSync(corruptPath, '{not json')
+    const corrupt = new PermissionRuleStore({ filePath: corruptPath, logger: silentLog }).load()
+    assert.deepEqual(corrupt.getRules('/proj/a'), [])
+  })
+})
+
+describe('#6771 PermissionManager + durable rules', () => {
+  let dir
+  let filePath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-rule-mgr-'))
+    filePath = join(dir, 'permission-rules.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function makeStore() {
+    return new PermissionRuleStore({ filePath, logger: silentLog }).load()
+  }
+
+  it('seeds persistent rules for its cwd on construction, auto-allowing without a prompt', async () => {
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      let prompted = false
+      pm.on('permission_request', () => { prompted = true })
+      const result = await pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(result.behavior, 'allow')
+      assert.equal(prompted, false, 'seeded persistent rule auto-allows without a prompt')
+      assert.deepEqual(pm.getPersistentRules(), [{ tool: 'Write', decision: 'allow', persist: 'project' }])
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('a different cwd does NOT inherit another project\'s persistent rules', async () => {
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/OTHER', ruleStore: store })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(events.length, 1, 'unrelated cwd still prompts (no inherited rule)')
+      assert.deepEqual(pm.getPersistentRules(), [])
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('allowAlways persists a durable rule AND survives a simulated daemon restart', async () => {
+    const store = makeStore()
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(events.length, 1)
+      const ok = pm.respondToPermission(events[0].requestId, 'allowAlways')
+      assert.equal(ok, true)
+      // Persisted to disk.
+      assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+    } finally {
+      pm.destroy()
+    }
+
+    // Simulate a restart: a brand-new store instance + a brand-new manager.
+    const store2 = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    const pm2 = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store2 })
+    try {
+      let prompted = false
+      pm2.on('permission_request', () => { prompted = true })
+      const result = await pm2.handlePermission('Write', { file_path: 'src/y.js' }, null, 'approve')
+      assert.equal(result.behavior, 'allow')
+      assert.equal(prompted, false, 'grant survives restart — no re-prompt')
+    } finally {
+      pm2.destroy()
+    }
+  })
+
+  it('allowAlways on a NEVER_AUTO_ALLOW tool (Bash) allows once but does NOT persist', async () => {
+    const store = makeStore()
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      const pending = pm.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+      const ok = pm.respondToPermission(events[0].requestId, 'allowAlways')
+      assert.equal(ok, true)
+      const result = await pending
+      assert.equal(result.behavior, 'allow', 'one-shot allow still granted')
+      // Nothing durable written for Bash.
+      assert.deepEqual(store.getRules('/proj/a'), [])
+      assert.deepEqual(pm.getPersistentRules(), [])
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('FLOOR INTERACTION: a persisted allow rule NEVER overrides the protected-path floor', async () => {
+    // Persist an allow-always for Write, then aim Write at a protected path
+    // (.git/config). The #6794 floor must still force an interactive prompt.
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      // Benign path → auto-allowed by the persistent rule (no prompt).
+      pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(events.length, 0, 'benign write auto-allowed by persistent rule')
+
+      // Protected path → floored to a prompt despite the persistent allow rule.
+      pm.handlePermission('Write', { file_path: '.git/config' }, null, 'approve')
+      assert.equal(events.length, 1, 'protected-path write still prompts (floor wins over persistent allow)')
+
+      // Also holds for a .env secret.
+      pm.handlePermission('Write', { file_path: '.env' }, null, 'approve')
+      assert.equal(events.length, 2, '.env write still prompts')
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('a persistent DENY rule is honoured (deny still denies under the floor)', async () => {
+    const store = makeStore()
+    store.setRules('/proj/a', [{ tool: 'Read', decision: 'deny' }])
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      const result = await pm.handlePermission('Read', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(result.behavior, 'deny')
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('clearRules() does NOT wipe persistent (project) rules', async () => {
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      pm.setRules([{ tool: 'Read', decision: 'allow' }])
+      pm.clearRules() // simulates the permission-mode-switch clear
+      assert.deepEqual(pm.getRules(), [], 'session rules cleared')
+      assert.deepEqual(pm.getPersistentRules(), [{ tool: 'Write', decision: 'allow', persist: 'project' }],
+        'persistent rules survive clearRules')
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('session rules take precedence over persistent rules for the same tool', async () => {
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Read', decision: 'allow' })
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      pm.setRules([{ tool: 'Read', decision: 'deny' }])
+      const result = await pm.handlePermission('Read', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(result.behavior, 'deny', 'session deny wins over persistent allow')
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('the written file is valid JSON with the versioned project shape', () => {
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8'))
+    assert.equal(parsed.version, 1)
+    assert.ok(parsed.projects['/proj/a'])
+    assert.equal(parsed.projects['/proj/a'].rules[0].tool, 'Write')
+    assert.equal(typeof parsed.projects['/proj/a'].rules[0].createdAt, 'number')
+  })
+})

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -261,6 +261,39 @@ describe('#6771 PermissionManager + durable rules', () => {
     }
   })
 
+  it('#6828: a PERSISTED apply_patch allow rule never overrides the floor for a protected changes[] member', async () => {
+    // Persist an allow-always for codex's apply_patch, then aim a fileChange at
+    // .git/ via the changes[] array (the flat file_path is the benign grantRoot).
+    // Without the #6805 array walk this would be durably auto-approved forever.
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'apply_patch', decision: 'allow' })
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      // All-benign members → auto-allowed by the persisted rule (no prompt).
+      const benign = await pm.handlePermission('apply_patch', {
+        file_path: '/proj/a',
+        changes: [{ path: 'src/a.js', kind: 'update', diff: 'd' }],
+      }, null, 'approve')
+      assert.equal(benign.behavior, 'allow')
+      assert.equal(events.length, 0, 'benign apply_patch auto-allowed by persisted rule')
+
+      // A protected member → floored to a prompt despite the persisted allow rule.
+      pm.handlePermission('apply_patch', {
+        file_path: '/proj/a',
+        changes: [
+          { path: 'src/a.js', kind: 'update', diff: 'd' },
+          { path: '.git/config', kind: 'update', diff: 'd' },
+        ],
+      }, null, 'approve')
+      assert.equal(events.length, 1, 'protected changes[] member still prompts (floor wins over persisted allow)')
+    } finally {
+      pm.destroy()
+    }
+  })
+
   it('a persistent DENY rule is honoured (deny still denies under the floor)', async () => {
     const store = makeStore()
     store.setRules('/proj/a', [{ tool: 'Read', decision: 'deny' }])

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -134,6 +134,83 @@ describe('#6771 PermissionRuleStore', () => {
     const corrupt = new PermissionRuleStore({ filePath: corruptPath, logger: silentLog }).load()
     assert.deepEqual(corrupt.getRules('/proj/a'), [])
   })
+
+  // -- load() hardening (Copilot review on PR #6826) --
+
+  it('double-load leaves exactly the file\'s rules — no ghosts, no duplicates', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+    store.addRule('/proj/b', { tool: 'Read', decision: 'allow' })
+
+    // Re-loading the same file must be idempotent (no per-project duplicates).
+    store.load()
+    store.load()
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+    assert.deepEqual(store.getRules('/proj/b'), [{ tool: 'Read', decision: 'allow' }])
+
+    // Overwrite the file externally with a REDUCED set, then re-load: the
+    // dropped project must not survive as an in-memory ghost that a later
+    // _persist would resurrect.
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      projects: { '/proj/b': { rules: [{ tool: 'Read', decision: 'allow' }] } },
+    }))
+    store.load()
+    assert.deepEqual(store.getRules('/proj/a'), [], 'externally-removed project does not ghost')
+    assert.deepEqual(store.getRules('/proj/b'), [{ tool: 'Read', decision: 'allow' }])
+
+    // Delete the file entirely, re-load: empty (stale rules dropped).
+    rmSync(filePath)
+    store.load()
+    assert.deepEqual(store.getRules('/proj/b'), [], 'load after file deletion resets to empty')
+  })
+
+  it('load() rejects an unknown store version whole (fail-open empty, no crash, no partial read)', () => {
+    writeFileSync(filePath, JSON.stringify({
+      version: 999,
+      projects: { '/proj/a': { rules: [{ tool: 'Write', decision: 'allow' }] } },
+    }))
+    const store = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store.getRules('/proj/a'), [], 'unknown version is never partially read')
+
+    // A missing version field is equally rejected (not silently assumed v1).
+    writeFileSync(filePath, JSON.stringify({
+      projects: { '/proj/a': { rules: [{ tool: 'Write', decision: 'allow' }] } },
+    }))
+    const store2 = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store2.getRules('/proj/a'), [])
+  })
+
+  it('load() re-normalizes hand-edited non-normalized keys so the session\'s normalized cwd still matches', () => {
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      projects: {
+        '/proj/a/': { rules: [{ tool: 'Write', decision: 'allow' }] },          // trailing slash
+        '/proj/x/../b': { rules: [{ tool: 'Read', decision: 'allow' }] },       // .. traversal
+      },
+    }))
+    const store = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+    assert.deepEqual(store.getRules('/proj/b'), [{ tool: 'Read', decision: 'allow' }])
+  })
+
+  it('load() merges two file keys that normalize to the same cwd without duplicating rules', () => {
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      projects: {
+        '/proj/a': { rules: [{ tool: 'Write', decision: 'allow' }] },
+        '/proj/a/': { rules: [
+          { tool: 'Write', decision: 'deny' },   // same tool — first key wins, no dup
+          { tool: 'Read', decision: 'allow' },   // new tool — merged in
+        ] },
+      },
+    }))
+    const store = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(
+      store.getRules('/proj/a').sort((x, y) => x.tool.localeCompare(y.tool)),
+      [{ tool: 'Read', decision: 'allow' }, { tool: 'Write', decision: 'allow' }],
+    )
+  })
 })
 
 describe('#6771 PermissionManager + durable rules', () => {

--- a/packages/server/tests/settings-handlers-permission-rules.test.js
+++ b/packages/server/tests/settings-handlers-permission-rules.test.js
@@ -10,12 +10,16 @@
  * - Provider without setPermissionRules returns session_error
  * - Reconnect replay via sendSessionInfo
  */
-import { describe, it, beforeEach, mock } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { settingsHandlers, ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../src/handlers/settings-handlers.js'
 import { ELIGIBLE_TOOLS as PM_ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW as PM_NEVER_AUTO_ALLOW } from '../src/permission-manager.js'
 import { sendSessionInfo } from '../src/ws-history.js'
 import { PermissionAuditLog } from '../src/permission-audit.js'
+import { PermissionRuleStore } from '../src/permission-rule-store.js'
 import { nsCtx } from './test-helpers.js'
 
 // ---- Fixtures ----
@@ -130,6 +134,72 @@ describe('handleSetPermissionRules — valid rules', () => {
     // Should not throw
     handler(WS, client, { type: 'set_permission_rules', rules }, ctx)
     assert.equal(ctx.transport.broadcastToSession.mock.callCount(), 1)
+  })
+})
+
+// #6771 — durable per-project ("always allow") rules via the projectRules field
+// on set_permission_rules (the client "manage / remove persistent rule" path).
+describe('handleSetPermissionRules — projectRules (#6771)', () => {
+  let ctx, client, session, store, dir
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sh-rules-'))
+    store = new PermissionRuleStore({ filePath: join(dir, 'permission-rules.json'), logger: { info() {}, warn() {}, error() {} } })
+    let _persistent = []
+    session = makeSession({
+      cwd: '/proj/a',
+      setPersistentPermissionRules: mock.fn((r) => { _persistent = r.slice() }),
+      getPersistentPermissionRules: mock.fn(() => _persistent.map((r) => ({ ...r, persist: 'project' }))),
+    })
+    const entry = { session, cwd: '/proj/a', name: 'test' }
+    ctx = makeCtx(entry, {
+      sessionManager: {
+        getSession: (id) => (id === 'sess-1' ? entry : null),
+        permissionRuleStore: store,
+      },
+    })
+    client = makeClient()
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('persists projectRules to the store keyed by the session cwd and re-seeds the session', () => {
+    const projectRules = [{ tool: 'Write', decision: 'allow' }]
+    handler(WS, client, { type: 'set_permission_rules', rules: [], projectRules }, ctx)
+
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }])
+    assert.equal(session.setPersistentPermissionRules.mock.callCount(), 1)
+    assert.deepEqual(session.setPersistentPermissionRules.mock.calls[0].arguments[0], [{ tool: 'Write', decision: 'allow' }])
+  })
+
+  it('broadcasts permission_rules_updated including persistentRules', () => {
+    handler(WS, client, { type: 'set_permission_rules', rules: [], projectRules: [{ tool: 'Read', decision: 'allow' }] }, ctx)
+
+    const [, msg] = ctx.transport.broadcastToSession.mock.calls[0].arguments
+    assert.equal(msg.type, 'permission_rules_updated')
+    assert.deepEqual(msg.persistentRules, [{ tool: 'Read', decision: 'allow', persist: 'project' }])
+  })
+
+  it('removes a rule when the reduced projectRules list is sent', () => {
+    store.setRules('/proj/a', [{ tool: 'Write', decision: 'allow' }, { tool: 'Read', decision: 'allow' }])
+    handler(WS, client, { type: 'set_permission_rules', rules: [], projectRules: [{ tool: 'Read', decision: 'allow' }] }, ctx)
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Read', decision: 'allow' }])
+  })
+
+  it('rejects a projectRules allow for a NEVER_AUTO_ALLOW tool without persisting', () => {
+    handler(WS, client, { type: 'set_permission_rules', rules: [], projectRules: [{ tool: 'Bash', decision: 'allow' }] }, ctx)
+    const errMsg = ctx.transport.send.mock.calls[0]?.arguments[1]
+    assert.equal(errMsg?.type, 'session_error')
+    assert.deepEqual(store.getRules('/proj/a'), [])
+  })
+
+  it('leaves persistent rules untouched when projectRules is absent (session-only edit)', () => {
+    store.setRules('/proj/a', [{ tool: 'Write', decision: 'allow' }])
+    handler(WS, client, { type: 'set_permission_rules', rules: [{ tool: 'Read', decision: 'allow' }] }, ctx)
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow' }], 'store unchanged')
+    assert.equal(session.setPersistentPermissionRules.mock.callCount(), 0)
   })
 })
 
@@ -439,6 +509,29 @@ describe('SdkSession permission rules delegation', () => {
     const result = session.getPermissionRules()
     assert.deepEqual(result, [])
     session.destroy()
+  })
+
+  // #6771 — the durable rule store threads through BASE_SESSION_OPT_KEYS to the
+  // session's PermissionManager, which seeds persistent rules for its cwd.
+  it('seeds persistent rules from the injected rule store for its cwd', async () => {
+    const { SdkSession } = await import('../src/sdk-session.js')
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-sdk-seed-'))
+    try {
+      const store = new PermissionRuleStore({ filePath: join(dir, 'permission-rules.json'), logger: { info() {}, warn() {}, error() {} } })
+      store.addRule('/proj/seed', { tool: 'Write', decision: 'allow' })
+
+      const session = new SdkSession({ cwd: '/proj/seed', permissionRuleStore: store })
+      assert.deepEqual(session.getPersistentPermissionRules(), [{ tool: 'Write', decision: 'allow', persist: 'project' }])
+
+      // A session in a DIFFERENT cwd does not inherit the rule.
+      const other = new SdkSession({ cwd: '/proj/other', permissionRuleStore: store })
+      assert.deepEqual(other.getPersistentPermissionRules(), [])
+
+      session.destroy()
+      other.destroy()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -919,6 +919,25 @@ describe('shared dispatch table', () => {
       dispatch(env, { type: 'permission_rules_updated', sessionId: 's1' })
       expect(env.sessions.s1.sessionRules).toEqual([])
     })
+
+    // #6771 — durable per-project rules ride on a distinct `persistentRules` field.
+    it('writes persistentRules alongside session rules', () => {
+      const persistentRules = [{ tool: 'Write', decision: 'allow', persist: 'project' }]
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], sessionRules: [], persistentRules: [] } },
+      })
+      dispatch(env, { type: 'permission_rules_updated', sessionId: 's1', rules: [], persistentRules })
+      expect(env.sessions.s1.persistentRules).toEqual(persistentRules)
+      expect(env.sessions.s1.sessionRules).toEqual([])
+    })
+
+    it('defaults persistentRules to an empty array when the field is absent (older server)', () => {
+      const env = makeAdapter({
+        sessions: { s1: { sessionId: 's1', messages: [], sessionRules: [], persistentRules: [{ tool: 'Read', decision: 'allow' }] } },
+      })
+      dispatch(env, { type: 'permission_rules_updated', sessionId: 's1', rules: [{ tool: 'Edit', decision: 'allow' }] })
+      expect(env.sessions.s1.persistentRules).toEqual([])
+    })
   })
 
   describe('confirm_permission_mode', () => {

--- a/packages/store-core/src/dispatch-table.ts
+++ b/packages/store-core/src/dispatch-table.ts
@@ -191,6 +191,11 @@ export interface DispatchSessionBase {
   pendingClientMessageId?: string | null
   conversationId?: string | null
   sessionRules?: PermissionRule[]
+  // #6771: durable per-project rules ("always allow / deny") applied to this
+  // session, tagged `persist:'project'`. Distinct from `sessionRules` so a
+  // client can render standing project grants without conflating them with the
+  // session-scoped set. Both clients' real `SessionState` carry it.
+  persistentRules?: PermissionRule[]
   isIdle?: boolean
   // --- slice 2 reads (epic #5556) ---
   // `activeAgents` — read+rewritten by agent_spawned / agent_completed
@@ -666,6 +671,8 @@ export interface DispatchMessageMap {
     type: 'permission_rules_updated'
     sessionId?: string
     rules?: unknown[]
+    // #6771: durable per-project rules ("always allow / deny").
+    persistentRules?: unknown[]
   }
   confirm_permission_mode: {
     type: 'confirm_permission_mode'
@@ -1252,14 +1259,16 @@ function dispatchPermissionRulesUpdated<S extends DispatchSessionBase>(
   msg: DispatchMessageMap['permission_rules_updated'],
   adapter: ClientStoreAdapter<S>,
 ): void {
-  const { sessionId: explicitId, rules } = handlePermissionRulesUpdated(
+  const { sessionId: explicitId, rules, persistentRules } = handlePermissionRulesUpdated(
     msg as Record<string, unknown>,
   )
   const rulesSessionId = explicitId || adapter.getActiveSessionId()
   if (rulesSessionId && adapter.hasSession(rulesSessionId)) {
     adapter.updateSession(
       rulesSessionId,
-      () => ({ sessionRules: rules } as Partial<S>),
+      // #6771: persistentRules is a distinct field so a client can render
+      // durable project grants alongside session rules without conflating them.
+      () => ({ sessionRules: rules, persistentRules } as Partial<S>),
     )
   }
 }

--- a/packages/store-core/src/handlers/permission.ts
+++ b/packages/store-core/src/handlers/permission.ts
@@ -38,6 +38,13 @@ export interface PermissionRule {
   tool: string
   decision: 'allow' | 'deny'
   pattern?: string
+  /**
+   * #6771: present + set to `'project'` on a DURABLE (persistent) rule — one
+   * backed by the daemon's per-project rule store that survives a restart, as
+   * opposed to a session-scoped rule (marker absent). Clients use it to badge
+   * the rule and route its removal through the project-rule path.
+   */
+  persist?: 'project'
 }
 
 /**
@@ -188,6 +195,13 @@ export function handlePermissionTimeout(msg: Record<string, unknown>): {
 export interface PermissionRulesUpdatedPayload {
   sessionId: string | null
   rules: PermissionRule[]
+  /**
+   * #6771: durable per-project rules ("always allow / deny"), each tagged
+   * `persist:'project'` by the server. Empty array when the message omits the
+   * field (older server) or carries no persistent rules. Kept SEPARATE from
+   * `rules` so the session-rule round-trip (set_permission_rules) is unchanged.
+   */
+  persistentRules: PermissionRule[]
 }
 
 export function handlePermissionRulesUpdated(
@@ -195,7 +209,8 @@ export function handlePermissionRulesUpdated(
 ): PermissionRulesUpdatedPayload {
   const sessionId = parseRawStringField(msg, 'sessionId')
   const rules = parseUnknownArrayField(msg, 'rules') as PermissionRule[]
-  return { sessionId, rules }
+  const persistentRules = parseUnknownArrayField(msg, 'persistentRules') as PermissionRule[]
+  return { sessionId, rules, persistentRules }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A permission "allow" only lasted as long as the daemon process — "Allow for Session" wrote into `PermissionManager._sessionRules`, an in-memory array that was never serialized, so every approved rule was lost on restart. A dormant `allowAlways` branch (`permission-manager.js`) plus its wire-schema slot existed but no client ever sent `decision:'allowAlways'`.

## What this does

Wires the dormant `allowAlways` path end-to-end, backed by a durable per-project rule store.

### Server
- **`permission-rule-store.js`** (new) — `PermissionRuleStore`: rules keyed by normalized cwd (`path.resolve`), persisted atomically (temp+rename, mode 0600) to `~/.chroxy/permission-rules.json` (a sibling of `session-state.json`; temp-redirected under a test `stateFilePath`). Enforces the same `NEVER_AUTO_ALLOW` / `ELIGIBLE_TOOLS` floor as session rules **on both write and load** — Bash / Task / WebFetch / WebSearch / codex `shell` can never be permanently auto-approved, even via a hand-edited file.
- **`PermissionManager`** — injectable `ruleStore`; seeds a **separate** `_persistentRules` set from the store for its cwd on construction; `_matchesRule` consults session rules first, then persistent rules; `allowAlways` persists a durable rule (eligible tools only — otherwise a one-shot allow). `clearRules()` (mode switch / session-rule replace) leaves persistent rules intact.
- **Composes with the #6794 protected-path floor** — a persisted `allow` rule NEVER overrides the floor: a `Write` aimed at `.git/`, `.claude/`, `.vscode/`, `.config/git`, or `.env*` still falls through to an interactive prompt.
- `BaseSession` gains a `permissionRuleStore` opt (added to `BASE_SESSION_OPT_KEYS`); `SessionManager` creates + loads the store and threads it to every SDK / BYOK / codex-app-server session.
- `set_permission_rules` accepts optional `projectRules` (manage/remove durable rules); `permission_rules_updated` (WS handler, HTTP fallback, and reconnect replay) carries a `persistentRules` field. `allowAlways` decisions are recorded by the existing `PermissionAuditLog`.

### Protocol / store-core
- `SetPermissionRulesSchema` gains optional `projectRules`; `PermissionRule` gains an optional `persist:'project'` marker; the shared dispatch table writes `persistentRules` onto session state.

### Clients
- Dashboard + mobile permission prompts add an **"Always allow (this project)"** option next to allow-once / allow-for-session / deny, gated on the provider's `sessionRules` capability (so it appears exactly where it persists — SDK/BYOK). Mobile's SessionRules screen lists persisted rules with a remove affordance.

## Floor-interaction evidence

`permission-rule-store.test.js` › *"FLOOR INTERACTION: a persisted allow rule NEVER overrides the protected-path floor"*: with a persisted `{Write, allow}` rule for the cwd, a benign `Write` auto-allows (no prompt), while `Write .git/config` and `Write .env` both still emit a prompt.

## Tests
- New `permission-rule-store.test.js` (19): store round-trip, **survives a simulated restart** (fresh store + fresh manager read the file), per-cwd scoping (a different cwd does not inherit), NEVER_AUTO_ALLOW floor on write + load, floor interaction, deny honoured, clearRules preserves persistent, session-rule precedence.
- `settings-handlers-permission-rules.test.js`: projectRules persist/remove/reject + broadcast, and SdkSession seeding from the injected store.
- `base-session.test.js`: opt-forwarding sentinel covers the new opt.
- store-core dispatch + dashboard PermissionPrompt + mobile message-handler option assertions updated/added.

## Folded pre-merge fix (#6805 / #6828)

`isProtectedPathTarget` only read the flat `file_path`/`path`/`notebook_path` fields, so codex `apply_patch`'s array-shaped `input.changes` (`FileUpdateChange[] = { path, kind, diff }`, flat `file_path` = the benign `grantRoot`) escaped the floor — and a persisted `{apply_patch, allow}` rule from this PR would have durably auto-approved `.git`/`.env`/`.claude` edits forever. The matcher now also walks every `changes[]` entry's `path` with the same lowercase-segment semantics — ANY protected member floors the whole request (a string-shaped legacy `item.patch` carries no parseable paths and is skipped). Tests: floored under an allow rule / acceptEdits / auto / a **persisted** allow rule; negative control (all members under `src/`) still short-circuits.

Closes #6771
Closes #6805
Closes #6828

