### PR TITLE
feat(server): semantic LLM-generated session titles (opt-in)

### DIFF
--- a/docs/setup-and-smoke-test.md
+++ b/docs/setup-and-smoke-test.md
@@ -140,9 +140,9 @@ CHROXY_ENABLE_IDE=1 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start 
 label is the first user message truncated at a word boundary. With this flag on,
 that label is upgraded — once per session, asynchronously (never blocking the
 turn) — to a short model-generated title via a cheap one-shot Haiku call. If the
-call fails or no model access is available, the truncation label is kept. Off by
-default; enable with `features.semanticTitles: true` in `~/.chroxy/config.json`
-or `CHROXY_SEMANTIC_TITLES=1`:
+call fails, times out, or no model access is available, the truncation label is
+kept. Off by default; enable with `features.semanticTitles: true` in
+`~/.chroxy/config.json` or `CHROXY_SEMANTIC_TITLES=1`:
 
 ```bash
 CHROXY_SEMANTIC_TITLES=1 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --tunnel none
@@ -150,6 +150,10 @@ CHROXY_SEMANTIC_TITLES=1 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy s
 
 The title model defaults to a cheap Haiku alias; override it with
 `CHROXY_SEMANTIC_TITLES_MODEL=<id>` or the existing `summarize.model` config key.
+The one-shot is hard-bounded by a timeout (default 15s) so a stalled provider
+aborts the call and falls back to the truncation label rather than leaking a
+never-settling request; override it with `CHROXY_SEMANTIC_TITLES_TIMEOUT_MS=<ms>`
+or the `summarize.titleTimeoutMs` config key.
 
 ---
 

--- a/docs/setup-and-smoke-test.md
+++ b/docs/setup-and-smoke-test.md
@@ -136,6 +136,21 @@ feature flag — off by default. Enable with `CHROXY_ENABLE_IDE=1`:
 CHROXY_ENABLE_IDE=1 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --tunnel none
 ```
 
+**Opt-in semantic session titles (#6764):** by default a new session's sidebar
+label is the first user message truncated at a word boundary. With this flag on,
+that label is upgraded — once per session, asynchronously (never blocking the
+turn) — to a short model-generated title via a cheap one-shot Haiku call. If the
+call fails or no model access is available, the truncation label is kept. Off by
+default; enable with `features.semanticTitles: true` in `~/.chroxy/config.json`
+or `CHROXY_SEMANTIC_TITLES=1`:
+
+```bash
+CHROXY_SEMANTIC_TITLES=1 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --tunnel none
+```
+
+The title model defaults to a cheap Haiku alias; override it with
+`CHROXY_SEMANTIC_TITLES_MODEL=<id>` or the existing `summarize.model` config key.
+
 ---
 
 ## 6. Connect

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -18,9 +18,10 @@ import { createLogger } from './logger.js'
 // deliberately a dependency-free module so importing it here never pulls
 // the BYOK/SDK machinery into the config-load path.
 import { validateProvidersConfigBlock } from './anthropic-compatible-config.js'
-// #6764: default cheap model for the one-shot semantic-title call. Imported from
-// the pure title module (no provider/SDK deps) so config load stays lightweight.
-import { DEFAULT_SEMANTIC_TITLE_MODEL } from './session-title.js'
+// #6764: default cheap model + timeout for the one-shot semantic-title call.
+// Imported from the pure title module (no provider/SDK deps) so config load stays
+// lightweight.
+import { DEFAULT_SEMANTIC_TITLE_MODEL, DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS } from './session-title.js'
 
 const log = createLogger('config')
 
@@ -723,6 +724,29 @@ export function resolveSemanticTitleModel(config) {
     ? config.summarize.model.trim()
     : null
   return summarizeModel || DEFAULT_SEMANTIC_TITLE_MODEL
+}
+
+// #6764 — resolve the timeout (ms) for the one-shot title call. Precedence:
+//   CHROXY_SEMANTIC_TITLES_TIMEOUT_MS env  >  config.summarize.titleTimeoutMs  >  default.
+// The title call is fire-and-forget, so without a timeout a stalled provider
+// connection leaves its promise pending forever (retaining the SessionManager +
+// first message → an unbounded per-session leak) and never tears the one-shot
+// subprocess down. The resolved value is passed to SessionManager, which turns it
+// into an `AbortSignal.timeout(...)` so the call aborts and falls open to the
+// truncation label. Invalid / non-positive values fall back to the default.
+export function resolveSemanticTitleTimeoutMs(config) {
+  const env = typeof process.env.CHROXY_SEMANTIC_TITLES_TIMEOUT_MS === 'string'
+    ? process.env.CHROXY_SEMANTIC_TITLES_TIMEOUT_MS.trim()
+    : ''
+  if (env) {
+    const n = Number(env)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  const cfg = config?.summarize && typeof config.summarize === 'object'
+    ? config.summarize.titleTimeoutMs
+    : undefined
+  if (typeof cfg === 'number' && Number.isFinite(cfg) && cfg > 0) return cfg
+  return DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS
 }
 
 // #6277: single source of truth for "does a user-shell spawn need host-local

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -18,6 +18,9 @@ import { createLogger } from './logger.js'
 // deliberately a dependency-free module so importing it here never pulls
 // the BYOK/SDK machinery into the config-load path.
 import { validateProvidersConfigBlock } from './anthropic-compatible-config.js'
+// #6764: default cheap model for the one-shot semantic-title call. Imported from
+// the pure title module (no provider/SDK deps) so config load stays lightweight.
+import { DEFAULT_SEMANTIC_TITLE_MODEL } from './session-title.js'
 
 const log = createLogger('config')
 
@@ -688,6 +691,38 @@ export function isIdeFeatureEnabled(config) {
 export function isOrchestrationEnabled(config) {
   if (process.env.CHROXY_ENABLE_ORCHESTRATION === '1') return true
   return config?.features?.orchestration === true
+}
+
+// #6764 — opt-in semantic session titles. When on, the first user turn's sidebar
+// label is upgraded from a raw truncation of the message to a short model-
+// generated summary via a cheap one-shot (Haiku) call. Off by default; the
+// truncation fallback is used when off, when the call fails, or when no model
+// access is available. Enabled by `features.semanticTitles === true` OR the
+// `CHROXY_SEMANTIC_TITLES=1` env override; `CHROXY_SEMANTIC_TITLES=0` force-
+// disables (handy for tests / A-B without editing config).
+export function isSemanticTitlesEnabled(config) {
+  const env = process.env.CHROXY_SEMANTIC_TITLES
+  if (env === '1') return true
+  if (env === '0') return false
+  return config?.features?.semanticTitles === true
+}
+
+// #6764 — resolve the model for the one-shot title call. Precedence:
+//   CHROXY_SEMANTIC_TITLES_MODEL env  >  config.summarize.model  >  Haiku default.
+// The `summarize.{model}` cheap-model override is reused (per #6764) so an
+// operator who already tuned the summarizer's model gets the same for titles;
+// the default stays a cheap Haiku alias so titles never burn a premium model.
+export function resolveSemanticTitleModel(config) {
+  const envModel = typeof process.env.CHROXY_SEMANTIC_TITLES_MODEL === 'string'
+    && process.env.CHROXY_SEMANTIC_TITLES_MODEL.trim()
+    ? process.env.CHROXY_SEMANTIC_TITLES_MODEL.trim()
+    : null
+  if (envModel) return envModel
+  const summarizeModel = config?.summarize && typeof config.summarize === 'object'
+    && typeof config.summarize.model === 'string' && config.summarize.model.trim()
+    ? config.summarize.model.trim()
+    : null
+  return summarizeModel || DEFAULT_SEMANTIC_TITLE_MODEL
 }
 
 // #6277: single source of truth for "does a user-shell spawn need host-local

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -47,7 +47,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // environment-manager.js itself remains behind the dynamic import below
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
-import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel } from './config.js'
+import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel, resolveSemanticTitleTimeoutMs } from './config.js'
 import { buildOrchestrationManager } from './orchestration/build-manager.js'
 import { parseDuration } from './duration.js'
 import { createSessionTokenStore } from './session-token-store.js'
@@ -682,6 +682,11 @@ export async function startCliServer(config) {
     // label is used unchanged.
     semanticTitlesEnabled: isSemanticTitlesEnabled(config),
     semanticTitleModel: resolveSemanticTitleModel(config),
+    // #6764: hard timeout (ms) for the fire-and-forget one-shot title call so a
+    // stalled provider aborts the subprocess and falls open to the truncation
+    // label instead of leaking a never-settling promise. Env / summarize.titleTimeoutMs
+    // override; default ~15s (resolveSemanticTitleTimeoutMs).
+    semanticTitleTimeoutMs: resolveSemanticTitleTimeoutMs(config),
     // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). null = BaseSession default (30 min).
     // #3899: HARD-cap inactivity timeout (ms). null = BaseSession default (2h).
     // #4467: stream-stall recovery (ms). null = BaseSession default (5min).

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -47,7 +47,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // environment-manager.js itself remains behind the dynamic import below
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
-import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders } from './config.js'
+import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel } from './config.js'
 import { buildOrchestrationManager } from './orchestration/build-manager.js'
 import { parseDuration } from './duration.js'
 import { createSessionTokenStore } from './session-token-store.js'
