### PR TITLE
fix(dashboard,server): gate deny-reason textarea on provider capability

### DIFF
--- a/packages/dashboard/src/components/PermissionPrompt.test.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.test.tsx
@@ -19,7 +19,7 @@ type MockStore = {
   resolvedPermissions: Record<string, PermissionDecision>
   activeSessionId: string | null
   sessions: { sessionId: string; provider?: string }[]
-  availableProviders: { name: string; capabilities?: { sessionRules?: boolean } }[]
+  availableProviders: { name: string; capabilities?: { sessionRules?: boolean; denyReason?: boolean } }[]
   connectionPhase: string
   // #6773 — the command-edit + write-review affordances read these; default
   // undefined (ide off) so existing tests render neither and stay unchanged.
@@ -31,7 +31,11 @@ const DEFAULT_MOCK_STORE: MockStore = {
   resolvedPermissions: {},
   activeSessionId: 's1',
   sessions: [{ sessionId: 's1', provider: 'claude-sdk' }],
-  availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true } }],
+  // #6888 — claude-sdk is a deny-reason-honoring provider (in-process
+  // PermissionManager forwards the reason as the tool's denial message), so
+  // the default mock keeps every pre-existing deny-reason test rendering the
+  // textarea unchanged.
+  availableProviders: [{ name: 'claude-sdk', capabilities: { sessionRules: true, denyReason: true } }],
   // #5699 — answer buttons gate on connected; default the mock to connected so
   // the existing button-interaction tests keep working.
   connectionPhase: 'connected',
@@ -54,6 +58,15 @@ vi.mock('../store/connection', () => ({
   ) => {
     if (!provider) return false
     return available.find((p) => p.name === provider)?.capabilities?.sessionRules === true
+  },
+  // #6888 — mirrors the real isDenyReasonHonoredProvider: fails closed (false)
+  // for an unknown provider or a provider whose capability isn't exactly true.
+  isDenyReasonHonoredProvider: (
+    provider: string | null | undefined,
+    available: { name: string; capabilities?: { denyReason?: boolean } }[],
+  ) => {
+    if (!provider) return false
+    return available.find((p) => p.name === provider)?.capabilities?.denyReason === true
   },
   // #6773 — mirrors the real store's wire ceiling for the deny-reason textarea's
   // `maxLength` (protocol's `PermissionResponseSchema.reason: z.string().max(2000)`).
@@ -1071,5 +1084,60 @@ describe('PermissionPrompt — deny reason + command edit (#6773)', () => {
     )
     fireEvent.click(screen.getByText('Allow'))
     expect(onRespond).toHaveBeenCalledWith('req-1', 'allow', null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Deny-reason honesty gate (#6888) — the "sent with Deny" textarea must not
+// overpromise on a provider whose respondToPermission path drops the reason
+// (codex app-server: message never forwarded in _routeApproval's RPC reply;
+// legacy-CLI: no in-process PermissionManager at all).
+// ---------------------------------------------------------------------------
+describe('PermissionPrompt — deny-reason honesty gate (#6888)', () => {
+  beforeEach(() => {
+    resetMockStore()
+  })
+
+  it('shows the deny-reason field with the "sent with Deny" hint for a consuming provider (SDK/BYOK)', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'claude-byok' }]
+    mockStoreState.availableProviders = [{ name: 'claude-byok', capabilities: { denyReason: true } }]
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={60000} onRespond={vi.fn()} />
+    )
+    const field = screen.getByTestId('perm-deny-reason')
+    expect(field).toBeInTheDocument()
+    expect(field).toHaveAttribute('placeholder', expect.stringContaining('sent with Deny'))
+  })
+
+  it('hides the deny-reason field for a provider that drops it (codex)', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'codex' }]
+    mockStoreState.availableProviders = [{ name: 'codex', capabilities: { denyReason: false } }]
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={60000} onRespond={vi.fn()} />
+    )
+    expect(screen.queryByTestId('perm-deny-reason')).not.toBeInTheDocument()
+    // The Allow/Deny buttons are unaffected — only the reason affordance is gone.
+    expect(screen.getByText('Allow')).toBeInTheDocument()
+    expect(screen.getByText('Deny')).toBeInTheDocument()
+  })
+
+  it('hides the deny-reason field for a provider whose capability is missing entirely (fail-closed)', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'mystery' }]
+    mockStoreState.availableProviders = []
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={60000} onRespond={vi.fn()} />
+    )
+    expect(screen.queryByTestId('perm-deny-reason')).not.toBeInTheDocument()
+  })
+
+  it('a Deny on a drop-provider never carries a reason (the field cannot be typed into)', () => {
+    mockStoreState.sessions = [{ sessionId: 's1', provider: 'codex' }]
+    mockStoreState.availableProviders = [{ name: 'codex', capabilities: { denyReason: false } }]
+    const onRespond = vi.fn()
+    render(
+      <PermissionPrompt requestId="req-1" tool="Bash" description="ls" remainingMs={60000} onRespond={onRespond} />
+    )
+    fireEvent.click(screen.getByText('Deny'))
+    expect(onRespond).toHaveBeenCalledWith('req-1', 'deny', null)
   })
 })

