### PR TITLE
feat(dashboard,app): editable pre-write diff on the IDE file viewer + mobile FileEditor (#6544)

### DIFF
--- a/packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts
+++ b/packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ViewerPreWriteReview (#6544, IDE P3.3 feature A — mobile) — the editable
+ * pre-write diff surfaced inside the FileEditor.
+ *
+ * The app has no RN render harness (@testing-library/react-native is not a
+ * dep), so — matching the repo's mobile convention (FileEditor.test.ts is a
+ * source scan) — behavior is covered two ways:
+ *   1. Pure-logic tests of the correlation helpers (pathMatchesViewer /
+ *      findPendingWriteForFile): a pending write for the OPEN file is found;
+ *      the no-match / resolved(answered) / expired / non-reviewable gates.
+ *   2. A source scan pinning the wiring: it reuses PreWriteDiffReview, pulls the
+ *      input via requestPermissionInput, routes `editedInput` through
+ *      sendPermissionResponse on Approve (and drops it on Deny), and FileEditor
+ *      renders <ViewerPreWriteReview>.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ChatMessage } from '@chroxy/store-core';
+import { pathMatchesViewer, findPendingWriteForFile } from '../../components/ViewerPreWriteReview';
+
+const FILE = '/home/dev/project/src/app.ts';
+
+function editPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'perm-1',
+    type: 'prompt',
+    content: 'Edit: change app.ts',
+    tool: 'Edit',
+    requestId: 'req-1',
+    toolInput: { file_path: FILE, old_string: 'a\nb\nc', new_string: 'a\nB\nc' },
+    expiresAt: Date.now() + 60_000,
+    timestamp: Date.now(),
+    ...overrides,
+  } as ChatMessage;
+}
+
+describe('pathMatchesViewer', () => {
+  it('matches identical absolute paths', () => {
+    expect(pathMatchesViewer('/a/b/c.ts', '/a/b/c.ts')).toBe(true);
+  });
+  it('tail-matches an absolute file_path against a workspace-relative selection', () => {
+    expect(pathMatchesViewer('/root/pkg/src/x.ts', 'src/x.ts')).toBe(true);
+    expect(pathMatchesViewer('/root/pkg/src/x.ts', './src/x.ts')).toBe(true);
+  });
+  it('does not match unrelated files or when either side is empty', () => {
+    expect(pathMatchesViewer('/a/b/x.ts', '/a/b/y.ts')).toBe(false);
+    expect(pathMatchesViewer(null, '/a/b/x.ts')).toBe(false);
+    expect(pathMatchesViewer('/a/b/x.ts', null)).toBe(false);
+  });
+});
+
+describe('findPendingWriteForFile', () => {
+  const now = Date.now();
+
+  it('finds a live Write/Edit targeting the open file', () => {
+    expect(findPendingWriteForFile([editPrompt()], FILE, now)?.requestId).toBe('req-1');
+  });
+
+  it('ignores expired, resolved(answered), non-reviewable, or non-matching prompts', () => {
+    expect(findPendingWriteForFile([editPrompt({ expiresAt: now - 1 })], FILE, now)).toBeNull();
+    // resolved gate: markPromptAnswered / permission_resolved set `answered`.
+    expect(findPendingWriteForFile([editPrompt({ answered: 'allow' })], FILE, now)).toBeNull();
+    expect(findPendingWriteForFile([editPrompt({ tool: 'Bash' })], FILE, now)).toBeNull();
+    expect(findPendingWriteForFile([editPrompt()], '/other/file.ts', now)).toBeNull();
+    expect(findPendingWriteForFile([editPrompt()], null, now)).toBeNull();
+  });
+});
+
+describe('ViewerPreWriteReview — wiring (source scan)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/ViewerPreWriteReview.tsx'),
+    'utf-8',
+  );
+
+  it('exports ViewerPreWriteReview and the correlation helpers', () => {
+    expect(source).toMatch(/export\s+function\s+ViewerPreWriteReview/);
+    expect(source).toMatch(/export\s+function\s+pathMatchesViewer/);
+    expect(source).toMatch(/export\s+function\s+findPendingWriteForFile/);
+  });
+
+  it('reuses the #6556 PreWriteDiffReview for the diff/hunk mechanics', () => {
+    expect(source).toContain("import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'");
+    expect(source).toContain('<PreWriteDiffReview');
+    expect(source).toContain('onEditedInputChange={setEditedInput}');
+  });
+
+  it('pulls the full tool input via requestPermissionInput (get_permission_input seam)', () => {
+    expect(source).toContain('requestPermissionInput(requestId)');
+  });
+
+  it('routes editedInput through sendPermissionResponse on approve, and drops it on deny', () => {
+    expect(source).toContain(
+      "sendPermissionResponse(requestId, decision, decision === 'deny' ? null : editedInput)",
+    );
+  });
+
+  it('marks the prompt answered locally on a successful send (resolved gate)', () => {
+    expect(source).toContain("sent === 'sent'");
+    expect(source).toContain('markPromptAnswered(messageId');
+  });
+
+  it('gates on features.ide (serverCapabilities.ide)', () => {
+    expect(source).toContain('s.serverCapabilities?.ide');
+    expect(source).toContain('if (!ideEnabled || !pending || !requestId) return null');
+  });
+});
+
+describe('FileEditor — mounts the pre-write review (source scan)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/FileEditor.tsx'),
+    'utf-8',
+  );
+
+  it('imports and renders ViewerPreWriteReview for the open file', () => {
+    expect(source).toContain("import { ViewerPreWriteReview } from './ViewerPreWriteReview'");
+    expect(source).toContain('<ViewerPreWriteReview filePath={filePath} />');
+  });
+});

--- a/packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts
+++ b/packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts
@@ -94,14 +94,53 @@ describe('ViewerPreWriteReview — wiring (source scan)', () => {
     );
   });
 
