### PR TITLE
feat(dashboard): memory panel — merged CLAUDE.md hierarchy with provenance

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -59,6 +59,7 @@ import { PendingPairRequests } from './components/PendingPairRequests'
 import { type ToastItem } from './components/Toast'
 import { FileBrowserPanel } from './components/FileBrowserPanel'
 import { GitPanel } from './components/GitPanel'
+import { MemoryPanel } from './components/MemoryPanel'
 import { CheckpointTimeline } from './components/CheckpointTimeline'
 import { FooterBar } from './components/FooterBar'
 import { type ShortcutEntry } from './components/ShortcutHelp'
@@ -2554,6 +2555,12 @@ export function App() {
                     status/diff wiring. */}
                 {viewMode === 'git' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <GitPanel />
+                )}
+                {/* #6867 (epic #6760) — dashboard memory panel: merged
+                    CLAUDE.md hierarchy with per-file provenance, plus the
+                    auto-generated MEMORY.md browsable read view. */}
+                {viewMode === 'memory' && connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <MemoryPanel />
                 )}
                 {/*
                   #4397 — system tab uses the same display:none kept-alive

--- a/packages/dashboard/src/components/MemoryPanel.test.tsx
+++ b/packages/dashboard/src/components/MemoryPanel.test.tsx
@@ -17,6 +17,7 @@ let mockEntries: MemoryStackEntry[] | null = null
 let mockFile: MemoryFileDescriptor | null = null
 let mockError: string | null = null
 let mockLoading = false
+let mockActiveSessionId: string | null = 's1'
 
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: unknown) => unknown) =>
@@ -27,6 +28,7 @@ vi.mock('../store/connection', () => ({
       memoryStackFile: mockFile,
       memoryStackError: mockError,
       memoryStackLoading: mockLoading,
+      activeSessionId: mockActiveSessionId,
     }),
 }))
 
@@ -39,6 +41,7 @@ beforeEach(() => {
   mockFile = null
   mockError = null
   mockLoading = false
+  mockActiveSessionId = 's1'
 })
 
 const GLOBAL_ENTRY: MemoryStackEntry = {
@@ -177,6 +180,42 @@ describe('MemoryPanel', () => {
     render(<MemoryPanel />)
     mockRequestMemoryRead.mockClear()
     fireEvent.click(screen.getByTestId('memory-refresh-btn'))
+    expect(mockRequestMemoryRead).toHaveBeenCalledOnce()
+  })
+
+  // #6996 review — CRITICAL regression guard: memory_read has no
+  // client-supplied sessionId (the server scopes it to the caller's active
+  // session cwd), so a switch to a different session must never leave the
+  // PREVIOUS session's stack on screen. switchSession() (store/connection.ts)
+  // resets memoryStackEntries/File/Error/Loading to null on every switch;
+  // this test proves the panel actually re-fetches for the new session
+  // *while it stays mounted* (no unmount/remount — the same MemoryPanel
+  // instance persists across the rerender, exactly as it would if the panel
+  // is open and the user clicks a different session tab) rather than relying
+  // on App.tsx's incidental unmount/remount around session switches.
+  it('re-fetches when the active session changes while the panel stays mounted, instead of showing stale entries', () => {
+    mockActiveSessionId = 's1'
+    mockEntries = [PROJECT_ENTRY]
+    const { rerender } = render(<MemoryPanel />)
+    expect(screen.getByText('/repo/CLAUDE.md')).toBeTruthy()
+    mockRequestMemoryRead.mockClear()
+
+    // Simulate switchSession('s2'): the store resets the memory-stack fields
+    // to null/false and flips activeSessionId — same component instance,
+    // no unmount.
+    mockActiveSessionId = 's2'
+    mockEntries = null
+    mockFile = null
+    mockError = null
+    mockLoading = false
+    rerender(<MemoryPanel />)
+
+    // The previous session's entry must be gone immediately (store already
+    // cleared it) ...
+    expect(screen.queryByText('/repo/CLAUDE.md')).toBeNull()
+    // ... and the panel must have fired a fresh request for the new session
+    // rather than sitting blank waiting for a mount effect that will never
+    // re-run.
     expect(mockRequestMemoryRead).toHaveBeenCalledOnce()
   })
 })

--- a/packages/dashboard/src/components/MemoryPanel.test.tsx
+++ b/packages/dashboard/src/components/MemoryPanel.test.tsx
@@ -134,6 +134,27 @@ describe('MemoryPanel', () => {
     expect(screen.getByTestId('memory-entry-content-0').textContent).toContain('Project notes')
   })
 
+  // #6996 review — an entry whose file exists but whose content is empty (or
+  // whitespace-only) must still be shown as PRESENT (honest provenance — an
+  // empty CLAUDE.md is not the same as a missing one), but must NOT offer a
+  // dead expand affordance that opens to nothing.
+  it('shows an existing-but-empty entry as present without an expand affordance', () => {
+    mockEntries = [{ ...PROJECT_ENTRY, content: '   \n\t  ' }]
+    render(<MemoryPanel />)
+    const row = screen.getByTestId('memory-entry-0')
+    expect(row.textContent).toContain('Present')
+    const toggle = screen.getByTestId('memory-entry-toggle-0')
+    expect(toggle).toBeDisabled()
+    fireEvent.click(toggle)
+    expect(screen.queryByTestId('memory-entry-content-0')).toBeNull()
+  })
+
+  it('still allows expanding a non-empty entry (regression guard alongside the empty-content fix)', () => {
+    mockEntries = [PROJECT_ENTRY]
+    render(<MemoryPanel />)
+    expect(screen.getByTestId('memory-entry-toggle-0')).not.toBeDisabled()
+  })
+
   it('renders entry content escaped — a <script> tag never executes and appears as text', () => {
     mockEntries = [
       { ...PROJECT_ENTRY, content: 'Notes: <script>window.__xss = true</script> after' },
@@ -163,6 +184,22 @@ describe('MemoryPanel', () => {
     const section = screen.getByTestId('memory-file-section')
     expect(section.textContent).toContain('MEMORY.md')
     expect(section.textContent).toContain('/home/me/.claude/projects/repo/memory/MEMORY.md')
+  })
+
+  it('shows the MEMORY.md section as present without an expand affordance when its content is blank', () => {
+    mockEntries = [PROJECT_ENTRY]
+    mockFile = {
+      path: '/home/me/.claude/projects/repo/memory/MEMORY.md',
+      exists: true,
+      content: '',
+      truncated: false,
+      skipped: false,
+      error: null,
+    }
+    render(<MemoryPanel />)
+    const section = screen.getByTestId('memory-file-section')
+    expect(section.textContent).toContain('Present')
+    expect(screen.getByTestId('memory-file-toggle')).toBeDisabled()
   })
 
   it('surfaces a request-level error state instead of crashing', () => {

--- a/packages/dashboard/src/components/MemoryPanel.test.tsx
+++ b/packages/dashboard/src/components/MemoryPanel.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * MemoryPanel — tests for the dashboard memory panel (#6867, epic #6760).
+ *
+ * Mirrors the FileBrowserPanel.test.tsx mocking idiom: the store is mocked
+ * with a mutable state getter so tests can simulate a `memory_stack_result`
+ * having landed by mutating the module-level state and re-rendering.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MemoryPanel } from './MemoryPanel'
+import type { MemoryFileDescriptor, MemoryStackEntry } from '../store/types'
+
+const mockRequestMemoryRead = vi.fn()
+
+let mockConnectionPhase: string = 'connected'
+let mockEntries: MemoryStackEntry[] | null = null
+let mockFile: MemoryFileDescriptor | null = null
+let mockError: string | null = null
+let mockLoading = false
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      connectionPhase: mockConnectionPhase,
+      requestMemoryRead: mockRequestMemoryRead,
+      memoryStackEntries: mockEntries,
+      memoryStackFile: mockFile,
+      memoryStackError: mockError,
+      memoryStackLoading: mockLoading,
+    }),
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockConnectionPhase = 'connected'
+  mockEntries = null
+  mockFile = null
+  mockError = null
+  mockLoading = false
+})
+
+const GLOBAL_ENTRY: MemoryStackEntry = {
+  path: '/home/me/.claude/CLAUDE.md',
+  exists: true,
+  content: '# Global notes\n\nSome global guidance.',
+  truncated: false,
+  skipped: false,
+  error: null,
+  scope: 'global',
+  importedFrom: null,
+}
+
+const PROJECT_ENTRY: MemoryStackEntry = {
+  path: '/repo/CLAUDE.md',
+  exists: true,
+  content: '# Project notes',
+  truncated: false,
+  skipped: false,
+  error: null,
+  scope: 'project',
+  importedFrom: null,
+}
+
+const LOCAL_ENTRY_MISSING: MemoryStackEntry = {
+  path: '/repo/CLAUDE.local.md',
+  exists: false,
+  content: null,
+  truncated: false,
+  skipped: false,
+  error: null,
+  scope: 'local',
+  importedFrom: null,
+}
+
+describe('MemoryPanel', () => {
+  it('requests the memory stack on mount', () => {
+    render(<MemoryPanel />)
+    expect(mockRequestMemoryRead).toHaveBeenCalledOnce()
+  })
+
+  it('shows a loading state before the first reply', () => {
+    mockLoading = true
+    render(<MemoryPanel />)
+    expect(screen.getByTestId('memory-loading')).toBeTruthy()
+  })
+
+  it('renders the stack in precedence order (global, project, local)', () => {
+    mockEntries = [GLOBAL_ENTRY, PROJECT_ENTRY, LOCAL_ENTRY_MISSING]
+    render(<MemoryPanel />)
+    const badges = screen.getAllByText(/Global|Project|Local/)
+    expect(badges.map((el) => el.textContent)).toEqual(['Global', 'Project', 'Local'])
+  })
+
+  it('shows a missing file as "Not present" rather than hiding it', () => {
+    mockEntries = [GLOBAL_ENTRY, PROJECT_ENTRY, LOCAL_ENTRY_MISSING]
+    render(<MemoryPanel />)
+    const localRow = screen.getByTestId('memory-entry-2')
+    expect(localRow.textContent).toContain('Not present')
+    expect(localRow.textContent).toContain('/repo/CLAUDE.local.md')
+    // A missing entry has no content to expand — the toggle must be disabled.
+    expect(screen.getByTestId('memory-entry-toggle-2')).toBeDisabled()
+  })
+
+  it('shows a skipped @import entry with its skip reason instead of hiding it', () => {
+    mockEntries = [
+      {
+        path: '/home/me/.claude/.credentials.json',
+        exists: false,
+        content: null,
+        truncated: false,
+        skipped: true,
+        error: 'Outside allowed memory roots — read skipped',
+        scope: 'import',
+        importedFrom: '/repo/CLAUDE.md',
+      },
+    ]
+    render(<MemoryPanel />)
+    expect(screen.getByTestId('memory-entry-0').textContent).toContain('Skipped')
+    expect(screen.getByTestId('memory-entry-error-0').textContent).toBe(
+      'Outside allowed memory roots — read skipped',
+    )
+  })
+
+  it('expands an entry to reveal its content on click', () => {
+    mockEntries = [PROJECT_ENTRY]
+    render(<MemoryPanel />)
+    expect(screen.queryByTestId('memory-entry-content-0')).toBeNull()
+    fireEvent.click(screen.getByTestId('memory-entry-toggle-0'))
+    expect(screen.getByTestId('memory-entry-content-0').textContent).toContain('Project notes')
+  })
+
+  it('renders entry content escaped — a <script> tag never executes and appears as text', () => {
+    mockEntries = [
+      { ...PROJECT_ENTRY, content: 'Notes: <script>window.__xss = true</script> after' },
+    ]
+    const { container } = render(<MemoryPanel />)
+    fireEvent.click(screen.getByTestId('memory-entry-toggle-0'))
+    // The sanitized markdown pipeline must never leave a live <script> element
+    // in the DOM, and the global flag it would have set must never be defined.
+    expect(container.querySelector('script')).toBeNull()
+    expect((window as unknown as { __xss?: boolean }).__xss).toBeUndefined()
+    // The literal text still appears (escaped), proving the content wasn't
+    // silently dropped — only rendered inert.
+    expect(container.textContent).toContain('after')
+  })
+
+  it('renders the auto-generated MEMORY.md as a separate browsable section', () => {
+    mockEntries = [PROJECT_ENTRY]
+    mockFile = {
+      path: '/home/me/.claude/projects/repo/memory/MEMORY.md',
+      exists: true,
+      content: '# Auto memory',
+      truncated: false,
+      skipped: false,
+      error: null,
+    }
+    render(<MemoryPanel />)
+    const section = screen.getByTestId('memory-file-section')
+    expect(section.textContent).toContain('MEMORY.md')
+    expect(section.textContent).toContain('/home/me/.claude/projects/repo/memory/MEMORY.md')
+  })
+
+  it('surfaces a request-level error state instead of crashing', () => {
+    mockError = 'Memory is not available in this mode'
+    expect(() => render(<MemoryPanel />)).not.toThrow()
+    expect(screen.getByTestId('memory-stack-error').textContent).toBe(
+      'Memory is not available in this mode',
+    )
+    // The stack itself must not render while a request-level error is set.
+    expect(screen.queryByTestId('memory-stack')).toBeNull()
+  })
+
+  it('refresh button re-requests the stack', () => {
+    mockEntries = [PROJECT_ENTRY]
+    render(<MemoryPanel />)
+    mockRequestMemoryRead.mockClear()
+    fireEvent.click(screen.getByTestId('memory-refresh-btn'))
+    expect(mockRequestMemoryRead).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/dashboard/src/components/MemoryPanel.tsx
+++ b/packages/dashboard/src/components/MemoryPanel.tsx
@@ -1,0 +1,218 @@
+/**
+ * MemoryPanel (#6867, epic #6760) — dashboard memory panel.
+ *
+ * Renders the effective merged CLAUDE.md stack (global → project → local,
+ * Claude Code's own load/precedence order, with recursively-resolved
+ * @imports inlined depth-first right after the file that referenced them) in
+ * the order the server returns it — so the list itself IS the precedence
+ * order: earlier entries are loaded first, a later scope (local) overrides an
+ * earlier one (global/project). Also surfaces the project's auto-generated
+ * MEMORY.md as a browsable read view.
+ *
+ * Wiring: consumes the `memory_read` / `memory_stack_result` wire pair
+ * (#6864, PR #6969) via the dashboard store — requestMemoryRead() sends the
+ * request, handleMemoryStackResult (store/message-handler.ts) writes the
+ * reply into memoryStackEntries/memoryStackFile/memoryStackError
+ * (store/connection.ts). Mirrors the request/state-field shape
+ * requestHostStatus + hostStatus already use (not the one-shot-callback shape
+ * GitPanel's mutations use, since this is a plain read-and-display survey).
+ *
+ * READ-ONLY for v1. The parent issue's AC also asks for edit+save parity
+ * with the mobile app's full-screen FileEditor (reusing the existing
+ * write_file endpoint, gated by rejectMutationIfBound). That's deferred to a
+ * follow-up: the dashboard has ZERO client-side write plumbing today
+ * (write_file_result is an app-only wire type per the store-core contract
+ * fixtures, #5653 — FileBrowserPanel is read-only, confirmed by the IDE epic
+ * #6469), and the issue itself calls for reconciling the write path with the
+ * overlapping #6478 IDE P3 editable-file-browser slice first, to avoid
+ * shipping two divergent dashboard write paths. See the PR body for the
+ * follow-up issue link.
+ *
+ * Render safety: CLAUDE.md content is arbitrary, untrusted text. Every
+ * entry's content renders through MarkdownBody — the same sanitized
+ * renderMarkdown() + DOMPurify pipeline chat messages use (including the
+ * #6986 link-scheme allowlist) — never a raw dangerouslySetInnerHTML of file
+ * content.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { useConnectionStore } from '../store/connection'
+import { MarkdownBody } from './MarkdownBody'
+import type { MemoryFileDescriptor, MemoryStackEntry } from '../store/types'
+
+const SCOPE_LABEL: Record<MemoryStackEntry['scope'], string> = {
+  global: 'Global',
+  project: 'Project',
+  local: 'Local',
+  import: '@import',
+}
+
+function entryState(d: MemoryFileDescriptor): { label: string; cls: string } {
+  if (d.skipped) return { label: 'Skipped', cls: 'skipped' }
+  if (d.error) return { label: 'Error', cls: 'error' }
+  if (d.exists) return { label: 'Present', cls: 'exists' }
+  return { label: 'Not present', cls: 'missing' }
+}
+
+function DescriptorHeader({
+  descriptor, canExpand, expanded, onToggle, testId, children,
+}: {
+  descriptor: MemoryFileDescriptor
+  canExpand: boolean
+  expanded: boolean
+  onToggle: () => void
+  testId: string
+  children?: React.ReactNode
+}) {
+  const state = entryState(descriptor)
+  return (
+    <button
+      type="button"
+      className="memory-entry-header"
+      onClick={onToggle}
+      disabled={!canExpand}
+      data-testid={testId}
+    >
+      {children}
+      <span className="memory-entry-path" title={descriptor.path ?? undefined}>
+        {descriptor.path ?? '(unresolved)'}
+      </span>
+      <span className={`memory-entry-state memory-entry-state-${state.cls}`}>{state.label}</span>
+      {descriptor.truncated && <span className="memory-entry-truncated">Truncated</span>}
+      {canExpand && <span className="memory-entry-caret">{expanded ? '▾' : '▸'}</span>}
+    </button>
+  )
+}
+
+function EntryRow({ entry, index }: { entry: MemoryStackEntry; index: number }) {
+  const [expanded, setExpanded] = useState(false)
+  const canExpand = entry.exists && !entry.skipped && !entry.error && !!entry.content
+  return (
+    <div className={`memory-entry memory-entry-scope-${entry.scope}`} data-testid={`memory-entry-${index}`}>
+      <DescriptorHeader
+        descriptor={entry}
+        canExpand={canExpand}
+        expanded={expanded}
+        onToggle={() => canExpand && setExpanded((e) => !e)}
+        testId={`memory-entry-toggle-${index}`}
+      >
+        <span
+          className="memory-entry-precedence"
+          title="Load order — later entries take precedence over earlier ones"
+        >
+          {index + 1}
+        </span>
+        <span className={`memory-scope-badge memory-scope-${entry.scope}`}>{SCOPE_LABEL[entry.scope]}</span>
+        {entry.importedFrom && (
+          <span className="memory-entry-imported-from" title={`Imported from ${entry.importedFrom}`}>
+            via {entry.importedFrom.split('/').pop()}
+          </span>
+        )}
+      </DescriptorHeader>
+      {entry.error && (
+        <div
+          className={entry.skipped ? 'memory-entry-skip-reason' : 'memory-entry-error'}
+          data-testid={`memory-entry-error-${index}`}
+        >
+          {entry.error}
+        </div>
+      )}
+      {expanded && canExpand && (
+        <div className="memory-entry-content" data-testid={`memory-entry-content-${index}`}>
+          <MarkdownBody content={entry.content!} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MemoryFileSection({ file }: { file: MemoryFileDescriptor }) {
+  const [expanded, setExpanded] = useState(false)
+  const canExpand = file.exists && !file.skipped && !file.error && !!file.content
+  return (
+    <div className="memory-file-section" data-testid="memory-file-section">
+      <div className="memory-section-title">Auto-generated memory (MEMORY.md)</div>
+      <DescriptorHeader
+        descriptor={file}
+        canExpand={canExpand}
+        expanded={expanded}
+        onToggle={() => canExpand && setExpanded((e) => !e)}
+        testId="memory-file-toggle"
+      />
+      {file.error && (
+        <div
+          className={file.skipped ? 'memory-entry-skip-reason' : 'memory-entry-error'}
+          data-testid="memory-file-error"
+        >
+          {file.error}
+        </div>
+      )}
+      {expanded && canExpand && (
+        <div className="memory-entry-content" data-testid="memory-file-content">
+          <MarkdownBody content={file.content!} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function MemoryPanel() {
+  const connectionPhase = useConnectionStore((s) => s.connectionPhase)
+  const requestMemoryRead = useConnectionStore((s) => s.requestMemoryRead)
+  const entries = useConnectionStore((s) => s.memoryStackEntries)
+  const memoryFile = useConnectionStore((s) => s.memoryStackFile)
+  const stackError = useConnectionStore((s) => s.memoryStackError)
+  const loading = useConnectionStore((s) => s.memoryStackLoading)
+
+  const refresh = useCallback(() => {
+    requestMemoryRead()
+  }, [requestMemoryRead])
+
+  // Request once on mount / reconnect if nothing has loaded yet — mirrors
+  // GitPanel's "request status once connected" effect.
+  useEffect(() => {
+    if (connectionPhase !== 'connected') return
+    if (entries === null && !loading) refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionPhase])
+
+  return (
+    <div className="memory-panel" data-testid="memory-panel">
+      <div className="memory-toolbar">
+        <span className="memory-toolbar-title">Memory</span>
+        <button
+          type="button"
+          className="memory-refresh-btn"
+          onClick={refresh}
+          disabled={loading}
+          data-testid="memory-refresh-btn"
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {loading && entries === null && (
+        <div className="memory-loading" data-testid="memory-loading">Loading memory stack…</div>
+      )}
+
+      {!loading && stackError && (
+        <div className="memory-error" data-testid="memory-stack-error">{stackError}</div>
+      )}
+
+      {!stackError && entries !== null && (
+        <div className="memory-stack" data-testid="memory-stack">
+          <div className="memory-section-title">
+            Effective CLAUDE.md stack — later entries override earlier ones
+          </div>
+          {entries.length === 0 && (
+            <div className="memory-empty" data-testid="memory-stack-empty">No memory files found</div>
+          )}
+          {entries.map((entry, i) => (
+            <EntryRow key={`${entry.scope}-${entry.path ?? 'unresolved'}-${i}`} entry={entry} index={i} />
+          ))}
+        </div>
+      )}
+
+      {!stackError && memoryFile && <MemoryFileSection file={memoryFile} />}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/MemoryPanel.tsx
+++ b/packages/dashboard/src/components/MemoryPanel.tsx
@@ -53,6 +53,18 @@ function entryState(d: MemoryFileDescriptor): { label: string; cls: string } {
   return { label: 'Not present', cls: 'missing' }
 }
 
+// #6996 review — `!!d.content` alone treats a whitespace-only file (e.g. an
+// existing-but-blank CLAUDE.md) as expandable: the toggle enables, but
+// MarkdownBody renders nothing, so the user gets a dead affordance. Require
+// actual renderable (post-trim, non-empty) content instead. This only gates
+// the expand toggle — entryState() above is untouched, so a blank file still
+// reports as "Present" (honest provenance: existing, just empty), never
+// hidden or downgraded to "Not present". Shared by both descriptor sites
+// (entry rows + the MEMORY.md section) so the predicate lives in one place.
+function canExpandDescriptor(d: MemoryFileDescriptor): boolean {
+  return d.exists && !d.skipped && !d.error && typeof d.content === 'string' && d.content.trim().length > 0
+}
+
 function DescriptorHeader({
   descriptor, canExpand, expanded, onToggle, testId, children,
 }: {
@@ -85,7 +97,7 @@ function DescriptorHeader({
 
 function EntryRow({ entry, index }: { entry: MemoryStackEntry; index: number }) {
   const [expanded, setExpanded] = useState(false)
-  const canExpand = entry.exists && !entry.skipped && !entry.error && !!entry.content
+  const canExpand = canExpandDescriptor(entry)
   return (
     <div className={`memory-entry memory-entry-scope-${entry.scope}`} data-testid={`memory-entry-${index}`}>
       <DescriptorHeader
@@ -127,7 +139,7 @@ function EntryRow({ entry, index }: { entry: MemoryStackEntry; index: number }) 
 
 function MemoryFileSection({ file }: { file: MemoryFileDescriptor }) {
   const [expanded, setExpanded] = useState(false)
-  const canExpand = file.exists && !file.skipped && !file.error && !!file.content
+  const canExpand = canExpandDescriptor(file)
   return (
     <div className="memory-file-section" data-testid="memory-file-section">
       <div className="memory-section-title">Auto-generated memory (MEMORY.md)</div>
@@ -162,17 +174,19 @@ export function MemoryPanel() {
   const memoryFile = useConnectionStore((s) => s.memoryStackFile)
   const stackError = useConnectionStore((s) => s.memoryStackError)
   const loading = useConnectionStore((s) => s.memoryStackLoading)
-  // #6996 review — memory_read has no client-supplied sessionId; the server
-  // scopes the CLAUDE.md stack to the caller's *active* session cwd, so a
-  // reply is only valid for whichever session was active when the request
-  // went out. switchSession() resets memoryStackEntries to null on every
-  // switch so a stale stack is never rendered against the new session, but
-  // that reset alone only re-triggers a fetch if this effect re-runs. Keying
-  // the effect on activeSessionId (not just connectionPhase) guarantees the
-  // refetch fires on a switch even if App.tsx ever stops unmounting this
-  // panel across a session change (App.tsx's chat/terminal/system panes
-  // already use a kept-alive display:none pattern instead of unmount/remount
-  // — #4305/#4397 — so this panel should not depend on staying unmounted).
+  // #6996 review — requestMemoryRead() now stamps `memory_read` with the
+  // active sessionId + a fresh requestId nonce (store/connection.ts), and
+  // handleMemoryStackResult drops a reply whose echoed requestId is stale.
+  // That closes the common case, but a reply still doesn't echo sessionId,
+  // so switchSession() also resets memoryStackEntries to null on every
+  // switch as defence-in-depth — a stale stack is never rendered against the
+  // new session. That reset alone only re-triggers a fetch if this effect
+  // re-runs, so keying the effect on activeSessionId (not just
+  // connectionPhase) guarantees the refetch fires on a switch even if
+  // App.tsx ever stops unmounting this panel across a session change
+  // (App.tsx's chat/terminal/system panes already use a kept-alive
+  // display:none pattern instead of unmount/remount — #4305/#4397 — so this
+  // panel should not depend on staying unmounted).
   const activeSessionId = useConnectionStore((s) => s.activeSessionId)
 
   const refresh = useCallback(() => {

--- a/packages/dashboard/src/components/MemoryPanel.tsx
+++ b/packages/dashboard/src/components/MemoryPanel.tsx
@@ -162,18 +162,31 @@ export function MemoryPanel() {
   const memoryFile = useConnectionStore((s) => s.memoryStackFile)
   const stackError = useConnectionStore((s) => s.memoryStackError)
   const loading = useConnectionStore((s) => s.memoryStackLoading)
+  // #6996 review — memory_read has no client-supplied sessionId; the server
+  // scopes the CLAUDE.md stack to the caller's *active* session cwd, so a
+  // reply is only valid for whichever session was active when the request
+  // went out. switchSession() resets memoryStackEntries to null on every
+  // switch so a stale stack is never rendered against the new session, but
+  // that reset alone only re-triggers a fetch if this effect re-runs. Keying
+  // the effect on activeSessionId (not just connectionPhase) guarantees the
+  // refetch fires on a switch even if App.tsx ever stops unmounting this
+  // panel across a session change (App.tsx's chat/terminal/system panes
+  // already use a kept-alive display:none pattern instead of unmount/remount
+  // — #4305/#4397 — so this panel should not depend on staying unmounted).
+  const activeSessionId = useConnectionStore((s) => s.activeSessionId)
 
   const refresh = useCallback(() => {
     requestMemoryRead()
   }, [requestMemoryRead])
 
-  // Request once on mount / reconnect if nothing has loaded yet — mirrors
-  // GitPanel's "request status once connected" effect.
+  // Request on mount / reconnect / session switch if nothing has loaded yet
+  // for the current session — mirrors GitPanel's "request status once
+  // connected" effect, plus the activeSessionId key described above.
   useEffect(() => {
     if (connectionPhase !== 'connected') return
     if (entries === null && !loading) refresh()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionPhase])
+  }, [connectionPhase, activeSessionId])
 
   return (
     <div className="memory-panel" data-testid="memory-panel">

--- a/packages/dashboard/src/components/ViewSwitcher.tsx
+++ b/packages/dashboard/src/components/ViewSwitcher.tsx
@@ -5,7 +5,7 @@ import { formatShortcutKeys } from '../utils/platform'
 // #5204 — 'control-room' is no longer a per-session viewMode; the Control
 // Room is a dedicated session-independent top-level tab (see `controlRoomOpen`
 // / `controlRoomActive` in App).
-export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages' | 'devices'
+export type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages' | 'devices' | 'memory'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 export function ViewSwitcher({
@@ -136,6 +136,10 @@ export function ViewSwitcher({
         {/* #6780 — stage/unstage/commit UI on top of the existing git status
             wiring (Files tab already shows read-only decorations + branch). */}
         <button className={`view-tab${viewMode === 'git' ? ' active' : ''}`} onClick={() => setViewMode('git')} type="button">Git</button>
