### PR TITLE
feat(dashboard,store-core): structured WebSearch/WebFetch tool-result render with safe links

### DIFF
--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -29,6 +29,11 @@ let showBashPartialCounter = 0
 // invocations on the same session need unique toolUseIds so the
 // app's user_question handler doesn't collide on a fixed id.
 let showAskUserQuestionCounter = 0
+// #6757: per-trigger counters for the WebSearch/WebFetch structured-render
+// fixtures. Same rationale as `show-todos` — repeated invocations need
+// unique toolUseIds so React keys + tool_result patching stay independent.
+let showWebSearchCounter = 0
+let showWebFetchCounter = 0
 
 // #5468: connection counter — incremented once per `auth` message, used only
 // for the marker's text ("mock reconnect #N") + the [mock] Auth #N log line.
@@ -710,6 +715,105 @@ wss.on('connection', (ws) => {
             sessionId: 'mock-sess-1',
             toolUseId,
             result: todoResult,
+          })
+          secureSend(ws, { type: 'result', cost: 0.001, duration: 100, usage: {}, sessionId: 'mock-sess-1' })
+          secureSend(ws, { type: 'agent_idle', sessionId: 'mock-sess-1' })
+          break
+        }
+
+        // #6757: trigger phrase 'show-websearch' emits a synthetic WebSearch
+        // tool_use + tool_result so the structured result-list renderer
+        // (packages/dashboard/src/components/WebToolResult.tsx
+        // WebSearchResultList, driven by @chroxy/store-core's
+        // parseWebSearchResults) can be exercised end-to-end — over the
+        // real WS protocol, same path production tool messages take, no
+        // live WebSearch API call needed. Also usable from a browser: point
+        // a dashboard dev instance's "Add Server" (ServerPicker, manual
+        // entry) at ws://localhost:9876 with token 'test-token-maestro',
+        // open the session, and send this phrase in chat.
+        //
+        // The result payload is a JSON array of {title,url,snippet} —
+        // one of the shapes `parseWebSearchResults` recognizes (see
+        // packages/store-core/src/web-tool-results.ts).
+        if (text.trim() === 'show-websearch') {
+          secureSend(ws, { type: 'agent_busy', sessionId: 'mock-sess-1' })
+          showWebSearchCounter += 1
+          const toolUseId = `tu-websearch-mock-${showWebSearchCounter}`
+          const toolMessageId = `tool-websearch-mock-${showWebSearchCounter}`
+          secureSend(ws, {
+            type: 'tool_start',
+            sessionId: 'mock-sess-1',
+            tool: 'WebSearch',
+            input: { query: 'chroxy remote terminal' },
+            messageId: toolMessageId,
+            toolUseId,
+          })
+          const webSearchResult = JSON.stringify({
+            query: 'chroxy remote terminal',
+            results: [
+              {
+                title: 'chroxy — remote terminal for Claude Code',
+                url: 'https://github.com/blamechris/chroxy',
+                snippet: 'Run a lightweight daemon on your dev machine, connect from your phone via a secure tunnel.',
+              },
+              {
+                title: 'Chroxy docs — architecture reference',
+                url: 'https://github.com/blamechris/chroxy/blob/main/docs/architecture/reference.md',
+                snippet: 'Component tables, WebSocket protocol messages, and data flow diagrams.',
+              },
+              {
+                title: 'A result with an unsafe scheme (should be dropped, not rendered)',
+                url: 'javascript:alert(1)',
+              },
+            ],
+          })
+          secureSend(ws, {
+            type: 'tool_result',
+            sessionId: 'mock-sess-1',
+            toolUseId,
+            result: webSearchResult,
+          })
+          secureSend(ws, { type: 'result', cost: 0.001, duration: 100, usage: {}, sessionId: 'mock-sess-1' })
+          secureSend(ws, { type: 'agent_idle', sessionId: 'mock-sess-1' })
+          break
+        }
+
+        // #6757: trigger phrase 'show-webfetch' emits a synthetic WebFetch
+        // tool_use + tool_result so the markdown-formatted renderer
+        // (WebToolResult.tsx WebFetchResult, driven by
+        // @chroxy/store-core's parseWebFetchResult) can be exercised the
+        // same way as 'show-websearch' above.
+        //
+        // The result payload mirrors the BYOK executor's real wire shape
+        // (packages/server/src/byok-tool-executor.js runWebFetch):
+        // `Prompt: <p>\nURL: <u>\n\n<body>`.
+        if (text.trim() === 'show-webfetch') {
+          secureSend(ws, { type: 'agent_busy', sessionId: 'mock-sess-1' })
+          showWebFetchCounter += 1
+          const toolUseId = `tu-webfetch-mock-${showWebFetchCounter}`
+          const toolMessageId = `tool-webfetch-mock-${showWebFetchCounter}`
+          secureSend(ws, {
+            type: 'tool_start',
+            sessionId: 'mock-sess-1',
+            tool: 'WebFetch',
+            input: { url: 'https://example.com/chroxy', prompt: 'Summarize this page' },
+            messageId: toolMessageId,
+            toolUseId,
+          })
+          const webFetchResult = [
+            'Prompt: Summarize this page',
+            'URL: https://example.com/chroxy',
+            '',
+            '# Chroxy',
+            '',
+            'Chroxy is a **remote terminal app** for Claude Code. See also '
+              + 'https://github.com/blamechris/chroxy for the source.',
+          ].join('\n')
+          secureSend(ws, {
+            type: 'tool_result',
+            sessionId: 'mock-sess-1',
+            toolUseId,
+            result: webFetchResult,
           })
           secureSend(ws, { type: 'result', cost: 0.001, duration: 100, usage: {}, sessionId: 'mock-sess-1' })
           secureSend(ws, { type: 'agent_idle', sessionId: 'mock-sess-1' })

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -886,3 +886,54 @@ describe('ToolBubble', () => {
     })
   })
 })
