### PR TITLE
feat(dashboard,app): split-view diff comments + mobile diff-comment E2E

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,7 @@ export PATH="$PATH:$HOME/.maestro/bin"
 
 # Full green gate (recommended) — each flow in its OWN maestro process (#6091).
 # Reliable on a single simulator over long runs: avoids the XCUITest instability
-# that accumulates when all 22 flows share one process (run-all.yaml). Parses the
+# that accumulates when all 23 flows share one process (run-all.yaml). Parses the
 # flow inventory from run-all.yaml, starts/reuses the mock server, retries a
 # failing flow once (env flakiness vs real defect), prints a pass/fail summary.
 bash packages/app/.maestro/scripts/run-all-sequential.sh --device <device-id>
@@ -394,7 +394,7 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 22 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, …) |
+| `run-all.yaml` | Runs all 23 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ export PATH="$PATH:$HOME/.maestro/bin"
 
 # Full green gate (recommended) — each flow in its OWN maestro process (#6091).
 # Reliable on a single simulator over long runs: avoids the XCUITest instability
-# that accumulates when all 22 flows share one process (run-all.yaml). Parses the
+# that accumulates when all 23 flows share one process (run-all.yaml). Parses the
 # flow inventory from run-all.yaml, starts/reuses the mock server, retries a
 # failing flow once (env flakiness vs real defect), prints a pass/fail summary.
 bash packages/app/.maestro/scripts/run-all-sequential.sh --device <device-id>
@@ -375,7 +375,7 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 22 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, …) |
+| `run-all.yaml` | Runs all 23 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/packages/app/.maestro/diff-comment.yaml
+++ b/packages/app/.maestro/diff-comment.yaml
@@ -1,0 +1,93 @@
+appId: com.blamechris.chroxy
+name: DiffViewer inline comment submit
+---
+
+# #6800 follow-up — End-to-end coverage for the mobile DiffViewer inline-comment
+# → submit-to-Claude path. Opens the Changes viewer, taps a diff line, leaves a
+# comment, submits it, and asserts the composed review prompt lands in chat as
+# the next user turn.
+#
+# Trigger: opening the Changes viewer sends `get_diff`; mock-server.mjs answers
+# with a canned `diff_result` (one modified file, one hunk). Saving a comment
+# queues a DiffLineComment; tapping Submit sends composeCommentReviewPrompt()
+# over the normal `input` wire path, which the mock echoes back — the composed
+# prompt therefore appears in the chat transcript (also rendered optimistically
+# by the app). The fixture-seeding pattern is documented in CLAUDE.md →
+# "Fixture Seeding for Structured Renderers".
+#
+# Tested devices: iPhone 16 Pro (iOS 18), portrait. iPad / Android untested.
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+
+- runFlow: setup/ensure-session-screen.yaml
+
+# Make sure Chat is selected so the composed prompt lands in the chat transcript.
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# The Changes viewer opens from the collapsed "secondary tools" row. Both
+# buttons are icon-only, so they match on their accessibilityLabel (Maestro's
+# `text` matcher reads the accessible label on iOS — same as the setup flow's
+# "Disconnect and go back").
+- tapOn:
+    text: "Show tools"
+- tapOn:
+    text: "View changes"
+
+# Opening the viewer sends `get_diff`; wait for the mock's diff_result to land
+# the file entry (testID set in DiffViewer.tsx's FlatList renderItem).
+- extendedWaitUntil:
+    visible:
+      id: "diff-file-src/utils/helper.ts"
+    timeout: 10000
+
+# Open the file's hunk view.
+- tapOn:
+    id: "diff-file-src/utils/helper.ts"
+- waitForAnimationToEnd
+
+# Tap the addition line `const y = 3` (index 2 in the hunk) to open its inline
+# comment editor. testID `diff-line-<i>` is on the per-line TouchableOpacity
+# whose onPress calls onOpen — a direct tap-by-id propagates to the RN touch
+# responder (unlike the nested-View case in chat-todolist.yaml).
+- tapOn:
+    id: "diff-line-2"
+- extendedWaitUntil:
+    visible:
+      id: "diff-comment-input"
+    timeout: 5000
+
+# Type the comment and save it (queues a pending DiffLineComment). The editor
+# renders near the top of the hunk, above the keyboard, so the save button is
+# reachable without dismissing it (hideKeyboard is broken on the current
+# Maestro CLI — see #6089).
+- tapOn:
+    id: "diff-comment-input"
+- inputText: "prefer a named constant"
+- tapOn:
+    id: "diff-comment-save"
+
+# The bottom action bar's Submit control appears once ≥1 comment is queued.
+- extendedWaitUntil:
+    visible:
+      id: "diff-submit-comments"
+    timeout: 5000
+- takeScreenshot: diff-comment-queued
+
+# Submit — sends composeCommentReviewPrompt() as the next user turn and closes
+# the viewer (handleSubmitComments → sendInput → handleClose).
+- tapOn:
+    id: "diff-submit-comments"
+
+# Back in the chat, the composed prompt lands as the user turn. Assert on the
+# prompt's stable opening line and the comment text carried through from the
+# fixture. Both are single-line substrings, so they survive markdown rendering
+# and Maestro's per-element text matching.
+- extendedWaitUntil:
+    visible:
+      text: ".*Please address the following 1 review comment.*"
+    timeout: 10000
+- assertVisible:
+    text: ".*prefer a named constant.*"
+- takeScreenshot: diff-comment-submitted

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -480,6 +480,45 @@ wss.on('connection', (ws) => {
         })
         break
 
