### PR TITLE
feat(server,dashboard): mcp_servers visibility parity — TUI emission + dashboard list (#6820)

### DIFF
--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -5,14 +5,16 @@
  * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback, useRef, useMemo } from 'react'
-import type { CumulativeUsage, SessionInfo, SessionVisualStatus, SessionRole, ChatActivityState } from '@chroxy/store-core'
+import type { CumulativeUsage, McpServer, SessionInfo, SessionVisualStatus, SessionRole, ChatActivityState } from '@chroxy/store-core'
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
+import { useConnectionStore } from '../store/connection'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
 import { ViewersIndicator } from './ViewersIndicator'
 import { SidebarPanelSlot, type SidebarPanelView, type SidebarPanelLauncher } from './SidebarPanelSlot'
 import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
+import { SidebarMcpView, mcpViewCollapsedMetric } from './SidebarMcpView'
 import type { SearchResult, ConnectedClient, MonthlyBudgetState } from '../store/types'
 import {
   persistSidebarPanelHeight,
@@ -127,6 +129,10 @@ function abbreviateTunnel(url: string): string {
   }
 }
 
+// #6820 — stable empty array so the active-session MCP selector's fallback keeps
+// a referentially-stable identity across renders (avoids render loops).
+const EMPTY_MCP_SERVERS: McpServer[] = []
+
 export function Sidebar({
   repos,
   activeSessionId,
@@ -200,8 +206,17 @@ export function Sidebar({
     persistSidebarPanelCollapsed(next)
   }, [])
 
+  // #6820 — active session's MCP servers, for the read-only "MCP" panel view
+  // and its collapsed-header metric. Reads the same store field the mobile
+  // SettingsBar renders (written by the `mcp_servers` broadcast handler); the
+  // stable EMPTY_MCP_SERVERS fallback keeps a referentially-stable identity.
+  const activeMcpServers = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    return id && s.sessionStates[id] ? s.sessionStates[id].mcpServers : EMPTY_MCP_SERVERS
+  })
+
   // #4303 — view registry. Order here = order in the tab strip. Adding a
-  // future view (MCP, skills, etc.) is a one-entry append.
+  // future view (skills, etc.) is a one-entry append.
   const panelViews = useMemo<SidebarPanelView[]>(() => ([
     {
       id: 'tokens',
@@ -216,10 +231,18 @@ export function Sidebar({
       ),
       collapsedHeaderMetric: () => tokenViewCollapsedMetric(sessions),
     },
+    // #6820 — read-only MCP server list for the active session (name + status),
+    // the desktop analogue of the mobile SettingsBar "MCP Servers (N)" section.
+    {
+      id: 'mcp',
+      label: 'MCP',
+      render: () => <SidebarMcpView servers={activeMcpServers} />,
+      collapsedHeaderMetric: () => mcpViewCollapsedMetric(activeMcpServers),
+    },
     // #5176 (epic #5170) — the Control Room v1 sidebar panel was retired here;
     // the per-session activity tree now drills down inside the main-tab
     // ControlRoomSection (mapped repo → active session → activity tree).
-  ]), [sessions, activeSessionId, onSessionClick, monthlyBudget])
+  ]), [sessions, activeSessionId, onSessionClick, monthlyBudget, activeMcpServers])
 
   // #5200 — Control Room launcher in the slot header. The host/repo table is
   // wide, so the launcher opens it in the main content area (via

