### PR TITLE
fix(dashboard): client-side timeout for git one-shot callbacks (commit + create-PR)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -484,41 +484,90 @@ function activeSessionIsClaudeTui(get: () => ConnectionState): boolean {
 }
 
 // #6939 — client-side timeout for the git one-shot request/reply callbacks
-// (git_commit + git_create_pr). GitPanel arms a one-shot callback and flips a
-// busy flag (committing / prSubmitting) before sending the request. If the
-// socket send succeeds but the daemon never replies (mid-flight disconnect,
-// crash), the callback would stay armed and the button stuck spinning forever,
-// unrecoverable without a remount. We arm a timer alongside the callback; on
-// expiry, if the callback is still armed, we resolve it with a timeout-error
-// result so GitPanel surfaces an error and clears its busy flag, then disarm.
-// A real reply — or the not-connected send-failure path — both flow through
-// setGit*Callback(null), which clears the timer. One shared mechanism (DRY),
-// keyed by the store field name so commit + create-PR share it.
+// (git_stage/git_unstage + git_commit + git_create_pr). GitPanel arms a
+// one-shot callback and flips a busy flag (stagingInProgress / committing /
+// prSubmitting) before sending the request. If the socket send succeeds but
+// the daemon never replies (mid-flight disconnect, crash), the callback would
+// stay armed and the button stuck spinning forever, unrecoverable without a
+// remount. We arm a timer alongside the callback; on expiry, if the callback
+// is still armed, we resolve it with a timeout-error result so GitPanel
+// surfaces an error and clears its busy flag, then disarm. A real reply — or
+// the not-connected send-failure path — both flow through setGit*Callback(null),
+// which clears the timer. One shared mechanism (DRY), keyed by the store
+// field name so stage/unstage + commit + create-PR all share it.
+//
+// #6954 — the same timer registry backs a disconnect/close/error fast-reject
+// (clearGitOneshotCallbacks below): a dead socket means the daemon can never
+// reply, so there's no reason to make the user wait out the full timeout.
 export const GIT_ONESHOT_CALLBACK_TIMEOUT_MS = 30_000;
 
-// Message handed to a still-armed callback when the daemon never replies.
+// Message handed to a still-armed callback when the daemon never replies —
+// whether because the deadline elapsed or the socket dropped out from under it.
 export const GIT_ONESHOT_TIMEOUT_ERROR = 'No response from the daemon — reconnect and try again';
 
-type GitOneshotCallbackKey = '_gitCommitCallback' | '_gitCreatePrCallback';
+type GitOneshotCallbackKey = '_gitStageCallback' | '_gitCommitCallback' | '_gitCreatePrCallback';
+
+// The result type a given git one-shot callback key expects, derived directly
+// from ConnectionState's field type (GitStageResult / GitCommitResult /
+// GitCreatePrResult) rather than duplicated here — single source of truth.
+// #6955 Copilot review: replaces the earlier `unknown`-typed
+// `timeoutResult` param + `as ((result: unknown) => void)` cast in
+// armGitOneshotCallback, which let a mismatched (key, result) pair through
+// uncaught. With this, passing e.g. a GitCommitResult shape for
+// `_gitStageCallback` is now a compile error.
+type GitOneshotResult<K extends GitOneshotCallbackKey> =
+  ConnectionState[K] extends ((result: infer R) => void) | null ? R : never;
 
 // Module-level timer registry (mirrors `searchTimeoutId` above) — keeps raw
 // timer handles out of the persisted store state.
 const gitOneshotTimers: Record<GitOneshotCallbackKey, ReturnType<typeof setTimeout> | undefined> = {
+  _gitStageCallback: undefined,
   _gitCommitCallback: undefined,
   _gitCreatePrCallback: undefined,
 };
 
