### PR TITLE
feat(protocol): schema conversation_id / permission_expired / permission_resolved wire types

### DIFF
--- a/packages/protocol/dist/schemas/server/messages.d.ts
+++ b/packages/protocol/dist/schemas/server/messages.d.ts
@@ -6,10 +6,10 @@
  */
 import { z } from 'zod';
 import { BillingCanarySnapshotSchema, BillingCanaryWarningSchema, ServerAuthOkSchema, ServerPairPendingSchema, ServerPairRequestPendingSchema, ServerPairResolvedSchema, ServerPairResultSchema } from './connection.ts';
-import { ServerPermissionRequestSchema, ServerPermissionInputSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts';
+import { ServerPermissionRequestSchema, ServerPermissionInputSchema, ServerPermissionExpiredSchema, ServerPermissionResolvedSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts';
 import { ActivityEntrySchema, ActivityKindSchema, ActivityOutputRefSchema, ActivityStatusSchema, ServerActivityDeltaSchema, ServerActivitySnapshotSchema, ServerCancelActivityAckSchema, ServerMessageDequeuedSchema, ServerMessageQueuedSchema } from './activity.ts';
 import { ExternalSessionEntrySchema, HostStatusSummarySchema, IntegrationActionCountsSchema, IntegrationCliStatusSchema, IntegrationRepoSchema, IntegrationStatusSummarySchema, MailboxDeliveryEventSchema, MailboxRegistrationSchema, RepoEventSchema, ServerRepoEventsDeltaSchema, RepoMemoryCacheSchema, RepoMemoryReportSchema, RepoMemoryStatusSchema, RepoRelayRunSchema, RepoRelayStatusSchema, RepoRelayVerdictSchema, RepoRunnersSchema, RepoRuntimeConfigEntrySchema, RepoStatusSchema, RepoTreeSchema, RepoVerdictSchema, RunnerInfoSchema, RunnerServiceStateSchema, RunnerStatusSummarySchema, RunnerVerdictSchema, ServerByokPoolActionAckSchema, ServerByokPoolStatusSnapshotSchema, ServerContainersActionAckSchema, ServerContainersStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerHostPruneActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerSessionPresetDisclosureSchema, ServerSessionPresetFullSchema, ServerSessionPresetSnapshotSchema, ServerSimulatorActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerSummarizeSessionResultSchema, ServerWslActionAckSchema, ServerWslStatusSnapshotSchema, SkillInventoryEntrySchema, SkillInventoryRepoSchema } from './control-room.ts';
-import { CumulativeUsageSchema, ServerAuthBootstrapSchema, ServerSessionStoppedSchema, ServerSkillTrustGrantInvalidAuthorSchema, ServerSkillTrustGrantOkSchema, ServerSkillsListSchema, ServerTunnelUrlChangedSchema } from './session.ts';
+import { CumulativeUsageSchema, ServerAuthBootstrapSchema, ServerConversationIdSchema, ServerSessionStoppedSchema, ServerSkillTrustGrantInvalidAuthorSchema, ServerSkillTrustGrantOkSchema, ServerSkillsListSchema, ServerTunnelUrlChangedSchema } from './session.ts';
 import { ServerBillingCanarySchema, ServerBudgetResumeAckSchema, ServerByokCredentialsStatusSchema, ServerCostUpdateSchema, ServerCredentialTestResultSchema, ServerCredentialsStatusSchema, ServerErrorEnvelopeSchema, ServerErrorSchema, ServerEvaluateDraftResultSchema, ServerEvaluatorClarifySchema, ServerEvaluatorRewriteSchema, ServerExtensionMessageSchema, ServerMonthlyBudgetSchema, ServerSessionCostThresholdCrossedSchema, ServerSessionUsageSchema } from './billing.ts';
 export type BillingCanaryWarning = z.infer<typeof BillingCanaryWarningSchema>;
 export type BillingCanarySnapshot = z.infer<typeof BillingCanarySnapshotSchema>;
@@ -22,6 +22,9 @@ export type ServerPairResolvedMessage = z.infer<typeof ServerPairResolvedSchema>
 export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>;
 export type ServerShellPendingApprovalMessage = z.infer<typeof ServerShellPendingApprovalSchema>;
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>;
+export type ServerPermissionExpiredMessage = z.infer<typeof ServerPermissionExpiredSchema>;
+export type ServerPermissionResolvedMessage = z.infer<typeof ServerPermissionResolvedSchema>;
+export type ServerConversationIdMessage = z.infer<typeof ServerConversationIdSchema>;
 export type ServerPermissionInputMessage = z.infer<typeof ServerPermissionInputSchema>;
 export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;
 export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchema>;

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -222,6 +222,11 @@ export declare const ServerSessionStoppedSchema: z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     code: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
+export declare const ServerConversationIdSchema: z.ZodObject<{
+    type: z.ZodLiteral<"conversation_id">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    conversationId: z.ZodString;
+}, z.core.$strip>;
 export declare const ServerProviderListSchema: z.ZodObject<{
     type: z.ZodLiteral<"provider_list">;
     providers: z.ZodArray<z.ZodObject<{

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -281,6 +281,21 @@ export const ServerSessionStoppedSchema = z.object({
     sessionId: z.string().optional(),
     code: z.number().int().optional(),
 });
+// #6891: the provider (SDK) reported a fresh conversation handle for a session —
+// the client stamps `conversationId` onto the target session so the session is
+// portable/resumable. Emitted by the event-normalizer `conversation_id` mapping
+// (event-normalizer.js).
+//   - `sessionId` — the owning chroxy session; the normalizer stamps it from
+//     `ctx.sessionId`, absent in single-session mode, so OPTIONAL. Both clients
+//     deliberately DO NOT fall back to the active session when it is missing
+//     (handleConversationId → dispatchConversationId), so a message with no
+//     sessionId is a valid no-op on the wire.
+//   - `conversationId` — the provider's conversation handle (always emitted).
+export const ServerConversationIdSchema = z.object({
+    type: z.literal('conversation_id'),
+    sessionId: z.string().optional(),
+    conversationId: z.string(),
+});
 // #3404 audit (F1+F5): per-provider auth/billing summary so clients can
 // grey-out unusable providers and surface billing-identity confidence.
 // Optional on the wire so older servers stay parseable.

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -183,6 +183,18 @@ export declare const ServerPermissionRequestSchema: z.ZodObject<{
     remainingMs: z.ZodOptional<z.ZodNumber>;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const ServerPermissionExpiredSchema: z.ZodObject<{
+    type: z.ZodLiteral<"permission_expired">;
+    requestId: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+    message: z.ZodString;
+}, z.core.$strip>;
+export declare const ServerPermissionResolvedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"permission_resolved">;
+    requestId: z.ZodString;
+    decision: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 /**
  * #6543 (IDE P3, feature B) — reply to a `get_permission_input`. The
  * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -275,6 +275,46 @@ export const ServerPermissionRequestSchema = z.object({
     // Emitted by ws-permissions.js (resendPendingPermissions + HTTP fallback).
     sessionId: z.string().optional(),
 });
+// #6891: a pending permission prompt expired (session hard-cap / SDK timeout)
+// and can no longer be answered — the client clears the stale prompt bubble and
+// dismisses the matching notification banner. Emitted by the event-normalizer
+// `permission_expired` mapping (event-normalizer.js) from the session layer's
+// `permission_expired` event (cli-session / sdk-session fire it for every
+// outstanding permission when a turn is force-cleared).
+//   - `requestId` — the expired permission's id (always present).
+//   - `sessionId` — the owning chroxy session; the normalizer stamps it from
+//     `ctx.sessionId`, which is absent in single-session mode, so OPTIONAL
+//     (mirrors ServerPermissionRequestSchema.sessionId).
+//   - `message` — the human-readable expiry reason the client surfaces
+//     (e.g. "Permission request expired (session timeout)").
+export const ServerPermissionExpiredSchema = z.object({
+    type: z.literal('permission_expired'),
+    requestId: z.string(),
+    sessionId: z.string().optional(),
+    message: z.string(),
+});
+// #6891: a permission prompt was RESOLVED (via any path — user response, abort,
+// timeout, auto-mode, clearAll); the client dismisses the prompt on every
+// connected client and marks the bubble answered. Emitted by the
+// event-normalizer `permission_resolved` mapping (event-normalizer.js) ONLY for
+// the `requestId` (permission-prompt) variant; the AskUserQuestion `toolUseId`
+// variant emits NO wire message (routing-map cleanup only), so this schema
+// covers just the requestId shape.
+//   - `requestId` — the resolved permission's id (always present here).
+//   - `decision` — the resolution outcome, a free-form string that varies by
+//     path/provider ('allow' / 'deny' / the user's raw choice); a PLAIN string,
+//     NOT a closed enum, so a new decision value can't fail the parse. Always
+//     present in the requestId variant.
+//   - `sessionId` — the owning chroxy session (stamped from `ctx.sessionId`;
+//     absent in single-session mode → OPTIONAL).
+//   The normalizer does NOT forward the internal `reason` field to the wire, so
+//   it is intentionally absent from this schema.
+export const ServerPermissionResolvedSchema = z.object({
+    type: z.literal('permission_resolved'),
+    requestId: z.string(),
+    decision: z.string(),
+    sessionId: z.string().optional(),
+});
 /**
  * #6543 (IDE P3, feature B) — reply to a `get_permission_input`. The
  * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a

--- a/packages/protocol/src/schemas/server/messages.ts
+++ b/packages/protocol/src/schemas/server/messages.ts
@@ -8,10 +8,10 @@
 import { z } from 'zod'
 
 import { BillingCanarySnapshotSchema, BillingCanaryWarningSchema, ServerAuthOkSchema, ServerPairPendingSchema, ServerPairRequestPendingSchema, ServerPairResolvedSchema, ServerPairResultSchema } from './connection.ts'
-import { ServerPermissionRequestSchema, ServerPermissionInputSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts'
+import { ServerPermissionRequestSchema, ServerPermissionInputSchema, ServerPermissionExpiredSchema, ServerPermissionResolvedSchema, ServerStreamDeltaSchema, ServerShellPendingApprovalSchema } from './stream.ts'
 import { ActivityEntrySchema, ActivityKindSchema, ActivityOutputRefSchema, ActivityStatusSchema, ServerActivityDeltaSchema, ServerActivitySnapshotSchema, ServerCancelActivityAckSchema, ServerMessageDequeuedSchema, ServerMessageQueuedSchema } from './activity.ts'
 import { ExternalSessionEntrySchema, HostStatusSummarySchema, IntegrationActionCountsSchema, IntegrationCliStatusSchema, IntegrationRepoSchema, IntegrationStatusSummarySchema, MailboxDeliveryEventSchema, MailboxRegistrationSchema, RepoEventSchema, ServerRepoEventsDeltaSchema, RepoMemoryCacheSchema, RepoMemoryReportSchema, RepoMemoryStatusSchema, RepoRelayRunSchema, RepoRelayStatusSchema, RepoRelayVerdictSchema, RepoRunnersSchema, RepoRuntimeConfigEntrySchema, RepoStatusSchema, RepoTreeSchema, RepoVerdictSchema, RunnerInfoSchema, RunnerServiceStateSchema, RunnerStatusSummarySchema, RunnerVerdictSchema, ServerByokPoolActionAckSchema, ServerByokPoolStatusSnapshotSchema, ServerContainersActionAckSchema, ServerContainersStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerHostPruneActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostStatusSnapshotSchema, ServerIntegrationActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerSessionPresetDisclosureSchema, ServerSessionPresetFullSchema, ServerSessionPresetSnapshotSchema, ServerSimulatorActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerSummarizeSessionResultSchema, ServerWslActionAckSchema, ServerWslStatusSnapshotSchema, SkillInventoryEntrySchema, SkillInventoryRepoSchema } from './control-room.ts'
-import { CumulativeUsageSchema, ServerAuthBootstrapSchema, ServerSessionStoppedSchema, ServerSkillTrustGrantInvalidAuthorSchema, ServerSkillTrustGrantOkSchema, ServerSkillsListSchema, ServerTunnelUrlChangedSchema } from './session.ts'
+import { CumulativeUsageSchema, ServerAuthBootstrapSchema, ServerConversationIdSchema, ServerSessionStoppedSchema, ServerSkillTrustGrantInvalidAuthorSchema, ServerSkillTrustGrantOkSchema, ServerSkillsListSchema, ServerTunnelUrlChangedSchema } from './session.ts'
 import { ServerBillingCanarySchema, ServerBudgetResumeAckSchema, ServerByokCredentialsStatusSchema, ServerCostUpdateSchema, ServerCredentialTestResultSchema, ServerCredentialsStatusSchema, ServerErrorEnvelopeSchema, ServerErrorSchema, ServerEvaluateDraftResultSchema, ServerEvaluatorClarifySchema, ServerEvaluatorRewriteSchema, ServerExtensionMessageSchema, ServerMonthlyBudgetSchema, ServerSessionCostThresholdCrossedSchema, ServerSessionUsageSchema } from './billing.ts'
 
 // -- Inferred TypeScript types --
@@ -28,6 +28,13 @@ export type ServerStreamDeltaMessage = z.infer<typeof ServerStreamDeltaSchema>
 // #6277 — host-local user-shell approval pending notice (dashboard-only v1).
 export type ServerShellPendingApprovalMessage = z.infer<typeof ServerShellPendingApprovalSchema>
 export type ServerPermissionRequestMessage = z.infer<typeof ServerPermissionRequestSchema>
+// #6891: typed aliases for the permission-lifecycle broadcasts that gained a
+// schema — a pending prompt expiring, and a prompt resolving (requestId variant).
+export type ServerPermissionExpiredMessage = z.infer<typeof ServerPermissionExpiredSchema>
+export type ServerPermissionResolvedMessage = z.infer<typeof ServerPermissionResolvedSchema>
+// #6891: typed alias for the SDK conversation-handle stamp used for session
+// portability.
+export type ServerConversationIdMessage = z.infer<typeof ServerConversationIdSchema>
 // #6543 (IDE P3 feature B): reply to a get_permission_input pull — the full
 // secret-redacted tool input for building a pre-write diff.
 export type ServerPermissionInputMessage = z.infer<typeof ServerPermissionInputSchema>

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -296,6 +296,22 @@ export const ServerSessionStoppedSchema = z.object({
   code: z.number().int().optional(),
 })
 
+// #6891: the provider (SDK) reported a fresh conversation handle for a session —
+// the client stamps `conversationId` onto the target session so the session is
+// portable/resumable. Emitted by the event-normalizer `conversation_id` mapping
+// (event-normalizer.js).
+//   - `sessionId` — the owning chroxy session; the normalizer stamps it from
+//     `ctx.sessionId`, absent in single-session mode, so OPTIONAL. Both clients
+//     deliberately DO NOT fall back to the active session when it is missing
+//     (handleConversationId → dispatchConversationId), so a message with no
+//     sessionId is a valid no-op on the wire.
+//   - `conversationId` — the provider's conversation handle (always emitted).
+export const ServerConversationIdSchema = z.object({
+  type: z.literal('conversation_id'),
+  sessionId: z.string().optional(),
+  conversationId: z.string(),
+})
+
 // #3404 audit (F1+F5): per-provider auth/billing summary so clients can
 // grey-out unusable providers and surface billing-identity confidence.
 // Optional on the wire so older servers stay parseable.

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -299,6 +299,48 @@ export const ServerPermissionRequestSchema = z.object({
   sessionId: z.string().optional(),
 })
 
+// #6891: a pending permission prompt expired (session hard-cap / SDK timeout)
+// and can no longer be answered — the client clears the stale prompt bubble and
+// dismisses the matching notification banner. Emitted by the event-normalizer
+// `permission_expired` mapping (event-normalizer.js) from the session layer's
+// `permission_expired` event (cli-session / sdk-session fire it for every
+// outstanding permission when a turn is force-cleared).
+//   - `requestId` — the expired permission's id (always present).
+//   - `sessionId` — the owning chroxy session; the normalizer stamps it from
+//     `ctx.sessionId`, which is absent in single-session mode, so OPTIONAL
+//     (mirrors ServerPermissionRequestSchema.sessionId).
+//   - `message` — the human-readable expiry reason the client surfaces
+//     (e.g. "Permission request expired (session timeout)").
+export const ServerPermissionExpiredSchema = z.object({
+  type: z.literal('permission_expired'),
+  requestId: z.string(),
+  sessionId: z.string().optional(),
+  message: z.string(),
+})
+
+// #6891: a permission prompt was RESOLVED (via any path — user response, abort,
+// timeout, auto-mode, clearAll); the client dismisses the prompt on every
+// connected client and marks the bubble answered. Emitted by the
+// event-normalizer `permission_resolved` mapping (event-normalizer.js) ONLY for
+// the `requestId` (permission-prompt) variant; the AskUserQuestion `toolUseId`
+// variant emits NO wire message (routing-map cleanup only), so this schema
+// covers just the requestId shape.
+//   - `requestId` — the resolved permission's id (always present here).
+//   - `decision` — the resolution outcome, a free-form string that varies by
+//     path/provider ('allow' / 'deny' / the user's raw choice); a PLAIN string,
+//     NOT a closed enum, so a new decision value can't fail the parse. Always
+//     present in the requestId variant.
+//   - `sessionId` — the owning chroxy session (stamped from `ctx.sessionId`;
+//     absent in single-session mode → OPTIONAL).
+//   The normalizer does NOT forward the internal `reason` field to the wire, so
+//   it is intentionally absent from this schema.
+export const ServerPermissionResolvedSchema = z.object({
+  type: z.literal('permission_resolved'),
+  requestId: z.string(),
+  decision: z.string(),
+  sessionId: z.string().optional(),
+})
+
 /**
  * #6543 (IDE P3, feature B) — reply to a `get_permission_input`. The
  * `permission_request` broadcast truncates `input` at ~10K (secret-safe), so a

--- a/packages/server/tests/event-normalizer-schema.test.js
+++ b/packages/server/tests/event-normalizer-schema.test.js
@@ -37,6 +37,9 @@ import {
   ServerBudgetExceededSchema,
   ServerUserQuestionSchema,
   ServerPermissionRequestSchema,
+  ServerPermissionExpiredSchema,
+  ServerPermissionResolvedSchema,
+  ServerConversationIdSchema,
   ServerSessionStoppedSchema,
   ServerStdinDroppedTotalsSchema,
 } from '@chroxy/protocol'
@@ -102,22 +105,29 @@ const SCHEMA_BY_TYPE = {
   budget_exceeded: ServerBudgetExceededSchema,
   user_question: ServerUserQuestionSchema,
   permission_request: ServerPermissionRequestSchema,
+  permission_expired: ServerPermissionExpiredSchema,
+  permission_resolved: ServerPermissionResolvedSchema,
+  conversation_id: ServerConversationIdSchema,
   session_stopped: ServerSessionStoppedSchema,
   stdin_dropped_totals: ServerStdinDroppedTotalsSchema,
 }
 
 // Wire types the normalizer emits that have NO `Server*Schema` in
-// `@chroxy/protocol` today. Documented here so the round-trip harness can tell
+// `@chroxy/protocol`. Documented here so the round-trip harness can tell
 // "deliberately un-schemaed" apart from "a new emitter shipped a type nobody
 // gave a schema". If a schema is later added for one of these, WIRE IT INTO
 // `SCHEMA_BY_TYPE` above and drop it from this set (the meta-test below fails
-// until both sides agree). See the PR for #6841 — these are tracked as a
-// follow-up schema-gap, not a licence to leave new types unchecked.
-const KNOWN_UNSCHEMAED = new Set([
-  'conversation_id', // conversation_id emitter — no ServerConversationIdSchema
-  'permission_expired', // permission_expired emitter — no schema
-  'permission_resolved', // permission_resolved emitter — no schema
-])
+// until both sides agree).
+//
+// #6891 closed the last of the original #6841 gaps — `conversation_id`,
+// `permission_expired`, and `permission_resolved` now have `Server*Schema`s and
+// moved up into `SCHEMA_BY_TYPE`. The set is intentionally EMPTY now: the
+// `emits un-schemaed wire types only for the documented KNOWN_UNSCHEMAED set`
+// meta-test below therefore enforces the stronger invariant that EVERY emitted
+// wire type is schema-validated. A new emitter that ships an un-schemaed type
+// fails that meta-test until it is either schemaed (preferred) or documented
+// here with a reason.
+const KNOWN_UNSCHEMAED = new Set([])
 
 // Standard multi-session context (mirrors event-normalizer.test.js).
 function makeCtx(overrides = {}) {


### PR DESCRIPTION
## Summary

Adds `Server*Schema`s for the three server→client wire types the event normalizer emits that had **no schema** in `@chroxy/protocol` — surfaced by the #6889 round-trip harness (from #6841), which pinned them in a `KNOWN_UNSCHEMAED` allowlist as a stopgap. They crossed the wire completely unvalidated at the serialization boundary and at the store-core client.

Schemas match the **real emitted shapes** exactly (over-strict schemas would reject valid production messages):

| Wire type | Schema (file) | Shape |
|---|---|---|
| `conversation_id` | `ServerConversationIdSchema` (`session.ts`) | `{ type, sessionId?, conversationId }` |
| `permission_expired` | `ServerPermissionExpiredSchema` (`stream.ts`) | `{ type, requestId, sessionId?, message }` |
| `permission_resolved` | `ServerPermissionResolvedSchema` (`stream.ts`) | `{ type, requestId, decision, sessionId? }` |

Shape decisions, verified against the emitters (`event-normalizer.js`) and every emit site:
- **`sessionId` is optional** on all three — the normalizer stamps it from `ctx.sessionId`, which is absent in single-session mode (mirrors `ServerPermissionRequestSchema.sessionId`). For `conversation_id` both clients deliberately no-op on a missing sessionId.
- **`decision` is a plain `z.string()`**, not a closed enum — the value varies by path/provider (`allow` / `deny` / the user's raw choice), so a new decision value can't fail the parse. Always present in the `requestId` variant.
- **`permission_resolved` omits `reason`** — the normalizer does not forward the internal `reason` to the wire.
- The `permission_resolved` AskUserQuestion (`toolUseId`) variant emits **no** wire message (routing-map cleanup only), so only the `requestId` shape is schemaed.

## Harness (#6889) forcing function

- Moved all three from `KNOWN_UNSCHEMAED` into `SCHEMA_BY_TYPE` in `packages/server/tests/event-normalizer-schema.test.js`. The `KNOWN_UNSCHEMAED` set is now **empty**, so the meta-test enforces the stronger invariant: *every* emitted wire type is schema-validated. (The three `FIXTURES` entries already existed.)
- Added `z.infer` type aliases in `messages.ts` for house-style parity.

## Coverage guards

All three types are **already handled by both clients** — `conversation_id` via the shared store-core dispatch table; `permission_expired` / `permission_resolved` via each client's switch / HANDLERS map — so the schema-driven `protocol-type-coverage-lint` passes without any asymmetry-allowlist entry. `permission_resolved` stays in handler-coverage's `SYNTHETIC_TYPES` (roster is the ws-server.js JSDoc, not schemas), so that guard is unaffected.

## Verification

- `npm run build -w packages/protocol` — clean, dist regenerated and committed; no untracked/drifted dist.
- **Full protocol suite** (`npm test -w packages/protocol`): **375 pass / 0 fail** (incl. handler-coverage).
- **Full store-core suite** (`vitest run`): **2031 pass / 0 fail** (incl. `protocol-type-coverage-lint` + both-clients `coverage-lint`).
- Normalizer-schema harness (`event-normalizer-schema.test.js`): **43 pass / 0 fail**.
- Store-core `tsc --noEmit`: clean.
- All `packages/server/scripts/lint-*.sh`: pass.

Closes #6891