--- a/packages/dashboard/src/components/SidebarMcpView.test.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * SidebarMcpView tests (#6820) — read-only MCP server list in the sidebar
+ * panel slot, the desktop analogue of the mobile SettingsBar section.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import type { McpServer } from '@chroxy/store-core'
+import { SidebarMcpView, mcpViewCollapsedMetric } from './SidebarMcpView'
+
+// Mock the store so the fallback path (no `servers` prop) is deterministic.
+// Tests that pass `servers` directly never touch it. The variable is prefixed
+// `mock` so vitest allows it inside the hoisted factory.
+let mockStoreState: Record<string, unknown> = { activeSessionId: null, sessionStates: {} }
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockStoreState),
+}))
+
+afterEach(() => {
+  cleanup()
+  mockStoreState = { activeSessionId: null, sessionStates: {} }
+})
+
+function srv(name: string, status: string): McpServer {
+  return { name, status }
+}
+
+describe('SidebarMcpView (#6820)', () => {
+  it('renders the empty state when there are no servers', () => {
+    render(<SidebarMcpView servers={[]} />)
+    expect(screen.getByTestId('sidebar-mcp-view-empty').textContent).toBe('No MCP servers')
+    expect(screen.queryByTestId('sidebar-mcp-view-list')).toBeNull()
+  })
+
+  it('renders one row per server with name + status text', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected'), srv('github', 'configured')]} />)
+    expect(screen.getByTestId('sidebar-mcp-view-name-filesystem').textContent).toBe('filesystem')
+    expect(screen.getByTestId('sidebar-mcp-view-status-filesystem').textContent).toBe('connected')
+    expect(screen.getByTestId('sidebar-mcp-view-name-github').textContent).toBe('github')
+    expect(screen.getByTestId('sidebar-mcp-view-status-github').textContent).toBe('configured')
+  })
+
+  it('marks the status dot connected only for status "connected"', () => {
+    render(<SidebarMcpView servers={[srv('live', 'connected'), srv('declared', 'configured')]} />)
+    const liveDot = screen.getByTestId('sidebar-mcp-view-dot-live')
+    const declaredDot = screen.getByTestId('sidebar-mcp-view-dot-declared')
+    expect(liveDot.className).toContain('connected')
+    expect(declaredDot.className).not.toContain('connected')
+    // The raw status is exposed on the dot for styling/debugging.
+    expect(declaredDot.getAttribute('data-status')).toBe('configured')
+  })
+
+  it('falls back to the active session store field when no prop is given', () => {
+    mockStoreState = {
+      activeSessionId: 's1',
+      sessionStates: { s1: { mcpServers: [srv('storefs', 'connected')] } },
+    }
+    render(<SidebarMcpView />)
+    expect(screen.getByTestId('sidebar-mcp-view-name-storefs').textContent).toBe('storefs')
+  })
+
+  it('renders empty when the store has no active session', () => {
+    render(<SidebarMcpView />)
+    expect(screen.getByTestId('sidebar-mcp-view-empty')).toBeTruthy()
+  })
+})
+
+describe('mcpViewCollapsedMetric (#6820)', () => {
+  it('reports "No MCP" when empty', () => {
+    expect(mcpViewCollapsedMetric([])).toBe('No MCP')
+  })
+
+  it('reports a singular server count', () => {
+    expect(mcpViewCollapsedMetric([srv('a', 'connected')])).toBe('1 server')
+  })
+
+  it('reports a plural server count', () => {
+    expect(mcpViewCollapsedMetric([srv('a', 'connected'), srv('b', 'configured')])).toBe('2 servers')
+  })
+})

