### PR TITLE
feat(server,dashboard,app): per-server MCP enable/disable (#6824)

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable, ScrollView, Switch } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { resolveContextWindow, contextOccupancyTokens, contextFillPercent } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm, SessionIntervention } from '@chroxy/store-core';
@@ -75,6 +75,10 @@ export interface SettingsBarProps {
   customAgents: CustomAgent[];
   mcpServers: McpServer[];
   onInvokeAgent?: (agentName: string) => void;
+  // #6824 — toggle an MCP server on/off for the active session. Only invoked
+  // for servers that report `canToggle` (the BYOK lane). Absent → the MCP list
+  // stays read-only (matches sdk/cli/tui providers).
+  onToggleMcpServer?: (server: string, enabled: boolean) => void;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
   pendingPermissionConfirm?: PendingPermissionConfirm | null;
@@ -206,6 +210,7 @@ export function SettingsBar({
   customAgents,
   mcpServers,
   onInvokeAgent,
+  onToggleMcpServer,
   setModel,
   setPermissionMode,
   pendingPermissionConfirm,
@@ -697,17 +702,35 @@ export function SettingsBar({
               <Text style={styles.deviceSectionTitle}>
                 MCP Servers ({mcpServers.length})
               </Text>
-              {mcpServers.map((server) => (
-                <View key={server.name} style={styles.agentEntry}>
-                  <View style={[styles.statusDot, { backgroundColor: server.status === 'connected' ? COLORS.accentGreen : COLORS.textMuted }]} />
-                  <Text style={styles.agentDescription} numberOfLines={1}>
-                    {server.name}
-                  </Text>
-                  <Text style={styles.agentElapsed}>
-                    {server.status}
-                  </Text>
-                </View>
-              ))}
+              {mcpServers.map((server) => {
+                // #6824: a server is "on" unless parked. Prefer the explicit
+                // `enabled` flag (BYOK emits it); fall back to status so a
+                // pre-#6824 payload still reads sensibly. The Switch renders
+                // only when the server reports `canToggle` (BYOK lane) and the
+                // parent wired an onToggle handler — otherwise read-only.
+                const enabled = typeof server.enabled === 'boolean' ? server.enabled : server.status !== 'disabled';
+                const canToggle = !!server.canToggle && !!onToggleMcpServer;
+                return (
+                  <View key={server.name} style={styles.agentEntry}>
+                    <View style={[styles.statusDot, { backgroundColor: server.status === 'connected' ? COLORS.accentGreen : COLORS.textMuted }]} />
+                    <Text style={styles.agentDescription} numberOfLines={1}>
+                      {server.name}
+                    </Text>
+                    {canToggle ? (
+                      <Switch
+                        testID={`mcp-server-toggle-${server.name}`}
+                        value={enabled}
+                        onValueChange={(next) => onToggleMcpServer?.(server.name, next)}
+                        accessibilityLabel={`${enabled ? 'Disable' : 'Enable'} MCP server ${server.name}`}
+                      />
+                    ) : (
+                      <Text style={styles.agentElapsed}>
+                        {server.status}
+                      </Text>
+                    )}
+                  </View>
+                );
+              })}
             </View>
           )}
           {customAgents.length > 0 && (

--- a/packages/app/src/components/__tests__/SettingsBarMcpToggle.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarMcpToggle.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Render tests for the mobile SettingsBar MCP enable/disable toggle (#6824).
+ *
+ * The MCP section lists configured servers; when a server reports `canToggle`
+ * (the BYOK lane) and the parent wires `onToggleMcpServer`, the row renders a
+ * Switch. Toggling it calls the handler with (serverName, nextEnabled).
+ * Servers without `canToggle` (sdk/cli/tui) stay read-only.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Switch } from 'react-native';
+import { SettingsBar } from '../SettingsBar';
+import type { McpServer } from '@chroxy/store-core';
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    expanded: true,
+    onToggle: () => {},
+    activeModel: 'claude-opus-4-8',
+    availableModels: [],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextOccupancy: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [] as McpServer[],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+function findSwitchByTestId(root: ReactTestInstance, testID: string): ReactTestInstance | null {
+  return root.findAllByType(Switch).find((n) => n.props.testID === testID) ?? null;
+}
+
+describe('SettingsBar MCP enable/disable toggle (#6824)', () => {
+  it('renders a Switch for a canToggle server and calls onToggleMcpServer on change', () => {
+    const onToggle = jest.fn();
+    const servers: McpServer[] = [{ name: 'filesystem', status: 'connected', enabled: true, canToggle: true }];
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: servers, onToggleMcpServer: onToggle })} />);
+    });
+    const sw = findSwitchByTestId(tree.root, 'mcp-server-toggle-filesystem');
+    expect(sw).not.toBeNull();
+    expect(sw!.props.value).toBe(true);
+
+    act(() => { sw!.props.onValueChange(false); });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith('filesystem', false);
+  });
+
+  it('reflects a disabled server as an off Switch', () => {
+    const servers: McpServer[] = [{ name: 'gh', status: 'disabled', enabled: false, canToggle: true }];
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: servers, onToggleMcpServer: () => {} })} />);
+    });
+    const sw = findSwitchByTestId(tree.root, 'mcp-server-toggle-gh');
+    expect(sw).not.toBeNull();
+    expect(sw!.props.value).toBe(false);
+  });
+
+  it('does NOT render a Switch for a read-only (non-canToggle) server', () => {
+    const servers: McpServer[] = [{ name: 'readonly', status: 'connected' }];
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: servers, onToggleMcpServer: () => {} })} />);
+    });
+    expect(findSwitchByTestId(tree.root, 'mcp-server-toggle-readonly')).toBeNull();
+  });
+
+  it('does NOT render a Switch when the parent wired no onToggleMcpServer handler', () => {
+    const servers: McpServer[] = [{ name: 'filesystem', status: 'connected', enabled: true, canToggle: true }];
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: servers })} />);
+    });
+    expect(findSwitchByTestId(tree.root, 'mcp-server-toggle-filesystem')).toBeNull();
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -248,6 +248,7 @@ export function SessionScreen() {
   const updateInputSettings = useConnectionStore((s) => s.updateInputSettings);
   const setModel = useConnectionStore((s) => s.setModel);
   const setPermissionMode = useConnectionStore((s) => s.setPermissionMode);
+  const setMcpServerEnabled = useConnectionStore((s) => s.setMcpServerEnabled);
   const confirmPermissionMode = useConnectionStore((s) => s.confirmPermissionMode);
   const cancelPermissionConfirm = useConnectionStore((s) => s.cancelPermissionConfirm);
   const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse);
@@ -1296,6 +1297,7 @@ export function SessionScreen() {
           customAgents={customAgents}
           mcpServers={mcpServers}
           onInvokeAgent={handleInvokeAgent}
+          onToggleMcpServer={setMcpServerEnabled}
           setModel={setModel}
           setPermissionMode={setPermissionMode}
           pendingPermissionConfirm={pendingPermissionConfirm}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -2161,6 +2161,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     sendIfOpen(payload);
   },
 
