### PR TITLE
fix(server): replay mcp_servers snapshot to late subscribers (#6832)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -400,6 +400,22 @@ export class BaseSession extends EventEmitter {
       emit: (event, payload) => this.emit(event, payload),
     })
     this._setupActivityRegistry()
+    // #6832: `mcp_servers` is a transient event (sdk/cli parse it off the live
+    // stream-json `system/init`; claude-tui re-derives the CONFIGURED list on
+    // warmup/respawn — see claude-tui-session.js `_emitConfiguredMcpServers`,
+    // #6820/#6831) — forwarded to currently-connected clients but never
+    // recorded in history. A client that subscribes to an already-warmed
+    // session (dashboard reconnect, second client joining a shared session)
+    // never received the list until the NEXT emission. Cache the last payload
+    // here — self-listening on the session's own emit, so every provider that
+    // emits `mcp_servers` through `this.emit(...)` feeds this for free, same
+    // as `_setupActivityRegistry` above — and expose it via
+    // `getMcpServersSnapshot()` so `ws-history.sendSessionInfo`'s snapshot-on-
+    // subscribe can replay it, mirroring the `activity_snapshot` /
+    // `permission_rules_updated` late-join pattern. Cleared on full teardown
+    // (see `removeAllListeners` below).
+    this._lastMcpServers = null
+    this.on('mcp_servers', (data) => { this._lastMcpServers = data })
     this._messageCounter = 0
     // Boot-unique prefix mixed into every emitted messageId (#3700).
     // The dashboard caches up to 100 messages per session in localStorage
