### PR TITLE
feat(server): BYOK MCP remote transport — streamable HTTP/SSE (#6821)

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -1,17 +1,23 @@
 /**
- * MCP child-process lifecycle for the claude-byok provider (#4077).
+ * MCP client lifecycle for the claude-byok provider (#4077, #6821).
  *
- * One MCPClient owns one MCP server child. Handles spawn, JSON-RPC handshake
- * (initialize → initialized → tools/list), crash detection with exponential
- * backoff between restart attempts (1s/2s/4s, #4453), and SIGTERM/SIGKILL
- * grace on destroy.
+ * Two transports live here behind one interface (state / tools / start() /
+ * callTool() / destroy() + the same state/ready/dead events):
  *
- * Per #4077 scope:
- *   - Lazy spawn: caller decides when to call start().
- *   - Crash detection on child exit / spawn error → schedule restart per the
- *     RESTART_BACKOFF_MS schedule (1s/2s/4s).
- *   - After MAX_RESTART_ATTEMPTS failures, state=dead and tools=[].
- *   - Session destroy sends SIGTERM, escalates to SIGKILL at KILL_GRACE_MS.
+ *   - MCPClient       — stdio: owns one MCP server CHILD PROCESS. Handles
+ *     spawn, JSON-RPC handshake (initialize → initialized → tools/list), crash
+ *     detection with exponential backoff between restart attempts (1s/2s/4s,
+ *     #4453), and SIGTERM/SIGKILL grace on destroy.
+ *   - MCPRemoteClient — network (#6821): speaks the MCP Streamable HTTP
+ *     transport (POST JSON-RPC to a url, honour the Mcp-Session-Id header,
+ *     read an SSE-upgraded response when the server streams one) with a
+ *     legacy HTTP+SSE fallback for `type: 'sse'` servers. No child process,
+ *     so the process-restart model does not apply — a network client makes a
+ *     single connect attempt and surfaces a clear status on failure (notably
+ *     `oauth-required` on a 401, deferred to #6822).
+ *
+ * `createMcpClient(config, opts)` picks the transport from the config shape
+ * (a `url` selects the remote client) so the fleet stays transport-agnostic.
  *
  * Out of scope (next stages):
  *   - Materializing into Anthropic SDK tools[] (#4078).
@@ -401,4 +407,535 @@ export class MCPClient extends EventEmitter {
     this._state = next
     this.emit('state', { prev, next })
   }
+}
+
+// ---------------------------------------------------------------------------
+// Remote transport (#6821): MCP Streamable HTTP + legacy HTTP+SSE.
+// ---------------------------------------------------------------------------
+
+/**
+ * Iterate a fetch response body as chunks. Node's `fetch` returns a web
+ * ReadableStream (undici); prefer async iteration when available, else fall
+ * back to an explicit reader so the SSE loop works across node versions.
+ */
+async function* iterateStream(stream) {
+  if (!stream) return
+  if (typeof stream[Symbol.asyncIterator] === 'function') {
+    yield* stream
+    return
+  }
+  const reader = stream.getReader()
+  try {
+    for (;;) {
+      const { value, done } = await reader.read()
+      if (done) return
+      if (value) yield value
+    }
+  } finally {
+    try { reader.releaseLock() } catch { /* stream already closed */ }
+  }
+}
+
+/**
+ * Parse one SSE event block into `{ event, data }`. Per the SSE grammar a
+ * `data:` field drops a single leading space and multiple `data:` lines join
+ * with newlines; `id:`/`retry:`/comment (`:`) lines are ignored — we only
+ * need the event name and its JSON-RPC data payload.
+ */
+function parseSseEvent(rawEvent) {
+  let event = 'message'
+  const dataLines = []
+  for (const line of rawEvent.split('\n')) {
+    if (line.length === 0 || line.startsWith(':')) continue
+    if (line.startsWith('event:')) event = line.slice(6).replace(/^ /, '').trim()
+    else if (line.startsWith('data:')) dataLines.push(line.slice(5).replace(/^ /, ''))
+  }
+  return { event, data: dataLines.length > 0 ? dataLines.join('\n') : null }
+}
+
+/** Parse a POST body (single object or JSON-RPC batch array) for the response matching `id`. */
+function extractJsonRpcResponse(text, id) {
+  let parsed
+  try { parsed = JSON.parse(text) } catch { return null }
+  const list = Array.isArray(parsed) ? parsed : [parsed]
+  return list.find((m) => m && m.id === id) || null
+}
+
+export class MCPRemoteClient extends EventEmitter {
+  constructor(config, opts = {}) {
+    super()
+    this.name = config.name
+    this._config = config
+    this._log = opts.log || createLogger('byok-mcp')
+    // Injectable HTTP client (defaults to the global fetch), mirroring the
+    // fetchImpl seam in get-public-ip / discord-webhook-client so tests can
+    // drive the transport against an in-process http server. fetch is a node
+    // primitive — no new npm dependency, consistent with the hand-rolled
+    // stdio client above.
+    this._fetchImpl = opts.fetchImpl || globalThis.fetch
+    // #4457 parity: optional async trust gate consulted before the first
+    // connect. true → proceed; false / throw → permanent DEAD, no request
+    // ever leaves the process.
+    this._trustGate = opts.trustGate || null
+    // #4454 parity: per-request handshake timeout. Same precedence + defensive
+    // guard as the stdio client (opts > config > module default).
+    this._handshakeTimeoutMs =
+      (Number.isFinite(opts.handshakeTimeoutMs) && opts.handshakeTimeoutMs > 0 && opts.handshakeTimeoutMs) ||
+      (Number.isFinite(config?.handshakeTimeoutMs) && config.handshakeTimeoutMs > 0 && config.handshakeTimeoutMs) ||
+      DEFAULT_HANDSHAKE_TIMEOUT_MS
+    this._url = config.url
+    // 'sse' → legacy HTTP+SSE two-endpoint transport; anything else → modern
+    // Streamable HTTP (single endpoint, POST + optional SSE-upgraded response).
+    this._transportType = config.type === 'sse' ? 'sse' : 'http'
+    this._headers = config.headers || {}
+    this._state = MCP_STATES.IDLE
+    this._tools = []
+    this._nextId = 1
+    this._sessionId = null
+    this._negotiatedProtocolVersion = null
+    // 'oauth-required' after a 401/407 (needs the OAuth flow from #6822), else
+    // null. Read for status surfacing — never carries any header/token value.
+    this._statusReason = null
+    this._destroyed = false
+    // In-flight AbortControllers, aborted on destroy() so a hung request or a
+    // persistent SSE stream cannot keep the process alive after teardown.
+    this._controllers = new Set()
+    // Legacy-SSE only: resolved POST endpoint + pending-request registry
+    // (streamable HTTP awaits each POST inline, so it leaves these empty).
+    this._endpointUrl = null
+    this._pending = new Map()
+    this._endpointTimer = null
+    this._endpointResolve = null
+    this._endpointReject = null
+  }
+
+  get state() { return this._state }
+  get tools() { return this._tools }
+  get statusReason() { return this._statusReason }
+
+  async start() {
+    if (this._destroyed) throw new Error('MCPRemoteClient destroyed')
+    if (this._state === MCP_STATES.READY || this._state === MCP_STATES.DEAD) return
+    // #4457 parity: trust gate fires BEFORE any network request. Deny/throw →
+    // permanent DEAD, fail-closed.
+    if (this._trustGate) {
+      let allowed
+      try {
+        allowed = await this._trustGate()
+      } catch (err) {
+        this._log.warn(`MCP server ${this.name}: trust gate threw: ${err?.message || err}`)
+        allowed = false
+      }
+      if (!allowed) {
+        this._toDead()
+        return
+      }
+    }
+    this._setState(MCP_STATES.STARTING)
+    try {
+      if (this._transportType === 'sse') await this._connectLegacySse()
+      else await this._handshakeStreamableHttp()
+      if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
+      this._setState(MCP_STATES.READY)
+      this.emit('ready', this._tools)
+    } catch (err) {
+      if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
+      if (err && err._oauthRequired) {
+        // Deferred to #6822 — surface a clear status instead of crashing.
+        this._statusReason = 'oauth-required'
+        this._log.warn(`MCP server ${this.name}: requires OAuth — not yet supported (#6822)`)
+      } else {
+        this._log.warn(`MCP server ${this.name}: connect failed: ${err?.message || err}`)
+      }
+      this._toDead()
+    }
+  }
+
+  async callTool(toolName, args, timeoutMs = DEFAULT_TOOL_CALL_TIMEOUT_MS) {
+    if (this._state !== MCP_STATES.READY) {
+      throw new Error(`MCP server ${this.name} not ready (state=${this._state})`)
+    }
+    const params = { name: toolName, arguments: args || {} }
+    return this._transportType === 'sse'
+      ? this._rpcViaEndpoint('tools/call', params, timeoutMs)
+      : this._rpcPost('tools/call', params, timeoutMs)
+  }
+
+  async destroy() {
+    if (this._destroyed) return
+    this._destroyed = true
+    if (this._endpointTimer) { clearTimeout(this._endpointTimer); this._endpointTimer = null }
+    this._rejectAllPending(new Error('MCP remote client destroyed'))
+    for (const c of this._controllers) { try { c.abort() } catch { /* already settled */ } }
+    this._controllers.clear()
+    // Best-effort Streamable HTTP session teardown (spec: DELETE with the
+    // session header). Bounded by KILL_GRACE_MS and fully error-swallowed —
+    // it must never make destroy() hang or throw.
+    if (this._transportType === 'http' && this._sessionId && typeof this._fetchImpl === 'function') {
+      const controller = new AbortController()
+      const timer = setTimeout(() => { try { controller.abort() } catch {} }, KILL_GRACE_MS)
+      try {
+        const res = await this._fetchImpl(this._url, {
+          method: 'DELETE',
+          headers: this._buildHeaders(),
+          signal: controller.signal,
+        })
+        await this._discardBody(res)
+      } catch { /* teardown is best-effort */ } finally {
+        clearTimeout(timer)
+      }
+    }
+    this._setState(MCP_STATES.DESTROYED)
+  }
+
+  // --- Streamable HTTP -----------------------------------------------------
+
+  async _handshakeStreamableHttp() {
+    const initResult = await this._rpcPost('initialize', {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'chroxy-byok', version: MCP_CLIENT_VERSION },
+    }, this._handshakeTimeoutMs, { captureSession: true })
+    this._applyInitResult(initResult)
+    await this._notifyPost('notifications/initialized')
+    const toolsResult = await this._rpcPost('tools/list', {}, this._handshakeTimeoutMs)
+    this._setTools(toolsResult)
+  }
+
+  /** POST one JSON-RPC request; resolve its result from a JSON or SSE-upgraded response. */
+  async _rpcPost(method, params, timeoutMs, { captureSession = false } = {}) {
+    const id = this._nextId++
+    const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params })
+    const controller = new AbortController()
+    this._controllers.add(controller)
+    let timedOut = false
+    const timer = setTimeout(() => { timedOut = true; try { controller.abort() } catch {} }, timeoutMs)
+    try {
+      let res
+      try {
+        res = await this._fetchImpl(this._url, {
+          method: 'POST',
+          headers: this._buildHeaders({ json: true, acceptStream: true }),
+          body: payload,
+          signal: controller.signal,
+        })
+      } catch (err) {
+        if (timedOut) throw new Error(`MCP ${method} timeout`)
+        throw err
+      }
+      this._checkStatus(res, method)
+      if (captureSession) {
+        const sid = res.headers.get('mcp-session-id')
+        if (sid) this._sessionId = sid
+      }
+      const contentType = (res.headers.get('content-type') || '').toLowerCase()
+      let message
+      if (contentType.includes('text/event-stream')) {
+        message = await this._readSseUntilId(res.body, id)
+      } else {
+        let text
+        try { text = await res.text() } catch (err) {
+          if (timedOut) throw new Error(`MCP ${method} timeout`)
+          throw err
+        }
+        message = extractJsonRpcResponse(text, id)
+      }
+      if (message == null) {
+        if (timedOut) throw new Error(`MCP ${method} timeout`)
+        throw new Error(`MCP ${method}: no matching JSON-RPC response`)
+      }
+      if (message.error) throw new Error(message.error?.message || `MCP ${method} RPC error`)
+      return message.result
+    } finally {
+      clearTimeout(timer)
+      this._controllers.delete(controller)
+    }
+  }
+
+  /** POST a JSON-RPC notification (no id, no response expected). Best-effort but honours a 401. */
+  async _notifyPost(method, params) {
+    const controller = new AbortController()
+    this._controllers.add(controller)
+    const timer = setTimeout(() => { try { controller.abort() } catch {} }, this._handshakeTimeoutMs)
+    try {
+      let res
+      try {
+        res = await this._fetchImpl(this._url, {
+          method: 'POST',
+          headers: this._buildHeaders({ json: true, acceptStream: true }),
+          body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+          signal: controller.signal,
+        })
+      } catch {
+        return // initialize already succeeded; a lost `initialized` is non-fatal
+      }
+      if (res.status === 401 || res.status === 407) {
+        const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${res.status})`)
+        err._oauthRequired = true
+        throw err
+      }
+      await this._discardBody(res)
+    } finally {
+      clearTimeout(timer)
+      this._controllers.delete(controller)
+    }
+  }
+
+  /** Read an SSE stream until the JSON-RPC response with `id` arrives (or the stream ends). */
+  async _readSseUntilId(body, id) {
+    if (!body) return null
+    const decoder = new TextDecoder()
+    let buf = ''
+    for await (const chunk of iterateStream(body)) {
+      buf += decoder.decode(chunk, { stream: true })
+      buf = buf.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+      let idx
+      while ((idx = buf.indexOf('\n\n')) !== -1) {
+        const { data } = parseSseEvent(buf.slice(0, idx))
+        buf = buf.slice(idx + 2)
+        if (data == null) continue
+        let msg
+        try { msg = JSON.parse(data) } catch { continue }
+        if (msg && msg.id === id) return msg
+        // Server-initiated notifications/requests before the response: ignore.
+      }
+    }
+    return null
+  }
+
+  // --- Legacy HTTP+SSE (type: 'sse') ---------------------------------------
+
+  async _connectLegacySse() {
+    const controller = new AbortController()
+    this._controllers.add(controller)
+    let res
+    try {
+      res = await this._fetchImpl(this._url, {
+        method: 'GET',
+        headers: { ...this._headers, Accept: 'text/event-stream' },
+        signal: controller.signal,
+      })
+    } catch (err) {
+      this._controllers.delete(controller)
+      throw err
+    }
+    if (res.status === 401 || res.status === 407) {
+      const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${res.status})`)
+      err._oauthRequired = true
+      throw err
+    }
+    if (res.status < 200 || res.status >= 300) {
+      throw new Error(`MCP server ${this.name} HTTP ${res.status} opening SSE stream`)
+    }
+    const endpointReady = new Promise((resolve, reject) => {
+      this._endpointResolve = resolve
+      this._endpointReject = reject
+      this._endpointTimer = setTimeout(
+        () => reject(new Error(`MCP server ${this.name}: timeout waiting for SSE endpoint`)),
+        this._handshakeTimeoutMs,
+      )
+    })
+    // Background dispatch loop: resolves the endpoint, then routes responses.
+    this._runSseDispatchLoop(res.body)
+    await endpointReady
+    await this._legacyHandshake()
+  }
+
+  async _legacyHandshake() {
+    const initResult = await this._rpcViaEndpoint('initialize', {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'chroxy-byok', version: MCP_CLIENT_VERSION },
+    }, this._handshakeTimeoutMs)
+    this._applyInitResult(initResult)
+    await this._notifyViaEndpoint('notifications/initialized')
+    const toolsResult = await this._rpcViaEndpoint('tools/list', {}, this._handshakeTimeoutMs)
+    this._setTools(toolsResult)
+  }
+
+  async _runSseDispatchLoop(body) {
+    const decoder = new TextDecoder()
+    let buf = ''
+    try {
+      for await (const chunk of iterateStream(body)) {
+        buf += decoder.decode(chunk, { stream: true })
+        buf = buf.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+        let idx
+        while ((idx = buf.indexOf('\n\n')) !== -1) {
+          this._handleLegacyEvent(buf.slice(0, idx))
+          buf = buf.slice(idx + 2)
+        }
+      }
+    } catch (err) {
+      if (!this._destroyed) this._log.debug(`MCP server ${this.name}: SSE stream error: ${err?.message || err}`)
+    } finally {
+      if (!this._destroyed) this._rejectAllPending(new Error('SSE stream closed'))
+    }
+  }
+
+  _handleLegacyEvent(rawEvent) {
+    const { event, data } = parseSseEvent(rawEvent)
+    if (event === 'endpoint') {
+      if (!this._endpointResolve) return
+      let endpoint = null
+      try { endpoint = new URL(data, this._url).toString() } catch { endpoint = null }
+      if (this._endpointTimer) { clearTimeout(this._endpointTimer); this._endpointTimer = null }
+      if (endpoint) {
+        this._endpointUrl = endpoint
+        this._endpointResolve()
+      } else {
+        this._endpointReject?.(new Error(`MCP server ${this.name}: invalid SSE endpoint event`))
+      }
+      this._endpointResolve = null
+      this._endpointReject = null
+      return
+    }
+    if (data == null) return
+    let msg
+    try { msg = JSON.parse(data) } catch { return }
+    if (msg && msg.id != null && this._pending.has(msg.id)) {
+      const settle = this._pending.get(msg.id)
+      settle(msg)
+    }
+  }
+
+  /** POST a JSON-RPC request to the legacy endpoint; await the response off the persistent SSE stream. */
+  async _rpcViaEndpoint(method, params, timeoutMs) {
+    if (!this._endpointUrl) throw new Error(`MCP server ${this.name}: no SSE endpoint`)
+    const id = this._nextId++
+    const responsePromise = new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this._pending.delete(id)
+        resolve({ id, error: { message: `MCP ${method} timeout` } })
+      }, timeoutMs)
+      this._pending.set(id, (msg) => { clearTimeout(timer); this._pending.delete(id); resolve(msg) })
+    })
+    const controller = new AbortController()
+    this._controllers.add(controller)
+    const postTimer = setTimeout(() => { try { controller.abort() } catch {} }, timeoutMs)
+    try {
+      const res = await this._fetchImpl(this._endpointUrl, {
+        method: 'POST',
+        headers: this._buildHeaders({ json: true }),
+        body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+        signal: controller.signal,
+      })
+      this._checkStatus(res, method)
+      await this._discardBody(res)
+    } catch (err) {
+      this._pending.delete(id)
+      throw err
+    } finally {
+      clearTimeout(postTimer)
+      this._controllers.delete(controller)
+    }
+    const msg = await responsePromise
+    if (msg.error) throw new Error(msg.error?.message || `MCP ${method} RPC error`)
+    return msg.result
+  }
+
+  async _notifyViaEndpoint(method, params) {
+    if (!this._endpointUrl) return
+    const controller = new AbortController()
+    this._controllers.add(controller)
+    const timer = setTimeout(() => { try { controller.abort() } catch {} }, this._handshakeTimeoutMs)
+    try {
+      const res = await this._fetchImpl(this._endpointUrl, {
+        method: 'POST',
+        headers: this._buildHeaders({ json: true }),
+        body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+        signal: controller.signal,
+      })
+      await this._discardBody(res)
+    } catch { /* best-effort */ } finally {
+      clearTimeout(timer)
+      this._controllers.delete(controller)
+    }
+  }
+
+  // --- shared helpers ------------------------------------------------------
+
+  _applyInitResult(initResult) {
+    if (!initResult || typeof initResult !== 'object') {
+      throw new Error('initialize returned non-object result')
+    }
+    const serverVersion = initResult.protocolVersion
+    if (typeof serverVersion === 'string') {
+      this._negotiatedProtocolVersion = serverVersion
+      if (serverVersion !== MCP_PROTOCOL_VERSION) {
+        this._log.warn(`MCP server ${this.name}: protocolVersion mismatch — requested=${MCP_PROTOCOL_VERSION} server=${serverVersion} (negotiating to server value)`)
+      }
+    }
+  }
+
+  _setTools(toolsResult) {
+    const tools = Array.isArray(toolsResult?.tools) ? toolsResult.tools : []
+    this._tools = Object.freeze(tools.map((t) => Object.freeze({ ...t })))
+  }
+
+  _buildHeaders({ json = false, acceptStream = false } = {}) {
+    const headers = { ...this._headers }
+    if (acceptStream) headers.Accept = 'application/json, text/event-stream'
+    if (json) headers['Content-Type'] = 'application/json'
+    // #6821 Streamable HTTP: echo the session id + negotiated protocol version
+    // on every post-initialize request per the 2025-03-26 / 2025-06-18 spec.
+    if (this._sessionId) headers['Mcp-Session-Id'] = this._sessionId
+    if (this._negotiatedProtocolVersion) headers['MCP-Protocol-Version'] = this._negotiatedProtocolVersion
+    return headers
+  }
+
+  _checkStatus(res, method) {
+    const status = res.status
+    if (status === 401 || status === 407) {
+      const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${status})`)
+      err._oauthRequired = true
+      throw err
+    }
+    if (status === 404) {
+      // Session expired / endpoint gone — drop the session so a future connect
+      // re-initializes; this request still fails below.
+      this._sessionId = null
+    }
+    if (status < 200 || status >= 300) {
+      throw new Error(`MCP server ${this.name} HTTP ${status} on ${method}`)
+    }
+  }
+
+  async _discardBody(res) {
+    try {
+      if (res?.body && typeof res.body.cancel === 'function') await res.body.cancel()
+      else if (res && typeof res.arrayBuffer === 'function') await res.arrayBuffer()
+    } catch { /* nothing to drain */ }
+  }
+
+  _rejectAllPending(err) {
+    for (const settle of this._pending.values()) {
+      try { settle({ id: null, error: { message: err.message } }) } catch { /* already settled */ }
+    }
+    this._pending.clear()
+  }
+
+  _toDead() {
+    this._tools = []
+    this._rejectAllPending(new Error('MCP remote client dead'))
+    this._setState(MCP_STATES.DEAD)
+    this.emit('dead')
+  }
+
+  _setState(next) {
+    if (this._state === next) return
+    const prev = this._state
+    this._state = next
+    this.emit('state', { prev, next })
+  }
+}
+
+/**
+ * Pick the transport for a parsed MCP server config (#6821). A `url` selects
+ * the remote (Streamable HTTP / SSE) client; otherwise the stdio child-process
+ * client. Keeps byok-mcp-fleet.js transport-agnostic — it just calls this.
+ */
+export function createMcpClient(config, opts = {}) {
+  const isRemote = typeof config?.url === 'string' && config.url.length > 0
+  return isRemote ? new MCPRemoteClient(config, opts) : new MCPClient(config, opts)
 }

--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -24,11 +24,13 @@
  */
 
 import { spawn } from 'node:child_process'
+import { lookup } from 'node:dns/promises'
 import { EventEmitter } from 'node:events'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { createLogger } from './logger.js'
+import { isBlockedMetadataHost } from './byok-mcp-config.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { prepareSpawn } from './utils/win-spawn.js'
 
@@ -516,6 +518,17 @@ export class MCPRemoteClient extends EventEmitter {
   async start() {
     if (this._destroyed) throw new Error('MCPRemoteClient destroyed')
     if (this._state === MCP_STATES.READY || this._state === MCP_STATES.DEAD) return
+    // #6834 sharp edge, folded in pre-merge: unconditionally refuse
+    // cloud-metadata / link-local targets at REQUEST time too (parse already
+    // rejects them; this guards configs constructed programmatically). Checked
+    // before the trust gate so the user is never prompted to trust a URL we
+    // will refuse regardless.
+    const refusal = await this._refuseMetadataTarget()
+    if (refusal) {
+      this._log.warn(`MCP server ${this.name}: ${refusal}`)
+      this._toDead()
+      return
+    }
     // #4457 parity: trust gate fires BEFORE any network request. Deny/throw →
     // permanent DEAD, fail-closed.
     if (this._trustGate) {
@@ -578,6 +591,7 @@ export class MCPRemoteClient extends EventEmitter {
         const res = await this._fetchImpl(this._url, {
           method: 'DELETE',
           headers: this._buildHeaders(),
+          redirect: 'manual', // #6834: never follow a redirect off-origin
           signal: controller.signal,
         })
         await this._discardBody(res)
@@ -617,6 +631,9 @@ export class MCPRemoteClient extends EventEmitter {
           method: 'POST',
           headers: this._buildHeaders({ json: true, acceptStream: true }),
           body: payload,
+          // #6834: never auto-follow — a redirect must not carry our
+          // credentialed headers to a different origin. 3xx → _checkStatus throws.
+          redirect: 'manual',
           signal: controller.signal,
         })
       } catch (err) {
@@ -664,6 +681,7 @@ export class MCPRemoteClient extends EventEmitter {
           method: 'POST',
           headers: this._buildHeaders({ json: true, acceptStream: true }),
           body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+          redirect: 'manual', // #6834: never follow a redirect off-origin
           signal: controller.signal,
         })
       } catch {
@@ -713,6 +731,7 @@ export class MCPRemoteClient extends EventEmitter {
       res = await this._fetchImpl(this._url, {
         method: 'GET',
         headers: { ...this._headers, Accept: 'text/event-stream' },
+        redirect: 'manual', // #6834: never follow a redirect off-origin
         signal: controller.signal,
       })
     } catch (err) {
@@ -723,6 +742,9 @@ export class MCPRemoteClient extends EventEmitter {
       const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${res.status})`)
       err._oauthRequired = true
       throw err
