### PR TITLE
feat: editable Bash command + free-text deny reason on permission prompts (#6773)

### DIFF
--- a/packages/dashboard/src/components/PermissionCommandEdit.test.tsx
+++ b/packages/dashboard/src/components/PermissionCommandEdit.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * PermissionCommandEdit tests (#6773) — the editable Bash command field.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PermissionCommandEdit, isEditableCommandTool } from './PermissionCommandEdit'
+
+afterEach(() => cleanup())
+
+describe('isEditableCommandTool (#6773)', () => {
+  it('Bash is editable', () => {
+    expect(isEditableCommandTool('Bash')).toBe(true)
+  })
+  it('codex `shell` is NOT editable (codex owns command execution)', () => {
+    expect(isEditableCommandTool('shell')).toBe(false)
+  })
+  it('non-command tools are not editable', () => {
+    for (const t of ['Write', 'Edit', 'Read', 'Task', 'WebFetch']) {
+      expect(isEditableCommandTool(t)).toBe(false)
+    }
+  })
+})
+
+describe('PermissionCommandEdit (#6773)', () => {
+  it('renders the original command and emits null before any edit', () => {
+    const onChange = vi.fn()
+    render(<PermissionCommandEdit input={{ command: 'ls -a' }} onEditedInputChange={onChange} />)
+    expect(screen.getByTestId('perm-command-input')).toHaveValue('ls -a')
+    // The reset effect fires on mount → emits null (no edit yet).
+    expect(onChange).toHaveBeenLastCalledWith(null)
+  })
+
+  it('emits { command } when edited, and null again when reverted to the original', () => {
+    const onChange = vi.fn()
+    render(<PermissionCommandEdit input={{ command: 'ls' }} onEditedInputChange={onChange} />)
+    const editor = screen.getByTestId('perm-command-input')
+
+    fireEvent.change(editor, { target: { value: 'ls -la' } })
+    expect(onChange).toHaveBeenLastCalledWith({ command: 'ls -la' })
+    expect(screen.getByTestId('perm-command-edited-hint')).toBeInTheDocument()
+
+    fireEvent.change(editor, { target: { value: 'ls' } })
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(screen.queryByTestId('perm-command-edited-hint')).not.toBeInTheDocument()
+  })
+
+  it('tolerates a missing command field (renders empty, emits null)', () => {
+    const onChange = vi.fn()
+    render(<PermissionCommandEdit input={{}} onEditedInputChange={onChange} />)
+    expect(screen.getByTestId('perm-command-input')).toHaveValue('')
+    expect(onChange).toHaveBeenLastCalledWith(null)
+  })
+})

--- a/packages/dashboard/src/components/PermissionCommandEdit.tsx
+++ b/packages/dashboard/src/components/PermissionCommandEdit.tsx
@@ -35,7 +35,14 @@ export interface PermissionCommandEditProps {
 }
 
 export function PermissionCommandEdit({ input, onEditedInputChange }: PermissionCommandEditProps) {
-  const original = String(input.command ?? '')
+  // Guard against a malformed/unexpected `command` (e.g. an object or number) —
+  // `String(input.command ?? '')` would stringify it to "[object Object]" and
+  // seed the editor with a corrupted default. Only a genuine string is treated
+  // as editable content; anything else (missing or wrong-typed) degrades to the
+  // same empty-field fallback as no command at all (matches the `typeof x ===
+  // 'string' ? x : fallback` guard used elsewhere in this codebase, e.g.
+  // ChildAgentEventList.tsx).
+  const original = typeof input.command === 'string' ? input.command : ''
   const [value, setValue] = useState(original)
 
   // Reset when a new prompt/command arrives, and clear any pending edit.

--- a/packages/dashboard/src/components/PermissionCommandEdit.tsx
+++ b/packages/dashboard/src/components/PermissionCommandEdit.tsx
@@ -1,0 +1,78 @@
+/**
+ * PermissionCommandEdit (#6773) — the editable command field rendered inside a
+ * Bash permission prompt. Unlike the per-hunk Write/Edit review
+ * (PreWriteDiffReview), a shell command is a single string, so this is a plain
+ * editable textarea rather than diff machinery.
+ *
+ * It hands the edited command back as an `editedInput = { command }` the prompt
+ * sends on Approve — but ONLY when the operator actually changed it (emits `null`
+ * when the text is untouched, so a plain Allow runs the original command and we
+ * never round-trip a redacted-pull command the operator didn't intend to edit).
+ *
+ * The server-side merge whitelist (permission-manager.js EDITABLE_INPUT_FIELDS,
+ * `Bash: ['command']`) is the enforcement point: only `command` is substitutable,
+ * and Bash carries no path field, so an edit changes WHAT runs but can't redirect
+ * a write. Codex `shell` is deliberately NOT editable (codex owns command
+ * execution and ignores updatedInput) — see isEditableCommandTool.
+ */
+import { useEffect, useState } from 'react'
+
+type ToolInput = Record<string, unknown>
+
+/**
+ * Whether a tool exposes an editable single-line command field. Bash only — the
+ * SDK/BYOK executor honours the merged `updatedInput`. Codex `shell` is excluded
+ * (it re-runs its own already-parsed command regardless of updatedInput).
+ */
+export function isEditableCommandTool(tool: string): boolean {
+  return tool === 'Bash'
+}
+
+export interface PermissionCommandEditProps {
+  input: ToolInput
+  /** Called with `{ command }` when edited, or `null` when unchanged. */
+  onEditedInputChange: (editedInput: Record<string, string> | null) => void
+}
+
+export function PermissionCommandEdit({ input, onEditedInputChange }: PermissionCommandEditProps) {
+  const original = String(input.command ?? '')
+  const [value, setValue] = useState(original)
+
+  // Reset when a new prompt/command arrives, and clear any pending edit.
+  useEffect(() => {
+    setValue(original)
+    onEditedInputChange(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [original])
+
+  function onChange(next: string) {
+    setValue(next)
+    // Emit only a genuine edit — an untouched command is a plain Allow (null),
+    // so we never re-send the (redacted) pulled command the operator didn't edit.
+    onEditedInputChange(next === original ? null : { command: next })
+  }
+
+  const edited = value !== original
+  return (
+    <div className="perm-command-edit" data-testid="perm-command-edit">
+      <label className="perm-command-edit-label" htmlFor="perm-command-input">
+        Edit the command before running (optional):
+      </label>
+      <textarea
+        id="perm-command-input"
+        className="perm-command-edit-input"
+        data-testid="perm-command-input"
+        value={value}
+        rows={2}
+        spellCheck={false}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Editable shell command"
+      />
+      {edited && (
+        <div className="perm-command-edit-hint" data-testid="perm-command-edited-hint">
+          Command edited — Approve runs the modified command.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -55,6 +55,9 @@ vi.mock('../store/connection', () => ({
     if (!provider) return false
     return available.find((p) => p.name === provider)?.capabilities?.sessionRules === true
   },
+  // #6773 — mirrors the real store's wire ceiling for the deny-reason textarea's
+  // `maxLength` (protocol's `PermissionResponseSchema.reason: z.string().max(2000)`).
+  DENY_REASON_MAX_LENGTH: 2000,
 }))
 
 afterEach(() => {

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -21,6 +21,11 @@ type MockStore = {
   sessions: { sessionId: string; provider?: string }[]
   availableProviders: { name: string; capabilities?: { sessionRules?: boolean } }[]
   connectionPhase: string
+  // #6773 — the command-edit + write-review affordances read these; default
+  // undefined (ide off) so existing tests render neither and stay unchanged.
+  serverCapabilities?: { ide?: boolean }
+  permissionInputs?: Record<string, { found: boolean; input?: Record<string, unknown> }>
+  requestPermissionInput?: (requestId: string) => void
 }
 const DEFAULT_MOCK_STORE: MockStore = {
   resolvedPermissions: {},
@@ -926,5 +931,80 @@ describe('PermissionPrompt — keyboard shortcut hints (#2840)', () => {
     act(() => { vi.advanceTimersByTime(3000) })
     expect(screen.queryByTestId('perm-shortcut-hints')).not.toBeInTheDocument()
     vi.useRealTimers()
+  })
+})
+
+// #6773 — free-text deny reason + editable Bash command before approve.
+describe('PermissionPrompt — deny reason + command edit (#6773)', () => {
+  it('renders an optional deny-reason field while the prompt is actionable', () => {
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={vi.fn()} />
+    )
+    expect(screen.getByTestId('perm-deny-reason')).toBeInTheDocument()
+  })
+
+  it('Deny with a typed reason threads the trimmed reason to onRespond', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={onRespond} />
+    )
+    fireEvent.change(screen.getByTestId('perm-deny-reason'), { target: { value: '  run it read-only  ' } })
+    fireEvent.click(screen.getByText('Deny'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny', null, 'run it read-only')
+  })
+
+  it('Deny with a blank reason omits the reason (server falls back to default)', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={onRespond} />
+    )
+    fireEvent.change(screen.getByTestId('perm-deny-reason'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByText('Deny'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny', null)
+  })
+
+  it('Allow never carries a deny reason even when text is present', () => {
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={onRespond} />
+    )
+    fireEvent.change(screen.getByTestId('perm-deny-reason'), { target: { value: 'nope' } })
+    fireEvent.click(screen.getByText('Allow'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', null)
+  })
+
+  it('does NOT show the Bash command editor when features.ide is off', () => {
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={vi.fn()} />
+    )
+    expect(screen.queryByTestId('perm-command-edit')).not.toBeInTheDocument()
+  })
+
+  it('shows the Bash command editor (features.ide on) and sends an edited command on Allow', () => {
+    mockStoreState.serverCapabilities = { ide: true }
+    mockStoreState.requestPermissionInput = vi.fn()
+    mockStoreState.permissionInputs = { 'req-1': { found: true, input: { command: 'ls' } } }
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={onRespond} />
+    )
+    const editor = screen.getByTestId('perm-command-input')
+    expect(editor).toBeInTheDocument()
+    fireEvent.change(editor, { target: { value: 'ls -la' } })
+    expect(screen.getByTestId('perm-command-edited-hint')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Allow'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', { command: 'ls -la' })
+  })
+
+  it('an untouched Bash command sends a plain Allow (no editedInput)', () => {
+    mockStoreState.serverCapabilities = { ide: true }
+    mockStoreState.requestPermissionInput = vi.fn()
+    mockStoreState.permissionInputs = { 'req-1': { found: true, input: { command: 'ls' } } }
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={2000} onRespond={onRespond} />
+    )
+    fireEvent.click(screen.getByText('Allow'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', null)
   })
 })

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -19,7 +19,7 @@
  * fire onRespond twice before the store's answered state catches up.
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider } from '../store/connection'
+import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider, DENY_REASON_MAX_LENGTH } from '../store/connection'
 import type { PermissionDecision } from '../store/types'
 import { isMacPlatform } from '../utils/platform'
 import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
@@ -282,6 +282,7 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
             data-testid="perm-deny-reason"
             value={denyReason}
             rows={2}
+            maxLength={DENY_REASON_MAX_LENGTH}
             placeholder="Optional: tell the agent what to do differently (sent with Deny)"
             aria-label="Deny reason (optional)"
             onChange={(e) => setDenyReason(e.target.value)}

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -23,6 +23,7 @@ import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider } from '
 import type { PermissionDecision } from '../store/types'
 import { isMacPlatform } from '../utils/platform'
 import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
+import { PermissionCommandEdit, isEditableCommandTool } from './PermissionCommandEdit'
 
 export interface PermissionPromptProps {
   requestId: string
@@ -30,11 +31,13 @@ export interface PermissionPromptProps {
   description: string
   remainingMs: number
   /**
-   * #6543 (feature B): `editedInput` carries the operator's per-hunk narrowing
-   * for an approve (omitted for a plain Allow / a Deny). The server whitelists
-   * which fields it merges.
+   * #6543 (feature B): `editedInput` carries the operator's per-hunk narrowing /
+   * edited Bash command for an approve (omitted for a plain Allow / a Deny). The
+   * server whitelists which fields it merges.
+   * #6773: `reason` carries the operator's free-text deny note (only on a Deny) —
+   * the server feeds it back to the agent as the denial message.
    */
-  onRespond: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null) => void
+  onRespond: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null, reason?: string) => void
   /**
    * #5667 — human label for the session that asked (e.g. "ltl · CLI"),
    * derived by the renderer from the message's `originSessionId`. Rendered as
@@ -105,14 +108,20 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   const requestPermissionInput = useConnectionStore((s) => s.requestPermissionInput)
   const pulledInput = useConnectionStore((s) => s.permissionInputs?.[requestId])
   const reviewEligible = ideEnabled && isReviewableTool(tool)
+  // #6773 — Bash command edit reuses the same features.ide gate + full-input pull
+  // as the Write/Edit review (the broadcast command is truncated to 200 chars).
+  const commandEditEligible = ideEnabled && isEditableCommandTool(tool)
   const [editedInput, setEditedInput] = useState<Record<string, string> | null>(null)
+  // #6773 — free-text deny reason (tool-agnostic, NOT ide-gated). Sent only on Deny.
+  const [denyReason, setDenyReason] = useState('')
 
-  // Pull the input once when a reviewable prompt appears (before it's answered).
+  // Pull the input once when a reviewable / command-edit prompt appears (before
+  // it's answered) — both need the full untruncated (still redacted) tool input.
   useEffect(() => {
-    if (reviewEligible && !answered && pulledInput === undefined) {
+    if ((reviewEligible || commandEditEligible) && !answered && pulledInput === undefined) {
       requestPermissionInput(requestId)
     }
-  }, [reviewEligible, answered, pulledInput, requestPermissionInput, requestId])
+  }, [reviewEligible, commandEditEligible, answered, pulledInput, requestPermissionInput, requestId])
 
   useEffect(() => {
     if (intervalRef.current) clearInterval(intervalRef.current)
@@ -161,9 +170,18 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
     const effective: PermissionDecision =
       (decision === 'allowSession' || decision === 'allowAlways') && !ruleOk ? 'allow' : decision
     if (intervalRef.current) clearInterval(intervalRef.current)
-    // #6543: carry the per-hunk edits on an approve only (never on deny).
-    onRespond(requestId, effective, effective === 'deny' ? null : editedInput)
-  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules, connected, editedInput])
+    // #6543: carry the per-hunk / command edits on an approve only (never on deny).
+    // #6773: carry the free-text deny reason on a deny only (trimmed; the reason
+    // arg is passed ONLY when non-blank so a plain deny keeps the 3-arg call shape
+    // and the server falls back to its default 'User denied').
+    const isDeny = effective === 'deny'
+    const trimmedReason = denyReason.trim()
+    if (isDeny && trimmedReason.length > 0) {
+      onRespond(requestId, effective, null, trimmedReason)
+    } else {
+      onRespond(requestId, effective, isDeny ? null : editedInput)
+    }
+  }, [requestId, onRespond, answered, remaining, tool, providerSupportsRules, connected, editedInput, denyReason])
 
   // #6287 — the Cmd/Ctrl+Y, Cmd/Ctrl+Shift+Y and Escape keyboard shortcuts moved
   // to a SINGLE document-level listener (useChatKeyboard, wired in App.tsx) that
@@ -226,6 +244,16 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
         />
       )}
 
+      {/* #6773: editable Bash command before Approve (features.ide on). Renders
+          once the full input lands; a genuine edit becomes `editedInput` on
+          Approve. A refusal / not-yet-pulled state simply shows no editor. */}
+      {commandEditEligible && showButtons && pulledInput?.found && pulledInput.input && (
+        <PermissionCommandEdit
+          input={pulledInput.input as Record<string, unknown>}
+          onEditedInputChange={setEditedInput}
+        />
+      )}
+
       {!answered && (
         <div
           className={`perm-countdown${isUrgent ? ' urgent' : ''}${isExpired ? ' expired' : ''}`}
@@ -244,6 +272,21 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
 
       {showButtons && (
         <>
+          {/* #6773: optional free-text deny reason (tool-agnostic). When the
+              operator types here and clicks Deny, the note is fed back to the
+              agent as the denial message so it can adjust without a fresh turn
+              (desktop-app "tell Claude what to do differently" parity). Ignored
+              on Allow. */}
+          <textarea
+            className="perm-deny-reason"
+            data-testid="perm-deny-reason"
+            value={denyReason}
+            rows={2}
+            placeholder="Optional: tell the agent what to do differently (sent with Deny)"
+            aria-label="Deny reason (optional)"
+            onChange={(e) => setDenyReason(e.target.value)}
+            disabled={submitting || !connected}
+          />
           <div className="perm-buttons">
             <button
               className="btn-allow"

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -126,7 +126,7 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
           tool={storeMsg.tool || 'Unknown'}
           description={storeMsg.content}
           remainingMs={remainingMs}
-          onRespond={(reqId, decision, editedInput) => sendPermissionResponse(reqId, decision, editedInput)}
+          onRespond={(reqId, decision, editedInput, reason) => sendPermissionResponse(reqId, decision, editedInput, reason)}
           sessionLabel={buildSessionLabel(storeMsg.originSessionId, sessions)}
         />
       )

--- a/packages/dashboard/src/store/connection-send-fail-closed.test.ts
+++ b/packages/dashboard/src/store/connection-send-fail-closed.test.ts
@@ -217,6 +217,34 @@ describe('#6308 — dashboard sendPermissionResponse', () => {
     useConnectionStore.getState().sendPermissionResponse('req-1', 'deny', { content: 'x' }) // deny drops it
     expect(last().editedInput).toBeUndefined()
   })
+
+  it('#6773: a deny carries a trimmed reason on the wire; allow / blank omit it', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: unknown[] = []
+    const socket = liveSocket(sent)
+    useConnectionStore.setState({
+      activeSessionId: 'sess-1',
+      sessionStates: {
+        'sess-1': {
+          ...createEmptySessionState(),
+          messages: [{ id: 'p1', type: 'prompt', requestId: 'req-1', tool: 'Bash', timestamp: 1 }],
+        } as unknown as SessionState,
+      },
+      sessionNotifications: [],
+      socket,
+    } as never)
+    const last = () => sent[sent.length - 1] as { decision?: string; reason?: unknown }
+
+    useConnectionStore.getState().sendPermissionResponse('req-1', 'deny', null, '  use rg  ')
+    expect(last().decision).toBe('deny')
+    expect(last().reason).toBe('use rg') // trimmed
+
+    useConnectionStore.getState().sendPermissionResponse('req-1', 'deny', null, '   ') // blank → omitted
+    expect(last().reason).toBeUndefined()
+
+    useConnectionStore.getState().sendPermissionResponse('req-1', 'allow', null, 'ignored on allow')
+    expect(last().reason).toBeUndefined() // reason never rides an allow
+  })
 })
 
 describe('#6308 — dashboard sendInterrupt / sendUserQuestionResponse', () => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -302,6 +302,16 @@ export function capResolvedPermissions<T>(
   return next;
 }
 
+/**
+ * Wire ceiling for a permission response's free-text deny `reason` (#6773).
+ * Mirrors the protocol schema (`PermissionResponseSchema.reason: z.string().max(2000)`,
+ * packages/protocol/src/schemas/client.ts) and the server's `MAX_DENY_REASON_LEN`
+ * (permission-manager.js `buildDenyMessage`). Exported so PermissionPrompt.tsx can cap
+ * the textarea's `maxLength` to match — without a client-side bound an over-long
+ * reason would be silently rejected by the wire schema, dropping the operator's deny.
+ */
+export const DENY_REASON_MAX_LENGTH = 2000;
+
 /** Read a simple string setting from localStorage with fallback */
 function loadPersistedSetting(key: string, fallback: string): string {
   try {
@@ -3231,12 +3241,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // mergeEditedInput).
     // #6773: a free-text deny reason rides along on a deny only — the server
     // bounds + redacts it and feeds it back to the agent as the denial message.
+    // Bounded here too (DENY_REASON_MAX_LENGTH, mirrors the server's
+    // MAX_DENY_REASON_LEN / the wire schema's `.max(2000)`) so an over-long
+    // reason can't be silently rejected by the wire schema and drop the deny.
+    const trimmedReason = typeof reason === 'string' ? reason.trim().slice(0, DENY_REASON_MAX_LENGTH) : '';
     const payload = {
       type: 'permission_response',
       requestId,
       decision: wireDecision,
       ...(editedInput && Object.keys(editedInput).length > 0 && wireDecision !== 'deny' ? { editedInput } : {}),
-      ...(wireDecision === 'deny' && typeof reason === 'string' && reason.trim().length > 0 ? { reason: reason.trim() } : {}),
+      ...(wireDecision === 'deny' && trimmedReason.length > 0 ? { reason: trimmedReason } : {}),
     };
     // #6308: the socket can flip OPEN → CLOSING before this synchronous send (wsSend
     // → false). Bail BEFORE markPermissionResolved/markPromptAnswered — otherwise the

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -3203,7 +3203,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     });
   },
 
-  sendPermissionResponse: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null) => {
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null, reason?: string) => {
     const { socket } = get();
     // #5699 — refuse to answer a permission prompt while disconnected. A
     // permission request is NOT safely queueable: the server expires the pending
@@ -3225,14 +3225,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // per-project rule (permission-manager.js), no follow-up needed. (The schema
     // accepts 'allow' | 'allowAlways' | 'deny'.)
     const wireDecision = decision === 'allowSession' ? 'allow' : decision;
-    // #6543 (feature B): the operator's per-hunk edits ride along on an approve.
-    // Only sent when present (a plain Allow omits it); the server whitelists
-    // which fields it can substitute (permission-manager.js mergeEditedInput).
+    // #6543 (feature B): the operator's per-hunk / command edits ride along on an
+    // approve. Only sent when present (a plain Allow omits it); the server
+    // whitelists which fields it can substitute (permission-manager.js
+    // mergeEditedInput).
+    // #6773: a free-text deny reason rides along on a deny only — the server
+    // bounds + redacts it and feeds it back to the agent as the denial message.
     const payload = {
       type: 'permission_response',
       requestId,
       decision: wireDecision,
       ...(editedInput && Object.keys(editedInput).length > 0 && wireDecision !== 'deny' ? { editedInput } : {}),
+      ...(wireDecision === 'deny' && typeof reason === 'string' && reason.trim().length > 0 ? { reason: reason.trim() } : {}),
     };
     // #6308: the socket can flip OPEN → CLOSING before this synchronous send (wsSend
     // → false). Bail BEFORE markPermissionResolved/markPromptAnswered — otherwise the

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1486,7 +1486,7 @@ export interface ConnectionState {
    * payload, or rejects on disconnect / 60s timeout. Errors from the server
    * arrive as the `error` field on the resolved value, not as a Promise reject. */
   evaluateDraft: (draft: string) => Promise<EvaluatorResultPayload>;
-  sendPermissionResponse: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null) => 'sent' | 'queued' | false;
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision, editedInput?: Record<string, string> | null, reason?: string) => 'sent' | 'queued' | false;
   /** Mark a permission request as resolved in the store (separate from the
    * wire-level response). Used by PermissionPrompt to render its answered
    * state across remounts (#2833). Safe to call for an already-resolved

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3998,6 +3998,57 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-orange);
 }
 
+/* #6773: editable Bash command before Approve. Mirrors the prewrite review's
+ * bordered card; the textarea is monospace so a shell command reads clearly. */
+.perm-command-edit {
+  margin: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.perm-command-edit-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.perm-command-edit-input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  padding: 6px 8px;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+}
+
+.perm-command-edit-hint {
+  font-size: var(--text-sm);
+  color: var(--accent-orange);
+}
+
+/* #6773: optional free-text deny reason fed back to the agent on Deny. */
+.perm-deny-reason {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  margin: 8px 0 4px;
+  padding: 6px 8px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+}
+
+.perm-deny-reason:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .perm-buttons {
   display: flex;
   gap: 8px;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -305,6 +305,7 @@ export declare const PermissionResponseSchema: z.ZodObject<{
         allowAlways: "allowAlways";
     }>;
     editedInput: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+    reason: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const GetPermissionInputSchema: z.ZodObject<{
     type: z.ZodLiteral<"get_permission_input">;
@@ -1066,6 +1067,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         allowAlways: "allowAlways";
     }>;
     editedInput: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+    reason: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"get_permission_input">;
     requestId: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -396,15 +396,24 @@ export const PermissionResponseSchema = z.object({
     type: z.literal('permission_response'),
     requestId: z.string().min(1).max(256),
     decision: z.enum(['allow', 'allowAlways', 'deny']),
-    // #6543 (IDE P3 feature B): optional per-hunk-review edits for an `allow` —
-    // a client that reviewed the agent's proposed Write/Edit and dropped some
-    // hunks sends the reduced CONTENT here. The server merges ONLY the whitelisted
-    // content field(s) per tool (Write→content, Edit→new_string) and NEVER the
-    // path/anchor fields, so an edit can narrow the write but can't redirect where
-    // it lands. Ignored on deny, and for tools with no editable content field. A
-    // loose object — the server-side whitelist (permission-manager.js) is the
-    // enforcement point.
+    // #6543 (IDE P3 feature B) / #6773: optional per-hunk-review or command edits
+    // for an `allow` — a client that reviewed the agent's proposed Write/Edit and
+    // dropped some hunks sends the reduced CONTENT here; a client that tweaked a
+    // Bash command before approving sends the edited `command`. The server merges
+    // ONLY the whitelisted content field(s) per tool (Write→content, Edit→new_string,
+    // Bash→command) and NEVER the path/anchor fields, so an edit can narrow the
+    // write (or change what runs) but can't redirect where a write lands. Ignored
+    // on deny, and for tools with no editable content field. A loose object — the
+    // server-side whitelist (permission-manager.js) is the enforcement point.
     editedInput: z.record(z.string(), z.unknown()).optional(),
+    // #6773: optional free-text DENY REASON. Fed back to the agent as the tool
+    // result's denial message (permission-manager.js buildDenyMessage) instead of
+    // the fixed 'User denied' string, so the operator can steer the model's next
+    // attempt without typing a whole new turn (desktop-app "tell Claude what to do
+    // differently" parity). Ignored on allow. Bounded here at the wire ceiling; the
+    // server re-caps and redacts it (like every other freeform field) before it
+    // reaches the agent / the streamed tool result.
+    reason: z.string().max(2000).optional(),
 });
 // #6543 (IDE P3 feature B): pull the FULL secret-redacted tool input for a
 // pending permission, so a client can build a per-hunk pre-write diff. The

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -443,15 +443,24 @@ export const PermissionResponseSchema = z.object({
   type: z.literal('permission_response'),
   requestId: z.string().min(1).max(256),
   decision: z.enum(['allow', 'allowAlways', 'deny']),
-  // #6543 (IDE P3 feature B): optional per-hunk-review edits for an `allow` —
-  // a client that reviewed the agent's proposed Write/Edit and dropped some
-  // hunks sends the reduced CONTENT here. The server merges ONLY the whitelisted
-  // content field(s) per tool (Write→content, Edit→new_string) and NEVER the
-  // path/anchor fields, so an edit can narrow the write but can't redirect where
-  // it lands. Ignored on deny, and for tools with no editable content field. A
-  // loose object — the server-side whitelist (permission-manager.js) is the
-  // enforcement point.
+  // #6543 (IDE P3 feature B) / #6773: optional per-hunk-review or command edits
+  // for an `allow` — a client that reviewed the agent's proposed Write/Edit and
+  // dropped some hunks sends the reduced CONTENT here; a client that tweaked a
+  // Bash command before approving sends the edited `command`. The server merges
+  // ONLY the whitelisted content field(s) per tool (Write→content, Edit→new_string,
+  // Bash→command) and NEVER the path/anchor fields, so an edit can narrow the
+  // write (or change what runs) but can't redirect where a write lands. Ignored
+  // on deny, and for tools with no editable content field. A loose object — the
+  // server-side whitelist (permission-manager.js) is the enforcement point.
   editedInput: z.record(z.string(), z.unknown()).optional(),
+  // #6773: optional free-text DENY REASON. Fed back to the agent as the tool
+  // result's denial message (permission-manager.js buildDenyMessage) instead of
+  // the fixed 'User denied' string, so the operator can steer the model's next
+  // attempt without typing a whole new turn (desktop-app "tell Claude what to do
+  // differently" parity). Ignored on allow. Bounded here at the wire ceiling; the
+  // server re-caps and redacts it (like every other freeform field) before it
+  // reaches the agent / the streamed tool result.
+  reason: z.string().max(2000).optional(),
 })
 
 // #6543 (IDE P3 feature B): pull the FULL secret-redacted tool input for a

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -35,6 +35,32 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!result.success, 'Should reject data over 100k chars')
   })
 
+  // #6543 / #6773 — permission_response carries an optional editedInput (per-hunk /
+  // command edit) and an optional free-text deny reason.
+  it('validates permission_response with editedInput and reason (#6773)', async () => {
+    const { PermissionResponseSchema } = await import('../src/schemas/client.ts')
+    const bare = PermissionResponseSchema.safeParse({ type: 'permission_response', requestId: 'r1', decision: 'deny' })
+    assert.ok(bare.success, 'bare allow/deny should validate (both fields optional)')
+
+    const withReason = PermissionResponseSchema.safeParse({
+      type: 'permission_response', requestId: 'r1', decision: 'deny', reason: 'run it read-only instead',
+    })
+    assert.ok(withReason.success, 'deny with a reason should validate')
+
+    const withEdit = PermissionResponseSchema.safeParse({
+      type: 'permission_response', requestId: 'r1', decision: 'allow', editedInput: { command: 'ls -la' },
+    })
+    assert.ok(withEdit.success, 'allow with an edited command should validate')
+  })
+
+  it('rejects a permission_response reason over the wire cap (#6773)', async () => {
+    const { PermissionResponseSchema } = await import('../src/schemas/client.ts')
+    const result = PermissionResponseSchema.safeParse({
+      type: 'permission_response', requestId: 'r1', decision: 'deny', reason: 'x'.repeat(2001),
+    })
+    assert.ok(!result.success, 'reason over 2000 chars must be rejected')
+  })
+
   // Swarm-audit (W2): bound the client auth collections so an adversarial auth
   // can't DoS the server (capabilities is `new Set()`-iterated server-side).
   it('degrades an oversized / over-long capabilities array to [] (no DoS, no reject)', async () => {

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -2109,7 +2109,7 @@ export class ClaudeByokSession extends BaseSession {
    * PermissionManager which resolves the pending Promise in
    * handlePermission() above.
    */
-  respondToPermission(requestId, decision, editedInput) {
+  respondToPermission(requestId, decision, editedInput, reason) {
     // #5056: if this requestId belongs to a Task subagent (its pending
     // entry lives in the CHILD's PermissionManager, not ours), forward
     // the decision to that child. ws-permissions only ever calls the
@@ -2126,9 +2126,10 @@ export class ClaudeByokSession extends BaseSession {
       // here too is idempotent and closes the lifetime tightly.
       this._subagentPermissionRouting.delete(requestId)
       // #6543: forward the operator's per-hunk editedInput to the child too.
-      return child.respondToPermission(requestId, decision, editedInput)
+      // #6773: the deny `reason` forwards to the child as well.
+      return child.respondToPermission(requestId, decision, editedInput, reason)
     }
-    return this._permissions.respondToPermission(requestId, decision, editedInput)
+    return this._permissions.respondToPermission(requestId, decision, editedInput, reason)
   }
 
   /**

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -937,8 +937,8 @@ export class CodexAppServerSession extends BaseSession {
 
   // In-process permission responses (capabilities.inProcessPermissions) — thin
   // delegators to the PermissionManager, mirroring SdkSession.
-  respondToPermission(requestId, decision, editedInput) {
-    return this._permissions.respondToPermission(requestId, decision, editedInput)
+  respondToPermission(requestId, decision, editedInput, reason) {
+    return this._permissions.respondToPermission(requestId, decision, editedInput, reason)
   }
 
   respondToQuestion(text, answers) {

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -463,6 +463,10 @@ function handlePermissionResponse(ws, client, msg, ctx) {
     // mergeEditedInput) — a client can narrow the content but not redirect the
     // path. Only present when the client reviewed + edited the proposed write.
     editedInput: msg.editedInput,
+    // #6773: the operator's free-text deny reason. Used only on a `deny` — the
+    // server bounds + redacts it (permission-manager.js buildDenyMessage) and
+    // feeds it back to the agent as the denial message instead of 'User denied'.
+    reason: msg.reason,
   })
 
   if (result.kind === 'binding_mismatch') {

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -74,8 +74,10 @@ const SECRET_FILE_EXTENSIONS = ['.pem', '.key', '.p12', '.pfx']
 // makes a tool "path-carrying" for the floor (Write/Edit → file_path,
 // NotebookEdit → notebook_path, Read/Glob/Grep → file_path/path). A tool with
 // none of these (Bash, Task, WebFetch, WebSearch) cannot be floored here —
-// command-shaped access is out of scope for a path floor.
-const PROTECTED_PATH_INPUT_FIELDS = ['file_path', 'path', 'notebook_path']
+// command-shaped access is out of scope for a path floor. Exported (#6773) so
+// the editedInput whitelist guard test can assert no editable field is ever a
+// path field (a path-redirect would let an edit slip past the protected floor).
+export const PROTECTED_PATH_INPUT_FIELDS = ['file_path', 'path', 'notebook_path']
 
 // #6803 — tools whose floor is SECRETS-ONLY (non-mutating reads). handlePermission
 // routes these through isSecretReadTarget (env files + key material) instead of
@@ -145,19 +147,42 @@ const MAX_SESSION_RULES = 100         // session-scoped auto-allow rules
 const MAX_RAW_DESCRIPTION_LEN = 8192  // raw tool field length fed to redactValue (far above the 200-char shown window)
 
 /**
- * #6543 (IDE P3 feature B) — per-tool whitelist of the CONTENT field(s) a client
- * may substitute via `editedInput` on an `allow` (the per-hunk pre-write review).
- * ONLY these content fields can come from the client; the path/anchor fields
- * (`file_path`, `old_string`, `command`, …) are always taken from the ORIGINAL
- * input. So an operator can narrow/edit the shown content but can NEVER redirect
- * where the write lands or what runs. A tool absent from this map ignores
- * `editedInput` entirely (accept/reject-the-whole-tool). `old_string` is
- * deliberately NOT editable — it is the Edit's match anchor, not shown content.
+ * #6543 (IDE P3 feature B) / #6773 — per-tool whitelist of the field(s) a client
+ * may substitute via `editedInput` on an `allow` (the pre-approve review/edit).
+ * ONLY these fields can come from the client; the path/anchor fields
+ * (`file_path`, `old_string`, …) are always taken from the ORIGINAL input, so an
+ * operator can narrow/edit the shown content or the command but can NEVER
+ * redirect where a write lands. A tool absent from this map ignores `editedInput`
+ * entirely (accept/reject-the-whole-tool). `old_string` is deliberately NOT
+ * editable — it is the Edit's match anchor, not shown content.
+ *
+ * #6773 — `Bash: ['command']` makes the shell command text editable before
+ * approve. For Bash the WHOLE command IS the reviewed content (there is no
+ * separate path field to redirect), and Bash carries none of
+ * {@link PROTECTED_PATH_INPUT_FIELDS}, so the protected-path floor never applied
+ * to it — editing `command` therefore cannot "edit around" the floor (the floor
+ * only ever guards a path-carrying tool's path fields, and no path field is ever
+ * whitelisted here — asserted by the editedInput-whitelist guard test). The
+ * merged command still flows to the SDK/BYOK tool executor as `updatedInput`,
+ * which runs the operator-approved text.
+ *
+ * Codex's `shell` is deliberately ABSENT: the codex app-server owns and runs its
+ * own already-parsed command and ignores `updatedInput` (see
+ * codex-app-server-session.js `_routeApproval`, which reads only allow/deny), so
+ * a `shell` edit would silently not take effect — surfacing an editable field
+ * there would mislead the operator. Deferred to a codex follow-up.
  */
-const EDITABLE_INPUT_FIELDS = {
+export const EDITABLE_INPUT_FIELDS = {
   Write: ['content'],
   Edit: ['new_string'],
+  Bash: ['command'],
 }
+
+// #6773 — hard cap on the operator-supplied DENY REASON before it becomes the
+// agent-facing tool-result message. Far above any reasonable one-liner; it only
+// bites a pathological paste. The wire schema (PermissionResponseSchema) caps at
+// the same ceiling — this is the server-authoritative re-cap.
+const MAX_DENY_REASON_LEN = 2000
 
 /**
  * Merge a client's `editedInput` into the agent's original tool input under the
@@ -184,6 +209,27 @@ export function mergeEditedInput(originalInput, editedInput, toolName) {
     }
   }
   return merged
+}
+
+/**
+ * #6773 — build the agent-facing DENY message from an optional operator reason.
+ * A deny used to always resolve as the fixed `'User denied'` string, so nothing
+ * the operator typed reached the agent. When a non-empty reason is supplied it
+ * REPLACES that string (verbatim, so the model reads the operator's intent as
+ * the refusal reason and can adjust its next attempt — desktop-app "tell Claude
+ * what to do differently" parity). Bounded ({@link MAX_DENY_REASON_LEN}) and
+ * redacted (same {@link redactValue} pass every other freeform field entering
+ * the broadcast/agent stream gets, so an operator can't accidentally leak a
+ * secret into the streamed tool result). Falls back to `'User denied'` for a
+ * missing / non-string / blank reason.
+ * @param {*} reason  the operator-supplied deny reason (untrusted)
+ * @returns {string}
+ */
+export function buildDenyMessage(reason) {
+  if (typeof reason !== 'string') return 'User denied'
+  const trimmed = reason.trim()
+  if (trimmed.length === 0) return 'User denied'
+  return redactValue(trimmed.slice(0, MAX_DENY_REASON_LEN))
 }
 
 /**
@@ -956,10 +1002,14 @@ export class PermissionManager extends EventEmitter {
    *
    * @param {string} requestId - The permission request ID
    * @param {string} decision - 'allow', 'deny', or 'allowAlways'
+   * @param {*} [editedInput] - #6543/#6773 client edits merged under the
+   *   {@link EDITABLE_INPUT_FIELDS} whitelist on an approve (ignored on deny).
+   * @param {string} [reason] - #6773 operator-supplied free-text deny reason;
+   *   used only on a `deny` to replace the fixed 'User denied' agent message.
    * @returns {boolean} true if a pending permission was found and resolved,
    *   false if the requestId was unknown (already resolved or expired).
    */
-  respondToPermission(requestId, decision, editedInput) {
+  respondToPermission(requestId, decision, editedInput, reason) {
     const pending = this._pendingPermissions.get(requestId)
     if (!pending) {
       this._logWarn(`No pending permission for ${requestId}`)
@@ -1027,7 +1077,9 @@ export class PermissionManager extends EventEmitter {
       }
       pending.resolve(result)
     } else {
-      pending.resolve({ behavior: 'deny', message: 'User denied' })
+      // #6773 — carry the operator's free-text reason (bounded + redacted) back
+      // to the agent as the denial message, instead of the fixed 'User denied'.
+      pending.resolve({ behavior: 'deny', message: buildDenyMessage(reason) })
     }
     return true
   }

--- a/packages/server/src/permission-resolver.js
+++ b/packages/server/src/permission-resolver.js
@@ -93,14 +93,17 @@ export function createPermissionResolver({
    * @param {string} requestId
    * @param {string} decision
    * @param {string|null} callerBoundSessionId  token-bound id (HTTP) / client.boundSessionId (WS); null/undefined = unbound
-   * @param {{ clientId?: string|null, dispatchFallbackSessionId?: string|null }} [opts]
+   * @param {{ clientId?: string|null, dispatchFallbackSessionId?: string|null, editedInput?: any, reason?: string }} [opts]
    *   `dispatchFallbackSessionId` is the WS-only legacy "map wasn't populated"
    *   fallback (client.activeSessionId). It is used ONLY to pick the dispatch
    *   session — NEVER for the binding check (invariant B). HTTP passes nothing.
+   *   `editedInput` (#6543) and `reason` (#6773) flow only to the in-process
+   *   (SDK/BYOK) respondToPermission — the legacy pendingPermissions path ignores
+   *   both (the CLI tool executes / denies with its own fixed message).
    * @returns {{ kind: string, [k: string]: any }} ResolveResult
    */
   function resolve(requestId, decision, callerBoundSessionId, opts = {}) {
-    const { clientId = null, dispatchFallbackSessionId = null, editedInput = undefined } = opts
+    const { clientId = null, dispatchFallbackSessionId = null, editedInput = undefined, reason = undefined } = opts
 
     // Invariant B (#2806 residual): the binding check reads the RAW map entry —
     // never an activeSessionId fallback. For a bound caller the request MUST be
@@ -137,7 +140,9 @@ export function createPermissionResolver({
         const toolName = entry.session._lastPermissionData?.get(requestId)?.tool
         // #6543 (feature B): editedInput flows ONLY to the in-process (SDK/BYOK)
         // path — the legacy HTTP path below ignores it (CLI tool executes as-is).
-        const resolved = entry.session.respondToPermission(requestId, decision, editedInput)
+        // #6773: a deny `reason` rides the same in-process path and becomes the
+        // agent-facing denial message (permission-manager.js buildDenyMessage).
+        const resolved = entry.session.respondToPermission(requestId, decision, editedInput, reason)
         consumeRoute(requestId)
         if (resolved) {
           const extra = {}

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1541,8 +1541,8 @@ export class SdkSession extends BaseSession {
    * Resolve a pending permission request (called by WsServer when
    * the app sends permission_response).
    */
-  respondToPermission(requestId, decision, editedInput) {
-    return this._permissions.respondToPermission(requestId, decision, editedInput)
+  respondToPermission(requestId, decision, editedInput, reason) {
+    return this._permissions.respondToPermission(requestId, decision, editedInput, reason)
   }
 
   /**

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -430,7 +430,10 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // entries (clientId=null) in forensic queries. HTTP passes NO dispatch
       // fallback — it has no per-connection activeSessionId, so the dispatch
       // session is the raw mapping only (unchanged from the prior inline code).
-      const result = permissionResolver.resolve(requestId, decision, callerBoundSessionId, { clientId: 'http' })
+      // #6773: forward an optional free-text deny reason (the WS path's msg.reason
+      // analog) so an HTTP caller can also steer a denial. buildDenyMessage bounds
+      // + redacts it and ignores it on a non-deny; a missing field is a no-op.
+      const result = permissionResolver.resolve(requestId, decision, callerBoundSessionId, { clientId: 'http', reason: parsed.reason })
       switch (result.kind) {
         case 'binding_mismatch': {
           // For a bound caller the requestId MUST be explicitly mapped to that

--- a/packages/server/tests/edited-input-merge.test.js
+++ b/packages/server/tests/edited-input-merge.test.js
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { PermissionManager, mergeEditedInput } from '../src/permission-manager.js'
+import {
+  PermissionManager,
+  mergeEditedInput,
+  buildDenyMessage,
+  EDITABLE_INPUT_FIELDS,
+  PROTECTED_PATH_INPUT_FIELDS,
+} from '../src/permission-manager.js'
 
 /**
  * #6543 (IDE P3 feature B) — the editedInput execution seam. The load-bearing
@@ -28,9 +34,20 @@ describe('mergeEditedInput whitelist (#6543)', () => {
     assert.equal(r.file_path, '/repo/a.js') // path not editable
   })
 
-  it('a non-editable tool (Bash) ignores editedInput ENTIRELY (no command change)', () => {
-    const r = mergeEditedInput({ command: 'ls' }, { command: 'rm -rf /', content: 'x' }, 'Bash')
-    assert.deepEqual(r, { command: 'ls' })
+  it('#6773 — Bash: substitutes the command (whole command is the reviewed content)', () => {
+    const r = mergeEditedInput({ command: 'ls' }, { command: 'ls -la', content: 'x' }, 'Bash')
+    assert.equal(r.command, 'ls -la')     // command IS editable for Bash now
+    assert.equal(r.content, undefined)    // non-whitelisted field ignored (can't ADD)
+  })
+
+  it('a non-editable tool (Task) ignores editedInput ENTIRELY (no field change)', () => {
+    const r = mergeEditedInput({ prompt: 'go' }, { prompt: 'HIJACK', command: 'rm -rf /' }, 'Task')
+    assert.deepEqual(r, { prompt: 'go' })
+  })
+
+  it('#6773 — codex `shell` is NOT editable (codex owns command execution)', () => {
+    const r = mergeEditedInput({ command: 'ls' }, { command: 'rm -rf /' }, 'shell')
+    assert.deepEqual(r, { command: 'ls' }) // absent from whitelist → editedInput ignored
   })
 
   it('ignores non-whitelisted fields, non-string values, and cannot ADD fields', () => {
@@ -110,5 +127,93 @@ describe('respondToPermission editedInput integration (#6543)', () => {
     const { pm, resolved } = seed('Write', { file_path: '/a', content: 'x' })
     assert.equal(pm.respondToPermission('nope', 'allow', { content: 'y' }), false)
     assert.equal(resolved(), undefined)
+  })
+
+  it('#6773 — Bash allow + editedInput.command ⇒ updatedInput runs the edited command', () => {
+    const { pm, resolved } = seed('Bash', { command: 'ls' })
+    pm.respondToPermission('req-1', 'allow', { command: 'ls -la' })
+    assert.equal(resolved().behavior, 'allow')
+    assert.equal(resolved().updatedInput.command, 'ls -la')
+  })
+})
+
+/**
+ * #6773 — the editedInput WHITELIST GUARD. The load-bearing invariant is that a
+ * client-substitutable field can NEVER be a filesystem-target (path) field — a
+ * path-redirect would let an approved edit slip a write past the protected-path
+ * floor. This guard fails if a future tool addition puts a path field in the
+ * whitelist, mirroring the "narrow-only" contract the mergeEditedInput tests prove.
+ */
+describe('editedInput whitelist guard (#6773)', () => {
+  it('no editable field is ever a protected PATH field (no path redirect possible)', () => {
+    const pathFields = new Set(PROTECTED_PATH_INPUT_FIELDS)
+    for (const [tool, fields] of Object.entries(EDITABLE_INPUT_FIELDS)) {
+      for (const field of fields) {
+        assert.ok(
+          !pathFields.has(field),
+          `EDITABLE_INPUT_FIELDS[${tool}] must not include the path field '${field}' — it would let an edit redirect the write past the floor`,
+        )
+      }
+    }
+  })
+
+  it('every editable-field list is a non-empty array of strings', () => {
+    for (const [tool, fields] of Object.entries(EDITABLE_INPUT_FIELDS)) {
+      assert.ok(Array.isArray(fields) && fields.length > 0, `${tool} must map to a non-empty field array`)
+      for (const field of fields) assert.equal(typeof field, 'string', `${tool} fields must be strings`)
+    }
+  })
+
+  it('codex `shell` is NOT in the whitelist (codex ignores updatedInput)', () => {
+    assert.equal(EDITABLE_INPUT_FIELDS.shell, undefined)
+  })
+})
+
+/**
+ * #6773 — buildDenyMessage: an operator's free-text reason replaces the fixed
+ * 'User denied' string fed back to the agent, bounded + redacted; blank / missing
+ * / non-string falls back to 'User denied'.
+ */
+describe('buildDenyMessage (#6773)', () => {
+  it('a non-empty reason replaces the default message', () => {
+    assert.equal(buildDenyMessage('use rg instead of grep'), 'use rg instead of grep')
+  })
+
+  it('missing / non-string / blank falls back to "User denied"', () => {
+    assert.equal(buildDenyMessage(undefined), 'User denied')
+    assert.equal(buildDenyMessage(null), 'User denied')
+    assert.equal(buildDenyMessage(42), 'User denied')
+    assert.equal(buildDenyMessage('   '), 'User denied')
+    assert.equal(buildDenyMessage(''), 'User denied')
+  })
+
+  it('trims and bounds the reason (no unbounded paste reaches the agent)', () => {
+    const long = 'x'.repeat(5000)
+    const out = buildDenyMessage(`   ${long}   `)
+    assert.equal(out.length, 2000)
+  })
+
+  it('redacts a secret-shaped token in the reason before it reaches the agent', () => {
+    const out = buildDenyMessage('do not use sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+    assert.ok(!out.includes('sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'), 'raw secret must not survive')
+  })
+
+  it('respondToPermission deny ⇒ agent message carries the reason', () => {
+    const pm = new PermissionManager({ log: { info() {}, warn() {}, error() {} } })
+    let resolved
+    pm._pendingPermissions.set('req-1', { resolve: (r) => { resolved = r }, input: { command: 'ls' }, suggestions: [] })
+    pm._lastPermissionData.set('req-1', { tool: 'Bash' })
+    pm.respondToPermission('req-1', 'deny', undefined, 'run it read-only instead')
+    assert.equal(resolved.behavior, 'deny')
+    assert.equal(resolved.message, 'run it read-only instead')
+  })
+
+  it('respondToPermission deny WITHOUT a reason ⇒ default "User denied"', () => {
+    const pm = new PermissionManager({ log: { info() {}, warn() {}, error() {} } })
+    let resolved
+    pm._pendingPermissions.set('req-1', { resolve: (r) => { resolved = r }, input: { command: 'ls' }, suggestions: [] })
+    pm._lastPermissionData.set('req-1', { tool: 'Bash' })
+    pm.respondToPermission('req-1', 'deny')
+    assert.equal(resolved.message, 'User denied')
   })
 })

--- a/packages/server/tests/handlers/settings-handlers.test.js
+++ b/packages/server/tests/handlers/settings-handlers.test.js
@@ -627,7 +627,7 @@ describe('settings-handlers', () => {
       settingsHandlers.permission_response(makeWs(), client, { requestId: 'req-1', decision: 'allow' }, ctx)
 
       assert.equal(session.respondToPermission.callCount, 1)
-      assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow', undefined]) // #6543: editedInput 3rd arg (absent here)
+      assert.deepEqual(session.respondToPermission.lastCall, ['req-1', 'allow', undefined, undefined]) // #6543 editedInput 3rd arg + #6773 reason 4th arg (both absent here)
     })
 
     it('#6590 legacy-unmapped resolve broadcasts permission_resolved to ALL clients incl. the resolver', () => {
@@ -848,7 +848,7 @@ describe('settings-handlers', () => {
 
         assert.equal(sessionA.respondToPermission.callCount, 1,
           'unbound client with matching activeSessionId must route normally')
-        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-active', 'allow', undefined])
+        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-active', 'allow', undefined, undefined]) // #6773 reason 4th arg
         assert.equal(ctx.permissions.permissionSessionMap.has('perm-ok-active'), false,
           'mapping must be consumed when the decision is routed')
       })
@@ -878,7 +878,7 @@ describe('settings-handlers', () => {
 
         assert.equal(sessionA.respondToPermission.callCount, 1,
           'subscribed unbound client must route normally — matches _broadcastToSession filter')
-        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-sub', 'allow', undefined])
+        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-ok-sub', 'allow', undefined, undefined]) // #6773 reason 4th arg
       })
 
       it('leaves the bound-client guard unchanged (different code path)', () => {
@@ -944,7 +944,7 @@ describe('settings-handlers', () => {
 
         assert.equal(sessionA.respondToPermission.callCount, 1,
           'after-switch decision must route to the originating session A')
-        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-after-switch', 'allow', undefined])
+        assert.deepEqual(sessionA.respondToPermission.lastCall, ['perm-after-switch', 'allow', undefined, undefined]) // #6773 reason 4th arg
         assert.equal(sessionB.respondToPermission.callCount, 0,
           'must not bleed onto the now-active session B')
         assert.equal(ctx.permissions.permissionSessionMap.has('perm-after-switch'), false,

--- a/packages/server/tests/permission-resolver.test.js
+++ b/packages/server/tests/permission-resolver.test.js
@@ -127,6 +127,17 @@ describe('permission-resolver — SDK-before-legacy (F) + dispatch states', () =
     assert.equal(legacyResolved.length, 0, 'legacy resolver not used when SDK handled it')
   })
 
+  it('#6773: forwards the editedInput and reason opts to the SDK respondToPermission', () => {
+    const owner = makeSdkSession({ pending: ['perm-r'] })
+    const { resolver } = build({ map: [['perm-r', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-r', 'deny', OWNER, { clientId: 'c1', editedInput: { command: 'ls' }, reason: 'read-only please' })
+    assert.equal(owner.respondToPermission.mock.calls.length, 1)
+    assert.deepStrictEqual(
+      owner.respondToPermission.mock.calls[0].arguments,
+      ['perm-r', 'deny', { command: 'ls' }, 'read-only please'],
+    )
+  })
+
   it('an unmapped request that exists in the legacy store resolves via legacy', () => {
     const { resolver, legacyResolved } = build({ map: [], legacy: ['perm-5'] })
     const r = resolver.resolve('perm-5', 'allow', null, { clientId: 'c1' })

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -493,7 +493,7 @@ describe('handleSessionMessage', () => {
         decision: 'allow',
       }, ctx)
       assert.equal(entry.session.respondToPermission.callCount, 1)
-      assert.deepStrictEqual(entry.session.respondToPermission.lastCall, ['req-broadcast', 'allow', undefined]) // #6543: editedInput 3rd arg (absent here)
+      assert.deepStrictEqual(entry.session.respondToPermission.lastCall, ['req-broadcast', 'allow', undefined, undefined]) // #6543 editedInput 3rd arg + #6773 reason 4th arg (both absent here)
       assert.equal(ctx.transport.broadcast.mock.calls.length, 0,
         'SDK path must NOT broadcast inline — the unified pipeline handles it (#3048)')
     })

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -1008,7 +1008,7 @@ describe('createPermissionHandler', () => {
       assert.equal(res.statusCode, 200)
       assert.equal(respondToPermission.mock.calls.length, 1,
         'SDK session.respondToPermission must be invoked')
-      assert.deepStrictEqual(respondToPermission.mock.calls[0].arguments, ['sdk-req', 'allow', undefined]) // #6543: editedInput 3rd arg (HTTP path never sets it)
+      assert.deepStrictEqual(respondToPermission.mock.calls[0].arguments, ['sdk-req', 'allow', undefined, undefined]) // #6543 editedInput 3rd arg + #6773 reason 4th arg (HTTP path passes reason=parsed.reason, undefined here)
       assert.equal(opts.broadcastFn.mock.calls.length, 0,
         'SDK path must NOT broadcast inline — the unified pipeline handles it (#3048)')
     })


### PR DESCRIPTION
## What

Bash (and codex `shell`) permission prompts were strict allow/deny — no way to tweak the proposed command before running it, and every deny resolved with the fixed `'User denied'` message regardless of operator intent. This extends the pre-approve editing seam from the Write/Edit per-hunk review (#6543) to shell commands and adds a general free-text **deny-reason** channel fed straight back to the agent (desktop-app "tell Claude what to do differently" parity).

## Scope (server + protocol + dashboard)

Per the cross-stack decomposition guidance, this PR implements the highest-value coherent slice — the **Claude SDK/BYOK path**, where an edited command's `updatedInput` and the deny `message` actually reach the agent. Mobile-app parity and codex-effective wiring are tracked as a follow-up (see below).

### Server
- `EDITABLE_INPUT_FIELDS` gains `Bash: ['command']`. For Bash the whole command **is** the reviewed content, and Bash carries none of `PROTECTED_PATH_INPUT_FIELDS`, so an edit can change *what runs* but can never redirect a write past the #6803/#6873 protected-path floor (the floor only ever guards a path-carrying tool's path fields, and no path field is ever whitelisted here — asserted by a new guard test).
- Codex `shell` is **deliberately excluded**: `codex-app-server-session._routeApproval` reads only allow/deny and re-runs its own already-parsed command (ignores `updatedInput`), so a `shell` edit would silently not take effect.
- `respondToPermission(requestId, decision, editedInput, reason)` — the new `reason` replaces the fixed `'User denied'` agent message on a deny, **bounded (2000) + redacted** via the new exported `buildDenyMessage()`. Threaded through `permission-resolver` and the sdk/byok/codex session wrappers, plus the WS (`settings-handlers`) and HTTP (`ws-permissions`) response handlers.

### Protocol
- `PermissionResponseSchema` gains an optional bounded `reason` (wire cap 2000). Dist rebuilt.

### Dashboard
- New `PermissionCommandEdit` — an editable single-line command field (features.ide gated, reuses the existing full-input pull). Emits an edit only when the command actually changed, so an untouched command stays a plain Allow.
- `PermissionPrompt` renders the command editor plus a **tool-agnostic** deny-reason textarea; the reason threads through `sendPermissionResponse` on a deny only (trimmed; omitted when blank so the server falls back to its default).

## Tests
- Server: updated the `edited-input-merge` suite (Bash is now editable; `Task`/`shell` are the non-editable examples), added an **editedInput whitelist guard** (no editable field may ever be a protected path field), `buildDenyMessage` coverage, and resolver + handler arg-threading updates. All targeted permission suites green; all `scripts/lint-*.sh` green.
- Protocol: `PermissionResponseSchema` accepts editedInput/reason, rejects over-cap reason. Full suite green (367).
- Dashboard: `PermissionCommandEdit` + `PermissionPrompt` deny-reason/command-edit interaction + store payload tests. Full suite green (4573). Typecheck clean.
- store-core full suite green (2021) — no contract-guard impact (added an optional field to an existing client→server type, not a new both-clients type).

## Acceptance criteria
- [x] A deny response can carry free-text operator reasoning back to the agent instead of the fixed 'User denied' message
- [x] The operator can edit the proposed Bash command text before approving it
- [x] Edited Bash commands still pass through the same execution/path-confinement checks as the original (Bash has no path field; the whitelist guard forbids a path field ever becoming editable)

## Follow-up
Mobile-app parity (`PermissionDetail` deny-reason + command edit, `connection.ts sendPermissionResponse` reason param) and codex-effective deny-reason/command-edit are deferred to a tracked follow-up issue.

Closes #6773