### PR TITLE
fix(dashboard): stop composer textbox collapsing into a narrow column (#6624)

### DIFF
--- a/packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts
+++ b/packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts
@@ -1,0 +1,63 @@
+/**
+ * InputBar composer-layout CSS regression (#6624).
+ *
+ * The composer textbox collapsed into a narrow vertical column (text wrapping
+ * 1–2 words per line) whenever the flex-shrink:0 actions row (keyhint + mic +
+ * Evaluate + Send/Stop) was wide relative to a narrow composer. The row is a
+ * `flex-wrap: wrap` container, so the intended behaviour is for the actions to
+ * wrap onto their own line once the text input would drop below a readable
+ * minimum — NOT for the input to keep shrinking to nothing.
+ *
+ * jsdom has no layout engine, so we lock the structural CSS invariants that
+ * produce that behaviour instead of asserting pixel widths:
+ *   1. `.input-bar` wraps (so the actions can drop to a new line).
+ *   2. `.input-bar-textarea-wrap` grows AND has a positive min-width floor
+ *      (regressing back to `min-width: 0` reintroduces the collapse).
+ *   3. `.input-bar-actions` never shrinks (buttons stay usable; the input
+ *      yields the row, the actions do not shrink into it).
+ */
+import { describe, test, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+
+// Strip `/* ... */` comments so an explanatory comment that mentions a
+// declaration (e.g. describing the old `min-width: 0` regression) can't be
+// mistaken for a live rule by the naive selector matcher below.
+const componentsCss = fs
+  .readFileSync(path.resolve(__dirname, '../theme/components.css'), 'utf-8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+
+function ruleBody(selector: string): string {
+  // Escape regex metacharacters in the selector, then capture its `{ ... }`.
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = componentsCss.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+  expect(match, `expected a CSS rule for \`${selector}\``).not.toBeNull()
+  return match![1]!
+}
+
+describe('InputBar composer layout (#6624)', () => {
+  test('.input-bar is a wrapping flex row so the actions can drop to their own line', () => {
+    const body = ruleBody('.input-bar')
+    expect(body).toMatch(/display:\s*flex/)
+    expect(body).toMatch(/flex-wrap:\s*wrap/)
+  })
+
+  test('.input-bar-textarea-wrap grows and keeps a positive min-width floor (not 0)', () => {
+    const body = ruleBody('.input-bar-textarea-wrap')
+    expect(body).toMatch(/flex:\s*1/)
+    // The fix: a usable minimum width so the actions wrap instead of the
+    // textarea collapsing. A bare `min-width: 0` here is the regression.
+    const minWidth = body.match(/min-width:\s*([^;]+);/)
+    expect(minWidth, 'expected a min-width declaration').not.toBeNull()
+    const value = minWidth![1]!.trim()
+    expect(value).not.toBe('0')
+    // Guard the specific shape of the fix: a px floor capped at 100% so it
+    // never overflows panes narrower than the minimum.
+    expect(value).toMatch(/min\(\s*\d+px\s*,\s*100%\s*\)/)
+  })
+
+  test('.input-bar-actions never shrinks into the text input', () => {
+    const body = ruleBody('.input-bar-actions')
+    expect(body).toMatch(/flex-shrink:\s*0/)
+  })
+})

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5665,7 +5665,18 @@ button.sidebar-token-view-session-row:hover {
   position: relative;
   flex: 1;
   display: flex;
-  min-width: 0;
+  /* #6624 — usable minimum width. `.input-bar` is a `flex-wrap: wrap` row and
+   * `.input-bar-actions` is `flex-shrink: 0` (keyhint + mic + Evaluate +
+   * Send/Stop), so a bare `min-width: 0` here let the textarea collapse to a
+   * 1–2-word-wide column on a narrow composer (resized window / narrow session
+   * pane) while the actions kept their full width. Flooring the wrap at a
+   * readable minimum makes the actions wrap onto their own line instead of
+   * squeezing the input; the `100%` cap keeps the floor from overflowing panes
+   * narrower than the minimum (the wrap then takes the full row and actions
+   * wrap below — no horizontal scroll). Overlay-safe: the #4306 overlay is
+   * `inset: 0` inside this wrap and the textarea is `flex: 1` filling it, so
+   * both share the same box at any width and stay pixel-aligned. */
+  min-width: min(200px, 100%);
 }
 
 .input-bar-textarea-wrap > textarea {


### PR DESCRIPTION
Closes #6624

## Problem
The dashboard chat composer's textarea could collapse into an extremely narrow vertical column (text wrapping 1–2 words per line) while an attachment preview and the action buttons (`Evaluate`, `Send`, `Stop`, mic) were visible.

## Root cause
`.input-bar` is a `flex-wrap: wrap` row. Its two main-row flex children are:
- `.input-bar-textarea-wrap` — `flex: 1; min-width: 0`
- `.input-bar-actions` — `flex-shrink: 0` (keyhint + mic + Evaluate + Send/Stop)

Because the actions row never shrinks and the textarea wrapper had `min-width: 0`, on a **narrow composer** (resized desktop window, or a narrow session pane in multi-pane) the wide actions claimed the space and the textarea wrapper shrank to a sliver — instead of the actions wrapping to their own line. The attachment thumbnail in the report is a red herring; the previews already take their own full-width row (`width: 100%`). The squeeze came entirely from the actions-vs-input flex fight.

## Fix
Floor `.input-bar-textarea-wrap` at `min-width: min(200px, 100%)`:
- **200px** is a readable minimum for the text input. Once the input would drop below it, the `flex-wrap: wrap` container drops `.input-bar-actions` to their own line instead of squeezing the input.
- The **`100%` cap** keeps the floor from overflowing panes narrower than 200px — the wrapper then just takes the full row and the actions wrap below (no horizontal scroll).

`min(…)` is already used elsewhere in `components.css`; token-pure, no color literals (hex-lint clean).

### Overlay safety (#4306)
The `min-width: 0` was suspected to be load-bearing for the thinking-keyword highlight overlay. It is not: the overlay is `position: absolute; inset: 0` **inside** this wrapper and the textarea is `flex: 1` filling the wrapper, so overlay and textarea share the same box at any width and stay pixel-aligned regardless of the min-width floor.

## Validation
- New `InputBarComposerLayoutCss.test.ts` regression test locks the structural invariants (wrapping `.input-bar`, positive `min-width` floor on the wrap — guards against regressing to `min-width: 0`, non-shrinking `.input-bar-actions`).
- Full dashboard suite green: **265 files / 4619 tests pass**; `tsc --noEmit` clean; raw-color-literal lint clean.

## ⚠️ Manual verification requested (visual change)
jsdom has no layout engine, so the pixel behaviour can't be unit-tested. Please confirm live:
1. Start a session and keep the assistant turn active (Send/Stop + Evaluate + mic all visible).
2. Attach or paste an image into the composer.
3. Narrow the window (or use a narrow session pane) and type a follow-up.
4. **Expected:** the action buttons wrap onto their own line and the textarea keeps a readable, full-width row — no 1–2-word-per-line column.
5. Also sanity-check a wide composer (actions stay inline) and the thinking-keyword highlight overlay stays aligned with typed text while narrow.