### PR TITLE
feat(server,protocol): path-scoped permission rules + secret-read floor (#6803)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -156,6 +156,7 @@ export declare const PermissionRuleSchema: z.ZodObject<{
         allow: "allow";
         deny: "deny";
     }>;
+    path: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 /**
  * Request the current BYOK credentials status. Server replies with a
@@ -225,6 +226,7 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
             allow: "allow";
             deny: "deny";
         }>;
+        path: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>;
     projectRules: z.ZodOptional<z.ZodArray<z.ZodObject<{
         tool: z.ZodString;
@@ -232,6 +234,7 @@ export declare const SetPermissionRulesSchema: z.ZodObject<{
             allow: "allow";
             deny: "deny";
         }>;
+        path: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
@@ -985,6 +988,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             allow: "allow";
             deny: "deny";
         }>;
+        path: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>;
     projectRules: z.ZodOptional<z.ZodArray<z.ZodObject<{
         tool: z.ZodString;
@@ -992,6 +996,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             allow: "allow";
             deny: "deny";
         }>;
+        path: z.ZodOptional<z.ZodString>;
     }, z.core.$strip>>>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -177,6 +177,15 @@ export const SetThinkingLevelSchema = z.object({
 export const PermissionRuleSchema = z.object({
     tool: z.string().min(1).max(256),
     decision: z.enum(['allow', 'deny']),
+    // #6803 — OPTIONAL path/glob SCOPE. When present, the rule only matches a
+    // tool call whose target path(s) resolve UNDER this scope (a directory prefix
+    // like `src/`, or a glob like `src/**/*.ts`). ABSENT → the rule matches every
+    // path exactly as before (unscoped, no behaviour change). This lets a user
+    // express "allow Write under src/ only" instead of an attractive-but-blunt
+    // all-paths `allow Write`. The server (permission-manager._ruleScopeMatches)
+    // resolves the scope against the session cwd; a scoped rule for a tool whose
+    // input carries no concrete path never matches (falls through to a prompt).
+    path: z.string().min(1).max(1024).optional(),
 });
 // -- BYOK credentials (#4052) --
 /**

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -185,7 +185,12 @@ export const PermissionRuleSchema = z.object({
     // all-paths `allow Write`. The server (permission-manager._ruleScopeMatches)
     // resolves the scope against the session cwd; a scoped rule for a tool whose
     // input carries no concrete path never matches (falls through to a prompt).
-    path: z.string().min(1).max(1024).optional(),
+    // #6873 review — reject a whitespace-only scope via `.refine` (NOT `.catch`,
+    // the #6436 swallow trap) so the wire contract matches the server's
+    // `!rule.path.trim()` guard rather than admitting a useless blank scope.
+    path: z.string().min(1).max(1024).refine((s) => s.trim().length > 0, {
+        message: 'path scope must not be whitespace-only',
+    }).optional(),
 });
 // -- BYOK credentials (#4052) --
 /**

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -203,6 +203,15 @@ export const SetThinkingLevelSchema = z.object({
 export const PermissionRuleSchema = z.object({
   tool: z.string().min(1).max(256),
   decision: z.enum(['allow', 'deny']),
+  // #6803 — OPTIONAL path/glob SCOPE. When present, the rule only matches a
+  // tool call whose target path(s) resolve UNDER this scope (a directory prefix
+  // like `src/`, or a glob like `src/**/*.ts`). ABSENT → the rule matches every
+  // path exactly as before (unscoped, no behaviour change). This lets a user
+  // express "allow Write under src/ only" instead of an attractive-but-blunt
+  // all-paths `allow Write`. The server (permission-manager._ruleScopeMatches)
+  // resolves the scope against the session cwd; a scoped rule for a tool whose
+  // input carries no concrete path never matches (falls through to a prompt).
+  path: z.string().min(1).max(1024).optional(),
 })
 
 // -- BYOK credentials (#4052) --

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -211,7 +211,12 @@ export const PermissionRuleSchema = z.object({
   // all-paths `allow Write`. The server (permission-manager._ruleScopeMatches)
   // resolves the scope against the session cwd; a scoped rule for a tool whose
   // input carries no concrete path never matches (falls through to a prompt).
-  path: z.string().min(1).max(1024).optional(),
+  // #6873 review — reject a whitespace-only scope via `.refine` (NOT `.catch`,
+  // the #6436 swallow trap) so the wire contract matches the server's
+  // `!rule.path.trim()` guard rather than admitting a useless blank scope.
+  path: z.string().min(1).max(1024).refine((s) => s.trim().length > 0, {
+    message: 'path scope must not be whitespace-only',
+  }).optional(),
 })
 
 // -- BYOK credentials (#4052) --

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3244,4 +3244,23 @@ describe('@chroxy/protocol schemas', () => {
       assert.equal(missing.data.input, undefined)
     })
   })
+
+  describe('PermissionRuleSchema path scope (#6803, PR #6873 review)', () => {
+    it('accepts an unscoped rule (no path) and a valid path scope', async () => {
+      const { PermissionRuleSchema } = await import('../src/schemas/client.ts')
+      assert.ok(PermissionRuleSchema.safeParse({ tool: 'Write', decision: 'allow' }).success, 'unscoped')
+      assert.ok(PermissionRuleSchema.safeParse({ tool: 'Write', decision: 'allow', path: 'src/' }).success, 'prefix scope')
+      assert.ok(PermissionRuleSchema.safeParse({ tool: 'Write', decision: 'allow', path: 'src/**/*.ts' }).success, 'glob scope')
+    })
+
+    it('REJECTS a whitespace-only path scope (wire contract matches the server guard)', async () => {
+      const { PermissionRuleSchema } = await import('../src/schemas/client.ts')
+      for (const path of ['   ', '\t', '\n', ' \t ']) {
+        const r = PermissionRuleSchema.safeParse({ tool: 'Write', decision: 'allow', path })
+        assert.equal(r.success, false, `whitespace-only path ${JSON.stringify(path)} must be rejected`)
+      }
+      // empty string is already rejected by min(1)
+      assert.equal(PermissionRuleSchema.safeParse({ tool: 'Write', decision: 'allow', path: '' }).success, false)
+    })
+  })
 })

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -744,6 +744,11 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
       sendSessionError(ws, ctx, `rules[${i}]: tool '${rule.tool}' is not eligible for permission rules`)
       return
     }
+    // #6803 — optional path/glob scope: a non-empty string when present.
+    if (rule.path !== undefined && (typeof rule.path !== 'string' || !rule.path.trim())) {
+      sendSessionError(ws, ctx, `rules[${i}]: path scope must be a non-empty string`)
+      return
+    }
   }
 
   // #6771 — optional durable (project-scoped) rule set. When present, it FULLY
@@ -776,6 +781,11 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
       }
       if (rule.decision === 'allow' && !ELIGIBLE_TOOLS.has(rule.tool)) {
         sendSessionError(ws, ctx, `projectRules[${i}]: tool '${rule.tool}' is not eligible for permission rules`)
+        return
+      }
+      // #6803 — optional path/glob scope: a non-empty string when present.
+      if (rule.path !== undefined && (typeof rule.path !== 'string' || !rule.path.trim())) {
+        sendSessionError(ws, ctx, `projectRules[${i}]: path scope must be a non-empty string`)
         return
       }
     }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -101,6 +101,39 @@ function isSecretFileSegment(seg) {
   return false
 }
 
+/**
+ * #6803 (PR #6873 security review) — credential-DENSE config FILES that must be
+ * floored for READS too (not just writes). These live INSIDE a config dir, so
+ * the secret-file matcher above misses them, but they routinely carry secrets:
+ *   - `.git/config`            — a remote URL can embed a PAT (`https://TOKEN@…`)
+ *   - `.git/credentials`       — git's plaintext credential store
+ *   - `.config/git/config` + `.config/git/credentials` — the XDG equivalents
+ *   - `.claude/settings*.json` — may hold ANTHROPIC_API_KEY / env secrets
+ * A broad `allow Read` / auto / bypass must not silently read these (Chroxy
+ * streams tool-results to phone/Discord, amplifying any leak). OTHER files in
+ * the config dirs (`.claude/skills/*.md`, a secret-free `.vscode/settings.json`)
+ * stay un-floored for reads per #6803's intent.
+ *
+ * Matched as a 2-/3-segment sequence anchored at index `i` of the (lowercased,
+ * `..`-stripped) segment array, so any depth prefix (`sub/.git/config`) matches.
+ * Pure string ops (no regex) — consistent with the rest of the floor.
+ * @param {string[]} segments  lowercased path segments
+ * @param {number} i           the current segment index
+ * @returns {boolean}
+ */
+function isCredentialConfigSegment(segments, i) {
+  const seg = segments[i]
+  // .git/config (PAT-embedded remote URLs) and .git/credentials (git store).
+  if (seg === '.git' && (segments[i + 1] === 'config' || segments[i + 1] === 'credentials')) return true
+  // XDG git: .config/git/config and .config/git/credentials.
+  if (seg === '.config' && segments[i + 1] === 'git' &&
+      (segments[i + 2] === 'config' || segments[i + 2] === 'credentials')) return true
+  // .claude/settings*.json (settings.json / settings.local.json — may hold keys).
+  const child = segments[i + 1]
+  if (seg === '.claude' && typeof child === 'string' && child.startsWith('settings') && child.endsWith('.json')) return true
+  return false
+}
+
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000
 
@@ -206,10 +239,14 @@ function isProtectedPathValue(target, base, secretsOnly = false) {
     .map((s) => s.toLowerCase())
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i]
-    // Secret files are floored under BOTH the read and the write floor.
+    // Secret files, and credential-dense config files, are floored under BOTH
+    // the read and the write floor (PR #6873 review — the read floor must not
+    // silently auto-read .git/config, git credentials, or .claude/settings*.json).
     if (isSecretFileSegment(seg)) return true
