### PR TITLE
feat(dashboard): persist bounded thumbnail data URI for resumed image previews

### DIFF
--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -56,6 +56,14 @@ export interface ImageAttachment {
   data: string // base64
   mediaType: string
   name: string
+  /**
+   * #6729 — a small, size-bounded `data:` URI thumbnail (see
+   * `makeThumbnailDataUri` in utils/image-utils). Used as the transcript
+   * preview URI so a resumed session can still render the thumbnail after the
+   * full-size preview is stripped from localStorage. Undefined when generation
+   * failed (off-DOM / oversized).
+   */
+  thumbnailDataUri?: string
 }
 
 export interface InputBarProps {

--- a/packages/dashboard/src/store/persistence-attachment-thumbnail.test.ts
+++ b/packages/dashboard/src/store/persistence-attachment-thumbnail.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #6729 — a bounded image thumbnail `data:` URI must survive persist + reload
+ * so a resumed session renders the preview instead of a filename chip, while
+ * oversized `data:` blobs are still stripped to keep localStorage bounded.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  setServerScope,
+  persistSessionMessages,
+  loadSessionMessages,
+  flushPendingWrites,
+  _resetForTesting,
+} from './persistence'
+import { THUMBNAIL_MAX_BYTES } from '../utils/image-utils'
+import type { ChatMessage } from './types'
+
+beforeEach(() => {
+  localStorage.clear()
+  _resetForTesting()
+  setServerScope(null)
+})
+
+function userMessageWithAttachments(attachments: ChatMessage['attachments']): ChatMessage {
+  return {
+    id: 'msg-1',
+    type: 'user_input',
+    content: 'here is a screenshot',
+    timestamp: Date.now(),
+    attachments,
+  }
+}
+
+describe('stripLargeData attachment thumbnails (#6729)', () => {
+  const smallThumb = 'data:image/jpeg;base64,SHORTTHUMB'
+  const oversized = 'data:image/png;base64,' + 'A'.repeat(THUMBNAIL_MAX_BYTES)
+
+  it('preserves a bounded thumbnail data URI across persist + reload', () => {
+    persistSessionMessages('s1', [userMessageWithAttachments([
+      { id: 'img-0', type: 'image', uri: smallThumb, name: 'shot.png', mediaType: 'image/png', size: 1234 },
+    ])])
+    flushPendingWrites()
+
+    const [msg] = loadSessionMessages('s1')
+    expect(msg!.attachments![0]!.uri).toBe(smallThumb)
+  })
+
+  it('strips an oversized data URI to the sentinel', () => {
+    expect(oversized.length).toBeGreaterThan(THUMBNAIL_MAX_BYTES)
+    persistSessionMessages('s1', [userMessageWithAttachments([
+      { id: 'img-0', type: 'image', uri: oversized, name: 'big.png', mediaType: 'image/png', size: 999999 },
+    ])])
+    flushPendingWrites()
+
+    const [msg] = loadSessionMessages('s1')
+    expect(msg!.attachments![0]!.uri).toBe('[data stripped]')
+  })
+
+  it('leaves a non-data document path URI untouched', () => {
+    persistSessionMessages('s1', [userMessageWithAttachments([
+      { id: 'doc-0', type: 'document', uri: '/tmp/notes.pdf', name: 'notes.pdf', mediaType: '', size: 0 },
+    ])])
+    flushPendingWrites()
+
+    const [msg] = loadSessionMessages('s1')
+    expect(msg!.attachments![0]!.uri).toBe('/tmp/notes.pdf')
+  })
+
+  it('mixed: keeps the small thumbnail, strips the oversized blob, keeps the doc', () => {
+    persistSessionMessages('s1', [userMessageWithAttachments([
+      { id: 'img-0', type: 'image', uri: smallThumb, name: 'a.png', mediaType: 'image/png', size: 1 },
+      { id: 'img-1', type: 'image', uri: oversized, name: 'b.png', mediaType: 'image/png', size: 1 },
+      { id: 'doc-0', type: 'document', uri: '/tmp/c.pdf', name: 'c.pdf', mediaType: '', size: 0 },
+    ])])
+    flushPendingWrites()
+
+    const [msg] = loadSessionMessages('s1')
+    const uris = msg!.attachments!.map((a) => a.uri)
+    expect(uris).toEqual([smallThumb, '[data stripped]', '/tmp/c.pdf'])
+  })
+})

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -9,6 +9,7 @@
  * Data is debounced to avoid excessive writes on rapid message streams.
  */
 import type { ChatMessage, SessionInfo } from './types';
