### PR TITLE
fix(dashboard): globalize sidebar-panel-slot prefs

### DIFF
--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -712,6 +712,13 @@ export function clearPersistedState(): void {
  * `interventionPing`, and `compactChatFilter` are device-level choices, not
  * server-scoped session state, so they should survive an unscoped
  * `clearPersistedState()` just like `theme`/`view_mode` do.
+ *
+ * Also includes the sidebar-panel-slot prefs (#6917) — panel height, active
+ * view, and collapsed state (#4303) are plain unscoped device-level keys
+ * (they never go through `scopedKey`/`scopedRead`, unlike the genuinely
+ * server-scoped repo/session/tab ordering below), so they belong in the same
+ * survive-clear class as the #6915 device prefs. Pre-existing asymmetry from
+ * #4304 — this was never intentional exclusion.
  */
 function isGlobalKey(key: string): boolean {
   return key === KEY_VIEW_MODE
@@ -721,7 +728,10 @@ function isGlobalKey(key: string): boolean {
     || key === KEY_THEME
     || key === KEY_SHOW_CONSOLE_TAB
     || key === KEY_INTERVENTION_PING
-    || key === KEY_COMPACT_CHAT_FILTER;
+    || key === KEY_COMPACT_CHAT_FILTER
+    || key === KEY_SIDEBAR_PANEL_HEIGHT
+    || key === KEY_SIDEBAR_PANEL_VIEW
+    || key === KEY_SIDEBAR_PANEL_COLLAPSED;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -177,6 +177,26 @@ describe('persistence', () => {
     expect(loadPersistedState().activeSessionId).toBeNull();
   });
 
+  // #6917 — sidebar-panel-slot prefs (height, view, collapsed; #4303) are
+  // per-device UI choices, not server-scoped session state, so an unscoped
+  // clearPersistedState() must not reset them (matching theme / view_mode /
+  // the #6915 device prefs). Pre-#6917, these were wiped alongside session
+  // data — a pre-existing asymmetry from #4304.
+  it('clearPersistedState preserves sidebar-panel-slot prefs but still clears session state', () => {
+    persistSidebarPanelHeight(320);
+    persistSidebarPanelView('files');
+    persistSidebarPanelCollapsed(true);
+    persistActiveSession('sess-1');
+
+    clearPersistedState();
+
+    expect(loadPersistedSidebarPanelHeight()).toBe(320);
+    expect(loadPersistedSidebarPanelView()).toBe('files');
+    expect(loadPersistedSidebarPanelCollapsed()).toBe(true);
+    // Session-scoped state still clears
+    expect(loadPersistedState().activeSessionId).toBeNull();
+  });
+
   it('loadPersistedState returns defaults when empty', () => {
     const state = loadPersistedState();
     expect(state.viewMode).toBeNull();


### PR DESCRIPTION
## Summary
- The sidebar-panel-slot prefs (panel height / active view / collapsed, #4303, `packages/dashboard/src/store/persistence.ts`) are plain unscoped device-level `localStorage` keys — the same class as the device prefs #6915 added to `isGlobalKey` — but were left out, so an unscoped `clearPersistedState()` wiped them alongside session state. Pre-existing asymmetry from #4304.
- Added `KEY_SIDEBAR_PANEL_HEIGHT`, `KEY_SIDEBAR_PANEL_VIEW`, and `KEY_SIDEBAR_PANEL_COLLAPSED` to `isGlobalKey` so they survive an unscoped clear, matching `theme`/`view_mode` and the #6915 prefs.
- Confirmed the genuinely server-scoped keys (repo order, session order, session-tab order — all route through `scopedKey`/`scopedRead`) were **not** touched; globalizing those would regress per-server ordering.

## Test plan
- [x] New test `clearPersistedState preserves sidebar-panel-slot prefs but still clears session state` in `packages/dashboard/src/store/store.test.ts` (mirrors the #6915/#6883 survive-clear test) — asserts panel height/view/collapsed survive an unscoped clear while `activeSessionId` still clears.
- [x] `npx vitest run` (full dashboard suite) — 270 files / 4667 tests passed.
- [x] `npx tsc --noEmit` — clean.

Closes #6917