+        {/* #6867 (epic #6760) — dashboard memory panel: merged CLAUDE.md
+            hierarchy (global/project/local) with per-file provenance, plus the
+            auto-generated MEMORY.md browsable read view. */}
+        <button className={`view-tab${viewMode === 'memory' ? ' active' : ''}`} onClick={() => setViewMode('memory')} type="button">Memory</button>
         <button className={`view-tab${viewMode === 'system' ? ' active' : ''}`} onClick={() => { setViewMode('system'); setSplitMode(null); persistSplitMode(null) }} type="button">
           System{unreadSystemCount > 0 && <span className="system-badge">{unreadSystemCount}</span>}
         </button>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -658,6 +658,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // symbols_snapshot handler. Null until the first list_symbols reply lands.
   symbols: null,
   symbolsLoading: false,
+  // #6867 (epic #6760): dashboard memory panel — merged CLAUDE.md stack, fed
+  // by the memory_stack_result handler. Null until the panel's first request.
+  memoryStackEntries: null,
+  memoryStackFile: null,
+  memoryStackError: null,
+  memoryStackLoading: false,
   // Mailbox (#5914 follow-up): Control Room "Mailbox" tab snapshot, fed by the
   // mailbox_status_snapshot handler. Null until the first survey lands.
   mailboxStatus: null,
