### PR TITLE
fix(server): bound codex reconnect suppression with a dedicated deadline (harden #6854)

### DIFF
--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -44,6 +44,34 @@ const MAX_MCP_RESULT_CHARS = 10_000
 // cycle while bounding the worst-case stale state far below the 30-min default.
 const RECONNECT_WATCHDOG_MS = 2 * 60 * 1000
 
+// #6856: dedicated HARD CAP on how long a codex turn may stay in the transient-
+// reconnect-SUPPRESSED state opened by #6854. The #6629 watchdog above is a
+// SILENCE detector — it is RE-ARMED on every `Reconnecting...` tick, so it only
+// fires after codex goes QUIET for a full window. That leaves one path still
+// unbounded-but-slow: a codex that emits reconnect notifications FOREVER (never
+// recovering, never silent, never emitting a terminal give-up). Each tick runs
+// `_resetResultTimeout` (pushing the 30-min result timeout out) AND re-arms the
+// silence watchdog — so BOTH backstops keep sliding forward and the turn stays
+// "Working..." far longer than it should. This deadline is armed ONCE the moment
+// the turn first enters suppression and is deliberately NOT re-armed on later
+// reconnect ticks, so a never-ending reconnect storm fails on a fixed bound. It
+// is cleared the instant codex makes genuine forward progress (any non-`error`
+// notification) or the turn ends. 5 min sits above codex's bounded N/5 retry
+// burst AND above the 2-min silence watchdog (so the faster silence path still
+// wins its own case), while capping the worst case 6x below the 30-min result
+// timeout. Override via `reconnectDeadlineMs` opt / CHROXY_CODEX_RECONNECT_DEADLINE_MS.
+const RECONNECT_DEADLINE_MS = 5 * 60 * 1000
+
+// #6856: resolve the reconnect-suppression deadline. Opt wins over the env var;
+// a non-finite / non-positive value (unset env → NaN, garbage → NaN, 0/negative)
+// falls back to the default. Returns ms.
+function resolveReconnectDeadlineMs(optValue) {
+  for (const candidate of [optValue, Number(process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS)]) {
+    if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0) return candidate
+  }
+  return RECONNECT_DEADLINE_MS
+}
+
 const log = createLogger('codex-app-server')
 
 /**
@@ -130,6 +158,15 @@ export class CodexAppServerSession extends BaseSession {
     this._skillsPrepended = false // #6606 — inject the skills prefix once, on turn 1
     this._turnAbort = null // per-turn AbortController — cancels pending approvals
     this._reconnectWatchdog = null // #6629 — bounded backstop for a wedged reconnect
+    this._reconnectDeadline = null // #6856 — one-shot hard cap on total reconnect-suppression time
+    // #6856 — configurable reconnect-suppression deadline (opt / env / default).
+    this._reconnectDeadlineMs = resolveReconnectDeadlineMs(opts.reconnectDeadlineMs)
+    // #6856 — injectable timer seam (defaults to node globals) so the reconnect
+    // deadline is unit-testable without wall-clock waits, mirroring the #6908/#6911
+    // byok-mcp-config `setTimer`/`clearTimer` pattern. Only the deadline routes
+    // through this; the #6629 silence watchdog keeps using the globals directly.
+    this._setTimer = typeof opts.setTimer === 'function' ? opts.setTimer : setTimeout
+    this._clearTimer = typeof opts.clearTimer === 'function' ? opts.clearTimer : clearTimeout
     // #6638: per-session sandbox override (create_session `codexSandbox`) — wins
     // over CHROXY_CODEX_SANDBOX / the default. Applied at thread start.
     this._codexSandbox = opts.codexSandbox || null
@@ -357,11 +394,13 @@ export class CodexAppServerSession extends BaseSession {
       return
     }
     this._resetResultTimeout()
-    // #6629 — any notification that is NOT another `error` tick is genuine forward
-    // progress: codex's response stream is live again, so disarm the reconnect
-    // watchdog that #6623's suppression path may have armed. (A terminal `error`
-    // clears it below on its way to _failTurn; a transient reconnect `error` re-arms it.)
-    if (method !== 'error') this._clearReconnectWatchdog()
+    // #6629/#6856 — any notification that is NOT another `error` tick is genuine
+    // forward progress: codex's response stream is live again, so disarm BOTH the
+    // reconnect backstops that #6623's suppression path may have armed — the #6629
+    // silence watchdog and the #6856 one-shot suppression deadline. (A terminal
+    // `error` clears both below on its way to _failTurn; a transient reconnect
+    // `error` re-arms the watchdog but leaves the deadline untouched.)
+    if (method !== 'error') { this._clearReconnectWatchdog(); this._clearReconnectDeadline() }
     const t = this._activeTurn
     switch (method) {
       case 'turn/started':
@@ -406,9 +445,16 @@ export class CodexAppServerSession extends BaseSession {
           // timeout. Re-arms on each reconnect tick so codex's legit N/5 retry
           // burst doesn't trip it mid-recovery.
           this._armReconnectWatchdog()
+          // #6856 — arm the one-shot suppression deadline the FIRST time this turn
+          // enters the reconnect-suppressed state. Unlike the watchdog it is NOT
+          // re-armed here on subsequent ticks (the guard in _armReconnectDeadline
+          // makes a later call a no-op), so a reconnect storm that keeps ticking
+          // forever still fails on a fixed bound instead of sliding both backstops out.
+          this._armReconnectDeadline()
           break
         }
-        this._clearReconnectWatchdog() // terminal error → about to fail; drop the backstop
+        this._clearReconnectWatchdog() // terminal error → about to fail; drop the backstops
+        this._clearReconnectDeadline() // #6856
         this._failTurn(`Codex error: ${JSON.stringify(params).slice(0, 200)}`)
         break
       }
@@ -645,6 +691,7 @@ export class CodexAppServerSession extends BaseSession {
     super._clearMessageState()
     this._pendingFileChanges.clear()
     this._clearReconnectWatchdog() // #6629 — drop the reconnect backstop on any turn teardown
+    this._clearReconnectDeadline() // #6856 — drop the suppression deadline on any turn teardown
   }
 
   // Abort this turn's approval scope (any pending permission_request resolves as
@@ -710,6 +757,31 @@ export class CodexAppServerSession extends BaseSession {
 
   _clearReconnectWatchdog() {
     if (this._reconnectWatchdog) { clearTimeout(this._reconnectWatchdog); this._reconnectWatchdog = null }
+  }
+
+  // #6856 — one-shot HARD CAP on the transient-reconnect-suppressed state. Armed
+  // ONCE on entering suppression; the `if (this._reconnectDeadline) return` guard
+  // is load-bearing — a subsequent reconnect tick must NOT push the deadline out
+  // (that re-arming is exactly the #6854 gap this closes). It is a strictly-shorter
+  // bound than the 30-min result timeout and independent of the #6629 silence
+  // watchdog (which keeps sliding forward on every tick). Cleared on genuine
+  // forward progress or turn teardown. Routes through the injectable timer seam so
+  // it is hermetically testable, and unref's the handle so a bare test/CI run
+  // self-exits with no leaked timer (#6933).
+  _armReconnectDeadline() {
+    if (this._reconnectDeadline) return // already suppressed — do NOT extend the deadline
+    this._reconnectDeadline = this._setTimer(() => {
+      this._reconnectDeadline = null
+      if (!this._activeTurn) return
+      const secs = Math.round(this._reconnectDeadlineMs / 1000)
+      ;(this._log || log).warn(`codex app-server reconnect exceeded ${secs}s without recovery — failing the turn (#6856)`)
+      this._failTurn(`Codex reconnect exceeded ${secs}s without recovery — the turn was stopped. Retry to continue.`, { code: 'stream_stall' })
+    }, this._reconnectDeadlineMs)
+    if (this._reconnectDeadline && typeof this._reconnectDeadline.unref === 'function') this._reconnectDeadline.unref()
+  }
+
+  _clearReconnectDeadline() {
+    if (this._reconnectDeadline) { this._clearTimer(this._reconnectDeadline); this._reconnectDeadline = null }
   }
 
   // ------------------------------------------------------------------
@@ -1077,6 +1149,7 @@ export class CodexAppServerSession extends BaseSession {
     this._clearIntentionalStop()
     this._clearResultTimeout()
     this._clearReconnectWatchdog() // #6629 — never leave the reconnect timer armed past teardown
+    this._clearReconnectDeadline() // #6856 — never leave the suppression deadline armed past teardown
     this._endTurnAbort() // resolve any in-flight approval as a deny before teardown
     try { this._permissions?.destroy() } catch { /* noop */ }
     // #6609 — drop the materialized-attachment temp dir.

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -630,6 +630,180 @@ describe('CodexAppServerSession — reconnect watchdog / stale-state reconciliat
   })
 })
 
