### PR TITLE
refactor(app,store-core): mobile compact filter consumes shared predicate

### DIFF
--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -126,4 +126,29 @@ describe('SessionScreen component structure', () => {
     expect(src).toMatch(/import.*CreateSessionModal/)
     expect(src).toMatch(/<CreateSessionModal/)
   })
+
+  describe('compact chat filter consumes the shared predicate (#6882)', () => {
+    test('imports isHiddenInCompactMode from @chroxy/store-core', () => {
+      expect(src).toMatch(
+        /import\s*\{[^}]*\bisHiddenInCompactMode\b[^}]*\}\s*from\s*'@chroxy\/store-core'/,
+      )
+    })
+
+    test('the compact filter calls the shared predicate, not a hand-rolled duplicate', () => {
+      expect(src).toMatch(
+        /chatFilterCompact\s*&&\s*isHiddenInCompactMode\(m\.type\)/,
+      )
+      // The old hard-coded duplicate must be gone — this is the exact string
+      // #6882 was filed to remove (drift risk vs. the store-core predicate).
+      expect(src).not.toMatch(
+        /chatFilterCompact\s*&&\s*\(m\.type === 'tool_use' \|\| m\.type === 'thinking'\)/,
+      )
+    })
+
+    test('system messages are still filtered inline, separately from the compact predicate', () => {
+      // #6882: system filtering stays inline — isHiddenInCompactMode is
+      // specifically the compact-hide rule, not a catch-all message filter.
+      expect(src).toMatch(/if \(m\.type === 'system'\) return false;/)
+    })
+  })
 })

--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -140,8 +140,11 @@ describe('SessionScreen component structure', () => {
       )
       // The old hard-coded duplicate must be gone — this is the exact string
       // #6882 was filed to remove (drift risk vs. the store-core predicate).
+      // Whitespace-tolerant: catches the duplicate regardless of spacing
+      // around `===`/`||` (e.g. `m.type==='tool_use'`), without matching the
+      // legitimate isHiddenInCompactMode(m.type) call.
       expect(src).not.toMatch(
-        /chatFilterCompact\s*&&\s*\(m\.type === 'tool_use' \|\| m\.type === 'thinking'\)/,
+        /chatFilterCompact\s*&&\s*\(\s*m\.type\s*===\s*'tool_use'\s*\|\|\s*m\.type\s*===\s*'thinking'\s*\)/,
       )
     })
 

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -192,7 +192,7 @@ export function SessionScreen() {
       if (chatFilterCompact && isHiddenInCompactMode(m.type)) return false;
       return true;
     }),
