### PR TITLE
feat(server): show resolved address in MCP server trust prompt (#6834)

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -215,6 +215,17 @@ const _CLASSIFICATION_LABELS = {
 // internal address surfaces that fact at consent time.
 const _CLASSIFICATION_PRIORITY = ['loopback', 'private', 'link-local', 'public', 'unknown']
 
+// #6852 — cap on the trust-prompt DNS lookup. resolveTrustAddress runs inside
+// the fleet's withTrustStoreLock (byok-mcp-fleet.js), so a slow/hanging
+// resolver would both delay the consent prompt AND hold the lock for every
+// other MCP client. 2s is generous for a real resolver yet bounds the worst
+// case; on timeout we fall back to the same graceful "could not resolve host".
+export const DEFAULT_TRUST_DNS_TIMEOUT_MS = 2000
+
+// Resolved by the timeout arm of the lookup race (distinct from any address the
+// resolver could return), so a timeout maps to the graceful fallback.
+const _LOOKUP_TIMEOUT = Symbol('trust-address-lookup-timeout')
+
 function _summariseClassification(classifications) {
   for (const c of _CLASSIFICATION_PRIORITY) {
     if (classifications.includes(c)) return c
@@ -240,8 +251,12 @@ function _summariseClassification(classifications) {
  * same resolver the transport's metadata guard uses) so tests never touch real
  * DNS. Credentials are NOT this function's concern: pass an already-redacted or
  * raw url — only the hostname is read, and only IPs are returned.
+ *
+ * The lookup is bounded by `timeoutMs` (#6852): resolveTrustAddress runs under
+ * the fleet's trust-store lock, so a hanging resolver must not stall the prompt
+ * or the lock — a timeout falls back to 'could not resolve host'.
  */
-export async function resolveTrustAddress(url, { lookup = dnsLookup } = {}) {
+export async function resolveTrustAddress(url, { lookup = dnsLookup, timeoutMs = DEFAULT_TRUST_DNS_TIMEOUT_MS } = {}) {
   const miss = (hostname = null) => ({
     resolved: false,
     hostname,
@@ -268,8 +283,20 @@ export async function resolveTrustAddress(url, { lookup = dnsLookup } = {}) {
       display: `resolves to ${bare} (${_CLASSIFICATION_LABELS[classification] || classification})`,
     }
   }
+  let timer
   try {
-    const addrs = await lookup(bare, { all: true })
+    // Bound the lookup: whichever settles first wins. The timeout arm RESOLVES
+    // with a sentinel (never rejects) so a slow resolver maps to the graceful
+    // fallback, not an error. Promise.race registers a reaction on the lookup
+    // promise, so a late rejection from the loser stays handled. The timer is
+    // NOT unref'd — it is always cleared in `finally` once the race settles, so
+    // it never outlives this (awaited) resolution, and keeping the loop alive
+    // while we resolve is the intended behaviour.
+    const timeoutArm = new Promise((resolve) => {
+      timer = setTimeout(() => resolve(_LOOKUP_TIMEOUT), timeoutMs)
+    })
+    const addrs = await Promise.race([lookup(bare, { all: true }), timeoutArm])
+    if (addrs === _LOOKUP_TIMEOUT) return miss(hostname)
     const addresses = (Array.isArray(addrs) ? addrs : [])
       .map((a) => (a && typeof a.address === 'string' ? a.address : null))
       .filter(Boolean)
@@ -285,6 +312,8 @@ export async function resolveTrustAddress(url, { lookup = dnsLookup } = {}) {
     }
   } catch {
     return miss(hostname)
+  } finally {
+    clearTimeout(timer)
   }
 }
 

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -195,7 +195,11 @@ export function classifyIpAddress(ip) {
   }
   // IPv6 literals.
   if (h === '::1') return 'loopback'
-  if (h.startsWith('fe80:') || h.startsWith('fe80::')) return 'link-local'
+  // Link-local is fe80::/10 — the leading hextet spans fe80 through febf (top
+  // 10 bits fixed: 1111111010). Match the first two hex digits (fe) plus the
+  // third digit constrained to 8..b, not just the `fe80` literal. The trailing
+  // `:` covers both `fe80:...` and the compressed `fe80::...` (which begins `:`).
+  if (/^fe[89ab][0-9a-f]:/.test(h)) return 'link-local'
   if (/^f[cd][0-9a-f]{2}:/.test(h)) return 'private' // fc00::/7 unique-local
   if (h.includes(':')) return 'public'
   return 'unknown'
@@ -272,15 +276,20 @@ export async function resolveTrustAddress(url, { lookup = dnsLookup, timeoutMs =
   }
   if (!hostname) return miss()
   const bare = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
-  const isLiteral = /^[\d.]+$/.test(bare) || bare.includes(':')
-  if (isLiteral) {
-    const classification = classifyIpAddress(bare)
+  // Short-circuit ONLY for a syntactically-valid IP literal. A dotted-quad-
+  // shaped string with an out-of-range octet (e.g. 999.1.1.1) is NOT an IP —
+  // classifyIpAddress returns 'unknown' — so it is really a hostname and must
+  // go through the DNS path, not be echoed as a misleading "resolves to
+  // 999.1.1.1". A bracketed / colon-bearing IPv6 host is always a literal.
+  const looksLikeLiteral = /^[\d.]+$/.test(bare) || bare.includes(':')
+  const literalClass = looksLikeLiteral ? classifyIpAddress(bare) : 'unknown'
+  if (looksLikeLiteral && literalClass !== 'unknown') {
     return {
       resolved: true,
       hostname,
       addresses: [bare],
-      classification,
-      display: `resolves to ${bare} (${_CLASSIFICATION_LABELS[classification] || classification})`,
+      classification: literalClass,
+      display: `resolves to ${bare} (${_CLASSIFICATION_LABELS[literalClass] || literalClass})`,
     }
   }
   let timer

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { lookup as dnsLookup } from 'node:dns/promises'
 
 /**
  * Defensive upper bound on the size of `~/.claude.json`. Today the file is
@@ -154,6 +155,136 @@ export function redactMcpUrl(url) {
     return u.toString()
   } catch {
     return '[unparseable url]'
+  }
+}
+
+/**
+ * Classify a bare IP address for trust-prompt display (#6834). Returns one of
+ * 'loopback' | 'private' | 'link-local' | 'public' | 'unknown'. Purely for the
+ * human-facing consent string — the cloud-metadata range is hard-BLOCKED
+ * upstream (isBlockedMetadataHost, at config-parse and request time) so a
+ * metadata address never reaches this classifier.
+ *
+ * Covers the common private ranges a "remote" MCP server might secretly point
+ * at: IPv4 loopback (127/8), RFC1918 (10/8, 172.16/12, 192.168/16), link-local
+ * (169.254/16), and their IPv6 equivalents (::1, fc00::/7 ULA, fe80::/10
+ * link-local). IPv4-mapped IPv6 (`::ffff:a.b.c.d`) is unwrapped to its v4 form
+ * first. Anything else is 'public'. Best-effort — an unrecognisable string maps
+ * to 'unknown' (shown as such), never throws.
+ */
+export function classifyIpAddress(ip) {
+  if (typeof ip !== 'string' || ip.length === 0) return 'unknown'
+  let h = ip.toLowerCase().trim()
+  if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1)
+  const zone = h.indexOf('%') // strip an IPv6 zone id (fe80::1%en0)
+  if (zone !== -1) h = h.slice(0, zone)
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d) — classify by the embedded v4 address.
+  const mapped = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
+  if (mapped) h = mapped[1]
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (v4) {
+    const a = Number(v4[1])
+    const b = Number(v4[2])
+    if (v4.slice(1).some((o) => Number(o) > 255)) return 'unknown'
+    if (a === 127) return 'loopback'
+    if (a === 10) return 'private'
+    if (a === 172 && b >= 16 && b <= 31) return 'private'
+    if (a === 192 && b === 168) return 'private'
+    if (a === 169 && b === 254) return 'link-local'
+    return 'public'
+  }
+  // IPv6 literals.
+  if (h === '::1') return 'loopback'
+  if (h.startsWith('fe80:') || h.startsWith('fe80::')) return 'link-local'
+  if (/^f[cd][0-9a-f]{2}:/.test(h)) return 'private' // fc00::/7 unique-local
+  if (h.includes(':')) return 'public'
+  return 'unknown'
+}
+
+// Human-readable label per classification, for the trust-prompt string.
+const _CLASSIFICATION_LABELS = {
+  loopback: 'loopback',
+  private: 'private LAN',
+  'link-local': 'link-local',
+  public: 'public',
+  unknown: 'unknown',
+}
+
+// Order of "notability" when a host resolves to several addresses — the most
+// internal wins the summary label so a remote server that ALSO resolves to an
+// internal address surfaces that fact at consent time.
+const _CLASSIFICATION_PRIORITY = ['loopback', 'private', 'link-local', 'public', 'unknown']
+
+function _summariseClassification(classifications) {
+  for (const c of _CLASSIFICATION_PRIORITY) {
+    if (classifications.includes(c)) return c
+  }
+  return 'unknown'
+}
+
+/**
+ * Best-effort resolution of a remote MCP server url's host, for the first-use
+ * trust prompt (#6834). Returns a small structured record describing WHERE the
+ * host actually points so a user approving a 'remote' server can see when it
+ * resolves to a loopback / private / internal address and make an informed
+ * consent decision (owner decision 2026-07-18: display, don't block).
+ *
+ * Shape: `{ resolved, hostname, addresses, classification, display }`.
+ *   - resolved:false + display 'could not resolve host' when the url is
+ *     unparseable OR DNS lookup fails / returns nothing. NEVER throws.
+ *   - a literal IP host is classified directly (no DNS round-trip).
+ *   - a DNS name is resolved via `lookup(..., { all: true })`; the summary
+ *     classification is the most-internal of the returned addresses.
+ *
+ * The `lookup` seam is injectable (defaults to node:dns/promises lookup — the
+ * same resolver the transport's metadata guard uses) so tests never touch real
+ * DNS. Credentials are NOT this function's concern: pass an already-redacted or
+ * raw url — only the hostname is read, and only IPs are returned.
+ */
+export async function resolveTrustAddress(url, { lookup = dnsLookup } = {}) {
+  const miss = (hostname = null) => ({
+    resolved: false,
+    hostname,
+    addresses: [],
+    classification: 'unknown',
+    display: 'could not resolve host',
+  })
+  let hostname
+  try {
+    hostname = new URL(url).hostname
+  } catch {
+    return miss()
+  }
+  if (!hostname) return miss()
+  const bare = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+  const isLiteral = /^[\d.]+$/.test(bare) || bare.includes(':')
+  if (isLiteral) {
+    const classification = classifyIpAddress(bare)
+    return {
+      resolved: true,
+      hostname,
+      addresses: [bare],
+      classification,
+      display: `resolves to ${bare} (${_CLASSIFICATION_LABELS[classification] || classification})`,
+    }
+  }
+  try {
+    const addrs = await lookup(bare, { all: true })
+    const addresses = (Array.isArray(addrs) ? addrs : [])
+      .map((a) => (a && typeof a.address === 'string' ? a.address : null))
+      .filter(Boolean)
+    if (addresses.length === 0) return miss(hostname)
+    const classifications = addresses.map(classifyIpAddress)
+    const classification = _summariseClassification(classifications)
+    return {
+      resolved: true,
+      hostname,
+      addresses,
+      classification,
+      display: `resolves to ${addresses.join(', ')} (${_CLASSIFICATION_LABELS[classification] || classification})`,
+    }
+  } catch {
+    return miss(hostname)
   }
 }
 

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -6,7 +6,7 @@ import { createLogger } from './logger.js'
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
 // redaction.js (a leaf module — no import cycle / HTTP-handler weight).
 import { sanitizeToolInput, redactValue } from './redaction.js'
-import { redactMcpUrl } from './byok-mcp-config.js'
+import { redactMcpUrl, resolveTrustAddress } from './byok-mcp-config.js'
 // #6842 review (Copilot) — audit entries must carry the store's NORMALIZED
 // project key, not the raw session cwd, or a relative / `..`-laden cwd
 // produces entries that never correlate with the persisted rule they audit.
@@ -207,10 +207,14 @@ export function isProtectedPathTarget(input, cwd) {
  *   user_question       { toolUseId, questions }
  */
 export class PermissionManager extends EventEmitter {
-  constructor({ timeoutMs, log, maxPendingPermissions, cwd, ruleStore } = {}) {
+  constructor({ timeoutMs, log, maxPendingPermissions, cwd, ruleStore, mcpTrustLookup } = {}) {
     super()
     this._timeoutMs = timeoutMs || DEFAULT_TIMEOUT_MS
     this._log = log || console
+    // #6834 — injectable DNS resolver for the MCP-trust prompt's resolved-address
+    // display. Defaults to node:dns/promises lookup (via resolveTrustAddress)
+    // when unset; tests pass a fake so they never touch real DNS.
+    this._mcpTrustLookup = typeof mcpTrustLookup === 'function' ? mcpTrustLookup : null
     // #6448 — bound on concurrent pending permissions; injectable so the cap is
     // testable without minting 1000 real requests.
     this._maxPendingPermissions = maxPendingPermissions || MAX_PENDING_PERMISSIONS
@@ -935,18 +939,42 @@ export class PermissionManager extends EventEmitter {
    * @param {{ name: string, command?: string, args?: string[], envKeys?: string[], url?: string, headerKeys?: string[] }} server
    * @returns {Promise<boolean>}
    */
-  requestMcpTrust(server) {
+  async requestMcpTrust(server) {
+    const isRemote = typeof server.url === 'string' && server.url.length > 0
+    const safeUrl = isRemote ? redactMcpUrl(server.url) : ''
+    // #6834 — for a REMOTE server, best-effort-resolve the host BEFORE we build
+    // the prompt so the consent string can show when a "remote" URL actually
+    // points at a loopback / private / internal address (owner decision:
+    // display, never block beyond the existing cloud-metadata hard-block).
+    // Resolution is non-fatal — resolveTrustAddress returns a 'could not
+    // resolve host' record on any failure and never throws. Only the hostname
+    // is read (from the already-redacted url); only IPs come back. The stdio
+    // path has no url, so no await runs and its prompt still emits synchronously
+    // (autoAllowPending / pending-size assertions depend on that).
+    const resolved = isRemote
+      ? await resolveTrustAddress(safeUrl, { lookup: this._mcpTrustLookup || undefined })
+      : null
     return new Promise((resolve) => {
       const requestId = `mcp-trust-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
-      const isRemote = typeof server.url === 'string' && server.url.length > 0
       const argv0 = Array.isArray(server.args) && server.args.length > 0 ? server.args[0] : ''
-      const safeUrl = isRemote ? redactMcpUrl(server.url) : ''
       const input = {
         mcpServer: isRemote
           ? {
               name: server.name,
               url: safeUrl,
               headerKeys: Array.isArray(server.headerKeys) ? [...server.headerKeys] : [],
+              // Structured mirror of the resolved-address marker embedded in
+              // `description`. Plain strings/arrays/bools — survives
+              // sanitizeToolInput untouched — so a client that renders MCP-trust
+              // input structurally can surface it without re-parsing the string.
+              resolvedAddress: resolved
+                ? {
+                    resolved: resolved.resolved,
+                    addresses: resolved.addresses,
+                    classification: resolved.classification,
+                    display: resolved.display,
+                  }
+                : null,
             }
           : {
               name: server.name,
@@ -956,7 +984,7 @@ export class PermissionManager extends EventEmitter {
             },
       }
       const description = isRemote
-        ? `Connect to MCP server "${server.name}" at ${safeUrl}`
+        ? `Connect to MCP server "${server.name}" at ${safeUrl}${resolved ? ` — ${resolved.display}` : ''}`
         : `Spawn MCP server "${server.name}" running ${server.command}${argv0 ? ' ' + argv0 : ''}`
 
       // Wrap pending entry so respondToPermission's standard mapping

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -5,11 +5,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   CLAUDE_CONFIG_MAX_BYTES,
+  classifyIpAddress,
   discoverConfiguredMcpServers,
   isBlockedMetadataHost,
   loadClaudeMcpConfig,
   parseClaudeMcpConfig,
   redactMcpUrl,
+  resolveTrustAddress,
   toMcpServerMetadata,
 } from '../src/byok-mcp-config.js'
 
@@ -347,5 +349,105 @@ describe('discoverConfiguredMcpServers (#6820)', () => {
     assert.deepEqual(res.servers, [{ name: 'good' }])
     assert.equal(res.warnings.length, 1)
     assert.match(res.warnings[0], /bad/)
+  })
+})
+
+describe('classifyIpAddress (#6834)', () => {
+  it('classifies IPv4 loopback / RFC1918 / link-local / public', () => {
+    assert.equal(classifyIpAddress('127.0.0.1'), 'loopback')
+    assert.equal(classifyIpAddress('127.5.5.5'), 'loopback')
+    assert.equal(classifyIpAddress('10.0.0.1'), 'private')
+    assert.equal(classifyIpAddress('172.16.0.1'), 'private')
+    assert.equal(classifyIpAddress('172.31.255.255'), 'private')
+    assert.equal(classifyIpAddress('172.32.0.1'), 'public') // just outside /12
+    assert.equal(classifyIpAddress('192.168.1.5'), 'private')
+    assert.equal(classifyIpAddress('169.254.10.10'), 'link-local')
+    assert.equal(classifyIpAddress('93.184.216.34'), 'public')
+    assert.equal(classifyIpAddress('8.8.8.8'), 'public')
+  })
+
+  it('classifies IPv6 loopback / ULA / link-local / public + mapped v4', () => {
+    assert.equal(classifyIpAddress('::1'), 'loopback')
+    assert.equal(classifyIpAddress('[::1]'), 'loopback')
+    assert.equal(classifyIpAddress('fe80::1'), 'link-local')
+    assert.equal(classifyIpAddress('fe80::1%en0'), 'link-local')
+    assert.equal(classifyIpAddress('fd00::1'), 'private')
+    assert.equal(classifyIpAddress('fc00::1'), 'private')
+    assert.equal(classifyIpAddress('2606:4700:4700::1111'), 'public')
+    assert.equal(classifyIpAddress('::ffff:127.0.0.1'), 'loopback')
+    assert.equal(classifyIpAddress('::ffff:10.0.0.1'), 'private')
+  })
+
+  it('maps junk / out-of-range to unknown, never throws', () => {
+    assert.equal(classifyIpAddress(''), 'unknown')
+    assert.equal(classifyIpAddress(null), 'unknown')
+    assert.equal(classifyIpAddress('not-an-ip'), 'unknown')
+    assert.equal(classifyIpAddress('999.1.1.1'), 'unknown')
+  })
+})
+
+describe('resolveTrustAddress (#6834)', () => {
+  it('classifies a literal loopback host without a DNS round-trip', async () => {
+    let called = false
+    const lookup = async () => { called = true; return [] }
+    const r = await resolveTrustAddress('http://127.0.0.1:8080/mcp', { lookup })
+    assert.equal(called, false, 'literal IP must not hit DNS')
+    assert.equal(r.resolved, true)
+    assert.equal(r.classification, 'loopback')
+    assert.deepEqual(r.addresses, ['127.0.0.1'])
+    assert.match(r.display, /resolves to 127\.0\.0\.1 \(loopback\)/)
+  })
+
+  it('classifies a literal private-LAN host', async () => {
+    const r = await resolveTrustAddress('https://192.168.1.50/', { lookup: async () => [] })
+    assert.equal(r.classification, 'private')
+    assert.match(r.display, /resolves to 192\.168\.1\.50 \(private LAN\)/)
+  })
+
+  it('resolves a DNS name to loopback via the injected lookup', async () => {
+    const lookup = async () => [{ address: '127.0.0.1', family: 4 }]
+    const r = await resolveTrustAddress('http://lm.local:1234/', { lookup })
+    assert.equal(r.resolved, true)
+    assert.equal(r.hostname, 'lm.local')
+    assert.equal(r.classification, 'loopback')
+    assert.match(r.display, /resolves to 127\.0\.0\.1 \(loopback\)/)
+  })
+
+  it('resolves a public DNS name as public', async () => {
+    const lookup = async () => [{ address: '93.184.216.34', family: 4 }]
+    const r = await resolveTrustAddress('https://example.com/mcp', { lookup })
+    assert.equal(r.classification, 'public')
+    assert.match(r.display, /resolves to 93\.184\.216\.34 \(public\)/)
+  })
+
+  it('summarises to the most-internal address when a name resolves to several', async () => {
+    const lookup = async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.1.2.3', family: 4 },
+    ]
+    const r = await resolveTrustAddress('https://mixed.example/', { lookup })
+    assert.equal(r.classification, 'private')
+    assert.deepEqual(r.addresses, ['93.184.216.34', '10.1.2.3'])
+    assert.match(r.display, /private LAN/)
+  })
+
+  it('gracefully falls back when DNS lookup throws', async () => {
+    const lookup = async () => { throw new Error('ENOTFOUND') }
+    const r = await resolveTrustAddress('https://nope.invalid/', { lookup })
+    assert.equal(r.resolved, false)
+    assert.equal(r.display, 'could not resolve host')
+    assert.deepEqual(r.addresses, [])
+  })
+
+  it('gracefully falls back when DNS returns nothing', async () => {
+    const r = await resolveTrustAddress('https://empty.example/', { lookup: async () => [] })
+    assert.equal(r.resolved, false)
+    assert.equal(r.display, 'could not resolve host')
+  })
+
+  it('gracefully falls back on an unparseable url (no throw)', async () => {
+    const r = await resolveTrustAddress('not a url', { lookup: async () => [] })
+    assert.equal(r.resolved, false)
+    assert.equal(r.display, 'could not resolve host')
   })
 })

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -381,6 +381,18 @@ describe('classifyIpAddress (#6834)', () => {
     assert.equal(classifyIpAddress('::ffff:10.0.0.1'), 'private')
   })
 
+  it('matches the full fe80::/10 link-local range, not just the fe80 literal (#6850 review)', () => {
+    // fe80::/10 spans the leading hextet fe80 through febf.
+    assert.equal(classifyIpAddress('fe80::1'), 'link-local')
+    assert.equal(classifyIpAddress('fe90::1'), 'link-local')
+    assert.equal(classifyIpAddress('fea0::1'), 'link-local')
+    assert.equal(classifyIpAddress('feaf::abcd'), 'link-local')
+    assert.equal(classifyIpAddress('febf::1'), 'link-local')
+    // fec0::/10 is deprecated site-local, NOT link-local — must not match.
+    assert.notEqual(classifyIpAddress('fec0::1'), 'link-local')
+    assert.notEqual(classifyIpAddress('fe7f::1'), 'link-local') // just below the range
+  })
+
   it('maps junk / out-of-range to unknown, never throws', () => {
     assert.equal(classifyIpAddress(''), 'unknown')
     assert.equal(classifyIpAddress(null), 'unknown')
@@ -414,6 +426,44 @@ describe('resolveTrustAddress (#6834)', () => {
     assert.equal(r.hostname, 'lm.local')
     assert.equal(r.classification, 'loopback')
     assert.match(r.display, /resolves to 127\.0\.0\.1 \(loopback\)/)
+  })
+
+  it('treats an out-of-range dotted-quad host as a hostname (DNS lookup), not a literal IP (#6850 review)', async () => {
+    // 999.1.1.1 is dotted-quad-SHAPED but not a valid IP (classifyIpAddress →
+    // 'unknown'), so it must go through the DNS path, never be echoed as a
+    // misleading "resolves to 999.1.1.1". A non-special scheme preserves the
+    // opaque host verbatim, so this reaches (and exercises) the guard.
+    assert.equal(classifyIpAddress('999.1.1.1'), 'unknown')
+    let looked = null
+    const lookup = async (host) => { looked = host; return [{ address: '93.184.216.34', family: 4 }] }
+    const r = await resolveTrustAddress('mcp://999.1.1.1/x', { lookup })
+    assert.equal(looked, '999.1.1.1', 'the invalid dotted-quad must be passed to DNS lookup, not treated as a literal')
+    assert.equal(r.resolved, true)
+    assert.equal(r.hostname, '999.1.1.1')
+    assert.deepEqual(r.addresses, ['93.184.216.34'])
+    assert.equal(r.classification, 'public')
+    assert.doesNotMatch(r.display, /resolves to 999\.1\.1\.1/)
+    assert.match(r.display, /resolves to 93\.184\.216\.34 \(public\)/)
+  })
+
+  it('for an http URL, the parser rejects an out-of-range quad before any lookup (graceful fallback)', async () => {
+    // Defence-in-depth alongside the guard: a special-scheme (http) URL with an
+    // out-of-range IPv4 host is rejected by the WHATWG parser outright, so it
+    // never reaches DNS and never surfaces a bogus literal — just the fallback.
+    let called = false
+    const r = await resolveTrustAddress('http://999.1.1.1/mcp', { lookup: async () => { called = true; return [] } })
+    assert.equal(called, false)
+    assert.equal(r.resolved, false)
+    assert.equal(r.display, 'could not resolve host')
+    assert.doesNotMatch(r.display, /999\.1\.1\.1/)
+  })
+
+  it('a valid IP literal still short-circuits without a DNS round-trip', async () => {
+    let called = false
+    const r = await resolveTrustAddress('http://10.0.0.1:9000/', { lookup: async () => { called = true; return [] } })
+    assert.equal(called, false)
+    assert.equal(r.classification, 'private')
+    assert.deepEqual(r.addresses, ['10.0.0.1'])
   })
 
   it('resolves a public DNS name as public', async () => {

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   CLAUDE_CONFIG_MAX_BYTES,
+  DEFAULT_TRUST_DNS_TIMEOUT_MS,
   classifyIpAddress,
   discoverConfiguredMcpServers,
   isBlockedMetadataHost,
@@ -359,8 +360,10 @@ describe('classifyIpAddress (#6834)', () => {
     assert.equal(classifyIpAddress('10.0.0.1'), 'private')
     assert.equal(classifyIpAddress('172.16.0.1'), 'private')
     assert.equal(classifyIpAddress('172.31.255.255'), 'private')
+    assert.equal(classifyIpAddress('172.15.255.255'), 'public') // just below /12
     assert.equal(classifyIpAddress('172.32.0.1'), 'public') // just outside /12
     assert.equal(classifyIpAddress('192.168.1.5'), 'private')
+    assert.equal(classifyIpAddress('192.167.255.255'), 'public') // just below 192.168/16
     assert.equal(classifyIpAddress('169.254.10.10'), 'link-local')
     assert.equal(classifyIpAddress('93.184.216.34'), 'public')
     assert.equal(classifyIpAddress('8.8.8.8'), 'public')
@@ -449,5 +452,38 @@ describe('resolveTrustAddress (#6834)', () => {
     const r = await resolveTrustAddress('not a url', { lookup: async () => [] })
     assert.equal(r.resolved, false)
     assert.equal(r.display, 'could not resolve host')
+  })
+
+  it('exports a sane default DNS timeout constant (#6852)', () => {
+    assert.equal(typeof DEFAULT_TRUST_DNS_TIMEOUT_MS, 'number')
+    assert.ok(DEFAULT_TRUST_DNS_TIMEOUT_MS > 0 && DEFAULT_TRUST_DNS_TIMEOUT_MS <= 5000)
+  })
+
+  it('times out a hanging lookup and returns the graceful fallback (#6852)', async () => {
+    // A resolver that stalls past the timeout must not hang the prompt (or the
+    // fleet's trust-store lock). The timeout arm wins the race → fallback. The
+    // lookup is gated on a promise we release AFTER asserting, so the stub
+    // settles deterministically (no dangling never-resolving promise).
+    let release
+    const gate = new Promise((resolve) => { release = resolve })
+    const stalledLookup = () => gate.then(() => [{ address: '203.0.113.7', family: 4 }])
+    const started = Date.now()
+    const r = await resolveTrustAddress('https://slow.example/mcp', { lookup: stalledLookup, timeoutMs: 40 })
+    const elapsed = Date.now() - started
+    assert.equal(r.resolved, false)
+    assert.equal(r.display, 'could not resolve host')
+    assert.equal(r.hostname, 'slow.example')
+    assert.ok(elapsed >= 40, `should wait for the timeout (elapsed ${elapsed}ms)`)
+    assert.ok(elapsed < 2000, `should not hang past the timeout (elapsed ${elapsed}ms)`)
+    // Let the abandoned lookup settle so the test leaves nothing pending.
+    release()
+    await gate
+  })
+
+  it('a lookup that resolves before the timeout still wins (#6852)', async () => {
+    const lookup = async () => [{ address: '10.0.0.9', family: 4 }]
+    const r = await resolveTrustAddress('https://fast.example/', { lookup, timeoutMs: 2000 })
+    assert.equal(r.resolved, true)
+    assert.equal(r.classification, 'private')
   })
 })

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -1155,4 +1155,86 @@ describe('PermissionManager', () => {
       custom.destroy()
     })
   })
+
+  // #6834 — the first-use trust prompt for a REMOTE server shows the resolved
+  // address so a user can see when a 'remote' URL points at an internal address.
+  describe('requestMcpTrust remote resolved-address display (#6834)', () => {
+    async function firstEvent(manager, server) {
+      const events = []
+      manager.on('permission_request', (e) => events.push(e))
+      const promise = manager.requestMcpTrust(server)
+      // requestMcpTrust awaits DNS before emitting for remote servers — let the
+      // emit land, then resolve the prompt so nothing dangles.
+      await new Promise((r) => setImmediate(r))
+      if (events[0]) manager.respondToPermission(events[0].requestId, 'deny')
+      await promise
+      return events[0]
+    }
+
+    it('shows the loopback marker for a URL that resolves to 127.0.0.1', async () => {
+      const pmLoop = createManager({ mcpTrustLookup: async () => [{ address: '127.0.0.1', family: 4 }] })
+      const e = await firstEvent(pmLoop, { name: 'lmstudio', url: 'http://lm.local:1234/mcp', headerKeys: [] })
+      assert.equal(e.tool, 'mcp_spawn')
+      assert.match(e.description, /Connect to MCP server "lmstudio"/)
+      assert.match(e.description, /resolves to 127\.0\.0\.1 \(loopback\)/)
+      assert.equal(e.input.mcpServer.resolvedAddress.classification, 'loopback')
+      assert.deepEqual(e.input.mcpServer.resolvedAddress.addresses, ['127.0.0.1'])
+      pmLoop.destroy()
+    })
+
+    it('shows the private-LAN marker for an RFC1918 literal host', async () => {
+      const pmLan = createManager({ mcpTrustLookup: async () => [] })
+      const e = await firstEvent(pmLan, { name: 'lan', url: 'http://192.168.1.9:3000/', headerKeys: [] })
+      assert.match(e.description, /resolves to 192\.168\.1\.9 \(private LAN\)/)
+      assert.equal(e.input.mcpServer.resolvedAddress.classification, 'private')
+      pmLan.destroy()
+    })
+
+    it('shows the public marker for a public host', async () => {
+      const pmPub = createManager({ mcpTrustLookup: async () => [{ address: '93.184.216.34', family: 4 }] })
+      const e = await firstEvent(pmPub, { name: 'remote', url: 'https://mcp.example.com/sse', headerKeys: [] })
+      assert.match(e.description, /resolves to 93\.184\.216\.34 \(public\)/)
+      assert.equal(e.input.mcpServer.resolvedAddress.classification, 'public')
+      pmPub.destroy()
+    })
+
+    it('shows a graceful fallback when DNS resolution fails', async () => {
+      const pmFail = createManager({ mcpTrustLookup: async () => { throw new Error('ENOTFOUND') } })
+      const e = await firstEvent(pmFail, { name: 'gone', url: 'https://nope.invalid/', headerKeys: [] })
+      assert.match(e.description, /could not resolve host/)
+      assert.equal(e.input.mcpServer.resolvedAddress.resolved, false)
+      pmFail.destroy()
+    })
+
+    it('redacts URL credentials in the displayed prompt (reuses #6833 redaction)', async () => {
+      const pmRedact = createManager({ mcpTrustLookup: async () => [{ address: '10.0.0.5', family: 4 }] })
+      const e = await firstEvent(pmRedact, {
+        name: 'creds',
+        url: 'https://user:sekret@internal.example/mcp?token=abc123',
+        headerKeys: ['Authorization'],
+      })
+      assert.doesNotMatch(e.description, /sekret/)
+      assert.doesNotMatch(e.description, /abc123/)
+      assert.doesNotMatch(e.input.mcpServer.url, /sekret|abc123/)
+      assert.match(e.description, /resolves to 10\.0\.0\.5 \(private LAN\)/)
+      pmRedact.destroy()
+    })
+
+    it('does not resolve or annotate a stdio (command) server', async () => {
+      let called = false
+      const pmStdio = createManager({ mcpTrustLookup: async () => { called = true; return [] } })
+      const events = []
+      pmStdio.on('permission_request', (e) => events.push(e))
+      // Stdio path has no url → no await → emits synchronously (pending-size
+      // assertions elsewhere depend on this).
+      const promise = pmStdio.requestMcpTrust({ name: 'fs', command: 'node', args: ['fs.js'] })
+      assert.equal(pmStdio._pendingPermissions.size, 1)
+      assert.equal(called, false)
+      assert.doesNotMatch(events[0].description, /resolves to|could not resolve/)
+      assert.equal(events[0].input.mcpServer.resolvedAddress, undefined)
+      pmStdio.respondToPermission(events[0].requestId, 'deny')
+      await promise
+      pmStdio.destroy()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

SSRF hardening for the BYOK MCP remote transport — the **remaining policy piece** after #6833 (transport + same-origin legacy-SSE + manual-redirect + cloud-metadata block) and #6848 (OAuth-endpoint guard).

Per the owner decision recorded on the issue (2026-07-18): **keep loopback / RFC1918 (localhost/LAN) MCP servers allowed** — LM Studio and local dev servers are legitimate, and a blanket private-range block would break real setups. Instead, the first-use **trust prompt now displays the resolved address** for the server URL, so a user approving a `remote` MCP server can see when it actually resolves to an internal / private / loopback address and make an informed consent decision. No config flag, no strict-block.

## What changed

- **`byok-mcp-config.js`**
  - `classifyIpAddress(ip)` — classifies a bare IP as `loopback` / `private` (RFC1918) / `link-local` / `public` / `unknown`, covering IPv4, IPv6 loopback (`::1`), ULA (`fc00::/7`), link-local (`fe80::/10`), and IPv4-mapped IPv6 (`::ffff:a.b.c.d`).
  - `resolveTrustAddress(url, { lookup })` — best-effort host resolution with an **injectable `lookup` seam** (defaults to the transport's `node:dns/promises` lookup). Literal IPs are classified without a DNS round-trip; DNS names resolve and summarise to the most-internal address. **Non-fatal**: an unparseable URL, a lookup throw, or an empty result returns `could not resolve host` — never a throw or block.
- **`permission-manager.js`**
  - `requestMcpTrust()` is now `async`; for a remote server it resolves the (already credential-redacted via #6833 `redactMcpUrl`) URL host **before** composing the prompt, appends the marker to the `description` string (e.g. `resolves to 127.0.0.1 (loopback)`), and mirrors it in a structured `input.mcpServer.resolvedAddress` field. The **stdio path is unchanged** and still emits synchronously.

The existing cloud-metadata hard-block (`169.254.0.0/16` + `fd00:ec2::254`, refused at config-parse **and** request time) is untouched — never allowed.

Both the dashboard (`PermissionPrompt`) and mobile (`PermissionDetail`) render the permission `description` string, so the resolved-address marker surfaces on **both clients with no client-side change**.

## Testing

- `byok-mcp-config.test.js` — `classifyIpAddress` (v4/v6/mapped/junk) + `resolveTrustAddress` (literal loopback/private, DNS→loopback/public, multi-address most-internal summary, lookup-throw / empty-result / unparseable-URL graceful fallback). Lookup seam is mocked — **no real DNS**.
- `permission-manager.test.js` — remote trust prompt shows the loopback / private-LAN / public marker, graceful fallback on DNS failure, credentials redacted in the displayed prompt, and the stdio path neither resolves nor annotates (and still emits synchronously).
- Directly-affected suites green under Node 22: `byok-mcp-config`, `permission-manager`, `byok-mcp-fleet`, `byok-mcp-remote-client`, `byok-mcp-trust`, `permission-broadcast-redaction`, `byok-mcp-client`.
- All 5 custom server lints pass. (Three unrelated MCP-adjacent suites fail locally only because this isolated worktree lacks `node_modules/@anthropic-ai/claude-agent-sdk`, which they transitively import via `sdk-session.js` — not touched by this change; green on CI.)

Closes #6834

Closes #6852
