### PR TITLE
fix(server): codex permission response no longer ends in responseStreamDisconnected (#6623)

### DIFF
--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -302,9 +302,25 @@ export class CodexAppServerSession extends BaseSession {
       case 'turn/completed':
         this._finishTurn(params?.turn)
         break
-      case 'error':
+      case 'error': {
+        // #6623 — codex emits transient `error` notifications WHILE its OWN retry
+        // loop re-establishes a dropped response stream (a `Reconnecting... N/M`
+        // message + `codexErrorInfo.responseStreamDisconnected`). This commonly
+        // fires right after a permission / escalation round-trip stalls a shell
+        // turn. These are NOT terminal: failing here surfaces a red provider error
+        // and orphans the in-flight turn even though codex is still recovering and
+        // may yet emit turn/completed. Keep the turn OPEN on a reconnect-in-progress
+        // notification — the result timeout (re-armed by _resetResultTimeout above)
+        // is the backstop if codex never recovers, and codex's terminal give-up
+        // (a disconnect WITHOUT a reconnecting message) still falls through to fail.
+        const err = this._errorPayload(params)
+        if (this._isTransientReconnect(err)) {
+          ;(this._log || log).warn(`codex app-server response stream reconnecting (turn kept open): ${err.message || 'responseStreamDisconnected'}`)
+          break
+        }
         this._failTurn(`Codex error: ${JSON.stringify(params).slice(0, 200)}`)
         break
+      }
       default:
         break // reasoning/plan/other items are ignored in Phase 1
     }
@@ -504,6 +520,28 @@ export class CodexAppServerSession extends BaseSession {
     this._endTurnAbort()
     this._clearMessageState()
     this._maybeDequeue()
+  }
+
+  // #6623 — codex's `error` notification carries the error under an `error` wrapper
+  // in the wild ({ error: { message, codexErrorInfo, ... } }) but a bare shape
+  // ({ message, ... }) elsewhere. Normalize to the inner error object either way so
+  // the callers read one shape.
+  _errorPayload(params) {
+    return params?.error && typeof params.error === 'object' ? params.error : (params || {})
+  }
+
+  // #6623 — true iff this error is codex's OWN transient response-stream reconnect
+  // (its retry loop is still running) rather than a terminal failure. Codex tags the
+  // retry with BOTH `codexErrorInfo.responseStreamDisconnected` AND a
+  // `Reconnecting... N/M` message; the terminal give-up drops the reconnecting
+  // message (or is a different error entirely), so it still fails the turn. Gating
+  // on both keeps the suppression conservative — anything not clearly a retry falls
+  // through to _failTurn.
+  _isTransientReconnect(err) {
+    const info = err?.codexErrorInfo
+    const disconnected = info && typeof info === 'object' && info.responseStreamDisconnected != null
+    if (!disconnected) return false
+    return /reconnect/i.test(typeof err?.message === 'string' ? err.message : '')
   }
 
   // #6638: also release cached fileChange diffs when per-turn state is cleared

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -373,6 +373,95 @@ describe('CodexAppServerSession — crash / stop paths (#6607)', () => {
   })
 })
 
