### PR TITLE
feat(server,dashboard,app): OAuth flow for remote MCP servers (#6822)

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -35,6 +35,17 @@ export const HEADER_BADGE_HIT_SLOP = {
   right: 14,
 } as const;
 
+// #6822 — the MCP OAuth "Authorize" + "Submit" buttons use a compact look; this
+// hitSlop (paired with minHeight: 44 on the button styles) brings the effective
+// touch target above Apple HIG's 44 × 44pt on both axes even for the narrowest
+// plausible label.
+export const MCP_AUTH_HIT_SLOP = {
+  top: 12,
+  bottom: 12,
+  left: 12,
+  right: 12,
+} as const;
+
 // -- Props --
 
 export interface SettingsBarProps {
@@ -921,6 +932,7 @@ function McpServerRow({
             <TouchableOpacity
               style={styles.mcpAuthorizeButton}
               testID={`mcp-server-authorize-${server.name}`}
+              hitSlop={MCP_AUTH_HIT_SLOP}
               accessibilityRole="button"
               accessibilityLabel={`Authorize MCP server ${server.name}`}
               onPress={() => { if (server.authUrl) Linking.openURL(server.authUrl).catch(() => {}); }}
@@ -943,6 +955,7 @@ function McpServerRow({
             <TouchableOpacity
               style={[styles.mcpAuthSubmit, !code.trim() && styles.mcpAuthSubmitDisabled]}
               testID={`mcp-server-auth-submit-${server.name}`}
+              hitSlop={MCP_AUTH_HIT_SLOP}
               disabled={!code.trim()}
               accessibilityRole="button"
               accessibilityLabel={`Submit authorization code for MCP server ${server.name}`}
@@ -1209,6 +1222,9 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     paddingHorizontal: 10,
     paddingVertical: 4,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
     borderRadius: 6,
     borderWidth: 1,
     borderColor: COLORS.accentBlue,
@@ -1238,6 +1254,9 @@ const styles = StyleSheet.create({
   mcpAuthSubmit: {
     paddingHorizontal: 12,
     paddingVertical: 5,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
     borderRadius: 6,
     borderWidth: 1,
     borderColor: COLORS.accentBlue,

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable, ScrollView, Switch } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable, ScrollView, Switch, TextInput, Linking } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { resolveContextWindow, contextOccupancyTokens, contextFillPercent } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm, SessionIntervention } from '@chroxy/store-core';
@@ -79,6 +79,9 @@ export interface SettingsBarProps {
   // for servers that report `canToggle` (the BYOK lane). Absent → the MCP list
   // stays read-only (matches sdk/cli/tui providers).
   onToggleMcpServer?: (server: string, enabled: boolean) => void;
+  // #6822 — submit a pasted OAuth authorization code for a remote MCP server that
+  // reported `oauth-required`. Absent → the paste-code affordance stays hidden.
+  onSubmitMcpAuthCode?: (server: string, code: string) => void;
   setModel: (model: string) => void;
   setPermissionMode: (mode: string) => void;
   pendingPermissionConfirm?: PendingPermissionConfirm | null;
@@ -211,6 +214,7 @@ export function SettingsBar({
   mcpServers,
   onInvokeAgent,
   onToggleMcpServer,
+  onSubmitMcpAuthCode,
   setModel,
   setPermissionMode,
   pendingPermissionConfirm,
@@ -702,35 +706,14 @@ export function SettingsBar({
               <Text style={styles.deviceSectionTitle}>
                 MCP Servers ({mcpServers.length})
               </Text>
-              {mcpServers.map((server) => {
-                // #6824: a server is "on" unless parked. Prefer the explicit
-                // `enabled` flag (BYOK emits it); fall back to status so a
-                // pre-#6824 payload still reads sensibly. The Switch renders
-                // only when the server reports `canToggle` (BYOK lane) and the
-                // parent wired an onToggle handler — otherwise read-only.
-                const enabled = typeof server.enabled === 'boolean' ? server.enabled : server.status !== 'disabled';
-                const canToggle = !!server.canToggle && !!onToggleMcpServer;
-                return (
-                  <View key={server.name} style={styles.agentEntry}>
-                    <View style={[styles.statusDot, { backgroundColor: server.status === 'connected' ? COLORS.accentGreen : COLORS.textMuted }]} />
-                    <Text style={styles.agentDescription} numberOfLines={1}>
-                      {server.name}
-                    </Text>
-                    {canToggle ? (
-                      <Switch
-                        testID={`mcp-server-toggle-${server.name}`}
-                        value={enabled}
-                        onValueChange={(next) => onToggleMcpServer?.(server.name, next)}
-                        accessibilityLabel={`${enabled ? 'Disable' : 'Enable'} MCP server ${server.name}`}
-                      />
-                    ) : (
-                      <Text style={styles.agentElapsed}>
-                        {server.status}
-                      </Text>
-                    )}
-                  </View>
-                );
-              })}
+              {mcpServers.map((server) => (
+                <McpServerRow
+                  key={server.name}
+                  server={server}
+                  onToggleMcpServer={onToggleMcpServer}
+                  onSubmitMcpAuthCode={onSubmitMcpAuthCode}
+                />
+              ))}
             </View>
           )}
           {customAgents.length > 0 && (
@@ -881,6 +864,99 @@ export function SettingsBar({
             </Pressable>
           </Pressable>
         </Modal>
+      )}
+    </View>
+  );
+}
+
+/**
+ * One row in the SettingsBar "MCP Servers" list. Extracted so an oauth-required
+ * server (#6822) can hold its own paste-code input state. Renders:
+ *   - the status dot + name (always);
+ *   - a Switch when the server reports `canToggle` (BYOK lane) and a toggle
+ *     handler is wired (#6824), else read-only status text;
+ *   - an "Authorize" button (opens the browser authorization URL on the user's
+ *     device) + a paste-code input (the universal fallback) when the server
+ *     reports `status: 'oauth-required'` and a submit handler is wired (#6822).
+ */
+function McpServerRow({
+  server,
+  onToggleMcpServer,
+  onSubmitMcpAuthCode,
+}: {
+  server: McpServer;
+  onToggleMcpServer?: (server: string, enabled: boolean) => void;
+  onSubmitMcpAuthCode?: (server: string, code: string) => void;
+}) {
+  const [code, setCode] = useState('');
+  // #6824: a server is "on" unless parked. Prefer the explicit `enabled` flag
+  // (BYOK emits it); fall back to status so a pre-#6824 payload still reads.
+  const enabled = typeof server.enabled === 'boolean' ? server.enabled : server.status !== 'disabled';
+  const canToggle = !!server.canToggle && !!onToggleMcpServer;
+  const needsAuth = server.status === 'oauth-required';
+
+  return (
+    <View style={styles.mcpServerRow}>
+      <View style={styles.agentEntry}>
+        <View style={[styles.statusDot, { backgroundColor: server.status === 'connected' ? COLORS.accentGreen : COLORS.textMuted }]} />
+        <Text style={styles.agentDescription} numberOfLines={1}>
+          {server.name}
+        </Text>
+        {canToggle ? (
+          <Switch
+            testID={`mcp-server-toggle-${server.name}`}
+            value={enabled}
+            onValueChange={(next) => onToggleMcpServer?.(server.name, next)}
+            accessibilityLabel={`${enabled ? 'Disable' : 'Enable'} MCP server ${server.name}`}
+          />
+        ) : (
+          <Text style={styles.agentElapsed}>
+            {server.status}
+          </Text>
+        )}
+      </View>
+      {needsAuth && !!onSubmitMcpAuthCode && (
+        <View style={styles.mcpAuthContainer} testID={`mcp-server-auth-${server.name}`}>
+          {!!server.authUrl && (
+            <TouchableOpacity
+              style={styles.mcpAuthorizeButton}
+              testID={`mcp-server-authorize-${server.name}`}
+              accessibilityRole="button"
+              accessibilityLabel={`Authorize MCP server ${server.name}`}
+              onPress={() => { if (server.authUrl) Linking.openURL(server.authUrl).catch(() => {}); }}
+            >
+              <Text style={styles.mcpAuthorizeButtonText}>Authorize in browser</Text>
+            </TouchableOpacity>
+          )}
+          <View style={styles.mcpAuthPasteRow}>
+            <TextInput
+              style={styles.mcpAuthInput}
+              testID={`mcp-server-auth-input-${server.name}`}
+              placeholder="Paste code"
+              placeholderTextColor={COLORS.textMuted}
+              value={code}
+              onChangeText={setCode}
+              autoCapitalize="none"
+              autoCorrect={false}
+              accessibilityLabel={`Authorization code for MCP server ${server.name}`}
+            />
+            <TouchableOpacity
+              style={[styles.mcpAuthSubmit, !code.trim() && styles.mcpAuthSubmitDisabled]}
+              testID={`mcp-server-auth-submit-${server.name}`}
+              disabled={!code.trim()}
+              accessibilityRole="button"
+              accessibilityLabel={`Submit authorization code for MCP server ${server.name}`}
+              onPress={() => {
+                const trimmed = code.trim();
+                if (!trimmed) return;
+                onSubmitMcpAuthCode?.(server.name, trimmed);
+                setCode('');
+              }}
+            >
+              <Text style={styles.mcpAuthSubmitText}>Submit</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
       )}
     </View>
   );
@@ -1117,6 +1193,62 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
+  },
+  // #6822 — oauth-required MCP server: the row stacks the status line above the
+  // authorize + paste-code affordance.
+  mcpServerRow: {
+    flexDirection: 'column',
+    gap: 6,
+  },
+  mcpAuthContainer: {
+    flexDirection: 'column',
+    gap: 6,
+    paddingLeft: 12,
+  },
+  mcpAuthorizeButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: COLORS.accentBlue,
+  },
+  mcpAuthorizeButtonText: {
+    color: COLORS.accentBlue,
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  mcpAuthPasteRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  mcpAuthInput: {
+    flex: 1,
+    minWidth: 0,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: COLORS.borderPrimary,
+    color: COLORS.textPrimary,
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  mcpAuthSubmit: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: COLORS.accentBlue,
+  },
+  mcpAuthSubmitDisabled: {
+    opacity: 0.5,
+  },
+  mcpAuthSubmitText: {
+    color: COLORS.accentBlue,
+    fontSize: 11,
+    fontWeight: '600',
   },
   agentDot: {
     width: 6,

--- a/packages/app/src/components/__tests__/SettingsBarMcpToggle.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarMcpToggle.test.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
 import { Switch, TextInput, TouchableOpacity, Linking } from 'react-native';
-import { SettingsBar } from '../SettingsBar';
+import { SettingsBar, MCP_AUTH_HIT_SLOP } from '../SettingsBar';
 import type { McpServer } from '@chroxy/store-core';
 
 function makeProps(overrides: Record<string, unknown> = {}) {
@@ -137,5 +137,58 @@ describe('SettingsBar MCP OAuth affordance (#6822)', () => {
       tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [{ name: 'fs', status: 'connected', canToggle: true }], onSubmitMcpAuthCode: () => {} })} />);
     });
     expect(findByTestId(tree.root, TextInput, 'mcp-server-auth-input-fs')).toBeNull();
+  });
+});
+
+// #6822 — Apple HIG: interactive elements need a ≥44×44pt effective touch target.
+// The compact Authorize + Submit buttons use minHeight:44 (height) + a shared
+// hitSlop (width) to clear it on BOTH axes even for the narrowest label.
+describe('SettingsBar MCP OAuth touch targets (#6822)', () => {
+  const oauthSrv: McpServer = { name: 'remote', status: 'oauth-required', enabled: true, canToggle: true, authUrl: 'https://as.example/authorize' };
+  const FONT = 11; // mcpAuthorizeButtonText / mcpAuthSubmitText fontSize
+
+  function flatStyle(node: ReactTestInstance) {
+    const s = node.props.style;
+    return Array.isArray(s) ? Object.assign({}, ...s.filter(Boolean)) : (s ?? {});
+  }
+  // Worst-case (single-glyph) effective bounds from style + hitSlop.
+  function effective(node: ReactTestInstance) {
+    const style = flatStyle(node);
+    const hit = (node.props.hitSlop ?? {}) as { top?: number; bottom?: number; left?: number; right?: number };
+    const border = (style.borderWidth ?? 0) * 2;
+    const intrinsicW = Math.ceil(FONT * 0.6) + (style.paddingHorizontal ?? 0) * 2 + border;
+    const intrinsicH = Math.max(style.minHeight ?? 0, FONT + (style.paddingVertical ?? 0) * 2 + border);
+    return {
+      width: intrinsicW + (hit.left ?? 0) + (hit.right ?? 0),
+      height: intrinsicH + (hit.top ?? 0) + (hit.bottom ?? 0),
+    };
+  }
+
+  it('exports a shared MCP_AUTH_HIT_SLOP with all four sides set', () => {
+    expect(MCP_AUTH_HIT_SLOP).toEqual({ top: 12, bottom: 12, left: 12, right: 12 });
+  });
+
+  it('the Authorize button clears 44×44 on both axes', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [oauthSrv], onSubmitMcpAuthCode: () => {} })} />);
+    });
+    const btn = findByTestId(tree.root, TouchableOpacity, 'mcp-server-authorize-remote')!;
+    expect(btn.props.hitSlop).toBe(MCP_AUTH_HIT_SLOP);
+    const e = effective(btn);
+    expect(e.width).toBeGreaterThanOrEqual(44);
+    expect(e.height).toBeGreaterThanOrEqual(44);
+  });
+
+  it('the Submit button clears 44×44 on both axes', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [oauthSrv], onSubmitMcpAuthCode: () => {} })} />);
+    });
+    const btn = findByTestId(tree.root, TouchableOpacity, 'mcp-server-auth-submit-remote')!;
+    expect(btn.props.hitSlop).toBe(MCP_AUTH_HIT_SLOP);
+    const e = effective(btn);
+    expect(e.width).toBeGreaterThanOrEqual(44);
+    expect(e.height).toBeGreaterThanOrEqual(44);
   });
 });

--- a/packages/app/src/components/__tests__/SettingsBarMcpToggle.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarMcpToggle.test.tsx
@@ -8,7 +8,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Switch } from 'react-native';
+import { Switch, TextInput, TouchableOpacity, Linking } from 'react-native';
 import { SettingsBar } from '../SettingsBar';
 import type { McpServer } from '@chroxy/store-core';
 
@@ -87,5 +87,55 @@ describe('SettingsBar MCP enable/disable toggle (#6824)', () => {
       tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: servers })} />);
     });
     expect(findSwitchByTestId(tree.root, 'mcp-server-toggle-filesystem')).toBeNull();
+  });
+});
+
+function findByTestId(root: ReactTestInstance, type: React.ComponentType, testID: string): ReactTestInstance | null {
+  return root.findAllByType(type as never).find((n) => n.props.testID === testID) ?? null;
+}
+
+describe('SettingsBar MCP OAuth affordance (#6822)', () => {
+  const oauthSrv: McpServer = { name: 'remote', status: 'oauth-required', enabled: true, canToggle: true, authUrl: 'https://as.example/authorize?x=1' };
+
+  it('renders an Authorize button + paste input for an oauth-required server', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [oauthSrv], onSubmitMcpAuthCode: () => {} })} />);
+    });
+    expect(findByTestId(tree.root, TouchableOpacity, 'mcp-server-authorize-remote')).not.toBeNull();
+    expect(findByTestId(tree.root, TextInput, 'mcp-server-auth-input-remote')).not.toBeNull();
+  });
+
+  it('opens the authUrl via Linking on Authorize press', () => {
+    const openSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [oauthSrv], onSubmitMcpAuthCode: () => {} })} />);
+    });
+    const btn = findByTestId(tree.root, TouchableOpacity, 'mcp-server-authorize-remote')!;
+    act(() => { btn.props.onPress(); });
+    expect(openSpy).toHaveBeenCalledWith('https://as.example/authorize?x=1');
+    openSpy.mockRestore();
+  });
+
+  it('submits the pasted code (trimmed) via onSubmitMcpAuthCode and clears the input', () => {
+    const onSubmit = jest.fn();
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [oauthSrv], onSubmitMcpAuthCode: onSubmit })} />);
+    });
+    const input = findByTestId(tree.root, TextInput, 'mcp-server-auth-input-remote')!;
+    act(() => { input.props.onChangeText('  paste-code  '); });
+    const submit = findByTestId(tree.root, TouchableOpacity, 'mcp-server-auth-submit-remote')!;
+    act(() => { submit.props.onPress(); });
+    expect(onSubmit).toHaveBeenCalledWith('remote', 'paste-code');
+  });
+
+  it('does NOT render the affordance for a connected server', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ mcpServers: [{ name: 'fs', status: 'connected', canToggle: true }], onSubmitMcpAuthCode: () => {} })} />);
+    });
+    expect(findByTestId(tree.root, TextInput, 'mcp-server-auth-input-fs')).toBeNull();
   });
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -249,6 +249,7 @@ export function SessionScreen() {
   const setModel = useConnectionStore((s) => s.setModel);
   const setPermissionMode = useConnectionStore((s) => s.setPermissionMode);
   const setMcpServerEnabled = useConnectionStore((s) => s.setMcpServerEnabled);
+  const submitMcpAuthCode = useConnectionStore((s) => s.submitMcpAuthCode);
   const confirmPermissionMode = useConnectionStore((s) => s.confirmPermissionMode);
   const cancelPermissionConfirm = useConnectionStore((s) => s.cancelPermissionConfirm);
   const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse);
@@ -1298,6 +1299,7 @@ export function SessionScreen() {
           mcpServers={mcpServers}
           onInvokeAgent={handleInvokeAgent}
           onToggleMcpServer={setMcpServerEnabled}
+          onSubmitMcpAuthCode={submitMcpAuthCode}
           setModel={setModel}
           setPermissionMode={setPermissionMode}
           pendingPermissionConfirm={pendingPermissionConfirm}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -2179,6 +2179,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     sendIfOpen(payload);
   },
 