+import { isPersistableThumbnailUri } from '../utils/image-utils';
 
 const KEY_PREFIX = 'chroxy_persist_';
 const KEY_VIEW_MODE = `${KEY_PREFIX}view_mode`;
@@ -739,9 +740,15 @@ function stripLargeData(msg: ChatMessage): ChatMessage {
       ...img,
       data: img.data ? '[image data stripped for storage]' : img.data,
     })),
-    attachments: msg.attachments?.map(att => ({
-      ...att,
-      uri: att.uri.startsWith('data:') ? '[data stripped]' : att.uri,
-    })),
+    // #6729 — carve a size-bounded exception: keep a small `data:` image URI
+    // (a downscaled thumbnail within THUMBNAIL_MAX_BYTES) so a resumed session
+    // renders the preview, but still strip any oversized `data:` blob so
+    // localStorage stays bounded. Non-`data:` URIs (document paths) pass through.
+    attachments: msg.attachments?.map(att => {
+      if (!att.uri.startsWith('data:')) return att;
+      return isPersistableThumbnailUri(att.uri)
+        ? att
+        : { ...att, uri: '[data stripped]' };
+    }),
   };
 }

--- a/packages/dashboard/src/utils/attachment-preview.test.ts
+++ b/packages/dashboard/src/utils/attachment-preview.test.ts
@@ -26,6 +26,21 @@ describe('toMessageAttachments (#6632)', () => {
     expect(toMessageAttachments()).toEqual([])
     expect(toMessageAttachments([], [])).toEqual([])
   })
