### PR TITLE
fix(server): tear down BYOK MCP client on Streamable HTTP session expiry

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -1362,13 +1362,41 @@ export class MCPRemoteClient extends EventEmitter {
       throw new Error(`MCP server ${this.name} HTTP ${status} redirect on ${method} — refused (redirects are not followed)`)
     }
     if (status === 404) {
-      // Session expired / endpoint gone — drop the session so a future connect
-      // re-initializes; this request still fails below.
-      this._sessionId = null
+      // #6835: a 404 means our Streamable HTTP session id is no longer valid —
+      // the server GC'd the session (a real long-lived-session scenario). Drop
+      // the stale id and, if this happened mid-session (live READY client with a
+      // held session), tear the client down to DEAD. See _expireSession.
+      this._expireSession(method)
     }
     if (status < 200 || status >= 300) {
       throw new Error(`MCP server ${this.name} HTTP ${status} on ${method}`)
     }
+  }
+
+  /**
+   * #6835: handle a 404 (Streamable HTTP session expiry). Always drops the stale
+   * session id. When it fired on a LIVE session (state READY with a session id we
+   * were echoing), the server has GC'd our session server-side — leaving the
+   * client READY would keep the fleet advertising tools that now silently 404 on
+   * every call (the zombie). The remote transport has no lazy re-handshake
+   * (single-connect model, #6821), so tear the client down to DEAD: the fleet
+   * drops its tools, matching the stdio restart-exhaustion contract; recovery is
+   * a session restart or a server re-enable (which rebuilds a fresh client).
+   *
+   * A stateless server (never issued a session id) keeps the prior per-call
+   * behaviour — a lone 404 there stays READY and the next call retries, mirroring
+   * the transient-network-blip handling.
+   */
+  _expireSession(method) {
+    const wasLive = this._state === MCP_STATES.READY && this._sessionId != null
+    this._sessionId = null
+    if (!wasLive) return
+    this._log.warn(`MCP server ${this.name}: Streamable HTTP session expired (HTTP 404 on ${method}) — marking the server dead`)
+    // Abort any other in-flight requests against the now-dead session so no
+    // reader/stream lingers past the transition (the request that observed the
+    // 404 has already resolved; aborting its controller is a no-op).
+    for (const c of this._controllers) { try { c.abort() } catch { /* already settled */ } }
+    this._toDead()
   }
 
   async _discardBody(res) {

--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -983,7 +983,7 @@ export class MCPRemoteClient extends EventEmitter {
         if (timedOut) throw new Error(`MCP ${method} timeout`)
         throw err
       }
-      this._checkStatus(res, method)
+      await this._checkStatus(res, method)
       if (captureSession) {
         const sid = res.headers.get('mcp-session-id')
         if (sid) this._sessionId = sid
@@ -1197,7 +1197,7 @@ export class MCPRemoteClient extends EventEmitter {
         redirect: 'manual', // #6834: never follow a redirect off-origin
         signal: controller.signal,
       })
-      this._checkStatus(res, method)
+      await this._checkStatus(res, method)
       await this._discardBody(res)
     } catch (err) {
       this._pending.delete(id)
@@ -1233,7 +1233,7 @@ export class MCPRemoteClient extends EventEmitter {
       // → oauth-required (propagates → DEAD), redirect/other non-2xx → error →
       // DEAD. Pre-fix this swallowed ALL statuses, letting the handshake
       // proceed past `initialized` while the server was rejecting our requests.
-      this._checkStatus(res, method)
+      await this._checkStatus(res, method)
       await this._discardBody(res)
     } finally {
       clearTimeout(timer)
@@ -1350,8 +1350,16 @@ export class MCPRemoteClient extends EventEmitter {
     return err
   }
 
-  _checkStatus(res, method) {
+  async _checkStatus(res, method) {
     const status = res.status
+    if (status >= 200 && status < 300) return
+    // Non-2xx: no throw path below ever reads the body, so cancel/drain it
+    // first — an unread Streamable-HTTP response body keeps its stream/socket
+    // dangling (a leaked handle, the #6835 hang class), and for the legacy SSE
+    // call sites the caller's own `_discardBody(res)` never runs once we throw.
+    // _discardBody wraps its own work in try/catch, so this drain can never
+    // throw-and-mask the status error we raise below.
+    await this._discardBody(res)
     if (status === 401 || status === 407) {
       throw this._oauthError(res, status)
     }
@@ -1368,9 +1376,7 @@ export class MCPRemoteClient extends EventEmitter {
       // held session), tear the client down to DEAD. See _expireSession.
       this._expireSession(method)
     }
-    if (status < 200 || status >= 300) {
-      throw new Error(`MCP server ${this.name} HTTP ${status} on ${method}`)
-    }
+    throw new Error(`MCP server ${this.name} HTTP ${status} on ${method}`)
   }
 
   /**
@@ -1394,8 +1400,11 @@ export class MCPRemoteClient extends EventEmitter {
     this._log.warn(`MCP server ${this.name}: Streamable HTTP session expired (HTTP 404 on ${method}) — marking the server dead`)
     // Abort any other in-flight requests against the now-dead session so no
     // reader/stream lingers past the transition (the request that observed the
-    // 404 has already resolved; aborting its controller is a no-op).
+    // 404 has already resolved; aborting its controller is a no-op). Clear the
+    // set after aborting — mirroring destroy() — so the DEAD transition retains
+    // no now-aborted controllers and a later destroy() repeats no abort work.
     for (const c of this._controllers) { try { c.abort() } catch { /* already settled */ } }
+    this._controllers.clear()
     this._toDead()
   }
 

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -209,9 +209,37 @@ describe('MCPRemoteClient — Streamable HTTP (#6821)', () => {
     assert.equal(client.tools.length, 0, 'a dead client contributes zero tools to the fleet')
     assert.equal(client._sessionId, null, 'the expired session id must be dropped')
     assert.equal(deadEvents.length, 1, 'the DEAD transition must emit exactly one dead event')
+    // _expireSession aborts AND clears the controller set — nothing lingers
+    // post-DEAD (parity with destroy()), so no aborted controllers are retained.
+    assert.equal(client._controllers.size, 0, 'no in-flight controllers may linger after the session-expiry DEAD transition')
 
     // A subsequent call is cleanly rejected as not-ready — no zombie retries.
     await assert.rejects(client.callTool('echo', {}), /not ready/)
+    await client.destroy()
+    assert.equal(client.state, MCP_STATES.DESTROYED)
+  })
+
+  it('#6835: the non-2xx (404) throw path drains the response body — no leaked stream/socket', async () => {
+    // A non-2xx status is never read as a body on any throw path, so _checkStatus
+    // must cancel/drain it before throwing (else the Streamable-HTTP response
+    // stream lingers open — the leaked-handle / hang class this fix targets).
+    srv = await startMockMcpServer({ sessionId: 'sess-live-2', expireOnToolCall: true })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    // Spy on _discardBody without changing behaviour — record the statuses it is
+    // asked to drain so we can prove the 404 throw path cancels its body.
+    const drainedStatuses = []
+    const realDiscard = client._discardBody.bind(client)
+    client._discardBody = (res) => { drainedStatuses.push(res?.status); return realDiscard(res) }
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+
+    await assert.rejects(client.callTool('echo', { msg: 'hi' }), /404/)
+    assert.equal(client.state, MCP_STATES.DEAD)
+    // The 404 response body must have been drained before _checkStatus threw.
+    assert.ok(drainedStatuses.includes(404), 'the non-2xx (404) response body must be drained before throwing')
+    // And no aborted controller may survive the DEAD transition.
+    assert.equal(client._controllers.size, 0, 'no in-flight controllers may linger after the session-expiry DEAD transition')
+
     await client.destroy()
     assert.equal(client.state, MCP_STATES.DESTROYED)
   })

