### PR TITLE
feat(dashboard,server): permission rules panel + audit history + codex rule getters (#6772, #6829)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import fs from 'node:fs'
 import path from 'node:path'
-import { SettingsPanel } from './SettingsPanel'
+import { SettingsPanel, describePermissionAuditEntry } from './SettingsPanel'
 
 // Mock theme-engine
 vi.mock('../theme/theme-engine', () => ({
@@ -126,6 +126,13 @@ setMockState()
 
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockState),
+  // #6772/#6829: SettingsPanel now imports this pure capability helper. Faithful
+  // reimplementation (a provider supports rules iff its caps say sessionRules:true)
+  // so the Session Rules section's visibility gate behaves like production.
+  isRuleEligibleProvider: (
+    provider: string | null | undefined,
+    providers: { name: string; capabilities?: { sessionRules?: boolean } }[] | undefined,
+  ) => !!provider && providers?.find((p) => p.name === provider)?.capabilities?.sessionRules === true,
 }))
 
 beforeEach(() => {
@@ -2734,5 +2741,139 @@ describe('SettingsPanel', () => {
       fireEvent.click(toggle)
       await waitFor(() => expect(toggle.checked).toBe(false))
     })
+  })
+})
+
+// #6772/#6829 — Session Rules viewer + Permission history (the desktop-parity
+// half of the permission-rules panel). Mirrors the mobile SettingsScreen SESSION
+// RULES / PROJECT RULES lists on the dashboard's primary surface.
+describe('SettingsPanel — permission rules + audit history (#6772/#6829)', () => {
+  const rulesState = (extra: Record<string, unknown> = {}) => ({
+    activeSessionId: 's1',
+    sessions: [{ sessionId: 's1', name: 'Session 1', cwd: '/home/me/proj', provider: 'claude-sdk' }],
+    availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } }],
+    sessionStates: {
+      s1: {
+        sessionRules: [{ tool: 'Edit', decision: 'allow' }],
+        persistentRules: [{ tool: 'Write', decision: 'allow', persist: 'project' }],
+      },
+    },
+    ...extra,
+  })
+
+  it('renders session AND project rules with distinct scope labels', () => {
+    setMockState(rulesState())
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+    // Section header + both scoped lists present.
+    expect(screen.getByTestId('session-rules-section')).toBeInTheDocument()
+    const sessionRow = screen.getByTestId('session-rule-item-Edit')
+    const projectRow = screen.getByTestId('project-rule-item-Write')
+    expect(sessionRow).toHaveTextContent('session')
+    expect(sessionRow).toHaveTextContent('Edit')
+    expect(sessionRow).toHaveTextContent('auto-allow')
+    expect(projectRow).toHaveTextContent('project')
+    expect(projectRow).toHaveTextContent('Write')
+    expect(projectRow).toHaveTextContent('always allow')
+    // Project scope shows the durable rule's project path.
+    expect(screen.getByTestId('project-rules-path')).toHaveTextContent('/home/me/proj')
+  })
+
+  it('removing a session rule sends the reduced list via setPermissionRules', () => {
+    const setPermissionRules = vi.fn()
+    setMockState(rulesState({ setPermissionRules }))
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('session-rule-remove-Edit'))
+    // Only one session rule → filtering it out sends an empty list.
+    expect(setPermissionRules).toHaveBeenCalledTimes(1)
+    expect(setPermissionRules).toHaveBeenCalledWith([])
+  })
+
+  it('clearing all session rules sends [] via setPermissionRules', () => {
+    const setPermissionRules = vi.fn()
+    setMockState(
+      rulesState({
+        setPermissionRules,
+        sessionStates: {
+          s1: {
+            sessionRules: [
+              { tool: 'Edit', decision: 'allow' },
+              { tool: 'Read', decision: 'allow' },
+            ],
+            persistentRules: [],
+          },
+        },
+      }),
+    )
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('session-rules-clear'))
+    expect(setPermissionRules).toHaveBeenCalledWith([])
+  })
+
+  it('removing a project rule sends the reduced list via setProjectPermissionRules', () => {
+    const setProjectPermissionRules = vi.fn()
+    setMockState(rulesState({ setProjectPermissionRules }))
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('project-rule-remove-Write'))
+    expect(setProjectPermissionRules).toHaveBeenCalledTimes(1)
+    expect(setProjectPermissionRules).toHaveBeenCalledWith([])
+  })
+
+  it('does not render the Session Rules section for a provider without rules and no standing rules', () => {
+    setMockState({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S', cwd: '/x', provider: 'codex' }],
+      availableProviders: [{ name: 'codex', capabilities: { sessionRules: false } }],
+      sessionStates: { s1: { sessionRules: [], persistentRules: [] } },
+    })
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('session-rules-section')).not.toBeInTheDocument()
+  })
+
+  it('Permission history: Load history triggers queryPermissionAudit and renders returned entries', () => {
+    const queryPermissionAudit = vi.fn()
+    setMockState(
+      rulesState({
+        queryPermissionAudit,
+        permissionAudit: [
+          { type: 'decision', sessionId: 's1', decision: 'allow', timestamp: Date.now() },
+          { type: 'mode_change', sessionId: 's1', previousMode: 'approve', newMode: 'auto', timestamp: Date.now() },
+        ],
+        permissionAuditLoading: false,
+      }),
+    )
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+    // The section renders and the pull button is wired.
+    expect(screen.getByTestId('permission-history-section')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('permission-history-load'))
+    expect(queryPermissionAudit).toHaveBeenCalledTimes(1)
+
+    // The two mocked entries render with their described labels.
+    const list = screen.getByTestId('permission-history-list')
+    expect(list).toHaveTextContent('Allowed')
+    expect(list).toHaveTextContent('Permission mode: approve → auto')
+  })
+
+  it('Permission history: empty result shows the no-events hint', () => {
+    setMockState(rulesState({ permissionAudit: [], permissionAuditLoading: false }))
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByTestId('permission-history-empty')).toBeInTheDocument()
+  })
+
+  it('describePermissionAuditEntry labels each audit kind', () => {
+    expect(describePermissionAuditEntry({ type: 'mode_change', previousMode: 'approve', newMode: 'auto', timestamp: 0 })).toBe(
+      'Permission mode: approve → auto',
+    )
+    expect(
+      describePermissionAuditEntry({ type: 'whitelist_change', rules: [{ tool: 'Edit', decision: 'allow' }], timestamp: 0 }),
+    ).toBe('Session rules changed (1 rule)')
+    expect(describePermissionAuditEntry({ type: 'decision', decision: 'deny', reason: 'timeout', timestamp: 0 })).toBe(
+      'Denied (timeout)',
+    )
+    expect(describePermissionAuditEntry({ type: 'decision', decision: 'allow', reason: 'user', timestamp: 0 })).toBe('Allowed')
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2864,6 +2864,25 @@ describe('SettingsPanel — permission rules + audit history (#6772/#6829)', () 
     expect(screen.getByTestId('permission-history-empty')).toBeInTheDocument()
   })
 
+  it('Permission history: parse-failure error state shows the load-failed hint and keeps the button actionable', () => {
+    setMockState(rulesState({ permissionAudit: null, permissionAuditLoading: false, permissionAuditError: true }))
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByTestId('permission-history-error')).toBeInTheDocument()
+    // The button is NOT wedged in a disabled loading state — retry stays possible.
+    expect(screen.getByTestId('permission-history-load')).not.toBeDisabled()
+  })
+
+  it('Permission history: an UNKNOWN audit kind renders with the generic fallback label', () => {
+    setMockState(
+      rulesState({
+        permissionAudit: [{ type: 'rule_expired', sessionId: 's1', timestamp: Date.now() }],
+        permissionAuditLoading: false,
+      }),
+    )
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+    expect(screen.getByTestId('permission-history-list')).toHaveTextContent('Permission event')
+  })
+
   it('describePermissionAuditEntry labels each audit kind', () => {
     expect(describePermissionAuditEntry({ type: 'mode_change', previousMode: 'approve', newMode: 'auto', timestamp: 0 })).toBe(
       'Permission mode: approve → auto',
@@ -2875,5 +2894,7 @@ describe('SettingsPanel — permission rules + audit history (#6772/#6829)', () 
       'Denied (timeout)',
     )
     expect(describePermissionAuditEntry({ type: 'decision', decision: 'allow', reason: 'user', timestamp: 0 })).toBe('Allowed')
+    // Forward-compat (#6836 review): an unknown future kind gets the generic label.
+    expect(describePermissionAuditEntry({ type: 'rule_expired', timestamp: 0 })).toBe('Permission event')
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -57,10 +57,12 @@ const EMPTY_PERMISSION_RULES: PermissionRule[] = []
 
 /**
  * #6772 — human label for one permission audit entry. The server's audit log
- * (permission-audit.js) records three heterogeneous kinds; render each by its
- * distinguishing fields (a `decision` entry carries no tool name — the audit log
- * keys on requestId, not tool). Pure + exported-shape so the SettingsPanel test
- * can assert on the rendered text.
+ * (permission-audit.js) records heterogeneous kinds; render each known kind by
+ * its distinguishing fields (a `decision` entry carries no tool name — the audit
+ * log keys on requestId, not tool). `entry.type` is an OPEN string (PR #6836
+ * review — the wire schema is forward-compatible), so any UNKNOWN kind falls
+ * through to the generic label rather than breaking the list. Pure +
+ * exported-shape so the SettingsPanel test can assert on the rendered text.
  */
 export function describePermissionAuditEntry(entry: PermissionAuditEntry): string {
   switch (entry.type) {
@@ -803,6 +805,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
   const queryPermissionAudit = useConnectionStore(s => s.queryPermissionAudit)
   const permissionAudit = useConnectionStore(s => s.permissionAudit)
   const permissionAuditLoading = useConnectionStore(s => s.permissionAuditLoading)
+  const permissionAuditError = useConnectionStore(s => s.permissionAuditError)
   const themes = getAvailableThemes()
   const inTauri = isTauri()
   const [tunnelMode, setTunnelModeState] = useState<string>('none')
@@ -1659,6 +1662,13 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
               >
                 {permissionAuditLoading ? 'Loading…' : permissionAudit == null ? 'Load history' : 'Refresh'}
               </button>
+              {/* PR #6836 review — a malformed reply clears loading and lands here
+                  instead of wedging the button; retry via the same Load button. */}
+              {permissionAuditError && (
+                <p className="settings-hint" role="alert" data-testid="permission-history-error">
+                  Couldn't load permission history. Try again.
+                </p>
+              )}
               {permissionAudit != null && (
                 permissionAudit.length === 0 ? (
                   <p className="settings-hint" data-testid="permission-history-empty">

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -5,7 +5,8 @@
  * and persist to localStorage.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useConnectionStore } from '../store/connection'
+import { useConnectionStore, isRuleEligibleProvider } from '../store/connection'
+import type { PermissionRule, PermissionAuditEntry } from '../store/types'
 import { ShortcutsSection } from '../shortcuts/ShortcutsSection'
 import { ProviderCredentialsPane } from './ProviderCredentialsPane'
 import { getAvailableThemes, applyTheme } from '../theme/theme-engine'
@@ -46,6 +47,36 @@ import { useDebouncedSetter } from '../hooks/useDebouncedSetter'
 /** Confirmation copy from issue #3077 — keep verbatim. */
 const AUTO_PERMISSION_CONFIRM_MESSAGE =
   'Auto-permission mode disables all per-tool prompts for non-paired clients. Continue?'
+
+/**
+ * #6772/#6829 — stable empty reference for the permission-rules selectors so
+ * Zustand doesn't re-render the panel on every unrelated store write (mirrors the
+ * mobile SettingsScreen `EMPTY_RULES`).
+ */
+const EMPTY_PERMISSION_RULES: PermissionRule[] = []
+
+/**
+ * #6772 — human label for one permission audit entry. The server's audit log
+ * (permission-audit.js) records three heterogeneous kinds; render each by its
+ * distinguishing fields (a `decision` entry carries no tool name — the audit log
+ * keys on requestId, not tool). Pure + exported-shape so the SettingsPanel test
+ * can assert on the rendered text.
+ */
+export function describePermissionAuditEntry(entry: PermissionAuditEntry): string {
+  switch (entry.type) {
+    case 'mode_change':
+      return `Permission mode: ${entry.previousMode ?? '?'} → ${entry.newMode ?? '?'}`
+    case 'whitelist_change':
+      return `Session rules changed (${entry.rules?.length ?? 0} rule${(entry.rules?.length ?? 0) === 1 ? '' : 's'})`
+    case 'decision': {
+      const verb = entry.decision === 'deny' ? 'Denied' : 'Allowed'
+      const reason = entry.reason && entry.reason !== 'user' ? ` (${entry.reason})` : ''
+      return `${verb}${reason}`
+    }
+    default:
+      return 'Permission event'
+  }
+}
 
 /**
  * #4588: confirmation copy for clearing the current device's per-device
@@ -752,6 +783,26 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
   // (older servers pre-#4660 omit it entirely). The server is the
   // authoritative trim/cap site so we render exactly what it confirmed.
   const activeSessionSessionPreamble = sessions.find(s => s.sessionId === activeSessionId)?.sessionPreamble
+  // #6772/#6829 — per-session permission rules viewer + audit history. sessionRules /
+  // persistentRules live on sessionStates (kept current by `permission_rules_updated`);
+  // the active session's cwd (project-rule scope label) + provider are on the sessions
+  // list. Stable empty refs keep the selectors from re-rendering on unrelated writes.
+  const activeSessionRules = useConnectionStore(s => {
+    const id = s.activeSessionId
+    return (id ? s.sessionStates?.[id]?.sessionRules : undefined) ?? EMPTY_PERMISSION_RULES
+  })
+  const activePersistentRules = useConnectionStore(s => {
+    const id = s.activeSessionId
+    return (id ? s.sessionStates?.[id]?.persistentRules : undefined) ?? EMPTY_PERMISSION_RULES
+  })
+  const activeSessionCwd = sessions.find(s => s.sessionId === activeSessionId)?.cwd ?? null
+  const activeSessionProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider ?? null
+  const providerSupportsRules = isRuleEligibleProvider(activeSessionProvider, availableProviders)
+  const setPermissionRules = useConnectionStore(s => s.setPermissionRules)
+  const setProjectPermissionRules = useConnectionStore(s => s.setProjectPermissionRules)
+  const queryPermissionAudit = useConnectionStore(s => s.queryPermissionAudit)
+  const permissionAudit = useConnectionStore(s => s.permissionAudit)
+  const permissionAuditLoading = useConnectionStore(s => s.permissionAuditLoading)
   const themes = getAvailableThemes()
   const inTauri = isTauri()
   const [tunnelMode, setTunnelModeState] = useState<string>('none')
@@ -1480,6 +1531,153 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
                     across server restarts.
                   </p>
                 </div>
+              )}
+            </section>
+          )}
+
+          {/* #6772/#6829 — Session Rules viewer. Mirrors the mobile
+              SettingsScreen SESSION RULES / PROJECT RULES lists: view the active
+              session's auto-approval rules (session-scoped AND durable per-project
+              "always allow" grants, clearly distinguished by scope), remove one, or
+              clear all. Removing/clearing sends set_permission_rules via the store.
+              Rendered when the active session's provider supports rules OR there are
+              already-standing rules to manage. */}
+          {activeSessionId != null && (providerSupportsRules || activeSessionRules.length > 0 || activePersistentRules.length > 0) && (
+            <section className="settings-section" data-testid="session-rules-section">
+              <h3>Session rules</h3>
+              <p className="settings-hint">
+                Tools you auto-approved for this session (<strong>Allow for Session</strong>)
+                and durable grants that survive daemon restarts
+                (<strong>Always allow</strong>). Remove one to require a prompt again.
+              </p>
+
+              {/* Session-scoped rules */}
+              <div className="settings-field" data-testid="session-rules-list">
+                <label>Session-scoped</label>
+                {activeSessionRules.length === 0 ? (
+                  <p className="settings-hint" data-testid="session-rules-empty">No active session rules.</p>
+                ) : (
+                  <>
+                    <ul className="perm-rules-list">
+                      {activeSessionRules.map((rule, index) => (
+                        <li
+                          key={`session-${rule.tool}-${rule.decision}-${index}`}
+                          className="perm-rule-row"
+                          data-testid={`session-rule-item-${rule.tool}`}
+                        >
+                          <span className="perm-rule-label">
+                            <span className="perm-rule-scope perm-rule-scope-session">session</span>
+                            {' '}<code>{rule.tool}</code> — {rule.decision === 'allow' ? 'auto-allow' : 'auto-deny'}
+                          </span>
+                          <button
+                            type="button"
+                            className="perm-rule-remove"
+                            aria-label={`Remove session rule ${rule.tool}`}
+                            data-testid={`session-rule-remove-${rule.tool}`}
+                            onClick={() => setPermissionRules(activeSessionRules.filter((_, i) => i !== index))}
+                          >
+                            Remove
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                    <button
+                      type="button"
+                      className="settings-secondary-button"
+                      data-testid="session-rules-clear"
+                      onClick={() => setPermissionRules([])}
+                    >
+                      Clear all session rules
+                    </button>
+                  </>
+                )}
+              </div>
+
+              {/* Durable per-project ("always allow") rules — only shown when present */}
+              {activePersistentRules.length > 0 && (
+                <div className="settings-field" data-testid="project-rules-list">
+                  <label data-testid="project-rules-header">Project (always allow)</label>
+                  <p className="settings-hint">
+                    Persisted for{' '}
+                    <code data-testid="project-rules-path">{activeSessionCwd ?? 'this project'}</code>
+                    {' '}— survives daemon restarts.
+                  </p>
+                  <ul className="perm-rules-list">
+                    {activePersistentRules.map((rule, index) => (
+                      <li
+                        key={`project-${rule.tool}-${rule.decision}-${index}`}
+                        className="perm-rule-row"
+                        data-testid={`project-rule-item-${rule.tool}`}
+                      >
+                        <span className="perm-rule-label">
+                          <span className="perm-rule-scope perm-rule-scope-project">project</span>
+                          {' '}<code>{rule.tool}</code> — {rule.decision === 'allow' ? 'always allow' : 'always deny'}
+                        </span>
+                        <button
+                          type="button"
+                          className="perm-rule-remove"
+                          aria-label={`Remove project rule ${rule.tool}`}
+                          data-testid={`project-rule-remove-${rule.tool}`}
+                          onClick={() => setProjectPermissionRules(activePersistentRules.filter((_, i) => i !== index))}
+                        >
+                          Remove
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    type="button"
+                    className="settings-secondary-button"
+                    data-testid="project-rules-clear"
+                    onClick={() => setProjectPermissionRules([])}
+                  >
+                    Clear all project rules
+                  </button>
+                </div>
+              )}
+            </section>
+          )}
+
+          {/* #6772 — Permission history. Read-only view of the server's permission
+              audit trail (mode changes, session-rule changes, allow/deny decisions)
+              for the active session — the first client to query the daemon's
+              query_permission_audit API. Pull-on-demand (not live) so it never adds
+              wire traffic unless opened. */}
+          {activeSessionId != null && (
+            <section className="settings-section" data-testid="permission-history-section">
+              <h3>Permission history</h3>
+              <p className="settings-hint">
+                Recent permission decisions and rule changes for this session, from the
+                server's audit log.
+              </p>
+              <button
+                type="button"
+                className="settings-secondary-button"
+                data-testid="permission-history-load"
+                disabled={permissionAuditLoading}
+                onClick={() => queryPermissionAudit()}
+              >
+                {permissionAuditLoading ? 'Loading…' : permissionAudit == null ? 'Load history' : 'Refresh'}
+              </button>
+              {permissionAudit != null && (
+                permissionAudit.length === 0 ? (
+                  <p className="settings-hint" data-testid="permission-history-empty">
+                    No permission events recorded for this session yet.
+                  </p>
+                ) : (
+                  <ul className="perm-audit-list" data-testid="permission-history-list">
+                    {permissionAudit.map((entry, index) => (
+                      <li
+                        key={`audit-${entry.timestamp}-${index}`}
+                        className="perm-audit-row"
+                        data-testid={`permission-audit-entry-${index}`}
+                      >
+                        <span className="perm-audit-label">{describePermissionAuditEntry(entry)}</span>
+                        <span className="perm-audit-time">{formatRelativeTime(entry.timestamp)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )
               )}
             </section>
           )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -65,6 +65,7 @@ import type {
   InputSettings,
   RestoreCheckpointMode,
   PermissionDecision,
+  PermissionRule,
   ServerEntry,
   SessionInfo,
   SessionState,
@@ -688,6 +689,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   referencesSymbol: '',
   referencesOpen: false,
   referencesLoading: false,
+  permissionAudit: null,
+  permissionAuditLoading: false,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2673,6 +2676,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   referencesSymbol: '',
   referencesOpen: false,
   referencesLoading: false,
+  permissionAudit: null,
+  permissionAuditLoading: false,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3274,6 +3279,47 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #2838: cap map size to prevent unbounded growth across long sessions.
       resolvedPermissions: capResolvedPermissions(state.resolvedPermissions, requestId, decision),
     }));
+  },
+
+  // #6772/#6829 — replace the active session's session-scoped rule set (the
+  // SettingsPanel "Session Rules" viewer's remove / clear-all). Strips the
+  // client-only `persist` marker — the server's PermissionRuleSchema accepts only
+  // { tool, decision }. Mirrors the mobile SettingsScreen action.
+  setPermissionRules: (rules: PermissionRule[]) => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) return;
+    const bare = rules.map((r) => ({ tool: r.tool, decision: r.decision }));
+    wsSend(socket, { type: 'set_permission_rules', sessionId: activeSessionId, rules: bare });
+  },
+
+  // #6772/#6829 — replace the active session's DURABLE per-project rule set
+  // (remove a persistent rule by sending the reduced list, or clear all with []).
+  // Session rules are left untouched: we re-send the current sessionRules so the
+  // server's single set_permission_rules handler doesn't clobber them. Mirrors the
+  // mobile SettingsScreen action.
+  setProjectPermissionRules: (projectRules: PermissionRule[]) => {
+    const { socket, activeSessionId, sessionStates } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) return;
+    const ss = sessionStates[activeSessionId];
+    const bare = (rs?: PermissionRule[]) => (rs ?? []).map((r) => ({ tool: r.tool, decision: r.decision }));
+    wsSend(socket, {
+      type: 'set_permission_rules',
+      sessionId: activeSessionId,
+      rules: bare(ss?.sessionRules),
+      projectRules: bare(projectRules),
+    });
+  },
+
+  // #6772 — pull the permission audit history for the active session. Sets the
+  // loading flag; the reply (`permission_audit_result`) lands in `permissionAudit`
+  // (handlePermissionAuditResult). The server filters by sessionId when provided.
+  queryPermissionAudit: () => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN) return;
+    set({ permissionAuditLoading: true });
+    const msg: Record<string, unknown> = { type: 'query_permission_audit' };
+    if (activeSessionId) msg.sessionId = activeSessionId;
+    wsSend(socket, msg);
   },
 
   sendUserQuestionResponse: (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -691,6 +691,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   referencesLoading: false,
   permissionAudit: null,
   permissionAuditLoading: false,
+  permissionAuditError: false,
   customAgents: [],
   checkpoints: [],
   _directoryListingCallback: null,
@@ -2678,6 +2679,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   referencesLoading: false,
   permissionAudit: null,
   permissionAuditLoading: false,
+  permissionAuditError: false,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -3316,7 +3318,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   queryPermissionAudit: () => {
     const { socket, activeSessionId } = get();
     if (!socket || socket.readyState !== WebSocket.OPEN) return;
-    set({ permissionAuditLoading: true });
+    set({ permissionAuditLoading: true, permissionAuditError: false });
     const msg: Record<string, unknown> = { type: 'query_permission_audit' };
     if (activeSessionId) msg.sessionId = activeSessionId;
     wsSend(socket, msg);
@@ -4039,9 +4041,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // per-session pull (queryPermissionAudit scopes to the active session).
     // Clear it on every switch so the SettingsPanel "Permission history" view
     // never shows the PREVIOUS session's entries against the new session; the
-    // user re-pulls on demand. The loading flag resets too so an in-flight
-    // pull for the old session can't wedge the button.
-    set({ permissionAudit: null, permissionAuditLoading: false });
+    // user re-pulls on demand. The loading + error flags reset too so an
+    // in-flight pull for the old session can't wedge the button.
+    set({ permissionAudit: null, permissionAuditLoading: false, permissionAuditError: false });
 
     // Optimistically switch to cached state + mark notifications for target
     // session as read. #4890 — pre-widget we filtered the target session's

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -4035,6 +4035,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // a stale banner doesn't outlive the resolution.
     if (get().sessionNotFoundError) set({ sessionNotFoundError: null });
 
+    // #6772 (PR #6836 review) — the permission audit history is a FLAT,
+    // per-session pull (queryPermissionAudit scopes to the active session).
+    // Clear it on every switch so the SettingsPanel "Permission history" view
+    // never shows the PREVIOUS session's entries against the new session; the
+    // user re-pulls on demand. The loading flag resets too so an in-flight
+    // pull for the old session can't wedge the button.
+    set({ permissionAudit: null, permissionAuditLoading: false });
+
     // Optimistically switch to cached state + mark notifications for target
     // session as read. #4890 — pre-widget we filtered the target session's
     // alerts out entirely, but the new Slack-style widget needs the entries

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -140,7 +140,7 @@ import {
   applyRunDelta,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -165,6 +165,7 @@ import type {
   FileEntry,
   PendingCommunitySkill,
   PendingEvaluatorClarify,
+  PermissionAuditEntry,
   QueuedMessage,
   SessionInfo,
   SessionNotification,
@@ -2672,6 +2673,21 @@ function handleReferencesResult(msg: Record<string, unknown>, _get: MsgGet, set:
 }
 
 /**
+ * #6772 — reply to a `query_permission_audit` pull: REPLACE the stored audit
+ * history with the returned entries and clear the loading flag. Zod-validated
+ * (a malformed payload is dropped rather than crashing the view), and the
+ * loading flag clears only on a successful parse — the same defensive
+ * query-response pattern as code_search_results / references_result. Drives the
+ * SettingsPanel "Permission history" view. Dashboard-only for v1 (the mobile
+ * PermissionHistory screen derives its summary from the chat transcript).
+ */
+function handlePermissionAuditResult(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerPermissionAuditResultSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({ permissionAudit: parsed.data.entries as PermissionAuditEntry[], permissionAuditLoading: false });
+}
+
+/**
  * Mailbox (#5914 follow-up) — Control Room "Mailbox" tab `mailbox_status_snapshot`:
  * REPLACE the stored snapshot with the carried one and clear the in-flight
  * loading flag. Same defensive pattern as the host/runner snapshots — the wire
@@ -3476,6 +3492,8 @@ const HANDLERS: Record<string, Handler> = {
   orchestration_action_ack: handleOrchestrationActionAck,
   // #6543 (IDE P3 feature B): pulled full redacted tool input for a pre-write diff.
   permission_input: handlePermissionInput,
+  // #6772: reply to query_permission_audit — the SettingsPanel "Permission history" view.
+  permission_audit_result: handlePermissionAuditResult,
   session_preset_snapshot: handleSessionPresetSnapshot,
   // #5253: self-hosted runner Control Room survey snapshot.
   runner_status_snapshot: handleRunnerStatusSnapshot,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2674,17 +2674,22 @@ function handleReferencesResult(msg: Record<string, unknown>, _get: MsgGet, set:
 
 /**
  * #6772 — reply to a `query_permission_audit` pull: REPLACE the stored audit
- * history with the returned entries and clear the loading flag. Zod-validated
- * (a malformed payload is dropped rather than crashing the view), and the
- * loading flag clears only on a successful parse — the same defensive
- * query-response pattern as code_search_results / references_result. Drives the
+ * history with the returned entries and clear the loading flag. Zod-validated —
+ * a malformed payload is dropped rather than crashing the view — but a parse
+ * failure STILL clears the loading flag and raises `permissionAuditError`
+ * (PR #6836 review): this is a request/reply pair, so an early return that left
+ * `permissionAuditLoading` latched would wedge the history button forever (no
+ * later broadcast re-clears it, unlike the snapshot-style handlers). Drives the
  * SettingsPanel "Permission history" view. Dashboard-only for v1 (the mobile
  * PermissionHistory screen derives its summary from the chat transcript).
  */
 function handlePermissionAuditResult(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerPermissionAuditResultSchema.safeParse(msg);
-  if (!parsed.success) return;
-  set({ permissionAudit: parsed.data.entries as PermissionAuditEntry[], permissionAuditLoading: false });
+  if (!parsed.success) {
+    set({ permissionAuditLoading: false, permissionAuditError: true });
+    return;
+  }
+  set({ permissionAudit: parsed.data.entries as PermissionAuditEntry[], permissionAuditLoading: false, permissionAuditError: false });
 }
 
 /**

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2141,6 +2141,27 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     _testMessageHandler.clearContext();
   });
 
+  it('switchSession clears the permission audit history so it never shows another session\'s entries', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState() }, s2: { ...createEmptySessionState() } },
+      sessionNotifications: [],
+      permissionAudit: [{ type: 'decision', sessionId: 's1', decision: 'allow', timestamp: 1 }],
+      permissionAuditLoading: true,
+      socket: null,
+    });
+
+    useConnectionStore.getState().switchSession('s2');
+
+    const state = useConnectionStore.getState();
+    expect(state.activeSessionId).toBe('s2');
+    expect(state.permissionAudit).toBeNull();
+    expect(state.permissionAuditLoading).toBe(false);
+  });
+
   it('permission_expired for an already-resolved requestId does not mutate the prompt message', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2137,6 +2137,62 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(state.permissionAudit).toHaveLength(2);
     expect(state.permissionAudit![0]!.type).toBe('decision');
     expect(state.permissionAudit![1]!.newMode).toBe('auto');
+    expect(state.permissionAuditError).toBe(false);
+
+    _testMessageHandler.clearContext();
+  });
+
+  it('a MALFORMED permission_audit_result clears the loading flag and raises the error state (no wedge)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { _testMessageHandler } = await import('./message-handler');
+
+    useConnectionStore.setState({ permissionAudit: null, permissionAuditLoading: true, permissionAuditError: false });
+    _testMessageHandler.setContext({
+      url: 'ws://localhost:3000',
+      token: 'test-token',
+      isReconnect: false,
+      silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    });
+
+    // entries must be an array — a scalar fails the schema parse.
+    _testMessageHandler.handle({ type: 'permission_audit_result', entries: 'not-an-array' });
+
+    const state = useConnectionStore.getState();
+    expect(state.permissionAuditLoading).toBe(false); // button unwedged
+    expect(state.permissionAuditError).toBe(true);    // generic load-failed state
+    expect(state.permissionAudit).toBeNull();         // no garbage stored
+
+    _testMessageHandler.clearContext();
+  });
+
+  it('an UNKNOWN audit entry type still parses (forward-compatible wire schema)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { _testMessageHandler } = await import('./message-handler');
+
+    useConnectionStore.setState({ permissionAudit: null, permissionAuditLoading: true, permissionAuditError: false });
+    _testMessageHandler.setContext({
+      url: 'ws://localhost:3000',
+      token: 'test-token',
+      isReconnect: false,
+      silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    });
+
+    // A future server-side audit kind must not fail the WHOLE payload (#6836 review).
+    _testMessageHandler.handle({
+      type: 'permission_audit_result',
+      entries: [
+        { type: 'rule_expired', sessionId: 's1', timestamp: 1 },
+        { type: 'decision', sessionId: 's1', decision: 'allow', timestamp: 2 },
+      ],
+    });
+
+    const state = useConnectionStore.getState();
+    expect(state.permissionAuditLoading).toBe(false);
+    expect(state.permissionAuditError).toBe(false);
+    expect(state.permissionAudit).toHaveLength(2);
+    expect(state.permissionAudit![0]!.type).toBe('rule_expired');
 
     _testMessageHandler.clearContext();
   });

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2034,6 +2034,113 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(sent.some((m) => m.type === 'set_permission_rules')).toBe(false);
   });
 
+  // #6772/#6829 — Session Rules viewer store actions (the SettingsPanel remove /
+  // clear-all path). These assert the exact wire shape the panel produces.
+  it('setPermissionRules sends set_permission_rules with the (bare) session rule list', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = { readyState: 1, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState(), sessionRules: [{ tool: 'Edit', decision: 'allow' }] } },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    // Remove the only session rule → send an empty list.
+    useConnectionStore.getState().setPermissionRules([]);
+
+    const msg = sent.find((m) => m.type === 'set_permission_rules');
+    expect(msg).toBeDefined();
+    expect(msg!.sessionId).toBe('s1');
+    expect(msg!.rules).toEqual([]);
+    expect(msg!.projectRules).toBeUndefined();
+  });
+
+  it('setProjectPermissionRules sends the reduced projectRules AND re-sends the current session rules (stripped of persist)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = { readyState: 1, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          sessionRules: [{ tool: 'Glob', decision: 'allow' }],
+          persistentRules: [
+            { tool: 'Write', decision: 'allow', persist: 'project' },
+            { tool: 'Edit', decision: 'allow', persist: 'project' },
+          ],
+        },
+      },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    // Remove the first project rule (Write) → send the reduced project list.
+    useConnectionStore.getState().setProjectPermissionRules([{ tool: 'Edit', decision: 'allow', persist: 'project' }]);
+
+    const msg = sent.find((m) => m.type === 'set_permission_rules');
+    expect(msg).toBeDefined();
+    expect(msg!.sessionId).toBe('s1');
+    // Session rules preserved (server's single handler would otherwise clobber them).
+    expect(msg!.rules).toEqual([{ tool: 'Glob', decision: 'allow' }]);
+    // projectRules carry only { tool, decision } — the client-only `persist` marker is stripped.
+    expect(msg!.projectRules).toEqual([{ tool: 'Edit', decision: 'allow' }]);
+  });
+
+  it('queryPermissionAudit sets the loading flag and sends query_permission_audit scoped to the active session', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = { readyState: 1, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      socket: mockSocket as unknown as WebSocket,
+      permissionAudit: null,
+      permissionAuditLoading: false,
+    });
+
+    useConnectionStore.getState().queryPermissionAudit();
+
+    expect(useConnectionStore.getState().permissionAuditLoading).toBe(true);
+    const msg = sent.find((m) => m.type === 'query_permission_audit');
+    expect(msg).toBeDefined();
+    expect(msg!.sessionId).toBe('s1');
+  });
+
+  it('permission_audit_result populates permissionAudit and clears the loading flag', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { _testMessageHandler } = await import('./message-handler');
+
+    useConnectionStore.setState({ permissionAudit: null, permissionAuditLoading: true });
+    _testMessageHandler.setContext({
+      url: 'ws://localhost:3000',
+      token: 'test-token',
+      isReconnect: false,
+      silent: false,
+      socket: { send: () => {}, readyState: 1 } as unknown as WebSocket,
+    });
+
+    _testMessageHandler.handle({
+      type: 'permission_audit_result',
+      entries: [
+        { type: 'decision', sessionId: 's1', decision: 'allow', reason: 'user', timestamp: 1 },
+        { type: 'mode_change', sessionId: 's1', previousMode: 'approve', newMode: 'auto', timestamp: 2 },
+      ],
+    });
+
+    const state = useConnectionStore.getState();
+    expect(state.permissionAuditLoading).toBe(false);
+    expect(state.permissionAudit).toHaveLength(2);
+    expect(state.permissionAudit![0]!.type).toBe('decision');
+    expect(state.permissionAudit![1]!.newMode).toBe('auto');
+
+    _testMessageHandler.clearContext();
+  });
+
   it('permission_expired for an already-resolved requestId does not mutate the prompt message', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -292,13 +292,16 @@ export interface PermissionRule {
 
 /**
  * #6772 — one entry from the server's permission audit trail (permission-audit.js
- * ring buffer), returned by a `query_permission_audit` pull. Three heterogeneous
- * `type`s share this shape; per-type fields are optional (mirrors the wire
- * `ServerPermissionAuditEntrySchema`). Rendered read-only in the SettingsPanel
- * "Permission history" view.
+ * ring buffer), returned by a `query_permission_audit` pull. Heterogeneous `type`s
+ * share this shape; per-type fields are optional (mirrors the wire
+ * `ServerPermissionAuditEntrySchema`). Known kinds: 'mode_change' /
+ * 'whitelist_change' / 'decision' — but `type` is an OPEN string (PR #6836
+ * review): a future server-side audit kind must not fail the payload parse, and
+ * the view renders unknown kinds with a generic label. Rendered read-only in the
+ * SettingsPanel "Permission history" view.
  */
 export interface PermissionAuditEntry {
-  type: 'mode_change' | 'whitelist_change' | 'decision';
+  type: string;
   clientId?: string | null;
   sessionId?: string | null;
   timestamp: number;
@@ -1322,9 +1325,13 @@ export interface ConnectionState {
   // #6772 — permission audit history (query_permission_audit reply). `permissionAudit`
   // holds the entries from the latest pull (null until the first query this session);
   // `permissionAuditLoading` is true between dispatching the query and its reply.
-  // Scoped to the active session by the query action (the server filters by sessionId).
+  // `permissionAuditError` is true when the reply failed the wire-schema parse
+  // (PR #6836 review) — the view shows a generic load-failed hint and the button
+  // stays actionable instead of wedging on a stuck loading flag. Scoped to the
+  // active session by the query action (the server filters by sessionId).
   permissionAudit: PermissionAuditEntry[] | null;
   permissionAuditLoading: boolean;
+  permissionAuditError: boolean;
 
   // Custom agents from server
   customAgents: CustomAgent[];

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -291,6 +291,29 @@ export interface PermissionRule {
 }
 
 /**
+ * #6772 — one entry from the server's permission audit trail (permission-audit.js
+ * ring buffer), returned by a `query_permission_audit` pull. Three heterogeneous
+ * `type`s share this shape; per-type fields are optional (mirrors the wire
+ * `ServerPermissionAuditEntrySchema`). Rendered read-only in the SettingsPanel
+ * "Permission history" view.
+ */
+export interface PermissionAuditEntry {
+  type: 'mode_change' | 'whitelist_change' | 'decision';
+  clientId?: string | null;
+  sessionId?: string | null;
+  timestamp: number;
+  // mode_change
+  previousMode?: string;
+  newMode?: string;
+  // whitelist_change
+  rules?: { tool: string; decision: string }[];
+  // decision
+  requestId?: string;
+  decision?: string;
+  reason?: string;
+}
+
+/**
  * Decision stored when the user resolves a permission prompt. Persists
  * across tab switches (fixes #2833) so the prompt component does not
  * re-render with Allow/Deny buttons after the user already answered.
@@ -1296,6 +1319,12 @@ export interface ConnectionState {
   referencesSymbol: string;
   referencesOpen: boolean;
   referencesLoading: boolean;
+  // #6772 — permission audit history (query_permission_audit reply). `permissionAudit`
+  // holds the entries from the latest pull (null until the first query this session);
+  // `permissionAuditLoading` is true between dispatching the query and its reply.
+  // Scoped to the active session by the query action (the server filters by sessionId).
+  permissionAudit: PermissionAuditEntry[] | null;
+  permissionAuditLoading: boolean;
 
   // Custom agents from server
   customAgents: CustomAgent[];
@@ -1419,6 +1448,27 @@ export interface ConnectionState {
    * state across remounts (#2833). Safe to call for an already-resolved
    * requestId — last write wins. */
   markPermissionResolved: (requestId: string, decision: PermissionDecision) => void;
+  /**
+   * #6772/#6829 — replace the active session's session-scoped permission rules
+   * (the SettingsPanel "Session Rules" viewer's remove / clear-all affordance).
+   * Sends `set_permission_rules` with the given list for the active session.
+   * Mirrors the mobile SettingsScreen `setPermissionRules`.
+   */
+  setPermissionRules: (rules: PermissionRule[]) => void;
+  /**
+   * #6772/#6829 — replace the active session's DURABLE per-project ("always allow")
+   * rule set. Used to remove a persistent rule (send the reduced list) or clear all.
+   * Re-sends the current session rules alongside so the server's single
+   * `set_permission_rules` handler doesn't clobber them. Mirrors the mobile
+   * SettingsScreen `setProjectPermissionRules`.
+   */
+  setProjectPermissionRules: (projectRules: PermissionRule[]) => void;
+  /**
+   * #6772 — pull the permission audit history for the active session
+   * (`query_permission_audit`). Sets `permissionAuditLoading`; the reply lands in
+   * `permissionAudit`. No-op when disconnected.
+   */
+  queryPermissionAudit: () => void;
   /**
    * #4604 Chunk B / #4621 / #4651 / #4735 — answer may be one of three shapes:
    * - `string`: legacy single-question / free-text path (back-compat).

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -10436,6 +10436,81 @@ button.sidebar-token-view-session-row:hover {
   cursor: not-allowed;
 }
 
+/* #6772/#6829 — Session Rules viewer + Permission history layout. Pure layout;
+   buttons reuse .settings-secondary-button. */
+.perm-rules-list,
+.perm-audit-list {
+  list-style: none;
+  margin: 6px 0 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.perm-rule-row,
+.perm-audit-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  font-size: var(--text-sm);
+}
+
+.perm-rule-label,
+.perm-audit-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.perm-rule-scope {
+  display: inline-block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.perm-rule-scope-session {
+  background: rgba(80, 140, 220, 0.18);
+  color: var(--text-secondary);
+}
+
+.perm-rule-scope-project {
+  background: rgba(90, 190, 120, 0.18);
+  color: var(--text-secondary);
+}
+
+.perm-rule-remove {
+  flex: 0 0 auto;
+  background: transparent;
+  border: 1px solid var(--border-primary);
+  color: var(--text-secondary);
+  border-radius: 4px;
+  padding: 1px 8px;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.perm-rule-remove:hover {
+  background: rgba(220, 40, 40, 0.12);
+  border-color: rgba(220, 40, 40, 0.6);
+  color: var(--text-primary);
+}
+
+.perm-audit-time {
+  flex: 0 0 auto;
+  color: var(--text-tertiary, var(--text-secondary));
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 .settings-error {
   background: rgba(220, 40, 40, 0.12);
   border: 1px solid rgba(220, 40, 40, 0.6);

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -209,22 +209,24 @@ export declare const ServerPermissionInputSchema: z.ZodDiscriminatedUnion<[z.Zod
 }, z.core.$strip>], "found">;
 /**
  * #6772 — one entry in the server's permission audit trail (permission-audit.js
- * ring buffer). Three heterogeneous shapes share a `type` discriminator; the
- * per-type fields are all optional so a single object covers every kind:
+ * ring buffer). Heterogeneous shapes share a `type` discriminator; the per-type
+ * fields are all optional so a single object covers every kind. Known kinds:
  *   - `mode_change`      — previousMode / newMode
  *   - `whitelist_change` — rules (the new session-rule set)
  *   - `decision`         — requestId / decision (allow|deny) / reason
- * The entry `type` uses `z.enum` (NOT `z.literal`) so the protocol type-coverage
- * lint — which greps `type: z.literal('…')` for server→client message types —
- * does not mistake an audit-entry kind for a wire message type. `.passthrough()`
- * tolerates future audit fields without a schema bump; consumers read defensively.
+ * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
+ *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
+ *      the moment the server adds a new audit kind; clients render unknown kinds
+ *      generically instead. (NOT `z.enum(...).catch(...)` — the repo's #6436 rule:
+ *      `.catch` on a strict-reject field swallows ALL field errors.)
+ *   2. It is not `z.literal`, so the protocol type-coverage lint — which greps
+ *      `type: z.literal('…')` for server→client MESSAGE types — does not mistake
+ *      an audit-entry kind for a wire message type.
+ * `.passthrough()` tolerates future audit fields without a schema bump; consumers
+ * read defensively.
  */
 export declare const ServerPermissionAuditEntrySchema: z.ZodObject<{
-    type: z.ZodEnum<{
-        decision: "decision";
-        mode_change: "mode_change";
-        whitelist_change: "whitelist_change";
-    }>;
+    type: z.ZodString;
     clientId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     sessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     timestamp: z.ZodNumber;
@@ -249,11 +251,7 @@ export declare const ServerPermissionAuditEntrySchema: z.ZodObject<{
 export declare const ServerPermissionAuditResultSchema: z.ZodObject<{
     type: z.ZodLiteral<"permission_audit_result">;
     entries: z.ZodArray<z.ZodObject<{
-        type: z.ZodEnum<{
-            decision: "decision";
-            mode_change: "mode_change";
-            whitelist_change: "whitelist_change";
-        }>;
+        type: z.ZodString;
         clientId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         sessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         timestamp: z.ZodNumber;

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -208,6 +208,67 @@ export declare const ServerPermissionInputSchema: z.ZodDiscriminatedUnion<[z.Zod
     }, z.core.$strip>;
 }, z.core.$strip>], "found">;
 /**
+ * #6772 — one entry in the server's permission audit trail (permission-audit.js
+ * ring buffer). Three heterogeneous shapes share a `type` discriminator; the
+ * per-type fields are all optional so a single object covers every kind:
+ *   - `mode_change`      — previousMode / newMode
+ *   - `whitelist_change` — rules (the new session-rule set)
+ *   - `decision`         — requestId / decision (allow|deny) / reason
+ * The entry `type` uses `z.enum` (NOT `z.literal`) so the protocol type-coverage
+ * lint — which greps `type: z.literal('…')` for server→client message types —
+ * does not mistake an audit-entry kind for a wire message type. `.passthrough()`
+ * tolerates future audit fields without a schema bump; consumers read defensively.
+ */
+export declare const ServerPermissionAuditEntrySchema: z.ZodObject<{
+    type: z.ZodEnum<{
+        decision: "decision";
+        mode_change: "mode_change";
+        whitelist_change: "whitelist_change";
+    }>;
+    clientId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    sessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    timestamp: z.ZodNumber;
+    previousMode: z.ZodOptional<z.ZodString>;
+    newMode: z.ZodOptional<z.ZodString>;
+    rules: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        tool: z.ZodString;
+        decision: z.ZodString;
+    }, z.core.$loose>>>;
+    requestId: z.ZodOptional<z.ZodString>;
+    decision: z.ZodOptional<z.ZodString>;
+    reason: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+/**
+ * #6772 — reply to a `query_permission_audit` pull: the recent permission audit
+ * entries (mode changes, session-rule changes, allow/deny decisions) matching
+ * the query's optional sessionId / auditType / since / limit filters. First
+ * client caller is the dashboard's per-session "Permission history" view;
+ * dashboard-only for v1 (the mobile app's PermissionHistory screen derives its
+ * summary from the live chat transcript, not this wire query).
+ */
+export declare const ServerPermissionAuditResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"permission_audit_result">;
+    entries: z.ZodArray<z.ZodObject<{
+        type: z.ZodEnum<{
+            decision: "decision";
+            mode_change: "mode_change";
+            whitelist_change: "whitelist_change";
+        }>;
+        clientId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        sessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        timestamp: z.ZodNumber;
+        previousMode: z.ZodOptional<z.ZodString>;
+        newMode: z.ZodOptional<z.ZodString>;
+        rules: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            tool: z.ZodString;
+            decision: z.ZodString;
+        }, z.core.$loose>>>;
+        requestId: z.ZodOptional<z.ZodString>;
+        decision: z.ZodOptional<z.ZodString>;
+        reason: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>>;
+}, z.core.$strip>;
+/**
  * Single validated builder for the `permission_request` wire message (#6031).
  *
  * `permission_request` is the most security-relevant message on the wire — a

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -307,19 +307,25 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
 ]);
 /**
  * #6772 — one entry in the server's permission audit trail (permission-audit.js
- * ring buffer). Three heterogeneous shapes share a `type` discriminator; the
- * per-type fields are all optional so a single object covers every kind:
+ * ring buffer). Heterogeneous shapes share a `type` discriminator; the per-type
+ * fields are all optional so a single object covers every kind. Known kinds:
  *   - `mode_change`      — previousMode / newMode
  *   - `whitelist_change` — rules (the new session-rule set)
  *   - `decision`         — requestId / decision (allow|deny) / reason
- * The entry `type` uses `z.enum` (NOT `z.literal`) so the protocol type-coverage
- * lint — which greps `type: z.literal('…')` for server→client message types —
- * does not mistake an audit-entry kind for a wire message type. `.passthrough()`
- * tolerates future audit fields without a schema bump; consumers read defensively.
+ * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
+ *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
+ *      the moment the server adds a new audit kind; clients render unknown kinds
+ *      generically instead. (NOT `z.enum(...).catch(...)` — the repo's #6436 rule:
+ *      `.catch` on a strict-reject field swallows ALL field errors.)
+ *   2. It is not `z.literal`, so the protocol type-coverage lint — which greps
+ *      `type: z.literal('…')` for server→client MESSAGE types — does not mistake
+ *      an audit-entry kind for a wire message type.
+ * `.passthrough()` tolerates future audit fields without a schema bump; consumers
+ * read defensively.
  */
 export const ServerPermissionAuditEntrySchema = z
     .object({
-    type: z.enum(['mode_change', 'whitelist_change', 'decision']),
+    type: z.string(),
     clientId: z.string().nullable().optional(),
     sessionId: z.string().nullable().optional(),
     timestamp: z.number(),

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -306,6 +306,47 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
     }),
 ]);
 /**
+ * #6772 — one entry in the server's permission audit trail (permission-audit.js
+ * ring buffer). Three heterogeneous shapes share a `type` discriminator; the
+ * per-type fields are all optional so a single object covers every kind:
+ *   - `mode_change`      — previousMode / newMode
+ *   - `whitelist_change` — rules (the new session-rule set)
+ *   - `decision`         — requestId / decision (allow|deny) / reason
+ * The entry `type` uses `z.enum` (NOT `z.literal`) so the protocol type-coverage
+ * lint — which greps `type: z.literal('…')` for server→client message types —
+ * does not mistake an audit-entry kind for a wire message type. `.passthrough()`
+ * tolerates future audit fields without a schema bump; consumers read defensively.
+ */
+export const ServerPermissionAuditEntrySchema = z
+    .object({
+    type: z.enum(['mode_change', 'whitelist_change', 'decision']),
+    clientId: z.string().nullable().optional(),
+    sessionId: z.string().nullable().optional(),
+    timestamp: z.number(),
+    // mode_change
+    previousMode: z.string().optional(),
+    newMode: z.string().optional(),
+    // whitelist_change
+    rules: z.array(z.object({ tool: z.string(), decision: z.string() }).passthrough()).optional(),
+    // decision
+    requestId: z.string().optional(),
+    decision: z.string().optional(),
+    reason: z.string().optional(),
+})
+    .passthrough();
+/**
+ * #6772 — reply to a `query_permission_audit` pull: the recent permission audit
+ * entries (mode changes, session-rule changes, allow/deny decisions) matching
+ * the query's optional sessionId / auditType / since / limit filters. First
+ * client caller is the dashboard's per-session "Permission history" view;
+ * dashboard-only for v1 (the mobile app's PermissionHistory screen derives its
+ * summary from the live chat transcript, not this wire query).
+ */
+export const ServerPermissionAuditResultSchema = z.object({
+    type: z.literal('permission_audit_result'),
+    entries: z.array(ServerPermissionAuditEntrySchema),
+});
+/**
  * Single validated builder for the `permission_request` wire message (#6031).
  *
  * `permission_request` is the most security-relevant message on the wire — a

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -332,19 +332,25 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
 
 /**
  * #6772 — one entry in the server's permission audit trail (permission-audit.js
- * ring buffer). Three heterogeneous shapes share a `type` discriminator; the
- * per-type fields are all optional so a single object covers every kind:
+ * ring buffer). Heterogeneous shapes share a `type` discriminator; the per-type
+ * fields are all optional so a single object covers every kind. Known kinds:
  *   - `mode_change`      — previousMode / newMode
  *   - `whitelist_change` — rules (the new session-rule set)
  *   - `decision`         — requestId / decision (allow|deny) / reason
- * The entry `type` uses `z.enum` (NOT `z.literal`) so the protocol type-coverage
- * lint — which greps `type: z.literal('…')` for server→client message types —
- * does not mistake an audit-entry kind for a wire message type. `.passthrough()`
- * tolerates future audit fields without a schema bump; consumers read defensively.
+ * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
+ *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
+ *      the moment the server adds a new audit kind; clients render unknown kinds
+ *      generically instead. (NOT `z.enum(...).catch(...)` — the repo's #6436 rule:
+ *      `.catch` on a strict-reject field swallows ALL field errors.)
+ *   2. It is not `z.literal`, so the protocol type-coverage lint — which greps
+ *      `type: z.literal('…')` for server→client MESSAGE types — does not mistake
+ *      an audit-entry kind for a wire message type.
+ * `.passthrough()` tolerates future audit fields without a schema bump; consumers
+ * read defensively.
  */
 export const ServerPermissionAuditEntrySchema = z
   .object({
-    type: z.enum(['mode_change', 'whitelist_change', 'decision']),
+    type: z.string(),
     clientId: z.string().nullable().optional(),
     sessionId: z.string().nullable().optional(),
     timestamp: z.number(),

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -331,6 +331,49 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
 ])
 
 /**
+ * #6772 — one entry in the server's permission audit trail (permission-audit.js
+ * ring buffer). Three heterogeneous shapes share a `type` discriminator; the
+ * per-type fields are all optional so a single object covers every kind:
+ *   - `mode_change`      — previousMode / newMode
+ *   - `whitelist_change` — rules (the new session-rule set)
+ *   - `decision`         — requestId / decision (allow|deny) / reason
+ * The entry `type` uses `z.enum` (NOT `z.literal`) so the protocol type-coverage
+ * lint — which greps `type: z.literal('…')` for server→client message types —
+ * does not mistake an audit-entry kind for a wire message type. `.passthrough()`
+ * tolerates future audit fields without a schema bump; consumers read defensively.
+ */
+export const ServerPermissionAuditEntrySchema = z
+  .object({
+    type: z.enum(['mode_change', 'whitelist_change', 'decision']),
+    clientId: z.string().nullable().optional(),
+    sessionId: z.string().nullable().optional(),
+    timestamp: z.number(),
+    // mode_change
+    previousMode: z.string().optional(),
+    newMode: z.string().optional(),
+    // whitelist_change
+    rules: z.array(z.object({ tool: z.string(), decision: z.string() }).passthrough()).optional(),
+    // decision
+    requestId: z.string().optional(),
+    decision: z.string().optional(),
+    reason: z.string().optional(),
+  })
+  .passthrough()
+
+/**
+ * #6772 — reply to a `query_permission_audit` pull: the recent permission audit
+ * entries (mode changes, session-rule changes, allow/deny decisions) matching
+ * the query's optional sessionId / auditType / since / limit filters. First
+ * client caller is the dashboard's per-session "Permission history" view;
+ * dashboard-only for v1 (the mobile app's PermissionHistory screen derives its
+ * summary from the live chat transcript, not this wire query).
+ */
+export const ServerPermissionAuditResultSchema = z.object({
+  type: z.literal('permission_audit_result'),
+  entries: z.array(ServerPermissionAuditEntrySchema),
+})
+
+/**
  * Single validated builder for the `permission_request` wire message (#6031).
  *
  * `permission_request` is the most security-relevant message on the wire — a

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -159,6 +159,7 @@ const PLATFORM_SPECIFIC = {
   // fast-follow per epic #5159), so they are BOTH-CLIENTS and the coverage test
   // passes because each handler has a `case 'activity_snapshot'/'activity_delta':`.
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
+  'permission_audit_result': 'dashboard', // #6772 reply to query_permission_audit — the dashboard SettingsPanel "Permission history" view is the first (and only, for v1) client caller; the mobile PermissionHistory screen derives its summary from the live chat transcript, not this wire query, so mobile parity is a fast-follow
   // 'permission_input' removed from PLATFORM_SPECIFIC — the mobile app now
   // handles it too (#6543 PR-4, the pre-write-diff mobile parity fast-follow),
   // so it is BOTH-CLIENTS. Coverage passes because the dashboard has a

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -813,6 +813,48 @@ export class CodexAppServerSession extends BaseSession {
     return this._permissions.respondToQuestion(text, answers)
   }
 
+  // #6829 — permission-rule accessors, mirroring SdkSession/ByokSession. Codex's
+  // PermissionManager already owns a rule store (seeded per-cwd in the ctor), but
+  // without these thin wrappers a codex session's rules were invisible on the
+  // wire: the `permission_rules_updated` broadcast (settings-handlers.js) and the
+  // ws-history reconnect replay (ws-history.js) both gate on `getPermissionRules`
+  // / `getPersistentPermissionRules`, and the projectRules re-seed calls
+  // `setPersistentPermissionRules` — so on codex an allowAlways persisted at the
+  // enforcement layer but never broadcast, replayed, or re-seeded. Session-rule
+  // MUTATION (`setPermissionRules`) is intentionally NOT exposed so codex keeps
+  // advertising `sessionRules:false` in the provider picker (providers.js derives
+  // the capability from `setPermissionRules` presence); only the durable
+  // project-rule read/replay surface is wired.
+
+  /** Current session-scoped permission rules. Delegates to PermissionManager. */
+  getPermissionRules() {
+    if (typeof this._permissions.getRules === 'function') {
+      return this._permissions.getRules()
+    }
+    return []
+  }
+
+  /**
+   * #6771/#6829 — durable (project-scoped) permission rules applied to this
+   * session, tagged `persist:'project'`. Delegates to PermissionManager.
+   */
+  getPersistentPermissionRules() {
+    if (typeof this._permissions.getPersistentRules === 'function') {
+      return this._permissions.getPersistentRules()
+    }
+    return []
+  }
+
+  /**
+   * #6771/#6829 — re-seed this session's in-memory durable rule set (no persist;
+   * the caller owns the store write). Delegates to PermissionManager.
+   */
+  setPersistentPermissionRules(rules) {
+    if (typeof this._permissions.setPersistentRules === 'function') {
+      this._permissions.setPersistentRules(rules)
+    }
+  }
+
   // A permission prompt can outlast the result timeout while it waits on a human;
   // pause the timer on request, re-arm it once the decision lands (#3920 pattern).
   _pauseResultTimeoutForPermission() { this._clearResultTimeout() }

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -554,6 +554,20 @@ function handlePermissionResponse(ws, client, msg, ctx) {
 }
 
 function handleQueryPermissionAudit(ws, client, msg, ctx) {
+  // #6837 — same authority principle as the adjacent handleGetPermissionInput: a
+  // pairing-bound (share-a-session) token is scoped to ITS OWN session. Without
+  // this gate a bound client could read another session's decision history, or
+  // omit sessionId entirely and pull the GLOBAL cross-session audit log. Bound
+  // clients must name their own boundSessionId explicitly; the global query is
+  // host-authority (unbound / primary token) only.
+  if (client.boundSessionId && msg.sessionId !== client.boundSessionId) {
+    loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to query permission audit for ${msg.sessionId || 'ALL sessions'} — rejected`)
+    sendError(ws, msg?.requestId, 'PERMISSION_AUDIT_FORBIDDEN_BOUND_CLIENT',
+      "Pairing-issued session tokens can only query their own session's permission audit.",
+      undefined, ctx)
+    return
+  }
+
   if (ctx.permissions.permissionAudit) {
     const entries = ctx.permissions.permissionAudit.query({
       sessionId: msg.sessionId,
@@ -771,21 +785,50 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
   const entry = resolveSessionOrError(ws, ctx, msg, client)
   if (!entry) return
 
-  if (!requireSessionMethod(ws, ctx, entry, 'setPermissionRules', 'This provider does not support permission rules')) {
-    return
+  // #6829 — the two halves have DIFFERENT capability gates. Session rules need
+  // the session-rule setter (`setPermissionRules` — absent on codex by design,
+  // so it keeps advertising sessionRules:false). Durable project rules need only
+  // the persistent re-seed setter (`setPersistentPermissionRules` — which codex
+  // HAS since #6829). Gating the whole handler on `setPermissionRules` made the
+  // projectRules remove/clear path dead on codex: durable rules could be CREATED
+  // (allowAlways resolves inside the PermissionManager, no handler involved) but
+  // never removed from any client.
+  const supportsSessionRules = typeof entry.session?.setPermissionRules === 'function'
+
+  if (projectRules === undefined) {
+    // Session-rules-only request — unchanged legacy gate: providers without the
+    // session-rule setter (codex, cli, tui, gemini) are rejected.
+    if (!requireSessionMethod(ws, ctx, entry, 'setPermissionRules', 'This provider does not support permission rules')) {
+      return
+    }
+  } else {
+    // projectRules present — the durable half needs the persistent setter (all
+    // in-process-permission providers: sdk / byok / codex). Providers with no
+    // PermissionManager at all stay rejected, as before.
+    if (!requireSessionMethod(ws, ctx, entry, 'setPersistentPermissionRules', 'This provider does not support persistent permission rules')) {
+      return
+    }
+    // A NON-EMPTY session-rule set aimed at a provider without the session-rule
+    // setter must fail loudly, not be silently dropped. The rules:[] echo the
+    // clients send alongside a project-rule removal is a no-op and passes.
+    if (!supportsSessionRules && rules.length > 0) {
+      sendSessionError(ws, ctx, 'This provider does not support session permission rules')
+      return
+    }
   }
 
-  entry.session.setPermissionRules(rules)
+  if (supportsSessionRules) {
+    entry.session.setPermissionRules(rules)
+  }
 
   // #6771 — apply the durable project-rule replacement (if any) to the store,
   // then re-seed THIS session's in-memory persistent set so it takes effect
-  // immediately. The store is keyed by the session's cwd.
+  // immediately. The store is keyed by the session's cwd. (The persistent-setter
+  // gate above already guaranteed the method exists on this path.)
   const ruleStore = ctx.sessions.sessionManager?.permissionRuleStore
   if (projectRules !== undefined && ruleStore && typeof ruleStore.setRules === 'function') {
     const stored = ruleStore.setRules(entry.session.cwd, projectRules)
-    if (typeof entry.session.setPersistentPermissionRules === 'function') {
-      entry.session.setPersistentPermissionRules(stored)
-    }
+    entry.session.setPersistentPermissionRules(stored)
   }
 
   // Audit the whitelist change

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -352,6 +352,7 @@ function _isSecureRequest(req) {
  *   { type: 'model_changed', model: '...' }          — active model updated
  *   { type: 'available_models', models: [...], provider?, defaultModel? } — models the active provider accepts
  *   { type: 'permission_input', requestId, found, tool?, input?, error? } — #6543 (IDE P3 feature B) reply to a `get_permission_input` pull: the FULL secret-redacted tool input for a pending permission (the `permission_request` broadcast truncates `input` at ~10K), so a client can build a per-hunk pre-write diff. `found:false` (+ `error`) when the request is unknown / already resolved / owned by another session — the handler is session-bound (a client only gets input for a permission its session owns).
+ *   { type: 'permission_audit_result', entries } — #6772 reply to a `query_permission_audit` pull: recent permission audit entries (mode changes / session-rule changes / allow-deny decisions) matching the query's optional sessionId/auditType/since/limit. Consumed by the dashboard's per-session "Permission history" view.
  *   { type: 'permission_request', requestId, tool, description, input, remainingMs } — permission prompt
  *   { type: 'confirm_permission_mode', mode, warning } — server challenges auto mode (client must re-send with confirmed: true)
  *   { type: 'permission_mode_changed', mode: '...' } — permission mode updated

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -981,3 +981,70 @@ describe('usage mapping (#6692)', () => {
     cleanup()
   })
 })
+
+// #6829 — the permission-rule accessors that #6826 gave SdkSession/ByokSession
+// but left off CodexAppServerSession, so a codex session's rules never broadcast
+// (permission_rules_updated) or replayed on reconnect (ws-history gates on the
+// getters). Mirrors the SdkSession seeding test in
+// settings-handlers-permission-rules.test.js.
+describe('CodexAppServerSession — permission rule accessors (#6829)', () => {
+  it('getPermissionRules / getPersistentPermissionRules / setPersistentPermissionRules delegate to the PermissionManager', () => {
+    const { s, cleanup } = mkSession()
+    try {
+      // Session rules — codex keeps setPermissionRules OFF (sessionRules:false in
+      // the picker), so seed the manager directly to prove the getter delegates.
+      s._permissions.setRules([{ tool: 'Read', decision: 'allow' }])
+      assert.deepEqual(s.getPermissionRules(), [{ tool: 'Read', decision: 'allow' }])
+
+      // Persistent (project) rules — the setter re-seeds the in-memory set, the
+      // getter tags each `persist:'project'` (the shape the wire broadcast carries).
+      s.setPersistentPermissionRules([{ tool: 'Write', decision: 'allow' }])
+      assert.deepEqual(s.getPersistentPermissionRules(), [
+        { tool: 'Write', decision: 'allow', persist: 'project' },
+      ])
+    } finally {
+      s.destroy()
+      cleanup()
+    }
+  })
+
+  it('seeds persistent rules from the injected rule store for its cwd', async () => {
+    const { PermissionRuleStore } = await import('../src/permission-rule-store.js')
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-codex-seed-'))
+    try {
+      const store = new PermissionRuleStore({
+        filePath: join(dir, 'permission-rules.json'),
+        logger: { info() {}, warn() {}, error() {} },
+      })
+      store.addRule('/proj/codex-seed', { tool: 'apply_patch', decision: 'allow' })
+
+      const { s, cleanup } = mkSession({ cwd: '/proj/codex-seed', permissionRuleStore: store })
+      assert.deepEqual(s.getPersistentPermissionRules(), [
+        { tool: 'apply_patch', decision: 'allow', persist: 'project' },
+      ])
+      s.destroy()
+      cleanup()
+
+      // A codex session in a DIFFERENT cwd does not inherit the rule.
+      const other = mkSession({ cwd: '/proj/other', permissionRuleStore: store })
+      assert.deepEqual(other.s.getPersistentPermissionRules(), [])
+      other.s.destroy()
+      other.cleanup()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('getPermissionRules / getPersistentPermissionRules return [] when the delegate is absent', () => {
+    const { s, cleanup } = mkSession()
+    try {
+      delete s._permissions.getRules
+      delete s._permissions.getPersistentRules
+      assert.deepEqual(s.getPermissionRules(), [])
+      assert.deepEqual(s.getPersistentPermissionRules(), [])
+    } finally {
+      s.destroy()
+      cleanup()
+    }
+  })
+})

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -531,6 +531,57 @@ describe('settings-handlers', () => {
       assert.equal(ctx._sent[0].entries.length, 1)
     })
 
+    // #6837 — a pairing-bound (share-a-session) token is scoped to its OWN
+    // session's audit trail: cross-session and global (omit-sessionId) queries
+    // are rejected. Mirrors the authority gate on the adjacent
+    // handleGetPermissionInput / handleSetPermissionRules.
+    it('rejects a bound client querying ANOTHER session\'s audit', () => {
+      const ctx = makeCtx()
+      ctx.permissions.permissionAudit = { query: createSpy(() => [{ id: 1 }]) }
+      const client = makeClient({ boundSessionId: 's-own' })
+
+      settingsHandlers.query_permission_audit(makeWs(), client, { sessionId: 's-other' }, ctx)
+
+      assert.equal(ctx.permissions.permissionAudit.query.calls.length, 0, 'audit log never queried')
+      assert.equal(ctx._sent[0].type, 'error')
+      assert.equal(ctx._sent[0].code, 'PERMISSION_AUDIT_FORBIDDEN_BOUND_CLIENT')
+      assert.ok(!ctx._sent.some((m) => m.type === 'permission_audit_result'), 'no audit result leaked')
+    })
+
+    it('rejects a bound client\'s GLOBAL query (sessionId omitted)', () => {
+      const ctx = makeCtx()
+      ctx.permissions.permissionAudit = { query: createSpy(() => [{ id: 1 }]) }
+      const client = makeClient({ boundSessionId: 's-own' })
+
+      settingsHandlers.query_permission_audit(makeWs(), client, {}, ctx)
+
+      assert.equal(ctx.permissions.permissionAudit.query.calls.length, 0, 'audit log never queried')
+      assert.equal(ctx._sent[0].type, 'error')
+      assert.equal(ctx._sent[0].code, 'PERMISSION_AUDIT_FORBIDDEN_BOUND_CLIENT')
+    })
+
+    it('allows a bound client to query its OWN session\'s audit', () => {
+      const ctx = makeCtx()
+      ctx.permissions.permissionAudit = { query: createSpy(() => [{ id: 1 }]) }
+      const client = makeClient({ boundSessionId: 's-own' })
+
+      settingsHandlers.query_permission_audit(makeWs(), client, { sessionId: 's-own' }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'permission_audit_result')
+      assert.equal(ctx._sent[0].entries.length, 1)
+    })
+
+    it('leaves an unbound (primary) client unrestricted — global and cross-session queries work', () => {
+      const ctx = makeCtx()
+      ctx.permissions.permissionAudit = { query: createSpy(() => [{ id: 1 }]) }
+
+      settingsHandlers.query_permission_audit(makeWs(), makeClient(), {}, ctx)
+      settingsHandlers.query_permission_audit(makeWs(), makeClient(), { sessionId: 'any-session' }, ctx)
+
+      assert.equal(ctx._sent.length, 2)
+      assert.ok(ctx._sent.every((m) => m.type === 'permission_audit_result'))
+    })
+
     // #6772 — the dashboard "Permission history" view queries this API scoped to
     // the active session. Prove the existing API genuinely serves a per-session
     // query end-to-end through the handler with a REAL audit log (no server change

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
+import { PermissionAuditLog } from '../../src/permission-audit.js'
 import { registerProvider } from '../../src/providers.js'
 import { addLogListener, removeLogListener } from '../../src/logger.js'
 import { createSpy, createMockSession, nsCtx } from '../test-helpers.js'
@@ -528,6 +529,26 @@ describe('settings-handlers', () => {
 
       assert.equal(ctx._sent[0].type, 'permission_audit_result')
       assert.equal(ctx._sent[0].entries.length, 1)
+    })
+
+    // #6772 — the dashboard "Permission history" view queries this API scoped to
+    // the active session. Prove the existing API genuinely serves a per-session
+    // query end-to-end through the handler with a REAL audit log (no server change
+    // was needed — the ring buffer already filters by sessionId).
+    it('filters entries by sessionId with a real PermissionAuditLog', () => {
+      const audit = new PermissionAuditLog()
+      audit.logDecision({ clientId: 'c', sessionId: 's1', requestId: 'r1', decision: 'allow' })
+      audit.logModeChange({ clientId: 'c', sessionId: 's2', previousMode: 'approve', newMode: 'auto' })
+      audit.logDecision({ clientId: 'c', sessionId: 's1', requestId: 'r2', decision: 'deny', reason: 'timeout' })
+      const ctx = makeCtx()
+      ctx.permissions.permissionAudit = audit
+
+      settingsHandlers.query_permission_audit(makeWs(), makeClient(), { sessionId: 's1' }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'permission_audit_result')
+      assert.equal(ctx._sent[0].entries.length, 2)
+      assert.ok(ctx._sent[0].entries.every((e) => e.sessionId === 's1'))
+      assert.deepEqual(ctx._sent[0].entries.map((e) => e.decision), ['allow', 'deny'])
     })
   })
 

--- a/packages/server/tests/settings-handlers-permission-rules.test.js
+++ b/packages/server/tests/settings-handlers-permission-rules.test.js
@@ -203,6 +203,99 @@ describe('handleSetPermissionRules — projectRules (#6771)', () => {
   })
 })
 
+// #6829 (PR #6836 review) — the projectRules half must be applicable on a
+// CODEX-shaped session: one WITH the persistent setter/getters but WITHOUT
+// `setPermissionRules` (deliberately absent so codex advertises
+// sessionRules:false). The old handler gated the WHOLE request on
+// `setPermissionRules`, making durable-rule remove/clear dead on codex.
+describe('handleSetPermissionRules — codex-shaped session (persistent setter, no session-rule setter) (#6829)', () => {
+  let ctx, client, session, store, dir
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sh-codex-rules-'))
+    store = new PermissionRuleStore({ filePath: join(dir, 'permission-rules.json'), logger: { info() {}, warn() {}, error() {} } })
+    let _persistent = []
+    // NO setPermissionRules — the codex capability shape.
+    session = {
+      isReady: true,
+      cwd: '/proj/codex',
+      permissionMode: 'approve',
+      getPermissionRules: mock.fn(() => []),
+      setPersistentPermissionRules: mock.fn((r) => { _persistent = r.slice() }),
+      getPersistentPermissionRules: mock.fn(() => _persistent.map((r) => ({ ...r, persist: 'project' }))),
+    }
+    const entry = { session, cwd: '/proj/codex', name: 'codex-test' }
+    ctx = makeCtx(entry, {
+      sessionManager: {
+        getSession: (id) => (id === 'sess-1' ? entry : null),
+        permissionRuleStore: store,
+      },
+    })
+    client = makeClient()
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('removing a persistent rule succeeds (store updated + re-seeded) and broadcasts persistentRules', () => {
+    store.setRules('/proj/codex', [{ tool: 'apply_patch', decision: 'allow' }, { tool: 'Read', decision: 'allow' }])
+
+    handler(WS, client, { type: 'set_permission_rules', rules: [], projectRules: [{ tool: 'Read', decision: 'allow' }] }, ctx)
+
+    // No rejection.
+    assert.equal(ctx.transport.send.mock.callCount(), 0, 'no error frame')
+    // Store reduced + session re-seeded.
+    assert.deepEqual(store.getRules('/proj/codex'), [{ tool: 'Read', decision: 'allow' }])
+    assert.equal(session.setPersistentPermissionRules.mock.callCount(), 1)
+    // Broadcast carries the updated persistentRules (the codex getters from #6829).
+    const [sid, msg] = ctx.transport.broadcastToSession.mock.calls[0].arguments
+    assert.equal(sid, 'sess-1')
+    assert.equal(msg.type, 'permission_rules_updated')
+    assert.deepEqual(msg.persistentRules, [{ tool: 'Read', decision: 'allow', persist: 'project' }])
+  })
+
+  it('clearing all persistent rules (projectRules: []) succeeds', () => {
+    store.setRules('/proj/codex', [{ tool: 'Write', decision: 'allow' }])
+    handler(WS, client, { type: 'set_permission_rules', rules: [], projectRules: [] }, ctx)
+    assert.equal(ctx.transport.send.mock.callCount(), 0, 'no error frame')
+    assert.deepEqual(store.getRules('/proj/codex'), [])
+  })
+
+  it('a session-rules-only request is still rejected (no setPermissionRules)', () => {
+    handler(WS, client, { type: 'set_permission_rules', rules: [{ tool: 'Read', decision: 'allow' }] }, ctx)
+    const errMsg = ctx.transport.send.mock.calls[0]?.arguments[1]
+    assert.equal(errMsg?.type, 'session_error')
+    assert.match(errMsg?.message ?? '', /does not support permission rules/)
+    assert.equal(ctx.transport.broadcastToSession.mock.callCount(), 0, 'no broadcast')
+  })
+
+  it('a NON-EMPTY session-rule set alongside projectRules is rejected loudly, not silently dropped', () => {
+    handler(WS, client, {
+      type: 'set_permission_rules',
+      rules: [{ tool: 'Read', decision: 'allow' }],
+      projectRules: [{ tool: 'Write', decision: 'allow' }],
+    }, ctx)
+    const errMsg = ctx.transport.send.mock.calls[0]?.arguments[1]
+    assert.equal(errMsg?.type, 'session_error')
+    assert.match(errMsg?.message ?? '', /session permission rules/)
+    assert.deepEqual(store.getRules('/proj/codex'), [], 'nothing persisted')
+  })
+
+  it('a projectRules request on a session WITHOUT the persistent setter is rejected', () => {
+    const bare = { isReady: true, cwd: '/proj/cli', permissionMode: 'approve' }
+    const entry = { session: bare, cwd: '/proj/cli', name: 'cli-test' }
+    const cliCtx = makeCtx(entry, {
+      sessionManager: { getSession: (id) => (id === 'sess-1' ? entry : null), permissionRuleStore: store },
+    })
+    handler(WS, makeClient(), { type: 'set_permission_rules', rules: [], projectRules: [{ tool: 'Write', decision: 'allow' }] }, cliCtx)
+    const errMsg = cliCtx.transport.send.mock.calls[0]?.arguments[1]
+    assert.equal(errMsg?.type, 'session_error')
+    assert.match(errMsg?.message ?? '', /persistent permission rules/)
+    assert.deepEqual(store.getRules('/proj/cli'), [], 'nothing persisted')
+  })
+})
+
 describe('rule-eligibility sets share ONE source of truth (#6605/#6613)', () => {
   it('settings-handlers re-exports the SAME sets as permission-manager (no drift)', () => {
     // A duplicate hard-coded copy here silently drifted from permission-manager's

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -192,6 +192,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'evaluator_clarify',          // auto-evaluator clarify banner (#3188) — dashboard-only
   'evaluator_rewrite',          // auto-evaluator rewrite banner (#3188) — dashboard-only
   'host_status_snapshot',       // Control Room Host/Repo Status (#5170) — dashboard-only for v1
+  'permission_audit_result',    // #6772 query_permission_audit reply — dashboard SettingsPanel "Permission history"; first client caller, dashboard-only for v1 (mobile PermissionHistory reads the chat transcript, not this wire query)
   // permission_input removed — the mobile app now handles it too (#6543 PR-4,
   // the pre-write-diff mobile parity fast-follow), so it is no longer
   // dashboard-only. Both clients dispatch it into `permissionInputs[requestId]`.


### PR DESCRIPTION
## Problem

Two desktop-parity gaps in the permission-rules surface:

- **#6772** — the dashboard could *create* a per-session auto-approval rule ("Allow for Session") but had no way to **view or remove** what rules are active, and the server's full **permission audit trail** (mode changes, rule changes, allow/deny decisions) — queryable over the wire — was never queried by *any* client.
- **#6829** (follow-up from #6826) — durable "always allow (this project)" rules can be created from the dashboard but only **mobile** could view/remove them. Separately, `CodexAppServerSession` lacked the persistent-rule getters, so on a codex session an `allowAlways` persisted at the enforcement layer but never **broadcast** (`permission_rules_updated`) or **replayed** on reconnect (`ws-history` gates on the getter).

## What this does

### Dashboard — Session Rules viewer (`SettingsPanel`)
- New **"Session rules"** section lists the active session's **session-scoped** and **durable per-project** rules, distinguished by a scope badge (and the project path for persistent grants), with **per-rule remove** + **clear-all** for each scope. Mirrors mobile's `SettingsScreen` capabilities via the existing `set_permission_rules` / `projectRules` wire path.
- New store actions `setPermissionRules` / `setProjectPermissionRules` (project removals re-send the current session rules so the single server handler doesn't clobber them; the client-only `persist` marker is stripped).

### Dashboard — Permission history (`SettingsPanel`)
- New **"Permission history"** section: read-only, pull-on-demand view of the server's audit trail for the active session — the **first client caller** of the existing `query_permission_audit` API. New `queryPermissionAudit` action + `handlePermissionAuditResult` receipt handler.

### Protocol
- Declared `permission_audit_result` as a proper server→client schema (`ServerPermissionAuditResultSchema`) so a client can consume the reply without manual parsing. Added to the ws-server doc roster + both coverage allowlists (dashboard-only for v1; the mobile PermissionHistory screen derives its summary from the chat transcript, not this wire query).

### Server — codex rule getters (#6829)
- `CodexAppServerSession` gains `getPermissionRules` / `getPersistentPermissionRules` / `setPersistentPermissionRules` (mirroring `SdkSession`/`ByokSession`) so codex persistent rules **broadcast** and **replay**. Session-rule *mutation* (`setPermissionRules`) is intentionally **not** exposed, so codex keeps advertising `sessionRules:false` in the picker (matching the deliberate `providers.test.js` assertion).

### Audit API finding
The server already serves a per-session query (`PermissionAuditLog.query({ sessionId })` + `handleQueryPermissionAudit`). **No server audit-query change was needed** — only the client-facing schema. Added a real-`PermissionAuditLog` per-session filter test through the handler as concrete evidence.

## Tests
- **Server:** codex rule-accessor + store-seeding tests (`codex-app-server-session.test.js`); real-`PermissionAuditLog` per-session filter through the handler (`settings-handlers.test.js`).
- **Dashboard:** component tests (session/project scope labels, remove + clear-all wire messages, audit list render, provider-gating) in `SettingsPanel.test.tsx`; store-action + receipt-handler wire tests in `store.test.ts`.
- Green: dashboard vitest (261 files / 4493) + tsc; protocol (362); store-core (1998, incl. both coverage lints); targeted server permission suites (613) + all 5 `lint-*.sh`.

Closes #6772
Closes #6829

## Review fixes (9db247f)

- **projectRules independent of the session-rule capability** — `handleSetPermissionRules` no longer gates the whole request on `setPermissionRules`; requests carrying `projectRules` are gated on `setPersistentPermissionRules` instead, so codex durable-rule remove/clear actually works. A non-empty session-rule set on a provider without the session setter is rejected loudly.
- **Audit query authority gate (#6837)** — a pairing-bound token may only query its own session's audit; cross-session and global (omit-sessionId) queries are rejected with `PERMISSION_AUDIT_FORBIDDEN_BOUND_CLIENT`, mirroring `handleGetPermissionInput`.
- **Stale history cleared on session switch** — `switchSession` resets `permissionAudit`/`permissionAuditLoading` so the Permission history view never shows another session's entries.

Closes #6837
