### PR TITLE
fix(server): close `..`-after-symlink evasion in the async BYOK file-ops floor (#6923)

### DIFF
--- a/packages/server/src/built-in-tools/file-ops.js
+++ b/packages/server/src/built-in-tools/file-ops.js
@@ -7,9 +7,10 @@
  *   Edit   — string-replace with strict-uniqueness check unless `replaceAll`
  *
  * Path-safety is the caller's responsibility — by the time we reach here
- * the BYOK tool executor has already run validatePathWithinCwd() from
- * ws-file-ops/common.js to defeat symlink escape attempts. These helpers
- * receive realpaths that are known to be inside the session cwd.
+ * the BYOK tool executor has already run validateRawPathWithinCwd() from
+ * ws-file-ops/common.js to defeat symlink escape attempts (including a `..`
+ * after a symlinked component, #6923). These helpers receive realpaths that
+ * are known to be inside the session cwd.
  *
  * Each function returns `{ ok: true, ... }` on success or
  * `{ ok: false, code, message }` on a recoverable error (file not found,
@@ -118,7 +119,7 @@ export async function writeFileTool({ filePath, content, mode = 0o644 } = {}) {
 
   // Ensure parent directory exists. recursive:true is a no-op when the
   // directory already exists, so this is safe to call unconditionally.
-  // Path safety was already enforced by the caller (validatePathWithinCwd
+  // Path safety was already enforced by the caller (validateRawPathWithinCwd
   // in byok-tool-executor.js), so the dirname is guaranteed to be
   // inside the workspace cwd.
   if (!existedBefore) {

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -9,17 +9,18 @@
  * the session is in `auto` mode which auto-approves). We don't do
  * permission gating in here; this module is execution only.
  *
- * Path safety is enforced for file tools by validatePathWithinCwd from
- * ws-file-ops/common.js — every file_path is realpath-ed and confirmed
- * to be inside the session cwd before any read/write happens. Symlink
- * escapes are blocked by the realpath-of-deepest-ancestor pattern there
- * (see common.js + the 2026-04-11 production-readiness audit).
+ * Path safety is enforced for file tools by validateRawPathWithinCwd from
+ * ws-file-ops/common.js — every file_path is resolved COMPONENT BY COMPONENT
+ * (open(2)-faithfully) and confirmed to be inside the session cwd before any
+ * read/write happens. Symlink escapes — including a `..` that follows a
+ * symlinked component (#6923) — are blocked by walking the RAW path rather than
+ * a pre-`resolve()`d one (see common.js + the 2026-04-11 production-readiness
+ * audit).
  */
 
-import { resolve, isAbsolute } from 'node:path'
 import { isIP } from 'node:net'
 import { lookup as dnsLookup } from 'node:dns/promises'
-import { validatePathWithinCwd } from './ws-file-ops/common.js'
+import { validateRawPathWithinCwd } from './ws-file-ops/common.js'
 import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec.js'
 import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
 import {
@@ -140,9 +141,14 @@ async function safeResolve(filePath, cwd, cwdRealCache, cwdCacheTtl) {
   if (typeof filePath !== 'string' || filePath.length === 0) {
     throw Object.assign(new Error('file_path is required'), { code: 'EINVAL' })
   }
-  const absolute = isAbsolute(filePath) ? filePath : resolve(cwd, filePath)
-  const { valid, realPath, cwdReal } = await validatePathWithinCwd(
-    absolute,
+  // #6923 — hand the RAW filePath (its `..` intact) to the component-wise walker.
+  // Do NOT pre-`resolve(cwd, filePath)`: `resolve()` collapses a `..` that follows
+  // a symlinked component LEXICALLY, so `link/../x` cancelled the symlink before it
+  // was followed and an escape via a symlink-out-of-workspace + `..` looked in
+  // bounds. validateRawPathWithinCwd walks the raw path open(2)-faithfully so the
+  // true (escaping) destination is seen and rejected.
+  const { valid, realPath, cwdReal } = await validateRawPathWithinCwd(
+    filePath,
     cwd,
     cwdRealCache,
     cwdCacheTtl,
@@ -323,9 +329,10 @@ async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
  */
 async function safeResolveRoot(p, cwd, cwdRealCache, cwdCacheTtl) {
   if (typeof p !== 'string' || p.length === 0) return cwd
-  const absolute = isAbsolute(p) ? p : resolve(cwd, p)
-  const { valid, realPath, cwdReal } = await validatePathWithinCwd(
-    absolute,
+  // #6923 — pass the RAW path; see safeResolve for why pre-`resolve()` is unsafe
+  // (lexical `..` collapse hides a symlink+`..` escape).
+  const { valid, realPath, cwdReal } = await validateRawPathWithinCwd(
+    p,
     cwd,
     cwdRealCache,
     cwdCacheTtl,

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -298,6 +298,19 @@ function realpathDeepestAncestorSync(absPath) {
   throw Object.assign(new Error(`realpathDeepestAncestorSync: path depth exceeds ${_FLOOR_REALPATH_MAX_DEPTH}`), { code: 'ENAMETOOLONG' })
 }
 
+// #6928 — split a raw path into the components BELOW its parsed root, separating
+// on BOTH `/` and `\` regardless of platform. Node accepts forward slashes on
+// Windows, so a platform-`sep`-only split (`\` on Windows) would leave a
+// forward-slash path as ONE component — the component walk would then break and
+// fall back to a lexical `join()`, reopening the exact `..`-after-symlink escape
+// this resolver exists to close. `root` (already parsed by the caller, which
+// starts `resolved` there) is sliced off first so a drive/UNC/`/` root is never
+// walked as an ordinary component (a Windows `C:\` would otherwise appear as a
+// `C:` component and `join` straight back onto the drive root).
+function splitPathBelowRoot(p, root) {
+  return (root ? p.slice(root.length) : p).split(/[/\\]+/)
+}
+
 /**
  * #6921 — resolve `target` against a REAL base by walking it COMPONENT BY
  * COMPONENT, mirroring the kernel's `open(2)` path traversal. This is the crux
@@ -345,10 +358,13 @@ function realpathDeepestAncestorSync(absPath) {
  * @returns {string} the open(2)-faithful resolved absolute real path
  */
 function resolveTargetComponentwiseSync(realBase, target) {
-  // Absolute target ignores the base (as `open`/`resolve` do); start at the fs
-  // root so its own leading components are walked (and symlink-resolved) too.
-  let resolved = isAbsolute(target) ? parse(target).root : realBase
-  const pending = target.split(sep)
+  // Absolute target ignores the base (as `open`/`resolve` do); start at its
+  // parsed root so its own leading components are walked (and symlink-resolved)
+  // too. A relative target (empty root) starts at the base. The root is stripped
+  // BEFORE splitting so it is never re-walked as an ordinary component (#6928).
+  const targetRoot = isAbsolute(target) ? parse(target).root : ''
+  let resolved = targetRoot || realBase
+  const pending = splitPathBelowRoot(target, targetRoot)
   let symlinks = 0
   // Once a component doesn't exist, the rest is a to-be-created tail: no deeper
   // component can be a symlink, so stop lstat-ing and apply pop/append only.
@@ -373,12 +389,13 @@ function resolveTargetComponentwiseSync(realBase, target) {
         throw Object.assign(new Error(`resolveTargetComponentwiseSync: symlink depth exceeds ${_FLOOR_MAX_SYMLINKS}`), { code: 'ELOOP' })
       }
       const link = readlinkSync(candidate)
-      // An absolute link restarts resolution from the fs root; a relative link
-      // resolves from the symlink's PARENT (`resolved`, since `comp` was not
-      // appended). Splice the link's components in at the cursor so they — and
-      // any `..` they contain — are walked next, before the remaining tail.
-      if (isAbsolute(link)) resolved = parse(link).root
-      pending.splice(i, 0, ...link.split(sep))
+      // An absolute link restarts resolution from its parsed root; a relative
+      // link resolves from the symlink's PARENT (`resolved`, since `comp` was not
+      // appended). Splice the link's components (below its root) in at the cursor
+      // so they — and any `..` they contain — are walked next, before the tail.
+      const linkRoot = isAbsolute(link) ? parse(link).root : ''
+      if (linkRoot) resolved = linkRoot
+      pending.splice(i, 0, ...splitPathBelowRoot(link, linkRoot))
     } else {
       resolved = candidate
     }
@@ -416,7 +433,11 @@ function _scanResolvedTarget(base, resolved, secretsOnly) {
   const underCwd = rel === '' ||
     (!isAbsolute(rel) && rel !== '..' && !rel.startsWith('..' + sep))
   const scanned = underCwd ? rel : resolved
-  const segments = scanned.split(sep)
+  // Split on BOTH separators (#6928): `scanned` is a native-sep resolved path
+  // here, but a separator-agnostic split keeps the segment scan robust to any
+  // foreign `\`/`/` that survives (and can never wrongly merge two segments — a
+  // filename cannot contain a separator on the platform that produced it).
+  const segments = scanned.split(/[/\\]+/)
     .filter((s) => s.length > 0 && s !== '..')
     .map((s) => s.toLowerCase())
   for (let i = 0; i < segments.length; i++) {

--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -126,6 +126,19 @@ export async function realpathOfDeepestAncestor(absPath) {
 // (fail closed).
 const _COMPONENTWISE_MAX_SYMLINKS = 40
 
+// #6928 — split a raw path into the components BELOW its parsed root, separating
+// on BOTH `/` and `\` regardless of platform. Node accepts forward slashes on
+// Windows, so a platform-`sep`-only split (`\` on Windows) would leave a
+// forward-slash path as ONE component — the component walk would then break and
+// fall back to a lexical `join()`, reopening the exact `..`-after-symlink escape
+// this resolver exists to close. `root` (already parsed by the caller, which
+// starts `resolved` there) is sliced off first so a drive/UNC/`/` root is never
+// walked as an ordinary component (a Windows `C:\` would otherwise appear as a
+// `C:` component and `join` straight back onto the drive root).
+function splitPathBelowRoot(p, root) {
+  return (root ? p.slice(root.length) : p).split(/[/\\]+/)
+}
+
 /**
  * #6923 — resolve `target` against a REAL base by walking it COMPONENT BY
  * COMPONENT, mirroring the kernel's `open(2)` path traversal. This is the ASYNC
@@ -170,10 +183,13 @@ const _COMPONENTWISE_MAX_SYMLINKS = 40
  * @returns {Promise<string>} the open(2)-faithful resolved absolute real path
  */
 export async function resolveTargetComponentwiseAsync(realBase, target) {
-  // Absolute target ignores the base (as `open`/`resolve` do); start at the fs
-  // root so its own leading components are walked (and symlink-resolved) too.
-  let resolved = isAbsolute(target) ? parse(target).root : realBase
-  const pending = target.split(sep)
+  // Absolute target ignores the base (as `open`/`resolve` do); start at its
+  // parsed root so its own leading components are walked (and symlink-resolved)
+  // too. A relative target (empty root) starts at the base. The root is stripped
+  // BEFORE splitting so it is never re-walked as an ordinary component (#6928).
+  const targetRoot = isAbsolute(target) ? parse(target).root : ''
+  let resolved = targetRoot || realBase
+  const pending = splitPathBelowRoot(target, targetRoot)
   let symlinks = 0
   // Once a component doesn't exist, the rest is a to-be-created tail: no deeper
   // component can be a symlink, so stop lstat-ing and apply pop/append only.
@@ -198,12 +214,13 @@ export async function resolveTargetComponentwiseAsync(realBase, target) {
         throw Object.assign(new Error(`resolveTargetComponentwiseAsync: symlink depth exceeds ${_COMPONENTWISE_MAX_SYMLINKS}`), { code: 'ELOOP' })
       }
       const link = await readlink(candidate)
-      // An absolute link restarts resolution from the fs root; a relative link
-      // resolves from the symlink's PARENT (`resolved`, since `comp` was not
-      // appended). Splice the link's components in at the cursor so they — and
-      // any `..` they contain — are walked next, before the remaining tail.
-      if (isAbsolute(link)) resolved = parse(link).root
-      pending.splice(i, 0, ...link.split(sep))
+      // An absolute link restarts resolution from its parsed root; a relative
+      // link resolves from the symlink's PARENT (`resolved`, since `comp` was not
+      // appended). Splice the link's components (below its root) in at the cursor
+      // so they — and any `..` they contain — are walked next, before the tail.
+      const linkRoot = isAbsolute(link) ? parse(link).root : ''
+      if (linkRoot) resolved = linkRoot
+      pending.splice(i, 0, ...splitPathBelowRoot(link, linkRoot))
     } else {
       resolved = candidate
     }

--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -1,5 +1,5 @@
-import { realpath } from 'fs/promises'
-import { resolve, dirname, basename, join, isAbsolute } from 'path'
+import { realpath, lstat, readlink } from 'fs/promises'
+import { resolve, dirname, basename, join, isAbsolute, parse, sep } from 'path'
 
 /**
  * Shared utilities for file operations: CWD resolution, path validation, exec helpers.
@@ -42,22 +42,23 @@ export async function resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl) {
  * defeats the otherwise-correct 04a2fbbb1 realpath-TOCTOU fix on the
  * new-file code path.
  *
- * #6921 — KNOWN RESIDUAL LIMITATION (shared with the pre-#6921 protected-path
+ * #6921/#6923 — RESIDUAL LIMITATION (shared with the pre-#6921 protected-path
  * floor): this resolves the deepest EXISTING ancestor via `realpath()`, then
  * re-appends the unresolved tail LEXICALLY. It therefore cannot honour a `..`
  * that FOLLOWS a symlinked component the way `open(2)` does — both this helper's
- * `realpath` step AND every caller (which pre-computes `absPath = resolve(...)`,
+ * `realpath` step AND its callers (which pre-compute `absPath = resolve(...)`,
  * collapsing `..` textually before calling in) discard the ordering the kernel
  * uses (follow symlink, THEN apply `..`). The floor closed the same gap by
- * switching to a COMPONENT-BY-COMPONENT walk (see
- * `permission-manager.js` `resolveTargetComponentwiseSync`, #6921). Bringing this
- * BYOK confinement path to parity needs a caller-signature change (pass the RAW
- * target + base, walk componentwise) rather than a local edit here, so it is
- * tracked as a separate follow-up. Impact here is narrower than the floor's — the
+ * switching to a COMPONENT-BY-COMPONENT walk (`permission-manager.js`
+ * `resolveTargetComponentwiseSync`, #6921); the BYOK confinement path was brought
+ * to parity in #6923 via the async {@link resolveTargetComponentwiseAsync} +
+ * {@link validateRawPathWithinCwd} (raw target, walked componentwise), which the
+ * BYOK executor now uses instead of this helper. This helper is retained for the
+ * ws-file-ops (dashboard) callers, which hand in paths they have already
+ * `resolve()`d / `normalize()`d (no surviving `..`), so the evasion cannot reach
+ * it there. Impact of the limitation is narrower than the floor's — the
  * containment check only asks "does it escape the workspace?", and the common
- * chroxy topology (`.claude`/`.git` under the workspace) stays inside it — but a
- * symlink pointing OUT of the workspace followed by `..` can still evade the
- * `startsWith(cwdReal)` check, so this remains worth fixing.
+ * chroxy topology (`.claude`/`.git` under the workspace) stays inside it.
  *
  * @param {string} absPath - Absolute path to resolve (may not exist)
  * @returns {Promise<string>} Real path with all symlink ancestors resolved
@@ -118,6 +119,129 @@ export async function realpathOfDeepestAncestor(absPath) {
   )
 }
 
+// #6923 — symlink-expansion cap for the async component-wise resolver below,
+// matching the kernel's typical MAXSYMLINKS (40) and the sync floor's
+// _FLOOR_MAX_SYMLINKS in permission-manager.js. A chain deeper than this — or a
+// cycle — throws ELOOP, which the raw-path validator's caller treats as a reject
+// (fail closed).
+const _COMPONENTWISE_MAX_SYMLINKS = 40
+
+/**
+ * #6923 — resolve `target` against a REAL base by walking it COMPONENT BY
+ * COMPONENT, mirroring the kernel's `open(2)` path traversal. This is the ASYNC
+ * sibling of `resolveTargetComponentwiseSync` in `permission-manager.js` (#6921),
+ * and the replacement — on the BYOK confinement path — for the
+ * `realpathOfDeepestAncestor(resolve(base, target))` shape above, which could NOT
+ * honour a `..` that FOLLOWS a symlinked component: BOTH `path.resolve()` (in the
+ * caller) AND Node's `realpath` collapse `..` LEXICALLY, so `link/..` cancels the
+ * symlink textually before it is ever followed, whereas `open(2)` follows `link`
+ * to its TARGET and applies `..` from THERE. So `work/agent-x/../../x` (with
+ * `work -> .claude/worktrees`) lexically cancels to a benign in-cwd `x`, but
+ * really lands on `.claude/x`. Only a component walk that applies `..` AFTER
+ * resolving symlinks-so-far (as the kernel does) sees the real destination.
+ *
+ * The walk starts from `realBase` (the session cwd already resolved to its real
+ * path) for a relative target, or from the filesystem root for an absolute
+ * target, and for each remaining component:
+ *   - `''` / `.`      → skip.
+ *   - `..`            → pop to the PARENT of the resolved-so-far real path
+ *                       (`dirname`), i.e. apply `..` AFTER following symlinks so
+ *                       far — NOT lexically on the pre-resolution path.
+ *   - a SYMLINK       → `readlink` it; if the link is absolute, reset the resolved
+ *                       path to the fs root; splice the link's own components into
+ *                       the walk at the current position and keep going (so a
+ *                       relative link resolves from the symlink's parent, and any
+ *                       `..` inside the link is honoured too). Bounded by
+ *                       {@link _COMPONENTWISE_MAX_SYMLINKS} — a deeper chain or a
+ *                       cycle THROWS `ELOOP` (→ fail closed).
+ *   - a NON-symlink   → append it.
+ *   - a NON-EXISTENT tail component (`ENOENT` on the `lstat`) → stop filesystem
+ *                       resolution (nothing deeper can exist, so nothing deeper
+ *                       can be a symlink) and apply the REMAINING components —
+ *                       INCLUDING any `..` — against the resolved-so-far real path
+ *                       by the same pop/append rules. Models a to-be-created file:
+ *                       a `..` in the tail still pops the RESOLVED real path, never
+ *                       the unresolved lexical one.
+ *
+ * A non-ENOENT `lstat`/`readlink` error (EACCES, ELOOP) propagates so the caller
+ * fails closed. Returns the fully resolved absolute real path.
+ * @param {string} realBase  the session cwd, already resolved to its real path
+ * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path value
+ * @returns {Promise<string>} the open(2)-faithful resolved absolute real path
+ */
+export async function resolveTargetComponentwiseAsync(realBase, target) {
+  // Absolute target ignores the base (as `open`/`resolve` do); start at the fs
+  // root so its own leading components are walked (and symlink-resolved) too.
+  let resolved = isAbsolute(target) ? parse(target).root : realBase
+  const pending = target.split(sep)
+  let symlinks = 0
+  // Once a component doesn't exist, the rest is a to-be-created tail: no deeper
+  // component can be a symlink, so stop lstat-ing and apply pop/append only.
+  let tailOnly = false
+  let i = 0
+  while (i < pending.length) {
+    const comp = pending[i]
+    i++
+    if (comp === '' || comp === '.') continue
+    if (comp === '..') { resolved = dirname(resolved); continue }
+    const candidate = join(resolved, comp)
+    if (tailOnly) { resolved = candidate; continue }
+    let st
+    try {
+      st = await lstat(candidate)
+    } catch (err) {
+      if (err.code === 'ENOENT') { tailOnly = true; resolved = candidate; continue }
+      throw err // EACCES etc. — fail closed via the caller
+    }
+    if (st.isSymbolicLink()) {
+      if (++symlinks > _COMPONENTWISE_MAX_SYMLINKS) {
+        throw Object.assign(new Error(`resolveTargetComponentwiseAsync: symlink depth exceeds ${_COMPONENTWISE_MAX_SYMLINKS}`), { code: 'ELOOP' })
+      }
+      const link = await readlink(candidate)
+      // An absolute link restarts resolution from the fs root; a relative link
+      // resolves from the symlink's PARENT (`resolved`, since `comp` was not
+      // appended). Splice the link's components in at the cursor so they — and
+      // any `..` they contain — are walked next, before the remaining tail.
+      if (isAbsolute(link)) resolved = parse(link).root
+      pending.splice(i, 0, ...link.split(sep))
+    } else {
+      resolved = candidate
+    }
+  }
+  return resolved
+}
+
+/**
+ * #6923 — validate that a RAW (un-`resolve`d) target stays within the session
+ * CWD, resolving it `open(2)`-faithfully via {@link resolveTargetComponentwiseAsync}.
+ *
+ * The async sibling / hardened replacement of {@link validatePathWithinCwd} for
+ * the BYOK file-ops confinement path. The old path had the caller pre-compute
+ * `absPath = resolve(cwd, filePath)` and then ran {@link realpathOfDeepestAncestor}
+ * over it — but `resolve()` collapses `..` LEXICALLY, so a `..` that follows a
+ * symlinked component was cancelled before any symlink was followed (the #6921
+ * evasion, on the sync floor). Handing the RAW target (its `..` intact) to a
+ * component-by-component walk closes it: a symlink-out-of-workspace followed by
+ * `..` that lexically looks in-bounds now RESOLVES to its true (escaping)
+ * destination and is rejected.
+ *
+ * FAIL-CLOSED: any error resolving the real target (EACCES on a directory, ELOOP
+ * on a symlink cycle / depth bomb) propagates to the caller, whose own catch
+ * turns it into a rejected tool call — never a silent allow.
+ *
+ * @param {string} rawTarget - The RAW tool-supplied path (relative or absolute; `..` intact)
+ * @param {string} sessionCwd - Session working directory
+ * @param {Map} cwdRealCache - Shared cache
+ * @param {number} cwdCacheTtl - Cache TTL
+ * @returns {Promise<{ valid: boolean, realPath: string, cwdReal: string }>}
+ */
+export async function validateRawPathWithinCwd(rawTarget, sessionCwd, cwdRealCache, cwdCacheTtl) {
+  const cwdReal = await resolveSessionCwd(sessionCwd, cwdRealCache, cwdCacheTtl)
+  const realPath = await resolveTargetComponentwiseAsync(cwdReal, rawTarget)
+  const valid = realPath.startsWith(cwdReal + sep) || realPath === cwdReal
+  return { valid, realPath, cwdReal }
+}
+
 /**
  * Validate that a resolved path is within the session CWD.
  * Follows symlinks to prevent symlink escape.
@@ -126,6 +250,15 @@ export async function realpathOfDeepestAncestor(absPath) {
  * deepest existing ancestor so symlinks in the parent chain still get
  * resolved — see realpathOfDeepestAncestor above for the failure mode
  * this closes.
+ *
+ * NOTE (#6923): this variant takes an already-ABSOLUTE path and resolves via the
+ * deepest-existing-ancestor + lexical-tail helper, so a `..` that follows a
+ * symlinked component is collapsed lexically before the symlink is followed. The
+ * BYOK file-ops path now uses {@link validateRawPathWithinCwd} (raw target +
+ * component-wise walk) to close that evasion; the ws-file-ops (dashboard) callers
+ * still route here with paths they have already `resolve()`d/`normalize()`d (no
+ * surviving `..`), so this function's contract — and its ENAMETOOLONG
+ * depth-ceiling fail-closed — is preserved for them unchanged.
  *
  * @param {string} absPath - Absolute path to validate
  * @param {string} sessionCwd - Session working directory

--- a/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
+++ b/packages/server/tests/permission-manager-floor-symlink-evasion.test.js
@@ -352,4 +352,57 @@ describe('protected-path floor resolves symlinks (#6851)', () => {
       'an absolute existing base resolves normally and a benign target is not floored',
     )
   })
+
+  // ==========================================================================
+  // #6928 — the component split must be SEPARATOR-AGNOSTIC (`/` AND `\`). Node
+  // accepts forward slashes on Windows, so the old `target.split(path.sep)` (`\`
+  // on Windows) left a forward-slash path as ONE component: the walk broke and
+  // fell back to a lexical `join()` that collapses `..` textually — reopening the
+  // symlink+`..` evasion #6921 closed, and mis-handling Windows drive roots.
+  // These run on POSIX but prove the LOGIC is separator-agnostic by feeding
+  // backslash / mixed separators a POSIX `sep='/'` split would NOT break apart.
+  // ==========================================================================
+  it('#6928: the `work\\agent-x\\..\\..\\settings.local.json` evasion is floored regardless of `/` vs `\\` separators', () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL')
+    symlinkSync(join(root, '.claude/worktrees'), join(root, 'work'))
+    const cwd = root // session runs at the repo root; work -> .claude/worktrees
+
+    const forms = [
+      'work/agent-x/../../settings.local.json',      // POSIX separators (canonical)
+      'work\\agent-x\\..\\..\\settings.local.json',  // Windows separators (all backslash)
+      'work/agent-x\\..\\..\\settings.local.json',   // mixed `/` and `\`
+    ]
+    for (const f of forms) {
+      assert.equal(isProtectedPathTarget({ file_path: f }, cwd), true, `write floor must flag the evasion regardless of separator: ${f}`)
+      assert.equal(isSecretReadTarget({ file_path: f }, cwd), true, `read/credential floor must flag settings.local.json regardless of separator: ${f}`)
+    }
+  })
+
+  it('#6928: a Windows-style BACKSLASH path exposes its `.git` segment to the floor (split component-wise, not one blob)', () => {
+    // A pure-backslash path with no forward slashes: the old `sep='/'` split left
+    // it as ONE segment (no `.git` visible → missed); the fix splits it so the
+    // protected `.git` segment is caught, under BOTH the write and read floors.
+    const cwd = root
+    const winPath = 'Users\\me\\repo\\.git\\config'
+    assert.equal(isProtectedPathTarget({ file_path: winPath }, cwd), true, 'the `.git` segment inside a backslash path must be floored')
+    assert.equal(isSecretReadTarget({ file_path: winPath }, cwd), true, '.git/config embeds credentials — the read floor must flag it too')
+  })
+
+  it('#6928: an ABSOLUTE (rooted) target is walked from its root without treating the root as a component — a `.git` in an absolute path is still floored', () => {
+    // The leading-root case: the parsed root (`/`) must be stripped and never
+    // walked as a `.`/`..`-poppable component; the walk resolves the REAL .git.
+    mkdirSync(join(root, 'repo/.git'), { recursive: true })
+    writeFileSync(join(root, 'repo/.git/config'), '[core]\n')
+    const cwd = join(root, 'repo')
+    const abs = join(root, 'repo/.git/config') // e.g. /tmp/.../repo/.git/config
+    assert.equal(isProtectedPathTarget({ file_path: abs }, cwd), true)
+    assert.equal(isSecretReadTarget({ file_path: abs }, cwd), true)
+  })
+
+  it('#6928: does NOT over-flag a benign relative BACKSLASH path', () => {
+    // The fix must split separators, not flag anything containing a `\`: a benign
+    // in-workspace backslash path resolves to a plain file and stays unfloored.
+    assert.equal(isProtectedPathTarget({ file_path: 'src\\lib\\util.js' }, root), false)
+  })
 })

--- a/packages/server/tests/ws-file-ops-raw-path-symlink-evasion.test.js
+++ b/packages/server/tests/ws-file-ops-raw-path-symlink-evasion.test.js
@@ -1,0 +1,208 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, readFileSync, rmSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { validateRawPathWithinCwd, resolveTargetComponentwiseAsync } from '../src/ws-file-ops/common.js'
+import { executeBuiltinTool } from '../src/byok-tool-executor.js'
+
+/**
+ * #6923 — async parity for the `..`-after-symlink evasion, on the BYOK file-ops
+ * confinement path (the async sibling of the sync protected-path floor closed in
+ * #6921 / #6920). The old confinement pre-computed `absPath = resolve(cwd, path)`
+ * and ran `realpathOfDeepestAncestor` over it — but BOTH `path.resolve()` AND
+ * Node's `realpath` collapse `..` LEXICALLY, so a `..` that FOLLOWS a symlinked
+ * component was cancelled textually before any symlink was followed. `open(2)`
+ * (any raw `fs` write) follows the symlink FIRST and applies `..` from the target.
+ *
+ * The fix hands the RAW target (its `..` intact) to a COMPONENT-BY-COMPONENT walk
+ * (`resolveTargetComponentwiseAsync`) via `validateRawPathWithinCwd`, so a symlink
+ * that (with a trailing `..`) escapes the workspace is now resolved to its true
+ * destination and rejected. Both PoCs below build the exact issue topologies on
+ * REAL disk and PROVE (a) the raw path physically lands on the protected file, and
+ * (b) the async confinement now FLAGS it (valid=false / the BYOK executor errors).
+ */
+describe('BYOK raw-path symlink-`..` evasion (#6923)', () => {
+  let root
+  const cwdRealCache = () => new Map()
+  const cwdCacheTtl = 30_000
+
+  beforeEach(() => {
+    // realpath so the temp root has no symlink prefix of its own (macOS /tmp ->
+    // /private/tmp) that would confuse the startsWith() containment assertions.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'chroxy-raw-evasion-')))
+  })
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true })
+  })
+
+  // ==========================================================================
+  // PoC 1 — symlinked cwd-prefix + `..`. The REAL chroxy topology: the session
+  // runs inside the worktree (.claude/worktrees/agent-x), and the protected
+  // .claude/settings.local.json lives ABOVE it. `work -> .claude/worktrees`
+  // (a plausible convenience symlink inside the worktree) plus a trailing `..`
+  // climbs back up into the parent .claude, escaping the worktree cwd.
+  // ==========================================================================
+  it('PoC 1: `work/agent-x/../../settings.local.json` (work -> .claude/worktrees) resolves to the REAL .claude/settings.local.json and is flagged', async () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL')
+    const cwd = join(root, '.claude/worktrees/agent-x') // session cwd = the worktree
+    symlinkSync(join(root, '.claude/worktrees'), join(cwd, 'work'))
+    const evasion = 'work/agent-x/../../settings.local.json'
+
+    // path.resolve() LEXICALLY collapses the `..`s to a benign IN-cwd target —
+    // exactly why the pre-fix (pre-`resolve()` + realpath) confinement missed it.
+    assert.equal(resolve(cwd, evasion), join(cwd, 'settings.local.json'))
+    assert.ok(resolve(cwd, evasion).startsWith(cwd + '/'), 'lexical resolve stays inside the worktree — the blind spot')
+
+    // PROOF the target is genuinely dangerous: a raw open(2)-style write through
+    // the exact path physically clobbers the REAL .claude/settings.local.json
+    // (the file that governs the permission system itself). The write path is
+    // built by STRING concat, NOT path.join — path.join would lexically collapse
+    // the `..`s and never traverse the symlink.
+    writeFileSync(`${cwd}/${evasion}`, 'PWNED')
+    assert.equal(
+      readFileSync(join(root, '.claude/settings.local.json'), 'utf8'),
+      'PWNED',
+      'the raw write really lands on the protected .claude/settings.local.json',
+    )
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL') // reset
+
+    // The async confinement now resolves the RAW path open(2)-faithfully to the
+    // real protected file (ABOVE the worktree cwd) and FLAGS it as an escape.
+    const { valid, realPath } = await validateRawPathWithinCwd(evasion, cwd, cwdRealCache(), cwdCacheTtl)
+    assert.equal(valid, false, 'the symlink+`..` escape must be flagged (valid=false)')
+    assert.equal(realPath, join(root, '.claude/settings.local.json'), 'realPath reflects the TRUE destination, not the lexical collapse')
+  })
+
+  it('PoC 1 end-to-end: the BYOK Write executor rejects the evasion and does NOT clobber the protected file', async () => {
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL')
+    const cwd = join(root, '.claude/worktrees/agent-x')
+    symlinkSync(join(root, '.claude/worktrees'), join(cwd, 'work'))
+
+    const r = await executeBuiltinTool({
+      toolName: 'Write',
+      input: { file_path: 'work/agent-x/../../settings.local.json', content: 'PWNED' },
+      cwd,
+      cwdRealCache: cwdRealCache(),
+      cwdCacheTtl,
+    })
+    assert.equal(r.isError, true, 'the executor must reject the escape')
+    assert.match(r.content, /outside workspace/)
+    assert.equal(readFileSync(join(root, '.claude/settings.local.json'), 'utf8'), 'ORIGINAL', 'protected file untouched')
+  })
+
+  // ==========================================================================
+  // PoC 2 — symlinked TARGET component + `..`. glink -> repo/.git/hooks ;
+  // `glink/../config` follows glink INTO .git/hooks, then `..` climbs to .git,
+  // landing on .git/config (a credential file — a remote URL can embed a PAT),
+  // which sits ABOVE the session cwd (repo/work).
+  // ==========================================================================
+  it('PoC 2: `glink/../config` (glink -> .git/hooks) resolves to the REAL .git/config and is flagged', async () => {
+    mkdirSync(join(root, 'repo/.git/hooks'), { recursive: true })
+    mkdirSync(join(root, 'repo/work'), { recursive: true })
+    writeFileSync(join(root, 'repo/.git/config'), '[core]\n')
+    const cwd = join(root, 'repo/work') // session runs in a repo subdir
+    symlinkSync(join(root, 'repo/.git/hooks'), join(cwd, 'glink'))
+    const evasion = 'glink/../config'
+
+    // Lexically benign (glink/.. cancels) and IN-cwd — the old confinement missed it.
+    assert.equal(resolve(cwd, evasion), join(cwd, 'config'))
+
+    // PROOF: a raw write (STRING concat, not path.join) lands on the real .git/config.
+    writeFileSync(`${cwd}/${evasion}`, 'PWNED')
+    assert.equal(readFileSync(join(root, 'repo/.git/config'), 'utf8'), 'PWNED', 'the raw write really lands on .git/config')
+
+    const { valid, realPath } = await validateRawPathWithinCwd(evasion, cwd, cwdRealCache(), cwdCacheTtl)
+    assert.equal(valid, false, 'the glink+`..` escape must be flagged')
+    assert.equal(realPath, join(root, 'repo/.git/config'), 'realPath reflects the TRUE .git/config destination')
+  })
+
+  // ==========================================================================
+  // The component walk must NOT over-flag a benign `link/..` that lands safe.
+  // ==========================================================================
+  it('does NOT over-flag a benign `link/..` that resolves back INSIDE the cwd', async () => {
+    // safe/inner -> safe/other ; `inner/../file.js` follows inner into other,
+    // then `..` climbs back to safe -> safe/file.js. No escape: the walk resolves
+    // the symlink correctly but the destination stays inside cwd, so valid=true.
+    mkdirSync(join(root, 'safe/other'), { recursive: true })
+    symlinkSync(join(root, 'safe/other'), join(root, 'safe/inner'))
+    const cwd = join(root, 'safe')
+
+    const { valid, realPath } = await validateRawPathWithinCwd('inner/../file.js', cwd, cwdRealCache(), cwdCacheTtl)
+    assert.equal(valid, true, 'a symlink+`..` that lands back inside cwd must NOT be flagged')
+    assert.equal(realPath, join(cwd, 'file.js'))
+
+    // And it genuinely lands where we claim (safe/file.js).
+    writeFileSync(`${cwd}/inner/../file.js`, 'x')
+    assert.equal(readFileSync(join(root, 'safe/file.js'), 'utf8'), 'x')
+  })
+
+  it('accepts an ordinary relative new-file target under the cwd', async () => {
+    mkdirSync(join(root, 'src'), { recursive: true })
+    const cwd = root
+    const { valid, realPath } = await validateRawPathWithinCwd('src/new.txt', cwd, cwdRealCache(), cwdCacheTtl)
+    assert.equal(valid, true)
+    assert.equal(realPath, join(root, 'src/new.txt'))
+  })
+
+  // ==========================================================================
+  // Fail-closed: a symlink CYCLE (or a chain past MAXSYMLINKS) must THROW so the
+  // caller rejects the operation — never a lexical guess.
+  // ==========================================================================
+  it('fails closed (throws ELOOP) on a symlink cycle', async () => {
+    symlinkSync(join(root, 'b'), join(root, 'a')) // a -> b
+    symlinkSync(join(root, 'a'), join(root, 'b')) // b -> a
+    await assert.rejects(
+      validateRawPathWithinCwd('a/x', root, cwdRealCache(), cwdCacheTtl),
+      (err) => err.code === 'ELOOP',
+    )
+  })
+
+  it('BYOK executor surfaces the symlink cycle as a tool error (fail closed)', async () => {
+    symlinkSync(join(root, 'b'), join(root, 'a'))
+    symlinkSync(join(root, 'a'), join(root, 'b'))
+    const r = await executeBuiltinTool({
+      toolName: 'Read',
+      input: { file_path: 'a/x' },
+      cwd: root,
+      cwdRealCache: cwdRealCache(),
+      cwdCacheTtl,
+    })
+    assert.equal(r.isError, true)
+  })
+
+  // ==========================================================================
+  // No regression: the classic symlinked-PARENT escape (no `..`) that the
+  // original realpath-of-deepest-ancestor guard already caught stays rejected.
+  // ==========================================================================
+  it('still rejects the classic symlinked-parent escape (`.venv -> /outside`, `.venv/bin/evil.sh`)', async () => {
+    const outside = realpathSync(mkdtempSync(join(tmpdir(), 'chroxy-raw-outside-')))
+    try {
+      symlinkSync(outside, join(root, '.venv'))
+      const { valid, realPath } = await validateRawPathWithinCwd('.venv/bin/evil.sh', root, cwdRealCache(), cwdCacheTtl)
+      assert.equal(valid, false, 'a symlinked parent pointing out of the workspace must be flagged')
+      assert.ok(realPath.startsWith(outside + '/'), 'the walk chases the symlink to the outside location')
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  // ==========================================================================
+  // resolveTargetComponentwiseAsync unit coverage — the open(2)-faithful crux.
+  // ==========================================================================
+  it('resolveTargetComponentwiseAsync applies `..` AFTER following a symlink (kernel order)', async () => {
+    mkdirSync(join(root, 'real/deep'), { recursive: true })
+    symlinkSync(join(root, 'real/deep'), join(root, 'link')) // link -> real/deep
+    // link/../sibling: follow link -> real/deep, `..` -> real, sibling -> real/sibling
+    const resolved = await resolveTargetComponentwiseAsync(root, 'link/../sibling')
+    assert.equal(resolved, join(root, 'real/sibling'), '`..` must pop the symlink TARGET, not its lexical parent')
+  })
+
+  it('resolveTargetComponentwiseAsync walks an absolute target from the fs root, ignoring the base', async () => {
+    mkdirSync(join(root, 'a/b'), { recursive: true })
+    const resolved = await resolveTargetComponentwiseAsync(join(root, 'unrelated'), join(root, 'a/b/c.txt'))
+    assert.equal(resolved, join(root, 'a/b/c.txt'))
+  })
+})

--- a/packages/server/tests/ws-file-ops-raw-path-symlink-evasion.test.js
+++ b/packages/server/tests/ws-file-ops-raw-path-symlink-evasion.test.js
@@ -205,4 +205,57 @@ describe('BYOK raw-path symlink-`..` evasion (#6923)', () => {
     const resolved = await resolveTargetComponentwiseAsync(join(root, 'unrelated'), join(root, 'a/b/c.txt'))
     assert.equal(resolved, join(root, 'a/b/c.txt'))
   })
+
+  // ==========================================================================
+  // #6928 — the component split must be SEPARATOR-AGNOSTIC (`/` AND `\`). Node
+  // accepts forward slashes on Windows, so the old `target.split(path.sep)` (`\`
+  // on Windows) left a forward-slash path as ONE component: the component walk
+  // broke and fell back to a lexical `join()` that collapses `..` textually —
+  // reopening the exact symlink+`..` escape this resolver closes. These tests run
+  // on POSIX but prove the LOGIC is separator-agnostic by feeding backslash /
+  // mixed separators (which a POSIX `sep='/'` split would NOT break apart) and a
+  // rooted target whose root must never be walked as a `..`-poppable component.
+  // ==========================================================================
+  it('#6928: backslash and mixed separators resolve IDENTICALLY to the forward-slash form (and stay flagged)', async () => {
+    // The PoC 1 topology — session cwd IS the worktree; `work -> .claude/worktrees`
+    // inside it, a trailing `..` climbs back into the parent .claude (above cwd).
+    mkdirSync(join(root, '.claude/worktrees/agent-x'), { recursive: true })
+    writeFileSync(join(root, '.claude/settings.local.json'), 'ORIGINAL')
+    const cwd = join(root, '.claude/worktrees/agent-x')
+    symlinkSync(join(root, '.claude/worktrees'), join(cwd, 'work'))
+
+    const forms = [
+      'work/agent-x/../../settings.local.json',      // POSIX separators (canonical)
+      'work\\agent-x\\..\\..\\settings.local.json',  // Windows separators (all backslash)
+      'work/agent-x\\..\\..\\settings.local.json',   // mixed `/` and `\`
+    ]
+    for (const f of forms) {
+      const { valid, realPath } = await validateRawPathWithinCwd(f, cwd, cwdRealCache(), cwdCacheTtl)
+      assert.equal(realPath, join(root, '.claude/settings.local.json'), `separator-agnostic walk must reach the REAL target: ${f}`)
+      assert.equal(valid, false, `the symlink+\`..\` escape must be flagged regardless of separator: ${f}`)
+    }
+  })
+
+  it('#6928: a plain relative BACKSLASH path is walked component-by-component, not treated as one blob', async () => {
+    mkdirSync(join(root, 'real/deep'), { recursive: true })
+    // With the platform `sep='/'` split, `real\deep\file.txt` would be ONE
+    // component (a literal filename with backslashes); the fix splits it.
+    const resolved = await resolveTargetComponentwiseAsync(root, 'real\\deep\\file.txt')
+    assert.equal(resolved, join(root, 'real/deep/file.txt'))
+  })
+
+  it('#6928: a rooted target strips its root — `..` at the fs root is a no-op, the root is never walked as a component', async () => {
+    // A leading-root absolute target: the parsed root (`/`) must be stripped and
+    // never treated as a `.`/`..`-poppable component. `..` at the root stays at
+    // the root (kernel semantics), so `/../..` resolves to `/`, not underflow.
+    assert.equal(await resolveTargetComponentwiseAsync(root, '/../..'), '/')
+
+    // A Windows-style backslash path is likewise split component-wise (never one
+    // blob). On POSIX `parse` can't recognise the `C:` drive, so it walks as a
+    // relative path safely UNDER the base; on win32 `parse` strips the `C:\` root.
+    assert.equal(
+      await resolveTargetComponentwiseAsync(root, 'Windows\\System32\\drivers'),
+      join(root, 'Windows/System32/drivers'),
+    )
+  })
 })


### PR DESCRIPTION
Closes #6923

## Problem
The BYOK file-ops confinement (`byok-tool-executor.js` → `validatePathWithinCwd` in `ws-file-ops/common.js`) shared the same `..`-after-symlink evasion the sync protected-path floor had before #6921/#6920. The callers pre-computed `absPath = resolve(cwd, filePath)` and then ran `realpathOfDeepestAncestor` over it — but **both** `path.resolve()` and Node's `realpath` collapse `..` **lexically**, so a `..` that follows a symlinked component is cancelled textually *before* any symlink is followed. `open(2)` (any raw `fs` write) follows the symlink **first** and applies `..` from its target, so a symlink-out-of-workspace plus a trailing `..` looked in-bounds while a raw write landed elsewhere.

Confirmed on real disk: `work/agent-x/../../settings.local.json` (with `work -> .claude/worktrees`, session cwd = the worktree) lexically collapses to a benign in-cwd path, but a raw kernel write physically clobbers the real `.claude/settings.local.json`. The pre-fix BYOK executor **accepted** the write (`isError: false`), silently redirecting it to the collapsed benign location — treating an escaping raw path as safe.

## Approach — port the component-wise walk to async (approach a)
- **`resolveTargetComponentwiseAsync`** (new, `ws-file-ops/common.js`): an exact async mirror of `resolveTargetComponentwiseSync` (`permission-manager.js`, #6921) — append normal names, pop on `..` against the resolved-so-far **real** path (post-symlink), follow symlinks via `readlink` with an absolute/relative splice and a MAXSYMLINKS(40) cap, and once a component is ENOENT apply the remaining tail (including `..`) by the same pop/append rules. Non-blocking (`fs/promises`), unlike routing the async path through the sync resolver.
- **`validateRawPathWithinCwd`** (new): resolves the cwd to its real path, walks the **raw** target (its `..` intact) component-wise, and containment-checks the result. Fail-closed: EACCES/ELOOP/depth propagate to the caller's `catch` → rejected tool call.
- **`safeResolve` / `safeResolveRoot`** (`byok-tool-executor.js`) now route through it, **dropping the caller-side `resolve()`** that lexically collapsed `..` — the required change so the raw path reaches the walk.

`validatePathWithinCwd` / `realpathOfDeepestAncestor` and the **ws-file-ops (dashboard) callers are left unchanged** — those hand in already-`resolve()`d / `normalize()`d paths (no surviving `..`), so the evasion can't reach them, and their `ENAMETOOLONG` depth-ceiling fail-closed contract (asserted by existing tests) is preserved.

## Both PoCs closed (physical-write tests, real disk)
`tests/ws-file-ops-raw-path-symlink-evasion.test.js` — the write path is built with **string concat, not `path.join`** (which would collapse `..` lexically):
1. **symlinked cwd-prefix + `..`** — `work -> .claude/worktrees`, `work/agent-x/../../settings.local.json` → raw write clobbers the real `.claude/settings.local.json`; the async floor now resolves faithfully to it and returns `valid=false`; the BYOK `Write` executor rejects it end-to-end and the protected file is untouched.
2. **symlinked target-component + `..`** — `glink -> .git/hooks`, `glink/../config` → raw write clobbers the real `.git/config`; flagged `valid=false`.

Plus: a benign `link/..` that lands back inside cwd (**not** over-flagged), an ordinary relative new-file target (accepted), a symlink cycle → **ELOOP fail-closed** (unit + BYOK-executor), and the classic no-`..` symlinked-parent escape still rejected (no regression), plus two `resolveTargetComponentwiseAsync` unit cases.

## Verification
- New suite: **10/10 pass**.
- Floor + BYOK + common suites (`permission-manager-floor-symlink-evasion`, `permission-manager-protected-path-floor`, `byok-tools`, `ws-file-ops-common`, `byok-tool-executor`, new): **210/210 pass**.
- All `packages/server/scripts/lint-*.sh`: **green**. eslint on touched src files: **clean**.
- Three adjacent `ws-file-ops-*` files fail **only** on a missing optional dep (`@anthropic-ai/claude-agent-sdk`) in this worktree's `node_modules` — confirmed pre-existing (identical failure with the change stashed); resolves in CI.