### PR TITLE
fix(server): measure thinking duration with a monotonic clock (perf_hooks)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -17,6 +17,7 @@
 import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
 import { join } from 'path'
 import { homedir } from 'os'
+import { performance } from 'node:perf_hooks'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { synthesizeModelUsage } from './usage-normalize.js'
 import { PermissionManager, wirePermissionManager } from './permission-manager.js'
@@ -333,10 +334,12 @@ export class ClaudeByokSession extends BaseSession {
     // correctly. Cleared alongside `_streamingIndexToToolUseId`.
     this._streamingIndexToThinkingId = new Map()
 
-    // #6391 (chat-redesign footer-stat): thinking messageId → Date.now() when
-    // the reasoning block opened, so its content_block_stop can stamp the
+    // #6391 (chat-redesign footer-stat): thinking messageId → performance.now()
+    // when the reasoning block opened, so its content_block_stop can stamp the
     // elapsed `thinkingDurationMs` on the thinking stream_end. Cleared alongside
-    // `_streamingIndexToThinkingId`.
+    // `_streamingIndexToThinkingId`. #6943: monotonic clock (perf_hooks), not
+    // Date.now() — wall-clock jumps (NTP step, manual change, DST) would
+    // otherwise clamp a backward jump to 0 or inflate a forward jump.
     this._thinkingStartMs = new Map()
 
     // #4080: toolUseIds whose permission_request is currently pending.
@@ -812,8 +815,9 @@ export class ClaudeByokSession extends BaseSession {
                 thinkingId = `${messageId}-thinking-${idx}`
                 this._streamingIndexToThinkingId.set(idx, thinkingId)
                 // #6391 footer-stat: mark the block's start for the
-                // content_block_stop elapsed-time computation.
-                this._thinkingStartMs.set(thinkingId, Date.now())
+                // content_block_stop elapsed-time computation. #6943:
+                // performance.now() (monotonic), not Date.now().
+                this._thinkingStartMs.set(thinkingId, performance.now())
                 this.emit('stream_start', { messageId: thinkingId, thinking: true })
               }
               this.emit('stream_delta', { messageId: thinkingId, delta: t.text, thinking: true })
@@ -908,16 +912,20 @@ export class ClaudeByokSession extends BaseSession {
                 const thinkingId = this._streamingIndexToThinkingId.get(t.index)
                 if (thinkingId) {
                   this._streamingIndexToThinkingId.delete(t.index)
-                  // #6391 footer-stat: elapsed wall time from the block's open to
-                  // now → the client's `thought for Xs` footer. Omit when the
-                  // start wasn't tracked so we never send a bogus 0. No token
-                  // count: Anthropic's usage folds thinking tokens into
-                  // output_tokens with no per-block breakdown (see follow-up).
+                  // #6391 footer-stat: elapsed monotonic time from the block's
+                  // open to now → the client's `thought for Xs` footer. Omit
+                  // when the start wasn't tracked so we never send a bogus 0.
+                  // No token count: Anthropic's usage folds thinking tokens
+                  // into output_tokens with no per-block breakdown (see
+                  // follow-up). #6943: startMs is a performance.now() sample
+                  // (monotonic, immune to wall-clock jumps), so elapsed can
+                  // never legitimately be negative — Math.max(0, …) is a
+                  // defensive floor only, not a correctness requirement.
                   const startMs = this._thinkingStartMs.get(thinkingId)
                   this._thinkingStartMs.delete(thinkingId)
                   const streamEndMsg = { messageId: thinkingId, thinking: true }
                   if (typeof startMs === 'number') {
-                    streamEndMsg.thinkingDurationMs = Math.max(0, Date.now() - startMs)
+                    streamEndMsg.thinkingDurationMs = Math.max(0, Math.round(performance.now() - startMs))
                   }
                   this.emit('stream_end', streamEndMsg)
                 }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1,6 +1,7 @@
 import { query, forkSession } from '@anthropic-ai/claude-agent-sdk'
 import { join } from 'path'
 import { homedir } from 'os'
+import { performance } from 'node:perf_hooks'
 import { updateModels, saveModelsCache, updateContextWindow, getModels, ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
@@ -654,10 +655,13 @@ export class SdkSession extends BaseSession {
     // maps the SDK stream event `index` → that thinking id so the thinking_delta
     // and content_block_stop events (which carry only the index) route correctly.
     const thinkingBlocks = new Map()
-    // #6391 (chat-redesign footer-stat) — thinkingId -> Date.now() when the
-    // reasoning block opened, so its content_block_stop can stamp the elapsed
-    // `thinkingDurationMs` on the thinking stream_end. Turn-local; entries are
-    // deleted alongside thinkingBlocks when the block closes.
+    // #6391 (chat-redesign footer-stat) — thinkingId -> performance.now() when
+    // the reasoning block opened, so its content_block_stop can stamp the
+    // elapsed `thinkingDurationMs` on the thinking stream_end. Turn-local;
+    // entries are deleted alongside thinkingBlocks when the block closes.
+    // #6943: monotonic clock (perf_hooks), not Date.now() — wall-clock jumps
+    // (NTP step, manual change, DST) would otherwise clamp a backward jump to
+    // 0 or inflate a forward jump.
     const thinkingStartMs = new Map()
     let thinkingBlockCount = 0
     let didStreamThinking = false
@@ -938,8 +942,9 @@ export class SdkSession extends BaseSession {
                     thinkingId = `${messageId}-thinking-${thinkingBlockCount++}`
                     thinkingBlocks.set(event.index, thinkingId)
                     // #6391 footer-stat: mark the block's start for the
-                    // content_block_stop elapsed-time computation.
-                    thinkingStartMs.set(thinkingId, Date.now())
+                    // content_block_stop elapsed-time computation. #6943:
+                    // performance.now() (monotonic), not Date.now().
+                    thinkingStartMs.set(thinkingId, performance.now())
                     this.emit('stream_start', { messageId: thinkingId, thinking: true })
                   }
                   didStreamThinking = true
@@ -983,7 +988,8 @@ export class SdkSession extends BaseSession {
                     thinkingBlocks.set(event.index, thinkingId)
                     // #6391 footer-stat: mark the block's start (lazy-open path)
                     // for the content_block_stop elapsed-time computation.
-                    thinkingStartMs.set(thinkingId, Date.now())
+                    // #6943: performance.now() (monotonic), not Date.now().
+                    thinkingStartMs.set(thinkingId, performance.now())
                     this.emit('stream_start', { messageId: thinkingId, thinking: true })
                   }
                   didStreamThinking = true
@@ -999,16 +1005,20 @@ export class SdkSession extends BaseSession {
                 const thinkingId = thinkingBlocks.get(event.index)
                 if (thinkingId) {
                   thinkingBlocks.delete(event.index)
-                  // #6391 footer-stat: elapsed wall time from the block's open to
-                  // now → the client's `thought for Xs` footer. Omit when the
-                  // start wasn't tracked (defensive) so we never send a bogus 0.
-                  // No token count: Anthropic's usage folds thinking tokens into
-                  // output_tokens with no per-block breakdown (see follow-up).
+                  // #6391 footer-stat: elapsed monotonic time from the block's
+                  // open to now → the client's `thought for Xs` footer. Omit
+                  // when the start wasn't tracked (defensive) so we never send
+                  // a bogus 0. No token count: Anthropic's usage folds thinking
+                  // tokens into output_tokens with no per-block breakdown (see
+                  // follow-up). #6943: startMs is a performance.now() sample
+                  // (monotonic, immune to wall-clock jumps), so elapsed can
+                  // never legitimately be negative — Math.max(0, …) is a
+                  // defensive floor only, not a correctness requirement.
                   const startMs = thinkingStartMs.get(thinkingId)
                   thinkingStartMs.delete(thinkingId)
                   const streamEndMsg = { messageId: thinkingId, thinking: true }
                   if (typeof startMs === 'number') {
-                    streamEndMsg.thinkingDurationMs = Math.max(0, Date.now() - startMs)
+                    streamEndMsg.thinkingDurationMs = Math.max(0, Math.round(performance.now() - startMs))
                   }
                   this.emit('stream_end', streamEndMsg)
                 }

--- a/packages/server/tests/byok-session-thinking.test.js
+++ b/packages/server/tests/byok-session-thinking.test.js
@@ -22,7 +22,7 @@ function fakeStream(events, finalMessage) {
         // #6391 — a `__delayMs` marker event advances wall-clock between the
         // real events around it (so the thinking start→stop elapsed time the
         // session measures is provably > 0), then is dropped from the stream.
-        if (e && e.__delayMs) {
+        if (e && typeof e.__delayMs === 'number') {
           await new Promise((r) => setTimeout(r, e.__delayMs))
           continue
         }

--- a/packages/server/tests/byok-session-thinking.test.js
+++ b/packages/server/tests/byok-session-thinking.test.js
@@ -26,6 +26,13 @@ function fakeStream(events, finalMessage) {
           await new Promise((r) => setTimeout(r, e.__delayMs))
           continue
         }
+        // #6943 — a `__exec` marker runs an arbitrary side-effect (e.g.
+        // freezing/restoring Date.now()) at a precise point in the stream,
+        // without itself being yielded as a stream event.
+        if (e && typeof e.__exec === 'function') {
+          await e.__exec()
+          continue
+        }
         yield e
       }
     },
@@ -160,5 +167,62 @@ describe('ClaudeByokSession — thinking content forwarding (#6756)', () => {
     const responseEnd = captured.find((e) => e.name === 'stream_end' && !e.thinking)
     assert.ok(responseEnd)
     assert.equal(responseEnd.thinkingDurationMs, undefined)
+  })
+
+  it('measures thinkingDurationMs from a monotonic clock, immune to a Date.now() jump (#6943)', async () => {
+    // Both server emit paths (sdk-session.js + byok-session.js) previously
+    // measured a reasoning block's elapsed time with Date.now(), which can
+    // jump (NTP step, manual clock change, DST) and produce a wrong
+    // thinkingDurationMs — a backward jump clamps to 0, a forward jump
+    // inflates it. #6943 switches the measurement to performance.now()
+    // (perf_hooks), which is immune to wall-clock jumps. This test freezes
+    // Date.now() for the reasoning block's entire open→close window: if the
+    // implementation still read Date.now(), the measured duration would be
+    // exactly 0ms despite the real 12ms delay injected below.
+    const session = new ClaudeByokSession({ cwd: '/tmp' })
+    const realDateNow = Date.now
+    session._client = {
+      messages: {
+        stream: () =>
+          fakeStream([
+            { type: 'message_start', message: { id: 'msg_1', model: 'claude-opus-4-8' } },
+            { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } },
+            { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Reasoning.' } },
+            { __exec: () => { Date.now = () => 1_700_000_000_000 } },
+            { __delayMs: 12 },
+            { type: 'content_block_stop', index: 0 },
+            // Restore Date.now() before the rest of the turn runs (result
+            // handling, cost accounting, etc. legitimately need real time).
+            { __exec: () => { Date.now = realDateNow } },
+            { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+            { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hi' } },
+            { type: 'content_block_stop', index: 1 },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { input_tokens: 5, output_tokens: 4 } },
+            { type: 'message_stop' },
+          ], {
+            stop_reason: 'end_turn',
+            content: [{ type: 'thinking', thinking: 'Reasoning.' }, { type: 'text', text: 'Hi' }],
+            usage: { input_tokens: 5, output_tokens: 4 },
+          }),
+      },
+    }
+    const captured = capture(session)
+    try {
+      await session.start()
+      await session.sendMessage('hi')
+    } finally {
+      // Safety net in case the stream errored before the restore `__exec` ran.
+      Date.now = realDateNow
+    }
+
+    const thinkingEnds = captured.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    const end = thinkingEnds[0]
+    assert.equal(typeof end.thinkingDurationMs, 'number')
+    assert.ok(Number.isInteger(end.thinkingDurationMs), 'duration is an integer ms')
+    assert.ok(
+      end.thinkingDurationMs > 0,
+      `duration should be > 0 despite a frozen Date.now(), got ${end.thinkingDurationMs}`
+    )
   })
 })

--- a/packages/server/tests/sdk-session-thinking.test.js
+++ b/packages/server/tests/sdk-session-thinking.test.js
@@ -34,7 +34,24 @@ function createSession(opts = {}) {
 
 function asyncStream(messages) {
   return (async function* () {
-    for (const m of messages) yield m
+    for (const m of messages) {
+      // #6943 — a `__delayMs` marker advances real wall-clock time between
+      // the events around it (so a thinking block's start→stop elapsed time
+      // is provably > 0), then is dropped from the stream. Mirrors the
+      // pattern in byok-session-thinking.test.js (#6391).
+      if (m && m.__delayMs) {
+        await new Promise((r) => setTimeout(r, m.__delayMs))
+        continue
+      }
+      // #6943 — a `__exec` marker runs an arbitrary side-effect (e.g.
+      // freezing/restoring Date.now()) at a precise point in the stream,
+      // without itself being yielded as a stream event.
+      if (m && typeof m.__exec === 'function') {
+        await m.__exec()
+        continue
+      }
+      yield m
+    }
   })()
 }
 
@@ -157,5 +174,81 @@ describe('SdkSession — thinking content forwarding (#6756)', () => {
     assert.equal(thinkingDeltas[0].delta, 'Whole-message reasoning.')
     assert.ok(events.some((e) => e.name === 'stream_start' && e.thinking === true))
     assert.ok(events.some((e) => e.name === 'stream_end' && e.thinking === true))
+  })
+
+  it('stamps thinkingDurationMs on the thinking stream_end (#6943)', async () => {
+    session._callQuery = () => asyncStream([
+      initMsg,
+      { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Reasoning.' } } },
+      // Advance real wall-clock so start→stop elapsed is provably positive.
+      { __delayMs: 12 },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'stream_event', event: { type: 'content_block_start', index: 1, content_block: { type: 'text' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hi' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 1 } },
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'Reasoning.' }, { type: 'text', text: 'Hi' }] } },
+      resultMsg,
+    ])
+    const events = capture(session)
+    await session.sendMessage('hi')
+
+    const thinkingEnds = events.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    const end = thinkingEnds[0]
+    assert.equal(typeof end.thinkingDurationMs, 'number')
+    assert.ok(Number.isInteger(end.thinkingDurationMs), 'duration is an integer ms')
+    assert.ok(end.thinkingDurationMs > 0, `duration should be > 0, got ${end.thinkingDurationMs}`)
+
+    // The response text stream_end (untagged) carries no footer-stat fields.
+    const responseEnd = events.find((e) => e.name === 'stream_end' && !e.thinking)
+    assert.ok(responseEnd)
+    assert.equal(responseEnd.thinkingDurationMs, undefined)
+  })
+
+  it('measures thinkingDurationMs from a monotonic clock, immune to a Date.now() jump (#6943)', async () => {
+    // Both server emit paths (sdk-session.js + byok-session.js) previously
+    // measured a reasoning block's elapsed time with Date.now(), which can
+    // jump (NTP step, manual clock change, DST) and produce a wrong
+    // thinkingDurationMs — a backward jump clamps to 0, a forward jump
+    // inflates it. #6943 switches the measurement to performance.now()
+    // (perf_hooks), which is immune to wall-clock jumps. This test freezes
+    // Date.now() for the reasoning block's entire open→close window: if the
+    // implementation still read Date.now(), the measured duration would be
+    // exactly 0ms despite the real 12ms delay injected below.
+    const realDateNow = Date.now
+    session._callQuery = () => asyncStream([
+      initMsg,
+      { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Reasoning.' } } },
+      { __exec: () => { Date.now = () => 1_700_000_000_000 } },
+      { __delayMs: 12 },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      // Restore Date.now() before the rest of the turn runs (result
+      // handling, cost accounting, etc. legitimately need real time).
+      { __exec: () => { Date.now = realDateNow } },
+      { type: 'stream_event', event: { type: 'content_block_start', index: 1, content_block: { type: 'text' } } },
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hi' } } },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 1 } },
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'Reasoning.' }, { type: 'text', text: 'Hi' }] } },
+      resultMsg,
+    ])
+    const events = capture(session)
+    try {
+      await session.sendMessage('hi')
+    } finally {
+      // Safety net in case the stream errored before the restore `__exec` ran.
+      Date.now = realDateNow
+    }
+
+    const thinkingEnds = events.filter((e) => e.name === 'stream_end' && e.thinking === true)
+    assert.equal(thinkingEnds.length, 1)
+    const end = thinkingEnds[0]
+    assert.equal(typeof end.thinkingDurationMs, 'number')
+    assert.ok(Number.isInteger(end.thinkingDurationMs))
+    assert.ok(
+      end.thinkingDurationMs > 0,
+      `duration should be > 0 despite a frozen Date.now(), got ${end.thinkingDurationMs}`
+    )
   })
 })

