### PR TITLE
feat: surface active Codex sandbox mode in session_info (#6901)

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -4,6 +4,9 @@ import * as Clipboard from 'expo-clipboard';
 import { resolveContextWindow, contextOccupancyTokens, contextFillPercent } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm, SessionIntervention } from '@chroxy/store-core';
 import { formatCostBadge } from '@chroxy/store-core';
+// #6901: single-source the Codex sandbox label/description for the read-only
+// active-sandbox badge (same list the create-time selector uses).
+import { CODEX_SANDBOX_MODE_META, type CodexSandboxMode } from '@chroxy/protocol';
 import type { ModelInfo, ContextOccupancy, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer, PermissionMode } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
@@ -122,6 +125,12 @@ export interface SettingsBarProps {
   // chips are hidden entirely.
   modelSwitchSupported?: boolean;
   permissionModeSwitchSupported?: boolean;
+  // #6901: active/resolved Codex sandbox mode for a running codex session
+  // (from session_list — only codex sessions carry it). When set, a READ-ONLY
+  // badge shows the current sandbox. Display-only: Codex applies the sandbox
+  // once at thread start, so changing it needs a new session. `null`/`undefined`
+  // (every non-codex session) renders nothing.
+  codexSandbox?: CodexSandboxMode | null;
 }
 
 // -- Helpers --
@@ -239,6 +248,7 @@ export function SettingsBar({
   provider,
   modelSwitchSupported = true,
   permissionModeSwitchSupported = true,
+  codexSandbox = null,
 }: SettingsBarProps) {
   // Elapsed time ticker — only runs when expanded with active agents
   const [now, setNow] = useState(Date.now());
@@ -589,6 +599,32 @@ export function SettingsBar({
                   >
                     {hint}
                   </Text>
+                );
+              })()}
+              {/* #6901: read-only Codex sandbox badge. session_list carries
+                  `codexSandbox` only for codex sessions; it's display-only —
+                  Codex applies the sandbox once at thread start, so a change
+                  needs a new session (docs/design/codex-permission-model.md §5).
+                  Label/description single-sourced from CODEX_SANDBOX_MODE_META. */}
+              {codexSandbox && (() => {
+                const meta = CODEX_SANDBOX_MODE_META.find((m) => m.id === codexSandbox);
+                const label = meta?.label ?? codexSandbox;
+                const hint = `${meta?.description ?? ''} Changing the sandbox requires a new session.`.trim();
+                return (
+                  <>
+                    <View style={styles.chipRow}>
+                      <View style={styles.chipReadOnly} testID="codex-sandbox-badge">
+                        <Text style={styles.chipReadOnlyText}>{`Sandbox: ${label}`}</Text>
+                      </View>
+                    </View>
+                    <Text
+                      style={styles.permissionModeHint}
+                      testID="codex-sandbox-hint"
+                      accessibilityLabel={`Codex sandbox: ${label}. ${hint}`}
+                    >
+                      {hint}
+                    </Text>
+                  </>
                 );
               })()}
               {(lastResultCost != null || sessionCost != null || contextOccupancy) && (

--- a/packages/app/src/components/__tests__/SettingsBarCodexSandbox.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarCodexSandbox.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Render tests for the SettingsBar read-only Codex sandbox badge (#6901).
+ *
+ * session_list carries `codexSandbox` only for codex sessions; the SettingsBar
+ * renders a read-only badge showing the active/resolved sandbox mode with copy
+ * noting a change requires a new session (Codex applies the sandbox at thread
+ * start — display-only, not an in-place switch).
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { SettingsBar } from '../SettingsBar';
+import type { CodexSandboxMode } from '@chroxy/protocol';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function makeProps(overrides: Partial<{ codexSandbox: CodexSandboxMode | null }> = {}) {
+  return {
+    expanded: true,
+    onToggle: () => {},
+    activeModel: 'gpt-5-codex',
+    availableModels: [],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextOccupancy: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+describe('SettingsBar codex sandbox badge (#6901)', () => {
+  it('renders the read-only badge with the mode label for a codex session', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ codexSandbox: 'read-only' })} />);
+    });
+    const root = tree!.root;
+    const badge = root.findByProps({ testID: 'codex-sandbox-badge' });
+    // Label single-sourced from CODEX_SANDBOX_MODE_META ('Read-only').
+    expect(collectVisibleText(badge)).toContain('Read-only');
+  });
+
+  it('surfaces the mid-session constraint in the sandbox hint', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ codexSandbox: 'workspace-write' })} />);
+    });
+    const root = tree!.root;
+    const hint = root.findByProps({ testID: 'codex-sandbox-hint' });
+    expect(collectVisibleText(hint)).toMatch(/new session/i);
+  });
+
+  it('renders nothing when codexSandbox is null (non-codex session)', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ codexSandbox: null })} />);
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'codex-sandbox-badge' })).toThrow();
+    expect(() => root.findByProps({ testID: 'codex-sandbox-hint' })).toThrow();
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -277,6 +277,13 @@ export function SessionScreen() {
     const id = s.activeSessionId;
     return id ? s.sessions.find((sess) => sess.sessionId === id)?.provider ?? null : null;
   });
