### PR TITLE
fix(server): clear stale codex working state after stream disconnect (#6629)

### DIFF
--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -23,6 +23,23 @@ const MAX_PENDING_FILE_CHANGES = 500
 // tool_result can't balloon the transcript or the persisted history ring.
 const MAX_MCP_RESULT_CHARS = 10_000
 
+// #6629: bounded backstop for codex's OWN response-stream reconnect loop. #6623
+// keeps the turn OPEN on a transient `Reconnecting... N/M` error so codex can
+// recover, and the only pre-existing backstop was the 30-min result timeout —
+// but that timer is PAUSED while a permission prompt is pending
+// (`_pauseResultTimeoutForPermission`), which is exactly the situation the #6629
+// report hit: the reconnect fired right after a shell-escalation prompt. So a
+// codex whose stream silently wedged mid-reconnect left the session stuck
+// "Working..." for up to 30 min — or indefinitely if a permission had paused the
+// result timeout. This watchdog runs INDEPENDENTLY of that pause: it is armed on
+// the first reconnect notification, disarmed the moment codex makes any real
+// forward progress, and — if codex neither recovers nor emits its terminal
+// give-up — fails the turn cleanly (clears busy + sweeps orphan tool_starts) with
+// `error{code:'stream_stall'}` so the client shows its existing retry affordance
+// instead of a stale spinner. 2 min comfortably clears codex's bounded N/5 retry
+// cycle while bounding the worst-case stale state far below the 30-min default.
+const RECONNECT_WATCHDOG_MS = 2 * 60 * 1000
+
 const log = createLogger('codex-app-server')
 
 /**
@@ -99,6 +116,7 @@ export class CodexAppServerSession extends BaseSession {
     this._lastUsage = null
     this._skillsPrepended = false // #6606 — inject the skills prefix once, on turn 1
     this._turnAbort = null // per-turn AbortController — cancels pending approvals
+    this._reconnectWatchdog = null // #6629 — bounded backstop for a wedged reconnect
     // #6638: per-session sandbox override (create_session `codexSandbox`) — wins
     // over CHROXY_CODEX_SANDBOX / the default. Applied at thread start.
     this._codexSandbox = opts.codexSandbox || null
@@ -278,6 +296,11 @@ export class CodexAppServerSession extends BaseSession {
       return
     }
     this._resetResultTimeout()
+    // #6629 — any notification that is NOT another `error` tick is genuine forward
+    // progress: codex's response stream is live again, so disarm the reconnect
+    // watchdog #6623's suppression path may have armed. (A terminal `error` clears
+    // it below on its way to _failTurn; a transient reconnect `error` re-arms it.)
+    if (method !== 'error') this._clearReconnectWatchdog()
     const t = this._activeTurn
     switch (method) {
       case 'turn/started':
@@ -316,8 +339,15 @@ export class CodexAppServerSession extends BaseSession {
         const err = this._errorPayload(params)
         if (this._isTransientReconnect(err)) {
           ;(this._log || log).warn(`codex app-server response stream reconnecting (turn kept open): ${err.message || 'responseStreamDisconnected'}`)
+          // #6629 — arm the bounded watchdog so a reconnect that NEVER recovers
+          // (nor emits codex's terminal give-up) still reconciles the stale
+          // working state, even when a pending permission has paused the result
+          // timeout. Re-arms on each reconnect tick so codex's legit N/5 retry
+          // burst doesn't trip it mid-recovery.
+          this._armReconnectWatchdog()
           break
         }
+        this._clearReconnectWatchdog() // terminal error → about to fail; drop the backstop
         this._failTurn(`Codex error: ${JSON.stringify(params).slice(0, 200)}`)
         break
       }
@@ -509,13 +539,17 @@ export class CodexAppServerSession extends BaseSession {
     this._maybeDequeue()
   }
 
-  _failTurn(message) {
+  // #6629 — `code` lets the reconnect-watchdog surface its failure as
+  // `error{code:'stream_stall'}` so clients reuse the existing recoverable-stall
+  // retry chip (parity with SdkSession's stall recovery) instead of rendering a
+  // bare, non-actionable error. An intentional stop still wins and reports `stopped`.
+  _failTurn(message, { code } = {}) {
     this._clearResultTimeout()
     const t = this._activeTurn
     if (t?.didStreamStart) this.emit('stream_end', { messageId: t.messageId })
     const wasIntentional = this._consumeIntentionalStop()
     if (wasIntentional) this.emit('stopped', {})
-    else this.emit('error', { message })
+    else this.emit('error', code ? { message, code } : { message })
     this._activeTurn = null
     this._endTurnAbort()
     this._clearMessageState()
@@ -549,6 +583,7 @@ export class CodexAppServerSession extends BaseSession {
   _clearMessageState() {
     super._clearMessageState()
     this._pendingFileChanges.clear()
+    this._clearReconnectWatchdog() // #6629 — drop the reconnect backstop on any turn teardown
   }
 
   // Abort this turn's approval scope (any pending permission_request resolves as
@@ -581,6 +616,29 @@ export class CodexAppServerSession extends BaseSession {
 
   _clearResultTimeout() {
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+  }
+
+  // #6629 — bounded reconnect watchdog. Armed when #6623 keeps a turn open on a
+  // transient response-stream reconnect; unlike the result timeout it is NOT
+  // paused by a pending permission, so a codex that wedges mid-reconnect (never
+  // recovers, never emits its terminal give-up) still reconciles the stale
+  // working state promptly. Re-armed (clear + set) on each reconnect tick so
+  // codex's legit multi-attempt retry burst doesn't trip it — it only fires
+  // after a full window of silence following the last thing codex said. Disarmed
+  // by any genuine forward-progress notification (recovery) and on turn teardown.
+  _armReconnectWatchdog() {
+    this._clearReconnectWatchdog()
+    this._reconnectWatchdog = setTimeout(() => {
+      this._reconnectWatchdog = null
+      if (!this._activeTurn) return
+      ;(this._log || log).warn(`codex app-server response stream did not recover within ${RECONNECT_WATCHDOG_MS}ms — reconciling stale working state (#6629)`)
+      this._failTurn('Codex response stream disconnected and did not recover — the turn was stopped. Retry to continue.', { code: 'stream_stall' })
+    }, RECONNECT_WATCHDOG_MS)
+    if (typeof this._reconnectWatchdog.unref === 'function') this._reconnectWatchdog.unref()
+  }
+
+  _clearReconnectWatchdog() {
+    if (this._reconnectWatchdog) { clearTimeout(this._reconnectWatchdog); this._reconnectWatchdog = null }
   }
 
   // ------------------------------------------------------------------
@@ -937,6 +995,7 @@ export class CodexAppServerSession extends BaseSession {
     this.clearOutgoingQueue({ emit: false })
     this._clearIntentionalStop()
     this._clearResultTimeout()
+    this._clearReconnectWatchdog() // #6629 — never leave the reconnect timer armed past teardown
     this._endTurnAbort() // resolve any in-flight approval as a deny before teardown
     try { this._permissions?.destroy() } catch { /* noop */ }
     // #6609 — drop the materialized-attachment temp dir.

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -25,16 +25,19 @@ const MAX_MCP_RESULT_CHARS = 10_000
 
 // #6629: bounded backstop for codex's OWN response-stream reconnect loop. #6623
 // keeps the turn OPEN on a transient `Reconnecting... N/M` error so codex can