+    if (isCredentialConfigSegment(segments, i)) return true
     if (secretsOnly) continue
-    // Config DIRS are floored only under the full (write) floor.
+    // Config DIRS (any file within them) are floored only under the full (write)
+    // floor; a read of a NON-credential config file stays un-prompted.
     if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
     if (seg === '.config' && segments[i + 1] === 'git') return true
   }
@@ -380,8 +417,15 @@ function globToRegExp(glob) {
 function pathWithinScope(target, scope, base) {
   const resolvedTarget = resolve(base, target)
   if (_scopeHasGlobMagic(scope)) {
-    const relPosix = relative(base, resolvedTarget).split(sep).join('/')
-    return globToRegExp(scope).test(relPosix)
+    // PR #6873 review — a glob scope must NEVER reach ABOVE the session cwd:
+    // `**/*.js` must not match `../evil.js`, `**` must not match `/etc/passwd`.
+    // Reject an escaping target FIRST (same under-base guard the prefix branch
+    // uses), THEN glob-match the under-base relative path. Without this the glob
+    // ran against `relative(base, target)` unchecked, so `..`/absolute targets
+    // supplied via set_permission_rules could be auto-approved out of scope.
+    const rel = relative(base, resolvedTarget)
+    if (isAbsolute(rel) || rel === '..' || rel.startsWith('..' + sep)) return false
+    return globToRegExp(scope).test(rel.split(sep).join('/'))
   }
   const resolvedScope = resolve(base, scope)
   const rel = relative(resolvedScope, resolvedTarget)

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -368,10 +368,12 @@ function collectTargetPaths(input) {
 }
 
 // #6803 — a scope string is a GLOB (vs a plain directory prefix) when it carries
-// a wildcard/character-class metachar. Globs match path-shaped; prefixes match
-// "at or under this directory".
+// a wildcard metachar (`*` or `?`). Globs match path-shaped; prefixes match "at
+// or under this directory". Only `*` / `**` / `?` are supported — NOT character
+// classes, so a scope containing `[`/`]` is a literal directory prefix, not a
+// class (globToRegExp would escape the brackets anyway).
 function _scopeHasGlobMagic(scope) {
-  return /[*?[\]]/.test(scope)
+  return /[*?]/.test(scope)
 }
 
 /**
@@ -383,7 +385,8 @@ function _scopeHasGlobMagic(scope) {
  *     matches a bare `x`
  *   - `*`  → any run of NON-separator characters (one path segment)
  *   - `?`  → a single non-separator character
- * every other character is matched literally (regex metachars escaped).
+ * Only these wildcards are supported — NOT character classes: `[`/`]` (and every
+ * other regex metachar) are ESCAPED and matched literally.
  * @param {string} glob
  * @returns {RegExp}
  */

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -48,12 +48,58 @@ export const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'
 // git-config dir) is a two-segment sequence handled separately, not a bare segment.
 const PROTECTED_DIR_SEGMENTS = new Set(['.git', '.claude', '.vscode'])
 
+// #6803 — SECRET FILE names. Distinct from the protected DIRECTORY segments
+// above: these carry credentials / private keys, so their floor applies to
+// READS as well as writes (mirrors Claude Code's "don't auto-read known
+// secrets" floor). The write floor (isProtectedPathTarget) matches the config
+// DIRS *and* these secret files; the read floor (isSecretReadTarget) matches
+// ONLY these secret files — reading `.git/config` or `.claude/settings.json`
+// is a common benign operation and must not prompt, but auto-reading a private
+// key or an env file under a broad `allow Read` must not silently succeed.
+//
+// Matched (case-insensitively, see isProtectedPathValue) at ANY path segment:
+//   - `.env` or `.env.*`                 → env files (.env / .env.local / …)
+//   - one of SECRET_FILE_EXACT           → SSH keys, credential dotfiles
+//   - a segment ending in an extension in SECRET_FILE_EXTENSIONS → PEM / keys /
+//     PKCS#12 keystores
+// A floor only ever forces a PROMPT (never a deny), so a rare false positive on
+// an unrelated `.key`/`.pem` file is acceptable and conservative.
+const SECRET_FILE_EXACT = new Set([
+  'id_rsa', 'id_dsa', 'id_ecdsa', 'id_ed25519', // SSH private keys
+  '.npmrc', '.pgpass', '.netrc',                // credential dotfiles
+])
+const SECRET_FILE_EXTENSIONS = ['.pem', '.key', '.p12', '.pfx']
+
 // Tool-input fields that name a filesystem target. Presence of one is what
 // makes a tool "path-carrying" for the floor (Write/Edit → file_path,
 // NotebookEdit → notebook_path, Read/Glob/Grep → file_path/path). A tool with
 // none of these (Bash, Task, WebFetch, WebSearch) cannot be floored here —
 // command-shaped access is out of scope for a path floor.
 const PROTECTED_PATH_INPUT_FIELDS = ['file_path', 'path', 'notebook_path']
+
+// #6803 — tools whose floor is SECRETS-ONLY (non-mutating reads). handlePermission
+// routes these through isSecretReadTarget (env files + key material) instead of
+// the full config-dir floor. EVERY OTHER path-carrying tool — the mutating ones
+// (Write / Edit / NotebookEdit / apply_patch) and any future tool — gets the full
+// isProtectedPathTarget floor. Defaulting the unknown/mutating case to the FULL
+// floor is fail-safe: a new write-shaped tool inherits the stronger floor.
+const SECRET_READ_FLOOR_TOOLS = new Set(['Read', 'Glob', 'Grep'])
+
+/**
+ * #6803 — is a single (already-lowercased) path segment a known secret FILE?
+ * Env files, SSH/credential dotfiles, and PEM/key/keystore extensions. Pure
+ * string ops (no regex) so it can't be mangled by a later edit.
+ * @param {string} seg  a lowercased path segment
+ * @returns {boolean}
+ */
+function isSecretFileSegment(seg) {
+  if (seg === '.env' || seg.startsWith('.env.')) return true
+  if (SECRET_FILE_EXACT.has(seg)) return true
+  for (const ext of SECRET_FILE_EXTENSIONS) {
+    if (seg.length > ext.length && seg.endsWith(ext)) return true
+  }
+  return false
+}
 
 // Default permission timeout (5 minutes)
 const DEFAULT_TIMEOUT_MS = 300_000
@@ -136,11 +182,17 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
  * Windows) `.GIT/config` IS `.git/config`, so a case-sensitive match would let
  * case variants evade the floor. Over-flooring a genuinely distinct `.GIT` on
  * case-sensitive Linux is fine — the floor only forces a prompt, never denies.
+ * #6803 — `secretsOnly` narrows the match to SECRET FILES (env + key material)
+ * and SKIPS the config-DIR segments (.git/.claude/.vscode/.config/git). It is
+ * the read floor: a Read/Glob/Grep must not silently auto-read a secret, but
+ * reading a config dir is benign and must not prompt. The full (write) floor
+ * passes `secretsOnly = false` and matches both dirs and secret files.
  * @param {string} target  a path value from a tool input
  * @param {string} base    the resolution base (session cwd)
+ * @param {boolean} [secretsOnly]  match only secret files, skip config dirs
  * @returns {boolean}
  */
-function isProtectedPathValue(target, base) {
+function isProtectedPathValue(target, base, secretsOnly = false) {
   const resolved = resolve(base, target)
   const rel = relative(base, resolved)
   // Target is inside cwd's own subtree when the relative path neither is nor
@@ -154,8 +206,11 @@ function isProtectedPathValue(target, base) {
     .map((s) => s.toLowerCase())
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i]
+    // Secret files are floored under BOTH the read and the write floor.
+    if (isSecretFileSegment(seg)) return true
+    if (secretsOnly) continue
+    // Config DIRS are floored only under the full (write) floor.
     if (PROTECTED_DIR_SEGMENTS.has(seg)) return true
-    if (seg === '.env' || seg.startsWith('.env.')) return true
     if (seg === '.config' && segments[i + 1] === 'git') return true
   }
   return false
@@ -205,20 +260,147 @@ function isProtectedPathValue(target, base) {
  * @returns {boolean}
  */
 export function isProtectedPathTarget(input, cwd) {
+  return _matchesFloor(input, cwd, false)
+}
+
+/**
+ * #6803 — the READ floor: does this tool input target a known SECRET FILE
+ * (env file or key material)? Same field-scanning as {@link isProtectedPathTarget}
+ * (every present path field + `changes[]`, resolved against cwd) but matches
+ * ONLY secret files — the config DIRS (.git/.claude/.vscode/.config/git) are a
+ * WRITE concern and are deliberately NOT floored for reads, so a Read/Glob/Grep
+ * of a config dir stays a normal, un-prompted operation. handlePermission uses
+ * this for {@link SECRET_READ_FLOOR_TOOLS}; every other tool uses the full floor.
+ * @param {object} input  the tool input
+ * @param {string} [cwd]  the session cwd (falls back to process.cwd())
+ * @returns {boolean}
+ */
+export function isSecretReadTarget(input, cwd) {
+  return _matchesFloor(input, cwd, true)
+}
+
+/**
+ * Shared floor matcher — inspects every present {@link PROTECTED_PATH_INPUT_FIELDS}
+ * value AND every `changes[]` member path (codex apply_patch, #6805/#6828),
+ * resolving each against the session cwd, and tests it with {@link isProtectedPathValue}.
+ * `secretsOnly` selects the read floor (secret files) vs the full write floor
+ * (config dirs + secret files). ANY protected field/member floors the input.
+ * @param {object} input
+ * @param {string} [cwd]
+ * @param {boolean} secretsOnly
+ * @returns {boolean}
+ */
+function _matchesFloor(input, cwd, secretsOnly) {
   if (!input || typeof input !== 'object') return false
   const base = (typeof cwd === 'string' && cwd.length > 0) ? cwd : process.cwd()
   for (const field of PROTECTED_PATH_INPUT_FIELDS) {
     if (typeof input[field] !== 'string' || input[field].length === 0) continue
-    if (isProtectedPathValue(input[field], base)) return true
+    if (isProtectedPathValue(input[field], base, secretsOnly)) return true
   }
   // #6805/#6828 — walk the array-shaped per-file targets (codex apply_patch).
   if (Array.isArray(input.changes)) {
     for (const change of input.changes) {
       if (!change || typeof change.path !== 'string' || change.path.length === 0) continue
-      if (isProtectedPathValue(change.path, base)) return true
+      if (isProtectedPathValue(change.path, base, secretsOnly)) return true
     }
   }
   return false
+}
+
+/**
+ * #6803 — collect every concrete target path a tool input names: the flat
+ * {@link PROTECTED_PATH_INPUT_FIELDS} plus `changes[]` member paths (codex
+ * apply_patch). Used by the rule-scope test so a path-scoped rule can confirm
+ * ALL of a tool call's targets fall inside its scope. Returns [] for a
+ * command-shaped / path-less input.
+ * @param {object} input
+ * @returns {string[]}
+ */
+function collectTargetPaths(input) {
+  if (!input || typeof input !== 'object') return []
+  const out = []
+  for (const field of PROTECTED_PATH_INPUT_FIELDS) {
+    if (typeof input[field] === 'string' && input[field].length > 0) out.push(input[field])
+  }
+  if (Array.isArray(input.changes)) {
+    for (const change of input.changes) {
+      if (change && typeof change.path === 'string' && change.path.length > 0) out.push(change.path)
+    }
+  }
+  return out
+}
+
+// #6803 — a scope string is a GLOB (vs a plain directory prefix) when it carries
+// a wildcard/character-class metachar. Globs match path-shaped; prefixes match
+// "at or under this directory".
+function _scopeHasGlobMagic(scope) {
+  return /[*?[\]]/.test(scope)
+}
+
+/**
+ * #6803 — compile a rule-scope GLOB to an anchored RegExp. Dependency-free
+ * (the existing floor is pure string ops; a scope glob shouldn't drag in
+ * minimatch). Semantics, POSIX `/`-separated:
+ *   - `**` → any run of characters INCLUDING separators (crosses directories)
+ *   - `**` + `/` → the same, with the trailing `/` optional so `**​/x` also
+ *     matches a bare `x`
+ *   - `*`  → any run of NON-separator characters (one path segment)
+ *   - `?`  → a single non-separator character
+ * every other character is matched literally (regex metachars escaped).
+ * @param {string} glob
+ * @returns {RegExp}
+ */
+function globToRegExp(glob) {
+  let re = ''
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === '*' && glob[i + 1] === '*') {
+      if (glob[i + 2] === '/') { re += '(?:.*/)?'; i += 2 } // `**/` → optional dir prefix
+      else { re += '.*'; i += 1 }                           // bare `**`
+      continue
+    }
+    if (c === '*') { re += '[^/]*'; continue }
+    if (c === '?') { re += '[^/]'; continue }
+    re += c.replace(/[.+^${}()|[\]\\/]/g, '\\$&')
+  }
+  return new RegExp('^' + re + '$')
+}
+
+/**
+ * #6803 — is `target` inside the rule `scope`, both resolved against `base`
+ * (the session cwd)? A GLOB scope is matched against the target's cwd-relative,
+ * POSIX-normalized path; a plain scope is a DIRECTORY PREFIX (target is at or
+ * under the resolved scope dir). Used by _ruleScopeMatches — a scoped rule only
+ * auto-decides a tool call whose targets all fall within scope.
+ * @param {string} target  a tool-input path value
+ * @param {string} scope   the rule's `path` scope
+ * @param {string} base    the session cwd
+ * @returns {boolean}
+ */
+function pathWithinScope(target, scope, base) {
+  const resolvedTarget = resolve(base, target)
+  if (_scopeHasGlobMagic(scope)) {
+    const relPosix = relative(base, resolvedTarget).split(sep).join('/')
+    return globToRegExp(scope).test(relPosix)
+  }
+  const resolvedScope = resolve(base, scope)
+  const rel = relative(resolvedScope, resolvedTarget)
+  // At the scope dir itself (rel === '') or under it (not `..`, not absolute).
+  return rel === '' || (!isAbsolute(rel) && rel !== '..' && !rel.startsWith('..' + sep))
+}
+
+/**
+ * #6803 — normalize a rule to the stored shape `{ tool, decision }`, carrying an
+ * optional `path` scope ONLY when it is a non-empty string. Keeping `path` off
+ * the object entirely when unscoped means unscoped rules stay deepEqual to a
+ * plain `{ tool, decision }` (the shape every existing test/consumer asserts).
+ * @param {{tool: string, decision: string, path?: string}} rule
+ * @returns {{tool: string, decision: string, path?: string}}
+ */
+function normalizeStoredRule(rule) {
+  const out = { tool: rule.tool, decision: rule.decision }
+  if (typeof rule.path === 'string' && rule.path.length > 0) out.path = rule.path
+  return out
 }
 
 /**
@@ -281,7 +463,7 @@ export class PermissionManager extends EventEmitter {
     this._lastPermissionData = new Map() // requestId -> emitted permission_request payload
 
     // Session-scoped permission rules
-    this._sessionRules = [] // [{ tool, decision }]
+    this._sessionRules = [] // [{ tool, decision, path? }] — path = #6803 optional scope
 
     // #6771 — durable per-project rules seeded from the store for THIS
     // session's cwd. Kept SEPARATE from `_sessionRules` so `setRules`/
@@ -301,9 +483,12 @@ export class PermissionManager extends EventEmitter {
   /**
    * Set session-scoped permission rules.
    * Each rule must have a `tool` in ELIGIBLE_TOOLS and a `decision` of 'allow' or 'deny'.
-   * Rules for NEVER_AUTO_ALLOW tools are rejected with an error.
+   * Rules for NEVER_AUTO_ALLOW tools are rejected with an error. #6803 — a rule
+   * may carry an optional `path` SCOPE (a non-empty string); the stored rule
+   * preserves it and {@link _matchesRule} only matches a scoped rule when the
+   * tool's target paths fall within it.
    *
-   * @param {Array<{tool: string, decision: string}>} rules
+   * @param {Array<{tool: string, decision: string, path?: string}>} rules
    * @throws {Error} if any rule is invalid
    */
   setRules(rules) {
@@ -327,17 +512,23 @@ export class PermissionManager extends EventEmitter {
       if (!ELIGIBLE_TOOLS.has(rule.tool)) {
         throw new Error(`${rule.tool} is not in ELIGIBLE_TOOLS`)
       }
+      if (rule.path !== undefined && (typeof rule.path !== 'string' || rule.path.length === 0)) {
+        throw new Error('rule path scope must be a non-empty string')
+      }
     }
-    this._sessionRules = rules.slice()
+    // #6803 — normalize to the stored shape, carrying `path` only when present so
+    // an unscoped rule stays a plain { tool, decision } (deepEqual-friendly).
+    this._sessionRules = rules.map(normalizeStoredRule)
   }
 
   /**
-   * Return a copy of the current session rules.
+   * Return a copy of the current session rules (each rule object cloned so a
+   * caller can't mutate the internal set; #6803 — carries `path` when scoped).
    *
-   * @returns {Array<{tool: string, decision: string}>}
+   * @returns {Array<{tool: string, decision: string, path?: string}>}
    */
   getRules() {
-    return this._sessionRules.slice()
+    return this._sessionRules.map(normalizeStoredRule)
   }
 
   /**
@@ -357,7 +548,11 @@ export class PermissionManager extends EventEmitter {
    * @returns {Array<{tool: string, decision: string, persist: 'project'}>}
    */
   getPersistentRules() {
-    return this._persistentRules.map((r) => ({ tool: r.tool, decision: r.decision, persist: 'project' }))
+    return this._persistentRules.map((r) => {
+      const out = { tool: r.tool, decision: r.decision, persist: 'project' }
+      if (typeof r.path === 'string' && r.path.length > 0) out.path = r.path
+      return out
+    })
   }
 
   /**
@@ -371,26 +566,50 @@ export class PermissionManager extends EventEmitter {
     this._persistentRules = Array.isArray(rules)
       ? rules
         .filter((r) => r && typeof r.tool === 'string' && (r.decision === 'allow' || r.decision === 'deny'))
-        .map((r) => ({ tool: r.tool, decision: r.decision }))
+        .map(normalizeStoredRule) // #6803 — preserve an optional `path` scope
       : []
   }
 
   /**
-   * Check whether a toolName matches a session or persistent rule. Session
+   * #6803 — does this rule's optional `path` SCOPE admit `input`? An UNSCOPED
+   * rule (no `path`) matches every input, exactly as before. A SCOPED rule
+   * matches only when the input names at least one concrete target path AND
+   * EVERY target falls within the scope (resolved against the session cwd) — so
+   * a scoped `allow` never auto-approves an out-of-scope target, and an input
+   * with no path (a command-shaped tool, or a bare `Read` with no file) never
+   * matches a scoped rule and falls through to a prompt.
+   * @param {{tool: string, decision: string, path?: string}} rule
+   * @param {object} [input]
+   * @returns {boolean}
+   */
+  _ruleScopeMatches(rule, input) {
+    if (typeof rule.path !== 'string' || rule.path.length === 0) return true
+    const targets = collectTargetPaths(input)
+    if (targets.length === 0) return false
+    const base = this._cwd || process.cwd()
+    return targets.every((t) => pathWithinScope(t, rule.path, base))
+  }
+
+  /**
+   * Check whether a tool call matches a session or persistent rule. Session
    * rules are consulted FIRST (a live, intentional session decision wins over a
-   * standing project grant), then the durable project rules (#6771).
+   * standing project grant), then the durable project rules (#6771). #6803 — a
+   * rule with a `path` scope only matches when the tool's target paths fall
+   * within it (see {@link _ruleScopeMatches}); `input` is optional, so a bare
+   * `_matchesRule(tool)` still resolves unscoped rules unchanged.
    *
    * @param {string} toolName
+   * @param {object} [input]  the tool input (for path-scope matching)
    * @returns {'allow'|'deny'|null} null if no rule matches
    */
-  _matchesRule(toolName) {
+  _matchesRule(toolName, input) {
     for (const rule of this._sessionRules) {
-      if (rule.tool === toolName) {
+      if (rule.tool === toolName && this._ruleScopeMatches(rule, input)) {
         return rule.decision
       }
     }
     for (const rule of this._persistentRules) {
-      if (rule.tool === toolName) {
+      if (rule.tool === toolName && this._ruleScopeMatches(rule, input)) {
         return rule.decision
       }
     }
@@ -408,12 +627,16 @@ export class PermissionManager extends EventEmitter {
    * _auditPersistedRuleAutoApprove) — a session-rule-sourced allow is an
    * explicit, non-durable decision the user already made this session and
    * needs no extra trail beyond what's already logged for it.
+   * #6803 — mirrors _matchesRule's scope filter too: a session rule only shadows
+   * when it actually MATCHES this input (scope included), and the persistent
+   * source must be a scope-matching allow.
    * @param {string} toolName
+   * @param {object} [input]
    * @returns {boolean}
    */
-  _persistentRuleSourced(toolName) {
-    if (this._sessionRules.some((r) => r.tool === toolName)) return false
-    return this._persistentRules.some((r) => r.tool === toolName && r.decision === 'allow')
+  _persistentRuleSourced(toolName, input) {
+    if (this._sessionRules.some((r) => r.tool === toolName && this._ruleScopeMatches(r, input))) return false
+    return this._persistentRules.some((r) => r.tool === toolName && r.decision === 'allow' && this._ruleScopeMatches(r, input))
   }
 
   /**
@@ -493,7 +716,14 @@ export class PermissionManager extends EventEmitter {
     // short-circuiting for these paths. A `deny` rule still denies (the floor
     // never widens access), and if the prompt path then auto-denies on
     // no-client/timeout, that is the existing fail-closed behavior.
-    const protectedTarget = isProtectedPathTarget(input, this._cwd)
+    //
+    // #6803 — the floor is TOOL-AWARE. A non-mutating read (Read/Glob/Grep) is
+    // floored ONLY on secret files (env + key material) via isSecretReadTarget —
+    // reading a config dir is benign and must stay un-prompted. Every other
+    // (mutating / unknown) tool gets the full config-dir + secret write floor.
+    const protectedTarget = SECRET_READ_FLOOR_TOOLS.has(toolName)
+      ? isSecretReadTarget(input, this._cwd)
+      : isProtectedPathTarget(input, this._cwd)
 
     // 'auto' (= SDK bypassPermissions) short-circuit: approve every tool
     // call without consulting rules or emitting a prompt. SdkSession also
@@ -510,7 +740,7 @@ export class PermissionManager extends EventEmitter {
     // Session rules: check before acceptEdits and the prompt path. #6794: a
     // protected target skips the `allow` branch (fall through to the prompt);
     // a `deny` rule still denies.
-    const ruleDecision = this._matchesRule(toolName)
+    const ruleDecision = this._matchesRule(toolName, input)
     if (ruleDecision !== null && !(protectedTarget && ruleDecision === 'allow')) {
       this._logInfo(`Permission rule matched for ${toolName}: ${ruleDecision}`)
       if (ruleDecision === 'allow') {
@@ -518,7 +748,7 @@ export class PermissionManager extends EventEmitter {
         // auto-approved this tool call. Record it via the direct audit sink
         // (NOT an event — see _auditPersistedRuleAutoApprove) so the
         // permission audit log has a trace even though no prompt was shown.
-        if (this._persistentRuleSourced(toolName)) {
+        if (this._persistentRuleSourced(toolName, input)) {
           this._auditPersistedRuleAutoApprove(toolName)
         }
         return Promise.resolve({ behavior: 'allow', updatedInput: input || {} })

--- a/packages/server/src/permission-rule-store.js
+++ b/packages/server/src/permission-rule-store.js
@@ -53,6 +53,44 @@ export function isPersistableTool(tool) {
 }
 
 /**
+ * #6803 — the DEDUPE KEY for a durable rule. Before path-scoped rules a project
+ * held at most one rule per tool; a scope makes `{Write, src/}` and
+ * `{Write, tests/}` DISTINCT persisted rules, so identity is (tool, path) — a
+ * missing scope normalizes to null so two unscoped rules for a tool still
+ * collapse (last-writer-wins), exactly as before.
+ * @param {{tool: string, path?: string}} rule
+ * @returns {string}
+ */
+function ruleKey(rule) {
+  const scope = (typeof rule?.path === 'string' && rule.path.length > 0) ? rule.path : ''
+  return JSON.stringify([rule?.tool, scope])
+}
+
+/**
+ * #6803 — build the persisted record, carrying `path` ONLY when it is a
+ * non-empty string so an unscoped rule stays a plain { tool, decision,
+ * createdAt } (unchanged on-disk shape for existing files).
+ * @param {{tool: string, decision: string, path?: string}} rule
+ * @param {number} createdAt
+ */
+function storedRecord(rule, createdAt) {
+  const rec = { tool: rule.tool, decision: rule.decision, createdAt }
+  if (typeof rule.path === 'string' && rule.path.length > 0) rec.path = rule.path
+  return rec
+}
+
+/**
+ * #6803 — the public read shape PermissionManager consumes: `{ tool, decision }`
+ * plus `path` when scoped (metadata like createdAt stripped).
+ * @param {{tool: string, decision: string, path?: string}} rule
+ */
+function publicRule(rule) {
+  const out = { tool: rule.tool, decision: rule.decision }
+  if (typeof rule.path === 'string' && rule.path.length > 0) out.path = rule.path
+  return out
+}
+
+/**
  * Durable, per-project permission rule store — the "always allow / always deny"
  * decisions that must survive a daemon restart (issue #6771). Persists to a
  * single JSON file (a sibling of `session-state.json`, e.g.
@@ -149,12 +187,13 @@ export class PermissionRuleStore {
         // Enforce the same durable-eligibility floor on LOAD as on write, so a
         // hand-edited file can't smuggle a Bash allow past NEVER_AUTO_ALLOW.
         if (rule.decision === 'allow' && !isPersistableTool(rule.tool)) continue
-        if (clean.some((r) => r.tool === rule.tool)) continue
-        clean.push({
-          tool: rule.tool,
-          decision: rule.decision,
-          createdAt: typeof rule.createdAt === 'number' ? rule.createdAt : Date.now(),
-        })
+        // #6803 — ignore a malformed scope (non-string / empty) rather than
+        // persist it as an unscoped rule (which would silently WIDEN the grant).
+        if (rule.path !== undefined && (typeof rule.path !== 'string' || rule.path.length === 0)) continue
+        // #6803 — dedupe by (tool, path): two scopes for one tool coexist; two
+        // unscoped rules for one tool still collapse (first file key wins).
+        if (clean.some((r) => ruleKey(r) === ruleKey(rule))) continue
+        clean.push(storedRecord(rule, typeof rule.createdAt === 'number' ? rule.createdAt : Date.now()))
         if (clean.length >= MAX_RULES_PER_PROJECT) break
       }
       if (clean.length > 0) this._projects.set(key, clean)
@@ -176,7 +215,7 @@ export class PermissionRuleStore {
     if (!key) return []
     const rules = this._projects.get(key)
     if (!rules) return []
-    return rules.map((r) => ({ tool: r.tool, decision: r.decision }))
+    return rules.map(publicRule)
   }
 
   /**
@@ -198,13 +237,21 @@ export class PermissionRuleStore {
       this._log.warn(`Refusing to persist allow rule for non-persistable tool '${rule.tool}'`)
       return false
     }
+    // #6803 — a scope, if given, must be a non-empty string.
+    if (rule.path !== undefined && (typeof rule.path !== 'string' || rule.path.length === 0)) {
+      this._log.warn(`Refusing to persist rule for '${rule.tool}' with an invalid path scope`)
+      return false
+    }
     const existing = this._projects.get(key) || []
-    if (existing.length >= MAX_RULES_PER_PROJECT && !existing.some((r) => r.tool === rule.tool)) {
+    // #6803 — replace the same (tool, scope); different scopes coexist as
+    // separate rules, so the cap counts against a genuinely new (tool, scope).
+    const isReplacement = existing.some((r) => ruleKey(r) === ruleKey(rule))
+    if (existing.length >= MAX_RULES_PER_PROJECT && !isReplacement) {
       this._log.warn(`Project ${key} at persistent-rule cap (${MAX_RULES_PER_PROJECT}) — not adding '${rule.tool}'`)
       return false
     }
-    const next = existing.filter((r) => r.tool !== rule.tool)
-    next.push({ tool: rule.tool, decision: rule.decision, createdAt: Date.now() })
+    const next = existing.filter((r) => ruleKey(r) !== ruleKey(rule))
+    next.push(storedRecord(rule, Date.now()))
     this._projects.set(key, next)
     this._persist()
     return true
@@ -228,8 +275,11 @@ export class PermissionRuleStore {
         if (!rule || typeof rule.tool !== 'string') continue
         if (rule.decision !== 'allow' && rule.decision !== 'deny') continue
         if (rule.decision === 'allow' && !isPersistableTool(rule.tool)) continue
-        const idx = clean.findIndex((r) => r.tool === rule.tool)
-        const record = { tool: rule.tool, decision: rule.decision, createdAt: Date.now() }
+        // #6803 — drop a malformed scope; dedupe by (tool, path) so distinct
+        // scopes for one tool are preserved, same scope is last-writer-wins.
+        if (rule.path !== undefined && (typeof rule.path !== 'string' || rule.path.length === 0)) continue
+        const idx = clean.findIndex((r) => ruleKey(r) === ruleKey(rule))
+        const record = storedRecord(rule, Date.now())
         if (idx >= 0) clean[idx] = record
         else clean.push(record)
         if (clean.length >= MAX_RULES_PER_PROJECT) break
@@ -238,7 +288,7 @@ export class PermissionRuleStore {
     if (clean.length === 0) this._projects.delete(key)
     else this._projects.set(key, clean)
     this._persist()
-    return clean.map((r) => ({ tool: r.tool, decision: r.decision }))
+    return clean.map(publicRule)
   }
 
   /**
@@ -269,7 +319,7 @@ export class PermissionRuleStore {
   listProjects() {
     const out = {}
     for (const [key, rules] of this._projects) {
-      out[key] = rules.map((r) => ({ tool: r.tool, decision: r.decision }))
+      out[key] = rules.map(publicRule)
     }
     return out
   }

--- a/packages/server/src/permission-rule-store.js
+++ b/packages/server/src/permission-rule-store.js
@@ -56,8 +56,8 @@ export function isPersistableTool(tool) {
  * #6803 — the DEDUPE KEY for a durable rule. Before path-scoped rules a project
  * held at most one rule per tool; a scope makes `{Write, src/}` and
  * `{Write, tests/}` DISTINCT persisted rules, so identity is (tool, path) — a
- * missing scope normalizes to null so two unscoped rules for a tool still
- * collapse (last-writer-wins), exactly as before.
+ * missing scope normalizes to an empty string so two unscoped rules for a tool
+ * still collapse (last-writer-wins), exactly as before.
  * @param {{tool: string, path?: string}} rule
  * @returns {string}
  */
@@ -292,18 +292,27 @@ export class PermissionRuleStore {
   }
 
   /**
-   * Remove a single durable rule (by tool) for a project cwd and persist.
-   * Returns true when a rule was actually removed.
+   * Remove a durable rule for a project cwd and persist. #6803 (PR #6873 review)
+   * — SCOPE-AWARE: with a non-empty `path`, only the specific `(tool, path)`
+   * entry is removed, so removing one scoped rule can NOT clobber sibling scopes
+   * for the same tool. With `path` omitted (or empty), ALL scopes for the tool
+   * are removed — the existing "remove this tool entirely" affordance. Returns
+   * true when a rule was actually removed.
    * @param {string} cwd
    * @param {string} tool
+   * @param {string} [path]  optional scope; when set, remove only that (tool, path)
    * @returns {boolean}
    */
-  removeRule(cwd, tool) {
+  removeRule(cwd, tool, path) {
     const key = normalizeProjectKey(cwd)
     if (!key) return false
     const existing = this._projects.get(key)
     if (!existing) return false
-    const next = existing.filter((r) => r.tool !== tool)
+    const scoped = typeof path === 'string' && path.length > 0
+    const target = ruleKey({ tool, path })
+    const next = scoped
+      ? existing.filter((r) => ruleKey(r) !== target) // drop only the matching scope
+      : existing.filter((r) => r.tool !== tool)         // drop every scope for the tool
     if (next.length === existing.length) return false
     if (next.length === 0) this._projects.delete(key)
     else this._projects.set(key, next)

--- a/packages/server/tests/permission-path-scoped-rules.test.js
+++ b/packages/server/tests/permission-path-scoped-rules.test.js
@@ -229,6 +229,33 @@ describe('#6803 path-scoped rules persist + round-trip through the store', () =>
     ])
   })
 
+  it('scoped removeRule drops only its own scope, preserving sibling scopes (PR #6873 review)', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'src/' })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'tests/' })
+    store.addRule('/proj/a', { tool: 'Read', decision: 'allow' })
+    // Remove ONE scope → the sibling scope and the unscoped Read rule survive.
+    assert.equal(store.removeRule('/proj/a', 'Write', 'src/'), true)
+    assert.deepEqual(store.getRules('/proj/a'), [
+      { tool: 'Write', decision: 'allow', path: 'tests/' },
+      { tool: 'Read', decision: 'allow' },
+    ])
+    // Removing a non-existent (tool, scope) is a no-op.
+    assert.equal(store.removeRule('/proj/a', 'Write', 'nope/'), false)
+    // Tool-wide removal (no path) clears every remaining scope for the tool.
+    assert.equal(store.removeRule('/proj/a', 'Write'), true)
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Read', decision: 'allow' }])
+  })
+
+  it('scoped removeRule persists (a reloaded store reflects the removal)', () => {
+    const s1 = new PermissionRuleStore({ filePath, logger: silentLog })
+    s1.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'src/' })
+    s1.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'tests/' })
+    s1.removeRule('/proj/a', 'Write', 'src/')
+    const s2 = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(s2.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow', path: 'tests/' }])
+  })
+
   it('setRules preserves scopes and drops a malformed one', () => {
     const store = new PermissionRuleStore({ filePath, logger: silentLog })
     const stored = store.setRules('/proj/a', [

--- a/packages/server/tests/permission-path-scoped-rules.test.js
+++ b/packages/server/tests/permission-path-scoped-rules.test.js
@@ -86,6 +86,35 @@ describe('#6803 path-scoped session rules — _matchesRule', () => {
     assert.equal(pm._matchesRule('Write', { file_path: 'src/deep/b.js' }), null, '* does not cross /')
   })
 
+  it('glob scope NEVER matches a target that escapes the session cwd (PR #6873 review)', () => {
+    // `**/*.js` / `**` must not reach ABOVE base via `..` or an absolute path.
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: '**/*.js' }])
+    assert.equal(pm._matchesRule('Write', { file_path: '../evil.js' }), null, '../ escape must not match')
+    assert.equal(pm._matchesRule('Write', { file_path: '../../etc/x.js' }), null)
+    assert.equal(pm._matchesRule('Write', { file_path: '/etc/passwd.js' }), null, 'absolute escape must not match')
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.js' }), 'allow', 'an in-cwd target still matches')
+
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: '**' }])
+    assert.equal(pm._matchesRule('Write', { file_path: '/etc/passwd' }), null, 'bare ** must not match an absolute target')
+    assert.equal(pm._matchesRule('Write', { file_path: '../secret' }), null)
+    assert.equal(pm._matchesRule('Write', { file_path: 'a/b/c' }), 'allow')
+
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/**' }])
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a/b.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: '../../etc/x' }), null, 'a ..-escape falls through to a prompt')
+  })
+
+  it('a glob-escape target falls through to a fresh prompt end-to-end', async () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: '**/*.js' }])
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+    const promise = pm.handlePermission('Write', { file_path: '../evil.js' }, null, 'approve')
+    assert.equal(events.length, 1, 'an out-of-cwd glob target must prompt, not auto-approve')
+    pm.respondToPermission(events[0].requestId, 'deny')
+    const result = await promise
+    assert.equal(result.behavior, 'deny')
+  })
+
   it('multi-target: matches only when EVERY target is in scope', () => {
     pm.setRules([{ tool: 'apply_patch', decision: 'allow', path: 'src/' }])
     // all in scope → allow

--- a/packages/server/tests/permission-path-scoped-rules.test.js
+++ b/packages/server/tests/permission-path-scoped-rules.test.js
@@ -1,0 +1,230 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { PermissionManager } from '../src/permission-manager.js'
+import { PermissionRuleStore } from '../src/permission-rule-store.js'
+
+/**
+ * #6803 — path-scoped permission rules.
+ *
+ * PermissionRuleSchema gained an OPTIONAL `path` scope. A scoped rule only
+ * matches a tool call whose target path(s) all resolve UNDER the scope (a
+ * directory prefix like `src/`, or a glob like `src/**​/*.ts`). UNSCOPED rules
+ * behave exactly as before (match every path). This covers the manager's rule
+ * matching AND the durable store round-trip, plus the interaction with the
+ * #6794/#6803 protected-path floor.
+ *
+ * Every store writes to a temp dir (never the real ~/.chroxy) so the #4633
+ * sandbox guard is satisfied. Paths are synthetic (string ops only).
+ */
+
+const silentLog = { info() {}, warn() {}, error() {} }
+const CWD = '/work/project'
+
+function createManager(opts = {}) {
+  return new PermissionManager({ log: silentLog, cwd: CWD, ...opts })
+}
+
+async function run(pm, tool, input, mode = 'approve') {
+  const events = []
+  const onReq = (d) => events.push(d)
+  pm.on('permission_request', onReq)
+  const promise = pm.handlePermission(tool, input, null, mode)
+  if (events.length > 0) pm.respondToPermission(events[0].requestId, 'deny')
+  const behavior = (await promise).behavior
+  pm.off('permission_request', onReq)
+  return { floored: events.length === 1, behavior }
+}
+
+describe('#6803 path-scoped session rules — _matchesRule', () => {
+  let pm
+  beforeEach(() => { pm = createManager() })
+  afterEach(() => { pm.destroy() })
+
+  it('a scoped allow Write matches a target inside the scope', () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/' }])
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/deep/nested/b.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: `${CWD}/src/abs.js` }), 'allow')
+  })
+
+  it('a scoped allow Write does NOT match a target outside the scope', () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/' }])
+    assert.equal(pm._matchesRule('Write', { file_path: 'lib/a.js' }), null)
+    assert.equal(pm._matchesRule('Write', { file_path: 'a.js' }), null)
+    assert.equal(pm._matchesRule('Write', { file_path: '../escape.js' }), null)
+  })
+
+  it('an UNSCOPED allow Write matches every path (unchanged)', () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow' }])
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'lib/a.js' }), 'allow')
+    // bare _matchesRule(tool) with no input still resolves an unscoped rule.
+    assert.equal(pm._matchesRule('Write'), 'allow')
+  })
+
+  it('a scoped rule never matches a command-shaped / path-less input', () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/' }])
+    assert.equal(pm._matchesRule('Write', { command: 'ls' }), null)
+    assert.equal(pm._matchesRule('Write', {}), null)
+    assert.equal(pm._matchesRule('Write'), null, 'no input → a scoped rule cannot confirm scope')
+  })
+
+  it('glob scope: src/**/*.js matches nested .js only', () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/**/*.js' }])
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/deep/b.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.ts' }), null, 'ext mismatch')
+    assert.equal(pm._matchesRule('Write', { file_path: 'lib/a.js' }), null, 'outside src/')
+  })
+
+  it('glob scope: single-* stays within one segment', () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/*.js' }])
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/deep/b.js' }), null, '* does not cross /')
+  })
+
+  it('multi-target: matches only when EVERY target is in scope', () => {
+    pm.setRules([{ tool: 'apply_patch', decision: 'allow', path: 'src/' }])
+    // all in scope → allow
+    assert.equal(pm._matchesRule('apply_patch', {
+      changes: [{ path: 'src/a.js', kind: 'update', diff: 'd' }, { path: 'src/b.js', kind: 'add', diff: 'd' }],
+    }), 'allow')
+    // one out of scope → no match
+    assert.equal(pm._matchesRule('apply_patch', {
+      changes: [{ path: 'src/a.js', kind: 'update', diff: 'd' }, { path: 'lib/c.js', kind: 'update', diff: 'd' }],
+    }), null)
+  })
+
+  it('a scoped deny only bites inside the scope', () => {
+    pm.setRules([{ tool: 'Read', decision: 'deny', path: 'secrets/' }])
+    assert.equal(pm._matchesRule('Read', { file_path: 'secrets/x.txt' }), 'deny')
+    assert.equal(pm._matchesRule('Read', { file_path: 'src/x.txt' }), null)
+  })
+
+  it('two scopes for the same tool coexist and match independently', () => {
+    pm.setRules([
+      { tool: 'Write', decision: 'allow', path: 'src/' },
+      { tool: 'Write', decision: 'allow', path: 'tests/' },
+    ])
+    assert.equal(pm._matchesRule('Write', { file_path: 'src/a.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'tests/a.js' }), 'allow')
+    assert.equal(pm._matchesRule('Write', { file_path: 'lib/a.js' }), null)
+  })
+
+  it('setRules rejects an empty / non-string path scope', () => {
+    assert.throws(() => pm.setRules([{ tool: 'Write', decision: 'allow', path: '' }]), /non-empty string/)
+    assert.throws(() => pm.setRules([{ tool: 'Write', decision: 'allow', path: 42 }]), /non-empty string/)
+  })
+
+  it('getRules round-trips a scoped rule and keeps unscoped rules plain', () => {
+    pm.setRules([
+      { tool: 'Write', decision: 'allow', path: 'src/' },
+      { tool: 'Read', decision: 'allow' },
+    ])
+    assert.deepEqual(pm.getRules(), [
+      { tool: 'Write', decision: 'allow', path: 'src/' },
+      { tool: 'Read', decision: 'allow' },
+    ])
+  })
+})
+
+describe('#6803 path-scoped rules end-to-end (handlePermission)', () => {
+  let pm
+  beforeEach(() => { pm = createManager() })
+  afterEach(() => { pm.destroy() })
+
+  it('(a) scoped allow Write under src/ → auto-approves a src/ write', async () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/' }])
+    const r = await run(pm, 'Write', { file_path: 'src/a.js' })
+    assert.equal(r.floored, false)
+    assert.equal(r.behavior, 'allow')
+  })
+
+  it('(a) scoped allow Write under src/ → prompts for a write OUTSIDE src/', async () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/' }])
+    const r = await run(pm, 'Write', { file_path: 'lib/a.js' })
+    assert.equal(r.floored, true, 'out-of-scope write must fall through to a prompt')
+  })
+
+  it('(a) UNSCOPED allow Write still auto-approves everywhere', async () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow' }])
+    const r = await run(pm, 'Write', { file_path: 'lib/a.js' })
+    assert.equal(r.floored, false)
+    assert.equal(r.behavior, 'allow')
+  })
+
+  it('FLOOR still wins: scoped allow Write under src/ → a secret in src/ still prompts', async () => {
+    pm.setRules([{ tool: 'Write', decision: 'allow', path: 'src/' }])
+    const r = await run(pm, 'Write', { file_path: 'src/.env' })
+    assert.equal(r.floored, true, 'the protected-path floor beats a scoped allow')
+  })
+})
+
+describe('#6803 path-scoped rules persist + round-trip through the store', () => {
+  let dir, filePath
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-scoped-rules-'))
+    filePath = join(dir, 'permission-rules.json')
+  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('addRule persists a scoped rule; getRules reads path back', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    assert.equal(store.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'src/' }), true)
+    assert.deepEqual(store.getRules('/proj/a'), [{ tool: 'Write', decision: 'allow', path: 'src/' }])
+  })
+
+  it('two distinct scopes for one tool coexist; same scope is replaced', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'src/' })
+    store.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'tests/' })
+    assert.equal(store.getRules('/proj/a').length, 2, 'distinct scopes coexist')
+    // same (tool, scope) → replaced, not duplicated
+    store.addRule('/proj/a', { tool: 'Write', decision: 'deny', path: 'src/' })
+    const rules = store.getRules('/proj/a')
+    assert.equal(rules.length, 2)
+    assert.deepEqual(rules.find((r) => r.path === 'src/'), { tool: 'Write', decision: 'deny', path: 'src/' })
+  })
+
+  it('survives a simulated restart: a NEW store instance reads the scope back', () => {
+    const s1 = new PermissionRuleStore({ filePath, logger: silentLog })
+    s1.addRule('/proj/a', { tool: 'Write', decision: 'allow', path: 'src/' })
+    s1.addRule('/proj/a', { tool: 'Read', decision: 'allow' })
+    const s2 = new PermissionRuleStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(s2.getRules('/proj/a'), [
+      { tool: 'Write', decision: 'allow', path: 'src/' },
+      { tool: 'Read', decision: 'allow' },
+    ])
+  })
+
+  it('setRules preserves scopes and drops a malformed one', () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    const stored = store.setRules('/proj/a', [
+      { tool: 'Write', decision: 'allow', path: 'src/' },
+      { tool: 'Read', decision: 'allow', path: 42 }, // invalid scope → dropped
+      { tool: 'Edit', decision: 'allow' },
+    ])
+    assert.deepEqual(stored, [
+      { tool: 'Write', decision: 'allow', path: 'src/' },
+      { tool: 'Edit', decision: 'allow' },
+    ])
+  })
+
+  it('a store-seeded scoped rule auto-allows in-scope and prompts out-of-scope in a session', async () => {
+    const store = new PermissionRuleStore({ filePath, logger: silentLog })
+    store.addRule(CWD, { tool: 'Write', decision: 'allow', path: 'src/' })
+    const pm = new PermissionManager({ log: silentLog, cwd: CWD, ruleStore: store })
+    try {
+      // seeded persistent scoped rule applies without a prompt in-scope
+      const inScope = await run(pm, 'Write', { file_path: 'src/a.js' })
+      assert.equal(inScope.floored, false)
+      assert.equal(inScope.behavior, 'allow')
+      // out-of-scope → prompt
+      const outScope = await run(pm, 'Write', { file_path: 'lib/a.js' })
+      assert.equal(outScope.floored, true)
+    } finally { pm.destroy() }
+  })
+})

--- a/packages/server/tests/permission-secret-read-floor.test.js
+++ b/packages/server/tests/permission-secret-read-floor.test.js
@@ -97,15 +97,50 @@ describe('secret-read floor (#6803)', () => {
     })
   })
 
+  // -- PR #6873 review: credential-DENSE config files must floor for READS --
+
+  describe('READS of credential config files are floored (PR #6873 review)', () => {
+    const credentialReads = [
+      '.git/config',                 // PAT-embedded remote URL
+      '.git/credentials',            // git plaintext store
+      '.config/git/config',          // XDG git config
+      '.config/git/credentials',     // XDG git store
+      '.claude/settings.json',       // may hold ANTHROPIC_API_KEY / env
+      '.claude/settings.local.json',
+      'sub/dir/.git/config',         // any depth
+    ]
+    for (const file_path of credentialReads) {
+      it(`allow Read + Read ${file_path} → prompt`, async () => {
+        const r = await run(pm, 'Read', { file_path }, 'approve', [{ tool: 'Read', decision: 'allow' }])
+        assert.equal(r.floored, true, `${file_path} read must prompt (credential leak risk), not auto-approve`)
+      })
+    }
+
+    it('auto/bypass mode + Read .git/config → prompt (floor beats bypass)', async () => {
+      const r = await run(pm, 'Read', { file_path: '.git/config' }, 'auto')
+      assert.equal(r.floored, true)
+    })
+
+    it('case-insensitive: Read .GIT/config and .Claude/Settings.Local.json → prompt', async () => {
+      const a = await run(pm, 'Read', { file_path: '.GIT/config' }, 'approve', [{ tool: 'Read', decision: 'allow' }])
+      assert.equal(a.floored, true)
+      const pm2 = createManager()
+      try {
+        const b = await run(pm2, 'Read', { file_path: '.Claude/Settings.Local.json' }, 'approve', [{ tool: 'Read', decision: 'allow' }])
+        assert.equal(b.floored, true)
+      } finally { pm2.destroy() }
+    })
+  })
+
   // -- The key #6803 change: READS of config DIRS are NOT floored --
 
-  describe('READS of config dirs stay auto-approved (not a secret concern)', () => {
+  describe('READS of NON-credential config-dir files stay auto-approved', () => {
     const benignReads = [
-      '.git/config',
-      '.git/HEAD',
-      '.claude/settings.local.json',
-      '.vscode/settings.json',
-      '.config/git/config',
+      '.git/HEAD',              // not a credential file
+      '.git/refs/heads/main',
+      '.vscode/settings.json',  // secret-free per the issue's intent
+      '.claude/skills/foo.md',  // a runtime skill, not settings
+      '.claude/agents/x.md',
       'src/foo.js',
       'docs/readme.md',
     ]
@@ -117,8 +152,8 @@ describe('secret-read floor (#6803)', () => {
       })
     }
 
-    it('auto mode + Read .claude/settings.local.json → auto-approved (no prompt)', async () => {
-      const r = await run(pm, 'Read', { file_path: '.claude/settings.local.json' }, 'auto')
+    it('auto mode + Read .git/HEAD → auto-approved (no prompt)', async () => {
+      const r = await run(pm, 'Read', { file_path: '.git/HEAD' }, 'auto')
       assert.equal(r.floored, false)
       assert.equal(r.behavior, 'allow')
     })
@@ -199,19 +234,39 @@ describe('isSecretReadTarget vs isProtectedPathTarget (#6803)', () => {
     })
   }
 
-  // Config dirs: floored by the WRITE floor ONLY — NOT the read floor.
-  const configDirs = [
+  // Credential config files: floored by BOTH floors (PR #6873 review).
+  const credentialConfig = [
     { file_path: '.git/config' },
-    { file_path: 'sub/.git/HEAD' },
-    { file_path: '.claude/settings.local.json' },
-    { file_path: '.vscode/settings.json' },
+    { file_path: '.git/credentials' },
+    { file_path: 'sub/.git/config' },
     { file_path: '.config/git/config' },
-    { file_path: '.GIT/config' },     // case-insensitive dir
+    { file_path: '.config/git/credentials' },
+    { file_path: '.claude/settings.json' },
+    { file_path: '.claude/settings.local.json' },
+    { file_path: '.GIT/config' },                    // case-insensitive
+    { path: '.git/config' },                          // any path field
+    { changes: [{ path: 'src/ok.js', kind: 'update', diff: 'd' }, { path: '.git/config', kind: 'update', diff: 'd' }] },
+  ]
+  for (const input of credentialConfig) {
+    it(`credential config ${JSON.stringify(input)}: both floors catch it`, () => {
+      assert.equal(isSecretReadTarget(input, cwd), true, 'read floor must catch credential config files')
+      assert.equal(isProtectedPathTarget(input, cwd), true, 'write floor must catch them too')
+    })
+  }
+
+  // NON-credential config-dir files: floored by the WRITE floor ONLY.
+  const configDirs = [
+    { file_path: '.git/HEAD' },
+    { file_path: 'sub/.git/HEAD' },
+    { file_path: '.claude/skills/foo.md' },
+    { file_path: '.claude/agents/x.md' },
+    { file_path: '.vscode/settings.json' },
+    { file_path: '.config/git/attributes' },   // not config/credentials
   ]
   for (const input of configDirs) {
     it(`config dir ${JSON.stringify(input)}: write floor yes, read floor no`, () => {
       assert.equal(isProtectedPathTarget(input, cwd), true, 'write floor must catch config dirs')
-      assert.equal(isSecretReadTarget(input, cwd), false, 'read floor must NOT catch config dirs')
+      assert.equal(isSecretReadTarget(input, cwd), false, 'read floor must NOT catch a non-credential config file')
     })
   }
 

--- a/packages/server/tests/permission-secret-read-floor.test.js
+++ b/packages/server/tests/permission-secret-read-floor.test.js
@@ -1,0 +1,241 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { PermissionManager, isProtectedPathTarget, isSecretReadTarget } from '../src/permission-manager.js'
+
+/**
+ * #6803 — secret-read floor (follow-up to the #6794 write floor).
+ *
+ * The #6794 floor treats every path-carrying tool the same: it floored a Read
+ * of a config DIR (.git/.claude/.vscode/.config/git) exactly like a write. That
+ * over-prompts on benign reads. #6803 makes the floor TOOL-AWARE:
+ *
+ *   - READS (Read/Glob/Grep) are floored ONLY on SECRET FILES (env files + key
+ *     material) — reading a config dir stays a normal, un-prompted operation.
+ *   - WRITES (and any other/unknown tool) keep the FULL floor (config dirs +
+ *     secret files), now also covering key material (a strict superset — no
+ *     regression, additive).
+ *
+ * A floor only ever forces a PROMPT (never a deny); a `deny` rule still denies.
+ * Paths are synthetic (string ops only), so a fixed cwd needs no on-disk dir.
+ */
+
+const silentLog = { info() {}, warn() {} }
+const CWD = '/work/project'
+
+function createManager(opts = {}) {
+  return new PermissionManager({ log: silentLog, cwd: CWD, ...opts })
+}
+
+/**
+ * Drive handlePermission and report whether it FLOORED (emitted a prompt) or
+ * auto-decided. Resolves the pending promise/timer for a clean teardown.
+ */
+async function run(pm, tool, input, mode, rules) {
+  if (rules) pm.setRules(rules)
+  const events = []
+  const onReq = (d) => events.push(d)
+  pm.on('permission_request', onReq)
+  const promise = pm.handlePermission(tool, input, null, mode)
+  let behavior
+  if (events.length > 0) {
+    pm.respondToPermission(events[0].requestId, 'deny')
+    behavior = (await promise).behavior
+  } else {
+    behavior = (await promise).behavior
+  }
+  pm.off('permission_request', onReq)
+  return { floored: events.length === 1, behavior }
+}
+
+describe('secret-read floor (#6803)', () => {
+  let pm
+  beforeEach(() => { pm = createManager() })
+  afterEach(() => { pm.destroy() })
+
+  // -- AC: a Read of a secret under a broad `allow Read` is NOT auto-approved --
+
+  describe('READS of secret files are floored (fall through to a prompt)', () => {
+    const secretReads = [
+      '.env',
+      '.env.local',
+      '.env.production',
+      '.ssh/id_rsa',
+      'id_ed25519',
+      'certs/server.pem',
+      'keys/app.key',
+      'keystore.p12',
+      'cert.pfx',
+      '.npmrc',
+      '.pgpass',
+      '.netrc',
+    ]
+    for (const file_path of secretReads) {
+      it(`allow Read + Read ${file_path} → prompt`, async () => {
+        const r = await run(pm, 'Read', { file_path }, 'approve', [{ tool: 'Read', decision: 'allow' }])
+        assert.equal(r.floored, true, `${file_path} read must prompt, not auto-approve`)
+      })
+    }
+
+    it('auto mode + Read .env → prompt (floor beats bypass)', async () => {
+      const r = await run(pm, 'Read', { file_path: '.env' }, 'auto')
+      assert.equal(r.floored, true)
+    })
+
+    it('acceptEdits + Read .env.production → prompt', async () => {
+      const r = await run(pm, 'Read', { file_path: '.env.production' }, 'acceptEdits')
+      assert.equal(r.floored, true)
+    })
+
+    it('Grep / Glob of a secret file are floored too', async () => {
+      const g = await run(pm, 'Grep', { path: '.env' }, 'approve', [{ tool: 'Grep', decision: 'allow' }])
+      assert.equal(g.floored, true)
+      const pm2 = createManager()
+      try {
+        const gl = await run(pm2, 'Glob', { path: 'secrets/id_rsa' }, 'approve', [{ tool: 'Glob', decision: 'allow' }])
+        assert.equal(gl.floored, true)
+      } finally { pm2.destroy() }
+    })
+  })
+
+  // -- The key #6803 change: READS of config DIRS are NOT floored --
+
+  describe('READS of config dirs stay auto-approved (not a secret concern)', () => {
+    const benignReads = [
+      '.git/config',
+      '.git/HEAD',
+      '.claude/settings.local.json',
+      '.vscode/settings.json',
+      '.config/git/config',
+      'src/foo.js',
+      'docs/readme.md',
+    ]
+    for (const file_path of benignReads) {
+      it(`allow Read + Read ${file_path} → auto-approved`, async () => {
+        const r = await run(pm, 'Read', { file_path }, 'approve', [{ tool: 'Read', decision: 'allow' }])
+        assert.equal(r.floored, false, `${file_path} read must NOT prompt`)
+        assert.equal(r.behavior, 'allow')
+      })
+    }
+
+    it('auto mode + Read .claude/settings.local.json → auto-approved (no prompt)', async () => {
+      const r = await run(pm, 'Read', { file_path: '.claude/settings.local.json' }, 'auto')
+      assert.equal(r.floored, false)
+      assert.equal(r.behavior, 'allow')
+    })
+  })
+
+  // -- WRITES keep the FULL floor (config dirs + secrets, incl. key material) --
+
+  describe('WRITES keep the full floor (superset — no regression)', () => {
+    const flooredWrites = [
+      '.git/config',
+      '.claude/settings.local.json',
+      '.vscode/settings.json',
+      '.config/git/config',
+      '.env',
+      '.env.local',
+      'id_rsa',
+      'certs/server.pem',
+    ]
+    for (const file_path of flooredWrites) {
+      it(`allow Write + Write ${file_path} → prompt`, async () => {
+        const r = await run(pm, 'Write', { file_path }, 'approve', [{ tool: 'Write', decision: 'allow' }])
+        assert.equal(r.floored, true, `${file_path} write must prompt`)
+      })
+    }
+
+    it('allow Write + Write src/foo.js → auto-approved (benign)', async () => {
+      const r = await run(pm, 'Write', { file_path: 'src/foo.js' }, 'approve', [{ tool: 'Write', decision: 'allow' }])
+      assert.equal(r.floored, false)
+      assert.equal(r.behavior, 'allow')
+    })
+  })
+
+  // -- deny rules still deny (the floor never widens access) --
+
+  it('a deny Read rule on a secret still denies without a prompt', async () => {
+    const events = []
+    pm.on('permission_request', (d) => events.push(d))
+    pm.setRules([{ tool: 'Read', decision: 'deny' }])
+    const result = await pm.handlePermission('Read', { file_path: '.env' }, null, 'approve')
+    assert.equal(result.behavior, 'deny')
+    assert.equal(events.length, 0, 'a deny rule short-circuits without a prompt')
+  })
+})
+
+// -- The exported pure matchers, exercised directly --
+
+describe('isSecretReadTarget vs isProtectedPathTarget (#6803)', () => {
+  const cwd = '/work/project'
+
+  // Secret files: floored by BOTH the read floor and the write floor.
+  const secretFiles = [
+    { file_path: '.env' },
+    { file_path: '.env.local' },
+    { file_path: 'a/b/.env.production' },
+    { file_path: '.ssh/id_rsa' },
+    { file_path: 'id_dsa' },
+    { file_path: 'id_ecdsa' },
+    { file_path: 'id_ed25519' },
+    { file_path: 'certs/server.pem' },
+    { file_path: 'app.key' },
+    { file_path: 'store.p12' },
+    { file_path: 'client.pfx' },
+    { file_path: '.npmrc' },
+    { file_path: '.pgpass' },
+    { file_path: '.netrc' },
+    { file_path: '.ENV' },            // case-insensitive
+    { file_path: 'ID_RSA' },
+    { file_path: 'CERT.PEM' },
+    { path: '.env' },                 // any path field
+    { notebook_path: 'secret.pem' },
+    { changes: [{ path: 'src/ok.js', kind: 'update', diff: 'd' }, { path: '.env', kind: 'update', diff: 'd' }] },
+  ]
+  for (const input of secretFiles) {
+    it(`isSecretReadTarget floors ${JSON.stringify(input)}`, () => {
+      assert.equal(isSecretReadTarget(input, cwd), true)
+      // A secret is a subset of the full floor, so the write floor floors it too.
+      assert.equal(isProtectedPathTarget(input, cwd), true)
+    })
+  }
+
+  // Config dirs: floored by the WRITE floor ONLY — NOT the read floor.
+  const configDirs = [
+    { file_path: '.git/config' },
+    { file_path: 'sub/.git/HEAD' },
+    { file_path: '.claude/settings.local.json' },
+    { file_path: '.vscode/settings.json' },
+    { file_path: '.config/git/config' },
+    { file_path: '.GIT/config' },     // case-insensitive dir
+  ]
+  for (const input of configDirs) {
+    it(`config dir ${JSON.stringify(input)}: write floor yes, read floor no`, () => {
+      assert.equal(isProtectedPathTarget(input, cwd), true, 'write floor must catch config dirs')
+      assert.equal(isSecretReadTarget(input, cwd), false, 'read floor must NOT catch config dirs')
+    })
+  }
+
+  // Neither floor touches these.
+  const benign = [
+    { file_path: 'src/foo.js' },
+    { file_path: 'foo.env' },          // trailing .env is not a .env file
+    { file_path: '.environment/x' },   // .env* must be exactly .env or .env.
+    { file_path: '.github/workflows/ci.yml' },
+    { file_path: 'notes.pemx' },       // must END with .pem
+    { file_path: 'keyboard.md' },      // must END with .key
+    { command: 'ls' },                 // no path field
+    {},
+    null,
+  ]
+  for (const input of benign) {
+    it(`neither floor touches ${JSON.stringify(input)}`, () => {
+      assert.equal(isSecretReadTarget(input, cwd), false)
+      assert.equal(isProtectedPathTarget(input, cwd), false)
+    })
+  }
+
+  it('a .env under a cwd that itself contains .env-like prefix still resolves relative to cwd', () => {
+    assert.equal(isSecretReadTarget({ file_path: '.env' }, '/a/b'), true)
+    assert.equal(isSecretReadTarget({ file_path: 'src/a.js' }, '/a/b'), false)
+  })
+})


### PR DESCRIPTION
## Summary

Security follow-up to the merged #6794 protected-path write floor, implementing the two adjacent pieces deliberately cut from it (builds on #6794 / #6804 / #6805 / #6828 / #6849 / #6771).

### 1. Path-scoped permission rules (AC1)
`PermissionRuleSchema` was `{ tool, decision }` only, so users could not express "allow Write under `src/` only" — the gap that makes blunt all-paths `allow` rules attractive.

- **Protocol:** `PermissionRuleSchema` gains an **optional** `path` scope (a directory prefix like `src/`, or a glob like `src/**/*.ts`). Absent → unchanged (matches every path).
- **Matching:** `PermissionManager._matchesRule` honors the scope — a scoped rule only auto-decides a tool call whose target path(s) **all** resolve under the scope (against the session cwd). A scoped rule never matches a path-less / command-shaped input, so it falls through to a prompt. The `..`/absolute/`./` normalization reuses the floor's resolution logic; globs use a dependency-free `globToRegExp` (`*` = one segment, `**` = crosses dirs, `?` = one char).
- **Persistence (#6771):** the durable store round-trips the scope. Rule identity is now `(tool, path)`, so distinct scopes for one tool coexist and survive a daemon restart; two unscoped rules for a tool still collapse (last-writer-wins). A malformed scope on load/write is dropped rather than silently widened to unscoped.
- **Server handler** validates the optional scope (non-empty string) on both session and project rule sets.

### 2. Secret-read floor (AC2)
The #6794 floor treated every path-carrying tool identically, so it over-prompted on benign config-dir **reads** and — the real gap — never floored **key material** at all. The floor is now **tool-aware**:

- **Reads** (`Read`/`Glob`/`Grep`) are floored **only on secret files** — env files (`.env*`) and key material (SSH keys `id_rsa`/`id_ed25519`/…, `.pem`/`.key`/`.p12`/`.pfx`, `.npmrc`/`.pgpass`/`.netrc`). A broad `allow Read` no longer silently auto-reads a secret, but reading `.git/config` / `.claude/settings.json` stays un-prompted (mirrors Claude Code's "don't auto-read known secrets" floor without disrupting normal reads).
- **Writes** (and any other/unknown tool) keep the **full** floor (config dirs + secret files), now also covering key material — a strict superset, purely additive (no write regression).

A floor only ever forces a **prompt**, never a deny; a `deny` rule still denies.

## Acceptance criteria
- [x] `PermissionRuleSchema` accepts an optional path/glob scope; rule matching honors it; unscoped rules behave exactly as today
- [x] A `Read` of `.env` under a broad `allow Read` session rule is not silently auto-approved — it falls through to a fresh prompt
- [x] Full protocol + store-core suites green (coverage guards on the schema change)

## Testing
- New `permission-path-scoped-rules.test.js` (20) and `permission-secret-read-floor.test.js` (69) — TDD for both ACs incl. persistence round-trip, glob/prefix scoping, multi-target `changes[]`, floor-beats-scope interaction, write-floor superset, case variants.
- No regression: `permission-manager` (90), `permission-manager-protected-path-floor` (61), `permission-rule-store` (26), `settings-handlers-permission-rules` (40); every permission/ws-permission/settings test file passes individually.
- Protocol `npm test` (362) green; store-core vitest (2004) green — the three coverage guards pass (the schema change adds no new message type).
- Both required server lints pass (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`); eslint clean.
- New tests self-tear-down (destroy managers, temp `stateFilePath`, no leaked handles) and exit cleanly **without** `--test-force-exit`, so they won't hang the full CI suite.

## Notes for review
- **Behavior change to call out:** config-dir **reads** (`.git/`, `.claude/`, `.vscode/`, `.config/git/`) are no longer floored — only **secret-file** reads are. This is intentional per the issue's read-floor scoping ("for reads the concern is `.env`/secrets specifically"); config-dir flooring on reads in #6794 was an incidental side effect of the uniform matcher, and the `.env` read parity test it added is preserved. Writes to config dirs remain floored.
- `path` is additive/optional, so no existing rule-consuming client breaks. A dashboard/app UI to *author* scoped rules is a natural follow-up, out of scope for these ACs.

Closes #6803