+    }
+    if (res.status >= 300 && res.status < 400) {
+      throw new Error(`MCP server ${this.name} HTTP ${res.status} redirect opening SSE stream — refused (redirects are not followed)`)
     }
     if (res.status < 200 || res.status >= 300) {
       throw new Error(`MCP server ${this.name} HTTP ${res.status} opening SSE stream`)
@@ -778,11 +800,22 @@ export class MCPRemoteClient extends EventEmitter {
     if (event === 'endpoint') {
       if (!this._endpointResolve) return
       let endpoint = null
-      try { endpoint = new URL(data, this._url).toString() } catch { endpoint = null }
+      try { endpoint = new URL(data, this._url) } catch { endpoint = null }
       if (this._endpointTimer) { clearTimeout(this._endpointTimer); this._endpointTimer = null }
-      if (endpoint) {
-        this._endpointUrl = endpoint
+      // #6834 sharp edge: the endpoint event is SERVER-SUPPLIED — an absolute
+      // url here could pivot our credentialed POSTs (headers carry auth)
+      // anywhere. Enforce SAME-ORIGIN (scheme+host+port, via URL.origin)
+      // against the configured url; a cross-origin endpoint warns + rejects,
+      // which fails the connect → DEAD. Origins are creds/query-free, so
+      // logging them leaks nothing.
+      let configuredOrigin = null
+      try { configuredOrigin = new URL(this._url).origin } catch { /* refused below */ }
+      if (endpoint && configuredOrigin && endpoint.origin === configuredOrigin) {
+        this._endpointUrl = endpoint.toString()
         this._endpointResolve()
+      } else if (endpoint && configuredOrigin) {
+        this._log.warn(`MCP server ${this.name}: SSE endpoint origin ${endpoint.origin} != configured origin ${configuredOrigin} — refusing cross-origin endpoint`)
+        this._endpointReject?.(new Error(`MCP server ${this.name}: cross-origin SSE endpoint refused`))
       } else {
         this._endpointReject?.(new Error(`MCP server ${this.name}: invalid SSE endpoint event`))
       }
@@ -818,6 +851,7 @@ export class MCPRemoteClient extends EventEmitter {
         method: 'POST',
         headers: this._buildHeaders({ json: true }),
         body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+        redirect: 'manual', // #6834: never follow a redirect off-origin
         signal: controller.signal,
       })
       this._checkStatus(res, method)
@@ -844,6 +878,7 @@ export class MCPRemoteClient extends EventEmitter {
         method: 'POST',
         headers: this._buildHeaders({ json: true }),
         body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+        redirect: 'manual', // #6834: never follow a redirect off-origin
         signal: controller.signal,
       })
       await this._discardBody(res)
@@ -854,6 +889,38 @@ export class MCPRemoteClient extends EventEmitter {
   }
 
   // --- shared helpers ------------------------------------------------------
+
+  /**
+   * Return a refusal reason when the configured url targets the cloud
+   * metadata service / link-local range (#6834 sharp edge), else null.
+   * Literal hosts are checked directly (the URL parser already canonicalized
+   * hex/decimal tricks); DNS names get a best-effort lookup so a name
+   * resolving into the blocked range is refused too. Lookup ERRORS pass
+   * through — fetch will surface them as ordinary connect failures. Full
+   * resolution pinning / DNS-rebinding defence stays in #6834.
+   */
+  async _refuseMetadataTarget() {
+    let hostname
+    try {
+      hostname = new URL(this._url).hostname
+    } catch {
+      return null // fetch will surface the malformed url as a connect failure
+    }
+    if (isBlockedMetadataHost(hostname)) {
+      return 'refusing cloud-metadata / link-local endpoint (never a legitimate MCP server)'
+    }
+    const bare = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+    const isLiteral = /^[\d.]+$/.test(bare) || bare.includes(':')
+    if (!isLiteral) {
+      try {
+        const addrs = await lookup(bare, { all: true })
+        if (addrs.some(({ address }) => isBlockedMetadataHost(address))) {
+          return 'refusing DNS name resolving to a cloud-metadata / link-local address'
+        }
+      } catch { /* resolution failures surface via fetch */ }
+    }
+    return null
+  }
 
   _applyInitResult(initResult) {
     if (!initResult || typeof initResult !== 'object') {
@@ -890,6 +957,12 @@ export class MCPRemoteClient extends EventEmitter {
       const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${status})`)
       err._oauthRequired = true
       throw err
+    }
+    // #6834: with redirect:'manual' a 3xx surfaces here as-is. Refuse it
+    // explicitly — following would replay our credentialed headers against
+    // whatever origin the Location header names.
+    if (status >= 300 && status < 400) {
+      throw new Error(`MCP server ${this.name} HTTP ${status} redirect on ${method} — refused (redirects are not followed)`)
     }
     if (status === 404) {
       // Session expired / endpoint gone — drop the session so a future connect

--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -874,15 +874,25 @@ export class MCPRemoteClient extends EventEmitter {
     this._controllers.add(controller)
     const timer = setTimeout(() => { try { controller.abort() } catch {} }, this._handshakeTimeoutMs)
     try {
-      const res = await this._fetchImpl(this._endpointUrl, {
-        method: 'POST',
-        headers: this._buildHeaders({ json: true }),
-        body: JSON.stringify({ jsonrpc: '2.0', method, params }),
-        redirect: 'manual', // #6834: never follow a redirect off-origin
-        signal: controller.signal,
-      })
+      let res
+      try {
+        res = await this._fetchImpl(this._endpointUrl, {
+          method: 'POST',
+          headers: this._buildHeaders({ json: true }),
+          body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+          redirect: 'manual', // #6834: never follow a redirect off-origin
+          signal: controller.signal,
+        })
+      } catch {
+        return // network-level failure is best-effort — initialize already succeeded
+      }
+      // Same status semantics as every other call site (_checkStatus): 401/407
+      // → oauth-required (propagates → DEAD), redirect/other non-2xx → error →
+      // DEAD. Pre-fix this swallowed ALL statuses, letting the handshake
+      // proceed past `initialized` while the server was rejecting our requests.
+      this._checkStatus(res, method)
       await this._discardBody(res)
-    } catch { /* best-effort */ } finally {
+    } finally {
       clearTimeout(timer)
       this._controllers.delete(controller)
     }

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -108,6 +108,35 @@ function coerceHeaders(value, { warnings, serverName }) {
 }
 
 /**
+ * True when a hostname (or a bare IP from dns.lookup) targets the cloud
+ * metadata service / IPv4 link-local range — never a legitimate MCP server
+ * (#6821, sharpest edge of #6834). Covers:
+ *   - 169.254.0.0/16 (link-local; the metadata endpoint 169.254.169.254
+ *     lives here). The WHATWG URL parser canonicalizes hex/decimal/octal
+ *     host tricks (0xa9fea9fe, 2852039166) to dotted-quad first, so a
+ *     literal-host check on the PARSED hostname catches those too.
+ *   - IPv4-mapped IPv6 forms of the same range: the URL parser serializes
+ *     them as hex groups (`::ffff:a9fe:xxxx`; a9fe == 169.254), dns.lookup
+ *     may return the dotted form (`::ffff:169.254.x.x`).
+ *   - fd00:ec2::254, the AWS IMDS IPv6 endpoint (URL-canonical compressed
+ *     form plus the expanded spelling).
+ * Deliberately does NOT block loopback / RFC1918 generally — localhost MCP
+ * servers are legitimate; the broader egress policy is #6834's scope.
+ */
+export function isBlockedMetadataHost(hostname) {
+  if (typeof hostname !== 'string' || hostname.length === 0) return false
+  let h = hostname.toLowerCase()
+  if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1)
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/)
+  if (v4) return Number(v4[1]) === 169 && Number(v4[2]) === 254
+  if (/^::ffff:a9fe:[0-9a-f]{1,4}$/.test(h)) return true
+  const mapped = h.match(/^::ffff:(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/)
+  if (mapped) return Number(mapped[1]) === 169 && Number(mapped[2]) === 254
+  if (h === 'fd00:ec2::254' || h === 'fd00:ec2:0:0:0:0:0:254') return true
+  return false
+}
+
+/**
  * Return a credential-stripped form of an MCP server url, safe to log or
  * surface as metadata (#6821). Strips URL userinfo (`user:pass@`), the query
  * string, and the fragment — any of which can carry a token — while keeping
@@ -151,6 +180,13 @@ function parseRemoteEntry(name, entry, { warnings }) {
   }
   if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
     warnings.push(`Skipping MCP server ${name}: url must be http(s) (got ${parsedUrl.protocol})`)
+    return null
+  }
+  // #6834 sharp edge, folded in pre-merge: the cloud-metadata service /
+  // link-local range is never a legitimate MCP server. Refused again at
+  // request time in MCPRemoteClient for configs that bypass this parser.
+  if (isBlockedMetadataHost(parsedUrl.hostname)) {
+    warnings.push(`Skipping MCP server ${name}: url targets a cloud-metadata / link-local address (refused)`)
     return null
   }
   const rawType = typeof entry.type === 'string' ? entry.type.trim().toLowerCase() : ''

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -79,10 +79,104 @@ function coerceEnv(value, { warnings, serverName }) {
 }
 
 /**
+ * Coerce an HTTP `headers` object to string→string only, for remote (#6821)
+ * MCP transports. Same defensive shape as coerceEnv: one warning per dropped
+ * key naming the field (`headers.<KEY>`), and the whole field is dropped with
+ * a single warning if it is not a plain object. Header VALUES (bearer tokens,
+ * api keys) are never logged or surfaced — the warning names only the key.
+ */
+function coerceHeaders(value, { warnings, serverName }) {
+  if (value == null) return {}
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    warnings.push(
+      `MCP server ${serverName}: ignoring headers (expected object, got ${Array.isArray(value) ? 'array' : typeof value})`,
+    )
+    return {}
+  }
+  const headers = {}
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0) continue
+    if (typeof raw === 'string') {
+      headers[key] = raw
+    } else {
+      warnings.push(
+        `MCP server ${serverName}: dropping headers.${key} (expected string, got ${typeof raw})`,
+      )
+    }
+  }
+  return headers
+}
+
+/**
+ * Return a credential-stripped form of an MCP server url, safe to log or
+ * surface as metadata (#6821). Strips URL userinfo (`user:pass@`), the query
+ * string, and the fragment — any of which can carry a token — while keeping
+ * the origin + path that identify the endpoint. An unparseable url yields a
+ * fixed placeholder so a malformed value can never leak verbatim.
+ */
+export function redactMcpUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return ''
+  try {
+    const u = new URL(url)
+    u.username = ''
+    u.password = ''
+    u.search = ''
+    u.hash = ''
+    return u.toString()
+  } catch {
+    return '[unparseable url]'
+  }
+}
+
+/**
+ * Parse a remote (streamable-HTTP / SSE) MCP server entry (#6821). Claude
+ * Code represents these in `~/.claude.json` as `{ "type": "http"|"sse",
+ * "url": "https://...", "headers": { ... } }` — no `command`. Returns a
+ * normalized `{ name, type, url, headers }` server or null (with a warning)
+ * when the entry is unusable. Only http(s) urls are accepted; file:/ws:/etc.
+ * are rejected so a config typo can't point the transport at a local socket.
+ */
+function parseRemoteEntry(name, entry, { warnings }) {
+  const url = typeof entry.url === 'string' ? entry.url.trim() : ''
+  if (!url) {
+    warnings.push(`Skipping MCP server ${name}: url is required for a remote (http/sse) server`)
+    return null
+  }
+  let parsedUrl
+  try {
+    parsedUrl = new URL(url)
+  } catch {
+    warnings.push(`Skipping MCP server ${name}: url is not a valid URL`)
+    return null
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    warnings.push(`Skipping MCP server ${name}: url must be http(s) (got ${parsedUrl.protocol})`)
+    return null
+  }
+  const rawType = typeof entry.type === 'string' ? entry.type.trim().toLowerCase() : ''
+  // 'sse' selects the legacy HTTP+SSE two-endpoint transport; everything else
+  // ('http', 'streamable-http', or an inferred remote with only a url) maps to
+  // the modern Streamable HTTP transport.
+  const type = rawType === 'sse' ? 'sse' : 'http'
+  return {
+    name,
+    type,
+    url,
+    headers: coerceHeaders(entry.headers, { warnings, serverName: name }),
+  }
+}
+
+/**
  * Parse a Claude-style MCP config object.
  *
+ * Handles two server shapes (#6821):
+ *   - stdio: `{ command, args, env }` — spawned as a local child process.
+ *   - remote: `{ type: 'http'|'sse', url, headers }` — connected over the
+ *     network. A remote entry is recognised by an explicit `type` of
+ *     http/streamable-http/sse, or by carrying a `url` without a `command`.
+ *
  * @param {unknown} raw
- * @returns {{ servers: Array<{ name: string, command: string, args: string[], env: Record<string, string> }>, warnings: string[] }}
+ * @returns {{ servers: Array<object>, warnings: string[] }}
  */
 export function parseClaudeMcpConfig(raw) {
   const warnings = []
@@ -105,7 +199,17 @@ export function parseClaudeMcpConfig(raw) {
       warnings.push(`Skipping MCP server ${name}: entry must be an object`)
       continue
     }
-    if (typeof entry.command !== 'string' || entry.command.length === 0) {
+    const rawType = typeof entry.type === 'string' ? entry.type.trim().toLowerCase() : ''
+    const hasCommand = typeof entry.command === 'string' && entry.command.length > 0
+    const hasUrl = typeof entry.url === 'string' && entry.url.trim().length > 0
+    const isRemote =
+      rawType === 'http' || rawType === 'streamable-http' || rawType === 'sse' || (!hasCommand && hasUrl)
+    if (isRemote) {
+      const remote = parseRemoteEntry(name, entry, { warnings })
+      if (remote) servers.push(remote)
+      continue
+    }
+    if (!hasCommand) {
       warnings.push(`Skipping MCP server ${name}: command is required`)
       continue
     }
@@ -150,6 +254,17 @@ export function loadClaudeMcpConfig(filePath = defaultClaudeConfigPath()) {
 }
 
 export function toMcpServerMetadata(server) {
+  // Remote transport (#6821): expose the transport type + a credential-stripped
+  // url + header KEY names only. Header values (bearer tokens, api keys) and any
+  // url userinfo/query never appear in metadata that could reach a log or wire.
+  if (typeof server.url === 'string' && server.url.length > 0) {
+    return Object.freeze({
+      name: server.name,
+      type: server.type || 'http',
+      url: redactMcpUrl(server.url),
+      headerKeys: Object.freeze(Object.keys(server.headers || {}).sort()),
+    })
+  }
   return Object.freeze({
     name: server.name,
     command: server.command,

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -11,7 +11,7 @@
  * the next turn's tool list.
  */
 
-import { MCPClient, MCP_STATES, DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
+import { createMcpClient, MCP_STATES, DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
 import {
   loadTrustStore,
   recordTrust,
@@ -89,18 +89,20 @@ export class MCPFleet {
           return withTrustStoreLock(resolvedTrustPath, async () => {
             const store = loadTrustStore(resolvedTrustPath, { log: opts.log })
             if (isTrusted(store, cfg)) return true
-            const allowed = await permissionManager.requestMcpTrust({
-              name: cfg.name,
-              command: cfg.command,
-              args: cfg.args,
-              envKeys: Object.keys(cfg.env || {}).sort(),
-            })
+            // #6821: a remote server has no command/args — prompt on
+            // (name, url) + header KEY names. Header VALUES (tokens) never
+            // reach the permission payload, the trust store, or any log.
+            const isRemote = typeof cfg.url === 'string' && cfg.url.length > 0
+            const trustReq = isRemote
+              ? { name: cfg.name, url: cfg.url, headerKeys: Object.keys(cfg.headers || {}).sort() }
+              : { name: cfg.name, command: cfg.command, args: cfg.args, envKeys: Object.keys(cfg.env || {}).sort() }
+            const allowed = await permissionManager.requestMcpTrust(trustReq)
             if (allowed) recordTrust(cfg, resolvedTrustPath)
             return allowed
           })
         }
       }
-      return new MCPClient(cfg, clientOpts)
+      return createMcpClient(cfg, clientOpts)
     })
   }
 

--- a/packages/server/src/byok-mcp-trust.js
+++ b/packages/server/src/byok-mcp-trust.js
@@ -76,7 +76,12 @@ export function defaultTrustStorePath() {
  * use as a trust key (#6821). Strips userinfo (`user:pass@`), query, and
  * fragment — none of those belong on disk, and stripping them means a
  * rotated token or a changed query param does not re-prompt for the same
- * endpoint. An unparseable url is keyed verbatim (best-effort stable key).
+ * endpoint. An unparseable url maps to a fixed placeholder — NEVER the raw
+ * input: recordTrust persists this value to disk, and a malformed url can
+ * still embed credential material (`user:pass@`, `?token=`). Collapsing all
+ * unparseable urls for a server name onto one key is fail-safe, because an
+ * unparseable url can never be connected to anyway (config parsing rejects
+ * it and fetch would throw).
  */
 function sanitizeTrustUrl(url) {
   if (typeof url !== 'string' || url.length === 0) return ''
@@ -88,7 +93,7 @@ function sanitizeTrustUrl(url) {
     u.hash = ''
     return u.toString()
   } catch {
-    return url
+    return 'invalid-url'
   }
 }
 

--- a/packages/server/src/byok-mcp-trust.js
+++ b/packages/server/src/byok-mcp-trust.js
@@ -72,9 +72,41 @@ export function defaultTrustStorePath() {
 }
 
 /**
- * Build the canonical tuple key. server.args may be undefined or empty —
- * we still produce a key (args[0] is the empty string) so the consent flow
- * works for shell-built-in-style configs like { command: 'true' }.
+ * Return a credential-stripped, stable form of a remote MCP server url for
+ * use as a trust key (#6821). Strips userinfo (`user:pass@`), query, and
+ * fragment — none of those belong on disk, and stripping them means a
+ * rotated token or a changed query param does not re-prompt for the same
+ * endpoint. An unparseable url is keyed verbatim (best-effort stable key).
+ */
+function sanitizeTrustUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return ''
+  try {
+    const u = new URL(url)
+    u.username = ''
+    u.password = ''
+    u.search = ''
+    u.hash = ''
+    return u.toString()
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Build the canonical tuple key.
+ *
+ * Two shapes (#6821):
+ *   - remote transport: `{ name, url }` → keyed on `(name, sanitized-url)` as
+ *     a 2-element array. A remote server has no `command`, so it needs its own
+ *     tuple; the sanitized url carries no credentials onto disk.
+ *   - stdio transport:  `{ name, command, args }` → keyed on
+ *     `(name, command, args[0])` as a 3-element array. server.args may be
+ *     undefined or empty — we still produce a key (args[0] is the empty
+ *     string) so the consent flow works for shell-built-in-style configs like
+ *     `{ command: 'true' }`.
+ *
+ * The two shapes never alias: a 2-element JSON array can never string-equal a
+ * 3-element one.
  *
  * #4461: serialise via JSON.stringify so component values containing the
  * separator (spaces, NUL bytes, brackets, quotes) cannot collide. The
@@ -88,6 +120,10 @@ export function defaultTrustStorePath() {
 export function trustTupleKey(server) {
   if (!server || typeof server !== 'object') throw new Error('trustTupleKey: missing server')
   const name = String(server.name || '')
+  const url = sanitizeTrustUrl(typeof server.url === 'string' ? server.url : '')
+  if (url) {
+    return JSON.stringify([name, url])
+  }
   const command = String(server.command || '')
   const arg0 = Array.isArray(server.args) && server.args.length > 0 ? String(server.args[0]) : ''
   return JSON.stringify([name, command, arg0])
@@ -116,6 +152,10 @@ export function loadTrustStore(filePath = defaultTrustStorePath(), { log } = {})
       const recomputed = trustTupleKey({
         name: typeof t.name === 'string' ? t.name : '',
         command: typeof t.command === 'string' ? t.command : '',
+        // Remote entries (#6821) persist a `url` and no command/args — the
+        // recompute keys on it. Stdio entries have no `url`, so this is '' and
+        // the (command, args0) branch is taken.
+        url: typeof t.url === 'string' ? t.url : '',
         args: [args0],
       })
       if (recomputed !== t.key) {
@@ -142,13 +182,25 @@ export function recordTrust(server, filePath = defaultTrustStorePath()) {
   const existing = loadTrustStore(filePath)
   if (existing.tuples.has(key)) return existing
   const entries = Array.isArray(existing.entries) ? [...existing.entries] : []
-  entries.push({
-    key,
-    name: server.name,
-    command: server.command,
-    args0: Array.isArray(server.args) && server.args.length > 0 ? server.args[0] : '',
-    trustedAt: new Date().toISOString(),
-  })
+  const isRemote = typeof server.url === 'string' && server.url.length > 0
+  entries.push(
+    isRemote
+      // Remote transport (#6821): persist name + sanitized url only — never
+      // the headers/tokens, and never url credentials.
+      ? {
+          key,
+          name: server.name,
+          url: sanitizeTrustUrl(server.url),
+          trustedAt: new Date().toISOString(),
+        }
+      : {
+          key,
+          name: server.name,
+          command: server.command,
+          args0: Array.isArray(server.args) && server.args.length > 0 ? server.args[0] : '',
+          trustedAt: new Date().toISOString(),
+        },
+  )
   const dir = dirname(filePath)
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
   const tmp = `${filePath}.tmp`

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -6,6 +6,7 @@ import { createLogger } from './logger.js'
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
 // redaction.js (a leaf module — no import cycle / HTTP-handler weight).
 import { sanitizeToolInput, redactValue } from './redaction.js'
+import { redactMcpUrl } from './byok-mcp-config.js'
 
 const _fallbackLog = createLogger('permission-manager')
 
@@ -838,22 +839,37 @@ export class PermissionManager extends EventEmitter {
    *  - On deny: resolves to false; caller marks the client DEAD.
    *  - On timeout (default permissionTimeout): treated as deny.
    *
-   * @param {{ name: string, command: string, args?: string[], envKeys?: string[] }} server
+   * #6821: also handles REMOTE (streamable-HTTP / SSE) servers, which carry a
+   * `url` + `headerKeys` instead of `command`/`args`/`envKeys`. The url is
+   * credential-stripped (via redactMcpUrl) before it reaches the description
+   * or the broadcast input; header VALUES are never passed in.
+   *
+   * @param {{ name: string, command?: string, args?: string[], envKeys?: string[], url?: string, headerKeys?: string[] }} server
    * @returns {Promise<boolean>}
    */
   requestMcpTrust(server) {
     return new Promise((resolve) => {
       const requestId = `mcp-trust-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
+      const isRemote = typeof server.url === 'string' && server.url.length > 0
       const argv0 = Array.isArray(server.args) && server.args.length > 0 ? server.args[0] : ''
+      const safeUrl = isRemote ? redactMcpUrl(server.url) : ''
       const input = {
-        mcpServer: {
-          name: server.name,
-          command: server.command,
-          args: Array.isArray(server.args) ? [...server.args] : [],
-          envKeys: Array.isArray(server.envKeys) ? [...server.envKeys] : [],
-        },
+        mcpServer: isRemote
+          ? {
+              name: server.name,
+              url: safeUrl,
+              headerKeys: Array.isArray(server.headerKeys) ? [...server.headerKeys] : [],
+            }
+          : {
+              name: server.name,
+              command: server.command,
+              args: Array.isArray(server.args) ? [...server.args] : [],
+              envKeys: Array.isArray(server.envKeys) ? [...server.envKeys] : [],
+            },
       }
-      const description = `Spawn MCP server "${server.name}" running ${server.command}${argv0 ? ' ' + argv0 : ''}`
+      const description = isRemote
+        ? `Connect to MCP server "${server.name}" at ${safeUrl}`
+        : `Spawn MCP server "${server.name}" running ${server.command}${argv0 ? ' ' + argv0 : ''}`
 
       // Wrap pending entry so respondToPermission's standard mapping
       // ({behavior:'allow'} or {behavior:'deny'}) translates to a boolean

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -8,6 +8,7 @@ import {
   discoverConfiguredMcpServers,
   loadClaudeMcpConfig,
   parseClaudeMcpConfig,
+  redactMcpUrl,
   toMcpServerMetadata,
 } from '../src/byok-mcp-config.js'
 
@@ -125,6 +126,92 @@ describe('byok-mcp-config', () => {
       args: ['server.js'],
       envKeys: ['A_TOKEN', 'Z_TOKEN'],
     })
+  })
+})
+
+// #6821 — remote (streamable-HTTP / SSE) transport parsing. A remote server
+// carries a url/type instead of a command; the parser must keep it (not drop
+// it as pre-#6821 did) while leaving stdio entries byte-identical.
+describe('byok-mcp-config remote transport (#6821)', () => {
+  it('parses an explicit http remote server with headers', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        remote: {
+          type: 'http',
+          url: 'https://mcp.example.com/api',
+          headers: { Authorization: 'Bearer tok', COUNT: 7 },
+        },
+      },
+    })
+    assert.deepEqual(parsed.servers, [
+      { name: 'remote', type: 'http', url: 'https://mcp.example.com/api', headers: { Authorization: 'Bearer tok' } },
+    ])
+    // The non-string header value is dropped with a naming-only warning.
+    assert.equal(parsed.warnings.length, 1)
+    assert.match(parsed.warnings[0], /headers\.COUNT/)
+    assert.ok(!parsed.warnings[0].includes('Bearer'), 'header value must never appear in a warning')
+  })
+
+  it('normalizes streamable-http and infers a remote entry from a bare url', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        a: { type: 'streamable-http', url: 'https://a/mcp' },
+        b: { url: 'https://b/mcp' }, // no command, no type → inferred remote
+      },
+    })
+    assert.deepEqual(parsed.servers, [
+      { name: 'a', type: 'http', url: 'https://a/mcp', headers: {} },
+      { name: 'b', type: 'http', url: 'https://b/mcp', headers: {} },
+    ])
+  })
+
+  it('parses an sse remote server (legacy transport)', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: { s: { type: 'sse', url: 'https://s/sse' } },
+    })
+    assert.deepEqual(parsed.servers, [{ name: 's', type: 'sse', url: 'https://s/sse', headers: {} }])
+  })
+
+  it('rejects a non-http(s) url and a missing url with warnings, keeps siblings', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        good: { type: 'http', url: 'https://good/mcp' },
+        badproto: { type: 'http', url: 'file:///etc/passwd' },
+        nourl: { type: 'http' },
+        stdio: { command: 'node', args: ['x.js'] },
+      },
+    })
+    assert.deepEqual(parsed.servers.map((s) => s.name), ['good', 'stdio'])
+    assert.ok(parsed.warnings.some((w) => /badproto.*http/.test(w)))
+    assert.ok(parsed.warnings.some((w) => /nourl.*url is required/.test(w)))
+    // stdio entry keeps its exact legacy shape.
+    assert.deepEqual(parsed.servers.find((s) => s.name === 'stdio'), {
+      name: 'stdio', command: 'node', args: ['x.js'], env: {},
+    })
+  })
+
+  it('toMcpServerMetadata redacts remote url credentials + exposes header keys only', () => {
+    const metadata = toMcpServerMetadata({
+      name: 'remote',
+      type: 'http',
+      url: 'https://user:pass@mcp.example.com/api?token=abc#frag',
+      headers: { Authorization: 'Bearer secret', 'X-Api-Key': 'k' },
+    })
+    assert.deepEqual(metadata, {
+      name: 'remote',
+      type: 'http',
+      url: 'https://mcp.example.com/api',
+      headerKeys: ['Authorization', 'X-Api-Key'],
+    })
+    const s = JSON.stringify(metadata)
+    assert.ok(!s.includes('secret') && !s.includes('pass') && !s.includes('token=abc'),
+      'no credential (header value, url userinfo, or query token) may survive into metadata')
+  })
+
+  it('redactMcpUrl strips userinfo, query, and fragment', () => {
+    assert.equal(redactMcpUrl('https://u:p@h.example/path?k=v#x'), 'https://h.example/path')
+    assert.equal(redactMcpUrl('not a url'), '[unparseable url]')
+    assert.equal(redactMcpUrl(''), '')
   })
 })
 

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import {
   CLAUDE_CONFIG_MAX_BYTES,
   discoverConfiguredMcpServers,
+  isBlockedMetadataHost,
   loadClaudeMcpConfig,
   parseClaudeMcpConfig,
   redactMcpUrl,
@@ -212,6 +213,33 @@ describe('byok-mcp-config remote transport (#6821)', () => {
     assert.equal(redactMcpUrl('https://u:p@h.example/path?k=v#x'), 'https://h.example/path')
     assert.equal(redactMcpUrl('not a url'), '[unparseable url]')
     assert.equal(redactMcpUrl(''), '')
+  })
+
+  // #6834 sharp edge, folded pre-merge: cloud-metadata / link-local block.
+  it('rejects a cloud-metadata url at parse time (169.254.169.254), keeps siblings', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        imds: { type: 'http', url: 'http://169.254.169.254/latest/meta-data' },
+        good: { type: 'http', url: 'https://good/mcp' },
+      },
+    })
+    assert.deepEqual(parsed.servers.map((s) => s.name), ['good'])
+    assert.ok(parsed.warnings.some((w) => /imds.*metadata|imds.*link-local/i.test(w)),
+      `expected a metadata-block warning for imds, got: ${JSON.stringify(parsed.warnings)}`)
+  })
+
+  it('isBlockedMetadataHost catches the metadata endpoint + host-encoding tricks, allows normal + loopback', () => {
+    // Blocked: link-local range incl. hex/decimal host tricks (URL parser canonicalizes) + IMDSv6.
+    for (const h of ['169.254.169.254', '169.254.1.2', '[fd00:ec2::254]', 'fd00:ec2::254', '[::ffff:169.254.169.254]']) {
+      assert.equal(isBlockedMetadataHost(h), true, `${h} must be blocked`)
+    }
+    for (const trick of ['http://0xa9fea9fe/', 'http://2852039166/']) {
+      assert.equal(isBlockedMetadataHost(new URL(trick).hostname), true, `${trick} must canonicalize to a blocked host`)
+    }
+    // Allowed: NOT blocked here — loopback + RFC1918 stay legitimate (that policy is #6834).
+    for (const h of ['127.0.0.1', 'localhost', '10.0.0.5', '192.168.1.10', 'mcp.example.com', '169.253.0.1', '170.254.0.1']) {
+      assert.equal(isBlockedMetadataHost(h), false, `${h} must NOT be blocked by the metadata rule`)
+    }
   })
 })
 

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -1,0 +1,334 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import {
+  MCPRemoteClient,
+  MCPClient,
+  createMcpClient,
+  MCP_STATES,
+  MCP_PROTOCOL_VERSION,
+  DEFAULT_HANDSHAKE_TIMEOUT_MS,
+} from '../src/byok-mcp-client.js'
+
+function silentLog() {
+  return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} }
+}
+
+const DEFAULT_TOOLS = [
+  { name: 'echo', description: 'echo input', inputSchema: { type: 'object' } },
+]
+
+/**
+ * A minimal in-process Streamable HTTP MCP server for driving MCPRemoteClient
+ * without a real network. Behaviour is knob-driven so one helper covers the
+ * json/SSE/401/timeout/headers matrix. Every inbound request's method +
+ * headers are captured for assertions.
+ */
+function startMockMcpServer(opts = {}) {
+  const {
+    mode = 'json', // 'json' | 'sse'
+    tools = DEFAULT_TOOLS,
+    sessionId = null, // when set, issued on initialize and required afterwards
+    status = null, // force an HTTP status (e.g. 401) on every POST
+    hangMethods = [], // methods the server never answers (timeout path)
+    toolCallError = false,
+  } = opts
+
+  const captured = []
+
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      const bodyText = Buffer.concat(chunks).toString('utf8')
+      let msg = null
+      try { msg = bodyText ? JSON.parse(bodyText) : null } catch { msg = null }
+      captured.push({
+        method: req.method,
+        rpcMethod: msg?.method,
+        headers: { ...req.headers },
+      })
+
+      if (req.method === 'DELETE') {
+        res.writeHead(200).end()
+        return
+      }
+      if (req.method === 'GET') {
+        // Not used by streamable-HTTP tests; decline the optional SSE stream.
+        res.writeHead(405).end()
+        return
+      }
+
+      // Forced auth failure — the OAuth-required path (#6822).
+      if (status === 401) {
+        res.writeHead(401, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: 'unauthorized' }))
+        return
+      }
+
+      const rpc = msg?.method
+      // Notifications (no id) → 202 Accepted, no body.
+      if (msg && msg.id == null) {
+        res.writeHead(202).end()
+        return
+      }
+      // Timeout path — accept the request but never answer.
+      if (hangMethods.includes(rpc)) {
+        // Intentionally leave the socket open; the client must time out.
+        return
+      }
+
+      let result
+      if (rpc === 'initialize') {
+        result = {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: 'mock-http-mcp', version: '0.1.0' },
+        }
+      } else if (rpc === 'tools/list') {
+        result = { tools }
+      } else if (rpc === 'tools/call') {
+        if (toolCallError) {
+          respond(res, mode, { jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: 'forced remote RPC error' } })
+          return
+        }
+        result = { content: [{ type: 'text', text: JSON.stringify(msg.params?.arguments ?? {}) }] }
+      } else {
+        respond(res, mode, { jsonrpc: '2.0', id: msg.id, error: { code: -32601, message: 'method not found' } })
+        return
+      }
+
+      const extraHeaders = {}
+      if (sessionId && rpc === 'initialize') extraHeaders['Mcp-Session-Id'] = sessionId
+      respond(res, mode, { jsonrpc: '2.0', id: msg.id, result }, extraHeaders)
+    })
+  })
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({
+        url: `http://127.0.0.1:${port}/mcp`,
+        captured,
+        close: () => new Promise((r) => server.close(r)),
+      })
+    })
+  })
+}
+
+function respond(res, mode, message, extraHeaders = {}) {
+  if (mode === 'sse') {
+    res.writeHead(200, { 'content-type': 'text/event-stream', ...extraHeaders })
+    // Emit a server notification first to exercise the "ignore until our id"
+    // branch, then the real response.
+    res.write('event: message\ndata: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n\n')
+    res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`)
+    res.end()
+    return
+  }
+  res.writeHead(200, { 'content-type': 'application/json', ...extraHeaders })
+  res.end(JSON.stringify(message))
+}
+
+describe('MCPRemoteClient — Streamable HTTP (#6821)', () => {
+  let srv
+  afterEach(async () => {
+    if (srv) { await srv.close(); srv = null }
+  })
+
+  it('completes initialize → tools/list and reaches READY (JSON response)', async () => {
+    srv = await startMockMcpServer()
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+    assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
+    const result = await client.callTool('echo', { msg: 'hi' })
+    assert.equal(result.content[0].text, JSON.stringify({ msg: 'hi' }))
+    // initialize + initialized + tools/list + tools/call all POSTed.
+    const rpcMethods = srv.captured.filter((c) => c.method === 'POST').map((c) => c.rpcMethod)
+    assert.deepEqual(rpcMethods, ['initialize', 'notifications/initialized', 'tools/list', 'tools/call'])
+    await client.destroy()
+    assert.equal(client.state, MCP_STATES.DESTROYED)
+  })
+
+  it('reads an SSE-upgraded response and reaches READY', async () => {
+    srv = await startMockMcpServer({ mode: 'sse' })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+    assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
+    const result = await client.callTool('echo', { a: 1 })
+    assert.equal(result.content[0].text, JSON.stringify({ a: 1 }))
+    await client.destroy()
+  })
+
+  it('honours the Mcp-Session-Id header on post-initialize requests', async () => {
+    srv = await startMockMcpServer({ sessionId: 'sess-abc-123' })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+    const toolsListReq = srv.captured.find((c) => c.rpcMethod === 'tools/list')
+    assert.equal(toolsListReq.headers['mcp-session-id'], 'sess-abc-123',
+      'tools/list must echo the session id issued at initialize')
+    await client.destroy()
+  })
+
+  it('401 → DEAD with oauth-required status, no crash', async () => {
+    srv = await startMockMcpServer({ status: 401 })
+    const warns = []
+    const log = { info: () => {}, warn: (m) => warns.push(m), debug: () => {}, error: () => {} }
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log })
+    await client.start() // must resolve, not throw
+    assert.equal(client.state, MCP_STATES.DEAD)
+    assert.equal(client.statusReason, 'oauth-required')
+    assert.equal(client.tools.length, 0)
+    assert.ok(warns.some((m) => /OAuth/i.test(m) && /#6822/.test(m)),
+      `expected an OAuth-required warn naming #6822, got: ${JSON.stringify(warns)}`)
+    await client.destroy()
+  })
+
+  it('handshake timeout → DEAD with no oauth status', async () => {
+    srv = await startMockMcpServer({ hangMethods: ['initialize'] })
+    const client = new MCPRemoteClient(
+      { name: 'remote', type: 'http', url: srv.url, headers: {} },
+      { log: silentLog(), handshakeTimeoutMs: 150 },
+    )
+    const t0 = Date.now()
+    await client.start()
+    assert.equal(client.state, MCP_STATES.DEAD)
+    assert.equal(client.statusReason, null, 'a timeout is not an oauth failure')
+    assert.ok(Date.now() - t0 < 5000, 'timeout must fire well under the default 5s handshake budget')
+    await client.destroy()
+  })
+
+  it('passes configured headers on every request without leaking them into events', async () => {
+    srv = await startMockMcpServer()
+    const SECRET = 'Bearer super-secret-token-xyz'
+    const events = []
+    const client = new MCPRemoteClient(
+      { name: 'remote', type: 'http', url: srv.url, headers: { Authorization: SECRET, 'X-Api-Key': 'k-9876' } },
+      { log: silentLog() },
+    )
+    for (const ev of ['state', 'ready', 'dead', 'restart']) {
+      client.on(ev, (payload) => events.push({ ev, payload }))
+    }
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+    // Every POST carried the configured auth headers.
+    for (const c of srv.captured.filter((x) => x.method === 'POST')) {
+      assert.equal(c.headers['authorization'], SECRET)
+      assert.equal(c.headers['x-api-key'], 'k-9876')
+    }
+    // Nothing sensitive leaked into any emitted event payload.
+    const serialized = JSON.stringify(events)
+    assert.ok(!serialized.includes('super-secret-token-xyz'), 'token must not appear in emitted events')
+    assert.ok(!serialized.includes('k-9876'), 'api key must not appear in emitted events')
+    await client.destroy()
+  })
+
+  it('surfaces a JSON-RPC error from tools/call', async () => {
+    srv = await startMockMcpServer({ toolCallError: true })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start()
+    await assert.rejects(client.callTool('echo', {}), /forced remote RPC error/)
+    await client.destroy()
+  })
+
+  it('callTool throws when not READY', async () => {
+    srv = await startMockMcpServer({ status: 401 })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start()
+    await assert.rejects(client.callTool('echo', {}), /not ready/)
+    await client.destroy()
+  })
+
+  it('trust-gate deny → DEAD, no HTTP request made', async () => {
+    srv = await startMockMcpServer()
+    const client = new MCPRemoteClient(
+      { name: 'remote', type: 'http', url: srv.url, headers: {} },
+      { log: silentLog(), trustGate: async () => false },
+    )
+    await client.start()
+    assert.equal(client.state, MCP_STATES.DEAD)
+    assert.equal(srv.captured.length, 0, 'a trust-denied client must not touch the network')
+    await client.destroy()
+  })
+
+  it('exposes the same handshake-timeout precedence as the stdio client', () => {
+    for (const bogus of [NaN, Infinity, 0, -1, '5s', null, undefined]) {
+      const c = new MCPRemoteClient({ name: 'r', url: 'http://x/mcp' }, { log: silentLog(), handshakeTimeoutMs: bogus })
+      assert.equal(c._handshakeTimeoutMs, DEFAULT_HANDSHAKE_TIMEOUT_MS)
+    }
+    const c2 = new MCPRemoteClient({ name: 'r', url: 'http://x/mcp', handshakeTimeoutMs: 777 }, { log: silentLog() })
+    assert.equal(c2._handshakeTimeoutMs, 777)
+  })
+})
+
+describe('createMcpClient factory (#6821)', () => {
+  it('returns MCPRemoteClient for a url config and MCPClient for a command config', () => {
+    const remote = createMcpClient({ name: 'r', type: 'http', url: 'https://example.com/mcp' }, { log: silentLog() })
+    assert.ok(remote instanceof MCPRemoteClient)
+    const stdio = createMcpClient({ name: 's', command: 'node', args: ['x.js'], env: {} }, { log: silentLog() })
+    assert.ok(stdio instanceof MCPClient)
+  })
+})
+
+// Legacy HTTP+SSE two-endpoint transport (type: 'sse').
+function startMockSseServer(tools = DEFAULT_TOOLS) {
+  let sseRes = null
+  const server = createServer((req, res) => {
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'content-type': 'text/event-stream' })
+      sseRes = res
+      // Announce the POST endpoint per the legacy transport handshake.
+      res.write('event: endpoint\ndata: /messages\n\n')
+      return
+    }
+    // POST to /messages — respond over the persistent SSE stream, matched by id.
+    const chunks = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      let msg = null
+      try { msg = JSON.parse(Buffer.concat(chunks).toString('utf8')) } catch { msg = null }
+      res.writeHead(202).end()
+      if (!msg || msg.id == null || !sseRes) return
+      let result
+      if (msg.method === 'initialize') {
+        result = { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: {}, serverInfo: { name: 'sse', version: '0' } }
+      } else if (msg.method === 'tools/list') {
+        result = { tools }
+      } else if (msg.method === 'tools/call') {
+        result = { content: [{ type: 'text', text: JSON.stringify(msg.params?.arguments ?? {}) }] }
+      } else {
+        sseRes.write(`event: message\ndata: ${JSON.stringify({ jsonrpc: '2.0', id: msg.id, error: { code: -32601, message: 'nope' } })}\n\n`)
+        return
+      }
+      sseRes.write(`event: message\ndata: ${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result })}\n\n`)
+    })
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({
+        url: `http://127.0.0.1:${port}/sse`,
+        close: () => new Promise((r) => { try { sseRes?.end() } catch {} ; server.close(r) }),
+      })
+    })
+  })
+}
+
+describe('MCPRemoteClient — legacy HTTP+SSE (#6821)', () => {
+  let srv
+  afterEach(async () => { if (srv) { await srv.close(); srv = null } })
+
+  it('resolves the endpoint event, handshakes, and calls a tool', async () => {
+    srv = await startMockSseServer()
+    const client = new MCPRemoteClient({ name: 'legacy', type: 'sse', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+    assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
+    const result = await client.callTool('echo', { z: 9 })
+    assert.equal(result.content[0].text, JSON.stringify({ z: 9 }))
+    await client.destroy()
+  })
+})

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -274,14 +274,18 @@ describe('createMcpClient factory (#6821)', () => {
 })
 
 // Legacy HTTP+SSE two-endpoint transport (type: 'sse').
-function startMockSseServer(tools = DEFAULT_TOOLS) {
+// endpointOverride: literal absolute url to emit (SSRF tests, e.g. an attacker origin).
+// sameOriginAbsolute: emit this server's OWN absolute origin + /messages (regression guard).
+function startMockSseServer({ tools = DEFAULT_TOOLS, endpointOverride = null, sameOriginAbsolute = false } = {}) {
   let sseRes = null
+  let ownOrigin = null
   const server = createServer((req, res) => {
     if (req.method === 'GET') {
       res.writeHead(200, { 'content-type': 'text/event-stream' })
       sseRes = res
       // Announce the POST endpoint per the legacy transport handshake.
-      res.write('event: endpoint\ndata: /messages\n\n')
+      const endpoint = endpointOverride || (sameOriginAbsolute ? `${ownOrigin}/messages` : '/messages')
+      res.write(`event: endpoint\ndata: ${endpoint}\n\n`)
       return
     }
     // POST to /messages — respond over the persistent SSE stream, matched by id.
@@ -309,8 +313,9 @@ function startMockSseServer(tools = DEFAULT_TOOLS) {
   return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', () => {
       const { port } = server.address()
+      ownOrigin = `http://127.0.0.1:${port}`
       resolve({
-        url: `http://127.0.0.1:${port}/sse`,
+        url: `${ownOrigin}/sse`,
         close: () => new Promise((r) => { try { sseRes?.end() } catch {} ; server.close(r) }),
       })
     })
@@ -329,6 +334,124 @@ describe('MCPRemoteClient — legacy HTTP+SSE (#6821)', () => {
     assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
     const result = await client.callTool('echo', { z: 9 })
     assert.equal(result.content[0].text, JSON.stringify({ z: 9 }))
+    await client.destroy()
+  })
+})
+
+// --- SSRF hardening (#6834 sharp edges, folded pre-merge) -------------------
+
+/** Plain capture server standing in for an attacker origin: records every request, replies 200. */
+function startCaptureServer() {
+  const captured = []
+  const server = createServer((req, res) => {
+    captured.push({ method: req.method, url: req.url, headers: { ...req.headers } })
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end('{}')
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({
+        origin: `http://127.0.0.1:${port}`,
+        captured,
+        close: () => new Promise((r) => server.close(r)),
+      })
+    })
+  })
+}
+
+/** Server that 302-redirects every request to `location`. */
+function startRedirectServer(location) {
+  const server = createServer((req, res) => {
+    res.writeHead(302, { Location: location })
+    res.end()
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({
+        url: `http://127.0.0.1:${port}/mcp`,
+        close: () => new Promise((r) => server.close(r)),
+      })
+    })
+  })
+}
+
+describe('MCPRemoteClient — SSRF hardening (#6834 sharp edges)', () => {
+  it('refuses an HTTP redirect — DEAD, headers never reach the redirect target', async () => {
+    const attacker = await startCaptureServer()
+    const redirector = await startRedirectServer(`${attacker.origin}/mcp`)
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'redir', type: 'http', url: redirector.url, headers: { Authorization: 'Bearer redirect-secret' } },
+        { log: silentLog() },
+      )
+      await client.start() // must resolve, not throw
+      assert.equal(client.state, MCP_STATES.DEAD)
+      assert.equal(client.statusReason, null, 'a refused redirect is not an oauth failure')
+      assert.equal(attacker.captured.length, 0,
+        'the redirect target must never receive a request (our credentialed headers must not follow)')
+      await client.destroy()
+    } finally {
+      await redirector.close()
+      await attacker.close()
+    }
+  })
+
+  it('refuses a cross-origin legacy SSE endpoint — DEAD, no credentialed POST leaves the origin', async () => {
+    const attacker = await startCaptureServer()
+    const srv = await startMockSseServer({ endpointOverride: `${attacker.origin}/messages` })
+    try {
+      const warns = []
+      const log = { info: () => {}, warn: (m) => warns.push(m), debug: () => {}, error: () => {} }
+      const client = new MCPRemoteClient(
+        { name: 'legacy', type: 'sse', url: srv.url, headers: { Authorization: 'Bearer sse-secret' } },
+        { log },
+      )
+      await client.start()
+      assert.equal(client.state, MCP_STATES.DEAD)
+      assert.equal(attacker.captured.length, 0,
+        'no request (initialize would carry auth headers) may reach the cross-origin endpoint')
+      assert.ok(warns.some((m) => /cross-origin/.test(m)),
+        `expected a cross-origin refusal warn, got: ${JSON.stringify(warns)}`)
+      assert.ok(!JSON.stringify(warns).includes('sse-secret'), 'the warn must not leak header values')
+      await client.destroy()
+    } finally {
+      await srv.close()
+      await attacker.close()
+    }
+  })
+
+  it('still accepts a SAME-origin absolute endpoint url', async () => {
+    // Regression guard: an absolute endpoint on the CONFIGURED origin is
+    // legitimate per the legacy transport and must not be refused.
+    const srv = await startMockSseServer({ sameOriginAbsolute: true })
+    try {
+      const client = new MCPRemoteClient({ name: 'legacy', type: 'sse', url: srv.url, headers: {} }, { log: silentLog() })
+      await client.start()
+      assert.equal(client.state, MCP_STATES.READY, 'a same-origin absolute endpoint must be accepted')
+      assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('refuses a cloud-metadata url at request time even when parsing was bypassed', async () => {
+    const calls = []
+    let gateConsulted = false
+    const client = new MCPRemoteClient(
+      { name: 'imds', type: 'http', url: 'http://169.254.169.254/latest/api', headers: {} },
+      {
+        log: silentLog(),
+        fetchImpl: async (...a) => { calls.push(a); throw new Error('must not be called') },
+        trustGate: async () => { gateConsulted = true; return true },
+      },
+    )
+    await client.start() // must resolve, not throw
+    assert.equal(client.state, MCP_STATES.DEAD)
+    assert.equal(calls.length, 0, 'no request may ever be attempted against the metadata endpoint')
+    assert.equal(gateConsulted, false, 'the user must not be prompted to trust an unconditionally-refused url')
     await client.destroy()
   })
 })

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import {
@@ -276,7 +276,8 @@ describe('createMcpClient factory (#6821)', () => {
 // Legacy HTTP+SSE two-endpoint transport (type: 'sse').
 // endpointOverride: literal absolute url to emit (SSRF tests, e.g. an attacker origin).
 // sameOriginAbsolute: emit this server's OWN absolute origin + /messages (regression guard).
-function startMockSseServer({ tools = DEFAULT_TOOLS, endpointOverride = null, sameOriginAbsolute = false } = {}) {
+// notifyStatus: HTTP status for NOTIFICATION posts (id == null) — e.g. 401 for the oauth path.
+function startMockSseServer({ tools = DEFAULT_TOOLS, endpointOverride = null, sameOriginAbsolute = false, notifyStatus = null } = {}) {
   let sseRes = null
   let ownOrigin = null
   const server = createServer((req, res) => {
@@ -294,6 +295,10 @@ function startMockSseServer({ tools = DEFAULT_TOOLS, endpointOverride = null, sa
     req.on('end', () => {
       let msg = null
       try { msg = JSON.parse(Buffer.concat(chunks).toString('utf8')) } catch { msg = null }
+      if (notifyStatus && msg && msg.id == null) {
+        res.writeHead(notifyStatus).end()
+        return
+      }
       res.writeHead(202).end()
       if (!msg || msg.id == null || !sseRes) return
       let result
@@ -334,6 +339,20 @@ describe('MCPRemoteClient — legacy HTTP+SSE (#6821)', () => {
     assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
     const result = await client.callTool('echo', { z: 9 })
     assert.equal(result.content[0].text, JSON.stringify({ z: 9 }))
+    await client.destroy()
+  })
+
+  it('401 on the initialized NOTIFICATION → oauth-required DEAD, not silently ignored', async () => {
+    // Pre-fix, _notifyViaEndpoint swallowed every HTTP status, so a server
+    // rejecting our requests after initialize let the handshake sail past
+    // `initialized`. It now shares _checkStatus semantics with every other
+    // call site.
+    srv = await startMockSseServer({ notifyStatus: 401 })
+    const client = new MCPRemoteClient({ name: 'legacy', type: 'sse', url: srv.url, headers: {} }, { log: silentLog() })
+    await client.start() // must resolve, not throw
+    assert.equal(client.state, MCP_STATES.DEAD)
+    assert.equal(client.statusReason, 'oauth-required')
+    assert.equal(client.tools.length, 0)
     await client.destroy()
   })
 })

--- a/packages/server/tests/byok-mcp-trust.test.js
+++ b/packages/server/tests/byok-mcp-trust.test.js
@@ -323,6 +323,24 @@ describe('byok-mcp-trust', () => {
       assert.equal(store.tuples.size, 1)
       assert.equal(warned.length, 0, 'a well-formed remote entry must not warn')
     })
+
+    it('never persists credential material from an UNPARSEABLE url', () => {
+      // Space in the authority makes this URL-unparseable, yet it still embeds
+      // a password and a token-ish query. Pre-fix, sanitizeTrustUrl returned
+      // the raw input on parse failure and recordTrust wrote it to disk.
+      const server = { name: 'weird', url: 'http://u:hunter2@bad host/api?token=tok123' }
+      recordTrust(server, storePath)
+      const disk = readFileSync(storePath, 'utf8')
+      assert.ok(!disk.includes('hunter2'), 'password must not reach disk')
+      assert.ok(!disk.includes('tok123'), 'query token must not reach disk')
+      assert.ok(!disk.includes('bad host'), 'no fragment of the raw url may reach disk')
+      // The placeholder key still round-trips: same malformed url → trusted;
+      // recompute on load does not drop it as tampered.
+      const warned = []
+      const store = loadTrustStore(storePath, { log: { warn: (m) => warned.push(m) } })
+      assert.equal(warned.length, 0)
+      assert.equal(isTrusted(store, server), true)
+    })
   })
 
   describe('withTrustStoreLock (#4460)', () => {

--- a/packages/server/tests/byok-mcp-trust.test.js
+++ b/packages/server/tests/byok-mcp-trust.test.js
@@ -86,6 +86,28 @@ describe('byok-mcp-trust', () => {
       const b = trustTupleKey({ name: 'x', command: 'y", "c", "d', args: [''] })
       assert.notEqual(a, b)
     })
+
+    // #6821 — remote transport keys on (name, sanitized-url).
+    it('keys a remote server on (name, url), distinct from any stdio tuple', () => {
+      const remote = trustTupleKey({ name: 'gh', url: 'https://mcp.example.com/api' })
+      assert.equal(remote, JSON.stringify(['gh', 'https://mcp.example.com/api']))
+      const stdio = trustTupleKey({ name: 'gh', command: 'node', args: ['mcp.js'] })
+      assert.notEqual(remote, stdio, 'a 2-element remote tuple can never alias a 3-element stdio tuple')
+    })
+
+    it('strips url credentials + query + fragment from the remote key (no re-prompt on token rotation)', () => {
+      const a = trustTupleKey({ name: 'gh', url: 'https://u:p1@mcp.example.com/api?t=1#x' })
+      const b = trustTupleKey({ name: 'gh', url: 'https://u:p2@mcp.example.com/api?t=2#y' })
+      assert.equal(a, b, 'rotated credentials / changed query must not re-prompt for the same endpoint')
+      assert.equal(a, JSON.stringify(['gh', 'https://mcp.example.com/api']))
+      assert.ok(!a.includes('p1') && !a.includes('t=1'), 'no credential may reach the key')
+    })
+
+    it('distinguishes different remote endpoints', () => {
+      const a = trustTupleKey({ name: 'gh', url: 'https://mcp.example.com/a' })
+      const b = trustTupleKey({ name: 'gh', url: 'https://mcp.example.com/b' })
+      assert.notEqual(a, b)
+    })
   })
 
   describe('loadTrustStore', () => {
@@ -266,6 +288,40 @@ describe('byok-mcp-trust', () => {
       recordTrust({ name: 'gh', command: 'node', args: ['mcp.js'] }, storePath)
       const store = loadTrustStore(storePath)
       assert.equal(isTrusted(store, { name: 'gh', command: '/bin/rm', args: ['-rf'] }), false)
+    })
+  })
+
+  // #6821 — remote transport trust round-trips through the same store.
+  describe('remote servers (#6821)', () => {
+    it('records + loads a remote server, persisting name + sanitized url only', () => {
+      const server = { name: 'remote', type: 'http', url: 'https://u:pw@mcp.example.com/api?tok=secret', headers: { Authorization: 'Bearer x' } }
+      recordTrust(server, storePath)
+      const raw = JSON.parse(readFileSync(storePath, 'utf8'))
+      assert.equal(raw.trustedTuples.length, 1)
+      const entry = raw.trustedTuples[0]
+      assert.equal(entry.name, 'remote')
+      assert.equal(entry.url, 'https://mcp.example.com/api', 'stored url must be credential-stripped')
+      assert.equal(entry.command, undefined, 'remote entries carry no command')
+      const disk = readFileSync(storePath, 'utf8')
+      assert.ok(!disk.includes('Bearer') && !disk.includes('pw') && !disk.includes('tok=secret'),
+        'no header value or url credential may ever be written to the trust store')
+      const store = loadTrustStore(storePath)
+      assert.equal(isTrusted(store, server), true)
+    })
+
+    it('does not confuse a remote trust with a same-named stdio server', () => {
+      recordTrust({ name: 'gh', url: 'https://mcp.example.com/api' }, storePath)
+      const store = loadTrustStore(storePath)
+      assert.equal(isTrusted(store, { name: 'gh', url: 'https://mcp.example.com/api' }), true)
+      assert.equal(isTrusted(store, { name: 'gh', command: 'node', args: ['mcp.js'] }), false)
+    })
+
+    it('survives a load-time recompute (not dropped as tampered)', () => {
+      recordTrust({ name: 'remote', url: 'https://mcp.example.com/api' }, storePath)
+      const warned = []
+      const store = loadTrustStore(storePath, { log: { warn: (m) => warned.push(m) } })
+      assert.equal(store.tuples.size, 1)
+      assert.equal(warned.length, 0, 'a well-formed remote entry must not warn')
     })
   })
 


### PR DESCRIPTION
## Summary

BYOK's homegrown MCP client only spoke stdio JSON-RPC to a locally-spawned child, so a remote MCP server configured in `~/.claude.json` (`{ "type": "http", "url": "..." }`) was silently dropped and could never connect. This adds a network transport parallel to the stdio one, behind the same `MCPClient` interface.

**Spec revision:** MCP **Streamable HTTP** transport (`2025-03-26`, the revision that replaced the old HTTP+SSE transport), with the JSON-RPC `protocolVersion` on `initialize` kept at the stdio client's `MCP_PROTOCOL_VERSION` (`2024-11-05`) — the transport layer and the JSON-RPC version negotiation are independent, so both transports negotiate identically. The `MCP-Protocol-Version` header (a `2025-06-18` addition) is echoed on post-initialize requests for forward-compat.

**OAuth is out of scope (#6822):** a remote server answering `401`/`407` surfaces a clear `oauth-required` status ("requires OAuth — not yet supported (#6822)"), not a crash.

## What changed

- **`byok-mcp-config.js`** — parse remote entries (`{ type: 'http'|'sse', url, headers }`) alongside the existing stdio `{ command, args, env }` shape. A remote entry is recognised by an explicit `type` (`http`/`streamable-http`/`sse`) or by a `url` with no `command`; the url is validated as http(s) (rejects `file:`/`ws:`). stdio parsing is byte-identical. New `redactMcpUrl` strips userinfo/query/fragment; `toMcpServerMetadata` exposes `type` + redacted `url` + header **key** names only. Kept consistent with `discoverConfiguredMcpServers` (#6820/#6831).
- **`byok-mcp-client.js`** — `MCPRemoteClient` implementing Streamable HTTP (POST JSON-RPC, `Mcp-Session-Id` handling, SSE-upgraded responses when the server streams) plus a legacy HTTP+SSE fallback for `type: 'sse'`. Same interface as `MCPClient` (`state`/`tools`/`start`/`callTool`/`destroy` + `state`/`ready`/`dead` events); reuses the stdio handshake/tool-call timeout caps. A network client makes a single connect attempt (process-restart backoff doesn't map 1:1). `createMcpClient` factory picks the transport from the config.
- **`byok-mcp-fleet.js`** — dispatch via `createMcpClient`; build a remote-aware trust payload (`(name, url)` + header keys, never header values). Minimal change.
- **`byok-mcp-trust.js`** — remote servers key on `(name, sanitized-url)` (2-element tuple, structurally distinct from the 3-element stdio tuple); persist + recompute without `command`/`args`. URL credentials never reach disk.
- **`permission-manager.js`** — `requestMcpTrust` renders remote servers with a credential-stripped url; header values are never passed in.

## Security

Headers/tokens are never logged or emitted; url credentials are redacted in metadata, logs, the permission broadcast, and the trust store. The `mcp_servers` wire schema (name + status) is unchanged.

## Tests

New `byok-mcp-remote-client.test.js` drives an in-process node `http` MCP server: initialize/tools-list round-trip, SSE-streamed response, `Mcp-Session-Id` echo, `401` → `oauth-required` (no crash), handshake timeout → DEAD, configured headers passed without leaking into emitted events, JSON-RPC error surfacing, trust-gate deny (no network), timeout precedence, factory selection, and legacy HTTP+SSE. Config + trust suites gain remote-parsing / remote-key / credential-redaction coverage. Existing stdio tests untouched.

- All `byok-mcp-*` suites: **123 pass / 1 skip** (pre-existing `mock.module` skip)
- `byok-session` + `permission-manager` suites: **299 pass**
- All 5 server `lint-*.sh`: green
- ESLint: no new warnings (only 3 pre-existing unused-`err` warnings in untouched stdio code)

Closes #6821