### PR TITLE
feat(dashboard): git stage + commit UI (#6780)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -56,6 +56,7 @@ import { NotificationBanners } from './components/NotificationBanners'
 import { PendingPairRequests } from './components/PendingPairRequests'
 import { type ToastItem } from './components/Toast'
 import { FileBrowserPanel } from './components/FileBrowserPanel'
+import { GitPanel } from './components/GitPanel'
 import { CheckpointTimeline } from './components/CheckpointTimeline'
 import { FooterBar } from './components/FooterBar'
 import { type ShortcutEntry } from './components/ShortcutHelp'
@@ -2472,6 +2473,11 @@ export function App() {
                 )}
                 {viewMode === 'files' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <FileBrowserPanel />
+                )}
+                {/* #6780 — stage/unstage/commit UI on top of the existing git
+                    status/diff wiring. */}
+                {viewMode === 'git' && connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <GitPanel />
                 )}
                 {/*
                   #4397 — system tab uses the same display:none kept-alive

--- a/packages/dashboard/src/components/GitPanel.test.tsx
+++ b/packages/dashboard/src/components/GitPanel.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * GitPanel — tests for the dashboard git stage/commit UI (#6780).
+ *
+ * Mirrors the DiffViewerPanel.test.tsx mocking idiom: the store is mocked
+ * entirely, callbacks passed to setGit*Callback are captured so tests can
+ * simulate a *_result reply landing on the wire.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { GitPanel } from './GitPanel'
+
+const mockRequestGitStatus = vi.fn()
+const mockRequestGitBranches = vi.fn()
+const mockRequestGitStage = vi.fn(() => true)
+const mockRequestGitUnstage = vi.fn(() => true)
+const mockRequestGitCommit = vi.fn(() => true)
+
+let storeState: Record<string, unknown> = {}
+let capturedStatusCallback: ((result: any) => void) | null = null
+let capturedBranchesCallback: ((result: any) => void) | null = null
+let capturedStageCallback: ((result: any) => void) | null = null
+let capturedCommitCallback: ((result: any) => void) | null = null
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: any) => {
+    const store = {
+      setGitStatusCallback: (cb: any) => { capturedStatusCallback = cb },
+      requestGitStatus: mockRequestGitStatus,
+      setGitBranchesCallback: (cb: any) => { capturedBranchesCallback = cb },
+      requestGitBranches: mockRequestGitBranches,
+      setGitStageCallback: (cb: any) => { capturedStageCallback = cb },
+      requestGitStage: mockRequestGitStage,
+      requestGitUnstage: mockRequestGitUnstage,
+      setGitCommitCallback: (cb: any) => { capturedCommitCallback = cb },
+      requestGitCommit: mockRequestGitCommit,
+      connectionPhase: storeState.connectionPhase ?? 'connected',
+    }
+    return selector(store)
+  },
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequestGitStage.mockReturnValue(true)
+  mockRequestGitUnstage.mockReturnValue(true)
+  mockRequestGitCommit.mockReturnValue(true)
+  storeState = { connectionPhase: 'connected' }
+  capturedStatusCallback = null
+  capturedBranchesCallback = null
+  capturedStageCallback = null
+  capturedCommitCallback = null
+})
+
+const GIT_STATUS_WITH_CHANGES = {
+  branch: 'feat/git-panel',
+  staged: [{ path: 'src/staged.ts', status: 'modified' as const }],
+  unstaged: [{ path: 'src/unstaged.ts', status: 'modified' as const }],
+  untracked: ['src/new-file.ts'],
+  error: null,
+}
+
+const GIT_BRANCHES = {
+  branches: [
+    { name: 'main', isCurrent: false, isRemote: false },
+    { name: 'feat/git-panel', isCurrent: true, isRemote: false },
+    { name: 'origin/main', isCurrent: false, isRemote: true },
+  ],
+  currentBranch: 'feat/git-panel',
+  error: null,
+}
+
+describe('GitPanel', () => {
+  it('requests git status and branches on mount', () => {
+    render(<GitPanel />)
+    expect(mockRequestGitStatus).toHaveBeenCalledOnce()
+    expect(mockRequestGitBranches).toHaveBeenCalledOnce()
+  })
+
+  it('shows loading state initially', () => {
+    render(<GitPanel />)
+    expect(screen.getByText('Loading git status...')).toBeInTheDocument()
+  })
+
+  it('shows working tree clean when there are no changes', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!({ branch: 'main', staged: [], unstaged: [], untracked: [], error: null }))
+    expect(screen.getByText('Working tree clean')).toBeInTheDocument()
+  })
+
+  it('shows error state', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!({ branch: null, staged: [], unstaged: [], untracked: [], error: 'Git status is not available in this mode' }))
+    expect(screen.getByText('Git status is not available in this mode')).toBeInTheDocument()
+  })
+
+  it('renders staged, unstaged, and untracked file lists', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    expect(screen.getByTestId('git-staged-section').textContent).toContain('staged.ts')
+    expect(screen.getByTestId('git-unstaged-section').textContent).toContain('unstaged.ts')
+    expect(screen.getByTestId('git-untracked-section').textContent).toContain('new-file.ts')
+  })
+
+  it('shows the current branch badge', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+    expect(screen.getByTitle('Branch: feat/git-panel')).toHaveTextContent('feat/git-panel')
+  })
+
+  it('sends requestGitStage with the selected unstaged path (per-file stage)', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.click(screen.getByLabelText('Select src/unstaged.ts'))
+    fireEvent.click(screen.getByTestId('git-stage-selected-btn'))
+
+    expect(mockRequestGitStage).toHaveBeenCalledWith(['src/unstaged.ts'])
+  })
+
+  it('sends requestGitStage with all unstaged + untracked paths (stage all)', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.click(screen.getAllByText('Stage all')[0]!)
+
+    expect(mockRequestGitStage).toHaveBeenCalledWith(['src/unstaged.ts', 'src/new-file.ts'])
+  })
+
+  it('sends requestGitUnstage with the selected staged path (per-file unstage)', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.click(screen.getByLabelText('Select src/staged.ts'))
+    fireEvent.click(screen.getByTestId('git-unstage-selected-btn'))
+
+    expect(mockRequestGitUnstage).toHaveBeenCalledWith(['src/staged.ts'])
+  })
+
+  it('sends requestGitUnstage with all staged paths (unstage all)', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.click(screen.getByText('Unstage all'))
+
+    expect(mockRequestGitUnstage).toHaveBeenCalledWith(['src/staged.ts'])
+  })
+
+  it('re-fetches git status after a successful stage', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+    mockRequestGitStatus.mockClear()
+
+    fireEvent.click(screen.getByLabelText('Select src/unstaged.ts'))
+    fireEvent.click(screen.getByTestId('git-stage-selected-btn'))
+    act(() => capturedStageCallback!({ error: null }))
+
+    expect(mockRequestGitStatus).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces a stage error without clearing the selection state forever', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.click(screen.getByLabelText('Select src/unstaged.ts'))
+    fireEvent.click(screen.getByTestId('git-stage-selected-btn'))
+    act(() => capturedStageCallback!({ error: 'fatal: not a git repository' }))
+
+    expect(screen.getByTestId('git-action-error')).toHaveTextContent('fatal: not a git repository')
+  })
+
+  it('surfaces a "not connected" error when requestGitStage returns false (#6288-style guard)', () => {
+    mockRequestGitStage.mockReturnValue(false)
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.click(screen.getByLabelText('Select src/unstaged.ts'))
+    fireEvent.click(screen.getByTestId('git-stage-selected-btn'))
+
+    expect(screen.getByTestId('git-action-error')).toHaveTextContent('Stage not sent — reconnect and try again')
+    // The button must not be stuck disabled forever.
+    expect(screen.getByTestId('git-stage-selected-btn')).not.toBeDisabled()
+  })
+
+  it('disables the commit button when the message is empty (empty-message guard)', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    const commitBtn = screen.getByTestId('git-commit-btn')
+    expect(commitBtn).toBeDisabled()
+
+    fireEvent.click(commitBtn)
+    expect(mockRequestGitCommit).not.toHaveBeenCalled()
+  })
+
+  it('does not call requestGitCommit for a whitespace-only message', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    const input = screen.getByTestId('git-commit-input')
+    fireEvent.change(input, { target: { value: '   ' } })
+
+    expect(screen.getByTestId('git-commit-btn')).toBeDisabled()
+  })
+
+  it('sends requestGitCommit with the trimmed message', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    const input = screen.getByTestId('git-commit-input')
+    fireEvent.change(input, { target: { value: '  fix: typo  ' } })
+    fireEvent.click(screen.getByTestId('git-commit-btn'))
+
+    expect(mockRequestGitCommit).toHaveBeenCalledWith('fix: typo')
+  })
+
+  it('clears the commit message and re-fetches status after a successful commit', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+    mockRequestGitStatus.mockClear()
+
+    const input = screen.getByTestId('git-commit-input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'fix: typo' } })
+    fireEvent.click(screen.getByTestId('git-commit-btn'))
+    act(() => capturedCommitCallback!({ hash: 'abc1234', message: 'fix: typo', error: null }))
+
+    expect((screen.getByTestId('git-commit-input') as HTMLTextAreaElement).value).toBe('')
+    expect(mockRequestGitStatus).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces a commit error and keeps the message so the user can retry', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    const input = screen.getByTestId('git-commit-input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'fix: typo' } })
+    fireEvent.click(screen.getByTestId('git-commit-btn'))
+    act(() => capturedCommitCallback!({ hash: null, message: null, error: 'Commit message cannot be empty' }))
+
+    expect(screen.getByTestId('git-action-error')).toHaveTextContent('Commit message cannot be empty')
+    expect(input.value).toBe('fix: typo')
+  })
+
+  it('renders the branches tab with local and remote branches, current marked', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+    act(() => capturedBranchesCallback!(GIT_BRANCHES))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Branches' }))
+
+    const branchesTab = screen.getByTestId('git-branches-tab')
+    expect(branchesTab.textContent).toContain('main')
+    expect(branchesTab.textContent).toContain('feat/git-panel')
+    expect(branchesTab.textContent).toContain('origin/main')
+  })
+
+  it('does not render the commit form when nothing is staged', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!({ branch: 'main', staged: [], unstaged: [{ path: 'a.ts', status: 'modified' }], untracked: [], error: null }))
+
+    expect(screen.queryByTestId('git-commit-input')).not.toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/GitPanel.test.tsx
+++ b/packages/dashboard/src/components/GitPanel.test.tsx
@@ -205,13 +205,37 @@ describe('GitPanel', () => {
     expect(screen.getByTestId('git-commit-btn')).toBeDisabled()
   })
 
-  it('sends requestGitCommit with the trimmed message', () => {
+  it('opens a confirmation dialog before committing (does not commit on the first click)', () => {
     render(<GitPanel />)
     act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
 
-    const input = screen.getByTestId('git-commit-input')
-    fireEvent.change(input, { target: { value: '  fix: typo  ' } })
+    fireEvent.change(screen.getByTestId('git-commit-input'), { target: { value: 'fix: typo' } })
     fireEvent.click(screen.getByTestId('git-commit-btn'))
+
+    // The confirm dialog is shown and nothing has been committed yet.
+    expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument()
+    expect(mockRequestGitCommit).not.toHaveBeenCalled()
+  })
+
+  it('does not commit when the confirmation is cancelled', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.change(screen.getByTestId('git-commit-input'), { target: { value: 'fix: typo' } })
+    fireEvent.click(screen.getByTestId('git-commit-btn'))
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'))
+
+    expect(mockRequestGitCommit).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument()
+  })
+
+  it('sends requestGitCommit with the trimmed message after confirming', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.change(screen.getByTestId('git-commit-input'), { target: { value: '  fix: typo  ' } })
+    fireEvent.click(screen.getByTestId('git-commit-btn'))
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
 
     expect(mockRequestGitCommit).toHaveBeenCalledWith('fix: typo')
   })
@@ -224,6 +248,7 @@ describe('GitPanel', () => {
     const input = screen.getByTestId('git-commit-input') as HTMLTextAreaElement
     fireEvent.change(input, { target: { value: 'fix: typo' } })
     fireEvent.click(screen.getByTestId('git-commit-btn'))
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
     act(() => capturedCommitCallback!({ hash: 'abc1234', message: 'fix: typo', error: null }))
 
     expect((screen.getByTestId('git-commit-input') as HTMLTextAreaElement).value).toBe('')
@@ -237,10 +262,53 @@ describe('GitPanel', () => {
     const input = screen.getByTestId('git-commit-input') as HTMLTextAreaElement
     fireEvent.change(input, { target: { value: 'fix: typo' } })
     fireEvent.click(screen.getByTestId('git-commit-btn'))
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
     act(() => capturedCommitCallback!({ hash: null, message: null, error: 'Commit message cannot be empty' }))
 
     expect(screen.getByTestId('git-action-error')).toHaveTextContent('Commit message cannot be empty')
     expect(input.value).toBe('fix: typo')
+  })
+
+  // Regression: the durable git_status_result handler must survive a mutation.
+  // The earlier version swapped in a one-shot status callback that nulled the
+  // slot after each stage/commit — so a subsequent Refresh produced a
+  // git_status_result no callback consumed, wedging the panel on the spinner.
+  it('keeps consuming git_status_result (Refresh works) after a stage', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    // Stage a file and let the post-stage refresh land.
+    fireEvent.click(screen.getByLabelText('Select src/unstaged.ts'))
+    fireEvent.click(screen.getByTestId('git-stage-selected-btn'))
+    act(() => capturedStageCallback!({ error: null }))
+    act(() => capturedStatusCallback!({ branch: 'feat/git-panel', staged: [{ path: 'src/unstaged.ts', status: 'modified' }], unstaged: [], untracked: [], error: null }))
+
+    // Now Refresh: its git_status_result must still be consumed (status updates,
+    // no stuck "Loading git status…" spinner).
+    fireEvent.click(screen.getByText('Refresh'))
+    act(() => capturedStatusCallback!({ branch: 'main', staged: [], unstaged: [{ path: 'other.ts', status: 'modified' }], untracked: [], error: null }))
+
+    expect(screen.queryByText('Loading git status...')).not.toBeInTheDocument()
+    expect(screen.getByTestId('git-unstaged-section').textContent).toContain('other.ts')
+    expect(screen.getByTitle('Branch: main')).toBeInTheDocument()
+  })
+
+  it('keeps consuming git_status_result (Refresh works) after a commit', () => {
+    render(<GitPanel />)
+    act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    fireEvent.change(screen.getByTestId('git-commit-input'), { target: { value: 'fix: typo' } })
+    fireEvent.click(screen.getByTestId('git-commit-btn'))
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+    act(() => capturedCommitCallback!({ hash: 'abc1234', message: 'fix: typo', error: null }))
+    act(() => capturedStatusCallback!({ branch: 'feat/git-panel', staged: [], unstaged: [], untracked: [], error: null }))
+
+    // Refresh after the commit must still be consumed.
+    fireEvent.click(screen.getByText('Refresh'))
+    act(() => capturedStatusCallback!({ branch: 'feat/git-panel', staged: [], unstaged: [{ path: 'again.ts', status: 'modified' }], untracked: [], error: null }))
+
+    expect(screen.queryByText('Loading git status...')).not.toBeInTheDocument()
+    expect(screen.getByTestId('git-unstaged-section').textContent).toContain('again.ts')
   })
 
   it('renders the branches tab with local and remote branches, current marked', () => {

--- a/packages/dashboard/src/components/GitPanel.tsx
+++ b/packages/dashboard/src/components/GitPanel.tsx
@@ -1,0 +1,444 @@
+/**
+ * GitPanel — dashboard git stage/commit UI (#6780).
+ *
+ * Mirrors the mobile app's GitView (packages/app/src/components/GitView.tsx):
+ * a "Changes" tab (staged/unstaged/untracked file lists with stage/unstage
+ * checkboxes + a commit-message box) and a read-only "Branches" tab (local +
+ * remote, current branch marked). The wire messages (git_status / git_branches
+ * / git_stage / git_unstage / git_commit) and their server-side handlers
+ * (packages/server/src/ws-file-ops/git.js, packages/server/src/handlers/file-handlers.js)
+ * already existed and are provider-agnostic — this is purely the dashboard's
+ * store wiring (packages/dashboard/src/store/connection.ts + message-handler.ts)
+ * and UI, following the same request/callback shape as the existing
+ * DiffViewerPanel / FileBrowserPanel git-status wiring.
+ *
+ * Branch SWITCHING (checkout) and PR creation are NOT implemented here — no
+ * wire message exists for either today (the server's createGitOps only
+ * exposes status/branches/stage/unstage/commit), and the mobile app's own
+ * Branches tab is read-only too. Both are follow-up work.
+ */
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useConnectionStore } from '../store/connection'
+import type {
+  GitFileStatus,
+  GitStatusResult,
+  GitBranchesResult,
+  GitStageResult,
+  GitCommitResult,
+} from '../store/types'
+
+type TabId = 'changes' | 'branches'
+
+function statusLabel(status: GitFileStatus['status']): string {
+  switch (status) {
+    case 'added': return 'A'
+    case 'deleted': return 'D'
+    case 'renamed': return 'R'
+    case 'copied': return 'C'
+    case 'unknown': return '?'
+    default: return 'M'
+  }
+}
+
+function statusClass(status: GitFileStatus['status']): string {
+  switch (status) {
+    case 'added': return 'git-status-added'
+    case 'deleted': return 'git-status-deleted'
+    case 'renamed': return 'git-status-renamed'
+    case 'copied': return 'git-status-renamed'
+    case 'unknown': return 'git-status-unknown'
+    default: return 'git-status-modified'
+  }
+}
+
+function FileRow({
+  path, status, selected, onToggle,
+}: {
+  path: string
+  status: GitFileStatus['status'] | 'untracked'
+  selected: boolean
+  onToggle: () => void
+}) {
+  const name = path.includes('/') ? path.split('/').pop()! : path
+  const dir = path.includes('/') ? path.slice(0, path.lastIndexOf('/') + 1) : ''
+  const cls = status === 'untracked' ? 'git-status-untracked' : statusClass(status)
+  const label = status === 'untracked' ? 'U' : statusLabel(status)
+  return (
+    <label className="git-file-row" data-testid={`git-file-row-${path}`}>
+      <input
+        type="checkbox"
+        className="git-file-checkbox"
+        checked={selected}
+        onChange={onToggle}
+        aria-label={`${selected ? 'Deselect' : 'Select'} ${path}`}
+      />
+      <span className={`git-status-badge ${cls}`}>{label}</span>
+      <span className="git-file-path" title={path}>
+        {dir && <span className="git-file-dir">{dir}</span>}
+        <span className="git-file-name">{name}</span>
+      </span>
+    </label>
+  )
+}
+
+export function GitPanel() {
+  const setGitStatusCallback = useConnectionStore(s => s.setGitStatusCallback)
+  const requestGitStatus = useConnectionStore(s => s.requestGitStatus)
+  const setGitBranchesCallback = useConnectionStore(s => s.setGitBranchesCallback)
+  const requestGitBranches = useConnectionStore(s => s.requestGitBranches)
+  const setGitStageCallback = useConnectionStore(s => s.setGitStageCallback)
+  const requestGitStage = useConnectionStore(s => s.requestGitStage)
+  const requestGitUnstage = useConnectionStore(s => s.requestGitUnstage)
+  const setGitCommitCallback = useConnectionStore(s => s.setGitCommitCallback)
+  const requestGitCommit = useConnectionStore(s => s.requestGitCommit)
+  const connectionPhase = useConnectionStore(s => s.connectionPhase)
+
+  const [activeTab, setActiveTab] = useState<TabId>('changes')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [branch, setBranch] = useState<string | null>(null)
+  const [staged, setStaged] = useState<GitFileStatus[]>([])
+  const [unstaged, setUnstaged] = useState<GitFileStatus[]>([])
+  const [untracked, setUntracked] = useState<string[]>([])
+  const [branches, setBranches] = useState<{ name: string; isCurrent: boolean; isRemote: boolean }[]>([])
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
+  const [commitMessage, setCommitMessage] = useState('')
+  const [committing, setCommitting] = useState(false)
+  const [stagingInProgress, setStagingInProgress] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const refreshStatus = useCallback(() => {
+    setLoading(true)
+    requestGitStatus()
+  }, [requestGitStatus])
+
+  // Wire the git_status_result callback
+  useEffect(() => {
+    setGitStatusCallback((result: GitStatusResult) => {
+      setLoading(false)
+      setError(result.error)
+      if (!result.error) {
+        setBranch(result.branch)
+        setStaged(result.staged)
+        setUnstaged(result.unstaged)
+        setUntracked(result.untracked)
+      }
+    })
+    return () => setGitStatusCallback(null)
+  }, [setGitStatusCallback])
+
+  // Wire the git_branches_result callback
+  useEffect(() => {
+    setGitBranchesCallback((result: GitBranchesResult) => {
+      if (!result.error) setBranches(result.branches)
+    })
+    return () => setGitBranchesCallback(null)
+  }, [setGitBranchesCallback])
+
+  // Request status + branches once connected
+  useEffect(() => {
+    if (connectionPhase !== 'connected') return
+    refreshStatus()
+    requestGitBranches()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionPhase])
+
+  const toggleSelection = useCallback((path: string) => {
+    setSelectedPaths(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+
+  const stagedPaths = useMemo(() => new Set(staged.map(f => f.path)), [staged])
+  const unstagedPaths = useMemo(() => new Set(unstaged.map(f => f.path)), [unstaged])
+  const untrackedSet = useMemo(() => new Set(untracked), [untracked])
+
+  const hasUnstagedSelected = useMemo(
+    () => Array.from(selectedPaths).some(p => unstagedPaths.has(p) || untrackedSet.has(p)),
+    [selectedPaths, unstagedPaths, untrackedSet],
+  )
+  const hasStagedSelected = useMemo(
+    () => Array.from(selectedPaths).some(p => stagedPaths.has(p)),
+    [selectedPaths, stagedPaths],
+  )
+
+  // Shared stage/unstage mutation runner: arms the git_stage_result callback,
+  // fires the request, and on success re-fetches git_status. `request` is
+  // requestGitStage or requestGitUnstage (both return false when the socket
+  // is closed, mirroring the app's #6288 not-connected guard).
+  const performMutation = useCallback((
+    paths: string[],
+    request: (paths: string[]) => boolean,
+    notConnectedMessage: string,
+  ) => {
+    if (paths.length === 0) return
+    setActionError(null)
+    setStagingInProgress(true)
+    setGitStageCallback((result: GitStageResult) => {
+      setGitStageCallback(null)
+      if (result.error) {
+        setStagingInProgress(false)
+        setActionError(result.error)
+        return
+      }
+      setSelectedPaths(new Set())
+      setGitStatusCallback((r: GitStatusResult) => {
+        setStagingInProgress(false)
+        setError(r.error)
+        if (!r.error) {
+          setBranch(r.branch)
+          setStaged(r.staged)
+          setUnstaged(r.unstaged)
+          setUntracked(r.untracked)
+        }
+        setGitStatusCallback(null)
+      })
+      requestGitStatus()
+    })
+    if (!request(paths)) {
+      setGitStageCallback(null)
+      setStagingInProgress(false)
+      setActionError(notConnectedMessage)
+    }
+  }, [setGitStageCallback, setGitStatusCallback, requestGitStatus])
+
+  const handleStageSelected = useCallback(() => {
+    const paths = Array.from(selectedPaths).filter(p => unstagedPaths.has(p) || untrackedSet.has(p))
+    performMutation(paths, requestGitStage, 'Stage not sent — reconnect and try again')
+  }, [selectedPaths, unstagedPaths, untrackedSet, performMutation, requestGitStage])
+
+  const handleUnstageSelected = useCallback(() => {
+    const paths = Array.from(selectedPaths).filter(p => stagedPaths.has(p))
+    performMutation(paths, requestGitUnstage, 'Unstage not sent — reconnect and try again')
+  }, [selectedPaths, stagedPaths, performMutation, requestGitUnstage])
+
+  const handleStageAll = useCallback(() => {
+    const paths = [...unstaged.map(f => f.path), ...untracked]
+    performMutation(paths, requestGitStage, 'Stage not sent — reconnect and try again')
+  }, [unstaged, untracked, performMutation, requestGitStage])
+
+  const handleUnstageAll = useCallback(() => {
+    performMutation(staged.map(f => f.path), requestGitUnstage, 'Unstage not sent — reconnect and try again')
+  }, [staged, performMutation, requestGitUnstage])
+
+  const handleCommit = useCallback(() => {
+    const msg = commitMessage.trim()
+    // Empty-message guard: the server rejects an empty commit message too
+    // (packages/server/src/ws-file-ops/git.js gitCommit), but guarding here
+    // avoids a round-trip and matches the app's disabled-button behavior.
+    if (!msg || staged.length === 0) return
+    setActionError(null)
+    setCommitting(true)
+    setGitCommitCallback((result: GitCommitResult) => {
+      setGitCommitCallback(null)
+      setCommitting(false)
+      if (result.error) {
+        setActionError(result.error)
+        return
+      }
+      setCommitMessage('')
+      setGitStatusCallback((r: GitStatusResult) => {
+        setError(r.error)
+        if (!r.error) {
+          setBranch(r.branch)
+          setStaged(r.staged)
+          setUnstaged(r.unstaged)
+          setUntracked(r.untracked)
+        }
+        setGitStatusCallback(null)
+      })
+      requestGitStatus()
+    })
+    if (!requestGitCommit(msg)) {
+      setGitCommitCallback(null)
+      setCommitting(false)
+      setActionError('Commit not sent — reconnect and try again')
+    }
+  }, [commitMessage, staged.length, setGitCommitCallback, requestGitCommit, setGitStatusCallback, requestGitStatus])
+
+  const hasChanges = staged.length > 0 || unstaged.length > 0 || untracked.length > 0
+  const localBranches = useMemo(() => branches.filter(b => !b.isRemote), [branches])
+  const remoteBranches = useMemo(() => branches.filter(b => b.isRemote), [branches])
+
+  return (
+    <div className="git-panel" data-testid="git-panel">
+      <div className="git-toolbar">
+        <div className="git-tabs">
+          <button
+            type="button"
+            className={`git-tab${activeTab === 'changes' ? ' active' : ''}`}
+            onClick={() => setActiveTab('changes')}
+          >
+            Changes
+          </button>
+          <button
+            type="button"
+            className={`git-tab${activeTab === 'branches' ? ' active' : ''}`}
+            onClick={() => setActiveTab('branches')}
+          >
+            Branches
+          </button>
+        </div>
+        <div className="git-toolbar-right">
+          {branch && (
+            <span className="git-branch-badge" title={`Branch: ${branch}`}>{branch}</span>
+          )}
+          <button type="button" className="git-refresh-btn" onClick={refreshStatus} title="Refresh git status">
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {loading && <div className="git-loading">Loading git status...</div>}
+      {!loading && error && <div className="git-error">{error}</div>}
+
+      {!loading && !error && activeTab === 'changes' && (
+        <div className="git-changes" data-testid="git-changes-tab">
+          {actionError && <div className="git-action-error" data-testid="git-action-error">{actionError}</div>}
+
+          {staged.length > 0 && (
+            <div className="git-section" data-testid="git-staged-section">
+              <div className="git-section-header">
+                <span className="git-section-title">Staged ({staged.length})</span>
+                <button type="button" className="git-section-action" onClick={handleUnstageAll} disabled={stagingInProgress}>
+                  Unstage all
+                </button>
+              </div>
+              {staged.map(f => (
+                <FileRow
+                  key={`staged-${f.path}`}
+                  path={f.path}
+                  status={f.status}
+                  selected={selectedPaths.has(f.path)}
+                  onToggle={() => toggleSelection(f.path)}
+                />
+              ))}
+            </div>
+          )}
+
+          {unstaged.length > 0 && (
+            <div className="git-section" data-testid="git-unstaged-section">
+              <div className="git-section-header">
+                <span className="git-section-title">Changes ({unstaged.length})</span>
+                <button type="button" className="git-section-action" onClick={handleStageAll} disabled={stagingInProgress}>
+                  Stage all
+                </button>
+              </div>
+              {unstaged.map(f => (
+                <FileRow
+                  key={`unstaged-${f.path}`}
+                  path={f.path}
+                  status={f.status}
+                  selected={selectedPaths.has(f.path)}
+                  onToggle={() => toggleSelection(f.path)}
+                />
+              ))}
+            </div>
+          )}
+
+          {untracked.length > 0 && (
+            <div className="git-section" data-testid="git-untracked-section">
+              <div className="git-section-header">
+                <span className="git-section-title">Untracked ({untracked.length})</span>
+                <button type="button" className="git-section-action" onClick={handleStageAll} disabled={stagingInProgress}>
+                  Stage all
+                </button>
+              </div>
+              {untracked.map(p => (
+                <FileRow
+                  key={`untracked-${p}`}
+                  path={p}
+                  status="untracked"
+                  selected={selectedPaths.has(p)}
+                  onToggle={() => toggleSelection(p)}
+                />
+              ))}
+            </div>
+          )}
+
+          {!hasChanges && <div className="git-empty">Working tree clean</div>}
+
+          {selectedPaths.size > 0 && (
+            <div className="git-action-bar">
+              {hasUnstagedSelected && (
+                <button
+                  type="button"
+                  className="git-action-btn git-action-stage"
+                  onClick={handleStageSelected}
+                  disabled={stagingInProgress}
+                  data-testid="git-stage-selected-btn"
+                >
+                  {stagingInProgress ? 'Staging…' : 'Stage selected'}
+                </button>
+              )}
+              {hasStagedSelected && (
+                <button
+                  type="button"
+                  className="git-action-btn git-action-unstage"
+                  onClick={handleUnstageSelected}
+                  disabled={stagingInProgress}
+                  data-testid="git-unstage-selected-btn"
+                >
+                  {stagingInProgress ? 'Unstaging…' : 'Unstage selected'}
+                </button>
+              )}
+            </div>
+          )}
+
+          {staged.length > 0 && (
+            <div className="git-commit-area">
+              <textarea
+                className="git-commit-input"
+                placeholder="Commit message..."
+                value={commitMessage}
+                onChange={e => setCommitMessage(e.target.value)}
+                maxLength={2000}
+                disabled={committing}
+                data-testid="git-commit-input"
+              />
+              <button
+                type="button"
+                className="git-commit-btn"
+                onClick={handleCommit}
+                disabled={!commitMessage.trim() || committing}
+                data-testid="git-commit-btn"
+              >
+                {committing ? 'Committing…' : `Commit ${staged.length} file${staged.length !== 1 ? 's' : ''}`}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!loading && !error && activeTab === 'branches' && (
+        <div className="git-branches" data-testid="git-branches-tab">
+          {localBranches.length > 0 && (
+            <div className="git-section">
+              <span className="git-section-title">Local ({localBranches.length})</span>
+              {localBranches.map(b => (
+                <div key={b.name} className={`git-branch-row${b.isCurrent ? ' is-current' : ''}`}>
+                  {b.isCurrent && <span className="git-branch-current-mark">✓</span>}
+                  <span className="git-branch-name">{b.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {remoteBranches.length > 0 && (
+            <div className="git-section">
+              <span className="git-section-title">Remote ({remoteBranches.length})</span>
+              {remoteBranches.map(b => (
+                <div key={b.name} className="git-branch-row git-branch-row--remote">
+                  <span className="git-branch-name">{b.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {branches.length === 0 && <div className="git-empty">No branches found</div>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/GitPanel.tsx
+++ b/packages/dashboard/src/components/GitPanel.tsx
@@ -19,6 +19,7 @@
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useConnectionStore } from '../store/connection'
+import { ConfirmDialog } from './ConfirmDialog'
 import type {
   GitFileStatus,
   GitStatusResult,
@@ -106,26 +107,42 @@ export function GitPanel() {
   const [committing, setCommitting] = useState(false)
   const [stagingInProgress, setStagingInProgress] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  // #6875 review — commit is irreversible-ish; gate it behind a confirm dialog
+  // for parity with the mobile app's GitView.handleCommit (which shows an
+  // Alert "Commit N staged file(s)?" before committing).
+  const [commitConfirmOpen, setCommitConfirmOpen] = useState(false)
+
+  // The single, DURABLE git_status_result handler. Stable identity (empty deps)
+  // so the mount effect installs it exactly once, and — critically — so the
+  // stage/commit success paths can re-fire `requestGitStatus()` WITHOUT ever
+  // swapping this slot for a one-shot callback. The earlier version installed a
+  // temporary status callback ending in `setGitStatusCallback(null)` after each
+  // mutation, which tore down the durable handler with nothing to re-arm it: the
+  // next Refresh (or a reconnect refresh) produced a git_status_result no
+  // callback consumed, wedging the panel on "Loading git status…" until remount.
+  const applyStatusResult = useCallback((result: GitStatusResult) => {
+    setLoading(false)
+    setStagingInProgress(false)
+    setError(result.error)
+    if (!result.error) {
+      setBranch(result.branch)
+      setStaged(result.staged)
+      setUnstaged(result.unstaged)
+      setUntracked(result.untracked)
+    }
+  }, [])
 
   const refreshStatus = useCallback(() => {
     setLoading(true)
     requestGitStatus()
   }, [requestGitStatus])
 
-  // Wire the git_status_result callback
+  // Wire the durable git_status_result callback (installed once; never swapped
+  // out by a mutation — see applyStatusResult).
   useEffect(() => {
-    setGitStatusCallback((result: GitStatusResult) => {
-      setLoading(false)
-      setError(result.error)
-      if (!result.error) {
-        setBranch(result.branch)
-        setStaged(result.staged)
-        setUnstaged(result.unstaged)
-        setUntracked(result.untracked)
-      }
-    })
+    setGitStatusCallback(applyStatusResult)
     return () => setGitStatusCallback(null)
-  }, [setGitStatusCallback])
+  }, [setGitStatusCallback, applyStatusResult])
 
   // Wire the git_branches_result callback
   useEffect(() => {
@@ -165,8 +182,11 @@ export function GitPanel() {
     [selectedPaths, stagedPaths],
   )
 
-  // Shared stage/unstage mutation runner: arms the git_stage_result callback,
-  // fires the request, and on success re-fetches git_status. `request` is
+  // Shared stage/unstage mutation runner: arms the (one-shot) git_stage_result
+  // callback, fires the request, and on success re-fetches git_status. The
+  // refresh is consumed by the DURABLE status handler (applyStatusResult) —
+  // this path only ever touches the stage slot, never the status slot, so the
+  // durable handler survives every mutation (the wedge fix). `request` is
   // requestGitStage or requestGitUnstage (both return false when the socket
   // is closed, mirroring the app's #6288 not-connected guard).
   const performMutation = useCallback((
@@ -185,17 +205,8 @@ export function GitPanel() {
         return
       }
       setSelectedPaths(new Set())
-      setGitStatusCallback((r: GitStatusResult) => {
-        setStagingInProgress(false)
-        setError(r.error)
-        if (!r.error) {
-          setBranch(r.branch)
-          setStaged(r.staged)
-          setUnstaged(r.unstaged)
-          setUntracked(r.untracked)
-        }
-        setGitStatusCallback(null)
-      })
+      // The durable status handler consumes this refresh and clears
+      // stagingInProgress once the fresh file lists land.
       requestGitStatus()
     })
     if (!request(paths)) {
@@ -203,7 +214,7 @@ export function GitPanel() {
       setStagingInProgress(false)
       setActionError(notConnectedMessage)
     }
-  }, [setGitStageCallback, setGitStatusCallback, requestGitStatus])
+  }, [setGitStageCallback, requestGitStatus])
 
   const handleStageSelected = useCallback(() => {
     const paths = Array.from(selectedPaths).filter(p => unstagedPaths.has(p) || untrackedSet.has(p))
@@ -224,11 +235,23 @@ export function GitPanel() {
     performMutation(staged.map(f => f.path), requestGitUnstage, 'Unstage not sent — reconnect and try again')
   }, [staged, performMutation, requestGitUnstage])
 
-  const handleCommit = useCallback(() => {
+  // Commit-button click: empty-message + nothing-staged guard, then open the
+  // confirmation dialog (#6875 review — parity with the mobile app's
+  // "Commit N staged file(s)?" gate; commit is irreversible-ish).
+  const handleCommitClick = useCallback(() => {
     const msg = commitMessage.trim()
     // Empty-message guard: the server rejects an empty commit message too
     // (packages/server/src/ws-file-ops/git.js gitCommit), but guarding here
     // avoids a round-trip and matches the app's disabled-button behavior.
+    if (!msg || staged.length === 0) return
+    setCommitConfirmOpen(true)
+  }, [commitMessage, staged.length])
+
+  // Confirmed commit: fires git_commit; on success clears the message and
+  // re-fetches status via the DURABLE handler (never swaps the status slot).
+  const handleCommitConfirmed = useCallback(() => {
+    setCommitConfirmOpen(false)
+    const msg = commitMessage.trim()
     if (!msg || staged.length === 0) return
     setActionError(null)
     setCommitting(true)
@@ -240,16 +263,7 @@ export function GitPanel() {
         return
       }
       setCommitMessage('')
-      setGitStatusCallback((r: GitStatusResult) => {
-        setError(r.error)
-        if (!r.error) {
-          setBranch(r.branch)
-          setStaged(r.staged)
-          setUnstaged(r.unstaged)
-          setUntracked(r.untracked)
-        }
-        setGitStatusCallback(null)
-      })
+      // The durable status handler consumes this refresh.
       requestGitStatus()
     })
     if (!requestGitCommit(msg)) {
@@ -257,7 +271,7 @@ export function GitPanel() {
       setCommitting(false)
       setActionError('Commit not sent — reconnect and try again')
     }
-  }, [commitMessage, staged.length, setGitCommitCallback, requestGitCommit, setGitStatusCallback, requestGitStatus])
+  }, [commitMessage, staged.length, setGitCommitCallback, requestGitCommit, requestGitStatus])
 
   const hasChanges = staged.length > 0 || unstaged.length > 0 || untracked.length > 0
   const localBranches = useMemo(() => branches.filter(b => !b.isRemote), [branches])
@@ -402,7 +416,7 @@ export function GitPanel() {
               <button
                 type="button"
                 className="git-commit-btn"
-                onClick={handleCommit}
+                onClick={handleCommitClick}
                 disabled={!commitMessage.trim() || committing}
                 data-testid="git-commit-btn"
               >
@@ -439,6 +453,23 @@ export function GitPanel() {
           {branches.length === 0 && <div className="git-empty">No branches found</div>}
         </div>
       )}
+
+      {/* #6875 review — commit confirmation (parity with the mobile app's
+          "Commit N staged file(s)?" gate). Reuses the dashboard's shared
+          ConfirmDialog, the same primitive other destructive actions use. */}
+      <ConfirmDialog
+        open={commitConfirmOpen}
+        title="Commit staged changes?"
+        confirmLabel="Commit"
+        message={
+          <>
+            Commit {staged.length} staged file{staged.length !== 1 ? 's' : ''}
+            {branch ? <> on <b>{branch}</b></> : null}?
+          </>
+        }
+        onConfirm={handleCommitConfirmed}
+        onCancel={() => setCommitConfirmOpen(false)}
+      />
     </div>
   )
 }

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -5,7 +5,7 @@ import { formatShortcutKeys } from '../utils/platform'
 // #5204 — 'control-room' is no longer a per-session viewMode; the Control
 // Room is a dedicated session-independent top-level tab (see `controlRoomOpen`
 // / `controlRoomActive` in App).
-export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages'
+export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 export function ViewSwitcher({
@@ -127,6 +127,9 @@ export function ViewSwitcher({
           >Split</button>
         )}
         <button className={`view-tab${viewMode === 'files' ? ' active' : ''}`} onClick={() => setViewMode('files')} type="button">Files</button>
+        {/* #6780 — stage/unstage/commit UI on top of the existing git status
+            wiring (Files tab already shows read-only decorations + branch). */}
+        <button className={`view-tab${viewMode === 'git' ? ' active' : ''}`} onClick={() => setViewMode('git')} type="button">Git</button>
         <button className={`view-tab${viewMode === 'system' ? ' active' : ''}`} onClick={() => { setViewMode('system'); setSplitMode(null); persistSplitMode(null) }} type="button">
           System{unreadSystemCount > 0 && <span className="system-badge">{unreadSystemCount}</span>}
         </button>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -700,6 +700,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   _fileContentCallback: null,
   lastFileContentRequestId: null,
   _gitStatusCallback: null,
+  _gitBranchesCallback: null,
+  _gitStageCallback: null,
+  _gitCommitCallback: null,
   _diffCallback: null,
   conversationHistory: [],
   conversationHistoryLoading: false,
@@ -4019,6 +4022,58 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'git_status' });
     }
+  },
+
+  // #6780 — git branches (read-only listing). The wire message and its
+  // git_branches_result reply already existed server-side (createGitOps) and
+  // app-side; the dashboard simply had no handler for it (protocol comment,
+  // packages/protocol/src/schemas/server/file-ops.ts).
+  setGitBranchesCallback: (cb) => {
+    set({ _gitBranchesCallback: cb });
+  },
+
+  requestGitBranches: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'git_branches' });
+    }
+  },
+
+  // #6780 — stage/unstage mutations. Mirrors the app's requestGitStage /
+  // requestGitUnstage (packages/app/src/store/connection.ts): both return
+  // false when the socket is closed so GitPanel can surface a "not
+  // connected" error instead of leaving its spinner stuck forever (#6288).
+  setGitStageCallback: (cb) => {
+    set({ _gitStageCallback: cb });
+  },
+
+  requestGitStage: (paths) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      return wsSend(socket, { type: 'git_stage', files: paths });
+    }
+    return false;
+  },
+
+  requestGitUnstage: (paths) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      return wsSend(socket, { type: 'git_unstage', files: paths });
+    }
+    return false;
+  },
+
+  // #6780 — commit mutation. Same not-connected-guard rationale as stage/unstage.
+  setGitCommitCallback: (cb) => {
+    set({ _gitCommitCallback: cb });
+  },
+
+  requestGitCommit: (message) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      return wsSend(socket, { type: 'git_commit', message });
+    }
+    return false;
   },
 
   // Diff viewer

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -85,6 +85,11 @@ import {
   handleFileList as sharedFileList,
   handleDiffResult as sharedDiffResult,
   handleGitStatusResult as sharedGitStatusResult,
+  // #6780 — git branches (read-only listing) + stage/unstage/commit mutations.
+  // Same parsers the app already uses; the dashboard just had no callers.
+  handleGitBranchesResult as sharedGitBranchesResult,
+  handleGitStageResult as sharedGitStageResult,
+  handleGitCommitResult as sharedGitCommitResult,
   // agent_spawned / agent_completed / agent_event / background_work_changed
   // migrated to the shared dispatch table (#5556 slice 2)
   handleEnvironmentList as sharedEnvironmentList,
@@ -5067,6 +5072,46 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           staged: payload.staged,
           unstaged: payload.unstaged,
           untracked: payload.untracked,
+          error: payload.error,
+        });
+      }
+      break;
+    }
+
+    // #6780 — git branches (read-only listing) + stage/unstage/commit
+    // mutations. Same callback-then-invoke shape as diff_result /
+    // git_status_result above; git_stage_result and git_unstage_result share
+    // one callback since their payloads are identical (mirrors the app).
+    case 'git_branches_result': {
+      const gitBranchesCb = get()._gitBranchesCallback;
+      if (gitBranchesCb) {
+        const payload = sharedGitBranchesResult(msg);
+        gitBranchesCb({
+          branches: payload.branches,
+          currentBranch: payload.currentBranch,
+          error: payload.error,
+        });
+      }
+      break;
+    }
+
+    case 'git_stage_result':
+    case 'git_unstage_result': {
+      const gitStageCb = get()._gitStageCallback;
+      if (gitStageCb) {
+        const payload = sharedGitStageResult(msg);
+        gitStageCb({ error: payload.error });
+      }
+      break;
+    }
+
+    case 'git_commit_result': {
+      const gitCommitCb = get()._gitCommitCallback;
+      if (gitCommitCb) {
+        const payload = sharedGitCommitResult(msg);
+        gitCommitCb({
+          hash: payload.hash,
+          message: payload.message,
           error: payload.error,
         });
       }

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -100,7 +100,7 @@ const MAX_TERMINAL_SIZE = 50_000;
 // Containers section. A persisted 'environments' viewMode no longer validates
 // and falls back to the default, so a carried-over value can't render a
 // now-removed surface.
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'snapshots', 'pool', 'pages'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'git', 'system', 'console', 'snapshots', 'pool', 'pages'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -78,6 +78,9 @@ export type {
   // dashboard-local GitStatusEntry. Same shape (path + status union) — was
   // missed by the #3132 dedup sweep that moved DiffFile/Hunk/HunkLine.
   GitFileStatus,
+  // #6780 — re-export GitBranch from store-core for the dashboard git panel's
+  // branch listing (mirrors the app's GitBranchesResult.branches shape).
+  GitBranch,
   // #5163 (epic #5159): Control Room activity state. The reducer + selector
   // live in store-core (#5162); the dashboard holds one `ActivityState` on
   // the connection store and the Control Room panel renders it via
@@ -105,6 +108,7 @@ import type {
   MessageAttachment,
   ModelInfo,
   GitFileStatus,
+  GitBranch,
   PendingPermissionConfirm,
   SavedConnection,
   SearchResult,
@@ -264,6 +268,30 @@ export interface GitStatusResult {
   staged: GitFileStatus[];
   unstaged: GitFileStatus[];
   untracked: string[];
+  error: string | null;
+}
+
+// #6780 — dashboard adoption of the git_branches_result / git_stage_result /
+// git_unstage_result / git_commit_result payloads. Mirrors the app's
+// packages/app/src/store/types.ts shapes 1:1 (same wire messages, same
+// store-core parsers — @chroxy/store-core's handleGitBranchesResult /
+// handleGitStageResult / handleGitCommitResult).
+
+export interface GitBranchesResult {
+  branches: GitBranch[];
+  currentBranch: string | null;
+  error: string | null;
+}
+
+// Shared by both git_stage_result and git_unstage_result (identical payload
+// shape — only an optional error string).
+export interface GitStageResult {
+  error: string | null;
+}
+
+export interface GitCommitResult {
+  hash: string | null;
+  message: string | null;
   error: string | null;
 }
 
@@ -1394,6 +1422,14 @@ export interface ConnectionState {
   // Git status callback
   _gitStatusCallback: ((result: GitStatusResult) => void) | null;
 
+  // #6780 — git branches / stage-unstage / commit callbacks. Mirrors the
+  // app's imperative-callback slots (gitBranches / gitStage / gitCommit).
+  _gitBranchesCallback: ((result: GitBranchesResult) => void) | null;
+  // Shared by requestGitStage and requestGitUnstage (git_stage_result and
+  // git_unstage_result carry the same payload shape).
+  _gitStageCallback: ((result: GitStageResult) => void) | null;
+  _gitCommitCallback: ((result: GitCommitResult) => void) | null;
+
   // Diff viewer callback
   _diffCallback: ((result: DiffResult) => void) | null;
 
@@ -1409,7 +1445,7 @@ export interface ConnectionState {
 
   // View mode. #5204 — 'control-room' removed: the Control Room is now a
   // session-independent top-level tab in App, not a per-session view mode.
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages';
 
   // Input settings
   inputSettings: InputSettings;
@@ -1428,7 +1464,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   appendTerminalData: (data: string) => void;
@@ -1634,6 +1670,22 @@ export interface ConnectionState {
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;
   requestGitStatus: () => void;
+
+  // #6780 — git branches (read-only listing) + stage/unstage/commit mutations.
+  // Wire messages (git_branches / git_stage / git_unstage / git_commit) and
+  // their *_result replies were already server-side (packages/server/src/ws-file-ops/git.js)
+  // and app-side (packages/app/src/store/connection.ts); this is the dashboard's
+  // adoption of the same request/callback pair shape.
+  setGitBranchesCallback: (cb: ((result: GitBranchesResult) => void) | null) => void;
+  requestGitBranches: () => void;
+  setGitStageCallback: (cb: ((result: GitStageResult) => void) | null) => void;
+  // Mutation requests return false when the socket is closed (frame not
+  // sent) so callers can surface a "not connected" error instead of arming a
+  // callback that will never resolve (mirrors the app's #6288 fix).
+  requestGitStage: (paths: string[]) => boolean;
+  requestGitUnstage: (paths: string[]) => boolean;
+  setGitCommitCallback: (cb: ((result: GitCommitResult) => void) | null) => void;
+  requestGitCommit: (message: string) => boolean;
 
   // Diff viewer
   setDiffCallback: (cb: ((result: DiffResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9222,6 +9222,257 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.5;
 }
 
+/* ---- Git Panel (#6780) ---- */
+.git-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.git-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.git-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.git-tab {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.git-tab.active {
+  background: var(--accent-blue);
+  color: #fff;
+  border-color: var(--accent-blue);
+}
+
+.git-tab:hover { background: var(--bg-card); }
+
+.git-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.git-branch-badge {
+  font-size: 11px;
+  color: var(--accent-blue);
+  background: var(--bg-tertiary);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.git-refresh-btn {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.git-refresh-btn:hover { background: var(--bg-card); }
+
+.git-loading, .git-error, .git-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.git-error { color: var(--text-error); }
+
+.git-changes, .git-branches {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+.git-action-error {
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--text-error);
+  font-size: var(--text-sm);
+}
+
+.git-section {
+  margin-bottom: 16px;
+}
+
+.git-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.git-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.git-section-action {
+  padding: 2px 8px;
+  font-size: 11px;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.git-section-action:hover { background: var(--bg-card); }
+.git-section-action:disabled { opacity: 0.5; cursor: default; }
+
+.git-file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+}
+
+.git-file-row:hover { background: var(--bg-tertiary); }
+
+.git-file-checkbox {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.git-status-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+.git-status-badge.git-status-modified { background: rgba(234, 179, 8, 0.2); color: var(--accent-yellow-500); }
+.git-status-badge.git-status-added { background: rgba(34, 197, 94, 0.2); color: var(--accent-green); }
+.git-status-badge.git-status-deleted { background: rgba(239, 68, 68, 0.2); color: var(--accent-red); }
+.git-status-badge.git-status-renamed { background: rgba(59, 130, 246, 0.2); color: var(--accent-blue); }
+.git-status-badge.git-status-untracked { background: rgba(148, 163, 184, 0.2); color: var(--text-dim); }
+.git-status-badge.git-status-unknown { background: rgba(148, 163, 184, 0.2); color: var(--text-dim); }
+
+.git-file-path {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.git-file-dir { color: var(--text-dim); }
+.git-file-name { color: var(--text-primary); }
+
+.git-action-bar {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.git-action-btn {
+  padding: 6px 14px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-primary);
+  cursor: pointer;
+}
+
+.git-action-btn:disabled { opacity: 0.5; cursor: default; }
+
+.git-action-stage { color: var(--accent-green); border-color: var(--accent-green); }
+.git-action-unstage { color: var(--accent-yellow-500); border-color: var(--accent-yellow-500); }
+
+.git-commit-area {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.git-commit-input {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.4;
+  min-height: 60px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.git-commit-input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.git-commit-btn {
+  align-self: flex-start;
+  padding: 8px 16px;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  border-radius: 6px;
+  border: none;
+  background: var(--accent-green);
+  color: #fff;
+  cursor: pointer;
+}
+
+.git-commit-btn:disabled { opacity: 0.5; cursor: default; }
+
+.git-branch-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.git-branch-row--remote { color: var(--text-dim); }
+.git-branch-row.is-current { font-weight: 600; color: var(--accent-green); }
+.git-branch-current-mark { color: var(--accent-green); }
+.git-branch-name { font-family: var(--font-mono); }
+
 /* ---- Agent Monitor Panel ---- */
 .agent-monitor-panel {
   border-top: 1px solid var(--border-primary);

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9257,7 +9257,7 @@ button.sidebar-token-view-session-row:hover {
 
 .git-tab.active {
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--text-on-accent, #fff);
   border-color: var(--accent-blue);
 }
 
@@ -9453,7 +9453,7 @@ button.sidebar-token-view-session-row:hover {
   border-radius: 6px;
   border: none;
   background: var(--accent-green);
-  color: #fff;
+  color: var(--text-on-accent, #fff);
   cursor: pointer;
 }
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -105,10 +105,12 @@ const PLATFORM_SPECIFIC = {
   //  paste-a-pairing-URL support in #5297 — so it's no longer platform-specific.)
   'push_token_error': 'app',    // push notifications are mobile-only
   'write_file_result': 'app',   // app file editing UI
-  'git_branches_result': 'app', // app git UI
-  'git_stage_result': 'app',    // app git UI
-  'git_unstage_result': 'app',  // app git UI
-  'git_commit_result': 'app',   // app git UI
+  // git_branches_result / git_stage_result / git_unstage_result /
+  // git_commit_result removed from PLATFORM_SPECIFIC — the dashboard now
+  // handles them too (#6780: git stage + commit UI), so they are BOTH-CLIENTS.
+  // Coverage passes because each handler covers them (the app via the shared
+  // store-core dispatch-table git callbacks, the dashboard via its new
+  // `case 'git_*_result':` clauses).
 
   // Dashboard only
   'pairing_refreshed': 'dashboard',  // QR display and auto-refresh is dashboard-only (#2916)


### PR DESCRIPTION
## Summary

Adds a **Git** panel tab to the dashboard (and, by extension, the desktop shell that wraps it) with stage/unstage and commit-message-to-commit actions on top of the existing read-only git status wiring. The server and wire protocol already fully implemented this (`git_status` / `git_branches` / `git_stage` / `git_unstage` / `git_commit` in `packages/server/src/ws-file-ops/git.js` + `packages/server/src/handlers/file-handlers.js`, and their `@chroxy/store-core` parsers in `packages/store-core/src/handlers/git.ts`) — the mobile app (`packages/app/src/components/GitView.tsx`) already used all of it. This PR is purely the dashboard's store wiring + UI, mirroring the app 1:1.

- **New `GitPanel` component** (`packages/dashboard/src/components/GitPanel.tsx`): a "Changes" tab (staged / unstaged / untracked lists with per-file checkboxes, per-section "stage all" / "unstage all", a selection-based stage/unstage action bar, and a commit-message box) and a read-only "Branches" tab (local + remote, current branch marked) — same shape as the mobile app's `GitView`.
- **Dashboard store wiring** for `git_branches` / `git_stage` / `git_unstage` / `git_commit` and their `*_result` replies (`packages/dashboard/src/store/connection.ts`, `message-handler.ts`, `types.ts`), reusing the existing `handleGitBranchesResult` / `handleGitStageResult` / `handleGitCommitResult` parsers from `@chroxy/store-core` — the same functions the app already called. No server or wire-protocol changes.
- Mutation requests (`requestGitStage` / `requestGitUnstage` / `requestGitCommit`) return `false` when the socket is closed, so the UI surfaces a "not connected" error instead of leaving a spinner stuck forever — mirrors the app's existing `#6288` guard.
- New `Git` tab in `ViewSwitcher` (`viewMode: 'git'`), wired into `App.tsx` and the persisted-view-mode allowlist (`persistence.ts`).
- **Commit confirmation** — the commit button opens the dashboard's shared `ConfirmDialog` ("Commit N staged files on `<branch>`?") before committing, matching the mobile app's `GitView.handleCommit` confirm gate; commit is irreversible-ish.
- New CSS in the hand-authored `packages/dashboard/src/theme/components.css`. Layout/spacing/typography use design tokens (`var(--accent-green)`, `var(--accent-blue)`, `var(--text-dim)`, `var(--bg-card)`, `var(--font-mono)`, etc.). The M/A/D/R/U status-badge backgrounds and error/on-accent-text colors reuse the **file's existing rgba/#fff convention verbatim** — the 6 `rgba()` values are byte-identical to the sibling `.diff-status-badge` rules, and `#fff` on accent buttons matches `.btn-modal-create` / `.btn-modal-danger` / `.diff-view-btn.active`. These are deliberately kept as literals for visual parity with the Diff panel's identical badges; no exact-match design token exists (the `--accent-*-light` tokens differ in base color and alpha, so swapping to them would diverge the Git badges from the Diff badges). `generate-tokens` shows no drift in the generated `theme.css`/`tokens.ts`, and Style Lint passes (the ratchet's grandfathered-file rule + `theme/` scope).

### Deferred (follow-up, not in this PR)

- **Branch switching (checkout)** — no wire message exists for it today (the server's `createGitOps` only exposes status/branches/stage/unstage/commit); the Branches tab is read-only, matching the mobile app's own Branches tab exactly.
- **In-app PR creation** (the issue's second acceptance criterion) — a separate, larger concern needing a new wire message + `gh` integration on the server side. Out of scope here to keep this PR focused and land stage/commit cleanly, per the issue's own suggested scoping.

Related to #6780 (stage/unstage/commit + branch listing land here; branch switching and PR creation are follow-ups).

## Test plan

- [x] New `GitPanel.test.tsx` (24 tests): stage/unstage send the right store calls with the right file paths (per-file and "all"), commit is gated behind a confirmation dialog (opens on click, cancel is a no-op, confirm sends `requestGitCommit` with the trimmed message), empty/whitespace-only message guard disables the commit button, the durable `git_status_result` handler survives a stage/commit so a subsequent **Refresh still updates status (no stuck spinner)**, staged/unstaged/untracked lists render, branch badge + Branches tab render, error and not-connected-socket paths surface without leaving the UI stuck.
- [x] Full dashboard vitest suite green.
- [x] `tsc --noEmit` clean.
- [x] `scripts/lint-no-raw-color-literals.sh` and `scripts/lint-undefined-css-vars.sh` clean.
- [x] `npm run generate-tokens` shows no diff (components.css is hand-authored, not the generated theme.css).
- [x] `vite build` succeeds.
