### PR TITLE
feat(app): compaction marker render (mobile parity)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,7 @@ export PATH="$PATH:$HOME/.maestro/bin"
 
 # Full green gate (recommended) — each flow in its OWN maestro process (#6091).
 # Reliable on a single simulator over long runs: avoids the XCUITest instability
-# that accumulates when all 23 flows share one process (run-all.yaml). Parses the
+# that accumulates when all 24 flows share one process (run-all.yaml). Parses the
 # flow inventory from run-all.yaml, starts/reuses the mock server, retries a
 # failing flow once (env flakiness vs real defect), prints a pass/fail summary.
 bash packages/app/.maestro/scripts/run-all-sequential.sh --device <device-id>
@@ -394,7 +394,7 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 23 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
+| `run-all.yaml` | Runs all 24 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, compaction marker, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ export PATH="$PATH:$HOME/.maestro/bin"
 
 # Full green gate (recommended) — each flow in its OWN maestro process (#6091).
 # Reliable on a single simulator over long runs: avoids the XCUITest instability
-# that accumulates when all 23 flows share one process (run-all.yaml). Parses the
+# that accumulates when all 24 flows share one process (run-all.yaml). Parses the
 # flow inventory from run-all.yaml, starts/reuses the mock server, retries a
 # failing flow once (env flakiness vs real defect), prints a pass/fail summary.
 bash packages/app/.maestro/scripts/run-all-sequential.sh --device <device-id>
@@ -375,7 +375,7 @@ When you modify app components (screens, UI elements, styling), verify with Maes
 | `manual-connect.yaml` | Manual entry form, URL input, Connect → optimistic SessionScreen + reconnect banner on unreachable server, header Disconnect back to ConnectScreen |
 | `lan-scan.yaml` | LAN scan trigger, in-progress or results state (scan can finish near-instantly) |
 | `chat-todolist.yaml` | TodoList renderer end-to-end (mock-server emits TodoWrite tool_use+tool_result, entry expands, structured TodoList renders with testIDs) |
-| `run-all.yaml` | Runs all 23 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, …) |
+| `run-all.yaml` | Runs all 24 flows sequentially — see its commented list for the full per-flow inventory (session, plan approval, AskUserQuestion, terminal, reconnect, disconnected-permission no-op, diff inline-comment, compaction marker, …) |
 
 ### Fixture Seeding for Structured Renderers
 

--- a/packages/app/.maestro/compaction-marker.yaml
+++ b/packages/app/.maestro/compaction-marker.yaml
@@ -51,13 +51,19 @@ name: ChatView compaction marker rendering
 
 # Assert the structured content: headline, token delta, and trigger.
 # The mock fixture's exact numbers/trigger are pinned in mock-server.mjs's
-# 'show-compaction' branch (128,000 → 12,000 tokens, auto).
+# 'show-compaction' branch (128,000 → 12,000 tokens, auto). The token-delta
+# assertion below is deliberately separator-agnostic: CompactionMarker.tsx
+# formats the counts via locale-dependent toLocaleString(), so a non-en-US
+# simulator renders e.g. "128.000" (de-DE) or "128 000" (fr-FR, narrow
+# no-break space) instead of "128,000". `.?` matches any single separator
+# character (or none), while the pinned digit groups still fail the
+# assertion if the wrong NUMBER renders.
 - assertVisible:
     text: "Context compacted"
 - assertVisible:
     id: "compaction-marker-tokens"
 - assertVisible:
-    text: ".*128,000.*12,000.*tokens.*"
+    text: ".*128.?000.*12.?000.*tokens.*"
 - assertVisible:
     id: "compaction-marker-trigger"
 

