### PR TITLE
fix(server,dashboard): enrich permission audit entries — tool, scope, provenance (#6830)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2897,4 +2897,50 @@ describe('SettingsPanel — permission rules + audit history (#6772/#6829)', () 
     // Forward-compat (#6836 review): an unknown future kind gets the generic label.
     expect(describePermissionAuditEntry({ type: 'rule_expired', timestamp: 0 })).toBe('Permission event')
   })
+
+  // #6830 — the allowAlways audit entry now carries tool + a durable-rule
+  // marker, and a persisted-rule auto-approve (no prompt ever shown) gets its
+  // own distinct label. Pre-#6830 entries (no tool/persist fields at all)
+  // must keep rendering exactly as before — pinned above.
+  it('describePermissionAuditEntry renders #6830 tool + persist enrichment', () => {
+    // A plain allow/deny with a known tool appends the tool name.
+    expect(
+      describePermissionAuditEntry({ type: 'decision', decision: 'allow', reason: 'user', tool: 'Read', timestamp: 0 }),
+    ).toBe('Allowed Read')
+    expect(
+      describePermissionAuditEntry({ type: 'decision', decision: 'deny', reason: 'timeout', tool: 'Bash', timestamp: 0 }),
+    ).toBe('Denied Bash (timeout)')
+
+    // allowAlways that actually persisted a durable project rule.
+    expect(
+      describePermissionAuditEntry({
+        type: 'decision',
+        decision: 'allowAlways',
+        reason: 'user',
+        tool: 'Write',
+        persist: 'project',
+        projectKey: '/abs/proj',
+        timestamp: 0,
+      }),
+    ).toBe('Always-allowed Write — saved as a project rule')
+
+    // allowAlways on a NEVER_AUTO_ALLOW / non-eligible tool degrades to a
+    // one-shot allow — nothing persisted, so no durable-rule marker.
+    expect(
+      describePermissionAuditEntry({ type: 'decision', decision: 'allowAlways', reason: 'user', tool: 'Bash', timestamp: 0 }),
+    ).toBe('Always-allowed Bash (not saved — one-time only)')
+
+    // A persisted project rule silently auto-approving with NO prompt shown.
+    expect(
+      describePermissionAuditEntry({
+        type: 'decision',
+        decision: 'allow',
+        reason: 'persisted_rule',
+        tool: 'Write',
+        persist: 'project',
+        projectKey: '/abs/proj',
+        timestamp: 0,
+      }),
+    ).toBe('Auto-allowed Write (persisted rule)')
+  })
 })

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2939,8 +2939,24 @@ describe('SettingsPanel — permission rules + audit history (#6772/#6829)', () 
         tool: 'Write',
         persist: 'project',
         projectKey: '/abs/proj',
+        count: 1,
         timestamp: 0,
       }),
     ).toBe('Auto-allowed Write (persisted rule)')
+
+    // PR #6842 review — persisted-rule entries are coalesced server-side;
+    // count > 1 renders as ×N so one row summarizes the whole run.
+    expect(
+      describePermissionAuditEntry({
+        type: 'decision',
+        decision: 'allow',
+        reason: 'persisted_rule',
+        tool: 'Write',
+        persist: 'project',
+        projectKey: '/abs/proj',
+        count: 50,
+        timestamp: 0,
+      }),
+    ).toBe('Auto-allowed Write ×50 (persisted rule)')
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -75,7 +75,8 @@ const EMPTY_PERMISSION_RULES: PermissionRule[] = []
  *   - `reason:'persisted_rule'` is a rule silently auto-approving a tool call
  *     with NO prompt ever shown (permission-manager.js
  *     _auditPersistedRuleAutoApprove) — rendered distinctly ("Auto-allowed")
