### PR TITLE
feat(server,security): opt-in provenance verification for spawned provider binaries (#6858)

### DIFF
--- a/docs/security/spawned-binary-provenance.md
+++ b/docs/security/spawned-binary-provenance.md
@@ -2,9 +2,12 @@
 
 How Chroxy verifies the external binaries it executes as providers, what that
 verification does — and does **not** — protect against, and where the deeper
-hardening line sits. Implemented in `packages/server/src/utils/verify-binary.js`,
-wired into `utils/preflight.js`, the subprocess spawn path, and `chroxy doctor`
-(#6708).
+hardening line sits. P1 (detect & surface, #6708) is implemented in
+`packages/server/src/utils/verify-binary.js`, wired into `utils/preflight.js`, the
+subprocess spawn path, and `chroxy doctor`. P2 (opt-in provenance: a SHA-256 pin
+ledger + a macOS signature gate, #6858) is in `utils/verify-provenance.js` +
+`binary-provenance-trust.js`, wired into the same preflight and the `cloudflared`
+spawn — see §4.
 
 This is distinct from the [credentials-at-rest model](./credentials-at-rest.md)
 and the [transport-layer model](./encryption-threat-model.md). Those protect
@@ -88,35 +91,97 @@ mac-specific step cleanly — there is no equivalent Gatekeeper block to detect.
 - A since-moved/removed binary being spawned from a stale cached path.
 - An operator being unable to tell "quarantined/blocked" from "not installed".
 
-**Does NOT protect against (out of P1 scope):**
-- **Supply-chain compromise / PATH planting.** The daemon still executes whatever
-  binary resolves first on `PATH`. A malicious binary planted earlier in `PATH`,
-  or a compromised upstream provider release, is spawned automatically. Quarantine
-  detection is orthogonal to provenance — a planted binary carries no quarantine
-  xattr.
-- **Signature / notarization enforcement.** Chroxy deliberately does **not** gate
-  on `codesign --verify` / `spctl --assess`. The bundled provider binaries are
-  ad-hoc/linker-signed and `spctl` rejects them, so a hard spctl gate would break
-  every un-notarized provider. Verifying a signature would only prove the binary
-  is *signed*, not that it is the binary the operator intends to run.
+**Does NOT protect against in P1 (addressed by the opt-in P2 gate, §4):**
+- **Supply-chain compromise / PATH planting.** With P1 alone the daemon still
+  executes whatever binary resolves first on `PATH`. A malicious binary planted
+  earlier in `PATH`, or an in-place swap of a resolved binary, is spawned
+  automatically. Quarantine detection is orthogonal to provenance — a planted
+  binary carries no quarantine xattr. The **opt-in SHA-256 pin ledger** (§4) closes
+  the in-place-swap case: a changed hash on a previously-seen path re-gates the
+  binary. (A brand-new path planted earlier on `PATH` is pinned on first sight
+  under trust-on-first-use, so the ledger catches *changes*, not a first-run
+  plant — pair it with a controlled `PATH` for defence in depth.)
+- **Signature / notarization enforcement.** P1 deliberately does **not** gate on
+  `codesign --verify` / `spctl --assess`, because chroxy's bundled provider
+  binaries are ad-hoc/linker-signed and `spctl` rejects them, so a hard spctl gate
+  would break every un-notarized provider. §4 adds this as an **opt-in** gate for
+  operators who run only notarized provider builds.
 
-## 4. P2 — provenance verification (proposed, not yet implemented)
+## 4. P2 — opt-in provenance verification (implemented, #6858)
 
 The residual supply-chain surface grows materially once the orchestration epic
 (#6691) auto-spawns worker sessions headless with the operator's credentials —
 "the daemon runs whatever is on PATH" stops being a foreground, operator-visible
-action. Proposed P2 hardening, to land before write-capable orchestration workers
-ship:
+action. P2 adds two **opt-in, OFF-by-default** gates, so P1 behaviour is
+byte-identical unless an operator explicitly turns one on. Implemented in
+`utils/verify-provenance.js` + `binary-provenance-trust.js`, wired into
+`utils/preflight.js` (provider spawn) and `tunnel/cloudflare.js` (cloudflared
+spawn).
 
-- **Opt-in signature gate.** An optional `codesign --verify` / `spctl` assessment
-  on macOS for operators who run only notarized provider builds.
-- **Cross-platform SHA-256 pin ledger.** Reuse the existing content-trust pattern
-  (`path-hash-trust-ledger.js`, already backing `skills-trust.js` and
-  `session-preset-trust.js`: a `path → { sha256, firstSeen, approvedAt }` map,
-  fail-open, atomic `0600` writes). Pin each provider binary's hash on first
-  sight; a changed hash re-gates the binary (warn/block) until an operator
-  re-approves — catching an unexpected in-place binary swap regardless of
-  signature or quarantine state. Fold `cloudflared` into the same ledger.
+### Cross-platform SHA-256 pin ledger
+
+`binary-provenance-trust.js` (`BinaryProvenanceLedger`) is a thin subclass of the
+same `PathHashTrustLedger` that backs `skills-trust.js` / `session-preset-trust.js`
+— a `path → { sha256, firstSeen, approvedAt }` map, fail-open on a corrupt/missing
+file, atomic `0600` writes. Default file: `~/.chroxy/binary-trust.json` (next to
+the other trust ledgers), under a `binaries` wrapper key.
+
+- **First sight → pin + allow** (trust-on-first-use).
+- **Matching hash → allow.**
+- **Changed hash → re-gate.** `warn` mode logs the change and still spawns;
+  `block` mode **refuses the spawn** until the operator re-approves. This catches
+  an in-place binary swap regardless of code signature or quarantine state, and
+  works on every platform (it is pure content hashing).
+
+This is folded across **every spawned binary** — the provider binaries (`claude`,
+`codex`, `gemini`) via preflight, and `cloudflared` via the tunnel gate — sharing
+one ledger instance so pins are unified.
+
+### macOS signature gate
+
+When enabled, a binary that fails `spctl --assess --type execute` (Gatekeeper /
+notarization) is **hard-blocked** before spawn. This is for operators who run only
+notarized provider builds; chroxy's own bundled providers are ad-hoc/linker-signed
+and `spctl` rejects them, which is exactly why it can only ever be opt-in. `spctl`
+is invoked by its absolute SIP-protected path (`/usr/sbin/spctl`), never a PATH
+lookup, so a shadowed `spctl` can't subvert the gate (same hardening as the P1
+`/usr/bin/xattr` probe). The gate is **macOS-only**: on Linux/Windows it is a
+documented no-op (skipped) and the pin ledger carries the cross-platform integrity
+story alone. Windows Authenticode signature gating is a tracked follow-up.
+
+### Fail-safe semantics
+
+When a gate is ON, a verification failure blocks (`block` mode / signature gate) or
+loudly surfaces (`warn` mode) — it **never silently spawns an unverified binary**.
+A binary that can't even be hashed is treated as unverifiable: blocked in `block`
+mode, surfaced-but-allowed in `warn` mode. A `block`-mode failure throws
+`ProviderBinaryProvenanceError` (`code: PROVIDER_BINARY_PROVENANCE`) from preflight,
+or `TunnelBinaryProvenanceError` (`code: TUNNEL_BINARY_PROVENANCE`) from the tunnel.
+
+### Configuration
+
+Both gates are OFF by default. Config block (mirrored by env overrides):
+
+```jsonc
+{
+  "binaryProvenance": {
+    "mode": "off",           // "off" (default) | "warn" | "block" — pin ledger
+    "signatureGate": false   // macOS spctl gate; hard-blocks un-notarized builds
+  }
+}
+```
+
+- `CHROXY_BINARY_PROVENANCE` = `off` | `warn` | `block` (overrides `mode`)
+- `CHROXY_BINARY_SIGNATURE_GATE` = `1` | `0` (overrides `signatureGate`)
+
+Resolved by `resolveBinaryProvenanceMode()` / `isBinarySignatureGateEnabled()` in
+`config.js` — both fail-closed (anything but an explicit opt-in value ⇒ off).
+
+**Re-approving a legitimately changed binary** (e.g. after `npm i -g @openai/codex@latest`):
+remove that path's entry from `~/.chroxy/binary-trust.json` (or delete the file —
+it fails open to empty and re-pins every binary on next spawn). A programmatic
+`revoke(path)` / `approve(path, hash)` API exists on the ledger for a future CLI /
+dashboard surface.
 
 ## 5. Operator remediation quick reference
 

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -32,6 +32,7 @@ Configuration values are resolved in the following order (highest priority first
 | `maxTotalSkillBytes` | number | - | - | Global skills-context budget. When a session's merged active-skill set exceeds this size, lower-priority skills are dropped first (frontmatter `priority` defaults to 100; ties broken alphabetically). Default `262144` (256KB). Set to `0` to disable the global cap. |
 | `providerSkillAllowlist` | object | - | - | Per-provider skill allowlist. Object keyed by provider id (e.g. `codex`, `gemini`); each value is an array of skill names that may load for that provider. See [Per-provider skill allowlist](#per-provider-skill-allowlist) below. |
 | `trustMismatchMode` | string | - | - | One of `warn` or `block`. When set, the server records a SHA-256 hash of every loaded skill on first activation and compares it on every subsequent load. See [Skill content-hash trust](#skill-content-hash-trust) below. Disabled (no hashing) when omitted. |
+| `binaryProvenance` | object | - | `CHROXY_BINARY_PROVENANCE`, `CHROXY_BINARY_SIGNATURE_GATE` | Opt-in provenance verification for spawned provider binaries (`claude`, `codex`, `gemini`, `cloudflared`). `mode` (`off`/`warn`/`block`) drives a cross-platform SHA-256 pin ledger; `signatureGate` (boolean) toggles a macOS `spctl` notarization gate. Both OFF by default. See [Binary provenance verification](#binary-provenance-verification) below. |
 | `dangerouslySkipPermissions` | boolean | `--dangerously-skip-permissions` | `CHROXY_DANGEROUSLY_SKIP_PERMISSIONS` | Server-wide default for the per-session skip-permissions flag (#4246, #4384). Honoured only by the `claude-tui` provider — spawns claude with `--dangerously-skip-permissions` and elides chroxy's permission hook. Off by default. Legacy alias `skipPermissions` (config key) and `CHROXY_SKIP_PERMISSIONS` (env var) are still honoured for one deprecation window and emit a warning at boot — rename to the canonical key. See [Skip permissions (TUI provider)](#skip-permissions-tui-provider) below. |
 | `resultTimeoutMs` | number | - | `CHROXY_RESULT_TIMEOUT_MS` | Per-session **soft-warning** inactivity window in milliseconds. When no SDK / CLI event arrives within this window, the server emits an `inactivity_warning` event (#3899) so clients can render a check-in chip and surface a push notification — the session stays alive. The kill path is `hardTimeoutMs` (below). See [Inactivity safety net](#inactivity-safety-net). Default `1800000` (30 min); range `30000`–`86400000` (30 s – 24 h). |
 | `hardTimeoutMs` | number | - | `CHROXY_HARD_TIMEOUT_MS` | Per-session **hard-kill** inactivity window in milliseconds. When `resultTimeoutMs` has already fired and silence continues to this longer threshold, the server emits `permission_expired` for every outstanding permission prompt, force-clears busy state, and emits a generic `error` event with `"Response timed out after <duration> of inactivity"` (#3899). Default `7200000` (2 h); range `30000`–`86400000` (30 s – 24 h). Must be ≥ `resultTimeoutMs` or the soft warning never fires — validator warns. |
@@ -141,6 +142,45 @@ directly. Format:
 
 A corrupted or missing trust file is treated as empty (fail-open) so a single
 bad write can't lock every skill out of every session.
+
+### Binary provenance verification
+
+`binaryProvenance` opts the daemon into pre-spawn provenance verification of the
+external binaries it executes as providers (`claude`, `codex`, `gemini`) and of
+`cloudflared`. This extends the always-on P1 integrity/quarantine check (#6708)
+with two **opt-in, OFF-by-default** gates — see
+[`docs/security/spawned-binary-provenance.md`](../../docs/security/spawned-binary-provenance.md).
+
+```jsonc
+{
+  "binaryProvenance": {
+    "mode": "off",           // "off" (default) | "warn" | "block"
+    "signatureGate": false   // macOS spctl notarization gate
+  }
+}
+```
+
+- **`mode`** — a cross-platform SHA-256 **pin ledger** (`~/.chroxy/binary-trust.json`,
+  same fail-open/atomic-0600 sidecar as the skill ledger). Each binary's hash is
+  pinned on first sight (trust-on-first-use); a later change to that hash re-gates
+  the binary. `warn` logs the change and still spawns; `block` **refuses the
+  spawn** until the operator re-approves. Catches an in-place binary swap
+  regardless of signature or quarantine state. `off` (default) skips the ledger
+  entirely. Env override: `CHROXY_BINARY_PROVENANCE` = `off`/`warn`/`block`.
+- **`signatureGate`** — when `true`, a binary that fails `spctl --assess`
+  (Gatekeeper / notarization) is hard-blocked. For operators who run only
+  notarized provider builds; chroxy's bundled providers are ad-hoc-signed and
+  would be rejected, so it can only ever be opt-in. **macOS-only** — a documented
+  no-op on Linux/Windows (the pin ledger still applies). Env override:
+  `CHROXY_BINARY_SIGNATURE_GATE` = `1`/`0`.
+
+Both fail-safe: when a gate is on, a failure blocks (`block` / signature) or is
+loudly surfaced (`warn`) — an unverified binary is never silently spawned. A
+`block`-mode failure surfaces as a `session_error`
+(`code: PROVIDER_BINARY_PROVENANCE`) for providers, or aborts the tunnel start
+(`code: TUNNEL_BINARY_PROVENANCE`) for `cloudflared`. To re-approve a
+legitimately-updated binary, remove its entry from `~/.chroxy/binary-trust.json`
+(or delete the file — it fails open and re-pins on next spawn).
 
 ### Skip permissions (TUI provider)
 

--- a/packages/server/src/binary-provenance-trust.js
+++ b/packages/server/src/binary-provenance-trust.js
@@ -61,9 +61,10 @@ export function _normalizeKey(absPath) {
 
 /**
  * In-memory + on-disk pin ledger for spawned provider binaries. One instance per
- * daemon (constructed by SessionManager); the cloudflared spawn path constructs
- * a second instance over the SAME default file so pins are unified. Tests pass an
- * explicit `filePath` so they never touch the real ledger.
+ * daemon, constructed by SessionManager; that SAME instance is threaded into the
+ * tunnel config (server-cli.js → `binaryProvenance.ledger`) so the cloudflared
+ * gate and the provider spawns share one ledger and one set of pins — no second
+ * instance. Tests pass an explicit `filePath` so they never touch the real ledger.
  */
 export class BinaryProvenanceLedger extends PathHashTrustLedger {
   /**

--- a/packages/server/src/binary-provenance-trust.js
+++ b/packages/server/src/binary-provenance-trust.js
@@ -1,0 +1,94 @@
+/**
+ * Provider-binary provenance trust ledger (#6858).
+ *
+ * Pins the SHA-256 hash of every spawned provider binary (`claude`, `codex`,
+ * `gemini`, `cloudflared`) the daemon has seen. A later change to a pinned hash
+ * re-gates the binary (warn / block) — catching an in-place binary swap
+ * regardless of code signature or macOS quarantine state. See
+ * `utils/verify-provenance.js` for the verification logic and
+ * `docs/security/spawned-binary-provenance.md` for the threat model.
+ *
+ * Storage shape (sidecar JSON file, next to skills-trust.json / session-preset-
+ * trust.json):
+ *
+ *   {
+ *     "binaries": {
+ *       "/opt/homebrew/bin/codex": {
+ *         "sha256": "<64 hex chars>",       // the binary's CONTENT hash
+ *         "firstSeen": "2026-07-22T12:34:56.000Z",
+ *         "approvedAt": "2026-07-22T12:34:56.000Z"
+ *       }
+ *     }
+ *   }
+ *
+ * A path is TRUSTED only when its stored `sha256` equals the hash of the
+ * currently-resolved binary. First sight (no record) → pin + allow
+ * (trust-on-first-use). A changed hash → re-gated. The operator re-approves the
+ * CURRENT hash via `approve(path, hash)`; `revoke(path)` drops the record.
+ *
+ * Since #5580 the ledger mechanics (load/isTrusted/approve/revoke/getRecord +
+ * atomic 0600 persist + fail-open) live in `PathHashTrustLedger`; this class is
+ * a thin subclass that pins the `binaries` wrapper key and the `approvedAt`
+ * timestamp field. Best-effort flush (a read-only $HOME must never break
+ * spawning — provenance is a defence-in-depth layer, not a hard dependency).
+ */
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { createLogger } from './logger.js'
+import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
+
+const log = createLogger('binary-provenance-trust')
+
+export const DEFAULT_BINARY_TRUST_FILE = join(homedir(), '.chroxy', 'binary-trust.json')
+
+/**
+ * Normalise a ledger key for storage / lookup. On case-insensitive filesystems
+ * (macOS APFS, Windows NTFS) the same binary can resolve to different casings,
+ * so keys are lowercased there; on case-sensitive Linux the key is kept verbatim.
+ * Mirrors the skills/preset stores' normaliser (kept local per the base-ledger
+ * convention that each subclass owns its own key hook).
+ *
+ * @param {string} absPath
+ * @returns {string}
+ */
+export function _normalizeKey(absPath) {
+  if (typeof absPath !== 'string') return ''
+  return (process.platform === 'darwin' || process.platform === 'win32')
+    ? absPath.toLowerCase()
+    : absPath
+}
+
+/**
+ * In-memory + on-disk pin ledger for spawned provider binaries. One instance per
+ * daemon (constructed by SessionManager); the cloudflared spawn path constructs
+ * a second instance over the SAME default file so pins are unified. Tests pass an
+ * explicit `filePath` so they never touch the real ledger.
+ */
+export class BinaryProvenanceLedger extends PathHashTrustLedger {
+  /**
+   * @param {{ filePath?: string }} [opts]
+   */
+  constructor({ filePath } = {}) {
+    super({
+      filePath: filePath || DEFAULT_BINARY_TRUST_FILE,
+      log,
+      normalizeKey: _normalizeKey,
+      approvalField: 'approvedAt',
+      wrapperKey: 'binaries',
+      throwOnFlushError: false, // best-effort: a read-only $HOME never breaks spawning
+    })
+    const loaded = this._loadRecords()
+    this._records = loaded.records
+    this._dirty = false
+  }
+}
+
+// Helper so tests / callers can confirm the ledger file exists.
+export function binaryTrustFileExists(filePath) {
+  try {
+    return existsSync(filePath)
+  } catch {
+    return false
+  }
+}

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -249,6 +249,18 @@ const CONFIG_SCHEMA = {
   // implicit.
   // Documented in CONFIG.md.
   trustMismatchMode: 'string',
+  // #6858: opt-in provenance verification for spawned provider binaries.
+  // Nested object:
+  //   binaryProvenance.mode           'off' (default) | 'warn' | 'block' —
+  //     SHA-256 pin ledger. Pins each provider binary on first sight; a changed
+  //     hash re-gates (warn surfaces + allows, block refuses the spawn).
+  //   binaryProvenance.signatureGate  boolean (default false) — macOS `spctl`
+  //     signature/notarization gate; hard-blocks un-notarized builds when on.
+  // Both OFF by default so P1 (#6708) behaviour is unchanged. Env overrides:
+  //   CHROXY_BINARY_PROVENANCE (off|warn|block), CHROXY_BINARY_SIGNATURE_GATE (1|0).
+  // See resolveBinaryProvenanceMode() / isBinarySignatureGateEnabled() and
+  // docs/security/spawned-binary-provenance.md.
+  binaryProvenance: 'object',
   // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). When no
   // SDK / CLI event fires within this window, the server emits an
   // `inactivity_warning` event (and push notification) — the session
@@ -692,6 +704,35 @@ export function isIdeFeatureEnabled(config) {
 export function isOrchestrationEnabled(config) {
   if (process.env.CHROXY_ENABLE_ORCHESTRATION === '1') return true
   return config?.features?.orchestration === true
+}
+
+// #6858 — resolve the opt-in provider-binary provenance PIN-LEDGER mode. One of
+// 'off' | 'warn' | 'block'. Fail-closed to 'off' (behaviour identical to the
+// pre-#6858 spawn path) for anything but an explicit 'warn' / 'block'. Precedence:
+//   CHROXY_BINARY_PROVENANCE env  >  config.binaryProvenance.mode  >  'off'.
+// 'warn' pins on first sight and surfaces a later hash change while still
+// spawning; 'block' refuses the spawn on a hash change until re-approved.
+export function resolveBinaryProvenanceMode(config) {
+  const env = typeof process.env.CHROXY_BINARY_PROVENANCE === 'string'
+    ? process.env.CHROXY_BINARY_PROVENANCE.trim().toLowerCase()
+    : ''
+  if (env === 'warn' || env === 'block') return env
+  if (env === 'off') return 'off'
+  const cfg = config?.binaryProvenance && typeof config.binaryProvenance === 'object'
+    ? config.binaryProvenance.mode
+    : undefined
+  return (cfg === 'warn' || cfg === 'block') ? cfg : 'off'
+}
+
+// #6858 — is the opt-in macOS signature/notarization gate (`spctl --assess`)
+// enabled? Fail-closed to false (chroxy's own bundled providers are ad-hoc
+// signed and would be rejected, so this can only ever be opt-in). Precedence:
+//   CHROXY_BINARY_SIGNATURE_GATE env (1/0)  >  config.binaryProvenance.signatureGate  >  false.
+export function isBinarySignatureGateEnabled(config) {
+  const env = process.env.CHROXY_BINARY_SIGNATURE_GATE
+  if (env === '1') return true
+  if (env === '0') return false
+  return config?.binaryProvenance?.signatureGate === true
 }
 
 // #6764 — opt-in semantic session titles. When on, the first user turn's sidebar

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -47,7 +47,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 // environment-manager.js itself remains behind the dynamic import below
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
-import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel, resolveSemanticTitleTimeoutMs } from './config.js'
+import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel, resolveSemanticTitleTimeoutMs, resolveBinaryProvenanceMode, isBinarySignatureGateEnabled } from './config.js'
 import { buildOrchestrationManager } from './orchestration/build-manager.js'
 import { parseDuration } from './duration.js'
 import { createSessionTokenStore } from './session-token-store.js'
@@ -666,6 +666,12 @@ export async function startCliServer(config) {
     // API-valid model id without a release). Empty Set unless the operator set
     // config.providers.allowAnyModel.
     allowAnyModelProviders: getAllowAnyModelProviders(config),
+    // #6858: opt-in provenance verification for spawned provider binaries. Both
+    // OFF by default (behaviour identical to #6708). `mode` drives the SHA-256
+    // pin ledger (warn surfaces a swap + allows; block refuses the spawn);
+    // `signatureGate` toggles the macOS `spctl` notarization gate.
+    binaryProvenanceMode: resolveBinaryProvenanceMode(config),
+    binarySignatureGate: isBinarySignatureGateEnabled(config),
     providerType,
     maxToolInput: config.maxToolInput || null,
     transforms: config.transforms || [],
@@ -1149,6 +1155,15 @@ export async function startCliServer(config) {
         tunnelConfig: config.tunnelConfig,
         tunnelName: config.tunnelName || null,
         tunnelHostname: config.tunnelHostname || null,
+        // #6858: fold cloudflared into the SAME opt-in provenance gate + pin
+        // ledger as the provider binaries. Reuse the SessionManager's ledger
+        // instance so pins are unified across every spawned binary. Off by
+        // default (mode 'off' + gate false) ⇒ the tunnel gate is a no-op.
+        binaryProvenance: {
+          mode: resolveBinaryProvenanceMode(config),
+          signatureGate: isBinarySignatureGateEnabled(config),
+          ledger: sessionManager.binaryProvenanceLedger,
+        },
       },
       wsServer,
       startupDisplay,

--- a/packages/server/src/server-cli/tunnel-lifecycle-handler.js
+++ b/packages/server/src/server-cli/tunnel-lifecycle-handler.js
@@ -28,7 +28,7 @@ export class TunnelLifecycleHandler {
    * @param {{
    *   createTunnel: Function, emergencyCleanup: Function, wireTunnelEvents: Function,
    *   waitForTunnel: Function, buildTunnelWarmingStatus: Function, buildTunnelReadyStatus: Function,
-   *   config: { port: number, tunnelArg: { mode: string }, tunnelConfig?: object, tunnelName?: string|null, tunnelHostname?: string|null },
+   *   config: { port: number, tunnelArg: { mode: string }, tunnelConfig?: object, tunnelName?: string|null, tunnelHostname?: string|null, binaryProvenance?: object|null },
    *   wsServer: object, startupDisplay: object, pairingManager: (object|null),
    *   cleanupRefs: { mdnsService?: object, bonjourInstance?: object, tokenManager?: object, sessionManager: object },
    *   logger: object,
@@ -73,7 +73,7 @@ export class TunnelLifecycleHandler {
    * @returns {Promise<{ ok: boolean, tunnel?: object }>}
    */
   async createAndStart() {
-    const { port, tunnelArg, tunnelConfig, tunnelName, tunnelHostname } = this._config
+    const { port, tunnelArg, tunnelConfig, tunnelName, tunnelHostname, binaryProvenance } = this._config
     const wsServer = this._wsServer
     const startupDisplay = this._startupDisplay
     const pairingManager = this._pairingManager
@@ -95,6 +95,7 @@ export class TunnelLifecycleHandler {
       tunnelConfig,
       tunnelName: tunnelName || null,
       tunnelHostname: tunnelHostname || null,
+      binaryProvenance: binaryProvenance || null,
     })
     let wsUrl, httpUrl
     try {

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -8,7 +8,7 @@ import { getProvider, getProviderAuthInfo, DEFAULT_PROVIDER } from './providers.
 import { isClaudeProvider } from './models.js'
 import { billingClassForProvider, BILLING_CLASSES } from './billing-class.js'
 import { MonthlyProgrammaticBudgetManager } from './billing-budget.js'
-import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderCredentialMissingError } from './utils/preflight.js'
+import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderBinaryProvenanceError, ProviderCredentialMissingError } from './utils/preflight.js'
 import { GIT } from './git.js'
 import { sweepOrphanChroxyWorktrees } from './worktree-gc.js'
 import { resolveJsonlPath, readConversationHistoryAsync } from './jsonl-reader.js'
@@ -28,6 +28,7 @@ import { generateSessionTitle, DEFAULT_SEMANTIC_TITLE_MODEL, DEFAULT_SEMANTIC_TI
 import { SkillsUsageRecorder } from './skills-usage.js'
 import { resolveSessionPreset, foldPreamble } from './session-preset.js'
 import { SessionPresetTrustStore } from './session-preset-trust.js'
+import { BinaryProvenanceLedger } from './binary-provenance-trust.js'
 import { PermissionRuleStore } from './permission-rule-store.js'
 import { ScheduledTaskStore, defaultScheduledTasksPath } from './scheduled-task-store.js'
 import { createLogger } from './logger.js'
@@ -176,9 +177,9 @@ export { formatIdleDuration }
 
 // Re-export preflight errors so call sites that catch createSession() failures
 // can detect/branch on PROVIDER_BINARY_NOT_FOUND / PROVIDER_BINARY_QUARANTINED /
-// PROVIDER_CREDENTIAL_MISSING without taking a separate dependency on
-// utils/preflight.js.
-export { ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderCredentialMissingError }
+// PROVIDER_BINARY_PROVENANCE / PROVIDER_CREDENTIAL_MISSING without taking a
+// separate dependency on utils/preflight.js.
+export { ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderBinaryProvenanceError, ProviderCredentialMissingError }
 
 /**
  * @typedef {Object} SessionManagerConfig
@@ -336,6 +337,18 @@ export class SessionManager extends EventEmitter {
     // #5553: config path for the daemon-side preset override map. Tests point
     // this at a temp config.json; production uses the default ~/.chroxy/config.json.
     presetConfigPath,
+
+    // #6858: opt-in provenance verification for spawned provider binaries.
+    // `binaryProvenanceMode` ('off'|'warn'|'block') drives the SHA-256 pin
+    // ledger; `binarySignatureGate` toggles the macOS `spctl` gate. Both wired
+    // from `resolveBinaryProvenanceMode` / `isBinarySignatureGateEnabled` in
+    // server-cli. Off by default → the gate is skipped and preflight behaviour is
+    // identical to #6708. Tests pass their own temp-pathed `binaryProvenanceLedger`
+    // (like presetTrustStore) so a temp stateFilePath keeps the ledger out of the
+    // real ~/.chroxy.
+    binaryProvenanceMode = 'off',
+    binarySignatureGate = false,
+    binaryProvenanceLedger,
     // #6771: durable per-project permission rule store (persistent "always
     // allow / deny"). Tests pass their own temp-pathed store; production wires a
     // default whose file (permission-rules.json) sits next to the session-state
@@ -546,6 +559,18 @@ export class SessionManager extends EventEmitter {
     // file so a test's temp stateFilePath keeps the ledger out of the real home.
     this.presetTrustStore = presetTrustStore
       || new SessionPresetTrustStore({ filePath: join(dirname(this._stateFilePath), 'session-preset-trust.json') })
+    // #6858: opt-in provider-binary provenance. The pin ledger's default file
+    // sits next to the session-state file (same temp-redirect reasoning as the
+    // sidecars above) so a test's temp stateFilePath keeps it out of the real
+    // home. Constructing the ledger is read-only (it only writes on a first-sight
+    // pin / approve), so it is always constructed; the MODE decides whether the
+    // gate actually runs at createSession. Anything but 'warn'/'block' → 'off'.
+    this._binaryProvenanceMode = (binaryProvenanceMode === 'warn' || binaryProvenanceMode === 'block')
+      ? binaryProvenanceMode
+      : 'off'
+    this._binarySignatureGate = binarySignatureGate === true
+    this.binaryProvenanceLedger = binaryProvenanceLedger
+      || new BinaryProvenanceLedger({ filePath: join(dirname(this._stateFilePath), 'binary-trust.json') })
     // Config path the preset resolver reads the daemon override map from.
     // Defaults to undefined → resolveSessionPreset uses its own DEFAULT_CONFIG_PATH.
     this.presetConfigPath = typeof presetConfigPath === 'string' ? presetConfigPath : null
@@ -951,7 +976,17 @@ export class SessionManager extends EventEmitter {
       throw new UserShellDisabledError()
     }
     if (!this._skipPreflight) {
-      runProviderPreflight(PreflightProviderClass)
+      // #6858: opt-in provenance gate. Only build the provenance bag when the
+      // operator opted in (mode warn/block or the signature gate); otherwise pass
+      // null so runProviderPreflight skips the step entirely (unchanged behaviour).
+      const provenance = (this._binaryProvenanceMode !== 'off' || this._binarySignatureGate)
+        ? {
+          mode: this._binaryProvenanceMode,
+          signatureGate: this._binarySignatureGate,
+          ledger: this.binaryProvenanceLedger,
+        }
+        : null
+      runProviderPreflight(PreflightProviderClass, { provenance })
     }
     // #6378: a provider opted into `config.providers.allowAnyModel` skips static
     // allowlist validation entirely — the model id passes through verbatim and

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -68,6 +68,12 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
     this._resolveBinary = resolveBinary
     this._verifyBinary = verifyBinary
     this._verifyProvenance = verifyProvenance
+    // #6937: the EXACT absolute cloudflared path the provenance gate resolved +
+    // verified, pinned so the spawn execs the same bytes we checked even if PATH
+    // changes between verify and spawn. null when the gate is off or the binary
+    // didn't resolve/verify — the spawn then falls back to the bare name and the
+    // normal ENOENT/doctor path, so default (feature-off) behaviour is unchanged.
+    this._resolvedCloudflaredPath = null
   }
 
   static get name() {
@@ -108,7 +114,12 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
   /** Override point for test injection */
   _spawnCloudflared(argv, spawnOpts) {
-    return spawn('cloudflared', argv, spawnOpts)
+    // Spawn the EXACT verified absolute path when the provenance gate pinned one
+    // (#6937), so a PATH change between verify and spawn can't swap in a different
+    // binary than the one we checked. Falls back to the bare name when the gate is
+    // off / the binary didn't resolve — preserving default (feature-off) behaviour.
+    const bin = this._resolvedCloudflaredPath || 'cloudflared'
+    return spawn(bin, argv, spawnOpts)
   }
 
   /**
@@ -125,6 +136,11 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
    * proceeds.
    */
   _verifyCloudflaredProvenance() {
+    // Clear any path pinned by a previous start attempt up front, so if the gate
+    // is now off — or the binary has since become unresolvable/unhealthy — the
+    // spawn falls back to the bare name instead of exec'ing a stale absolute path.
+    this._resolvedCloudflaredPath = null
+
     const prov = this.config && this.config.binaryProvenance
     const enabled = prov
       && (prov.mode === 'warn' || prov.mode === 'block' || prov.signatureGate === true)
@@ -156,6 +172,11 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
     ) {
       log.warn(`cloudflared provenance ${verdict.status}: ${verdict.message || ''} (allowed — mode=${prov.mode})`)
     }
+
+    // Provenance passed (or a warn-mode issue was surfaced + allowed): pin the
+    // EXACT absolute path we just verified so _spawnCloudflared execs those bytes,
+    // not whatever `cloudflared` resolves to off PATH at spawn time (#6937).
+    this._resolvedCloudflaredPath = health.path
   }
 
   async _startTunnel() {

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -1,9 +1,35 @@
 import { spawn, execFileSync } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
 import { BaseTunnelAdapter } from './base.js'
 import { createLogger, redactSensitive } from '../logger.js'
 import { cloudflaredInstallHint } from '../platform.js'
+import { resolveBinary as defaultResolveBinary } from '../utils/resolve-binary.js'
+import { verifyBinary as defaultVerifyBinary } from '../utils/verify-binary.js'
+import { verifyProvenance as defaultVerifyProvenance, PROVENANCE_STATUS } from '../utils/verify-provenance.js'
 
 const log = createLogger('tunnel')
+
+// Well-known cloudflared install locations (mirrors doctor.js) so provenance can
+// resolve the SAME absolute path the spawn will use even under a minimal PATH.
+const CLOUDFLARED_CANDIDATES = [
+  '/opt/homebrew/bin/cloudflared',
+  '/usr/local/bin/cloudflared',
+  join(homedir(), '.local/bin/cloudflared'),
+]
+
+/**
+ * Thrown when the opt-in provenance gate (#6858) refuses to spawn `cloudflared`
+ * because its pinned SHA-256 changed in place (block mode) or it failed the
+ * macOS signature gate. Never thrown when the gate is off (the default).
+ */
+export class TunnelBinaryProvenanceError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'TunnelBinaryProvenanceError'
+    this.code = 'TUNNEL_BINARY_PROVENANCE'
+  }
+}
 
 // #5328 (WP-5.6): how much of cloudflared's recent output to retain so a
 // startup failure can quote the REAL reason in its error, not just an exit code.
@@ -27,11 +53,21 @@ function redactedTail(rawTail) {
  * Named mode: spawns `cloudflared tunnel run <name>` — stable URL via DNS CNAME.
  */
 export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
-  constructor({ port, mode = 'quick', config = {}, tunnelName, tunnelHostname }) {
+  constructor({
+    port, mode = 'quick', config = {}, tunnelName, tunnelHostname,
+    // #6858 test seams — injected so the provenance gate is exercisable without a
+    // real cloudflared / ledger file. Production falls through to the real ones.
+    resolveBinary = defaultResolveBinary,
+    verifyBinary = defaultVerifyBinary,
+    verifyProvenance = defaultVerifyProvenance,
+  } = {}) {
     super({ port, mode, config })
     // Support both config object keys and legacy top-level constructor args
     this.tunnelName = config.tunnelName ?? tunnelName ?? null
     this.tunnelHostname = config.tunnelHostname ?? tunnelHostname ?? null
+    this._resolveBinary = resolveBinary
+    this._verifyBinary = verifyBinary
+    this._verifyProvenance = verifyProvenance
   }
 
   static get name() {
@@ -75,7 +111,56 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
     return spawn('cloudflared', argv, spawnOpts)
   }
 
+  /**
+   * #6858: opt-in pre-spawn provenance gate for `cloudflared`. `cloudflared` is
+   * spawned by bare name (resolved off PATH) with the operator's network, so it
+   * shares the provider binaries' supply-chain surface — this folds it into the
+   * SAME pin ledger + signature gate.
+   *
+   * No-op unless `config.binaryProvenance` opted in (mode warn/block or the
+   * signature gate). A binary that can't be resolved is left to the normal spawn
+   * ENOENT path (provenance must not mask "cloudflared not installed"). Fail-safe:
+   * a block-mode hash mismatch or a failed signature gate THROWS
+   * TunnelBinaryProvenanceError before any spawn; a warn-mode issue logs and
+   * proceeds.
+   */
+  _verifyCloudflaredProvenance() {
+    const prov = this.config && this.config.binaryProvenance
+    const enabled = prov
+      && (prov.mode === 'warn' || prov.mode === 'block' || prov.signatureGate === true)
+    if (!enabled) return
+
+    const resolved = this._resolveBinary('cloudflared', CLOUDFLARED_CANDIDATES)
+    // Only gate a binary that actually resolves to a real, healthy file — a
+    // missing/quarantined cloudflared is surfaced by the spawn / doctor path, not
+    // here (provenance is about "is this the binary I pinned", not "does it exist").
+    const health = this._verifyBinary(resolved)
+    if (!health.ok) return
+
+    const verdict = this._verifyProvenance({
+      resolvedPath: health.path,
+      mode: prov.mode || 'off',
+      signatureGate: prov.signatureGate === true,
+      ledger: prov.ledger || null,
+    })
+    if (verdict.blocked) {
+      throw new TunnelBinaryProvenanceError(
+        `Refusing to spawn cloudflared: "${verdict.path}" ${verdict.message || 'failed provenance verification'}`
+        + `${verdict.remediation ? ` — ${verdict.remediation}` : ''}`,
+      )
+    }
+    if (
+      verdict.status === PROVENANCE_STATUS.HASH_MISMATCH
+      || verdict.status === PROVENANCE_STATUS.SIGNATURE_INVALID
+      || verdict.status === PROVENANCE_STATUS.UNREADABLE
+    ) {
+      log.warn(`cloudflared provenance ${verdict.status}: ${verdict.message || ''} (allowed — mode=${prov.mode})`)
+    }
+  }
+
   async _startTunnel() {
+    // #6858: gate the binary before either start path spawns it.
+    this._verifyCloudflaredProvenance()
     if (this.mode === 'named') {
       return this._startNamedTunnel()
     }

--- a/packages/server/src/tunnel/index.js
+++ b/packages/server/src/tunnel/index.js
@@ -38,7 +38,7 @@ export function parseTunnelArg(value) {
 /**
  * Create a CloudflareTunnelAdapter instance from a config object.
  *
- * @param {{ port: number, mode: string, tunnelConfig?: object, tunnelName?: string, tunnelHostname?: string }} config
+ * @param {{ port: number, mode: string, tunnelConfig?: object, tunnelName?: string, tunnelHostname?: string, binaryProvenance?: object }} config
  * @returns {CloudflareTunnelAdapter}
  */
 export function createTunnel(config) {
@@ -49,6 +49,9 @@ export function createTunnel(config) {
       ...config.tunnelConfig,
       tunnelName: config.tunnelName || null,
       tunnelHostname: config.tunnelHostname || null,
+      // #6858: opt-in provenance gate for the cloudflared spawn. A plain-ish bag
+      // ({ mode, signatureGate, ledger }); undefined ⇒ the gate is skipped.
+      binaryProvenance: config.binaryProvenance || null,
     },
   })
 }

--- a/packages/server/src/utils/preflight.js
+++ b/packages/server/src/utils/preflight.js
@@ -31,6 +31,10 @@
 
 import { resolveBinary } from './resolve-binary.js'
 import { verifyBinary as defaultVerifyBinary, BINARY_STATUS, describeBinaryHealth } from './verify-binary.js'
+import { verifyProvenance as defaultVerifyProvenance, PROVENANCE_STATUS } from './verify-provenance.js'
+import { createLogger } from '../logger.js'
+
+const log = createLogger('preflight')
 
 /**
  * Thrown when a provider's required binary cannot be located or executed.
@@ -74,6 +78,29 @@ export class ProviderBinaryQuarantinedError extends Error {
 }
 
 /**
+ * Thrown when the opt-in provenance gate (#6858) blocks a spawn: either the
+ * binary's pinned SHA-256 changed in place (`binaryProvenance.mode: 'block'`) or
+ * it failed the macOS signature/notarization gate. Distinct code so the client /
+ * doctor can render a provenance-specific remediation. Never thrown when the
+ * gate is off (the default) — behaviour is then identical to #6708.
+ */
+export class ProviderBinaryProvenanceError extends Error {
+  constructor({ provider, binary, path, status, message, remediation, pinnedHash, hash }) {
+    const detail = message || 'binary failed provenance verification'
+    super(`${provider}: "${binary}" at ${path} ${detail}${remediation ? ` — ${remediation}` : ''}`)
+    this.name = 'ProviderBinaryProvenanceError'
+    this.code = 'PROVIDER_BINARY_PROVENANCE'
+    this.provider = provider
+    this.binary = binary
+    this.path = path
+    this.provenanceStatus = status
+    this.remediation = remediation || null
+    this.pinnedHash = pinnedHash || null
+    this.hash = hash || null
+  }
+}
+
+/**
  * Thrown when none of a provider's required credential env vars are present.
  */
 export class ProviderCredentialMissingError extends Error {
@@ -104,13 +131,32 @@ export class ProviderCredentialMissingError extends Error {
  * `static get resolvedBinary`, we verify THAT exact path so preflight and the
  * eventual spawn can't diverge (#6708 defect #3).
  *
+ * ## Opt-in provenance gate (#6858)
+ *
+ * When `provenance` is supplied AND enabled (`mode` is 'warn'/'block', or the
+ * signature gate is on), a healthy binary is additionally run through
+ * `verifyProvenance`: a SHA-256 pin-ledger check plus (opt-in) a macOS signature
+ * gate. A `block`-mode hash mismatch or a failed signature gate throws
+ * `ProviderBinaryProvenanceError` — fail-safe: the spawn is refused, never
+ * silently allowed. A `warn`-mode issue logs and proceeds. When `provenance` is
+ * absent or disabled (the default), this step is skipped entirely and behaviour
+ * is identical to #6708.
+ *
  * @param {Function} ProviderClass - Session class with optional `preflight` getter
  * @param {object}   [options]
  * @param {NodeJS.ProcessEnv} [options.env=process.env] - Env source (for tests)
  * @param {Function} [options.verifyBinary] - integrity checker (injected in tests)
- * @throws {ProviderBinaryNotFoundError|ProviderBinaryQuarantinedError|ProviderCredentialMissingError}
+ * @param {{ mode?: string, signatureGate?: boolean, ledger?: object }|null} [options.provenance]
+ *   - opt-in provenance config + pin ledger; null/disabled ⇒ gate skipped
+ * @param {Function} [options.verifyProvenance] - provenance checker (injected in tests)
+ * @throws {ProviderBinaryNotFoundError|ProviderBinaryQuarantinedError|ProviderBinaryProvenanceError|ProviderCredentialMissingError}
  */
-export function runProviderPreflight(ProviderClass, { env = process.env, verifyBinary = defaultVerifyBinary } = {}) {
+export function runProviderPreflight(ProviderClass, {
+  env = process.env,
+  verifyBinary = defaultVerifyBinary,
+  provenance = null,
+  verifyProvenance = defaultVerifyProvenance,
+} = {}) {
   if (!ProviderClass) return
 
   // Containerised providers run their binary inside the container, so a host
@@ -155,6 +201,41 @@ export function runProviderPreflight(ProviderClass, { env = process.env, verifyB
         candidates,
         installHint: spec.binary.installHint,
       })
+    }
+
+    // #6858: opt-in provenance gate on the SAME healthy path the spawn will use.
+    // Skipped entirely unless the operator opted in (mode warn/block or the
+    // signature gate). Fail-safe: a `block`-mode hash mismatch or a failed
+    // signature gate throws; a `warn`-mode issue logs and proceeds.
+    const provenanceOn = provenance
+      && (provenance.mode === 'warn' || provenance.mode === 'block' || provenance.signatureGate === true)
+    if (provenanceOn) {
+      const verdict = verifyProvenance({
+        resolvedPath: health.path,
+        mode: provenance.mode,
+        signatureGate: provenance.signatureGate === true,
+        ledger: provenance.ledger || null,
+      })
+      if (verdict.blocked) {
+        throw new ProviderBinaryProvenanceError({
+          provider: providerLabel,
+          binary: spec.binary.name,
+          path: verdict.path,
+          status: verdict.status,
+          message: verdict.message,
+          remediation: verdict.remediation,
+          pinnedHash: verdict.pinnedHash,
+          hash: verdict.hash,
+        })
+      }
+      if (
+        verdict.status === PROVENANCE_STATUS.HASH_MISMATCH
+        || verdict.status === PROVENANCE_STATUS.SIGNATURE_INVALID
+        || verdict.status === PROVENANCE_STATUS.UNREADABLE
+      ) {
+        // warn-mode (or unverifiable-but-allowed) — surface loudly, still spawn.
+        log.warn(`Provider "${spec.binary.name}" provenance ${verdict.status}: ${verdict.message || ''} (allowed — mode=${provenance.mode})`)
+      }
     }
   }
 

--- a/packages/server/src/utils/verify-provenance.js
+++ b/packages/server/src/utils/verify-provenance.js
@@ -1,0 +1,241 @@
+/**
+ * Opt-in provenance verification for spawned provider binaries (#6858).
+ *
+ * P1 (#6708, `verify-binary.js`) detects a binary that is missing, not
+ * executable, or macOS-Gatekeeper-quarantined. It does NOT protect against a
+ * binary being SWAPPED in place, or against running an un-notarized build when
+ * the operator wants only notarized ones. Those are the residual supply-chain
+ * surfaces that matter once the orchestration harness (#6691) auto-spawns worker
+ * sessions headless with the operator's credentials.
+ *
+ * This module adds two OPT-IN gates, both OFF by default so P1 behaviour is
+ * byte-identical unless an operator opts in:
+ *
+ *   1. **SHA-256 pin ledger (cross-platform).** The binary's content hash is
+ *      pinned on first sight (trust-on-first-use). A later change to the pinned
+ *      hash re-gates the binary — `warn` surfaces the change and allows the
+ *      spawn; `block` refuses the spawn until an operator re-approves. This
+ *      catches an in-place binary swap regardless of signature or quarantine
+ *      state. The ledger is `binary-provenance-trust.js` — the same path-keyed,
+ *      atomic-0600, fail-open `PathHashTrustLedger` that backs skills/preset
+ *      trust.
+ *   2. **macOS signature gate (opt-in, hard block).** When enabled, a binary
+ *      that fails `spctl --assess` (Gatekeeper / notarization) is refused. This
+ *      is for operators who run ONLY notarized provider builds — chroxy's own
+ *      bundled providers are ad-hoc/linker-signed and `spctl` rejects them, so
+ *      this can only ever be opt-in. It is macOS-only: on other platforms the
+ *      gate is a documented no-op (skipped) — the pin ledger still applies
+ *      cross-platform. Windows Authenticode is a tracked follow-up.
+ *
+ * FAIL-SAFE: when a gate is ON, a verification failure blocks (`block` mode) or
+ * loudly surfaces (`warn` mode) — it never silently spawns an unverified binary.
+ * A binary we cannot even hash is treated as unverifiable: blocked in `block`
+ * mode, surfaced-but-allowed in `warn` mode.
+ *
+ * Every filesystem / subprocess touchpoint is an injectable seam so the whole
+ * module is unit-testable with no real binary, ledger file, or `spctl`.
+ */
+
+import { createHash } from 'crypto'
+import { readFileSync as fsReadFileSync } from 'fs'
+import { execFileSync } from 'child_process'
+
+/**
+ * Classification of a provenance verification.
+ * @enum {string}
+ */
+export const PROVENANCE_STATUS = Object.freeze({
+  /** Verified: pinned hash matches (and signature gate, if on, passed). */
+  OK: 'ok',
+  /** First sight: hash recorded (trust-on-first-use) and allowed. */
+  PINNED: 'pinned',
+  /** Pinned hash differs from the current binary — an in-place swap. */
+  HASH_MISMATCH: 'hash_mismatch',
+  /** macOS signature gate on and the binary failed `spctl` assessment. */
+  SIGNATURE_INVALID: 'signature_invalid',
+  /** The binary could not be read to hash it. */
+  UNREADABLE: 'unreadable',
+  /** No gate applied (both off, or nothing to check). */
+  SKIPPED: 'skipped',
+})
+
+// Absolute path to the system `spctl`. Like `verify-binary.js`'s use of the
+// absolute `/usr/bin/xattr`, this is deliberately NOT a bare-name PATH lookup: a
+// shadowed `spctl` planted earlier on PATH could lie about the assessment and
+// defeat the gate. `/usr/sbin/spctl` is a fixed, SIP-protected macOS binary.
+export const MACOS_SPCTL = '/usr/sbin/spctl'
+
+/**
+ * Compute the SHA-256 hex digest of a file's raw bytes.
+ *
+ * @param {string} path
+ * @param {object} [opts]
+ * @param {(p:string)=>Buffer} [opts.readFileSync=fsReadFileSync]
+ * @returns {string} 64-char lower-case hex digest
+ */
+export function sha256File(path, { readFileSync = fsReadFileSync } = {}) {
+  const buf = readFileSync(path)
+  return createHash('sha256').update(buf).digest('hex')
+}
+
+/**
+ * Assess a binary's code signature / notarization with `spctl --assess`.
+ *
+ * macOS-only. On any other platform this is a no-op that returns
+ * `{ ok: true, skipped: true }` — there is no equivalent Gatekeeper assessment,
+ * and the pin ledger carries the cross-platform integrity story on its own.
+ *
+ * `spctl --assess --type execute` exits 0 for an accepted (notarized / approved)
+ * binary and non-zero otherwise; `execFileSync` throws on a non-zero exit, which
+ * we treat as "not accepted" (fail-safe — the gate is opt-in and its whole point
+ * is to refuse un-notarized builds).
+ *
+ * @param {string} path - absolute path to the binary
+ * @param {object} [opts]
+ * @param {string} [opts.platform=process.platform]
+ * @param {Function} [opts.execFile=execFileSync]
+ * @returns {{ ok: boolean, skipped: boolean, detail?: string }}
+ */
+export function assessMacSignature(path, { platform = process.platform, execFile = execFileSync } = {}) {
+  if (platform !== 'darwin') {
+    return { ok: true, skipped: true, detail: 'signature assessment is macOS-only' }
+  }
+  try {
+    const out = execFile(MACOS_SPCTL, ['--assess', '--type', 'execute', '--verbose', path], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    })
+    return { ok: true, skipped: false, detail: (typeof out === 'string' ? out.trim() : '') || 'accepted' }
+  } catch (err) {
+    // Non-zero exit (rejected / error) OR spctl itself unavailable. Both mean
+    // "could not confirm this binary is notarized" → not ok. spctl writes its
+    // verdict to stderr ("rejected\nsource=Unnotarized Developer ID").
+    const stderr = err && typeof err.stderr === 'string' ? err.stderr.trim() : ''
+    const detail = stderr || (err && err.message) || 'spctl assessment failed'
+    return { ok: false, skipped: false, detail }
+  }
+}
+
+/**
+ * @typedef {Object} ProvenanceVerdict
+ * @property {boolean} ok       True when the spawn is allowed (not blocked, no fatal issue).
+ * @property {string}  status   One of {@link PROVENANCE_STATUS}.
+ * @property {boolean} blocked  True when the spawn MUST be refused.
+ * @property {string}  path     The path that was checked.
+ * @property {string|null} hash The computed hash (null when not hashed).
+ * @property {string} [pinnedHash]  The previously-pinned hash on a mismatch.
+ * @property {string} [message]     Human-facing description of a non-OK verdict.
+ * @property {string} [remediation] How to resolve a non-OK verdict.
+ */
+
+/**
+ * Verify a resolved binary's provenance against the opt-in gates.
+ *
+ * Runs AFTER the P1 `verifyBinary()` existence/quarantine check — the caller
+ * only invokes this on an otherwise-healthy, absolute, resolved path.
+ *
+ * Order: the signature gate runs FIRST (so a signature-rejected binary is never
+ * pinned), then the pin ledger.
+ *
+ * @param {object} opts
+ * @param {string} opts.resolvedPath          - absolute path the spawn will exec
+ * @param {'off'|'warn'|'block'} [opts.mode='off'] - pin-ledger mode
+ * @param {boolean} [opts.signatureGate=false] - macOS spctl gate (hard block when on)
+ * @param {{ getRecord:Function, approve:Function }|null} [opts.ledger=null] - pin ledger
+ * @param {string} [opts.platform=process.platform]
+ * @param {Function} [opts.sha256File=sha256File]         - injectable hasher
+ * @param {Function} [opts.assessSignature=assessMacSignature] - injectable signature assessor
+ * @returns {ProvenanceVerdict}
+ */
+export function verifyProvenance({
+  resolvedPath,
+  mode = 'off',
+  signatureGate = false,
+  ledger = null,
+  platform = process.platform,
+  sha256File: hashFn = sha256File,
+  assessSignature = assessMacSignature,
+} = {}) {
+  const path = typeof resolvedPath === 'string' ? resolvedPath : ''
+  const pinning = mode === 'warn' || mode === 'block'
+
+  // Nothing to do — behaviour identical to the pre-#6858 spawn path.
+  if ((!pinning && !signatureGate) || !path) {
+    return { ok: true, status: PROVENANCE_STATUS.SKIPPED, blocked: false, path, hash: null }
+  }
+
+  // 1. macOS signature gate — a hard block when enabled. Checked first so a
+  //    signature-rejected binary is never pinned into the trust ledger.
+  if (signatureGate) {
+    const sig = assessSignature(path, { platform })
+    if (!sig.skipped && !sig.ok) {
+      return {
+        ok: false,
+        status: PROVENANCE_STATUS.SIGNATURE_INVALID,
+        blocked: true,
+        path,
+        hash: null,
+        message: `code signature / notarization check failed (${sig.detail || 'spctl rejected the binary'})`,
+        remediation: 'install a notarized build of this provider, or disable the signature gate (binaryProvenance.signatureGate=false / CHROXY_BINARY_SIGNATURE_GATE=0)',
+      }
+    }
+  }
+
+  // 2. SHA-256 pin ledger.
+  if (pinning) {
+    let hash
+    try {
+      hash = hashFn(path)
+    } catch (err) {
+      // Cannot read the binary to hash it → unverifiable. Fail-safe: block in
+      // `block` mode, surface-but-allow in `warn` mode.
+      const blocked = mode === 'block'
+      return {
+        ok: !blocked,
+        status: PROVENANCE_STATUS.UNREADABLE,
+        blocked,
+        path,
+        hash: null,
+        message: `could not read binary to verify its hash (${(err && err.code) || (err && err.message) || 'read failed'})`,
+        remediation: 'ensure the binary is readable, or disable provenance pinning (binaryProvenance.mode=off)',
+      }
+    }
+
+    if (!ledger) {
+      // Pinning requested but no ledger wired — treat as skipped rather than
+      // guessing. (Production always wires a ledger when mode is on.)
+      return { ok: true, status: PROVENANCE_STATUS.SKIPPED, blocked: false, path, hash }
+    }
+
+    const record = ledger.getRecord(path)
+    if (!record) {
+      // First sight — trust-on-first-use: pin the hash and allow.
+      ledger.approve(path, hash)
+      return { ok: true, status: PROVENANCE_STATUS.PINNED, blocked: false, path, hash }
+    }
+    if (record.sha256 === hash) {
+      return { ok: true, status: PROVENANCE_STATUS.OK, blocked: false, path, hash }
+    }
+
+    // Mismatch — the binary changed in place since it was pinned. Do NOT re-pin
+    // here: the mismatch must stay visible until an operator explicitly approves
+    // (matches the skills/preset trust ledgers).
+    const blocked = mode === 'block'
+    return {
+      ok: !blocked,
+      status: PROVENANCE_STATUS.HASH_MISMATCH,
+      blocked,
+      path,
+      hash,
+      pinnedHash: record.sha256,
+      message: `binary hash changed since it was pinned (pinned ${record.sha256.slice(0, 8)}…, now ${hash.slice(0, 8)}…)`,
+      remediation: blocked
+        ? `if this change is expected, re-approve it by removing this path's entry from the binary trust ledger and re-spawning; otherwise investigate the unexpected binary swap`
+        : 'if this change is unexpected, investigate the binary swap',
+    }
+  }
+
+  // Signature gate on, pinning off, signature OK → nothing left to check.
+  return { ok: true, status: PROVENANCE_STATUS.OK, blocked: false, path, hash: null }
+}

--- a/packages/server/tests/binary-provenance-trust.test.js
+++ b/packages/server/tests/binary-provenance-trust.test.js
@@ -1,0 +1,98 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHash } from 'crypto'
+import {
+  BinaryProvenanceLedger,
+  DEFAULT_BINARY_TRUST_FILE,
+  binaryTrustFileExists,
+} from '../src/binary-provenance-trust.js'
+
+/**
+ * Unit tests for the provider-binary provenance pin ledger (#6858) — a thin
+ * subclass of the well-tested PathHashTrustLedger. Exercises the wiring
+ * (wrapper key, approval field, best-effort flush) and the pin lifecycle over a
+ * temp file so the real ~/.chroxy/binary-trust.json is never touched.
+ */
+
+const sha = (s) => createHash('sha256').update(s).digest('hex')
+const HASH_A = sha('binary-a')
+const HASH_B = sha('binary-b')
+
+describe('BinaryProvenanceLedger (#6858)', () => {
+  let dir
+  let ledgerPath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-binary-trust-'))
+    ledgerPath = join(dir, 'binary-trust.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('defaults its file to ~/.chroxy/binary-trust.json', () => {
+    assert.match(DEFAULT_BINARY_TRUST_FILE, /\.chroxy[/\\]binary-trust\.json$/)
+  })
+
+  it('pins on approve and reports the record as trusted', () => {
+    const led = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    assert.equal(led.getRecord('/opt/homebrew/bin/codex'), null)
+    assert.equal(led.isTrusted('/opt/homebrew/bin/codex', HASH_A), false)
+
+    assert.equal(led.approve('/opt/homebrew/bin/codex', HASH_A), true)
+    assert.equal(led.isTrusted('/opt/homebrew/bin/codex', HASH_A), true)
+    const rec = led.getRecord('/opt/homebrew/bin/codex')
+    assert.equal(rec.sha256, HASH_A)
+    assert.ok(rec.firstSeen)
+    assert.ok(rec.approvedAt)
+  })
+
+  it('a changed hash is no longer trusted until re-approved (re-gate)', () => {
+    const led = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    led.approve('/opt/homebrew/bin/codex', HASH_A)
+    // Binary swapped: the new hash does not match the pinned one.
+    assert.equal(led.isTrusted('/opt/homebrew/bin/codex', HASH_B), false)
+    // Operator re-approves the new hash.
+    led.approve('/opt/homebrew/bin/codex', HASH_B)
+    assert.equal(led.isTrusted('/opt/homebrew/bin/codex', HASH_B), true)
+  })
+
+  it('persists to disk under the "binaries" wrapper key at mode 0600', () => {
+    const led = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    led.approve('/opt/homebrew/bin/codex', HASH_A)
+    assert.ok(binaryTrustFileExists(ledgerPath))
+    const parsed = JSON.parse(readFileSync(ledgerPath, 'utf8'))
+    assert.ok(parsed.binaries, 'on-disk shape wraps records under "binaries"')
+    assert.equal(parsed.binaries['/opt/homebrew/bin/codex'].sha256, HASH_A)
+    // POSIX: owner-only permissions on the sidecar.
+    if (process.platform !== 'win32') {
+      const mode = statSync(ledgerPath).mode & 0o777
+      assert.equal(mode, 0o600)
+    }
+  })
+
+  it('reloads a persisted ledger from disk', () => {
+    const first = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    first.approve('/opt/homebrew/bin/codex', HASH_A)
+    const second = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    assert.equal(second.isTrusted('/opt/homebrew/bin/codex', HASH_A), true)
+  })
+
+  it('fails open to an empty ledger on a corrupt file', () => {
+    writeFileSync(ledgerPath, '{ this is not valid json', 'utf8')
+    const led = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    // A corrupt ledger must not lock every binary out — it loads empty.
+    assert.equal(led.getRecord('/opt/homebrew/bin/codex'), null)
+  })
+
+  it('revoke drops the record so the binary re-gates', () => {
+    const led = new BinaryProvenanceLedger({ filePath: ledgerPath })
+    led.approve('/opt/homebrew/bin/codex', HASH_A)
+    assert.equal(led.revoke('/opt/homebrew/bin/codex'), true)
+    assert.equal(led.getRecord('/opt/homebrew/bin/codex'), null)
+  })
+})

--- a/packages/server/tests/cloudflare-provenance.test.js
+++ b/packages/server/tests/cloudflare-provenance.test.js
@@ -13,6 +13,28 @@ import { PROVENANCE_STATUS } from '../src/utils/verify-provenance.js'
 
 const okHealth = (path) => ({ ok: true, status: 'ok', path, quarantine: null })
 
+// #6937: the spawn-path tests below exec a REAL child (`/bin/echo` when the gate
+// pinned a path, a bare-name ENOENT otherwise) purely to read its `spawnfile`.
+// That child MUST be fully reaped before the test returns — a dangling
+// ChildProcess handle keeps the test process's event loop alive, which under
+// coverage (`c8`, no `--test-force-exit`) never drains and hangs the whole CI
+// suite. Kill it and await its terminal event; a bare-name spawn that never
+// started (pid undefined → ENOENT) has nothing to reap and settles immediately.
+function reapChild(proc) {
+  return new Promise((resolve) => {
+    let settled = false
+    const done = () => { if (!settled) { settled = true; resolve() } }
+    proc.once('close', done)
+    proc.once('exit', done)
+    proc.once('error', done)
+    if (proc.exitCode !== null || proc.signalCode !== null || proc.pid === undefined) {
+      done()
+      return
+    }
+    try { proc.kill('SIGKILL') } catch { done() }
+  })
+}
+
 function makeAdapter({ binaryProvenance, resolveBinary, verifyBinary, verifyProvenance } = {}) {
   return new CloudflareTunnelAdapter({
     port: 8765,
@@ -127,7 +149,7 @@ describe('cloudflared spawns the exact verified path (#6937)', () => {
   // A pinnable, always-present absolute path so the real spawn is harmless.
   const REAL_ABS = '/bin/echo'
 
-  it('spawns the pinned verified absolute path after a passing gate', () => {
+  it('spawns the pinned verified absolute path after a passing gate', async () => {
     const adapter = makeAdapter({
       binaryProvenance: { mode: 'block', signatureGate: true, ledger: {} },
       resolveBinary: () => REAL_ABS,
@@ -139,10 +161,10 @@ describe('cloudflared spawns the exact verified path (#6937)', () => {
     const proc = adapter._spawnCloudflared([], { stdio: 'ignore' })
     proc.on('error', () => {})
     assert.equal(proc.spawnfile, REAL_ABS, 'spawn must exec the pinned absolute path, not the bare name')
-    proc.kill()
+    await reapChild(proc)
   })
 
-  it('falls back to the bare name when the gate is off (feature-off unchanged)', () => {
+  it('falls back to the bare name when the gate is off (feature-off unchanged)', async () => {
     const adapter = makeAdapter({ binaryProvenance: null })
     adapter._verifyCloudflaredProvenance()
     assert.equal(adapter._resolvedCloudflaredPath, null, 'nothing pinned when the gate is off')
@@ -150,10 +172,10 @@ describe('cloudflared spawns the exact verified path (#6937)', () => {
     const proc = adapter._spawnCloudflared([], { stdio: 'ignore' })
     proc.on('error', () => {})
     assert.equal(proc.spawnfile, 'cloudflared', 'spawn must fall back to the bare name when off')
-    proc.kill()
+    await reapChild(proc)
   })
 
-  it('clears a previously-pinned path when the binary becomes unhealthy on re-check', () => {
+  it('clears a previously-pinned path when the binary becomes unhealthy on re-check', async () => {
     const adapter = makeAdapter({
       binaryProvenance: { mode: 'block', signatureGate: true, ledger: {} },
       resolveBinary: () => REAL_ABS,
@@ -171,6 +193,6 @@ describe('cloudflared spawns the exact verified path (#6937)', () => {
     const proc = adapter._spawnCloudflared([], { stdio: 'ignore' })
     proc.on('error', () => {})
     assert.equal(proc.spawnfile, 'cloudflared')
-    proc.kill()
+    await reapChild(proc)
   })
 })

--- a/packages/server/tests/cloudflare-provenance.test.js
+++ b/packages/server/tests/cloudflare-provenance.test.js
@@ -115,3 +115,62 @@ describe('cloudflared provenance gate (#6858)', () => {
     assert.equal(seen.ledger, ledger)
   })
 })
+
+/**
+ * #6937 regression guard: the gate must exec the EXACT absolute path it verified,
+ * not the bare `cloudflared` name (which a PATH change could re-resolve to a
+ * DIFFERENT binary between verify and spawn), and must clear that pin if the
+ * binary later becomes unresolvable/unhealthy so it never spawns a stale path.
+ * `spawnfile` on the returned ChildProcess is the command spawn actually exec'd.
+ */
+describe('cloudflared spawns the exact verified path (#6937)', () => {
+  // A pinnable, always-present absolute path so the real spawn is harmless.
+  const REAL_ABS = '/bin/echo'
+
+  it('spawns the pinned verified absolute path after a passing gate', () => {
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'block', signatureGate: true, ledger: {} },
+      resolveBinary: () => REAL_ABS,
+      verifyBinary: (p) => okHealth(p),
+    })
+    adapter._verifyCloudflaredProvenance()
+    assert.equal(adapter._resolvedCloudflaredPath, REAL_ABS, 'gate must pin the verified path')
+
+    const proc = adapter._spawnCloudflared([], { stdio: 'ignore' })
+    proc.on('error', () => {})
+    assert.equal(proc.spawnfile, REAL_ABS, 'spawn must exec the pinned absolute path, not the bare name')
+    proc.kill()
+  })
+
+  it('falls back to the bare name when the gate is off (feature-off unchanged)', () => {
+    const adapter = makeAdapter({ binaryProvenance: null })
+    adapter._verifyCloudflaredProvenance()
+    assert.equal(adapter._resolvedCloudflaredPath, null, 'nothing pinned when the gate is off')
+
+    const proc = adapter._spawnCloudflared([], { stdio: 'ignore' })
+    proc.on('error', () => {})
+    assert.equal(proc.spawnfile, 'cloudflared', 'spawn must fall back to the bare name when off')
+    proc.kill()
+  })
+
+  it('clears a previously-pinned path when the binary becomes unhealthy on re-check', () => {
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'block', signatureGate: true, ledger: {} },
+      resolveBinary: () => REAL_ABS,
+      verifyBinary: (p) => okHealth(p),
+    })
+    adapter._verifyCloudflaredProvenance()
+    assert.equal(adapter._resolvedCloudflaredPath, REAL_ABS, 'first pass pins the path')
+
+    // The binary is now unresolvable/unhealthy — the stale pin must be dropped so
+    // the next spawn falls back to the bare name + normal ENOENT/doctor path.
+    adapter._verifyBinary = (p) => ({ ok: false, status: 'not_found', path: p, quarantine: null })
+    adapter._verifyCloudflaredProvenance()
+    assert.equal(adapter._resolvedCloudflaredPath, null, 'stale path must be cleared on an unhealthy re-check')
+
+    const proc = adapter._spawnCloudflared([], { stdio: 'ignore' })
+    proc.on('error', () => {})
+    assert.equal(proc.spawnfile, 'cloudflared')
+    proc.kill()
+  })
+})

--- a/packages/server/tests/cloudflare-provenance.test.js
+++ b/packages/server/tests/cloudflare-provenance.test.js
@@ -1,0 +1,117 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { CloudflareTunnelAdapter, TunnelBinaryProvenanceError } from '../src/tunnel/cloudflare.js'
+import { PROVENANCE_STATUS } from '../src/utils/verify-provenance.js'
+
+/**
+ * Tests for the opt-in cloudflared provenance gate (#6858). The gate is folded
+ * into the SAME pin ledger + signature gate as the provider binaries and runs
+ * BEFORE either tunnel-start path spawns cloudflared. All binary / ledger /
+ * verification touchpoints are injected so no real cloudflared or ledger is
+ * needed.
+ */
+
+const okHealth = (path) => ({ ok: true, status: 'ok', path, quarantine: null })
+
+function makeAdapter({ binaryProvenance, resolveBinary, verifyBinary, verifyProvenance } = {}) {
+  return new CloudflareTunnelAdapter({
+    port: 8765,
+    mode: 'quick',
+    config: { binaryProvenance: binaryProvenance ?? null },
+    resolveBinary: resolveBinary || (() => '/opt/homebrew/bin/cloudflared'),
+    verifyBinary: verifyBinary || okHealth,
+    verifyProvenance: verifyProvenance || (() => ({ ok: true, status: PROVENANCE_STATUS.OK, blocked: false })),
+  })
+}
+
+describe('cloudflared provenance gate (#6858)', () => {
+  it('is a no-op when no provenance config is supplied', () => {
+    let resolved = false
+    const adapter = makeAdapter({
+      binaryProvenance: null,
+      resolveBinary: () => { resolved = true; return '/x' },
+    })
+    assert.doesNotThrow(() => adapter._verifyCloudflaredProvenance())
+    assert.equal(resolved, false, 'must not even resolve the binary when off')
+  })
+
+  it('is a no-op when mode is off and the signature gate is off', () => {
+    let verified = false
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'off', signatureGate: false, ledger: {} },
+      verifyProvenance: () => { verified = true; return { blocked: false } },
+    })
+    assert.doesNotThrow(() => adapter._verifyCloudflaredProvenance())
+    assert.equal(verified, false)
+  })
+
+  it('block mode + a blocked verdict throws TunnelBinaryProvenanceError BEFORE any spawn', async () => {
+    let spawned = false
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'block', signatureGate: false, ledger: {} },
+      verifyProvenance: () => ({
+        ok: false,
+        status: PROVENANCE_STATUS.HASH_MISMATCH,
+        blocked: true,
+        path: '/opt/homebrew/bin/cloudflared',
+        message: 'binary hash changed since it was pinned',
+        remediation: 're-approve it',
+      }),
+    })
+    adapter._spawnCloudflared = () => { spawned = true; return {} }
+
+    await assert.rejects(
+      () => adapter._startTunnel(),
+      (err) => {
+        assert.ok(err instanceof TunnelBinaryProvenanceError, `got ${err?.name}`)
+        assert.equal(err.code, 'TUNNEL_BINARY_PROVENANCE')
+        assert.match(err.message, /cloudflared/)
+        assert.match(err.message, /changed/i)
+        return true
+      },
+    )
+    assert.equal(spawned, false, 'gate must block before cloudflared is spawned')
+  })
+
+  it('warn mode + a non-blocked mismatch does NOT throw (surfaced, allowed)', () => {
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'warn', signatureGate: false, ledger: {} },
+      verifyProvenance: () => ({
+        ok: true,
+        status: PROVENANCE_STATUS.HASH_MISMATCH,
+        blocked: false,
+        path: '/opt/homebrew/bin/cloudflared',
+        message: 'binary hash changed since it was pinned',
+      }),
+    })
+    assert.doesNotThrow(() => adapter._verifyCloudflaredProvenance())
+  })
+
+  it('does not gate (nor call verifyProvenance) when the binary is not resolvable/healthy', () => {
+    let verified = false
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'block', signatureGate: false, ledger: {} },
+      verifyBinary: (path) => ({ ok: false, status: 'not_found', path, quarantine: null }),
+      verifyProvenance: () => { verified = true; return { blocked: true } },
+    })
+    // A missing cloudflared is surfaced by the normal spawn / doctor path — the
+    // provenance gate must not mask it, and must not block.
+    assert.doesNotThrow(() => adapter._verifyCloudflaredProvenance())
+    assert.equal(verified, false)
+  })
+
+  it('passes the resolved healthy path + ledger through to verifyProvenance', () => {
+    let seen = null
+    const ledger = { getRecord: () => null, approve: () => true }
+    const adapter = makeAdapter({
+      binaryProvenance: { mode: 'block', signatureGate: true, ledger },
+      resolveBinary: () => '/usr/local/bin/cloudflared',
+      verifyProvenance: (args) => { seen = args; return { blocked: false, status: PROVENANCE_STATUS.OK } },
+    })
+    adapter._verifyCloudflaredProvenance()
+    assert.equal(seen.resolvedPath, '/usr/local/bin/cloudflared')
+    assert.equal(seen.mode, 'block')
+    assert.equal(seen.signatureGate, true)
+    assert.equal(seen.ledger, ledger)
+  })
+})

--- a/packages/server/tests/config-binary-provenance.test.js
+++ b/packages/server/tests/config-binary-provenance.test.js
@@ -1,0 +1,84 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveBinaryProvenanceMode, isBinarySignatureGateEnabled, validateConfig } from '../src/config.js'
+
+/**
+ * #6858 — the opt-in provenance resolvers are the fail-closed single source of
+ * truth for the pin-ledger mode + macOS signature gate. Precedence:
+ *   env  >  config.binaryProvenance.*  >  off/false (default, behaviour unchanged).
+ */
+
+describe('resolveBinaryProvenanceMode (#6858)', () => {
+  let savedEnv
+
+  beforeEach(() => { savedEnv = process.env.CHROXY_BINARY_PROVENANCE; delete process.env.CHROXY_BINARY_PROVENANCE })
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CHROXY_BINARY_PROVENANCE
+    else process.env.CHROXY_BINARY_PROVENANCE = savedEnv
+  })
+
+  it('defaults to off with no config and no env', () => {
+    assert.equal(resolveBinaryProvenanceMode(undefined), 'off')
+    assert.equal(resolveBinaryProvenanceMode({}), 'off')
+  })
+
+  it('reads warn / block from config.binaryProvenance.mode', () => {
+    assert.equal(resolveBinaryProvenanceMode({ binaryProvenance: { mode: 'warn' } }), 'warn')
+    assert.equal(resolveBinaryProvenanceMode({ binaryProvenance: { mode: 'block' } }), 'block')
+  })
+
+  it('fails closed to off for an unrecognised config mode', () => {
+    assert.equal(resolveBinaryProvenanceMode({ binaryProvenance: { mode: 'loud' } }), 'off')
+    assert.equal(resolveBinaryProvenanceMode({ binaryProvenance: { mode: true } }), 'off')
+  })
+
+  it('env overrides config (both directions)', () => {
+    process.env.CHROXY_BINARY_PROVENANCE = 'block'
+    assert.equal(resolveBinaryProvenanceMode({ binaryProvenance: { mode: 'warn' } }), 'block')
+    process.env.CHROXY_BINARY_PROVENANCE = 'off'
+    assert.equal(resolveBinaryProvenanceMode({ binaryProvenance: { mode: 'block' } }), 'off')
+  })
+
+  it('is case-insensitive on the env value', () => {
+    process.env.CHROXY_BINARY_PROVENANCE = 'WARN'
+    assert.equal(resolveBinaryProvenanceMode({}), 'warn')
+  })
+})
+
+describe('isBinarySignatureGateEnabled (#6858)', () => {
+  let savedEnv
+
+  beforeEach(() => { savedEnv = process.env.CHROXY_BINARY_SIGNATURE_GATE; delete process.env.CHROXY_BINARY_SIGNATURE_GATE })
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CHROXY_BINARY_SIGNATURE_GATE
+    else process.env.CHROXY_BINARY_SIGNATURE_GATE = savedEnv
+  })
+
+  it('defaults to false (fail-closed — bundled providers are ad-hoc signed)', () => {
+    assert.equal(isBinarySignatureGateEnabled(undefined), false)
+    assert.equal(isBinarySignatureGateEnabled({}), false)
+    assert.equal(isBinarySignatureGateEnabled({ binaryProvenance: {} }), false)
+  })
+
+  it('reads the boolean from config.binaryProvenance.signatureGate', () => {
+    assert.equal(isBinarySignatureGateEnabled({ binaryProvenance: { signatureGate: true } }), true)
+    assert.equal(isBinarySignatureGateEnabled({ binaryProvenance: { signatureGate: false } }), false)
+  })
+
+  it('env 1/0 overrides config', () => {
+    process.env.CHROXY_BINARY_SIGNATURE_GATE = '1'
+    assert.equal(isBinarySignatureGateEnabled({ binaryProvenance: { signatureGate: false } }), true)
+    process.env.CHROXY_BINARY_SIGNATURE_GATE = '0'
+    assert.equal(isBinarySignatureGateEnabled({ binaryProvenance: { signatureGate: true } }), false)
+  })
+})
+
+describe('config schema — binaryProvenance is a known key (#6858)', () => {
+  it('does not warn "Unknown config key" for a binaryProvenance block', () => {
+    const result = validateConfig({ binaryProvenance: { mode: 'warn', signatureGate: true } })
+    assert.ok(
+      !result.warnings.some((w) => w.includes('binaryProvenance') && w.includes('Unknown')),
+      `unexpected unknown-key warning: ${JSON.stringify(result.warnings)}`,
+    )
+  })
+})

--- a/packages/server/tests/permission-expired-broadcast.test.js
+++ b/packages/server/tests/permission-expired-broadcast.test.js
@@ -141,7 +141,13 @@ describe('permission_expired end-to-end broadcast (#2831)', () => {
 
       const tmpState = `/tmp/chroxy-permexp-${Date.now()}-${Math.random()}.json`
       const sm = new SessionManager({ skipPreflight: true,
-        provider: 'fake-permexp',
+        // providerType (NOT provider) is the SessionManager ctor opt that sets
+        // the default provider for createSession(). Passing `provider` here was
+        // silently ignored, so createSession() fell back to DEFAULT_PROVIDER
+        // (claude-tui) and spawned a REAL `claude` PTY (node-pty tty.ReadStream)
+        // that was never torn down — leaking a live handle that kept the test
+        // worker alive and hung the suite when run without --test-force-exit.
+        providerType: 'fake-permexp',
         stateFilePath: tmpState,
         persistenceDebounceMs: 0,
       })
@@ -165,7 +171,7 @@ describe('permission_expired end-to-end broadcast (#2831)', () => {
       assert.equal(events[0].sessionId, sessionId)
       assert.equal(events[0].data.requestId, 'req-prox')
 
-      sm.destroy?.()
+      sm.destroySession(sessionId)
     })
   })
 })

--- a/packages/server/tests/permission-resolved-broadcast.test.js
+++ b/packages/server/tests/permission-resolved-broadcast.test.js
@@ -165,7 +165,13 @@ describe('permission_resolved end-to-end broadcast (#3048)', () => {
       const tmpState = `/tmp/chroxy-permresolved-${Date.now()}-${Math.random()}.json`
       const sm = new SessionManager({
         skipPreflight: true,
-        provider: 'fake-permresolved',
+        // providerType (NOT provider) is the SessionManager ctor opt that sets
+        // the default provider for createSession(). Passing `provider` here was
+        // silently ignored, so createSession() fell back to DEFAULT_PROVIDER
+        // (claude-tui) and spawned a REAL `claude` PTY (node-pty tty.ReadStream)
+        // that was never torn down — leaking a live handle that kept the test
+        // worker alive and hung the suite when run without --test-force-exit.
+        providerType: 'fake-permresolved',
         stateFilePath: tmpState,
         persistenceDebounceMs: 0,
       })
@@ -191,7 +197,7 @@ describe('permission_resolved end-to-end broadcast (#3048)', () => {
       assert.equal(events[0].data.requestId, 'req-prox')
       assert.equal(events[0].data.decision, 'allow')
 
-      sm.destroy?.()
+      sm.destroySession(sessionId)
     })
   })
 })

--- a/packages/server/tests/preflight.test.js
+++ b/packages/server/tests/preflight.test.js
@@ -4,9 +4,11 @@ import {
   runProviderPreflight,
   ProviderBinaryNotFoundError,
   ProviderBinaryQuarantinedError,
+  ProviderBinaryProvenanceError,
   ProviderCredentialMissingError,
 } from '../src/utils/preflight.js'
 import { BINARY_STATUS } from '../src/utils/verify-binary.js'
+import { PROVENANCE_STATUS } from '../src/utils/verify-provenance.js'
 
 /**
  * Tests for runProviderPreflight — verifies binary + credential checks
@@ -161,6 +163,119 @@ describe('runProviderPreflight — quarantine detection (#6708)', () => {
     assert.throws(
       () => runProviderPreflight(Provider, { env: {}, verifyBinary: notExec }),
       ProviderBinaryNotFoundError,
+    )
+  })
+})
+
+describe('runProviderPreflight — opt-in provenance gate (#6858)', () => {
+  // A healthy binary so we always reach the provenance step.
+  const okVerify = (path) => ({ ok: true, status: BINARY_STATUS.OK, path, quarantine: null })
+  const Provider = makeProvider({
+    preflight: { label: 'Codex', binary: { name: 'node', candidates: [] } },
+  })
+
+  // Minimal in-memory pin ledger (getRecord + approve) for end-to-end tests.
+  function fakeLedger(seed = {}) {
+    const records = new Map(Object.entries(seed))
+    return {
+      getRecord: (p) => (records.has(p) ? { ...records.get(p) } : null),
+      approve: (p, h) => { records.set(p, { sha256: h, firstSeen: 'x', approvedAt: 'x' }); return true },
+      _records: records,
+    }
+  }
+
+  it('is SKIPPED entirely when no provenance config is supplied (default)', () => {
+    // Inject a provenance checker that would explode if called — it must not be.
+    const boom = () => { throw new Error('provenance must not run when disabled') }
+    assert.doesNotThrow(() =>
+      runProviderPreflight(Provider, { env: {}, verifyBinary: okVerify, verifyProvenance: boom }),
+    )
+  })
+
+  it('is SKIPPED when provenance mode is off and the signature gate is off', () => {
+    const boom = () => { throw new Error('provenance must not run when off') }
+    assert.doesNotThrow(() =>
+      runProviderPreflight(Provider, {
+        env: {},
+        verifyBinary: okVerify,
+        verifyProvenance: boom,
+        provenance: { mode: 'off', signatureGate: false, ledger: fakeLedger() },
+      }),
+    )
+  })
+
+  it('block mode + a blocked verdict throws ProviderBinaryProvenanceError (fail-safe)', () => {
+    const blockedVerdict = () => ({
+      ok: false,
+      status: PROVENANCE_STATUS.HASH_MISMATCH,
+      blocked: true,
+      path: '/usr/bin/node',
+      hash: 'b'.repeat(64),
+      pinnedHash: 'a'.repeat(64),
+      message: 'binary hash changed since it was pinned',
+      remediation: 're-approve it',
+    })
+    assert.throws(
+      () => runProviderPreflight(Provider, {
+        env: {},
+        verifyBinary: okVerify,
+        verifyProvenance: blockedVerdict,
+        provenance: { mode: 'block', signatureGate: false, ledger: fakeLedger() },
+      }),
+      (err) => {
+        assert.ok(err instanceof ProviderBinaryProvenanceError, `got ${err?.name}`)
+        assert.equal(err.code, 'PROVIDER_BINARY_PROVENANCE')
+        assert.equal(err.binary, 'node')
+        assert.equal(err.provenanceStatus, PROVENANCE_STATUS.HASH_MISMATCH)
+        assert.equal(err.pinnedHash, 'a'.repeat(64))
+        assert.match(err.message, /changed/i)
+        return true
+      },
+    )
+  })
+
+  it('warn mode + a non-blocked mismatch does NOT throw (surfaced, allowed)', () => {
+    const warnVerdict = () => ({
+      ok: true,
+      status: PROVENANCE_STATUS.HASH_MISMATCH,
+      blocked: false,
+      path: '/usr/bin/node',
+      hash: 'b'.repeat(64),
+      pinnedHash: 'a'.repeat(64),
+      message: 'binary hash changed since it was pinned',
+    })
+    assert.doesNotThrow(() =>
+      runProviderPreflight(Provider, {
+        env: {},
+        verifyBinary: okVerify,
+        verifyProvenance: warnVerdict,
+        provenance: { mode: 'warn', signatureGate: false, ledger: fakeLedger() },
+      }),
+    )
+  })
+
+  it('end-to-end: real verifyProvenance pins on first sight, then blocks a swapped hash', () => {
+    // First sight over the REAL node binary + a fresh ledger: pins + allows.
+    const led = fakeLedger()
+    assert.doesNotThrow(() =>
+      runProviderPreflight(Provider, {
+        env: {},
+        verifyBinary: okVerify,
+        provenance: { mode: 'block', signatureGate: false, ledger: led },
+      }),
+    )
+    assert.equal(led._records.size, 1, 'first sight pinned exactly one binary')
+
+    // Now simulate an in-place swap: overwrite the pinned hash with a bogus one.
+    for (const [p, rec] of led._records) led._records.set(p, { ...rec, sha256: 'c'.repeat(64) })
+
+    assert.throws(
+      () => runProviderPreflight(Provider, {
+        env: {},
+        verifyBinary: okVerify,
+        provenance: { mode: 'block', signatureGate: false, ledger: led },
+      }),
+      ProviderBinaryProvenanceError,
     )
   })
 })

--- a/packages/server/tests/verify-provenance.test.js
+++ b/packages/server/tests/verify-provenance.test.js
@@ -1,0 +1,264 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash } from 'crypto'
+import {
+  PROVENANCE_STATUS,
+  sha256File,
+  assessMacSignature,
+  verifyProvenance,
+  MACOS_SPCTL,
+} from '../src/utils/verify-provenance.js'
+
+/**
+ * Unit tests for opt-in provider-binary provenance verification (#6858).
+ *
+ * The pin ledger + signature gate are exercised over injected seams (a fake
+ * ledger, a fake hash fn, a fake signature assessor), so these run identically
+ * on macOS, Linux, and Windows CI with NO real binary, ledger file, or `spctl`.
+ */
+
+// A minimal in-memory ledger implementing exactly the surface verifyProvenance
+// consults: getRecord() + approve(). Records the same shape PathHashTrustLedger
+// returns so a swap for the real ledger changes nothing here.
+function makeLedger(seed = {}) {
+  const records = new Map(Object.entries(seed))
+  const approvals = []
+  return {
+    getRecord(path) {
+      const rec = records.get(path)
+      return rec ? { ...rec } : null
+    },
+    approve(path, hash) {
+      approvals.push({ path, hash })
+      records.set(path, { sha256: hash, firstSeen: 'x', approvedAt: 'x' })
+      return true
+    },
+    _approvals: approvals,
+    _records: records,
+  }
+}
+
+const HASH_A = 'a'.repeat(64)
+const HASH_B = 'b'.repeat(64)
+
+describe('verifyProvenance — flag off (default, behaviour unchanged)', () => {
+  it('SKIPS entirely when mode is off and the signature gate is off', () => {
+    const ledger = makeLedger()
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'off',
+      signatureGate: false,
+      ledger,
+      sha256File: () => { throw new Error('must not hash when off') },
+      assessSignature: () => { throw new Error('must not assess when off') },
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.SKIPPED)
+    assert.equal(v.ok, true)
+    assert.equal(v.blocked, false)
+    assert.equal(ledger._approvals.length, 0)
+  })
+
+  it('SKIPS when resolvedPath is empty even with a mode set', () => {
+    const v = verifyProvenance({ resolvedPath: '', mode: 'block', signatureGate: true, ledger: makeLedger() })
+    assert.equal(v.status, PROVENANCE_STATUS.SKIPPED)
+    assert.equal(v.blocked, false)
+  })
+})
+
+describe('verifyProvenance — SHA-256 pin ledger (cross-platform)', () => {
+  it('first sight PINS the hash and allows (trust on first use)', () => {
+    const ledger = makeLedger()
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'warn',
+      ledger,
+      sha256File: () => HASH_A,
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.PINNED)
+    assert.equal(v.ok, true)
+    assert.equal(v.blocked, false)
+    assert.equal(v.hash, HASH_A)
+    assert.deepEqual(ledger._approvals, [{ path: '/opt/homebrew/bin/codex', hash: HASH_A }])
+  })
+
+  it('a matching pinned hash passes without re-pinning', () => {
+    const ledger = makeLedger({ '/opt/homebrew/bin/codex': { sha256: HASH_A, firstSeen: 'x', approvedAt: 'x' } })
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'block',
+      ledger,
+      sha256File: () => HASH_A,
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.OK)
+    assert.equal(v.ok, true)
+    assert.equal(v.blocked, false)
+    assert.equal(ledger._approvals.length, 0, 'must not re-approve a matching binary')
+  })
+
+  it('warn mode: a changed hash surfaces a mismatch but ALLOWS the spawn', () => {
+    const ledger = makeLedger({ '/opt/homebrew/bin/codex': { sha256: HASH_A, firstSeen: 'x', approvedAt: 'x' } })
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'warn',
+      ledger,
+      sha256File: () => HASH_B,
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.HASH_MISMATCH)
+    assert.equal(v.ok, true, 'warn mode never blocks')
+    assert.equal(v.blocked, false)
+    assert.equal(v.pinnedHash, HASH_A)
+    assert.equal(v.hash, HASH_B)
+    // Must NOT silently re-pin — the mismatch stays visible until an operator approves.
+    assert.equal(ledger._approvals.length, 0)
+    assert.match(v.message, /changed/i)
+  })
+
+  it('block mode: a changed hash BLOCKS the spawn (fail-safe)', () => {
+    const ledger = makeLedger({ '/opt/homebrew/bin/codex': { sha256: HASH_A, firstSeen: 'x', approvedAt: 'x' } })
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'block',
+      ledger,
+      sha256File: () => HASH_B,
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.HASH_MISMATCH)
+    assert.equal(v.ok, false)
+    assert.equal(v.blocked, true)
+    assert.equal(ledger._approvals.length, 0)
+    assert.ok(v.remediation && v.remediation.length > 0)
+  })
+})
+
+describe('verifyProvenance — unreadable binary (fail-safe)', () => {
+  it('block mode: an unreadable binary BLOCKS (cannot verify → deny)', () => {
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'block',
+      ledger: makeLedger(),
+      sha256File: () => { const e = new Error('boom'); e.code = 'EACCES'; throw e },
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.UNREADABLE)
+    assert.equal(v.ok, false)
+    assert.equal(v.blocked, true)
+  })
+
+  it('warn mode: an unreadable binary is surfaced but ALLOWED', () => {
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'warn',
+      ledger: makeLedger(),
+      sha256File: () => { throw new Error('boom') },
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.UNREADABLE)
+    assert.equal(v.ok, true)
+    assert.equal(v.blocked, false)
+  })
+})
+
+describe('verifyProvenance — macOS signature gate (opt-in, hard block)', () => {
+  it('blocks a binary that fails spctl assessment when the gate is on', () => {
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'off',
+      signatureGate: true,
+      platform: 'darwin',
+      ledger: makeLedger(),
+      assessSignature: () => ({ ok: false, skipped: false, detail: 'rejected: source=Unnotarized' }),
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.SIGNATURE_INVALID)
+    assert.equal(v.ok, false)
+    assert.equal(v.blocked, true)
+    assert.match(v.message, /signature|notariz/i)
+  })
+
+  it('a notarized binary passes the gate (and still pins when pinning is on)', () => {
+    const ledger = makeLedger()
+    const v = verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'warn',
+      signatureGate: true,
+      platform: 'darwin',
+      ledger,
+      assessSignature: () => ({ ok: true, skipped: false }),
+      sha256File: () => HASH_A,
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.PINNED)
+    assert.equal(v.blocked, false)
+    assert.equal(ledger._approvals.length, 1)
+  })
+
+  it('a signature-gate FAILURE is checked BEFORE pinning (a rejected binary is never pinned)', () => {
+    const ledger = makeLedger()
+    verifyProvenance({
+      resolvedPath: '/opt/homebrew/bin/codex',
+      mode: 'warn',
+      signatureGate: true,
+      platform: 'darwin',
+      ledger,
+      assessSignature: () => ({ ok: false, skipped: false, detail: 'rejected' }),
+      sha256File: () => { throw new Error('must not hash a signature-rejected binary') },
+    })
+    assert.equal(ledger._approvals.length, 0)
+  })
+
+  it('the gate is a no-op on non-macOS platforms (skipped), pinning still runs', () => {
+    const ledger = makeLedger()
+    const v = verifyProvenance({
+      resolvedPath: '/usr/bin/codex',
+      mode: 'warn',
+      signatureGate: true,
+      platform: 'linux',
+      ledger,
+      // Real assessMacSignature returns skipped on non-darwin; the default is used here.
+      sha256File: () => HASH_A,
+    })
+    assert.equal(v.status, PROVENANCE_STATUS.PINNED)
+    assert.equal(v.blocked, false)
+  })
+})
+
+describe('assessMacSignature', () => {
+  it('returns skipped:true on non-darwin without invoking spctl', () => {
+    let called = false
+    const r = assessMacSignature('/usr/bin/codex', {
+      platform: 'linux',
+      execFile: () => { called = true; return '' },
+    })
+    assert.equal(r.skipped, true)
+    assert.equal(r.ok, true)
+    assert.equal(called, false)
+  })
+
+  it('invokes the ABSOLUTE spctl path (never a PATH lookup) on darwin', () => {
+    let invokedWith = null
+    const r = assessMacSignature('/opt/homebrew/bin/codex', {
+      platform: 'darwin',
+      execFile: (bin, args) => { invokedWith = { bin, args }; return 'accepted\n' },
+    })
+    assert.equal(invokedWith.bin, MACOS_SPCTL)
+    assert.equal(MACOS_SPCTL, '/usr/sbin/spctl')
+    assert.ok(invokedWith.args.includes('/opt/homebrew/bin/codex'))
+    assert.equal(r.ok, true)
+    assert.equal(r.skipped, false)
+  })
+
+  it('a non-zero spctl exit (throw) is reported as not-ok (fail-safe)', () => {
+    const r = assessMacSignature('/opt/homebrew/bin/codex', {
+      platform: 'darwin',
+      execFile: () => { const e = new Error('rejected'); e.status = 3; e.stderr = 'source=Unnotarized'; throw e },
+    })
+    assert.equal(r.ok, false)
+    assert.equal(r.skipped, false)
+    assert.match(r.detail, /Unnotarized|rejected/)
+  })
+})
+
+describe('sha256File', () => {
+  it('hashes the raw bytes of the file via the injected reader', () => {
+    const bytes = Buffer.from('hello-binary')
+    const expected = createHash('sha256').update(bytes).digest('hex')
+    const h = sha256File('/any/path', { readFileSync: () => bytes })
+    assert.equal(h, expected)
+    assert.match(h, /^[a-f0-9]{64}$/)
+  })
+})