--- a/packages/dashboard/src/components/PermissionPrompt.tsx
+++ b/packages/dashboard/src/components/PermissionPrompt.tsx
@@ -19,7 +19,7 @@
  * fire onRespond twice before the store's answered state catches up.
  */
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider, DENY_REASON_MAX_LENGTH } from '../store/connection'
+import { useConnectionStore, isRuleEligibleTool, isRuleEligibleProvider, isDenyReasonHonoredProvider, DENY_REASON_MAX_LENGTH } from '../store/connection'
 import type { PermissionDecision } from '../store/types'
 import { isMacPlatform } from '../utils/platform'
 import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
@@ -99,6 +99,14 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
   })
   const availableProviders = useConnectionStore((s) => s.availableProviders)
   const providerSupportsRules = isRuleEligibleProvider(activeProvider, availableProviders)
+
+  // #6888 — the free-text deny-reason textarea's "(sent with Deny)" hint only
+  // holds true on providers whose respondToPermission path actually forwards
+  // the reason to the agent (SDK/BYOK). codex (message dropped in
+  // _routeApproval, tracked by #6885) and legacy-CLI (no in-process
+  // PermissionManager at all) silently discard it, so the honest fix is to
+  // hide the affordance rather than promise a delivery that never happens.
+  const denyReasonHonored = isDenyReasonHonoredProvider(activeProvider, availableProviders)
 
   // #6543 (feature B): per-hunk pre-write review. Gated on the server's `ide`
   // capability (features.ide) + a reviewable tool (Write/Edit). When eligible we
