### PR TITLE
feat(server): scheduled-task data model + persisted registry (#6862)

### DIFF
--- a/packages/server/src/schedule-parser.js
+++ b/packages/server/src/schedule-parser.js
@@ -1,0 +1,288 @@
+// Dependency-free schedule parsing + next-run computation for the scheduled-task
+// registry (#6862, foundation slice of epic #6784). This module ONLY parses a
+// cadence and COMPUTES the next fire time — it never fires anything. The headless
+// engine that actually spawns sessions is a sibling slice (#6865); it will import
+// computeNextRun to advance a task's schedule after a run.
+//
+// Three cadence kinds are supported, all without any npm dependency:
+//   - once:     { kind: 'once', at }                     — a single future timestamp
+//   - interval: { kind: 'interval', everyMs[, anchor] }  — every N ms from an anchor
+//   - cron:     { kind: 'cron', expression }             — a 5-field crontab expression
+//
+// Deliberately distinct from `ScheduleWakeup` (transcript-tasks.js), which is an
+// intra-session, single-shot, transcript-derived self-resume ({delaySeconds,
+// reason, prompt}). This is a standing, persisted, recurring registry cadence.
+
+// Minimum interval a task may fire on. Sub-second scheduling is meaningless for a
+// cadence that spawns a whole agent session, and a 0/tiny value would be a
+// runaway. The engine (#6865) enforces its own real-world minimum; this is a
+// data-integrity floor so the stored model can never carry an absurd interval.
+export const MIN_INTERVAL_MS = 1000
+
+// Forward-search horizon for cron next-run. A legitimate crontab always fires
+// within a few years even for the rare leap-day-only expression
+// (`0 0 29 2 *` — next match up to ~4 years out); 5 years gives headroom. An
+// impossible expression (e.g. day-of-month 31 in a 30-day-only month set) yields
+// no match inside the horizon and computeNextRun returns null rather than
+// looping forever.
+const CRON_HORIZON_MS = 5 * 366 * 24 * 60 * 60 * 1000
+
+const MONTH_NAMES = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+}
+const DOW_NAMES = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+}
+
+const FIELD_BOUNDS = {
+  minute: { min: 0, max: 59 },
+  hour: { min: 0, max: 23 },
+  dom: { min: 1, max: 31 },
+  month: { min: 1, max: 12 },
+  dow: { min: 0, max: 7 }, // 0 and 7 both mean Sunday
+}
+
+/**
+ * Error thrown when a cron expression cannot be parsed. Carries the offending
+ * expression so a caller (CLI #6868 / dashboard #6871) can surface a precise
+ * message rather than a bare "invalid".
+ */
+export class CronParseError extends Error {
+  constructor(message, expression) {
+    super(message)
+    this.name = 'CronParseError'
+    this.expression = expression
+  }
+}
+
+/**
+ * Parse a single crontab field (one of minute/hour/dom/month/dow) into a Set of
+ * the integer values it matches. Supports `*`, `?` (alias for `*`), single
+ * values, `a-b` ranges, star-step and range-step forms (`* / s`, `a-b / s`,
+ * written without the spaces), and comma lists combining any
+ * of those. Month and day-of-week also accept 3-letter names (jan..dec /
+ * sun..sat, case-insensitive).
+ * @param {string} raw
+ * @param {'minute'|'hour'|'dom'|'month'|'dow'} field
+ * @param {string} expression - full expression, for error messages
+ * @returns {{ values: Set<number>, star: boolean }}
+ */
+function parseField(raw, field, expression) {
+  const { min, max } = FIELD_BOUNDS[field]
+  const names = field === 'month' ? MONTH_NAMES : field === 'dow' ? DOW_NAMES : null
+
+  const resolveToken = (tok) => {
+    const lower = tok.toLowerCase()
+    if (names && Object.prototype.hasOwnProperty.call(names, lower)) return names[lower]
+    if (!/^\d+$/.test(tok)) {
+      throw new CronParseError(`Invalid ${field} token '${tok}'`, expression)
+    }
+    return Number(tok)
+  }
+
+  const values = new Set()
+  const star = raw === '*' || raw === '?'
+
+  for (const part of raw.split(',')) {
+    if (part === '') throw new CronParseError(`Empty ${field} list item`, expression)
+    // Split an optional step: "<range>/<step>".
+    const [rangeText, stepText, ...rest] = part.split('/')
+    if (rest.length > 0) throw new CronParseError(`Malformed ${field} step '${part}'`, expression)
+    let step = 1
+    if (stepText !== undefined) {
+      if (!/^\d+$/.test(stepText) || Number(stepText) === 0) {
+        throw new CronParseError(`Invalid ${field} step '${stepText}'`, expression)
+      }
+      step = Number(stepText)
+    }
+
+    // Determine the [lo, hi] range this part iterates over.
+    let lo
+    let hi
+    if (rangeText === '*' || rangeText === '?') {
+      lo = min
+      hi = max
+    } else if (rangeText.includes('-')) {
+      const [a, b, ...more] = rangeText.split('-')
+      if (more.length > 0) throw new CronParseError(`Malformed ${field} range '${rangeText}'`, expression)
+      lo = resolveToken(a)
+      hi = resolveToken(b)
+    } else {
+      lo = resolveToken(rangeText)
+      // A bare value with a step (`5/10`) iterates from the value up to the max.
+      hi = stepText !== undefined ? max : lo
+    }
+
+    if (lo < min || hi > max || lo > hi) {
+      throw new CronParseError(`${field} value out of range in '${part}' (allowed ${min}-${max})`, expression)
+    }
+    for (let v = lo; v <= hi; v += step) values.add(v)
+  }
+
+  // Normalize day-of-week 7 -> 0 (both are Sunday) so matching against JS
+  // Date.getDay() (0=Sun..6=Sat) is a straight Set lookup.
+  if (field === 'dow' && values.has(7)) {
+    values.delete(7)
+    values.add(0)
+  }
+
+  return { values, star }
+}
+
+/**
+ * Parse a standard 5-field crontab expression (minute hour day-of-month month
+ * day-of-week) into matched-value sets. Whitespace between fields is collapsed.
+ * Throws {@link CronParseError} on any malformed field.
+ * @param {string} expression
+ * @returns {{minute:Set<number>,hour:Set<number>,dom:Set<number>,month:Set<number>,dow:Set<number>,domStar:boolean,dowStar:boolean}}
+ */
+export function parseCron(expression) {
+  if (typeof expression !== 'string') {
+    throw new CronParseError('Cron expression must be a string', expression)
+  }
+  const fields = expression.trim().split(/\s+/)
+  if (fields.length !== 5) {
+    throw new CronParseError(`Expected 5 cron fields, got ${fields.length}`, expression)
+  }
+  const [min, hour, dom, month, dow] = fields
+  const minute = parseField(min, 'minute', expression)
+  const hourF = parseField(hour, 'hour', expression)
+  const domF = parseField(dom, 'dom', expression)
+  const monthF = parseField(month, 'month', expression)
+  const dowF = parseField(dow, 'dow', expression)
+  return {
+    minute: minute.values,
+    hour: hourF.values,
+    dom: domF.values,
+    month: monthF.values,
+    dow: dowF.values,
+    domStar: domF.star,
+    dowStar: dowF.star,
+  }
+}
+
+/**
+ * Whether a Date's calendar day matches a parsed cron's day-of-month /
+ * day-of-week fields, using Vixie-cron OR-semantics: when BOTH fields are
+ * restricted (neither is `*`), a day matches if EITHER matches; when only one is
+ * restricted, only that one is consulted.
+ * @param {ReturnType<typeof parseCron>} c
+ * @param {Date} d - local Date
+ * @returns {boolean}
+ */
+function dayMatches(c, d) {
+  const domOk = c.dom.has(d.getDate())
+  const dowOk = c.dow.has(d.getDay())
+  if (!c.domStar && !c.dowStar) return domOk || dowOk
+  if (!c.domStar) return domOk
+  if (!c.dowStar) return dowOk
+  return true
+}
+
+/**
+ * Compute the next time a parsed cron fires strictly AFTER `fromMs`, in the
+ * daemon's LOCAL time zone. Returns an epoch-ms timestamp, or null if no match
+ * falls within the search horizon (an impossible expression).
+ *
+ * Local time is deliberate: `0 9 * * *` should mean 9am wall-clock. Times that
+ * do not exist on a DST spring-forward day (e.g. 02:30 where the clock jumps
+ * 02:00->03:00) are naturally skipped by the Date arithmetic; on a fall-back day
+ * the task fires once. Explicit per-task time zones are a future concern.
+ * @param {ReturnType<typeof parseCron>} c
+ * @param {number} fromMs
+ * @returns {number|null}
+ */
+export function computeCronNextRun(c, fromMs) {
+  const horizon = fromMs + CRON_HORIZON_MS
+  const d = new Date(fromMs)
+  // Advance to the next whole minute strictly after fromMs.
+  d.setSeconds(0, 0)
+  d.setMinutes(d.getMinutes() + 1)
+
+  while (d.getTime() <= horizon) {
+    if (!c.month.has(d.getMonth() + 1)) {
+      // Jump to the first day of the next month at 00:00 local.
+      d.setMonth(d.getMonth() + 1, 1)
+      d.setHours(0, 0, 0, 0)
+      continue
+    }
+    if (!dayMatches(c, d)) {
+      d.setDate(d.getDate() + 1)
+      d.setHours(0, 0, 0, 0)
+      continue
+    }
+    if (!c.hour.has(d.getHours())) {
+      d.setHours(d.getHours() + 1, 0, 0, 0)
+      continue
+    }
+    if (!c.minute.has(d.getMinutes())) {
+      d.setMinutes(d.getMinutes() + 1, 0, 0)
+      continue
+    }
+    return d.getTime()
+  }
+  return null
+}
+
+/**
+ * Compute the next fire time strictly AFTER `fromMs` for an interval cadence.
+ * The anchor (defaulting to the caller's supplied base, typically the task's
+ * createdAt) fixes the phase so the boundaries do not drift with computation
+ * time. When the anchor itself is still in the future, that first anchor time is
+ * the next run.
+ * @param {number} everyMs
+ * @param {number} anchorMs
+ * @param {number} fromMs
+ * @returns {number|null}
+ */
+export function computeIntervalNextRun(everyMs, anchorMs, fromMs) {
+  if (!Number.isFinite(everyMs) || everyMs < MIN_INTERVAL_MS) return null
+  if (!Number.isFinite(anchorMs)) return null
+  if (fromMs < anchorMs) return anchorMs
+  const steps = Math.floor((fromMs - anchorMs) / everyMs) + 1
+  return anchorMs + steps * everyMs
+}
+
+/**
+ * Compute a task's next run time (epoch ms) strictly after `fromMs`, or null
+ * when the task will not run again: it is disabled, it is a one-time task that
+ * has already run, its cadence is malformed, or a cron match falls beyond the
+ * search horizon. Pure — computes only, never fires.
+ *
+ * A one-time task that has NOT run yet returns its `at` even when `at` is in the
+ * past: that "overdue" state is meaningful for display, and the engine (#6865)
+ * decides whether to fire it immediately.
+ * @param {object} task - normalized scheduled task (see scheduled-task-store.js)
+ * @param {object} [opts]
+ * @param {number} [opts.from] - reference time (defaults to Date.now())
+ * @returns {number|null}
+ */
+export function computeNextRun(task, { from = Date.now() } = {}) {
+  if (!task || task.enabled === false) return null
+  const cadence = task.cadence
+  if (!cadence || typeof cadence !== 'object') return null
+
+  switch (cadence.kind) {
+    case 'once': {
+      if (task.lastRun) return null
+      return Number.isFinite(cadence.at) ? cadence.at : null
+    }
+    case 'interval': {
+      const anchor = Number.isFinite(cadence.anchor) ? cadence.anchor
+        : (Number.isFinite(task.createdAt) ? task.createdAt : from)
+      return computeIntervalNextRun(cadence.everyMs, anchor, from)
+    }
+    case 'cron': {
+      let parsed
+      try {
+        parsed = parseCron(cadence.expression)
+      } catch {
+        return null
+      }
+      return computeCronNextRun(parsed, from)
+    }
+    default:
+      return null
+  }
+}