@@ -4238,6 +4244,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (activeSessionId) msg.sessionId = activeSessionId;
       wsSend(socket, msg);
     }
+  },
+
+  // #6867 (epic #6760): request the effective merged CLAUDE.md memory stack
+  // for the dashboard memory panel. Mirrors requestHostStatus — sends
+  // `memory_read`, flips memoryStackLoading, returns false (without setting
+  // loading) when the socket is closed so the panel can render a "not
+  // connected" state rather than spinning forever.
+  requestMemoryRead: (): boolean => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      set({ memoryStackLoading: true, memoryStackError: null });
+      wsSend(socket, { type: 'memory_read' });
+      return true;
+    }
+    return false;
   },
 
   // Git status

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -664,6 +664,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   memoryStackFile: null,
   memoryStackError: null,
   memoryStackLoading: false,
+  lastMemoryStackRequestId: null,
   // Mailbox (#5914 follow-up): Control Room "Mailbox" tab snapshot, fed by the
   // mailbox_status_snapshot handler. Null until the first survey lands.
   mailboxStatus: null,
@@ -2912,16 +2913,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   permissionAudit: null,
   permissionAuditLoading: false,
   permissionAuditError: false,
-  // #6996 review — mirror permissionAudit: memory_read is the same FLAT,
-  // per-session-cwd shape (no client-supplied sessionId), so a reconnect
-  // must not leave a stale memory stack from before the drop presented as
-  // current. viewingCachedSession/activeSessionId are preserved on
-  // disconnect, but the underlying server-side data can differ after a
-  // reconnect (e.g. server restart) — clear and let the panel re-fetch.
+  // #6996 review — mirror permissionAudit: memory_read is a FLAT,
+  // per-session-cwd pull, so a reconnect must not leave a stale memory stack
+  // from before the drop presented as current. viewingCachedSession/
+  // activeSessionId are preserved on disconnect, but the underlying
+  // server-side data can differ after a reconnect (e.g. server restart) —
+  // clear and let the panel re-fetch.
   memoryStackEntries: null,
   memoryStackFile: null,
   memoryStackError: null,
   memoryStackLoading: false,
