### PR TITLE
fix(dashboard): treat device-view prefs as global persistence keys

### DIFF
--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -705,13 +705,23 @@ export function clearPersistedState(): void {
   }
 }
 
-/** Keys that should never be cleared during server switch */
+/**
+ * Keys that should never be cleared during server switch.
+ *
+ * Includes per-device UI/view preferences (#6883) — `showConsoleTab`,
+ * `interventionPing`, and `compactChatFilter` are device-level choices, not
+ * server-scoped session state, so they should survive an unscoped
+ * `clearPersistedState()` just like `theme`/`view_mode` do.
+ */
 function isGlobalKey(key: string): boolean {
   return key === KEY_VIEW_MODE
     || key === KEY_SIDEBAR_WIDTH
     || key === KEY_SPLIT_MODE
     || key === KEY_ACTIVE_SERVER
-    || key === KEY_THEME;
+    || key === KEY_THEME
+    || key === KEY_SHOW_CONSOLE_TAB
+    || key === KEY_INTERVENTION_PING
+    || key === KEY_COMPACT_CHAT_FILTER;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -21,6 +21,13 @@ import {
   loadPersistedSidebarPanelView,
   persistSidebarPanelCollapsed,
   loadPersistedSidebarPanelCollapsed,
+  // #6883 — device-view preferences must survive an unscoped clear
+  persistShowConsoleTab,
+  loadPersistedShowConsoleTab,
+  persistInterventionPing,
+  loadPersistedInterventionPing,
+  persistCompactChatFilter,
+  loadPersistedCompactChatFilter,
 } from './persistence';
 import {
   createKeyPair,
@@ -149,6 +156,25 @@ describe('persistence', () => {
     expect(state.viewMode).toBe('chat');
     // Session-specific data is cleared
     expect(state.activeSessionId).toBeNull();
+  });
+
+  // #6883 — device-view prefs (compact filter, console tab, intervention
+  // ping) are per-device UI choices, not server-scoped session state, so an
+  // unscoped clearPersistedState() must not reset them (matching theme /
+  // view_mode). Pre-#6883, these were wiped alongside session data.
+  it('clearPersistedState preserves device-view prefs but still clears session state', () => {
+    persistShowConsoleTab(true);
+    persistInterventionPing(false);
+    persistCompactChatFilter(true);
+    persistActiveSession('sess-1');
+
+    clearPersistedState();
+
+    expect(loadPersistedShowConsoleTab()).toBe(true);
+    expect(loadPersistedInterventionPing()).toBe(false);
+    expect(loadPersistedCompactChatFilter()).toBe(true);
+    // Session-scoped state still clears
+    expect(loadPersistedState().activeSessionId).toBeNull();
   });
 
   it('loadPersistedState returns defaults when empty', () => {


### PR DESCRIPTION
## Summary

- Adds `KEY_SHOW_CONSOLE_TAB`, `KEY_INTERVENTION_PING`, and `KEY_COMPACT_CHAT_FILTER` to `isGlobalKey()` in `packages/dashboard/src/store/persistence.ts` so an unscoped `clearPersistedState()` preserves them, matching the existing treatment of `theme`/`view_mode`.
- These three are per-device UI preferences (console-tab visibility, audible intervention-ping mute state, compact chat filter) rather than server-scoped session state — wiping them on a "clear data" / unscoped state clear was an asymmetry flagged during review of #6880.
- Deliberately narrow: the sidebar panel slot / repo-order / session-order / tab-order keys are NOT added — those are explicitly documented as server-scoped by design (different servers have different sessions/repos) and are out of scope for this issue.

## Test plan

- [x] Added `clearPersistedState preserves device-view prefs but still clears session state` to `packages/dashboard/src/store/store.test.ts`, asserting the three device-view prefs survive an unscoped clear while session-scoped state (`activeSessionId`) still clears.
- [x] Full dashboard suite: `npx vitest run` — 269 test files / 4665 tests passed.
- [x] `npx tsc --noEmit` — clean.

Closes #6883