+  // #6822 — submit a pasted OAuth authorization code for a remote MCP server that
+  // reported `oauth-required` (BYOK lane). Broadcast-driven: the server redeems
+  // the code, reconnects the server authenticated, and re-emits `mcp_servers`
+  // with the new status. No-op for an empty code. The code is a one-time
+  // authorization code and is never stored client-side.
+  submitMcpAuthCode: (server: string, code: string) => {
+    const trimmed = typeof code === 'string' ? code.trim() : '';
+    if (!trimmed) return;
+    const { activeSessionId } = get();
+    const payload: Record<string, unknown> = {
+      type: 'submit_mcp_auth_code',
+      server,
+      code: trimmed,
+      requestId: `mcp-auth-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    sendIfOpen(payload);
+  },
+
   confirmPermissionMode: (mode: string) => {
     const { socket, activeSessionId, sessionStates } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -578,6 +578,12 @@ export interface ModelsAndPermissionsActions {
   // broadcast (no optimistic mutation to roll back). The toggle is gated on the
   // server's `canToggle` flag so this only reaches a provider that supports it.
   setMcpServerEnabled: (server: string, enabled: boolean) => void;
+  // #6822 — submit a pasted OAuth authorization code for a remote MCP server that
+  // reported `oauth-required` (BYOK lane). Sends `submit_mcp_auth_code`; the
+  // server redeems the code, persists the tokens encrypted at rest, and reconnects
+  // authenticated, then re-emits `mcp_servers` with the new status. No-op for an
+  // empty code. The code is a one-time authorization code, never stored client-side.
+  submitMcpAuthCode: (server: string, code: string) => void;
 }
 
 /**

--- a/packages/dashboard/src/components/SidebarMcpView.test.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.test.tsx
@@ -12,10 +12,12 @@ import { SidebarMcpView, mcpViewCollapsedMetric } from './SidebarMcpView'
 // `mock` so vitest allows it inside the hoisted factory. #6824 — the component
 // also selects `setMcpServerEnabled`, so the state carries a spy.
 const mockSetMcpServerEnabled = vi.fn()
+const mockSubmitMcpAuthCode = vi.fn()
 let mockStoreState: Record<string, unknown> = {
   activeSessionId: null,
   sessionStates: {},
   setMcpServerEnabled: mockSetMcpServerEnabled,
+  submitMcpAuthCode: mockSubmitMcpAuthCode,
 }
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockStoreState),
@@ -24,7 +26,8 @@ vi.mock('../store/connection', () => ({
 afterEach(() => {
   cleanup()
   mockSetMcpServerEnabled.mockClear()
-  mockStoreState = { activeSessionId: null, sessionStates: {}, setMcpServerEnabled: mockSetMcpServerEnabled }
+  mockSubmitMcpAuthCode.mockClear()
+  mockStoreState = { activeSessionId: null, sessionStates: {}, setMcpServerEnabled: mockSetMcpServerEnabled, submitMcpAuthCode: mockSubmitMcpAuthCode }
 })
 
 function srv(name: string, status: string): McpServer {
@@ -109,6 +112,48 @@ describe('SidebarMcpView enable/disable toggle (#6824)', () => {
     render(<SidebarMcpView servers={[{ name: 'legacy', status: 'disabled', canToggle: true }]} />)
     const t = screen.getByTestId('sidebar-mcp-view-toggle-legacy')
     expect(t.getAttribute('aria-checked')).toBe('false')
+  })
+})
+
+describe('SidebarMcpView OAuth affordance (#6822)', () => {
+  const oauthSrv: McpServer = { name: 'remote', status: 'oauth-required', enabled: true, canToggle: true, authUrl: 'https://as.example/authorize?x=1' }
+
+  it('renders an Authorize link pointing at the authUrl for an oauth-required server', () => {
+    render(<SidebarMcpView servers={[oauthSrv]} />)
+    const link = screen.getByTestId('sidebar-mcp-view-authorize-remote') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://as.example/authorize?x=1')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(screen.getByTestId('sidebar-mcp-view-auth-input-remote')).toBeTruthy()
+  })
+
+  it('does NOT render the auth affordance for a connected server', () => {
+    render(<SidebarMcpView servers={[{ name: 'fs', status: 'connected', canToggle: true }]} />)
+    expect(screen.queryByTestId('sidebar-mcp-view-auth-fs')).toBeNull()
+  })
+
+  it('submits the pasted code via submitMcpAuthCode(name, code)', () => {
+    render(<SidebarMcpView servers={[oauthSrv]} />)
+    const input = screen.getByTestId('sidebar-mcp-view-auth-input-remote') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '  auth-code-123  ' } })
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-auth-submit-remote'))
+    expect(mockSubmitMcpAuthCode).toHaveBeenCalledTimes(1)
+    expect(mockSubmitMcpAuthCode).toHaveBeenCalledWith('remote', 'auth-code-123')
+    // The input clears after submit.
+    expect(input.value).toBe('')
+  })
+
+  it('does not submit an empty/whitespace code', () => {
+    render(<SidebarMcpView servers={[oauthSrv]} />)
+    const submit = screen.getByTestId('sidebar-mcp-view-auth-submit-remote') as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+    fireEvent.click(submit)
+    expect(mockSubmitMcpAuthCode).not.toHaveBeenCalled()
+  })
+
+  it('renders the paste input even when authUrl is absent (paste-only fallback)', () => {
+    render(<SidebarMcpView servers={[{ name: 'remote', status: 'oauth-required', canToggle: true }]} />)
+    expect(screen.queryByTestId('sidebar-mcp-view-authorize-remote')).toBeNull()
+    expect(screen.getByTestId('sidebar-mcp-view-auth-input-remote')).toBeTruthy()
   })
 })
 

--- a/packages/dashboard/src/components/SidebarMcpView.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.tsx
@@ -19,7 +19,15 @@
  * the switch is broadcast-driven (it reflects the server's re-emitted
  * `mcp_servers` state, not an optimistic guess), so a rejected toggle simply
  * never moves rather than flashing a wrong state.
+ *
+ * #6822 — a remote server that answered 401 reports `status: 'oauth-required'`
+ * with an `authUrl`. The row shows an "Authorize" button that opens the URL in a
+ * new tab (the browser lives on the user's device) plus a paste-code input for
+ * the universal fallback (a remote/tunneled daemon whose loopback callback the
+ * browser can't reach): the user pastes the code back and the daemon redeems it.
+ * Both routes converge on the daemon-side redemption; the flow is broadcast-driven.
  */
+import { useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { McpServer } from '@chroxy/store-core'
 
@@ -51,6 +59,7 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
     return id && s.sessionStates[id] ? s.sessionStates[id].mcpServers : EMPTY_MCP_SERVERS
   })
   const setMcpServerEnabled = useConnectionStore((s) => s.setMcpServerEnabled)
+  const submitMcpAuthCode = useConnectionStore((s) => s.submitMcpAuthCode)
   const servers = serversProp ?? storeServers
 
   return (
@@ -61,47 +70,106 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
         </div>
       ) : (
         <ul className="sidebar-mcp-view-list" data-testid="sidebar-mcp-view-list">
-          {servers.map((server) => {
-            const connected = server.status === 'connected'
-            const enabled = isServerEnabled(server)
-            return (
-              <li
-                key={server.name}
-                className="sidebar-mcp-view-row"
-                data-testid={`sidebar-mcp-view-row-${server.name}`}
-              >
-                <span
-                  className={`sidebar-mcp-view-dot${connected ? ' connected' : ''}`}
-                  data-testid={`sidebar-mcp-view-dot-${server.name}`}
-                  data-status={server.status}
-                  aria-hidden="true"
-                />
-                <span className="sidebar-mcp-view-name" data-testid={`sidebar-mcp-view-name-${server.name}`}>
-                  {server.name}
-                </span>
-                <span className="sidebar-mcp-view-status" data-testid={`sidebar-mcp-view-status-${server.name}`}>
-                  {server.status}
-                </span>
-                {server.canToggle && (
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={enabled}
-                    className={`sidebar-mcp-view-toggle${enabled ? ' enabled' : ''}`}
-                    data-testid={`sidebar-mcp-view-toggle-${server.name}`}
-                    aria-label={`${enabled ? 'Disable' : 'Enable'} MCP server ${server.name}`}
-                    title={enabled ? 'Disable server' : 'Enable server'}
-                    onClick={() => setMcpServerEnabled(server.name, !enabled)}
-                  >
-                    {enabled ? 'On' : 'Off'}
-                  </button>
-                )}
-              </li>
-            )
-          })}
+          {servers.map((server) => (
+            <McpServerRow
+              key={server.name}
+              server={server}
+              onToggle={setMcpServerEnabled}
+              onSubmitAuthCode={submitMcpAuthCode}
+            />
+          ))}
         </ul>
       )}
     </div>
+  )
+}
+
+interface McpServerRowProps {
+  server: McpServer
+  onToggle: (server: string, enabled: boolean) => void
+  onSubmitAuthCode: (server: string, code: string) => void
+}
+
+function McpServerRow({ server, onToggle, onSubmitAuthCode }: McpServerRowProps) {
+  const [code, setCode] = useState('')
+  const connected = server.status === 'connected'
+  const enabled = isServerEnabled(server)
+  const needsAuth = server.status === 'oauth-required'
+
+  return (
+    <li className="sidebar-mcp-view-row" data-testid={`sidebar-mcp-view-row-${server.name}`}>
+      <div className="sidebar-mcp-view-row-main">
+        <span
+          className={`sidebar-mcp-view-dot${connected ? ' connected' : ''}`}
+          data-testid={`sidebar-mcp-view-dot-${server.name}`}
+          data-status={server.status}
+          aria-hidden="true"
+        />
+        <span className="sidebar-mcp-view-name" data-testid={`sidebar-mcp-view-name-${server.name}`}>
+          {server.name}
+        </span>
+        <span className="sidebar-mcp-view-status" data-testid={`sidebar-mcp-view-status-${server.name}`}>
+          {server.status}
+        </span>
+        {server.canToggle && (
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            className={`sidebar-mcp-view-toggle${enabled ? ' enabled' : ''}`}
+            data-testid={`sidebar-mcp-view-toggle-${server.name}`}
+            aria-label={`${enabled ? 'Disable' : 'Enable'} MCP server ${server.name}`}
+            title={enabled ? 'Disable server' : 'Enable server'}
+            onClick={() => onToggle(server.name, !enabled)}
+          >
+            {enabled ? 'On' : 'Off'}
+          </button>
+        )}
+      </div>
+      {needsAuth && (
+        <div className="sidebar-mcp-view-auth" data-testid={`sidebar-mcp-view-auth-${server.name}`}>
+          {server.authUrl && (
+            <a
+              href={server.authUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="sidebar-mcp-view-authorize"
+              data-testid={`sidebar-mcp-view-authorize-${server.name}`}
+            >
+              Authorize
+            </a>
+          )}
+          <form
+            className="sidebar-mcp-view-auth-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              const trimmed = code.trim()
+              if (!trimmed) return
+              onSubmitAuthCode(server.name, trimmed)
+              setCode('')
+            }}
+          >
+            <input
+              type="text"
+              className="sidebar-mcp-view-auth-input"
+              data-testid={`sidebar-mcp-view-auth-input-${server.name}`}
+              placeholder="Paste authorization code"
+              aria-label={`Authorization code for MCP server ${server.name}`}
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+            />
+            <button
+              type="submit"
+              className="sidebar-mcp-view-auth-submit"
+              data-testid={`sidebar-mcp-view-auth-submit-${server.name}`}
+              disabled={!code.trim()}
+            >
+              Submit
+            </button>
+          </form>
+        </div>
+      )}
+    </li>
   )
 }
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3335,6 +3335,28 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
+  // #6822 — submit a pasted OAuth authorization code for a remote MCP server that
+  // reported `oauth-required` (BYOK lane). Broadcast-driven: the server redeems
+  // the code, reconnects the server authenticated, and re-emits `mcp_servers`
+  // with the new status (which drives SidebarMcpView back to `connected` or, on
+  // failure, leaves it `oauth-required`). A `requestId` correlates a rejection
+  // in the server log. No-op when the socket is closed or there is no active
+  // session — mirrors setMcpServerEnabled's silent guard. The code is never
+  // stored client-side.
+  submitMcpAuthCode: (server: string, code: string) => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) return;
+    if (!code || !code.trim()) return;
+    const requestId = `mcp-auth-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    wsSend(socket, {
+      type: 'submit_mcp_auth_code',
+      sessionId: activeSessionId,
+      server,
+      code: code.trim(),
+      requestId,
+    });
+  },
+
   // #6772 — pull the permission audit history for the active session. Sets the
   // loading flag; the reply (`permission_audit_result`) lands in `permissionAudit`
   // (handlePermissionAuditResult). The server filters by sessionId when provided.

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2130,6 +2130,51 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(sent.find((m) => m.type === 'set_mcp_server_enabled')).toBeUndefined();
   });
 
