### PR TITLE
feat(dashboard,server): surface existing PR as a clickable link in GitPanel

### DIFF
--- a/packages/dashboard/src/components/GitPanel.test.tsx
+++ b/packages/dashboard/src/components/GitPanel.test.tsx
@@ -413,6 +413,32 @@ describe('GitPanel', () => {
       expect(screen.getByTestId('git-pr-title-input')).toBeInTheDocument()
     })
 
+    // #6938 — a "PR already exists" result carries the existing PR's URL as a
+    // structured `existingUrl` field. It must render as a real clickable link
+    // (the same git-pr-url testid/affordance as a fresh success), not as
+    // plain git-pr-error text.
+    it('renders the existing PR as a clickable link when existingUrl is set', () => {
+      render(<GitPanel />)
+      seedBranch()
+      fireEvent.click(screen.getByTestId('git-create-pr-open-btn'))
+      fireEvent.click(screen.getByTestId('git-pr-submit-btn'))
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+      act(() => capturedCreatePrCallback!({
+        url: null,
+        number: null,
+        branch: 'feat/git-panel',
+        base: 'main',
+        error: 'A pull request already exists for this branch: https://github.com/o/r/pull/7',
+        existingUrl: 'https://github.com/o/r/pull/7',
+      }))
+
+      expect(screen.getByTestId('git-pr-existing')).toBeInTheDocument()
+      const link = screen.getByTestId('git-pr-url') as HTMLAnchorElement
+      expect(link).toHaveAttribute('href', 'https://github.com/o/r/pull/7')
+      // Not rendered as plain error text.
+      expect(screen.queryByTestId('git-pr-error')).not.toBeInTheDocument()
+    })
+
     it('surfaces a "not connected" error when requestGitCreatePr returns false', () => {
       mockRequestGitCreatePr.mockReturnValue(false)
       render(<GitPanel />)

--- a/packages/dashboard/src/components/GitPanel.tsx
+++ b/packages/dashboard/src/components/GitPanel.tsx
@@ -125,6 +125,10 @@ export function GitPanel() {
   const [prSubmitting, setPrSubmitting] = useState(false)
   const [prError, setPrError] = useState<string | null>(null)
   const [prCreatedUrl, setPrCreatedUrl] = useState<string | null>(null)
+  // #6938 — the pre-existing PR's URL (structured field on git_create_pr_result)
+  // when `gh pr create` fails because a PR is already open for this branch.
+  // Rendered as a clickable link instead of buried inside `prError` text.
+  const [prExistingUrl, setPrExistingUrl] = useState<string | null>(null)
   const [prConfirmOpen, setPrConfirmOpen] = useState(false)
 
   // The single, DURABLE git_status_result handler. Stable identity (empty deps)
@@ -293,6 +297,7 @@ export function GitPanel() {
   const openPrForm = useCallback(() => {
     setPrError(null)
     setPrCreatedUrl(null)
+    setPrExistingUrl(null)
     setPrTitle(prev => prev || branch || '')
     setPrFormOpen(true)
   }, [branch])
@@ -319,10 +324,19 @@ export function GitPanel() {
     if (!title) return
     setPrError(null)
     setPrCreatedUrl(null)
+    setPrExistingUrl(null)
     setPrSubmitting(true)
     setGitCreatePrCallback((result: GitCreatePrResult) => {
       setGitCreatePrCallback(null)
       setPrSubmitting(false)
+      // #6938 — a PR already existing for this branch is still an "error"
+      // outcome (no new PR was created), but the server now returns the
+      // existing PR's URL as a structured field — surface it as a link
+      // rather than leaving the operator to dig it out of the error text.
+      if (result.existingUrl) {
+        setPrExistingUrl(result.existingUrl)
+        return
+      }
       if (result.error || !result.url) {
         setPrError(result.error || 'PR creation failed')
         return
@@ -402,6 +416,17 @@ export function GitPanel() {
             <div className="git-pr-success" data-testid="git-pr-success">
               <span>Pull request opened:</span>
               <a href={prCreatedUrl} target="_blank" rel="noreferrer" data-testid="git-pr-url">{prCreatedUrl}</a>
+              <button type="button" className="git-section-action" onClick={closePrForm} data-testid="git-pr-done-btn">
+                Done
+              </button>
+            </div>
+          ) : prExistingUrl ? (
+            // #6938 — "already exists" is not a fresh success, so this gets its
+            // own testid/copy, but reuses the same clickable-link affordance
+            // (git-pr-url) rather than burying the URL in git-pr-error text.
+            <div className="git-pr-success git-pr-existing" data-testid="git-pr-existing">
+              <span>PR already exists →</span>
+              <a href={prExistingUrl} target="_blank" rel="noreferrer" data-testid="git-pr-url">{prExistingUrl}</a>
               <button type="button" className="git-section-action" onClick={closePrForm} data-testid="git-pr-done-btn">
                 Done
               </button>

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -4332,7 +4332,36 @@ describe('dashboard message-handler dispatch', () => {
         branch: 'feat/x',
         base: 'main',
         error: null,
+        existingUrl: null,
       })
+    })
+
+    // #6938 — the "PR already exists" path returns `existingUrl` as a
+    // structured field; the dispatch must forward it verbatim to the callback
+    // so GitPanel can render a clickable link instead of parsing `error` text.
+    it('forwards existingUrl on the "PR already exists" payload', () => {
+      const calls: Array<any> = []
+      store = createMockStore(baseState({
+        _gitCreatePrCallback: (r: any) => calls.push(r),
+      } as any))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'git_create_pr_result',
+          url: null,
+          number: null,
+          branch: 'feat/x',
+          base: 'main',
+          error: 'A pull request already exists for this branch: https://github.com/o/r/pull/7',
+          existingUrl: 'https://github.com/o/r/pull/7',
+        } as any,
+        ctx() as any,
+      )
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].existingUrl).toBe('https://github.com/o/r/pull/7')
+      expect(calls[0].url).toBeNull()
     })
 
     it('still resolves the callback with an error on an INVALID payload (unsticks GitPanel submitting state)', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -5155,6 +5155,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             branch: null,
             base: null,
             error: 'Received a malformed PR-creation response from the server',
+            existingUrl: null,
           });
           break;
         }
@@ -5165,6 +5166,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           branch: payload.branch,
           base: payload.base,
           error: payload.error,
+          // #6938 — the pre-existing PR's URL (structured field), set only on
+          // the "PR already exists" error path.
+          existingUrl: payload.existingUrl ?? null,
         });
       }
       break;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -309,12 +309,16 @@ export interface GitCommitResult {
 // failure), `number` its integer id (best-effort), `branch`/`base` echo the
 // head/base used, and `error` carries a clear message on failure. Dashboard-only
 // for v1 (mobile PR-creation UI is a tracked follow-up).
+// #6938 — `existingUrl` is set (non-null) only on the "a pull request already
+// exists for this branch" error path, so the UI can render it as a real link
+// instead of the URL only ever appearing embedded inside `error` text.
 export interface GitCreatePrResult {
   url: string | null;
   number: number | null;
   branch: string | null;
   base: string | null;
   error: string | null;
+  existingUrl?: string | null;
 }
 
 // `DiffHunkLine`, `DiffHunk`, and `DiffFile` are now re-exported from

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9908,6 +9908,14 @@ button.sidebar-token-view-session-row:hover {
   word-break: break-all;
 }
 
+/* #6938 — "PR already exists" result: same layout as .git-pr-success (reuses
+   the clickable-link affordance) but the lead-in label reads as a notice
+   rather than a fresh success, so it borrows the warning/attention accent
+   already used elsewhere in this file (--accent-orange) instead of green. */
+.git-pr-existing span:first-child {
+  color: var(--accent-orange);
+}
+
 .git-branch-row {
   display: flex;
   align-items: center;

--- a/packages/protocol/dist/schemas/server/file-ops.d.ts
+++ b/packages/protocol/dist/schemas/server/file-ops.d.ts
@@ -101,6 +101,7 @@ export declare const ServerGitCreatePrResultSchema: z.ZodObject<{
     branch: z.ZodNullable<z.ZodString>;
     base: z.ZodNullable<z.ZodString>;
     error: z.ZodNullable<z.ZodString>;
+    existingUrl: z.ZodOptional<z.ZodNullable<z.ZodString>>;
 }, z.core.$strip>;
 export declare const ServerWriteFileResultSchema: z.ZodObject<{
     type: z.ZodLiteral<"write_file_result">;

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -102,6 +102,11 @@ export const ServerDirectoryListingSchema = z.object({
 // tried — so only `url`/`number` are guaranteed null on failure, not every data
 // field. Handled by the dashboard only for v1 (mobile PR-creation UI is a
 // tracked follow-up).
+// #6938 — `existingUrl` is populated (non-null) ONLY on the "a pull request
+// already exists for this branch" error path — the pre-existing PR's URL as a
+// structured field, so the dashboard can render a real link (instead of the
+// URL only ever appearing embedded inside the `error` string). Every other
+// path (success or any other error) leaves it null.
 export const ServerGitCreatePrResultSchema = z.object({
     type: z.literal('git_create_pr_result'),
     url: z.string().nullable(),
@@ -109,6 +114,7 @@ export const ServerGitCreatePrResultSchema = z.object({
     branch: z.string().nullable(),
     base: z.string().nullable(),
     error: z.string().nullable(),
+    existingUrl: z.string().nullable().optional(),
 });
 // `write_file` response — the wire type is `write_file_result` (NOT
 // file_write_result). Only path + error beyond type. App-only today (the

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -109,6 +109,11 @@ export const ServerDirectoryListingSchema = z.object({
 // tried — so only `url`/`number` are guaranteed null on failure, not every data
 // field. Handled by the dashboard only for v1 (mobile PR-creation UI is a
 // tracked follow-up).
+// #6938 — `existingUrl` is populated (non-null) ONLY on the "a pull request
+// already exists for this branch" error path — the pre-existing PR's URL as a
+// structured field, so the dashboard can render a real link (instead of the
+// URL only ever appearing embedded inside the `error` string). Every other
+// path (success or any other error) leaves it null.
 export const ServerGitCreatePrResultSchema = z.object({
   type: z.literal('git_create_pr_result'),
   url: z.string().nullable(),
@@ -116,6 +121,7 @@ export const ServerGitCreatePrResultSchema = z.object({
   branch: z.string().nullable(),
   base: z.string().nullable(),
   error: z.string().nullable(),
+  existingUrl: z.string().nullable().optional(),
 })
 
 // `write_file` response — the wire type is `write_file_result` (NOT

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -11,9 +11,12 @@ const execFileAsync = promisify(execFileCb)
 
 // #6876 — result sender for the git_create_pr flow. Every field is always
 // present (present-and-nullable) so the wire payload satisfies
-// ServerGitCreatePrResultSchema on every path.
-function prResult({ url = null, number = null, branch = null, base = null, error = null } = {}) {
-  return { type: 'git_create_pr_result', url, number, branch, base, error }
+// ServerGitCreatePrResultSchema on every path. #6938 — `existingUrl` is a
+// structured (non-null) field only on the "PR already exists" error path, so
+// the dashboard can render it as a clickable link instead of parsing it back
+// out of the `error` string.
+function prResult({ url = null, number = null, branch = null, base = null, error = null, existingUrl = null } = {}) {
+  return { type: 'git_create_pr_result', url, number, branch, base, error, existingUrl }
 }
 
 /** Extract the first `.../pull/<n>` URL from gh output (stdout or stderr). */
@@ -71,27 +74,43 @@ function mapPushError(err) {
   return line ? `Failed to push branch: ${line}` : 'Failed to push the current branch to origin'
 }
 
-/** Map a `gh pr create` failure to an operator-actionable message. */
+/**
+ * Map a `gh pr create` failure to an operator-actionable message.
+ *
+ * Returns `{ message, existingUrl }` — `existingUrl` is the pre-existing PR's
+ * `/pull/<n>` URL (non-null) only on the "PR already exists" path, so the
+ * caller can surface it as a structured field on `git_create_pr_result`
+ * (#6938) rather than the dashboard having to regex it back out of `message`.
+ */
 function mapGhCreateError(err) {
   if (err && err.code === 'ENOENT') {
-    return 'GitHub CLI (gh) is not installed on the daemon host — install it from https://cli.github.com to open PRs from Chroxy'
+    return {
+      message: 'GitHub CLI (gh) is not installed on the daemon host — install it from https://cli.github.com to open PRs from Chroxy',
+      existingUrl: null,
+    }
   }
   const stderr = String((err && (err.stderr || err.message)) || '')
   const lower = stderr.toLowerCase()
   if (/already exists|a pull request for branch/.test(lower)) {
     const existing = extractPrUrl(stderr)
-    return existing
-      ? `A pull request already exists for this branch: ${existing}`
-      : 'A pull request already exists for this branch'
+    return {
+      message: existing
+        ? `A pull request already exists for this branch: ${existing}`
+        : 'A pull request already exists for this branch',
+      existingUrl: existing,
+    }
   }
   if (/gh auth login|not logged in|authentication required|no credentials|requires authentication|http 401|gh auth status/.test(lower)) {
-    return 'GitHub CLI is not authenticated — run `gh auth login` on the daemon host to enable PR creation'
+    return {
+      message: 'GitHub CLI is not authenticated — run `gh auth login` on the daemon host to enable PR creation',
+      existingUrl: null,
+    }
   }
   if (/no git remotes found|not a git repository|does not appear to be a git repository|could not determine base repo/.test(lower)) {
-    return 'No GitHub remote is configured for this repository'
+    return { message: 'No GitHub remote is configured for this repository', existingUrl: null }
   }
   const line = firstLine(stderr)
-  return line || (err && err.message) || 'Failed to create pull request'
+  return { message: line || (err && err.message) || 'Failed to create pull request', existingUrl: null }
 }
 
 /**
@@ -459,7 +478,8 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
           stdout = res?.stdout || ''
           stderr = res?.stderr || ''
         } catch (err) {
-          sendFn(ws, prResult({ branch, base: base || null, error: mapGhCreateError(err) }))
+          const mapped = mapGhCreateError(err)
+          sendFn(ws, prResult({ branch, base: base || null, error: mapped.message, existingUrl: mapped.existingUrl }))
           return
         }
       } finally {

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -92,7 +92,10 @@ function mapGhCreateError(err) {
   const stderr = String((err && (err.stderr || err.message)) || '')
   const lower = stderr.toLowerCase()
   if (/already exists|a pull request for branch/.test(lower)) {
-    const existing = extractPrUrl(stderr)
+    // gh sometimes writes the existing-PR URL to stdout rather than stderr —
+    // parse both streams (and the error message) the same way the success
+    // path does, so the URL isn't missed depending on which stream gh used.
+    const existing = extractPrUrl(err && err.stdout) || extractPrUrl(stderr)
     return {
       message: existing
         ? `A pull request already exists for this branch: ${existing}`

--- a/packages/server/tests/git-create-pr.test.js
+++ b/packages/server/tests/git-create-pr.test.js
@@ -230,6 +230,22 @@ describe('gitCreatePR (#6876)', () => {
     assert.equal(responses[0].existingUrl, 'https://github.com/o/r/pull/7')
   })
 
+  it('surfaces the existing PR URL from gh stdout when stderr carries none (#6951)', async () => {
+    const err = Object.assign(new Error('exit 1'), {
+      code: 1,
+      stdout: 'https://github.com/o/r/pull/9\n',
+      stderr: 'a pull request for branch "feat/pr" into branch "main" already exists:',
+    })
+    const { exec } = router({ gh: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /already exists/i)
+    assert.equal(responses[0].url, null)
+    assert.equal(responses[0].existingUrl, 'https://github.com/o/r/pull/9')
+  })
+
   it('leaves existingUrl null on non-"already exists" gh failures (#6938)', async () => {
     const err = Object.assign(new Error('exit 1'), {
       code: 1,

--- a/packages/server/tests/git-create-pr.test.js
+++ b/packages/server/tests/git-create-pr.test.js
@@ -211,7 +211,7 @@ describe('gitCreatePR (#6876)', () => {
     assert.match(responses[0].error, /not authenticated/i)
   })
 
-  it('surfaces the existing PR URL when one already exists', async () => {
+  it('surfaces the existing PR URL when one already exists (#6938: as a structured field too)', async () => {
     const err = Object.assign(new Error('exit 1'), {
       code: 1,
       stderr: 'a pull request for branch "feat/pr" into branch "main" already exists:\nhttps://github.com/o/r/pull/7',
@@ -224,6 +224,24 @@ describe('gitCreatePR (#6876)', () => {
     assert.match(responses[0].error, /already exists/i)
     assert.match(responses[0].error, /pull\/7/)
     assert.equal(responses[0].url, null)
+    // #6938 — the existing PR URL is ALSO returned as a structured field (not
+    // just embedded in the error string) so the dashboard can render a real
+    // link instead of plain error text.
+    assert.equal(responses[0].existingUrl, 'https://github.com/o/r/pull/7')
+  })
+
+  it('leaves existingUrl null on non-"already exists" gh failures (#6938)', async () => {
+    const err = Object.assign(new Error('exit 1'), {
+      code: 1,
+      stderr: 'To get started with GitHub CLI, please run:  gh auth login',
+    })
+    const { exec } = router({ gh: { throw: err } })
+    const { git, responses } = makeGit(exec)
+
+    await git.gitCreatePR({}, { title: 't' }, tmpDir)
+
+    assert.match(responses[0].error, /not authenticated/i)
+    assert.equal(responses[0].existingUrl, null)
   })
 
   it('surfaces a push failure (no origin) without calling gh', async () => {


### PR DESCRIPTION
## Summary

When `gh pr create` fails because a PR already exists for the branch, `mapGhCreateError` (`packages/server/src/ws-file-ops/git.js`) embedded the existing `/pull/<n>` URL into the `error` **string** only, leaving `url: null` — so the dashboard's `GitPanel` rendered it as plain text (`git-pr-error`) instead of the clickable `git-pr-url` link.

- **Server**: `mapGhCreateError` now returns `{ message, existingUrl }`. The `git_create_pr_result` reply carries `existingUrl` as a structured field on the "PR already exists" path (`url` stays `null` — nothing new was created). Every other path leaves `existingUrl: null`.
- **Protocol**: `existingUrl` added as an optional/nullable field on `ServerGitCreatePrResultSchema` — optional field on an existing wire type, no new type, coverage guards untouched. `packages/protocol/dist/` rebuilt and included.
- **Dashboard**: `GitPanel` now renders `existingUrl` via the same clickable-link affordance (`git-pr-url` testid) used for a fresh success, with distinct "PR already exists →" copy and its own `git-pr-existing` container, instead of burying the URL in `git-pr-error` text. Token-only CSS addition (`--accent-orange`, already used elsewhere for this kind of notice).

Closes #6938

## Test plan
- [x] `packages/server`: extended `git-create-pr.test.js` ("already exists" now asserts `existingUrl`; new test asserts `existingUrl` stays `null` on other failures) — `node --test` green (48/48 tests)
- [x] `packages/server`: all 5 lint scripts pass (`lint-claude-family-explicit`, `lint-logger-session-scoping`, `lint-session-opt-forwarding`, `lint-tests-state-file-path`, `lint-ws-index-mutations`)
- [x] `packages/protocol`: full `npm test` green (377/377), including the handler-coverage and type-coverage-lint guards
- [x] `packages/dashboard`: full `npx vitest run` green (273 files / 4723 tests), including new GitPanel + message-handler dispatch tests for `existingUrl`
- [x] `packages/dashboard`: `npx tsc --noEmit` clean
- [x] `packages/store-core`: full `npm test` green (58 files / 2079 tests) — `protocol-type-coverage-lint` + `dispatch-table` guards pass with the new optional field