+describe('CodexAppServerSession — transient stream reconnect (#6623)', () => {
+  // The `error` notification codex emits WHILE its OWN retry loop re-establishes a
+  // dropped response stream — commonly right after a permission / escalation
+  // round-trip stalls a shell turn. params.error.message is `Reconnecting... N/5`
+  // and codexErrorInfo carries responseStreamDisconnected (the exact shape from the
+  // #6623 report). This is a retry-in-progress, NOT a terminal failure.
+  const reconnectParams = (attempt = 2, max = 5) => ({
+    error: {
+      message: `Reconnecting... ${attempt}/${max}`,
+      codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+      additionalDetails: 'stream disconnected before completion: failed to send websocket frame',
+    },
+  })
+
+  it('a Reconnecting responseStreamDisconnected error keeps the turn open (does NOT fail it)', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error', 'stopped', 'stream_end', 'result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+    // OLD behavior: case 'error' → _failTurn → emits 'error' + clears the turn.
+    // NEW: a reconnect-in-progress is suppressed and the in-flight turn is preserved.
+    assert.deepEqual(ev.map(([e]) => e), [], 'no error/stopped/stream_end/result for a reconnect-in-progress')
+    assert.equal(s._isBusy, true, 'session stays busy while codex reconnects')
+    assert.ok(s._activeTurn, 'the in-flight turn is preserved across the reconnect')
+    s._clearResultTimeout() // release the re-armed backstop timer
+    cleanup()
+  })
+
+  it('recovers cleanly: after reconnect notifications the turn still completes normally', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error', 'stream_end', 'result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'error', params: reconnectParams(1, 5) })
+    s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+    // codex re-establishes the stream and finishes the turn
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 5 } } })
+    assert.deepEqual(ev.map(([e]) => e), ['stream_end', 'result'], 'turn completed cleanly, no error surfaced')
+    assert.equal(s._isBusy, false, 'busy cleared after recovery')
+    assert.equal(s._activeTurn, null, 'turn cleared after recovery')
+    cleanup()
+  })
+
+  it('a terminal responseStreamDisconnected (no Reconnecting message) still fails the turn', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    // codex gave up: the disconnect surfaces WITHOUT a retry message → terminal.
+    s._onNotification({
+      method: 'error',
+      params: { error: { message: 'stream disconnected before completion', codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } } } },
+    })
+    assert.equal(ev[0]?.[0], 'error', 'a terminal disconnect fails the turn')
+    assert.equal(s._isBusy, false, 'busy cleared on a terminal failure')
+    assert.equal(s._activeTurn, null, 'turn cleared on a terminal failure')
+    cleanup()
+  })
+
+  it('a Reconnecting message WITHOUT responseStreamDisconnected still fails (conservative gate)', () => {
+    const { s, cleanup } = mkSession()
+    const ev = capture(s, ['error'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+    // Only a responseStreamDisconnected reconnect is suppressed; a bare reconnect
+    // string with no disconnect info is not something we trust as recoverable.
+    s._onNotification({ method: 'error', params: { error: { message: 'Reconnecting... 1/5' } } })
+    assert.equal(ev[0]?.[0], 'error', 'no codexErrorInfo → not suppressed')
+    cleanup()
+  })
+
+  it('_isTransientReconnect / _errorPayload tolerate both wrapped and bare shapes', () => {
+    const { s, cleanup } = mkSession()
+    // wrapped { error: {...} } (the shape in the wild)
+    assert.equal(s._isTransientReconnect(s._errorPayload(reconnectParams(3, 5))), true)
+    // bare { message, codexErrorInfo } (no wrapper)
+    assert.equal(
+      s._isTransientReconnect(s._errorPayload({ message: 'Reconnecting... 3/5', codexErrorInfo: { responseStreamDisconnected: {} } })),
+      true,
+    )
+    // terminal disconnect (no reconnect text) and plain errors are NOT transient
+    assert.equal(s._isTransientReconnect(s._errorPayload({ message: 'boom', codexErrorInfo: { responseStreamDisconnected: {} } })), false)
+    assert.equal(s._isTransientReconnect(s._errorPayload({ message: 'boom' })), false)
+    assert.equal(s._isTransientReconnect(s._errorPayload(undefined)), false)
+    cleanup()
+  })
+})
+
 describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
   const tick = () => new Promise((r) => setImmediate(r))
   function mkApprovalSession(mode = 'approve') {


### PR DESCRIPTION
## Problem

A Codex-backed session (app-server driver — the default since #6616) could hit a red provider error during or immediately after a shell permission/escalation flow:

```
Codex error: {"error":{"message":"Reconnecting... 2/5","codexErrorInfo":{"responseStreamDisconnected":{"httpStatusCode":null}},"additionalDetails":"stream disconnected before completion: failed to send websocket ..."}}
```

The turn was left in an unstable working/reconnecting state instead of recovering cleanly.

## Root cause

`codex-app-server-session.js` `_onNotification` → `case 'error'` called `_failTurn(...)` on **every** codex `error` notification. But codex emits transient `error` notifications from its **own** retry loop while re-establishing a dropped response stream — the `Reconnecting... N/5` payload above, tagged `codexErrorInfo.responseStreamDisconnected`. A permission/escalation round-trip that stalls a shell/network command triggers exactly that stream drop, so Chroxy failed the turn **mid-recovery**: it surfaced the red error and orphaned the in-flight turn even though codex was still reconnecting and could yet emit `turn/completed`.

## Fix

Distinguish a reconnect-in-progress from a terminal error:

- On a `responseStreamDisconnected` + `Reconnecting...` notification, **keep the turn open** (warn-log only). The per-turn result timeout — re-armed on every notification — is the backstop if codex never recovers.
- Codex's terminal give-up (a disconnect **without** a reconnecting message), and any other error notification, still fall through to `_failTurn` with an actionable error.
- Two small helpers: `_errorPayload` (normalizes the wrapped `{ error: {...} }` shape seen in the wild vs. a bare `{ message, ... }`) and `_isTransientReconnect` (gates on **both** the disconnect info and the reconnect message, keeping suppression conservative).

Scope is strictly #6623's failure (permission flow → `responseStreamDisconnected`). The sibling #6629 (stale working state after a stream disconnect during a long shell task, i.e. the orphan-tool-result sweep) is intentionally **not** touched.

## Tests

New `CodexAppServerSession — transient stream reconnect (#6623)` block:
- a `Reconnecting` disconnect keeps the turn open (no `error`/`stopped`/`result`, busy preserved) — the pre-fix behavior would have emitted `error`;
- recovery: reconnect notifications followed by `turn/completed` finish the turn cleanly;
- a terminal disconnect (no reconnect message) and a plain `error` still fail the turn (no regression);
- `_errorPayload`/`_isTransientReconnect` cover both wrapped and bare payload shapes.

`codex-app-server-session` suite: 88 pass. Related codex suites (`codex-session`, `codex-session-env`, `codex-ratchet-persistence`): 133 pass. Both server lints green (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`).

Closes #6623