+// Clear `key`'s pending timer (if any) and, if a callback is still armed,
+// disarm it (null the store slot) and invoke it with `result`. Shared by the
+// timeout path (armGitOneshotCallback's setTimeout, below) and the
+// disconnect/close/error fast-reject path (clearGitOneshotCallbacks, below)
+// so both go through the exact same one-shot / null-before-invoke contract:
+// disarm BEFORE invoking so the callback's own setGit*Callback(null) is a
+// harmless no-op and a later reply/timeout/disconnect can never double-fire it.
+function disarmGitOneshotCallback<K extends GitOneshotCallbackKey>(
+  set: (partial: Partial<ConnectionState>) => void,
+  get: () => ConnectionState,
+  key: K,
+  result: GitOneshotResult<K>,
+): void {
+  const timer = gitOneshotTimers[key];
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    gitOneshotTimers[key] = undefined;
+  }
+  const armed = get()[key];
+  if (!armed) return; // no callback armed (already resolved, or never armed)
+  set({ [key]: null } as Partial<ConnectionState>);
+  // TS can't fully distribute a generic conditional (infer) type over a
+  // type-parameterized index access inside a generic function body — `armed`
+  // and `result` are provably matched at every concrete call site (each
+  // passes a literal key), so this narrows the otherwise-unresolvable
+  // `ConnectionState[K]` to the same `GitOneshotResult<K>` used for `result`
+  // above, rather than falling back to `unknown`.
+  (armed as (result: GitOneshotResult<K>) => void)(result);
+}
+
 // Arm (cb non-null) or disarm (cb null) a git one-shot callback, managing its
 // timeout in one place. Always clears any prior timer first, so re-arming or
 // disarming is race-free. `timeoutResult` is the payload handed to a still-armed
