### PR TITLE
test(store-core,dashboard,app): guard wire-ordering of setPermissionMode before approve

### DIFF
--- a/packages/app/src/__tests__/store/plan-approve-wire-order.test.ts
+++ b/packages/app/src/__tests__/store/plan-approve-wire-order.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #6895 — client-level wire-ordering guard for the combined "approve plan +
+ * auto-accept edits" action (follow-up from the #6893 / #6774 review).
+ *
+ * `packages/store-core/src/plan-approval.test.ts` pins the SHARED HELPER's
+ * call order, but with `setPermissionMode`/`approve` replaced by plain mock
+ * functions — it proves `approvePlanWithAcceptEdits` invokes them in the
+ * right order, but says nothing about what either call actually puts on the
+ * wire, or when. The real guarantee (documented in `plan-approval.ts` and
+ * `SessionScreen.tsx`'s `handleApprovePlanAcceptEdits`) is that the mobile
+ * app's REAL `setPermissionMode` action sends the `set_permission_mode`
+ * frame SYNCHRONOUSLY before `sendInput(...)` sends the `input` frame —
+ * because the server drops a mid-turn permission-mode change once the
+ * implementation turn has started (`PERMISSION_MODE_NOT_APPLIED`).
+ *
+ * This test wires the combined action to the store's REAL setPermissionMode,
+ * addUserMessage, sendInput and clearPlanState (mirroring SessionScreen.tsx's
+ * `handleApprovePlanAcceptEdits` / `handleApprovePlan` exactly), with a
+ * socket stub that records frames in send order, and asserts
+ * `set_permission_mode` lands strictly before the approve `input` frame. If
+ * a future refactor of either action deferred its `wsSend` call behind a
+ * microtask/await, this test — unlike the store-core helper test — would
+ * catch the reordering, because it observes the actual wire, not just the
+ * order the two functions were called in.
+ */
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../utils/haptics', () => ({
+  hapticLight: jest.fn(),
+  hapticMedium: jest.fn(),
+  hapticWarning: jest.fn(),
+  hapticSuccess: jest.fn(),
+}));
+
+import { approvePlanWithAcceptEdits } from '@chroxy/store-core';
+import { useConnectionStore, createEmptySessionState } from '../../store/connection';
+import type { SessionState } from '../../store/types';
+
+interface FakeSocket {
+  readyState: number;
+  send: jest.Mock;
+}
+
+const OPEN = 1; // WebSocket.OPEN
+
+/** Healthy OPEN socket that records sent frames in order (mirrors #6308's liveSocket). */
+function liveSocket(sent: Array<Record<string, unknown>>): FakeSocket {
+  return {
+    readyState: OPEN,
+    send: jest.fn((raw: string) => {
+      try {
+        sent.push(JSON.parse(raw));
+      } catch {
+        /* noop */
+      }
+    }),
+  };
+}
+
+describe('#6895 — app combined plan-approve+acceptEdits wire order', () => {
+  it('sends set_permission_mode(acceptEdits) strictly before the approve input frame', () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const socket = liveSocket(sent);
+    const sessionId = 'sess-plan-1';
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessions: [{ sessionId, name: sessionId, provider: 'claude-sdk' }],
+      sessionStates: {
+        [sessionId]: {
+          ...createEmptySessionState(),
+          permissionMode: 'plan',
+          isPlanPending: true,
+        } as unknown as SessionState,
+      },
+      socket,
+    } as never);
+
+    const { setPermissionMode, addUserMessage, sendInput, clearPlanState } = useConnectionStore.getState();
+    // Mirrors SessionScreen.tsx's handleApprovePlan exactly: addUserMessage
+    // (local-only, no wire effect) + sendInput + clearPlanState (local-only).
+    const approve = (): void => {
+      addUserMessage('Go ahead with the plan');
+      sendInput('Go ahead with the plan');
+      clearPlanState();
+    };
+
+    approvePlanWithAcceptEdits({ setPermissionMode, approve });
+
+    // Strict order: exactly two frames, mode change first.
+    expect(sent.map((f) => f.type)).toEqual(['set_permission_mode', 'input']);
+    expect(sent[0]).toMatchObject({ type: 'set_permission_mode', mode: 'acceptEdits' });
+    expect(sent[1]).toMatchObject({ type: 'input', data: 'Go ahead with the plan' });
+  });
+});

