### PR TITLE
feat(app): structured WebSearch/WebFetch tool-result render (mobile parity)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,7 @@ export PATH="$PATH:$HOME/.maestro/bin"
 
 # Full green gate (recommended) — each flow in its OWN maestro process (#6091).
 # Reliable on a single simulator over long runs: avoids the XCUITest instability
-# that accumulates when all 23 flows share one process (run-all.yaml). Parses the
+# that accumulates when all 25 flows share one process (run-all.yaml). Parses the
 # flow inventory from run-all.yaml, starts/reuses the mock server, retries a
 # failing flow once (env flakiness vs real defect), prints a pass/fail summary.
 bash packages/app/.maestro/scripts/run-all-sequential.sh --device <device-id>
@@ -394,7 +394,9 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 23 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
+| `chat-websearch.yaml` | WebSearch structured renderer (mock-server emits WebSearch tool_start+tool_result via `show-websearch`, entry expands, `WebSearchResultList` renders title/domain/snippet rows; asserts the fixture's `javascript:` result produced no row) |
+| `chat-webfetch.yaml` | WebFetch structured renderer (`show-webfetch` trigger → source-URL link + markdown-formatted body) |
+| `run-all.yaml` | Runs all 25 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ export PATH="$PATH:$HOME/.maestro/bin"
 
 # Full green gate (recommended) — each flow in its OWN maestro process (#6091).
 # Reliable on a single simulator over long runs: avoids the XCUITest instability
-# that accumulates when all 23 flows share one process (run-all.yaml). Parses the
+# that accumulates when all 25 flows share one process (run-all.yaml). Parses the
 # flow inventory from run-all.yaml, starts/reuses the mock server, retries a
 # failing flow once (env flakiness vs real defect), prints a pass/fail summary.
 bash packages/app/.maestro/scripts/run-all-sequential.sh --device <device-id>
@@ -375,7 +375,9 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 23 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
+| `chat-websearch.yaml` | WebSearch structured renderer (mock-server emits WebSearch tool_start+tool_result via `show-websearch`, entry expands, `WebSearchResultList` renders title/domain/snippet rows; asserts the fixture's `javascript:` result produced no row) |
+| `chat-webfetch.yaml` | WebFetch structured renderer (`show-webfetch` trigger → source-URL link + markdown-formatted body) |
+| `run-all.yaml` | Runs all 25 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/packages/app/.maestro/chat-webfetch.yaml
+++ b/packages/app/.maestro/chat-webfetch.yaml
@@ -1,0 +1,60 @@
+appId: com.blamechris.chroxy
+name: ChatView WebFetch structured tool result
+---
+
+# #6982 — End-to-end coverage for the mobile WebFetch structured
+# renderer (packages/app/src/components/chat/WebToolResult.tsx
+# WebFetchResult), the sibling of chat-websearch.yaml.
+#
+# Trigger: 'show-webfetch' user input (added by #6757 in
+# mock-server.mjs). The fixture mirrors the BYOK executor's real wire
+# shape — `Prompt: <p>\nURL: <u>\n\n<body>` — which
+# @chroxy/store-core's parseWebFetchResult splits into the source URL
+# (rendered as a tappable link, gated on isSafeWebUrl) and the body
+# (rendered through the app's existing markdown pipeline instead of a
+# raw text dump).
+#
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+
+- runFlow: setup/ensure-session-screen.yaml
+
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-webfetch"
+
+- tapOn:
+    id: "chat-send-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "activity-group"
+    timeout: 10000
+
+- tapOn:
+    id: "activity-group-header"
+- waitForAnimationToEnd
+
+# Expand the WebFetch entry by tapping its collapsed-preview text (the
+# head of the raw tool_result, which begins with the Prompt: line). Same
+# tap-by-text rationale as chat-todolist.yaml / chat-websearch.yaml.
+- tapOn:
+    text: ".*Summarize this page.*"
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      id: "web-fetch-result"
+    timeout: 5000
+
+# Source URL rendered as a link above the formatted body.
+- assertVisible:
+    id: "web-fetch-source"
+- assertVisible:
+    id: "web-fetch-content"
+
+- takeScreenshot: chat-webfetch-expanded

--- a/packages/app/.maestro/chat-websearch.yaml
+++ b/packages/app/.maestro/chat-websearch.yaml
@@ -1,0 +1,92 @@
+appId: com.blamechris.chroxy
+name: ChatView WebSearch structured tool result
+---
+
+# #6982 — End-to-end coverage for the mobile WebSearch structured
+# renderer (packages/app/src/components/chat/WebToolResult.tsx),
+# reaching it through the real WS protocol path: mock-server emits a
+# synthetic WebSearch tool_start + tool_result, store-core's
+# handleToolStart/handleToolResult process it, the message lands in an
+# ActivityGroup, and expanding the entry runs
+# parseWebToolResult(message.tool, message.toolResult) →
+# <WebSearchResultList />.
+#
+# Trigger: 'show-websearch' user input (added by #6757 in
+# mock-server.mjs, shared with the dashboard's manual verification).
+# The fixture seeding pattern is documented in CLAUDE.md → "Fixture
+# Seeding for Structured Renderers".
+#
+# SECURITY REGRESSION GUARD: the fixture's THIRD result has a
+# `javascript:alert(1)` URL. @chroxy/store-core's parseWebSearchResults
+# drops it, so only two rows may ever render — the assertNotVisible on
+# `web-search-result-2` below fails loudly if that scheme allowlist
+# regresses and an unsafe result reaches the UI.
+#
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+
+- runFlow: setup/ensure-session-screen.yaml
+
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# Type the trigger phrase that makes the mock server emit a WebSearch
+# tool_use + tool_result pair.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-websearch"
+
+- tapOn:
+    id: "chat-send-button"
+
+# Wait for the activity group wrapping the WebSearch tool row.
+- extendedWaitUntil:
+    visible:
+      id: "activity-group"
+    timeout: 10000
+
+- takeScreenshot: chat-websearch-activity-group-collapsed
+
+# Expand the activity group — the onPress lives on the inner
+# `activity-group-header` TouchableOpacity (the outer `activity-group`
+# testID is for assertion only).
+- tapOn:
+    id: "activity-group-header"
+- waitForAnimationToEnd
+
+# Expand the WebSearch entry. Same rationale as chat-todolist.yaml: an
+# iOS XCUITest tap-by-id on a nested TouchableOpacity doesn't reliably
+# reach RN's touch responder, so tap the entry's collapsed-preview TEXT
+# (the head of the raw JSON tool_result, which contains the fixture's
+# query) — that resolves to coordinates on the entry row on every device.
+- tapOn:
+    text: ".*chroxy remote terminal.*"
+- waitForAnimationToEnd
+
+# LayoutAnimation can defer the state→render commit on iOS.
+- extendedWaitUntil:
+    visible:
+      id: "web-search-results"
+    timeout: 5000
+
+# The structured list replaced the flat-text dump: query header, one row
+# per SAFE result, a tappable title link, the domain, and the snippet.
+- assertVisible:
+    id: "web-search-query"
+- assertVisible:
+    id: "web-search-result-0"
+- assertVisible:
+    id: "web-search-result-link-0"
+- assertVisible:
+    id: "web-search-result-domain-0"
+- assertVisible:
+    id: "web-search-result-snippet-0"
+- assertVisible:
+    id: "web-search-result-1"
+
+# The `javascript:` fixture result must NOT have produced a row.
+- assertNotVisible:
+    id: "web-search-result-2"
+
+- takeScreenshot: chat-websearch-expanded

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -39,6 +39,15 @@ name: All E2E flows
 # #4180 mobile TodoList via mock-server tool_start + tool_result.
 - runFlow: chat-todolist.yaml
 
+# Flow 9b: Chat WebSearch structured renderer (#6982) — mock-server
+# 'show-websearch' trigger; also guards the store-core scheme allowlist
+# (the fixture's `javascript:` result must not render a row).
+- runFlow: chat-websearch.yaml
+
+# Flow 9c: Chat WebFetch structured renderer (#6982) — mock-server
+# 'show-webfetch' trigger; source URL as a gated link + markdown body.
+- runFlow: chat-webfetch.yaml
+
 # Flow 10: ToolBubble collapsed-preview field-priority (#4260) —
 # exercises the #4243 partial-summary extraction via mock-server
 # 'show-bash-partial' trigger (tool_start + streaming tool_input_delta).

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -217,7 +217,7 @@ export function ChatView({
   const [showScrollToTop, setShowScrollToTop] = useState(false);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const showScrollToBottomRef = useRef(false);
-  const [toolDetail, setToolDetail] = useState<{ toolName: string; content: string; toolResult?: string; toolResultTruncated?: boolean; toolResultImages?: ToolResultImage[]; serverName?: string } | null>(null);
+  const [toolDetail, setToolDetail] = useState<{ toolName: string; rawToolName?: string; content: string; toolResult?: string; toolResultTruncated?: boolean; toolResultImages?: ToolResultImage[]; serverName?: string } | null>(null);
   const [viewerUri, setViewerUri] = useState<string | null>(null);
 
   // #5750 (item 2) — assertively announce a newly-arrived permission prompt to
@@ -324,8 +324,11 @@ export function ChatView({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- scrollViewRef, isSelectingRef, and showScrollToBottomRef are stable refs
   }, [hasUnansweredPrompt]);
 
-  const handleOpenDetail = (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string) => {
-    setToolDetail({ toolName, content, toolResult, toolResultTruncated, toolResultImages, serverName });
+  // #6982: `rawToolName` is the UNFORMATTED `message.tool`, carried alongside
+  // the display `toolName` so ToolDetailModal can route WebSearch/WebFetch
+  // results through the structured renderer.
+  const handleOpenDetail = (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string, rawToolName?: string) => {
+    setToolDetail({ toolName, rawToolName, content, toolResult, toolResultTruncated, toolResultImages, serverName });
   };
 
   // #4806: shared ChatView message pipeline (lifted from dashboard's
@@ -629,6 +632,7 @@ export function ChatView({
       <ToolDetailModal
         visible={toolDetail !== null}
         toolName={toolDetail?.toolName || ''}
+        rawToolName={toolDetail?.rawToolName}
         content={toolDetail?.content || ''}
         toolResult={toolDetail?.toolResult}
         toolResultTruncated={toolDetail?.toolResultTruncated}

--- a/packages/app/src/components/__tests__/WebToolResult.test.tsx
+++ b/packages/app/src/components/__tests__/WebToolResult.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * Tests for the mobile WebSearch/WebFetch structured renderers (#6982).
+ *
+ * Mirrors the dashboard coverage in
+ * `packages/dashboard/src/components/WebToolResult.test.tsx`. The parsing
+ * itself lives in (and is tested by) `@chroxy/store-core`; what matters
+ * here is the RN render layer's contract:
+ *
+ *   - routing (raw tool name in, structured shape out, `null` → the
+ *     caller's existing flat-text fallback),
+ *   - link SAFETY — an unsafe URL must produce no press handler at all,
+ *     not merely a handler that declines to open,
+ *   - never throwing on malformed input.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Alert, Linking } from 'react-native';
+import type { ParsedWebSearchResults, ParsedWebFetchResult } from '@chroxy/store-core';
+import {
+  WebSearchResultList,
+  WebFetchResult,
+  WebToolResultView,
+  parseWebToolResult,
+  openWebResultUrl,
+  domainFromUrl,
+} from '../chat/WebToolResult';
+
+function render(el: React.ReactElement): renderer.ReactTestRenderer {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(el);
+  });
+  return root;
+}
+
+function byTestId(root: renderer.ReactTestRenderer, id: string): ReactTestInstance[] {
+  return root.root.findAllByProps({ testID: id });
+}
+
+/** The node that actually carries the press handler for `id`, if any. */
+function pressableByTestId(root: renderer.ReactTestRenderer, id: string): ReactTestInstance | undefined {
+  return byTestId(root, id).find((n) => typeof n.props.onPress === 'function');
+}
+
+/** Every node in the tree that has a press handler — used to prove that an
+ *  unsafe result produces NO tappable element whatsoever. */
+function allPressHandlers(root: renderer.ReactTestRenderer): ReactTestInstance[] {
+  return root.root.findAll((n) => typeof n.props?.onPress === 'function', { deep: true });
+}
+
+const SAFE_SEARCH: ParsedWebSearchResults = {
+  query: 'chroxy remote terminal',
+  results: [
+    {
+      title: 'chroxy — remote terminal for Claude Code',
+      url: 'https://github.com/blamechris/chroxy',
+      snippet: 'Run a lightweight daemon on your dev machine.',
+    },
+    { title: 'Docs', url: 'https://www.example.com:8443/docs' },
+  ],
+};
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  // RN mocks Linking.openURL as a shared jest.fn — clear leaked calls.
+  jest.clearAllMocks();
+});
+
+describe('parseWebToolResult routing', () => {
+  const searchJson = JSON.stringify({
+    query: 'q',
+    results: [{ title: 'T', url: 'https://example.com/a', snippet: 'S' }],
+  });
+
+  it('routes WebSearch (and its separator variants) to the search shape', () => {
+    for (const tool of ['WebSearch', 'web_search', 'web-search', 'websearch']) {
+      const parsed = parseWebToolResult(tool, searchJson);
+      expect(parsed?.kind).toBe('search');
+    }
+  });
+
+  it('routes WebFetch to the fetch shape and splits the executor header', () => {
+    const text = 'Prompt: Summarize\nURL: https://example.com/p\n\n# Body';
+    const parsed = parseWebToolResult('WebFetch', text);
+    expect(parsed?.kind).toBe('fetch');
+    if (parsed?.kind !== 'fetch') throw new Error('expected fetch');
+    expect(parsed.fetch.url).toBe('https://example.com/p');
+    expect(parsed.fetch.content).toBe('# Body');
+  });
+
+  it('returns null for unrelated tools so the caller keeps its flat-text render', () => {
+    expect(parseWebToolResult('Bash', searchJson)).toBeNull();
+    expect(parseWebToolResult('TodoWrite', searchJson)).toBeNull();
+    // `fetch` must NOT cross-match WebFetch (store-core scoping decision).
+    expect(parseWebToolResult('fetch', 'some text')).toBeNull();
+  });
+
+  it('returns null for a missing/empty result (tool still in flight)', () => {
+    expect(parseWebToolResult('WebSearch', undefined)).toBeNull();
+    expect(parseWebToolResult('WebSearch', null)).toBeNull();
+    expect(parseWebToolResult('WebSearch', '')).toBeNull();
+  });
+
+  it('returns null — not a throw — for malformed WebSearch payloads', () => {
+    expect(parseWebToolResult('WebSearch', '{"results":[')).toBeNull();
+    expect(parseWebToolResult('WebSearch', 'total garbage, no links here')).toBeNull();
+    expect(parseWebToolResult('WebSearch', JSON.stringify({ results: [] }))).toBeNull();
+  });
+
+  it('drops results whose URL fails the scheme allowlist', () => {
+    // Mirrors the `show-websearch` mock fixture, whose third result is a
+    // deliberate `javascript:` entry.
+    const payload = JSON.stringify({
+      results: [
+        { title: 'ok', url: 'https://example.com/ok' },
+        { title: 'xss', url: 'javascript:alert(1)' },
+        { title: 'proto-relative', url: '//evil.example/x' },
+        { title: 'data', url: 'data:text/html,<script>alert(1)</script>' },
+      ],
+    });
+    const parsed = parseWebToolResult('WebSearch', payload);
+    if (parsed?.kind !== 'search') throw new Error('expected search');
+    expect(parsed.search.results).toHaveLength(1);
+    expect(parsed.search.results[0]?.url).toBe('https://example.com/ok');
+  });
+});
+
+describe('domainFromUrl', () => {
+  it('strips www and the port', () => {
+    expect(domainFromUrl('https://www.example.com/a/b')).toBe('example.com');
+    expect(domainFromUrl('https://example.com:8443/x')).toBe('example.com');
+  });
+
+  it('shows the REAL host when userinfo is used to spoof a prefix', () => {
+    expect(domainFromUrl('https://github.com@evil.example/x')).toBe('evil.example');
+  });
+
+  it('falls back to the raw string rather than throwing', () => {
+    expect(domainFromUrl('not a url')).toBe('not a url');
+  });
+});
+
+describe('WebSearchResultList render', () => {
+  it('renders the query and one row per result with structured testIDs', () => {
+    const root = render(<WebSearchResultList parsed={SAFE_SEARCH} />);
+    expect(byTestId(root, 'web-search-results').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-search-query').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-search-result-0').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-search-result-1').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-search-result-snippet-0').length).toBeGreaterThan(0);
+    // Second fixture result has no snippet — the element must be omitted.
+    expect(byTestId(root, 'web-search-result-snippet-1')).toHaveLength(0);
+  });
+
+  it('renders the domain, not the full URL, under each title', () => {
+    const root = render(<WebSearchResultList parsed={SAFE_SEARCH} />);
+    expect(byTestId(root, 'web-search-result-domain-0')[0]?.props.children).toBe('github.com');
+    expect(byTestId(root, 'web-search-result-domain-1')[0]?.props.children).toBe('example.com');
+  });
+
+  it('gives every safe link a 44pt minimum touch target', () => {
+    const root = render(<WebSearchResultList parsed={SAFE_SEARCH} />);
+    const link = pressableByTestId(root, 'web-search-result-link-0');
+    expect(link).toBeTruthy();
+    const style = StyleSheetFlatten(link!.props.style);
+    expect(style.minHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  it('renders an unsafe URL as inert text with NO press handler', () => {
+    // Hand-built parsed value — the parser would have dropped these, so this
+    // is the render layer's independent second gate.
+    const unsafe: ParsedWebSearchResults = {
+      results: [
+        { title: 'javascript payload', url: 'javascript:alert(1)' },
+        { title: 'protocol relative', url: '//evil.example/x' },
+      ],
+    };
+    const root = render(<WebSearchResultList parsed={unsafe} />);
+    // Titles are still shown...
+    expect(byTestId(root, 'web-search-result-unsafe-0').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-search-result-unsafe-1').length).toBeGreaterThan(0);
+    // ...but nothing is a link, and nothing anywhere in the tree is tappable.
+    expect(byTestId(root, 'web-search-result-link-0')).toHaveLength(0);
+    expect(byTestId(root, 'web-search-result-link-1')).toHaveLength(0);
+    expect(allPressHandlers(root)).toHaveLength(0);
+  });
+
+  it('tapping a safe link confirms first, then opens it', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const openSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+    const root = render(<WebSearchResultList parsed={SAFE_SEARCH} />);
+
+    act(() => {
+      pressableByTestId(root, 'web-search-result-link-0')!.props.onPress();
+    });
+
+    // The confirm dialog shows the FULL destination (anti-phishing, #6447).
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy.mock.calls[0]?.[1]).toBe('https://github.com/blamechris/chroxy');
+    expect(openSpy).not.toHaveBeenCalled();
+
+    // Confirming actually opens it.
+    const buttons = alertSpy.mock.calls[0]?.[2] as Array<{ text: string; onPress?: () => void }>;
+    act(() => {
+      buttons.find((b) => b.text === 'Open')!.onPress!();
+    });
+    expect(openSpy).toHaveBeenCalledWith('https://github.com/blamechris/chroxy');
+  });
+});
+
+describe('openWebResultUrl', () => {
+  it('refuses unsafe schemes without prompting or opening', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const openSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+    for (const bad of [
+      'javascript:alert(1)',
+      'JavaScript:alert(1)',
+      '//evil.example/x',
+      'data:text/html,<script>alert(1)</script>',
+      'file:///etc/passwd',
+      'chroxy://session/1',
+    ]) {
+      openWebResultUrl(bad);
+    }
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows a Linking.openURL rejection instead of leaving it unhandled', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    jest.spyOn(Linking, 'openURL').mockRejectedValue(new Error('no handler') as never);
+    openWebResultUrl('https://example.com/x');
+    const buttons = alertSpy.mock.calls[0]?.[2] as Array<{ text: string; onPress?: () => void }>;
+    expect(() => buttons.find((b) => b.text === 'Open')!.onPress!()).not.toThrow();
+    // Flush the rejected promise — an unhandled rejection would fail the run.
+    await act(async () => { await Promise.resolve(); });
+  });
+
+  it('does not strip trailing punctuation that belongs to the URL', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const wiki = 'https://en.wikipedia.org/wiki/Ruby_(programming_language)';
+    openWebResultUrl(wiki);
+    expect(alertSpy.mock.calls[0]?.[1]).toBe(wiki);
+  });
+});
+
+describe('WebFetchResult render', () => {
+  const parsed: ParsedWebFetchResult = {
+    url: 'https://example.com/chroxy',
+    prompt: 'Summarize this page',
+    content: '# Chroxy\n\nA **remote terminal** app.',
+  };
+
+  it('renders the source link and the formatted content', () => {
+    const root = render(<WebFetchResult parsed={parsed} />);
+    expect(byTestId(root, 'web-fetch-result').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-fetch-content').length).toBeGreaterThan(0);
+    expect(pressableByTestId(root, 'web-fetch-source')).toBeTruthy();
+  });
+
+  it('omits the source link entirely when the URL is unsafe', () => {
+    const root = render(
+      <WebFetchResult parsed={{ url: 'javascript:alert(1)', content: 'body' }} />,
+    );
+    expect(byTestId(root, 'web-fetch-source')).toHaveLength(0);
+  });
+
+  it('renders content with no source header when the result carried no URL', () => {
+    const root = render(<WebFetchResult parsed={{ content: 'just some text' }} />);
+    expect(byTestId(root, 'web-fetch-source')).toHaveLength(0);
+    expect(byTestId(root, 'web-fetch-content').length).toBeGreaterThan(0);
+  });
+
+  it('does not throw on empty content', () => {
+    expect(() => render(<WebFetchResult parsed={{ content: '' }} />)).not.toThrow();
+  });
+});
+
+describe('WebToolResultView dispatch', () => {
+  it('renders the search list for a search shape', () => {
+    const root = render(<WebToolResultView parsed={{ kind: 'search', search: SAFE_SEARCH }} />);
+    expect(byTestId(root, 'web-search-results').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-fetch-result')).toHaveLength(0);
+  });
+
+  it('renders the fetch view for a fetch shape', () => {
+    const root = render(
+      <WebToolResultView parsed={{ kind: 'fetch', fetch: { content: 'hello' } }} />,
+    );
+    expect(byTestId(root, 'web-fetch-result').length).toBeGreaterThan(0);
+    expect(byTestId(root, 'web-search-results')).toHaveLength(0);
+  });
+});
+
+/** Minimal style flattener — avoids importing StyleSheet.flatten typing noise. */
+function StyleSheetFlatten(style: unknown): Record<string, number> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, number>>((acc, s) => ({ ...acc, ...StyleSheetFlatten(s) }), {});
+  }
+  if (style && typeof style === 'object') return style as Record<string, number>;
+  return {};
+}

--- a/packages/app/src/components/__tests__/WebToolResult.test.tsx
+++ b/packages/app/src/components/__tests__/WebToolResult.test.tsx
@@ -14,7 +14,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Alert, Linking } from 'react-native';
+import { Alert, Linking, StyleSheet } from 'react-native';
 import type { ParsedWebSearchResults, ParsedWebFetchResult } from '@chroxy/store-core';
 import {
   WebSearchResultList,
@@ -303,11 +303,11 @@ describe('WebToolResultView dispatch', () => {
   });
 });
 
