### PR TITLE
feat(dashboard,app): edit a queued follow-up before it flushes

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -88,6 +88,9 @@ export interface ChatViewProps {
   queuedIds?: Set<string>;
   /** #5938 — cancel a still-queued follow-up by its clientMessageId. */
   onCancelQueued?: (id: string) => void;
+  /** #6628 — edit a still-queued follow-up: reopen its text in the composer and
+   *  cancel the queued entry. Receives the message id and its current text. */
+  onEditQueued?: (id: string, text: string) => void;
   isPlanPending?: boolean;
   planAllowedPrompts?: { tool: string; prompt: string }[];
   onApprovePlan?: () => void;
@@ -199,6 +202,7 @@ export function ChatView({
   streamingMessageId,
   queuedIds,
   onCancelQueued,
+  onEditQueued,
   isPlanPending,
   planAllowedPrompts,
   onApprovePlan,
@@ -461,6 +465,7 @@ export function ChatView({
               message={msg}
               queued={msg.type === 'user_input' && (queuedIds?.has(msg.id) ?? false)}
               onCancelQueued={onCancelQueued}
+              onEditQueued={onEditQueued}
               onSelectOption={onSelectOption}
               onSubmitMultiQuestion={onSubmitMultiQuestion}
               allowMultiQuestion={allowMultiQuestion}
@@ -505,6 +510,7 @@ export function ChatView({
       allowSingleMultiSelect,
       queuedIds,
       onCancelQueued,
+      onEditQueued,
       chatTailMessageId,
       lastUserInputContent,
       sendInput,

--- a/packages/app/src/components/__tests__/MessageBubble.queuedEdit.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.queuedEdit.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * MessageBubble queued-follow-up edit/cancel controls — #6628
+ *
+ * A follow-up sent mid-turn sits in the server's outgoing queue with a "Queued"
+ * badge under its user bubble. Before it flushes the user must be able to:
+ *   - cancel it (existing #5938 affordance), and
+ *   - edit it — reopen its text in the composer and cancel the queued entry.
+ *
+ * This suite asserts the queued row renders both controls with role + label and
+ * that tapping Edit fires `onEditQueued(id, text)` while Cancel fires
+ * `onCancelQueued(id)`. The cancel-and-reopen wiring lives in SessionScreen; the
+ * bubble's job is just to surface the two intents with the right payloads.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+
+function makeQueuedUserMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'uin-1',
+    type: 'user_input',
+    content: 'follow-up text',
+    timestamp: Date.now(),
+    ...overrides,
+  } as ChatMessage;
+}
+
+function render(
+  message: ChatMessage,
+  handlers: {
+    onEditQueued?: jest.Mock;
+    onCancelQueued?: jest.Mock;
+  } = {},
+) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        queued
+        onCancelQueued={handlers.onCancelQueued}
+        onEditQueued={handlers.onEditQueued}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onSelectOption={() => {}}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('MessageBubble queued edit/cancel (#6628)', () => {
+  it('renders an Edit control with role + label that fires onEditQueued(id, text)', () => {
+    const onEditQueued = jest.fn();
+    const tree = render(makeQueuedUserMessage(), { onEditQueued });
+    const edit = tree.root.findByProps({ testID: 'msg-queued-edit-uin-1' });
+    expect(edit.props.accessibilityRole).toBe('button');
+    expect(edit.props.accessibilityLabel).toBe('Edit queued message');
+    act(() => { edit.props.onPress(); });
+    expect(onEditQueued).toHaveBeenCalledTimes(1);
+    expect(onEditQueued).toHaveBeenCalledWith('uin-1', 'follow-up text');
+  });
+
+  it('still fires onCancelQueued(id) from the Cancel control alongside Edit', () => {
+    const onCancelQueued = jest.fn();
+    const tree = render(makeQueuedUserMessage(), { onCancelQueued, onEditQueued: jest.fn() });
+    const cancel = tree.root.findByProps({ testID: 'msg-queued-cancel-uin-1' });
+    act(() => { cancel.props.onPress(); });
+    expect(onCancelQueued).toHaveBeenCalledTimes(1);
+    expect(onCancelQueued).toHaveBeenCalledWith('uin-1');
+  });
+
+  it('omits the Edit control when no onEditQueued handler is supplied', () => {
+    const tree = render(makeQueuedUserMessage(), { onCancelQueued: jest.fn() });
+    expect(tree.root.findAllByProps({ testID: 'msg-queued-edit-uin-1' })).toHaveLength(0);
+    // The cancel control (and the queued badge) still render.
+    expect(tree.root.findAllByProps({ testID: 'msg-queued-cancel-uin-1' }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -116,7 +116,7 @@ function ThinkingBubble({ content, streaming, truncated }: { content: string; st
   );
 }
 
-function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, allowSingleMultiSelect, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
+function MessageBubbleImpl({ message, queued, onCancelQueued, onEditQueued, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, allowSingleMultiSelect, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall, getInitialExpanded, onExpandedChange }: {
   message: ChatMessage;
   /**
    * #5938 — true when this `user_input` bubble was sent mid-turn and is sitting
@@ -126,6 +126,9 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
   queued?: boolean;
   /** #5938 — cancel this queued follow-up by its message id before it flushes. */
   onCancelQueued?: (id: string) => void;
+  /** #6628 — edit this queued follow-up before it flushes: reopens its text in
+   *  the composer and cancels the queued entry. Receives the id and its text. */
+  onEditQueued?: (id: string, text: string) => void;
   // #6543 (feature B): `editedInput` carries the operator's per-hunk narrowing
   // from a Write/Edit pre-write-diff review — sent on an Approve so the server
   // writes only the kept hunks. `null`/omitted = no narrowing (a plain response);
@@ -552,6 +555,18 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onSelectOption, on
       {isUser && queued && (
         <View style={styles.queuedRow} testID={`msg-queued-${message.id}`}>
           <Text style={styles.queuedLabel}>Queued</Text>
+          {onEditQueued && (
+            <TouchableOpacity
+              onPress={() => onEditQueued(message.id, typeof message.content === 'string' ? message.content : '')}
+              // #6628 — same ~44pt tap target as the cancel control.
+              hitSlop={{ top: 14, bottom: 14, left: 12, right: 12 }}
+              accessibilityRole="button"
+              accessibilityLabel="Edit queued message"
+              testID={`msg-queued-edit-${message.id}`}
+            >
+              <Text style={styles.queuedEdit}>Edit</Text>
+            </TouchableOpacity>
+          )}
           {onCancelQueued && (
             <TouchableOpacity
               onPress={() => onCancelQueued(message.id)}
@@ -827,8 +842,10 @@ export const MessageBubble = React.memo(MessageBubbleImpl, (prev, next) => {
     prev.allowSingleMultiSelect === next.allowSingleMultiSelect &&
     // #5938 — re-render when the queued flag flips (badge appears/clears on
     // enqueue/flush) or the cancel handler's presence changes.
+    // #6628 — likewise for the edit handler's presence.
     prev.queued === next.queued &&
     (prev.onCancelQueued == null) === (next.onCancelQueued == null) &&
+    (prev.onEditQueued == null) === (next.onEditQueued == null) &&
     (prev.onRetryStreamStall == null) === (next.onRetryStreamStall == null)
   );
 });
@@ -904,6 +921,13 @@ const styles = StyleSheet.create({
   },
   queuedCancel: {
     color: COLORS.accentRed,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  // #6628 — edit affordance sits left of Cancel; neutral (muted) so Cancel's
+  // red stays the only destructive accent in the row.
+  queuedEdit: {
+    color: COLORS.textMuted,
     fontSize: 12,
     fontWeight: '600',
   },

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -558,8 +558,13 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onEditQueued, onSe
           {onEditQueued && (
             <TouchableOpacity
               onPress={() => onEditQueued(message.id, typeof message.content === 'string' ? message.content : '')}
-              // #6628 — same ~44pt tap target as the cancel control.
-              hitSlop={{ top: 14, bottom: 14, left: 12, right: 12 }}
+              // #6628 — ~44pt tap target (vertical via top/bottom:14). Horizontal
+              // hitSlop is ASYMMETRIC so Edit's and Cancel's enlarged targets don't
+              // overlap across the row's 10pt gap and dispatch ambiguously: Edit
+              // grows LEFT (toward the label), Cancel grows RIGHT (toward the edge),
+              // and the facing edges stay small (3 + 3 < 10) so a tap can't hit the
+              // wrong — and Cancel is destructive — control.
+              hitSlop={{ top: 14, bottom: 14, left: 12, right: 3 }}
               accessibilityRole="button"
               accessibilityLabel="Edit queued message"
               testID={`msg-queued-edit-${message.id}`}
@@ -572,7 +577,10 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onEditQueued, onSe
               onPress={() => onCancelQueued(message.id)}
               // #5938 — pad the tap target to ~44pt (iOS HIG): the "Cancel"
               // text is ~16pt tall, so ≥14pt of vertical hitSlop clears the bar.
-              hitSlop={{ top: 14, bottom: 14, left: 12, right: 12 }}
+              // #6628 — asymmetric horizontal hitSlop (small LEFT toward Edit,
+              // full RIGHT toward the edge) so this destructive control's target
+              // doesn't overlap Edit's across the 10pt gap.
+              hitSlop={{ top: 14, bottom: 14, left: 3, right: 12 }}
               accessibilityRole="button"
               accessibilityLabel="Cancel queued message"
               testID={`msg-queued-cancel-${message.id}`}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -685,6 +685,20 @@ export function SessionScreen() {
   // longer churn the TextInput on every delta.
   const inputRef = useRef<InputBarHandle>(null);
 
+  // #6628 — edit a still-queued follow-up before it flushes. Cancel-and-reopen:
+  // cancel the queued entry first (its optimistic drop clears the bubble +
+  // badge), then reopen the message text in the composer for amend + re-send.
+  // `sendCancelQueued` returns `false` on a closed socket without dropping the
+  // entry — bail then so we neither clobber the composer nor strand a queued
+  // message the cancel never reached. The already-flushing race is handled like
+  // plain cancel: the server no-ops and the badge (with these controls) is gone
+  // once `message_dequeued` lands.
+  const handleEditQueued = useCallback((id: string, text: string) => {
+    if (sendCancelQueued(id) === false) return;
+    inputRef.current?.setValue(text);
+    inputRef.current?.focus();
+  }, [sendCancelQueued]);
+
   const toggleSelection = useCallback((id: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -1649,6 +1663,7 @@ export function SessionScreen() {
                   streamingMessageId={streamingMessageId}
                   queuedIds={queuedIds}
                   onCancelQueued={handleCancelQueued}
+                  onEditQueued={handleEditQueued}
                   isPlanPending={isPlanPending}
                   planAllowedPrompts={planAllowedPrompts}
                   onApprovePlan={handleApprovePlan}
@@ -1687,6 +1702,7 @@ export function SessionScreen() {
               streamingMessageId={streamingMessageId}
               queuedIds={queuedIds}
               onCancelQueued={handleCancelQueued}
+              onEditQueued={handleEditQueued}
               isPlanPending={isPlanPending}
               planAllowedPrompts={planAllowedPrompts}
               onApprovePlan={handleApprovePlan}

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -61,6 +61,7 @@ import { useDictationComposer } from '../hooks/useDictationComposer';
 import { useAndroidSessionNotification } from '../hooks/useAndroidSessionNotification';
 import { pickFromCamera, pickFromGallery, pickDocument, toWireAttachments, MAX_ATTACHMENTS } from '../utils/attachments';
 import type { Attachment } from '../utils/attachments';
+import { runQueuedEdit } from '../utils/edit-queued';
 import { formatPasteMarker, expandPasteMarkers, parseMemoryAppend } from '@chroxy/store-core';
 import { PastedTextModal } from '../components/PastedTextModal';
 import { disconnectWithQueueGuard } from '../store/disconnectWithQueueGuard';
@@ -688,15 +689,28 @@ export function SessionScreen() {
   // #6628 — edit a still-queued follow-up before it flushes. Cancel-and-reopen:
   // cancel the queued entry first (its optimistic drop clears the bubble +
   // badge), then reopen the message text in the composer for amend + re-send.
-  // `sendCancelQueued` returns `false` on a closed socket without dropping the
-  // entry — bail then so we neither clobber the composer nor strand a queued
-  // message the cancel never reached. The already-flushing race is handled like
-  // plain cancel: the server no-ops and the badge (with these controls) is gone
-  // once `message_dequeued` lands.
+  // The decision logic (draft-clobber guard + fail-closed bail) lives in
+  // `runQueuedEdit`; here we wire the app's effects:
+  //   - guard: queue-while-processing is a multi-message flow, so if the
+  //     composer already holds a non-empty draft (a second follow-up mid-type)
+  //     we surface an alert and leave the queued entry intact rather than
+  //     silently discarding the draft.
+  //   - `sendCancelQueued` returns `false` on a closed socket without dropping
+  //     the entry — the helper bails then so we neither clobber the composer nor
+  //     strand a queued message the cancel never reached. The already-flushing
+  //     race is handled like plain cancel: the server no-ops and the badge (with
+  //     these controls) is gone once `message_dequeued` lands.
   const handleEditQueued = useCallback((id: string, text: string) => {
-    if (sendCancelQueued(id) === false) return;
-    inputRef.current?.setValue(text);
-    inputRef.current?.focus();
+    runQueuedEdit(id, text, {
+      getDraft: () => inputRef.current?.getValue() ?? '',
+      // sendCancelQueued returns `false` on a closed socket (fail-closed, the
+      // entry is NOT dropped) or `'sent'` otherwise — normalize to the helper's
+      // boolean contract where `false` means fail-closed.
+      cancelQueued: (mid) => sendCancelQueued(mid) !== false,
+      reopenComposer: (next) => inputRef.current?.setValue(next),
+      notify: (message) => Alert.alert('Finish your current message', message),
+      focusComposer: () => inputRef.current?.focus(),
+    });
   }, [sendCancelQueued]);
 
   const toggleSelection = useCallback((id: string) => {

--- a/packages/app/src/utils/__tests__/edit-queued.test.ts
+++ b/packages/app/src/utils/__tests__/edit-queued.test.ts
@@ -1,0 +1,66 @@
+import { runQueuedEdit, EDIT_QUEUED_BUSY_NOTICE, type EditQueuedEffects } from '../edit-queued';
+
+// Handler-level coverage for the #6628 "Edit a queued follow-up" decision logic
+// (the review blocker: the naive handler clobbered a non-empty draft and could
+// strand a queued entry). Each effect is a spy so we assert exactly which
+// side-effects fire on each branch. Mirrors the dashboard's edit-queued.test.ts.
+function makeEffects(overrides: Partial<EditQueuedEffects> = {}) {
+  const fx = {
+    getDraft: jest.fn(() => ''),
+    cancelQueued: jest.fn(() => true),
+    reopenComposer: jest.fn(),
+    notify: jest.fn(),
+    focusComposer: jest.fn(),
+    ...overrides,
+  };
+  return fx;
+}
+
+describe('runQueuedEdit (#6628)', () => {
+  it('empty draft (happy path): cancels the queued entry and reopens its text', () => {
+    const fx = makeEffects({ getDraft: jest.fn(() => '') });
+    runQueuedEdit('cmid-1', 'draft body', fx);
+
+    expect(fx.cancelQueued).toHaveBeenCalledWith('cmid-1');
+    expect(fx.reopenComposer).toHaveBeenCalledWith('draft body');
+    expect(fx.focusComposer).toHaveBeenCalledTimes(1);
+    expect(fx.notify).not.toHaveBeenCalled();
+  });
+
+  it('treats a whitespace-only draft as empty (still reopens)', () => {
+    const fx = makeEffects({ getDraft: jest.fn(() => '   \n  ') });
+    runQueuedEdit('cmid-1', 'draft body', fx);
+
+    expect(fx.cancelQueued).toHaveBeenCalledTimes(1);
+    expect(fx.reopenComposer).toHaveBeenCalledWith('draft body');
+    expect(fx.notify).not.toHaveBeenCalled();
+  });
+
+  it('non-empty-draft guard: notifies and preserves BOTH the draft and the queued entry', () => {
+    const fx = makeEffects({ getDraft: jest.fn(() => 'a second follow-up mid-type') });
+    runQueuedEdit('cmid-1', 'draft body', fx);
+
+    // Notice surfaced...
+    expect(fx.notify).toHaveBeenCalledWith(EDIT_QUEUED_BUSY_NOTICE);
+    // ...and nothing destructive happened: the queued entry is NOT cancelled
+    // (not stranded) and the composer draft is NOT overwritten (not clobbered).
+    expect(fx.cancelQueued).not.toHaveBeenCalled();
+    expect(fx.reopenComposer).not.toHaveBeenCalled();
+    expect(fx.focusComposer).not.toHaveBeenCalled();
+  });
+
+  it('fail-closed bail: cancelQueued() === false leaves the composer untouched and no notice', () => {
+    const fx = makeEffects({
+      getDraft: jest.fn(() => ''),
+      cancelQueued: jest.fn(() => false),
+    });
+    runQueuedEdit('cmid-1', 'draft body', fx);
+
+    expect(fx.cancelQueued).toHaveBeenCalledWith('cmid-1');
+    // Closed socket: entry is NOT dropped by sendCancelQueued (retryable), and
+    // the handler must not touch the composer.
+    expect(fx.reopenComposer).not.toHaveBeenCalled();
+    expect(fx.focusComposer).not.toHaveBeenCalled();
+    expect(fx.notify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/utils/edit-queued.ts
+++ b/packages/app/src/utils/edit-queued.ts
@@ -1,0 +1,66 @@
+/**
+ * edit-queued — shared decision logic for "Edit a still-queued follow-up"
+ * (#6628, queue-while-processing).
+ *
+ * Editing a queued message is cancel-and-reopen: cancel the queued entry (its
+ * optimistic drop clears the bubble + badge) and reopen its text in the composer
+ * for amend + re-send. The naive version overwrote the composer unconditionally,
+ * which SILENTLY DISCARDS an in-progress draft — queue-while-processing is a
+ * multi-message flow, so a user mid-typing a SECOND follow-up who taps Edit on
+ * the queued one loses their in-progress draft (the #6628 review blocker).
+ *
+ * The invariant this helper enforces:
+ *   - No in-progress composer draft is ever discarded without the user's
+ *     awareness.
+ *   - The queued message is never stranded.
+ *
+ * Branches:
+ *   - Non-empty draft → notify + bail. The queued entry is left intact and the
+ *     draft is untouched (no silent clobber, nothing stranded).
+ *   - cancelQueued() === false (closed socket — fail-closed, entry NOT dropped)
+ *     → bail. Composer untouched, queued entry preserved.
+ *   - Empty draft (the common case) → cancel the queued entry and reopen its
+ *     text; behavior is unchanged from before the guard.
+ *
+ * The dashboard (`packages/dashboard/src/lib/edit-queued.ts`) carries a parallel
+ * copy — keep the two in sync. It is kept local to each client rather than
+ * shared via store-core so this PR stays free of protocol/dist rebuild concerns.
+ */
+
+export interface EditQueuedEffects {
+  /** Current composer draft text (untrimmed). */
+  getDraft: () => string
+  /**
+   * Cancel the queued entry by id. Returns `false` on a closed socket WITHOUT
+   * dropping the entry (fail-closed), `true` otherwise.
+   */
+  cancelQueued: (id: string) => boolean
+  /** Reopen `text` in the composer for amend + re-send. */
+  reopenComposer: (text: string) => void
+  /** Surface a notice (the draft-would-be-clobbered guard). */
+  notify: (message: string) => void
+  /** Optional: focus the composer after reopening. */
+  focusComposer?: () => void
+}
+
+export const EDIT_QUEUED_BUSY_NOTICE =
+  'Finish or clear your current message before editing the queued one.'
+
+/**
+ * Decide + apply what editing a still-queued follow-up should do, given the
+ * composer's current draft. Pure control flow over injected effects so both
+ * clients (and their unit tests) share one implementation.
+ */
+export function runQueuedEdit(id: string, text: string, fx: EditQueuedEffects): void {
+  // Guard: never clobber an in-progress draft. Leave the queued entry intact
+  // (do NOT cancel) so nothing is stranded, and tell the user why.
+  if (fx.getDraft().trim().length > 0) {
+    fx.notify(EDIT_QUEUED_BUSY_NOTICE)
+    return
+  }
+  // Fail-closed: a closed socket returns false without dropping the entry —
+  // bail without touching the composer so nothing is clobbered or stranded.
+  if (fx.cancelQueued(id) === false) return
+  fx.reopenComposer(text)
+  fx.focusComposer?.()
+}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -42,6 +42,7 @@ import { getAuthToken } from './utils/auth'
 import { SessionBar, type SessionTabData, type SessionStatus } from './components/SessionBar'
 import { formatTranscript } from './lib/transcript'
 import { extractRowSearchText } from './lib/transcriptSearch'
+import { runQueuedEdit } from './lib/edit-queued'
 import { ActivityIndicator, findInFlightToolUse } from './components/ActivityIndicator'
 import { CheckInChip } from './components/CheckInChip'
 import { EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
@@ -1526,19 +1527,35 @@ export function App() {
   // #6628 — edit a still-queued follow-up before it flushes. Cancel-and-reopen:
   // cancel the queued entry FIRST (its own optimistic-drop clears the bubble +
   // badge), then reopen the message text in the composer so the user can amend
-  // and re-send. `sendCancelQueued` returns `false` on a closed socket without
-  // dropping the entry — bail then so we neither clobber the current draft nor
-  // strand a queued message the cancel never reached. The race where the entry
-  // has already flushed is handled the same way plain cancel handles it: the
-  // server's `cancelQueuedMessage` is a no-op and the badge (with these
-  // controls) is already gone once `message_dequeued` lands.
+  // and re-send. The decision logic (draft-clobber guard + fail-closed bail)
+  // lives in `runQueuedEdit`; here we wire the dashboard's effects:
+  //   - guard: queue-while-processing is a multi-message flow, so if the
+  //     composer already holds a non-empty draft (a second follow-up mid-type)
+  //     we surface a notice and leave the queued entry intact rather than
+  //     silently discarding the draft.
+  //   - `sendCancelQueued` returns `false` on a closed socket without dropping
+  //     the entry — the helper bails then so we neither clobber the current
+  //     draft nor strand a queued message the cancel never reached. The race
+  //     where the entry has already flushed is handled the same way plain cancel
+  //     handles it: the server's `cancelQueuedMessage` is a no-op and the badge
+  //     (with these controls) is already gone once `message_dequeued` lands.
   const onEditQueued = useCallback(
     (id: string, text: string) => {
-      if (sendCancelQueued(id) === false) return
-      setInputDraftValue(text)
-      if (activeSessionId) inputDraftsRef.current.set(activeSessionId, text)
+      runQueuedEdit(id, text, {
+        getDraft: () =>
+          (activeSessionId ? inputDraftsRef.current.get(activeSessionId) : '') ?? '',
+        // sendCancelQueued returns `false` on a closed socket (fail-closed, the
+        // entry is NOT dropped) or `'sent'` otherwise — normalize to the
+        // helper's boolean contract where `false` means fail-closed.
+        cancelQueued: (mid) => sendCancelQueued(mid) !== false,
+        reopenComposer: (next) => {
+          setInputDraftValue(next)
+          if (activeSessionId) inputDraftsRef.current.set(activeSessionId, next)
+        },
+        notify: addInfoNotification,
+      })
     },
-    [sendCancelQueued, activeSessionId],
+    [sendCancelQueued, activeSessionId, addInfoNotification],
   )
 
   // Per-session collapsed-paste storage (#3797). Each composer paste that

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1523,6 +1523,24 @@ export function App() {
     if (activeSessionId) inputDraftsRef.current.set(activeSessionId, text)
   }, [activeSessionId])
 
+  // #6628 — edit a still-queued follow-up before it flushes. Cancel-and-reopen:
+  // cancel the queued entry FIRST (its own optimistic-drop clears the bubble +
+  // badge), then reopen the message text in the composer so the user can amend
+  // and re-send. `sendCancelQueued` returns `false` on a closed socket without
+  // dropping the entry — bail then so we neither clobber the current draft nor
+  // strand a queued message the cancel never reached. The race where the entry
+  // has already flushed is handled the same way plain cancel handles it: the
+  // server's `cancelQueuedMessage` is a no-op and the badge (with these
+  // controls) is already gone once `message_dequeued` lands.
+  const onEditQueued = useCallback(
+    (id: string, text: string) => {
+      if (sendCancelQueued(id) === false) return
+      setInputDraftValue(text)
+      if (activeSessionId) inputDraftsRef.current.set(activeSessionId, text)
+    },
+    [sendCancelQueued, activeSessionId],
+  )
+
   // Per-session collapsed-paste storage (#3797). Each composer paste that
   // crosses the size threshold is stashed by id; the textarea sees only
   // the marker. Mirrors the draft-text per-session storage so switching
@@ -2428,6 +2446,7 @@ export function App() {
                         scrollToBottomSignal={scrollToBottomSignal}
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
+                        onEditQueued={onEditQueued}
                         workingLabel={workingLabel}
                         inFlightToolColor={inFlightToolColor}
                         openSearchSignal={openSearchSignal}
@@ -2477,6 +2496,7 @@ export function App() {
                         scrollToBottomSignal={scrollToBottomSignal}
                         queuedIds={queuedIds}
                         onCancelQueued={onCancelQueued}
+                        onEditQueued={onEditQueued}
                         workingLabel={workingLabel}
                         inFlightToolColor={inFlightToolColor}
                         openSearchSignal={openSearchSignal}

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -348,6 +348,22 @@ describe('ChatView', () => {
       expect(screen.getByTestId('msg-queued-uin-1')).toBeInTheDocument()
       expect(screen.queryByTestId('msg-queued-cancel-uin-1')).not.toBeInTheDocument()
     })
+
+    // #6628 — edit a still-queued follow-up: reopen its text in the composer and
+    // cancel the queued entry.
+    it('renders an edit button that calls onEditQueued with the id and message text', () => {
+      const onEditQueued = vi.fn()
+      render(<ChatView messages={[userMsg]} isStreaming queuedIds={new Set(['uin-1'])} onEditQueued={onEditQueued} />)
+      fireEvent.click(screen.getByTestId('msg-queued-edit-uin-1'))
+      expect(onEditQueued).toHaveBeenCalledTimes(1)
+      expect(onEditQueued).toHaveBeenCalledWith('uin-1', 'follow-up')
+    })
+
+    it('omits the edit button when no onEditQueued is supplied', () => {
+      render(<ChatView messages={[userMsg]} isStreaming queuedIds={new Set(['uin-1'])} onCancelQueued={() => {}} />)
+      expect(screen.getByTestId('msg-queued-cancel-uin-1')).toBeInTheDocument()
+      expect(screen.queryByTestId('msg-queued-edit-uin-1')).not.toBeInTheDocument()
+    })
   })
 
   it('hides scroll-to-bottom when at bottom', () => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -192,6 +192,13 @@ export interface ChatViewProps {
   /** #5939: cancel a single queued follow-up by its message id (cancel_queued). */
   onCancelQueued?: (id: string) => void
   /**
+   * #6628: edit a still-queued follow-up before it flushes. The parent reopens
+   * the message text in the composer for editing and cancels the queued entry
+   * (cancel + re-send, reusing `cancel_queued`); the caller supplies both the id
+   * and the current text so the composer can be pre-filled.
+   */
+  onEditQueued?: (id: string, text: string) => void
+  /**
    * #5953 (epic #5951): label for the in-chat "Claude is working" indicator
    * shown at the streaming tail. The parent derives it from the active session's
    * in-flight tool ("Running Bash…") or passes nothing for the generic default
@@ -355,6 +362,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   attachments,
   queued,
   onCancelQueued,
+  onEditQueued,
   queuePosition,
 }: {
   id: string
@@ -374,6 +382,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   queued?: boolean
   /** #5939: cancel this queued follow-up (stable callback from ChatView). */
   onCancelQueued?: (id: string) => void
+  /** #6628: edit this queued follow-up — reopen its text in the composer and
+   *  cancel the queued entry (stable callback from ChatView). */
+  onEditQueued?: (id: string, text: string) => void
   /** #6392: 1-based send position among queued follow-ups, shown only when more
    *  than one is queued (so a lone queued message stays a plain "Queued"). */
   queuePosition?: number
@@ -442,6 +453,18 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
             {queuePosition != null && (
               <span className="msg-queued-position" data-testid={`msg-queued-position-${id}`}>#{queuePosition}</span>
             )}
+            {onEditQueued && (
+              <button
+                type="button"
+                className="msg-queued-edit"
+                aria-label="Edit queued message"
+                title="Edit queued message"
+                data-testid={`msg-queued-edit-${id}`}
+                onClick={() => onEditQueued(id, content)}
+              >
+                Edit
+              </button>
+            )}
             {onCancelQueued && (
               <button
                 type="button"
@@ -463,7 +486,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   )
 })
 
-function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, workingLabel, openSearchSignal, getSearchText }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlightToolColor, renderMessage, scrollToBottomSignal, queuedIds, onCancelQueued, onEditQueued, workingLabel, openSearchSignal, getSearchText }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
   // #6392 — 1-based send position for each queued follow-up, derived from the
@@ -1007,6 +1030,7 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   queued={queuedIds?.has(msg.id) ?? false}
                   queuePosition={queuePositions?.get(msg.id)}
                   onCancelQueued={onCancelQueued}
+                  onEditQueued={onEditQueued}
                 />
               </MessageRowShell>
             )

--- a/packages/dashboard/src/lib/edit-queued.test.ts
+++ b/packages/dashboard/src/lib/edit-queued.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runQueuedEdit, EDIT_QUEUED_BUSY_NOTICE, type EditQueuedEffects } from './edit-queued'
+
+// Handler-level coverage for the #6628 "Edit a queued follow-up" decision logic
+// (the review blocker: the naive handler clobbered a non-empty draft and could
+// strand a queued entry). Each effect is a spy so we assert exactly which
+// side-effects fire on each branch.
+function makeEffects(overrides: Partial<EditQueuedEffects> = {}) {
+  const fx = {
+    getDraft: vi.fn(() => ''),
+    cancelQueued: vi.fn(() => true),
+    reopenComposer: vi.fn(),
+    notify: vi.fn(),
+    focusComposer: vi.fn(),
+    ...overrides,
+  }
+  return fx
+}
+
+describe('runQueuedEdit (#6628)', () => {
+  it('empty draft (happy path): cancels the queued entry and reopens its text', () => {
+    const fx = makeEffects({ getDraft: vi.fn(() => '') })
+    runQueuedEdit('cmid-1', 'draft body', fx)
+
+    expect(fx.cancelQueued).toHaveBeenCalledWith('cmid-1')
+    expect(fx.reopenComposer).toHaveBeenCalledWith('draft body')
+    expect(fx.focusComposer).toHaveBeenCalledTimes(1)
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('treats a whitespace-only draft as empty (still reopens)', () => {
+    const fx = makeEffects({ getDraft: vi.fn(() => '   \n  ') })
+    runQueuedEdit('cmid-1', 'draft body', fx)
+
+    expect(fx.cancelQueued).toHaveBeenCalledTimes(1)
+    expect(fx.reopenComposer).toHaveBeenCalledWith('draft body')
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+
+  it('non-empty-draft guard: notifies and preserves BOTH the draft and the queued entry', () => {
+    const fx = makeEffects({ getDraft: vi.fn(() => 'a second follow-up mid-type') })
+    runQueuedEdit('cmid-1', 'draft body', fx)
+
+    // Notice surfaced...
+    expect(fx.notify).toHaveBeenCalledWith(EDIT_QUEUED_BUSY_NOTICE)
+    // ...and nothing destructive happened: the queued entry is NOT cancelled
+    // (not stranded) and the composer draft is NOT overwritten (not clobbered).
+    expect(fx.cancelQueued).not.toHaveBeenCalled()
+    expect(fx.reopenComposer).not.toHaveBeenCalled()
+    expect(fx.focusComposer).not.toHaveBeenCalled()
+  })
+
+  it('fail-closed bail: cancelQueued() === false leaves the composer untouched and no notice', () => {
+    const fx = makeEffects({
+      getDraft: vi.fn(() => ''),
+      cancelQueued: vi.fn(() => false),
+    })
+    runQueuedEdit('cmid-1', 'draft body', fx)
+
+    expect(fx.cancelQueued).toHaveBeenCalledWith('cmid-1')
+    // Closed socket: entry is NOT dropped by sendCancelQueued (retryable), and
+    // the handler must not touch the composer.
+    expect(fx.reopenComposer).not.toHaveBeenCalled()
+    expect(fx.focusComposer).not.toHaveBeenCalled()
+    expect(fx.notify).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/lib/edit-queued.ts
+++ b/packages/dashboard/src/lib/edit-queued.ts
@@ -1,0 +1,66 @@
+/**
+ * edit-queued — shared decision logic for "Edit a still-queued follow-up"
+ * (#6628, queue-while-processing).
+ *
+ * Editing a queued message is cancel-and-reopen: cancel the queued entry (its
+ * optimistic drop clears the bubble + badge) and reopen its text in the composer
+ * for amend + re-send. The naive version overwrote the composer unconditionally,
+ * which SILENTLY DISCARDS an in-progress draft — queue-while-processing is a
+ * multi-message flow, so a user mid-typing a SECOND follow-up who clicks Edit on
+ * the queued one loses their in-progress draft (the #6628 review blocker).
+ *
+ * The invariant this helper enforces:
+ *   - No in-progress composer draft is ever discarded without the user's
+ *     awareness.
+ *   - The queued message is never stranded.
+ *
+ * Branches:
+ *   - Non-empty draft → notify + bail. The queued entry is left intact and the
+ *     draft is untouched (no silent clobber, nothing stranded).
+ *   - cancelQueued() === false (closed socket — fail-closed, entry NOT dropped)
+ *     → bail. Composer untouched, queued entry preserved.
+ *   - Empty draft (the common case) → cancel the queued entry and reopen its
+ *     text; behavior is unchanged from before the guard.
+ *
+ * The app (`packages/app/src/utils/edit-queued.ts`) carries a parallel copy —
+ * keep the two in sync. It is kept local to each client rather than shared via
+ * store-core so this PR stays free of protocol/dist rebuild concerns.
+ */
+
+export interface EditQueuedEffects {
+  /** Current composer draft text (untrimmed). */
+  getDraft: () => string
+  /**
+   * Cancel the queued entry by id. Returns `false` on a closed socket WITHOUT
+   * dropping the entry (fail-closed), `true` otherwise.
+   */
+  cancelQueued: (id: string) => boolean
+  /** Reopen `text` in the composer for amend + re-send. */
+  reopenComposer: (text: string) => void
+  /** Surface a non-blocking notice (the draft-would-be-clobbered guard). */
+  notify: (message: string) => void
+  /** Optional: focus the composer after reopening. */
+  focusComposer?: () => void
+}
+
+export const EDIT_QUEUED_BUSY_NOTICE =
+  'Finish or clear your current message before editing the queued one.'
+
+/**
+ * Decide + apply what editing a still-queued follow-up should do, given the
+ * composer's current draft. Pure control flow over injected effects so both
+ * clients (and their unit tests) share one implementation.
+ */
+export function runQueuedEdit(id: string, text: string, fx: EditQueuedEffects): void {
+  // Guard: never clobber an in-progress draft. Leave the queued entry intact
+  // (do NOT cancel) so nothing is stranded, and tell the user why.
+  if (fx.getDraft().trim().length > 0) {
+    fx.notify(EDIT_QUEUED_BUSY_NOTICE)
+    return
+  }
+  // Fail-closed: a closed socket returns false without dropping the entry —
+  // bail without touching the composer so nothing is clobbered or stranded.
+  if (fx.cancelQueued(id) === false) return
+  fx.reopenComposer(text)
+  fx.focusComposer?.()
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3130,6 +3130,28 @@ button.sidebar-token-view-session-row:hover {
   font-variant-numeric: tabular-nums;
 }
 
+/* #6628 — edit a still-queued follow-up: reopens its text in the composer and
+   cancels the queued entry. Sits left of the ✕ cancel control. */
+.msg-queued-edit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.msg-queued-edit:hover {
+  background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  color: var(--text-primary);
+}
+
 .msg-queued-cancel {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What

Adds an **Edit** control to queued send-while-busy follow-ups on both clients (dashboard + mobile app), alongside the existing Cancel affordance.

Chroxy's queue-while-processing feature lets a user send a follow-up mid-turn; it queues and auto-flushes when the turn ends. A queued bubble already showed a `QUEUED` badge, position (`#N`), and a per-item cancel (`×` → `cancel_queued`, #5943). This adds the missing **edit** control so a user who spots a typo — or wants to add context — can amend a queued message before it is sent.

## How

**Edit is cancel-and-reopen** (no new wire message — the server-side outgoing-queue logic is unchanged):
1. Cancel the queued entry via the existing `cancel_queued` path, which optimistically drops the queued bubble + badge.
2. Reopen the message text in the composer so the user can amend it and re-send (which re-queues it).

This reuses the fully-built, already-tested cancel plumbing (server `cancelQueuedMessage` + `handleCancelQueued`, both clients' `sendCancelQueued`). Cancel already existed end-to-end; this PR is the edit half plus wiring the UI.

- **dashboard**: `onEditQueued` in `App` + `ChatView`; an `Edit` button in the queued decoration (`msg-queued-edit-<id>`); `.msg-queued-edit` style; ChatView interaction tests.
- **app**: `onEditQueued` threaded through `ChatView` → `MessageBubble` → `SessionScreen`; `Edit` affordance with a ~44pt tap target + accessibility label; `MessageBubble` render/interaction test.

## Race handling (AC5)

`sendCancelQueued` returns `false` on a closed socket **without** dropping the entry, so the edit handler bails then — it neither clobbers the current composer draft nor strands a queued message the cancel never reached. Once a message flushes, its `message_dequeued` clears the queued badge (and with it these controls), and the server's `cancelQueuedMessage` is a no-op for an already-flushed item — so the edit/cancel intents can't corrupt a message mid-dispatch.

## Position note

Because edit re-sends through the composer, an edited message re-queues at the **tail**. For the common case (editing the message you just queued, which *is* the tail) ordering is preserved exactly; a mid-queue edit moves that one item to the end. This matches the issue's "preserved position where possible" hedge. A true in-place, position-preserving edit would need a new `edit_queued` wire message + a history/bubble-text rewrite broadcast across clients — filed as a follow-up if desired.

## Acceptance criteria

- [x] Users can cancel a queued follow-up before it is sent (pre-existing #5943; verified end-to-end).
- [x] Users can edit a queued follow-up before it is sent (this PR).
- [x] Cancel/edit actions have clear resolved UI states (bubble/badge clears; edit text lands in the composer).
- [x] Queue ordering remains correct after an edit (preserved for the tail case; documented tail-append for mid-queue).
- [x] The UI handles the race where a queued message transitions to sending while the user attempts to edit/cancel (bail-on-closed-socket + no-op-once-flushed).

## Tests

- dashboard `ChatView.test.tsx`: edit button renders + fires `onEditQueued(id, text)`; omitted with no handler. Full dashboard suite green (4640).
- app `MessageBubble.queuedEdit.test.tsx`: edit control role/label + `onEditQueued(id, text)`; cancel still fires; omitted with no handler. Full app suite green (2253).
- dashboard + app typecheck clean. No server / store-core / protocol changes (edit reuses `cancel_queued`), so no protocol-dist rebuild or coverage-guard updates.

Closes #6628