+
+  it('prefers the composer thumbnail data URI as the preview uri (#6729)', () => {
+    const out = toMessageAttachments(
+      [{ data: 'AAAA', mediaType: 'image/png', name: 'shot.png', thumbnailDataUri: 'data:image/jpeg;base64,THUMB' }],
+      undefined,
+    )
+    expect(out[0]!.uri).toBe('data:image/jpeg;base64,THUMB')
+    // `size` still reflects the original payload, not the thumbnail.
+    expect(out[0]!.size).toBe(4)
+  })
+
+  it('falls back to the full data URI when no thumbnail was generated (#6729)', () => {
+    const out = toMessageAttachments([{ data: 'AAAA', mediaType: 'image/png', name: 'shot.png' }], undefined)
+    expect(out[0]!.uri).toBe('data:image/png;base64,AAAA')
+  })
 })
 
 describe('isRenderableImageUri (#6632)', () => {

--- a/packages/dashboard/src/utils/attachment-preview.ts
+++ b/packages/dashboard/src/utils/attachment-preview.ts
@@ -7,6 +7,12 @@ import type { ImageAttachment, FileAttachment } from '../components/InputBar'
  * base64 → a `data:` URI thumbnail; files carry only a path/name → a document
  * chip. Ids are index-scoped (unique within the one message's list, which is
  * all React keys need).
+ *
+ * #6729 — prefer the composer's size-bounded `thumbnailDataUri` (a downscaled
+ * `data:` URI, see `makeThumbnailDataUri`) as the preview `uri` so it survives
+ * persistence: `stripLargeData` keeps small `data:` image URIs but strips
+ * oversized ones. When no thumbnail was generated (off-DOM / oversized) the
+ * full data URI is used and degrades to a filename chip on reload.
  */
 export function toMessageAttachments(
   images?: ImageAttachment[],
@@ -17,7 +23,7 @@ export function toMessageAttachments(
     out.push({
       id: `img-${i}`,
       type: 'image',
-      uri: `data:${img.mediaType};base64,${img.data}`,
+      uri: img.thumbnailDataUri ?? `data:${img.mediaType};base64,${img.data}`,
       name: img.name,
       mediaType: img.mediaType,
       size: img.data.length,

--- a/packages/dashboard/src/utils/image-utils.test.ts
+++ b/packages/dashboard/src/utils/image-utils.test.ts
@@ -6,10 +6,13 @@ import {
   ALLOWED_IMAGE_TYPES,
   MAX_IMAGE_SIZE,
   MAX_IMAGE_COUNT,
+  THUMBNAIL_MAX_BYTES,
   validateImageFile,
   fileToBase64,
   compressImage,
   processImageFiles,
+  isPersistableThumbnailUri,
+  makeThumbnailDataUri,
 } from './image-utils'
 
 function createMockFile(name: string, size: number, type: string): File {
@@ -263,6 +266,147 @@ describe('processImageFiles', () => {
     expect(result.accepted).toHaveLength(0)
     expect(result.rejected).toHaveLength(1)
     expect(result.rejected[0]).toMatch(/2MB/i)
+  })
+})
+
+describe('isPersistableThumbnailUri (#6729)', () => {
+  it('accepts a small data:image URI', () => {
+    expect(isPersistableThumbnailUri('data:image/jpeg;base64,AAAA')).toBe(true)
+    expect(isPersistableThumbnailUri('data:image/png;base64,AAAA')).toBe(true)
+  })
+
+  it('accepts a data:image URI exactly at the byte cap', () => {
+    const uri = 'data:image/jpeg;base64,'
+    const padded = uri + 'A'.repeat(THUMBNAIL_MAX_BYTES - uri.length)
+    expect(padded.length).toBe(THUMBNAIL_MAX_BYTES)
+    expect(isPersistableThumbnailUri(padded)).toBe(true)
+  })
+
+  it('rejects a data:image URI over the byte cap', () => {
+    const oversized = 'data:image/png;base64,' + 'A'.repeat(THUMBNAIL_MAX_BYTES)
+    expect(oversized.length).toBeGreaterThan(THUMBNAIL_MAX_BYTES)
+    expect(isPersistableThumbnailUri(oversized)).toBe(false)
+  })
+
+  it('rejects non-image data URIs and non-data schemes', () => {
+    expect(isPersistableThumbnailUri('data:text/html,x')).toBe(false)
+    expect(isPersistableThumbnailUri('blob:https://app/abc')).toBe(false)
+    expect(isPersistableThumbnailUri('https://cdn/x.png')).toBe(false)
+    expect(isPersistableThumbnailUri('/local/path.png')).toBe(false)
+    expect(isPersistableThumbnailUri('[data stripped]')).toBe(false)
+  })
+
+  it('rejects null/undefined', () => {
+    expect(isPersistableThumbnailUri(null)).toBe(false)
+    expect(isPersistableThumbnailUri(undefined)).toBe(false)
+  })
+
+  it('honours a custom cap', () => {
+    expect(isPersistableThumbnailUri('data:image/png;base64,AAAA', 4)).toBe(false)
+    expect(isPersistableThumbnailUri('data:image/png;base64,AAAA', 10_000)).toBe(true)
+  })
+})
+
+describe('makeThumbnailDataUri (#6729)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes an already-small image through verbatim (no canvas)', async () => {
+    const base64 = 'aGVsbG8=' // "hello"
+    const result = await makeThumbnailDataUri(base64, 'image/png')
+    expect(result).toBe(`data:image/png;base64,${base64}`)
+  })
+
+  // A base64 payload guaranteed to exceed the byte cap → the canvas path.
+  const oversizedBase64 = 'A'.repeat(THUMBNAIL_MAX_BYTES + 1024)
+
+  function mockCanvasThumbnail(toDataURL: (type: string, q: number) => string) {
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage: vi.fn() }),
+      toDataURL: vi.fn(toDataURL),
+    }
+    const origCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement
+      return origCreateElement(tag)
+    })
+    const OrigImage = globalThis.Image
+    class MockImage {
+      width = 1024
+      height = 768
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      set src(_: string) { setTimeout(() => this.onload?.(), 0) }
+    }
+    globalThis.Image = MockImage as unknown as typeof Image
+    return { mockCanvas, restore: () => { globalThis.Image = OrigImage } }
+  }
+
+  it('downscales an oversized image to fit maxEdge and returns a bounded thumbnail', async () => {
+    const small = 'data:image/jpeg;base64,SHORT'
+    const { mockCanvas, restore } = mockCanvasThumbnail(() => small)
+    try {
+      const result = await makeThumbnailDataUri(oversizedBase64, 'image/png')
+      expect(result).toBe(small)
+      // 1024x768 scaled to a 256px longest edge → 256x192
+      expect(mockCanvas.width).toBe(256)
+      expect(mockCanvas.height).toBe(192)
+    } finally {
+      restore()
+    }
+  })
+
+  it('returns null when even the lowest-quality encode exceeds the cap', async () => {
+    const tooBig = 'data:image/jpeg;base64,' + 'B'.repeat(THUMBNAIL_MAX_BYTES)
+    const { restore } = mockCanvasThumbnail(() => tooBig)
+    try {
+      const result = await makeThumbnailDataUri(oversizedBase64, 'image/png')
+      expect(result).toBeNull()
+    } finally {
+      restore()
+    }
+  })
+
+  it('returns null on image load error', async () => {
+    const OrigImage = globalThis.Image
+    class FailImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      set src(_: string) { setTimeout(() => this.onerror?.(), 0) }
+    }
+    globalThis.Image = FailImage as unknown as typeof Image
+    try {
+      const result = await makeThumbnailDataUri(oversizedBase64, 'image/png')
+      expect(result).toBeNull()
+    } finally {
+      globalThis.Image = OrigImage
+    }
+  })
+
+  it('returns null when a 2d context is unavailable', async () => {
+    const origCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'canvas') return { width: 0, height: 0, getContext: () => null, toDataURL: () => '' } as unknown as HTMLCanvasElement
+      return origCreateElement(tag)
+    })
+    const OrigImage = globalThis.Image
+    class MockImage {
+      width = 1024
+      height = 768
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      set src(_: string) { setTimeout(() => this.onload?.(), 0) }
+    }
+    globalThis.Image = MockImage as unknown as typeof Image
+    try {
+      const result = await makeThumbnailDataUri(oversizedBase64, 'image/png')
+      expect(result).toBeNull()
+    } finally {
+      globalThis.Image = OrigImage
+    }
   })
 })
 