--- a/packages/app/.maestro/compaction-marker.yaml
+++ b/packages/app/.maestro/compaction-marker.yaml
@@ -1,0 +1,64 @@
+appId: com.blamechris.chroxy
+name: ChatView compaction marker rendering
+---
+
+# #6972 — mobile parity for the dashboard's CompactionMarker (#6768/#6970).
+# End-to-end coverage for the "Context compacted" divider: the wire's
+# `compact_boundary` system event carries structured `compactMetadata`
+# (trigger/preTokens/postTokens/durationMs), and the shared
+# `buildChatViewMessages` pipeline (@chroxy/store-core) filters ALL
+# `type: 'system'` messages off the Chat tab (they're meant for the
+# dashboard's System tab). Mobile has no System-tab equivalent, so
+# ChatView.tsx's `insertCompactionMarkers` reinserts the
+# compactMetadata-carrying subset back inline — this flow pins that the
+# marker actually reaches the screen, not just that the component renders
+# in isolation (jest already covers that).
+#
+# Trigger: 'show-compaction' user input → mock-server.mjs emits a
+# synthetic `{ type: 'message', messageType: 'system',
+# subtype: 'compact_boundary', compactMetadata }` envelope — the same
+# wire shape sdk-session.js / cli-session.js emit for a real compaction
+# boundary. The fixture seeding pattern is documented in CLAUDE.md →
+# "Fixture Seeding for Structured Renderers".
+#
+# Tested devices: iPhone 16 Pro (iOS 18.6), portrait.
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+
+- runFlow: setup/ensure-session-screen.yaml
+
+# Make sure Chat tab is selected
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# Find the input area and type the trigger phrase that makes the mock
+# server emit a synthetic compact_boundary system event.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-compaction"
+
+# Send the message — testID added in InputBar.tsx.
+- tapOn:
+    id: "chat-send-button"
+
+# Wait for the marker row to land. testID set on the outer View in
+# CompactionMarker.tsx.
+- extendedWaitUntil:
+    visible:
+      id: "compaction-marker"
+    timeout: 10000
+
+# Assert the structured content: headline, token delta, and trigger.
+# The mock fixture's exact numbers/trigger are pinned in mock-server.mjs's
+# 'show-compaction' branch (128,000 → 12,000 tokens, auto).
+- assertVisible:
+    text: "Context compacted"
+- assertVisible:
+    id: "compaction-marker-tokens"
+- assertVisible:
+    text: ".*128,000.*12,000.*tokens.*"
+- assertVisible:
+    id: "compaction-marker-trigger"
+
+- takeScreenshot: compaction-marker-inline

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -34,6 +34,10 @@ let showAskUserQuestionCounter = 0
 // unique toolUseIds so React keys + tool_result patching stay independent.
 let showWebSearchCounter = 0
 let showWebFetchCounter = 0
+// #6972: per-trigger counter for the compaction-marker fixture. Same
+// rationale as `show-todos` — repeated invocations need a unique
+// messageId so React keys stay independent.
+let showCompactionCounter = 0
 
 // #5468: connection counter — incremented once per `auth` message, used only
 // for the marker's text ("mock reconnect #N") + the [mock] Auth #N log line.
@@ -817,6 +821,44 @@ wss.on('connection', (ws) => {
           })
           secureSend(ws, { type: 'result', cost: 0.001, duration: 100, usage: {}, sessionId: 'mock-sess-1' })
           secureSend(ws, { type: 'agent_idle', sessionId: 'mock-sess-1' })
+          break
+        }
+
+        // #6972: trigger phrase 'show-compaction' emits a synthetic
+        // `compact_boundary` system event so the mobile CompactionMarker
+        // (mobile parity for the dashboard's #6768/#6970 marker) can be
+        // exercised end-to-end over the real WS protocol — same wire
+        // shape sdk-session.js / cli-session.js emit (see
+        // packages/server/src/claude-stream-parser.js
+        // parseCompactBoundaryMeta / formatCompactBoundaryContent) and
+        // the same shape packages/store-core/src/handlers/stream.ts
+        // handleMessage's `parseCompactMetadata` gate expects
+        // (`messageType: 'system'`, `subtype: 'compact_boundary'`,
+        // `compactMetadata`). Not a tool call and not an assistant turn —
+        // no agent_busy/agent_idle wrapper, matching how a real compaction
+        // boundary can land mid-session on its own.
+        //
+        // `preTokens`/`postTokens`/`durationMs` are deliberately non-null
+        // here (the "full metadata" case); CompactionMarker's null-safety
+        // for an SDK/CLI that omits a sub-field is covered by the jest
+        // unit tests, not this fixture.
+        if (text.trim() === 'show-compaction') {
+          showCompactionCounter += 1
+          secureSend(ws, {
+            type: 'message',
+            messageType: 'system',
+            subtype: 'compact_boundary',
+            content: 'Context compacted (auto): 128,000 → 12,000 tokens',
+            compactMetadata: {
+              trigger: 'auto',
+              preTokens: 128000,
+              postTokens: 12000,
+              durationMs: 2500,
+            },
+            messageId: `sys-compaction-mock-${showCompactionCounter}`,
+            timestamp: Date.now(),
+            sessionId: 'mock-sess-1',
+          })
           break
         }
 

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -138,3 +138,10 @@ name: All E2E flows
 # taps a diff line, leaves a comment, submits it, and asserts the composed
 # composeCommentReviewPrompt() text lands in chat as the next user turn.
 - runFlow: diff-comment.yaml