+  // #6824 — enable/disable an already-configured MCP server for the active
+  // session (BYOK lane). Broadcast-driven: the server re-emits `mcp_servers`
+  // with the new per-server status on success, which the SettingsBar switch
+  // reflects — no optimistic mutation, so a rejection just never moves the
+  // switch. A `requestId` correlates a rejection in the server log. Gated on
+  // the server's `canToggle` flag at the call site (only BYOK sets it).
+  setMcpServerEnabled: (server: string, enabled: boolean) => {
+    const { activeSessionId } = get();
+    const payload: Record<string, unknown> = {
+      type: 'set_mcp_server_enabled',
+      server,
+      enabled,
+      requestId: `set-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    sendIfOpen(payload);
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId, sessionStates } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -572,6 +572,12 @@ export interface ModelsAndPermissionsActions {
   // #6771 — replace the durable per-project ("always allow") rule set for the
   // active session's project cwd (SessionRules screen removal path).
   setProjectPermissionRules: (projectRules: PermissionRule[]) => void;
+  // #6824 — enable/disable an already-configured MCP server for the active
+  // session (BYOK lane). Sends `set_mcp_server_enabled`; the server re-emits
+  // `mcp_servers` on success so the SettingsBar switch converges from the
+  // broadcast (no optimistic mutation to roll back). The toggle is gated on the
+  // server's `canToggle` flag so this only reaches a provider that supports it.
+  setMcpServerEnabled: (server: string, enabled: boolean) => void;
 }
 
 /**

--- a/packages/dashboard/src/components/SidebarMcpView.test.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.test.tsx
@@ -3,25 +3,36 @@
  * panel slot, the desktop analogue of the mobile SettingsBar section.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, cleanup, screen } from '@testing-library/react'
+import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import type { McpServer } from '@chroxy/store-core'
 import { SidebarMcpView, mcpViewCollapsedMetric } from './SidebarMcpView'
 
 // Mock the store so the fallback path (no `servers` prop) is deterministic.
 // Tests that pass `servers` directly never touch it. The variable is prefixed
-// `mock` so vitest allows it inside the hoisted factory.
-let mockStoreState: Record<string, unknown> = { activeSessionId: null, sessionStates: {} }
+// `mock` so vitest allows it inside the hoisted factory. #6824 — the component
+// also selects `setMcpServerEnabled`, so the state carries a spy.
+const mockSetMcpServerEnabled = vi.fn()
+let mockStoreState: Record<string, unknown> = {
+  activeSessionId: null,
+  sessionStates: {},
+  setMcpServerEnabled: mockSetMcpServerEnabled,
+}
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockStoreState),
 }))
 
 afterEach(() => {
   cleanup()
-  mockStoreState = { activeSessionId: null, sessionStates: {} }
+  mockSetMcpServerEnabled.mockClear()
+  mockStoreState = { activeSessionId: null, sessionStates: {}, setMcpServerEnabled: mockSetMcpServerEnabled }
 })
 
 function srv(name: string, status: string): McpServer {
   return { name, status }
+}
+
+function toggleSrv(name: string, status: string, enabled: boolean): McpServer {
+  return { name, status, enabled, canToggle: true }
 }
 
 describe('SidebarMcpView (#6820)', () => {
@@ -61,6 +72,43 @@ describe('SidebarMcpView (#6820)', () => {
   it('renders empty when the store has no active session', () => {
     render(<SidebarMcpView />)
     expect(screen.getByTestId('sidebar-mcp-view-empty')).toBeTruthy()
+  })
+})
+
+describe('SidebarMcpView enable/disable toggle (#6824)', () => {
+  it('does NOT render a toggle for a read-only (non-canToggle) server', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    expect(screen.queryByTestId('sidebar-mcp-view-toggle-filesystem')).toBeNull()
+  })
+
+  it('renders a toggle reflecting enabled state when the server reports canToggle', () => {
+    render(<SidebarMcpView servers={[toggleSrv('fs', 'connected', true), toggleSrv('gh', 'disabled', false)]} />)
+    const on = screen.getByTestId('sidebar-mcp-view-toggle-fs')
+    const off = screen.getByTestId('sidebar-mcp-view-toggle-gh')
+    expect(on.getAttribute('aria-checked')).toBe('true')
+    expect(on.textContent).toBe('On')
+    expect(off.getAttribute('aria-checked')).toBe('false')
+    expect(off.textContent).toBe('Off')
+  })
+
+  it('clicking an enabled toggle calls setMcpServerEnabled(name, false)', () => {
+    render(<SidebarMcpView servers={[toggleSrv('fs', 'connected', true)]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-toggle-fs'))
+    expect(mockSetMcpServerEnabled).toHaveBeenCalledTimes(1)
+    expect(mockSetMcpServerEnabled).toHaveBeenCalledWith('fs', false)
+  })
+
+  it('clicking a disabled toggle calls setMcpServerEnabled(name, true)', () => {
+    render(<SidebarMcpView servers={[toggleSrv('gh', 'disabled', false)]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-toggle-gh'))
+    expect(mockSetMcpServerEnabled).toHaveBeenCalledWith('gh', true)
+  })
+
+  it('falls back to status when `enabled` is absent (pre-#6824 payload with canToggle)', () => {
+    // canToggle but no explicit `enabled` → derive from status.
+    render(<SidebarMcpView servers={[{ name: 'legacy', status: 'disabled', canToggle: true }]} />)
+    const t = screen.getByTestId('sidebar-mcp-view-toggle-legacy')
+    expect(t.getAttribute('aria-checked')).toBe('false')
   })
 })
 

--- a/packages/dashboard/src/components/SidebarMcpView.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.tsx
@@ -1,11 +1,10 @@
 /**
- * SidebarMcpView (#6820) — read-only MCP server list in the sidebar panel slot.
+ * SidebarMcpView (#6820) — MCP server list in the sidebar panel slot.
  *
  * The desktop analogue of the mobile app's `SettingsBar.tsx` "MCP Servers (N)"
  * section: it renders the active session's `mcpServers` store field (already
  * carried in `connection.ts`, written by the `mcp_servers` broadcast handler)
- * as a status dot + name + status text per server. Purely informational — no
- * enable/disable affordance (that's #6824).
+ * as a status dot + name + status text per server.
  *
  * Status semantics mirror the mobile pattern: the dot is green only when a
  * server reports `connected` (a live status from an sdk/cli-mode session),
@@ -13,6 +12,13 @@
  * declares the server but the PTY exposes no live connection status), which
  * renders muted — honest about the difference between "connected" and
  * "declared in config".
+ *
+ * #6824 — per-server enable/disable toggle. Rendered ONLY when the server
+ * reports `canToggle` (the BYOK lane, which runs an in-daemon MCP fleet);
+ * sdk/cli/tui servers stay read-only. Toggling sends `set_mcp_server_enabled`;
+ * the switch is broadcast-driven (it reflects the server's re-emitted
+ * `mcp_servers` state, not an optimistic guess), so a rejected toggle simply
+ * never moves rather than flashing a wrong state.
  */
 import { useConnectionStore } from '../store/connection'
 import type { McpServer } from '@chroxy/store-core'
@@ -20,6 +26,14 @@ import type { McpServer } from '@chroxy/store-core'
 // Module-level stable empty array so the store selector's fallback keeps a
 // referentially-stable identity (avoids needless re-renders / render loops).
 const EMPTY_MCP_SERVERS: McpServer[] = []
+
+// #6824: a server is "on" when it isn't parked. Prefer the explicit `enabled`
+// flag (BYOK emits it); fall back to the status so a pre-#6824 payload (no
+// `enabled`) still reads sensibly.
+function isServerEnabled(server: McpServer): boolean {
+  if (typeof server.enabled === 'boolean') return server.enabled
+  return server.status !== 'disabled'
+}
 
 export interface SidebarMcpViewProps {
   /**
@@ -36,6 +50,7 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
     const id = s.activeSessionId
     return id && s.sessionStates[id] ? s.sessionStates[id].mcpServers : EMPTY_MCP_SERVERS
   })
+  const setMcpServerEnabled = useConnectionStore((s) => s.setMcpServerEnabled)
   const servers = serversProp ?? storeServers
 
   return (
@@ -48,6 +63,7 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
         <ul className="sidebar-mcp-view-list" data-testid="sidebar-mcp-view-list">
           {servers.map((server) => {
             const connected = server.status === 'connected'
+            const enabled = isServerEnabled(server)
             return (
               <li
                 key={server.name}
@@ -66,6 +82,20 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
                 <span className="sidebar-mcp-view-status" data-testid={`sidebar-mcp-view-status-${server.name}`}>
                   {server.status}
                 </span>
+                {server.canToggle && (
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={enabled}
+                    className={`sidebar-mcp-view-toggle${enabled ? ' enabled' : ''}`}
+                    data-testid={`sidebar-mcp-view-toggle-${server.name}`}
+                    aria-label={`${enabled ? 'Disable' : 'Enable'} MCP server ${server.name}`}
+                    title={enabled ? 'Disable server' : 'Enable server'}
+                    onClick={() => setMcpServerEnabled(server.name, !enabled)}
+                  >
+                    {enabled ? 'On' : 'Off'}
+                  </button>
+                )}
               </li>
             )
           })}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3320,13 +3320,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // toggle to the truth (no optimistic store mutation → no stale state to roll
   // back on a rejection). A `requestId` is attached so a rejection correlates
   // in the server log; capability rejections never reach here because the
-  // toggle is gated on `server.canToggle`. Returns false when the socket is
-  // closed / there's no active session so the caller can surface an error.
-  setMcpServerEnabled: (server: string, enabled: boolean): boolean => {
+  // toggle is gated on `server.canToggle`. No-op when the socket is closed or
+  // there is no active session — mirrors setPermissionRules' silent guard.
+  setMcpServerEnabled: (server: string, enabled: boolean) => {
     const { socket, activeSessionId } = get();
-    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) return false;
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) return;
     const requestId = `set-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    return wsSend(socket, {
+    wsSend(socket, {
       type: 'set_mcp_server_enabled',
       sessionId: activeSessionId,
       server,

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3314,6 +3314,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
+  // #6824 — enable/disable an already-configured MCP server for the active
+  // session (BYOK lane). Broadcast-driven: the server re-emits `mcp_servers`
+  // with the new per-server status on success, which drives the SidebarMcpView
+  // toggle to the truth (no optimistic store mutation → no stale state to roll
+  // back on a rejection). A `requestId` is attached so a rejection correlates
+  // in the server log; capability rejections never reach here because the
+  // toggle is gated on `server.canToggle`. Returns false when the socket is
+  // closed / there's no active session so the caller can surface an error.
+  setMcpServerEnabled: (server: string, enabled: boolean): boolean => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) return false;
+    const requestId = `set-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    return wsSend(socket, {
+      type: 'set_mcp_server_enabled',
+      sessionId: activeSessionId,
+      server,
+      enabled,
+      requestId,
+    });
+  },
+
   // #6772 — pull the permission audit history for the active session. Sets the
   // loading flag; the reply (`permission_audit_result`) lands in `permissionAudit`
   // (handlePermissionAuditResult). The server filters by sessionId when provided.

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2091,6 +2091,47 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(msg!.projectRules).toEqual([{ tool: 'Edit', decision: 'allow' }]);
   });
 
+  // #6824 — per-server MCP enable/disable action.
+  it('setMcpServerEnabled sends set_mcp_server_enabled scoped to the active session', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = { readyState: 1, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState() } },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    const ok = useConnectionStore.getState().setMcpServerEnabled('filesystem', false);
+    expect(ok).toBe(true);
+
+    const msg = sent.find((m) => m.type === 'set_mcp_server_enabled');
+    expect(msg).toBeDefined();
+    expect(msg!.sessionId).toBe('s1');
+    expect(msg!.server).toBe('filesystem');
+    expect(msg!.enabled).toBe(false);
+    expect(typeof msg!.requestId).toBe('string');
+  });
+
+  it('setMcpServerEnabled returns false and sends nothing when the socket is closed', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = { readyState: 3, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState() } },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    const ok = useConnectionStore.getState().setMcpServerEnabled('filesystem', true);
+    expect(ok).toBe(false);
+    expect(sent.find((m) => m.type === 'set_mcp_server_enabled')).toBeUndefined();
+  });
+
   it('queryPermissionAudit sets the loading flag and sends query_permission_audit scoped to the active session', async () => {
     const { useConnectionStore } = await import('./connection');
 

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2104,8 +2104,7 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
       socket: mockSocket as unknown as WebSocket,
     });
 
-    const ok = useConnectionStore.getState().setMcpServerEnabled('filesystem', false);
-    expect(ok).toBe(true);
+    useConnectionStore.getState().setMcpServerEnabled('filesystem', false);
 
     const msg = sent.find((m) => m.type === 'set_mcp_server_enabled');
     expect(msg).toBeDefined();
@@ -2115,7 +2114,7 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(typeof msg!.requestId).toBe('string');
   });
 
-  it('setMcpServerEnabled returns false and sends nothing when the socket is closed', async () => {
+  it('setMcpServerEnabled sends nothing when the socket is closed (silent no-op, mirrors setPermissionRules)', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');
 
@@ -2127,8 +2126,7 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
       socket: mockSocket as unknown as WebSocket,
     });
 
-    const ok = useConnectionStore.getState().setMcpServerEnabled('filesystem', true);
-    expect(ok).toBe(false);
+    useConnectionStore.getState().setMcpServerEnabled('filesystem', true);
     expect(sent.find((m) => m.type === 'set_mcp_server_enabled')).toBeUndefined();
   });
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1505,14 +1505,15 @@ export interface ConnectionState {
   setProjectPermissionRules: (projectRules: PermissionRule[]) => void;
   /**
    * #6824 — enable or disable an already-configured MCP server for the active
-   * session (BYOK lane). Sends `set_mcp_server_enabled`; the server re-emits
-   * `mcp_servers` on success so the list converges across every device. The
-   * caller (SidebarMcpView) applies an optimistic status flip so the toggle is
-   * responsive; a rejection (`MCP_SERVER_*` error) rolls it back. Returns
-   * `false` when the socket is closed / no active session so the caller can
-   * surface an inline error instead of a silent drop.
+   * session (BYOK lane). Sends `set_mcp_server_enabled`; the toggle is
+   * broadcast-driven — no optimistic store mutation. The server re-emits
+   * `mcp_servers` with the new per-server status on success (converging every
+   * connected device), so the SidebarMcpView switch reflects the re-emitted
+   * truth after the round-trip; a rejected toggle simply never moves. No-op
+   * when the socket is closed or there is no active session (mirrors
+   * `setPermissionRules`).
    */
-  setMcpServerEnabled: (server: string, enabled: boolean) => boolean;
+  setMcpServerEnabled: (server: string, enabled: boolean) => void;
   /**
    * #6772 — pull the permission audit history for the active session
    * (`query_permission_audit`). Sets `permissionAuditLoading`; the reply lands in

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1504,6 +1504,16 @@ export interface ConnectionState {
    */
   setProjectPermissionRules: (projectRules: PermissionRule[]) => void;
   /**
+   * #6824 — enable or disable an already-configured MCP server for the active
+   * session (BYOK lane). Sends `set_mcp_server_enabled`; the server re-emits
+   * `mcp_servers` on success so the list converges across every device. The
+   * caller (SidebarMcpView) applies an optimistic status flip so the toggle is
+   * responsive; a rejection (`MCP_SERVER_*` error) rolls it back. Returns
+   * `false` when the socket is closed / no active session so the caller can
+   * surface an inline error instead of a silent drop.
+   */
+  setMcpServerEnabled: (server: string, enabled: boolean) => boolean;
+  /**
    * #6772 — pull the permission audit history for the active session
    * (`query_permission_audit`). Sets `permissionAuditLoading`; the reply lands in
    * `permissionAudit`. No-op when disconnected.

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1493,6 +1493,35 @@ button.sidebar-token-view-session-row:hover {
   font-size: 11px;
 }
 
+/* #6824 — per-server enable/disable toggle (BYOK lane only). A compact pill
+   switch; "On" reads accent, "Off" reads muted. Broadcast-driven, so it
+   reflects the server's actual state after a round-trip. */
+.sidebar-mcp-view-toggle {
+  flex-shrink: 0;
+  align-self: center;
+  min-width: 34px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle, var(--text-muted));
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+}
+
+.sidebar-mcp-view-toggle.enabled {
+  border-color: var(--accent-green, #22c55e);
+  color: var(--accent-green, #22c55e);
+}
+
+.sidebar-mcp-view-toggle:hover {
+  filter: brightness(1.15);
+}
+
 /* #5163 (epic #5159) — Control Room panel: live read-only activity tree. */
 .control-room-panel {
   display: flex;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -235,6 +235,13 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
     }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SetMcpServerEnabledSchema: z.ZodObject<{
+    type: z.ZodLiteral<"set_mcp_server_enabled">;
+    server: z.ZodString;
+    enabled: z.ZodBoolean;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const SetPromptEvaluatorSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_prompt_evaluator">;
     value: z.ZodBoolean;
@@ -981,6 +988,12 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"set_mcp_server_enabled">;
+    server: z.ZodString;
+    enabled: z.ZodBoolean;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"set_prompt_evaluator">;
     value: z.ZodBoolean;
     sessionId: z.ZodOptional<z.ZodString>;
@@ -1529,6 +1542,7 @@ export type CancelQueuedMessage = z.infer<typeof CancelQueuedSchema>;
 export type SetModelMessage = z.infer<typeof SetModelSchema>;
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>;
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>;
+export type SetMcpServerEnabledMessage = z.infer<typeof SetMcpServerEnabledSchema>;
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>;
 export type GetPermissionInputMessage = z.infer<typeof GetPermissionInputSchema>;
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -259,6 +259,24 @@ export const SetPermissionRulesSchema = z.object({
     projectRules: z.array(PermissionRuleSchema).max(1000).optional(),
     sessionId: z.string().max(256).optional(),
 });
+// #6824: per-server MCP enable/disable. Runtime, per-session toggle of an
+// ALREADY-CONFIGURED MCP server (not add/remove — that mutates ~/.claude.json
+// and is a separate follow-up). `enabled: false` parks the server's fleet
+// client (its tools/prompts/resources vanish from the next turn and it stops
+// respawning); `enabled: true` restarts it through the same trust gate
+// (already-trusted servers reconnect silently). Only BYOK-lane providers run
+// an in-daemon MCP fleet, so the server rejects this on other providers with
+// an `MCP_SERVER_TOGGLE_UNSUPPORTED` capability error. `requestId` (optional)
+// echoes back on rejection so a client can roll back its optimistic toggle.
+// `sessionId` is optional; the handler falls back to the client's bound
+// active session — and a pairing-bound token may only target its own session.
+export const SetMcpServerEnabledSchema = z.object({
+    type: z.literal('set_mcp_server_enabled'),
+    server: z.string().min(1).max(256),
+    enabled: z.boolean(),
+    sessionId: z.string().max(256).optional(),
+    requestId: z.string().max(256).optional(),
+});
 // #3185: per-session promptEvaluator toggle. Strict boolean — the server
 // rejects anything else with a `session_error`. `sessionId` is optional;
 // the handler falls back to the client's bound active session.
@@ -1347,6 +1365,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetPermissionModeSchema,
     SetThinkingLevelSchema,
     SetPermissionRulesSchema,
+    SetMcpServerEnabledSchema,
     SetPromptEvaluatorSchema,
     SetPromptEvaluatorSkipPatternSchema,
     SetChroxyContextHintSchema,

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -26,9 +26,12 @@ export declare const ServerMultiQuestionInterventionSchema: z.ZodObject<{
 }, z.core.$strip>;
 export declare const ServerMcpServersSchema: z.ZodObject<{
     type: z.ZodLiteral<"mcp_servers">;
+    sessionId: z.ZodOptional<z.ZodString>;
     servers: z.ZodArray<z.ZodObject<{
         name: z.ZodString;
         status: z.ZodString;
+        enabled: z.ZodOptional<z.ZodBoolean>;
+        canToggle: z.ZodOptional<z.ZodBoolean>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
 export declare const ServerPlanStartedSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -66,9 +66,23 @@ export const ServerMultiQuestionInterventionSchema = z.object({
 });
 export const ServerMcpServersSchema = z.object({
     type: z.literal('mcp_servers'),
+    // #6832: sessionId is injected by the multi-session broadcast path so a
+    // client can route the list to the right session; omitted on the legacy-cli
+    // path. Optional here — the field is documented for completeness (server →
+    // client messages are not strict-parsed on send, but a client that DOES
+    // validate must not have it stripped).
+    sessionId: z.string().optional(),
     servers: z.array(z.object({
         name: z.string(),
         status: z.string(),
+        // #6824: per-server enable/disable. `enabled` is the toggle's on/off
+        // state (false = the operator parked this server; distinct from a live
+        // 'dead' status the operator never touched). `canToggle` gates whether a
+        // client renders the toggle at all — only the BYOK lane (which runs an
+        // in-daemon MCP fleet) sets it true; sdk/cli/tui emit a read-only list.
+        // Both optional so pre-#6824 emitters (and other providers) round-trip.
+        enabled: z.boolean().optional(),
+        canToggle: z.boolean().optional(),
     })),
 });
 export const ServerPlanStartedSchema = z.object({

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -66,11 +66,12 @@ export const ServerMultiQuestionInterventionSchema = z.object({
 });
 export const ServerMcpServersSchema = z.object({
     type: z.literal('mcp_servers'),
-    // #6832: sessionId is injected by the multi-session broadcast path so a
-    // client can route the list to the right session; omitted on the legacy-cli
-    // path. Optional here — the field is documented for completeness (server →
-    // client messages are not strict-parsed on send, but a client that DOES
-    // validate must not have it stripped).
+    // #6847: stamped by the event-normalizer on the multi-session path (live
+    // emits + toggle re-emits) and by ws-history's snapshot-on-subscribe replay,
+    // so a client subscribed to several sessions routes the list to the RIGHT
+    // one instead of falling back to its active session. Omitted on the
+    // legacy-cli path (single implicit session). Optional here — a validating
+    // client must not have it stripped.
     sessionId: z.string().optional(),
     servers: z.array(z.object({
         name: z.string(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -296,6 +296,25 @@ export const SetPermissionRulesSchema = z.object({
   sessionId: z.string().max(256).optional(),
 })
 
+// #6824: per-server MCP enable/disable. Runtime, per-session toggle of an
+// ALREADY-CONFIGURED MCP server (not add/remove — that mutates ~/.claude.json
+// and is a separate follow-up). `enabled: false` parks the server's fleet
+// client (its tools/prompts/resources vanish from the next turn and it stops
+// respawning); `enabled: true` restarts it through the same trust gate
+// (already-trusted servers reconnect silently). Only BYOK-lane providers run
+// an in-daemon MCP fleet, so the server rejects this on other providers with
+// an `MCP_SERVER_TOGGLE_UNSUPPORTED` capability error. `requestId` (optional)
+// echoes back on rejection so a client can roll back its optimistic toggle.
+// `sessionId` is optional; the handler falls back to the client's bound
+// active session — and a pairing-bound token may only target its own session.
+export const SetMcpServerEnabledSchema = z.object({
+  type: z.literal('set_mcp_server_enabled'),
+  server: z.string().min(1).max(256),
+  enabled: z.boolean(),
+  sessionId: z.string().max(256).optional(),
+  requestId: z.string().max(256).optional(),
+})
+
 // #3185: per-session promptEvaluator toggle. Strict boolean — the server
 // rejects anything else with a `session_error`. `sessionId` is optional;
 // the handler falls back to the client's bound active session.
@@ -1517,6 +1536,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SetPermissionModeSchema,
   SetThinkingLevelSchema,
   SetPermissionRulesSchema,
+  SetMcpServerEnabledSchema,
   SetPromptEvaluatorSchema,
   SetPromptEvaluatorSkipPatternSchema,
   SetChroxyContextHintSchema,
@@ -1647,6 +1667,7 @@ export type CancelQueuedMessage = z.infer<typeof CancelQueuedSchema>
 export type SetModelMessage = z.infer<typeof SetModelSchema>
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>
+export type SetMcpServerEnabledMessage = z.infer<typeof SetMcpServerEnabledSchema>
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>
 export type GetPermissionInputMessage = z.infer<typeof GetPermissionInputSchema>
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -72,9 +72,23 @@ export const ServerMultiQuestionInterventionSchema = z.object({
 
 export const ServerMcpServersSchema = z.object({
   type: z.literal('mcp_servers'),
+  // #6832: sessionId is injected by the multi-session broadcast path so a
+  // client can route the list to the right session; omitted on the legacy-cli
+  // path. Optional here — the field is documented for completeness (server →
+  // client messages are not strict-parsed on send, but a client that DOES
+  // validate must not have it stripped).
+  sessionId: z.string().optional(),
   servers: z.array(z.object({
     name: z.string(),
     status: z.string(),
+    // #6824: per-server enable/disable. `enabled` is the toggle's on/off
+    // state (false = the operator parked this server; distinct from a live
+    // 'dead' status the operator never touched). `canToggle` gates whether a
+    // client renders the toggle at all — only the BYOK lane (which runs an
+    // in-daemon MCP fleet) sets it true; sdk/cli/tui emit a read-only list.
+    // Both optional so pre-#6824 emitters (and other providers) round-trip.
+    enabled: z.boolean().optional(),
+    canToggle: z.boolean().optional(),
   })),
 })
 

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -72,11 +72,12 @@ export const ServerMultiQuestionInterventionSchema = z.object({
 
 export const ServerMcpServersSchema = z.object({
   type: z.literal('mcp_servers'),
-  // #6832: sessionId is injected by the multi-session broadcast path so a
-  // client can route the list to the right session; omitted on the legacy-cli
-  // path. Optional here — the field is documented for completeness (server →
-  // client messages are not strict-parsed on send, but a client that DOES
-  // validate must not have it stripped).
+  // #6847: stamped by the event-normalizer on the multi-session path (live
+  // emits + toggle re-emits) and by ws-history's snapshot-on-subscribe replay,
+  // so a client subscribed to several sessions routes the list to the RIGHT
+  // one instead of falling back to its active session. Omitted on the
+  // legacy-cli path (single implicit session). Optional here — a validating
+  // client must not have it stripped.
   sessionId: z.string().optional(),
   servers: z.array(z.object({
     name: z.string(),

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -51,6 +51,24 @@ function mcpToolName(serverName, toolName) {
 // the intent reads clearly at the call site.
 const mcpPromptName = mcpToolName
 
+// #6824: map an MCPClient's internal lifecycle state to the wire `status`
+// string the `mcp_servers` broadcast carries. Kept aligned with the sdk/cli
+// convention (dashboard/mobile only treat `connected` as the live/green dot;
+// everything else renders muted). A parked (disabled) server has NO client, so
+// this is only ever called for enabled ones — the disabled status is applied
+// by `getServerStatuses()` directly.
+export function mcpStateToStatus(state) {
+  switch (state) {
+    case MCP_STATES.READY:
+      return 'connected'
+    case MCP_STATES.DEAD:
+      return 'failed'
+    default:
+      // IDLE / STARTING / RESTARTING — spawned but not yet handshaken.
+      return 'connecting'
+  }
+}
+
 export class MCPFleet {
   constructor(configs, opts = {}) {
     // #4457: build a per-client trust gate when a PermissionManager is
@@ -80,39 +98,154 @@ export class MCPFleet {
       Number.isFinite(opts.startCapMs) && opts.startCapMs > 0
         ? opts.startCapMs
         : DEFAULT_FLEET_START_CAP_MS
-    this._clients = configs.map((cfg) => {
-      const clientOpts = { ...opts }
-      if (permissionManager) {
-        clientOpts.trustGate = async () => {
-          // #4460: serialise the load→prompt→recordTrust sequence across
-          // all fleet clients that share this trust-store path. Without
-          // the lock, two concurrent gates can both observe an empty
-          // store, both prompt, both call recordTrust — and the last
-          // writer's snapshot (read at step 1, missing the other's
-          // entry) clobbers the first allow. The lock also surfaces
-          // prompts one at a time, which the dashboard / mobile UI
-          // already assumes (one modal at a time).
-          return withTrustStoreLock(resolvedTrustPath, async () => {
-            const store = loadTrustStore(resolvedTrustPath, { log: opts.log })
-            if (isTrusted(store, cfg)) return true
-            // #6821: a remote server has no command/args — prompt on
-            // (name, url) + header KEY names. Header VALUES (tokens) never
-            // reach the permission payload, the trust store, or any log.
-            const isRemote = typeof cfg.url === 'string' && cfg.url.length > 0
-            const trustReq = isRemote
-              ? { name: cfg.name, url: cfg.url, headerKeys: Object.keys(cfg.headers || {}).sort() }
-              : { name: cfg.name, command: cfg.command, args: cfg.args, envKeys: Object.keys(cfg.env || {}).sort() }
-            const allowed = await permissionManager.requestMcpTrust(trustReq)
-            if (allowed) recordTrust(cfg, resolvedTrustPath)
-            return allowed
-          })
-        }
+    // #6824: retain the raw config list + the wiring inputs so a re-enable can
+    // rebuild a client from scratch (a destroyed MCPClient can't be revived —
+    // start() throws once `_destroyed`). `getServerStatuses()` also iterates
+    // `_configs` so it can report parked servers the live `_clients` array no
+    // longer holds.
+    this._configs = configs
+    this._opts = opts
+    this._permissionManager = permissionManager
+    this._resolvedTrustPath = resolvedTrustPath
+    // #6824: per-session parked (disabled) server names. Seeded from the
+    // caller's persisted set (byok-session forwards the restored
+    // `disabledMcpServers`), filtered to names that are actually configured so
+    // a stale entry for a removed server can't wedge. Parked servers get NO
+    // client on construction — they contribute zero tools and report status
+    // 'disabled' until re-enabled.
+    const configuredNames = new Set(configs.map((c) => c.name))
+    this._disabled = new Set(
+      (Array.isArray(opts.disabledServers) ? opts.disabledServers : [])
+        .filter((name) => configuredNames.has(name)),
+    )
+    this._clients = configs
+      .filter((cfg) => !this._disabled.has(cfg.name))
+      .map((cfg) => this._makeClient(cfg))
+  }
+
+  /**
+   * #6824: build one MCPClient for a config, wiring the trust gate exactly as
+   * the constructor did inline pre-#6824. Extracted so the re-enable path
+   * (`setEnabled(name, true)`) rebuilds a client with an IDENTICAL gate — an
+   * already-trusted (name, command, args[0]) tuple reconnects silently; an
+   * untrusted one still prompts, so re-enabling can never bypass trust.
+   */
+  _makeClient(cfg) {
+    const clientOpts = { ...this._opts }
+    if (this._permissionManager) {
+      clientOpts.trustGate = async () => {
+        // #4460: serialise the load→prompt→recordTrust sequence across
+        // all fleet clients that share this trust-store path. Without
+        // the lock, two concurrent gates can both observe an empty
+        // store, both prompt, both call recordTrust — and the last
+        // writer's snapshot (read at step 1, missing the other's
+        // entry) clobbers the first allow. The lock also surfaces
+        // prompts one at a time, which the dashboard / mobile UI
+        // already assumes (one modal at a time).
+        return withTrustStoreLock(this._resolvedTrustPath, async () => {
+          const store = loadTrustStore(this._resolvedTrustPath, { log: this._opts.log })
+          if (isTrusted(store, cfg)) return true
+          // #6821: a remote server has no command/args — prompt on
+          // (name, url) + header KEY names. Header VALUES (tokens) never
+          // reach the permission payload, the trust store, or any log.
+          const isRemote = typeof cfg.url === 'string' && cfg.url.length > 0
+          const trustReq = isRemote
+            ? { name: cfg.name, url: cfg.url, headerKeys: Object.keys(cfg.headers || {}).sort() }
+            : { name: cfg.name, command: cfg.command, args: cfg.args, envKeys: Object.keys(cfg.env || {}).sort() }
+          const allowed = await this._permissionManager.requestMcpTrust(trustReq)
+          if (allowed) recordTrust(cfg, this._resolvedTrustPath)
+          return allowed
+        })
       }
-      return createMcpClient(cfg, clientOpts)
-    })
+    }
+    return createMcpClient(cfg, clientOpts)
   }
 
   get clients() { return this._clients }
+
+  /**
+   * #6824: read-only view of the parked (disabled) server names. Byok-session
+   * reads this to persist the set into session state so a respawn honours it.
+   */
+  get disabledServers() { return [...this._disabled].sort() }
+
+  /**
+   * #6824: status snapshot for EVERY configured server — the payload the
+   * `mcp_servers` broadcast carries. Parked servers report status 'disabled'
+   * with `enabled: false`; live ones map their MCPClient state. `canToggle`
+   * is true for all (the whole BYOK fleet is toggleable) so the client can
+   * gate its per-row switch on a single field.
+   */
+  getServerStatuses() {
+    return this._configs.map((cfg) => {
+      if (this._disabled.has(cfg.name)) {
+        return { name: cfg.name, status: 'disabled', enabled: false, canToggle: true }
+      }
+      const client = this._clients.find((c) => c.name === cfg.name)
+      const status = client ? mcpStateToStatus(client.state) : 'connecting'
+      return { name: cfg.name, status, enabled: true, canToggle: true }
+    })
+  }
+
+  /**
+   * #6824: park or unpark a single configured server without tearing down the
+   * rest of the fleet.
+   *
+   *   - disable: destroy the server's MCPClient (SIGTERM→SIGKILL grace) and
+   *     add it to `_disabled`. Its tools/prompts/resources drop from the next
+   *     turn's aggregates immediately; it never respawns while parked.
+   *   - enable: remove it from `_disabled`, rebuild a fresh client through the
+   *     SAME trust gate, and start it (bounded by the client's own
+   *     restart budget). Already-trusted servers reconnect with no prompt.
+   *
+   * Idempotent: toggling to the current state is a no-op (`changed: false`).
+   * Returns `{ found, changed, status }` — `found: false` when `name` is not a
+   * configured server (caller surfaces a clean error rather than silently
+   * creating a phantom entry).
+   */
+  async setEnabled(name, enabled) {
+    const cfg = this._configs.find((c) => c.name === name)
+    if (!cfg) return { found: false, changed: false, status: null }
+
+    const currentlyDisabled = this._disabled.has(name)
+    // Target state already holds → no-op.
+    if (enabled && !currentlyDisabled) {
+      const client = this._clients.find((c) => c.name === name)
+      return { found: true, changed: false, status: client ? mcpStateToStatus(client.state) : 'connecting' }
+    }
+    if (!enabled && currentlyDisabled) {
+      return { found: true, changed: false, status: 'disabled' }
+    }
+
+    if (!enabled) {
+      // Disable: destroy the live client, mark parked.
+      this._disabled.add(name)
+      const idx = this._clients.findIndex((c) => c.name === name)
+      if (idx !== -1) {
+        const [client] = this._clients.splice(idx, 1)
+        try {
+          await client.destroy()
+        } catch (err) {
+          ;(this._opts.log || console).warn?.(`MCP fleet: destroy of ${name} on disable threw: ${err?.message || err}`)
+        }
+      }
+      return { found: true, changed: true, status: 'disabled' }
+    }
+
+    // Enable: unpark + rebuild + start through the same trust gate.
+    this._disabled.delete(name)
+    const client = this._makeClient(cfg)
+    this._clients.push(client)
+    try {
+      await client.start()
+    } catch (err) {
+      // A failed start leaves the client in DEAD (contributes zero tools) —
+      // mirror fleet.start()'s non-fatal handling. Keep it in `_clients` so its
+      // 'failed' status still surfaces on the next snapshot.
+      ;(this._opts.log || console).warn?.(`MCP fleet: start of ${name} on enable threw: ${err?.message || err}`)
+    }
+    return { found: true, changed: true, status: mcpStateToStatus(client.state) }
+  }
 
   /**
    * Spawn every client and resolve when either (a) every client has reached

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -118,6 +118,11 @@ export class MCPFleet {
       (Array.isArray(opts.disabledServers) ? opts.disabledServers : [])
         .filter((name) => configuredNames.has(name)),
     )
+    // #6824: per-server in-flight toggle latch — names whose park/unpark is
+    // currently awaiting (destroy grace / restart handshake). A second toggle
+    // for the same server arriving mid-flight is churn and is ignored (see
+    // setEnabled) rather than interleaving destroy/start on one client.
+    this._toggling = new Set()
     this._clients = configs
       .filter((cfg) => !this._disabled.has(cfg.name))
       .map((cfg) => this._makeClient(cfg))
@@ -207,6 +212,19 @@ export class MCPFleet {
     const cfg = this._configs.find((c) => c.name === name)
     if (!cfg) return { found: false, changed: false, status: null }
 
+    // #6824 review follow-up: churn guard. If a park/unpark for THIS server is
+    // already awaiting, ignore the new toggle (changed: false) — interleaving a
+    // start into an in-flight destroy (or vice versa) on one client is the only
+    // way this API can corrupt fleet state. The in-flight op's completion
+    // re-emit is the authoritative state the client converges to.
+    if (this._toggling.has(name)) {
+      const client = this._clients.find((c) => c.name === name)
+      const status = this._disabled.has(name)
+        ? 'disabled'
+        : (client ? mcpStateToStatus(client.state) : 'connecting')
+      return { found: true, changed: false, status }
+    }
+
     const currentlyDisabled = this._disabled.has(name)
     // Target state already holds → no-op.
     if (enabled && !currentlyDisabled) {
@@ -217,34 +235,39 @@ export class MCPFleet {
       return { found: true, changed: false, status: 'disabled' }
     }
 
-    if (!enabled) {
-      // Disable: destroy the live client, mark parked.
-      this._disabled.add(name)
-      const idx = this._clients.findIndex((c) => c.name === name)
-      if (idx !== -1) {
-        const [client] = this._clients.splice(idx, 1)
-        try {
-          await client.destroy()
-        } catch (err) {
-          ;(this._opts.log || console).warn?.(`MCP fleet: destroy of ${name} on disable threw: ${err?.message || err}`)
-        }
-      }
-      return { found: true, changed: true, status: 'disabled' }
-    }
-
-    // Enable: unpark + rebuild + start through the same trust gate.
-    this._disabled.delete(name)
-    const client = this._makeClient(cfg)
-    this._clients.push(client)
+    this._toggling.add(name)
     try {
-      await client.start()
-    } catch (err) {
-      // A failed start leaves the client in DEAD (contributes zero tools) —
-      // mirror fleet.start()'s non-fatal handling. Keep it in `_clients` so its
-      // 'failed' status still surfaces on the next snapshot.
-      ;(this._opts.log || console).warn?.(`MCP fleet: start of ${name} on enable threw: ${err?.message || err}`)
+      if (!enabled) {
+        // Disable: destroy the live client, mark parked.
+        this._disabled.add(name)
+        const idx = this._clients.findIndex((c) => c.name === name)
+        if (idx !== -1) {
+          const [client] = this._clients.splice(idx, 1)
+          try {
+            await client.destroy()
+          } catch (err) {
+            ;(this._opts.log || console).warn?.(`MCP fleet: destroy of ${name} on disable threw: ${err?.message || err}`)
+          }
+        }
+        return { found: true, changed: true, status: 'disabled' }
+      }
+
+      // Enable: unpark + rebuild + start through the same trust gate.
+      this._disabled.delete(name)
+      const client = this._makeClient(cfg)
+      this._clients.push(client)
+      try {
+        await client.start()
+      } catch (err) {
+        // A failed start leaves the client in DEAD (contributes zero tools) —
+        // mirror fleet.start()'s non-fatal handling. Keep it in `_clients` so its
+        // 'failed' status still surfaces on the next snapshot.
+        ;(this._opts.log || console).warn?.(`MCP fleet: start of ${name} on enable threw: ${err?.message || err}`)
+      }
+      return { found: true, changed: true, status: mcpStateToStatus(client.state) }
+    } finally {
+      this._toggling.delete(name)
     }
-    return { found: true, changed: true, status: mcpStateToStatus(client.state) }
   }
 
   /**

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -578,13 +578,17 @@ export class ClaudeByokSession extends BaseSession {
     let result
     if (this._mcpFleet) {
       result = await this._mcpFleet.setEnabled(name, enabled)
+      // Sync the persisted set from the fleet's AUTHORITATIVE one rather than
+      // applying the requested state — the fleet's in-flight churn latch can
+      // legitimately ignore this toggle (changed:false while another park/
+      // unpark for the same server is awaiting), and blindly recording the
+      // request here would diverge what respawn honours from what actually ran.
+      this._disabledMcpServers = new Set(this._mcpFleet.disabledServers)
     } else {
       // Fleet not yet started (no servers spawned): just record intent so
       // start() honours it. Treat as changed only if the set actually moves.
       const was = this._disabledMcpServers.has(name)
       result = { found: true, changed: was === enabled, status: enabled ? 'configured' : 'disabled' }
-    }
-    if (result.found) {
       if (enabled) this._disabledMcpServers.delete(name)
       else this._disabledMcpServers.add(name)
     }

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -402,6 +402,18 @@ export class ClaudeByokSession extends BaseSession {
     }
     this._mcpServerConfigs = mcpConfig.servers
     this.mcpServers = Object.freeze(mcpConfig.servers.map(toMcpServerMetadata))
+    // #6824: per-session set of parked (disabled) MCP server names. Seeded from
+    // the persisted `disabledMcpServers` opt (session-manager forwards the
+    // restored set), filtered to names actually present in this session's
+    // config so a stale entry can't wedge. Threaded into the MCPFleet at
+    // start() (parked servers get no client) and round-tripped back to session
+    // state via `getDisabledMcpServers()`. Byok-local opt — read straight off
+    // `opts`, not a BaseSession key.
+    const configuredMcpNames = new Set(mcpConfig.servers.map((s) => s.name))
+    this._disabledMcpServers = new Set(
+      (Array.isArray(opts.disabledMcpServers) ? opts.disabledMcpServers : [])
+        .filter((name) => typeof name === 'string' && configuredMcpNames.has(name)),
+    )
     // #4077: MCPFleet is lazy — created in start() only if servers exist.
     // Held here so destroy() can tear down even if start() never ran.
     this._mcpFleet = null
@@ -499,12 +511,94 @@ export class ClaudeByokSession extends BaseSession {
       // what we want when no override is in play.
       const fleetOpts = { log, permissionManager: this._permissions }
       if (this._mcpStartCapMs !== null) fleetOpts.startCapMs = this._mcpStartCapMs
+      // #6824: seed the fleet with the persisted parked set so a respawn skips
+      // starting servers the operator disabled before the restart.
+      fleetOpts.disabledServers = [...this._disabledMcpServers]
       this._mcpFleet = new MCPFleet(this._mcpServerConfigs, fleetOpts)
       await this._mcpFleet.start()
     }
 
     this._processReady = true
     this.emit('ready', { sessionId: null, model: this.model, tools: [] })
+    // #6824: BYOK is the authoritative MCP lane — publish the live server list
+    // (with per-server enabled/canToggle) so the dashboard/mobile MCP views can
+    // render the enable/disable toggle. sdk/cli parse their list off the live
+    // stream; the BYOK fleet is in-daemon, so we emit it here after start().
+    this._emitMcpServers()
+  }
+
+  /**
+   * #6824: build the `mcp_servers` broadcast payload — one entry per configured
+   * server with `{ name, status, enabled, canToggle: true }`. When the fleet
+   * exists (the normal post-start case) its `getServerStatuses()` is
+   * authoritative (live states + parked servers). Before start() / when the
+   * fleet never spun up, fall back to the static config list so the payload is
+   * still coherent (parked → 'disabled', otherwise 'configured').
+   */
+  _buildMcpServersPayload() {
+    if (this._mcpFleet) return this._mcpFleet.getServerStatuses()
+    return this._mcpServerConfigs.map((cfg) => {
+      const disabled = this._disabledMcpServers.has(cfg.name)
+      return {
+        name: cfg.name,
+        status: disabled ? 'disabled' : 'configured',
+        enabled: !disabled,
+        canToggle: true,
+      }
+    })
+  }
+
+  /**
+   * #6824: emit the current MCP server list to all subscribers. Best-effort —
+   * a throwing listener must not escape the ready / toggle paths this is called
+   * from (mirrors claude-tui-session `_emitConfiguredMcpServers`). No servers
+   * configured → nothing to publish.
+   */
+  _emitMcpServers() {
+    if (this._mcpServerConfigs.length === 0) return
+    try {
+      this.emit('mcp_servers', { servers: this._buildMcpServersPayload() })
+    } catch (err) {
+      log.warn(`BYOK MCP: mcp_servers emit failed: ${err?.message || err}`)
+    }
+  }
+
+  /**
+   * #6824: enable or disable a single configured MCP server for this session.
+   * Delegates the park/unpark to the fleet (destroy-and-forget vs
+   * rebuild-through-trust-gate), updates the persisted parked set, and
+   * re-emits `mcp_servers` so every connected client converges. Returns
+   * `{ found, changed, status }` — `found: false` when `name` is not a
+   * configured server so the WS handler can surface a clean error.
+   */
+  async setMcpServerEnabled(name, enabled) {
+    if (typeof name !== 'string' || !this._mcpServerConfigs.some((c) => c.name === name)) {
+      return { found: false, changed: false, status: null }
+    }
+    let result
+    if (this._mcpFleet) {
+      result = await this._mcpFleet.setEnabled(name, enabled)
+    } else {
+      // Fleet not yet started (no servers spawned): just record intent so
+      // start() honours it. Treat as changed only if the set actually moves.
+      const was = this._disabledMcpServers.has(name)
+      result = { found: true, changed: was === enabled, status: enabled ? 'configured' : 'disabled' }
+    }
+    if (result.found) {
+      if (enabled) this._disabledMcpServers.delete(name)
+      else this._disabledMcpServers.add(name)
+    }
+    if (result.changed) this._emitMcpServers()
+    return result
+  }
+
+  /**
+   * #6824: the parked (disabled) server names, sorted, for persistence into
+   * session-state.json. Session-manager reads this in `_serializeSessionEntry`
+   * and forwards it back as `disabledMcpServers` on restore.
+   */
+  getDisabledMcpServers() {
+    return [...this._disabledMcpServers].sort()
   }
 
   async sendMessage(prompt, attachments, _options = {}) {

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -355,11 +355,22 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
-  mcp_servers: (data) => ({
-    messages: [{
-      msg: { type: 'mcp_servers', servers: data.servers },
-    }],
-  }),
+  // #6847: stamp the canonical `ctx.sessionId` so the message routes to the
+  // RIGHT session on the client — without it, a client subscribed to sessions
+  // A+B with B active would patch A's toggle re-emit onto B (store-core's
+  // handleMcpServers falls back to activeSessionId when the field is absent).
+  // The field is OMITTED on the legacy-cli path where ctx.sessionId is null,
+  // matching the `stopped` builder's convention ("applies to the connected
+  // legacy CLI" rather than `sessionId: null`) — mcp_servers is in that path's
+  // FORWARDED_EVENTS list, unlike the always-multi-session siblings
+  // (message_queued / background_work_changed) that stamp unconditionally.
+  mcp_servers: (data, ctx) => {
+    const msg = { type: 'mcp_servers', servers: data.servers }
+    if (typeof ctx.sessionId === 'string' && ctx.sessionId.length > 0) {
+      msg.sessionId = ctx.sessionId
+    }
+    return { messages: [{ msg }] }
+  },
 
   // #5936 (epic #5935): outgoing-message queue mirror. The session emits these
   // when a send-while-busy follow-up enters (`message_queued`) or leaves

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -857,15 +857,18 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
  * in-daemon MCP fleet that can be parked/unparked, so this rejects other
  * providers with a capability error the client uses to keep its toggle hidden.
  *
- * AUTH: routed through `resolveSessionOrError`, which enforces session-token
+ * AUTH: routed through `resolveSession`, which enforces session-token
  * binding — a pairing-bound client may only act on ITS OWN session; a bound
- * token naming a different session is rejected with "No active session". This
+ * token naming a different session resolves to no entry and is rejected. This
  * is the own-session gate, not the host-authority (unbound-only) gate that
  * `set_permission_rules` uses: enabling a server can never ADD an untrusted
  * one (the fleet re-runs the trust gate on unpark) and disabling only REDUCES
  * capability, so neither direction is the privilege escalation that rule-
- * setting is. Every rejection echoes `requestId` (when supplied) with a stable
- * code so an optimistic client toggle can roll back.
+ * setting is. Every rejection — validation, session resolution, capability,
+ * unknown server — echoes `requestId` (when supplied) with a stable code
+ * (MCP_SERVER_NOT_APPLIED / MCP_SERVER_TOGGLE_UNSUPPORTED /
+ * MCP_SERVER_NOT_FOUND), the same echo discipline as the set_model /
+ * set_permission_mode / set_thinking_level NOT_APPLIED family.
  *
  * On success the session re-emits `mcp_servers` (broadcast to every subscriber
  * → multi-device consistency), so this handler does not send its own ack — the
@@ -884,8 +887,16 @@ async function handleSetMcpServerEnabled(ws, client, msg, ctx) {
   }
 
   const sessionId = msg?.sessionId || client?.activeSessionId
-  const entry = resolveSessionOrError(ws, ctx, msg, client)
-  if (!entry) return
+  // Session resolution failures (no active session, or a bound token naming a
+  // DIFFERENT session — resolveSession enforces the binding) echo requestId +
+  // the stable NOT_APPLIED code, mirroring handleSetThinkingLevel, rather than
+  // resolveSessionOrError's code-less session_error, so the doc-block contract
+  // ("every rejection echoes requestId with a stable code") holds on ALL paths.
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    sendError(ws, requestId, 'MCP_SERVER_NOT_APPLIED', 'No active session', undefined, ctx)
+    return
+  }
 
   // Capability gate — only providers that expose `setMcpServerEnabled` (the
   // BYOK lane) can toggle. Others ride the claude binary's own MCP config.

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -851,6 +851,74 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
   loggerForSession('ws', sessionId).info(`Permission rules updated by ${client.id} on session ${sessionId}: ${rules.length} session rule(s)${projectRules !== undefined ? `, ${projectRules.length} project rule(s)` : ''}`)
 }
 
+/**
+ * #6824 — enable/disable an already-configured MCP server for the active
+ * session (runtime toggle, not add/remove). Only the BYOK lane runs an
+ * in-daemon MCP fleet that can be parked/unparked, so this rejects other
+ * providers with a capability error the client uses to keep its toggle hidden.
+ *
+ * AUTH: routed through `resolveSessionOrError`, which enforces session-token
+ * binding — a pairing-bound client may only act on ITS OWN session; a bound
+ * token naming a different session is rejected with "No active session". This
+ * is the own-session gate, not the host-authority (unbound-only) gate that
+ * `set_permission_rules` uses: enabling a server can never ADD an untrusted
+ * one (the fleet re-runs the trust gate on unpark) and disabling only REDUCES
+ * capability, so neither direction is the privilege escalation that rule-
+ * setting is. Every rejection echoes `requestId` (when supplied) with a stable
+ * code so an optimistic client toggle can roll back.
+ *
+ * On success the session re-emits `mcp_servers` (broadcast to every subscriber
+ * → multi-device consistency), so this handler does not send its own ack — the
+ * updated list IS the confirmation.
+ */
+async function handleSetMcpServerEnabled(ws, client, msg, ctx) {
+  const requestId = msg?.requestId
+  const server = typeof msg?.server === 'string' ? msg.server.trim() : ''
+  if (!server) {
+    sendError(ws, requestId, 'MCP_SERVER_NOT_APPLIED', 'set_mcp_server_enabled requires a non-empty `server` name', undefined, ctx)
+    return
+  }
+  if (typeof msg?.enabled !== 'boolean') {
+    sendError(ws, requestId, 'MCP_SERVER_NOT_APPLIED', 'set_mcp_server_enabled requires a boolean `enabled`', undefined, ctx)
+    return
+  }
+
+  const sessionId = msg?.sessionId || client?.activeSessionId
+  const entry = resolveSessionOrError(ws, ctx, msg, client)
+  if (!entry) return
+
+  // Capability gate — only providers that expose `setMcpServerEnabled` (the
+  // BYOK lane) can toggle. Others ride the claude binary's own MCP config.
+  if (!entry.session || typeof entry.session.setMcpServerEnabled !== 'function') {
+    sendError(ws, requestId, 'MCP_SERVER_TOGGLE_UNSUPPORTED',
+      'This provider does not support enabling/disabling MCP servers (its MCP config is managed by the underlying CLI).',
+      undefined, ctx)
+    return
+  }
+
+  try {
+    const result = await entry.session.setMcpServerEnabled(server, msg.enabled)
+    if (!result || result.found === false) {
+      sendError(ws, requestId, 'MCP_SERVER_NOT_FOUND', `No configured MCP server named '${server}' for this session.`, undefined, ctx)
+      return
+    }
+    // The session re-emits `mcp_servers` on a real change (forwarded to all
+    // subscribers). Persist immediately so a crash inside the debounce window
+    // can't lose the parked-set change — same discipline as the permission-rule
+    // and per-session-setting handlers.
+    if (result.changed) {
+      try {
+        ctx.sessions.sessionManager?.serializeState?.()
+      } catch (err) {
+        loggerForSession('ws', sessionId).warn(`Failed to persist disabledMcpServers for ${sessionId}: ${err?.message || err}`)
+      }
+    }
+    loggerForSession('ws', sessionId).info(`MCP server '${server}' ${msg.enabled ? 'enabled' : 'disabled'} by ${client.id} on session ${sessionId} (changed=${result.changed})`)
+  } catch (err) {
+    sendError(ws, requestId, 'MCP_SERVER_NOT_APPLIED', `Failed to ${msg.enabled ? 'enable' : 'disable'} MCP server '${server}': ${err?.message || String(err)}`, undefined, ctx)
+  }
+}
+
 // #4664: assemble the per-session-setting WS handlers from the registry.
 // Each setting's `requestType` (e.g. `'set_prompt_evaluator'`) is the
 // message-type key the dispatcher looks up; the factory-built handler
@@ -924,6 +992,8 @@ export const settingsHandlers = {
   list_providers: handleListProviders,
   set_thinking_level: handleSetThinkingLevel,
   set_permission_rules: handleSetPermissionRules,
+  // #6824: per-server MCP enable/disable (BYOK lane; capability-gated).
+  set_mcp_server_enabled: handleSetMcpServerEnabled,
   // promptEvaluatorSkipPattern keeps its bespoke handler because the
   // payload shape (string-or-null + pre-validation regex compile to
   // surface a distinct error code) doesn't fit the boolean/string

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1134,7 +1134,7 @@ export class SessionManager extends EventEmitter {
    *   it (#6743).
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, codexSandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, agentCommId, metadata = null, skipPersist = false, preserveId, isRestore = false } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, codexSandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, disabledMcpServers, bootedModel, messageCounter, skipPermissions, agentCommId, metadata = null, skipPersist = false, preserveId, isRestore = false } = {}) {
     // #6036 — front-half SRP extraction: preflight + isolation + provider/preset
     // resolution (incl. the limit guard, cwd check, id/name, #2962 preflight,
     // #5985 user-shell gate, #3403 model fallback, worktree create/restore, and
@@ -1263,6 +1263,15 @@ export class SessionManager extends EventEmitter {
     // signal only originates from SidecarProcess paths).
     if (stdinForwardingDisabled === true) {
       providerOpts.stdinForwardingDisabled = true
+    }
+    // #6824: per-session parked (disabled) MCP server names. Byok-local opt —
+    // forwarded only when it's a non-empty array of strings so non-BYOK
+    // providers (which ignore the unknown key via the opt picker) never see a
+    // meaningless value, and older state files (no field) restore cleanly. The
+    // BYOK session filters this against its own config, so a stale name is a
+    // harmless no-op.
+    if (Array.isArray(disabledMcpServers) && disabledMcpServers.length > 0) {
+      providerOpts.disabledMcpServers = disabledMcpServers.filter((n) => typeof n === 'string')
     }
     // #4208 / #4209: per-session skipPermissions, with the server-wide
     // default as fallback. Only forwarded when truthy so non-TUI providers
@@ -2160,6 +2169,15 @@ export class SessionManager extends EventEmitter {
         // was not replayed. Strict-boolean coerce so non-Sdk providers
         // (which never set this field) round-trip as `false`.
         stdinForwardingDisabled: !!entry.session._stdinForwardingDisabled,
+        // #6824: persist the per-session parked (disabled) MCP server set so a
+        // respawn skips starting those servers. Only the BYOK lane exposes the
+        // getter; other providers round-trip as [] (their MCP config is owned
+        // by the claude binary, not toggleable here). Older state files (no
+        // field) restore as [] → nothing parked.
+        disabledMcpServers:
+          typeof entry.session.getDisabledMcpServers === 'function'
+            ? entry.session.getDisabledMcpServers()
+            : [],
         // #4089: persist cumulativeUsage so the dashboard sidebar badge
         // (#4073) and mobile session-header badge (#4074) survive a
         // server restart. Without this, the badge resets to $0 on
@@ -2271,6 +2289,13 @@ export class SessionManager extends EventEmitter {
           // ensures no warn/error is re-emitted on restore — clients
           // observe the disabled state via session_list metadata.
           stdinForwardingDisabled: saved.stdinForwardingDisabled === true ? true : undefined,
+          // #6824: forward the persisted parked MCP server set so the respawned
+          // BYOK fleet skips starting them. Non-array / empty values are
+          // dropped (createSession only forwards a non-empty string array), so
+          // older state files restore with nothing parked.
+          disabledMcpServers: Array.isArray(saved.disabledMcpServers) && saved.disabledMcpServers.length > 0
+            ? saved.disabledMcpServers.filter((n) => typeof n === 'string')
+            : undefined,
           // Restore the previously-booted model (#3700b) so the dashboard
           // dropdown shows the real model on reconnect, not the registry
           // fallback. createSession() ignores non-string / empty values so

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -345,7 +345,7 @@ function _isSecureRequest(req) {
  *   { type: 'tool_start',   messageId, toolUseId, tool, input, serverName? } — tool invocation (serverName present for MCP tools)
  *   { type: 'tool_input_delta', messageId, toolUseId, partialJson } — #4080/#4081: incremental partial JSON for the streaming tool_use `input`; concatenate per-toolUseId for the live bubble preview
  *   { type: 'tool_result',  toolUseId, result, truncated, images?, isError? }  — tool result (images: [{mediaType, data}]; #6712 isError flags a failed tool for the error affordance)
- *   { type: 'mcp_servers',  servers: [{ name, status }] }     — connected MCP servers
+ *   { type: 'mcp_servers',  servers: [{ name, status, enabled?, canToggle? }] } — configured MCP servers (#6824: enabled + canToggle per-server; BYOK lane sets canToggle:true so clients render the enable/disable toggle; status 'disabled' = parked)
  *   { type: 'result',       ... }                     — query stats
  *   { type: 'status',       connected: true }         — connection status
  *   { type: 'claude_ready' }                          — Claude Code ready for input

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -325,4 +325,112 @@ describe('MCPFleet', () => {
       await fleet.destroy()
     })
   })
+
+  describe('enable/disable (#6824)', () => {
+    it('disable parks the client — its tools disappear and status becomes disabled', async () => {
+      const fleet = new MCPFleet([cfg('alpha'), cfg('beta')], { log: silentLog() })
+      await fleet.start()
+      assert.deepEqual(fleet.tools.map((t) => t.name).sort(), ['mcp__alpha__echo', 'mcp__beta__echo'])
+
+      const res = await fleet.setEnabled('beta', false)
+      assert.deepEqual(res, { found: true, changed: true, status: 'disabled' })
+      // beta's tools are gone; alpha remains.
+      assert.deepEqual(fleet.tools.map((t) => t.name), ['mcp__alpha__echo'])
+      // beta has no live client anymore.
+      assert.equal(fleet.clients.find((c) => c.name === 'beta'), undefined)
+      // status snapshot reports beta parked.
+      const statuses = fleet.getServerStatuses()
+      const beta = statuses.find((s) => s.name === 'beta')
+      assert.deepEqual(beta, { name: 'beta', status: 'disabled', enabled: false, canToggle: true })
+      assert.deepEqual(fleet.disabledServers, ['beta'])
+      await fleet.destroy()
+    })
+
+    it('re-enable rebuilds + restarts the client — its tools reappear', async () => {
+      const fleet = new MCPFleet([cfg('alpha'), cfg('beta')], { log: silentLog() })
+      await fleet.start()
+      await fleet.setEnabled('beta', false)
+      assert.deepEqual(fleet.tools.map((t) => t.name), ['mcp__alpha__echo'])
+
+      const res = await fleet.setEnabled('beta', true)
+      assert.equal(res.found, true)
+      assert.equal(res.changed, true)
+      assert.equal(res.status, 'connected')
+      assert.deepEqual(fleet.tools.map((t) => t.name).sort(), ['mcp__alpha__echo', 'mcp__beta__echo'])
+      assert.deepEqual(fleet.disabledServers, [])
+      await fleet.destroy()
+    })
+
+    it('re-enabling an already-trusted server does NOT re-prompt for trust', async () => {
+      const tmpStorePath = `/tmp/chroxy-mcp-trust-test-${process.pid}-${Date.now()}-toggle.json`
+      const fs = await import('node:fs')
+      let prompts = 0
+      const fakePermissionManager = { requestMcpTrust: async () => { prompts += 1; return true } }
+      const fleet = new MCPFleet([cfg('alpha')], {
+        log: silentLog(),
+        permissionManager: fakePermissionManager,
+        trustStorePath: tmpStorePath,
+      })
+      await fleet.start()
+      assert.equal(prompts, 1, 'first spawn prompts once (untrusted → allowed + recorded)')
+
+      await fleet.setEnabled('alpha', false)
+      await fleet.setEnabled('alpha', true)
+      // The re-enable rebuilds the client, but the tuple is now in the trust
+      // store, so the gate short-circuits without a new prompt.
+      assert.equal(prompts, 1, 'already-trusted server reconnects silently on re-enable')
+      assert.equal(fleet.clients.find((c) => c.name === 'alpha')?.state, MCP_STATES.READY)
+      await fleet.destroy()
+      try { fs.rmSync(tmpStorePath) } catch {}
+    })
+
+    it('disabledServers seed: a parked server never spawns a client at start', async () => {
+      const fleet = new MCPFleet(
+        [cfg('alpha'), cfg('beta')],
+        { log: silentLog(), disabledServers: ['beta'] },
+      )
+      await fleet.start()
+      // Only alpha has a live client / tools.
+      assert.deepEqual(fleet.clients.map((c) => c.name), ['alpha'])
+      assert.deepEqual(fleet.tools.map((t) => t.name), ['mcp__alpha__echo'])
+      const statuses = fleet.getServerStatuses()
+      assert.deepEqual(statuses.find((s) => s.name === 'beta'), { name: 'beta', status: 'disabled', enabled: false, canToggle: true })
+      assert.deepEqual(fleet.disabledServers, ['beta'])
+      await fleet.destroy()
+    })
+
+    it('disabledServers seed filters out names that are not configured', async () => {
+      const fleet = new MCPFleet(
+        [cfg('alpha')],
+        { log: silentLog(), disabledServers: ['ghost', 'alpha'] },
+      )
+      // 'ghost' isn't configured → dropped; 'alpha' is parked.
+      assert.deepEqual(fleet.disabledServers, ['alpha'])
+      await fleet.start()
+      assert.deepEqual(fleet.tools.map((t) => t.name), [])
+      await fleet.destroy()
+    })
+
+    it('setEnabled on an unknown server returns found:false', async () => {
+      const fleet = new MCPFleet([cfg('alpha')], { log: silentLog() })
+      await fleet.start()
+      const res = await fleet.setEnabled('nope', false)
+      assert.deepEqual(res, { found: false, changed: false, status: null })
+      await fleet.destroy()
+    })
+
+    it('setEnabled is idempotent — toggling to the current state is a no-op', async () => {
+      const fleet = new MCPFleet([cfg('alpha')], { log: silentLog() })
+      await fleet.start()
+      // Already enabled → enabling again is a no-op.
+      const a = await fleet.setEnabled('alpha', true)
+      assert.equal(a.changed, false)
+      await fleet.setEnabled('alpha', false)
+      // Already disabled → disabling again is a no-op.
+      const b = await fleet.setEnabled('alpha', false)
+      assert.equal(b.changed, false)
+      assert.equal(b.status, 'disabled')
+      await fleet.destroy()
+    })
+  })
 })

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -432,5 +432,29 @@ describe('MCPFleet', () => {
       assert.equal(b.status, 'disabled')
       await fleet.destroy()
     })
+
+    it('ignores a churn toggle while the same server\'s park/unpark is in flight', async () => {
+      const fleet = new MCPFleet([cfg('alpha')], { log: silentLog() })
+      await fleet.start()
+      // Fire a disable (enters the latch, awaits the client's destroy grace)
+      // and, before awaiting it, a flip-back enable for the SAME server. The
+      // second call must be ignored (changed:false) rather than interleaving a
+      // start into the in-flight destroy.
+      const p1 = fleet.setEnabled('alpha', false)
+      const p2 = fleet.setEnabled('alpha', true)
+      const [r1, r2] = await Promise.all([p1, p2])
+      assert.equal(r1.changed, true, 'first toggle proceeds')
+      assert.equal(r1.status, 'disabled')
+      assert.equal(r2.found, true)
+      assert.equal(r2.changed, false, 'in-flight churn is ignored')
+      // The first (in-flight) op is authoritative: server ends parked.
+      assert.deepEqual(fleet.disabledServers, ['alpha'])
+      assert.deepEqual(fleet.tools, [])
+      // The latch releases after settle — a later toggle works normally.
+      const r3 = await fleet.setEnabled('alpha', true)
+      assert.equal(r3.changed, true, 'latch released after the in-flight op settled')
+      assert.equal(r3.status, 'connected')
+      await fleet.destroy()
+    })
   })
 })

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -421,6 +421,107 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    // #6824: per-server enable/disable (BYOK lane authoritative).
+    describe('MCP enable/disable (#6824)', () => {
+      function writeStubConfig() {
+        const configPath = join(tmpHome, '.claude.json')
+        writeFileSync(configPath, JSON.stringify({
+          mcpServers: { stub: { command: process.execPath, args: [MCP_STUB], env: {} } },
+        }))
+        return configPath
+      }
+
+      it('emits mcp_servers on start with per-server enabled + canToggle', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        const emitted = []
+        session.on('mcp_servers', (d) => emitted.push(d))
+        await session.start()
+        assert.equal(emitted.length, 1, 'exactly one mcp_servers emit on start')
+        assert.deepEqual(emitted[0].servers, [
+          { name: 'stub', status: 'connected', enabled: true, canToggle: true },
+        ])
+        await session.destroy()
+      })
+
+      it('disable parks the server — tools drop, re-emits status disabled, persists the set', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        const emitted = []
+        session.on('mcp_servers', (d) => emitted.push(d))
+        await session.start()
+        assert.ok(session._mcpFleet.tools.length >= 1, 'tools present while enabled')
+
+        const res = await session.setMcpServerEnabled('stub', false)
+        assert.deepEqual(res, { found: true, changed: true, status: 'disabled' })
+        assert.deepEqual(session._mcpFleet.tools, [], 'parked server contributes no tools')
+        assert.deepEqual(session.getDisabledMcpServers(), ['stub'])
+        // A fresh mcp_servers emit reflects the parked status.
+        const last = emitted[emitted.length - 1]
+        assert.deepEqual(last.servers, [
+          { name: 'stub', status: 'disabled', enabled: false, canToggle: true },
+        ])
+        await session.destroy()
+      })
+
+      it('re-enable restarts the server — tools reappear, set cleared', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        await session.start()
+        await session.setMcpServerEnabled('stub', false)
+        assert.deepEqual(session._mcpFleet.tools, [])
+
+        const res = await session.setMcpServerEnabled('stub', true)
+        assert.equal(res.changed, true)
+        assert.equal(res.status, 'connected')
+        assert.ok(session._mcpFleet.tools.length >= 1, 'tools reappear after re-enable')
+        assert.deepEqual(session.getDisabledMcpServers(), [])
+        await session.destroy()
+      })
+
+      it('respawn honors the persisted disabled set — a seeded server never starts', async () => {
+        // No preTrustStub needed: a parked server is never spawned, so the
+        // trust gate is never consulted.
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({
+          cwd: '/tmp',
+          mcpConfigPath: configPath,
+          disabledMcpServers: ['stub'],
+        })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        const emitted = []
+        session.on('mcp_servers', (d) => emitted.push(d))
+        await session.start()
+        assert.equal(session._mcpFleet.clients.length, 0, 'seeded-disabled server has no client')
+        assert.deepEqual(session._mcpFleet.tools, [])
+        assert.deepEqual(session.getDisabledMcpServers(), ['stub'])
+        assert.deepEqual(emitted[emitted.length - 1].servers, [
+          { name: 'stub', status: 'disabled', enabled: false, canToggle: true },
+        ])
+        await session.destroy()
+      })
+
+      it('setMcpServerEnabled on an unknown server returns found:false and does not emit', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        await session.start()
+        const emittedBefore = []
+        session.on('mcp_servers', (d) => emittedBefore.push(d))
+        const res = await session.setMcpServerEnabled('ghost', false)
+        assert.deepEqual(res, { found: false, changed: false, status: null })
+        assert.equal(emittedBefore.length, 0, 'no re-emit for an unknown server')
+        await session.destroy()
+      })
+    })
+
     it('#4457: untrusted MCP server fires a permission_request prompt; deny → DEAD without spawn', async () => {
       const configPath = join(tmpHome, '.claude.json')
       writeFileSync(configPath, JSON.stringify({

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -440,6 +440,23 @@ describe('EventNormalizer', () => {
       assert.equal(msg.servers.length, 2)
       assert.equal(msg.servers[0].name, 'filesystem')
     })
+
+    // #6847: the live re-emit must carry the canonical session id — without it,
+    // a client subscribed to sessions A+B with B active patches A's toggle
+    // re-emit onto B (handleMcpServers falls back to activeSessionId).
+    it('stamps ctx.sessionId on the multi-session path (#6847)', () => {
+      const data = { servers: [{ name: 'filesystem', status: 'disabled', enabled: false, canToggle: true }] }
+      const result = normalizer.normalize('mcp_servers', data, makeCtx({ sessionId: 'sess-A' }))
+      assert.equal(result.messages[0].msg.sessionId, 'sess-A')
+    })
+
+    it('omits sessionId on the legacy-cli path (ctx.sessionId null) — matches the stopped convention', () => {
+      const data = { servers: [{ name: 'filesystem', status: 'connected' }] }
+      const result = normalizer.normalize('mcp_servers', data, makeCtx({ sessionId: null, mode: 'legacy-cli' }))
+      const msg = result.messages[0].msg
+      assert.equal(Object.prototype.hasOwnProperty.call(msg, 'sessionId'), false,
+        'legacy path must omit the field entirely, not emit sessionId: null')
+    })
   })
 
   describe('tool_result event', () => {

--- a/packages/server/tests/mcp-server-toggle-persistence.test.js
+++ b/packages/server/tests/mcp-server-toggle-persistence.test.js
@@ -1,0 +1,142 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { EventEmitter } from 'node:events'
+import { SessionManager } from '../src/session-manager.js'
+import { registerProvider } from '../src/providers.js'
+
+/**
+ * #6824 — persistence of the per-session parked (disabled) MCP server set.
+ *
+ * SessionManager must:
+ *   1. serialize `disabledMcpServers` from a session's `getDisabledMcpServers()`
+ *      getter (BYOK lane), and [] for providers without the getter;
+ *   2. forward a non-empty persisted set into `providerOpts.disabledMcpServers`
+ *      on createSession (so a respawned BYOK fleet skips the parked servers);
+ *   3. round-trip the set through serialize → state file → restoreState.
+ *
+ * Uses a capturing provider (not the real BYOK session) so the plumbing is
+ * asserted in isolation — the BYOK fleet-seed behaviour is covered by
+ * byok-session.test.js / byok-mcp-fleet.test.js.
+ */
+
+// Module-scoped buffer of providerOpts handed to the capturing provider.
+const capturedOpts = []
+
+class McpCaptureProvider extends EventEmitter {
+  constructor(opts) {
+    super()
+    capturedOpts.push(opts)
+    this.cwd = opts.cwd
+    this.model = opts.model || null
+    this.permissionMode = opts.permissionMode || 'approve'
+    this.isRunning = false
+    this.resumeSessionId = null
+    // #6824: mirror the BYOK getter so serialize can read the parked set back
+    // out of a live entry. Seeded from the forwarded opt.
+    this._disabled = Array.isArray(opts.disabledMcpServers) ? [...opts.disabledMcpServers] : []
+  }
+  static get capabilities() { return {} }
+  getDisabledMcpServers() { return [...this._disabled].sort() }
+  start() {}
+  destroy() {}
+  interrupt() {}
+  sendMessage() {}
+  setModel() {}
+  setPermissionMode() {}
+}
+
+let registered = false
+function ensureProvider() {
+  if (registered) return
+  registerProvider('test-mcp-capture', McpCaptureProvider)
+  registered = true
+}
+
+describe('MCP server disabled-set persistence (#6824)', () => {
+  let tmpDir
+  let stateFile
+
+  beforeEach(() => {
+    ensureProvider()
+    capturedOpts.length = 0
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-persist-'))
+    stateFile = join(tmpDir, 'session-state.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('serializes disabledMcpServers from the session getter', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    const session = new EventEmitter()
+    session.model = 'sonnet'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.getDisabledMcpServers = () => ['beta', 'alpha']
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'byok', name: 'T', cwd: '/tmp', provider: 'test-mcp-capture' })
+
+    const state = mgr.serializeState()
+    assert.deepEqual(state.sessions[0].disabledMcpServers, ['beta', 'alpha'])
+  })
+
+  it('serializes [] when the provider lacks the getter', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    const session = new EventEmitter()
+    session.model = 'sonnet'
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, type: 'cli', name: 'T', cwd: '/tmp', provider: 'test-mcp-capture' })
+
+    const state = mgr.serializeState()
+    assert.deepEqual(state.sessions[0].disabledMcpServers, [])
+  })
+
+  it('forwards a non-empty set into providerOpts.disabledMcpServers on createSession', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    mgr.createSession({ cwd: '/tmp', provider: 'test-mcp-capture', disabledMcpServers: ['x', 'y'] })
+    assert.equal(capturedOpts.length, 1)
+    assert.deepEqual(capturedOpts[0].disabledMcpServers, ['x', 'y'])
+  })
+
+  it('omits disabledMcpServers from providerOpts when unset or empty', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    mgr.createSession({ cwd: '/tmp', provider: 'test-mcp-capture' })
+    mgr.createSession({ cwd: '/tmp', provider: 'test-mcp-capture', disabledMcpServers: [] })
+    assert.equal(capturedOpts.length, 2)
+    assert.equal(Object.prototype.hasOwnProperty.call(capturedOpts[0], 'disabledMcpServers'), false)
+    assert.equal(Object.prototype.hasOwnProperty.call(capturedOpts[1], 'disabledMcpServers'), false)
+  })
+
+  it('round-trips the parked set through serialize → state file → restoreState', () => {
+    // Write a state file directly (mirrors what serializeState produces) with a
+    // session that parked two servers, then restore in a fresh manager and
+    // assert the respawned provider receives the set.
+    const mgr1 = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    mgr1.createSession({
+      cwd: '/tmp',
+      provider: 'test-mcp-capture',
+      disabledMcpServers: ['gamma'],
+    })
+    const state = mgr1.serializeState()
+    assert.deepEqual(state.sessions[0].disabledMcpServers, ['gamma'])
+
+    // Fresh manager restores from the just-written file.
+    capturedOpts.length = 0
+    const mgr2 = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: stateFile })
+    mgr2.restoreState()
+    // The restored provider was constructed with the parked set forwarded.
+    const restored = capturedOpts.find((o) => Array.isArray(o.disabledMcpServers))
+    assert.ok(restored, 'restored provider should receive disabledMcpServers')
+    assert.deepEqual(restored.disabledMcpServers, ['gamma'])
+
+    // And the on-disk file carried it.
+    const onDisk = JSON.parse(readFileSync(stateFile, 'utf8'))
+    assert.deepEqual(onDisk.sessions[0].disabledMcpServers, ['gamma'])
+  })
+})

--- a/packages/server/tests/settings-handlers-mcp-toggle.test.js
+++ b/packages/server/tests/settings-handlers-mcp-toggle.test.js
@@ -105,17 +105,23 @@ describe('handleSetMcpServerEnabled (#6824)', () => {
 
   it('bound token is REJECTED when it targets a different session (cross-session)', async () => {
     const session = makeSession()
+    const other = makeSession()
     // Two sessions exist; the client is bound to sess-1 but targets sess-2.
-    const ctx = makeCtx({ 'sess-1': { session }, 'sess-2': { session: makeSession() } })
+    const ctx = makeCtx({ 'sess-1': { session }, 'sess-2': { session: other } })
     const client = { id: 'c1', activeSessionId: 'sess-1', boundSessionId: 'sess-1' }
 
-    await handler(WS, client, { type: 'set_mcp_server_enabled', sessionId: 'sess-2', server: 'stub', enabled: false }, ctx)
+    await handler(WS, client, { type: 'set_mcp_server_enabled', sessionId: 'sess-2', server: 'stub', enabled: false, requestId: 'r-x' }, ctx)
 
-    // resolveSessionOrError rejects the cross-session resolve → session_error,
-    // and the target session's toggle is never invoked.
+    // resolveSession's binding check rejects the cross-session resolve; NEITHER
+    // session's toggle is invoked, and the rejection carries the stable code +
+    // requestId echo — same discipline as every other rejection path (the
+    // set_thinking_level NOT_APPLIED convention).
     assert.equal(session.setMcpServerEnabled.mock.callCount(), 0, 'cross-session toggle blocked')
+    assert.equal(other.setMcpServerEnabled.mock.callCount(), 0, 'target session untouched')
     const err = lastErr(ctx)
-    assert.equal(err?.type, 'session_error')
+    assert.equal(err?.type, 'error')
+    assert.equal(err?.code, 'MCP_SERVER_NOT_APPLIED')
+    assert.equal(err?.requestId, 'r-x', 'echoes requestId so the client can roll back its switch')
   })
 
   it('rejects a missing server name', async () => {

--- a/packages/server/tests/settings-handlers-mcp-toggle.test.js
+++ b/packages/server/tests/settings-handlers-mcp-toggle.test.js
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for handleSetMcpServerEnabled in settings-handlers.js (#6824).
+ *
+ * Covers:
+ *  - happy path: setMcpServerEnabled invoked + serializeState persisted on change
+ *  - capability rejection for a provider without the toggle method (non-BYOK)
+ *  - auth gating: a bound (pairing-issued) token can toggle its OWN session but
+ *    is rejected when it targets a DIFFERENT session (cross-session)
+ *  - payload validation (missing server, non-boolean enabled)
+ *  - unknown server (found:false) → MCP_SERVER_NOT_FOUND, no persist
+ */
+import { describe, it, beforeEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { settingsHandlers } from '../src/handlers/settings-handlers.js'
+import { nsCtx } from './test-helpers.js'
+
+const handler = settingsHandlers['set_mcp_server_enabled']
+
+// readyState: 1 (OPEN) — sendError guards on `ws.readyState === 1` before it
+// routes through ctx.transport.send, so an opaque `{}` would silently swallow
+// the error frame.
+const WS = { readyState: 1 }
+
+function makeSession(overrides = {}) {
+  return {
+    isReady: true,
+    model: 'claude-opus-4-8',
+    permissionMode: 'approve',
+    setMcpServerEnabled: mock.fn(async () => ({ found: true, changed: true, status: 'disabled' })),
+    ...overrides,
+  }
+}
+
+function makeCtx(entriesById = {}) {
+  const sessionMap = new Map(Object.entries(entriesById))
+  const serializeState = mock.fn(() => {})
+  return nsCtx({
+    sessionManager: {
+      getSession: mock.fn((id) => sessionMap.get(id) ?? null),
+      serializeState,
+    },
+    send: mock.fn(),
+    broadcast: mock.fn(),
+    broadcastToSession: mock.fn(),
+  })
+}
+
+function lastErr(ctx) {
+  const calls = ctx.transport.send.mock.calls
+  return calls.length ? calls[calls.length - 1].arguments[1] : null
+}
+
+describe('handleSetMcpServerEnabled (#6824)', () => {
+  it('happy path — invokes setMcpServerEnabled and persists on change', async () => {
+    const session = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: 'stub', enabled: false }, ctx)
+
+    assert.equal(session.setMcpServerEnabled.mock.callCount(), 1)
+    assert.deepEqual(session.setMcpServerEnabled.mock.calls[0].arguments, ['stub', false])
+    assert.equal(ctx.sessions.sessionManager.serializeState.mock.callCount(), 1, 'persisted on change')
+    // No error frame on success.
+    assert.equal(ctx.transport.send.mock.callCount(), 0)
+  })
+
+  it('does not persist when the toggle is a no-op (changed:false)', async () => {
+    const session = makeSession({
+      setMcpServerEnabled: mock.fn(async () => ({ found: true, changed: false, status: 'connected' })),
+    })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: 'stub', enabled: true }, ctx)
+
+    assert.equal(session.setMcpServerEnabled.mock.callCount(), 1)
+    assert.equal(ctx.sessions.sessionManager.serializeState.mock.callCount(), 0, 'no persist on no-op')
+  })
+
+  it('rejects a provider without setMcpServerEnabled with a capability error', async () => {
+    const session = makeSession({ setMcpServerEnabled: undefined })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: 'stub', enabled: false, requestId: 'r1' }, ctx)
+
+    const err = lastErr(ctx)
+    assert.equal(err?.type, 'error')
+    assert.equal(err?.code, 'MCP_SERVER_TOGGLE_UNSUPPORTED')
+    assert.equal(err?.requestId, 'r1', 'echoes requestId for optimistic rollback')
+  })
+
+  it('bound token CAN toggle its own session', async () => {
+    const session = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session } })
+    // Bound to sess-1, no explicit sessionId → falls back to activeSessionId = sess-1.
+    const client = { id: 'c1', activeSessionId: 'sess-1', boundSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: 'stub', enabled: false }, ctx)
+
+    assert.equal(session.setMcpServerEnabled.mock.callCount(), 1, 'own-session toggle allowed')
+    assert.equal(ctx.transport.send.mock.callCount(), 0, 'no error frame')
+  })
+
+  it('bound token is REJECTED when it targets a different session (cross-session)', async () => {
+    const session = makeSession()
+    // Two sessions exist; the client is bound to sess-1 but targets sess-2.
+    const ctx = makeCtx({ 'sess-1': { session }, 'sess-2': { session: makeSession() } })
+    const client = { id: 'c1', activeSessionId: 'sess-1', boundSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', sessionId: 'sess-2', server: 'stub', enabled: false }, ctx)
+
+    // resolveSessionOrError rejects the cross-session resolve → session_error,
+    // and the target session's toggle is never invoked.
+    assert.equal(session.setMcpServerEnabled.mock.callCount(), 0, 'cross-session toggle blocked')
+    const err = lastErr(ctx)
+    assert.equal(err?.type, 'session_error')
+  })
+
+  it('rejects a missing server name', async () => {
+    const session = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: '   ', enabled: false, requestId: 'r2' }, ctx)
+
+    const err = lastErr(ctx)
+    assert.equal(err?.code, 'MCP_SERVER_NOT_APPLIED')
+    assert.equal(err?.requestId, 'r2')
+    assert.equal(session.setMcpServerEnabled.mock.callCount(), 0)
+  })
+
+  it('rejects a non-boolean enabled', async () => {
+    const session = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: 'stub', enabled: 'yes' }, ctx)
+
+    const err = lastErr(ctx)
+    assert.equal(err?.code, 'MCP_SERVER_NOT_APPLIED')
+    assert.equal(session.setMcpServerEnabled.mock.callCount(), 0)
+  })
+
+  it('returns MCP_SERVER_NOT_FOUND for an unknown server and does not persist', async () => {
+    const session = makeSession({
+      setMcpServerEnabled: mock.fn(async () => ({ found: false, changed: false, status: null })),
+    })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'set_mcp_server_enabled', server: 'ghost', enabled: false, requestId: 'r3' }, ctx)
+
+    const err = lastErr(ctx)
+    assert.equal(err?.code, 'MCP_SERVER_NOT_FOUND')
+    assert.equal(err?.requestId, 'r3')
+    assert.equal(ctx.sessions.sessionManager.serializeState.mock.callCount(), 0)
+  })
+})

--- a/packages/store-core/src/dispatch-table.test.ts
+++ b/packages/store-core/src/dispatch-table.test.ts
@@ -1350,6 +1350,32 @@ describe('shared dispatch table', () => {
       dispatch(env, { type: 'mcp_servers', servers: [] })
       expect(env.sessions.active.mcpServers).toEqual([])
     })
+
+    // #6847: two-subscription routing. A client viewing sessions A+B with B
+    // active must patch a session-A toggle re-emit onto A — not onto the
+    // active session B. Pre-#6847 the server's live re-emit omitted sessionId,
+    // so the active-session fallback misrouted it; this pins the post-fix
+    // behaviour (explicit sessionId wins over the active fallback).
+    it('routes to the NAMED session, not the active one, when both are subscribed (#6847)', () => {
+      const env = makeAdapter({
+        activeSessionId: 'sess-B',
+        sessions: {
+          'sess-A': { sessionId: 'sess-A', messages: [], mcpServers: [{ name: 'fs', status: 'connected' }] },
+          'sess-B': { sessionId: 'sess-B', messages: [], mcpServers: [{ name: 'gh', status: 'connected' }] },
+        },
+      })
+      dispatch(env, {
+        type: 'mcp_servers',
+        sessionId: 'sess-A',
+        servers: [{ name: 'fs', status: 'disabled', enabled: false, canToggle: true }],
+      })
+      // Target session updated…
+      expect(env.sessions['sess-A'].mcpServers).toEqual([
+        { name: 'fs', status: 'disabled', enabled: false, canToggle: true },
+      ])
+      // …and the ACTIVE session's list is untouched.
+      expect(env.sessions['sess-B'].mcpServers).toEqual([{ name: 'gh', status: 'connected' }])
+    })
   })
 
   describe('session_usage', () => {

--- a/packages/store-core/src/types/session.ts
+++ b/packages/store-core/src/types/session.ts
@@ -240,6 +240,13 @@ export interface SessionContext {
 export interface McpServer {
   name: string;
   status: string;
+  // #6824: per-server enable/disable state. `enabled` is the toggle's on/off
+  // value (false = operator-parked; a distinct signal from a 'dead' status the
+  // operator never touched). `canToggle` gates whether the UI renders a toggle
+  // — only the BYOK lane (in-daemon MCP fleet) sets it; sdk/cli/tui stay
+  // read-only. Both optional so a message from a pre-#6824 emitter round-trips.
+  enabled?: boolean;
+  canToggle?: boolean;
 }
 
 export interface DevPreview {


### PR DESCRIPTION
## Summary

Implements #6824 — a runtime, **per-session enable/disable toggle for already-configured MCP servers** on the BYOK lane. Deliberately scoped to enable/disable only; full **add/remove** (which mutates `~/.claude.json`, "owned by Claude Code, not by us") remains an explicit, separable follow-up.

Builds on the recently-landed MCP work: #6831 (visibility parity), #6833 (remote transport), #6838 (snapshot replay), #6844 (prompts/resources).

## Wire protocol

- **New client→server** `set_mcp_server_enabled { server, enabled, sessionId?, requestId? }` — added to `client.ts`, the `ClientMessageSchema` discriminated union, and the type exports; dist rebuilt + committed.
- **Extended `mcp_servers` broadcast** with per-server `enabled` + `canToggle` (`ServerMcpServersSchema` + store-core `McpServer`). No new server→client message type — the re-emitted list *is* the ack, so every connected client converges (multi-device consistency). `requestId` echoes on rejection for optimistic rollback.

## Server (BYOK authoritative)

- **`MCPFleet`**: a `_makeClient` factory + a parked (`_disabled`) set. Disabling destroys the server's `MCPClient` (its tools/prompts/resources drop from the next turn; no respawn while parked). Enabling rebuilds + restarts through the **same trust gate**, so an already-trusted server reconnects **with no prompt**. `getServerStatuses()` reports every configured server (parked → status `disabled`).
- **`ClaudeByokSession`**: emits `mcp_servers` on start and on every toggle (`canToggle: true`); exposes `setMcpServerEnabled` + `getDisabledMcpServers`; seeds the fleet from a persisted `disabledMcpServers` opt so a respawn honours parked servers.
- **`SessionManager`**: persists `disabledMcpServers` in session state and forwards it back on restore.
- **WS handler** `set_mcp_server_enabled`: **capability-gated** (non-BYOK providers → `MCP_SERVER_TOGGLE_UNSUPPORTED`, since they ride the claude binary's own config), and **bound to the caller's own session** via `resolveSessionOrError` (a pairing-bound token cannot toggle another session — per `docs/security/bearer-token-authority.md`). Persists on change.

## Clients

- **Dashboard** `SidebarMcpView`: per-row On/Off switch gated on `canToggle`, broadcast-driven via a new `setMcpServerEnabled` store action.
- **Mobile** `SettingsBar`: a `Switch` per `canToggle` server, wired through `SessionScreen` to the same new store action; non-toggleable servers stay read-only.

## Tests

- **Fleet**: park/unpark (tools vanish/reappear), no re-trust on re-enable, `disabledServers` seed honoured + filtered, idempotent no-op, unknown-server.
- **byok-session**: emit shape, disable/enable/persist, respawn-honours-seed, unknown-server no-emit.
- **session-manager**: serialize from getter, `[]` without getter, createSession forwarding (set + omitted), full serialize→file→restore round-trip.
- **handler**: happy path + persist, no-op no-persist, capability rejection, bound own-session allowed, **bound cross-session rejected**, validation, not-found.
- **dashboard**: `SidebarMcpView` toggle rendering/gating/click + store-action wire shape.
- **mobile**: `SettingsBar` Switch rendering/gating/onChange.

### Verification

- Protocol suite (362), store-core suite (2002), server MCP/session/handler/ws suites, all 5 `lint-*.sh`, dashboard vitest (4531), app SettingsBar/store/screens (753), `tsc` dashboard + app — all green.

Closes #6824

## Review follow-ups (Approve w/ minors)

- **#6847**: live `mcp_servers` re-emits now stamp `ctx.sessionId` in the event-normalizer (omitted on legacy-cli, matching the `stopped` convention) so multi-subscription clients route a toggle re-emit to the named session, not the active one; normalizer + store-core two-subscription routing tests pin it.
- `ServerMcpServersSchema` sessionId comment corrected to the actual stamping sites (dist rebuilt).
- Dashboard `setMcpServerEnabled` JSDoc now describes the broadcast-ack model; dead boolean return dropped (void, mirrors `setPermissionRules`).
- Fleet `setEnabled` gains a per-server in-flight latch — churn toggles while a park/unpark is awaiting are ignored, and the session syncs its persisted set from the fleet's authoritative one.

Closes #6847
