### PR TITLE
fix(server): forward queueLength through the result normalizer (#6819)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -499,6 +499,14 @@ Object.assign(EVENT_MAP, {
           duration: data.duration,
           usage: data.usage,
           sessionId: data.sessionId,
+          // #6819: the session's authoritative outgoing-queue length, stamped
+          // centrally by base-session.js's emit() override (#6627/#6706) onto
+          // every `result` payload. Forwarding it lets store-core's
+          // result-boundary reconcile self-heal a stale "Queued" bubble left
+          // by a dropped/late message_dequeued. Only forwarded when finite —
+          // absent/non-finite keeps the field off the wire so older-server
+          // semantics (client takes the no-op reconcile path) are preserved.
+          ...(Number.isFinite(data.queueLength) ? { queueLength: data.queueLength } : {}),
           // #6769: occupancy snapshot (claude-sdk getContextUsage() / the
           // byok agent loop's final-round prompt, incl. subclasses like
           // ollama whose endpoint reports usage). Only forwarded when the

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -88,6 +88,41 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- EVENT_MAP: result queueLength passthrough (#6819) ----
+
+  describe('result event queueLength passthrough (#6819)', () => {
+    it('forwards a finite queueLength to the wire (base-session #6627/#6706 stamp)', () => {
+      const result = normalizer.normalize(
+        'result',
+        { cost: 0.01, duration: 5, usage: { input_tokens: 1 }, sessionId: 'sess-1', queueLength: 2 },
+        makeCtx(),
+      )
+      const resultMsg = result.messages.find((m) => m.msg.type === 'result')
+      assert.equal(resultMsg.msg.queueLength, 2)
+    })
+
+    it('forwards a zero queueLength (finite, not truthy — must not be treated as absent)', () => {
+      const result = normalizer.normalize(
+        'result',
+        { cost: 0.01, duration: 5, usage: { input_tokens: 1 }, sessionId: 'sess-1', queueLength: 0 },
+        makeCtx(),
+      )
+      const resultMsg = result.messages.find((m) => m.msg.type === 'result')
+      assert.equal(resultMsg.msg.queueLength, 0)
+    })
+
+    it('omits queueLength from the wire when the session did not stamp one (older/non-finite)', () => {
+      const result = normalizer.normalize(
+        'result',
+        { cost: 0.01, duration: 5, usage: { input_tokens: 1 }, sessionId: 'sess-1' },
+        makeCtx(),
+      )
+      const resultMsg = result.messages.find((m) => m.msg.type === 'result')
+      assert.equal('queueLength' in resultMsg.msg, false,
+        'absent/non-finite queueLength stays off the wire so clients take the no-op reconcile path')
+    })
+  })
+
   // ---- EVENT_MAP: ready ----
 
   describe('ready event', () => {

--- a/packages/store-core/src/handlers/outgoing-queue.test.ts
+++ b/packages/store-core/src/handlers/outgoing-queue.test.ts
@@ -394,3 +394,38 @@ describe('handleResultQueueReconcile (#6627 — self-heal a stale queued bubble 
     expect(builder.sessionId).toBe('sess-x')
   })
 })
+
+describe('handleResultQueueReconcile — end-to-end wire contract (#6819)', () => {
+  it('activates from a ServerResultSchema-validated payload carrying a finite queueLength', async () => {
+    // #6819: the event-normalizer previously dropped `queueLength` off the wire
+    // `result` message (only cost/duration/usage/sessionId/contextOccupancy were
+    // forwarded), so this reconcile always no-op'd in production even though the
+    // unit tests above (fed hand-built objects) looked green. Round-trip through
+    // the REAL @chroxy/protocol schema — the actual wire contract — to prove the
+    // fix's shape is both schema-valid and activates the self-heal end-to-end.
+    const { ServerResultSchema } = await import('@chroxy/protocol')
+    const wireMsg = ServerResultSchema.parse({
+      type: 'result',
+      cost: 0.01,
+      duration: 1200,
+      usage: { input_tokens: 10 },
+      sessionId: 's1',
+      queueLength: 1,
+    })
+
+    const current = [confirmed('uin-1', 'a'), confirmed('uin-2', 'b')]
+    const builder = handleResultQueueReconcile(wireMsg as unknown as Record<string, unknown>, null)
+    expect(builder).not.toBeNull()
+    const next = builder!.applyTo(current).queuedMessages
+    expect(next.map((m) => m.clientMessageId)).toEqual(['uin-2'])
+  })
+
+  it('ServerResultSchema carries queueLength as optional — no protocol change needed for #6819', async () => {
+    const { ServerResultSchema } = await import('@chroxy/protocol')
+    // Absent queueLength (older server / providers with no stamp) must still parse.
+    expect(() => ServerResultSchema.parse({ type: 'result', sessionId: 's1' })).not.toThrow()
+    // A finite queueLength (including zero) must parse and round-trip untouched.
+    const parsed = ServerResultSchema.parse({ type: 'result', sessionId: 's1', queueLength: 0 })
+    expect(parsed.queueLength).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

`base-session.js` stamps `queueLength` onto every session-level `result` payload via its `emit()` override (#6627/#6706), but the event-normalizer's `result` pick forwarded only `cost`/`duration`/`usage`/`sessionId`/`contextOccupancy` — dropping the field before the wire. Client-side, store-core's result-boundary reconcile (`handleResultQueueReconcile`) returns null without a finite `queueLength`, so clients always took the "older server" no-op path and the #6627 stale queued-bubble self-heal never fired in production.

## Changes

- **`packages/server/src/event-normalizer.js`** — forward `queueLength` in the `result` pick, only when finite (`Number.isFinite`): absent/undefined stays off the wire so older-server semantics (client takes the no-op reconcile path) are preserved, and `0` (finite, falsy) is forwarded correctly.
- **`packages/server/tests/event-normalizer.test.js`** — passthrough tests: finite value forwarded, zero forwarded (not treated as absent), absent stays off the wire.
- **`packages/store-core/src/handlers/outgoing-queue.test.ts`** — end-to-end wire-contract tests: the reconcile activates from a payload round-tripped through the real `ServerResultSchema` (the prior unit tests fed hand-built objects, so the dropped field went unnoticed), plus a pin that the schema already carries `queueLength` as optional — **no protocol change needed** (#6627 landed it).

## Test results

- `packages/server` event-normalizer suite: 124/124 pass (incl. 3 new)
- `packages/server` outgoing-queue suite: 19/19 pass
- `packages/store-core` full vitest suite: 2000/2000 pass across 54 files (incl. 2 new)
- `lint-tests-state-file-path.sh`: OK
- `lint-session-opt-forwarding.sh`: OK
- `store-core` typecheck (`tsc --noEmit`): clean
- eslint on `src/event-normalizer.js`: clean

## Acceptance criteria

- [x] `result` messages on the wire carry `queueLength` when the session stamped it
- [x] A normalizer passthrough test pins the field
- [x] The outgoing-queue result-boundary reconcile activates with a finite `queueLength` end-to-end

Related to #6627, #6706, PR #6816 (discovery context).

Closes #6819