+
+# Flow 24: ChatView compaction marker rendering (#6972) — mobile parity
+# for the dashboard's CompactionMarker (#6768/#6970). Exercises the
+# `compact_boundary` system event → insertCompactionMarkers reinsertion →
+# CompactionMarker render chain via mock-server 'show-compaction' trigger,
+# asserting the "Context compacted" headline + token delta + trigger.
+- runFlow: compaction-marker.yaml

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -23,6 +23,8 @@ import { ToolDetailModal } from './chat/ToolDetailModal';
 import { MessageBubble } from './chat/MessageBubble';
 import type { SelectOptionValue } from './chat/MessageBubble';
 import type { MultiQuestionAnswersMap } from './chat/MultiQuestionForm';
+import { CompactionMarker } from './CompactionMarker';
+import { insertCompactionMarkers } from './insertCompactionMarkers';
 import { buildChatViewMessages, isRetryableAskUserQuestionError } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 import { usePermissionAnnouncer } from '../hooks/usePermissionAnnouncer';
@@ -336,12 +338,23 @@ export function ChatView({
   // ActivityGroup / MessageBubble; `chatTailMessageId` and
   // `stalledPromptIds` (#4615) flow straight through.
   const {
-    displayGroups,
+    displayGroups: baseDisplayGroups,
     chatTailMessageId,
     stalledPromptIds,
   } = useMemo(
     () => buildChatViewMessages(messages, streamingMessageId),
     [messages, streamingMessageId],
+  );
+
+  // #6972 — mobile parity: buildChatViewMessages filters `type: 'system'`
+  // off the Chat tab entirely (they're meant for the dashboard's System
+  // tab, which mobile has no equivalent of). Reinsert only the
+  // `compactMetadata`-carrying subset inline, in timestamp order, so the
+  // "Context compacted" marker is reachable at all on mobile. See
+  // insertCompactionMarkers's doc comment for the full placement rationale.
+  const displayGroups = useMemo(
+    () => insertCompactionMarkers(baseDisplayGroups, messages),
+    [baseDisplayGroups, messages],
   );
 
   // #5517: map every message id (and each id inside an activity group) to its
@@ -436,6 +449,23 @@ export function ChatView({
         );
       }
       const msg = group.message;
+      // #6972 — distinct "Context compacted" marker for a system message
+      // carrying `compactMetadata` (reinserted by insertCompactionMarkers
+      // above). Replaces the whole row — same early-return-before-the-
+      // generic-bubble shape the dashboard's useMessageRenderer uses for
+      // this same field.
+      if (msg.type === 'system' && msg.compactMetadata) {
+        return (
+          <AnimatedMessage
+            type={msg.type}
+            timestamp={msg.timestamp}
+            mountTime={mountTimeRef.current}
+            reduceMotion={reduceMotion}
+          >
+            <CompactionMarker meta={msg.compactMetadata} />
+          </AnimatedMessage>
+        );
+      }
       // #4615 (mobile parity via #4806): suppress unanswered prompts
       // invalidated by a subsequent ASK_USER_QUESTION_STALL. The pending
       // prompt has already been discarded server-side; the stall-chip

--- a/packages/app/src/components/CompactionMarker.tsx
+++ b/packages/app/src/components/CompactionMarker.tsx
@@ -1,0 +1,98 @@
+/**
+ * CompactionMarker — #6972 (mobile parity for the dashboard's
+ * packages/dashboard/src/components/CompactionMarker.tsx, #6768/#6970).
+ *
+ * Distinct "Context compacted" divider for a `compact_boundary` SDK/CLI
+ * system event (see store-core `ChatMessage.compactMetadata`). Renders in
+ * place of the generic muted system bubble that would otherwise show only
+ * the improved-but-plain fallback `content` string (e.g. "Context
+ * compacted (auto): 128,000 → 12,000 tokens") — same class of upgrade
+ * #6768 gave the dashboard.
+ *
+ * Placement (#6972 acceptance criterion — deliberate, not copy-pasted from
+ * the dashboard's System-tab convention): the dashboard shows this on a
+ * dedicated System tab because its shared `buildChatViewMessages` pipeline
+ * (`@chroxy/store-core`) filters `type: 'system'` off the Chat tab
+ * entirely. Mobile has no System-tab equivalent (dual-view is Chat/
+ * Terminal only), so `ChatView.tsx` reinserts compaction-marker messages
+ * back into the Chat feed inline via `insertCompactionMarkers` — this
+ * component is that inline row, not a System-tab card.
+ *
+ * Deliberately non-interactive (mirrors the dashboard) — a compaction
+ * boundary is informational. `preTokens`/`postTokens`/`durationMs` are
+ * `null`, not absent, when the SDK/CLI itself omitted that sub-field
+ * (store-core's `CompactBoundaryMeta` gives renderers a stable shape); the
+ * `formatTokens` guard below renders `?` instead of the literal string
+ * "null", and the duration/token clauses are omitted entirely rather than
+ * printing "NaN" when their value is null.
+ */
+import { StyleSheet, Text, View } from 'react-native';
+import { formatDurationTerse } from '@chroxy/store-core';
+import type { CompactBoundaryMeta } from '@chroxy/store-core';
+import { COLORS } from '../constants/colors';
+
+export interface CompactionMarkerProps {
+  meta: CompactBoundaryMeta;
+}
+
+function formatTokens(n: number | null): string {
+  return n == null ? '?' : n.toLocaleString();
+}
+
+export function CompactionMarker({ meta }: CompactionMarkerProps) {
+  const hasTokens = meta.preTokens != null || meta.postTokens != null;
+  const triggerLabel = meta.trigger === 'manual' ? 'manual' : 'auto';
+
+  return (
+    <View testID="compaction-marker" style={styles.container}>
+      <Text
+        style={styles.icon}
+        accessibilityElementsHidden
+        importantForAccessibility="no"
+      >
+        ⊙
+      </Text>
+      <Text style={styles.text} selectable>
+        <Text>Context compacted</Text>
+        {hasTokens && (
+          <Text testID="compaction-marker-tokens">
+            {` · ${formatTokens(meta.preTokens)} → ${formatTokens(meta.postTokens)} tokens`}
+          </Text>
+        )}
+        {meta.durationMs != null && (
+          <Text testID="compaction-marker-duration">
+            {` · ${formatDurationTerse(meta.durationMs)}`}
+          </Text>
+        )}
+        <Text testID="compaction-marker-trigger">{` · ${triggerLabel}`}</Text>
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    alignSelf: 'stretch',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    marginVertical: 4,
+    gap: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.accentGrayBorder,
+    backgroundColor: COLORS.accentGrayLight,
+  },
+  icon: {
+    fontSize: 12,
+    lineHeight: 16,
+    color: COLORS.textDim,
+  },
+  text: {
+    flex: 1,
+    fontSize: 11,
+    lineHeight: 16,
+    color: COLORS.textDim,
+  },
+});

--- a/packages/app/src/components/__tests__/CompactionMarker.test.tsx
+++ b/packages/app/src/components/__tests__/CompactionMarker.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * CompactionMarker tests — #6972 (mobile parity for the dashboard's
+ * packages/dashboard/src/components/CompactionMarker.tsx, #6768/#6970).
+ *
+ * Mirrors ResumeUnknownChip.test.tsx / StreamStallChip.test.tsx — plain
+ * react-test-renderer + act, no `@testing-library/react-native` dependency.
+ *
+ * Covers the three cases called out in #6972's acceptance criteria:
+ *   - full metadata renders the token delta + duration + trigger
+ *   - null token counts / null duration render gracefully (never the
+ *     literal string "null" or "NaN" — store-core's `CompactBoundaryMeta`
+ *     uses null, not absent, for an SDK/CLI sub-field the producer omitted)
+ *   - trigger renders 'manual' vs 'auto' correctly
+ *
+ * The "absent compactMetadata → no marker" case lives in
+ * insertCompactionMarkers.test.tsx: this component's `meta` prop is
+ * required (mirrors the dashboard's signature exactly), so "absent" is a
+ * wiring/selector decision, not something this component can be asked to
+ * render.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import type { CompactBoundaryMeta } from '@chroxy/store-core';
+import { CompactionMarker } from '../CompactionMarker';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root
+    .findAllByType(Text)
+    .map((node) => {
+      const c = node.props.children;
+      if (typeof c === 'string' || typeof c === 'number') return String(c);
+      if (Array.isArray(c)) {
+        return c
+          .map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : ''))
+          .join('');
+      }
+      return '';
+    })
+    .join('');
+}
+
+describe('CompactionMarker (#6972)', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => {
+        activeTree!.unmount();
+      });
+      activeTree = null;
+    }
+  });
+
+  function render(node: React.ReactElement): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(node);
+    });
+    activeTree = tree;
+    return tree;
+  }
+
+  const fullMeta: CompactBoundaryMeta = {
+    trigger: 'auto',
+    preTokens: 128_000,
+    postTokens: 12_000,
+    durationMs: 2_500,
+  };
+
+  it('renders the token delta, duration, and trigger from full metadata', () => {
+    const tree = render(<CompactionMarker meta={fullMeta} />);
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Context compacted');
+    // Locale-agnostic — assert against the runtime's own toLocaleString()
+    // rather than a hard-coded "128,000" (a prior PR was bitten by this,
+    // see CLAUDE.md's "Numbers" testing convention).
+    expect(text).toContain(`${(128_000).toLocaleString()} → ${(12_000).toLocaleString()} tokens`);
+    expect(text).toContain('2s');
+    expect(text).toContain('auto');
+    expect(tree.root.findByProps({ testID: 'compaction-marker' })).toBeTruthy();
+  });
+
+  it('renders the "manual" trigger label when trigger is manual', () => {
+    const tree = render(
+      <CompactionMarker meta={{ ...fullMeta, trigger: 'manual' }} />,
+    );
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('manual');
+    expect(text).not.toContain('auto');
+  });
+
+  it('renders gracefully when preTokens/postTokens/durationMs are all null (never prints "null" or "NaN")', () => {
+    const tree = render(
+      <CompactionMarker
+        meta={{ trigger: 'manual', preTokens: null, postTokens: null, durationMs: null }}
+      />,
+    );
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Context compacted');
+    expect(text).toContain('manual');
+    expect(text).not.toMatch(/null/i);
+    expect(text).not.toMatch(/nan/i);
+    // Both token fields null → the token clause is omitted entirely
+    // (mirrors the dashboard: `if (preTokens != null || postTokens != null)`).
+    expect(text).not.toContain('tokens');
+    expect(tree.root.findAllByProps({ testID: 'compaction-marker-tokens' })).toHaveLength(0);
+    expect(tree.root.findAllByProps({ testID: 'compaction-marker-duration' })).toHaveLength(0);
+  });
+
+  it('falls back to "?" for a single null token field without crashing or printing "null"', () => {
+    const tree = render(
+      <CompactionMarker
+        meta={{ trigger: 'auto', preTokens: null, postTokens: 12_000, durationMs: null }}
+      />,
+    );
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain(`? → ${(12_000).toLocaleString()} tokens`);
+    expect(text).not.toMatch(/null/i);
+    expect(text).not.toMatch(/nan/i);
+  });
+
+  it('omits the duration clause when durationMs is null but still renders the token delta', () => {
+    const tree = render(
+      <CompactionMarker
+        meta={{ trigger: 'auto', preTokens: 1_000, postTokens: 500, durationMs: null }}
+      />,
+    );
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain(`${(1_000).toLocaleString()} → ${(500).toLocaleString()} tokens`);
+    expect(tree.root.findAllByProps({ testID: 'compaction-marker-duration' })).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/__tests__/insertCompactionMarkers.test.ts
+++ b/packages/app/src/components/__tests__/insertCompactionMarkers.test.ts
@@ -1,0 +1,108 @@
+/**
+ * insertCompactionMarkers tests — #6972.
+ *
+ * Pins the mobile-only placement decision: buildChatViewMessages
+ * (@chroxy/store-core, shared with the dashboard) filters ALL
+ * `type: 'system'` messages off the Chat-tab derivation. Mobile has no
+ * System-tab equivalent to show them on instead, so ChatView reinserts
+ * only the `compactMetadata`-carrying subset back in, positioned by
+ * timestamp. See the module's own doc comment for the full rationale
+ * (including why widening the shared store-core filter was rejected).
+ */
+import type { DisplayGroup } from '@chroxy/store-core';
+import type { ChatMessage } from '../../store/connection';
+import { insertCompactionMarkers } from '../insertCompactionMarkers';
+
+function msg(partial: Partial<ChatMessage> & { id: string; type: ChatMessage['type'] }): ChatMessage {
+  return {
+    content: '',
+    timestamp: 0,
+    ...partial,
+  } as ChatMessage;
+}
+
+function singleGroup(message: ChatMessage): DisplayGroup {
+  return { type: 'single', message };
+}
+
+describe('insertCompactionMarkers (#6972)', () => {
+  it('returns the base groups unchanged when no message carries compactMetadata', () => {
+    const messages: ChatMessage[] = [
+      msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 1 }),
+      msg({ id: 'r1', type: 'response', content: 'hello', timestamp: 2 }),
+    ];
+    const baseGroups = [singleGroup(messages[0]), singleGroup(messages[1])];
+    const out = insertCompactionMarkers(baseGroups, messages);
+    expect(out).toEqual(baseGroups);
+  });
+
+  it('does NOT insert a marker for a system message without compactMetadata (absent → no marker)', () => {
+    const messages: ChatMessage[] = [
+      msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 1 }),
+      // Plain system chatter (e.g. a connected/disconnected notice) — no
+      // compactMetadata, so it should stay filtered out exactly as
+      // buildChatViewMessages already does for every non-compaction
+      // system message.
+      msg({ id: 's1', type: 'system', content: 'connected', timestamp: 2 }),
+    ];
+    const baseGroups = [singleGroup(messages[0])]; // buildChatViewMessages already dropped s1
+    const out = insertCompactionMarkers(baseGroups, messages);
+    expect(out).toEqual(baseGroups);
+    expect(out.some((g) => g.type === 'single' && g.message.id === 's1')).toBe(false);
+  });
+
+  it('reinserts a compactMetadata system message at the end when it is the most recent', () => {
+    const compactionMeta: ChatMessage['compactMetadata'] = {
+      trigger: 'auto',
+      preTokens: 128_000,
+      postTokens: 12_000,
+      durationMs: 2_500,
+    };
+    const messages: ChatMessage[] = [
+      msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 1 }),
+      msg({ id: 'r1', type: 'response', content: 'hello', timestamp: 2 }),
+      msg({ id: 'sys1', type: 'system', content: 'Context compacted', timestamp: 3, compactMetadata: compactionMeta }),
+    ];
+    // buildChatViewMessages would have already dropped sys1 from the base groups.
+    const baseGroups = [singleGroup(messages[0]), singleGroup(messages[1])];
+    const out = insertCompactionMarkers(baseGroups, messages);
+    expect(out).toHaveLength(3);
+    expect(out[2]).toEqual(singleGroup(messages[2]));
+  });
+
+  it('reinserts a compactMetadata system message in chronological order between existing rows', () => {
+    const compactionMeta: ChatMessage['compactMetadata'] = {
+      trigger: 'manual',
+      preTokens: null,
+      postTokens: null,
+      durationMs: null,
+    };
+    const early = msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 1 });
+    const boundary = msg({ id: 'sys1', type: 'system', content: 'Context compacted', timestamp: 5, compactMetadata: compactionMeta });
+    const late = msg({ id: 'r1', type: 'response', content: 'hello', timestamp: 10 });
+    const messages: ChatMessage[] = [early, boundary, late];
+    const baseGroups = [singleGroup(early), singleGroup(late)];
+    const out = insertCompactionMarkers(baseGroups, messages);
+    expect(out.map((g) => (g.type === 'single' ? g.message.id : g.key))).toEqual([
+      'u1',
+      'sys1',
+      'r1',
+    ]);
+  });
+
+  it('reinserts multiple compactMetadata markers, each in its own timestamp slot', () => {
+    const metaA: ChatMessage['compactMetadata'] = { trigger: 'auto', preTokens: 100, postTokens: 10, durationMs: 100 };
+    const metaB: ChatMessage['compactMetadata'] = { trigger: 'manual', preTokens: 200, postTokens: 20, durationMs: 200 };
+    const first = msg({ id: 'sysA', type: 'system', content: 'a', timestamp: 2, compactMetadata: metaA });
+    const middle = msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 5 });
+    const second = msg({ id: 'sysB', type: 'system', content: 'b', timestamp: 8, compactMetadata: metaB });
+    const messages: ChatMessage[] = [first, middle, second];
+    const baseGroups = [singleGroup(middle)];
+    const out = insertCompactionMarkers(baseGroups, messages);
+    expect(out.map((g) => (g.type === 'single' ? g.message.id : g.key))).toEqual([
+      'sysA',
+      'u1',
+      'sysB',
+    ]);
+  });
+});