+  // #6822 — submit a pasted OAuth authorization code.
+  it('submitMcpAuthCode sends submit_mcp_auth_code scoped to the active session, trimming the code', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const mockSocket = { readyState: 1, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState() } },
+      socket: mockSocket as unknown as WebSocket,
+    });
+
+    useConnectionStore.getState().submitMcpAuthCode('remote', '  code-123  ');
+
+    const msg = sent.find((m) => m.type === 'submit_mcp_auth_code');
+    expect(msg).toBeDefined();
+    expect(msg!.sessionId).toBe('s1');
+    expect(msg!.server).toBe('remote');
+    expect(msg!.code).toBe('code-123');
+    expect(typeof msg!.requestId).toBe('string');
+  });
+
+  it('submitMcpAuthCode is a no-op for an empty code or a closed socket', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    const sent: Array<Record<string, unknown>> = [];
+    const openSocket = { readyState: 1, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState() } },
+      socket: openSocket as unknown as WebSocket,
+    });
+    // Empty/whitespace code → nothing sent.
+    useConnectionStore.getState().submitMcpAuthCode('remote', '   ');
+    expect(sent.find((m) => m.type === 'submit_mcp_auth_code')).toBeUndefined();
+
+    // Closed socket → nothing sent.
+    const closedSocket = { readyState: 3, send: (d: string) => { sent.push(JSON.parse(d)); } };
+    useConnectionStore.setState({ socket: closedSocket as unknown as WebSocket });
+    useConnectionStore.getState().submitMcpAuthCode('remote', 'code');
+    expect(sent.find((m) => m.type === 'submit_mcp_auth_code')).toBeUndefined();
+  });
+
   it('queryPermissionAudit sets the loading flag and sends query_permission_audit scoped to the active session', async () => {
     const { useConnectionStore } = await import('./connection');
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1515,6 +1515,16 @@ export interface ConnectionState {
    */
   setMcpServerEnabled: (server: string, enabled: boolean) => void;
   /**
+   * #6822 — submit a pasted OAuth authorization code for a remote MCP server that
+   * reported `status: 'oauth-required'` (BYOK lane). Sends `submit_mcp_auth_code`;
+   * the daemon redeems the code, persists the tokens encrypted at rest, and
+   * reconnects the server authenticated, then re-emits `mcp_servers` with the new
+   * status (converging every device). No-op when the socket is closed or there is
+   * no active session. `code` is a one-time authorization code — never persisted
+   * client-side.
+   */
+  submitMcpAuthCode: (server: string, code: string) => void;
+  /**
    * #6772 — pull the permission audit history for the active session
    * (`query_permission_audit`). Sets `permissionAuditLoading`; the reply lands in
    * `permissionAudit`. No-op when disconnected.

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1458,9 +1458,17 @@ button.sidebar-token-view-session-row:hover {
 
 .sidebar-mcp-view-row {
   display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+
+/* The name/status/toggle line — the row's primary content. The oauth-required
+   authorize affordance (#6822) stacks beneath it. */
+.sidebar-mcp-view-row-main {
+  display: flex;
   align-items: baseline;
   gap: 8px;
-  font-size: 12px;
 }
 
 .sidebar-mcp-view-dot {
@@ -1520,6 +1528,65 @@ button.sidebar-token-view-session-row:hover {
 
 .sidebar-mcp-view-toggle:hover {
   filter: brightness(1.15);
+}
+
+/* #6822 — OAuth authorize affordance for an oauth-required remote MCP server.
+   The "Authorize" link opens the browser authorization URL (on the user's own
+   device); the paste-code form is the universal fallback for a remote/tunneled
+   daemon whose loopback callback the browser can't reach. */
+.sidebar-mcp-view-auth {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 16px;
+}
+
+.sidebar-mcp-view-authorize {
+  align-self: flex-start;
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--accent, #3b82f6);
+  color: var(--accent, #3b82f6);
+  font-size: 11px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.sidebar-mcp-view-authorize:hover {
+  filter: brightness(1.15);
+}
+
+.sidebar-mcp-view-auth-form {
+  display: flex;
+  gap: 6px;
+}
+
+.sidebar-mcp-view-auth-input {
+  flex: 1;
+  min-width: 0;
+  padding: 3px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border-subtle, var(--text-muted));
+  background: var(--surface-1, transparent);
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
+.sidebar-mcp-view-auth-submit {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--accent, #3b82f6);
+  background: transparent;
+  color: var(--accent, #3b82f6);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sidebar-mcp-view-auth-submit:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
 /* #5163 (epic #5159) — Control Room panel: live read-only activity tree. */

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -242,6 +242,13 @@ export declare const SetMcpServerEnabledSchema: z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const SubmitMcpAuthCodeSchema: z.ZodObject<{
+    type: z.ZodLiteral<"submit_mcp_auth_code">;
+    server: z.ZodString;
+    code: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const SetPromptEvaluatorSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_prompt_evaluator">;
     value: z.ZodBoolean;
@@ -994,6 +1001,12 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"submit_mcp_auth_code">;
+    server: z.ZodString;
+    code: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"set_prompt_evaluator">;
     value: z.ZodBoolean;
     sessionId: z.ZodOptional<z.ZodString>;
@@ -1543,6 +1556,7 @@ export type SetModelMessage = z.infer<typeof SetModelSchema>;
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>;
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>;
 export type SetMcpServerEnabledMessage = z.infer<typeof SetMcpServerEnabledSchema>;
+export type SubmitMcpAuthCodeMessage = z.infer<typeof SubmitMcpAuthCodeSchema>;
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>;
 export type GetPermissionInputMessage = z.infer<typeof GetPermissionInputSchema>;
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -277,6 +277,26 @@ export const SetMcpServerEnabledSchema = z.object({
     sessionId: z.string().max(256).optional(),
     requestId: z.string().max(256).optional(),
 });
+// #6822: submit a pasted OAuth authorization code for a remote MCP server that
+// reported `status: 'oauth-required'`. The daemon holds the PKCE verifier +
+// state server-side; the user completed consent in a browser on THEIR device
+// and pastes back the code (the universal fallback when the daemon's loopback
+// callback isn't reachable from a remote/tunneled browser). The daemon redeems
+// the code, persists the tokens encrypted at rest, and reconnects the server
+// authenticated — then re-emits `mcp_servers` so all clients converge. Only the
+// BYOK lane runs an in-daemon MCP fleet, so other providers reject this with an
+// `MCP_AUTH_UNSUPPORTED` capability error. `requestId` (optional) echoes back on
+// rejection. `sessionId` is optional; the handler falls back to the client's
+// bound active session — and a pairing-bound token may only target its own
+// session (the same own-session gate as `set_mcp_server_enabled`). The `code`
+// is a short-lived one-time authorization code, never logged.
+export const SubmitMcpAuthCodeSchema = z.object({
+    type: z.literal('submit_mcp_auth_code'),
+    server: z.string().min(1).max(256),
+    code: z.string().min(1).max(4096),
+    sessionId: z.string().max(256).optional(),
+    requestId: z.string().max(256).optional(),
+});
 // #3185: per-session promptEvaluator toggle. Strict boolean — the server
 // rejects anything else with a `session_error`. `sessionId` is optional;
 // the handler falls back to the client's bound active session.
@@ -1366,6 +1386,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     SetThinkingLevelSchema,
     SetPermissionRulesSchema,
     SetMcpServerEnabledSchema,
+    SubmitMcpAuthCodeSchema,
     SetPromptEvaluatorSchema,
     SetPromptEvaluatorSkipPatternSchema,
     SetChroxyContextHintSchema,

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -32,6 +32,7 @@ export declare const ServerMcpServersSchema: z.ZodObject<{
         status: z.ZodString;
         enabled: z.ZodOptional<z.ZodBoolean>;
         canToggle: z.ZodOptional<z.ZodBoolean>;
+        authUrl: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>;
 }, z.core.$strip>;
 export declare const ServerPlanStartedSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -84,6 +84,14 @@ export const ServerMcpServersSchema = z.object({
         // Both optional so pre-#6824 emitters (and other providers) round-trip.
         enabled: z.boolean().optional(),
         canToggle: z.boolean().optional(),
+        // #6822: when a remote MCP server answered a connect with 401, the daemon
+        // surfaces the browser authorization URL here alongside `status:
+        // 'oauth-required'`. The client opens it (new-tab / Linking.openURL) and,
+        // for a remote/tunneled daemon whose loopback callback the browser can't
+        // reach, submits the pasted code back via `submit_mcp_auth_code`. Carries
+        // ONLY the public authorization URL — never a token/verifier/secret.
+        // Optional (present only on the oauth-required entry).
+        authUrl: z.string().optional(),
     })),
 });
 export const ServerPlanStartedSchema = z.object({

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -315,6 +315,27 @@ export const SetMcpServerEnabledSchema = z.object({
   requestId: z.string().max(256).optional(),
 })
 
+// #6822: submit a pasted OAuth authorization code for a remote MCP server that
+// reported `status: 'oauth-required'`. The daemon holds the PKCE verifier +
+// state server-side; the user completed consent in a browser on THEIR device
+// and pastes back the code (the universal fallback when the daemon's loopback
+// callback isn't reachable from a remote/tunneled browser). The daemon redeems
+// the code, persists the tokens encrypted at rest, and reconnects the server
+// authenticated — then re-emits `mcp_servers` so all clients converge. Only the
+// BYOK lane runs an in-daemon MCP fleet, so other providers reject this with an
+// `MCP_AUTH_UNSUPPORTED` capability error. `requestId` (optional) echoes back on
+// rejection. `sessionId` is optional; the handler falls back to the client's
+// bound active session — and a pairing-bound token may only target its own
+// session (the same own-session gate as `set_mcp_server_enabled`). The `code`
+// is a short-lived one-time authorization code, never logged.
+export const SubmitMcpAuthCodeSchema = z.object({
+  type: z.literal('submit_mcp_auth_code'),
+  server: z.string().min(1).max(256),
+  code: z.string().min(1).max(4096),
+  sessionId: z.string().max(256).optional(),
+  requestId: z.string().max(256).optional(),
+})
+
 // #3185: per-session promptEvaluator toggle. Strict boolean — the server
 // rejects anything else with a `session_error`. `sessionId` is optional;
 // the handler falls back to the client's bound active session.
@@ -1537,6 +1558,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   SetThinkingLevelSchema,
   SetPermissionRulesSchema,
   SetMcpServerEnabledSchema,
+  SubmitMcpAuthCodeSchema,
   SetPromptEvaluatorSchema,
   SetPromptEvaluatorSkipPatternSchema,
   SetChroxyContextHintSchema,
@@ -1668,6 +1690,7 @@ export type SetModelMessage = z.infer<typeof SetModelSchema>
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>
 export type SetMcpServerEnabledMessage = z.infer<typeof SetMcpServerEnabledSchema>
+export type SubmitMcpAuthCodeMessage = z.infer<typeof SubmitMcpAuthCodeSchema>
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>
 export type GetPermissionInputMessage = z.infer<typeof GetPermissionInputSchema>
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -90,6 +90,14 @@ export const ServerMcpServersSchema = z.object({
     // Both optional so pre-#6824 emitters (and other providers) round-trip.
     enabled: z.boolean().optional(),
     canToggle: z.boolean().optional(),
+    // #6822: when a remote MCP server answered a connect with 401, the daemon
+    // surfaces the browser authorization URL here alongside `status:
+    // 'oauth-required'`. The client opens it (new-tab / Linking.openURL) and,
+    // for a remote/tunneled daemon whose loopback callback the browser can't
+    // reach, submits the pasted code back via `submit_mcp_auth_code`. Carries
+    // ONLY the public authorization URL — never a token/verifier/secret.
+    // Optional (present only on the oauth-required entry).
+    authUrl: z.string().optional(),
   })),
 })
 

--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -33,6 +33,8 @@ import { createLogger } from './logger.js'
 import { isBlockedMetadataHost } from './byok-mcp-config.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { prepareSpawn } from './utils/win-spawn.js'
+import * as realOAuthFlow from './byok-mcp-oauth.js'
+import * as realOAuthStore from './byok-mcp-oauth-store.js'
 
 // #4453: exponential restart backoff. The first restart still fires at ~1s
 // after the death (no regression on the existing acceptance test); the
@@ -582,9 +584,31 @@ export class MCPRemoteClient extends EventEmitter {
     this._nextId = 1
     this._sessionId = null
     this._negotiatedProtocolVersion = null
-    // 'oauth-required' after a 401/407 (needs the OAuth flow from #6822), else
-    // null. Read for status surfacing — never carries any header/token value.
+    // 'oauth-required' after a 401/407 that the OAuth flow (#6822) could not
+    // silently satisfy — the client surfaces `authorizationUrl` for the user to
+    // open. null otherwise. Never carries any header/token value.
     this._statusReason = null
+    // #6822 OAuth 2.1 + PKCE for a remote server that answers 401. Injectable
+    // seams (default the real modules) keep the flow testable against an
+    // in-process mock AS/RS with no real network + no real keychain.
+    this._oauthEnabled = opts.oauthEnabled !== false
+    this._oauthFlow = opts.oauthFlow || realOAuthFlow
+    this._oauthStore = opts.oauthStore || realOAuthStore
+    // The redirect_uri the daemon registers + surfaces. Defaults to the
+    // configured daemon callback (loopback/tunnel); tests pass a fixed value.
+    this._oauthRedirectUri = opts.oauthRedirectUri || null
+    // Bearer access token (from a stored record or a completed authorization).
+    // Merged into every request's headers via `_authHeader()` — OAuth wins over
+    // any static Authorization header the config carried.
+    this._accessToken = null
+    // The browser authorization URL surfaced to clients while `oauth-required`.
+    this._authorizationUrl = null
+    // Server-side PKCE/state/token-endpoint bag from beginAuthorization, consumed
+    // by completeAuthorization. Holds secret material — never logged/surfaced.
+    this._authPending = null
+    // Guards a single proactive/reactive refresh attempt per start() so a broken
+    // refresh token can't spin the connect loop.
+    this._refreshAttempted = false
     this._destroyed = false
     // In-flight AbortControllers, aborted on destroy() so a hung request or a
     // persistent SSE stream cannot keep the process alive after teardown.
@@ -603,6 +627,10 @@ export class MCPRemoteClient extends EventEmitter {
   get prompts() { return this._prompts }
   get resources() { return this._resources }
   get statusReason() { return this._statusReason }
+  /** #6822: the browser authorization URL to open while `oauth-required`, else null. */
+  get authorizationUrl() { return this._authorizationUrl }
+  /** #6822: true when this server is waiting for the user to complete OAuth. */
+  get needsAuthorization() { return this._statusReason === 'oauth-required' }
 
   async start() {
     if (this._destroyed) throw new Error('MCPRemoteClient destroyed')
@@ -633,24 +661,199 @@ export class MCPRemoteClient extends EventEmitter {
         return
       }
     }
+    // #6822: prime a stored access token (refreshing it up front if expired) so a
+    // previously-authorized server reconnects with no user prompt.
+    await this._prepareStoredToken()
     this._setState(MCP_STATES.STARTING)
     try {
-      if (this._transportType === 'sse') await this._connectLegacySse()
-      else await this._handshakeStreamableHttp()
+      await this._attemptConnect()
       if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
       this._setState(MCP_STATES.READY)
       this.emit('ready', this._tools)
     } catch (err) {
       if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
       if (err && err._oauthRequired) {
-        // Deferred to #6822 — surface a clear status instead of crashing.
-        this._statusReason = 'oauth-required'
-        this._log.warn(`MCP server ${this.name}: requires OAuth — not yet supported (#6822)`)
-      } else {
-        this._log.warn(`MCP server ${this.name}: connect failed: ${err?.message || err}`)
+        await this._onOAuthRequired(err)
+        return
       }
+      this._log.warn(`MCP server ${this.name}: connect failed: ${err?.message || err}`)
       this._toDead()
     }
+  }
+
+  /** Run the transport handshake once (fresh transport counters each attempt). */
+  async _attemptConnect() {
+    this._resetTransportState()
+    if (this._transportType === 'sse') await this._connectLegacySse()
+    else await this._handshakeStreamableHttp()
+  }
+
+  /** Reset per-connection transport state so a re-attempt starts clean (#6822). */
+  _resetTransportState() {
+    this._sessionId = null
+    this._negotiatedProtocolVersion = null
+    this._nextId = 1
+    this._endpointUrl = null
+    this._rejectAllPending(new Error('reconnecting'))
+  }
+
+  /**
+   * #6822: a connect answered 401/407. Try, in order:
+   *   1. a silent refresh (an existing-but-expired token whose refresh works) →
+   *      reconnect authenticated;
+   *   2. begin a browser authorization — discover the AS, register a client, and
+   *      surface the authorization URL (status `oauth-required`).
+   * Any failure falls through to a value-free `oauth-required` DEAD state.
+   */
+  async _onOAuthRequired(err) {
+    // (1) silent refresh of an existing token.
+    if (this._oauthEnabled && this._accessToken && !this._refreshAttempted) {
+      this._refreshAttempted = true
+      const refreshed = await this._tryRefresh()
+      if (refreshed && !this._destroyed) {
+        try {
+          await this._attemptConnect()
+          if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
+          this._setState(MCP_STATES.READY)
+          this.emit('ready', this._tools)
+          return
+        } catch (retryErr) {
+          if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
+          if (!(retryErr && retryErr._oauthRequired)) {
+            this._log.warn(`MCP server ${this.name}: reconnect after refresh failed: ${retryErr?.message || retryErr}`)
+            this._toDead()
+            return
+          }
+          // Refresh succeeded but the server still rejects — fall through to a
+          // fresh browser authorization below.
+          err = retryErr
+        }
+      }
+    }
+    // (2) begin browser authorization.
+    await this._beginBrowserAuthorization(err)
+  }
+
+  /**
+   * Attempt to refresh the stored token in place. Returns true on success (with
+   * `_accessToken` updated + the record persisted), false otherwise. The stored
+   * record is left intact on failure so a subsequent full re-auth can replace it.
+   */
+  async _tryRefresh() {
+    let record
+    try { record = this._oauthStore.getStoredToken(this._url) } catch { record = null }
+    if (!record || !record.refreshToken || !record.tokenEndpoint) return false
+    try {
+      const tokens = await this._oauthFlow.refreshAccessToken({
+        tokenEndpoint: record.tokenEndpoint,
+        clientId: record.clientId,
+        clientSecret: record.clientSecret,
+        refreshToken: record.refreshToken,
+        scope: record.scope,
+        resource: record.resource,
+        fetchImpl: this._fetchImpl,
+      })
+      const next = { ...record, ...tokens }
+      this._oauthStore.setStoredToken(this._url, next)
+      this._accessToken = next.accessToken
+      return true
+    } catch (refreshErr) {
+      this._log.debug(`MCP server ${this.name}: token refresh failed: ${refreshErr?.message || refreshErr}`)
+      return false
+    }
+  }
+
+  /**
+   * Discover + register + build the authorization URL, surfacing it as
+   * `oauth-required`. Registers a callback keyed by the flow's `state` so the
+   * daemon's loopback/tunnel callback can auto-complete; the paste-code path
+   * (completeAuthorization) is the universal fallback. Never throws.
+   */
+  async _beginBrowserAuthorization(err) {
+    const redirectUri = this._oauthRedirectUri || this._oauthFlow.mcpOAuthRedirectUri?.()
+    if (!this._oauthEnabled || !redirectUri) {
+      this._statusReason = 'oauth-required'
+      this._log.warn(`MCP server ${this.name}: requires OAuth but the flow is disabled or no redirect URI is configured`)
+      this._toDead()
+      return
+    }
+    try {
+      const { authorizationUrl, pending } = await this._oauthFlow.beginAuthorization({
+        serverUrl: this._url,
+        wwwAuthenticate: err?._wwwAuthenticate || null,
+        redirectUri,
+        fetchImpl: this._fetchImpl,
+        log: this._log,
+      })
+      if (this._destroyed) { this._setState(MCP_STATES.DESTROYED); return }
+      this._authPending = pending
+      this._authorizationUrl = authorizationUrl
+      this._statusReason = 'oauth-required'
+      // Register the loopback/tunnel auto-complete handler. The paste-code path
+      // shares completeAuthorization, so both redemption routes are equivalent.
+      try {
+        this._oauthFlow.registerOAuthCallback?.(pending.state, (code) => this.completeAuthorization(code))
+      } catch { /* registry is best-effort — paste-code still works */ }
+      this._log.info(`MCP server ${this.name}: OAuth authorization required — surfaced an authorization URL`)
+    } catch (authErr) {
+      this._statusReason = 'oauth-required'
+      this._log.warn(`MCP server ${this.name}: could not begin OAuth authorization: ${authErr?.message || authErr}`)
+    }
+    // Not ready — DEAD until a code is submitted (contributes zero tools). The
+    // oauth-required fields survive _toDead so the fleet can surface them.
+    this._toDead()
+  }
+
+  /**
+   * #6822: complete an authorization by redeeming `code` against the pending
+   * PKCE/state bag, persisting the tokens, and reconnecting authenticated. Shared
+   * by the loopback callback and the paste-code wire path. Throws (value-free) on
+   * redemption failure; resolves once the reconnect settles.
+   *
+   * @param {string} code
+   * @returns {Promise<{ ok: true }>}
+   */
+  async completeAuthorization(code) {
+    if (this._destroyed) throw new Error('MCPRemoteClient destroyed')
+    if (!this._authPending) throw new Error(`MCP server ${this.name}: no pending authorization`)
+    if (typeof code !== 'string' || !code.trim()) throw new Error('an authorization code is required')
+    const pending = this._authPending
+    const record = await this._oauthFlow.completeAuthorization({
+      pending,
+      code: code.trim(),
+      fetchImpl: this._fetchImpl,
+    })
+    this._oauthStore.setStoredToken(this._url, record)
+    this._accessToken = record.accessToken
+    // Clear the pending-auth surface and reconnect.
+    try { this._oauthFlow.unregisterOAuthCallback?.(pending.state) } catch { /* best-effort */ }
+    this._authPending = null
+    this._authorizationUrl = null
+    this._statusReason = null
+    this._refreshAttempted = false
+    this._state = MCP_STATES.IDLE
+    await this.start()
+    return { ok: true }
+  }
+
+  /**
+   * Load a stored token for this server, refreshing it up front when expired.
+   * Sets `_accessToken` when a usable token is available. Read/refresh failures
+   * degrade to unauthenticated (the connect then 401s and re-authorizes).
+   */
+  async _prepareStoredToken() {
+    this._refreshAttempted = false
+    if (!this._oauthEnabled) return
+    let record
+    try { record = this._oauthStore.getStoredToken(this._url) } catch { record = null }
+    if (!record) return
+    if (this._oauthStore.isTokenExpired(record)) {
+      this._refreshAttempted = true
+      const refreshed = await this._tryRefresh()
+      if (!refreshed) this._accessToken = null
+      return
+    }
+    this._accessToken = record.accessToken
   }
 
   /**
@@ -712,6 +915,11 @@ export class MCPRemoteClient extends EventEmitter {
     if (this._destroyed) return
     this._destroyed = true
     if (this._endpointTimer) { clearTimeout(this._endpointTimer); this._endpointTimer = null }
+    // #6822: drop any pending-auth callback so a torn-down client can't be
+    // completed via the loopback registry after destroy.
+    if (this._authPending?.state) {
+      try { this._oauthFlow.unregisterOAuthCallback?.(this._authPending.state) } catch { /* best-effort */ }
+    }
     this._rejectAllPending(new Error('MCP remote client destroyed'))
     for (const c of this._controllers) { try { c.abort() } catch { /* already settled */ } }
     this._controllers.clear()
@@ -823,9 +1031,7 @@ export class MCPRemoteClient extends EventEmitter {
         return // initialize already succeeded; a lost `initialized` is non-fatal
       }
       if (res.status === 401 || res.status === 407) {
-        const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${res.status})`)
-        err._oauthRequired = true
-        throw err
+        throw this._oauthError(res, res.status)
       }
       await this._discardBody(res)
     } finally {
@@ -865,7 +1071,8 @@ export class MCPRemoteClient extends EventEmitter {
     try {
       res = await this._fetchImpl(this._url, {
         method: 'GET',
-        headers: { ...this._headers, Accept: 'text/event-stream' },
+        // #6822: include the OAuth bearer token (if any) on the SSE GET too.
+        headers: { ...this._headers, ...this._authHeader(), Accept: 'text/event-stream' },
         redirect: 'manual', // #6834: never follow a redirect off-origin
         signal: controller.signal,
       })
@@ -874,9 +1081,7 @@ export class MCPRemoteClient extends EventEmitter {
       throw err
     }
     if (res.status === 401 || res.status === 407) {
-      const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${res.status})`)
-      err._oauthRequired = true
-      throw err
+      throw this._oauthError(res, res.status)
     }
     if (res.status >= 300 && res.status < 400) {
       throw new Error(`MCP server ${this.name} HTTP ${res.status} redirect opening SSE stream — refused (redirects are not followed)`)
@@ -1111,15 +1316,34 @@ export class MCPRemoteClient extends EventEmitter {
     // on every post-initialize request per the 2025-03-26 / 2025-06-18 spec.
     if (this._sessionId) headers['Mcp-Session-Id'] = this._sessionId
     if (this._negotiatedProtocolVersion) headers['MCP-Protocol-Version'] = this._negotiatedProtocolVersion
+    // #6822: an OAuth access token (from a stored record or a completed flow)
+    // overrides any static Authorization header the config carried — it is the
+    // fresher credential. Set LAST so it wins the spread above.
+    Object.assign(headers, this._authHeader())
     return headers
+  }
+
+  /** #6822: the OAuth Authorization header, or an empty object when no token. */
+  _authHeader() {
+    return this._accessToken ? { Authorization: `Bearer ${this._accessToken}` } : {}
+  }
+
+  /**
+   * #6822: build the 401/407 error, capturing the `WWW-Authenticate` header so the
+   * OAuth flow can discover the resource metadata. The header names only public
+   * discovery URLs (never a token), so retaining it is safe.
+   */
+  _oauthError(res, status) {
+    const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${status})`)
+    err._oauthRequired = true
+    try { err._wwwAuthenticate = res?.headers?.get?.('www-authenticate') || null } catch { err._wwwAuthenticate = null }
+    return err
   }
 
   _checkStatus(res, method) {
     const status = res.status
     if (status === 401 || status === 407) {
-      const err = new Error(`MCP server ${this.name} requires OAuth (HTTP ${status})`)
-      err._oauthRequired = true
-      throw err
+      throw this._oauthError(res, status)
     }
     // #6834: with redirect:'manual' a 3xx surfaces here as-is. Refuse it
     // explicitly — following would replay our credentialed headers against

--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -1071,8 +1071,10 @@ export class MCPRemoteClient extends EventEmitter {
     try {
       res = await this._fetchImpl(this._url, {
         method: 'GET',
-        // #6822: include the OAuth bearer token (if any) on the SSE GET too.
-        headers: { ...this._headers, ...this._authHeader(), Accept: 'text/event-stream' },
+        // #6822: include the OAuth bearer token (if any) on the SSE GET too, via
+        // _applyOAuthHeader so a config-supplied `authorization` doesn't collide
+        // with a fresh `Authorization` (two auth headers).
+        headers: this._applyOAuthHeader({ ...this._headers, Accept: 'text/event-stream' }),
         redirect: 'manual', // #6834: never follow a redirect off-origin
         signal: controller.signal,
       })
@@ -1316,16 +1318,24 @@ export class MCPRemoteClient extends EventEmitter {
     // on every post-initialize request per the 2025-03-26 / 2025-06-18 spec.
     if (this._sessionId) headers['Mcp-Session-Id'] = this._sessionId
     if (this._negotiatedProtocolVersion) headers['MCP-Protocol-Version'] = this._negotiatedProtocolVersion
-    // #6822: an OAuth access token (from a stored record or a completed flow)
-    // overrides any static Authorization header the config carried — it is the
-    // fresher credential. Set LAST so it wins the spread above.
-    Object.assign(headers, this._authHeader())
-    return headers
+    return this._applyOAuthHeader(headers)
   }
 
-  /** #6822: the OAuth Authorization header, or an empty object when no token. */
-  _authHeader() {
-    return this._accessToken ? { Authorization: `Bearer ${this._accessToken}` } : {}
+  /**
+   * #6822: when an OAuth access token exists, replace ANY authorization header
+   * the config carried (case-insensitively — a config `authorization` collides
+   * with a fresh `Authorization`, sending TWO auth headers) with the OAuth
+   * bearer, which is the fresher credential. Mutates + returns `headers`. When
+   * there is no token, the config's own header (whatever its case) passes
+   * through untouched.
+   */
+  _applyOAuthHeader(headers) {
+    if (!this._accessToken) return headers
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'authorization') delete headers[key]
+    }
+    headers.Authorization = `Bearer ${this._accessToken}`
+    return headers
   }
 
   /**

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -187,9 +187,40 @@ export class MCPFleet {
         return { name: cfg.name, status: 'disabled', enabled: false, canToggle: true }
       }
       const client = this._clients.find((c) => c.name === cfg.name)
+      // #6822: a remote server awaiting OAuth reports `oauth-required` + the
+      // browser authorization URL (never a token/secret), so the client can
+      // render an "Authorize" affordance instead of a bare failure.
+      if (client && client.needsAuthorization) {
+        const entry = { name: cfg.name, status: 'oauth-required', enabled: true, canToggle: true }
+        if (client.authorizationUrl) entry.authUrl = client.authorizationUrl
+        return entry
+      }
       const status = client ? mcpStateToStatus(client.state) : 'connecting'
       return { name: cfg.name, status, enabled: true, canToggle: true }
     })
+  }
+
+  /**
+   * #6822: submit a pasted OAuth authorization code for a configured remote MCP
+   * server, redeeming it at the daemon and reconnecting authenticated. Returns
+   * `{ found, ok?, status?, error? }` — `found: false` when `name` is not a
+   * configured server; `ok: false` with a value-free `error` on a redemption
+   * failure. On success the fleet re-emits nothing itself (byok-session re-emits
+   * `mcp_servers` after the call so all clients converge).
+   */
+  async submitAuthCode(name, code) {
+    const client = this._clients.find((c) => c.name === name)
+    if (!client) return { found: false }
+    if (typeof client.completeAuthorization !== 'function') {
+      return { found: true, ok: false, error: 'This MCP server does not use OAuth authorization.' }
+    }
+    try {
+      await client.completeAuthorization(code)
+      const status = client.needsAuthorization ? 'oauth-required' : mcpStateToStatus(client.state)
+      return { found: true, ok: true, status }
+    } catch (err) {
+      return { found: true, ok: false, error: err?.message || String(err) }
+    }
   }
 
   /**

--- a/packages/server/src/byok-mcp-oauth-store.js
+++ b/packages/server/src/byok-mcp-oauth-store.js
@@ -27,6 +27,7 @@ import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
 import * as realKeychain from './keychain.js'
+import { createLogger } from './logger.js'
 import {
   isEncryptedEnvelope,
   decryptEnvelope,
@@ -34,6 +35,21 @@ import {
   getMasterKey,
   getOrCreateMasterKey,
 } from './credential-cipher.js'
+
+// One-time breadcrumb when an intact encrypted token record exists on disk but
+// its keychain data key is currently unavailable (locked keychain / transient
+// probe failure) — matches credential-store's warnKeychainUnavailableOnce so a
+// silent unauthenticated MCP reconnect is observable. The value is NEVER logged.
+const _log = createLogger('mcp-oauth-store')
+let _keychainUnavailableWarned = false
+function warnKeychainUnavailableOnce() {
+  if (_keychainUnavailableWarned) return
+  _keychainUnavailableWarned = true
+  _log.warn(
+    'an MCP OAuth token is stored (encrypted) but its OS keychain data key is currently unavailable — ' +
+    'resolving as absent; the server may re-prompt for authorization. Unlock the OS keychain and retry.',
+  )
+}
 
 // A keychain stub reporting "no keychain here" — selects the plaintext fallback.
 const NO_KEYCHAIN = { isKeychainAvailable: () => false }
@@ -160,6 +176,16 @@ function writeStoreAtomically(nextObj) {
     if (process.platform !== 'win32') chmodSync(tmp, 0o600)
     renameSync(tmp, target)
     renamed = true
+    // Post-rename mode re-check (POSIX), matching credential-store: if the file
+    // landed with anything other than 0600, remove it and fail rather than
+    // leaving tokens at a more permissive mode.
+    if (process.platform !== 'win32') {
+      const perms = statSync(target).mode & 0o777
+      if (perms !== 0o600) {
+        try { unlinkSync(target) } catch { /* best-effort */ }
+        throw new Error(`mcp-oauth-tokens ended up with mode ${perms.toString(8)} after write; refused`)
+      }
+    }
   } finally {
     if (!renamed && existsSync(tmp)) {
       try { unlinkSync(tmp) } catch { /* best-effort */ }
@@ -194,8 +220,14 @@ function writeStoreAtomically(nextObj) {
 export function getStoredToken(url) {
   const serverKey = serverKeyForUrl(url)
   if (!serverKey) return null
-  const { data, error } = readStore()
-  if (error) return null
+  const { data, error, keychainUnavailable } = readStore()
+  if (error) {
+    // Distinguish the RECOVERABLE keychain-locked case (intact envelope, key
+    // temporarily unfetchable) from a corrupt/bad-mode read: only the former
+    // gets the one-time breadcrumb, matching credential-store's discipline.
+    if (keychainUnavailable) warnKeychainUnavailableOnce()
+    return null
+  }
   const rec = data[serverKey]
   if (!rec || typeof rec !== 'object' || typeof rec.accessToken !== 'string' || !rec.accessToken) return null
   return rec

--- a/packages/server/src/byok-mcp-oauth-store.js
+++ b/packages/server/src/byok-mcp-oauth-store.js
@@ -1,0 +1,258 @@
+/**
+ * Encrypted-at-rest token store for remote MCP OAuth (#6822).
+ *
+ * A remote MCP server (BYOK remote transport, #6821) that requires browser-based
+ * OAuth (#6822) yields access + refresh tokens the daemon must persist so a
+ * previously-authorized server reconnects without re-prompting. Those tokens are
+ * CREDENTIALS — this module stores them with the same at-rest protection the
+ * credential store uses (#5154 / #6644): a 0600 owner-only JSON file whose whole
+ * body is encrypted with a random data key held in the OS keychain (macOS
+ * Keychain / Linux libsecret / Windows DPAPI), via credential-cipher.js. Where no
+ * keychain is available the store falls back to 0600 plaintext (a key beside the
+ * file would be obfuscation, not security) — identical posture to credential-store.
+ *
+ * File: `~/.chroxy/mcp-oauth-tokens.json`
+ * Layout (decrypted): `{ "<serverKey>": <McpOAuthRecord>, ... }` keyed by a
+ * normalized form of the server URL (origin + path, no userinfo/query/fragment)
+ * so a single server identity survives header/token rotation on the config side.
+ *
+ * SECURITY: token/secret VALUES never leave this module except through the
+ * getters that hand them to the OAuth flow. Nothing here is ever logged — not the
+ * record, not the key, not a masked form. The keychain is dependency-injected
+ * (mirrors credential-cipher) so tests drive the encrypted path with an in-memory
+ * key and NEVER touch the real OS keychain.
+ */
+import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import { randomBytes } from 'node:crypto'
+import * as realKeychain from './keychain.js'
+import {
+  isEncryptedEnvelope,
+  decryptEnvelope,
+  encryptJson,
+  getMasterKey,
+  getOrCreateMasterKey,
+} from './credential-cipher.js'
+
+// A keychain stub reporting "no keychain here" — selects the plaintext fallback.
+const NO_KEYCHAIN = { isKeychainAvailable: () => false }
+
+// Explicit test injection (an in-memory keychain), or null to use the resolved
+// default. Mirrors credential-store's `_setCredentialKeychainForTests` seam.
+let _keychainOverride = null
+
+/**
+ * Resolve the keychain to use for at-rest encryption, evaluated lazily per call
+ * (never captured at import). Precedence:
+ *   1. explicit test injection wins;
+ *   2. `CHROXY_CRED_DISABLE_KEYCHAIN=1` forces the plaintext fallback (the switch
+ *      the test bootstrap sets so suites never touch the real keychain);
+ *   3. the real OS keychain.
+ */
+function activeKeychain() {
+  if (_keychainOverride) return _keychainOverride
+  if (process.env.CHROXY_CRED_DISABLE_KEYCHAIN === '1') return NO_KEYCHAIN
+  return realKeychain
+}
+
+/** Test seam: inject a keychain (e.g. an in-memory one), or null to reset. */
+export function _setMcpOAuthKeychainForTests(keychain) {
+  _keychainOverride = keychain || null
+}
+
+// Lazy-resolved per call so tests that mutate process.env.HOME between cases pick
+// up the new home (frozen-at-import would break the CHROXY_*_HOME isolation the
+// provider-oauth-test-isolation memory prescribes).
+function tokensFilePath() {
+  return process.env.CHROXY_MCP_OAUTH_TOKENS_PATH || join(homedir(), '.chroxy', 'mcp-oauth-tokens.json')
+}
+
+/**
+ * Normalize a server URL into the stable per-server storage key: origin + path,
+ * lowercased host, no userinfo / query / fragment, no trailing slash. This is the
+ * server's OAuth "resource" identity — two configs pointing at the same endpoint
+ * with different bearer headers share one token record. Returns null for an
+ * unparseable url (caller treats that as "not storable").
+ *
+ * @param {string} url
+ * @returns {string|null}
+ */
+export function serverKeyForUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return null
+  try {
+    const u = new URL(url)
+    u.username = ''
+    u.password = ''
+    u.search = ''
+    u.hash = ''
+    let s = u.toString()
+    if (s.endsWith('/')) s = s.slice(0, -1)
+    return s
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read + parse the tokens file, enforcing the 0600 mode boundary and decrypting
+ * an encrypted envelope. Returns `{ data, fileExists, error }`. On any read error
+ * `data` is `{}` and `error` carries a VALUE-FREE reason (never a token). Modeled
+ * on credential-store.readStore.
+ */
+function readStore() {
+  const file = tokensFilePath()
+  let stat
+  try {
+    stat = statSync(file)
+  } catch (err) {
+    if (err.code === 'ENOENT') return { data: {}, fileExists: false, error: null }
+    return { data: {}, fileExists: false, error: `unable to stat ${file}: ${err.message}` }
+  }
+  if (process.platform !== 'win32') {
+    const perms = stat.mode & 0o777
+    if (perms !== 0o600) {
+      return {
+        data: {},
+        fileExists: true,
+        error: `${file} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600)`,
+      }
+    }
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf8'))
+  } catch (err) {
+    return { data: {}, fileExists: true, error: `${file} unreadable or not valid JSON: ${err.message}` }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { data: {}, fileExists: true, error: `${file} is not a JSON object` }
+  }
+  if (isEncryptedEnvelope(parsed)) {
+    const key = getMasterKey(activeKeychain())
+    if (!key) {
+      return { data: {}, fileExists: true, error: `${file} is encrypted but its keychain data key is unavailable`, keychainUnavailable: true }
+    }
+    try {
+      return { data: decryptEnvelope(parsed, key), fileExists: true, error: null, encrypted: true }
+    } catch (err) {
+      return { data: {}, fileExists: true, error: `${file} could not be decrypted: ${err.message}`, encrypted: true }
+    }
+  }
+  return { data: parsed, fileExists: true, error: null, encrypted: false }
+}
+
+/**
+ * Serialize + atomically write the store, encrypting when a keychain-backed data
+ * key is available and otherwise writing 0600 plaintext (temp → chmod 0600 →
+ * rename). Mirrors credential-store.writeStoreAtomically minus the Windows
+ * held-handle retry (not load-bearing for this low-churn store).
+ */
+function writeStoreAtomically(nextObj) {
+  const target = tokensFilePath()
+  mkdirSync(dirname(target), { recursive: true, mode: 0o700 })
+  const key = getOrCreateMasterKey(activeKeychain())
+  const payload = key ? encryptJson(nextObj, key) : nextObj
+  const tmp = `${target}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`
+  let renamed = false
+  try {
+    writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })
+    if (process.platform !== 'win32') chmodSync(tmp, 0o600)
+    renameSync(tmp, target)
+    renamed = true
+  } finally {
+    if (!renamed && existsSync(tmp)) {
+      try { unlinkSync(tmp) } catch { /* best-effort */ }
+    }
+  }
+}
+
+/**
+ * @typedef {object} McpOAuthRecord
+ * @property {string} accessToken
+ * @property {string} [refreshToken]
+ * @property {string} [tokenType]        - 'Bearer' by default.
+ * @property {string} [scope]
+ * @property {number} expiresAt          - epoch ms; 0 when the server omitted expires_in.
+ * @property {string} clientId
+ * @property {string} [clientSecret]     - present only for confidential DCR clients.
+ * @property {string} tokenEndpoint
+ * @property {string} [authorizationEndpoint]
+ * @property {string} [registrationEndpoint]
+ * @property {string} [resource]         - canonical resource indicator (RFC 8707).
+ */
+
+/**
+ * Read the stored OAuth record for a server URL, or null when none exists (or on
+ * a read error — the caller falls back to the unauthenticated / re-auth path). A
+ * read error is intentionally swallowed to null here: a locked keychain must not
+ * wedge the connect, and the flow re-authorizes cleanly.
+ *
+ * @param {string} url
+ * @returns {McpOAuthRecord|null}
+ */
+export function getStoredToken(url) {
+  const serverKey = serverKeyForUrl(url)
+  if (!serverKey) return null
+  const { data, error } = readStore()
+  if (error) return null
+  const rec = data[serverKey]
+  if (!rec || typeof rec !== 'object' || typeof rec.accessToken !== 'string' || !rec.accessToken) return null
+  return rec
+}
+
+/**
+ * Persist an OAuth record for a server URL (merging into the existing store). A
+ * prior read error aborts rather than clobbering sibling records — same
+ * discipline as credential-store.setStoredCredential.
+ *
+ * @param {string} url
+ * @param {McpOAuthRecord} record
+ */
+export function setStoredToken(url, record) {
+  const serverKey = serverKeyForUrl(url)
+  if (!serverKey) throw new Error('MCP OAuth store: unstorable server url')
+  if (!record || typeof record.accessToken !== 'string' || !record.accessToken) {
+    throw new Error('MCP OAuth store: record requires a non-empty accessToken')
+  }
+  const { data, error } = readStore()
+  if (error) throw new Error(error)
+  writeStoreAtomically({ ...data, [serverKey]: record })
+}
+
+/**
+ * Remove the stored record for a server URL (no-op when absent). Deletes the file
+ * entirely when it would be left empty. A read error aborts rather than guessing.
+ *
+ * @param {string} url
+ */
+export function deleteStoredToken(url) {
+  const serverKey = serverKeyForUrl(url)
+  if (!serverKey) return
+  const { data, fileExists, error } = readStore()
+  if (!fileExists) return
+  if (error) throw new Error(error)
+  if (!(serverKey in data)) return
+  const next = { ...data }
+  delete next[serverKey]
+  if (Object.keys(next).length === 0) {
+    try { unlinkSync(tokensFilePath()) } catch (err) { if (err.code !== 'ENOENT') throw err }
+    return
+  }
+  writeStoreAtomically(next)
+}
+
+/**
+ * True when a record's access token is expired (or within `skewMs` of expiry).
+ * A record with `expiresAt === 0` (server omitted expires_in) is treated as
+ * NON-expiring here — the reactive 401 path re-auths it if the server later
+ * rejects it.
+ *
+ * @param {McpOAuthRecord} record
+ * @param {number} [skewMs] - refresh-ahead window (default 60s).
+ * @returns {boolean}
+ */
+export function isTokenExpired(record, skewMs = 60_000) {
+  if (!record || typeof record.expiresAt !== 'number' || record.expiresAt <= 0) return false
+  return Date.now() >= record.expiresAt - skewMs
+}

--- a/packages/server/src/byok-mcp-oauth-store.js
+++ b/packages/server/src/byok-mcp-oauth-store.js
@@ -36,6 +36,43 @@ import {
   getOrCreateMasterKey,
 } from './credential-cipher.js'
 
+// #6822 review: on Windows an antivirus / Search-indexer held handle on the
+// destination can make an otherwise-atomic renameSync fail transiently with one
+// of these codes. Mirrors session-state-persistence.WINDOWS_LOCK_CODES /
+// credential-store.CRED_WINDOWS_LOCK_CODES; renameWithRetry backs off and retries.
+const WINDOWS_LOCK_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'EEXIST'])
+
+/** Synchronous millisecond sleep (Atomics.wait on a throwaway SharedArrayBuffer). */
+function sleepSync(ms) {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+  } catch {
+    // Atomics/SharedArrayBuffer unavailable — skip the backoff; the syscall
+    // overhead of the retry still spaces attempts.
+  }
+}
+
+/**
+ * renameSync with a small retry-with-backoff on Windows held-handle locks. On
+ * POSIX (or any non-lock error) the first failure throws unchanged. On Windows
+ * a transient EPERM/EACCES/EBUSY/EEXIST is retried a few times before giving up.
+ */
+function renameWithRetry(tmp, target) {
+  const maxAttempts = process.platform === 'win32' ? 5 : 1
+  let lastErr
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      renameSync(tmp, target)
+      return
+    } catch (err) {
+      lastErr = err
+      if (process.platform !== 'win32' || !err || !WINDOWS_LOCK_CODES.has(err.code)) throw err
+      if (attempt < maxAttempts - 1) sleepSync(20 * (attempt + 1)) // 20/40/60/80ms
+    }
+  }
+  throw lastErr
+}
+
 // One-time breadcrumb when an intact encrypted token record exists on disk but
 // its keychain data key is currently unavailable (locked keychain / transient
 // probe failure) — matches credential-store's warnKeychainUnavailableOnce so a
@@ -174,7 +211,7 @@ function writeStoreAtomically(nextObj) {
   try {
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })
     if (process.platform !== 'win32') chmodSync(tmp, 0o600)
-    renameSync(tmp, target)
+    renameWithRetry(tmp, target)
     renamed = true
     // Post-rename mode re-check (POSIX), matching credential-store: if the file
     // landed with anything other than 0600, remove it and fail rather than

--- a/packages/server/src/byok-mcp-oauth.js
+++ b/packages/server/src/byok-mcp-oauth.js
@@ -1,0 +1,527 @@
+/**
+ * OAuth 2.1 authorization-code + PKCE flow for remote MCP servers (#6822).
+ *
+ * Implements the MCP authorization spec's browser-based flow for the BYOK remote
+ * transport (#6821 / #6833): when a remote MCP server answers a connect attempt
+ * with 401 + `WWW-Authenticate` resource metadata, the daemon
+ *   1. discovers the protected-resource metadata → the authorization server(s),
+ *   2. discovers the authorization-server metadata (RFC 8414 / OIDC fallback),
+ *   3. runs dynamic client registration (RFC 7591) when the AS supports it,
+ *   4. generates a PKCE verifier/challenge + a state parameter, and builds the
+ *      authorization URL the USER opens in a browser (on their own device),
+ *   5. redeems the returned code (+ PKCE verifier) at the token endpoint for
+ *      access/refresh tokens, and later refreshes them on expiry.
+ *
+ * CORE CONSTRAINT (remote user): the browser that completes consent lives on the
+ * user's phone/dashboard, while token REDEMPTION must land at the daemon. So the
+ * daemon holds the PKCE verifier + state server-side and only surfaces the
+ * authorization URL over the wire. The redirect can either hit a daemon-hosted
+ * loopback/tunnel callback (auto-complete) or the user copy-pastes the code back
+ * over the wire (the universal fallback). Both converge on `completeAuthorization`.
+ *
+ * SECURITY: this module handles secrets (client secrets, codes, tokens) but never
+ * logs any of them. `fetchImpl` is injectable (defaults to global fetch) so tests
+ * drive the whole flow against an in-process mock AS/RS with no real network.
+ * Redirects are followed by fetch for the well-known GETs (metadata is public),
+ * but every credentialed POST (registration, token) uses `redirect: 'manual'` so
+ * a token request can never be bounced off-origin with the code/secret attached.
+ */
+import { createHash, randomBytes } from 'node:crypto'
+import { URL, URLSearchParams } from 'node:url'
+import { createLogger } from './logger.js'
+
+const DEFAULT_TIMEOUT_MS = 10_000
+const CLIENT_NAME = 'Chroxy'
+
+// -- PKCE (RFC 7636) --------------------------------------------------------
+
+/** base64url with no padding — the PKCE + state encoding. */
+function base64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * Generate a PKCE verifier + S256 challenge. The verifier is a 32-byte
+ * base64url random string (43 chars, within the RFC's 43–128 range); the
+ * challenge is base64url(SHA-256(verifier)).
+ *
+ * @returns {{ verifier: string, challenge: string, method: 'S256' }}
+ */
+export function generatePkce() {
+  const verifier = base64url(randomBytes(32))
+  const challenge = base64url(createHash('sha256').update(verifier).digest())
+  return { verifier, challenge, method: 'S256' }
+}
+
+/** A high-entropy opaque `state` value bound (by the caller's registry) to a session+server. */
+export function generateState() {
+  return base64url(randomBytes(24))
+}
+
+// -- fetch helpers ----------------------------------------------------------
+
+function withTimeout(fetchImpl, url, init, timeoutMs) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => { try { controller.abort() } catch { /* already settled */ } }, timeoutMs)
+  return Promise.resolve(fetchImpl(url, { ...init, signal: controller.signal }))
+    .finally(() => clearTimeout(timer))
+}
+
+async function fetchJson(fetchImpl, url, init, timeoutMs) {
+  const res = await withTimeout(fetchImpl, url, init, timeoutMs)
+  const text = await res.text()
+  let json = null
+  if (text) { try { json = JSON.parse(text) } catch { json = null } }
+  return { status: res.status, json, res }
+}
+
+// -- Discovery --------------------------------------------------------------
+
+/**
+ * Parse `resource_metadata="<url>"` out of a `WWW-Authenticate: Bearer ...`
+ * header (MCP spec / RFC 9728). Returns the url or null when absent/malformed.
+ *
+ * @param {string|null|undefined} header
+ * @returns {string|null}
+ */
+export function parseResourceMetadataUrl(header) {
+  if (typeof header !== 'string' || header.length === 0) return null
+  const m = header.match(/resource_metadata\s*=\s*"([^"]+)"/i) || header.match(/resource_metadata\s*=\s*([^\s,]+)/i)
+  return m ? m[1] : null
+}
+
+/**
+ * Discover the protected-resource metadata → the authorization server issuer(s).
+ * Prefers the `resource_metadata` URL from the WWW-Authenticate header; falls
+ * back to `<origin>/.well-known/oauth-protected-resource` (MCP spec default).
+ * Returns `{ authorizationServers: string[], resource: string|null, scopesSupported: string[] }`.
+ *
+ * @param {{ serverUrl: string, wwwAuthenticate?: string|null, fetchImpl: Function, timeoutMs?: number }} args
+ */
+export async function discoverProtectedResource({ serverUrl, wwwAuthenticate, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  const candidates = []
+  const fromHeader = parseResourceMetadataUrl(wwwAuthenticate)
+  if (fromHeader) candidates.push(fromHeader)
+  try {
+    const origin = new URL(serverUrl).origin
+    candidates.push(`${origin}/.well-known/oauth-protected-resource`)
+  } catch { /* serverUrl already validated upstream; ignore */ }
+
+  for (const url of candidates) {
+    try {
+      const { status, json } = await fetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
+      if (status >= 200 && status < 300 && json && typeof json === 'object') {
+        const servers = Array.isArray(json.authorization_servers) ? json.authorization_servers.filter((s) => typeof s === 'string') : []
+        return {
+          authorizationServers: servers,
+          resource: typeof json.resource === 'string' ? json.resource : null,
+          scopesSupported: Array.isArray(json.scopes_supported) ? json.scopes_supported.filter((s) => typeof s === 'string') : [],
+        }
+      }
+    } catch { /* try the next candidate */ }
+  }
+  return { authorizationServers: [], resource: null, scopesSupported: [] }
+}
+
+/**
+ * Discover the authorization-server metadata for an issuer. Tries the RFC 8414
+ * well-known (`/.well-known/oauth-authorization-server` with the issuer's path
+ * inserted per spec), then the OIDC `/.well-known/openid-configuration`. Returns
+ * the metadata object, or null when neither resolves.
+ *
+ * @param {{ issuer: string, fetchImpl: Function, timeoutMs?: number }} args
+ */
+export async function discoverAuthorizationServer({ issuer, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  let base
+  try { base = new URL(issuer) } catch { return null }
+  const path = base.pathname.replace(/\/$/, '')
+  // RFC 8414: for an issuer with a path, the well-known segment is inserted
+  // between the host and the path. For a root issuer both forms coincide.
+  const candidates = [
+    `${base.origin}/.well-known/oauth-authorization-server${path}`,
+    `${base.origin}${path}/.well-known/oauth-authorization-server`,
+    `${base.origin}/.well-known/openid-configuration${path}`,
+    `${base.origin}${path}/.well-known/openid-configuration`,
+  ]
+  for (const url of candidates) {
+    try {
+      const { status, json } = await fetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
+      if (status >= 200 && status < 300 && json && typeof json.authorization_endpoint === 'string' && typeof json.token_endpoint === 'string') {
+        return json
+      }
+    } catch { /* try the next candidate */ }
+  }
+  return null
+}
+
+// -- Dynamic client registration (RFC 7591) ---------------------------------
+
+/**
+ * Register a client dynamically at the AS `registration_endpoint`. Returns
+ * `{ clientId, clientSecret? }`, or null when the AS has no registration endpoint
+ * (caller falls back to a pre-provisioned/public client id) or registration
+ * fails. Never logs the response body (may carry a client secret).
+ *
+ * @param {{ registrationEndpoint: string, redirectUri: string, scope?: string, fetchImpl: Function, timeoutMs?: number }} args
+ */
+export async function registerClient({ registrationEndpoint, redirectUri, scope, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  if (typeof registrationEndpoint !== 'string' || !registrationEndpoint) return null
+  const body = {
+    client_name: CLIENT_NAME,
+    redirect_uris: [redirectUri],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+    application_type: 'native',
+  }
+  if (scope) body.scope = scope
+  try {
+    const { status, json } = await fetchJson(fetchImpl, registrationEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+      redirect: 'manual',
+    }, timeoutMs)
+    if (status >= 200 && status < 300 && json && typeof json.client_id === 'string') {
+      return {
+        clientId: json.client_id,
+        clientSecret: typeof json.client_secret === 'string' ? json.client_secret : undefined,
+      }
+    }
+  } catch { /* registration failed — caller falls back */ }
+  return null
+}
+
+// -- Authorization URL ------------------------------------------------------
+
+/**
+ * Build the browser authorization URL (OAuth 2.1 authorization-code + PKCE).
+ *
+ * @param {{ authorizationEndpoint: string, clientId: string, redirectUri: string,
+ *   codeChallenge: string, state: string, scope?: string, resource?: string }} args
+ * @returns {string}
+ */
+export function buildAuthorizationUrl({ authorizationEndpoint, clientId, redirectUri, codeChallenge, state, scope, resource }) {
+  const u = new URL(authorizationEndpoint)
+  u.searchParams.set('response_type', 'code')
+  u.searchParams.set('client_id', clientId)
+  u.searchParams.set('redirect_uri', redirectUri)
+  u.searchParams.set('code_challenge', codeChallenge)
+  u.searchParams.set('code_challenge_method', 'S256')
+  u.searchParams.set('state', state)
+  if (scope) u.searchParams.set('scope', scope)
+  // RFC 8707 resource indicator — MCP spec requires binding the token to the
+  // resource so a token minted for one MCP server can't be replayed at another.
+  if (resource) u.searchParams.set('resource', resource)
+  return u.toString()
+}
+
+// -- Token endpoint ---------------------------------------------------------
+
+function normalizeTokenResponse(json) {
+  if (!json || typeof json.access_token !== 'string' || !json.access_token) {
+    throw new Error('token endpoint returned no access_token')
+  }
+  const expiresIn = Number(json.expires_in)
+  return {
+    accessToken: json.access_token,
+    refreshToken: typeof json.refresh_token === 'string' ? json.refresh_token : undefined,
+    tokenType: typeof json.token_type === 'string' ? json.token_type : 'Bearer',
+    scope: typeof json.scope === 'string' ? json.scope : undefined,
+    expiresAt: Number.isFinite(expiresIn) && expiresIn > 0 ? Date.now() + expiresIn * 1000 : 0,
+  }
+}
+
+/**
+ * Redeem an authorization code for tokens (grant_type=authorization_code).
+ * `redirect: 'manual'` keeps the credentialed POST on-origin. Throws with a
+ * value-free message on any non-2xx / missing access_token.
+ *
+ * @param {{ tokenEndpoint: string, clientId: string, clientSecret?: string, code: string,
+ *   redirectUri: string, codeVerifier: string, resource?: string, fetchImpl: Function, timeoutMs?: number }} args
+ */
+export async function redeemCode({ tokenEndpoint, clientId, clientSecret, code, redirectUri, codeVerifier, resource, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  const form = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    client_id: clientId,
+    code_verifier: codeVerifier,
+  })
+  if (resource) form.set('resource', resource)
+  if (clientSecret) form.set('client_secret', clientSecret)
+  const { status, json } = await fetchJson(fetchImpl, tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: form.toString(),
+    redirect: 'manual',
+  }, timeoutMs)
+  if (status < 200 || status >= 300) {
+    throw new Error(`token endpoint returned HTTP ${status}${json && typeof json.error === 'string' ? ` (${json.error})` : ''}`)
+  }
+  return normalizeTokenResponse(json)
+}
+
+/**
+ * Refresh an access token (grant_type=refresh_token). Preserves the existing
+ * refresh token when the AS rotates-optional (does not return a new one). Throws
+ * on any non-2xx / missing access_token so the caller can fall back to a full
+ * re-authorization.
+ *
+ * @param {{ tokenEndpoint: string, clientId: string, clientSecret?: string, refreshToken: string,
+ *   scope?: string, resource?: string, fetchImpl: Function, timeoutMs?: number }} args
+ */
+export async function refreshAccessToken({ tokenEndpoint, clientId, clientSecret, refreshToken, scope, resource, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  const form = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId,
+  })
+  if (scope) form.set('scope', scope)
+  if (resource) form.set('resource', resource)
+  if (clientSecret) form.set('client_secret', clientSecret)
+  const { status, json } = await fetchJson(fetchImpl, tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: form.toString(),
+    redirect: 'manual',
+  }, timeoutMs)
+  if (status < 200 || status >= 300) {
+    throw new Error(`refresh token endpoint returned HTTP ${status}${json && typeof json.error === 'string' ? ` (${json.error})` : ''}`)
+  }
+  const normalized = normalizeTokenResponse(json)
+  // Rotation-optional: keep the old refresh token when the AS didn't issue one.
+  if (!normalized.refreshToken) normalized.refreshToken = refreshToken
+  return normalized
+}
+
+// -- High-level orchestration -----------------------------------------------
+
+/**
+ * @typedef {object} OAuthPending
+ * @property {string} authorizationEndpoint
+ * @property {string} tokenEndpoint
+ * @property {string} [registrationEndpoint]
+ * @property {string} clientId
+ * @property {string} [clientSecret]
+ * @property {string} codeVerifier
+ * @property {string} redirectUri
+ * @property {string} state
+ * @property {string} [scope]
+ * @property {string} [resource]
+ */
+
+/**
+ * Run the full discovery → DCR → PKCE → authorization-URL sequence for a server
+ * that answered a connect with 401. Returns `{ authorizationUrl, pending }` where
+ * `pending` is the server-side secret material (`completeAuthorization` consumes
+ * it), or throws a value-free Error when the AS can't be discovered / registered.
+ *
+ * @param {{ serverUrl: string, wwwAuthenticate?: string|null, redirectUri: string,
+ *   clientId?: string, fetchImpl: Function, log?: object, timeoutMs?: number }} args
+ * @returns {Promise<{ authorizationUrl: string, pending: OAuthPending }>}
+ */
+export async function beginAuthorization({ serverUrl, wwwAuthenticate, redirectUri, clientId: preClientId, fetchImpl, log = createLogger('byok-mcp-oauth'), timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  const resourceMeta = await discoverProtectedResource({ serverUrl, wwwAuthenticate, fetchImpl, timeoutMs })
+  // The issuer is the first advertised authorization server, else the server's
+  // own origin (some MCP servers co-locate the AS and skip resource metadata).
+  const issuer = resourceMeta.authorizationServers[0] || new URL(serverUrl).origin
+  const asMeta = await discoverAuthorizationServer({ issuer, fetchImpl, timeoutMs })
+  if (!asMeta) {
+    throw new Error('could not discover the authorization server metadata')
+  }
+  const scope = resourceMeta.scopesSupported.length > 0 ? resourceMeta.scopesSupported.join(' ') : undefined
+  const resource = resourceMeta.resource || undefined
+
+  let clientId = preClientId
+  let clientSecret
+  if (!clientId) {
+    const registered = await registerClient({
+      registrationEndpoint: asMeta.registration_endpoint,
+      redirectUri,
+      scope,
+      fetchImpl,
+      timeoutMs,
+    })
+    if (!registered) {
+      throw new Error('the authorization server does not support dynamic client registration and no client id is configured')
+    }
+    clientId = registered.clientId
+    clientSecret = registered.clientSecret
+  }
+
+  const pkce = generatePkce()
+  const state = generateState()
+  const authorizationUrl = buildAuthorizationUrl({
+    authorizationEndpoint: asMeta.authorization_endpoint,
+    clientId,
+    redirectUri,
+    codeChallenge: pkce.challenge,
+    state,
+    scope,
+    resource,
+  })
+  log.info(`MCP OAuth: authorization URL generated for a remote server (issuer=${redactUrl(issuer)})`)
+  return {
+    authorizationUrl,
+    pending: {
+      authorizationEndpoint: asMeta.authorization_endpoint,
+      tokenEndpoint: asMeta.token_endpoint,
+      registrationEndpoint: asMeta.registration_endpoint,
+      clientId,
+      clientSecret,
+      codeVerifier: pkce.verifier,
+      redirectUri,
+      state,
+      scope,
+      resource,
+    },
+  }
+}
+
+/**
+ * Complete authorization by redeeming a code against a `pending` bag from
+ * `beginAuthorization`. Returns a persistable token record (the shape
+ * byok-mcp-oauth-store expects). Throws (value-free) on redemption failure.
+ *
+ * @param {{ pending: OAuthPending, code: string, fetchImpl: Function, timeoutMs?: number }} args
+ */
+export async function completeAuthorization({ pending, code, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  const tokens = await redeemCode({
+    tokenEndpoint: pending.tokenEndpoint,
+    clientId: pending.clientId,
+    clientSecret: pending.clientSecret,
+    code,
+    redirectUri: pending.redirectUri,
+    codeVerifier: pending.codeVerifier,
+    resource: pending.resource,
+    fetchImpl,
+    timeoutMs,
+  })
+  return {
+    ...tokens,
+    clientId: pending.clientId,
+    clientSecret: pending.clientSecret,
+    tokenEndpoint: pending.tokenEndpoint,
+    authorizationEndpoint: pending.authorizationEndpoint,
+    registrationEndpoint: pending.registrationEndpoint,
+    scope: tokens.scope || pending.scope,
+    resource: pending.resource,
+  }
+}
+
+/** Origin+path only, for logs — never carries a token/secret/query. */
+function redactUrl(url) {
+  try {
+    const u = new URL(url)
+    return `${u.origin}${u.pathname}`
+  } catch {
+    return '[unparseable url]'
+  }
+}
+
+// -- Callback registry (loopback/tunnel auto-complete) ----------------------
+//
+// Process-wide map keyed by the high-entropy `state` value. A client registers
+// its completion handler when it builds the authorization URL; the daemon's
+// `/mcp/oauth/callback` route (http-routes.js) looks it up by state and drives
+// the redemption. The state's entropy IS the capability — an attacker cannot
+// guess it — and entries expire so a never-completed flow can't leak.
+
+const CALLBACK_TTL_MS = 15 * 60 * 1000 // an authorization attempt is abandoned after 15m
+const MAX_PENDING_CALLBACKS = 100
+const _pendingCallbacks = new Map() // state -> { handler, expiresAt }
+
+/**
+ * Register a callback handler for a `state`. `handler(code)` returns a promise
+ * resolving to `{ ok: true }` (or throwing). Overwrites a prior entry for the
+ * same state; evicts the oldest when the map is full.
+ *
+ * @param {string} state
+ * @param {(code: string) => Promise<any>} handler
+ */
+export function registerOAuthCallback(state, handler) {
+  if (typeof state !== 'string' || !state || typeof handler !== 'function') return
+  pruneCallbacks()
+  if (_pendingCallbacks.size >= MAX_PENDING_CALLBACKS) {
+    const oldest = _pendingCallbacks.keys().next().value
+    if (oldest !== undefined) _pendingCallbacks.delete(oldest)
+  }
+  _pendingCallbacks.set(state, { handler, expiresAt: Date.now() + CALLBACK_TTL_MS })
+}
+
+/** Drop a pending callback (called after completion / on teardown). */
+export function unregisterOAuthCallback(state) {
+  if (typeof state === 'string') _pendingCallbacks.delete(state)
+}
+
+function pruneCallbacks() {
+  const now = Date.now()
+  for (const [state, entry] of _pendingCallbacks) {
+    if (entry.expiresAt <= now) _pendingCallbacks.delete(state)
+  }
+}
+
+/**
+ * Resolve a callback by state, invoking its handler with the code. Returns
+ * `{ found: boolean, ok?: boolean, error?: string }`. The entry is consumed on a
+ * successful handler run; a failed run leaves it so the user can retry (e.g. paste
+ * the code) without re-authorizing.
+ *
+ * @param {string} state
+ * @param {string} code
+ */
+export async function resolveOAuthCallback(state, code) {
+  pruneCallbacks()
+  const entry = typeof state === 'string' ? _pendingCallbacks.get(state) : undefined
+  if (!entry) return { found: false }
+  try {
+    await entry.handler(code)
+    _pendingCallbacks.delete(state)
+    return { found: true, ok: true }
+  } catch (err) {
+    return { found: true, ok: false, error: err?.message || String(err) }
+  }
+}
+
+/** Test-only: clear the pending-callback registry between cases. */
+export function _clearOAuthCallbacksForTests() {
+  _pendingCallbacks.clear()
+}
+
+// -- Redirect URI configuration ---------------------------------------------
+//
+// The redirect_uri the daemon registers + surfaces. Set once at server start to
+// the daemon's reachable callback (loopback for desktop-local, or an operator-
+// supplied base). Remote/tunneled users whose browser can't reach it fall back to
+// the paste-code path — the code is redeemed at the daemon regardless.
+
+const DEFAULT_CALLBACK_PATH = '/mcp/oauth/callback'
+let _callbackBaseUrl = null
+
+/**
+ * Configure the base URL the OAuth callback is reachable at (no trailing path).
+ * e.g. `http://127.0.0.1:8765`. Called by ws-server once it knows its port.
+ *
+ * @param {string|null} baseUrl
+ */
+export function setMcpOAuthCallbackBase(baseUrl) {
+  _callbackBaseUrl = typeof baseUrl === 'string' && baseUrl ? baseUrl.replace(/\/$/, '') : null
+}
+
+/**
+ * The redirect_uri to register + surface. Precedence:
+ *   1. `CHROXY_MCP_OAUTH_REDIRECT_URI` (operator override — a full URI),
+ *   2. `<configured base>` + callback path,
+ *   3. a loopback default on the conventional daemon port.
+ *
+ * @returns {string}
+ */
+export function mcpOAuthRedirectUri() {
+  const override = process.env.CHROXY_MCP_OAUTH_REDIRECT_URI
+  if (typeof override === 'string' && override) return override
+  const base = _callbackBaseUrl || 'http://127.0.0.1:8765'
+  return `${base}${DEFAULT_CALLBACK_PATH}`
+}
+
+export const MCP_OAUTH_CALLBACK_PATH = DEFAULT_CALLBACK_PATH

--- a/packages/server/src/byok-mcp-oauth.js
+++ b/packages/server/src/byok-mcp-oauth.js
@@ -60,6 +60,23 @@ const CLIENT_NAME = 'Chroxy'
  * @param {string} url
  * @returns {Promise<string|null>}
  */
+/**
+ * True only for an http(s) URL. Every endpoint the daemon takes from discovered
+ * OAuth metadata (authorization / token / registration) must be http(s) — a
+ * `javascript:` / `file:` / `data:` endpoint from a malicious AS metadata doc
+ * must never be fetched or handed to a client to open. Mirrors the transport's
+ * parseRemoteEntry protocol check.
+ */
+function isHttpUrl(value) {
+  if (typeof value !== 'string' || !value) return false
+  try {
+    const p = new URL(value).protocol
+    return p === 'http:' || p === 'https:'
+  } catch {
+    return false
+  }
+}
+
 async function refuseUnsafeMetadataUrl(url) {
   let hostname
   try {
@@ -214,6 +231,12 @@ export async function discoverAuthorizationServer({ issuer, fetchImpl, timeoutMs
       // (resource metadata's authorization_servers) — SSRF-guarded.
       const { status, json } = await guardedFetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
       if (status >= 200 && status < 300 && json && typeof json.authorization_endpoint === 'string' && typeof json.token_endpoint === 'string') {
+        // Every endpoint the daemon will fetch (or hand to a client to open)
+        // MUST be http(s) — reject a javascript:/file:/data: endpoint smuggled
+        // into the metadata rather than trusting it. registration_endpoint is
+        // optional (no DCR) but validated when present.
+        if (!isHttpUrl(json.authorization_endpoint) || !isHttpUrl(json.token_endpoint)) continue
+        if (json.registration_endpoint != null && !isHttpUrl(json.registration_endpoint)) continue
         // RFC 8414 §3.3: the metadata `issuer` MUST exactly match the issuer
         // that was used to build the well-known URL. A mismatch is a mix-up /
         // spoofing signal — reject it rather than trusting the endpoints.

--- a/packages/server/src/byok-mcp-oauth.js
+++ b/packages/server/src/byok-mcp-oauth.js
@@ -28,10 +28,60 @@
  */
 import { createHash, randomBytes } from 'node:crypto'
 import { URL, URLSearchParams } from 'node:url'
+import { lookup } from 'node:dns/promises'
 import { createLogger } from './logger.js'
+import { isBlockedMetadataHost } from './byok-mcp-config.js'
 
 const DEFAULT_TIMEOUT_MS = 10_000
 const CLIENT_NAME = 'Chroxy'
+
+// -- SSRF hardening (#6822 / #6834) -----------------------------------------
+//
+// Every OAuth endpoint the daemon fetches — the resource_metadata URL from a
+// server's WWW-Authenticate header, the authorization server's issuer, and the
+// registration/token endpoints inside the discovered AS metadata — is
+// ATTACKER-INFLUENCEABLE (a malicious/compromised MCP server chooses them). A
+// server could point any of them at the cloud-metadata service (169.254.169.254
+// / fd00:ec2::254) to make the daemon fetch instance credentials on its behalf.
+// This is the exact hole the remote transport closed in #6834; the OAuth flow
+// threads the SAME guard. Loopback / RFC1918 are deliberately NOT blocked — a
+// localhost authorization server is legitimate (that broader egress policy is
+// #6834's scope, which the user chose to keep permissive).
+
+/**
+ * Return a refusal reason when `url` targets the cloud-metadata service /
+ * link-local range (literal host OR a DNS name that resolves into it), else
+ * null. Mirrors MCPRemoteClient._refuseMetadataTarget: literal hosts are checked
+ * directly (the URL parser already canonicalized hex/decimal tricks); DNS names
+ * get a best-effort lookup so a name resolving into the blocked range is refused
+ * too. Lookup ERRORS pass through (the subsequent fetch surfaces them as an
+ * ordinary connect failure). An unparseable url returns null — fetch surfaces it.
+ *
+ * @param {string} url
+ * @returns {Promise<string|null>}
+ */
+async function refuseUnsafeMetadataUrl(url) {
+  let hostname
+  try {
+    hostname = new URL(url).hostname
+  } catch {
+    return null
+  }
+  if (isBlockedMetadataHost(hostname)) {
+    return 'refusing cloud-metadata / link-local OAuth endpoint (never a legitimate authorization server)'
+  }
+  const bare = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+  const isLiteral = /^[\d.]+$/.test(bare) || bare.includes(':')
+  if (!isLiteral) {
+    try {
+      const addrs = await lookup(bare, { all: true })
+      if (addrs.some(({ address }) => isBlockedMetadataHost(address))) {
+        return 'refusing DNS name resolving to a cloud-metadata / link-local address'
+      }
+    } catch { /* resolution failures surface via the fetch */ }
+  }
+  return null
+}
 
 // -- PKCE (RFC 7636) --------------------------------------------------------
 
@@ -75,6 +125,19 @@ async function fetchJson(fetchImpl, url, init, timeoutMs) {
   return { status: res.status, json, res }
 }
 
+/**
+ * SSRF-guarded `fetchJson`: refuse a cloud-metadata / link-local target BEFORE
+ * any request leaves the process, and force `redirect: 'manual'` so a benign URL
+ * that 3xx-redirects to an internal host can never carry the request off-origin
+ * (a host check on only the initial URL would otherwise be bypassed by a 302).
+ * A refused target throws — `fetchImpl` is never called for it.
+ */
+async function guardedFetchJson(fetchImpl, url, init, timeoutMs) {
+  const refusal = await refuseUnsafeMetadataUrl(url)
+  if (refusal) throw new Error(`MCP OAuth: ${refusal}`)
+  return fetchJson(fetchImpl, url, { redirect: 'manual', ...init }, timeoutMs)
+}
+
 // -- Discovery --------------------------------------------------------------
 
 /**
@@ -109,7 +172,9 @@ export async function discoverProtectedResource({ serverUrl, wwwAuthenticate, fe
 
   for (const url of candidates) {
     try {
-      const { status, json } = await fetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
+      // (a) resource_metadata is attacker-influenceable (WWW-Authenticate) —
+      // SSRF-guarded + redirect:'manual' via guardedFetchJson.
+      const { status, json } = await guardedFetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
       if (status >= 200 && status < 300 && json && typeof json === 'object') {
         const servers = Array.isArray(json.authorization_servers) ? json.authorization_servers.filter((s) => typeof s === 'string') : []
         return {
@@ -118,7 +183,7 @@ export async function discoverProtectedResource({ serverUrl, wwwAuthenticate, fe
           scopesSupported: Array.isArray(json.scopes_supported) ? json.scopes_supported.filter((s) => typeof s === 'string') : [],
         }
       }
-    } catch { /* try the next candidate */ }
+    } catch { /* refused target or fetch failure — try the next candidate */ }
   }
   return { authorizationServers: [], resource: null, scopesSupported: [] }
 }
@@ -145,11 +210,17 @@ export async function discoverAuthorizationServer({ issuer, fetchImpl, timeoutMs
   ]
   for (const url of candidates) {
     try {
-      const { status, json } = await fetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
+      // (b) the issuer (→ these well-known URLs) is attacker-influenceable
+      // (resource metadata's authorization_servers) — SSRF-guarded.
+      const { status, json } = await guardedFetchJson(fetchImpl, url, { method: 'GET', headers: { Accept: 'application/json' } }, timeoutMs)
       if (status >= 200 && status < 300 && json && typeof json.authorization_endpoint === 'string' && typeof json.token_endpoint === 'string') {
+        // RFC 8414 §3.3: the metadata `issuer` MUST exactly match the issuer
+        // that was used to build the well-known URL. A mismatch is a mix-up /
+        // spoofing signal — reject it rather than trusting the endpoints.
+        if (typeof json.issuer === 'string' && json.issuer !== issuer) continue
         return json
       }
-    } catch { /* try the next candidate */ }
+    } catch { /* refused target or fetch failure — try the next candidate */ }
   }
   return null
 }
@@ -166,6 +237,12 @@ export async function discoverAuthorizationServer({ issuer, fetchImpl, timeoutMs
  */
 export async function registerClient({ registrationEndpoint, redirectUri, scope, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   if (typeof registrationEndpoint !== 'string' || !registrationEndpoint) return null
+  // (c) registration_endpoint comes from the (attacker-influenceable) AS
+  // metadata body — refuse a cloud-metadata / link-local target BEFORE the POST.
+  // A refusal THROWS (propagates to beginAuthorization) rather than returning
+  // null so it is never confused with "the AS supports no DCR".
+  const refusal = await refuseUnsafeMetadataUrl(registrationEndpoint)
+  if (refusal) throw new Error(`MCP OAuth: ${refusal}`)
   const body = {
     client_name: CLIENT_NAME,
     redirect_uris: [redirectUri],
@@ -241,6 +318,10 @@ function normalizeTokenResponse(json) {
  *   redirectUri: string, codeVerifier: string, resource?: string, fetchImpl: Function, timeoutMs?: number }} args
  */
 export async function redeemCode({ tokenEndpoint, clientId, clientSecret, code, redirectUri, codeVerifier, resource, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  // (d) token_endpoint comes from the (attacker-influenceable) AS metadata —
+  // refuse a cloud-metadata / link-local target before the credentialed POST.
+  const refusal = await refuseUnsafeMetadataUrl(tokenEndpoint)
+  if (refusal) throw new Error(`MCP OAuth: ${refusal}`)
   const form = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
@@ -272,6 +353,10 @@ export async function redeemCode({ tokenEndpoint, clientId, clientSecret, code, 
  *   scope?: string, resource?: string, fetchImpl: Function, timeoutMs?: number }} args
  */
 export async function refreshAccessToken({ tokenEndpoint, clientId, clientSecret, refreshToken, scope, resource, fetchImpl, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  // (d) token_endpoint (from stored record / AS metadata) — same SSRF guard as
+  // redeemCode so a refresh can't be steered at the metadata service either.
+  const refusal = await refuseUnsafeMetadataUrl(tokenEndpoint)
+  if (refusal) throw new Error(`MCP OAuth: ${refusal}`)
   const form = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: refreshToken,

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -597,6 +597,26 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   /**
+   * #6822: submit a pasted OAuth authorization code for a remote MCP server that
+   * reported `oauth-required`. Delegates redemption + authenticated reconnect to
+   * the fleet, then re-emits `mcp_servers` so every client converges on the new
+   * status. Returns `{ found, ok?, status?, error? }`; `found: false` when the
+   * server isn't configured (or the fleet never started), so the WS handler can
+   * surface a clean error. The code + tokens never touch a log or the wire.
+   */
+  async submitMcpAuthCode(name, code) {
+    if (typeof name !== 'string' || !this._mcpServerConfigs.some((c) => c.name === name)) {
+      return { found: false }
+    }
+    if (!this._mcpFleet) {
+      return { found: false }
+    }
+    const result = await this._mcpFleet.submitAuthCode(name, code)
+    if (result?.ok) this._emitMcpServers()
+    return result
+  }
+
+  /**
    * #6824: the parked (disabled) server names, sorted, for persistence into
    * session-state.json. Session-manager reads this in `_serializeSessionEntry`
    * and forwards it back as `disabledMcpServers` on restore.

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -930,6 +930,68 @@ async function handleSetMcpServerEnabled(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * #6822 — submit a pasted OAuth authorization code for a remote MCP server that
+ * reported `oauth-required`. The daemon redeems the code (holding the PKCE
+ * verifier + state server-side), persists the tokens encrypted at rest, and
+ * reconnects the server authenticated. Only the BYOK lane runs an in-daemon MCP
+ * fleet, so this rejects other providers with a capability error.
+ *
+ * AUTH: identical own-session gate as `set_mcp_server_enabled` (routed through
+ * `resolveSession`, which enforces session-token binding). Redeeming a code can
+ * only authorize the server the user is already trying to connect — it never
+ * escalates. Every rejection echoes `requestId` (when supplied) with a stable
+ * code (MCP_AUTH_NOT_APPLIED / MCP_AUTH_UNSUPPORTED / MCP_AUTH_NOT_FOUND /
+ * MCP_AUTH_FAILED). On success the session re-emits `mcp_servers` (the new
+ * status IS the confirmation) — no separate ack. The `code` and any token are
+ * NEVER logged.
+ */
+async function handleSubmitMcpAuthCode(ws, client, msg, ctx) {
+  const requestId = msg?.requestId
+  const server = typeof msg?.server === 'string' ? msg.server.trim() : ''
+  const code = typeof msg?.code === 'string' ? msg.code.trim() : ''
+  if (!server) {
+    sendError(ws, requestId, 'MCP_AUTH_NOT_APPLIED', 'submit_mcp_auth_code requires a non-empty `server` name', undefined, ctx)
+    return
+  }
+  if (!code) {
+    sendError(ws, requestId, 'MCP_AUTH_NOT_APPLIED', 'submit_mcp_auth_code requires a non-empty `code`', undefined, ctx)
+    return
+  }
+
+  const sessionId = msg?.sessionId || client?.activeSessionId
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    sendError(ws, requestId, 'MCP_AUTH_NOT_APPLIED', 'No active session', undefined, ctx)
+    return
+  }
+
+  if (!entry.session || typeof entry.session.submitMcpAuthCode !== 'function') {
+    sendError(ws, requestId, 'MCP_AUTH_UNSUPPORTED',
+      'This provider does not support MCP OAuth authorization (its MCP config is managed by the underlying CLI).',
+      undefined, ctx)
+    return
+  }
+
+  try {
+    const result = await entry.session.submitMcpAuthCode(server, code)
+    if (!result || result.found === false) {
+      sendError(ws, requestId, 'MCP_AUTH_NOT_FOUND', `No configured MCP server named '${server}' awaiting authorization for this session.`, undefined, ctx)
+      return
+    }
+    if (result.ok === false) {
+      // Value-free reason — redemption failed (wrong/expired code, AS error).
+      sendError(ws, requestId, 'MCP_AUTH_FAILED', result.error || `Authorization for MCP server '${server}' failed.`, undefined, ctx)
+      return
+    }
+    // Success: the session re-emitted `mcp_servers` (status now connected or,
+    // if the server still rejects, oauth-required again). Never log the code.
+    loggerForSession('ws', sessionId).info(`MCP server '${server}' authorization completed by ${client.id} on session ${sessionId} (status=${result.status || 'unknown'})`)
+  } catch (err) {
+    sendError(ws, requestId, 'MCP_AUTH_FAILED', `Authorization for MCP server '${server}' failed: ${err?.message || String(err)}`, undefined, ctx)
+  }
+}
+
 // #4664: assemble the per-session-setting WS handlers from the registry.
 // Each setting's `requestType` (e.g. `'set_prompt_evaluator'`) is the
 // message-type key the dispatcher looks up; the factory-built handler
@@ -1005,6 +1067,8 @@ export const settingsHandlers = {
   set_permission_rules: handleSetPermissionRules,
   // #6824: per-server MCP enable/disable (BYOK lane; capability-gated).
   set_mcp_server_enabled: handleSetMcpServerEnabled,
+  // #6822: submit a pasted OAuth authorization code (BYOK lane; capability-gated).
+  submit_mcp_auth_code: handleSubmitMcpAuthCode,
   // promptEvaluatorSkipPattern keeps its bespoke handler because the
   // payload shape (string-or-null + pre-validation regex compile to
   // surface a distinct error code) doesn't fit the boolean/string

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -15,6 +15,7 @@ import { isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
 import { isValidSlug, mimeForPath } from './pages-store.js'
 import { sendOversizeResponse } from './http-oversize.js'
+import { resolveOAuthCallback, MCP_OAUTH_CALLBACK_PATH } from './byok-mcp-oauth.js'
 
 /**
  * #5683 — read + JSON-parse a request body with a byte cap. Resolves to the
@@ -95,6 +96,13 @@ const PAGE_SECURITY_HEADERS = {
 }
 
 const log = createLogger('ws')
+
+/** Minimal HTML-escape for interpolating an untrusted value into a page body. */
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ))
+}
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -391,6 +399,73 @@ export function createHttpHandler(server) {
         gitBranch: server._gitInfo.branch,
         uptime: Math.round((Date.now() - server._startedAt) / 1000),
       }))
+      return
+    }
+
+    // #6822 — MCP OAuth redirect callback. The browser that completed consent
+    // (on the user's own device) is redirected here with `?code=...&state=...`.
+    // This route is intentionally UNAUTHENTICATED: the redirect carries no bearer
+    // token, and the high-entropy `state` value (bound server-side to a specific
+    // pending authorization) IS the capability. We hand the code to the matching
+    // pending client, which redeems it + persists tokens. When the daemon isn't
+    // reachable from the user's browser (remote/tunneled) this page never loads —
+    // the user copy-pastes the code back over the wire instead (the universal
+    // fallback). Never logs the code.
+    const oauthCbPath = (req.url ?? '').split('?')[0]
+    if (req.method === 'GET' && oauthCbPath === MCP_OAUTH_CALLBACK_PATH) {
+      let code = null
+      let state = null
+      let oauthError = null
+      try {
+        const parsed = new URL(req.url, 'http://localhost')
+        code = parsed.searchParams.get('code')
+        state = parsed.searchParams.get('state')
+        oauthError = parsed.searchParams.get('error')
+      } catch { /* malformed url — handled as missing params below */ }
+
+      const page = (title, body) =>
+        `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` +
+        `<title>${title}</title><style>body{font-family:system-ui,-apple-system,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1rem;color:#1a2332;line-height:1.5}` +
+        `code{background:#eef1f6;padding:.15rem .35rem;border-radius:.25rem;word-break:break-all}h1{font-size:1.25rem}</style></head><body>${body}</body></html>`
+
+      const sendPage = (status, title, body) => {
+        res.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8', ...PAGE_SECURITY_HEADERS })
+        res.end(page(title, body))
+      }
+
+      if (oauthError) {
+        sendPage(400, 'Authorization failed',
+          `<h1>Authorization was not completed</h1><p>The authorization server reported an error. You can close this tab and try authorizing again from Chroxy.</p>`)
+        return
+      }
+      if (!code || !state) {
+        sendPage(400, 'Authorization callback',
+          `<h1>Missing authorization details</h1><p>This page expects a <code>code</code> and <code>state</code> from the authorization server. If you reached it manually, return to Chroxy and use the paste-code option.</p>`)
+        return
+      }
+
+      resolveOAuthCallback(state, code)
+        .then((outcome) => {
+          if (outcome.found && outcome.ok) {
+            sendPage(200, 'Authorized',
+              `<h1>MCP server authorized</h1><p>You can close this tab and return to Chroxy — the server is reconnecting now.</p>`)
+          } else if (outcome.found) {
+            // The daemon received the callback but redemption failed. Surface the
+            // code so the user can retry via paste (value shown only to the user
+            // whose browser holds the redirect; never logged server-side).
+            sendPage(200, 'Finish in Chroxy',
+              `<h1>Almost there</h1><p>Automatic completion didn't succeed. Copy this authorization code and paste it into Chroxy:</p><p><code>${escapeHtml(code)}</code></p>`)
+          } else {
+            // No pending authorization matched this state (expired, wrong daemon,
+            // or already completed). Offer the paste-code fallback.
+            sendPage(200, 'Finish in Chroxy',
+              `<h1>Finish in Chroxy</h1><p>Copy this authorization code and paste it into Chroxy to finish connecting:</p><p><code>${escapeHtml(code)}</code></p>`)
+          }
+        })
+        .catch(() => {
+          sendPage(200, 'Finish in Chroxy',
+            `<h1>Finish in Chroxy</h1><p>Copy this authorization code and paste it into Chroxy to finish connecting:</p><p><code>${escapeHtml(code)}</code></p>`)
+        })
       return
     }
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -24,6 +24,7 @@ import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } 
 import { createDevicePreferences } from './device-preferences.js'
 import { isUserShellEnabled, isIdeFeatureEnabled, isOrchestrationEnabled } from './config.js'
 import { createHttpHandler } from './http-routes.js'
+import { setMcpOAuthCallbackBase } from './byok-mcp-oauth.js'
 import { CheckpointManager } from './checkpoint-manager.js'
 import { DevPreviewManager } from './dev-preview.js'
 import { WebTaskManager } from './web-task-manager.js'
@@ -345,7 +346,7 @@ function _isSecureRequest(req) {
  *   { type: 'tool_start',   messageId, toolUseId, tool, input, serverName? } — tool invocation (serverName present for MCP tools)
  *   { type: 'tool_input_delta', messageId, toolUseId, partialJson } — #4080/#4081: incremental partial JSON for the streaming tool_use `input`; concatenate per-toolUseId for the live bubble preview
  *   { type: 'tool_result',  toolUseId, result, truncated, images?, isError? }  — tool result (images: [{mediaType, data}]; #6712 isError flags a failed tool for the error affordance)
- *   { type: 'mcp_servers',  servers: [{ name, status, enabled?, canToggle? }] } — configured MCP servers (#6824: enabled + canToggle per-server; BYOK lane sets canToggle:true so clients render the enable/disable toggle; status 'disabled' = parked)
+ *   { type: 'mcp_servers',  servers: [{ name, status, enabled?, canToggle?, authUrl? }] } — configured MCP servers (#6824: enabled + canToggle per-server; BYOK lane sets canToggle:true so clients render the enable/disable toggle; status 'disabled' = parked; #6822: status 'oauth-required' + authUrl surfaces the browser authorization URL a remote server needs)
  *   { type: 'result',       ... }                     — query stats
  *   { type: 'status',       connected: true }         — connection status
  *   { type: 'claude_ready' }                          — Claude Code ready for input
@@ -2160,6 +2161,11 @@ export class WsServer {
     }, 60_000)
 
     log.info(`Server listening on ${host || '0.0.0.0'}:${this.port} (${this.serverMode} mode)`)
+    // #6822: point the MCP OAuth redirect at this daemon's loopback callback so a
+    // desktop-local browser auto-completes the flow; remote/tunneled browsers
+    // that can't reach loopback fall back to the paste-code path. An operator
+    // override (CHROXY_MCP_OAUTH_REDIRECT_URI) still wins inside the module.
+    try { setMcpOAuthCallbackBase(`http://127.0.0.1:${this.port}`) } catch { /* best-effort */ }
   }
 
   /**

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -457,4 +457,61 @@ describe('MCPFleet', () => {
       await fleet.destroy()
     })
   })
+
+  describe('OAuth surfacing (#6822)', () => {
+    // Build a fleet with a remote config, then swap in a fake client so we can
+    // exercise getServerStatuses / submitAuthCode without a live OAuth server
+    // (the client-level flow is covered in byok-mcp-remote-client.test.js).
+    function fleetWithFakeClient(fake) {
+      const fleet = new MCPFleet([{ name: 'remote', url: 'https://ex.example/mcp' }], { log: silentLog() })
+      fleet._clients = [fake]
+      return fleet
+    }
+
+    it('getServerStatuses reports oauth-required + authUrl for a client awaiting authorization', () => {
+      const fleet = fleetWithFakeClient({
+        name: 'remote', state: MCP_STATES.DEAD, needsAuthorization: true, authorizationUrl: 'https://as.example/authorize?x=1',
+      })
+      const [s] = fleet.getServerStatuses()
+      assert.equal(s.status, 'oauth-required')
+      assert.equal(s.authUrl, 'https://as.example/authorize?x=1')
+      assert.equal(s.enabled, true)
+      assert.equal(s.canToggle, true)
+    })
+
+    it('submitAuthCode delegates to the client and reports the reconnected status', async () => {
+      let received = null
+      const fleet = fleetWithFakeClient({
+        name: 'remote', state: MCP_STATES.READY, needsAuthorization: false,
+        completeAuthorization: async (code) => { received = code; return { ok: true } },
+      })
+      const res = await fleet.submitAuthCode('remote', 'the-code')
+      assert.deepEqual(res, { found: true, ok: true, status: 'connected' })
+      assert.equal(received, 'the-code')
+    })
+
+    it('submitAuthCode returns found:false for an unknown server', async () => {
+      const fleet = fleetWithFakeClient({ name: 'remote', state: MCP_STATES.READY })
+      assert.deepEqual(await fleet.submitAuthCode('ghost', 'x'), { found: false })
+    })
+
+    it('submitAuthCode surfaces a redemption failure as ok:false with a value-free reason', async () => {
+      const fleet = fleetWithFakeClient({
+        name: 'remote', state: MCP_STATES.DEAD, needsAuthorization: true,
+        completeAuthorization: async () => { throw new Error('token endpoint returned HTTP 400') },
+      })
+      const res = await fleet.submitAuthCode('remote', 'x')
+      assert.equal(res.found, true)
+      assert.equal(res.ok, false)
+      assert.match(res.error, /HTTP 400/)
+    })
+
+    it('submitAuthCode rejects a stdio client that has no completeAuthorization method', async () => {
+      const fleet = fleetWithFakeClient({ name: 'remote', state: MCP_STATES.READY })
+      const res = await fleet.submitAuthCode('remote', 'x')
+      assert.equal(res.found, true)
+      assert.equal(res.ok, false)
+      assert.match(res.error, /does not use OAuth/)
+    })
+  })
 })

--- a/packages/server/tests/byok-mcp-oauth-store.test.js
+++ b/packages/server/tests/byok-mcp-oauth-store.test.js
@@ -1,0 +1,151 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync, existsSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import {
+  serverKeyForUrl,
+  getStoredToken,
+  setStoredToken,
+  deleteStoredToken,
+  isTokenExpired,
+  _setMcpOAuthKeychainForTests,
+} from '../src/byok-mcp-oauth-store.js'
+
+/**
+ * #6822 — token store for remote MCP OAuth. The suite runs with the real
+ * keychain disabled (tests/_setup.mjs sets CHROXY_CRED_DISABLE_KEYCHAIN=1) and
+ * points the store at a temp file (CHROXY_MCP_OAUTH_TOKENS_PATH) so it never
+ * touches the real ~/.chroxy tree or the real OS keychain.
+ */
+
+// A deterministic in-memory keychain to exercise the ENCRYPTED-at-rest path
+// without any OS call — the same seam credential-cipher/keychain expose.
+function makeMemoryKeychain() {
+  const store = new Map()
+  return {
+    isKeychainAvailable: () => true,
+    getToken: (service) => (store.has(service) ? store.get(service) : null),
+    setToken: (token, service) => { store.set(service, token) },
+    deleteToken: (service) => { store.delete(service) },
+  }
+}
+
+let dir
+let tokensPath
+const prevPath = process.env.CHROXY_MCP_OAUTH_TOKENS_PATH
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-oauth-'))
+  tokensPath = join(dir, 'mcp-oauth-tokens.json')
+  process.env.CHROXY_MCP_OAUTH_TOKENS_PATH = tokensPath
+  _setMcpOAuthKeychainForTests(null)
+})
+
+afterEach(() => {
+  _setMcpOAuthKeychainForTests(null)
+  if (prevPath === undefined) delete process.env.CHROXY_MCP_OAUTH_TOKENS_PATH
+  else process.env.CHROXY_MCP_OAUTH_TOKENS_PATH = prevPath
+  try { rmSync(dir, { recursive: true, force: true }) } catch { /* best-effort */ }
+})
+
+const RECORD = {
+  accessToken: 'access-secret-abc123',
+  refreshToken: 'refresh-secret-xyz789',
+  tokenType: 'Bearer',
+  scope: 'mcp',
+  expiresAt: 0,
+  clientId: 'client-1',
+  tokenEndpoint: 'https://as.example/token',
+}
+
+describe('serverKeyForUrl', () => {
+  it('normalizes to origin + path with no userinfo/query/fragment/trailing slash', () => {
+    assert.equal(serverKeyForUrl('https://u:p@Host.Example:8443/mcp/?q=1#frag'), 'https://host.example:8443/mcp')
+    assert.equal(serverKeyForUrl('https://host.example/mcp/'), 'https://host.example/mcp')
+    assert.equal(serverKeyForUrl('https://host.example/'), 'https://host.example')
+  })
+  it('returns null for an unparseable url', () => {
+    assert.equal(serverKeyForUrl('not a url'), null)
+    assert.equal(serverKeyForUrl(''), null)
+    assert.equal(serverKeyForUrl(null), null)
+  })
+})
+
+describe('token store (plaintext fallback — no keychain)', () => {
+  it('round-trips a record and returns null before any write', () => {
+    assert.equal(getStoredToken('https://host.example/mcp'), null)
+    setStoredToken('https://host.example/mcp', RECORD)
+    assert.deepEqual(getStoredToken('https://host.example/mcp'), RECORD)
+  })
+
+  it('keys by the normalized url so header rotation shares one record', () => {
+    setStoredToken('https://u:p@host.example/mcp?tok=1', RECORD)
+    assert.deepEqual(getStoredToken('https://host.example/mcp'), RECORD)
+  })
+
+  it('writes the file mode 0600', function () {
+    if (process.platform === 'win32') return
+    setStoredToken('https://host.example/mcp', RECORD)
+    assert.equal(statSync(tokensPath).mode & 0o777, 0o600)
+  })
+
+  it('merges without clobbering sibling records', () => {
+    setStoredToken('https://a.example/mcp', { ...RECORD, accessToken: 'A' })
+    setStoredToken('https://b.example/mcp', { ...RECORD, accessToken: 'B' })
+    assert.equal(getStoredToken('https://a.example/mcp').accessToken, 'A')
+    assert.equal(getStoredToken('https://b.example/mcp').accessToken, 'B')
+  })
+
+  it('deleteStoredToken removes one record and deletes the file when empty', () => {
+    setStoredToken('https://a.example/mcp', { ...RECORD, accessToken: 'A' })
+    setStoredToken('https://b.example/mcp', { ...RECORD, accessToken: 'B' })
+    deleteStoredToken('https://a.example/mcp')
+    assert.equal(getStoredToken('https://a.example/mcp'), null)
+    assert.equal(getStoredToken('https://b.example/mcp').accessToken, 'B')
+    deleteStoredToken('https://b.example/mcp')
+    assert.equal(existsSync(tokensPath), false)
+  })
+
+  it('rejects a record with no access token', () => {
+    assert.throws(() => setStoredToken('https://a.example/mcp', { refreshToken: 'x' }), /accessToken/)
+  })
+})
+
+describe('token store (encrypted at rest — injected keychain)', () => {
+  it('round-trips through the encrypted envelope and never writes the token in plaintext', () => {
+    _setMcpOAuthKeychainForTests(makeMemoryKeychain())
+    setStoredToken('https://host.example/mcp', RECORD)
+    // On-disk bytes must not contain either secret verbatim.
+    const raw = readFileSync(tokensPath, 'utf8')
+    assert.ok(!raw.includes(RECORD.accessToken), 'access token must not appear in plaintext on disk')
+    assert.ok(!raw.includes(RECORD.refreshToken), 'refresh token must not appear in plaintext on disk')
+    // The parsed file is an encrypted envelope, not the plain object.
+    const parsed = JSON.parse(raw)
+    assert.equal(parsed.alg, 'nacl-secretbox')
+    // But a read (with the same keychain) decrypts back to the record.
+    assert.deepEqual(getStoredToken('https://host.example/mcp'), RECORD)
+  })
+})
+
+describe('isTokenExpired', () => {
+  it('treats expiresAt=0 (no expires_in) as non-expiring', () => {
+    assert.equal(isTokenExpired({ expiresAt: 0 }), false)
+  })
+  it('is true within the skew window and false well before', () => {
+    assert.equal(isTokenExpired({ expiresAt: Date.now() + 5_000 }), true)  // inside 60s skew
+    assert.equal(isTokenExpired({ expiresAt: Date.now() + 5 * 60_000 }), false)
+    assert.equal(isTokenExpired({ expiresAt: Date.now() - 1_000 }), true)
+  })
+})
+
+// Guard: writing then reading a large token is stable (no truncation), and the
+// key derivation is stable across a random URL host.
+describe('token store misc', () => {
+  it('handles a long opaque token value', () => {
+    const big = randomBytes(512).toString('base64')
+    setStoredToken('https://host.example/mcp', { ...RECORD, accessToken: big })
+    assert.equal(getStoredToken('https://host.example/mcp').accessToken, big)
+  })
+})

--- a/packages/server/tests/byok-mcp-oauth.test.js
+++ b/packages/server/tests/byok-mcp-oauth.test.js
@@ -441,3 +441,46 @@ describe('AS metadata issuer validation (RFC 8414, #6822)', () => {
     assert.ok(as && as.token_endpoint === 'http://127.0.0.1:9999/token')
   })
 })
+
+describe('AS metadata endpoint scheme validation (#6822)', () => {
+  it('rejects metadata with a non-http(s) token_endpoint (javascript:)', async () => {
+    const fetchImpl = async () => fakeRes(200, {
+      issuer: 'http://127.0.0.1:9999/as',
+      authorization_endpoint: 'http://127.0.0.1:9999/authorize',
+      token_endpoint: 'javascript:alert(1)',
+    })
+    const as = await discoverAuthorizationServer({ issuer: 'http://127.0.0.1:9999/as', fetchImpl })
+    assert.equal(as, null, 'a javascript: token_endpoint must be rejected')
+  })
+
+  it('rejects metadata with a non-http(s) authorization_endpoint (file:)', async () => {
+    const fetchImpl = async () => fakeRes(200, {
+      issuer: 'http://127.0.0.1:9999/as',
+      authorization_endpoint: 'file:///etc/passwd',
+      token_endpoint: 'http://127.0.0.1:9999/token',
+    })
+    const as = await discoverAuthorizationServer({ issuer: 'http://127.0.0.1:9999/as', fetchImpl })
+    assert.equal(as, null, 'a file: authorization_endpoint must be rejected')
+  })
+
+  it('rejects metadata with a non-http(s) registration_endpoint (data:) when present', async () => {
+    const fetchImpl = async () => fakeRes(200, {
+      issuer: 'http://127.0.0.1:9999/as',
+      authorization_endpoint: 'http://127.0.0.1:9999/authorize',
+      token_endpoint: 'http://127.0.0.1:9999/token',
+      registration_endpoint: 'data:text/plain,evil',
+    })
+    const as = await discoverAuthorizationServer({ issuer: 'http://127.0.0.1:9999/as', fetchImpl })
+    assert.equal(as, null, 'a data: registration_endpoint must be rejected')
+  })
+
+  it('accepts https endpoints (scheme check does not reject legitimate metadata)', async () => {
+    const fetchImpl = async () => fakeRes(200, {
+      issuer: 'http://127.0.0.1:9999/as',
+      authorization_endpoint: 'https://127.0.0.1:9999/authorize',
+      token_endpoint: 'https://127.0.0.1:9999/token',
+    })
+    const as = await discoverAuthorizationServer({ issuer: 'http://127.0.0.1:9999/as', fetchImpl })
+    assert.ok(as && as.token_endpoint === 'https://127.0.0.1:9999/token')
+  })
+})

--- a/packages/server/tests/byok-mcp-oauth.test.js
+++ b/packages/server/tests/byok-mcp-oauth.test.js
@@ -332,3 +332,112 @@ describe('redirect URI configuration', () => {
     assert.equal(mcpOAuthRedirectUri(), 'https://tunnel.example/mcp/oauth/callback')
   })
 })
+
+// A Response-like stub + a fetch spy that records every (url, init) it sees.
+function fakeRes(status, body, headers = {}) {
+  const lower = {}
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v
+  return {
+    status,
+    headers: { get: (k) => (k.toLowerCase() in lower ? lower[k.toLowerCase()] : null) },
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  }
+}
+function spyFetch(handler) {
+  const calls = []
+  const fn = async (url, init) => { calls.push({ url: String(url), init }); return handler(url, init) }
+  fn.calls = calls
+  return fn
+}
+
+describe('SSRF hardening on OAuth endpoint fetches (#6822 / #6834)', () => {
+  const IMDS = 'http://169.254.169.254'
+  const IMDS_V6 = 'http://[fd00:ec2::254]'
+
+  it('(a) refuses a 169.254 resource_metadata target — never fetched', async () => {
+    const fetchImpl = spyFetch(async () => fakeRes(404, ''))
+    const res = await discoverProtectedResource({
+      serverUrl: 'http://127.0.0.1:1/mcp',
+      wwwAuthenticate: `Bearer resource_metadata="${IMDS}/latest/meta-data/"`,
+      fetchImpl,
+    })
+    assert.deepEqual(res.authorizationServers, [])
+    assert.ok(!fetchImpl.calls.some((c) => c.url.includes('169.254')), 'the metadata service must never be fetched')
+  })
+
+  it('(a) also refuses the IPv6 IMDS resource_metadata (fd00:ec2::254)', async () => {
+    const fetchImpl = spyFetch(async () => fakeRes(404, ''))
+    await discoverProtectedResource({
+      serverUrl: 'http://127.0.0.1:1/mcp',
+      wwwAuthenticate: `Bearer resource_metadata="${IMDS_V6}/x"`,
+      fetchImpl,
+    })
+    assert.ok(!fetchImpl.calls.some((c) => c.url.includes('fd00:ec2')), 'the IPv6 metadata endpoint must never be fetched')
+  })
+
+  it('(b) refuses a 169.254 issuer for AS metadata — never fetched, returns null', async () => {
+    const fetchImpl = spyFetch(async () => fakeRes(200, { issuer: IMDS, authorization_endpoint: `${IMDS}/a`, token_endpoint: `${IMDS}/t` }))
+    const as = await discoverAuthorizationServer({ issuer: IMDS, fetchImpl })
+    assert.equal(as, null)
+    assert.equal(fetchImpl.calls.length, 0, 'no candidate under the metadata host may be fetched')
+  })
+
+  it('(c) refuses a 169.254 registration_endpoint — throws, never fetched', async () => {
+    const fetchImpl = spyFetch(async () => fakeRes(201, { client_id: 'x' }))
+    await assert.rejects(
+      () => registerClient({ registrationEndpoint: `${IMDS}/register`, redirectUri: 'http://127.0.0.1/cb', fetchImpl }),
+      /cloud-metadata|link-local/,
+    )
+    assert.equal(fetchImpl.calls.length, 0)
+  })
+
+  it('(d) refuses a 169.254 token_endpoint on redeem AND refresh — throws, never fetched', async () => {
+    const fetchImpl = spyFetch(async () => fakeRes(200, { access_token: 'x' }))
+    await assert.rejects(
+      () => redeemCode({ tokenEndpoint: `${IMDS}/token`, clientId: 'c', code: 'x', redirectUri: 'http://127.0.0.1/cb', codeVerifier: 'v', fetchImpl }),
+      /cloud-metadata|link-local/,
+    )
+    await assert.rejects(
+      () => refreshAccessToken({ tokenEndpoint: `${IMDS}/token`, clientId: 'c', refreshToken: 'r', fetchImpl }),
+      /cloud-metadata|link-local/,
+    )
+    assert.equal(fetchImpl.calls.length, 0, 'the credentialed token POST must never reach the metadata service')
+  })
+
+  it('does not follow a 3xx on a metadata GET — redirect:manual, 302→internal not chased', async () => {
+    // A benign resource_metadata URL that 302s to the metadata service. With
+    // redirect:'manual' the daemon sees the 302 and does NOT follow it.
+    const fetchImpl = spyFetch(async () => fakeRes(302, '', { location: `${IMDS}/` }))
+    const res = await discoverProtectedResource({
+      serverUrl: 'http://127.0.0.1:1/mcp',
+      wwwAuthenticate: 'Bearer resource_metadata="http://127.0.0.1:2/.well-known/oauth-protected-resource"',
+      fetchImpl,
+    })
+    assert.deepEqual(res.authorizationServers, [], 'a 302 yields no metadata (not followed)')
+    assert.ok(fetchImpl.calls.length > 0 && fetchImpl.calls.every((c) => c.init.redirect === 'manual'),
+      'every metadata GET must set redirect:manual')
+    assert.ok(!fetchImpl.calls.some((c) => c.url.includes('169.254')), 'the 302 target must never be fetched')
+  })
+})
+
+describe('AS metadata issuer validation (RFC 8414, #6822)', () => {
+  it('rejects AS metadata whose issuer does not match the requested issuer', async () => {
+    const fetchImpl = async () => fakeRes(200, {
+      issuer: 'http://127.0.0.1:1111/evil',
+      authorization_endpoint: 'http://127.0.0.1:9999/authorize',
+      token_endpoint: 'http://127.0.0.1:9999/token',
+    })
+    const as = await discoverAuthorizationServer({ issuer: 'http://127.0.0.1:9999/as', fetchImpl })
+    assert.equal(as, null, 'an issuer mix-up must be rejected')
+  })
+
+  it('accepts AS metadata whose issuer matches exactly', async () => {
+    const fetchImpl = async () => fakeRes(200, {
+      issuer: 'http://127.0.0.1:9999/as',
+      authorization_endpoint: 'http://127.0.0.1:9999/authorize',
+      token_endpoint: 'http://127.0.0.1:9999/token',
+    })
+    const as = await discoverAuthorizationServer({ issuer: 'http://127.0.0.1:9999/as', fetchImpl })
+    assert.ok(as && as.token_endpoint === 'http://127.0.0.1:9999/token')
+  })
+})

--- a/packages/server/tests/byok-mcp-oauth.test.js
+++ b/packages/server/tests/byok-mcp-oauth.test.js
@@ -1,0 +1,334 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { createHash } from 'node:crypto'
+import {
+  generatePkce,
+  generateState,
+  parseResourceMetadataUrl,
+  discoverProtectedResource,
+  discoverAuthorizationServer,
+  registerClient,
+  buildAuthorizationUrl,
+  redeemCode,
+  refreshAccessToken,
+  beginAuthorization,
+  completeAuthorization,
+  registerOAuthCallback,
+  resolveOAuthCallback,
+  unregisterOAuthCallback,
+  _clearOAuthCallbacksForTests,
+  mcpOAuthRedirectUri,
+  setMcpOAuthCallbackBase,
+} from '../src/byok-mcp-oauth.js'
+
+function silentLog() {
+  return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} }
+}
+
+function base64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * A minimal in-process OAuth authorization server + protected-resource metadata
+ * host (#6822). One origin serves:
+ *   - /.well-known/oauth-protected-resource → authorization_servers = [self]
+ *   - /.well-known/oauth-authorization-server → endpoints
+ *   - POST /register → dynamic client registration
+ *   - POST /token → authorization_code + refresh_token grants, verifying PKCE
+ * Plus a test-only `issueCode(challenge, redirectUri)` that simulates the browser
+ * consent step (the AS binding a code to the presented code_challenge).
+ */
+function startMockAuthServer(opts = {}) {
+  const { supportsRegistration = true } = opts
+  const codes = new Map()      // code -> { challenge, redirectUri }
+  const refreshTokens = new Map() // refresh -> { count }
+  let clientSeq = 0
+  let tokenSeq = 0
+  const captured = { register: [], token: [] }
+
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      const url = new URL(req.url, 'http://127.0.0.1')
+      const bodyText = Buffer.concat(chunks).toString('utf8')
+      const origin = `http://127.0.0.1:${server.address().port}`
+
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-protected-resource') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({
+          resource: `${origin}/mcp`,
+          authorization_servers: [origin],
+          scopes_supported: ['mcp'],
+        }))
+        return
+      }
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-authorization-server') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        const meta = {
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+        }
+        if (supportsRegistration) meta.registration_endpoint = `${origin}/register`
+        res.end(JSON.stringify(meta))
+        return
+      }
+      if (req.method === 'POST' && url.pathname === '/register') {
+        let body = null
+        try { body = JSON.parse(bodyText) } catch { body = null }
+        captured.register.push(body)
+        clientSeq += 1
+        res.writeHead(201, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ client_id: `client-${clientSeq}`, redirect_uris: body?.redirect_uris }))
+        return
+      }
+      if (req.method === 'POST' && url.pathname === '/token') {
+        const form = new URLSearchParams(bodyText)
+        captured.token.push(Object.fromEntries(form.entries()))
+        const grant = form.get('grant_type')
+        if (grant === 'authorization_code') {
+          const code = form.get('code')
+          const verifier = form.get('code_verifier')
+          const redirectUri = form.get('redirect_uri')
+          const entry = codes.get(code)
+          if (!entry) { res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid_grant' })); return }
+          const computed = base64url(createHash('sha256').update(verifier || '').digest())
+          if (computed !== entry.challenge) { res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid_grant', error_description: 'pkce mismatch' })); return }
+          if (redirectUri !== entry.redirectUri) { res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid_grant', error_description: 'redirect mismatch' })); return }
+          codes.delete(code)
+          tokenSeq += 1
+          const refresh = `refresh-${tokenSeq}`
+          refreshTokens.set(refresh, { count: 0 })
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ access_token: `access-${tokenSeq}`, refresh_token: refresh, token_type: 'Bearer', expires_in: 3600, scope: 'mcp' }))
+          return
+        }
+        if (grant === 'refresh_token') {
+          const refresh = form.get('refresh_token')
+          if (!refreshTokens.has(refresh)) { res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid_grant' })); return }
+          const rec = refreshTokens.get(refresh)
+          rec.count += 1
+          tokenSeq += 1
+          res.writeHead(200, { 'content-type': 'application/json' })
+          // Rotation-optional: do NOT return a new refresh token.
+          res.end(JSON.stringify({ access_token: `access-refreshed-${tokenSeq}`, token_type: 'Bearer', expires_in: 3600 }))
+          return
+        }
+        res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'unsupported_grant_type' }))
+        return
+      }
+      res.writeHead(404).end()
+    })
+  })
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      const origin = `http://127.0.0.1:${port}`
+      resolve({
+        origin,
+        mcpUrl: `${origin}/mcp`,
+        captured,
+        issueCode: (challenge, redirectUri) => {
+          const code = `code-${Math.random().toString(36).slice(2)}`
+          codes.set(code, { challenge, redirectUri })
+          return code
+        },
+        close: () => new Promise((r) => server.close(r)),
+      })
+    })
+  })
+}
+
+describe('PKCE + state', () => {
+  it('generatePkce yields a verifier whose S256 challenge is base64url(sha256(verifier))', () => {
+    const { verifier, challenge, method } = generatePkce()
+    assert.equal(method, 'S256')
+    assert.match(verifier, /^[A-Za-z0-9\-_]+$/)
+    assert.equal(challenge, base64url(createHash('sha256').update(verifier).digest()))
+  })
+  it('generateState is high-entropy and unique', () => {
+    assert.notEqual(generateState(), generateState())
+  })
+})
+
+describe('parseResourceMetadataUrl', () => {
+  it('extracts the resource_metadata URL from a WWW-Authenticate header', () => {
+    assert.equal(
+      parseResourceMetadataUrl('Bearer resource_metadata="https://rs.example/.well-known/oauth-protected-resource", error="invalid_token"'),
+      'https://rs.example/.well-known/oauth-protected-resource',
+    )
+  })
+  it('returns null when absent', () => {
+    assert.equal(parseResourceMetadataUrl('Bearer realm="x"'), null)
+    assert.equal(parseResourceMetadataUrl(null), null)
+  })
+})
+
+describe('buildAuthorizationUrl', () => {
+  it('includes response_type, PKCE S256, state, scope, and the RFC 8707 resource', () => {
+    const url = new URL(buildAuthorizationUrl({
+      authorizationEndpoint: 'https://as.example/authorize',
+      clientId: 'client-1',
+      redirectUri: 'http://127.0.0.1:8765/mcp/oauth/callback',
+      codeChallenge: 'CHAL',
+      state: 'STATE',
+      scope: 'mcp',
+      resource: 'https://rs.example/mcp',
+    }))
+    assert.equal(url.searchParams.get('response_type'), 'code')
+    assert.equal(url.searchParams.get('client_id'), 'client-1')
+    assert.equal(url.searchParams.get('code_challenge'), 'CHAL')
+    assert.equal(url.searchParams.get('code_challenge_method'), 'S256')
+    assert.equal(url.searchParams.get('state'), 'STATE')
+    assert.equal(url.searchParams.get('scope'), 'mcp')
+    assert.equal(url.searchParams.get('resource'), 'https://rs.example/mcp')
+    assert.equal(url.searchParams.get('redirect_uri'), 'http://127.0.0.1:8765/mcp/oauth/callback')
+  })
+})
+
+describe('discovery + registration against a mock AS', () => {
+  let srv
+  afterEach(async () => { if (srv) { await srv.close(); srv = null } })
+
+  it('discovers the protected resource → authorization server, and registers a client', async () => {
+    srv = await startMockAuthServer()
+    const pr = await discoverProtectedResource({ serverUrl: srv.mcpUrl, wwwAuthenticate: null, fetchImpl: globalThis.fetch })
+    assert.deepEqual(pr.authorizationServers, [srv.origin])
+    assert.equal(pr.resource, `${srv.origin}/mcp`)
+    assert.deepEqual(pr.scopesSupported, ['mcp'])
+
+    const as = await discoverAuthorizationServer({ issuer: srv.origin, fetchImpl: globalThis.fetch })
+    assert.equal(as.authorization_endpoint, `${srv.origin}/authorize`)
+    assert.equal(as.token_endpoint, `${srv.origin}/token`)
+
+    const reg = await registerClient({ registrationEndpoint: as.registration_endpoint, redirectUri: 'http://127.0.0.1:9/cb', scope: 'mcp', fetchImpl: globalThis.fetch })
+    assert.match(reg.clientId, /^client-\d+$/)
+    // Registration requested the PKCE-friendly native/public client shape.
+    assert.equal(srv.captured.register[0].token_endpoint_auth_method, 'none')
+  })
+})
+
+describe('full begin → complete round trip (PKCE verified end-to-end)', () => {
+  let srv
+  afterEach(async () => { if (srv) { await srv.close(); srv = null } })
+
+  it('redeems a code whose challenge matches the verifier and yields tokens', async () => {
+    srv = await startMockAuthServer()
+    const redirectUri = 'http://127.0.0.1:8765/mcp/oauth/callback'
+    const { authorizationUrl, pending } = await beginAuthorization({
+      serverUrl: srv.mcpUrl,
+      wwwAuthenticate: `Bearer resource_metadata="${srv.origin}/.well-known/oauth-protected-resource"`,
+      redirectUri,
+      fetchImpl: globalThis.fetch,
+      log: silentLog(),
+    })
+    const authUrl = new URL(authorizationUrl)
+    const challenge = authUrl.searchParams.get('code_challenge')
+    // Sanity: the URL's challenge is exactly S256 of the pending verifier.
+    assert.equal(challenge, base64url(createHash('sha256').update(pending.codeVerifier).digest()))
+    assert.equal(authUrl.searchParams.get('state'), pending.state)
+
+    // Simulate the browser consent — the AS issues a code bound to the challenge.
+    const code = srv.issueCode(challenge, redirectUri)
+    const record = await completeAuthorization({ pending, code, fetchImpl: globalThis.fetch })
+    assert.match(record.accessToken, /^access-\d+$/)
+    assert.match(record.refreshToken, /^refresh-\d+$/)
+    assert.ok(record.expiresAt > Date.now())
+    assert.equal(record.tokenEndpoint, `${srv.origin}/token`)
+    assert.equal(record.clientId, pending.clientId)
+
+    // The /token request carried the code_verifier + resource (RFC 8707).
+    const tokenReq = srv.captured.token.find((t) => t.grant_type === 'authorization_code')
+    assert.equal(tokenReq.code_verifier, pending.codeVerifier)
+    assert.equal(tokenReq.resource, `${srv.origin}/mcp`)
+  })
+
+  it('rejects a mismatched verifier (PKCE enforced by the AS)', async () => {
+    srv = await startMockAuthServer()
+    const redirectUri = 'http://127.0.0.1:8765/mcp/oauth/callback'
+    const { pending } = await beginAuthorization({ serverUrl: srv.mcpUrl, redirectUri, fetchImpl: globalThis.fetch, log: silentLog() })
+    // Issue a code bound to a DIFFERENT challenge → redemption must fail.
+    const code = srv.issueCode('some-other-challenge', redirectUri)
+    await assert.rejects(() => completeAuthorization({ pending, code, fetchImpl: globalThis.fetch }), /HTTP 400|invalid_grant/)
+  })
+
+  it('refreshes an access token, preserving the refresh token when the AS does not rotate', async () => {
+    srv = await startMockAuthServer()
+    const redirectUri = 'http://127.0.0.1:8765/mcp/oauth/callback'
+    const { authorizationUrl, pending } = await beginAuthorization({ serverUrl: srv.mcpUrl, redirectUri, fetchImpl: globalThis.fetch, log: silentLog() })
+    const challenge = new URL(authorizationUrl).searchParams.get('code_challenge')
+    const code = srv.issueCode(challenge, redirectUri)
+    const record = await completeAuthorization({ pending, code, fetchImpl: globalThis.fetch })
+
+    const refreshed = await refreshAccessToken({
+      tokenEndpoint: record.tokenEndpoint,
+      clientId: record.clientId,
+      refreshToken: record.refreshToken,
+      resource: record.resource,
+      fetchImpl: globalThis.fetch,
+    })
+    assert.match(refreshed.accessToken, /^access-refreshed-\d+$/)
+    assert.equal(refreshed.refreshToken, record.refreshToken, 'rotation-optional: old refresh token retained')
+  })
+
+  it('fails cleanly when the AS supports no dynamic client registration', async () => {
+    srv = await startMockAuthServer({ supportsRegistration: false })
+    await assert.rejects(
+      () => beginAuthorization({ serverUrl: srv.mcpUrl, redirectUri: 'http://127.0.0.1:8765/cb', fetchImpl: globalThis.fetch, log: silentLog() }),
+      /dynamic client registration/,
+    )
+  })
+})
+
+describe('callback registry', () => {
+  beforeEach(() => _clearOAuthCallbacksForTests())
+  afterEach(() => _clearOAuthCallbacksForTests())
+
+  it('resolves a registered state by invoking its handler with the code', async () => {
+    let got = null
+    registerOAuthCallback('state-1', async (code) => { got = code })
+    const out = await resolveOAuthCallback('state-1', 'the-code')
+    assert.deepEqual(out, { found: true, ok: true })
+    assert.equal(got, 'the-code')
+    // Consumed on success — a second resolve misses.
+    assert.deepEqual(await resolveOAuthCallback('state-1', 'x'), { found: false })
+  })
+
+  it('reports not-found for an unknown state', async () => {
+    assert.deepEqual(await resolveOAuthCallback('nope', 'c'), { found: false })
+  })
+
+  it('reports a failed handler and leaves the entry for a retry', async () => {
+    registerOAuthCallback('state-2', async () => { throw new Error('redeem boom') })
+    const out = await resolveOAuthCallback('state-2', 'c')
+    assert.equal(out.found, true)
+    assert.equal(out.ok, false)
+    assert.match(out.error, /redeem boom/)
+    // Still present — the user can retry.
+    unregisterOAuthCallback('state-2')
+    assert.deepEqual(await resolveOAuthCallback('state-2', 'c'), { found: false })
+  })
+})
+
+describe('redirect URI configuration', () => {
+  const prev = process.env.CHROXY_MCP_OAUTH_REDIRECT_URI
+  afterEach(() => {
+    if (prev === undefined) delete process.env.CHROXY_MCP_OAUTH_REDIRECT_URI
+    else process.env.CHROXY_MCP_OAUTH_REDIRECT_URI = prev
+    setMcpOAuthCallbackBase(null)
+  })
+  it('derives the callback from the configured base', () => {
+    delete process.env.CHROXY_MCP_OAUTH_REDIRECT_URI
+    setMcpOAuthCallbackBase('http://127.0.0.1:9999')
+    assert.equal(mcpOAuthRedirectUri(), 'http://127.0.0.1:9999/mcp/oauth/callback')
+  })
+  it('an operator override wins', () => {
+    process.env.CHROXY_MCP_OAUTH_REDIRECT_URI = 'https://tunnel.example/mcp/oauth/callback'
+    setMcpOAuthCallbackBase('http://127.0.0.1:9999')
+    assert.equal(mcpOAuthRedirectUri(), 'https://tunnel.example/mcp/oauth/callback')
+  })
+})

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -1,6 +1,7 @@
 import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
