### PR TITLE
perf(server): coalesce thinking-delta broadcasts

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -186,15 +186,23 @@ Object.assign(EVENT_MAP, {
   },
 
   stream_delta: (data, _ctx) => {
-    // #6756 — thinking deltas broadcast IMMEDIATELY (no coalescing). The delta
-    // buffer keys only on sessionId:messageId and reconstructs a bare
-    // {messageId, delta} on flush, so it can't carry the `thinking` flag; and a
-    // thinking bubble uses a distinct messageId anyway, so it never shares a
-    // buffer key with the response text. Returning no `buffer` flag sends it
-    // straight through with the flag intact.
+    // #6818 — thinking deltas ALSO coalesce now. Before this, they broadcast
+    // IMMEDIATELY (one WS frame per thinking_delta) because the delta buffer
+    // reconstructed a bare {messageId, delta} on flush and so couldn't carry the
+    // `thinking: true` flag — a frame/bandwidth storm on a high-budget turn
+    // (`high` = 32k, `max` = 128k thinking tokens streamed over the tunnel). The
+    // buffer now tracks the flag per key and stamps it back onto every flushed
+    // frame, so thinking coalesces the same way response text does. A thinking
+    // bubble uses a DISTINCT messageId (`<turnId>-thinking-<n>`, see #6756), so
+    // its deltas never share a buffer key with the response text — the two
+    // coalesce independently and flush as separate frames with distinct flags.
+    // The `thinking` flag rides the result so the caller forwards it to
+    // bufferDelta (parallel to how it reads messageId/delta off `data`).
     if (data.thinking) {
       return {
         messages: [{ msg: { type: 'stream_delta', messageId: data.messageId, delta: data.delta, thinking: true } }],
+        buffer: true, // signal to caller to buffer this delta
+        thinking: true, // signal to caller to buffer it as a thinking delta
       }
     }
     // Delta buffering is handled externally — normalizer returns the raw delta
@@ -206,9 +214,13 @@ Object.assign(EVENT_MAP, {
   },
 
   stream_end: (data, ctx) => {
-    // #6756 — a thinking stream_end finalises the reasoning bubble's label. No
-    // flush_deltas: thinking deltas were never buffered, and flushing here would
-    // prematurely emit the response text buffer.
+    // #6756/#6818 — a thinking stream_end finalises the reasoning bubble's label.
+    // Since #6818 thinking deltas ARE buffered (coalesced), so this MUST flush
+    // them first — exactly like the response-text path below — or the
+    // finalisation frame could overtake the still-buffered thinking deltas and
+    // break the "Thinking… → Thought" ordering. flush_deltas runs as a side
+    // effect BEFORE the messages broadcast (see ws-forwarding), so the coalesced
+    // thinking text is on the wire before this stream_end.
     if (data.thinking) {
       // #6391 footer-stat: forward the session-measured elapsed time (+ token
       // count when a provider supplies one — claude SDK/BYOK do not) so the
@@ -231,6 +243,8 @@ Object.assign(EVENT_MAP, {
       if (thinkingTokens !== undefined) msg.thinkingTokens = thinkingTokens
       return {
         messages: [{ msg }],
+        // #6818: flush the coalesced thinking deltas before this finalisation.
+        sideEffects: [{ type: 'flush_deltas', sessionId: ctx.sessionId }],
       }
     }
     return {
@@ -904,6 +918,15 @@ export class EventNormalizer {
     // oldest token in a flush spent inside the server (coalescing + forwarding)
     // — a true monotonic duration, same process both ends.
     this._deltaEmitMono = new Map()
+    // #6818: key -> true when this buffer key holds THINKING deltas (reasoning
+    // content) rather than response text. A thinking stream uses a DISTINCT
+    // messageId (`<turnId>-thinking-<n>`, see #6756), so it never shares a key
+    // with the response text — this map simply carries the `thinking: true` flag
+    // alongside the coalesced text so each flushed entry can be reconstructed as
+    // a thinking stream_delta instead of a bare response delta. Only thinking
+    // keys are recorded (response keys stay absent), and it is pruned in every
+    // flush/clear path in lockstep with _deltaBuffer.
+    this._deltaThinking = new Map()
     this._deltaFlushTimer = null
     // #5516: monotonic deadline (performance.now ms) the pending flush timer is
     // scheduled to fire at. Lets a later single-client buffer SHORTEN an
@@ -964,7 +987,9 @@ export class EventNormalizer {
 
   /**
    * Set the flush callback. Called with buffered deltas when the timer fires.
-   * @param {Function} cb - (entries: Array<{ key, sessionId, messageId, delta }>) => void
+   * @param {Function} cb - (entries: Array<{ key, sessionId, messageId, delta, emitMonoMs, thinking? }>) => void
+   *   `thinking` is present (=== true) only on entries that hold reasoning
+   *   content (#6818) so the caller stamps `thinking: true` back onto the wire.
    */
   set onFlush(cb) {
     this._onFlush = cb
@@ -992,8 +1017,13 @@ export class EventNormalizer {
    * @param {number} [emitMonoMs] - #5515: monotonic ms the provider emitted this
    *   delta. First-write-wins per flush window so the flushed entry reports how
    *   long the OLDEST coalesced token waited inside the server.
+   * @param {boolean} [thinking] - #6818: true when this is a reasoning
+   *   (extended-thinking) delta. Recorded per key so the flushed entry carries
+   *   the `thinking` flag and the caller reconstructs a thinking stream_delta.
+   *   Thinking uses a distinct messageId (#6756), so the flag is constant per
+   *   key — first-write-wins, mirroring emitMonoMs.
    */
-  bufferDelta(sessionId, messageId, delta, emitMonoMs) {
+  bufferDelta(sessionId, messageId, delta, emitMonoMs, thinking) {
     const key = sessionId ? `${sessionId}:${messageId}` : messageId
     // #5555: coerce a non-string delta to its string form ONCE and use that for
     // both the buffer concat AND the byte count. A bare `existing + delta` would
@@ -1007,6 +1037,12 @@ export class EventNormalizer {
     this._deltaBuffer.set(key, existing + text)
     if (typeof emitMonoMs === 'number' && !this._deltaEmitMono.has(key)) {
       this._deltaEmitMono.set(key, emitMonoMs)
+    }
+    // #6818: record the thinking flag once per key (constant per key — thinking
+    // uses a distinct messageId). Only thinking keys are stored; response keys
+    // stay absent so their flushed entries are byte-identical to pre-#6818.
+    if (thinking === true && !this._deltaThinking.has(key)) {
+      this._deltaThinking.set(key, true)
     }
     // #5555: maintain byte-size counters incrementally (UTF-8) — no
     // re-serialization on the hot path. `text` is the only new content, so its
@@ -1073,8 +1109,10 @@ export class EventNormalizer {
     if (!this._deltaBuffer.has(key)) return
     const delta = this._deltaBuffer.get(key)
     const emitMonoMs = this._deltaEmitMono.get(key)
+    const thinking = this._deltaThinking.get(key) === true
     this._deltaBuffer.delete(key)
     this._deltaEmitMono.delete(key)
+    this._deltaThinking.delete(key)
     this._deltaTotalBytes -= this._deltaKeyBytes.get(key) || 0
     this._deltaKeyBytes.delete(key)
     if (this._deltaTotalBytes < 0) this._deltaTotalBytes = 0
@@ -1083,6 +1121,7 @@ export class EventNormalizer {
       const entry = sepIdx !== -1
         ? { key, sessionId: key.slice(0, sepIdx), messageId: key.slice(sepIdx + 1), delta, emitMonoMs }
         : { key, sessionId: null, messageId: key, delta, emitMonoMs }
+      if (thinking) entry.thinking = true
       // Mirror _flushDeltas' containment: a throwing broadcast must not escape
       // the buffer hot path (which runs under the provider's event emit).
       try {
@@ -1098,7 +1137,8 @@ export class EventNormalizer {
    * Flush all buffered deltas for a specific session (called before stream_end).
    * Returns the flushed entries so the caller can broadcast them.
    * @param {string|null} sessionId - Session to flush (null = flush all)
-   * @returns {Array<{ key, sessionId, messageId, delta, emitMonoMs }>}
+   * @returns {Array<{ key, sessionId, messageId, delta, emitMonoMs, thinking? }>}
+   *   `thinking` is present (=== true) only on reasoning entries (#6818).
    */
   flushSession(sessionId) {
     const entries = []
@@ -1107,9 +1147,12 @@ export class EventNormalizer {
       for (const [key, delta] of this._deltaBuffer) {
         if (key.startsWith(prefix)) {
           const messageId = key.slice(prefix.length)
-          entries.push({ key, sessionId, messageId, delta, emitMonoMs: this._deltaEmitMono.get(key) })
+          const entry = { key, sessionId, messageId, delta, emitMonoMs: this._deltaEmitMono.get(key) }
+          if (this._deltaThinking.get(key) === true) entry.thinking = true
+          entries.push(entry)
           this._deltaBuffer.delete(key)
           this._deltaEmitMono.delete(key)
+          this._deltaThinking.delete(key)
           // #5555: keep residency counters in sync as keys leave the buffer.
           this._deltaTotalBytes -= this._deltaKeyBytes.get(key) || 0
           this._deltaKeyBytes.delete(key)
@@ -1119,10 +1162,13 @@ export class EventNormalizer {
     } else {
       // Legacy mode: flush everything
       for (const [key, delta] of this._deltaBuffer) {
-        entries.push({ key, sessionId: null, messageId: key, delta, emitMonoMs: this._deltaEmitMono.get(key) })
+        const entry = { key, sessionId: null, messageId: key, delta, emitMonoMs: this._deltaEmitMono.get(key) }
+        if (this._deltaThinking.get(key) === true) entry.thinking = true
+        entries.push(entry)
       }
       this._deltaBuffer.clear()
       this._deltaEmitMono.clear()
+      this._deltaThinking.clear()
       this._deltaKeyBytes.clear()
       this._deltaTotalBytes = 0
     }
@@ -1147,11 +1193,11 @@ export class EventNormalizer {
       for (const [key, delta] of this._deltaBuffer) {
         const emitMonoMs = this._deltaEmitMono.get(key)
         const sepIdx = key.indexOf(':')
-        if (sepIdx !== -1) {
-          entries.push({ key, sessionId: key.slice(0, sepIdx), messageId: key.slice(sepIdx + 1), delta, emitMonoMs })
-        } else {
-          entries.push({ key, sessionId: null, messageId: key, delta, emitMonoMs })
-        }
+        const entry = sepIdx !== -1
+          ? { key, sessionId: key.slice(0, sepIdx), messageId: key.slice(sepIdx + 1), delta, emitMonoMs }
+          : { key, sessionId: null, messageId: key, delta, emitMonoMs }
+        if (this._deltaThinking.get(key) === true) entry.thinking = true
+        entries.push(entry)
       }
       // #5313 (WP-1.3): _onFlush is a broadcast callback invoked from a
       // setTimeout. A throw here escapes the timer → uncaughtException →
@@ -1167,6 +1213,7 @@ export class EventNormalizer {
       } finally {
         this._deltaBuffer.clear()
         this._deltaEmitMono.clear()
+        this._deltaThinking.clear()
         this._deltaKeyBytes.clear()
         this._deltaTotalBytes = 0
       }
@@ -1174,6 +1221,7 @@ export class EventNormalizer {
     }
     this._deltaBuffer.clear()
     this._deltaEmitMono.clear()
+    this._deltaThinking.clear()
     this._deltaKeyBytes.clear()
     this._deltaTotalBytes = 0
   }
@@ -1189,6 +1237,7 @@ export class EventNormalizer {
     this._deltaFlushDeadline = 0
     this._deltaBuffer.clear()
     this._deltaEmitMono.clear()
+    this._deltaThinking.clear()
     this._deltaKeyBytes.clear()
     this._deltaTotalBytes = 0
   }

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -89,12 +89,17 @@ export function setupForwarding(ctx) {
 
   // Wire the normalizer's timer-based delta flush to broadcast
   normalizer.onFlush = (entries) => {
-    for (const { sessionId, messageId, delta, emitMonoMs } of entries) {
+    for (const { sessionId, messageId, delta, emitMonoMs, thinking } of entries) {
       recordEmitToBroadcast(emitMonoMs)
+      // #6818: stamp `thinking: true` back on so a coalesced reasoning frame
+      // routes to the thinking bubble, not the response slot. Absent for
+      // response text (byte-identical to pre-#6818).
+      const msg = { type: 'stream_delta', messageId, delta }
+      if (thinking) msg.thinking = true
       if (sessionId) {
-        broadcastToSession(sessionId, withServerTs({ type: 'stream_delta', messageId, delta }))
+        broadcastToSession(sessionId, withServerTs(msg))
       } else {
-        broadcast(withServerTs({ type: 'stream_delta', messageId, delta }))
+        broadcast(withServerTs(msg))
       }
     }
   }
@@ -207,7 +212,9 @@ function setupSessionForwarding(normalizer, ctx) {
 
     // Handle delta buffering
     if (result.buffer) {
-      normalizer.bufferDelta(sessionId, data.messageId, data.delta, data._emitMonoMs)
+      // #6818: forward the thinking flag so the coalesced frame reconstructs as
+      // a thinking stream_delta on flush.
+      normalizer.bufferDelta(sessionId, data.messageId, data.delta, data._emitMonoMs, result.thinking === true)
       return
     }
 
@@ -365,7 +372,9 @@ function setupCliForwarding(normalizer, ctx) {
         if (!result) return
 
         if (result.buffer) {
-          normalizer.bufferDelta(null, data.messageId, data.delta, data._emitMonoMs)
+          // #6818: forward the thinking flag (legacy-CLI path) so a coalesced
+          // reasoning frame reconstructs as a thinking stream_delta on flush.
+          normalizer.bufferDelta(null, data.messageId, data.delta, data._emitMonoMs, result.thinking === true)
           return
         }
 
@@ -467,12 +476,15 @@ function executeSideEffects(sideEffects, sessionId, ctx) {
       case 'flush_deltas': {
         const sid = effect.sessionId ?? sessionId
         const entries = normalizer.flushSession(sid)
-        for (const { sessionId: eSid, messageId, delta, emitMonoMs } of entries) {
+        for (const { sessionId: eSid, messageId, delta, emitMonoMs, thinking } of entries) {
           recordEmitToBroadcast(emitMonoMs)
+          // #6818: preserve the thinking flag through the pre-stream_end flush.
+          const msg = { type: 'stream_delta', messageId, delta }
+          if (thinking) msg.thinking = true
           if (eSid) {
-            broadcastToSession(eSid, withServerTs({ type: 'stream_delta', messageId, delta }))
+            broadcastToSession(eSid, withServerTs(msg))
           } else {
-            broadcast(withServerTs({ type: 'stream_delta', messageId, delta }))
+            broadcast(withServerTs(msg))
           }
         }
         break

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -464,11 +464,13 @@ describe('EventNormalizer', () => {
       assert.equal(result.messages[0].msg.delta, 'hello')
     })
 
-    // #6756 — thinking deltas broadcast immediately (no buffering) with the flag
-    // intact; the coalescing buffer can't carry the flag.
-    it('thinking delta is NOT buffered and carries thinking:true', () => {
+    // #6818 — thinking deltas now coalesce through the same buffer as response
+    // text (was: broadcast per-token). The result carries `buffer: true` AND a
+    // `thinking: true` signal so the caller buffers it as a thinking delta.
+    it('thinking delta IS buffered and signals thinking:true (#6818)', () => {
       const result = normalizer.normalize('stream_delta', { messageId: 'msg-1-thinking-0', delta: 'reason', thinking: true }, makeCtx())
-      assert.ok(!result.buffer, 'thinking deltas bypass the coalescing buffer')
+      assert.equal(result.buffer, true, 'thinking deltas now coalesce like response text')
+      assert.equal(result.thinking, true, 'result flags the delta as thinking for the buffer')
       assert.equal(result.messages[0].msg.type, 'stream_delta')
       assert.equal(result.messages[0].msg.delta, 'reason')
       assert.equal(result.messages[0].msg.thinking, true)
@@ -485,13 +487,16 @@ describe('EventNormalizer', () => {
       assert.ok(result.sideEffects.some(se => se.type === 'flush_deltas'))
     })
 
-    // #6756 — a thinking stream_end carries the flag and does NOT flush the
-    // response-text buffer.
-    it('tags thinking:true and omits flush_deltas', () => {
+    // #6818 — a thinking stream_end now flushes the coalesced thinking deltas
+    // first (they ARE buffered since #6818), exactly like the response path, so
+    // the finalisation frame can't overtake still-buffered thinking text.
+    it('tags thinking:true and emits flush_deltas (#6818)', () => {
       const result = normalizer.normalize('stream_end', { messageId: 'msg-1-thinking-0', thinking: true }, makeCtx())
       assert.equal(result.messages[0].msg.type, 'stream_end')
       assert.equal(result.messages[0].msg.thinking, true)
-      assert.ok(!result.sideEffects, 'thinking end does not flush the text buffer')
+      assert.ok(result.sideEffects.some(se => se.type === 'flush_deltas'), 'thinking end flushes the coalesced thinking buffer')
+      const flush = result.sideEffects.find(se => se.type === 'flush_deltas')
+      assert.equal(flush.sessionId, 'sess-1')
     })
   })
 
@@ -1271,6 +1276,103 @@ describe('EventNormalizer', () => {
       normalizer.destroy()
       assert.equal(normalizer._deltaBuffer.size, 0)
       assert.equal(normalizer._deltaFlushTimer, null)
+    })
+  })
+
+  // ---- #6818: thinking-delta coalescing ----
+  //
+  // Thinking deltas used to bypass the coalescing buffer entirely (one WS frame
+  // per token) because the flush reconstructed a bare {messageId, delta} that
+  // couldn't carry `thinking: true`. They now coalesce through the SAME buffer,
+  // with the flag carried per key and stamped onto every flushed entry. A
+  // thinking stream uses a DISTINCT messageId from the response text, so the two
+  // never share a buffer key and never merge into one frame.
+  describe('thinking-delta coalescing (#6818)', () => {
+    it('coalesces multiple thinking deltas into one entry carrying thinking:true', () => {
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'Let me ', 1000, true)
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'reason ', 1005, true)
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'about this', 1010, true)
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries.length, 1, 'one coalesced frame, not three')
+      assert.equal(entries[0].delta, 'Let me reason about this')
+      assert.equal(entries[0].messageId, 'm1-thinking-0')
+      assert.equal(entries[0].thinking, true, 'coalesced thinking frame keeps the flag')
+    })
+
+    it('does NOT merge thinking and response deltas of the same turn (separate frames, correct flags)', () => {
+      // Distinct messageIds mirror production (#6756): <turnId>-thinking-<n> vs <turnId>.
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'reasoning', 1000, true)
+      normalizer.bufferDelta('sess-1', 'm1', 'visible answer', 1000, false)
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries.length, 2, 'thinking and response stay in separate frames')
+      const thinkingEntry = entries.find(e => e.messageId === 'm1-thinking-0')
+      const responseEntry = entries.find(e => e.messageId === 'm1')
+      assert.ok(thinkingEntry && responseEntry, 'both frames present')
+      assert.equal(thinkingEntry.delta, 'reasoning')
+      assert.equal(thinkingEntry.thinking, true)
+      assert.equal(responseEntry.delta, 'visible answer')
+      assert.ok(!('thinking' in responseEntry), 'response frame carries no thinking flag')
+    })
+
+    it('leaves response-only coalescing byte-identical — no thinking key on the entry', () => {
+      normalizer.bufferDelta('sess-1', 'm1', 'Hello')
+      normalizer.bufferDelta('sess-1', 'm1', ' World')
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries.length, 1)
+      assert.equal(entries[0].delta, 'Hello World')
+      assert.ok(!('thinking' in entries[0]), 'no thinking property on a response entry')
+    })
+
+    it('preserves order across a thinking→text transition (thinking flushes before response)', () => {
+      // A thinking block completes, then the response streams. flushSession
+      // returns thinking BEFORE response (insertion order into the buffer Map),
+      // and each carries its own flag — the client renders the reasoning bubble
+      // first, then the answer.
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'first I think', 1000, true)
+      normalizer.bufferDelta('sess-1', 'm1', 'then I answer', 1010, false)
+      const entries = normalizer.flushSession('sess-1')
+      assert.equal(entries.length, 2)
+      assert.equal(entries[0].messageId, 'm1-thinking-0', 'thinking frame comes first')
+      assert.equal(entries[0].thinking, true)
+      assert.equal(entries[1].messageId, 'm1', 'response frame comes second')
+      assert.ok(!('thinking' in entries[1]))
+    })
+
+    it('carries the thinking flag through the timer-driven onFlush path', async () => {
+      let flushed = null
+      normalizer.onFlush = (entries) => { flushed = entries }
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'reason a', undefined, true)
+      normalizer.bufferDelta('sess-1', 'm1-thinking-0', ' reason b', undefined, true)
+      await new Promise((resolve) => setTimeout(resolve, 30))
+      assert.ok(flushed)
+      assert.equal(flushed.length, 1)
+      assert.equal(flushed[0].delta, 'reason a reason b')
+      assert.equal(flushed[0].thinking, true)
+    })
+
+    it('preserves the thinking flag when a residency cap force-flushes the key', () => {
+      const flushed = []
+      const n = new EventNormalizer({ flushIntervalMs: 10, maxKeyBytes: 100, maxTotalBytes: 10_000 })
+      n.onFlush = (entries) => { flushed.push(...entries) }
+      try {
+        n.bufferDelta('sess-1', 'm1-thinking-0', 'a'.repeat(120), undefined, true) // trips per-key cap
+        assert.equal(flushed.length, 1, 'over-cap thinking key force-flushes')
+        assert.equal(flushed[0].thinking, true, 'force-flushed thinking frame keeps the flag')
+        assert.equal(flushed[0].delta, 'a'.repeat(120))
+      } finally {
+        n.destroy()
+      }
+    })
+
+    it('does not leak the thinking flag across flush windows for a reused key', () => {
+      // A thinking key flushes, then the SAME key (unlikely, but defensive) is
+      // reused for a non-thinking delta — the flag must not persist.
+      normalizer.bufferDelta('sess-1', 'reused', 'x', undefined, true)
+      const first = normalizer.flushSession('sess-1')
+      assert.equal(first[0].thinking, true)
+      normalizer.bufferDelta('sess-1', 'reused', 'y', undefined, false)
+      const second = normalizer.flushSession('sess-1')
+      assert.ok(!('thinking' in second[0]), 'stale thinking flag must not survive the flush')
     })
   })
 })

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -79,6 +79,59 @@ describe('setupForwarding', () => {
       const msg = ctx.broadcast.mock.calls[0].arguments[0]
       assert.equal(msg.type, 'stream_delta')
     })
+
+    // #6818: a flushed THINKING entry stamps `thinking: true` back onto the wire
+    // so the coalesced frame routes to the reasoning bubble; a response entry
+    // carries no such flag.
+    it('stamps thinking:true on a flushed thinking delta and omits it for response deltas', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.normalizer._onFlush([
+        { sessionId: 'sess-1', messageId: 'm1-thinking-0', delta: 'reason', thinking: true },
+        { sessionId: 'sess-1', messageId: 'm1', delta: 'answer' },
+      ])
+
+      const byId = Object.fromEntries(
+        ctx.broadcastToSession.mock.calls.map(c => [c.arguments[1].messageId, c.arguments[1]]),
+      )
+      assert.equal(byId['m1-thinking-0'].thinking, true, 'thinking frame carries the flag on the wire')
+      assert.equal(byId['m1'].thinking, undefined, 'response frame carries no thinking flag')
+    })
+
+    // #6818 end-to-end: a thinking stream_delta is buffered (coalesced), then the
+    // thinking stream_end flushes it as a `thinking: true` frame BEFORE the
+    // stream_end finalisation — preserving the "Thinking… → Thought" ordering.
+    it('coalesces thinking deltas and flushes them (thinking:true) before the thinking stream_end', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1', event: 'stream_delta',
+        data: { messageId: 'm1-thinking-0', delta: 'think ', thinking: true },
+      })
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1', event: 'stream_delta',
+        data: { messageId: 'm1-thinking-0', delta: 'harder', thinking: true },
+      })
+      // No per-token broadcast yet — coalesced in the buffer.
+      const preEnd = ctx.broadcastToSession.mock.calls.map(c => c.arguments[1]).filter(m => m.type === 'stream_delta')
+      assert.equal(preEnd.length, 0, 'thinking deltas are buffered, not broadcast per-token')
+
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-1', event: 'stream_end',
+        data: { messageId: 'm1-thinking-0', thinking: true },
+      })
+
+      const msgs = ctx.broadcastToSession.mock.calls.map(c => c.arguments[1])
+      const deltaIdx = msgs.findIndex(m => m.type === 'stream_delta')
+      const endIdx = msgs.findIndex(m => m.type === 'stream_end')
+      assert.ok(deltaIdx !== -1, 'one coalesced thinking delta frame emitted')
+      assert.equal(msgs[deltaIdx].delta, 'think harder', 'two thinking deltas coalesced into one')
+      assert.equal(msgs[deltaIdx].thinking, true)
+      assert.equal(msgs[endIdx].thinking, true)
+      assert.ok(deltaIdx < endIdx, 'coalesced thinking delta lands before the stream_end')
+    })
   })
 
   // #5515 (epic #5514): latency instrumentation — broadcast-time serverTs.


### PR DESCRIPTION
## Problem

Thinking `stream_delta`s bypassed the server-side coalescing buffer in `event-normalizer.js`. The buffer keys on `sessionId:messageId` and reconstructed a bare `{messageId, delta}` on flush, so it couldn't carry the `thinking: true` flag. Thinking content therefore broadcast **per-token** (one WS frame per `thinking_delta`) while visible response text was coalesced — up to tens of thousands of uncoalesced frames streamed over the Cloudflare tunnel on a high-budget turn (`high` = 32k, `max` = 128k thinking tokens).

## Change

Extend the coalescing buffer so thinking deltas coalesce the same way response text does, carrying the `thinking` flag through flush:

- **Per-key thinking flag** (`_deltaThinking`) tracked alongside the buffered text and carried through every flush path — timer flush (`_flushDeltas`), `flushSession`, and the residency-cap force-flush (`_forceFlushKey`) — so each flushed entry reconstructs as a thinking `stream_delta` rather than a bare response delta. Pruned in lockstep with `_deltaBuffer` in every clear path.
- **`bufferDelta`** gains a `thinking` param. The `stream_delta` normalizer now returns `buffer: true` for thinking (was: immediate broadcast) and signals `thinking` on the result so `ws-forwarding` forwards the flag.
- **Thinking `stream_end`** now emits `flush_deltas` (like the response path) so the coalesced thinking text lands **before** the finalisation frame — preserving the "Thinking… → Thought" ordering and the distinct-id routing (no regression per the acceptance criteria).
- **`ws-forwarding`** `onFlush` + `flush_deltas` reconstruction stamp `thinking: true` back onto the wire when the entry carries it.

A thinking stream uses a **distinct** `messageId` (`<turnId>-thinking-<n>`, #6756), so thinking and response deltas never share a buffer key and never merge into one frame. Response-text coalescing is **byte-identical** — thinking is additive (absent flag = no property).

**No protocol change:** the `stream_delta` schema (`packages/protocol/src/schemas/server/stream.ts`) already carries the optional `thinking` flag, so the wire shape is unchanged.

## Tests

Added to `tests/event-normalizer.test.js` (new `thinking-delta coalescing (#6818)` block) and `tests/ws-forwarding.test.js`:

1. Multiple `thinking_delta`s for one message coalesce into one frame carrying `thinking: true` + concatenated delta (both `flushSession` and the timer `onFlush` path).
2. Thinking and response deltas of the same turn do **not** merge — separate frames, correct flags.
3. Response-only coalescing is unchanged (no `thinking` key on the entry).
4. Ordering across a thinking→text transition is preserved (thinking frame first).
5. Residency-cap force-flush preserves the thinking flag; the flag doesn't leak across flush windows for a reused key.
6. End-to-end: thinking deltas are buffered (not per-token), then flushed as one `thinking: true` frame **before** the thinking `stream_end`.

Updated the two pre-existing #6756 tests that asserted the old immediate-broadcast / no-flush behavior.

### Verification

- `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/event-normalizer.test.js tests/*thinking*.test.*` → **176 pass, 0 fail, exit 0** (self-exits, no `--test-force-exit`).
- `tests/ws-forwarding.test.js` → 65 pass, exit 0. Adjacent buffer/schema suites → 239 pass, exit 0.
- All 5 server lints rc=0; server eslint rc=0 on changed source.

Closes #6818