### PR TITLE
fix(dashboard): prevent .input-bar-actions horizontal overflow at extreme pane widths

### DIFF
--- a/packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts
+++ b/packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts
@@ -79,4 +79,21 @@ describe('InputBar composer layout — actions overflow (#6897)', () => {
     expect(maxWidth, 'expected a max-width declaration').not.toBeNull()
     expect(maxWidth![1]!.trim()).toBe('100%')
   })
+
+  // Copilot review on #6912: `.input-bar-keyhint` is a flex item of
+  // `.input-bar-actions` and, like any flex item, defaults to
+  // `min-width: auto` — a floor at its own (nowrap) content width regardless
+  // of the parent's `flex-wrap`/`max-width`. At pane widths narrower than the
+  // hint text that floor still forces horizontal overflow. It must shrink
+  // below its content width and truncate instead (decorative/aria-hidden, so
+  // truncation is a11y-safe).
+  test('.input-bar-keyhint can shrink below its content width and truncates instead of overflowing', () => {
+    const body = ruleBody('.input-bar-keyhint')
+    expect(body).toMatch(/white-space:\s*nowrap/)
+    const minWidth = body.match(/min-width:\s*([^;]+);/)
+    expect(minWidth, 'expected a min-width declaration').not.toBeNull()
+    expect(minWidth![1]!.trim()).toBe('0')
+    expect(body).toMatch(/overflow:\s*hidden/)
+    expect(body).toMatch(/text-overflow:\s*ellipsis/)
+  })
 })

--- a/packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts
+++ b/packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts
@@ -61,3 +61,22 @@ describe('InputBar composer layout (#6624)', () => {
     expect(body).toMatch(/flex-shrink:\s*0/)
   })
 })
