### PR TITLE
feat(server,dashboard): parse compact_boundary into a context-compacted marker

### DIFF
--- a/packages/dashboard/src/components/CompactionMarker.test.tsx
+++ b/packages/dashboard/src/components/CompactionMarker.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * CompactionMarker component tests (#6768).
+ *
+ * Covers the "Context compacted" marker rendered for a parsed
+ * compact_boundary SDK/CLI event — token delta, duration, and
+ * manual-vs-auto trigger, plus the graceful-degradation paths when the
+ * SDK/CLI itself omitted a sub-field.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { CompactionMarker } from './CompactionMarker'
+import type { CompactBoundaryMeta } from '../store/types'
+
+afterEach(cleanup)
+
+describe('CompactionMarker (#6768)', () => {
+  it('renders the token delta, duration, and trigger for a well-formed auto-compaction', () => {
+    const meta: CompactBoundaryMeta = {
+      trigger: 'auto',
+      preTokens: 128_000,
+      postTokens: 12_000,
+      durationMs: 2_500,
+    }
+    render(<CompactionMarker meta={meta} />)
+    const marker = screen.getByTestId('compaction-marker')
+    expect(marker).toHaveTextContent('Context compacted')
+    expect(marker).toHaveTextContent('128,000 → 12,000 tokens')
+    expect(marker).toHaveTextContent('2s')
+    expect(marker).toHaveTextContent('auto')
+  })
+
+  it('labels a manual /compact distinctly from auto-compaction', () => {
+    const meta: CompactBoundaryMeta = {
+      trigger: 'manual',
+      preTokens: 50_000,
+      postTokens: 8_000,
+      durationMs: 1_000,
+    }
+    render(<CompactionMarker meta={meta} />)
+    expect(screen.getByTestId('compaction-marker')).toHaveTextContent('manual')
+  })
+
+  it('omits the token clause when both counts are unknown, without crashing', () => {
+    const meta: CompactBoundaryMeta = { trigger: 'auto', preTokens: null, postTokens: null, durationMs: null }
+    render(<CompactionMarker meta={meta} />)
+    const marker = screen.getByTestId('compaction-marker')
+    expect(marker).toHaveTextContent('Context compacted')
+    expect(marker).not.toHaveTextContent('tokens')
+  })
+
+  it('renders "?" for a single missing token count rather than dropping the whole clause', () => {
+    const meta: CompactBoundaryMeta = { trigger: 'auto', preTokens: 90_000, postTokens: null, durationMs: null }
+    render(<CompactionMarker meta={meta} />)
+    expect(screen.getByTestId('compaction-marker')).toHaveTextContent('90,000 → ? tokens')
+  })
+})

--- a/packages/dashboard/src/components/CompactionMarker.test.tsx
+++ b/packages/dashboard/src/components/CompactionMarker.test.tsx
@@ -13,6 +13,13 @@ import type { CompactBoundaryMeta } from '../store/types'
 
 afterEach(cleanup)
 
+// Locale-agnostic helper — `toLocaleString()` output varies by runtime
+// locale (comma grouping in en-US, period in de-DE, space in fr-FR, none in
+// some locales); derive the expected grouped strings from the runtime's own
+// formatter instead of hard-coding en-US commas (mirrors
+// SidebarCostBadge.test.tsx's `localeNum` pattern).
+const localeNum = (n: number) => n.toLocaleString()
+
 describe('CompactionMarker (#6768)', () => {
   it('renders the token delta, duration, and trigger for a well-formed auto-compaction', () => {
     const meta: CompactBoundaryMeta = {
@@ -24,7 +31,7 @@ describe('CompactionMarker (#6768)', () => {
     render(<CompactionMarker meta={meta} />)
     const marker = screen.getByTestId('compaction-marker')
     expect(marker).toHaveTextContent('Context compacted')
-    expect(marker).toHaveTextContent('128,000 → 12,000 tokens')
+    expect(marker).toHaveTextContent(`${localeNum(128_000)} → ${localeNum(12_000)} tokens`)
     expect(marker).toHaveTextContent('2s')
     expect(marker).toHaveTextContent('auto')
   })
@@ -51,6 +58,6 @@ describe('CompactionMarker (#6768)', () => {
   it('renders "?" for a single missing token count rather than dropping the whole clause', () => {
     const meta: CompactBoundaryMeta = { trigger: 'auto', preTokens: 90_000, postTokens: null, durationMs: null }
     render(<CompactionMarker meta={meta} />)
-    expect(screen.getByTestId('compaction-marker')).toHaveTextContent('90,000 → ? tokens')
+    expect(screen.getByTestId('compaction-marker')).toHaveTextContent(`${localeNum(90_000)} → ? tokens`)
   })
 })

--- a/packages/dashboard/src/components/CompactionMarker.tsx
+++ b/packages/dashboard/src/components/CompactionMarker.tsx
@@ -1,0 +1,43 @@
+/**
+ * CompactionMarker — #6768
+ *
+ * Distinct "Context compacted" divider for a `compact_boundary` SDK/CLI
+ * system event (see store-core `ChatMessage.compactMetadata`), replacing
+ * the generic muted system bubble that used to show the literal string
+ * `compact_boundary` with no human-readable text and no token/trigger
+ * data. Rendered by `useMessageRenderer` for `type: 'system'` messages
+ * carrying `compactMetadata` — same wiring as `EvaluatorRewriteBanner`, so
+ * today it surfaces on the System tab (where every `type: 'system'`
+ * message renders; see `buildChatViewMessages.ts`'s chat-tab filter).
+ *
+ * Deliberately non-interactive and single-line — a compaction boundary is
+ * informational, not something the operator acts on.
+ */
+import type { CompactBoundaryMeta } from '../store/types'
+import { formatDurationTerse } from '@chroxy/store-core'
+
+export interface CompactionMarkerProps {
+  meta: CompactBoundaryMeta
+}
+
+function formatTokens(n: number | null): string {
+  return n == null ? '?' : n.toLocaleString()
+}
+
+export function CompactionMarker({ meta }: CompactionMarkerProps) {
+  const parts: string[] = ['Context compacted']
+  if (meta.preTokens != null || meta.postTokens != null) {
+    parts.push(`${formatTokens(meta.preTokens)} → ${formatTokens(meta.postTokens)} tokens`)
+  }
+  if (meta.durationMs != null) {
+    parts.push(formatDurationTerse(meta.durationMs))
+  }
+  parts.push(meta.trigger === 'manual' ? 'manual' : 'auto')
+
+  return (
+    <div className="compaction-marker" data-testid="compaction-marker">
+      <span className="compaction-marker-icon" aria-hidden="true">⊙</span>
+      <span className="compaction-marker-text">{parts.join(' · ')}</span>
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/CompactionMarker.tsx
+++ b/packages/dashboard/src/components/CompactionMarker.tsx
@@ -10,8 +10,11 @@
  * today it surfaces on the System tab (where every `type: 'system'`
  * message renders; see `buildChatViewMessages.ts`'s chat-tab filter).
  *
- * Deliberately non-interactive and single-line — a compaction boundary is
- * informational, not something the operator acts on.
+ * Deliberately non-interactive — a compaction boundary is informational, not
+ * something the operator acts on. The text clause wraps rather than
+ * truncating (`.compaction-marker-text` in components.css uses `pre-wrap` +
+ * `word-break: break-word`), so a long token-count/trigger combination stays
+ * fully readable.
  */
 import type { CompactBoundaryMeta } from '../store/types'
 import { formatDurationTerse } from '@chroxy/store-core'

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -10,6 +10,7 @@ import { ToolBubble } from '../components/ToolBubble'
 import { PermissionPrompt } from '../components/PermissionPrompt'
 import { QuestionPrompt } from '../components/QuestionPrompt'
 import { EvaluatorRewriteBanner } from '../components/EvaluatorPrompts'
+import { CompactionMarker } from '../components/CompactionMarker'
 import { StreamStallChip } from '../components/StreamStallChip'
 import { AskUserQuestionStallChip } from '../components/AskUserQuestionStallChip'
 import { ResumeUnknownChip } from '../components/ResumeUnknownChip'
@@ -245,6 +246,14 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
     // re-fire the transient wire event.
     if (storeMsg.type === 'system' && storeMsg.evaluator?.kind === 'rewrite') {
       return <EvaluatorRewriteBanner meta={storeMsg.evaluator} />
+    }
+
+    // #6768: distinct "Context compacted" marker for a parsed
+    // compact_boundary SDK/CLI event (sdk-session.js / cli-session.js),
+    // replacing the generic muted system bubble that used to show the
+    // literal string `compact_boundary`.
+    if (storeMsg.type === 'system' && storeMsg.compactMetadata) {
+      return <CompactionMarker meta={storeMsg.compactMetadata} />
     }
 
     // #4476: distinct chip for stream-stall errors (server PR #4475 emits

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -32,6 +32,9 @@ export type {
   // components can type-check banner props without reaching into
   // store-core.
   EvaluatorRewriteMeta,
+  // #6768: re-export the compaction-boundary marker metadata so the
+  // CompactionMarker component can type-check its props the same way.
+  CompactBoundaryMeta,
   SavedConnection,
   ContextUsage,
   // #6769: occupancy snapshot type (the context meter's only honest input).

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -10992,9 +10992,13 @@ button.sidebar-token-view-session-row:hover {
 .evaluator-rewrite-original { color: var(--text-secondary); font-style: italic; }
 .evaluator-rewrite-reasoning { color: var(--text-secondary); }
 
-/* #6768 — compaction-boundary marker: a single-line, non-interactive
-   divider (distinct from the muted system bubble) for a parsed
-   compact_boundary SDK/CLI event. */
+/* #6768 — compaction-boundary marker: a non-interactive divider (distinct
+   from the muted system bubble) for a parsed compact_boundary SDK/CLI
+   event. `.compaction-marker-text` below wraps (pre-wrap + break-word)
+   rather than truncating, so a long token-count/trigger clause stays fully
+   readable on the System tab instead of clipping — wrapping is fine here
+   since the marker is informational, not something the operator scans past
+   quickly. */
 .compaction-marker {
   display: flex;
   align-items: center;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -10992,6 +10992,34 @@ button.sidebar-token-view-session-row:hover {
 .evaluator-rewrite-original { color: var(--text-secondary); font-style: italic; }
 .evaluator-rewrite-reasoning { color: var(--text-secondary); }
 
+/* #6768 — compaction-boundary marker: a single-line, non-interactive
+   divider (distinct from the muted system bubble) for a parsed
+   compact_boundary SDK/CLI event. */
+.compaction-marker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 12px;
+  margin: 4px 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: var(--text-xs, 11px);
+}
+
+.compaction-marker-icon {
+  flex-shrink: 0;
+  color: var(--text-dim);
+}
+
+.compaction-marker-text {
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .evaluator-clarify-prompt {
   background: var(--bg-secondary);
   border: 1px solid var(--accent-purple, #a78bfa);

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -30,9 +30,11 @@ export declare const ServerStreamEndSchema: z.ZodObject<{
 /**
  * #6768 — structured payload for a `compact_boundary` system event (the
  * Agent SDK/CLI's compaction-boundary marker, emitted on both auto-compact
- * near the context limit and a manual `/compact`). Carried on
- * `ServerMessageSchema.compactMetadata` when `messageType === 'system'` and
- * `subtype === 'compact_boundary'` — see the sibling `subtype` field. Mirrors
+ * near the context limit and a manual `/compact`). By producer convention
+ * (not a schema-enforced constraint — see the sibling `subtype` field's
+ * comment on `ServerMessageSchema`), carried on
+ * `ServerMessageSchema.compactMetadata` alongside `messageType === 'system'`
+ * and `subtype === 'compact_boundary'`. Mirrors
  * the SDK's `SDKCompactBoundaryMessage.compact_metadata` shape (camelCased),
  * minus `preserved_segment` (an internal resume-relink detail with no
  * client-facing use).

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -27,6 +27,31 @@ export declare const ServerStreamEndSchema: z.ZodObject<{
     thinkingDurationMs: z.ZodOptional<z.ZodNumber>;
     thinkingTokens: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
+/**
+ * #6768 — structured payload for a `compact_boundary` system event (the
+ * Agent SDK/CLI's compaction-boundary marker, emitted on both auto-compact
+ * near the context limit and a manual `/compact`). Carried on
+ * `ServerMessageSchema.compactMetadata` when `messageType === 'system'` and
+ * `subtype === 'compact_boundary'` — see the sibling `subtype` field. Mirrors
+ * the SDK's `SDKCompactBoundaryMessage.compact_metadata` shape (camelCased),
+ * minus `preserved_segment` (an internal resume-relink detail with no
+ * client-facing use).
+ *
+ * `preTokens`/`postTokens`/`durationMs` are nullable rather than optional:
+ * the server always emits the field once it recognizes a compact_boundary
+ * event, using `null` for any sub-field the SDK/CLI itself omitted, so
+ * clients get a stable shape to pattern-match against instead of needing an
+ * `in` check per field.
+ */
+export declare const ServerCompactMetadataSchema: z.ZodObject<{
+    trigger: z.ZodEnum<{
+        auto: "auto";
+        manual: "manual";
+    }>;
+    preTokens: z.ZodNullable<z.ZodNumber>;
+    postTokens: z.ZodNullable<z.ZodNumber>;
+    durationMs: z.ZodNullable<z.ZodNumber>;
+}, z.core.$strip>;
 export declare const ServerMessageSchema: z.ZodObject<{
     type: z.ZodLiteral<"message">;
     messageType: z.ZodString;
@@ -35,6 +60,16 @@ export declare const ServerMessageSchema: z.ZodObject<{
     options: z.ZodOptional<z.ZodAny>;
     timestamp: z.ZodNumber;
     code: z.ZodOptional<z.ZodString>;
+    subtype: z.ZodOptional<z.ZodString>;
+    compactMetadata: z.ZodOptional<z.ZodObject<{
+        trigger: z.ZodEnum<{
+            auto: "auto";
+            manual: "manual";
+        }>;
+        preTokens: z.ZodNullable<z.ZodNumber>;
+        postTokens: z.ZodNullable<z.ZodNumber>;
+        durationMs: z.ZodNullable<z.ZodNumber>;
+    }, z.core.$strip>>;
     attemptedResumeId: z.ZodOptional<z.ZodString>;
     stdout: z.ZodOptional<z.ZodString>;
     stderr: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -77,9 +77,11 @@ export const ServerStreamEndSchema = z.object({
 /**
  * #6768 — structured payload for a `compact_boundary` system event (the
  * Agent SDK/CLI's compaction-boundary marker, emitted on both auto-compact
- * near the context limit and a manual `/compact`). Carried on
- * `ServerMessageSchema.compactMetadata` when `messageType === 'system'` and
- * `subtype === 'compact_boundary'` — see the sibling `subtype` field. Mirrors
+ * near the context limit and a manual `/compact`). By producer convention
+ * (not a schema-enforced constraint — see the sibling `subtype` field's
+ * comment on `ServerMessageSchema`), carried on
+ * `ServerMessageSchema.compactMetadata` alongside `messageType === 'system'`
+ * and `subtype === 'compact_boundary'`. Mirrors
  * the SDK's `SDKCompactBoundaryMessage.compact_metadata` shape (camelCased),
  * minus `preserved_segment` (an internal resume-relink detail with no
  * client-facing use).
@@ -104,12 +106,16 @@ export const ServerMessageSchema = z.object({
     options: z.any().optional(),
     timestamp: z.number(),
     code: z.string().max(64).optional(),
-    // #6768: only set on `messageType: 'system'` envelopes whose `subtype` is
-    // `'compact_boundary'` — the structured compaction marker (see
-    // ServerCompactMetadataSchema). Distinct from `code` (error-envelope
-    // classification) — `subtype` mirrors the SDK/CLI's own system-event
-    // subtype field so a future second structured system event doesn't have
-    // to hijack `code`'s error-only semantics.
+    // #6768: by producer convention (NOT enforced by this schema — like the
+    // `code`/`attemptedResumeId` pairing below, `subtype` and
+    // `compactMetadata` are both independently optional/unconstrained here;
+    // nothing in this object cross-validates `messageType`), the server only
+    // populates `subtype`/`compactMetadata` on `messageType: 'system'`
+    // envelopes whose `subtype` is `'compact_boundary'` — the structured
+    // compaction marker (see ServerCompactMetadataSchema). Distinct from
+    // `code` (error-envelope classification) — `subtype` mirrors the SDK/CLI's
+    // own system-event subtype field so a future second structured system
+    // event doesn't have to hijack `code`'s error-only semantics.
     subtype: z.string().max(64).optional(),
     compactMetadata: ServerCompactMetadataSchema.optional(),
     // #4947 / #5006: only set on `messageType: 'error'` envelopes whose

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -74,6 +74,28 @@ export const ServerStreamEndSchema = z.object({
     thinkingDurationMs: ThinkingDurationMsSchema,
     thinkingTokens: ThinkingTokensSchema,
 });
+/**
+ * #6768 — structured payload for a `compact_boundary` system event (the
+ * Agent SDK/CLI's compaction-boundary marker, emitted on both auto-compact
+ * near the context limit and a manual `/compact`). Carried on
+ * `ServerMessageSchema.compactMetadata` when `messageType === 'system'` and
+ * `subtype === 'compact_boundary'` — see the sibling `subtype` field. Mirrors
+ * the SDK's `SDKCompactBoundaryMessage.compact_metadata` shape (camelCased),
+ * minus `preserved_segment` (an internal resume-relink detail with no
+ * client-facing use).
+ *
+ * `preTokens`/`postTokens`/`durationMs` are nullable rather than optional:
+ * the server always emits the field once it recognizes a compact_boundary
+ * event, using `null` for any sub-field the SDK/CLI itself omitted, so
+ * clients get a stable shape to pattern-match against instead of needing an
+ * `in` check per field.
+ */
+export const ServerCompactMetadataSchema = z.object({
+    trigger: z.enum(['manual', 'auto']),
+    preTokens: z.number().nullable(),
+    postTokens: z.number().nullable(),
+    durationMs: z.number().nullable(),
+});
 export const ServerMessageSchema = z.object({
     type: z.literal('message'),
     messageType: z.string(),
@@ -82,6 +104,14 @@ export const ServerMessageSchema = z.object({
     options: z.any().optional(),
     timestamp: z.number(),
     code: z.string().max(64).optional(),
+    // #6768: only set on `messageType: 'system'` envelopes whose `subtype` is
+    // `'compact_boundary'` — the structured compaction marker (see
+    // ServerCompactMetadataSchema). Distinct from `code` (error-envelope
+    // classification) — `subtype` mirrors the SDK/CLI's own system-event
+    // subtype field so a future second structured system event doesn't have
+    // to hijack `code`'s error-only semantics.
+    subtype: z.string().max(64).optional(),
+    compactMetadata: ServerCompactMetadataSchema.optional(),
     // #4947 / #5006: only set on `messageType: 'error'` envelopes whose
     // `code` is one of the two resume-failure codes emitted by CliSession's
     // `_handleChildClose` resume-failure path:

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -85,6 +85,29 @@ export const ServerStreamEndSchema = z.object({
   thinkingTokens: ThinkingTokensSchema,
 })
 
+/**
+ * #6768 — structured payload for a `compact_boundary` system event (the
+ * Agent SDK/CLI's compaction-boundary marker, emitted on both auto-compact
+ * near the context limit and a manual `/compact`). Carried on
+ * `ServerMessageSchema.compactMetadata` when `messageType === 'system'` and
+ * `subtype === 'compact_boundary'` — see the sibling `subtype` field. Mirrors
+ * the SDK's `SDKCompactBoundaryMessage.compact_metadata` shape (camelCased),
+ * minus `preserved_segment` (an internal resume-relink detail with no
+ * client-facing use).
+ *
+ * `preTokens`/`postTokens`/`durationMs` are nullable rather than optional:
+ * the server always emits the field once it recognizes a compact_boundary
+ * event, using `null` for any sub-field the SDK/CLI itself omitted, so
+ * clients get a stable shape to pattern-match against instead of needing an
+ * `in` check per field.
+ */
+export const ServerCompactMetadataSchema = z.object({
+  trigger: z.enum(['manual', 'auto']),
+  preTokens: z.number().nullable(),
+  postTokens: z.number().nullable(),
+  durationMs: z.number().nullable(),
+})
+
 export const ServerMessageSchema = z.object({
   type: z.literal('message'),
   messageType: z.string(),
@@ -93,6 +116,14 @@ export const ServerMessageSchema = z.object({
   options: z.any().optional(),
   timestamp: z.number(),
   code: z.string().max(64).optional(),
+  // #6768: only set on `messageType: 'system'` envelopes whose `subtype` is
+  // `'compact_boundary'` — the structured compaction marker (see
+  // ServerCompactMetadataSchema). Distinct from `code` (error-envelope
+  // classification) — `subtype` mirrors the SDK/CLI's own system-event
+  // subtype field so a future second structured system event doesn't have
+  // to hijack `code`'s error-only semantics.
+  subtype: z.string().max(64).optional(),
+  compactMetadata: ServerCompactMetadataSchema.optional(),
   // #4947 / #5006: only set on `messageType: 'error'` envelopes whose
   // `code` is one of the two resume-failure codes emitted by CliSession's
   // `_handleChildClose` resume-failure path:

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -88,9 +88,11 @@ export const ServerStreamEndSchema = z.object({
 /**
  * #6768 — structured payload for a `compact_boundary` system event (the
  * Agent SDK/CLI's compaction-boundary marker, emitted on both auto-compact
- * near the context limit and a manual `/compact`). Carried on
- * `ServerMessageSchema.compactMetadata` when `messageType === 'system'` and
- * `subtype === 'compact_boundary'` — see the sibling `subtype` field. Mirrors
+ * near the context limit and a manual `/compact`). By producer convention
+ * (not a schema-enforced constraint — see the sibling `subtype` field's
+ * comment on `ServerMessageSchema`), carried on
+ * `ServerMessageSchema.compactMetadata` alongside `messageType === 'system'`
+ * and `subtype === 'compact_boundary'`. Mirrors
  * the SDK's `SDKCompactBoundaryMessage.compact_metadata` shape (camelCased),
  * minus `preserved_segment` (an internal resume-relink detail with no
  * client-facing use).
@@ -116,12 +118,16 @@ export const ServerMessageSchema = z.object({
   options: z.any().optional(),
   timestamp: z.number(),
   code: z.string().max(64).optional(),
-  // #6768: only set on `messageType: 'system'` envelopes whose `subtype` is
-  // `'compact_boundary'` — the structured compaction marker (see
-  // ServerCompactMetadataSchema). Distinct from `code` (error-envelope
-  // classification) — `subtype` mirrors the SDK/CLI's own system-event
-  // subtype field so a future second structured system event doesn't have
-  // to hijack `code`'s error-only semantics.
+  // #6768: by producer convention (NOT enforced by this schema — like the
+  // `code`/`attemptedResumeId` pairing below, `subtype` and
+  // `compactMetadata` are both independently optional/unconstrained here;
+  // nothing in this object cross-validates `messageType`), the server only
+  // populates `subtype`/`compactMetadata` on `messageType: 'system'`
+  // envelopes whose `subtype` is `'compact_boundary'` — the structured
+  // compaction marker (see ServerCompactMetadataSchema). Distinct from
+  // `code` (error-envelope classification) — `subtype` mirrors the SDK/CLI's
+  // own system-event subtype field so a future second structured system
+  // event doesn't have to hijack `code`'s error-only semantics.
   subtype: z.string().max(64).optional(),
   compactMetadata: ServerCompactMetadataSchema.optional(),
   // #4947 / #5006: only set on `messageType: 'error'` envelopes whose

--- a/packages/server/src/claude-stream-parser.js
+++ b/packages/server/src/claude-stream-parser.js
@@ -27,6 +27,16 @@
  *     the wire schema (`ServerToolStartSchema.toolUseId: z.string()`)
  *     holds even on the defensive fallback path when `content_block.id`
  *     is absent.
+ *
+ *   parseCompactBoundaryMeta(compactMetadata)
+ *     -> { trigger, preTokens, postTokens, durationMs }
+ *     #6768: camelCases a `compact_boundary` system event's
+ *     `compact_metadata` for the wire `message.compactMetadata` field.
+ *
+ *   formatCompactBoundaryContent(meta)
+ *     -> string
+ *     #6768: human-readable fallback `content` text for clients that
+ *     don't render `compactMetadata` as a dedicated marker.
  */
 
 import { parseMcpToolName } from './mcp-tools.js'
@@ -103,4 +113,50 @@ export function buildToolStartData(messageId, contentBlock) {
   const mcp = parseMcpToolName(contentBlock.name)
   if (mcp) data.serverName = mcp.serverName
   return data
+}
+
+/**
+ * #6768 — parse a `compact_boundary` system event's `compact_metadata` into
+ * the camelCase shape carried on the wire `message` event's
+ * `compactMetadata` field. Both providers receive the same
+ * `SDKCompactBoundaryMessage.compact_metadata` shape (the CLI's
+ * `--output-format stream-json` mirrors the SDK's message types — see
+ * `@anthropic-ai/claude-agent-sdk/sdk.d.ts` `SDKCompactBoundaryMessage`), so
+ * this is a pure function shared by both session drivers to keep field
+ * names / fallback values from drifting between them.
+ *
+ * Numeric fields fall back to `null` (not `undefined`) when missing or
+ * non-finite so the wire payload always has a stable shape; `trigger`
+ * defaults to `'auto'` for any value other than the literal `'manual'`
+ * (matches the SDK's `'manual' | 'auto'` union — an unrecognized value is
+ * more likely a spontaneous auto-compaction than a user-issued `/compact`).
+ *
+ * @param {{ trigger?: string, pre_tokens?: number, post_tokens?: number, duration_ms?: number }} [compactMetadata]
+ * @returns {{ trigger: 'manual'|'auto', preTokens: number|null, postTokens: number|null, durationMs: number|null }}
+ */
+export function parseCompactBoundaryMeta(compactMetadata) {
+  const meta = compactMetadata || {}
+  const asFiniteNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : null)
+  return {
+    trigger: meta.trigger === 'manual' ? 'manual' : 'auto',
+    preTokens: asFiniteNumber(meta.pre_tokens),
+    postTokens: asFiniteNumber(meta.post_tokens),
+    durationMs: asFiniteNumber(meta.duration_ms),
+  }
+}
+
+/**
+ * #6768 — human-readable fallback text for the `compact_boundary` system
+ * `message` envelope's `content` field, used by any client that doesn't yet
+ * understand `compactMetadata` (older dashboard/app builds render `content`
+ * as a plain muted system bubble).
+ *
+ * @param {{ trigger: 'manual'|'auto', preTokens: number|null, postTokens: number|null }} meta
+ * @returns {string}
+ */
+export function formatCompactBoundaryContent(meta) {
+  if (meta.preTokens != null && meta.postTokens != null) {
+    return `Context compacted (${meta.trigger}): ${meta.preTokens.toLocaleString()} → ${meta.postTokens.toLocaleString()} tokens`
+  }
+  return `Context compacted (${meta.trigger})`
 }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -13,7 +13,7 @@ import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-cata
 import { forceKill, killProcessTree } from './platform.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
-import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
+import { buildToolStartData, extractToolInputSemantics, parseCompactBoundaryMeta, formatCompactBoundaryContent } from './claude-stream-parser.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { prepareSpawn } from './utils/win-spawn.js'
@@ -1019,6 +1019,25 @@ export class CliSession extends BaseSession {
             }
             this.emit('mcp_servers', { servers: data.mcp_servers })
           }
+        } else if (data.subtype === 'compact_boundary') {
+          // #6768: `claude -p --output-format stream-json` mirrors the SDK's
+          // `SDKCompactBoundaryMessage` shape, so this is the CLI equivalent
+          // of SdkSession's compact_boundary branch — parse the structured
+          // `compact_metadata` into a distinct marker instead of the generic
+          // fallback below, which would forward the literal string
+          // `compact_boundary` with no human-readable text.
+          const meta = parseCompactBoundaryMeta(data.compact_metadata)
+          ;(this._log || log).info(
+            `Context compacted (${meta.trigger}): ${meta.preTokens ?? '?'} -> ${meta.postTokens ?? '?'} tokens` +
+              (meta.durationMs != null ? ` in ${meta.durationMs}ms` : '')
+          )
+          this.emit('message', {
+            type: 'system',
+            subtype: 'compact_boundary',
+            content: formatCompactBoundaryContent(meta),
+            compactMetadata: meta,
+            timestamp: Date.now(),
+          })
         } else {
           // Forward non-init system events (e.g. usage limits, sub-agent
           // notifications) as system messages to the client

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -58,6 +58,39 @@ function boundedNonNegInt(value, { max } = {}) {
 }
 
 /**
+ * #6973 (agent-review on #6970) — coerce+bound `compactMetadata`'s
+ * `preTokens`/`postTokens`/`durationMs` sub-fields before forwarding onto
+ * the wire, same defense-in-depth as `boundedNonNegInt` above (the #6941
+ * thinkingDurationMs pattern) applied field-by-field. Unlike
+ * thinkingDurationMs/thinkingTokens (fully optional on the wire), these
+ * three sub-fields are `.nullable()` — not `.optional()` — on
+ * `ServerCompactMetadataSchema`, so the shape always carries all three keys;
+ * an out-of-range/malformed value is coerced to `null` here rather than
+ * dropped, matching `parseCompactBoundaryMeta`'s own "null for
+ * missing/malformed" convention (claude-stream-parser.js) so a client always
+ * gets the stable shape to pattern-match against. `durationMs` is
+ * additionally bounded by `MAX_SANE_DURATION_MS` (the same clock-jump guard
+ * as `thinkingDurationMs`); `preTokens`/`postTokens` have no documented
+ * ceiling — legitimate context windows run into the millions of tokens — so
+ * only non-negative-integer coercion applies.
+ *
+ * @param {{trigger?: *, preTokens?: *, postTokens?: *, durationMs?: *}} meta
+ * @returns {{trigger: 'manual'|'auto', preTokens: number|null, postTokens: number|null, durationMs: number|null}}
+ */
+function boundedCompactMetadata(meta) {
+  const boundedOrNull = (value, opts) => {
+    const bounded = boundedNonNegInt(value, opts)
+    return bounded === undefined ? null : bounded
+  }
+  return {
+    trigger: meta.trigger === 'manual' ? 'manual' : 'auto',
+    preTokens: boundedOrNull(meta.preTokens),
+    postTokens: boundedOrNull(meta.postTokens),
+    durationMs: boundedOrNull(meta.durationMs, { max: MAX_SANE_DURATION_MS }),
+  }
+}
+
+/**
  * Declarative event-to-WS-message mapping.
  *
  * Each entry in EVENT_MAP is:
@@ -269,10 +302,13 @@ Object.assign(EVENT_MAP, {
     // Gated strictly on `messageType === 'system'` + the compact_boundary
     // subtype (mirrors the `code`/`attemptedResumeId` gating pattern in the
     // `error:` normalizer below) so a buggy producer can't sneak
-    // `compactMetadata` onto an unrelated message type.
+    // `compactMetadata` onto an unrelated message type. #6973: the numeric
+    // sub-fields are bounded (see `boundedCompactMetadata`) rather than
+    // forwarded raw, so a malformed/out-of-range value from the SDK/CLI
+    // can't reach the wire unbounded.
     if (data.type === 'system' && data.subtype === 'compact_boundary' && data.compactMetadata) {
       msg.subtype = data.subtype
-      msg.compactMetadata = data.compactMetadata
+      msg.compactMetadata = boundedCompactMetadata(data.compactMetadata)
     }
     return { messages: [{ msg }] }
   },

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -265,6 +265,15 @@ Object.assign(EVENT_MAP, {
       options: data.options,
       timestamp: data.timestamp,
     }
+    // #6768: forward the structured compaction-boundary marker fields.
+    // Gated strictly on `messageType === 'system'` + the compact_boundary
+    // subtype (mirrors the `code`/`attemptedResumeId` gating pattern in the
+    // `error:` normalizer below) so a buggy producer can't sneak
+    // `compactMetadata` onto an unrelated message type.
+    if (data.type === 'system' && data.subtype === 'compact_boundary' && data.compactMetadata) {
+      msg.subtype = data.subtype
+      msg.compactMetadata = data.compactMetadata
+    }
     return { messages: [{ msg }] }
   },
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -15,7 +15,7 @@ import {
   isRunInBackgroundInput,
   parseBashOutputShellId,
 } from './background-shells.js'
-import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
+import { buildToolStartData, extractToolInputSemantics, parseCompactBoundaryMeta, formatCompactBoundaryContent } from './claude-stream-parser.js'
 import { createLogger, loggerForSession } from './logger.js'
 import { PermissionManager, wirePermissionManager } from './permission-manager.js'
 import { formatBytes } from './utils/format-bytes.js'
@@ -891,6 +891,28 @@ export class SdkSession extends BaseSession {
               // cancel feels responsive instead of waiting for the turn-end
               // sweep. Idempotent (no-op if already finalized).
               this._finalizeAgentByToolUseId(msg.tool_use_id)
+              break
+            } else if (msg.subtype === 'compact_boundary') {
+              // #6768: the SDK compacted the conversation (auto-triggered
+              // near the context limit, or manually via `/compact`). Parse
+              // the structured `compact_metadata` into a distinct marker
+              // instead of letting it fall through to the generic
+              // "unknown system event" branch below, which would forward
+              // the literal string `compact_boundary` as `content` with no
+              // human-readable text and drop trigger/token/duration data
+              // entirely.
+              const meta = parseCompactBoundaryMeta(msg.compact_metadata)
+              ;(this._log || log).info(
+                `Context compacted (${meta.trigger}): ${meta.preTokens ?? '?'} -> ${meta.postTokens ?? '?'} tokens` +
+                  (meta.durationMs != null ? ` in ${meta.durationMs}ms` : '')
+              )
+              this.emit('message', {
+                type: 'system',
+                subtype: 'compact_boundary',
+                content: formatCompactBoundaryContent(meta),
+                compactMetadata: meta,
+                timestamp: Date.now(),
+              })
               break
             } else {
               // Forward non-init system events (e.g. /usage, /cost, other

--- a/packages/server/tests/compact-boundary-marker.test.js
+++ b/packages/server/tests/compact-boundary-marker.test.js
@@ -87,10 +87,17 @@ describe('#6768 compact_boundary parsing', () => {
     })
 
     it('formats a human-readable fallback with the token delta when both counts are known', () => {
+      // Locale-agnostic — `toLocaleString()` output varies by runtime locale
+      // (comma grouping in en-US, period in de-DE, space in fr-FR, none in
+      // some locales); derive the expected grouped strings from the
+      // runtime's own formatter instead of hard-coding en-US commas
+      // (mirrors dashboard/src/components/SidebarCostBadge.test.tsx's
+      // `localeNum` pattern).
+      const localeNum = (n) => n.toLocaleString()
       const text = formatCompactBoundaryContent({ trigger: 'auto', preTokens: 128_000, postTokens: 12_000 })
       assert.match(text, /Context compacted/)
-      assert.match(text, /128,000/)
-      assert.match(text, /12,000/)
+      assert.ok(text.includes(localeNum(128_000)), `expected "${text}" to include "${localeNum(128_000)}"`)
+      assert.ok(text.includes(localeNum(12_000)), `expected "${text}" to include "${localeNum(12_000)}"`)
     })
 
     it('falls back to a trigger-only string when token counts are unknown', () => {

--- a/packages/server/tests/compact-boundary-marker.test.js
+++ b/packages/server/tests/compact-boundary-marker.test.js
@@ -1,0 +1,255 @@
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { SdkSession } from '../src/sdk-session.js'
+import { CliSession } from '../src/cli-session.js'
+import { parseCompactBoundaryMeta, formatCompactBoundaryContent } from '../src/claude-stream-parser.js'
+
+/**
+ * Tests for #6768 — a `compact_boundary` system event from the Agent
+ * SDK/CLI must be parsed into a distinct structured "context compacted"
+ * marker (`type: 'system'`, `subtype: 'compact_boundary'`,
+ * `compactMetadata: { trigger, preTokens, postTokens, durationMs }`)
+ * rather than falling through to the generic "unknown system event"
+ * branch, which forwards the literal string `compact_boundary` as
+ * `content` with no structured fields.
+ *
+ * #4700: every session under test routes through a per-test temp
+ * `stateFilePath` so a future persistence regression can never
+ * contaminate `~/.chroxy/session-state.json` — mirrors sdk-session.test.js
+ * / cli-session.test.js.
+ */
+
+let _tmpDir
+function tmpStateFile() {
+  if (!_tmpDir) _tmpDir = mkdtempSync(join(tmpdir(), 'compact-boundary-test-'))
+  return join(_tmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_tmpDir) rmSync(_tmpDir, { recursive: true, force: true })
+})
+
+// A realistic SDKCompactBoundaryMessage.compact_metadata fixture, matching
+// @anthropic-ai/claude-agent-sdk/sdk.d.ts's SDKCompactBoundaryMessage shape
+// (snake_case on the wire from the SDK/CLI).
+function fixtureCompactMetadata(overrides = {}) {
+  return {
+    trigger: 'auto',
+    pre_tokens: 128_000,
+    post_tokens: 12_000,
+    duration_ms: 2_500,
+    ...overrides,
+  }
+}
+
+describe('#6768 compact_boundary parsing', () => {
+  describe('parseCompactBoundaryMeta / formatCompactBoundaryContent (shared parser)', () => {
+    it('camelCases a well-formed compact_metadata payload', () => {
+      const meta = parseCompactBoundaryMeta(fixtureCompactMetadata())
+      assert.deepEqual(meta, {
+        trigger: 'auto',
+        preTokens: 128_000,
+        postTokens: 12_000,
+        durationMs: 2_500,
+      })
+    })
+
+    it('preserves an explicit manual trigger', () => {
+      const meta = parseCompactBoundaryMeta(fixtureCompactMetadata({ trigger: 'manual' }))
+      assert.equal(meta.trigger, 'manual')
+    })
+
+    it('defaults an unrecognized/missing trigger to auto', () => {
+      assert.equal(parseCompactBoundaryMeta({}).trigger, 'auto')
+      assert.equal(parseCompactBoundaryMeta(undefined).trigger, 'auto')
+      assert.equal(parseCompactBoundaryMeta({ trigger: 'bogus' }).trigger, 'auto')
+    })
+
+    it('coerces missing/non-finite optional numeric fields to null, not undefined', () => {
+      const meta = parseCompactBoundaryMeta({ trigger: 'auto', pre_tokens: 50_000 })
+      assert.deepEqual(meta, {
+        trigger: 'auto',
+        preTokens: 50_000,
+        postTokens: null,
+        durationMs: null,
+      })
+
+      const malformed = parseCompactBoundaryMeta({
+        trigger: 'auto',
+        pre_tokens: 'a lot',
+        post_tokens: NaN,
+      })
+      assert.equal(malformed.preTokens, null)
+      assert.equal(malformed.postTokens, null)
+    })
+
+    it('formats a human-readable fallback with the token delta when both counts are known', () => {
+      const text = formatCompactBoundaryContent({ trigger: 'auto', preTokens: 128_000, postTokens: 12_000 })
+      assert.match(text, /Context compacted/)
+      assert.match(text, /128,000/)
+      assert.match(text, /12,000/)
+    })
+
+    it('falls back to a trigger-only string when token counts are unknown', () => {
+      const text = formatCompactBoundaryContent({ trigger: 'manual', preTokens: null, postTokens: null })
+      assert.match(text, /Context compacted \(manual\)/)
+    })
+  })
+
+  describe('SdkSession', () => {
+    function createSdkSession(opts = {}) {
+      return new SdkSession({ cwd: '/tmp', stateFilePath: tmpStateFile(), ...opts })
+    }
+
+    function fakeQueryWithCompactBoundary(compactMetadata) {
+      return (async function* () {
+        yield {
+          type: 'system',
+          subtype: 'compact_boundary',
+          compact_metadata: compactMetadata,
+          uuid: 'test-uuid-1',
+          session_id: 'sdk-compact-1',
+        }
+        yield {
+          type: 'result',
+          session_id: 'sdk-compact-1',
+          total_cost_usd: 0,
+          duration_ms: 0,
+          usage: {},
+        }
+      })()
+    }
+
+    it('emits a structured compact_boundary marker (not the generic system fallback)', async () => {
+      const s = createSdkSession()
+      s._processReady = true
+      s._callQuery = () => fakeQueryWithCompactBoundary(fixtureCompactMetadata())
+
+      const messages = []
+      s.on('message', (m) => messages.push(m))
+      await s.sendMessage('hello')
+      s.destroy()
+
+      const marker = messages.find((m) => m.type === 'system')
+      assert.ok(marker, 'expected a system message event')
+      assert.equal(marker.subtype, 'compact_boundary')
+      assert.deepEqual(marker.compactMetadata, {
+        trigger: 'auto',
+        preTokens: 128_000,
+        postTokens: 12_000,
+        durationMs: 2_500,
+      })
+      assert.equal(typeof marker.timestamp, 'number')
+
+      // Must NOT be the generic "unknown system event" fallback, which
+      // forwards the literal subtype string as content with no structured
+      // fields at all.
+      assert.notEqual(marker.content, 'compact_boundary')
+      assert.match(marker.content, /Context compacted/)
+    })
+
+    it('marks a manual /compact trigger distinctly from auto-compaction', async () => {
+      const s = createSdkSession()
+      s._processReady = true
+      s._callQuery = () => fakeQueryWithCompactBoundary(fixtureCompactMetadata({ trigger: 'manual' }))
+
+      const messages = []
+      s.on('message', (m) => messages.push(m))
+      await s.sendMessage('hello')
+      s.destroy()
+
+      const marker = messages.find((m) => m.subtype === 'compact_boundary')
+      assert.equal(marker.compactMetadata.trigger, 'manual')
+    })
+
+    it('coerces a missing duration/post_tokens to null instead of dropping the marker', async () => {
+      const s = createSdkSession()
+      s._processReady = true
+      s._callQuery = () => fakeQueryWithCompactBoundary({ trigger: 'auto', pre_tokens: 200_000 })
+
+      const messages = []
+      s.on('message', (m) => messages.push(m))
+      await s.sendMessage('hello')
+      s.destroy()
+
+      const marker = messages.find((m) => m.subtype === 'compact_boundary')
+      assert.ok(marker)
+      assert.deepEqual(marker.compactMetadata, {
+        trigger: 'auto',
+        preTokens: 200_000,
+        postTokens: null,
+        durationMs: null,
+      })
+    })
+
+    it('still routes an unrelated system subtype through the generic fallback', async () => {
+      const s = createSdkSession()
+      s._processReady = true
+      s._callQuery = () => (async function* () {
+        yield { type: 'system', subtype: 'some_other_event', message: 'hi there', session_id: 'sdk-other-1' }
+        yield { type: 'result', session_id: 'sdk-other-1', total_cost_usd: 0, duration_ms: 0, usage: {} }
+      })()
+
+      const messages = []
+      s.on('message', (m) => messages.push(m))
+      await s.sendMessage('hello')
+      s.destroy()
+
+      const marker = messages.find((m) => m.type === 'system')
+      assert.ok(marker)
+      assert.equal(marker.content, 'hi there')
+      assert.equal(marker.subtype, undefined)
+      assert.equal(marker.compactMetadata, undefined)
+    })
+  })
+
+  describe('CliSession', () => {
+    function createCliSession() {
+      const session = new CliSession({ cwd: '/tmp', stateFilePath: tmpStateFile() })
+      session._isBusy = true
+      return session
+    }
+
+    it('emits a structured compact_boundary marker (not the generic system fallback)', () => {
+      const session = createCliSession()
+      const messages = []
+      session.on('message', (m) => messages.push(m))
+
+      session._handleEvent({
+        type: 'system',
+        subtype: 'compact_boundary',
+        compact_metadata: fixtureCompactMetadata({ trigger: 'manual', post_tokens: 9_000, duration_ms: 1_800 }),
+        session_id: 'cli-compact-1',
+      })
+
+      assert.equal(messages.length, 1)
+      const [marker] = messages
+      assert.equal(marker.type, 'system')
+      assert.equal(marker.subtype, 'compact_boundary')
+      assert.deepEqual(marker.compactMetadata, {
+        trigger: 'manual',
+        preTokens: 128_000,
+        postTokens: 9_000,
+        durationMs: 1_800,
+      })
+      assert.notEqual(marker.content, 'compact_boundary')
+      assert.match(marker.content, /Context compacted/)
+    })
+
+    it('still routes an unrelated system subtype through the generic fallback', () => {
+      const session = createCliSession()
+      const messages = []
+      session.on('message', (m) => messages.push(m))
+
+      session._handleEvent({ type: 'system', subtype: 'some_other_event', message: 'usage info', session_id: 'cli-other-1' })
+
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].content, 'usage info')
+      assert.equal(messages[0].subtype, undefined)
+      assert.equal(messages[0].compactMetadata, undefined)
+    })
+  })
+})

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -159,6 +159,124 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- compact_boundary compactMetadata bounding (#6973) ----
+  //
+  // #6973 (agent-review on #6970): compactMetadata's preTokens/postTokens/
+  // durationMs were forwarded onto the wire raw — unlike the sibling
+  // thinkingDurationMs (#6941, above), nothing bounded them. These pin the
+  // same defense-in-depth via `boundedCompactMetadata`.
+  describe('compact_boundary compactMetadata bounding (#6973)', () => {
+    function compactBoundaryEvent(compactMetadata) {
+      return {
+        type: 'system',
+        subtype: 'compact_boundary',
+        content: 'Context compacted',
+        timestamp: Date.now(),
+        compactMetadata,
+      }
+    }
+
+    it('forwards a well-formed compactMetadata unchanged', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: 128_000, postTokens: 12_000, durationMs: 2_500 }),
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.deepEqual(msg.compactMetadata, {
+        trigger: 'auto',
+        preTokens: 128_000,
+        postTokens: 12_000,
+        durationMs: 2_500,
+      })
+    })
+
+    it('nulls a durationMs that exceeds MAX_SANE_DURATION_MS rather than forwarding or clamping it', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: MAX_SANE_DURATION_MS + 1 }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.compactMetadata
+      assert.equal(meta.durationMs, null, 'out-of-range duration must null, not clamp to the ceiling')
+      assert.equal(meta.preTokens, 1_000, 'an in-range sibling field still forwards')
+    })
+
+    it('accepts the exact MAX_SANE_DURATION_MS boundary', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: MAX_SANE_DURATION_MS }),
+        makeCtx(),
+      )
+      assert.equal(result.messages[0].msg.compactMetadata.durationMs, MAX_SANE_DURATION_MS)
+    })
+
+    it('nulls a negative durationMs', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: -50 }),
+        makeCtx(),
+      )
+      assert.equal(result.messages[0].msg.compactMetadata.durationMs, null)
+    })
+
+    it('nulls negative preTokens/postTokens', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'manual', preTokens: -5, postTokens: -1, durationMs: 1_000 }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.compactMetadata
+      assert.equal(meta.preTokens, null)
+      assert.equal(meta.postTokens, null)
+      assert.equal(meta.durationMs, 1_000)
+    })
+
+    it('does not cap preTokens/postTokens — only enforces non-negative int (context windows run into the millions)', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: 5_000_000, postTokens: 500_000, durationMs: 1_000 }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.compactMetadata
+      assert.equal(meta.preTokens, 5_000_000)
+      assert.equal(meta.postTokens, 500_000)
+    })
+
+    it('floors fractional preTokens/postTokens/durationMs rather than forwarding as-is', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: 1_000.9, postTokens: 500.2, durationMs: 2_500.7 }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.compactMetadata
+      assert.equal(meta.preTokens, 1_000)
+      assert.equal(meta.postTokens, 500)
+      assert.equal(meta.durationMs, 2_500)
+    })
+
+    it('nulls (not forwards) a non-finite/missing preTokens/postTokens/durationMs', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ trigger: 'auto', preTokens: Number.NaN, postTokens: null, durationMs: undefined }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.compactMetadata
+      assert.equal(meta.preTokens, null)
+      assert.equal(meta.postTokens, null)
+      assert.equal(meta.durationMs, null)
+    })
+
+    it('defaults an unrecognized/missing trigger to auto', () => {
+      const result = normalizer.normalize(
+        'message',
+        compactBoundaryEvent({ preTokens: 1_000, postTokens: 500, durationMs: 1_000 }),
+        makeCtx(),
+      )
+      assert.equal(result.messages[0].msg.compactMetadata.trigger, 'auto')
+    })
+  })
+
   // ---- EVENT_MAP: session_usage (#4072) ----
 
   describe('session_usage event', () => {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -6855,6 +6855,120 @@ describe('handleMessage', () => {
       expect(out.chatMessage.tool).toBeUndefined()
     }
   })
+
+  // #6768: server (sdk-session.js / cli-session.js) parses a `compact_boundary`
+  // SDK/CLI system event into a structured `message{messageType:'system',
+  // subtype:'compact_boundary', compactMetadata}` envelope (see
+  // event-normalizer.js `message:` normalizer). The store must preserve
+  // `compactMetadata` onto the ChatMessage so the dashboard/app can render a
+  // distinct "Context compacted" marker instead of the generic muted system
+  // bubble.
+  describe('compactMetadata preservation (#6768)', () => {
+    it('preserves a well-formed compactMetadata on a compact_boundary system message', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted (auto): 128,000 → 12,000 tokens',
+          compactMetadata: { trigger: 'auto', preTokens: 128_000, postTokens: 12_000, durationMs: 2_500 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.type).toBe('system')
+        // `subtype` is a routing/gating field read off the raw wire payload —
+        // ChatMessage has no `subtype` property, only the resulting
+        // `compactMetadata`.
+        expect(out.chatMessage.compactMetadata).toEqual({
+          trigger: 'auto',
+          preTokens: 128_000,
+          postTokens: 12_000,
+          durationMs: 2_500,
+        })
+      }
+    })
+
+    it('preserves null sub-fields (SDK/CLI omitted post_tokens/duration_ms) rather than dropping the marker', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted (manual)',
+          compactMetadata: { trigger: 'manual', preTokens: null, postTokens: null, durationMs: null },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata).toEqual({
+          trigger: 'manual',
+          preTokens: null,
+          postTokens: null,
+          durationMs: null,
+        })
+      }
+    })
+
+    it('leaves compactMetadata undefined when the wire field is missing (pre-#6768 server / non-compaction system message)', () => {
+      const out = handleMessage(
+        { messageType: 'system', content: 'MCP server foo connected', timestamp: 100 },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata).toBeUndefined()
+      }
+    })
+
+    it('drops a malformed compactMetadata (bad trigger) rather than passing junk through', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'bogus', preTokens: 1, postTokens: 2, durationMs: 3 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata).toBeUndefined()
+      }
+    })
+
+    it('does NOT attach compactMetadata to an unrelated message type even if present on the payload', () => {
+      // Gating hardening — mirrors the resume_unknown / attemptedResumeId gate
+      // above: a buggy producer shouldn't be able to sneak compactMetadata
+      // onto e.g. a response bubble.
+      const out = handleMessage(
+        {
+          messageType: 'response',
+          content: 'hello',
+          compactMetadata: { trigger: 'auto', preTokens: 1, postTokens: 2, durationMs: 3 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata).toBeUndefined()
+      }
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -2,6 +2,7 @@
  * Tests for shared stateless message handler functions.
  */
 import { describe, it, expect, vi } from 'vitest'
+import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 import {
   resolveSessionId,
   handleModelChanged,
@@ -6945,6 +6946,131 @@ describe('handleMessage', () => {
       expect(out.shouldDispatch).toBe(true)
       if (out.shouldDispatch) {
         expect(out.chatMessage.compactMetadata).toBeUndefined()
+      }
+    })
+
+    // #6973 (agent-review on #6970): preTokens/postTokens/durationMs were
+    // trusted verbatim off the wire — unlike the sibling thinkingDurationMs
+    // (#6941), nothing re-bounded them client-side. These pin the
+    // `parseFiniteNonNegIntField` defense-in-depth (second layer behind the
+    // server's own event-normalizer.js `boundedCompactMetadata`).
+    it('nulls a durationMs that exceeds MAX_SANE_DURATION_MS rather than passing it through or clamping it', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: MAX_SANE_DURATION_MS + 1 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata?.durationMs).toBeNull()
+        expect(out.chatMessage.compactMetadata?.preTokens).toBe(1_000)
+      }
+    })
+
+    it('accepts the exact MAX_SANE_DURATION_MS boundary', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: MAX_SANE_DURATION_MS },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata?.durationMs).toBe(MAX_SANE_DURATION_MS)
+      }
+    })
+
+    it('nulls a negative durationMs', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: -50 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata?.durationMs).toBeNull()
+      }
+    })
+
+    it('nulls negative preTokens/postTokens rather than passing them through', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'manual', preTokens: -5, postTokens: -1, durationMs: 1_000 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata?.preTokens).toBeNull()
+        expect(out.chatMessage.compactMetadata?.postTokens).toBeNull()
+        expect(out.chatMessage.compactMetadata?.durationMs).toBe(1_000)
+      }
+    })
+
+    it('does not cap large preTokens/postTokens — only enforces non-negative int (context windows run into the millions)', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'auto', preTokens: 5_000_000, postTokens: 500_000, durationMs: 1_000 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata?.preTokens).toBe(5_000_000)
+        expect(out.chatMessage.compactMetadata?.postTokens).toBe(500_000)
+      }
+    })
+
+    it('floors fractional preTokens/postTokens/durationMs and nulls non-finite values', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'compact_boundary',
+          content: 'Context compacted',
+          compactMetadata: { trigger: 'auto', preTokens: 1_000.9, postTokens: Number.NaN, durationMs: 2_500.7 },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.compactMetadata?.preTokens).toBe(1_000)
+        expect(out.chatMessage.compactMetadata?.postTokens).toBeNull()
+        expect(out.chatMessage.compactMetadata?.durationMs).toBe(2_500)
       }
     })
 

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -92,18 +92,29 @@ export type MessagePayload =
  * `postTokens` / `durationMs` coerce a non-finite-number value to `null`
  * (matches the server's own null-not-absent convention) rather than
  * dropping the whole object over one bad sub-field.
+ *
+ * #6973 (agent-review on #6970): reuses `parseFiniteNonNegIntField` — the
+ * same #6941 helper `handleThinkingStreamEnd` uses for `thinkingDurationMs`
+ * / `thinkingTokens` below — so an out-of-range/negative/non-integer
+ * sub-field is client-side re-bounded defense-in-depth, not trusted verbatim
+ * off the wire (a second layer behind the server's own
+ * `boundedCompactMetadata` in event-normalizer.js). `durationMs` gets the
+ * same `MAX_SANE_DURATION_MS` clock-jump ceiling as `thinkingDurationMs`;
+ * `preTokens`/`postTokens` have no documented ceiling (legitimate context
+ * windows run into the millions of tokens) so only non-negative-integer
+ * coercion applies. `parseFiniteNonNegIntField` returns `undefined` for an
+ * absent/invalid/out-of-range field — mapped to `null` here since this
+ * shape's fields are nullable, not optional.
  */
 function parseCompactMetadata(value: unknown): ChatMessage['compactMetadata'] {
   if (!value || typeof value !== 'object') return undefined
   const obj = value as Record<string, unknown>
   if (obj.trigger !== 'manual' && obj.trigger !== 'auto') return undefined
-  const asNullableNumber = (v: unknown): number | null =>
-    typeof v === 'number' && Number.isFinite(v) ? v : null
   return {
     trigger: obj.trigger,
-    preTokens: asNullableNumber(obj.preTokens),
-    postTokens: asNullableNumber(obj.postTokens),
-    durationMs: asNullableNumber(obj.durationMs),
+    preTokens: parseFiniteNonNegIntField(obj, 'preTokens') ?? null,
+    postTokens: parseFiniteNonNegIntField(obj, 'postTokens') ?? null,
+    durationMs: parseFiniteNonNegIntField(obj, 'durationMs', MAX_SANE_DURATION_MS) ?? null,
   }
 }
 

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -83,6 +83,30 @@ export type MessagePayload =
  * `addMessage` vs `updateSession` choice — this helper returns the built
  * ChatMessage rather than driving the dispatch itself.
  */
+/**
+ * #6768 — validate and coerce the wire `message.compactMetadata` object
+ * into the store's `CompactBoundaryMeta` shape. Defensive against a
+ * malformed/partial payload (a future server bug, or a hand-crafted replay
+ * blob) — returns `undefined` rather than attaching a half-formed object
+ * that would crash a renderer expecting the full shape. `preTokens` /
+ * `postTokens` / `durationMs` coerce a non-finite-number value to `null`
+ * (matches the server's own null-not-absent convention) rather than
+ * dropping the whole object over one bad sub-field.
+ */
+function parseCompactMetadata(value: unknown): ChatMessage['compactMetadata'] {
+  if (!value || typeof value !== 'object') return undefined
+  const obj = value as Record<string, unknown>
+  if (obj.trigger !== 'manual' && obj.trigger !== 'auto') return undefined
+  const asNullableNumber = (v: unknown): number | null =>
+    typeof v === 'number' && Number.isFinite(v) ? v : null
+  return {
+    trigger: obj.trigger,
+    preTokens: asNullableNumber(obj.preTokens),
+    postTokens: asNullableNumber(obj.postTokens),
+    durationMs: asNullableNumber(obj.durationMs),
+  }
+}
+
 export function handleMessage(
   msg: Record<string, unknown>,
   _activeSessionId: string | null,
@@ -178,6 +202,18 @@ export function handleMessage(
           const trimmed = msg.attemptedResumeId.trim()
           if (trimmed.length === 0) return {}
           return { attemptedResumeId: trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed }
+        })()
+      : {}),
+    // #6768: preserve the structured compaction-boundary marker so
+    // renderers can show a distinct "Context compacted" callout instead of
+    // the generic muted system bubble. Gated on `msgType === 'system'` +
+    // the compact_boundary subtype (mirrors the resume_unknown gate above)
+    // so a buggy producer can't sneak `compactMetadata` onto an unrelated
+    // message type.
+    ...(msgType === 'system' && msg.subtype === 'compact_boundary'
+      ? (() => {
+          const meta = parseCompactMetadata(msg.compactMetadata)
+          return meta ? { compactMetadata: meta } : {}
         })()
       : {}),
   }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -85,6 +85,9 @@ export type {
   ChatMessageQuestion,
   // #3188: auto-evaluator rewrite metadata attached to system ChatMessages
   EvaluatorRewriteMeta,
+  // #6768: structured compaction-boundary marker metadata attached to
+  // system ChatMessages parsed from a compact_boundary SDK/CLI event.
+  CompactBoundaryMeta,
   SavedConnection,
   ContextUsage,
   // #6769: occupancy snapshot type (the context meter's only honest input).

--- a/packages/store-core/src/types/chat.ts
+++ b/packages/store-core/src/types/chat.ts
@@ -41,6 +41,23 @@ export interface EvaluatorRewriteMeta {
 }
 
 /**
+ * #6768 — structured compaction-boundary marker payload, attached to a
+ * `type: 'system'` ChatMessage when the server parses a `compact_boundary`
+ * SDK/CLI event into a dedicated marker (instead of falling through to a
+ * generic muted system bubble showing the literal string `compact_boundary`).
+ * Mirrors `ServerCompactMetadataSchema` on the wire (`@chroxy/protocol`).
+ * `preTokens`/`postTokens`/`durationMs` are `null` — not absent — when the
+ * SDK/CLI itself omitted that sub-field, giving renderers a stable shape to
+ * pattern-match without per-field `in` checks.
+ */
+export interface CompactBoundaryMeta {
+  trigger: 'manual' | 'auto';
+  preTokens: number | null;
+  postTokens: number | null;
+  durationMs: number | null;
+}
+
+/**
  * #4604 Chunk B — one entry per question in a multi-question
  * AskUserQuestion form. `questions[0]` always mirrors the legacy
  * top-level `content` + `options` on the ChatMessage so single-question
@@ -228,6 +245,14 @@ export interface ChatMessage {
    * the banner from the cached metadata.
    */
   evaluator?: EvaluatorRewriteMeta;
+  /**
+   * #6768 — set on a `type: 'system'` ChatMessage when the server parsed a
+   * `compact_boundary` event into a distinct marker. Renderers show a
+   * "Context compacted" divider/callout with the token delta and
+   * manual-vs-auto trigger instead of the generic muted system bubble.
+   * Undefined for every other system message and for pre-#6768 servers.
+   */
+  compactMetadata?: CompactBoundaryMeta;
   /**
    * #5016 — Task subagent child progress, attached to the parent's
    * `tool_use` (Task) bubble. Each entry is one wire event the child


### PR DESCRIPTION
## Summary

- Both session drivers (`sdk-session.js`, `cli-session.js`) now special-case the SDK/CLI's `compact_boundary` system event instead of letting it fall through to the generic unknown-system-event branch, which forwarded the literal string `compact_boundary` as `content` with no structured data.
- New shared `parseCompactBoundaryMeta` / `formatCompactBoundaryContent` helpers in `claude-stream-parser.js` keep the two providers from drifting on field names or fallback values (both receive the same `compact_metadata` shape per `@anthropic-ai/claude-agent-sdk/sdk.d.ts`'s `SDKCompactBoundaryMessage`).
- Protocol: `ServerMessageSchema` gains optional `subtype` + `compactMetadata` (`trigger`/`preTokens`/`postTokens`/`durationMs`) fields, gated on `messageType: 'system'` + `subtype: 'compact_boundary'`. This extends the existing wire type rather than adding a new one, avoiding the three-guard new-type registration surface (roster/doc-block/type-coverage lints) — `dist/` rebuilt via `npm run build`.
- `event-normalizer.js` forwards `subtype`/`compactMetadata` on the generic `message:` normalizer, gated the same way as the existing `code`/`attemptedResumeId` fields on the `error:` normalizer.
- `store-core`: `ChatMessage` gains `compactMetadata` (`CompactBoundaryMeta`); `handleMessage` validates and preserves it defensively (drops a malformed payload rather than passing junk through).
- Dashboard: new `CompactionMarker` component renders a single-line "Context compacted · N → M tokens · Xs · trigger" divider in place of the muted system bubble, wired into `useMessageRenderer` alongside the existing evaluator-rewrite banner (same convention — both render on the System tab, since `buildChatViewMessages.ts` deliberately filters all `type: 'system'` messages out of the live chat tab).

## Needs your visual check

The marker render is visual and untested beyond component-level assertions — please eyeball it live:

- Where it renders: the dashboard **System tab** (not inline in the live chat transcript) — same placement as the existing evaluator-rewrite banner, since system messages are filtered out of the chat pane by design (`buildChatViewMessages.ts`). If you'd rather it show inline in the transcript at the point of compaction (closer to the issue's "visible summary boundary in the transcript" framing), that filter would need a follow-up change to let `compact_boundary` markers through specifically.
- Mobile app: **not implemented**. The app has no existing structured-system-message renderer to mirror (unlike the dashboard's evaluator banner), so the fix there is the improved `content` fallback text only (readable "Context compacted (auto): 128,000 → 12,000 tokens" instead of the literal string `compact_boundary`) — no dedicated marker component. Flagging as a possible follow-up if you want parity.
- Busy-indicator "Compacting…" state (the issue's third, optional acceptance criterion) is not implemented — out of scope for this pass.

## Test plan

- [x] Server: `packages/server/tests/compact-boundary-marker.test.js` — SdkSession + CliSession both parse a realistic `compact_boundary` fixture into the structured marker (trigger/preTokens/postTokens/durationMs), confirmed distinct from the generic fallback path; plus unit coverage of the shared parser helpers. Ran alongside `event-normalizer*.test.js`, `sdk-session.test.js`, `cli-session*.test.js` — 489 tests, exit 0, no `--test-force-exit`.
- [x] All 5 server lints (`lint-claude-family-explicit`, `lint-logger-session-scoping`, `lint-session-opt-forwarding`, `lint-tests-state-file-path`, `lint-ws-index-mutations`) — rc=0.
- [x] Protocol: `npm test` (full suite, 377 tests) — exit 0, both coverage-guard tests pass unaffected (optional-field extension, no new literal type). `npm run build` rebuilt `dist/` cleanly (2-file diff, no drift).
- [x] Store-core: `npm run typecheck` clean; `npx vitest run` (full suite, 2093 tests) — exit 0, includes 5 new `handleMessage` tests for `compactMetadata` preservation/gating/malformed-payload handling.
- [x] Dashboard: `npx tsc --noEmit` clean; `npx vitest run` (full suite, 4748 tests) — exit 0, includes new `CompactionMarker.test.tsx` + `useMessageRenderer.test.tsx` passing.
- [x] Mobile app: `npx tsc --noEmit` clean (confirms the store-core type addition doesn't break the app build).

Closes #6768

Closes #6973
