### PR TITLE
fix(server,docs): semantic-title pending-guard cleanup + headless-pool metering note

### DIFF
--- a/docs/setup-and-smoke-test.md
+++ b/docs/setup-and-smoke-test.md
@@ -155,6 +155,13 @@ aborts the call and falls back to the truncation label rather than leaking a
 never-settling request; override it with `CHROXY_SEMANTIC_TITLES_TIMEOUT_MS=<ms>`
 or the `summarize.titleTimeoutMs` config key.
 
+**Metering note:** this one-shot runs through the Agent SDK / headless path
+(the same call the `summarize.model` summarizer uses). On a Claude
+subscription, headless/SDK calls are billed against the separate metered pool,
+not the plan's main quota — so an opted-in user on a subscription spends one
+(small) metered-pool call per new session's first turn. The cost is
+negligible, but it is non-zero and separate from your interactive usage.
+
 ---
 
 ## 6. Connect

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1984,47 +1984,59 @@ export class SessionManager extends EventEmitter {
    * @param {string} fallbackLabel
    */
   async _generateSemanticTitle(sessionId, firstMessage, fallbackLabel) {
-    // Default runner is the SDK one-shot shared with the #5547 summarizer; loaded
-    // lazily so the SDK stays out of SessionManager's static import graph. Tests
-    // inject `titleRunOneShot`, short-circuiting the import entirely.
-    const runOneShot = this._titleRunOneShot
-      || (await import('./summarize-session.js')).defaultRunOneShot
+    try {
+      // Default runner is the SDK one-shot shared with the #5547 summarizer; loaded
+      // lazily so the SDK stays out of SessionManager's static import graph. Tests
+      // inject `titleRunOneShot`, short-circuiting the import entirely.
+      const runOneShot = this._titleRunOneShot
+        || (await import('./summarize-session.js')).defaultRunOneShot
 
-    // Hard-bound the fire-and-forget call: AbortSignal.timeout fires after
-    // _semanticTitleTimeoutMs, which threads to defaultRunOneShot →
-    // query({ abortController }) so a stalled provider stream is torn down (not
-    // just abandoned). generateSessionTitle catches the resulting abort rejection
-    // and fails open to the truncation label. Without this the detached promise
-    // could stay pending forever, leaking `this` + the first message (#6764).
-    const signal = AbortSignal.timeout(this._semanticTitleTimeoutMs)
+      // Hard-bound the fire-and-forget call: AbortSignal.timeout fires after
+      // _semanticTitleTimeoutMs, which threads to defaultRunOneShot →
+      // query({ abortController }) so a stalled provider stream is torn down (not
+      // just abandoned). generateSessionTitle catches the resulting abort rejection
+      // and fails open to the truncation label. Without this the detached promise
+      // could stay pending forever, leaking `this` + the first message (#6764).
+      const signal = AbortSignal.timeout(this._semanticTitleTimeoutMs)
 
-    const { title, source } = await generateSessionTitle({
-      firstUserMessage: firstMessage,
-      enabled: true,
-      model: this._semanticTitleModel,
-      cwd: this._sessions.get(sessionId)?.cwd,
-      runOneShot,
-      signal,
-      fallback: fallbackLabel,
-    })
+      const { title, source } = await generateSessionTitle({
+        firstUserMessage: firstMessage,
+        enabled: true,
+        model: this._semanticTitleModel,
+        cwd: this._sessions.get(sessionId)?.cwd,
+        runOneShot,
+        signal,
+        fallback: fallbackLabel,
+      })
 
-    // Only a model-generated title is worth replacing the truncation with.
-    if (source !== 'model' || typeof title !== 'string' || !title) return
+      // Only a model-generated title is worth replacing the truncation with.
+      if (source !== 'model' || typeof title !== 'string' || !title) return
 
-    const current = this._sessions.get(sessionId)
-    if (!current) return // session was destroyed while the call was in flight
-    current._semanticTitleDone = true
-    current._semanticTitlePending = false
-    // Respect a manual rename (or any other label change) that landed mid-flight:
-    // only upgrade when the name is still exactly the truncation we applied.
-    if (current.name !== fallbackLabel) return
-    if (current.name === title) return // identical — nothing to broadcast
+      const current = this._sessions.get(sessionId)
+      if (!current) return // session was destroyed while the call was in flight
+      current._semanticTitleDone = true
+      // Respect a manual rename (or any other label change) that landed mid-flight:
+      // only upgrade when the name is still exactly the truncation we applied.
+      if (current.name !== fallbackLabel) return
+      if (current.name === title) return // identical — nothing to broadcast
 
-    current.name = title
-    current._autoLabeled = true
-    log.info(`Semantic-titled session ${sessionId} to "${title}"`)
-    this.emit('session_updated', { sessionId, name: title })
-    this._flushPersistOrWarn(sessionId, title)
+      current.name = title
+      current._autoLabeled = true
+      log.info(`Semantic-titled session ${sessionId} to "${title}"`)
+      this.emit('session_updated', { sessionId, name: title })
+      this._flushPersistOrWarn(sessionId, title)
+    } finally {
+      // #6886 — clear the once-per-session in-flight guard on EVERY exit path
+      // (success, the truncation/no-usable-title early return above, or a
+      // thrown error), not just the success branch. Previously a failed or
+      // timed-out title call left `_semanticTitlePending` stuck `true` for
+      // the session's lifetime — harmless today (`auto_label` fires at most
+      // once per session, so nothing re-checks the flag) but a latent trap
+      // for any future retry logic keyed on it. Not persisted
+      // (`_serializeSessionEntry` is field-explicit) — purely in-memory hygiene.
+      const current = this._sessions.get(sessionId)
+      if (current) current._semanticTitlePending = false
+    }
   }
 
   /**

--- a/packages/server/tests/semantic-title.test.js
+++ b/packages/server/tests/semantic-title.test.js
@@ -100,6 +100,9 @@ describe('SessionManager semantic titles (#6764)', () => {
     // Name stays the truncation; no second (model) broadcast landed.
     assert.equal(mgr.getSession('s1').name, 'help me refactor the tunnel reconnect...')
     assert.equal(modelNames.length, 1, 'only the truncation update was broadcast')
+    // #6886 — the once-per-session in-flight guard must be cleared on the fail
+    // path too, not just the success path, or it gets stuck `true` forever.
+    assert.equal(mgr._sessions.get('s1')._semanticTitlePending, false, 'pending flag must be cleared after a failed title call')
   })
 
   it('only fires once per session (second turn does not re-trigger)', async () => {
@@ -191,6 +194,8 @@ describe('SessionManager semantic titles (#6764)', () => {
 
     assert.equal(mgr.getSession('s1').name, 'help me refactor the tunnel reconnect...')
     assert.equal(names.length, 1, 'only the truncation update was broadcast — the model call timed out and failed open')
+    // #6886 — same guard-clearing requirement on the timeout/abort path.
+    assert.equal(mgr._sessions.get('s1')._semanticTitlePending, false, 'pending flag must be cleared after a timed-out title call')
   })
 
   it('does not upgrade custom-named sessions (no auto_label fires)', async () => {


### PR DESCRIPTION
## Summary

Two small follow-ups from the review of #6881 (semantic session titles), bundled together per #6886 + #6887.

- **#6886** — `_generateSemanticTitle` (`packages/server/src/session-manager.js`) set `entry._semanticTitlePending = true` before firing the one-shot model call but only cleared it on the model-title success branch. The truncation/no-usable-title early return (`if (source !== 'model' || ...) return`) — hit on any fail, timeout, or unusable-reply outcome — left `_semanticTitlePending` stuck `true` for the session's lifetime. No user-visible impact today (`auto_label` only fires once per session), but it's a latent trap for any future retry logic keyed on the flag. Fixed by wrapping the method body in `try/finally` so the flag clears on every exit path (success, early return, or a thrown error).
- **#6887** — the setup guide's semantic-titles section described the upgrade as "a cheap one-shot Haiku call" without noting it runs through the headless/SDK path, which on a Claude subscription is metered against the separate headless pool rather than the main quota. Added a short "Metering note" paragraph to `docs/setup-and-smoke-test.md` so an opted-in user on a subscription knows what the call consumes.

## Test plan

- [x] Extended `packages/server/tests/semantic-title.test.js`'s existing "model call fails" and "model call times out" tests with an assertion that `_semanticTitlePending` is `false` afterward — confirmed red (assertion failed, `true !== false`) before the fix, green after.
- [x] `node --test packages/server/tests/semantic-title.test.js` — 8/8 pass
- [x] `node --test packages/server/tests/session-manager.test.js` — 204/204 pass (full regression on the touched file)
- [x] All `packages/server/scripts/lint-*.sh` — pass (claude-family-explicit, logger-session-scoping, session-opt-forwarding, tests-state-file-path, ws-index-mutations)

Closes #6886
Closes #6887