@@ -272,22 +280,28 @@ export function PermissionPrompt({ requestId, tool, description, remainingMs, on
 
       {showButtons && (
         <>
-          {/* #6773: optional free-text deny reason (tool-agnostic). When the
-              operator types here and clicks Deny, the note is fed back to the
-              agent as the denial message so it can adjust without a fresh turn
-              (desktop-app "tell Claude what to do differently" parity). Ignored
-              on Allow. */}
-          <textarea
-            className="perm-deny-reason"
-            data-testid="perm-deny-reason"
-            value={denyReason}
-            rows={2}
-            maxLength={DENY_REASON_MAX_LENGTH}
-            placeholder="Optional: tell the agent what to do differently (sent with Deny)"
-            aria-label="Deny reason (optional)"
-            onChange={(e) => setDenyReason(e.target.value)}
-            disabled={submitting || !connected}
-          />
+          {/* #6773/#6888: optional free-text deny reason (tool-agnostic). When
+              the operator types here and clicks Deny, the note is fed back to
+              the agent as the denial message so it can adjust without a fresh
+              turn (desktop-app "tell Claude what to do differently" parity).
+              Ignored on Allow. Gated on denyReasonHonored (#6888) — only
+              rendered when the active provider's respondToPermission path
+              actually forwards the reason (SDK/BYOK); hidden entirely on
+              codex / legacy-CLI / other providers that silently drop it, so
+              the affordance never overpromises delivery. */}
+          {denyReasonHonored && (
+            <textarea
+              className="perm-deny-reason"
+              data-testid="perm-deny-reason"
+              value={denyReason}
+              rows={2}
+              maxLength={DENY_REASON_MAX_LENGTH}
+              placeholder="Optional: tell the agent what to do differently (sent with Deny)"
+              aria-label="Deny reason (optional)"
+              onChange={(e) => setDenyReason(e.target.value)}
+              disabled={submitting || !connected}
+            />
+          )}
           <div className="perm-buttons">
             <button
               className="btn-allow"

--- a/packages/dashboard/src/hooks/useMessageRenderer.test.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.test.tsx
@@ -32,6 +32,10 @@ vi.mock('../store/connection', () => ({
     }),
   isRuleEligibleTool: () => false,
   isRuleEligibleProvider: () => false,
+  // #6888 — this fixture's provider ('codex') drops the deny reason, so the
+  // real isDenyReasonHonoredProvider would also resolve false here; the stub
+  // just short-circuits that.
+  isDenyReasonHonoredProvider: () => false,
   DENY_REASON_MAX_LENGTH: 2000,
 }))
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -269,6 +269,25 @@ export function isRuleEligibleProvider(
 }
 
 /**
+ * Whether the active session's provider actually forwards a Deny's free-text
+ * reason to the agent (#6888). Reads the `denyReason` capability surfaced by
+ * the server's provider_list message (server.js `ProviderClass.capabilities`).
+ * Mirrors isRuleEligibleProvider's shape/fail-closed default: an unknown or
+ * capability-less provider reports false, so PermissionPrompt hides the
+ * deny-reason textarea rather than showing an affordance the provider would
+ * silently discard (legacy-CLI, claude-tui, Gemini, legacy codex `exec`, and
+ * codex app-server until #6885 wires the RPC forwarding).
+ */
+export function isDenyReasonHonoredProvider(
+  provider: string | null | undefined,
+  availableProviders: { name: string; capabilities?: { denyReason?: boolean } }[],
+): boolean {
+  if (!provider) return false;
+  const info = availableProviders.find((p) => p.name === provider);
+  return info?.capabilities?.denyReason === true;
+}
+
+/**
  * Cap for `resolvedPermissions` to prevent unbounded growth over long sessions (#2838).
  * Exported for tests. LRU eviction: oldest insertion-order entry is dropped when
  * the map exceeds the cap. Re-resolving a requestId bumps it to the most-recent

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -180,6 +180,16 @@ export interface ProviderCapabilities {
   // "Conversation" option — providers that can't fork (CLI/TUI/BYOK/Gemini/Codex
   // and containerized SDK) omit it / report false, so the option is disabled.
   conversationFork?: boolean;
+  // #6888: true when an operator's free-text deny reason (PermissionPrompt's
+  // "sent with Deny" textarea) actually reaches the agent. SDK/BYOK (+ their
+  // Docker variants, DeepSeek, Ollama) report true — the reason feeds back as
+  // the tool's denial message on the in-process PermissionManager path. Legacy
+  // CLI, claude-tui, Gemini, and the legacy codex `exec` driver never take that
+  // path and omit the field (falsy). codex app-server explicitly reports false:
+  // it HAS an in-process respondToPermission but its RPC response back to codex
+  // drops the message (tracked by #6885). The dashboard gates the deny-reason
+  // textarea on this so it never promises delivery a provider won't honor.
+  denyReason?: boolean;
 }
 
 // #3404 audit (F1+F5): per-provider auth state for grey-out + billing panel.

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -141,6 +141,10 @@ export class ClaudeByokSession extends BaseSession {
       // takes effect on the next user message. Same property as the
       // SDK provider.
       skillToggle: true,
+      // #6888: BYOK shares SdkSession's PermissionManager/respondToPermission
+      // path — see the matching comment in sdk-session.js's capabilities. A
+      // deny reason genuinely reaches the agent as the tool's denial message.
+      denyReason: true,
     }
   }
 

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -104,6 +104,15 @@ export class CodexAppServerSession extends BaseSession {
       terminal: false,
       thinkingLevel: false,
       streaming: true,
+      // #6888: despite inProcessPermissions:true (this session's
+      // respondToPermission delegates to the shared PermissionManager, which DOES
+      // compute a deny message via buildDenyMessage(reason)), _routeApproval only
+      // reads `result.behavior` when building the RPC response back to codex —
+      // `result.message` is never forwarded, so the operator's deny reason is
+      // silently dropped. Explicit false (not just omitted) so this doesn't read
+      // as an oversight: tracked by #6885 ("Codex deny reason either reaches the
+      // model or is documented as unsupported"). Flip to true once that lands.
+      denyReason: false,
     }
   }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -140,6 +140,13 @@ export class SdkSession extends BaseSession {
       // providers — claude-tui sets this to false (deliver-on-complete), all
       // others stream incremental deltas via stream_delta during a turn.
       streaming: true,
+      // #6888: true when an operator's free-text deny reason (PermissionPrompt's
+      // "sent with Deny" textarea) actually reaches the agent. The in-process
+      // PermissionManager path feeds it back as the tool's denial message
+      // (permission-manager.js buildDenyMessage) on the very next turn — the SDK
+      // honors this end to end. Gates the dashboard's deny-reason affordance so
+      // it isn't shown on providers that silently drop it (legacy-CLI, codex).
+      denyReason: true,
       // #3209/#3246: SDK rebuilds systemPrompt.append on every turn
       // (see sdk-session.js#_callQuery), so a runtime toggle of
       // _activeManualSkills + _loadSkills() takes effect on the next


### PR DESCRIPTION
Closes #6888

## Context

PR #6884 (#6773) added a tool-agnostic free-text deny-reason `<textarea>` to
`PermissionPrompt` with the placeholder "Optional: tell the agent what to do
differently (sent with Deny)". It rendered unconditionally, but the reason
only ever reached the agent on the in-process SDK/BYOK `respondToPermission`
path (`permission-resolver.js`):

- **Legacy CLI** (`cli-session.js`): no in-process `PermissionManager` at all
  — every deny falls to the legacy `pendingPermissions` path, which ignores
  `reason` entirely.
- **codex app-server** (`codex-app-server-session.js`): shares the same
  `PermissionManager` as SDK/BYOK, so `buildDenyMessage(reason)` *is*
  computed — but `_routeApproval` only reads `result.behavior` when building
  the RPC reply back to codex; `result.message` is never forwarded. Tracked
  separately by #6885.

Net: on legacy-CLI and codex sessions the operator typed a reason expecting
delivery, and it was silently dropped — a UX/trust honesty gap (the deny
*decision* was still honored correctly).

## Fix

Added a `denyReason` capability to `ProviderCapabilities`, surfaced through
the existing `provider_list` → `availableProviders` plumbing:

- `SdkSession` / `ClaudeByokSession`: `denyReason: true` (and inherited by
  their Docker/DeepSeek/Ollama variants, which share the same
  `PermissionManager` path).
- `CodexAppServerSession`: explicit `denyReason: false`, with a comment
  pointing at #6885 as the follow-up that would flip it to `true`.
- Everything else (legacy CLI, claude-tui, Gemini, legacy codex `exec`)
  leaves the field unset — falsy by default, matching reality.

`PermissionPrompt.tsx` gates the textarea on a new `isDenyReasonHonoredProvider`
helper (mirrors the existing `isRuleEligibleProvider` gate used for "Allow for
Session"): the field now only renders when the active session's provider
actually forwards the reason. Hidden entirely (not just reworded) — cleanest
fix since the capability signal was already available via the same
`activeProvider` + `availableProviders` plumbing the codebase already uses.

## Testing

- Extended `PermissionPrompt.test.tsx`: new `#6888` describe block asserting
  the field renders with the "sent with Deny" hint for a consuming provider
  (claude-byok), is hidden for a drop-provider (codex), is hidden fail-closed
  when provider info is missing, and that a Deny on a drop-provider never
  carries a reason.
- Updated the default mock provider (claude-sdk) to declare `denyReason: true`
  so all pre-existing #6773 deny-reason tests are unaffected.
- Fixed a second `../store/connection` mock (`useMessageRenderer.test.tsx`)
  that needed the new export stubbed.
- `packages/dashboard`: full vitest suite green — 270 files / 4670 tests.
- `packages/dashboard`: `tsc --noEmit` clean.
- `packages/server`: targeted node --test run across
  `sdk-session`, `byok-session`, `codex-app-server-session`,
  `docker-sdk-session`, `docker-byok-session`, `providers`, `cli-session` —
  834 tests / 0 failures.
- `lint-session-opt-forwarding.sh` — OK (no BaseSession opt changes; only
  static `capabilities` getters touched).
- Manually verified the resulting capability matrix via `listProviders()`:
  `claude-sdk`/`claude-byok`/`deepseek`/`ollama` → `true`, `codex` → `false`,
  `claude-cli` → `undefined` (falsy).

## Test plan

- [x] Dashboard vitest suite green
- [x] Dashboard `tsc --noEmit` clean
- [x] Targeted server test files green
- [x] `lint-session-opt-forwarding.sh` green