+
+describe('ToolBubble — WebSearch/WebFetch structured render (#6757)', () => {
+  it('renders a WebSearch result as a structured list, not a <pre> dump', () => {
+    const result = JSON.stringify([
+      { title: 'Chroxy', url: 'https://github.com/blamechris/chroxy', snippet: 'Remote terminal app.' },
+    ])
+    render(<ToolBubble toolName="WebSearch" toolUseId="ws-1" result={result} isTail />)
+    expect(screen.getByTestId('web-search-results')).toBeInTheDocument()
+    expect(screen.getByTestId('web-search-result-link-0')).toHaveAttribute(
+      'href',
+      'https://github.com/blamechris/chroxy',
+    )
+    // The raw JSON must not leak into a <pre> alongside the structured render.
+    expect(document.querySelector('pre')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the raw <pre> render when a WebSearch result is unparseable', () => {
+    render(<ToolBubble toolName="WebSearch" toolUseId="ws-2" result="just some plain unstructured text" isTail />)
+    expect(screen.queryByTestId('web-search-results')).not.toBeInTheDocument()
+    expect(screen.getByText('just some plain unstructured text')).toBeInTheDocument()
+  })
+
+  it('renders a WebFetch result through the markdown pipeline, not a <pre> dump', () => {
+    const result = 'Prompt: Summarize\nURL: https://example.com/page\n\nThe **fetched** content.'
+    render(<ToolBubble toolName="WebFetch" toolUseId="wf-1" result={result} isTail />)
+    const content = screen.getByTestId('web-fetch-content')
+    expect(content.querySelector('strong')).toHaveTextContent('fetched')
+    expect(screen.getByTestId('web-fetch-source')).toHaveTextContent('https://example.com/page')
+    expect(document.querySelector('pre')).not.toBeInTheDocument()
+  })
+
+  it('still renders WebFetch content (never a bare fallback) when no header is present', () => {
+    render(<ToolBubble toolName="WebFetch" toolUseId="wf-2" result="Just fetched body text." isTail />)
+    expect(screen.getByTestId('web-fetch-content')).toHaveTextContent('Just fetched body text.')
+  })
+
+  it('leaves other tools on the existing raw <pre> render (only WebSearch/WebFetch get structured treatment)', () => {
+    const result = JSON.stringify([{ title: 'Not a search result', url: 'https://example.com/' }])
+    render(<ToolBubble toolName="Bash" toolUseId="bash-1" result={result} isTail />)
+    expect(screen.queryByTestId('web-search-results')).not.toBeInTheDocument()
+    expect(document.querySelector('pre')).toBeInTheDocument()
+  })
+
+  it('does not route a merely-similar tool name (web_search_results) into the structured renderer', () => {
+    // Regression guard: this exact tool name is used elsewhere to pin
+    // formatToolName's title-casing and must keep rendering plain text.
+    const result = JSON.stringify([{ title: 'X', url: 'https://example.com/' }])
+    render(<ToolBubble toolName="web_search_results" toolUseId="wsr-1" result={result} isTail />)
+    expect(screen.queryByTestId('web-search-results')).not.toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -31,9 +31,14 @@ import {
   shouldSuppressRawToolInput,
   TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD,
   TOOL_OUTPUT_COLLAPSE_HEAD_LINES,
+  isWebSearchToolName,
+  isWebFetchToolName,
+  parseWebSearchResults,
+  parseWebFetchResult,
 } from '@chroxy/store-core'
 import type { ChildAgentEvent, ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
+import { WebSearchResultList, WebFetchResult } from './WebToolResult'
 import { ChildAgentEventList } from './ChildAgentEventList'
 import { ImageLightbox } from './ImageLightbox'
 import { useInitialExpanded } from './chatExpandRegistry'
@@ -199,13 +204,29 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   const todoParsed = expanded && result && toolName === 'TodoWrite'
     ? parseTodoList(result)
     : null
+  // #6757 — WebSearch/WebFetch get the same parse-with-fallback-to-`<pre>`
+  // treatment as TodoWrite: a structured render when the result text
+  // parses cleanly, otherwise the tool falls through to the existing
+  // plain-text panel below with no data loss. The parse logic lives in
+  // `@chroxy/store-core` (`parseWebSearchResults` / `parseWebFetchResult`)
+  // so mobile can reuse it.
+  const webSearchParsed = expanded && result && isWebSearchToolName(toolName)
+    ? parseWebSearchResults(result)
+    : null
+  const webFetchParsed = expanded && result && isWebFetchToolName(toolName)
+    ? parseWebFetchResult(result)
+    : null
   // #6391 (slice 7): collapse a long tool result to its head behind a "Show N
   // more lines" pill. Independent of the bubble's own expand/collapse; the
   // per-row ResizeObserver (MeasuredRow, #5561) re-measures the row when this
   // toggles, so the virtualized list stays correct with no extra plumbing.
   const [resultExpanded, setResultExpanded] = useState(false)
   const resultLineCount = useMemo(() => (result ? result.split('\n').length : 0), [result])
-  const isLongResult = !todoParsed && resultLineCount > TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD
+  // #6757 — a structured WebSearch/WebFetch render owns its own layout
+  // (card list / markdown), so exclude both from the raw-text collapse
+  // pill exactly like `todoParsed` already does.
+  const isLongResult = !todoParsed && !webSearchParsed && !webFetchParsed
+    && resultLineCount > TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD
   // #4081: streaming preview — render the accumulator as a code block
   // while the result hasn't arrived. Best-effort pretty-print: try
   // JSON.parse first (the final delta often completes the JSON), fall
@@ -297,6 +318,10 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
         >
           {todoParsed ? (
             <TodoList parsed={todoParsed} />
+          ) : webSearchParsed ? (
+            <WebSearchResultList parsed={webSearchParsed} />
+          ) : webFetchParsed ? (
+            <WebFetchResult parsed={webFetchParsed} />
           ) : hasTextResult && isLongResult && !resultExpanded ? (
             <>
               <pre>{result!.split('\n').slice(0, TOOL_OUTPUT_COLLAPSE_HEAD_LINES).join('\n')}</pre>

--- a/packages/dashboard/src/components/WebToolResult.css
+++ b/packages/dashboard/src/components/WebToolResult.css
@@ -1,0 +1,81 @@
+/* Structured WebSearch/WebFetch tool_result renderers (#6757). */
+
+.web-search-results,
+.web-fetch-result {
+  font-family: var(--font-ui, system-ui, sans-serif);
+  white-space: normal;
+}
+
+.web-search-query {
+  font-weight: 600;
+  margin-bottom: var(--space-2, 8px);
+  color: var(--text-secondary, #ccc);
+  font-size: 0.9em;
+}
+
+.web-search-result-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+}
+
+.web-search-result-item {
+  padding: var(--space-2, 8px) var(--space-3, 12px);
+  border-left: 3px solid var(--accent-cyan, #22d3ee);
+  background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border-radius: var(--radius-sm, 6px);
+}
+
+.web-search-result-title {
+  display: block;
+  font-weight: 600;
+  color: var(--accent-cyan, #22d3ee);
+  text-decoration: none;
+  word-break: break-word;
+}
+
+a.web-search-result-title:hover {
+  text-decoration: underline;
+}
+
+.web-search-result-domain {
+  display: block;
+  font-size: 0.8em;
+  color: var(--text-muted, #888);
+  margin-top: 2px;
+}
+
+.web-search-result-snippet {
+  margin: var(--space-1, 4px) 0 0;
+  font-size: 0.9em;
+  color: var(--text-secondary, #ccc);
+  word-break: break-word;
+}
+
+.web-fetch-source {
+  margin-bottom: var(--space-2, 8px);
+  font-size: 0.85em;
+  word-break: break-all;
+}
+
+.web-fetch-source a {
+  color: var(--accent-cyan, #22d3ee);
+}
+
+.web-fetch-content {
+  font-size: 0.95em;
+  line-height: 1.5;
+  color: var(--text-secondary, #ccc);
+}
+
+.web-fetch-content a {
+  color: var(--accent-cyan, #22d3ee);
+}
+
+.web-fetch-content pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/packages/dashboard/src/components/WebToolResult.css
+++ b/packages/dashboard/src/components/WebToolResult.css
@@ -9,7 +9,7 @@
 .web-search-query {
   font-weight: 600;
   margin-bottom: var(--space-2, 8px);
-  color: var(--text-secondary, #ccc);
+  color: var(--text-secondary);
   font-size: 0.9em;
 }
 
@@ -24,15 +24,15 @@
 
 .web-search-result-item {
   padding: var(--space-2, 8px) var(--space-3, 12px);
-  border-left: 3px solid var(--accent-cyan, #22d3ee);
-  background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border-left: 3px solid var(--accent-cyan);
+  background: var(--bg-secondary);
   border-radius: var(--radius-sm, 6px);
 }
 
 .web-search-result-title {
   display: block;
   font-weight: 600;
-  color: var(--accent-cyan, #22d3ee);
+  color: var(--accent-cyan);
   text-decoration: none;
   word-break: break-word;
 }
@@ -44,14 +44,14 @@ a.web-search-result-title:hover {
 .web-search-result-domain {
   display: block;
   font-size: 0.8em;
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
   margin-top: 2px;
 }
 
 .web-search-result-snippet {
   margin: var(--space-1, 4px) 0 0;
   font-size: 0.9em;
-  color: var(--text-secondary, #ccc);
+  color: var(--text-secondary);
   word-break: break-word;
 }
 
@@ -62,17 +62,17 @@ a.web-search-result-title:hover {
 }
 
 .web-fetch-source a {
-  color: var(--accent-cyan, #22d3ee);
+  color: var(--accent-cyan);
 }
 
 .web-fetch-content {
   font-size: 0.95em;
   line-height: 1.5;
-  color: var(--text-secondary, #ccc);
+  color: var(--text-secondary);
 }
 
 .web-fetch-content a {
-  color: var(--accent-cyan, #22d3ee);
+  color: var(--accent-cyan);
 }
 
 .web-fetch-content pre {

--- a/packages/dashboard/src/components/WebToolResult.test.tsx
+++ b/packages/dashboard/src/components/WebToolResult.test.tsx
@@ -115,7 +115,10 @@ describe('WebFetchResult', () => {
     expect(document.querySelector('a[href^="javascript:"]')).not.toBeInTheDocument()
   })
 
-  it('does not use dangerouslySetInnerHTML for raw content — the markdown pipeline HTML-escapes non-markup text', () => {
+  it('HTML-escapes non-markup fetched content so no live element is created (XSS guard)', () => {
+    // WebFetchResult DOES render via dangerouslySetInnerHTML, but only with
+    // DOMPurify-sanitized output from renderMarkdown — non-markup text like an
+    // `<img onerror>` is HTML-escaped, so no live <img> element is ever built.
     render(<WebFetchResult parsed={{ content: '<img src=x onerror=alert(1)>' }} />)
     expect(document.querySelector('img[src="x"]')).not.toBeInTheDocument()
   })

--- a/packages/dashboard/src/components/WebToolResult.test.tsx
+++ b/packages/dashboard/src/components/WebToolResult.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * WebSearchResultList / WebFetchResult tests (#6757).
+ *
+ * The parser (`@chroxy/store-core`) is tested independently — these
+ * tests cover the render layer: safe links only (http/https, target,
+ * rel), escaped text (no raw HTML injection from title/snippet/query),
+ * and that the WebFetch markdown pipeline renders through the same
+ * sanitized path as chat messages.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import type { ParsedWebSearchResults, ParsedWebFetchResult } from '@chroxy/store-core'
+import { WebSearchResultList, WebFetchResult } from './WebToolResult'
+
+afterEach(cleanup)
+
+describe('WebSearchResultList', () => {
+  it('renders each result as a safe clickable link with domain + snippet', () => {
+    const parsed: ParsedWebSearchResults = {
+      query: 'chroxy',
+      results: [
+        { title: 'Chroxy on GitHub', url: 'https://github.com/blamechris/chroxy', snippet: 'Remote terminal app.' },
+        { title: 'Second Result', url: 'http://example.com/page' },
+      ],
+    }
+    render(<WebSearchResultList parsed={parsed} />)
+
+    expect(screen.getByTestId('web-search-query')).toHaveTextContent('chroxy')
+
+    const link0 = screen.getByTestId('web-search-result-link-0')
+    expect(link0).toHaveAttribute('href', 'https://github.com/blamechris/chroxy')
+    expect(link0).toHaveAttribute('target', '_blank')
+    expect(link0).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(link0).toHaveTextContent('Chroxy on GitHub')
+
+    const item0 = screen.getByTestId('web-search-result-0')
+    expect(item0).toHaveTextContent('github.com')
+    expect(item0).toHaveTextContent('Remote terminal app.')
+
+    const link1 = screen.getByTestId('web-search-result-link-1')
+    expect(link1).toHaveAttribute('href', 'http://example.com/page')
+  })
+
+  it('renders without a query header when query is absent', () => {
+    render(<WebSearchResultList parsed={{ results: [{ title: 'A', url: 'https://a.example.com/' }] }} />)
+    expect(screen.queryByTestId('web-search-query')).not.toBeInTheDocument()
+  })
+
+  it('escapes result text instead of interpreting it as HTML (XSS guard)', () => {
+    const parsed: ParsedWebSearchResults = {
+      results: [
+        {
+          title: '<img src=x onerror=alert(1)>',
+          url: 'https://example.com/',
+          snippet: '<script>alert(2)</script>',
+        },
+      ],
+    }
+    render(<WebSearchResultList parsed={parsed} />)
+    // React renders these as literal text nodes, not markup — no <img>/<script>
+    // element should be created from result content.
+    expect(document.querySelector('img[src="x"]')).not.toBeInTheDocument()
+    expect(document.querySelector('script')).not.toBeInTheDocument()
+    expect(screen.getByTestId('web-search-result-0').textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+
+  it('never renders an <a href> for a URL that fails the safety check (defense in depth)', () => {
+    // The parser is expected to have already filtered unsafe schemes, but the
+    // render layer must not trust that blindly — simulate a value that
+    // slipped through (e.g. a future parser regression) and confirm no <a>
+    // is emitted for it.
+    const parsed: ParsedWebSearchResults = {
+      results: [{ title: 'Should not link', url: 'javascript:alert(1)' }],
+    }
+    render(<WebSearchResultList parsed={parsed} />)
+    expect(screen.queryByTestId('web-search-result-link-0')).not.toBeInTheDocument()
+    expect(screen.getByTestId('web-search-result-0')).toHaveTextContent('Should not link')
+    expect(document.querySelector('a[href^="javascript:"]')).not.toBeInTheDocument()
+  })
+})
+
+describe('WebFetchResult', () => {
+  it('renders the source URL as a safe link and the content via markdown', () => {
+    const parsed: ParsedWebFetchResult = {
+      url: 'https://example.com/article',
+      prompt: 'Summarize',
+      content: 'The **article** body with a https://example.com/other link.',
+    }
+    render(<WebFetchResult parsed={parsed} />)
+
+    const source = screen.getByTestId('web-fetch-source')
+    const link = source.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link).toHaveAttribute('href', 'https://example.com/article')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+
+    const content = screen.getByTestId('web-fetch-content')
+    expect(content.querySelector('strong')).toHaveTextContent('article')
+    // Embedded bare URL autolinked by the shared markdown pipeline.
+    const contentLink = content.querySelector('a[href="https://example.com/other"]')
+    expect(contentLink).not.toBeNull()
+    expect(contentLink).toHaveAttribute('target', '_blank')
+  })
+
+  it('omits the source header when no url was parsed', () => {
+    render(<WebFetchResult parsed={{ content: 'Just body text.' }} />)
+    expect(screen.queryByTestId('web-fetch-source')).not.toBeInTheDocument()
+    expect(screen.getByTestId('web-fetch-content')).toHaveTextContent('Just body text.')
+  })
+
+  it('never renders a javascript: url as the source link', () => {
+    render(<WebFetchResult parsed={{ url: 'javascript:alert(1)', content: 'Body.' }} />)
+    expect(screen.queryByTestId('web-fetch-source')).not.toBeInTheDocument()
+    expect(document.querySelector('a[href^="javascript:"]')).not.toBeInTheDocument()
+  })
+
+  it('does not use dangerouslySetInnerHTML for raw content — the markdown pipeline HTML-escapes non-markup text', () => {
+    render(<WebFetchResult parsed={{ content: '<img src=x onerror=alert(1)>' }} />)
+    expect(document.querySelector('img[src="x"]')).not.toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/WebToolResult.test.tsx
+++ b/packages/dashboard/src/components/WebToolResult.test.tsx
@@ -119,4 +119,26 @@ describe('WebFetchResult', () => {
     render(<WebFetchResult parsed={{ content: '<img src=x onerror=alert(1)>' }} />)
     expect(document.querySelector('img[src="x"]')).not.toBeInTheDocument()
   })
+
+  it('neutralizes a protocol-relative //host link embedded in fetched content (#6986)', () => {
+    // The exact link-injection vector: a WebFetch of an attacker-controlled
+    // page whose (model/web-controlled) content embeds a markdown link to an
+    // external origin via `//host`. The shared allowlist markdown gate must
+    // NOT emit a functional anchor for it — otherwise it is openable via
+    // middle-click / right-click "Open Link in New Tab" despite the click gate.
+    render(<WebFetchResult parsed={{ content: 'Read more: [click here](//evil.example/steal)' }} />)
+    const content = screen.getByTestId('web-fetch-content')
+    expect(content.querySelector('a')).toBeNull()
+    expect(document.querySelector('a[href^="//evil"]')).not.toBeInTheDocument()
+    // The link text survives as plain text.
+    expect(content).toHaveTextContent('click here')
+  })
+
+  it('still renders a legitimate https markdown link in fetched content', () => {
+    render(<WebFetchResult parsed={{ content: 'See [the docs](https://example.com/docs).' }} />)
+    const content = screen.getByTestId('web-fetch-content')
+    const link = content.querySelector('a[href="https://example.com/docs"]')
+    expect(link).not.toBeNull()
+    expect(link).toHaveAttribute('target', '_blank')
+  })
 })

--- a/packages/dashboard/src/components/WebToolResult.tsx
+++ b/packages/dashboard/src/components/WebToolResult.tsx
@@ -1,0 +1,108 @@
+/**
+ * Structured WebSearch/WebFetch tool-result renderers (#6757).
+ *
+ * `ToolBubble` special-cased TodoWrite (#4139) and Task (#5016) results
+ * with a dedicated structured render, parse-with-fallback-to-`<pre>`.
+ * This extends the same pattern to WebSearch (a list of clickable source
+ * cards) and WebFetch (the fetched page run through the existing
+ * markdown pipeline). The parse logic (`parseWebSearchResults` /
+ * `parseWebFetchResult`) lives in `@chroxy/store-core` so mobile can
+ * reuse it; these components are the dashboard-side render only.
+ *
+ * Security: `url` in both shapes is model/web-controlled content — the
+ * parser already filters to http(s)-only via `isSafeWebUrl`, but every
+ * `<a href>` here re-checks it before rendering as a link (defense in
+ * depth, matching `lib/markdown.ts` + `lib/links.ts`'s parse-time +
+ * click-time double gate). All text is rendered as plain React children
+ * (auto-escaped) — WebFetch's body is the one exception, which reuses
+ * `renderMarkdown` (the same DOMPurify-sanitized pipeline `ChatMessage`
+ * uses for assistant prose) rather than a bespoke unescaped path.
+ */
+import { useMemo } from 'react'
+import type { ParsedWebSearchResults, ParsedWebFetchResult } from '@chroxy/store-core'
+import { isSafeWebUrl } from '@chroxy/store-core'
+import { renderMarkdown } from '../lib/markdown'
+import { handleMarkdownLinkClick } from '../lib/links'
+import './WebToolResult.css'
+
+function domainFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+export interface WebSearchResultListProps {
+  parsed: ParsedWebSearchResults
+}
+
+/** WebSearch: a compact list of source cards (title, domain, snippet) —
+ *  the desktop-app-parity treatment cited in #6757, replacing the raw
+ *  joined-text dump. */
+export function WebSearchResultList({ parsed }: WebSearchResultListProps) {
+  return (
+    <div className="web-search-results" data-testid="web-search-results">
+      {parsed.query && (
+        <div className="web-search-query" data-testid="web-search-query">
+          Results for &ldquo;{parsed.query}&rdquo;
+        </div>
+      )}
+      <ul className="web-search-result-list">
+        {parsed.results.map((r, i) => {
+          const safe = isSafeWebUrl(r.url)
+          return (
+            <li key={`${r.url}-${i}`} className="web-search-result-item" data-testid={`web-search-result-${i}`}>
+              {safe ? (
+                <a
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="web-search-result-title"
+                  data-testid={`web-search-result-link-${i}`}
+                >
+                  {r.title}
+                </a>
+              ) : (
+                // Defense in depth — the parser already drops unsafe schemes,
+                // so this branch should be unreachable in practice, but never
+                // render an <a href> for anything that fails the check twice.
+                <span className="web-search-result-title">{r.title}</span>
+              )}
+              <span className="web-search-result-domain">{domainFromUrl(r.url)}</span>
+              {r.snippet && <p className="web-search-result-snippet">{r.snippet}</p>}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export interface WebFetchResultProps {
+  parsed: ParsedWebFetchResult
+}
+
+/** WebFetch: the fetched page content run through the same markdown
+ *  pipeline chat messages use (autolinks embedded URLs, sanitized via
+ *  DOMPurify) instead of a raw `<pre>` dump. The source URL, when
+ *  present, renders as a small linked header above the content. */
+export function WebFetchResult({ parsed }: WebFetchResultProps) {
+  const html = useMemo(() => renderMarkdown(parsed.content), [parsed.content])
+  const safeUrl = parsed.url && isSafeWebUrl(parsed.url) ? parsed.url : undefined
+  return (
+    <div className="web-fetch-result" data-testid="web-fetch-result">
+      {safeUrl && (
+        <div className="web-fetch-source" data-testid="web-fetch-source">
+          <a href={safeUrl} target="_blank" rel="noopener noreferrer">{safeUrl}</a>
+        </div>
+      )}
+      <div
+        className="web-fetch-content"
+        data-testid="web-fetch-content"
+        onClick={handleMarkdownLinkClick}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/links.test.ts
+++ b/packages/dashboard/src/lib/links.test.ts
@@ -1,5 +1,47 @@
 import { describe, it, expect, vi } from 'vitest'
-import { resolveLinkOpen, handleMarkdownLinkClick } from './links'
+import { resolveLinkOpen, handleMarkdownLinkClick, isRenderableLinkHref } from './links'
+
+describe('isRenderableLinkHref (#6986)', () => {
+  it('allows http, https and mailto', () => {
+    expect(isRenderableLinkHref('https://example.com')).toBe(true)
+    expect(isRenderableLinkHref('http://example.com/x')).toBe(true)
+    expect(isRenderableLinkHref('mailto:a@b.com')).toBe(true)
+    expect(isRenderableLinkHref('HTTPS://Example.com')).toBe(true)
+  })
+
+  it('rejects the protocol-relative //host injection vector', () => {
+    expect(isRenderableLinkHref('//evil.example/x')).toBe(false)
+    expect(isRenderableLinkHref('//evil.example')).toBe(false)
+  })
+
+  it('rejects dangerous schemes', () => {
+    expect(isRenderableLinkHref('javascript:alert(1)')).toBe(false)
+    expect(isRenderableLinkHref('data:text/html,x')).toBe(false)
+    expect(isRenderableLinkHref('vbscript:msgbox(1)')).toBe(false)
+  })
+
+  it('rejects relative paths and bare fragments', () => {
+    expect(isRenderableLinkHref('/admin/delete')).toBe(false)
+    expect(isRenderableLinkHref('#section')).toBe(false)
+    expect(isRenderableLinkHref('relative/path')).toBe(false)
+  })
+
+  it('rejects other non-allowlisted schemes', () => {
+    expect(isRenderableLinkHref('ftp://files.example.com')).toBe(false)
+    expect(isRenderableLinkHref('file:///etc/passwd')).toBe(false)
+  })
+
+  it('trims before testing (a leading-space scheme does not evade)', () => {
+    expect(isRenderableLinkHref('  https://example.com  ')).toBe(true)
+    expect(isRenderableLinkHref(' javascript:alert(1)')).toBe(false)
+  })
+
+  it('rejects blank / non-string input', () => {
+    expect(isRenderableLinkHref(null)).toBe(false)
+    expect(isRenderableLinkHref(undefined)).toBe(false)
+    expect(isRenderableLinkHref('   ')).toBe(false)
+  })
+})
 
 describe('resolveLinkOpen (#6625)', () => {
   it('returns the URL for a modifier-click on an http(s) link', () => {

--- a/packages/dashboard/src/lib/links.ts
+++ b/packages/dashboard/src/lib/links.ts
@@ -17,6 +17,46 @@
 
 const OPENABLE_SCHEME = /^https?:\/\//i
 
+/**
+ * Schemes safe to emit as a real `<a href>` in rendered markdown / chat
+ * content (#6986). ALLOWLIST — `http:`, `https:`, `mailto:` only. Everything
+ * else renders as plain text, never a clickable anchor:
+ *   - dangerous schemes (`javascript:` / `data:` / `vbscript:`),
+ *   - protocol-relative `//host` — the link-injection vector,
+ *   - same-origin relative paths (`/foo`) and `#fragment` anchors.
+ *
+ * Why an allowlist, and why render-time: the previous markdown link check was
+ * a BLOCKLIST (`javascript|data|vbscript`). DOMPurify treats a bare `//host`
+ * href as a "safe relative URL" and KEEPS it, so a WebFetch of an
+ * attacker-controlled page (its fetched content is rendered through the same
+ * `renderMarkdown` pipeline) could smuggle a working `[text](//evil.example)`
+ * link past both the blocklist and DOMPurify. The click-time JS gate
+ * ({@link resolveLinkOpen}) suppresses a plain left-click, but middle-click
+ * (`auxclick`) and the browser's native right-click "Open Link in New Tab"
+ * read the raw DOM href and open it anyway — so the ONLY reliable place to
+ * neutralize it is to never emit the anchor at all, here at render time.
+ *
+ * A SUPERSET of {@link OPENABLE_SCHEME} (the open gate): `mailto:` is safe to
+ * render as an anchor (it hands off to the user's mail client, not a web
+ * origin) but is deliberately NOT window.open-ed, so it's absent from the open
+ * gate. Kept separate from store-core's `isSafeWebUrl` (http/https-only —
+ * that gate decides which WebSearch/WebFetch RESULT urls to keep, where a
+ * `mailto:` result would be meaningless).
+ */
+const RENDERABLE_LINK_SCHEME = /^(?:https?|mailto):/i
+
+/**
+ * True when `href` is safe to emit as a real `<a href>` in rendered markdown.
+ * Trims first (browsers ignore leading/trailing whitespace in an href, so a
+ * ` javascript:` with a leading space must not sneak past). Pure — no DOM.
+ * The markdown renderer routes its `[text](url)` check through this so the
+ * render gate and the click gate agree on scheme safety.
+ */
+export function isRenderableLinkHref(href: string | null | undefined): boolean {
+  if (typeof href !== 'string') return false
+  return RENDERABLE_LINK_SCHEME.test(href.trim())
+}
+
 /** Activation state read off a click event (test-friendly subset). */
 export interface LinkActivation {
   metaKey?: boolean

--- a/packages/dashboard/src/lib/markdown.test.ts
+++ b/packages/dashboard/src/lib/markdown.test.ts
@@ -67,6 +67,77 @@ describe('renderMarkdown', () => {
     expect(html).not.toContain('<a')
   })
 
+  // #6986 — the inline `[text](url)` scheme check is an ALLOWLIST
+  // (http/https/mailto), NOT a blocklist. This closes the link-injection
+  // hole where a WebFetch of an attacker page (its content runs through this
+  // same renderer) embeds a protocol-relative `[text](//evil)` link that
+  // DOMPurify keeps as a "safe relative URL" and that is openable via
+  // middle-click / right-click "Open Link in New Tab".
+  describe('link scheme allowlist (#6986)', () => {
+    const anchorHrefs = (html: string): string[] => {
+      const div = document.createElement('div')
+      div.innerHTML = html
+      return [...div.querySelectorAll('a')].map((a) => a.getAttribute('href') ?? '')
+    }
+
+    it('neutralizes a protocol-relative //host link (renders as text, no anchor)', () => {
+      const html = renderMarkdown('[click](//evil.example/x)')
+      // No anchor at all — and specifically no href pointing at the attacker host.
+      expect(anchorHrefs(html)).toHaveLength(0)
+      expect(html).not.toContain('<a')
+      expect(html).not.toContain('href="//evil')
+      // The link TEXT is preserved (rendered as plain text).
+      expect(html).toContain('click')
+    })
+
+    it('neutralizes a javascript: link (renders as text, no anchor)', () => {
+      const html = renderMarkdown('[js](javascript:alert(1))')
+      expect(anchorHrefs(html)).toHaveLength(0)
+      expect(html).not.toContain('<a')
+      expect(html).not.toContain('javascript:')
+      expect(html).toContain('js')
+    })
+
+    it('neutralizes leading-whitespace scheme evasion ( javascript:)', () => {
+      const html = renderMarkdown('[x]( javascript:alert(1))')
+      expect(anchorHrefs(html)).toHaveLength(0)
+      expect(html).not.toContain('<a')
+    })
+
+    it('neutralizes a same-origin relative path and a bare #fragment', () => {
+      expect(anchorHrefs(renderMarkdown('[a](/admin/delete)'))).toHaveLength(0)
+      expect(anchorHrefs(renderMarkdown('[b](#section)'))).toHaveLength(0)
+    })
+
+    it('neutralizes other non-allowlisted schemes (ftp, file, vbscript)', () => {
+      expect(anchorHrefs(renderMarkdown('[a](ftp://files.example.com)'))).toHaveLength(0)
+      expect(anchorHrefs(renderMarkdown('[b](file:///etc/passwd)'))).toHaveLength(0)
+      expect(anchorHrefs(renderMarkdown('[c](vbscript:msgbox(1))'))).toHaveLength(0)
+    })
+
+    it('STILL renders a legitimate https link as a proper anchor', () => {
+      const html = renderMarkdown('[ok](https://example.com)')
+      const div = document.createElement('div')
+      div.innerHTML = html
+      const a = div.querySelector('a')
+      expect(a).not.toBeNull()
+      expect(a!.getAttribute('href')).toBe('https://example.com')
+      expect(a!.getAttribute('target')).toBe('_blank')
+      expect(a!.getAttribute('rel')).toBe('noopener')
+      expect(a!.textContent).toBe('ok')
+    })
+
+    it('STILL renders legitimate http and mailto links as anchors', () => {
+      expect(anchorHrefs(renderMarkdown('[h](http://example.com)'))).toEqual(['http://example.com'])
+      expect(anchorHrefs(renderMarkdown('[mail](mailto:a@b.com)'))).toEqual(['mailto:a@b.com'])
+    })
+
+    it('trims surrounding whitespace from a legitimate href', () => {
+      const html = renderMarkdown('[ok]( https://example.com )')
+      expect(anchorHrefs(html)).toEqual(['https://example.com'])
+    })
+  })
+
   // Bare-URL autolinking (#3849) — bare http(s) URLs in prose render as
   // clickable anchors, not plain text. Without this, build artefact URLs
   // (e.g. expo.dev links) emitted by the agent show up unclickable.

--- a/packages/dashboard/src/lib/markdown.ts
+++ b/packages/dashboard/src/lib/markdown.ts
@@ -7,6 +7,7 @@
  */
 import DOMPurify from 'dompurify'
 import { highlightCode } from '@chroxy/store-core'
+import { isRenderableLinkHref } from './links'
 
 function escapeHtml(text: string): string {
   return text
@@ -66,12 +67,19 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
   html = html.replace(/\*(.+?)\*/g, '<em>$1</em>')
 
-  // Links — sanitize URL scheme
+  // Links — ALLOWLIST the URL scheme (#6986). Only http:/https:/mailto: emit a
+  // real anchor; every other href (dangerous `javascript:`/`data:`/`vbscript:`,
+  // protocol-relative `//host`, same-origin relative paths, `#fragment`) renders
+  // as plain text. A blocklist here was the link-injection bug: DOMPurify keeps a
+  // bare `//host` as a "safe relative URL", so attacker-controlled WebFetch'd
+  // content (rendered through this same pipeline) could smuggle an openable link
+  // to an external origin. `isRenderableLinkHref` is the shared gate in lib/links.
   html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, linkText: string, url: string) => {
-    if (/^\s*(javascript|data|vbscript)\s*:/i.test(url)) {
+    const trimmed = url.trim()
+    if (!isRenderableLinkHref(trimmed)) {
       return linkText
     }
-    const safeUrl = url.replace(/"/g, '&quot;')
+    const safeUrl = trimmed.replace(/"/g, '&quot;')
     return `<a href="${safeUrl}" target="_blank" rel="noopener">${linkText}</a>`
   })
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -451,6 +451,22 @@ export {
   TOOL_OUTPUT_COLLAPSE_HEAD_LINES,
 } from './tool-output'
 
+// #6757 — shared WebSearch/WebFetch tool_result parse logic, so both the
+// dashboard and mobile ToolBubble can render a structured result list /
+// formatted view instead of a raw text dump, from the same parser.
+export {
+  isSafeWebUrl,
+  isWebSearchToolName,
+  isWebFetchToolName,
+  parseWebSearchResults,
+  parseWebFetchResult,
+} from './web-tool-results'
+export type {
+  WebSearchResultItem,
+  ParsedWebSearchResults,
+  ParsedWebFetchResult,
+} from './web-tool-results'
+
 export {
   PASTE_COLLAPSE_CHAR_THRESHOLD,
   PASTE_COLLAPSE_LINE_THRESHOLD,

--- a/packages/store-core/src/web-tool-results.test.ts
+++ b/packages/store-core/src/web-tool-results.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the WebSearch/WebFetch tool_result parsers (#6757).
+ *
+ * Mirrors TodoList's parser test shape: well-formed input parses to a
+ * structured shape, malformed input falls back to null (WebSearch) or a
+ * content-only shape (WebFetch), and an unsafe URL scheme never survives
+ * into the parsed output.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  isSafeWebUrl,
+  isWebSearchToolName,
+  isWebFetchToolName,
+  parseWebSearchResults,
+  parseWebFetchResult,
+} from './web-tool-results'
+
+describe('isSafeWebUrl', () => {
+  it('allows http(s) URLs', () => {
+    expect(isSafeWebUrl('https://example.com/page')).toBe(true)
+    expect(isSafeWebUrl('http://example.com')).toBe(true)
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeWebUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+    expect(isSafeWebUrl('vbscript:msgbox(1)')).toBe(false)
+    expect(isSafeWebUrl('//evil.com/x')).toBe(false)
+    expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+  })
+
+  it('rejects non-string input without throwing', () => {
+    expect(isSafeWebUrl(undefined)).toBe(false)
+    expect(isSafeWebUrl(null)).toBe(false)
+    expect(isSafeWebUrl(42)).toBe(false)
+    expect(isSafeWebUrl({ url: 'https://example.com' })).toBe(false)
+  })
+})
+
+describe('isWebSearchToolName / isWebFetchToolName', () => {
+  it('matches WebSearch case/separator-insensitively', () => {
+    expect(isWebSearchToolName('WebSearch')).toBe(true)
+    expect(isWebSearchToolName('web_search')).toBe(true)
+    expect(isWebSearchToolName('web-search')).toBe(true)
+    expect(isWebSearchToolName('websearch')).toBe(true)
+  })
+
+  it('matches WebFetch case/separator-insensitively', () => {
+    expect(isWebFetchToolName('WebFetch')).toBe(true)
+    expect(isWebFetchToolName('web_fetch')).toBe(true)
+    expect(isWebFetchToolName('web-fetch')).toBe(true)
+  })
+
+  it('does not cross-match or match unrelated/similar names', () => {
+    expect(isWebSearchToolName('WebFetch')).toBe(false)
+    expect(isWebFetchToolName('WebSearch')).toBe(false)
+    // Regression guard: an existing ToolBubble test uses this tool name
+    // to exercise generic title-casing — it must NOT route into the
+    // WebSearch structured renderer.
+    expect(isWebSearchToolName('web_search_results')).toBe(false)
+    // The generic `fetch` alias (mapped to the `web` ToolKind for icon
+    // purposes elsewhere) is deliberately NOT treated as WebFetch here.
+    expect(isWebFetchToolName('fetch')).toBe(false)
+    expect(isWebSearchToolName(undefined)).toBe(false)
+    expect(isWebFetchToolName(null)).toBe(false)
+  })
+})
+
+describe('parseWebSearchResults', () => {
+  it('parses a bare JSON array of {title,url,snippet}', () => {
+    const text = JSON.stringify([
+      { title: 'Example Domain', url: 'https://example.com/', snippet: 'An example.' },
+      { title: 'Second Result', url: 'https://example.org/page' },
+    ])
+    const parsed = parseWebSearchResults(text)
+    expect(parsed).not.toBeNull()
+    expect(parsed?.results).toHaveLength(2)
+    expect(parsed?.results[0]).toEqual({
+      title: 'Example Domain',
+      url: 'https://example.com/',
+      snippet: 'An example.',
+    })
+    expect(parsed?.results[1]).toEqual({ title: 'Second Result', url: 'https://example.org/page' })
+  })
+
+  it('parses a {query, results:[...]} wrapper and surfaces the query', () => {
+    const text = JSON.stringify({
+      query: 'chroxy github',
+      results: [{ title: 'chroxy', url: 'https://github.com/blamechris/chroxy' }],
+    })
+    const parsed = parseWebSearchResults(text)
+    expect(parsed?.query).toBe('chroxy github')
+    expect(parsed?.results).toHaveLength(1)
+  })
+
+  it('parses the Agent SDK WebSearchOutput shape (results[].content[] mixed with commentary strings)', () => {
+    const text = JSON.stringify({
+      query: 'anthropic',
+      results: [
+        {
+          tool_use_id: 'srvtoolu_1',
+          content: [
+            { title: 'Anthropic', url: 'https://www.anthropic.com/' },
+            { title: 'Claude', url: 'https://claude.ai/' },
+          ],
+        },
+        'Some commentary text with no link.',
+      ],
+      durationSeconds: 1.2,
+    })
+    const parsed = parseWebSearchResults(text)
+    expect(parsed?.results).toHaveLength(2)
+    expect(parsed?.results.map(r => r.url)).toEqual(['https://www.anthropic.com/', 'https://claude.ai/'])
+  })
+
+  it('parses the raw Anthropic web_search_result block array shape', () => {
+    const text = JSON.stringify([
+      {
+        type: 'web_search_result',
+        title: 'Result A',
+        url: 'https://a.example.com/',
+        encrypted_content: 'opaque',
+        page_age: '2 days ago',
+      },
+    ])
+    const parsed = parseWebSearchResults(text)
+    expect(parsed?.results).toEqual([{ title: 'Result A', url: 'https://a.example.com/' }])
+  })
+
+  it('falls back to a title from the URL hostname when title is missing', () => {
+    const text = JSON.stringify([{ url: 'https://no-title.example.com/path' }])
+    const parsed = parseWebSearchResults(text)
+    expect(parsed?.results[0]).toEqual({ title: 'no-title.example.com', url: 'https://no-title.example.com/path' })
+  })
+
+  it('parses a markdown-style link list fallback', () => {
+    const text = [
+      '1. [First Result](https://example.com/1)',
+      '   A short snippet describing the first result.',
+      '2. [Second Result](https://example.com/2)',
+    ].join('\n')
+    const parsed = parseWebSearchResults(text)
+    expect(parsed?.results).toHaveLength(2)
+    expect(parsed?.results[0]).toEqual({
+      title: 'First Result',
+      url: 'https://example.com/1',
+      snippet: 'A short snippet describing the first result.',
+    })
+    expect(parsed?.results[1]).toEqual({ title: 'Second Result', url: 'https://example.com/2' })
+  })
+
+  it('drops entries with an unsafe URL scheme rather than rendering them', () => {
+    const text = JSON.stringify([
+      { title: 'Safe', url: 'https://safe.example.com/' },
+      { title: 'Unsafe', url: 'javascript:alert(document.cookie)' },
+    ])
+    const parsed = parseWebSearchResults(text)
+    expect(parsed?.results).toHaveLength(1)
+    expect(parsed?.results[0]?.url).toBe('https://safe.example.com/')
+  })
+
+  it('returns null when every candidate has an unsafe URL scheme', () => {
+    const text = JSON.stringify([{ title: 'Unsafe', url: 'javascript:alert(1)' }])
+    expect(parseWebSearchResults(text)).toBeNull()
+  })
+
+  it('returns null for unrecognized / malformed input (fallback to raw text)', () => {
+    expect(parseWebSearchResults('this is just plain prose with no links')).toBeNull()
+    expect(parseWebSearchResults('')).toBeNull()
+    expect(parseWebSearchResults('   ')).toBeNull()
+    expect(parseWebSearchResults('{not valid json')).toBeNull()
+  })
+
+  it('never throws on garbage input', () => {
+    expect(() => parseWebSearchResults('[{"url": 42}]')).not.toThrow()
+    expect(() => parseWebSearchResults('null')).not.toThrow()
+    expect(() => parseWebSearchResults('"just a string"')).not.toThrow()
+  })
+})
+
+describe('parseWebFetchResult', () => {
+  it('parses the BYOK executor Prompt/URL/body shape', () => {
+    const text = 'Prompt: Summarize this page\nURL: https://example.com/article\n\nThe article body goes here.\nMore text.'
+    const parsed = parseWebFetchResult(text)
+    expect(parsed).toEqual({
+      url: 'https://example.com/article',
+      prompt: 'Summarize this page',
+      content: 'The article body goes here.\nMore text.',
+    })
+  })
+
+  it('parses the userinfo-stripped marker suffix on the URL line', () => {
+    const text = 'Prompt: p\nURL: https://example.com/page [userinfo stripped from input URL]\n\nBody text.'
+    const parsed = parseWebFetchResult(text)
+    expect(parsed?.url).toBe('https://example.com/page')
+    expect(parsed?.content).toBe('Body text.')
+  })
+
+  it('parses a URL-only header with no prompt line', () => {
+    const text = 'URL: https://example.com/\n\nFetched content.'
+    const parsed = parseWebFetchResult(text)
+    expect(parsed).toEqual({ url: 'https://example.com/', content: 'Fetched content.' })
+  })
+
+  it('treats the whole string as content when no recognizable header is present', () => {
+    const text = '# Example Page\n\nSome fetched markdown content with a https://example.com link in it.'
+    const parsed = parseWebFetchResult(text)
+    expect(parsed).toEqual({ content: text })
+  })
+
+  it('drops an unsafe URL scheme from the header but keeps the content', () => {
+    const text = 'Prompt: p\nURL: javascript:alert(1)\n\nBody text.'
+    const parsed = parseWebFetchResult(text)
+    expect(parsed?.url).toBeUndefined()
+    expect(parsed?.content).toBe('Body text.')
+  })
+
+  it('returns null only for empty input', () => {
+    expect(parseWebFetchResult('')).toBeNull()
+  })
+
+  it('never throws on garbage input', () => {
+    expect(() => parseWebFetchResult('Prompt: \nURL: \n\n')).not.toThrow()
+    expect(() => parseWebFetchResult('URL:\n\n')).not.toThrow()
+  })
+})

--- a/packages/store-core/src/web-tool-results.ts
+++ b/packages/store-core/src/web-tool-results.ts
@@ -1,0 +1,274 @@
+/**
+ * Shared parse logic for WebSearch/WebFetch tool_result content (#6757).
+ *
+ * WebSearch and WebFetch results reach the client as a single flattened
+ * text string (`packages/server/src/tool-result.js` `emitToolResults`
+ * joins every text content block into one string before it ever reaches
+ * a client — there is no structured title/url/snippet payload on the
+ * wire). This module re-parses that text back into a structured shape so
+ * both the dashboard and mobile `ToolBubble` can render a real result
+ * list / formatted view instead of a raw `<pre>` dump, mirroring the
+ * precedent `parseTodoList` set for TodoWrite (#4139).
+ *
+ * Known real-world shapes this module targets:
+ *   - WebSearch: the Claude Agent SDK's `WebSearchOutput.results` shape
+ *     (an array of `{ tool_use_id, content: { title, url }[] }` entries
+ *     interleaved with plain-string commentary) and the raw Anthropic
+ *     Messages API `web_search_tool_result` content shape (an array of
+ *     `{ type: 'web_search_result', title, url, ... }`), both typically
+ *     serialized to JSON text by the time they reach `emitToolResults`.
+ *     A markdown-link-list fallback (`- [title](url)`) covers providers
+ *     that pre-format the result text instead.
+ *   - WebFetch: the BYOK executor (`packages/server/src/
+ *     byok-tool-executor.js` `runWebFetch`) emits
+ *     `Prompt: <prompt>\nURL: <url>\n\n<content>` — parsed into its
+ *     three parts so the client can show the source URL as a link and
+ *     the body as formatted text. Any other shape still renders — the
+ *     whole string becomes `content` with no `url`/`prompt` extracted.
+ *
+ * Both parsers are defensive: malformed / unrecognized-shape input never
+ * throws. `parseWebSearchResults` returns `null` (caller falls back to
+ * the raw `<pre>` render) when it can't find at least one safe result.
+ * `parseWebFetchResult` only returns `null` for empty input — any other
+ * text still renders as formatted content, since arbitrary text is
+ * always safe to run through the markdown pipeline.
+ *
+ * Security: a search/fetch result's `url` is fully model/web-controlled
+ * (it's exactly the content an attacker-influenced page or search index
+ * can inject). `isSafeWebUrl` is the single scheme allowlist (http/https
+ * only) both parsers filter through — rendering layers MUST NOT
+ * second-guess a URL this module already dropped, but SHOULD still
+ * re-check with `isSafeWebUrl` before emitting an `<a href>` (defense in
+ * depth, matching the existing `lib/markdown.ts` + `lib/links.ts`
+ * pattern of gating scheme at both parse time and click time).
+ */
+
+/** One search hit. `snippet` is optional — most real payloads are
+ *  title+url only; a snippet/description field is included when present
+ *  so a richer source is not truncated to just a link. */
+export interface WebSearchResultItem {
+  title: string
+  url: string
+  snippet?: string
+}
+
+export interface ParsedWebSearchResults {
+  /** The search query, when the payload carries one. */
+  query?: string
+  results: WebSearchResultItem[]
+}
+
+export interface ParsedWebFetchResult {
+  /** The fetched URL, when the result text carries a recognizable header. */
+  url?: string
+  /** The prompt the fetch was run with, when present (BYOK executor shape). */
+  prompt?: string
+  /** The fetched page content (or the entire input, if no header matched). */
+  content: string
+}
+
+const OPENABLE_SCHEME = /^https?:\/\//i
+
+/**
+ * The only URL schemes this module (and its renderers) treat as safe to
+ * link to. `javascript:` / `data:` / `vbscript:` / bare `//host` and
+ * anything else is rejected outright — mirrors `lib/links.ts`'s
+ * `OPENABLE_SCHEME` gate so search/fetch results can't smuggle a
+ * dangerous scheme past the chat-message autolinker's equivalent check.
+ */
+export function isSafeWebUrl(url: unknown): url is string {
+  return typeof url === 'string' && OPENABLE_SCHEME.test(url.trim())
+}
+
+function normalizeToolName(name: string | undefined | null): string {
+  if (!name) return ''
+  return name.toLowerCase().replace(/[_-]/g, '')
+}
+
+/** True for `WebSearch` / `web_search` / `web-search` (case/separator
+ *  insensitive) — the exact tool name the dashboard/mobile ToolBubble
+ *  should route through {@link parseWebSearchResults}. */
+export function isWebSearchToolName(name: string | undefined | null): boolean {
+  return normalizeToolName(name) === 'websearch'
+}
+
+/** True for `WebFetch` / `web_fetch` / `web-fetch` — routes through
+ *  {@link parseWebFetchResult}. Deliberately does NOT match the generic
+ *  `fetch` alias some providers use for unrelated tools (#6757 scopes
+ *  structured rendering to WebSearch/WebFetch specifically). */
+export function isWebFetchToolName(name: string | undefined | null): boolean {
+  return normalizeToolName(name) === 'webfetch'
+}
+
+function titleFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return url
+  }
+}
+
+function coerceString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+/**
+ * Pull `{ title, url, snippet }` candidates out of one already-parsed
+ * JSON value, recursing into common wrapper shapes:
+ *   - a bare array of result-like objects
+ *   - `{ results: [...] }` / `{ content: [...] }`
+ *   - the SDK's `WebSearchOutput.results` shape: an array mixing
+ *     `{ tool_use_id, content: [{ title, url }] }` entries with plain
+ *     commentary strings (the strings are skipped — no link to extract)
+ * Returns raw candidates (not yet URL/scheme-filtered) — filtering
+ * happens once at the end of {@link parseWebSearchResults} so every
+ * branch shares the same safety gate.
+ */
+function collectResultCandidates(value: unknown, depth = 0): Array<{ title?: string; url?: string; snippet?: string }> {
+  if (depth > 4 || value == null) return []
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => collectResultCandidates(v, depth + 1))
+  }
+  if (typeof value !== 'object') return []
+  const obj = value as Record<string, unknown>
+  // A direct result-shaped object: has a url. Anthropic's raw
+  // `web_search_result` block and the SDK's `{title,url}` hits both
+  // match this.
+  if (typeof obj.url === 'string') {
+    return [{
+      title: coerceString(obj.title),
+      url: obj.url,
+      snippet: coerceString(obj.snippet) ?? coerceString(obj.description) ?? coerceString(obj.text),
+    }]
+  }
+  // Wrapper shapes: recurse into known array-valued fields.
+  const out: Array<{ title?: string; url?: string; snippet?: string }> = []
+  if (Array.isArray(obj.results)) out.push(...collectResultCandidates(obj.results, depth + 1))
+  if (Array.isArray(obj.content)) out.push(...collectResultCandidates(obj.content, depth + 1))
+  return out
+}
+
+// Markdown-style link-list fallback: `- [title](url)` / `1. [title](url)`,
+// optionally with a snippet on the following indented line. Matches the
+// same `[text](url)` shape `lib/markdown.ts` autolinks, so a provider that
+// pre-formats WebSearch results as markdown still parses.
+const MD_LINK_LINE_RE = /^\s*(?:[-*]|\d+[.)])\s*\[([^\]]+)\]\(([^)]+)\)\s*$/
+const SNIPPET_LINE_RE = /^\s{2,}(\S.*)$/
+
+function parseMarkdownLinkList(text: string): WebSearchResultItem[] {
+  const lines = text.split('\n')
+  const results: WebSearchResultItem[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    const m = line.match(MD_LINK_LINE_RE)
+    if (!m) continue
+    const title = (m[1] ?? '').trim()
+    const url = (m[2] ?? '').trim()
+    if (!title || !url) continue
+    let snippet: string | undefined
+    const next = lines[i + 1]
+    if (next && !MD_LINK_LINE_RE.test(next)) {
+      const sm = next.match(SNIPPET_LINE_RE)
+      if (sm) snippet = sm[1]!.trim()
+    }
+    results.push({ title, url, snippet })
+  }
+  return results
+}
+
+/**
+ * Parse a WebSearch tool_result string into a structured result list.
+ * Returns `null` when nothing safely link-shaped can be recovered — the
+ * caller (ToolBubble) falls back to the raw `<pre>` render in that case,
+ * matching `parseTodoList`'s failure contract.
+ *
+ * A result whose `url` fails {@link isSafeWebUrl} (e.g. `javascript:` /
+ * `data:`) is dropped, not merely neutralized — there's no safe partial
+ * form of a non-http(s) "link". If every candidate is unsafe/malformed
+ * the return is `null` (empty list is never useful to render as a
+ * "structured" result — the raw text carries more information at that
+ * point).
+ */
+export function parseWebSearchResults(text: string): ParsedWebSearchResults | null {
+  if (typeof text !== 'string' || text.trim().length === 0) return null
+  const trimmed = text.trim()
+
+  let query: string | undefined
+  let candidates: Array<{ title?: string; url?: string; snippet?: string }> = []
+
+  if (trimmed[0] === '[' || trimmed[0] === '{') {
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        query = coerceString((parsed as Record<string, unknown>).query)
+      }
+      candidates = collectResultCandidates(parsed)
+    } catch {
+      // Not JSON (or truncated JSON) — fall through to the markdown-link
+      // fallback below.
+    }
+  }
+
+  if (candidates.length === 0) {
+    candidates = parseMarkdownLinkList(text)
+  }
+
+  const results: WebSearchResultItem[] = []
+  for (const c of candidates) {
+    if (!isSafeWebUrl(c.url)) continue
+    const url = c.url.trim()
+    const title = c.title?.trim() || titleFromUrl(url)
+    results.push(c.snippet ? { title, url, snippet: c.snippet } : { title, url })
+  }
+
+  if (results.length === 0) return null
+  return query ? { query, results } : { results }
+}
+
+// BYOK `runWebFetch`'s success shape: `Prompt: <p>\nURL: <u>[marker]\n\n<body>`.
+// The optional bracketed marker is the `[userinfo stripped ...]` suffix
+// `byok-tool-executor.js` appends to the URL line.
+const WEBFETCH_HEADER_RE = /^Prompt:[ \t]*(.*)\r?\nURL:[ \t]*(\S+)(?:[ \t]*\[[^\]]*\])?\r?\n\r?\n([\s\S]*)$/
+// A lighter header some providers may emit: just the URL, no prompt echo.
+const WEBFETCH_URL_ONLY_RE = /^URL:[ \t]*(\S+)\r?\n\r?\n([\s\S]*)$/
+
+/**
+ * Parse a WebFetch tool_result string. Always succeeds for non-empty
+ * input — WebFetch's body is free-form fetched text, which is always
+ * safe to hand to the markdown renderer, so there's no "unparseable"
+ * shape to reject. Only the empty-string case returns `null` (nothing to
+ * show; caller's existing `hasTextResult` gate already treats an empty
+ * result as "no panel").
+ *
+ * When the text carries a `url` header, it's still passed through
+ * {@link isSafeWebUrl} before being returned — the header's value is
+ * take-what-the-tool-said, not attacker-input-checked at the transport
+ * layer, and the caller renders `url` as a clickable link.
+ */
+export function parseWebFetchResult(text: string): ParsedWebFetchResult | null {
+  if (typeof text !== 'string' || text.length === 0) return null
+
+  const full = text.match(WEBFETCH_HEADER_RE)
+  if (full) {
+    const prompt = (full[1] ?? '').trim()
+    const rawUrl = (full[2] ?? '').trim()
+    const content = full[3] ?? ''
+    return {
+      ...(isSafeWebUrl(rawUrl) ? { url: rawUrl } : {}),
+      ...(prompt ? { prompt } : {}),
+      content,
+    }
+  }
+
+  const urlOnly = text.match(WEBFETCH_URL_ONLY_RE)
+  if (urlOnly) {
+    const rawUrl = (urlOnly[1] ?? '').trim()
+    const content = urlOnly[2] ?? ''
+    return {
+      ...(isSafeWebUrl(rawUrl) ? { url: rawUrl } : {}),
+      content,
+    }
+  }
+
+  return { content: text }
+}


### PR DESCRIPTION
Renders WebSearch/WebFetch tool results as structured source cards (title/domain/snippet) with safe clickable links instead of a flat text blob. Shared parse in store-core (web-tool-results.ts); links are http(s)-only (rel=noopener target=_blank), javascript:/data: schemes neutralized. Malformed results fall back to raw text. Visually verified: cards render, a javascript: URL is shown as text with no href. Mobile → follow-up.

## Security hardening (#6986 — resolves the C1 REQUEST-CHANGES)

The fetched WebFetch page content renders through the shared `renderMarkdown()` pipeline, whose inline `[text](url)` scheme check was a **blocklist** (`javascript|data|vbscript`). A bare protocol-relative `//host` href survives `DOMPurify.sanitize()` (treated as a "safe relative URL") and rendered as a real anchor — openable via middle-click / native right-click "Open Link in New Tab" despite the click-time JS gate. Since WebFetch content is attacker-controlled, this exposed a link-injection vector.

Hardened `packages/dashboard/src/lib/markdown.ts` to an **allowlist**: only `http:`/`https:`/`mailto:` emit an anchor; every other href (dangerous schemes, `//host`, same-origin relative paths, `#fragment`) renders as plain text. The check routes through a shared `isRenderableLinkHref` gate in `lib/links.ts`, next to the existing `OPENABLE_SCHEME` click gate, so all link paths agree. Legitimate http/https/mailto links in normal chat messages are unaffected. Regression tests added: an embedded `[text](//host)` in WebFetch content is neutralized, and a legitimate `[ok](https://…)` still renders a proper anchor.

Closes #6757
Closes #6986
