### PR TITLE
fix(server): provider binary integrity + quarantine preflight (#6708)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,7 @@ For component tables, WS protocol messages, data flow diagrams, and file listing
 
 - [`docs/security/bearer-token-authority.md`](docs/security/bearer-token-authority.md) — token classes (primary / pairing-bound / hook secret), what each one grants, and the checklist for adding new endpoints. Read this before touching `ws-auth.js`, `ws-permissions.js`, `pairing.js`, or any new HTTP route that touches session state.
 - [`docs/security/encryption-threat-model.md`](docs/security/encryption-threat-model.md) — transport-layer (key exchange + message encryption) threat model.
+- [`docs/security/spawned-binary-provenance.md`](docs/security/spawned-binary-provenance.md) — provider-binary integrity + macOS quarantine preflight (`verify-binary.js`) and the supply-chain threat model. Read this before touching `utils/verify-binary.js`, `utils/preflight.js`, `utils/resolve-binary.js`, or any provider `resolvedBinary`/spawn path.
 
 ## Dev Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ For component tables, WS protocol messages, data flow diagrams, and file listing
 
 - [`docs/security/bearer-token-authority.md`](docs/security/bearer-token-authority.md) — token classes (primary / pairing-bound / hook secret), what each one grants, and the checklist for adding new endpoints. Read this before touching `ws-auth.js`, `ws-permissions.js`, `pairing.js`, or any new HTTP route that touches session state.
 - [`docs/security/encryption-threat-model.md`](docs/security/encryption-threat-model.md) — transport-layer (key exchange + message encryption) threat model.
+- [`docs/security/spawned-binary-provenance.md`](docs/security/spawned-binary-provenance.md) — provider-binary integrity + macOS quarantine preflight (`verify-binary.js`) and the supply-chain threat model. Read this before touching `utils/verify-binary.js`, `utils/preflight.js`, `utils/resolve-binary.js`, or any provider `resolvedBinary`/spawn path.
 
 ## Dev Commands
 

--- a/docs/security/spawned-binary-provenance.md
+++ b/docs/security/spawned-binary-provenance.md
@@ -1,0 +1,135 @@
+# Spawned-Binary Provenance & Integrity
+
+How Chroxy verifies the external binaries it executes as providers, what that
+verification does — and does **not** — protect against, and where the deeper
+hardening line sits. Implemented in `packages/server/src/utils/verify-binary.js`,
+wired into `utils/preflight.js`, the subprocess spawn path, and `chroxy doctor`
+(#6708).
+
+This is distinct from the [credentials-at-rest model](./credentials-at-rest.md)
+and the [transport-layer model](./encryption-threat-model.md). Those protect
+data. This document is about the **code Chroxy runs**: the daemon execs
+`claude`, `codex`, `gemini`, and `cloudflared` as child processes, and until
+#6708 it did so with no integrity, provenance, or quarantine check of any kind.
+
+## 1. The gap this closes
+
+Chroxy resolves a provider binary by PATH lookup (`which`/`where`) with a
+hardcoded candidate-path fallback (`utils/resolve-binary.js`), then spawns
+whatever resolves first. Two concrete failure modes motivated this work:
+
+- **Quarantined-but-present binary.** On macOS a Gatekeeper-quarantined binary
+  keeps its execute bit. The old preflight checked only `existsSync` +
+  `access(X_OK)`, so it green-lit the binary and the failure surfaced *later* as
+  an opaque mid-turn spawn error the operator couldn't diagnose, and
+  `chroxy doctor` mislabeled it "Not found — install …".
+- **Stale module-load path.** Each provider cached its resolved binary path in a
+  module-level `const` frozen at import. A binary quarantined, moved, or removed
+  *after* daemon start was still spawned from the stale path — and, because
+  preflight re-resolved independently, the existence gate and the actual spawn
+  could even resolve *different* paths.
+
+The triggering incident: macOS **XProtect Remediator** removed the OpenAI Codex
+native binary out from under a running daemon during a background scan. (That
+specific verdict is a probable XProtect false positive; the daemon-executes-
+unverified-binaries gap it exposed is real regardless.)
+
+## 2. What Chroxy checks now (P1 — detect & surface)
+
+`verifyBinary(resolvedPath)` classifies a resolved path into one of four states:
+
+| Status | Meaning | Where surfaced |
+| --- | --- | --- |
+| `ok` | absolute, exists, executable, not Gatekeeper-blocked | proceeds to spawn |
+| `not_found` | not absolute (bare-name resolver fallback) or missing on disk | `ProviderBinaryNotFoundError` / doctor `fail` |
+| `not_executable` | present but no `X` bit for this process | `ProviderBinaryNotFoundError` / doctor `fail` |
+| `quarantined` | macOS: present + executable but carries a **blocking** `com.apple.quarantine` xattr | `ProviderBinaryQuarantinedError` / doctor `fail` |
+
+- **Preflight gate (per session-create).** `runProviderPreflight` re-resolves the
+  binary fresh and prefers the provider's live `resolvedBinary` — the exact path
+  the spawn will use — so the existence gate and the spawn can no longer diverge.
+  A quarantined binary throws `ProviderBinaryQuarantinedError`
+  (`code: PROVIDER_BINARY_QUARANTINED`), which `createSession` propagates and the
+  WS layer surfaces as a `session_error` with that code (see
+  [error-taxonomy.md](../error-taxonomy.md)).
+- **Fresh re-resolution (no stale const).** The `resolvedBinary` accessors for
+  `codex`, `gemini`, `claude-cli`, and `claude-tui` re-resolve on every access
+  instead of returning a frozen import-time `const`, so a binary that changed
+  after boot is spawned from its current path.
+- **Spawn-time backstop.** If a spawn still fails after preflight passed (the
+  binary changed between create and turn), the subprocess catch re-verifies and
+  labels the error (quarantine vs vanished) instead of an opaque `ENOENT`.
+- **`chroxy doctor`.** The provider-binary and `cloudflared` health checks report
+  a quarantined binary distinctly from a missing one, with a copy-pasteable fix:
+  `xattr -d com.apple.quarantine <path>` (after verifying provenance) or
+  re-download.
+
+### The quarantine flag nuance (no false positives)
+
+The `com.apple.quarantine` xattr value is `flags;timestamp;agent;uuid`. Bit
+`0x0040` (`QTN_FLAG_ASSESSMENT_OK`) is set once Gatekeeper has assessed the file
+or the user approved it — such a binary launches normally. Chroxy treats a
+quarantine xattr as **blocking only when that bit is clear**, so an approved
+binary that still carries the xattr is not flagged. Package-manager installs
+(Homebrew, `npm -g`) strip the xattr entirely and are never flagged. An
+unparseable flags field is treated conservatively as blocking (a labeled,
+fixable error beats a silent exec failure).
+
+### Cross-platform behavior
+
+The xattr probe is macOS-only. On Linux and Windows `verifyBinary` performs
+exactly the existence + executable check it always did and skips the
+mac-specific step cleanly — there is no equivalent Gatekeeper block to detect.
+
+## 3. Threat model — what this does and does NOT protect against
+
+**Protects against (P1):**
+- A Gatekeeper-quarantined provider binary being spawned, then failing opaquely.
+- A since-moved/removed binary being spawned from a stale cached path.
+- An operator being unable to tell "quarantined/blocked" from "not installed".
+
+**Does NOT protect against (out of P1 scope):**
+- **Supply-chain compromise / PATH planting.** The daemon still executes whatever
+  binary resolves first on `PATH`. A malicious binary planted earlier in `PATH`,
+  or a compromised upstream provider release, is spawned automatically. Quarantine
+  detection is orthogonal to provenance — a planted binary carries no quarantine
+  xattr.
+- **Signature / notarization enforcement.** Chroxy deliberately does **not** gate
+  on `codesign --verify` / `spctl --assess`. The bundled provider binaries are
+  ad-hoc/linker-signed and `spctl` rejects them, so a hard spctl gate would break
+  every un-notarized provider. Verifying a signature would only prove the binary
+  is *signed*, not that it is the binary the operator intends to run.
+
+## 4. P2 — provenance verification (proposed, not yet implemented)
+
+The residual supply-chain surface grows materially once the orchestration epic
+(#6691) auto-spawns worker sessions headless with the operator's credentials —
+"the daemon runs whatever is on PATH" stops being a foreground, operator-visible
+action. Proposed P2 hardening, to land before write-capable orchestration workers
+ship:
+
+- **Opt-in signature gate.** An optional `codesign --verify` / `spctl` assessment
+  on macOS for operators who run only notarized provider builds.
+- **Cross-platform SHA-256 pin ledger.** Reuse the existing content-trust pattern
+  (`path-hash-trust-ledger.js`, already backing `skills-trust.js` and
+  `session-preset-trust.js`: a `path → { sha256, firstSeen, approvedAt }` map,
+  fail-open, atomic `0600` writes). Pin each provider binary's hash on first
+  sight; a changed hash re-gates the binary (warn/block) until an operator
+  re-approves — catching an unexpected in-place binary swap regardless of
+  signature or quarantine state. Fold `cloudflared` into the same ledger.
+
+## 5. Operator remediation quick reference
+
+When `chroxy doctor` or a session error reports a **quarantined** binary:
+
+1. Confirm the file is what you expect (reinstall from a clean source and compare
+   — e.g. `npm i -g @openai/codex@latest`, then `spctl --assess -vv $(which codex)`
+   / inspect `codesign`).
+2. Only after provenance is confirmed, clear the quarantine:
+   `xattr -d com.apple.quarantine <path>` (or allow it in
+   System Settings → Privacy & Security).
+3. If it was an XProtect false positive, consider reporting it to Apple (Feedback
+   Assistant) and the provider's maintainers.
+
+Reading the matched XProtect signature (requires `sudo`) confirms FP vs real:
+`sudo log show --last 24h --predicate 'process BEGINSWITH "XProtect"' | grep -i <binary>`.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -43,7 +43,7 @@ import {
 import {
   ANSI_STRIP,
   formatHexDump,
-  CLAUDE,
+  resolveClaudeBinary,
   AUTH_FAILURE_PATTERNS,
   AUTH_REQUIRED_CODE,
   AUTH_REQUIRED_MESSAGE,
@@ -175,6 +175,14 @@ export class ClaudeTuiSession extends BaseSession {
       // called per connection), so it reflects the daemon's env.
       multiSelectReinject: multiSelectReinjectEnabled(),
     }
+  }
+
+  /**
+   * The exact path node-pty will spawn, re-resolved fresh so preflight verifies
+   * the SAME path the spawn uses (no stale module-load const). (#6708)
+   */
+  static get resolvedBinary() {
+    return resolveClaudeBinary()
   }
 
   static get preflight() {
@@ -1933,7 +1941,7 @@ export class ClaudeTuiSession extends BaseSession {
       // through conpty/cmd.exe internally and runs a `.cmd` fine (verified),
       // unlike child_process.spawn which throws EINVAL on a `.cmd` (Node 24) and
       // needs the utils/win-spawn.js escaping the cli-session path uses.
-      this._term = ptyMod.spawn(CLAUDE, args, {
+      this._term = ptyMod.spawn(resolveClaudeBinary(), args, {
         name: 'xterm-256color',
         // #5839: single-sourced default so the dashboard mirror renders at the
         // same grid. #5835 Phase 2: a prior resize is preserved across respawns

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1936,13 +1936,16 @@ export class ClaudeTuiSession extends BaseSession {
     }
     log.info(`spawn claude TUI (uuid=${this._sessionId.slice(0, 8)} model=${this.model || 'default'} perms=${permissionsEnabled} skills=${skillsPrefix ? skillsPrefix.length + 'b' : 'none'})`)
 
+    // Captured so the spawn-time backstop (#6708) verifies the EXACT binary this
+    // attempt used, not a fresh re-resolve that could land on a different path.
+    const attemptedBinary = resolveClaudeBinary()
     try {
       // node-pty spawns CLAUDE directly — no cmd.exe routing needed even when
       // the Windows resolver lands on a `claude.cmd` shim. node-pty routes
       // through conpty/cmd.exe internally and runs a `.cmd` fine (verified),
       // unlike child_process.spawn which throws EINVAL on a `.cmd` (Node 24) and
       // needs the utils/win-spawn.js escaping the cli-session path uses.
-      this._term = ptyMod.spawn(resolveClaudeBinary(), args, {
+      this._term = ptyMod.spawn(attemptedBinary, args, {
         name: 'xterm-256color',
         // #5839: single-sourced default so the dashboard mirror renders at the
         // same grid. #5835 Phase 2: a prior resize is preserved across respawns
@@ -1958,7 +1961,7 @@ export class ClaudeTuiSession extends BaseSession {
       // running daemon (also the respawn path), name the cause + fix rather than
       // a bare error. Falls back to the raw message when the binary looks healthy.
       const labeled = labelBinarySpawnFailure({
-        resolvedBinary: resolveClaudeBinary,
+        attemptedPath: err?.path || attemptedBinary,
         binary: 'claude',
         prefix: 'Failed to spawn claude under PTY',
       })

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -22,6 +22,7 @@ import { discoverConfiguredMcpServers } from './byok-mcp-config.js'
 import { ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
+import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { createLogger, loggerForSession, redactSensitive, redactSensitivePreservingEscapes } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
@@ -1952,7 +1953,16 @@ export class ClaudeTuiSession extends BaseSession {
         env,
       })
     } catch (err) {
-      this.emit('error', { message: `Failed to spawn claude under PTY: ${err.message}` })
+      // #6708 — node-pty throws synchronously when the binary is missing/
+      // unspawnable. If it was quarantined/moved/removed out from under the
+      // running daemon (also the respawn path), name the cause + fix rather than
+      // a bare error. Falls back to the raw message when the binary looks healthy.
+      const labeled = labelBinarySpawnFailure({
+        resolvedBinary: resolveClaudeBinary,
+        binary: 'claude',
+        prefix: 'Failed to spawn claude under PTY',
+      })
+      this.emit('error', { message: labeled || `Failed to spawn claude under PTY: ${err.message}` })
       return
     }
 

--- a/packages/server/src/claude-tui/pty-driver.js
+++ b/packages/server/src/claude-tui/pty-driver.js
@@ -87,13 +87,26 @@ export function formatHexDump(input, maxBytes) {
   return `${header}\n${lines.join('\n')}`
 }
 
-export const CLAUDE = resolveBinary('claude', [
+// Well-known fallback locations for the `claude` binary. Under a GUI launch
+// (e.g. Tauri on macOS) PATH is minimal and may exclude the user's install dir.
+export const CLAUDE_BINARY_CANDIDATES = [
   join(homedir(), '.local/bin/claude'),
   '/opt/homebrew/bin/claude',
   '/usr/local/bin/claude',
   join(homedir(), '.claude/local/node_modules/.bin/claude'),
   join(homedir(), '.npm-global/bin/claude'),
-])
+]
+
+// Re-resolve fresh on each call (NOT a frozen module-load const) so a binary
+// quarantined / moved / reinstalled after daemon start is spawned from its
+// CURRENT path — and matches what preflight verified (#6708 defect #3).
+export function resolveClaudeBinary() {
+  return resolveBinary('claude', CLAUDE_BINARY_CANDIDATES)
+}
+
+// Back-compat: kept as a lazy-resolved snapshot for any consumer that still
+// imports the constant. Prefer `resolveClaudeBinary()` at spawn time.
+export const CLAUDE = resolveClaudeBinary()
 
 // #5321 (WP-4.1) — subscription-auth failure detection. claude-tui routes via
 // the OAuth subscription (ANTHROPIC_API_KEY is deleted from the spawn env), so a

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -535,7 +535,10 @@ export class CliSession extends BaseSession {
     // with no native `claude.exe`); spawning a `.cmd` via child_process throws
     // EINVAL on Node 24, so route it through cmd.exe with proper escaping. No-op
     // for a directly-runnable `.exe` and on POSIX. See utils/win-spawn.js.
-    const spawnSpec = prepareSpawn(resolveClaudeBinary(), args)
+    // Captured so the spawn-time backstop (#6708) verifies the EXACT binary this
+    // attempt used, not a fresh re-resolve that could land on a different path.
+    const attemptedBinary = resolveClaudeBinary()
+    const spawnSpec = prepareSpawn(attemptedBinary, args)
     const child = spawn(spawnSpec.command, spawnSpec.args, {
       cwd: this.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -595,9 +598,9 @@ export class CliSession extends BaseSession {
       this._child = null
       // #6708 — a spawn error (ENOENT/EACCES) can mean the binary was quarantined
       // /moved/removed out from under the running daemon (this is the respawn
-      // path too, so it fires mid-session). Re-verify and label the cause + fix
-      // instead of surfacing a bare ENOENT. Falls back to the raw message.
-      const labeled = labelBinarySpawnFailure({ resolvedBinary: resolveClaudeBinary, binary: 'claude' })
+      // path too, so it fires mid-session). Verify the ATTEMPTED path and label
+      // the cause + fix instead of surfacing a bare ENOENT. Falls back to raw.
+      const labeled = labelBinarySpawnFailure({ attemptedPath: err?.path || attemptedBinary, binary: 'claude' })
       this.emit('error', { message: labeled || `Failed to spawn claude: ${err.message}` })
       this._scheduleRespawn()
     })

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -24,16 +24,23 @@ import { BILLING_CLASSES, isProgrammaticCreditEra } from './billing-class.js'
 
 const log = createLogger('cli-session')
 
-// Resolve the claude binary once at module load. Under a GUI launch
-// (e.g. Tauri on macOS) PATH is minimal and may exclude the user's
-// install dir — fall through to known locations so `spawn()` succeeds.
-const CLAUDE = resolveBinary('claude', [
+// Well-known fallback locations. Under a GUI launch (e.g. Tauri on macOS) PATH
+// is minimal and may exclude the user's install dir — fall through to these so
+// `spawn()` succeeds.
+const CLAUDE_BINARY_CANDIDATES = [
   join(homedir(), '.local/bin/claude'),
   '/opt/homebrew/bin/claude',
   '/usr/local/bin/claude',
   join(homedir(), '.claude/local/node_modules/.bin/claude'),
   join(homedir(), '.npm-global/bin/claude'),
-])
+]
+
+// Re-resolve fresh on every spawn (NOT a frozen module-load const) so a binary
+// quarantined / moved / reinstalled after daemon start is spawned from its
+// CURRENT path — and matches what preflight verified (#6708 defect #3).
+function resolveClaudeBinary() {
+  return resolveBinary('claude', CLAUDE_BINARY_CANDIDATES)
+}
 
 // Default max accumulated size for tool_use input_json_delta chunks (~256KB)
 const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
@@ -258,6 +265,14 @@ export class CliSession extends BaseSession {
       // providers — claude-tui is the only one that sets this to false.
       streaming: true,
     }
+  }
+
+  /**
+   * The exact path the CLI subprocess will spawn, re-resolved fresh so
+   * preflight verifies the SAME path the spawn uses (no stale const). (#6708)
+   */
+  static get resolvedBinary() {
+    return resolveClaudeBinary()
   }
 
   /**
@@ -519,7 +534,7 @@ export class CliSession extends BaseSession {
     // with no native `claude.exe`); spawning a `.cmd` via child_process throws
     // EINVAL on Node 24, so route it through cmd.exe with proper escaping. No-op
     // for a directly-runnable `.exe` and on POSIX. See utils/win-spawn.js.
-    const spawnSpec = prepareSpawn(CLAUDE, args)
+    const spawnSpec = prepareSpawn(resolveClaudeBinary(), args)
     const child = spawn(spawnSpec.command, spawnSpec.args, {
       cwd: this.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -15,6 +15,7 @@ import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
 import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { prepareSpawn } from './utils/win-spawn.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
@@ -592,7 +593,12 @@ export class CliSession extends BaseSession {
       this._cleanupReadlines()
       this._processReady = false
       this._child = null
-      this.emit('error', { message: `Failed to spawn claude: ${err.message}` })
+      // #6708 — a spawn error (ENOENT/EACCES) can mean the binary was quarantined
+      // /moved/removed out from under the running daemon (this is the respawn
+      // path too, so it fires mid-session). Re-verify and label the cause + fix
+      // instead of surfacing a bare ENOENT. Falls back to the raw message.
+      const labeled = labelBinarySpawnFailure({ resolvedBinary: resolveClaudeBinary, binary: 'claude' })
+      this.emit('error', { message: labeled || `Failed to spawn claude: ${err.message}` })
       this._scheduleRespawn()
     })
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -130,8 +130,13 @@ export class CodexAppServerSession extends BaseSession {
 
   async start() {
     const sandbox = resolveCodexSandbox(this._codexSandbox)
+    // Capture the EXACT binary the client will spawn so the spawn-time backstop
+    // (#6708) verifies that path — in start()'s catch AND later in
+    // _onClientExit — rather than a fresh re-resolve.
+    const attemptedBinary = CodexAppServerSession.resolvedBinary
+    this._spawnedBinary = attemptedBinary
     this._client = new CodexAppServerClient({
-      bin: CodexAppServerSession.resolvedBinary,
+      bin: attemptedBinary,
       cwd: this.cwd,
       env: this._buildChildEnv(),
       logger: log,
@@ -157,7 +162,7 @@ export class CodexAppServerSession extends BaseSession {
       // "codex app-server exited". Only relabels when the binary is actually
       // unhealthy; otherwise the original protocol error rethrows unchanged.
       const labeled = labelBinarySpawnFailure({
-        resolvedBinary: () => CodexAppServerSession.resolvedBinary,
+        attemptedPath: err?.path || this._spawnedBinary,
         binary: 'codex',
         prefix: 'Failed to start codex app-server',
       })
@@ -888,7 +893,7 @@ export class CodexAppServerSession extends BaseSession {
     // from under the running daemon, name the cause + fix instead of a bare
     // "exited (spawn … ENOENT)". Only relabels when the binary is unhealthy.
     const labeled = labelBinarySpawnFailure({
-      resolvedBinary: () => CodexAppServerSession.resolvedBinary,
+      attemptedPath: error?.path || this._spawnedBinary,
       binary: 'codex',
       prefix: 'Codex app-server exited',
     })

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -8,6 +8,7 @@ import { CodexAppServerClient } from './codex-app-server-client.js'
 import { PermissionManager, wirePermissionManager } from './permission-manager.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
+import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { createLogger, loggerForSession } from './logger.js'
 
 // Image extensions codex can attach for VISION via a `localImage` input item.
@@ -139,13 +140,30 @@ export class CodexAppServerSession extends BaseSession {
     this._client.on('serverRequest', (r) => this._onServerRequest(r))
     this._client.on('exit', (e) => this._onClientExit(e))
 
-    await this._client.initialize({ name: 'chroxy', version: '1' })
-    const started = await this._client.request('thread/start', {
-      approvalPolicy: this._approvalPolicy(), // #6605 P2 — derived from permission mode
-      cwd: this.cwd,
-      sandbox,
-      ...(this.model ? { model: this.model } : {}),
-    })
+    let started
+    try {
+      await this._client.initialize({ name: 'chroxy', version: '1' })
+      started = await this._client.request('thread/start', {
+        approvalPolicy: this._approvalPolicy(), // #6605 P2 — derived from permission mode
+        cwd: this.cwd,
+        sandbox,
+        ...(this.model ? { model: this.model } : {}),
+      })
+    } catch (err) {
+      // #6708 — the app-server child is spawned inside initialize(); a missing/
+      // quarantined codex binary surfaces here as an initialize rejection (the
+      // child errors and _onError rejects the pending request). Re-verify so the
+      // session_create_failed names the quarantine + fix rather than an opaque
+      // "codex app-server exited". Only relabels when the binary is actually
+      // unhealthy; otherwise the original protocol error rethrows unchanged.
+      const labeled = labelBinarySpawnFailure({
+        resolvedBinary: () => CodexAppServerSession.resolvedBinary,
+        binary: 'codex',
+        prefix: 'Failed to start codex app-server',
+      })
+      if (labeled) throw new Error(labeled)
+      throw err
+    }
     this._threadId = started?.thread?.id || null
     // #6608 — do NOT set this.resumeSessionId in Phase 1: capabilities.resume is
     // false, and SessionManager persists resumeSessionId as the conversationId to
@@ -865,8 +883,18 @@ export class CodexAppServerSession extends BaseSession {
     const detail = error ? error.message : `code=${code}${signal ? ` signal=${signal}` : ''}`
     ;(this._log || log).warn(`codex app-server exited unexpectedly (${detail})`)
     this._processReady = false
-    if (this._activeTurn) this._failTurn(`Codex app-server exited (${detail})`)
-    else this.emit('error', { message: `Codex app-server exited (${detail})`, recoverable: true })
+    // #6708 — app-server has no respawn, so an unexpected exit IS the terminal
+    // signal. If the child died because its binary was quarantined/removed out
+    // from under the running daemon, name the cause + fix instead of a bare
+    // "exited (spawn … ENOENT)". Only relabels when the binary is unhealthy.
+    const labeled = labelBinarySpawnFailure({
+      resolvedBinary: () => CodexAppServerSession.resolvedBinary,
+      binary: 'codex',
+      prefix: 'Codex app-server exited',
+    })
+    const message = labeled || `Codex app-server exited (${detail})`
+    if (this._activeTurn) this._failTurn(message)
+    else this.emit('error', { message, recoverable: true })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -60,7 +60,10 @@ const BINARY_CANDIDATES = [
   join(homedir(), '.npm-global/bin/codex'),
 ]
 
-const CODEX = resolveBinary('codex', BINARY_CANDIDATES)
+// NOTE: the codex binary is intentionally NOT cached in a module-load const.
+// A frozen path is spawned even after XProtect/Gatekeeper quarantines or moves
+// the binary out from under a long-running daemon (#6708 defect #3). The
+// `resolvedBinary` getter re-resolves fresh per access instead.
 
 /**
  * Codex CLI sandbox modes. Source: `codex exec --sandbox <MODE>` accepts
@@ -314,7 +317,10 @@ export class CodexSession extends JsonlSubprocessSession {
   }
 
   static get resolvedBinary() {
-    return CODEX
+    // Re-resolve fresh on every access (NOT a frozen module-load const) so a
+    // binary quarantined / moved / reinstalled after daemon start is spawned
+    // from its CURRENT path — and matches what preflight verified (#6708).
+    return resolveBinary('codex', BINARY_CANDIDATES)
   }
 
   static get apiKeyEnv() {

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -6,6 +6,7 @@ import { homedir } from 'os'
 import { createServer } from 'net'
 import { validateConfig } from './config.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { verifyBinary as defaultVerifyBinary, BINARY_STATUS, describeBinaryHealth } from './utils/verify-binary.js'
 import { prepareSpawn } from './utils/win-spawn.js'
 import { cloudflaredInstallHint } from './platform.js'
 import { getProvider, DEFAULT_PROVIDER } from './providers.js'
@@ -599,8 +600,18 @@ function checkProvider(providerName) {
  *
  * Exported for tests — callers in production should use `runDoctorChecks`.
  */
-export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [], minVersion = null }) {
+export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [], minVersion = null, verify = defaultVerifyBinary }) {
   const resolved = resolveBinary(name, candidates)
+  // #6708 — integrity/quarantine gate BEFORE we try to exec for a version.
+  // A macOS Gatekeeper-quarantined binary keeps its X bit and only fails at
+  // exec, where the catch below would mislabel it "Not found — install …".
+  // Detect it up front so doctor distinguishes "quarantined/blocked" from
+  // "not installed" with a fix-it hint (`xattr -d …`). No-op off darwin.
+  const health = verify(resolved)
+  if (health.status === BINARY_STATUS.QUARANTINED) {
+    const { message } = describeBinaryHealth(health, { binary: name, installHint })
+    return { name, status: required ? 'fail' : 'warn', message }
+  }
   try {
     // #6484 — a resolved `.cmd` shim (npm-only Windows host) can't be spawned
     // directly on Node 24; route it through cmd.exe via prepareSpawn. No-op for

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -602,13 +602,16 @@ function checkProvider(providerName) {
  */
 export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [], minVersion = null, verify = defaultVerifyBinary }) {
   const resolved = resolveBinary(name, candidates)
-  // #6708 — integrity/quarantine gate BEFORE we try to exec for a version.
-  // A macOS Gatekeeper-quarantined binary keeps its X bit and only fails at
-  // exec, where the catch below would mislabel it "Not found — install …".
-  // Detect it up front so doctor distinguishes "quarantined/blocked" from
-  // "not installed" with a fix-it hint (`xattr -d …`). No-op off darwin.
+  // #6708 — integrity gate BEFORE we try to exec for a version. A macOS
+  // Gatekeeper-quarantined binary keeps its X bit, and a present-but-non-
+  // executable binary throws EACCES in the version probe — in both cases the
+  // catch below would mislabel it "Not found — install …". Detect them up front
+  // so doctor reports "quarantined/blocked" and "not executable" distinctly from
+  // "not installed", each with its own fix-it hint. The quarantine step is a
+  // no-op off darwin; NOT_FOUND still falls through to the version probe (whose
+  // catch owns the install message).
   const health = verify(resolved)
-  if (health.status === BINARY_STATUS.QUARANTINED) {
+  if (health.status === BINARY_STATUS.QUARANTINED || health.status === BINARY_STATUS.NOT_EXECUTABLE) {
     const { message } = describeBinaryHealth(health, { binary: name, installHint })
     return { name, status: required ? 'fail' : 'warn', message }
   }

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -49,7 +49,10 @@ const BINARY_CANDIDATES = [
   join(homedir(), '.npm-global/bin/gemini'),
 ]
 
-const GEMINI = resolveBinary('gemini', BINARY_CANDIDATES)
+// NOTE: the gemini binary is intentionally NOT cached in a module-load const.
+// A frozen path is spawned even after the binary is quarantined/moved out from
+// under a long-running daemon (#6708 defect #3); the `resolvedBinary` getter
+// re-resolves fresh per access instead.
 
 // Per-provider model metadata — #2956.
 // Context windows come from the Gemini model docs. Kept explicit here so the
@@ -122,7 +125,10 @@ export class GeminiSession extends JsonlSubprocessSession {
   }
 
   static get resolvedBinary() {
-    return GEMINI
+    // Re-resolve fresh on every access (NOT a frozen module-load const) so a
+    // binary quarantined / moved / reinstalled after daemon start is spawned
+    // from its CURRENT path — and matches what preflight verified (#6708).
+    return resolveBinary('gemini', BINARY_CANDIDATES)
   }
 
   static get apiKeyEnv() {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -5,6 +5,7 @@ import { createLogger } from './logger.js'
 import { guardChildStreams } from './child-stream-guard.js'
 import { getErrorMessage } from './utils/error-message.js'
 import { prepareSpawn } from './utils/win-spawn.js'
+import { verifyBinary, describeBinaryHealth, BINARY_STATUS } from './utils/verify-binary.js'
 import { killProcessTree } from './platform.js'
 
 const log = createLogger('jsonl-subprocess-session')
@@ -317,9 +318,19 @@ export class JsonlSubprocessSession extends BaseSession {
       // etc.) — leave _skillsPrepended false so a retry still injects the
       // skills text. Reset busy state and surface the error to the caller.
       this._isBusy = false
-      this.emit('error', {
-        message: getErrorMessage(err, `Failed to spawn ${Klass.providerName}`),
-      })
+      // #6708 — a spawn failure AFTER preflight passed means the binary changed
+      // out from under us (quarantined / moved / removed by XProtect between
+      // session-create and this turn). Re-verify the path so the error names
+      // the real cause + fix instead of an opaque ENOENT.
+      let message = getErrorMessage(err, `Failed to spawn ${Klass.providerName}`)
+      try {
+        const health = verifyBinary(Klass.resolvedBinary)
+        if (health.status === BINARY_STATUS.QUARANTINED || health.status === BINARY_STATUS.NOT_FOUND) {
+          const desc = describeBinaryHealth(health, { binary: Klass.providerName })
+          message = `Failed to spawn ${Klass.providerName}: ${desc.message}`
+        }
+      } catch { /* resolvedBinary getter may throw on a misconfigured subclass */ }
+      this.emit('error', { message })
       return
     }
 

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -298,12 +298,18 @@ export class JsonlSubprocessSession extends BaseSession {
 
     const args = this._buildArgs(effectiveText)
     let proc
+    // Captured once here so the spawn-time backstop (#6708) verifies the EXACT
+    // binary this attempt used — both the sync catch below and the async
+    // proc.on('error') handler — rather than a fresh re-resolve that could land
+    // on a different path than the one that failed.
+    let attemptedBinary = null
     try {
       // #6484 — the resolver can hand us a `.cmd` shim on Windows (npm-only host,
       // no native `.exe`); spawning a `.cmd` via child_process throws EINVAL on
       // Node 24, so route it through cmd.exe with proper escaping — the same
       // prepareSpawn cli-session.js uses. No-op for a `.exe` and on POSIX.
-      const spawnSpec = prepareSpawn(Klass.resolvedBinary, args)
+      attemptedBinary = Klass.resolvedBinary
+      const spawnSpec = prepareSpawn(attemptedBinary, args)
       proc = spawn(spawnSpec.command, spawnSpec.args, {
         cwd: this.cwd,
         // We pass the prompt as argv, not stdin. Some CLIs, notably
@@ -314,16 +320,16 @@ export class JsonlSubprocessSession extends BaseSession {
         ...spawnSpec.options,
       })
     } catch (err) {
-      // spawn() can throw synchronously (ENOENT for missing binary, EACCES,
+      // spawn() can throw synchronously (EINVAL for a bad `.cmd` on Node 24,
       // etc.) — leave _skillsPrepended false so a retry still injects the
       // skills text. Reset busy state and surface the error to the caller.
       this._isBusy = false
       // #6708 — a spawn failure AFTER preflight passed means the binary changed
       // out from under us (quarantined / moved / removed by XProtect between
-      // session-create and this turn). Re-verify the path so the error names
-      // the real cause + fix instead of an opaque ENOENT.
+      // session-create and this turn). Re-verify the ATTEMPTED path so the error
+      // names the real cause + fix instead of an opaque failure.
       const labeled = labelBinarySpawnFailure({
-        resolvedBinary: () => Klass.resolvedBinary,
+        attemptedPath: err?.path || attemptedBinary,
         binary: Klass.providerName,
       })
       this.emit('error', {
@@ -445,8 +451,15 @@ export class JsonlSubprocessSession extends BaseSession {
         this._skillsPrepended = false
       }
       if (this._destroying) return
+      // #6708 — a launch failure here (async ENOENT/EACCES is the REAL missing-
+      // /quarantined-binary path; the sync catch above only sees Node-24 `.cmd`
+      // EINVAL) → label the ATTEMPTED path's cause + fix instead of a bare ENOENT.
+      const labeled = labelBinarySpawnFailure({
+        attemptedPath: err?.path || attemptedBinary,
+        binary: Klass.providerName,
+      })
       this.emit('error', {
-        message: err.message || `Failed to spawn ${Klass.providerName}`,
+        message: labeled || err.message || `Failed to spawn ${Klass.providerName}`,
       })
     })
   }

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -308,8 +308,12 @@ export class JsonlSubprocessSession extends BaseSession {
       // no native `.exe`); spawning a `.cmd` via child_process throws EINVAL on
       // Node 24, so route it through cmd.exe with proper escaping — the same
       // prepareSpawn cli-session.js uses. No-op for a `.exe` and on POSIX.
+      // The prepareSpawn(Klass.resolvedBinary, args) call is kept verbatim (the
+      // #6484 source guard scans for it); attemptedBinary captures the same
+      // binary for the #6708 spawn-time backstop (err.path is preferred at the
+      // catch sites, this is only the fallback).
       attemptedBinary = Klass.resolvedBinary
-      const spawnSpec = prepareSpawn(attemptedBinary, args)
+      const spawnSpec = prepareSpawn(Klass.resolvedBinary, args)
       proc = spawn(spawnSpec.command, spawnSpec.args, {
         cwd: this.cwd,
         // We pass the prompt as argv, not stdin. Some CLIs, notably

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -5,7 +5,7 @@ import { createLogger } from './logger.js'
 import { guardChildStreams } from './child-stream-guard.js'
 import { getErrorMessage } from './utils/error-message.js'
 import { prepareSpawn } from './utils/win-spawn.js'
-import { verifyBinary, describeBinaryHealth, BINARY_STATUS } from './utils/verify-binary.js'
+import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { killProcessTree } from './platform.js'
 
 const log = createLogger('jsonl-subprocess-session')
@@ -322,15 +322,13 @@ export class JsonlSubprocessSession extends BaseSession {
       // out from under us (quarantined / moved / removed by XProtect between
       // session-create and this turn). Re-verify the path so the error names
       // the real cause + fix instead of an opaque ENOENT.
-      let message = getErrorMessage(err, `Failed to spawn ${Klass.providerName}`)
-      try {
-        const health = verifyBinary(Klass.resolvedBinary)
-        if (health.status === BINARY_STATUS.QUARANTINED || health.status === BINARY_STATUS.NOT_FOUND) {
-          const desc = describeBinaryHealth(health, { binary: Klass.providerName })
-          message = `Failed to spawn ${Klass.providerName}: ${desc.message}`
-        }
-      } catch { /* resolvedBinary getter may throw on a misconfigured subclass */ }
-      this.emit('error', { message })
+      const labeled = labelBinarySpawnFailure({
+        resolvedBinary: () => Klass.resolvedBinary,
+        binary: Klass.providerName,
+      })
+      this.emit('error', {
+        message: labeled || getErrorMessage(err, `Failed to spawn ${Klass.providerName}`),
+      })
       return
     }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -8,7 +8,7 @@ import { getProvider, getProviderAuthInfo, DEFAULT_PROVIDER } from './providers.
 import { isClaudeProvider } from './models.js'
 import { billingClassForProvider, BILLING_CLASSES } from './billing-class.js'
 import { MonthlyProgrammaticBudgetManager } from './billing-budget.js'
-import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderCredentialMissingError } from './utils/preflight.js'
+import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderCredentialMissingError } from './utils/preflight.js'
 import { GIT } from './git.js'
 import { sweepOrphanChroxyWorktrees } from './worktree-gc.js'
 import { resolveJsonlPath, readConversationHistoryAsync } from './jsonl-reader.js'
@@ -168,9 +168,10 @@ const DEFAULT_WORKTREE_BASE = join(homedir(), '.chroxy', 'worktrees')
 export { formatIdleDuration }
 
 // Re-export preflight errors so call sites that catch createSession() failures
-// can detect/branch on PROVIDER_BINARY_NOT_FOUND / PROVIDER_CREDENTIAL_MISSING
-// without taking a separate dependency on utils/preflight.js.
-export { ProviderBinaryNotFoundError, ProviderCredentialMissingError }
+// can detect/branch on PROVIDER_BINARY_NOT_FOUND / PROVIDER_BINARY_QUARANTINED /
+// PROVIDER_CREDENTIAL_MISSING without taking a separate dependency on
+// utils/preflight.js.
+export { ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderCredentialMissingError }
 
 /**
  * @typedef {Object} SessionManagerConfig

--- a/packages/server/src/utils/preflight.js
+++ b/packages/server/src/utils/preflight.js
@@ -29,9 +29,8 @@
  * cannot meaningfully check it.
  */
 
-import { existsSync, accessSync, constants } from 'fs'
-import { isAbsolute } from 'path'
 import { resolveBinary } from './resolve-binary.js'
+import { verifyBinary as defaultVerifyBinary, BINARY_STATUS, describeBinaryHealth } from './verify-binary.js'
 
 /**
  * Thrown when a provider's required binary cannot be located or executed.
@@ -53,6 +52,28 @@ export class ProviderBinaryNotFoundError extends Error {
 }
 
 /**
+ * Thrown when a provider's binary is present but blocked by macOS Gatekeeper
+ * (a `com.apple.quarantine` xattr whose assessment-OK bit is clear). Distinct
+ * from ProviderBinaryNotFoundError so the client / doctor can render a
+ * quarantine-specific remediation (`xattr -d …`) rather than "install …". (#6708)
+ */
+export class ProviderBinaryQuarantinedError extends Error {
+  constructor({ provider, binary, path, quarantine, installHint }) {
+    const { message } = describeBinaryHealth(
+      { status: BINARY_STATUS.QUARANTINED, path },
+      { binary, installHint },
+    )
+    super(`${provider}: ${message}`)
+    this.name = 'ProviderBinaryQuarantinedError'
+    this.code = 'PROVIDER_BINARY_QUARANTINED'
+    this.provider = provider
+    this.binary = binary
+    this.path = path
+    this.quarantine = quarantine || null
+  }
+}
+
+/**
  * Thrown when none of a provider's required credential env vars are present.
  */
 export class ProviderCredentialMissingError extends Error {
@@ -69,37 +90,27 @@ export class ProviderCredentialMissingError extends Error {
 }
 
 /**
- * Verify a binary path exists and is executable by the current process.
- * Returns true if the resolved path is absolute, exists, and the X bit is set.
- *
- * @param {string} resolvedPath
- * @returns {boolean}
- */
-function isExecutableFile(resolvedPath) {
-  if (!isAbsolute(resolvedPath)) return false
-  if (!existsSync(resolvedPath)) return false
-  try {
-    accessSync(resolvedPath, constants.X_OK)
-    return true
-  } catch {
-    return false
-  }
-}
-
-/**
  * Run binary + credential preflight for a provider class.
  *
- * Throws ProviderBinaryNotFoundError or ProviderCredentialMissingError if
- * the spec's requirements aren't met. No-op when:
+ * Throws ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, or
+ * ProviderCredentialMissingError if the spec's requirements aren't met. No-op
+ * when:
  *   - The provider doesn't declare a `static get preflight()`
  *   - The provider is containerised (binary lives inside the container)
+ *
+ * The binary is re-resolved fresh here (per session-create), not read off a
+ * frozen module-load path, so a binary quarantined/moved AFTER daemon start is
+ * caught before spawn. When the provider exposes its real spawn path via
+ * `static get resolvedBinary`, we verify THAT exact path so preflight and the
+ * eventual spawn can't diverge (#6708 defect #3).
  *
  * @param {Function} ProviderClass - Session class with optional `preflight` getter
  * @param {object}   [options]
  * @param {NodeJS.ProcessEnv} [options.env=process.env] - Env source (for tests)
- * @throws {ProviderBinaryNotFoundError|ProviderCredentialMissingError}
+ * @param {Function} [options.verifyBinary] - integrity checker (injected in tests)
+ * @throws {ProviderBinaryNotFoundError|ProviderBinaryQuarantinedError|ProviderCredentialMissingError}
  */
-export function runProviderPreflight(ProviderClass, { env = process.env } = {}) {
+export function runProviderPreflight(ProviderClass, { env = process.env, verifyBinary = defaultVerifyBinary } = {}) {
   if (!ProviderClass) return
 
   // Containerised providers run their binary inside the container, so a host
@@ -114,10 +125,30 @@ export function runProviderPreflight(ProviderClass, { env = process.env } = {}) 
 
   if (spec.binary && spec.binary.name) {
     const candidates = spec.binary.candidates || []
-    const resolved = resolveBinary(spec.binary.name, candidates)
-    // resolveBinary returns the bare name when nothing on PATH or in
-    // candidates matched — that's the failure signal.
-    if (!isExecutableFile(resolved)) {
+    // Prefer the provider's live spawn path when it exposes one — that is the
+    // exact path child_process.spawn will exec — so the existence gate and the
+    // real spawn always agree. Fall back to a fresh PATH/candidate resolve.
+    let resolved
+    try {
+      resolved = ProviderClass.resolvedBinary
+    } catch { /* subclass throws if unset — fall through */ }
+    if (typeof resolved !== 'string' || resolved.length === 0) {
+      resolved = resolveBinary(spec.binary.name, candidates)
+    }
+    const health = verifyBinary(resolved)
+    if (health.status === BINARY_STATUS.QUARANTINED) {
+      throw new ProviderBinaryQuarantinedError({
+        provider: providerLabel,
+        binary: spec.binary.name,
+        path: health.path,
+        quarantine: health.quarantine,
+        installHint: spec.binary.installHint,
+      })
+    }
+    // NOT_FOUND / NOT_EXECUTABLE both mean "can't spawn it" — resolveBinary
+    // returns the bare name when nothing matched, which verifyBinary reports as
+    // NOT_FOUND.
+    if (!health.ok) {
       throw new ProviderBinaryNotFoundError({
         provider: providerLabel,
         binary: spec.binary.name,

--- a/packages/server/src/utils/verify-binary.js
+++ b/packages/server/src/utils/verify-binary.js
@@ -197,3 +197,46 @@ export function describeBinaryHealth(health, { binary, installHint } = {}) {
     }
   }
 }
+
+/**
+ * Spawn-time backstop: given a spawn failure, produce a labeled message naming a
+ * quarantine / not-found root cause + fix when the provider binary changed out
+ * from under a running daemon — the between-preflight-and-spawn / mid-session-
+ * respawn window that motivated #6708 (XProtect removed the binary while the
+ * daemon was live). Returns `null` when the binary still looks healthy, so the
+ * caller keeps its own error text (the failure was something else).
+ *
+ * Shared by every provider spawn site so the labeling lives in one place:
+ * jsonl-subprocess (codex-exec + gemini), cli-session (claude), claude-tui, and
+ * codex-app-server.
+ *
+ * `resolvedBinary` accepts a string OR a getter function — the provider
+ * `resolvedBinary` static re-resolves fresh and can throw on a misconfigured
+ * subclass, both of which are handled (a throw yields `null`, no crash).
+ *
+ * @param {object} opts
+ * @param {string|(()=>string)} opts.resolvedBinary - spawn path, or a getter for it
+ * @param {string} opts.binary   - provider/binary name for labeling (e.g. 'codex')
+ * @param {string} [opts.prefix] - message prefix (default `Failed to spawn <binary>`)
+ * @param {Function} [opts.verify=verifyBinary] - integrity checker (injected in tests)
+ * @returns {string|null} labeled message, or null when the binary looks healthy
+ */
+export function labelBinarySpawnFailure({ resolvedBinary, binary, prefix, verify = verifyBinary } = {}) {
+  let resolved
+  try {
+    resolved = typeof resolvedBinary === 'function' ? resolvedBinary() : resolvedBinary
+  } catch {
+    return null // resolvedBinary getter threw (misconfigured subclass) — no label
+  }
+  let health
+  try {
+    health = verify(resolved)
+  } catch {
+    return null
+  }
+  if (health && (health.status === BINARY_STATUS.QUARANTINED || health.status === BINARY_STATUS.NOT_FOUND)) {
+    const desc = describeBinaryHealth(health, { binary })
+    return `${prefix || `Failed to spawn ${binary}`}: ${desc.message}`
+  }
+  return null
+}

--- a/packages/server/src/utils/verify-binary.js
+++ b/packages/server/src/utils/verify-binary.js
@@ -1,0 +1,199 @@
+/**
+ * Pre-spawn binary integrity + quarantine verification (#6708).
+ *
+ * Chroxy execs external provider binaries (`claude`, `codex`, `gemini`,
+ * `cloudflared`) resolved off PATH. Before this module the only gate was
+ * "exists + X-bit" (see the old `isExecutableFile` in preflight.js), which
+ * green-lights a binary that macOS Gatekeeper will refuse to launch: a
+ * quarantined binary keeps its execute bit and only fails at `exec()`, so the
+ * failure surfaced later as a confusing mid-turn error instead of a clean,
+ * actionable preflight rejection.
+ *
+ * `verifyBinary()` classifies a resolved path into one of {@link BINARY_STATUS}
+ * and (on macOS) detects a **blocking `com.apple.quarantine` xattr** so the
+ * caller can distinguish "quarantined/blocked by Gatekeeper" from "not
+ * installed". The mac-specific probe is cleanly skipped on Linux/Windows —
+ * there the check is exactly the existence + executable check it always was.
+ *
+ * ## Why the assessment-OK flag matters (no false positives)
+ *
+ * The `com.apple.quarantine` xattr value is `flags;timestamp;agent;uuid`. The
+ * low bits of the first (hex) field encode quarantine state; bit `0x0040`
+ * (`QTN_FLAG_ASSESSMENT_OK`) is set once Gatekeeper has assessed the file OK or
+ * the user has approved it — such a binary launches normally and MUST NOT be
+ * flagged. We therefore treat a quarantine xattr as *blocking* only when that
+ * bit is CLEAR. An unparseable flags field is treated conservatively as
+ * blocking (surfaced as a labeled, fixable error rather than a silent exec
+ * failure). Homebrew / package-manager installs strip the xattr entirely and
+ * so are never flagged.
+ *
+ * Signature / notarization gating (`codesign`/`spctl`) is deliberately NOT done
+ * here: chroxy's bundled provider binaries are ad-hoc/linker-signed and
+ * `spctl --assess` rejects them, so a hard spctl gate would break every
+ * un-notarized provider. That is P2 (opt-in) territory — see
+ * docs/security/spawned-binary-provenance.md.
+ *
+ * Every filesystem / subprocess touchpoint is an injectable seam so the whole
+ * module is unit-testable over a mocked fs/xattr layer with no real quarantined
+ * binary required.
+ */
+
+import { existsSync as fsExistsSync, accessSync as fsAccessSync, constants as fsConstants } from 'fs'
+import { isAbsolute as pathIsAbsolute } from 'path'
+import { execFileSync } from 'child_process'
+
+/**
+ * Classification of a resolved binary path.
+ * @enum {string}
+ */
+export const BINARY_STATUS = Object.freeze({
+  /** Absolute path, exists, executable, and not blocked by Gatekeeper. */
+  OK: 'ok',
+  /** Path is not absolute, or does not exist on disk. */
+  NOT_FOUND: 'not_found',
+  /** Exists but the current process cannot execute it (no X bit / EACCES). */
+  NOT_EXECUTABLE: 'not_executable',
+  /** macOS: present + executable but carries a blocking com.apple.quarantine xattr. */
+  QUARANTINED: 'quarantined',
+})
+
+// macOS quarantine flag: Gatekeeper assessment passed / user approved. When set,
+// the binary launches normally, so a quarantine xattr with this bit is NOT a block.
+const QTN_FLAG_ASSESSMENT_OK = 0x0040
+
+/**
+ * Default macOS reader for the `com.apple.quarantine` xattr. Returns the raw
+ * attribute value, or `null` when the attribute is absent (the common case —
+ * `xattr -p` exits non-zero, which we swallow). Only ever called on darwin.
+ *
+ * @param {string} path
+ * @returns {string|null}
+ */
+function defaultReadQuarantineXattr(path) {
+  try {
+    const out = execFileSync('xattr', ['-p', 'com.apple.quarantine', path], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    })
+    const trimmed = out.trim()
+    return trimmed.length > 0 ? trimmed : null
+  } catch {
+    // No such xattr (exit 1) or xattr unavailable — treat as "not quarantined".
+    return null
+  }
+}
+
+/**
+ * Decide whether a `com.apple.quarantine` xattr value blocks launch. Blocks
+ * unless the ASSESSMENT_OK bit is set. An unparseable flags field is treated
+ * as blocking (conservative — better a fixable labeled error than a silent
+ * exec failure).
+ *
+ * @param {string|null|undefined} xattrValue
+ * @returns {boolean}
+ */
+export function isBlockingQuarantine(xattrValue) {
+  if (typeof xattrValue !== 'string' || xattrValue.length === 0) return false
+  const firstField = xattrValue.split(';')[0].trim()
+  const flags = parseInt(firstField, 16)
+  if (Number.isNaN(flags)) return true
+  return (flags & QTN_FLAG_ASSESSMENT_OK) === 0
+}
+
+/**
+ * @typedef {Object} BinaryHealth
+ * @property {boolean}     ok         True only when status === 'ok'.
+ * @property {string}      status     One of {@link BINARY_STATUS}.
+ * @property {string}      path       The resolved path that was checked.
+ * @property {string|null} quarantine Raw quarantine xattr value when blocking, else null.
+ */
+
+/**
+ * Verify a resolved binary path is safe to spawn: absolute, present,
+ * executable, and (macOS) not blocked by a quarantine xattr.
+ *
+ * Pure/deterministic given its injected seams — pass mocks in tests; production
+ * calls pass nothing and use the real fs + `xattr`.
+ *
+ * @param {string} resolvedPath - absolute path from resolveBinary()
+ * @param {object} [opts]
+ * @param {string} [opts.platform=process.platform]
+ * @param {(p:string)=>boolean}     [opts.existsSync]
+ * @param {(p:string,mode:number)=>void} [opts.accessSync] - throws when not accessible
+ * @param {(p:string)=>boolean}     [opts.isAbsolute]
+ * @param {(p:string)=>(string|null)} [opts.readQuarantineXattr] - macOS xattr reader
+ * @returns {BinaryHealth}
+ */
+export function verifyBinary(resolvedPath, {
+  platform = process.platform,
+  existsSync = fsExistsSync,
+  accessSync = fsAccessSync,
+  isAbsolute = pathIsAbsolute,
+  readQuarantineXattr = defaultReadQuarantineXattr,
+} = {}) {
+  const path = typeof resolvedPath === 'string' ? resolvedPath : ''
+
+  // resolveBinary returns the bare name when nothing matched — a non-absolute
+  // path is the "not found on PATH or in candidates" signal.
+  if (!path || !isAbsolute(path) || !existsSync(path)) {
+    return { ok: false, status: BINARY_STATUS.NOT_FOUND, path, quarantine: null }
+  }
+
+  try {
+    accessSync(path, fsConstants.X_OK)
+  } catch {
+    return { ok: false, status: BINARY_STATUS.NOT_EXECUTABLE, path, quarantine: null }
+  }
+
+  // macOS-only: a Gatekeeper-quarantined binary keeps its X bit but refuses to
+  // launch. Skip entirely off darwin — there is no equivalent block.
+  if (platform === 'darwin') {
+    const xattrValue = readQuarantineXattr(path)
+    if (isBlockingQuarantine(xattrValue)) {
+      return { ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: xattrValue }
+    }
+  }
+
+  return { ok: true, status: BINARY_STATUS.OK, path, quarantine: null }
+}
+
+/**
+ * Build a user-facing message + remediation for a non-OK {@link BinaryHealth}.
+ * Centralised so preflight errors, the spawn-time catch, and `chroxy doctor`
+ * all speak the same language about what is wrong and how to fix it.
+ *
+ * @param {BinaryHealth} health
+ * @param {object} [ctx]
+ * @param {string} [ctx.binary]     - binary name (e.g. 'codex')
+ * @param {string} [ctx.installHint] - how to (re)install, e.g. 'install Codex CLI'
+ * @returns {{ message: string, remediation: string }}
+ */
+export function describeBinaryHealth(health, { binary, installHint } = {}) {
+  const name = binary || 'binary'
+  const path = health && health.path ? health.path : ''
+  switch (health && health.status) {
+    case BINARY_STATUS.QUARANTINED: {
+      const remediation = `verify its provenance, then run: xattr -d com.apple.quarantine ${path} (or approve it in System Settings → Privacy & Security), or re-download ${name}`
+      return {
+        message: `"${name}" at ${path} is quarantined/blocked by macOS Gatekeeper — ${remediation}`,
+        remediation,
+      }
+    }
+    case BINARY_STATUS.NOT_EXECUTABLE: {
+      const remediation = `run: chmod +x ${path}`
+      return {
+        message: `"${name}" at ${path} exists but is not executable — ${remediation}`,
+        remediation,
+      }
+    }
+    case BINARY_STATUS.NOT_FOUND:
+    default: {
+      const remediation = installHint || `install ${name}`
+      return {
+        message: `"${name}" not found — ${remediation}`,
+        remediation,
+      }
+    }
+  }
+}

--- a/packages/server/src/utils/verify-binary.js
+++ b/packages/server/src/utils/verify-binary.js
@@ -61,17 +61,29 @@ export const BINARY_STATUS = Object.freeze({
 // the binary launches normally, so a quarantine xattr with this bit is NOT a block.
 const QTN_FLAG_ASSESSMENT_OK = 0x0040
 
+// Absolute path to the system `xattr`. This is security-hardening code — reading
+// it by bare name (`xattr`) would resolve through PATH, so a shadowed `xattr`
+// planted earlier on PATH could lie about the quarantine state and defeat the
+// whole check. `/usr/bin/xattr` is a fixed, SIP-protected macOS system binary.
+export const MACOS_XATTR = '/usr/bin/xattr'
+
 /**
  * Default macOS reader for the `com.apple.quarantine` xattr. Returns the raw
  * attribute value, or `null` when the attribute is absent (the common case —
  * `xattr -p` exits non-zero, which we swallow). Only ever called on darwin.
  *
+ * Invokes the ABSOLUTE system path {@link MACOS_XATTR} (never a PATH lookup) so
+ * a shadowed `xattr` cannot subvert the integrity check. `execFile` is injected
+ * in tests to assert exactly that.
+ *
  * @param {string} path
+ * @param {object} [opts]
+ * @param {Function} [opts.execFile=execFileSync]
  * @returns {string|null}
  */
-function defaultReadQuarantineXattr(path) {
+export function readQuarantineXattr(path, { execFile = execFileSync } = {}) {
   try {
-    const out = execFileSync('xattr', ['-p', 'com.apple.quarantine', path], {
+    const out = execFile(MACOS_XATTR, ['-p', 'com.apple.quarantine', path], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 3000,
@@ -130,7 +142,7 @@ export function verifyBinary(resolvedPath, {
   existsSync = fsExistsSync,
   accessSync = fsAccessSync,
   isAbsolute = pathIsAbsolute,
-  readQuarantineXattr = defaultReadQuarantineXattr,
+  readQuarantineXattr: readXattr = readQuarantineXattr,
 } = {}) {
   const path = typeof resolvedPath === 'string' ? resolvedPath : ''
 
@@ -149,7 +161,7 @@ export function verifyBinary(resolvedPath, {
   // macOS-only: a Gatekeeper-quarantined binary keeps its X bit but refuses to
   // launch. Skip entirely off darwin — there is no equivalent block.
   if (platform === 'darwin') {
-    const xattrValue = readQuarantineXattr(path)
+    const xattrValue = readXattr(path)
     if (isBlockingQuarantine(xattrValue)) {
       return { ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: xattrValue }
     }
@@ -159,9 +171,26 @@ export function verifyBinary(resolvedPath, {
 }
 
 /**
+ * POSIX shell-quote a string so it survives copy-paste as a single argument.
+ * Leaves an already-safe token (the common `/opt/homebrew/bin/codex` case)
+ * unquoted; single-quotes anything containing whitespace or shell metacharacters
+ * (e.g. a path with spaces), escaping embedded single quotes. Keeps the
+ * `xattr -d …` / `chmod +x …` remediations copy-pasteable for any path.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+export function shellQuotePath(s) {
+  if (typeof s !== 'string' || s.length === 0) return "''"
+  if (/^[A-Za-z0-9_/.:@%+=-]+$/.test(s)) return s
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
+/**
  * Build a user-facing message + remediation for a non-OK {@link BinaryHealth}.
  * Centralised so preflight errors, the spawn-time catch, and `chroxy doctor`
- * all speak the same language about what is wrong and how to fix it.
+ * all speak the same language about what is wrong and how to fix it. Paths in
+ * the copy-pasteable remediations are shell-quoted so spaces don't break them.
  *
  * @param {BinaryHealth} health
  * @param {object} [ctx]
@@ -172,16 +201,17 @@ export function verifyBinary(resolvedPath, {
 export function describeBinaryHealth(health, { binary, installHint } = {}) {
   const name = binary || 'binary'
   const path = health && health.path ? health.path : ''
+  const qPath = shellQuotePath(path)
   switch (health && health.status) {
     case BINARY_STATUS.QUARANTINED: {
-      const remediation = `verify its provenance, then run: xattr -d com.apple.quarantine ${path} (or approve it in System Settings → Privacy & Security), or re-download ${name}`
+      const remediation = `verify its provenance, then run: xattr -d com.apple.quarantine ${qPath} (or approve it in System Settings → Privacy & Security), or re-download ${name}`
       return {
         message: `"${name}" at ${path} is quarantined/blocked by macOS Gatekeeper — ${remediation}`,
         remediation,
       }
     }
     case BINARY_STATUS.NOT_EXECUTABLE: {
-      const remediation = `run: chmod +x ${path}`
+      const remediation = `run: chmod +x ${qPath}`
       return {
         message: `"${name}" at ${path} exists but is not executable — ${remediation}`,
         remediation,
@@ -200,41 +230,45 @@ export function describeBinaryHealth(health, { binary, installHint } = {}) {
 
 /**
  * Spawn-time backstop: given a spawn failure, produce a labeled message naming a
- * quarantine / not-found root cause + fix when the provider binary changed out
- * from under a running daemon — the between-preflight-and-spawn / mid-session-
- * respawn window that motivated #6708 (XProtect removed the binary while the
- * daemon was live). Returns `null` when the binary still looks healthy, so the
- * caller keeps its own error text (the failure was something else).
+ * quarantine / not-found / not-executable root cause + fix when the provider
+ * binary changed out from under a running daemon — the between-preflight-and-
+ * spawn / mid-session-respawn window that motivated #6708 (XProtect removed the
+ * binary while the daemon was live). Returns `null` when the binary still looks
+ * healthy, so the caller keeps its own error text (the failure was something
+ * else).
  *
  * Shared by every provider spawn site so the labeling lives in one place:
  * jsonl-subprocess (codex-exec + gemini), cli-session (claude), claude-tui, and
  * codex-app-server.
  *
- * `resolvedBinary` accepts a string OR a getter function — the provider
- * `resolvedBinary` static re-resolves fresh and can throw on a misconfigured
- * subclass, both of which are handled (a throw yields `null`, no crash).
+ * `attemptedPath` is the EXACT path the spawn tried to exec — take it from the
+ * spawn error's `err.path`, or the command captured at the spawn call site. It
+ * is deliberately NOT re-resolved here: a fresh `resolveBinary()` can land on a
+ * DIFFERENT path than the one that actually failed (PATH/candidate order can
+ * shift, or a since-repaired binary now resolves), so the backstop would then
+ * describe the wrong file. Verifying the attempted path describes exactly what
+ * failed.
  *
  * @param {object} opts
- * @param {string|(()=>string)} opts.resolvedBinary - spawn path, or a getter for it
+ * @param {string} opts.attemptedPath - the exact path spawn tried to exec
  * @param {string} opts.binary   - provider/binary name for labeling (e.g. 'codex')
  * @param {string} [opts.prefix] - message prefix (default `Failed to spawn <binary>`)
  * @param {Function} [opts.verify=verifyBinary] - integrity checker (injected in tests)
  * @returns {string|null} labeled message, or null when the binary looks healthy
  */
-export function labelBinarySpawnFailure({ resolvedBinary, binary, prefix, verify = verifyBinary } = {}) {
-  let resolved
-  try {
-    resolved = typeof resolvedBinary === 'function' ? resolvedBinary() : resolvedBinary
-  } catch {
-    return null // resolvedBinary getter threw (misconfigured subclass) — no label
-  }
+export function labelBinarySpawnFailure({ attemptedPath, binary, prefix, verify = verifyBinary } = {}) {
+  if (typeof attemptedPath !== 'string' || attemptedPath.length === 0) return null
   let health
   try {
-    health = verify(resolved)
+    health = verify(attemptedPath)
   } catch {
     return null
   }
-  if (health && (health.status === BINARY_STATUS.QUARANTINED || health.status === BINARY_STATUS.NOT_FOUND)) {
+  if (health && (
+    health.status === BINARY_STATUS.QUARANTINED
+    || health.status === BINARY_STATUS.NOT_FOUND
+    || health.status === BINARY_STATUS.NOT_EXECUTABLE
+  )) {
     const desc = describeBinaryHealth(health, { binary })
     return `${prefix || `Failed to spawn ${binary}`}: ${desc.message}`
   }

--- a/packages/server/tests/binary-spawn-backstop.test.js
+++ b/packages/server/tests/binary-spawn-backstop.test.js
@@ -1,0 +1,73 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { CodexAppServerSession } from '../src/codex-app-server-session.js'
+
+/**
+ * Spawn-time binary backstop on a DEFAULT provider (#6708).
+ *
+ * codex-app-server is a default provider whose child is spawned inside
+ * `initialize()`, so a missing/quarantined binary surfaces as an initialize
+ * rejection ("codex app-server exited (code=…)") rather than the synchronous
+ * ENOENT the exec-path providers throw. `start()` must re-verify the binary and
+ * reject with a LABELED, actionable error naming the cause + fix instead of that
+ * opaque transport message.
+ *
+ * This drives the REAL `start()` / client spawn with a deterministically-missing
+ * binary path (no real quarantined binary, no module mock). The QUARANTINED
+ * branch of the shared labeling helper is proven with an injected verify seam in
+ * verify-binary.test.js; here we prove the default-provider WIRING end-to-end.
+ *
+ * `resolvedBinary` is referenced by the hardcoded class name inside start(), so
+ * the override is applied to `CodexAppServerSession` itself and restored after
+ * each test. This is the only test file that touches that static, so there is no
+ * cross-file race (node runs test files in separate processes).
+ */
+describe('codex-app-server start() — spawn-time binary backstop (#6708)', () => {
+  let restore = null
+  const cleanupDirs = []
+
+  afterEach(() => {
+    if (restore) { restore(); restore = null }
+    while (cleanupDirs.length) rmSync(cleanupDirs.pop(), { recursive: true, force: true })
+  })
+
+  function overrideResolvedBinary(path) {
+    const original = Object.getOwnPropertyDescriptor(CodexAppServerSession, 'resolvedBinary')
+    Object.defineProperty(CodexAppServerSession, 'resolvedBinary', { get: () => path, configurable: true })
+    restore = () => Object.defineProperty(CodexAppServerSession, 'resolvedBinary', original)
+  }
+
+  function mkSession() {
+    const sk = mkdtempSync(join(tmpdir(), 'chroxy-backstop-'))
+    cleanupDirs.push(sk)
+    return new CodexAppServerSession({ cwd: tmpdir(), skillsDir: sk, repoSkillsDir: null })
+  }
+
+  it('rejects with a labeled "not found" error, not the opaque "app-server exited"', async () => {
+    // A guaranteed-missing absolute path — verifyBinary → NOT_FOUND on every OS.
+    overrideResolvedBinary('/var/empty/__chroxy_missing_codex_6708__')
+    const s = mkSession()
+    // The client's exit fires a concurrent session `error` event (the mid-session
+    // channel). Capture it so Node's unhandled-'error' throw doesn't fail the
+    // test, and so we can assert it is ALSO labeled (not the raw ENOENT).
+    const errorEvents = []
+    s.on('error', (e) => errorEvents.push(e))
+    await assert.rejects(
+      s.start(),
+      (err) => {
+        assert.match(err.message, /Failed to start codex app-server/)
+        assert.match(err.message, /not found/i)
+        // Must NOT surface the raw transport error the operator can't act on.
+        assert.doesNotMatch(err.message, /app-server exited \(spawn/)
+        return true
+      },
+    )
+    // The concurrent exit-channel error is relabeled too.
+    assert.ok(errorEvents.length > 0, 'expected a session error event from the exit channel')
+    assert.match(errorEvents[0].message, /not found/i)
+    try { s.destroy() } catch { /* best effort */ }
+  })
+})

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -361,6 +361,21 @@ describe('checkBinary quarantine detection (#6708)', () => {
     assert.match(result.message, /Gatekeeper/)
   })
 
+  it('reports a present-but-not-executable binary distinctly (not "Not found")', () => {
+    const result = checkBinary('codex', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install Codex CLI',
+      verify: (path) => ({ ok: false, status: 'not_executable', path, quarantine: null }),
+    })
+    assert.equal(result.status, 'fail')
+    assert.match(result.message, /not executable/)
+    assert.match(result.message, /chmod \+x/)
+    // A non-executable binary must not be mislabeled as missing.
+    assert.doesNotMatch(result.message, /Not found/)
+  })
+
   it('still runs the version probe when the binary is clean (verify=ok)', () => {
     const result = checkBinary('node', ['--version'], {
       parseVersion: (out) => out.trim(),

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -330,6 +330,50 @@ describe('checkBinary minVersion gate (#3953)', () => {
   })
 })
 
+// #6708 — doctor must distinguish "quarantined/blocked by Gatekeeper" from
+// "not installed" so an operator can preflight the exact failure XProtect
+// caused. The verify seam is injected so no real quarantined binary is needed.
+describe('checkBinary quarantine detection (#6708)', () => {
+  it('reports a quarantined binary as fail with an xattr remediation hint', () => {
+    const result = checkBinary('codex', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install Codex CLI',
+      verify: (path) => ({ ok: false, status: 'quarantined', path, quarantine: '0081;a;b;c' }),
+    })
+    assert.equal(result.status, 'fail')
+    assert.match(result.message, /Gatekeeper/)
+    assert.match(result.message, /xattr -d com\.apple\.quarantine/)
+    // Must NOT mislabel a quarantined binary as "Not found — install …".
+    assert.doesNotMatch(result.message, /Not found/)
+  })
+
+  it('downgrades a quarantined optional binary to warn (not fail)', () => {
+    const result = checkBinary('cloudflared', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: false,
+      candidates: [process.execPath],
+      installHint: 'brew install cloudflared',
+      verify: (path) => ({ ok: false, status: 'quarantined', path, quarantine: '0081;a;b;c' }),
+    })
+    assert.equal(result.status, 'warn')
+    assert.match(result.message, /Gatekeeper/)
+  })
+
+  it('still runs the version probe when the binary is clean (verify=ok)', () => {
+    const result = checkBinary('node', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install node',
+      verify: (path) => ({ ok: true, status: 'ok', path, quarantine: null }),
+    })
+    assert.equal(result.status, 'pass')
+    assert.match(result.message, /^v\d+\.\d+\.\d+/)
+  })
+})
+
 describe('parseLeadingSemver / compareSemver helpers (#3953)', () => {
   it('parses a leading semver out of a decorated version string', () => {
     assert.deepEqual(parseLeadingSemver('2.1.163 (Claude Code)'), [2, 1, 163])

--- a/packages/server/tests/preflight.test.js
+++ b/packages/server/tests/preflight.test.js
@@ -142,13 +142,24 @@ describe('runProviderPreflight — quarantine detection (#6708)', () => {
     assert.equal(verifiedPath, '/custom/spawn/path/codex')
   })
 
-  it('reports a quarantined binary as not-ok via the ok flag (belt-and-braces)', () => {
+  it('a not-found result (ok:false) throws ProviderBinaryNotFoundError, not the quarantine error', () => {
     const Provider = makeProvider({
       preflight: { label: 'X', binary: { name: 'node', candidates: [] } },
     })
     const notFound = () => ({ ok: false, status: BINARY_STATUS.NOT_FOUND, path: 'node', quarantine: null })
     assert.throws(
       () => runProviderPreflight(Provider, { env: {}, verifyBinary: notFound }),
+      ProviderBinaryNotFoundError,
+    )
+  })
+
+  it('a not-executable result (ok:false) also throws ProviderBinaryNotFoundError', () => {
+    const Provider = makeProvider({
+      preflight: { label: 'X', binary: { name: 'node', candidates: [] } },
+    })
+    const notExec = (path) => ({ ok: false, status: BINARY_STATUS.NOT_EXECUTABLE, path, quarantine: null })
+    assert.throws(
+      () => runProviderPreflight(Provider, { env: {}, verifyBinary: notExec }),
       ProviderBinaryNotFoundError,
     )
   })

--- a/packages/server/tests/preflight.test.js
+++ b/packages/server/tests/preflight.test.js
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict'
 import {
   runProviderPreflight,
   ProviderBinaryNotFoundError,
+  ProviderBinaryQuarantinedError,
   ProviderCredentialMissingError,
 } from '../src/utils/preflight.js'
+import { BINARY_STATUS } from '../src/utils/verify-binary.js'
 
 /**
  * Tests for runProviderPreflight — verifies binary + credential checks
@@ -88,6 +90,67 @@ describe('runProviderPreflight — binary checks', () => {
       },
     })
     assert.doesNotThrow(() => runProviderPreflight(Provider, { env: {} }))
+  })
+})
+
+describe('runProviderPreflight — quarantine detection (#6708)', () => {
+  it('throws ProviderBinaryQuarantinedError when the binary is present but quarantined', () => {
+    // `node` resolves to a real absolute path; the injected verifyBinary reports
+    // it as QUARANTINED so we exercise the branch with no real quarantined file.
+    const Provider = makeProvider({
+      preflight: {
+        label: 'Codex',
+        binary: { name: 'node', candidates: [], installHint: 'install Codex CLI' },
+      },
+    })
+    const fakeVerify = (path) => ({
+      ok: false,
+      status: BINARY_STATUS.QUARANTINED,
+      path,
+      quarantine: '0081;66a1;Safari;uuid',
+    })
+    assert.throws(
+      () => runProviderPreflight(Provider, { env: {}, verifyBinary: fakeVerify }),
+      (err) => {
+        assert.ok(err instanceof ProviderBinaryQuarantinedError, `got ${err?.name}`)
+        assert.equal(err.code, 'PROVIDER_BINARY_QUARANTINED')
+        assert.equal(err.binary, 'node')
+        assert.equal(err.quarantine, '0081;66a1;Safari;uuid')
+        assert.match(err.message, /Gatekeeper/)
+        assert.match(err.message, /xattr -d com\.apple\.quarantine/)
+        return true
+      },
+    )
+  })
+
+  it('verifies the provider\'s live resolvedBinary path when it exposes one', () => {
+    // Preflight must check the SAME path the spawn will use (not a stale const),
+    // so a provider with a resolvedBinary getter has THAT path handed to verify.
+    let verifiedPath = null
+    class Provider {
+      static get preflight() {
+        return { label: 'Codex', binary: { name: 'codex', candidates: [] } }
+      }
+      static get capabilities() { return {} }
+      static get resolvedBinary() { return '/custom/spawn/path/codex' }
+    }
+    const fakeVerify = (path) => {
+      verifiedPath = path
+      return { ok: true, status: BINARY_STATUS.OK, path, quarantine: null }
+    }
+    runProviderPreflight(Provider, { env: {}, verifyBinary: fakeVerify })
+    assert.equal(verifiedPath, '/custom/spawn/path/codex')
+  })
+
+  it('reports a quarantined binary as not-ok via the ok flag (belt-and-braces)', () => {
+    const Provider = makeProvider({
+      preflight: { label: 'X', binary: { name: 'node', candidates: [] } },
+    })
+    const notFound = () => ({ ok: false, status: BINARY_STATUS.NOT_FOUND, path: 'node', quarantine: null })
+    assert.throws(
+      () => runProviderPreflight(Provider, { env: {}, verifyBinary: notFound }),
+      ProviderBinaryNotFoundError,
+    )
   })
 })
 

--- a/packages/server/tests/verify-binary.test.js
+++ b/packages/server/tests/verify-binary.test.js
@@ -5,6 +5,9 @@ import {
   isBlockingQuarantine,
   describeBinaryHealth,
   labelBinarySpawnFailure,
+  readQuarantineXattr,
+  shellQuotePath,
+  MACOS_XATTR,
   BINARY_STATUS,
 } from '../src/utils/verify-binary.js'
 
@@ -139,13 +142,18 @@ describe('isBlockingQuarantine', () => {
 })
 
 describe('labelBinarySpawnFailure — shared spawn-time backstop (#6708)', () => {
-  it('labels a quarantined-at-spawn binary with the xattr fix (not a raw error)', () => {
-    const quarantined = (path) => ({ ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: '0081;a;b;c' })
+  it('verifies the EXACT attempted path (not a re-resolve) and labels quarantine', () => {
+    let verifiedPath = null
+    const quarantined = (path) => {
+      verifiedPath = path
+      return { ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: '0081;a;b;c' }
+    }
     const msg = labelBinarySpawnFailure({
-      resolvedBinary: '/opt/homebrew/bin/codex',
+      attemptedPath: '/opt/homebrew/bin/codex',
       binary: 'codex',
       verify: quarantined,
     })
+    assert.equal(verifiedPath, '/opt/homebrew/bin/codex', 'must verify the attempted path verbatim')
     assert.ok(msg, 'expected a labeled message')
     assert.match(msg, /^Failed to spawn codex:/)
     assert.match(msg, /Gatekeeper/)
@@ -154,14 +162,25 @@ describe('labelBinarySpawnFailure — shared spawn-time backstop (#6708)', () =>
 
   it('labels a vanished-at-spawn binary as not found', () => {
     const gone = (path) => ({ ok: false, status: BINARY_STATUS.NOT_FOUND, path, quarantine: null })
-    const msg = labelBinarySpawnFailure({ resolvedBinary: 'codex', binary: 'codex', verify: gone })
+    const msg = labelBinarySpawnFailure({ attemptedPath: 'codex', binary: 'codex', verify: gone })
     assert.match(msg, /Failed to spawn codex:.*not found/)
+  })
+
+  it('labels a present-but-not-executable binary (with a chmod fix)', () => {
+    const notExec = (path) => ({ ok: false, status: BINARY_STATUS.NOT_EXECUTABLE, path, quarantine: null })
+    const msg = labelBinarySpawnFailure({
+      attemptedPath: '/opt/homebrew/bin/codex',
+      binary: 'codex',
+      verify: notExec,
+    })
+    assert.match(msg, /not executable/)
+    assert.match(msg, /chmod \+x \/opt\/homebrew\/bin\/codex/)
   })
 
   it('honors a custom prefix (PTY / app-server call sites)', () => {
     const gone = (path) => ({ ok: false, status: BINARY_STATUS.NOT_FOUND, path, quarantine: null })
     const msg = labelBinarySpawnFailure({
-      resolvedBinary: 'claude',
+      attemptedPath: 'claude',
       binary: 'claude',
       prefix: 'Failed to spawn claude under PTY',
       verify: gone,
@@ -171,38 +190,72 @@ describe('labelBinarySpawnFailure — shared spawn-time backstop (#6708)', () =>
 
   it('returns null when the binary is healthy (caller keeps its own error)', () => {
     const ok = (path) => ({ ok: true, status: BINARY_STATUS.OK, path, quarantine: null })
-    assert.equal(labelBinarySpawnFailure({ resolvedBinary: '/bin/x', binary: 'x', verify: ok }), null)
+    assert.equal(labelBinarySpawnFailure({ attemptedPath: '/bin/x', binary: 'x', verify: ok }), null)
   })
 
-  it('accepts a getter for resolvedBinary and calls it', () => {
+  it('returns null for an empty/missing attemptedPath (no verify call)', () => {
     let called = false
-    const quarantined = (path) => ({ ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: '0081' })
-    const msg = labelBinarySpawnFailure({
-      resolvedBinary: () => { called = true; return '/opt/homebrew/bin/gemini' },
-      binary: 'gemini',
-      verify: quarantined,
-    })
-    assert.equal(called, true)
-    assert.match(msg, /gemini/)
-  })
-
-  it('returns null (no crash) when the resolvedBinary getter throws', () => {
-    const quarantined = () => ({ ok: false, status: BINARY_STATUS.QUARANTINED, path: 'x', quarantine: '0081' })
-    const msg = labelBinarySpawnFailure({
-      resolvedBinary: () => { throw new Error('resolvedBinary must be overridden') },
-      binary: 'codex',
-      verify: quarantined,
-    })
-    assert.equal(msg, null)
+    const spy = () => { called = true; return { ok: false, status: BINARY_STATUS.NOT_FOUND, path: '', quarantine: null } }
+    assert.equal(labelBinarySpawnFailure({ attemptedPath: '', binary: 'x', verify: spy }), null)
+    assert.equal(labelBinarySpawnFailure({ attemptedPath: undefined, binary: 'x', verify: spy }), null)
+    assert.equal(called, false, 'verify must not run without a concrete attempted path')
   })
 
   it('returns null (no crash) when verify itself throws', () => {
     const msg = labelBinarySpawnFailure({
-      resolvedBinary: '/bin/x',
+      attemptedPath: '/bin/x',
       binary: 'x',
       verify: () => { throw new Error('boom') },
     })
     assert.equal(msg, null)
+  })
+})
+
+describe('readQuarantineXattr — invokes the ABSOLUTE system xattr (#6708 security)', () => {
+  it('execs /usr/bin/xattr, never a bare PATH-resolved "xattr"', () => {
+    let calledCmd = null
+    let calledArgs = null
+    const execSpy = (cmd, args) => { calledCmd = cmd; calledArgs = args; return '0081;a;b;c\n' }
+    const value = readQuarantineXattr('/opt/homebrew/bin/codex', { execFile: execSpy })
+    assert.equal(calledCmd, '/usr/bin/xattr', 'must use the absolute system path, not a PATH lookup')
+    assert.equal(MACOS_XATTR, '/usr/bin/xattr')
+    assert.deepEqual(calledArgs, ['-p', 'com.apple.quarantine', '/opt/homebrew/bin/codex'])
+    assert.equal(value, '0081;a;b;c')
+  })
+
+  it('returns null when the attribute is absent (xattr exits non-zero)', () => {
+    const execThrows = () => { throw Object.assign(new Error('No such xattr'), { status: 1 }) }
+    assert.equal(readQuarantineXattr('/bin/x', { execFile: execThrows }), null)
+  })
+})
+
+describe('shellQuotePath — copy-pasteable remediations for spaced paths (#6708)', () => {
+  it('leaves an already-safe path unquoted', () => {
+    assert.equal(shellQuotePath('/opt/homebrew/bin/codex'), '/opt/homebrew/bin/codex')
+  })
+
+  it('single-quotes a path containing spaces', () => {
+    assert.equal(shellQuotePath('/Users/me/My Tools/codex'), "'/Users/me/My Tools/codex'")
+  })
+
+  it('escapes embedded single quotes', () => {
+    assert.equal(shellQuotePath("/a/b'c/codex"), "'/a/b'\\''c/codex'")
+  })
+
+  it('describeBinaryHealth quotes a spaced path in the xattr remediation', () => {
+    const { remediation } = describeBinaryHealth(
+      { status: BINARY_STATUS.QUARANTINED, path: '/Users/me/My Tools/codex' },
+      { binary: 'codex' },
+    )
+    assert.match(remediation, /xattr -d com\.apple\.quarantine '\/Users\/me\/My Tools\/codex'/)
+  })
+
+  it('describeBinaryHealth quotes a spaced path in the chmod remediation', () => {
+    const { remediation } = describeBinaryHealth(
+      { status: BINARY_STATUS.NOT_EXECUTABLE, path: '/Users/me/My Tools/codex' },
+      { binary: 'codex' },
+    )
+    assert.match(remediation, /chmod \+x '\/Users\/me\/My Tools\/codex'/)
   })
 })
 

--- a/packages/server/tests/verify-binary.test.js
+++ b/packages/server/tests/verify-binary.test.js
@@ -4,6 +4,7 @@ import {
   verifyBinary,
   isBlockingQuarantine,
   describeBinaryHealth,
+  labelBinarySpawnFailure,
   BINARY_STATUS,
 } from '../src/utils/verify-binary.js'
 
@@ -134,6 +135,74 @@ describe('isBlockingQuarantine', () => {
 
   it('returns true for an unparseable flags field', () => {
     assert.equal(isBlockingQuarantine('zzzz;t;a;u'), true)
+  })
+})
+
+describe('labelBinarySpawnFailure — shared spawn-time backstop (#6708)', () => {
+  it('labels a quarantined-at-spawn binary with the xattr fix (not a raw error)', () => {
+    const quarantined = (path) => ({ ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: '0081;a;b;c' })
+    const msg = labelBinarySpawnFailure({
+      resolvedBinary: '/opt/homebrew/bin/codex',
+      binary: 'codex',
+      verify: quarantined,
+    })
+    assert.ok(msg, 'expected a labeled message')
+    assert.match(msg, /^Failed to spawn codex:/)
+    assert.match(msg, /Gatekeeper/)
+    assert.match(msg, /xattr -d com\.apple\.quarantine \/opt\/homebrew\/bin\/codex/)
+  })
+
+  it('labels a vanished-at-spawn binary as not found', () => {
+    const gone = (path) => ({ ok: false, status: BINARY_STATUS.NOT_FOUND, path, quarantine: null })
+    const msg = labelBinarySpawnFailure({ resolvedBinary: 'codex', binary: 'codex', verify: gone })
+    assert.match(msg, /Failed to spawn codex:.*not found/)
+  })
+
+  it('honors a custom prefix (PTY / app-server call sites)', () => {
+    const gone = (path) => ({ ok: false, status: BINARY_STATUS.NOT_FOUND, path, quarantine: null })
+    const msg = labelBinarySpawnFailure({
+      resolvedBinary: 'claude',
+      binary: 'claude',
+      prefix: 'Failed to spawn claude under PTY',
+      verify: gone,
+    })
+    assert.match(msg, /^Failed to spawn claude under PTY:/)
+  })
+
+  it('returns null when the binary is healthy (caller keeps its own error)', () => {
+    const ok = (path) => ({ ok: true, status: BINARY_STATUS.OK, path, quarantine: null })
+    assert.equal(labelBinarySpawnFailure({ resolvedBinary: '/bin/x', binary: 'x', verify: ok }), null)
+  })
+
+  it('accepts a getter for resolvedBinary and calls it', () => {
+    let called = false
+    const quarantined = (path) => ({ ok: false, status: BINARY_STATUS.QUARANTINED, path, quarantine: '0081' })
+    const msg = labelBinarySpawnFailure({
+      resolvedBinary: () => { called = true; return '/opt/homebrew/bin/gemini' },
+      binary: 'gemini',
+      verify: quarantined,
+    })
+    assert.equal(called, true)
+    assert.match(msg, /gemini/)
+  })
+
+  it('returns null (no crash) when the resolvedBinary getter throws', () => {
+    const quarantined = () => ({ ok: false, status: BINARY_STATUS.QUARANTINED, path: 'x', quarantine: '0081' })
+    const msg = labelBinarySpawnFailure({
+      resolvedBinary: () => { throw new Error('resolvedBinary must be overridden') },
+      binary: 'codex',
+      verify: quarantined,
+    })
+    assert.equal(msg, null)
+  })
+
+  it('returns null (no crash) when verify itself throws', () => {
+    const msg = labelBinarySpawnFailure({
+      resolvedBinary: '/bin/x',
+      binary: 'x',
+      verify: () => { throw new Error('boom') },
+    })
+    assert.equal(msg, null)
   })
 })
 

--- a/packages/server/tests/verify-binary.test.js
+++ b/packages/server/tests/verify-binary.test.js
@@ -1,0 +1,167 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  verifyBinary,
+  isBlockingQuarantine,
+  describeBinaryHealth,
+  BINARY_STATUS,
+} from '../src/utils/verify-binary.js'
+
+/**
+ * Unit tests for pre-spawn binary integrity + quarantine verification (#6708).
+ *
+ * Every filesystem / xattr touchpoint is injected, so these run identically on
+ * macOS, Linux, and Windows CI with NO real quarantined binary — the exact
+ * "detection logic over a mocked fs/xattr layer" the issue calls for.
+ */
+
+// A stub seam bag that makes an absolute, existing, executable, clean binary.
+function healthySeams(overrides = {}) {
+  return {
+    platform: 'darwin',
+    isAbsolute: () => true,
+    existsSync: () => true,
+    accessSync: () => {}, // no throw = executable
+    readQuarantineXattr: () => null, // no xattr = not quarantined
+    ...overrides,
+  }
+}
+
+describe('verifyBinary — existence + executability', () => {
+  it('returns ok for an absolute, existing, executable, unquarantined binary', () => {
+    const health = verifyBinary('/opt/homebrew/bin/codex', healthySeams())
+    assert.equal(health.status, BINARY_STATUS.OK)
+    assert.equal(health.ok, true)
+    assert.equal(health.path, '/opt/homebrew/bin/codex')
+    assert.equal(health.quarantine, null)
+  })
+
+  it('returns not_found for a non-absolute path (bare-name resolver fallback)', () => {
+    // resolveBinary returns the bare name when nothing matched on PATH/candidates.
+    const health = verifyBinary('codex', healthySeams({ isAbsolute: () => false }))
+    assert.equal(health.status, BINARY_STATUS.NOT_FOUND)
+    assert.equal(health.ok, false)
+  })
+
+  it('returns not_found when the path does not exist', () => {
+    const health = verifyBinary('/opt/homebrew/bin/codex', healthySeams({ existsSync: () => false }))
+    assert.equal(health.status, BINARY_STATUS.NOT_FOUND)
+  })
+
+  it('returns not_found for an empty/undefined path', () => {
+    assert.equal(verifyBinary('', healthySeams()).status, BINARY_STATUS.NOT_FOUND)
+    assert.equal(verifyBinary(undefined, healthySeams()).status, BINARY_STATUS.NOT_FOUND)
+  })
+
+  it('returns not_executable when access(X_OK) throws', () => {
+    const health = verifyBinary('/opt/homebrew/bin/codex', healthySeams({
+      accessSync: () => { throw new Error('EACCES') },
+    }))
+    assert.equal(health.status, BINARY_STATUS.NOT_EXECUTABLE)
+    assert.equal(health.ok, false)
+  })
+})
+
+describe('verifyBinary — macOS quarantine detection', () => {
+  it('flags a present+executable binary carrying a blocking quarantine xattr', () => {
+    let probedPath = null
+    const health = verifyBinary('/opt/homebrew/bin/codex', healthySeams({
+      readQuarantineXattr: (p) => { probedPath = p; return '0081;66a1b2c3;Safari;ABC-123' },
+    }))
+    assert.equal(health.status, BINARY_STATUS.QUARANTINED)
+    assert.equal(health.ok, false)
+    assert.equal(health.quarantine, '0081;66a1b2c3;Safari;ABC-123')
+    // Only probed after existence + executable passed (the exact "passes preflight
+    // then fails at exec" gap the issue describes).
+    assert.equal(probedPath, '/opt/homebrew/bin/codex')
+  })
+
+  it('does NOT flag a quarantine xattr whose ASSESSMENT_OK (0x40) bit is set', () => {
+    // 0x00c1 has 0x40 set → Gatekeeper-approved → launches normally.
+    const health = verifyBinary('/opt/homebrew/bin/codex', healthySeams({
+      readQuarantineXattr: () => '00c1;66a1b2c3;Safari;ABC-123',
+    }))
+    assert.equal(health.status, BINARY_STATUS.OK)
+    assert.equal(health.quarantine, null)
+  })
+
+  it('treats an unparseable flags field as blocking (conservative)', () => {
+    const health = verifyBinary('/opt/homebrew/bin/codex', healthySeams({
+      readQuarantineXattr: () => 'not-hex;whatever',
+    }))
+    assert.equal(health.status, BINARY_STATUS.QUARANTINED)
+  })
+})
+
+describe('verifyBinary — cross-platform safety', () => {
+  it('skips the xattr probe entirely on linux', () => {
+    let probed = false
+    const health = verifyBinary('/usr/bin/codex', healthySeams({
+      platform: 'linux',
+      readQuarantineXattr: () => { probed = true; return '0081;x;y;z' },
+    }))
+    assert.equal(health.status, BINARY_STATUS.OK)
+    assert.equal(probed, false, 'xattr must not be probed off darwin')
+  })
+
+  it('skips the xattr probe entirely on win32', () => {
+    let probed = false
+    const health = verifyBinary('C:/tools/codex.exe', healthySeams({
+      platform: 'win32',
+      readQuarantineXattr: () => { probed = true; return '0081;x;y;z' },
+    }))
+    assert.equal(health.status, BINARY_STATUS.OK)
+    assert.equal(probed, false, 'xattr must not be probed off darwin')
+  })
+})
+
+describe('isBlockingQuarantine', () => {
+  it('returns false for empty/absent xattr', () => {
+    assert.equal(isBlockingQuarantine(null), false)
+    assert.equal(isBlockingQuarantine(undefined), false)
+    assert.equal(isBlockingQuarantine(''), false)
+  })
+
+  it('returns true when the ASSESSMENT_OK bit is clear', () => {
+    assert.equal(isBlockingQuarantine('0081;t;a;u'), true) // 0x81, no 0x40
+    assert.equal(isBlockingQuarantine('0002;t;a;u'), true) // sandbox only
+  })
+
+  it('returns false when the ASSESSMENT_OK bit is set', () => {
+    assert.equal(isBlockingQuarantine('0040;t;a;u'), false)
+    assert.equal(isBlockingQuarantine('00c1;t;a;u'), false)
+  })
+
+  it('returns true for an unparseable flags field', () => {
+    assert.equal(isBlockingQuarantine('zzzz;t;a;u'), true)
+  })
+})
+
+describe('describeBinaryHealth', () => {
+  it('produces a quarantine remediation naming the xattr command and path', () => {
+    const { message, remediation } = describeBinaryHealth(
+      { status: BINARY_STATUS.QUARANTINED, path: '/opt/homebrew/bin/codex' },
+      { binary: 'codex', installHint: 'install Codex CLI' },
+    )
+    assert.match(message, /codex/)
+    assert.match(message, /Gatekeeper/)
+    assert.match(remediation, /xattr -d com\.apple\.quarantine \/opt\/homebrew\/bin\/codex/)
+  })
+
+  it('produces a not-found remediation using the install hint', () => {
+    const { message } = describeBinaryHealth(
+      { status: BINARY_STATUS.NOT_FOUND, path: '' },
+      { binary: 'codex', installHint: 'install Codex CLI' },
+    )
+    assert.match(message, /not found/)
+    assert.match(message, /install Codex CLI/)
+  })
+
+  it('produces a chmod remediation for a non-executable binary', () => {
+    const { remediation } = describeBinaryHealth(
+      { status: BINARY_STATUS.NOT_EXECUTABLE, path: '/opt/homebrew/bin/codex' },
+      { binary: 'codex' },
+    )
+    assert.match(remediation, /chmod \+x \/opt\/homebrew\/bin\/codex/)
+  })
+})


### PR DESCRIPTION
## Problem

Chroxy execs external provider binaries (`claude`, `codex`, `gemini`, `cloudflared`) resolved off `PATH` with **zero integrity, provenance, or quarantine verification**. Two concrete failure modes (both verified against source in #6708):

- **Quarantined-but-present binary passes preflight.** On macOS a Gatekeeper-quarantined binary keeps its execute bit. The old preflight (`preflight.js isExecutableFile`) checked only `existsSync` + `access(X_OK)`, so it green-lit the binary and the failure surfaced *later* as an opaque mid-turn spawn error; `chroxy doctor` mislabeled it "Not found — install …".
- **Stale module-load path.** Each provider froze its resolved binary path in an import-time `const` (`CODEX`/`GEMINI`/`CLAUDE`). A binary quarantined/moved/removed **after** daemon start was still spawned from the stale path — and, because preflight re-resolved independently, the existence gate and the actual spawn could resolve *different* paths.

Triggering incident: macOS **XProtect Remediator** removed the OpenAI Codex native binary out from under a running daemon (probable XProtect false positive; the daemon-executes-unverified-binaries gap it exposed is real regardless).

## Approach

New shared pre-spawn check, `packages/server/src/utils/verify-binary.js`:

- `verifyBinary(resolvedPath)` classifies a path as `ok` / `not_found` / `not_executable` / `quarantined`.
- macOS-only `com.apple.quarantine` xattr probe. Treated as **blocking only when the `ASSESSMENT_OK` (0x40) flag is clear** — so Gatekeeper-approved and package-manager-installed binaries (which strip the xattr) are never false-flagged. Cleanly **skipped off darwin** (existence + executable only on Linux/Windows).
- Every fs / xattr / spawn touchpoint is an **injectable seam** — fully unit-tested over a mocked layer with no real quarantined binary.

Wired into the four surfaces the issue names:

1. **Preflight (per session-create):** `runProviderPreflight` re-resolves fresh and prefers the provider's live `resolvedBinary` (the exact spawn path), then throws a new `ProviderBinaryQuarantinedError` (`code: PROVIDER_BINARY_QUARANTINED`) for a quarantined binary. `createSession` propagates it; the WS layer already surfaces `err.code` as a `session_error` — so it routes through the existing error taxonomy alongside `PROVIDER_BINARY_NOT_FOUND`.
2. **No stale const:** `codex` / `gemini` / `claude-cli` / `claude-tui` `resolvedBinary` now re-resolve fresh per access; spawn and preflight verify the same current path.
3. **Spawn-time backstop (all providers):** a shared `labelBinarySpawnFailure()` (in `verify-binary.js`) re-verifies at spawn failure and relabels a post-preflight `ENOENT` as quarantined/vanished (with the `xattr -d` fix) instead of a raw error. Wired into **every** provider spawn site — not just the exec path:
   - `jsonl-subprocess-session.js` — codex-exec + gemini (the sync spawn catch)
   - `cli-session.js` — `claude` legacy `-p` (`child.on('error')`, the async ENOENT + respawn path)
   - `claude-tui-session.js` — the **default** provider (the node-pty spawn catch)
   - `codex-app-server-session.js` — the **default** codex driver: `start()` (the child is spawned inside `initialize()`, so a bad binary surfaces as an initialize rejection) **and** `_onClientExit()` (app-server has no respawn, so an unexpected exit is the terminal mid-session signal — relabeled too).
4. **`chroxy doctor`:** `checkBinary` reports quarantine distinctly (`fail`/`warn`) with an `xattr -d com.apple.quarantine <path>` remediation; `cloudflared` inherits it for free (already goes through `checkBinary`).

Plus `docs/security/spawned-binary-provenance.md` — spawned-binary provenance / supply-chain threat model and the P2 direction (indexed from CLAUDE.md; AGENTS.md regenerated).

## Phases shipped vs deferred

**Shipped (P1 — detect & surface, autonomously buildable):**
- ✅ AC: `chroxy doctor` distinguishes "quarantined/blocked" from "not installed", with a remediation hint.
- ✅ AC: preflight/`verifyBinary` detects a quarantined-but-present binary before spawn and surfaces a correctly-labeled error.
- ✅ AC: provider binary re-resolved/re-validated per session-create (no stale module-load path) — for codex, gemini, claude-cli, and claude-tui (the default).
- ✅ AC: design note in `docs/security/` covering spawned-binary provenance / supply-chain threat model.
- ✅ Spawn-time backstop covers **all** provider spawn sites (exec + both default providers + legacy cli), not exec-only.

**Deferred:**
- ⏸️ **P2 — opt-in signature/hash-pin verification** (`codesign`/`spctl` gate + cross-platform SHA-256 pin ledger reusing `path-hash-trust-ledger.js`, folding in `cloudflared`). Design captured in the new security doc, and **carried forward in #6858** so `Closes #6708` is honest for the P1 scope. Intentionally out of scope here — a hard `spctl` gate would reject chroxy's ad-hoc/linker-signed bundled binaries, and the pin ledger is a larger surface best landed before write-capable orchestration workers (#6691) ship.
- **Live-validation slice:** the macOS quarantine *detection* is unit-tested over a mocked fs/xattr seam (no real quarantined binary is used or required, per the issue's guidance). Exercising `verifyBinary` against a genuinely Gatekeeper-quarantined binary on a physical mac is the one slice that can't run in CI and is left for manual validation.

## Testing

- New `tests/verify-binary.test.js` (25 tests): status classification, the `ASSESSMENT_OK` flag nuance, cross-platform skip on linux/win32, and `labelBinarySpawnFailure` (quarantined → `xattr -d` fix, not-found, custom prefix, healthy → null, getter-throws → null, verify-throws → null) — all over injected seams.
- New `tests/binary-spawn-backstop.test.js`: default-provider integration — drives **real** `codex-app-server` `start()` with a missing binary → labeled rejection + labeled exit-channel error, asserting it is **not** the opaque `app-server exited (spawn … ENOENT)`.
- Extended `tests/preflight.test.js`: `ProviderBinaryQuarantinedError` throw + verifies the live `resolvedBinary` path is the one checked.
- Extended `tests/doctor.test.js`: `checkBinary` reports quarantine as `fail`/`warn` with the `xattr -d` hint and does not mislabel it "Not found".
- Green locally (Node 22): `verify-binary`, `preflight`, `binary-spawn-backstop`, `session-manager-preflight`, `resolve-binary`, `jsonl-subprocess*`, `windows-cmd-routing`, `cli-session`, `claude-tui-session`, `skills-integration`, `codex-app-server-session`, `codex-session`, `gemini-session` (746 tests across the session suites, all pass).
- All 5 server `lint-*.sh` pass; eslint clean (0 errors) on changed files.
- One pre-existing, environment-only failure on the dev box (`doctor.test.js` "codex provider reports credential status") — caused by `~/.codex/auth.json` existing locally (the `#6563` OAuth-aware credential check downgrades to `warn`); reproduces with these changes stashed and is green in CI. CI is the authoritative gate.

Closes #6708