+      // #6800 follow-up: the DiffViewer requests `get_diff` when the Changes
+      // viewer opens; answer with a small canned diff so the Maestro
+      // diff-comment flow can exercise the inline-comment path (tap a line →
+      // comment → submit) end-to-end. Mirrors the production wire shape — a
+      // PTY/SDK server replies with a `diff_result` carrying validated
+      // DiffFile[] (see packages/store-core/src/handlers/git.ts handleDiffResult
+      // + isDiffFile; malformed elements are dropped fail-soft). One modified
+      // file with a single hunk (context / deletion / addition / addition /
+      // context) is enough to render the `diff-line-<i>` touch targets the flow
+      // taps, and its `deriveLineNumber` values match the dashboard fixture so
+      // the composed prompt is byte-identical across clients.
+      case 'get_diff':
+        secureSend(ws, {
+          type: 'diff_result',
+          sessionId: 'mock-sess-1',
+          files: [
+            {
+              path: 'src/utils/helper.ts',
+              status: 'modified',
+              additions: 2,
+              deletions: 1,
+              hunks: [
+                {
+                  header: '@@ -10,5 +10,6 @@',
+                  lines: [
+                    { type: 'context', content: 'const x = 1' },
+                    { type: 'deletion', content: 'const y = 2' },
+                    { type: 'addition', content: 'const y = 3' },
+                    { type: 'addition', content: 'const z = 4' },
+                    { type: 'context', content: 'export { x }' },
+                  ],
+                },
+              ],
+            },
+          ],
+          error: null,
+        })
+        break
+
       case 'input': {
         const text = msg.data || ''
         console.log(`[mock] Input: "${text}"`)

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -132,3 +132,9 @@ name: All E2E flows
 # a regression that optimistically answered the tap would clear the
 # hint and fail the flow. Recovers via the self-releasing hold.
 - runFlow: permission-disconnected-noop.yaml
+
+# Flow 23: DiffViewer inline comment → submit (#6800 follow-up) — opens
+# the Changes viewer (mock answers `get_diff` with a canned diff_result),
+# taps a diff line, leaves a comment, submits it, and asserts the composed
+# composeCommentReviewPrompt() text lands in chat as the next user turn.
+- runFlow: diff-comment.yaml

--- a/packages/dashboard/src/components/DiffViewerPanel.test.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.test.tsx
@@ -195,11 +195,60 @@ describe('DiffViewerPanel', () => {
     expect(screen.getAllByTestId('diff-line-comment-btn')).toHaveLength(5)
   })
 
-  it('does not render comment buttons in split view', () => {
+  it('exposes a comment affordance on the split view lines too', () => {
     render(<DiffViewerPanel />)
     act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
     fireEvent.click(screen.getByText('Split'))
-    expect(screen.queryByTestId('diff-line-comment-btn')).toBeNull()
+    // Each non-empty split cell is commentable: the 2 context lines appear on
+    // both sides (2 buttons each), the deletion + its first paired addition are
+    // one button each, and the standalone second addition adds one more →
+    // 2 + 2 + 1 + 1 + 1 = 7 buttons across the 4 split rows.
+    expect(screen.getAllByTestId('diff-line-comment-btn')).toHaveLength(7)
+  })
+
+  it('queues and submits a comment made in the split view', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+    fireEvent.click(screen.getByText('Split'))
+
+    // Button order follows the split rows: [ctx0-L, ctx0-R, del1-L, add2-R,
+    // add3-R, ctx4-L, ctx4-R]. Index 3 is the addition `const y = 3` (new-file
+    // line 11) on the right side of the second row.
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[3]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'use a const enum' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+
+    // The comment renders full-width below the row and the toolbar exposes the
+    // submit control (still in split view — never toggled back to unified).
+    expect(screen.getByTestId('diff-line-comment-note').textContent).toContain('use a const enum')
+    fireEvent.click(screen.getByTestId('diff-submit-comments-btn'))
+
+    expect(mockSendInput).toHaveBeenCalledTimes(1)
+    const prompt = mockSendInput.mock.calls[0]![0] as string
+    expect(prompt).toContain('review comment')
+    expect(prompt).toContain('src/utils/helper.ts:')
+    expect(prompt).toContain('use a const enum')
+    expect(prompt).toContain('Line 11')
+  })
+
+  it('shows a comment added in unified view when switched to split (shared state)', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    // Add a comment on the addition (index 2) in the default unified view.
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[2]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), {
+      target: { value: 'parity note' },
+    })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+
+    // The same position-keyed comment is present after switching to split.
+    fireEvent.click(screen.getByText('Split'))
+    expect(screen.getByTestId('diff-line-comment-note').textContent).toContain('parity note')
+    // The commented line's cell carries the has-comment accent in split too.
+    expect(document.querySelector('.diff-split-cell-has-comment')).toBeTruthy()
   })
 
   it('opens an inline editor and queues a comment, showing the submit control', () => {

--- a/packages/dashboard/src/components/DiffViewerPanel.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.tsx
@@ -7,11 +7,11 @@
  * - Unified/split view toggle
  * - Auto-refresh on mount, manual refresh button
  * - #6800: per-line inline comments + a one-click "Review code" trigger. A line
- *   in the unified view can be annotated with free text; pending comments across
- *   files are queued and submitted together as the next user turn for the agent
- *   to address (via the normal `input` wire path — no new WS message type). This
- *   is always on (not gated behind features.ide) since it acts on already-written
- *   uncommitted changes, not the pre-write edit surface.
+ *   in either the unified or split view can be annotated with free text; pending
+ *   comments across files are queued and submitted together as the next user
+ *   turn for the agent to address (via the normal `input` wire path — no new WS
+ *   message type). This is always on (not gated behind features.ide) since it
+ *   acts on already-written uncommitted changes, not the pre-write edit surface.
  */
 import { useState, useEffect, useCallback, useRef } from 'react'
 import {
@@ -43,8 +43,8 @@ type LineCommentTarget = {
 }
 
 /**
- * Commenting wiring threaded down to the unified-view lines. Absent for the
- * read-only / split-view / PreWriteDiffReview renders, which stay unchanged.
+ * Commenting wiring threaded down to the diff lines (unified + split). Absent
+ * for the read-only PreWriteDiffReview render, which stays unchanged.
  */
 type CommentApi = {
   comments: DiffLineComment[]
@@ -106,14 +106,37 @@ function UnifiedLine({ line }: { line: DiffHunkLine }) {
   )
 }
 
+/** The gutter "+"/"×" button that opens a line's inline comment editor. */
+function CommentGutterButton({
+  target,
+  hasComment,
+  onOpen,
+}: {
+  target: LineCommentTarget
+  hasComment: boolean
+  onOpen: (target: LineCommentTarget) => void
+}) {
+  return (
+    <button
+      type="button"
+      className="diff-line-comment-btn"
+      onClick={() => onOpen(target)}
+      title={hasComment ? 'Edit comment' : 'Comment on this line'}
+      aria-label={hasComment ? 'Edit comment on this line' : 'Comment on this line'}
+      data-testid="diff-line-comment-btn"
+    >
+      <span aria-hidden="true">{hasComment ? '×' : '+'}</span>
+    </button>
+  )
+}
+
 /**
- * A unified-view line with an inline-comment affordance (#6800). Renders the
- * same content as UnifiedLine plus a gutter "comment" button; when a comment is
- * attached it shows below the line, and clicking the button (or an existing
- * comment) opens the inline editor. Only used when a CommentApi is supplied.
+ * The saved-comment note (with a Remove control) or the open editor for one
+ * line. Shared by the unified `CommentableLine` (rendered inline below the
+ * line) and the split-view row (rendered full-width below the pair), so both
+ * modes present an identical comment surface.
  */
-function CommentableLine({
-  line,
+function CommentBody({
   target,
   hasComment,
   existingText,
@@ -125,7 +148,6 @@ function CommentableLine({
   onCancel,
   onRemove,
 }: {
-  line: DiffHunkLine
   target: LineCommentTarget
   hasComment: boolean
   existingText: string | undefined
@@ -137,30 +159,8 @@ function CommentableLine({
   onCancel: () => void
   onRemove: (key: string) => void
 }) {
-  const cls =
-    line.type === 'addition' ? 'diff-line-add' :
-    line.type === 'deletion' ? 'diff-line-del' :
-    'diff-line-ctx'
-  const prefix = line.type === 'addition' ? '+' : line.type === 'deletion' ? '-' : ' '
   return (
     <>
-      <div
-        className={`diff-line diff-line-commentable ${cls}${hasComment ? ' diff-line-has-comment' : ''}`}
-        data-testid="diff-line"
-      >
-        <button
-          type="button"
-          className="diff-line-comment-btn"
-          onClick={() => onOpen(target)}
-          title={hasComment ? 'Edit comment' : 'Comment on this line'}
-          aria-label={hasComment ? 'Edit comment on this line' : 'Comment on this line'}
-          data-testid="diff-line-comment-btn"
-        >
-          <span aria-hidden="true">{hasComment ? '×' : '+'}</span>
-        </button>
-        <span className="diff-line-prefix">{prefix}</span>
-        <span className="diff-line-content">{line.content}</span>
-      </div>
       {hasComment && !isEditing && (
         <div className="diff-line-comment-note" data-testid="diff-line-comment-note">
           <button
@@ -212,37 +212,205 @@ function CommentableLine({
   )
 }
 
-function SplitLine({ left, right }: { left: DiffHunkLine | null; right: DiffHunkLine | null }) {
+/**
+ * A unified-view line with an inline-comment affordance (#6800). Renders the
+ * same content as UnifiedLine plus a gutter "comment" button; when a comment is
+ * attached it shows below the line, and clicking the button (or an existing
+ * comment) opens the inline editor. Only used when a CommentApi is supplied.
+ */
+function CommentableLine({
+  line,
+  target,
+  hasComment,
+  existingText,
+  isEditing,
+  draft,
+  onOpen,
+  onDraftChange,
+  onSave,
+  onCancel,
+  onRemove,
+}: {
+  line: DiffHunkLine
+  target: LineCommentTarget
+  hasComment: boolean
+  existingText: string | undefined
+  isEditing: boolean
+  draft: string
+  onOpen: (target: LineCommentTarget) => void
+  onDraftChange: (text: string) => void
+  onSave: () => void
+  onCancel: () => void
+  onRemove: (key: string) => void
+}) {
+  const cls =
+    line.type === 'addition' ? 'diff-line-add' :
+    line.type === 'deletion' ? 'diff-line-del' :
+    'diff-line-ctx'
+  const prefix = line.type === 'addition' ? '+' : line.type === 'deletion' ? '-' : ' '
   return (
-    <div className="diff-split-row" data-testid="split-row">
-      <div className={`diff-split-cell ${left ? (left.type === 'deletion' ? 'diff-line-del' : 'diff-line-ctx') : 'diff-line-empty'}`}>
-        {left && <span className="diff-line-content">{left.content}</span>}
+    <>
+      <div
+        className={`diff-line diff-line-commentable ${cls}${hasComment ? ' diff-line-has-comment' : ''}`}
+        data-testid="diff-line"
+      >
+        <CommentGutterButton target={target} hasComment={hasComment} onOpen={onOpen} />
+        <span className="diff-line-prefix">{prefix}</span>
+        <span className="diff-line-content">{line.content}</span>
       </div>
-      <div className={`diff-split-cell ${right ? (right.type === 'addition' ? 'diff-line-add' : 'diff-line-ctx') : 'diff-line-empty'}`}>
-        {right && <span className="diff-line-content">{right.content}</span>}
-      </div>
-    </div>
+      <CommentBody
+        target={target}
+        hasComment={hasComment}
+        existingText={existingText}
+        isEditing={isEditing}
+        draft={draft}
+        onOpen={onOpen}
+        onDraftChange={onDraftChange}
+        onSave={onSave}
+        onCancel={onCancel}
+        onRemove={onRemove}
+      />
+    </>
   )
 }
 
-function buildSplitPairs(lines: DiffHunkLine[]): { left: DiffHunkLine | null; right: DiffHunkLine | null }[] {
-  const pairs: { left: DiffHunkLine | null; right: DiffHunkLine | null }[] = []
+/** One side of a split-view row: the line plus its index in `hunk.lines`. */
+type SplitCell = { line: DiffHunkLine; index: number } | null
+
+/** Comment wiring for the split view — the panel-level API + per-line targets. */
+type SplitCommentApi = { api: CommentApi; targets: LineCommentTarget[] }
+
+/**
+ * One split-view row (#6800 follow-up). Read-only when `comment` is absent —
+ * byte-identical to the original render. With `comment`, each non-empty cell
+ * gets the same gutter button as a unified line, keyed by the cell's underlying
+ * `hunk.lines` index, and any saved comment / open editor renders full-width
+ * below the row. A context line is the same index on both sides, so it shares a
+ * single comment surface; a deletion/addition pair carries one per side.
+ */
+function SplitLine({
+  left,
+  right,
+  comment,
+}: {
+  left: SplitCell
+  right: SplitCell
+  comment?: SplitCommentApi
+}) {
+  const leftLine = left?.line ?? null
+  const rightLine = right?.line ?? null
+
+  const renderCell = (cell: SplitCell, line: DiffHunkLine | null, side: 'left' | 'right') => {
+    const base = line
+      ? side === 'left'
+        ? (line.type === 'deletion' ? 'diff-line-del' : 'diff-line-ctx')
+        : (line.type === 'addition' ? 'diff-line-add' : 'diff-line-ctx')
+      : 'diff-line-empty'
+    if (!comment || !cell) {
+      return (
+        <div className={`diff-split-cell ${base}`}>
+          {line && <span className="diff-line-content">{line.content}</span>}
+        </div>
+      )
+    }
+    const target = comment.targets[cell.index]!
+    const hasComment = comment.api.comments.some((c) => c.id === target.key)
+    return (
+      <div
+        className={`diff-split-cell diff-split-cell-commentable${hasComment ? ' diff-split-cell-has-comment' : ''} ${base}`}
+      >
+        <CommentGutterButton target={target} hasComment={hasComment} onOpen={comment.api.onOpen} />
+        {line && <span className="diff-line-content">{line.content}</span>}
+      </div>
+    )
+  }
+
+  // Distinct underlying line indices in this row: a context line is the same
+  // index on both sides (one comment surface); a deletion/addition pair is two.
+  const indices: number[] = []
+  if (left) indices.push(left.index)
+  if (right && (!left || right.index !== left.index)) indices.push(right.index)
+
+  return (
+    <>
+      <div className="diff-split-row" data-testid="split-row">
+        {renderCell(left, leftLine, 'left')}
+        {renderCell(right, rightLine, 'right')}
+      </div>
+      {comment &&
+        indices.map((idx) => {
+          const target = comment.targets[idx]!
+          const existing = comment.api.comments.find((c) => c.id === target.key)
+          const isEditing = comment.api.editingKey === target.key
+          if (!existing && !isEditing) return null
+          return (
+            <CommentBody
+              key={target.key}
+              target={target}
+              hasComment={!!existing}
+              existingText={existing?.comment}
+              isEditing={isEditing}
+              draft={comment.api.draft}
+              onOpen={comment.api.onOpen}
+              onDraftChange={comment.api.onDraftChange}
+              onSave={comment.api.onSave}
+              onCancel={comment.api.onCancel}
+              onRemove={comment.api.onRemove}
+            />
+          )
+        })}
+    </>
+  )
+}
+
+/**
+ * Build the per-line comment targets for a hunk in a single forward pass over
+ * `hunk.lines`, accumulating the old/new line counters exactly as
+ * deriveLineNumber does (deletions resolve to the old-file line, everything
+ * else to the new-file line). Shared by the unified and split renders so a
+ * comment keyed on line index `i` lands on the same line — with the same
+ * derived line number and comment id — in either mode.
+ */
+function buildLineTargets(hunk: DiffHunk, filePath: string, hunkIndex: number): LineCommentTarget[] {
+  const starts = parseHunkStartLines(hunk.header)
+  let oldLine = starts?.oldStart ?? 0
+  let newLine = starts?.newStart ?? 0
+  return hunk.lines.map((line, i) => {
+    const lineNumber = starts ? (line.type === 'deletion' ? oldLine : newLine) : null
+    if (line.type === 'deletion') oldLine++
+    else if (line.type === 'addition') newLine++
+    else {
+      oldLine++
+      newLine++
+    }
+    return {
+      key: lineKey(filePath, hunkIndex, i),
+      filePath,
+      lineNumber,
+      lineType: line.type,
+      lineContent: line.content,
+    }
+  })
+}
+
+function buildSplitPairs(lines: DiffHunkLine[]): { left: SplitCell; right: SplitCell }[] {
+  const pairs: { left: SplitCell; right: SplitCell }[] = []
   let i = 0
   while (i < lines.length) {
     const line = lines[i]!
     if (line.type === 'context') {
-      pairs.push({ left: line, right: line })
+      pairs.push({ left: { line, index: i }, right: { line, index: i } })
       i++
     } else if (line.type === 'deletion') {
       // Collect consecutive deletions and additions to pair them
-      const dels: DiffHunkLine[] = []
+      const dels: SplitCell[] = []
       while (i < lines.length && lines[i]!.type === 'deletion') {
-        dels.push(lines[i]!)
+        dels.push({ line: lines[i]!, index: i })
         i++
       }
-      const adds: DiffHunkLine[] = []
+      const adds: SplitCell[] = []
       while (i < lines.length && lines[i]!.type === 'addition') {
-        adds.push(lines[i]!)
+        adds.push({ line: lines[i]!, index: i })
         i++
       }
       const max = Math.max(dels.length, adds.length)
@@ -251,7 +419,7 @@ function buildSplitPairs(lines: DiffHunkLine[]): { left: DiffHunkLine | null; ri
       }
     } else {
       // Standalone addition (no preceding deletion)
-      pairs.push({ left: null, right: line })
+      pairs.push({ left: null, right: { line, index: i } })
       i++
     }
   }
@@ -273,7 +441,7 @@ type HunkSelectionProps =
 export type HunkViewProps = {
   hunk: DiffHunk
   viewMode: ViewMode
-  /** #6800: identity + comment wiring for the unified-view inline comments. */
+  /** #6800: identity + comment wiring for the inline comments (unified + split). */
   filePath?: string
   hunkIndex?: number
   commentApi?: CommentApi
@@ -290,9 +458,15 @@ export function HunkView({
   onToggle,
 }: HunkViewProps) {
   const cls = `diff-hunk${selectable ? ` diff-hunk-selectable${selected ? '' : ' diff-hunk-rejected'}` : ''}`
-  // Inline comments only in unified view, and only when a CommentApi + filePath
-  // are supplied. Split view and read-only consumers keep the original render.
-  const commentsOn = viewMode === 'unified' && !!commentApi && filePath != null
+  // Inline comments in BOTH unified and split view, whenever a CommentApi +
+  // filePath are supplied. Read-only consumers (PreWriteDiffReview) pass
+  // neither, so their render is byte-for-byte unchanged.
+  const commentsOn = !!commentApi && filePath != null
+  // #6930: precompute the per-line targets once (single forward pass over
+  // hunk.lines — mirrors deriveLineNumber's logic without the O(n^2) per-line
+  // rescan). Shared by the unified lines and the split cells so a comment keyed
+  // on index `i` resolves to the same line number + id in either mode.
+  const targets = commentsOn ? buildLineTargets(hunk, filePath!, hunkIndex) : null
   return (
     <div className={cls} data-testid="diff-hunk">
       {selectable ? (
@@ -311,55 +485,42 @@ export function HunkView({
         <HunkHeader header={hunk.header} />
       )}
       {viewMode === 'unified' ? (
-        !commentsOn
-          ? hunk.lines.map((line, i) => <UnifiedLine key={i} line={line} />)
-          : (() => {
+        targets
+          ? hunk.lines.map((line, i) => {
               const api = commentApi!
-              // #6930: single forward pass over hunk.lines, accumulating the
-              // old/new line counters as we go — mirrors deriveLineNumber's
-              // logic exactly, but avoids the O(i) rescan that calling
-              // deriveLineNumber(hunk, i) per line would incur (making the
-              // whole hunk render O(n^2)). Rendered line numbers stay
-              // byte-identical to the per-line helper.
-              const starts = parseHunkStartLines(hunk.header)
-              let oldLine = starts?.oldStart ?? 0
-              let newLine = starts?.newStart ?? 0
-              return hunk.lines.map((line, i) => {
-                const lineNumber = starts ? (line.type === 'deletion' ? oldLine : newLine) : null
-                if (line.type === 'deletion') oldLine++
-                else if (line.type === 'addition') newLine++
-                else {
-                  oldLine++
-                  newLine++
-                }
-                const key = lineKey(filePath!, hunkIndex, i)
-                const existing = api.comments.find((c) => c.id === key)
-                return (
-                  <CommentableLine
-                    key={i}
-                    line={line}
-                    target={{
-                      key,
-                      filePath: filePath!,
-                      lineNumber,
-                      lineType: line.type,
-                      lineContent: line.content,
-                    }}
-                    hasComment={!!existing}
-                    existingText={existing?.comment}
-                    isEditing={api.editingKey === key}
-                    draft={api.draft}
-                    onOpen={api.onOpen}
-                    onDraftChange={api.onDraftChange}
-                    onSave={api.onSave}
-                    onCancel={api.onCancel}
-                    onRemove={api.onRemove}
-                  />
-                )
-              })
-            })()
+              const target = targets[i]!
+              const existing = api.comments.find((c) => c.id === target.key)
+              return (
+                <CommentableLine
+                  key={i}
+                  line={line}
+                  target={target}
+                  hasComment={!!existing}
+                  existingText={existing?.comment}
+                  isEditing={api.editingKey === target.key}
+                  draft={api.draft}
+                  onOpen={api.onOpen}
+                  onDraftChange={api.onDraftChange}
+                  onSave={api.onSave}
+                  onCancel={api.onCancel}
+                  onRemove={api.onRemove}
+                />
+              )
+            })
+          : hunk.lines.map((line, i) => <UnifiedLine key={i} line={line} />)
       ) : (
-        buildSplitPairs(hunk.lines).map((pair, i) => <SplitLine key={i} left={pair.left} right={pair.right} />)
+        buildSplitPairs(hunk.lines).map((pair, i) =>
+          targets ? (
+            <SplitLine
+              key={i}
+              left={pair.left}
+              right={pair.right}
+              comment={{ api: commentApi!, targets }}
+            />
+          ) : (
+            <SplitLine key={i} left={pair.left} right={pair.right} />
+          ),
+        )
       )}
     </div>
   )

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9384,6 +9384,30 @@ button.sidebar-token-view-session-row:hover {
   opacity: 0.5;
 }
 
+/* #6800 follow-up: split-view line comments reuse the same gutter button as
+ * the unified line. The cell reserves a left gutter for it and shows the button
+ * on hover / focus, or persistently once the line carries a comment. Saved
+ * notes + the editor render full-width below the row (the CommentBody shares
+ * the .diff-line-comment-note / .diff-line-comment-editor rules above). */
+.diff-split-cell-commentable {
+  position: relative;
+  padding-left: 30px;
+}
+
+.diff-split-cell-commentable .diff-line-comment-btn {
+  left: 6px;
+}
+
+.diff-split-cell-commentable:hover .diff-line-comment-btn,
+.diff-split-cell-has-comment .diff-line-comment-btn,
+.diff-split-cell-commentable .diff-line-comment-btn:focus-visible {
+  opacity: 1;
+}
+
+.diff-split-cell-has-comment {
+  box-shadow: inset 2px 0 0 0 var(--accent-blue);
+}
+
 /* ---- #6800: inline line comments + review triggers ---- */
 /* Toolbar actions: "Submit N comments" + "Review code". */
 .diff-submit-btn,


### PR DESCRIPTION
Follow-up to #6930 (issue #6800, already closed by that PR). Ships the two out-of-scope polish items that were deferred there. Both are additive — the core feature and its unit/render tests landed in #6930.

## 1. Dashboard split-view line comments

`DiffViewerPanel` wired inline comments to the **unified** view only; the split view stayed read-only. This extends the affordance to split view by sharing the wiring rather than duplicating it:

- Drop the `viewMode === 'unified'` gate — `commentsOn` now applies to both renders whenever a `CommentApi` + `filePath` are supplied.
- Extract `CommentGutterButton` (the `+`/`×` button) and `CommentBody` (note + editor) so unified lines and split rows present an **identical** comment surface.
- `buildLineTargets()` — the single forward pass deriving per-line numbers + stable comment ids — is computed once in `HunkView` and shared by both branches, so a comment keyed on a line index resolves to the same line + id in either mode (comment in unified, see it in split, and vice-versa).
- `buildSplitPairs` / `SplitLine` carry each cell's underlying `hunk.lines` index. Each non-empty split cell gets a gutter button (a context line shares one comment across both sides; a deletion/addition pair gets one per side); saved notes / the editor render full-width below the row.
- Reuses the existing panel-level comment state and the shared `composeCommentReviewPrompt` helper from `@chroxy/store-core` — no new state, no wire changes. Scoped CSS uses design tokens only.

**Tests** (`DiffViewerPanel.test.tsx`): replaced the old "no buttons in split view" case with three — buttons render on split lines, a comment made *in split view* submits the composed prompt, and a unified-view comment appears after switching to split (shared-state parity).

## 2. Mobile diff-comment Maestro flow

- `mock-server.mjs`: added a `get_diff` handler returning a canned `diff_result` (validated against `isDiffFile`; line numbers chosen so the composed prompt is byte-identical to the dashboard fixture).
- `diff-comment.yaml`: opens the Changes viewer → taps the file → `diff-line-2` → types in `diff-comment-input` → `diff-comment-save` → `diff-submit-comments`, then asserts the composed prompt lands in chat. Registered as Flow 23 in `run-all.yaml`.
- Bumped the run-all flow count (22 → 23) in `CLAUDE.md`; regenerated `AGENTS.md`.

## Verification

- Full dashboard vitest suite: **4721 passed**; dashboard typecheck clean.
- Read-only `HunkView` / `PreWriteDiffReview` consumers unchanged (byte-for-byte render preserved) — their suites pass.
- Maestro flow validated statically (mock-server syntax, YAML parse, `isDiffFile` shape) and the exact composed prompt verified against the real `composeCommentReviewPrompt`. Executing the flow itself requires the device harness (booted simulator + chroxy dev client + mock server on :9876) and runs in the nightly Maestro gate.

Related to #6800, #6930.