- *     rather than folded into the generic allow/deny verb.
+ *     rather than folded into the generic allow/deny verb. These entries are
+ *     coalesced server-side (PR #6842 review): `count` > 1 renders as "×N".
  */
 export function describePermissionAuditEntry(entry: PermissionAuditEntry): string {
   switch (entry.type) {
@@ -88,7 +89,10 @@ export function describePermissionAuditEntry(entry: PermissionAuditEntry): strin
       if (entry.reason === 'persisted_rule') {
         // A durable project rule auto-approved with no prompt shown — no
         // human responder, so there's no "(user)"/reason suffix to add.
-        return `Auto-allowed${toolPart} (persisted rule)`
+        // Coalesced server-side: count > 1 means N approvals folded into
+        // this one entry (PR #6842 review).
+        const countPart = typeof entry.count === 'number' && entry.count > 1 ? ` ×${entry.count}` : ''
+        return `Auto-allowed${toolPart}${countPart} (persisted rule)`
       }
       const verb = entry.decision === 'deny' ? 'Denied' : entry.decision === 'allowAlways' ? 'Always-allowed' : 'Allowed'
       const persistPart = entry.persist === 'project'

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -56,13 +56,26 @@ const AUTO_PERMISSION_CONFIRM_MESSAGE =
 const EMPTY_PERMISSION_RULES: PermissionRule[] = []
 
 /**
- * #6772 — human label for one permission audit entry. The server's audit log
- * (permission-audit.js) records heterogeneous kinds; render each known kind by
- * its distinguishing fields (a `decision` entry carries no tool name — the audit
- * log keys on requestId, not tool). `entry.type` is an OPEN string (PR #6836
+ * #6772/#6830 — human label for one permission audit entry. The server's audit
+ * log (permission-audit.js) records heterogeneous kinds; render each known kind
+ * by its distinguishing fields. `entry.type` is an OPEN string (PR #6836
  * review — the wire schema is forward-compatible), so any UNKNOWN kind falls
  * through to the generic label rather than breaking the list. Pure +
  * exported-shape so the SettingsPanel test can assert on the rendered text.
+ *
+ * #6830 — a `decision` entry now MAY carry `tool` and, for a durable grant,
+ * `persist:'project'`:
+ *   - a plain `allow`/`deny` (`tool` present or absent — pre-#6830 entries in
+ *     an existing log have neither) renders as before, with the tool name
+ *     appended when known.
+ *   - an `allowAlways` renders as "Always-allowed" and calls out whether it
+ *     was actually saved as a durable project rule (a NEVER_AUTO_ALLOW /
+ *     non-eligible tool, e.g. Bash, degrades to a one-time allow — nothing
+ *     persisted, so no rule survives a restart).
+ *   - `reason:'persisted_rule'` is a rule silently auto-approving a tool call
+ *     with NO prompt ever shown (permission-manager.js
+ *     _auditPersistedRuleAutoApprove) — rendered distinctly ("Auto-allowed")
+ *     rather than folded into the generic allow/deny verb.
  */
 export function describePermissionAuditEntry(entry: PermissionAuditEntry): string {
   switch (entry.type) {
@@ -71,9 +84,20 @@ export function describePermissionAuditEntry(entry: PermissionAuditEntry): strin
     case 'whitelist_change':
       return `Session rules changed (${entry.rules?.length ?? 0} rule${(entry.rules?.length ?? 0) === 1 ? '' : 's'})`
     case 'decision': {
-      const verb = entry.decision === 'deny' ? 'Denied' : 'Allowed'
+      const toolPart = entry.tool ? ` ${entry.tool}` : ''
+      if (entry.reason === 'persisted_rule') {
+        // A durable project rule auto-approved with no prompt shown — no
+        // human responder, so there's no "(user)"/reason suffix to add.
+        return `Auto-allowed${toolPart} (persisted rule)`
+      }
+      const verb = entry.decision === 'deny' ? 'Denied' : entry.decision === 'allowAlways' ? 'Always-allowed' : 'Allowed'
+      const persistPart = entry.persist === 'project'
+        ? ' — saved as a project rule'
+        : entry.decision === 'allowAlways' && entry.tool
+          ? ' (not saved — one-time only)'
+          : ''
       const reason = entry.reason && entry.reason !== 'user' ? ` (${entry.reason})` : ''
-      return `${verb}${reason}`
+      return `${verb}${toolPart}${reason}${persistPart}`
     }
     default:
       return 'Permission event'

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -299,6 +299,13 @@ export interface PermissionRule {
  * review): a future server-side audit kind must not fail the payload parse, and
  * the view renders unknown kinds with a generic label. Rendered read-only in the
  * SettingsPanel "Permission history" view.
+ *
+ * #6830 — `decision` entries are enriched with `tool` (the tool the decision
+ * applied to) and, for a durable grant, `persist:'project'` + `projectKey` (the
+ * project cwd the rule is scoped to). Set on an `allowAlways` that actually
+ * persisted a project rule, and on a `reason:'persisted_rule'` entry — a
+ * durable rule silently auto-approving a tool call with NO prompt ever shown
+ * (clientId is null there, same as the other auto-deny reasons).
  */
 export interface PermissionAuditEntry {
   type: string;
@@ -314,6 +321,9 @@ export interface PermissionAuditEntry {
   requestId?: string;
   decision?: string;
   reason?: string;
+  tool?: string | null;
+  persist?: string | null;
+  projectKey?: string | null;
 }
 
 /**

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -305,7 +305,11 @@ export interface PermissionRule {
  * project cwd the rule is scoped to). Set on an `allowAlways` that actually
  * persisted a project rule, and on a `reason:'persisted_rule'` entry — a
  * durable rule silently auto-approving a tool call with NO prompt ever shown
- * (clientId is null there, same as the other auto-deny reasons).
+ * (clientId is null, no requestId). Persisted-rule entries are COALESCED
+ * server-side per (sessionId, tool, projectKey): `count` is how many
+ * approvals folded into the entry, `firstAt` the first one's time,
+ * `timestamp` the latest (PR #6842 review — keeps the audit ring from being
+ * flooded at tool-call speed).
  */
 export interface PermissionAuditEntry {
   type: string;
@@ -324,6 +328,8 @@ export interface PermissionAuditEntry {
   tool?: string | null;
   persist?: string | null;
   projectKey?: string | null;
+  count?: number;
+  firstAt?: number;
 }
 
 /**

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -216,7 +216,11 @@ export declare const ServerPermissionInputSchema: z.ZodDiscriminatedUnion<[z.Zod
  *   - `decision`         — requestId / decision (allow|deny|allowAlways) / reason
  *     (`reason:'persisted_rule'` — #6830 — is a decision entry with NO human
  *     responder: a durable project rule auto-approved the tool with no prompt
- *     ever shown; `clientId` is null just like the other auto-deny reasons)
+ *     ever shown; `clientId` is null and there is no requestId. These are
+ *     COALESCED server-side per (sessionId, tool, projectKey) — `count` is
+ *     the number of coalesced approvals, `firstAt` the first one's time,
+ *     `timestamp` the latest — so a rule matching at machine speed can never
+ *     flood the audit ring; see permission-audit.js logPersistedRuleApproval)
  * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
  *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
  *      the moment the server adds a new audit kind; clients render unknown kinds
@@ -245,6 +249,8 @@ export declare const ServerPermissionAuditEntrySchema: z.ZodObject<{
     tool: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     persist: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     projectKey: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    count: z.ZodOptional<z.ZodNumber>;
+    firstAt: z.ZodOptional<z.ZodNumber>;
 }, z.core.$loose>;
 /**
  * #6772 — reply to a `query_permission_audit` pull: the recent permission audit
@@ -273,6 +279,8 @@ export declare const ServerPermissionAuditResultSchema: z.ZodObject<{
         tool: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         persist: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         projectKey: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        count: z.ZodOptional<z.ZodNumber>;
+        firstAt: z.ZodOptional<z.ZodNumber>;
     }, z.core.$loose>>;
 }, z.core.$strip>;
 /**

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -213,7 +213,10 @@ export declare const ServerPermissionInputSchema: z.ZodDiscriminatedUnion<[z.Zod
  * fields are all optional so a single object covers every kind. Known kinds:
  *   - `mode_change`      — previousMode / newMode
  *   - `whitelist_change` — rules (the new session-rule set)
- *   - `decision`         — requestId / decision (allow|deny) / reason
+ *   - `decision`         — requestId / decision (allow|deny|allowAlways) / reason
+ *     (`reason:'persisted_rule'` — #6830 — is a decision entry with NO human
+ *     responder: a durable project rule auto-approved the tool with no prompt
+ *     ever shown; `clientId` is null just like the other auto-deny reasons)
  * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
  *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
  *      the moment the server adds a new audit kind; clients render unknown kinds
@@ -239,6 +242,9 @@ export declare const ServerPermissionAuditEntrySchema: z.ZodObject<{
     requestId: z.ZodOptional<z.ZodString>;
     decision: z.ZodOptional<z.ZodString>;
     reason: z.ZodOptional<z.ZodString>;
+    tool: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    persist: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    projectKey: z.ZodOptional<z.ZodNullable<z.ZodString>>;
 }, z.core.$loose>;
 /**
  * #6772 — reply to a `query_permission_audit` pull: the recent permission audit
@@ -264,6 +270,9 @@ export declare const ServerPermissionAuditResultSchema: z.ZodObject<{
         requestId: z.ZodOptional<z.ZodString>;
         decision: z.ZodOptional<z.ZodString>;
         reason: z.ZodOptional<z.ZodString>;
+        tool: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        persist: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        projectKey: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     }, z.core.$loose>>;
 }, z.core.$strip>;
 /**

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -314,7 +314,11 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
  *   - `decision`         — requestId / decision (allow|deny|allowAlways) / reason
  *     (`reason:'persisted_rule'` — #6830 — is a decision entry with NO human
  *     responder: a durable project rule auto-approved the tool with no prompt
- *     ever shown; `clientId` is null just like the other auto-deny reasons)
+ *     ever shown; `clientId` is null and there is no requestId. These are
+ *     COALESCED server-side per (sessionId, tool, projectKey) — `count` is
+ *     the number of coalesced approvals, `firstAt` the first one's time,
+ *     `timestamp` the latest — so a rule matching at machine speed can never
+ *     flood the audit ring; see permission-audit.js logPersistedRuleApproval)
  * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
  *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
  *      the moment the server adds a new audit kind; clients render unknown kinds
@@ -350,6 +354,10 @@ export const ServerPermissionAuditEntrySchema = z
     tool: z.string().nullable().optional(),
     persist: z.string().nullable().optional(),
     projectKey: z.string().nullable().optional(),
+    // #6830 — coalesced persisted-rule entries only: number of approvals
+    // folded into this entry, and the first approval's timestamp.
+    count: z.number().optional(),
+    firstAt: z.number().optional(),
 })
     .passthrough();
 /**

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -311,7 +311,10 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
  * fields are all optional so a single object covers every kind. Known kinds:
  *   - `mode_change`      — previousMode / newMode
  *   - `whitelist_change` — rules (the new session-rule set)
- *   - `decision`         — requestId / decision (allow|deny) / reason
+ *   - `decision`         — requestId / decision (allow|deny|allowAlways) / reason
+ *     (`reason:'persisted_rule'` — #6830 — is a decision entry with NO human
+ *     responder: a durable project rule auto-approved the tool with no prompt
+ *     ever shown; `clientId` is null just like the other auto-deny reasons)
  * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
  *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
  *      the moment the server adds a new audit kind; clients render unknown kinds
@@ -338,6 +341,15 @@ export const ServerPermissionAuditEntrySchema = z
     requestId: z.string().optional(),
     decision: z.string().optional(),
     reason: z.string().optional(),
+    // #6830 — decision enrichment: the tool the decision applied to, and (for
+    // an `allowAlways` that actually persisted, or a `persisted_rule`
+    // auto-approve) the durable-rule marker + the project cwd it's scoped to.
+    // Nullable (not just optional): existing callers explicitly pass `null`
+    // for "known absent" rather than omitting the key (permission-audit.js
+    // `logDecision` defaults).
+    tool: z.string().nullable().optional(),
+    persist: z.string().nullable().optional(),
+    projectKey: z.string().nullable().optional(),
 })
     .passthrough();
 /**

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -339,7 +339,11 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
  *   - `decision`         — requestId / decision (allow|deny|allowAlways) / reason
  *     (`reason:'persisted_rule'` — #6830 — is a decision entry with NO human
  *     responder: a durable project rule auto-approved the tool with no prompt
- *     ever shown; `clientId` is null just like the other auto-deny reasons)
+ *     ever shown; `clientId` is null and there is no requestId. These are
+ *     COALESCED server-side per (sessionId, tool, projectKey) — `count` is
+ *     the number of coalesced approvals, `firstAt` the first one's time,
+ *     `timestamp` the latest — so a rule matching at machine speed can never
+ *     flood the audit ring; see permission-audit.js logPersistedRuleApproval)
  * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
  *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
  *      the moment the server adds a new audit kind; clients render unknown kinds
@@ -375,6 +379,10 @@ export const ServerPermissionAuditEntrySchema = z
     tool: z.string().nullable().optional(),
     persist: z.string().nullable().optional(),
     projectKey: z.string().nullable().optional(),
+    // #6830 — coalesced persisted-rule entries only: number of approvals
+    // folded into this entry, and the first approval's timestamp.
+    count: z.number().optional(),
+    firstAt: z.number().optional(),
   })
   .passthrough()
 

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -336,7 +336,10 @@ export const ServerPermissionInputSchema = z.discriminatedUnion('found', [
  * fields are all optional so a single object covers every kind. Known kinds:
  *   - `mode_change`      — previousMode / newMode
  *   - `whitelist_change` — rules (the new session-rule set)
- *   - `decision`         — requestId / decision (allow|deny) / reason
+ *   - `decision`         — requestId / decision (allow|deny|allowAlways) / reason
+ *     (`reason:'persisted_rule'` — #6830 — is a decision entry with NO human
+ *     responder: a durable project rule auto-approved the tool with no prompt
+ *     ever shown; `clientId` is null just like the other auto-deny reasons)
  * The entry `type` is a PLAIN `z.string()` (PR #6836 review), for two reasons:
  *   1. Forward compatibility — a closed enum would fail the WHOLE payload parse
  *      the moment the server adds a new audit kind; clients render unknown kinds
@@ -363,6 +366,15 @@ export const ServerPermissionAuditEntrySchema = z
     requestId: z.string().optional(),
     decision: z.string().optional(),
     reason: z.string().optional(),
+    // #6830 — decision enrichment: the tool the decision applied to, and (for
+    // an `allowAlways` that actually persisted, or a `persisted_rule`
+    // auto-approve) the durable-rule marker + the project cwd it's scoped to.
+    // Nullable (not just optional): existing callers explicitly pass `null`
+    // for "known absent" rather than omitting the key (permission-audit.js
+    // `logDecision` defaults).
+    tool: z.string().nullable().optional(),
+    persist: z.string().nullable().optional(),
+    projectKey: z.string().nullable().optional(),
   })
   .passthrough()
 

--- a/packages/server/src/permission-audit.js
+++ b/packages/server/src/permission-audit.js
@@ -55,18 +55,34 @@ export class PermissionAuditLog {
    * @param {string|null} params.clientId - Identifies the responder. Three states:
    *   - WS-origin user response: the connection's synthetic id (e.g. an 8-char hex)
    *   - HTTP-origin user response: the literal string 'http' (#3059)
-   *   - Auto-deny paths (timeout / aborted / cleared): null (no responder)
+   *   - Auto-deny paths (timeout / aborted / cleared) and rule-driven
+   *     auto-approvals (#6830): null (no human responder)
    * @param {string|null} params.sessionId - Session the permission belongs to,
    *   or null for genuinely unmapped legacy HTTP requests (see ws-permissions.js
    *   legacy branch — pendingPermissions entry with no permissionSessionMap entry).
    * @param {string} params.requestId - The permission request ID
-   * @param {string} params.decision - 'allow' or 'deny'
+   * @param {string} params.decision - 'allow', 'deny', or 'allowAlways'
    * @param {string} [params.reason] - How the permission was resolved.
    *   Defaults to 'user' for backwards compatibility with the inline WS-path
    *   audit. Auto-deny paths pass 'timeout' | 'aborted' | 'cleared' so
    *   forensic queries can distinguish user denies from auto-denies (#3057).
+   *   A persisted-rule auto-approve (no prompt ever shown) passes
+   *   'persisted_rule' (#6830).
+   * @param {string|null} [params.tool] - The tool the decision applied to
+   *   (#6830). Without this, `_lastPermissionData` (which carries the tool
+   *   name) is already deleted by the time an auditor queries the log, so a
+   *   `requestId -> tool` lookup is impossible from the audit trail alone.
+   *   Defaults to null so pre-#6830 callers keep working.
+   * @param {string|null} [params.persist] - `'project'` when this decision
+   *   resulted in (or matched) a DURABLE project-scoped rule (#6771/#6830) —
+   *   set on an `allowAlways` that the rule store actually persisted, and on
+   *   a `reason:'persisted_rule'` auto-approve. Null otherwise (a one-shot
+   *   allow/deny, or an `allowAlways` on a NEVER_AUTO_ALLOW / non-eligible
+   *   tool that degrades to a one-time allow with nothing persisted).
+   * @param {string|null} [params.projectKey] - The normalized project cwd the
+   *   persisted rule is scoped to (present only alongside `persist:'project'`).
    */
-  logDecision({ clientId, sessionId, requestId, decision, reason = 'user' }) {
+  logDecision({ clientId, sessionId, requestId, decision, reason = 'user', tool = null, persist = null, projectKey = null }) {
     this._append({
       type: 'decision',
       clientId,
@@ -74,6 +90,9 @@ export class PermissionAuditLog {
       requestId,
       decision,
       reason,
+      tool,
+      persist,
+      projectKey,
       timestamp: Date.now(),
     })
   }

--- a/packages/server/src/permission-audit.js
+++ b/packages/server/src/permission-audit.js
@@ -119,7 +119,10 @@ export class PermissionAuditLog {
    * @param {object} params
    * @param {string|null} params.sessionId - Session whose tool call was auto-approved
    * @param {string} params.tool - The auto-approved tool
-   * @param {string|null} [params.projectKey] - The project cwd the durable rule is scoped to
+   * @param {string|null} [params.projectKey] - The NORMALIZED project cwd the
+   *   durable rule is scoped to (permission-rule-store.js normalizeProjectKey —
+   *   callers normalize before logging so the entry correlates with the
+   *   persisted rule's key in permission-rules.json, #6842 review)
    */
   logPersistedRuleApproval({ sessionId, tool, projectKey = null }) {
     const idx = this._entries.findIndex((e) =>

--- a/packages/server/src/permission-audit.js
+++ b/packages/server/src/permission-audit.js
@@ -66,8 +66,8 @@ export class PermissionAuditLog {
    *   Defaults to 'user' for backwards compatibility with the inline WS-path
    *   audit. Auto-deny paths pass 'timeout' | 'aborted' | 'cleared' so
    *   forensic queries can distinguish user denies from auto-denies (#3057).
-   *   A persisted-rule auto-approve (no prompt ever shown) passes
-   *   'persisted_rule' (#6830).
+   *   (Persisted-rule auto-approves do NOT go through this method — they use
+   *   the coalescing {@link logPersistedRuleApproval}, #6830.)
    * @param {string|null} [params.tool] - The tool the decision applied to
    *   (#6830). Without this, `_lastPermissionData` (which carries the tool
    *   name) is already deleted by the time an auditor queries the log, so a
@@ -93,6 +93,60 @@ export class PermissionAuditLog {
       tool,
       persist,
       projectKey,
+      timestamp: Date.now(),
+    })
+  }
+
+  /**
+   * #6830 (PR #6842 review) — record a persisted (project-scoped) rule
+   * silently auto-approving a tool call, COALESCED per
+   * `(sessionId, tool, projectKey)`.
+   *
+   * Why coalesced: a convenience rule (always-allow Read / Write / Grep …)
+   * matches at machine speed in an agentic session — one raw entry per
+   * matched tool call would flood the 500-entry no-dedup ring and evict
+   * exactly the high-value entries (#6830's whole point: whitelist changes,
+   * user allow/deny decisions, mode changes) an auditor needs kept.
+   *
+   * Coalescing shape — "one live entry per key, with a running count":
+   * repeated approvals for the same key UPDATE the existing entry
+   * (`count`++, `timestamp` = now, `firstAt` preserved) and MOVE it to the
+   * ring tail so the query contract ("most recent entries = tail") stays
+   * true. Distinct sessions / tools / project keys keep distinct entries.
+   * There is deliberately no `requestId` and no `clientId` responder: no
+   * prompt was ever minted and no human answered — the rule did.
+   *
+   * @param {object} params
+   * @param {string|null} params.sessionId - Session whose tool call was auto-approved
+   * @param {string} params.tool - The auto-approved tool
+   * @param {string|null} [params.projectKey] - The project cwd the durable rule is scoped to
+   */
+  logPersistedRuleApproval({ sessionId, tool, projectKey = null }) {
+    const idx = this._entries.findIndex((e) =>
+      e.type === 'decision'
+      && e.reason === 'persisted_rule'
+      && e.sessionId === sessionId
+      && e.tool === tool
+      && e.projectKey === projectKey,
+    )
+    if (idx >= 0) {
+      const [existing] = this._entries.splice(idx, 1)
+      existing.count = (existing.count || 1) + 1
+      existing.timestamp = Date.now()
+      this._entries.push(existing)
+      return
+    }
+    this._append({
+      type: 'decision',
+      clientId: null,
+      sessionId,
+      decision: 'allow',
+      reason: 'persisted_rule',
+      tool,
+      persist: 'project',
+      projectKey,
+      count: 1,
+      firstAt: Date.now(),
       timestamp: Date.now(),
     })
   }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -351,6 +351,56 @@ export class PermissionManager extends EventEmitter {
   }
 
   /**
+   * #6830 — was the 'allow' decision _matchesRule just returned for `toolName`
+   * SOURCED from a durable project-scoped rule (as opposed to a session rule)?
+   * Mirrors _matchesRule's own precedence (session rules are checked first and
+   * shadow a persistent rule for the same tool) WITHOUT changing _matchesRule's
+   * tested return contract (a plain 'allow'|'deny'|null string, asserted
+   * directly in permission-manager.test.js). Used only to decide whether a
+   * silent auto-approve needs an audit-only signal (see
+   * _auditPersistedRuleAutoApprove) — a session-rule-sourced allow is an
+   * explicit, non-durable decision the user already made this session and
+   * needs no extra trail beyond what's already logged for it.
+   * @param {string} toolName
+   * @returns {boolean}
+   */
+  _persistentRuleSourced(toolName) {
+    if (this._sessionRules.some((r) => r.tool === toolName)) return false
+    return this._persistentRules.some((r) => r.tool === toolName && r.decision === 'allow')
+  }
+
+  /**
+   * #6830 — audit-only signal for a persisted (project-scoped) rule silently
+   * auto-approving `toolName` with NO visible prompt: handlePermission
+   * short-circuits BEFORE minting a requestId or emitting permission_request,
+   * so without this the audit log has ZERO trace of the tool call — an
+   * auditor querying permission history can't answer "why did tool X
+   * auto-approve after a restart?" from the log alone.
+   *
+   * Emits the EXISTING `permission_resolved` event — already wired through
+   * wirePermissionManager -> session -> SessionManager (`permission_resolved`
+   * is in session-manager.js's builtinTransient list) -> ws-server's
+   * `_sessionEventAuditHandler`, which records any non-'user'-reason
+   * resolution. A synthetic id (same `<prefix>-<nonce>-<counter>-<ms>` scheme
+   * as a real prompt, `rule-` prefixed so it reads distinctly from a real
+   * `perm-` id in logs) gives the entry a stable, unique correlation key; it
+   * is audit-only and is never registered in `_pendingPermissions` — there is
+   * nothing to resolve later.
+   * @param {string} toolName
+   */
+  _auditPersistedRuleAutoApprove(toolName) {
+    const requestId = `rule-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
+    this.emit('permission_resolved', {
+      requestId,
+      decision: 'allow',
+      reason: 'persisted_rule',
+      tool: toolName,
+      persist: 'project',
+      projectKey: this._cwd,
+    })
+  }
+
+  /**
    * Handle a permission check from the SDK canUseTool callback.
    *
    * For AskUserQuestion: emits user_question and waits for respondToQuestion().
@@ -403,6 +453,12 @@ export class PermissionManager extends EventEmitter {
     if (ruleDecision !== null && !(protectedTarget && ruleDecision === 'allow')) {
       this._logInfo(`Permission rule matched for ${toolName}: ${ruleDecision}`)
       if (ruleDecision === 'allow') {
+        // #6830 — a durable project rule (not a session rule) just silently
+        // auto-approved this tool call. Emit the audit-only signal so the
+        // permission audit log has a trace even though no prompt was shown.
+        if (this._persistentRuleSourced(toolName)) {
+          this._auditPersistedRuleAutoApprove(toolName)
+        }
         return Promise.resolve({ behavior: 'allow', updatedInput: input || {} })
       }
       return Promise.resolve({ behavior: 'deny', message: 'Denied by session rule' })

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -216,6 +216,15 @@ export class PermissionManager extends EventEmitter {
     // on construction (below) so a prior grant takes effect without re-prompting
     // after a daemon restart.
     this._ruleStore = ruleStore || null
+    // #6830 (PR #6842 review) — direct audit callback for persisted-rule
+    // auto-approves. Deliberately NOT an EventEmitter event: emitting
+    // `permission_resolved` here would ride wirePermissionManager →
+    // SessionManager → ws-forwarding → broadcastToSession, spamming every
+    // subscribed client with a wire message per rule-matched tool call. The
+    // sink is a plain function the WsServer wires straight into its
+    // PermissionAuditLog (see ws-server.js _attachPermissionAuditSink), so
+    // the signal stays in the audit lane only. Null until wired.
+    this._auditSink = null
 
     this._pendingPermissions = new Map() // requestId -> { resolve, input }
     this._permissionTimers = new Map()   // requestId -> timer
@@ -370,6 +379,16 @@ export class PermissionManager extends EventEmitter {
   }
 
   /**
+   * #6830 (PR #6842 review) — install the direct audit callback for
+   * persisted-rule auto-approves. Single-slot (last writer wins — one
+   * WsServer audits at a time); pass null/non-function to detach.
+   * @param {null|((info: {tool: string, projectKey: string|null}) => void)} sink
+   */
+  setAuditSink(sink) {
+    this._auditSink = typeof sink === 'function' ? sink : null
+  }
+
+  /**
    * #6830 — audit-only signal for a persisted (project-scoped) rule silently
    * auto-approving `toolName` with NO visible prompt: handlePermission
    * short-circuits BEFORE minting a requestId or emitting permission_request,
@@ -377,27 +396,24 @@ export class PermissionManager extends EventEmitter {
    * auditor querying permission history can't answer "why did tool X
    * auto-approve after a restart?" from the log alone.
    *
-   * Emits the EXISTING `permission_resolved` event — already wired through
-   * wirePermissionManager -> session -> SessionManager (`permission_resolved`
-   * is in session-manager.js's builtinTransient list) -> ws-server's
-   * `_sessionEventAuditHandler`, which records any non-'user'-reason
-   * resolution. A synthetic id (same `<prefix>-<nonce>-<counter>-<ms>` scheme
-   * as a real prompt, `rule-` prefixed so it reads distinctly from a real
-   * `perm-` id in logs) gives the entry a stable, unique correlation key; it
-   * is audit-only and is never registered in `_pendingPermissions` — there is
-   * nothing to resolve later.
+   * PR #6842 review — this must NOT emit `permission_resolved` (or any other
+   * session event): permission_resolved is a broadcast-lane event
+   * (session-manager.js builtinTransient → ws-forwarding →
+   * broadcastToSession), so an emission here would send a wire message to
+   * every subscribed client on EVERY rule-matched tool call, at machine
+   * speed. Instead it calls the WsServer-wired `_auditSink` directly — the
+   * audit lane only, coalesced ring-side by
+   * PermissionAuditLog.logPersistedRuleApproval. Guarded so a sink bug can
+   * never break tool approval; a no-op when no server has wired a sink.
    * @param {string} toolName
    */
   _auditPersistedRuleAutoApprove(toolName) {
-    const requestId = `rule-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
-    this.emit('permission_resolved', {
-      requestId,
-      decision: 'allow',
-      reason: 'persisted_rule',
-      tool: toolName,
-      persist: 'project',
-      projectKey: this._cwd,
-    })
+    if (!this._auditSink) return
+    try {
+      this._auditSink({ tool: toolName, projectKey: this._cwd })
+    } catch (err) {
+      this._logWarn(`Permission audit sink threw: ${err?.message || err}`)
+    }
   }
 
   /**
@@ -454,7 +470,8 @@ export class PermissionManager extends EventEmitter {
       this._logInfo(`Permission rule matched for ${toolName}: ${ruleDecision}`)
       if (ruleDecision === 'allow') {
         // #6830 — a durable project rule (not a session rule) just silently
-        // auto-approved this tool call. Emit the audit-only signal so the
+        // auto-approved this tool call. Record it via the direct audit sink
+        // (NOT an event — see _auditPersistedRuleAutoApprove) so the
         // permission audit log has a trace even though no prompt was shown.
         if (this._persistentRuleSourced(toolName)) {
           this._auditPersistedRuleAutoApprove(toolName)
@@ -1092,4 +1109,9 @@ export function wirePermissionManager(session, permissions, { onRequest, onResol
   // Backward-compatible accessors used by ws-permissions.js + settings-handlers.js.
   session._pendingPermissions = permissions._pendingPermissions
   session._lastPermissionData = permissions._lastPermissionData
+  // #6830 (PR #6842 review) — public delegate so the WsServer can wire its
+  // PermissionAuditLog straight into this manager's persisted-rule audit path
+  // (ws-server.js _attachPermissionAuditSink) without reaching into privates.
+  // Installed for every wirePermissionManager provider (sdk / byok / codex).
+  session.setPermissionAuditSink = (sink) => permissions.setAuditSink(sink)
 }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -7,6 +7,14 @@ import { createLogger } from './logger.js'
 // redaction.js (a leaf module — no import cycle / HTTP-handler weight).
 import { sanitizeToolInput, redactValue } from './redaction.js'
 import { redactMcpUrl } from './byok-mcp-config.js'
+// #6842 review (Copilot) — audit entries must carry the store's NORMALIZED
+// project key, not the raw session cwd, or a relative / `..`-laden cwd
+// produces entries that never correlate with the persisted rule they audit.
+// Import is cycle-safe: permission-rule-store.js imports our ELIGIBLE_TOOLS /
+// NEVER_AUTO_ALLOW consts, but both modules only touch each other's exports
+// inside function bodies (call time), never at module evaluation, and
+// normalizeProjectKey is a hoisted function declaration.
+import { normalizeProjectKey } from './permission-rule-store.js'
 
 const _fallbackLog = createLogger('permission-manager')
 
@@ -382,6 +390,8 @@ export class PermissionManager extends EventEmitter {
    * #6830 (PR #6842 review) — install the direct audit callback for
    * persisted-rule auto-approves. Single-slot (last writer wins — one
    * WsServer audits at a time); pass null/non-function to detach.
+   * `projectKey` arrives pre-NORMALIZED (normalizeProjectKey — the
+   * PermissionRuleStore key), or null for an unkeyable cwd.
    * @param {null|((info: {tool: string, projectKey: string|null}) => void)} sink
    */
   setAuditSink(sink) {
@@ -410,7 +420,12 @@ export class PermissionManager extends EventEmitter {
   _auditPersistedRuleAutoApprove(toolName) {
     if (!this._auditSink) return
     try {
-      this._auditSink({ tool: toolName, projectKey: this._cwd })
+      // #6842 review (Copilot) — projectKey is the store's NORMALIZED key
+      // (normalizeProjectKey, the same helper every PermissionRuleStore
+      // read/write path uses), NOT the raw session cwd: a relative or
+      // `..`-laden cwd would otherwise stamp entries an auditor can never
+      // match against the persisted rule's key in permission-rules.json.
+      this._auditSink({ tool: toolName, projectKey: normalizeProjectKey(this._cwd) })
     } catch (err) {
       this._logWarn(`Permission audit sink threw: ${err?.message || err}`)
     }

--- a/packages/server/src/permission-resolver.js
+++ b/packages/server/src/permission-resolver.js
@@ -22,6 +22,13 @@
 //   { kind: 'expired', sessionId }                          -> HTTP 410 / WS permission_expired
 //   { kind: 'not_found' }                                   -> HTTP 404 / WS permission_expired
 
+// #6842 review (Copilot) — audit `projectKey` must be the PermissionRuleStore's
+// NORMALIZED key (path.resolve semantics), not the raw session cwd, so an
+// auditor can correlate the entry with the persisted rule's key in
+// permission-rules.json even when the session was started with a relative or
+// `..`-laden cwd. Reused, not duplicated.
+import { normalizeProjectKey } from './permission-rule-store.js'
+
 /**
  * #6030: the single source of truth for the permission "dispatch origin"
  * session id — the mapped session if the request was registered, else the
@@ -145,7 +152,11 @@ export function createPermissionResolver({
             const persistentRules = entry.session.getPersistentPermissionRules()
             if (persistentRules.some((r) => r.tool === toolName && r.decision === 'allow')) {
               extra.persist = 'project'
-              if (typeof entry.session.cwd === 'string') extra.projectKey = entry.session.cwd
+              // #6842 review — normalize to the store's key (see header import
+              // note); null for an unkeyable cwd, in which case the field is
+              // simply omitted (same as the tool-unknown case).
+              const projectKey = normalizeProjectKey(entry.session.cwd)
+              if (projectKey) extra.projectKey = projectKey
             }
           }
           audit(clientId, originSessionId, requestId, decision, extra)

--- a/packages/server/src/permission-resolver.js
+++ b/packages/server/src/permission-resolver.js
@@ -71,11 +71,15 @@ export function createPermissionResolver({
     if (typeof onRouteTeardown === 'function') onRouteTeardown(requestId)
     else permissionSessionMap.delete(requestId)
   }
-  function audit(clientId, sessionId, requestId, decision) {
+  function audit(clientId, sessionId, requestId, decision, extra = {}) {
     // #3059: only user-initiated resolutions reach here (auto-deny is audited by
     // the unified pipeline), hence reason:'user'.
+    // #6830 — `extra` carries tool/persist/projectKey when known (see the two
+    // call sites below). Keys are OMITTED entirely (not passed as null) when
+    // unknown, so a caller/fixture with no tool info produces the exact same
+    // 5-field call shape audit consumers already assert on.
     const a = getPermissionAudit?.()
-    if (a) a.logDecision({ clientId, sessionId, requestId, decision, reason: 'user' })
+    if (a) a.logDecision({ clientId, sessionId, requestId, decision, reason: 'user', ...extra })
   }
 
   /**
@@ -117,12 +121,34 @@ export function createPermissionResolver({
     if (originSessionId && sm) {
       const entry = sm.getSession(originSessionId)
       if (entry && typeof entry.session.respondToPermission === 'function') {
+        // #6830 — read the tool name BEFORE respondToPermission runs: it deletes
+        // the _lastPermissionData entry as part of resolving (permission-manager.js
+        // stashes it there precisely so the editedInput whitelist can read it
+        // pre-delete; the audit trail needs the same pre-delete read). Back-compat
+        // accessor — absent on a fixture/provider with no PermissionManager wiring,
+        // in which case toolName stays undefined and is simply omitted below.
+        const toolName = entry.session._lastPermissionData?.get(requestId)?.tool
         // #6543 (feature B): editedInput flows ONLY to the in-process (SDK/BYOK)
         // path — the legacy HTTP path below ignores it (CLI tool executes as-is).
         const resolved = entry.session.respondToPermission(requestId, decision, editedInput)
         consumeRoute(requestId)
         if (resolved) {
-          audit(clientId, originSessionId, requestId, decision)
+          const extra = {}
+          if (toolName) extra.tool = toolName
+          // #6830 — an `allowAlways` that persisted a DURABLE project rule
+          // (permission-manager.js respondToPermission) is reflected
+          // synchronously in getPersistentPermissionRules() by the time we get
+          // here. A tool that degrades to a one-shot allow (NEVER_AUTO_ALLOW /
+          // non-ELIGIBLE, e.g. Bash) never appears there, so persist stays
+          // unset — exactly the "not actually durable" signal an auditor needs.
+          if (decision === 'allowAlways' && toolName && typeof entry.session.getPersistentPermissionRules === 'function') {
+            const persistentRules = entry.session.getPersistentPermissionRules()
+            if (persistentRules.some((r) => r.tool === toolName && r.decision === 'allow')) {
+              extra.persist = 'project'
+              if (typeof entry.session.cwd === 'string') extra.projectKey = entry.session.cwd
+            }
+          }
+          audit(clientId, originSessionId, requestId, decision, extra)
           return { kind: 'resolved', via: 'sdk', sessionId: originSessionId }
         }
         return { kind: 'expired', sessionId: originSessionId }
@@ -131,9 +157,15 @@ export function createPermissionResolver({
 
     // Legacy HTTP-held / pendingPermissions store.
     if (pendingPermissions.has(requestId)) {
+      // #6830 — capture tool BEFORE resolveLegacyPermission runs: it synchronously
+      // deletes the pendingPermissions entry (ws-permissions.js resolvePermission
+      // -> pending.resolve -> cleanup()), so the `.data.tool` read must happen first.
+      const toolName = pendingPermissions.get(requestId)?.data?.tool
       consumeRoute(requestId)
       resolveLegacyPermission(requestId, decision)
-      audit(clientId, originSessionId ?? null, requestId, decision)
+      // Legacy (non-SDK) sessions have no PermissionManager/rule store, so
+      // 'allowAlways' here is never durable — tool is the only enrichment.
+      audit(clientId, originSessionId ?? null, requestId, decision, toolName ? { tool: toolName } : {})
       return { kind: 'resolved', via: 'legacy', sessionId: originSessionId ?? null }
     }
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1153,6 +1153,13 @@ export class WsServer {
           requestId: data.requestId,
           decision: data.decision,
           reason: data.reason,
+          // #6830 — the persisted-rule auto-approve signal (permission-manager.js
+          // _auditPersistedRuleAutoApprove) carries tool/persist/projectKey;
+          // other auto-deny reasons (timeout/aborted/cleared/auto_mode) don't
+          // set these, so they fall back to logDecision's own null defaults.
+          tool: data.tool ?? null,
+          persist: data.persist ?? null,
+          projectKey: data.projectKey ?? null,
         })
       }
       sessionManager.on('session_created', this._sessionCreatedHandler)

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1088,6 +1088,7 @@ export class WsServer {
       this._sessionCreatedHandler = ({ sessionId }) => {
         const entry = sessionManager.getSession(sessionId)
         this._registerSessionHookSecretIfMissing(sessionId, entry)
+        this._attachPermissionAuditSink(sessionId, entry)
       }
       this._sessionDestroyedHandler = ({ sessionId }) => {
         // Look up the stored secret — the session is already removed from the map
@@ -1153,13 +1154,6 @@ export class WsServer {
           requestId: data.requestId,
           decision: data.decision,
           reason: data.reason,
-          // #6830 — the persisted-rule auto-approve signal (permission-manager.js
-          // _auditPersistedRuleAutoApprove) carries tool/persist/projectKey;
-          // other auto-deny reasons (timeout/aborted/cleared/auto_mode) don't
-          // set these, so they fall back to logDecision's own null defaults.
-          tool: data.tool ?? null,
-          persist: data.persist ?? null,
-          projectKey: data.projectKey ?? null,
         })
       }
       sessionManager.on('session_created', this._sessionCreatedHandler)
@@ -1182,7 +1176,12 @@ export class WsServer {
       if (sessionManager._sessions instanceof Map && typeof sessionManager.getSession === 'function') {
         for (const [sessionId, entry] of sessionManager._sessions) {
           if (entry?._destroying) continue
-          this._registerSessionHookSecretIfMissing(sessionId, sessionManager.getSession(sessionId))
+          const resolved = sessionManager.getSession(sessionId)
+          this._registerSessionHookSecretIfMissing(sessionId, resolved)
+          // #6830 — restored sessions predate this WsServer (restoreState runs
+          // before construction, same shape as the #3716 hook-secret gap), so
+          // their persisted-rule audit sinks must be wired retroactively too.
+          this._attachPermissionAuditSink(sessionId, resolved)
         }
       }
     }
@@ -1607,6 +1606,38 @@ export class WsServer {
     this.registerHookSecret(secret)
     this._sessionHookSecrets.set(sessionId, secret)
     log.debug(`Registered hook secret for session ${sessionId}`)
+  }
+
+  /**
+   * #6830 (PR #6842 review) — wire this server's PermissionAuditLog straight
+   * into a session's persisted-rule audit path. Called from the
+   * `session_created` handler AND the constructor's retroactive scan (same
+   * dual wiring as _registerSessionHookSecretIfMissing, for the same #3716
+   * restored-session reason).
+   *
+   * A persisted-rule auto-approve deliberately bypasses the whole
+   * session-event pipeline: emitting `permission_resolved` for it would ride
+   * ws-forwarding → broadcastToSession to every client on EVERY rule-matched
+   * tool call (the PR #6842 review finding). The sink is a plain callback
+   * into logPersistedRuleApproval, which also COALESCES repeats per
+   * (sessionId, tool, projectKey) so the 500-entry ring is never flooded.
+   *
+   * The closure captures ONLY the audit log + sessionId — never `this` — so
+   * a session outliving a retired WsServer pins a small ring buffer, not the
+   * whole server (the #3060 concern that motivated the removable
+   * session_event listeners). Single-slot on the manager side: a replacement
+   * WsServer's attach overwrites this one (last writer wins).
+   *
+   * @param {string} sessionId
+   * @param {object|null} entry - SessionManager entry ({ session, ... })
+   */
+  _attachPermissionAuditSink(sessionId, entry) {
+    const session = entry?.session
+    if (typeof session?.setPermissionAuditSink !== 'function') return
+    const audit = this._permissionAudit
+    session.setPermissionAuditSink((info) => {
+      audit.logPersistedRuleApproval({ sessionId, tool: info?.tool, projectKey: info?.projectKey ?? null })
+    })
   }
 
   /**

--- a/packages/server/tests/permission-audit.test.js
+++ b/packages/server/tests/permission-audit.test.js
@@ -118,6 +118,60 @@ describe('PermissionAuditLog (#1851)', () => {
     assert.equal(entries[0].projectKey, null)
   })
 
+  // #6830 (PR #6842 review) — persisted-rule auto-approves are COALESCED per
+  // (sessionId, tool, projectKey): a convenience rule matching at machine
+  // speed must never flood the 500-entry ring and evict the high-value
+  // entries (whitelist changes, user decisions) #6830 set out to preserve.
+  describe('logPersistedRuleApproval coalescing (#6830 / PR #6842 review)', () => {
+    it('N=50 identical approvals produce ONE entry with count=50', () => {
+      for (let i = 0; i < 50; i++) {
+        log.logPersistedRuleApproval({ sessionId: 's1', tool: 'Write', projectKey: '/proj/a' })
+      }
+      const entries = log.query({ type: 'decision' })
+      assert.equal(entries.length, 1, 'bounded: one coalesced entry, not 50')
+      assert.equal(entries[0].count, 50)
+      assert.equal(entries[0].reason, 'persisted_rule')
+      assert.equal(entries[0].decision, 'allow')
+      assert.equal(entries[0].tool, 'Write')
+      assert.equal(entries[0].persist, 'project')
+      assert.equal(entries[0].projectKey, '/proj/a')
+      assert.equal(entries[0].clientId, null, 'no human responder')
+      assert.equal(entries[0].requestId, undefined, 'no prompt was ever minted')
+      assert.equal(typeof entries[0].firstAt, 'number')
+      assert.ok(entries[0].firstAt <= entries[0].timestamp)
+    })
+
+    it('a repeat approval refreshes timestamp, preserves firstAt, and moves the entry to the ring tail', () => {
+      log.logPersistedRuleApproval({ sessionId: 's1', tool: 'Write', projectKey: '/proj/a' })
+      // Backdate the stored entry so the refresh is observable, then interleave
+      // an unrelated entry so tail position is meaningful.
+      const stored = log.query({ type: 'decision' })[0]
+      stored.timestamp = 1000
+      stored.firstAt = 1000
+      log.logDecision({ clientId: 'c1', sessionId: 's1', requestId: 'r-mid', decision: 'deny' })
+
+      log.logPersistedRuleApproval({ sessionId: 's1', tool: 'Write', projectKey: '/proj/a' })
+
+      const entries = log.query()
+      assert.equal(entries.length, 2)
+      const tail = entries[entries.length - 1]
+      assert.equal(tail.reason, 'persisted_rule', 'coalesced entry moved to the tail (query contract: recent = tail)')
+      assert.equal(tail.count, 2)
+      assert.equal(tail.firstAt, 1000, 'firstAt preserved across coalesces')
+      assert.ok(tail.timestamp > 1000, 'timestamp refreshed to the latest approval')
+    })
+
+    it('distinct (sessionId, tool, projectKey) keys keep distinct entries', () => {
+      log.logPersistedRuleApproval({ sessionId: 's1', tool: 'Write', projectKey: '/proj/a' })
+      log.logPersistedRuleApproval({ sessionId: 's1', tool: 'Read', projectKey: '/proj/a' })
+      log.logPersistedRuleApproval({ sessionId: 's2', tool: 'Write', projectKey: '/proj/a' })
+      log.logPersistedRuleApproval({ sessionId: 's1', tool: 'Write', projectKey: '/proj/b' })
+      const entries = log.query({ type: 'decision' })
+      assert.equal(entries.length, 4)
+      assert.ok(entries.every((e) => e.count === 1))
+    })
+  })
+
   it('defaults reason to "user" for backwards compatibility (#3057)', () => {
     // Older callers (and any code we missed) pass no reason — they should
     // be tagged 'user' so forensic queries can still filter on the new

--- a/packages/server/tests/permission-audit.test.js
+++ b/packages/server/tests/permission-audit.test.js
@@ -83,6 +83,41 @@ describe('PermissionAuditLog (#1851)', () => {
     )
   })
 
+  // #6830 — an allowAlways decision (or a persisted-rule auto-approve) needs
+  // `requestId -> tool` in the audit log alone; _lastPermissionData (where the
+  // tool name otherwise lives) is deleted on resolution.
+  it('records tool/persist/projectKey when provided (#6830)', () => {
+    log.logDecision({
+      clientId: 'c1',
+      sessionId: 's1',
+      requestId: 'req-allow-always',
+      decision: 'allowAlways',
+      tool: 'Write',
+      persist: 'project',
+      projectKey: '/abs/proj',
+    })
+
+    const entries = log.query({ type: 'decision' })
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0].tool, 'Write')
+    assert.equal(entries[0].persist, 'project')
+    assert.equal(entries[0].projectKey, '/abs/proj')
+  })
+
+  it('defaults tool/persist/projectKey to null when omitted (#6830, backwards compat)', () => {
+    log.logDecision({
+      clientId: 'c1',
+      sessionId: 's1',
+      requestId: 'req-plain',
+      decision: 'allow',
+    })
+
+    const entries = log.query({ type: 'decision' })
+    assert.equal(entries[0].tool, null)
+    assert.equal(entries[0].persist, null)
+    assert.equal(entries[0].projectKey, null)
+  })
+
   it('defaults reason to "user" for backwards compatibility (#3057)', () => {
     // Older callers (and any code we missed) pass no reason — they should
     // be tagged 'user' so forensic queries can still filter on the new

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { PermissionManager, ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../src/permission-manager.js'
+import { EventEmitter } from 'events'
+import { PermissionManager, wirePermissionManager, ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../src/permission-manager.js'
 
 /**
  * Tests for PermissionManager — permission request lifecycle,
@@ -969,47 +970,100 @@ describe('PermissionManager', () => {
   // ZERO audit trail: handlePermission short-circuits before a requestId is
   // ever minted or a permission_request emitted, so the audit log had no way
   // to answer "why did tool X auto-approve after a restart?" These pin the
-  // gap-fill signal (_auditPersistedRuleAutoApprove, wired through the
-  // existing permission_resolved event) and its precedence rules.
+  // gap-fill signal and its precedence rules.
+  //
+  // PR #6842 review — the signal is a DIRECT audit sink callback, NOT a
+  // permission_resolved emission: permission_resolved rides ws-forwarding →
+  // broadcastToSession, so emitting it here would spam every client with a
+  // wire message per rule-matched tool call. The zero-emission contract is
+  // pinned below via a wirePermissionManager forwarding spy.
   describe('handlePermission with persistent (project) rules — #6830 audit gap', () => {
-    it('auto-allowing via a PERSISTENT rule emits an audit-only permission_resolved with tool + persist + reason', async () => {
-      const resolvedEvents = []
-      pm.on('permission_resolved', (data) => resolvedEvents.push(data))
-      const requestEvents = []
-      pm.on('permission_request', (data) => requestEvents.push(data))
-      pm._persistentRules = [{ tool: 'Write', decision: 'allow' }]
+    it('auto-allowing via a PERSISTENT rule calls the audit sink with tool + projectKey and emits NOTHING', async () => {
+      const sinkCalls = []
+      const events = []
+      const cwdPm = createManager({ cwd: '/proj/a' })
+      try {
+        cwdPm.setAuditSink((info) => sinkCalls.push(info))
+        cwdPm.on('permission_resolved', (data) => events.push(['permission_resolved', data]))
+        cwdPm.on('permission_request', (data) => events.push(['permission_request', data]))
+        cwdPm._persistentRules = [{ tool: 'Write', decision: 'allow' }]
 
-      const result = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
-      assert.equal(result.behavior, 'allow')
-      assert.equal(requestEvents.length, 0, 'no prompt was ever shown')
-      assert.equal(resolvedEvents.length, 1, 'the gap-fill audit signal must fire')
-      assert.equal(resolvedEvents[0].decision, 'allow')
-      assert.equal(resolvedEvents[0].reason, 'persisted_rule')
-      assert.equal(resolvedEvents[0].tool, 'Write')
-      assert.equal(resolvedEvents[0].persist, 'project')
-      assert.ok(resolvedEvents[0].requestId, 'needs a stable correlation key')
-      assert.match(resolvedEvents[0].requestId, /^rule-/)
+        const result = await cwdPm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
+        assert.equal(result.behavior, 'allow')
+        assert.equal(events.length, 0, 'no prompt AND no wire-lane event — audit sink only')
+        assert.deepEqual(sinkCalls, [{ tool: 'Write', projectKey: '/proj/a' }])
+      } finally {
+        cwdPm.destroy()
+      }
     })
 
-    it('a SESSION rule match does NOT emit the persisted-rule audit signal (session rules shadow persistent rules)', async () => {
-      const resolvedEvents = []
-      pm.on('permission_resolved', (data) => resolvedEvents.push(data))
+    it('N=50 persisted-rule approvals forward ZERO permission_resolved through wirePermissionManager (the wire lane)', async () => {
+      const cwdPm = createManager({ cwd: '/proj/a' })
+      const session = new EventEmitter()
+      const forwarded = []
+      try {
+        // The exact wiring every provider (sdk/byok/codex) uses — anything the
+        // session re-emits here is what SessionManager → ws-forwarding →
+        // broadcastToSession would put on the wire.
+        wirePermissionManager(session, cwdPm)
+        session.on('permission_resolved', (d) => forwarded.push(d))
+        session.on('permission_request', (d) => forwarded.push(d))
+
+        const sinkCalls = []
+        cwdPm.setAuditSink((info) => sinkCalls.push(info))
+        cwdPm._persistentRules = [{ tool: 'Read', decision: 'allow' }]
+
+        for (let i = 0; i < 50; i++) {
+          const result = await cwdPm.handlePermission('Read', { file_path: `/tmp/f${i}` }, null, 'approve')
+          assert.equal(result.behavior, 'allow')
+        }
+        assert.equal(forwarded.length, 0, 'zero wire emissions across 50 silent auto-approves')
+        assert.equal(sinkCalls.length, 50, 'every approve still reaches the audit sink (coalescing is ring-side)')
+      } finally {
+        cwdPm.destroy()
+      }
+    })
+
+    it('a missing sink is a safe no-op, and a throwing sink never breaks tool approval', async () => {
+      pm._persistentRules = [{ tool: 'Write', decision: 'allow' }]
+      // No sink wired at all.
+      const r1 = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
+      assert.equal(r1.behavior, 'allow')
+      // A sink that throws.
+      pm.setAuditSink(() => { throw new Error('sink boom') })
+      const r2 = await pm.handlePermission('Write', { file_path: '/tmp/y' }, null, 'approve')
+      assert.equal(r2.behavior, 'allow', 'sink failure must not affect the approval')
+    })
+
+    it('wirePermissionManager installs the setPermissionAuditSink delegate on the session', () => {
+      const session = new EventEmitter()
+      wirePermissionManager(session, pm)
+      assert.equal(typeof session.setPermissionAuditSink, 'function')
+      const sinkCalls = []
+      session.setPermissionAuditSink((info) => sinkCalls.push(info))
+      pm._auditSink({ tool: 'Read', projectKey: null })
+      assert.equal(sinkCalls.length, 1, 'delegate routes to the manager sink slot')
+    })
+
+    it('a SESSION rule match does NOT call the persisted-rule audit sink (session rules shadow persistent rules)', async () => {
+      const sinkCalls = []
+      pm.setAuditSink((info) => sinkCalls.push(info))
       pm.setRules([{ tool: 'Write', decision: 'allow' }])
       pm._persistentRules = [{ tool: 'Write', decision: 'allow' }] // same tool, both sets
 
       const result = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
       assert.equal(result.behavior, 'allow')
-      assert.equal(resolvedEvents.length, 0, 'session rule wins precedence — no persisted-rule audit needed')
+      assert.equal(sinkCalls.length, 0, 'session rule wins precedence — no persisted-rule audit needed')
     })
 
-    it('a persistent DENY rule match does not emit the (allow-only) audit signal', async () => {
-      const resolvedEvents = []
-      pm.on('permission_resolved', (data) => resolvedEvents.push(data))
+    it('a persistent DENY rule match does not call the (allow-only) audit sink', async () => {
+      const sinkCalls = []
+      pm.setAuditSink((info) => sinkCalls.push(info))
       pm._persistentRules = [{ tool: 'Write', decision: 'deny' }]
 
       const result = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
       assert.equal(result.behavior, 'deny')
-      assert.equal(resolvedEvents.length, 0)
+      assert.equal(sinkCalls.length, 0)
     })
 
     it('_persistentRuleSourced reflects session-rule shadowing directly', () => {

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -965,6 +965,61 @@ describe('PermissionManager', () => {
     })
   })
 
+  // #6830 — a persisted (project-scoped) rule auto-approving a tool call had
+  // ZERO audit trail: handlePermission short-circuits before a requestId is
+  // ever minted or a permission_request emitted, so the audit log had no way
+  // to answer "why did tool X auto-approve after a restart?" These pin the
+  // gap-fill signal (_auditPersistedRuleAutoApprove, wired through the
+  // existing permission_resolved event) and its precedence rules.
+  describe('handlePermission with persistent (project) rules — #6830 audit gap', () => {
+    it('auto-allowing via a PERSISTENT rule emits an audit-only permission_resolved with tool + persist + reason', async () => {
+      const resolvedEvents = []
+      pm.on('permission_resolved', (data) => resolvedEvents.push(data))
+      const requestEvents = []
+      pm.on('permission_request', (data) => requestEvents.push(data))
+      pm._persistentRules = [{ tool: 'Write', decision: 'allow' }]
+
+      const result = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
+      assert.equal(result.behavior, 'allow')
+      assert.equal(requestEvents.length, 0, 'no prompt was ever shown')
+      assert.equal(resolvedEvents.length, 1, 'the gap-fill audit signal must fire')
+      assert.equal(resolvedEvents[0].decision, 'allow')
+      assert.equal(resolvedEvents[0].reason, 'persisted_rule')
+      assert.equal(resolvedEvents[0].tool, 'Write')
+      assert.equal(resolvedEvents[0].persist, 'project')
+      assert.ok(resolvedEvents[0].requestId, 'needs a stable correlation key')
+      assert.match(resolvedEvents[0].requestId, /^rule-/)
+    })
+
+    it('a SESSION rule match does NOT emit the persisted-rule audit signal (session rules shadow persistent rules)', async () => {
+      const resolvedEvents = []
+      pm.on('permission_resolved', (data) => resolvedEvents.push(data))
+      pm.setRules([{ tool: 'Write', decision: 'allow' }])
+      pm._persistentRules = [{ tool: 'Write', decision: 'allow' }] // same tool, both sets
+
+      const result = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
+      assert.equal(result.behavior, 'allow')
+      assert.equal(resolvedEvents.length, 0, 'session rule wins precedence — no persisted-rule audit needed')
+    })
+
+    it('a persistent DENY rule match does not emit the (allow-only) audit signal', async () => {
+      const resolvedEvents = []
+      pm.on('permission_resolved', (data) => resolvedEvents.push(data))
+      pm._persistentRules = [{ tool: 'Write', decision: 'deny' }]
+
+      const result = await pm.handlePermission('Write', { file_path: '/tmp/x' }, null, 'approve')
+      assert.equal(result.behavior, 'deny')
+      assert.equal(resolvedEvents.length, 0)
+    })
+
+    it('_persistentRuleSourced reflects session-rule shadowing directly', () => {
+      pm._persistentRules = [{ tool: 'Read', decision: 'allow' }]
+      assert.equal(pm._persistentRuleSourced('Read'), true)
+      pm._sessionRules = [{ tool: 'Read', decision: 'deny' }]
+      assert.equal(pm._persistentRuleSourced('Read'), false, 'a session rule for the same tool shadows the persistent rule')
+    })
+  })
+
   // -- clearRules on mode change --
 
   describe('clearRules on mode change', () => {

--- a/packages/server/tests/permission-resolver.test.js
+++ b/packages/server/tests/permission-resolver.test.js
@@ -47,12 +47,19 @@ import { createPermissionResolver } from '../src/permission-resolver.js'
 const OWNER = 'sess-OWNER'
 const OTHER = 'sess-OTHER'
 
-function makeSdkSession({ pending = [] } = {}) {
+function makeSdkSession({ pending = [], lastPermissionData, persistentRules, cwd } = {}) {
   const set = new Set(pending)
-  return {
+  const session = {
     _pendingPermissions: { has: (id) => set.has(id) },
     respondToPermission: mock.fn((id) => { const had = set.has(id); set.delete(id); return had }),
   }
+  // #6830 — only wired when the test opts in, so pre-existing fixtures (no
+  // tool info at all) keep producing the exact same resolver.audit() call
+  // shape they always have.
+  if (lastPermissionData) session._lastPermissionData = lastPermissionData
+  if (persistentRules) session.getPersistentPermissionRules = () => persistentRules
+  if (cwd) session.cwd = cwd
+  return session
 }
 
 function build({ map = [], legacy = [], ownerSession } = {}) {
@@ -156,5 +163,91 @@ describe('permission-resolver — audit (D)', () => {
     const { resolver, audited } = build({ map: [['perm-8', OWNER]] })
     resolver.resolve('perm-8', 'allow', OTHER, { clientId: 'c1' })
     assert.equal(audited.length, 0)
+  })
+})
+
+// #6830 — the allowAlways audit entry omits the tool name and a durable-rule
+// marker (filed from PR #6826's security review). The resolver is the ONE
+// place both transports (WS via settings-handlers.js, HTTP via
+// ws-permissions.js) route their audit call through, so the tool/persist
+// capture belongs here.
+describe('permission-resolver — #6830 tool + persist enrichment', () => {
+  it('captures the tool name from _lastPermissionData BEFORE respondToPermission consumes it', () => {
+    const lastPermissionData = new Map([['perm-9', { tool: 'Read' }]])
+    const owner = makeSdkSession({ pending: ['perm-9'], lastPermissionData })
+    const { resolver, audited } = build({ map: [['perm-9', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-9', 'allow', null, { clientId: 'c1' })
+    assert.equal(audited.length, 1)
+    assert.equal(audited[0].tool, 'Read')
+    assert.equal(audited[0].persist, undefined, 'a plain allow never sets persist')
+  })
+
+  it('allowAlways that persisted a durable project rule carries tool + persist:"project" + projectKey', () => {
+    const lastPermissionData = new Map([['perm-10', { tool: 'Write' }]])
+    const owner = makeSdkSession({
+      pending: ['perm-10'],
+      lastPermissionData,
+      persistentRules: [{ tool: 'Write', decision: 'allow', persist: 'project' }],
+      cwd: '/abs/proj',
+    })
+    const { resolver, audited } = build({ map: [['perm-10', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-10', 'allowAlways', null, { clientId: 'c1' })
+    assert.equal(audited.length, 1)
+    assert.deepEqual(audited[0], {
+      clientId: 'c1',
+      sessionId: OWNER,
+      requestId: 'perm-10',
+      decision: 'allowAlways',
+      reason: 'user',
+      tool: 'Write',
+      persist: 'project',
+      projectKey: '/abs/proj',
+    })
+  })
+
+  it('allowAlways on a tool that degraded to a one-shot allow (nothing durable) carries tool but no persist marker', () => {
+    // e.g. Bash — NEVER_AUTO_ALLOW, so the rule store never persists it; the
+    // session's persistent set does NOT include it.
+    const lastPermissionData = new Map([['perm-11', { tool: 'Bash' }]])
+    const owner = makeSdkSession({
+      pending: ['perm-11'],
+      lastPermissionData,
+      persistentRules: [],
+      cwd: '/abs/proj',
+    })
+    const { resolver, audited } = build({ map: [['perm-11', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-11', 'allowAlways', null, { clientId: 'c1' })
+    assert.equal(audited.length, 1)
+    assert.equal(audited[0].tool, 'Bash')
+    assert.equal(audited[0].persist, undefined)
+    assert.equal(audited[0].projectKey, undefined)
+  })
+
+  it('a fixture with no tool info at all produces the exact pre-#6830 5-field audit shape (backwards compat)', () => {
+    const owner = makeSdkSession({ pending: ['perm-12'] })
+    const { resolver, audited } = build({ map: [['perm-12', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-12', 'deny', null, { clientId: 'http' })
+    assert.deepEqual(audited[0], { clientId: 'http', sessionId: OWNER, requestId: 'perm-12', decision: 'deny', reason: 'user' })
+  })
+
+  it('the legacy HTTP path captures tool from pendingPermissions.data BEFORE resolveLegacyPermission runs', () => {
+    const pendingPermissions = new Map([['perm-13', { data: { tool: 'Edit' } }]])
+    const audited = []
+    const resolver = createPermissionResolver({
+      permissionSessionMap: new Map(),
+      pendingPermissions,
+      getSessionManager: () => null,
+      resolveLegacyPermission: (requestId, decision) => {
+        // Mirrors ws-permissions.js: the entry is gone from pendingPermissions
+        // by the time resolveLegacyPermission's caller-side cleanup runs.
+        pendingPermissions.delete(requestId)
+      },
+      getPermissionAudit: () => ({ logDecision: (e) => audited.push(e) }),
+    })
+    const r = resolver.resolve('perm-13', 'allow', null, { clientId: 'http' })
+    assert.equal(r.kind, 'resolved')
+    assert.equal(r.via, 'legacy')
+    assert.equal(audited[0].tool, 'Edit')
+    assert.equal(audited[0].persist, undefined, 'legacy sessions have no durable-rule concept')
   })
 })

--- a/packages/server/tests/permission-resolver.test.js
+++ b/packages/server/tests/permission-resolver.test.js
@@ -43,6 +43,7 @@ import assert from 'node:assert/strict'
  */
 
 import { createPermissionResolver } from '../src/permission-resolver.js'
+import { normalizeProjectKey } from '../src/permission-rule-store.js'
 
 const OWNER = 'sess-OWNER'
 const OTHER = 'sess-OTHER'
@@ -203,6 +204,25 @@ describe('permission-resolver — #6830 tool + persist enrichment', () => {
       persist: 'project',
       projectKey: '/abs/proj',
     })
+  })
+
+  it('allowAlways projectKey is the store\'s NORMALIZED key, not the raw ..-laden session cwd (#6842 review)', () => {
+    // A session started with a trailing-slash / `..`-laden cwd. The store keys
+    // rules by normalizeProjectKey(cwd) — the audit entry must carry that SAME
+    // key or an auditor can never correlate entry ↔ persisted rule.
+    const messyCwd = '/abs/proj/sub/../'
+    const lastPermissionData = new Map([['perm-norm', { tool: 'Write' }]])
+    const owner = makeSdkSession({
+      pending: ['perm-norm'],
+      lastPermissionData,
+      persistentRules: [{ tool: 'Write', decision: 'allow', persist: 'project' }],
+      cwd: messyCwd,
+    })
+    const { resolver, audited } = build({ map: [['perm-norm', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-norm', 'allowAlways', null, { clientId: 'c1' })
+    assert.equal(audited.length, 1)
+    assert.equal(audited[0].projectKey, '/abs/proj', 'collapsed to the resolved absolute path')
+    assert.equal(audited[0].projectKey, normalizeProjectKey(messyCwd), 'exactly the store\'s key for this cwd')
   })
 
   it('allowAlways on a tool that degraded to a one-shot allow (nothing durable) carries tool but no persist marker', () => {

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -247,6 +247,31 @@ describe('#6771 PermissionManager + durable rules', () => {
     }
   })
 
+  // #6830 — end-to-end (real PermissionRuleStore, not a hand-set _persistentRules
+  // array): a rule seeded from disk auto-approving a tool call must leave a
+  // trace in the audit pipeline (an auditor can't answer "why did tool X
+  // auto-approve after a restart?" otherwise — no prompt, no requestId, no
+  // permission_resolved at all pre-#6830).
+  it('a store-seeded persistent rule auto-approve emits the audit-only permission_resolved signal', async () => {
+    const store = makeStore()
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
+
+    const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
+    try {
+      const resolvedEvents = []
+      pm.on('permission_resolved', (d) => resolvedEvents.push(d))
+      const result = await pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(result.behavior, 'allow')
+      assert.equal(resolvedEvents.length, 1)
+      assert.equal(resolvedEvents[0].reason, 'persisted_rule')
+      assert.equal(resolvedEvents[0].tool, 'Write')
+      assert.equal(resolvedEvents[0].persist, 'project')
+      assert.equal(resolvedEvents[0].projectKey, '/proj/a')
+    } finally {
+      pm.destroy()
+    }
+  })
+
   it('a different cwd does NOT inherit another project\'s persistent rules', async () => {
     const store = makeStore()
     store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { PermissionRuleStore, normalizeProjectKey, isPersistableTool } from '../src/permission-rule-store.js'
 import { PermissionManager } from '../src/permission-manager.js'
+import { PermissionAuditLog } from '../src/permission-audit.js'
 
 /**
  * #6771 — durable "always allow" permission rules.
@@ -247,26 +248,39 @@ describe('#6771 PermissionManager + durable rules', () => {
     }
   })
 
-  // #6830 — end-to-end (real PermissionRuleStore, not a hand-set _persistentRules
-  // array): a rule seeded from disk auto-approving a tool call must leave a
-  // trace in the audit pipeline (an auditor can't answer "why did tool X
-  // auto-approve after a restart?" otherwise — no prompt, no requestId, no
-  // permission_resolved at all pre-#6830).
-  it('a store-seeded persistent rule auto-approve emits the audit-only permission_resolved signal', async () => {
+  // #6830 (PR #6842 review) — end-to-end with a real PermissionRuleStore AND a
+  // real PermissionAuditLog wired the way ws-server's
+  // _attachPermissionAuditSink does it: a rule seeded from disk silently
+  // auto-approving N=50 tool calls must (a) put ZERO events on the wire lane
+  // (no permission_resolved, no permission_request — those broadcast to every
+  // client) and (b) land as ONE coalesced audit entry, not 50 ring slots.
+  it('a store-seeded persistent rule auto-approve is audited via the sink — one coalesced entry, zero wire events', async () => {
     const store = makeStore()
     store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })
 
+    const auditLog = new PermissionAuditLog()
     const pm = new PermissionManager({ log: silentLog, cwd: '/proj/a', ruleStore: store })
     try {
-      const resolvedEvents = []
-      pm.on('permission_resolved', (d) => resolvedEvents.push(d))
-      const result = await pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
-      assert.equal(result.behavior, 'allow')
-      assert.equal(resolvedEvents.length, 1)
-      assert.equal(resolvedEvents[0].reason, 'persisted_rule')
-      assert.equal(resolvedEvents[0].tool, 'Write')
-      assert.equal(resolvedEvents[0].persist, 'project')
-      assert.equal(resolvedEvents[0].projectKey, '/proj/a')
+      // Same wiring shape as ws-server.js _attachPermissionAuditSink.
+      pm.setAuditSink((info) => auditLog.logPersistedRuleApproval({ sessionId: 's1', tool: info?.tool, projectKey: info?.projectKey ?? null }))
+      const wireEvents = []
+      pm.on('permission_resolved', (d) => wireEvents.push(d))
+      pm.on('permission_request', (d) => wireEvents.push(d))
+
+      for (let i = 0; i < 50; i++) {
+        const result = await pm.handlePermission('Write', { file_path: `src/x${i}.js` }, null, 'approve')
+        assert.equal(result.behavior, 'allow')
+      }
+
+      assert.equal(wireEvents.length, 0, 'zero broadcast-lane emissions across 50 silent auto-approves')
+      const entries = auditLog.query({ type: 'decision' })
+      assert.equal(entries.length, 1, 'one coalesced entry — the ring is never flooded')
+      assert.equal(entries[0].count, 50)
+      assert.equal(entries[0].reason, 'persisted_rule')
+      assert.equal(entries[0].tool, 'Write')
+      assert.equal(entries[0].persist, 'project')
+      assert.equal(entries[0].projectKey, '/proj/a')
+      assert.equal(entries[0].sessionId, 's1')
     } finally {
       pm.destroy()
     }

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -286,6 +286,33 @@ describe('#6771 PermissionManager + durable rules', () => {
     }
   })
 
+  // #6842 review (Copilot) — a session started with a `..`-laden / trailing-
+  // slash cwd must produce persisted-rule audit entries whose projectKey is
+  // EXACTLY the store's normalized key (the key in permission-rules.json),
+  // not the raw cwd — otherwise entry ↔ rule correlation is impossible.
+  it('sink-path projectKey matches the store\'s NORMALIZED key for a ..-laden session cwd', async () => {
+    const messyCwd = '/proj/a/sub/..'
+    const store = makeStore()
+    store.addRule(messyCwd, { tool: 'Write', decision: 'allow' })
+    const storeKeys = Object.keys(store.listProjects())
+    assert.deepEqual(storeKeys, ['/proj/a'], 'precondition: the store keyed the rule by the normalized cwd')
+
+    const auditLog = new PermissionAuditLog()
+    const pm = new PermissionManager({ log: silentLog, cwd: messyCwd, ruleStore: store })
+    try {
+      pm.setAuditSink((info) => auditLog.logPersistedRuleApproval({ sessionId: 's1', tool: info?.tool, projectKey: info?.projectKey ?? null }))
+      const result = await pm.handlePermission('Write', { file_path: 'src/x.js' }, null, 'approve')
+      assert.equal(result.behavior, 'allow', 'seeding via the messy cwd still matches the persisted rule')
+
+      const entries = auditLog.query({ type: 'decision' })
+      assert.equal(entries.length, 1)
+      assert.equal(entries[0].projectKey, storeKeys[0], 'audit projectKey === the persisted rule\'s store key, exactly')
+      assert.equal(entries[0].projectKey, normalizeProjectKey(messyCwd))
+    } finally {
+      pm.destroy()
+    }
+  })
+
   it('a different cwd does NOT inherit another project\'s persistent rules', async () => {
     const store = makeStore()
     store.addRule('/proj/a', { tool: 'Write', decision: 'allow' })

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1836,6 +1836,36 @@ describe('audit trail for auto-deny resolution paths (#3057)', () => {
     )
   })
 
+  // #6830 — a persisted-rule auto-approve (permission-manager.js
+  // _auditPersistedRuleAutoApprove) reaches this same listener as a
+  // permission_resolved session_event with reason:'persisted_rule' and no
+  // human responder (clientId stays null, matching the other auto-* reasons).
+  // The tool/persist/projectKey fields must pass through into the stored entry.
+  it('records tool/persist/projectKey for a persisted-rule auto-approve (#6830)', () => {
+    const manager = makeManager()
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    manager.emit('session_event', {
+      sessionId: 'sess-x',
+      event: 'permission_resolved',
+      data: {
+        requestId: 'rule-abc-1-123',
+        decision: 'allow',
+        reason: 'persisted_rule',
+        tool: 'Write',
+        persist: 'project',
+        projectKey: '/abs/proj',
+      },
+    })
+
+    const entries = server._permissionAudit.query({ type: 'decision' })
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0].clientId, null, 'no human responder for a rule-driven auto-approve')
+    assert.equal(entries[0].tool, 'Write')
+    assert.equal(entries[0].persist, 'project')
+    assert.equal(entries[0].projectKey, '/abs/proj')
+  })
+
   it('skips user-initiated resolutions to avoid double-auditing the inline WS path', () => {
     const manager = makeManager()
     server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -1836,34 +1836,48 @@ describe('audit trail for auto-deny resolution paths (#3057)', () => {
     )
   })
 
-  // #6830 — a persisted-rule auto-approve (permission-manager.js
-  // _auditPersistedRuleAutoApprove) reaches this same listener as a
-  // permission_resolved session_event with reason:'persisted_rule' and no
-  // human responder (clientId stays null, matching the other auto-* reasons).
-  // The tool/persist/projectKey fields must pass through into the stored entry.
-  it('records tool/persist/projectKey for a persisted-rule auto-approve (#6830)', () => {
+  // #6830 (PR #6842 review) — persisted-rule auto-approves bypass the
+  // session-event broadcast lane entirely: the WsServer wires a direct sink
+  // (session.setPermissionAuditSink → logPersistedRuleApproval) on
+  // session_created, and the log coalesces repeats so tool-call-speed
+  // matches can never flood the ring.
+  it('attaches a coalescing persisted-rule audit sink on session_created (#6830)', () => {
     const manager = makeManager()
+    let sink = null
+    const session = { setPermissionAuditSink: (fn) => { sink = fn } }
+    manager.getSession = (id) => (id === 'sess-x' ? { session } : null)
     server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
 
-    manager.emit('session_event', {
-      sessionId: 'sess-x',
-      event: 'permission_resolved',
-      data: {
-        requestId: 'rule-abc-1-123',
-        decision: 'allow',
-        reason: 'persisted_rule',
-        tool: 'Write',
-        persist: 'project',
-        projectKey: '/abs/proj',
-      },
-    })
+    manager.emit('session_created', { sessionId: 'sess-x' })
+    assert.equal(typeof sink, 'function', 'sink wired on session_created')
+
+    // N=50 rule-matched approvals → ONE coalesced audit entry, count 50.
+    for (let i = 0; i < 50; i++) sink({ tool: 'Write', projectKey: '/proj/a' })
 
     const entries = server._permissionAudit.query({ type: 'decision' })
-    assert.equal(entries.length, 1)
-    assert.equal(entries[0].clientId, null, 'no human responder for a rule-driven auto-approve')
+    assert.equal(entries.length, 1, 'coalesced — the ring is never flooded')
+    assert.equal(entries[0].count, 50)
+    assert.equal(entries[0].sessionId, 'sess-x')
     assert.equal(entries[0].tool, 'Write')
     assert.equal(entries[0].persist, 'project')
-    assert.equal(entries[0].projectKey, '/abs/proj')
+    assert.equal(entries[0].projectKey, '/proj/a')
+    assert.equal(entries[0].reason, 'persisted_rule')
+    assert.equal(entries[0].clientId, null, 'no human responder for a rule-driven auto-approve')
+  })
+
+  it('attaches the audit sink retroactively to sessions restored before WsServer construction (#6830)', () => {
+    const manager = makeManager()
+    let sink = null
+    const session = { setPermissionAuditSink: (fn) => { sink = fn } }
+    manager._sessions = new Map([['sess-restored', { session }]])
+    manager.getSession = (id) => (id === 'sess-restored' ? { session } : null)
+    server = new WsServer({ port: 0, apiToken: 'test-token', sessionManager: manager })
+
+    assert.equal(typeof sink, 'function', 'retroactive scan wires restored sessions (same shape as #3716)')
+    sink({ tool: 'Read', projectKey: '/proj/b' })
+    const entries = server._permissionAudit.query({ type: 'decision' })
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0].sessionId, 'sess-restored')
   })
 
   it('skips user-initiated resolutions to avoid double-auditing the inline WS path', () => {


### PR DESCRIPTION
## Summary

- `allowAlways` audit entries now carry the tool name and, when a durable project rule was actually persisted, `persist: 'project'` + `projectKey` (the normalized project cwd). Previously the entry recorded only `{ decision, requestId, reason }` — an auditor had no way to answer "why did this auto-approve?" once `_lastPermissionData` was gone.
- A tool call silently auto-approved by an already-persisted project rule (no prompt, no requestId minted) now emits an audit-only entry (`reason: 'persisted_rule'`, `tool`, `persist: 'project'`, `projectKey`, `clientId: null`) so the audit log has a trace of it at all. A same-tool **session** rule still shadows the persistent rule and produces no extra entry (it's an explicit, non-durable decision the user already made this session).
- Dashboard's `describePermissionAuditEntry` renders the enriched shapes: tool name appended to `Allowed`/`Denied`, `Always-allowed X — saved as a project rule` vs `Always-allowed X (not saved — one-time only)` for a degraded (e.g. `Bash`) `allowAlways`, and a distinct `Auto-allowed X (persisted rule)` label for the new persisted-rule signal.

## Changes

- `packages/server/src/permission-audit.js` — `logDecision` accepts optional `tool`/`persist`/`projectKey`, defaulting to `null` (backwards compatible).
- `packages/server/src/permission-resolver.js` — captures the tool name from `_lastPermissionData` (SDK path) / `pendingPermissions.data` (legacy HTTP path) **before** it's consumed by `respondToPermission`/`resolveLegacyPermission`, and detects whether an `allowAlways` actually persisted a durable rule via `getPersistentPermissionRules()`. Enrichment fields are **omitted** (not passed as `null`) when unknown, so existing exact-shape test fixtures are unaffected.
- `packages/server/src/permission-manager.js` — new `_persistentRuleSourced` (mirrors `_matchesRule`'s session-then-persistent precedence without changing its tested return contract) and `_auditPersistedRuleAutoApprove` (emits the existing `permission_resolved` event with a synthetic `rule-` prefixed id, purely for audit correlation — never registered as a pending permission).
- `packages/server/src/ws-server.js` — the `_sessionEventAuditHandler` now passes `tool`/`persist`/`projectKey` through into the stored entry.
- `packages/protocol/src/schemas/server/stream.ts` (+ regenerated `dist/`) — documents the three new optional/nullable fields on `ServerPermissionAuditEntrySchema`. Still `.passthrough()`, so this is additive/non-breaking.
- `packages/dashboard/src/store/types.ts` + `SettingsPanel.tsx` — `PermissionAuditEntry` type and `describePermissionAuditEntry` updated.

## Test plan

- [x] `packages/server/tests/permission-audit.test.js` — `logDecision` stores/defaults tool/persist/projectKey
- [x] `packages/server/tests/permission-resolver.test.js` — tool capture (SDK + legacy paths), allowAlways persisted vs degraded, backwards-compat 5-field shape
- [x] `packages/server/tests/permission-manager.test.js` — persistent-rule auto-approve emits the audit signal; session-rule match does not; deny rule does not
- [x] `packages/server/tests/permission-rule-store.test.js` — end-to-end with a real `PermissionRuleStore`
- [x] `packages/server/tests/ws-server-permissions.test.js` — `tool`/`persist`/`projectKey` pass through the session_event listener
- [x] `packages/dashboard/src/components/SettingsPanel.test.tsx` — `describePermissionAuditEntry` renders all enriched shapes
- [x] Full permission-related server suite (562 tests across 30 files) + sdk-session/byok-session/codex-app-server-session/edited-input-merge suites (414 tests) green
- [x] `packages/server/scripts/lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` (+ the other 3 lint-*.sh) green
- [x] `packages/protocol` test suite (362 tests) green; `npm run build` regenerated `dist/`
- [x] `packages/dashboard` `tsc --noEmit` clean; `vitest run SettingsPanel.test.tsx` (174 tests) green

Closes #6830