### PR TITLE
fix(server,security): make acute security-tightening writes power-loss durable (audit post-#6914)

### DIFF
--- a/packages/server/src/cli/tokens-cmd.js
+++ b/packages/server/src/cli/tokens-cmd.js
@@ -132,7 +132,12 @@ export function runTokensRevoke(target, options = {}, deps = {}) {
       )
       return { revoked: 0, mode: 'all', confirmed: false }
     }
-    if (!store.save([])) {
+    // #6927 — DURABLE revoke: fsync the emptied store before reporting success,
+    // mirroring the daemon's live revoke (`_persistSessionTokensSnapshot`, #6914).
+    // Without it a power loss within the OS writeback window rolls the file back
+    // and every "revoked" token RESURRECTS on the next daemon start — after the
+    // operator was told the panic-button revoke landed.
+    if (!store.save([], { durable: true })) {
       out(`Failed to write the session-token store — nothing revoked. ${UNREADABLE_NOTE}`)
       return { revoked: 0, mode: 'all', error: 'persist-failed' }
     }
@@ -159,7 +164,10 @@ export function runTokensRevoke(target, options = {}, deps = {}) {
   }
 
   const remaining = list.filter((e) => !tokenOf(e).startsWith(target))
-  if (!store.save(remaining)) {
+  // #6927 — DURABLE revoke (see the --all branch above): fsync the post-removal
+  // snapshot before reporting success so a power loss can't resurrect the revoked
+  // token on the next start.
+  if (!store.save(remaining, { durable: true })) {
     out(`Failed to write the session-token store — nothing revoked. ${UNREADABLE_NOTE}`)
     return { revoked: 0, mode: 'one', error: 'persist-failed' }
   }

--- a/packages/server/src/permission-rule-store.js
+++ b/packages/server/src/permission-rule-store.js
@@ -91,6 +91,35 @@ function publicRule(rule) {
 }
 
 /**
+ * #6927 — does the transition `before → after` TIGHTEN the auto-approval surface?
+ * A rollback of a tightening edit (after the dashboard reported it saved) would
+ * silently re-WIDEN what auto-approves — the same power-loss-after-reported-success
+ * gap the session-token revoke closes (#6914). Two directions tighten:
+ *   - an `allow` grant present BEFORE is gone AFTER — an auto-approve was revoked
+ *     (its rollback resurrects the grant → the tool auto-approves again); and
+ *   - a `deny` rule present AFTER was absent BEFORE — a new restriction was added
+ *     (its rollback drops the restriction, re-exposing whatever it masked).
+ * The widening directions (a new `allow`, a removed `deny`) are fail-SAFE: a lost
+ * persist reverts to a broader-but-still-PROMPTING posture, so they stay
+ * non-durable (no fsync on the frequent allowAlways path). Rules are matched by
+ * `(tool, path)` identity via `ruleKey`.
+ * @param {Array<{tool: string, decision: string, path?: string}>} before
+ * @param {Array<{tool: string, decision: string, path?: string}>} after
+ * @returns {boolean}
+ */
+function tightensSurface(before, after) {
+  const allowKeys = (rules) => new Set(rules.filter((r) => r.decision === 'allow').map(ruleKey))
+  const denyKeys = (rules) => new Set(rules.filter((r) => r.decision === 'deny').map(ruleKey))
+  const beforeAllow = allowKeys(before)
+  const afterAllow = allowKeys(after)
+  const beforeDeny = denyKeys(before)
+  const afterDeny = denyKeys(after)
+  const allowRevoked = [...beforeAllow].some((k) => !afterAllow.has(k))
+  const denyAdded = [...afterDeny].some((k) => !beforeDeny.has(k))
+  return allowRevoked || denyAdded
+}
+
+/**
  * Durable, per-project permission rule store — the "always allow / always deny"
  * decisions that must survive a daemon restart (issue #6771). Persists to a
  * single JSON file (a sibling of `session-state.json`, e.g.
@@ -116,11 +145,15 @@ export class PermissionRuleStore {
    * @param {object} options
    * @param {string} options.filePath - Path to the rules JSON file.
    * @param {object} [options.logger] - Optional logger (defaults to module logger).
+   * @param {Function} [options._write] - Test seam for the atomic writer
+   *   (defaults to `writeFileRestricted`); lets a test observe the `{ durable }`
+   *   opt that a security-tightening persist forwards (#6927).
    */
-  constructor({ filePath, logger } = {}) {
+  constructor({ filePath, logger, _write = writeFileRestricted } = {}) {
     if (!filePath) throw new Error('PermissionRuleStore requires a filePath')
     this._filePath = filePath
     this._log = logger || log
+    this._write = _write
     // projectKey -> [{ tool, decision, createdAt }]
     this._projects = new Map()
     this._loaded = false
@@ -253,7 +286,9 @@ export class PermissionRuleStore {
     const next = existing.filter((r) => ruleKey(r) !== ruleKey(rule))
     next.push(storedRecord(rule, Date.now()))
     this._projects.set(key, next)
-    this._persist()
+    // #6927 — a `deny` addition tightens; an `allow` addition (the frequent
+    // allowAlways path) widens and stays fail-safe / non-durable.
+    this._persist(rule.decision === 'deny')
     return true
   }
 
@@ -269,6 +304,10 @@ export class PermissionRuleStore {
   setRules(cwd, rules) {
     const key = normalizeProjectKey(cwd)
     if (!key) return []
+    // #6927 — snapshot the prior set BEFORE replacing it, so we can tell whether
+    // this replacement tightens the auto-approval surface (a durable write) or
+    // merely widens it (fail-safe, non-durable).
+    const before = this._projects.get(key) || []
     const clean = []
     if (Array.isArray(rules)) {
       for (const rule of rules) {
@@ -287,7 +326,7 @@ export class PermissionRuleStore {
     }
     if (clean.length === 0) this._projects.delete(key)
     else this._projects.set(key, clean)
-    this._persist()
+    this._persist(tightensSurface(before, clean))
     return clean.map(publicRule)
   }
 
@@ -316,7 +355,12 @@ export class PermissionRuleStore {
     if (next.length === existing.length) return false
     if (next.length === 0) this._projects.delete(key)
     else this._projects.set(key, next)
-    this._persist()
+    // #6927 — removing an `allow` rule REVOKES an auto-approve grant (tightening):
+    // its rollback would resurrect the grant and silently auto-approve the tool
+    // again — the same class as a session-token revoke. Removing a `deny` widens
+    // (fail-safe). Durable only when an allow was actually dropped.
+    const removedAllow = tightensSurface(existing, next)
+    this._persist(removedAllow)
     return true
   }
 
@@ -333,8 +377,18 @@ export class PermissionRuleStore {
     return out
   }
 
-  /** @private — atomic write of the whole store. */
-  _persist() {
+  /**
+   * @private — atomic write of the whole store.
+   * @param {boolean} [durable] — #6927: fsync the file before reporting success
+   *   (temp before rename + dir after, via `writeFileRestricted`'s `durable`
+   *   option). Set ONLY by the security-TIGHTENING callers (a persisted `deny`,
+   *   or a revoked `allow`), where a power-loss rollback after the dashboard
+   *   reported the edit saved would silently re-WIDEN the auto-approval surface —
+   *   the same acute class as the session-token revoke (#6914). The widening
+   *   edits (a new `allow`, a removed `deny`) stay non-durable so the frequent
+   *   allowAlways grant path never pays an fsync for a fail-safe write.
+   */
+  _persist(durable = false) {
     try {
       const dir = dirname(this._filePath)
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
@@ -343,7 +397,7 @@ export class PermissionRuleStore {
         projects[key] = { rules }
       }
       const state = { version: STORE_VERSION, projects }
-      writeFileRestricted(this._filePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
+      this._write(this._filePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}`, durable })
     } catch (err) {
       // Best-effort: a failed persist leaves the in-memory set intact for this
       // process; the prior good file (if any) survives (atomic write). Surface

--- a/packages/server/src/permission-rule-store.js
+++ b/packages/server/src/permission-rule-store.js
@@ -286,9 +286,12 @@ export class PermissionRuleStore {
     const next = existing.filter((r) => ruleKey(r) !== ruleKey(rule))
     next.push(storedRecord(rule, Date.now()))
     this._projects.set(key, next)
-    // #6927 — a `deny` addition tightens; an `allow` addition (the frequent
-    // allowAlways path) widens and stays fail-safe / non-durable.
-    this._persist(rule.decision === 'deny')
+    // #6927 — durable only when this genuinely TIGHTENS the auto-approval
+    // surface (a new/tightening deny, or an allow being revoked by a deny
+    // replacing it), per `tightensSurface`. A no-op replace of an already-
+    // identical deny rule — same (tool, path), same decision — must NOT pay
+    // the fsync cost; raw `rule.decision === 'deny'` durabled that no-op too.
+    this._persist(tightensSurface(existing, next))
     return true
   }
 

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -829,12 +829,20 @@ export async function startCliServer(config) {
   const tokenManager = NO_AUTH ? null : new TokenManager({
     token: API_TOKEN,
     tokenExpiry: config.tokenExpiry || null,
-    onPersist: (newToken) => {
+    onPersist: (newToken, { reason } = {}) => {
+      // #6927 — a 'revoke' is the operator panic button (a compromised primary
+      // token killed NOW). Persist it DURABLY so a power loss within the OS
+      // writeback window can't roll config.json back to the compromised token and
+      // resurrect it on the next daemon start. A routine 'scheduled' rotation is
+      // fail-safe (the old token keeps working through its grace window), so it
+      // stays non-durable. Only the file fallback is fsync-controllable here; the
+      // keychain path's durability is the OS keychain's responsibility.
+      const durable = reason === 'revoke'
       const persistToFile = () => {
         const raw = existsSync(configFile) ? readFileSync(configFile, 'utf-8') : '{}'
         const cfg = JSON.parse(raw)
         cfg.apiToken = newToken
-        writeFileRestricted(configFile, JSON.stringify(cfg, null, 2))
+        writeFileRestricted(configFile, JSON.stringify(cfg, null, 2), { durable })
       }
       try {
         if (isKeychainAvailable()) {

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -192,9 +192,20 @@ function readIdentityFromKeychain(keychain) {
  * @param {object} [opts]
  * @param {object} [opts.keychain]
  * @param {string} [opts.filePath]
+ * @param {boolean} [opts.durable] - #6927: fsync the fallback-file write before
+ *   returning (temp before rename + dir after). Set ONLY by `rotateServerIdentity`
+ *   (the compromise-response path); first-run mint leaves it off (fail-safe — a
+ *   lost mint just re-mints). Applies only to the FILE fallback; the keychain
+ *   path's durability is the OS keychain's responsibility, not ours.
+ * @param {Function} [opts._write] - test seam for the atomic writer.
  * @returns {'keychain'|'file'}
  */
-export function persistServerIdentity(keyPair, { keychain = realKeychain, filePath = DEFAULT_IDENTITY_FILE } = {}) {
+export function persistServerIdentity(keyPair, {
+  keychain = realKeychain,
+  filePath = DEFAULT_IDENTITY_FILE,
+  durable = false,
+  _write = writeFileRestricted,
+} = {}) {
   const secretB64 = Buffer.from(keyPair.secretKey).toString('base64')
   if (keychain.isKeychainAvailable()) {
     try {
@@ -211,7 +222,7 @@ export function persistServerIdentity(keyPair, { keychain = realKeychain, filePa
   // on CREATION — a pre-existing file at a looser mode would keep that mode.
   // writeFileRestricted chmods the final file to 0600 unconditionally.
   mkdirSync(dirname(filePath), { recursive: true })
-  writeFileRestricted(filePath, JSON.stringify({ v: 1, secretKey: secretB64 }))
+  _write(filePath, JSON.stringify({ v: 1, secretKey: secretB64 }), { durable })
   return 'file'
 }
 
@@ -338,6 +349,7 @@ export function rotateServerIdentity({
   keychain = realKeychain,
   filePath = DEFAULT_IDENTITY_FILE,
   rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE,
+  _write = writeFileRestricted,
 } = {}) {
   const current = loadServerIdentity({ keychain, filePath })
   if (!current) {
@@ -366,8 +378,15 @@ export function rotateServerIdentity({
   // reuse writeFileRestricted for its ATOMIC temp+rename write so a crash can't
   // leave a half-written cert — the 0600 mode it also sets is incidental here
   // (nothing secret), not a requirement.
+  //
+  // #6927 — the sidecar is left NON-durable on purpose: its rollback is a
+  // CONTINUITY concern, not a security one. If a power loss drops the sidecar
+  // (while the durable secret persist below survives), the daemon serves the NEW
+  // identity and pinned clients fall back to a manual re-pair — an availability
+  // regression, never a resurrection of the retired key. Only the secret persist
+  // (whose rollback WOULD resurrect the retired/compromised key) is made durable.
   mkdirSync(dirname(rotationFilePath), { recursive: true })
-  writeFileRestricted(
+  _write(
     rotationFilePath,
     JSON.stringify({
       v: 1,
@@ -377,7 +396,12 @@ export function rotateServerIdentity({
     }),
   )
   // Persist the new secret in place of the old (keychain or fallback file).
-  const backend = persistServerIdentity(next, { keychain, filePath })
+  // #6927 — DURABLE: `chroxy identity rotate` is the compromise-response path, so
+  // a power-loss rollback resurrecting the RETIRED secret is the same acute class
+  // as a token revoke. fsync the fallback-file write before reporting success
+  // (the keychain path's durability is the OS's job). First-run mint stays
+  // non-durable (fail-safe — a lost mint just re-mints).
+  const backend = persistServerIdentity(next, { keychain, filePath, durable: true, _write })
   log.info(`Rotated server identity (backend: ${backend}); continuity cert written for previous pin`)
   return { previousPublicKey: current.publicKey, newPublicKey: next.publicKey, backend }
 }

--- a/packages/server/src/token-manager.js
+++ b/packages/server/src/token-manager.js
@@ -44,7 +44,10 @@ export class TokenManager extends EventEmitter {
    * @param {string} opts.token - Current API token
    * @param {string|null} opts.tokenExpiry - Expiry duration (e.g. '24h', '7d') or null
    * @param {number} opts.graceMs - Grace period in ms (default: 5 min)
-   * @param {Function} opts.onPersist - Callback to save new token: async (newToken) => {}
+   * @param {Function} opts.onPersist - Callback to save new token:
+   *   `async (newToken, { reason }) => {}`. `reason` is 'scheduled' | 'revoke'
+   *   (#6927) so the persist site can make the panic-button revoke DURABLE while
+   *   leaving the routine scheduled rotation non-durable.
    */
   constructor({ token, tokenExpiry, graceMs, onPersist } = {}) {
     super()
@@ -162,9 +165,11 @@ export class TokenManager extends EventEmitter {
       reason,
     })
 
-    // Persist the new token
+    // Persist the new token. #6927 — forward `reason` so the persist site can
+    // fsync a 'revoke' (the operator panic button killing a compromised token)
+    // while leaving a routine 'scheduled' rotation non-durable.
     if (this._onPersist) {
-      Promise.resolve(this._onPersist(newToken)).catch(err => {
+      Promise.resolve(this._onPersist(newToken, { reason })).catch(err => {
         log.error(`Failed to persist new token: ${err.message}`)
       })
     }

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -487,3 +487,76 @@ describe('#6771 PermissionManager + durable rules', () => {
     assert.equal(typeof parsed.projects['/proj/a'].rules[0].createdAt, 'number')
   })
 })
+
+// #6927 — a persist that TIGHTENS the auto-approval surface (a new deny, or a
+// revoked allow) must be DURABLE: if a power loss rolls it back after the
+// dashboard reported the edit saved, the restriction silently vanishes and the
+// broader auto-approve surface comes back — the same acute class as a token
+// revoke (#6914). The WIDENING edits (a new allow — the frequent allowAlways
+// path — or a removed deny) are fail-safe and stay non-durable (no fsync cost on
+// the hot path). We observe the `{ durable }` opt via the store's `_write` seam.
+const CWD = '/proj/durable'
+describe('#6927 tightening persists are durable; widening persists are not', () => {
+  let recordDir
+  function makeRecordingStore() {
+    const calls = []
+    const store = new PermissionRuleStore({
+      filePath: join(recordDir, 'permission-rules.json'),
+      logger: silentLog,
+      _write: (_path, _data, opts = {}) => { calls.push({ durable: opts.durable === true }) },
+    })
+    return { store, calls }
+  }
+
+  beforeEach(() => { recordDir = mkdtempSync(join(tmpdir(), 'chroxy-rule-durable-')) })
+  afterEach(() => { rmSync(recordDir, { recursive: true, force: true }) })
+
+  it('addRule(deny) is durable; addRule(allow) is not', () => {
+    const { store, calls } = makeRecordingStore()
+    store.addRule(CWD, { tool: 'Bash', decision: 'deny' })
+    assert.equal(calls.at(-1).durable, true, 'a persisted deny is durable')
+    store.addRule(CWD, { tool: 'Write', decision: 'allow' })
+    assert.equal(calls.at(-1).durable, false, 'a persisted allow (widening) is not durable')
+  })
+
+  it('removeRule that drops an ALLOW is durable; dropping a DENY is not', () => {
+    const { store, calls } = makeRecordingStore()
+    store.addRule(CWD, { tool: 'Write', decision: 'allow' }) // widening, not durable
+    store.addRule(CWD, { tool: 'Bash', decision: 'deny' })   // tightening, durable
+    calls.length = 0
+    store.removeRule(CWD, 'Write') // revokes an auto-grant → tightening
+    assert.equal(calls.at(-1).durable, true, 'removing an allow revokes an auto-grant (durable)')
+    store.removeRule(CWD, 'Bash') // drops a deny → widening
+    assert.equal(calls.at(-1).durable, false, 'removing a deny widens (not durable)')
+  })
+
+  it('setRules is durable when it adds a deny', () => {
+    const { store, calls } = makeRecordingStore()
+    store.setRules(CWD, [{ tool: 'Bash', decision: 'deny' }])
+    assert.equal(calls.at(-1).durable, true)
+  })
+
+  it('setRules is durable when it revokes an existing allow', () => {
+    const { store, calls } = makeRecordingStore()
+    store.setRules(CWD, [{ tool: 'Write', decision: 'allow' }]) // widening, not durable
+    assert.equal(calls.at(-1).durable, false)
+    store.setRules(CWD, []) // drops the allow → tightening
+    assert.equal(calls.at(-1).durable, true)
+  })
+
+  it('setRules that only ADDS an allow (pure widening) is not durable', () => {
+    const { store, calls } = makeRecordingStore()
+    store.setRules(CWD, [{ tool: 'Write', decision: 'allow' }])
+    assert.equal(calls.at(-1).durable, false)
+    store.setRules(CWD, [{ tool: 'Write', decision: 'allow' }, { tool: 'Read', decision: 'allow' }])
+    assert.equal(calls.at(-1).durable, false)
+  })
+
+  it('setRules that replaces an allow with a deny (same tool) is durable', () => {
+    const { store, calls } = makeRecordingStore()
+    store.setRules(CWD, [{ tool: 'Write', decision: 'allow' }])
+    calls.length = 0
+    store.setRules(CWD, [{ tool: 'Write', decision: 'deny' }])
+    assert.equal(calls.at(-1).durable, true, 'the allow→deny swap both revokes an allow AND adds a deny')
+  })
+})

--- a/packages/server/tests/permission-rule-store.test.js
+++ b/packages/server/tests/permission-rule-store.test.js
@@ -519,6 +519,27 @@ describe('#6927 tightening persists are durable; widening persists are not', () 
     assert.equal(calls.at(-1).durable, false, 'a persisted allow (widening) is not durable')
   })
 
+  // Gate on tightensSurface, not the raw decision (avoid a no-op fsync).
+  it('addRule: a NO-OP re-add of an already-persisted identical deny is NOT durable', () => {
+    const { store, calls } = makeRecordingStore()
+    store.addRule(CWD, { tool: 'Bash', decision: 'deny' })
+    assert.equal(calls.at(-1).durable, true, 'the first (genuinely new) deny is durable')
+    calls.length = 0
+    store.addRule(CWD, { tool: 'Bash', decision: 'deny' }) // identical (tool, path, decision) replace
+    assert.equal(calls.at(-1).durable, false, 're-adding an identical deny is a no-op — no fsync cost')
+    assert.deepEqual(store.getRules(CWD), [{ tool: 'Bash', decision: 'deny' }])
+  })
+
+  it('addRule: replacing an existing ALLOW with a deny for the same (tool, path) is durable', () => {
+    const { store, calls } = makeRecordingStore()
+    store.addRule(CWD, { tool: 'Write', decision: 'allow' })
+    assert.equal(calls.at(-1).durable, false, 'the initial allow (widening) is not durable')
+    calls.length = 0
+    store.addRule(CWD, { tool: 'Write', decision: 'deny' }) // revokes the allow AND adds a deny
+    assert.equal(calls.at(-1).durable, true, 'revoking an allow via addRule tightens the surface — durable')
+    assert.deepEqual(store.getRules(CWD), [{ tool: 'Write', decision: 'deny' }])
+  })
+
   it('removeRule that drops an ALLOW is durable; dropping a DENY is not', () => {
     const { store, calls } = makeRecordingStore()
     store.addRule(CWD, { tool: 'Write', decision: 'allow' }) // widening, not durable

--- a/packages/server/tests/server-identity.test.js
+++ b/packages/server/tests/server-identity.test.js
@@ -364,3 +364,52 @@ describe('server identity rotation (#5616/#5976)', () => {
     })
   })
 })
+
+// #6927 — `chroxy identity rotate` is the compromise-response path: a power-loss
+// rollback that resurrects the RETIRED secret is the same acute class as a token
+// revoke, so the rotation's secret persist (file fallback) MUST be durable. The
+// first-run mint stays non-durable (fail-safe — a lost mint just re-mints), and
+// the rotation SIDECAR stays non-durable (its rollback forces a re-pair, an
+// availability concern, never a resurrection of the retired key). We observe the
+// `{ durable }` opt via the injected `_write` seam.
+describe('#6927 rotation secret persist is durable; mint + sidecar are not', () => {
+  const rotPath = (filePath) => join(dirname(filePath), 'server-identity-rotation.json')
+
+  it('rotateServerIdentity fsyncs the NEW secret (durable) but not the sidecar', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false }) // force the file backend
+      const rotationFilePath = rotPath(filePath)
+      getOrCreateServerIdentity({ keychain: kc, filePath })
+
+      const writes = []
+      rotateServerIdentity({
+        keychain: kc,
+        filePath,
+        rotationFilePath,
+        _write: (path, _data, opts = {}) => { writes.push({ path, durable: opts.durable === true }) },
+      })
+
+      const secretWrite = writes.find((w) => w.path === filePath)
+      const sidecarWrite = writes.find((w) => w.path === rotationFilePath)
+      assert.ok(secretWrite, 'the new secret was persisted to the fallback file')
+      assert.equal(secretWrite.durable, true, 'the rotation secret persist is durable')
+      assert.ok(sidecarWrite, 'the continuity sidecar was written')
+      assert.equal(sidecarWrite.durable, false, 'the sidecar (continuity, not security) is not durable')
+    })
+  })
+
+  it('first-run mint persists the secret NON-durably (fail-safe)', () => {
+    withTempDir((filePath) => {
+      const kc = fakeKeychain({ available: false })
+      const kp = getOrCreateServerIdentity({ keychain: kc, filePath })
+
+      let observed
+      persistServerIdentity(kp, {
+        keychain: kc,
+        filePath,
+        _write: (_path, _data, opts = {}) => { observed = opts.durable === true },
+      })
+      assert.equal(observed, false, 'a plain persist (mint) does not fsync')
+    })
+  })
+})

--- a/packages/server/tests/token-manager.test.js
+++ b/packages/server/tests/token-manager.test.js
@@ -181,6 +181,21 @@ describe('TokenManager', () => {
     assert.equal(persisted, newToken)
   })
 
+  // #6927 — onPersist receives the rotation `reason` so the persist site can make
+  // the panic-button revoke DURABLE (fsync config before the compromised token can
+  // resurrect on a crash) while leaving a routine scheduled rotation non-durable.
+  it('revoke() passes reason "revoke" to onPersist; scheduled rotate passes "scheduled"', async () => {
+    const reasons = []
+    manager = new TokenManager({
+      token: 'abc-123',
+      onPersist: (_newToken, opts = {}) => { reasons.push(opts.reason) },
+    })
+    manager.rotate()   // routine scheduled rotation
+    manager.revoke()   // operator panic button
+    await new Promise(r => setTimeout(r, 10))
+    assert.deepEqual(reasons, ['scheduled', 'revoke'])
+  })
+
   it('successive rotations invalidate older tokens', () => {
     manager = new TokenManager({ token: 'first', graceMs: 5000 })
     const second = manager.rotate()

--- a/packages/server/tests/tokens-cmd.test.js
+++ b/packages/server/tests/tokens-cmd.test.js
@@ -9,6 +9,7 @@ function fakeStore(initial = [], opts = {}) {
   let entries = initial.map((e) => [e[0], { ...e[1] }])
   const status = opts.status || 'ok'
   const saveOk = opts.saveOk !== false
+  const saveCalls = [] // records the { durable } opt each save() was called with (#6927)
   return {
     load: () => entries.map((e) => [e[0], { ...e[1] }]),
     loadResult: () => ({
@@ -16,12 +17,14 @@ function fakeStore(initial = [], opts = {}) {
       entries: status === 'unreadable' ? [] : entries.map((e) => [e[0], { ...e[1] }]),
     }),
     exists: () => status !== 'absent',
-    save: (next) => {
+    save: (next, saveOpts = {}) => {
+      saveCalls.push({ durable: saveOpts.durable === true })
       if (!saveOk) return false
       entries = next.map((e) => [e[0], { ...e[1] }])
       return true
     },
     _current: () => entries,
+    _saveCalls: () => saveCalls,
   }
 }
 
@@ -226,5 +229,35 @@ describe('chroxy tokens — revoke --all (#6599)', () => {
     const res = runTokensRevoke(undefined, { all: true, yes: true }, { store: s, write: w.write })
     assert.equal(res.error, 'persist-failed')
     assert.match(w.text(), /Failed to write/)
+  })
+})
+
+// #6927 — the CLI revoke is the same acute class as the daemon's live revoke
+// (#6914): an operator runs `chroxy tokens revoke`, is told it landed, and a power
+// loss must NOT roll the store back and resurrect the token on the next start. So
+// the CLI persist MUST opt into the durable (fsync) write, exactly as
+// `_persistSessionTokensSnapshot` does in the daemon.
+describe('#6927 CLI revoke persists DURABLY', () => {
+  const A = 'aaaa1111bbbb2222cccc'
+  const B = 'bbbb3333dddd4444eeee'
+
+  it('revoke <handle> saves the remaining snapshot with { durable: true }', () => {
+    const store = fakeStore([[A, { createdAt: NOW, sessionId: 's-a' }], [B, { createdAt: NOW, sessionId: 's-b' }]])
+    const res = runTokensRevoke('aaaa1111', {}, { store, write: cap().write })
+    assert.equal(res.revoked, 1)
+    assert.deepEqual(store._saveCalls(), [{ durable: true }], 'the one revoke write is durable')
+  })
+
+  it('revoke --all --yes clears the store with { durable: true }', () => {
+    const store = fakeStore([[A, { createdAt: NOW }], [B, { createdAt: NOW }]])
+    const res = runTokensRevoke(undefined, { all: true, yes: true }, { store, write: cap().write })
+    assert.equal(res.revoked, 2)
+    assert.deepEqual(store._saveCalls(), [{ durable: true }], 'the revoke-all write is durable')
+  })
+
+  it('a no-op path (no --yes) performs no write at all — nothing to make durable', () => {
+    const store = fakeStore([[A, { createdAt: NOW }]])
+    runTokensRevoke(undefined, { all: true }, { store, write: cap().write })
+    assert.deepEqual(store._saveCalls(), [], 'the confirmation gate wrote nothing')
   })
 })


### PR DESCRIPTION
## Summary

#6914 added an opt-in `{ durable: true }` (fsync temp-before-rename + directory-after-rename) to `writeFileRestricted` and wired it into the **session-token revoke snapshot only**. This PR audits every other security-tightening writer against the same **acute model** — *an operator performs a security-downgrade-preventing action, gets a success response, and a power loss within the OS writeback window must not silently roll it back* — and opts the acute ones in. Frequent, fail-safe writers stay non-durable (fsync has a cost; only revoke-class rollbacks warrant it).

## Audit trail (every security-tightening write examined)

| Write / caller | Verdict | Reason |
|---|---|---|
| Session-token **revoke** — daemon live (`pairing._persistSessionTokensSnapshot`) | durable (pre-existing, #6914) | The acute case #6914 fixed. |
| Session-token **revoke** — CLI (`cli/tokens-cmd.js` `revoke` / `revoke --all`) | **durable (NEW)** | Twin of the daemon revoke; the daemon doc-comment itself flags this CLI path as the gap. A rolled-back CLI revoke resurrects the token on the next daemon start after the operator was told it landed. |
| Permission-rule **tightening** — add a `deny`, or revoke an `allow` (`permission-rule-store.js`) | **durable (NEW)** | Rollback re-widens the auto-approval surface after the dashboard reported the edit saved. Driven by a `tightensSurface` delta check across `addRule` / `removeRule` / `setRules`. |
| Permission-rule **widening** — new `allow` (the frequent allowAlways path), removed `deny` | non-durable | Fail-safe: a lost persist reverts to a broader-but-**prompting** posture, never a silent auto-approve. No fsync on the hot path. |
| Identity-key **rotation** secret persist (`server-identity.rotateServerIdentity`, file fallback) | **durable (NEW)** | `chroxy identity rotate` is the compromise-response path; a rollback resurrecting the **retired** key is revoke-class. Keychain path is OS-durable (not fsync-controllable here). |
| Identity first-run **mint** (`persistServerIdentity` default) | non-durable | Fail-safe — a lost mint just re-mints. |
| Identity rotation **continuity sidecar** | non-durable | Its rollback forces a re-pair (availability), never a resurrection of the retired key. |
| **Primary-token** panic revoke — config file fallback (`token-manager` + `server-cli` `onPersist`) | **durable (NEW)** | Highest-authority token; the panic button kills a compromised token. `onPersist` now receives the rotation `reason`; the file fallback fsyncs on `revoke` only. Routine scheduled rotation stays non-durable (old token rides its grace window — fail-safe). Keychain path is OS-durable. |
| **Credential deletion** (`credential-store.deleteStoredCredential` / `deleteStoredField`, DPAPI `_winDeleteToken`) | non-durable (documented) | Removal is an `unlink` or a *separate* atomic writer with no fsync plumbing; and severity is low — the secret must be rotated at the provider regardless, so a resurrected copy authenticates nothing. |
| Binary-provenance **trust-ledger revoke** (`path-hash-trust-ledger.revoke`) | already durable | Persists via `saveJsonState({ fsync: true })` (#5620) — the other durable seam. No change. |
| Credential **set**, session-state, config, models, device-prefs, push subscriptions, discord state, environment/compose state, checkpoints, event-ingest secret, mint/slide/sweep, service/hook install | non-durable | Frequent / fail-safe: a lost persist forces a harmless re-pair or reverts to an earlier safe state. |

## Implementation notes

- `writeFileRestricted`'s `{ durable }` plumbing (#6914) is reused unchanged. `server-identity`, `permission-rule-store` gained an injectable `_write` **test seam** (defaulting to `writeFileRestricted`) so tests observe the flag; `token-manager.onPersist` gained a backward-compatible `{ reason }` second arg.
- Tightening detection (`tightensSurface`) = *an allow present before is gone after* (auto-grant revoked) **or** *a deny present after was absent before* (restriction added).

## Tests

Assert the `{ durable }` flag reaches the writer for each acute path (spy/seam on the write); no real fsync / power-loss is exercised, mirroring the existing revoke tests.

- `tokens-cmd.test.js` — CLI revoke (one + all) saves `{ durable: true }`; the no-op confirmation gate writes nothing.
- `permission-rule-store.test.js` — `addRule(deny)` / `removeRule(allow)` / `setRules` deny-add / allow-revoke are durable; allow-add / deny-remove are not.
- `server-identity.test.js` — rotation fsyncs the new secret but not the sidecar; first-run mint is non-durable.
- `token-manager.test.js` — `revoke()` passes `reason:'revoke'`, scheduled `rotate()` passes `reason:'scheduled'`.

Verification (Node 22, no `--test-force-exit`): touched + related suites **exit 0** (360 tests, 0 fail); all **5 server lints rc=0**; `eslint src/` clean on changed files.

Closes #6927