### PR TITLE
fix(dashboard): stop doubling the tool label on permission cards (#6626)

### DIFF
--- a/packages/dashboard/src/hooks/useMessageRenderer.test.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.test.tsx
@@ -11,10 +11,46 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, renderHook } from '@testing-library/react'
 import type { ChatMessage } from '@chroxy/store-core'
-import { useMessageRenderer, type UseMessageRendererArgs } from './useMessageRenderer'
+import { useMessageRenderer, permissionPromptDescription, type UseMessageRendererArgs } from './useMessageRenderer'
 import type { ChatViewMessage } from '../components/ChatView'
 
+// Mock the store so the #6626 render test can mount `PermissionPrompt` (the only
+// store-connected component this renderer produces) without booting Zustand —
+// mirrors PermissionPrompt.test.tsx. The error-chip components in this file don't
+// touch the store, so the mock is a no-op for the existing tests.
+vi.mock('../store/connection', () => ({
+  useConnectionStore: <T,>(selector: (s: Record<string, unknown>) => T): T =>
+    selector({
+      resolvedPermissions: {},
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', provider: 'codex' }],
+      availableProviders: [],
+      connectionPhase: 'connected',
+      serverCapabilities: undefined,
+      permissionInputs: {},
+      requestPermissionInput: () => {},
+    }),
+  isRuleEligibleTool: () => false,
+  isRuleEligibleProvider: () => false,
+  DENY_REASON_MAX_LENGTH: 2000,
+}))
+
 afterEach(cleanup)
