### PR TITLE
feat(app,dashboard,protocol): codex sandbox selector on session create

### DIFF
--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -21,6 +21,7 @@ import {
   CODEX_PROVIDER,
   CODEX_DEFAULT_SANDBOX,
   CODEX_SANDBOX_MODE_META,
+  type CodexSandboxMode,
 } from '@chroxy/protocol';
 
 const PROVIDERS_TIMEOUT_MS = 5000;
@@ -40,7 +41,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   const [provider, setProvider] = useState('');
   // #6689 — per-session Codex sandbox mode; defaults to workspace-write and is
   // only surfaced/forwarded for the codex provider.
-  const [codexSandbox, setCodexSandbox] = useState<string>(CODEX_DEFAULT_SANDBOX);
+  const [codexSandbox, setCodexSandbox] = useState<CodexSandboxMode>(CODEX_DEFAULT_SANDBOX);
   const createSession = useConnectionStore((s) => s.createSession);
   const sessions = useConnectionStore((s) => s.sessions);
   const availableProviders = useConnectionStore((s) => s.availableProviders);

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -19,7 +19,6 @@ import { buildProviderLimitationNote } from '@chroxy/store-core';
 import {
   DEFAULT_PROVIDER,
   CODEX_PROVIDER,
-  CODEX_DEFAULT_SANDBOX,
   CODEX_SANDBOX_MODE_META,
   type CodexSandboxMode,
 } from '@chroxy/protocol';
@@ -34,14 +33,27 @@ interface CreateSessionModalProps {
 // '' means "use server default provider"; always shown as the first chip.
 const DEFAULT_PROVIDER_CHIP = { id: '', label: 'Default' };
 
+// #6903: "Default" forwards no `codexSandbox`, so the daemon's configured
+// sandbox (CHROXY_CODEX_SANDBOX floor, else workspace-write) is honored
+// instead of being silently overridden — mirrors the dashboard's Default
+// sandbox option (packages/dashboard/src/components/CreateSessionModal.tsx).
+// Always shown as the first chip, same as DEFAULT_PROVIDER_CHIP above.
+const CODEX_SANDBOX_DEFAULT_CHIP = { id: '' as const, label: 'Default' };
+const CODEX_SANDBOX_CHIPS: ReadonlyArray<{ id: '' | CodexSandboxMode; label: string }> = [
+  CODEX_SANDBOX_DEFAULT_CHIP,
+  ...CODEX_SANDBOX_MODE_META,
+];
+
 export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps) {
   const [name, setName] = useState('');
   const [cwd, setCwd] = useState('');
   const [worktree, setWorktree] = useState(false);
   const [provider, setProvider] = useState('');
-  // #6689 — per-session Codex sandbox mode; defaults to workspace-write and is
-  // only surfaced/forwarded for the codex provider.
-  const [codexSandbox, setCodexSandbox] = useState<CodexSandboxMode>(CODEX_DEFAULT_SANDBOX);
+  // #6689/#6903 — per-session Codex sandbox mode. '' is the "Default" option —
+  // it forwards no `codexSandbox`, so the daemon's CHROXY_CODEX_SANDBOX floor
+  // (else workspace-write) is honored, matching the dashboard's Default-omit
+  // path. Only surfaced/forwarded for the codex provider.
+  const [codexSandbox, setCodexSandbox] = useState<'' | CodexSandboxMode>('');
   const createSession = useConnectionStore((s) => s.createSession);
   const sessions = useConnectionStore((s) => s.sessions);
   const availableProviders = useConnectionStore((s) => s.availableProviders);
@@ -75,7 +87,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setShowBrowser(false);
       setWorktree(false);
       setProvider('');
-      setCodexSandbox(CODEX_DEFAULT_SANDBOX);
+      setCodexSandbox('');
       fetchProviders();
       startProvidersTimeout();
     } else {
@@ -108,11 +120,11 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
     }
   }, [availableProviders.length]);
 
-  // #6689 — reset the codex sandbox to the default on every provider change so
-  // a stale (e.g. danger-full-access) selection can't survive a provider
-  // round-trip and silently apply to a fresh codex session.
+  // #6689/#6903 — reset the codex sandbox to "Default" on every provider
+  // change so a stale (e.g. danger-full-access) selection can't survive a
+  // provider round-trip and silently apply to a fresh codex session.
   useEffect(() => {
-    setCodexSandbox(CODEX_DEFAULT_SANDBOX);
+    setCodexSandbox('');
   }, [provider]);
 
   const providerChips = [
@@ -151,14 +163,18 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       cwd: sessionCwd,
       worktree: worktree || undefined,
       provider: provider || undefined,
-      // #6689 — only forward the sandbox mode for codex; other providers ignore it.
-      codexSandbox: provider === CODEX_PROVIDER ? codexSandbox : undefined,
+      // #6689/#6903 — only forward the sandbox mode for codex, and only when
+      // the user explicitly picked one — '' is the "Default" option → omit so
+      // the daemon's CHROXY_CODEX_SANDBOX floor (else workspace-write) is
+      // honored instead of being silently overridden. Other providers never
+      // forward it.
+      codexSandbox: provider === CODEX_PROVIDER && codexSandbox ? codexSandbox : undefined,
     });
     setName('');
     setCwd('');
     setWorktree(false);
     setProvider('');
-    setCodexSandbox(CODEX_DEFAULT_SANDBOX);
+    setCodexSandbox('');
     onClose();
   };
 
@@ -167,7 +183,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
     setCwd('');
     setWorktree(false);
     setProvider('');
-    setCodexSandbox(CODEX_DEFAULT_SANDBOX);
+    setCodexSandbox('');
     onClose();
   };
 
@@ -315,18 +331,21 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
               </Text>
             ) : null}
 
-            {/* #6689 — Codex-only sandbox selector. Codex applies the sandbox at
-                thread start, so this is a create-time choice. Hidden for every
-                non-codex provider (they ignore the field). Options + labels are
-                single-sourced from CODEX_SANDBOX_MODE_META. */}
+            {/* #6689/#6903 — Codex-only sandbox selector. Codex applies the
+                sandbox at thread start, so this is a create-time choice.
+                Hidden for every non-codex provider (they ignore the field).
+                "Default" (the first chip, '') forwards no codexSandbox so the
+                daemon's CHROXY_CODEX_SANDBOX floor (else workspace-write) is
+                honored — mirrors the dashboard's Default option. The concrete
+                modes are single-sourced from CODEX_SANDBOX_MODE_META. */}
             {provider === CODEX_PROVIDER ? (
               <View testID="codex-sandbox-field">
                 <Text style={styles.label}>Codex sandbox</Text>
                 <View style={styles.providerRow}>
-                  {CODEX_SANDBOX_MODE_META.map((m) => (
+                  {CODEX_SANDBOX_CHIPS.map((m) => (
                     <TouchableOpacity
-                      key={m.id}
-                      testID={`codex-sandbox-chip-${m.id}`}
+                      key={m.id || '__default__'}
+                      testID={`codex-sandbox-chip-${m.id || 'default'}`}
                       style={[
                         styles.providerChip,
                         codexSandbox === m.id && styles.providerChipActive,
@@ -346,8 +365,10 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
                   ))}
                 </View>
                 <Text style={styles.toggleHint} testID="codex-sandbox-hint">
-                  {CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox)?.description
-                    ?? 'Controls how much of the filesystem the Codex sandbox may write.'}
+                  {codexSandbox === ''
+                    ? "Use the daemon's configured sandbox (CHROXY_CODEX_SANDBOX, else workspace-write)."
+                    : CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox)?.description
+                      ?? 'Controls how much of the filesystem the Codex sandbox may write.'}
                 </Text>
               </View>
             ) : null}

--- a/packages/app/src/components/CreateSessionModal.tsx
+++ b/packages/app/src/components/CreateSessionModal.tsx
@@ -16,7 +16,12 @@ import { FolderBrowser } from './FolderBrowser';
 import { COLORS } from '../constants/colors';
 import { getProviderLabel } from '../constants/providers';
 import { buildProviderLimitationNote } from '@chroxy/store-core';
-import { DEFAULT_PROVIDER } from '@chroxy/protocol';
+import {
+  DEFAULT_PROVIDER,
+  CODEX_PROVIDER,
+  CODEX_DEFAULT_SANDBOX,
+  CODEX_SANDBOX_MODE_META,
+} from '@chroxy/protocol';
 
 const PROVIDERS_TIMEOUT_MS = 5000;
 
@@ -33,6 +38,9 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
   const [cwd, setCwd] = useState('');
   const [worktree, setWorktree] = useState(false);
   const [provider, setProvider] = useState('');
+  // #6689 — per-session Codex sandbox mode; defaults to workspace-write and is
+  // only surfaced/forwarded for the codex provider.
+  const [codexSandbox, setCodexSandbox] = useState<string>(CODEX_DEFAULT_SANDBOX);
   const createSession = useConnectionStore((s) => s.createSession);
   const sessions = useConnectionStore((s) => s.sessions);
   const availableProviders = useConnectionStore((s) => s.availableProviders);
@@ -66,6 +74,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setShowBrowser(false);
       setWorktree(false);
       setProvider('');
+      setCodexSandbox(CODEX_DEFAULT_SANDBOX);
       fetchProviders();
       startProvidersTimeout();
     } else {
@@ -97,6 +106,13 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       setProvidersTimedOut(false);
     }
   }, [availableProviders.length]);
