### PR TITLE
fix(server): protected-path floor catches ../ traversal to config dirs above cwd (#6806)

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import { resolve, relative, sep } from 'node:path'
+import { resolve, relative, sep, isAbsolute } from 'node:path'
 import { createLogger } from './logger.js'
 // #6038: the SDK/TUI permission path broadcasts to clients too, so it must apply
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
@@ -42,9 +42,10 @@ export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'
 // parity): the target simply falls through to the interactive prompt instead
 // of short-circuiting — a floor, never a hard deny.
 //
-// Protected DIRECTORY segment names, matched at any depth relative to the
-// session cwd. `.config/git` (the XDG git-config dir) is a two-segment
-// sequence handled separately in isProtectedPathTarget, not a bare segment.
+// Protected DIRECTORY segment names, matched at any depth of the path the write
+// RESOLVES into (see isProtectedPathValue for the relative-vs-absolute framing
+// that keeps a session's own cwd from false-matching). `.config/git` (the XDG
+// git-config dir) is a two-segment sequence handled separately, not a bare segment.
 const PROTECTED_DIR_SEGMENTS = new Set(['.git', '.claude', '.vscode'])
 
 // Tool-input fields that name a filesystem target. Presence of one is what
@@ -107,9 +108,30 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
 }
 
 /**
- * #6794 — is a single path value protected, resolved against `base`?
- * `resolve()` absorbs absolute paths, a leading `./`, and `..` traversal; the
- * relative path is what we segment-match so cwd's own name can't false-match.
+ * #6794 / #6806 — is a single path value protected, resolved against `base`?
+ * `resolve()` absorbs absolute paths, a leading `./`, and `..` traversal, giving
+ * the true target the write lands on.
+ *
+ * #6806 — WHICH segments we scan reconciles two goals that pull opposite ways:
+ *   (1) floor any write that RESOLVES into a protected config dir/file,
+ *       regardless of how `..` is arranged; and
+ *   (2) preserve the #6794 worktree guard — a session whose OWN cwd lives under
+ *       a real `.claude/` (the chroxy agent-worktree topology
+ *       `…/.claude/worktrees/agent-*`) must still write its own workspace files,
+ *       so cwd's own protected prefix segments must NOT false-floor it.
+ * The discriminator is whether the resolved target stays INSIDE the session's
+ * own workspace subtree (cwd):
+ *   - UNDER cwd → scan the path RELATIVE to cwd, so cwd's own prefix segments
+ *     (its `.claude`) are excluded and a benign in-workspace write is never
+ *     floored (goal 2). Under-cwd relatives never contain `..`.
+ *   - ESCAPES cwd (a `..`-traversal ABOVE it — itself suspicious) → scan the
+ *     RESOLVED ABSOLUTE path, so a protected segment sitting in cwd's PREFIX
+ *     (e.g. the very `.claude/` the worktree lives under, reached by
+ *     `../../settings.local.json`) is caught (goal 1). A protected segment that
+ *     appears BELOW the `..`s (an out-of-cwd `.git`) is caught either way. The
+ *     floor only ever forces a PROMPT, so over-flooring a sibling traversal
+ *     (which is already escaping the workspace) is safe and conservative.
+ *
  * Segments are lowercased first: on case-insensitive filesystems (macOS APFS,
  * Windows) `.GIT/config` IS `.git/config`, so a case-sensitive match would let
  * case variants evade the floor. Over-flooring a genuinely distinct `.GIT` on
@@ -119,8 +141,15 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
  * @returns {boolean}
  */
 function isProtectedPathValue(target, base) {
-  const rel = relative(base, resolve(base, target))
-  const segments = rel.split(sep)
+  const resolved = resolve(base, target)
+  const rel = relative(base, resolved)
+  // Target is inside cwd's own subtree when the relative path neither is nor
+  // begins with `..` (and isn't a foreign absolute — a Windows cross-drive
+  // `relative()` can return one). Empty rel = the target IS cwd (still "inside").
+  const underCwd = rel === '' ||
+    (!isAbsolute(rel) && rel !== '..' && !rel.startsWith('..' + sep))
+  const scanned = underCwd ? rel : resolved
+  const segments = scanned.split(sep)
     .filter((s) => s.length > 0 && s !== '..')
     .map((s) => s.toLowerCase())
   for (let i = 0; i < segments.length; i++) {
@@ -137,8 +166,9 @@ function isProtectedPathValue(target, base) {
  * {@link PROTECTED_PATH_INPUT_FIELDS} value (a benign `file_path` must not
  * shadow a protected `path`), resolves each against the session cwd (so
  * absolute paths, a leading `./`, and `..` traversal all normalize), then
- * tests the path RELATIVE to cwd segment-by-segment. ANY protected field
- * floors the input.
+ * tests the resolved path segment-by-segment. ANY protected field floors the
+ * input. See {@link isProtectedPathValue} for the #6806 relative-vs-absolute
+ * framing that decides which segments are scanned.
  *
  * #6805/#6828 — codex `apply_patch` carries its per-file targets in an ARRAY:
  * `input.changes` is `FileUpdateChange[] = { path, kind, diff }` (see
@@ -152,10 +182,13 @@ function isProtectedPathValue(target, base) {
  * `item.patch` passthrough) carries no parseable paths and is skipped, same
  * as any other non-array field.
  *
- * Matching relative-to-cwd (not the raw absolute path) is deliberate: the
- * session's OWN location can never trigger a false positive — e.g. a git
- * worktree that itself lives under a real `.claude/` dir writing to
- * `packages/…` is NOT floored, because the `.claude` segment is above cwd.
+ * A benign in-workspace write is never floored — a git worktree that itself
+ * lives under a real `.claude/` dir writing to `packages/…` stays UNfloored
+ * because a target under cwd is scanned relative to cwd (its own `.claude`
+ * prefix excluded). But a `..`-traversal back UP into that same `.claude`
+ * (`../../settings.local.json` → the real agent config) IS floored, because an
+ * above-cwd target is scanned as its resolved ABSOLUTE path (#6806). See
+ * {@link isProtectedPathValue} for the full reconciliation.
  *
  * Segment rules (a match on ANY segment floors the write; see
  * {@link isProtectedPathValue} for the lowercase rationale):
@@ -163,12 +196,9 @@ function isProtectedPathValue(target, base) {
  *   - a `.config` segment immediately followed by `git` (the XDG git-config dir)
  *   - a segment that is `.env` or starts with `.env.` (`.env` / `.env.local` / …)
  *
- * A target ABOVE cwd yields leading `..` segments; those are dropped before the
- * scan, so the real names beyond them are still checked (an out-of-cwd `.git`
- * still floors — conservative, and the floor only forces a prompt). Returns
- * false for any missing / non-string path field, so a command-shaped tool
- * (Bash, WebFetch) is never floored. Pure + side-effect-free (string ops only —
- * no regex, so the `.env.*` match can't be mangled by later edits).
+ * Returns false for any missing / non-string path field, so a command-shaped
+ * tool (Bash, WebFetch) is never floored. Pure + side-effect-free (string ops
+ * only — no regex, so the `.env.*` match can't be mangled by later edits).
  *
  * @param {object} input  the tool input
  * @param {string} [cwd]  the session cwd (falls back to process.cwd())

--- a/packages/server/tests/permission-manager-protected-path-floor.test.js
+++ b/packages/server/tests/permission-manager-protected-path-floor.test.js
@@ -290,6 +290,57 @@ describe('isProtectedPathTarget (#6794)', () => {
     assert.equal(isProtectedPathTarget({ file_path: 'src/a.js' }, '/home/me/.claude/wt/agent'), false)
   })
 
+  // #6806 — a session whose cwd is INSIDE a real `.claude/` (the agent-worktree
+  // topology …/.claude/worktrees/agent-*) traversing `..` back UP into that
+  // same `.claude` must be floored, even though the `.claude` segment lives in
+  // cwd's PREFIX (above cwd) rather than in the relative path.
+  describe('above-cwd `..` traversal into a protected dir in cwd\'s prefix (#6806)', () => {
+    const wtCwd = '/home/me/.claude/worktrees/agent-x'
+
+    it('floors the exact issue repro: ../../settings.local.json → the real .claude config', () => {
+      // resolve → /home/me/.claude/settings.local.json (the REAL agent config)
+      assert.equal(isProtectedPathTarget({ file_path: '../../settings.local.json' }, wtCwd), true)
+    })
+
+    it('floors a traversal that lands directly in the containing .claude dir', () => {
+      assert.equal(isProtectedPathTarget({ file_path: '../../hooks/pre.sh' }, wtCwd), true)
+    })
+
+    it('preserves the #6794 guard: a benign in-workspace write from the same cwd is NOT floored', () => {
+      assert.equal(isProtectedPathTarget({ file_path: 'packages/server/foo.js' }, wtCwd), false)
+      assert.equal(isProtectedPathTarget({ file_path: 'src/a.js' }, wtCwd), false)
+      // A deep in-workspace path that itself contains a benign nested dir stays fine.
+      assert.equal(isProtectedPathTarget({ file_path: 'a/b/c/d.js' }, wtCwd), false)
+    })
+
+    it('floors an above-cwd traversal that reaches a .git in the prefix', () => {
+      // cwd under a repo's .git-adjacent worktree; ../../.git/config escapes up.
+      assert.equal(isProtectedPathTarget({ file_path: '../../.git/config' }, '/repo/.git/wt/x'), true)
+    })
+
+    it('floors an above-cwd .git/.env even from a NORMAL (non-.claude) cwd', () => {
+      // The old relative-minus-`..` scan already caught this; keep it green.
+      assert.equal(isProtectedPathTarget({ file_path: '../sibling/.git/config' }, '/work/project'), true)
+      assert.equal(isProtectedPathTarget({ file_path: '../../.env.local' }, '/work/project'), true)
+    })
+
+    it('does NOT floor a benign above-cwd traversal from a normal cwd (no over-deny)', () => {
+      // Escaping the workspace to a plain sibling file is unusual but not a
+      // protected-config target — stays unfloored.
+      assert.equal(isProtectedPathTarget({ file_path: '../other/src/a.js' }, '/work/project'), false)
+    })
+
+    it('also floors the traversal when carried on a changes[] member (apply_patch)', () => {
+      assert.equal(isProtectedPathTarget({
+        file_path: wtCwd, // grantRoot — benign
+        changes: [
+          { path: 'src/ok.js', kind: 'update', diff: 'd' },
+          { path: '../../settings.local.json', kind: 'update', diff: 'd' },
+        ],
+      }, wtCwd), true)
+    })
+  })
+
   // #6805/#6828 — codex apply_patch carries per-file targets in an ARRAY
   // (input.changes = FileUpdateChange[] = { path, kind, diff }); the flat
   // file_path is the approval's grantRoot (typically the benign repo root).
@@ -414,6 +465,55 @@ describe('protected-path floor walks apply_patch changes[] (#6805/#6828)', () =>
 
     const result = await pm.handlePermission('apply_patch', benignInput(), null, 'acceptEdits')
     assert.equal(result.behavior, 'allow')
+    assert.equal(events.length, 0)
+  })
+})
+
+// #6806 — end-to-end acceptance: a session whose cwd is INSIDE a real `.claude/`
+// (the agent-worktree topology) must be floored on a `..`-traversal back up into
+// that `.claude`, and must NOT be floored on its own in-workspace writes.
+describe('protected-path floor catches ../ traversal above an under-.claude cwd (#6806)', () => {
+  const WT_CWD = '/home/me/.claude/worktrees/agent-x'
+  let pm
+
+  beforeEach(() => {
+    pm = new PermissionManager({ log: silentLog, cwd: WT_CWD })
+  })
+
+  afterEach(() => {
+    pm.destroy()
+  })
+
+  it('(a) auto mode + ../../settings.local.json (the real .claude config) falls through to the prompt', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const promise = pm.handlePermission('Write', { file_path: '../../settings.local.json' }, null, 'auto')
+    assert.equal(events.length, 1, 'a ../ escape into the containing .claude must prompt, not auto-approve')
+
+    pm.respondToPermission(events[0].requestId, 'deny')
+    const result = await promise
+    assert.equal(result.behavior, 'deny')
+  })
+
+  it('(a) allow Write rule + ../../hooks/pre.sh in the containing .claude falls through to the prompt', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+    pm.setRules([{ tool: 'Write', decision: 'allow' }])
+
+    const promise = pm.handlePermission('Write', { file_path: '../../hooks/pre.sh' }, null, 'approve')
+    assert.equal(events.length, 1)
+
+    pm.respondToPermission(events[0].requestId, 'deny')
+    await promise
+  })
+
+  it('(b) the #6794 guard holds: a benign in-workspace write from the same cwd stays auto-approved', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+
+    const result = await pm.handlePermission('Write', { file_path: 'packages/server/foo.js' }, null, 'auto')
+    assert.equal(result.behavior, 'allow', 'cwd-internal .claude must not floor a benign in-workspace write')
     assert.equal(events.length, 0)
   })
 })

--- a/packages/server/tests/permission-manager-protected-path-floor.test.js
+++ b/packages/server/tests/permission-manager-protected-path-floor.test.js
@@ -516,4 +516,58 @@ describe('protected-path floor catches ../ traversal above an under-.claude cwd 
     assert.equal(result.behavior, 'allow', 'cwd-internal .claude must not floor a benign in-workspace write')
     assert.equal(events.length, 0)
   })
+
+  // #6849 review — pin the three traversal edge cases the reviewer verified by
+  // hand. They already pass; these guard against a future refactor silently
+  // reopening the escape. All assert FLOORED through the real handlePermission
+  // path (WT_CWD = /home/me/.claude/worktrees/agent-x).
+  describe('pinned traversal edge cases (regression guard, #6849 review)', () => {
+    it('bare `..` resolving to a protected parent dir is floored', async () => {
+      // `..` → /home/me/.claude/worktrees (contains `.claude`). This is the
+      // exact edge the `rel !== '..'` clause in isProtectedPathValue exists for:
+      // drop it and underCwd flips true, the sole `..` segment is filtered, and
+      // the write silently stops being floored.
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission('Write', { file_path: '..' }, null, 'auto')
+      assert.equal(events.length, 1, 'bare `..` into a protected parent must prompt, not auto-approve')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      const result = await promise
+      assert.equal(result.behavior, 'deny')
+    })
+
+    it('an absolute file_path landing on a protected config path is floored', async () => {
+      // Absolute input wins over cwd in resolve(); it lands outside cwd's
+      // subtree, so the absolute-path scan catches the `.claude` in the prefix.
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+      pm.setRules([{ tool: 'Write', decision: 'allow' }])
+
+      const promise = pm.handlePermission(
+        'Write',
+        { file_path: '/home/me/.claude/settings.local.json' },
+        null,
+        'approve',
+      )
+      assert.equal(events.length, 1, 'an absolute protected target must prompt even under an allow rule')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+
+    it('mixed traversal `sub/../../.claude/x` from an under-.claude cwd is floored', async () => {
+      // Resolves to /home/me/.claude/worktrees/.claude/x — escapes cwd, so the
+      // absolute scan sees `.claude`.
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission('Write', { file_path: 'sub/../../.claude/x' }, null, 'acceptEdits')
+      assert.equal(events.length, 1, 'mixed traversal into .claude must prompt, not auto-approve')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      await promise
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a traversal escape in the protected-path floor (`isProtectedPathTarget` in `packages/server/src/permission-manager.js`, shipped in #6794/#6804). A session whose cwd is **inside** a real `.claude/` (the chroxy agent-worktree topology `.../.claude/worktrees/agent-*`) could silently auto-approve a write to its own `.claude/settings.local.json` via `../` traversal.

### The gap

The floor resolved the target relative to cwd and segment-matched the path **relative to cwd**, filtering leading `..` segments. When cwd is e.g. `/home/me/.claude/worktrees/agent-x`, a write to `../../settings.local.json`:

```
resolve  -> /home/me/.claude/settings.local.json   (the REAL agent config)
relative -> ../../settings.local.json
segments -> ['settings.local.json']  (..'s filtered) -> NOT floored
```

The `.claude` lives in the base **prefix** (above cwd), so filtering the `..`s left only the filename. Reachable on the SDK/TUI providers (no server-side cwd confinement).

### The fix — resolved semantics

`isProtectedPathValue` now chooses **which segments it scans** based on whether the resolved target stays inside cwd's own subtree — reconciling two goals that pull opposite ways:

- **UNDER cwd** → scan the path **relative to cwd**, so cwd's own protected prefix segments (its `.claude`) are excluded and a benign in-workspace write is never floored. **This preserves the #6794 worktree false-positive guard** — an agent worktree under `.claude/worktrees` writing to `packages/…` is not bricked.
- **ESCAPES cwd** (a `..`-traversal above it — itself suspicious) → scan the resolved **absolute** path, so a protected segment sitting in cwd's prefix (the very `.claude/` the worktree lives under) is caught.

The floor only ever forces a **prompt** (never a deny), so over-flooring a sibling `..` traversal — already suspicious as a workspace escape — is safe and conservative. The lowercase-segment, multi-field, and `apply_patch` `changes[]` handling from #6794/#6804/#6805/#6828 are all preserved.

## Tests (TDD)

- The exact issue repro: cwd inside `.claude` + `../../settings.local.json` → **floored** (pure matcher + end-to-end `handlePermission` under `auto`/`allow`).
- The #6794 guard preserved: a benign in-workspace write from that same cwd → **not floored**.
- Above-cwd `.git`/`.env` traversals floored; a benign above-cwd traversal from a normal cwd not floored; traversal on an `apply_patch` `changes[]` member floored.
- All existing floor tests stay green (case variants, multi-field, `apply_patch` `changes[]`, `.github` ≠ `.git`, etc.).

## Verification

- Floor test file: **69 tests pass**.
- Permission-manager-related suites that run in the worktree (permission-manager, resource-caps, resolver, rule-store, audit): **220 pass**. Two files (`get-permission-input`, `permission-response-parity`) fail to load in the worktree due to a missing `node_modules` SDK dependency (env gap, no coupling to the floor logic) — CI is authoritative.
- Both required server lints green (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`); eslint clean on the source.

Closes #6806