+import { createHash } from 'node:crypto'
 import {
   MCPRemoteClient,
   MCPClient,
@@ -9,6 +10,11 @@ import {
   MCP_PROTOCOL_VERSION,
   DEFAULT_HANDSHAKE_TIMEOUT_MS,
 } from '../src/byok-mcp-client.js'
+import {
+  registerOAuthCallback,
+  resolveOAuthCallback,
+  _clearOAuthCallbacksForTests,
+} from '../src/byok-mcp-oauth.js'
 
 function silentLog() {
   return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} }
@@ -173,17 +179,20 @@ describe('MCPRemoteClient — Streamable HTTP (#6821)', () => {
     await client.destroy()
   })
 
-  it('401 → DEAD with oauth-required status, no crash', async () => {
+  it('401 → DEAD with oauth-required status, no crash (flow disabled)', async () => {
+    // With the OAuth flow disabled, a 401 still classifies as oauth-required and
+    // fails closed to DEAD — the base detection the #6822 flow builds on. The
+    // full discover→authorize→reconnect path has its own suite below.
     srv = await startMockMcpServer({ status: 401 })
     const warns = []
     const log = { info: () => {}, warn: (m) => warns.push(m), debug: () => {}, error: () => {} }
-    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log, oauthEnabled: false })
     await client.start() // must resolve, not throw
     assert.equal(client.state, MCP_STATES.DEAD)
     assert.equal(client.statusReason, 'oauth-required')
     assert.equal(client.tools.length, 0)
-    assert.ok(warns.some((m) => /OAuth/i.test(m) && /#6822/.test(m)),
-      `expected an OAuth-required warn naming #6822, got: ${JSON.stringify(warns)}`)
+    assert.ok(warns.some((m) => /OAuth/i.test(m)),
+      `expected an OAuth-required warn, got: ${JSON.stringify(warns)}`)
     await client.destroy()
   })
 
@@ -348,7 +357,10 @@ describe('MCPRemoteClient — legacy HTTP+SSE (#6821)', () => {
     // `initialized`. It now shares _checkStatus semantics with every other
     // call site.
     srv = await startMockSseServer({ notifyStatus: 401 })
-    const client = new MCPRemoteClient({ name: 'legacy', type: 'sse', url: srv.url, headers: {} }, { log: silentLog() })
+    // oauthEnabled:false isolates the 401→oauth-required classification (this
+    // mock serves an SSE stream for every GET, so a discovery probe would just
+    // hang against it — the full flow has its own suite with a real mock AS).
+    const client = new MCPRemoteClient({ name: 'legacy', type: 'sse', url: srv.url, headers: {} }, { log: silentLog(), oauthEnabled: false })
     await client.start() // must resolve, not throw
     assert.equal(client.state, MCP_STATES.DEAD)
     assert.equal(client.statusReason, 'oauth-required')
@@ -472,5 +484,307 @@ describe('MCPRemoteClient — SSRF hardening (#6834 sharp edges)', () => {
     assert.equal(calls.length, 0, 'no request may ever be attempted against the metadata endpoint')
     assert.equal(gateConsulted, false, 'the user must not be prompted to trust an unconditionally-refused url')
     await client.destroy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #6822 — OAuth authorization flow (401 → authorize → authenticated reconnect).
+// ---------------------------------------------------------------------------
+
+function base64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * An in-process MCP server that ALSO acts as its own OAuth authorization server:
+ *   - POST /mcp with no/invalid Bearer → 401 + WWW-Authenticate resource metadata
+ *   - POST /mcp with a valid Bearer → normal Streamable-HTTP MCP handshake
+ *   - the OAuth well-knowns + /register + /token (PKCE-verified) at the origin
+ * Exposes `issueCode(challenge, redirectUri)` to simulate browser consent and
+ * `addValidToken(t)` to pre-authorize a seeded token.
+ */
+function startOAuthMcpServer(opts = {}) {
+  const { tools = DEFAULT_TOOLS } = opts
+  const codes = new Map()
+  const refreshTokens = new Map()
+  const validTokens = new Set()
+  let seq = 0
+  const captured = { mcpAuthHeaders: [], token: [] }
+
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      const origin = `http://127.0.0.1:${server.address().port}`
+      const url = new URL(req.url, origin)
+      const bodyText = Buffer.concat(chunks).toString('utf8')
+
+      // OAuth discovery + endpoints.
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-protected-resource') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ resource: `${origin}/mcp`, authorization_servers: [origin], scopes_supported: ['mcp'] }))
+        return
+      }
+      if (req.method === 'GET' && url.pathname === '/.well-known/oauth-authorization-server') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          registration_endpoint: `${origin}/register`,
+        }))
+        return
+      }
+      if (req.method === 'POST' && url.pathname === '/register') {
+        seq += 1
+        res.writeHead(201, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ client_id: `client-${seq}` }))
+        return
+      }
+      if (req.method === 'POST' && url.pathname === '/token') {
+        const form = new URLSearchParams(bodyText)
+        captured.token.push(Object.fromEntries(form.entries()))
+        const grant = form.get('grant_type')
+        if (grant === 'authorization_code') {
+          const entry = codes.get(form.get('code'))
+          const computed = base64url(createHash('sha256').update(form.get('code_verifier') || '').digest())
+          if (!entry || computed !== entry.challenge) { res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid_grant' })); return }
+          codes.delete(form.get('code'))
+          seq += 1
+          const access = `access-${seq}`
+          const refresh = `refresh-${seq}`
+          validTokens.add(access)
+          refreshTokens.set(refresh, true)
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ access_token: access, refresh_token: refresh, token_type: 'Bearer', expires_in: 3600, scope: 'mcp' }))
+          return
+        }
+        if (grant === 'refresh_token') {
+          if (!refreshTokens.has(form.get('refresh_token'))) { res.writeHead(400, { 'content-type': 'application/json' }); res.end(JSON.stringify({ error: 'invalid_grant' })); return }
+          seq += 1
+          const access = `access-refreshed-${seq}`
+          validTokens.add(access)
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ access_token: access, token_type: 'Bearer', expires_in: 3600 }))
+          return
+        }
+        res.writeHead(400).end()
+        return
+      }
+
+      // MCP endpoint — bearer-gated.
+      if (req.method === 'DELETE') { res.writeHead(200).end(); return }
+      const auth = req.headers['authorization'] || ''
+      captured.mcpAuthHeaders.push(auth)
+      const token = auth.replace(/^Bearer\s+/i, '')
+      if (!token || !validTokens.has(token)) {
+        res.writeHead(401, {
+          'content-type': 'application/json',
+          'www-authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+        })
+        res.end(JSON.stringify({ error: 'unauthorized' }))
+        return
+      }
+      let msg = null
+      try { msg = bodyText ? JSON.parse(bodyText) : null } catch { msg = null }
+      if (msg && msg.id == null) { res.writeHead(202).end(); return }
+      let result
+      if (msg?.method === 'initialize') result = { protocolVersion: MCP_PROTOCOL_VERSION, capabilities: {}, serverInfo: { name: 'mock', version: '1' } }
+      else if (msg?.method === 'tools/list') result = { tools }
+      else { res.writeHead(200, { 'content-type': 'application/json' }); res.end(JSON.stringify({ jsonrpc: '2.0', id: msg?.id, error: { code: -32601, message: 'method not found' } })); return }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result }))
+    })
+  })
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      const origin = `http://127.0.0.1:${port}`
+      resolve({
+        origin,
+        url: `${origin}/mcp`,
+        captured,
+        issueCode: (challenge, redirectUri) => { const code = `code-${Math.random().toString(36).slice(2)}`; codes.set(code, { challenge, redirectUri }); return code },
+        addValidToken: (t) => validTokens.add(t),
+        close: () => new Promise((r) => server.close(r)),
+      })
+    })
+  })
+}
+
+// An in-memory token store injected into the client so the flow never touches
+// the real ~/.chroxy tokens file or the OS keychain.
+function makeMemStore(seed = {}) {
+  const map = new Map(Object.entries(seed))
+  return {
+    _map: map,
+    getStoredToken: (url) => map.get(url) || null,
+    setStoredToken: (url, rec) => { map.set(url, rec) },
+    deleteStoredToken: (url) => { map.delete(url) },
+    isTokenExpired: (rec) => (rec && rec.expiresAt > 0 ? Date.now() >= rec.expiresAt - 60_000 : false),
+  }
+}
+
+const REDIRECT = 'http://127.0.0.1:8765/mcp/oauth/callback'
+
+describe('MCPRemoteClient — OAuth flow (#6822)', () => {
+  afterEach(() => _clearOAuthCallbacksForTests())
+
+  it('401 → surfaces an authorization URL (oauth-required), no crash, no tools', async () => {
+    const srv = await startOAuthMcpServer()
+    const store = makeMemStore()
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'oauth', type: 'http', url: srv.url, headers: {} },
+        { log: silentLog(), oauthStore: store, oauthRedirectUri: REDIRECT },
+      )
+      await client.start()
+      assert.equal(client.needsAuthorization, true)
+      assert.equal(client.statusReason, 'oauth-required')
+      assert.ok(client.authorizationUrl, 'an authorization URL must be surfaced')
+      const u = new URL(client.authorizationUrl)
+      assert.equal(u.searchParams.get('code_challenge_method'), 'S256')
+      assert.equal(u.searchParams.get('redirect_uri'), REDIRECT)
+      assert.deepEqual(client.tools, [])
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('submit code → redeems + persists tokens + reconnects authenticated (READY with tools)', async () => {
+    const srv = await startOAuthMcpServer()
+    const store = makeMemStore()
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'oauth', type: 'http', url: srv.url, headers: {} },
+        { log: silentLog(), oauthStore: store, oauthRedirectUri: REDIRECT },
+      )
+      await client.start()
+      const challenge = new URL(client.authorizationUrl).searchParams.get('code_challenge')
+      const code = srv.issueCode(challenge, REDIRECT)
+
+      const out = await client.completeAuthorization(code)
+      assert.deepEqual(out, { ok: true })
+      assert.equal(client.state, MCP_STATES.READY)
+      assert.equal(client.needsAuthorization, false)
+      assert.equal(client.statusReason, null)
+      assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
+      // The token was persisted to the store and used as a Bearer on reconnect.
+      const rec = store.getStoredToken(srv.url)
+      assert.match(rec.accessToken, /^access-\d+$/)
+      assert.ok(srv.captured.mcpAuthHeaders.some((h) => h === `Bearer ${rec.accessToken}`), 'the reconnect must carry the bearer token')
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('the daemon loopback callback auto-completes via the state registry', async () => {
+    const srv = await startOAuthMcpServer()
+    const store = makeMemStore()
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'oauth', type: 'http', url: srv.url, headers: {} },
+        { log: silentLog(), oauthStore: store, oauthRedirectUri: REDIRECT },
+      )
+      await client.start()
+      const authUrl = new URL(client.authorizationUrl)
+      const challenge = authUrl.searchParams.get('code_challenge')
+      const state = authUrl.searchParams.get('state')
+      const code = srv.issueCode(challenge, REDIRECT)
+      // Drive the callback exactly as http-routes.js does.
+      const outcome = await resolveOAuthCallback(state, code)
+      assert.deepEqual(outcome, { found: true, ok: true })
+      assert.equal(client.state, MCP_STATES.READY)
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('a previously-authorized server reconnects with the stored token — no 401, no re-prompt', async () => {
+    const srv = await startOAuthMcpServer()
+    srv.addValidToken('seeded-access')
+    const store = makeMemStore({
+      [srv.url]: { accessToken: 'seeded-access', refreshToken: 'seeded-refresh', expiresAt: 0, clientId: 'c', tokenEndpoint: `${srv.origin}/token` },
+    })
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'oauth', type: 'http', url: srv.url, headers: {} },
+        { log: silentLog(), oauthStore: store, oauthRedirectUri: REDIRECT },
+      )
+      await client.start()
+      assert.equal(client.state, MCP_STATES.READY, 'stored token should connect without a prompt')
+      assert.equal(client.needsAuthorization, false)
+      // Every MCP request carried the seeded bearer; none was a 401 re-auth.
+      assert.ok(srv.captured.mcpAuthHeaders.every((h) => h === 'Bearer seeded-access'))
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('refreshes an expired stored token up front and connects authenticated', async () => {
+    const srv = await startOAuthMcpServer()
+    // Register a refresh token the mock will honour (mimics a prior authorization).
+    const store = makeMemStore({
+      [srv.url]: { accessToken: 'stale-access', refreshToken: 'seeded-refresh', expiresAt: Date.now() - 1000, clientId: 'c', tokenEndpoint: `${srv.origin}/token` },
+    })
+    // Teach the mock this refresh token (its /token refresh grant checks the set).
+    const challenge = base64url(createHash('sha256').update('v').digest())
+    const code = srv.issueCode(challenge, REDIRECT)
+    await fetch(`${srv.origin}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'authorization_code', code, code_verifier: 'v', redirect_uri: REDIRECT, client_id: 'c' }).toString(),
+    }).then((r) => r.json()).then((j) => { store._map.get(srv.url).refreshToken = j.refresh_token })
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'oauth', type: 'http', url: srv.url, headers: {} },
+        { log: silentLog(), oauthStore: store, oauthRedirectUri: REDIRECT },
+      )
+      await client.start()
+      assert.equal(client.state, MCP_STATES.READY)
+      // The stored record was refreshed to a new access token.
+      assert.match(store.getStoredToken(srv.url).accessToken, /^access-refreshed-\d+$/)
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('never logs a token or authorization code (redaction)', async () => {
+    const srv = await startOAuthMcpServer()
+    const store = makeMemStore()
+    const lines = []
+    const log = { info: (m) => lines.push(m), warn: (m) => lines.push(m), debug: (m) => lines.push(m), error: (m) => lines.push(m) }
+    try {
+      const client = new MCPRemoteClient(
+        { name: 'oauth', type: 'http', url: srv.url, headers: {} },
+        { log, oauthStore: store, oauthRedirectUri: REDIRECT },
+      )
+      await client.start()
+      const challenge = new URL(client.authorizationUrl).searchParams.get('code_challenge')
+      const code = srv.issueCode(challenge, REDIRECT)
+      await client.completeAuthorization(code)
+      const rec = store.getStoredToken(srv.url)
+      const blob = JSON.stringify(lines)
+      assert.ok(!blob.includes(rec.accessToken), 'access token must never be logged')
+      assert.ok(!blob.includes(rec.refreshToken), 'refresh token must never be logged')
+      assert.ok(!blob.includes(code), 'authorization code must never be logged')
+      await client.destroy()
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('registerOAuthCallback is a no-op for a malformed state/handler', () => {
+    // Defensive: bad inputs must not throw (the client wraps registration in try).
+    registerOAuthCallback('', () => {})
+    registerOAuthCallback('s', null)
+    // Nothing to assert beyond "did not throw"; the registry stays clean.
+    assert.ok(true)
   })
 })

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -787,4 +787,27 @@ describe('MCPRemoteClient — OAuth flow (#6822)', () => {
     // Nothing to assert beyond "did not throw"; the registry stays clean.
     assert.ok(true)
   })
+
+  it('dedupes the auth header: a config lowercase `authorization` + OAuth token → one Authorization, OAuth wins', () => {
+    const client = new MCPRemoteClient(
+      { name: 'oauth', type: 'http', url: 'http://127.0.0.1:1/mcp', headers: { authorization: 'Bearer STATIC' } },
+      { log: silentLog() },
+    )
+    client._accessToken = 'OAUTH-TOKEN'
+    const headers = client._buildHeaders({ json: true })
+    const authKeys = Object.keys(headers).filter((k) => k.toLowerCase() === 'authorization')
+    assert.deepEqual(authKeys, ['Authorization'], 'exactly one authorization header, canonical case')
+    assert.equal(headers.Authorization, 'Bearer OAUTH-TOKEN', 'the OAuth token wins over the static header')
+  })
+
+  it('leaves a config authorization header untouched when there is no OAuth token', () => {
+    const client = new MCPRemoteClient(
+      { name: 'noauth', type: 'http', url: 'http://127.0.0.1:1/mcp', headers: { authorization: 'Bearer STATIC' } },
+      { log: silentLog() },
+    )
+    const headers = client._buildHeaders()
+    // No token → the config's own header (whatever its case) passes through.
+    assert.equal(headers.authorization, 'Bearer STATIC')
+    assert.equal(headers.Authorization, undefined)
+  })
 })

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -520,6 +520,57 @@ describe('ClaudeByokSession', () => {
         assert.equal(emittedBefore.length, 0, 'no re-emit for an unknown server')
         await session.destroy()
       })
+
+      // #6822 — submitMcpAuthCode delegates to the fleet and re-emits mcp_servers.
+      it('submitMcpAuthCode delegates to the fleet and re-emits mcp_servers on success', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        await session.start()
+        // Swap in a fake fleet that records the code and reports success.
+        let received = null
+        session._mcpFleet = {
+          submitAuthCode: async (name, code) => { received = { name, code }; return { found: true, ok: true, status: 'connected' } },
+          getServerStatuses: () => [{ name: 'stub', status: 'connected', enabled: true, canToggle: true }],
+        }
+        const emitted = []
+        session.on('mcp_servers', (d) => emitted.push(d))
+        const res = await session.submitMcpAuthCode('stub', 'the-code')
+        assert.deepEqual(res, { found: true, ok: true, status: 'connected' })
+        assert.deepEqual(received, { name: 'stub', code: 'the-code' })
+        assert.equal(emitted.length, 1, 're-emits mcp_servers on a successful redemption')
+        await session.destroy()
+      })
+
+      it('submitMcpAuthCode returns found:false for an unknown server (no emit)', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        await session.start()
+        const emitted = []
+        session.on('mcp_servers', (d) => emitted.push(d))
+        const res = await session.submitMcpAuthCode('ghost', 'x')
+        assert.deepEqual(res, { found: false })
+        assert.equal(emitted.length, 0)
+        await session.destroy()
+      })
+
+      it('submitMcpAuthCode does not re-emit when redemption fails (ok:false)', async () => {
+        preTrustStub()
+        const configPath = writeStubConfig()
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        session._client = { messages: { stream: () => fakeStream([]) } }
+        await session.start()
+        session._mcpFleet = { submitAuthCode: async () => ({ found: true, ok: false, error: 'bad code' }) }
+        const emitted = []
+        session.on('mcp_servers', (d) => emitted.push(d))
+        const res = await session.submitMcpAuthCode('stub', 'x')
+        assert.equal(res.ok, false)
+        assert.equal(emitted.length, 0, 'no re-emit on a failed redemption')
+        await session.destroy()
+      })
     })
 
     it('#4457: untrusted MCP server fires a permission_request prompt; deny → DEAD without spawn', async () => {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -522,18 +522,23 @@ describe('ClaudeByokSession', () => {
       })
 
       // #6822 — submitMcpAuthCode delegates to the fleet and re-emits mcp_servers.
+      // These use a FAKE fleet injected without start() — a real fleet would
+      // spawn an MCP stub child, and swapping `_mcpFleet` after start() would
+      // orphan that child (a leaked handle that hangs `node --test` with no
+      // --test-force-exit; see the CI-hang investigation for #6822).
+      function fakeFleetSession(fleet) {
+        const session = new ClaudeByokSession({ cwd: '/tmp' })
+        session._mcpServerConfigs = [{ name: 'stub', url: 'https://ex.example/mcp' }]
+        session._mcpFleet = { destroy: async () => {}, ...fleet }
+        return session
+      }
+
       it('submitMcpAuthCode delegates to the fleet and re-emits mcp_servers on success', async () => {
-        preTrustStub()
-        const configPath = writeStubConfig()
-        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
-        session._client = { messages: { stream: () => fakeStream([]) } }
-        await session.start()
-        // Swap in a fake fleet that records the code and reports success.
         let received = null
-        session._mcpFleet = {
+        const session = fakeFleetSession({
           submitAuthCode: async (name, code) => { received = { name, code }; return { found: true, ok: true, status: 'connected' } },
           getServerStatuses: () => [{ name: 'stub', status: 'connected', enabled: true, canToggle: true }],
-        }
+        })
         const emitted = []
         session.on('mcp_servers', (d) => emitted.push(d))
         const res = await session.submitMcpAuthCode('stub', 'the-code')
@@ -544,11 +549,9 @@ describe('ClaudeByokSession', () => {
       })
 
       it('submitMcpAuthCode returns found:false for an unknown server (no emit)', async () => {
-        preTrustStub()
-        const configPath = writeStubConfig()
-        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
-        session._client = { messages: { stream: () => fakeStream([]) } }
-        await session.start()
+        const session = fakeFleetSession({
+          submitAuthCode: async () => { throw new Error('must not be called for an unknown server') },
+        })
         const emitted = []
         session.on('mcp_servers', (d) => emitted.push(d))
         const res = await session.submitMcpAuthCode('ghost', 'x')
@@ -558,12 +561,9 @@ describe('ClaudeByokSession', () => {
       })
 
       it('submitMcpAuthCode does not re-emit when redemption fails (ok:false)', async () => {
-        preTrustStub()
-        const configPath = writeStubConfig()
-        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
-        session._client = { messages: { stream: () => fakeStream([]) } }
-        await session.start()
-        session._mcpFleet = { submitAuthCode: async () => ({ found: true, ok: false, error: 'bad code' }) }
+        const session = fakeFleetSession({
+          submitAuthCode: async () => ({ found: true, ok: false, error: 'bad code' }),
+        })
         const emitted = []
         session.on('mcp_servers', (d) => emitted.push(d))
         const res = await session.submitMcpAuthCode('stub', 'x')

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -6,6 +6,7 @@ import { existsSync, renameSync, mkdtempSync, mkdirSync, writeFileSync, rmSync }
 import { join } from 'node:path'
 import { homedir, tmpdir } from 'node:os'
 import { createHttpHandler, resolveRemoveImage, _resetSnapshotBackendCacheForTests } from '../src/http-routes.js'
+import { registerOAuthCallback, _clearOAuthCallbacksForTests } from '../src/byok-mcp-oauth.js'
 
 // The QR endpoint falls back to reading ~/.chroxy/connection.json from disk.
 // If a Chroxy server is running (or left a stale file), the test gets 200 instead of 503.
@@ -937,6 +938,50 @@ describe('http-routes', () => {
       assert.equal(res.status, 500)
       const body = await res.json()
       assert.ok(body.error)
+    })
+  })
+
+  // #6822 — MCP OAuth redirect callback. Unauthenticated (the redirect carries
+  // no bearer); the high-entropy state is the capability.
+  describe('MCP OAuth callback (#6822)', () => {
+    afterEach(() => _clearOAuthCallbacksForTests())
+
+    it('auto-completes a known state via the callback registry (no auth header needed)', async () => {
+      let received = null
+      registerOAuthCallback('state-abc', async (code) => { received = code })
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?code=the-code&state=state-abc`)
+      assert.equal(res.status, 200)
+      const html = await res.text()
+      assert.match(html, /authorized/i)
+      assert.equal(received, 'the-code', 'the pending client received the code')
+    })
+
+    it('shows the code for a paste-fallback when no pending state matches', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?code=orphan-code&state=unknown`)
+      assert.equal(res.status, 200)
+      const html = await res.text()
+      assert.match(html, /Finish in Chroxy/i)
+      assert.match(html, /orphan-code/, 'the code is surfaced for the paste-code fallback')
+    })
+
+    it('returns 400 on a missing code/state', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?state=only-state`)
+      assert.equal(res.status, 400)
+    })
+
+    it('returns 400 when the authorization server reports an error', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?error=access_denied&state=s`)
+      assert.equal(res.status, 400)
+      const html = await res.text()
+      assert.match(html, /not completed/i)
     })
   })
 })

--- a/packages/server/tests/settings-handlers-mcp-auth.test.js
+++ b/packages/server/tests/settings-handlers-mcp-auth.test.js
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for handleSubmitMcpAuthCode in settings-handlers.js (#6822).
+ *
+ * Covers:
+ *  - happy path: submitMcpAuthCode invoked; no error frame on success
+ *  - capability rejection for a provider without the method (non-BYOK)
+ *  - redemption failure (ok:false) → MCP_AUTH_FAILED with the value-free reason
+ *  - unknown/not-awaiting server (found:false) → MCP_AUTH_NOT_FOUND
+ *  - auth gating: a bound token may submit for its OWN session but not another
+ *  - payload validation (missing server, missing code)
+ *  - the code is passed through but never surfaced in an error frame
+ */
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { settingsHandlers } from '../src/handlers/settings-handlers.js'
+import { nsCtx } from './test-helpers.js'
+
+const handler = settingsHandlers['submit_mcp_auth_code']
+
+const WS = { readyState: 1 }
+
+function makeSession(overrides = {}) {
+  return {
+    isReady: true,
+    submitMcpAuthCode: mock.fn(async () => ({ found: true, ok: true, status: 'connected' })),
+    ...overrides,
+  }
+}
+
+function makeCtx(entriesById = {}) {
+  const sessionMap = new Map(Object.entries(entriesById))
+  return nsCtx({
+    sessionManager: {
+      getSession: mock.fn((id) => sessionMap.get(id) ?? null),
+      serializeState: mock.fn(() => {}),
+    },
+    send: mock.fn(),
+    broadcast: mock.fn(),
+    broadcastToSession: mock.fn(),
+  })
+}
+
+function lastErr(ctx) {
+  const calls = ctx.transport.send.mock.calls
+  return calls.length ? calls[calls.length - 1].arguments[1] : null
+}
+
+describe('handleSubmitMcpAuthCode (#6822)', () => {
+  it('happy path — invokes submitMcpAuthCode with (server, code), no error frame', async () => {
+    const session = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: 'remote', code: 'the-code' }, ctx)
+
+    assert.equal(session.submitMcpAuthCode.mock.callCount(), 1)
+    assert.deepEqual(session.submitMcpAuthCode.mock.calls[0].arguments, ['remote', 'the-code'])
+    assert.equal(ctx.transport.send.mock.callCount(), 0, 'no error frame on success')
+  })
+
+  it('rejects a provider without submitMcpAuthCode with a capability error', async () => {
+    const session = makeSession({ submitMcpAuthCode: undefined })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: 'remote', code: 'x', requestId: 'r1' }, ctx)
+
+    const err = lastErr(ctx)
+    assert.equal(err?.code, 'MCP_AUTH_UNSUPPORTED')
+    assert.equal(err?.requestId, 'r1')
+  })
+
+  it('surfaces a redemption failure as MCP_AUTH_FAILED without leaking the code', async () => {
+    const session = makeSession({
+      submitMcpAuthCode: mock.fn(async () => ({ found: true, ok: false, error: 'token endpoint returned HTTP 400' })),
+    })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: 'remote', code: 'super-secret-code', requestId: 'r2' }, ctx)
+
+    const err = lastErr(ctx)
+    assert.equal(err?.code, 'MCP_AUTH_FAILED')
+    assert.equal(err?.requestId, 'r2')
+    assert.ok(!JSON.stringify(err).includes('super-secret-code'), 'the code must never appear in the error frame')
+  })
+
+  it('returns MCP_AUTH_NOT_FOUND for a server not awaiting authorization', async () => {
+    const session = makeSession({
+      submitMcpAuthCode: mock.fn(async () => ({ found: false })),
+    })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: 'ghost', code: 'x', requestId: 'r3' }, ctx)
+
+    assert.equal(lastErr(ctx)?.code, 'MCP_AUTH_NOT_FOUND')
+  })
+
+  it('bound token CAN submit for its own session but NOT another', async () => {
+    const own = makeSession()
+    const other = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session: own }, 'sess-2': { session: other } })
+    const client = { id: 'c1', activeSessionId: 'sess-1', boundSessionId: 'sess-1' }
+
+    // Own session — allowed.
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: 'remote', code: 'x' }, ctx)
+    assert.equal(own.submitMcpAuthCode.mock.callCount(), 1)
+
+    // Cross-session — blocked before reaching either session.
+    await handler(WS, client, { type: 'submit_mcp_auth_code', sessionId: 'sess-2', server: 'remote', code: 'x', requestId: 'r-x' }, ctx)
+    assert.equal(other.submitMcpAuthCode.mock.callCount(), 0)
+    assert.equal(lastErr(ctx)?.code, 'MCP_AUTH_NOT_APPLIED')
+    assert.equal(lastErr(ctx)?.requestId, 'r-x')
+  })
+
+  it('rejects a missing server or empty code', async () => {
+    const session = makeSession()
+    const ctx = makeCtx({ 'sess-1': { session } })
+    const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: '  ', code: 'x', requestId: 'a' }, ctx)
+    assert.equal(lastErr(ctx)?.code, 'MCP_AUTH_NOT_APPLIED')
+
+    await handler(WS, client, { type: 'submit_mcp_auth_code', server: 'remote', code: '   ', requestId: 'b' }, ctx)
+    assert.equal(lastErr(ctx)?.code, 'MCP_AUTH_NOT_APPLIED')
+    assert.equal(session.submitMcpAuthCode.mock.callCount(), 0)
+  })
+})

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -901,6 +901,21 @@ export const DISPATCH_FIXTURES: ContractFixture[] = [
     expect: { sessions: { s1: { mcpServers: [{ name: 'fs', status: 'connected' }] } } },
   },
 
+  // 14b. mcp_servers — #6822 oauth-required entry carries the browser authUrl
+  {
+    name: 'mcp_servers carries the oauth-required authUrl for a remote server',
+    type: 'mcp_servers',
+    init: { sessions: { s1: { mcpServers: [] } } },
+    message: {
+      type: 'mcp_servers',
+      sessionId: 's1',
+      servers: [{ name: 'remote', status: 'oauth-required', enabled: true, canToggle: true, authUrl: 'https://as.example/authorize?x=1' }],
+    },
+    expect: {
+      sessions: { s1: { mcpServers: [{ name: 'remote', status: 'oauth-required', enabled: true, canToggle: true, authUrl: 'https://as.example/authorize?x=1' }] } },
+    },
+  },
+
   // 15. session_usage — store cumulative usage
   {
     name: 'session_usage stores the session cumulative usage',

--- a/packages/store-core/src/types/session.ts
+++ b/packages/store-core/src/types/session.ts
@@ -247,6 +247,10 @@ export interface McpServer {
   // read-only. Both optional so a message from a pre-#6824 emitter round-trips.
   enabled?: boolean;
   canToggle?: boolean;
+  // #6822: when `status === 'oauth-required'`, the browser authorization URL the
+  // user opens to authorize this remote MCP server. Carries only the public URL
+  // (never a token/secret). Absent for every other status.
+  authUrl?: string;
 }
 
 export interface DevPreview {


### PR DESCRIPTION
## What & why

No OAuth flow existed anywhere in the MCP path, so a remote MCP server (BYOK remote transport, #6821/#6833) that requires browser-based authorization was a silent dead end on 401. This implements the MCP-spec **OAuth 2.1 authorization-code + PKCE** flow end-to-end.

**Core design constraint (remote user):** the browser that completes consent lives on the user's phone/dashboard, while token redemption must land at the daemon. The daemon holds the PKCE verifier + state server-side and only surfaces the authorization URL over the wire.

## Flow design — callback vs paste-code

Both redemption routes converge on the same daemon-side `completeAuthorization`:

1. **Loopback/tunnel callback (auto-complete)** — the daemon serves `GET /mcp/oauth/callback`. On generating the auth URL, the client registers a completion handler keyed by the high-entropy `state` (the state IS the capability; entries TTL out). When the browser can reach the daemon (desktop-local, or a tunnel with `CHROXY_MCP_OAUTH_REDIRECT_URI` set), the redirect auto-completes.
2. **Paste-code (universal fallback)** — when the browser can't reach the daemon loopback (the remote/tunneled case), the callback page shows the code, the user pastes it into Chroxy, and the client sends `submit_mcp_auth_code` back over the wire. This path always works and satisfies the acceptance criteria.

## Token-storage design

`byok-mcp-oauth-store.js` persists a per-server-URL record (access/refresh tokens, client id/secret, token endpoint, resource) in `~/.chroxy/mcp-oauth-tokens.json`, **encrypted at rest** via the existing `credential-cipher` + OS keychain (macOS Keychain / libsecret / DPAPI, #6644/#5154), 0600 owner-only, with a plaintext fallback where no keychain exists — identical posture to the credential store. Tokens/secrets never leave the module except to the flow and are never logged (redaction from #6833 applies).

## Wire (guard-cheapest)

- `mcp_servers` per-server entry gains an **optional `authUrl`** + `status: 'oauth-required'` — no new server→client message type, so none of the three server-message coverage guards move.
- New client→server message **`submit_mcp_auth_code`** (capability-gated, own-session, mirrors the #6846 `set_mcp_server_enabled` template).

## Clients

Dashboard `SidebarMcpView` and mobile `SettingsBar` render an **Authorize** action (opens the URL — new-tab / `Linking.openURL`) plus a **paste-code** input for the fallback.

## Shipped vs deferred

**Shipped (full):** discovery → dynamic client registration → PKCE → authorization URL → code redemption → encrypted token storage → authenticated reconnect → stored-token reconnect (no re-prompt) → up-front + reactive refresh → loopback callback auto-complete → paste-code fallback → dashboard + mobile UI.

DCR client id/secret and the token endpoint are persisted alongside the tokens, so **refresh survives a daemon restart**. No honesty-fence deferrals were required.

## Acceptance criteria

- [x] A `type:'http'`/`'sse'` server returning 401 triggers an authorization-URL flow surfaced to the client (not a silent failure)
- [x] The daemon receives the callback (loopback listener or copy-URL round-trip) and persists the token encrypted at rest
- [x] A previously-authorized server reconnects using the persisted token without re-prompting
- [x] New protocol messages documented + covered by contract tests

## Tests

In-process mock OAuth AS/RS covering: discovery, **PKCE round-trip (challenge = S256(verifier) verified by the AS)**, redemption, authenticated reconnect, stored-token reconnect, refresh (rotation-optional), paste-code path, loopback callback registry, keychain-mocked encrypted storage (never touches the real keychain — `CHROXY_MCP_OAUTH_TOKENS_PATH` temp isolation), and redaction asserts. Handler, fleet, byok-session, and http-route coverage added.

Run green locally: server (oauth/store/remote-client/fleet/session/handler/http-routes/schema-coverage), all 5 server `lint-*.sh`, eslint, protocol (362), store-core (2003 + new contract fixture), dashboard (typecheck + tests), app (typecheck + 2195), all Node 22.

Closes #6822