--- a/packages/dashboard/src/components/SidebarMcpView.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.tsx
@@ -1,0 +1,86 @@
+/**
+ * SidebarMcpView (#6820) — read-only MCP server list in the sidebar panel slot.
+ *
+ * The desktop analogue of the mobile app's `SettingsBar.tsx` "MCP Servers (N)"
+ * section: it renders the active session's `mcpServers` store field (already
+ * carried in `connection.ts`, written by the `mcp_servers` broadcast handler)
+ * as a status dot + name + status text per server. Purely informational — no
+ * enable/disable affordance (that's #6824).
+ *
+ * Status semantics mirror the mobile pattern: the dot is green only when a
+ * server reports `connected` (a live status from an sdk/cli-mode session),
+ * muted otherwise. claude-tui-mode sessions report `configured` (the config
+ * declares the server but the PTY exposes no live connection status), which
+ * renders muted — honest about the difference between "connected" and
+ * "declared in config".
+ */
+import { useConnectionStore } from '../store/connection'
+import type { McpServer } from '@chroxy/store-core'
+
+// Module-level stable empty array so the store selector's fallback keeps a
+// referentially-stable identity (avoids needless re-renders / render loops).
+const EMPTY_MCP_SERVERS: McpServer[] = []
+
+export interface SidebarMcpViewProps {
+  /**
+   * Server list override (defaults to the active session's `mcpServers`). The
+   * parent Sidebar already selects this for the collapsed-header metric, so it
+   * passes the same array here to avoid a second store subscription; tests pass
+   * a fixture directly.
+   */
+  servers?: McpServer[]
+}
+
+export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {}) {
+  const storeServers = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    return id && s.sessionStates[id] ? s.sessionStates[id].mcpServers : EMPTY_MCP_SERVERS
+  })
+  const servers = serversProp ?? storeServers
+
+  return (
+    <div className="sidebar-mcp-view" data-testid="sidebar-mcp-view">
+      {servers.length === 0 ? (
+        <div className="sidebar-mcp-view-empty" data-testid="sidebar-mcp-view-empty">
+          No MCP servers
+        </div>
+      ) : (
+        <ul className="sidebar-mcp-view-list" data-testid="sidebar-mcp-view-list">
+          {servers.map((server) => {
+            const connected = server.status === 'connected'
+            return (
+              <li
+                key={server.name}
+                className="sidebar-mcp-view-row"
+                data-testid={`sidebar-mcp-view-row-${server.name}`}
+              >
+                <span
+                  className={`sidebar-mcp-view-dot${connected ? ' connected' : ''}`}
+                  data-testid={`sidebar-mcp-view-dot-${server.name}`}
+                  data-status={server.status}
+                  aria-hidden="true"
+                />
+                <span className="sidebar-mcp-view-name" data-testid={`sidebar-mcp-view-name-${server.name}`}>
+                  {server.name}
+                </span>
+                <span className="sidebar-mcp-view-status" data-testid={`sidebar-mcp-view-status-${server.name}`}>
+                  {server.status}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Collapsed-panel header metric for the MCP view — mirrors
+ * `tokenViewCollapsedMetric`. Shows the configured/connected server count so a
+ * user with the panel collapsed still sees at-a-glance MCP presence.
+ */
+export function mcpViewCollapsedMetric(servers: McpServer[]): string {
+  if (servers.length === 0) return 'No MCP'
+  return `${servers.length} server${servers.length === 1 ? '' : 's'}`
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1432,6 +1432,67 @@ button.sidebar-token-view-session-row:hover {
   flex-shrink: 0;
 }
 
+/* #6820 — read-only MCP server list in the sidebar panel slot. Desktop
+ * analogue of the mobile SettingsBar "MCP Servers (N)" section: a status dot +
+ * name + status per server, no toggle (enable/disable is #6824). */
+.sidebar-mcp-view {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar-mcp-view-empty {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: italic;
+}
+
+.sidebar-mcp-view-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-mcp-view-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.sidebar-mcp-view-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  /* Default (muted) — e.g. claude-tui "configured" (declared, not live). */
+  background: var(--text-muted);
+  align-self: center;
+}
+
+/* Green only for a live "connected" status (sdk/cli-mode sessions). */
+.sidebar-mcp-view-dot.connected {
+  background: var(--accent-green, #22c55e);
+}
+
+.sidebar-mcp-view-name {
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-mcp-view-status {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 /* #5163 (epic #5159) — Control Room panel: live read-only activity tree. */
 .control-room-panel {
   display: flex;

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -6,7 +6,7 @@
  * children or wire tools.
  */
 
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -156,4 +156,146 @@ export function toMcpServerMetadata(server) {
     args: Object.freeze([...server.args]),
     envKeys: Object.freeze(Object.keys(server.env).sort()),
   })
+}
+
+/**
+ * Collect the NAMES of every configured MCP server in an `mcpServers` block,
+ * without the exec-oriented validation `parseClaudeMcpConfig` applies.
+ *
+ * `parseClaudeMcpConfig` is built for the byok stdio exec path — it requires a
+ * `command` and drops any entry without one. For pure VISIBILITY (#6820) we
+ * want every declared server by name, including remote/HTTP transports (which
+ * carry `url`/`type` instead of `command`). So this is deliberately lenient:
+ * any key mapping to a non-null object counts. Malformed entries accumulate a
+ * warning rather than throwing.
+ *
+ * @param {unknown} mcpBlock — the `mcpServers` object from a config source
+ * @param {{ warnings: string[], source: string }} ctx
+ * @returns {string[]} declared server names (order preserved)
+ */
+function collectConfiguredNames(mcpBlock, { warnings, source }) {
+  const names = []
+  if (mcpBlock == null) return names
+  if (typeof mcpBlock !== 'object' || Array.isArray(mcpBlock)) {
+    warnings.push(`${source}: mcpServers must be an object`)
+    return names
+  }
+  for (const [name, entry] of Object.entries(mcpBlock)) {
+    if (!name) {
+      warnings.push(`${source}: skipping MCP server with empty name`)
+      continue
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      warnings.push(`${source}: skipping MCP server ${name} (entry must be an object)`)
+      continue
+    }
+    names.push(name)
+  }
+  return names
+}
+
+/**
+ * Resolve the project-scoped config block Claude Code stores under
+ * `projects[<realpath(cwd)>]` in `~/.claude.json`. Claude keys these by the
+ * realpath, so try that first and fall back to the literal `cwd` (a cwd that no
+ * longer resolves — e.g. a removed test tmp dir — still matches a literal key).
+ *
+ * @param {unknown} raw — parsed `~/.claude.json`
+ * @param {string} cwd
+ * @returns {object|null}
+ */
+function resolveProjectBlock(raw, cwd) {
+  if (!cwd) return null
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const projects = raw.projects
+  if (!projects || typeof projects !== 'object' || Array.isArray(projects)) return null
+  let realCwd = cwd
+  try {
+    realCwd = realpathSync(cwd)
+  } catch {
+    // cwd may not exist (tests / stale dir) — fall through to the literal key.
+  }
+  if (Object.prototype.hasOwnProperty.call(projects, realCwd)) return projects[realCwd]
+  if (Object.prototype.hasOwnProperty.call(projects, cwd)) return projects[cwd]
+  return null
+}
+
+/**
+ * Discover the CONFIGURED (not live-connected) MCP servers a Claude Code
+ * session running in `cwd` would load. This is the honest fallback the
+ * claude-tui provider uses (#6820): the interactive TUI communicates over a
+ * PTY + hook payloads and exposes NO runtime MCP status, unlike the SDK/CLI
+ * stream-json `system/init` event that carries live `mcp_servers` with real
+ * connection status. So the TUI path can only report what the config DECLARES.
+ *
+ * Merges the three sources Claude Code itself reads, deduped by name (first
+ * source wins on a name collision, matching read precedence):
+ *   1. user/global scope  — `mcpServers` at the root of `~/.claude.json`
+ *   2. project scope      — `projects[<realpath(cwd)>].mcpServers` in `~/.claude.json`
+ *   3. project-local      — `mcpServers` in `<cwd>/.mcp.json`
+ *
+ * Never throws: each read is guarded and failures accumulate as warnings, so a
+ * corrupt config can't take down session start.
+ *
+ * @param {string} cwd — the session's working directory
+ * @param {{ configPath?: string }} [opts]
+ * @returns {{ servers: Array<{ name: string }>, warnings: string[] }}
+ */
+export function discoverConfiguredMcpServers(cwd, { configPath = defaultClaudeConfigPath() } = {}) {
+  const warnings = []
+  const byName = new Map()
+  const add = (names) => {
+    for (const name of names) {
+      if (!byName.has(name)) byName.set(name, { name })
+    }
+  }
+
+  const readJson = (filePath, source) => {
+    try {
+      // statSync before readFileSync so a pathologically large file (see
+      // CLAUDE_CONFIG_MAX_BYTES) doesn't block session start.
+      const stat = statSync(filePath)
+      if (stat.size > CLAUDE_CONFIG_MAX_BYTES) {
+        warnings.push(
+          `MCP config ${filePath} exceeds size cap (${stat.size} bytes > ${CLAUDE_CONFIG_MAX_BYTES} bytes); skipping load`,
+        )
+        return null
+      }
+      return JSON.parse(readFileSync(filePath, 'utf8'))
+    } catch (err) {
+      warnings.push(`${source}: failed to read ${filePath}: ${err?.message || String(err)}`)
+      return null
+    }
+  }
+
+  // 1 + 2 — ~/.claude.json global root + project-scoped block.
+  if (configPath && existsSync(configPath)) {
+    const raw = readJson(configPath, 'user config')
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      add(collectConfiguredNames(raw.mcpServers, { warnings, source: 'user config mcpServers' }))
+      const projectBlock = resolveProjectBlock(raw, cwd)
+      if (projectBlock && typeof projectBlock === 'object' && !Array.isArray(projectBlock)) {
+        add(collectConfiguredNames(projectBlock.mcpServers, {
+          warnings,
+          source: 'project config mcpServers',
+        }))
+      }
+    }
+  }
+
+  // 3 — <cwd>/.mcp.json project-local.
+  if (cwd) {
+    const mcpJsonPath = join(cwd, '.mcp.json')
+    if (existsSync(mcpJsonPath)) {
+      const raw = readJson(mcpJsonPath, 'project .mcp.json')
+      if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+        add(collectConfiguredNames(raw.mcpServers, {
+          warnings,
+          source: 'project .mcp.json mcpServers',
+        }))
+      }
+    }
+  }
+
+  return { servers: [...byName.values()], warnings }
 }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1417,7 +1417,8 @@ export class ClaudeTuiSession extends BaseSession {
    * emitted with status `configured` (never `connected`) so the client renders
    * a neutral, not-live indicator. Emits even an empty list so a stale list
    * clears on respawn — mirroring sdk/cli-session's "including empty list to
-   * clear stale state" behaviour. Best-effort: a discovery failure logs a warn
+   * clear stale state" behaviour. Best-effort: a discovery failure logs a warn,
+   * still emits the EMPTY list (so clients don't keep rendering stale servers),
    * and never blocks the ready path.
    */
   _emitConfiguredMcpServers() {
@@ -1437,6 +1438,15 @@ export class ClaudeTuiSession extends BaseSession {
       ;(this._log || log).warn(
         `MCP configured-server discovery failed: ${err?.message || String(err)}`,
       )
+      // Documented contract: even on failure, emit the empty list so a client
+      // holding a previous session's servers clears instead of rendering stale
+      // state forever. Guarded — a throwing listener must not escape the ready
+      // path this method is called from.
+      try {
+        this.emit('mcp_servers', { servers: [] })
+      } catch {
+        // Swallow: nothing more to do if even the emit fails.
+      }
     }
   }
 

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -14,6 +14,11 @@ import { CLAUDE_TUI_PTY_SIZE } from '@chroxy/protocol'
 // (RESUME_UNKNOWN_STDERR_PATTERNS, #4929/#4950) via this matcher: the PTY
 // merges stdout+stderr, so claude's resume rejection lands in _outputTail.
 import { stderrIndicatesUnknownResume } from './cli-session.js'
+// #6820 — the interactive TUI exposes no runtime MCP status (unlike SDK/CLI
+// stream-json `system/init`), so for MCP visibility parity we emit the
+// CONFIGURED server list discovered from the same ~/.claude.json / .mcp.json
+// sources Claude Code reads, labelled `configured` (not live).
+import { discoverConfiguredMcpServers } from './byok-mcp-config.js'
 import { ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
@@ -1398,6 +1403,41 @@ export class ClaudeTuiSession extends BaseSession {
 
     this._processReady = true
     this.emit('ready', { sessionId: this._sessionId, model: this.model, tools: [] })
+    this._emitConfiguredMcpServers()
+  }
+
+  /**
+   * #6820 — emit the CONFIGURED MCP server list for MCP visibility parity.
+   *
+   * The interactive claude TUI communicates over a PTY + hook payloads and
+   * exposes NO runtime MCP status (unlike the SDK/CLI stream-json `system/init`
+   * event, which carries live `mcp_servers` with real connection status). The
+   * honest signal we CAN give is what the config DECLARES: the merged
+   * user/global + project + `.mcp.json` server list for this session's cwd,
+   * emitted with status `configured` (never `connected`) so the client renders
+   * a neutral, not-live indicator. Emits even an empty list so a stale list
+   * clears on respawn — mirroring sdk/cli-session's "including empty list to
+   * clear stale state" behaviour. Best-effort: a discovery failure logs a warn
+   * and never blocks the ready path.
+   */
+  _emitConfiguredMcpServers() {
+    try {
+      const { servers, warnings } = discoverConfiguredMcpServers(this.cwd)
+      for (const warning of warnings) {
+        ;(this._log || log).warn(`MCP config: ${warning}`)
+      }
+      const payload = servers.map((s) => ({ name: s.name, status: 'configured' }))
+      if (payload.length > 0) {
+        ;(this._log || log).info(
+          `MCP servers (configured, not live): ${payload.map((s) => s.name).join(', ')}`,
+        )
+      }
+      this.emit('mcp_servers', { servers: payload })
+    } catch (err) {
+      ;(this._log || log).warn(
+        `MCP configured-server discovery failed: ${err?.message || String(err)}`,
+      )
+    }
   }
 
   /**
@@ -1731,6 +1771,7 @@ export class ClaudeTuiSession extends BaseSession {
     this._didFallbackFromUnknownResume = false
     this._processReady = true
     this.emit('ready', { sessionId: this._sessionId, model: this.model, tools: [] })
+    this._emitConfiguredMcpServers()
   }
 
   /**

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -1,10 +1,11 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   CLAUDE_CONFIG_MAX_BYTES,
+  discoverConfiguredMcpServers,
   loadClaudeMcpConfig,
   parseClaudeMcpConfig,
   toMcpServerMetadata,
@@ -124,5 +125,112 @@ describe('byok-mcp-config', () => {
       args: ['server.js'],
       envKeys: ['A_TOKEN', 'Z_TOKEN'],
     })
+  })
+})
+
+// #6820 — configured-server discovery used by the claude-tui provider for MCP
+// visibility parity. Merges the three sources Claude Code reads (global +
+// project-scoped block + project-local .mcp.json), deduped by name.
+describe('discoverConfiguredMcpServers (#6820)', () => {
+  let cfgDir
+  let cwd
+  let configPath
+
+  beforeEach(() => {
+    cfgDir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-discover-cfg-'))
+    cwd = mkdtempSync(join(tmpdir(), 'chroxy-mcp-discover-cwd-'))
+    configPath = join(cfgDir, 'claude.json')
+  })
+
+  afterEach(() => {
+    rmSync(cfgDir, { recursive: true, force: true })
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it('returns empty (no warnings) when nothing is configured', () => {
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [])
+    assert.deepEqual(res.warnings, [])
+  })
+
+  it('reads global (user-scope) mcpServers from ~/.claude.json', () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { fs: { command: 'npx' }, gh: { command: 'node' } } }),
+    )
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [{ name: 'fs' }, { name: 'gh' }])
+    assert.deepEqual(res.warnings, [])
+  })
+
+  it('includes remote/HTTP servers declared with url/type instead of command', () => {
+    // parseClaudeMcpConfig would drop these (no command); visibility keeps them.
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { remote: { type: 'http', url: 'https://example/mcp' } } }),
+    )
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [{ name: 'remote' }])
+    assert.deepEqual(res.warnings, [])
+  })
+
+  it('merges the project-scoped block (projects[realpath(cwd)].mcpServers)', () => {
+    const realCwd = realpathSync(cwd)
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: { global1: { command: 'npx' } },
+        projects: { [realCwd]: { mcpServers: { proj1: { command: 'node' } } } },
+      }),
+    )
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [{ name: 'global1' }, { name: 'proj1' }])
+  })
+
+  it('merges project-local .mcp.json under cwd', () => {
+    writeFileSync(
+      join(cwd, '.mcp.json'),
+      JSON.stringify({ mcpServers: { local1: { command: 'node' } } }),
+    )
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [{ name: 'local1' }])
+  })
+
+  it('dedupes by name across all sources (first source wins)', () => {
+    const realCwd = realpathSync(cwd)
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: { shared: { command: 'npx' } },
+        projects: {
+          [realCwd]: { mcpServers: { shared: { command: 'other' }, projonly: { command: 'node' } } },
+        },
+      }),
+    )
+    writeFileSync(
+      join(cwd, '.mcp.json'),
+      JSON.stringify({ mcpServers: { shared: { command: 'z' }, localonly: { command: 'y' } } }),
+    )
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [{ name: 'shared' }, { name: 'projonly' }, { name: 'localonly' }])
+  })
+
+  it('never throws on corrupt JSON — accumulates a warning, returns empty', () => {
+    writeFileSync(configPath, '{ not valid json')
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [])
+    assert.equal(res.warnings.length, 1)
+    assert.match(res.warnings[0], /failed to read/)
+  })
+
+  it('warns and skips a malformed entry but keeps the valid siblings', () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { good: { command: 'npx' }, bad: 'not-an-object' } }),
+    )
+    const res = discoverConfiguredMcpServers(cwd, { configPath })
+    assert.deepEqual(res.servers, [{ name: 'good' }])
+    assert.equal(res.warnings.length, 1)
+    assert.match(res.warnings[0], /bad/)
   })
 })

--- a/packages/server/tests/claude-tui-mcp-servers.test.js
+++ b/packages/server/tests/claude-tui-mcp-servers.test.js
@@ -1,0 +1,107 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+/**
+ * #6820 — MCP visibility parity for the claude-tui provider.
+ *
+ * The interactive TUI communicates over a PTY + hook payloads and exposes NO
+ * runtime MCP status, so unlike sdk/cli-session (which parse live `mcp_servers`
+ * off the stream-json `system/init` event), ClaudeTuiSession emits the
+ * CONFIGURED server list discovered from the same ~/.claude.json / .mcp.json
+ * sources Claude Code reads, tagged with status `configured` (never `connected`)
+ * so the client renders a neutral, not-live indicator.
+ *
+ * The test drives `_emitConfiguredMcpServers()` directly (the method both
+ * `emit('ready')` sites call) rather than spawning a real PTY, and points
+ * config discovery at a temp file via CHROXY_CLAUDE_CONFIG so the assertions
+ * never depend on the dev machine's real ~/.claude.json.
+ */
+describe('ClaudeTuiSession — configured mcp_servers emission (#6820)', () => {
+  let skillsDir
+  let cwd
+  let cfgDir
+  let configPath
+  let prevConfigEnv
+
+  beforeEach(() => {
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-skills-'))
+    cwd = mkdtempSync(join(tmpdir(), 'chroxy-tui-mcp-cwd-'))
+    cfgDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-mcp-cfg-'))
+    configPath = join(cfgDir, 'claude.json')
+    prevConfigEnv = process.env.CHROXY_CLAUDE_CONFIG
+    process.env.CHROXY_CLAUDE_CONFIG = configPath
+  })
+
+  afterEach(() => {
+    if (prevConfigEnv === undefined) delete process.env.CHROXY_CLAUDE_CONFIG
+    else process.env.CHROXY_CLAUDE_CONFIG = prevConfigEnv
+    rmSync(skillsDir, { recursive: true, force: true })
+    rmSync(cwd, { recursive: true, force: true })
+    rmSync(cfgDir, { recursive: true, force: true })
+  })
+
+  it('emits configured servers with status "configured"', () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { fs: { command: 'npx' }, gh: { command: 'node' } } }),
+    )
+    const session = new ClaudeTuiSession({ cwd, skillsDir, repoSkillsDir: null })
+    const events = []
+    session.on('mcp_servers', (data) => events.push(data))
+
+    session._emitConfiguredMcpServers()
+
+    assert.equal(events.length, 1)
+    assert.deepEqual(events[0], {
+      servers: [
+        { name: 'fs', status: 'configured' },
+        { name: 'gh', status: 'configured' },
+      ],
+    })
+  })
+
+  it('merges project-local .mcp.json into the emitted list', () => {
+    writeFileSync(configPath, JSON.stringify({ mcpServers: { globalfs: { command: 'npx' } } }))
+    writeFileSync(
+      join(cwd, '.mcp.json'),
+      JSON.stringify({ mcpServers: { repotool: { command: 'node' } } }),
+    )
+    const session = new ClaudeTuiSession({ cwd, skillsDir, repoSkillsDir: null })
+    const events = []
+    session.on('mcp_servers', (data) => events.push(data))
+
+    session._emitConfiguredMcpServers()
+
+    assert.deepEqual(events[0], {
+      servers: [
+        { name: 'globalfs', status: 'configured' },
+        { name: 'repotool', status: 'configured' },
+      ],
+    })
+  })
+
+  it('emits an empty list when nothing is configured (clears stale state)', () => {
+    writeFileSync(configPath, JSON.stringify({ mcpServers: {} }))
+    const session = new ClaudeTuiSession({ cwd, skillsDir, repoSkillsDir: null })
+    const events = []
+    session.on('mcp_servers', (data) => events.push(data))
+
+    session._emitConfiguredMcpServers()
+
+    assert.deepEqual(events, [{ servers: [] }])
+  })
+
+  it('never throws on a corrupt config — still emits an empty list', () => {
+    writeFileSync(configPath, '{ corrupt json')
+    const session = new ClaudeTuiSession({ cwd, skillsDir, repoSkillsDir: null })
+    const events = []
+    session.on('mcp_servers', (data) => events.push(data))
+
+    assert.doesNotThrow(() => session._emitConfiguredMcpServers())
+    assert.deepEqual(events, [{ servers: [] }])
+  })
+})

--- a/packages/server/tests/claude-tui-mcp-servers.test.js
+++ b/packages/server/tests/claude-tui-mcp-servers.test.js
@@ -104,4 +104,23 @@ describe('ClaudeTuiSession — configured mcp_servers emission (#6820)', () => {
     assert.doesNotThrow(() => session._emitConfiguredMcpServers())
     assert.deepEqual(events, [{ servers: [] }])
   })
+
+  it('emits an empty list even when discovery itself THROWS (clears stale client state)', () => {
+    // discoverConfiguredMcpServers is designed never to throw, but the catch
+    // block's documented contract must hold if it ever does: clients holding a
+    // previous list must still get the clearing empty-list emission. Force the
+    // throw deterministically by making the `cwd` read (the discovery
+    // argument, evaluated inside the try) blow up.
+    const session = new ClaudeTuiSession({ cwd, skillsDir, repoSkillsDir: null })
+    Object.defineProperty(session, 'cwd', {
+      get() {
+        throw new Error('boom: forced discovery failure')
+      },
+    })
+    const events = []
+    session.on('mcp_servers', (data) => events.push(data))
+
+    assert.doesNotThrow(() => session._emitConfiguredMcpServers())
+    assert.deepEqual(events, [{ servers: [] }])
+  })
 })


### PR DESCRIPTION
## Summary

Closes the `mcp_servers` visibility gap from epic #6775: claude-tui sessions never emitted the `mcp_servers` event (sdk/cli sessions do), and the dashboard never rendered the `mcpServers` store field it already carried (mobile has a read-only list).

## What TUI actually exposes: configured, not live

The interactive claude TUI communicates over a PTY + hook payloads and exposes **no runtime MCP status** — there is no stream-json `system/init` event carrying live `mcp_servers` (that is the sdk/cli path). Verified against current `main`: the only MCP references in `claude-tui-session.js` are comments about warmup timing and hook payloads.

So the honest signal the TUI path *can* give is what the config **declares**. It emits the **configured** server list with `status: 'configured'` (never `'connected'`), so clients render a neutral, not-live indicator — honest about declared-vs-live.

## Changes

**Server**
- `claude-tui-session.js`: new `_emitConfiguredMcpServers()`, called after both `emit('ready')` sites (fresh warmup + respawn). Emits `{ servers: [{ name, status: 'configured' }] }`, matching the `{ name, status }` shape sdk/cli emit. Best-effort — a discovery failure logs a warn and never blocks ready; emits an empty list to clear stale state (mirrors sdk/cli).
- `byok-mcp-config.js`: new `discoverConfiguredMcpServers(cwd)` merges the three sources Claude Code itself reads — `~/.claude.json` global `mcpServers` + `projects[realpath(cwd)].mcpServers` + `<cwd>/.mcp.json` — deduped by name (first source wins). Deliberately lenient vs the exec-oriented `parseClaudeMcpConfig`: includes remote/HTTP servers declared with `url`/`type` (no `command`), since this is a pure visibility list. Guarded reads never throw.

**Dashboard**
- `SidebarMcpView.tsx`: read-only list (status dot + name + status text), the desktop analogue of the mobile `SettingsBar.tsx:692-710` section. Green dot only for a live `connected` status; muted otherwise (including TUI `configured`). Empty state when none.
- `Sidebar.tsx`: registered `SidebarMcpView` as the `MCP` sidebar panel-slot view via the existing "one-entry append" extension point, with a collapsed-header metric. Reads the active session's `mcpServers` off the store (same field mobile reads).
- `components.css`: styles for the new view.

No enable/disable actions — that is #6824.

## No protocol change

`ServerMcpServersSchema.status` is `z.string()`, so `'configured'` is valid on the existing wire shape; store-core's `handleMcpServers` already writes the `mcpServers` field both clients consume. Verified — no schema/store-core edits needed.

## Tests

- Server: `byok-mcp-config.test.js` — 8 new cases for `discoverConfiguredMcpServers` (global / project-scope / `.mcp.json` merge, dedupe, remote-transport inclusion, corrupt-config resilience). `claude-tui-mcp-servers.test.js` — TUI emission with `status: 'configured'`, `.mcp.json` merge, empty-clear, never-throws. Config discovery pointed at a temp file via `CHROXY_CLAUDE_CONFIG` so assertions never read the real `~/.claude.json`.
- Dashboard: `SidebarMcpView.test.tsx` — render (empty / rows / connected-dot / store-fallback) + `mcpViewCollapsedMetric`.

### Verification
- Server: targeted TUI + byok-mcp suites — 507 pass / 1 pre-existing skip / 0 fail. All 5 `lint-*.sh` green.
- Dashboard: full vitest suite 4485 pass; `tsc --noEmit` clean.

## Related
Epic #6775. Siblings: #6821 (BYOK remote transport), #6822 (OAuth), #6823 (prompts/resources), #6824 (enable/disable — depends on this rendered list).

Closes #6820