-/** Minimal style flattener — avoids importing StyleSheet.flatten typing noise. */
+/** Thin wrapper around RN's own `StyleSheet.flatten` (#6988 review) — a
+ *  hand-rolled merge happened to work only because `StyleSheet.create`
+ *  returns plain objects in RN 0.81; using the real API means the 44pt
+ *  touch-target assertion below fails loudly instead of vacuously passing
+ *  if that ever changes back to numeric style IDs. */
 function StyleSheetFlatten(style: unknown): Record<string, number> {
-  if (Array.isArray(style)) {
-    return style.reduce<Record<string, number>>((acc, s) => ({ ...acc, ...StyleSheetFlatten(s) }), {});
-  }
-  if (style && typeof style === 'object') return style as Record<string, number>;
-  return {};
+  return (StyleSheet.flatten(style as never) ?? {}) as Record<string, number>;
 }

--- a/packages/app/src/components/__tests__/WebToolResult.test.tsx
+++ b/packages/app/src/components/__tests__/WebToolResult.test.tsx
@@ -135,6 +135,17 @@ describe('domainFromUrl', () => {
     expect(domainFromUrl('https://github.com@evil.example/x')).toBe('evil.example');
   });
 
+  it('terminates the authority on a backslash (WHATWG parity) instead of reading past it to a spoofed @-suffix', () => {
+    // WHATWG/browsers treat `\` like `/` for special schemes, so the
+    // backslash ends the authority BEFORE `@github.com` is ever reached —
+    // the real navigation target is `evil.example`. A regex that doesn't
+    // terminate on `\` would read all the way to the last `@` and display
+    // `github.com`: a trusted-looking domain over a phishing target.
+    expect(domainFromUrl('https://evil.example\\@github.com/')).toBe('evil.example');
+    expect(domainFromUrl('https://evil.example\\\\@github.com/')).toBe('evil.example');
+    expect(domainFromUrl('https://evil.example\\?@github.com/')).toBe('evil.example');
+  });
+
   it('falls back to the raw string rather than throwing', () => {
     expect(domainFromUrl('not a url')).toBe('not a url');
   });

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -12,6 +12,7 @@ import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { TodoList, parseTodoList } from './TodoList';
+import { WebToolResultView, parseWebToolResult } from './WebToolResult';
 import { ChildAgentEventList } from './ChildAgentEventList';
 import {
   summarizeToolCounts,
@@ -95,6 +96,15 @@ function ActivityEntry({
   const todoParsed = expanded && message.tool === 'TodoWrite' && message.toolResult
     ? parseTodoList(message.toolResult)
     : null;
+  // #6982: same parse-with-fallback for WebSearch/WebFetch, sharing
+  // @chroxy/store-core's parsers with the dashboard (#6757). Routes on the
+  // RAW `message.tool` (not `displayTool` — `formatToolName` would turn
+  // `web_search` into `Web Search`, which the separator-normalizing
+  // matchers do not accept). Falls through to the plain-text branch below
+  // whenever the parse yields null.
+  const webParsed = expanded && !todoParsed
+    ? parseWebToolResult(message.tool, message.toolResult)
+    : null;
 
   return (
     <TouchableOpacity
@@ -133,6 +143,7 @@ function ActivityEntry({
         <>
           {(() => {
             if (todoParsed) return <TodoList parsed={todoParsed} />
+            if (webParsed) return <WebToolResultView parsed={webParsed} />
             // #4203: prefer toolResult text when present; otherwise fall back to
             // content (pre-result/pending state). When toolResult is undefined
             // but images are attached (e.g. screenshot tool with no text body),

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -171,7 +171,10 @@ function MessageBubbleImpl({ message, queued, onCancelQueued, onEditQueued, onSe
   isSelecting: boolean;
   onLongPress: () => void;
   onPress: () => void;
-  onOpenDetail: (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string) => void;
+  /** #6982: the trailing `rawToolName` carries the UNFORMATTED `message.tool`
+   *  so the detail modal can route WebSearch/WebFetch results through the
+   *  structured renderer (`toolName` is the `formatToolName` display label). */
+  onOpenDetail: (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string, rawToolName?: string) => void;
   onImagePress?: (uri: string) => void;
   /**
    * #4496: retry handler for stream-stall error chips. ChatView wires

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -13,6 +13,7 @@ import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { formatToolName } from './chat-utils';
 import { TodoList, parseTodoList } from './TodoList';
+import { WebToolResultView, parseWebToolResult } from './WebToolResult';
 import { ChildAgentEventList } from './ChildAgentEventList';
 
 /**
@@ -45,7 +46,11 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
   isSelected: boolean;
   isSelecting: boolean;
   onToggleSelection: () => void;
-  onOpenDetail: (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string) => void;
+  /** The trailing `rawToolName` is the UNFORMATTED `message.tool` (#6982) —
+   *  the detail modal needs it to route WebSearch/WebFetch results through
+   *  the structured renderer, since `toolName` has already been through
+   *  `formatToolName`. */
+  onOpenDetail: (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string, rawToolName?: string) => void;
   /** #5517: seed + persist expand state in ChatView's id-keyed registry so
    *  it survives FlatList row recycling. */
   getInitialExpanded?: (id: string) => boolean;
@@ -121,7 +126,7 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
     if (isSelecting) {
       onToggleSelection();
     } else if (expanded) {
-      onOpenDetail(displayTool, content, message.toolResult, message.toolResultTruncated, message.toolResultImages, message.serverName);
+      onOpenDetail(displayTool, content, message.toolResult, message.toolResultTruncated, message.toolResultImages, message.serverName, message.tool);
     } else {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
       setExpanded(true);
@@ -188,10 +193,20 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
   const todoParsed = expanded && message.tool === 'TodoWrite' && message.toolResult
     ? parseTodoList(message.toolResult)
     : null;
+  // #6982: the same parse-with-fallback treatment for WebSearch/WebFetch,
+  // reusing @chroxy/store-core's parsers (shared with the dashboard's
+  // WebToolResult, #6757). Parses `message.toolResult` — NOT `content`,
+  // which is the JSON-stringified tool *input* — and routes on the RAW
+  // `message.tool` so `web_search`/`web-search` match too. `null` (wrong
+  // tool, no result yet, unparseable payload) falls through to the
+  // existing plain-text branches below.
+  const webParsed = expanded && !todoParsed
+    ? parseWebToolResult(message.tool, message.toolResult)
+    : null;
   // #6391 (mobile auto-collapse): collapse a long expanded result to its head
   // behind a "Show N more lines" pill (shared store-core threshold).
   const contentLineCount = content ? content.split('\n').length : 0;
-  const isLongContent = !todoParsed && contentLineCount > TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD;
+  const isLongContent = !todoParsed && !webParsed && contentLineCount > TOOL_OUTPUT_COLLAPSE_LINE_THRESHOLD;
 
   return (
     <TouchableOpacity
@@ -225,6 +240,8 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
         <>
           {todoParsed ? (
             <TodoList parsed={todoParsed} />
+          ) : webParsed ? (
+            <WebToolResultView parsed={webParsed} />
           ) : isLongContent && !resultExpanded ? (
             <>
               <Text selectable style={styles.toolContentExpanded}>{content.split('\n').slice(0, TOOL_OUTPUT_COLLAPSE_HEAD_LINES).join('\n')}</Text>

--- a/packages/app/src/components/chat/ToolDetailModal.tsx
+++ b/packages/app/src/components/chat/ToolDetailModal.tsx
@@ -13,10 +13,21 @@ import {
 import type { ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
+import { WebToolResultView, parseWebToolResult } from './WebToolResult';
 
-export function ToolDetailModal({ visible, toolName, content, toolResult, toolResultTruncated, toolResultImages, serverName, onClose, onImagePress }: {
+export function ToolDetailModal({ visible, toolName, rawToolName, content, toolResult, toolResultTruncated, toolResultImages, serverName, onClose, onImagePress }: {
   visible: boolean;
   toolName: string;
+  /**
+   * #6982: the UNFORMATTED tool name (`message.tool`), used only to route
+   * the result through the structured WebSearch/WebFetch renderer.
+   * `toolName` is the human-facing label from `formatToolName`, which
+   * rewrites `web_search` to `Web Search` — the shared matchers normalize
+   * `_`/`-` but not spaces, so routing on it would silently fail. Optional
+   * so callers that only have a display name keep working (they just fall
+   * back to the plain-text result render).
+   */
+  rawToolName?: string;
   content: string;
   toolResult?: string;
   toolResultTruncated?: boolean;
@@ -25,6 +36,10 @@ export function ToolDetailModal({ visible, toolName, content, toolResult, toolRe
   onClose: () => void;
   onImagePress: (uri: string) => void;
 }) {
+  // #6982: structured WebSearch/WebFetch render, parse-with-fallback —
+  // `null` (non-web tool, absent or unparseable result) keeps the existing
+  // `<Text selectable>` dump below.
+  const webParsed = parseWebToolResult(rawToolName, toolResult);
   return (
     <Modal
       visible={visible}
@@ -83,7 +98,11 @@ export function ToolDetailModal({ visible, toolName, content, toolResult, toolRe
             {toolResult != null ? (
               <>
                 <Text style={[styles.toolModalSectionLabel, (content || toolResultImages?.length) ? { marginTop: 12 } : undefined]}>Result{toolResultTruncated ? ' (truncated)' : ''}</Text>
-                <Text selectable style={styles.toolModalContent}>{toolResult}</Text>
+                {webParsed ? (
+                  <WebToolResultView parsed={webParsed} />
+                ) : (
+                  <Text selectable style={styles.toolModalContent}>{toolResult}</Text>
+                )}
               </>
             ) : null}
           </ScrollView>

--- a/packages/app/src/components/chat/WebToolResult.tsx
+++ b/packages/app/src/components/chat/WebToolResult.tsx
@@ -1,0 +1,308 @@
+/**
+ * WebToolResult — React Native structured renderers for WebSearch /
+ * WebFetch tool_result content.
+ *
+ * Mobile port of `packages/dashboard/src/components/WebToolResult.tsx`
+ * (#6757), closing the parity gap tracked in #6982. Both platforms share
+ * the SAME parser (`@chroxy/store-core`'s `parseWebSearchResults` /
+ * `parseWebFetchResult`) — this module is the RN render layer only, and
+ * deliberately re-implements nothing the parser already does.
+ *
+ * Contract mirrors `parseTodoList`/`TodoList` (#4180): the parse can fail
+ * (returns `null`) and every call site falls back to its existing
+ * plain-text render, so a malformed or unrecognized result never blanks
+ * or crashes the bubble.
+ *
+ * ## Security
+ *
+ * A search/fetch result's `url` is fully model- and web-controlled — it is
+ * exactly the content an attacker-influenced page or search index can
+ * inject. Two independent gates apply:
+ *
+ * 1. **Parse time** — the shared parser already drops any result whose URL
+ *    fails `isSafeWebUrl` (http/https only; `javascript:`, `data:`,
+ *    `vbscript:` and protocol-relative `//host` are all rejected).
+ * 2. **Render time** — every URL is re-checked with the same `isSafeWebUrl`
+ *    here before it is allowed to become a `Pressable`. A URL that fails
+ *    renders as inert `<Text>`: not tappable, no press handler, nothing to
+ *    open. This branch is unreachable through the parser today; it exists
+ *    so a future caller that hand-builds a `Parsed*` value cannot smuggle a
+ *    dangerous scheme into a tappable element.
+ *
+ * There is no HTML-injection surface: RN `<Text>` renders strings as text
+ * nodes, never as markup, so titles/snippets/domains are inherently
+ * escaped. WebFetch's body is the one rich-rendered field and it goes
+ * through the app's existing `FormattedResponse` markdown renderer — the
+ * same pipeline assistant prose already uses, whose own `openURL` helper
+ * enforces an `^https?://` scheme gate before calling `Linking.openURL`.
+ *
+ * Opening a link routes through {@link openWebResultUrl}, which shows the
+ * full destination URL in a confirm dialog first (the #6447 anti-phishing
+ * treatment applied to every model-supplied link in the app).
+ */
+import React from 'react';
+import { View, Text, Pressable, StyleSheet, Platform, Alert, Linking } from 'react-native';
+import {
+  isSafeWebUrl,
+  isWebSearchToolName,
+  isWebFetchToolName,
+  parseWebSearchResults,
+  parseWebFetchResult,
+} from '@chroxy/store-core';
+import type { ParsedWebSearchResults, ParsedWebFetchResult } from '@chroxy/store-core';
+import { COLORS } from '../../constants/colors';
+import { FormattedResponse } from '../MarkdownRenderer';
+
+/** Minimum tappable height for a link row (iOS HIG / Android a11y: 44pt). */
+const MIN_TOUCH_TARGET = 44;
+
+/**
+ * Extract a display host from a URL WITHOUT depending on the global `URL`
+ * constructor — React Native's bundled `URL` polyfill is incomplete and
+ * does not reliably implement `.hostname`, so the dashboard's
+ * `new URL(url).hostname` approach is not portable here.
+ *
+ * Userinfo is stripped by taking the segment after the LAST `@`, which is
+ * the real host per the URL spec. That matters for display integrity: for
+ * `https://github.com@evil.example/x` this shows `evil.example`, not the
+ * `github.com` prefix an attacker put there to look legitimate.
+ */
+export function domainFromUrl(url: string): string {
+  const m = /^https?:\/\/([^/?#]+)/i.exec(url.trim());
+  const authority = m?.[1];
+  if (!authority) return url;
+  const hostAndPort = authority.split('@').pop() ?? authority;
+  const host = hostAndPort.replace(/:\d+$/, '');
+  return host.replace(/^www\./i, '') || url;
+}
+
+/**
+ * Open a web result's URL, gated on the shared scheme allowlist.
+ *
+ * Unsafe schemes return silently — callers already render those as inert
+ * text, so reaching here with one means a bug, not a user action worth
+ * surfacing. Safe URLs get the #6447 confirm-with-full-URL prompt before
+ * `Linking.openURL`, whose rejection (no handler installed for the
+ * scheme, user cancelled at the OS layer) is swallowed rather than left
+ * as an unhandled promise rejection.
+ *
+ * Unlike `MarkdownRenderer`'s `openURL`, this does NOT strip trailing
+ * punctuation: that strip exists to undo greedy bare-URL autolinking in
+ * prose, and applying it to an exact structured URL would corrupt
+ * legitimate links such as
+ * `https://en.wikipedia.org/wiki/Ruby_(programming_language)`.
+ */
+export function openWebResultUrl(url: string): void {
+  if (!isSafeWebUrl(url)) return;
+  const target = url.trim();
+  Alert.alert(
+    'Open link?',
+    target,
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Open',
+        onPress: () => {
+          void Linking.openURL(target).catch(() => {
+            // Nothing actionable for the user — the OS declined to handle
+            // the URL. Never let this surface as an unhandled rejection.
+          });
+        },
+      },
+    ],
+    { cancelable: true },
+  );
+}
+
+/** Discriminated result of {@link parseWebToolResult} — lets a call site
+ *  make ONE routing decision and hand the outcome straight to
+ *  {@link WebToolResultView}. */
+export type ParsedWebToolResult =
+  | { kind: 'search'; search: ParsedWebSearchResults }
+  | { kind: 'fetch'; fetch: ParsedWebFetchResult };
+
+/**
+ * Route a tool_result through the right shared parser based on the tool
+ * name. Returns `null` for any non-web tool, an absent result, or a
+ * payload the parser could not make sense of — in every one of those
+ * cases the caller must fall back to its existing plain-text render.
+ *
+ * IMPORTANT: pass the RAW tool name (`message.tool`), not the formatted
+ * display name. `formatToolName` turns `web_search` into `Web Search`,
+ * and the shared matchers normalize separators (`_`/`-`) but not spaces,
+ * so a display name would silently fail to route.
+ */
+export function parseWebToolResult(
+  tool: string | undefined | null,
+  toolResult: string | undefined | null,
+): ParsedWebToolResult | null {
+  if (typeof toolResult !== 'string' || toolResult.length === 0) return null;
+  if (isWebSearchToolName(tool)) {
+    const search = parseWebSearchResults(toolResult);
+    return search ? { kind: 'search', search } : null;
+  }
+  if (isWebFetchToolName(tool)) {
+    const fetched = parseWebFetchResult(toolResult);
+    return fetched ? { kind: 'fetch', fetch: fetched } : null;
+  }
+  return null;
+}
+
+export interface WebSearchResultListProps {
+  parsed: ParsedWebSearchResults;
+}
+
+/** WebSearch: a compact list of source rows (title link, domain, snippet),
+ *  replacing the raw joined-text dump. */
+export function WebSearchResultList({ parsed }: WebSearchResultListProps) {
+  return (
+    <View style={styles.container} testID="web-search-results">
+      {parsed.query ? (
+        <Text style={styles.query} testID="web-search-query" numberOfLines={2}>
+          Results for “{parsed.query}”
+        </Text>
+      ) : null}
+      {parsed.results.map((r, i) => {
+        // Defense in depth — the parser already dropped unsafe URLs, so a
+        // failure here means the value was constructed by hand. Render the
+        // title as inert text with NO press handler in that case.
+        const safe = isSafeWebUrl(r.url);
+        return (
+          <View key={`${r.url}-${i}`} style={styles.item} testID={`web-search-result-${i}`}>
+            {safe ? (
+              <Pressable
+                onPress={() => openWebResultUrl(r.url)}
+                style={styles.linkPressable}
+                hitSlop={4}
+                accessibilityRole="link"
+                accessibilityLabel={`${r.title}, ${domainFromUrl(r.url)}`}
+                accessibilityHint="Opens in your browser after confirmation"
+                testID={`web-search-result-link-${i}`}
+              >
+                <Text style={styles.title}>{r.title}</Text>
+              </Pressable>
+            ) : (
+              <View style={styles.linkPressable}>
+                <Text style={styles.titleUnsafe} testID={`web-search-result-unsafe-${i}`}>
+                  {r.title}
+                </Text>
+              </View>
+            )}
+            <Text style={styles.domain} testID={`web-search-result-domain-${i}`} numberOfLines={1}>
+              {domainFromUrl(r.url)}
+            </Text>
+            {r.snippet ? (
+              <Text style={styles.snippet} testID={`web-search-result-snippet-${i}`}>
+                {r.snippet}
+              </Text>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export interface WebFetchResultProps {
+  parsed: ParsedWebFetchResult;
+}
+
+/** WebFetch: the fetched page body run through the app's existing markdown
+ *  renderer (the same one assistant prose uses), with the source URL shown
+ *  as a link above it when the result carried a safe one. */
+export function WebFetchResult({ parsed }: WebFetchResultProps) {
+  const safeUrl = isSafeWebUrl(parsed.url) ? parsed.url : undefined;
+  return (
+    <View style={styles.container} testID="web-fetch-result">
+      {safeUrl ? (
+        <Pressable
+          onPress={() => openWebResultUrl(safeUrl)}
+          style={styles.linkPressable}
+          hitSlop={4}
+          accessibilityRole="link"
+          accessibilityLabel={`Source: ${domainFromUrl(safeUrl)}`}
+          accessibilityHint="Opens in your browser after confirmation"
+          testID="web-fetch-source"
+        >
+          <Text style={styles.sourceUrl} numberOfLines={1}>
+            {safeUrl}
+          </Text>
+        </Pressable>
+      ) : null}
+      <View testID="web-fetch-content">
+        <FormattedResponse content={parsed.content} messageTextStyle={styles.fetchContent} />
+      </View>
+    </View>
+  );
+}
+
+/** Render whichever web-tool shape {@link parseWebToolResult} produced. */
+export function WebToolResultView({ parsed }: { parsed: ParsedWebToolResult }) {
+  return parsed.kind === 'search' ? (
+    <WebSearchResultList parsed={parsed.search} />
+  ) : (
+    <WebFetchResult parsed={parsed.fetch} />
+  );
+}
+
+const styles = StyleSheet.create({
+  // Matches TodoList's inset-rule treatment so the three structured
+  // tool-result renderers read as one family.
+  container: {
+    paddingVertical: 4,
+    paddingHorizontal: 6,
+    borderLeftWidth: 2,
+    borderLeftColor: COLORS.accentBlue,
+    marginVertical: 2,
+  },
+  query: {
+    color: COLORS.textSecondary,
+    fontSize: 11,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  item: {
+    paddingVertical: 2,
+  },
+  // 44pt minimum tappable height (iOS HIG). `justifyContent: 'center'`
+  // keeps a single-line title vertically centred in the taller target.
+  linkPressable: {
+    minHeight: MIN_TOUCH_TARGET,
+    justifyContent: 'center',
+  },
+  title: {
+    color: COLORS.accentBlue,
+    fontSize: 13,
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+  },
+  // An unsafe URL still shows its title so the user sees what was returned
+  // — just with no link affordance and no press handler.
+  titleUnsafe: {
+    color: COLORS.textSecondary,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  domain: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  snippet: {
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 2,
+  },
+  sourceUrl: {
+    color: COLORS.accentBlue,
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    textDecorationLine: 'underline',
+  },
+  fetchContent: {
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    lineHeight: 17,
+  },
+});

--- a/packages/app/src/components/chat/WebToolResult.tsx
+++ b/packages/app/src/components/chat/WebToolResult.tsx
@@ -66,9 +66,19 @@ const MIN_TOUCH_TARGET = 44;
  * the real host per the URL spec. That matters for display integrity: for
  * `https://github.com@evil.example/x` this shows `evil.example`, not the
  * `github.com` prefix an attacker put there to look legitimate.
+ *
+ * The authority character class excludes `\` as well as `/?#`: WHATWG URL
+ * parsing (what every browser actually does for special schemes like
+ * http/https) treats a backslash exactly like a forward slash — it ends the
+ * authority component. Leaving `\` out of this class let an authority like
+ * `evil.example\@github.com` be read past the backslash all the way to the
+ * LAST `@`, extracting `github.com` as the "host" while the browser (and
+ * `isSafeWebUrl`'s own parsing) resolve the real target as `evil.example`.
+ * That mismatch is a display-vs-navigation spoof: the card shows a trusted
+ * domain while tapping it opens something else entirely.
  */
 export function domainFromUrl(url: string): string {
-  const m = /^https?:\/\/([^/?#]+)/i.exec(url.trim());
+  const m = /^https?:\/\/([^/?#\\]+)/i.exec(url.trim());
   const authority = m?.[1];
   if (!authority) return url;
   const hostAndPort = authority.split('@').pop() ?? authority;


### PR DESCRIPTION
Mobile port of the dashboard's `WebToolResult` (#6757). WebSearch/WebFetch results rendered as flat text on mobile; they now render as a structured source list and a formatted fetch view.

Closes #6982

## How to see it in the iOS simulator

The `show-websearch` / `show-webfetch` mock-server trigger phrases already exist (added by #6757 for the dashboard) — no new fixture plumbing needed.

```bash
# 1. Dev client + Metro (one-time build if not already installed)
cd packages/app && npx expo run:ios
npx expo start

# 2. Mock server on :9876
bash packages/app/.maestro/scripts/start-mock-server.sh
```

Then in the app: connect to the mock server → **Chat** tab → type **`show-websearch`** → send.

A "1 tool used — 1 WebSearch" activity group appears. **Tap the group header** to expand it, then **tap the WebSearch row** to expand the entry — the structured list replaces the raw JSON dump. Repeat with **`show-webfetch`** for the fetch view (source-URL link + markdown body).

Tapping a result title shows an "Open link?" confirmation with the full destination URL before anything opens.

Deterministic version:

```bash
export PATH="$PATH:$HOME/.maestro/bin"
maestro test --device <device-id> packages/app/.maestro/chat-websearch.yaml
maestro test --device <device-id> packages/app/.maestro/chat-webfetch.yaml
```

Both are added to `run-all.yaml` (now 25 flows), so `run-all-sequential.sh` and the Maestro nightly pick them up automatically.

## Render approach

`packages/app/src/components/chat/WebToolResult.tsx` — RN idiom (`View`/`Text`/`Pressable`), no HTML. It reuses `@chroxy/store-core`'s `parseWebSearchResults` / `parseWebFetchResult` / `isSafeWebUrl` / `isWebSearchToolName` / `isWebFetchToolName`; **no parsing is re-implemented** and store-core is untouched.

- **WebSearch** → one row per result: title (link), domain, snippet.
- **WebFetch** → source URL link + body through the app's existing `FormattedResponse` markdown renderer.
- Malformed / unrecognized / not-yet-arrived result → parser returns `null` → each call site keeps its existing flat-text render. Never blanks or crashes the bubble.

Wired into **three** sites, not two. The issue named `ToolBubble` and `ToolDetailModal`, but `ActivityGroup`'s `ActivityEntry` is the site actually on screen in the chat flow (every tool message is grouped into an activity group), so it needed the same treatment — otherwise none of this would be visible in the simulator.

`ToolDetailModal` now also receives the **raw** tool name. It previously only had the `formatToolName` output, which rewrites `web_search` → `"Web Search"`; the shared matchers normalize `_`/`-` but not spaces, so routing on the display name would silently fail for that provider spelling.

## Link safety

- Every URL is re-checked with the shared `isSafeWebUrl` **at render time**, independent of the parser's own filter. A URL that fails renders as inert `<Text>` with **no press handler at all** — there is nothing to open, not merely a handler that declines.
- All result text is RN `<Text>`, which renders strings as text nodes — no HTML injection surface.
- Opening goes through the confirm-with-full-URL prompt (the #6447 anti-phishing treatment) before `Linking.openURL`; the promise rejection is swallowed rather than left unhandled.
- Unlike `MarkdownRenderer`'s `openURL`, this does **not** strip trailing punctuation — that strip exists to undo greedy bare-URL autolinking in prose, and applying it to an exact structured URL would corrupt e.g. `https://en.wikipedia.org/wiki/Ruby_(programming_language)`.
- `domainFromUrl` avoids the global `URL` constructor (RN's bundled polyfill does not reliably implement `.hostname`, so the dashboard's `new URL(url).hostname` is not portable) and resolves userinfo to the **real** host: `https://github.com@evil.example/x` displays `evil.example`.

### RN markdown renderer — checked for the `//host` bypass class (#6986)

**No equivalent bug.** `packages/app/src/components/MarkdownRenderer.tsx` `openURL` gates on `/^https?:\/\//i` — a strict prefix test, so protocol-relative `//host`, `javascript:`, `data:` and `file:` are all rejected. The dashboard's #6986 bypass came from a looser check that treated `//host` as schemeless-but-safe; the RN side never had that shape, so no fix was needed here. It is in fact *stricter* than the dashboard's post-#6986 allowlist — `mailto:` is not openable on mobile either.

One cosmetic (non-security) nuance worth noting: `renderInline` still styles an unsafe markdown link as a link and attaches an `onPress`; the press is a silent no-op at `openURL`. Nothing opens, so this is a UX wart rather than a hole. The new `WebToolResult` deliberately does not copy that pattern — it omits the press handler entirely.

## Tests

- `packages/app/src/components/__tests__/WebToolResult.test.tsx` — **23 tests**: routing (incl. `web_search`/`web-search` variants and the deliberate non-cross-match of bare `fetch`), scheme-allowlist drops, unsafe URL renders with zero press handlers anywhere in the tree, confirm-then-open ordering, `openURL` rejection handling, malformed-input fallback, 44pt minimum touch target, `domainFromUrl` userinfo spoofing.
- Full app suite: **177 suites / 2297 tests pass**. `npx tsc --noEmit` clean.
- `testID`s mirror the dashboard's (`web-search-result-<i>`, `web-search-result-link-<i>`, `web-fetch-source`, …) so both platforms anchor on the same names.