### PR TITLE
feat(server,app): route notification tap to the triggering session (#6792)

### DIFF
--- a/packages/app/__tests__/ios-live-activity.test.ts
+++ b/packages/app/__tests__/ios-live-activity.test.ts
@@ -111,9 +111,24 @@ describe('ios-live-activity', () => {
         { state: 'thinking', elapsedSeconds: 0 }
       )
       expect(result).toBe('native-activity-1')
+      // #6792: no sessionId provided → the bare (non-routable) deep link,
+      // matching pre-#6792 behavior for this edge case.
       expect(mockStartActivity).toHaveBeenCalledWith(
         { title: 'Chroxy', subtitle: 'Thinking...' },
-        expect.objectContaining({ backgroundColor: '#0f0f1a', deepLinkUrl: 'chroxy://' }),
+        expect.objectContaining({ backgroundColor: '#0f0f1a', deepLinkUrl: 'chroxy://open' }),
+      )
+    })
+
+    it('#6792: scopes deepLinkUrl to the session id when provided', async () => {
+      mockPlatform('ios', '17.0')
+      const { startLiveActivity } = requireBridge()
+      await startLiveActivity(
+        { sessionName: 'My Session', sessionId: 'sess-live-1' },
+        { state: 'thinking', elapsedSeconds: 0 }
+      )
+      expect(mockStartActivity).toHaveBeenCalledWith(
+        { title: 'Chroxy', subtitle: 'Thinking...' },
+        expect.objectContaining({ deepLinkUrl: 'chroxy://open?session=sess-live-1' }),
       )
     })
 

--- a/packages/app/__tests__/live-activity-manager.test.ts
+++ b/packages/app/__tests__/live-activity-manager.test.ts
@@ -95,6 +95,16 @@ describe('LiveActivityManager', () => {
       expect(manager.isActive).toBe(false);
       expect(manager.activityId).toBeNull();
     });