--- a/packages/app/src/components/insertCompactionMarkers.ts
+++ b/packages/app/src/components/insertCompactionMarkers.ts
@@ -1,0 +1,61 @@
+/**
+ * insertCompactionMarkers — #6972 mobile parity for the dashboard's
+ * CompactionMarker (#6768/#6970).
+ *
+ * The shared `buildChatViewMessages` pipeline (`@chroxy/store-core`)
+ * unconditionally filters `type: 'system'` messages off the Chat-tab
+ * derivation for BOTH the dashboard and mobile — see its own doc comment:
+ * "System events render on the System tab." That's correct for the
+ * dashboard, which has a dedicated System tab to show them on instead. The
+ * mobile app has no equivalent surface (its dual-view is Chat/Terminal
+ * only), so leaving that filter as the final word makes a `compact_
+ * boundary` marker invisible on mobile entirely — worse than the
+ * pre-#6970 plain-text fallback it was meant to replace.
+ *
+ * Deliberate placement decision (#6972 acceptance criterion — "not just
+ * copy-pasted from dashboard's System-tab convention"): mobile reinserts
+ * ONLY the subset of system messages carrying `compactMetadata` back into
+ * the Chat-tab display list, positioned by original timestamp, as their
+ * own single-row group rendered by `CompactionMarker`. Every OTHER system
+ * message (a stray `evaluator`/`mcpPromptExpansion`/generic system
+ * chatter) still has no mobile renderer and stays hidden — this is scoped
+ * strictly to the one field this issue is chartered to surface, not a
+ * blanket un-filter of `buildChatViewMessages`. Widening the shared
+ * filter itself was considered and rejected: `useMessageRenderer` on the
+ * dashboard is shared across its Chat AND System tabs, so un-filtering at
+ * the store-core layer would make the marker render TWICE there.
+ *
+ * Pure and React-free so it's unit-testable without mounting a component;
+ * `ChatView.tsx` wraps the call in `useMemo`, keyed off the same
+ * `displayGroups` + `messages` it already recomputes on.
+ */
+import type { DisplayGroup } from '@chroxy/store-core';
+import type { ChatMessage } from '../store/connection';
+
+function groupTimestamp(group: DisplayGroup): number {
+  if (group.type === 'single') return group.message.timestamp;
+  return group.messages[0]?.timestamp ?? 0;
+}
+
+export function insertCompactionMarkers(
+  displayGroups: DisplayGroup[],
+  messages: ChatMessage[],
+): DisplayGroup[] {
+  const markers = messages.filter(
+    (m) => m.type === 'system' && m.compactMetadata != null,
+  );
+  if (markers.length === 0) return displayGroups;
+
+  const merged = [...displayGroups];
+  for (const marker of markers) {
+    let insertAt = merged.length;
+    for (let i = 0; i < merged.length; i++) {
+      if (groupTimestamp(merged[i]) > marker.timestamp) {
+        insertAt = i;
+        break;
+      }
+    }
+    merged.splice(insertAt, 0, { type: 'single', message: marker });
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

Mobile parity for the dashboard's `CompactionMarker` (#6768/#6970). Closes #6972.

The server already parses a `compact_boundary` SDK/CLI event into structured `compactMetadata` (`trigger`/`preTokens`/`postTokens`/`durationMs`) on a `type: 'system'` `ChatMessage`, and store-core's field already flows through to the app's `ChatMessage` type. The mobile app had no renderer for it and fell back to plain `content` text (or, as this PR discovered, to *nothing at all* — see the placement note below).

### What's new

- **`packages/app/src/components/CompactionMarker.tsx`** — RN divider showing the token delta (`128,000 → 12,000 tokens`), duration (`2s`), and manual/auto trigger, styled with the existing gray "system message" `COLORS` tokens (`accentGrayLight`/`accentGrayBorder`/`textDim`). Null-safe: `preTokens`/`postTokens`/`durationMs` are `null`, not absent, when the SDK/CLI itself omitted a sub-field — the component renders `?` for a missing token count and omits the duration/token clauses entirely rather than ever printing `"null"`/`"NaN"`.

### Placement decision (the acceptance criterion this PR takes most seriously)

The dashboard shows `CompactionMarker` on its **System tab** because the shared `buildChatViewMessages` pipeline (`@chroxy/store-core`, used by both dashboard and mobile) unconditionally filters **every** `type: 'system'` message off the Chat tab. Mobile has no System-tab equivalent (its dual-view is Chat/Terminal only) — so a `compact_boundary` system message was actually invisible on mobile entirely, not just rendered as plain text as the issue assumed.

Two options were considered:
1. Widen the shared `buildChatViewMessages` filter to let `compactMetadata` messages through to the Chat tab. **Rejected** — the dashboard's `useMessageRenderer` (which owns the `CompactionMarker` dispatch) is shared across its Chat tab AND System tab, so this would make the marker render **twice** on the dashboard.
2. Reinsert only the `compactMetadata`-carrying subset back into mobile's Chat feed, inline, positioned by timestamp — **without touching store-core**.

Went with (2): **`packages/app/src/components/insertCompactionMarkers.ts`** is a pure, React-free function that `ChatView.tsx` calls after `buildChatViewMessages` to splice compaction markers back into `displayGroups` by original timestamp. Every other `type: 'system'` message (there's no mobile renderer for `evaluator`/`mcpPromptExpansion` system messages either) stays filtered out exactly as before — this is scoped strictly to the one field #6972 charters.

`ChatView.tsx`'s `renderItem` then early-returns `<CompactionMarker>` for a `system` row carrying `compactMetadata`, replacing the row entirely — mirroring the dashboard's own early-return-before-the-generic-bubble shape in `useMessageRenderer`.

`store-core`/`protocol` are untouched — this reuses the existing wire fields end-to-end.

## How to verify in the iOS simulator

1. Build + install the dev client once, start Metro, and start the mock server (all from `packages/app/`):
   ```bash
   npx expo run:ios
   npx expo start
   bash .maestro/scripts/start-mock-server.sh
   ```
2. Either drive it by hand — connect to `ws://localhost:9876` / token `test-token-maestro`, land on Chat, and type **`show-compaction`** into the message input and send. The mock server (`packages/app/.maestro/mock-server.mjs`, `'show-compaction'` branch) emits the exact wire shape `sdk-session.js`/`cli-session.js` send for a real compaction boundary (`{ type: 'message', messageType: 'system', subtype: 'compact_boundary', compactMetadata: { trigger: 'auto', preTokens: 128000, postTokens: 12000, durationMs: 2500 } }`) — no live compaction needed.
3. Or run the new Maestro flow end-to-end:
   ```bash
   export PATH="$PATH:$HOME/.maestro/bin"
   maestro test --device <device-id> packages/app/.maestro/compaction-marker.yaml
   ```
   It types `show-compaction`, sends it, waits for `testID="compaction-marker"`, asserts the "Context compacted" headline + the `128,000 → 12,000 tokens` delta + the `auto` trigger, and screenshots as `compaction-marker-inline`.

Registered as flow 24 in `run-all.yaml`; flow count bumped in `CLAUDE.md` (23 → 24) with `AGENTS.md` regenerated via `node scripts/gen-agents-md.mjs` in the same commit.

## Test plan

- [x] `cd packages/app && npx tsc --noEmit` — clean
- [x] `npx jest src/components/__tests__/CompactionMarker.test.tsx src/components/__tests__/insertCompactionMarkers.test.ts --coverage=false` — 10/10 passing. Covers: full metadata render, `manual` vs `auto` trigger, all-null token/duration fields (never prints `"null"`/`"NaN"`), single-null-token fallback to `?`, omitted duration clause, `insertCompactionMarkers`' timestamp-ordering + multi-marker + **absent-`compactMetadata`-→-no-marker** case
- [x] `npx jest ChatView MessageBubble StreamStallChip ResumeUnknownChip --coverage=false` — no regressions (81+17 passing)
- [x] `npx jest --coverage=false` (full app suite) — 178 suites / 2284 tests passing
- [ ] Manual/Maestro simulator verification (see instructions above) — over to you