--- a/packages/dashboard/src/utils/image-utils.ts
+++ b/packages/dashboard/src/utils/image-utils.ts
@@ -22,6 +22,16 @@ export interface ImageAttachment {
   mediaType: string
   data: string // base64
   name: string
+  /**
+   * #6729 — a small, size-bounded `data:` URI thumbnail computed at compose
+   * time (see {@link makeThumbnailDataUri}). Used as the transcript preview
+   * `uri` so a resumed session can render the thumbnail: the full-size preview
+   * is stripped from localStorage, but a thumbnail within the persist cap
+   * survives. Undefined when generation failed (off-DOM / oversized) — the
+   * caller then falls back to the full data URI, which is stripped to a
+   * filename chip on reload.
+   */
+  thumbnailDataUri?: string
 }
 
 /**
@@ -128,11 +138,14 @@ export async function processImageFiles(
     try {
       const base64 = await fileToBase64(file)
       const compressed = await compressImage(base64, file.type)
+      // #6729 — bounded thumbnail for the persisted transcript preview.
+      const thumbnailDataUri = await makeThumbnailDataUri(compressed.data, compressed.mediaType)
       accepted.push({
         type: 'image',
         mediaType: compressed.mediaType,
         data: compressed.data,
         name: file.name,
+        ...(thumbnailDataUri ? { thumbnailDataUri } : {}),
       })
     } catch {
       rejected.push(`${file.name}: failed to read file.`)
@@ -140,6 +153,102 @@ export async function processImageFiles(
   }
 
   return { accepted, rejected }
+}
+
+// ---------------------------------------------------------------------------
+// #6729 — bounded thumbnail data URIs for resumed-session previews
+//
+// A sent user image keeps a `data:` URI preview so the transcript shows a
+// thumbnail. On reload, `stripLargeData` (store/persistence.ts) drops a
+// full-size `data:` URI to keep localStorage bounded, degrading the resumed
+// preview to a filename chip (#6632). To keep the thumbnail across a reload we
+// persist a SMALL, size-capped `data:` URI: a downscaled JPEG thumbnail whose
+// string length stays under `THUMBNAIL_MAX_BYTES`. Generation is client-side
+// (canvas), mirroring the existing `compressImage` pipeline, and degrades to
+// `null` off-DOM so nothing balloons localStorage.
+// ---------------------------------------------------------------------------
+
+/** Longest edge (px) of a persisted preview thumbnail. */
+export const THUMBNAIL_MAX_EDGE = 256
+
+/**
+ * Max length (characters) of a persisted thumbnail `data:` URI. localStorage is
+ * only a few MB per origin and we persist up to MAX_MESSAGES per session, so the
+ * per-image preview must stay small. ~20 KB of base64 ≈ a 256px JPEG. This is
+ * the explicit bound: any preview URI longer than this is stripped, not stored.
+ */
+export const THUMBNAIL_MAX_BYTES = 20 * 1024
+
+/** Descending JPEG quality ladder tried when re-encoding a downscaled thumbnail. */
+const THUMBNAIL_QUALITY_STEPS = [0.7, 0.55, 0.4] as const
+
+/**
+ * Whether a URI is a `data:image/…` thumbnail small enough to persist. Pure —
+ * the size-bound decision that `stripLargeData` and the thumbnail generator
+ * share. Non-`data:`, non-image, or oversized URIs return false (the caller
+ * then strips them to the `[data stripped]` sentinel / filename chip).
+ */
+export function isPersistableThumbnailUri(
+  uri: string | null | undefined,
+  maxBytes: number = THUMBNAIL_MAX_BYTES,
+): boolean {
+  return typeof uri === 'string'
+    && uri.startsWith('data:image/')
+    && uri.length <= maxBytes
+}
+
+/**
+ * Produce a bounded `data:` URI thumbnail for a base64 image, for persistence.
+ *
+ * - **already-small** — the full `data:` URI is already within `maxBytes`:
+ *   passthrough (returns it verbatim; pure, no canvas needed).
+ * - **oversized** — downscale via canvas to fit `maxEdge`, re-encode as JPEG at
+ *   a descending quality ladder, and return the first candidate within
+ *   `maxBytes`.
+ * - **off-DOM (SSR/node), canvas failure, or still too large at the smallest
+ *   step** → `null` (the caller falls back to the full URI, which is stripped
+ *   to a filename chip on reload).
+ */
+export async function makeThumbnailDataUri(
+  base64: string,
+  mediaType: string,
+  opts: { maxEdge?: number; maxBytes?: number } = {},
+): Promise<string | null> {
+  const maxEdge = opts.maxEdge ?? THUMBNAIL_MAX_EDGE
+  const maxBytes = opts.maxBytes ?? THUMBNAIL_MAX_BYTES
+
+  const full = `data:${mediaType};base64,${base64}`
+  if (full.length <= maxBytes) return full // already small — passthrough
+
+  // Canvas downscale only works in browsers; off-DOM callers get a chip fallback.
+  if (typeof document === 'undefined') return null
+
+  return new Promise<string | null>((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      let { width, height } = img
+      if (width <= 0 || height <= 0) { resolve(null); return }
+      if (width > maxEdge || height > maxEdge) {
+        const scale = maxEdge / Math.max(width, height)
+        width = Math.max(1, Math.round(width * scale))
+        height = Math.max(1, Math.round(height * scale))
+      }
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) { resolve(null); return }
+      ctx.drawImage(img, 0, 0, width, height)
+      // Thumbnails are opaque previews — JPEG keeps them well under the cap.
+      for (const quality of THUMBNAIL_QUALITY_STEPS) {
+        const candidate = canvas.toDataURL('image/jpeg', quality)
+        if (candidate && candidate.length <= maxBytes) { resolve(candidate); return }
+      }
+      resolve(null) // couldn't fit under the cap even at lowest quality
+    }
+    img.onerror = () => resolve(null)
+    img.src = full
+  })
 }
 
 /**
@@ -177,12 +286,15 @@ export async function processBase64Image(
     return { accepted: null, rejected: `${name} exceeds 2MB limit (${(sizeBytes / (1024 * 1024)).toFixed(1)}MB).` }
   }
   const compressed = await compressImage(base64, mediaType)
+  // #6729 — bounded thumbnail for the persisted transcript preview.
+  const thumbnailDataUri = await makeThumbnailDataUri(compressed.data, compressed.mediaType)
   return {
     accepted: {
       type: 'image',
       mediaType: compressed.mediaType,
       data: compressed.data,
       name,
+      ...(thumbnailDataUri ? { thumbnailDataUri } : {}),
     },
     rejected: null,
   }

--- a/packages/dashboard/src/utils/image-utils.ts
+++ b/packages/dashboard/src/utils/image-utils.ts
@@ -176,6 +176,8 @@ export const THUMBNAIL_MAX_EDGE = 256
  * only a few MB per origin and we persist up to MAX_MESSAGES per session, so the
  * per-image preview must stay small. ~20 KB of base64 ≈ a 256px JPEG. This is
  * the explicit bound: any preview URI longer than this is stripped, not stored.
+ * Bounds are checked with `uri.length`, which equals the byte count here because
+ * a base64 `data:` URI is pure ASCII (no multi-byte chars) — so "_BYTES" is exact.
  */
 export const THUMBNAIL_MAX_BYTES = 20 * 1024
 


