### PR TITLE
fix(server): resolve symlinks in the protected-path floor (#6851)

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import { realpathSync } from 'node:fs'
-import { resolve, relative, sep, isAbsolute, dirname, basename, join } from 'node:path'
+import { realpathSync, lstatSync, readlinkSync } from 'node:fs'
+import { resolve, relative, sep, isAbsolute, dirname, basename, join, parse } from 'node:path'
 import { createLogger } from './logger.js'
 // #6038: the SDK/TUI permission path broadcasts to clients too, so it must apply
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
@@ -239,6 +239,11 @@ export function buildDenyMessage(reason) {
 // under a symlinked parent), which FAILS CLOSED rather than trust a lexical guess.
 const _FLOOR_REALPATH_MAX_DEPTH = 256
 
+// #6921 — symlink-expansion cap for the component-wise resolver below, matching
+// the kernel's typical MAXSYMLINKS (40). A chain deeper than this — or a cycle —
+// throws ELOOP, which the floor's `catch` treats as PROTECTED (fail closed).
+const _FLOOR_MAX_SYMLINKS = 40
+
 /**
  * #6851 — SYNC deepest-existing-ancestor realpath: the symlink-resolving core of
  * the floor's #6851 hardening, and the synchronous sibling of
@@ -291,6 +296,94 @@ function realpathDeepestAncestorSync(absPath) {
   }
   // Depth ceiling hit — FAIL CLOSED rather than trust a pathological tail.
   throw Object.assign(new Error(`realpathDeepestAncestorSync: path depth exceeds ${_FLOOR_REALPATH_MAX_DEPTH}`), { code: 'ENAMETOOLONG' })
+}
+
+/**
+ * #6921 — resolve `target` against a REAL base by walking it COMPONENT BY
+ * COMPONENT, mirroring the kernel's `open(2)` path traversal. This is the crux
+ * of the #6921 hardening: it replaces the `realpath(resolve(base, target))`
+ * shape (#6851, {@link realpathDeepestAncestorSync}), which could NOT catch a
+ * `..` that follows a SYMLINKED component — because BOTH `path.resolve()` AND
+ * Node's `fs.realpathSync` collapse `..` LEXICALLY (textually) before/instead of
+ * following symlinks. `realpathSync('link/..')` yields the symlink's LEXICAL
+ * parent; `open(2)` follows `link` to its TARGET and applies `..` from THERE. So
+ * `work/agent-x/../../settings.local.json` (with `work -> .claude/worktrees`)
+ * lexically cancels to a benign `settings.local.json`, but really lands on
+ * `.claude/settings.local.json`. Only a component walk that applies `..` AFTER
+ * resolving symlinks-so-far (as the kernel does) sees the real destination.
+ *
+ * The walk starts from `realBase` (the session cwd already resolved to its real
+ * path) for a relative target, or from the filesystem root for an absolute
+ * target, and for each remaining component:
+ *   - `''` / `.`      → skip.
+ *   - `..`            → pop to the PARENT of the resolved-so-far real path
+ *                       (`dirname`), i.e. apply `..` AFTER following symlinks so
+ *                       far — NOT lexically on the pre-resolution path.
+ *   - a SYMLINK       → `readlinkSync` it; if the link is absolute, reset the
+ *                       resolved path to the fs root; splice the link's own
+ *                       components into the walk at the current position and keep
+ *                       going (so a relative link resolves from the symlink's
+ *                       parent, and any `..` inside the link is honoured too).
+ *                       Bounded by {@link _FLOOR_MAX_SYMLINKS} — a deeper chain or
+ *                       a cycle THROWS `ELOOP` (→ fail closed).
+ *   - a NON-symlink   → append it.
+ *   - a NON-EXISTENT tail component (`ENOENT` on the `lstat`) → stop filesystem
+ *                       resolution (nothing deeper can exist, so nothing deeper
+ *                       can be a symlink) and apply the REMAINING components —
+ *                       INCLUDING any `..` — against the resolved-so-far real
+ *                       path by the same pop/append rules. This models a
+ *                       to-be-created file: a `..` in the tail still pops the
+ *                       RESOLVED real path, never the unresolved lexical one. (A
+ *                       real write of a path whose intermediate dir is missing
+ *                       fails anyway, so not following a later symlink after the
+ *                       first ENOENT can't hide a write that would actually land.)
+ *
+ * A non-ENOENT `lstat`/`readlink` error (EACCES, ELOOP) propagates so the
+ * caller's `catch` fails closed. Returns the fully resolved absolute real path.
+ * @param {string} realBase  the session cwd, already resolved to its real path
+ * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path value
+ * @returns {string} the open(2)-faithful resolved absolute real path
+ */
+function resolveTargetComponentwiseSync(realBase, target) {
+  // Absolute target ignores the base (as `open`/`resolve` do); start at the fs
+  // root so its own leading components are walked (and symlink-resolved) too.
+  let resolved = isAbsolute(target) ? parse(target).root : realBase
+  const pending = target.split(sep)
+  let symlinks = 0
+  // Once a component doesn't exist, the rest is a to-be-created tail: no deeper
+  // component can be a symlink, so stop lstat-ing and apply pop/append only.
+  let tailOnly = false
+  let i = 0
+  while (i < pending.length) {
+    const comp = pending[i]
+    i++
+    if (comp === '' || comp === '.') continue
+    if (comp === '..') { resolved = dirname(resolved); continue }
+    const candidate = join(resolved, comp)
+    if (tailOnly) { resolved = candidate; continue }
+    let st
+    try {
+      st = lstatSync(candidate)
+    } catch (err) {
+      if (err.code === 'ENOENT') { tailOnly = true; resolved = candidate; continue }
+      throw err // EACCES etc. — fail closed via the caller's catch
+    }
+    if (st.isSymbolicLink()) {
+      if (++symlinks > _FLOOR_MAX_SYMLINKS) {
+        throw Object.assign(new Error(`resolveTargetComponentwiseSync: symlink depth exceeds ${_FLOOR_MAX_SYMLINKS}`), { code: 'ELOOP' })
+      }
+      const link = readlinkSync(candidate)
+      // An absolute link restarts resolution from the fs root; a relative link
+      // resolves from the symlink's PARENT (`resolved`, since `comp` was not
+      // appended). Splice the link's components in at the cursor so they — and
+      // any `..` they contain — are walked next, before the remaining tail.
+      if (isAbsolute(link)) resolved = parse(link).root
+      pending.splice(i, 0, ...link.split(sep))
+    } else {
+      resolved = candidate
+    }
+  }
+  return resolved
 }
 
 /**
@@ -351,23 +444,40 @@ function _scanResolvedTarget(base, resolved, secretsOnly) {
  *       paths, a leading `./`, and `..` traversal; the resolved path is scanned
  *       segment-by-segment ({@link _scanResolvedTarget}). Pure string ops, no fs
  *       access — fast, and every input the old floor flagged still flags.
- *   (2) #6851 SYMLINK. The lexical pass is symlink-BLIND: because `resolve()`
- *       collapses `..` textually, a symlink in cwd's PREFIX (the chroxy agent
- *       worktree can live under a *symlink* to a real `.claude/`) or a symlinked
- *       COMPONENT of the target can make a path that lexically looks OUTSIDE a
- *       protected dir RESOLVE INTO `.git`/`.claude`/`.vscode`/`.config/git` or a
- *       secret file (and vice-versa). Pass (2) resolves BOTH the base and the
- *       target through their real (symlink-followed) paths — collapsing the
- *       target's `..` against the REAL base so a `..` after a symlinked cwd
- *       component climbs from the symlink's TARGET, not its lexical parent —
- *       then re-runs the SAME segment scan. It only ADDS matches on top of (1);
- *       it never un-floors a lexical hit (pass (1) already returned).
+ *   (2) #6851/#6921 SYMLINK. The lexical pass is symlink-BLIND: because
+ *       `resolve()` collapses `..` textually, a symlink in cwd's PREFIX (the
+ *       chroxy agent worktree can live under a *symlink* to a real `.claude/`),
+ *       a symlinked COMPONENT of the target, OR a `..` that FOLLOWS a symlinked
+ *       component can make a path that lexically looks OUTSIDE a protected dir
+ *       RESOLVE INTO `.git`/`.claude`/`.vscode`/`.config/git` or a secret file
+ *       (and vice-versa). Pass (2) resolves the base to its real path, then walks
+ *       the target COMPONENT BY COMPONENT via
+ *       {@link resolveTargetComponentwiseSync} — following each symlink and
+ *       applying each `..` against the resolved-so-far REAL path, exactly as
+ *       `open(2)` does — and re-runs the SAME segment scan. It only ADDS matches
+ *       on top of (1); it never un-floors a lexical hit (pass (1) already
+ *       returned). The raw (NOT pre-`resolve`d) target is handed to the walker so
+ *       its `..` survives to be applied post-symlink — the #6921 fix. The earlier
+ *       #6851 shape (`realpathDeepestAncestorSync(resolve(realBase, target))`)
+ *       could not close this: both `resolve()` and Node's `realpathSync` collapse
+ *       `..` LEXICALLY, so a `..` after a symlinked component was cancelled before
+ *       any symlink was followed.
  *
  * FAIL-CLOSED: any error resolving the real paths (EACCES on a directory, ELOOP
- * on a symlink cycle, an unresolvable ancestor, a depth bomb) is treated as
- * PROTECTED — the floor forces the interactive prompt, never assumes the target
- * is safe. The floor only ever forces a PROMPT (never a hard deny), so
- * over-flooring an ambiguous resolution is conservative and correct.
+ * on a symlink cycle/depth bomb, an unresolvable base) is treated as PROTECTED —
+ * the floor forces the interactive prompt, never assumes the target is safe. The
+ * floor only ever forces a PROMPT (never a hard deny), so over-flooring an
+ * ambiguous resolution is conservative and correct.
+ *
+ * #6922 — TOCTOU: this resolution happens at permission-CHECK time and is NOT
+ * atomic with the downstream read/write. A symlink anywhere in the path can be
+ * swapped between this check and the executor's `open` (e.g. via an un-floored
+ * `Bash` step interleaved with the write), so a benign realpath here does not
+ * GUARANTEE a benign open later. This floor is defense-in-depth / prompt-only,
+ * and chroxy does not own the downstream `open` for SDK/TUI/codex providers, so a
+ * fully atomic guard (`openat2(RESOLVE_NO_SYMLINKS)` held across the write) is not
+ * achievable at this layer. Do not over-trust the resolved path as an atomic
+ * guarantee — see #6922.
  *
  * #6806 — WHICH segments each pass scans, and the #6794 worktree false-positive
  * guard it preserves, live in {@link _scanResolvedTarget}. #6803 —
@@ -382,16 +492,17 @@ function isProtectedPathValue(target, base, secretsOnly = false) {
   // (1) LEXICAL floor — pre-#6851 behavior, authoritative on a hit (no fs cost).
   const resolvedLexical = resolve(base, target)
   if (_scanResolvedTarget(base, resolvedLexical, secretsOnly)) return true
-  // (2) #6851 SYMLINK floor — resolve the real paths and re-scan. A resolution
+  // (2) #6851/#6921 SYMLINK floor — resolve the real base, then walk the RAW
+  // target component-by-component (open(2) semantics) and re-scan. A resolution
   // error FAILS CLOSED (return true → force the prompt). Runs only on a
   // lexically-clean target (the common benign case), so the fs cost is a couple
-  // of realpath walks per otherwise-auto-approved permission check.
+  // of realpath/lstat walks per otherwise-auto-approved permission check.
   try {
     const realBase = realpathDeepestAncestorSync(resolve(base))
-    // resolve() against the REAL base first (so a `..` after a symlinked cwd
-    // component collapses from the real location), then chase symlinks in the
-    // target's own existing ancestors.
-    const realTarget = realpathDeepestAncestorSync(resolve(realBase, target))
+    // Pass the RAW `target` (its `..` intact) to the component walker, so a `..`
+    // after a symlinked component climbs from the symlink's TARGET, not its
+    // lexical parent. Do NOT pre-resolve() it — that would collapse the `..`.
+    const realTarget = resolveTargetComponentwiseSync(realBase, target)
     return _scanResolvedTarget(realBase, realTarget, secretsOnly)
   } catch {
     return true

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -498,7 +498,17 @@ function isProtectedPathValue(target, base, secretsOnly = false) {
   // lexically-clean target (the common benign case), so the fs cost is a couple
   // of realpath/lstat walks per otherwise-auto-approved permission check.
   try {
-    const realBase = realpathDeepestAncestorSync(resolve(base))
+    // Pass `base` DIRECTLY — never `resolve(base)`. `realpathDeepestAncestorSync`
+    // REQUIRES an absolute path and THROWS on a relative one; that guard exists
+    // precisely so a relative base can't be silently reframed against the SERVER
+    // process cwd (`process.cwd()`) — the WRONG root (the floor must be anchored
+    // on the SESSION's cwd). In normal operation `base` IS absolute (the session
+    // cwd from the WS client / a worktree dir / the process.cwd() fallback), so
+    // this is a no-op; a relative/malformed base hits the throw and FAILS CLOSED
+    // (caught below → return true → force the prompt) instead of resolving
+    // against process.cwd(). Wrapping in resolve() would defeat BOTH the guard
+    // and the wrong-root framing it protects against.
+    const realBase = realpathDeepestAncestorSync(base)
     // Pass the RAW `target` (its `..` intact) to the component walker, so a `..`
     // after a symlinked component climbs from the symlink's TARGET, not its
     // lexical parent. Do NOT pre-resolve() it — that would collapse the `..`.

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import { resolve, relative, sep, isAbsolute } from 'node:path'
+import { realpathSync } from 'node:fs'
+import { resolve, relative, sep, isAbsolute, dirname, basename, join } from 'node:path'
 import { createLogger } from './logger.js'
 // #6038: the SDK/TUI permission path broadcasts to clients too, so it must apply
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
@@ -232,51 +233,93 @@ export function buildDenyMessage(reason) {
   return redactValue(trimmed.slice(0, MAX_DENY_REASON_LEN))
 }
 
+// #6851 — depth ceiling for the sync deepest-ancestor realpath walk. Absolute
+// paths never legitimately nest this deep; the cap only guards a pathological /
+// malicious tail (a to-be-created path with hundreds of nonexistent components
+// under a symlinked parent), which FAILS CLOSED rather than trust a lexical guess.
+const _FLOOR_REALPATH_MAX_DEPTH = 256
+
 /**
- * #6794 / #6806 — is a single path value protected, resolved against `base`?
- * `resolve()` absorbs absolute paths, a leading `./`, and `..` traversal, giving
- * the true target the write lands on.
+ * #6851 — SYNC deepest-existing-ancestor realpath: the symlink-resolving core of
+ * the floor's #6851 hardening, and the synchronous sibling of
+ * {@link realpathOfDeepestAncestor} in `ws-file-ops/common.js` (BYOK's
+ * post-approval confinement). The floor runs inside the SYNCHRONOUS
+ * `handlePermission` hot-path, so it cannot await that async twin — it uses
+ * `realpathSync` instead.
  *
- * #6806 — WHICH segments we scan reconciles two goals that pull opposite ways:
- *   (1) floor any write that RESOLVES into a protected config dir/file,
- *       regardless of how `..` is arranged; and
- *   (2) preserve the #6794 worktree guard — a session whose OWN cwd lives under
- *       a real `.claude/` (the chroxy agent-worktree topology
- *       `…/.claude/worktrees/agent-*`) must still write its own workspace files,
- *       so cwd's own protected prefix segments must NOT false-floor it.
- * The discriminator is whether the resolved target stays INSIDE the session's
- * own workspace subtree (cwd):
- *   - UNDER cwd → scan the path RELATIVE to cwd, so cwd's own prefix segments
+ * Resolves every symlink in the EXISTING ancestor chain of a (possibly not-yet-
+ * created) ABSOLUTE path, then re-appends the non-existent tail components. The
+ * naive "realpath the whole target, fall back to the lexical path on ENOENT"
+ * pattern has a symlink-escape hole on to-be-created files: a symlinked PARENT
+ * plus a non-existent leaf makes the lexical fallback hide the parent symlink.
+ * Walking up to the deepest EXISTING ancestor and realpath-ing THAT closes it.
+ *
+ * FAIL-CLOSED at every ambiguous edge — it THROWS (never returns a lexical
+ * guess) when no ancestor resolves or the depth is pathological, and lets a
+ * non-ENOENT error (EACCES on a directory, ELOOP on a symlink cycle) propagate,
+ * so the floor's `catch` treats the target as protected.
+ * @param {string} absPath  an absolute path (may not exist yet)
+ * @returns {string} the real path with all symlink ancestors resolved
+ */
+function realpathDeepestAncestorSync(absPath) {
+  if (!isAbsolute(absPath)) {
+    // A relative path would resolve against the SERVER process cwd, not the
+    // session cwd — fail loudly (and, via the caller's catch, closed).
+    throw Object.assign(new Error(`realpathDeepestAncestorSync requires an absolute path, got: ${absPath}`), { code: 'EINVAL' })
+  }
+  const segments = []
+  let cursor = absPath
+  for (let i = 0; i < _FLOOR_REALPATH_MAX_DEPTH; i++) {
+    try {
+      const realAncestor = realpathSync(cursor)
+      if (segments.length === 0) return realAncestor
+      // `segments` was pushed leaf-first while cursor climbed, so reverse to
+      // rebuild ancestor→leaf order for join().
+      return join(realAncestor, ...segments.slice().reverse())
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err
+      const parent = dirname(cursor)
+      if (parent === cursor) {
+        // Reached the fs root without resolving any ancestor — unreachable on a
+        // real OS (`/` always realpaths). FAIL CLOSED: a lexical fallback here
+        // would reopen the exact bypass this helper closes.
+        throw Object.assign(new Error(`realpathDeepestAncestorSync: no existing ancestor for ${absPath}`), { code: 'ENOENT' })
+      }
+      segments.push(basename(cursor))
+      cursor = parent
+    }
+  }
+  // Depth ceiling hit — FAIL CLOSED rather than trust a pathological tail.
+  throw Object.assign(new Error(`realpathDeepestAncestorSync: path depth exceeds ${_FLOOR_REALPATH_MAX_DEPTH}`), { code: 'ENAMETOOLONG' })
+}
+
+/**
+ * #6851 — the pure segment scan, factored out of {@link isProtectedPathValue} so
+ * the lexical pass and the symlink-resolved pass share ONE matcher. Given a
+ * resolution `base` and an already-resolved absolute `resolved` target, applies
+ * the #6806 relative-vs-absolute framing (below) and tests each segment. No fs
+ * access — string ops only.
+ *
+ * #6806 — the discriminator is whether the resolved target stays INSIDE base's
+ * own subtree:
+ *   - UNDER base → scan the path RELATIVE to base, so base's own prefix segments
  *     (its `.claude`) are excluded and a benign in-workspace write is never
- *     floored (goal 2). Under-cwd relatives never contain `..`.
- *   - ESCAPES cwd (a `..`-traversal ABOVE it — itself suspicious) → scan the
- *     RESOLVED ABSOLUTE path, so a protected segment sitting in cwd's PREFIX
- *     (e.g. the very `.claude/` the worktree lives under, reached by
- *     `../../settings.local.json`) is caught (goal 1). A protected segment that
- *     appears BELOW the `..`s (an out-of-cwd `.git`) is caught either way. The
- *     floor only ever forces a PROMPT, so over-flooring a sibling traversal
- *     (which is already escaping the workspace) is safe and conservative.
- *
- * Segments are lowercased first: on case-insensitive filesystems (macOS APFS,
- * Windows) `.GIT/config` IS `.git/config`, so a case-sensitive match would let
- * case variants evade the floor. Over-flooring a genuinely distinct `.GIT` on
- * case-sensitive Linux is fine — the floor only forces a prompt, never denies.
- * #6803 — `secretsOnly` narrows the match to SECRET FILES (env + key material)
- * and SKIPS the config-DIR segments (.git/.claude/.vscode/.config/git). It is
- * the read floor: a Read/Glob/Grep must not silently auto-read a secret, but
- * reading a config dir is benign and must not prompt. The full (write) floor
- * passes `secretsOnly = false` and matches both dirs and secret files.
- * @param {string} target  a path value from a tool input
- * @param {string} base    the resolution base (session cwd)
- * @param {boolean} [secretsOnly]  match only secret files, skip config dirs
+ *     floored. Under-base relatives never contain `..`.
+ *   - ESCAPES base (a `..`-traversal ABOVE it — itself suspicious) → scan the
+ *     RESOLVED ABSOLUTE path, so a protected segment sitting in base's PREFIX
+ *     (the very `.claude/` a worktree lives under, reached by `../../x`) is
+ *     caught. The floor only ever forces a PROMPT, so over-flooring a sibling
+ *     traversal (already escaping the workspace) is safe and conservative.
+ * @param {string} base
+ * @param {string} resolved  an absolute path already resolved against base
+ * @param {boolean} secretsOnly
  * @returns {boolean}
  */
-function isProtectedPathValue(target, base, secretsOnly = false) {
-  const resolved = resolve(base, target)
+function _scanResolvedTarget(base, resolved, secretsOnly) {
   const rel = relative(base, resolved)
-  // Target is inside cwd's own subtree when the relative path neither is nor
+  // Target is inside base's own subtree when the relative path neither is nor
   // begins with `..` (and isn't a foreign absolute — a Windows cross-drive
-  // `relative()` can return one). Empty rel = the target IS cwd (still "inside").
+  // `relative()` can return one). Empty rel = the target IS base (still "inside").
   const underCwd = rel === '' ||
     (!isAbsolute(rel) && rel !== '..' && !rel.startsWith('..' + sep))
   const scanned = underCwd ? rel : resolved
@@ -297,6 +340,62 @@ function isProtectedPathValue(target, base, secretsOnly = false) {
     if (seg === '.config' && segments[i + 1] === 'git') return true
   }
   return false
+}
+
+/**
+ * #6794 / #6806 / #6851 — is a single path value protected, resolved against
+ * `base` (the session cwd)?
+ *
+ * TWO passes, ORed — a hit on EITHER floors the target:
+ *   (1) LEXICAL (the pre-#6851 floor, unchanged). `resolve()` absorbs absolute
+ *       paths, a leading `./`, and `..` traversal; the resolved path is scanned
+ *       segment-by-segment ({@link _scanResolvedTarget}). Pure string ops, no fs
+ *       access — fast, and every input the old floor flagged still flags.
+ *   (2) #6851 SYMLINK. The lexical pass is symlink-BLIND: because `resolve()`
+ *       collapses `..` textually, a symlink in cwd's PREFIX (the chroxy agent
+ *       worktree can live under a *symlink* to a real `.claude/`) or a symlinked
+ *       COMPONENT of the target can make a path that lexically looks OUTSIDE a
+ *       protected dir RESOLVE INTO `.git`/`.claude`/`.vscode`/`.config/git` or a
+ *       secret file (and vice-versa). Pass (2) resolves BOTH the base and the
+ *       target through their real (symlink-followed) paths — collapsing the
+ *       target's `..` against the REAL base so a `..` after a symlinked cwd
+ *       component climbs from the symlink's TARGET, not its lexical parent —
+ *       then re-runs the SAME segment scan. It only ADDS matches on top of (1);
+ *       it never un-floors a lexical hit (pass (1) already returned).
+ *
+ * FAIL-CLOSED: any error resolving the real paths (EACCES on a directory, ELOOP
+ * on a symlink cycle, an unresolvable ancestor, a depth bomb) is treated as
+ * PROTECTED — the floor forces the interactive prompt, never assumes the target
+ * is safe. The floor only ever forces a PROMPT (never a hard deny), so
+ * over-flooring an ambiguous resolution is conservative and correct.
+ *
+ * #6806 — WHICH segments each pass scans, and the #6794 worktree false-positive
+ * guard it preserves, live in {@link _scanResolvedTarget}. #6803 —
+ * `secretsOnly` narrows the match to SECRET / credential files (the read floor);
+ * the full (write) floor passes `secretsOnly = false`.
+ * @param {string} target  a path value from a tool input
+ * @param {string} base    the resolution base (session cwd)
+ * @param {boolean} [secretsOnly]  match only secret / credential files
+ * @returns {boolean}
+ */
+function isProtectedPathValue(target, base, secretsOnly = false) {
+  // (1) LEXICAL floor — pre-#6851 behavior, authoritative on a hit (no fs cost).
+  const resolvedLexical = resolve(base, target)
+  if (_scanResolvedTarget(base, resolvedLexical, secretsOnly)) return true
+  // (2) #6851 SYMLINK floor — resolve the real paths and re-scan. A resolution
+  // error FAILS CLOSED (return true → force the prompt). Runs only on a
+  // lexically-clean target (the common benign case), so the fs cost is a couple
+  // of realpath walks per otherwise-auto-approved permission check.
+  try {
+    const realBase = realpathDeepestAncestorSync(resolve(base))
+    // resolve() against the REAL base first (so a `..` after a symlinked cwd
+    // component collapses from the real location), then chase symlinks in the
+    // target's own existing ancestors.
+    const realTarget = realpathDeepestAncestorSync(resolve(realBase, target))
+    return _scanResolvedTarget(realBase, realTarget, secretsOnly)
+  } catch {
+    return true
+  }
 }
 
 /**

--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -42,6 +42,23 @@ export async function resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl) {
  * defeats the otherwise-correct 04a2fbbb1 realpath-TOCTOU fix on the
  * new-file code path.
  *
+ * #6921 — KNOWN RESIDUAL LIMITATION (shared with the pre-#6921 protected-path
+ * floor): this resolves the deepest EXISTING ancestor via `realpath()`, then
+ * re-appends the unresolved tail LEXICALLY. It therefore cannot honour a `..`
+ * that FOLLOWS a symlinked component the way `open(2)` does — both this helper's
+ * `realpath` step AND every caller (which pre-computes `absPath = resolve(...)`,
+ * collapsing `..` textually before calling in) discard the ordering the kernel
+ * uses (follow symlink, THEN apply `..`). The floor closed the same gap by
+ * switching to a COMPONENT-BY-COMPONENT walk (see
+ * `permission-manager.js` `resolveTargetComponentwiseSync`, #6921). Bringing this
+ * BYOK confinement path to parity needs a caller-signature change (pass the RAW
+ * target + base, walk componentwise) rather than a local edit here, so it is
+ * tracked as a separate follow-up. Impact here is narrower than the floor's — the
+ * containment check only asks "does it escape the workspace?", and the common
+ * chroxy topology (`.claude`/`.git` under the workspace) stays inside it — but a
+ * symlink pointing OUT of the workspace followed by `..` can still evade the
+ * `startsWith(cwdReal)` check, so this remains worth fixing.
+ *
  * @param {string} absPath - Absolute path to resolve (may not exist)
  * @returns {Promise<string>} Real path with all symlink ancestors resolved
  */

--- a/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
+++ b/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
@@ -1,0 +1,202 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PermissionManager, isProtectedPathTarget, isSecretReadTarget } from '../src/permission-manager.js'
+
+/**
+ * #6851 — the protected-path floor resolves SYMLINKS before the segment scan.
+ *
+ * The #6794/#6806/#6803 floor was LEXICAL-only: it string-resolved targets with
+ * `path.resolve`/`path.relative` and never touched the filesystem. A symlink in
+ * the session cwd's PREFIX (the chroxy agent worktree can live under a *symlink*
+ * to a real `.claude/`), or a symlinked COMPONENT of the target, could make a
+ * path that lexically looks OUTSIDE a protected dir RESOLVE INTO `.git`/`.claude`
+ * (or a secret/credential file), escaping the floor.
+ *
+ * #6851 adds a second pass that resolves the REAL (symlink-followed) paths of
+ * both the base and the target and re-runs the same scan. These tests build
+ * REAL on-disk symlink topologies under a temp dir (the synthetic string-only
+ * fixtures in the sibling floor suites can't exercise fs symlink resolution),
+ * and assert the evasions are now caught — via the exported pure matchers AND
+ * end-to-end through handlePermission (a floor forces a PROMPT, never a deny).
+ *
+ * Fail-closed: an unresolvable path (symlink cycle → ELOOP) is treated as
+ * protected, never as safe.
+ */
+
+const silentLog = { info() {}, warn() {} }
+
+/** Make a fresh temp root and return its REAL path (macOS tmpdir is itself
+ *  under a `/var → /private/var` firmlink; realpath gives a stable base). */
+function mkRoot() {
+  return realpathSync(mkdtempSync(join(tmpdir(), 'chroxy-floor-sym-')))
+}
+
+describe('protected-path floor resolves symlinks (#6851)', () => {
+  let root
+  const roots = []
+
+  beforeEach(() => {
+    root = mkRoot()
+    roots.push(root)
+  })
+
+  afterEach(() => {
+    while (roots.length) {
+      const r = roots.pop()
+      try { rmSync(r, { recursive: true, force: true }) } catch { /* best-effort */ }
+    }
+  })
+
+  // -- The exact issue repro: a symlinked cwd PREFIX + `..` into the real .claude --
+
+  it('floors a `..` traversal through a SYMLINKED cwd prefix into the real .claude', () => {
+    // work -> .claude/worktrees ; the session runs in work/agent-x, whose REAL
+    // location is .claude/worktrees/agent-x. `../../foo.js` lexically resolves to
+    // <root>/foo.js (benign — NOT floored lexically), but the real target is
+    // <root>/.claude/foo.js (inside the REAL .claude).
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const symCwd = join(root, 'work/agent-x')
+
+    assert.equal(
+      isProtectedPathTarget({ file_path: '../../foo.js' }, symCwd),
+      true,
+      'a symlinked-prefix `..` into the real .claude must be floored',
+    )
+  })
+
+  it('CONTRAST: the same `..` from a NON-symlinked prefix is NOT floored (proves the symlink is what triggers it)', () => {
+    // work2 is a REAL directory (no symlink). `../../foo.js` resolves to
+    // <root>/foo.js both lexically AND really — no protected segment.
+    mkdirSync(join(root, 'work2/agent-x'), { recursive: true })
+    const realCwd = join(root, 'work2/agent-x')
+
+    assert.equal(
+      isProtectedPathTarget({ file_path: '../../foo.js' }, realCwd),
+      false,
+      'without a prefix symlink the same traversal stays benign',
+    )
+  })
+
+  it('preserves the #6794 worktree guard: a benign in-workspace write through the symlinked cwd is NOT floored', () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x/packages/server'), { recursive: true })
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const symCwd = join(root, 'work/agent-x')
+
+    assert.equal(isProtectedPathTarget({ file_path: 'packages/server/foo.js' }, symCwd), false)
+    // Also holds when addressed via the session's REAL cwd (the real worktree topology).
+    const realCwd = join(root, '.claude/worktrees/agent-x')
+    assert.equal(isProtectedPathTarget({ file_path: 'packages/server/foo.js' }, realCwd), false)
+  })
+
+  // -- A symlinked directory COMPONENT of the target pointing into a protected dir --
+
+  it('floors a target whose SYMLINKED component resolves into .claude', () => {
+    // proj/logs -> .claude ; `logs/x.json` lexically has no `.claude` segment,
+    // but resolves to <root>/.claude/x.json.
+    mkdirSync(join(root, 'proj'), { recursive: true })
+    mkdirSync(join(root, '.claude'), { recursive: true })
+    symlinkSync(join(root, '.claude'), join(root, 'proj/logs'))
+    const cwd = join(root, 'proj')
+
+    assert.equal(isProtectedPathTarget({ file_path: 'logs/x.json' }, cwd), true)
+  })
+
+  it('floors a symlinked .git DIRECTORY component under BOTH the write floor and the read (credential) floor', () => {
+    // repo/gitlink -> repo/.git ; `gitlink/config` lexically has no `.git`
+    // segment, but resolves to repo/.git/config — a credential-dense file the
+    // READ floor must catch too (a remote URL can embed a PAT).
+    mkdirSync(join(root, 'repo/.git'), { recursive: true })
+    writeFileSync(join(root, 'repo/.git/config'), '[remote]\n')
+    symlinkSync(join(root, 'repo/.git'), join(root, 'repo/gitlink'))
+    const cwd = join(root, 'repo')
+
+    assert.equal(isProtectedPathTarget({ file_path: 'gitlink/config' }, cwd), true, 'write floor')
+    assert.equal(isSecretReadTarget({ file_path: 'gitlink/config' }, cwd), true, 'read/credential floor')
+  })
+
+  // -- The ENOENT / to-be-created-file path (deepest existing ancestor) --
+
+  it('floors a NOT-YET-CREATED file under a symlinked-into-.claude dir (deepest existing ancestor)', () => {
+    // proj/logs -> .claude ; the leaf and intermediate dirs do NOT exist yet, so
+    // a naive "realpath the whole target, fall back to lexical on ENOENT" would
+    // miss the `logs` symlink. Walking to the deepest existing ancestor (logs →
+    // .claude) closes it.
+    mkdirSync(join(root, 'proj'), { recursive: true })
+    mkdirSync(join(root, '.claude'), { recursive: true })
+    symlinkSync(join(root, '.claude'), join(root, 'proj/logs'))
+    const cwd = join(root, 'proj')
+
+    assert.equal(isProtectedPathTarget({ file_path: 'logs/new/deep/created.js' }, cwd), true)
+  })
+
+  // -- Reverse direction: a symlink pointing OUT must NOT be over-blocked --
+
+  it('does NOT over-block: an in-cwd symlink pointing OUT to a benign location stays unfloored', () => {
+    // The session's real cwd is under .claude/worktrees; `outlink` inside it
+    // points OUT to a plain sibling dir. Writing through it lands on a benign
+    // path — must not be floored just because cwd sits under a `.claude`.
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    mkdirSync(join(root, 'plain'), { recursive: true })
+    symlinkSync(join(root, 'plain'), join(root, '.claude/worktrees/agent-x/outlink'))
+    const cwd = join(root, '.claude/worktrees/agent-x')
+
+    assert.equal(isProtectedPathTarget({ file_path: 'outlink/a.js' }, cwd), false)
+  })
+
+  // -- Fail-closed: an unresolvable path (symlink cycle) is treated as protected --
+
+  it('FAILS CLOSED on a symlink cycle (ELOOP): an unresolvable target is floored, not assumed safe', () => {
+    // a -> b, b -> a ; realpath'ing a/x throws ELOOP. The floor treats a
+    // resolution error as protected (force the prompt), never as safe.
+    symlinkSync('b', join(root, 'a'))
+    symlinkSync('a', join(root, 'b'))
+    const cwd = root
+
+    // Sanity: the target is lexically benign (a/x has no protected segment), so
+    // the flooring here comes purely from the fail-closed resolution error.
+    assert.equal(isProtectedPathTarget({ file_path: 'a/x' }, cwd), true)
+  })
+
+  // -- End-to-end: the evasion falls through handlePermission to a PROMPT --
+
+  it('end-to-end: auto mode + a symlink-evasion write falls through to the prompt (not auto-approved)', async () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const symCwd = join(root, 'work/agent-x')
+    const pm = new PermissionManager({ log: silentLog, cwd: symCwd })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission('Write', { file_path: '../../foo.js' }, null, 'auto')
+      assert.equal(events.length, 1, 'a symlink evasion into the real .claude must prompt even under auto/bypass')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      const result = await promise
+      assert.equal(result.behavior, 'deny')
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  it('end-to-end: a benign in-workspace write through the symlinked cwd stays auto-approved', async () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x/src'), { recursive: true })
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const symCwd = join(root, 'work/agent-x')
+    const pm = new PermissionManager({ log: silentLog, cwd: symCwd })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const result = await pm.handlePermission('Write', { file_path: 'src/foo.js' }, null, 'auto')
+      assert.equal(result.behavior, 'allow', 'a benign in-workspace write must not be floored by the symlink pass')
+      assert.equal(events.length, 0)
+    } finally {
+      pm.destroy()
+    }
+  })
+})

