### PR TITLE
feat(dashboard,app): inline diff comments + submit-to-Claude + one-click review

### DIFF
--- a/packages/app/src/components/DiffViewer.tsx
+++ b/packages/app/src/components/DiffViewer.tsx
@@ -183,6 +183,12 @@ export function DiffHunkView({
                   accessibilityRole="button"
                   accessibilityLabel="Remove comment"
                   testID={`diff-comment-remove-${i}`}
+                  // The visual label stays a compact inline "Remove" so it sits
+                  // neatly next to the comment note text, but the actionable tap
+                  // area expands via hitSlop to meet the 44pt accessibility
+                  // minimum (rendered text is ~16-18pt tall; +12 top/bottom
+                  // clears 44pt, +10 left/right gives a comfortable margin).
+                  hitSlop={{ top: 12, right: 10, bottom: 12, left: 10 }}
                 >
                   <Text style={styles.commentRemove}>Remove</Text>
                 </TouchableOpacity>

--- a/packages/app/src/components/DiffViewer.tsx
+++ b/packages/app/src/components/DiffViewer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   FlatList,
   ActivityIndicator,
@@ -10,11 +11,46 @@ import {
   ScrollView,
   Platform,
 } from 'react-native';
+import {
+  composeCommentReviewPrompt,
+  composeReviewRequestPrompt,
+  deriveLineNumber,
+  type DiffLineComment,
+} from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
-import type { DiffResult, DiffFile, DiffHunk } from '../store/connection';
+import type { DiffResult, DiffFile, DiffHunk, DiffHunkLine } from '../store/connection';
 import { COLORS } from '../constants/colors';
 import { ICON_DIFF } from '../constants/icons';
 import { Icon } from './Icon';
+
+/** Stable, position-derived key for one diff line (used as the comment id). */
+function lineKey(filePath: string, hunkIndex: number, lineIndex: number): string {
+  return `${filePath}#${hunkIndex}#${lineIndex}`;
+}
+
+/** Everything the composer needs to build a DiffLineComment on save. */
+type LineCommentTarget = {
+  key: string;
+  filePath: string;
+  lineNumber: number | null;
+  lineType: DiffHunkLine['type'];
+  lineContent: string;
+};
+
+/**
+ * #6800: inline-comment wiring threaded down to the diff lines. Absent for the
+ * read-only / PreWriteDiffReview renders, which stay unchanged.
+ */
+type CommentApi = {
+  comments: DiffLineComment[];
+  editingKey: string | null;
+  draft: string;
+  onOpen: (target: LineCommentTarget) => void;
+  onDraftChange: (text: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onRemove: (key: string) => void;
+};
 
 /** Status badge color mapping */
 function statusColor(status: DiffFile['status']): string {
@@ -45,18 +81,26 @@ function statusLabel(status: DiffFile['status']): string {
  * props are a discriminated union so `selectable` ALWAYS carries `selected` +
  * `onToggle` — no dead checkbox (a control with a checkbox role but no handler).
  * The selection STATE + applyHunks wiring live in the consuming surface (#6543/#6544).
+ *
+ * #6800: when `commentApi` + `filePath` are supplied, each line becomes a
+ * touch-target that opens an inline comment editor. Read-only consumers pass
+ * neither, so the existing render is unchanged.
  */
-export type DiffHunkViewProps = { hunk: DiffHunk } & (
+export type DiffHunkViewProps = { hunk: DiffHunk; filePath?: string; hunkIndex?: number; commentApi?: CommentApi } & (
   | { selectable?: false; selected?: never; onToggle?: never }
   | { selectable: true; selected: boolean; onToggle: () => void }
 );
 
 export function DiffHunkView({
   hunk,
+  filePath,
+  hunkIndex = 0,
+  commentApi,
   selectable = false,
   selected = false,
   onToggle,
 }: DiffHunkViewProps) {
+  const commentsOn = !!commentApi && filePath != null;
   return (
     <View style={[styles.hunk, selectable && !selected ? styles.hunkRejected : null]}>
       {selectable ? (
@@ -83,11 +127,96 @@ export function DiffHunkView({
           line.type === 'addition' ? '+' :
           line.type === 'deletion' ? '-' :
           ' ';
+
+        if (!commentsOn) {
+          return (
+            <Text key={i} style={lineStyle} selectable>
+              <Text style={styles.linePrefix}>{prefix}</Text>
+              {line.content}
+            </Text>
+          );
+        }
+
+        const api = commentApi!;
+        const key = lineKey(filePath!, hunkIndex, i);
+        const existing = api.comments.find((c) => c.id === key);
+        const isEditing = api.editingKey === key;
         return (
-          <Text key={i} style={lineStyle} selectable>
-            <Text style={styles.linePrefix}>{prefix}</Text>
-            {line.content}
-          </Text>
+          <View key={i}>
+            <TouchableOpacity
+              onPress={() =>
+                api.onOpen({
+                  key,
+                  filePath: filePath!,
+                  lineNumber: deriveLineNumber(hunk, i),
+                  lineType: line.type,
+                  lineContent: line.content,
+                })
+              }
+              accessibilityRole="button"
+              accessibilityLabel={existing ? 'Edit comment on this line' : 'Comment on this line'}
+              testID={`diff-line-${i}`}
+            >
+              <Text style={[lineStyle, existing ? styles.lineHasComment : null]}>
+                <Text style={styles.linePrefix}>{prefix}</Text>
+                {line.content}
+              </Text>
+            </TouchableOpacity>
+
+            {existing && !isEditing && (
+              <TouchableOpacity
+                style={styles.commentNote}
+                onPress={() =>
+                  api.onOpen({
+                    key,
+                    filePath: filePath!,
+                    lineNumber: deriveLineNumber(hunk, i),
+                    lineType: line.type,
+                    lineContent: line.content,
+                  })
+                }
+                testID={`diff-comment-note-${i}`}
+              >
+                <Text style={styles.commentNoteText}>{existing.comment}</Text>
+                <TouchableOpacity
+                  onPress={() => api.onRemove(key)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Remove comment"
+                  testID={`diff-comment-remove-${i}`}
+                >
+                  <Text style={styles.commentRemove}>Remove</Text>
+                </TouchableOpacity>
+              </TouchableOpacity>
+            )}
+
+            {isEditing && (
+              <View style={styles.commentEditor} testID={`diff-comment-editor-${i}`}>
+                <TextInput
+                  style={styles.commentInput}
+                  value={api.draft}
+                  onChangeText={api.onDraftChange}
+                  placeholder="Leave a comment for Claude…"
+                  placeholderTextColor={COLORS.textMuted}
+                  multiline
+                  autoFocus
+                  testID="diff-comment-input"
+                />
+                <View style={styles.commentEditorActions}>
+                  <TouchableOpacity
+                    style={[styles.commentSave, api.draft.trim().length === 0 ? styles.commentSaveDisabled : null]}
+                    onPress={api.onSave}
+                    disabled={api.draft.trim().length === 0}
+                    testID="diff-comment-save"
+                  >
+                    <Text style={styles.commentSaveText}>Add comment</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity style={styles.commentCancel} onPress={api.onCancel} testID="diff-comment-cancel">
+                    <Text style={styles.commentCancelText}>Cancel</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
+          </View>
         );
       })}
     </View>
@@ -98,9 +227,11 @@ export function DiffHunkView({
 function FileDiffView({
   file,
   onBack,
+  commentApi,
 }: {
   file: DiffFile;
   onBack: () => void;
+  commentApi?: CommentApi;
 }) {
   return (
     <View style={styles.container}>
@@ -121,7 +252,7 @@ function FileDiffView({
         <ScrollView horizontal showsHorizontalScrollIndicator>
           <View>
             {file.hunks.map((hunk, i) => (
-              <DiffHunkView key={i} hunk={hunk} />
+              <DiffHunkView key={i} hunk={hunk} filePath={file.path} hunkIndex={i} commentApi={commentApi} />
             ))}
             {file.hunks.length === 0 && (
               <Text style={styles.emptyText}>No diff content</Text>
@@ -146,8 +277,14 @@ export function DiffViewer({
   const [error, setError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<DiffFile | null>(null);
 
+  // #6800: pending inline comments + the open editor.
+  const [comments, setComments] = useState<DiffLineComment[]>([]);
+  const [editing, setEditing] = useState<LineCommentTarget | null>(null);
+  const [draft, setDraft] = useState('');
+
   const setDiffCallback = useConnectionStore((s) => s.setDiffCallback);
   const requestDiff = useConnectionStore((s) => s.requestDiff);
+  const sendInput = useConnectionStore((s) => s.sendInput);
 
   const requestIdRef = useRef(0);
   const activeRequestRef = useRef(0);
@@ -159,6 +296,9 @@ export function DiffViewer({
     setLoading(true);
     setError(null);
     setSelectedFile(null);
+    setComments([]);
+    setEditing(null);
+    setDraft('');
 
     const handleResult = (result: DiffResult) => {
       if (activeRequestRef.current !== requestIdRef.current) return;
@@ -202,7 +342,83 @@ export function DiffViewer({
     setSelectedFile(null);
   }, []);
 
+  const handleOpenComment = useCallback((target: LineCommentTarget) => {
+    setEditing(target);
+    setComments((prev) => {
+      const existing = prev.find((c) => c.id === target.key);
+      setDraft(existing?.comment ?? '');
+      return prev;
+    });
+  }, []);
+
+  const handleSaveComment = useCallback(() => {
+    if (!editing) return;
+    const text = draft.trim();
+    if (!text) return;
+    setComments((prev) => {
+      const next: DiffLineComment = {
+        id: editing.key,
+        filePath: editing.filePath,
+        lineNumber: editing.lineNumber,
+        lineType: editing.lineType,
+        lineContent: editing.lineContent,
+        comment: text,
+      };
+      const idx = prev.findIndex((c) => c.id === editing.key);
+      if (idx >= 0) {
+        const copy = [...prev];
+        copy[idx] = next;
+        return copy;
+      }
+      return [...prev, next];
+    });
+    setEditing(null);
+    setDraft('');
+  }, [editing, draft]);
+
+  const handleCancelComment = useCallback(() => {
+    setEditing(null);
+    setDraft('');
+  }, []);
+
+  const handleRemoveComment = useCallback((key: string) => {
+    setComments((prev) => prev.filter((c) => c.id !== key));
+    setEditing((cur) => (cur?.key === key ? null : cur));
+  }, []);
+
+  const handleSubmitComments = useCallback(() => {
+    if (comments.length === 0) return;
+    const prompt = composeCommentReviewPrompt(comments);
+    if (!prompt) return;
+    const result = sendInput(prompt);
+    if (result) {
+      setComments([]);
+      setEditing(null);
+      setDraft('');
+      handleClose();
+    }
+  }, [comments, sendInput, handleClose]);
+
+  const handleReview = useCallback(() => {
+    const prompt = composeReviewRequestPrompt(files.map((f) => ({ path: f.path })));
+    const result = sendInput(prompt);
+    if (result) handleClose();
+  }, [files, sendInput, handleClose]);
+
+  const commentApi: CommentApi = {
+    comments,
+    editingKey: editing?.key ?? null,
+    draft,
+    onOpen: handleOpenComment,
+    onDraftChange: setDraft,
+    onSave: handleSaveComment,
+    onCancel: handleCancelComment,
+    onRemove: handleRemoveComment,
+  };
+
   if (!visible) return null;
+
+  const showActionBar = !loading && !error && files.length > 0;
 
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={handleClose}>
@@ -226,7 +442,7 @@ export function DiffViewer({
 
         {/* Content */}
         {selectedFile ? (
-          <FileDiffView file={selectedFile} onBack={handleBack} />
+          <FileDiffView file={selectedFile} onBack={handleBack} commentApi={commentApi} />
         ) : (
           <View style={styles.container}>
             {loading && (
@@ -248,26 +464,63 @@ export function DiffViewer({
               <FlatList
                 data={files}
                 keyExtractor={(item) => item.path}
-                renderItem={({ item }) => (
-                  <TouchableOpacity
-                    style={styles.fileEntry}
-                    onPress={() => setSelectedFile(item)}
-                  >
-                    <View style={[styles.statusBadge, { backgroundColor: statusColor(item.status) + '33' }]}>
-                      <Text style={[styles.statusText, { color: statusColor(item.status) }]}>
-                        {statusLabel(item.status)}
+                renderItem={({ item }) => {
+                  const fileComments = comments.filter((c) => c.filePath === item.path).length;
+                  return (
+                    <TouchableOpacity
+                      style={styles.fileEntry}
+                      onPress={() => setSelectedFile(item)}
+                      testID={`diff-file-${item.path}`}
+                    >
+                      <View style={[styles.statusBadge, { backgroundColor: statusColor(item.status) + '33' }]}>
+                        <Text style={[styles.statusText, { color: statusColor(item.status) }]}>
+                          {statusLabel(item.status)}
+                        </Text>
+                      </View>
+                      <Text style={styles.fileEntryName} numberOfLines={1}>{item.path}</Text>
+                      {fileComments > 0 && (
+                        <View style={styles.fileCommentBadge}>
+                          <Text style={styles.fileCommentBadgeText}>{fileComments}</Text>
+                        </View>
+                      )}
+                      <Text style={styles.fileEntryStat}>
+                        <Text style={styles.additionsStat}>+{item.additions}</Text>
+                        {'  '}
+                        <Text style={styles.deletionsStat}>-{item.deletions}</Text>
                       </Text>
-                    </View>
-                    <Text style={styles.fileEntryName} numberOfLines={1}>{item.path}</Text>
-                    <Text style={styles.fileEntryStat}>
-                      <Text style={styles.additionsStat}>+{item.additions}</Text>
-                      {'  '}
-                      <Text style={styles.deletionsStat}>-{item.deletions}</Text>
-                    </Text>
-                  </TouchableOpacity>
-                )}
+                    </TouchableOpacity>
+                  );
+                }}
               />
             )}
+          </View>
+        )}
+
+        {/* #6800: review action bar — submit queued comments / one-click review. */}
+        {showActionBar && (
+          <View style={styles.actionBar} testID="diff-action-bar">
+            {comments.length > 0 && (
+              <TouchableOpacity
+                style={styles.submitButton}
+                onPress={handleSubmitComments}
+                accessibilityRole="button"
+                accessibilityLabel={`Submit ${comments.length} comment${comments.length !== 1 ? 's' : ''} to Claude`}
+                testID="diff-submit-comments"
+              >
+                <Text style={styles.submitButtonText}>
+                  Submit {comments.length} comment{comments.length !== 1 ? 's' : ''}
+                </Text>
+              </TouchableOpacity>
+            )}
+            <TouchableOpacity
+              style={styles.reviewButton}
+              onPress={handleReview}
+              accessibilityRole="button"
+              accessibilityLabel="Ask Claude to review these changes"
+              testID="diff-review-code"
+            >
+              <Text style={styles.reviewButtonText}>Review code</Text>
+            </TouchableOpacity>
           </View>
         )}
       </View>
@@ -400,6 +653,22 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
   },
+  // #6800: a per-file badge showing how many pending comments it carries.
+  fileCommentBadge: {
+    marginLeft: 8,
+    minWidth: 20,
+    height: 20,
+    paddingHorizontal: 6,
+    borderRadius: 10,
+    backgroundColor: COLORS.accentBlue,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fileCommentBadgeText: {
+    color: COLORS.textPrimary,
+    fontSize: 11,
+    fontWeight: '700',
+  },
   additionsStat: {
     color: COLORS.accentGreen,
   },
@@ -468,5 +737,119 @@ const styles = StyleSheet.create({
   },
   linePrefix: {
     fontWeight: '700',
+  },
+  // #6800: a commented line gets a left accent so it reads at a glance.
+  lineHasComment: {
+    borderLeftWidth: 2,
+    borderLeftColor: COLORS.accentBlue,
+  },
+  commentNote: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    marginLeft: 4,
+    backgroundColor: COLORS.accentBlueLight,
+    borderLeftWidth: 2,
+    borderLeftColor: COLORS.accentBlue,
+  },
+  commentNoteText: {
+    flex: 1,
+    color: COLORS.textPrimary,
+    fontSize: 13,
+  },
+  commentRemove: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+  },
+  commentEditor: {
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    marginLeft: 4,
+    backgroundColor: COLORS.backgroundTertiary,
+    borderLeftWidth: 2,
+    borderLeftColor: COLORS.accentBlue,
+  },
+  commentInput: {
+    minHeight: 44,
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    backgroundColor: COLORS.backgroundInput,
+    borderWidth: 1,
+    borderColor: COLORS.borderSecondary,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    textAlignVertical: 'top',
+  },
+  commentEditorActions: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 6,
+  },
+  commentSave: {
+    minHeight: 36,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    borderRadius: 4,
+    backgroundColor: COLORS.accentBlue,
+  },
+  commentSaveDisabled: {
+    opacity: 0.5,
+  },
+  commentSaveText: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  commentCancel: {
+    minHeight: 36,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: COLORS.borderPrimary,
+  },
+  commentCancelText: {
+    color: COLORS.textSecondary,
+    fontSize: 13,
+  },
+  // #6800: bottom action bar with review triggers.
+  actionBar: {
+    flexDirection: 'row',
+    gap: 8,
+    padding: 12,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.borderPrimary,
+    backgroundColor: COLORS.backgroundSecondary,
+  },
+  submitButton: {
+    flex: 1,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 6,
+    backgroundColor: COLORS.accentBlue,
+  },
+  submitButtonText: {
+    color: COLORS.textPrimary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  reviewButton: {
+    flex: 1,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: COLORS.borderSecondary,
+    backgroundColor: COLORS.backgroundTertiary,
+  },
+  reviewButtonText: {
+    color: COLORS.textSecondary,
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/packages/app/src/components/__tests__/DiffViewer.test.tsx
+++ b/packages/app/src/components/__tests__/DiffViewer.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Render/interaction tests for the mobile DiffViewer inline comments +
+ * review triggers (#6800).
+ *
+ * react-test-renderer + act, Zustand store driven via setState (mirrors
+ * CheckInChip.test.tsx). Covers: line comment affordance, adding a comment,
+ * submitting queued comments (composed prompt via sendInput + modal closes),
+ * and the one-click "Review code" trigger.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { DiffViewer } from '../DiffViewer';
+import { useConnectionStore } from '../../store/connection';
+import type { DiffFile, DiffResult } from '../../store/connection';
+
+const FILES: DiffFile[] = [
+  {
+    path: 'src/utils/helper.ts',
+    status: 'modified',
+    additions: 5,
+    deletions: 2,
+    hunks: [
+      {
+        header: '@@ -10,6 +10,9 @@',
+        lines: [
+          { type: 'context', content: 'const x = 1' },
+          { type: 'deletion', content: 'const y = 2' },
+          { type: 'addition', content: 'const y = 3' },
+          { type: 'addition', content: 'const z = 4' },
+          { type: 'context', content: 'export { x }' },
+        ],
+      },
+    ],
+  },
+];
+
+describe('DiffViewer inline comments (#6800)', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+  const sendInputSpy = jest.fn((_input: string) => 'sent' as 'sent' | 'queued' | false);
+  const requestDiffSpy = jest.fn();
+  const onClose = jest.fn();
+  let capturedCallback: ((r: DiffResult) => void) | null = null;
+
+  function render() {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<DiffViewer visible onClose={onClose} />);
+    });
+    activeTree = tree;
+    return tree;
+  }
+
+  function seedFiles(tree: renderer.ReactTestRenderer, files: DiffFile[] = FILES) {
+    act(() => {
+      capturedCallback?.({ files, error: null });
+    });
+    // Drill into the first file so the hunk lines render.
+    const entry = tree.root.findByProps({ testID: `diff-file-${files[0]!.path}` });
+    act(() => {
+      entry.props.onPress?.();
+    });
+  }
+
+  beforeEach(() => {
+    sendInputSpy.mockClear();
+    sendInputSpy.mockReturnValue('sent');
+    requestDiffSpy.mockClear();
+    onClose.mockClear();
+    capturedCallback = null;
+    useConnectionStore.setState({
+      sendInput: sendInputSpy as any,
+      requestDiff: requestDiffSpy as any,
+      setDiffCallback: ((cb: any) => {
+        capturedCallback = cb;
+      }) as any,
+    });
+  });
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => {
+        activeTree!.unmount();
+      });
+      activeTree = null;
+    }
+  });
+
+  it('requests the diff on open', () => {
+    render();
+    expect(requestDiffSpy).toHaveBeenCalled();
+  });
+
+  it('renders a comment affordance per diff line', () => {
+    const tree = render();
+    seedFiles(tree);
+    // 5 lines → 5 tappable line targets.
+    expect(tree.root.findAllByProps({ testID: 'diff-line-0' }).length).toBeGreaterThan(0);
+    expect(tree.root.findAllByProps({ testID: 'diff-line-4' }).length).toBeGreaterThan(0);
+  });
+
+  it('adds a comment and exposes the submit action', () => {
+    const tree = render();
+    seedFiles(tree);
+
+    // Open editor on the deletion line (index 1).
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-line-1' }).props.onPress?.();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-input' }).props.onChangeText?.('why remove?');
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-save' }).props.onPress?.();
+    });
+
+    // Submit control now present.
+    expect(tree.root.findAllByProps({ testID: 'diff-submit-comments' }).length).toBeGreaterThan(0);
+  });
+
+  it('submits queued comments as a composed prompt via sendInput and closes', () => {
+    const tree = render();
+    seedFiles(tree);
+
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-line-2' }).props.onPress?.(); // addition `const y = 3`
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-input' }).props.onChangeText?.('use a const enum');
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-save' }).props.onPress?.();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-submit-comments' }).props.onPress?.();
+    });
+
+    expect(sendInputSpy).toHaveBeenCalledTimes(1);
+    const prompt = sendInputSpy.mock.calls[0]![0] as unknown as string;
+    expect(prompt).toContain('review comment');
+    expect(prompt).toContain('src/utils/helper.ts:');
+    expect(prompt).toContain('use a const enum');
+    expect(prompt).toContain('Line 11'); // derived new-file line number
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('triggers a one-click review over the whole diff via sendInput', () => {
+    const tree = render();
+    seedFiles(tree);
+
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-review-code' }).props.onPress?.();
+    });
+
+    expect(sendInputSpy).toHaveBeenCalledTimes(1);
+    const prompt = sendInputSpy.mock.calls[0]![0] as unknown as string;
+    expect(prompt).toContain('review the current uncommitted changes');
+    expect(prompt).toContain('src/utils/helper.ts');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('removes a queued comment', () => {
+    const tree = render();
+    seedFiles(tree);
+
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-line-0' }).props.onPress?.();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-input' }).props.onChangeText?.('note');
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-save' }).props.onPress?.();
+    });
+    expect(tree.root.findAllByProps({ testID: 'diff-submit-comments' }).length).toBeGreaterThan(0);
+
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-remove-0' }).props.onPress?.();
+    });
+    expect(tree.root.findAllByProps({ testID: 'diff-submit-comments' }).length).toBe(0);
+  });
+});

--- a/packages/dashboard/src/components/DiffViewerPanel.test.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.test.tsx
@@ -7,6 +7,7 @@ import { DiffViewerPanel } from './DiffViewerPanel'
 
 const mockSetDiffCallback = vi.fn()
 const mockRequestDiff = vi.fn()
+const mockSendInput = vi.fn((_input: string) => 'sent' as 'sent' | 'queued' | false)
 
 let storeState: Record<string, unknown> = {}
 let capturedCallback: ((result: any) => void) | null = null
@@ -20,6 +21,7 @@ vi.mock('../store/connection', () => ({
       },
       requestDiff: mockRequestDiff,
       connectionPhase: storeState.connectionPhase ?? 'connected',
+      sendInput: mockSendInput,
     }
     return selector(store)
   },
@@ -29,6 +31,7 @@ afterEach(() => cleanup())
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockSendInput.mockReturnValue('sent')
   storeState = { connectionPhase: 'connected' }
   capturedCallback = null
 })
@@ -181,5 +184,111 @@ describe('DiffViewerPanel', () => {
     const fileViews = screen.getAllByTestId('diff-file-view')
     expect(fileViews[0]!.textContent).toContain('M')
     expect(fileViews[1]!.textContent).toContain('A')
+  })
+
+  // ---- #6800: inline comments + review triggers ----
+
+  it('exposes a comment affordance on each unified line', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+    // 5 lines in the fixture hunk → 5 comment buttons.
+    expect(screen.getAllByTestId('diff-line-comment-btn')).toHaveLength(5)
+  })
+
+  it('does not render comment buttons in split view', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+    fireEvent.click(screen.getByText('Split'))
+    expect(screen.queryByTestId('diff-line-comment-btn')).toBeNull()
+  })
+
+  it('opens an inline editor and queues a comment, showing the submit control', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    // Open the editor on the second line (the deletion `const y = 2`).
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[1]!)
+    const input = screen.getByTestId('diff-comment-input') as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'why remove this?' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+
+    // The note is shown and the toolbar exposes a single-comment submit button.
+    expect(screen.getByTestId('diff-line-comment-note').textContent).toContain('why remove this?')
+    expect(screen.getByTestId('diff-submit-comments-btn').textContent).toContain('Submit 1 comment')
+  })
+
+  it('submits queued comments as a composed prompt via sendInput', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[2]!) // addition `const y = 3`
+    fireEvent.change(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'use a const enum' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    fireEvent.click(screen.getByTestId('diff-submit-comments-btn'))
+
+    expect(mockSendInput).toHaveBeenCalledTimes(1)
+    const prompt = mockSendInput.mock.calls[0]![0] as string
+    expect(prompt).toContain('review comment')
+    expect(prompt).toContain('src/utils/helper.ts:')
+    expect(prompt).toContain('use a const enum')
+    // The derived new-file line number for the first addition is 11.
+    expect(prompt).toContain('Line 11')
+
+    // After a successful send the queue clears and a confirmation shows.
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
+    expect(screen.getByTestId('diff-toolbar-sent')).toBeTruthy()
+  })
+
+  it('keeps queued comments when the send fails', () => {
+    mockSendInput.mockReturnValue(false as any)
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    fireEvent.click(screen.getByTestId('diff-submit-comments-btn'))
+
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+  })
+
+  it('removes a queued comment', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Remove comment'))
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
+  })
+
+  it('triggers a one-click review over the whole diff via sendInput', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: DIFF_FILES, error: null }))
+
+    fireEvent.click(screen.getByTestId('diff-review-btn'))
+    expect(mockSendInput).toHaveBeenCalledTimes(1)
+    const prompt = mockSendInput.mock.calls[0]![0] as string
+    expect(prompt).toContain('review the current uncommitted changes')
+    expect(prompt).toContain('src/utils/helper.ts')
+    expect(prompt).toContain('src/new-file.ts')
+  })
+
+  it('drops queued comments on refresh (positions may have shifted)', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Refresh'))
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/DiffViewerPanel.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.tsx
@@ -6,12 +6,56 @@
  * - Unified diff view with syntax-highlighted lines
  * - Unified/split view toggle
  * - Auto-refresh on mount, manual refresh button
+ * - #6800: per-line inline comments + a one-click "Review code" trigger. A line
+ *   in the unified view can be annotated with free text; pending comments across
+ *   files are queued and submitted together as the next user turn for the agent
+ *   to address (via the normal `input` wire path — no new WS message type). This
+ *   is always on (not gated behind features.ide) since it acts on already-written
+ *   uncommitted changes, not the pre-write edit surface.
  */
 import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  composeCommentReviewPrompt,
+  composeReviewRequestPrompt,
+  deriveLineNumber,
+  type DiffLineComment,
+} from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
 import type { DiffFile, DiffHunk, DiffHunkLine, DiffResult } from '../store/types'
 
 type ViewMode = 'unified' | 'split'
