### PR TITLE
feat(server,protocol): merged-CLAUDE.md read endpoint with per-file provenance

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -499,6 +499,11 @@ export declare const AppendMemorySchema: z.ZodObject<{
     text: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
+export declare const MemoryReadSchema: z.ZodObject<{
+    type: z.ZodLiteral<"memory_read">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const ListFilesSchema: z.ZodObject<{
     type: z.ZodLiteral<"list_files">;
     query: z.ZodOptional<z.ZodString>;
@@ -1197,6 +1202,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"append_memory">;
     text: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"memory_read">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"list_files">;
     query: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -699,6 +699,20 @@ export const AppendMemorySchema = z.object({
     text: z.string().min(1).max(10_000),
     sessionId: z.string().max(256).optional(),
 }).passthrough();
+// #6864 (epic #6760): read the effective merged CLAUDE.md memory stack
+// (global/project/local + @imports) plus the auto-generated MEMORY.md
+// descriptor — the read-only counterpart to append_memory (#6861). No
+// client-supplied path: every location the server reads is chosen
+// SERVER-side (fixed relative to the session cwd + the user's ~/.claude
+// home), so the request carries no path field at all — there is no
+// client-controlled traversal surface. `requestId` is an optional nonce
+// (mirrors read_file's #6502 pattern) echoed on the reply so a client can
+// drop a superseded response after a rapid session switch.
+export const MemoryReadSchema = z.object({
+    type: z.literal('memory_read'),
+    sessionId: z.string().max(256).optional(),
+    requestId: z.string().max(200).optional(),
+}).passthrough();
 export const ListFilesSchema = z.object({
     type: z.literal('list_files'),
     query: z.string().max(1000).optional(),
@@ -1521,6 +1535,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     ReadFileSchema,
     WriteFileSchema,
     AppendMemorySchema,
+    MemoryReadSchema,
     ListFilesSchema,
     ListSymbolsSchema,
     ResolveSymbolSchema,

--- a/packages/protocol/dist/schemas/server/file-ops.d.ts
+++ b/packages/protocol/dist/schemas/server/file-ops.d.ts
@@ -114,3 +114,31 @@ export declare const ServerAppendMemoryResultSchema: z.ZodObject<{
     created: z.ZodBoolean;
     error: z.ZodNullable<z.ZodString>;
 }, z.core.$strip>;
+export declare const ServerMemoryStackResultSchema: z.ZodObject<{
+    type: z.ZodLiteral<"memory_stack_result">;
+    entries: z.ZodArray<z.ZodObject<{
+        path: z.ZodNullable<z.ZodString>;
+        exists: z.ZodBoolean;
+        content: z.ZodNullable<z.ZodString>;
+        truncated: z.ZodBoolean;
+        skipped: z.ZodBoolean;
+        error: z.ZodNullable<z.ZodString>;
+        scope: z.ZodEnum<{
+            project: "project";
+            global: "global";
+            local: "local";
+            import: "import";
+        }>;
+        importedFrom: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    memoryFile: z.ZodNullable<z.ZodObject<{
+        path: z.ZodNullable<z.ZodString>;
+        exists: z.ZodBoolean;
+        content: z.ZodNullable<z.ZodString>;
+        truncated: z.ZodBoolean;
+        skipped: z.ZodBoolean;
+        error: z.ZodNullable<z.ZodString>;
+    }, z.core.$strip>>;
+    error: z.ZodNullable<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server/file-ops.js
+++ b/packages/protocol/dist/schemas/server/file-ops.js
@@ -135,3 +135,39 @@ export const ServerAppendMemoryResultSchema = z.object({
     created: z.boolean(),
     error: z.string().nullable(),
 });
+// #6864 (epic #6760): `memory_read` reply — the effective merged CLAUDE.md
+// memory stack with per-file provenance, plus the project's auto-generated
+// MEMORY.md descriptor. `entries` is ordered global -> project -> local
+// (Claude Code's own load order — https://code.claude.com/docs/en/memory:
+// "content is ordered from the filesystem root down to your working
+// directory"), with each root's own @import references inlined depth-first
+// immediately after it (`importedFrom` names the file that referenced them).
+// An import whose target resolves outside the session cwd or the user's
+// ~/.claude home is reported with `skipped: true` / `content: null` — the
+// read-only path-confinement guard; it is never opened, so its existence is
+// never disclosed either. `memoryFile` is null only when the request-level
+// `error` fires (memory unavailable in this mode / session cwd unresolvable);
+// otherwise it always carries the resolved MEMORY.md descriptor
+// (`exists: false` when the project has no auto-memory yet).
+const MemoryFileDescriptorSchema = z.object({
+    path: z.string().nullable(),
+    exists: z.boolean(),
+    content: z.string().nullable(),
+    truncated: z.boolean(),
+    skipped: z.boolean(),
+    error: z.string().nullable(),
+});
+const MemoryStackEntrySchema = MemoryFileDescriptorSchema.extend({
+    scope: z.enum(['global', 'project', 'local', 'import']),
+    importedFrom: z.string().nullable(),
+});
+export const ServerMemoryStackResultSchema = z.object({
+    type: z.literal('memory_stack_result'),
+    entries: z.array(MemoryStackEntrySchema),
+    memoryFile: MemoryFileDescriptorSchema.nullable(),
+    error: z.string().nullable(),
+    // Echoes the `memory_read` request nonce when the client supplied one, so a
+    // rapid session switch can drop a superseded reply (mirrors read_file's
+    // #6502 `requestId` pattern).
+    requestId: z.string().max(200).optional(),
+});

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -777,6 +777,21 @@ export const AppendMemorySchema = z.object({
   sessionId: z.string().max(256).optional(),
 }).passthrough()
 
+// #6864 (epic #6760): read the effective merged CLAUDE.md memory stack
+// (global/project/local + @imports) plus the auto-generated MEMORY.md
+// descriptor — the read-only counterpart to append_memory (#6861). No
+// client-supplied path: every location the server reads is chosen
+// SERVER-side (fixed relative to the session cwd + the user's ~/.claude
+// home), so the request carries no path field at all — there is no
+// client-controlled traversal surface. `requestId` is an optional nonce
+// (mirrors read_file's #6502 pattern) echoed on the reply so a client can
+// drop a superseded response after a rapid session switch.
+export const MemoryReadSchema = z.object({
+  type: z.literal('memory_read'),
+  sessionId: z.string().max(256).optional(),
+  requestId: z.string().max(200).optional(),
+}).passthrough()
+
 export const ListFilesSchema = z.object({
   type: z.literal('list_files'),
   query: z.string().max(1000).optional(),
@@ -1700,6 +1715,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   ReadFileSchema,
   WriteFileSchema,
   AppendMemorySchema,
+  MemoryReadSchema,
   ListFilesSchema,
   ListSymbolsSchema,
   ResolveSymbolSchema,

--- a/packages/protocol/src/schemas/server/file-ops.ts
+++ b/packages/protocol/src/schemas/server/file-ops.ts
@@ -144,3 +144,42 @@ export const ServerAppendMemoryResultSchema = z.object({
   created: z.boolean(),
   error: z.string().nullable(),
 })
+
+// #6864 (epic #6760): `memory_read` reply — the effective merged CLAUDE.md
+// memory stack with per-file provenance, plus the project's auto-generated
+// MEMORY.md descriptor. `entries` is ordered global -> project -> local
+// (Claude Code's own load order — https://code.claude.com/docs/en/memory:
+// "content is ordered from the filesystem root down to your working
+// directory"), with each root's own @import references inlined depth-first
+// immediately after it (`importedFrom` names the file that referenced them).
+// An import whose target resolves outside the session cwd or the user's
+// ~/.claude home is reported with `skipped: true` / `content: null` — the
+// read-only path-confinement guard; it is never opened, so its existence is
+// never disclosed either. `memoryFile` is null only when the request-level
+// `error` fires (memory unavailable in this mode / session cwd unresolvable);
+// otherwise it always carries the resolved MEMORY.md descriptor
+// (`exists: false` when the project has no auto-memory yet).
+const MemoryFileDescriptorSchema = z.object({
+  path: z.string().nullable(),
+  exists: z.boolean(),
+  content: z.string().nullable(),
+  truncated: z.boolean(),
+  skipped: z.boolean(),
+  error: z.string().nullable(),
+})
+
+const MemoryStackEntrySchema = MemoryFileDescriptorSchema.extend({
+  scope: z.enum(['global', 'project', 'local', 'import']),
+  importedFrom: z.string().nullable(),
+})
+
+export const ServerMemoryStackResultSchema = z.object({
+  type: z.literal('memory_stack_result'),
+  entries: z.array(MemoryStackEntrySchema),
+  memoryFile: MemoryFileDescriptorSchema.nullable(),
+  error: z.string().nullable(),
+  // Echoes the `memory_read` request nonce when the client supplied one, so a
+  // rapid session switch can drop a superseded reply (mirrors read_file's
+  // #6502 `requestId` pattern).
+  requestId: z.string().max(200).optional(),
+})

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -83,6 +83,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
+  'memory_stack_result', // #6864 (epic #6760) reply to memory_read — server-only for v1, no client handler yet; the dashboard/mobile memory-panel consumers are the sibling slices #6867/#6870
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.

--- a/packages/server/src/handlers/file-handlers.js
+++ b/packages/server/src/handlers/file-handlers.js
@@ -87,6 +87,15 @@ function handleAppendMemory(ws, client, msg, ctx) {
   ctx.services.fileOps.appendMemory(ws, msg.text, entry?.cwd || null)
 }
 
+function handleMemoryRead(ws, client, msg, ctx) {
+  // #6864 (epic #6760) — server read of the effective merged CLAUDE.md memory
+  // stack (global/project/local + @imports) plus the auto-generated
+  // MEMORY.md descriptor. Read-only: no mutation gate needed (a bound/
+  // share-a-session client may read memory, matching read_file/get_diff).
+  const entry = resolveSession(ctx, msg, client)
+  ctx.services.fileOps.readMemory(ws, entry?.cwd || null, msg.requestId)
+}
+
 function handleGetDiff(ws, client, msg, ctx) {
   const entry = resolveSession(ctx, msg, client)
   ctx.services.fileOps.getDiff(ws, msg.base, entry?.cwd || null)
@@ -164,6 +173,7 @@ export const fileHandlers = {
   read_file: handleReadFile,
   write_file: handleWriteFile,
   append_memory: handleAppendMemory,
+  memory_read: handleMemoryRead,
   get_diff: handleGetDiff,
   git_status: handleGitStatus,
   git_branches: handleGitBranches,

--- a/packages/server/src/ws-file-ops/index.js
+++ b/packages/server/src/ws-file-ops/index.js
@@ -3,6 +3,7 @@ import { resolveSessionCwd, validatePathWithinCwd } from './common.js'
 import { createBrowserOps } from './browser.js'
 import { createReaderOps } from './reader.js'
 import { createGitOps } from './git.js'
+import { createMemoryOps } from './memory.js'
 
 /**
  * Create file operation handlers for the WsServer.
@@ -29,6 +30,7 @@ export function createFileOps(sendFn, workspaceRoot) {
   const browser = createBrowserOps(sendFn, boundResolve, boundValidate)
   const reader = createReaderOps(sendFn, boundResolve, boundValidate)
   const git = createGitOps(sendFn, boundResolve, boundValidate, gitWorkspaceRoot)
+  const memory = createMemoryOps(sendFn, boundResolve)
 
   return {
     listDirectory: browser.listDirectory,
@@ -36,6 +38,7 @@ export function createFileOps(sendFn, workspaceRoot) {
     readFile: reader.readFile,
     writeFile: reader.writeFile,
     appendMemory: reader.appendMemory,
+    readMemory: memory.readMemory,
     getDiff: reader.getDiff,
     listSlashCommands: browser.listSlashCommands,
     listAgents: browser.listAgents,

--- a/packages/server/src/ws-file-ops/memory.js
+++ b/packages/server/src/ws-file-ops/memory.js
@@ -90,35 +90,35 @@ function hasMarkdownExt(p) {
 }
 
 /**
- * Read+validate a single memory file that MUST resolve within one of the
- * given allowed roots — the read-only path-confinement guard for #6864.
+ * Phase 1 of the confined-memory-file read: resolve + validate a LEXICAL
+ * target path within one of the given allowed roots WITHOUT touching file
+ * content — no `stat`/`open`/read, just the markdown-extension gate,
+ * symlink-safe realpath resolution, and the containment check. Split out
+ * from `readConfinedMemoryFile` so a caller (namely `collectImports`) can
+ * compute a target's cycle-guard identity — the resolved real path — and
+ * consult the `visited` set BEFORE paying for the actual read, so a
+ * duplicate/cyclical `@import` short-circuits before any I/O beyond this
+ * lightweight resolution (#6971 perf follow-up).
  *
  * Symlink-safe: resolves the deepest existing real ancestor before the
  * containment check (same helper reader.js uses), so a symlinked parent
- * directory can't smuggle the target outside the allowed roots. The
- * containment check runs BEFORE any `stat`/`open` — a path outside the
- * allowed roots is never even stat'd, so its existence can't be inferred
- * from the response (mirrors the "don't leak existence as an oracle"
- * reasoning in readFileContent). The final open uses O_NOFOLLOW to close
- * the post-validation TOCTOU window (a symlink swapped in at the target
- * between validation and open is rejected, not followed).
+ * directory can't smuggle the target outside the allowed roots.
  *
  * With `{ requireMarkdownExt: true }` (the `@import` path passes this; the fixed
  * root files do NOT), a resolved target whose extension is not in
  * IMPORT_ALLOWED_EXTS is rejected up front — same skip shape as out-of-bounds —
  * closing the "@import a non-markdown sensitive file under ~/.claude" class (#6971).
  *
- * Never throws — every failure mode folds into `error`/`skipped` so a caller
- * can push the result straight onto the response array. All skip branches share
- * MEMORY_SKIP_ERROR and echo the LEXICAL request path, so they're byte-identical
- * (no distinguishing oracle).
+ * Never throws — every failure mode folds into a ready-to-push `skipEntry`
+ * (byte-identical MEMORY_SKIP_ERROR shape, echoing the LEXICAL request path —
+ * no distinguishing oracle) instead of a resolved path.
  *
  * @param {string} lexicalAbsPath - Absolute LEXICAL (pre-realpath) target path
  * @param {string[]} allowedRoots - Real-path roots the target must resolve within
  * @param {{requireMarkdownExt?: boolean}} [opts] - `@import`-only markdown-extension gate
- * @returns {Promise<{path: string|null, exists: boolean, content: string|null, truncated: boolean, skipped: boolean, error: string|null}>}
+ * @returns {Promise<{resolvedPath: string|null, skipEntry: object|null}>}
  */
-async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMarkdownExt = false } = {}) {
+async function resolveConfinedMemoryPath(lexicalAbsPath, allowedRoots, { requireMarkdownExt = false } = {}) {
   const base = { path: lexicalAbsPath, exists: false, content: null, truncated: false, skipped: false, error: null }
 
   // `@import` markdown allowlist (import path ONLY; the fixed root files are
@@ -129,7 +129,7 @@ async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMar
   // markdown", and "doesn't exist". Purely LEXICAL and BEFORE any realpath/stat,
   // so a non-markdown import never even touches the filesystem. (#6971)
   if (requireMarkdownExt && !hasMarkdownExt(lexicalAbsPath)) {
-    return { ...base, skipped: true, error: MEMORY_SKIP_ERROR }
+    return { resolvedPath: null, skipEntry: { ...base, skipped: true, error: MEMORY_SKIP_ERROR } }
   }
 
   let resolvedPath
@@ -139,7 +139,7 @@ async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMar
     // Resolution failed (EACCES on an ancestor dir, symlink-depth ceiling, …).
     // Normalize to the identical clean-skip shape rather than echoing the raw
     // error message — no error-string oracle, no content leak. (#6971)
-    return { ...base, skipped: true, error: MEMORY_SKIP_ERROR }
+    return { resolvedPath: null, skipEntry: { ...base, skipped: true, error: MEMORY_SKIP_ERROR } }
   }
 
   const withinRoot = allowedRoots.some((root) => resolvedPath === root || resolvedPath.startsWith(root + sep))
@@ -147,22 +147,38 @@ async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMar
     // Outside every allowed root — reject WITHOUT stat'ing (no existence oracle).
     // Echo the LEXICAL request path (base.path), NOT the realpath-resolved path,
     // so a skipped entry can't be used as a symlink-target oracle. (#6971)
-    return { ...base, skipped: true, error: MEMORY_SKIP_ERROR }
+    return { resolvedPath: null, skipEntry: { ...base, skipped: true, error: MEMORY_SKIP_ERROR } }
   }
+
+  return { resolvedPath, skipEntry: null }
+}
+
+/**
+ * Phase 2 of the confined-memory-file read: `stat`/`open`/read an ALREADY
+ * resolved+validated real path (see `resolveConfinedMemoryPath`). The final
+ * open uses O_NOFOLLOW to close the post-validation TOCTOU window (a symlink
+ * swapped in at the target between validation and open is rejected, not
+ * followed).
+ *
+ * @param {string} resolvedPath - Real (post-realpath, already containment-checked) path
+ * @returns {Promise<{path: string, exists: boolean, content: string|null, truncated: boolean, skipped: boolean, error: string|null}>}
+ */
+async function readResolvedMemoryFile(resolvedPath) {
+  const base = { path: resolvedPath, exists: false, content: null, truncated: false, skipped: false, error: null }
 
   let fileStat
   try {
     fileStat = await stat(resolvedPath)
   } catch (err) {
-    if (err.code === 'ENOENT') return { ...base, path: resolvedPath, exists: false }
-    return { ...base, path: resolvedPath, error: err.code === 'EACCES' ? 'Permission denied' : (err.message || 'Unknown error') }
+    if (err.code === 'ENOENT') return { ...base, exists: false }
+    return { ...base, error: err.code === 'EACCES' ? 'Permission denied' : (err.message || 'Unknown error') }
   }
 
   if (!fileStat.isFile()) {
-    return { ...base, path: resolvedPath, exists: true, error: 'Not a regular file' }
+    return { ...base, exists: true, error: 'Not a regular file' }
   }
   if (fileStat.size > MAX_FILE_SIZE) {
-    return { ...base, path: resolvedPath, exists: true, error: 'File too large (max 512KB)' }
+    return { ...base, exists: true, error: 'File too large (max 512KB)' }
   }
 
   let buf
@@ -173,9 +189,9 @@ async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMar
   } catch (err) {
     if (err.code === 'ELOOP') {
       // Symlink appeared at the canonical path after validation — reject.
-      return { ...base, path: resolvedPath, exists: true, skipped: true, error: 'Access denied: possible symlink race — read skipped' }
+      return { ...base, exists: true, skipped: true, error: 'Access denied: possible symlink race — read skipped' }
     }
-    return { ...base, path: resolvedPath, exists: true, error: err.message || 'Unknown error' }
+    return { ...base, exists: true, error: err.message || 'Unknown error' }
   } finally {
     await fh?.close()
   }
@@ -187,7 +203,26 @@ async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMar
     truncated = true
   }
 
-  return { ...base, path: resolvedPath, exists: true, content, truncated }
+  return { ...base, exists: true, content, truncated }
+}
+
+/**
+ * Read+validate a single memory file that MUST resolve within one of the
+ * given allowed roots — the read-only path-confinement guard for #6864.
+ * Thin composition of `resolveConfinedMemoryPath` (validate, no I/O beyond
+ * resolution) + `readResolvedMemoryFile` (stat/open/read) — kept as a single
+ * entry point for callers (the three fixed root files, the MEMORY.md
+ * descriptor) that don't need to consult a cycle guard before reading.
+ *
+ * @param {string} lexicalAbsPath - Absolute LEXICAL (pre-realpath) target path
+ * @param {string[]} allowedRoots - Real-path roots the target must resolve within
+ * @param {{requireMarkdownExt?: boolean}} [opts] - `@import`-only markdown-extension gate
+ * @returns {Promise<{path: string|null, exists: boolean, content: string|null, truncated: boolean, skipped: boolean, error: string|null}>}
+ */
+async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, opts = {}) {
+  const { resolvedPath, skipEntry } = await resolveConfinedMemoryPath(lexicalAbsPath, allowedRoots, opts)
+  if (skipEntry) return skipEntry
+  return readResolvedMemoryFile(resolvedPath)
 }
 
 /**
@@ -203,11 +238,16 @@ async function collectImports(content, importingFileAbsPath, allowedRoots, visit
     if (outEntries.length >= MAX_IMPORT_ENTRIES) return
     const lexicalTarget = resolveImportTarget(rawPath, importingFileAbsPath)
     // Import targets are confined to the same roots AND restricted to markdown
-    // memory files (the root files themselves are not) — see #6971.
-    const entry = await readConfinedMemoryFile(lexicalTarget, allowedRoots, { requireMarkdownExt: true })
-    const key = entry.path || lexicalTarget
-    if (visited.has(key)) continue // cycle guard
+    // memory files (the root files themselves are not) — see #6971. Resolve
+    // the target's identity FIRST (no stat/open/read yet) so a duplicate
+    // `@import` of an already-visited file — or a cycle back to one — hits
+    // the `visited` check and short-circuits BEFORE the read, instead of
+    // paying for a redundant stat/open/read only to discard it.
+    const { resolvedPath, skipEntry } = await resolveConfinedMemoryPath(lexicalTarget, allowedRoots, { requireMarkdownExt: true })
+    const key = resolvedPath || lexicalTarget
+    if (visited.has(key)) continue // cycle/dup guard — before any read
     visited.add(key)
+    const entry = skipEntry ?? await readResolvedMemoryFile(resolvedPath)
     outEntries.push({ ...entry, scope: 'import', importedFrom: importingFileAbsPath })
     if (entry.exists && entry.content && !entry.skipped && !entry.error) {
       await collectImports(entry.content, entry.path, allowedRoots, visited, depth + 1, outEntries)

--- a/packages/server/src/ws-file-ops/memory.js
+++ b/packages/server/src/ws-file-ops/memory.js
@@ -1,6 +1,6 @@
 import { stat, open } from 'fs/promises'
 import { constants as fsConstants } from 'fs'
-import { resolve, dirname, normalize, sep } from 'path'
+import { resolve, dirname, normalize, sep, extname } from 'path'
 import { homedir } from 'os'
 import { realpathOfDeepestAncestor } from './common.js'
 import { encodeProjectPath } from '../jsonl-reader.js'
@@ -13,6 +13,24 @@ const MAX_CONTENT_SIZE = 100 * 1024
 const MAX_IMPORT_DEPTH = 4
 /** hard ceiling on total import entries per read — defence against import fan-out */
 const MAX_IMPORT_ENTRIES = 50
+/**
+ * Extensions an `@import` target may resolve to. Memory `@import`s are meant to
+ * pull in MARKDOWN memory files, not arbitrary files — restricting the resolved
+ * target to this allowlist blocks the sensitive-file class under an allowed root
+ * (`~/.claude/.credentials.json`, `~/.claude/settings.json`, identity keys,
+ * other projects' `~/.claude/projects/**` `.jsonl` transcripts, extensionless
+ * files) that would otherwise resolve IN-BOUNDS and be surfaced to the client.
+ * More robust than a filename blocklist — it closes the whole class. (#6971)
+ */
+const IMPORT_ALLOWED_EXTS = ['.md', '.markdown']
+/**
+ * Single "not readable — skipped" reason string shared by EVERY skip branch
+ * (out-of-bounds, non-markdown `@import`, resolution failure). Reusing ONE
+ * message keeps the skip entries byte-identical so a client cannot distinguish
+ * "outside allowed roots" from "not a markdown file" from "couldn't resolve" —
+ * no error-string oracle. (#6971)
+ */
+const MEMORY_SKIP_ERROR = 'Outside allowed memory roots — read skipped'
 
 // Matches an `@path` memory-import reference (Claude Code's CLAUDE.md import
 // syntax — see docs.claude.com "Manage Claude's memory" / "Import additional
@@ -63,6 +81,15 @@ function resolveImportTarget(rawPath, importingFileAbsPath) {
 }
 
 /**
+ * True iff `p`'s extension is in the `@import` markdown allowlist
+ * (case-insensitive) — see IMPORT_ALLOWED_EXTS. An extensionless path
+ * (`extname` → '') is NOT markdown and is rejected.
+ */
+function hasMarkdownExt(p) {
+  return IMPORT_ALLOWED_EXTS.includes(extname(p).toLowerCase())
+}
+
+/**
  * Read+validate a single memory file that MUST resolve within one of the
  * given allowed roots — the read-only path-confinement guard for #6864.
  *
@@ -76,25 +103,51 @@ function resolveImportTarget(rawPath, importingFileAbsPath) {
  * the post-validation TOCTOU window (a symlink swapped in at the target
  * between validation and open is rejected, not followed).
  *
- * Never throws — every failure mode folds into `error`/`skipped` so a caller
- * can push the result straight onto the response array.
+ * With `{ requireMarkdownExt: true }` (the `@import` path passes this; the fixed
+ * root files do NOT), a resolved target whose extension is not in
+ * IMPORT_ALLOWED_EXTS is rejected up front — same skip shape as out-of-bounds —
+ * closing the "@import a non-markdown sensitive file under ~/.claude" class (#6971).
  *
+ * Never throws — every failure mode folds into `error`/`skipped` so a caller
+ * can push the result straight onto the response array. All skip branches share
+ * MEMORY_SKIP_ERROR and echo the LEXICAL request path, so they're byte-identical
+ * (no distinguishing oracle).
+ *
+ * @param {string} lexicalAbsPath - Absolute LEXICAL (pre-realpath) target path
+ * @param {string[]} allowedRoots - Real-path roots the target must resolve within
+ * @param {{requireMarkdownExt?: boolean}} [opts] - `@import`-only markdown-extension gate
  * @returns {Promise<{path: string|null, exists: boolean, content: string|null, truncated: boolean, skipped: boolean, error: string|null}>}
  */
-async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots) {
+async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots, { requireMarkdownExt = false } = {}) {
   const base = { path: lexicalAbsPath, exists: false, content: null, truncated: false, skipped: false, error: null }
+
+  // `@import` markdown allowlist (import path ONLY; the fixed root files are
+  // exempt). A non-markdown target — `~/.claude/.credentials.json`,
+  // `~/.claude/settings.json`, an identity key, a `.jsonl` transcript, an
+  // extensionless file — is rejected with the SAME shape an out-of-bounds path
+  // gets, so there's no distinguishing oracle between "out of bounds", "not
+  // markdown", and "doesn't exist". Purely LEXICAL and BEFORE any realpath/stat,
+  // so a non-markdown import never even touches the filesystem. (#6971)
+  if (requireMarkdownExt && !hasMarkdownExt(lexicalAbsPath)) {
+    return { ...base, skipped: true, error: MEMORY_SKIP_ERROR }
+  }
 
   let resolvedPath
   try {
     resolvedPath = await realpathOfDeepestAncestor(lexicalAbsPath)
-  } catch (err) {
-    return { ...base, error: err.message || 'Failed to resolve path' }
+  } catch {
+    // Resolution failed (EACCES on an ancestor dir, symlink-depth ceiling, …).
+    // Normalize to the identical clean-skip shape rather than echoing the raw
+    // error message — no error-string oracle, no content leak. (#6971)
+    return { ...base, skipped: true, error: MEMORY_SKIP_ERROR }
   }
 
   const withinRoot = allowedRoots.some((root) => resolvedPath === root || resolvedPath.startsWith(root + sep))
   if (!withinRoot) {
     // Outside every allowed root — reject WITHOUT stat'ing (no existence oracle).
-    return { ...base, path: resolvedPath, skipped: true, error: 'Outside allowed memory roots — read skipped' }
+    // Echo the LEXICAL request path (base.path), NOT the realpath-resolved path,
+    // so a skipped entry can't be used as a symlink-target oracle. (#6971)
+    return { ...base, skipped: true, error: MEMORY_SKIP_ERROR }
   }
 
   let fileStat
@@ -149,7 +202,9 @@ async function collectImports(content, importingFileAbsPath, allowedRoots, visit
   for (const rawPath of extractImportPaths(content)) {
     if (outEntries.length >= MAX_IMPORT_ENTRIES) return
     const lexicalTarget = resolveImportTarget(rawPath, importingFileAbsPath)
-    const entry = await readConfinedMemoryFile(lexicalTarget, allowedRoots)
+    // Import targets are confined to the same roots AND restricted to markdown
+    // memory files (the root files themselves are not) — see #6971.
+    const entry = await readConfinedMemoryFile(lexicalTarget, allowedRoots, { requireMarkdownExt: true })
     const key = entry.path || lexicalTarget
     if (visited.has(key)) continue // cycle guard
     visited.add(key)
@@ -191,9 +246,13 @@ export function createMemoryOps(sendFn, resolveSessionCwd) {
    * design), so there is no client-controlled traversal surface for the three
    * root files. The ONLY variable input is @import references found INSIDE
    * those files' own content, which are confined to the same two roots
-   * (session cwd, user's ~/.claude) via `readConfinedMemoryFile` — an import
-   * resolving outside both is reported (for provenance/transparency) with
-   * `skipped: true` and is never opened.
+   * (session cwd, user's ~/.claude) via `readConfinedMemoryFile` AND restricted
+   * to markdown targets (`.md`/`.markdown`) — an import resolving outside both
+   * roots, or to a non-markdown file (e.g. `~/.claude/.credentials.json`), is
+   * reported (for provenance/transparency) with `skipped: true` and is never
+   * opened. #6971 added the markdown restriction so a malicious project
+   * CLAUDE.md can't `@import` a sensitive non-memory file that happens to sit
+   * under the ~/.claude allowed root.
    *
    * Also resolves the project's auto-generated MEMORY.md descriptor, keyed by
    * the SAME per-cwd path encoding `resolveJsonlPath` uses for transcript

--- a/packages/server/src/ws-file-ops/memory.js
+++ b/packages/server/src/ws-file-ops/memory.js
@@ -1,0 +1,259 @@
+import { stat, open } from 'fs/promises'
+import { constants as fsConstants } from 'fs'
+import { resolve, dirname, normalize, sep } from 'path'
+import { homedir } from 'os'
+import { realpathOfDeepestAncestor } from './common.js'
+import { encodeProjectPath } from '../jsonl-reader.js'
+
+/** stat-size ceiling before attempting a read (matches readFileContent) */
+const MAX_FILE_SIZE = 512 * 1024
+/** returned content is truncated past this (matches readFileContent) */
+const MAX_CONTENT_SIZE = 100 * 1024
+/** max recursive @import hops — matches Claude Code's own import recursion cap */
+const MAX_IMPORT_DEPTH = 4
+/** hard ceiling on total import entries per read — defence against import fan-out */
+const MAX_IMPORT_ENTRIES = 50
+
+// Matches an `@path` memory-import reference (Claude Code's CLAUDE.md import
+// syntax — see docs.claude.com "Manage Claude's memory" / "Import additional
+// files"). Requires a non-word/non-@ character (or start-of-string) before the
+// `@` so `user@example.com` / `foo@bar` prose is never mistaken for an import.
+const IMPORT_RE = /(^|[^\w@])@([\w./~-][\w./~-]*)/g
+
+/**
+ * Strip fenced code blocks and inline code spans before import scanning — the
+ * real @import syntax explicitly does NOT resolve inside code spans/blocks (a
+ * backtick-wrapped `@README` stays literal). We only need the SET of import
+ * paths, not their offsets, so stripped content is simply discarded.
+ */
+function stripCodeForImportScan(content) {
+  return content
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`\n]*`/g, '')
+}
+
+function extractImportPaths(content) {
+  const stripped = stripCodeForImportScan(content)
+  const paths = []
+  for (const m of stripped.matchAll(IMPORT_RE)) {
+    // Trim common trailing sentence punctuation a markdown author would have
+    // typed right after the path (period, comma, colon, closing paren).
+    const p = m[2].replace(/[.,:;)]+$/, '')
+    if (p) paths.push(p)
+  }
+  return paths
+}
+
+/**
+ * Resolve an @import target to an absolute LEXICAL path.
+ *   - `~/...` / `~`  -> resolved against the user's home directory
+ *   - `/...`         -> already absolute
+ *   - anything else  -> resolved relative to the DIRECTORY of the file that
+ *     contained the @import (matches real Claude Code semantics: imports
+ *     resolve relative to the importing file, not the session cwd).
+ */
+function resolveImportTarget(rawPath, importingFileAbsPath) {
+  if (rawPath === '~' || rawPath.startsWith('~/')) {
+    return normalize(resolve(homedir(), rawPath.slice(1).replace(/^\//, '')))
+  }
+  if (rawPath.startsWith('/')) {
+    return normalize(rawPath)
+  }
+  return normalize(resolve(dirname(importingFileAbsPath), rawPath))
+}
+
+/**
+ * Read+validate a single memory file that MUST resolve within one of the
+ * given allowed roots — the read-only path-confinement guard for #6864.
+ *
+ * Symlink-safe: resolves the deepest existing real ancestor before the
+ * containment check (same helper reader.js uses), so a symlinked parent
+ * directory can't smuggle the target outside the allowed roots. The
+ * containment check runs BEFORE any `stat`/`open` — a path outside the
+ * allowed roots is never even stat'd, so its existence can't be inferred
+ * from the response (mirrors the "don't leak existence as an oracle"
+ * reasoning in readFileContent). The final open uses O_NOFOLLOW to close
+ * the post-validation TOCTOU window (a symlink swapped in at the target
+ * between validation and open is rejected, not followed).
+ *
+ * Never throws — every failure mode folds into `error`/`skipped` so a caller
+ * can push the result straight onto the response array.
+ *
+ * @returns {Promise<{path: string|null, exists: boolean, content: string|null, truncated: boolean, skipped: boolean, error: string|null}>}
+ */
+async function readConfinedMemoryFile(lexicalAbsPath, allowedRoots) {
+  const base = { path: lexicalAbsPath, exists: false, content: null, truncated: false, skipped: false, error: null }
+
+  let resolvedPath
+  try {
+    resolvedPath = await realpathOfDeepestAncestor(lexicalAbsPath)
+  } catch (err) {
+    return { ...base, error: err.message || 'Failed to resolve path' }
+  }
+
+  const withinRoot = allowedRoots.some((root) => resolvedPath === root || resolvedPath.startsWith(root + sep))
+  if (!withinRoot) {
+    // Outside every allowed root — reject WITHOUT stat'ing (no existence oracle).
+    return { ...base, path: resolvedPath, skipped: true, error: 'Outside allowed memory roots — read skipped' }
+  }
+
+  let fileStat
+  try {
+    fileStat = await stat(resolvedPath)
+  } catch (err) {
+    if (err.code === 'ENOENT') return { ...base, path: resolvedPath, exists: false }
+    return { ...base, path: resolvedPath, error: err.code === 'EACCES' ? 'Permission denied' : (err.message || 'Unknown error') }
+  }
+
+  if (!fileStat.isFile()) {
+    return { ...base, path: resolvedPath, exists: true, error: 'Not a regular file' }
+  }
+  if (fileStat.size > MAX_FILE_SIZE) {
+    return { ...base, path: resolvedPath, exists: true, error: 'File too large (max 512KB)' }
+  }
+
+  let buf
+  let fh
+  try {
+    fh = await open(resolvedPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+    buf = await fh.readFile()
+  } catch (err) {
+    if (err.code === 'ELOOP') {
+      // Symlink appeared at the canonical path after validation — reject.
+      return { ...base, path: resolvedPath, exists: true, skipped: true, error: 'Access denied: possible symlink race — read skipped' }
+    }
+    return { ...base, path: resolvedPath, exists: true, error: err.message || 'Unknown error' }
+  } finally {
+    await fh?.close()
+  }
+
+  let content = buf.toString('utf-8')
+  let truncated = false
+  if (content.length > MAX_CONTENT_SIZE) {
+    content = content.slice(0, MAX_CONTENT_SIZE)
+    truncated = true
+  }
+
+  return { ...base, path: resolvedPath, exists: true, content, truncated }
+}
+
+/**
+ * Recursively resolve @imports referenced FROM `content`, appending entries
+ * (depth-first, matching the order Claude Code itself would inline them) to
+ * `outEntries`. `visited` is the whole-read cycle guard (keyed by resolved
+ * real path, falling back to the lexical target for a skipped/unresolvable
+ * one); `depth` enforces the same import-recursion ceiling Claude Code uses.
+ */
+async function collectImports(content, importingFileAbsPath, allowedRoots, visited, depth, outEntries) {
+  if (depth > MAX_IMPORT_DEPTH) return
+  for (const rawPath of extractImportPaths(content)) {
+    if (outEntries.length >= MAX_IMPORT_ENTRIES) return
+    const lexicalTarget = resolveImportTarget(rawPath, importingFileAbsPath)
+    const entry = await readConfinedMemoryFile(lexicalTarget, allowedRoots)
+    const key = entry.path || lexicalTarget
+    if (visited.has(key)) continue // cycle guard
+    visited.add(key)
+    outEntries.push({ ...entry, scope: 'import', importedFrom: importingFileAbsPath })
+    if (entry.exists && entry.content && !entry.skipped && !entry.error) {
+      await collectImports(entry.content, entry.path, allowedRoots, visited, depth + 1, outEntries)
+    }
+  }
+}
+
+/**
+ * File reading operations for the effective merged CLAUDE.md memory stack.
+ *
+ * @param {Function} sendFn - (ws, message) => void
+ * @param {Function} resolveSessionCwd - shared, cached CWD resolver (same one createReaderOps uses)
+ * @returns {Object} memory operation methods
+ */
+export function createMemoryOps(sendFn, resolveSessionCwd) {
+  /**
+   * Resolve the effective merged CLAUDE.md memory stack for a session
+   * (#6864, epic #6760) — the SERVER-side read counterpart to `appendMemory`
+   * (#6861).
+   *
+   * Scopes, in Claude Code's own load/precedence order — see
+   * https://code.claude.com/docs/en/memory ("content is ordered from the
+   * filesystem root down to your working directory"; within one directory,
+   * CLAUDE.local.md is read right after that directory's CLAUDE.md):
+   *   1. global  — ~/.claude/CLAUDE.md          (loaded first, lowest precedence)
+   *   2. project — <sessionCwd>/CLAUDE.md
+   *   3. local   — <sessionCwd>/CLAUDE.local.md  (loaded last, highest precedence)
+   * Managed/enterprise policy memory is out of scope — chroxy has no managed-
+   * policy surface today. Chroxy also does not walk from the session cwd UP to
+   * the filesystem root the way the real CLI does (every intermediate
+   * directory's CLAUDE.md) — only the session cwd's own root files are read,
+   * matching this slice's explicit path-confinement requirement.
+   *
+   * Every path here is SERVER-chosen — the request carries no client-supplied
+   * path at all (mirrors `appendMemory`'s "target is chosen server-side"
+   * design), so there is no client-controlled traversal surface for the three
+   * root files. The ONLY variable input is @import references found INSIDE
+   * those files' own content, which are confined to the same two roots
+   * (session cwd, user's ~/.claude) via `readConfinedMemoryFile` — an import
+   * resolving outside both is reported (for provenance/transparency) with
+   * `skipped: true` and is never opened.
+   *
+   * Also resolves the project's auto-generated MEMORY.md descriptor, keyed by
+   * the SAME per-cwd path encoding `resolveJsonlPath` uses for transcript
+   * storage (`encodeProjectPath` in jsonl-reader.js) — confirmed empirically
+   * against a live `~/.claude/projects/` tree to be keyed by the literal
+   * session cwd, not the git repository root (each worktree gets its own,
+   * separate memory directory).
+   */
+  async function readMemoryStack(ws, sessionCwd, requestId) {
+    const send = (payload) => sendFn(ws, requestId === undefined ? payload : { ...payload, requestId })
+
+    if (!sessionCwd) {
+      send({ type: 'memory_stack_result', entries: [], memoryFile: null, error: 'Memory is not available in this mode' })
+      return
+    }
+
+    let cwdReal
+    try {
+      cwdReal = await resolveSessionCwd(sessionCwd)
+    } catch (err) {
+      send({ type: 'memory_stack_result', entries: [], memoryFile: null, error: err.message || 'Failed to resolve session directory' })
+      return
+    }
+
+    let claudeHomeReal
+    try {
+      claudeHomeReal = await realpathOfDeepestAncestor(resolve(homedir(), '.claude'))
+    } catch {
+      claudeHomeReal = normalize(resolve(homedir(), '.claude'))
+    }
+
+    const allowedRoots = [cwdReal, claudeHomeReal]
+    const visited = new Set()
+    const entries = []
+
+    const roots = [
+      { scope: 'global', lexicalPath: resolve(claudeHomeReal, 'CLAUDE.md') },
+      { scope: 'project', lexicalPath: resolve(cwdReal, 'CLAUDE.md') },
+      { scope: 'local', lexicalPath: resolve(cwdReal, 'CLAUDE.local.md') },
+    ]
+
+    for (const { scope, lexicalPath } of roots) {
+      const entry = await readConfinedMemoryFile(lexicalPath, allowedRoots)
+      visited.add(entry.path || lexicalPath)
+      entries.push({ ...entry, scope, importedFrom: null })
+      if (entry.exists && entry.content && !entry.skipped && !entry.error) {
+        await collectImports(entry.content, entry.path, allowedRoots, visited, 1, entries)
+      }
+    }
+
+    // Auto-generated project memory (MEMORY.md) — restricted to the
+    // ~/.claude root only (it never lives under the session cwd).
+    const encoded = encodeProjectPath(cwdReal)
+    const memoryFilePath = resolve(claudeHomeReal, 'projects', encoded, 'memory', 'MEMORY.md')
+    const memoryFile = await readConfinedMemoryFile(memoryFilePath, [claudeHomeReal])
+
+    send({ type: 'memory_stack_result', entries, memoryFile, error: null })
+  }
+
+  return {
+    readMemory: readMemoryStack,
+  }
+}

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -271,6 +271,7 @@ function _isSecureRequest(req) {
  *   { type: 'browse_files', path? }                   — request file/directory listing for file browser
  *   { type: 'read_file', path }                       — request file content for file viewer
  *   { type: 'write_file', path, content }              — write file content (path validated, 5MB limit)
+ *   { type: 'memory_read', requestId? }                 — request the effective merged CLAUDE.md memory stack + auto-memory descriptor (#6864, epic #6760); no client-supplied path (server-chosen locations only)
  *   { type: 'list_slash_commands' }                     — request available slash commands
  *   { type: 'list_agents' }                             — request available custom agents
  *   { type: 'request_full_history', sessionId? }         — request full JSONL history for a session
@@ -429,6 +430,7 @@ function _isSecureRequest(req) {
  *   { type: 'git_unstage_result', success, error? }     — git unstage result
  *   { type: 'write_file_result', success, error? }      — write file result
  *   { type: 'append_memory_result', path, created, error? } — `#`-quick-append ack (#6861)
+ *   { type: 'memory_stack_result', entries, memoryFile, error?, requestId? } — reply to `memory_read` (#6864, epic #6760): ordered global/project/local CLAUDE.md stack with per-file provenance (+ recursively-resolved @imports, path-confined to the session cwd + ~/.claude) plus the auto-generated MEMORY.md descriptor. Server-only for v1 — no client handler yet; the dashboard/mobile memory-panel consumers are the sibling slices #6867/#6870
  *   { type: 'log_entry', level, message, timestamp }    — server log entry for dashboard
  *   { type: 'session_activity', sessionId, isBusy, lastCost } — session busy/idle state change
  *   { type: 'session_context', sessionId, cwd, conversationId?, ... } — session context data

--- a/packages/server/tests/memory-read.test.js
+++ b/packages/server/tests/memory-read.test.js
@@ -1,0 +1,262 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile, symlink, realpath } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createFileOps } from '../src/ws-file-ops/index.js'
+import { encodeProjectPath } from '../src/jsonl-reader.js'
+
+/**
+ * `readMemory` op (#6864, epic #6760) — server read of the effective merged
+ * CLAUDE.md memory stack (global/project/local + @imports) plus the project's
+ * auto-generated MEMORY.md descriptor. Every location is SERVER-chosen (no
+ * client-supplied path), so these tests exercise: the fixed three-file
+ * precedence stack, missing-file reporting, @import resolution (including
+ * relative-to-importing-file, code-fence exclusion, and cycle handling), the
+ * path-confinement guard against a traversal attempt, the symlink-escape
+ * defence, the MEMORY.md descriptor, and the requestId echo.
+ *
+ * HOME is redirected to a temp dir per test (the sandbox guard in _setup.mjs
+ * locks onto the REAL home recorded at process startup, so this is safe —
+ * same pattern as claude-tui-session.test.js / byok-credentials.test.js).
+ */
+describe('memory_read (readMemory) handler', () => {
+  let fileOps
+  let originalHome
+  let fakeHome
+  const responses = []
+  const mockSend = (_ws, msg) => responses.push(msg)
+  const mockWs = {}
+
+  before(() => {
+    fileOps = createFileOps(mockSend)
+    originalHome = process.env.HOME
+  })
+
+  after(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+  })
+
+  beforeEach(async () => {
+    fakeHome = await mkdtemp(join(tmpdir(), 'chroxy-memhome-'))
+    process.env.HOME = fakeHome
+    responses.length = 0
+  })
+
+  afterEach(async () => {
+    await rm(fakeHome, { recursive: true, force: true })
+  })
+
+  it('returns an error and no entries when there is no session cwd', async () => {
+    await fileOps.readMemory(mockWs, null)
+
+    assert.equal(responses.length, 1)
+    assert.equal(responses[0].type, 'memory_stack_result')
+    assert.ok(responses[0].error)
+    assert.deepEqual(responses[0].entries, [])
+    assert.equal(responses[0].memoryFile, null)
+  })
+
+  it('reports exists:false for global/project/local and the MEMORY.md descriptor when nothing is present', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-empty-'))
+
+    await fileOps.readMemory(mockWs, dir)
+
+    assert.equal(responses.length, 1)
+    const { entries, memoryFile, error } = responses[0]
+    assert.equal(error, null)
+    assert.equal(entries.length, 3)
+    assert.deepEqual(entries.map((e) => e.scope), ['global', 'project', 'local'])
+    for (const e of entries) {
+      assert.equal(e.exists, false)
+      assert.equal(e.content, null)
+      assert.equal(e.error, null)
+      assert.equal(e.skipped, false)
+      assert.equal(e.importedFrom, null)
+    }
+    assert.equal(memoryFile.exists, false)
+    assert.equal(memoryFile.content, null)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('reads global, project, and local CLAUDE.md in precedence order (global -> project -> local)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-stack-'))
+    await mkdir(join(fakeHome, '.claude'), { recursive: true })
+    await writeFile(join(fakeHome, '.claude', 'CLAUDE.md'), 'global notes', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'project notes', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.local.md'), 'local notes', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    // First three entries are the fixed root stack, in order.
+    assert.deepEqual(entries.slice(0, 3).map((e) => e.scope), ['global', 'project', 'local'])
+    assert.deepEqual(entries.slice(0, 3).map((e) => e.content), ['global notes', 'project notes', 'local notes'])
+    for (const e of entries.slice(0, 3)) {
+      assert.equal(e.exists, true)
+      assert.equal(e.truncated, false)
+      assert.equal(e.error, null)
+    }
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('resolves an @import relative to the IMPORTING file, not the session cwd', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-import-'))
+    await mkdir(join(dir, 'docs'), { recursive: true })
+    await writeFile(join(dir, 'docs', 'extra.md'), 'imported content', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'See @docs/extra.md for more.', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const projectEntry = entries.find((e) => e.scope === 'project')
+    assert.equal(projectEntry.content, 'See @docs/extra.md for more.')
+
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry, 'expected an import entry')
+    assert.equal(importEntry.content, 'imported content')
+    assert.equal(importEntry.exists, true)
+    assert.equal(importEntry.skipped, false)
+    assert.match(importEntry.path, /docs\/extra\.md$/)
+    assert.equal(importEntry.importedFrom, projectEntry.path)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('does not treat an @-reference inside a fenced code block or inline code span as an import', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-codefence-'))
+    await writeFile(
+      join(dir, 'CLAUDE.md'),
+      [
+        'Use `@literal-not-an-import` inline.',
+        '```',
+        '@also-not-an-import',
+        '```',
+      ].join('\n'),
+      'utf-8',
+    )
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntries = entries.filter((e) => e.scope === 'import')
+    assert.equal(importEntries.length, 0, 'no import should have been extracted from code spans/blocks')
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('handles a circular @import chain without an infinite loop', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-cycle-'))
+    await writeFile(join(dir, 'CLAUDE.md'), 'See @b.md', 'utf-8')
+    await writeFile(join(dir, 'b.md'), 'Back to @CLAUDE.md', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntries = entries.filter((e) => e.scope === 'import')
+    // b.md is pulled in once; CLAUDE.md is already visited (it's a root entry)
+    // so the cycle back to it must NOT produce a second entry.
+    assert.equal(importEntries.length, 1)
+    assert.equal(importEntries[0].content, 'Back to @CLAUDE.md')
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('rejects an @import that traverses outside the allowed roots (path-confinement guard)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-traversal-'))
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-mem-outside-'))
+    await writeFile(join(outsideDir, 'secret.md'), 'top secret contents', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), `Reference @${outsideDir}/secret.md here.`, 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry, 'expected the escaping import to still be reported (for provenance)')
+    assert.equal(importEntry.skipped, true)
+    assert.equal(importEntry.content, null, 'escaping import content must never be disclosed')
+    assert.equal(importEntry.exists, false, 'existence of an out-of-bounds path must not be disclosed either')
+    assert.match(importEntry.error, /outside|denied|restricted/i)
+
+    await rm(dir, { recursive: true, force: true })
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('rejects a relative-.. @import that escapes the session cwd', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'chroxy-mem-parent-'))
+    const dir = join(parent, 'project')
+    await mkdir(dir)
+    await writeFile(join(parent, 'sibling-secret.md'), 'sibling secret', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'Reference @../sibling-secret.md here.', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry)
+    assert.equal(importEntry.skipped, true)
+    assert.equal(importEntry.content, null)
+
+    await rm(parent, { recursive: true, force: true })
+  })
+
+  it('blocks reading through a CLAUDE.md symlink that escapes the workspace', async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-mem-symout-'))
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-symescape-'))
+    const outsideFile = join(outsideDir, 'target.md')
+    await writeFile(outsideFile, 'should not be readable', 'utf-8')
+    await symlink(outsideFile, join(dir, 'CLAUDE.md'))
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const projectEntry = entries.find((e) => e.scope === 'project')
+    assert.equal(projectEntry.content, null)
+    assert.equal(projectEntry.skipped, true)
+    assert.ok(projectEntry.error)
+
+    await rm(outsideDir, { recursive: true, force: true })
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('resolves the auto-generated MEMORY.md descriptor via the same per-cwd path encoding as transcripts', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-automemory-'))
+    const dirReal = await realpath(dir)
+    const encoded = encodeProjectPath(dirReal)
+    const memoryDir = join(fakeHome, '.claude', 'projects', encoded, 'memory')
+    await mkdir(memoryDir, { recursive: true })
+    await writeFile(join(memoryDir, 'MEMORY.md'), '# Project Memory\nsome learned fact', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { memoryFile } = responses[0]
+    assert.equal(memoryFile.exists, true)
+    assert.equal(memoryFile.content, '# Project Memory\nsome learned fact')
+    assert.match(memoryFile.path, /projects.*memory\/MEMORY\.md$/)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('echoes the requestId when the request supplied one', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-reqid-'))
+
+    await fileOps.readMemory(mockWs, dir, 'req-42')
+
+    assert.equal(responses[0].requestId, 'req-42')
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('omits requestId when the request did not supply one', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-noreqid-'))
+
+    await fileOps.readMemory(mockWs, dir)
+
+    assert.equal('requestId' in responses[0], false)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+})

--- a/packages/server/tests/memory-read.test.js
+++ b/packages/server/tests/memory-read.test.js
@@ -1,10 +1,11 @@
-import { describe, it, before, after, beforeEach, afterEach } from 'node:test'
+import { describe, it, before, after, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, rm, writeFile, symlink, realpath } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { createFileOps } from '../src/ws-file-ops/index.js'
 import { encodeProjectPath } from '../src/jsonl-reader.js'
+import { resolveSessionCwd } from '../src/ws-file-ops/common.js'
 
 /**
  * `readMemory` op (#6864, epic #6760) — server read of the effective merged
@@ -122,6 +123,53 @@ describe('memory_read (readMemory) handler', () => {
     assert.equal(importEntry.skipped, false)
     assert.match(importEntry.path, /docs\/extra\.md$/)
     assert.equal(importEntry.importedFrom, projectEntry.path)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('does not re-read an already-visited @import target on a duplicate reference (perf follow-up, #6971)', async () => {
+    // Two @import references to the SAME file must still only produce one
+    // entry (dedup already worked before the fix) — the assertion that
+    // matters here is that the underlying file is only actually opened
+    // ONCE, not once per reference. Requires a module instance whose
+    // `fs/promises` `open` binding resolves to the mock below, so this
+    // dynamically re-imports memory.js under a cache-busted specifier
+    // AFTER registering the mock — a plain top-of-file static import (as
+    // used by `fileOps` elsewhere in this suite) would already be bound to
+    // the real `open` before any per-test mock.module() call could apply.
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-dupimport-'))
+    await writeFile(join(dir, 'dup.md'), 'dup content', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'See @dup.md and again @dup.md here.', 'utf-8')
+
+    const realFsp = await import('fs/promises')
+    const dupOpens = []
+    const mockHandle = mock.module('fs/promises', {
+      namedExports: {
+        ...realFsp,
+        open: async (...args) => {
+          if (String(args[0]).endsWith('dup.md')) dupOpens.push(args[0])
+          return realFsp.open(...args)
+        },
+      },
+    })
+
+    try {
+      const { createMemoryOps } = await import(`../src/ws-file-ops/memory.js?dupimport=${Date.now()}`)
+      const cwdCache = new Map()
+      const freshResponses = []
+      const freshSend = (_ws, msg) => freshResponses.push(msg)
+      const freshMemory = createMemoryOps(freshSend, (cwd) => resolveSessionCwd(cwd, cwdCache, 60_000))
+
+      await freshMemory.readMemory(mockWs, dir)
+
+      const { entries } = freshResponses[0]
+      const importEntries = entries.filter((e) => e.scope === 'import')
+      assert.equal(importEntries.length, 1, 'duplicate @import must still collapse to one entry')
+      assert.equal(importEntries[0].content, 'dup content')
+      assert.equal(dupOpens.length, 1, 'dup.md must only be opened once despite two @import references to it')
+    } finally {
+      mockHandle.restore()
+    }
 
     await rm(dir, { recursive: true, force: true })
   })

--- a/packages/server/tests/memory-read.test.js
+++ b/packages/server/tests/memory-read.test.js
@@ -222,6 +222,114 @@ describe('memory_read (readMemory) handler', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
+  it('skips an @import of ~/.claude/.credentials.json (non-markdown target under an allowed root) without reading it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-cred-'))
+    const secret = 'SUPER-SECRET-OAUTH-TOKEN'
+    await mkdir(join(fakeHome, '.claude'), { recursive: true })
+    await writeFile(join(fakeHome, '.claude', '.credentials.json'), JSON.stringify({ token: secret }), 'utf-8')
+    // A malicious/untrusted project CLAUDE.md pointing at a sensitive non-.md
+    // file that DOES live under an allowed root (~/.claude).
+    await writeFile(join(dir, 'CLAUDE.md'), 'Steal @~/.claude/.credentials.json now.', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry, 'the credential @import must still be reported for provenance')
+    assert.equal(importEntry.skipped, true)
+    assert.equal(importEntry.content, null, 'credential file content must never be disclosed')
+    assert.equal(importEntry.exists, false)
+    // Belt-and-suspenders: the secret must appear NOWHERE in the response.
+    assert.equal(JSON.stringify(responses[0]).includes(secret), false, 'secret leaked into the response')
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('skips an @import of ~/.claude/settings.json (non-markdown target under an allowed root)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-settings-'))
+    await mkdir(join(fakeHome, '.claude'), { recursive: true })
+    await writeFile(join(fakeHome, '.claude', 'settings.json'), '{"private":"value"}', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'See @~/.claude/settings.json here.', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry)
+    assert.equal(importEntry.skipped, true)
+    assert.equal(importEntry.content, null)
+    assert.equal(JSON.stringify(responses[0]).includes('"private":"value"'), false)
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('still resolves and reads a legitimate in-bounds .md @import', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-mdok-'))
+    await writeFile(join(dir, 'notes.md'), 'legit markdown notes', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'See @./notes.md for details.', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry, 'a legitimate .md import must still resolve')
+    assert.equal(importEntry.skipped, false)
+    assert.equal(importEntry.exists, true)
+    assert.equal(importEntry.content, 'legit markdown notes')
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('also allows a .markdown extension @import (case-insensitive)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-markdown-'))
+    await writeFile(join(dir, 'extra.MARKDOWN'), 'markdown-ext content', 'utf-8')
+    await writeFile(join(dir, 'CLAUDE.md'), 'See @./extra.MARKDOWN here.', 'utf-8')
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const { entries } = responses[0]
+    const importEntry = entries.find((e) => e.scope === 'import')
+    assert.ok(importEntry, 'a .markdown import must resolve')
+    assert.equal(importEntry.skipped, false)
+    assert.equal(importEntry.content, 'markdown-ext content')
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('produces a non-markdown skip entry byte-identical to an out-of-bounds skip entry (no oracle)', async () => {
+    // One CLAUDE.md with BOTH an out-of-bounds .md import AND an in-bounds
+    // non-.md import → both skip entries share scope + importedFrom, so any
+    // divergence other than the echoed `path` would be a distinguishing oracle.
+    const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-oracle-'))
+    const outsideDir = await mkdtemp(join(tmpdir(), 'chroxy-mem-oracle-out-'))
+    await writeFile(join(outsideDir, 'secret.md'), 'out-of-bounds markdown', 'utf-8')
+    await mkdir(join(fakeHome, '.claude'), { recursive: true })
+    await writeFile(join(fakeHome, '.claude', '.credentials.json'), '{"t":"x"}', 'utf-8')
+    await writeFile(
+      join(dir, 'CLAUDE.md'),
+      `Out-of-bounds @${join(outsideDir, 'secret.md')} and non-md @~/.claude/.credentials.json.`,
+      'utf-8',
+    )
+
+    await fileOps.readMemory(mockWs, dir)
+
+    const imports = responses[0].entries.filter((e) => e.scope === 'import')
+    assert.equal(imports.length, 2, 'both imports must be reported')
+    const oob = imports.find((e) => e.path.includes('secret.md'))
+    const nonMd = imports.find((e) => e.path.includes('.credentials.json'))
+    assert.ok(oob && nonMd)
+    // Strip the echoed request path (legitimately differs per input); everything
+    // else — exists/content/truncated/skipped/error/scope/importedFrom — must match.
+    const { path: _p1, ...oobShape } = oob
+    const { path: _p2, ...nonMdShape } = nonMd
+    assert.deepEqual(nonMdShape, oobShape)
+    assert.equal(oob.skipped, true)
+    assert.equal(oob.content, null)
+
+    await rm(dir, { recursive: true, force: true })
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
   it('resolves the auto-generated MEMORY.md descriptor via the same per-cwd path encoding as transcripts', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'chroxy-mem-automemory-'))
     const dirReal = await realpath(dir)

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -253,6 +253,9 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
+  'memory_stack_result',                  // #6864 (epic #6760) reply to memory_read — server-only for v1,
+                                          //   no client handler yet; dashboard/mobile memory-panel consumers
+                                          //   are the sibling slices #6867/#6870
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Server + protocol half of #6864. Adds a read-only WS endpoint that resolves the effective CLAUDE.md memory hierarchy — the same stack Claude Code's own `/memory` view shows — with per-file provenance, plus the project's auto-generated MEMORY.md descriptor. Dashboard/mobile memory-panel UI consumers are the sibling slices #6867/#6870 — no UI here.

**Wire shape:** `{ type: 'memory_read', sessionId?, requestId? }` → `{ type: 'memory_stack_result', entries, memoryFile, error, requestId? }`

**Hierarchy / precedence** (verified against Claude Code's own docs — content is concatenated in filesystem-root-to-cwd order, so later = higher precedence):
- `global`  — `~/.claude/CLAUDE.md` (loaded first, lowest precedence)
- `project` — `<sessionCwd>/CLAUDE.md`
- `local`   — `<sessionCwd>/CLAUDE.local.md` (loaded last, highest precedence)

plus recursively-resolved `@import` references found inside those files (relative to the *importing file*, not cwd; code-fence/inline-code excluded from scanning; cycle-safe; capped at the same max depth of 4 hops Claude Code's own importer uses). Managed/enterprise policy memory and walking above the session cwd are explicitly out of scope for this slice.

**MEMORY.md descriptor:** resolved via the same per-cwd path encoding `resolveJsonlPath` already uses for transcript storage (`encodeProjectPath` in `jsonl-reader.js`). Verified empirically against a live `~/.claude/projects/` tree — it's keyed by the literal session cwd, not the git repository root (each worktree gets its own, separate memory directory).

**Security:** every location read is chosen **server-side** — the request carries no client-supplied path at all (mirrors `append_memory`'s #6861 design), so there's no client-controlled traversal surface for the three root files. The only variable input is `@import` text found inside those files' own content; each import target is confined to the session cwd + the user's `~/.claude` home via a symlink-safe containment check (deepest-existing-ancestor `realpath`, O_NOFOLLOW open) that runs **before** any `stat`/`open` — a path outside the allowed roots is reported `skipped: true` / `content: null` and is never opened or even existence-checked (no oracle leak).

## Coverage guards

`memory_stack_result` is a new server→client type with no client handler yet (by design — the UI is #6867/#6870), so it's registered as an explicit server-only-for-v1 asymmetry in all guards that require it:
- `packages/server/src/ws-server.js` — `Server -> Client:` doc-block roster (+ `Client -> Server:` line for `memory_read`)
- `packages/protocol/tests/handler-coverage.test.js` — `INTENTIONALLY_UNHANDLED`
- `packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts` — `UNHANDLED_BY_DESIGN`
- `packages/store-core/src/contract-fixtures/coverage-lint.test.ts` needed no change — the type isn't in either client's switch, so it's outside that lint's both-clients universe by construction.

Protocol dist rebuilt (`npm run build -w packages/protocol`) and staged.

## Test plan
- [x] New `packages/server/tests/memory-read.test.js` (12 tests): missing-file `exists:false` reporting, correct global→project→local precedence order, `@import` resolved relative to the importing file, code-fence/inline-code exclusion, circular-import safety, traversal-attempt rejection (absolute path outside roots, and relative `../..` escape) — content/existence never disclosed, symlink-escape defence on the root CLAUDE.md itself, MEMORY.md descriptor resolution, `requestId` echo/omission.
- [x] `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/memory-read.test.js tests/ws-handler-coverage.test.js tests/ws-schema-coverage.test.js` — 52/52 pass, exit 0, no force-exit.
- [x] Broader file-ops regression pass (`append-memory`, `ws-file-ops-*`, `jsonl-reader`) — 179/179 pass, exit 0.
- [x] All 5 server lints — rc=0.
- [x] `cd packages/protocol && npm test` — 377/377 pass (coverage guards included).
- [x] `cd packages/store-core && npm run typecheck && npx vitest run` — typecheck clean, 2088/2088 pass (both coverage-lint files included).


---

Closes #6971 — restrict `@import` targets to markdown memory files (`.md`/`.markdown`), blocking `@import ~/.claude/.credentials.json` (and any non-markdown file under an allowed root) from resolving in-bounds and surfacing to the client. Security-review finding #1.
