### PR TITLE
refactor(server): single-source the open(2)-faithful component-wise resolver

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,8 +1,9 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import { realpathSync, lstatSync, readlinkSync } from 'node:fs'
-import { resolve, relative, sep, isAbsolute, dirname, basename, join, parse } from 'node:path'
+import { realpathSync } from 'node:fs'
+import { resolve, relative, sep, isAbsolute, dirname, basename, join } from 'node:path'
 import { createLogger } from './logger.js'
+import { resolveTargetComponentwiseSync } from './utils/componentwise-resolver.js'
 // #6038: the SDK/TUI permission path broadcasts to clients too, so it must apply
 // the same redaction as the hook path. Shared sanitizer + value redactor live in
 // redaction.js (a leaf module — no import cycle / HTTP-handler weight).
@@ -239,11 +240,6 @@ export function buildDenyMessage(reason) {
 // under a symlinked parent), which FAILS CLOSED rather than trust a lexical guess.
 const _FLOOR_REALPATH_MAX_DEPTH = 256
 
-// #6921 — symlink-expansion cap for the component-wise resolver below, matching
-// the kernel's typical MAXSYMLINKS (40). A chain deeper than this — or a cycle —
-// throws ELOOP, which the floor's `catch` treats as PROTECTED (fail closed).
-const _FLOOR_MAX_SYMLINKS = 40
-
 /**
  * #6851 — SYNC deepest-existing-ancestor realpath: the symlink-resolving core of
  * the floor's #6851 hardening, and the synchronous sibling of
@@ -298,110 +294,13 @@ function realpathDeepestAncestorSync(absPath) {
   throw Object.assign(new Error(`realpathDeepestAncestorSync: path depth exceeds ${_FLOOR_REALPATH_MAX_DEPTH}`), { code: 'ENAMETOOLONG' })
 }
 
-// #6928 — split a raw path into the components BELOW its parsed root, separating
-// on BOTH `/` and `\` regardless of platform. Node accepts forward slashes on
-// Windows, so a platform-`sep`-only split (`\` on Windows) would leave a
-// forward-slash path as ONE component — the component walk would then break and
-// fall back to a lexical `join()`, reopening the exact `..`-after-symlink escape
-// this resolver exists to close. `root` (already parsed by the caller, which
-// starts `resolved` there) is sliced off first so a drive/UNC/`/` root is never
-// walked as an ordinary component (a Windows `C:\` would otherwise appear as a
-// `C:` component and `join` straight back onto the drive root).
-function splitPathBelowRoot(p, root) {
-  return (root ? p.slice(root.length) : p).split(/[/\\]+/)
-}
-
-/**
- * #6921 — resolve `target` against a REAL base by walking it COMPONENT BY
- * COMPONENT, mirroring the kernel's `open(2)` path traversal. This is the crux
- * of the #6921 hardening: it replaces the `realpath(resolve(base, target))`
- * shape (#6851, {@link realpathDeepestAncestorSync}), which could NOT catch a
- * `..` that follows a SYMLINKED component — because BOTH `path.resolve()` AND
- * Node's `fs.realpathSync` collapse `..` LEXICALLY (textually) before/instead of
- * following symlinks. `realpathSync('link/..')` yields the symlink's LEXICAL
- * parent; `open(2)` follows `link` to its TARGET and applies `..` from THERE. So
- * `work/agent-x/../../settings.local.json` (with `work -> .claude/worktrees`)
- * lexically cancels to a benign `settings.local.json`, but really lands on
- * `.claude/settings.local.json`. Only a component walk that applies `..` AFTER
- * resolving symlinks-so-far (as the kernel does) sees the real destination.
- *
- * The walk starts from `realBase` (the session cwd already resolved to its real
- * path) for a relative target, or from the filesystem root for an absolute
- * target, and for each remaining component:
- *   - `''` / `.`      → skip.
- *   - `..`            → pop to the PARENT of the resolved-so-far real path
- *                       (`dirname`), i.e. apply `..` AFTER following symlinks so
- *                       far — NOT lexically on the pre-resolution path.
- *   - a SYMLINK       → `readlinkSync` it; if the link is absolute, reset the
- *                       resolved path to the fs root; splice the link's own
- *                       components into the walk at the current position and keep
- *                       going (so a relative link resolves from the symlink's
- *                       parent, and any `..` inside the link is honoured too).
- *                       Bounded by {@link _FLOOR_MAX_SYMLINKS} — a deeper chain or
- *                       a cycle THROWS `ELOOP` (→ fail closed).
- *   - a NON-symlink   → append it.
- *   - a NON-EXISTENT tail component (`ENOENT` on the `lstat`) → stop filesystem
- *                       resolution (nothing deeper can exist, so nothing deeper
- *                       can be a symlink) and apply the REMAINING components —
- *                       INCLUDING any `..` — against the resolved-so-far real
- *                       path by the same pop/append rules. This models a
- *                       to-be-created file: a `..` in the tail still pops the
- *                       RESOLVED real path, never the unresolved lexical one. (A
- *                       real write of a path whose intermediate dir is missing
- *                       fails anyway, so not following a later symlink after the
- *                       first ENOENT can't hide a write that would actually land.)
- *
- * A non-ENOENT `lstat`/`readlink` error (EACCES, ELOOP) propagates so the
- * caller's `catch` fails closed. Returns the fully resolved absolute real path.
- * @param {string} realBase  the session cwd, already resolved to its real path
- * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path value
- * @returns {string} the open(2)-faithful resolved absolute real path
- */
-function resolveTargetComponentwiseSync(realBase, target) {
-  // Absolute target ignores the base (as `open`/`resolve` do); start at its
-  // parsed root so its own leading components are walked (and symlink-resolved)
-  // too. A relative target (empty root) starts at the base. The root is stripped
-  // BEFORE splitting so it is never re-walked as an ordinary component (#6928).
-  const targetRoot = isAbsolute(target) ? parse(target).root : ''
-  let resolved = targetRoot || realBase
-  const pending = splitPathBelowRoot(target, targetRoot)
-  let symlinks = 0
-  // Once a component doesn't exist, the rest is a to-be-created tail: no deeper
-  // component can be a symlink, so stop lstat-ing and apply pop/append only.
-  let tailOnly = false
-  let i = 0
-  while (i < pending.length) {
-    const comp = pending[i]
-    i++
-    if (comp === '' || comp === '.') continue
-    if (comp === '..') { resolved = dirname(resolved); continue }
-    const candidate = join(resolved, comp)
-    if (tailOnly) { resolved = candidate; continue }
-    let st
-    try {
-      st = lstatSync(candidate)
-    } catch (err) {
-      if (err.code === 'ENOENT') { tailOnly = true; resolved = candidate; continue }
-      throw err // EACCES etc. — fail closed via the caller's catch
-    }
-    if (st.isSymbolicLink()) {
-      if (++symlinks > _FLOOR_MAX_SYMLINKS) {
-        throw Object.assign(new Error(`resolveTargetComponentwiseSync: symlink depth exceeds ${_FLOOR_MAX_SYMLINKS}`), { code: 'ELOOP' })
-      }
-      const link = readlinkSync(candidate)
-      // An absolute link restarts resolution from its parsed root; a relative
-      // link resolves from the symlink's PARENT (`resolved`, since `comp` was not
-      // appended). Splice the link's components (below its root) in at the cursor
-      // so they — and any `..` they contain — are walked next, before the tail.
-      const linkRoot = isAbsolute(link) ? parse(link).root : ''
-      if (linkRoot) resolved = linkRoot
-      pending.splice(i, 0, ...splitPathBelowRoot(link, linkRoot))
-    } else {
-      resolved = candidate
-    }
-  }
-  return resolved
-}
+// #6921/#6928 — the SYNC open(2)-faithful component-wise resolver (the crux of the
+// #6921 floor hardening: it applies `..` AFTER following each symlink, unlike the
+// lexical `realpath(resolve(base, target))` shape it replaced) now lives in
+// `utils/componentwise-resolver.js`, the SINGLE SOURCE shared with the async BYOK
+// confinement path (`ws-file-ops/common.js`). Co-locating the two open(2)-faithful
+// walks is what keeps them from drifting again — #6928 was a bug present in BOTH
+// copies. Imported as `resolveTargetComponentwiseSync` at the top of this file.
 
 /**
  * #6851 — the pure segment scan, factored out of {@link isProtectedPathValue} so

--- a/packages/server/src/utils/componentwise-resolver.js
+++ b/packages/server/src/utils/componentwise-resolver.js
@@ -1,0 +1,205 @@
+import { lstatSync, readlinkSync } from 'node:fs'
+import { lstat, readlink } from 'node:fs/promises'
+import { dirname, isAbsolute, join, parse } from 'node:path'
+
+/**
+ * open(2)-faithful, component-by-component path resolver — the SINGLE SOURCE for
+ * both security floors that need it:
+ *   - the SYNCHRONOUS protected-path floor (`permission-manager.js`, #6921), which
+ *     runs inside the sync `handlePermission` hot-path and cannot await; and
+ *   - the ASYNC BYOK file-ops confinement (`ws-file-ops/common.js`, #6923), which
+ *     walks a raw tool-supplied path before a subprocess write.
+ *
+ * Both were introduced as near-identical twins (a sync copy and an async copy) and
+ * PROMPTLY DRIFTED: #6928 was a bug present in BOTH — a `target.split(path.sep)`
+ * that, on Windows, left a forward-slash path as ONE component and fell back to a
+ * lexical `join()`, reopening the exact `..`-after-symlink escape the walk exists to
+ * close. It had to be patched in two places. This module exists so the drift-prone
+ * logic — the separator-agnostic split, the per-component lexical classification,
+ * and the symlink splice — lives ONCE; the sync and async entry points are thin fs
+ * drivers over that shared core, and `componentwise-resolver.test.js` pins them to
+ * IDENTICAL results across a battery of on-disk topologies so they cannot diverge
+ * again.
+ *
+ * ---------------------------------------------------------------------------------
+ * WHY A COMPONENT WALK (and not `realpath(resolve(base, target))`):
+ *
+ * BOTH `path.resolve()` AND Node's `fs.realpath` collapse `..` LEXICALLY — textually,
+ * before/instead of following symlinks. `realpath('link/..')` yields the symlink's
+ * LEXICAL parent; `open(2)` follows `link` to its TARGET and applies `..` from THERE.
+ * So `work/agent-x/../../settings.local.json` (with `work -> .claude/worktrees`)
+ * lexically cancels to a benign in-cwd `settings.local.json`, but a raw write really
+ * lands on `.claude/settings.local.json`. Only a walk that applies `..` AFTER
+ * resolving the symlinks so far — as the kernel does — sees the true destination.
+ * ---------------------------------------------------------------------------------
+ */
+
+// #6921/#6923 — symlink-expansion cap, matching the kernel's typical MAXSYMLINKS.
+// A chain deeper than this — or a cycle — THROWS `ELOOP`, which every caller's
+// `catch` treats as protected / rejected (fail closed).
+export const COMPONENTWISE_MAX_SYMLINKS = 40
+
+/**
+ * #6928 — split a raw path into the components BELOW its parsed root, separating on
+ * BOTH `/` and `\` regardless of platform. Node accepts forward slashes on Windows,
+ * so a platform-`sep`-only split (`\` on Windows) would leave a forward-slash path
+ * as ONE component — the walk would then break and fall back to a lexical `join()`,
+ * reopening the exact `..`-after-symlink escape this resolver exists to close.
+ * `root` (already parsed by the caller, which starts `resolved` there) is sliced off
+ * first so a drive/UNC/`/` root is never walked as an ordinary component (a Windows
+ * `C:\` would otherwise appear as a `C:` component and `join` straight back onto the
+ * drive root).
+ * @param {string} p
+ * @param {string} root  the already-`parse`d root of `p` (`''` for a relative path)
+ * @returns {string[]}
+ */
+export function splitPathBelowRoot(p, root) {
+  return (root ? p.slice(root.length) : p).split(/[/\\]+/)
+}
+
+/**
+ * Pure: initialise the walk. An absolute target ignores the base (as `open`/`resolve`
+ * do) and starts at its parsed root so its own leading components are walked (and
+ * symlink-resolved) too; a relative target (empty root) starts at `realBase`. The
+ * root is stripped BEFORE splitting so it is never re-walked as an ordinary
+ * component (#6928).
+ * @param {string} realBase  the session cwd, already resolved to its real path
+ * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path
+ * @returns {{ resolved: string, pending: string[] }}
+ */
+function beginWalk(realBase, target) {
+  const targetRoot = isAbsolute(target) ? parse(target).root : ''
+  return { resolved: targetRoot || realBase, pending: splitPathBelowRoot(target, targetRoot) }
+}
+
+/**
+ * Pure: resolve a single component AS FAR AS POSSIBLE without touching the
+ * filesystem. This is the ordering that must never drift between the sync and async
+ * drivers, so it lives here exactly once:
+ *   - `''` / `.`  → skip (resolved unchanged, no stat).
+ *   - `..`        → pop to the PARENT of the resolved-so-far real path (`dirname`),
+ *                   i.e. apply `..` AFTER following symlinks so far — NOT lexically
+ *                   on the pre-resolution path. No stat.
+ *   - tail-only   → once a component was ENOENT, everything after it is a
+ *                   to-be-created tail: append by `join` with no stat.
+ *   - otherwise   → return the `candidate` to lstat; `resolved` is left UNCHANGED
+ *                   (it is committed only after the driver confirms `candidate` is
+ *                   not a symlink).
+ * @param {string} resolved   resolved-so-far real path
+ * @param {string} comp       the raw component
+ * @param {boolean} tailOnly  true once a prior component was ENOENT
+ * @returns {{ resolved: string, stat: string|null }}  `stat` is the path to lstat,
+ *   or `null` when the component was fully consumed lexically (skip / `..` / tail).
+ */
+function resolveComponentLexically(resolved, comp, tailOnly) {
+  if (comp === '' || comp === '.') return { resolved, stat: null }
+  if (comp === '..') return { resolved: dirname(resolved), stat: null }
+  const candidate = join(resolved, comp)
+  if (tailOnly) return { resolved: candidate, stat: null }
+  return { resolved, stat: candidate }
+}
+
+/**
+ * Pure: a symlink was found at the cursor. Splice the link's own components (below
+ * its root) into `pending` AT the cursor so they — and any `..` they contain — are
+ * walked next, before the tail. Returns the resolved base to continue from: an
+ * ABSOLUTE link restarts resolution from its parsed root; a RELATIVE link continues
+ * from the symlink's PARENT (`resolved`, since the symlink component itself was not
+ * appended). Mutates `pending`.
+ * @param {string[]} pending
+ * @param {number} i         cursor (index of the NEXT component to walk)
+ * @param {string} resolved  resolved-so-far real path (the symlink's parent)
+ * @param {string} link      the raw `readlink` target
+ * @returns {string}
+ */
+function spliceSymlink(pending, i, resolved, link) {
+  const linkRoot = isAbsolute(link) ? parse(link).root : ''
+  pending.splice(i, 0, ...splitPathBelowRoot(link, linkRoot))
+  return linkRoot || resolved
+}
+
+function symlinkBudgetError(fnName) {
+  return Object.assign(
+    new Error(`${fnName}: symlink depth exceeds ${COMPONENTWISE_MAX_SYMLINKS}`),
+    { code: 'ELOOP' },
+  )
+}
+
+/**
+ * #6921 — SYNC open(2)-faithful resolver (protected-path floor hot-path). A thin
+ * `lstatSync`/`readlinkSync` driver over the shared core above. A non-ENOENT
+ * `lstat`/`readlink` error (EACCES, ELOOP) PROPAGATES so the caller's `catch` fails
+ * closed; ENOENT stops filesystem resolution (nothing deeper can be a symlink) and
+ * the remaining tail — INCLUDING any `..` — is applied against the resolved-so-far
+ * REAL path by the same pop/append rules.
+ * @param {string} realBase  the session cwd, already resolved to its real path
+ * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path
+ * @returns {string} the open(2)-faithful resolved absolute real path
+ */
+export function resolveTargetComponentwiseSync(realBase, target) {
+  const { resolved: base, pending } = beginWalk(realBase, target)
+  let resolved = base
+  let symlinks = 0
+  let tailOnly = false
+  let i = 0
+  while (i < pending.length) {
+    const comp = pending[i]
+    i++
+    const step = resolveComponentLexically(resolved, comp, tailOnly)
+    resolved = step.resolved
+    if (step.stat === null) continue
+    let st
+    try {
+      st = lstatSync(step.stat)
+    } catch (err) {
+      if (err.code === 'ENOENT') { tailOnly = true; resolved = step.stat; continue }
+      throw err // EACCES etc. — fail closed via the caller's catch
+    }
+    if (st.isSymbolicLink()) {
+      if (++symlinks > COMPONENTWISE_MAX_SYMLINKS) throw symlinkBudgetError('resolveTargetComponentwiseSync')
+      resolved = spliceSymlink(pending, i, resolved, readlinkSync(step.stat))
+    } else {
+      resolved = step.stat
+    }
+  }
+  return resolved
+}
+
+/**
+ * #6923 — ASYNC open(2)-faithful resolver (BYOK file-ops confinement). The async
+ * sibling of {@link resolveTargetComponentwiseSync} over the SAME shared core, so
+ * the two cannot diverge (pinned by `componentwise-resolver.test.js`). Same
+ * fail-closed contract: EACCES/ELOOP propagate; ENOENT applies the remaining tail
+ * (including `..`) by pop/append.
+ * @param {string} realBase  the session cwd, already resolved to its real path
+ * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path
+ * @returns {Promise<string>} the open(2)-faithful resolved absolute real path
+ */
+export async function resolveTargetComponentwiseAsync(realBase, target) {
+  const { resolved: base, pending } = beginWalk(realBase, target)
+  let resolved = base
+  let symlinks = 0
+  let tailOnly = false
+  let i = 0
+  while (i < pending.length) {
+    const comp = pending[i]
+    i++
+    const step = resolveComponentLexically(resolved, comp, tailOnly)
+    resolved = step.resolved
+    if (step.stat === null) continue
+    let st
+    try {
+      st = await lstat(step.stat)
+    } catch (err) {
+      if (err.code === 'ENOENT') { tailOnly = true; resolved = step.stat; continue }
+      throw err // EACCES etc. — fail closed via the caller
+    }
+    if (st.isSymbolicLink()) {
+      if (++symlinks > COMPONENTWISE_MAX_SYMLINKS) throw symlinkBudgetError('resolveTargetComponentwiseAsync')
+      resolved = spliceSymlink(pending, i, resolved, await readlink(step.stat))
+    } else {
+      resolved = step.stat
+    }
+  }
+  return resolved
+}

--- a/packages/server/src/ws-file-ops/common.js
+++ b/packages/server/src/ws-file-ops/common.js
@@ -1,5 +1,6 @@
-import { realpath, lstat, readlink } from 'fs/promises'
-import { resolve, dirname, basename, join, isAbsolute, parse, sep } from 'path'
+import { realpath } from 'fs/promises'
+import { resolve, dirname, basename, join, isAbsolute, sep } from 'path'
+import { resolveTargetComponentwiseAsync } from '../utils/componentwise-resolver.js'
 
 /**
  * Shared utilities for file operations: CWD resolution, path validation, exec helpers.
@@ -119,114 +120,13 @@ export async function realpathOfDeepestAncestor(absPath) {
   )
 }
 
-// #6923 — symlink-expansion cap for the async component-wise resolver below,
-// matching the kernel's typical MAXSYMLINKS (40) and the sync floor's
-// _FLOOR_MAX_SYMLINKS in permission-manager.js. A chain deeper than this — or a
-// cycle — throws ELOOP, which the raw-path validator's caller treats as a reject
-// (fail closed).
-const _COMPONENTWISE_MAX_SYMLINKS = 40
-
-// #6928 — split a raw path into the components BELOW its parsed root, separating
-// on BOTH `/` and `\` regardless of platform. Node accepts forward slashes on
-// Windows, so a platform-`sep`-only split (`\` on Windows) would leave a
-// forward-slash path as ONE component — the component walk would then break and
-// fall back to a lexical `join()`, reopening the exact `..`-after-symlink escape
-// this resolver exists to close. `root` (already parsed by the caller, which
-// starts `resolved` there) is sliced off first so a drive/UNC/`/` root is never
-// walked as an ordinary component (a Windows `C:\` would otherwise appear as a
-// `C:` component and `join` straight back onto the drive root).
-function splitPathBelowRoot(p, root) {
-  return (root ? p.slice(root.length) : p).split(/[/\\]+/)
-}
-
-/**
- * #6923 — resolve `target` against a REAL base by walking it COMPONENT BY
- * COMPONENT, mirroring the kernel's `open(2)` path traversal. This is the ASYNC
- * sibling of `resolveTargetComponentwiseSync` in `permission-manager.js` (#6921),
- * and the replacement — on the BYOK confinement path — for the
- * `realpathOfDeepestAncestor(resolve(base, target))` shape above, which could NOT
- * honour a `..` that FOLLOWS a symlinked component: BOTH `path.resolve()` (in the
- * caller) AND Node's `realpath` collapse `..` LEXICALLY, so `link/..` cancels the
- * symlink textually before it is ever followed, whereas `open(2)` follows `link`
- * to its TARGET and applies `..` from THERE. So `work/agent-x/../../x` (with
- * `work -> .claude/worktrees`) lexically cancels to a benign in-cwd `x`, but
- * really lands on `.claude/x`. Only a component walk that applies `..` AFTER
- * resolving symlinks-so-far (as the kernel does) sees the real destination.
- *
- * The walk starts from `realBase` (the session cwd already resolved to its real
- * path) for a relative target, or from the filesystem root for an absolute
- * target, and for each remaining component:
- *   - `''` / `.`      → skip.
- *   - `..`            → pop to the PARENT of the resolved-so-far real path
- *                       (`dirname`), i.e. apply `..` AFTER following symlinks so
- *                       far — NOT lexically on the pre-resolution path.
- *   - a SYMLINK       → `readlink` it; if the link is absolute, reset the resolved
- *                       path to the fs root; splice the link's own components into
- *                       the walk at the current position and keep going (so a
- *                       relative link resolves from the symlink's parent, and any
- *                       `..` inside the link is honoured too). Bounded by
- *                       {@link _COMPONENTWISE_MAX_SYMLINKS} — a deeper chain or a
- *                       cycle THROWS `ELOOP` (→ fail closed).
- *   - a NON-symlink   → append it.
- *   - a NON-EXISTENT tail component (`ENOENT` on the `lstat`) → stop filesystem
- *                       resolution (nothing deeper can exist, so nothing deeper
- *                       can be a symlink) and apply the REMAINING components —
- *                       INCLUDING any `..` — against the resolved-so-far real path
- *                       by the same pop/append rules. Models a to-be-created file:
- *                       a `..` in the tail still pops the RESOLVED real path, never
- *                       the unresolved lexical one.
- *
- * A non-ENOENT `lstat`/`readlink` error (EACCES, ELOOP) propagates so the caller
- * fails closed. Returns the fully resolved absolute real path.
- * @param {string} realBase  the session cwd, already resolved to its real path
- * @param {string} target    a raw (NOT pre-`resolve`d — its `..` must survive) path value
- * @returns {Promise<string>} the open(2)-faithful resolved absolute real path
- */
-export async function resolveTargetComponentwiseAsync(realBase, target) {
-  // Absolute target ignores the base (as `open`/`resolve` do); start at its
-  // parsed root so its own leading components are walked (and symlink-resolved)
-  // too. A relative target (empty root) starts at the base. The root is stripped
-  // BEFORE splitting so it is never re-walked as an ordinary component (#6928).
-  const targetRoot = isAbsolute(target) ? parse(target).root : ''
-  let resolved = targetRoot || realBase
-  const pending = splitPathBelowRoot(target, targetRoot)
-  let symlinks = 0
-  // Once a component doesn't exist, the rest is a to-be-created tail: no deeper
-  // component can be a symlink, so stop lstat-ing and apply pop/append only.
-  let tailOnly = false
-  let i = 0
-  while (i < pending.length) {
-    const comp = pending[i]
-    i++
-    if (comp === '' || comp === '.') continue
-    if (comp === '..') { resolved = dirname(resolved); continue }
-    const candidate = join(resolved, comp)
-    if (tailOnly) { resolved = candidate; continue }
-    let st
-    try {
-      st = await lstat(candidate)
-    } catch (err) {
-      if (err.code === 'ENOENT') { tailOnly = true; resolved = candidate; continue }
-      throw err // EACCES etc. — fail closed via the caller
-    }
-    if (st.isSymbolicLink()) {
-      if (++symlinks > _COMPONENTWISE_MAX_SYMLINKS) {
-        throw Object.assign(new Error(`resolveTargetComponentwiseAsync: symlink depth exceeds ${_COMPONENTWISE_MAX_SYMLINKS}`), { code: 'ELOOP' })
-      }
-      const link = await readlink(candidate)
-      // An absolute link restarts resolution from its parsed root; a relative
-      // link resolves from the symlink's PARENT (`resolved`, since `comp` was not
-      // appended). Splice the link's components (below its root) in at the cursor
-      // so they — and any `..` they contain — are walked next, before the tail.
-      const linkRoot = isAbsolute(link) ? parse(link).root : ''
-      if (linkRoot) resolved = linkRoot
-      pending.splice(i, 0, ...splitPathBelowRoot(link, linkRoot))
-    } else {
-      resolved = candidate
-    }
-  }
-  return resolved
-}
+// #6923/#6928 — the async component-wise resolver (and its separator-agnostic
+// split + MAXSYMLINKS cap) moved to `utils/componentwise-resolver.js`, the SINGLE
+// SOURCE shared with the sync protected-path floor (`permission-manager.js`), so
+// the two open(2)-faithful walks can no longer drift (#6928 was a bug present in
+// BOTH copies). Re-exported here so existing importers of the async resolver from
+// this module keep working.
+export { resolveTargetComponentwiseAsync }
 
 /**
  * #6923 — validate that a RAW (un-`resolve`d) target stays within the session

--- a/packages/server/tests/componentwise-resolver.test.js
+++ b/packages/server/tests/componentwise-resolver.test.js
@@ -1,0 +1,157 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  resolveTargetComponentwiseSync,
+  resolveTargetComponentwiseAsync,
+  splitPathBelowRoot,
+  COMPONENTWISE_MAX_SYMLINKS,
+} from '../src/utils/componentwise-resolver.js'
+
+/**
+ * #6923/#6928 — the SYNC (protected-path floor) and ASYNC (BYOK confinement)
+ * open(2)-faithful resolvers were extracted into one shared module so they can no
+ * longer drift (they were introduced as twins and #6928 was a bug present in BOTH).
+ * This suite is the DRIFT TRIPWIRE: every case runs the SAME on-disk topology
+ * through BOTH entry points and asserts they return the IDENTICAL result (and throw
+ * the IDENTICAL error code). If a future edit changes one variant's ordering /
+ * fail-closed behaviour but not the other, `assertParity` / `assertBothThrow` fail.
+ */
+describe('componentwise-resolver: sync ≡ async parity (#6923/#6928)', () => {
+  let root
+  beforeEach(() => {
+    // realpath so the temp root has no symlink prefix of its own (macOS
+    // /tmp -> /private/tmp) that would perturb the equality assertions.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'chroxy-cw-resolver-')))
+  })
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true })
+  })
+
+  // Run a (base, target) through both resolvers; assert they agree, and (if given)
+  // that they resolve to `expected`. Returns the shared resolved value.
+  async function assertParity(base, target, expected) {
+    const s = resolveTargetComponentwiseSync(base, target)
+    const a = await resolveTargetComponentwiseAsync(base, target)
+    assert.equal(s, a, `sync and async must resolve IDENTICALLY for target=${JSON.stringify(target)}`)
+    if (expected !== undefined) assert.equal(s, expected, `resolved value for target=${JSON.stringify(target)}`)
+    return s
+  }
+
+  // Assert both resolvers fail closed with the same error code.
+  async function assertBothThrow(base, target, code) {
+    assert.throws(() => resolveTargetComponentwiseSync(base, target), (e) => e.code === code, `sync must throw ${code} for ${target}`)
+    await assert.rejects(resolveTargetComponentwiseAsync(base, target), (e) => e.code === code, `async must throw ${code} for ${target}`)
+  }
+
+  it('ordinary relative new-file target', async () => {
+    mkdirSync(join(root, 'src'), { recursive: true })
+    await assertParity(root, 'src/new.txt', join(root, 'src/new.txt'))
+  })
+
+  it('applies `..` AFTER following a symlink (the open(2) crux)', async () => {
+    // link -> real/deep ; link/../sibling: follow link, `..` -> real, -> real/sibling
+    mkdirSync(join(root, 'real/deep'), { recursive: true })
+    symlinkSync(join(root, 'real/deep'), join(root, 'link'))
+    await assertParity(root, 'link/../sibling', join(root, 'real/sibling'))
+  })
+
+  it('classic symlinked-parent escape resolves OUT of the base (both agree)', async () => {
+    const outside = realpathSync(mkdtempSync(join(tmpdir(), 'chroxy-cw-outside-')))
+    try {
+      symlinkSync(outside, join(root, '.venv')) // .venv -> /outside
+      const resolved = await assertParity(root, '.venv/bin/evil.sh')
+      assert.ok(resolved.startsWith(outside + '/'), 'both chase the symlink to the outside location')
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('benign `link/..` that lands back inside the base', async () => {
+    mkdirSync(join(root, 'safe/other'), { recursive: true })
+    symlinkSync(join(root, 'safe/other'), join(root, 'safe/inner'))
+    await assertParity(join(root, 'safe'), 'inner/../file.js', join(root, 'safe/file.js'))
+  })
+
+  it('absolute target ignores the base and walks from the fs root', async () => {
+    mkdirSync(join(root, 'a/b'), { recursive: true })
+    await assertParity(join(root, 'unrelated'), join(root, 'a/b/c.txt'), join(root, 'a/b/c.txt'))
+  })
+
+  it('`..` in a to-be-created tail pops the RESOLVED real path', async () => {
+    // link -> real ; link/nonexistent/../file: follow link -> real, then the tail
+    // (nonexistent, .., file) applies pop/append against `real` -> real/file
+    mkdirSync(join(root, 'real'), { recursive: true })
+    symlinkSync(join(root, 'real'), join(root, 'link'))
+    await assertParity(root, 'link/nonexistent/../file', join(root, 'real/file'))
+  })
+
+  // #6928 — separator-agnostic split: `\` and mixed separators must resolve exactly
+  // like the forward-slash form (a POSIX `sep='/'` split would treat these as one
+  // blob and fall back to a lexical join, reopening the `..`-after-symlink escape).
+  it('#6928: backslash and mixed separators resolve identically to `/` (both agree)', async () => {
+    mkdirSync(join(root, 'real/deep'), { recursive: true })
+    symlinkSync(join(root, 'real/deep'), join(root, 'link'))
+    const forms = [
+      'link/../sibling',       // POSIX
+      'link\\..\\sibling',     // all backslash
+      'link/..\\sibling',      // mixed
+    ]
+    for (const f of forms) {
+      await assertParity(root, f, join(root, 'real/sibling'))
+    }
+  })
+
+  it('#6928: a rooted target strips its root; `..` at the fs root is a no-op', async () => {
+    await assertParity(root, '/../..', '/')
+  })
+
+  // ==========================================================================
+  // Fail-closed parity — both variants must throw the SAME code, never a guess.
+  // ==========================================================================
+  it('symlink cycle → both throw ELOOP', async () => {
+    symlinkSync(join(root, 'b'), join(root, 'a')) // a -> b
+    symlinkSync(join(root, 'a'), join(root, 'b')) // b -> a
+    await assertBothThrow(root, 'a/x', 'ELOOP')
+  })
+
+  it(`a chain longer than COMPONENTWISE_MAX_SYMLINKS (${COMPONENTWISE_MAX_SYMLINKS}) → both throw ELOOP`, async () => {
+    // s0 -> s1 -> s2 -> ... -> s(N+1) (a straight chain past the cap; every hop is
+    // a distinct symlink so it never cycles, it just exceeds the budget).
+    const N = COMPONENTWISE_MAX_SYMLINKS + 1
+    for (let k = 0; k <= N; k++) {
+      symlinkSync(join(root, `s${k + 1}`), join(root, `s${k}`))
+    }
+    await assertBothThrow(root, 's0', 'ELOOP')
+  })
+
+  it('EACCES on an unreadable directory propagates from both (fail closed)', async (t) => {
+    if (process.getuid && process.getuid() === 0) {
+      t.skip('root bypasses directory permission bits')
+      return
+    }
+    // A symlink INTO a chmod-000 dir: resolving it must lstat inside the locked
+    // dir, which EACCESes — and neither variant may swallow it into an allow.
+    mkdirSync(join(root, 'locked'), { recursive: true })
+    symlinkSync(join(root, 'locked/inner'), join(root, 'gate')) // gate -> locked/inner
+    const { chmodSync } = await import('node:fs')
+    chmodSync(join(root, 'locked'), 0o000)
+    try {
+      await assertBothThrow(root, 'gate/x', 'EACCES')
+    } finally {
+      chmodSync(join(root, 'locked'), 0o755) // restore so afterEach rm can clean up
+    }
+  })
+
+  // ==========================================================================
+  // splitPathBelowRoot — the #6928 footgun in isolation.
+  // ==========================================================================
+  it('splitPathBelowRoot splits on BOTH separators and strips the root', () => {
+    assert.deepEqual(splitPathBelowRoot('a/b\\c', ''), ['a', 'b', 'c'])
+    assert.deepEqual(splitPathBelowRoot('/a/b', '/'), ['a', 'b'])
+    // collapses runs of mixed separators
+    assert.deepEqual(splitPathBelowRoot('a//b\\\\c', ''), ['a', 'b', 'c'])
+  })
+})

--- a/packages/server/tests/componentwise-resolver.test.js
+++ b/packages/server/tests/componentwise-resolver.test.js
@@ -134,8 +134,12 @@ describe('componentwise-resolver: sync ≡ async parity (#6923/#6928)', () => {
     }
     // A symlink INTO a chmod-000 dir: resolving it must lstat inside the locked
     // dir, which EACCESes — and neither variant may swallow it into an allow.
-    mkdirSync(join(root, 'locked'), { recursive: true })
-    symlinkSync(join(root, 'locked/inner'), join(root, 'gate')) // gate -> locked/inner
+    // Create `locked/inner` (the symlink target) BEFORE the chmod so the leaf
+    // EXISTS: lstat-ing it then fails unambiguously on the search-permission
+    // check of `locked` (EACCES), never on a missing-leaf ENOENT that some
+    // platforms/filesystems could surface first for a non-existent target.
+    mkdirSync(join(root, 'locked/inner'), { recursive: true })
+    symlinkSync(join(root, 'locked/inner'), join(root, 'gate')) // gate -> locked/inner (exists)
     const { chmodSync } = await import('node:fs')
     chmodSync(join(root, 'locked'), 0o000)
     try {


### PR DESCRIPTION
## What

The protected-path floor (**sync**, `permission-manager.js` — #6921) and the BYOK file-ops confinement (**async**, `ws-file-ops/common.js` — #6923) each carried a near-identical copy of the component-by-component symlink resolver. They were introduced as twins and promptly drifted: **#6928 was a `split(path.sep)` footgun present in BOTH copies** that had to be patched in two places.

This extracts a single shared module, **`packages/server/src/utils/componentwise-resolver.js`**, that owns the drift-prone logic exactly once:

- `COMPONENTWISE_MAX_SYMLINKS` (the MAXSYMLINKS=40 cap)
- `splitPathBelowRoot` — the separator-agnostic split (#6928's footgun)
- `resolveComponentLexically` — the per-component ordering (skip / `..`-pop / candidate / tail-append), the piece most prone to drift
- `spliceSymlink` — absolute/relative link splice + root reset
- `resolveTargetComponentwiseSync` (sync fs) and `resolveTargetComponentwiseAsync` (async fs) — thin fs drivers over the shared core

The floor and the BYOK confinement path now **import** from it; `common.js` **re-exports** the async resolver so existing importers (and the evasion test) are unchanged. Behavior-preserving refactor (**−221 / +20** across the two files).

## Why

Item #2 of the #6923 follow-up: *"extract a single shared component-wise resolver so the floor and the confinement path can't drift again."* #6928 already demonstrated the drift risk is real, not hypothetical.

## Drift tripwire

New `componentwise-resolver.test.js` runs **identical on-disk topologies** through **both** resolvers and asserts identical results **and** identical fail-closed error codes:

- symlink + `..` escape (the open(2) crux)
- classic symlinked-parent escape (`.venv -> /outside`)
- `..` in a to-be-created tail
- absolute target ignoring the base
- #6928 separator-agnostic (`\` and mixed)
- a chain past `COMPONENTWISE_MAX_SYMLINKS` → both throw `ELOOP`
- a symlink cycle → both throw `ELOOP`
- `EACCES` on a locked dir → both propagate (fail closed)

If a future edit changes one variant's ordering or fail-closed behaviour but not the other, this test goes red.

## Verification

- **330 tests green** across the 9 touched suites (parity, raw-path evasion, floor evasion, protected-path floor, secret-read floor, ws-file-ops-common, ws-file-ops-git-paths, write-file, byok-tool-executor).
- All 5 `packages/server/scripts/lint-*.sh` pass.
- No export-surface change; no lockfile/tracked-config changes.

Related to #6921, #6923, #6928.