+  lastMemoryStackRequestId: null,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -4261,11 +4263,23 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // `memory_read`, flips memoryStackLoading, returns false (without setting
   // loading) when the socket is closed so the panel can render a "not
   // connected" state rather than spinning forever.
+  //
+  // #6996 review — the request now carries the active sessionId explicitly
+  // (MemoryReadSchema has supported it since #6864; the server's
+  // resolveSession() already prefers a client-supplied sessionId over the
+  // implicit client.activeSessionId fallback) rather than leaving resolution
+  // entirely implicit, plus a fresh requestId nonce (mirrors requestFileContent's
+  // #6502 pattern) so handleMemoryStackResult can drop a reply superseded by
+  // a later request — e.g. a rapid session switch firing a second
+  // memory_read before the first one's answer lands.
   requestMemoryRead: (): boolean => {
-    const { socket } = get();
+    const { socket, activeSessionId } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
-      set({ memoryStackLoading: true, memoryStackError: null });
-      wsSend(socket, { type: 'memory_read' });
+      const requestId = `memory-read-${nextMessageId()}`;
+      set({ memoryStackLoading: true, memoryStackError: null, lastMemoryStackRequestId: requestId });
+      const msg: Record<string, unknown> = { type: 'memory_read', requestId };
+      if (activeSessionId) msg.sessionId = activeSessionId;
+      wsSend(socket, msg);
       return true;
     }
     return false;
@@ -4459,14 +4473,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ permissionAudit: null, permissionAuditLoading: false, permissionAuditError: false });
 
     // #6996 review — same FLAT, per-session-cwd shape as permissionAudit
-    // above (memory_read has no client-supplied sessionId; the server scopes
-    // the CLAUDE.md stack to the caller's active session cwd). Without this
-    // reset, MemoryPanel's `entries === null` mount-guard never re-fires
-    // across a switch, so the panel keeps rendering the PREVIOUS session's
-    // memory stack as though it were the new session's — the exact
-    // provenance failure this panel exists to prevent. Clear it here so the
-    // panel re-fetches for the new session; the loading + error flags reset
-    // too so an in-flight pull for the old session can't wedge the button.
+    // above. requestMemoryRead() now sends an explicit sessionId and a
+    // requestId nonce that handleMemoryStackResult uses to drop a superseded
+    // reply, but the reply itself still doesn't echo sessionId — so this
+    // reset stays as defence-in-depth. Without it, MemoryPanel's
+    // `entries === null` mount-guard never re-fires across a switch, so the
+    // panel keeps rendering the PREVIOUS session's memory stack as though it
+    // were the new session's — the exact provenance failure this panel
+    // exists to prevent. Clear it here so the panel re-fetches for the new
+    // session; the loading + error flags reset too so an in-flight pull for
+    // the old session can't wedge the button.
     set({ memoryStackEntries: null, memoryStackFile: null, memoryStackError: null, memoryStackLoading: false });
 
     // Optimistically switch to cached state + mark notifications for target

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2912,6 +2912,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   permissionAudit: null,
   permissionAuditLoading: false,
   permissionAuditError: false,
+  // #6996 review — mirror permissionAudit: memory_read is the same FLAT,
+  // per-session-cwd shape (no client-supplied sessionId), so a reconnect
+  // must not leave a stale memory stack from before the drop presented as
+  // current. viewingCachedSession/activeSessionId are preserved on
+  // disconnect, but the underlying server-side data can differ after a
+  // reconnect (e.g. server restart) — clear and let the panel re-fetch.
+  memoryStackEntries: null,
+  memoryStackFile: null,
+  memoryStackError: null,
+  memoryStackLoading: false,
       customAgents: [],
       checkpoints: [],
       _directoryListingCallback: null,
@@ -4447,6 +4457,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // user re-pulls on demand. The loading + error flags reset too so an
     // in-flight pull for the old session can't wedge the button.
     set({ permissionAudit: null, permissionAuditLoading: false, permissionAuditError: false });
+
+    // #6996 review — same FLAT, per-session-cwd shape as permissionAudit
+    // above (memory_read has no client-supplied sessionId; the server scopes
+    // the CLAUDE.md stack to the caller's active session cwd). Without this
+    // reset, MemoryPanel's `entries === null` mount-guard never re-fires
+    // across a switch, so the panel keeps rendering the PREVIOUS session's
+    // memory stack as though it were the new session's — the exact
+    // provenance failure this panel exists to prevent. Clear it here so the
+    // panel re-fetches for the new session; the loading + error flags reset
+    // too so an in-flight pull for the old session can't wedge the button.
+    set({ memoryStackEntries: null, memoryStackFile: null, memoryStackError: null, memoryStackLoading: false });
 
     // Optimistically switch to cached state + mark notifications for target
     // session as read. #4890 — pre-widget we filtered the target session's