--- a/packages/server/src/schedule-parser.js
+++ b/packages/server/src/schedule-parser.js
@@ -82,7 +82,13 @@ function parseField(raw, field, expression) {
   }
 
   const values = new Set()
-  const star = raw === '*' || raw === '?'
+  // Vixie star flag: set when the field's FIRST CHARACTER is `*` (or the Quartz
+  // `?` alias) — which deliberately INCLUDES step forms like `*/5`. Vixie's
+  // DOM_STAR / DOW_STAR are set off the leading `*` even though `*/5` also
+  // restricts the value set, and that flag drives the dom/dow OR-vs-AND rule in
+  // dayMatches. A literal-star-only check (`raw === '*'`) would wrongly treat
+  // `*/5` as non-star and OR it against a weekday instead of AND-ing (#6879).
+  const star = raw[0] === '*' || raw[0] === '?'
 
   for (const part of raw.split(',')) {
     if (part === '') throw new CronParseError(`Empty ${field} list item`, expression)
@@ -164,9 +170,20 @@ export function parseCron(expression) {
 
 /**
  * Whether a Date's calendar day matches a parsed cron's day-of-month /
- * day-of-week fields, using Vixie-cron OR-semantics: when BOTH fields are
- * restricted (neither is `*`), a day matches if EITHER matches; when only one is
- * restricted, only that one is consulted.
+ * day-of-week fields, using the standard Vixie-cron rule (#6879 — this mirrors
+ * cron.c's `(DOM_STAR || DOW_STAR) ? (dom && dow) : (dom || dow)`):
+ *
+ *   - If EITHER field is a star (its first char is `*`, which INCLUDES a
+ *     step form such as star-slash-5), the two constraints are AND-ed: the day
+ *     must satisfy BOTH. Because a bare `*` field matches every value, this
+ *     reduces to "use the non-star field" for the common `0 0 15 * *` /
+ *     `0 0 * * 1` cases — but for a dom step against a weekday (star-slash-5 in
+ *     dom, Monday in dow) it correctly means "a Monday that ALSO falls on a day
+ *     in the step set", NOT an OR of the two.
+ *   - If NEITHER field is a star (both are explicitly restricted, e.g.
+ *     `0 0 1,15 * 5` or `0 0 1-7 * 1`), the constraints are OR-ed: the day
+ *     matches if EITHER matches.
+ *
  * @param {ReturnType<typeof parseCron>} c
  * @param {Date} d - local Date
  * @returns {boolean}
@@ -174,10 +191,8 @@ export function parseCron(expression) {
 function dayMatches(c, d) {
   const domOk = c.dom.has(d.getDate())
   const dowOk = c.dow.has(d.getDay())
-  if (!c.domStar && !c.dowStar) return domOk || dowOk
-  if (!c.domStar) return domOk
-  if (!c.dowStar) return dowOk
-  return true
+  if (c.domStar || c.dowStar) return domOk && dowOk
+  return domOk || dowOk
 }
 
 /**
@@ -185,10 +200,18 @@ function dayMatches(c, d) {
  * daemon's LOCAL time zone. Returns an epoch-ms timestamp, or null if no match
  * falls within the search horizon (an impossible expression).
  *
- * Local time is deliberate: `0 9 * * *` should mean 9am wall-clock. Times that
- * do not exist on a DST spring-forward day (e.g. 02:30 where the clock jumps
- * 02:00->03:00) are naturally skipped by the Date arithmetic; on a fall-back day
- * the task fires once. Explicit per-task time zones are a future concern.
+ * Local time is deliberate: `0 9 * * *` should mean 9am wall-clock.
+ *
+ * DST is an INTENTIONAL product choice (#6879), not an accident of the
+ * arithmetic: on a spring-forward day a wall-clock time that DOES NOT EXIST
+ * (e.g. `30 2 * * *` when the clock jumps 02:00->03:00) is SKIPPED for that day
+ * rather than fired at the shifted 03:00 — we would rather miss the
+ * non-existent slot for one day than run at a time the user did not ask for.
+ * This falls out of reading getHours()/getMinutes() back off a local Date after
+ * each step: the Date never reports the non-existent 02:xx (setHours(2) on that
+ * day normalizes to 03:00), so the 02:xx minute is never matched. On a fall-back
+ * day the duplicated hour fires once. Explicit per-task time zones are a future
+ * concern.
  * @param {ReturnType<typeof parseCron>} c
  * @param {number} fromMs
  * @returns {number|null}

--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -1,0 +1,432 @@
+import fs from 'fs'
+import { randomUUID } from 'crypto'
+import { dirname, resolve } from 'path'
+import { writeFileRestricted } from './platform.js'
+import { createLogger } from './logger.js'
+import { computeNextRun, parseCron, MIN_INTERVAL_MS } from './schedule-parser.js'
+
+const log = createLogger('scheduled-task-store')
+
+// Current on-disk schema version. Bumped only on a breaking shape change so a
+// future loader can migrate (or discard) an older file rather than silently
+// mis-reading it. Mirrors permission-rule-store.js's version gate.
+const STORE_VERSION = 1
+
+// Hard cap on persisted tasks. A normal daemon has a handful of standing
+// schedules; this only bites a hand-edited or runaway file. Extra entries beyond
+// the cap are dropped on load (oldest kept) and refused on add.
+const MAX_TASKS = 500
+
+const CADENCE_KINDS = new Set(['once', 'interval', 'cron'])
+const LAST_RUN_STATUSES = new Set(['success', 'error', 'skipped', 'timeout'])
+
+/**
+ * Error thrown when a task submitted to add()/update() is malformed. Carries the
+ * offending field name so a caller (CLI #6868 / dashboard #6871) can surface a
+ * precise validation message. Corrupt entries read off DISK are silently dropped
+ * instead (fail-open), never thrown — only programmatic input is strict.
+ */
+export class ScheduledTaskValidationError extends Error {
+  constructor(message, field) {
+    super(message)
+    this.name = 'ScheduledTaskValidationError'
+    this.field = field
+  }
+}
+
+/**
+ * Trim and validate an optional string target field. Returns the trimmed string,
+ * or undefined when absent/empty. Throws on a non-string.
+ */
+function optionalString(value, field) {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') throw new ScheduledTaskValidationError(`${field} must be a string`, field)
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Normalize + validate a target session config `{ provider, model, cwd,
+ * permissionMode }`. All fields optional; unknown keys are dropped. Returns a
+ * plain object (possibly empty).
+ */
+function normalizeTarget(target) {
+  if (target === undefined || target === null) return {}
+  if (typeof target !== 'object') throw new ScheduledTaskValidationError('target must be an object', 'target')
+  const out = {}
+  const provider = optionalString(target.provider, 'target.provider')
+  const model = optionalString(target.model, 'target.model')
+  const cwd = optionalString(target.cwd, 'target.cwd')
+  const permissionMode = optionalString(target.permissionMode, 'target.permissionMode')
+  if (provider !== undefined) out.provider = provider
+  if (model !== undefined) out.model = model
+  if (cwd !== undefined) out.cwd = cwd
+  if (permissionMode !== undefined) out.permissionMode = permissionMode
+  return out
+}
+
+/**
+ * Normalize + validate a cadence into its canonical stored form. Throws
+ * {@link ScheduledTaskValidationError} on anything malformed.
+ * @returns {{kind:'once',at:number} | {kind:'interval',everyMs:number,anchor?:number} | {kind:'cron',expression:string}}
+ */
+function normalizeCadence(cadence) {
+  if (!cadence || typeof cadence !== 'object') {
+    throw new ScheduledTaskValidationError('cadence is required', 'cadence')
+  }
+  if (!CADENCE_KINDS.has(cadence.kind)) {
+    throw new ScheduledTaskValidationError(`cadence.kind must be one of ${[...CADENCE_KINDS].join(', ')}`, 'cadence.kind')
+  }
+  switch (cadence.kind) {
+    case 'once': {
+      if (!Number.isFinite(cadence.at)) {
+        throw new ScheduledTaskValidationError('once cadence requires a numeric `at` (epoch ms)', 'cadence.at')
+      }
+      return { kind: 'once', at: cadence.at }
+    }
+    case 'interval': {
+      if (!Number.isFinite(cadence.everyMs) || cadence.everyMs < MIN_INTERVAL_MS) {
+        throw new ScheduledTaskValidationError(`interval cadence requires everyMs >= ${MIN_INTERVAL_MS}`, 'cadence.everyMs')
+      }
+      const out = { kind: 'interval', everyMs: Math.floor(cadence.everyMs) }
+      if (cadence.anchor !== undefined) {
+        if (!Number.isFinite(cadence.anchor)) {
+          throw new ScheduledTaskValidationError('interval cadence anchor must be numeric (epoch ms)', 'cadence.anchor')
+        }
+        out.anchor = cadence.anchor
+      }
+      return out
+    }
+    case 'cron': {
+      if (typeof cadence.expression !== 'string') {
+        throw new ScheduledTaskValidationError('cron cadence requires a string `expression`', 'cadence.expression')
+      }
+      // parseCron throws CronParseError on a malformed field — re-surface it as a
+      // validation error so callers get one error type off add()/update().
+      try {
+        parseCron(cadence.expression)
+      } catch (err) {
+        throw new ScheduledTaskValidationError(`invalid cron expression: ${err.message}`, 'cadence.expression')
+      }
+      return { kind: 'cron', expression: cadence.expression.trim() }
+    }
+    default:
+      // Unreachable — CADENCE_KINDS gates kind above.
+      throw new ScheduledTaskValidationError('unsupported cadence', 'cadence.kind')
+  }
+}
+
+/**
+ * Normalize + validate a `lastRun` result stub. Optional; when present must be
+ * `{ at, status[, sessionId, error] }`. The engine (#6865) fills this after a
+ * run — the foundation just stores it. Throws on a malformed shape.
+ */
+function normalizeLastRun(lastRun) {
+  if (lastRun === undefined || lastRun === null) return null
+  if (typeof lastRun !== 'object') throw new ScheduledTaskValidationError('lastRun must be an object', 'lastRun')
+  if (!Number.isFinite(lastRun.at)) throw new ScheduledTaskValidationError('lastRun.at must be numeric (epoch ms)', 'lastRun.at')
+  if (!LAST_RUN_STATUSES.has(lastRun.status)) {
+    throw new ScheduledTaskValidationError(`lastRun.status must be one of ${[...LAST_RUN_STATUSES].join(', ')}`, 'lastRun.status')
+  }
+  const out = { at: lastRun.at, status: lastRun.status }
+  const sessionId = optionalString(lastRun.sessionId, 'lastRun.sessionId')
+  const error = optionalString(lastRun.error, 'lastRun.error')
+  if (sessionId !== undefined) out.sessionId = sessionId
+  if (error !== undefined) out.error = error
+  return out
+}
+
+/**
+ * The scheduled-task data model (#6862). A standing, persisted schedule for a
+ * future/recurring agent run — explicitly SEPARATE from live session state and
+ * from `ScheduleWakeup` (transcript-tasks.js), which is an intra-session,
+ * single-shot self-resume. No firing here; that is the engine slice (#6865).
+ *
+ * Stored shape:
+ *   {
+ *     id: string,                    // stable uuid
+ *     name: string | null,           // optional human label
+ *     enabled: boolean,              // paused === !enabled
+ *     prompt: string,                // instructions the run executes
+ *     target: {                      // session config the run is created with
+ *       provider?, model?, cwd?, permissionMode?
+ *     },
+ *     cadence:                       // one-time vs recurring
+ *       | { kind: 'once', at }
+ *       | { kind: 'interval', everyMs, anchor? }
+ *       | { kind: 'cron', expression },
+ *     nextRun: number | null,        // COMPUTED (never fired here), for display
+ *     lastRun: { at, status, sessionId?, error? } | null,  // engine fills this
+ *     createdAt: number,
+ *     updatedAt: number,
+ *   }
+ *
+ * Persistence mirrors permission-rule-store.js exactly: a single JSON file (a
+ * sibling of session-state.json, e.g. ~/.chroxy/scheduled-tasks.json) written
+ * atomically (temp + rename via writeFileRestricted, mode 0600), version-gated,
+ * and fail-open-empty on a corrupt/unknown-version file. Loaded once on daemon
+ * start; keyed by task id.
+ */
+export class ScheduledTaskStore {
+  /**
+   * @param {object} options
+   * @param {string} options.filePath - Path to the scheduled-tasks JSON file.
+   * @param {object} [options.logger] - Optional logger (defaults to module logger).
+   * @param {() => number} [options.now] - Test seam for the clock.
+   */
+  constructor({ filePath, logger, now } = {}) {
+    if (!filePath) throw new Error('ScheduledTaskStore requires a filePath')
+    this._filePath = filePath
+    this._log = logger || log
+    this._now = typeof now === 'function' ? now : Date.now
+    // id -> normalized task record
+    this._tasks = new Map()
+    this._loaded = false
+  }
+
+  /**
+   * Load tasks from disk, REPLACING any in-memory state — load() is a true
+   * snapshot of the file, so a second load() (or a load after the file was
+   * deleted or corrupted) can never keep stale in-memory tasks alive and
+   * re-persist them on the next write. A missing file is treated as an empty
+   * store; an unparseable / malformed / unknown-version file is logged and
+   * skipped whole (fail-open to "no scheduled tasks", never a partial read).
+   *
+   * Individual entries that fail normalization are dropped (logged) while valid
+   * siblings load — a single hand-edited bad task can't nuke the whole registry.
+   * `nextRun` is recomputed on load so a stored value can't drift from the
+   * cadence (and a disabled task always loads with nextRun null).
+   * @returns {this}
+   */
+  load() {
+    this._loaded = true
+    // Reset FIRST — every early return below must leave the store EMPTY, not
+    // holding the previous load's (now unbacked) tasks.
+    this._tasks.clear()
+    let raw
+    try {
+      raw = fs.readFileSync(this._filePath, 'utf-8')
+    } catch (err) {
+      if (err && err.code !== 'ENOENT') {
+        this._log.warn(`Failed to read scheduled tasks at ${this._filePath}: ${err.message}`)
+      }
+      return this
+    }
+    let parsed
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      this._log.warn(`Failed to parse scheduled tasks at ${this._filePath}: ${err.message} — ignoring`)
+      return this
+    }
+    if (!parsed || typeof parsed !== 'object') return this
+    // Version gate: an unknown (future / hand-mangled) version is skipped WHOLE
+    // rather than partially read against the wrong shape assumptions.
+    if (parsed.version !== STORE_VERSION) {
+      this._log.warn(`Unsupported scheduled-tasks version ${JSON.stringify(parsed.version)} at ${this._filePath} (expected ${STORE_VERSION}) — ignoring`)
+      return this
+    }
+    const tasks = parsed.tasks
+    if (!Array.isArray(tasks)) return this
+    for (const entry of tasks) {
+      if (this._tasks.size >= MAX_TASKS) {
+        this._log.warn(`Scheduled-tasks file exceeds cap (${MAX_TASKS}) — dropping the rest`)
+        break
+      }
+      let record
+      try {
+        record = this._normalizeStoredTask(entry)
+      } catch (err) {
+        this._log.warn(`Dropping malformed scheduled task on load: ${err.message}`)
+        continue
+      }
+      if (this._tasks.has(record.id)) {
+        this._log.warn(`Dropping duplicate scheduled-task id ${record.id} on load`)
+        continue
+      }
+      this._tasks.set(record.id, record)
+    }
+    if (this._tasks.size > 0) this._log.info(`Loaded ${this._tasks.size} scheduled task(s)`)
+    return this
+  }
+
+  /**
+   * Add a new task. Assigns a fresh id (or accepts a caller-supplied id that
+   * does not collide), timestamps it, and computes `nextRun`. Persists. Throws
+   * {@link ScheduledTaskValidationError} on invalid input.
+   * @param {object} input - `{ prompt, cadence, target?, enabled?, name?, id?, lastRun? }`
+   * @returns {object} the stored task (a copy)
+   */
+  add(input) {
+    if (!input || typeof input !== 'object') {
+      throw new ScheduledTaskValidationError('task input is required', 'task')
+    }
+    if (this._tasks.size >= MAX_TASKS) {
+      throw new ScheduledTaskValidationError(`scheduled-task cap reached (${MAX_TASKS})`, 'task')
+    }
+    let id = input.id
+    if (id === undefined || id === null) {
+      id = randomUUID()
+    } else {
+      if (typeof id !== 'string' || id.trim().length === 0) {
+        throw new ScheduledTaskValidationError('id must be a non-empty string', 'id')
+      }
+      id = id.trim()
+      if (this._tasks.has(id)) throw new ScheduledTaskValidationError(`task id ${id} already exists`, 'id')
+    }
+
+    const now = this._now()
+    const record = {
+      id,
+      name: optionalString(input.name, 'name') ?? null,
+      enabled: input.enabled === undefined ? true : Boolean(input.enabled),
+      prompt: this._requirePrompt(input.prompt),
+      target: normalizeTarget(input.target),
+      cadence: normalizeCadence(input.cadence),
+      nextRun: null,
+      lastRun: normalizeLastRun(input.lastRun),
+      createdAt: now,
+      updatedAt: now,
+    }
+    record.nextRun = computeNextRun(record, { from: now })
+    this._tasks.set(id, record)
+    this._persist()
+    return this._clone(record)
+  }
+
+  /**
+   * Return a task by id (a copy), or null when absent.
+   * @param {string} id
+   * @returns {object|null}
+   */
+  get(id) {
+    const record = this._tasks.get(id)
+    return record ? this._clone(record) : null
+  }
+
+  /**
+   * Snapshot of every task (copies), insertion order.
+   * @returns {object[]}
+   */
+  list() {
+    return Array.from(this._tasks.values(), (r) => this._clone(r))
+  }
+
+  /**
+   * Apply a partial patch to an existing task and persist. Recomputes `nextRun`
+   * (so a cadence/enabled change is reflected) and bumps `updatedAt`. The `id`
+   * and `createdAt` are immutable. Returns the updated task (a copy), or null
+   * when the id is unknown. Throws {@link ScheduledTaskValidationError} on an
+   * invalid patch value.
+   * @param {string} id
+   * @param {object} patch - any subset of `{ prompt, cadence, target, enabled, name, lastRun }`
+   * @returns {object|null}
+   */
+  update(id, patch) {
+    const existing = this._tasks.get(id)
+    if (!existing) return null
+    if (!patch || typeof patch !== 'object') {
+      throw new ScheduledTaskValidationError('update patch is required', 'patch')
+    }
+    const next = { ...existing }
+    if ('prompt' in patch) next.prompt = this._requirePrompt(patch.prompt)
+    if ('cadence' in patch) next.cadence = normalizeCadence(patch.cadence)
+    if ('target' in patch) next.target = normalizeTarget(patch.target)
+    if ('enabled' in patch) next.enabled = Boolean(patch.enabled)
+    if ('name' in patch) next.name = optionalString(patch.name, 'name') ?? null
+    if ('lastRun' in patch) next.lastRun = normalizeLastRun(patch.lastRun)
+    next.updatedAt = this._now()
+    next.nextRun = computeNextRun(next, { from: next.updatedAt })
+    this._tasks.set(id, next)
+    this._persist()
+    return this._clone(next)
+  }
+
+  /**
+   * Remove a task by id and persist. Returns true when a task was removed.
+   * @param {string} id
+   * @returns {boolean}
+   */
+  remove(id) {
+    if (!this._tasks.has(id)) return false
+    this._tasks.delete(id)
+    this._persist()
+    return true
+  }
+
+  /** @private — require a non-empty string prompt. */
+  _requirePrompt(prompt) {
+    if (typeof prompt !== 'string' || prompt.trim().length === 0) {
+      throw new ScheduledTaskValidationError('prompt is required (non-empty string)', 'prompt')
+    }
+    return prompt
+  }
+
+  /**
+   * @private — normalize an entry read from disk into a stored record, filling
+   * missing timestamps and recomputing nextRun. Throws on anything that can't be
+   * coerced into a valid task (the caller drops it, logging).
+   */
+  _normalizeStoredTask(entry) {
+    if (!entry || typeof entry !== 'object') {
+      throw new ScheduledTaskValidationError('task entry must be an object', 'task')
+    }
+    if (typeof entry.id !== 'string' || entry.id.trim().length === 0) {
+      throw new ScheduledTaskValidationError('task id must be a non-empty string', 'id')
+    }
+    const createdAt = Number.isFinite(entry.createdAt) ? entry.createdAt : this._now()
+    const updatedAt = Number.isFinite(entry.updatedAt) ? entry.updatedAt : createdAt
+    const record = {
+      id: entry.id.trim(),
+      name: optionalString(entry.name, 'name') ?? null,
+      enabled: entry.enabled === undefined ? true : Boolean(entry.enabled),
+      prompt: this._requirePrompt(entry.prompt),
+      target: normalizeTarget(entry.target),
+      cadence: normalizeCadence(entry.cadence),
+      nextRun: null,
+      lastRun: normalizeLastRun(entry.lastRun),
+      createdAt,
+      updatedAt,
+    }
+    // Recompute nextRun from the cadence rather than trusting the stored value,
+    // so a stale/hand-edited nextRun can never diverge from the schedule.
+    record.nextRun = computeNextRun(record, { from: this._now() })
+    return record
+  }
+
+  /** @private — deep-ish copy so callers can't mutate the in-memory record. */
+  _clone(record) {
+    return {
+      ...record,
+      target: { ...record.target },
+      cadence: { ...record.cadence },
+      lastRun: record.lastRun ? { ...record.lastRun } : null,
+    }
+  }
+
+  /** @private — atomic write of the whole store. */
+  _persist() {
+    try {
+      const dir = dirname(this._filePath)
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+      const state = { version: STORE_VERSION, tasks: Array.from(this._tasks.values()) }
+      writeFileRestricted(this._filePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
+    } catch (err) {
+      // Best-effort: a failed persist leaves the in-memory set intact for this
+      // process; the prior good file (if any) survives (atomic write). Surface
+      // it so an operator can see the schedule won't survive a restart.
+      this._log.error(`Failed to persist scheduled tasks to ${this._filePath}: ${err?.stack || err}`)
+    }
+  }
+}
+
+/**
+ * Default on-disk path for the registry given the session-state file's dir — a
+ * sibling of session-state.json. Kept here so both session-manager wiring and a
+ * future CLI/engine resolve the same path.
+ * @param {string} stateFilePath
+ * @returns {string}
+ */
+export function defaultScheduledTasksPath(stateFilePath) {
+  return resolve(dirname(stateFilePath), 'scheduled-tasks.json')
+}

--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 import { computeNextRun, parseCron, MIN_INTERVAL_MS } from './schedule-parser.js'
+import { ALLOWED_PERMISSION_MODE_IDS } from './handler-utils.js'
 
 const log = createLogger('scheduled-task-store')
 
@@ -46,18 +47,38 @@ function optionalString(value, field) {
 }
 
 /**
+ * True only for a plain `{}` object — rejects arrays, class instances, and
+ * primitives. `typeof [] === 'object'` alone would let an array masquerade as a
+ * valid target, so callers that want a `{ provider, ... }` bag must use this.
+ */
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+/**
  * Normalize + validate a target session config `{ provider, model, cwd,
- * permissionMode }`. All fields optional; unknown keys are dropped. Returns a
- * plain object (possibly empty).
+ * permissionMode }`. All fields optional; unknown keys are dropped. `target`
+ * must be a plain object (an array or other non-plain value is rejected, since
+ * `typeof [] === 'object'`), and `permissionMode`, when present, must be one of
+ * the server's supported mode IDs ({@link ALLOWED_PERMISSION_MODE_IDS}). Returns
+ * a plain object (possibly empty).
  */
 function normalizeTarget(target) {
   if (target === undefined || target === null) return {}
-  if (typeof target !== 'object') throw new ScheduledTaskValidationError('target must be an object', 'target')
+  if (!isPlainObject(target)) throw new ScheduledTaskValidationError('target must be a plain object', 'target')
   const out = {}
   const provider = optionalString(target.provider, 'target.provider')
   const model = optionalString(target.model, 'target.model')
   const cwd = optionalString(target.cwd, 'target.cwd')
   const permissionMode = optionalString(target.permissionMode, 'target.permissionMode')
+  if (permissionMode !== undefined && !ALLOWED_PERMISSION_MODE_IDS.has(permissionMode)) {
+    throw new ScheduledTaskValidationError(
+      `target.permissionMode must be one of ${[...ALLOWED_PERMISSION_MODE_IDS].join(', ')}`,
+      'target.permissionMode',
+    )
+  }
   if (provider !== undefined) out.provider = provider
   if (model !== undefined) out.model = model
   if (cwd !== undefined) out.cwd = cwd

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -23,6 +23,7 @@ import { SkillsUsageRecorder } from './skills-usage.js'
 import { resolveSessionPreset, foldPreamble } from './session-preset.js'
 import { SessionPresetTrustStore } from './session-preset-trust.js'
 import { PermissionRuleStore } from './permission-rule-store.js'
+import { ScheduledTaskStore, defaultScheduledTasksPath } from './scheduled-task-store.js'
 import { createLogger } from './logger.js'
 import { ExternalSessionRegistry } from './external-session-registry.js'
 import { metrics } from './metrics.js'
@@ -334,6 +335,14 @@ export class SessionManager extends EventEmitter {
     // file so a temp stateFilePath keeps it out of the real ~/.chroxy.
     permissionRuleStore,
 
+    // #6862: durable scheduled-task registry (standing schedules that run on a
+    // future/recurring cadence — SEPARATE from live session state and from the
+    // intra-session ScheduleWakeup). Tests pass their own temp-pathed store;
+    // production wires a default whose file (scheduled-tasks.json) sits next to
+    // the session-state file so a temp stateFilePath keeps it out of the real
+    // ~/.chroxy. No firing here — the engine is a sibling slice (#6865).
+    scheduledTaskStore,
+
     // Message history
     maxMessages,
     maxHistory,
@@ -527,6 +536,18 @@ export class SessionManager extends EventEmitter {
     } else {
       this.permissionRuleStore = new PermissionRuleStore({ filePath: join(dirname(this._stateFilePath), 'permission-rules.json') })
       this.permissionRuleStore.load()
+    }
+    // #6862: durable scheduled-task registry. Same temp-redirect logic as the
+    // sidecars above — the default file sits next to the session-state file so a
+    // test's temp stateFilePath keeps schedules out of the real home. Loaded once
+    // here on daemon start; a caller-supplied store owns its own load() lifecycle.
+    // Nothing fires it — the store just persists tasks + computes next-run; the
+    // engine slice (#6865) reads it off `sessionManager.scheduledTaskStore`.
+    if (scheduledTaskStore) {
+      this.scheduledTaskStore = scheduledTaskStore
+    } else {
+      this.scheduledTaskStore = new ScheduledTaskStore({ filePath: defaultScheduledTasksPath(this._stateFilePath) })
+      this.scheduledTaskStore.load()
     }
     Object.defineProperty(this, '_persistTimer', {
       get: () => this._persistence._persistTimer,

--- a/packages/server/tests/schedule-parser.test.js
+++ b/packages/server/tests/schedule-parser.test.js
@@ -1,0 +1,172 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseCron,
+  computeCronNextRun,
+  computeIntervalNextRun,
+  computeNextRun,
+  CronParseError,
+  MIN_INTERVAL_MS,
+} from '../src/schedule-parser.js'
+
+/**
+ * #6862 — schedule parsing + next-run computation for the scheduled-task
+ * registry. Pure math, no persistence, no firing. Cron next-run is computed in
+ * LOCAL time, so expected timestamps are built with the local Date constructor
+ * (new Date(y, m, d, h, min)) to stay timezone-independent.
+ */
+
+// Local wall-clock helper — month is 0-indexed like the Date constructor.
+const local = (y, mon, d, h = 0, min = 0) => new Date(y, mon, d, h, min, 0, 0).getTime()
+
+describe('#6862 parseCron', () => {
+  it('parses a 5-field expression into matched-value sets', () => {
+    const c = parseCron('30 9 * * *')
+    assert.deepEqual([...c.minute], [30])
+    assert.deepEqual([...c.hour], [9])
+    assert.equal(c.domStar, true)
+    assert.equal(c.dowStar, true)
+    assert.equal(c.month.size, 12)
+  })
+
+  it('supports ranges, steps, and lists', () => {
+    const c = parseCron('0,15,30,45 9-17 * * 1-5')
+    assert.deepEqual([...c.minute], [0, 15, 30, 45])
+    assert.deepEqual([...c.hour], [9, 10, 11, 12, 13, 14, 15, 16, 17])
+    assert.deepEqual([...c.dow].sort((a, b) => a - b), [1, 2, 3, 4, 5])
+
+    const step = parseCron('*/20 */6 * * *')
+    assert.deepEqual([...step.minute], [0, 20, 40])
+    assert.deepEqual([...step.hour], [0, 6, 12, 18])
+  })
+
+  it('normalizes day-of-week 7 to 0 (both Sunday)', () => {
+    const c = parseCron('0 0 * * 7')
+    assert.deepEqual([...c.dow], [0])
+    assert.equal(c.dowStar, false)
+  })
+
+  it('accepts 3-letter month and weekday names', () => {
+    const c = parseCron('0 0 1 jan-mar mon')
+    assert.deepEqual([...c.month].sort((a, b) => a - b), [1, 2, 3])
+    assert.deepEqual([...c.dow], [1])
+  })
+
+  it('rejects malformed expressions with CronParseError', () => {
+    assert.throws(() => parseCron('* * * *'), CronParseError) // 4 fields
+    assert.throws(() => parseCron('60 * * * *'), CronParseError) // minute out of range
+    assert.throws(() => parseCron('* 24 * * *'), CronParseError) // hour out of range
+    assert.throws(() => parseCron('* * * * 9'), CronParseError) // dow out of range
+    assert.throws(() => parseCron('*/0 * * * *'), CronParseError) // zero step
+    assert.throws(() => parseCron('5-1 * * * *'), CronParseError) // inverted range
+    assert.throws(() => parseCron('abc * * * *'), CronParseError) // non-numeric minute
+    assert.throws(() => parseCron(42), CronParseError) // not a string
+  })
+})
+
+describe('#6862 computeCronNextRun (local time)', () => {
+  it('finds the next daily fire strictly after `from`', () => {
+    const c = parseCron('0 9 * * *')
+    // 08:00 -> same day 09:00
+    assert.equal(computeCronNextRun(c, local(2026, 6, 20, 8, 0)), local(2026, 6, 20, 9, 0))
+    // 09:00 exactly -> next day 09:00 (strictly after)
+    assert.equal(computeCronNextRun(c, local(2026, 6, 20, 9, 0)), local(2026, 6, 21, 9, 0))
+    // 10:00 -> next day 09:00
+    assert.equal(computeCronNextRun(c, local(2026, 6, 20, 10, 0)), local(2026, 6, 21, 9, 0))
+  })
+
+  it('rolls across month boundaries (1st of month at midnight)', () => {
+    const c = parseCron('0 0 1 * *')
+    assert.equal(computeCronNextRun(c, local(2026, 6, 15, 12, 0)), local(2026, 7, 1, 0, 0))
+  })
+
+  it('honours weekday restriction (Mondays only)', () => {
+    const c = parseCron('0 0 * * 1')
+    // 2026-07-20 is a Monday. From Sunday 2026-07-19 -> Monday 2026-07-20 00:00.
+    assert.equal(new Date(local(2026, 6, 20)).getDay(), 1, 'sanity: 2026-07-20 is Monday')
+    assert.equal(computeCronNextRun(c, local(2026, 6, 19, 12, 0)), local(2026, 6, 20, 0, 0))
+  })
+
+  it('applies Vixie OR-semantics when both dom and dow are restricted', () => {
+    // Fires on the 1st of the month OR any Monday.
+    const c = parseCron('0 0 1 * 1')
+    // From 2026-07-02 (Thu): next Monday is 2026-07-06, which is sooner than the
+    // 1st of August — so the Monday wins (OR, not AND).
+    const next = computeCronNextRun(c, local(2026, 6, 2, 12, 0))
+    assert.equal(next, local(2026, 6, 6, 0, 0))
+    assert.equal(new Date(next).getDay(), 1)
+  })
+
+  it('finds a leap-day-only schedule within the horizon', () => {
+    const c = parseCron('0 0 29 2 *')
+    // From 2026-03-01, the next Feb 29 is 2028-02-29 (2028 is a leap year).
+    assert.equal(computeCronNextRun(c, local(2026, 2, 1, 0, 0)), local(2028, 1, 29, 0, 0))
+  })
+
+  it('returns null for an impossible expression (Feb 30)', () => {
+    const c = parseCron('0 0 30 2 *')
+    assert.equal(computeCronNextRun(c, local(2026, 0, 1, 0, 0)), null)
+  })
+})
+
+describe('#6862 computeIntervalNextRun', () => {
+  const HOUR = 60 * 60 * 1000
+  it('returns the next phase-aligned boundary strictly after `from`', () => {
+    const anchor = 1_000_000
+    assert.equal(computeIntervalNextRun(HOUR, anchor, anchor), anchor + HOUR)
+    assert.equal(computeIntervalNextRun(HOUR, anchor, anchor + 10), anchor + HOUR)
+    assert.equal(computeIntervalNextRun(HOUR, anchor, anchor + HOUR), anchor + 2 * HOUR) // on boundary -> next
+    assert.equal(computeIntervalNextRun(HOUR, anchor, anchor + HOUR + 1), anchor + 2 * HOUR)
+  })
+
+  it('returns the anchor itself when the anchor is still in the future', () => {
+    assert.equal(computeIntervalNextRun(HOUR, 5_000, 1_000), 5_000)
+  })
+
+  it('rejects a sub-minimum or non-finite interval', () => {
+    assert.equal(computeIntervalNextRun(MIN_INTERVAL_MS - 1, 0, 0), null)
+    assert.equal(computeIntervalNextRun(0, 0, 0), null)
+    assert.equal(computeIntervalNextRun(Number.NaN, 0, 0), null)
+    assert.equal(computeIntervalNextRun(HOUR, Number.NaN, 0), null)
+  })
+})
+
+describe('#6862 computeNextRun (task-level dispatch)', () => {
+  const HOUR = 60 * 60 * 1000
+  it('returns null for a disabled task', () => {
+    const task = { enabled: false, cadence: { kind: 'interval', everyMs: HOUR }, createdAt: 0 }
+    assert.equal(computeNextRun(task, { from: 0 }), null)
+  })
+
+  it('once: returns `at` when unrun, null once lastRun is set', () => {
+    const at = local(2030, 0, 1, 12, 0)
+    assert.equal(computeNextRun({ enabled: true, cadence: { kind: 'once', at }, lastRun: null }, { from: 0 }), at)
+    assert.equal(computeNextRun({ enabled: true, cadence: { kind: 'once', at }, lastRun: { at, status: 'success' } }, { from: 0 }), null)
+  })
+
+  it('once: an overdue unrun task still reports its (past) `at`', () => {
+    const at = 1000
+    assert.equal(computeNextRun({ enabled: true, cadence: { kind: 'once', at }, lastRun: null }, { from: 5000 }), at)
+  })
+
+  it('interval: anchors on createdAt when no explicit anchor', () => {
+    const task = { enabled: true, cadence: { kind: 'interval', everyMs: HOUR }, createdAt: 0 }
+    assert.equal(computeNextRun(task, { from: 10 }), HOUR)
+  })
+
+  it('interval: an explicit cadence.anchor overrides createdAt', () => {
+    const task = { enabled: true, cadence: { kind: 'interval', everyMs: HOUR, anchor: 500 }, createdAt: 0 }
+    assert.equal(computeNextRun(task, { from: 500 }), 500 + HOUR)
+  })
+
+  it('cron: computes the next fire from a valid expression', () => {
+    const task = { enabled: true, cadence: { kind: 'cron', expression: '0 9 * * *' } }
+    assert.equal(computeNextRun(task, { from: local(2026, 6, 20, 8, 0) }), local(2026, 6, 20, 9, 0))
+  })
+
+  it('returns null for a malformed cron / unknown cadence kind', () => {
+    assert.equal(computeNextRun({ enabled: true, cadence: { kind: 'cron', expression: 'nope' } }, { from: 0 }), null)
+    assert.equal(computeNextRun({ enabled: true, cadence: { kind: 'weekly' } }, { from: 0 }), null)
+    assert.equal(computeNextRun({ enabled: true, cadence: null }, { from: 0 }), null)
+  })
+})

--- a/packages/server/tests/schedule-parser.test.js
+++ b/packages/server/tests/schedule-parser.test.js
@@ -16,6 +16,13 @@ import {
  * (new Date(y, m, d, h, min)) to stay timezone-independent.
  */
 
+// Pin the whole file to a US-DST zone so the spring-forward skip (#6879) is
+// deterministic. Every cron assertion here is TZ-RELATIVE — expected values are
+// built with the same local Date constructor that computeCronNextRun reads back —
+// so pinning the zone does not change any of the non-DST expectations (a calendar
+// date's weekday is globally invariant).
+process.env.TZ = 'America/New_York'
+
 // Local wall-clock helper — month is 0-indexed like the Date constructor.
 const local = (y, mon, d, h = 0, min = 0) => new Date(y, mon, d, h, min, 0, 0).getTime()
 
@@ -106,6 +113,70 @@ describe('#6862 computeCronNextRun (local time)', () => {
   it('returns null for an impossible expression (Feb 30)', () => {
     const c = parseCron('0 0 30 2 *')
     assert.equal(computeCronNextRun(c, local(2026, 0, 1, 0, 0)), null)
+  })
+})
+
+describe('#6879 Vixie dom/dow star rule (OR vs AND)', () => {
+  it('treats a */step dom field as a STAR -> AND with dow (not OR)', () => {
+    // `*/5` starts with `*`, so DOM_STAR is set even though it also restricts the
+    // value set to {1,6,11,16,21,26,31}. With dow restricted (Monday), the Vixie
+    // rule ANDs: fire only on Mondays that ALSO fall on a */5 day.
+    const c = parseCron('0 0 */5 * 1')
+    assert.equal(c.domStar, true, '*/5 sets the dom star flag')
+    assert.deepEqual([...c.dom].sort((a, b) => a - b), [1, 6, 11, 16, 21, 26, 31])
+
+    // July 2026 Mondays are 6/13/20/27; only the 6th is in the */5 set.
+    assert.equal(computeCronNextRun(c, local(2026, 6, 1, 0, 0)), local(2026, 6, 6, 0, 0))
+
+    // Decisive AND proof: from that Monday it SKIPS 07-13/20/27 (Mondays NOT in
+    // the */5 set) — an OR would have fired on 07-13 — and lands on 2026-08-31
+    // (a Monday that is also day 31, a */5 member).
+    const next = computeCronNextRun(c, local(2026, 6, 6, 0, 0))
+    assert.equal(next, local(2026, 7, 31, 0, 0))
+    assert.equal(new Date(next).getDay(), 1, 'is a Monday')
+    assert.equal(new Date(next).getDate(), 31, 'and a */5 day')
+  })
+
+  it('ORs when NEITHER dom nor dow is a star (both explicitly restricted)', () => {
+    // `1-7` and `1` are both restricted (no leading `*`) -> OR: fire on any day
+    // 1-7 OR any Monday.
+    const c = parseCron('0 0 1-7 * 1')
+    assert.equal(c.domStar, false)
+    assert.equal(c.dowStar, false)
+
+    // Fires on day 1 even though it is a Wednesday (OR: dom matched, dow did not).
+    const firstOfMonth = computeCronNextRun(c, local(2026, 5, 30, 12, 0))
+    assert.equal(firstOfMonth, local(2026, 6, 1, 0, 0))
+    assert.notEqual(new Date(firstOfMonth).getDay(), 1, 'day-1 fire is a non-Monday -> proves OR')
+
+    // Fires on a Monday (07-13) that is NOT in the 1-7 dom set (OR: dow matched,
+    // dom did not). Under AND it would have to also be day 1-7.
+    const monday = computeCronNextRun(c, local(2026, 6, 8, 0, 0))
+    assert.equal(monday, local(2026, 6, 13, 0, 0))
+    assert.equal(new Date(monday).getDay(), 1)
+    assert.equal(new Date(monday).getDate(), 13, 'Monday outside the dom set still fires -> proves OR')
+  })
+})
+
+describe('#6879 cron DST spring-forward skip (intended)', () => {
+  // 2026 US DST starts 2026-03-08: the local clock jumps 02:00 -> 03:00, so any
+  // 02:xx wall-clock time does not exist that day. The parser SKIPS it for that
+  // day rather than firing at the shifted 03:xx (documented product choice).
+  it('skips a daily 02:30 on the spring-forward day instead of firing at 03:30', () => {
+    const c = parseCron('30 2 * * *')
+    const next = computeCronNextRun(c, local(2026, 2, 8, 0, 0))
+    assert.equal(new Date(next).getMonth(), 2, 'March')
+    assert.equal(new Date(next).getDate(), 9, 'skipped the 8th (02:30 did not exist)')
+    assert.equal(new Date(next).getHours(), 2, 'fires at the real 02:xx that exists on the 9th')
+    assert.equal(new Date(next).getMinutes(), 30)
+  })
+
+  it('still fires 02:30 on a normal (non-transition) day', () => {
+    const c = parseCron('30 2 * * *')
+    const next = computeCronNextRun(c, local(2026, 2, 9, 12, 0))
+    assert.equal(new Date(next).getDate(), 10)
+    assert.equal(new Date(next).getHours(), 2)
+    assert.equal(new Date(next).getMinutes(), 30)
   })
 })
 

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -66,10 +66,56 @@ describe('#6862 ScheduledTaskStore', () => {
     const store = newStore()
     assert.throws(() => store.add({ cadence: { kind: 'interval', everyMs: HOUR } }), ScheduledTaskValidationError) // no prompt
     assert.throws(() => store.add({ prompt: 'x' }), ScheduledTaskValidationError) // no cadence
-    assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'interval', everyMs: 10 } }), ScheduledTaskValidationError) // sub-min interval
+    assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'interval', everyMs: 10 } }), ScheduledTaskValidationError) // everyMs below the MIN_INTERVAL_MS floor (1000ms)
     assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'cron', expression: 'bad cron' } }), ScheduledTaskValidationError) // bad cron
     assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'once' } }), ScheduledTaskValidationError) // once without `at`
     assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'weekly' } }), ScheduledTaskValidationError) // unknown kind