+
+  // #6689 — reset the codex sandbox to the default on every provider change so
+  // a stale (e.g. danger-full-access) selection can't survive a provider
+  // round-trip and silently apply to a fresh codex session.
+  useEffect(() => {
+    setCodexSandbox(CODEX_DEFAULT_SANDBOX);
+  }, [provider]);
 
   const providerChips = [
     { ...DEFAULT_PROVIDER_CHIP, ready: true, detail: '' },
@@ -134,11 +150,14 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
       cwd: sessionCwd,
       worktree: worktree || undefined,
       provider: provider || undefined,
+      // #6689 — only forward the sandbox mode for codex; other providers ignore it.
+      codexSandbox: provider === CODEX_PROVIDER ? codexSandbox : undefined,
     });
     setName('');
     setCwd('');
     setWorktree(false);
     setProvider('');
+    setCodexSandbox(CODEX_DEFAULT_SANDBOX);
     onClose();
   };
 
@@ -147,6 +166,7 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
     setCwd('');
     setWorktree(false);
     setProvider('');
+    setCodexSandbox(CODEX_DEFAULT_SANDBOX);
     onClose();
   };
 
@@ -294,11 +314,53 @@ export function CreateSessionModal({ visible, onClose }: CreateSessionModalProps
               </Text>
             ) : null}
 