-// callback if the daemon never replies — its shape must match what GitPanel
-// expects for that flow (GitCommitResult / GitCreatePrResult).
-function armGitOneshotCallback(
+// callback if the daemon never replies — its shape is inferred from `key`'s
+// own callback type (GitStageResult / GitCommitResult / GitCreatePrResult), so
+// a mismatched shape for the given key fails to compile.
+function armGitOneshotCallback<K extends GitOneshotCallbackKey>(
   set: (partial: Partial<ConnectionState>) => void,
   get: () => ConnectionState,
-  key: GitOneshotCallbackKey,
-  cb: ConnectionState[GitOneshotCallbackKey],
-  timeoutResult: unknown,
+  key: K,
+  cb: ConnectionState[K],
+  timeoutResult: GitOneshotResult<K>,
 ): void {
   const prev = gitOneshotTimers[key];
   if (prev !== undefined) {
@@ -532,13 +581,37 @@ function armGitOneshotCallback(
 
   gitOneshotTimers[key] = setTimeout(() => {
     gitOneshotTimers[key] = undefined;
-    const armed = get()[key] as ((result: unknown) => void) | null;
-    if (!armed) return; // a real reply already resolved + nulled the callback
-    // One-shot: disarm before invoking so the callback's own setGit*Callback(null)
-    // is a harmless no-op and the reply path can never double-fire it.
-    set({ [key]: null } as Partial<ConnectionState>);
-    armed(timeoutResult);
+    disarmGitOneshotCallback(set, get, key, timeoutResult);
   }, GIT_ONESHOT_CALLBACK_TIMEOUT_MS);
+}
+
+// #6954 — fast-reject every still-armed git one-shot callback (stage/unstage,
+// commit, create-PR) on socket disconnect/close/error, mirroring the sibling
+// rejectAllEvaluatorRequests / clearPendingTrustGrants / clearPendingModelReverts
+// calls in the same onclose/onerror/disconnect() paths below. Without this, a
+// mid-flight disconnect left GitPanel's busy flag (stagingInProgress /
+// committing / prSubmitting) spinning for up to the full
+// GIT_ONESHOT_CALLBACK_TIMEOUT_MS (30s) instead of clearing instantly with an
+// error — a dead socket means the daemon really can never reply. Each
+// callback gets the disconnect-shaped result matching its own type (the same
+// result the timeout path would eventually send).
+function clearGitOneshotCallbacks(
+  set: (partial: Partial<ConnectionState>) => void,
+  get: () => ConnectionState,
+): void {
+  disarmGitOneshotCallback(set, get, '_gitStageCallback', { error: GIT_ONESHOT_TIMEOUT_ERROR });
+  disarmGitOneshotCallback(set, get, '_gitCommitCallback', {
+    hash: null,
+    message: null,
+    error: GIT_ONESHOT_TIMEOUT_ERROR,
+  });
+  disarmGitOneshotCallback(set, get, '_gitCreatePrCallback', {
+    url: null,
+    number: null,
+    branch: null,
+    base: null,
+    error: GIT_ONESHOT_TIMEOUT_ERROR,
+  });
 }
 
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
@@ -2491,6 +2564,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       clearPendingModelReverts();
       clearPendingPermissionModeReverts();
       clearPendingThinkingLevelReverts();
+      // #6954: a dropped socket means any in-flight git one-shot reply
+      // (stage/unstage, commit, create-PR) will never arrive — fast-reject
+      // the still-armed callback so GitPanel's busy flag clears immediately
+      // instead of spinning for up to the full 30s client-side timeout.
+      clearGitOneshotCallbacks(set, get);
       // #3605: also clear the per-session pendingTrustGrants arrays
       // (added in #3588). disconnect() handles user-initiated closes, but
       // an unexpected drop here would otherwise leave the SkillsPanel
@@ -2678,6 +2756,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       clearPendingModelReverts();
       clearPendingPermissionModeReverts();
       clearPendingThinkingLevelReverts();
+      // #6954: same fast-reject as onclose above — an errored socket means
+      // any in-flight git one-shot reply will never arrive.
+      clearGitOneshotCallbacks(set, get);
       const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
       set({ socket: null, sessionStates: cleanedSessionStates });
@@ -2716,6 +2797,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     clearPendingModelReverts();
     clearPendingPermissionModeReverts();
     clearPendingThinkingLevelReverts();
+    // #6954: same fast-reject as onclose/onerror — an explicit disconnect
+    // means any in-flight git one-shot reply will never arrive on this socket.
+    clearGitOneshotCallbacks(set, get);
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -4185,8 +4269,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // requestGitUnstage (packages/app/src/store/connection.ts): both return
   // false when the socket is closed so GitPanel can surface a "not
   // connected" error instead of leaving its spinner stuck forever (#6288).
+  // #6955 — arm (or clear) a client-side timeout alongside the one-shot
+  // callback so a never-arriving git_stage_result/git_unstage_result can't
+  // strand GitPanel's stagingInProgress flag (same failure mode + mechanism
+  // as the commit/create-PR flows below).
   setGitStageCallback: (cb) => {
-    set({ _gitStageCallback: cb });
+    armGitOneshotCallback(set, get, '_gitStageCallback', cb, {
+      error: GIT_ONESHOT_TIMEOUT_ERROR,
+    });
   },
 
   requestGitStage: (paths) => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -483,6 +483,64 @@ function activeSessionIsClaudeTui(get: () => ConnectionState): boolean {
   return s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.provider === DEFAULT_PROVIDER;
 }
 
+// #6939 — client-side timeout for the git one-shot request/reply callbacks
+// (git_commit + git_create_pr). GitPanel arms a one-shot callback and flips a
+// busy flag (committing / prSubmitting) before sending the request. If the
+// socket send succeeds but the daemon never replies (mid-flight disconnect,
+// crash), the callback would stay armed and the button stuck spinning forever,
+// unrecoverable without a remount. We arm a timer alongside the callback; on
+// expiry, if the callback is still armed, we resolve it with a timeout-error
+// result so GitPanel surfaces an error and clears its busy flag, then disarm.
+// A real reply — or the not-connected send-failure path — both flow through
+// setGit*Callback(null), which clears the timer. One shared mechanism (DRY),
+// keyed by the store field name so commit + create-PR share it.
+export const GIT_ONESHOT_CALLBACK_TIMEOUT_MS = 30_000;
+
+// Message handed to a still-armed callback when the daemon never replies.
+export const GIT_ONESHOT_TIMEOUT_ERROR = 'No response from the daemon — reconnect and try again';
+
+type GitOneshotCallbackKey = '_gitCommitCallback' | '_gitCreatePrCallback';
+
+// Module-level timer registry (mirrors `searchTimeoutId` above) — keeps raw
+// timer handles out of the persisted store state.
+const gitOneshotTimers: Record<GitOneshotCallbackKey, ReturnType<typeof setTimeout> | undefined> = {
+  _gitCommitCallback: undefined,
+  _gitCreatePrCallback: undefined,
+};
+
+// Arm (cb non-null) or disarm (cb null) a git one-shot callback, managing its
+// timeout in one place. Always clears any prior timer first, so re-arming or
+// disarming is race-free. `timeoutResult` is the payload handed to a still-armed
+// callback if the daemon never replies — its shape must match what GitPanel
+// expects for that flow (GitCommitResult / GitCreatePrResult).
+function armGitOneshotCallback(
+  set: (partial: Partial<ConnectionState>) => void,
+  get: () => ConnectionState,
+  key: GitOneshotCallbackKey,
+  cb: ConnectionState[GitOneshotCallbackKey],
+  timeoutResult: unknown,
+): void {
+  const prev = gitOneshotTimers[key];
+  if (prev !== undefined) {
+    clearTimeout(prev);
+    gitOneshotTimers[key] = undefined;
+  }
+
+  set({ [key]: cb } as Partial<ConnectionState>);
+
+  if (!cb) return;
+
+  gitOneshotTimers[key] = setTimeout(() => {
+    gitOneshotTimers[key] = undefined;
+    const armed = get()[key] as ((result: unknown) => void) | null;
+    if (!armed) return; // a real reply already resolved + nulled the callback
+    // One-shot: disarm before invoking so the callback's own setGit*Callback(null)
+    // is a harmless no-op and the reply path can never double-fire it.
+    set({ [key]: null } as Partial<ConnectionState>);
+    armed(timeoutResult);
+  }, GIT_ONESHOT_CALLBACK_TIMEOUT_MS);
+}
+
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
   connectionPhase: 'disconnected',
   wsUrl: null,
@@ -4148,8 +4206,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   // #6780 — commit mutation. Same not-connected-guard rationale as stage/unstage.
+  // #6939 — arm (or clear) a client-side timeout alongside the one-shot callback
+  // so a never-arriving git_commit_result can't strand GitPanel's committing flag.
   setGitCommitCallback: (cb) => {
-    set({ _gitCommitCallback: cb });
+    armGitOneshotCallback(set, get, '_gitCommitCallback', cb, {
+      hash: null,
+      message: null,
+      error: GIT_ONESHOT_TIMEOUT_ERROR,
+    });
   },
 
   requestGitCommit: (message) => {
@@ -4164,8 +4228,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // and shells out to `gh pr create`, replying with git_create_pr_result. Same
   // not-connected guard as stage/commit so GitPanel can surface an error instead
   // of leaving a spinner stuck.
+  // #6939 — arm (or clear) a client-side timeout alongside the one-shot callback
+  // so a never-arriving git_create_pr_result can't strand GitPanel's prSubmitting
+  // flag (same failure mode + mechanism as the commit flow above).
   setGitCreatePrCallback: (cb) => {
-    set({ _gitCreatePrCallback: cb });
+    armGitOneshotCallback(set, get, '_gitCreatePrCallback', cb, {
+      url: null,
+      number: null,
+      branch: null,
+      base: null,
+      error: GIT_ONESHOT_TIMEOUT_ERROR,
+    });
   },
 
   requestGitCreatePr: (params) => {

--- a/packages/dashboard/src/store/git-oneshot-callback-timeout.test.ts
+++ b/packages/dashboard/src/store/git-oneshot-callback-timeout.test.ts
@@ -1,0 +1,166 @@
+/**
+ * #6939 — client-side timeout for the git one-shot request/reply callbacks
+ * (git_commit + git_create_pr).
+ *
+ * GitPanel arms a one-shot callback (`_gitCommitCallback` / `_gitCreatePrCallback`)
+ * and flips a busy flag (committing / prSubmitting) before sending the request. If
+ * the socket send succeeds but the daemon never replies (mid-flight disconnect,
+ * crash), the callback would stay armed and the button stuck spinning forever. The
+ * store now arms a timer alongside the callback so a never-arriving reply resolves
+ * the callback with a timeout error and lets the panel recover.
+ *
+ * These tests drive the REAL Zustand store (the timeout lives in the store setters),
+ * with vitest fake timers, and model GitPanel's callback faithfully: it nulls itself
+ * (which clears the store timer) and drops its busy flag.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  useConnectionStore,
+  GIT_ONESHOT_CALLBACK_TIMEOUT_MS,
+  GIT_ONESHOT_TIMEOUT_ERROR,
+} from './connection';
+
+// Both one-shot git flows share the arm-with-timeout mechanism (DRY), so the
+// scenarios are parametrized over the commit + create-PR setters/fields.
+const FLOWS = [
+  {
+    label: 'git_commit',
+    setCb: (cb: unknown) =>
+      useConnectionStore.getState().setGitCommitCallback(cb as never),
+    getArmed: () => useConnectionStore.getState()._gitCommitCallback,
+    successReply: { hash: 'abc123', message: 'feat: x', error: null },
+    // Shape a still-armed git_commit callback receives on timeout (GitCommitResult).
+    timeoutShape: { hash: null, message: null, error: GIT_ONESHOT_TIMEOUT_ERROR },
+  },
+  {
+    label: 'git_create_pr',
+    setCb: (cb: unknown) =>
+      useConnectionStore.getState().setGitCreatePrCallback(cb as never),
+    getArmed: () => useConnectionStore.getState()._gitCreatePrCallback,
+    successReply: {
+      url: 'https://github.com/o/r/pull/1',
+      number: 1,
+      branch: 'feat/x',
+      base: 'main',
+      error: null,
+    },
+    // Shape a still-armed git_create_pr callback receives on timeout (GitCreatePrResult).
+    timeoutShape: {
+      url: null,
+      number: null,
+      branch: null,
+      base: null,
+      error: GIT_ONESHOT_TIMEOUT_ERROR,
+    },
+  },
+] as const;
+
+type Flow = (typeof FLOWS)[number];
+
+// Faithful stand-in for GitPanel's one-shot callback: it nulls itself first
+// (which clears the store timer), then drops its busy flag and records the
+// result — the exact recovery path the panel relies on.
+function armPanel(flow: Flow) {
+  const rec = { busy: true, calls: [] as unknown[] };
+  flow.setCb((result: unknown) => {
+    flow.setCb(null);
+    rec.busy = false;
+    rec.calls.push(result);
+  });
+  return rec;
+}
+
+describe.each(FLOWS)('git one-shot callback timeout — $label (#6939)', (flow) => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Start from a clean slate (also clears any timer a prior test left armed).
+    useConnectionStore.getState().setGitCommitCallback(null);
+    useConnectionStore.getState().setGitCreatePrCallback(null);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  afterEach(() => {
+    useConnectionStore.getState().setGitCommitCallback(null);
+    useConnectionStore.getState().setGitCreatePrCallback(null);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('resolves the armed callback with a timeout error and clears busy when no reply arrives', () => {
+    const rec = armPanel(flow);
+    expect(flow.getArmed()).toBeTypeOf('function');
+    expect(vi.getTimerCount()).toBe(1);
+
+    // The daemon never replies; the deadline elapses.
+    vi.advanceTimersByTime(GIT_ONESHOT_CALLBACK_TIMEOUT_MS);
+
+    // Callback invoked exactly once with the timeout-error payload…
+    expect(rec.calls).toEqual([flow.timeoutShape]);
+    // …the busy flag is cleared (panel recovers)…
+    expect(rec.busy).toBe(false);
+    // …and the one-shot callback is disarmed.
+    expect(flow.getArmed()).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not fire early — the callback stays armed right up to the deadline', () => {
+    const rec = armPanel(flow);
+
+    vi.advanceTimersByTime(GIT_ONESHOT_CALLBACK_TIMEOUT_MS - 1);
+    expect(rec.calls).toHaveLength(0);
+    expect(rec.busy).toBe(true);
+    expect(flow.getArmed()).toBeTypeOf('function');
+
+    vi.advanceTimersByTime(1);
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.busy).toBe(false);
+  });
+
+  it('a real reply clears the timeout — no late timeout error fires', () => {
+    const rec = armPanel(flow);
+
+    // message-handler dispatch: read the armed callback and invoke it with the reply.
+    flow.getArmed()!(flow.successReply as never);
+
+    expect(rec.calls).toEqual([flow.successReply]);
+    expect(rec.busy).toBe(false);
+    expect(flow.getArmed()).toBeNull();
+    // The pending timer must be cleared so it can't fire late.
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Advancing well past the deadline must NOT re-invoke the callback.
+    vi.advanceTimersByTime(GIT_ONESHOT_CALLBACK_TIMEOUT_MS * 2);
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]).toEqual(flow.successReply);
+  });
+
+  it('the not-connected send-failure path clears the timeout', () => {
+    const rec = armPanel(flow);
+    expect(vi.getTimerCount()).toBe(1);
+
+    // GitPanel's send-failure branch disarms the callback directly (requestGit*
+    // returned false), then sets its own error + clears busy.
+    flow.setCb(null);
+
+    expect(flow.getArmed()).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+
+    // No timer remains to fire a spurious timeout error.
+    vi.advanceTimersByTime(GIT_ONESHOT_CALLBACK_TIMEOUT_MS * 2);
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  it('re-arming replaces the prior timer (no stale timeout from a superseded request)', () => {
+    const first = armPanel(flow);
+    // A second request arms a fresh callback before the first ever resolves.
+    const second = armPanel(flow);
+    // Only one timer is live — the first was cleared on re-arm.
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.advanceTimersByTime(GIT_ONESHOT_CALLBACK_TIMEOUT_MS);
+
+    // The stale first callback must NOT fire; only the current one times out.
+    expect(first.calls).toHaveLength(0);
+    expect(second.calls).toEqual([flow.timeoutShape]);
+  });
+});

--- a/packages/dashboard/src/store/git-oneshot-callback-timeout.test.ts
+++ b/packages/dashboard/src/store/git-oneshot-callback-timeout.test.ts
@@ -1,13 +1,22 @@
 /**
  * #6939 — client-side timeout for the git one-shot request/reply callbacks
- * (git_commit + git_create_pr).
+ * (git_stage/git_unstage + git_commit + git_create_pr).
  *
- * GitPanel arms a one-shot callback (`_gitCommitCallback` / `_gitCreatePrCallback`)
- * and flips a busy flag (committing / prSubmitting) before sending the request. If
- * the socket send succeeds but the daemon never replies (mid-flight disconnect,
- * crash), the callback would stay armed and the button stuck spinning forever. The
- * store now arms a timer alongside the callback so a never-arriving reply resolves
- * the callback with a timeout error and lets the panel recover.
+ * GitPanel arms a one-shot callback (`_gitStageCallback` / `_gitCommitCallback` /
+ * `_gitCreatePrCallback`) and flips a busy flag (stagingInProgress / committing /
+ * prSubmitting) before sending the request. If the socket send succeeds but
+ * the daemon never replies (mid-flight disconnect, crash), the callback would
+ * stay armed and the button stuck spinning forever. The store now arms a
+ * timer alongside the callback so a never-arriving reply resolves the
+ * callback with a timeout error and lets the panel recover.
+ *
+ * #6954/#6955 — a mid-flight WS disconnect (onclose/onerror/disconnect()) now
+ * ALSO fast-rejects any still-armed git one-shot callback immediately, rather
+ * than leaving it to spin for up to the full client-side timeout: a dead
+ * socket means the daemon can never reply. `disconnect()` is the directly
+ * unit-testable entry point (onclose/onerror require a live mock WebSocket
+ * mid-handshake) and drives the exact same shared `clearGitOneshotCallbacks`
+ * helper the close/error paths use.
  *
  * These tests drive the REAL Zustand store (the timeout lives in the store setters),
  * with vitest fake timers, and model GitPanel's callback faithfully: it nulls itself
@@ -20,9 +29,20 @@ import {
   GIT_ONESHOT_TIMEOUT_ERROR,
 } from './connection';
 
-// Both one-shot git flows share the arm-with-timeout mechanism (DRY), so the
-// scenarios are parametrized over the commit + create-PR setters/fields.
+// All three one-shot git flows share the arm-with-timeout mechanism (DRY), so
+// the scenarios are parametrized over the stage + commit + create-PR
+// setters/fields.
 const FLOWS = [
+  {
+    label: 'git_stage',
+    setCb: (cb: unknown) =>
+      useConnectionStore.getState().setGitStageCallback(cb as never),
+    getArmed: () => useConnectionStore.getState()._gitStageCallback,
+    successReply: { error: null },
+    // Shape a still-armed git_stage/git_unstage callback receives on timeout
+    // (GitStageResult) — and, per #6954, on a mid-flight disconnect too.
+    timeoutShape: { error: GIT_ONESHOT_TIMEOUT_ERROR },
+  },
   {
     label: 'git_commit',
     setCb: (cb: unknown) =>
@@ -74,12 +94,14 @@ describe.each(FLOWS)('git one-shot callback timeout — $label (#6939)', (flow) 
   beforeEach(() => {
     vi.useFakeTimers();
     // Start from a clean slate (also clears any timer a prior test left armed).
+    useConnectionStore.getState().setGitStageCallback(null);
     useConnectionStore.getState().setGitCommitCallback(null);
     useConnectionStore.getState().setGitCreatePrCallback(null);
     expect(vi.getTimerCount()).toBe(0);
   });
 
   afterEach(() => {
+    useConnectionStore.getState().setGitStageCallback(null);
     useConnectionStore.getState().setGitCommitCallback(null);
     useConnectionStore.getState().setGitCreatePrCallback(null);
     vi.clearAllTimers();
@@ -162,5 +184,43 @@ describe.each(FLOWS)('git one-shot callback timeout — $label (#6939)', (flow) 
     // The stale first callback must NOT fire; only the current one times out.
     expect(first.calls).toHaveLength(0);
     expect(second.calls).toEqual([flow.timeoutShape]);
+  });
+
+  // #6954 — a mid-flight WS disconnect must fast-reject a still-armed git
+  // one-shot callback immediately, instead of leaving GitPanel's busy flag
+  // spinning for up to the full 30s client-side timeout. `disconnect()`
+  // shares the exact clearGitOneshotCallbacks() helper the socket
+  // onclose/onerror handlers call, so exercising it here covers the same
+  // fast-reject logic those transport-drop paths run.
+  it('disconnect() fast-rejects the armed callback immediately and clears its timer (#6954)', () => {
+    const rec = armPanel(flow);
+    expect(flow.getArmed()).toBeTypeOf('function');
+    expect(vi.getTimerCount()).toBe(1);
+
+    useConnectionStore.getState().disconnect();
+
+    // Fast-rejected synchronously — no need to advance the fake clock at all.
+    expect(rec.calls).toEqual([flow.timeoutShape]);
+    // …the busy flag is cleared (panel recovers) immediately…
+    expect(rec.busy).toBe(false);
+    // …and the one-shot callback is disarmed.
+    expect(flow.getArmed()).toBeNull();
+    // The pending 30s timer must be cleared — it can't fire a duplicate/late
+    // reject after the fast-reject already resolved the callback.
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Advancing well past the deadline must NOT re-invoke the callback.
+    vi.advanceTimersByTime(GIT_ONESHOT_CALLBACK_TIMEOUT_MS * 2);
+    expect(rec.calls).toHaveLength(1);
+  });
+
+  it('disconnect() is a no-op when no git one-shot callback is armed', () => {
+    expect(flow.getArmed()).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+
+    expect(() => useConnectionStore.getState().disconnect()).not.toThrow();
+
+    expect(flow.getArmed()).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up hardening from review of #6934. The dashboard `GitPanel` arms a **one-shot** callback (`_gitCommitCallback` / `_gitCreatePrCallback`) and flips a busy flag (`committing` / `prSubmitting`) before sending `git_commit` / `git_create_pr`. The callback nulls itself on reply, and there is a not-connected guard for a failed send. But if the socket sends successfully and the daemon then **never replies** (mid-flight disconnect, daemon crash), the callback stayed armed and the busy flag stayed `true` — the button stuck on "Committing…" / "Opening…" forever, with no recovery short of a remount.

This adds a **purely client-side** timeout so a never-arriving reply resolves the callback with a timeout error and lets the panel recover.

## Approach

A single shared helper `armGitOneshotCallback(set, get, key, cb, timeoutResult)` (DRY — used by both flows) routed through `setGitCommitCallback` and `setGitCreatePrCallback`:

- **Arm:** when a non-null callback is set, start a timer (`GIT_ONESHOT_CALLBACK_TIMEOUT_MS = 30_000`). On expiry, if the callback is still armed, resolve it with a timeout-error result (`GIT_ONESHOT_TIMEOUT_ERROR = "No response from the daemon — reconnect and try again"`), then disarm. GitPanel's **existing** callback path shows the error and clears its busy flag — no `GitPanel.tsx` change needed.
- **Real reply:** GitPanel's callback nulls itself via `setGit*Callback(null)`, which clears the pending timer so it can't fire late.
- **Send-failure path:** GitPanel's not-connected branch also calls `setGit*Callback(null)`, clearing the timer.
- **Re-arm:** any prior timer is cleared first, so a superseded request can't fire a stale timeout.

Timer handles live in a module-level registry (mirrors the existing `searchTimeoutId`), keeping raw handles out of the persisted store state.

**No new wire message; no protocol / store-core changes.** Coverage guards untouched.

## Tests

New `packages/dashboard/src/store/git-oneshot-callback-timeout.test.ts` drives the real Zustand store with `vi.useFakeTimers()`, parametrized over both flows (commit + create-PR), covering:
1. Timeout with no reply → callback invoked once with the timeout-error result, busy flag cleared, callback nulled.
2. No early fire (armed right up to the deadline).
3. A real reply clears the timeout → no late error fires.
4. The not-connected send-failure path clears the timeout.
5. Re-arming replaces the prior timer (no stale timeout from a superseded request).

## Verification

- `npx vitest run` (full dashboard suite): **274 files / 4731 tests passing** (10 new).
- `npx tsc --noEmit`: clean.
- store-core / protocol untouched.

Closes #6939