-// recover, and the only pre-existing backstop was the 30-min result timeout —
-// but that timer is PAUSED while a permission prompt is pending
-// (`_pauseResultTimeoutForPermission`), which is exactly the situation the #6629
-// report hit: the reconnect fired right after a shell-escalation prompt. So a
-// codex whose stream silently wedged mid-reconnect left the session stuck
-// "Working..." for up to 30 min — or indefinitely if a permission had paused the
-// result timeout. This watchdog runs INDEPENDENTLY of that pause: it is armed on
-// the first reconnect notification, disarmed the moment codex makes any real
-// forward progress, and — if codex neither recovers nor emits its terminal
-// give-up — fails the turn cleanly (clears busy + sweeps orphan tool_starts) with
+// recover, and the only pre-existing backstop was the 30-min result timeout.
+// But a pending permission prompt CLEARS that timer outright
+// (`_pauseResultTimeoutForPermission` → `_clearResultTimeout`), and it is only
+// re-armed when the NEXT notification arrives (`_resetResultTimeout`, run at the
+// top of `_onNotification`). A codex approval is a server→client REQUEST, not a
+// notification, so it never re-arms anything. So the exact #6629 situation — a
+// shell-escalation prompt pending, then the response stream wedges mid-reconnect
+// with no further notifications — leaves NO active result timeout at all, and the
+// session hangs in "Working..." indefinitely. This watchdog is the independent
+// backstop for that gap: armed on a transient reconnect notification, NOT touched
+// by the permission pause, disarmed the moment codex makes any real forward
+// progress, and — if codex neither recovers nor emits its terminal give-up —
+// fails the turn cleanly (clears busy + sweeps orphan tool_starts) with
 // `error{code:'stream_stall'}` so the client shows its existing retry affordance
 // instead of a stale spinner. 2 min comfortably clears codex's bounded N/5 retry
 // cycle while bounding the worst-case stale state far below the 30-min default.

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -298,8 +298,8 @@ export class CodexAppServerSession extends BaseSession {
     this._resetResultTimeout()
     // #6629 — any notification that is NOT another `error` tick is genuine forward
     // progress: codex's response stream is live again, so disarm the reconnect
-    // watchdog #6623's suppression path may have armed. (A terminal `error` clears
-    // it below on its way to _failTurn; a transient reconnect `error` re-arms it.)
+    // watchdog that #6623's suppression path may have armed. (A terminal `error`
+    // clears it below on its way to _failTurn; a transient reconnect `error` re-arms it.)
     if (method !== 'error') this._clearReconnectWatchdog()
     const t = this._activeTurn
     switch (method) {
@@ -631,6 +631,16 @@ export class CodexAppServerSession extends BaseSession {
     this._reconnectWatchdog = setTimeout(() => {
       this._reconnectWatchdog = null
       if (!this._activeTurn) return
+      // #6629 — INTENTIONAL that this fires even while a permission prompt is
+      // pending. The watchdog only arms on a genuine disconnect and is disarmed by
+      // ANY forward-progress notification, so reaching this callback means codex
+      // emitted no ticks and made no progress for the full window — the response
+      // stream is genuinely wedged and the turn cannot complete regardless of the
+      // pending approval. Failing cleanly (deny the pending approval via
+      // _endTurnAbort + surface a recoverable stall) is the actionable outcome;
+      // deliberately NOT firing during a pending permission would just restore the
+      // #6629 indefinite-stale-state bug (the paused result timeout is exactly what
+      // this watchdog exists to backstop). The user can retry to continue.
       ;(this._log || log).warn(`codex app-server response stream did not recover within ${RECONNECT_WATCHDOG_MS}ms — reconciling stale working state (#6629)`)
       this._failTurn('Codex response stream disconnected and did not recover — the turn was stopped. Retry to continue.', { code: 'stream_stall' })
     }, RECONNECT_WATCHDOG_MS)

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test'
+import { describe, it, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
@@ -399,6 +399,7 @@ describe('CodexAppServerSession — transient stream reconnect (#6623)', () => {
     assert.equal(s._isBusy, true, 'session stays busy while codex reconnects')
     assert.ok(s._activeTurn, 'the in-flight turn is preserved across the reconnect')
     s._clearResultTimeout() // release the re-armed backstop timer
+    s._clearReconnectWatchdog() // #6629 — release the reconnect watchdog armed alongside it
     cleanup()
   })
 
@@ -459,6 +460,165 @@ describe('CodexAppServerSession — transient stream reconnect (#6623)', () => {
     assert.equal(s._isTransientReconnect(s._errorPayload({ message: 'boom' })), false)
     assert.equal(s._isTransientReconnect(s._errorPayload(undefined)), false)
     cleanup()
+  })
+})
+
+describe('CodexAppServerSession — reconnect watchdog / stale-state reconciliation (#6629)', () => {
+  // #6623 keeps the turn OPEN on a transient reconnect so codex can recover; the
+  // ONLY pre-existing backstop was the 30-min result timeout — and a pending
+  // permission PAUSES that timer. #6629: a codex whose response stream wedges
+  // mid-reconnect (never recovers, never emits its terminal give-up) left the
+  // session stuck "Working..." (and any orphan in-flight tool_start unresolved)
+  // for up to 30 min, or indefinitely if a permission had paused the timer. The
+  // watchdog reconciles that stale state on a bounded window, independent of the
+  // permission pause, surfacing error{code:'stream_stall'} (the existing retry chip).
+  const RECONNECT_WATCHDOG_MS = 2 * 60 * 1000
+  const reconnectParams = (attempt = 2, max = 5) => ({
+    error: {
+      message: `Reconnecting... ${attempt}/${max}`,
+      codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+      additionalDetails: 'stream disconnected before completion: failed to send websocket frame',
+    },
+  })
+
+  // A turn mid-shell-task: an in-flight commandExecution tool_start with no
+  // matching tool_result yet (the exact stale in-flight tool the issue describes).
+  function armBusyTurnWithInflightShell(s) {
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'commandExecution', id: 'shell-1', command: 'npm run desktop:build', cwd: '/tmp' } } })
+  }
+
+  it('fires after a non-recovering reconnect: clears busy + sweeps the orphan tool_start with error{code:stream_stall}', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    const { s, cleanup } = mkSession()
+    try {
+      const ev = capture(s, ['error', 'stopped', 'tool_result', 'stream_end'])
+      armBusyTurnWithInflightShell(s)
+      // Stream drops → codex is reconnecting → #6623 keeps the turn open + arms the watchdog.
+      s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+      assert.ok(s._reconnectWatchdog, 'watchdog armed on a transient reconnect')
+      assert.equal(s._isBusy, true, 'still busy while codex reconnects')
+
+      // codex never recovers and never emits its terminal give-up.
+      mock.timers.tick(RECONNECT_WATCHDOG_MS - 1)
+      assert.equal(ev.length, 0, 'watchdog must not fire 1ms before the window')
+      mock.timers.tick(1)
+
+      const err = ev.find(([e]) => e === 'error')
+      assert.ok(err, 'watchdog fails the turn with an error')
+      assert.equal(err[1].code, 'stream_stall', 'error carries stream_stall so the client shows a retry chip')
+      assert.ok(ev.some(([e, p]) => e === 'tool_result' && p.toolUseId === 'shell-1'), 'the orphan in-flight shell tool_start is swept with a synthetic tool_result')
+      assert.equal(s._isBusy, false, 'stale working state cleared')
+      assert.equal(s._activeTurn, null, 'turn cleared')
+      assert.equal(s._reconnectWatchdog, null, 'watchdog handle cleared after firing')
+    } finally {
+      s.destroy()
+      mock.timers.reset()
+      cleanup()
+    }
+  })
+
+  it('recovery disarms the watchdog: a forward-progress notification prevents a premature fail', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    const { s, cleanup } = mkSession()
+    try {
+      const ev = capture(s, ['error', 'stream_end', 'result'])
+      s._isBusy = true
+      s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+      s._onNotification({ method: 'error', params: reconnectParams(1, 5) })
+      assert.ok(s._reconnectWatchdog, 'watchdog armed')
+      // codex re-establishes the stream and streams a delta → recovery.
+      s._onNotification({ method: 'item/agentMessage/delta', params: { delta: 'back online' } })
+      assert.equal(s._reconnectWatchdog, null, 'watchdog disarmed on genuine forward progress')
+
+      // Ticking past the window must NOT fail the turn.
+      mock.timers.tick(RECONNECT_WATCHDOG_MS * 2)
+      assert.ok(!ev.some(([e, p]) => e === 'error' && p?.code === 'stream_stall'), 'no stall error after recovery')
+
+      // …and the turn still completes normally.
+      s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 5 } } })
+      assert.equal(s._isBusy, false, 'busy cleared on clean completion')
+      assert.equal(s._activeTurn, null, 'turn cleared on clean completion')
+    } finally {
+      s.destroy()
+      mock.timers.reset()
+      cleanup()
+    }
+  })
+
+  it('fires even while a pending permission has paused the result timeout (the #6629 gap)', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    const { s, cleanup } = mkSession()
+    try {
+      const ev = capture(s, ['error', 'tool_result'])
+      armBusyTurnWithInflightShell(s)
+      // A shell-escalation prompt is pending → the result timeout is PAUSED (cleared).
+      s._pauseResultTimeoutForPermission()
+      assert.equal(s._resultTimeout, null, 'result timeout is paused while a permission is pending')
+
+      // THEN the stream drops. The reconnect watchdog is independent of the pause.
+      s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+      assert.ok(s._reconnectWatchdog, 'watchdog armed despite the paused result timeout')
+
+      mock.timers.tick(RECONNECT_WATCHDOG_MS)
+      const err = ev.find(([e]) => e === 'error')
+      assert.ok(err && err[1].code === 'stream_stall', 'watchdog still reconciles the stale state even with the result timeout paused')
+      assert.equal(s._isBusy, false, 'no longer stuck Working with a pending permission')
+      assert.ok(ev.some(([e, p]) => e === 'tool_result' && p.toolUseId === 'shell-1'), 'orphan shell tool_start swept')
+    } finally {
+      s.destroy()
+      mock.timers.reset()
+      cleanup()
+    }
+  })
+
+  it('a reconnect burst re-arms the watchdog so legit N/5 retries do not trip it early', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    const { s, cleanup } = mkSession()
+    try {
+      const ev = capture(s, ['error'])
+      s._isBusy = true
+      s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+
+      s._onNotification({ method: 'error', params: reconnectParams(1, 5) })
+      mock.timers.tick(RECONNECT_WATCHDOG_MS - 1_000) // almost expired…
+      s._onNotification({ method: 'error', params: reconnectParams(2, 5) }) // …then a new retry re-arms it
+      mock.timers.tick(RECONNECT_WATCHDOG_MS - 1_000)
+      assert.equal(ev.length, 0, 'no fire: each retry within the window re-armed the watchdog')
+
+      // Silence past a full window after the LAST retry → fires.
+      mock.timers.tick(1_000)
+      assert.ok(ev.some(([e, p]) => e === 'error' && p?.code === 'stream_stall'), 'fires a full window after the last reconnect tick')
+      assert.equal(s._isBusy, false, 'busy cleared')
+    } finally {
+      s.destroy()
+      mock.timers.reset()
+      cleanup()
+    }
+  })
+
+  it('a terminal give-up clears the watchdog on its way to _failTurn (no double fail)', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    const { s, cleanup } = mkSession()
+    try {
+      const ev = capture(s, ['error'])
+      s._isBusy = true
+      s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: false }
+      s._onNotification({ method: 'error', params: reconnectParams(2, 5) }) // arms watchdog
+      assert.ok(s._reconnectWatchdog, 'watchdog armed')
+      // codex gives up: a disconnect WITHOUT a Reconnecting message → terminal.
+      s._onNotification({ method: 'error', params: { error: { message: 'stream disconnected before completion', codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } } } } })
+      assert.equal(ev.length, 1, 'exactly one failure surfaced')
+      assert.equal(s._reconnectWatchdog, null, 'watchdog cleared by the terminal failure')
+      // Ticking must not produce a second (stale) failure.
+      mock.timers.tick(RECONNECT_WATCHDOG_MS * 2)
+      assert.equal(ev.length, 1, 'no second fail from a stale watchdog after teardown')
+    } finally {
+      s.destroy()
+      mock.timers.reset()
+      cleanup()
+    }
   })
 })
 

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -547,23 +547,31 @@ describe('CodexAppServerSession — reconnect watchdog / stale-state reconciliat
     }
   })
 