@@ -675,6 +675,13 @@ export async function startCliServer(config) {
     // #5665: monthly programmatic-credit budget meter config.
     billing: config.billing || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
+    // #6764: opt-in semantic session titles. Off unless the operator set
+    // features.semanticTitles:true (or CHROXY_SEMANTIC_TITLES=1). The title model
+    // defaults to a cheap Haiku alias; summarize.model / CHROXY_SEMANTIC_TITLES_MODEL
+    // override it (resolveSemanticTitleModel). When off, the historical truncation
+    // label is used unchanged.
+    semanticTitlesEnabled: isSemanticTitlesEnabled(config),
+    semanticTitleModel: resolveSemanticTitleModel(config),
     // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). null = BaseSession default (30 min).
     // #3899: HARD-cap inactivity timeout (ms). null = BaseSession default (2h).
     // #4467: stream-stall recovery (ms). null = BaseSession default (5min).

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -19,7 +19,7 @@ import { CostBudgetManager } from './cost-budget-manager.js'
 import { SessionStatePersistence } from './session-state-persistence.js'
 import { SessionTimeoutManager, formatIdleDuration } from './session-timeout-manager.js'
 import { SessionMessageHistory } from './session-message-history.js'
-import { generateSessionTitle, DEFAULT_SEMANTIC_TITLE_MODEL } from './session-title.js'
+import { generateSessionTitle, DEFAULT_SEMANTIC_TITLE_MODEL, DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS } from './session-title.js'
 // NB: the default one-shot title runner (defaultRunOneShot) lives in
 // summarize-session.js, which statically imports the Agent SDK. It is loaded
 // LAZILY (dynamic import inside _generateSemanticTitle) so the core
@@ -362,6 +362,13 @@ export class SessionManager extends EventEmitter {
     // that injects the model runner; production falls through to the SDK one-shot.
     semanticTitlesEnabled = false,
     semanticTitleModel = null,
+    // #6764: hard timeout (ms) for the fire-and-forget one-shot title call. The
+    // call MUST be abortable — a stalled provider stream otherwise leaves the
+    // detached promise pending forever, retaining `this`, the first message, and
+    // the sessionId (an unbounded per-session leak) and never tearing the one-shot
+    // subprocess down. `_generateSemanticTitle` turns this into an
+    // `AbortSignal.timeout(...)`; null → the DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS.
+    semanticTitleTimeoutMs = null,
     titleRunOneShot = null,
 
     // #5859 (audit P1-7): opt-in boot-time sweep of orphaned chroxy session
@@ -590,6 +597,12 @@ export class SessionManager extends EventEmitter {
     this._semanticTitleModel = typeof semanticTitleModel === 'string' && semanticTitleModel
       ? semanticTitleModel
       : DEFAULT_SEMANTIC_TITLE_MODEL
+    // Hard timeout for the one-shot title call (#6764) — see the ctor opt above.
+    // Positive finite ms only; anything else falls back to the default.
+    this._semanticTitleTimeoutMs = typeof semanticTitleTimeoutMs === 'number'
+      && Number.isFinite(semanticTitleTimeoutMs) && semanticTitleTimeoutMs > 0
+      ? semanticTitleTimeoutMs
+      : DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS
     // null → resolve the default SDK one-shot lazily on first use (see above).
     this._titleRunOneShot = typeof titleRunOneShot === 'function' ? titleRunOneShot : null
 
@@ -1977,12 +1990,21 @@ export class SessionManager extends EventEmitter {
     const runOneShot = this._titleRunOneShot
       || (await import('./summarize-session.js')).defaultRunOneShot
 
+    // Hard-bound the fire-and-forget call: AbortSignal.timeout fires after
+    // _semanticTitleTimeoutMs, which threads to defaultRunOneShot →
+    // query({ abortController }) so a stalled provider stream is torn down (not
+    // just abandoned). generateSessionTitle catches the resulting abort rejection
+    // and fails open to the truncation label. Without this the detached promise
+    // could stay pending forever, leaking `this` + the first message (#6764).
+    const signal = AbortSignal.timeout(this._semanticTitleTimeoutMs)
+
     const { title, source } = await generateSessionTitle({
       firstUserMessage: firstMessage,
       enabled: true,
       model: this._semanticTitleModel,
       cwd: this._sessions.get(sessionId)?.cwd,
       runOneShot,
+      signal,
       fallback: fallbackLabel,
     })
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -19,6 +19,12 @@ import { CostBudgetManager } from './cost-budget-manager.js'
 import { SessionStatePersistence } from './session-state-persistence.js'
 import { SessionTimeoutManager, formatIdleDuration } from './session-timeout-manager.js'
 import { SessionMessageHistory } from './session-message-history.js'
+import { generateSessionTitle, DEFAULT_SEMANTIC_TITLE_MODEL } from './session-title.js'
+// NB: the default one-shot title runner (defaultRunOneShot) lives in
+// summarize-session.js, which statically imports the Agent SDK. It is loaded
+// LAZILY (dynamic import inside _generateSemanticTitle) so the core
+// SessionManager module — imported by nearly every test — never pulls the SDK
+// into its graph unless the semantic-title feature actually fires a model call.
 import { SkillsUsageRecorder } from './skills-usage.js'
 import { resolveSessionPreset, foldPreamble } from './session-preset.js'
 import { SessionPresetTrustStore } from './session-preset-trust.js'
@@ -348,6 +354,16 @@ export class SessionManager extends EventEmitter {
     maxMessages,
     maxHistory,
 
+    // #6764: opt-in semantic session titles. When enabled, the first user turn's
+    // auto-label is upgraded from a raw truncation to a short model-generated
+    // title via a cheap one-shot (Haiku) call, fired at most once per session and
+    // fully async (never blocks the turn). Wired from `isSemanticTitlesEnabled` /
+    // `resolveSemanticTitleModel` in server-cli. `titleRunOneShot` is a test seam
+    // that injects the model runner; production falls through to the SDK one-shot.
+    semanticTitlesEnabled = false,
+    semanticTitleModel = null,
+    titleRunOneShot = null,
+
     // #5859 (audit P1-7): opt-in boot-time sweep of orphaned chroxy session
     // worktrees (dirs under the worktree base whose session id is no longer
     // live). Off by default — server-cli enables it from config.worktreeGc.autoReap,
@@ -565,9 +581,27 @@ export class SessionManager extends EventEmitter {
     this._pendingStreams = this._history.pendingStreams
     this._historyTruncated = this._history._historyTruncated
 
-    // Wire auto_label events from history to session_updated emissions
-    this._history.on('auto_label', ({ sessionId, label }) => {
+    // #6764: semantic-title feature gate + one-shot model runner. When enabled,
+    // the truncation auto-label is asynchronously upgraded to a short model-
+    // generated title. `_titleRunOneShot` is the injectable seam (tests stub the
+    // model call); production uses the SDK one-shot shared with the #5547
+    // summarizer, so no Anthropic client / API key is hardcoded here.
+    this._semanticTitlesEnabled = semanticTitlesEnabled === true
+    this._semanticTitleModel = typeof semanticTitleModel === 'string' && semanticTitleModel
+      ? semanticTitleModel
+      : DEFAULT_SEMANTIC_TITLE_MODEL
+    // null → resolve the default SDK one-shot lazily on first use (see above).
+    this._titleRunOneShot = typeof titleRunOneShot === 'function' ? titleRunOneShot : null
+
+    // Wire auto_label events from history to session_updated emissions. The
+    // synchronous truncation label is broadcast immediately (never blocked), then
+    // — when the feature is on — an async cheap-model call may upgrade it to a
+    // semantic title (#6764). Firing off auto_label means the upgrade inherits the
+    // once-per-session + default-name + manual-rename guards already enforced by
+    // SessionMessageHistory._autoLabelSession.
+    this._history.on('auto_label', ({ sessionId, label, text }) => {
       this.emit('session_updated', { sessionId, name: label })
+      this._maybeGenerateSemanticTitle(sessionId, text, label)
     })
 
     // Internal state
@@ -1896,6 +1930,79 @@ export class SessionManager extends EventEmitter {
     // so a restart would show the pre-rename label.
     this._flushPersistOrWarn(sessionId, name)
     return true
+  }
+
+  /**
+   * #6764 — kick off the async semantic-title upgrade for a session that was
+   * just truncation-auto-labeled. Fire-and-forget: it MUST NOT block or delay the
+   * first turn, so it returns immediately after guarding + scheduling the model
+   * call. The once-per-session guard (`_semanticTitlePending`) is belt-and-braces
+   * — `auto_label` already fires at most once per session — so a reconnect or a
+   * second turn never re-triggers the call.
+   *
+   * @param {string} sessionId
+   * @param {string} firstMessage - the untruncated first user message.
+   * @param {string} fallbackLabel - the truncation label already applied.
+   */
+  _maybeGenerateSemanticTitle(sessionId, firstMessage, fallbackLabel) {
+    if (!this._semanticTitlesEnabled) return
+    const entry = this._sessions.get(sessionId)
+    if (!entry) return
+    if (entry._semanticTitlePending || entry._semanticTitleDone) return
+    if (typeof firstMessage !== 'string' || !firstMessage.trim()) return
+    entry._semanticTitlePending = true
+    // Detach from the caller (the auto_label handler / the first-turn record
+    // path). Errors are swallowed into a fallback inside generateSessionTitle;
+    // the .catch here only guards against an unexpected throw in the apply step.
+    this._generateSemanticTitle(sessionId, firstMessage, fallbackLabel).catch((err) => {
+      log.warn(`Semantic title generation failed for ${sessionId}: ${getErrorMessage(err, 'unknown error')}`)
+    })
+  }
+
+  /**
+   * #6764 — run the one-shot title call and, only if it yields a MODEL title,
+   * replace the truncation label and broadcast the update. The truncation label
+   * is already applied, so a truncation result here is a no-op. A manual rename
+   * that lands while the call is in flight is respected: if the session name has
+   * moved away from the truncation label we set, we leave it alone.
+   *
+   * @param {string} sessionId
+   * @param {string} firstMessage
+   * @param {string} fallbackLabel
+   */
+  async _generateSemanticTitle(sessionId, firstMessage, fallbackLabel) {
+    // Default runner is the SDK one-shot shared with the #5547 summarizer; loaded
+    // lazily so the SDK stays out of SessionManager's static import graph. Tests
+    // inject `titleRunOneShot`, short-circuiting the import entirely.
+    const runOneShot = this._titleRunOneShot
+      || (await import('./summarize-session.js')).defaultRunOneShot
+
+    const { title, source } = await generateSessionTitle({
+      firstUserMessage: firstMessage,
+      enabled: true,
+      model: this._semanticTitleModel,
+      cwd: this._sessions.get(sessionId)?.cwd,
+      runOneShot,
+      fallback: fallbackLabel,
+    })
+
+    // Only a model-generated title is worth replacing the truncation with.
+    if (source !== 'model' || typeof title !== 'string' || !title) return
+
+    const current = this._sessions.get(sessionId)
+    if (!current) return // session was destroyed while the call was in flight
+    current._semanticTitleDone = true
+    current._semanticTitlePending = false
+    // Respect a manual rename (or any other label change) that landed mid-flight:
+    // only upgrade when the name is still exactly the truncation we applied.
+    if (current.name !== fallbackLabel) return
+    if (current.name === title) return // identical — nothing to broadcast
+
+    current.name = title
+    current._autoLabeled = true
+    log.info(`Semantic-titled session ${sessionId} to "${title}"`)
+    this.emit('session_updated', { sessionId, name: title })
+    this._flushPersistOrWarn(sessionId, title)
   }
 
   /**

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 import { createLogger } from './logger.js'
+import { truncateTitle } from './session-title.js'
 
 const log = createLogger('session-message-history')
 const MAX_PENDING_STREAM_SIZE = 100 * 1024 * 1024 // 100MB
@@ -11,7 +12,9 @@ const MAX_PENDING_STREAM_SIZE = 100 * 1024 * 1024 // 100MB
  * Extracted from SessionManager to isolate history concerns.
  *
  * Events emitted:
- *   auto_label  { sessionId, label }  — when first user input triggers session rename
+ *   auto_label  { sessionId, label, text }  — when first user input triggers a
+ *     session rename. `label` is the truncation applied synchronously; `text` is
+ *     the untruncated first message (source for the #6764 semantic-title upgrade).
  */
 export class SessionMessageHistory extends EventEmitter {
   /**
@@ -443,7 +446,15 @@ export class SessionMessageHistory extends EventEmitter {
 
   /**
    * Auto-label a session from the first user input if it still has a default name.
-   * Truncates to ~40 chars at word boundary, appends "..." if truncated.
+   *
+   * Applies the word-boundary truncation label SYNCHRONOUSLY (via
+   * `truncateTitle`) so a session is never left unnamed — this is the always-
+   * available fallback. It also emits `auto_label` carrying the original first
+   * message `text`, so a listener (SessionManager, #6764) can optionally fire an
+   * asynchronous cheap-model call to UPGRADE the truncation to a short semantic
+   * title. Firing only from here means the semantic path inherits this method's
+   * once-per-session + default-name + manual-rename guards for free.
+   *
    * @param {string} sessionId
    * @param {string} text
    * @param {object} sessionEntry - Must have { name, _autoLabeled } properties
@@ -464,18 +475,12 @@ export class SessionMessageHistory extends EventEmitter {
 
     sessionEntry._autoLabeled = true
 
-    const MAX_LEN = 40
-    let label
-    if (trimmed.length <= MAX_LEN) {
-      label = trimmed
-    } else {
-      const cut = trimmed.lastIndexOf(' ', MAX_LEN)
-      label = (cut > 10 ? trimmed.slice(0, cut) : trimmed.slice(0, MAX_LEN)) + '...'
-    }
-
+    const label = truncateTitle(trimmed)
     sessionEntry.name = label
     log.info(`Auto-labeled session ${sessionId} to "${label}"`)
-    this.emit('auto_label', { sessionId, label })
+    // `text` is the untruncated first message — the semantic-title upgrade path
+    // needs the full source, not the already-truncated label.
+    this.emit('auto_label', { sessionId, label, text: trimmed })
   }
 
   /**

--- a/packages/server/src/session-title.js
+++ b/packages/server/src/session-title.js
@@ -25,6 +25,15 @@ export const TITLE_MODEL_MAX_LEN = 60
 // Default cheap model for the one-shot title call. The short alias resolves to
 // the latest Haiku (see claude-model-catalog.js), so it survives model bumps.
 export const DEFAULT_SEMANTIC_TITLE_MODEL = 'haiku'
+// Default timeout (ms) for the one-shot title call. The call is fire-and-forget,
+// so a stalled provider connection must never leave its promise pending forever:
+// the closure retains the SessionManager, the first message, and the sessionId,
+// so an un-timed-out call is an unbounded per-session leak for opted-in users, and
+// the underlying one-shot subprocess is never torn down. The caller passes
+// `AbortSignal.timeout(this)` as the `signal` so the call aborts (and the SDK
+// tears the subprocess down) and `generateSessionTitle` fails open to the
+// truncation label. Server-side only (Node's AbortSignal.timeout).
+export const DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS = 15_000
 
 /**
  * Word-boundary truncation used as the ALWAYS-available fallback label. Byte-for

--- a/packages/server/src/session-title.js
+++ b/packages/server/src/session-title.js
@@ -1,0 +1,159 @@
+/**
+ * #6764 — semantic session titles (pure logic).
+ *
+ * The sidebar's auto-generated session title has historically been the raw
+ * first user message truncated to ~40 chars at a word boundary. That is a
+ * copy of the prompt, not a summary — long or code-heavy first messages produce
+ * noisy, low-signal labels. This module produces a short, semantic title from a
+ * cheap one-shot model call instead, and ALWAYS falls back to the truncation
+ * behaviour when the feature is off, the call fails, or the model returns
+ * nothing usable.
+ *
+ * Everything here is PURE and dependency-free (no provider, no SDK import): the
+ * one-shot model runner is INJECTED (`runOneShot`) so the prompt/sanitise/gate
+ * logic is unit-testable without a live provider. Production wires
+ * `defaultRunOneShot` from summarize-session.js as the runner (reusing the same
+ * SDK one-shot + credential plumbing as the #5547 summarizer).
+ */
+
+// Truncation-fallback cap — matches the historical `_autoLabelSession` length so
+// the fallback label is byte-for-byte what the old behaviour produced.
+export const TITLE_MAX_LEN = 40
+// Cap for a model-generated title. A well-behaved Haiku reply is ~5-8 words; the
+// cap only bites when the model ignores instructions and returns prose.
+export const TITLE_MODEL_MAX_LEN = 60
+// Default cheap model for the one-shot title call. The short alias resolves to
+// the latest Haiku (see claude-model-catalog.js), so it survives model bumps.
+export const DEFAULT_SEMANTIC_TITLE_MODEL = 'haiku'
+
+/**
+ * Word-boundary truncation used as the ALWAYS-available fallback label. Byte-for
+ * -byte compatible with the pre-#6764 `_autoLabelSession` truncation.
+ *
+ * @param {string} text
+ * @param {number} [maxLen=TITLE_MAX_LEN]
+ * @returns {string} the label, or '' when the input has no usable text.
+ */
+export function truncateTitle(text, maxLen = TITLE_MAX_LEN) {
+  const trimmed = typeof text === 'string' ? text.trim() : ''
+  if (!trimmed) return ''
+  if (trimmed.length <= maxLen) return trimmed
+  const cut = trimmed.lastIndexOf(' ', maxLen)
+  return (cut > 10 ? trimmed.slice(0, cut) : trimmed.slice(0, maxLen)) + '...'
+}
+
+/**
+ * Clean a raw model reply into a usable one-line title. Models occasionally wrap
+ * the title in quotes, add a trailing period, prepend prose, or emit multiple
+ * lines — this strips all of that and returns '' when nothing usable remains
+ * (which the caller treats as "fall back to truncation").
+ *
+ * @param {string} raw
+ * @param {number} [maxLen=TITLE_MODEL_MAX_LEN]
+ * @returns {string} a cleaned title, or '' when unusable.
+ */
+export function sanitizeModelTitle(raw, maxLen = TITLE_MODEL_MAX_LEN) {
+  if (typeof raw !== 'string') return ''
+  // First non-empty line — models sometimes prepend a preamble or add newlines.
+  let line = ''
+  for (const l of raw.split('\n')) {
+    if (l.trim()) { line = l.trim(); break }
+  }
+  if (!line) return ''
+  // Strip surrounding quotes/backticks (straight or curly) the model wrapped it in.
+  line = line.replace(/^["'`“‘]+/, '').replace(/["'`”’]+$/, '').trim()
+  // Collapse internal whitespace runs to single spaces.
+  line = line.replace(/\s+/g, ' ')
+  // Drop a single trailing sentence period, but preserve a real ellipsis ('...').
+  line = line.replace(/(?<!\.)\.$/, '').trim()
+  if (!line) return ''
+  if (line.length <= maxLen) return line
+  const cut = line.lastIndexOf(' ', maxLen)
+  return (cut > 10 ? line.slice(0, cut) : line.slice(0, maxLen)) + '...'
+}
+
+/**
+ * Build the one-shot prompt asking for a short semantic title. The first user
+ * message is the primary signal; an optional first assistant response can be
+ * supplied for extra context. Both are length-capped so the call stays cheap
+ * even when the opening message is huge.
+ *
+ * @param {object} args
+ * @param {string} args.firstUserMessage
+ * @param {string} [args.firstAssistantResponse]
+ * @returns {string}
+ */
+export function buildTitlePrompt({ firstUserMessage, firstAssistantResponse } = {}) {
+  const parts = [
+    'Generate a short, specific title (5 to 8 words maximum) that summarizes what this coding session is about, based on the first message below.',
+    'Rules:',
+    '- Output ONLY the title text: no surrounding quotes, no trailing punctuation, no preamble, no explanation.',
+    '- Be concrete — name the actual task, file, feature, or bug. Avoid generic titles like "Help request" or "Coding question".',
+    '- Never exceed 8 words.',
+    '',
+    'First user message:',
+    String(firstUserMessage == null ? '' : firstUserMessage).slice(0, 4000),
+  ]
+  if (typeof firstAssistantResponse === 'string' && firstAssistantResponse.trim()) {
+    parts.push('', 'First assistant response (extra context):', firstAssistantResponse.slice(0, 2000))
+  }
+  parts.push('', 'Title:')
+  return parts.join('\n')
+}
+
+/**
+ * Produce a session title, gated + fail-open.
+ *
+ * Resolution order:
+ *   1. Feature off / no runner / no source text → truncation fallback.
+ *   2. Model call succeeds with usable text     → the sanitised semantic title.
+ *   3. Model call errors, times out, or returns
+ *      nothing usable                            → truncation fallback.
+ *
+ * The returned `source` lets the caller decide whether to broadcast an update
+ * (only a `'model'` title is worth replacing the already-applied truncation).
+ *
+ * @param {object} args
+ * @param {string} args.firstUserMessage
+ * @param {string} [args.firstAssistantResponse]
+ * @param {boolean} [args.enabled] - feature gate; false → truncation.
+ * @param {string} [args.model] - model id/alias for the one-shot.
+ * @param {string} [args.cwd] - working dir for the one-shot.
+ * @param {Function} [args.runOneShot] - injected model runner ({ prompt, model, cwd, signal }) => Promise<string>.
+ * @param {AbortSignal} [args.signal]
+ * @param {string} [args.fallback] - precomputed truncation label (else derived from firstUserMessage).
+ * @returns {Promise<{ title: string, source: 'model'|'truncation' }>}
+ */
+export async function generateSessionTitle({
+  firstUserMessage,
+  firstAssistantResponse,
+  enabled,
+  model,
+  cwd,
+  runOneShot,
+  signal,
+  fallback,
+} = {}) {
+  const fallbackTitle = typeof fallback === 'string' && fallback
+    ? fallback
+    : truncateTitle(firstUserMessage)
+  const truncated = { title: fallbackTitle, source: 'truncation' }
+
+  if (enabled !== true) return truncated
+  if (typeof runOneShot !== 'function') return truncated
+
+  const source = typeof firstUserMessage === 'string' ? firstUserMessage.trim() : ''
+  if (!source) return truncated
+
+  try {
+    const prompt = buildTitlePrompt({ firstUserMessage: source, firstAssistantResponse })
+    const raw = await runOneShot({ prompt, model, cwd, signal })
+    const clean = sanitizeModelTitle(raw)
+    if (clean) return { title: clean, source: 'model' }
+    return truncated
+  } catch {
+    // Fail open — a failed/timed-out title call must never leave a session
+    // unnamed; the truncation label is always good enough.
+    return truncated
+  }
+}

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import { writeFileSync, mkdtempSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { validateConfig, mergeConfig, readReposFromConfig, writeReposToConfig, sanitizeConfig, isFatalConfigWarning } from '../src/config.js'
+import { validateConfig, mergeConfig, readReposFromConfig, writeReposToConfig, sanitizeConfig, isFatalConfigWarning, resolveSemanticTitleTimeoutMs } from '../src/config.js'
+import { DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS } from '../src/session-title.js'
 
 // audit P1-9: fatality must come from the single isFatalConfigWarning policy,
 // and the wording convention (type=fatal, value=non-fatal) must hold — a typo
@@ -797,5 +798,43 @@ describe('sanitizeConfig', () => {
   it('handles empty config object', () => {
     const safe = sanitizeConfig({})
     assert.deepEqual(safe, {})
+  })
+})
+
+// #6764 / #6881 — timeout resolver for the fire-and-forget one-shot title call.
+describe('resolveSemanticTitleTimeoutMs', () => {
+  const ENV = 'CHROXY_SEMANTIC_TITLES_TIMEOUT_MS'
+  let saved
+  beforeEach(() => { saved = process.env[ENV]; delete process.env[ENV] })
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV]
+    else process.env[ENV] = saved
+  })
+
+  it('defaults when nothing is configured', () => {
+    assert.equal(resolveSemanticTitleTimeoutMs(undefined), DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS)
+    assert.equal(resolveSemanticTitleTimeoutMs({}), DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS)
+  })
+
+  it('reads a positive summarize.titleTimeoutMs override', () => {
+    assert.equal(resolveSemanticTitleTimeoutMs({ summarize: { titleTimeoutMs: 3000 } }), 3000)
+  })
+
+  it('ignores a non-positive / non-numeric config value and uses the default', () => {
+    assert.equal(resolveSemanticTitleTimeoutMs({ summarize: { titleTimeoutMs: 0 } }), DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS)
+    assert.equal(resolveSemanticTitleTimeoutMs({ summarize: { titleTimeoutMs: -5 } }), DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS)
+    assert.equal(resolveSemanticTitleTimeoutMs({ summarize: { titleTimeoutMs: 'nope' } }), DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS)
+  })
+
+  it('lets the env override win over config', () => {
+    process.env[ENV] = '5000'
+    assert.equal(resolveSemanticTitleTimeoutMs({ summarize: { titleTimeoutMs: 3000 } }), 5000)
+  })
+
+  it('ignores an invalid env value and falls through', () => {
+    process.env[ENV] = 'abc'
+    assert.equal(resolveSemanticTitleTimeoutMs({ summarize: { titleTimeoutMs: 3000 } }), 3000)
+    process.env[ENV] = '0'
+    assert.equal(resolveSemanticTitleTimeoutMs({}), DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS)
   })
 })

--- a/packages/server/tests/semantic-title.test.js
+++ b/packages/server/tests/semantic-title.test.js
@@ -1,0 +1,164 @@
+import { describe, it, beforeEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { EventEmitter } from 'events'
+import { SessionManager } from '../src/session-manager.js'
+
+/**
+ * #6764 — SessionManager wiring for semantic session titles. The model call is
+ * injected via the `titleRunOneShot` seam so no provider is needed.
+ *
+ * CRITICAL: every SessionManager MUST use a temp stateFilePath (#4633) or it
+ * clobbers the real ~/.chroxy/session-state.json.
+ */
+
+let _tmpDir
+function tmpStateFile() {
+  if (!_tmpDir) _tmpDir = mkdtempSync(join(tmpdir(), 'sm-semantic-title-'))
+  return join(_tmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_tmpDir) rmSync(_tmpDir, { recursive: true, force: true })
+})
+
+function makeMockSession() {
+  const s = new EventEmitter()
+  s.isRunning = false
+  s.destroy = () => {}
+  return s
+}
+
+// Drain the microtask + immediate queues so the fire-and-forget title chain
+// (recordUserInput → auto_label → _maybeGenerateSemanticTitle → async model
+// call → apply) completes before assertions run.
+async function flush() {
+  for (let i = 0; i < 4; i++) await new Promise((r) => setImmediate(r))
+}
+
+describe('SessionManager semantic titles (#6764)', () => {
+  it('upgrades the truncation label to a model title when enabled', async () => {
+    let calls = 0
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      titleRunOneShot: async () => { calls++; return 'Fix flaky reconnect test' },
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    const events = []
+    mgr.on('session_updated', (d) => events.push(d.name))
+
+    mgr.recordUserInput('s1', 'please help me fix the flaky WebSocket reconnect test in ws-server.js')
+
+    // Synchronous truncation label is applied + broadcast immediately.
+    assert.equal(events[0], 'please help me fix the flaky WebSocket...')
+
+    await flush()
+
+    assert.equal(calls, 1, 'model call fires exactly once')
+    assert.equal(mgr.getSession('s1').name, 'Fix flaky reconnect test')
+    assert.equal(events[events.length - 1], 'Fix flaky reconnect test')
+    assert.equal(mgr._sessions.get('s1')._semanticTitleDone, true)
+  })
+
+  it('does not call the model when the feature is disabled (default)', async () => {
+    let calls = 0
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      // semanticTitlesEnabled omitted → off
+      titleRunOneShot: async () => { calls++; return 'Should Not Happen' },
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    mgr.recordUserInput('s1', 'help me refactor the tunnel reconnect logic')
+    await flush()
+
+    assert.equal(calls, 0, 'model must not be called when disabled')
+    assert.equal(mgr.getSession('s1').name, 'help me refactor the tunnel reconnect...')
+  })
+
+  it('falls back to the truncation label when the model call fails', async () => {
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      titleRunOneShot: async () => { throw new Error('provider exploded') },
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    const modelNames = []
+    mgr.on('session_updated', (d) => modelNames.push(d.name))
+
+    mgr.recordUserInput('s1', 'help me refactor the tunnel reconnect logic in tunnel.js')
+    await flush()
+
+    // Name stays the truncation; no second (model) broadcast landed.
+    assert.equal(mgr.getSession('s1').name, 'help me refactor the tunnel reconnect...')
+    assert.equal(modelNames.length, 1, 'only the truncation update was broadcast')
+  })
+
+  it('only fires once per session (second turn does not re-trigger)', async () => {
+    let calls = 0
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      titleRunOneShot: async () => { calls++; return 'Auth Middleware Refactor' },
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    mgr.recordUserInput('s1', 'first message about refactoring the auth middleware layer')
+    await flush()
+    mgr.recordUserInput('s1', 'a second, unrelated follow-up message entirely')
+    await flush()
+
+    assert.equal(calls, 1, 'model call must not re-fire on later turns')
+    assert.equal(mgr.getSession('s1').name, 'Auth Middleware Refactor')
+  })
+
+  it('respects a manual rename that lands while the model call is in flight', async () => {
+    let resolveRun
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      titleRunOneShot: () => new Promise((res) => { resolveRun = res }),
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    mgr.recordUserInput('s1', 'help me with the flaky reconnect test in ws-server.js')
+    // The model call is now in flight (runOneShot invoked, awaiting resolveRun).
+    assert.equal(typeof resolveRun, 'function')
+
+    // User renames mid-flight.
+    mgr.renameSession('s1', 'My Manual Name')
+
+    // Model call now returns — the semantic title must NOT clobber the rename.
+    resolveRun('A Different Model Title')
+    await flush()
+
+    assert.equal(mgr.getSession('s1').name, 'My Manual Name')
+  })
+
+  it('does not upgrade custom-named sessions (no auto_label fires)', async () => {
+    let calls = 0
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      titleRunOneShot: async () => { calls++; return 'Nope' },
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'My Custom Session', cwd: '/tmp' })
+
+    mgr.recordUserInput('s1', 'some input text that would otherwise be a label')
+    await flush()
+
+    assert.equal(calls, 0)
+    assert.equal(mgr.getSession('s1').name, 'My Custom Session')
+  })
+})

--- a/packages/server/tests/semantic-title.test.js
+++ b/packages/server/tests/semantic-title.test.js
@@ -145,6 +145,54 @@ describe('SessionManager semantic titles (#6764)', () => {
     assert.equal(mgr.getSession('s1').name, 'My Manual Name')
   })
 
+  it('threads a non-undefined AbortSignal through to the model runner (#6881)', async () => {
+    // Regression for the #6881 blocking finding: _generateSemanticTitle must pass
+    // a real abort signal so a stalled one-shot can be torn down (and fail open)
+    // instead of leaking a never-settling promise.
+    let seen = 'UNSET'
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      titleRunOneShot: async (opts) => { seen = opts.signal; return 'Fix flaky reconnect test' },
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    mgr.recordUserInput('s1', 'please help me fix the flaky WebSocket reconnect test in ws-server.js')
+    await flush()
+
+    assert.ok(seen instanceof AbortSignal, 'a non-undefined AbortSignal is threaded to the runner')
+  })
+
+  it('falls back to the truncation label when the model call times out (#6881)', async () => {
+    // End-to-end proof that the timeout aborts a stalled runner and the session
+    // keeps its truncation label — no hang, no leaked pending promise.
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      stateFilePath: tmpStateFile(),
+      semanticTitlesEnabled: true,
+      semanticTitleTimeoutMs: 20,
+      // Mimic a stalled provider stream: the runner only settles by REJECTING when
+      // the injected signal aborts (i.e. on the timeout) — it never resolves itself.
+      titleRunOneShot: ({ signal }) => new Promise((_res, rej) => {
+        signal.addEventListener('abort', () => rej(new Error('aborted')), { once: true })
+      }),
+    })
+    mgr._sessions.set('s1', { session: makeMockSession(), name: 'Session 1', cwd: '/tmp' })
+
+    const names = []
+    mgr.on('session_updated', (d) => names.push(d.name))
+
+    mgr.recordUserInput('s1', 'help me refactor the tunnel reconnect logic in tunnel.js')
+    // Give the 20ms AbortSignal.timeout room to fire, then let the fail-open apply
+    // step settle.
+    await new Promise((r) => setTimeout(r, 80))
+    await flush()
+
+    assert.equal(mgr.getSession('s1').name, 'help me refactor the tunnel reconnect...')
+    assert.equal(names.length, 1, 'only the truncation update was broadcast — the model call timed out and failed open')
+  })
+
   it('does not upgrade custom-named sessions (no auto_label fires)', async () => {
     let calls = 0
     const mgr = new SessionManager({

--- a/packages/server/tests/session-title.test.js
+++ b/packages/server/tests/session-title.test.js
@@ -170,6 +170,46 @@ describe('generateSessionTitle', () => {
     assert.equal(res.title, truncateTitle('help me fix the flaky reconnect test'))
   })
 
+  it('fails open to truncation when the runner never resolves and the signal aborts (#6881)', async () => {
+    // Regression for the #6881 blocking finding: a stalled provider stream must
+    // not leave the call pending forever. The runner RESPECTS the injected signal
+    // — it only settles by rejecting on abort, never on its own — so determinism
+    // comes from the abort, not from racing a wall clock. Aborting the signal is
+    // exactly what production's AbortSignal.timeout(...) does when it fires; here
+    // we drive it synchronously so the test has no wall-clock dependence.
+    const msg = 'help me fix the flaky reconnect test in ws-server.js'
+    const controller = new AbortController()
+    const runOneShot = ({ signal }) => new Promise((_resolve, reject) => {
+      if (signal.aborted) { reject(new Error('aborted')); return }
+      signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+    })
+    // The runner is invoked synchronously inside generateSessionTitle (before its
+    // first await suspends), so the abort listener is registered by the time this
+    // returns the pending promise — aborting now deterministically rejects it.
+    const pending = generateSessionTitle({
+      firstUserMessage: msg,
+      enabled: true,
+      runOneShot,
+      signal: controller.signal,
+    })
+    controller.abort()
+    const res = await pending
+    assert.equal(res.source, 'truncation')
+    assert.equal(res.title, truncateTitle(msg))
+  })
+
+  it('threads the signal through to the runner (#6881)', async () => {
+    let seen = 'UNSET'
+    const { signal } = new AbortController()
+    await generateSessionTitle({
+      firstUserMessage: 'do a thing',
+      enabled: true,
+      runOneShot: async (args) => { seen = args.signal; return 'A Title' },
+      signal,
+    })
+    assert.ok(seen instanceof AbortSignal, 'the injected signal reaches the runner')
+  })
+
   it('uses the provided fallback label verbatim', async () => {
     const res = await generateSessionTitle({
       firstUserMessage: 'anything',

--- a/packages/server/tests/session-title.test.js
+++ b/packages/server/tests/session-title.test.js
@@ -1,0 +1,214 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  truncateTitle,
+  sanitizeModelTitle,
+  buildTitlePrompt,
+  generateSessionTitle,
+  TITLE_MAX_LEN,
+  DEFAULT_SEMANTIC_TITLE_MODEL,
+} from '../src/session-title.js'
+
+/**
+ * #6764 — unit tests for the pure semantic-title logic: the truncation fallback,
+ * model-reply sanitising, prompt assembly, and the gated/fail-open orchestration.
+ * The model call is injected (`runOneShot`) so no provider is needed.
+ */
+
+describe('truncateTitle', () => {
+  it('passes short text through unchanged', () => {
+    assert.equal(truncateTitle('Fix the bug'), 'Fix the bug')
+  })
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(truncateTitle('   Fix the bug   '), 'Fix the bug')
+  })
+
+  it('truncates long text at a word boundary with an ellipsis', () => {
+    const label = truncateTitle('Help me fix the authentication bug in login.ts right now')
+    assert.ok(label.length <= TITLE_MAX_LEN + 3, `expected <= ${TITLE_MAX_LEN + 3}, got ${label.length}`)
+    assert.ok(label.endsWith('...'))
+    assert.ok(!label.includes('...login'), 'should break before a partial word')
+  })
+
+  it('returns empty string for empty / non-string input', () => {
+    assert.equal(truncateTitle(''), '')
+    assert.equal(truncateTitle('   '), '')
+    assert.equal(truncateTitle(null), '')
+    assert.equal(truncateTitle(undefined), '')
+    assert.equal(truncateTitle(42), '')
+  })
+
+  it('matches the historical _autoLabelSession output (byte-for-byte fallback)', () => {
+    // The exact case asserted in auto-label.test.js.
+    assert.equal(
+      truncateTitle('Help me fix the authentication bug in login.ts'),
+      'Help me fix the authentication bug in...',
+    )
+  })
+})
+
+describe('sanitizeModelTitle', () => {
+  it('returns a clean title unchanged', () => {
+    assert.equal(sanitizeModelTitle('Fix flaky WebSocket reconnect test'), 'Fix flaky WebSocket reconnect test')
+  })
+
+  it('strips surrounding straight and curly quotes and backticks', () => {
+    assert.equal(sanitizeModelTitle('"Fix reconnect test"'), 'Fix reconnect test')
+    assert.equal(sanitizeModelTitle("'Fix reconnect test'"), 'Fix reconnect test')
+    assert.equal(sanitizeModelTitle('`Fix reconnect test`'), 'Fix reconnect test')
+    assert.equal(sanitizeModelTitle('“Fix reconnect test”'), 'Fix reconnect test')
+  })
+
+  it('drops a single trailing period but preserves a real ellipsis', () => {
+    assert.equal(sanitizeModelTitle('Refactor the auth middleware.'), 'Refactor the auth middleware')
+    assert.equal(sanitizeModelTitle('Refactor the auth...'), 'Refactor the auth...')
+  })
+
+  it('takes only the first non-empty line', () => {
+    assert.equal(sanitizeModelTitle('\n\nAdd retry to the tunnel\nHere is why: ...'), 'Add retry to the tunnel')
+  })
+
+  it('collapses internal whitespace runs', () => {
+    assert.equal(sanitizeModelTitle('Add   retry\tto  tunnel'), 'Add retry to tunnel')
+  })
+
+  it('word-boundary caps an over-long reply', () => {
+    const long = 'This is a rambling model reply that ignored the eight word instruction and just kept going forever'
+    const out = sanitizeModelTitle(long)
+    assert.ok(out.length <= 63, `expected <= 63, got ${out.length}`)
+    assert.ok(out.endsWith('...'))
+  })
+
+  it('returns empty string for unusable input', () => {
+    assert.equal(sanitizeModelTitle(''), '')
+    assert.equal(sanitizeModelTitle('   \n  '), '')
+    assert.equal(sanitizeModelTitle('""'), '')
+    assert.equal(sanitizeModelTitle(null), '')
+    assert.equal(sanitizeModelTitle(undefined), '')
+    assert.equal(sanitizeModelTitle(42), '')
+  })
+})
+
+describe('buildTitlePrompt', () => {
+  it('includes the first user message', () => {
+    const prompt = buildTitlePrompt({ firstUserMessage: 'refactor the auth middleware' })
+    assert.match(prompt, /refactor the auth middleware/)
+    assert.match(prompt, /Title:/)
+  })
+
+  it('includes the assistant response only when provided', () => {
+    const without = buildTitlePrompt({ firstUserMessage: 'hi' })
+    assert.ok(!without.includes('First assistant response'))
+    const withResp = buildTitlePrompt({ firstUserMessage: 'hi', firstAssistantResponse: 'planning the work' })
+    assert.match(withResp, /First assistant response/)
+    assert.match(withResp, /planning the work/)
+  })
+
+  it('caps a huge first message so the call stays cheap', () => {
+    const huge = 'x'.repeat(20000)
+    const prompt = buildTitlePrompt({ firstUserMessage: huge })
+    // The message segment is sliced to 4000 chars; the prompt is far under 20k.
+    assert.ok(prompt.length < 6000, `prompt should be capped, got ${prompt.length}`)
+  })
+
+  it('tolerates missing / non-string message', () => {
+    assert.doesNotThrow(() => buildTitlePrompt({}))
+    assert.doesNotThrow(() => buildTitlePrompt({ firstUserMessage: null }))
+  })
+})
+
+describe('generateSessionTitle', () => {
+  const good = async () => 'Fix flaky reconnect test'
+
+  it('returns the truncation fallback when disabled (no model call)', async () => {
+    let called = false
+    const runOneShot = async () => { called = true; return 'Model Title' }
+    const res = await generateSessionTitle({
+      firstUserMessage: 'please help me fix the flaky reconnect test in ws-server',
+      enabled: false,
+      runOneShot,
+    })
+    assert.equal(res.source, 'truncation')
+    assert.equal(called, false, 'model must not be called when disabled')
+    assert.equal(res.title, truncateTitle('please help me fix the flaky reconnect test in ws-server'))
+  })
+
+  it('returns the truncation fallback when no runner is provided', async () => {
+    const res = await generateSessionTitle({ firstUserMessage: 'fix the bug', enabled: true })
+    assert.equal(res.source, 'truncation')
+    assert.equal(res.title, 'fix the bug')
+  })
+
+  it('returns a sanitised model title on success', async () => {
+    const res = await generateSessionTitle({
+      firstUserMessage: 'help me fix the flaky reconnect test',
+      enabled: true,
+      runOneShot: async () => '"Fix flaky reconnect test."',
+    })
+    assert.equal(res.source, 'model')
+    assert.equal(res.title, 'Fix flaky reconnect test')
+  })
+
+  it('falls back to truncation when the model returns nothing usable', async () => {
+    const res = await generateSessionTitle({
+      firstUserMessage: 'help me fix the flaky reconnect test',
+      enabled: true,
+      runOneShot: async () => '   \n  ',
+    })
+    assert.equal(res.source, 'truncation')
+    assert.equal(res.title, truncateTitle('help me fix the flaky reconnect test'))
+  })
+
+  it('fails open to truncation when the model call throws', async () => {
+    const res = await generateSessionTitle({
+      firstUserMessage: 'help me fix the flaky reconnect test',
+      enabled: true,
+      runOneShot: async () => { throw new Error('provider exploded') },
+    })
+    assert.equal(res.source, 'truncation')
+    assert.equal(res.title, truncateTitle('help me fix the flaky reconnect test'))
+  })
+
+  it('uses the provided fallback label verbatim', async () => {
+    const res = await generateSessionTitle({
+      firstUserMessage: 'anything',
+      enabled: false,
+      fallback: 'Prebuilt Truncation',
+      runOneShot: good,
+    })
+    assert.equal(res.title, 'Prebuilt Truncation')
+    assert.equal(res.source, 'truncation')
+  })
+
+  it('falls back when the first message is blank even if enabled', async () => {
+    let called = false
+    const res = await generateSessionTitle({
+      firstUserMessage: '   ',
+      enabled: true,
+      fallback: 'the fallback',
+      runOneShot: async () => { called = true; return 'x' },
+    })
+    assert.equal(called, false)
+    assert.equal(res.source, 'truncation')
+    assert.equal(res.title, 'the fallback')
+  })
+
+  it('threads model + cwd through to the runner', async () => {
+    let seen = null
+    await generateSessionTitle({
+      firstUserMessage: 'do a thing',
+      enabled: true,
+      model: 'haiku',
+      cwd: '/tmp/work',
+      runOneShot: async (args) => { seen = args; return 'A Title' },
+    })
+    assert.equal(seen.model, 'haiku')
+    assert.equal(seen.cwd, '/tmp/work')
+    assert.ok(typeof seen.prompt === 'string' && seen.prompt.includes('do a thing'))
+  })
+
+  it('exposes a cheap default model constant', () => {
+    assert.equal(DEFAULT_SEMANTIC_TITLE_MODEL, 'haiku')
+  })
+})


### PR DESCRIPTION
## What & why

Closes #6764.

Chroxy's `_autoLabelSession` set a session's sidebar title to the **raw first user message truncated to ~40 chars** — a copy of the prompt, not a summary. Long / rambling / code-heavy first messages produced noisy, low-signal labels.

This adds an **opt-in, flag-gated, once-per-session Haiku one-shot** that upgrades that label to a short (~5-8 word) semantic title. It is **fully asynchronous** — the synchronous truncation label is applied and broadcast immediately (the first turn is never blocked or slowed), then a cheap model call may replace it. It **fails open**: when the feature is off, the model call errors/times out, or no model access is available, the existing truncation label is kept.

## How it works

- **`packages/server/src/session-title.js`** (new, pure, dependency-free):
  - `truncateTitle` — the always-available fallback (byte-for-byte the old truncation).
  - `sanitizeModelTitle` — strips quotes/backticks/trailing period, first-line-only, whitespace-collapse, length cap.
  - `buildTitlePrompt` — the Haiku prompt (first user message, optional first assistant response; length-capped so the call stays cheap).
  - `generateSessionTitle` — gated + fail-open orchestration over an **injected** one-shot runner (unit-testable without a provider). Returns `{ title, source: 'model' | 'truncation' }`.
- **`session-message-history.js`** — `_autoLabelSession` now reuses `truncateTitle` and carries the untruncated first message on the `auto_label` event.
- **`session-manager.js`** — on `auto_label`, fires a fire-and-forget one-shot title call. The default runner is the **SDK one-shot shared with the #5547 summarizer** (lazy-imported so the SDK stays out of SessionManager's static graph; **no hardcoded Anthropic client or API key**). Guards keep it once-per-session and **respect a manual rename that lands mid-flight**. The existing `_autoLabeled` / manual-rename precedence is unchanged.
- **`config.js`** — `features.semanticTitles` / `CHROXY_SEMANTIC_TITLES` gate (mirrors `features.ide`), plus a Haiku-default model resolver (`CHROXY_SEMANTIC_TITLES_MODEL` / `summarize.model` override).
- **`server-cli.js`** — wires the flag + model into `SessionManager`.
- **docs** — the flag is documented in the setup guide.

## Flag

- Config: `features.semanticTitles: true` in `~/.chroxy/config.json`
- Env: `CHROXY_SEMANTIC_TITLES=1` (force on) / `=0` (force off)
- Model override: `CHROXY_SEMANTIC_TITLES_MODEL=<id>` or `summarize.model`; defaults to the cheap `haiku` alias.
- **Off by default** — the historical truncation behavior is unchanged when disabled.

## Acceptance criteria

- [x] A new session's auto-generated title is a short model-generated summary (when enabled), not a raw truncation.
- [x] If the summarization call errors or times out, the session falls back to today's truncation label (never left unnamed).
- [x] Existing `_autoLabeled` / manual-rename precedence is unchanged.

## Testing

- New pure tests: `tests/session-title.test.js` (truncation, sanitize, prompt, gated/fail-open orchestration).
- New integration tests: `tests/semantic-title.test.js` (enabled → upgrade; disabled → no call; call fails → truncation fallback; once-per-session; manual-rename mid-flight respected; custom-named sessions untouched). All construct `SessionManager` with a temp `stateFilePath`.
- Ran the new suites + the touched-area suites (`auto-label`, `session-message-history`, `summarize-session`, `summarize-handlers`) — **130 pass, 0 fail**. Config + session-manager suites — **313 pass, 0 fail**.
- All `packages/server/scripts/lint-*.sh` pass; eslint clean on changed source files.