--- a/packages/app/src/__tests__/store/plan-approve-wire-order.test.ts
+++ b/packages/app/src/__tests__/store/plan-approve-wire-order.test.ts
@@ -15,13 +15,15 @@
  *
  * This test wires the combined action to the store's REAL setPermissionMode,
  * addUserMessage, sendInput and clearPlanState (mirroring SessionScreen.tsx's
- * `handleApprovePlanAcceptEdits` / `handleApprovePlan` exactly), with a
- * socket stub that records frames in send order, and asserts
- * `set_permission_mode` lands strictly before the approve `input` frame. If
- * a future refactor of either action deferred its `wsSend` call behind a
- * microtask/await, this test — unlike the store-core helper test — would
- * catch the reordering, because it observes the actual wire, not just the
- * order the two functions were called in.
+ * `handleApprovePlanAcceptEdits` / `handleApprovePlan` exactly — including
+ * the client-generated `clientMessageId` that production passes to BOTH
+ * `addUserMessage` and `sendInput` so the optimistic bubble and the wire
+ * frame correlate, per #2902), with a socket stub that records frames in
+ * send order, and asserts `set_permission_mode` lands strictly before the
+ * approve `input` frame. If a future refactor of either action deferred its
+ * `wsSend` call behind a microtask/await, this test — unlike the store-core
+ * helper test — would catch the reordering, because it observes the actual
+ * wire, not just the order the two functions were called in.
  */
 jest.mock('expo-secure-store', () => ({
   getItemAsync: jest.fn(() => Promise.resolve(null)),
@@ -37,7 +39,7 @@ jest.mock('../../utils/haptics', () => ({
 }));
 
 import { approvePlanWithAcceptEdits } from '@chroxy/store-core';
-import { useConnectionStore, createEmptySessionState } from '../../store/connection';
+import { useConnectionStore, createEmptySessionState, nextMessageId } from '../../store/connection';
 import type { SessionState } from '../../store/types';
 
 interface FakeSocket {
@@ -80,11 +82,15 @@ describe('#6895 — app combined plan-approve+acceptEdits wire order', () => {
     } as never);
 
     const { setPermissionMode, addUserMessage, sendInput, clearPlanState } = useConnectionStore.getState();
-    // Mirrors SessionScreen.tsx's handleApprovePlan exactly: addUserMessage
-    // (local-only, no wire effect) + sendInput + clearPlanState (local-only).
+    // Mirrors SessionScreen.tsx's handleApprovePlan exactly: a client-generated
+    // clientMessageId passed to BOTH addUserMessage (local-only, no wire
+    // effect) and sendInput (which puts it on the `input` frame so the
+    // optimistic bubble and server history record correlate, #2902), then
+    // clearPlanState (local-only).
     const approve = (): void => {
-      addUserMessage('Go ahead with the plan');
-      sendInput('Go ahead with the plan');
+      const clientMessageId = nextMessageId('user');
+      addUserMessage('Go ahead with the plan', undefined, { clientMessageId });
+      sendInput('Go ahead with the plan', undefined, { clientMessageId });
       clearPlanState();
     };
 
@@ -93,6 +99,13 @@ describe('#6895 — app combined plan-approve+acceptEdits wire order', () => {
     // Strict order: exactly two frames, mode change first.
     expect(sent.map((f) => f.type)).toEqual(['set_permission_mode', 'input']);
     expect(sent[0]).toMatchObject({ type: 'set_permission_mode', mode: 'acceptEdits' });
-    expect(sent[1]).toMatchObject({ type: 'input', data: 'Go ahead with the plan' });
+    // Defensive: the input frame should carry the same clientMessageId
+    // production correlates against (not the core assertion above, but
+    // guards against a regression that drops it from the wire payload).
+    expect(sent[1]).toMatchObject({
+      type: 'input',
+      data: 'Go ahead with the plan',
+      clientMessageId: expect.any(String),
+    });
   });
 });

--- a/packages/dashboard/src/store/plan-approve-wire-order.test.ts
+++ b/packages/dashboard/src/store/plan-approve-wire-order.test.ts
@@ -1,0 +1,84 @@
+/**
+ * #6895 — client-level wire-ordering guard for the combined "approve plan +
+ * auto-accept edits" action (follow-up from the #6893 / #6774 review).
+ *
+ * `packages/store-core/src/plan-approval.test.ts` pins the SHARED HELPER's
+ * call order, but with `setPermissionMode`/`approve` replaced by plain
+ * `vi.fn()` mocks — it proves `approvePlanWithAcceptEdits` invokes them in
+ * the right order, but says nothing about what either call actually puts on
+ * the wire, or when. The real guarantee (documented in `plan-approval.ts`
+ * and `App.tsx`'s `handlePlanApproveAcceptEdits`) is that the dashboard's
+ * REAL `setPermissionMode` action sends the `set_permission_mode` frame
+ * SYNCHRONOUSLY before `sendInput('approve')` sends the `input` frame —
+ * because the server drops a mid-turn permission-mode change once the
+ * implementation turn has started (`PERMISSION_MODE_NOT_APPLIED`).
+ *
+ * This test wires the combined action to the store's REAL setPermissionMode
+ * and sendInput (mirroring `App.tsx`'s `handlePlanApproveAcceptEdits`
+ * exactly), with a socket stub that records frames in send order, and
+ * asserts `set_permission_mode` lands strictly before the approve `input`
+ * frame. If a future refactor of either action deferred its `wsSend` call
+ * behind a microtask/await, this test — unlike the store-core helper test —
+ * would catch the reordering, because it observes the actual wire, not just
+ * the order the two functions were called in.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { approvePlanWithAcceptEdits } from '@chroxy/store-core'
+import type { SessionState } from './types'
+
+/** Healthy OPEN socket that records sent frames in order (mirrors #6308's liveSocket helper). */
+function liveSocket(sent: Array<Record<string, unknown>>): WebSocket {
+  return {
+    send: vi.fn((raw: string) => {
+      try {
+        sent.push(JSON.parse(raw))
+      } catch {
+        /* noop */
+      }
+    }),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+describe('#6895 — dashboard combined plan-approve+acceptEdits wire order', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('sends set_permission_mode(acceptEdits) strictly before the approve input frame', async () => {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const sent: Array<Record<string, unknown>> = []
+    const socket = liveSocket(sent)
+    const sessionId = 'sess-plan-1'
+    useConnectionStore.setState({
+      activeSessionId: sessionId,
+      sessions: [{ sessionId, name: sessionId, provider: 'claude-sdk' }],
+      sessionStates: {
+        [sessionId]: {
+          ...createEmptySessionState(),
+          permissionMode: 'plan',
+          isPlanPending: true,
+        } as unknown as SessionState,
+      },
+      permissionMode: 'plan',
+      socket,
+    } as never)
+
+    const { setPermissionMode, sendInput } = useConnectionStore.getState()
+    // Mirrors App.tsx's handlePlanApprove exactly, minus the UI-only scroll
+    // signal (setScrollToBottomSignal), which has no wire effect.
+    const approve = (): void => {
+      sendInput('approve')
+    }
+
+    approvePlanWithAcceptEdits({ setPermissionMode, approve })
+
+    // Strict order: exactly two frames, mode change first.
+    expect(sent.map((f) => f.type)).toEqual(['set_permission_mode', 'input'])
+    expect(sent[0]).toMatchObject({ type: 'set_permission_mode', mode: 'acceptEdits' })
+    expect(sent[1]).toMatchObject({ type: 'input', data: 'approve' })
+  })
+})


### PR DESCRIPTION
Closes #6895

## Summary

Follow-up from PR #6893, which added the combined "Approve & auto-accept edits" plan action (originally #6774) via `approvePlanWithAcceptEdits({ setPermissionMode, approve })` (`packages/store-core/src/plan-approval.ts`).

The feature's correctness rests on a **wire ordering**: `set_permission_mode` (acceptEdits) must reach the server BEFORE the `approve` input, because the server drops a mid-turn permission-mode change (`BaseSession.setPermissionMode` returns `false` when `_isBusy`; surfaced as `PERMISSION_MODE_NOT_APPLIED`).

`plan-approval.test.ts` already pins the shared helper's call order, but only with mocked `setPermissionMode`/`approve` functions — it proves the two functions are *called* in the right order, but says nothing about whether either client's REAL implementation puts frames on the wire in that order. A future refactor that deferred either action's `wsSend` call behind a microtask/await would silently invert the wire order while that test stayed green.

- **Dashboard** (`packages/dashboard/src/store/plan-approve-wire-order.test.ts`): wires `approvePlanWithAcceptEdits` to the store's real `setPermissionMode` and `sendInput('approve')` — mirroring `App.tsx`'s `handlePlanApproveAcceptEdits` exactly — against a socket stub that records sent frames in order, and asserts `set_permission_mode` lands strictly before the `input` frame.
- **App** (`packages/app/src/__tests__/store/plan-approve-wire-order.test.ts`): same guard, wired to the real `setPermissionMode`, `addUserMessage`, `sendInput`, `clearPlanState` — mirroring `SessionScreen.tsx`'s `handleApprovePlanAcceptEdits` / `handleApprovePlan`.

Test-only change; no production behavior modified.

## Test plan

- [x] `packages/store-core` — full vitest suite green (56 files / 2031 tests)
- [x] `packages/dashboard` — full vitest suite green (270 files / 4665 tests)
- [x] `packages/app` — full jest suite green (174 suites / 2258 tests)
- [x] `tsc --noEmit` clean for `store-core`, `dashboard`, and `app`