### PR TITLE
feat(chat-redesign): footer-stat thinking — "thought for Xs · N tokens"

### DIFF
--- a/packages/app/src/components/__tests__/MessageBubble.thinking.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.thinking.test.tsx
@@ -80,6 +80,27 @@ describe('MessageBubble thinking content (#6756)', () => {
     expect(toggleLabel(tree)).toContain('Thinking…');
   });
 
+  // #6391 footer-stat — a finished thinking bubble carrying a measured duration
+  // (+ tokens) shows the compact `thought for Xs · N tokens` footer.
+  it('renders the footer-stat "thought for Xs · N tokens" when duration + tokens are present (#6391)', () => {
+    const tree = render(makeThinking({ thinkingStreaming: false, thinkingDurationMs: 4200, thinkingTokens: 128 }));
+    expect(toggleLabel(tree)).toContain('thought for 4.2s · 128 tokens');
+  });
+
+  it('renders duration alone when tokens are absent (claude SDK/BYOK) (#6391)', () => {
+    const tree = render(makeThinking({ thinkingStreaming: false, thinkingDurationMs: 19000 }));
+    const label = toggleLabel(tree);
+    expect(label).toContain('thought for 19s');
+    expect(label).not.toContain('tokens');
+  });
+
+  it('degrades to a bare "Thought" when no footer-stat is present (old sessions) (#6391)', () => {
+    const tree = render(makeThinking({ thinkingStreaming: false }));
+    const label = toggleLabel(tree);
+    expect(label).toContain('Thought');
+    expect(label).not.toContain('thought for');
+  });
+
   it('falls back to the ThinkingIndicator animation when there is no content', () => {
     const tree = render(makeThinking({ content: '' }));
     // No disclosure bubble…

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -8,7 +8,7 @@ import {
   Image,
   LayoutAnimation,
 } from 'react-native';
-import { OTHER_OPTION_VALUE, bumpRenderCount, getErrorPresentation, isRetryableAskUserQuestionError, isSingleMultiSelectForm } from '@chroxy/store-core';
+import { OTHER_OPTION_VALUE, bumpRenderCount, formatThinkingFooter, getErrorPresentation, isRetryableAskUserQuestionError, isSingleMultiSelectForm } from '@chroxy/store-core';
 // #4875: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
 // so the mobile store, the mobile screen, and (eventually) the dashboard
 // can converge on a single declaration paired with the shared
@@ -75,15 +75,23 @@ export function buildPromptSessionLabel(
 }
 
 /**
- * #6756 — content-capable thinking view. The mobile parity of the dashboard's
- * `ThinkingBody`: a quiet collapsible disclosure ("▸ Thinking…" while streaming,
- * "▸ Thought" once done) that reveals the model's reasoning text on tap. Used
- * only when a thinking bubble actually carries reasoning content; an empty
- * thinking bubble (the ephemeral placeholder) keeps the `ThinkingIndicator`
- * animation.
+ * #6756 + #6391 footer-stat — content-capable thinking view. The mobile parity
+ * of the dashboard's `ThinkingBody`: a quiet collapsible disclosure ("▸
+ * Thinking…" while streaming, and once done a compact turn-footer stat "▸
+ * thought for 4.2s · 128 tokens") that reveals the model's reasoning text on
+ * tap. The footer degrades gracefully — the server stamps `durationMs` on the
+ * thinking stream_end, but old sessions (and the token count, which the claude
+ * SDK/BYOK providers can't cleanly separate) may be absent; with neither stat
+ * the label falls back to a bare "Thought". Used only when a thinking bubble
+ * actually carries reasoning content; an empty thinking bubble (the ephemeral
+ * placeholder) keeps the `ThinkingIndicator` animation.
  */
-function ThinkingBubble({ content, streaming, truncated }: { content: string; streaming: boolean; truncated?: boolean }) {
+function ThinkingBubble({ content, streaming, truncated, durationMs, tokens }: { content: string; streaming: boolean; truncated?: boolean; durationMs?: number; tokens?: number }) {
   const [expanded, setExpanded] = useState(false);
+  // Compose the footer from whatever stats arrived; empty when none, so we fall
+  // back to a bare "Thought" (old sessions / no measured stats).
+  const footer = formatThinkingFooter({ durationMs, tokens });
+  const label = streaming ? 'Thinking…' : (footer || 'Thought');
   return (
     <View style={styles.thinkingBubble} testID="thinking-bubble">
       <TouchableOpacity
@@ -93,7 +101,7 @@ function ThinkingBubble({ content, streaming, truncated }: { content: string; st
         }}
         testID="thinking-toggle"
         accessibilityRole="button"
-        accessibilityLabel={streaming ? 'Thinking' : 'Thought'}
+        accessibilityLabel={streaming ? 'Thinking' : (footer || 'Thought')}
         // Small horizontal hitSlop for comfort past the text's visual bounds;
         // the ≥44pt minimum on both axes is carried by the style's
         // minHeight/minWidth (see thinkingToggleTouchable).
@@ -101,7 +109,7 @@ function ThinkingBubble({ content, streaming, truncated }: { content: string; st
         style={styles.thinkingToggleTouchable}
       >
         <Text style={styles.thinkingToggle}>
-          {expanded ? '▾' : '▸'} {streaming ? 'Thinking…' : 'Thought'}
+          {expanded ? '▾' : '▸'} {label}
         </Text>
       </TouchableOpacity>
       {expanded && (
@@ -384,6 +392,8 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onEditQueued, onSe
           content={thinkingContent}
           streaming={message.thinkingStreaming === true}
           truncated={message.thinkingTruncated === true}
+          durationMs={message.thinkingDurationMs}
+          tokens={message.thinkingTokens}
         />
       );
     }

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -184,6 +184,47 @@ describe('ChatView', () => {
     expect(screen.getByTestId('thinking-toggle')).toHaveTextContent('Thought')
   })
 
+  // #6391 footer-stat — a finished thinking bubble carrying a measured duration
+  // (+ token count) renders the compact `thought for Xs · N tokens` footer in
+  // place of the bare "Thought" label.
+  it('renders the footer-stat "thought for Xs · N tokens" when duration + tokens are present (#6391)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 't1', type: 'thinking', content: 'reasoning', thinkingStreaming: false, thinkingDurationMs: 4200, thinkingTokens: 128, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    expect(screen.getByTestId('thinking-toggle')).toHaveTextContent('thought for 4.2s · 128 tokens')
+  })
+
+  it('renders the footer-stat with duration alone when tokens are absent (claude SDK/BYOK) (#6391)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 't1', type: 'thinking', content: 'reasoning', thinkingStreaming: false, thinkingDurationMs: 19000, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    const toggle = screen.getByTestId('thinking-toggle')
+    expect(toggle).toHaveTextContent('thought for 19s')
+    expect(toggle).not.toHaveTextContent('tokens')
+  })
+
+  it('degrades to a bare "Thought" when no footer-stat is present (old sessions) (#6391)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 't1', type: 'thinking', content: 'reasoning', thinkingStreaming: false, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    const toggle = screen.getByTestId('thinking-toggle')
+    expect(toggle).toHaveTextContent('Thought')
+    expect(toggle).not.toHaveTextContent('thought for')
+  })
+
+  it('shows "Thinking…" (not the footer) while streaming even if a stale duration is set (#6391)', () => {
+    const messages: ChatViewMessage[] = [
+      { id: 't1', type: 'thinking', content: 'reasoning', thinkingStreaming: true, thinkingDurationMs: 4200, timestamp: Date.now() },
+    ]
+    render(<ChatView messages={messages} isStreaming={false} />)
+    const toggle = screen.getByTestId('thinking-toggle')
+    expect(toggle).toHaveTextContent('Thinking…')
+    expect(toggle).not.toHaveTextContent('thought for')
+  })
+
   it('surfaces a "[thinking truncated]" marker when the content hit the size cap (#6756)', () => {
     const messages: ChatViewMessage[] = [
       { id: 'msg-1-thinking-0', type: 'thinking', content: 'capped reasoning', thinkingStreaming: false, thinkingTruncated: true, timestamp: Date.now() },

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -17,7 +17,7 @@
  * survives a row scrolling out of and back into the window.
  */
 import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
-import { bumpRenderCount, type ChatActivityState, type MessageAttachment } from '@chroxy/store-core'
+import { bumpRenderCount, formatThinkingFooter, type ChatActivityState, type MessageAttachment } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
 import { renderMarkdown } from '../lib/markdown'
 import { handleMarkdownBodyClick } from '../lib/codeCopy'
@@ -122,6 +122,18 @@ export interface ChatViewMessage {
    * marker so the cut is never silent.
    */
   thinkingTruncated?: boolean
+  /**
+   * #6391 (chat-redesign footer-stat): on a `thinking` row, the reasoning
+   * block's measured elapsed time (ms) — ThinkingBody renders it as
+   * `thought for Xs`. Undefined on old sessions → the label stays "Thought".
+   */
+  thinkingDurationMs?: number
+  /**
+   * #6391 (chat-redesign footer-stat): on a `thinking` row, the reasoning
+   * block's token count — appended as ` · N tokens`. Undefined for providers
+   * that don't separate reasoning tokens (claude SDK/BYOK) → clause omitted.
+   */
+  thinkingTokens?: number
   /**
    * #4476: structured error code mirrored from the store ChatMessage.
    * Renderers may switch on this to surface a distinct variant for known
@@ -312,15 +324,23 @@ function rowClassFor(type: string, hasIcon: boolean): string {
 }
 
 /**
- * Chat redesign #6391 (slice 6): thinking renders as a quiet, collapsed
- * disclosure instead of a standing wall of reasoning text — "▸ Thinking…" while
- * it streams, "▸ Thought" once done; click reveals the full reasoning. (The
- * "thought for Ns" duration/token stat is deferred — it needs a thinking
- * start/end the client doesn't carry yet.) The row's MeasuredRow ResizeObserver
- * re-measures on toggle, so the virtualized list stays correct.
+ * Chat redesign #6391 (slice 6 + footer-stat): thinking renders as a quiet,
+ * collapsed disclosure instead of a standing wall of reasoning text — "▸
+ * Thinking…" while it streams, and once done a compact turn-footer stat
+ * "▸ thought for 4.2s · 128 tokens" (the signature-moment §5 footnote). Click
+ * reveals the full reasoning. The footer degrades gracefully: the server stamps
+ * `durationMs` on the thinking stream_end, but old sessions (and the token
+ * count, which the claude SDK/BYOK providers can't cleanly separate) may be
+ * absent — with neither stat the label falls back to a bare "Thought". The
+ * row's MeasuredRow ResizeObserver re-measures on toggle, so the virtualized
+ * list stays correct.
  */
-function ThinkingBody({ content, streaming, truncated }: { content: string; streaming: boolean; truncated?: boolean }) {
+function ThinkingBody({ content, streaming, truncated, durationMs, tokens }: { content: string; streaming: boolean; truncated?: boolean; durationMs?: number; tokens?: number }) {
   const [expanded, setExpanded] = useState(false)
+  // Compose the footer text from whatever stats arrived; empty when none, so we
+  // fall back to the bare "Thought" label (old sessions / no measured stats).
+  const footer = formatThinkingFooter({ durationMs, tokens })
+  const label = streaming ? 'Thinking…' : (footer || 'Thought')
   return (
     <div className="thinking-body">
       <button
@@ -333,7 +353,7 @@ function ThinkingBody({ content, streaming, truncated }: { content: string; stre
           setExpanded(v => !v)
         }}
       >
-        {expanded ? '▾' : '▸'} {streaming ? 'Thinking…' : 'Thought'}
+        {expanded ? '▾' : '▸'} {label}
       </button>
       {expanded && (
         <div className="thinking-full">
@@ -359,6 +379,8 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   isStreaming,
   thinkingStreaming,
   thinkingTruncated,
+  thinkingDurationMs,
+  thinkingTokens,
   attachments,
   queued,
   onCancelQueued,
@@ -376,6 +398,12 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
   /** #6756: on a `thinking` row, the reasoning content hit the size cap —
    *  ThinkingBody appends a "[thinking truncated]" marker. */
   thinkingTruncated?: boolean
+  /** #6391: on a `thinking` row, the reasoning block's elapsed time (ms) →
+   *  ThinkingBody's `thought for Xs` footer. */
+  thinkingDurationMs?: number
+  /** #6391: on a `thinking` row, the reasoning block's token count →
+   *  appended as ` · N tokens`. */
+  thinkingTokens?: number
   /** #6632: user-message attachments (images/documents) to preview. */
   attachments?: ChatViewMessage['attachments']
   /** #5939: this user_input is held in the server's outgoing queue. */
@@ -409,7 +437,7 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
       // #6793: same container also owns the per-code-block copy button click.
       ? <div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
       : type === 'thinking'
-        ? <ThinkingBody content={content} streaming={!!thinkingStreaming} truncated={thinkingTruncated} />
+        ? <ThinkingBody content={content} streaming={!!thinkingStreaming} truncated={thinkingTruncated} durationMs={thinkingDurationMs} tokens={thinkingTokens} />
         : content
 
   return (
@@ -1026,6 +1054,8 @@ function ChatViewImpl({ messages, isStreaming, isBusy, chatActivityState, inFlig
                   isStreaming={msg.isStreaming}
                   thinkingStreaming={msg.thinkingStreaming}
                   thinkingTruncated={msg.thinkingTruncated}
+                  thinkingDurationMs={msg.thinkingDurationMs}
+                  thinkingTokens={msg.thinkingTokens}
                   attachments={msg.attachments}
                   queued={queuedIds?.has(msg.id) ?? false}
                   queuePosition={queuePositions?.get(msg.id)}

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -24,6 +24,8 @@ export declare const ServerStreamEndSchema: z.ZodObject<{
     messageId: z.ZodString;
     serverTs: z.ZodOptional<z.ZodNumber>;
     thinking: z.ZodOptional<z.ZodBoolean>;
+    thinkingDurationMs: z.ZodOptional<z.ZodNumber>;
+    thinkingTokens: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
 export declare const ServerMessageSchema: z.ZodObject<{
     type: z.ZodLiteral<"message">;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -24,6 +24,31 @@ const ServerTsSchema = z.number().int().nonnegative().finite().optional();
 // the id is distinct from the ephemeral placeholder id `'thinking'`, the
 // client's `filterThinking` still only strips the placeholder.
 const ThinkingFlagSchema = z.boolean().optional();
+// Chat-redesign footer-stat (#6391, part of epic #6389). On a THINKING
+// `stream_end` (one tagged `thinking: true`), the server stamps the reasoning
+// block's measured elapsed wall time — ms from its first streamed token to its
+// close — so the client can render a quiet `thought for 4.2s` turn footer
+// instead of a standing "Thought" block. Bounded by the shared sane-duration
+// ceiling; `.int().nonnegative()` matches the millisecond wire convention.
+// Always optional + additive: absent on response streams, on old servers, and
+// on the synchronous fallback path where no real time elapsed. Clients degrade
+// to a bare "Thought" when it is missing.
+const ThinkingDurationMsSchema = z
+    .number()
+    .int()
+    .nonnegative()
+    .finite()
+    .max(MAX_SANE_DURATION_MS)
+    .optional();
+// Chat-redesign footer-stat (#6391) — the reasoning block's token count, shown
+// as ` · N tokens` after the duration. Optional and NOT populated by the claude
+// SDK/BYOK providers: Anthropic's usage folds thinking tokens into
+// `output_tokens` with no per-block breakdown, so there is nothing clean to
+// report (tracked as a follow-up). The field exists so a future provider that
+// DOES separate reasoning tokens (e.g. an OpenAI-compatible `reasoning_tokens`)
+// can populate it without a wire change; the footer omits the token clause when
+// it is absent rather than fabricating a number.
+const ThinkingTokensSchema = z.number().int().nonnegative().finite().optional();
 export const ServerStreamStartSchema = z.object({
     type: z.literal('stream_start'),
     messageId: z.string(),
@@ -42,6 +67,12 @@ export const ServerStreamEndSchema = z.object({
     messageId: z.string(),
     serverTs: ServerTsSchema,
     thinking: ThinkingFlagSchema,
+    // #6391 footer-stat — the reasoning block's elapsed time + (when a provider
+    // separates it) token count, carried on the THINKING stream_end so the client
+    // renders `thought for Xs · N tokens`. Both optional; see the schema
+    // definitions above for why `thinkingTokens` is absent on claude SDK/BYOK.
+    thinkingDurationMs: ThinkingDurationMsSchema,
+    thinkingTokens: ThinkingTokensSchema,
 });
 export const ServerMessageSchema = z.object({
     type: z.literal('message'),

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -30,6 +30,33 @@ const ServerTsSchema = z.number().int().nonnegative().finite().optional()
 // client's `filterThinking` still only strips the placeholder.
 const ThinkingFlagSchema = z.boolean().optional()
 
+// Chat-redesign footer-stat (#6391, part of epic #6389). On a THINKING
+// `stream_end` (one tagged `thinking: true`), the server stamps the reasoning
+// block's measured elapsed wall time — ms from its first streamed token to its
+// close — so the client can render a quiet `thought for 4.2s` turn footer
+// instead of a standing "Thought" block. Bounded by the shared sane-duration
+// ceiling; `.int().nonnegative()` matches the millisecond wire convention.
+// Always optional + additive: absent on response streams, on old servers, and
+// on the synchronous fallback path where no real time elapsed. Clients degrade
+// to a bare "Thought" when it is missing.
+const ThinkingDurationMsSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .finite()
+  .max(MAX_SANE_DURATION_MS)
+  .optional()
+
+// Chat-redesign footer-stat (#6391) — the reasoning block's token count, shown
+// as ` · N tokens` after the duration. Optional and NOT populated by the claude
+// SDK/BYOK providers: Anthropic's usage folds thinking tokens into
+// `output_tokens` with no per-block breakdown, so there is nothing clean to
+// report (tracked as a follow-up). The field exists so a future provider that
+// DOES separate reasoning tokens (e.g. an OpenAI-compatible `reasoning_tokens`)
+// can populate it without a wire change; the footer omits the token clause when
+// it is absent rather than fabricating a number.
+const ThinkingTokensSchema = z.number().int().nonnegative().finite().optional()
+
 export const ServerStreamStartSchema = z.object({
   type: z.literal('stream_start'),
   messageId: z.string(),
@@ -50,6 +77,12 @@ export const ServerStreamEndSchema = z.object({
   messageId: z.string(),
   serverTs: ServerTsSchema,
   thinking: ThinkingFlagSchema,
+  // #6391 footer-stat — the reasoning block's elapsed time + (when a provider
+  // separates it) token count, carried on the THINKING stream_end so the client
+  // renders `thought for Xs · N tokens`. Both optional; see the schema
+  // definitions above for why `thinkingTokens` is absent on claude SDK/BYOK.
+  thinkingDurationMs: ThinkingDurationMsSchema,
+  thinkingTokens: ThinkingTokensSchema,
 })
 
 export const ServerMessageSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3150,6 +3150,38 @@ describe('@chroxy/protocol schemas', () => {
           serverTs: 'nope',
         }).success)
       })
+
+      it('ServerStreamEndSchema accepts the #6391 footer-stat thinkingDurationMs + thinkingTokens', async () => {
+        const { ServerStreamEndSchema } = await import('../src/schemas/server.ts')
+        // Both stats present (a provider that separates reasoning tokens).
+        assert.ok(ServerStreamEndSchema.safeParse({
+          type: 'stream_end',
+          messageId: 'm1-thinking-0',
+          thinking: true,
+          thinkingDurationMs: 4200,
+          thinkingTokens: 128,
+        }).success)
+        // Duration only (claude SDK/BYOK — no separable token count).
+        assert.ok(ServerStreamEndSchema.safeParse({
+          type: 'stream_end',
+          messageId: 'm1-thinking-0',
+          thinking: true,
+          thinkingDurationMs: 900,
+        }).success)
+        // Additive: a stream_end still validates without either (old server).
+        assert.ok(ServerStreamEndSchema.safeParse({ type: 'stream_end', messageId: 'm1' }).success)
+      })
+
+      it('rejects a negative / fractional / non-numeric thinkingDurationMs', async () => {
+        const { ServerStreamEndSchema } = await import('../src/schemas/server.ts')
+        const base = { type: 'stream_end', messageId: 'm1', thinking: true }
+        assert.ok(!ServerStreamEndSchema.safeParse({ ...base, thinkingDurationMs: -1 }).success)
+        assert.ok(!ServerStreamEndSchema.safeParse({ ...base, thinkingDurationMs: 4200.5 }).success)
+        assert.ok(!ServerStreamEndSchema.safeParse({ ...base, thinkingDurationMs: 'nope' }).success)
+        // Bounded by the shared sane-duration ceiling (24h in ms).
+        assert.ok(!ServerStreamEndSchema.safeParse({ ...base, thinkingDurationMs: 24 * 60 * 60 * 1000 + 1 }).success)
+        assert.ok(!ServerStreamEndSchema.safeParse({ ...base, thinkingTokens: -5 }).success)
+      })
     })
   })
 

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -333,6 +333,12 @@ export class ClaudeByokSession extends BaseSession {
     // correctly. Cleared alongside `_streamingIndexToToolUseId`.
     this._streamingIndexToThinkingId = new Map()
 
+    // #6391 (chat-redesign footer-stat): thinking messageId → Date.now() when
+    // the reasoning block opened, so its content_block_stop can stamp the
+    // elapsed `thinkingDurationMs` on the thinking stream_end. Cleared alongside
+    // `_streamingIndexToThinkingId`.
+    this._thinkingStartMs = new Map()
+
     // #4080: toolUseIds whose permission_request is currently pending.
     // Populated when this session re-emits permission_request (line
     // ~165), drained on permission_resolved (line ~167). Consulted on
@@ -805,6 +811,9 @@ export class ClaudeByokSession extends BaseSession {
               if (!thinkingId) {
                 thinkingId = `${messageId}-thinking-${idx}`
                 this._streamingIndexToThinkingId.set(idx, thinkingId)
+                // #6391 footer-stat: mark the block's start for the
+                // content_block_stop elapsed-time computation.
+                this._thinkingStartMs.set(thinkingId, Date.now())
                 this.emit('stream_start', { messageId: thinkingId, thinking: true })
               }
               this.emit('stream_delta', { messageId: thinkingId, delta: t.text, thinking: true })
@@ -899,7 +908,18 @@ export class ClaudeByokSession extends BaseSession {
                 const thinkingId = this._streamingIndexToThinkingId.get(t.index)
                 if (thinkingId) {
                   this._streamingIndexToThinkingId.delete(t.index)
-                  this.emit('stream_end', { messageId: thinkingId, thinking: true })
+                  // #6391 footer-stat: elapsed wall time from the block's open to
+                  // now → the client's `thought for Xs` footer. Omit when the
+                  // start wasn't tracked so we never send a bogus 0. No token
+                  // count: Anthropic's usage folds thinking tokens into
+                  // output_tokens with no per-block breakdown (see follow-up).
+                  const startMs = this._thinkingStartMs.get(thinkingId)
+                  this._thinkingStartMs.delete(thinkingId)
+                  const streamEndMsg = { messageId: thinkingId, thinking: true }
+                  if (typeof startMs === 'number') {
+                    streamEndMsg.thinkingDurationMs = Math.max(0, Date.now() - startMs)
+                  }
+                  this.emit('stream_end', streamEndMsg)
                 }
               }
               break
@@ -928,6 +948,7 @@ export class ClaudeByokSession extends BaseSession {
         // starts with an empty per-stream map.
         this._streamingIndexToToolUseId.clear()
         this._streamingIndexToThinkingId.clear()
+        this._thinkingStartMs.clear()
         lastStopReason = final.stop_reason
         const roundUsage = final.usage || {}
         // #6769: keep the raw per-round usage — the LAST one standing at emit
@@ -1206,6 +1227,7 @@ export class ClaudeByokSession extends BaseSession {
       // Safe to call when already empty.
       this._streamingIndexToToolUseId.clear()
       this._streamingIndexToThinkingId.clear()
+      this._thinkingStartMs.clear()
       this._finishTurn()
     }
   }
@@ -2389,6 +2411,7 @@ export class ClaudeByokSession extends BaseSession {
     // reference (test capture, future export) would keep them alive.
     this._streamingIndexToToolUseId.clear()
     this._streamingIndexToThinkingId.clear()
+    this._thinkingStartMs.clear()
     this._pendingPermissionToolUseIds.clear()
     // #5056: drop any outstanding subagent permission-routing pointers so
     // the destroyed parent doesn't retain references to its children.

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -1,7 +1,7 @@
 import { performance } from 'node:perf_hooks'
 import { toShortModelId } from './models.js'
 import { createLogger } from './logger.js'
-import { buildPermissionRequestMessage } from '@chroxy/protocol'
+import { buildPermissionRequestMessage, MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 
 const log = createLogger('event-normalizer')
 
@@ -34,6 +34,28 @@ const MAX_DELTA_TOTAL_BYTES = 2 * 1024 * 1024 // 2 MB across all streams
 // the links that pay for each frame. LAN sessions keep the tight floors.
 const DEFLATE_FLUSH_INTERVAL_MS = 25 // any deflate subscriber, multi-client
 const DEFLATE_SINGLE_CLIENT_FLUSH_INTERVAL_MS = 16 // any deflate subscriber, single client
+
+/**
+ * #6941 review (Copilot) — coerce+bound a footer-stat numeric field
+ * (`thinkingDurationMs` / `thinkingTokens`) before forwarding it onto the
+ * wire. Mirrors the protocol schema's
+ * `z.number().int().nonnegative().finite()[.max(ceiling)]`: floors a stray
+ * fractional value (matches store-core's `parseFiniteNonNegIntField`, which
+ * re-guards the same field client-side) and OMITS — never clamps — when the
+ * value is negative, non-finite, or exceeds an optional ceiling. A clock
+ * jump / suspend producing a bogus multi-day duration should vanish from the
+ * footer, not render as an incorrect exact-ceiling number.
+ *
+ * @param {*} value - candidate value straight off the session event.
+ * @param {{ max?: number }} [opts] - optional upper bound (inclusive).
+ * @returns {number|undefined}
+ */
+function boundedNonNegInt(value, { max } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined
+  const floored = Math.floor(value)
+  if (typeof max === 'number' && floored > max) return undefined
+  return floored
+}
 
 /**
  * Declarative event-to-WS-message mapping.
@@ -191,14 +213,22 @@ Object.assign(EVENT_MAP, {
       // #6391 footer-stat: forward the session-measured elapsed time (+ token
       // count when a provider supplies one — claude SDK/BYOK do not) so the
       // client renders `thought for Xs · N tokens`. Both optional and additive;
-      // the wire schema (ServerStreamEndSchema) validates them.
+      // the wire schema (ServerStreamEndSchema) validates them. #6941 review
+      // (Copilot): a clock jump/suspend on the measuring side could hand us a
+      // negative or wildly-oversized duration that would otherwise slip past a
+      // bare finite-check and violate the schema's
+      // `.int().nonnegative().max(MAX_SANE_DURATION_MS)` contract if a client
+      // ever validates leniently. `boundedNonNegInt` enforces that same
+      // ceiling here (defense-in-depth) and OMITS the field outright rather
+      // than clamping — the deeper monotonic-clock fix is tracked separately
+      // (#6943).
       const msg = { type: 'stream_end', messageId: data.messageId, thinking: true }
-      if (typeof data.thinkingDurationMs === 'number' && Number.isFinite(data.thinkingDurationMs)) {
-        msg.thinkingDurationMs = data.thinkingDurationMs
-      }
-      if (typeof data.thinkingTokens === 'number' && Number.isFinite(data.thinkingTokens)) {
-        msg.thinkingTokens = data.thinkingTokens
-      }
+      const thinkingDurationMs = boundedNonNegInt(data.thinkingDurationMs, { max: MAX_SANE_DURATION_MS })
+      if (thinkingDurationMs !== undefined) msg.thinkingDurationMs = thinkingDurationMs
+      // thinkingTokens has no protocol ceiling (ThinkingTokensSchema is
+      // int().nonnegative().finite() only) — just enforce non-negative int.
+      const thinkingTokens = boundedNonNegInt(data.thinkingTokens)
+      if (thinkingTokens !== undefined) msg.thinkingTokens = thinkingTokens
       return {
         messages: [{ msg }],
       }

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -188,8 +188,19 @@ Object.assign(EVENT_MAP, {
     // flush_deltas: thinking deltas were never buffered, and flushing here would
     // prematurely emit the response text buffer.
     if (data.thinking) {
+      // #6391 footer-stat: forward the session-measured elapsed time (+ token
+      // count when a provider supplies one — claude SDK/BYOK do not) so the
+      // client renders `thought for Xs · N tokens`. Both optional and additive;
+      // the wire schema (ServerStreamEndSchema) validates them.
+      const msg = { type: 'stream_end', messageId: data.messageId, thinking: true }
+      if (typeof data.thinkingDurationMs === 'number' && Number.isFinite(data.thinkingDurationMs)) {
+        msg.thinkingDurationMs = data.thinkingDurationMs
+      }
+      if (typeof data.thinkingTokens === 'number' && Number.isFinite(data.thinkingTokens)) {
+        msg.thinkingTokens = data.thinkingTokens
+      }
       return {
-        messages: [{ msg: { type: 'stream_end', messageId: data.messageId, thinking: true } }],
+        messages: [{ msg }],
       }
     }
     return {

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -654,6 +654,11 @@ export class SdkSession extends BaseSession {
     // maps the SDK stream event `index` → that thinking id so the thinking_delta
     // and content_block_stop events (which carry only the index) route correctly.
     const thinkingBlocks = new Map()
+    // #6391 (chat-redesign footer-stat) — thinkingId -> Date.now() when the
+    // reasoning block opened, so its content_block_stop can stamp the elapsed
+    // `thinkingDurationMs` on the thinking stream_end. Turn-local; entries are
+    // deleted alongside thinkingBlocks when the block closes.
+    const thinkingStartMs = new Map()
     let thinkingBlockCount = 0
     let didStreamThinking = false
 
@@ -932,6 +937,9 @@ export class SdkSession extends BaseSession {
                   if (!thinkingId) {
                     thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
                     thinkingBlocks.set(event.index, thinkingId)
+                    // #6391 footer-stat: mark the block's start for the
+                    // content_block_stop elapsed-time computation.
+                    thinkingStartMs.set(thinkingId, Date.now())
                     this.emit('stream_start', { messageId: thinkingId, thinking: true })
                   }
                   didStreamThinking = true
@@ -973,6 +981,9 @@ export class SdkSession extends BaseSession {
                   if (!thinkingId) {
                     thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
                     thinkingBlocks.set(event.index, thinkingId)
+                    // #6391 footer-stat: mark the block's start (lazy-open path)
+                    // for the content_block_stop elapsed-time computation.
+                    thinkingStartMs.set(thinkingId, Date.now())
                     this.emit('stream_start', { messageId: thinkingId, thinking: true })
                   }
                   didStreamThinking = true
@@ -988,7 +999,18 @@ export class SdkSession extends BaseSession {
                 const thinkingId = thinkingBlocks.get(event.index)
                 if (thinkingId) {
                   thinkingBlocks.delete(event.index)
-                  this.emit('stream_end', { messageId: thinkingId, thinking: true })
+                  // #6391 footer-stat: elapsed wall time from the block's open to
+                  // now → the client's `thought for Xs` footer. Omit when the
+                  // start wasn't tracked (defensive) so we never send a bogus 0.
+                  // No token count: Anthropic's usage folds thinking tokens into
+                  // output_tokens with no per-block breakdown (see follow-up).
+                  const startMs = thinkingStartMs.get(thinkingId)
+                  thinkingStartMs.delete(thinkingId)
+                  const streamEndMsg = { messageId: thinkingId, thinking: true }
+                  if (typeof startMs === 'number') {
+                    streamEndMsg.thinkingDurationMs = Math.max(0, Date.now() - startMs)
+                  }
+                  this.emit('stream_end', streamEndMsg)
                 }
                 break
               }

--- a/packages/server/tests/byok-session-thinking.test.js
+++ b/packages/server/tests/byok-session-thinking.test.js
@@ -18,7 +18,16 @@ import { ClaudeByokSession } from '../src/byok-session.js'
 function fakeStream(events, finalMessage) {
   return {
     async *[Symbol.asyncIterator]() {
-      for (const e of events) yield e
+      for (const e of events) {
+        // #6391 — a `__delayMs` marker event advances wall-clock between the
+        // real events around it (so the thinking start→stop elapsed time the
+        // session measures is provably > 0), then is dropped from the stream.
+        if (e && e.__delayMs) {
+          await new Promise((r) => setTimeout(r, e.__delayMs))
+          continue
+        }
+        yield e
+      }
     },
     async finalMessage() {
       return (
@@ -105,5 +114,51 @@ describe('ClaudeByokSession — thinking content forwarding (#6756)', () => {
     const textDeltas = captured.filter((e) => e.name === 'stream_delta' && !e.thinking)
     assert.deepEqual(textDeltas.map((e) => e.delta), ['Hi'])
     assert.notEqual(textDeltas[0].messageId, thinkingId)
+  })
+
+  it('stamps thinkingDurationMs on the thinking stream_end and omits thinkingTokens (#6391)', async () => {
+    const session = new ClaudeByokSession({ cwd: '/tmp' })
+    session._client = {
+      messages: {
+        stream: () =>
+          fakeStream([
+            { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
+            { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } },
+            { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Reasoning.' } },
+            // Advance wall-clock so start→stop elapsed is provably positive.
+            { __delayMs: 12 },
+            { type: 'content_block_stop', index: 0 },
+            { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+            { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hi' } },
+            { type: 'content_block_stop', index: 1 },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 5, output_tokens: 4 } },
+            { type: 'message_stop' },
+          ], {
+            stop_reason: 'end_turn',
+            content: [{ type: 'thinking', thinking: 'Reasoning.' }, { type: 'text', text: 'Hi' }],
+            usage: { input_tokens: 5, output_tokens: 4 },
+          }),
+      },
+    }
+    const captured = capture(session)
+    await session.start()
+    await session.sendMessage('hi')
+
+    const thinkingEnds = captured.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    const end = thinkingEnds[0]
+    // Duration is a finite non-negative integer measured start→stop (> 0 given
+    // the injected 12ms delay).
+    assert.equal(typeof end.thinkingDurationMs, 'number')
+    assert.ok(Number.isInteger(end.thinkingDurationMs), 'duration is an integer ms')
+    assert.ok(end.thinkingDurationMs > 0, `duration should be > 0, got ${end.thinkingDurationMs}`)
+    // No token count: Anthropic's usage folds thinking tokens into output_tokens
+    // with no per-block breakdown, so BYOK omits it (tracked follow-up).
+    assert.equal(end.thinkingTokens, undefined)
+
+    // The response text stream_end (untagged) carries no footer-stat fields.
+    const responseEnd = captured.find((e) => e.name === 'stream_end' && !e.thinking)
+    assert.ok(responseEnd)
+    assert.equal(responseEnd.thinkingDurationMs, undefined)
   })
 })

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -44,6 +44,55 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- thinking stream_end footer-stat pass-through (#6391) ----
+  describe('thinking stream_end footer-stat (#6391)', () => {
+    it('forwards thinkingDurationMs (+ thinkingTokens) on the thinking stream_end', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: 4200, thinkingTokens: 128 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'stream_end')
+      assert.equal(msg.thinking, true)
+      assert.equal(msg.thinkingDurationMs, 4200)
+      assert.equal(msg.thinkingTokens, 128)
+    })
+
+    it('forwards duration alone (claude SDK/BYOK omit tokens) without an undefined tokens key', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: 900 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.thinkingDurationMs, 900)
+      assert.ok(!('thinkingTokens' in msg), 'no undefined tokens key on the wire')
+    })
+
+    it('drops a non-finite duration rather than forwarding it', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: Number.NaN },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.ok(!('thinkingDurationMs' in msg))
+    })
+
+    it('never stamps footer-stat fields on a NON-thinking (response) stream_end', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1', thinkingDurationMs: 4200 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'stream_end')
+      assert.ok(!('thinkingDurationMs' in msg))
+      assert.ok(!('thinking' in msg))
+    })
+  })
+
   // ---- EVENT_MAP: session_usage (#4072) ----
 
   describe('session_usage event', () => {

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventNormalizer, EVENT_MAP } from '../src/event-normalizer.js'
-import { ServerSkillChangedSchema } from '@chroxy/protocol'
+import { ServerSkillChangedSchema, MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 
 // -- Helper to create a standard multi-session context --
 function makeCtx(overrides = {}) {
@@ -78,6 +78,72 @@ describe('EventNormalizer', () => {
       )
       const msg = result.messages[0].msg
       assert.ok(!('thinkingDurationMs' in msg))
+    })
+
+    // #6941 review (Copilot): the normalizer only finite-checked the fields
+    // before forwarding, so an out-of-range value (clock jump / suspend, or a
+    // malformed upstream event) could violate the wire schema's
+    // `.int().nonnegative().max(MAX_SANE_DURATION_MS)` contract. These cases
+    // pin the defense-in-depth bound.
+    it('omits a duration that exceeds MAX_SANE_DURATION_MS rather than forwarding or clamping it', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: MAX_SANE_DURATION_MS + 1, thinkingTokens: 128 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.ok(!('thinkingDurationMs' in msg), 'out-of-range duration must vanish, not clamp to the ceiling')
+      assert.equal(msg.thinkingTokens, 128, 'an in-range sibling field still forwards')
+    })
+
+    it('accepts the exact MAX_SANE_DURATION_MS boundary', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: MAX_SANE_DURATION_MS },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.thinkingDurationMs, MAX_SANE_DURATION_MS)
+    })
+
+    it('omits a negative duration', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: -50 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.ok(!('thinkingDurationMs' in msg))
+    })
+
+    it('floors a fractional duration rather than forwarding it as-is', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingDurationMs: 4200.9 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.thinkingDurationMs, 4200)
+    })
+
+    it('thinkingTokens has no ceiling — only enforces non-negative int', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingTokens: MAX_SANE_DURATION_MS * 10 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.thinkingTokens, MAX_SANE_DURATION_MS * 10)
+    })
+
+    it('omits a negative thinkingTokens', () => {
+      const result = normalizer.normalize(
+        'stream_end',
+        { messageId: 'm1-thinking-0', thinking: true, thinkingTokens: -1 },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.ok(!('thinkingTokens' in msg))
     })
 
     it('never stamps footer-stat fields on a NON-thinking (response) stream_end', () => {

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -11,7 +11,13 @@
  * the dashboard hook test had, run directly against the pure function.
  */
 import { describe, it, expect } from 'vitest'
-import { buildChatViewMessages, toChatViewMessage, isHiddenInCompactMode } from './buildChatViewMessages'
+import {
+  buildChatViewMessages,
+  toChatViewMessage,
+  isHiddenInCompactMode,
+  formatThinkingDuration,
+  formatThinkingFooter,
+} from './buildChatViewMessages'
 import type { ChatMessage } from './types'
 
 function msg(partial: Partial<ChatMessage> & { id: string; type: ChatMessage['type'] }): ChatMessage {
@@ -397,6 +403,72 @@ describe('buildChatViewMessages', () => {
     it('does NOT propagate attachments for a non-user_input message (contract: user messages only)', () => {
       const attachments = [{ id: 'a1', type: 'image' as const, uri: 'data:image/png;base64,x', name: 'x.png', mediaType: 'image/png', size: 1 }]
       expect('attachments' in toChatViewMessage(msg({ id: 'r1', type: 'response', content: 'hi', attachments }))).toBe(false)
+    })
+
+    it('propagates the footer-stat duration + tokens on thinking rows (#6391)', () => {
+      const v = toChatViewMessage(
+        msg({ id: 't1', type: 'thinking', content: 'reasoning', thinkingDurationMs: 4200, thinkingTokens: 128 }),
+      )
+      expect(v.thinkingDurationMs).toBe(4200)
+      expect(v.thinkingTokens).toBe(128)
+    })
+
+    it('propagates duration alone when tokens are absent (claude SDK/BYOK) (#6391)', () => {
+      const v = toChatViewMessage(msg({ id: 't1', type: 'thinking', content: 'x', thinkingDurationMs: 900 }))
+      expect(v.thinkingDurationMs).toBe(900)
+      expect('thinkingTokens' in v).toBe(false)
+    })
+
+    it('omits the footer-stat fields on a thinking row that carries none (old sessions) (#6391)', () => {
+      const v = toChatViewMessage(msg({ id: 't1', type: 'thinking', content: 'x' }))
+      expect('thinkingDurationMs' in v).toBe(false)
+      expect('thinkingTokens' in v).toBe(false)
+    })
+
+    it('does NOT propagate footer-stat fields onto a non-thinking row (contract: thinking only) (#6391)', () => {
+      const v = toChatViewMessage(
+        msg({ id: 'r1', type: 'response', content: 'hi', thinkingDurationMs: 4200, thinkingTokens: 128 }),
+      )
+      expect('thinkingDurationMs' in v).toBe(false)
+      expect('thinkingTokens' in v).toBe(false)
+    })
+  })
+
+  describe('formatThinkingDuration (#6391)', () => {
+    it('keeps one decimal under 10s', () => {
+      expect(formatThinkingDuration(4200)).toBe('4.2s')
+      expect(formatThinkingDuration(300)).toBe('0.3s')
+      expect(formatThinkingDuration(0)).toBe('0.0s')
+    })
+
+    it('rounds to whole seconds at 10s and above', () => {
+      expect(formatThinkingDuration(19000)).toBe('19s')
+      expect(formatThinkingDuration(19400)).toBe('19s')
+      expect(formatThinkingDuration(19600)).toBe('20s')
+      expect(formatThinkingDuration(10000)).toBe('10s')
+    })
+  })
+
+  describe('formatThinkingFooter (#6391)', () => {
+    it('composes duration + tokens', () => {
+      expect(formatThinkingFooter({ durationMs: 4200, tokens: 128 })).toBe('thought for 4.2s · 128 tokens')
+    })
+
+    it('renders duration alone when tokens are absent (claude SDK/BYOK)', () => {
+      expect(formatThinkingFooter({ durationMs: 4200 })).toBe('thought for 4.2s')
+    })
+
+    it('renders tokens alone when only a token count is present', () => {
+      expect(formatThinkingFooter({ tokens: 128 })).toBe('128 tokens')
+    })
+
+    it('returns "" when neither stat is present, so the caller falls back to "Thought"', () => {
+      expect(formatThinkingFooter({})).toBe('')
+    })
+
+    it('drops malformed (negative / non-finite) inputs rather than rendering them', () => {
+      expect(formatThinkingFooter({ durationMs: -5, tokens: 128 })).toBe('128 tokens')
+      expect(formatThinkingFooter({ durationMs: Number.NaN, tokens: Number.POSITIVE_INFINITY })).toBe('')
     })
   })
 })

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -77,6 +77,21 @@ export interface ChatViewMessage {
    */
   thinkingTruncated?: boolean
   /**
+   * #6391 (chat-redesign footer-stat) — mirrored from the store ChatMessage on
+   * `thinking` rows: the reasoning block's measured elapsed time (ms). Drives
+   * the `thought for Xs` turn footer; renderers compose it via
+   * {@link formatThinkingFooter}. Undefined on old sessions → footer falls back
+   * to "Thought".
+   */
+  thinkingDurationMs?: number
+  /**
+   * #6391 (chat-redesign footer-stat) — mirrored from the store ChatMessage on
+   * `thinking` rows: the reasoning block's token count, rendered as ` · N
+   * tokens` after the duration. Undefined for providers that don't separate
+   * reasoning tokens (claude SDK/BYOK) → the token clause is omitted.
+   */
+  thinkingTokens?: number
+  /**
    * #4476 — structured error code mirrored from the store ChatMessage so
    * renderers can switch on it (e.g. `'stream_stall'` → chip + retry).
    */
@@ -166,12 +181,56 @@ export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
     ...(msg.type === 'thinking' && msg.thinkingTruncated
       ? { thinkingTruncated: true }
       : {}),
+    // #6391 footer-stat: carry the reasoning block's duration (+ token count
+    // when a provider reports one) through on thinking rows so ThinkingBody /
+    // ThinkingBubble can render `thought for Xs · N tokens`. Gated to `thinking`
+    // to match the contract (these live only on thinking bubbles).
+    ...(msg.type === 'thinking' && typeof msg.thinkingDurationMs === 'number'
+      ? { thinkingDurationMs: msg.thinkingDurationMs }
+      : {}),
+    ...(msg.type === 'thinking' && typeof msg.thinkingTokens === 'number'
+      ? { thinkingTokens: msg.thinkingTokens }
+      : {}),
     // #6632: carry user-message attachments through so the transcript can
     // preview them (dropped previously → no thumbnail on the sent message).
     // Gated to `user_input` to match the contract (attachments live only on user
     // messages) — don't thread attachment data onto non-user bubbles.
     ...(msg.type === 'user_input' && msg.attachments?.length ? { attachments: msg.attachments } : {}),
   }
+}
+
+/**
+ * #6391 (chat-redesign footer-stat) — format a reasoning block's elapsed time
+ * for the `thought for Xs` footer. Sub-10s durations keep one decimal
+ * (`4.2s`, `0.3s`) so short thoughts stay legible; ≥10s rounds to whole
+ * seconds (`19s`) since the decimal is noise at that scale. Pure; shared by
+ * both clients so the dashboard and mobile footers never drift.
+ */
+export function formatThinkingDuration(ms: number): string {
+  const s = ms / 1000
+  return s < 10 ? `${s.toFixed(1)}s` : `${Math.round(s)}s`
+}
+
+/**
+ * #6391 — compose the thinking footer-stat text (WITHOUT the leading spark/caret,
+ * which each client owns) from the optional duration + token stats:
+ *   - both present → `thought for 4.2s · 128 tokens`
+ *   - duration only → `thought for 4.2s`
+ *   - neither (old session / token-less provider with no duration) → `''`
+ * Callers fall back to a bare "Thought" label on an empty string, so the footer
+ * degrades gracefully. Guards each input so a malformed value is dropped rather
+ * than rendered.
+ */
+export function formatThinkingFooter(opts: { durationMs?: number; tokens?: number }): string {
+  const parts: string[] = []
+  const { durationMs, tokens } = opts
+  if (typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0) {
+    parts.push(`thought for ${formatThinkingDuration(durationMs)}`)
+  }
+  if (typeof tokens === 'number' && Number.isFinite(tokens) && tokens >= 0) {
+    parts.push(`${tokens} tokens`)
+  }
+  return parts.join(' · ')
 }
 
 /**

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -14,7 +14,7 @@ import type { ActiveTool, ChatMessage, ContextOccupancy, ContextUsage, ToolResul
 import { nextMessageId } from '../utils'
 import { isReplayDuplicate } from '../replay-dedup'
 import { resolveStreamId } from '../stream-id'
-import { isRateLimitMessage } from '@chroxy/protocol'
+import { isRateLimitMessage, MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 import { parseRawStringField } from './_shared'
 
 // ---------------------------------------------------------------------------
@@ -1480,10 +1480,24 @@ export interface ThinkingStreamEndPayload {
  * off the raw wire message. Defensive re-guard mirroring the protocol schema:
  * a finite non-negative integer, or `undefined` when absent/malformed. Floors
  * so a stray float can never leak a fractional ms/token onto the bubble.
+ *
+ * #6941 review (Copilot): this helper claimed to mirror the protocol schema
+ * but did not enforce `ThinkingDurationMsSchema`'s `.max(MAX_SANE_DURATION_MS)`
+ * ceiling, so a malformed payload that bypassed Zod (or a clock-jump artifact
+ * from the server side) could leak an out-of-range duration into state/UI.
+ * `max` is optional and per-call: `thinkingDurationMs` passes
+ * `MAX_SANE_DURATION_MS`, `thinkingTokens` (no documented ceiling) omits it.
+ * Out-of-range values are OMITTED (return `undefined`), never clamped — same
+ * "vanish, don't render a fake ceiling" behaviour as the server-side
+ * normalizer (packages/server/src/event-normalizer.js `boundedNonNegInt`),
+ * so both sides agree.
  */
-function parseFiniteNonNegIntField(msg: Record<string, unknown>, key: string): number | undefined {
+function parseFiniteNonNegIntField(msg: Record<string, unknown>, key: string, max?: number): number | undefined {
   const v = msg[key]
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : undefined
+  if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return undefined
+  const floored = Math.floor(v)
+  if (typeof max === 'number' && floored > max) return undefined
+  return floored
 }
 
 /**
@@ -1501,7 +1515,7 @@ export function handleThinkingStreamEnd(
 ): ThinkingStreamEndPayload {
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
   const thinkingMessageId = parseRawStringField(msg, 'messageId')
-  const thinkingDurationMs = parseFiniteNonNegIntField(msg, 'thinkingDurationMs')
+  const thinkingDurationMs = parseFiniteNonNegIntField(msg, 'thinkingDurationMs', MAX_SANE_DURATION_MS)
   const thinkingTokens = parseFiniteNonNegIntField(msg, 'thinkingTokens')
   return {
     sessionId,

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -1476,8 +1476,24 @@ export interface ThinkingStreamEndPayload {
 }
 
 /**
+ * #6391 — parse a footer-stat numeric field (thinkingDurationMs / thinkingTokens)
+ * off the raw wire message. Defensive re-guard mirroring the protocol schema:
+ * a finite non-negative integer, or `undefined` when absent/malformed. Floors
+ * so a stray float can never leak a fractional ms/token onto the bubble.
+ */
+function parseFiniteNonNegIntField(msg: Record<string, unknown>, key: string): number | undefined {
+  const v = msg[key]
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : undefined
+}
+
+/**
  * Resolve a thinking `stream_end` (a `stream_end` with `thinking: true`).
- * Finalises the bubble's streaming label without touching `streamingMessageId`.
+ * Finalises the bubble's streaming label without touching `streamingMessageId`,
+ * and — for the #6391 footer-stat — threads the server-measured
+ * `thinkingDurationMs` (+ `thinkingTokens` when a provider reports it) onto the
+ * bubble so renderers show `thought for Xs · N tokens`. Both stats are optional:
+ * a stream_end without them (old server, token-less provider) just flips the
+ * label, and the footer degrades to a bare "Thought".
  */
 export function handleThinkingStreamEnd(
   msg: Record<string, unknown>,
@@ -1485,6 +1501,8 @@ export function handleThinkingStreamEnd(
 ): ThinkingStreamEndPayload {
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : activeSessionId
   const thinkingMessageId = parseRawStringField(msg, 'messageId')
+  const thinkingDurationMs = parseFiniteNonNegIntField(msg, 'thinkingDurationMs')
+  const thinkingTokens = parseFiniteNonNegIntField(msg, 'thinkingTokens')
   return {
     sessionId,
     thinkingMessageId,
@@ -1495,9 +1513,29 @@ export function handleThinkingStreamEnd(
       )
       if (idx === -1) return messages
       const existing = messages[idx]!
-      if (existing.thinkingStreaming !== true) return messages
+      // Attach only stats that differ from what's already on the bubble, so a
+      // replayed / orphan-swept stream_end that carries the same numbers stays
+      // a same-reference no-op (React skip). Finalising the label is its own
+      // reason to write, independent of the stats.
+      const nextDuration =
+        thinkingDurationMs !== undefined && existing.thinkingDurationMs !== thinkingDurationMs
+          ? thinkingDurationMs
+          : undefined
+      const nextTokens =
+        thinkingTokens !== undefined && existing.thinkingTokens !== thinkingTokens
+          ? thinkingTokens
+          : undefined
+      const needsFinalize = existing.thinkingStreaming === true
+      if (!needsFinalize && nextDuration === undefined && nextTokens === undefined) {
+        return messages
+      }
       const updated = [...messages]
-      updated[idx] = { ...existing, thinkingStreaming: false }
+      updated[idx] = {
+        ...existing,
+        thinkingStreaming: false,
+        ...(nextDuration !== undefined ? { thinkingDurationMs: nextDuration } : null),
+        ...(nextTokens !== undefined ? { thinkingTokens: nextTokens } : null),
+      }
       return updated
     },
   }

--- a/packages/store-core/src/handlers/thinking.test.ts
+++ b/packages/store-core/src/handlers/thinking.test.ts
@@ -163,4 +163,79 @@ describe('handleThinkingStreamEnd (#6756)', () => {
     expect(p.applyTo(finalised)).toBe(finalised)
     expect(p.applyTo([])).toEqual([])
   })
+
+  // #6391 — footer-stat: the thinking stream_end carries the server-measured
+  // elapsed time (+ token count for providers that separate it).
+  it('threads thinkingDurationMs + thinkingTokens onto the bubble when the wire carries them (#6391)', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const p = handleThinkingStreamEnd(
+      { type: 'stream_end', messageId: 't0', thinking: true, thinkingDurationMs: 4200, thinkingTokens: 128 },
+      SESSION,
+    )
+    const next = p.applyTo(messages)
+    expect(next[0]!.thinkingStreaming).toBe(false)
+    expect(next[0]!.thinkingDurationMs).toBe(4200)
+    expect(next[0]!.thinkingTokens).toBe(128)
+  })
+
+  it('threads duration alone when tokens are absent (claude SDK/BYOK) (#6391)', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const next = handleThinkingStreamEnd(
+      { type: 'stream_end', messageId: 't0', thinking: true, thinkingDurationMs: 900 },
+      SESSION,
+    ).applyTo(messages)
+    expect(next[0]!.thinkingDurationMs).toBe(900)
+    expect(next[0]!.thinkingTokens).toBeUndefined()
+  })
+
+  it('degrades gracefully when the wire carries NO stats (old server): flips label, no stat fields (#6391)', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const next = handleThinkingStreamEnd({ type: 'stream_end', messageId: 't0', thinking: true }, SESSION).applyTo(messages)
+    expect(next[0]!.thinkingStreaming).toBe(false)
+    expect(next[0]!.thinkingDurationMs).toBeUndefined()
+    expect(next[0]!.thinkingTokens).toBeUndefined()
+  })
+
+  it('floors a fractional duration and rejects a negative one (defensive re-guard) (#6391)', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const next = handleThinkingStreamEnd(
+      { type: 'stream_end', messageId: 't0', thinking: true, thinkingDurationMs: 4200.9, thinkingTokens: -3 },
+      SESSION,
+    ).applyTo(messages)
+    expect(next[0]!.thinkingDurationMs).toBe(4200)
+    expect(next[0]!.thinkingTokens).toBeUndefined()
+  })
+
+  it('attaches stats even when the bubble was already orphan-swept to finalised (#6391)', () => {
+    // The response-stream backstop (finalizeThinkingStreams) can flip the label
+    // before the thinking block's own stream_end lands; the late stat still sticks.
+    const swept: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: false, timestamp: 0 },
+    ]
+    const next = handleThinkingStreamEnd(
+      { type: 'stream_end', messageId: 't0', thinking: true, thinkingDurationMs: 1500 },
+      SESSION,
+    ).applyTo(swept)
+    expect(next).not.toBe(swept)
+    expect(next[0]!.thinkingDurationMs).toBe(1500)
+  })
+
+  it('is idempotent — a replayed stream_end with identical stats is a same-reference no-op (#6391)', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: false, thinkingDurationMs: 4200, thinkingTokens: 128, timestamp: 0 },
+    ]
+    const again = handleThinkingStreamEnd(
+      { type: 'stream_end', messageId: 't0', thinking: true, thinkingDurationMs: 4200, thinkingTokens: 128 },
+      SESSION,
+    ).applyTo(messages)
+    expect(again).toBe(messages)
+  })
 })

--- a/packages/store-core/src/handlers/thinking.test.ts
+++ b/packages/store-core/src/handlers/thinking.test.ts
@@ -5,6 +5,7 @@
  * disclosure, separate from the response-text stream.
  */
 import { describe, it, expect } from 'vitest'
+import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 import {
   handleThinkingStreamStart,
   handleThinkingDelta,
@@ -212,6 +213,41 @@ describe('handleThinkingStreamEnd (#6756)', () => {
     ).applyTo(messages)
     expect(next[0]!.thinkingDurationMs).toBe(4200)
     expect(next[0]!.thinkingTokens).toBeUndefined()
+  })
+
+  it('omits a duration that exceeds MAX_SANE_DURATION_MS while keeping in-range tokens (#6941 review)', () => {
+    // A clock jump / suspend on the measuring side could hand us a bogus
+    // multi-day duration; a malformed payload could also bypass Zod entirely.
+    // The parse helper must enforce the same ceiling the protocol schema
+    // does (ThinkingDurationMsSchema.max(MAX_SANE_DURATION_MS)) and OMIT
+    // (not clamp) the field so the footer degrades instead of showing a fake
+    // exact-24h number.
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const next = handleThinkingStreamEnd(
+      {
+        type: 'stream_end',
+        messageId: 't0',
+        thinking: true,
+        thinkingDurationMs: MAX_SANE_DURATION_MS + 1,
+        thinkingTokens: 128,
+      },
+      SESSION,
+    ).applyTo(messages)
+    expect(next[0]!.thinkingDurationMs).toBeUndefined()
+    expect(next[0]!.thinkingTokens).toBe(128)
+  })
+
+  it('accepts the exact MAX_SANE_DURATION_MS boundary (#6941 review)', () => {
+    const messages: ChatMessage[] = [
+      { id: 't0', type: 'thinking', content: 'done', thinkingStreaming: true, timestamp: 0 },
+    ]
+    const next = handleThinkingStreamEnd(
+      { type: 'stream_end', messageId: 't0', thinking: true, thinkingDurationMs: MAX_SANE_DURATION_MS },
+      SESSION,
+    ).applyTo(messages)
+    expect(next[0]!.thinkingDurationMs).toBe(MAX_SANE_DURATION_MS)
   })
 
   it('attaches stats even when the bubble was already orphan-swept to finalised (#6391)', () => {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -388,6 +388,10 @@ export {
   toChatViewMessage,
   // #6799 — shared predicate for the global compact chat filter (mobile parity).
   isHiddenInCompactMode,
+  // #6391 — shared thinking footer-stat formatters (both clients render the
+  // same `thought for Xs · N tokens` string).
+  formatThinkingDuration,
+  formatThinkingFooter,
 } from './buildChatViewMessages'
 
 // #5793: single source of truth for "is this an AskUserQuestion teardown

--- a/packages/store-core/src/types/chat.ts
+++ b/packages/store-core/src/types/chat.ts
@@ -180,6 +180,26 @@ export interface ChatMessage {
    * affordance.
    */
   thinkingTruncated?: boolean;
+  /**
+   * #6391 (chat-redesign footer-stat) — on a `type: 'thinking'` bubble, the
+   * server-measured elapsed wall time (ms) the reasoning block took, from its
+   * first streamed token to its close. Threaded off the thinking `stream_end`
+   * by {@link handleThinkingStreamEnd}. Renderers show it as a quiet
+   * `thought for 4.2s` turn footer in place of the plain "Thought" label.
+   * Undefined on old sessions / servers and on the synchronous fallback path
+   * (no measurable elapsed time) — the footer degrades to "Thought".
+   */
+  thinkingDurationMs?: number;
+  /**
+   * #6391 (chat-redesign footer-stat) — on a `type: 'thinking'` bubble, the
+   * reasoning block's token count, rendered as ` · N tokens` after the
+   * duration. Optional and NOT populated by the claude SDK/BYOK providers:
+   * Anthropic's usage folds thinking tokens into `output_tokens` with no
+   * per-block breakdown, so there is nothing clean to report (tracked follow-up).
+   * Present only for a provider that cleanly separates reasoning tokens; the
+   * footer omits the token clause when absent rather than fabricating a number.
+   */
+  thinkingTokens?: number;
   answered?: string;
   /**
    * #4973 — structured per-question answers map recorded when the user


### PR DESCRIPTION
## Summary

Implements the **footer-stat thinking** signature moment — a deferred Phase-1 item of the chat-redesign epic. Part of #6389; references #6391 (§5 signature moments: *"reasoning reduced to a quiet `thought for Ns` footnote"*).

Replaces the standing `▸ Thinking…/Thought` disclosure with a compact turn-footer stat on **both clients**:

- `▸ Thinking…` while the reasoning streams
- `▸ thought for 4.2s · 128 tokens` once done (token clause only when a provider reports it)
- degrades to a bare `▸ Thought` on old sessions / providers without stats

## Why it was deferred — and how each blocker was solved

**1. Duration** — thinking messages carried only a single timestamp (no start→end). The **server** now captures the reasoning block's open time and stamps the elapsed `thinkingDurationMs` on the block's `content_block_stop` → thinking `stream_end`, in *both* emit paths (`sdk-session.js`, `byok-session.js`).

**2. Tokens** — investigated whether the provider separates thinking-block tokens. **It does not, for claude SDK/BYOK:** Anthropic's usage folds thinking tokens into `output_tokens` with **no per-block breakdown**, and the stream events carry no per-block token counts (`usage-normalize.js` only tracks input/output/cache tokens). So `thinkingTokens` is **wired end-to-end but not populated** for these providers — the footer omits the clause rather than fabricating a number. A future provider that separates reasoning tokens (e.g. OpenAI-compatible `reasoning_tokens`) can populate it with no wire change. Tracked as a follow-up (filed separately).

## Changes

- **protocol** — optional `thinkingDurationMs` (bounded by `MAX_SANE_DURATION_MS`) + `thinkingTokens` on `ServerStreamEndSchema`; additive/optional (old servers/clients interop unchanged). Rebuilt `dist/`.
- **store-core** — fields on `ChatMessage` + `ChatViewMessage`; `handleThinkingStreamEnd` threads them (idempotent; attaches late stats even after the orphan-sweep). New shared `formatThinkingDuration`/`formatThinkingFooter` so both clients render an identical string.
- **server** — duration capture in both emit paths; `event-normalizer` forwards the fields on the thinking `stream_end`.
- **dashboard** `ThinkingBody` + **app** `ThinkingBubble` — render the footer stat; token-pure (no new color literals).

## Coverage guards / dist

Optional fields on the **existing** `stream_end` type — no new wire type, so the three coverage guards are untouched. Verified by running the full protocol + store-core suites.

## Tests

- **store-core** 2048 ✓ + typecheck ✓ (new: footer-stat mapping, `formatThinking*`, `handleThinkingStreamEnd` threading/idempotency/degradation)
- **protocol** 377 ✓ (new: schema accepts + bounds-rejects the fields)
- **server** byok-thinking + event-normalizer 134 ✓ (new: duration stamped start→end with an injected delay proving `> 0`; pass-through) + all 5 `lint-*.sh` ✓
- **dashboard** full vitest 4679 ✓ + typecheck ✓ (new: footer render + graceful degradation)
- **app** MessageBubble family + store message-handler 250 ✓ + typecheck ✓ (new: footer render + degradation)

## Live check (please verify visually)

Run a thinking-capable session (claude SDK or BYOK, thinking level on). Ask something that triggers extended thinking. Expect the thinking row to read **`▸ thought for Xs`** once the block finishes (no `· N tokens` clause — expected for claude), and **`▸ Thinking…`** while it streams. Confirm both the **dashboard** and the **mobile app**.