--- a/packages/server/tests/sdk-session-thinking.test.js
+++ b/packages/server/tests/sdk-session-thinking.test.js
@@ -39,7 +39,7 @@ function asyncStream(messages) {
       // the events around it (so a thinking block's start→stop elapsed time
       // is provably > 0), then is dropped from the stream. Mirrors the
       // pattern in byok-session-thinking.test.js (#6391).
-      if (m && m.__delayMs) {
+      if (m && typeof m.__delayMs === 'number') {
         await new Promise((r) => setTimeout(r, m.__delayMs))
         continue
       }


### PR DESCRIPTION
## Summary

Both server emit paths measured a reasoning block's elapsed time with wall-clock `Date.now()`, which can jump on NTP correction, a manual clock change, or DST — a backward jump silently clamped `thinkingDurationMs` to 0 (`thought for 0.0s`), and a forward jump inflated it.

- `packages/server/src/sdk-session.js` — the `thinkingId → start` map and the `content_block_stop` elapsed computation
- `packages/server/src/byok-session.js` — same pattern (`_thinkingStartMs`)

Both now record the block's start with `performance.now()` (`node:perf_hooks`) and compute elapsed as `Math.round(performance.now() - start)` — monotonic, immune to wall-clock jumps. The existing guards are preserved: `thinkingDurationMs` is still omitted when the block's start wasn't tracked, and the downstream `MAX_SANE_DURATION_MS` schema ceiling (`event-normalizer.js`) is untouched. No other `Date.now()` usage in either file was touched.

## Test plan

- [x] Extended `tests/byok-session-thinking.test.js` and `tests/sdk-session-thinking.test.js` (mirroring the #6941/#6391 injected-delay style) with a case that freezes `Date.now()` for a reasoning block's entire open→close window while a real ~12ms delay elapses, then asserts `thinkingDurationMs > 0` — this fails with `got 0` against the pre-fix `Date.now()` implementation and passes against `performance.now()`, confirmed by reverting the source fix locally and re-running.
- [x] `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit` across the thinking/byok/sdk-session/event-normalizer test files: 505 passing, 0 failing.
- [x] Both changed test files also run clean **without** `--test-force-exit` (exit code 0, no hang) — no handle leak introduced.
- [x] All 5 `packages/server/scripts/lint-*.sh` pass.
- [x] `npx eslint src/sdk-session.js src/byok-session.js` clean.

Closes #6943