+describe('CodexAppServerSession — reconnect suppression deadline (#6856)', () => {
+  // #6854 keeps a codex turn OPEN on a transient `responseStreamDisconnected` +
+  // `Reconnecting... N/M` error so codex can recover. The #6629 SILENCE watchdog
+  // is re-armed on every tick, so a codex that emits reconnect notifications
+  // FOREVER (never recovering, never silent) keeps pushing BOTH the 30-min result
+  // timeout and the silence watchdog out — the turn stays "Working..." far too
+  // long. This deadline is armed ONCE on entering suppression, is NOT re-armed on
+  // later ticks, and fails the turn on a fixed bound. It routes through an
+  // injectable timer seam so it is exercised with zero wall-clock (and without
+  // mock.timers, so the #6629 watchdog's real unref'd global timer never fires
+  // inside these synchronous tests).
+  const reconnectParams = (attempt = 2, max = 5) => ({
+    error: {
+      message: `Reconnecting... ${attempt}/${max}`,
+      codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+      additionalDetails: 'stream disconnected before completion: failed to send websocket frame',
+    },
+  })
+
+  // Minimal deterministic double for the deadline timer: records each scheduled
+  // timer and lets a test fire the pending one by hand.
+  function fakeReconnectTimers() {
+    const scheduled = []
+    const setTimer = (fn, ms) => {
+      const entry = { fn, ms, cleared: false, unref() { return this } }
+      scheduled.push(entry)
+      return entry
+    }
+    const clearTimer = (handle) => { if (handle) handle.cleared = true }
+    // Fire the still-pending deadline (no-op if none / already cleared).
+    const fire = () => {
+      const entry = scheduled.find((e) => !e.cleared)
+      if (entry) { entry.cleared = true; entry.fn() }
+      return entry
+    }
+    return { scheduled, setTimer, clearTimer, fire }
+  }
+
+  function mkDeadlineSession(extraOpts = {}) {
+    const timers = fakeReconnectTimers()
+    const { s, cleanup } = mkSession({
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      reconnectDeadlineMs: 60_000,
+      ...extraOpts,
+    })
+    return { s, cleanup, timers }
+  }
+
+  // A busy turn with an in-flight commandExecution tool_start (no matching result
+  // yet) — the stale in-flight tool the deadline must sweep when it fires.
+  function armBusyTurnWithInflightShell(s) {
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'item/started', params: { item: { type: 'commandExecution', id: 'shell-1', command: 'npm run build', cwd: '/tmp' } } })
+  }
+
+  it('arms the deadline on entering the reconnect-suppressed state', () => {
+    const { s, cleanup, timers } = mkDeadlineSession()
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+    assert.ok(s._reconnectDeadline, 'deadline armed on the first transient reconnect')
+    assert.equal(timers.scheduled.length, 1, 'exactly one deadline timer scheduled')
+    assert.equal(timers.scheduled[0].ms, 60_000, 'armed with the configured deadline ms')
+    assert.equal(timers.scheduled[0].cleared, false, 'the deadline is pending')
+    s.destroy()
+    cleanup()
+  })
+
+  it('a flurry of reconnect notifications does NOT push the deadline out (the #6854 gap)', () => {
+    const { s, cleanup, timers } = mkDeadlineSession()
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    // The exact bug: many reconnect ticks, none of which may re-arm the deadline.
+    s._onNotification({ method: 'error', params: reconnectParams(1, 5) })
+    const armed = s._reconnectDeadline
+    s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+    s._onNotification({ method: 'error', params: reconnectParams(3, 5) })
+    s._onNotification({ method: 'error', params: reconnectParams(4, 5) })
+    assert.equal(timers.scheduled.length, 1, 'the deadline was armed exactly once across the whole flurry')
+    assert.equal(timers.scheduled[0].cleared, false, 'the single deadline was never cleared/re-armed')
+    assert.equal(s._reconnectDeadline, armed, 'still the SAME deadline handle — not extended by later ticks')
+    s.destroy()
+    cleanup()
+  })
+
+  it('genuine recovery before the deadline clears it (no fail)', () => {
+    const { s, cleanup, timers } = mkDeadlineSession()
+    const ev = capture(s, ['error', 'stream_end', 'result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'error', params: reconnectParams(1, 5) })
+    assert.ok(s._reconnectDeadline, 'deadline armed')
+    // codex re-establishes the stream and streams a delta → genuine forward progress.
+    s._onNotification({ method: 'item/agentMessage/delta', params: { delta: 'back online' } })
+    assert.equal(s._reconnectDeadline, null, 'deadline cleared on forward progress')
+    assert.equal(timers.scheduled[0].cleared, true, 'the scheduled deadline timer was cleared')
+    // Firing whatever the fake still holds must be a no-op — nothing pending.
+    timers.fire()
+    assert.ok(!ev.some(([e]) => e === 'error'), 'no stall error after recovery')
+    // …and the turn still completes cleanly.
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 5 } } })
+    assert.equal(s._isBusy, false, 'busy cleared on clean completion')
+    assert.equal(s._activeTurn, null, 'turn cleared on clean completion')
+    s.destroy()
+    cleanup()
+  })
+
+  it('the deadline firing while still suppressed fails the turn with the reconnect error + sweeps the orphan tool_start', () => {
+    const { s, cleanup, timers } = mkDeadlineSession()
+    const ev = capture(s, ['error', 'stopped', 'tool_result', 'stream_end'])
+    armBusyTurnWithInflightShell(s)
+    s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
+    assert.ok(s._reconnectDeadline, 'deadline armed while suppressed')
+    // codex never recovers, never goes silent, never emits a terminal give-up —
+    // the deadline is the backstop.
+    timers.fire()
+    const err = ev.find(([e]) => e === 'error')
+    assert.ok(err, 'the deadline fails the turn')
+    assert.match(err[1].message, /reconnect exceeded 60s/i, 'a clear "codex reconnect exceeded Ns" error')
+    assert.equal(err[1].code, 'stream_stall', 'carries stream_stall so the client shows its retry chip')
+    assert.ok(ev.some(([e, p]) => e === 'tool_result' && p.toolUseId === 'shell-1'), 'the orphan in-flight shell tool_start is swept')
+    assert.equal(s._isBusy, false, 'stale working state cleared')
+    assert.equal(s._activeTurn, null, 'turn cleared')
+    assert.equal(s._reconnectDeadline, null, 'deadline handle cleared after firing')
+    s.destroy()
+    cleanup()
+  })
+
+  it('non-reconnect turns are unaffected (no deadline ever armed)', () => {
+    const { s, cleanup, timers } = mkDeadlineSession()
+    const ev = capture(s, ['error', 'result'])
+    s._isBusy = true
+    s._activeTurn = { messageId: 'm1', turnId: 't1', didStreamStart: true }
+    s._onNotification({ method: 'item/agentMessage/delta', params: { delta: 'hello' } })
+    s._onNotification({ method: 'turn/completed', params: { turn: { durationMs: 5 } } })
+    assert.equal(timers.scheduled.length, 0, 'no reconnect deadline armed for a normal turn')
+    assert.equal(s._reconnectDeadline, null, 'deadline never armed')
+    assert.ok(!ev.some(([e]) => e === 'error'), 'no error surfaced for a clean turn')
+    assert.equal(s._isBusy, false, 'turn completed normally')
+    s.destroy()
+    cleanup()
+  })
+
+  it('the deadline is configurable via the opt (with a sensible default)', () => {
+    const custom = mkSession({ reconnectDeadlineMs: 90_000 })
+    assert.equal(custom.s._reconnectDeadlineMs, 90_000, 'opt overrides the default')
+    custom.s.destroy(); custom.cleanup()
+
+    const def = mkSession()
+    assert.equal(def.s._reconnectDeadlineMs, 5 * 60 * 1000, 'default is 5 min')
+    def.s.destroy(); def.cleanup()
+
+    // A bogus opt (non-positive / non-finite) falls back to the default.
+    const bogus = mkSession({ reconnectDeadlineMs: 0 })
+    assert.equal(bogus.s._reconnectDeadlineMs, 5 * 60 * 1000, 'a non-positive opt falls back to the default')
+    bogus.s.destroy(); bogus.cleanup()
+  })
+
+  it('the deadline is configurable via CHROXY_CODEX_RECONNECT_DEADLINE_MS', () => {
+    const prev = process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
+    process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = '120000'
+    try {
+      const { s, cleanup } = mkSession()
+      assert.equal(s._reconnectDeadlineMs, 120_000, 'env var sets the deadline')
+      s.destroy(); cleanup()
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
+      else process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = prev
+    }
+  })
+})
+
 describe('CodexAppServerSession — approval surfacing (#6605 Phase 2)', () => {
   const tick = () => new Promise((r) => setImmediate(r))
   function mkApprovalSession(mode = 'approve') {


### PR DESCRIPTION
## Problem

#6854 (fixes #6623) stops `_failTurn`-ing on codex's own transient `responseStreamDisconnected` + `Reconnecting... N/M` `error` notifications, keeping the turn open so codex can recover and emit `turn/completed`. The backstops for a never-recovering reconnect are the 30-min per-turn result timeout and the #6629 silence watchdog — but **both are re-armed on every notification**.

So a codex that emits reconnect notifications **forever** (never recovering, never going silent, never emitting a distinct terminal give-up) keeps pushing *both* backstops out on every tick, holding the turn in `Working...` far longer than it should. The #6629 watchdog is a *silence* detector (re-armed each tick → only fires after a full window of quiet); it does not bound a continuous reconnect **storm**.

Closes #6856.

## Fix

Add a dedicated one-shot **reconnect-suppression deadline** — a hard cap on how long a turn may stay in the transient-reconnect-suppressed state, independent of and shorter than the general result timeout:

- **Armed ONCE** the first time a turn enters suppression. The `if (this._reconnectDeadline) return` guard in `_armReconnectDeadline` makes any later reconnect tick a no-op, so a storm **cannot** slide the deadline forward — this is the core fix (the existing re-arm is the bug).
- **Cleared** on genuine forward progress (any non-`error` notification), on the terminal-error path, and on turn teardown (`_clearMessageState` / `destroy`).
- **Fires** `_failTurn('Codex reconnect exceeded Ns without recovery …', { code: 'stream_stall' })` so the client shows its existing retry chip, and the shared orphan-tool sweep pairs any in-flight `tool_start` with a synthetic `tool_result`.
- **5-min default**, configurable via the `reconnectDeadlineMs` opt / `CHROXY_CODEX_RECONNECT_DEADLINE_MS`. Sits above codex's bounded N/5 retry burst **and** above the 2-min silence watchdog (so the faster silence path still wins its own case), 6x below the 30-min result timeout.
- Routes through an injectable `setTimer`/`clearTimer` seam (mirrors the #6908/#6911 hermetic-DNS pattern) and `unref`'s the handle, so the deadline is unit-tested with zero wall-clock and a bare run self-exits with no leaked timer (#6933).

The #6629 silence watchdog and the general result-timeout behavior for non-reconnect cases are unchanged.

## Tests

New `CodexAppServerSession — reconnect suppression deadline (#6856)` block (7 tests, injected timers, no wall-clock):
1. entering the reconnect-suppressed state arms the deadline;
2. a flurry of reconnect notifications does **not** push the deadline out (the bug — asserts exactly one timer scheduled across the whole flurry, same handle);
3. genuine recovery before the deadline clears it (no fail);
4. the deadline firing while still suppressed fails the turn with the `reconnect exceeded 60s` / `stream_stall` error and sweeps the orphan `tool_start`;
5. non-reconnect turns are unaffected (no deadline ever armed);
6-7. configurable via opt (+ default / bogus-value fallback) and via the env var.

`codex*` suites: **244 pass, 0 fail**, exit 0 **without** `--test-force-exit` (no leaked handle). All 5 server shell lints rc=0; `npm run lint` 0 errors.