### PR TITLE
test(server): commit negative meta-test for event-normalizer schema guard

### DIFF
--- a/packages/server/tests/event-normalizer-schema.test.js
+++ b/packages/server/tests/event-normalizer-schema.test.js
@@ -293,3 +293,78 @@ describe('EventNormalizer output → Server*Schema round-trip (#6841)', () => {
     )
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #6892 — negative meta-test: prove the round-trip harness above is
+// non-vacuous.
+//
+// Every `it()` above only means something if `safeParse` can actually FAIL for
+// a real drift. The #6889 PR body claimed the guard "bites" — a
+// `message_queued` missing required `sessionId`, and a `result` with a
+// non-numeric `cost`, both fail `safeParse` — but that check was only run by
+// hand, never committed. A future refactor could make every test above pass
+// VACUOUSLY (a fixture stops reaching `parse`, an emitter starts returning
+// `undefined`, `validateMessage` gets short-circuited) without a single test
+// failing.
+//
+// This reuses the SAME plumbing as the harness above (a real FIXTURES entry
+// driven through the real EventNormalizer, checked against the real
+// SCHEMA_BY_TYPE mapping) and corrupts the normalizer's actual OUTPUT the same
+// two ways: dropping a required field, and wrong-typing a required field. Each
+// case first asserts the pre-corruption field is present with the expected
+// type (proof the corruption mutates a real value, not a no-op), then asserts
+// `safeParse` on the corrupted message FAILS. If either assertion is ever
+// satisfied by a passing `safeParse`, the drift guard above has gone vacuous.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('negative meta-test: the round-trip harness catches real drift (#6892)', () => {
+  // Drive one FIXTURES entry through the real normalizer and return the first
+  // emitted message of the given wire `type` — same path the harness above
+  // uses, so the corrupted message below is a genuine normalizer output.
+  function emitFixture(event, wireType) {
+    const fixture = FIXTURES.find(([e]) => e === event)
+    assert.ok(fixture, `no FIXTURES entry for '${event}' — this meta-test must target a real fixture`)
+    const [, data, ctx] = fixture
+    const normalizer = new EventNormalizer({ flushIntervalMs: 10 })
+    try {
+      const result = normalizer.normalize(event, data, ctx)
+      const entry = (result?.messages ?? []).find((m) => m.msg?.type === wireType)
+      assert.ok(entry, `expected '${event}' to emit a '${wireType}' message`)
+      return entry.msg
+    } finally {
+      normalizer.destroy()
+    }
+  }
+
+  it('catches a dropped required field: message_queued without sessionId', () => {
+    const msg = emitFixture('message_queued', 'message_queued')
+    assert.equal(
+      typeof msg.sessionId,
+      'string',
+      'fixture sanity: sessionId must be a real string before corruption, or this proves nothing',
+    )
+    const corrupted = { ...msg }
+    delete corrupted.sessionId
+    const parsed = SCHEMA_BY_TYPE.message_queued.safeParse(corrupted)
+    assert.equal(
+      parsed.success,
+      false,
+      'dropping required sessionId must fail safeParse — a `true` here means the drift guard is vacuous',
+    )
+  })
+
+  it('catches a wrong-typed required field: result with non-numeric cost', () => {
+    const msg = emitFixture('result', 'result')
+    assert.equal(
+      typeof msg.cost,
+      'number',
+      'fixture sanity: cost must be a real number before corruption, or this proves nothing',
+    )
+    const corrupted = { ...msg, cost: 'not-a-number' }
+    const parsed = SCHEMA_BY_TYPE.result.safeParse(corrupted)
+    assert.equal(
+      parsed.success,
+      false,
+      'a non-numeric cost must fail safeParse — a `true` here means the drift guard is vacuous',
+    )
+  })
+})