### PR DESCRIPTION
## Summary

Resumed sessions dropped user-attached image previews to a filename chip: `stripLargeData` (`packages/dashboard/src/store/persistence.ts`) replaced every persisted `data:` URI with the `[data stripped]` sentinel, so the thumbnail couldn't survive a reload (follow-up from #6632 / PR #6726).

This persists a **bounded** `data:` URI — a small downscaled thumbnail — so a resumed session renders the actual image, while large blobs are still stripped and localStorage stays bounded.

## What changed

- **`utils/image-utils.ts`**
  - `makeThumbnailDataUri(base64, mediaType, opts)` — async, client-side (canvas): downscales an oversized image to a **256px max edge** (`THUMBNAIL_MAX_EDGE`), re-encodes JPEG down a quality ladder (0.7 → 0.55 → 0.4), and returns the first candidate whose `data:` URI is within **20 KB** (`THUMBNAIL_MAX_BYTES`). Already-small images pass through verbatim (no canvas); off-DOM / canvas failure / still-too-large returns `null`.
  - `isPersistableThumbnailUri(uri, maxBytes?)` — pure, shared size-bound decision (a `data:image/…` URI within the cap).
  - Generate the thumbnail at compose time in `processImageFiles` / `processBase64Image`, carried on the composer `ImageAttachment.thumbnailDataUri`.