+
+    it('#6792: forwards a sessionId to the bridge when provided', async () => {
+      manager = createManager();
+      await manager.start('My Session', 'sess-live-manager-1');
+
+      expect(mockStart).toHaveBeenCalledWith(
+        { sessionName: 'My Session', sessionId: 'sess-live-manager-1' },
+        { state: 'active', elapsedSeconds: 0 },
+      );
+    });
   });
 
   describe('update', () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -85,8 +85,13 @@ export default function App() {
   // paths. Covers both cold start (Linking.getInitialURL — the app was
   // launched by opening the URL) and warm (the 'url' event — the app was
   // already running). A URL with no `session` param, or that isn't the
-  // chroxy scheme, is a no-op here (e.g. pairing links stay handled by
-  // ConnectScreen's own parser).
+  // chroxy scheme, is a no-op here: extractSessionIdFromDeepLink returns
+  // null and we never switch. This is the safety net for the pairing flow's
+  // `chroxy://host?pair=...` / `?token=...` URLs — those CAN now reach this
+  // global listener (it's the only OS-level Linking handler in the app;
+  // ConnectScreen parses pairing URLs from QR-scan/manual-entry, not from
+  // the Linking API), and they're ignored precisely because they carry no
+  // `session` param.
   useEffect(() => {
     const handleUrl = (url: string | null) => {
       const sessionId = extractSessionIdFromDeepLink(url);

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Platform, UIManager, TouchableOpacity, Text } from 'react-native';
+import { Platform, UIManager, TouchableOpacity, Text, Linking } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator, NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -19,9 +19,10 @@ import { ConnectionAnnouncer } from './components/ConnectionAnnouncer';
 import { useConnectionStore } from './store/connection';
 import { disconnectWithQueueGuard } from './store/disconnectWithQueueGuard';
 import { useConnectionLifecycleStore } from './store/connection-lifecycle';
-import { setupNotificationResponseListener } from './notifications';
+import { setupNotificationResponseListener, handleColdStartNotificationResponse } from './notifications';
 import { useBiometricLock } from './hooks/useBiometricLock';
 import { useNotificationStore } from './store/notifications';
+import { extractSessionIdFromDeepLink } from './utils/session-deep-link';
 
 // Enable LayoutAnimation on Android (must be called before any component uses it)
 if (Platform.OS === 'android') {
@@ -69,8 +70,30 @@ export default function App() {
 
   useEffect(() => {
     const sub = setupNotificationResponseListener();
+    // #6792 — replay the notification response that already launched the
+    // app (cold start): the live listener above only sees responses
+    // delivered after it's attached.
+    void handleColdStartNotificationResponse();
     // Load persistent activity history on mount
     void useNotificationStore.getState().loadActivityHistory();
+    return () => sub.remove();
+  }, []);
+
+  // #6792 — route a `chroxy://open?session=<id>` deep link (today: the iOS
+  // Live Activity's deepLinkUrl) to the session it names, reusing the same
+  // switchSession primitive as the notification-tap and in-app banner
+  // paths. Covers both cold start (Linking.getInitialURL — the app was
+  // launched by opening the URL) and warm (the 'url' event — the app was
+  // already running). A URL with no `session` param, or that isn't the
+  // chroxy scheme, is a no-op here (e.g. pairing links stay handled by
+  // ConnectScreen's own parser).
+  useEffect(() => {
+    const handleUrl = (url: string | null) => {
+      const sessionId = extractSessionIdFromDeepLink(url);
+      if (sessionId) useConnectionStore.getState().switchSession(sessionId);
+    };
+    Linking.getInitialURL().then(handleUrl).catch(() => {});
+    const sub = Linking.addEventListener('url', ({ url }) => handleUrl(url));
     return () => sub.remove();
   }, []);
 

--- a/packages/app/src/__tests__/notifications.test.ts
+++ b/packages/app/src/__tests__/notifications.test.ts
@@ -10,6 +10,7 @@ jest.mock('expo-notifications', () => ({
   setNotificationCategoryAsync: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(),
   getLastNotificationResponse: jest.fn(() => null),
+  clearLastNotificationResponse: jest.fn(),
   getPermissionsAsync: jest.fn(() =>
     Promise.resolve({ status: 'granted' }),
   ),
@@ -72,6 +73,8 @@ const mockAddListener =
   Notifications.addNotificationResponseReceivedListener as jest.Mock;
 const mockGetLastNotificationResponse =
   Notifications.getLastNotificationResponse as jest.Mock;
+const mockClearLastNotificationResponse =
+  Notifications.clearLastNotificationResponse as jest.Mock;
 
 const originalFetch = global.fetch;
 
@@ -79,6 +82,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockSocket.readyState = 1; // WebSocket.OPEN
   mockGetLastNotificationResponse.mockReturnValue(null);
+  // Reset to a plain no-op — clearAllMocks() clears call history but NOT a
+  // .mockImplementation set by an earlier test (e.g. the throw-path case).
+  mockClearLastNotificationResponse.mockImplementation(() => {});
   // Reset getState mock to default
   const { useConnectionStore } = require('../store/connection');
   useConnectionStore.getState.mockReturnValue({
@@ -703,6 +709,52 @@ describe('handleColdStartNotificationResponse', () => {
 
     expect(mockSwitchSession).toHaveBeenCalledWith('sess-cold-start');
     expect(mockSocket.send).not.toHaveBeenCalled();
+  });
+
+  it('clears the last notification response after handling it (no stale re-fire on a later launch)', async () => {
+    mockGetLastNotificationResponse.mockReturnValue({
+      actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+      notification: {
+        request: {
+          identifier: 'notif-cold-start-clear',
+          content: {
+            data: { category: 'activity_update', sessionId: 'sess-cold-clear' },
+          },
+        },
+      },
+    });
+
+    await handleColdStartNotificationResponse();
+
+    expect(mockClearLastNotificationResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear when there is no last response to handle', async () => {
+    mockGetLastNotificationResponse.mockReturnValue(null);
+
+    await handleColdStartNotificationResponse();
+
+    expect(mockClearLastNotificationResponse).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully when clearLastNotificationResponse throws (still switches session)', async () => {
+    mockGetLastNotificationResponse.mockReturnValue({
+      actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+      notification: {
+        request: {
+          identifier: 'notif-cold-start-clear-throws',
+          content: {
+            data: { category: 'activity_update', sessionId: 'sess-cold-clear-throw' },
+          },
+        },
+      },
+    });
+    mockClearLastNotificationResponse.mockImplementation(() => {
+      throw new Error('UnavailabilityError');
+    });
+
+    await expect(handleColdStartNotificationResponse()).resolves.toBeUndefined();
+    expect(mockSwitchSession).toHaveBeenCalledWith('sess-cold-clear-throw');
   });
 
   it('does not double-deliver a WS decision if the live listener also replays the same response', async () => {

--- a/packages/app/src/__tests__/notifications.test.ts
+++ b/packages/app/src/__tests__/notifications.test.ts
@@ -9,6 +9,7 @@ jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
   setNotificationCategoryAsync: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(),
+  getLastNotificationResponse: jest.fn(() => null),
   getPermissionsAsync: jest.fn(() =>
     Promise.resolve({ status: 'granted' }),
   ),
@@ -47,6 +48,7 @@ const mockSocket = {
 };
 
 const mockMarkPromptAnsweredByRequestId = jest.fn();
+const mockSwitchSession = jest.fn();
 
 jest.mock('../store/connection', () => ({
   useConnectionStore: {
@@ -55,6 +57,7 @@ jest.mock('../store/connection', () => ({
       apiToken: 'test-token',
       socket: mockSocket,
       markPromptAnsweredByRequestId: mockMarkPromptAnsweredByRequestId,
+      switchSession: mockSwitchSession,
     })),
   },
   loadConnection: jest.fn(() =>
@@ -63,16 +66,19 @@ jest.mock('../store/connection', () => ({
 }));
 
 // Import after mocks
-import { setupNotificationResponseListener } from '../notifications';
+import { setupNotificationResponseListener, handleColdStartNotificationResponse } from '../notifications';
 
 const mockAddListener =
   Notifications.addNotificationResponseReceivedListener as jest.Mock;
+const mockGetLastNotificationResponse =
+  Notifications.getLastNotificationResponse as jest.Mock;
 
 const originalFetch = global.fetch;
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockSocket.readyState = 1; // WebSocket.OPEN
+  mockGetLastNotificationResponse.mockReturnValue(null);
   // Reset getState mock to default
   const { useConnectionStore } = require('../store/connection');
   useConnectionStore.getState.mockReturnValue({
@@ -80,6 +86,7 @@ beforeEach(() => {
     apiToken: 'test-token',
     socket: mockSocket,
     markPromptAnsweredByRequestId: mockMarkPromptAnsweredByRequestId,
+    switchSession: mockSwitchSession,
   });
 });
 
@@ -161,6 +168,113 @@ describe('setupNotificationResponseListener', () => {
 
     expect(mockSocket.send).not.toHaveBeenCalled();
     expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
+  });
+
+  // #6792 — a notification tap must route to the session that triggered it.
+  describe('routes to the triggering session (#6792)', () => {
+    it('default tap with a sessionId switches session and sends no WS/HTTP', async () => {
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
+
+      await handler({
+        actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+        notification: {
+          request: {
+            identifier: 'notif-default-tap-1',
+            content: {
+              data: { category: 'permission', requestId: 'perm-route-1', sessionId: 'sess-abc' },
+            },
+          },
+        },
+      });
+
+      expect(mockSwitchSession).toHaveBeenCalledWith('sess-abc');
+      expect(mockSocket.send).not.toHaveBeenCalled();
+      expect(mockMarkPromptAnsweredByRequestId).not.toHaveBeenCalled();
+    });
+
+    it('default tap on a non-permission category (idle/waiting) still switches session', async () => {
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
+
+      await handler({
+        actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+        notification: {
+          request: {
+            identifier: 'notif-default-tap-2',
+            content: {
+              data: { category: 'activity_waiting', sessionId: 'sess-waiting' },
+            },
+          },
+        },
+      });
+
+      expect(mockSwitchSession).toHaveBeenCalledWith('sess-waiting');
+      expect(mockSocket.send).not.toHaveBeenCalled();
+    });
+
+    it('approve action switches session AND sends the WS decision', async () => {
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
+
+      await handler({
+        actionIdentifier: 'approve',
+        notification: {
+          request: {
+            identifier: 'notif-approve-route-1',
+            content: {
+              data: { category: 'permission', requestId: 'perm-route-2', sessionId: 'sess-def' },
+            },
+          },
+        },
+      });
+
+      expect(mockSwitchSession).toHaveBeenCalledWith('sess-def');
+      expect(mockSocket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'permission_response', requestId: 'perm-route-2', decision: 'allow' }),
+      );
+    });
+
+    it('does not switch session when the payload has no sessionId', async () => {
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
+
+      await handler({
+        actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+        notification: {
+          request: {
+            identifier: 'notif-no-session-1',
+            content: {
+              data: { category: 'permission', requestId: 'perm-no-session' },
+            },
+          },
+        },
+      });
+
+      expect(mockSwitchSession).not.toHaveBeenCalled();
+    });
+
+    it('dedupes the same notification delivered twice — no duplicate WS send', async () => {
+      setupNotificationResponseListener();
+      const handler = mockAddListener.mock.calls[0][0];
+      const response = {
+        actionIdentifier: 'approve',
+        notification: {
+          request: {
+            identifier: 'notif-dedupe-1',
+            content: {
+              data: { category: 'permission', requestId: 'perm-dedupe-1', sessionId: 'sess-dedupe' },
+            },
+          },
+        },
+      };
+
+      await handler(response);
+      await handler(response);
+
+      expect(mockSwitchSession).toHaveBeenCalledTimes(1);
+      expect(mockSocket.send).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('ignores unknown action identifiers', async () => {
@@ -556,5 +670,73 @@ describe('setupNotificationResponseListener', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+});
+
+// #6792 — cold start: the app was launched by tapping a notification, so
+// addNotificationResponseReceivedListener never fires for it (it only sees
+// responses delivered after a listener attaches). getLastNotificationResponse()
+// replays it instead.
+describe('handleColdStartNotificationResponse', () => {
+  it('does nothing when there is no last notification response', async () => {
+    mockGetLastNotificationResponse.mockReturnValue(null);
+
+    await handleColdStartNotificationResponse();
+
+    expect(mockSwitchSession).not.toHaveBeenCalled();
+  });
+
+  it('switches to the session named by the launching notification (default tap)', async () => {
+    mockGetLastNotificationResponse.mockReturnValue({
+      actionIdentifier: 'expo.modules.notifications.actions.DEFAULT',
+      notification: {
+        request: {
+          identifier: 'notif-cold-start-1',
+          content: {
+            data: { category: 'activity_update', sessionId: 'sess-cold-start' },
+          },
+        },
+      },
+    });
+
+    await handleColdStartNotificationResponse();
+
+    expect(mockSwitchSession).toHaveBeenCalledWith('sess-cold-start');
+    expect(mockSocket.send).not.toHaveBeenCalled();
+  });
+
+  it('does not double-deliver a WS decision if the live listener also replays the same response', async () => {
+    const response = {
+      actionIdentifier: 'approve',
+      notification: {
+        request: {
+          identifier: 'notif-cold-start-2',
+          content: {
+            data: { category: 'permission', requestId: 'perm-cold-2', sessionId: 'sess-cold-2' },
+          },
+        },
+      },
+    };
+    mockGetLastNotificationResponse.mockReturnValue(response);
+
+    // Cold-start replay handles it first...
+    await handleColdStartNotificationResponse();
+    // ...then the live listener (registered in the same mount effect) sees
+    // the SAME response replayed natively.
+    setupNotificationResponseListener();
+    const handler = mockAddListener.mock.calls[0][0];
+    await handler(response);
+
+    expect(mockSwitchSession).toHaveBeenCalledTimes(1);
+    expect(mockSocket.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades gracefully when getLastNotificationResponse throws (unavailable on this platform)', async () => {
+    mockGetLastNotificationResponse.mockImplementation(() => {
+      throw new Error('UnavailabilityError');
+    });
+
+    await expect(handleColdStartNotificationResponse()).resolves.toBeUndefined();
+    expect(mockSwitchSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/__tests__/utils/session-deep-link.test.ts
+++ b/packages/app/src/__tests__/utils/session-deep-link.test.ts
@@ -13,6 +13,11 @@ describe('extractSessionIdFromDeepLink', () => {
     expect(extractSessionIdFromDeepLink('chroxy://')).toBeNull();
   });
 
+  it('returns null for an empty or whitespace-only session param (contract: null on no id)', () => {
+    expect(extractSessionIdFromDeepLink('chroxy://open?session=')).toBeNull();
+    expect(extractSessionIdFromDeepLink('chroxy://open?session=%20%20')).toBeNull();
+  });
+
   it('returns null for null/undefined/empty input', () => {
     expect(extractSessionIdFromDeepLink(null)).toBeNull();
     expect(extractSessionIdFromDeepLink(undefined)).toBeNull();

--- a/packages/app/src/__tests__/utils/session-deep-link.test.ts
+++ b/packages/app/src/__tests__/utils/session-deep-link.test.ts
@@ -1,0 +1,42 @@
+import { extractSessionIdFromDeepLink } from '../../utils/session-deep-link';
+
+// #6792 — the iOS Live Activity's deepLinkUrl (and any future chroxy://
+// deep-link source) carries the originating session id so a tap can route
+// back to it via App.tsx's Linking listener.
+describe('extractSessionIdFromDeepLink', () => {
+  it('extracts the session id from a chroxy://open?session=<id> URL', () => {
+    expect(extractSessionIdFromDeepLink('chroxy://open?session=sess-123')).toBe('sess-123');
+  });
+
+  it('returns null for a bare chroxy:// URL with no session param', () => {
+    expect(extractSessionIdFromDeepLink('chroxy://open')).toBeNull();
+    expect(extractSessionIdFromDeepLink('chroxy://')).toBeNull();
+  });
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(extractSessionIdFromDeepLink(null)).toBeNull();
+    expect(extractSessionIdFromDeepLink(undefined)).toBeNull();
+    expect(extractSessionIdFromDeepLink('')).toBeNull();
+  });
+
+  it('returns null for a non-chroxy URL', () => {
+    expect(extractSessionIdFromDeepLink('https://example.com?session=sess-1')).toBeNull();
+  });
+
+  it('ignores the pairing flow\'s chroxy://host?pair=... / ?token=... URLs (no session param)', () => {
+    expect(extractSessionIdFromDeepLink('chroxy://example.com?pair=abc123')).toBeNull();
+    expect(extractSessionIdFromDeepLink('chroxy://example.com?token=xyz')).toBeNull();
+  });
+
+  it('decodes a URL-encoded session id', () => {
+    expect(extractSessionIdFromDeepLink('chroxy://open?session=sess%20with%20space')).toBe('sess with space');
+  });
+
+  it('returns null for a malformed chroxy:// URL', () => {
+    expect(extractSessionIdFromDeepLink('chroxy://[invalid')).toBeNull();
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(extractSessionIdFromDeepLink('  chroxy://open?session=sess-trim  ')).toBe('sess-trim');
+  });
+});

--- a/packages/app/src/ios-live-activity/live-activity-bridge.ts
+++ b/packages/app/src/ios-live-activity/live-activity-bridge.ts
@@ -85,8 +85,8 @@ const WIDGET_CONFIG_BASE = {
  * originating session (#6792) so tapping the Live Activity on the Lock
  * Screen / Dynamic Island routes straight to that session instead of the
  * app's default screen. `App.tsx`'s Linking handler parses the `session`
- * query param back out. Falls back to a bare `chroxy://` (pre-#6792
- * behavior — opens the app, no routing) when no sessionId is available yet.
+ * query param back out. Falls back to `chroxy://open` (no `session` param —
+ * opens the app, no session routing) when no sessionId is available yet.
  */
 function buildWidgetConfig(sessionId?: string) {
   return {

--- a/packages/app/src/ios-live-activity/live-activity-bridge.ts
+++ b/packages/app/src/ios-live-activity/live-activity-bridge.ts
@@ -73,20 +73,36 @@ function stateToSubtitle(
   }
 }
 
-/** Chroxy Live Activity widget config — dark theme matching the app. */
-const WIDGET_CONFIG = {
+/** Chroxy Live Activity widget config (minus the session-scoped deep link) — dark theme matching the app. */
+const WIDGET_CONFIG_BASE = {
   backgroundColor: '#0f0f1a',
   titleColor: '#ffffff',
   subtitleColor: '#a0a0b0',
-  deepLinkUrl: 'chroxy://',
 } as const;
+
+/**
+ * Build the widget config for a Live Activity, scoping `deepLinkUrl` to the
+ * originating session (#6792) so tapping the Live Activity on the Lock
+ * Screen / Dynamic Island routes straight to that session instead of the
+ * app's default screen. `App.tsx`'s Linking handler parses the `session`
+ * query param back out. Falls back to a bare `chroxy://` (pre-#6792
+ * behavior — opens the app, no routing) when no sessionId is available yet.
+ */
+function buildWidgetConfig(sessionId?: string) {
+  return {
+    ...WIDGET_CONFIG_BASE,
+    deepLinkUrl: sessionId
+      ? `chroxy://open?session=${encodeURIComponent(sessionId)}`
+      : 'chroxy://open',
+  };
+}
 
 /**
  * Request a new Live Activity. Returns the activity ID, or null if
  * the native module is unavailable or the request fails.
  */
 export async function startLiveActivity(
-  _attributes: LiveActivityAttributes,
+  attributes: LiveActivityAttributes,
   initialState: LiveActivityContentState,
 ): Promise<string | null> {
   const mod = getNativeModule();
@@ -98,7 +114,7 @@ export async function startLiveActivity(
         title: 'Chroxy',
         subtitle: stateToSubtitle(initialState.state, initialState.detail, initialState.elapsedSeconds),
       },
-      WIDGET_CONFIG,
+      buildWidgetConfig(attributes.sessionId),
     );
     return id ?? null;
   } catch {

--- a/packages/app/src/ios-live-activity/live-activity-manager.ts
+++ b/packages/app/src/ios-live-activity/live-activity-manager.ts
@@ -68,14 +68,14 @@ export class LiveActivityManager {
    * Start a new Live Activity for the given session.
    * No-ops if unsupported or if one is already active.
    */
-  async start(sessionName: string): Promise<void> {
+  async start(sessionName: string, sessionId?: string): Promise<void> {
     if (!this._supported) return;
     if (this._activityId !== null) return;
 
     this._startedAt = Date.now();
 
     const id = await startLiveActivity(
-      { sessionName },
+      { sessionName, sessionId },
       { state: 'active', elapsedSeconds: 0 },
     );
 

--- a/packages/app/src/ios-live-activity/types.ts
+++ b/packages/app/src/ios-live-activity/types.ts
@@ -12,6 +12,11 @@ export type LiveActivityState = 'active' | 'thinking' | 'waiting' | 'error' | 'e
 /** Attributes set once when the Live Activity is started (immutable). */
 export interface LiveActivityAttributes {
   sessionName: string;
+  /** #6792 — the originating chroxy session id, threaded into the widget's
+   *  deep-link URL so tapping the Live Activity routes back to this session
+   *  instead of the app's default screen. Optional: absent when the Live
+   *  Activity starts before a session is active yet. */
+  sessionId?: string;
 }
 
 /** Content state that can be updated while the Live Activity is running. */

--- a/packages/app/src/ios-live-activity/useLiveActivity.ts
+++ b/packages/app/src/ios-live-activity/useLiveActivity.ts
@@ -49,7 +49,7 @@ export function useLiveActivity(): LiveActivityHookResult {
         isActiveRef.current = true;
         const session = activeId ? state.sessions.find((s) => s.sessionId === activeId) : undefined;
         const sessionName = session?.name ?? 'Session';
-        void manager.start(sessionName).then(() => {
+        void manager.start(sessionName, activeId ?? undefined).then(() => {
           // Send initial state update after start
           const liveState = mapActivityState(activityState);
           void manager.update(liveState, activity?.detail);

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -351,4 +351,14 @@ export async function handleColdStartNotificationResponse(): Promise<void> {
   }
   if (!response) return;
   await handleNotificationResponse(response);
+  // #6792: explicitly clear the last response once handled so a LATER normal
+  // launch can't re-replay this same stale cold-start tap. The identifier
+  // dedupe + server idempotency already neutralize a re-fire, but clearing
+  // makes the safety explicit. Guarded — unavailable on some platform/SDK
+  // builds, and a clear failure must not throw out of the mount effect.
+  try {
+    Notifications.clearLastNotificationResponse();
+  } catch (err) {
+    console.log('[push] clearLastNotificationResponse unavailable:', err);
+  }
 }

--- a/packages/app/src/notifications.ts
+++ b/packages/app/src/notifications.ts
@@ -197,85 +197,158 @@ async function sendPermissionResponseHttp(
   return false;
 }
 
+/** Shape of the `data` payload a Chroxy push notification's response can carry. */
+type NotificationResponseData = {
+  category?: string;
+  requestId?: string;
+  sessionId?: string;
+  tool?: string;
+};
+
+// #6792: getLastNotificationResponse() (cold start — see
+// handleColdStartNotificationResponse below) and the live
+// addNotificationResponseReceivedListener can both deliver the SAME
+// response — dedupe by the notification's own identifier so an
+// action-button tap (approve/deny) is never sent to the server twice.
+let _lastHandledNotificationId: string | null = null;
+
 /**
- * Set up a listener for notification action responses (Approve/Deny buttons).
- * Returns the subscription — caller should call .remove() on cleanup.
+ * Handle a single notification response — shared by the live listener
+ * (setupNotificationResponseListener) and the cold-start replay
+ * (handleColdStartNotificationResponse). Two responsibilities:
+ *
+ *  1. Route to the session that triggered the notification (#6792). Every
+ *     push category that has a triggering session carries a `sessionId` in
+ *     its data (permission, activity_update, activity_waiting,
+ *     activity_error, inactivity_warning — see push.js / ws-permissions.js /
+ *     event-normalizer.js / push-notification-handler.js). Reuses the same
+ *     `switchSession` primitive as the in-app SessionNotificationBanner and
+ *     sendPermissionResponse's auto-switch, so a tap — whether the
+ *     notification body (default action) or an action button — always
+ *     lands on the right session. `switchSession` no-ops if the session id
+ *     isn't in the client's session list yet (e.g. reconnect still in
+ *     flight); it optimistically sets `activeSessionId` and the UI degrades
+ *     gracefully (SessionScreen reads via `sessions.find(...)`, which is
+ *     `undefined`-safe) rather than crashing.
+ *  2. For the 'permission' category's Approve/Deny action buttons only,
+ *     also deliver the decision over WS/HTTP — unchanged from the
+ *     pre-#6792 behavior. The default tap is pure navigation, no WS send.
  */
-export function setupNotificationResponseListener(): Notifications.EventSubscription {
+async function handleNotificationResponse(
+  response: Notifications.NotificationResponse,
+): Promise<void> {
+  const notificationId = response.notification?.request?.identifier;
+  if (notificationId && notificationId === _lastHandledNotificationId) return;
+  if (notificationId) _lastHandledNotificationId = notificationId;
+
   // Lazy import to break require cycle: connection → message-handler → notifications → connection
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { useConnectionStore }: {
     useConnectionStore: typeof import('./store/connection')['useConnectionStore'];
   } = require('./store/connection');
 
-  return Notifications.addNotificationResponseReceivedListener(async (response) => {
-    const actionId = response.actionIdentifier;
+  const actionId = response.actionIdentifier;
+  const data = response.notification.request.content.data as
+    | NotificationResponseData
+    | undefined;
 
-    // Ignore default tap (just opens app) — only handle explicit action buttons
-    if (actionId === Notifications.DEFAULT_ACTION_IDENTIFIER) return;
+  if (data?.sessionId) {
+    useConnectionStore.getState().switchSession(data.sessionId);
+  }
 
-    const data = response.notification.request.content.data as
-      | { category?: string; requestId?: string }
-      | undefined;
+  // Default tap (notification body, not an action button) is pure
+  // navigation — the switchSession call above already handled it.
+  if (actionId === Notifications.DEFAULT_ACTION_IDENTIFIER) return;
 
-    if (data?.category !== 'permission' || !data.requestId) return;
+  if (data?.category !== 'permission' || !data.requestId) return;
 
-    const { requestId } = data;
+  const { requestId } = data;
 
-    // Explicitly handle only known action identifiers
-    let decision: 'allow' | 'deny';
-    if (actionId === 'approve') {
-      decision = 'allow';
-    } else if (actionId === 'deny') {
-      decision = 'deny';
-    } else {
-      // Ignore unexpected action identifiers
-      return;
-    }
+  // Explicitly handle only known action identifiers
+  let decision: 'allow' | 'deny';
+  if (actionId === 'approve') {
+    decision = 'allow';
+  } else if (actionId === 'deny') {
+    decision = 'deny';
+  } else {
+    // Ignore unexpected action identifiers
+    return;
+  }
 
-    console.log(`[push] Notification action: ${actionId} → ${decision} for ${requestId}`);
+  console.log(`[push] Notification action: ${actionId} → ${decision} for ${requestId}`);
 
-    // Try WebSocket first if connected
-    let delivered = false;
-    const { socket } = useConnectionStore.getState();
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      socket.send(
-        JSON.stringify({ type: 'permission_response', requestId, decision }),
-      );
-      console.log(`[push] Permission ${requestId} sent via WS: ${decision}`);
-      delivered = true;
-    } else {
-      // Fall back to HTTP POST via Cloudflare tunnel
-      delivered = await sendPermissionResponseHttp(requestId, decision);
-    }
+  // Try WebSocket first if connected
+  let delivered = false;
+  const { socket } = useConnectionStore.getState();
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(
+      JSON.stringify({ type: 'permission_response', requestId, decision }),
+    );
+    console.log(`[push] Permission ${requestId} sent via WS: ${decision}`);
+    delivered = true;
+  } else {
+    // Fall back to HTTP POST via Cloudflare tunnel
+    delivered = await sendPermissionResponseHttp(requestId, decision);
+  }
 
-    // Only update chat UI if the response was actually delivered
-    if (delivered) {
-      useConnectionStore.getState().markPromptAnsweredByRequestId(requestId, decision);
-    } else {
-      console.warn(`[push] Permission ${requestId} could not be delivered — UI not updated`);
-      Alert.alert(
-        'Permission Response Failed',
-        'Could not deliver your response. Open the app to respond manually.',
-        [
-          { text: 'OK', style: 'cancel' },
-          {
-            text: 'Retry',
-            onPress: () => {
-              sendPermissionResponseHttp(requestId, decision).then((ok) => {
-                if (ok) {
-                  useConnectionStore.getState().markPromptAnsweredByRequestId(requestId, decision);
-                } else {
-                  Alert.alert('Still Failed', 'Open the app to respond manually.');
-                }
-              }).catch(() => {
-                // Already logged inside sendPermissionResponseHttp
+  // Only update chat UI if the response was actually delivered
+  if (delivered) {
+    useConnectionStore.getState().markPromptAnsweredByRequestId(requestId, decision);
+  } else {
+    console.warn(`[push] Permission ${requestId} could not be delivered — UI not updated`);
+    Alert.alert(
+      'Permission Response Failed',
+      'Could not deliver your response. Open the app to respond manually.',
+      [
+        { text: 'OK', style: 'cancel' },
+        {
+          text: 'Retry',
+          onPress: () => {
+            sendPermissionResponseHttp(requestId, decision).then((ok) => {
+              if (ok) {
+                useConnectionStore.getState().markPromptAnsweredByRequestId(requestId, decision);
+              } else {
                 Alert.alert('Still Failed', 'Open the app to respond manually.');
-              });
-            },
+              }
+            }).catch(() => {
+              // Already logged inside sendPermissionResponseHttp
+              Alert.alert('Still Failed', 'Open the app to respond manually.');
+            });
           },
-        ],
-      );
-    }
-  });
+        },
+      ],
+    );
+  }
+}
+
+/**
+ * Set up a listener for notification responses — both the default tap
+ * (notification body) and the explicit Approve/Deny action buttons.
+ * Returns the subscription — caller should call .remove() on cleanup.
+ */
+export function setupNotificationResponseListener(): Notifications.EventSubscription {
+  return Notifications.addNotificationResponseReceivedListener(handleNotificationResponse);
+}
+
+/**
+ * Replay the notification response that already launched the app (cold
+ * start) — tapping a notification while Chroxy wasn't running at all.
+ * `addNotificationResponseReceivedListener` only delivers responses
+ * received AFTER a JS listener is attached; the one that woke the process
+ * has to be read back explicitly (#6792). Call once on mount, alongside
+ * `setupNotificationResponseListener` — `handleNotificationResponse`'s
+ * dedupe guard makes the call order and any native replay of the same
+ * response safe either way.
+ */
+export async function handleColdStartNotificationResponse(): Promise<void> {
+  let response: Notifications.NotificationResponse | null = null;
+  try {
+    response = Notifications.getLastNotificationResponse();
+  } catch (err) {
+    // Unavailable on this platform/SDK build (e.g. Expo Go) — nothing to replay.
+    console.log('[push] getLastNotificationResponse unavailable:', err);
+    return;
+  }
+  if (!response) return;
+  await handleNotificationResponse(response);
 }

--- a/packages/app/src/utils/session-deep-link.ts
+++ b/packages/app/src/utils/session-deep-link.ts
@@ -9,9 +9,11 @@
  *
  * Returns null for anything that isn't the chroxy scheme, or that doesn't
  * carry a `session` query param — including the pairing flow's
- * `chroxy://host?pair=...` / `chroxy://host?token=...` URLs, which
- * ConnectScreen's QR-scan/manual-entry paths already handle via
- * `parseChroxyUrl` and never reach the OS-level Linking listener today.
+ * `chroxy://host?pair=...` / `chroxy://host?token=...` URLs. Those CAN reach
+ * App.tsx's global Linking listener (it's the app's only OS-level deep-link
+ * handler; ConnectScreen parses pairing URLs from QR-scan/manual-entry via
+ * `parseChroxyUrl`, not from the Linking API) — this null return is exactly
+ * what makes the listener ignore them safely.
  */
 export function extractSessionIdFromDeepLink(url: string | null | undefined): string | null {
   if (!url) return null;

--- a/packages/app/src/utils/session-deep-link.ts
+++ b/packages/app/src/utils/session-deep-link.ts
@@ -19,7 +19,11 @@ export function extractSessionIdFromDeepLink(url: string | null | undefined): st
   if (!trimmed.startsWith('chroxy://')) return null;
   try {
     const parsed = new URL(trimmed.replace('chroxy://', 'https://'));
-    return parsed.searchParams.get('session');
+    // `?session=` (present but empty) or `?session=%20%20` parses to '' /
+    // whitespace — treat that as "no id" per the contract above rather than
+    // returning a blank string a caller would switchSession() to.
+    const sessionId = parsed.searchParams.get('session')?.trim();
+    return sessionId ? sessionId : null;
   } catch {
     return null;
   }

--- a/packages/app/src/utils/session-deep-link.ts
+++ b/packages/app/src/utils/session-deep-link.ts
@@ -1,0 +1,26 @@
+/**
+ * Parse a Chroxy deep link for a session id (#6792).
+ *
+ * Handles the `chroxy://open?session=<id>` shape used by the iOS Live
+ * Activity's `deepLinkUrl` (ios-live-activity/live-activity-bridge.ts) —
+ * tapping the Live Activity on the Lock Screen / Dynamic Island now opens
+ * this URL instead of a bare `chroxy://`, so App.tsx's Linking listener can
+ * route straight back to the originating session.
+ *
+ * Returns null for anything that isn't the chroxy scheme, or that doesn't
+ * carry a `session` query param — including the pairing flow's
+ * `chroxy://host?pair=...` / `chroxy://host?token=...` URLs, which
+ * ConnectScreen's QR-scan/manual-entry paths already handle via
+ * `parseChroxyUrl` and never reach the OS-level Linking listener today.
+ */
+export function extractSessionIdFromDeepLink(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed.startsWith('chroxy://')) return null;
+  try {
+    const parsed = new URL(trimmed.replace('chroxy://', 'https://'));
+    return parsed.searchParams.get('session');
+  } catch {
+    return null;
+  }
+}

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -589,7 +589,12 @@ Object.assign(EVENT_MAP, {
       category: 'permission',
       title: 'Permission needed',
       body: `Claude wants to use: ${data.tool}`,
-      data: { requestId: data.requestId, tool: data.tool },
+      // #6792: carry the triggering sessionId in the push data (data-only,
+      // doesn't change the visible notification) so a notification tap can
+      // route straight to this session — matches the registration above and
+      // the sessionId already carried by the HTTP hook path's push
+      // (ws-permissions.js) and the activity_* pushes.
+      data: { requestId: data.requestId, tool: data.tool, sessionId: ctx.sessionId },
       channelId: 'permission',
     }],
   }),

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -593,8 +593,10 @@ Object.assign(EVENT_MAP, {
       // doesn't change the visible notification) so a notification tap can
       // route straight to this session — matches the registration above and
       // the sessionId already carried by the HTTP hook path's push
-      // (ws-permissions.js) and the activity_* pushes.
-      data: { requestId: data.requestId, tool: data.tool, sessionId: ctx.sessionId },
+      // (ws-permissions.js) and the activity_* pushes. #6847 "omit not null":
+      // include the key ONLY when truthy so the wire shape matches the HTTP
+      // hook path (ws-permissions.js), which omits it for the null-ctx path.
+      data: { requestId: data.requestId, tool: data.tool, ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}) },
       channelId: 'permission',
     }],
   }),

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -251,8 +251,16 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // #5702 (8d): settle the fire-and-forget send so a failed phone
         // notification is logged (named), not silently dropped while the
         // dashboard card still appears.
+        // #6792: carry the owning sessionId in the push data payload (data-only,
+        // doesn't change the visible notification) so the app can route a
+        // notification tap straight to the session that asked, instead of the
+        // OS just opening the app to its default screen. Mirrors the
+        // sessionId already included in the broadcastFn call above (#5667)
+        // and in the activity_update/activity_waiting/inactivity_warning
+        // pushes (push-notification-handler.js). Omitted (not null) when the
+        // request maps to no chroxy session, matching the broadcast's convention.
         settlePush(
-          pushManager.send('permission', 'Permission needed', `Claude wants to use: ${tool}`, { requestId, tool }, 'permission'),
+          pushManager.send('permission', 'Permission needed', `Claude wants to use: ${tool}`, { requestId, tool, sessionId: ownerSessionId || undefined }, 'permission'),
           `permission requested: ${tool}`,
           log,
         )

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -688,6 +688,15 @@ describe('EventNormalizer', () => {
       assert.equal(pushEffect.category, 'permission')
       assert.ok(pushEffect.body.includes('Bash'))
     })
+
+    it('includes ctx.sessionId in the push data so a notification tap can route to it (#6792)', () => {
+      const data = { requestId: 'req-1', tool: 'Bash', description: 'run ls', input: 'ls', remainingMs: 60000 }
+      const result = normalizer.normalize('permission_request', data, makeCtx({ sessionId: 'sess-push' }))
+      const pushEffect = result.sideEffects.find(se => se.type === 'push')
+      assert.equal(pushEffect.data.sessionId, 'sess-push')
+      assert.equal(pushEffect.data.requestId, 'req-1')
+      assert.equal(pushEffect.data.tool, 'Bash')
+    })
   })
 
   // ---- EVENT_MAP: permission_resolved (#3048) ----

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -697,6 +697,15 @@ describe('EventNormalizer', () => {
       assert.equal(pushEffect.data.requestId, 'req-1')
       assert.equal(pushEffect.data.tool, 'Bash')
     })
+
+    it('omits the sessionId key entirely when ctx.sessionId is falsy (#6847 omit-not-null, #6792)', () => {
+      const data = { requestId: 'req-1', tool: 'Bash', description: 'run ls', input: 'ls', remainingMs: 60000 }
+      const result = normalizer.normalize('permission_request', data, makeCtx({ sessionId: null }))
+      const pushEffect = result.sideEffects.find(se => se.type === 'push')
+      // The key must be ABSENT, not present-as-null — matches the HTTP hook
+      // path's omit-when-falsy wire shape (ws-permissions.js).
+      assert.equal(Object.prototype.hasOwnProperty.call(pushEffect.data, 'sessionId'), false)
+    })
   })
 
   // ---- EVENT_MAP: permission_resolved (#3048) ----

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -465,6 +465,53 @@ describe('createPermissionHandler', () => {
       assert.equal(pushManager.send.mock.calls.length, 1)
     })
 
+    it('includes sessionId in the push data when the hook resolves to a chroxy session (#6792)', async () => {
+      // The push payload must carry the owning sessionId so a notification
+      // tap can route straight to the session that asked, instead of the OS
+      // just opening the app to its default screen.
+      const pushManager = { send: mock.fn() }
+      const ownerSession = {
+        notifyPermissionPending: mock.fn(),
+        notifyPermissionResolved: mock.fn(),
+      }
+      const findSessionByHookSecret = mock.fn(() => ({
+        session: ownerSession,
+        sessionId: 'chroxy-sess-push',
+      }))
+      const opts = makeHandlerOpts({ pushManager, findSessionByHookSecret })
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+      const body = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+      const req = makeReq(body, { authorization: 'Bearer hook-secret-push' })
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(pushManager.send.mock.calls.length, 1)
+      const pushData = pushManager.send.mock.calls[0].arguments[3]
+      assert.equal(pushData.sessionId, 'chroxy-sess-push',
+        'push data must carry the owning sessionId so a notification tap can route to it (#6792)')
+    })
+
+    it('omits sessionId from the push data when the request maps to no chroxy session (#6792)', async () => {
+      // No hook secret → ownerSessionId stays null → the push must not
+      // invent a sessionId, matching the broadcast's #5667 convention.
+      const pushManager = { send: mock.fn() }
+      const opts = makeHandlerOpts({ pushManager })
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+      const body = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+      const req = makeReq(body)
+      const res = makeRes()
+      handlePermissionRequest(req, res)
+      await new Promise(r => setImmediate(r))
+
+      assert.equal(pushManager.send.mock.calls.length, 1)
+      const pushData = pushManager.send.mock.calls[0].arguments[3]
+      assert.equal(pushData.sessionId, undefined,
+        'unmapped requests must not carry an invented sessionId in the push data (#6792)')
+    })
+
     it('populates permissionSessionMap when hookSecret resolves to a chroxy session (#2832)', async () => {
       // Regression: paired clients (boundSessionId set) cannot approve
       // hook-originated permissions unless permissionSessionMap[requestId]


### PR DESCRIPTION
## Summary

Tapping a Chroxy push notification opened the app to its default screen instead of the session that triggered it. The default tap (notification body) was explicitly ignored, and the permission notification's Approve/Deny action buttons sent their decision without navigating anywhere — and the 'permission' category push didn't even carry a `sessionId` to route to.

- **Server**: both permission-push paths (the HTTP hook path in `ws-permissions.js`, and the SDK path in `event-normalizer.js`) now include `sessionId` in the push's data payload — a data-only addition, the visible notification is unchanged. Matches the `sessionId` convention already used by `activity_update` / `activity_waiting` / `activity_error` / `inactivity_warning` pushes.
- **App**: `notifications.ts`'s response handler now routes to the session named by the payload's `sessionId` for both the default tap (pure navigation) and the action buttons (navigation + the existing WS/HTTP decision send), reusing the same `switchSession` primitive the in-app `SessionNotificationBanner` and `sendPermissionResponse`'s auto-switch already use.
- **Cold start** (app launched by the tap): `handleColdStartNotificationResponse` replays `Notifications.getLastNotificationResponse()` on mount, since the live `addNotificationResponseReceivedListener` only sees responses delivered after it's attached. A dedupe guard (keyed on the notification's own identifier) prevents a native replay of the same response from double-sending a permission decision.
- **Graceful degradation**: `switchSession` optimistically sets `activeSessionId` without requiring the session to already be in the client's list; `SessionScreen` already reads the active session via `sessions.find(...)`, which is `undefined`-safe, so an unsynced/reconnecting session id never crashes — it just surfaces once the session list catches up.
- **Live Activity**: the iOS Live Activity's `deepLinkUrl` is now session-scoped (`chroxy://open?session=<id>`) instead of a bare `chroxy://`; a new `Linking` listener in `App.tsx` (cold start via `getInitialURL`, warm via the `url` event) parses it and routes the same way.

Closes #6792

## Test plan
- [x] Server: `packages/server/tests/ws-permissions.test.js` — new tests assert the push data includes `sessionId` when the hook resolves to a chroxy session, and omits it (no invented id) when unmapped.
- [x] Server: `packages/server/tests/event-normalizer.test.js` — new test asserts `ctx.sessionId` lands in the `permission_request` push effect's data.
- [x] App: `packages/app/src/__tests__/notifications.test.ts` — new tests cover default-tap routing, action-button routing + WS send, no-sessionId no-op, and response-dedupe (no duplicate WS send).
- [x] App: new `handleColdStartNotificationResponse` describe block — no-op with no last response, switches session from the launching notification, dedupes against a live-listener replay, degrades gracefully if the native API throws.
- [x] App: new `packages/app/src/__tests__/utils/session-deep-link.test.ts` for the Live Activity URL parser.
- [x] App: updated `ios-live-activity.test.ts` / `live-activity-manager.test.ts` for the session-scoped `deepLinkUrl`.
- [x] `packages/server/scripts/lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` — both green.
- [x] Full app `jest` suite (both `__tests__` roots) — 169 suites / 2217 tests passing.
- [x] `tsc --noEmit` — clean.