### PR TITLE
feat(server,dashboard,app): # quick-append to CLAUDE.md from the composer (#6861)

### DIFF
--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -61,7 +61,7 @@ import { useDictationComposer } from '../hooks/useDictationComposer';
 import { useAndroidSessionNotification } from '../hooks/useAndroidSessionNotification';
 import { pickFromCamera, pickFromGallery, pickDocument, toWireAttachments, MAX_ATTACHMENTS } from '../utils/attachments';
 import type { Attachment } from '../utils/attachments';
-import { formatPasteMarker, expandPasteMarkers } from '@chroxy/store-core';
+import { formatPasteMarker, expandPasteMarkers, parseMemoryAppend } from '@chroxy/store-core';
 import { PastedTextModal } from '../components/PastedTextModal';
 import { disconnectWithQueueGuard } from '../store/disconnectWithQueueGuard';
 
@@ -786,6 +786,19 @@ export function SessionScreen() {
           return;
         }
         launchWebTask(webPrompt, sessionCwd || undefined);
+        return;
+      }
+    }
+
+    // #6861 — `#`-prefix quick-append. A leading `# ` (hash + space) routes the
+    // note to the project CLAUDE.md instead of sending a chat turn. Disabled for
+    // terminal sessions (`#` is a shell comment there) and when attachments are
+    // pending (they can't go to memory). The confirmation lands via the
+    // `append_memory_result` ack.
+    if (text && !hasTerminal && !hasAttachments) {
+      const memory = parseMemoryAppend(text);
+      if (memory.isMemory) {
+        useConnectionStore.getState().appendMemory(memory.note);
         return;
       }
     }

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -798,7 +798,19 @@ export function SessionScreen() {
     if (text && !hasTerminal && !hasAttachments) {
       const memory = parseMemoryAppend(text);
       if (memory.isMemory) {
-        useConnectionStore.getState().appendMemory(memory.note);
+        const sent = useConnectionStore.getState().appendMemory(memory.note);
+        if (sent === false) {
+          // #6308/#6309 — disconnected: appendMemory is NOT offline-queued, so
+          // restore the draft (the input was cleared above) and surface a notice
+          // rather than silently losing the note.
+          inputRef.current?.setValue(text);
+          useConnectionStore.getState().addMessage({
+            id: `memory-fail-${Date.now()}`,
+            type: 'system',
+            content: 'Not connected — memory note not saved. Try again once reconnected.',
+            timestamp: Date.now(),
+          });
+        }
         return;
       }
     }

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1827,6 +1827,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return result;
   },
 
+  // #6861 — `#`-prefix composer quick-append. The server owns the target (the
+  // session cwd's project CLAUDE.md), so we send only the note text. Like a
+  // file mutation this is NOT offline-queued; the confirmation lands via the
+  // `append_memory_result` ack (handled in message-handler.ts).
+  appendMemory: (note) => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const payload: Record<string, unknown> = { type: 'append_memory', text: note };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    return wsSend(socket, payload) ? 'sent' : false;
+  },
+
   sendInterrupt: () => {
     const { socket, activeSessionId } = get();
     const payload: Record<string, unknown> = { type: 'interrupt' };

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -136,6 +136,10 @@ import {
   // through this table; a miss falls through to the switch below unchanged.
   createDispatchTable,
   runDispatch,
+  // #6861 — `#`-prefix quick-append ack: shared parser + confirmation formatter
+  // (byte-identical wording with the dashboard).
+  handleAppendMemoryResult as sharedAppendMemoryResult,
+  formatMemoryAppendNotice,
 } from '@chroxy/store-core';
 import type {
   DeltaFlusher,
@@ -3250,6 +3254,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }));
       } else {
         get().addMessage(statusMsg);
+      }
+      break;
+    }
+
+    // #6861 — `#`-prefix quick-append ack. Append a system confirmation (or the
+    // error) to the active session transcript, naming the file it landed in.
+    // Byte-identical wording with the dashboard via formatMemoryAppendNotice.
+    case 'append_memory_result': {
+      const noticeMsg: ChatMessage = {
+        id: nextMessageId('memory'),
+        type: 'system',
+        content: formatMemoryAppendNotice(sharedAppendMemoryResult(msg)),
+        timestamp: Date.now(),
+      };
+      const activeMemId = get().activeSessionId;
+      if (activeMemId && get().sessionStates[activeMemId]) {
+        updateActiveSession((ss) => ({ messages: [...ss.messages, noticeMsg] }));
+      } else {
+        get().addMessage(noticeMsg);
       }
       break;
     }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -516,6 +516,10 @@ export interface MessageInputActions {
   // badge) instead of starting a fresh turn.
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   sendInput: (input: string, wireAttachments?: BinaryAttachment[], options?: { isVoice?: boolean; clientMessageId?: string }) => 'sent' | 'queued' | false;
+  // #6861 — `#`-prefix composer quick-append: send the note to the server, which
+  // appends it to the session cwd's project CLAUDE.md and acks with
+  // `append_memory_result`. Not offline-queued; returns false when disconnected.
+  appendMemory: (note: string) => 'sent' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
   // #5938 (#5943) — cancel one queued follow-up by its clientMessageId before
   // it flushes. Returns false (refused) while disconnected; never offline-queued.

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -762,6 +762,61 @@ describe('App', () => {
     })
   })
 
