### PR TITLE
feat(dashboard): global compact chat filter to hide tool calls + thinking (mobile parity)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -85,7 +85,7 @@ import { useMessageRenderer } from './hooks/useMessageRenderer'
 import { SplitPane } from './components/SplitPane'
 import { ViewSwitcher } from './components/ViewSwitcher'
 import { DEFAULT_PROVIDER, USER_SHELL_PROVIDER } from '@chroxy/protocol'
-import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
+import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, persistCompactChatFilter, loadPersistedCompactChatFilter, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
 import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import { AgentMonitorPanel } from './components/AgentMonitorPanel'
@@ -813,6 +813,15 @@ export function App() {
   const [showConsoleTab, setShowConsoleTab] = useState(() => {
     return loadPersistedShowConsoleTab()
   })
+  // #6799 — global compact chat filter (hide tool calls + thinking, mobile
+  // parity). Seeded from the persisted preference so the choice survives a
+  // reload; the filter is applied in the shared `buildChatViewMessages` pass
+  // via useChatMessages below.
+  const [compactChatFilter, setCompactChatFilter] = useState(() => loadPersistedCompactChatFilter())
+  const toggleCompactChatFilter = useCallback((enabled: boolean) => {
+    setCompactChatFilter(enabled)
+    persistCompactChatFilter(enabled)
+  }, [])
   const [isSwitchingSession, setIsSwitchingSession] = useState(false)
 
   // Clear the switching flag once the active session actually changes
@@ -1156,6 +1165,9 @@ export function App() {
   } = useChatMessages({
     storeMessages,
     streamingMessageId,
+    // #6799 — global compact chat filter: drop tool_use + thinking rows
+    // session-wide when the header toggle is on (mobile parity).
+    hideToolAndThinking: compactChatFilter,
   })
 
   // #6788 — searchable-text extractor for the ChatView in-session find bar.
@@ -2366,6 +2378,8 @@ export function App() {
               unreadSystemCount={unreadSystemCount}
               checkpointsOpen={checkpointsOpen}
               setCheckpointsOpen={setCheckpointsOpen}
+              compactChatFilter={compactChatFilter}
+              onToggleCompactChatFilter={toggleCompactChatFilter}
             />
 
             {/* Main content */}

--- a/packages/dashboard/src/components/ViewSwitcher.test.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.test.tsx
@@ -10,7 +10,7 @@
  *     path is unaffected.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { ViewSwitcher } from './ViewSwitcher'
 
 afterEach(cleanup)
@@ -79,5 +79,53 @@ describe('ViewSwitcher tab gates', () => {
     cleanup()
     renderSwitcher({ showChatTab: true, showTerminalTab: false })
     expect(screen.queryByRole('button', { name: 'Split' })).not.toBeInTheDocument()
+  })
+})
+
+// #6799 — global compact chat filter toggle (hide tool calls + thinking, mobile
+// parity). The control only renders while a chat surface is on screen and only
+// when a handler is wired.
+describe('ViewSwitcher compact chat filter toggle (#6799)', () => {
+  const TOGGLE = 'compact-chat-filter-toggle'
+
+  it('renders the toggle on the chat view when a handler is supplied', () => {
+    renderSwitcher({ viewMode: 'chat', onToggleCompactChatFilter: vi.fn() })
+    expect(screen.getByTestId(TOGGLE)).toBeInTheDocument()
+  })
+
+  it('renders the toggle in split view too (split always shows a ChatView)', () => {
+    renderSwitcher({ viewMode: 'terminal', splitMode: 'horizontal', showTerminalTab: true, onToggleCompactChatFilter: vi.fn() })
+    expect(screen.getByTestId(TOGGLE)).toBeInTheDocument()
+  })
+
+  it('hides the toggle on non-chat views (e.g. the terminal tab)', () => {
+    renderSwitcher({ viewMode: 'terminal', showTerminalTab: true, onToggleCompactChatFilter: vi.fn() })
+    expect(screen.queryByTestId(TOGGLE)).not.toBeInTheDocument()
+  })
+
+  it('hides the toggle for terminal-only providers (no chat surface)', () => {
+    renderSwitcher({ viewMode: 'chat', showChatTab: false, showTerminalTab: true, onToggleCompactChatFilter: vi.fn() })
+    expect(screen.queryByTestId(TOGGLE)).not.toBeInTheDocument()
+  })
+
+  it('hides the toggle entirely when no handler is wired', () => {
+    renderSwitcher({ viewMode: 'chat' })
+    expect(screen.queryByTestId(TOGGLE)).not.toBeInTheDocument()
+  })
+
+  it('reflects the current filter state via aria-pressed', () => {
+    renderSwitcher({ viewMode: 'chat', compactChatFilter: true, onToggleCompactChatFilter: vi.fn() })
+    expect(screen.getByTestId(TOGGLE)).toHaveAttribute('aria-pressed', 'true')
+
+    cleanup()
+    renderSwitcher({ viewMode: 'chat', compactChatFilter: false, onToggleCompactChatFilter: vi.fn() })
+    expect(screen.getByTestId(TOGGLE)).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('invokes the handler with the negated state on click', () => {
+    const onToggle = vi.fn()
+    renderSwitcher({ viewMode: 'chat', compactChatFilter: false, onToggleCompactChatFilter: onToggle })
+    fireEvent.click(screen.getByTestId(TOGGLE))
+    expect(onToggle).toHaveBeenCalledWith(true)
   })
 })

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -11,6 +11,7 @@ export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'cons
 export function ViewSwitcher({
   viewMode, setViewMode, splitMode, setSplitMode, persistSplitMode,
   showChatTab = true, showTerminalTab = true, showConsoleTab, unreadSystemCount, checkpointsOpen, setCheckpointsOpen,
+  compactChatFilter = false, onToggleCompactChatFilter,
 }: {
   viewMode: string
   setViewMode: (m: ViewMode) => void
@@ -27,6 +28,11 @@ export function ViewSwitcher({
   unreadSystemCount: number
   checkpointsOpen: boolean
   setCheckpointsOpen: (fn: (prev: boolean) => boolean) => void
+  // #6799 — global compact chat filter (hide tool calls + thinking, mobile
+  // parity). The toggle only renders while a chat surface is on screen. When
+  // `onToggleCompactChatFilter` is omitted the control is hidden entirely.
+  compactChatFilter?: boolean
+  onToggleCompactChatFilter?: (enabled: boolean) => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [canScrollLeft, setCanScrollLeft] = useState(false)
@@ -137,6 +143,21 @@ export function ViewSwitcher({
         <button className={`view-tab${viewMode === 'pool' ? ' active' : ''}`} onClick={() => { setViewMode('pool'); setSplitMode(null); persistSplitMode(null) }} type="button">Pool</button>
         <button className={`view-tab${viewMode === 'pages' ? ' active' : ''}`} onClick={() => { setViewMode('pages'); setSplitMode(null); persistSplitMode(null) }} type="button">Pages</button>
         <div className="view-switch-spacer" />
+        {/* #6799 — global compact chat filter: hide every tool call + thinking
+            block from the transcript at once (mobile parity). Only meaningful
+            while a chat surface is showing — split always renders a ChatView, so
+            it counts too. A pressed/`active` toggle button rather than a tab: it
+            doesn't change viewMode, it filters the current one. */}
+        {showChatTab && onToggleCompactChatFilter && (viewMode === 'chat' || splitMode !== null) && (
+          <button
+            className={`view-tab view-tab-right${compactChatFilter ? ' active' : ''}`}
+            data-testid="compact-chat-filter-toggle"
+            onClick={() => onToggleCompactChatFilter(!compactChatFilter)}
+            type="button"
+            aria-pressed={compactChatFilter}
+            title={compactChatFilter ? 'Showing compact chat — click to show tool calls and thinking' : 'Hide tool calls and thinking from the transcript'}
+          >Compact</button>
+        )}
         <button className={`view-tab view-tab-right${checkpointsOpen ? ' active' : ''}`} onClick={() => setCheckpointsOpen(prev => !prev)} type="button" title="Toggle checkpoint timeline">Checkpoints</button>
         <button className={`view-tab${viewMode === 'diff' ? ' active' : ''}`} onClick={() => setViewMode('diff')} type="button">Diff</button>
       </div>

--- a/packages/dashboard/src/hooks/useChatMessages.test.ts
+++ b/packages/dashboard/src/hooks/useChatMessages.test.ts
@@ -169,6 +169,49 @@ describe('useChatMessages', () => {
     expect(second).toBe(first)
   })
 
+  // #6799 — global compact chat filter (mobile parity). The hook forwards
+  // `hideToolAndThinking` to the shared `buildChatViewMessages` pipeline so the
+  // dashboard toggle drops tool_use + thinking rows session-wide.
+  describe('compact chat filter — hideToolAndThinking (#6799)', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'do a thing' }),
+      msg({ id: 'th1', type: 'thinking', content: 'planning' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
+      msg({ id: 'r1', type: 'response', content: 'done' }),
+    ]
+
+    it('excludes tool_use and thinking rows from the rendered list when on', () => {
+      const { result } = renderHook(() =>
+        useChatMessages({ storeMessages: messages, streamingMessageId: null, hideToolAndThinking: true }),
+      )
+      // Only the conversation rows are handed to the ChatView; no tool_group
+      // collapse row forms because the tools are filtered before grouping.
+      expect(result.current.chatMessages.map(m => m.id)).toEqual(['u1', 'r1'])
+      expect(result.current.chatMessages.map(m => m.type)).toEqual(['user_input', 'response'])
+      expect(result.current.chatToolGroupPayloads.size).toBe(0)
+    })
+
+    it('keeps every row when off (default), preserving tool_group collapse', () => {
+      const { result } = renderHook(() =>
+        useChatMessages({ storeMessages: messages, streamingMessageId: null, hideToolAndThinking: false }),
+      )
+      expect(result.current.chatMessages.map(m => m.type)).toEqual([
+        'user_input', 'thinking', 'tool_group', 'response',
+      ])
+      expect(result.current.chatToolGroupPayloads.size).toBe(1)
+    })
+
+    it('defaults to off when the flag is omitted', () => {
+      const { result } = renderHook(() =>
+        useChatMessages({ storeMessages: messages, streamingMessageId: null }),
+      )
+      expect(result.current.chatMessages.map(m => m.type)).toEqual([
+        'user_input', 'thinking', 'tool_group', 'response',
+      ])
+    })
+  })
+
   describe('storeMsgMap', () => {
     it('keys by message id and preserves the original ChatMessage shape', () => {
       const messages = [

--- a/packages/dashboard/src/hooks/useChatMessages.ts
+++ b/packages/dashboard/src/hooks/useChatMessages.ts
@@ -48,6 +48,12 @@ void _assert
 export interface UseChatMessagesProps {
   storeMessages: ChatMessage[]
   streamingMessageId: string | null
+  /**
+   * #6799 — global compact chat filter. When true, `buildChatViewMessages`
+   * drops every `tool_use` and `thinking` row session-wide (mobile parity), so
+   * the transcript shows only the conversation. Defaults to false (off).
+   */
+  hideToolAndThinking?: boolean
 }
 
 export interface UseChatMessagesResult {
@@ -73,11 +79,11 @@ export interface UseChatMessagesResult {
 export { toChatViewMessage }
 
 export function useChatMessages(props: UseChatMessagesProps): UseChatMessagesResult {
-  const { storeMessages, streamingMessageId } = props
+  const { storeMessages, streamingMessageId, hideToolAndThinking = false } = props
 
   const result = useMemo(
-    () => buildChatViewMessages(storeMessages, streamingMessageId),
-    [storeMessages, streamingMessageId],
+    () => buildChatViewMessages(storeMessages, streamingMessageId, { hideToolAndThinking }),
+    [storeMessages, streamingMessageId, hideToolAndThinking],
   )
 
   // Destructure to drop `displayGroups` (dashboard uses the flattened

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -23,6 +23,9 @@ const KEY_SHOW_CONSOLE_TAB = `${KEY_PREFIX}show_console_tab`;
 // #4891 — audible intervention ping. Defaults on; persisted per-device so a
 // muted browser tab stays muted across reload + Tauri restart.
 const KEY_INTERVENTION_PING = `${KEY_PREFIX}intervention_ping`;
+// #6799 — global "compact" chat filter (hide tool calls + thinking, mobile
+// parity). Defaults off; persisted per-device so the choice survives reload.
+const KEY_COMPACT_CHAT_FILTER = `${KEY_PREFIX}compact_chat_filter`;
 // #4303 — pluggable sidebar panel slot persistence
 const KEY_SIDEBAR_PANEL_HEIGHT = `${KEY_PREFIX}sidebar_panel_height`;
 const KEY_SIDEBAR_PANEL_VIEW = `${KEY_PREFIX}sidebar_panel_view`;
@@ -483,6 +486,34 @@ export function loadPersistedInterventionPing(): boolean {
     return localStorage.getItem(KEY_INTERVENTION_PING) !== 'false';
   } catch {
     return true;
+  }
+}
+
+/**
+ * Persist the compact-chat-filter preference (#6799 — hide tool calls +
+ * thinking across the whole transcript, mirroring the mobile app's coarse
+ * All/Compact filter).
+ */
+export function persistCompactChatFilter(enabled: boolean): void {
+  try {
+    localStorage.setItem(KEY_COMPACT_CHAT_FILTER, String(enabled));
+  } catch {
+    // Storage not available
+  }
+}
+
+/**
+ * Load the persisted compact-chat-filter preference (#6799).
+ *
+ * Defaults to OFF (returns false) when unset so the transcript ships showing
+ * every message — the filter is opt-in. Only an explicit `'true'` enables it;
+ * falls back to OFF if storage is unavailable.
+ */
+export function loadPersistedCompactChatFilter(): boolean {
+  try {
+    return localStorage.getItem(KEY_COMPACT_CHAT_FILTER) === 'true';
+  } catch {
+    return false;
   }
 }
 

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -11,7 +11,7 @@
  * the dashboard hook test had, run directly against the pure function.
  */
 import { describe, it, expect } from 'vitest'
-import { buildChatViewMessages, toChatViewMessage } from './buildChatViewMessages'
+import { buildChatViewMessages, toChatViewMessage, isHiddenInCompactMode } from './buildChatViewMessages'
 import type { ChatMessage } from './types'
 
 function msg(partial: Partial<ChatMessage> & { id: string; type: ChatMessage['type'] }): ChatMessage {
@@ -276,6 +276,83 @@ describe('buildChatViewMessages', () => {
       expect(joined).toContain('Delegating')
       expect(joined).not.toContain('Del\n\nDel')
       expect(joined).not.toMatch(/Del\negating/)
+    })
+  })
+
+  // #6799 — global compact chat filter (mobile parity): hide all tool_use +
+  // thinking rows session-wide via a shared pipeline flag, mirroring mobile's
+  // `chatFilterCompact` pre-filter so both clients agree on WHAT is hidden.
+  describe('compact chat filter — hideToolAndThinking (#6799)', () => {
+    it('drops tool_use and thinking rows when the flag is on', () => {
+      const messages = [
+        msg({ id: 'u1', type: 'user_input', content: 'do a thing' }),
+        msg({ id: 'th1', type: 'thinking', content: 'planning' }),
+        msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+        msg({ id: 'r1', type: 'response', content: 'done' }),
+      ]
+      const out = buildChatViewMessages(messages, null, { hideToolAndThinking: true })
+      // Only the conversation rows survive — the tool + thinking are hidden.
+      expect(out.chatMessages.map(m => m.id)).toEqual(['u1', 'r1'])
+      expect(out.chatMessages.map(m => m.type)).toEqual(['user_input', 'response'])
+    })
+
+    it('does not collapse a run of hidden tools into a tool_group when the flag is on', () => {
+      const messages = [
+        msg({ id: 'u1', type: 'user_input', content: 'do many things' }),
+        msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+        msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
+        msg({ id: 'r1', type: 'response', content: 'done' }),
+      ]
+      const out = buildChatViewMessages(messages, null, { hideToolAndThinking: true })
+      // The tools are filtered out BEFORE grouping, so no synthetic tool_group
+      // row is emitted and the payload map stays empty.
+      expect(out.chatMessages.map(m => m.type)).toEqual(['user_input', 'response'])
+      expect(out.chatToolGroupPayloads.size).toBe(0)
+      // The tail is the last surviving conversation row, not a group id.
+      expect(out.chatTailMessageId).toBe('r1')
+    })
+
+    it('is a no-op equal to the default when the flag is off or omitted', () => {
+      const messages = [
+        msg({ id: 'u1', type: 'user_input', content: 'go' }),
+        msg({ id: 'th1', type: 'thinking', content: 'planning' }),
+        msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+        msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
+        msg({ id: 'r1', type: 'response', content: 'done' }),
+      ]
+      const off = buildChatViewMessages(messages, null, { hideToolAndThinking: false })
+      const omitted = buildChatViewMessages(messages, null)
+      const offTypes = off.chatMessages.map(m => m.type)
+      // Filter off leaves the full pipeline behaviour intact (thinking standalone,
+      // the 2-tool run collapsed to a tool_group).
+      expect(offTypes).toEqual(['user_input', 'thinking', 'tool_group', 'response'])
+      expect(omitted.chatMessages.map(m => m.type)).toEqual(offTypes)
+      expect(off.chatToolGroupPayloads.size).toBe(1)
+    })
+
+    it('keeps storeMsgMap complete (hidden rows stay resolvable for the renderer)', () => {
+      const messages = [
+        msg({ id: 'u1', type: 'user_input', content: 'go' }),
+        msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      ]
+      const out = buildChatViewMessages(messages, null, { hideToolAndThinking: true })
+      // The tool row is hidden from the visible list but still present in the
+      // lookup map — the map is built from the unfiltered storeMessages.
+      expect(out.chatMessages.map(m => m.id)).toEqual(['u1'])
+      expect(out.storeMsgMap.get('t1')?.tool).toBe('Bash')
+    })
+  })
+
+  describe('isHiddenInCompactMode (#6799)', () => {
+    it('hides exactly tool_use and thinking', () => {
+      expect(isHiddenInCompactMode('tool_use')).toBe(true)
+      expect(isHiddenInCompactMode('thinking')).toBe(true)
+    })
+
+    it('keeps conversation and action rows visible', () => {
+      for (const type of ['response', 'user_input', 'prompt', 'error', 'system'] as const) {
+        expect(isHiddenInCompactMode(type)).toBe(false)
+      }
     })
   })
 

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -110,8 +110,10 @@ export interface BuildChatViewMessagesOptions {
  * #6799 — predicate for the global compact chat filter: which message types
  * vanish entirely when the filter is on. `tool_use` and `thinking` are the two
  * "noise" categories the mobile app already hides session-wide; the dashboard
- * toggle (and any future client) narrows off this single predicate so every
- * surface agrees on WHAT compact mode hides. Pure — safe to call per row.
+ * toggle narrows off this single predicate. It is the shared definition other
+ * clients can adopt so every surface agrees on WHAT compact mode hides — mobile
+ * still hard-codes the same rule inline in SessionScreen.tsx; converging it onto
+ * this predicate is tracked in #6882. Pure — safe to call per row.
  */
 export function isHiddenInCompactMode(type: ChatMessage['type']): boolean {
   return type === 'tool_use' || type === 'thinking'

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -89,6 +89,34 @@ export interface ChatViewMessage {
   attachments?: MessageAttachment[]
 }
 
+/**
+ * Options for the chat-view derivation.
+ */
+export interface BuildChatViewMessagesOptions {
+  /**
+   * #6799 — global "compact" chat filter (mobile parity). When true, drop
+   * every `tool_use` and `thinking` message from the transcript session-wide,
+   * so the chat pane shows only the assistant's responses (and anything needing
+   * action). Mirrors mobile's `chatFilterCompact` (SessionScreen.tsx), which
+   * pre-filters the same two types inline. Additive on top of the per-item
+   * ToolBubble/ToolGroup collapse — those stay untouched when this is off (the
+   * hidden types never reach the grouping pass, so no `tool_group` rows form).
+   * Default `false`.
+   */
+  hideToolAndThinking?: boolean
+}
+
+/**
+ * #6799 — predicate for the global compact chat filter: which message types
+ * vanish entirely when the filter is on. `tool_use` and `thinking` are the two
+ * "noise" categories the mobile app already hides session-wide; the dashboard
+ * toggle (and any future client) narrows off this single predicate so every
+ * surface agrees on WHAT compact mode hides. Pure — safe to call per row.
+ */
+export function isHiddenInCompactMode(type: ChatMessage['type']): boolean {
+  return type === 'tool_use' || type === 'thinking'
+}
+
 export interface ChatViewPipelineResult {
   /** Chat-view rows with contiguous tool runs collapsed to `tool_group`. */
   chatMessages: ChatViewMessage[]
@@ -153,13 +181,23 @@ export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
  * @param storeMessages full message list from BaseSessionState.messages
  * @param streamingMessageId currently-streaming message id (drives the
  *   trailing activity group's `isActive` overlay); `null` when idle.
+ * @param options derivation options — `hideToolAndThinking` (#6799) drops
+ *   `tool_use` + `thinking` rows session-wide for the compact chat filter.
  */
 export function buildChatViewMessages(
   storeMessages: ChatMessage[],
   streamingMessageId: string | null,
+  options: BuildChatViewMessagesOptions = {},
 ): ChatViewPipelineResult {
-  // Filter out `system` events — they belong on the System tab.
-  const chatFilteredMessages = storeMessages.filter(m => m.type !== 'system')
+  const { hideToolAndThinking = false } = options
+  // Filter out `system` events — they belong on the System tab. When the #6799
+  // compact filter is on, also drop tool_use + thinking session-wide (before
+  // grouping, so no `tool_group` collapse row forms for a run of hidden tools).
+  const chatFilteredMessages = storeMessages.filter(m => {
+    if (m.type === 'system') return false
+    if (hideToolAndThinking && isHiddenInCompactMode(m.type)) return false
+    return true
+  })
 
   // Group contiguous tool_use runs (#6756: thinking stays standalone), then
   // apply the streaming overlay so the trailing group flips to isActive while

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -374,11 +374,14 @@ export {
 export type {
   ChatViewMessage,
   ChatViewPipelineResult,
+  BuildChatViewMessagesOptions,
 } from './buildChatViewMessages'
 
 export {
   buildChatViewMessages,
   toChatViewMessage,
+  // #6799 — shared predicate for the global compact chat filter (mobile parity).
+  isHiddenInCompactMode,
 } from './buildChatViewMessages'
 
 // #5793: single source of truth for "is this an AskUserQuestion teardown


### PR DESCRIPTION
Closes #6799

## What

Adds a single global toggle to the web dashboard that hides every `tool_use` and `thinking` message from the chat transcript **session-wide** — bringing the dashboard up to the mobile app's coarse **All / Compact** chat filter. In a long agentic session, a user who just wants to follow the conversation can now collapse the whole wall of tool noise with one click instead of collapsing each `ToolBubble`/`ToolGroup` by hand.

## How it mirrors mobile

Mobile (`SessionScreen.tsx`) owns a `chatFilterCompact` boolean and pre-filters the message list to drop `tool_use` + `thinking`. This PR lifts that exact semantic into the **shared** pipeline both clients build from, so they converge on one definition of what compact mode hides rather than drifting:

- **`@chroxy/store-core` — `buildChatViewMessages`** gains an optional `{ hideToolAndThinking }` flag that drops `tool_use` + `thinking` **before** the grouping pass (so no synthetic `tool_group` collapse row forms for a hidden run). The rule lives in a new exported pure predicate **`isHiddenInCompactMode(type)`** — the single source of truth. `storeMsgMap` is still built from the unfiltered list, so hidden rows stay resolvable for the renderer.
- **Dashboard** — a "Compact" toggle in the `ViewSwitcher` chrome, rendered only while a chat surface is on screen (chat tab or split, which always shows a `ChatView`). It's a pressed/`aria-pressed` toggle button (reuses the existing `view-tab` class — no new CSS/colors), wired through `useChatMessages` → `buildChatViewMessages`.
- **Persistence** — seeded from and written to `localStorage` via the existing view-preference pattern (`persistCompactChatFilter` / `loadPersistedCompactChatFilter`, mirroring `showConsoleTab`), so the choice survives reload. (Deliberate divergence from mobile, which resets per-session: the dashboard persists view prefs globally like its other toggles — the *semantics of what is hidden* are what mirror mobile.)

Existing per-item `ToolBubble`/`ToolGroup` expand/collapse and the long-output auto-collapse threshold are untouched — the filter is **additive** (hide entirely) on top of them and only when the toggle is on.

## Acceptance criteria
- [x] Single dashboard toggle hides all `tool_use` + `thinking` messages session-wide
- [x] Implemented via a shared `buildChatViewMessages` flag, not a dashboard-only bespoke filter
- [x] Toggle state persists across reloads via the existing view-preference persistence
- [x] Per-item collapse + long-output auto-collapse continue to work unchanged when off

## Tests
- **store-core** (`buildChatViewMessages.test.ts`): filter drops tool/thinking, no `tool_group` forms for a hidden run, no-op equality when off/omitted, `storeMsgMap` stays complete; `isHiddenInCompactMode` predicate.
- **dashboard** (`useChatMessages.test.ts`): rows excluded when on, full list + `tool_group` preserved when off, defaults off.
- **dashboard** (`ViewSwitcher.test.tsx`): toggle visibility gating (chat / split / non-chat / terminal-only / no-handler), `aria-pressed` state, click invokes handler with negated state.

Results: store-core `2027` tests + typecheck green; dashboard `4569` tests + typecheck green.