### PR TITLE
docs(security): document binary-provenance TOCTOU, ledger pre-seed, and Linux signature no-op

### DIFF
--- a/docs/security/spawned-binary-provenance.md
+++ b/docs/security/spawned-binary-provenance.md
@@ -145,9 +145,13 @@ notarized provider builds; chroxy's own bundled providers are ad-hoc/linker-sign
 and `spctl` rejects them, which is exactly why it can only ever be opt-in. `spctl`
 is invoked by its absolute SIP-protected path (`/usr/sbin/spctl`), never a PATH
 lookup, so a shadowed `spctl` can't subvert the gate (same hardening as the P1
-`/usr/bin/xattr` probe). The gate is **macOS-only**: on Linux/Windows it is a
-documented no-op (skipped) and the pin ledger carries the cross-platform integrity
-story alone. Windows Authenticode signature gating is a tracked follow-up.
+`/usr/bin/xattr` probe). The gate is **macOS-only**: `assessMacSignature()` checks
+`process.platform` and returns `{ ok: true, skipped: true }` immediately on any
+other platform, performing no check at all — there is no Linux or Windows
+equivalent wired up yet, regardless of the `signatureGate` config value. On those
+platforms `binaryProvenance` is **hash-pin-only**: the SHA-256 ledger is the entire
+provenance story, with no code-signature / notarization backstop. Windows
+Authenticode signature gating is tracked in #6932.
 
 ### Fail-safe semantics
 
@@ -157,6 +161,51 @@ A binary that can't even be hashed is treated as unverifiable: blocked in `block
 mode, surfaced-but-allowed in `warn` mode. A `block`-mode failure throws
 `ProviderBinaryProvenanceError` (`code: PROVIDER_BINARY_PROVENANCE`) from preflight,
 or `TunnelBinaryProvenanceError` (`code: TUNNEL_BINARY_PROVENANCE`) from the tunnel.
