### PR TITLE
fix(dashboard,app): dedupe split-view comment gutter + clear stale comments on auto-refresh

### DIFF
--- a/packages/app/src/components/__tests__/DiffViewer.test.tsx
+++ b/packages/app/src/components/__tests__/DiffViewer.test.tsx
@@ -158,6 +158,35 @@ describe('DiffViewer inline comments (#6800)', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('keeps queued comments when the send fails (#6946)', () => {
+    const tree = render();
+    seedFiles(tree);
+
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-line-0' }).props.onPress?.();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-input' }).props.onChangeText?.('note');
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-comment-save' }).props.onPress?.();
+    });
+    expect(tree.root.findAllByProps({ testID: 'diff-submit-comments' }).length).toBeGreaterThan(0);
+
+    sendInputSpy.mockReturnValue(false as any);
+    act(() => {
+      tree.root.findByProps({ testID: 'diff-submit-comments' }).props.onPress?.();
+    });
+
+    // A dropped send (falsy `sendInput` result, mirroring the
+    // wssend_false_sideeffect_callsites convention) must preserve the queue
+    // and leave the modal open — not silently discard the pending comment.
+    expect(sendInputSpy).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(tree.root.findAllByProps({ testID: 'diff-submit-comments' }).length).toBeGreaterThan(0);
+    expect(tree.root.findAllByProps({ testID: 'diff-comment-note-0' }).length).toBeGreaterThan(0);
+  });
+
   it('removes a queued comment', () => {
     const tree = render();
     seedFiles(tree);

--- a/packages/app/src/components/__tests__/DiffViewer.test.tsx
+++ b/packages/app/src/components/__tests__/DiffViewer.test.tsx
@@ -173,7 +173,7 @@ describe('DiffViewer inline comments (#6800)', () => {
     });
     expect(tree.root.findAllByProps({ testID: 'diff-submit-comments' }).length).toBeGreaterThan(0);
 
-    sendInputSpy.mockReturnValue(false as any);
+    sendInputSpy.mockReturnValue(false);
     act(() => {
       tree.root.findByProps({ testID: 'diff-submit-comments' }).props.onPress?.();
     });

--- a/packages/dashboard/src/components/DiffViewerPanel.test.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.test.tsx
@@ -71,6 +71,25 @@ const DIFF_FILES = [
   },
 ]
 
+// A structurally-identical clone of DIFF_FILES[0] — a different object/array
+// reference but the same content, simulating a no-op reconnect re-landing the
+// same diff (#6961).
+const DIFF_FILES_0_CLONE = JSON.parse(JSON.stringify(DIFF_FILES[0]))
+
+// DIFF_FILES[0] with one line's content changed — simulates a genuine diff
+// change (e.g. positions shifted) landing on a reconnect (#6946).
+const DIFF_FILES_0_CHANGED = {
+  ...DIFF_FILES[0]!,
+  hunks: [
+    {
+      ...DIFF_FILES[0]!.hunks[0]!,
+      lines: DIFF_FILES[0]!.hunks[0]!.lines.map((l, i) =>
+        i === 2 ? { ...l, content: 'const y = 99' } : l,
+      ),
+    },
+  ],
+}
+
 describe('DiffViewerPanel', () => {
   it('requests diff on mount', () => {
     render(<DiffViewerPanel />)
@@ -359,7 +378,7 @@ describe('DiffViewerPanel', () => {
     expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
   })
 
-  it('drops queued comments when an auto-refresh/reconnect pushes a new diff, not just manual Refresh (#6946)', () => {
+  it('drops queued comments when an auto-refresh/reconnect pushes a genuinely CHANGED diff, not just manual Refresh (#6946)', () => {
     render(<DiffViewerPanel />)
     act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
 
@@ -370,8 +389,79 @@ describe('DiffViewerPanel', () => {
 
     // Simulate an auto-refresh/reconnect diff push driven by the store — the
     // same `capturedCallback` the connection layer invokes on every diff
-    // (re)request — WITHOUT going through the manual Refresh button.
+    // (re)request — WITHOUT going through the manual Refresh button. The
+    // landed diff has genuinely changed content (positions may have shifted),
+    // which is the case #6946 targets — as opposed to a no-op re-delivery of
+    // the identical diff, which #6961 below asserts is now spared.
+    act(() => capturedCallback!({ files: [DIFF_FILES_0_CHANGED as typeof DIFF_FILES[0]], error: null }))
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
+  })
+
+  it('preserves queued comments and an open draft across a no-op reconnect landing (identical diff) (#6961)', () => {
+    render(<DiffViewerPanel />)
     act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    // Queue a saved comment on the first line.
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+
+    // Open a SECOND line's editor and leave an unsaved draft in it.
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[1]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'unsaved draft' } })
+
+    // A routine WS reconnect re-lands a byte-identical diff — same content,
+    // different object/array reference (as a fresh WS payload would be).
+    act(() => capturedCallback!({ files: [DIFF_FILES_0_CLONE], error: null }))
+
+    // The queued comment survives...
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+    // ...and the open editor + its unsaved draft survive too.
+    expect((screen.getByTestId('diff-comment-input') as HTMLTextAreaElement).value).toBe('unsaved draft')
+  })
+
+  it('clears queued comments and the open draft when a diff-landing genuinely changes (#6946 still holds)', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+
+    // Open a second line's editor with an unsaved draft.
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[1]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'unsaved draft' } })
+
+    // A reconnect that lands genuinely different diff content (positions may
+    // have shifted) still invalidates position-keyed comments + the open
+    // draft — the #6946 behavior is unchanged for the real-change case.
+    act(() => capturedCallback!({ files: [DIFF_FILES_0_CHANGED as typeof DIFF_FILES[0]], error: null }))
+
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
+    expect(screen.queryByTestId('diff-comment-input')).toBeNull()
+  })
+
+  it('clears queued comments on manual Refresh even though the returned diff turns out unchanged', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+
+    // Manual Refresh clears synchronously, regardless of what the diff
+    // eventually turns out to contain when it lands.
+    fireEvent.click(screen.getByText('Refresh'))
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
+
+    // Even if the diff that lands afterward is identical to what was shown
+    // before the refresh, the comments stay cleared (there's nothing to
+    // preserve — handleRefresh already dropped them as an explicit user
+    // action).
+    act(() => capturedCallback!({ files: [DIFF_FILES_0_CLONE], error: null }))
     expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/DiffViewerPanel.test.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.test.tsx
@@ -199,11 +199,28 @@ describe('DiffViewerPanel', () => {
     render(<DiffViewerPanel />)
     act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
     fireEvent.click(screen.getByText('Split'))
-    // Each non-empty split cell is commentable: the 2 context lines appear on
-    // both sides (2 buttons each), the deletion + its first paired addition are
-    // one button each, and the standalone second addition adds one more →
-    // 2 + 2 + 1 + 1 + 1 = 7 buttons across the 4 split rows.
-    expect(screen.getAllByTestId('diff-line-comment-btn')).toHaveLength(7)
+    // Each non-empty split cell is commentable, but a context line (same
+    // target on both sides) contributes exactly ONE button, on the new-file
+    // (right) side (#6947) — not two. The 2 context lines contribute 1 each,
+    // the deletion + its paired addition are one button each, and the
+    // standalone second addition adds one more → 1 + 2 + 1 + 1 = 5 buttons
+    // across the 4 split rows.
+    expect(screen.getAllByTestId('diff-line-comment-btn')).toHaveLength(5)
+  })
+
+  it('shows exactly one comment affordance for a context line in split view (#6947)', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+    fireEvent.click(screen.getByText('Split'))
+
+    // The two context rows (index 0 and 4 in the fixture hunk) each carry a
+    // SINGLE comment target shared by both columns — assert only one gutter
+    // button renders per context row, not one per side.
+    const rows = screen.getAllByTestId('split-row')
+    const contextRows = [rows[0]!, rows[3]!]
+    for (const row of contextRows) {
+      expect(row.querySelectorAll('[data-testid="diff-line-comment-btn"]')).toHaveLength(1)
+    }
   })
 
   it('queues and submits a comment made in the split view', () => {
@@ -211,10 +228,11 @@ describe('DiffViewerPanel', () => {
     act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
     fireEvent.click(screen.getByText('Split'))
 
-    // Button order follows the split rows: [ctx0-L, ctx0-R, del1-L, add2-R,
-    // add3-R, ctx4-L, ctx4-R]. Index 3 is the addition `const y = 3` (new-file
-    // line 11) on the right side of the second row.
-    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[3]!)
+    // Button order follows the split rows: [ctx0-R, del1-L, add2-R, add3-R,
+    // ctx4-R] (context rows now contribute a single right-side button —
+    // #6947). Index 2 is the addition `const y = 3` (new-file line 11) on
+    // the right side of the second row.
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[2]!)
     fireEvent.change(screen.getByTestId('diff-comment-input'), {
       target: { value: 'use a const enum' },
     })
@@ -338,6 +356,22 @@ describe('DiffViewerPanel', () => {
     expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
 
     fireEvent.click(screen.getByText('Refresh'))
+    expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
+  })
+
+  it('drops queued comments when an auto-refresh/reconnect pushes a new diff, not just manual Refresh (#6946)', () => {
+    render(<DiffViewerPanel />)
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
+
+    fireEvent.click(screen.getAllByTestId('diff-line-comment-btn')[0]!)
+    fireEvent.change(screen.getByTestId('diff-comment-input'), { target: { value: 'note' } })
+    fireEvent.click(screen.getByTestId('diff-comment-save'))
+    expect(screen.getByTestId('diff-submit-comments-btn')).toBeTruthy()
+
+    // Simulate an auto-refresh/reconnect diff push driven by the store — the
+    // same `capturedCallback` the connection layer invokes on every diff
+    // (re)request — WITHOUT going through the manual Refresh button.
+    act(() => capturedCallback!({ files: [DIFF_FILES[0]!], error: null }))
     expect(screen.queryByTestId('diff-submit-comments-btn')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/DiffViewerPanel.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.tsx
@@ -287,6 +287,14 @@ type SplitCommentApi = { api: CommentApi; targets: LineCommentTarget[] }
  * `hunk.lines` index, and any saved comment / open editor renders full-width
  * below the row. A context line is the same index on both sides, so it shares a
  * single comment surface; a deletion/addition pair carries one per side.
+ *
+ * #6947: a context line's left and right cells resolve to the same comment
+ * target, so rendering the gutter button on both sides offered two clickable
+ * affordances for one logical comment. The button now renders once — on the
+ * new-file (right) side, matching the target's derived new-file line number —
+ * while the left cell still renders the line content and (if present) the
+ * has-comment accent. Deletion/addition cells are single-sided already and are
+ * unaffected.
  */
 function SplitLine({
   left,
@@ -315,11 +323,18 @@ function SplitLine({
     }
     const target = comment.targets[cell.index]!
     const hasComment = comment.api.comments.some((c) => c.id === target.key)
+    // #6947: a context line is the same target on both sides — only the
+    // right (new-file) cell gets the button, so a single comment offers a
+    // single affordance. Deletion (left-only) and addition (right-only)
+    // cells always show their one button as before.
+    const showButton = line?.type !== 'context' || side === 'right'
     return (
       <div
         className={`diff-split-cell diff-split-cell-commentable${hasComment ? ' diff-split-cell-has-comment' : ''} ${base}`}
       >
-        <CommentGutterButton target={target} hasComment={hasComment} onOpen={comment.api.onOpen} />
+        {showButton && (
+          <CommentGutterButton target={target} hasComment={hasComment} onOpen={comment.api.onOpen} />
+        )}
         {line && <span className="diff-line-content">{line.content}</span>}
       </div>
     )
@@ -587,9 +602,17 @@ export function DiffViewerPanel() {
   // Wire callback
   useEffect(() => {
     setDiffCallback((result: DiffResult) => {
+      // #6946: any diff push — the manual Refresh landing OR an unprompted
+      // auto-refresh/reconnect — can shift line positions, invalidating
+      // position-keyed comments. Clear them here (not just in handleRefresh)
+      // so an auto-refresh matches mobile's DiffViewer, which drops pending
+      // comments on every diff (re)request.
       setFiles(result.files)
       setError(result.error)
       setLoading(false)
+      setComments([])
+      setEditing(null)
+      setDraft('')
     })
     return () => setDiffCallback(null)
   }, [setDiffCallback])
@@ -610,8 +633,11 @@ export function DiffViewerPanel() {
   }, [justSent])
 
   const handleRefresh = useCallback(() => {
-    // A refreshed diff can shift line positions, invalidating position-keyed
-    // comments — drop pending annotations so none land on the wrong line.
+    // Clear immediately for snappy UI feedback (the toolbar's submit control
+    // isn't gated on `loading`, so it would otherwise still show a stale
+    // count while the new diff is in flight). The setDiffCallback callback
+    // above clears again once the new diff actually lands, covering the
+    // auto-refresh/reconnect path that never calls this handler (#6946).
     setComments([])
     setEditing(null)
     setDraft('')

--- a/packages/dashboard/src/components/DiffViewerPanel.tsx
+++ b/packages/dashboard/src/components/DiffViewerPanel.tsx
@@ -57,6 +57,51 @@ type CommentApi = {
   onRemove: (key: string) => void
 }
 
+/**
+ * #6961: content-level equality for a landed diff payload. A routine WS
+ * reconnect re-runs the diff-request mount effect and re-lands a diff that is
+ * very often byte-identical to what's already shown. Comparing structurally
+ * (not by reference) lets the landing callback tell a genuine diff change
+ * (positions may have shifted — stale position-keyed comments must still be
+ * cleared, #6946) apart from a no-op re-delivery of the same content (which
+ * must NOT wipe already-queued comments or an actively-open unsaved draft).
+ */
+function diffLinesEqual(a: DiffHunkLine[], b: DiffHunkLine[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]!.type !== b[i]!.type || a[i]!.content !== b[i]!.content) return false
+  }
+  return true
+}
+
+function diffHunksEqual(a: DiffHunk[], b: DiffHunk[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]!.header !== b[i]!.header) return false
+    if (!diffLinesEqual(a[i]!.lines, b[i]!.lines)) return false
+  }
+  return true
+}
+
+function diffFilesEqual(a: DiffFile[], b: DiffFile[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const fa = a[i]!
+    const fb = b[i]!
+    if (
+      fa.path !== fb.path ||
+      fa.status !== fb.status ||
+      fa.additions !== fb.additions ||
+      fa.deletions !== fb.deletions
+    ) {
+      return false
+    }
+    if (!diffHunksEqual(fa.hunks, fb.hunks)) return false
+  }
+  return true
+}
+
 function statusLabel(status: DiffFile['status']): string {
   switch (status) {
     case 'added': return 'A'
@@ -599,20 +644,34 @@ export function DiffViewerPanel() {
   const [draft, setDraft] = useState('')
   const [justSent, setJustSent] = useState<'comments' | 'review' | null>(null)
 
+  // #6961: the last diff content actually landed, so the callback below can
+  // tell a genuine diff change apart from a no-op re-delivery of the same
+  // content (see diffFilesEqual above).
+  const lastDiffRef = useRef<{ files: DiffFile[]; error: string | null }>({ files: [], error: null })
+
   // Wire callback
   useEffect(() => {
     setDiffCallback((result: DiffResult) => {
-      // #6946: any diff push — the manual Refresh landing OR an unprompted
-      // auto-refresh/reconnect — can shift line positions, invalidating
-      // position-keyed comments. Clear them here (not just in handleRefresh)
-      // so an auto-refresh matches mobile's DiffViewer, which drops pending
-      // comments on every diff (re)request.
+      const changed =
+        result.error !== lastDiffRef.current.error ||
+        !diffFilesEqual(result.files, lastDiffRef.current.files)
+      lastDiffRef.current = { files: result.files, error: result.error }
       setFiles(result.files)
       setError(result.error)
       setLoading(false)
-      setComments([])
-      setEditing(null)
-      setDraft('')
+      // #6946: a genuine diff change — the manual Refresh landing OR an
+      // unprompted auto-refresh/reconnect — can shift line positions,
+      // invalidating position-keyed comments. Clear them here (not just in
+      // handleRefresh) so an auto-refresh matches mobile's DiffViewer, which
+      // drops pending comments on every diff (re)request.
+      // #6961: but a routine WS reconnect very often re-lands a
+      // byte-identical diff — in that no-op case, leave already-queued
+      // comments and an actively-open unsaved draft untouched.
+      if (changed) {
+        setComments([])
+        setEditing(null)
+        setDraft('')
+      }
     })
     return () => setDiffCallback(null)
   }, [setDiffCallback])


### PR DESCRIPTION
## Summary

Two diff-comment review follow-ups from #6930/#6945, in the same files.

- **#6947 (dashboard):** in the split diff view, a context line renders in both the left and right columns, and both cells resolved to the same comment target — showing two gutter "+" buttons for one logical comment. `SplitLine`'s `renderCell` now renders the gutter button only on the new-file (right) cell for context lines; deletion/addition cells (single-sided already) are unaffected. Unified view is untouched.
- **#6946 part 1 (dashboard):** `DiffViewerPanel` previously cleared position-keyed comments only on the manual Refresh click. The `setDiffCallback` callback (which also fires on auto-refresh/reconnect) now clears `comments`/`editing`/`draft` whenever a new diff lands, matching mobile's `DiffViewer`, which already clears on every diff (re)request. `handleRefresh`'s synchronous clear is kept for immediate UI feedback (the submit-comments button isn't gated on `loading`).
- **#6946 part 2 (mobile):** added the "send-failure preserves the queued comment" test to `packages/app/src/components/__tests__/DiffViewer.test.tsx`, mirroring the dashboard's existing coverage — asserting that when `sendInput` returns falsy, the comment queue and note are preserved and the modal doesn't close.
- **#6961 (dashboard, data-loss fix):** the #6946 part 1 fix above was too broad — `setDiffCallback` cleared comments/editing/draft on *every* diff landing, including a routine WS reconnect (the mount effect re-runs on every `connectionPhase → 'connected'`), where the returned diff is very often byte-identical to what's already shown. A no-op reconnect was unconditionally wiping already-queued comments and an actively-open unsaved draft. The landing callback now compares the incoming diff to the last-landed one via a structural equality check (path/status/additions/deletions + hunk headers/lines) and only clears comments/editing/draft when the content actually differs. `handleRefresh`'s synchronous clear is unchanged (a manual Refresh is an explicit user action).

Comment id/line-number derivation is unchanged — this is rendering/state-clearing only, so cross-mode stability (#6945) is preserved.

## Test plan

- [x] `packages/dashboard`: `npx vitest run` — 274 files / 4749 tests passed
- [x] `packages/dashboard`: `npx tsc --noEmit` — clean
- [x] `packages/app`: `npx jest src/components/__tests__/DiffViewer.test.tsx --coverage=false` — 7/7 passed
- [x] `packages/app`: `npx tsc --noEmit` — clean
- [x] `store-core/diff-comments.ts` untouched — no store-core test run needed
- [x] New `DiffViewerPanel.test.tsx` coverage for #6961: identical-diff reconnect preserves queued comments + an open unsaved draft; genuinely-changed diff still clears them (#6946 behavior held); manual Refresh still clears even if the diff that lands afterward turns out unchanged

Closes #6947
Closes #6946
Closes #6961
