### PR TITLE
feat(dashboard): render fenced mermaid code blocks as diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
       "version": "0.2.114",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.114.tgz",
@@ -1683,6 +1696,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -1695,6 +1714,12 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@chroxy/app": {
       "resolved": "packages/app",
@@ -3378,6 +3403,23 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@ide/backoff": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
@@ -4040,6 +4082,15 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -5008,6 +5059,259 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5030,6 +5334,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -5251,6 +5561,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@urql/core": {
       "version": "5.2.0",
@@ -6934,6 +7254,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -7032,6 +7361,514 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -7045,6 +7882,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7231,6 +8074,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -7543,6 +8395,17 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -9277,6 +10140,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -9500,7 +10369,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9601,6 +10469,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -9642,6 +10520,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -11596,6 +12483,31 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11605,6 +12517,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -11623,6 +12540,12 @@
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11950,6 +12873,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -12149,6 +13078,18 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -12215,6 +13156,48 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/metro": {
       "version": "0.83.3",
@@ -13315,6 +14298,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13381,6 +14370,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -13645,6 +14640,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -14692,6 +15703,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -14737,6 +15754,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -14757,6 +15786,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
       "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
@@ -15520,6 +16555,12 @@
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==",
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -15802,7 +16843,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
       "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15944,6 +16984,15 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -17068,6 +18117,7 @@
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
         "dompurify": "^3.3.1",
+        "mermaid": "^11.6.0",
         "react-resizable-panels": "^4.7.1",
         "zustand": "^5.0.11"
       },

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -15,6 +15,7 @@
     "@chroxy/protocol": "*",
     "@chroxy/store-core": "*",
     "dompurify": "^3.3.1",