-  it('marks the prompt answered locally on a successful send (resolved gate)', () => {
-    expect(source).toContain("sent === 'sent'");
-    expect(source).toContain('markPromptAnswered(messageId');
+  it('resets the submit guard when the send did not go through (#6308 wsSend-false / disconnected)', () => {
+    expect(source).toContain("sent !== 'sent'");
+    expect(source).toContain('submittingRef.current = false');
+    expect(source).toContain('setSubmitting(false)');
   });
 
   it('gates on features.ide (serverCapabilities.ide)', () => {
     expect(source).toContain('s.serverCapabilities?.ide');
     expect(source).toContain('if (!ideEnabled || !pending || !requestId) return null');
+  });
+});
+
+// The High the first review caught: respond() used to re-mark the prompt with a
+// display LABEL ('Approved'/'Denied') AFTER sendPermissionResponse had already
+// stored the canonical decision TOKEN via markPromptAnsweredByRequestId, clobbering
+// it. PermissionDetail renders the answered pill via `isDenied = answer === 'deny'`,
+// so a 'Denied' LABEL (not === 'deny') renders a green "Allowed" pill for a denied
+// write. Pin the token semantics so the label clobber can't come back (#6222/#6223).
+describe('decision-token semantics (#6222/#6223)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/ViewerPreWriteReview.tsx'),
+    'utf-8',
+  );
+  const permDetailSource = fs.readFileSync(
+    path.resolve(__dirname, '../../components/PermissionDetail.tsx'),
+    'utf-8',
+  );
+  // Mirrors PermissionDetail's pill predicate — kept coupled to real code by the
+  // source assertion below — so the token-vs-label divergence is pinned, not invented.
+  const pillIsDenied = (answer: string) => answer === 'deny';
+
+  it('PermissionDetail still keys the denied pill off the exact decision token', () => {
+    expect(permDetailSource).toContain("const isDenied = answer === 'deny'");
+  });
+
+  it('the token deny renders Denied, while a display label renders Allowed (the clobber bug)', () => {
+    expect(pillIsDenied('deny')).toBe(true); // token → "Denied" pill
+    expect(pillIsDenied('Denied')).toBe(false); // label → wrongly "Allowed" pill
+    expect(pillIsDenied('Approved')).toBe(false);
+  });
+
+  it('respond passes the raw decision token and does NOT clobber it with a display label', () => {
+    // The token reaches the store via sendPermissionResponse's own
+    // markPromptAnsweredByRequestId(requestId, decision); respond must pass the raw
+    // `decision` and must NOT re-mark via markPromptAnswered( with a display label.
+    expect(source).toContain('sendPermissionResponse(requestId, decision,');
+    expect(source).not.toContain('markPromptAnswered(');
   });
 });
 

--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -17,6 +17,7 @@ import { useConnectionStore } from '../store/connection';
 import type { FileWriteResult } from '../store/connection';
 import { COLORS } from '../constants/colors';
 import { SyntaxHighlightedCode, langFromPath } from './PermissionDetail';
