### PR TITLE
test(server): make resolveTrustAddress timeout test hermetic (#6908)

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -258,9 +258,20 @@ function _summariseClassification(classifications) {
  *
  * The lookup is bounded by `timeoutMs` (#6852): resolveTrustAddress runs under
  * the fleet's trust-store lock, so a hanging resolver must not stall the prompt
- * or the lock — a timeout falls back to 'could not resolve host'.
+ * or the lock — a timeout falls back to 'could not resolve host'. The timer
+ * itself is injectable via `setTimer`/`clearTimer` (default node globals) so a
+ * test can drive the timeout deterministically — firing it by hand instead of
+ * waiting on the wall clock (#6908) — with no real DNS and no real timer.
  */
-export async function resolveTrustAddress(url, { lookup = dnsLookup, timeoutMs = DEFAULT_TRUST_DNS_TIMEOUT_MS } = {}) {
+export async function resolveTrustAddress(
+  url,
+  {
+    lookup = dnsLookup,
+    timeoutMs = DEFAULT_TRUST_DNS_TIMEOUT_MS,
+    setTimer = setTimeout,
+    clearTimer = clearTimeout,
+  } = {},
+) {
   const miss = (hostname = null) => ({
     resolved: false,
     hostname,
@@ -300,9 +311,10 @@ export async function resolveTrustAddress(url, { lookup = dnsLookup, timeoutMs =
     // promise, so a late rejection from the loser stays handled. The timer is
     // NOT unref'd — it is always cleared in `finally` once the race settles, so
     // it never outlives this (awaited) resolution, and keeping the loop alive
-    // while we resolve is the intended behaviour.
+    // while we resolve is the intended behaviour. `setTimer`/`clearTimer` are
+    // injectable (default globals) so a test drives the timeout deterministically.
     const timeoutArm = new Promise((resolve) => {
-      timer = setTimeout(() => resolve(_LOOKUP_TIMEOUT), timeoutMs)
+      timer = setTimer(() => resolve(_LOOKUP_TIMEOUT), timeoutMs)
     })
     const addrs = await Promise.race([lookup(bare, { all: true }), timeoutArm])
     if (addrs === _LOOKUP_TIMEOUT) return miss(hostname)
@@ -322,7 +334,7 @@ export async function resolveTrustAddress(url, { lookup = dnsLookup, timeoutMs =
   } catch {
     return miss(hostname)
   } finally {
-    clearTimeout(timer)
+    clearTimer(timer)
   }
 }
 

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -510,30 +510,57 @@ describe('resolveTrustAddress (#6834)', () => {
   })
 
   it('times out a hanging lookup and returns the graceful fallback (#6852)', async () => {
-    // A resolver that stalls past the timeout must not hang the prompt (or the
-    // fleet's trust-store lock). The timeout arm wins the race → fallback. The
-    // lookup is gated on a promise we release AFTER asserting, so the stub
-    // settles deterministically (no dangling never-resolving promise).
-    let release
-    const gate = new Promise((resolve) => { release = resolve })
-    const stalledLookup = () => gate.then(() => [{ address: '203.0.113.7', family: 4 }])
-    const started = Date.now()
-    const r = await resolveTrustAddress('https://slow.example/mcp', { lookup: stalledLookup, timeoutMs: 40 })
-    const elapsed = Date.now() - started
+    // Hermetic (#6908): no real DNS, no real timer, no wall clock. A resolver
+    // that NEVER settles races an INJECTED timer we fire by hand — so the
+    // timeout arm wins deterministically → the graceful fallback. The lookup
+    // would resolve to a routable address if it ever won, so `resolved:false`
+    // proves the TIMEOUT path (not an empty/failed lookup) produced the miss.
+    const scheduled = []
+    let clearedHandle = null
+    const setTimer = (fn, ms) => {
+      scheduled.push({ fn, ms })
+      return { handle: scheduled.length }
+    }
+    const clearTimer = (h) => { clearedHandle = h }
+    const hangingLookup = () => new Promise(() => {}) // never settles on its own
+    const p = resolveTrustAddress('https://slow.example/mcp', {
+      lookup: hangingLookup,
+      timeoutMs: 40,
+      setTimer,
+      clearTimer,
+    })
+    // The timeout is scheduled synchronously while resolveTrustAddress runs up
+    // to its first await, so exactly one timer exists before we drive it.
+    assert.equal(scheduled.length, 1, 'exactly one timeout must be scheduled')
+    assert.equal(scheduled[0].ms, 40, 'the timeout uses the injected timeoutMs')
+    scheduled[0].fn() // fire the timeout arm; it wins the race vs the hanging lookup
+    const r = await p
     assert.equal(r.resolved, false)
     assert.equal(r.display, 'could not resolve host')
     assert.equal(r.hostname, 'slow.example')
-    assert.ok(elapsed >= 40, `should wait for the timeout (elapsed ${elapsed}ms)`)
-    assert.ok(elapsed < 2000, `should not hang past the timeout (elapsed ${elapsed}ms)`)
-    // Let the abandoned lookup settle so the test leaves nothing pending.
-    release()
-    await gate
+    assert.deepEqual(clearedHandle, { handle: 1 }, 'the timer must be cleared in finally')
   })
 
   it('a lookup that resolves before the timeout still wins (#6852)', async () => {
+    // Also hermetic: the injected timer is never fired, so the immediately-
+    // resolving lookup wins the race and the timer is cleared without waiting.
+    const scheduled = []
+    let clearedHandle = null
+    const setTimer = (fn, ms) => {
+      scheduled.push({ fn, ms })
+      return { handle: scheduled.length }
+    }
+    const clearTimer = (h) => { clearedHandle = h }
     const lookup = async () => [{ address: '10.0.0.9', family: 4 }]
-    const r = await resolveTrustAddress('https://fast.example/', { lookup, timeoutMs: 2000 })
+    const r = await resolveTrustAddress('https://fast.example/', {
+      lookup,
+      timeoutMs: 2000,
+      setTimer,
+      clearTimer,
+    })
     assert.equal(r.resolved, true)
     assert.equal(r.classification, 'private')
+    assert.equal(scheduled.length, 1, 'a timeout is scheduled but never fires')
+    assert.deepEqual(clearedHandle, { handle: 1 }, 'the timer is cleared once the lookup wins')
   })
 })


### PR DESCRIPTION
## Summary

Closes #6908.

The `resolveTrustAddress` DNS tests flaked twice on the **Server Tests** job of PR #6904 — a dashboard-only change touching zero server files — as `not ok 110 - resolveTrustAddress (#6834)` / `not ok 13 - times out a hanging lookup and returns the graceful fallback (#6852)`. Those two names are the **same failure**: the parent suite fails because subtest #13 fails.

The DNS resolver was already injectable (all the address-classification tests inject a fake `lookup`). The remaining real-world dependency was the **clock**: the "times out a hanging lookup" test drove a real `setTimeout(40)` and asserted on real `Date.now()` elapsed time:

```js
assert.ok(elapsed >= 40, ...)   // Node timers can fire ~1ms early -> 39 >= 40 fails
assert.ok(elapsed < 2000, ...)  // a loaded self-hosted runner can delay the timer
```

That wall-clock assertion is the flake.

## Change

- **Add injectable `setTimer`/`clearTimer` seams to `resolveTrustAddress`** (default to the node `setTimeout`/`clearTimeout` globals). Production behavior is unchanged — the sole caller (`permission-manager.js`) passes only `lookup` and inherits the defaults.
- **Rewrite the timeout test to be hermetic**: it races a never-settling lookup against an **injected timer fired by hand** — deterministic, no real DNS, no real timer, no wall clock. `resolved:false` proves the *timeout* path produced the fallback (the lookup would return a routable address if it ever won), and it asserts the timer is cleared in `finally`.
- **Make the sibling "resolves before the timeout" test hermetic the same way**: the injected timer is never fired, the immediate lookup wins the race, the timer is cleared.

No change to production DNS behavior — only the timer became injectable, and only the tests use the fake.

## Verification

- Touched test file: **41/41 pass**, run 5× back-to-back with no flake.
- Exits cleanly on its own with **no leaked handles/timers** (no `--test-force-exit` needed for this file).
- All five server `lint-*.sh` scripts (the CI `server-lint` gate) exit 0.

## Out of scope

The ancillary `[claude-tui-session] PTY respawn threw` async-after-teardown null-deref noted in the issue is marked optional / separate and lower priority — left for a follow-up to keep this PR focused on the DNS/clock hermeticity.