### PR TITLE
feat(dashboard,server,protocol): in-app PR creation (Create PR action)

### DIFF
--- a/packages/dashboard/src/components/GitPanel.test.tsx
+++ b/packages/dashboard/src/components/GitPanel.test.tsx
@@ -14,12 +14,14 @@ const mockRequestGitBranches = vi.fn()
 const mockRequestGitStage = vi.fn(() => true)
 const mockRequestGitUnstage = vi.fn(() => true)
 const mockRequestGitCommit = vi.fn(() => true)
+const mockRequestGitCreatePr = vi.fn(() => true)
 
 let storeState: Record<string, unknown> = {}
 let capturedStatusCallback: ((result: any) => void) | null = null
 let capturedBranchesCallback: ((result: any) => void) | null = null
 let capturedStageCallback: ((result: any) => void) | null = null
 let capturedCommitCallback: ((result: any) => void) | null = null
+let capturedCreatePrCallback: ((result: any) => void) | null = null
 
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: any) => {
@@ -33,6 +35,8 @@ vi.mock('../store/connection', () => ({
       requestGitUnstage: mockRequestGitUnstage,
       setGitCommitCallback: (cb: any) => { capturedCommitCallback = cb },
       requestGitCommit: mockRequestGitCommit,
+      setGitCreatePrCallback: (cb: any) => { capturedCreatePrCallback = cb },
+      requestGitCreatePr: mockRequestGitCreatePr,
       connectionPhase: storeState.connectionPhase ?? 'connected',
     }
     return selector(store)
@@ -46,11 +50,13 @@ beforeEach(() => {
   mockRequestGitStage.mockReturnValue(true)
   mockRequestGitUnstage.mockReturnValue(true)
   mockRequestGitCommit.mockReturnValue(true)
+  mockRequestGitCreatePr.mockReturnValue(true)
   storeState = { connectionPhase: 'connected' }
   capturedStatusCallback = null
   capturedBranchesCallback = null
   capturedStageCallback = null
   capturedCommitCallback = null
+  capturedCreatePrCallback = null
 })
 
 const GIT_STATUS_WITH_CHANGES = {
@@ -329,5 +335,103 @@ describe('GitPanel', () => {
     act(() => capturedStatusCallback!({ branch: 'main', staged: [], unstaged: [{ path: 'a.ts', status: 'modified' }], untracked: [], error: null }))
 
     expect(screen.queryByTestId('git-commit-input')).not.toBeInTheDocument()
+  })
+
+  // #6876 — in-app PR creation.
+  describe('Create PR', () => {
+    const seedBranch = () =>
+      act(() => capturedStatusCallback!(GIT_STATUS_WITH_CHANGES))
+
+    it('shows the Create PR button once a branch is known', () => {
+      render(<GitPanel />)
+      expect(screen.queryByTestId('git-create-pr-open-btn')).not.toBeInTheDocument()
+      seedBranch()
+      expect(screen.getByTestId('git-create-pr-open-btn')).toBeInTheDocument()
+    })
+
+    it('opens the PR form (prefilled with the branch name) on click', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+
+      expect(screen.getByTestId('git-pr-form')).toBeInTheDocument()
+      expect((screen.getByTestId('git-pr-title-input') as HTMLInputElement).value).toBe('feat/git-panel')
+    })
+
+    it('is confirmation-gated: submitting opens the confirm dialog without firing the request', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+      fireEvent.click(screen.getByTestId('git-pr-submit-btn'))
+
+      expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument()
+      expect(mockRequestGitCreatePr).not.toHaveBeenCalled()
+    })
+
+    it('fires requestGitCreatePr with title/body/base/draft after confirming', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+
+      fireEvent.change(screen.getByTestId('git-pr-title-input'), { target: { value: 'feat: cool' } })
+      fireEvent.change(screen.getByTestId('git-pr-body-input'), { target: { value: 'body text' } })
+      fireEvent.change(screen.getByTestId('git-pr-base-input'), { target: { value: 'develop' } })
+      fireEvent.click(screen.getByTestId('git-pr-draft-checkbox'))
+      fireEvent.click(screen.getByTestId('git-pr-submit-btn'))
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+
+      expect(mockRequestGitCreatePr).toHaveBeenCalledWith({
+        title: 'feat: cool',
+        body: 'body text',
+        base: 'develop',
+        draft: true,
+      })
+    })
+
+    it('shows the created PR URL on success', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+      fireEvent.click(screen.getByTestId('git-pr-submit-btn'))
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+      act(() => capturedCreatePrCallback!({ url: 'https://github.com/o/r/pull/42', number: 42, branch: 'feat/git-panel', base: 'main', error: null }))
+
+      const link = screen.getByTestId('git-pr-url') as HTMLAnchorElement
+      expect(link).toHaveAttribute('href', 'https://github.com/o/r/pull/42')
+    })
+
+    it('surfaces the server error on failure and keeps the form open', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+      fireEvent.click(screen.getByTestId('git-pr-submit-btn'))
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+      act(() => capturedCreatePrCallback!({ url: null, number: null, branch: 'feat/git-panel', base: 'main', error: 'GitHub CLI is not authenticated — run `gh auth login` on the daemon host to enable PR creation' }))
+
+      expect(screen.getByTestId('git-pr-error')).toHaveTextContent('not authenticated')
+      // Form still open (title input present), so the operator can retry.
+      expect(screen.getByTestId('git-pr-title-input')).toBeInTheDocument()
+    })
+
+    it('surfaces a "not connected" error when requestGitCreatePr returns false', () => {
+      mockRequestGitCreatePr.mockReturnValue(false)
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+      fireEvent.click(screen.getByTestId('git-pr-submit-btn'))
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+
+      expect(screen.getByTestId('git-pr-error')).toHaveTextContent('PR not sent — reconnect and try again')
+    })
+
+    it('closes the form on cancel', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+      expect(screen.getByTestId('git-pr-form')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('git-pr-cancel-btn'))
+      expect(screen.queryByTestId('git-pr-form')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/dashboard/src/components/GitPanel.tsx
+++ b/packages/dashboard/src/components/GitPanel.tsx
@@ -12,10 +12,12 @@
  * and UI, following the same request/callback shape as the existing
  * DiffViewerPanel / FileBrowserPanel git-status wiring.
  *
- * Branch SWITCHING (checkout) and PR creation are NOT implemented here — no
- * wire message exists for either today (the server's createGitOps only
- * exposes status/branches/stage/unstage/commit), and the mobile app's own
- * Branches tab is read-only too. Both are follow-up work.
+ * In-app PR creation (#6876) IS implemented here: the "Create PR" toolbar
+ * action opens a title/body/base form, confirmation-gates it, and fires the
+ * git_create_pr wire message — the server pushes the current branch and shells
+ * out to `gh pr create`, returning the PR URL (or a clear error) via
+ * git_create_pr_result. Branch SWITCHING (checkout) is still follow-up work (no
+ * wire message exists for it, and the mobile app's Branches tab is read-only).
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useConnectionStore } from '../store/connection'
@@ -26,6 +28,7 @@ import type {
   GitBranchesResult,
   GitStageResult,
   GitCommitResult,
+  GitCreatePrResult,
 } from '../store/types'
 
 type TabId = 'changes' | 'branches'
@@ -92,6 +95,8 @@ export function GitPanel() {
   const requestGitUnstage = useConnectionStore(s => s.requestGitUnstage)
   const setGitCommitCallback = useConnectionStore(s => s.setGitCommitCallback)
   const requestGitCommit = useConnectionStore(s => s.requestGitCommit)
+  const setGitCreatePrCallback = useConnectionStore(s => s.setGitCreatePrCallback)
+  const requestGitCreatePr = useConnectionStore(s => s.requestGitCreatePr)
   const connectionPhase = useConnectionStore(s => s.connectionPhase)
 
   const [activeTab, setActiveTab] = useState<TabId>('changes')
@@ -111,6 +116,16 @@ export function GitPanel() {
   // for parity with the mobile app's GitView.handleCommit (which shows an
   // Alert "Commit N staged file(s)?" before committing).
   const [commitConfirmOpen, setCommitConfirmOpen] = useState(false)
+  // #6876 — in-app PR creation form + confirmation + result state.
+  const [prFormOpen, setPrFormOpen] = useState(false)
+  const [prTitle, setPrTitle] = useState('')
+  const [prBody, setPrBody] = useState('')
+  const [prBase, setPrBase] = useState('')
+  const [prDraft, setPrDraft] = useState(false)
+  const [prSubmitting, setPrSubmitting] = useState(false)
+  const [prError, setPrError] = useState<string | null>(null)
+  const [prCreatedUrl, setPrCreatedUrl] = useState<string | null>(null)
+  const [prConfirmOpen, setPrConfirmOpen] = useState(false)
 
   // The single, DURABLE git_status_result handler. Stable identity (empty deps)
   // so the mount effect installs it exactly once, and — critically — so the
@@ -273,6 +288,62 @@ export function GitPanel() {
     }
   }, [commitMessage, staged.length, setGitCommitCallback, requestGitCommit, requestGitStatus])
 
+  // #6876 — open the Create-PR form. Prefill the title with the current branch
+  // name (a sensible default the operator can edit) and clear any prior result.
+  const openPrForm = useCallback(() => {
+    setPrError(null)
+    setPrCreatedUrl(null)
+    setPrTitle(prev => prev || branch || '')
+    setPrFormOpen(true)
+  }, [branch])
+
+  const closePrForm = useCallback(() => {
+    setPrFormOpen(false)
+    setPrConfirmOpen(false)
+  }, [])
+
+  // Create-PR submit: empty-title guard, then open the confirmation dialog
+  // (AC: the action must be confirmation-gated).
+  const handleCreatePrClick = useCallback(() => {
+    if (!prTitle.trim() || prSubmitting) return
+    setPrConfirmOpen(true)
+  }, [prTitle, prSubmitting])
+
+  // Confirmed PR creation: arms the one-shot git_create_pr_result callback,
+  // fires git_create_pr, and on success shows the PR URL. Mirrors the commit
+  // flow's not-connected guard (requestGitCreatePr returns false on a closed
+  // socket).
+  const handleCreatePrConfirmed = useCallback(() => {
+    setPrConfirmOpen(false)
+    const title = prTitle.trim()
+    if (!title) return
+    setPrError(null)
+    setPrCreatedUrl(null)
+    setPrSubmitting(true)
+    setGitCreatePrCallback((result: GitCreatePrResult) => {
+      setGitCreatePrCallback(null)
+      setPrSubmitting(false)
+      if (result.error || !result.url) {
+        setPrError(result.error || 'PR creation failed')
+        return
+      }
+      setPrCreatedUrl(result.url)
+      // Refresh branches so the just-pushed branch's remote tracking shows.
+      requestGitBranches()
+    })
+    const sent = requestGitCreatePr({
+      title,
+      body: prBody.trim() || undefined,
+      base: prBase.trim() || undefined,
+      draft: prDraft || undefined,
+    })
+    if (!sent) {
+      setGitCreatePrCallback(null)
+      setPrSubmitting(false)
+      setPrError('PR not sent — reconnect and try again')
+    }
+  }, [prTitle, prBody, prBase, prDraft, setGitCreatePrCallback, requestGitCreatePr, requestGitBranches])
+
   const hasChanges = staged.length > 0 || unstaged.length > 0 || untracked.length > 0
   const localBranches = useMemo(() => branches.filter(b => !b.isRemote), [branches])
   const remoteBranches = useMemo(() => branches.filter(b => b.isRemote), [branches])
@@ -300,11 +371,107 @@ export function GitPanel() {
           {branch && (
             <span className="git-branch-badge" title={`Branch: ${branch}`}>{branch}</span>
           )}
+          {branch && (
+            <button
+              type="button"
+              className="git-refresh-btn git-create-pr-btn"
+              onClick={() => (prFormOpen ? closePrForm() : openPrForm())}
+              title="Open a pull request for the current branch"
+              data-testid="git-create-pr-open-btn"
+            >
+              Create PR
+            </button>
+          )}
           <button type="button" className="git-refresh-btn" onClick={refreshStatus} title="Refresh git status">
             Refresh
           </button>
         </div>
       </div>
+
+      {/* #6876 — in-app PR creation form. Independent of the Changes/Branches
+          tab (it acts on the whole branch). Confirmation-gated via ConfirmDialog. */}
+      {prFormOpen && (
+        <div className="git-pr-form" data-testid="git-pr-form">
+          <div className="git-pr-form-header">
+            <span className="git-pr-form-title">Open pull request</span>
+            <span className="git-pr-form-branchline" data-testid="git-pr-headline">
+              {branch}{prBase.trim() ? ` → ${prBase.trim()}` : ''}
+            </span>
+          </div>
+          {prCreatedUrl ? (
+            <div className="git-pr-success" data-testid="git-pr-success">
+              <span>Pull request opened:</span>
+              <a href={prCreatedUrl} target="_blank" rel="noreferrer" data-testid="git-pr-url">{prCreatedUrl}</a>
+              <button type="button" className="git-section-action" onClick={closePrForm} data-testid="git-pr-done-btn">
+                Done
+              </button>
+            </div>
+          ) : (
+            <>
+              {prError && <div className="git-action-error" data-testid="git-pr-error">{prError}</div>}
+              <input
+                type="text"
+                className="git-pr-input"
+                placeholder="Pull request title"
+                value={prTitle}
+                onChange={e => setPrTitle(e.target.value)}
+                maxLength={500}
+                disabled={prSubmitting}
+                data-testid="git-pr-title-input"
+              />
+              <textarea
+                className="git-pr-input git-pr-body"
+                placeholder="Description (optional)"
+                value={prBody}
+                onChange={e => setPrBody(e.target.value)}
+                maxLength={50000}
+                disabled={prSubmitting}
+                data-testid="git-pr-body-input"
+              />
+              <input
+                type="text"
+                className="git-pr-input"
+                placeholder="Base branch (optional — defaults to the repo default)"
+                value={prBase}
+                onChange={e => setPrBase(e.target.value)}
+                maxLength={255}
+                disabled={prSubmitting}
+                data-testid="git-pr-base-input"
+              />
+              <label className="git-pr-draft">
+                <input
+                  type="checkbox"
+                  checked={prDraft}
+                  onChange={e => setPrDraft(e.target.checked)}
+                  disabled={prSubmitting}
+                  data-testid="git-pr-draft-checkbox"
+                />
+                Create as draft
+              </label>
+              <div className="git-pr-actions">
+                <button
+                  type="button"
+                  className="git-commit-btn git-pr-submit"
+                  onClick={handleCreatePrClick}
+                  disabled={!prTitle.trim() || prSubmitting}
+                  data-testid="git-pr-submit-btn"
+                >
+                  {prSubmitting ? 'Opening…' : 'Create pull request'}
+                </button>
+                <button
+                  type="button"
+                  className="git-section-action"
+                  onClick={closePrForm}
+                  disabled={prSubmitting}
+                  data-testid="git-pr-cancel-btn"
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
 
       {loading && <div className="git-loading">Loading git status...</div>}
       {!loading && error && <div className="git-error">{error}</div>}
@@ -469,6 +636,22 @@ export function GitPanel() {
         }
         onConfirm={handleCommitConfirmed}
         onCancel={() => setCommitConfirmOpen(false)}
+      />
+
+      {/* #6876 — PR-creation confirmation (AC: the action must be
+          confirmation-gated). Pushes the branch + opens the PR on confirm. */}
+      <ConfirmDialog
+        open={prConfirmOpen}
+        title="Open a pull request?"
+        confirmLabel="Create PR"
+        message={
+          <>
+            Push <b>{branch}</b> and open a pull request
+            {prBase.trim() ? <> into <b>{prBase.trim()}</b></> : <> into the default branch</>}?
+          </>
+        }
+        onConfirm={handleCreatePrConfirmed}
+        onCancel={() => setPrConfirmOpen(false)}
       />
     </div>
   )

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -732,6 +732,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   _gitBranchesCallback: null,
   _gitStageCallback: null,
   _gitCommitCallback: null,
+  _gitCreatePrCallback: null,
   _diffCallback: null,
   conversationHistory: [],
   conversationHistoryLoading: false,
@@ -4109,6 +4110,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       return wsSend(socket, { type: 'git_commit', message });
+    }
+    return false;
+  },
+
+  // #6876 — in-app PR creation. The server pushes the current branch (if needed)
+  // and shells out to `gh pr create`, replying with git_create_pr_result. Same
+  // not-connected guard as stage/commit so GitPanel can surface an error instead
+  // of leaving a spinner stuck.
+  setGitCreatePrCallback: (cb) => {
+    set({ _gitCreatePrCallback: cb });
+  },
+
+  requestGitCreatePr: (params) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const msg: Record<string, unknown> = { type: 'git_create_pr', title: params.title };
+      if (params.body) msg.body = params.body;
+      if (params.base) msg.base = params.base;
+      if (params.draft) msg.draft = params.draft;
+      return wsSend(socket, msg);
     }
     return false;
   },

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -4305,6 +4305,67 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  describe('git_create_pr_result dispatch (#6934)', () => {
+    it('invokes the armed callback with the parsed fields on a valid payload', () => {
+      const calls: Array<any> = []
+      store = createMockStore(baseState({
+        _gitCreatePrCallback: (r: any) => calls.push(r),
+      } as any))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'git_create_pr_result',
+          url: 'https://github.com/o/r/pull/5',
+          number: 5,
+          branch: 'feat/x',
+          base: 'main',
+          error: null,
+        } as any,
+        ctx() as any,
+      )
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual({
+        url: 'https://github.com/o/r/pull/5',
+        number: 5,
+        branch: 'feat/x',
+        base: 'main',
+        error: null,
+      })
+    })
+
+    it('still resolves the callback with an error on an INVALID payload (unsticks GitPanel submitting state)', () => {
+      // Pre-fix a schema-invalid payload `break`d without invoking the callback,
+      // leaving GitPanel's `prSubmitting` stuck true — the Create-PR button
+      // spins forever, unrecoverable without a remount. The handler must still
+      // resolve the callback (with an error) so the panel clears its state.
+      const calls: Array<any> = []
+      store = createMockStore(baseState({
+        _gitCreatePrCallback: (r: any) => calls.push(r),
+      } as any))
+      setStore(store)
+
+      handleMessage(
+        // `number` as a string fails ServerGitCreatePrResultSchema.
+        {
+          type: 'git_create_pr_result',
+          url: null,
+          number: 'not-a-number',
+          branch: null,
+          base: null,
+          error: null,
+        } as any,
+        ctx() as any,
+      )
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].url).toBeNull()
+      expect(calls[0].number).toBeNull()
+      expect(calls[0].error).toBeTruthy()
+    })
+  })
+
   describe('result — cost calculation for Codex/Gemini (cost: null from server)', () => {
     // #4206: the client-side cost fallback is now gated on the session's
     // provider matching CLIENT_ESTIMATED_COST_PROVIDERS. Tests must

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -149,7 +149,7 @@ import {
   formatMemoryAppendNotice,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema, ServerGitCreatePrResultSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -5112,6 +5112,32 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         gitCommitCb({
           hash: payload.hash,
           message: payload.message,
+          error: payload.error,
+        });
+      }
+      break;
+    }
+
+    // #6876 — in-app PR creation result. Dashboard-only (no store-core shared
+    // dispatch): validate the wire payload via the protocol schema so a
+    // malformed server can't poison the panel, then hand the parsed fields to
+    // the GitPanel-armed callback. Same callback-then-invoke shape as
+    // git_commit_result above.
+    case 'git_create_pr_result': {
+      const gitCreatePrCb = get()._gitCreatePrCallback;
+      if (gitCreatePrCb) {
+        const parsed = ServerGitCreatePrResultSchema.safeParse(msg);
+        if (!parsed.success) {
+          // eslint-disable-next-line no-console
+          console.warn('git_create_pr_result: invalid payload from server', parsed.error.issues);
+          break;
+        }
+        const payload = parsed.data;
+        gitCreatePrCb({
+          url: payload.url,
+          number: payload.number,
+          branch: payload.branch,
+          base: payload.base,
           error: payload.error,
         });
       }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5130,6 +5130,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         if (!parsed.success) {
           // eslint-disable-next-line no-console
           console.warn('git_create_pr_result: invalid payload from server', parsed.error.issues);
+          // Still resolve the armed callback (with an error) rather than a bare
+          // `break`: GitPanel clears `prSubmitting` only from the callback, so
+          // swallowing an invalid payload would leave the Create-PR button stuck
+          // spinning, unrecoverable without a remount. (#6934)
+          gitCreatePrCb({
+            url: null,
+            number: null,
+            branch: null,
+            base: null,
+            error: 'Received a malformed PR-creation response from the server',
+          });
           break;
         }
         const payload = parsed.data;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -305,6 +305,18 @@ export interface GitCommitResult {
   error: string | null;
 }
 
+// #6876 — in-app PR creation result. `url` is the created PR's URL (null on any
+// failure), `number` its integer id (best-effort), `branch`/`base` echo the
+// head/base used, and `error` carries a clear message on failure. Dashboard-only
+// for v1 (mobile PR-creation UI is a tracked follow-up).
+export interface GitCreatePrResult {
+  url: string | null;
+  number: number | null;
+  branch: string | null;
+  base: string | null;
+  error: string | null;
+}
+
 // `DiffHunkLine`, `DiffHunk`, and `DiffFile` are now re-exported from
 // `@chroxy/store-core` above (#3132).
 
@@ -1439,6 +1451,8 @@ export interface ConnectionState {
   // git_unstage_result carry the same payload shape).
   _gitStageCallback: ((result: GitStageResult) => void) | null;
   _gitCommitCallback: ((result: GitCommitResult) => void) | null;
+  // #6876 — in-app PR creation callback (git_create_pr_result). Dashboard-only.
+  _gitCreatePrCallback: ((result: GitCreatePrResult) => void) | null;
 
   // Diff viewer callback
   _diffCallback: ((result: DiffResult) => void) | null;
@@ -1696,6 +1710,10 @@ export interface ConnectionState {
   requestGitUnstage: (paths: string[]) => boolean;
   setGitCommitCallback: (cb: ((result: GitCommitResult) => void) | null) => void;
   requestGitCommit: (message: string) => boolean;
+  // #6876 — in-app PR creation. `requestGitCreatePr` returns false when the
+  // socket is closed (same not-connected guard as stage/commit/unstage).
+  setGitCreatePrCallback: (cb: ((result: GitCreatePrResult) => void) | null) => void;
+  requestGitCreatePr: (params: { title: string; body?: string; base?: string; draft?: boolean }) => boolean;
 
   // Diff viewer
   setDiffCallback: (cb: ((result: DiffResult) => void) | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9588,6 +9588,96 @@ button.sidebar-token-view-session-row:hover {
 
 .git-commit-btn:disabled { opacity: 0.5; cursor: default; }
 
+/* #6876 — in-app PR creation form. */
+.git-create-pr-btn {
+  background: var(--accent-blue);
+  color: var(--text-on-accent, #fff);
+  border-color: var(--accent-blue);
+}
+
+.git-pr-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+}
+
+.git-pr-form-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.git-pr-form-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.git-pr-form-branchline {
+  font-size: 12px;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-secondary);
+}
+
+.git-pr-input {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.4;
+  box-sizing: border-box;
+}
+
+.git-pr-input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+}
+
+.git-pr-body {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.git-pr-draft {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.git-pr-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.git-pr-submit {
+  background: var(--accent-blue);
+}
+
+.git-pr-success {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.git-pr-success a {
+  color: var(--accent-blue);
+  word-break: break-all;
+}
+
 .git-branch-row {
   display: flex;
   align-items: center;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -569,6 +569,13 @@ export declare const GitCommitSchema: z.ZodObject<{
     type: z.ZodLiteral<"git_commit">;
     message: z.ZodString;
 }, z.core.$loose>;
+export declare const GitCreatePrSchema: z.ZodObject<{
+    type: z.ZodLiteral<"git_create_pr">;
+    title: z.ZodString;
+    body: z.ZodOptional<z.ZodString>;
+    base: z.ZodOptional<z.ZodString>;
+    draft: z.ZodOptional<z.ZodBoolean>;
+}, z.core.$loose>;
 export declare const ResumeBudgetSchema: z.ZodObject<{
     type: z.ZodLiteral<"resume_budget">;
     sessionId: z.ZodOptional<z.ZodString>;
@@ -1224,6 +1231,12 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"git_commit">;
     message: z.ZodString;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"git_create_pr">;
+    title: z.ZodString;
+    body: z.ZodOptional<z.ZodString>;
+    base: z.ZodOptional<z.ZodString>;
+    draft: z.ZodOptional<z.ZodBoolean>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"resume_budget">;
     sessionId: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -791,6 +791,19 @@ export const GitCommitSchema = z.object({
     type: z.literal('git_commit'),
     message: z.string().min(1).max(10_000),
 }).passthrough();
+// #6876 — in-app PR creation. The server pushes the current branch (if needed)
+// and shells out to `gh pr create`, replying with `git_create_pr_result`
+// (ServerGitCreatePrResultSchema). `title` is required; `body`/`base`/`draft`
+// are optional (an absent `base` lets the server resolve the repo's default
+// branch). Gated server-side by the same pairing-bound mutation guard the
+// stage/commit path uses (#6541).
+export const GitCreatePrSchema = z.object({
+    type: z.literal('git_create_pr'),
+    title: z.string().min(1).max(500),
+    body: z.string().max(50_000).optional(),
+    base: z.string().max(255).optional(),
+    draft: z.boolean().optional(),
+}).passthrough();
 export const ResumeBudgetSchema = z.object({
     type: z.literal('resume_budget'),
     sessionId: z.string().max(256).optional(),
@@ -1492,6 +1505,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     GitStageSchema,
     GitUnstageSchema,
     GitCommitSchema,
+    GitCreatePrSchema,
     ResumeBudgetSchema,
     ListCheckpointsSchema,
     RestoreCheckpointSchema,

--- a/packages/protocol/dist/schemas/server/file-ops.d.ts
+++ b/packages/protocol/dist/schemas/server/file-ops.d.ts
@@ -94,6 +94,14 @@ export declare const ServerDirectoryListingSchema: z.ZodObject<{
     }, z.core.$strip>>;
     error: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
+export declare const ServerGitCreatePrResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"git_create_pr_result">;
+    url: z.ZodNullable<z.ZodString>;
+    number: z.ZodNullable<z.ZodNumber>;
+    branch: z.ZodNullable<z.ZodString>;
+    base: z.ZodNullable<z.ZodString>;
+    error: z.ZodNullable<z.ZodString>;
+}, z.core.$strip>;
 export declare const ServerWriteFileResultSchema: z.ZodObject<{
     type: z.ZodLiteral<"write_file_result">;
     path: z.ZodNullable<z.ZodString>;

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -94,10 +94,14 @@ export const ServerDirectoryListingSchema = z.object({
 // #6876 — `git_create_pr` response. The server pushes the current branch and
 // runs `gh pr create`; on success `url` is the created PR's URL and `number`
 // its integer number (best-effort — parsed from the URL). `branch`/`base` echo
-// the head/base used. On every failure path all data fields are null and
-// `error` carries a clear, operator-actionable message (gh not installed / not
-// authenticated / no origin remote / PR already exists / detached HEAD). Handled
-// by the dashboard only for v1 (mobile PR-creation UI is a tracked follow-up).
+// the head/base used. On failure `url`/`number` are always null and `error`
+// carries a clear, operator-actionable message (gh not installed / not
+// authenticated / no origin remote / PR already exists / detached HEAD). The
+// identifying fields `branch`/`base` MAY still be populated on some error paths
+// (e.g. base === head, or a push failure) to help the UI show which branch it
+// tried — so only `url`/`number` are guaranteed null on failure, not every data
+// field. Handled by the dashboard only for v1 (mobile PR-creation UI is a
+// tracked follow-up).
 export const ServerGitCreatePrResultSchema = z.object({
     type: z.literal('git_create_pr_result'),
     url: z.string().nullable(),

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -91,6 +91,21 @@ export const ServerDirectoryListingSchema = z.object({
     })),
     error: z.string().nullable(),
 });
+// #6876 — `git_create_pr` response. The server pushes the current branch and
+// runs `gh pr create`; on success `url` is the created PR's URL and `number`
+// its integer number (best-effort — parsed from the URL). `branch`/`base` echo
+// the head/base used. On every failure path all data fields are null and
+// `error` carries a clear, operator-actionable message (gh not installed / not
+// authenticated / no origin remote / PR already exists / detached HEAD). Handled
+// by the dashboard only for v1 (mobile PR-creation UI is a tracked follow-up).
+export const ServerGitCreatePrResultSchema = z.object({
+    type: z.literal('git_create_pr_result'),
+    url: z.string().nullable(),
+    number: z.number().nullable(),
+    branch: z.string().nullable(),
+    base: z.string().nullable(),
+    error: z.string().nullable(),
+});
 // `write_file` response — the wire type is `write_file_result` (NOT
 // file_write_result). Only path + error beyond type. App-only today (the
 // dashboard has no write_file handling).

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -886,6 +886,20 @@ export const GitCommitSchema = z.object({
   message: z.string().min(1).max(10_000),
 }).passthrough()
 
+// #6876 — in-app PR creation. The server pushes the current branch (if needed)
+// and shells out to `gh pr create`, replying with `git_create_pr_result`
+// (ServerGitCreatePrResultSchema). `title` is required; `body`/`base`/`draft`
+// are optional (an absent `base` lets the server resolve the repo's default
+// branch). Gated server-side by the same pairing-bound mutation guard the
+// stage/commit path uses (#6541).
+export const GitCreatePrSchema = z.object({
+  type: z.literal('git_create_pr'),
+  title: z.string().min(1).max(500),
+  body: z.string().max(50_000).optional(),
+  base: z.string().max(255).optional(),
+  draft: z.boolean().optional(),
+}).passthrough()
+
 export const ResumeBudgetSchema = z.object({
   type: z.literal('resume_budget'),
   sessionId: z.string().max(256).optional(),
@@ -1667,6 +1681,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   GitStageSchema,
   GitUnstageSchema,
   GitCommitSchema,
+  GitCreatePrSchema,
   ResumeBudgetSchema,
   ListCheckpointsSchema,
   RestoreCheckpointSchema,

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -101,10 +101,14 @@ export const ServerDirectoryListingSchema = z.object({
 // #6876 — `git_create_pr` response. The server pushes the current branch and
 // runs `gh pr create`; on success `url` is the created PR's URL and `number`
 // its integer number (best-effort — parsed from the URL). `branch`/`base` echo
-// the head/base used. On every failure path all data fields are null and
-// `error` carries a clear, operator-actionable message (gh not installed / not
-// authenticated / no origin remote / PR already exists / detached HEAD). Handled
-// by the dashboard only for v1 (mobile PR-creation UI is a tracked follow-up).
+// the head/base used. On failure `url`/`number` are always null and `error`
+// carries a clear, operator-actionable message (gh not installed / not
+// authenticated / no origin remote / PR already exists / detached HEAD). The
+// identifying fields `branch`/`base` MAY still be populated on some error paths
+// (e.g. base === head, or a push failure) to help the UI show which branch it
+// tried — so only `url`/`number` are guaranteed null on failure, not every data
+// field. Handled by the dashboard only for v1 (mobile PR-creation UI is a
+// tracked follow-up).
 export const ServerGitCreatePrResultSchema = z.object({
   type: z.literal('git_create_pr_result'),
   url: z.string().nullable(),

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -98,6 +98,22 @@ export const ServerDirectoryListingSchema = z.object({
   error: z.string().nullable(),
 })
 
+// #6876 — `git_create_pr` response. The server pushes the current branch and
+// runs `gh pr create`; on success `url` is the created PR's URL and `number`
+// its integer number (best-effort — parsed from the URL). `branch`/`base` echo
+// the head/base used. On every failure path all data fields are null and
+// `error` carries a clear, operator-actionable message (gh not installed / not
+// authenticated / no origin remote / PR already exists / detached HEAD). Handled
+// by the dashboard only for v1 (mobile PR-creation UI is a tracked follow-up).
+export const ServerGitCreatePrResultSchema = z.object({
+  type: z.literal('git_create_pr_result'),
+  url: z.string().nullable(),
+  number: z.number().nullable(),
+  branch: z.string().nullable(),
+  base: z.string().nullable(),
+  error: z.string().nullable(),
+})
+
 // `write_file` response — the wire type is `write_file_result` (NOT
 // file_write_result). Only path + error beyond type. App-only today (the
 // dashboard has no write_file handling).

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -113,6 +113,7 @@ const PLATFORM_SPECIFIC = {
   // `case 'git_*_result':` clauses).
 
   // Dashboard only
+  'git_create_pr_result': 'dashboard', // #6876 in-app PR creation reply — GitPanel "Create PR" flow is dashboard-only for v1 (the mobile app's git surface has no PR-creation UI yet); mobile parity is a tracked follow-up
   'pairing_refreshed': 'dashboard',  // QR display and auto-refresh is dashboard-only (#2916)
   'pair_pending': 'dashboard',       // #5510 pairing-approval primitive — host-level approval banner fan-out is dashboard-only for v1 (the mobile app has no approve surface yet); mobile/desktop-tray approve is an explicit out-of-scope fast-follow per epic #5509
   'pair_resolved': 'dashboard',      // #5510 pairing-approval primitive — banner retraction pairs with pair_pending; dashboard-only for v1, mobile parity deferred per epic #5509

--- a/packages/server/src/handlers/file-handlers.js
+++ b/packages/server/src/handlers/file-handlers.js
@@ -3,7 +3,7 @@
  *
  * Handles: list_directory, browse_files, list_files, read_file, write_file,
  *          get_diff, git_status, git_branches, git_stage, git_unstage,
- *          git_commit, list_slash_commands, list_agents
+ *          git_commit, git_create_pr, list_slash_commands, list_agents
  */
 import { resolveSession, sendError } from '../handler-utils.js'
 import { loggerForSession } from '../logger.js'
@@ -120,6 +120,19 @@ function handleGitCommit(ws, client, msg, ctx) {
   ctx.services.fileOps.gitCommit(ws, msg.message, entry?.cwd || null)
 }
 
+function handleGitCreatePr(ws, client, msg, ctx) {
+  // #6876 — same pairing-bound mutation gate as stage/commit: opening a PR
+  // pushes a branch + creates a remote PR, a host-level side effect a bound
+  // (share-a-session) token must not reach.
+  if (rejectMutationIfBound(ws, client, msg, ctx, 'git_create_pr')) return
+  const entry = resolveSession(ctx, msg, client)
+  ctx.services.fileOps.gitCreatePR(
+    ws,
+    { title: msg.title, body: msg.body, base: msg.base, draft: msg.draft },
+    entry?.cwd || null,
+  )
+}
+
 function handleListSlashCommands(ws, client, msg, ctx) {
   const sid = msg.sessionId || client.activeSessionId
   const entry = resolveSession(ctx, msg, client)
@@ -157,6 +170,7 @@ export const fileHandlers = {
   git_stage: handleGitStage,
   git_unstage: handleGitUnstage,
   git_commit: handleGitCommit,
+  git_create_pr: handleGitCreatePr,
   list_slash_commands: handleListSlashCommands,
   list_agents: handleListAgents,
 }

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -1,6 +1,9 @@
-import { normalize, resolve } from 'path'
+import { normalize, resolve, join } from 'path'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
+import { writeFile, unlink } from 'fs/promises'
+import { tmpdir } from 'os'
+import { randomBytes } from 'crypto'
 import { GIT } from '../git.js'
 import { validateGitPath } from './common.js'
 
@@ -435,21 +438,40 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
         return
       }
 
-      // 4. gh pr create.
-      const args = ['pr', 'create', '--title', title, '--body', body, '--head', branch]
-      if (base) args.push('--base', base)
-      if (draft) args.push('--draft')
-
+      // 4. gh pr create. Pass the body via a temp `--body-file` rather than an
+      // inline `--body <text>` argv element: the client schema permits a body up
+      // to 50k chars, which can blow past Windows' command-line length limit when
+      // inlined. A body-file sidesteps the limit entirely and keeps the body out
+      // of argv. The empty-body case writes an empty file (gh reads it as an
+      // empty body without opening an editor). (#6934)
+      const bodyFile = join(tmpdir(), `chroxy-pr-body-${randomBytes(8).toString('hex')}.md`)
       let stdout = ''
+      let stderr = ''
       try {
-        const res = await execImpl('gh', args, { cwd: cwdReal, timeout: 120000 })
-        stdout = res?.stdout || ''
-      } catch (err) {
-        sendFn(ws, prResult({ branch, base: base || null, error: mapGhCreateError(err) }))
-        return
+        await writeFile(bodyFile, body, 'utf8')
+
+        const args = ['pr', 'create', '--title', title, '--body-file', bodyFile, '--head', branch]
+        if (base) args.push('--base', base)
+        if (draft) args.push('--draft')
+
+        try {
+          const res = await execImpl('gh', args, { cwd: cwdReal, timeout: 120000 })
+          stdout = res?.stdout || ''
+          stderr = res?.stderr || ''
+        } catch (err) {
+          sendFn(ws, prResult({ branch, base: base || null, error: mapGhCreateError(err) }))
+          return
+        }
+      } finally {
+        // Best-effort cleanup — never fail the create because the temp body-file
+        // couldn't be removed.
+        await unlink(bodyFile).catch(() => {})
       }
 
-      const url = extractPrUrl(stdout)
+      // gh prints the created PR URL on stdout, but can emit it on stderr (or
+      // split its output). Parse both streams so a stderr-only URL still yields a
+      // success. (#6934)
+      const url = extractPrUrl(stdout) || extractPrUrl(stderr)
       if (!url) {
         sendFn(ws, prResult({ branch, base: base || null, error: 'PR command succeeded but gh returned no pull-request URL' }))
         return

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -6,16 +6,103 @@ import { validateGitPath } from './common.js'
 
 const execFileAsync = promisify(execFileCb)
 
+// #6876 — result sender for the git_create_pr flow. Every field is always
+// present (present-and-nullable) so the wire payload satisfies
+// ServerGitCreatePrResultSchema on every path.
+function prResult({ url = null, number = null, branch = null, base = null, error = null } = {}) {
+  return { type: 'git_create_pr_result', url, number, branch, base, error }
+}
+
+/** Extract the first `.../pull/<n>` URL from gh output (stdout or stderr). */
+function extractPrUrl(text) {
+  if (!text) return null
+  const m = String(text).match(/https?:\/\/\S*\/pull\/\d+/)
+  return m ? m[0] : null
+}
+
+/** Parse the numeric PR id out of a `.../pull/<n>` URL. */
+function extractPrNumber(url) {
+  if (!url) return null
+  const m = String(url).match(/\/pull\/(\d+)/)
+  return m ? Number(m[1]) : null
+}
+
 /**
- * Git operations: status, branches, stage, unstage, commit.
+ * Resolve the repo's default (base) branch from `origin/HEAD`. Returns '' when
+ * it can't be determined, in which case the caller omits `--base` and lets `gh`
+ * pick the repo default via the API.
+ */
+async function resolveDefaultBase(execImpl, cwdReal) {
+  try {
+    const { stdout } = await execImpl(GIT, ['rev-parse', '--abbrev-ref', 'origin/HEAD'], { cwd: cwdReal, timeout: 5000 })
+    const ref = (stdout || '').trim() // e.g. "origin/main"
+    if (ref && ref !== 'origin/HEAD') {
+      return ref.startsWith('origin/') ? ref.slice('origin/'.length) : ref
+    }
+  } catch {
+    // origin/HEAD not set (fresh clone / no default) — fall through to gh's default.
+  }
+  return ''
+}
+
+/** First non-empty trimmed line of a multi-line error string. */
+function firstLine(text) {
+  return String(text || '')
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)[0] || ''
+}
+
+/** Map a `git push` failure to an operator-actionable message. */
+function mapPushError(err) {
+  if (err && err.code === 'ENOENT') return 'git is not available on the daemon host'
+  const stderr = String((err && (err.stderr || err.message)) || '')
+  const lower = stderr.toLowerCase()
+  if (/does not appear to be a git repository|no configured push destination|no such remote|no remote/.test(lower)) {
+    return 'Cannot push — no `origin` remote is configured for this repository'
+  }
+  if (/permission denied|authentication failed|could not read|access rights|403|denied to|fatal: could not read/.test(lower)) {
+    return 'Cannot push — the daemon is not authorized to push to origin (check its git credentials)'
+  }
+  const line = firstLine(stderr)
+  return line ? `Failed to push branch: ${line}` : 'Failed to push the current branch to origin'
+}
+
+/** Map a `gh pr create` failure to an operator-actionable message. */
+function mapGhCreateError(err) {
+  if (err && err.code === 'ENOENT') {
+    return 'GitHub CLI (gh) is not installed on the daemon host — install it from https://cli.github.com to open PRs from Chroxy'
+  }
+  const stderr = String((err && (err.stderr || err.message)) || '')
+  const lower = stderr.toLowerCase()
+  if (/already exists|a pull request for branch/.test(lower)) {
+    const existing = extractPrUrl(stderr)
+    return existing
+      ? `A pull request already exists for this branch: ${existing}`
+      : 'A pull request already exists for this branch'
+  }
+  if (/gh auth login|not logged in|authentication required|no credentials|requires authentication|http 401|gh auth status/.test(lower)) {
+    return 'GitHub CLI is not authenticated — run `gh auth login` on the daemon host to enable PR creation'
+  }
+  if (/no git remotes found|not a git repository|does not appear to be a git repository|could not determine base repo/.test(lower)) {
+    return 'No GitHub remote is configured for this repository'
+  }
+  const line = firstLine(stderr)
+  return line || (err && err.message) || 'Failed to create pull request'
+}
+
+/**
+ * Git operations: status, branches, stage, unstage, commit, create PR.
  *
  * @param {Function} sendFn - (ws, message) => void
  * @param {Function} resolveSessionCwd - shared CWD resolver
  * @param {Function} validatePathWithinCwd - shared path validator
  * @param {string} workspaceRoot - workspace root directory; git ops are restricted to paths within it
+ * @param {Function} [execImpl] - injectable promisified execFile seam (defaults to the real one; the
+ *   git_create_pr tests inject a mock so no real branch is pushed or PR opened)
  * @returns {Object} git operation methods
  */
-export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, workspaceRoot) {
+export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, workspaceRoot, execImpl = execFileAsync) {
 
   /** Get git status (branch, staged, unstaged, untracked) for a session CWD */
   async function gitStatus(ws, sessionCwd) {
@@ -288,11 +375,97 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
     }
   }
 
+  /**
+   * #6876 — open a PR for the session's current branch without leaving Chroxy.
+   * Pushes the branch (creating/updating its `origin` upstream; a no-op when it
+   * is already current) then shells out to `gh pr create`. Returns the created
+   * PR URL + number to the client, or a clear, operator-actionable error on any
+   * failure (gh missing / not authenticated / no origin remote / PR already
+   * exists / detached HEAD / base === head). Never claims success on failure.
+   *
+   * @param {WebSocket} ws
+   * @param {{ title?: string, body?: string, base?: string, draft?: boolean }} opts
+   * @param {string|null} sessionCwd
+   */
+  async function gitCreatePR(ws, opts, sessionCwd) {
+    const title = typeof opts?.title === 'string' ? opts.title.trim() : ''
+    const body = typeof opts?.body === 'string' ? opts.body : ''
+    const requestedBase = typeof opts?.base === 'string' ? opts.base.trim() : ''
+    const draft = opts?.draft === true
+
+    if (!sessionCwd) {
+      sendFn(ws, prResult({ error: 'PR creation is not available in this mode' }))
+      return
+    }
+    if (!title) {
+      sendFn(ws, prResult({ error: 'Pull request title cannot be empty' }))
+      return
+    }
+
+    try {
+      await validateGitPath(sessionCwd, workspaceRoot)
+      const cwdReal = await resolveSessionCwd(sessionCwd)
+
+      // 1. Current branch (reject detached HEAD / not-a-repo).
+      let branch = null
+      try {
+        const { stdout } = await execImpl(GIT, ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: cwdReal, timeout: 5000 })
+        branch = (stdout || '').trim()
+      } catch {
+        sendFn(ws, prResult({ error: 'Not a git repository' }))
+        return
+      }
+      if (!branch || branch === 'HEAD') {
+        sendFn(ws, prResult({ error: 'Cannot open a PR from a detached HEAD — check out a branch first' }))
+        return
+      }
+
+      // 2. Base branch — explicit, else the repo default (origin/HEAD).
+      const base = requestedBase || (await resolveDefaultBase(execImpl, cwdReal))
+      if (base && base === branch) {
+        sendFn(ws, prResult({ branch, base, error: `The current branch (${branch}) is the base branch — create a feature branch before opening a PR` }))
+        return
+      }
+
+      // 3. Push the branch (set upstream). No-op when already up to date.
+      try {
+        await execImpl(GIT, ['push', '--set-upstream', 'origin', branch], { cwd: cwdReal, timeout: 120000 })
+      } catch (err) {
+        sendFn(ws, prResult({ branch, base: base || null, error: mapPushError(err) }))
+        return
+      }
+
+      // 4. gh pr create.
+      const args = ['pr', 'create', '--title', title, '--body', body, '--head', branch]
+      if (base) args.push('--base', base)
+      if (draft) args.push('--draft')
+
+      let stdout = ''
+      try {
+        const res = await execImpl('gh', args, { cwd: cwdReal, timeout: 120000 })
+        stdout = res?.stdout || ''
+      } catch (err) {
+        sendFn(ws, prResult({ branch, base: base || null, error: mapGhCreateError(err) }))
+        return
+      }
+
+      const url = extractPrUrl(stdout)
+      if (!url) {
+        sendFn(ws, prResult({ branch, base: base || null, error: 'PR command succeeded but gh returned no pull-request URL' }))
+        return
+      }
+      sendFn(ws, prResult({ url, number: extractPrNumber(url), branch, base: base || null, error: null }))
+    } catch (err) {
+      sendFn(ws, prResult({ error: err.message || 'Failed to create pull request' }))
+    }
+  }
+
   return {
     gitStatus,
     gitBranches,
     gitStage,
     gitUnstage,
     gitCommit,
+    gitCreatePR,
   }
 }

--- a/packages/server/src/ws-file-ops/index.js
+++ b/packages/server/src/ws-file-ops/index.js
@@ -49,5 +49,6 @@ export function createFileOps(sendFn, workspaceRoot) {
     gitStage: git.gitStage,
     gitUnstage: git.gitUnstage,
     gitCommit: git.gitCommit,
+    gitCreatePR: git.gitCreatePR,
   }
 }

--- a/packages/server/src/ws-schemas.js
+++ b/packages/server/src/ws-schemas.js
@@ -47,6 +47,7 @@ export {
   GitStageSchema,
   GitUnstageSchema,
   GitCommitSchema,
+  GitCreatePrSchema,
   ResumeBudgetSchema,
   ListCheckpointsSchema,
   RestoreCheckpointSchema,

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -287,6 +287,7 @@ function _isSecureRequest(req) {
  *   { type: 'get_diff', path? }                         — request git diff for working directory
  *   { type: 'git_branches' }                            — request git branch list
  *   { type: 'git_commit', message, files? }             — commit staged/specified files
+ *   { type: 'git_create_pr', title, body?, base?, draft? } — push current branch + open a PR via gh (#6876)
  *   { type: 'git_stage', files }                        — stage files for commit
  *   { type: 'git_status' }                              — request git status
  *   { type: 'git_unstage', files }                      — unstage files
@@ -420,6 +421,7 @@ function _isSecureRequest(req) {
  *   { type: 'file_list', path, files, error? }          — file listing response
  *   { type: 'git_branches_result', branches, current, error? } — git branches result
  *   { type: 'git_commit_result', success, hash?, error? }     — git commit result
+ *   { type: 'git_create_pr_result', url, number, branch, base, error } — in-app PR creation result (#6876; dashboard-only v1)
  *   { type: 'git_stage_result', success, error? }       — git stage result
  *   { type: 'git_status_result', status, error? }       — git status result
  *   { type: 'git_unstage_result', success, error? }     — git unstage result

--- a/packages/server/tests/git-create-pr.test.js
+++ b/packages/server/tests/git-create-pr.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtemp, realpath } from 'fs/promises'
+import { mkdtemp, realpath, readFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createGitOps } from '../src/ws-file-ops/git.js'
@@ -27,7 +27,7 @@ function resolveOrThrow(x) {
 // Build an injectable exec that routes git/gh commands per `spec` and records
 // every call for assertion.
 function router(spec = {}) {
-  const calls = { all: [], push: null, gh: null }
+  const calls = { all: [], push: null, gh: null, ghBodyFile: null, ghBody: null }
   const exec = async (file, args) => {
     calls.all.push({ file, args })
     if (file === GIT && args[0] === 'rev-parse' && args[2] === 'HEAD') {
@@ -42,6 +42,14 @@ function router(spec = {}) {
     }
     if (file === 'gh' && args[0] === 'pr' && args[1] === 'create') {
       calls.gh = args
+      // The body is passed out-of-band via `--body-file`; capture the temp file
+      // path and read its content here (the way gh would, before the caller's
+      // `finally` unlinks it) so tests can assert the body round-tripped.
+      const i = args.indexOf('--body-file')
+      if (i !== -1 && args[i + 1]) {
+        calls.ghBodyFile = args[i + 1]
+        calls.ghBody = await readFile(args[i + 1], 'utf8')
+      }
       return resolveOrThrow(spec.gh ?? { stdout: 'https://github.com/o/r/pull/1\n' })
     }
     return { stdout: '', stderr: '' }
@@ -88,14 +96,23 @@ describe('gitCreatePR (#6876)', () => {
 
     // Branch was pushed with an explicit upstream.
     assert.deepEqual(calls.push, ['push', '--set-upstream', 'origin', 'feat/pr'])
-    // gh received the title/body/head/base.
+    // gh received title/head/base and the body via `--body-file` — never an
+    // inline `--body <text>` (a up-to-50k-char body on the command line is a
+    // Windows cmdline-length hazard, #6934).
+    assert.ok(!calls.gh.includes('--body'), 'gh must not receive an inline --body')
+    const bodyFilePath = calls.ghBodyFile
+    assert.ok(bodyFilePath && bodyFilePath.length > 0, 'gh must receive a --body-file path')
     assert.deepEqual(calls.gh, [
       'pr', 'create',
       '--title', 'feat: add thing',
-      '--body', 'the description',
+      '--body-file', bodyFilePath,
       '--head', 'feat/pr',
       '--base', 'main',
     ])
+    // The body was written to that temp file verbatim…
+    assert.equal(calls.ghBody, 'the description')
+    // …and the temp file is cleaned up after the call.
+    await assert.rejects(() => readFile(bodyFilePath, 'utf8'))
   })
 
   it('honours an explicit base and the draft flag (skips default-base lookup)', async () => {
@@ -110,8 +127,10 @@ describe('gitCreatePR (#6876)', () => {
     // origin/HEAD must NOT have been consulted when base is explicit.
     assert.ok(!calls.all.some(c => c.args[2] === 'origin/HEAD'))
     assert.deepEqual(calls.gh, [
-      'pr', 'create', '--title', 't', '--body', '', '--head', 'feat/pr', '--base', 'develop', '--draft',
+      'pr', 'create', '--title', 't', '--body-file', calls.ghBodyFile, '--head', 'feat/pr', '--base', 'develop', '--draft',
     ])
+    // Empty body → an empty body-file (no inline `--body ''` on the command line).
+    assert.equal(calls.ghBody, '')
   })
 
   it('rejects an empty title without touching git/gh', async () => {
@@ -229,5 +248,37 @@ describe('gitCreatePR (#6876)', () => {
 
     assert.equal(responses[0].url, null)
     assert.match(responses[0].error, /no pull-request URL/i)
+  })
+
+  it('extracts the PR URL from gh stderr when stdout carries none (#6934)', async () => {
+    const { exec } = router({
+      gh: {
+        stdout: '',
+        stderr: 'Warning: 1 uncommitted change\nhttps://github.com/o/r/pull/42\n',
+      },
+    })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.equal(responses[0].error, null)
+    assert.equal(responses[0].url, 'https://github.com/o/r/pull/42')
+    assert.equal(responses[0].number, 42)
+  })
+
+  it('passes a large (50k) body via --body-file, never inline --body (#6934)', async () => {
+    const big = 'x'.repeat(50_000)
+    const { exec, calls } = router()
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't', body: big }, tmpDir)
+
+    assert.equal(responses[0].error, null)
+    assert.ok(!calls.gh.includes('--body'), 'a 50k body must not go inline on argv')
+    assert.ok(calls.gh.includes('--body-file'))
+    // The full body round-tripped through the temp file…
+    assert.equal(calls.ghBody, big)
+    // …and the temp file was cleaned up.
+    await assert.rejects(() => readFile(calls.ghBodyFile, 'utf8'))
   })
 })

--- a/packages/server/tests/git-create-pr.test.js
+++ b/packages/server/tests/git-create-pr.test.js
@@ -1,0 +1,233 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, realpath } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createGitOps } from '../src/ws-file-ops/git.js'
+import { GIT } from '../src/git.js'
+import { rmDirRobustAsync } from './test-helpers.js'
+
+/**
+ * #6876 — in-app PR creation (`git_create_pr`).
+ *
+ * The git/gh exec seam is INJECTED (createGitOps' 5th arg) so no real branch is
+ * pushed and no real PR is opened. A real temp dir is used only to satisfy the
+ * workspace-root path validation (`validateGitPath` realpaths it — the dir need
+ * not be a git repo since every git/gh call is mocked). Each test asserts the
+ * exact command/args issued and that success returns the URL while every failure
+ * surfaces a clear, actionable error (never a false success).
+ */
+
+// Resolve a mock exec route to the { stdout, stderr } execFile shape, or throw.
+function resolveOrThrow(x) {
+  if (x && x.throw) throw x.throw
+  return { stdout: x?.stdout ?? '', stderr: x?.stderr ?? '' }
+}
+
+// Build an injectable exec that routes git/gh commands per `spec` and records
+// every call for assertion.
+function router(spec = {}) {
+  const calls = { all: [], push: null, gh: null }
+  const exec = async (file, args) => {
+    calls.all.push({ file, args })
+    if (file === GIT && args[0] === 'rev-parse' && args[2] === 'HEAD') {
+      return resolveOrThrow(spec.revParseHead ?? { stdout: 'feat/pr\n' })
+    }
+    if (file === GIT && args[0] === 'rev-parse' && args[2] === 'origin/HEAD') {
+      return resolveOrThrow(spec.originHead ?? { stdout: 'origin/main\n' })
+    }
+    if (file === GIT && args[0] === 'push') {
+      calls.push = args
+      return resolveOrThrow(spec.push ?? { stdout: '' })
+    }
+    if (file === 'gh' && args[0] === 'pr' && args[1] === 'create') {
+      calls.gh = args
+      return resolveOrThrow(spec.gh ?? { stdout: 'https://github.com/o/r/pull/1\n' })
+    }
+    return { stdout: '', stderr: '' }
+  }
+  return { exec, calls }
+}
+
+describe('gitCreatePR (#6876)', () => {
+  let tmpDir
+  let cwdReal
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'chroxy-git-pr-'))
+    cwdReal = await realpath(tmpDir)
+  })
+
+  after(async () => {
+    await rmDirRobustAsync(tmpDir)
+  })
+
+  function makeGit(exec) {
+    const responses = []
+    const send = (_ws, m) => responses.push(m)
+    const resolveSessionCwd = async (p) => realpath(p)
+    const validatePathWithinCwd = async () => ({ valid: true })
+    const git = createGitOps(send, resolveSessionCwd, validatePathWithinCwd, tmpDir, exec)
+    return { git, responses }
+  }
+
+  it('pushes the branch and opens a PR against the resolved default base', async () => {
+    const { exec, calls } = router()
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 'feat: add thing', body: 'the description' }, tmpDir)
+
+    assert.equal(responses.length, 1)
+    const res = responses[0]
+    assert.equal(res.type, 'git_create_pr_result')
+    assert.equal(res.error, null)
+    assert.equal(res.url, 'https://github.com/o/r/pull/1')
+    assert.equal(res.number, 1)
+    assert.equal(res.branch, 'feat/pr')
+    assert.equal(res.base, 'main')
+
+    // Branch was pushed with an explicit upstream.
+    assert.deepEqual(calls.push, ['push', '--set-upstream', 'origin', 'feat/pr'])
+    // gh received the title/body/head/base.
+    assert.deepEqual(calls.gh, [
+      'pr', 'create',
+      '--title', 'feat: add thing',
+      '--body', 'the description',
+      '--head', 'feat/pr',
+      '--base', 'main',
+    ])
+  })
+
+  it('honours an explicit base and the draft flag (skips default-base lookup)', async () => {
+    const { exec, calls } = router({ gh: { stdout: 'https://github.com/o/r/pull/9\n' } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't', base: 'develop', draft: true }, tmpDir)
+
+    assert.equal(responses[0].error, null)
+    assert.equal(responses[0].number, 9)
+    assert.equal(responses[0].base, 'develop')
+    // origin/HEAD must NOT have been consulted when base is explicit.
+    assert.ok(!calls.all.some(c => c.args[2] === 'origin/HEAD'))
+    assert.deepEqual(calls.gh, [
+      'pr', 'create', '--title', 't', '--body', '', '--head', 'feat/pr', '--base', 'develop', '--draft',
+    ])
+  })
+
+  it('rejects an empty title without touching git/gh', async () => {
+    const { exec, calls } = router()
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: '   ' }, tmpDir)
+
+    assert.equal(responses[0].type, 'git_create_pr_result')
+    assert.match(responses[0].error, /title/i)
+    assert.equal(responses[0].url, null)
+    assert.equal(calls.all.length, 0)
+  })
+
+  it('returns an error when there is no session CWD', async () => {
+    const { exec, calls } = router()
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, null)
+
+    assert.match(responses[0].error, /not available in this mode/i)
+    assert.equal(calls.all.length, 0)
+  })
+
+  it('rejects a detached HEAD (no push/gh)', async () => {
+    const { exec, calls } = router({ revParseHead: { stdout: 'HEAD\n' } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /detached HEAD/i)
+    assert.equal(calls.push, null)
+    assert.equal(calls.gh, null)
+  })
+
+  it('reports "not a git repository" when the branch lookup fails', async () => {
+    const err = Object.assign(new Error('fatal: not a git repository'), { code: 128 })
+    const { exec } = router({ revParseHead: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /not a git repository/i)
+  })
+
+  it('rejects when the current branch IS the base branch', async () => {
+    const { exec, calls } = router({ revParseHead: { stdout: 'main\n' } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't', base: 'main' }, tmpDir)
+
+    assert.match(responses[0].error, /base branch/i)
+    assert.equal(calls.push, null)
+    assert.equal(calls.gh, null)
+  })
+
+  it('surfaces "gh not installed" on ENOENT', async () => {
+    const err = Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' })
+    const { exec } = router({ gh: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /not installed/i)
+    assert.equal(responses[0].url, null)
+  })
+
+  it('surfaces "not authenticated" when gh reports an auth error', async () => {
+    const err = Object.assign(new Error('exit 1'), {
+      code: 1,
+      stderr: 'To get started with GitHub CLI, please run:  gh auth login',
+    })
+    const { exec } = router({ gh: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /not authenticated/i)
+  })
+
+  it('surfaces the existing PR URL when one already exists', async () => {
+    const err = Object.assign(new Error('exit 1'), {
+      code: 1,
+      stderr: 'a pull request for branch "feat/pr" into branch "main" already exists:\nhttps://github.com/o/r/pull/7',
+    })
+    const { exec } = router({ gh: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /already exists/i)
+    assert.match(responses[0].error, /pull\/7/)
+    assert.equal(responses[0].url, null)
+  })
+
+  it('surfaces a push failure (no origin) without calling gh', async () => {
+    const err = Object.assign(new Error('exit 128'), {
+      code: 128,
+      stderr: "fatal: 'origin' does not appear to be a git repository",
+    })
+    const { exec, calls } = router({ push: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /origin/i)
+    assert.equal(calls.gh, null)
+  })
+
+  it('errors when gh succeeds but returns no PR URL (no false success)', async () => {
+    const { exec } = router({ gh: { stdout: 'Warning: some notice with no url\n' } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.equal(responses[0].url, null)
+    assert.match(responses[0].error, /no pull-request URL/i)
+  })
+})

--- a/packages/server/tests/handlers/file-handlers.test.js
+++ b/packages/server/tests/handlers/file-handlers.test.js
@@ -17,6 +17,7 @@ function makeFileOps(overrides = {}) {
     gitStage: createSpy(),
     gitUnstage: createSpy(),
     gitCommit: createSpy(),
+    gitCreatePR: createSpy(),
     listSlashCommands: createSpy(),
     listAgents: createSpy(),
     ...overrides,
@@ -213,6 +214,24 @@ describe('file-handlers', () => {
       assert.equal(callMessage, 'fix: bug')
       assert.equal(callCwd, '/repo')
     })
+
+    it('git_create_pr passes title/body/base/draft and cwd (#6876)', () => {
+      const sessions = new Map()
+      sessions.set('s1', { session: createMockSession(), name: 'S', cwd: '/repo' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      fileHandlers.git_create_pr(
+        makeWs(),
+        client,
+        { title: 'feat: x', body: 'desc', base: 'main', draft: true },
+        ctx,
+      )
+
+      const [, callOpts, callCwd] = ctx.services.fileOps.gitCreatePR.lastCall
+      assert.deepEqual(callOpts, { title: 'feat: x', body: 'desc', base: 'main', draft: true })
+      assert.equal(callCwd, '/repo')
+    })
   })
 
   describe('list_slash_commands / list_agents', () => {
@@ -307,6 +326,7 @@ describe('file-handlers', () => {
       ['git_stage', 'gitStage', { files: ['x.js'] }],
       ['git_unstage', 'gitUnstage', { files: ['x.js'] }],
       ['git_commit', 'gitCommit', { message: 'm' }],
+      ['git_create_pr', 'gitCreatePR', { title: 'feat: x' }],
     ]
 
     for (const [type, method, msg] of MUTATIONS) {

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -148,6 +148,7 @@ function clientCoverage(): { inApp: (t: string) => boolean; inDash: (t: string) 
 // pairing-approval banners, the prompt evaluator, the skills panel, the monthly
 // budget meter); mobile parity is a tracked follow-up under the cited epic.
 const DASHBOARD_ONLY = new Set<string>([
+  'git_create_pr_result',       // #6876 in-app PR creation reply — GitPanel "Create PR" flow is dashboard-only for v1; mobile PR-creation UI is a tracked follow-up
   'shell_pending_approval',     // #6277 host-local user-shell approval — "waiting for host approval" banner; dashboard-only for v1, mobile parity deferred
   // activity_snapshot / activity_delta removed — the mobile app now feeds them
   // too (#6246/#6247, the Phase-2 mobile-parity fast-follow per epic #5159), so


### PR DESCRIPTION
## What

Adds a confirmation-gated **Create PR** action to the dashboard **GitPanel** so the operator can open a pull request for the current branch without leaving Chroxy. The desktop tray app inherits it automatically (it wraps the dashboard). Split off from #6780 (AC2), which #6875 deferred because PR creation needed a brand-new wire message + `gh` integration that stage/commit did not.

## Flow

1. **Create PR** toolbar button (shown once a branch is known) opens a title / body / base / draft form.
2. Submit is **confirmation-gated** via `ConfirmDialog` ("Push `<branch>` and open a pull request into `<base>`?"), matching the commit gate idiom.
3. The server pushes the current branch (`git push --set-upstream origin <branch>` — a no-op when already current) then shells to `gh pr create`, returning the PR **URL + number**.
4. The dashboard renders the created PR URL as a link (or the error).

## Server (`ws-file-ops/git.js` → `gitCreatePR`)

- New `git_create_pr` client message + handler, gated by the **same pairing-bound mutation guard (#6541)** as stage/commit — a bound (share-a-session) token cannot open a PR.
- Up-front rejects: **no cwd**, **empty title**, **detached HEAD**, **base === head**.
- `git`/`gh` failures map to **clear, operator-actionable errors** and never claim success on failure:
  - `gh` not installed (`ENOENT`) → "install it from cli.github.com"
  - `gh` not authenticated → "run `gh auth login` on the daemon host"
  - no `origin` remote / not authorized to push
  - **PR already exists** → surfaces the existing PR URL
- The exec seam is **injectable**, so the unit tests assert the exact command/args and every failure branch **without pushing a real branch or opening a real PR**.

## Auth handling

Mirrors the read-side (`control-room/survey.js`, which already shells to `gh`): the server relies on the daemon host's `gh` being installed + authenticated. If it isn't, the failure is surfaced to the client with the exact remediation step rather than a silent/opaque error.

## Protocol

- `GitCreatePrSchema` (client) + `ServerGitCreatePrResultSchema` (server), wired into the barrels; dist rebuilt.
- Registered in the ws-server `Server -> Client` doc roster and **both coverage guards** (`handler-coverage` `PLATFORM_SPECIFIC` + `protocol-type-coverage-lint` `DASHBOARD_ONLY`) as **dashboard-only for v1**.

## Scope / follow-up

Dashboard + server, per the issue. **Mobile-app PR-creation UI is out of scope** for v1 (not in the issue's AC) and is filed as a follow-up. Branch **switch** (checkout) remains with the parent #6780.

## Tests

- Server: 12 unit tests for `gitCreatePR` (command/args on success + every failure case) + the bound-token gate for `git_create_pr`.
- Dashboard: 8 GitPanel form/interaction tests (open, confirmation-gate, args, success URL, error, not-connected, cancel).
- Green: full dashboard suite (4683), full protocol (375), full store-core (2031), targeted server git/schema tests (247), all 5 server custom lint scripts, dashboard `tsc`.

Closes #6876