### PR TITLE
fix(server): warn on SessionManager unknown/misnamed ctor opts (provider vs providerType)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -393,8 +393,53 @@ export class SessionManager extends EventEmitter {
     // Test-only: skip preflight checks (binary + credential). Production must
     // leave this false so missing providers surface cleanly at createSession.
     skipPreflight = false,
+
+    // #6944: object-rest captures every option key NOT destructured above.
+    // The destructure itself is the single source of truth for "known" keys —
+    // no parallel allow-list to drift. Anything landing here is a misnamed or
+    // unrecognized ctor option; the guard below surfaces it instead of letting
+    // it be silently swallowed (which is how `provider` — the createSession()
+    // opt, not the ctor's `providerType` — fell through to a claude-tui PTY
+    // spawn and hung CI, #6933).
+    ...unknownCtorOpts
   } = {}) {
     super()
+
+    // #6944: surface misnamed / unknown constructor options. Never throws — a
+    // production caller must not crash on a friendly alias — but it refuses to
+    // silently ignore a key.
+    const unknownOptKeys = Object.keys(unknownCtorOpts)
+    if (unknownOptKeys.length > 0) {
+      // Targeted alias: `provider` is the classic typo for `providerType` (the
+      // former is the createSession() option, the latter the ctor's). When only
+      // `provider` was supplied as a usable string, map it onto `providerType`
+      // so the caller gets the provider they intended rather than a silent
+      // DEFAULT_PROVIDER (claude-tui) PTY spawn. If `providerType` was ALSO set
+      // explicitly, or `provider` is not a usable string (undefined/null/''),
+      // keep the resolved `providerType` and just warn that `provider` is
+      // ignored — never overwrite a good default with a bad alias value.
+      if (Object.prototype.hasOwnProperty.call(unknownCtorOpts, 'provider')) {
+        const providerAlias = unknownCtorOpts.provider
+        const providerTypeIsExplicit = providerType !== DEFAULT_PROVIDER
+        if (!providerTypeIsExplicit && typeof providerAlias === 'string' && providerAlias.length > 0) {
+          log.warn(`SessionManager: 'provider' is not a constructor option — did you mean 'providerType'? Treating provider=${JSON.stringify(providerAlias)} as providerType (createSession() uses 'provider'; the constructor uses 'providerType').`)
+          providerType = providerAlias
+        } else {
+          const reason = providerTypeIsExplicit
+            ? `providerType=${JSON.stringify(providerType)} is already set`
+            : `provider=${JSON.stringify(providerAlias)} is not a usable provider id`
+          log.warn(`SessionManager: ignoring constructor option 'provider' (use 'providerType') — ${reason}.`)
+        }
+      }
+      // The rest of the class: warn on any other unrecognized key. Gated to
+      // test/dev so a single stray key can't spam a long-lived production daemon
+      // log (SessionManager is constructed once per daemon), while still
+      // catching the whole footgun class in the suite where it actually bites.
+      const otherUnknown = unknownOptKeys.filter((k) => k !== 'provider')
+      if (otherUnknown.length > 0 && (process.env.NODE_ENV === 'test' || process.env.CHROXY_DEBUG_CTOR_OPTS === '1')) {
+        log.warn(`SessionManager: ignoring unrecognized constructor option(s): ${otherUnknown.join(', ')}. Check for a misnamed option.`)
+      }
+    }
 
     // Server identity
     this._port = port || null

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -219,11 +219,30 @@ export { ProviderBinaryNotFoundError, ProviderBinaryQuarantinedError, ProviderBi
  * @property {number}  [maxMessages=1000]        - Max history messages per session (alias: maxHistory)
  * @property {number}  [maxHistory]              - Legacy alias for maxMessages
  */
+
+// #6944 / #6952 review: process-lifetime dedup for the general unknown-ctor-opt
+// warning below — keyed by the unrecognized option name so a given typo warns
+// at most once no matter how many SessionManager instances get constructed.
+// Module-level (not per-instance) is intentional: the warning is a one-time
+// "you have a bug" signal, not per-instance telemetry.
+const warnedUnknownCtorOptKeys = new Set()
+
 export class SessionManager extends EventEmitter {
   /**
-   * @param {SessionManagerConfig} config
+   * @param {SessionManagerConfig} opts
    */
-  constructor({
+  constructor(opts = {}) {
+    super()
+
+    // #6952 review: destructure the raw `opts` object here (instead of in the
+    // parameter list) so `opts` itself stays addressable below — needed to
+    // tell "providerType explicitly passed" apart from "providerType defaulted"
+    // (see providerTypeIsExplicit) without a parallel hand-maintained key list.
+    // `let` (not `const`): parameter destructuring made every one of these an
+    // independently mutable local binding, and `providerType` in particular is
+    // reassigned below when the `provider` alias resolves onto it — a `const`
+    // destructure would throw "Assignment to constant variable" at that point.
+    let {
     // Server identity
     port,
     apiToken,
@@ -402,8 +421,7 @@ export class SessionManager extends EventEmitter {
     // opt, not the ctor's `providerType` — fell through to a claude-tui PTY
     // spawn and hung CI, #6933).
     ...unknownCtorOpts
-  } = {}) {
-    super()
+    } = opts
 
     // #6944: surface misnamed / unknown constructor options. Never throws — a
     // production caller must not crash on a friendly alias — but it refuses to
@@ -420,7 +438,15 @@ export class SessionManager extends EventEmitter {
       // ignored — never overwrite a good default with a bad alias value.
       if (Object.prototype.hasOwnProperty.call(unknownCtorOpts, 'provider')) {
         const providerAlias = unknownCtorOpts.provider
-        const providerTypeIsExplicit = providerType !== DEFAULT_PROVIDER
+        // #6952 review: explicitness must come from the ORIGINAL `opts` object,
+        // not from comparing the (already-defaulted) `providerType` binding to
+        // DEFAULT_PROVIDER. A caller passing BOTH `provider` and an explicit
+        // `providerType` that happens to equal DEFAULT_PROVIDER (e.g.
+        // `providerType: 'claude-tui'`) is indistinguishable from omitting
+        // providerType entirely under the old check — the alias would
+        // incorrectly win. `'providerType' in opts` reflects what the caller
+        // actually passed, independent of its value.
+        const providerTypeIsExplicit = Object.prototype.hasOwnProperty.call(opts, 'providerType')
         if (!providerTypeIsExplicit && typeof providerAlias === 'string' && providerAlias.length > 0) {
           log.warn(`SessionManager: 'provider' is not a constructor option — did you mean 'providerType'? Treating provider=${JSON.stringify(providerAlias)} as providerType (createSession() uses 'provider'; the constructor uses 'providerType').`)
           providerType = providerAlias
@@ -431,13 +457,29 @@ export class SessionManager extends EventEmitter {
           log.warn(`SessionManager: ignoring constructor option 'provider' (use 'providerType') — ${reason}.`)
         }
       }
-      // The rest of the class: warn on any other unrecognized key. Gated to
-      // test/dev so a single stray key can't spam a long-lived production daemon
-      // log (SessionManager is constructed once per daemon), while still
-      // catching the whole footgun class in the suite where it actually bites.
+      // The rest of the class: warn on any other unrecognized key. #6952 review:
+      // this used to be gated on `process.env.NODE_ENV === 'test'`, but nothing
+      // in the harness/CI ever sets NODE_ENV=test, so the safety net never fired
+      // outside of someone manually exporting it — the whole-key-class catch
+      // (e.g. `persistenceDebounceMs` typo'd for `persistDebounceMs`) was dead.
+      // Always-on is safe for production: SessionManager's sole prod caller
+      // (server-cli.js) constructs it from a fixed set of destructured keys, so
+      // `unknownCtorOpts` is empty there and this never fires. The module-level
+      // dedup Set bounds repeat warnings to once per distinct key for the life
+      // of the process, so it can't spam a long-lived daemon log even if some
+      // future caller does pass an unknown key repeatedly (e.g. in a loop).
+      // CHROXY_DEBUG_CTOR_OPTS='1' bypasses the dedup for extra verbosity when
+      // actively debugging a ctor-opt issue (every occurrence re-warns).
       const otherUnknown = unknownOptKeys.filter((k) => k !== 'provider')
-      if (otherUnknown.length > 0 && (process.env.NODE_ENV === 'test' || process.env.CHROXY_DEBUG_CTOR_OPTS === '1')) {
-        log.warn(`SessionManager: ignoring unrecognized constructor option(s): ${otherUnknown.join(', ')}. Check for a misnamed option.`)
+      if (otherUnknown.length > 0) {
+        const verbose = process.env.CHROXY_DEBUG_CTOR_OPTS === '1'
+        const toWarn = verbose
+          ? otherUnknown
+          : otherUnknown.filter((k) => !warnedUnknownCtorOptKeys.has(k))
+        if (toWarn.length > 0) {
+          toWarn.forEach((k) => warnedUnknownCtorOptKeys.add(k))
+          log.warn(`SessionManager: ignoring unrecognized constructor option(s): ${toWarn.join(', ')}. Check for a misnamed option.`)
+        }
       }
     }
 

--- a/packages/server/tests/permission-expired-broadcast.test.js
+++ b/packages/server/tests/permission-expired-broadcast.test.js
@@ -149,7 +149,7 @@ describe('permission_expired end-to-end broadcast (#2831)', () => {
         // worker alive and hung the suite when run without --test-force-exit.
         providerType: 'fake-permexp',
         stateFilePath: tmpState,
-        persistenceDebounceMs: 0,
+        persistDebounceMs: 0,
       })
 
       const events = []

--- a/packages/server/tests/permission-resolved-broadcast.test.js
+++ b/packages/server/tests/permission-resolved-broadcast.test.js
@@ -173,7 +173,7 @@ describe('permission_resolved end-to-end broadcast (#3048)', () => {
         // worker alive and hung the suite when run without --test-force-exit.
         providerType: 'fake-permresolved',
         stateFilePath: tmpState,
-        persistenceDebounceMs: 0,
+        persistDebounceMs: 0,
       })
 
       const events = []

--- a/packages/server/tests/session-manager-unknown-opts.test.js
+++ b/packages/server/tests/session-manager-unknown-opts.test.js
@@ -4,9 +4,13 @@ import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { SessionManager } from '../src/session-manager.js'
-// DEFAULT_PROVIDER is single-sourced in @chroxy/protocol; import it from there
-// (Zod/SDK-free) rather than ../src/providers.js, whose provider registry
-// statically pulls the Agent SDK into the module graph (not installed locally).
+// DEFAULT_PROVIDER is single-sourced in @chroxy/protocol. Importing it from
+// there (rather than ../src/providers.js) makes no difference to whether the
+// Agent SDK loads in this suite: `../src/session-manager.js` above already
+// imports ../src/providers.js, whose registry statically pulls in every
+// provider session class including sdk-session.js's `@anthropic-ai/claude-agent-sdk`
+// import — so the SDK is in the module graph the moment SessionManager is
+// imported, regardless of where this test sources DEFAULT_PROVIDER from.
 import { DEFAULT_PROVIDER } from '@chroxy/protocol'
 import { getLogLevel, setLogLevel } from '../src/logger.js'
 
@@ -97,6 +101,48 @@ describe('SessionManager unknown/misnamed ctor opts (#6944)', () => {
     assert.ok(surfaced, `expected an "ignoring provider" warning; got: ${JSON.stringify(warnings)}`)
   })
 
+  it('keeps an explicit `providerType` that equals DEFAULT_PROVIDER — the alias does NOT win (#6952 review)', () => {
+    // Regression guard: explicitness used to be inferred as
+    // `providerType !== DEFAULT_PROVIDER`, so a caller passing BOTH `provider`
+    // and a `providerType` that happened to equal the default value
+    // (DEFAULT_PROVIDER === 'claude-tui') was indistinguishable from having
+    // omitted providerType — the `provider` alias would incorrectly clobber
+    // it. The fix reads explicitness off the original opts object
+    // (`'providerType' in opts`) instead of comparing the resolved value.
+    assert.equal(DEFAULT_PROVIDER, 'claude-tui', 'precondition: this test only proves the fix when providerType === DEFAULT_PROVIDER')
+    let mgr
+    const warnings = captureWarnings(() => {
+      mgr = new SessionManager({
+        skipPreflight: true,
+        provider: 'x',
+        providerType: 'claude-tui', // explicit, but == DEFAULT_PROVIDER
+        stateFilePath: tmpStateFile(),
+      })
+    })
+
+    assert.equal(mgr._providerType, 'claude-tui')
+    const surfaced = warnings.find((w) => w.includes("ignoring constructor option 'provider'"))
+    assert.ok(surfaced, `expected an "ignoring provider" warning; got: ${JSON.stringify(warnings)}`)
+  })
+
+  it('keeps the resolved providerType when `provider` is an empty string or null (no bogus map)', () => {
+    for (const emptyAlias of ['', null]) {
+      let mgr
+      const warnings = captureWarnings(() => {
+        mgr = new SessionManager({
+          skipPreflight: true,
+          provider: emptyAlias,
+          stateFilePath: tmpStateFile(),
+        })
+      })
+
+      // Falls back to the resolved default — never mapped to a falsy/bogus value.
+      assert.equal(mgr._providerType, DEFAULT_PROVIDER, `provider=${JSON.stringify(emptyAlias)} must not clobber providerType`)
+      const surfaced = warnings.find((w) => w.includes("ignoring constructor option 'provider'") && w.includes('not a usable provider id'))
+      assert.ok(surfaced, `expected a "not a usable provider id" warning for provider=${JSON.stringify(emptyAlias)}; got: ${JSON.stringify(warnings)}`)
+    }
+  })
+
   it('warns on any other unrecognized key under the debug flag (persistenceDebounceMs typo)', () => {
     const prev = process.env.CHROXY_DEBUG_CTOR_OPTS
     process.env.CHROXY_DEBUG_CTOR_OPTS = '1'
@@ -142,6 +188,82 @@ describe('SessionManager unknown/misnamed ctor opts (#6944)', () => {
     } finally {
       if (prev === undefined) delete process.env.CHROXY_DEBUG_CTOR_OPTS
       else process.env.CHROXY_DEBUG_CTOR_OPTS = prev
+    }
+  })
+
+  it('always warns on an unrecognized key with NO NODE_ENV/CHROXY_DEBUG_CTOR_OPTS set (#6952 review)', () => {
+    // The general unknown-key warning used to be gated on
+    // `process.env.NODE_ENV === 'test'`, but nothing in this repo's harness,
+    // tests/_setup.mjs, or CI workflows ever sets NODE_ENV=test — so the
+    // whole-key-class safety net (catching e.g. `persistenceDebounceMs`
+    // typo'd for `persistDebounceMs`) never actually fired outside of someone
+    // manually exporting the debug flag. This is the regression guard: both
+    // gates are explicitly unset here, proving the warning is now always-on.
+    //
+    // Uses a key distinct from the other tests in this file (rather than
+    // reusing `persistenceDebounceMs`) because the fix's dedup Set is
+    // module-level and process-lifetime — reusing an already-warned key here
+    // would make this assertion depend on test execution order.
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevDebug = process.env.CHROXY_DEBUG_CTOR_OPTS
+    delete process.env.NODE_ENV
+    delete process.env.CHROXY_DEBUG_CTOR_OPTS
+    try {
+      const warnings = captureWarnings(() => {
+        // eslint-disable-next-line no-new
+        new SessionManager({
+          skipPreflight: true,
+          legacyDebounceIntervalTypo: 0, // a genuinely unknown ctor option
+          stateFilePath: tmpStateFile(),
+        })
+      })
+      const surfaced = warnings.find((w) => w.includes('legacyDebounceIntervalTypo') && w.includes('unrecognized'))
+      assert.ok(surfaced, `expected an unrecognized-option warning with no env gates set; got: ${JSON.stringify(warnings)}`)
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevDebug === undefined) delete process.env.CHROXY_DEBUG_CTOR_OPTS
+      else process.env.CHROXY_DEBUG_CTOR_OPTS = prevDebug
+    }
+  })
+
+  it('dedups the general unknown-key warning — a repeated key warns only once per process', () => {
+    // Direct coverage of the new module-level dedup Set: the always-on
+    // warning above must not spam a long-lived daemon log if the same
+    // unrecognized key is passed to more than one SessionManager
+    // construction. Uses its own unique key so it can't be silenced by (or
+    // silence) any other test's use of the general-warning path.
+    const prevNodeEnv = process.env.NODE_ENV
+    const prevDebug = process.env.CHROXY_DEBUG_CTOR_OPTS
+    delete process.env.NODE_ENV
+    delete process.env.CHROXY_DEBUG_CTOR_OPTS
+    try {
+      const firstWarnings = captureWarnings(() => {
+        // eslint-disable-next-line no-new
+        new SessionManager({
+          skipPreflight: true,
+          totallyUniqueDedupTestKey: 0,
+          stateFilePath: tmpStateFile(),
+        })
+      })
+      const secondWarnings = captureWarnings(() => {
+        // eslint-disable-next-line no-new
+        new SessionManager({
+          skipPreflight: true,
+          totallyUniqueDedupTestKey: 0,
+          stateFilePath: tmpStateFile(),
+        })
+      })
+
+      const firstSurfaced = firstWarnings.find((w) => w.includes('totallyUniqueDedupTestKey'))
+      assert.ok(firstSurfaced, `expected the first construction to warn; got: ${JSON.stringify(firstWarnings)}`)
+      const secondSurfaced = secondWarnings.find((w) => w.includes('totallyUniqueDedupTestKey'))
+      assert.equal(secondSurfaced, undefined, `expected the second construction with the same key to be deduped (silent); got: ${JSON.stringify(secondWarnings)}`)
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prevNodeEnv
+      if (prevDebug === undefined) delete process.env.CHROXY_DEBUG_CTOR_OPTS
+      else process.env.CHROXY_DEBUG_CTOR_OPTS = prevDebug
     }
   })
 })

--- a/packages/server/tests/session-manager-unknown-opts.test.js
+++ b/packages/server/tests/session-manager-unknown-opts.test.js
@@ -1,0 +1,147 @@
+import { describe, it, beforeEach, afterEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { SessionManager } from '../src/session-manager.js'
+// DEFAULT_PROVIDER is single-sourced in @chroxy/protocol; import it from there
+// (Zod/SDK-free) rather than ../src/providers.js, whose provider registry
+// statically pulls the Agent SDK into the module graph (not installed locally).
+import { DEFAULT_PROVIDER } from '@chroxy/protocol'
+import { getLogLevel, setLogLevel } from '../src/logger.js'
+
+/**
+ * #6944 — the SessionManager constructor used to silently swallow any option key
+ * it didn't destructure. A caller passing `provider:` (the createSession() opt)
+ * where the constructor expects `providerType:` was ignored, so createSession()
+ * fell back to DEFAULT_PROVIDER (claude-tui) and spawned a REAL `claude` PTY —
+ * the leaked handle that hung the #6933 CI run.
+ *
+ * These tests assert the guard surfaces the misuse (never silently ignores it),
+ * and — critically — that they do NOT reach createSession(), so no provider is
+ * ever spawned. Construction alone is enough to exercise the guard.
+ *
+ * CRITICAL: every SessionManager MUST use a temp stateFilePath (see #4633) or it
+ * clobbers the real ~/.chroxy/session-state.json.
+ */
+
+let _tmpDir
+function tmpStateFile() {
+  if (!_tmpDir) _tmpDir = mkdtempSync(join(tmpdir(), 'sm-unknown-opts-'))
+  return join(_tmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_tmpDir) rmSync(_tmpDir, { recursive: true, force: true })
+})
+
+/** Spy console.warn (log.warn routes through it) and collect formatted lines. */
+function captureWarnings(fn) {
+  const warnings = []
+  const orig = console.warn
+  console.warn = (...args) => { warnings.push(args.join(' ')) }
+  try {
+    fn()
+  } finally {
+    console.warn = orig
+  }
+  return warnings
+}
+
+describe('SessionManager unknown/misnamed ctor opts (#6944)', () => {
+  let _origLevel
+  beforeEach(() => {
+    // Pin the log level so `log.warn` reliably reaches console.warn regardless
+    // of a globally-set LOG_LEVEL.
+    _origLevel = getLogLevel()
+    setLogLevel('debug')
+  })
+  afterEach(() => {
+    setLogLevel(_origLevel)
+  })
+
+  it('maps a misnamed `provider` to `providerType` and warns (does not silently default to claude-tui)', () => {
+    let mgr
+    const warnings = captureWarnings(() => {
+      mgr = new SessionManager({
+        skipPreflight: true,
+        provider: 'claude-cli', // WRONG key — the ctor opt is `providerType`
+        stateFilePath: tmpStateFile(),
+      })
+    })
+
+    // The misnamed key is recovered, not swallowed: the manager uses the
+    // provider the caller intended, NOT the silent DEFAULT_PROVIDER fallback
+    // (which is what spawned the real PTY in #6933).
+    assert.equal(mgr._providerType, 'claude-cli')
+    assert.notEqual(mgr._providerType, DEFAULT_PROVIDER)
+
+    const surfaced = warnings.find((w) => w.includes("'provider'") && w.includes('providerType'))
+    assert.ok(surfaced, `expected a warning naming both provider and providerType; got: ${JSON.stringify(warnings)}`)
+  })
+
+  it('keeps an explicit `providerType` and warns that `provider` is ignored when both are passed', () => {
+    let mgr
+    const warnings = captureWarnings(() => {
+      mgr = new SessionManager({
+        skipPreflight: true,
+        provider: 'claude-cli',
+        providerType: 'claude-sdk',
+        stateFilePath: tmpStateFile(),
+      })
+    })
+
+    // Explicit providerType wins; provider does not clobber it.
+    assert.equal(mgr._providerType, 'claude-sdk')
+    const surfaced = warnings.find((w) => w.includes("ignoring constructor option 'provider'"))
+    assert.ok(surfaced, `expected an "ignoring provider" warning; got: ${JSON.stringify(warnings)}`)
+  })
+
+  it('warns on any other unrecognized key under the debug flag (persistenceDebounceMs typo)', () => {
+    const prev = process.env.CHROXY_DEBUG_CTOR_OPTS
+    process.env.CHROXY_DEBUG_CTOR_OPTS = '1'
+    try {
+      const warnings = captureWarnings(() => {
+        // eslint-disable-next-line no-new
+        new SessionManager({
+          skipPreflight: true,
+          persistenceDebounceMs: 0, // WRONG key — the ctor opt is `persistDebounceMs`
+          stateFilePath: tmpStateFile(),
+        })
+      })
+      const surfaced = warnings.find((w) => w.includes('persistenceDebounceMs') && w.includes('unrecognized'))
+      assert.ok(surfaced, `expected an unrecognized-option warning naming the typo; got: ${JSON.stringify(warnings)}`)
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_DEBUG_CTOR_OPTS
+      else process.env.CHROXY_DEBUG_CTOR_OPTS = prev
+    }
+  })
+
+  it('does NOT warn about ctor opts when every option is recognized (no false positives)', () => {
+    // Force the general check on so a stray unknown key WOULD warn — proving the
+    // silence below is because all keys are legitimate, not because the check is
+    // dormant.
+    const prev = process.env.CHROXY_DEBUG_CTOR_OPTS
+    process.env.CHROXY_DEBUG_CTOR_OPTS = '1'
+    try {
+      const warnings = captureWarnings(() => {
+        // eslint-disable-next-line no-new
+        new SessionManager({
+          skipPreflight: true,
+          maxSessions: 5,
+          providerType: 'claude-cli',
+          persistDebounceMs: 0,
+          stateFilePath: tmpStateFile(),
+        })
+      })
+      const ctorWarn = warnings.find((w) =>
+        w.includes('unrecognized constructor option') ||
+        w.includes("'provider' is not a constructor option") ||
+        w.includes("ignoring constructor option 'provider'"))
+      assert.equal(ctorWarn, undefined, `unexpected ctor-opt warning: ${JSON.stringify(warnings)}`)
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_DEBUG_CTOR_OPTS
+      else process.env.CHROXY_DEBUG_CTOR_OPTS = prev
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`SessionManager`'s constructor destructured its known options and **silently dropped everything else**. A caller passing `provider:` — the `createSession()` option — where the constructor expects `providerType:` was ignored, so `createSession()` fell back to `DEFAULT_PROVIDER` (`claude-tui`) and spawned a **real `claude` node-pty PTY**. That leaked handle was the root cause of the #6933 CI hang (two tests passed `provider:` to the ctor).

This hardens the construction boundary the same way `lint-session-opt-forwarding.sh` guards `BaseSession` opt forwarding — but for the `SessionManager` ctor.

## Approach (and why)

- **Object-rest capture, not a parallel allow-list.** `...unknownCtorOpts` captures exactly the keys not destructured above, so the destructure itself stays the single source of truth for "known" keys — nothing to drift.
- **Targeted alias for `provider` (always on, warn-and-map, never throw).** When only `provider` is supplied as a usable string, it is mapped onto `providerType` with a warning, so the caller gets the provider they intended instead of a silent `claude-tui` PTY spawn. If `providerType` is already set explicitly (or `provider` is not a usable id — `undefined`/`null`/`''`), the resolved `providerType` is kept and a warning notes `provider` is ignored. **Never throws** — a prod caller must not crash on a friendly alias (per the issue's guidance).
- **General unrecognized-key warning, gated to `NODE_ENV==='test'` / `CHROXY_DEBUG_CTOR_OPTS=1`** so a long-lived daemon log isn't spammed (the manager is constructed once per daemon), while still catching the whole footgun class in the suite where it actually bites.

## Audit of other misuses (AC #3)

- The two files named in the issue (`permission-expired-broadcast.test.js`, `permission-resolved-broadcast.test.js`) were already corrected to `providerType:` in #6933. No other test passes `provider:` to the **constructor** — every remaining `provider:` is a `createSession()` call, where `provider` is the correct key.
- Both of those files, however, still passed a *second* misnamed key — `persistenceDebounceMs` (the real ctor opt is `persistDebounceMs`), silently ignored. Same class of bug; fixed to `persistDebounceMs`.

## Tests

New `packages/server/tests/session-manager-unknown-opts.test.js`:
- maps a misnamed `provider` → `providerType` and warns, and asserts it does **not** silently default to `claude-tui`;
- keeps an explicit `providerType` and warns `provider` is ignored when both are passed;
- warns on any other unrecognized key under the debug flag;
- no false positive when every option is recognized (debug flag forced on to prove the check is live).

## Verification

- New test: 4/4 pass.
- **Full server suite, CI-way** (`c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'`): **self-exits cleanly** in ~85s (no hang / no leaked handle — the #6933 concern), **12225/12241 pass**. The 3 remaining failures are pre-existing, environment-dependent tests unrelated to this change (`doctor.test.js` OpenAI-credential check, `codex-spawn-argv.integration.test.js` clap-argv harness needing the codex binary, `sidecar/agent.test.js` PodAgent pod-sidecar spawn) — reproduced identically on the clean base with these changes stashed.
- All 5 server custom lints green (`lint-tests-state-file-path`, `lint-session-opt-forwarding`, etc.).

Closes #6944