### PR TITLE
ci(repo-relay): stop pull_request_review from spawning stuck action_required runs

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -3,8 +3,15 @@ name: Repo Relay
 on:
   pull_request:
     types: [opened, closed, reopened, synchronize, edited, ready_for_review, converted_to_draft]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
+  # No pull_request_review trigger (#6749): GitHub's bot-triggered-workflow
+  # approval policy gates the run BEFORE job-level `if` conditions evaluate,
+  # so a Copilot-authored review still spawns a run held in action_required
+  # forever (the REST approve endpoint 403s on these) — the check suite
+  # never completes and green PRs read UNSTABLE. Actor filters can't reach
+  # far enough upstream to prevent it, so the trigger itself has to go.
+  # repo-relay's piggyback review detection already surfaces a missed
+  # review on the next pull_request event, so this only trades notification
+  # latency for a PR that never gets stuck.
   issue_comment:
     types: [created, edited, deleted]
   issues:


### PR DESCRIPTION
## Problem

Every time Copilot posts a PR review, the `pull_request_review` event triggers `.github/workflows/repo-relay.yml`. GitHub's bot-triggered-workflow approval policy holds that run in `action_required` — it never executes, its check suite never completes, and the PR's `mergeStateStatus` reads `UNSTABLE` even when every real check is green. The REST approve endpoint returns 403 for these runs ("not from a fork pull request"), so they can't be approved programmatically.

Observed on PR #6746 (run 29554446616) and PR #6739 (run 29550515821).

## Why a job-level `if:` guard can't fix it

The bot-triggered-workflow approval gate holds the run **before** job-level `if:` conditions are evaluated. An actor filter on the `notify` job (e.g. `github.event.review.user.login != 'copilot-pull-request-reviewer[bot]'`) never gets a chance to run — the workflow run itself is what's stuck pending approval, not a job inside it. Since `on:` triggers can't filter by actor, the only workflow-file-level fix is to stop triggering on `pull_request_review` altogether.

## Fix

Drop `pull_request_review` from the `on:` list in `repo-relay.yml`. A comment at the removal site documents why (points back to #6749).

This does not lose the relay's actual purpose: repo-relay's piggyback review detection (`src/github/reviews.ts` in `blamechris/repo-relay`) already surfaces a review that happened between events on the next `pull_request` event (e.g. `synchronize`, `edited`, `closed`). The only tradeoff is notification latency for human reviews between PR events — the Discord relay for PR/issue/comment/release activity via `pull_request`, `issue_comment`, `issues`, and `release` is untouched.

## Verification

- `actionlint .github/workflows/repo-relay.yml` — exits 0, no findings.
- Node YAML parse confirms the `on:` block now has exactly `pull_request`, `issue_comment`, `issues`, `release` (no `pull_request_review`), and all other trigger types are unchanged.
- No other workflow in this repo runs actionlint/yaml-lint in CI, so there's no additional gate to satisfy beyond the diff itself.
- Result: a Copilot review on any PR no longer creates a new `repo-relay` workflow run at all, so there's nothing to sit in `action_required` — the PR's check suite can reach `CLEAN` on green checks.

Closes #6749