+  // #6861 / PR #6878 (Copilot review thread) — the `#`-prefix quick-append must
+  // be SKIPPED for PTY-backed sessions (claude-tui / user-shell): the composer
+  // routes to the terminal there, where a leading `#` is a shell comment, not a
+  // memory command. Mirrors the mobile SessionScreen `!hasTerminal` guard so a
+  // `# note` in a shell/TUI session goes to the terminal instead of silently
+  // being eaten as a CLAUDE.md append.
+  describe('# quick-append terminal/PTY guard (#6861)', () => {
+    const baseSession = {
+      sessionId: 's1',
+      name: 'Test',
+      cwd: '/tmp',
+      hasTerminal: true,
+      model: null,
+      permissionMode: null,
+      isBusy: false,
+      createdAt: Date.now(),
+      conversationId: null,
+    }
+
+    function sendHash(provider: string) {
+      const appendMemory = vi.fn()
+      const sendInput = vi.fn()
+      stateOverrides = {
+        connectionPhase: 'connected',
+        sessions: [{ ...baseSession, type: 'cli', provider }],
+        activeSessionId: 's1',
+        appendMemory,
+        sendInput,
+      }
+      render(<App />)
+      const textarea = screen.getByRole('textbox', { name: /message input/i })
+      fireEvent.change(textarea, { target: { value: '# remember the port is 9876' } })
+      fireEvent.keyDown(textarea, { key: 'Enter' })
+      return { appendMemory, sendInput }
+    }
+
+    it('does NOT intercept for a user-shell (PTY) session — routes to the terminal', () => {
+      const { appendMemory, sendInput } = sendHash('user-shell')
+      expect(appendMemory).not.toHaveBeenCalled()
+      expect(sendInput).toHaveBeenCalled()
+    })
+
+    it('does NOT intercept for a claude-tui (PTY) session — routes to the terminal', () => {
+      const { appendMemory, sendInput } = sendHash('claude-tui')
+      expect(appendMemory).not.toHaveBeenCalled()
+      expect(sendInput).toHaveBeenCalled()
+    })
+
+    it('DOES intercept for a non-PTY chat session (claude-sdk) — appends to memory', () => {
+      const { appendMemory, sendInput } = sendHash('claude-sdk')
+      expect(appendMemory).toHaveBeenCalledWith('remember the port is 9876')
+      expect(sendInput).not.toHaveBeenCalled()
+    })
+  })
+
   describe('System events tab', () => {
     const connectedState = {
       connectionPhase: 'connected' as const,

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -11,6 +11,7 @@ import {
   formatPasteMarker,
   formatTokensCompact,
   expandPasteMarkers,
+  parseMemoryAppend,
   resolveContextWindow,
   contextOccupancyTokens,
   contextFillPercent,
@@ -509,6 +510,7 @@ export function App() {
   const connect = useConnectionStore(s => s.connect)
   const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
+  const appendMemory = useConnectionStore(s => s.appendMemory)
   const addInfoNotification = useConnectionStore(s => s.addInfoNotification)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
   const sendCancelQueued = useConnectionStore(s => s.sendCancelQueued)
@@ -1611,6 +1613,22 @@ export function App() {
   // Handlers
   const handleSend = useCallback((text: string, files?: FileAttachment[]) => {
     const allFiles = files || fileAttachments
+    // #6861 — `#`-prefix quick-append. A leading `# ` (hash + space) routes the
+    // note to the project CLAUDE.md instead of sending a chat turn. Skipped when
+    // attachments are pending (they can't go to memory). The confirmation lands
+    // via the `append_memory_result` ack.
+    if (allFiles.length === 0 && imageAttachments.length === 0) {
+      const memory = parseMemoryAppend(text)
+      if (memory.isMemory) {
+        appendMemory(memory.note)
+        const memSid = activeSessionId
+        if (memSid) evictSessionComposerState(memSid)
+        setInputDraftValue('')
+        setPastedTextBlocks([])
+        setInspectedPastedTextId(null)
+        return
+      }
+    }
     const wire = toWireAttachments(
       allFiles.length > 0 ? allFiles : undefined,
       imageAttachments.length > 0 ? imageAttachments : undefined,
@@ -1657,7 +1675,7 @@ export function App() {
     setInputDraftValue('')
     setPastedTextBlocks([])
     setInspectedPastedTextId(null)
-  }, [sendInput, addInfoNotification, fileAttachments, imageAttachments, activeSessionId])
+  }, [sendInput, appendMemory, addInfoNotification, fileAttachments, imageAttachments, activeSessionId])
 
   const handleInterrupt = useCallback(() => {
     sendInterrupt()

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1620,7 +1620,14 @@ export function App() {
     if (allFiles.length === 0 && imageAttachments.length === 0) {
       const memory = parseMemoryAppend(text)
       if (memory.isMemory) {
-        appendMemory(memory.note)
+        const sent = appendMemory(memory.note)
+        if (sent === false) {
+          // #6308/#6309 — disconnected: appendMemory is NOT offline-queued, so
+          // KEEP the draft (don't clear) and surface a notice rather than
+          // silently losing the note.
+          addInfoNotification('Not connected — memory note not saved. Try again once reconnected.')
+          return
+        }
         const memSid = activeSessionId
         if (memSid) evictSessionComposerState(memSid)
         setInputDraftValue('')

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1615,9 +1615,12 @@ export function App() {
     const allFiles = files || fileAttachments
     // #6861 — `#`-prefix quick-append. A leading `# ` (hash + space) routes the
     // note to the project CLAUDE.md instead of sending a chat turn. Skipped when
-    // attachments are pending (they can't go to memory). The confirmation lands
-    // via the `append_memory_result` ack.
-    if (allFiles.length === 0 && imageAttachments.length === 0) {
+    // attachments are pending (they can't go to memory) and for PTY-backed
+    // sessions (claude-tui / user-shell) where the composer writes to the
+    // terminal and a leading `#` is a shell comment, not a memory command —
+    // mirrors the mobile SessionScreen `!hasTerminal` guard. The confirmation
+    // lands via the `append_memory_result` ack.
+    if (!isPtyProvider && allFiles.length === 0 && imageAttachments.length === 0) {
       const memory = parseMemoryAppend(text)
       if (memory.isMemory) {
         const sent = appendMemory(memory.note)
@@ -1682,7 +1685,7 @@ export function App() {
     setInputDraftValue('')
     setPastedTextBlocks([])
     setInspectedPastedTextId(null)
-  }, [sendInput, appendMemory, addInfoNotification, fileAttachments, imageAttachments, activeSessionId])
+  }, [sendInput, appendMemory, addInfoNotification, fileAttachments, imageAttachments, activeSessionId, isPtyProvider])
 
   const handleInterrupt = useCallback(() => {
     sendInterrupt()

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2988,6 +2988,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
+  // #6861 — `#`-prefix composer quick-append. The server owns the target (the
+  // session cwd's project CLAUDE.md), so we send only the note text. Like a file
+  // mutation this is NOT offline-queued; the confirmation lands via the
+  // `append_memory_result` ack (handled in message-handler.ts).
+  appendMemory: (note: string) => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
+    const payload: Record<string, unknown> = { type: 'append_memory', text: note };
+    if (activeSessionId) payload.sessionId = activeSessionId;
+    return wsSend(socket, payload) ? 'sent' : false;
+  },
+
   sendInput: (input, wireAttachments, options) => {
     const { socket, activeSessionId } = get();
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -138,6 +138,10 @@ import {
   // thin wrappers over these (never reimplement the merge/seq logic here).
   upsertRunSummary,
   applyRunDelta,
+  // #6861 — `#`-prefix quick-append ack: shared parser + confirmation formatter
+  // (byte-identical wording with the mobile app).
+  handleAppendMemoryResult as sharedAppendMemoryResult,
+  formatMemoryAppendNotice,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
 import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema } from '@chroxy/protocol/schemas'
@@ -1875,6 +1879,24 @@ function handleClaudeReady(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
   }
 }
 
+// #6861 — `#`-prefix quick-append ack. Append a system confirmation (or the
+// error) to the active session transcript, naming the file it landed in.
+// Byte-identical wording with the mobile app via formatMemoryAppendNotice.
+function handleAppendMemoryResult(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet, _ctx: ConnectionContext): void {
+  const noticeMsg: ChatMessage = {
+    id: nextMessageId('memory'),
+    type: 'system',
+    content: formatMemoryAppendNotice(sharedAppendMemoryResult(msg)),
+    timestamp: Date.now(),
+  };
+  const activeId = get().activeSessionId;
+  if (activeId && get().sessionStates[activeId]) {
+    updateSession(activeId, (ss) => ({ messages: [...ss.messages, noticeMsg] }));
+  } else {
+    get().addMessage(noticeMsg);
+  }
+}
+
 // agent_idle — migrated to the shared dispatch table (#5618; runDispatch handles
 // it before this HANDLERS map). The seeded-session path is the shared
 // dispatchAgentIdle; the dashboard's no-session FLAT fallback (its UI reads flat
@@ -3490,6 +3512,8 @@ const HANDLERS: Record<string, Handler> = {
   stream_start: handleStreamStart,
   stream_delta: handleStreamDelta,
   stream_end: handleStreamEnd,
+  // #6861 — `#`-prefix composer quick-append ack.
+  append_memory_result: handleAppendMemoryResult,
   tool_start: handleToolStart,
   tool_input_delta: handleToolInputDelta,
   tool_result: handleToolResult,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1454,6 +1454,10 @@ export interface ConnectionState {
   // #6453 — canonical WIRE attachment type (was an inline loose shape with a
   // `[key: string]: string` index); the dashboard sends both file_ref + image.
   sendInput: (input: string, wireAttachments?: Attachment[], options?: { isVoice?: boolean; previewAttachments?: MessageAttachment[] }) => 'sent' | 'queued' | false;
+  // #6861 — `#`-prefix composer quick-append: send the note to the server, which
+  // appends it to the session cwd's project CLAUDE.md and acks with
+  // `append_memory_result`. Not offline-queued; returns false when disconnected.
+  appendMemory: (note: string) => 'sent' | false;
   /**
    * Interrupt the current turn. Defaults to the active session; pass an explicit
    * `sessionId` to interrupt a specific session (e.g. the Control Room

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -490,6 +490,11 @@ export declare const WriteFileSchema: z.ZodObject<{
     path: z.ZodString;
     content: z.ZodString;
 }, z.core.$loose>;
+export declare const AppendMemorySchema: z.ZodObject<{
+    type: z.ZodLiteral<"append_memory">;
+    text: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ListFilesSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_files">;
     query: z.ZodOptional<z.ZodString>;
@@ -1156,6 +1161,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"write_file">;
     path: z.ZodString;
     content: z.ZodString;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"append_memory">;
+    text: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_files">;
     query: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -663,6 +663,16 @@ export const WriteFileSchema = z.object({
     path: z.string().max(4096),
     content: z.string().max(10_000_000),
 }).passthrough();
+// #6861 (epic #6760): `#`-prefix composer quick-append. The client sends only
+// the note text — the TARGET is chosen SERVER-side (the session cwd's project
+// `CLAUDE.md`), never a client-supplied path, so the write is path-confined by
+// construction (defence-in-depth on top of validatePathWithinCwd). Gated behind
+// the same rejectMutationIfBound (#6541) gate as the other file mutations.
+export const AppendMemorySchema = z.object({
+    type: z.literal('append_memory'),
+    text: z.string().min(1).max(10_000),
+    sessionId: z.string().max(256).optional(),
+}).passthrough();
 export const ListFilesSchema = z.object({
     type: z.literal('list_files'),
     query: z.string().max(1000).optional(),
@@ -1410,6 +1420,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     BrowseFilesSchema,
     ReadFileSchema,
     WriteFileSchema,
+    AppendMemorySchema,
     ListFilesSchema,
     ListSymbolsSchema,
     ResolveSymbolSchema,

--- a/packages/protocol/dist/schemas/server/file-ops.d.ts
+++ b/packages/protocol/dist/schemas/server/file-ops.d.ts
@@ -99,3 +99,9 @@ export declare const ServerWriteFileResultSchema: z.ZodObject<{
     path: z.ZodNullable<z.ZodString>;
     error: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
+export declare const ServerAppendMemoryResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"append_memory_result">;
+    path: z.ZodNullable<z.ZodString>;
+    created: z.ZodBoolean;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -99,3 +99,14 @@ export const ServerWriteFileResultSchema = z.object({
     path: z.string().nullable(),
     error: z.string().nullable(),
 });
+// #6861 (epic #6760): ack for the `#`-prefix composer quick-append. `path` is
+// the absolute project `CLAUDE.md` the note landed in (null on error); `created`
+// distinguishes "created the file" from "appended to an existing one" so the
+// confirmation can name the outcome. Handled by BOTH clients — each appends a
+// system confirmation (or the error) to the active session transcript.
+export const ServerAppendMemoryResultSchema = z.object({
+    type: z.literal('append_memory_result'),
+    path: z.string().nullable(),
+    created: z.boolean(),
+    error: z.string().nullable(),
+});

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -740,6 +740,17 @@ export const WriteFileSchema = z.object({
   content: z.string().max(10_000_000),
 }).passthrough()
 
+// #6861 (epic #6760): `#`-prefix composer quick-append. The client sends only
+// the note text — the TARGET is chosen SERVER-side (the session cwd's project
+// `CLAUDE.md`), never a client-supplied path, so the write is path-confined by
+// construction (defence-in-depth on top of validatePathWithinCwd). Gated behind
+// the same rejectMutationIfBound (#6541) gate as the other file mutations.
+export const AppendMemorySchema = z.object({
+  type: z.literal('append_memory'),
+  text: z.string().min(1).max(10_000),
+  sessionId: z.string().max(256).optional(),
+}).passthrough()
+
 export const ListFilesSchema = z.object({
   type: z.literal('list_files'),
   query: z.string().max(1000).optional(),
@@ -1582,6 +1593,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   BrowseFilesSchema,
   ReadFileSchema,
   WriteFileSchema,
+  AppendMemorySchema,
   ListFilesSchema,
   ListSymbolsSchema,
   ResolveSymbolSchema,

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -106,3 +106,15 @@ export const ServerWriteFileResultSchema = z.object({
   path: z.string().nullable(),
   error: z.string().nullable(),
 })
+
+// #6861 (epic #6760): ack for the `#`-prefix composer quick-append. `path` is
+// the absolute project `CLAUDE.md` the note landed in (null on error); `created`
+// distinguishes "created the file" from "appended to an existing one" so the
+// confirmation can name the outcome. Handled by BOTH clients — each appends a
+// system confirmation (or the error) to the active session transcript.
+export const ServerAppendMemoryResultSchema = z.object({
+  type: z.literal('append_memory_result'),
+  path: z.string().nullable(),
+  created: z.boolean(),
+  error: z.string().nullable(),
+})

--- a/packages/server/src/handlers/file-handlers.js
+++ b/packages/server/src/handlers/file-handlers.js
@@ -79,6 +79,14 @@ function handleWriteFile(ws, client, msg, ctx) {
   ctx.services.fileOps.writeFile(ws, msg.path, msg.content, entry?.cwd || null)
 }
 
+function handleAppendMemory(ws, client, msg, ctx) {
+  // #6861 — `#`-prefix composer quick-append. Same mutation gate as write_file:
+  // a bound (share-a-session) token cannot append to the host's CLAUDE.md.
+  if (rejectMutationIfBound(ws, client, msg, ctx, 'append_memory')) return
+  const entry = resolveSession(ctx, msg, client)
+  ctx.services.fileOps.appendMemory(ws, msg.text, entry?.cwd || null)
+}
+
 function handleGetDiff(ws, client, msg, ctx) {
   const entry = resolveSession(ctx, msg, client)
   ctx.services.fileOps.getDiff(ws, msg.base, entry?.cwd || null)
@@ -142,6 +150,7 @@ export const fileHandlers = {
   list_files: handleListFiles,
   read_file: handleReadFile,
   write_file: handleWriteFile,
+  append_memory: handleAppendMemory,
   get_diff: handleGetDiff,
   git_status: handleGitStatus,
   git_branches: handleGitBranches,

--- a/packages/server/src/ws-file-ops/index.js
+++ b/packages/server/src/ws-file-ops/index.js
@@ -35,6 +35,7 @@ export function createFileOps(sendFn, workspaceRoot) {
     browseFiles: browser.browseFiles,
     readFile: reader.readFile,
     writeFile: reader.writeFile,
+    appendMemory: reader.appendMemory,
     getDiff: reader.getDiff,
     listSlashCommands: browser.listSlashCommands,
     listAgents: browser.listAgents,

--- a/packages/server/src/ws-file-ops/reader.js
+++ b/packages/server/src/ws-file-ops/reader.js
@@ -410,6 +410,13 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
    * validatePathWithinCwd is still run for symlink-escape defence (a CLAUDE.md
    * symlinked out of the workspace is rejected), and the open uses O_NOFOLLOW to
    * close the post-validation TOCTOU window, matching writeFileContent above.
+   *
+   * The write uses O_APPEND (+ O_CREAT): each append lands atomically at EOF, so
+   * concurrent appends can't lose a line and a crash can't truncate the file —
+   * the correct primitive for appending, unlike a read-modify-write O_TRUNC. The
+   * only read is a cheap 1-byte tail check to decide whether a separating newline
+   * is needed; a race there is benign (a stray/missing separator at worst — the
+   * note line itself is always written atomically and in full).
    */
   async function appendMemory(ws, note, sessionCwd) {
     if (!sessionCwd) {
@@ -457,24 +464,39 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       }
       absPath = fileExists ? resolvedTarget : target
 
-      // Read-modify-write the whole file: append the note on its own line,
-      // inserting a separating newline when the file doesn't already end with one.
-      let newContent
+      // Cheap tail check: does the existing file already end with a newline? If
+      // not, prepend one so the note lands on its own line. Best-effort (a race
+      // only affects the separator, never the note itself).
+      let needsLeadingNewline = false
       if (fileExists) {
-        const existing = await readFile(absPath, 'utf-8')
-        const sep = existing.length > 0 && !existing.endsWith('\n') ? '\n' : ''
-        newContent = existing + sep + line + '\n'
-      } else {
-        newContent = line + '\n'
+        try {
+          const st = await stat(absPath)
+          if (st.size > 0) {
+            let rfh
+            try {
+              rfh = await open(absPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+              const tail = Buffer.alloc(1)
+              await rfh.read(tail, 0, 1, st.size - 1)
+              needsLeadingNewline = tail[0] !== 0x0a
+            } finally {
+              await rfh?.close()
+            }
+          }
+        } catch {
+          // Tail read is advisory only — fall back to no separator.
+        }
       }
 
-      const data = Buffer.from(newContent, 'utf-8')
+      const data = Buffer.from((needsLeadingNewline ? '\n' : '') + line + '\n', 'utf-8')
+
+      // O_APPEND: atomic append at EOF (no lost-update / truncation window).
+      // O_CREAT (WITHOUT O_EXCL) opens-or-creates, so there is no EEXIST race to
+      // retry — a concurrent creator just means we append instead. O_NOFOLLOW
+      // keeps the symlink-escape defence on the final component.
       {
         let fh
         try {
-          const flags = fileExists
-            ? fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW | fsConstants.O_TRUNC
-            : fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW | fsConstants.O_CREAT | fsConstants.O_EXCL
+          const flags = fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW
           fh = await open(absPath, flags, 0o666)
           await fh.writeFile(data)
         } catch (openErr) {

--- a/packages/server/src/ws-file-ops/reader.js
+++ b/packages/server/src/ws-file-ops/reader.js
@@ -401,6 +401,107 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
     }
   }
 
+  /**
+   * Append a single note line to the session cwd's project CLAUDE.md, creating
+   * the file if it doesn't exist (#6861, epic #6760).
+   *
+   * The TARGET is chosen SERVER-side (`<cwd>/CLAUDE.md`) — the client sends only
+   * the note text, never a path — so the write is path-confined BY CONSTRUCTION.
+   * validatePathWithinCwd is still run for symlink-escape defence (a CLAUDE.md
+   * symlinked out of the workspace is rejected), and the open uses O_NOFOLLOW to
+   * close the post-validation TOCTOU window, matching writeFileContent above.
+   */
+  async function appendMemory(ws, note, sessionCwd) {
+    if (!sessionCwd) {
+      sendFn(ws, { type: 'append_memory_result', path: null, created: false, error: 'Memory is not available in this mode' })
+      return
+    }
+    if (typeof note !== 'string' || !note.trim()) {
+      sendFn(ws, { type: 'append_memory_result', path: null, created: false, error: 'No note provided' })
+      return
+    }
+    const MAX_NOTE = 10_000
+    if (note.length > MAX_NOTE) {
+      sendFn(ws, { type: 'append_memory_result', path: null, created: false, error: `Note too long (max ${MAX_NOTE} characters)` })
+      return
+    }
+    // Collapse to a single line — quick-append is a one-line note by definition.
+    const line = note.trim().replace(/\r?\n/g, ' ')
+
+    let absPath = null
+    try {
+      const cwdReal = await resolveSessionCwd(sessionCwd)
+      const target = normalize(resolve(cwdReal, 'CLAUDE.md'))
+
+      // Resolve symlinks: if CLAUDE.md already exists, validate its real path;
+      // if not, validate the lexical target (still inside cwd by construction).
+      let resolvedTarget
+      let fileExists = false
+      try {
+        resolvedTarget = await realpath(target)
+        fileExists = true
+      } catch (err) {
+        if (err.code === 'ENOENT') resolvedTarget = target
+        else throw err
+      }
+
+      const { valid } = await validatePathWithinCwd(fileExists ? resolvedTarget : target, sessionCwd)
+      if (!valid) {
+        sendFn(ws, {
+          type: 'append_memory_result',
+          path: null,
+          created: false,
+          error: 'Access denied: memory is restricted to the project directory',
+        })
+        return
+      }
+      absPath = fileExists ? resolvedTarget : target
+
+      // Read-modify-write the whole file: append the note on its own line,
+      // inserting a separating newline when the file doesn't already end with one.
+      let newContent
+      if (fileExists) {
+        const existing = await readFile(absPath, 'utf-8')
+        const sep = existing.length > 0 && !existing.endsWith('\n') ? '\n' : ''
+        newContent = existing + sep + line + '\n'
+      } else {
+        newContent = line + '\n'
+      }
+
+      const data = Buffer.from(newContent, 'utf-8')
+      {
+        let fh
+        try {
+          const flags = fileExists
+            ? fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW | fsConstants.O_TRUNC
+            : fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW | fsConstants.O_CREAT | fsConstants.O_EXCL
+          fh = await open(absPath, flags, 0o666)
+          await fh.writeFile(data)
+        } catch (openErr) {
+          if (openErr.code === 'ELOOP') {
+            sendFn(ws, {
+              type: 'append_memory_result',
+              path: null,
+              created: false,
+              error: 'Access denied: memory is restricted to the project directory',
+            })
+            return
+          }
+          throw openErr
+        } finally {
+          await fh?.close()
+        }
+      }
+
+      sendFn(ws, { type: 'append_memory_result', path: absPath, created: !fileExists, error: null })
+    } catch (err) {
+      let errorMessage
+      if (err.code === 'EACCES') errorMessage = 'Permission denied'
+      else errorMessage = err.message || 'Unknown error'
+      sendFn(ws, { type: 'append_memory_result', path: absPath, created: false, error: errorMessage })
+    }
+  }
+
   /** Get git diff for uncommitted changes in the session CWD */
   async function getDiff(ws, base, sessionCwd) {
     if (!sessionCwd) {
@@ -590,6 +691,7 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
   return {
     readFile: readFileContent,
     writeFile: writeFileContent,
+    appendMemory,
     getDiff,
   }
 }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -423,6 +423,7 @@ function _isSecureRequest(req) {
  *   { type: 'git_status_result', status, error? }       — git status result
  *   { type: 'git_unstage_result', success, error? }     — git unstage result
  *   { type: 'write_file_result', success, error? }      — write file result
+ *   { type: 'append_memory_result', path, created, error? } — `#`-quick-append ack (#6861)
  *   { type: 'log_entry', level, message, timestamp }    — server log entry for dashboard
  *   { type: 'session_activity', sessionId, isBusy, lastCost } — session busy/idle state change
  *   { type: 'session_context', sessionId, cwd, conversationId?, ... } — session context data

--- a/packages/server/tests/append-memory.test.js
+++ b/packages/server/tests/append-memory.test.js
@@ -1,0 +1,127 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, readFile, writeFile, symlink } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createFileOps } from '../src/ws-file-ops/index.js'
+
+/**
+ * `appendMemory` op (#6861, epic #6760) — the `#`-prefix composer quick-append.
+ * The TARGET is always the session cwd's project CLAUDE.md (never a client path),
+ * so these tests exercise create/append semantics, the null-cwd guard, note-length
+ * cap, and the symlink-escape defence carried over from writeFile.
+ */
+describe('appendMemory handler', () => {
+  let tmpDir
+  let fileOps
+  const responses = []
+  const mockSend = (_ws, msg) => responses.push(msg)
+  const mockWs = {}
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'chroxy-memory-'))
+    fileOps = createFileOps(mockSend)
+  })
+
+  after(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('creates CLAUDE.md with the note when it does not exist yet', async () => {
+    responses.length = 0
+    await fileOps.appendMemory(mockWs, 'first note', tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.equal(responses[0].type, 'append_memory_result')
+    assert.equal(responses[0].error, null)
+    assert.equal(responses[0].created, true)
+    assert.match(responses[0].path, /CLAUDE\.md$/)
+
+    const content = await readFile(join(tmpDir, 'CLAUDE.md'), 'utf-8')
+    assert.equal(content, 'first note\n')
+  })
+
+  it('appends a second note on its own line to the existing file', async () => {
+    responses.length = 0
+    await fileOps.appendMemory(mockWs, 'second note', tmpDir)
+
+    assert.equal(responses[0].error, null)
+    assert.equal(responses[0].created, false)
+    const content = await readFile(join(tmpDir, 'CLAUDE.md'), 'utf-8')
+    assert.equal(content, 'first note\nsecond note\n')
+  })
+
+  it('inserts a separating newline when the existing file does not end with one', async () => {
+    responses.length = 0
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-memory-nonl-'))
+    await writeFile(join(dir, 'CLAUDE.md'), 'no trailing newline', 'utf-8')
+
+    await fileOps.appendMemory(mockWs, 'appended', dir)
+
+    assert.equal(responses[0].error, null)
+    const content = await readFile(join(dir, 'CLAUDE.md'), 'utf-8')
+    assert.equal(content, 'no trailing newline\nappended\n')
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('collapses a multi-line note into a single line', async () => {
+    responses.length = 0
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-memory-ml-'))
+    await fileOps.appendMemory(mockWs, 'line one\nline two', dir)
+
+    assert.equal(responses[0].error, null)
+    const content = await readFile(join(dir, 'CLAUDE.md'), 'utf-8')
+    assert.equal(content, 'line one line two\n')
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('returns an error when there is no session cwd', async () => {
+    responses.length = 0
+    await fileOps.appendMemory(mockWs, 'note', null)
+
+    assert.equal(responses.length, 1)
+    assert.equal(responses[0].type, 'append_memory_result')
+    assert.ok(responses[0].error)
+    assert.equal(responses[0].created, false)
+  })
+
+  it('rejects an empty / whitespace-only note', async () => {
+    responses.length = 0
+    await fileOps.appendMemory(mockWs, '   ', tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.ok(responses[0].error)
+    assert.match(responses[0].error, /note/i)
+  })
+
+  it('rejects a note over the length cap', async () => {
+    responses.length = 0
+    await fileOps.appendMemory(mockWs, 'x'.repeat(10_001), tmpDir)
+
+    assert.equal(responses.length, 1)
+    assert.ok(responses[0].error)
+    assert.match(responses[0].error, /long|max|characters/i)
+  })
+
+  it('blocks appending through a CLAUDE.md symlink that escapes the workspace', async () => {
+    responses.length = 0
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-memory-outside-'))
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-memory-escape-'))
+    const outsideFile = join(outsideDir, 'target.md')
+    await writeFile(outsideFile, 'original', 'utf-8')
+    await symlink(outsideFile, join(dir, 'CLAUDE.md'))
+
+    await fileOps.appendMemory(mockWs, 'pwned', dir)
+
+    assert.equal(responses.length, 1)
+    assert.ok(responses[0].error)
+    assert.match(responses[0].error, /denied|restricted/i)
+
+    // The escape target must be untouched.
+    const targetContent = await readFile(outsideFile, 'utf-8')
+    assert.equal(targetContent, 'original')
+
+    await rm(outsideDir, { recursive: true, force: true })
+    await rm(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/server/tests/append-memory.test.js
+++ b/packages/server/tests/append-memory.test.js
@@ -75,6 +75,27 @@ describe('appendMemory handler', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
+  it('does not lose a line under concurrent appends (O_APPEND atomicity)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-memory-concurrent-'))
+    // Seed the file so every append takes the existing-file (append) path.
+    await writeFile(join(dir, 'CLAUDE.md'), 'seed\n', 'utf-8')
+
+    const N = 12
+    await Promise.all(
+      Array.from({ length: N }, (_, i) => fileOps.appendMemory(mockWs, `note-${i}`, dir)),
+    )
+
+    const content = await readFile(join(dir, 'CLAUDE.md'), 'utf-8')
+    const lines = content.split('\n').filter(Boolean)
+    // Every note line must be present exactly once (none clobbered by a race).
+    for (let i = 0; i < N; i++) {
+      const count = lines.filter((l) => l === `note-${i}`).length
+      assert.equal(count, 1, `note-${i} must appear exactly once (got ${count})`)
+    }
+    assert.equal(lines.length, N + 1, 'seed + all notes present, no lost lines')
+    await rm(dir, { recursive: true, force: true })
+  })
+
   it('returns an error when there is no session cwd', async () => {
     responses.length = 0
     await fileOps.appendMemory(mockWs, 'note', null)

--- a/packages/server/tests/handlers/file-handlers.test.js
+++ b/packages/server/tests/handlers/file-handlers.test.js
@@ -10,6 +10,7 @@ function makeFileOps(overrides = {}) {
     listFiles: createSpy(),
     readFile: createSpy(),
     writeFile: createSpy(),
+    appendMemory: createSpy(),
     getDiff: createSpy(),
     gitStatus: createSpy(),
     gitBranches: createSpy(),
@@ -136,6 +137,29 @@ describe('file-handlers', () => {
       assert.equal(callPath, 'README.md')
       assert.equal(callContent, '# Hi')
       assert.equal(callCwd, '/proj')
+    })
+  })
+
+  describe('append_memory (#6861)', () => {
+    it('passes the note text and session cwd to fileOps.appendMemory (no client path)', () => {
+      const sessions = new Map()
+      sessions.set('s1', { session: createMockSession(), name: 'S', cwd: '/proj' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      fileHandlers.append_memory(makeWs(), client, { type: 'append_memory', text: 'remember X' }, ctx)
+
+      assert.equal(ctx.services.fileOps.appendMemory.callCount, 1)
+      const [, callText, callCwd] = ctx.services.fileOps.appendMemory.lastCall
+      assert.equal(callText, 'remember X')
+      assert.equal(callCwd, '/proj')
+    })
+
+    it('passes null cwd when no active session', () => {
+      const ctx = makeCtx()
+      fileHandlers.append_memory(makeWs(), makeClient(), { type: 'append_memory', text: 'x' }, ctx)
+      const [, , callCwd] = ctx.services.fileOps.appendMemory.lastCall
+      assert.equal(callCwd, null)
     })
   })
 
@@ -279,6 +303,7 @@ describe('file-handlers', () => {
   describe('#6541 — bound-token mutation gate', () => {
     const MUTATIONS = [
       ['write_file', 'writeFile', { path: '/repo/x.js', content: 'x' }],
+      ['append_memory', 'appendMemory', { text: 'a note' }],
       ['git_stage', 'gitStage', { files: ['x.js'] }],
       ['git_unstage', 'gitUnstage', { files: ['x.js'] }],
       ['git_commit', 'gitCommit', { message: 'm' }],

--- a/packages/store-core/src/contract-fixtures/fixtures.ts
+++ b/packages/store-core/src/contract-fixtures/fixtures.ts
@@ -2653,4 +2653,36 @@ export const SWITCH_FIXTURES: ContractFixture[] = [
       },
     },
   },
+
+  // append_memory_result (#6861) — the `#`-quick-append ack. Both clients append
+  // an IDENTICAL system confirmation (via the shared formatMemoryAppendNotice) to
+  // the active session transcript, naming the file and whether it was created; an
+  // error surfaces as a system notice, not a silent optimistic "saved".
+  {
+    name: 'append_memory_result appends a "saved" system notice to the active session',
+    type: 'append_memory_result',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'append_memory_result', path: '/repo/CLAUDE.md', created: false, error: null },
+    expect: {
+      sessions: { s1: { messages: [sysMsg('Saved your note to CLAUDE.md.')] } },
+    },
+  },
+  {
+    name: 'append_memory_result names creation when the file did not exist',
+    type: 'append_memory_result',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'append_memory_result', path: '/repo/CLAUDE.md', created: true, error: null },
+    expect: {
+      sessions: { s1: { messages: [sysMsg('Created CLAUDE.md and saved your note.')] } },
+    },
+  },
+  {
+    name: 'append_memory_result surfaces the error as a system notice',
+    type: 'append_memory_result',
+    init: { activeSessionId: 's1', sessions: { s1: {} } },
+    message: { type: 'append_memory_result', path: null, created: false, error: 'denied' },
+    expect: {
+      sessions: { s1: { messages: [sysMsg("Couldn't save to memory: denied")] } },
+    },
+  },
 ]

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -45,6 +45,15 @@ export { buildProviderLimitationNote } from './provider-capabilities'
 export type { DegradableCapabilities } from './provider-capabilities'
 export type { OtherFreeformAnswer } from './freeform-answer'
 
+// #6861 (epic #6760) — `#`-prefix composer quick-append: the shared prefix
+// parser, the ack payload parser, and the confirmation formatter (both clients).
+export {
+  parseMemoryAppend,
+  handleAppendMemoryResult,
+  formatMemoryAppendNotice,
+} from './memory'
+export type { MemoryAppendParse, AppendMemoryResultPayload } from './memory'
+
 // #5555.3 / #5555.4 — lastSeq cursor tracking + no-blank-flash replay reconcile.
 export {
   resetReplayReconcile,

--- a/packages/store-core/src/memory.test.ts
+++ b/packages/store-core/src/memory.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the shared `#`-prefix composer quick-append logic (#6861).
+ *
+ * These pin the interception semantics (a leading `# ` routes to a memory
+ * append, a bare `#` / `#tag` / mid-text `#` does not) and the confirmation
+ * wording that BOTH clients render — the single source of truth so the two
+ * composers can't drift.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  parseMemoryAppend,
+  handleAppendMemoryResult,
+  formatMemoryAppendNotice,
+} from './memory'
+
+describe('parseMemoryAppend (#6861)', () => {
+  it('intercepts a leading `# ` with a non-empty note', () => {
+    expect(parseMemoryAppend('# remember to rebase')).toEqual({
+      isMemory: true,
+      note: 'remember to rebase',
+    })
+  })
+
+  it('trims surrounding whitespace and collapses multiple leading spaces', () => {
+    expect(parseMemoryAppend('#   spaced note  ')).toEqual({
+      isMemory: true,
+      note: 'spaced note',
+    })
+    expect(parseMemoryAppend('#\tuse tabs')).toEqual({
+      isMemory: true,
+      note: 'use tabs',
+    })
+  })
+
+  it('does NOT intercept a bare `#`', () => {
+    expect(parseMemoryAppend('#')).toEqual({ isMemory: false, note: '' })
+  })
+
+  it('does NOT intercept `#tag` (no space after the hash)', () => {
+    expect(parseMemoryAppend('#tag')).toEqual({ isMemory: false, note: '' })
+    expect(parseMemoryAppend('#123')).toEqual({ isMemory: false, note: '' })
+  })
+
+  it('does NOT intercept a `#` mid-text', () => {
+    expect(parseMemoryAppend('see issue #123')).toEqual({ isMemory: false, note: '' })
+    expect(parseMemoryAppend('done # note')).toEqual({ isMemory: false, note: '' })
+  })
+
+  it('does NOT intercept `# ` with an empty note', () => {
+    expect(parseMemoryAppend('#   ')).toEqual({ isMemory: false, note: '' })
+    expect(parseMemoryAppend('# ')).toEqual({ isMemory: false, note: '' })
+  })
+
+  it('does NOT intercept a leading space before the hash', () => {
+    expect(parseMemoryAppend(' # note')).toEqual({ isMemory: false, note: '' })
+  })
+
+  it('is defensive against non-string input', () => {
+    expect(parseMemoryAppend(undefined as unknown as string)).toEqual({ isMemory: false, note: '' })
+    expect(parseMemoryAppend(null as unknown as string)).toEqual({ isMemory: false, note: '' })
+  })
+})
+
+describe('handleAppendMemoryResult (#6861)', () => {
+  it('normalises a success ack', () => {
+    expect(
+      handleAppendMemoryResult({ type: 'append_memory_result', path: '/repo/CLAUDE.md', created: false, error: null }),
+    ).toEqual({ path: '/repo/CLAUDE.md', created: false, error: null })
+  })
+
+  it('normalises a created + error ack, defaulting missing fields', () => {
+    expect(handleAppendMemoryResult({ type: 'append_memory_result', created: true })).toEqual({
+      path: null,
+      created: true,
+      error: null,
+    })
+    expect(handleAppendMemoryResult({ type: 'append_memory_result', path: null, error: 'denied' })).toEqual({
+      path: null,
+      created: false,
+      error: 'denied',
+    })
+  })
+})
+
+describe('formatMemoryAppendNotice (#6861)', () => {
+  it('names the file on a plain append', () => {
+    expect(formatMemoryAppendNotice({ path: '/repo/CLAUDE.md', created: false, error: null })).toBe(
+      'Saved your note to CLAUDE.md.',
+    )
+  })
+
+  it('reports creation when the file did not exist', () => {
+    expect(formatMemoryAppendNotice({ path: '/repo/CLAUDE.md', created: true, error: null })).toBe(
+      'Created CLAUDE.md and saved your note.',
+    )
+  })
+
+  it('surfaces the error verbatim', () => {
+    expect(formatMemoryAppendNotice({ path: null, created: false, error: 'Pairing-issued tokens cannot modify files' })).toBe(
+      "Couldn't save to memory: Pairing-issued tokens cannot modify files",
+    )
+  })
+
+  it('falls back to CLAUDE.md when no path is provided', () => {
+    expect(formatMemoryAppendNotice({ path: null, created: false, error: null })).toBe(
+      'Saved your note to CLAUDE.md.',
+    )
+  })
+})

--- a/packages/store-core/src/memory.test.ts
+++ b/packages/store-core/src/memory.test.ts
@@ -32,6 +32,23 @@ describe('parseMemoryAppend (#6861)', () => {
     })
   })
 
+  it('does NOT intercept a multi-line draft that opens with a Markdown H1', () => {
+    // Pasting a spec/plan/doc that starts with `# Title` must reach Claude as a
+    // normal chat turn, NOT be collapsed to one line and eaten as a memory note.
+    expect(parseMemoryAppend('# Heading\nbody line one\nbody line two')).toEqual({
+      isMemory: false,
+      note: '',
+    })
+  })
+
+  it('does NOT intercept a single `# ` line followed by a trailing newline', () => {
+    expect(parseMemoryAppend('# just a heading\n')).toEqual({ isMemory: false, note: '' })
+  })
+
+  it('does NOT intercept when a later line carries the marker', () => {
+    expect(parseMemoryAppend('first\n# not a note')).toEqual({ isMemory: false, note: '' })
+  })
+
   it('does NOT intercept a bare `#`', () => {
     expect(parseMemoryAppend('#')).toEqual({ isMemory: false, note: '' })
   })

--- a/packages/store-core/src/memory.ts
+++ b/packages/store-core/src/memory.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared logic for the `#`-prefix composer quick-append (#6861, epic #6760).
+ *
+ * A composer message that starts with `# ` (hash + a space) is a "memory
+ * quick-append": instead of a chat turn, the note after the prefix is appended
+ * to the session's project `CLAUDE.md`. This module is the single source of
+ * truth BOTH clients (dashboard + mobile) use so the interception semantics and
+ * the confirmation wording can't drift between them.
+ *
+ * Pure data + string logic only — no store, no wire, no platform imports — so
+ * store-core vitest, the app jest suite, and the dashboard vitest suite can all
+ * consume it from one place.
+ */
+
+/** Result of testing a composer draft for the `#`-quick-append prefix. */
+export interface MemoryAppendParse {
+  /** True when the draft is a memory quick-append command. */
+  isMemory: boolean
+  /** The note to append (prefix stripped, trimmed). Empty when `isMemory` is false. */
+  note: string
+}
+
+/**
+ * Detect the `#`-prefix quick-append in a composer draft.
+ *
+ * Matches the desktop-app semantics: the draft must start with a `#` followed by
+ * at least one space/tab, and carry a non-empty note after it. Deliberately
+ * strict so ordinary prose isn't hijacked:
+ *   - `# remember X`  → memory append (note: "remember X")
+ *   - `#`             → NOT a command (no note)
+ *   - `#tag`          → NOT a command (no space after `#`)
+ *   - `see #123`      → NOT a command (`#` is mid-text, not leading)
+ *   - `#   ` (spaces) → NOT a command (empty note)
+ *
+ * The leading `#` must be the very first character — a leading space means the
+ * user didn't start the line with the marker, so it stays a normal message.
+ */
+export function parseMemoryAppend(text: unknown): MemoryAppendParse {
+  if (typeof text !== 'string') return { isMemory: false, note: '' }
+  const match = /^#[ \t]+(.+)$/s.exec(text)
+  const note = match?.[1]?.trim() ?? ''
+  if (!note) return { isMemory: false, note: '' }
+  return { isMemory: true, note }
+}
+
+/** Parsed payload for an `append_memory_result` ack. */
+export interface AppendMemoryResultPayload {
+  /** Absolute path the note landed in. Null on error / missing. */
+  path: string | null
+  /** Whether the server created the file (vs. appended to an existing one). */
+  created: boolean
+  /** Error string from the server, if any. Null on success. */
+  error: string | null
+}
+
+/**
+ * Parse an `append_memory_result` wire message into a normalised payload.
+ * Mirrors the `handleWriteFileResult` shape (both are file-mutation acks).
+ */
+export function handleAppendMemoryResult(
+  msg: Record<string, unknown>,
+): AppendMemoryResultPayload {
+  return {
+    path: typeof msg.path === 'string' ? msg.path : null,
+    created: msg.created === true,
+    error: typeof msg.error === 'string' ? msg.error : null,
+  }
+}
+
+/** Last path segment (handles both `/` and `\` separators). */
+function basenameOf(p: string): string {
+  const parts = p.split(/[/\\]/)
+  return parts[parts.length - 1] || p
+}
+
+/**
+ * Format the transcript confirmation shown after a quick-append. Honest about
+ * WHICH file the note landed in (the project `CLAUDE.md`) and whether it was
+ * created. Shared so both clients render byte-identical text (pinned by the
+ * behavioural-contract fixture).
+ */
+export function formatMemoryAppendNotice(payload: AppendMemoryResultPayload): string {
+  if (payload.error) return `Couldn't save to memory: ${payload.error}`
+  const file = payload.path ? basenameOf(payload.path) : 'CLAUDE.md'
+  return payload.created
+    ? `Created ${file} and saved your note.`
+    : `Saved your note to ${file}.`
+}

--- a/packages/store-core/src/memory.ts
+++ b/packages/store-core/src/memory.ts
@@ -23,10 +23,13 @@ export interface MemoryAppendParse {
 /**
  * Detect the `#`-prefix quick-append in a composer draft.
  *
- * Matches the desktop-app semantics: the draft must start with a `#` followed by
- * at least one space/tab, and carry a non-empty note after it. Deliberately
- * strict so ordinary prose isn't hijacked:
+ * Matches the desktop-app semantics: the draft must be a SINGLE LINE that starts
+ * with a `#` followed by at least one space/tab, and carry a non-empty note.
+ * Deliberately strict so ordinary prose — and pasted documents — aren't hijacked:
  *   - `# remember X`  → memory append (note: "remember X")
+ *   - `# Title\nbody` → NOT a command — a multi-line draft (even one opening with
+ *                       a Markdown H1) is a normal chat turn; intercepting it
+ *                       would collapse the body to one line and silently eat it.
  *   - `#`             → NOT a command (no note)
  *   - `#tag`          → NOT a command (no space after `#`)
  *   - `see #123`      → NOT a command (`#` is mid-text, not leading)
@@ -37,7 +40,11 @@ export interface MemoryAppendParse {
  */
 export function parseMemoryAppend(text: unknown): MemoryAppendParse {
   if (typeof text !== 'string') return { isMemory: false, note: '' }
-  const match = /^#[ \t]+(.+)$/s.exec(text)
+  // Single-line drafts only: a multi-line message is always a normal chat turn.
+  // (No dotAll flag AND an explicit newline guard — belt and suspenders, since a
+  // Markdown-H1 spec/plan paste opening with `# ` must never be eaten as memory.)
+  if (text.includes('\n')) return { isMemory: false, note: '' }
+  const match = /^#[ \t]+(.+)$/.exec(text)
   const note = match?.[1]?.trim() ?? ''
   if (!note) return { isMemory: false, note: '' }
   return { isMemory: true, note }


### PR DESCRIPTION
## Summary

Foundation slice of the #6760 memory epic. Adds the desktop-app-style `#` quick-append: a composer message starting with `# ` (hash + space) is intercepted in **both** composers and appended as a single line to the session cwd's **project `CLAUDE.md`**, instead of being sent as a chat turn.

Honest by design — the note always lands in the project `CLAUDE.md` at the session cwd (created if absent), and the confirmation names that file. No project/user/local chooser in this slice (the sibling slices add the merged-memory read endpoint + management panel).

## Server (path-confined, bound-gated)

- New `append_memory { text }` client message → `handleAppendMemory`, behind the **same `rejectMutationIfBound` (#6541) gate** as `write_file`/git mutations (a pairing-bound share-a-session token cannot write to the host's `CLAUDE.md`).
- New `ws-file-ops` `appendMemory` op: the **target is chosen server-side** (`<cwd>/CLAUDE.md`) — the client never sends a path — so the write is **path-confined by construction**. `validatePathWithinCwd` + `O_NOFOLLOW` carry the symlink-escape defence over from `writeFile`. Read-modify-write: appends the note on its own line, or creates the file with it.
- Acks with `append_memory_result { path, created, error }`.

## Composers (dashboard + mobile)

- Shared `parseMemoryAppend` (store-core) is the single source of the interception semantics: a leading **`# `** with a non-empty note routes to memory; a bare `#`, `#tag` (no space), a `#` mid-text, or a leading-space `#` all stay a normal message. Interception is skipped for terminal sessions (`#` is a shell comment there) and when attachments are pending.
- Both clients handle the ack via shared `formatMemoryAppendNotice`, appending a **byte-identical** system confirmation (or the error) to the active transcript — `Saved your note to CLAUDE.md.` / `Created CLAUDE.md and saved your note.` / `Couldn't save to memory: <error>`.

## Reuse vs new wire message

New `append_memory` request + `append_memory_result` ack (both AC-required). The append semantic (server-owned target, create-if-absent, read-modify-write a single line) doesn't map onto the truncate-write `write_file` path, and having the server own the target is what makes it path-confined by construction — the reason the issue calls for a *dedicated* append rather than a raw arbitrary write.

## Coverage guards

- `AppendMemorySchema` (client) + `ServerAppendMemoryResultSchema` (server), protocol dist rebuilt & committed.
- `ws-server.js` `Server -> Client:` doc-block line for `append_memory_result`.
- 3 both-clients `SWITCH_FIXTURES` (success / created / error) — the ack is handled by both clients' switches and pins identical behaviour.

## Tests (all green, Node 22)

- store-core vitest: 2018 (new `memory.test.ts` 14; contract fixtures; `coverage-lint` + `protocol-type-coverage-lint`)
- protocol node:test: 362 (`handler-coverage`, `schemas`)
- server file/memory: new `append-memory.test.js` (create/append/newline-sep/multiline/null-cwd/length-cap/symlink-escape) + `file-handlers` (delegation + bound-token gate) + `ws-schema-coverage`
- dashboard vitest: 4541 · app jest: 2224 · tsc: store-core/dashboard/app clean
- all 5 server `lint-*.sh` OK

Closes #6861