-  it('fires even while a pending permission has paused the result timeout (the #6629 gap)', () => {
+  it('is the sole backstop when a pending permission cleared the result timeout with no re-arm (the #6629 gap)', () => {
     mock.timers.enable({ apis: ['setTimeout', 'Date'] })
     const { s, cleanup } = mkSession()
     try {
       const ev = capture(s, ['error', 'tool_result'])
       armBusyTurnWithInflightShell(s)
-      // A shell-escalation prompt is pending → the result timeout is PAUSED (cleared).
-      s._pauseResultTimeoutForPermission()
-      assert.equal(s._resultTimeout, null, 'result timeout is paused while a permission is pending')
-
-      // THEN the stream drops. The reconnect watchdog is independent of the pause.
+      // Stream drops mid-shell → the reconnect arms the watchdog AND, via
+      // _resetResultTimeout at the top of _onNotification, re-arms the result timeout.
       s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
-      assert.ok(s._reconnectWatchdog, 'watchdog armed despite the paused result timeout')
+      assert.ok(s._reconnectWatchdog, 'watchdog armed on the reconnect')
+      assert.ok(s._resultTimeout, 'the reconnect notification re-armed the result timeout')
 
+      // THEN codex's shell-escalation approval lands. That is a server→client
+      // REQUEST, not a notification, so it does NOT re-arm the result timeout — it
+      // CLEARS it (_pauseResultTimeoutForPermission → _clearResultTimeout). With the
+      // stream now wedged (no further notifications), nothing re-arms it: there is
+      // NO active result timeout left. Without the watchdog this hangs forever.
+      s._pauseResultTimeoutForPermission()
+      assert.equal(s._resultTimeout, null, 'result timeout cleared by the pending permission and NOT re-armed (no further notifications)')
+      assert.ok(s._reconnectWatchdog, 'watchdog survives the pause — it is independent of the result timeout')
+
+      // The watchdog alone reconciles the stale state.
       mock.timers.tick(RECONNECT_WATCHDOG_MS)
       const err = ev.find(([e]) => e === 'error')
-      assert.ok(err && err[1].code === 'stream_stall', 'watchdog still reconciles the stale state even with the result timeout paused')
+      assert.ok(err && err[1].code === 'stream_stall', 'the watchdog alone reconciles the stale state as the sole backstop')
       assert.equal(s._isBusy, false, 'no longer stuck Working with a pending permission')
       assert.ok(ev.some(([e, p]) => e === 'tool_result' && p.toolUseId === 'shell-1'), 'orphan shell tool_start swept')
     } finally {


### PR DESCRIPTION
## Problem

During a long-running Codex shell task (a Tauri rebuild), the response stream disconnected and the session got stuck in a stale `Working...` / `Thinking...` state — the chat surfaced a red Codex `responseStreamDisconnected` error but the activity state never resolved into an actionable failed/stopped state. The user had no clear next action and had to interrupt/retry.

## Root cause (what #6629 adds beyond the just-merged #6623)

#6623 (`_isTransientReconnect`) correctly keeps a codex turn **open** on a transient `Reconnecting... N/M` error so codex's own retry loop can recover — but it relies on the **30-min result timeout** as the sole backstop. That timer is **paused** while a permission prompt is pending (`_pauseResultTimeoutForPermission`), which is exactly the reported scenario: the reconnect fired right after a shell-escalation prompt.

So a codex whose stream wedges mid-reconnect (never recovers, never emits its terminal give-up):
- stayed `Working...` for up to **30 min** — or **indefinitely** if a permission had paused the result timeout, and
- left the in-flight shell `tool_start` unresolved (orphaned running indicator).

This is a real additional gap, not covered by #6623.

## Fix

A bounded **reconnect watchdog** on `CodexAppServerSession`, mirroring `SdkSession`'s stream-stall recovery:

- **Armed** on each transient reconnect notification (the #6623 path), **independent of the permission pause**; re-armed on each retry tick so codex's legit N/5 retry burst doesn't trip it mid-recovery.
- **Disarmed** the moment codex makes any genuine forward progress (recovery), and on any turn teardown.
- On **expiry**, fails the turn cleanly via `_failTurn`: clears the busy flag, sweeps the orphan in-flight `tool_start` with a synthetic `tool_result`, and emits `error{code:'stream_stall'}` so the dashboard/app reuse their **existing** recoverable-stall retry chip — an actionable next step instead of a stale spinner.

Worst-case stale state drops from 30 min / indefinite to a bounded 2 min.

**No protocol or client changes** — error `code` is already an optional wire field and `stream_stall` already renders a retry affordance on both clients (parity with `cli-session` / `sdk-session`).

## Acceptance criteria

- [x] Session exits stale `Working...` / `Thinking...` state when the provider stream is disconnected and no recoverable work is active.
- [x] Pending permission prompts are reconciled with provider disconnect state (watchdog runs independent of the result-timeout pause; `_endTurnAbort` denies the pending approval).
- [x] The user has an obvious next action — `error{code:'stream_stall'}` renders the existing Retry chip.
- [x] Regression coverage for activity-state derivation after Codex `responseStreamDisconnected` events.

## Tests

New `#6629` describe block in `codex-app-server-session.test.js`:
- watchdog fires + reconciles (busy cleared, orphan swept, `stream_stall`) when codex never recovers;
- recovery (a forward-progress notification) disarms it — no premature fail;
- it still fires **with the result timeout paused for a pending permission** (the core #6629 gap);
- a reconnect burst re-arms it so legit N/5 retries don't trip it early;
- a terminal give-up clears it (no double fail).

All timers use `mock.timers` + `s.destroy()` teardown; the suite exits cleanly without `--test-force-exit` (no leaked handles). `codex-app-server-session` suite: **93/93 green**. Both required server lints (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`) pass.

Closes #6629