+  })
+
+  it('normalizeTarget rejects a non-plain-object target (array, etc.)', () => {
+    const store = newStore()
+    // `typeof [] === 'object'` must NOT slip an array through as a valid target.
+    assert.throws(
+      () => store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 }, target: ['claude'] }),
+      ScheduledTaskValidationError,
+    )
+    // update() path is equally strict.
+    const t = store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 } })
+    assert.throws(() => store.update(t.id, { target: [] }), ScheduledTaskValidationError)
+  })
+
+  it('normalizeTarget rejects an unknown permissionMode', () => {
+    const store = newStore()
+    assert.throws(
+      () => store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 }, target: { permissionMode: 'yolo' } }),
+      ScheduledTaskValidationError,
+    )
+    const t = store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 } })
+    assert.throws(
+      () => store.update(t.id, { target: { permissionMode: 'not-a-mode' } }),
+      ScheduledTaskValidationError,
+    )
+  })
+
+  it('normalizeTarget accepts every supported permissionMode', () => {
+    const store = newStore()
+    for (const mode of ['approve', 'acceptEdits', 'auto', 'plan']) {
+      const t = store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 }, target: { permissionMode: mode } })
+      assert.equal(t.target.permissionMode, mode, `permissionMode ${mode} accepted`)
+    }
+  })
+
+  it('load() drops a task with an invalid target permissionMode but keeps valid siblings', () => {
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      tasks: [
+        { id: 'ok', prompt: 'p', cadence: { kind: 'once', at: 1 }, target: { permissionMode: 'plan' }, createdAt: 0, updatedAt: 0 },
+        { id: 'bad-mode', prompt: 'p', cadence: { kind: 'once', at: 1 }, target: { permissionMode: 'bogus' }, createdAt: 0, updatedAt: 0 },
+        { id: 'bad-target', prompt: 'p', cadence: { kind: 'once', at: 1 }, target: ['nope'], createdAt: 0, updatedAt: 0 },
+      ],
+    }))
+    const store = new ScheduledTaskStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store.list().map((t) => t.id), ['ok'], 'only the valid task survives')
   })
 
   it('get()/list() return copies that cannot mutate stored state', () => {

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -1,0 +1,212 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync, readdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  ScheduledTaskStore,
+  ScheduledTaskValidationError,
+  defaultScheduledTasksPath,
+} from '../src/scheduled-task-store.js'
+
+/**
+ * #6862 — persisted scheduled-task registry. Covers CRUD round-trips, restart
+ * survival (a fresh store reads the file), atomic write + 0600 perms, the
+ * version gate + corrupt-json fail-open, per-entry drop of malformed tasks, and
+ * next-run computation on add/update/load. No firing — the engine is #6865.
+ *
+ * Every store writes to a temp dir (never the real ~/.chroxy), so the #4633
+ * sandbox guard is satisfied.
+ */
+
+const silentLog = { info() {}, warn() {}, error() {} }
+const HOUR = 60 * 60 * 1000
+
+describe('#6862 ScheduledTaskStore', () => {
+  let dir
+  let filePath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sched-store-'))
+    filePath = join(dir, 'scheduled-tasks.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const newStore = (now) => new ScheduledTaskStore({ filePath, logger: silentLog, now })
+
+  it('requires a filePath', () => {
+    assert.throws(() => new ScheduledTaskStore({}), /requires a filePath/)
+  })
+
+  it('defaultScheduledTasksPath sits next to the state file', () => {
+    assert.equal(defaultScheduledTasksPath('/home/x/.chroxy/session-state.json'), '/home/x/.chroxy/scheduled-tasks.json')
+  })
+
+  it('add() assigns id/timestamps, computes nextRun, and persists', () => {
+    const store = newStore(() => 1000)
+    const task = store.add({
+      prompt: 'run the nightly report',
+      cadence: { kind: 'interval', everyMs: HOUR },
+      target: { provider: 'claude', model: 'sonnet', cwd: '/proj', permissionMode: 'plan' },
+    })
+    assert.ok(task.id, 'id assigned')
+    assert.equal(task.enabled, true)
+    assert.equal(task.createdAt, 1000)
+    assert.equal(task.updatedAt, 1000)
+    assert.equal(task.nextRun, 1000 + HOUR, 'interval nextRun anchored on createdAt')
+    assert.deepEqual(task.target, { provider: 'claude', model: 'sonnet', cwd: '/proj', permissionMode: 'plan' })
+    assert.equal(task.lastRun, null)
+    assert.ok(existsSync(filePath), 'file written')
+  })
+
+  it('add() rejects invalid input with ScheduledTaskValidationError', () => {
+    const store = newStore()
+    assert.throws(() => store.add({ cadence: { kind: 'interval', everyMs: HOUR } }), ScheduledTaskValidationError) // no prompt
+    assert.throws(() => store.add({ prompt: 'x' }), ScheduledTaskValidationError) // no cadence
+    assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'interval', everyMs: 10 } }), ScheduledTaskValidationError) // sub-min interval
+    assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'cron', expression: 'bad cron' } }), ScheduledTaskValidationError) // bad cron
+    assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'once' } }), ScheduledTaskValidationError) // once without `at`
+    assert.throws(() => store.add({ prompt: 'x', cadence: { kind: 'weekly' } }), ScheduledTaskValidationError) // unknown kind
+  })
+
+  it('get()/list() return copies that cannot mutate stored state', () => {
+    const store = newStore()
+    const added = store.add({ prompt: 'p', cadence: { kind: 'once', at: 5000 } })
+    const fetched = store.get(added.id)
+    fetched.prompt = 'MUTATED'
+    fetched.target.provider = 'evil'
+    assert.equal(store.get(added.id).prompt, 'p', 'stored prompt untouched')
+    assert.equal(store.get(added.id).target.provider, undefined)
+    assert.equal(store.get('nope'), null)
+    assert.equal(store.list().length, 1)
+  })
+
+  it('update() patches fields, recomputes nextRun, bumps updatedAt, keeps id/createdAt', () => {
+    let clock = 1000
+    const store = newStore(() => clock)
+    const t = store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: HOUR } })
+    clock = 2000
+    const updated = store.update(t.id, { cadence: { kind: 'interval', everyMs: 2 * HOUR }, enabled: false, name: 'nightly' })
+    assert.equal(updated.id, t.id)
+    assert.equal(updated.createdAt, 1000, 'createdAt immutable')
+    assert.equal(updated.updatedAt, 2000, 'updatedAt bumped')
+    assert.equal(updated.name, 'nightly')
+    assert.equal(updated.enabled, false)
+    assert.equal(updated.nextRun, null, 'disabled -> nextRun null')
+    assert.equal(store.update('missing', { name: 'x' }), null)
+  })
+
+  it('update() can set a lastRun stub (engine #6865 territory) and advances nextRun', () => {
+    let clock = 0
+    const store = newStore(() => clock)
+    const t = store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: HOUR } })
+    clock = HOUR + 5
+    const updated = store.update(t.id, { lastRun: { at: HOUR, status: 'success', sessionId: 'sess-9' } })
+    assert.deepEqual(updated.lastRun, { at: HOUR, status: 'success', sessionId: 'sess-9' })
+    assert.equal(updated.nextRun, 2 * HOUR, 'nextRun advanced to the next boundary after now')
+    assert.throws(() => store.update(t.id, { lastRun: { at: 1, status: 'bogus' } }), ScheduledTaskValidationError)
+  })
+
+  it('remove() deletes and persists; returns false for an unknown id', () => {
+    const store = newStore()
+    const t = store.add({ prompt: 'p', cadence: { kind: 'once', at: 9999 } })
+    assert.equal(store.remove(t.id), true)
+    assert.equal(store.get(t.id), null)
+    assert.equal(store.remove(t.id), false)
+  })
+
+  it('survives a simulated restart: a NEW store reads persisted tasks', () => {
+    const store1 = newStore(() => 1000)
+    const a = store1.add({ prompt: 'a', cadence: { kind: 'cron', expression: '0 9 * * *' } })
+    const b = store1.add({ prompt: 'b', cadence: { kind: 'interval', everyMs: HOUR } })
+
+    const store2 = new ScheduledTaskStore({ filePath, logger: silentLog }).load()
+    const ids = store2.list().map((t) => t.id).sort()
+    assert.deepEqual(ids, [a.id, b.id].sort())
+    assert.equal(store2.get(a.id).prompt, 'a')
+    assert.equal(store2.get(a.id).cadence.expression, '0 9 * * *')
+    assert.ok(Number.isFinite(store2.get(a.id).nextRun), 'cron nextRun recomputed on load')
+  })
+
+  it('load() recomputes nextRun rather than trusting a stale stored value', () => {
+    // Hand-write a file whose stored nextRun is deliberately wrong.
+    const bogus = {
+      version: 1,
+      tasks: [{
+        id: 'fixed', name: null, enabled: true, prompt: 'p',
+        target: {}, cadence: { kind: 'interval', everyMs: HOUR, anchor: 0 },
+        nextRun: 999999999, lastRun: null, createdAt: 0, updatedAt: 0,
+      }],
+    }
+    writeFileSync(filePath, JSON.stringify(bogus))
+    const store = new ScheduledTaskStore({ filePath, logger: silentLog, now: () => 10 }).load()
+    assert.equal(store.get('fixed').nextRun, HOUR, 'nextRun recomputed from cadence, not the stored 999999999')
+  })
+
+  it('writes atomically (temp+rename) with 0600 perms and no leftover temp', () => {
+    const store = newStore()
+    store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 } })
+    const mode = statSync(filePath).mode & 0o777
+    // Windows does not honour POSIX mode bits; assert only on POSIX.
+    if (process.platform !== 'win32') assert.equal(mode, 0o600, 'file is owner-only')
+    const leftovers = readdirSync(dir).filter((f) => f.includes('.tmp'))
+    assert.deepEqual(leftovers, [], 'no orphaned temp file')
+  })
+
+  it('missing file loads as an empty store', () => {
+    const store = new ScheduledTaskStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('corrupt JSON fails open to empty (does not throw)', () => {
+    writeFileSync(filePath, '{ this is not json')
+    const store = new ScheduledTaskStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('an unknown version is skipped whole (fail-open)', () => {
+    writeFileSync(filePath, JSON.stringify({
+      version: 999,
+      tasks: [{ id: 'x', prompt: 'p', cadence: { kind: 'once', at: 1 }, createdAt: 0, updatedAt: 0 }],
+    }))
+    const store = new ScheduledTaskStore({ filePath, logger: silentLog }).load()
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('drops individual malformed entries but keeps valid siblings', () => {
+    writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      tasks: [
+        { id: 'good', prompt: 'p', cadence: { kind: 'once', at: 1 }, createdAt: 0, updatedAt: 0 },
+        { id: 'no-prompt', cadence: { kind: 'once', at: 1 }, createdAt: 0, updatedAt: 0 },
+        { id: 'bad-cadence', prompt: 'p', cadence: { kind: 'cron', expression: 'garbage' }, createdAt: 0, updatedAt: 0 },
+        { prompt: 'p', cadence: { kind: 'once', at: 1 } }, // no id
+        { id: 'good', prompt: 'dup', cadence: { kind: 'once', at: 2 }, createdAt: 0, updatedAt: 0 }, // duplicate id
+      ],
+    }))
+    const store = new ScheduledTaskStore({ filePath, logger: silentLog }).load()
+    const ids = store.list().map((t) => t.id)
+    assert.deepEqual(ids, ['good'], 'only the first valid task survives')
+    assert.equal(store.get('good').prompt, 'p', 'the duplicate did not overwrite')
+  })
+
+  it('load() replaces in-memory state (no stale re-persist)', () => {
+    const store = newStore()
+    store.add({ prompt: 'p', cadence: { kind: 'once', at: 1 } })
+    assert.equal(store.list().length, 1)
+    // Blow the file away, reload — the in-memory task must not survive.
+    rmSync(filePath)
+    store.load()
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('a caller-supplied id is honoured and collisions are rejected', () => {
+    const store = newStore()
+    const t = store.add({ id: 'my-id', prompt: 'p', cadence: { kind: 'once', at: 1 } })
+    assert.equal(t.id, 'my-id')
+    assert.throws(() => store.add({ id: 'my-id', prompt: 'q', cadence: { kind: 'once', at: 2 } }), ScheduledTaskValidationError)
+  })
+})

--- a/packages/server/tests/session-manager-scheduled-task-store.test.js
+++ b/packages/server/tests/session-manager-scheduled-task-store.test.js
@@ -1,0 +1,52 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { SessionManager } from '../src/session-manager.js'
+import { ScheduledTaskStore } from '../src/scheduled-task-store.js'
+
+/**
+ * #6862 — SessionManager wires + LOADS a default ScheduledTaskStore on daemon
+ * start, whose file sits next to the session-state file (so a temp stateFilePath
+ * keeps it out of the real ~/.chroxy). A caller may inject its own store. This
+ * only asserts the store is constructed + loaded on boot; nothing fires it.
+ *
+ * Per the #4633 rule every SessionManager here is given a temp stateFilePath.
+ */
+describe('#6862 SessionManager scheduled-task store wiring', () => {
+  let sm
+  let dir
+
+  afterEach(() => {
+    try { sm?.destroy?.() } catch { /* ignore */ }
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('constructs a default ScheduledTaskStore next to the state file and loads it', () => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sm-sched-'))
+    // Pre-seed the on-disk registry so load-on-start is observable.
+    writeFileSync(join(dir, 'scheduled-tasks.json'), JSON.stringify({
+      version: 1,
+      tasks: [{
+        id: 'seeded', name: 'Nightly', enabled: true, prompt: 'do the thing',
+        target: {}, cadence: { kind: 'cron', expression: '0 9 * * *' },
+        nextRun: null, lastRun: null, createdAt: 0, updatedAt: 0,
+      }],
+    }))
+    sm = new SessionManager({ stateFilePath: join(dir, 'state.json') })
+    assert.ok(sm.scheduledTaskStore instanceof ScheduledTaskStore, 'default store constructed')
+    const seeded = sm.scheduledTaskStore.get('seeded')
+    assert.ok(seeded, 'pre-seeded task loaded on daemon start')
+    assert.equal(seeded.prompt, 'do the thing')
+    assert.ok(Number.isFinite(seeded.nextRun), 'cron nextRun computed on load')
+  })
+
+  it('accepts an injected store instead of the default', () => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sm-sched-'))
+    const injected = new ScheduledTaskStore({ filePath: join(dir, 'custom.json') })
+    sm = new SessionManager({ stateFilePath: join(dir, 'state.json'), scheduledTaskStore: injected })
+    assert.equal(sm.scheduledTaskStore, injected, 'injected store used verbatim')
+  })
+})


### PR DESCRIPTION
## What

Foundation slice of the scheduled-tasks epic (#6784): the **scheduled-task data model** and a **persistence layer separate from live session state**. No firing engine (#6865), no CLI (#6868), no dashboard UI (#6871) — this PR just persists tasks and computes their schedule.

## Changes

**`packages/server/src/scheduled-task-store.js`** — durable per-id registry persisted to `~/.chroxy/scheduled-tasks.json` (a sibling of `session-state.json`, alongside `permission-rules.json`). Follows `permission-rule-store.js` exactly:
- Atomic temp+rename writes at mode `0600` (via `writeFileRestricted`)
- Version-gated; a corrupt / unknown-version file **fails open to empty**
- Individual malformed entries are dropped on load (logged) while valid siblings load
- CRUD: `add` / `get` / `list` / `update` / `remove`, keyed by task id
- Strict validation (throws `ScheduledTaskValidationError`) on programmatic input; lenient drop on disk corruption
- `nextRun` is recomputed on load so a stale stored value can't drift from the cadence

**Model:** `id`, `name`, `enabled` (paused = `!enabled`), `prompt`, `target` session config (`provider` / `model` / `cwd` / `permissionMode`), `cadence` (one-time `once` vs recurring `interval` / `cron`), computed `nextRun`, `lastRun` result stub (engine fills), `createdAt` / `updatedAt`.

**`packages/server/src/schedule-parser.js`** — dependency-free next-run computation (**no new npm dep**):
- Hand-rolled **5-field crontab** parser: `*`, values, `a-b` ranges, star/range steps, comma lists, 3-letter month/weekday names, Vixie day-of-month/day-of-week **OR-semantics**
- Interval math (phase-anchored, no drift) + one-time cadence
- Cron next-run: **local-time** forward search with a bounded horizon (leap-day safe; returns `null` for impossible expressions like Feb 30)
- **Computes only — never fires**

**`packages/server/src/session-manager.js`** — loads a default `ScheduledTaskStore` on daemon start next to the state file (a caller may inject its own); the engine (#6865) reads it off `sessionManager.scheduledTaskStore`.

## Decisions

- **cron *and* interval (and once):** the model explicitly supports recurring cron expressions per the issue, plus interval and one-time. The 5-field cron parser is well-bounded and thoroughly unit-tested, so it was safe to hand-roll here rather than deferring cron to the engine slice.
- **Server-internal model, no protocol wire type yet.** The store-core type-coverage lint scans every `type: z.literal(...)` in `packages/protocol/src/schemas/server/**` and requires both-client handlers. Adding a wire type now would trip it before any client can handle it — that churn belongs with the dashboard CRUD slice (**#6871**). The sibling *server* slices (#6865 / #6868) import the store directly, so a shared cross-package type isn't needed until the UI lands.
- **Distinct from `ScheduleWakeup`** (intra-session, single-shot, transcript-derived `{delaySeconds, reason, prompt}`) — left entirely unchanged.

## Tests (TDD)

- `schedule-parser.test.js` — cron parse (ranges/steps/lists/names/validation), cron next-run (daily/monthly/weekday/OR-semantics/leap-day/impossible), interval math, task-level dispatch (once/interval/cron/disabled)
- `scheduled-task-store.test.js` — CRUD round-trip, restart survival (fresh store reads file), atomic write + `0600` + no leftover temp, version gate, corrupt-json fail-open, per-entry drop, load-replaces-in-memory, nextRun recompute on load
- `session-manager-scheduled-task-store.test.js` — default store constructed + **loaded on daemon start**; injected store honoured

40 new tests, all green; all five custom server lints pass; existing SessionManager tests unaffected. Temp state paths throughout (sandbox-guard clean); suites self-tear-down and exit cleanly with no force-exit.

Closes #6862

Closes #6879