@@ -850,6 +866,11 @@ export class BaseSession extends EventEmitter {
     // shape with the right argument count.
     if (eventName === undefined) {
       this._activity.clear()
+      // #6832: clear the cached mcp_servers snapshot on full teardown too —
+      // a destroyed session must not replay a stale server list to a client
+      // that later subscribes to a NEW session that happens to reuse the id
+      // (or to any lingering reference to this now-dead session object).
+      this._lastMcpServers = null
       // #5177: stop the background-shell sweep on full teardown too. Most
       // providers (cli/jsonl/gemini/codex) destroy via removeAllListeners()
       // and never call _destroyPendingBackgroundShells, so this is the
@@ -877,6 +898,21 @@ export class BaseSession extends EventEmitter {
    */
   getActivitySnapshot() {
     return this._activity.getSnapshotMessage()
+  }
+
+  /**
+   * #6832: last-known `mcp_servers` payload, wrapped as the wire message
+   * shape (`{ type: 'mcp_servers', servers }`). Served to a fresh subscriber
+   * (snapshot-on-subscribe, via `ws-history.sendSessionInfo`) so a client
+   * that joins an already-warmed session sees the current list without
+   * waiting on the next emission — mirroring `getActivitySnapshot()` above.
+   * Returns `null` when this session has never emitted `mcp_servers` (no
+   * snapshot to replay; nothing to send).
+   * @returns {{type: 'mcp_servers', servers: object[]} | null}
+   */
+  getMcpServersSnapshot() {
+    if (!this._lastMcpServers) return null
+    return { type: 'mcp_servers', servers: this._lastMcpServers.servers }
   }
 
   /**

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2916,6 +2916,12 @@ export class SessionManager extends EventEmitter {
     // activity tree (ActivityRegistry on BaseSession). Transient — not
     // replayed from history; a reconnecting client gets the full tree from
     // the snapshot-on-subscribe in ws-history.sendSessionInfo.
+    // #6832: `mcp_servers` (sdk/cli parse it off the live stream-json
+    // `system/init`; claude-tui re-derives the CONFIGURED list on warmup /
+    // respawn, #6820/#6831) is likewise transient — not recorded in history —
+    // but a reconnecting/late-joining client still gets the current server
+    // list via BaseSession's cached last payload, replayed in
+    // ws-history.sendSessionInfo's snapshot-on-subscribe (getMcpServersSnapshot).
     // #5936: message_queued / message_dequeued mirror the server-authoritative
     // outgoing-message queue (BaseSession `_outgoingQueue`). Transient (like
     // activity_delta) — they are delta events, NOT replayed from history. This

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -985,6 +985,23 @@ export function sendSessionInfo(ctx, ws, sessionId, opts = {}) {
     }
   }
 
+  // #6832: replay the last-known `mcp_servers` list so a client subscribing
+  // to an already-warmed session (dashboard reconnect, second client joining
+  // a shared session) sees the current server list without waiting on the
+  // next emission. `mcp_servers` is a transient event (not recorded in
+  // history) — sdk/cli sessions emit it once at the stream-json `system/init`
+  // and claude-tui re-derives it on warmup/respawn (#6820/#6831), so a late
+  // joiner previously saw "No MCP servers" until the next respawn. The
+  // session caches the last payload (BaseSession `getMcpServersSnapshot()`,
+  // set via a self-listener on `mcp_servers`); null means this session has
+  // never emitted one, so there is nothing to replay.
+  if (typeof session.getMcpServersSnapshot === 'function') {
+    const mcpSnapshot = session.getMcpServersSnapshot()
+    if (mcpSnapshot) {
+      send(ws, { ...mcpSnapshot, sessionId })
+    }
+  }
+
   // #5731 T5 / #5623 / #5613: re-sync the session's primary owner so the
   // presence badge ("Observing" / "Take over" / driver name) doesn't go
   // stale across a reconnect or tab switch. `session_role` is otherwise only

--- a/packages/server/tests/mcp-servers-snapshot.test.js
+++ b/packages/server/tests/mcp-servers-snapshot.test.js
@@ -1,0 +1,191 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { BaseSession } from '../src/base-session.js'
+import { sendSessionInfo } from '../src/ws-history.js'
+// Side-effect: registers built-in providers so getRegistryForProvider() works
+// inside sendSessionInfo (it sends `available_models` keyed on provider).
+import '../src/providers.js'
+import { createSpy } from './test-helpers.js'
+
+/**
+ * #6832 — `mcp_servers` is a transient event (session-manager.js's
+ * `builtinTransient` list): forwarded to currently-connected clients but
+ * never recorded in history and never replayed on reconnect. A client that
+ * subscribes to an already-warmed session (dashboard reconnect, second
+ * client joining a shared session) previously saw "No MCP servers" until the
+ * NEXT emission — for sdk/cli sessions that's once at the stream-json
+ * `system/init` (i.e. never again this boot); for claude-tui (#6820/#6831)
+ * it's the next respawn/resume.
+ *
+ * Fix: BaseSession caches the last-emitted `mcp_servers` payload (a
+ * self-listener wired in the constructor, alongside the existing
+ * `_setupActivityRegistry` pattern) and exposes it via
+ * `getMcpServersSnapshot()`. `ws-history.sendSessionInfo` replays it to a
+ * fresh subscriber, mirroring the `activity_snapshot` /
+ * `permission_rules_updated` snapshot-on-subscribe pattern. The cache is
+ * cleared on full session teardown (`removeAllListeners()`, the same
+ * chokepoint that clears the Control Room ActivityRegistry, #5160).
+ *
+ * Since every emitting provider (CliSession, SdkSession, ClaudeTuiSession)
+ * extends BaseSession and emits via `this.emit('mcp_servers', ...)`, caching
+ * at the BaseSession level covers all of them without touching each
+ * provider's emit call site.
+ */
+
+describe('BaseSession — mcp_servers snapshot cache (#6832)', () => {
+  let skillsDir
+
+  beforeEach(() => {
+    // Pin skillsDir + repoSkillsDir to an empty temp dir so these tests
+    // don't pick up whatever lives in the developer's real ~/.chroxy/skills/.
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-snapshot-skills-'))
+  })
+
+  afterEach(() => {
+    if (skillsDir) rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  function makeSession() {
+    return new BaseSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+  }
+
+  it('returns null before any mcp_servers event has fired', () => {
+    const session = makeSession()
+    assert.equal(session.getMcpServersSnapshot(), null)
+  })
+
+  it('caches the last-emitted payload as an mcp_servers wire message', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+    assert.deepEqual(session.getMcpServersSnapshot(), {
+      type: 'mcp_servers',
+      servers: [{ name: 'fs', status: 'connected' }],
+    })
+  })
+
+  it('updates the snapshot on re-emission (list-replacement, not a merge)', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+    session.emit('mcp_servers', {
+      servers: [{ name: 'gh', status: 'connected' }, { name: 'fs', status: 'error' }],
+    })
+    assert.deepEqual(session.getMcpServersSnapshot(), {
+      type: 'mcp_servers',
+      servers: [{ name: 'gh', status: 'connected' }, { name: 'fs', status: 'error' }],
+    })
+  })
+
+  it('removeAllListeners (destroy chokepoint) clears the cached snapshot', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+    assert.ok(session.getMcpServersSnapshot(), 'sanity: snapshot cached before destroy')
+
+    session.removeAllListeners()
+
+    assert.equal(session.getMcpServersSnapshot(), null)
+  })
+
+  it('targeted removeAllListeners(event) does NOT clear the cached snapshot', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+
+    session.removeAllListeners('some_other_event')
+
+    assert.ok(session.getMcpServersSnapshot(), 'a targeted removeAllListeners must not drain the cache')
+  })
+})
+
+describe('sendSessionInfo — mcp_servers replay on subscribe (#6832)', () => {
+  let skillsDir
+
+  beforeEach(() => {
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-snapshot-ws-skills-'))
+  })
+
+  afterEach(() => {
+    if (skillsDir) rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  function makeSession() {
+    return new BaseSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+  }
+
+  function makeCtx(session) {
+    const sends = []
+    const ctx = {
+      sessionManager: { getSession: () => ({ session, provider: null }) },
+      send: createSpy((ws, msg) => sends.push(msg)),
+    }
+    ctx._sends = sends
+    return ctx
+  }
+
+  function makeFakeWs(readyState = 1) {
+    return { readyState, send: () => {}, close: () => {} }
+  }
+
+  it('replays the cached mcp_servers list to a late subscriber', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+    const ctx = makeCtx(session)
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    const mcpMsg = ctx._sends.find((m) => m.type === 'mcp_servers')
+    assert.ok(mcpMsg, 'mcp_servers was not replayed on subscribe')
+    assert.equal(mcpMsg.sessionId, 'sess-1')
+    assert.deepEqual(mcpMsg.servers, [{ name: 'fs', status: 'connected' }])
+  })
+
+  it('replays the LATEST snapshot after re-emission, not a stale first payload', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+    session.emit('mcp_servers', {
+      servers: [{ name: 'fs', status: 'connected' }, { name: 'gh', status: 'connected' }],
+    })
+    const ctx = makeCtx(session)
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    const mcpMsg = ctx._sends.find((m) => m.type === 'mcp_servers')
+    assert.deepEqual(mcpMsg.servers, [
+      { name: 'fs', status: 'connected' },
+      { name: 'gh', status: 'connected' },
+    ])
+  })
+
+  it('does not send mcp_servers for a session that never emitted one', () => {
+    const session = makeSession()
+    const ctx = makeCtx(session)
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    assert.equal(ctx._sends.find((m) => m.type === 'mcp_servers'), undefined)
+  })
+
+  it('clears the snapshot on destroy — a client subscribing post-destroy gets no replay', () => {
+    const session = makeSession()
+    session.emit('mcp_servers', { servers: [{ name: 'fs', status: 'connected' }] })
+    session.removeAllListeners()
+    const ctx = makeCtx(session)
+
+    sendSessionInfo(ctx, makeFakeWs(), 'sess-1')
+
+    assert.equal(ctx._sends.find((m) => m.type === 'mcp_servers'), undefined)
+  })
+
+  it('does not throw for a legacy/mock session lacking getMcpServersSnapshot', () => {
+    // Defensive: a session type that hasn't grown the method yet (or a
+    // hand-rolled test double) must not crash sendSessionInfo — it simply
+    // skips the mcp_servers replay, same as the getPermissionRules /
+    // getActivitySnapshot guards above it.
+    const session = { isReady: false, model: null, permissionMode: 'approve' }
+    const ctx = makeCtx(session)
+
+    assert.doesNotThrow(() => sendSessionInfo(ctx, makeFakeWs(), 'sess-1'))
+    assert.equal(ctx._sends.find((m) => m.type === 'mcp_servers'), undefined)
+  })
+})


### PR DESCRIPTION
## Summary

`mcp_servers` is a transient event (`session-manager.js`'s `builtinTransient` list) — forwarded to currently-connected clients but never recorded in history and never replayed on reconnect. A client that subscribes to an already-warmed session (dashboard reconnect, or a second client joining a shared session) previously saw "No MCP servers" until the next emission:
- **sdk/cli sessions** emit the list once at the stream-json `system/init` — a late joiner never sees it this boot.
- **claude-tui sessions** (#6820/#6831) re-emit on warmup/respawn — a late joiner sees the list only after a respawn.

## Fix

- `BaseSession` (`packages/server/src/base-session.js`) now caches the last-emitted `mcp_servers` payload via a self-listener wired in the constructor, alongside the existing `_setupActivityRegistry` pattern, and exposes it through `getMcpServersSnapshot()`. Since `CliSession`, `SdkSession`, and `ClaudeTuiSession` all extend `BaseSession` and emit through `this.emit('mcp_servers', ...)`, caching at this layer covers every emitting provider without touching each provider's emit call site.
- `ws-history.sendSessionInfo` (`packages/server/src/ws-history.js`) replays the cached snapshot to a fresh subscriber, mirroring the existing `activity_snapshot` / `permission_rules_updated` snapshot-on-subscribe pattern (stamping the canonical `sessionId`).
- The cache is cleared on full session teardown (`removeAllListeners()` with no event name) — the same chokepoint that already clears the Control Room `ActivityRegistry` (#5160). A targeted `removeAllListeners('event')` does not clear it.
- Updated the `builtinTransient` comment block in `session-manager.js` so it no longer reads as "never replayed" now that a snapshot-on-subscribe companion exists.

## Test plan

- [x] New `packages/server/tests/mcp-servers-snapshot.test.js` (10 tests): `BaseSession.getMcpServersSnapshot()` returns null until first emission, caches + updates on re-emission (list-replacement), clears on full `removeAllListeners()`, survives a targeted `removeAllListeners(event)`; `sendSessionInfo` replays the cached list to a late subscriber (with the correct `sessionId`), replays the latest snapshot after re-emission, sends nothing for a session that never emitted, sends nothing post-destroy, and doesn't throw for a legacy/mock session lacking the method.
- [x] Targeted suites green: `mcp-servers-snapshot.test.js`, `base-session.test.js`, `ws-history.test.js`, `claude-tui-mcp-servers.test.js`, `session-info-role-resync.test.js`, `session-info-booted-model.test.js`, `activity-registry.test.js`, `session-manager.test.js`, `ws-message-handlers.test.js`, `ws-server-broadcast.test.js` — 667/667 passing.
- [x] `packages/server/scripts/lint-tests-state-file-path.sh` — pass (no new `SessionManager` construction in tests).
- [x] `packages/server/scripts/lint-session-opt-forwarding.sh` — pass (no `BaseSession` opt changes).
- [x] `npm run lint` (server) — 0 errors (pre-existing warnings in unrelated files only).

Closes #6832