### PR TITLE
feat(dashboard,app): composer state lozenge

### DIFF
--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -275,6 +275,8 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
           style={[styles.lozenge, { borderColor: HAIRLINE_COLOR[activityState] }]}
           pointerEvents="none"
           testID="input-bar-lozenge"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
         >
           <Text style={[styles.lozengeText, { color: HAIRLINE_COLOR[activityState] }]}>{lozengeText}</Text>
         </View>

--- a/packages/app/src/components/InputBar.tsx
+++ b/packages/app/src/components/InputBar.tsx
@@ -7,6 +7,7 @@ import type { SlashCommand } from '../store/connection';
 import type { Attachment } from '../utils/attachments';
 import { formatFileSize } from '../utils/attachments';
 import type { ActivityState } from '../store/session-activity';
+import { formatComposerLozenge } from '@chroxy/store-core';
 
 
 // -- Props --
@@ -83,6 +84,15 @@ export interface InputBarProps {
    * primitive `.state` down. Mirrors the dashboard InputBar's data-activity-state.
    */
   activityState?: ActivityState;
+  /**
+   * Chat redesign #6391 composer state lozenge (Phase 1 deferred item): the
+   * number of queue-while-processing follow-ups currently staged for this
+   * session (SessionScreen's `queuedIds.size`, mirroring the dashboard).
+   * Combined with `activityState` via the shared `formatComposerLozenge`
+   * helper to render the top-left "◐ streaming · +N queued" badge; omitted
+   * defaults to 0 (just drops the queued suffix).
+   */
+  queuedCount?: number;
   isRecognizing?: boolean;
   onMicPress?: () => void;
   speechUnavailable?: boolean;
@@ -146,6 +156,7 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
   disabledPlaceholder,
   slashCommands = [],
   activityState = 'idle',
+  queuedCount = 0,
   isRecognizing,
   onMicPress,
   speechUnavailable,
@@ -244,8 +255,30 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
 
   const showDropdown = filteredCommands.length > 0;
 
+  // Chat redesign #6391 composer state lozenge (Phase 1 deferred item): the
+  // same pure formatter the dashboard InputBar uses, so the two composer
+  // twins can't drift on copy. `null` means "render nothing" (idle).
+  const lozengeText = useMemo(
+    () => formatComposerLozenge(activityState, queuedCount),
+    [activityState, queuedCount],
+  );
+
   return (
     <View style={[styles.inputContainer, { paddingBottom: bottomPadding, borderTopColor: HAIRLINE_COLOR[activityState] }]}>
+      {/* Chat redesign #6391 (composer state lozenge, Phase 1): a small badge
+          straddling the composer's top-left edge, mirroring the dashboard's
+          `.input-bar-lozenge`. `position: relative` on `inputContainer` below
+          anchors it; absolute positioning means it never affects the flex
+          layout of the rows beneath it (zero layout shift in every state). */}
+      {lozengeText && (
+        <View
+          style={[styles.lozenge, { borderColor: HAIRLINE_COLOR[activityState] }]}
+          pointerEvents="none"
+          testID="input-bar-lozenge"
+        >
+          <Text style={[styles.lozengeText, { color: HAIRLINE_COLOR[activityState] }]}>{lozengeText}</Text>
+        </View>
+      )}
       {showDropdown && (
         <ScrollView
           style={styles.dropdown}
@@ -502,9 +535,36 @@ export const InputBar = React.memo(forwardRef<InputBarHandle, InputBarProps>(fun
 
 const styles = StyleSheet.create({
   inputContainer: {
+    // #6391 composer lozenge: anchors the absolutely-positioned badge below
+    // so it straddles this container's top edge without affecting the
+    // flex layout of the rows inside it.
+    position: 'relative',
     borderTopWidth: 1,
     borderTopColor: COLORS.backgroundCard,
     backgroundColor: COLORS.backgroundSecondary,
+  },
+  // #6391 composer state lozenge — mirrors the dashboard's
+  // `.input-bar-lozenge`: a small pill straddling the composer's top-left
+  // edge, colored per chat-activity state (matching HAIRLINE_COLOR so the
+  // hairline and the lozenge read as one signal). `top`/`transform` place
+  // its vertical center on the container's top border, same as the
+  // dashboard's `transform: translateY(-50%)`.
+  lozenge: {
+    position: 'absolute',
+    top: 0,
+    left: 12,
+    transform: [{ translateY: -9 }],
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 1,
+    borderRadius: 999,
+    borderWidth: 1,
+    backgroundColor: COLORS.backgroundSecondary,
+  },
+  lozengeText: {
+    fontSize: 11,
+    fontWeight: '500',
   },
   dropdown: {
     maxHeight: 200,

--- a/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
+++ b/packages/app/src/components/__tests__/InputBar.imperative.test.tsx
@@ -369,3 +369,77 @@ describe('InputBar slash-command grouping (chat redesign #6391)', () => {
     expect(badgeStyle('user').backgroundColor).not.toBe('transparent');
   });
 });
+
+describe('InputBar composer state lozenge (chat redesign #6391)', () => {
+  // Mirrors the dashboard's InputBarLozenge.test.tsx — same three cases the
+  // design doc's signature moment calls out: streaming with a queued
+  // follow-up, streaming with none, and hidden at idle. `formatComposerLozenge`
+  // (shared via @chroxy/store-core) is the single source of the copy, so
+  // these assert the mobile twin actually renders what that helper returns.
+  function lozengeText(tree: renderer.ReactTestRenderer): string | null {
+    try {
+      const node = tree.root.findByProps({ testID: 'input-bar-lozenge' });
+      const textNode = node.findByType(Text);
+      return Array.isArray(textNode.props.children)
+        ? textNode.props.children.join('')
+        : textNode.props.children;
+    } catch {
+      return null;
+    }
+  }
+
+  it('shows "◐ streaming · +N queued" when thinking with queued follow-ups', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} onChangeText={noop} activityState="thinking" queuedCount={2} />,
+      );
+    });
+    expect(lozengeText(tree)).toBe('◐ streaming · +2 queued');
+  });
+
+  it('shows "◐ streaming" with no queued suffix when thinking with none queued', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} onChangeText={noop} activityState="thinking" queuedCount={0} />,
+      );
+    });
+    expect(lozengeText(tree)).toBe('◐ streaming');
+  });
+
+  it('hides the lozenge entirely at idle, even with a stale queued count', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} onChangeText={noop} activityState="idle" queuedCount={3} />,
+      );
+    });
+    expect(lozengeText(tree)).toBeNull();
+  });
+
+  it('hides the lozenge when activityState/queuedCount are omitted (default idle)', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<InputBar {...baseProps} onChangeText={noop} />);
+    });
+    expect(lozengeText(tree)).toBeNull();
+  });
+
+  it('labels the busy and waiting states distinctly from streaming', () => {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <InputBar {...baseProps} onChangeText={noop} activityState="busy" queuedCount={1} />,
+      );
+    });
+    expect(lozengeText(tree)).toBe('◐ busy · +1 queued');
+
+    act(() => {
+      tree.update(
+        <InputBar {...baseProps} onChangeText={noop} activityState="waiting" queuedCount={0} />,
+      );
+    });
+    expect(lozengeText(tree)).toBe('◐ waiting');
+  });
+});

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -1811,6 +1811,7 @@ export function SessionScreen() {
         disabledPlaceholder={viewingCachedSession ? 'Offline — viewing cached history' : connectionPhase === 'server_restarting' ? 'Server restarting...' : 'Reconnecting...'}
         slashCommands={slashCommands}
         activityState={activityState}
+        queuedCount={queuedIds.size}
         isRecognizing={isRecognizing}
         onMicPress={speechAvailable ? handleMicPress : undefined}
         speechUnavailable={!speechAvailable}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2654,6 +2654,7 @@ export function App() {
               isBusy={!isIdle}
               isStreaming={streamingMessageId !== null}
               chatActivityState={chatActivity.state}
+              queuedCount={queuedIds.size}
               placeholder={isConnected ? `Type a message... (${inputSettings.chatEnterToSend ? 'Enter' : formatShortcutKeys('Cmd+Enter')} to send)` : 'Connecting...'}
               controlledValue={inputDraftValue}
               onValueChange={handleDraftChange}

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -18,9 +18,9 @@ describe('InputBar', () => {
 
   it('exposes the chat-activity state as a data attribute (chat redesign #6391)', () => {
     const { rerender } = render(
-      <InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="streaming" />,
+      <InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="thinking" />,
     )
-    expect(screen.getByTestId('input-bar')).toHaveAttribute('data-activity-state', 'streaming')
+    expect(screen.getByTestId('input-bar')).toHaveAttribute('data-activity-state', 'thinking')
     rerender(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="waiting" />)
     expect(screen.getByTestId('input-bar')).toHaveAttribute('data-activity-state', 'waiting')
   })

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -12,7 +12,7 @@ import { SlashCommandPicker } from './SlashCommandPicker'
 import { ImageThumbnail } from './ImageThumbnail'
 import type { SlashCommand, EvaluatorResultPayload, MCPResourceItem } from '../store/types'
 import { filterImageFiles } from '../utils/image-utils'
-import { shouldCollapsePaste, findActiveMarkerIds, formatComposerLozenge } from '@chroxy/store-core'
+import { shouldCollapsePaste, findActiveMarkerIds, formatComposerLozenge, type ChatActivityState } from '@chroxy/store-core'
 import { PastedTextChip } from './PastedTextChip'
 import { tokenizeThinkingKeywords } from './thinking-keyword-tokens'
 
@@ -75,8 +75,10 @@ export interface InputBarProps {
   /** Chat redesign #6391: the canonical chat-activity state
    *  (idle/thinking/busy/waiting/error) from store-core's deriveChatActivity.
    *  Surfaced as a `data-activity-state` attribute so the live hairline +
-   *  state-lozenge (slices 4-5) are pure CSS keyed off it. */
-  chatActivityState?: string
+   *  state-lozenge (slices 4-5) are pure CSS keyed off it. Typed to the real
+   *  `ChatActivityState` union (matching FooterBar/Sidebar/AppHeader's props)
+   *  so a typo'd/unknown state is a compile error at the call site. */
+  chatActivityState?: ChatActivityState
   /** Chat redesign #6391 composer state lozenge (Phase 1 deferred item): the
    *  number of queue-while-processing follow-ups currently staged for this
    *  session (App.tsx's `queuedIds.size`). Combined with `chatActivityState`

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -12,7 +12,7 @@ import { SlashCommandPicker } from './SlashCommandPicker'
 import { ImageThumbnail } from './ImageThumbnail'
 import type { SlashCommand, EvaluatorResultPayload, MCPResourceItem } from '../store/types'
 import { filterImageFiles } from '../utils/image-utils'
-import { shouldCollapsePaste, findActiveMarkerIds } from '@chroxy/store-core'
+import { shouldCollapsePaste, findActiveMarkerIds, formatComposerLozenge } from '@chroxy/store-core'
 import { PastedTextChip } from './PastedTextChip'
 import { tokenizeThinkingKeywords } from './thinking-keyword-tokens'
 
@@ -77,6 +77,12 @@ export interface InputBarProps {
    *  Surfaced as a `data-activity-state` attribute so the live hairline +
    *  state-lozenge (slices 4-5) are pure CSS keyed off it. */
   chatActivityState?: string
+  /** Chat redesign #6391 composer state lozenge (Phase 1 deferred item): the
+   *  number of queue-while-processing follow-ups currently staged for this
+   *  session (App.tsx's `queuedIds.size`). Combined with `chatActivityState`
+   *  via `formatComposerLozenge` to render the top-left "◐ streaming ·
+   *  +N queued" badge; omitted/0 just drops the queued suffix. */
+  queuedCount?: number
   placeholder?: string
   filePickerFiles?: FilePickerItem[] | null
   /** #6823 — MCP-server resources surfaced in the `@`-picker (BYOK sessions). */
@@ -191,7 +197,7 @@ function isEditableElement(el: Element | null): boolean {
   return (el as HTMLElement).isContentEditable === true
 }
 
-export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, chatActivityState, placeholder, filePickerFiles, mcpResources, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory, highlightThinkingKeywords }: InputBarProps) {
+export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, chatActivityState, queuedCount, placeholder, filePickerFiles, mcpResources, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory, highlightThinkingKeywords }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
@@ -1074,6 +1080,15 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, c
 
   const hasImages = imageAttachments && imageAttachments.length > 0
 
+  // Chat redesign #6391 composer state lozenge (Phase 1 deferred item): a
+  // pure text formatter (shared with the mobile twin via store-core) so the
+  // dashboard and mobile copy can't drift. Hidden entirely at idle/undefined
+  // — `null` here means "render nothing", not an empty badge.
+  const lozengeText = useMemo(
+    () => formatComposerLozenge(chatActivityState, queuedCount ?? 0),
+    [chatActivityState, queuedCount],
+  )
+
   return (
     <div
       className={`input-bar${dragging ? ' dragging' : ''}`}
@@ -1084,6 +1099,18 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, c
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
+      {/* Chat redesign #6391 (composer state lozenge, Phase 1): absolutely-
+          positioned badge on the composer's top-left edge, straddling the
+          live hairline above. Presentational only (aria-hidden) — it repeats
+          the hairline's `data-activity-state` color as a label + the queued
+          count, it doesn't introduce new information a screen-reader user
+          would be missing (the Stop/Send controls and ActivityIndicator
+          already cover turn-active state accessibly). */}
+      {lozengeText && (
+        <span className="input-bar-lozenge" data-testid="input-bar-lozenge" aria-hidden="true">
+          {lozengeText}
+        </span>
+      )}
       {filePickerOpen && filePickerFiles !== undefined && (
         <FilePicker
           files={filePickerFiles}

--- a/packages/dashboard/src/components/InputBarLozenge.test.tsx
+++ b/packages/dashboard/src/components/InputBarLozenge.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Composer state lozenge tests (chat redesign #6389/#6391, Phase 1 —
+ * deferred item now shipping).
+ *
+ * The lozenge ("◐ streaming · +2 queued") is a pure text formatter
+ * (`formatComposerLozenge` in `@chroxy/store-core`) keyed off the same
+ * `chatActivityState` + queued-follow-up count that already drive the
+ * composer's live hairline. These tests cover the three cases called out
+ * in the design doc's signature moment: streaming with queued follow-ups,
+ * streaming with none, and hidden at idle.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { InputBar } from './InputBar'
+
+afterEach(cleanup)
+
+describe('InputBar composer state lozenge (chat redesign #6391)', () => {
+  it('shows "◐ streaming · +N queued" when thinking with queued follow-ups', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        chatActivityState="thinking"
+        queuedCount={2}
+      />,
+    )
+    expect(screen.getByTestId('input-bar-lozenge')).toHaveTextContent('◐ streaming · +2 queued')
+  })
+
+  it('shows "◐ streaming" with no queued suffix when thinking with none queued', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        chatActivityState="thinking"
+        queuedCount={0}
+      />,
+    )
+    expect(screen.getByTestId('input-bar-lozenge')).toHaveTextContent('◐ streaming')
+  })
+
+  it('hides the lozenge entirely at idle, even with a stale queued count', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        chatActivityState="idle"
+        queuedCount={3}
+      />,
+    )
+    expect(screen.queryByTestId('input-bar-lozenge')).not.toBeInTheDocument()
+  })
+
+  it('hides the lozenge when chatActivityState is omitted (default idle behavior)', () => {
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+    expect(screen.queryByTestId('input-bar-lozenge')).not.toBeInTheDocument()
+  })
+
+  it('labels the busy and waiting states distinctly from streaming', () => {
+    const { rerender } = render(
+      <InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="busy" queuedCount={1} />,
+    )
+    expect(screen.getByTestId('input-bar-lozenge')).toHaveTextContent('◐ busy · +1 queued')
+
+    rerender(
+      <InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="waiting" queuedCount={0} />,
+    )
+    expect(screen.getByTestId('input-bar-lozenge')).toHaveTextContent('◐ waiting')
+  })
+
+  it('is presentational — marked aria-hidden so it does not duplicate other live-region announcements', () => {
+    render(
+      <InputBar onSend={vi.fn()} onInterrupt={vi.fn()} chatActivityState="thinking" queuedCount={1} />,
+    )
+    expect(screen.getByTestId('input-bar-lozenge')).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5389,6 +5389,39 @@ button.sidebar-token-view-session-row:hover {
 .input-bar[data-activity-state="waiting"] { box-shadow: inset 0 2px 0 0 var(--accent-orange); }
 .input-bar[data-activity-state="error"] { box-shadow: inset 0 2px 0 0 var(--text-error); }
 
+/* Chat redesign #6391 (composer state lozenge, Phase 1 — deferred item now
+   shipping): "◐ streaming · +2 queued" badge straddling the composer's
+   top-left edge. Absolutely positioned against `.input-bar`'s existing
+   `position: relative` so it never participates in flex layout — zero
+   layout shift in any state, matching the hairline above it. The JSX only
+   mounts this element when `formatComposerLozenge` returns non-null (never
+   at idle), so there's no `display: none` state to gate here — the color
+   rules below just tint the already-rendered badge per state, mirroring
+   the hairline's color mapping one row up so the two read as one signal. */
+.input-bar-lozenge {
+  position: absolute;
+  top: 0;
+  left: var(--space-4);
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+  z-index: 3;
+}
+.input-bar[data-activity-state="thinking"] .input-bar-lozenge { color: var(--accent-blue); border-color: var(--accent-blue); }
+.input-bar[data-activity-state="busy"] .input-bar-lozenge { color: var(--accent-purple); border-color: var(--accent-purple); }
+.input-bar[data-activity-state="waiting"] .input-bar-lozenge { color: var(--accent-orange); border-color: var(--accent-orange); }
+.input-bar[data-activity-state="error"] .input-bar-lozenge { color: var(--text-error); border-color: var(--text-error); }
+
 /* ---- File Picker ---- */
 .file-picker {
   position: absolute;

--- a/packages/store-core/src/composer-lozenge.test.ts
+++ b/packages/store-core/src/composer-lozenge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { formatComposerLozenge } from './composer-lozenge'
+import type { ChatActivityState } from './chat-activity'
 
 describe('formatComposerLozenge', () => {
   it('hides the lozenge at idle regardless of queued count', () => {
@@ -9,7 +10,12 @@ describe('formatComposerLozenge', () => {
 
   it('hides the lozenge for an undefined/unrecognized state', () => {
     expect(formatComposerLozenge(undefined, 2)).toBeNull()
-    expect(formatComposerLozenge('some-future-state', 2)).toBeNull()
+    // `state` is typed `ChatActivityState | undefined`, so a genuinely
+    // unrecognized value can't reach here through TS-checked call sites —
+    // this cast simulates one that does anyway (a non-TS caller, or a
+    // future state added to the union without a STATE_LABEL entry) and
+    // asserts the defensive runtime fallback still hides the lozenge.
+    expect(formatComposerLozenge('some-future-state' as ChatActivityState, 2)).toBeNull()
   })
 
   it('shows "streaming" with no queued suffix when thinking and nothing queued', () => {

--- a/packages/store-core/src/composer-lozenge.test.ts
+++ b/packages/store-core/src/composer-lozenge.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { formatComposerLozenge } from './composer-lozenge'
+
+describe('formatComposerLozenge', () => {
+  it('hides the lozenge at idle regardless of queued count', () => {
+    expect(formatComposerLozenge('idle', 0)).toBeNull()
+    expect(formatComposerLozenge('idle', 3)).toBeNull()
+  })
+
+  it('hides the lozenge for an undefined/unrecognized state', () => {
+    expect(formatComposerLozenge(undefined, 2)).toBeNull()
+    expect(formatComposerLozenge('some-future-state', 2)).toBeNull()
+  })
+
+  it('shows "streaming" with no queued suffix when thinking and nothing queued', () => {
+    expect(formatComposerLozenge('thinking', 0)).toBe('◐ streaming')
+  })
+
+  it('shows "streaming · +N queued" when thinking with a queued follow-up', () => {
+    expect(formatComposerLozenge('thinking', 2)).toBe('◐ streaming · +2 queued')
+    expect(formatComposerLozenge('thinking', 1)).toBe('◐ streaming · +1 queued')
+  })
+
+  it('labels the busy state (turn active, not text-streaming)', () => {
+    expect(formatComposerLozenge('busy', 0)).toBe('◐ busy')
+    expect(formatComposerLozenge('busy', 4)).toBe('◐ busy · +4 queued')
+  })
+
+  it('labels the waiting state', () => {
+    expect(formatComposerLozenge('waiting', 0)).toBe('◐ waiting')
+    expect(formatComposerLozenge('waiting', 1)).toBe('◐ waiting · +1 queued')
+  })
+
+  it('labels the error state', () => {
+    expect(formatComposerLozenge('error', 0)).toBe('◐ error')
+  })
+
+  it('defensively floors a negative queued count to 0 (no suffix)', () => {
+    expect(formatComposerLozenge('thinking', -1)).toBe('◐ streaming')
+  })
+
+  it('defensively treats a non-finite queued count as 0 (no suffix)', () => {
+    expect(formatComposerLozenge('thinking', NaN)).toBe('◐ streaming')
+    expect(formatComposerLozenge('thinking', Infinity)).toBe('◐ streaming')
+  })
+
+  it('truncates a fractional queued count toward zero', () => {
+    expect(formatComposerLozenge('thinking', 2.9)).toBe('◐ streaming · +2 queued')
+  })
+})

--- a/packages/store-core/src/composer-lozenge.ts
+++ b/packages/store-core/src/composer-lozenge.ts
@@ -1,0 +1,67 @@
+/**
+ * Composer state lozenge (chat redesign epic #6389/#6391, Phase 1 — deferred
+ * item now approved).
+ *
+ * A small text badge on the composer's top-left edge — "◐ streaming ·
+ * +2 queued" — that names the canonical chat-activity state (from
+ * `deriveChatActivity` / `ChatActivityState`) alongside the queue-while-
+ * processing follow-up count. It sits on the SAME `data-activity-state` /
+ * `activityState` value that already drives the composer's live hairline
+ * (dashboard `InputBar.tsx` `.input-bar[data-activity-state]`, mobile
+ * `InputBar.tsx` `HAIRLINE_COLOR`) — the hairline supplies the color, the
+ * lozenge supplies the label, so the two read as one signal instead of two
+ * competing cues.
+ *
+ * Pure, no DOM / React Native deps — both clients import this one formatter
+ * so the composer copy can't drift between the dashboard and mobile twin.
+ */
+
+/** Fixed glyph for every active state — a generic "the machine is doing
+ *  something" marker, not a per-state icon. Keeps the badge visually calm;
+ *  the label text (and the hairline's color) carry the state distinction. */
+const LOZENGE_GLYPH = '◐'
+
+/**
+ * Display label per non-idle `ChatActivityState`. `thinking` reads
+ * "streaming" because `deriveChatActivity` sets that state precisely while
+ * `streamingMessageId` is set — i.e. while tokens are actively flowing (see
+ * `chat-activity.ts`'s doc comment: "busy is non-streaming work"). Any state
+ * absent from this map (currently only `idle`, plus defensively any future/
+ * unrecognized value) hides the lozenge rather than guessing a label.
+ */
+const STATE_LABEL: Record<string, string> = {
+  thinking: 'streaming',
+  busy: 'busy',
+  waiting: 'waiting',
+  error: 'error',
+}
+
+/**
+ * Format the composer lozenge text for a given chat-activity state and
+ * queued-follow-up count, or `null` when the lozenge should not render at
+ * all (idle, or any state this module doesn't recognize — fail closed
+ * rather than show a guessed label).
+ *
+ *   formatComposerLozenge('thinking', 2) → '◐ streaming · +2 queued'
+ *   formatComposerLozenge('thinking', 0) → '◐ streaming'
+ *   formatComposerLozenge('busy', 1)     → '◐ busy · +1 queued'
+ *   formatComposerLozenge('idle', 3)     → null (hidden even with a queue —
+ *                                           an idle turn has nothing "alive"
+ *                                           to report; #6906 flushes queued
+ *                                           messages as soon as idle anyway)
+ *
+ * `queuedCount` is defensively floored at 0 and truncated to an integer, so
+ * a stale/negative/non-finite count from an in-flight store update can't
+ * render nonsense like "+-1 queued" or "+2.5 queued".
+ */
+export function formatComposerLozenge(
+  state: string | undefined,
+  queuedCount: number,
+): string | null {
+  if (!state) return null
+  const label = STATE_LABEL[state]
+  if (!label) return null
+
+  const n = Number.isFinite(queuedCount) ? Math.max(0, Math.trunc(queuedCount)) : 0
+  return n > 0 ? `${LOZENGE_GLYPH} ${label} · +${n} queued` : `${LOZENGE_GLYPH} ${label}`
+}

--- a/packages/store-core/src/composer-lozenge.ts
+++ b/packages/store-core/src/composer-lozenge.ts
@@ -16,20 +16,33 @@
  * so the composer copy can't drift between the dashboard and mobile twin.
  */
 
+import type { ChatActivityState } from './chat-activity'
+
 /** Fixed glyph for every active state — a generic "the machine is doing
  *  something" marker, not a per-state icon. Keeps the badge visually calm;
  *  the label text (and the hairline's color) carry the state distinction. */
 const LOZENGE_GLYPH = '◐'
 
 /**
- * Display label per non-idle `ChatActivityState`. `thinking` reads
- * "streaming" because `deriveChatActivity` sets that state precisely while
+ * Display label per `ChatActivityState`. `thinking` reads "streaming"
+ * because `deriveChatActivity` sets that state precisely while
  * `streamingMessageId` is set — i.e. while tokens are actively flowing (see
- * `chat-activity.ts`'s doc comment: "busy is non-streaming work"). Any state
- * absent from this map (currently only `idle`, plus defensively any future/
- * unrecognized value) hides the lozenge rather than guessing a label.
+ * `chat-activity.ts`'s doc comment: "busy is non-streaming work").
+ *
+ * Typed as `Record<ChatActivityState, string>` (not `Record<string, string>`)
+ * so this map is keyed to the real state union: an unrecognized/typo'd key
+ * is a compile error here, and adding a new `ChatActivityState` without
+ * updating this map is *also* a compile error (missing property), rather
+ * than the old `Record<string, string>` silently accepting anything and
+ * making every lookup look always-defined.
+ *
+ * `idle` maps to the empty string (not omitted — a full `Record` requires
+ * every key) so the lozenge still hides for it: the `if (!label) return
+ * null` check below treats `''` the same as "no label", keeping a single
+ * fallback path for "hidden" rather than special-casing idle.
  */
-const STATE_LABEL: Record<string, string> = {
+const STATE_LABEL: Record<ChatActivityState, string> = {
+  idle: '',
   thinking: 'streaming',
   busy: 'busy',
   waiting: 'waiting',
@@ -39,8 +52,8 @@ const STATE_LABEL: Record<string, string> = {
 /**
  * Format the composer lozenge text for a given chat-activity state and
  * queued-follow-up count, or `null` when the lozenge should not render at
- * all (idle, or any state this module doesn't recognize — fail closed
- * rather than show a guessed label).
+ * all (idle, or an undefined state — fail closed rather than show a
+ * guessed label).
  *
  *   formatComposerLozenge('thinking', 2) → '◐ streaming · +2 queued'
  *   formatComposerLozenge('thinking', 0) → '◐ streaming'
@@ -50,12 +63,19 @@ const STATE_LABEL: Record<string, string> = {
  *                                           to report; #6906 flushes queued
  *                                           messages as soon as idle anyway)
  *
+ * `state` is typed `ChatActivityState | undefined` (not `string`) so a
+ * typo'd/unknown state is a compile error at call sites, not a silent
+ * runtime `null` — the `if (!label) return null` below is a *defensive*
+ * runtime fallback (idle's empty-string label, or a value that reaches
+ * here from outside TS's view, e.g. a non-TS caller), not the type
+ * contract.
+ *
  * `queuedCount` is defensively floored at 0 and truncated to an integer, so
  * a stale/negative/non-finite count from an in-flight store update can't
  * render nonsense like "+-1 queued" or "+2.5 queued".
  */
 export function formatComposerLozenge(
-  state: string | undefined,
+  state: ChatActivityState | undefined,
   queuedCount: number,
 ): string | null {
   if (!state) return null

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -353,6 +353,11 @@ export {
 export { deriveChatActivity } from './chat-activity'
 export type { ChatActivityState, SessionChatActivity, ChatActivityInput } from './chat-activity'
 
+// Chat redesign #6391 (composer state lozenge, Phase 1 deferred item): pure
+// "◐ streaming · +N queued" text formatter shared by both InputBar twins so
+// the composer copy can't drift between the dashboard and mobile app.
+export { formatComposerLozenge } from './composer-lozenge'
+
 // #4242: cheap structural gate for `JSON.parse` on streaming
 // `tool_input_delta` accumulators. Amortises N-1 throws on long
 // streams (every Bash invocation, every Edit).


### PR DESCRIPTION
## Summary

Part of #6391 (chat redesign Phase 1 — Quick wins), part of the epic #6389.

Implements the "Composer state lozenge + live hairline" checklist item's lozenge half (the live hairline itself already shipped). Adds a small presentational badge on the composer's top-left edge — `◐ streaming · +2 queued` — that names the canonical chat-activity state alongside the queue-while-processing follow-up count, per `docs/design/chat-redesign.md` §4.2 and the §5 signature moment ("A composer that knows the machine is alive").

- **`◐ streaming · +N queued`** when the turn is actively streaming with N queued follow-ups
- **`◐ streaming`** when streaming with nothing queued
- **`◐ busy` / `◐ waiting` / `◐ error`** for the other non-idle `ChatActivityState` values, using the same color mapping as the existing hairline
- **Hidden entirely at idle** — no lozenge, no layout reservation

Absolutely positioned against `.input-bar`'s / `inputContainer`'s existing `position: relative`, so it never participates in flex layout — zero layout shift transitioning between states.

## Implementation

- `packages/store-core/src/composer-lozenge.ts` — new pure `formatComposerLozenge(state, queuedCount)` helper, exported from the package index, so the dashboard and mobile composer can't drift on copy.
- Dashboard: `InputBar.tsx` renders the lozenge span keyed off the existing `chatActivityState` prop + a new `queuedCount` prop; `theme/components.css` adds `.input-bar-lozenge` (token-only: `--radius-pill`, `--space-2`/`--space-4`, `--bg-secondary`, `--border-primary`, `--text-xs`, `--accent-blue`/`--accent-purple`/`--accent-orange`/`--text-error`). `App.tsx` wires `queuedCount={queuedIds.size}` (the same `Set` already built from `queuedMessages` for `ChatView`).
- Mobile: `InputBar.tsx` renders the RN twin (`View`/`Text`, `COLORS.*`) keyed off the existing `activityState` prop + a new `queuedCount` prop, using the same shared formatter. `SessionScreen.tsx` wires `queuedCount={queuedIds.size}` the same way.
- No protocol/store-core wire changes — this reads state that already exists (`ChatActivityState` from `deriveChatActivity`, `queuedMessages`/`queuedIds` from the #6906 queue-while-processing plumbing).

## Test plan

- [x] `packages/store-core` — new `composer-lozenge.test.ts` (10 cases: idle/undefined/unrecognized → hidden, each active state's label, queued-suffix on/off, defensive negative/NaN/fractional counts). Full package suite: **57 files / 2041 tests passed**.
- [x] `packages/dashboard` — new `InputBarLozenge.test.tsx` covering the three called-out cases (streaming+queued, streaming+none, idle→hidden) plus busy/waiting labeling and the `aria-hidden` presentational contract. Full suite: **271 files / 4681 tests passed**.
- [x] `packages/app` — new cases appended to `InputBar.imperative.test.tsx`'s existing chat-redesign describe blocks, same three cases + busy/waiting. Full suite: **175 suites / 2269 tests passed**.
- [x] `tsc --noEmit` clean on `store-core`, `dashboard`, `app`.
- [x] `scripts/lint-no-raw-color-literals.sh` — OK, no new offenders.
- [x] `scripts/lint-undefined-css-vars.sh` — OK, every `var(--…)` resolves.

## Needs a live check (jsdom/RNTL can't verify pixels)

Please eyeball the actual composer in both clients:

1. Start a turn (send a message) and, while it's streaming, type + send a follow-up so it queues.
2. Expect the dashboard composer's top-left edge to show a small pill reading `◐ streaming · +1 queued`, straddling the existing colored hairline, with no jump/shift in the textarea or button row.
3. Same on the mobile app (dev build) — pill in the same spot, RN-styled equivalent.
4. Let the turn finish (queue flushes, session goes idle) — the lozenge should disappear cleanly, no leftover empty pill.
5. Optionally: trigger a permission/plan wait (`waiting`) and a stream error (`error`) to confirm the label + color swap sensibly and don't clash visually with the hairline or the ActivityIndicator/CheckInChip components already stacked above the composer.