--- a/packages/server/tests/byok-mcp-remote-client.test.js
+++ b/packages/server/tests/byok-mcp-remote-client.test.js
@@ -38,6 +38,7 @@ function startMockMcpServer(opts = {}) {
     status = null, // force an HTTP status (e.g. 401) on every POST
     hangMethods = [], // methods the server never answers (timeout path)
     toolCallError = false,
+    expireOnToolCall = false, // #6835: 404 every tools/call (server-side session GC)
   } = opts
 
   const captured = []
@@ -94,6 +95,13 @@ function startMockMcpServer(opts = {}) {
       } else if (rpc === 'tools/list') {
         result = { tools }
       } else if (rpc === 'tools/call') {
+        if (expireOnToolCall) {
+          // #6835: server-side session GC — the previously-issued session id is
+          // no longer valid, so every post-initialize request 404s.
+          res.writeHead(404, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ error: 'session expired' }))
+          return
+        }
         if (toolCallError) {
           respond(res, mode, { jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: 'forced remote RPC error' } })
           return
@@ -177,6 +185,35 @@ describe('MCPRemoteClient — Streamable HTTP (#6821)', () => {
     assert.equal(toolsListReq.headers['mcp-session-id'], 'sess-abc-123',
       'tools/list must echo the session id issued at initialize')
     await client.destroy()
+  })
+
+  it('#6835: a 404 on a live session (server-side GC) tears the client to DEAD, not a zombie READY', async () => {
+    // The server issues a session id at initialize, reaches READY, then 404s
+    // every subsequent tools/call — the real Streamable-HTTP session-GC path a
+    // long-lived session hits. Pre-fix, _checkStatus dropped the session id but
+    // left the client READY, so the fleet kept advertising tools that silently
+    // 404 on every call (the zombie). It must now transition to DEAD so the
+    // fleet cleanly drops the tools.
+    srv = await startMockMcpServer({ sessionId: 'sess-live-1', expireOnToolCall: true })
+    const client = new MCPRemoteClient({ name: 'remote', type: 'http', url: srv.url, headers: {} }, { log: silentLog() })
+    const deadEvents = []
+    client.on('dead', () => deadEvents.push(true))
+    await client.start()
+    assert.equal(client.state, MCP_STATES.READY)
+    assert.deepEqual(client.tools.map((t) => t.name), ['echo'])
+
+    // The tool call hits the expired session → 404. The call itself fails...
+    await assert.rejects(client.callTool('echo', { msg: 'hi' }), /404/)
+    // ...and the client must NOT linger in READY advertising now-dead tools.
+    assert.equal(client.state, MCP_STATES.DEAD, 'a session-expired client must go DEAD, not stay a zombie READY')
+    assert.equal(client.tools.length, 0, 'a dead client contributes zero tools to the fleet')
+    assert.equal(client._sessionId, null, 'the expired session id must be dropped')
+    assert.equal(deadEvents.length, 1, 'the DEAD transition must emit exactly one dead event')
+
+    // A subsequent call is cleanly rejected as not-ready — no zombie retries.
+    await assert.rejects(client.callTool('echo', {}), /not ready/)
+    await client.destroy()
+    assert.equal(client.state, MCP_STATES.DESTROYED)
   })
 
   it('401 → DEAD with oauth-required status, no crash (flow disabled)', async () => {


### PR DESCRIPTION
## Summary

Fixes the zombie READY MCP client described in #6835. When a BYOK remote MCP **Streamable HTTP** session is garbage-collected server-side (a real scenario for long-lived sessions), the next post-initialize request comes back `404`. Previously `_checkStatus` dropped the stale session id but left the client `READY` — so `MCPFleet` kept advertising its tools while every `callTool` POSTed without a valid `Mcp-Session-Id` and silently 404'd. Tools appeared available but errored on every use, with no recovery until the session was restarted.

## Root cause

`MCPRemoteClient._checkStatus` (`byok-mcp-client.js`), on a `404`:

```js
this._sessionId = null  // "a future connect re-initializes" — but nothing triggers it
```

`start()` early-returns when `state === READY` and there is no lazy re-`initialize` path, so the client was stuck advertising dead tools.

## Fix

A new `_expireSession(method)`, called from `_checkStatus` on a `404`:

- Always drops the stale session id.
- When the 404 fired **while live** (`state === READY` with a held session id), tears the client down to **DEAD**. The fleet's `tools`/`prompts`/`resources` getters already filter on `state === READY`, so a dead server cleanly drops its tools — matching the stdio restart-exhaustion contract. `getServerStatuses()` reports `failed`. Recovery is a session restart or a server re-enable (`setEnabled` rebuilds a fresh client with a new session).
- Aborts any in-flight request controllers so no reader/stream lingers past the transition (no leaked-handle / HANG-CLASS risk).
- A **stateless** server (never issued a session id) keeps the prior per-call behaviour — a lone 404 there stays `READY` and the next call retries, mirroring the transient-network-blip handling. The `READY + _sessionId != null` guard scopes the new teardown precisely to Streamable-HTTP session expiry; legacy HTTP+SSE (no session id) is unaffected.

The single-connect-no-backoff model from #6821 is preserved for the connect path; this only handles mid-session session-id expiry.

## Reproduction / test

Added a knob-driven mock (`expireOnToolCall`) that issues a session id at `initialize`, reaches `READY`, then 404s every `tools/call`. New test asserts the client transitions to `DEAD`, drops all tools, clears the session id, emits a single `dead` event, and rejects subsequent calls as `not ready` (instead of the zombie). RED confirmed before the fix (`'ready' !== 'dead'`), green after.

## Testing

- `byok-mcp-remote-client.test.js` — 27/27 pass (incl. new #6835 test)
- Consolidated MCP set (remote-client, client, fleet, prompts-resources, servers-snapshot, toggle-persistence, mcp-tools) — 143/143 pass
- All `packages/server/scripts/lint-*.sh` — pass

Closes #6835