+import { ViewerPreWriteReview } from './ViewerPreWriteReview';
 
 interface FileEditorProps {
   visible: boolean;
@@ -220,6 +221,13 @@ export function FileEditor({ visible, filePath, initialContent, onClose, onSave 
             </TouchableOpacity>
           )}
         </View>
+
+        {/* #6544 (IDE P3.3 feature A): when a Write/Edit permission is pending for
+            THIS file, surface the #6556 per-hunk pre-write diff review here on the
+            editor — the operator narrows/approves it in the file's own context.
+            Self-gates on features.ide + a matching live write (renders nothing
+            otherwise). Approve/Deny route through the same editedInput seam. */}
+        <ViewerPreWriteReview filePath={filePath} />
 
         {/* Content: syntax-highlighted view or editable TextInput */}
         {isEditing ? (

--- a/packages/app/src/components/ViewerPreWriteReview.tsx
+++ b/packages/app/src/components/ViewerPreWriteReview.tsx
@@ -237,7 +237,7 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   btnText: {
-    color: '#fff',
+    color: COLORS.textPrimary,
     fontSize: 15,
     fontWeight: '600',
   },

--- a/packages/app/src/components/ViewerPreWriteReview.tsx
+++ b/packages/app/src/components/ViewerPreWriteReview.tsx
@@ -1,0 +1,237 @@
+/**
+ * ViewerPreWriteReview (#6544, IDE P3.3 feature A — mobile) — the RN mirror of
+ * the dashboard's viewer review. When a Write/Edit permission is pending for the
+ * file open in the FileEditor, surface the #6556 per-hunk pre-write review right
+ * inside the editor and route Approve/Deny through the SAME `editedInput` seam
+ * (`get_permission_input` -> `sendPermissionResponse(requestId, decision,
+ * editedInput)`) — the exact wire path #6543/#6556 established. No new protocol:
+ * the narrowed content rides the existing per-hunk `editedInput` the server
+ * whitelists (#6552).
+ *
+ * Delta over #6556: LOCATION. #6556 renders the review inside the chat
+ * permission bubble (MessageBubble); this correlates the pending write to the
+ * file open in the FileEditor and renders it there, so the operator reviews (and
+ * narrows) the edit in the file's own context. Both surfaces read the same store
+ * state and drive the same response — the chat bubble keeps working independently.
+ *
+ * The correlation helpers mirror the dashboard's (`pathMatchesViewer` /
+ * `findPendingWriteForFile`). Gated on `features.ide`; hides when no live
+ * reviewable write targets the open file, or once the request is resolved
+ * (locally via `markPromptAnswered`, or by another client's `permission_resolved`
+ * — both set the message's `answered`, which `isLivePermissionPrompt` excludes).
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { isLivePermissionPrompt } from '@chroxy/store-core';
+import type { ChatMessage } from '@chroxy/store-core';
+import { useConnectionStore } from '../store/connection';
+import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview';
+import { COLORS } from '../constants/colors';
+
+// Stable empty array so the messages selector never returns a fresh reference.
+const EMPTY_MESSAGES: ChatMessage[] = [];
+
+/**
+ * Tolerant path match between a permission's `file_path` and the file open in
+ * the viewer. Claude passes an ABSOLUTE `file_path` for Write/Edit; the viewer
+ * path may be absolute or workspace-relative — match exactly or by tail. Both
+ * nulls => no match. Mirrors the dashboard helper of the same name.
+ */
+export function pathMatchesViewer(filePath: string | null | undefined, viewed: string | null): boolean {
+  if (!filePath || !viewed) return false;
+  const a = filePath.replace(/\\/g, '/');
+  const b = viewed.replace(/\\/g, '/');
+  if (a === b) return true;
+  const tail = (p: string) => p.replace(/^\.?\//, '');
+  return a.endsWith('/' + tail(b)) || b.endsWith('/' + tail(a));
+}
+
+/**
+ * The first live, reviewable (Write/Edit) permission whose target `file_path`
+ * matches the file open in the viewer — or null. Pure so it's unit-testable
+ * without the store. Mirrors the dashboard helper of the same name.
+ */
+export function findPendingWriteForFile(
+  messages: ChatMessage[],
+  viewed: string | null,
+  now: number,
+): ChatMessage | null {
+  if (!viewed) return null;
+  for (const m of messages) {
+    if (!isLivePermissionPrompt(m, now)) continue;
+    if (!m.tool || !isReviewableTool(m.tool)) continue;
+    const fp = m.toolInput && typeof m.toolInput.file_path === 'string' ? (m.toolInput.file_path as string) : null;
+    if (pathMatchesViewer(fp, viewed)) return m;
+  }
+  return null;
+}
+
+export interface ViewerPreWriteReviewProps {
+  /** The path currently open in the FileEditor (absolute, or workspace-relative). */
+  filePath: string | null;
+}
+
+export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
+  const ideEnabled = useConnectionStore((s) => Boolean(s.serverCapabilities?.ide));
+  const messages = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return (id ? s.sessionStates[id]?.messages : undefined) ?? EMPTY_MESSAGES;
+  });
+
+  // The live reviewable write (if any) targeting the open file. The store's
+  // permission_resolved / permission_expired handlers mutate the message (which
+  // re-runs this memo); the authoritative countdown lives on the chat bubble.
+  const pending = useMemo(
+    () => (ideEnabled ? findPendingWriteForFile(messages, filePath, Date.now()) : null),
+    [ideEnabled, messages, filePath],
+  );
+  const requestId = pending?.requestId ?? null;
+  const tool = pending?.tool ?? null;
+  const messageId = pending?.id ?? null;
+
+  const pulledInput = useConnectionStore((s) => (requestId ? s.permissionInputs?.[requestId] : undefined));
+  const requestPermissionInput = useConnectionStore((s) => s.requestPermissionInput);
+  const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse);
+  const markPromptAnswered = useConnectionStore((s) => s.markPromptAnswered);
+
+  const [editedInput, setEditedInput] = useState<Record<string, string> | null>(null);
+  // Double-submit guard: flips synchronously on the first press, before the
+  // store's answered state catches up a render later.
+  const submittingRef = useRef(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Reset per-request UI state when the target request changes.
+  useEffect(() => {
+    setEditedInput(null);
+    submittingRef.current = false;
+    setSubmitting(false);
+  }, [requestId]);
+
+  // Pull the full redacted tool input once for a live write (the broadcast input
+  // is truncated — #6543/#6550). The diff renders once it lands; until then the
+  // plain Approve/Deny still work.
+  useEffect(() => {
+    if (ideEnabled && requestId && pulledInput === undefined) {
+      requestPermissionInput(requestId);
+    }
+  }, [ideEnabled, requestId, pulledInput, requestPermissionInput]);
+
+  if (!ideEnabled || !pending || !requestId) return null;
+
+  // Narrow the discriminated `permission_input` union: only found:true carries
+  // `input` (found:false is a security message with no tool input).
+  const proposedInput = pulledInput?.found ? pulledInput.input : null;
+  const hasDiff = proposedInput !== null;
+
+  const respond = (decision: 'allow' | 'deny') => {
+    if (!requestId || submittingRef.current) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    // #6543: carry the per-hunk narrowing on an approve only (never on a deny).
+    const sent = sendPermissionResponse(requestId, decision, decision === 'deny' ? null : editedInput);
+    if (sent === 'sent' && messageId) {
+      markPromptAnswered(messageId, decision === 'deny' ? 'Denied' : 'Approved');
+    } else {
+      // Not sent (e.g. disconnected) — leave the review actionable.
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container} testID="viewer-prewrite-review">
+      <Text style={styles.title} testID="viewer-prewrite-title">
+        <Text style={styles.tool}>{tool}</Text> proposed for this file — review before approving.
+      </Text>
+
+      {hasDiff ? (
+        <PreWriteDiffReview
+          tool={tool as string}
+          input={proposedInput as Record<string, unknown>}
+          onEditedInputChange={setEditedInput}
+        />
+      ) : (
+        <Text style={styles.loading} testID="viewer-prewrite-loading">
+          {pulledInput?.found === false
+            ? 'Proposed change unavailable — approve to write it as-is.'
+            : 'Loading proposed change…'}
+        </Text>
+      )}
+
+      <View style={styles.buttons}>
+        <TouchableOpacity
+          style={[styles.btn, styles.approve, submitting && styles.btnDisabled]}
+          testID="viewer-prewrite-approve"
+          disabled={submitting}
+          onPress={() => respond('allow')}
+          accessibilityRole="button"
+          accessibilityLabel={`Approve ${tool} to this file`}
+        >
+          <Text style={styles.btnText}>Approve</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.btn, styles.deny, submitting && styles.btnDisabled]}
+          testID="viewer-prewrite-deny"
+          disabled={submitting}
+          onPress={() => respond('deny')}
+          accessibilityRole="button"
+          accessibilityLabel={`Deny ${tool} to this file`}
+        >
+          <Text style={styles.btnText}>Deny</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 12,
+    marginTop: 10,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: COLORS.accentOrange,
+    borderRadius: 8,
+    backgroundColor: COLORS.backgroundSecondary,
+  },
+  title: {
+    fontSize: 13,
+    color: COLORS.textSecondary,
+    marginBottom: 4,
+  },
+  tool: {
+    fontWeight: '600',
+    color: COLORS.textPrimary,
+  },
+  loading: {
+    fontSize: 12,
+    color: COLORS.textSecondary,
+    paddingVertical: 6,
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 8,
+  },
+  btn: {
+    flex: 1,
+    minHeight: 44,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  approve: {
+    backgroundColor: COLORS.accentGreen,
+  },
+  deny: {
+    backgroundColor: COLORS.accentRed,
+  },
+  btnDisabled: {
+    opacity: 0.5,
+  },
+  btnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/packages/app/src/components/ViewerPreWriteReview.tsx
+++ b/packages/app/src/components/ViewerPreWriteReview.tsx
@@ -87,12 +87,10 @@ export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
   );
   const requestId = pending?.requestId ?? null;
   const tool = pending?.tool ?? null;