-    [allMessages, chatFilterCompact],
+    [allMessages, chatFilterCompact, isHiddenInCompactMode],
   );
   const systemMessages = useMemo(
     () => allMessages.filter((m) => m.type === 'system'),

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -25,7 +25,12 @@ import type { SessionIntervention } from '@chroxy/store-core';
 // 'freeformText' in`) with the same 5-condition guard the store layer
 // uses, so widening `SelectOptionValue` to a third object shape can't
 // silently misroute it as freeform.
-import { isFreeformAnswer, providerSupportsMultiQuestion, providerSupportsSingleMultiSelect, approvePlanWithAcceptEdits } from '@chroxy/store-core';
+// #6882: `isHiddenInCompactMode` is the shared compact-filter predicate from
+// store-core's buildChatViewMessages.ts (added in #6880) — the single source
+// of truth for which message types compact mode hides. Converging mobile onto
+// it (instead of a hand-maintained duplicate of the same tool_use/thinking
+// check) keeps dashboard and mobile from silently drifting.
+import { isFreeformAnswer, providerSupportsMultiQuestion, providerSupportsSingleMultiSelect, approvePlanWithAcceptEdits, isHiddenInCompactMode } from '@chroxy/store-core';
 import { USER_SHELL_PROVIDER } from '@chroxy/protocol';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
@@ -178,11 +183,13 @@ export function SessionScreen() {
     closeGitView,
   } = useSessionViewState({ activeSessionId });
 
-  // Filter messages: exclude system (separate tab) and optionally tool_use/thinking (compact mode)
+  // Filter messages: exclude system (separate tab) and, in compact mode, whatever
+  // the shared #6880 predicate hides (tool_use/thinking today). `system` stays a
+  // separate inline check — isHiddenInCompactMode is specifically the compact-hide rule.
   const chatMessages = useMemo(
     () => allMessages.filter((m) => {
       if (m.type === 'system') return false;
-      if (chatFilterCompact && (m.type === 'tool_use' || m.type === 'thinking')) return false;
+      if (chatFilterCompact && isHiddenInCompactMode(m.type)) return false;
       return true;
     }),
     [allMessages, chatFilterCompact],

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -98,10 +98,10 @@ export interface BuildChatViewMessagesOptions {
    * every `tool_use` and `thinking` message from the transcript session-wide,
    * so the chat pane shows only the assistant's responses (and anything needing
    * action). Mirrors mobile's `chatFilterCompact` (SessionScreen.tsx), which
-   * pre-filters the same two types inline. Additive on top of the per-item
-   * ToolBubble/ToolGroup collapse — those stay untouched when this is off (the
-   * hidden types never reach the grouping pass, so no `tool_group` rows form).
-   * Default `false`.
+   * pre-filters via `isHiddenInCompactMode` (#6882) rather than a hand-rolled
+   * duplicate check. Additive on top of the per-item ToolBubble/ToolGroup
+   * collapse — those stay untouched when this is off (the hidden types never
+   * reach the grouping pass, so no `tool_group` rows form). Default `false`.
    */
   hideToolAndThinking?: boolean
 }
@@ -111,9 +111,9 @@ export interface BuildChatViewMessagesOptions {
  * vanish entirely when the filter is on. `tool_use` and `thinking` are the two
  * "noise" categories the mobile app already hides session-wide; the dashboard
  * toggle narrows off this single predicate. It is the shared definition other
- * clients can adopt so every surface agrees on WHAT compact mode hides — mobile
- * still hard-codes the same rule inline in SessionScreen.tsx; converging it onto
- * this predicate is tracked in #6882. Pure — safe to call per row.
+ * clients adopt so every surface agrees on WHAT compact mode hides — mobile's
+ * SessionScreen.tsx converged onto this predicate in #6882 (was previously a
+ * hand-rolled inline duplicate). Pure — safe to call per row.
  */
 export function isHiddenInCompactMode(type: ChatMessage['type']): boolean {
   return type === 'tool_use' || type === 'thinking'


### PR DESCRIPTION
## Summary

Spun out of the review of #6880. That PR added `isHiddenInCompactMode(type)` to `packages/store-core/src/buildChatViewMessages.ts` as "the single source of truth for what compact mode hides," and wired the dashboard to consume it via `buildChatViewMessages({ hideToolAndThinking })`. The mobile app's `SessionScreen.tsx` still hard-coded the same rule inline (`m.type === 'tool_use' || m.type === 'thinking'`), leaving room for the two definitions to silently drift.

- Import `isHiddenInCompactMode` from `@chroxy/store-core` in `SessionScreen.tsx`
- Replace the inline `tool_use`/`thinking` check with a call to the shared predicate (the `system`-type filter stays inline, as it's a separate concern from the compact-hide rule)
- Update `buildChatViewMessages.ts` doc comments to reflect that mobile has now converged onto the predicate
- Add `SessionScreen.test.ts` coverage asserting the shared predicate is imported and called, and that the old hard-coded duplicate is gone

This is a pure refactor — behavior is unchanged. `isHiddenInCompactMode(type)` returns exactly `type === 'tool_use' || type === 'thinking'`, the same check the inline code performed.

Closes #6882

## Test plan
- [x] `packages/app` — full jest suite (both `__tests__/` and `src/__tests__/` roots): 173/173 suites, 2260/2260 tests passing
- [x] `packages/store-core` — `buildChatViewMessages.test.ts` (33 tests, includes existing `isHiddenInCompactMode` coverage): passing
- [x] `tsc --noEmit` clean in both `packages/app` and `packages/store-core`