+
+function promptMsg(id: string, content: string, tool: string | undefined, requestId: string): ChatMessage {
+  return {
+    id,
+    type: 'prompt',
+    content,
+    tool,
+    requestId,
+    // A future expiry keeps the prompt unanswered/live so the renderer takes the
+    // PermissionPrompt branch (requestId && expiresAt && !answered).
+    expiresAt: Date.now() + 5 * 60 * 1000,
+    options: [{ label: 'Allow', value: 'allow' }, { label: 'Deny', value: 'deny' }],
+    timestamp: 0,
+  } as ChatMessage
+}
 
 function errorMsg(id: string, code: string): ChatMessage {
   return {
@@ -105,5 +141,58 @@ describe('useMessageRenderer — retryable AskUserQuestion errors (#5793)', () =
     const node = result.current({ id: 'e1', type: 'error', content: err.content, timestamp: 0, code: 'SESSION_TOKEN_MISMATCH' } as ChatViewMessage)
     render(<>{node}</>)
     expect(screen.queryByTestId('ask-user-question-stall-chip')).toBeNull()
+  })
+})
+
+describe('permissionPromptDescription — strip the composed tool prefix (#6626)', () => {
+  it('strips the redundant leading "<tool>: " so the raw description survives', () => {
+    // message-handler composes content as `"${tool}: ${description}"`; the raw
+    // description is everything after the first `"<tool>: "`.
+    expect(
+      permissionPromptDescription('shell: Do you want to allow npm registry install?', 'shell'),
+    ).toBe('Do you want to allow npm registry install?')
+  })
+
+  it('returns "" when content is the bare tool (description was empty)', () => {
+    expect(permissionPromptDescription('shell', 'shell')).toBe('')
+  })
+
+  it('passes content through unchanged when no tool is set', () => {
+    expect(permissionPromptDescription('Do you want to allow?', undefined)).toBe('Do you want to allow?')
+  })
+
+  it('only strips the FIRST prefix so a description that starts with the tool label is preserved', () => {
+    expect(permissionPromptDescription('shell: shell: nested', 'shell')).toBe('shell: nested')
+  })
+})
+
+describe('useMessageRenderer — Codex shell permission card has no duplicated label (#6626)', () => {
+  it('renders "shell: <desc>" once, not "shell: shell: <desc>"', () => {
+    const reqId = 'perm-1'
+    // Reproduces the reported payload: content stored as the composed
+    // `"shell: Do you want to allow ..."` with tool `"shell"`. Before the fix the
+    // renderer passed this composed content as PermissionPrompt's `description`,
+    // which re-prepends `"shell: "` → the `shell: shell: …` double label.
+    const desc = 'Do you want to allow npm registry install for a final @chroxy/server smoke test?'
+    const msg = promptMsg('m1', `shell: ${desc}`, 'shell', reqId)
+    const args = makeArgs({
+      storeMsgMap: new Map([['m1', msg]]),
+      chatTailMessageId: 'm1',
+      storeMessages: [msg],
+    })
+    const { result } = renderHook(() => useMessageRenderer(args))
+    // The permission branch routes off the store-message lookup (`storeMsgMap`),
+    // not the view message's `type`; ChatViewMessage has no 'prompt' member, so a
+    // valid discriminator is used here — routing is by `id`.
+    const node = result.current({ id: 'm1', type: 'system', content: msg.content, timestamp: 0 } as ChatViewMessage)
+    render(<>{node}</>)
+
+    const promptEl = screen.getByTestId('permission-prompt')
+    const descLine = promptEl.querySelector('.perm-desc')
+    expect(descLine).not.toBeNull()
+    const text = descLine!.textContent ?? ''
+    // Exactly one "shell:" label, and it reads as the single-prefixed prompt.
+    expect(text).toBe(`shell: ${desc}`)
+    expect(text).not.toContain('shell: shell:')
   })
 })

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -59,6 +59,25 @@ function buildSessionLabel(
 }
 
 /**
+ * #6626 — recover the RAW permission description from a prompt message's stored
+ * `content`. `handlePermissionRequest` composes `content` as `"${tool}: ${description}"`
+ * (or the bare `tool` when the description is empty — see message-handler.ts).
+ * `PermissionPrompt` re-prepends `"${tool}: "` itself, so feeding it the composed
+ * `content` as its `description` prop doubled the tool label — the reported
+ * `shell: shell: …` on Codex shell approvals (and any provider's prompt). Inverting
+ * the exact composition here keeps the single source of truth in the message-handler
+ * while stripping the redundant leading `"${tool}: "` before the card re-adds it.
+ * Only the FIRST occurrence of the prefix is removed, so a description that itself
+ * legitimately begins with `"${tool}: "` is preserved intact.
+ */
+export function permissionPromptDescription(content: string, tool?: string): string {
+  if (!tool) return content
+  if (content === tool) return ''
+  const prefix = `${tool}: `
+  return content.startsWith(prefix) ? content.slice(prefix.length) : content
+}
+
+/**
  * The custom chat-message renderer (#5560): permission prompts, question
  * prompts, tool bubbles/groups, the evaluator-rewrite banner, and the
  * stream-stall / ask-user-question-stall / resume-unknown chips.
@@ -124,7 +143,9 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
         <PermissionPrompt
           requestId={storeMsg.requestId}
           tool={storeMsg.tool || 'Unknown'}
-          description={storeMsg.content}
+          // #6626 — pass the RAW description, not the composed `"<tool>: <desc>"`
+          // `content`; PermissionPrompt re-prepends `"<tool>: "` (double label otherwise).
+          description={permissionPromptDescription(storeMsg.content, storeMsg.tool)}
           remainingMs={remainingMs}
           onRespond={(reqId, decision, editedInput, reason) => sendPermissionResponse(reqId, decision, editedInput, reason)}
           sessionLabel={buildSessionLabel(storeMsg.originSessionId, sessions)}


### PR DESCRIPTION
## Problem

Codex `shell` approval cards render the tool label twice — `shell: shell: Do you want to allow …` — as reported in #6626. The doubling affects the **pending permission card** in the dashboard for every provider, but it is most visible on Codex shell prompts (whose `reason` is a full natural-language question).

## Root cause (client-side, dashboard)

`handlePermissionRequest` stores a prompt message's `content` as the composed string `"${tool}: ${description}"` (this is the correct display string for the fallback/answered plain bubble). The renderer then reused that composed `content` as `PermissionPrompt`'s `description` prop:

- `packages/dashboard/src/hooks/useMessageRenderer.tsx` passed `description={storeMsg.content}`
- `PermissionPrompt.tsx` renders `<span className="perm-tool">{tool}</span>: {description}` — i.e. it **re-prepends** `"${tool}: "`

So `shell` + (`shell: Do you want…`) → `shell: shell: Do you want…`. The bare-tool (empty-description) case rendered `shell: shell` for the same reason.

The mobile app is unaffected — it passes the composed `content` to `PermissionDetailOrFallback` as a plain fallback string and does not re-prepend the tool.

## Fix

Recover the raw description in the renderer by stripping the redundant leading `"${tool}: "` before it reaches the card, keeping the handler's composition as the single source of truth. A new exported pure helper `permissionPromptDescription(content, tool)` inverts the exact composition and only strips the **first** prefix, so a description that itself legitimately begins with the tool label is preserved.

## Tests (TDD, RED→GREEN)

- Unit coverage for `permissionPromptDescription` (representative Codex shell payload + bare-tool + no-tool + nested-prefix cases).
- A renderer regression test that reproduces the reported payload (`content: "shell: Do you want to allow npm registry install …"`, `tool: "shell"`) and asserts the rendered `.perm-desc` reads `shell: <desc>` exactly once — verified to fail (`shell: shell: …`) without the fix.

Full dashboard suite green (264 files / 4612 tests) and `tsc --noEmit` clean.

## Scope note

This closes the primary, clearly-testable defect (the duplicated `shell:` label). The issue's broader UX items — a compact resolved/audit treatment for answered prompts and de-duping identical repeated prompts — are separate render-behavior changes and remain dogfood-gated per the issue's own manual-QA acceptance item; the mobile app already collapses answered permission prompts to a compact pill.

Closes #6626