+
+/** Stable, position-derived key for one diff line (used as the comment id). */
+function lineKey(filePath: string, hunkIndex: number, lineIndex: number): string {
+  return `${filePath}#${hunkIndex}#${lineIndex}`
+}
+
+/**
+ * Opening a line's comment editor: everything the composer needs to build the
+ * DiffLineComment on save, plus the stable key.
+ */
+type LineCommentTarget = {
+  key: string
+  filePath: string
+  lineNumber: number | null
+  lineType: DiffHunkLine['type']
+  lineContent: string
+}
+
+/**
+ * Commenting wiring threaded down to the unified-view lines. Absent for the
+ * read-only / split-view / PreWriteDiffReview renders, which stay unchanged.
+ */
+type CommentApi = {
+  comments: DiffLineComment[]
+  editingKey: string | null
+  draft: string
+  onOpen: (target: LineCommentTarget) => void
+  onDraftChange: (text: string) => void
+  onSave: () => void
+  onCancel: () => void
+  onRemove: (key: string) => void
+}
 
 function statusLabel(status: DiffFile['status']): string {
   switch (status) {
@@ -59,6 +103,112 @@ function UnifiedLine({ line }: { line: DiffHunkLine }) {
       <span className="diff-line-prefix">{prefix}</span>
       <span className="diff-line-content">{line.content}</span>
     </div>
+  )
+}
+
+/**
+ * A unified-view line with an inline-comment affordance (#6800). Renders the
+ * same content as UnifiedLine plus a gutter "comment" button; when a comment is
+ * attached it shows below the line, and clicking the button (or an existing
+ * comment) opens the inline editor. Only used when a CommentApi is supplied.
+ */
+function CommentableLine({
+  line,
+  target,
+  hasComment,
+  existingText,
+  isEditing,
+  draft,
+  onOpen,
+  onDraftChange,
+  onSave,
+  onCancel,
+  onRemove,
+}: {
+  line: DiffHunkLine
+  target: LineCommentTarget
+  hasComment: boolean
+  existingText: string | undefined
+  isEditing: boolean
+  draft: string
+  onOpen: (target: LineCommentTarget) => void
+  onDraftChange: (text: string) => void
+  onSave: () => void
+  onCancel: () => void
+  onRemove: (key: string) => void
+}) {
+  const cls =
+    line.type === 'addition' ? 'diff-line-add' :
+    line.type === 'deletion' ? 'diff-line-del' :
+    'diff-line-ctx'
+  const prefix = line.type === 'addition' ? '+' : line.type === 'deletion' ? '-' : ' '
+  return (
+    <>
+      <div
+        className={`diff-line diff-line-commentable ${cls}${hasComment ? ' diff-line-has-comment' : ''}`}
+        data-testid="diff-line"
+      >
+        <button
+          type="button"
+          className="diff-line-comment-btn"
+          onClick={() => onOpen(target)}
+          title={hasComment ? 'Edit comment' : 'Comment on this line'}
+          aria-label={hasComment ? 'Edit comment on this line' : 'Comment on this line'}
+          data-testid="diff-line-comment-btn"
+        >
+          <span aria-hidden="true">{hasComment ? '×' : '+'}</span>
+        </button>
+        <span className="diff-line-prefix">{prefix}</span>
+        <span className="diff-line-content">{line.content}</span>
+      </div>
+      {hasComment && !isEditing && (
+        <div className="diff-line-comment-note" data-testid="diff-line-comment-note">
+          <button
+            type="button"
+            className="diff-comment-note-text"
+            onClick={() => onOpen(target)}
+            title="Edit comment"
+          >
+            {existingText}
+          </button>
+          <button
+            type="button"
+            className="diff-comment-remove"
+            onClick={() => onRemove(target.key)}
+            aria-label="Remove comment"
+          >
+            Remove
+          </button>
+        </div>
+      )}
+      {isEditing && (
+        <div className="diff-line-comment-editor" data-testid="diff-line-comment-editor">
+          <textarea
+            className="diff-comment-input"
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            placeholder="Leave a comment for Claude…"
+            rows={2}
+            autoFocus
+            data-testid="diff-comment-input"
+          />
+          <div className="diff-comment-editor-actions">
+            <button
+              type="button"
+              className="diff-comment-save"
+              onClick={onSave}
+              disabled={draft.trim().length === 0}
+              data-testid="diff-comment-save"
+            >
+              Add comment
+            </button>
+            <button type="button" className="diff-comment-cancel" onClick={onCancel}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   )
 }
 
@@ -120,10 +270,29 @@ type HunkSelectionProps =
   | { selectable?: false; selected?: never; onToggle?: never }
   | { selectable: true; selected: boolean; onToggle: () => void }
 
-export type HunkViewProps = { hunk: DiffHunk; viewMode: ViewMode } & HunkSelectionProps
+export type HunkViewProps = {
+  hunk: DiffHunk
+  viewMode: ViewMode
+  /** #6800: identity + comment wiring for the unified-view inline comments. */
+  filePath?: string
+  hunkIndex?: number
+  commentApi?: CommentApi
+} & HunkSelectionProps
 
-export function HunkView({ hunk, viewMode, selectable = false, selected = false, onToggle }: HunkViewProps) {
+export function HunkView({
+  hunk,
+  viewMode,
+  filePath,
+  hunkIndex = 0,
+  commentApi,
+  selectable = false,
+  selected = false,
+  onToggle,
+}: HunkViewProps) {
   const cls = `diff-hunk${selectable ? ` diff-hunk-selectable${selected ? '' : ' diff-hunk-rejected'}` : ''}`
+  // Inline comments only in unified view, and only when a CommentApi + filePath
+  // are supplied. Split view and read-only consumers keep the original render.
+  const commentsOn = viewMode === 'unified' && !!commentApi && filePath != null
   return (
     <div className={cls} data-testid="diff-hunk">
       {selectable ? (
@@ -142,7 +311,34 @@ export function HunkView({ hunk, viewMode, selectable = false, selected = false,
         <HunkHeader header={hunk.header} />
       )}
       {viewMode === 'unified' ? (
-        hunk.lines.map((line, i) => <UnifiedLine key={i} line={line} />)
+        hunk.lines.map((line, i) => {
+          if (!commentsOn) return <UnifiedLine key={i} line={line} />
+          const api = commentApi!
+          const key = lineKey(filePath!, hunkIndex, i)
+          const existing = api.comments.find((c) => c.id === key)
+          return (
+            <CommentableLine
+              key={i}
+              line={line}
+              target={{
+                key,
+                filePath: filePath!,
+                lineNumber: deriveLineNumber(hunk, i),
+                lineType: line.type,
+                lineContent: line.content,
+              }}
+              hasComment={!!existing}
+              existingText={existing?.comment}
+              isEditing={api.editingKey === key}
+              draft={api.draft}
+              onOpen={api.onOpen}
+              onDraftChange={api.onDraftChange}
+              onSave={api.onSave}
+              onCancel={api.onCancel}
+              onRemove={api.onRemove}
+            />
+          )
+        })
       ) : (
         buildSplitPairs(hunk.lines).map((pair, i) => <SplitLine key={i} left={pair.left} right={pair.right} />)
       )}
@@ -150,7 +346,15 @@ export function HunkView({ hunk, viewMode, selectable = false, selected = false,
   )
 }
 
-function FileView({ file, viewMode }: { file: DiffFile; viewMode: ViewMode }) {
+function FileView({
+  file,
+  viewMode,
+  commentApi,
+}: {
+  file: DiffFile
+  viewMode: ViewMode
+  commentApi?: CommentApi
+}) {
   return (
     <div className="diff-file-view" data-testid="diff-file-view">
       <div className="diff-file-header">
@@ -166,7 +370,16 @@ function FileView({ file, viewMode }: { file: DiffFile; viewMode: ViewMode }) {
       {file.hunks.length === 0 ? (
         <div className="diff-empty-file">Binary file or no diff available</div>
       ) : (
-        file.hunks.map((hunk, i) => <HunkView key={i} hunk={hunk} viewMode={viewMode} />)
+        file.hunks.map((hunk, i) => (
+          <HunkView
+            key={i}
+            hunk={hunk}
+            viewMode={viewMode}
+            filePath={file.path}
+            hunkIndex={i}
+            commentApi={commentApi}
+          />
+        ))
       )}
     </div>
   )
@@ -176,6 +389,7 @@ export function DiffViewerPanel() {
   const setDiffCallback = useConnectionStore(s => s.setDiffCallback)
   const requestDiff = useConnectionStore(s => s.requestDiff)
   const connectionPhase = useConnectionStore(s => s.connectionPhase)
+  const sendInput = useConnectionStore(s => s.sendInput)
 
   const [files, setFiles] = useState<DiffFile[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -183,6 +397,12 @@ export function DiffViewerPanel() {
   const [viewMode, setViewMode] = useState<ViewMode>('unified')
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
+
+  // #6800: pending inline comments + the open editor.
+  const [comments, setComments] = useState<DiffLineComment[]>([])
+  const [editing, setEditing] = useState<LineCommentTarget | null>(null)
+  const [draft, setDraft] = useState('')
+  const [justSent, setJustSent] = useState<'comments' | 'review' | null>(null)
 
   // Wire callback
   useEffect(() => {
@@ -202,7 +422,19 @@ export function DiffViewerPanel() {
     }
   }, [connectionPhase, requestDiff])
 
+  // Auto-clear the "Sent to Claude" confirmation.
+  useEffect(() => {
+    if (!justSent) return
+    const t = setTimeout(() => setJustSent(null), 2500)
+    return () => clearTimeout(t)
+  }, [justSent])
+
   const handleRefresh = useCallback(() => {
+    // A refreshed diff can shift line positions, invalidating position-keyed
+    // comments — drop pending annotations so none land on the wrong line.
+    setComments([])
+    setEditing(null)
+    setDraft('')
     setLoading(true)
     requestDiff()
   }, [requestDiff])
@@ -214,8 +446,82 @@ export function DiffViewerPanel() {
     if (el && el.scrollIntoView) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [])
 
+  const handleOpenComment = useCallback((target: LineCommentTarget) => {
+    setEditing(target)
+    setComments((prev) => {
+      const existing = prev.find((c) => c.id === target.key)
+      setDraft(existing?.comment ?? '')
+      return prev
+    })
+  }, [])
+
+  const handleSaveComment = useCallback(() => {
+    if (!editing) return
+    const text = draft.trim()
+    if (!text) return
+    setComments((prev) => {
+      const next: DiffLineComment = {
+        id: editing.key,
+        filePath: editing.filePath,
+        lineNumber: editing.lineNumber,
+        lineType: editing.lineType,
+        lineContent: editing.lineContent,
+        comment: text,
+      }
+      const idx = prev.findIndex((c) => c.id === editing.key)
+      if (idx >= 0) {
+        const copy = [...prev]
+        copy[idx] = next
+        return copy
+      }
+      return [...prev, next]
+    })
+    setEditing(null)
+    setDraft('')
+  }, [editing, draft])
+
+  const handleCancelComment = useCallback(() => {
+    setEditing(null)
+    setDraft('')
+  }, [])
+
+  const handleRemoveComment = useCallback((key: string) => {
+    setComments((prev) => prev.filter((c) => c.id !== key))
+    setEditing((cur) => (cur?.key === key ? null : cur))
+  }, [])
+
+  const handleSubmitComments = useCallback(() => {
+    if (comments.length === 0) return
+    const prompt = composeCommentReviewPrompt(comments)
+    if (!prompt) return
+    const result = sendInput(prompt)
+    if (result) {
+      setComments([])
+      setEditing(null)
+      setDraft('')
+      setJustSent('comments')
+    }
+  }, [comments, sendInput])
+
+  const handleReview = useCallback(() => {
+    const prompt = composeReviewRequestPrompt(files.map((f) => ({ path: f.path })))
+    const result = sendInput(prompt)
+    if (result) setJustSent('review')
+  }, [files, sendInput])
+
   const totalAdditions = files.reduce((sum, f) => sum + f.additions, 0)
   const totalDeletions = files.reduce((sum, f) => sum + f.deletions, 0)
+
+  const commentApi: CommentApi = {
+    comments,
+    editingKey: editing?.key ?? null,
+    draft,
+    onOpen: handleOpenComment,
+    onDraftChange: setDraft,
+    onSave: handleSaveComment,
+    onCancel: handleCancelComment,
+    onRemove: handleRemoveComment,
+  }
 
   return (
     <div className="diff-viewer-panel" data-testid="diff-viewer-panel">
@@ -230,8 +536,35 @@ export function DiffViewerPanel() {
               {totalDeletions > 0 && <span className="diff-stat-del"> -{totalDeletions}</span>}
             </span>
           )}
+          {justSent && (
+            <span className="diff-toolbar-sent" data-testid="diff-toolbar-sent">
+              {' '}Sent to Claude
+            </span>
+          )}
         </span>
         <div className="diff-toolbar-actions">
+          {comments.length > 0 && (
+            <button
+              type="button"
+              className="diff-submit-btn"
+              onClick={handleSubmitComments}
+              data-testid="diff-submit-comments-btn"
+              title="Send your comments to Claude"
+            >
+              Submit {comments.length} comment{comments.length !== 1 ? 's' : ''}
+            </button>
+          )}
+          {files.length > 0 && (
+            <button
+              type="button"
+              className="diff-review-btn"
+              onClick={handleReview}
+              data-testid="diff-review-btn"
+              title="Ask Claude to review these changes"
+            >
+              Review code
+            </button>
+          )}
           <button
             type="button"
             className={`diff-view-btn${viewMode === 'unified' ? ' active' : ''}`}
@@ -289,7 +622,7 @@ export function DiffViewerPanel() {
           )}
           {!loading && !error && files.map(f => (
             <div key={f.path} data-diff-path={f.path}>
-              <FileView file={f} viewMode={viewMode} />
+              <FileView file={f} viewMode={viewMode} commentApi={commentApi} />
             </div>
           ))}
         </div>

--- a/packages/dashboard/src/components/DiffViewerPanel.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.tsx
@@ -17,7 +17,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   composeCommentReviewPrompt,
   composeReviewRequestPrompt,
-  deriveLineNumber,
+  parseHunkStartLines,
   type DiffLineComment,
 } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
@@ -311,34 +311,53 @@ export function HunkView({
         <HunkHeader header={hunk.header} />
       )}
       {viewMode === 'unified' ? (
-        hunk.lines.map((line, i) => {
-          if (!commentsOn) return <UnifiedLine key={i} line={line} />
-          const api = commentApi!
-          const key = lineKey(filePath!, hunkIndex, i)
-          const existing = api.comments.find((c) => c.id === key)
-          return (
-            <CommentableLine
-              key={i}
-              line={line}
-              target={{
-                key,
-                filePath: filePath!,
-                lineNumber: deriveLineNumber(hunk, i),
-                lineType: line.type,
-                lineContent: line.content,
-              }}
-              hasComment={!!existing}
-              existingText={existing?.comment}
-              isEditing={api.editingKey === key}
-              draft={api.draft}
-              onOpen={api.onOpen}
-              onDraftChange={api.onDraftChange}
-              onSave={api.onSave}
-              onCancel={api.onCancel}
-              onRemove={api.onRemove}
-            />
-          )
-        })
+        !commentsOn
+          ? hunk.lines.map((line, i) => <UnifiedLine key={i} line={line} />)
+          : (() => {
+              const api = commentApi!
+              // #6930: single forward pass over hunk.lines, accumulating the
+              // old/new line counters as we go — mirrors deriveLineNumber's
+              // logic exactly, but avoids the O(i) rescan that calling
+              // deriveLineNumber(hunk, i) per line would incur (making the
+              // whole hunk render O(n^2)). Rendered line numbers stay
+              // byte-identical to the per-line helper.
+              const starts = parseHunkStartLines(hunk.header)
+              let oldLine = starts?.oldStart ?? 0
+              let newLine = starts?.newStart ?? 0
+              return hunk.lines.map((line, i) => {
+                const lineNumber = starts ? (line.type === 'deletion' ? oldLine : newLine) : null
+                if (line.type === 'deletion') oldLine++
+                else if (line.type === 'addition') newLine++
+                else {
+                  oldLine++
+                  newLine++
+                }
+                const key = lineKey(filePath!, hunkIndex, i)
+                const existing = api.comments.find((c) => c.id === key)
+                return (
+                  <CommentableLine
+                    key={i}
+                    line={line}
+                    target={{
+                      key,
+                      filePath: filePath!,
+                      lineNumber,
+                      lineType: line.type,
+                      lineContent: line.content,
+                    }}
+                    hasComment={!!existing}
+                    existingText={existing?.comment}
+                    isEditing={api.editingKey === key}
+                    draft={api.draft}
+                    onOpen={api.onOpen}
+                    onDraftChange={api.onDraftChange}
+                    onSave={api.onSave}
+                    onCancel={api.onCancel}
+                    onRemove={api.onRemove}
+                  />
+                )
+              })
+            })()
       ) : (
         buildSplitPairs(hunk.lines).map((pair, i) => <SplitLine key={i} left={pair.left} right={pair.right} />)
       )}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9351,6 +9351,179 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.5;
 }
 
+/* ---- #6800: inline line comments + review triggers ---- */
+/* Toolbar actions: "Submit N comments" + "Review code". */
+.diff-submit-btn,
+.diff-review-btn {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.diff-review-btn {
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+}
+
+.diff-review-btn:hover {
+  background: var(--bg-card);
+}
+
+.diff-submit-btn {
+  background: var(--accent-blue);
+  color: var(--text-primary);
+  border-color: var(--accent-blue);
+  font-weight: 600;
+}
+
+.diff-submit-btn:hover {
+  background: var(--accent-blue-border-strong);
+}
+
+.diff-toolbar-sent {
+  font-size: var(--text-sm);
+  font-weight: 400;
+  color: var(--accent-green);
+}
+
+/* A commentable unified line reserves a left gutter for the "+" button and
+ * keeps the prefix/content aligned with the read-only lines above it. */
+.diff-line-commentable {
+  position: relative;
+  padding-left: 34px;
+}
+
+.diff-line-comment-btn {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  line-height: 1;
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  background: var(--bg-card);
+  color: var(--accent-blue);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.diff-line-commentable:hover .diff-line-comment-btn,
+.diff-line-has-comment .diff-line-comment-btn,
+.diff-line-comment-btn:focus-visible {
+  opacity: 1;
+}
+
+.diff-line-has-comment {
+  box-shadow: inset 2px 0 0 0 var(--accent-blue);
+}
+
+.diff-line-comment-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 16px 6px 34px;
+  background: var(--accent-blue-light);
+  border-left: 2px solid var(--accent-blue);
+  font-size: var(--text-sm);
+}
+
+.diff-comment-note-text {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  text-align: left;
+  white-space: pre-wrap;
+  word-break: break-word;
+  cursor: pointer;
+}
+
+.diff-comment-remove {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  font-size: var(--text-xs);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.diff-comment-remove:hover {
+  color: var(--accent-red);
+  border-color: var(--accent-red-border);
+}
+
+.diff-line-comment-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 16px 8px 34px;
+  background: var(--bg-tertiary);
+  border-left: 2px solid var(--accent-blue);
+}
+
+.diff-comment-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  background: var(--bg-input);
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  resize: vertical;
+}
+
+.diff-comment-input:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.diff-comment-editor-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.diff-comment-save {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  border: 1px solid var(--accent-blue);
+  border-radius: 4px;
+  background: var(--accent-blue);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.diff-comment-save:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.diff-comment-cancel {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
 /* ---- Git Panel (#6780) ---- */
 .git-panel {
   display: flex;

--- a/packages/store-core/src/diff-comments.test.ts
+++ b/packages/store-core/src/diff-comments.test.ts
@@ -137,6 +137,21 @@ describe('composeCommentReviewPrompt', () => {
     expect(prompt).toContain('…')
     expect(prompt.length).toBeLessThan(long.length + 200)
   })
+
+  it('uses a wider backtick fence when the snippet itself contains backticks', () => {
+    const prompt = composeCommentReviewPrompt([
+      comment({
+        lineNumber: 7,
+        lineType: 'addition',
+        lineContent: 'const msg = `hello ${name}`',
+        comment: 'avoid the template literal here',
+      }),
+    ])
+    // A single backtick fence would prematurely close on the snippet's own
+    // backticks and corrupt the prompt; the fence must widen to `` and pad.
+    expect(prompt).toContain('`` const msg = `hello ${name}` ``')
+    expect(prompt).toContain(': avoid the template literal here')
+  })
 })
 
 describe('composeReviewRequestPrompt', () => {

--- a/packages/store-core/src/diff-comments.test.ts
+++ b/packages/store-core/src/diff-comments.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the diff line-comment → prompt composition helpers (#6800).
+ *
+ * Both clients (dashboard `DiffViewerPanel` + mobile `DiffViewer`) call these to
+ * turn inline line comments / a review request into the user turn sent over the
+ * `input` wire path. The tests double as the contract that keeps the two
+ * clients' prompts identical.
+ */
+import { describe, it, expect } from 'vitest'
+import type { DiffHunk } from './types/git'
+import {
+  parseHunkStartLines,
+  deriveLineNumber,
+  composeCommentReviewPrompt,
+  composeReviewRequestPrompt,
+  type DiffLineComment,
+} from './diff-comments'
+
+const HUNK: DiffHunk = {
+  header: '@@ -10,6 +10,9 @@',
+  lines: [
+    { type: 'context', content: 'const x = 1' }, // new 10 / old 10
+    { type: 'deletion', content: 'const y = 2' }, // old 11
+    { type: 'addition', content: 'const y = 3' }, // new 11
+    { type: 'addition', content: 'const z = 4' }, // new 12
+    { type: 'context', content: 'export { x }' }, // new 13
+  ],
+}
+
+function comment(over: Partial<DiffLineComment>): DiffLineComment {
+  return {
+    id: over.id ?? 'a#0#0',
+    filePath: over.filePath ?? 'src/foo.ts',
+    lineNumber: 'lineNumber' in over ? (over.lineNumber ?? null) : 10,
+    lineType: over.lineType ?? 'addition',
+    lineContent: over.lineContent ?? 'const x = 1',
+    comment: over.comment ?? 'fix this',
+  }
+}
+
+describe('parseHunkStartLines', () => {
+  it('parses old and new start lines', () => {
+    expect(parseHunkStartLines('@@ -10,6 +10,9 @@')).toEqual({ oldStart: 10, newStart: 10 })
+  })
+
+  it('parses single-count headers (no comma)', () => {
+    expect(parseHunkStartLines('@@ -0,0 +1 @@')).toEqual({ oldStart: 0, newStart: 1 })
+  })
+
+  it('tolerates a trailing section heading', () => {
+    expect(parseHunkStartLines('@@ -5,3 +7,4 @@ function foo() {')).toEqual({
+      oldStart: 5,
+      newStart: 7,
+    })
+  })
+
+  it('returns null for a malformed header', () => {
+    expect(parseHunkStartLines('not a hunk header')).toBeNull()
+  })
+})
+
+describe('deriveLineNumber', () => {
+  it('maps context/addition lines to their new-file line number', () => {
+    expect(deriveLineNumber(HUNK, 0)).toBe(10) // context
+    expect(deriveLineNumber(HUNK, 2)).toBe(11) // first addition
+    expect(deriveLineNumber(HUNK, 3)).toBe(12) // second addition
+    expect(deriveLineNumber(HUNK, 4)).toBe(13) // trailing context
+  })
+
+  it('maps deletion lines to their old-file line number', () => {
+    expect(deriveLineNumber(HUNK, 1)).toBe(11) // deletion
+  })
+
+  it('returns null for an out-of-range index', () => {
+    expect(deriveLineNumber(HUNK, 99)).toBeNull()
+  })
+
+  it('returns null when the header is unparseable', () => {
+    expect(deriveLineNumber({ header: 'bad', lines: HUNK.lines }, 0)).toBeNull()
+  })
+})
+
+describe('composeCommentReviewPrompt', () => {
+  it('returns empty string for no comments', () => {
+    expect(composeCommentReviewPrompt([])).toBe('')
+  })
+
+  it('drops whitespace-only comments', () => {
+    expect(composeCommentReviewPrompt([comment({ comment: '   ' })])).toBe('')
+  })
+
+  it('composes a single comment with a line number and snippet', () => {
+    const prompt = composeCommentReviewPrompt([
+      comment({
+        filePath: 'src/foo.ts',
+        lineNumber: 42,
+        lineType: 'addition',
+        lineContent: '  const value = compute()',
+        comment: 'handle the null case',
+      }),
+    ])
+    expect(prompt).toContain('1 review comment on the current uncommitted changes')
+    expect(prompt).toContain('src/foo.ts:')
+    expect(prompt).toContain('- Line 42 (`const value = compute()`): handle the null case')
+  })
+
+  it('pluralizes the count and groups by file, ordered by line number', () => {
+    const prompt = composeCommentReviewPrompt([
+      comment({ id: 'b', filePath: 'src/b.ts', lineNumber: 20, comment: 'second file' }),
+      comment({ id: 'a2', filePath: 'src/a.ts', lineNumber: 30, comment: 'later line' }),
+      comment({ id: 'a1', filePath: 'src/a.ts', lineNumber: 5, comment: 'earlier line' }),
+    ])
+    expect(prompt).toContain('3 review comments')
+    // first-seen file order: src/b.ts before src/a.ts
+    expect(prompt.indexOf('src/b.ts:')).toBeLessThan(prompt.indexOf('src/a.ts:'))
+    // within src/a.ts, line 5 sorts before line 30
+    expect(prompt.indexOf('earlier line')).toBeLessThan(prompt.indexOf('later line'))
+  })
+
+  it('labels deletion lines as removed', () => {
+    const prompt = composeCommentReviewPrompt([
+      comment({ lineNumber: 12, lineType: 'deletion', lineContent: 'old()', comment: 'why removed?' }),
+    ])
+    expect(prompt).toContain('- Removed line 12 (`old()`): why removed?')
+  })
+
+  it('omits the number when line number is null', () => {
+    const prompt = composeCommentReviewPrompt([
+      comment({ lineNumber: null, lineType: 'context', lineContent: 'ctx', comment: 'note' }),
+    ])
+    expect(prompt).toContain('- Line (`ctx`): note')
+  })
+
+  it('truncates an overlong line snippet', () => {
+    const long = 'x'.repeat(500)
+    const prompt = composeCommentReviewPrompt([comment({ lineContent: long, comment: 'c' })])
+    expect(prompt).toContain('…')
+    expect(prompt.length).toBeLessThan(long.length + 200)
+  })
+})
+
+describe('composeReviewRequestPrompt', () => {
+  it('returns a bare review request with no files', () => {
+    const prompt = composeReviewRequestPrompt()
+    expect(prompt).toContain('Please review the current uncommitted changes')
+    expect(prompt).not.toContain('Changed files:')
+  })
+
+  it('lists changed file paths when provided', () => {
+    const prompt = composeReviewRequestPrompt([{ path: 'src/a.ts' }, { path: 'src/b.ts' }])
+    expect(prompt).toContain('Changed files:')
+    expect(prompt).toContain('- src/a.ts')
+    expect(prompt).toContain('- src/b.ts')
+  })
+
+  it('ignores empty paths', () => {
+    expect(composeReviewRequestPrompt([{ path: '' }])).not.toContain('Changed files:')
+  })
+})

--- a/packages/store-core/src/diff-comments.ts
+++ b/packages/store-core/src/diff-comments.ts
@@ -1,0 +1,135 @@
+/**
+ * Diff line-comment → prompt composition (#6800).
+ *
+ * Pure, client-agnostic helpers shared by the dashboard `DiffViewerPanel` and
+ * the mobile `DiffViewer`. They turn a set of inline line comments (or a bare
+ * "review this diff" request) into the plain-text user turn that gets sent to
+ * the agent over the normal `input` wire path — no new WS message type, no
+ * server-side relay. Keeping the composition here means both clients produce
+ * byte-identical prompts and the logic is unit-testable without a DOM.
+ */
+import type { DiffHunk, DiffHunkLine } from './types/git'
+
+/**
+ * A single pending inline comment attached to one diff line.
+ *
+ * `id` is a stable, position-derived key the UI uses to dedup/replace a comment
+ * on the same line — the prompt formatter ignores it. `lineNumber` is the
+ * 1-based line number in the relevant file (new file for additions/context,
+ * old file for deletions) or `null` when the hunk header can't be parsed.
+ */
+export interface DiffLineComment {
+  id: string
+  filePath: string
+  lineNumber: number | null
+  lineType: DiffHunkLine['type']
+  lineContent: string
+  comment: string
+}
+
+/** Cap a line snippet so one pathological line can't blow up the prompt. */
+const MAX_LINE_SNIPPET = 160
+
+/**
+ * Parse the `@@ -oldStart,oldCount +newStart,newCount @@` header into the two
+ * 1-based starting line numbers. Returns `null` for a malformed header.
+ */
+export function parseHunkStartLines(
+  header: string,
+): { oldStart: number; newStart: number } | null {
+  const m = /@@\s*-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s*@@/.exec(header)
+  if (!m) return null
+  return { oldStart: Number(m[1]), newStart: Number(m[2]) }
+}
+
+/**
+ * Derive the 1-based line number for `hunk.lines[lineIndex]`.
+ *
+ * Additions and context lines resolve to their new-file line number; deletions
+ * resolve to their old-file line number (they don't exist in the new file).
+ * Returns `null` if the header can't be parsed or the index is out of range.
+ */
+export function deriveLineNumber(hunk: DiffHunk, lineIndex: number): number | null {
+  const starts = parseHunkStartLines(hunk.header)
+  if (!starts) return null
+  const target = hunk.lines[lineIndex]
+  if (!target) return null
+  let oldLine = starts.oldStart
+  let newLine = starts.newStart
+  for (let i = 0; i < lineIndex; i++) {
+    const t = hunk.lines[i]!.type
+    if (t === 'deletion') oldLine++
+    else if (t === 'addition') newLine++
+    else {
+      oldLine++
+      newLine++
+    }
+  }
+  return target.type === 'deletion' ? oldLine : newLine
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s
+}
+
+function locatorFor(comment: DiffLineComment): string {
+  const removed = comment.lineType === 'deletion'
+  if (comment.lineNumber == null) return removed ? 'Removed line' : 'Line'
+  return removed ? `Removed line ${comment.lineNumber}` : `Line ${comment.lineNumber}`
+}
+
+/**
+ * Compose the user turn that asks the agent to address a set of inline line
+ * comments on the current uncommitted changes. Comments are grouped by file (in
+ * first-seen order) and, within a file, ordered by line number ascending
+ * (null line numbers last). Empty/whitespace-only comments are dropped; returns
+ * `''` when nothing actionable remains (callers guard the submit action on a
+ * non-empty prompt).
+ */
+export function composeCommentReviewPrompt(comments: DiffLineComment[]): string {
+  const valid = comments.filter((c) => c.comment.trim().length > 0)
+  if (valid.length === 0) return ''
+
+  const byFile = new Map<string, DiffLineComment[]>()
+  for (const c of valid) {
+    const list = byFile.get(c.filePath)
+    if (list) list.push(c)
+    else byFile.set(c.filePath, [c])
+  }
+
+  const count = valid.length
+  const out: string[] = [
+    `Please address the following ${count} review comment${count === 1 ? '' : 's'} on the current uncommitted changes. Each references a specific file and line.`,
+  ]
+
+  for (const [filePath, fileComments] of byFile) {
+    out.push('')
+    out.push(`${filePath}:`)
+    const sorted = [...fileComments].sort((a, b) => {
+      if (a.lineNumber == null) return b.lineNumber == null ? 0 : 1
+      if (b.lineNumber == null) return -1
+      return a.lineNumber - b.lineNumber
+    })
+    for (const c of sorted) {
+      const snippet = truncate(c.lineContent.trim(), MAX_LINE_SNIPPET)
+      out.push(`  - ${locatorFor(c)} (\`${snippet}\`): ${c.comment.trim()}`)
+    }
+  }
+
+  return out.join('\n')
+}
+
+/**
+ * Compose the one-click "Review code" user turn over the whole uncommitted
+ * diff. When `files` is provided the changed paths are listed so the agent can
+ * scope its pass; otherwise a bare review request is returned.
+ */
+export function composeReviewRequestPrompt(
+  files: readonly { path: string }[] = [],
+): string {
+  const base =
+    'Please review the current uncommitted changes in this repository. Look for correctness bugs, missed edge cases, security issues, and style problems, and propose or make fixes as appropriate.'
+  const paths = files.map((f) => f.path).filter((p) => p.length > 0)
+  if (paths.length === 0) return base
+  return `${base}\n\nChanged files:\n${paths.map((p) => `- ${p}`).join('\n')}`
+}

--- a/packages/store-core/src/diff-comments.ts
+++ b/packages/store-core/src/diff-comments.ts
@@ -72,6 +72,24 @@ function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max - 1)}…` : s
 }
 
+/**
+ * Wrap `content` as a Markdown inline-code span, using a backtick fence one
+ * character longer than the longest run of backticks already inside it (the
+ * CommonMark rule for nesting a backtick inside inline code — e.g. a JS
+ * template literal snippet). Content that starts/ends with a backtick gets a
+ * single space of padding on that side so it can't fuse with the fence.
+ *
+ * For the common case (no backticks in the snippet) this degrades to a plain
+ * single-backtick span, so existing prompts stay byte-identical.
+ */
+function inlineCode(content: string): string {
+  const runs = content.match(/`+/g)
+  const maxRun = runs ? Math.max(...runs.map((r) => r.length)) : 0
+  const fence = '`'.repeat(maxRun + 1)
+  const needsPadding = content.startsWith('`') || content.endsWith('`')
+  return needsPadding ? `${fence} ${content} ${fence}` : `${fence}${content}${fence}`
+}
+
 function locatorFor(comment: DiffLineComment): string {
   const removed = comment.lineType === 'deletion'
   if (comment.lineNumber == null) return removed ? 'Removed line' : 'Line'
@@ -112,7 +130,7 @@ export function composeCommentReviewPrompt(comments: DiffLineComment[]): string 
     })
     for (const c of sorted) {
       const snippet = truncate(c.lineContent.trim(), MAX_LINE_SNIPPET)
-      out.push(`  - ${locatorFor(c)} (\`${snippet}\`): ${c.comment.trim()}`)
+      out.push(`  - ${locatorFor(c)} (${inlineCode(snippet)}): ${c.comment.trim()}`)
     }
   }
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -447,6 +447,18 @@ export {
   detectPasteFromDiff,
 } from './paste-text'
 
+// #6800: diff line-comment → prompt composition. Shared by the dashboard
+// DiffViewerPanel and mobile DiffViewer so inline review comments / a one-click
+// "Review code" request compose the same user turn on both clients.
+export {
+  parseHunkStartLines,
+  deriveLineNumber,
+  composeCommentReviewPrompt,
+  composeReviewRequestPrompt,
+} from './diff-comments'
+
+export type { DiffLineComment } from './diff-comments'
+
 export {
   PROVIDER_LABELS,
   getProviderLabel,


### PR DESCRIPTION
Closes #6800

## What

The always-on **Changes** diff viewer (`DiffViewerPanel` on the dashboard, `DiffViewer` on mobile) rendered uncommitted changes read-only. This adds the three missing PR-review-style capabilities, with desktop-app parity across **both clients**:

1. **Inline line comments** — click (dashboard, unified view) / tap (mobile) a diff line to attach free-text, independent of the existing per-hunk accept/reject checkbox (#6543).
2. **Submit to Claude** — queue multiple comments across files, then a single **Submit N comments** action injects them as the next user turn for the agent to address.
3. **One-click review** — a **Review code** action composes a review-request turn over the current uncommitted diff without hand-typing a prompt.

Not gated behind `features.ide` — it acts on already-written uncommitted changes, not the pre-write edit surface.

## How

- **`@chroxy/store-core` — `diff-comments.ts` (new, pure + tested):** derives a line's file line number from the hunk header (`deriveLineNumber`) and composes the user turn for both queued line comments (`composeCommentReviewPrompt`) and a whole-diff review (`composeReviewRequestPrompt`). Shared so both clients emit byte-identical prompts.
- **No new WS message type.** Submission reuses the existing `input` / `sendInput` wire path — the composed prompt goes over the normal conversation channel, so the agent addresses it on its next turn with no new server-side surface.
- **Dashboard `DiffViewerPanel`:** per-line comment affordance in the unified view (opt-in props, so the read-only + `PreWriteDiffReview` consumers of `HunkView` are byte-for-byte unchanged), an inline editor, a cross-file pending-comment queue, `Submit N comments` + `Review code` toolbar actions, and a transient "Sent to Claude" confirmation. Token-pure CSS.
- **Mobile `DiffViewer`:** the same inline-comment + review-trigger flow — a bottom action bar, a per-file pending-comment badge, an inline editor per line — reusing the shared helper; submit/review send via `sendInput` and close the modal.

## Tests
- **store-core** (`diff-comments.test.ts`, 18 cases): hunk-header parsing, line-number derivation (additions/context → new-file line, deletions → old-file line), and prompt composition (grouping, ordering, pluralization, truncation, review template).
- **Dashboard** (`DiffViewerPanel.test.tsx`, +9 cases): comment affordance per unified line, none in split view, add → queue → **Submit** composes the right prompt via `sendInput` (incl. the derived `Line 11`), send-failure keeps the queue, remove, refresh drops stale comments, one-click review.
- **Mobile** (`DiffViewer.test.tsx`, new, 6 cases): line affordance, add → **Submit** composes prompt via `sendInput` + closes, one-click review, remove.

Local: dashboard vitest 4683 pass · dashboard tsc clean · store-core 2049 pass · store-core tsc clean · app jest 2270 pass · app tsc clean · style-lint (raw-color + undefined-css-vars) clean.

## Acceptance criteria
- [x] Click a diff line (dashboard + mobile) and attach a free-text comment, independent of per-hunk accept/reject.
- [x] Multiple pending comments across files queued + submitted together as the next user turn.
- [x] A "Review code" action composes a review-request turn over the current uncommitted diff without hand-typing.
- [x] Works in the always-on DiffViewerPanel/DiffViewer, without `features.ide`.

## Visual check needed
The inline-comment gutter button, comment note styling, and the mobile action bar are new UI — worth a quick live look on both clients. Dashboard line comments are wired for the **unified** view; split view keeps the read-only render (a follow-up could extend split).