--- a/packages/dashboard/src/store/dispatch-memory-read-request.test.ts
+++ b/packages/dashboard/src/store/dispatch-memory-read-request.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `requestMemoryRead` action contract (#6867, epic #6760; sessionId +
+ * requestId nonce added per #6996 review).
+ *
+ * Mirrors dispatch-host-status-request.test.ts's mocking idiom.
+ *   - WS OPEN → sends `memory_read` with an explicit sessionId (when one is
+ *     active) and a fresh requestId nonce, sets memoryStackLoading + records
+ *     lastMemoryStackRequestId, returns true.
+ *   - WS CLOSED / no socket → sends nothing, leaves loading untouched,
+ *     returns false.
+ *   - No active session → still sends `memory_read` (server falls back to
+ *     the client's bound/implicit session), just without a sessionId field.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+interface SentPayload {
+  type: string
+  [k: string]: unknown
+}
+
+function createMockSocket(sent: SentPayload[], readyState: number = WebSocket.OPEN): WebSocket {
+  return {
+    send: vi.fn((raw: string) => {
+      try { sent.push(JSON.parse(raw) as SentPayload) } catch { /* noop */ }
+    }),
+    close: vi.fn(),
+    readyState,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+describe('#6996 review — requestMemoryRead sessionId + requestId', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('sends memory_read with the active sessionId and a requestId, and records it as lastMemoryStackRequestId', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent, WebSocket.OPEN)
+    useConnectionStore.setState({ socket, activeSessionId: 's1', memoryStackLoading: false, lastMemoryStackRequestId: null })
+
+    const result = useConnectionStore.getState().requestMemoryRead()
+
+    expect(result).toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(sent[0].type).toBe('memory_read')
+    expect(sent[0].sessionId).toBe('s1')
+    expect(typeof sent[0].requestId).toBe('string')
+    expect((sent[0].requestId as string).length).toBeGreaterThan(0)
+
+    const state = useConnectionStore.getState()
+    expect(state.memoryStackLoading).toBe(true)
+    expect(state.lastMemoryStackRequestId).toBe(sent[0].requestId)
+  })
+
+  it('sends a fresh requestId on each call (never reuses the previous nonce)', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent, WebSocket.OPEN)
+    useConnectionStore.setState({ socket, activeSessionId: 's1', memoryStackLoading: false, lastMemoryStackRequestId: null })
+
+    useConnectionStore.getState().requestMemoryRead()
+    useConnectionStore.getState().requestMemoryRead()
+
+    expect(sent).toHaveLength(2)
+    expect(sent[0].requestId).not.toBe(sent[1].requestId)
+    expect(useConnectionStore.getState().lastMemoryStackRequestId).toBe(sent[1].requestId)
+  })
+
+  it('omits sessionId when there is no active session, but still sends a requestId', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent, WebSocket.OPEN)
+    useConnectionStore.setState({ socket, activeSessionId: null, memoryStackLoading: false, lastMemoryStackRequestId: null })
+
+    const result = useConnectionStore.getState().requestMemoryRead()
+
+    expect(result).toBe(true)
+    expect(sent[0]).not.toHaveProperty('sessionId')
+    expect(typeof sent[0].requestId).toBe('string')
+  })
+
+  it('returns false and sends nothing when WS is CLOSED', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent, WebSocket.CLOSED)
+    useConnectionStore.setState({ socket, activeSessionId: 's1', memoryStackLoading: false, lastMemoryStackRequestId: null })
+
+    const result = useConnectionStore.getState().requestMemoryRead()
+
+    expect(result).toBe(false)
+    expect(sent).toHaveLength(0)
+    expect(useConnectionStore.getState().memoryStackLoading).toBe(false)
+    expect(useConnectionStore.getState().lastMemoryStackRequestId).toBeNull()
+  })
+
+  it('returns false when there is no socket at all', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({ socket: null, activeSessionId: 's1', memoryStackLoading: false, lastMemoryStackRequestId: null })
+    expect(useConnectionStore.getState().requestMemoryRead()).toBe(false)
+    expect(useConnectionStore.getState().memoryStackLoading).toBe(false)
+  })
+})

