### PR TITLE
feat(server,protocol): read-only transcript endpoint for closed sessions (#6860)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -617,6 +617,11 @@ export declare const SearchConversationsSchema: z.ZodObject<{
     query: z.ZodString;
     maxResults: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
+export declare const RequestConversationTranscriptSchema: z.ZodObject<{
+    type: z.ZodLiteral<"request_conversation_transcript">;
+    conversationId: z.ZodString;
+    cwd: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const RequestCostSummarySchema: z.ZodObject<{
     type: z.ZodLiteral<"request_cost_summary">;
 }, z.core.$strip>;
@@ -1248,6 +1253,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"search_conversations">;
     query: z.ZodString;
     maxResults: z.ZodOptional<z.ZodNumber>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"request_conversation_transcript">;
+    conversationId: z.ZodString;
+    cwd: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"request_cost_summary">;
 }, z.core.$strip>, z.ZodObject<{

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -820,6 +820,16 @@ export const SearchConversationsSchema = z.object({
     query: z.string().trim().min(1).max(500),
     maxResults: z.number().int().min(1).max(100).optional(),
 });
+// conversationId shape — MUST stay byte-for-byte in sync with the server's
+// `CONVERSATION_ID_RE` gate (packages/server/src/handlers/conversation-handlers.js),
+// which resume_conversation + the transcript handler use to guard against path
+// traversal. It is a PERMISSIVE hex-group UUID shape (any hex per group, no
+// version/variant nibble) — deliberately NOT z.string().uuid(), which enforces an
+// RFC-4122 version nibble the server does not and would reject valid server ids
+// (e.g. `00000000-0000-0000-0000-0000000c0ffe`). Matching the server exactly means
+// the wire contract rejects precisely what the handler rejects — no stricter, no
+// looser. No z.catch (the #6436 field-error-swallow trap). (#6874 review)
+const CONVERSATION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 // #6860 (epic #6765): provider-agnostic READ-ONLY transcript request. Streams a
 // CLOSED conversation's full JSONL history back to the client WITHOUT creating a
 // SessionManager entry or spawning any provider process — so it works uniformly
@@ -834,7 +844,10 @@ export const SearchConversationsSchema = z.object({
 // falls back to this value when the scan can't find the conversation.
 export const RequestConversationTranscriptSchema = z.object({
     type: z.literal('request_conversation_transcript'),
-    conversationId: z.string().max(256),
+    // .max(256) short-circuits pathological input before the regex runs; the
+    // anchored regex then enforces the exact conversation-id shape (fail-fast at
+    // the protocol layer instead of relying on the handler's runtime guard).
+    conversationId: z.string().max(256).regex(CONVERSATION_ID_RE, 'conversationId must be a UUID'),
     cwd: z.string().max(4096).optional(),
 });
 export const RequestCostSummarySchema = z.object({

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -820,6 +820,23 @@ export const SearchConversationsSchema = z.object({
     query: z.string().trim().min(1).max(500),
     maxResults: z.number().int().min(1).max(100).optional(),
 });
+// #6860 (epic #6765): provider-agnostic READ-ONLY transcript request. Streams a
+// CLOSED conversation's full JSONL history back to the client WITHOUT creating a
+// SessionManager entry or spawning any provider process — so it works uniformly
+// even for providers whose `capabilities.resume === false` (BYOK, Codex, Gemini,
+// user-shell), for which `resume_conversation` is refused outright. Distinct from
+// `resume_conversation` (which spawns a live session) and `request_full_history`
+// (which reads a LIVE session's in-memory buffer). The response reuses the
+// existing `history_replay_start` / `message` / `history_replay_end` server→client
+// frames (sourced from disk instead of a live session) so existing renderers
+// light up unchanged. `cwd` is an optional hint — the server resolves the
+// conversation's recorded cwd authoritatively from the persisted store and only
+// falls back to this value when the scan can't find the conversation.
+export const RequestConversationTranscriptSchema = z.object({
+    type: z.literal('request_conversation_transcript'),
+    conversationId: z.string().max(256),
+    cwd: z.string().max(4096).optional(),
+});
 export const RequestCostSummarySchema = z.object({
     type: z.literal('request_cost_summary'),
 });
@@ -1437,6 +1454,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     ListConversationsSchema,
     ResumeConversationSchema,
     SearchConversationsSchema,
+    RequestConversationTranscriptSchema,
     RequestCostSummarySchema,
     SubscribeSessionsSchema,
     UnsubscribeSessionsSchema,

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -928,6 +928,17 @@ export const SearchConversationsSchema = z.object({
   maxResults: z.number().int().min(1).max(100).optional(),
 })
 
+// conversationId shape — MUST stay byte-for-byte in sync with the server's
+// `CONVERSATION_ID_RE` gate (packages/server/src/handlers/conversation-handlers.js),
+// which resume_conversation + the transcript handler use to guard against path
+// traversal. It is a PERMISSIVE hex-group UUID shape (any hex per group, no
+// version/variant nibble) — deliberately NOT z.string().uuid(), which enforces an
+// RFC-4122 version nibble the server does not and would reject valid server ids
+// (e.g. `00000000-0000-0000-0000-0000000c0ffe`). Matching the server exactly means
+// the wire contract rejects precisely what the handler rejects — no stricter, no
+// looser. No z.catch (the #6436 field-error-swallow trap). (#6874 review)
+const CONVERSATION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 // #6860 (epic #6765): provider-agnostic READ-ONLY transcript request. Streams a
 // CLOSED conversation's full JSONL history back to the client WITHOUT creating a
 // SessionManager entry or spawning any provider process — so it works uniformly
@@ -942,7 +953,10 @@ export const SearchConversationsSchema = z.object({
 // falls back to this value when the scan can't find the conversation.
 export const RequestConversationTranscriptSchema = z.object({
   type: z.literal('request_conversation_transcript'),
-  conversationId: z.string().max(256),
+  // .max(256) short-circuits pathological input before the regex runs; the
+  // anchored regex then enforces the exact conversation-id shape (fail-fast at
+  // the protocol layer instead of relying on the handler's runtime guard).
+  conversationId: z.string().max(256).regex(CONVERSATION_ID_RE, 'conversationId must be a UUID'),
   cwd: z.string().max(4096).optional(),
 })
 

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -928,6 +928,24 @@ export const SearchConversationsSchema = z.object({
   maxResults: z.number().int().min(1).max(100).optional(),
 })
 
+// #6860 (epic #6765): provider-agnostic READ-ONLY transcript request. Streams a
+// CLOSED conversation's full JSONL history back to the client WITHOUT creating a
+// SessionManager entry or spawning any provider process — so it works uniformly
+// even for providers whose `capabilities.resume === false` (BYOK, Codex, Gemini,
+// user-shell), for which `resume_conversation` is refused outright. Distinct from
+// `resume_conversation` (which spawns a live session) and `request_full_history`
+// (which reads a LIVE session's in-memory buffer). The response reuses the
+// existing `history_replay_start` / `message` / `history_replay_end` server→client
+// frames (sourced from disk instead of a live session) so existing renderers
+// light up unchanged. `cwd` is an optional hint — the server resolves the
+// conversation's recorded cwd authoritatively from the persisted store and only
+// falls back to this value when the scan can't find the conversation.
+export const RequestConversationTranscriptSchema = z.object({
+  type: z.literal('request_conversation_transcript'),
+  conversationId: z.string().max(256),
+  cwd: z.string().max(4096).optional(),
+})
+
 export const RequestCostSummarySchema = z.object({
   type: z.literal('request_cost_summary'),
 })
@@ -1609,6 +1627,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   ListConversationsSchema,
   ResumeConversationSchema,
   SearchConversationsSchema,
+  RequestConversationTranscriptSchema,
   RequestCostSummarySchema,
   SubscribeSessionsSchema,
   UnsubscribeSessionsSchema,

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -734,6 +734,38 @@ describe('@chroxy/protocol schemas', () => {
     }
   })
 
+  // #6874 review (Copilot): the transcript request must fail fast at the protocol
+  // layer for a malformed conversationId, matching the server's CONVERSATION_ID_RE
+  // gate exactly (no stricter, no looser) so a valid server id is never rejected.
+  it('RequestConversationTranscriptSchema requires a UUID conversationId', async () => {
+    const { RequestConversationTranscriptSchema } = await import('../src/schemas/client.ts')
+
+    const base = { type: 'request_conversation_transcript' }
+
+    // Rejected at the schema level: empty, whitespace, and non-UUID shapes.
+    for (const bad of ['', '   ', 'not-a-uuid', '../../etc/passwd', '12345', '00000000-0000-0000-0000-00000000000']) {
+      const r = RequestConversationTranscriptSchema.safeParse({ ...base, conversationId: bad })
+      assert.equal(r.success, false, `conversationId '${bad}' must be rejected`)
+    }
+
+    // Accepted: canonical hex-group UUIDs, including the permissive server-style
+    // ids that z.string().uuid() (RFC version nibble) would wrongly reject.
+    for (const good of [
+      '550e8400-e29b-41d4-a716-446655440000',
+      '00000000-0000-0000-0000-0000000c0ffe',
+      '11111111-2222-3333-4444-555555555555',
+    ]) {
+      const r = RequestConversationTranscriptSchema.safeParse({ ...base, conversationId: good })
+      assert.equal(r.success, true, `conversationId '${good}' must be accepted`)
+    }
+
+    // The optional cwd hint still round-trips.
+    const withCwd = RequestConversationTranscriptSchema.safeParse({
+      ...base, conversationId: '550e8400-e29b-41d4-a716-446655440000', cwd: '/home/dev/repo',
+    })
+    assert.equal(withCwd.success, true)
+  })
+
   it('accepts ServerMessageSchema with optional code field for structured errors', async () => {
     const { ServerMessageSchema } = await import('../src/schemas/server.ts')
     const result = ServerMessageSchema.safeParse({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -712,6 +712,7 @@ describe('@chroxy/protocol schemas', () => {
       'delete_checkpoint', 'close_dev_preview',
       'launch_web_task', 'list_web_tasks', 'teleport_web_task',
       'list_conversations', 'resume_conversation', 'search_conversations',
+      'request_conversation_transcript',
       'request_cost_summary', 'subscribe_sessions', 'unsubscribe_sessions',
       'client_visible',
       'list_providers', 'list_repos', 'add_repo', 'remove_repo',

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -2,15 +2,22 @@
  * Conversation, history, and cost summary handlers.
  *
  * Handles: list_conversations, search_conversations, resume_conversation,
- *          request_full_history, request_session_context, request_cost_summary
+ *          request_conversation_transcript, request_full_history,
+ *          request_session_context, request_cost_summary
  */
 import { scanConversations as defaultScanConversations } from '../conversation-scanner.js'
 import { searchConversations as defaultSearchConversations } from '../conversation-search.js'
+import { resolveJsonlPath, readConversationHistoryAsync as defaultReadConversationHistoryAsync } from '../jsonl-reader.js'
 import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError } from '../handler-utils.js'
 import { scopeConversationsToClient } from '../conversation-scope.js'
 import { createLogger, loggerForSession } from '../logger.js'
 
 const log = createLogger('ws')
+
+// UUID v4-ish shape guard shared by resume_conversation and the read-only
+// transcript handler — rejects anything that isn't a canonical conversation id
+// before it reaches the filesystem, closing path-traversal via the id segment.
+const CONVERSATION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 async function handleListConversations(ws, client, msg, ctx) {
   // ctx.scanConversations override allows tests to inject a stub and skip real fs.
@@ -76,7 +83,7 @@ async function handleResumeConversation(ws, client, msg, ctx) {
     return
   }
   // Validate conversationId is a UUID to prevent path traversal
-  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(conversationId)) {
+  if (!CONVERSATION_ID_RE.test(conversationId)) {
     sendSessionError(ws, ctx, 'Invalid conversationId format')
     return
   }
@@ -107,6 +114,113 @@ async function handleResumeConversation(ws, client, msg, ctx) {
   } catch (err) {
     sendSessionError(ws, ctx, err.message)
   }
+}
+
+/**
+ * Read-only transcript endpoint (#6860, epic #6765).
+ *
+ * Streams a CLOSED conversation's full history back to the requesting client
+ * straight off the persisted store (the Claude Code CLI JSONL layer under
+ * `~/.claude/projects/`) — WITHOUT calling `createSession` or spawning any
+ * provider process. Because it reads persisted bytes rather than driving a live
+ * process, it works uniformly for every provider, including those whose
+ * `capabilities.resume === false` (BYOK, Codex, Gemini, user-shell) for which
+ * `resume_conversation` is refused outright.
+ *
+ * Access follows the same cwd-scoping as `list_conversations`/`search_conversations`
+ * (`scopeConversationsToClient`): an UNBOUND client (primary token / dashboard)
+ * may read any conversation; a BOUND pairing-issued client may only read
+ * conversations recorded under its bound session's cwd — anything else is
+ * rejected. This mirrors bearer-token-authority.md: read-only history is the
+ * same authority class as other session-state reads.
+ *
+ * The response reuses the existing `history_replay_start` / `message` /
+ * `history_replay_end` server→client frames (identical to `handleRequestFullHistory`,
+ * only sourced from disk) so clients render it with their existing renderers.
+ * The replay frames carry the `conversationId` in the `sessionId` field — there
+ * is no live session, and a resumed session always gets a fresh id distinct from
+ * the conversationId, so this cannot collide with or clobber a live session's
+ * transcript.
+ */
+async function handleRequestConversationTranscript(ws, client, msg, ctx) {
+  const { conversationId } = msg
+  if (!conversationId || typeof conversationId !== 'string') {
+    sendSessionError(ws, ctx, 'Missing conversationId')
+    return
+  }
+  // UUID guard — path-traversal protection (same gate as resume_conversation).
+  if (!CONVERSATION_ID_RE.test(conversationId)) {
+    sendSessionError(ws, ctx, 'Invalid conversationId format')
+    return
+  }
+
+  // Resolve the conversation's recorded cwd authoritatively from the persisted
+  // store (the scanner reads the same JSONL layer list_conversations does). Only
+  // fall back to a client-provided cwd hint when the scan can't find it (e.g. a
+  // tiny conversation below the scanner's MIN_FILE_SIZE floor).
+  const scan = ctx.scanConversations || defaultScanConversations
+  let conv = null
+  try {
+    const scanOpts = ctx.runtime.projectsDirs ? { projectsDirs: ctx.runtime.projectsDirs } : {}
+    const all = await scan(scanOpts)
+    conv = Array.isArray(all) ? all.find((c) => c?.conversationId === conversationId) || null : null
+  } catch (err) {
+    // Scan failure is non-fatal — fall through to the client-provided cwd hint.
+    log.warn(`Transcript scan failed for ${conversationId}: ${err.message}`)
+  }
+
+  let cwd = conv?.cwd || null
+  if (!cwd && typeof msg.cwd === 'string' && msg.cwd) {
+    // Client-supplied fallback: validate it against the same path hygiene the
+    // create/resume paths enforce before trusting it to resolve a filesystem path.
+    const cwdError = validateCwdAllowed(msg.cwd, ctx.services.config)
+    if (cwdError) {
+      sendSessionError(ws, ctx, cwdError)
+      return
+    }
+    cwd = msg.cwd
+  }
+
+  if (!cwd) {
+    sendSessionError(ws, ctx, `Conversation not found: ${conversationId}`)
+    return
+  }
+
+  // Scope enforcement — reuse the guard list_conversations/search_conversations
+  // use. A bound client that can't see this cwd gets an empty set → reject.
+  const scoped = scopeConversationsToClient([{ conversationId, cwd }], client, ctx)
+  if (scoped.length === 0) {
+    sendSessionError(ws, ctx, 'Not authorized to view this conversation')
+    return
+  }
+
+  // Read the transcript from disk. NO createSession, NO provider spawn. Reader is
+  // injectable for tests so the suite never touches the real ~/.claude/projects.
+  const readTranscript = ctx.readConversationTranscript || defaultReadConversationHistoryAsync
+  let messages = []
+  try {
+    messages = await readTranscript(resolveJsonlPath(cwd, conversationId))
+  } catch (err) {
+    // A read error is graceful — surface an empty transcript rather than a crash.
+    log.warn(`Failed to read transcript for ${conversationId}: ${err.message}`)
+    messages = []
+  }
+
+  // Stream back using the SAME wire shape as request_full_history so existing
+  // renderers light up. `sessionId` carries the conversationId (read-only; no
+  // live session exists for a closed conversation).
+  ctx.transport.send(ws, { type: 'history_replay_start', sessionId: conversationId, fullHistory: true, conversationId })
+  for (const entry of messages) {
+    ctx.transport.send(ws, {
+      type: 'message',
+      messageType: entry.type,
+      content: entry.content,
+      tool: entry.tool,
+      timestamp: entry.timestamp,
+      sessionId: conversationId,
+    })
+  }
+  ctx.transport.send(ws, { type: 'history_replay_end', sessionId: conversationId })
 }
 
 async function handleRequestFullHistory(ws, client, msg, ctx) {
@@ -195,6 +309,7 @@ export const conversationHandlers = {
   list_conversations: handleListConversations,
   search_conversations: handleSearchConversations,
   resume_conversation: handleResumeConversation,
+  request_conversation_transcript: handleRequestConversationTranscript,
   request_full_history: handleRequestFullHistory,
   request_session_context: handleRequestSessionContext,
   request_cost_summary: handleRequestCostSummary,

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -5,6 +5,7 @@
  *          request_conversation_transcript, request_full_history,
  *          request_session_context, request_cost_summary
  */
+import { realpathSync } from 'fs'
 import { scanConversations as defaultScanConversations } from '../conversation-scanner.js'
 import { searchConversations as defaultSearchConversations } from '../conversation-search.js'
 import { resolveJsonlPath, readConversationHistoryAsync as defaultReadConversationHistoryAsync } from '../jsonl-reader.js'
@@ -178,7 +179,16 @@ async function handleRequestConversationTranscript(ws, client, msg, ctx) {
       sendSessionError(ws, ctx, cwdError)
       return
     }
-    cwd = msg.cwd
+    // Defense-in-depth: validateCwdAllowed already resolved + vetted the realpath
+    // but discarded it. Canonicalize ONCE here and reuse the resolved path for
+    // BOTH the scope check and the on-disk read, so a symlinked hint can't point
+    // the scope check at one directory and the file read at another.
+    try {
+      cwd = realpathSync(msg.cwd)
+    } catch {
+      sendSessionError(ws, ctx, `Cannot resolve path: ${msg.cwd}`)
+      return
+    }
   }
 
   if (!cwd) {

--- a/packages/server/src/jsonl-reader.js
+++ b/packages/server/src/jsonl-reader.js
@@ -1,9 +1,19 @@
-import { readFileSync, statSync, existsSync } from 'fs'
-import { readFile } from 'fs/promises'
+import { readFileSync, statSync, existsSync, openSync, readSync, closeSync, fstatSync } from 'fs'
+import { readFile, stat, open } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 
 const MAX_MESSAGES = 500
+
+// Byte ceiling for a single transcript read. The wire replay is capped at
+// MAX_MESSAGES frames, but the file read itself was previously unbounded — a
+// caller (including a bound client via the read-only transcript endpoint, #6860)
+// could trigger a full-file buffer of an arbitrarily large JSONL. Files larger
+// than this are read from the TAIL only (most-recent activity), so the result is
+// gracefully truncated to recent history rather than crashing or buffering the
+// whole file. 25MB comfortably fits even long real transcripts while bounding
+// worst-case memory. Overridable per-call for tests.
+export const MAX_TRANSCRIPT_BYTES = 25 * 1024 * 1024
 
 /**
  * Encode a filesystem path the same way Claude Code does for its project directories.
@@ -157,15 +167,38 @@ function parseJsonlContent(raw) {
  * @param {string} filePath - Absolute path to the JSONL file
  * @returns {Array<{ type: string, content: string, tool?: string, timestamp: number, messageId?: string }>}
  */
-export function readConversationHistory(filePath) {
+export function readConversationHistory(filePath, maxBytes = MAX_TRANSCRIPT_BYTES) {
   let raw
   try {
-    raw = readFileSync(filePath, 'utf-8')
+    const { size } = statSync(filePath)
+    raw = size > maxBytes
+      ? readTailBytesSync(filePath, maxBytes)
+      : readFileSync(filePath, 'utf-8')
   } catch {
     return []
   }
 
   return parseJsonlContent(raw)
+}
+
+/**
+ * Read the last `maxBytes` of a file (sync). Used when a JSONL exceeds the
+ * transcript byte ceiling so the read stays bounded. The window's first line is
+ * usually a partial JSONL record; parseJsonlContent skips unparseable lines, so
+ * the truncated head is dropped automatically.
+ */
+function readTailBytesSync(filePath, maxBytes) {
+  const fd = openSync(filePath, 'r')
+  try {
+    const { size } = fstatSync(fd)
+    const start = Math.max(0, size - maxBytes)
+    const length = size - start
+    const buf = Buffer.alloc(length)
+    readSync(fd, buf, 0, length, start)
+    return new TextDecoder('utf-8', { fatal: false }).decode(buf)
+  } finally {
+    closeSync(fd)
+  }
 }
 
 /**
@@ -175,13 +208,34 @@ export function readConversationHistory(filePath) {
  * @param {string} filePath - Absolute path to the JSONL file
  * @returns {Promise<Array<{ type: string, content: string, tool?: string, timestamp: number, messageId?: string }>>}
  */
-export async function readConversationHistoryAsync(filePath) {
+export async function readConversationHistoryAsync(filePath, maxBytes = MAX_TRANSCRIPT_BYTES) {
   let raw
   try {
-    raw = await readFile(filePath, 'utf-8')
+    const { size } = await stat(filePath)
+    raw = size > maxBytes
+      ? await readTailBytesAsync(filePath, maxBytes)
+      : await readFile(filePath, 'utf-8')
   } catch {
     return []
   }
 
   return parseJsonlContent(raw)
+}
+
+/**
+ * Async variant of readTailBytesSync — read the last `maxBytes` of a file so an
+ * oversized transcript read stays bounded (see MAX_TRANSCRIPT_BYTES).
+ */
+async function readTailBytesAsync(filePath, maxBytes) {
+  const handle = await open(filePath, 'r')
+  try {
+    const { size } = await handle.stat()
+    const start = Math.max(0, size - maxBytes)
+    const length = size - start
+    const buf = Buffer.alloc(length)
+    await handle.read(buf, 0, length, start)
+    return new TextDecoder('utf-8', { fatal: false }).decode(buf)
+  } finally {
+    await handle.close()
+  }
 }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -291,6 +291,7 @@ function _isSecureRequest(req) {
  *   { type: 'git_status' }                              — request git status
  *   { type: 'git_unstage', files }                      — unstage files
  *   { type: 'list_conversations' }                      — request saved conversation list
+ *   { type: 'request_conversation_transcript', conversationId, cwd? } — read-only replay of a CLOSED conversation from disk (no provider spawn; #6860)
  *   { type: 'list_files', path? }                       — request file listing for a path
  *   { type: 'list_symbols', path? }                     — request workspace symbol table (#6471, opt-in IDE — features.ide)
  *   { type: 'resolve_symbol', symbol, file? }           — resolve a symbol name to its definition (#6475, opt-in IDE — features.ide)

--- a/packages/server/tests/handlers/conversation-handlers.test.js
+++ b/packages/server/tests/handlers/conversation-handlers.test.js
@@ -723,6 +723,38 @@ describe('conversation-handlers', () => {
       assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
     })
 
+    it('uses the authoritative recorded cwd, ignoring a spoofed in-scope cwd hint', async () => {
+      // A bound client supplies a msg.cwd that IS within its scope but is NOT the
+      // conversation's real recorded cwd. The recorded cwd (from the scan) must
+      // win outright — the hint is ignored, so a client can't redirect the read
+      // to a different (still in-scope) directory it doesn't actually own.
+      const sessions = new Map()
+      sessions.set('bound-1', { session: createMockSession(), name: 'S', cwd: '/home/dev/Projects/chroxy' })
+      const ctx = makeCtx(sessions)
+      ctx.scanConversations = createSpy(async () => [
+        { conversationId: CONV_ID, cwd: '/home/dev/Projects/chroxy/real' },
+      ])
+      let readPath = null
+      ctx.readConversationTranscript = createSpy(async (p) => {
+        readPath = p
+        return [{ type: 'user_input', content: 'x', timestamp: 1 }]
+      })
+      const client = makeClient({ boundSessionId: 'bound-1' })
+
+      await conversationHandlers.request_conversation_transcript(makeWs(), client, {
+        type: 'request_conversation_transcript',
+        conversationId: CONV_ID,
+        cwd: '/home/dev/Projects/chroxy/fake', // in-scope but NOT the recorded cwd
+      }, ctx)
+
+      assert.match(readPath, /-home-dev-Projects-chroxy-real/,
+        'read path must derive from the recorded cwd, not the client-supplied hint')
+      assert.ok(!/fake/.test(readPath),
+        'the spoofed cwd hint must not influence the resolved path')
+      assert.ok(ctx._sent.find(m => m.type === 'history_replay_start'), 'in-scope recorded read must replay')
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+    })
+
     it('validates a client-supplied cwd fallback when the scan can not find the conversation', async () => {
       // The scan misses (empty), so the handler falls back to msg.cwd — which must
       // pass the same path-hygiene gate create/resume use. A bogus dir is rejected

--- a/packages/server/tests/handlers/conversation-handlers.test.js
+++ b/packages/server/tests/handlers/conversation-handlers.test.js
@@ -593,6 +593,156 @@ describe('conversation-handlers', () => {
     })
   })
 
+  // Issue #6860 (epic #6765) — read-only transcript endpoint.
+  //
+  // Serves a CLOSED conversation's full history straight off the persisted CLI
+  // JSONL store WITHOUT createSession or any provider spawn, so it works for
+  // every provider (including capabilities.resume === false ones). The reader is
+  // injected via ctx.readConversationTranscript so the suite never touches the
+  // real ~/.claude/projects tree.
+  describe('request_conversation_transcript', () => {
+    const CONV_ID = '00000000-0000-0000-0000-0000000c0ffe'
+
+    it('replays a closed conversation from disk WITHOUT spawning a provider', async () => {
+      const ctx = makeCtx()
+      ctx.scanConversations = createSpy(async () => [{ conversationId: CONV_ID, cwd: '/tmp/repo' }])
+      const transcript = [
+        { type: 'user_input', content: 'hello', timestamp: 1 },
+        { type: 'response', content: 'hi there', timestamp: 2 },
+        { type: 'tool_use', tool: 'Bash', content: '{"command":"ls"}', timestamp: 3 },
+      ]
+      let readPath = null
+      ctx.readConversationTranscript = createSpy(async (p) => { readPath = p; return transcript })
+
+      await conversationHandlers.request_conversation_transcript(makeWs(), makeClient(), {
+        type: 'request_conversation_transcript',
+        conversationId: CONV_ID,
+      }, ctx)
+
+      // The load-bearing assertion for this slice: NO provider was spawned.
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0,
+        'read-only transcript must NEVER call createSession (no provider spawn)')
+
+      // Wire shape mirrors request_full_history so existing renderers light up.
+      const start = ctx._sent.find(m => m.type === 'history_replay_start')
+      const end = ctx._sent.find(m => m.type === 'history_replay_end')
+      const messages = ctx._sent.filter(m => m.type === 'message')
+      assert.ok(start, 'history_replay_start must be sent')
+      assert.equal(start.sessionId, CONV_ID, 'replay frames carry the conversationId as sessionId')
+      assert.equal(start.fullHistory, true)
+      assert.equal(start.conversationId, CONV_ID)
+      assert.ok(end, 'history_replay_end must be sent')
+      assert.equal(end.sessionId, CONV_ID)
+      assert.deepEqual(messages.map(m => m.messageType), ['user_input', 'response', 'tool_use'])
+      assert.equal(messages[2].tool, 'Bash', 'tool_use frames must carry the tool name')
+
+      // Reader was pointed at the CLI JSONL path resolved from the recorded cwd.
+      assert.equal(ctx.readConversationTranscript.callCount, 1)
+      assert.match(readPath, new RegExp(`${CONV_ID}\\.jsonl$`))
+      assert.match(readPath, /-tmp-repo/, 'path must encode the recorded cwd (Claude Code layout)')
+    })
+
+    it('sends session_error for a missing conversationId', async () => {
+      const ctx = makeCtx()
+      await conversationHandlers.request_conversation_transcript(makeWs(), makeClient(), {
+        type: 'request_conversation_transcript',
+      }, ctx)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /Missing conversationId/)
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+    })
+
+    it('sends session_error for an invalid conversationId format (path-traversal guard)', async () => {
+      const ctx = makeCtx()
+      await conversationHandlers.request_conversation_transcript(makeWs(), makeClient(), {
+        type: 'request_conversation_transcript',
+        conversationId: '../../etc/passwd',
+      }, ctx)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /Invalid conversationId/)
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+    })
+
+    it('gracefully reports not-found when the conversation is not on disk (no provider spawn)', async () => {
+      const ctx = makeCtx() // default scanner returns []
+      ctx.readConversationTranscript = createSpy(async () => [])
+
+      await conversationHandlers.request_conversation_transcript(makeWs(), makeClient(), {
+        type: 'request_conversation_transcript',
+        conversationId: CONV_ID,
+      }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.match(ctx._sent[0].message, /Conversation not found/)
+      assert.equal(ctx.readConversationTranscript.callCount, 0,
+        'must not attempt a disk read when the cwd can not be resolved')
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+    })
+
+    it('rejects a bound client requesting a conversation OUTSIDE its bound cwd', async () => {
+      const sessions = new Map()
+      sessions.set('bound-1', { session: createMockSession(), name: 'S', cwd: '/home/dev/Projects/chroxy' })
+      const ctx = makeCtx(sessions)
+      ctx.scanConversations = createSpy(async () => [{ conversationId: CONV_ID, cwd: '/home/dev/Projects/secret' }])
+      ctx.readConversationTranscript = createSpy(async () => [{ type: 'user_input', content: 'x', timestamp: 1 }])
+      const client = makeClient({ boundSessionId: 'bound-1' })
+
+      await conversationHandlers.request_conversation_transcript(makeWs(), client, {
+        type: 'request_conversation_transcript',
+        conversationId: CONV_ID,
+      }, ctx)
+
+      const err = ctx._sent.find(m => m.type === 'session_error')
+      assert.ok(err, 'out-of-scope request must be rejected')
+      assert.match(err.message, /Not authorized/)
+      assert.equal(ctx.readConversationTranscript.callCount, 0,
+        'a rejected request must never read the transcript off disk')
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+      assert.equal(ctx._sent.some(m => m.type === 'history_replay_start'), false)
+    })
+
+    it('allows a bound client to read a conversation WITHIN its bound cwd', async () => {
+      const sessions = new Map()
+      sessions.set('bound-1', { session: createMockSession(), name: 'S', cwd: '/home/dev/Projects/chroxy' })
+      const ctx = makeCtx(sessions)
+      ctx.scanConversations = createSpy(async () => [
+        { conversationId: CONV_ID, cwd: '/home/dev/Projects/chroxy/packages/server' },
+      ])
+      ctx.readConversationTranscript = createSpy(async () => [{ type: 'user_input', content: 'in scope', timestamp: 1 }])
+      const client = makeClient({ boundSessionId: 'bound-1' })
+
+      await conversationHandlers.request_conversation_transcript(makeWs(), client, {
+        type: 'request_conversation_transcript',
+        conversationId: CONV_ID,
+      }, ctx)
+
+      assert.equal(ctx._sent.some(m => m.type === 'session_error'), false,
+        'an in-scope bound read must not error')
+      assert.ok(ctx._sent.find(m => m.type === 'history_replay_start'), 'in-scope read must replay')
+      assert.equal(ctx.readConversationTranscript.callCount, 1)
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+    })
+
+    it('validates a client-supplied cwd fallback when the scan can not find the conversation', async () => {
+      // The scan misses (empty), so the handler falls back to msg.cwd — which must
+      // pass the same path-hygiene gate create/resume use. A bogus dir is rejected
+      // BEFORE any disk read, and no provider is spawned.
+      const ctx = makeCtx() // default scanner returns []
+      ctx.readConversationTranscript = createSpy(async () => [])
+
+      await conversationHandlers.request_conversation_transcript(makeWs(), makeClient(), {
+        type: 'request_conversation_transcript',
+        conversationId: CONV_ID,
+        cwd: '/nonexistent/definitely/not/here',
+      }, ctx)
+
+      assert.equal(ctx._sent[0].type, 'session_error',
+        'an invalid fallback cwd must be rejected by validateCwdAllowed')
+      assert.equal(ctx.readConversationTranscript.callCount, 0)
+      assert.equal(ctx.sessions.sessionManager.createSession.callCount, 0)
+    })
+  })
+
   describe('request_full_history', () => {
     it('sends session_error when no active session', async () => {
       const ctx = makeCtx()

--- a/packages/server/tests/jsonl-reader.test.js
+++ b/packages/server/tests/jsonl-reader.test.js
@@ -10,6 +10,7 @@ import {
   getJsonlMtime,
   readConversationHistory,
   readConversationHistoryAsync,
+  MAX_TRANSCRIPT_BYTES,
 } from '../src/jsonl-reader.js'
 
 describe('encodeProjectPath', () => {
@@ -545,6 +546,89 @@ describe('readConversationHistoryAsync', () => {
 
       const result = await readConversationHistoryAsync(filePath)
       assert.equal(result.length, 2)
+    } finally {
+      teardown()
+    }
+  })
+})
+
+// #6860 — DoS guard: a transcript larger than the byte ceiling is read from the
+// TAIL only (bounded), never fully buffered. The maxBytes override lets these
+// tests exercise the cap without writing a real 25MB file.
+describe('transcript byte ceiling', () => {
+  let tempDir
+
+  function writeJsonl(filename, entries) {
+    const filePath = join(tempDir, filename)
+    const content = entries.map(e => JSON.stringify(e)).join('\n')
+    writeFileSync(filePath, content)
+    return filePath
+  }
+
+  function setup() {
+    tempDir = mkdtempSync(join(tmpdir(), 'chroxy-jsonl-ceiling-'))
+  }
+
+  function teardown() {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+
+  function manyEntries(n) {
+    const entries = []
+    for (let i = 0; i < n; i++) {
+      entries.push({ type: 'user', uuid: `u-${i}`, message: { content: [{ type: 'text', text: `message-${i}` }] } })
+    }
+    return entries
+  }
+
+  it('exposes a sane default ceiling', () => {
+    assert.equal(typeof MAX_TRANSCRIPT_BYTES, 'number')
+    assert.ok(MAX_TRANSCRIPT_BYTES >= 10 * 1024 * 1024 && MAX_TRANSCRIPT_BYTES <= 50 * 1024 * 1024,
+      'ceiling should sit in the 10-50MB band')
+  })
+
+  it('async: caps an oversized transcript to a tail window instead of buffering the whole file', async () => {
+    setup()
+    try {
+      const filePath = writeJsonl('big.jsonl', manyEntries(50))
+      // Default (huge) ceiling returns everything.
+      const full = await readConversationHistoryAsync(filePath)
+      assert.equal(full.length, 50)
+      // Tiny override forces a tail read — earliest messages are dropped.
+      const capped = await readConversationHistoryAsync(filePath, 200)
+      assert.ok(capped.length > 0 && capped.length < 50,
+        'must return a truncated subset (tail), not the whole file')
+      assert.equal(capped[capped.length - 1].content, 'message-49',
+        'the most-recent message must be retained')
+      assert.ok(!capped.some(m => m.content === 'message-0'),
+        'the earliest message must be dropped by the tail cap')
+    } finally {
+      teardown()
+    }
+  })
+
+  it('sync: caps an oversized transcript to a tail window', () => {
+    setup()
+    try {
+      const filePath = writeJsonl('big.jsonl', manyEntries(50))
+      const full = readConversationHistory(filePath)
+      assert.equal(full.length, 50)
+      const capped = readConversationHistory(filePath, 200)
+      assert.ok(capped.length > 0 && capped.length < 50)
+      assert.equal(capped[capped.length - 1].content, 'message-49')
+      assert.ok(!capped.some(m => m.content === 'message-0'))
+    } finally {
+      teardown()
+    }
+  })
+
+  it('reads the whole file untruncated when under the ceiling', async () => {
+    setup()
+    try {
+      const filePath = writeJsonl('small.jsonl', manyEntries(5))
+      const result = await readConversationHistoryAsync(filePath, 10 * 1024 * 1024)
+      assert.equal(result.length, 5)
+      assert.equal(result[0].content, 'message-0')
     } finally {
       teardown()
     }


### PR DESCRIPTION
## Summary

Foundation slice of the #6765 read-only-transcript epic. Adds a **provider-agnostic, read-only** handler that serves a **closed** conversation's full history straight off the persisted Claude Code CLI JSONL store (`~/.claude/projects/`) **without** calling `createSession` or spawning any provider process.

Today the only content path is `handleResumeConversation`, which always spawns a provider and is refused outright for every `capabilities.resume === false` provider (BYOK, Codex, Gemini, user-shell) — making a destroyed conversation unreachable once the process is gone. This slice reads persisted bytes instead of driving a live process, so it works uniformly for **any** provider's closed session.

## What changed

- **protocol** — new client→server `request_conversation_transcript { conversationId, cwd? }` schema, added to `ClientMessageSchema`. Dist rebuilt.
- **server** — `handleRequestConversationTranscript` (in `conversation-handlers.js`):
  - Resolves the conversation's recorded `cwd` **authoritatively** from the scanner (the same JSONL layer `list_conversations` reads); falls back to a **validated** client `cwd` hint only when the scan can't find it (e.g. a conversation below the scanner's size floor).
  - Enforces the same cwd-scoping guard (`scopeConversationsToClient`) as `list_conversations`/`search_conversations`: an unbound client may read any conversation; a **bound** pairing-issued client may only read conversations under its bound session's cwd — anything else is rejected (per `bearer-token-authority.md`, read-only history is the same authority class as other session-state reads).
  - Reads the JSONL via the existing `jsonl-reader`, then replays it using the **existing** `history_replay_start` / `message` / `history_replay_end` server→client frames (identical to `handleRequestFullHistory`, only sourced from disk) so existing renderers light up unchanged.
  - Graceful not-found / unresolvable-cwd / read-error handling — a `session_error` or empty replay, never a crash and never a spawn.
- Reused the shared UUID guard across `resume_conversation` + the new handler to close path-traversal via the id segment.

## Reused vs new message type
The **response reuses the existing** `history_replay_start` / `message` / `history_replay_end` server→client types — so **no new server→client type** and **zero server→client coverage-guard churn** (doc-block roster, handler-coverage, protocol type-coverage, store-core coverage-lint all untouched). Only a **new client→server** request type is added, which is covered by adding both the Zod schema (in `ClientMessageSchema`) and the registered handler — keeping the `ws-schema-coverage` guard green.

The replay frames carry the `conversationId` in the `sessionId` field; there is no live session and a resumed session always gets a fresh id, so this can't collide with or clobber a live session's transcript.

## Reads persisted history from
The Claude Code CLI JSONL layer under `~/.claude/projects/` — `resolveJsonlPath(cwd, conversationId)` + `readConversationHistoryAsync` (the same reader `list_conversations`/`search_conversations` build on).

## Tests
7 new handler tests: no-provider-spawn (`createSession` never called), the replay wire shape, graceful not-found, the path-traversal guard, bound-client in/out-of-scope access, and fallback-cwd validation. Reader injected via `ctx` so the suite never touches the real `~/.claude/projects`.

- protocol `npm test` — 362 pass
- server `conversation-handlers` + `ws-schema-coverage` + `ws-history` + conversation/ws sweep — pass
- store-core `npm test` (full vitest, incl. both coverage-lint guards) — 2004 pass
- both required server lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) — pass

Out of scope (sibling issues): the dashboard/mobile read-only viewer is #6863.

Closes #6860