### PR TITLE
feat(dashboard,app): combined "approve plan + auto-accept edits" action

### DIFF
--- a/packages/app/.maestro/plan-approval.yaml
+++ b/packages/app/.maestro/plan-approval.yaml
@@ -56,6 +56,14 @@ name: PlanApprovalCard approve path
 - assertVisible:
     id: "plan-deny-button"
 
+# #6774 — the combined "Approve & auto-accept edits" action is present too.
+# The mock session declares no `permissionModeSwitch: false` capability, so the
+# combined button renders (gated on the provider supporting mode switching).
+# We assert its presence but keep tapping the plain Approve below, so the rest
+# of this flow's approve-path assertions are unaffected.
+- assertVisible:
+    id: "plan-approve-accept-edits-button"
+
 # Screenshot the plan approval card before tapping Approve.
 - takeScreenshot: plan-approval-card
 

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -91,6 +91,18 @@ export interface ChatViewProps {
   isPlanPending?: boolean;
   planAllowedPrompts?: { tool: string; prompt: string }[];
   onApprovePlan?: () => void;
+  /**
+   * #6774 — combined "approve + auto-accept edits": approve the plan AND switch
+   * the session into acceptEdits in one tap. Only wired where the provider
+   * supports permission-mode switching (see {@link canApproveAcceptEdits}).
+   */
+  onApprovePlanAcceptEdits?: () => void;
+  /**
+   * #6774 — gate for the combined action. Mirrors the SettingsBar mode-chip
+   * gating (`caps?.permissionModeSwitch !== false`); false hides the button
+   * for providers that can't switch mode (e.g. claude-tui).
+   */
+  canApproveAcceptEdits?: boolean;
   onFocusInput?: () => void;
   /** Search query for highlighting matching messages */
   searchQuery?: string;
@@ -107,10 +119,16 @@ export interface ChatViewProps {
 function PlanApprovalCard({
   allowedPrompts,
   onApprove,
+  onApproveAcceptEdits,
+  showAcceptEdits,
   onFeedback,
 }: {
   allowedPrompts: { tool: string; prompt: string }[];
   onApprove: () => void;
+  // #6774 — combined "approve + auto-accept edits" action. Optional +
+  // capability-gated so it only renders where the provider supports it.
+  onApproveAcceptEdits?: () => void;
+  showAcceptEdits?: boolean;
   onFeedback: () => void;
 }) {
   return (
@@ -146,6 +164,19 @@ function PlanApprovalCard({
           <Text style={styles.planFeedbackText}>Give Feedback</Text>
         </TouchableOpacity>
       </View>
+      {/* #6774 — full-width secondary action below the primary row so three
+          touch targets don't crowd a narrow phone. */}
+      {showAcceptEdits && onApproveAcceptEdits && (
+        <TouchableOpacity
+          style={styles.planAcceptEditsButton}
+          onPress={onApproveAcceptEdits}
+          accessibilityRole="button"
+          accessibilityLabel="Approve plan and auto-accept edits"
+          testID="plan-approve-accept-edits-button"
+        >
+          <Text style={styles.planAcceptEditsText}>Approve &amp; auto-accept edits</Text>
+        </TouchableOpacity>
+      )}
     </View>
   );
 }
@@ -171,6 +202,8 @@ export function ChatView({
   isPlanPending,
   planAllowedPrompts,
   onApprovePlan,
+  onApprovePlanAcceptEdits,
+  canApproveAcceptEdits,
   onFocusInput,
   searchQuery,
   searchMatchIds,
@@ -553,6 +586,8 @@ export function ChatView({
             <PlanApprovalCard
               allowedPrompts={planAllowedPrompts || []}
               onApprove={onApprovePlan}
+              onApproveAcceptEdits={onApprovePlanAcceptEdits}
+              showAcceptEdits={canApproveAcceptEdits}
               onFeedback={onFocusInput}
             />
           ) : null
@@ -722,5 +757,25 @@ const styles = StyleSheet.create({
     color: COLORS.accentGreen,
     fontSize: 14,
     fontWeight: '600',
+  },
+  // #6774 — combined "approve + auto-accept edits". Full-width tinted-green
+  // outline below the primary row: reads as a sibling of Approve (same intent)
+  // while staying distinct from the solid primary Approve button.
+  planAcceptEditsButton: {
+    marginTop: 10,
+    backgroundColor: COLORS.accentGreenLight,
+    borderWidth: 1,
+    borderColor: COLORS.accentGreen,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  planAcceptEditsText: {
+    color: COLORS.accentGreen,
+    fontSize: 14,
+    fontWeight: '700',
   },
 });

--- a/packages/app/src/components/__tests__/ChatView.planAcceptEdits.test.tsx
+++ b/packages/app/src/components/__tests__/ChatView.planAcceptEdits.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * #6774 — mobile plan-approval combined "approve + auto-accept edits" action.
+ *
+ * The PlanApprovalCard (rendered as the FlatList footer while a plan is
+ * pending) gains a third action that approves the plan AND switches the
+ * session into acceptEdits. These tests pin:
+ *   1. The button renders (with the right testID) when the provider supports
+ *      permission-mode switching (`canApproveAcceptEdits`).
+ *   2. Tapping it invokes the combined handler.
+ *   3. It is gated: hidden when the provider can't switch mode, and hidden
+ *      when no combined handler is wired (so the plain Approve path is
+ *      unaffected).
+ *
+ * The mode-switch-BEFORE-approve ordering guarantee is covered where it lives,
+ * in `@chroxy/store-core`'s `plan-approval.test.ts`.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { FlatList } from 'react-native';
+
+jest.mock('../../store/connection', () => ({
+  useConnectionStore: (selector: (s: { sendInput: () => void; activeSessionId: string | null }) => unknown) =>
+    selector({ sendInput: () => {}, activeSessionId: null }),
+}));
+
+import { AccessibilityInfo } from 'react-native';
+import { ChatView } from '../ChatView';
+import type { ChatMessage } from '../../store/types';
+
+// Mirror the virtualization test: neutralise the async reduceMotion listener so
+// its post-teardown setState doesn't crash react-test-renderer + jsdom.
+beforeAll(() => {
+  jest.spyOn(AccessibilityInfo, 'addEventListener').mockReturnValue({ remove: () => {} } as never);
+  jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(true);
+});
+afterAll(() => jest.restoreAllMocks());
+
+// isPlanPending schedules a `scrollToEnd` on a 100ms timer; the real FlatList's
+// scroll path reads I18nManager.isRTL, which is undefined under
+// react-test-renderer and crashes if the timer fires. Fake timers keep it
+// queued (never executed), and unmounting each tree clears it via the effect
+// cleanup.
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
+
+const noop = () => {};
+
+type PlanProps = {
+  onApprovePlan: () => void;
+  onFocusInput: () => void;
+  onApprovePlanAcceptEdits?: () => void;
+  canApproveAcceptEdits?: boolean;
+};
+
+function makeProps(plan: PlanProps) {
+  const ref = React.createRef<FlatList>();
+  const message: ChatMessage = { id: 'm1', type: 'response', content: 'hi', timestamp: 1000 } as ChatMessage;
+  return {
+    messages: [message],
+    scrollViewRef: ref as unknown as React.RefObject<FlatList<unknown> | null>,
+    claudeReady: true,
+    onSelectOption: noop,
+    isCliMode: false,
+    selectedIds: new Set<string>(),
+    isSelecting: false,
+    isSelectingRef: { current: false } as React.MutableRefObject<boolean>,
+    onToggleSelection: noop,
+    streamingMessageId: null,
+    isPlanPending: true,
+    planAllowedPrompts: [],
+    ...plan,
+  };
+}
+
+function renderChatView(plan: PlanProps) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<ChatView {...makeProps(plan)} />);
+  });
+  return tree;
+}
+
+// A testID propagates to several nested host nodes under a TouchableOpacity, so
+// presence is "at least one match" rather than an exact count.
+function hasTestId(tree: renderer.ReactTestRenderer, testID: string): boolean {
+  return tree.root.findAll((n) => n.props?.testID === testID).length > 0;
+}
+
+// The single node that actually carries the press handler.
+function pressableWithTestId(tree: renderer.ReactTestRenderer, testID: string) {
+  return tree.root.find(
+    (n) => n.props?.testID === testID && typeof n.props?.onPress === 'function',
+  );
+}
+
+describe('PlanApprovalCard — combined approve + auto-accept edits (#6774)', () => {
+  it('renders the combined button when the provider supports mode switching', () => {
+    const tree = renderChatView({
+      onApprovePlan: noop,
+      onFocusInput: noop,
+      onApprovePlanAcceptEdits: noop,
+      canApproveAcceptEdits: true,
+    });
+    expect(hasTestId(tree, 'plan-approve-accept-edits-button')).toBe(true);
+    // The plain Approve button is still present (AC: plain Approve unchanged).
+    expect(hasTestId(tree, 'plan-approve-button')).toBe(true);
+    act(() => tree.unmount());
+  });
+
+  it('invokes the combined handler when tapped', () => {
+    const onApprovePlanAcceptEdits = jest.fn();
+    const onApprovePlan = jest.fn();
+    const tree = renderChatView({
+      onApprovePlan,
+      onFocusInput: noop,
+      onApprovePlanAcceptEdits,
+      canApproveAcceptEdits: true,
+    });
+    act(() => {
+      pressableWithTestId(tree, 'plan-approve-accept-edits-button').props.onPress();
+    });
+    expect(onApprovePlanAcceptEdits).toHaveBeenCalledTimes(1);
+    // The combined action does not also fire the plain approve callback.
+    expect(onApprovePlan).not.toHaveBeenCalled();
+    act(() => tree.unmount());
+  });
+
+  it('hides the combined button when the provider cannot switch mode', () => {
+    const tree = renderChatView({
+      onApprovePlan: noop,
+      onFocusInput: noop,
+      onApprovePlanAcceptEdits: noop,
+      canApproveAcceptEdits: false,
+    });
+    expect(hasTestId(tree, 'plan-approve-accept-edits-button')).toBe(false);
+    // Plain Approve remains.
+    expect(hasTestId(tree, 'plan-approve-button')).toBe(true);
+    act(() => tree.unmount());
+  });
+
+  it('hides the combined button when no combined handler is wired', () => {
+    const tree = renderChatView({
+      onApprovePlan: noop,
+      onFocusInput: noop,
+      canApproveAcceptEdits: true,
+    });
+    expect(hasTestId(tree, 'plan-approve-accept-edits-button')).toBe(false);
+    act(() => tree.unmount());
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -25,7 +25,7 @@ import type { SessionIntervention } from '@chroxy/store-core';
 // 'freeformText' in`) with the same 5-condition guard the store layer
 // uses, so widening `SelectOptionValue` to a third object shape can't
 // silently misroute it as freeform.
-import { isFreeformAnswer, providerSupportsMultiQuestion, providerSupportsSingleMultiSelect } from '@chroxy/store-core';
+import { isFreeformAnswer, providerSupportsMultiQuestion, providerSupportsSingleMultiSelect, approvePlanWithAcceptEdits } from '@chroxy/store-core';
 import { USER_SHELL_PROVIDER } from '@chroxy/protocol';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
@@ -1006,6 +1006,16 @@ export function SessionScreen() {
     clearPlanState();
   }, [addUserMessage, sendInput, clearPlanState]);
 
+  // #6774 — combined "approve + auto-accept edits": switch the session into
+  // acceptEdits AND approve the plan in one tap so the implementation turn runs
+  // with edits auto-accepted. `approvePlanWithAcceptEdits` dispatches the mode
+  // switch BEFORE the approval — the server drops a mid-turn mode change, so it
+  // must land while the session is idle (awaiting approval). Reuses
+  // handleApprovePlan unchanged as the approve step.
+  const handleApprovePlanAcceptEdits = useCallback(() => {
+    approvePlanWithAcceptEdits({ setPermissionMode, approve: handleApprovePlan });
+  }, [setPermissionMode, handleApprovePlan]);
+
   const handleFocusInput = useCallback(() => {
     inputRef.current?.focus();
   }, []);
@@ -1642,6 +1652,8 @@ export function SessionScreen() {
                   isPlanPending={isPlanPending}
                   planAllowedPrompts={planAllowedPrompts}
                   onApprovePlan={handleApprovePlan}
+                  onApprovePlanAcceptEdits={handleApprovePlanAcceptEdits}
+                  canApproveAcceptEdits={providerCaps.permissionModeSwitchSupported}
                   onFocusInput={handleFocusInput}
                   searchQuery={searchVisible ? inSessionSearchQuery : undefined}
                   searchMatchIds={searchVisible ? searchMatchIds : undefined}
@@ -1678,6 +1690,8 @@ export function SessionScreen() {
               isPlanPending={isPlanPending}
               planAllowedPrompts={planAllowedPrompts}
               onApprovePlan={handleApprovePlan}
+              onApprovePlanAcceptEdits={handleApprovePlanAcceptEdits}
+              canApproveAcceptEdits={providerCaps.permissionModeSwitchSupported}
               onFocusInput={handleFocusInput}
               searchQuery={searchVisible ? inSessionSearchQuery : undefined}
               searchMatchIds={searchVisible ? searchMatchIds : undefined}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -19,6 +19,7 @@ import {
   formatToolName,
   getToolPresentation,
   deriveChatActivity,
+  approvePlanWithAcceptEdits,
   type SessionInfo,
 } from '@chroxy/store-core'
 import { useConnectionStore } from './store/connection'
@@ -1785,6 +1786,16 @@ export function App() {
     setScrollToBottomSignal(n => n + 1)
   }, [sendInput])
 
+  // #6774 — combined "approve + auto-accept edits": switch the session into
+  // acceptEdits AND approve the plan in one step so the implementation turn runs
+  // with edits auto-accepted. `approvePlanWithAcceptEdits` dispatches the mode
+  // switch BEFORE the approval — the server drops a mid-turn mode change, so it
+  // has to land while the session is idle (awaiting approval). Reuses
+  // handlePlanApprove unchanged as the approve step (send 'approve' + scroll).
+  const handlePlanApproveAcceptEdits = useCallback(() => {
+    approvePlanWithAcceptEdits({ setPermissionMode, approve: handlePlanApprove })
+  }, [setPermissionMode, handlePlanApprove])
+
   const handlePlanFeedback = useCallback(() => {
     // Focus the input bar so the user can type feedback
     const textarea = document.querySelector<HTMLTextAreaElement>('.input-bar textarea')
@@ -2550,6 +2561,8 @@ export function App() {
               <PlanApproval
                 planHtml={planHtml}
                 onApprove={handlePlanApprove}
+                onApproveAcceptEdits={handlePlanApproveAcceptEdits}
+                showAcceptEdits={dropdownFlags.showPermissionMode}
                 onFeedback={handlePlanFeedback}
               />
             )}

--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -479,6 +479,68 @@ describe('PlanApproval', () => {
     )
     expect(container.querySelector('[data-testid="plan-approval"]')).not.toBeInTheDocument()
   })
+
+  // #6774 — combined "approve + auto-accept edits" action.
+  it('renders the "Approve & auto-accept edits" button when showAcceptEdits is set', () => {
+    render(
+      <PlanApproval
+        planHtml="Plan text"
+        onApprove={vi.fn()}
+        onFeedback={vi.fn()}
+        onApproveAcceptEdits={vi.fn()}
+        showAcceptEdits
+      />
+    )
+    expect(screen.getByTestId('btn-plan-approve-accept-edits')).toBeInTheDocument()
+    // The plain Approve button remains available (AC: plain Approve unchanged).
+    expect(screen.getByText('Approve')).toBeInTheDocument()
+  })
+
+  it('calls onApproveAcceptEdits when the combined button is clicked (#6774)', () => {
+    const onApproveAcceptEdits = vi.fn()
+    const onApprove = vi.fn()
+    render(
+      <PlanApproval
+        planHtml="Plan text"
+        onApprove={onApprove}
+        onFeedback={vi.fn()}
+        onApproveAcceptEdits={onApproveAcceptEdits}
+        showAcceptEdits
+      />
+    )
+    fireEvent.click(screen.getByTestId('btn-plan-approve-accept-edits'))
+    expect(onApproveAcceptEdits).toHaveBeenCalledTimes(1)
+    // The combined action does NOT also fire the plain approve callback.
+    expect(onApprove).not.toHaveBeenCalled()
+  })
+
+  it('hides the combined button when showAcceptEdits is false (provider lacks mode switch)', () => {
+    render(
+      <PlanApproval
+        planHtml="Plan text"
+        onApprove={vi.fn()}
+        onFeedback={vi.fn()}
+        onApproveAcceptEdits={vi.fn()}
+        showAcceptEdits={false}
+      />
+    )
+    expect(screen.queryByTestId('btn-plan-approve-accept-edits')).not.toBeInTheDocument()
+    // Plain Approve / Feedback still render.
+    expect(screen.getByText('Approve')).toBeInTheDocument()
+    expect(screen.getByText('Feedback')).toBeInTheDocument()
+  })
+
+  it('hides the combined button when no onApproveAcceptEdits handler is wired', () => {
+    render(
+      <PlanApproval
+        planHtml="Plan text"
+        onApprove={vi.fn()}
+        onFeedback={vi.fn()}
+        showAcceptEdits
+      />
+    )
+    expect(screen.queryByTestId('btn-plan-approve-accept-edits')).not.toBeInTheDocument()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/components/PlanApproval.tsx
+++ b/packages/dashboard/src/components/PlanApproval.tsx
@@ -11,9 +11,28 @@ export interface PlanApprovalProps {
   planHtml: string
   onApprove: () => void
   onFeedback: () => void
+  /**
+   * #6774 — combined "approve + auto-accept edits" action: approves the plan
+   * AND switches the session into `acceptEdits` in one step. Only wired (and
+   * only rendered, gated by {@link showAcceptEdits}) where the active
+   * provider supports permission-mode switching.
+   */
+  onApproveAcceptEdits?: () => void
+  /**
+   * Whether to render the combined "Approve & auto-accept edits" button.
+   * Mirrors the mode-picker gating (`caps?.permissionModeSwitch !== false`);
+   * providers that can't switch mode (e.g. claude-tui) don't get the button.
+   */
+  showAcceptEdits?: boolean
 }
 
-export function PlanApproval({ planHtml, onApprove, onFeedback }: PlanApprovalProps) {
+export function PlanApproval({
+  planHtml,
+  onApprove,
+  onFeedback,
+  onApproveAcceptEdits,
+  showAcceptEdits,
+}: PlanApprovalProps) {
   if (!planHtml) return null
 
   return (
@@ -37,6 +56,17 @@ export function PlanApproval({ planHtml, onApprove, onFeedback }: PlanApprovalPr
         <button className="btn-plan-approve" onClick={onApprove} type="button">
           Approve
         </button>
+        {showAcceptEdits && onApproveAcceptEdits && (
+          <button
+            className="btn-plan-approve-accept-edits"
+            data-testid="btn-plan-approve-accept-edits"
+            onClick={onApproveAcceptEdits}
+            type="button"
+            title="Approve this plan and auto-accept file edits for the work that follows"
+          >
+            Approve &amp; auto-accept edits
+          </button>
+        )}
         <button className="btn-plan-feedback" onClick={onFeedback} type="button">
           Feedback
         </button>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4502,6 +4502,25 @@ button.sidebar-token-view-session-row:hover {
 
 .btn-plan-approve:hover { background: #16a34a; }
 
+/* #6774 — combined "approve + auto-accept edits" action. Tinted-green outline
+   to read as a sibling of Approve (same intent) while staying visually
+   distinct from the solid primary Approve button. */
+.btn-plan-approve-accept-edits {
+  padding: 6px 18px;
+  border-radius: 6px;
+  border: 1px solid var(--accent-green);
+  background: transparent;
+  color: var(--accent-green);
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-plan-approve-accept-edits:hover {
+  background: var(--accent-green);
+  color: #fff;
+}
+
 .btn-plan-feedback {
   padding: 6px 18px;
   border-radius: 6px;

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -45,6 +45,12 @@ export { buildProviderLimitationNote } from './provider-capabilities'
 export type { DegradableCapabilities } from './provider-capabilities'
 export type { OtherFreeformAnswer } from './freeform-answer'
 
+// #6774 — combined "approve plan + auto-accept edits" action. Shared so both
+// clients dispatch the mode switch and the approval in the same (mode-first)
+// order — the server drops a mid-turn permission-mode change.
+export { approvePlanWithAcceptEdits, ACCEPT_EDITS_MODE } from './plan-approval'
+export type { ApprovePlanWithAcceptEditsDeps } from './plan-approval'
+
 // #6861 (epic #6760) — `#`-prefix composer quick-append: the shared prefix
 // parser, the ack payload parser, and the confirmation formatter (both clients).
 export {

--- a/packages/store-core/src/plan-approval.test.ts
+++ b/packages/store-core/src/plan-approval.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #6774 — combined "approve plan + auto-accept edits" action tests.
+ *
+ * The whole reason this logic is centralised is the ordering guarantee: the
+ * permission-mode switch must be dispatched BEFORE the approval (the server
+ * drops a mid-turn mode change). These tests lock that contract in.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { approvePlanWithAcceptEdits, ACCEPT_EDITS_MODE } from './plan-approval';
+
+describe('approvePlanWithAcceptEdits (#6774)', () => {
+  it('exposes acceptEdits as the target mode', () => {
+    expect(ACCEPT_EDITS_MODE).toBe('acceptEdits');
+  });
+
+  it('calls BOTH setPermissionMode(acceptEdits) and approve', () => {
+    const setPermissionMode = vi.fn();
+    const approve = vi.fn();
+    approvePlanWithAcceptEdits({ setPermissionMode, approve });
+    expect(setPermissionMode).toHaveBeenCalledTimes(1);
+    expect(setPermissionMode).toHaveBeenCalledWith('acceptEdits');
+    expect(approve).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches permission mode BEFORE approving (server rejects a mid-turn switch)', () => {
+    const order: string[] = [];
+    const setPermissionMode = vi.fn(() => order.push('setPermissionMode'));
+    const approve = vi.fn(() => order.push('approve'));
+    approvePlanWithAcceptEdits({ setPermissionMode, approve });
+    expect(order).toEqual(['setPermissionMode', 'approve']);
+  });
+
+  it('order holds even when approve is the client-supplied approve handler', () => {
+    // Simulate a client `approve` that, like the mobile handler, has its own
+    // side effects (send + clear plan state). The mode switch must still land
+    // first regardless of what approve does internally.
+    const calls: string[] = [];
+    const setPermissionMode = vi.fn((mode: string) => calls.push(`mode:${mode}`));
+    const approve = vi.fn(() => {
+      calls.push('send-approval');
+      calls.push('clear-plan-state');
+    });
+    approvePlanWithAcceptEdits({ setPermissionMode, approve });
+    expect(calls).toEqual(['mode:acceptEdits', 'send-approval', 'clear-plan-state']);
+  });
+});

--- a/packages/store-core/src/plan-approval.ts
+++ b/packages/store-core/src/plan-approval.ts
@@ -1,0 +1,57 @@
+/**
+ * #6774 — shared "approve plan + auto-accept edits" combined action.
+ *
+ * The plan-approval card in both clients (dashboard `PlanApproval.tsx`,
+ * mobile `PlanApprovalCard` in `ChatView.tsx`) offers a second affirmative
+ * action alongside the plain "Approve": approve the plan AND switch the
+ * session into `acceptEdits` permission mode in one step, so the
+ * implementation turn that follows runs with edits auto-accepted (desktop-app
+ * ExitPlanMode parity).
+ *
+ * The load-bearing detail is the ORDERING, which is why it lives here (single
+ * source of truth) rather than being open-coded twice: the mode switch MUST be
+ * dispatched BEFORE the approval. The server silently rejects a mid-turn
+ * permission-mode change (`packages/server/src/handlers/settings-handlers.js`
+ * — `set_permission_mode` no-ops with `PERMISSION_MODE_NOT_APPLIED` when the
+ * session is busy). Sending `approve` first starts the implementation turn, so
+ * a mode switch that arrived after it would land mid-turn and be dropped —
+ * leaving the user in `plan`/`approve` mode while believing edits are being
+ * auto-accepted. Switching first (while the session is idle, awaiting plan
+ * approval) guarantees `acceptEdits` is in effect before the turn begins.
+ *
+ * Gating (only offer the combined action for providers that support
+ * permission-mode switching) stays at each call site, mirroring the existing
+ * mode-picker gating (`caps?.permissionModeSwitch !== false`).
+ */
+
+/** The permission mode the combined plan-approval action switches into. */
+export const ACCEPT_EDITS_MODE = 'acceptEdits';
+
+export interface ApprovePlanWithAcceptEditsDeps {
+  /**
+   * Switch the active session's permission mode. Invoked with
+   * {@link ACCEPT_EDITS_MODE}. This is each client's existing
+   * `setPermissionMode` store action.
+   */
+  setPermissionMode: (mode: string) => void;
+  /**
+   * Register the plan approval — each client's existing plain-"Approve"
+   * handler (the dashboard `sendInput('approve')` path, the mobile
+   * `addUserMessage` + `sendInput` + `clearPlanState` path). Reusing it here
+   * keeps the plain and combined actions from drifting.
+   */
+  approve: () => void;
+}
+
+/**
+ * Run the combined "approve + auto-accept edits" action.
+ *
+ * Switches the session into {@link ACCEPT_EDITS_MODE} FIRST, then registers the
+ * approval — see the module comment for why the order is not interchangeable.
+ * Both dependencies are supplied by the caller so this stays a pure,
+ * client-agnostic orchestration of two side effects that is trivially testable.
+ */
+export function approvePlanWithAcceptEdits(deps: ApprovePlanWithAcceptEditsDeps): void {
+  deps.setPermissionMode(ACCEPT_EDITS_MODE);
+  deps.approve();
+}


### PR DESCRIPTION
## Summary

Adds a combined **"Approve & auto-accept edits"** action to the plan-approval card on **both** the dashboard and the mobile app. It approves the plan AND switches the session into `acceptEdits` permission mode in one step — desktop-app ExitPlanMode parity (proceed with edits auto-accepted). The existing plain **Approve** is untouched.

Previously, getting auto-accept after a plan required two manual steps: tap Approve, then separately open the permission-mode dropdown/SettingsBar and pick `acceptEdits`.

## What changed

- **`@chroxy/store-core` — shared `approvePlanWithAcceptEdits` helper** (`plan-approval.ts`). The load-bearing detail is ordering: it dispatches the **mode switch BEFORE the approval**. The server silently rejects a mid-turn permission-mode change (`settings-handlers.js` → `PERMISSION_MODE_NOT_APPLIED` when the session is busy), so `acceptEdits` must land while the session is idle (awaiting plan approval), before `approve` starts the implementation turn. Centralising it keeps both clients from drifting.
- **Dashboard** (`PlanApproval.tsx`, `App.tsx`, `components.css`) — new "Approve & auto-accept edits" button, gated on `dropdownFlags.showPermissionMode` (`caps?.permissionModeSwitch !== false`). `handlePlanApproveAcceptEdits` reuses the existing `handlePlanApprove` unchanged as the approve step.
- **App** (`ChatView.tsx` `PlanApprovalCard`, `SessionScreen.tsx`) — the same action as a full-width secondary button below the primary row, gated on `providerCaps.permissionModeSwitchSupported`. `handleApprovePlanAcceptEdits` reuses `handleApprovePlan`.
- **Degradation** — providers that declare `permissionModeSwitch: false` (e.g. `claude-tui`) never render the button; the plain Approve remains.

## How the two clients mirror

Both compute the same capability gate they already use for the mode picker, both reuse their existing plain-Approve handler as the `approve` step, and both route through the single `approvePlanWithAcceptEdits({ setPermissionMode, approve })` helper — so the mode-first ordering is identical across web and mobile.

## Acceptance criteria

- [x] A single action approves the plan and switches to `acceptEdits`
- [x] The plain "Approve" action is unchanged and still available
- [x] The combined action only appears for providers that support permission-mode switching

## Tests

- **store-core**: `plan-approval.test.ts` — asserts both `setPermissionMode('acceptEdits')` and `approve` fire, and that the mode switch precedes the approval.
- **dashboard**: extended `PermissionPrompt.test.tsx` — button renders when gated on, hidden when the provider can't switch / no handler wired, and fires `onApproveAcceptEdits` (without also firing plain approve).
- **app**: `ChatView.planAcceptEdits.test.tsx` — render/gate/tap coverage via react-test-renderer.
- **Maestro**: `plan-approval.yaml` asserts the combined button is present on the mobile card.

Full suites green locally: store-core (2031), dashboard (4611), app jest (2243), plus store-core/dashboard/app typechecks.

Closes #6774