--- a/packages/dashboard/src/store/dispatch-memory-read-request.test.ts
+++ b/packages/dashboard/src/store/dispatch-memory-read-request.test.ts
@@ -56,14 +56,15 @@ describe('#6996 review — requestMemoryRead sessionId + requestId', () => {
 
     expect(result).toBe(true)
     expect(sent).toHaveLength(1)
-    expect(sent[0].type).toBe('memory_read')
-    expect(sent[0].sessionId).toBe('s1')
-    expect(typeof sent[0].requestId).toBe('string')
-    expect((sent[0].requestId as string).length).toBeGreaterThan(0)
+    const msg = sent[0]!
+    expect(msg.type).toBe('memory_read')
+    expect(msg.sessionId).toBe('s1')
+    expect(typeof msg.requestId).toBe('string')
+    expect((msg.requestId as string).length).toBeGreaterThan(0)
 
     const state = useConnectionStore.getState()
     expect(state.memoryStackLoading).toBe(true)
-    expect(state.lastMemoryStackRequestId).toBe(sent[0].requestId)
+    expect(state.lastMemoryStackRequestId).toBe(msg.requestId)
   })
 
   it('sends a fresh requestId on each call (never reuses the previous nonce)', async () => {
@@ -76,8 +77,10 @@ describe('#6996 review — requestMemoryRead sessionId + requestId', () => {
     useConnectionStore.getState().requestMemoryRead()
 
     expect(sent).toHaveLength(2)
-    expect(sent[0].requestId).not.toBe(sent[1].requestId)
-    expect(useConnectionStore.getState().lastMemoryStackRequestId).toBe(sent[1].requestId)
+    const first = sent[0]!
+    const second = sent[1]!
+    expect(first.requestId).not.toBe(second.requestId)
+    expect(useConnectionStore.getState().lastMemoryStackRequestId).toBe(second.requestId)
   })
 
   it('omits sessionId when there is no active session, but still sends a requestId', async () => {
@@ -89,8 +92,10 @@ describe('#6996 review — requestMemoryRead sessionId + requestId', () => {
     const result = useConnectionStore.getState().requestMemoryRead()
 
     expect(result).toBe(true)
-    expect(sent[0]).not.toHaveProperty('sessionId')
-    expect(typeof sent[0].requestId).toBe('string')
+    expect(sent).toHaveLength(1)
+    const msg = sent[0]!
+    expect(msg).not.toHaveProperty('sessionId')
+    expect(typeof msg.requestId).toBe('string')
   })
 
   it('returns false and sends nothing when WS is CLOSED', async () => {

--- a/packages/dashboard/src/store/dispatch-memory-stack.test.ts
+++ b/packages/dashboard/src/store/dispatch-memory-stack.test.ts
@@ -73,6 +73,7 @@ function baseState(): Partial<ConnectionState> {
     memoryStackFile: null,
     memoryStackError: null,
     memoryStackLoading: true,
+    lastMemoryStackRequestId: null,
     messages: [],
   }
 }
@@ -222,5 +223,40 @@ describe('dashboard memory panel dispatch (#6867)', () => {
     )
     expect(store.getState().memoryStackEntries).toBe(before)
     expect(store.getState().memoryStackLoading).toBe(true)
+  })
+
+  // #6996 review — requestMemoryRead() stamps each memory_read with a fresh
+  // requestId nonce (tracked as lastMemoryStackRequestId); a reply that
+  // echoes a stale requestId is a superseded answer (e.g. a rapid session
+  // switch fired a second request before the first one's reply landed) and
+  // must be dropped without touching state or clearing the loading flag —
+  // the *new* request's own reply is what should clear it.
+  describe('requestId correlation', () => {
+    it('drops a reply whose requestId does not match the latest request', () => {
+      store = createMockStore({ ...baseState(), lastMemoryStackRequestId: 'req-2' })
+      setStore(store)
+      handleMessage(snapshot({ requestId: 'req-1' }), ctx() as never)
+      const s = store.getState()
+      expect(s.memoryStackEntries).toBeNull()
+      expect(s.memoryStackLoading).toBe(true)
+    })
+
+    it('applies a reply whose requestId matches the latest request', () => {
+      store = createMockStore({ ...baseState(), lastMemoryStackRequestId: 'req-2' })
+      setStore(store)
+      handleMessage(snapshot({ requestId: 'req-2' }), ctx() as never)
+      const s = store.getState()
+      expect(s.memoryStackEntries).toEqual([GLOBAL_ENTRY, PROJECT_ENTRY, LOCAL_ENTRY_MISSING])
+      expect(s.memoryStackLoading).toBe(false)
+    })
+
+    it('applies a reply with no requestId at all (older-server fallback)', () => {
+      store = createMockStore({ ...baseState(), lastMemoryStackRequestId: 'req-2' })
+      setStore(store)
+      handleMessage(snapshot(), ctx() as never)
+      const s = store.getState()
+      expect(s.memoryStackEntries).toEqual([GLOBAL_ENTRY, PROJECT_ENTRY, LOCAL_ENTRY_MISSING])
+      expect(s.memoryStackLoading).toBe(false)
+    })
   })
 })

--- a/packages/dashboard/src/store/dispatch-memory-stack.test.ts
+++ b/packages/dashboard/src/store/dispatch-memory-stack.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Integration test for the dashboard memory panel wiring (#6867, epic #6760).
+ *
+ * Guards the wire path between the dashboard message handler and the store:
+ *   - `memory_stack_result` REPLACES memoryStackEntries/memoryStackFile and
+ *     clears memoryStackLoading.
+ *   - a malformed payload is dropped (Zod safeParse) without mutating state
+ *     and WITHOUT clearing the loading flag (so a buggy server can't make
+ *     Refresh silently lie).
+ *   - a request-level `error` (memory unavailable in this mode / session cwd
+ *     unresolvable) is stored separately from a per-entry error.
+ *   - a second snapshot wholesale-replaces the first (full picture, no merge).
+ *
+ * Mirrors dispatch-host-status.test.ts's mocking idiom exactly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import type { ConnectionState, MemoryFileDescriptor, MemoryStackEntry } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: null,
+    sessionStates: {},
+    memoryStackEntries: null,
+    memoryStackFile: null,
+    memoryStackError: null,
+    memoryStackLoading: true,
+    messages: [],
+  }
+}
+
+const GLOBAL_ENTRY: MemoryStackEntry = {
+  path: '/home/me/.claude/CLAUDE.md',
+  exists: true,
+  content: '# Global memory',
+  truncated: false,
+  skipped: false,
+  error: null,
+  scope: 'global',
+  importedFrom: null,
+}
+
+const PROJECT_ENTRY: MemoryStackEntry = {
+  path: '/repo/CLAUDE.md',
+  exists: true,
+  content: '# Project memory',
+  truncated: false,
+  skipped: false,
+  error: null,
+  scope: 'project',
+  importedFrom: null,
+}
+
+const LOCAL_ENTRY_MISSING: MemoryStackEntry = {
+  path: '/repo/CLAUDE.local.md',
+  exists: false,
+  content: null,
+  truncated: false,
+  skipped: false,
+  error: null,
+  scope: 'local',
+  importedFrom: null,
+}
+
+const MEMORY_FILE: MemoryFileDescriptor = {
+  path: '/home/me/.claude/projects/repo/memory/MEMORY.md',
+  exists: true,
+  content: '# Auto memory',
+  truncated: false,
+  skipped: false,
+  error: null,
+}
+
+function snapshot(over: Record<string, unknown> = {}) {
+  return {
+    type: 'memory_stack_result',
+    entries: [GLOBAL_ENTRY, PROJECT_ENTRY, LOCAL_ENTRY_MISSING],
+    memoryFile: MEMORY_FILE,
+    error: null,
+    ...over,
+  }
+}
+
+describe('dashboard memory panel dispatch (#6867)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('applies memory_stack_result and clears the loading flag', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const s = store.getState()
+    expect(s.memoryStackEntries).toEqual([GLOBAL_ENTRY, PROJECT_ENTRY, LOCAL_ENTRY_MISSING])
+    expect(s.memoryStackFile).toEqual(MEMORY_FILE)
+    expect(s.memoryStackError).toBeNull()
+    expect(s.memoryStackLoading).toBe(false)
+  })
+
+  it('preserves precedence order (global, project, local) as sent by the server', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const scopes = store.getState().memoryStackEntries!.map((e) => e.scope)
+    expect(scopes).toEqual(['global', 'project', 'local'])
+  })
+
+  it('surfaces a missing file as exists: false rather than dropping the entry', () => {
+    handleMessage(snapshot(), ctx() as never)
+    const local = store.getState().memoryStackEntries!.find((e) => e.scope === 'local')
+    expect(local).toBeDefined()
+    expect(local!.exists).toBe(false)
+    expect(local!.content).toBeNull()
+  })
+
+  it('stores a request-level error separately without a crash', () => {
+    handleMessage(
+      snapshot({ entries: [], memoryFile: null, error: 'Memory is not available in this mode' }),
+      ctx() as never,
+    )
+    const s = store.getState()
+    expect(s.memoryStackError).toBe('Memory is not available in this mode')
+    expect(s.memoryStackEntries).toEqual([])
+    expect(s.memoryStackFile).toBeNull()
+    expect(s.memoryStackLoading).toBe(false)
+  })
+
+  it('replaces a prior snapshot wholesale (no merge)', () => {
+    handleMessage(snapshot(), ctx() as never)
+    handleMessage(
+      snapshot({ entries: [PROJECT_ENTRY] }),
+      ctx() as never,
+    )
+    expect(store.getState().memoryStackEntries).toEqual([PROJECT_ENTRY])
+  })
+
+  it('drops a malformed snapshot without mutating state or clearing loading', () => {
+    const before = store.getState().memoryStackEntries
+    // `entries` must be an array — this payload sends a string instead.
+    handleMessage(
+      { type: 'memory_stack_result', entries: 'not-an-array', memoryFile: null, error: null },
+      ctx() as never,
+    )
+    expect(store.getState().memoryStackEntries).toBe(before)
+    // Loading flag is untouched on a malformed payload.
+    expect(store.getState().memoryStackLoading).toBe(true)
+  })
+
+  it('drops a malformed entry (missing required scope) without mutating state', () => {
+    const before = store.getState().memoryStackEntries
+    handleMessage(
+      snapshot({ entries: [{ path: '/x', exists: true, content: 'x', truncated: false, skipped: false, error: null }] }),
+      ctx() as never,
+    )
+    expect(store.getState().memoryStackEntries).toBe(before)
+    expect(store.getState().memoryStackLoading).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -149,7 +149,7 @@ import {
   formatMemoryAppendNotice,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerGithubWebhookConfigSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema, ServerGitCreatePrResultSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema, ServerContainersStatusSnapshotSchema, ServerContainersActionAckSchema, ServerRepoRuntimeConfigSnapshotSchema, ServerByokPoolStatusSnapshotSchema, ServerByokPoolActionAckSchema, ServerHostPruneStatusSnapshotSchema, ServerHostPruneActionAckSchema, ServerSimulatorStatusSnapshotSchema, ServerSimulatorActionAckSchema, ServerEmulatorStatusSnapshotSchema, ServerEmulatorActionAckSchema, ServerWslStatusSnapshotSchema, ServerWslActionAckSchema, ServerIntegrationStatusSnapshotSchema, ServerSkillsInventorySnapshotSchema, ServerMailboxStatusSnapshotSchema, ServerExternalSessionsSnapshotSchema, ServerRepoEventsSnapshotSchema, ServerRepoEventsDeltaSchema, ServerGithubWebhookConfigSchema, ServerPermissionInputSchema, ServerPermissionAuditResultSchema, ServerIntegrationActionAckSchema, ServerSummarizeSessionResultSchema, ServerSessionPresetSnapshotSchema, ServerPairPendingSchema, ServerPairResolvedSchema, ServerBillingCanarySchema, BillingCanarySnapshotSchema, ServerSymbolsSnapshotSchema, ServerSymbolLocationSchema, ServerSearchResultsSchema, ServerReferencesResultSchema, ServerOrchestrationRunsSnapshotSchema, ServerOrchestrationRunSnapshotSchema, ServerOrchestrationRunDeltaSchema, ServerOrchestrationActionAckSchema, ServerGitCreatePrResultSchema, ServerMemoryStackResultSchema } from '@chroxy/protocol/schemas'
 import { resolveSummarizeRequest, rejectSummarizeRequest } from './summarizeRequests'
 import {
   createKeyPair,
@@ -2693,6 +2693,31 @@ function handleSymbolsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: 
 }
 
 /**
+ * #6867 (epic #6760) — dashboard memory panel: `memory_stack_result` REPLACES
+ * the stored merged CLAUDE.md stack (global/project/local + recursively-
+ * resolved @imports, server load order) and the auto-generated MEMORY.md
+ * descriptor, clearing memoryStackLoading. The wire shape is Zod-validated
+ * (same defensive pattern as host_status_snapshot / symbols_snapshot) so a
+ * malformed payload is dropped rather than corrupting the panel's state —
+ * memoryStackLoading is cleared only on a successful parse so a buggy server
+ * can't make the Refresh affordance silently lie. The request-level `error`
+ * (e.g. "Memory is not available in this mode") is stored separately from a
+ * per-entry error so the panel can distinguish "nothing to show" from
+ * "this one file failed". Dashboard-only for v1 — mobile parity is the
+ * sibling slice #6870.
+ */
+function handleMemoryStackResult(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerMemoryStackResultSchema.safeParse(msg);
+  if (!parsed.success) return;
+  set({
+    memoryStackEntries: parsed.data.entries,
+    memoryStackFile: parsed.data.memoryFile,
+    memoryStackError: parsed.data.error,
+    memoryStackLoading: false,
+  });
+}
+
+/**
  * Go-to-definition (#6475, epic #6469) — `symbol_location`: store the resolve
  * result (with a fresh nonce so a repeat resolve of the same symbol re-fires the
  * jump effect). FileBrowserPanel reacts to `symbolLocation`: on a hit it opens
@@ -3533,6 +3558,8 @@ const HANDLERS: Record<string, Handler> = {
   stream_end: handleStreamEnd,
   // #6861 — `#`-prefix composer quick-append ack.
   append_memory_result: handleAppendMemoryResult,
+  // #6867 (epic #6760) — dashboard memory panel: merged CLAUDE.md stack reply.
+  memory_stack_result: handleMemoryStackResult,
   tool_start: handleToolStart,
   tool_input_delta: handleToolInputDelta,
   tool_result: handleToolResult,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2705,10 +2705,23 @@ function handleSymbolsSnapshot(msg: Record<string, unknown>, _get: MsgGet, set: 
  * per-entry error so the panel can distinguish "nothing to show" from
  * "this one file failed". Dashboard-only for v1 — mobile parity is the
  * sibling slice #6870.
+ *
+ * #6996 review — requestMemoryRead() now stamps each `memory_read` with a
+ * fresh requestId nonce and tracks it as `lastMemoryStackRequestId`. If this
+ * reply echoes a requestId that doesn't match the latest one sent, it's a
+ * superseded answer (e.g. a rapid session switch fired a second memory_read
+ * before this one's reply landed) and is dropped without touching state —
+ * mirrors FileBrowserPanel's #6502 read_file correlation. A reply that
+ * doesn't echo a requestId at all (older server) falls through and is
+ * applied as before.
  */
-function handleMemoryStackResult(msg: Record<string, unknown>, _get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+function handleMemoryStackResult(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerMemoryStackResultSchema.safeParse(msg);
   if (!parsed.success) return;
+  if (parsed.data.requestId != null) {
+    const latest = get().lastMemoryStackRequestId;
+    if (latest != null && parsed.data.requestId !== latest) return;
+  }
   set({
     memoryStackEntries: parsed.data.entries,
     memoryStackFile: parsed.data.memoryFile,

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -104,7 +104,7 @@ const MAX_TERMINAL_SIZE = 50_000;
 // Containers section. A persisted 'environments' viewMode no longer validates
 // and falls back to the default, so a carried-over value can't render a
 // now-removed surface.
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'git', 'system', 'console', 'snapshots', 'pool', 'pages', 'devices'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'git', 'system', 'console', 'snapshots', 'pool', 'pages', 'devices', 'memory'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -2348,6 +2348,49 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     expect(state.permissionAuditLoading).toBe(false);
   });
 
+  it('switchSession clears the memory stack so it never shows another session\'s CLAUDE.md provenance (#6996 review)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { createEmptySessionState } = await import('./utils');
+
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: { s1: { ...createEmptySessionState() }, s2: { ...createEmptySessionState() } },
+      sessionNotifications: [],
+      memoryStackEntries: [
+        {
+          path: '/repo-a/CLAUDE.md',
+          exists: true,
+          content: '# repo-a notes',
+          truncated: false,
+          skipped: false,
+          error: null,
+          scope: 'project',
+          importedFrom: null,
+        },
+      ],
+      memoryStackFile: {
+        path: '/repo-a/.claude/projects/repo-a/memory/MEMORY.md',
+        exists: true,
+        content: '# repo-a memory',
+        truncated: false,
+        skipped: false,
+        error: null,
+      },
+      memoryStackError: 'some stale error',
+      memoryStackLoading: true,
+      socket: null,
+    });
+
+    useConnectionStore.getState().switchSession('s2');
+
+    const state = useConnectionStore.getState();
+    expect(state.activeSessionId).toBe('s2');
+    expect(state.memoryStackEntries).toBeNull();
+    expect(state.memoryStackFile).toBeNull();
+    expect(state.memoryStackError).toBeNull();
+    expect(state.memoryStackLoading).toBe(false);
+  });
+
   it('permission_expired for an already-resolved requestId does not mutate the prompt message', async () => {
     const { useConnectionStore } = await import('./connection');
     const { createEmptySessionState } = await import('./utils');
@@ -3818,6 +3861,53 @@ describe('server_error toast scope filtering', () => {
       const after = useConnectionStore.getState().sessionStates;
       expect(after.s1!.pendingTrustGrants).toEqual([]);
       expect(after.s2!.pendingTrustGrants).toEqual([]);
+
+      useConnectionStore.setState({
+        sessions: [],
+        activeSessionId: null,
+        sessionStates: {},
+        userDisconnected: false,
+      });
+    });
+
+    it('disconnect clears the memory stack, mirroring permissionAudit (#6996 review)', async () => {
+      const { useConnectionStore } = await import('./connection');
+
+      useConnectionStore.setState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+        memoryStackEntries: [
+          {
+            path: '/repo-a/CLAUDE.md',
+            exists: true,
+            content: '# repo-a notes',
+            truncated: false,
+            skipped: false,
+            error: null,
+            scope: 'project',
+            importedFrom: null,
+          },
+        ],
+        memoryStackFile: {
+          path: '/repo-a/.claude/projects/repo-a/memory/MEMORY.md',
+          exists: true,
+          content: '# repo-a memory',
+          truncated: false,
+          skipped: false,
+          error: null,
+        },
+        memoryStackError: 'some stale error',
+        memoryStackLoading: true,
+        socket: null,
+      });
+
+      useConnectionStore.getState().disconnect();
+
+      const after = useConnectionStore.getState();
+      expect(after.memoryStackEntries).toBeNull();
+      expect(after.memoryStackFile).toBeNull();
+      expect(after.memoryStackError).toBeNull();
+      expect(after.memoryStackLoading).toBe(false);
 
       useConnectionStore.setState({
         sessions: [],

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -938,7 +938,11 @@ export interface ConnectionState {
    * #6867 (epic #6760) — dashboard memory panel: the effective merged
    * CLAUDE.md stack (global/project/local + recursively-resolved @imports,
    * server load order) from the last `memory_read` reply. Null until the
-   * panel's first request lands.
+   * panel's first request lands. Scoped to the active session the same way
+   * `permissionAudit` is (the server resolves `memory_read` against the
+   * caller's active session cwd, no client-supplied sessionId) —
+   * `switchSession`/`disconnect` reset it to null (#6996 review) so it never
+   * shows a previous session's stack against a new one.
    */
   memoryStackEntries: MemoryStackEntry[] | null;
   /** The project's auto-generated MEMORY.md descriptor, from the same reply. */

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -275,6 +275,26 @@ export interface FileContent {
   requestId: string | null;
 }
 
+// #6867 (epic #6760): dashboard memory panel. Mirrors the server-side
+// descriptor shapes in packages/server/src/ws-file-ops/memory.js /
+// packages/protocol/src/schemas/server/file-ops.ts (MemoryFileDescriptorSchema
+// / MemoryStackEntrySchema) 1:1 — hand-written here (like FileContent /
+// GitStatusResult above) rather than imported from @chroxy/protocol, since the
+// file-ops schemas don't export z.infer type companions.
+export interface MemoryFileDescriptor {
+  path: string | null;
+  exists: boolean;
+  content: string | null;
+  truncated: boolean;
+  skipped: boolean;
+  error: string | null;
+}
+
+export interface MemoryStackEntry extends MemoryFileDescriptor {
+  scope: 'global' | 'project' | 'local' | 'import';
+  importedFrom: string | null;
+}
+
 // #3181: GitStatusEntry was structurally identical to @chroxy/store-core's
 // `GitFileStatus` (path + status union). Dropped in favour of the canonical
 // re-export above so the dashboard and app share a single shape for staged/
@@ -914,6 +934,24 @@ export interface ConnectionState {
    */
   symbolsLoading: boolean;
 
+  /**
+   * #6867 (epic #6760) — dashboard memory panel: the effective merged
+   * CLAUDE.md stack (global/project/local + recursively-resolved @imports,
+   * server load order) from the last `memory_read` reply. Null until the
+   * panel's first request lands.
+   */
+  memoryStackEntries: MemoryStackEntry[] | null;
+  /** The project's auto-generated MEMORY.md descriptor, from the same reply. */
+  memoryStackFile: MemoryFileDescriptor | null;
+  /** Request-level error (e.g. "Memory is not available in this mode"). */
+  memoryStackError: string | null;
+  /**
+   * True between `requestMemoryRead()` and the matching `memory_stack_result`,
+   * so the panel can show a loading state. Cleared only on a successful parse
+   * (see handleMemoryStackResult) so a malformed reply can't make Refresh lie.
+   */
+  memoryStackLoading: boolean;
+
   // Mailbox (#5914 follow-up) — Control Room "Mailbox" tab snapshot (live
   // agentCommId→session registrations + recent live-interrupt deliveries). Null
   // until the first survey lands.
@@ -1488,7 +1526,7 @@ export interface ConnectionState {
 
   // View mode. #5204 — 'control-room' removed: the Control Room is now a
   // session-independent top-level tab in App, not a per-session view mode.
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages' | 'devices';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages' | 'devices' | 'memory';
 
   // Input settings
   inputSettings: InputSettings;
@@ -1507,7 +1545,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages' | 'devices') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'git' | 'system' | 'console' | 'snapshots' | 'pool' | 'pages' | 'devices' | 'memory') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string; queued?: boolean }) => void;
   appendTerminalData: (data: string) => void;
@@ -1709,6 +1747,13 @@ export interface ConnectionState {
   // #6477 — find-all-references for a clicked symbol. Opens the references palette
   // (referencesOpen) + sets referencesLoading; the reply lands in referencesResult.
   requestFindReferences: (symbol: string, file?: string) => void;
+
+  // #6867 (epic #6760) — request the effective merged CLAUDE.md memory stack
+  // for the dashboard memory panel. Sets memoryStackLoading; the reply lands
+  // in memoryStackEntries/memoryStackFile/memoryStackError. Returns false
+  // (without setting loading) when the socket is closed, mirroring
+  // requestHostStatus's not-connected guard.
+  requestMemoryRead: () => boolean;
 
   // Git status
   setGitStatusCallback: (cb: ((result: GitStatusResult) => void) | null) => void;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -938,11 +938,11 @@ export interface ConnectionState {
    * #6867 (epic #6760) — dashboard memory panel: the effective merged
    * CLAUDE.md stack (global/project/local + recursively-resolved @imports,
    * server load order) from the last `memory_read` reply. Null until the
-   * panel's first request lands. Scoped to the active session the same way
-   * `permissionAudit` is (the server resolves `memory_read` against the
-   * caller's active session cwd, no client-supplied sessionId) —
-   * `switchSession`/`disconnect` reset it to null (#6996 review) so it never
-   * shows a previous session's stack against a new one.
+   * panel's first request lands. `requestMemoryRead()` sends an explicit
+   * `sessionId` (#6996 review) so the request is unambiguous, but the reply
+   * doesn't echo it back — `switchSession`/`disconnect` still reset this to
+   * null so a previous session's stack is never shown against a new one, and
+   * `lastMemoryStackRequestId` (below) drops an outright superseded reply.
    */
   memoryStackEntries: MemoryStackEntry[] | null;
   /** The project's auto-generated MEMORY.md descriptor, from the same reply. */
@@ -955,6 +955,15 @@ export interface ConnectionState {
    * (see handleMemoryStackResult) so a malformed reply can't make Refresh lie.
    */
   memoryStackLoading: boolean;
+  /**
+   * #6996 review — the requestId nonce stamped on the most recent
+   * `memory_read`. handleMemoryStackResult (store/message-handler.ts) drops
+   * any `memory_stack_result` whose echoed requestId doesn't match this,
+   * so a reply superseded by a newer request (e.g. a rapid session switch)
+   * can't land after the fact. Mirrors `lastFileContentRequestId`'s #6502
+   * read_file correlation.
+   */
+  lastMemoryStackRequestId: string | null;
 
   // Mailbox (#5914 follow-up) — Control Room "Mailbox" tab snapshot (live
   // agentCommId→session registrations + recent live-interrupt deliveries). Null

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -9985,6 +9985,193 @@ button.sidebar-token-view-session-row:hover {
 .git-branch-current-mark { color: var(--accent-green); }
 .git-branch-name { font-family: var(--font-mono); }
 
+/* ---- Memory Panel (#6867, epic #6760) ---- */
+.memory-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.memory-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.memory-toolbar-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.memory-refresh-btn {
+  padding: 4px 10px;
+  font-size: var(--text-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.memory-refresh-btn:hover { background: var(--bg-card); }
+.memory-refresh-btn:disabled { opacity: 0.5; cursor: default; }
+
+.memory-loading, .memory-error, .memory-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.memory-error { color: var(--text-error); }
+
+.memory-stack {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+.memory-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.memory-entry {
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+.memory-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+.memory-entry-header:hover:not(:disabled) { background: var(--bg-tertiary); }
+.memory-entry-header:disabled { cursor: default; }
+
+.memory-entry-precedence {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 50%;
+  background: var(--bg-tertiary);
+  color: var(--text-dim);
+}
+
+.memory-scope-badge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.memory-scope-badge.memory-scope-global { background: var(--accent-purple-light); color: var(--accent-purple); }
+.memory-scope-badge.memory-scope-project { background: var(--accent-blue-light); color: var(--accent-blue); }
+.memory-scope-badge.memory-scope-local { background: var(--accent-green-light); color: var(--accent-green); }
+.memory-scope-badge.memory-scope-import { background: rgba(148, 163, 184, 0.2); color: var(--text-dim); }
+
+.memory-entry-path {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.memory-entry-imported-from {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+}
+
+.memory-entry-state {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 8px;
+}
+
+.memory-entry-state-exists { background: var(--accent-green-light); color: var(--accent-green); }
+.memory-entry-state-missing { background: var(--bg-tertiary); color: var(--text-dim); }
+.memory-entry-state-skipped { background: var(--accent-orange-light); color: var(--accent-orange); }
+.memory-entry-state-error { background: var(--accent-red-light); color: var(--text-error); }
+
+.memory-entry-truncated {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--accent-orange);
+}
+
+.memory-entry-caret {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.memory-entry-error, .memory-entry-skip-reason {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text-error);
+  background: var(--accent-red-light);
+  border-top: 1px solid var(--border-primary);
+}
+
+.memory-entry-content {
+  padding: 12px;
+  border-top: 1px solid var(--border-primary);
+  background: var(--bg-primary);
+  max-height: 400px;
+  overflow-y: auto;
+  font-size: 13px;
+}
+
+.memory-file-section {
+  margin: 12px 16px 16px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
 /* ---- Agent Monitor Panel ---- */
 .agent-monitor-panel {
   border-top: 1px solid var(--border-primary);

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -83,7 +83,9 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5170.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
-  'memory_stack_result', // #6864 (epic #6760) reply to memory_read — server-only for v1, no client handler yet; the dashboard/mobile memory-panel consumers are the sibling slices #6867/#6870
+  // 'memory_stack_result' removed — the dashboard now handles it (#6867, the
+  // merged-CLAUDE.md-stack memory panel); it moved to PLATFORM_SPECIFIC as
+  // 'dashboard'. Mobile parity is the sibling slice #6870.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
   // because each handler has a `case 'session_usage':` clause.
@@ -164,6 +166,7 @@ const PLATFORM_SPECIFIC = {
   // passes because each handler has a `case 'activity_snapshot'/'activity_delta':`.
   'host_status_snapshot': 'dashboard', // Control Room Host/Repo Status survey reply (#5171 schema / #5174 server emitter / #5175 dashboard section) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5170
   'permission_audit_result': 'dashboard', // #6772 reply to query_permission_audit — the dashboard SettingsPanel "Permission history" view is the first (and only, for v1) client caller; the mobile PermissionHistory screen derives its summary from the live chat transcript, not this wire query, so mobile parity is a fast-follow
+  'memory_stack_result': 'dashboard', // #6867 (epic #6760) reply to memory_read — the dashboard memory panel (merged CLAUDE.md hierarchy + provenance) is the first client surface; mobile parity is the sibling slice #6870
   // 'permission_input' removed from PLATFORM_SPECIFIC — the mobile app now
   // handles it too (#6543 PR-4, the pre-write-diff mobile parity fast-follow),
   // so it is BOTH-CLIENTS. Coverage passes because the dashboard has a

--- a/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
+++ b/packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts
@@ -194,6 +194,7 @@ const DASHBOARD_ONLY = new Set<string>([
   'evaluator_rewrite',          // auto-evaluator rewrite banner (#3188) — dashboard-only
   'host_status_snapshot',       // Control Room Host/Repo Status (#5170) — dashboard-only for v1
   'permission_audit_result',    // #6772 query_permission_audit reply — dashboard SettingsPanel "Permission history"; first client caller, dashboard-only for v1 (mobile PermissionHistory reads the chat transcript, not this wire query)
+  'memory_stack_result',        // #6867 (epic #6760) reply to memory_read — dashboard memory panel (merged CLAUDE.md hierarchy + provenance); dashboard-only for v1, mobile parity is the sibling slice #6870
   // permission_input removed — the mobile app now handles it too (#6543 PR-4,
   // the pre-write-diff mobile parity fast-follow), so it is no longer
   // dashboard-only. Both clients dispatch it into `permissionInputs[requestId]`.
@@ -253,9 +254,8 @@ const UNHANDLED_BY_DESIGN = new Set<string>([
                                           //   no dedicated handler yet (dashboard exposure is a deferred follow-up)
   'stdin_dropped_totals',                 // #3544 transient counter — surface is the SessionInfo flag on
                                           //   session_list, not a dedicated wire-event handler
-  'memory_stack_result',                  // #6864 (epic #6760) reply to memory_read — server-only for v1,
-                                          //   no client handler yet; dashboard/mobile memory-panel consumers
-                                          //   are the sibling slices #6867/#6870
+  // 'memory_stack_result' removed — the dashboard now handles it (#6867); it
+  // moved to DASHBOARD_ONLY below. Mobile parity is the sibling slice #6870.
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a dashboard **memory panel** (new "Memory" tab, alongside Files/Git): renders the effective merged CLAUDE.md stack (global → project → local, Claude Code's own load/precedence order, with recursively-resolved `@import`s inlined right after the file that referenced them) plus the project's auto-generated MEMORY.md as a browsable read view.
- Wires the dashboard client to the existing `memory_read`/`memory_stack_result` server endpoint (#6864, PR #6969) — that endpoint had no client handler yet (`memory_stack_result` was `UNHANDLED_BY_DESIGN` in the coverage guards). Adds `requestMemoryRead()` + `memoryStackEntries`/`memoryStackFile`/`memoryStackError`/`memoryStackLoading` store state, a Zod-validated `handleMemoryStackResult` dispatcher, and promotes the type to a dashboard-only entry in the two coverage guards it trips.
- **Read-only for v1.** The issue's AC also asked for edit + save of CLAUDE.md (parity with the mobile `FileEditor`). That's deferred to **#6995** — the dashboard has zero client-side write plumbing today (`write_file_result` is an app-only wire type per the store-core contract fixtures, #5653; `FileBrowserPanel` is confirmed read-only per the IDE epic #6469), and the parent issue explicitly calls for reconciling the write path with the overlapping #6478 (IDE P3 editable file browser) first, to avoid shipping two divergent dashboard write paths. #6995 tracks that follow-up.

## How to visually verify

1. Run the server (`PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run server:dev`) and open the dashboard, connected to a session whose project has a `CLAUDE.md`.
2. Click the **Memory** tab in the view switcher (next to Git).
3. Expect:
   - An ordered list of stack entries, each showing a scope badge (**Global** / **Project** / **Local** / **@import**), the resolved file path, and a state pill (**Present** / **Not present** / **Skipped** / **Error**). The list order IS the precedence order — a caption reads "later entries override earlier ones".
   - Clicking a **Present** entry expands it to show the file's content, rendered as markdown (headers/lists/links) through the same sanitized pipeline chat messages use.
   - A **Not present** entry (e.g. no `CLAUDE.local.md`) shows honestly instead of being hidden, and its row can't be expanded.
   - A skipped `@import` (e.g. one that resolves outside the allowed roots) shows "Skipped" with the server's skip reason.
   - Below the stack, a separate **"Auto-generated memory (MEMORY.md)"** section shows the project's `~/.claude/projects/<encoded>/memory/MEMORY.md` if one exists.
   - A **Refresh** button re-requests the stack.

## Render safety

Every entry's content renders via `MarkdownBody` (`packages/dashboard/src/components/MarkdownBody.tsx`) — the same `renderMarkdown()` + DOMPurify pipeline chat messages use, including the #6986 link-scheme allowlist. Never a raw `dangerouslySetInnerHTML` of unsanitized file content. Covered by a test asserting a `<script>` tag embedded in a CLAUDE.md body never executes and never appears as a live DOM element.

## Coverage-guard / dist status

`memory_stack_result` moves from `UNHANDLED_BY_DESIGN`/`INTENTIONALLY_UNHANDLED` to a dashboard-only entry in:
- `packages/protocol/tests/handler-coverage.test.js` (`PLATFORM_SPECIFIC`)
- `packages/store-core/src/contract-fixtures/protocol-type-coverage-lint.test.ts` (`DASHBOARD_ONLY`)

The third guard (`packages/store-core/src/contract-fixtures/coverage-lint.test.ts`, the both-clients `SWITCH_FIXTURES` lint) is out of scope — its universe is the intersection of both clients' switches, and this type stays dashboard-only (mobile parity is the sibling slice #6870), so it never enters that guard's `bothSet`. Verified by running it directly.

No protocol schema changes — `ServerMemoryStackResultSchema`/`MemoryReadSchema` already existed and were already built into `packages/protocol/dist` from #6864/PR #6969, so **no dist rebuild was needed**. Server package untouched.

## Test plan

- [x] `cd packages/dashboard && npx vitest run` — 282 files / 4825 tests, all green (includes 2 new files: `MemoryPanel.test.tsx` component tests — precedence order, missing-file honesty, skipped-@import honesty, escaped/sanitized content incl. a `<script>`-doesn't-execute test, request-level error state doesn't crash, refresh; `dispatch-memory-stack.test.ts` — handler dispatch, malformed-payload drop without state corruption, request-level-error handling, wholesale replace).
- [x] `cd packages/dashboard && npx tsc --noEmit` — clean.
- [x] `cd packages/protocol && npm test` — 377/377 (untouched schemas, only the `handler-coverage.test.js` guard file changed).
- [x] `cd packages/store-core && npx vitest run` — 59 files / 2131 tests, all green (includes the two coverage-guard files touched).
- [x] Server package untouched — no server tests/lints run.

Closes #6867