+
+describe('InputBar composer layout — actions overflow (#6897)', () => {
+  // `.input-bar-actions` keeps `flex-shrink: 0` (the #6624 invariant above)
+  // so it isn't squeezed by the textarea, but with no wrap/width handling of
+  // its own its natural content width (keyhint + mic + Evaluate + Send/Stop)
+  // was a hard floor: at extreme pane widths the row `.input-bar` wraps it
+  // onto could still be narrower than that floor, overflowing horizontally.
+  test('.input-bar-actions wraps its own buttons instead of overflowing', () => {
+    const body = ruleBody('.input-bar-actions')
+    expect(body).toMatch(/flex-wrap:\s*wrap/)
+  })
+
+  test('.input-bar-actions is capped at the width of its row (never wider than 100%)', () => {
+    const body = ruleBody('.input-bar-actions')
+    const maxWidth = body.match(/max-width:\s*([^;]+);/)
+    expect(maxWidth, 'expected a max-width declaration').not.toBeNull()
+    expect(maxWidth![1]!.trim()).toBe('100%')
+  })
+})

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5962,7 +5962,18 @@ button.sidebar-token-view-session-row:hover {
 
 /* Chat redesign #6391 (slice 5): always-visible Enter-mode keyhint. Muted and
    small, sits inline before the action buttons — no extra row, so the composer
-   height never churns. Tokens only (ratchet-clean). */
+   height never churns. Tokens only (ratchet-clean).
+ *
+ * Copilot review (#6912) on the `.input-bar-actions` overflow fix above: this
+ * is a flex item of `.input-bar-actions` and, like any flex item, defaults to
+ * `min-width: auto` — a floor at its own content width regardless of parent
+ * `flex-wrap`/`max-width`. Combined with `white-space: nowrap` that floor
+ * still forced horizontal overflow at pane widths narrower than the hint
+ * text, even after the #6897 fix above. `min-width: 0` lets it shrink below
+ * content width; `overflow: hidden` + `text-overflow: ellipsis` truncate it
+ * instead of overflowing. Safe because the element is `aria-hidden="true"`
+ * (decorative) — truncation has no accessibility impact. At normal widths
+ * the hint fits and the ellipsis never renders. */
 .input-bar-keyhint {
   font-size: var(--text-xs);
   color: var(--text-dim);
@@ -5970,6 +5981,9 @@ button.sidebar-token-view-session-row:hover {
   white-space: nowrap;
   user-select: none;
   margin-right: 2px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .btn-mic {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5944,8 +5944,20 @@ button.sidebar-token-view-session-row:hover {
 .input-bar-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
   flex-shrink: 0;
+  /* #6897 — residual overflow noted during the #6624/#6896 composer-collapse
+   * review. `.input-bar-actions` keeps `flex-shrink: 0` so it never gets
+   * squeezed by the textarea (that's the #6624 fix), but with no wrap/width
+   * handling of its own its natural content width (keyhint + mic + Evaluate
+   * + Send/Stop) was a hard floor: at extreme pane widths (SplitPane's
+   * `minSize={20}` on a narrow window) `.input-bar` wraps this row onto its
+   * own line, and that line could still overflow the pane horizontally.
+   * `flex-wrap: wrap` lets the buttons stack onto additional lines instead
+   * of overflowing, and `max-width: 100%` is a defensive cap so the row
+   * itself is never wider than the space `.input-bar` gives it. */
+  max-width: 100%;
 }
 
 /* Chat redesign #6391 (slice 5): always-visible Enter-mode keyhint. Muted and


### PR DESCRIPTION
## Summary

Closes #6897.

`.input-bar-actions` (the composer's keyhint/mic/Evaluate/Send-Stop cluster in `packages/dashboard/src/theme/components.css`) was `flex-shrink: 0` with no wrap or width handling of its own. At extreme session-pane widths — reachable via `SplitPane.tsx`'s `Panel minSize={20}` on a narrow window — `.input-bar` (a `flex-wrap: wrap` row) wraps the actions cluster onto its own line, but that line's natural content width could still exceed the pane width and overflow horizontally instead of shrinking or wrapping internally.

This is the residual actions-overflow noted during the #6896 (`fix/composer-column-collapse`, #6624) review — #6896 fixed the *textarea* collapsing to a sliver, but that fix routes narrow-width pressure onto the actions cluster instead once the pane drops below roughly the actions row's natural width.

- `flex-wrap: wrap` on `.input-bar-actions` lets the buttons stack onto additional lines instead of overflowing.
- `max-width: 100%` is a defensive cap so the row is never wider than the space `.input-bar` gives it.
- `flex-shrink: 0` is kept — the actions still don't get squeezed by the textarea at moderate widths (the existing #6624 invariant).

## Validation

- Extended `packages/dashboard/src/components/InputBarComposerLayoutCss.test.ts` (jsdom has no layout engine, so this locks the structural CSS invariants rather than pixel widths) with two new tests asserting `.input-bar-actions` has `flex-wrap: wrap` and `max-width: 100%`, alongside the existing #6624 tests (all 5 tests in the file pass).
- Full dashboard suite: `npx vitest run` → 269 test files / 4663 tests passed.
- `npx tsc --noEmit` → clean.
- `scripts/lint-no-raw-color-literals.sh` → OK (no new raw color literals).
- `scripts/lint-undefined-css-vars.sh` → OK (no undefined custom properties).

**Flagged for manual/visual check** (CSS layout change, per the visual-change rule): open a session with an assistant turn active (Send/Stop + Evaluate + mic all visible), use the multi-pane split view, and drag a divider to a very narrow width (well under 200px) to confirm the actions row now wraps its buttons instead of clipping/overflowing horizontally, and that normal-width composer layout is unaffected.

## Test plan

- [ ] `npx vitest run src/components/InputBarComposerLayoutCss.test.ts` in `packages/dashboard`
- [ ] Manual: narrow a split-pane session below ~200px with an assistant turn active and confirm the actions cluster wraps instead of overflowing
- [ ] Manual: confirm normal-width composer layout (single-line actions row) is unchanged