### PR TITLE
refactor(store-core): hoist viewer↔pending-write correlation helpers (anti-drift)

### DIFF
--- a/packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts
+++ b/packages/app/src/__tests__/components/ViewerPreWriteReview.test.ts
@@ -4,67 +4,17 @@
  *
  * The app has no RN render harness (@testing-library/react-native is not a
  * dep), so — matching the repo's mobile convention (FileEditor.test.ts is a
- * source scan) — behavior is covered two ways:
- *   1. Pure-logic tests of the correlation helpers (pathMatchesViewer /
- *      findPendingWriteForFile): a pending write for the OPEN file is found;
- *      the no-match / resolved(answered) / expired / non-reviewable gates.
- *   2. A source scan pinning the wiring: it reuses PreWriteDiffReview, pulls the
- *      input via requestPermissionInput, routes `editedInput` through
- *      sendPermissionResponse on Approve (and drops it on Deny), and FileEditor
- *      renders <ViewerPreWriteReview>.
+ * source scan) — behavior is covered via a source scan pinning the wiring: it
+ * reuses PreWriteDiffReview, pulls the input via requestPermissionInput, routes
+ * `editedInput` through sendPermissionResponse on Approve (and drops it on
+ * Deny), and FileEditor renders <ViewerPreWriteReview>.
+ *
+ * #6859: the pure correlation helpers (`pathMatchesViewer` /
+ * `findPendingWriteForFile`) were hoisted into `@chroxy/store-core` and their
+ * unit tests moved to `packages/store-core/src/pending-permissions.test.ts`.
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import type { ChatMessage } from '@chroxy/store-core';
-import { pathMatchesViewer, findPendingWriteForFile } from '../../components/ViewerPreWriteReview';
-
-const FILE = '/home/dev/project/src/app.ts';
-
-function editPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
-  return {
-    id: 'perm-1',
-    type: 'prompt',
-    content: 'Edit: change app.ts',
-    tool: 'Edit',
-    requestId: 'req-1',
-    toolInput: { file_path: FILE, old_string: 'a\nb\nc', new_string: 'a\nB\nc' },
-    expiresAt: Date.now() + 60_000,
-    timestamp: Date.now(),
-    ...overrides,
-  } as ChatMessage;
-}
-
-describe('pathMatchesViewer', () => {
-  it('matches identical absolute paths', () => {
-    expect(pathMatchesViewer('/a/b/c.ts', '/a/b/c.ts')).toBe(true);
-  });
-  it('tail-matches an absolute file_path against a workspace-relative selection', () => {
-    expect(pathMatchesViewer('/root/pkg/src/x.ts', 'src/x.ts')).toBe(true);
-    expect(pathMatchesViewer('/root/pkg/src/x.ts', './src/x.ts')).toBe(true);
-  });
-  it('does not match unrelated files or when either side is empty', () => {
-    expect(pathMatchesViewer('/a/b/x.ts', '/a/b/y.ts')).toBe(false);
-    expect(pathMatchesViewer(null, '/a/b/x.ts')).toBe(false);
-    expect(pathMatchesViewer('/a/b/x.ts', null)).toBe(false);
-  });
-});
-
-describe('findPendingWriteForFile', () => {
-  const now = Date.now();
-
-  it('finds a live Write/Edit targeting the open file', () => {
-    expect(findPendingWriteForFile([editPrompt()], FILE, now)?.requestId).toBe('req-1');
-  });
-
-  it('ignores expired, resolved(answered), non-reviewable, or non-matching prompts', () => {
-    expect(findPendingWriteForFile([editPrompt({ expiresAt: now - 1 })], FILE, now)).toBeNull();
-    // resolved gate: markPromptAnswered / permission_resolved set `answered`.
-    expect(findPendingWriteForFile([editPrompt({ answered: 'allow' })], FILE, now)).toBeNull();
-    expect(findPendingWriteForFile([editPrompt({ tool: 'Bash' })], FILE, now)).toBeNull();
-    expect(findPendingWriteForFile([editPrompt()], '/other/file.ts', now)).toBeNull();
-    expect(findPendingWriteForFile([editPrompt()], null, now)).toBeNull();
-  });
-});
 
 describe('ViewerPreWriteReview — wiring (source scan)', () => {
   const source = fs.readFileSync(
@@ -72,10 +22,9 @@ describe('ViewerPreWriteReview — wiring (source scan)', () => {
     'utf-8',
   );
 
-  it('exports ViewerPreWriteReview and the correlation helpers', () => {
+  it('exports ViewerPreWriteReview and imports the correlation helpers from store-core (#6859)', () => {
     expect(source).toMatch(/export\s+function\s+ViewerPreWriteReview/);
-    expect(source).toMatch(/export\s+function\s+pathMatchesViewer/);
-    expect(source).toMatch(/export\s+function\s+findPendingWriteForFile/);
+    expect(source).toContain("import { findPendingWriteForFile } from '@chroxy/store-core'");
   });
 
   it('reuses the #6556 PreWriteDiffReview for the diff/hunk mechanics', () => {

--- a/packages/app/src/components/ViewerPreWriteReview.tsx
+++ b/packages/app/src/components/ViewerPreWriteReview.tsx
@@ -14,15 +14,17 @@
  * narrows) the edit in the file's own context. Both surfaces read the same store
  * state and drive the same response — the chat bubble keeps working independently.
  *
- * The correlation helpers mirror the dashboard's (`pathMatchesViewer` /
- * `findPendingWriteForFile`). Gated on `features.ide`; hides when no live
- * reviewable write targets the open file, or once the request is resolved
- * (locally via `markPromptAnswered`, or by another client's `permission_resolved`
- * — both set the message's `answered`, which `isLivePermissionPrompt` excludes).
+ * The correlation helpers (`pathMatchesViewer` / `findPendingWriteForFile`) are
+ * shared with the dashboard via `@chroxy/store-core` (#6859 — hoisted out of two
+ * byte-identical copies to prevent cross-client drift). Gated on `features.ide`;
+ * hides when no live reviewable write targets the open file, or once the
+ * request is resolved (locally via `markPromptAnswered`, or by another
+ * client's `permission_resolved` — both set the message's `answered`, which
+ * `isLivePermissionPrompt` excludes).
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { isLivePermissionPrompt } from '@chroxy/store-core';
+import { findPendingWriteForFile } from '@chroxy/store-core';
 import type { ChatMessage } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview';
@@ -30,41 +32,6 @@ import { COLORS } from '../constants/colors';
 
 // Stable empty array so the messages selector never returns a fresh reference.
 const EMPTY_MESSAGES: ChatMessage[] = [];
-
-/**
- * Tolerant path match between a permission's `file_path` and the file open in
- * the viewer. Claude passes an ABSOLUTE `file_path` for Write/Edit; the viewer
- * path may be absolute or workspace-relative — match exactly or by tail. Both
- * nulls => no match. Mirrors the dashboard helper of the same name.
- */
-export function pathMatchesViewer(filePath: string | null | undefined, viewed: string | null): boolean {
-  if (!filePath || !viewed) return false;
-  const a = filePath.replace(/\\/g, '/');
-  const b = viewed.replace(/\\/g, '/');
-  if (a === b) return true;
-  const tail = (p: string) => p.replace(/^\.?\//, '');
-  return a.endsWith('/' + tail(b)) || b.endsWith('/' + tail(a));
-}
-
-/**
- * The first live, reviewable (Write/Edit) permission whose target `file_path`
- * matches the file open in the viewer — or null. Pure so it's unit-testable
- * without the store. Mirrors the dashboard helper of the same name.
- */
-export function findPendingWriteForFile(
-  messages: ChatMessage[],
-  viewed: string | null,
-  now: number,
-): ChatMessage | null {
-  if (!viewed) return null;
-  for (const m of messages) {
-    if (!isLivePermissionPrompt(m, now)) continue;
-    if (!m.tool || !isReviewableTool(m.tool)) continue;
-    const fp = m.toolInput && typeof m.toolInput.file_path === 'string' ? (m.toolInput.file_path as string) : null;
-    if (pathMatchesViewer(fp, viewed)) return m;
-  }
-  return null;
-}
 
 export interface ViewerPreWriteReviewProps {
   /** The path currently open in the FileEditor (absolute, or workspace-relative). */
@@ -82,7 +49,7 @@ export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
   // permission_resolved / permission_expired handlers mutate the message (which
   // re-runs this memo); the authoritative countdown lives on the chat bubble.
   const pending = useMemo(
-    () => (ideEnabled ? findPendingWriteForFile(messages, filePath, Date.now()) : null),
+    () => (ideEnabled ? findPendingWriteForFile(messages, filePath, Date.now(), isReviewableTool) : null),
     [ideEnabled, messages, filePath],
   );
   const requestId = pending?.requestId ?? null;

--- a/packages/dashboard/src/components/ViewerPreWriteReview.test.tsx
+++ b/packages/dashboard/src/components/ViewerPreWriteReview.test.tsx
@@ -1,18 +1,19 @@
 /**
  * ViewerPreWriteReview (#6544, IDE P3.3 feature A) — the editable pre-write diff
- * surfaced ON THE FILE VIEWER. Covers the pure correlation helpers, that a live
- * reviewable write for the open file renders the proposed diff, that dropping a
- * hunk routes the narrowed content through the #6543 `editedInput` seam on
- * Approve, that a plain Approve sends no edit, that Deny never carries an edit,
- * and the gates (features.ide off, no matching write, resolved, disconnected).
+ * surfaced ON THE FILE VIEWER. Covers that a live reviewable write for the open
+ * file renders the proposed diff, that dropping a hunk routes the narrowed
+ * content through the #6543 `editedInput` seam on Approve, that a plain Approve
+ * sends no edit, that Deny never carries an edit, and the gates (features.ide
+ * off, no matching write, resolved, disconnected).
+ *
+ * #6859: the pure correlation helpers (`pathMatchesViewer` /
+ * `findPendingWriteForFile`) were hoisted into `@chroxy/store-core` and their
+ * unit tests moved to `packages/store-core/src/pending-permissions.test.ts` —
+ * this file now only covers the component's wiring.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import {
-  ViewerPreWriteReview,
-  pathMatchesViewer,
-  findPendingWriteForFile,
-} from './ViewerPreWriteReview'
+import { ViewerPreWriteReview } from './ViewerPreWriteReview'
 import type { ChatMessage, PermissionDecision } from '../store/types'
 
 // ---- store mock (only the connection store is mocked; PreWriteDiffReview and
@@ -87,35 +88,6 @@ function pulledEdit() {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
-})
-
-describe('pathMatchesViewer', () => {
-  it('matches identical absolute paths', () => {
-    expect(pathMatchesViewer('/a/b/c.ts', '/a/b/c.ts')).toBe(true)
-  })
-  it('tail-matches an absolute file_path against a workspace-relative selection', () => {
-    expect(pathMatchesViewer('/root/pkg/src/x.ts', 'src/x.ts')).toBe(true)
-    expect(pathMatchesViewer('/root/pkg/src/x.ts', './src/x.ts')).toBe(true)
-  })
-  it('does not match unrelated files or when either side is empty', () => {
-    expect(pathMatchesViewer('/a/b/x.ts', '/a/b/y.ts')).toBe(false)
-    expect(pathMatchesViewer(null, '/a/b/x.ts')).toBe(false)
-    expect(pathMatchesViewer('/a/b/x.ts', null)).toBe(false)
-  })
-})
-
-describe('findPendingWriteForFile', () => {
-  const now = Date.now()
-  it('finds a live Edit/Write targeting the viewed file', () => {
-    expect(findPendingWriteForFile([editPrompt()], FILE, now)?.requestId).toBe('req-1')
-  })
-  it('ignores expired, answered, non-reviewable, or non-matching prompts', () => {
-    expect(findPendingWriteForFile([editPrompt({ expiresAt: now - 1 })], FILE, now)).toBeNull()
-    expect(findPendingWriteForFile([editPrompt({ answered: 'allow' })], FILE, now)).toBeNull()
-    expect(findPendingWriteForFile([editPrompt({ tool: 'Bash' })], FILE, now)).toBeNull()
-    expect(findPendingWriteForFile([editPrompt()], '/other/file.ts', now)).toBeNull()
-    expect(findPendingWriteForFile([editPrompt()], null, now)).toBeNull()
-  })
 })
 
 describe('ViewerPreWriteReview', () => {

--- a/packages/dashboard/src/components/ViewerPreWriteReview.tsx
+++ b/packages/dashboard/src/components/ViewerPreWriteReview.tsx
@@ -25,48 +25,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { ChatMessage, PermissionDecision } from '../store/types'
-import { isLivePermissionPrompt } from '@chroxy/store-core'
+import { findPendingWriteForFile } from '@chroxy/store-core'
 import { PreWriteDiffReview, isReviewableTool } from './PreWriteDiffReview'
 
 // Stable empty array so the messages selector never returns a fresh reference
 // (a new `[]` each render would re-run the memo + churn the subscription).
 const EMPTY_MESSAGES: ChatMessage[] = []
-
-/**
- * Tolerant path match between a permission's `file_path` and the viewer's open
- * file. Claude passes an ABSOLUTE `file_path` for Write/Edit; the viewer's
- * selection is absolute (a file-tree click) OR workspace-relative (a symbol
- * jump), so compare tolerantly — an exact match, or one path tail-matching the
- * other. Both nulls => no match (nothing to correlate).
- */
-export function pathMatchesViewer(filePath: string | null | undefined, viewed: string | null): boolean {
-  if (!filePath || !viewed) return false
-  const a = filePath.replace(/\\/g, '/')
-  const b = viewed.replace(/\\/g, '/')
-  if (a === b) return true
-  const tail = (p: string) => p.replace(/^\.?\//, '')
-  return a.endsWith('/' + tail(b)) || b.endsWith('/' + tail(a))
-}
-
-/**
- * The first live, reviewable (Write/Edit) permission whose target `file_path`
- * matches the file open in the viewer — or null. Pure so it's unit-testable
- * without the store. `now` gates the expiry inside `isLivePermissionPrompt`.
- */
-export function findPendingWriteForFile(
-  messages: ChatMessage[],
-  viewed: string | null,
-  now: number,
-): ChatMessage | null {
-  if (!viewed) return null
-  for (const m of messages) {
-    if (!isLivePermissionPrompt(m, now)) continue
-    if (!m.tool || !isReviewableTool(m.tool)) continue
-    const fp = m.toolInput && typeof m.toolInput.file_path === 'string' ? (m.toolInput.file_path as string) : null
-    if (pathMatchesViewer(fp, viewed)) return m
-  }
-  return null
-}
 
 export interface ViewerPreWriteReviewProps {
   /** The path currently open in the viewer (absolute, or workspace-relative). */
@@ -85,7 +49,7 @@ export function ViewerPreWriteReview({ filePath }: ViewerPreWriteReviewProps) {
   // handlers mutate the message (which re-runs this memo); the authoritative
   // countdown lives on the permission card, not here.
   const pending = useMemo(
-    () => (ideEnabled ? findPendingWriteForFile(messages, filePath, Date.now()) : null),
+    () => (ideEnabled ? findPendingWriteForFile(messages, filePath, Date.now(), isReviewableTool) : null),
     [ideEnabled, messages, filePath],
   )
   const requestId = pending?.requestId ?? null

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -934,6 +934,11 @@ export {
   derivePendingPermissionSessions,
   totalPendingPermissions,
   selectNextPendingSession,
+  // #6859 (IDE P3.3 follow-up of #6857/#6544) — viewer↔pending-write
+  // correlation, hoisted out of two byte-identical copies in the dashboard's
+  // and app's ViewerPreWriteReview.tsx (anti-drift; safety-relevant).
+  pathMatchesViewer,
+  findPendingWriteForFile,
 } from './pending-permissions'
 
 // #6542 (IDE P3.1): client-side line hunk diff + per-hunk apply — the shared

--- a/packages/store-core/src/pending-permissions.test.ts
+++ b/packages/store-core/src/pending-permissions.test.ts
@@ -9,6 +9,8 @@ import {
   derivePendingPermissionCounts,
   totalPendingPermissions,
   selectNextPendingSession,
+  pathMatchesViewer,
+  findPendingWriteForFile,
 } from './pending-permissions'
 
 const NOW = 1_000_000
@@ -133,5 +135,95 @@ describe('selectNextPendingSession (#5693)', () => {
   it('scans from the start when the active id is not in the list', () => {
     expect(selectNextPendingSession(order, { c: 1 }, 'unknown')).toBe('c')
     expect(selectNextPendingSession(order, { c: 1 }, null)).toBe('c')
+  })
+})
+
+// #6859 (IDE P3.3 follow-up of #6857/#6544) — viewer↔pending-write correlation,
+// hoisted out of two byte-identical copies previously in the dashboard's and
+// app's ViewerPreWriteReview.tsx (each had its own describe blocks for these
+// same assertions; ported here verbatim as the single source of truth).
+
+describe('pathMatchesViewer (#6859)', () => {
+  it('matches identical absolute paths', () => {
+    expect(pathMatchesViewer('/a/b/c.ts', '/a/b/c.ts')).toBe(true)
+  })
+  it('tail-matches an absolute file_path against a workspace-relative selection', () => {
+    expect(pathMatchesViewer('/root/pkg/src/x.ts', 'src/x.ts')).toBe(true)
+    expect(pathMatchesViewer('/root/pkg/src/x.ts', './src/x.ts')).toBe(true)
+  })
+  it('normalizes backslashes before comparing (Windows-style paths)', () => {
+    expect(pathMatchesViewer('C:\\root\\pkg\\src\\x.ts', 'C:/root/pkg/src/x.ts')).toBe(true)
+    expect(pathMatchesViewer('C:\\root\\pkg\\src\\x.ts', 'src/x.ts')).toBe(true)
+    expect(pathMatchesViewer('C:\\root\\pkg\\src\\x.ts', './src/x.ts')).toBe(true)
+  })
+  it('does not match unrelated files or when either side is empty', () => {
+    expect(pathMatchesViewer('/a/b/x.ts', '/a/b/y.ts')).toBe(false)
+    expect(pathMatchesViewer(null, '/a/b/x.ts')).toBe(false)
+    expect(pathMatchesViewer('/a/b/x.ts', null)).toBe(false)
+    expect(pathMatchesViewer(undefined, '/a/b/x.ts')).toBe(false)
+  })
+})
+
+describe('findPendingWriteForFile (#6859)', () => {
+  const NOW2 = Date.now()
+  const FILE = '/home/dev/project/src/app.ts'
+  // Mirrors each client's local PreWriteDiffReview.isReviewableTool — injected
+  // as a predicate rather than hoisted, since which tools get a diff review is
+  // a presentation concern owned by each client's PreWriteDiffReview.tsx.
+  const isReviewableTool = (tool: string) => tool === 'Write' || tool === 'Edit'
+
+  function editPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+    return {
+      id: 'perm-1',
+      type: 'prompt',
+      content: 'Edit: change app.ts',
+      tool: 'Edit',
+      requestId: 'req-1',
+      toolInput: { file_path: FILE, old_string: 'a\nb\nc', new_string: 'a\nB\nc' },
+      expiresAt: NOW2 + 60_000,
+      timestamp: NOW2,
+      ...overrides,
+    }
+  }
+
+  it('finds a live Edit/Write targeting the viewed file', () => {
+    expect(findPendingWriteForFile([editPrompt()], FILE, NOW2, isReviewableTool)?.requestId).toBe('req-1')
+  })
+
+  it('ignores expired, answered, non-reviewable, or non-matching prompts', () => {
+    expect(findPendingWriteForFile([editPrompt({ expiresAt: NOW2 - 1 })], FILE, NOW2, isReviewableTool)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt({ answered: 'allow' })], FILE, NOW2, isReviewableTool)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt({ tool: 'Bash' })], FILE, NOW2, isReviewableTool)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt()], '/other/file.ts', NOW2, isReviewableTool)).toBeNull()
+    expect(findPendingWriteForFile([editPrompt()], null, NOW2, isReviewableTool)).toBeNull()
+  })
+
+  it('returns the FIRST live reviewable Write/Edit matching the file, skipping earlier non-matches', () => {
+    const msgs = [
+      editPrompt({ id: 'p-bash', requestId: 'r-bash', tool: 'Bash', toolInput: { command: 'ls' } }),
+      editPrompt({ id: 'p-other-file', requestId: 'r-other', toolInput: { file_path: '/other/file.ts' } }),
+      editPrompt({ id: 'p-match-1', requestId: 'r-match-1' }),
+      editPrompt({ id: 'p-match-2', requestId: 'r-match-2' }),
+    ]
+    expect(findPendingWriteForFile(msgs, FILE, NOW2, isReviewableTool)?.requestId).toBe('r-match-1')
+  })
+
+  it('honors the injected isReviewableTool predicate (a client that only reviews Write, not Edit)', () => {
+    const writeOnly = (tool: string) => tool === 'Write'
+    expect(findPendingWriteForFile([editPrompt()], FILE, NOW2, writeOnly)).toBeNull()
+    expect(
+      findPendingWriteForFile(
+        [editPrompt({ tool: 'Write', toolInput: { file_path: FILE, content: 'x' } })],
+        FILE,
+        NOW2,
+        writeOnly,
+      )?.tool,
+    ).toBe('Write')
+  })
+
+  it('respects `now` for staleness — a prompt live at an earlier `now` is expired at a later one', () => {
+    const msgs = [editPrompt({ expiresAt: NOW2 + 100 })]
+    expect(findPendingWriteForFile(msgs, FILE, NOW2, isReviewableTool)?.requestId).toBe('req-1')
+    expect(findPendingWriteForFile(msgs, FILE, NOW2 + 101, isReviewableTool)).toBeNull()
   })
 })

--- a/packages/store-core/src/pending-permissions.ts
+++ b/packages/store-core/src/pending-permissions.ts
@@ -121,3 +121,54 @@ export function selectNextPendingSession(
   }
   return null
 }
+
+/**
+ * #6859 (IDE P3.3 follow-up of #6857/#6544) — viewer↔pending-write
+ * correlation, hoisted out of two byte-identical copies in the dashboard's and
+ * app's `ViewerPreWriteReview.tsx`. Safety-relevant for the same reason
+ * `isLivePermissionPrompt` above lives here (#5759): a divergence in the match
+ * logic could correlate the WRONG pending write to the file open in the
+ * viewer — approving one file's write believing it's another's.
+ *
+ * `isReviewableTool` (which tools have a per-hunk diff review) stays owned by
+ * each client's local `PreWriteDiffReview.tsx` — it's a presentation concern,
+ * not a correlation one — so `findPendingWriteForFile` takes it as an injected
+ * predicate rather than pulling `TOOL_DIFF` in here too.
+ */
+
+/**
+ * Tolerant path match between a permission's `file_path` and the viewer's open
+ * file. Claude passes an ABSOLUTE `file_path` for Write/Edit; the viewer's
+ * selection is absolute (a file-tree click) OR workspace-relative (a symbol
+ * jump), so compare tolerantly — an exact match, or one path tail-matching the
+ * other. Both nulls => no match (nothing to correlate).
+ */
+export function pathMatchesViewer(filePath: string | null | undefined, viewed: string | null): boolean {
+  if (!filePath || !viewed) return false
+  const a = filePath.replace(/\\/g, '/')
+  const b = viewed.replace(/\\/g, '/')
+  if (a === b) return true
+  const tail = (p: string) => p.replace(/^\.?\//, '')
+  return a.endsWith('/' + tail(b)) || b.endsWith('/' + tail(a))
+}
+
+/**
+ * The first live, reviewable (Write/Edit) permission whose target `file_path`
+ * matches the file open in the viewer — or null. Pure so it's unit-testable
+ * without a store. `now` gates the expiry inside `isLivePermissionPrompt`.
+ */
+export function findPendingWriteForFile(
+  messages: ChatMessage[],
+  viewed: string | null,
+  now: number,
+  isReviewableTool: (tool: string) => boolean,
+): ChatMessage | null {
+  if (!viewed) return null
+  for (const m of messages) {
+    if (!isLivePermissionPrompt(m, now)) continue
+    if (!m.tool || !isReviewableTool(m.tool)) continue
+    const fp = m.toolInput && typeof m.toolInput.file_path === 'string' ? (m.toolInput.file_path as string) : null
+    if (pathMatchesViewer(fp, viewed)) return m
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

PR #6857 added `ViewerPreWriteReview` to both the dashboard and the app, each carrying an **identical copy** of two safety-relevant correlation helpers:

- `pathMatchesViewer(filePath, viewed)` — tolerant path match (exact / tail-match, `./` + backslash normalization)
- `findPendingWriteForFile(messages, viewed, now)` — the first live, reviewable Write/Edit whose `file_path` matches the file open in the viewer

A divergence between the two copies could correlate the **wrong** pending write to the open viewer — approving one file's write while believing it's another's. `store-core` already centralizes the sibling predicate `isLivePermissionPrompt` in `pending-permissions.ts` for exactly this reason (#5759 cross-client-drift audit), so this hoists both helpers next to it.

- `isReviewableTool` / `TOOL_DIFF` stay local to each client's `PreWriteDiffReview.tsx` (a presentation concern — which tools get a diff review). `findPendingWriteForFile` now takes `isReviewableTool` as an injected predicate instead of pulling `TOOL_DIFF` into `store-core` too.
- Both clients import `pathMatchesViewer` / `findPendingWriteForFile` from `@chroxy/store-core`; their local copies are deleted.
- Pure-logic unit tests for the two helpers moved from each client's `ViewerPreWriteReview.test.(ts|tsx)` into `packages/store-core/src/pending-permissions.test.ts` (the single source of truth), with added coverage: backslash-path normalization, first-match selection among multiple live prompts, the injected-predicate behavior, and `now`/staleness gating. Both clients' test files keep their component-wiring tests.
- Pure hoist — no behavior change.

Closes #6859

## Test plan

- [x] `cd packages/store-core && npm run typecheck` — clean
- [x] `cd packages/store-core && npx vitest run` — 58 files / 2088 tests passed (includes the coverage-lint tests; not tripped since these are pure helpers, not a wire message type)
- [x] `cd packages/dashboard && npx tsc --noEmit` — clean
- [x] `cd packages/dashboard && npx vitest run` — 274 files / 4739 tests passed (`ViewerPreWriteReview.test.tsx`: 10/10)
- [x] `cd packages/app && npx tsc --noEmit` — clean
- [x] `cd packages/app && npx jest src/__tests__/components/ViewerPreWriteReview.test.ts` — 10/10 passed