--- a/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
+++ b/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
@@ -1,8 +1,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, realpathSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, readFileSync, rmSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { PermissionManager, isProtectedPathTarget, isSecretReadTarget } from '../src/permission-manager.js'
 
 /**
@@ -195,6 +195,109 @@ describe('protected-path floor resolves symlinks (#6851)', () => {
       const result = await pm.handlePermission('Write', { file_path: 'src/foo.js' }, null, 'auto')
       assert.equal(result.behavior, 'allow', 'a benign in-workspace write must not be floored by the symlink pass')
       assert.equal(events.length, 0)
+    } finally {
+      pm.destroy()
+    }
+  })
+
+  // ==========================================================================
+  // #6921 — RESIDUAL evasion: a `..` AFTER a symlinked component. The #6851
+  // symlink pass used `realpathDeepestAncestorSync(resolve(realBase, target))`,
+  // and BOTH `path.resolve()` AND Node's `fs.realpathSync` collapse `..`
+  // LEXICALLY — so `link/../x` cancelled the symlink textually before it was
+  // ever followed. `open(2)` (any raw `fs` write/read) follows `link` FIRST and
+  // applies `..` from the TARGET, landing in the protected dir. The two PoCs
+  // below build the exact topologies from the issue and PROVE, with real
+  // on-disk writes, that (a) the raw path physically lands on the protected
+  // file, and (b) the floor now FLAGS it — closing the gap.
+  // ==========================================================================
+
+  it('PoC #6921/1: `work/agent-x/../../settings.local.json` from repo root is floored, and a raw write proves it lands on the REAL .claude/settings.local.json', () => {
+    // The REAL chroxy topology — no attacker-planted symlink: work -> .claude/worktrees.
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL')
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const cwd = root // session runs at the repo root
+    const evasion = 'work/agent-x/../../settings.local.json'
+
+    // path.resolve() still LEXICALLY collapses the `..`s to a benign target —
+    // this is exactly why the pre-#6921 (lexical + realpath) floor missed it.
+    assert.equal(resolve(cwd, evasion), join(root, 'settings.local.json'))
+
+    // PROOF the target is genuinely dangerous: a raw open(2)-style write through
+    // the exact path physically clobbers the REAL .claude/settings.local.json
+    // (the file that governs the permission system itself). NOTE: the write path
+    // is built by STRING concat, not path.join — path.join would lexically
+    // collapse the `..`s (exactly the bug), never traversing the symlink.
+    writeFileSync(`${cwd}/${evasion}`, 'PWNED')
+    assert.equal(
+      readFileSync(join(root, '.claude/settings.local.json'), 'utf8'),
+      'PWNED',
+      'the raw write really lands on the protected .claude/settings.local.json',
+    )
+
+    // The floor now FLAGS it — under BOTH the write floor and the read/credential
+    // floor (settings*.json is credential-dense: may hold ANTHROPIC_API_KEY).
+    assert.equal(isProtectedPathTarget({ file_path: evasion }, cwd), true, 'write floor must flag the symlink+`..` evasion')
+    assert.equal(isSecretReadTarget({ file_path: evasion }, cwd), true, 'read/credential floor must flag settings.local.json')
+  })
+
+  it('PoC #6921/2: `glink/../config` where glink -> .git/hooks is floored under BOTH floors, and a raw write proves it lands on the REAL .git/config', () => {
+    // glink -> repo/.git/hooks ; `glink/../config` follows glink into .git/hooks,
+    // then `..` climbs to .git, landing on .git/config — a credential file (a
+    // remote URL can embed a PAT).
+    mkdirSync(join(root, 'repo/.git/hooks'), { recursive: true })
+    writeFileSync(join(root, 'repo/.git/config'), '[core]\n')
+    symlinkSync(join(root, 'repo/.git/hooks'), join(root, 'repo/glink'))
+    const cwd = join(root, 'repo')
+    const evasion = 'glink/../config'
+
+    // Lexically benign (glink/.. cancels to nothing) — the old floor missed it.
+    assert.equal(resolve(cwd, evasion), join(root, 'repo/config'))
+
+    // PROOF: a raw write really lands on the real .git/config (STRING concat, not
+    // path.join — join would collapse `glink/..` lexically and miss the symlink).
+    writeFileSync(`${cwd}/${evasion}`, 'PWNED')
+    assert.equal(readFileSync(join(root, 'repo/.git/config'), 'utf8'), 'PWNED', 'the raw write really lands on .git/config')
+
+    // Floored under BOTH the write floor and the read/credential floor.
+    assert.equal(isProtectedPathTarget({ file_path: evasion }, cwd), true, 'write floor')
+    assert.equal(isSecretReadTarget({ file_path: evasion }, cwd), true, 'read/credential floor (.git/config embeds PATs)')
+  })
+
+  // -- The component walk must NOT over-flag a benign `link/..` that lands safe --
+
+  it('does NOT over-flag a benign `link/..`: a symlink followed by `..` that resolves to a SAFE location stays unfloored', () => {
+    // safe/inner -> safe/other ; `inner/../file.js` follows inner into other,
+    // then `..` climbs back to safe → safe/file.js. No protected segment: the
+    // component walk resolves the symlink correctly but the destination is benign,
+    // so the floor must not flag it (proving the fix isn't just "flag anything
+    // with a symlink and a `..`").
+    mkdirSync(join(root, 'safe/other'), { recursive: true })
+    symlinkSync(join(root, 'safe/other'), join(root, 'safe/inner'))
+    const cwd = join(root, 'safe')
+
+    assert.equal(isProtectedPathTarget({ file_path: 'inner/../file.js' }, cwd), false)
+    // And it genuinely lands where we claim (safe/file.js), not in a protected dir.
+    writeFileSync(`${cwd}/inner/../file.js`, 'x')
+    assert.equal(readFileSync(join(root, 'safe/file.js'), 'utf8'), 'x')
+  })
+
+  it('end-to-end: the PoC #6921/1 evasion falls through handlePermission to a PROMPT under auto mode', async () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL')
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const pm = new PermissionManager({ log: silentLog, cwd: root })
+    try {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      const promise = pm.handlePermission('Write', { file_path: 'work/agent-x/../../settings.local.json' }, null, 'auto')
+      assert.equal(events.length, 1, 'the `..`-after-symlink evasion must prompt even under auto/bypass')
+
+      pm.respondToPermission(events[0].requestId, 'deny')
+      const result = await promise
+      assert.equal(result.behavior, 'deny')
     } finally {
       pm.destroy()
     }

--- a/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
+++ b/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
@@ -302,4 +302,54 @@ describe('protected-path floor resolves symlinks (#6851)', () => {
       pm.destroy()
     }
   })
+
+  // ==========================================================================
+  // PR #6920 review (Copilot) — the SYMLINK pass must NEVER frame the floor
+  // against the SERVER process cwd. It resolves the real base via
+  // `realpathDeepestAncestorSync(base)`, whose absolute-path guard THROWS on a
+  // relative base — so a relative/`..`-laden session cwd (a defensive edge the
+  // codebase guards against elsewhere, e.g. audit-key normalization) FAILS
+  // CLOSED (the target is treated as protected → prompt) instead of being
+  // silently reframed against `process.cwd()` (the WRONG root). Wrapping `base`
+  // in `resolve()` would coerce a relative base against process.cwd() and defeat
+  // that guard; these tests pin the fail-closed behavior.
+  // ==========================================================================
+
+  it('FAILS CLOSED on a RELATIVE base: a lexically-benign target under a relative session cwd is floored, not framed against process.cwd()', () => {
+    // The target has no protected segment, so the LEXICAL pass cannot flag it —
+    // the flooring here comes purely from the symlink pass fail-closing on the
+    // relative base (`realpathDeepestAncestorSync` throws EINVAL on a non-absolute
+    // path). A deterministic assertion: it does not depend on process.cwd().
+    const relativeCwd = 'relative/session/dir'
+
+    assert.equal(
+      isProtectedPathTarget({ file_path: 'foo.js' }, relativeCwd),
+      true,
+      'a relative base must fail closed (protected), never resolve against process.cwd()',
+    )
+    // The read/credential floor takes the same base → same fail-closed outcome.
+    assert.equal(
+      isSecretReadTarget({ file_path: 'foo.js' }, relativeCwd),
+      true,
+      'the read floor must also fail closed on a relative base',
+    )
+  })
+
+  it('FAILS CLOSED on a `..`-laden relative base too (still non-absolute → guard throws)', () => {
+    assert.equal(
+      isProtectedPathTarget({ file_path: 'foo.js' }, '../up/one/dir'),
+      true,
+      'a `..`-laden relative base is still non-absolute and must fail closed',
+    )
+  })
+
+  it('CONTRAST: an ABSOLUTE base with the same benign target is NOT floored (proves the relative base is what fails closed)', () => {
+    // The same benign target under an absolute, real, existing cwd stays
+    // unfloored — the 14 absolute-base fixtures are unaffected by the fix.
+    assert.equal(
+      isProtectedPathTarget({ file_path: 'foo.js' }, root),
+      false,
+      'an absolute existing base resolves normally and a benign target is not floored',
+    )
+  })
 })


### PR DESCRIPTION
Closes #6851

## Problem

The protected-path floor (`isProtectedPathTarget` / `isSecretReadTarget` in `permission-manager.js`, from #6794/#6806/#6803) was **lexical-only**: it string-resolved targets with `path.resolve`/`path.relative` and never touched the filesystem. Because `resolve()` collapses `..` textually, a symlink can evade the floor:

- A symlink in the session **cwd's PREFIX** — the chroxy agent worktree can live under a *symlink* to a real `.claude/` — plus a `..` traversal. Lexically the target resolves outside a protected dir; on the real filesystem it resolves *into* `.claude`/`.git`.
- A symlinked **component of the target itself** (e.g. `gitlink -> .git`, then `gitlink/config`) — lexically has no `.git` segment, but resolves into `.git/config` (a credential file).

Example (the issue repro): cwd `<root>/work/agent-x` where `work -> .claude/worktrees`. `../../foo.js` lexically resolves to `<root>/foo.js` (benign, **not** floored), but really resolves to `<root>/.claude/foo.js` — inside the real `.claude`.

## Fix

`isProtectedPathValue` now runs **two passes, ORed** (a hit on either floors the target):

1. **Lexical** — the pre-#6851 floor, unchanged and authoritative on a hit (no fs cost). Every input the old floor flagged still flags identically.
2. **#6851 symlink** — resolves BOTH the base and the target through their real (symlink-followed) paths and re-runs the same segment scan. The target's `..` is collapsed against the **real** base first, so a `..` after a symlinked cwd component climbs from the symlink's *target*, not its lexical parent.

Supporting pieces:

- `realpathDeepestAncestorSync` — a **sync** sibling of `ws-file-ops/common.js`'s `realpathOfDeepestAncestor` (BYOK's post-approval confinement). The floor runs in the synchronous `handlePermission` hot-path, so it can't await the async twin. It resolves symlinks in the target's **existing** ancestor chain and re-appends the not-yet-created tail — closing the to-be-created-file symlink hole (a symlinked parent + a nonexistent leaf).
- **Fail-closed**: any resolution error (EACCES, ELOOP on a symlink cycle, an unresolvable ancestor, a depth bomb) is treated as **protected** — the floor forces the interactive prompt, never assumes the target is safe. The floor only ever forces a prompt (never a hard deny), so over-flooring an ambiguous resolution is conservative.
- The #6794 worktree false-positive guard and the #6806 relative-vs-absolute framing are **preserved** (factored into a shared `_scanResolvedTarget` used by both passes). The lexical `..` cases, case-insensitive segments, and `apply_patch` `changes[]` handling are untouched.

The symlink pass runs only on a lexically-clean target (the common benign case), so the fs cost is a couple of `realpath` walks per otherwise-auto-approved permission check — the same per-op realpath cost the BYOK confinement already pays.

## Tests

New suite `permission-manager-floor-symlink-evasion.test.js` builds **real on-disk symlink topologies** under a temp dir (the synthetic string-only fixtures in the sibling floor suites can't exercise fs symlink resolution) and asserts, via the exported matchers **and** end-to-end through `handlePermission`:

- symlinked cwd prefix + `..` into the real `.claude` is floored (+ a non-symlinked-prefix contrast that stays benign, proving the symlink is what triggers it);
- a symlinked target component into `.claude` is floored;
- a symlinked `.git` dir (`gitlink/config`) is floored under **both** the write floor and the read/credential floor;
- a **not-yet-created** file under a symlinked-into-`.claude` dir is floored (deepest existing ancestor);
- the **reverse** — an in-cwd symlink pointing OUT to a benign location — is **not** over-blocked;
- a symlink **cycle** (ELOOP) **fails closed** (floored);
- the #6794 worktree guard still holds (benign in-workspace writes through the symlinked cwd stay auto-approved).

## Verification

- New suite: 10/10 pass.
- Existing floor suites (`permission-manager-protected-path-floor`, `permission-secret-read-floor`) + `permission-manager`, `-resource-caps`, `-path-scoped-rules`, `permission-audit`: green (309/309 of the SDK-independent files; one unrelated file fails only on a missing `@anthropic-ai/claude-agent-sdk` dep in the isolated worktree — resolves in CI).
- All 5 `packages/server/scripts/lint-*.sh`: OK.
- `npm run lint` (server `eslint src/`): 0 errors.

The floor's guarantee is documented in its JSDoc (the issue's suggested location); `bearer-token-authority.md` does not describe the path floor, so nothing there went stale.