- **`utils/attachment-preview.ts`** — `toMessageAttachments` uses the bounded thumbnail as the transcript preview `uri`, falling back to the full data URI when none was generated (which then strips to a chip on reload). The inline preview renders at 160×160 with `object-fit: cover`, so a 256px thumbnail is visually identical to full-res there.
- **`store/persistence.ts`** — `stripLargeData` carves a **size-bounded exception**: keep a `data:` image URI within the cap, strip anything larger to `[data stripped]`, leave document paths untouched.
- **`components/InputBar.tsx`** — composer `ImageAttachment` type gains optional `thumbnailDataUri`.

Scope stays dashboard-only: no protocol/wire (`Attachment`) change, no `store-core` type change (the model still receives the full image via `toWireAttachments`; the thumbnail is preview-only).

## Bound

- Downscaled to a 256px longest edge, capped at a 20 KB `data:` URI string. With `MAX_MESSAGES = 100` per session this keeps persisted preview data explicitly bounded.

## Tests

- `image-utils.test.ts` — `isPersistableThumbnailUri` (small/at-cap/oversized/non-image/null/custom-cap) and `makeThumbnailDataUri` (passthrough, canvas downscale to 256px, over-cap → null, load error → null, no 2d context → null).
- `attachment-preview.test.ts` — prefers the composer thumbnail as the preview uri; falls back when absent.
- `persistence-attachment-thumbnail.test.ts` — persist + reload round-trip: bounded thumbnail preserved, oversized stripped to the sentinel, document path untouched, mixed list.
- Full dashboard suite green: **268 files / 4655 tests**; `tsc --noEmit` clean.

Closes #6729