### PR DESCRIPTION
Closes #6858.

Extends the merged P1 binary-integrity story (#6708 — `verify-binary.js` existence/quarantine + macOS quarantine preflight) with the deferred **P2 acceptance criterion**: opt-in provenance verification for the external binaries chroxy spawns as providers (`claude`, `codex`, `gemini`) and for `cloudflared`. Both gates are **OFF by default** — with them off, behaviour is byte-identical to #6708.

## What the flag verifies

`binaryProvenance` (config) / `CHROXY_BINARY_PROVENANCE` + `CHROXY_BINARY_SIGNATURE_GATE` (env), both fail-closed:

1. **Cross-platform SHA-256 pin ledger** (`binaryProvenance.mode`: `off`/`warn`/`block`). A thin `PathHashTrustLedger` subclass (`BinaryProvenanceLedger`, `~/.chroxy/binary-trust.json`, `binaries` wrapper key, fail-open, atomic 0600) — the same pattern behind `skills-trust.js` / `session-preset-trust.js`. Each binary is pinned on first sight (trust-on-first-use); a later change to the pinned hash re-gates the binary. `warn` logs + allows; `block` refuses the spawn. Catches an in-place binary swap regardless of signature or quarantine state. Works on every platform.
2. **macOS signature gate** (`binaryProvenance.signatureGate`, default `false`). Hard-blocks a binary that fails `spctl --assess` (Gatekeeper/notarization) — for operators who run only notarized provider builds (chroxy's own bundled providers are ad-hoc-signed, so this can only ever be opt-in). `spctl` is invoked by its **absolute SIP path** (`/usr/sbin/spctl`), never a PATH lookup — same hardening as the P1 `/usr/bin/xattr` probe. **macOS-only**: a documented no-op on Linux/Windows (the pin ledger still applies there).

## Fail-safe wiring

The gate runs after P1's `verifyBinary` on the **same healthy `resolvedBinary` path the spawn will use**:

- **Providers** — in `runProviderPreflight` (`utils/preflight.js`). A `block`-mode hash mismatch, a failed signature gate, or an unhashable binary throws `ProviderBinaryProvenanceError` (`code: PROVIDER_BINARY_PROVENANCE`); a `warn`-mode issue logs and proceeds. `SessionManager` builds the provenance bag + ledger and passes it through; `server-cli` wires the resolved config.
- **cloudflared** — a pre-spawn gate in `tunnel/cloudflare.js` before either tunnel-start path; blocks with `TunnelBinaryProvenanceError` (`code: TUNNEL_BINARY_PROVENANCE`). Reuses the SessionManager's ledger instance (threaded through the tunnel factory) so pins are unified across every spawned binary.

An unverified binary is **never silently spawned** when a gate is on.

## Re-approval

Remove a path's entry from `~/.chroxy/binary-trust.json` (or delete it — fails open and re-pins on next spawn). A programmatic `approve`/`revoke` API exists on the ledger for a future CLI/dashboard surface.

## Follow-up

- #6932 — Windows Authenticode signature gate (the signature half is macOS-only for now; the pin ledger already covers Windows).

## Tests / lint

- New: `verify-provenance.test.js` (16), `binary-provenance-trust.test.js` (7), `cloudflare-provenance.test.js` (6), `config-binary-provenance.test.js`; extended `preflight.test.js` (+provenance gate). 58 tests green across the new suites; verified/first-sight-pin/mismatch-warn/mismatch-block/unreadable-fail-safe/signature-gate/flag-off-skip all covered.
- All 5 `packages/server/scripts/lint-*.sh` pass; `eslint src/` clean (0 errors) on all changed source.
- Docs: `docs/security/spawned-binary-provenance.md` §4 marks P2 implemented; `CONFIG.md` documents the keys.

> Note: `session-manager-preflight.test.js` / `tunnel-lifecycle-handler.test.js` fail locally in this isolated worktree with `Cannot find package '@anthropic-ai/claude-agent-sdk'` — a pre-existing worktree node_modules gap (the SDK is a declared dep, installed in CI). Reverting this branch's edits reproduces the identical error, and no source change here adds an SDK import; these pass in CI.