### PR TITLE
feat(server,dashboard): surface MCP prompt expansion in the transcript (honesty)

### DIFF
--- a/packages/dashboard/src/components/McpPromptExpansionMarker.test.tsx
+++ b/packages/dashboard/src/components/McpPromptExpansionMarker.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * McpPromptExpansionMarker component tests (#6845).
+ *
+ * Covers the honesty marker rendered for a server-controlled MCP-prompt
+ * expansion: collapsed by default, names the source server + prompt with an
+ * explicit "server-controlled" provenance label, and reveals the actual
+ * injected text (plus a truncation note) on expand.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { McpPromptExpansionMarker } from './McpPromptExpansionMarker'
+import type { McpPromptExpansionMeta } from '../store/types'
+
+afterEach(cleanup)
+
+const baseMeta: McpPromptExpansionMeta = {
+  server: 'stub',
+  prompt: 'greet',
+  text: 'SERVER-AUTHORED CONTENT the user never typed',
+  truncated: false,
+}
+
+describe('McpPromptExpansionMarker (#6845)', () => {
+  it('names the source server + prompt and labels the content server-controlled', () => {
+    render(<McpPromptExpansionMarker meta={baseMeta} />)
+    const marker = screen.getByTestId('mcp-prompt-expansion-marker')
+    expect(marker).toHaveTextContent('Expanded from MCP prompt')
+    expect(screen.getByTestId('mcp-prompt-expansion-source')).toHaveTextContent('stub:greet')
+    expect(marker).toHaveTextContent('server-controlled')
+  })
+
+  it('is collapsed by default (injected text hidden until expanded)', () => {
+    render(<McpPromptExpansionMarker meta={baseMeta} />)
+    expect(screen.queryByTestId('mcp-prompt-expansion-text')).toBeNull()
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('reveals the actual server-controlled injected text on expand', () => {
+    render(<McpPromptExpansionMarker meta={baseMeta} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByTestId('mcp-prompt-expansion-text')).toHaveTextContent(
+      'SERVER-AUTHORED CONTENT the user never typed',
+    )
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('shows a truncation note only when the expansion was capped for display', () => {
+    render(<McpPromptExpansionMarker meta={{ ...baseMeta, truncated: true }} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByTestId('mcp-prompt-expansion-truncated')).toHaveTextContent(
+      'the full expansion was sent to the model',
+    )
+  })
+
+  it('omits the truncation note when not truncated', () => {
+    render(<McpPromptExpansionMarker meta={baseMeta} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByTestId('mcp-prompt-expansion-truncated')).toBeNull()
+  })
+})

--- a/packages/dashboard/src/components/McpPromptExpansionMarker.test.tsx
+++ b/packages/dashboard/src/components/McpPromptExpansionMarker.test.tsx
@@ -57,4 +57,42 @@ describe('McpPromptExpansionMarker (#6845)', () => {
     fireEvent.click(screen.getByRole('button'))
     expect(screen.queryByTestId('mcp-prompt-expansion-truncated')).toBeNull()
   })
+
+  // Honesty fix (post-#6845-review, thread 4): the server can ALSO prepend
+  // skills text (`BaseSession._buildPrependPrompt`) ahead of the MCP-prompt
+  // expansion, so the expansion is only PART of the turn, not the whole thing.
+  // The old label ("Sent to the model as your turn") overstated that.
+  it('labels the injected text as part of the turn, not the whole turn', () => {
+    render(<McpPromptExpansionMarker meta={baseMeta} />)
+    fireEvent.click(screen.getByRole('button'))
+    const details = screen.getByTestId('mcp-prompt-expansion-details')
+    expect(details).toHaveTextContent('Sent to the model as part of your turn')
+    expect(details).not.toHaveTextContent('Sent to the model as your turn')
+  })
+
+  // Fragile-id fix (post-#6845-review, thread 3): server/prompt names are
+  // server-controlled and can contain arbitrary characters. A raw
+  // interpolation into the HTML `id` produces an id that breaks
+  // `aria-controls` linkage / test selectors for anything but plain alnum
+  // names. The id must be sanitized to `[A-Za-z0-9_-]` while the
+  // aria-controls linkage between the toggle button and the details panel
+  // stays intact.
+  it('sanitizes punctuation/whitespace in server/prompt names into a valid, stable HTML id', () => {
+    const punctuatedMeta: McpPromptExpansionMeta = {
+      ...baseMeta,
+      server: 'my server/v2.0 (prod)',
+      prompt: 'greet user!!',
+    }
+    render(<McpPromptExpansionMarker meta={punctuatedMeta} />)
+    const toggle = screen.getByRole('button')
+    const ariaControlsId = toggle.getAttribute('aria-controls')
+    expect(ariaControlsId).toBeTruthy()
+    expect(ariaControlsId).toMatch(/^[A-Za-z0-9_-]+$/)
+
+    fireEvent.click(toggle)
+    const details = screen.getByTestId('mcp-prompt-expansion-details')
+    // The button's aria-controls must still resolve to the rendered details
+    // panel's actual id — sanitizing must not break the linkage.
+    expect(details.id).toBe(ariaControlsId)
+  })
 })

--- a/packages/dashboard/src/components/McpPromptExpansionMarker.tsx
+++ b/packages/dashboard/src/components/McpPromptExpansionMarker.tsx
@@ -24,6 +24,16 @@
 import { useState } from 'react'
 import type { McpPromptExpansionMeta } from '../store/types'
 
+// Post-#6845-review fix (thread 3): `meta.server`/`meta.prompt` are
+// server-controlled MCP provenance names — they can contain arbitrary
+// characters (spaces, slashes, punctuation) that produce an invalid or
+// fragile HTML `id` (breaking `aria-controls` linkage and any test selector
+// keyed on it). Slugify to the characters HTML ids are safe with; the id
+// stays stable and readable for the common alnum-only case.
+function slugifyForId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, '-')
+}
+
 export interface McpPromptExpansionMarkerProps {
   meta: McpPromptExpansionMeta
 }
@@ -31,7 +41,7 @@ export interface McpPromptExpansionMarkerProps {
 export function McpPromptExpansionMarker({ meta }: McpPromptExpansionMarkerProps) {
   const [expanded, setExpanded] = useState(false)
   const source = `${meta.server}:${meta.prompt}`
-  const detailsId = `mcp-prompt-expansion-${meta.server}-${meta.prompt}-details`
+  const detailsId = `mcp-prompt-expansion-${slugifyForId(meta.server)}-${slugifyForId(meta.prompt)}-details`
 
   return (
     <div className="mcp-prompt-expansion-marker" data-testid="mcp-prompt-expansion-marker">
@@ -59,7 +69,7 @@ export function McpPromptExpansionMarker({ meta }: McpPromptExpansionMarkerProps
       {expanded && (
         <div id={detailsId} className="mcp-prompt-expansion-details" data-testid="mcp-prompt-expansion-details">
           <div className="mcp-prompt-expansion-label">
-            Sent to the model as your turn
+            Sent to the model as part of your turn
           </div>
           <div className="mcp-prompt-expansion-text" data-testid="mcp-prompt-expansion-text">
             {meta.text}

--- a/packages/dashboard/src/components/McpPromptExpansionMarker.tsx
+++ b/packages/dashboard/src/components/McpPromptExpansionMarker.tsx
@@ -1,0 +1,76 @@
+/**
+ * McpPromptExpansionMarker — #6845
+ *
+ * Honesty surface for a server-controlled MCP-prompt expansion. When the user
+ * sends `/mcp__<server>__<prompt>`, the server (byok-session.js) expands it via
+ * the MCP server's `prompts/get` and injects the returned messages as the user
+ * turn to the model — but the raw slash command is all the transcript otherwise
+ * shows. This collapsible marker surfaces the ACTUAL injected text with explicit
+ * provenance so the transcript is honest about what the model received.
+ *
+ * The expansion is SERVER-CONTROLLED (authored by the MCP server, not typed by
+ * the user), so the marker is labeled as such rather than rendered like a user
+ * message — a trusted-but-verbose, or later-compromised, MCP server could inject
+ * surprising content, and the operator should be able to audit it. Rendered by
+ * `useMessageRenderer` for `type: 'system'` messages carrying
+ * `mcpPromptExpansion` — same wiring as `CompactionMarker` /
+ * `EvaluatorRewriteBanner`, so today it surfaces on the System tab.
+ *
+ * Collapsed by default (the injected text can be long): the header names the
+ * source server + prompt; expanding reveals the (bounded) server-controlled
+ * text, with a truncation note when the server capped a larger expansion for
+ * display (the FULL text still reached the model).
+ */
+import { useState } from 'react'
+import type { McpPromptExpansionMeta } from '../store/types'
+
+export interface McpPromptExpansionMarkerProps {
+  meta: McpPromptExpansionMeta
+}
+
+export function McpPromptExpansionMarker({ meta }: McpPromptExpansionMarkerProps) {
+  const [expanded, setExpanded] = useState(false)
+  const source = `${meta.server}:${meta.prompt}`
+  const detailsId = `mcp-prompt-expansion-${meta.server}-${meta.prompt}-details`
+
+  return (
+    <div className="mcp-prompt-expansion-marker" data-testid="mcp-prompt-expansion-marker">
+      <button
+        type="button"
+        className="mcp-prompt-expansion-toggle"
+        aria-expanded={expanded}
+        aria-controls={detailsId}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span className="mcp-prompt-expansion-icon" aria-hidden="true">⇲</span>
+        <span className="mcp-prompt-expansion-summary">
+          Expanded from MCP prompt{' '}
+          <code className="mcp-prompt-expansion-source" data-testid="mcp-prompt-expansion-source">
+            {source}
+          </code>
+        </span>
+        <span className="mcp-prompt-expansion-badge" title="This text was authored by the MCP server, not typed by you">
+          server-controlled
+        </span>
+        <span className="mcp-prompt-expansion-chevron" aria-hidden="true">
+          {expanded ? '▾' : '▸'}
+        </span>
+      </button>
+      {expanded && (
+        <div id={detailsId} className="mcp-prompt-expansion-details" data-testid="mcp-prompt-expansion-details">
+          <div className="mcp-prompt-expansion-label">
+            Sent to the model as your turn
+          </div>
+          <div className="mcp-prompt-expansion-text" data-testid="mcp-prompt-expansion-text">
+            {meta.text}
+          </div>
+          {meta.truncated && (
+            <div className="mcp-prompt-expansion-truncated" data-testid="mcp-prompt-expansion-truncated">
+              Display truncated — the full expansion was sent to the model.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/hooks/useMessageRenderer.tsx
+++ b/packages/dashboard/src/hooks/useMessageRenderer.tsx
@@ -11,6 +11,7 @@ import { PermissionPrompt } from '../components/PermissionPrompt'
 import { QuestionPrompt } from '../components/QuestionPrompt'
 import { EvaluatorRewriteBanner } from '../components/EvaluatorPrompts'
 import { CompactionMarker } from '../components/CompactionMarker'
+import { McpPromptExpansionMarker } from '../components/McpPromptExpansionMarker'
 import { StreamStallChip } from '../components/StreamStallChip'
 import { AskUserQuestionStallChip } from '../components/AskUserQuestionStallChip'
 import { ResumeUnknownChip } from '../components/ResumeUnknownChip'
@@ -254,6 +255,15 @@ export function useMessageRenderer(args: UseMessageRendererArgs): (msg: ChatView
     // literal string `compact_boundary`.
     if (storeMsg.type === 'system' && storeMsg.compactMetadata) {
       return <CompactionMarker meta={storeMsg.compactMetadata} />
+    }
+
+    // #6845: honesty marker for a server-controlled MCP-prompt expansion
+    // (byok-session.js). Surfaces the actual text the MCP server's `prompts/get`
+    // injected as the user turn — with explicit provenance — so the transcript
+    // is honest about what the model received instead of only the raw
+    // `/mcp__…` command the user typed.
+    if (storeMsg.type === 'system' && storeMsg.mcpPromptExpansion) {
+      return <McpPromptExpansionMarker meta={storeMsg.mcpPromptExpansion} />
     }
 
     // #4476: distinct chip for stream-stall errors (server PR #4475 emits

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -35,6 +35,9 @@ export type {
   // #6768: re-export the compaction-boundary marker metadata so the
   // CompactionMarker component can type-check its props the same way.
   CompactBoundaryMeta,
+  // #6845: re-export the MCP-prompt expansion marker metadata so the
+  // McpPromptExpansionMarker component can type-check its props the same way.
+  McpPromptExpansionMeta,
   SavedConnection,
   ContextUsage,
   // #6769: occupancy snapshot type (the context meter's only honest input).

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -11024,6 +11024,106 @@ button.sidebar-token-view-session-row:hover {
   word-break: break-word;
 }
 
+/* #6845 — MCP-prompt expansion marker: a collapsible honesty surface for a
+   server-controlled `/mcp__server__prompt` expansion injected as the user turn.
+   Warm-tinted (distinct from the blue evaluator-rewrite banner) to flag that
+   the content is SERVER-CONTROLLED, not user-typed — the operator should be
+   able to audit what the MCP server actually injected. Collapsed by default;
+   the injected text can be long. */
+.mcp-prompt-expansion-marker {
+  display: block;
+  width: 100%;
+  background: var(--accent-amber-subtle, rgba(251, 191, 36, 0.08));
+  border: 1px solid var(--accent-amber-subtle, rgba(251, 191, 36, 0.25));
+  border-radius: 8px;
+  padding: 0;
+  margin: 4px 0;
+  overflow: hidden;
+}
+
+.mcp-prompt-expansion-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: 0;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.mcp-prompt-expansion-toggle:hover {
+  background: var(--accent-amber-subtle, rgba(251, 191, 36, 0.15));
+}
+
+.mcp-prompt-expansion-icon {
+  display: inline-flex;
+  color: var(--accent-amber, #fbbf24);
+  flex-shrink: 0;
+}
+
+.mcp-prompt-expansion-summary {
+  flex: 1;
+  font-weight: 500;
+}
+
+.mcp-prompt-expansion-source {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.9em;
+  color: var(--text-secondary);
+}
+
+.mcp-prompt-expansion-badge {
+  flex-shrink: 0;
+  font-size: var(--text-xs, 11px);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--accent-amber, #fbbf24);
+  border: 1px solid var(--accent-amber-subtle, rgba(251, 191, 36, 0.35));
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.mcp-prompt-expansion-chevron {
+  color: var(--text-dim);
+  font-size: 0.9em;
+  flex-shrink: 0;
+}
+
+.mcp-prompt-expansion-details {
+  padding: 8px 12px 12px 12px;
+  border-top: 1px solid var(--border-primary, rgba(255, 255, 255, 0.08));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mcp-prompt-expansion-label {
+  font-size: var(--text-xs, 11px);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.mcp-prompt-expansion-text {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.mcp-prompt-expansion-truncated {
+  font-size: var(--text-xs, 11px);
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
 .evaluator-clarify-prompt {
   background: var(--bg-secondary);
   border: 1px solid var(--accent-purple, #a78bfa);

--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -54,6 +54,30 @@ export declare const ServerCompactMetadataSchema: z.ZodObject<{
     postTokens: z.ZodNullable<z.ZodNumber>;
     durationMs: z.ZodNullable<z.ZodNumber>;
 }, z.core.$strip>;
+/**
+ * #6845 — structured payload for an `mcp_prompt_expansion` system event. When a
+ * user sends `/mcp__<server>__<prompt>`, the server intercepts it, calls the
+ * MCP server's `prompts/get`, and injects the returned SERVER-CONTROLLED
+ * messages as the user turn to the model — but the transcript only shows the
+ * raw slash command the user typed. This marker surfaces what was ACTUALLY sent
+ * so the transcript is honest, with explicit provenance (`server`/`prompt`) so
+ * the content is never mistaken for user-typed text (a trusted-but-verbose, or
+ * later-compromised, MCP server could inject surprising content).
+ *
+ * Carried on `ServerMessageSchema.mcpPromptExpansion` alongside
+ * `messageType === 'system'` and `subtype === 'mcp_prompt_expansion'` — the
+ * same optional-field-on-the-existing-`message`-envelope convention as
+ * `compactMetadata` (no new wire message type). `text` is the (bounded) injected
+ * content; `truncated` flags that the producer capped a larger expansion for
+ * display (the FULL text still reached the model). Name fields are length-capped
+ * and `text` bounded so a malformed producer can't flood the wire.
+ */
+export declare const ServerMcpPromptExpansionSchema: z.ZodObject<{
+    server: z.ZodString;
+    prompt: z.ZodString;
+    text: z.ZodString;
+    truncated: z.ZodBoolean;
+}, z.core.$strip>;
 export declare const ServerMessageSchema: z.ZodObject<{
     type: z.ZodLiteral<"message">;
     messageType: z.ZodString;
@@ -71,6 +95,12 @@ export declare const ServerMessageSchema: z.ZodObject<{
         preTokens: z.ZodNullable<z.ZodNumber>;
         postTokens: z.ZodNullable<z.ZodNumber>;
         durationMs: z.ZodNullable<z.ZodNumber>;
+    }, z.core.$strip>>;
+    mcpPromptExpansion: z.ZodOptional<z.ZodObject<{
+        server: z.ZodString;
+        prompt: z.ZodString;
+        text: z.ZodString;
+        truncated: z.ZodBoolean;
     }, z.core.$strip>>;
     attemptedResumeId: z.ZodOptional<z.ZodString>;
     stdout: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -98,6 +98,30 @@ export const ServerCompactMetadataSchema = z.object({
     postTokens: z.number().nullable(),
     durationMs: z.number().nullable(),
 });
+/**
+ * #6845 — structured payload for an `mcp_prompt_expansion` system event. When a
+ * user sends `/mcp__<server>__<prompt>`, the server intercepts it, calls the
+ * MCP server's `prompts/get`, and injects the returned SERVER-CONTROLLED
+ * messages as the user turn to the model — but the transcript only shows the
+ * raw slash command the user typed. This marker surfaces what was ACTUALLY sent
+ * so the transcript is honest, with explicit provenance (`server`/`prompt`) so
+ * the content is never mistaken for user-typed text (a trusted-but-verbose, or
+ * later-compromised, MCP server could inject surprising content).
+ *
+ * Carried on `ServerMessageSchema.mcpPromptExpansion` alongside
+ * `messageType === 'system'` and `subtype === 'mcp_prompt_expansion'` — the
+ * same optional-field-on-the-existing-`message`-envelope convention as
+ * `compactMetadata` (no new wire message type). `text` is the (bounded) injected
+ * content; `truncated` flags that the producer capped a larger expansion for
+ * display (the FULL text still reached the model). Name fields are length-capped
+ * and `text` bounded so a malformed producer can't flood the wire.
+ */
+export const ServerMcpPromptExpansionSchema = z.object({
+    server: z.string().max(256),
+    prompt: z.string().max(256),
+    text: z.string().max(8192),
+    truncated: z.boolean(),
+});
 export const ServerMessageSchema = z.object({
     type: z.literal('message'),
     messageType: z.string(),
@@ -118,6 +142,13 @@ export const ServerMessageSchema = z.object({
     // event doesn't have to hijack `code`'s error-only semantics.
     subtype: z.string().max(64).optional(),
     compactMetadata: ServerCompactMetadataSchema.optional(),
+    // #6845: by the same producer convention as `subtype`/`compactMetadata`
+    // above, the server only populates `mcpPromptExpansion` on
+    // `messageType: 'system'` envelopes whose `subtype` is
+    // `'mcp_prompt_expansion'` — the honesty marker for a server-controlled
+    // `/mcp__server__prompt` expansion injected as the user turn (see
+    // ServerMcpPromptExpansionSchema).
+    mcpPromptExpansion: ServerMcpPromptExpansionSchema.optional(),
     // #4947 / #5006: only set on `messageType: 'error'` envelopes whose
     // `code` is one of the two resume-failure codes emitted by CliSession's
     // `_handleChildClose` resume-failure path:

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -110,6 +110,31 @@ export const ServerCompactMetadataSchema = z.object({
   durationMs: z.number().nullable(),
 })
 
+/**
+ * #6845 — structured payload for an `mcp_prompt_expansion` system event. When a
+ * user sends `/mcp__<server>__<prompt>`, the server intercepts it, calls the
+ * MCP server's `prompts/get`, and injects the returned SERVER-CONTROLLED
+ * messages as the user turn to the model — but the transcript only shows the
+ * raw slash command the user typed. This marker surfaces what was ACTUALLY sent
+ * so the transcript is honest, with explicit provenance (`server`/`prompt`) so
+ * the content is never mistaken for user-typed text (a trusted-but-verbose, or
+ * later-compromised, MCP server could inject surprising content).
+ *
+ * Carried on `ServerMessageSchema.mcpPromptExpansion` alongside
+ * `messageType === 'system'` and `subtype === 'mcp_prompt_expansion'` — the
+ * same optional-field-on-the-existing-`message`-envelope convention as
+ * `compactMetadata` (no new wire message type). `text` is the (bounded) injected
+ * content; `truncated` flags that the producer capped a larger expansion for
+ * display (the FULL text still reached the model). Name fields are length-capped
+ * and `text` bounded so a malformed producer can't flood the wire.
+ */
+export const ServerMcpPromptExpansionSchema = z.object({
+  server: z.string().max(256),
+  prompt: z.string().max(256),
+  text: z.string().max(8192),
+  truncated: z.boolean(),
+})
+
 export const ServerMessageSchema = z.object({
   type: z.literal('message'),
   messageType: z.string(),
@@ -130,6 +155,13 @@ export const ServerMessageSchema = z.object({
   // event doesn't have to hijack `code`'s error-only semantics.
   subtype: z.string().max(64).optional(),
   compactMetadata: ServerCompactMetadataSchema.optional(),
+  // #6845: by the same producer convention as `subtype`/`compactMetadata`
+  // above, the server only populates `mcpPromptExpansion` on
+  // `messageType: 'system'` envelopes whose `subtype` is
+  // `'mcp_prompt_expansion'` — the honesty marker for a server-controlled
+  // `/mcp__server__prompt` expansion injected as the user turn (see
+  // ServerMcpPromptExpansionSchema).
+  mcpPromptExpansion: ServerMcpPromptExpansionSchema.optional(),
   // #4947 / #5006: only set on `messageType: 'error'` envelopes whose
   // `code` is one of the two resume-failure codes emitted by CliSession's
   // `_handleChildClose` resume-failure path:

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -63,6 +63,23 @@ const MAX_TOOL_ROUNDS = 25
 // performance (don't re-realpath the same cwd on every file op).
 const CWD_CACHE_TTL_MS = 30_000
 
+// #6845: display cap for the server-controlled MCP-prompt expansion surfaced
+// in the transcript (the honesty marker). The FULL resolved text still goes to
+// the model as the user turn — only the copy shown in the transcript is capped
+// so a huge `prompts/get` response can't flood the chat. event-normalizer.js
+// re-bounds at the wire boundary and store-core re-bounds again (defense in
+// depth), mirroring the #6768 compact_boundary bounding chain.
+const MCP_PROMPT_EXPANSION_DISPLAY_CAP = 4000
+
+// Bound an MCP-prompt expansion to the display cap, appending a truncation
+// marker when it overflows. Returns the (possibly truncated) text plus a
+// `truncated` flag so the renderer can badge it.
+function boundMcpPromptExpansionText(text, cap = MCP_PROMPT_EXPANSION_DISPLAY_CAP) {
+  const s = typeof text === 'string' ? text : String(text ?? '')
+  if (s.length <= cap) return { text: s, truncated: false }
+  return { text: `${s.slice(0, cap)}\n…(truncated)`, truncated: true }
+}
+
 export class ClaudeByokSession extends BaseSession {
   // #5858: Claude-family flag — single source of truth for isClaudeProvider().
   // DockerByokSession (docker-byok) extends this and correctly inherits it.
@@ -670,6 +687,15 @@ export class ClaudeByokSession extends BaseSession {
         })
         return
       }
+      // #6845: honesty. The raw `/mcp__server__prompt` the user typed is NOT
+      // what the model receives — the SERVER-CONTROLLED expansion above is,
+      // injected as the user turn. Surface it in the transcript as a labeled
+      // system marker so the user can audit the actual injected content (a
+      // trusted-but-verbose, or later-compromised, MCP server could inject
+      // surprising text). Emitted before stream_start so it renders between the
+      // user's raw command echo and the assistant response. Never lets a marker
+      // failure break the turn — the message send is what matters.
+      this._emitMcpPromptExpansionMarker(mcpPromptMatch, promptText)
     }
 
     this._messageCounter += 1
@@ -2113,6 +2139,38 @@ export class ClaudeByokSession extends BaseSession {
     const text = this._extractPromptMessagesText(result)
     if (!text) throw new Error('prompt returned no injectable text content')
     return text
+  }
+
+  /**
+   * #6845: emit the honesty marker for an expanded MCP prompt. The expansion is
+   * SERVER-CONTROLLED (authored by the MCP server, not typed by the user) and
+   * lands in the user role, so the marker is explicitly provenance-labeled and
+   * carries the (bounded) injected text for audit. Structured on a `system`
+   * message with `subtype: 'mcp_prompt_expansion'` + a `mcpPromptExpansion`
+   * field — the same optional-field-on-an-existing-marker path #6768's
+   * compact_boundary uses, so no new wire type is introduced. `content` carries
+   * the same labeled+bounded text so generic renderers (mobile system bubble,
+   * the System tab) stay honest even without the dedicated marker component.
+   * A marker failure is logged and swallowed: surfacing the expansion must
+   * never break delivery of the actual user turn.
+   */
+  _emitMcpPromptExpansionMarker(match, expandedText) {
+    try {
+      const parsed = parseMcpToolName(match?.prefixedName) || {}
+      const server = typeof parsed.serverName === 'string' ? parsed.serverName : ''
+      const prompt = typeof parsed.toolName === 'string' ? parsed.toolName : ''
+      const { text, truncated } = boundMcpPromptExpansionText(expandedText)
+      const label = `Expanded /${match?.prefixedName ?? ''} (server-controlled MCP prompt)`
+      this.emit('message', {
+        type: 'system',
+        subtype: 'mcp_prompt_expansion',
+        content: `${label} →\n${text}`,
+        mcpPromptExpansion: { server, prompt, text, truncated },
+        timestamp: Date.now(),
+      })
+    } catch (err) {
+      log.warn(`failed to emit MCP prompt expansion marker: ${err?.message || String(err)}`)
+    }
   }
 
   /**

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -71,13 +71,28 @@ const CWD_CACHE_TTL_MS = 30_000
 // depth), mirroring the #6768 compact_boundary bounding chain.
 const MCP_PROMPT_EXPANSION_DISPLAY_CAP = 4000
 
+// Post-#6845-review fix (thread 2): the suffix names that the model still got
+// the full text — mirrors event-normalizer.js's and store-core's wording so a
+// reader sees the same honest note regardless of which layer's copy they're
+// looking at (the marker component, the mobile/System-tab `content` fallback
+// below, a wire-bypassing replay, etc).
+const MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX = '\n…(truncated for display; full text sent to the model)'
+
 // Bound an MCP-prompt expansion to the display cap, appending a truncation
 // marker when it overflows. Returns the (possibly truncated) text plus a
 // `truncated` flag so the renderer can badge it.
+//
+// Post-#6845-review fix (thread 2): previously sliced to `cap` and THEN
+// appended the suffix, so the returned string could exceed `cap` by the
+// suffix's length. The slice length now subtracts the suffix's own length so
+// `text.length` (slice + suffix) never exceeds `cap` — computed from the
+// suffix's actual `.length` rather than a hardcoded magic number, so this
+// stays correct if the wording changes again.
 function boundMcpPromptExpansionText(text, cap = MCP_PROMPT_EXPANSION_DISPLAY_CAP) {
   const s = typeof text === 'string' ? text : String(text ?? '')
   if (s.length <= cap) return { text: s, truncated: false }
-  return { text: `${s.slice(0, cap)}\n…(truncated)`, truncated: true }
+  const sliceLen = Math.max(0, cap - MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX.length)
+  return { text: `${s.slice(0, sliceLen)}${MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX}`, truncated: true }
 }
 
 export class ClaudeByokSession extends BaseSession {

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -90,6 +90,41 @@ function boundedCompactMetadata(meta) {
   }
 }
 
+// #6845: wire-boundary caps for the MCP-prompt expansion marker. server/prompt
+// mirror ServerMcpPromptExpansionSchema's 256-char names; `text` mirrors its
+// 8192 ceiling. byok-session already caps the display copy (4000 + a
+// truncation marker); this is the defense-in-depth re-bound at the serialization
+// choke point (same posture as boundedCompactMetadata) so a wire-bypassing or
+// malformed producer can't push an unbounded payload onto clients.
+const MCP_PROMPT_EXPANSION_NAME_CAP = 256
+const MCP_PROMPT_EXPANSION_TEXT_CAP = 8192
+
+/**
+ * #6845 — coerce+bound the `mcpPromptExpansion` marker fields before forwarding
+ * onto the wire. `server`/`prompt` coerce to strings and cap at 256; `text`
+ * coerces to a string and caps at 8192 (appending an explicit truncation marker
+ * when it overflows so the client never silently drops content); `truncated`
+ * stays true if EITHER the producer flagged it or this re-bound truncated.
+ *
+ * @param {{server?: *, prompt?: *, text?: *, truncated?: *}} meta
+ * @returns {{server: string, prompt: string, text: string, truncated: boolean}}
+ */
+function boundedMcpPromptExpansion(meta) {
+  const asString = (v) => (typeof v === 'string' ? v : String(v ?? ''))
+  const cap = (s, n) => (s.length > n ? s.slice(0, n) : s)
+  const rawText = asString(meta?.text)
+  const overflow = rawText.length > MCP_PROMPT_EXPANSION_TEXT_CAP
+  const text = overflow
+    ? `${cap(rawText, MCP_PROMPT_EXPANSION_TEXT_CAP - 14)}\n…(truncated)`
+    : rawText
+  return {
+    server: cap(asString(meta?.server), MCP_PROMPT_EXPANSION_NAME_CAP),
+    prompt: cap(asString(meta?.prompt), MCP_PROMPT_EXPANSION_NAME_CAP),
+    text,
+    truncated: meta?.truncated === true || overflow,
+  }
+}
+
 /**
  * Declarative event-to-WS-message mapping.
  *
@@ -309,6 +344,15 @@ Object.assign(EVENT_MAP, {
     if (data.type === 'system' && data.subtype === 'compact_boundary' && data.compactMetadata) {
       msg.subtype = data.subtype
       msg.compactMetadata = boundedCompactMetadata(data.compactMetadata)
+    }
+    // #6845: forward the MCP-prompt expansion marker (the honesty surface for a
+    // server-controlled `/mcp__server__prompt` expansion injected as the user
+    // turn). Gated identically to compact_boundary — `messageType: 'system'` +
+    // the `mcp_prompt_expansion` subtype + a present payload — and re-bounded
+    // here so a malformed producer can't reach the wire unbounded.
+    if (data.type === 'system' && data.subtype === 'mcp_prompt_expansion' && data.mcpPromptExpansion) {
+      msg.subtype = data.subtype
+      msg.mcpPromptExpansion = boundedMcpPromptExpansion(data.mcpPromptExpansion)
     }
     return { messages: [{ msg }] }
   },

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -99,23 +99,45 @@ function boundedCompactMetadata(meta) {
 const MCP_PROMPT_EXPANSION_NAME_CAP = 256
 const MCP_PROMPT_EXPANSION_TEXT_CAP = 8192
 
+// Thread-2/honesty-nit fix (post-#6845 review): the suffix now says the FULL
+// text still reached the model, matching byok-session.js's display-cap suffix
+// and store-core's client-side re-bound suffix — a reader who only sees the
+// truncated marker (mobile, System tab) must not conclude the model saw less
+// than it did. Sliced-length arithmetic below subtracts THIS string's actual
+// length rather than a hardcoded magic number, so the total (slice + suffix)
+// never exceeds the cap even if the wording changes again later.
+const MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX = '\n…(truncated for display; full text sent to the model)'
+
 /**
  * #6845 — coerce+bound the `mcpPromptExpansion` marker fields before forwarding
- * onto the wire. `server`/`prompt` coerce to strings and cap at 256; `text`
- * coerces to a string and caps at 8192 (appending an explicit truncation marker
- * when it overflows so the client never silently drops content); `truncated`
- * stays true if EITHER the producer flagged it or this re-bound truncated.
+ * onto the wire. Requires a string `text` (the marker is meaningless without
+ * the injected content) — returns `null` when `text` is not a string so the
+ * caller skips attaching `subtype`/`mcpPromptExpansion` entirely rather than
+ * forwarding a marker with blank/coerced content. This mirrors store-core's
+ * `parseMcpPromptExpansion` reject-on-non-string-text contract (post-#6845
+ * review thread 1 — the two layers previously disagreed: this function used to
+ * silently stringify a non-string `text`, while the client rejected the whole
+ * marker; they now agree on reject).
+ *
+ * `server`/`prompt` are cosmetic provenance labels (not content), so they stay
+ * on the more forgiving "coerce" side: a non-string value becomes `''` rather
+ * than failing the whole marker, then caps at 256. `text` caps at 8192,
+ * appending {@link MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX} when it overflows so
+ * the client never silently drops content; `truncated` stays true if EITHER
+ * the producer flagged it or this re-bound truncated.
  *
  * @param {{server?: *, prompt?: *, text?: *, truncated?: *}} meta
- * @returns {{server: string, prompt: string, text: string, truncated: boolean}}
+ * @returns {{server: string, prompt: string, text: string, truncated: boolean} | null}
  */
 function boundedMcpPromptExpansion(meta) {
-  const asString = (v) => (typeof v === 'string' ? v : String(v ?? ''))
+  if (typeof meta?.text !== 'string') return null
+  const asString = (v) => (typeof v === 'string' ? v : '')
   const cap = (s, n) => (s.length > n ? s.slice(0, n) : s)
-  const rawText = asString(meta?.text)
+  const rawText = meta.text
   const overflow = rawText.length > MCP_PROMPT_EXPANSION_TEXT_CAP
+  const sliceLen = Math.max(0, MCP_PROMPT_EXPANSION_TEXT_CAP - MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX.length)
   const text = overflow
-    ? `${cap(rawText, MCP_PROMPT_EXPANSION_TEXT_CAP - 14)}\n…(truncated)`
+    ? `${cap(rawText, sliceLen)}${MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX}`
     : rawText
   return {
     server: cap(asString(meta?.server), MCP_PROMPT_EXPANSION_NAME_CAP),
@@ -349,10 +371,18 @@ Object.assign(EVENT_MAP, {
     // server-controlled `/mcp__server__prompt` expansion injected as the user
     // turn). Gated identically to compact_boundary — `messageType: 'system'` +
     // the `mcp_prompt_expansion` subtype + a present payload — and re-bounded
-    // here so a malformed producer can't reach the wire unbounded.
+    // here so a malformed producer can't reach the wire unbounded. Unlike
+    // compact_boundary, `boundedMcpPromptExpansion` can return `null` (a
+    // non-string `text` — see its doc comment), in which case neither
+    // `subtype` nor `mcpPromptExpansion` is attached: the envelope falls back
+    // to a plain system message rather than claiming a structured marker it
+    // can't honestly populate.
     if (data.type === 'system' && data.subtype === 'mcp_prompt_expansion' && data.mcpPromptExpansion) {
-      msg.subtype = data.subtype
-      msg.mcpPromptExpansion = boundedMcpPromptExpansion(data.mcpPromptExpansion)
+      const bounded = boundedMcpPromptExpansion(data.mcpPromptExpansion)
+      if (bounded) {
+        msg.subtype = data.subtype
+        msg.mcpPromptExpansion = bounded
+      }
     }
     return { messages: [{ msg }] }
   },

--- a/packages/server/tests/byok-mcp-prompts-resources.test.js
+++ b/packages/server/tests/byok-mcp-prompts-resources.test.js
@@ -541,6 +541,93 @@ describe('ClaudeByokSession MCP prompts/resources (#6823)', () => {
     assert.ok(errors.some((e) => /server exploded/.test(e.message)), 'error surfaced to the client')
   })
 
+  // A stream mock that captures the last user turn sent to the model and ends
+  // the turn cleanly. Mirrors the shape the passing expansion test uses above.
+  function captureStreamMock(streamed) {
+    return {
+      messages: {
+        stream: ({ messages }) => {
+          streamed.push(messages[messages.length - 1])
+          return {
+            async *[Symbol.asyncIterator]() { yield { type: 'message_delta', delta: { stop_reason: 'end_turn' } } },
+            async finalMessage() { return { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } } },
+          }
+        },
+      },
+    }
+  }
+
+  it('sendMessage surfaces the expansion as a labeled server-controlled marker (#6845)', async () => {
+    const configPath = writeStubConfig({ prompts: PROMPTS })
+    const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+    const streamed = []
+    session._client = captureStreamMock(streamed)
+    await session.start()
+    // Override getPrompt (keeping the real fleet's prompts list) so the
+    // expansion is deterministic, SERVER-CONTROLLED text distinct from the
+    // raw command the user typed.
+    const SERVER_TEXT = 'SERVER-AUTHORED CONTENT the user never typed'
+    session._mcpFleet.getPrompt = async () => ({ messages: [{ role: 'user', content: { type: 'text', text: SERVER_TEXT } }] })
+    // Record the ordered event stream so we can assert the marker lands BEFORE
+    // the assistant response starts streaming.
+    const order = []
+    const markers = []
+    session.on('message', (m) => { order.push(`message:${m.type}:${m.subtype || ''}`); if (m.subtype === 'mcp_prompt_expansion') markers.push(m) })
+    session.on('stream_start', () => order.push('stream_start'))
+
+    await session.sendMessage('/mcp__stub__greet')
+
+    assert.equal(markers.length, 1, 'exactly one expansion marker emitted')
+    const marker = markers[0]
+    assert.equal(marker.type, 'system')
+    assert.equal(marker.subtype, 'mcp_prompt_expansion')
+    // Provenance: names the source server + prompt.
+    assert.deepEqual(
+      { server: marker.mcpPromptExpansion.server, prompt: marker.mcpPromptExpansion.prompt },
+      { server: 'stub', prompt: 'greet' },
+    )
+    // The marker carries the ACTUAL server-controlled text, not the raw command.
+    assert.match(marker.mcpPromptExpansion.text, /SERVER-AUTHORED CONTENT/)
+    assert.equal(marker.mcpPromptExpansion.truncated, false)
+    // content is honest + provenance-labeled for generic (non-marker) renderers.
+    assert.match(marker.content, /server-controlled MCP prompt/)
+    assert.match(marker.content, /SERVER-AUTHORED CONTENT/)
+    assert.doesNotMatch(marker.content, /^\/mcp__stub__greet$/, 'not merely the raw command')
+    // Ordering: marker precedes the assistant stream.
+    const markerIdx = order.indexOf('message:system:mcp_prompt_expansion')
+    const streamIdx = order.indexOf('stream_start')
+    assert.ok(markerIdx !== -1 && streamIdx !== -1 && markerIdx < streamIdx, 'marker emitted before stream_start')
+    // The FULL text (not the display copy) reached the model as the user turn.
+    assert.equal(streamed[0].role, 'user')
+    assert.match(streamed[0].content, /SERVER-AUTHORED CONTENT/)
+    await session.destroy()
+  })
+
+  it('sendMessage bounds a huge expansion in the marker but sends the full text to the model (#6845)', async () => {
+    const configPath = writeStubConfig({ prompts: PROMPTS })
+    const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+    const streamed = []
+    session._client = captureStreamMock(streamed)
+    await session.start()
+    const HUGE = 'X'.repeat(9000)
+    session._mcpFleet.getPrompt = async () => ({ messages: [{ role: 'user', content: HUGE }] })
+    const markers = []
+    session.on('message', (m) => { if (m.subtype === 'mcp_prompt_expansion') markers.push(m) })
+
+    await session.sendMessage('/mcp__stub__greet')
+
+    assert.equal(markers.length, 1)
+    const marker = markers[0]
+    assert.equal(marker.mcpPromptExpansion.truncated, true, 'display copy flagged truncated')
+    // Display copy is bounded (cap + short truncation marker), far below the raw 9000.
+    assert.ok(marker.mcpPromptExpansion.text.length < 4100, `marker text bounded (was ${marker.mcpPromptExpansion.text.length})`)
+    assert.match(marker.mcpPromptExpansion.text, /…\(truncated\)$/)
+    // The model still received the FULL 9000-char expansion — bounding is
+    // display-only and must never alter what was actually sent.
+    assert.equal(streamed[0].content.length, 9000)
+    await session.destroy()
+  })
+
   it('_extractPromptMessagesText flattens the MCP prompts/get content shapes', () => {
     const session = new ClaudeByokSession({ cwd: '/tmp' })
     const text = session._extractPromptMessagesText({

--- a/packages/server/tests/byok-mcp-prompts-resources.test.js
+++ b/packages/server/tests/byok-mcp-prompts-resources.test.js
@@ -619,9 +619,22 @@ describe('ClaudeByokSession MCP prompts/resources (#6823)', () => {
     assert.equal(markers.length, 1)
     const marker = markers[0]
     assert.equal(marker.mcpPromptExpansion.truncated, true, 'display copy flagged truncated')
-    // Display copy is bounded (cap + short truncation marker), far below the raw 9000.
-    assert.ok(marker.mcpPromptExpansion.text.length < 4100, `marker text bounded (was ${marker.mcpPromptExpansion.text.length})`)
-    assert.match(marker.mcpPromptExpansion.text, /…\(truncated\)$/)
+    // Post-#6845-review fix (thread 2): the display copy (slice + suffix) must
+    // never EXCEED the cap — previously it sliced to the cap and THEN appended
+    // the suffix, so the total ran past 4000. Assert the real invariant (total
+    // length <= cap), not a loose upper bound that would pass either way.
+    assert.ok(
+      marker.mcpPromptExpansion.text.length <= 4000,
+      `marker text (incl. truncation suffix) must not exceed the display cap (was ${marker.mcpPromptExpansion.text.length})`,
+    )
+    assert.match(marker.mcpPromptExpansion.text, /…\(truncated for display; full text sent to the model\)$/)
+    // Honesty nit (post-#6845-review): the `content` fallback string — what
+    // mobile / the System tab render for clients that don't have the
+    // dedicated marker component — must carry the same "full text sent to the
+    // model" note when truncated, not just the structured `mcpPromptExpansion`
+    // field. `content` embeds the same (already-suffixed) `text`, so this
+    // should fall out for free.
+    assert.match(marker.content, /truncated for display; full text sent to the model/)
     // The model still received the FULL 9000-char expansion — bounding is
     // display-only and must never alter what was actually sent.
     assert.equal(streamed[0].content.length, 9000)

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -313,20 +313,36 @@ describe('EventNormalizer', () => {
       )
       const meta = result.messages[0].msg.mcpPromptExpansion
       assert.ok(meta.text.length <= 8192, `text re-bounded to the 8192 wire cap (was ${meta.text.length})`)
-      assert.match(meta.text, /…\(truncated\)$/)
+      assert.match(meta.text, /…\(truncated for display; full text sent to the model\)$/)
       assert.equal(meta.truncated, true, 'wire-boundary truncation forces the flag on')
     })
 
-    it('caps overlong server/prompt names and coerces non-string fields', () => {
+    it('caps overlong server/prompt names and coerces non-string name fields to empty string', () => {
       const result = normalizer.normalize(
         'message',
-        expansionEvent({ server: 'S'.repeat(400), prompt: 42, text: null, truncated: 'yes' }),
+        expansionEvent({ server: 'S'.repeat(400), prompt: 42, text: 'hi', truncated: 'yes' }),
         makeCtx(),
       )
       const meta = result.messages[0].msg.mcpPromptExpansion
       assert.equal(meta.server.length, 256, 'server name capped at 256')
-      assert.equal(meta.prompt, '42', 'non-string prompt coerced to string')
-      assert.equal(meta.text, '', 'non-string text coerced to empty string')
+      assert.equal(meta.prompt, '', 'non-string prompt coerced to empty string (matches store-core, not stringified)')
+      assert.equal(meta.text, 'hi')
+    })
+
+    // Post-#6845-review fix (thread 1): a non-string `text` now drops the WHOLE
+    // marker at this layer too — this function used to silently stringify it
+    // (`String(v ?? '')`), which disagreed with store-core's
+    // `parseMcpPromptExpansion`, which has always rejected a non-string `text`
+    // outright. The two layers now share the same reject contract.
+    it('drops the marker (subtype + mcpPromptExpansion both absent) when text is not a string', () => {
+      const result = normalizer.normalize(
+        'message',
+        expansionEvent({ server: 'stub', prompt: 'greet', text: null, truncated: true }),
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.subtype, undefined, 'subtype not claimed when the payload cannot be honestly bounded')
+      assert.equal(msg.mcpPromptExpansion, undefined)
     })
 
     it('does not attach the marker when the subtype/payload is absent', () => {

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -277,6 +277,70 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- mcp_prompt_expansion marker bounding (#6845) ----
+  //
+  // The honesty marker for a server-controlled `/mcp__server__prompt` expansion
+  // injected as the user turn. Gated + re-bounded at the wire boundary exactly
+  // like compact_boundary above.
+  describe('mcp_prompt_expansion marker (#6845)', () => {
+    function expansionEvent(mcpPromptExpansion) {
+      return {
+        type: 'system',
+        subtype: 'mcp_prompt_expansion',
+        content: 'Expanded /mcp__stub__greet (server-controlled MCP prompt) →\nhi',
+        timestamp: Date.now(),
+        mcpPromptExpansion,
+      }
+    }
+
+    it('forwards a well-formed expansion with its subtype', () => {
+      const result = normalizer.normalize(
+        'message',
+        expansionEvent({ server: 'stub', prompt: 'greet', text: 'server text', truncated: false }),
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.subtype, 'mcp_prompt_expansion')
+      assert.deepEqual(msg.mcpPromptExpansion, { server: 'stub', prompt: 'greet', text: 'server text', truncated: false })
+    })
+
+    it('re-bounds an over-cap text and flips truncated even if the producer said false', () => {
+      const huge = 'Z'.repeat(20_000)
+      const result = normalizer.normalize(
+        'message',
+        expansionEvent({ server: 'stub', prompt: 'greet', text: huge, truncated: false }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.mcpPromptExpansion
+      assert.ok(meta.text.length <= 8192, `text re-bounded to the 8192 wire cap (was ${meta.text.length})`)
+      assert.match(meta.text, /…\(truncated\)$/)
+      assert.equal(meta.truncated, true, 'wire-boundary truncation forces the flag on')
+    })
+
+    it('caps overlong server/prompt names and coerces non-string fields', () => {
+      const result = normalizer.normalize(
+        'message',
+        expansionEvent({ server: 'S'.repeat(400), prompt: 42, text: null, truncated: 'yes' }),
+        makeCtx(),
+      )
+      const meta = result.messages[0].msg.mcpPromptExpansion
+      assert.equal(meta.server.length, 256, 'server name capped at 256')
+      assert.equal(meta.prompt, '42', 'non-string prompt coerced to string')
+      assert.equal(meta.text, '', 'non-string text coerced to empty string')
+    })
+
+    it('does not attach the marker when the subtype/payload is absent', () => {
+      const result = normalizer.normalize(
+        'message',
+        { type: 'system', content: 'plain system event', timestamp: Date.now() },
+        makeCtx(),
+      )
+      const msg = result.messages[0].msg
+      assert.equal(msg.subtype, undefined)
+      assert.equal(msg.mcpPromptExpansion, undefined)
+    })
+  })
+
   // ---- EVENT_MAP: session_usage (#4072) ----
 
   describe('session_usage event', () => {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -7160,6 +7160,57 @@ describe('handleMessage', () => {
       }
     })
 
+    // Post-#6845-review fix (thread 1): a present-but-non-string `text` must
+    // drop the whole marker the same way a MISSING `text` does — the server
+    // normalizer (`event-normalizer.js`'s `boundedMcpPromptExpansion`) now
+    // shares this exact reject contract (it used to stringify a non-string
+    // `text` instead of rejecting, which disagreed with this function).
+    it('drops a malformed expansion (non-string text) the same way it drops a missing one', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'mcp_prompt_expansion',
+          content: 'Expanded ...',
+          mcpPromptExpansion: { server: 'stub', prompt: 'greet', text: 42, truncated: false },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.mcpPromptExpansion).toBeUndefined()
+      }
+    })
+
+    // Non-string `server`/`prompt` are cosmetic provenance labels, not content
+    // — they coerce to `''` rather than failing the whole marker. Matches
+    // event-normalizer.js's coercion for the same fields post-#6845-review.
+    it('coerces non-string server/prompt fields to empty string (text stays valid)', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'mcp_prompt_expansion',
+          content: 'Expanded ...',
+          mcpPromptExpansion: { server: 42, prompt: null, text: 'hi', truncated: false },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.mcpPromptExpansion).toEqual({
+          server: '',
+          prompt: '',
+          text: 'hi',
+          truncated: false,
+        })
+      }
+    })
+
     it('re-bounds an over-cap text client-side and flips truncated on', () => {
       const huge = 'Z'.repeat(20_000)
       const out = handleMessage(
@@ -7177,7 +7228,11 @@ describe('handleMessage', () => {
       expect(out.shouldDispatch).toBe(true)
       if (out.shouldDispatch) {
         expect(out.chatMessage.mcpPromptExpansion!.text.length).toBeLessThanOrEqual(8192)
-        expect(out.chatMessage.mcpPromptExpansion!.text.endsWith('…(truncated)')).toBe(true)
+        expect(
+          out.chatMessage.mcpPromptExpansion!.text.endsWith(
+            '…(truncated for display; full text sent to the model)',
+          ),
+        ).toBe(true)
         expect(out.chatMessage.mcpPromptExpansion!.truncated).toBe(true)
       }
     })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -7095,6 +7095,111 @@ describe('handleMessage', () => {
       }
     })
   })
+
+  // #6845: server (byok-session.js) expands a `/mcp__server__prompt` slash
+  // command via the MCP server's `prompts/get` and injects the returned
+  // SERVER-CONTROLLED text as the user turn — but the transcript only shows the
+  // raw command. The server emits an `mcp_prompt_expansion` marker so the store
+  // preserves `mcpPromptExpansion` onto the ChatMessage and the dashboard/app
+  // can render the actual injected text with provenance.
+  describe('mcpPromptExpansion preservation (#6845)', () => {
+    it('preserves a well-formed expansion on an mcp_prompt_expansion system message', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'mcp_prompt_expansion',
+          content: 'Expanded /mcp__stub__greet (server-controlled MCP prompt) →\nhi',
+          mcpPromptExpansion: { server: 'stub', prompt: 'greet', text: 'server-authored text', truncated: false },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.type).toBe('system')
+        expect(out.chatMessage.mcpPromptExpansion).toEqual({
+          server: 'stub',
+          prompt: 'greet',
+          text: 'server-authored text',
+          truncated: false,
+        })
+      }
+    })
+
+    it('leaves mcpPromptExpansion undefined for a non-expansion system message (pre-#6845 server)', () => {
+      const out = handleMessage(
+        { messageType: 'system', content: 'MCP server foo connected', timestamp: 100 },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.mcpPromptExpansion).toBeUndefined()
+      }
+    })
+
+    it('drops a malformed expansion (missing text) rather than passing junk through', () => {
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'mcp_prompt_expansion',
+          content: 'Expanded ...',
+          mcpPromptExpansion: { server: 'stub', prompt: 'greet', truncated: false },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.mcpPromptExpansion).toBeUndefined()
+      }
+    })
+
+    it('re-bounds an over-cap text client-side and flips truncated on', () => {
+      const huge = 'Z'.repeat(20_000)
+      const out = handleMessage(
+        {
+          messageType: 'system',
+          subtype: 'mcp_prompt_expansion',
+          content: 'Expanded ...',
+          mcpPromptExpansion: { server: 'stub', prompt: 'greet', text: huge, truncated: false },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.mcpPromptExpansion!.text.length).toBeLessThanOrEqual(8192)
+        expect(out.chatMessage.mcpPromptExpansion!.text.endsWith('…(truncated)')).toBe(true)
+        expect(out.chatMessage.mcpPromptExpansion!.truncated).toBe(true)
+      }
+    })
+
+    it('does NOT attach mcpPromptExpansion to an unrelated message type even if present on the payload', () => {
+      const out = handleMessage(
+        {
+          messageType: 'response',
+          content: 'hello',
+          mcpPromptExpansion: { server: 'stub', prompt: 'greet', text: 'x', truncated: false },
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.mcpPromptExpansion).toBeUndefined()
+      }
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -125,14 +125,37 @@ function parseCompactMetadata(value: unknown): ChatMessage['compactMetadata'] {
 const MCP_PROMPT_EXPANSION_NAME_CAP = 256
 const MCP_PROMPT_EXPANSION_TEXT_CAP = 8192
 
+// Post-#6845-review fix (thread 2 / honesty nit): the suffix names that the
+// model still received the full text — kept byte-identical to
+// event-normalizer.js's and byok-session.js's suffix so a reader sees the same
+// honest note regardless of which layer re-bounded the text they're looking
+// at. The slice-length arithmetic below subtracts this string's actual
+// `.length` rather than a hardcoded magic number, so the total (slice +
+// suffix) never exceeds the cap even if the wording changes again later.
+const MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX = '\n…(truncated for display; full text sent to the model)'
+
 /**
  * #6845 — validate + coerce the wire `message.mcpPromptExpansion` object into
- * the store's `McpPromptExpansionMeta` shape. Requires a string `text` (the
- * marker is meaningless without the injected content); `server`/`prompt` coerce
- * to strings and cap at 256; `text` caps at 8192; `truncated` stays true if the
- * producer flagged it OR this re-bound truncated. Returns `undefined` for a
- * malformed payload rather than attaching a half-formed object that would crash
- * a renderer expecting the full shape.
+ * the store's `McpPromptExpansionMeta` shape.
+ *
+ * Requires a string `text` (the marker is meaningless without the injected
+ * content) — returns `undefined` for the WHOLE marker when `text` is not a
+ * string, rather than attaching a half-formed object that would crash a
+ * renderer expecting the full shape. Post-#6845-review (thread 1): the server
+ * normalizer (`event-normalizer.js`'s `boundedMcpPromptExpansion`) now mirrors
+ * this exact reject-on-non-string-text contract — the two layers previously
+ * disagreed (the server silently stringified a non-string `text` while this
+ * function rejected the whole marker), which meant a malformed/replayed
+ * payload could pass wire validation server-side yet still get dropped
+ * client-side for a DIFFERENT reason than the field the doc comment implied.
+ * They now agree: non-string `text` is invalid at both layers.
+ *
+ * `server`/`prompt` are cosmetic provenance labels (not content), so they stay
+ * on the more forgiving "coerce" side — a non-string value becomes `''`
+ * (matches event-normalizer.js's coercion for the same fields) — then cap at
+ * 256. `text` caps at 8192, appending
+ * {@link MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX} when it overflows; `truncated`
+ * stays true if the producer flagged it OR this re-bound truncated.
  */
 function parseMcpPromptExpansion(value: unknown): ChatMessage['mcpPromptExpansion'] {
   if (!value || typeof value !== 'object') return undefined
@@ -141,10 +164,11 @@ function parseMcpPromptExpansion(value: unknown): ChatMessage['mcpPromptExpansio
   const asString = (v: unknown): string => (typeof v === 'string' ? v : '')
   const cap = (s: string, n: number): string => (s.length > n ? s.slice(0, n) : s)
   const overflow = obj.text.length > MCP_PROMPT_EXPANSION_TEXT_CAP
+  const sliceLen = Math.max(0, MCP_PROMPT_EXPANSION_TEXT_CAP - MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX.length)
   return {
     server: cap(asString(obj.server), MCP_PROMPT_EXPANSION_NAME_CAP),
     prompt: cap(asString(obj.prompt), MCP_PROMPT_EXPANSION_NAME_CAP),
-    text: overflow ? `${cap(obj.text, MCP_PROMPT_EXPANSION_TEXT_CAP - 14)}\n…(truncated)` : obj.text,
+    text: overflow ? `${cap(obj.text, sliceLen)}${MCP_PROMPT_EXPANSION_TRUNCATION_SUFFIX}` : obj.text,
     truncated: obj.truncated === true || overflow,
   }
 }

--- a/packages/store-core/src/handlers/stream.ts
+++ b/packages/store-core/src/handlers/stream.ts
@@ -118,6 +118,37 @@ function parseCompactMetadata(value: unknown): ChatMessage['compactMetadata'] {
   }
 }
 
+// #6845: wire-boundary caps for the MCP-prompt expansion marker — a third layer
+// behind byok-session's display cap and event-normalizer's re-bound. Defends the
+// store against a wire-bypassing path (a corrupted localStorage replay blob) so
+// a renderer never receives an unbounded string.
+const MCP_PROMPT_EXPANSION_NAME_CAP = 256
+const MCP_PROMPT_EXPANSION_TEXT_CAP = 8192
+
+/**
+ * #6845 — validate + coerce the wire `message.mcpPromptExpansion` object into
+ * the store's `McpPromptExpansionMeta` shape. Requires a string `text` (the
+ * marker is meaningless without the injected content); `server`/`prompt` coerce
+ * to strings and cap at 256; `text` caps at 8192; `truncated` stays true if the
+ * producer flagged it OR this re-bound truncated. Returns `undefined` for a
+ * malformed payload rather than attaching a half-formed object that would crash
+ * a renderer expecting the full shape.
+ */
+function parseMcpPromptExpansion(value: unknown): ChatMessage['mcpPromptExpansion'] {
+  if (!value || typeof value !== 'object') return undefined
+  const obj = value as Record<string, unknown>
+  if (typeof obj.text !== 'string') return undefined
+  const asString = (v: unknown): string => (typeof v === 'string' ? v : '')
+  const cap = (s: string, n: number): string => (s.length > n ? s.slice(0, n) : s)
+  const overflow = obj.text.length > MCP_PROMPT_EXPANSION_TEXT_CAP
+  return {
+    server: cap(asString(obj.server), MCP_PROMPT_EXPANSION_NAME_CAP),
+    prompt: cap(asString(obj.prompt), MCP_PROMPT_EXPANSION_NAME_CAP),
+    text: overflow ? `${cap(obj.text, MCP_PROMPT_EXPANSION_TEXT_CAP - 14)}\n…(truncated)` : obj.text,
+    truncated: obj.truncated === true || overflow,
+  }
+}
+
 export function handleMessage(
   msg: Record<string, unknown>,
   _activeSessionId: string | null,
@@ -225,6 +256,18 @@ export function handleMessage(
       ? (() => {
           const meta = parseCompactMetadata(msg.compactMetadata)
           return meta ? { compactMetadata: meta } : {}
+        })()
+      : {}),
+    // #6845: preserve the MCP-prompt expansion marker so renderers can show an
+    // "expanded from MCP prompt" block with the actual server-controlled text
+    // injected as the user turn. Gated on `msgType === 'system'` + the
+    // `mcp_prompt_expansion` subtype (same shape as the compact_boundary gate
+    // above) so a buggy producer can't sneak `mcpPromptExpansion` onto an
+    // unrelated message type.
+    ...(msgType === 'system' && msg.subtype === 'mcp_prompt_expansion'
+      ? (() => {
+          const meta = parseMcpPromptExpansion(msg.mcpPromptExpansion)
+          return meta ? { mcpPromptExpansion: meta } : {}
         })()
       : {}),
   }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -88,6 +88,9 @@ export type {
   // #6768: structured compaction-boundary marker metadata attached to
   // system ChatMessages parsed from a compact_boundary SDK/CLI event.
   CompactBoundaryMeta,
+  // #6845: structured MCP-prompt expansion marker metadata attached to system
+  // ChatMessages parsed from an mcp_prompt_expansion event.
+  McpPromptExpansionMeta,
   SavedConnection,
   ContextUsage,
   // #6769: occupancy snapshot type (the context meter's only honest input).

--- a/packages/store-core/src/types/chat.ts
+++ b/packages/store-core/src/types/chat.ts
@@ -58,6 +58,28 @@ export interface CompactBoundaryMeta {
 }
 
 /**
+ * #6845 — structured payload for an MCP-prompt expansion marker, attached to a
+ * `type: 'system'` ChatMessage when the server parsed an `mcp_prompt_expansion`
+ * event. When a user sends `/mcp__<server>__<prompt>`, the server expands it via
+ * the MCP server's `prompts/get` and injects the returned SERVER-CONTROLLED text
+ * as the user turn — but the transcript only shows the raw slash command. This
+ * marker surfaces the actual injected text with explicit provenance so the
+ * transcript is honest about what the model received. Mirrors
+ * `ServerMcpPromptExpansionSchema` on the wire (`@chroxy/protocol`).
+ *
+ * `server`/`prompt` name the source (rendered as an "expanded from" attribution
+ * so the content is never mistaken for user-typed text); `text` is the (bounded)
+ * injected content; `truncated` is `true` when the server capped a larger
+ * expansion for display (the FULL text still reached the model).
+ */
+export interface McpPromptExpansionMeta {
+  server: string;
+  prompt: string;
+  text: string;
+  truncated: boolean;
+}
+
+/**
  * #4604 Chunk B — one entry per question in a multi-question
  * AskUserQuestion form. `questions[0]` always mirrors the legacy
  * top-level `content` + `options` on the ChatMessage so single-question
@@ -253,6 +275,15 @@ export interface ChatMessage {
    * Undefined for every other system message and for pre-#6768 servers.
    */
   compactMetadata?: CompactBoundaryMeta;
+  /**
+   * #6845 — set on a `type: 'system'` ChatMessage when the server parsed an
+   * `mcp_prompt_expansion` event into a distinct marker. Renderers show an
+   * "expanded from MCP prompt <server>:<prompt>" block with the actual
+   * server-controlled text injected as the user turn, so the transcript is
+   * honest about what the model received. Undefined for every other system
+   * message and for pre-#6845 servers.
+   */
+  mcpPromptExpansion?: McpPromptExpansionMeta;
   /**
    * #5016 — Task subagent child progress, attached to the parent's
    * `tool_use` (Task) bubble. Each entry is one wire event the child


### PR DESCRIPTION
## What

Closes #6845.

When a user sends `/mcp__<server>__<prompt>`, `ClaudeByokSession.sendMessage` intercepts it, calls the MCP server's `prompts/get`, and injects the returned **server-controlled** messages as the *user turn* to the model — but the transcript only ever showed the raw slash command the user typed. The actual injected text was never surfaced, so:

- A user auditing "what did the model actually receive for my turn?" couldn't see it.
- A verbose (or later-compromised) MCP server could inject arbitrary user-turn content with **zero visibility** (the #4457 spawn-trust gate governs *whether the server may run*, not *what its prompt content injects per-call*).

## How

Follows the #6768 `compact_boundary` precedent exactly — an **optional field on the existing `message`/`system` marker envelope**, not a new wire type, so none of the 3 coverage guards are tripped.

- **Server** (`byok-session.js`): after `_resolveMcpPromptToText` resolves, emit a `system` message with `subtype: 'mcp_prompt_expansion'` carrying the resolved text + server/prompt provenance, **before `stream_start`** (renders between the user's raw-command echo and the assistant response). The **FULL** text still reaches the model; only the displayed copy is bounded (4000-char display cap + `…(truncated)` marker). A marker failure is logged and swallowed so it can never break delivery of the actual turn. `content` also carries the honest bounded text so generic renderers stay honest.
- **Wire** (`@chroxy/protocol`): new `ServerMcpPromptExpansionSchema` + optional `mcpPromptExpansion` field on `ServerMessageSchema` (`server`/`prompt` capped at 256, `text` at 8192, `truncated` flag). Re-bounded at the `event-normalizer.js` serialization choke point and again in `store-core` (defense in depth), mirroring the `boundedCompactMetadata` chain.
- **store-core**: `McpPromptExpansionMeta` type + gated preservation onto the `system` ChatMessage (both-clients handler).
- **Dashboard**: a collapsible `McpPromptExpansionMarker`, warm-tinted and explicitly labeled **"server-controlled"**, naming `server:prompt` and revealing the actual injected text on expand (with a truncation note when capped).
- **Mobile**: shows the honest bounded text via the generic system bubble — the same parity level #6768 left it at (`content` carries it); a dedicated RN marker is a follow-up.

## Provenance / trust

The expansion is **server-authored**, lands in the user role, and is labeled as such (badge + "Expanded from MCP prompt server:prompt") so it's never mistaken for user-typed text.

## Tests (all exit 0 **without** `--test-force-exit`)

- Server: `byok-mcp-prompts-resources.test.js` — sendMessage surfaces a labeled server-controlled marker before `stream_start`, carries the actual expansion (not the raw command), names server+prompt; **size cap** — a 9000-char expansion is truncated in the marker while the **full** text still reaches the model.
- Server: `event-normalizer.test.js` — wire-boundary forwarding + re-bounding + coercion + absent-payload no-op.
- store-core: `handlers.test.ts` — preservation, gating on subtype/type, malformed-drop, client-side re-bound (2104 store-core tests pass; typecheck clean).
- Protocol: 377 tests pass; dist rebuilt + staged.
- Dashboard: `McpPromptExpansionMarker.test.tsx` — provenance label, collapsed-by-default, expand reveals injected text, truncation note; `tsc --noEmit` clean.
- All 5 server custom lints rc=0.

## Needs visual check

The dashboard `McpPromptExpansionMarker` render is visual — please eyeball it on the **System tab** (collapsed affordance, the "server-controlled" badge, expand → injected text). The server emit + store-core handler are the verifiable gate and are covered by unit tests.