--- a/packages/server/tests/event-normalizer-schema.test.js
+++ b/packages/server/tests/event-normalizer-schema.test.js
@@ -315,6 +315,19 @@ describe('EventNormalizer output → Server*Schema round-trip (#6841)', () => {
 // type (proof the corruption mutates a real value, not a no-op), then asserts
 // `safeParse` on the corrupted message FAILS. If either assertion is ever
 // satisfied by a passing `safeParse`, the drift guard above has gone vacuous.
+//
+// A direct `safeParse` call only proves the SCHEMA rejects the corrupted
+// value — it does not prove the HARNESS above would catch it. The per-fixture
+// `it()`s at the top of this file don't call `safeParse` directly; they call
+// `validateMessage(event, entry.msg)` (defined above), which wraps
+// `safeParse` in an `assert.ok` that THROWS on failure. If a future refactor
+// ever short-circuited `validateMessage` into a no-op (e.g. dropped the
+// `assert.ok`, or started returning early), every `it()` above would keep
+// passing vacuously — while a direct-`safeParse` negative test would still
+// pass too, hiding the regression. So each case below ALSO routes the
+// corrupted message through that SAME `validateMessage` helper and asserts it
+// throws, proving the harness's actual validation path — not just the
+// schema — bites on drift.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('negative meta-test: the round-trip harness catches real drift (#6892)', () => {
   // Drive one FIXTURES entry through the real normalizer and return the first
@@ -350,6 +363,18 @@ describe('negative meta-test: the round-trip harness catches real drift (#6892)'
       false,
       'dropping required sessionId must fail safeParse — a `true` here means the drift guard is vacuous',
     )
+    // Belt-and-suspenders: also drive the corrupted message through the same
+    // `validateMessage` helper the harness `it()`s above actually call. This
+    // proves the HARNESS path (not just the schema) rejects the drift — if
+    // `validateMessage` were ever short-circuited to a no-op, this throws()
+    // would stop firing even though the direct safeParse check above still
+    // passes.
+    assert.throws(
+      () => validateMessage('message_queued', corrupted),
+      (err) => err instanceof Error && /must validate against its Server\*Schema/.test(err.message),
+      'validateMessage(...) — the same harness helper the positive tests call — must also reject ' +
+        'the corrupted message; a silent pass here means the harness itself has been short-circuited',
+    )
   })
 
   it('catches a wrong-typed required field: result with non-numeric cost', () => {
@@ -365,6 +390,18 @@ describe('negative meta-test: the round-trip harness catches real drift (#6892)'
       parsed.success,
       false,
       'a non-numeric cost must fail safeParse — a `true` here means the drift guard is vacuous',
+    )
+    // Belt-and-suspenders: also drive the corrupted message through the same
+    // `validateMessage` helper the harness `it()`s above actually call. This
+    // proves the HARNESS path (not just the schema) rejects the drift — if
+    // `validateMessage` were ever short-circuited to a no-op, this throws()
+    // would stop firing even though the direct safeParse check above still
+    // passes.
+    assert.throws(
+      () => validateMessage('result', corrupted),
+      (err) => err instanceof Error && /must validate against its Server\*Schema/.test(err.message),
+      'validateMessage(...) — the same harness helper the positive tests call — must also reject ' +
+        'the corrupted message; a silent pass here means the harness itself has been short-circuited',
     )
   })
 })


### PR DESCRIPTION
## Summary
- The #6889 event-normalizer -> `Server*Schema` drift guard (`packages/server/tests/event-normalizer-schema.test.js`) was verified to actually catch drift only by hand, narrated in the PR body — not committed as a test. A future refactor could make the harness pass vacuously (fixtures stop reaching `parse`, an emitter returns `undefined`) without any test failing.
- Adds a negative meta-test that reuses the existing `FIXTURES` table and `SCHEMA_BY_TYPE` mapping: drives a real fixture through the real `EventNormalizer`, corrupts the emitted wire message the same two ways the #6889 PR body cited, and asserts `safeParse` fails:
  - `message_queued` with `sessionId` dropped (required field missing)
  - `result` with `cost` set to a non-numeric value (wrong-typed field)
- Each case asserts the pre-corruption field is present with the expected type first, proving the corruption mutates a real value rather than being a no-op.

Test-only change — no production code touched.

Closes #6892

## Test plan
- [x] `node --test --test-force-exit packages/server/tests/event-normalizer-schema.test.js` — 43/43 passing
- [x] Manually verified the negative meta-test correctly FAILS when the schema is satisfied (temporarily disabled both corruptions — both new subtests failed as expected, proving the assertions aren't vacuously true)
- [x] All `packages/server/scripts/lint-*.sh` pass (claude-family-explicit, logger-session-scoping, session-opt-forwarding, tests-state-file-path, ws-index-mutations)