-  const messageId = pending?.id ?? null;
 
   const pulledInput = useConnectionStore((s) => (requestId ? s.permissionInputs?.[requestId] : undefined));
   const requestPermissionInput = useConnectionStore((s) => s.requestPermissionInput);
   const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse);
-  const markPromptAnswered = useConnectionStore((s) => s.markPromptAnswered);
 
   const [editedInput, setEditedInput] = useState<Record<string, string> | null>(null);
   // Double-submit guard: flips synchronously on the first press, before the
@@ -128,14 +126,23 @@ export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
     submittingRef.current = true;
     setSubmitting(true);
     // #6543: carry the per-hunk narrowing on an approve only (never on a deny).
+    // sendPermissionResponse itself records the canonical decision TOKEN on the
+    // prompt (markPromptAnsweredByRequestId — 'allow' | 'deny'). Do NOT re-mark
+    // here with a display label: a viewer DENY that stored 'Denied' would clobber
+    // the 'deny' token, and PermissionDetail (`isDenied = answer === 'deny'`) would
+    // then render a green "Allowed" pill for a denied write (#6222/#6223 — answer
+    // is the decision token, not a label).
     const sent = sendPermissionResponse(requestId, decision, decision === 'deny' ? null : editedInput);
-    if (sent === 'sent' && messageId) {
-      markPromptAnswered(messageId, decision === 'deny' ? 'Denied' : 'Approved');
-    } else {
-      // Not sent (e.g. disconnected) — leave the review actionable.
+    if (sent !== 'sent') {
+      // #6308: the socket can flip OPEN→CLOSING before this synchronous send, so
+      // sendPermissionResponse returns false without marking the token — leave the
+      // review actionable instead of wedging with submitting=true.
       submittingRef.current = false;
       setSubmitting(false);
     }
+    // On 'sent': the message's `answered` token flips → the pending memo recomputes
+    // to null → this component unmounts. Keep submitting=true in the interim so a
+    // rapid second press can't double-fire.
   };
 
   return (

--- a/packages/dashboard/src/components/FileBrowserPanel.tsx
+++ b/packages/dashboard/src/components/FileBrowserPanel.tsx
@@ -14,6 +14,7 @@ import {
   computeVisibleEntries, toggleDir, ancestorDirs, buildBreadcrumbs, joinPath,
 } from './fileTreeLogic'
 import type { VisibleTreeItem } from './fileTreeLogic'
+import { ViewerPreWriteReview } from './ViewerPreWriteReview'
 
 /** File icon by extension */
 function fileIcon(name: string, isDirectory: boolean): string {
@@ -654,6 +655,12 @@ export function FileBrowserPanel() {
               &times;
             </button>
           </div>
+          {/* #6544 (IDE P3.3 feature A): when a Write/Edit permission is pending
+              for THIS file, surface the #6543 per-hunk pre-write diff here on the
+              viewer — the operator narrows/approves it in the file's own context.
+              Self-gates on features.ide + a matching live write (renders nothing
+              otherwise). Approve/Deny route through the same editedInput seam. */}
+          <ViewerPreWriteReview filePath={selectedFile} />
           {ideEnabled && fileContent !== null && fileLanguage !== 'image' && (
             <SymbolsList groups={groupedSymbols} loading={symbolsLoading} onPick={scrollToLine} />
           )}

--- a/packages/dashboard/src/components/ViewerPreWriteReview.test.tsx
+++ b/packages/dashboard/src/components/ViewerPreWriteReview.test.tsx
@@ -33,7 +33,7 @@ type MockStore = {
 }
 
 const mockRequestPermissionInput = vi.fn(() => true)
-const mockSendPermissionResponse = vi.fn(() => 'sent')
+const mockSendPermissionResponse = vi.fn((): 'sent' | 'queued' | false => 'sent')
 
 let mockState: MockStore
 function resetStore(overrides: Partial<MockStore> = {}) {
@@ -194,5 +194,20 @@ describe('ViewerPreWriteReview', () => {
     expect(screen.getByTestId('viewer-prewrite-disconnected')).toBeTruthy()
     fireEvent.click(screen.getByTestId('viewer-prewrite-approve'))
     expect(mockSendPermissionResponse).not.toHaveBeenCalled()
+  })
+
+  it('re-enables the buttons when the send fails while still connected (#6308 OPEN→CLOSING race)', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: pulledEdit() })
+    // The socket flips OPEN→CLOSING after the `connected` gate but before the
+    // synchronous send, so sendPermissionResponse returns false while connected.
+    mockSendPermissionResponse.mockReturnValueOnce(false)
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    const approve = screen.getByTestId('viewer-prewrite-approve') as HTMLButtonElement
+    expect(approve.disabled).toBe(false)
+    fireEvent.click(approve)
+    expect(mockSendPermissionResponse).toHaveBeenCalledWith('req-1', 'allow', null)
+    // result !== 'sent' → submitting is reset, so the buttons stay actionable
+    // instead of wedging disabled.
+    expect(approve.disabled).toBe(false)
   })
 })