+  // #6901 — active session's resolved Codex sandbox mode (only codex sessions
+  // carry it in session_list). Drives the read-only sandbox badge in the
+  // SettingsBar. Display-only: changing it needs a new session.
+  const activeSessionCodexSandbox = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessions.find((sess) => sess.sessionId === id)?.codexSandbox ?? null : null;
+  });
   // #5731 — gate the SettingsBar model/permission chips on the active provider's
   // capabilities, mirroring the dashboard's dropdownFlags. Default to supported
   // (true) unless the provider explicitly reports the capability as false, so a
@@ -1386,6 +1393,7 @@ export function SessionScreen() {
           provider={activeSessionProvider}
           modelSwitchSupported={providerCaps.modelSwitchSupported}
           permissionModeSwitchSupported={providerCaps.permissionModeSwitchSupported}
+          codexSandbox={activeSessionCodexSandbox}
         />
       )}
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -171,6 +171,14 @@ export function App() {
   const activeSessionProvider = useConnectionStore(s =>
     s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.provider ?? null,
   )
+  // #6901: active session's resolved Codex sandbox mode (only codex sessions
+  // carry it — session_list omits the field for every other provider). Drives
+  // the read-only sandbox badge in the header settings dropdown so a running
+  // codex session shows its current sandbox. Display-only: changing it needs a
+  // new session (Codex applies the sandbox once at thread start).
+  const activeSessionCodexSandbox = useConnectionStore(s =>
+    s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.codexSandbox ?? null,
+  )
   // #5986 (epic #5982): the embedded user-shell terminal. The server advertises
   // `userShell` in auth_ok.capabilities only when config.userShell.enabled is on
   // AND the connecting client holds the primary token class, so gating the "New
@@ -2184,6 +2192,7 @@ export function App() {
         permissionMode={permissionMode}
         onPermissionModeChange={setPermissionMode}
         showPermissionMode={dropdownFlags.showPermissionMode}
+        codexSandbox={activeSessionCodexSandbox}
         showThinkingLevel={dropdownFlags.showThinkingLevel}
         thinkingLevel={thinkingLevel}
         onThinkingLevelChange={(level) => setThinkingLevel(level as 'default' | 'high' | 'max')}

--- a/packages/dashboard/src/components/AppHeader.tsx
+++ b/packages/dashboard/src/components/AppHeader.tsx
@@ -44,6 +44,8 @@ export interface AppHeaderProps {
   permissionMode: ComponentProps<typeof ChatSettingsDropdown>['permissionMode']
   onPermissionModeChange: ComponentProps<typeof ChatSettingsDropdown>['onPermissionModeChange']
   showPermissionMode: boolean
+  // #6901: active codex session's resolved sandbox mode (read-only badge).
+  codexSandbox: ComponentProps<typeof ChatSettingsDropdown>['codexSandbox']
   showThinkingLevel: boolean
   thinkingLevel: ComponentProps<typeof ChatSettingsDropdown>['thinkingLevel']
   onThinkingLevelChange: (level: string) => void
@@ -176,6 +178,7 @@ export function AppHeader(props: AppHeaderProps) {
           permissionMode={props.permissionMode}
           onPermissionModeChange={props.onPermissionModeChange}
           showPermissionMode={props.showPermissionMode}
+          codexSandbox={props.codexSandbox}
           showThinkingLevel={props.showThinkingLevel}
           thinkingLevel={props.thinkingLevel}
           onThinkingLevelChange={level => props.onThinkingLevelChange(level as 'default' | 'high' | 'max')}

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -312,4 +312,37 @@ describe('ChatSettingsDropdown', () => {
       expect(legacyTitle === null || legacyTitle === '').toBe(true)
     })
   })
+
+  // #6901 — read-only Codex sandbox badge. session_list carries `codexSandbox`
+  // only for codex sessions; the badge is display-only (a change needs a new
+  // session — Codex applies the sandbox at thread start).
+  describe('#6901 codex sandbox read-only badge', () => {
+    it('renders a read-only badge with the mode label when codexSandbox is set', () => {
+      renderDropdown({ codexSandbox: 'read-only' })
+      const badge = screen.getByTestId('codex-sandbox-badge')
+      expect(badge).toBeInTheDocument()
+      expect(badge.tagName.toLowerCase()).not.toBe('select')
+      // Label single-sourced from CODEX_SANDBOX_MODE_META ('Read-only').
+      expect(badge.textContent).toContain('Read-only')
+    })
+
+    it('surfaces the mid-session constraint in the badge tooltip', () => {
+      renderDropdown({ codexSandbox: 'workspace-write' })
+      const badge = screen.getByTestId('codex-sandbox-badge')
+      const title = badge.getAttribute('title') || ''
+      expect(title).toContain('Workspace write')
+      expect(title).toMatch(/new session/i)
+      expect(badge.getAttribute('aria-label')).toBe(title)
+    })
+
+    it('does NOT render the badge for a non-codex session (codexSandbox null)', () => {
+      renderDropdown({ codexSandbox: null })
+      expect(screen.queryByTestId('codex-sandbox-badge')).toBeNull()
+    })
+
+    it('does NOT render the badge when codexSandbox is omitted entirely', () => {
+      renderDropdown()
+      expect(screen.queryByTestId('codex-sandbox-badge')).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -11,6 +11,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ModelInfo } from '../store/types'
 import type { PermissionMode } from '@chroxy/store-core'
+// #6901: single-source the sandbox label/description from protocol's
+// CODEX_SANDBOX_MODE_META so the read-only badge below never re-declares the
+// copy (same list the create-time selector uses).
+import { CODEX_SANDBOX_MODE_META, type CodexSandboxMode } from '@chroxy/protocol'
 import { ModelPickerModal } from './ModelPickerModal'
 
 /**
@@ -67,6 +71,12 @@ export interface ChatSettingsDropdownProps {
   // a permission-mode switch (e.g. Codex). Default true keeps Claude behavior
   // unchanged. #3835.
   showPermissionMode?: boolean
+  // #6901: the active/resolved Codex sandbox mode for a running codex session
+  // (from session_list — only codex sessions carry it). When set, a READ-ONLY
+  // badge renders showing the current sandbox. Codex applies the sandbox once at
+  // thread start, so this is display-only — changing it needs a new session.
+  // `null`/`undefined` (every non-codex session) renders nothing.
+  codexSandbox?: CodexSandboxMode | null
   showThinkingLevel: boolean
   thinkingLevel: string | null
   onThinkingLevelChange: (level: string) => void
@@ -86,6 +96,7 @@ export function ChatSettingsDropdown({
   permissionMode,
   onPermissionModeChange,
   showPermissionMode = true,
+  codexSandbox = null,
   showThinkingLevel,
   thinkingLevel,
   onThinkingLevelChange,
@@ -209,6 +220,28 @@ export function ChatSettingsDropdown({
           ))}
         </select>
       )}
+
+      {/* #6901: read-only Codex sandbox badge. Codex applies the sandbox once at
+          thread start, so it can't be switched mid-session — a change needs a new
+          session (docs/design/codex-permission-model.md §5). Present only for
+          codex sessions (session_list carries `codexSandbox` for no other
+          provider). Label/description single-sourced from CODEX_SANDBOX_MODE_META. */}
+      {codexSandbox && (() => {
+        const meta = CODEX_SANDBOX_MODE_META.find(m => m.id === codexSandbox)
+        const title = `Codex sandbox: ${meta?.label ?? codexSandbox}. ${meta?.description ?? ''} Changing the sandbox requires a new session — Codex applies it at thread start.`
+        return (
+          <span
+            data-testid="codex-sandbox-badge"
+            data-kind="codex-sandbox"
+            className="chat-settings-readonly-badge"
+            title={title.trim()}
+            aria-label={title.trim()}
+            role="status"
+          >
+            {`Sandbox: ${meta?.label ?? codexSandbox}`}
+          </span>
+        )
+      })()}
 
       {/* Thinking Level */}
       {showThinkingLevel && (

--- a/packages/protocol/dist/schemas/server/session.d.ts
+++ b/packages/protocol/dist/schemas/server/session.d.ts
@@ -114,6 +114,11 @@ export declare const ServerSessionListEntrySchema: z.ZodObject<{
     }, z.core.$strip>>>;
     orchestrationRunId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     orchestrationRole: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    codexSandbox: z.ZodOptional<z.ZodEnum<{
+        "read-only": "read-only";
+        "workspace-write": "workspace-write";
+        "danger-full-access": "danger-full-access";
+    }>>;
 }, z.core.$loose>;
 export declare const ServerSessionListSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_list">;
@@ -159,6 +164,11 @@ export declare const ServerSessionListSchema: z.ZodObject<{
         }, z.core.$strip>>>;
         orchestrationRunId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
         orchestrationRole: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        codexSandbox: z.ZodOptional<z.ZodEnum<{
+            "read-only": "read-only";
+            "workspace-write": "workspace-write";
+            "danger-full-access": "danger-full-access";
+        }>>;
     }, z.core.$loose>>;
 }, z.core.$strip>;
 /**

--- a/packages/protocol/dist/schemas/server/session.js
+++ b/packages/protocol/dist/schemas/server/session.js
@@ -7,6 +7,10 @@
 import { z } from 'zod';
 import { MAX_SANE_DURATION_MS } from "./connection.js";
 import { ServerPendingBackgroundShellSchema } from "./stream.js";
+// #6901: single-source the Codex sandbox enum so the `codexSandbox` field below
+// stays in lockstep with the create-time `create_session` control (client.ts)
+// and the server's `resolveCodexSandbox` — same list, one place.
+import { CODEX_SANDBOX_MODES } from "../../codex.js";
 export const ServerClientFocusChangedSchema = z.object({
     type: z.literal('client_focus_changed'),
     clientId: z.string(),
@@ -215,6 +219,14 @@ export const ServerSessionListEntrySchema = z.object({
     // metadata (E-4).
     orchestrationRunId: z.string().nullable().optional(),
     orchestrationRole: z.string().nullable().optional(),
+    // #6901: the active/resolved Codex sandbox mode for a running codex session
+    // (`resolveCodexSandbox` on the exec + app-server paths — the env/default,
+    // or the per-session create-time override from #6638/#6900). Present ONLY for
+    // the codex provider; every other provider omits it. Display-only: Codex
+    // applies the sandbox once at thread start, so changing it needs a NEW session
+    // (see docs/design/codex-permission-model.md §5) — clients should render it
+    // read-only. Older servers omit the field; treat `undefined` as "unknown".
+    codexSandbox: z.enum(CODEX_SANDBOX_MODES).optional(),
 }).passthrough();
 export const ServerSessionListSchema = z.object({
     type: z.literal('session_list'),

--- a/packages/protocol/src/schemas/server/session.ts
+++ b/packages/protocol/src/schemas/server/session.ts
@@ -9,6 +9,10 @@ import { z } from 'zod'
 
 import { MAX_SANE_DURATION_MS } from './connection.ts'
 import { ServerPendingBackgroundShellSchema } from './stream.ts'
+// #6901: single-source the Codex sandbox enum so the `codexSandbox` field below
+// stays in lockstep with the create-time `create_session` control (client.ts)
+// and the server's `resolveCodexSandbox` — same list, one place.
+import { CODEX_SANDBOX_MODES } from '../../codex.ts'
 
 export const ServerClientFocusChangedSchema = z.object({
   type: z.literal('client_focus_changed'),
@@ -225,6 +229,14 @@ export const ServerSessionListEntrySchema = z.object({
   // metadata (E-4).
   orchestrationRunId: z.string().nullable().optional(),
   orchestrationRole: z.string().nullable().optional(),
+  // #6901: the active/resolved Codex sandbox mode for a running codex session
+  // (`resolveCodexSandbox` on the exec + app-server paths — the env/default,
+  // or the per-session create-time override from #6638/#6900). Present ONLY for
+  // the codex provider; every other provider omits it. Display-only: Codex
+  // applies the sandbox once at thread start, so changing it needs a NEW session
+  // (see docs/design/codex-permission-model.md §5) — clients should render it
+  // read-only. Older servers omit the field; treat `undefined` as "unknown".
+  codexSandbox: z.enum(CODEX_SANDBOX_MODES).optional(),
 }).passthrough()
 
 export const ServerSessionListSchema = z.object({

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -124,6 +124,10 @@ export class CodexAppServerSession extends BaseSession {
     // #6638: per-session sandbox override (create_session `codexSandbox`) — wins
     // over CHROXY_CODEX_SANDBOX / the default. Applied at thread start.
     this._codexSandbox = opts.codexSandbox || null
+    // #6929 review — the sandbox actually resolved+applied to `thread/start`
+    // (set in start(), see below). null until then; getCodexSandbox() falls
+    // back to a live resolve for that (normally unreachable) pre-start window.
+    this._resolvedCodexSandbox = null
     // #6638: fileChange item.changes cached by itemId, so a fileChange approval
     // (whose params carry NO diff) can surface WHAT will change. Cleared per turn.
     this._pendingFileChanges = new Map()
@@ -144,16 +148,21 @@ export class CodexAppServerSession extends BaseSession {
   }
 
   /**
-   * #6901: the ACTIVE/resolved sandbox mode this thread runs under — mirrors the
-   * value passed to `thread/start` (`resolveCodexSandbox(this._codexSandbox)`,
-   * see start()). Surfaced by `SessionManager.listSessions()` as
-   * `SessionInfo.codexSandbox` so a client can DISPLAY the current sandbox for a
-   * running codex session. Display-only: changing it needs a new session (Codex
-   * applies the sandbox once at thread start).
+   * #6901: the ACTIVE/resolved sandbox mode this thread runs under — the exact
+   * value passed to `thread/start` (see start()), which STORES the resolved
+   * value on `this._resolvedCodexSandbox` at that moment. #6929 review: this
+   * returns the stored value instead of re-resolving `CHROXY_CODEX_SANDBOX` on
+   * every call, so a later env change can't make the display drift from what
+   * this already-running thread actually got (Codex applies the sandbox once
+   * at thread start; it cannot change mid-thread). Falls back to a live
+   * resolve only in the window before start() has run (session constructed but
+   * not yet started). Surfaced by `SessionManager.listSessions()` as
+   * `SessionInfo.codexSandbox` so a client can DISPLAY the current sandbox for
+   * a running codex session. Display-only: changing it needs a new session.
    * @returns {string} one of CODEX_SANDBOX_MODES
    */
   getCodexSandbox() {
-    return resolveCodexSandbox(this._codexSandbox)
+    return this._resolvedCodexSandbox || resolveCodexSandbox(this._codexSandbox)
   }
 
   _buildChildEnv() { return buildSpawnEnv('codex') }
@@ -163,7 +172,11 @@ export class CodexAppServerSession extends BaseSession {
   // ------------------------------------------------------------------
 
   async start() {
-    const sandbox = resolveCodexSandbox(this._codexSandbox)
+    // #6929 review — resolve AND STORE here, the actual `thread/start` apply
+    // site, so getCodexSandbox() can report what this thread really got instead
+    // of re-resolving the env (and potentially drifting from it) on every call.
+    this._resolvedCodexSandbox = resolveCodexSandbox(this._codexSandbox)
+    const sandbox = this._resolvedCodexSandbox
     // Capture the EXACT binary the client will spawn so the spawn-time backstop
     // (#6708) verifies that path — in start()'s catch AND later in
     // _onClientExit — rather than a fresh re-resolve.

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -143,6 +143,19 @@ export class CodexAppServerSession extends BaseSession {
     })
   }
 
+  /**
+   * #6901: the ACTIVE/resolved sandbox mode this thread runs under — mirrors the
+   * value passed to `thread/start` (`resolveCodexSandbox(this._codexSandbox)`,
+   * see start()). Surfaced by `SessionManager.listSessions()` as
+   * `SessionInfo.codexSandbox` so a client can DISPLAY the current sandbox for a
+   * running codex session. Display-only: changing it needs a new session (Codex
+   * applies the sandbox once at thread start).
+   * @returns {string} one of CODEX_SANDBOX_MODES
+   */
+  getCodexSandbox() {
+    return resolveCodexSandbox(this._codexSandbox)
+  }
+
   _buildChildEnv() { return buildSpawnEnv('codex') }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -527,20 +527,29 @@ export class CodexSession extends JsonlSubprocessSession {
     // #6638: per-session sandbox override — honored on the exec path too, so a
     // read-only/full-access session isn't a silent no-op under CHROXY_CODEX_APPSERVER=0.
     this._codexSandbox = opts.codexSandbox || null
+    // #6929 review — resolve ONCE here rather than on every `_buildArgs`/
+    // `getCodexSandbox()` call. `opts.codexSandbox` is fixed for the life of this
+    // session and nothing between construction and the first spawn can change it,
+    // so resolving now and reusing the stored value keeps every turn's `--sandbox`
+    // AND the displayed `getCodexSandbox()` value in permanent agreement — a later
+    // `CHROXY_CODEX_SANDBOX` env change can no longer retroactively change what a
+    // running session reports (display/reality drift).
+    this._resolvedCodexSandbox = resolveCodexSandbox(this._codexSandbox)
   }
 
   /**
    * #6901: the ACTIVE/resolved sandbox mode this session runs under, so
    * `SessionManager.listSessions()` can surface it in `session_list`
-   * (`SessionInfo.codexSandbox`) for a running codex session. Resolves the
-   * per-session override against `CHROXY_CODEX_SANDBOX`/the default via the same
-   * `resolveCodexSandbox` the spawn path uses — always one of
-   * `CODEX_SANDBOX_MODES`. Display-only: a mid-session change needs a new session
-   * (Codex applies `--sandbox` once at thread start).
+   * (`SessionInfo.codexSandbox`) for a running codex session. #6929 review:
+   * returns the value resolved ONCE at construction (see ctor) instead of
+   * re-resolving `CHROXY_CODEX_SANDBOX` on every call, so a later env change
+   * can't make the display drift from what this session's turns actually spawn
+   * with. Display-only: a mid-session change needs a new session (Codex
+   * applies `--sandbox` fresh per turn here, but always with this same value).
    * @returns {string} one of CODEX_SANDBOX_MODES
    */
   getCodexSandbox() {
-    return resolveCodexSandbox(this._codexSandbox)
+    return this._resolvedCodexSandbox
   }
 
   // ------------------------------------------------------------------
@@ -548,7 +557,7 @@ export class CodexSession extends JsonlSubprocessSession {
   // ------------------------------------------------------------------
 
   _buildArgs(text) {
-    return buildCodexArgs(text, this.model, this.resumeSessionId, this._codexSandbox)
+    return buildCodexArgs(text, this.model, this.resumeSessionId, this._resolvedCodexSandbox)
   }
 
   _buildChildEnv() {

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -529,6 +529,20 @@ export class CodexSession extends JsonlSubprocessSession {
     this._codexSandbox = opts.codexSandbox || null
   }
 
+  /**
+   * #6901: the ACTIVE/resolved sandbox mode this session runs under, so
+   * `SessionManager.listSessions()` can surface it in `session_list`
+   * (`SessionInfo.codexSandbox`) for a running codex session. Resolves the
+   * per-session override against `CHROXY_CODEX_SANDBOX`/the default via the same
+   * `resolveCodexSandbox` the spawn path uses — always one of
+   * `CODEX_SANDBOX_MODES`. Display-only: a mid-session change needs a new session
+   * (Codex applies `--sandbox` once at thread start).
+   * @returns {string} one of CODEX_SANDBOX_MODES
+   */
+  getCodexSandbox() {
+    return resolveCodexSandbox(this._codexSandbox)
+  }
+
   // ------------------------------------------------------------------
   // JsonlSubprocessSession overrides
   // ------------------------------------------------------------------

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1790,6 +1790,16 @@ export class SessionManager extends EventEmitter {
         // (ServerSessionListEntry), so a plain session omits them entirely.
         ...(entry.metadata?.orchestrationRunId ? { orchestrationRunId: entry.metadata.orchestrationRunId } : {}),
         ...(entry.metadata?.orchestrationRole ? { orchestrationRole: entry.metadata.orchestrationRole } : {}),
+        // #6901: surface the active/resolved Codex sandbox mode for a running
+        // codex session so a client can DISPLAY it (the optional half of #6689).
+        // Only the codex session classes expose `getCodexSandbox()`, so this is a
+        // provider-agnostic gate — non-codex sessions omit the field entirely
+        // (mirrors the orchestration-badge spread above). Display-only: a mid-
+        // session sandbox change needs a new session (Codex applies it once at
+        // thread start — docs/design/codex-permission-model.md §5).
+        ...(typeof entry.session.getCodexSandbox === 'function'
+          ? { codexSandbox: entry.session.getCodexSandbox() }
+          : {}),
         // #4664: per-session toggle/string settings (promptEvaluator,
         // chroxyContextHint, sessionPreamble) surface through the
         // registry so the dashboard can hydrate every knob's current

--- a/packages/server/tests/session-manager-codex-sandbox.test.js
+++ b/packages/server/tests/session-manager-codex-sandbox.test.js
@@ -139,3 +139,99 @@ describe('CodexSession/CodexAppServerSession getCodexSandbox() (#6901)', () => {
     assert.equal(typeof CodexAppServerSession.prototype.getCodexSandbox, 'function')
   })
 })
+
+// #6929 review — a codex thread's sandbox is chosen ONCE (at construction for the
+// exec-based CodexSession, at thread/start for CodexAppServerSession) and cannot
+// change without a new session/thread. getCodexSandbox() used to re-resolve
+// CHROXY_CODEX_SANDBOX at CALL time, so listSessions() could DISPLAY a sandbox
+// that no longer matches what the already-running session actually got if the
+// env changed mid-session. These pin the fix: the value is captured once and
+// stays fixed even when the env changes afterward.
+describe('getCodexSandbox() is fixed at start, not re-resolved on env change (#6929)', () => {
+  it('CodexSession: captured at construction; a later env change does not drift it', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+    try {
+      const s = new CodexSession({ cwd: '/tmp' })
+      assert.equal(s.getCodexSandbox(), 'read-only', 'resolved from the env at construction time')
+
+      process.env.CHROXY_CODEX_SANDBOX = 'danger-full-access'
+      assert.equal(s.getCodexSandbox(), 'read-only',
+        'still the value resolved at construction — must not drift with the env')
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+
+  it('CodexSession: a per-session override is likewise fixed at construction', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    try {
+      const s = new CodexSession({ cwd: '/tmp', codexSandbox: 'workspace-write' })
+      assert.equal(s.getCodexSandbox(), 'workspace-write')
+
+      process.env.CHROXY_CODEX_SANDBOX = 'read-only' // env changes after the fact
+      assert.equal(s.getCodexSandbox(), 'workspace-write', 'per-session override still wins, unchanged')
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+
+  it('CodexSession: the value stays fixed across turns too (_buildArgs reuses the stored value)', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+    try {
+      const s = new CodexSession({ cwd: '/tmp' })
+      const argsBefore = s._buildArgs('hello')
+      assert.ok(argsBefore.includes('read-only'), 'first turn spawns with the construction-time value')
+
+      process.env.CHROXY_CODEX_SANDBOX = 'danger-full-access'
+      const argsAfter = s._buildArgs('hello again')
+      assert.ok(argsAfter.includes('read-only'), 'later turn still spawns with the ORIGINAL value, not the new env')
+      assert.equal(s.getCodexSandbox(), 'read-only')
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+
+  it('CodexAppServerSession: pre-start getCodexSandbox() live-resolves (no thread yet to drift from)', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+    try {
+      const s = new CodexAppServerSession({ cwd: '/tmp' })
+      assert.equal(s._resolvedCodexSandbox, null, 'nothing captured yet — start() has not run')
+      assert.equal(s.getCodexSandbox(), 'read-only', 'pre-start falls back to a live resolve')
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+
+  // start() itself spawns a real `codex app-server` child process (via
+  // CodexAppServerClient.initialize()), so it isn't exercised directly in this
+  // unit suite (no codex binary in CI). What IS under test here is the actual
+  // fix: start()'s FIRST statement is
+  //   `this._resolvedCodexSandbox = resolveCodexSandbox(this._codexSandbox)`
+  // (see codex-app-server-session.js) — i.e. the resolve+store happens before
+  // anything else, at the exact `thread/start` apply site. This reproduces
+  // that assignment (the one line start() runs for sandbox purposes) and then
+  // asserts getCodexSandbox() reads the STORED value, not a live re-resolve.
+  it('CodexAppServerSession: captured at start(); a later env change does not drift it', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    process.env.CHROXY_CODEX_SANDBOX = 'read-only'
+    try {
+      const s = new CodexAppServerSession({ cwd: '/tmp' })
+      s._resolvedCodexSandbox = resolveCodexSandbox(s._codexSandbox) // start()'s apply-site line
+      assert.equal(s.getCodexSandbox(), 'read-only', 'resolved at "start" time')
+
+      process.env.CHROXY_CODEX_SANDBOX = 'danger-full-access'
+      assert.equal(s.getCodexSandbox(), 'read-only',
+        'still the value resolved at start — must not drift with the env')
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+})

--- a/packages/server/tests/session-manager-codex-sandbox.test.js
+++ b/packages/server/tests/session-manager-codex-sandbox.test.js
@@ -1,0 +1,141 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { EventEmitter } from 'events'
+import { SessionManager } from '../src/session-manager.js'
+import {
+  CodexSession,
+  resolveCodexSandbox,
+  CODEX_SANDBOX_MODES,
+  CODEX_DEFAULT_SANDBOX,
+} from '../src/codex-session.js'
+import { CodexAppServerSession } from '../src/codex-app-server-session.js'
+
+// #6901: the ACTIVE/resolved codex sandbox mode is surfaced in session_list
+// (SessionInfo.codexSandbox) so a client can DISPLAY the current sandbox for a
+// running codex session — the optional half of #6689. It is populated from the
+// codex session's `getCodexSandbox()` (resolveCodexSandbox of the per-session
+// override vs env/default) and OMITTED entirely for non-codex sessions.
+
+let registerProvider
+
+before(async () => {
+  ({ registerProvider } = await import('../src/providers.js'))
+  // A codex-like provider: exposes getCodexSandbox() (the contract listSessions
+  // gates on) without spawning a real `codex` binary.
+  class FakeCodexProvider extends EventEmitter {
+    constructor(opts) {
+      super()
+      this.cwd = opts.cwd
+      this.model = opts.model || null
+      this.permissionMode = opts.permissionMode || 'approve'
+      this.isRunning = false
+      this.resumeSessionId = null
+      this._sandbox = opts.codexSandbox || null
+    }
+    static get capabilities() { return {} }
+    getCodexSandbox() { return resolveCodexSandbox(this._sandbox) }
+    start() {}
+    destroy() {}
+    sendMessage() {}
+    interrupt() {}
+    setModel() {}
+    setPermissionMode() {}
+  }
+  // A plain (non-codex) provider with NO getCodexSandbox().
+  class PlainProvider extends EventEmitter {
+    constructor(opts) {
+      super()
+      this.cwd = opts.cwd
+      this.model = opts.model || null
+      this.permissionMode = opts.permissionMode || 'approve'
+      this.isRunning = false
+      this.resumeSessionId = null
+    }
+    static get capabilities() { return {} }
+    start() {}
+    destroy() {}
+    sendMessage() {}
+    interrupt() {}
+    setModel() {}
+    setPermissionMode() {}
+  }
+  registerProvider('test-fake-codex', FakeCodexProvider)
+  registerProvider('test-plain', PlainProvider)
+})
+
+function makeMgr() {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'sm-codex-sandbox-'))
+  const mgr = new SessionManager({ skipPreflight: true, maxSessions: 10, defaultCwd: '/tmp', stateFilePath: join(tmpDir, 'state.json') })
+  mgr._tmpDir = tmpDir
+  return mgr
+}
+function cleanup(mgr) { mgr.destroyAll(); rmSync(mgr._tmpDir, { recursive: true, force: true }) }
+
+describe('session-list codexSandbox (#6901)', () => {
+  it('surfaces the per-session sandbox override for a codex session', () => {
+    const mgr = makeMgr()
+    try {
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'test-fake-codex', codexSandbox: 'read-only' })
+      const entry = mgr.listSessions().find((s) => s.sessionId === id)
+      assert.ok(entry, 'session listed')
+      assert.equal(entry.codexSandbox, 'read-only')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+
+  it('falls back to the resolved default when no override is set', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    delete process.env.CHROXY_CODEX_SANDBOX
+    const mgr = makeMgr()
+    try {
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'test-fake-codex' })
+      const entry = mgr.listSessions().find((s) => s.sessionId === id)
+      assert.ok(entry)
+      assert.equal(entry.codexSandbox, CODEX_DEFAULT_SANDBOX)
+      assert.ok(CODEX_SANDBOX_MODES.includes(entry.codexSandbox))
+    } finally {
+      cleanup(mgr)
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+
+  it('omits codexSandbox entirely for a non-codex session', () => {
+    const mgr = makeMgr()
+    try {
+      const id = mgr.createSession({ cwd: '/tmp', provider: 'test-plain' })
+      const entry = mgr.listSessions().find((s) => s.sessionId === id)
+      assert.ok(entry)
+      assert.equal('codexSandbox' in entry, false, 'no codexSandbox key on a non-codex session')
+    } finally {
+      cleanup(mgr)
+    }
+  })
+})
+
+describe('CodexSession/CodexAppServerSession getCodexSandbox() (#6901)', () => {
+  it('CodexSession.getCodexSandbox() resolves the per-session override', () => {
+    const s = new CodexSession({ cwd: '/tmp', codexSandbox: 'danger-full-access' })
+    assert.equal(s.getCodexSandbox(), 'danger-full-access')
+  })
+
+  it('CodexSession.getCodexSandbox() falls back to the resolved default', () => {
+    const prev = process.env.CHROXY_CODEX_SANDBOX
+    delete process.env.CHROXY_CODEX_SANDBOX
+    try {
+      const s = new CodexSession({ cwd: '/tmp' })
+      assert.equal(s.getCodexSandbox(), CODEX_DEFAULT_SANDBOX)
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_SANDBOX
+      else process.env.CHROXY_CODEX_SANDBOX = prev
+    }
+  })
+
+  it('CodexAppServerSession also exposes getCodexSandbox() (app-server path)', () => {
+    assert.equal(typeof CodexAppServerSession.prototype.getCodexSandbox, 'function')
+  })
+})

--- a/packages/store-core/src/types/session.ts
+++ b/packages/store-core/src/types/session.ts
@@ -5,6 +5,10 @@
  */
 
 import type { ChatMessage } from './chat'
+// #6901: the Codex sandbox enum, single-sourced from the protocol package so the
+// client-side SessionInfo.codexSandbox field stays in lockstep with the wire
+// schema (ServerSessionListEntrySchema) and the create-time selector.
+import type { CodexSandboxMode } from '@chroxy/protocol'
 
 /**
  * Per-turn BILLING token counts from the most recent `result.usage` — the
@@ -148,6 +152,16 @@ export interface SessionInfo {
    * channel is the `background_work_changed` event.
    */
   pendingBackgroundShells?: PendingBackgroundShell[];
+  /**
+   * #6901: the active/resolved Codex sandbox mode for a running codex session
+   * (`read-only` | `workspace-write` | `danger-full-access`). Present ONLY for
+   * codex-provider sessions — every other provider omits it, and older servers
+   * (pre-#6901) omit it too, so renderers should treat `undefined` as "unknown"
+   * and hide the indicator. Display-only: Codex applies the sandbox once at
+   * thread start, so changing it requires a NEW session (a client MUST render
+   * this read-only with copy to that effect).
+   */
+  codexSandbox?: CodexSandboxMode;
 }
 
 export interface AgentInfo {


### PR DESCRIPTION
## Summary

Follow-up to #6689 / #6900 (create-time Codex sandbox selector). #6900 added the sandbox selector at session-create time, but the **active** sandbox mode of an existing codex session wasn't surfaced anywhere. This surfaces it so clients can **display** the current sandbox for a running codex session — the optional display half of #6689.

## What changed

- **protocol** (`schemas/server/session.ts`): add optional `codexSandbox` to `ServerSessionListEntrySchema` — the `SessionInfo` entry carried in `session_list`. Enum single-sourced from `CODEX_SANDBOX_MODES`. Because it's an **optional field on an existing message type** (not a new type, not a one-client→both-clients flip), it does not trip the three coverage guards. Dist rebuilt (only `session.d.ts` / `session.js` changed — already-tracked, no new files).
- **server**:
  - `CodexSession` + `CodexAppServerSession` expose `getCodexSandbox()` → `resolveCodexSandbox(this._codexSandbox)` (the same env/default-vs-per-session-override resolution applied at thread start).
  - `SessionManager.listSessions()` populates `codexSandbox` for codex sessions (provider-agnostic gate on the `getCodexSandbox` method) and **omits** it entirely for every other provider.
- **store-core** (`types/session.ts`): add `codexSandbox?: CodexSandboxMode` to the client-side `SessionInfo` type. `handleSessionList` passes the wire entry through untouched, so the field reaches both clients automatically.
- **dashboard**: read-only `Sandbox: <label>` badge in `ChatSettingsDropdown` (next to Model / Permission Mode), gated on the active codex session's `codexSandbox`. Tooltip notes a change requires a new session. Label/description single-sourced from `CODEX_SANDBOX_MODE_META`.
- **app**: matching read-only sandbox badge + hint in `SettingsBar`.

## Mid-session constraint

Display-only — Codex applies `--sandbox` **once at thread start**, so a mid-session sandbox change requires a **new session** (docs/design/codex-permission-model.md §5). The dashboard tooltip and app hint both say so.

## Tests

- **server** (`session-manager-codex-sandbox.test.js`, 6 tests): a codex session's `session_list` entry carries the override / resolved default; a non-codex session omits `codexSandbox` entirely; `getCodexSandbox()` unit tests on both codex classes.
- **dashboard** (`ChatSettingsDropdown.test.tsx`, +4): badge renders with label for a codex session, tooltip carries the new-session copy, absent for non-codex / omitted.
- **app** (`SettingsBarCodexSandbox.test.tsx`, +3): badge label, hint mentions new session, absent when null.

## Verification

- Protocol suite: 375 pass. store-core: 2031 pass + typecheck clean (coverage guards green — optional field on existing type did not trip them).
- Server: 6 new + 228 related codex/session-manager tests pass; all 5 `packages/server/scripts/lint-*.sh` green (opt-forwarding confirms codex subclasses still forward every BaseSession opt).
- Dashboard typecheck + `ChatSettingsDropdown` (34) green. App tsc clean + all `SettingsBar` suites (57) green.
- No dist drift beyond the two expected `session.*` files.

Closes #6901