+            {/* #6689 — Codex-only sandbox selector. Codex applies the sandbox at
+                thread start, so this is a create-time choice. Hidden for every
+                non-codex provider (they ignore the field). Options + labels are
+                single-sourced from CODEX_SANDBOX_MODE_META. */}
+            {provider === CODEX_PROVIDER ? (
+              <View testID="codex-sandbox-field">
+                <Text style={styles.label}>Codex sandbox</Text>
+                <View style={styles.providerRow}>
+                  {CODEX_SANDBOX_MODE_META.map((m) => (
+                    <TouchableOpacity
+                      key={m.id}
+                      testID={`codex-sandbox-chip-${m.id}`}
+                      style={[
+                        styles.providerChip,
+                        codexSandbox === m.id && styles.providerChipActive,
+                      ]}
+                      onPress={() => setCodexSandbox(m.id)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Codex sandbox: ${m.label}`}
+                      accessibilityState={{ selected: codexSandbox === m.id }}
+                    >
+                      <Text style={[
+                        styles.providerChipText,
+                        codexSandbox === m.id && styles.providerChipTextActive,
+                      ]}>
+                        {m.label}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+                <Text style={styles.toggleHint} testID="codex-sandbox-hint">
+                  {CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox)?.description
+                    ?? 'Controls how much of the filesystem the Codex sandbox may write.'}
+                </Text>
+              </View>
+            ) : null}
+
             <View style={styles.buttons}>
               <TouchableOpacity style={styles.cancelButton} onPress={handleCancel}>
                 <Text style={styles.cancelButtonText}>Cancel</Text>
               </TouchableOpacity>
-              <TouchableOpacity style={styles.createButton} onPress={handleCreate}>
+              <TouchableOpacity
+                style={styles.createButton}
+                onPress={handleCreate}
+                accessibilityRole="button"
+                accessibilityLabel="Create session"
+              >
                 <Text style={styles.createButtonText}>Create</Text>
               </TouchableOpacity>
             </View>

--- a/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
+++ b/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
@@ -307,7 +307,7 @@ describe('CreateSessionModal — #6312/#6352 provider capability-limitation note
   });
 });
 
-describe('CreateSessionModal — #6689 codex sandbox selector', () => {
+describe('CreateSessionModal — #6689/#6903 codex sandbox selector', () => {
   it('does NOT render the sandbox selector until codex is selected', () => {
     setupStore([{ name: 'codex', auth: { ready: true } }]);
 
@@ -320,7 +320,7 @@ describe('CreateSessionModal — #6689 codex sandbox selector', () => {
     expect(component!.root.findAllByProps({ testID: 'codex-sandbox-field' })).toHaveLength(0);
   });
 
-  it('renders the sandbox selector after selecting the codex provider', () => {
+  it('renders the sandbox selector after selecting the codex provider, including a Default chip', () => {
     setupStore([{ name: 'codex', auth: { ready: true } }]);
 
     let component: renderer.ReactTestRenderer;
@@ -333,13 +333,30 @@ describe('CreateSessionModal — #6689 codex sandbox selector', () => {
     });
 
     expect(component!.root.findByProps({ testID: 'codex-sandbox-field' })).toBeTruthy();
-    // All three mode chips are present.
+    // Default chip plus all three mode chips are present.
+    expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-default' })).toBeTruthy();
     expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-read-only' })).toBeTruthy();
     expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-workspace-write' })).toBeTruthy();
     expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-danger-full-access' })).toBeTruthy();
   });
 
-  it('forwards codexSandbox: workspace-write by default for a codex session', () => {
+  it('defaults to the "Default" chip on fresh open, selected via accessibilityState', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Provider: Codex (CLI)' }).props.onPress();
+    });
+
+    const defaultChip = component!.root.findByProps({ testID: 'codex-sandbox-chip-default' });
+    expect(defaultChip.props.accessibilityState).toMatchObject({ selected: true });
+  });
+
+  it('omits codexSandbox by default so the daemon env floor is honored (#6903)', () => {
     setupStore([{ name: 'codex', auth: { ready: true } }]);
 
     let component: renderer.ReactTestRenderer;
@@ -355,10 +372,8 @@ describe('CreateSessionModal — #6689 codex sandbox selector', () => {
     });
 
     expect(mockCreateSession).toHaveBeenCalledTimes(1);
-    expect(mockCreateSession.mock.calls[0][0]).toMatchObject({
-      provider: 'codex',
-      codexSandbox: 'workspace-write',
-    });
+    expect(mockCreateSession.mock.calls[0][0].provider).toBe('codex');
+    expect(mockCreateSession.mock.calls[0][0].codexSandbox).toBeUndefined();
   });
 
   it('forwards the chosen sandbox mode when a chip is tapped', () => {
@@ -384,6 +399,32 @@ describe('CreateSessionModal — #6689 codex sandbox selector', () => {
       provider: 'codex',
       codexSandbox: 'read-only',
     });
+  });
+
+  it('omits codexSandbox again when the Default chip is re-selected (#6903)', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Provider: Codex (CLI)' }).props.onPress();
+    });
+    act(() => {
+      component!.root.findByProps({ testID: 'codex-sandbox-chip-read-only' }).props.onPress();
+    });
+    act(() => {
+      component!.root.findByProps({ testID: 'codex-sandbox-chip-default' }).props.onPress();
+    });
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Create session' }).props.onPress();
+    });
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession.mock.calls[0][0].provider).toBe('codex');
+    expect(mockCreateSession.mock.calls[0][0].codexSandbox).toBeUndefined();
   });
 
   it('does NOT forward codexSandbox for a non-codex provider', () => {

--- a/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
+++ b/packages/app/src/components/__tests__/CreateSessionModal.test.tsx
@@ -306,3 +306,100 @@ describe('CreateSessionModal — #6312/#6352 provider capability-limitation note
     expect(component!.root.findAllByProps({ testID: 'provider-limitation-note' })).toHaveLength(0);
   });
 });
+
+describe('CreateSessionModal — #6689 codex sandbox selector', () => {
+  it('does NOT render the sandbox selector until codex is selected', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    // Default provider chip ('') is active on open — selector hidden.
+    expect(component!.root.findAllByProps({ testID: 'codex-sandbox-field' })).toHaveLength(0);
+  });
+
+  it('renders the sandbox selector after selecting the codex provider', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Provider: Codex (CLI)' }).props.onPress();
+    });
+
+    expect(component!.root.findByProps({ testID: 'codex-sandbox-field' })).toBeTruthy();
+    // All three mode chips are present.
+    expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-read-only' })).toBeTruthy();
+    expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-workspace-write' })).toBeTruthy();
+    expect(component!.root.findByProps({ testID: 'codex-sandbox-chip-danger-full-access' })).toBeTruthy();
+  });
+
+  it('forwards codexSandbox: workspace-write by default for a codex session', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Provider: Codex (CLI)' }).props.onPress();
+    });
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Create session' }).props.onPress();
+    });
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession.mock.calls[0][0]).toMatchObject({
+      provider: 'codex',
+      codexSandbox: 'workspace-write',
+    });
+  });
+
+  it('forwards the chosen sandbox mode when a chip is tapped', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Provider: Codex (CLI)' }).props.onPress();
+    });
+    act(() => {
+      component!.root.findByProps({ testID: 'codex-sandbox-chip-read-only' }).props.onPress();
+    });
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Create session' }).props.onPress();
+    });
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession.mock.calls[0][0]).toMatchObject({
+      provider: 'codex',
+      codexSandbox: 'read-only',
+    });
+  });
+
+  it('does NOT forward codexSandbox for a non-codex provider', () => {
+    setupStore([{ name: 'codex', auth: { ready: true } }]);
+
+    let component: renderer.ReactTestRenderer;
+    act(() => {
+      component = renderer.create(<CreateSessionModal visible onClose={jest.fn()} />);
+    });
+
+    // Leave the Default provider chip selected (resolves to a non-codex provider).
+    act(() => {
+      component!.root.findByProps({ accessibilityLabel: 'Create session' }).props.onPress();
+    });
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession.mock.calls[0][0].codexSandbox).toBeUndefined();
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -2450,7 +2450,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // future fields a one-place change. Server's `create_session` handler
   // accepts these fields plus others (e.g. `sandbox`) — see
   // packages/server/src/handlers/session-handlers.js for the full set.
-  createSession: ({ name, cwd, worktree, provider, model, permissionMode, environmentId }) => {
+  createSession: ({ name, cwd, worktree, provider, model, permissionMode, environmentId, codexSandbox }) => {
     const msg: Record<string, unknown> = { type: 'create_session' };
     if (name) msg.name = name;
     if (cwd) msg.cwd = cwd;
@@ -2459,6 +2459,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     if (model) msg.model = model;
     if (permissionMode) msg.permissionMode = permissionMode;
     if (environmentId) msg.environmentId = environmentId;
+    // #6689 — per-session Codex sandbox mode. Only present when the modal is
+    // creating a codex session; other providers omit it (server ignores it).
+    if (codexSandbox) msg.codexSandbox = codexSandbox;
     sendIfOpen(msg);
   },
 

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -480,6 +480,13 @@ export interface CreateSessionOptions {
    * selecting one but forwards it on the wire if a future caller passes it.
    */
   environmentId?: string;
+  /**
+   * #6689 — per-session Codex sandbox mode ('read-only' | 'workspace-write' |
+   * 'danger-full-access'). Only set when the selected provider is `codex`;
+   * other providers ignore it. Surfaced in the New Session modal as a
+   * codex-only selector.
+   */
+  codexSandbox?: string;
 }
 
 /**

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -481,11 +481,13 @@ export interface CreateSessionOptions {
    */
   environmentId?: string;
   /**
-   * #6689 — per-session Codex sandbox mode ('read-only' | 'workspace-write' |
-   * 'danger-full-access'). Only set when the selected provider is `codex`;
-   * other providers ignore it. Surfaced in the New Session modal as a
-   * codex-only selector. Narrowed to the wire enum so an invalid value can't
-   * compile (Copilot #6900).
+   * #6689/#6903 — per-session Codex sandbox mode ('read-only' |
+   * 'workspace-write' | 'danger-full-access'). `undefined` means "use the
+   * daemon's configured sandbox" (CHROXY_CODEX_SANDBOX, else workspace-write)
+   * — the modal's "Default" chip. Only set when the selected provider is
+   * `codex`; other providers ignore it. Surfaced in the New Session modal as
+   * a codex-only selector. Narrowed to the wire enum so an invalid value
+   * can't compile (Copilot #6900).
    */
   codexSandbox?: CodexSandboxMode;
 }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -11,7 +11,7 @@
 
 // #6453 — canonical WIRE attachment type for the sendInput signature (was an
 // inline `{ type; mediaType; data; name }[]`; the app only sends binary).
-import type { BinaryAttachment, ServerPermissionInputMessage } from '@chroxy/protocol';
+import type { BinaryAttachment, ServerPermissionInputMessage, CodexSandboxMode } from '@chroxy/protocol';
 
 // Re-export shared protocol types from store-core
 export type {
@@ -484,9 +484,10 @@ export interface CreateSessionOptions {
    * #6689 — per-session Codex sandbox mode ('read-only' | 'workspace-write' |
    * 'danger-full-access'). Only set when the selected provider is `codex`;
    * other providers ignore it. Surfaced in the New Session modal as a
-   * codex-only selector.
+   * codex-only selector. Narrowed to the wire enum so an invalid value can't
+   * compile (Copilot #6900).
    */
-  codexSandbox?: string;
+  codexSandbox?: CodexSandboxMode;
 }
 
 /**

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -13,8 +13,8 @@ import { useConnectionStore } from '../store/connection'
 import { buildProviderLimitationNote } from '@chroxy/store-core'
 import {
   CODEX_PROVIDER,
-  CODEX_DEFAULT_SANDBOX,
   CODEX_SANDBOX_MODE_META,
+  type CodexSandboxMode,
 } from '@chroxy/protocol'
 import type { DirectoryListing, DirectoryEntry, ModelInfo } from '../store/types'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
@@ -27,10 +27,12 @@ export interface CreateSessionData {
   model?: string
   worktree?: boolean
   environmentId?: string
-  // #6689: per-session Codex sandbox mode ('read-only' | 'workspace-write' |
-  // 'danger-full-access'). Only set when the selected provider is `codex`;
-  // undefined for all other providers (the server ignores it anyway).
-  codexSandbox?: string
+  // #6689/#6903: per-session Codex sandbox mode. `undefined` means "use the
+  // daemon's configured sandbox" (CHROXY_CODEX_SANDBOX, else workspace-write) —
+  // the picker's "Default" option. Only set when the selected provider is
+  // `codex`; undefined for all other providers (the server ignores it anyway).
+  // Narrowed to the wire enum so an invalid value can't compile (Copilot #6900).
+  codexSandbox?: CodexSandboxMode
   // #4208: spawn the claude TUI with --dangerously-skip-permissions and
   // elide chroxy's permission hook entirely. Only the `claude-tui`
   // provider honours this — the checkbox is hidden for other providers
@@ -210,9 +212,11 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [permissionMode, setPermissionMode] = useState('')
   const [worktree, setWorktree] = useState(false)
-  // #6689: per-session Codex sandbox mode. Defaults to workspace-write (the
-  // server default) and is only surfaced/forwarded for the `codex` provider.
-  const [codexSandbox, setCodexSandbox] = useState<string>(CODEX_DEFAULT_SANDBOX)
+  // #6689/#6903: per-session Codex sandbox mode. '' is the "Default" option — it
+  // forwards no `codexSandbox`, so the daemon's CHROXY_CODEX_SANDBOX floor (else
+  // workspace-write) is honored, matching the mobile app's Default-provider omit
+  // path. Only surfaced/forwarded for the `codex` provider.
+  const [codexSandbox, setCodexSandbox] = useState<'' | CodexSandboxMode>('')
   // #4208/#4244: TUI-only opt-in to spawn claude with
   // --dangerously-skip-permissions. Tri-state (#4244) so the modal can
   // submit an explicit `false` and override a server-wide
@@ -306,7 +310,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     setShowAdvanced(false)
     setPermissionMode('')
     setWorktree(false)
-    setCodexSandbox(CODEX_DEFAULT_SANDBOX)
+    setCodexSandbox('')
     setSkipPermissions('inherit')
     setShowSuggestions(false)
     setSelectedSuggestion(-1)
@@ -346,7 +350,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     // #6689: reset the codex sandbox to the default on every provider change so
     // a stale (e.g. danger-full-access) selection can't survive a provider
     // round-trip and silently apply to a fresh codex session.
-    setCodexSandbox(CODEX_DEFAULT_SANDBOX)
+    setCodexSandbox('')
   }, [provider])
 
   // #4340: gate the Create button on the selected provider being ready.
@@ -382,9 +386,12 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     const skipPermissionsOut: boolean | undefined = provider === 'claude-tui'
       ? (skipPermissions === 'on' ? true : skipPermissions === 'off' ? false : undefined)
       : undefined
-    // #6689: only forward the sandbox mode for codex — other providers ignore
-    // it, and sending it would pointlessly clutter the wire message.
-    const codexSandboxOut: string | undefined = provider === CODEX_PROVIDER ? codexSandbox : undefined
+    // #6689/#6903: only forward the sandbox mode for codex, and only when the
+    // user explicitly picked one — '' is the "Default" option → omit so the
+    // daemon's CHROXY_CODEX_SANDBOX floor (else workspace-write) is honored
+    // instead of being silently overridden. Other providers never forward it.
+    const codexSandboxOut: CodexSandboxMode | undefined =
+      provider === CODEX_PROVIDER && codexSandbox ? codexSandbox : undefined
     onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined, skipPermissions: skipPermissionsOut, codexSandbox: codexSandboxOut })
   }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions, codexSandbox, selectedProviderUnready])
 
@@ -921,17 +928,23 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 id="codex-sandbox-select"
                 data-testid="codex-sandbox-select"
                 value={codexSandbox}
-                onChange={e => setCodexSandbox(e.target.value)}
+                onChange={e => setCodexSandbox(e.target.value as '' | CodexSandboxMode)}
                 aria-label="Codex sandbox mode"
                 aria-describedby="codex-sandbox-hint"
               >
+                {/* #6903: "Default" forwards no codexSandbox, so the daemon's
+                    CHROXY_CODEX_SANDBOX floor (else workspace-write) is honored
+                    — matching the mobile app's Default-provider omit path. */}
+                <option value="">Default</option>
                 {CODEX_SANDBOX_MODE_META.map((m) => (
                   <option key={m.id} value={m.id}>{m.label}</option>
                 ))}
               </select>
               <span id="codex-sandbox-hint" className="form-hint">
-                {CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox)?.description
-                  ?? 'Controls how much of the filesystem the Codex sandbox may write.'}
+                {codexSandbox === ''
+                  ? "Use the daemon's configured sandbox (CHROXY_CODEX_SANDBOX, else workspace-write)."
+                  : CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox)?.description
+                    ?? 'Controls how much of the filesystem the Codex sandbox may write.'}
               </span>
             </div>
           )}

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -11,6 +11,11 @@ import { usePathAutocomplete } from '../hooks/usePathAutocomplete'
 import { DirectoryBrowser } from './DirectoryBrowser'
 import { useConnectionStore } from '../store/connection'
 import { buildProviderLimitationNote } from '@chroxy/store-core'
+import {
+  CODEX_PROVIDER,
+  CODEX_DEFAULT_SANDBOX,
+  CODEX_SANDBOX_MODE_META,
+} from '@chroxy/protocol'
 import type { DirectoryListing, DirectoryEntry, ModelInfo } from '../store/types'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
 
@@ -22,6 +27,10 @@ export interface CreateSessionData {
   model?: string
   worktree?: boolean
   environmentId?: string
+  // #6689: per-session Codex sandbox mode ('read-only' | 'workspace-write' |
+  // 'danger-full-access'). Only set when the selected provider is `codex`;
+  // undefined for all other providers (the server ignores it anyway).
+  codexSandbox?: string
   // #4208: spawn the claude TUI with --dangerously-skip-permissions and
   // elide chroxy's permission hook entirely. Only the `claude-tui`
   // provider honours this — the checkbox is hidden for other providers
@@ -201,6 +210,9 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [permissionMode, setPermissionMode] = useState('')
   const [worktree, setWorktree] = useState(false)
+  // #6689: per-session Codex sandbox mode. Defaults to workspace-write (the
+  // server default) and is only surfaced/forwarded for the `codex` provider.
+  const [codexSandbox, setCodexSandbox] = useState<string>(CODEX_DEFAULT_SANDBOX)
   // #4208/#4244: TUI-only opt-in to spawn claude with
   // --dangerously-skip-permissions. Tri-state (#4244) so the modal can
   // submit an explicit `false` and override a server-wide
@@ -294,6 +306,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     setShowAdvanced(false)
     setPermissionMode('')
     setWorktree(false)
+    setCodexSandbox(CODEX_DEFAULT_SANDBOX)
     setSkipPermissions('inherit')
     setShowSuggestions(false)
     setSelectedSuggestion(-1)
@@ -330,6 +343,10 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   // still acts as belt + braces in case this reset races a submit.
   useEffect(() => {
     setSkipPermissions('inherit')
+    // #6689: reset the codex sandbox to the default on every provider change so
+    // a stale (e.g. danger-full-access) selection can't survive a provider
+    // round-trip and silently apply to a fresh codex session.
+    setCodexSandbox(CODEX_DEFAULT_SANDBOX)
   }, [provider])
 
   // #4340: gate the Create button on the selected provider being ready.
@@ -365,8 +382,11 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     const skipPermissionsOut: boolean | undefined = provider === 'claude-tui'
       ? (skipPermissions === 'on' ? true : skipPermissions === 'off' ? false : undefined)
       : undefined
-    onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined, skipPermissions: skipPermissionsOut })
-  }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions, selectedProviderUnready])
+    // #6689: only forward the sandbox mode for codex — other providers ignore
+    // it, and sending it would pointlessly clutter the wire message.
+    const codexSandboxOut: string | undefined = provider === CODEX_PROVIDER ? codexSandbox : undefined
+    onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined, skipPermissions: skipPermissionsOut, codexSandbox: codexSandboxOut })
+  }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions, codexSandbox, selectedProviderUnready])
 
   const selectSuggestion = useCallback((path: string) => {
     setCwd(path)
@@ -888,6 +908,33 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
               })()}
             </span>
           </div>
+          {/* #6689: Codex-only sandbox selector. Codex applies the sandbox at
+              thread start, so this is a create-time choice; changing it later
+              needs a new session (see docs/design/codex-permission-model.md §5).
+              Hidden for every non-codex provider (they ignore the field). The
+              options + labels are single-sourced from CODEX_SANDBOX_MODE_META so
+              the picker can't drift from the wire enum. */}
+          {provider === CODEX_PROVIDER && (
+            <div className="form-field" data-testid="codex-sandbox-field">
+              <label htmlFor="codex-sandbox-select">Codex sandbox</label>
+              <select
+                id="codex-sandbox-select"
+                data-testid="codex-sandbox-select"
+                value={codexSandbox}
+                onChange={e => setCodexSandbox(e.target.value)}
+                aria-label="Codex sandbox mode"
+                aria-describedby="codex-sandbox-hint"
+              >
+                {CODEX_SANDBOX_MODE_META.map((m) => (
+                  <option key={m.id} value={m.id}>{m.label}</option>
+                ))}
+              </select>
+              <span id="codex-sandbox-hint" className="form-hint">
+                {CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox)?.description
+                  ?? 'Controls how much of the filesystem the Codex sandbox may write.'}
+              </span>
+            </div>
+          )}
           <div className="form-field form-field--checkbox">
             <label className="checkbox-label">
               <input

--- a/packages/dashboard/src/components/CreateSessionModalCodexSandbox.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalCodexSandbox.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for the codex-only sandbox selector on the Create Session modal (#6689).
+ *
+ * The control MUST:
+ *   - render only when the active provider is `codex`
+ *   - default to `workspace-write` on fresh open
+ *   - forward the chosen mode as `codexSandbox` for a codex session
+ *   - NOT forward `codexSandbox` for a non-codex provider
+ *
+ * The options + labels are single-sourced from `@chroxy/protocol`'s
+ * `CODEX_SANDBOX_MODE_META`, so a drift there would surface here.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+const CODEX_PROVIDER = {
+  name: 'codex',
+  capabilities: {},
+  auth: { ready: true, source: 'static', detail: '' },
+}
+const SDK_PROVIDER = {
+  name: 'claude-sdk',
+  capabilities: {},
+  auth: { ready: true, source: 'static', detail: '' },
+}
+
+function mockStore(defaultProvider: string, providers = [CODEX_PROVIDER, SDK_PROVIDER]) {
+  vi.doMock('../store/connection', () => ({
+    useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        defaultProvider,
+        defaultModel: null,
+        availableModels: [],
+        availableModelsProvider: null,
+        availableProviders: providers,
+        availablePermissionModes: [],
+        environments: [],
+        requestDirectoryListing: () => {},
+        setDirectoryListingCallback: () => {},
+        defaultCwd: null,
+      }),
+  }))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.resetModules()
+  vi.doUnmock('../store/connection')
+})
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  initialCwd: '/Users/me/projects',
+  knownCwds: [] as string[],
+  existingNames: [] as string[],
+}
+
+async function loadModal() {
+  const mod = await import('./CreateSessionModal')
+  return mod.CreateSessionModal
+}
+
+function openAdvanced() {
+  fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+}
+
+describe('CreateSessionModal codex sandbox selector (#6689)', () => {
+  it('renders the sandbox selector when the active provider is codex', async () => {
+    mockStore('codex')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    expect(screen.getByTestId('codex-sandbox-field')).toBeInTheDocument()
+    expect(screen.getByTestId('codex-sandbox-select')).toBeInTheDocument()
+  })
+
+  it('does NOT render the selector for a non-codex provider (claude-sdk)', async () => {
+    mockStore('claude-sdk')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    expect(screen.queryByTestId('codex-sandbox-field')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('codex-sandbox-select')).not.toBeInTheDocument()
+  })
+
+  it('defaults to workspace-write on fresh open', async () => {
+    mockStore('codex')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    const select = screen.getByTestId('codex-sandbox-select') as HTMLSelectElement
+    expect(select.value).toBe('workspace-write')
+  })
+
+  it('offers all three sandbox modes', async () => {
+    mockStore('codex')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    const select = screen.getByTestId('codex-sandbox-select') as HTMLSelectElement
+    const values = Array.from(select.options).map((o) => o.value)
+    expect(values).toEqual(['read-only', 'workspace-write', 'danger-full-access'])
+  })
+
+  it('forwards codexSandbox: workspace-write by default for a codex session', async () => {
+    mockStore('codex')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0]).toMatchObject({
+      provider: 'codex',
+      codexSandbox: 'workspace-write',
+    })
+  })
+
+  it('forwards the chosen sandbox mode when changed', async () => {
+    mockStore('codex')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    openAdvanced()
+    const select = screen.getByTestId('codex-sandbox-select') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'read-only' } })
+    expect(select.value).toBe('read-only')
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0]).toMatchObject({
+      provider: 'codex',
+      codexSandbox: 'read-only',
+    })
+  })
+
+  it('does NOT forward codexSandbox for a non-codex provider', async () => {
+    mockStore('claude-sdk')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0].codexSandbox).toBeUndefined()
+  })
+})

--- a/packages/dashboard/src/components/CreateSessionModalCodexSandbox.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalCodexSandbox.test.tsx
@@ -3,7 +3,10 @@
  *
  * The control MUST:
  *   - render only when the active provider is `codex`
- *   - default to `workspace-write` on fresh open
+ *   - default to the "Default" option (empty value) on fresh open, which
+ *     forwards NO `codexSandbox` so the daemon's CHROXY_CODEX_SANDBOX floor
+ *     (else workspace-write) is honored instead of being silently overridden
+ *     (#6903 — parity with the mobile app's Default-provider omit path)
  *   - forward the chosen mode as `codexSandbox` for a codex session
  *   - NOT forward `codexSandbox` for a non-codex provider
  *
@@ -88,36 +91,53 @@ describe('CreateSessionModal codex sandbox selector (#6689)', () => {
     expect(screen.queryByTestId('codex-sandbox-select')).not.toBeInTheDocument()
   })
 
-  it('defaults to workspace-write on fresh open', async () => {
+  it('defaults to the "Default" (omit) option on fresh open (#6903)', async () => {
     mockStore('codex')
     const CreateSessionModal = await loadModal()
     render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
     openAdvanced()
     const select = screen.getByTestId('codex-sandbox-select') as HTMLSelectElement
-    expect(select.value).toBe('workspace-write')
+    // '' is the "Default" option — it forwards no codexSandbox.
+    expect(select.value).toBe('')
   })
 
-  it('offers all three sandbox modes', async () => {
+  it('offers a Default option plus all three sandbox modes (#6903)', async () => {
     mockStore('codex')
     const CreateSessionModal = await loadModal()
     render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
     openAdvanced()
     const select = screen.getByTestId('codex-sandbox-select') as HTMLSelectElement
     const values = Array.from(select.options).map((o) => o.value)
-    expect(values).toEqual(['read-only', 'workspace-write', 'danger-full-access'])
+    expect(values).toEqual(['', 'read-only', 'workspace-write', 'danger-full-access'])
   })
 
-  it('forwards codexSandbox: workspace-write by default for a codex session', async () => {
+  it('omits codexSandbox by default so the daemon env floor is honored (#6903)', async () => {
     mockStore('codex')
     const CreateSessionModal = await loadModal()
     const onCreate = vi.fn()
     render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
     expect(onCreate).toHaveBeenCalledTimes(1)
-    expect(onCreate.mock.calls[0]![0]).toMatchObject({
-      provider: 'codex',
-      codexSandbox: 'workspace-write',
-    })
+    // Provider is codex, but the untouched "Default" selection forwards no
+    // codexSandbox — the server's resolveCodexSandbox honors CHROXY_CODEX_SANDBOX.
+    expect(onCreate.mock.calls[0]![0].provider).toBe('codex')
+    expect(onCreate.mock.calls[0]![0].codexSandbox).toBeUndefined()
+  })
+
+  it('omits codexSandbox again when the Default option is re-selected (#6903)', async () => {
+    mockStore('codex')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    openAdvanced()
+    const select = screen.getByTestId('codex-sandbox-select') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'read-only' } })
+    fireEvent.change(select, { target: { value: '' } })
+    expect(select.value).toBe('')
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0].provider).toBe('codex')
+    expect(onCreate.mock.calls[0]![0].codexSandbox).toBeUndefined()
   })
 
   it('forwards the chosen sandbox mode when changed', async () => {

--- a/packages/dashboard/src/components/CreateSessionModalFreshOpen.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalFreshOpen.test.tsx
@@ -181,9 +181,10 @@ describe('CreateSessionModal fresh-open guard (#2679)', () => {
       permissionMode: undefined,
       worktree: undefined,
       environmentId: undefined,
-      // #6689: a codex session now carries the per-session sandbox mode,
-      // defaulting to workspace-write.
-      codexSandbox: 'workspace-write',
+      // #6903: a codex session's sandbox now defaults to the "Default" option,
+      // which forwards no codexSandbox so the daemon's CHROXY_CODEX_SANDBOX floor
+      // (else workspace-write) is honored rather than silently overridden.
+      codexSandbox: undefined,
     })
   })
 

--- a/packages/dashboard/src/components/CreateSessionModalFreshOpen.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalFreshOpen.test.tsx
@@ -181,6 +181,9 @@ describe('CreateSessionModal fresh-open guard (#2679)', () => {
       permissionMode: undefined,
       worktree: undefined,
       environmentId: undefined,
+      // #6689: a codex session now carries the per-session sandbox mode,
+      // defaulting to workspace-write.
+      codexSandbox: 'workspace-write',
     })
   })
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -4255,7 +4255,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // the socket is closed the create is a silent no-op, so the caller must NOT
   // latch its "Creating…" spinner (it would wedge forever — nothing arrives to
   // clear it). Mirrors revokeToken's not-open guard: false = nothing sent.
-  createSession: ({ name, cwd, provider, model, permissionMode, worktree, environmentId, skipPermissions }): boolean => {
+  createSession: ({ name, cwd, provider, model, permissionMode, worktree, environmentId, skipPermissions, codexSandbox }): boolean => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       const msg: Record<string, unknown> = { type: 'create_session' };
@@ -4266,6 +4266,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (permissionMode) msg.permissionMode = permissionMode;
       if (worktree) msg.worktree = true;
       if (environmentId) msg.environmentId = environmentId;
+      // #6689: per-session Codex sandbox mode. Only forwarded when the caller
+      // (the create-session modal, for a codex session) passes it — non-codex
+      // providers omit it and the server ignores it if present. The wire schema
+      // rejects any value outside CODEX_SANDBOX_MODES.
+      if (codexSandbox) msg.codexSandbox = codexSandbox;
       // #4208: TUI-only opt-in to claude --dangerously-skip-permissions.
       // Forward whenever the caller passes a strict boolean so an explicit
       // `false` can override a server-wide `defaultSkipPermissions: true`

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1704,7 +1704,7 @@ export interface ConnectionState {
    * `false` means the socket was closed and nothing was sent, so the caller
    * must skip latching its "Creating…" spinner (no reply will arrive to clear it).
    */
-  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean }) => boolean;
+  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean; codexSandbox?: string }) => boolean;
   destroySession: (sessionId: string, force?: boolean) => void;
   /** #6006 — operator panic button: request an immediate token revoke (primary-token only). */
   revokeToken: () => void;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -16,7 +16,7 @@ import type { PermissionMode } from '@chroxy/store-core'
 // #5175: Host/Repo Status Control Room snapshot type (epic #5170). The store
 // holds the latest `host_status_snapshot` so the Control Room section can render
 // the fleet table; the type is the protocol contract pinned in @chroxy/protocol.
-import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerRepoEventsSnapshotMessage, ServerPermissionInputMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment, ServerOrchestrationRunsSnapshot } from '@chroxy/protocol'
+import type { ServerHostStatusSnapshotMessage, ServerRunnerStatusSnapshotMessage, ServerContainersStatusSnapshotMessage, ServerRepoRuntimeConfigSnapshotMessage, ServerByokPoolStatusSnapshotMessage, ServerHostPruneStatusSnapshotMessage, ServerSimulatorStatusSnapshotMessage, ServerEmulatorStatusSnapshotMessage, ServerWslStatusSnapshotMessage, ServerIntegrationStatusSnapshotMessage, ServerSkillsInventorySnapshotMessage, ServerMailboxStatusSnapshotMessage, ServerExternalSessionsSnapshotMessage, ServerRepoEventsSnapshotMessage, ServerPermissionInputMessage, ServerSymbolsSnapshotMessage, ServerSearchResultsMessage, ServerReferencesResultMessage, IntegrationActionCounts, ServerPairPendingMessage, ServerSessionPresetFull, Attachment, ServerOrchestrationRunsSnapshot, CodexSandboxMode } from '@chroxy/protocol'
 import type { HeldRunDetail } from '@chroxy/store-core'
 // #5184: header cost-badge display mode. Defined in a plain lib module
 // (which owns the union + runtime guard) — the store only needs the type
@@ -1704,7 +1704,7 @@ export interface ConnectionState {
    * `false` means the socket was closed and nothing was sent, so the caller
    * must skip latching its "Creating…" spinner (no reply will arrive to clear it).
    */
-  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean; codexSandbox?: string }) => boolean;
+  createSession: (opts: { name: string; cwd?: string; provider?: string; model?: string; permissionMode?: string; worktree?: boolean; environmentId?: string; skipPermissions?: boolean; codexSandbox?: CodexSandboxMode }) => boolean;
   destroySession: (sessionId: string, force?: boolean) => void;
   /** #6006 — operator panic button: request an immediate token revoke (primary-token only). */
   revokeToken: () => void;

--- a/packages/protocol/dist/codex.d.ts
+++ b/packages/protocol/dist/codex.d.ts
@@ -1,0 +1,44 @@
+/**
+ * @chroxy/protocol/codex — shared Codex constants.
+ *
+ * Single source of truth for the Codex sandbox modes so the wire contract
+ * (`create_session`'s `codexSandbox`, see `./schemas/client.ts`), the server
+ * (`packages/server/src/codex-session.js` re-exports these), and the clients
+ * (the dashboard + mobile session-creation controls) all agree on exactly one
+ * list — the same single-source pattern as `DEFAULT_PROVIDER` in `./index.ts`.
+ *
+ * Zod-free (plain consts) so this module stays importable from the
+ * dependency-light `./project` consumers if ever needed, and so the client
+ * schema can `z.enum(CODEX_SANDBOX_MODES)` without a circular import.
+ */
+/**
+ * The Codex CLI sandbox modes, in ascending order of filesystem authority.
+ * Verified against codex-cli 0.128.0 — Codex accepts exactly these three
+ * `--sandbox` values.
+ *
+ *   - `read-only`          — Codex may read the workspace but cannot write.
+ *   - `workspace-write`    — Codex may read/write within the workspace (default).
+ *   - `danger-full-access` — no sandbox; Codex may touch anything the daemon can.
+ */
+export declare const CODEX_SANDBOX_MODES: readonly ["read-only", "workspace-write", "danger-full-access"];
+export type CodexSandboxMode = (typeof CODEX_SANDBOX_MODES)[number];
+/**
+ * Default sandbox mode when nothing overrides it. `workspace-write` so a fresh
+ * codex session can edit files (Codex would otherwise fall back to read-only in
+ * any non-trusted dir — the #3846 stopgap).
+ */
+export declare const CODEX_DEFAULT_SANDBOX: CodexSandboxMode;
+/** The codex provider id — single-sourced so the clients gate the sandbox
+ * control on exactly this string. */
+export declare const CODEX_PROVIDER = "codex";
+/**
+ * UI-facing metadata for the sandbox selector: a short label and a one-line
+ * description per mode. Kept next to the canonical list so a new mode can't be
+ * added without a label. Descriptions are intentionally concise — the clients
+ * render them as form hints.
+ */
+export declare const CODEX_SANDBOX_MODE_META: ReadonlyArray<{
+    readonly id: CodexSandboxMode;
+    readonly label: string;
+    readonly description: string;
+}>;

--- a/packages/protocol/dist/codex.js
+++ b/packages/protocol/dist/codex.js
@@ -1,0 +1,59 @@
+/**
+ * @chroxy/protocol/codex — shared Codex constants.
+ *
+ * Single source of truth for the Codex sandbox modes so the wire contract
+ * (`create_session`'s `codexSandbox`, see `./schemas/client.ts`), the server
+ * (`packages/server/src/codex-session.js` re-exports these), and the clients
+ * (the dashboard + mobile session-creation controls) all agree on exactly one
+ * list — the same single-source pattern as `DEFAULT_PROVIDER` in `./index.ts`.
+ *
+ * Zod-free (plain consts) so this module stays importable from the
+ * dependency-light `./project` consumers if ever needed, and so the client
+ * schema can `z.enum(CODEX_SANDBOX_MODES)` without a circular import.
+ */
+/**
+ * The Codex CLI sandbox modes, in ascending order of filesystem authority.
+ * Verified against codex-cli 0.128.0 — Codex accepts exactly these three
+ * `--sandbox` values.
+ *
+ *   - `read-only`          — Codex may read the workspace but cannot write.
+ *   - `workspace-write`    — Codex may read/write within the workspace (default).
+ *   - `danger-full-access` — no sandbox; Codex may touch anything the daemon can.
+ */
+export const CODEX_SANDBOX_MODES = [
+    'read-only',
+    'workspace-write',
+    'danger-full-access',
+];
+/**
+ * Default sandbox mode when nothing overrides it. `workspace-write` so a fresh
+ * codex session can edit files (Codex would otherwise fall back to read-only in
+ * any non-trusted dir — the #3846 stopgap).
+ */
+export const CODEX_DEFAULT_SANDBOX = 'workspace-write';
+/** The codex provider id — single-sourced so the clients gate the sandbox
+ * control on exactly this string. */
+export const CODEX_PROVIDER = 'codex';
+/**
+ * UI-facing metadata for the sandbox selector: a short label and a one-line
+ * description per mode. Kept next to the canonical list so a new mode can't be
+ * added without a label. Descriptions are intentionally concise — the clients
+ * render them as form hints.
+ */
+export const CODEX_SANDBOX_MODE_META = [
+    {
+        id: 'read-only',
+        label: 'Read-only',
+        description: 'Codex can read the workspace but every write is blocked.',
+    },
+    {
+        id: 'workspace-write',
+        label: 'Workspace write',
+        description: 'Default. Codex can read and write within the workspace.',
+    },
+    {
+        id: 'danger-full-access',
+        label: 'Full access (danger)',
+        description: 'No sandbox — Codex can touch anything the daemon can. Use only in trusted, isolated contexts.',
+    },
+];

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -67,6 +67,7 @@ export declare const CLAUDE_TUI_PTY_SIZE: Readonly<{
     cols: 120;
     rows: 30;
 }>;
+export * from './codex.ts';
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, ServerBudgetResumeAckMessage, } from './schemas/server.ts';

--- a/packages/protocol/dist/index.js
+++ b/packages/protocol/dist/index.js
@@ -64,6 +64,11 @@ export const USER_SHELL_PROVIDER = 'user-shell';
  * mirror. Phase 2 (resize sync) makes the size dynamic and retires this.
  */
 export const CLAUDE_TUI_PTY_SIZE = Object.freeze({ cols: 120, rows: 30 });
+// #6689: Codex sandbox constants (modes, default, provider id, UI metadata).
+// Single-sourced so the wire schema, the server, and both clients agree. Kept
+// in a dedicated module so `./schemas/client.ts` can import the mode list for
+// `z.enum(CODEX_SANDBOX_MODES)` without a circular import through this entry.
+export * from "./codex.js";
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from "./schemas/index.js";
 // Re-export client-side error-category detection (#3151)

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -14,6 +14,7 @@
  * are). This keeps server and client schemas on a single sanity ceiling.
  */
 import { z } from 'zod';
+import { CODEX_SANDBOX_MODES } from "../codex.js";
 // -- Attachment schema (reusable) --
 const BinaryAttachmentSchema = z.object({
     type: z.enum(['image', 'document']),
@@ -466,7 +467,9 @@ export const CreateSessionSchema = z.object({
     sandbox: SandboxSchema.optional(),
     // #6638: per-session Codex sandbox mode (codex provider only; ignored by
     // others). Overrides the server-wide CHROXY_CODEX_SANDBOX / the default.
-    codexSandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+    // #6689: single-sourced from CODEX_SANDBOX_MODES so the wire enum, the server,
+    // and the client selectors can't drift.
+    codexSandbox: z.enum(CODEX_SANDBOX_MODES).optional(),
     isolation: z.enum(['none', 'worktree', 'sandbox', 'container']).optional(),
     environmentId: z.string().max(256).optional(),
     // #4208: opt-in to spawning the claude TUI with

--- a/packages/protocol/src/codex.ts
+++ b/packages/protocol/src/codex.ts
@@ -1,0 +1,69 @@
+/**
+ * @chroxy/protocol/codex — shared Codex constants.
+ *
+ * Single source of truth for the Codex sandbox modes so the wire contract
+ * (`create_session`'s `codexSandbox`, see `./schemas/client.ts`), the server
+ * (`packages/server/src/codex-session.js` re-exports these), and the clients
+ * (the dashboard + mobile session-creation controls) all agree on exactly one
+ * list — the same single-source pattern as `DEFAULT_PROVIDER` in `./index.ts`.
+ *
+ * Zod-free (plain consts) so this module stays importable from the
+ * dependency-light `./project` consumers if ever needed, and so the client
+ * schema can `z.enum(CODEX_SANDBOX_MODES)` without a circular import.
+ */
+
+/**
+ * The Codex CLI sandbox modes, in ascending order of filesystem authority.
+ * Verified against codex-cli 0.128.0 — Codex accepts exactly these three
+ * `--sandbox` values.
+ *
+ *   - `read-only`          — Codex may read the workspace but cannot write.
+ *   - `workspace-write`    — Codex may read/write within the workspace (default).
+ *   - `danger-full-access` — no sandbox; Codex may touch anything the daemon can.
+ */
+export const CODEX_SANDBOX_MODES = [
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
+] as const
+
+export type CodexSandboxMode = (typeof CODEX_SANDBOX_MODES)[number]
+
+/**
+ * Default sandbox mode when nothing overrides it. `workspace-write` so a fresh
+ * codex session can edit files (Codex would otherwise fall back to read-only in
+ * any non-trusted dir — the #3846 stopgap).
+ */
+export const CODEX_DEFAULT_SANDBOX: CodexSandboxMode = 'workspace-write'
+
+/** The codex provider id — single-sourced so the clients gate the sandbox
+ * control on exactly this string. */
+export const CODEX_PROVIDER = 'codex'
+
+/**
+ * UI-facing metadata for the sandbox selector: a short label and a one-line
+ * description per mode. Kept next to the canonical list so a new mode can't be
+ * added without a label. Descriptions are intentionally concise — the clients
+ * render them as form hints.
+ */
+export const CODEX_SANDBOX_MODE_META: ReadonlyArray<{
+  readonly id: CodexSandboxMode
+  readonly label: string
+  readonly description: string
+}> = [
+  {
+    id: 'read-only',
+    label: 'Read-only',
+    description: 'Codex can read the workspace but every write is blocked.',
+  },
+  {
+    id: 'workspace-write',
+    label: 'Workspace write',
+    description: 'Default. Codex can read and write within the workspace.',
+  },
+  {
+    id: 'danger-full-access',
+    label: 'Full access (danger)',
+    description: 'No sandbox — Codex can touch anything the daemon can. Use only in trusted, isolated contexts.',
+  },
+] as const

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -71,6 +71,12 @@ export const USER_SHELL_PROVIDER = 'user-shell'
  */
 export const CLAUDE_TUI_PTY_SIZE = Object.freeze({ cols: 120, rows: 30 })
 
+// #6689: Codex sandbox constants (modes, default, provider id, UI metadata).
+// Single-sourced so the wire schema, the server, and both clients agree. Kept
+// in a dedicated module so `./schemas/client.ts` can import the mode list for
+// `z.enum(CODEX_SANDBOX_MODES)` without a circular import through this entry.
+export * from './codex.ts'
+
 // Re-export schemas for convenience (also available via '@chroxy/protocol/schemas')
 export * from './schemas/index.ts'
 

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -14,6 +14,7 @@
  * are). This keeps server and client schemas on a single sanity ceiling.
  */
 import { z } from 'zod'
+import { CODEX_SANDBOX_MODES } from '../codex.ts'
 
 // -- Attachment schema (reusable) --
 const BinaryAttachmentSchema = z.object({
@@ -519,7 +520,9 @@ export const CreateSessionSchema = z.object({
   sandbox: SandboxSchema.optional(),
   // #6638: per-session Codex sandbox mode (codex provider only; ignored by
   // others). Overrides the server-wide CHROXY_CODEX_SANDBOX / the default.
-  codexSandbox: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
+  // #6689: single-sourced from CODEX_SANDBOX_MODES so the wire enum, the server,
+  // and the client selectors can't drift.
+  codexSandbox: z.enum(CODEX_SANDBOX_MODES).optional(),
   isolation: z.enum(['none', 'worktree', 'sandbox', 'container']).optional(),
   environmentId: z.string().max(256).optional(),
   // #4208: opt-in to spawning the claude TUI with

--- a/packages/protocol/tests/codex.test.js
+++ b/packages/protocol/tests/codex.test.js
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+describe('@chroxy/protocol codex constants (#6689)', () => {
+  it('exports the canonical sandbox mode list', async () => {
+    const { CODEX_SANDBOX_MODES } = await import('../src/codex.ts')
+    assert.deepEqual(
+      [...CODEX_SANDBOX_MODES],
+      ['read-only', 'workspace-write', 'danger-full-access'],
+      'the three codex-cli sandbox modes, in ascending authority order',
+    )
+  })
+
+  it('defaults to workspace-write', async () => {
+    const { CODEX_DEFAULT_SANDBOX, CODEX_SANDBOX_MODES } = await import('../src/codex.ts')
+    assert.equal(CODEX_DEFAULT_SANDBOX, 'workspace-write')
+    assert.ok(CODEX_SANDBOX_MODES.includes(CODEX_DEFAULT_SANDBOX), 'default is a member of the mode list')
+  })
+
+  it('exports the codex provider id', async () => {
+    const { CODEX_PROVIDER } = await import('../src/codex.ts')
+    assert.equal(CODEX_PROVIDER, 'codex')
+  })
+
+  it('has UI metadata (label + description) for every mode', async () => {
+    const { CODEX_SANDBOX_MODES, CODEX_SANDBOX_MODE_META } = await import('../src/codex.ts')
+    const metaIds = CODEX_SANDBOX_MODE_META.map((m) => m.id)
+    assert.deepEqual(metaIds, [...CODEX_SANDBOX_MODES], 'meta covers exactly the modes, in order')
+    for (const m of CODEX_SANDBOX_MODE_META) {
+      assert.ok(typeof m.label === 'string' && m.label.length > 0, `${m.id} has a non-empty label`)
+      assert.ok(typeof m.description === 'string' && m.description.length > 0, `${m.id} has a non-empty description`)
+    }
+  })
+
+  it('re-exports the codex constants from the main entry point', async () => {
+    const mod = await import('../src/index.ts')
+    assert.ok(mod.CODEX_SANDBOX_MODES, 'CODEX_SANDBOX_MODES re-exported')
+    assert.equal(mod.CODEX_DEFAULT_SANDBOX, 'workspace-write')
+    assert.equal(mod.CODEX_PROVIDER, 'codex')
+    assert.ok(mod.CODEX_SANDBOX_MODE_META, 'CODEX_SANDBOX_MODE_META re-exported')
+  })
+
+  it('create_session schema accepts every canonical sandbox mode', async () => {
+    const { CreateSessionSchema, CODEX_SANDBOX_MODES } = await import('../src/index.ts')
+    for (const mode of CODEX_SANDBOX_MODES) {
+      const result = CreateSessionSchema.safeParse({ type: 'create_session', codexSandbox: mode })
+      assert.ok(result.success, `codexSandbox=${mode} should be accepted`)
+    }
+  })
+
+  it('create_session schema rejects an out-of-enum sandbox mode', async () => {
+    const { CreateSessionSchema } = await import('../src/index.ts')
+    const result = CreateSessionSchema.safeParse({ type: 'create_session', codexSandbox: 'gimme-root' })
+    assert.ok(!result.success, 'an unknown sandbox mode is rejected by the single-sourced enum')
+  })
+
+  it('codexSandbox is optional (omitting it is valid)', async () => {
+    const { CreateSessionSchema } = await import('../src/index.ts')
+    const result = CreateSessionSchema.safeParse({ type: 'create_session', name: 'x' })
+    assert.ok(result.success, 'a create_session without codexSandbox is valid')
+  })
+})

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -11,6 +11,10 @@ import {
 } from './utils/context-window-learn.js'
 import { BILLING_CLASSES } from './billing-class.js'
 import { hasCodexOAuthCreds } from './auth-probes.js'
+import {
+  CODEX_SANDBOX_MODES as PROTOCOL_CODEX_SANDBOX_MODES,
+  CODEX_DEFAULT_SANDBOX as PROTOCOL_CODEX_DEFAULT_SANDBOX,
+} from '@chroxy/protocol'
 
 /**
  * Manages a Codex CLI session using `codex exec --json`.
@@ -70,18 +74,18 @@ const BINARY_CANDIDATES = [
  * exactly these three values (verified against codex-cli 0.128.0). Exported
  * so tests and consumers can pin the canonical list without re-declaring it.
  */
-export const CODEX_SANDBOX_MODES = Object.freeze([
-  'read-only',
-  'workspace-write',
-  'danger-full-access',
-])
+// #6689: single-sourced from @chroxy/protocol (the wire contract) so the
+// server, the create_session schema, and both client selectors share exactly
+// one list. Frozen re-export preserves the pre-#6689 API for the server
+// consumers that already `import { CODEX_SANDBOX_MODES } from './codex-session.js'`.
+export const CODEX_SANDBOX_MODES = Object.freeze([...PROTOCOL_CODEX_SANDBOX_MODES])
 
 /**
  * Default sandbox mode when nothing overrides it. Matches the #3846 stopgap
  * — Codex would otherwise fall back to read-only in any non-trusted dir and
  * be unable to edit files in fresh chroxy sessions.
  */
-export const CODEX_DEFAULT_SANDBOX = 'workspace-write'
+export const CODEX_DEFAULT_SANDBOX = PROTOCOL_CODEX_DEFAULT_SANDBOX
 
 /**
  * Module-level cache of invalid `CHROXY_CODEX_SANDBOX` values we have


### PR DESCRIPTION
## Summary

Closes #6689.

Follow-up to #6638, which shipped the server + API wiring for a per-session Codex sandbox mode (`create_session`'s `codexSandbox`: `read-only` / `workspace-write` / `danger-full-access`) but left it unexposed in the UI. This adds the **client control** to both session-creation surfaces.

## What changed

- **protocol** — new `codex.ts` single-sources the sandbox modes: `CODEX_SANDBOX_MODES`, `CODEX_DEFAULT_SANDBOX` (`workspace-write`), `CODEX_PROVIDER`, and `CODEX_SANDBOX_MODE_META` (label + description per mode, for the pickers). The `create_session` schema now derives its `codexSandbox` enum from `CODEX_SANDBOX_MODES` (`z.enum(CODEX_SANDBOX_MODES)`), and the server's `codex-session.js` re-exports the same constants — so the wire contract, the server, and both clients share exactly one list and can't drift.
- **dashboard** — a **Codex sandbox** `<select>` in the modal's Advanced section, rendered only for the `codex` provider, defaulting to `workspace-write`. Its value is forwarded as `create_session`'s `codexSandbox` (undefined for every other provider).
- **app (mobile)** — a matching codex-only chip selector in the New Session modal, same default and forwarding. (Also gave the Create button an accessibility label.)
- Both `createSession` store actions + their option types now carry `codexSandbox`.

## Modes exposed

| Mode | Label | Meaning |
|------|-------|---------|
| `read-only` | Read-only | Codex can read the workspace, all writes blocked |
| `workspace-write` | Workspace write | **Default** — read/write within the workspace |
| `danger-full-access` | Full access (danger) | No sandbox |

## Gating

The control only surfaces for the `codex` provider (both clients gate on `provider === CODEX_PROVIDER`) and resets to the default on modal open and on any provider change, so a stale `danger-full-access` selection can't survive a provider round-trip.

## Tests

- **protocol** — `tests/codex.test.js`: canonical mode list, default, provider id, meta coverage, and that the `create_session` schema accepts every mode / rejects out-of-enum / treats the field as optional.
- **dashboard** — `CreateSessionModalCodexSandbox.test.tsx`: renders only for codex, defaults to workspace-write, offers all three modes, forwards the chosen mode, and omits the field for non-codex.
- **app** — new cases in `__tests__/CreateSessionModal.test.tsx`: hidden until codex is selected, then renders, defaults to workspace-write on create, forwards the tapped chip's mode, and omits it for non-codex.

## Scope note / follow-up

Codex applies the sandbox at **thread start**, so this is a create-time choice — changing it mid-session needs a new session (see `docs/design/codex-permission-model.md` §5). Surfacing the **active** sandbox in `session_info` for display on an existing codex session is the optional half of the issue and is left as a follow-up (filed separately).

## Verification

- protocol: full suite green (375), incl. 8 new
- server: codex-session / codex-app-server-session / session-handlers green (295); all 5 `packages/server/scripts/lint-*.sh` pass
- dashboard: CreateSessionModal + store suites green (1087); `tsc --noEmit` clean
- app: CreateSessionModal jest green (16, incl. 5 new); `tsc --noEmit` clean

Live verification in a real codex session (read-only blocks writes / danger-full-access allows them) is left for the maintainer per the issue's acceptance checklist.