--- a/packages/dashboard/src/components/ViewerPreWriteReview.test.tsx
+++ b/packages/dashboard/src/components/ViewerPreWriteReview.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ViewerPreWriteReview (#6544, IDE P3.3 feature A) — the editable pre-write diff
+ * surfaced ON THE FILE VIEWER. Covers the pure correlation helpers, that a live
+ * reviewable write for the open file renders the proposed diff, that dropping a
+ * hunk routes the narrowed content through the #6543 `editedInput` seam on
+ * Approve, that a plain Approve sends no edit, that Deny never carries an edit,
+ * and the gates (features.ide off, no matching write, resolved, disconnected).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import {
+  ViewerPreWriteReview,
+  pathMatchesViewer,
+  findPendingWriteForFile,
+} from './ViewerPreWriteReview'
+import type { ChatMessage, PermissionDecision } from '../store/types'
+
+// ---- store mock (only the connection store is mocked; PreWriteDiffReview and
+// the store-core helpers run for real so the diff/hunk mechanics are exercised).
+type MockStore = {
+  serverCapabilities: { ide?: boolean }
+  activeSessionId: string | null
+  sessionStates: Record<string, { messages: ChatMessage[] }>
+  resolvedPermissions: Record<string, PermissionDecision>
+  permissionInputs: Record<string, unknown>
+  requestPermissionInput: (requestId: string) => boolean
+  sendPermissionResponse: (
+    requestId: string,
+    decision: PermissionDecision,
+    editedInput?: Record<string, string> | null,
+  ) => unknown
+  connectionPhase: string
+}
+
+const mockRequestPermissionInput = vi.fn(() => true)
+const mockSendPermissionResponse = vi.fn(() => 'sent')
+
+let mockState: MockStore
+function resetStore(overrides: Partial<MockStore> = {}) {
+  mockState = {
+    serverCapabilities: { ide: true },
+    activeSessionId: 's1',
+    sessionStates: { s1: { messages: [] } },
+    resolvedPermissions: {},
+    permissionInputs: {},
+    requestPermissionInput: mockRequestPermissionInput,
+    sendPermissionResponse: mockSendPermissionResponse,
+    connectionPhase: 'connected',
+    ...overrides,
+  }
+}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: <T,>(selector: (s: MockStore) => T): T => selector(mockState),
+}))
+
+const FILE = '/home/dev/project/src/app.ts'
+
+/** A live (unexpired, unanswered) Edit permission targeting FILE. */
+function editPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'perm-1',
+    type: 'prompt',
+    content: 'Edit: change app.ts',
+    tool: 'Edit',
+    requestId: 'req-1',
+    toolInput: { file_path: FILE, old_string: 'a\nb\nc', new_string: 'a\nB\nc' },
+    expiresAt: Date.now() + 60_000,
+    timestamp: Date.now(),
+    ...overrides,
+  }
+}
+
+/** The pulled full input the server returns for `get_permission_input`. */
+function pulledEdit() {
+  return {
+    'req-1': {
+      type: 'permission_input',
+      requestId: 'req-1',
+      found: true,
+      tool: 'Edit',
+      input: { file_path: FILE, old_string: 'a\nb\nc', new_string: 'a\nB\nc' },
+    },
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('pathMatchesViewer', () => {
+  it('matches identical absolute paths', () => {
+    expect(pathMatchesViewer('/a/b/c.ts', '/a/b/c.ts')).toBe(true)
+  })
+  it('tail-matches an absolute file_path against a workspace-relative selection', () => {
+    expect(pathMatchesViewer('/root/pkg/src/x.ts', 'src/x.ts')).toBe(true)
+    expect(pathMatchesViewer('/root/pkg/src/x.ts', './src/x.ts')).toBe(true)
+  })
+  it('does not match unrelated files or when either side is empty', () => {
+    expect(pathMatchesViewer('/a/b/x.ts', '/a/b/y.ts')).toBe(false)
+    expect(pathMatchesViewer(null, '/a/b/x.ts')).toBe(false)
+    expect(pathMatchesViewer('/a/b/x.ts', null)).toBe(false)
+  })
+})
+
+describe('findPendingWriteForFile', () => {
+  const now = Date.now()
+  it('finds a live Edit/Write targeting the viewed file', () => {
+    expect(findPendingWriteForFile([editPrompt()], FILE, now)?.requestId).toBe('req-1')
+  })
+  it('ignores expired, answered, non-reviewable, or non-matching prompts', () => {
+    expect(findPendingWriteForFile([editPrompt({ expiresAt: now - 1 })], FILE, now)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt({ answered: 'allow' })], FILE, now)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt({ tool: 'Bash' })], FILE, now)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt()], '/other/file.ts', now)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt()], null, now)).toBeNull()
+  })
+})
+
+describe('ViewerPreWriteReview', () => {
+  it('renders the proposed diff when a live write targets the open file', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: pulledEdit() })
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    expect(screen.getByTestId('viewer-prewrite-review')).toBeTruthy()
+    expect(screen.getByTestId('prewrite-diff-review')).toBeTruthy()
+  })
+
+  it('pulls the full tool input when it has not been fetched yet', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: {} })
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    expect(mockRequestPermissionInput).toHaveBeenCalledWith('req-1')
+    expect(screen.getByTestId('viewer-prewrite-loading')).toBeTruthy()
+  })
+
+  it('Approve with no edits sends a plain allow (editedInput null)', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: pulledEdit() })
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    fireEvent.click(screen.getByTestId('viewer-prewrite-approve'))
+    expect(mockSendPermissionResponse).toHaveBeenCalledWith('req-1', 'allow', null)
+  })
+
+  it('dropping a hunk routes the narrowed content through editedInput on Approve', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: pulledEdit() })
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    // Edit diffs old→new; dropping the only hunk reverts new_string to old_string.
+    fireEvent.click(screen.getAllByTestId('hunk-toggle')[0]!)
+    fireEvent.click(screen.getByTestId('viewer-prewrite-approve'))
+    expect(mockSendPermissionResponse).toHaveBeenCalledWith('req-1', 'allow', { new_string: 'a\nb\nc' })
+  })
+
+  it('Deny never carries an editedInput even after dropping a hunk', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: pulledEdit() })
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    fireEvent.click(screen.getAllByTestId('hunk-toggle')[0]!)
+    fireEvent.click(screen.getByTestId('viewer-prewrite-deny'))
+    expect(mockSendPermissionResponse).toHaveBeenCalledWith('req-1', 'deny', null)
+  })
+
+  it('renders nothing when features.ide is off', () => {
+    resetStore({
+      serverCapabilities: { ide: false },
+      sessionStates: { s1: { messages: [editPrompt()] } },
+      permissionInputs: pulledEdit(),
+    })
+    const { container } = render(<ViewerPreWriteReview filePath={FILE} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when no live write targets the open file', () => {
+    resetStore({ sessionStates: { s1: { messages: [editPrompt()] } }, permissionInputs: pulledEdit() })
+    const { container } = render(<ViewerPreWriteReview filePath="/some/other/file.ts" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing once the request is resolved locally', () => {
+    resetStore({
+      sessionStates: { s1: { messages: [editPrompt()] } },
+      permissionInputs: pulledEdit(),
+      resolvedPermissions: { 'req-1': 'allow' },
+    })
+    const { container } = render(<ViewerPreWriteReview filePath={FILE} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('disables the buttons and shows a hint while disconnected', () => {
+    resetStore({
+      sessionStates: { s1: { messages: [editPrompt()] } },
+      permissionInputs: pulledEdit(),
+      connectionPhase: 'reconnecting',
+    })
+    render(<ViewerPreWriteReview filePath={FILE} />)
+    expect((screen.getByTestId('viewer-prewrite-approve') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('viewer-prewrite-disconnected')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('viewer-prewrite-approve'))
+    expect(mockSendPermissionResponse).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/ViewerPreWriteReview.tsx
+++ b/packages/dashboard/src/components/ViewerPreWriteReview.tsx
@@ -130,7 +130,16 @@ export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
     submittingRef.current = true
     setSubmitting(true)
     // #6543: carry the per-hunk narrowing on an approve only (never on a deny).
-    sendPermissionResponse(requestId, decision, decision === 'deny' ? null : editedInput)
+    const result = sendPermissionResponse(requestId, decision, decision === 'deny' ? null : editedInput)
+    if (result !== 'sent') {
+      // #6308: the socket can flip OPEN→CLOSING after the `connected` gate but
+      // before this synchronous send, so sendPermissionResponse returns false
+      // while `connected` is still true. Reset so the buttons don't wedge with
+      // submitting=true. (On 'sent', markPermissionResolved flips `answered` and
+      // this component unmounts, so keeping submitting=true there is fine.)
+      submittingRef.current = false
+      setSubmitting(false)
+    }
   }
 
   if (!ideEnabled || !pending || !requestId || answered) return null

--- a/packages/dashboard/src/components/ViewerPreWriteReview.tsx
+++ b/packages/dashboard/src/components/ViewerPreWriteReview.tsx
@@ -1,0 +1,194 @@
+/**
+ * ViewerPreWriteReview (#6544, IDE P3.3 feature A) — surfaces the #6543 per-hunk
+ * pre-write diff review ON THE FILE VIEWER (the IDE editor surface), not only in
+ * the permission-prompt card.
+ *
+ * When a Write/Edit permission is pending for the file the operator is currently
+ * viewing in the FileBrowserPanel, this renders the agent's PROPOSED change as a
+ * diff right inside the viewer, lets the operator drop individual hunks, and
+ * Approve/Deny routes through the SAME `editedInput` → `sendPermissionResponse`
+ * seam #6543 established (#6552 whitelists which field the server merges). There
+ * is NO new approval protocol here: the narrowed content rides the existing
+ * per-hunk `editedInput` on the permission response.
+ *
+ * Delta over #6543: LOCATION. #6543 renders the review inside the permission
+ * card; this correlates the pending write to the open file and renders it on the
+ * IDE viewer so the operator reviews (and narrows) the edit in the file's own
+ * context before approving. The permission card keeps working independently —
+ * both surfaces read the same store state and drive the same `respond`.
+ *
+ * Gated on `features.ide` (the whole IDE surface is opt-in). Renders nothing
+ * when the flag is off, when no live reviewable write targets the open file, or
+ * once the request is resolved (locally via `resolvedPermissions` or by another
+ * client). Reuses PreWriteDiffReview for the diff/hunk-toggle mechanics.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type { ChatMessage, PermissionDecision } from '../store/types'
+import { isLivePermissionPrompt } from '@chroxy/store-core'
+import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
+
+// Stable empty array so the messages selector never returns a fresh reference
+// (a new `[]` each render would re-run the memo + churn the subscription).
+const EMPTY_MESSAGES: ChatMessage[] = []
+
+/**
+ * Tolerant path match between a permission's `file_path` and the viewer's open
+ * file. Claude passes an ABSOLUTE `file_path` for Write/Edit; the viewer's
+ * selection is absolute (a file-tree click) OR workspace-relative (a symbol
+ * jump), so compare tolerantly — an exact match, or one path tail-matching the
+ * other. Both nulls => no match (nothing to correlate).
+ */
+export function pathMatchesViewer(filePath: string | null | undefined, viewed: string | null): boolean {
+  if (!filePath || !viewed) return false
+  const a = filePath.replace(/\\/g, '/')
+  const b = viewed.replace(/\\/g, '/')
+  if (a === b) return true
+  const tail = (p: string) => p.replace(/^\.?\//, '')
+  return a.endsWith('/' + tail(b)) || b.endsWith('/' + tail(a))
+}
+
+/**
+ * The first live, reviewable (Write/Edit) permission whose target `file_path`
+ * matches the file open in the viewer — or null. Pure so it's unit-testable
+ * without the store. `now` gates the expiry inside `isLivePermissionPrompt`.
+ */
+export function findPendingWriteForFile(
+  messages: ChatMessage[],
+  viewed: string | null,
+  now: number,
+): ChatMessage | null {
+  if (!viewed) return null
+  for (const m of messages) {
+    if (!isLivePermissionPrompt(m, now)) continue
+    if (!m.tool || !isReviewableTool(m.tool)) continue
+    const fp = m.toolInput && typeof m.toolInput.file_path === 'string' ? (m.toolInput.file_path as string) : null
+    if (pathMatchesViewer(fp, viewed)) return m
+  }
+  return null
+}
+
+export interface ViewerPreWriteReviewProps {
+  /** The path currently open in the viewer (absolute, or workspace-relative). */
+  filePath: string | null
+}
+
+export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
+  const ideEnabled = useConnectionStore((s) => s.serverCapabilities?.ide === true)
+  const messages = useConnectionStore((s) => {
+    const id = s.activeSessionId
+    return (id ? s.sessionStates[id]?.messages : undefined) ?? EMPTY_MESSAGES
+  })
+
+  // The live reviewable write (if any) targeting the open file. Date.now() at
+  // memo time is sufficient — the store's permission_resolved / permission_expired
+  // handlers mutate the message (which re-runs this memo); the authoritative
+  // countdown lives on the permission card, not here.
+  const pending = useMemo(
+    () => (ideEnabled ? findPendingWriteForFile(messages, filePath, Date.now()) : null),
+    [ideEnabled, messages, filePath],
+  )
+  const requestId = pending?.requestId ?? null
+  const tool = pending?.tool ?? null
+
+  // A locally-recorded resolution (this client just answered — on the viewer OR
+  // the card) flips `resolvedPermissions` before the server's broadcast sets the
+  // message's `answered`, so read it here to hide the review immediately (#2833).
+  const answered = useConnectionStore((s) => (requestId ? s.resolvedPermissions?.[requestId] ?? null : null))
+  const pulledInput = useConnectionStore((s) => (requestId ? s.permissionInputs?.[requestId] : undefined))
+  const requestPermissionInput = useConnectionStore((s) => s.requestPermissionInput)
+  const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse)
+  // #5699 — answering is refused while disconnected (the server expires the
+  // request on drop); disable the buttons so a tap isn't a silent no-op.
+  const connected = useConnectionStore((s) => s.connectionPhase === 'connected')
+
+  const [editedInput, setEditedInput] = useState<Record<string, string> | null>(null)
+  // #2852-style double-submit guard: the ref flips synchronously on the first
+  // click, before the store's `answered` state catches up a render later.
+  const submittingRef = useRef(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Reset per-request UI state when the target request changes (a new write, or
+  // the current one resolved and a different one now matches this file).
+  useEffect(() => {
+    setEditedInput(null)
+    submittingRef.current = false
+    setSubmitting(false)
+  }, [requestId])
+
+  // Pull the full redacted tool input once for a live, not-yet-answered write
+  // (the broadcast input is truncated — #6543/#6550). The diff renders once it
+  // lands; until then the plain Approve/Deny still work.
+  useEffect(() => {
+    if (ideEnabled && requestId && !answered && pulledInput === undefined) {
+      requestPermissionInput(requestId)
+    }
+  }, [ideEnabled, requestId, answered, pulledInput, requestPermissionInput])
+
+  const respond = (decision: PermissionDecision) => {
+    if (!requestId || submittingRef.current || answered || !connected) return
+    submittingRef.current = true
+    setSubmitting(true)
+    // #6543: carry the per-hunk narrowing on an approve only (never on a deny).
+    sendPermissionResponse(requestId, decision, decision === 'deny' ? null : editedInput)
+  }
+
+  if (!ideEnabled || !pending || !requestId || answered) return null
+
+  // Narrow the discriminated `permission_input` union: only the found:true
+  // variant carries `input` (the found:false variant is a security message).
+  const proposedInput = pulledInput?.found ? pulledInput.input : null
+  const hasDiff = proposedInput !== null
+
+  return (
+    <div className="viewer-prewrite-review" data-testid="viewer-prewrite-review" role="group" aria-label="Pending write review">
+      <div className="viewer-prewrite-title" data-testid="viewer-prewrite-title">
+        <span className="viewer-prewrite-tool">{tool}</span> proposed for this file — review before approving.
+      </div>
+
+      {/* Reuse the #6543 per-hunk review: dropped hunks become `editedInput`. A
+          refusal / not-yet-pulled input simply shows no diff (the buttons still
+          send a plain Approve, which writes the full proposed content). */}
+      {hasDiff && (
+        <PreWriteDiffReview
+          tool={tool as string}
+          input={proposedInput as Record<string, unknown>}
+          onEditedInputChange={setEditedInput}
+        />
+      )}
+      {!hasDiff && (
+        <div className="viewer-prewrite-loading" data-testid="viewer-prewrite-loading">
+          {pulledInput?.found === false ? 'Proposed change unavailable — approve to write it as-is.' : 'Loading proposed change…'}
+        </div>
+      )}
+
+      <div className="viewer-prewrite-buttons">
+        <button
+          type="button"
+          className="btn-allow"
+          data-testid="viewer-prewrite-approve"
+          onClick={() => respond('allow')}
+          disabled={submitting || !connected}
+          aria-label={`Approve ${tool} to this file`}
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          className="btn-deny"
+          data-testid="viewer-prewrite-deny"
+          onClick={() => respond('deny')}
+          disabled={submitting || !connected}
+          aria-label={`Deny ${tool} to this file`}
+        >
+          Deny
+        </button>
+      </div>
+      {!connected && (
+        <div className="viewer-prewrite-disconnected" data-testid="viewer-prewrite-disconnected" role="status">
+          Disconnected — reconnect to answer.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3943,6 +3943,61 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-orange);
 }
 
+/* #6544 (IDE P3.3 feature A): the same per-hunk pre-write review surfaced on the
+ * file viewer when a Write/Edit permission targets the open file. A bordered,
+ * accent-tinted card at the top of the viewer content so the pending write reads
+ * as an interruption to review before the current disk content below. */
+.viewer-prewrite-review {
+  margin: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--accent-orange);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.viewer-prewrite-title {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.viewer-prewrite-tool {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.viewer-prewrite-loading {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  padding: 6px 0;
+}
+
+.viewer-prewrite-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.viewer-prewrite-buttons button {
+  padding: 5px 16px;
+  border-radius: 6px;
+  border: none;
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.viewer-prewrite-buttons button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.viewer-prewrite-disconnected {
+  margin-top: 6px;
+  font-size: var(--text-sm);
+  color: var(--accent-orange);
+}
+
 .perm-buttons {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## IDE P3.3 feature A — editable pre-write diff on the file viewer

Fast-follow of P3.2 (#6543). Surfaces the per-hunk pre-write diff review **on the file-viewing surface** (the IDE editor), not only in the permission prompt. Both acceptance bullets of #6544 are covered here. Behind `features.ide`.

### What it does
When a `Write`/`Edit` permission is pending for the file the operator is currently viewing/editing, the agent's **proposed change renders as a diff inline in the viewer**. The operator can drop individual hunks and Approve/Deny — routing through the **same `editedInput` → `sendPermissionResponse` seam #6543/#6556 established**. The narrowed content rides the existing per-hunk `editedInput` the server already whitelists (#6552). No new approval protocol, no wire change.

### Two halves (both AC bullets)
- **Dashboard** (`packages/dashboard`): `ViewerPreWriteReview` rendered at the top of `FileBrowserPanel`'s viewer content.
- **Mobile** (`packages/app`): `ViewerPreWriteReview` (RN) rendered inside the `FileEditor` modal — the per-hunk review step before writing.

### Delta over #6543/#6556
**Location.** #6543/#6556 render the review inside the permission card/bubble; this correlates the pending write to the open file and renders it on the viewer/editor so the edit is reviewed (and narrowed) in the file's own context. Both surfaces read the same store state and drive the same response — the card/bubble keeps working independently.

### How it reuses the shipped seam (no new protocol)
- Diff/hunk mechanics: reuses `PreWriteDiffReview` (#6543 PR-3 / #6556) + store-core differ (`computeHunks`/`applyHunks`, #6542).
- Full input: pulled via the existing `get_permission_input` (#6550) — `requestPermissionInput` / `permissionInputs`.
- Approve/Deny: the existing `sendPermissionResponse(requestId, decision, editedInput)` (#6552). Dropped hunks become `editedInput`; a plain Approve sends `null` (full proposed content); Deny never carries an edit.
- Correlation logic is mirrored across the two clients (`pathMatchesViewer` / `findPendingWriteForFile`), matching the same gates.

### Scope / gating (both clients)
- Self-gated on `features.ide` **and** a live reviewable write whose `file_path` matches the open file — renders nothing otherwise.
- Hides once the request is resolved (dashboard: `resolvedPermissions`; mobile: the message's `answered`, set by local `markPromptAnswered` or a remote `permission_resolved`).
- Dashboard buttons disable while disconnected (#5699 parity); mobile marks answered only on a `'sent'` response and stays actionable otherwise.

### Files
**Dashboard**
- `packages/dashboard/src/components/ViewerPreWriteReview.tsx` — new: correlation helpers + viewer review component.
- `packages/dashboard/src/components/ViewerPreWriteReview.test.tsx` — new: 14 vitest tests.
- `packages/dashboard/src/components/FileBrowserPanel.tsx` — render the review at the top of the viewer.
- `packages/dashboard/src/theme/components.css` — viewer review card styles (tokens only).

**Mobile**
- `packages/app/src/components/ViewerPreWriteReview.tsx` — new: RN mirror (correlation helpers + review component).
- `packages/app/src/components/FileEditor.tsx` — render the review inside the editor modal.
- `packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts` — new: pure-logic correlation tests + wiring source scan.

### Tests
- Dashboard: new 14/14 (`ViewerPreWriteReview.test.tsx`); full dashboard suite **262 files / 4552 tests** green; `tsc --noEmit` clean.
- Mobile: new tests green (correlation + wiring); full app jest **169 suites / 2210 tests** green; app `tsc --noEmit` clean.
- No protocol/store-core/server changes (reuses #6543/#6556's wire path) — no coverage-guard or wire-suite impact.

Part of #6478 (IDE P3) · epic #6469 · depends on #6541/#6542/#6543.

Closes #6544