+
+### Known limitations (accepted, not defects)
+
+Two properties of this design are inherent to how it's built, not gaps left to
+close. They're named here so they're legible to a reviewer rather than discovered
+by one.
+
+- **check→exec is not atomic (TOCTOU).** `verifyProvenance()` hashes the bytes at
+  a resolved *path* (`sha256File`); the spawn that follows execs that same path a
+  moment later. Those are two separate filesystem operations with an
+  application-visible gap between them — Node has no `fexecve` (no way to hash an
+  already-open file descriptor and then exec that exact descriptor), so there is
+  no way to make "the bytes I hashed" and "the bytes that run" the same syscall.
+  An attacker who can write to the resolved binary path in that window can swap in
+  a different binary than the one verified. #6937 closed the *wider* version of
+  this gap for `cloudflared` — `_verifyCloudflaredProvenance()` now pins the exact
+  absolute path it verified (`this._resolvedCloudflaredPath` in
+  `tunnel/cloudflare.js`) and `_spawnCloudflared()` execs that pinned path instead
+  of re-resolving the bare `cloudflared` name off `PATH`, matching the provider
+  preflight path's existing `resolvedBinary` invariant (verify-path ==
+  spawn-path). That removes the *independent-double-resolution* race (verify one
+  path, spawn a different one) but does not — cannot — remove the fundamental
+  check-then-exec race on a single path. This is the same limitation class as the
+  protected-path floor's check-time-realpath TOCTOU (#6922). The gate still raises
+  the bar materially: instead of a one-time silent plant, an attacker now has to
+  win a race against a live spawn. It is not, and cannot be with these OS
+  primitives, an atomic guarantee — accepted and documented rather than treated as
+  an open defect.
+- **The trust ledger is TOFU, and the ledger file itself is the trust root.** A
+  path's *first* sight pins its hash automatically (`ledger.approve(path, hash)`
+  inside `verifyProvenance`) with no operator gate on that initial pin —
+  trust-on-first-use, not trust-on-verification. An operator who wants a stronger
+  baseline than "whatever was there the first time this ran" can pre-seed
+  `~/.chroxy/binary-trust.json` out of band *before* first spawn — either
+  hand-editing the `binaries` map with hashes computed on a known-good host/build,
+  or calling `BinaryProvenanceLedger.approve(path, hash)` programmatically — so the
+  first real spawn is checked against a hash the operator chose, not one the gate
+  observed at an arbitrary first run. Because the ledger IS the trust root, its
+  `0600` permission (`path-hash-trust-ledger.js`'s atomic write) is
+  **integrity-relevant, not just confidentiality-relevant**: this file is
+  user-writable by design (best-effort persistence, fail-open on a read-only
+  `$HOME`), so anyone with write access to it can pin an attacker-chosen hash and
+  have the gate wave a malicious binary through as "verified." The ledger is only
+  as trustworthy as the account that owns `~/.chroxy` — protecting that account is
+  part of this gate's threat model, not an orthogonal concern.
 
 ### Configuration
 

--- a/docs/security/spawned-binary-provenance.md
+++ b/docs/security/spawned-binary-provenance.md
@@ -200,11 +200,18 @@ by one.
   first real spawn is checked against a hash the operator chose, not one the gate
   observed at an arbitrary first run. Because the ledger IS the trust root, its
   `0600` permission (`path-hash-trust-ledger.js`'s atomic write) is
-  **integrity-relevant, not just confidentiality-relevant**: this file is
-  user-writable by design (best-effort persistence, fail-open on a read-only
+  **integrity-relevant, not just confidentiality-relevant, on POSIX**: this file
+  is user-writable by design (best-effort persistence, fail-open on a read-only
   `$HOME`), so anyone with write access to it can pin an attacker-chosen hash and
-  have the gate wave a malicious binary through as "verified." The ledger is only
-  as trustworthy as the account that owns `~/.chroxy` — protecting that account is
+  have the gate wave a malicious binary through as "verified." On Windows the
+  mode bits are best-effort/advisory, not an enforced ACL — `flush()` persists
+  via `saveJsonState({ fsync: true })`, whose durable-write branch opens the temp
+  file directly with `openSync(tmpPath, 'wx', 0o600)` rather than going through
+  `writeFileRestricted` (the `icacls`-based owner-only-DACL writer used
+  elsewhere, e.g. for credential storage), so on Windows the ledger's real
+  protection is whatever ACL the surrounding `~/.chroxy` directory already
+  inherited, not an explicitly restricted one. The ledger is only as
+  trustworthy as the account that owns `~/.chroxy` — protecting that account is
   part of this gate's threat model, not an orthogonal concern.
 
 ### Configuration


### PR DESCRIPTION
## Summary

Doc-only follow-up to #6937. The code portion of #6937 (the cloudflared provenance gate exec'ing the exact verified absolute path instead of the bare `cloudflared` name, plus clearing the pin when the binary becomes unhealthy) already landed in #6933 (commit `f5d01bab1`, on `main`). This PR is only the deferred documentation items from that security review.

Updates `docs/security/spawned-binary-provenance.md` §4 with a new **Known limitations (accepted, not defects)** subsection plus a refinement to the macOS signature-gate paragraph:

- **check→exec TOCTOU** — `verifyProvenance()` hashes the bytes at a resolved path, then the subsequent spawn execs that same path moments later; two separate filesystem operations with an application-visible gap, since Node has no `fexecve`. #6937 closed the *independent-double-resolution* race for `cloudflared` (verify path == spawn path, matching the provider preflight invariant), but the single-path check-then-exec race is inherent and can't be closed with these OS primitives. Same limitation class as the protected-path floor's TOCTOU (#6922). Documented as accepted, not an open defect.
- **Trust ledger is TOFU, and the ledger file is the trust root** — first sight of a binary path pins its hash automatically with no operator gate. Documents that an operator can pre-seed `~/.chroxy/binary-trust.json` out of band with known-good hashes, and that the file's `0600` permission is integrity-relevant (not just confidentiality-relevant): anyone able to write it can pin an attacker-chosen hash and have the gate wave a malicious binary through as "verified."
- **Linux/Windows `signatureGate` no-op** — `assessMacSignature()` short-circuits to `{ skipped: true }` on any non-`darwin` platform, so on Linux/Windows `binaryProvenance` is hash-pin-only with no code-signature backstop. Windows Authenticode gating is tracked in #6932.

All three items were verified directly against the code on `main` (`packages/server/src/utils/verify-provenance.js`, `binary-provenance-trust.js`, `path-hash-trust-ledger.js`, `tunnel/cloudflare.js`) before writing — nothing here asserts behavior the code doesn't have.

No code changed, so no test run was needed. No markdown lint tooling exists in this repo to run.

Closes #6937

## Test plan

- [x] Confirmed #6933 (commit `f5d01bab1`) already implements the code portion of #6937 on `main` (`_resolvedCloudflaredPath` in `tunnel/cloudflare.js`)
- [x] Read `verify-provenance.js`, `binary-provenance-trust.js`, `path-hash-trust-ledger.js`, `tunnel/cloudflare.js` to confirm every documented behavior matches the code
- [x] Verified issue #6922 (floor TOCTOU) and #6932 (Windows Authenticode follow-up) exist and are open before citing them
- [x] `git diff --stat` shows only `docs/security/spawned-binary-provenance.md` changed