+    "mermaid": "^11.6.0",
     "react-resizable-panels": "^4.7.1",
     "zustand": "^5.0.11"
   },

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -19,8 +19,7 @@
 import { memo, useRef, useState, useCallback, useEffect, useLayoutEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
 import { bumpRenderCount, formatThinkingFooter, type ChatActivityState, type MessageAttachment } from '@chroxy/store-core'
 import { WorkingIndicator } from './WorkingIndicator'
-import { renderMarkdown } from '../lib/markdown'
-import { handleMarkdownBodyClick } from '../lib/codeCopy'
+import { MarkdownBody } from './MarkdownBody'
 import { CopyButton } from './CopyButton'
 import { isRenderableImageUri } from '../utils/attachment-preview'
 import { MessageRowShell } from './MeasuredRow'
@@ -435,7 +434,9 @@ const DefaultMessageRow = memo(function DefaultMessageRow({
     type === 'response' || type === 'tool_use'
       // #6625: modifier-click opens a rendered link; plain click keeps selection.
       // #6793: same container also owns the per-code-block copy button click.
-      ? <div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+      // #6754: MarkdownBody renders ```mermaid fences as diagrams (and keeps the
+      // single-innerHTML fast path + delegated click handler for everything else).
+      ? <MarkdownBody content={content} />
       : type === 'thinking'
         ? <ThinkingBody content={content} streaming={!!thinkingStreaming} truncated={thinkingTruncated} durationMs={thinkingDurationMs} tokens={thinkingTokens} />
         : content

--- a/packages/dashboard/src/components/MarkdownBody.test.tsx
+++ b/packages/dashboard/src/components/MarkdownBody.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * MarkdownBody routing tests (#6754).
+ *
+ * MermaidDiagram is stubbed so this focuses purely on the split/route logic:
+ * markdown segments hit `renderMarkdown` (innerHTML), mermaid segments mount
+ * the diagram component with the inner source.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MarkdownBody } from './MarkdownBody'
+
+vi.mock('./MermaidDiagram', () => ({
+  MermaidDiagram: ({ source }: { source: string }) => (
+    <div data-testid="stub-mermaid">{source}</div>
+  ),
+}))
+
+afterEach(cleanup)
+
+describe('MarkdownBody', () => {
+  it('renders plain markdown via the single-innerHTML fast path (no mixed wrapper)', () => {
+    const { container } = render(<MarkdownBody content={'# Hello\n\n```js\nx()\n```'} />)
+    // no mermaid → no diagram, no mixed-segment wrapper
+    expect(screen.queryByTestId('stub-mermaid')).toBeNull()
+    expect(container.querySelector('.markdown-body-mixed')).toBeNull()
+    expect(container.querySelector('h1')?.textContent).toBe('Hello')
+    // other-language fence still renders as a highlighted code block
+    expect(container.querySelector('pre code')).not.toBeNull()
+  })
+
+  it('routes a mermaid fence to MermaidDiagram with the inner source, keeping surrounding text', () => {
+    const { container } = render(
+      <MarkdownBody content={'intro\n\n```mermaid\ngraph TD; A-->B\n```\n\noutro'} />,
+    )
+    expect(container.querySelector('.markdown-body-mixed')).not.toBeNull()
+    const stub = screen.getByTestId('stub-mermaid')
+    expect(stub).toHaveTextContent('graph TD; A-->B')
+    // surrounding markdown preserved
+    expect(container.textContent).toContain('intro')
+    expect(container.textContent).toContain('outro')
+  })
+})

--- a/packages/dashboard/src/components/MarkdownBody.tsx
+++ b/packages/dashboard/src/components/MarkdownBody.tsx
@@ -21,8 +21,21 @@ import { handleMarkdownBodyClick } from '../lib/codeCopy'
 import { MermaidDiagram } from './MermaidDiagram'
 
 export function MarkdownBody({ content }: { content: string }) {
-  const segments = useMemo(() => splitMermaidSegments(content), [content])
-  const hasMermaid = useMemo(() => segments.some((s) => s.type === 'mermaid'), [segments])
+  // Cheap early-out BEFORE the full fence-scanning split: a real ```mermaid
+  // fence always contains the literal substring "mermaid", so this plain
+  // `includes` can never false-negative a real fence. It CAN false-positive
+  // (prose that merely mentions "mermaid" without a fence) — that case just
+  // falls through to `splitMermaidSegments`, which correctly finds no fence
+  // and this component takes the identical fast-path render below. This
+  // keeps the overwhelmingly common no-mermaid message from paying for a
+  // full regex scan on every render, on top of `renderMarkdown`'s own scan.
+  const mightHaveMermaid = content.includes('mermaid')
+
+  const segments = useMemo(
+    () => (mightHaveMermaid ? splitMermaidSegments(content) : null),
+    [content, mightHaveMermaid],
+  )
+  const hasMermaid = segments !== null && segments.some((s) => s.type === 'mermaid')
 
   // Fast path: no mermaid → byte-for-byte the pre-#6754 render.
   if (!hasMermaid) {
@@ -31,7 +44,7 @@ export function MarkdownBody({ content }: { content: string }) {
 
   return (
     <div onClick={handleMarkdownBodyClick} className="markdown-body-mixed">
-      {segments.map((seg, i) =>
+      {segments!.map((seg, i) =>
         seg.type === 'mermaid' ? (
           <MermaidDiagram key={i} source={seg.content} />
         ) : (

--- a/packages/dashboard/src/components/MarkdownBody.tsx
+++ b/packages/dashboard/src/components/MarkdownBody.tsx
@@ -1,0 +1,43 @@
+/**
+ * MarkdownBody (#6754) — the response/tool_use message body.
+ *
+ * Previously ChatView rendered the body as a single
+ * `<div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={renderMarkdown(content)} />`.
+ * That is preserved verbatim for the common case (no mermaid fence): same DOM,
+ * same delegated copy/link click handler, so nothing changes for existing
+ * messages.
+ *
+ * When the message contains a ```mermaid fence, the content is split into
+ * ordered segments (`splitMermaidSegments`): markdown segments keep the
+ * untouched string pipeline, mermaid segments render via `MermaidDiagram`. The
+ * delegated `onClick` moves to the outer wrapper — it uses `closest()`, so
+ * copy-button / link clicks inside any inner segment (including a mermaid
+ * block's code-block fallback) still resolve correctly.
+ */
+import { useMemo } from 'react'
+import { renderMarkdown } from '../lib/markdown'
+import { splitMermaidSegments } from '../lib/mermaid'
+import { handleMarkdownBodyClick } from '../lib/codeCopy'
+import { MermaidDiagram } from './MermaidDiagram'
+
+export function MarkdownBody({ content }: { content: string }) {
+  const segments = useMemo(() => splitMermaidSegments(content), [content])
+  const hasMermaid = useMemo(() => segments.some((s) => s.type === 'mermaid'), [segments])
+
+  // Fast path: no mermaid → byte-for-byte the pre-#6754 render.
+  if (!hasMermaid) {
+    return <div onClick={handleMarkdownBodyClick} dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
+  }
+
+  return (
+    <div onClick={handleMarkdownBodyClick} className="markdown-body-mixed">
+      {segments.map((seg, i) =>
+        seg.type === 'mermaid' ? (
+          <MermaidDiagram key={i} source={seg.content} />
+        ) : (
+          <div key={i} dangerouslySetInnerHTML={{ __html: renderMarkdown(seg.content) }} />
+        ),
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/MermaidDiagram.test.tsx
+++ b/packages/dashboard/src/components/MermaidDiagram.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * MermaidDiagram tests (#6754).
+ *
+ * `mermaid` is mocked so the test is deterministic and never pulls the real
+ * (large, browser-oriented) engine: a valid source resolves to a fake `<svg>`,
+ * a source containing `INVALID` rejects — exercising both the happy path (SVG
+ * injected) and the mandatory parse-error fallback (raw code block + error).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { MermaidDiagram } from './MermaidDiagram'
+
+const initialize = vi.fn()
+const renderFn = vi.fn(async (_id: string, src: string) => {
+  if (src.includes('INVALID')) throw new Error('Parse error on line 1')
+  return { svg: `<svg data-mermaid="1"><g><text>${src.trim()}</text></g></svg>` }
+})
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: (...args: unknown[]) => initialize(...args),
+    render: (id: string, src: string) => renderFn(id, src),
+  },
+}))
+
+afterEach(cleanup)
+// NB: `initialize` is intentionally NOT cleared between tests — the component
+// guards it to run once per page load, so only the first render in this file
+// calls it. `initialize.mock.calls[0]` therefore holds that one strict config
+// regardless of which test inspects it.
+beforeEach(() => {
+  renderFn.mockClear()
+})
+
+describe('MermaidDiagram', () => {
+  it('shows a loading placeholder before the async render resolves', () => {
+    render(<MermaidDiagram source="graph TD; A-->B" />)
+    expect(screen.getByTestId('mermaid-loading')).toBeInTheDocument()
+  })
+
+  it('renders sanitized SVG for a valid diagram', async () => {
+    render(<MermaidDiagram source="graph TD; A-->B" />)
+    const el = await screen.findByTestId('mermaid-diagram')
+    expect(el.querySelector('svg')).not.toBeNull()
+    // textContent decodes entities (innerHTML serializes `>` as `&gt;`)
+    expect(el.textContent).toContain('A-->B')
+  })
+
+  it('initializes mermaid with strict security level', async () => {
+    render(<MermaidDiagram source="graph TD; A-->B" />)
+    await screen.findByTestId('mermaid-diagram')
+    expect(initialize).toHaveBeenCalled()
+    const cfg = initialize.mock.calls[0]![0] as Record<string, unknown>
+    expect(cfg.securityLevel).toBe('strict')
+    expect(cfg.htmlLabels).toBe(false)
+  })
+
+  it('falls back to the raw code block (with the error) when the diagram is invalid', async () => {
+    render(<MermaidDiagram source="INVALID not a diagram" />)
+    const fallback = await screen.findByTestId('mermaid-fallback')
+    // parse error surfaced
+    expect(screen.getByTestId('mermaid-error')).toHaveTextContent('Parse error on line 1')
+    // and the source is preserved as a code block, not lost
+    expect(fallback.querySelector('pre')).not.toBeNull()
+    expect(fallback.textContent).toContain('INVALID not a diagram')
+    // no diagram was injected
+    expect(screen.queryByTestId('mermaid-diagram')).toBeNull()
+  })
+
+  it('re-renders when the source changes', async () => {
+    const { rerender } = render(<MermaidDiagram source="graph TD; A-->B" />)
+    await screen.findByTestId('mermaid-diagram')
+    rerender(<MermaidDiagram source="graph TD; C-->D" />)
+    await waitFor(() => {
+      expect(screen.getByTestId('mermaid-diagram').textContent).toContain('C-->D')
+    })
+  })
+})

--- a/packages/dashboard/src/components/MermaidDiagram.test.tsx
+++ b/packages/dashboard/src/components/MermaidDiagram.test.tsx
@@ -75,4 +75,35 @@ describe('MermaidDiagram', () => {
       expect(screen.getByTestId('mermaid-diagram').textContent).toContain('C-->D')
     })
   })
+
+  // Defense in depth (#6985): every other test here mocks mermaid.render()
+  // to return BENIGN SVG, so none of them prove the layer-2 DOMPurify.sanitize
+  // call actually strips anything — a refactor that silently dropped it would
+  // still pass. Mock a MALICIOUS render result (as if mermaid's own strict
+  // sanitization were bypassed or buggy) and assert the DOM we actually mount
+  // is clean, proving the second sanitize pass is load-bearing.
+  it('strips a malicious payload from the rendered SVG even if mermaid itself lets it through', async () => {
+    renderFn.mockImplementationOnce(async () => ({
+      svg:
+        '<svg data-mermaid="1">' +
+        '<script>window.__xss = "script"</script>' +
+        '<g onerror="window.__xss = &quot;onerror&quot;"><text>A</text></g>' +
+        '<foreignObject><div onclick="window.__xss = &quot;onclick&quot;">evil</div></foreignObject>' +
+        '<text>valid label</text>' +
+        '</svg>',
+    }))
+    render(<MermaidDiagram source="graph TD; A-->B" />)
+    const el = await screen.findByTestId('mermaid-diagram')
+
+    // The malicious elements/attributes are gone...
+    expect(el.querySelector('script')).toBeNull()
+    expect(el.querySelector('foreignObject')).toBeNull()
+    expect(el.innerHTML).not.toContain('onerror')
+    expect(el.innerHTML).not.toContain('onclick')
+    expect(el.textContent).not.toContain('__xss')
+    // ...while the legitimate diagram content survives (proves the SVG
+    // profile isn't just nuking the whole payload — it's targeted removal).
+    expect(el.querySelector('svg')).not.toBeNull()
+    expect(el.textContent).toContain('valid label')
+  })
 })

--- a/packages/dashboard/src/components/MermaidDiagram.tsx
+++ b/packages/dashboard/src/components/MermaidDiagram.tsx
@@ -77,9 +77,12 @@ export function MermaidDiagram({ source }: { source: string }) {
         const { svg } = await mermaid.render(id, source)
         if (cancelled) return
         // Defense in depth: mermaid strict already sanitizes, but re-run
-        // DOMPurify (its default profile keeps SVG + <style> while stripping
-        // <script>/`on*` handlers) before we inject the markup.
-        const clean = DOMPurify.sanitize(svg)
+        // DOMPurify (with the SVG profile — same as the QR-code sanitize
+        // calls elsewhere in the dashboard) before we inject the markup. The
+        // default HTML profile can strip legitimate SVG elements/attributes
+        // (breaking valid diagrams); the SVG profile both preserves the
+        // markup mermaid emits and narrows the allowed surface to SVG.
+        const clean = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } })
         setState({ status: 'rendered', svg: clean })
       } catch (err) {
         if (cancelled) return

--- a/packages/dashboard/src/components/MermaidDiagram.tsx
+++ b/packages/dashboard/src/components/MermaidDiagram.tsx
@@ -1,0 +1,125 @@
+/**
+ * MermaidDiagram (#6754) — renders a ```mermaid fence as an actual diagram.
+ *
+ * Security model (mandatory — the diagram source is MODEL-controlled and could
+ * be adversarial):
+ *  - mermaid is initialized with `securityLevel: 'strict'`, which sanitizes
+ *    node labels, disables click handlers / arbitrary-HTML labels, and runs the
+ *    generated SVG through mermaid's own internal DOMPurify pass before
+ *    returning it. `htmlLabels` is forced off (no `<foreignObject>` HTML escape
+ *    hatch) at every level that accepts it.
+ *  - We never `dangerouslySetInnerHTML` the raw model text. We call
+ *    `mermaid.render()` (which returns sanitized SVG) and then run that SVG
+ *    through DOMPurify AGAIN (defense in depth) before injecting it.
+ *
+ * Robustness:
+ *  - mermaid is LAZY-loaded via a dynamic `import()` so the (large) engine is a
+ *    separate bundle chunk pulled only when a mermaid block actually renders —
+ *    it never bloats the dashboard's initial load.
+ *  - Models frequently emit broken mermaid. A parse/render failure (or a
+ *    failure to even load the chunk, e.g. offline) MUST NOT break the message:
+ *    we catch it and fall back to the exact code-block render the normal
+ *    pipeline would have produced (`renderMarkdown` of the re-fenced source),
+ *    with the syntax error shown above it, so the user always keeps the source.
+ *  - `mermaid.render()` is async; the loading state shows a compact placeholder.
+ */
+import { useEffect, useState } from 'react'
+import DOMPurify from 'dompurify'
+import { renderMarkdown } from '../lib/markdown'
+
+/** Minimal surface of the mermaid module we depend on (keeps us off `any`). */
+interface MermaidApi {
+  initialize: (config: Record<string, unknown>) => void
+  render: (id: string, source: string) => Promise<{ svg: string }>
+}
+
+// Monotonic id for the transient element mermaid renders into. Must be a valid
+// DOM/CSS id (mermaid does `document.querySelector('#' + id)`), so no colons —
+// hence a plain counter rather than React's `useId()` (which yields `:r1:`).
+let idCounter = 0
+// mermaid.initialize is global + idempotent; run it once per page load.
+let initialized = false
+
+async function loadMermaid(): Promise<MermaidApi> {
+  const mod = (await import('mermaid')) as unknown as { default?: MermaidApi } & Partial<MermaidApi>
+  const mermaid = (mod.default ?? (mod as unknown as MermaidApi))
+  if (!initialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      // Dashboard is dark-navy; mermaid's `dark` theme reads well on it.
+      theme: 'dark',
+      // Belt-and-braces: keep HTML labels off everywhere so no `<foreignObject>`
+      // HTML is ever generated from model-controlled label text.
+      htmlLabels: false,
+      flowchart: { htmlLabels: false },
+    })
+    initialized = true
+  }
+  return mermaid
+}
+
+type RenderState =
+  | { status: 'loading' }
+  | { status: 'rendered'; svg: string }
+  | { status: 'error'; message: string }
+
+export function MermaidDiagram({ source }: { source: string }) {
+  const [state, setState] = useState<RenderState>({ status: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    setState({ status: 'loading' })
+    void (async () => {
+      try {
+        const mermaid = await loadMermaid()
+        const id = `chroxy-mermaid-${++idCounter}`
+        const { svg } = await mermaid.render(id, source)
+        if (cancelled) return
+        // Defense in depth: mermaid strict already sanitizes, but re-run
+        // DOMPurify (its default profile keeps SVG + <style> while stripping
+        // <script>/`on*` handlers) before we inject the markup.
+        const clean = DOMPurify.sanitize(svg)
+        setState({ status: 'rendered', svg: clean })
+      } catch (err) {
+        if (cancelled) return
+        setState({ status: 'error', message: err instanceof Error ? err.message : String(err) })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [source])
+
+  if (state.status === 'rendered') {
+    return (
+      <div
+        className="mermaid-diagram"
+        data-testid="mermaid-diagram"
+        // Sanitized (mermaid strict + DOMPurify) SVG string — see above.
+        dangerouslySetInnerHTML={{ __html: state.svg }}
+      />
+    )
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <div className="mermaid-loading" data-testid="mermaid-loading">
+        Rendering diagram…
+      </div>
+    )
+  }
+
+  // Error → the exact code-block render the normal pipeline would have produced
+  // (so it looks like any other fenced block, copy button included), with the
+  // parse error above it. Reconstruct the fence from the inner source.
+  const fallbackHtml = renderMarkdown('```mermaid\n' + source + '```')
+  return (
+    <div className="mermaid-error" data-testid="mermaid-fallback">
+      <div className="mermaid-error-note" data-testid="mermaid-error">
+        Diagram failed to render: {state.message}
+      </div>
+      <div dangerouslySetInnerHTML={{ __html: fallbackHtml }} />
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/mermaid.test.ts
+++ b/packages/dashboard/src/lib/mermaid.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Mermaid fence detection/split tests (#6754).
+ */
+import { describe, it, expect } from 'vitest'
+import { splitMermaidSegments, hasMermaidBlock, type MessageSegment } from './mermaid'
+
+describe('hasMermaidBlock', () => {
+  it('is false for empty / plain text', () => {
+    expect(hasMermaidBlock('')).toBe(false)
+    expect(hasMermaidBlock(undefined as unknown as string)).toBe(false)
+    expect(hasMermaidBlock('just some prose about mermaids')).toBe(false)
+  })
+
+  it('is true for a complete mermaid fence', () => {
+    expect(hasMermaidBlock('```mermaid\ngraph TD; A-->B\n```')).toBe(true)
+  })
+
+  it('is false for other-language fences', () => {
+    expect(hasMermaidBlock('```js\nconst x = 1\n```')).toBe(false)
+    expect(hasMermaidBlock('```\nplain\n```')).toBe(false)
+  })
+
+  it('is false for an unclosed (streaming) mermaid fence', () => {
+    expect(hasMermaidBlock('```mermaid\ngraph TD; A-->B')).toBe(false)
+  })
+
+  it('matches the language token case-insensitively and ignores trailing info', () => {
+    expect(hasMermaidBlock('```Mermaid\ngraph TD; A-->B\n```')).toBe(true)
+    expect(hasMermaidBlock('```mermaid  title=x\ngraph TD; A-->B\n```')).toBe(true)
+  })
+})
+
+describe('splitMermaidSegments', () => {
+  const types = (segs: MessageSegment[]) => segs.map((s) => s.type)
+
+  it('returns [] for empty input', () => {
+    expect(splitMermaidSegments('')).toEqual([])
+  })
+
+  it('returns a single markdown segment when there is no mermaid fence', () => {
+    const segs = splitMermaidSegments('# Title\n\n```js\nx()\n```')
+    expect(segs).toHaveLength(1)
+    expect(segs[0]).toEqual({ type: 'markdown', content: '# Title\n\n```js\nx()\n```' })
+  })
+
+  it('extracts a lone mermaid fence as the inner source only', () => {
+    const segs = splitMermaidSegments('```mermaid\ngraph TD; A-->B\n```')
+    expect(types(segs)).toEqual(['mermaid'])
+    expect(segs[0]!.content).toBe('graph TD; A-->B\n')
+  })
+
+  it('preserves surrounding markdown around a mermaid fence, in order', () => {
+    const segs = splitMermaidSegments('intro text\n\n```mermaid\ngraph TD; A-->B\n```\n\noutro text')
+    expect(types(segs)).toEqual(['markdown', 'mermaid', 'markdown'])
+    expect(segs[0]!.content).toContain('intro text')
+    expect(segs[1]!.content).toBe('graph TD; A-->B\n')
+    expect(segs[2]!.content).toContain('outro text')
+  })
+
+  it('handles multiple mermaid fences interleaved with text', () => {
+    const segs = splitMermaidSegments('a\n```mermaid\nA\n```\nb\n```mermaid\nB\n```\nc')
+    expect(types(segs)).toEqual(['markdown', 'mermaid', 'markdown', 'mermaid', 'markdown'])
+    expect(segs[1]!.content).toBe('A\n')
+    expect(segs[3]!.content).toBe('B\n')
+  })
+
+  it('leaves other-language fences inside the markdown segment (does not split them)', () => {
+    const segs = splitMermaidSegments('```js\nx()\n```\n\n```mermaid\ngraph TD; A-->B\n```')
+    expect(types(segs)).toEqual(['markdown', 'mermaid'])
+    // the js fence stays verbatim inside the markdown segment
+    expect(segs[0]!.content).toContain('```js')
+    expect(segs[0]!.content).toContain('x()')
+  })
+
+  it('treats an unclosed mermaid fence as plain markdown (streaming)', () => {
+    const segs = splitMermaidSegments('```mermaid\ngraph TD; A-->B')
+    expect(types(segs)).toEqual(['markdown'])
+    expect(segs[0]!.content).toContain('```mermaid')
+  })
+})

--- a/packages/dashboard/src/lib/mermaid.ts
+++ b/packages/dashboard/src/lib/mermaid.ts
@@ -1,0 +1,91 @@
+/**
+ * Mermaid fence detection (#6754).
+ *
+ * `renderMarkdown` (lib/markdown.ts) treats every fenced code block the same:
+ * run it through the shared syntax tokenizer and wrap it in `<pre><code>`.
+ * To render a ```mermaid fence as an actual diagram, the dashboard splits a
+ * message into ordered segments BEFORE it hits `renderMarkdown` — mermaid
+ * fences become their own `MermaidDiagram` component, everything else stays on
+ * the untouched string pipeline.
+ *
+ * The fence grammar here MUST match `renderMarkdown`'s exactly (same regex,
+ * same "first whitespace-delimited token is the language" rule) so a fence the
+ * markdown renderer would highlight as `mermaid` is the same one this splits
+ * out — no drift between "what renders as a diagram" and "what would have been
+ * highlighted". Only mermaid fences are cut; every other fence (js, python,
+ * bare) is left INSIDE the surrounding markdown segment and rendered by the
+ * normal pipeline, so this split is transparent for the 99% case with no
+ * mermaid.
+ *
+ * Pure + string-only so it is unit-testable without a DOM.
+ */
+
+export type MessageSegmentType = 'markdown' | 'mermaid'
+
+export interface MessageSegment {
+  type: MessageSegmentType
+  /**
+   * For a `markdown` segment: the raw markdown slice (fed to `renderMarkdown`).
+   * For a `mermaid` segment: the inner diagram source (the fence body, without
+   * the ```mermaid opener / closing ```).
+   */
+  content: string
+}
+
+/**
+ * The fence grammar, kept identical to `renderMarkdown`'s inline regex:
+ * an opening ``` with an optional info string on the same line, a newline, a
+ * lazily-matched body, then a closing ```. A fresh RegExp is created per call
+ * (not a shared module-level literal) so the stateful `g`-flag `lastIndex`
+ * can never leak across invocations.
+ */
+function fenceRegex(): RegExp {
+  return /```([^\n]*)?\n([\s\S]*?)```/g
+}
+
+/** The language token = first whitespace-delimited word of the info string. */
+function fenceLang(rawLang: string | undefined): string {
+  return rawLang ? rawLang.trim().split(/\s+/)[0]!.toLowerCase() : ''
+}
+
+/** True when `text` contains at least one complete (closed) ```mermaid fence. */
+export function hasMermaidBlock(text: string): boolean {
+  if (!text) return false
+  const re = fenceRegex()
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    if (fenceLang(m[1]) === 'mermaid') return true
+  }
+  return false
+}
+
+/**
+ * Split a message into ordered segments, cutting ONLY at complete ```mermaid
+ * fences. Returns a single `markdown` segment when there is no mermaid fence
+ * (including for a message that is entirely other-language code), and `[]` for
+ * empty input. An incomplete/streaming mermaid fence (opener typed, closer not
+ * yet arrived) does not match the grammar, so it stays inside a `markdown`
+ * segment and renders as text until it closes — then the next parse splits it
+ * out as a diagram.
+ */
+export function splitMermaidSegments(text: string): MessageSegment[] {
+  if (!text) return []
+  const segments: MessageSegment[] = []
+  const re = fenceRegex()
+  let lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    if (fenceLang(m[1]) !== 'mermaid') continue // leave non-mermaid fences in the markdown text
+    const before = text.slice(lastIndex, m.index)
+    if (before) segments.push({ type: 'markdown', content: before })
+    segments.push({ type: 'mermaid', content: m[2]! })
+    lastIndex = m.index + m[0].length
+  }
+  const after = text.slice(lastIndex)
+  if (after) segments.push({ type: 'markdown', content: after })
+  // No mermaid fence at all → the whole message is one markdown segment. (The
+  // loop's `after` slice already produces this, but guard the theoretical
+  // all-consumed case so callers always get at least one segment.)
+  if (segments.length === 0) segments.push({ type: 'markdown', content: text })
+  return segments
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3463,6 +3463,46 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-green, #22c55e);
 }
 
+/* #6754 — rendered ```mermaid diagrams. The SVG comes from mermaid (strict +
+   DOMPurify sanitized) and is centered in a padded card that matches the
+   code-block surface, so a diagram sits in the transcript like any other
+   block. `max-width` + `height:auto` on the SVG keeps a wide flowchart inside
+   the bubble (it scales down rather than forcing horizontal page scroll). */
+.mermaid-diagram {
+  display: flex;
+  justify-content: center;
+  margin: 8px 0;
+  padding: 12px;
+  background: var(--bg-code-block);
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  border-radius: var(--radius-sm, 6px);
+  overflow-x: auto;
+}
+
+.mermaid-diagram svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Loading placeholder while the (lazy-loaded) mermaid chunk renders. */
+.mermaid-loading {
+  margin: 8px 0;
+  padding: 12px;
+  font-size: 0.85em;
+  color: var(--text-muted);
+  background: var(--bg-code-block);
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  border-radius: var(--radius-sm, 6px);
+}
+
+/* Parse/render failure → the syntax error above the raw code-block fallback
+   (the `<pre><code>` inside is styled by the shared `.msg pre` rules). */
+.mermaid-error-note {
+  margin: 8px 0 4px;
+  font-size: 0.8em;
+  color: var(--text-error, #f87171);
+}
+
 .msg code {
   font-family: var(--font-mono);
   background: var(--bg-code-block);


### PR DESCRIPTION
## What

Renders a fenced ```mermaid code block as an actual diagram (flowchart, sequence, state, etc.) in the dashboard chat, instead of a raw `<pre><code>` text box — parity with the Claude.ai / Claude Code surfaces.

Closes #6754
Closes #6985

## Approach

The dashboard markdown pipeline is a synchronous string → HTML renderer (`renderMarkdown`) injected via `dangerouslySetInnerHTML`. Mermaid rendering is async and produces SVG, so the message is split into segments **before** it hits the string pipeline:

- **`lib/mermaid.ts`** — `splitMermaidSegments()` cuts a message into ordered `markdown` / `mermaid` segments using the **same fence grammar** as `renderMarkdown` (same regex, same "first token is the language" rule), so what renders as a diagram is exactly what would otherwise have been highlighted. **Only** mermaid fences are diverted; every other language (js, python, bare) stays inside the markdown segment on the untouched highlight path. Pure + string-only → unit-tested without a DOM.
- **`components/MermaidDiagram.tsx`** — a dedicated component that renders the diagram.
- **`components/MarkdownBody.tsx`** — routes segments (markdown → `renderMarkdown`, mermaid → `MermaidDiagram`). For the common **no-mermaid** case it takes a fast path that is byte-for-byte the prior single-`innerHTML` render, so the delegated copy/link click handler and existing behavior are unchanged.
- **`ChatView.tsx`** — response/tool_use bodies now render through `MarkdownBody`.

## Security (mandatory — diagram source is model-controlled)

- mermaid is initialized with **`securityLevel: 'strict'`** (sanitizes labels, disables click handlers / arbitrary-HTML labels, runs its own DOMPurify pass on the SVG). `htmlLabels` is forced **off** at every level (no `<foreignObject>` HTML escape hatch).
- We never `dangerouslySetInnerHTML` raw model text — we call `mermaid.render()` (which returns sanitized SVG) and then run that SVG through **DOMPurify again** (defense in depth) before injecting it.

## Parse-error fallback (mandatory)

Models frequently emit broken mermaid. A parse/render failure — **or a chunk-load failure** (e.g. offline) — is caught and falls back to the exact code-block render the normal pipeline would produce (`renderMarkdown` of the re-fenced source), with the syntax error shown above it. The user always keeps the source; a malformed diagram never breaks the message.

## Lazy-load / bundle impact

mermaid (large) is pulled via a dynamic `import()` and code-splits into its own chunks — it is **not** in the initial bundle. Verified in `vite build`:

- `mermaid.core-*.js` 592 kB (137 kB gzip) + per-diagram-type chunks (`flowDiagram`, `sequenceDiagram`, `cytoscape`, `katex`, …) — all loaded only when a mermaid block actually renders.
- Main `index` chunk contains **0** mermaid-engine identifiers (`mermaidAPI`, `flowchart-v2`); the `mermaid` string hits there are my CSS class names (`mermaid-diagram`) + the lazy-import chunk reference.

## How to visually verify (browser)

In a live dashboard session, send a prompt that yields a mermaid fence, e.g.:

> Reply with only a mermaid flowchart in a fenced code block, nothing else.

Or get a message whose content is:

    ```mermaid
    graph TD
      A[Start] --> B{Is it broken?}
      B -->|No| C[Ship it]
      B -->|Yes| D[Fix it] --> B
    ```

Expected: a rendered flowchart (dark theme, centered in a code-surface card), **not** highlighted text.

To verify the **fallback**, use an invalid diagram:

    ```mermaid
    graph TD
      A --> ??? this is not valid
    ```

Expected: a red "Diagram failed to render: …" line above the raw code block (source preserved).

## Mobile

**Deferred** — React Native has no DOM/SVG mermaid engine; `MarkdownRenderer.tsx` is a hand-rolled RN tree. Mobile stays on the raw code block (unchanged). Follow-up filed: **#6981** (WebView/SVG render + security + fallback parity).

## Tests

- `lib/mermaid.test.ts` — fence detection + split: mermaid vs other languages, case-insensitivity, multiple/interleaved fences, unclosed (streaming) fence stays markdown, other-language fences not split out.
- `components/MermaidDiagram.test.tsx` — mocks `mermaid.render`: valid source → `<svg>` injected; invalid → falls back to the code block with the error; strict-mode config asserted; loading state; re-render on source change.
- `components/MarkdownBody.test.tsx` — routing: no-mermaid fast path (no mixed wrapper), mermaid fence routed to the component with surrounding text preserved.

**Results:** dashboard `vitest run` — 279 files / 4777 tests green (20 new, incl. a defense-in-depth test that mocks a malicious `mermaid.render()` result and asserts DOMPurify strips it). `tsc --noEmit` clean. `vite build` succeeds with mermaid as separate lazy chunks. Server/store-core untouched.

## Review fixes

- Copilot review: `MermaidDiagram.tsx` now sanitizes with `DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } })` (matches the QR-code sanitize calls elsewhere in the dashboard) instead of the bare default profile.
- Copilot review: `MarkdownBody.tsx` adds a cheap `content.includes('mermaid')` early-out before `splitMermaidSegments()` runs, so the common no-mermaid message render skips the fence-scanning regex entirely.
- #6985: added a defense-in-depth test proving the layer-2 DOMPurify pass actually strips a malicious payload (`<script>`, `<foreignObject>`, `on*` handlers), not just that mermaid's own strict mode is trusted.

