### PR TITLE
feat(server): headless scheduler engine (fires due tasks into a session)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -582,6 +582,63 @@ Status-message state (message ids, current state per project) persists in
 id in `~/.chroxy/discord-billing-state.json`. Full setup walkthrough:
 [docs/guides/discord-notifications.md](../../docs/guides/discord-notifications.md).
 
+### Opt-in features (`features`)
+
+Some surfaces are **off by default** and activate only when the operator opts in.
+Each is gated by a strict-boolean config key under `features`, or by an env
+override that must be exactly `1`:
+
+```json
+{
+  "features": {
+    "scheduler": false
+  }
+}
+```
+
+| Key | Env override | Default | What it enables |
+|-----|--------------|---------|-----------------|
+| `features.scheduler` | `CHROXY_ENABLE_SCHEDULER=1` | `false` | Headless execution of scheduled tasks (#6865) |
+| `features.ide` | `CHROXY_ENABLE_IDE=1` | `false` | The IDE navigation surface (epic #6469) |
+| `features.orchestration` | `CHROXY_ENABLE_ORCHESTRATION=1` | `false` | The orchestration/delegation harness (epic #6691) |
+
+All three are **fail-closed**: anything other than a literal `true` in config (or
+a literal `"1"` in the env) leaves the feature off, so `"yes"`, `1`, or `"true"`
+in the config file do *not* enable it.
+
+#### `features.scheduler` — headless scheduled execution
+
+Scheduled tasks (`~/.chroxy/scheduled-tasks.json`) can be created, listed, and
+edited at any time, but they **never fire** unless this flag is on. With the flag
+off the daemon arms no scheduler timers and starts no sessions — behaviour is
+identical to a daemon without the feature.
+
+When on, at each task's due time the daemon spins up (or resumes) that task's
+session and runs its prompt with **no client connected**. Because nobody is
+watching that turn, it runs under a hard permission floor:
+
+- The run is pinned to the `approve` permission mode. A task whose stored
+  `target.permissionMode` is `auto` or `acceptEdits` is **clamped down** to
+  `approve` — a scheduled task can never grant itself auto-approval.
+- The run is created with an explicit `skipPermissions: false`, so it does **not**
+  inherit a server-wide [`dangerouslySkipPermissions`](#skip-permissions-tui-provider).
+- If the turn hits a permission prompt, there is no human to answer it: the prompt
+  is **denied**, the turn is aborted, and the run is recorded as a failed run with
+  the reason. A scheduled task that needs a permission fails visibly rather than
+  escalating silently.
+- To let a scheduled task actually perform a gated operation, author an explicit
+  **permission rule** for it. Rules are matched before a prompt is raised, so an
+  allow-rule is the one auditable, human-authored way to widen what a scheduled
+  run may do — and the protected-path / secret-read floor still cannot be
+  bypassed by one.
+
+Each run records a last-run result (`success` / `error` / `timeout` / `skipped`)
+plus its session id into the registry. Runs are serialized (one at a time by
+default) so a burst of simultaneously-due tasks cannot spawn a herd of sessions,
+a task is never re-fired while its previous run is still in flight, and a task
+whose due time passed while the daemon was down is skipped rather than fired late
+if it is more than an hour stale.
+
 ## Examples
 
 ### Using Config File Only

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -614,30 +614,79 @@ off the daemon arms no scheduler timers and starts no sessions — behaviour is
 identical to a daemon without the feature.
 
 When on, at each task's due time the daemon spins up (or resumes) that task's
-session and runs its prompt with **no client connected**. Because nobody is
-watching that turn, it runs under a hard permission floor:
+session and runs its prompt with **no client connected**.
+
+##### Supported providers — hook-routed providers (including the default) are refused
+
+> **A scheduled task only fires on a provider that answers permission prompts
+> in-process.** Right now that is `claude-sdk`, `claude-byok`, `codex` (the
+> app-server driver), `deepseek`, and `ollama`. Every other provider — **including
+> the daemon default `claude-tui`**, plus `claude-cli`, `claude-channel`, and
+> `gemini` — is **refused**: the task does not fire, no session is created, and the
+> run is recorded with status `refused` naming the provider.
+
+This is deliberate, not an oversight. The scheduler's whole safety story is that a
+permission prompt raised by an unattended turn gets **denied** and the run fails
+visibly. That requires observing the prompt and answering it programmatically,
+which only providers with in-process permissions expose. Hook-routed providers
+instead go out through `hooks/permission-hook.sh` → `POST /permission`, which the
+daemon cannot answer with no client attached — such a run would stall on every
+gated tool call until the 300-second auto-deny and then finish looking successful
+with nothing actually done. Refusing is the honest outcome.
+
+**A task with no explicit `target.provider` therefore does not fire**, because it
+resolves to the daemon default. Set `target.provider` to one of the supported ids.
+Widening support to hook-routed providers needs a programmatic
+permission-answering surface for them — tracked in
+[#7003](https://github.com/blamechris/chroxy/issues/7003).
+
+##### The permission floor
+
+Because nobody is watching the turn, a run that does fire runs under a hard floor:
 
 - The run is pinned to the `approve` permission mode. A task whose stored
   `target.permissionMode` is `auto` or `acceptEdits` is **clamped down** to
-  `approve` — a scheduled task can never grant itself auto-approval.
+  `approve` — a scheduled task can never grant itself auto-approval. (`plan` is
+  allowed: it is stricter than `approve`.)
+- **The clamp is re-asserted before every fire, not just at session creation.**
+  A task's session is deliberately kept alive and reused across runs, and an
+  operator inspecting it can change its permission mode by hand — so before each
+  fire the daemon forces the clamped mode back on and verifies it by reading it
+  back. If it cannot be verified, **the fire is skipped** and recorded `refused`.
+  A manual switch to Auto therefore cannot leak into the next unattended run.
 - The run is created with an explicit `skipPermissions: false`, so it does **not**
   inherit a server-wide [`dangerouslySkipPermissions`](#skip-permissions-tui-provider).
+- The task's `target.cwd` is checked against the **same working-directory
+  allowlist the dashboard enforces** — the credential-directory deny-list
+  (`~/.ssh`, `~/.aws`, `~/.config`, `~/.chroxy`, …), your `workspaceRoots`
+  allowlist if configured, and the `$HOME` fallback otherwise. `~/.chroxy/scheduled-tasks.json`
+  is an editable file, so a hand-written `target.cwd` gets no more trust than one
+  typed into the UI: a disallowed directory is recorded `refused` and does not fire.
 - If the turn hits a permission prompt, there is no human to answer it: the prompt
   is **denied**, the turn is aborted, and the run is recorded as a failed run with
   the reason. A scheduled task that needs a permission fails visibly rather than
-  escalating silently.
+  escalating silently. A run that raised any prompt is **never** recorded
+  `success`, even when the agent went on to finish its turn without the tool.
 - To let a scheduled task actually perform a gated operation, author an explicit
   **permission rule** for it. Rules are matched before a prompt is raised, so an
   allow-rule is the one auditable, human-authored way to widen what a scheduled
   run may do — and the protected-path / secret-read floor still cannot be
   bypassed by one.
 
-Each run records a last-run result (`success` / `error` / `timeout` / `skipped`)
-plus its session id into the registry. Runs are serialized (one at a time by
-default) so a burst of simultaneously-due tasks cannot spawn a herd of sessions,
-a task is never re-fired while its previous run is still in flight, and a task
-whose due time passed while the daemon was down is skipped rather than fired late
-if it is more than an hour stale.
+Each run records a last-run result plus its session id into the registry:
+
+| status | meaning |
+|--------|---------|
+| `success` | the turn completed and no permission prompt was raised |
+| `error` | the run happened and failed — including a run whose tool calls were denied |
+| `timeout` | the run exceeded the per-run timeout and was abandoned |
+| `skipped` | the slot passed unused (the daemon was down past the grace window) |
+| `refused` | **nothing ran** — unsupported provider, disallowed cwd, or an unverifiable permission mode. A misconfiguration to fix, not a transient failure |
+
+Runs are serialized (one at a time by default) so a burst of simultaneously-due
+tasks cannot spawn a herd of sessions, a task is never re-fired while its previous
+run is still in flight, and a task whose due time passed while the daemon was down
+is skipped rather than fired late if it is more than an hour stale.
 
 ## Examples
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -706,6 +706,19 @@ export function isOrchestrationEnabled(config) {
   return config?.features?.orchestration === true
 }
 
+// #6865 — the opt-in HEADLESS SCHEDULER: fires persisted scheduled tasks (#6862)
+// into a real agent session at their due time with NO client connected. Because
+// that runs a session with nobody watching, it is off unless explicitly enabled.
+// Fail-closed exactly like isIdeFeatureEnabled/isOrchestrationEnabled: only an
+// explicit env=1 or `features.scheduler === true` arms the engine; anything else
+// (absent, false, 'yes', 0) leaves the daemon byte-identical to pre-#6865 — no
+// timers armed, no sessions spawned. Exported standalone so the CLI (#6868) and
+// dashboard (#6871) can report the gate state without constructing an engine.
+export function isSchedulerEnabled(config) {
+  if (process.env.CHROXY_ENABLE_SCHEDULER === '1') return true
+  return config?.features?.scheduler === true
+}
+
 // #6858 — resolve the opt-in provider-binary provenance PIN-LEDGER mode. One of
 // 'off' | 'warn' | 'block'. Fail-closed to 'off' (behaviour identical to the
 // pre-#6858 spawn path) for anything but an explicit 'warn' / 'block'. Precedence:

--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -19,7 +19,12 @@ const STORE_VERSION = 1
 const MAX_TASKS = 500
 
 const CADENCE_KINDS = new Set(['once', 'interval', 'cron'])
-const LAST_RUN_STATUSES = new Set(['success', 'error', 'skipped', 'timeout'])
+// `refused` (#6997 review) = the engine declined to start the run at all — an
+// unsupported hook-routed provider, a cwd outside the allowlist, or a permission
+// mode it could not verify. Distinct from `error` (the run happened and failed)
+// and `skipped` (the slot passed) so a reader can tell an operator that NOTHING
+// ran and that the task definition needs fixing.
+const LAST_RUN_STATUSES = new Set(['success', 'error', 'skipped', 'timeout', 'refused'])
 
 /**
  * Error thrown when a task submitted to add()/update() is malformed. Carries the

--- a/packages/server/src/scheduler.js
+++ b/packages/server/src/scheduler.js
@@ -1,0 +1,628 @@
+// Headless scheduler engine (#6865, keystone slice of epic #6784). Owns the
+// TIMING and the SAFETY of firing a persisted scheduled task (#6862) into a real
+// agent session with NO client connected.
+//
+// Split of responsibility across the epic:
+//   - schedule-parser.js       — pure cadence parsing + next-run computation
+//   - scheduled-task-store.js  — persistence/CRUD of the standing registry
+//   - scheduler.js (this file) — arms timers, fires due tasks, records outcomes
+//   - #6868 CLI / #6871 panel  — read the registry + this engine's gate state
+//
+// Deliberately NOT `ScheduleWakeup` (transcript-tasks.js): that stays the
+// intra-session, single-shot, transcript-derived mid-turn self-resume. Nothing
+// here reads or writes it — TranscriptTaskScanner is a passive transcript
+// observer and is untouched by this slice.
+//
+// ── Why the daemon owns the timing ────────────────────────────────────────────
+// The upstream `claude` CLI emits its own `scheduled_task_fire` system-message
+// subtype (epic #6784 notes it in real transcripts; in Chroxy it lands in the
+// generic system-event log at sdk-session.js:920). Investigated and NOT used as
+// the timing source: it is a NOTIFICATION that the CLI's internal scheduler
+// fired, not a programmable API — there is no way to register a standing cadence
+// with it, no wire message to drive it, and it would only ever cover the one
+// `claude` provider, so it cannot serve a multi-provider registry. The engine
+// therefore owns timing in-daemon.
+//
+// ── Security posture (the crux — a turn fires with nobody watching) ───────────
+// 1. ENABLE GATE: off unless explicitly enabled (`features.scheduler` /
+//    CHROXY_ENABLE_SCHEDULER=1, via config.js's isSchedulerEnabled). A daemon
+//    with the gate closed arms NO timer and spawns NOTHING — start() is a no-op.
+// 2. PERMISSION FLOOR: a scheduled run is pinned to the safest posture and can
+//    never select an auto-approve mode. resolveScheduledPermissionMode() clamps a
+//    stored `target.permissionMode` DOWN to 'approve', so a task definition can
+//    never escalate itself. The run is also created with an EXPLICIT
+//    `skipPermissions: false`, which overrides the server-wide
+//    `dangerouslySkipPermissions` default (session-manager.js:1473) — a global
+//    bypass a human opted into for their own interactive TUI use must not silently
+//    extend to unattended runs.
+// 3. NOBODY TO ANSWER: a permission prompt raised by a scheduled turn rides the
+//    normal pipeline. Rules in the permission-rule store still short-circuit
+//    BEFORE a prompt is emitted, so an operator's explicit, auditable allow-rule
+//    remains the ONE way to let a scheduled task act — and the protected-path /
+//    secret-read floor still cannot be escaped by such a rule. Anything that
+//    actually reaches a prompt has no human to answer it, so this engine answers
+//    `deny` through the same door a human clicks (`session.respondToPermission`,
+//    mirroring orchestration/permission-gate.js), interrupts the turn, and
+//    records the run as a VISIBLE failure. It never waits out the 5-minute
+//    permission timeout, and it never auto-approves anything.
+// 4. Every fire attempt — success, error, timeout, permission-blocked, shed — is
+//    recorded into the registry so #6868/#6871 can surface it.
+// 5. Per-task scoping: the run is created with the task's own stored
+//    provider/model/cwd. No new path check is invented here; cwd confinement and
+//    the protected-path floor stay exactly where they already live (the store's
+//    validation and permission-manager's floor).
+//
+// ── Resource posture (#6933 lesson) ──────────────────────────────────────────
+// One self-rescheduling timer (never setInterval), injectable via
+// `setTimer`/`clearTimer` and `.unref()`'d by default so it can never keep the
+// event loop alive or wedge a coverage run. destroy() clears everything and is
+// idempotent. Overlapping fires of one task are refused; a burst of
+// simultaneously-due tasks is serialized under a concurrency cap.
+
+import { EventEmitter } from 'events'
+import { createLogger } from './logger.js'
+import { isSchedulerEnabled } from './config.js'
+import { TurnDriver, TurnError } from './orchestration/turn-driver.js'
+
+const log = createLogger('scheduler')
+
+/**
+ * Longest a single armed timer may sleep. The engine re-evaluates at least this
+ * often even when the next task is days away, so a registry mutated by the CLI
+ * (#6868) or the dashboard (#6871) is picked up without those callers having to
+ * know to poke us, and a large wall-clock jump (suspend/resume, NTP step) can
+ * never park us on a stale multi-day deadline.
+ */
+export const MAX_SLEEP_MS = 60 * 1000
+
+/**
+ * How long a single scheduled run may take before it is abandoned and recorded
+ * as `timeout`. Bounds the damage of a wedged provider so it cannot hold the
+ * concurrency slot (and thus every other task) forever.
+ */
+export const DEFAULT_RUN_TIMEOUT_MS = 15 * 60 * 1000
+
+/**
+ * How late an overdue task may still be fired. A daemon that was down (laptop
+ * closed, crash-restart) comes back to tasks whose slot has passed; firing all of
+ * them at once is a surprise burst of unattended agent sessions, so anything
+ * staler than this grace window is recorded `skipped` instead of run. Recurring
+ * cadences rarely reach it — the store recomputes nextRun FORWARD on load, so a
+ * missed slot is simply skipped and there is no backfill — it mainly bounds a
+ * one-time task whose `at` passed while the daemon was down.
+ */
+export const DEFAULT_OVERDUE_GRACE_MS = 60 * 60 * 1000
+
+/**
+ * Simultaneous scheduled runs. Default 1: each run drives a whole agent session
+ * (real cost, real tokens), and a registry where twenty tasks share one cron slot
+ * must not become twenty concurrent providers. Due tasks beyond the cap are shed
+ * for this tick and picked up on a later one — the thundering-herd guard.
+ */
+export const DEFAULT_MAX_CONCURRENT_RUNS = 1
+
+/**
+ * The permission mode an unattended run is pinned to. Chroxy's mode ids are
+ * `approve` | `acceptEdits` | `auto` | `plan` (handler-utils.js
+ * ALLOWED_PERMISSION_MODE_IDS); `approve` is the safest — every consequential
+ * tool call gates on a human decision.
+ */
+export const SCHEDULED_PERMISSION_MODE = 'approve'
+
+/**
+ * The only modes a task definition may select for an unattended run. `plan` is
+ * permitted because it is strictly MORE restrictive than `approve` (the model
+ * plans instead of acting), which is a legitimate thing to schedule.
+ *
+ * Everything else is clamped down. `auto` is Chroxy's bypass (it maps to the SDK's
+ * bypassPermissions and auto-approves every non-floored tool) and `acceptEdits`
+ * auto-approves Read/Write/Edit/NotebookEdit without asking — both would let a
+ * stored task grant itself approvals no human ever gave, which is exactly the
+ * escalation this engine exists to prevent. Clamping (rather than refusing to run)
+ * keeps the floor a FLOOR: the task still runs, just never above the ceiling.
+ */
+const SCHEDULED_ALLOWED_PERMISSION_MODES = new Set([SCHEDULED_PERMISSION_MODE, 'plan'])
+
+/** setTimeout that never keeps the event loop alive (self-exit safety, #6933). */
+function unrefTimer(fn, ms) {
+  const t = setTimeout(fn, ms)
+  if (typeof t.unref === 'function') t.unref()
+  return t
+}
+
+/**
+ * Clamp a task's requested permission mode down to what an unattended run may
+ * use. Returns the floor for anything absent, unrecognized, or more permissive
+ * than the floor. Never throws — a stored task must not be able to break the
+ * engine, only to be de-escalated.
+ *
+ * @param {string} [requested] - task.target.permissionMode
+ * @returns {string} a permission mode id safe for an unattended run
+ */
+export function resolveScheduledPermissionMode(requested) {
+  if (typeof requested === 'string' && SCHEDULED_ALLOWED_PERMISSION_MODES.has(requested)) return requested
+  return SCHEDULED_PERMISSION_MODE
+}
+
+/**
+ * Fires due scheduled tasks into headless sessions and records each outcome back
+ * into the registry.
+ *
+ * Emits (server-internal only — this slice adds NO wire message; #6871 can layer
+ * one on top of these events):
+ *   - 'run-start' { taskId, at, sessionId? }
+ *   - 'run-end'   { taskId, at, status, sessionId?, error? }
+ *   - 'run-skip'  { taskId, at, reason }
+ */
+export class SchedulerEngine extends EventEmitter {
+  /**
+   * @param {object} options
+   * @param {object} [options.sessionManager] - source of the registry (`.scheduledTaskStore`) and of sessions
+   * @param {import('./scheduled-task-store.js').ScheduledTaskStore} [options.store] - registry override (defaults to sessionManager.scheduledTaskStore)
+   * @param {object} [options.config] - loaded daemon config (read for the enable gate)
+   * @param {Function} [options.runTask] - injectable executor `(task, ctx) => Promise<{status, sessionId?, error?}>`;
+   *   defaults to the SessionManager+TurnDriver headless runner. This seam keeps
+   *   tests hermetic — no provider is ever spawned under test (#6933).
+   * @param {() => number} [options.now=Date.now] - clock seam
+   * @param {Function} [options.setTimer] - injectable setTimeout (unref'd by default)
+   * @param {Function} [options.clearTimer=clearTimeout] - injectable clearTimeout
+   * @param {number} [options.maxConcurrentRuns]
+   * @param {number} [options.runTimeoutMs]
+   * @param {number} [options.overdueGraceMs]
+   * @param {number} [options.maxSleepMs]
+   * @param {object} [options.logger]
+   */
+  constructor({
+    sessionManager = null,
+    store = null,
+    config = null,
+    runTask = null,
+    now = Date.now,
+    setTimer = unrefTimer,
+    clearTimer = clearTimeout,
+    maxConcurrentRuns = DEFAULT_MAX_CONCURRENT_RUNS,
+    runTimeoutMs = DEFAULT_RUN_TIMEOUT_MS,
+    overdueGraceMs = DEFAULT_OVERDUE_GRACE_MS,
+    maxSleepMs = MAX_SLEEP_MS,
+    logger = log,
+  } = {}) {
+    super()
+    const resolvedStore = store || sessionManager?.scheduledTaskStore || null
+    if (!resolvedStore) throw new Error('SchedulerEngine requires a store (or a sessionManager owning one)')
+    this._store = resolvedStore
+    this._sm = sessionManager
+    this._config = config
+    this._injectedRunTask = typeof runTask === 'function' ? runTask : null
+    this._now = now
+    this._setTimer = setTimer
+    this._clearTimer = clearTimer
+    this._maxConcurrentRuns = Math.max(1, Math.floor(maxConcurrentRuns) || 1)
+    this._runTimeoutMs = runTimeoutMs
+    this._overdueGraceMs = overdueGraceMs
+    this._maxSleepMs = Math.max(1, Math.floor(maxSleepMs) || MAX_SLEEP_MS)
+    this._log = logger
+
+    this._timer = null
+    this._started = false
+    this._destroyed = false
+    /** @type {Set<string>} task ids with a run in flight — the overlap guard. */
+    this._running = new Set()
+    /** @type {Map<string,string>} taskId -> sessionId, so a recurring task RESUMES its session. */
+    this._sessionByTask = new Map()
+    /**
+     * @type {Set<string>} task ids whose outcome could not be persisted. Recording
+     * the run is what advances nextRun, so a task we cannot record would stay
+     * permanently due and be re-fired on every tick. Quarantining it (for this
+     * process only — a restart re-reads the file) turns a storage fault into one
+     * logged error instead of a hot loop of unattended agent sessions.
+     */
+    this._quarantined = new Set()
+    /** @type {Map<string,{taskId:string,blocked:null|{toolName:string}}>} sessionId -> live run, for the permission answerer. */
+    this._ownedRuns = new Map()
+
+    // Lazily built on first real run so a disabled daemon (and every unit test
+    // using the runTask seam) never constructs a TurnDriver or attaches its
+    // SessionManager listeners.
+    this._turnDriver = null
+    this._permissionListener = null
+  }
+
+  /** Whether the enable gate is open for this daemon. */
+  get enabled() {
+    return isSchedulerEnabled(this._config)
+  }
+
+  /** Task ids currently mid-run (test/observability aid). */
+  get runningTaskIds() {
+    return new Set(this._running)
+  }
+
+  /** Whether a timer is currently armed (test/observability aid). */
+  get armed() {
+    return this._timer !== null
+  }
+
+  /**
+   * Arm the engine. A NO-OP when the enable gate is closed: no timer is armed, so
+   * a daemon with the feature off behaves exactly as it did before this slice
+   * existed. Idempotent.
+   * @returns {boolean} whether the engine actually started
+   */
+  start() {
+    if (this._destroyed || this._started) return this._started
+    if (!this.enabled) {
+      this._log.info('Scheduled execution is disabled (features.scheduler / CHROXY_ENABLE_SCHEDULER=1) — no scheduled tasks will fire')
+      return false
+    }
+    this._started = true
+    this._log.info('Scheduled execution ENABLED — arming headless scheduler')
+    this._armNextTick()
+    return true
+  }
+
+  /**
+   * Re-evaluate the schedule now (e.g. after the CLI/dashboard mutated the
+   * registry). Cheap and safe to call often; a no-op when not started.
+   */
+  refresh() {
+    if (!this._started || this._destroyed) return
+    this._armNextTick()
+  }
+
+  /**
+   * Clear every timer, detach listeners, and stop firing. Idempotent — the
+   * daemon's shutdown path may call it more than once. In-flight runs are left to
+   * settle (their recording is guarded on `_destroyed`), so shutdown never blocks
+   * on a provider.
+   */
+  destroy() {
+    this._destroyed = true
+    this._started = false
+    this._clearArmedTimer()
+    this._detachPermissionListener()
+    if (this._turnDriver) {
+      try { this._turnDriver.dispose() } catch (err) {
+        this._log.warn(`Scheduler turn-driver dispose failed: ${err?.message || err}`)
+      }
+      this._turnDriver = null
+    }
+    this._running.clear()
+    this._ownedRuns.clear()
+    this._sessionByTask.clear()
+    this._quarantined.clear()
+    this.removeAllListeners()
+  }
+
+  /** @private */
+  _clearArmedTimer() {
+    if (this._timer !== null) {
+      this._clearTimer(this._timer)
+      this._timer = null
+    }
+  }
+
+  /**
+   * @private — arm ONE timer for the earliest interesting moment, clamped to
+   * [0, maxSleepMs]. Replaces any previously armed timer, so repeated calls can
+   * never stack timers up.
+   */
+  _armNextTick() {
+    if (this._destroyed || !this._started) return
+    this._clearArmedTimer()
+    const now = this._now()
+    let earliest = null
+    // At capacity nothing new can start, and a shed task stays due — computing a
+    // 0ms delay off it would spin the CPU until the in-flight run finished. Sleep
+    // the full cadence instead; _fire() re-arms the moment a slot frees.
+    if (this._running.size < this._maxConcurrentRuns) {
+      for (const task of this._store.list()) {
+        if (!task.enabled || !Number.isFinite(task.nextRun)) continue
+        if (this._running.has(task.id) || this._quarantined.has(task.id)) continue
+        if (earliest === null || task.nextRun < earliest) earliest = task.nextRun
+      }
+    }
+    // Even with nothing scheduled we re-check on the max-sleep cadence, so a task
+    // added by another surface is noticed without an explicit refresh() call.
+    const delay = earliest === null
+      ? this._maxSleepMs
+      : Math.min(this._maxSleepMs, Math.max(0, earliest - now))
+    this._timer = this._setTimer(() => this._tick(), delay)
+  }
+
+  /**
+   * @private — one evaluation pass: fire everything due (under the concurrency
+   * cap), then re-arm. Never throws; a per-task failure is recorded and the pass
+   * continues.
+   */
+  _tick() {
+    if (this._destroyed || !this._started) return
+    this._timer = null
+    const now = this._now()
+    try {
+      for (const task of this._dueTasks(now)) {
+        if (this._isTooOverdue(task, now)) {
+          // Persist a `skipped` result so the schedule ADVANCES (and a one-time
+          // task retires) instead of re-evaluating as overdue forever.
+          this._recordSkip(task, now, `overdue by ${now - task.nextRun}ms (grace ${this._overdueGraceMs}ms)`, { persist: true })
+          continue
+        }
+        if (this._running.size >= this._maxConcurrentRuns) {
+          // Thundering-herd guard: shed the rest of this burst WITHOUT persisting.
+          // The task is still genuinely due and fires on a later tick.
+          this._recordSkip(task, now, `concurrency cap reached (${this._maxConcurrentRuns})`)
+          continue
+        }
+        // Fire-and-forget: _fire() owns its error handling and records its own
+        // outcome, so an in-flight run never blocks the evaluation pass. The
+        // trailing catch is the backstop for anything _fire's own try/catch cannot
+        // cover (chiefly a listener throwing inside emit) — an unhandled rejection
+        // here would take the daemon down.
+        void this._fire(task, now).catch((err) => {
+          this._running.delete(task.id)
+          this._log.error(`Scheduled task ${task.id} fire failed unexpectedly: ${err?.stack || err}`)
+        })
+      }
+    } catch (err) {
+      this._log.error(`Scheduler tick failed: ${err?.stack || err}`)
+    }
+    this._armNextTick()
+  }
+
+  /** @private — enabled tasks whose nextRun has arrived, oldest-due first. */
+  _dueTasks(now) {
+    return this._store
+      .list()
+      .filter((t) => t.enabled && Number.isFinite(t.nextRun) && t.nextRun <= now
+        && !this._running.has(t.id) && !this._quarantined.has(t.id))
+      .sort((a, b) => a.nextRun - b.nextRun)
+  }
+
+  /** @private — whether a due task's slot is staler than the grace window. */
+  _isTooOverdue(task, now) {
+    if (!Number.isFinite(this._overdueGraceMs) || this._overdueGraceMs < 0) return false
+    return now - task.nextRun > this._overdueGraceMs
+  }
+
+  /** @private — record a non-run (shed / too-overdue). */
+  _recordSkip(task, at, reason, { persist = false } = {}) {
+    this._log.warn(`Scheduled task ${task.id} not fired: ${reason}`)
+    if (persist) this._recordRun(task, { at, status: 'skipped', error: reason })
+    this.emit('run-skip', { taskId: task.id, at, reason })
+  }
+
+  /**
+   * @private — execute one task end-to-end: mark it in-flight (overlap guard),
+   * run it, then record the outcome and re-arm. Never rejects.
+   */
+  async _fire(task, at) {
+    this._running.add(task.id)
+    this.emit('run-start', { taskId: task.id, at })
+    this._log.info(`Firing scheduled task ${task.id}${task.name ? ` (${task.name})` : ''}`)
+
+    const ctx = {
+      at,
+      permissionMode: resolveScheduledPermissionMode(task.target?.permissionMode),
+      runTimeoutMs: this._runTimeoutMs,
+    }
+
+    let outcome
+    try {
+      const exec = this._injectedRunTask || ((t, c) => this._runViaSessionManager(t, c))
+      outcome = await exec(task, ctx)
+    } catch (err) {
+      outcome = { status: 'error', error: err?.message || String(err) }
+    } finally {
+      this._running.delete(task.id)
+    }
+
+    const status = outcome?.status
+    const result = {
+      at,
+      status: status === 'success' || status === 'timeout' || status === 'skipped' ? status : 'error',
+      ...(outcome?.sessionId ? { sessionId: outcome.sessionId } : {}),
+      ...(outcome?.error ? { error: String(outcome.error).slice(0, 500) } : {}),
+    }
+    this._recordRun(task, result)
+    this.emit('run-end', { taskId: task.id, ...result })
+    if (result.status === 'success') {
+      this._log.info(`Scheduled task ${task.id} completed`)
+    } else {
+      this._log.warn(`Scheduled task ${task.id} finished status=${result.status}${result.error ? `: ${result.error}` : ''}`)
+    }
+    // A finished run frees a concurrency slot and changed nextRun — re-evaluate.
+    this._armNextTick()
+  }
+
+  /**
+   * @private — persist a lastRun result. The store recomputes nextRun off the
+   * cadence on update(), which is what retires a one-time task (computeNextRun
+   * returns null for a `once` cadence that has a lastRun) and advances a recurring
+   * one to its next slot with no backfill of missed slots.
+   */
+  _recordRun(task, result) {
+    try {
+      this._store.update(task.id, { lastRun: result })
+    } catch (err) {
+      // A task removed mid-run (update() returns null — not a throw) or a rejected
+      // result value must not take the engine down. It must ALSO not be retried
+      // forever: without a recorded run its nextRun never advances, so quarantine
+      // it for this process rather than re-firing it every tick.
+      this._quarantined.add(task.id)
+      this._log.error(`Failed to record run for scheduled task ${task.id} — quarantining it until restart: ${err?.message || err}`)
+    }
+  }
+
+  // ── the default (production) executor ──────────────────────────────────────
+
+  /**
+   * @private — the real headless run: create (or RESUME) this task's session and
+   * drive the task prompt through it with no client connected.
+   *
+   * Session reuse is deliberate (the issue's "spins up (or resumes) a session"):
+   * one session per task id, reused while it is still alive. That bounds a daily
+   * task to ONE session instead of one per fire, keeps the recorded `sessionId`
+   * meaningful (the operator can open it and read what the run actually did), and
+   * gives a recurring task continuity across runs. Sessions are NOT auto-destroyed
+   * afterwards — they are ordinary sessions the operator can inspect and close.
+   */
+  async _runViaSessionManager(task, ctx) {
+    if (!this._sm) return { status: 'error', error: 'no sessionManager wired — cannot run scheduled task' }
+
+    let sessionId
+    try {
+      sessionId = this._resolveSession(task, ctx)
+    } catch (err) {
+      return { status: 'error', error: `session create failed: ${err?.message || err}` }
+    }
+    if (!sessionId) return { status: 'error', error: 'session create failed (no sessionId)' }
+
+    // Register as an OWNED run before the turn starts, so the permission answerer
+    // is armed for the very first tool call.
+    const runState = { taskId: task.id, blocked: null }
+    this._ownedRuns.set(sessionId, runState)
+    this._attachPermissionListener()
+
+    try {
+      const driver = this._ensureTurnDriver()
+      await driver.driveTurn(sessionId, task.prompt, {
+        label: `scheduled:${task.id}`,
+        timeoutMs: ctx.runTimeoutMs,
+      })
+      // A denied permission usually lets the agent finish "successfully" with the
+      // tool call refused. That is NOT a successful scheduled run — surface it.
+      if (runState.blocked) return this._blockedOutcome(runState, sessionId)
+      return { status: 'success', sessionId }
+    } catch (err) {
+      if (runState.blocked) return this._blockedOutcome(runState, sessionId)
+      if (err instanceof TurnError && err.code === 'TURN_TIMEOUT') {
+        return { status: 'timeout', sessionId, error: `run exceeded ${ctx.runTimeoutMs}ms` }
+      }
+      return { status: 'error', sessionId, error: err?.message || String(err) }
+    } finally {
+      this._ownedRuns.delete(sessionId)
+      if (this._ownedRuns.size === 0) this._detachPermissionListener()
+    }
+  }
+
+  /** @private — the permission-blocked outcome (a visible failure, never silent). */
+  _blockedOutcome(runState, sessionId) {
+    return {
+      status: 'error',
+      sessionId,
+      error: `permission required for ${runState.blocked.toolName || 'a tool'} but no client is connected to approve it — scheduled run denied. Author an explicit permission rule if this task should be allowed to do this.`,
+    }
+  }
+
+  /** @private — reuse this task's still-live session, else create a fresh one. */
+  _resolveSession(task, ctx) {
+    const existing = this._sessionByTask.get(task.id)
+    if (existing && this._sm.getSession?.(existing)) return existing
+
+    const target = task.target || {}
+    const sessionId = this._sm.createSession({
+      name: task.name || `Scheduled: ${task.id.slice(0, 8)}`,
+      ...(target.cwd ? { cwd: target.cwd } : {}),
+      ...(target.provider ? { provider: target.provider } : {}),
+      ...(target.model ? { model: target.model } : {}),
+      // The clamped floor — never the task's raw value (see resolveScheduledPermissionMode).
+      permissionMode: ctx.permissionMode,
+      // EXPLICIT false so an unattended run can never inherit the server-wide
+      // `dangerouslySkipPermissions` default (session-manager.js:1473).
+      skipPermissions: false,
+      metadata: { scheduledTaskId: task.id },
+    })
+    this._sessionByTask.set(task.id, sessionId)
+    return sessionId
+  }
+
+  /** @private — build the TurnDriver on first real run. */
+  _ensureTurnDriver() {
+    if (!this._turnDriver) {
+      this._turnDriver = new TurnDriver({ sessionManager: this._sm, log: this._log })
+    }
+    return this._turnDriver
+  }
+
+  /**
+   * @private — arm the headless permission answerer. Scoped to sessions this
+   * engine owns (never a user's session), mirroring
+   * orchestration/permission-gate.js. Attached only while a run is in flight.
+   */
+  _attachPermissionListener() {
+    if (this._permissionListener || !this._sm?.on) return
+    this._permissionListener = (payload) => this._handleSessionEvent(payload)
+    this._sm.on('session_event', this._permissionListener)
+  }
+
+  /** @private */
+  _detachPermissionListener() {
+    if (!this._permissionListener) return
+    this._sm?.off?.('session_event', this._permissionListener)
+    this._permissionListener = null
+  }
+
+  /**
+   * @private — a permission prompt reached a scheduled run, which means no rule
+   * settled it and there is no human to answer. DENY it through the normal door
+   * and interrupt the turn so the run fails fast and visibly rather than burning
+   * five minutes on the permission timeout (or, worse, being auto-approved).
+   */
+  _handleSessionEvent({ sessionId, event, data } = {}) {
+    if (event !== 'permission_request') return
+    const runState = this._ownedRuns.get(sessionId)
+    if (!runState) return // never answer a session this engine does not own
+    const requestId = data?.requestId ?? data?.id ?? null
+    const toolName = data?.toolName ?? data?.tool ?? ''
+    if (requestId == null) return
+    if (!runState.blocked) runState.blocked = { toolName }
+    this._log.warn(`Scheduled task ${runState.taskId} requested permission for ${toolName || 'a tool'} with no client connected — denying`)
+
+    const entry = this._sm.getSession?.(sessionId)
+    const session = entry?.session
+    if (!session) return
+    if (typeof session.respondToPermission === 'function') {
+      try {
+        session.respondToPermission(requestId, 'deny')
+      } catch (err) {
+        this._log.warn(`Scheduler permission deny failed for ${sessionId}: ${err?.message || err}`)
+      }
+    }
+    // Abort the rest of the turn: the task cannot complete what it was asked to do,
+    // so there is no value in letting it continue spending tokens.
+    if (typeof session.interrupt === 'function') {
+      try {
+        const maybe = session.interrupt()
+        if (maybe && typeof maybe.catch === 'function') maybe.catch(() => {})
+      } catch { /* best effort */ }
+    }
+  }
+}
+
+/**
+ * Build the scheduler engine for the daemon, or return null when the enable gate
+ * is closed. Mirrors buildOrchestrationManager (orchestration/build-manager.js):
+ * server-cli.js gets one call and a nullable handle to dispose.
+ *
+ * @param {object} opts
+ * @param {object} opts.sessionManager
+ * @param {object} [opts.config]
+ * @param {object} [opts.logger]
+ * @returns {SchedulerEngine|null}
+ */
+export function buildSchedulerEngine({ sessionManager, config = null, logger = log } = {}) {
+  if (!isSchedulerEnabled(config)) return null
+  if (!sessionManager?.scheduledTaskStore) {
+    logger.warn('Scheduled execution enabled but no scheduled-task store is available — scheduler not started')
+    return null
+  }
+  // Never throw out of here: a scheduler that fails to build must not break daemon
+  // boot (same contract as buildOrchestrationManager).
+  try {
+    const engine = new SchedulerEngine({ sessionManager, config, logger })
+    engine.start()
+    return engine
+  } catch (err) {
+    logger.error(`Failed to start the scheduler engine — scheduled tasks will not fire: ${err?.stack || err}`)
+    return null
+  }
+}

--- a/packages/server/src/scheduler.js
+++ b/packages/server/src/scheduler.js
@@ -45,12 +45,47 @@
 //    mirroring orchestration/permission-gate.js), interrupts the turn, and
 //    records the run as a VISIBLE failure. It never waits out the 5-minute
 //    permission timeout, and it never auto-approves anything.
-// 4. Every fire attempt — success, error, timeout, permission-blocked, shed — is
-//    recorded into the registry so #6868/#6871 can surface it.
-// 5. Per-task scoping: the run is created with the task's own stored
-//    provider/model/cwd. No new path check is invented here; cwd confinement and
-//    the protected-path floor stay exactly where they already live (the store's
-//    validation and permission-manager's floor).
+// 4. SUPPORTED PROVIDERS ONLY — the engine REFUSES what it cannot govern. The
+//    deny mechanism in (3) rides `session_event: permission_request` +
+//    `session.respondToPermission`, which exist ONLY on providers whose
+//    `capabilities.inProcessPermissions === true` (today: claude-sdk, claude-byok,
+//    codex via its app-server driver, deepseek, ollama — the live list is
+//    listSchedulableProviders(), read off the registry rather than hardcoded).
+//    Hook-routed providers — INCLUDING the daemon default `claude-tui`, plus
+//    claude-cli, claude-channel, gemini, and codex when CHROXY_CODEX_APPSERVER=0
+//    downgrades it to the exec driver — route prompts through
+//    hooks/permission-hook.sh → POST /permission → ws-permissions.js, which emits
+//    NO events this engine can observe and auto-denies after a 300s wait. On such
+//    a provider an unattended run would stall five minutes per gated tool call
+//    and then report SUCCESS for a turn whose every tool call was silently
+//    refused. Rather than pretend to govern it, a task resolving to a hook-routed
+//    provider is refused BEFORE any session is created and recorded `refused`
+//    with the provider named. Widening this to hook-routed providers needs a
+//    programmatic permission-answering surface — tracked in #7003.
+// 5. CWD CONFINEMENT is enforced HERE, on this path. It is NOT inherited: the
+//    store only trims the cwd string and SessionManager.createSession only
+//    `statSync`s it, so the real check (`validateCwdAllowed` — credential-dir
+//    deny-list + workspace allowlist + $HOME fallback) is handler-only. A task
+//    definition is a user-writable JSON file, so a hand-edited `target.cwd` of
+//    `/`, `~/.ssh`, or `~/.chroxy` would otherwise reach a session the dashboard
+//    would have rejected. This engine therefore calls the SAME imported
+//    `validateCwdAllowed` the WS handlers call, wired exactly the way the sibling
+//    feature does it (orchestration/build-manager.js:38), and refuses the run
+//    when it rejects. (Moving the check INTO createSession so no caller can miss
+//    it is the right long-term fix — tracked in #7005.)
+// 6. THE CLAMP IS RE-ASSERTED PER FIRE, not just at create. Scheduled sessions
+//    are deliberately kept alive and reused, and `set_permission_mode` accepts
+//    `auto` on any session (handlers/settings-handlers.js) — even mid-turn
+//    (base-session.js:1115-1133). An operator who opens a scheduled session and
+//    flips it to Auto once would otherwise make every subsequent unattended fire
+//    run in bypass, indefinitely. So before each fire the engine re-asserts the
+//    clamped mode on the session and VERIFIES it by read-back. The invariant is
+//    absolute: a scheduled fire runs at the clamped mode, or it does not run.
+// 7. Every fire attempt — success, error, timeout, permission-blocked, refused,
+//    shed — is recorded into the registry so #6868/#6871 can surface it. A run
+//    the engine refused is recorded `refused` (never `success`), and a run whose
+//    tool calls were blocked is recorded `error`. NOTHING reports `success`
+//    unless the turn actually completed with no permission prompt raised.
 //
 // ── Resource posture (#6933 lesson) ──────────────────────────────────────────
 // One self-rescheduling timer (never setInterval), injectable via
@@ -62,6 +97,8 @@
 import { EventEmitter } from 'events'
 import { createLogger } from './logger.js'
 import { isSchedulerEnabled } from './config.js'
+import { getProvider, listProviders, DEFAULT_PROVIDER } from './providers.js'
+import { validateCwdAllowed } from './handler-utils.js'
 import { TurnDriver, TurnError } from './orchestration/turn-driver.js'
 
 const log = createLogger('scheduler')
@@ -120,8 +157,102 @@ export const SCHEDULED_PERMISSION_MODE = 'approve'
  * stored task grant itself approvals no human ever gave, which is exactly the
  * escalation this engine exists to prevent. Clamping (rather than refusing to run)
  * keeps the floor a FLOOR: the task still runs, just never above the ceiling.
+ *
+ * DO NOT relax the `acceptEdits` clamp. It is load-bearing, not merely strict:
+ * `acceptEdits` auto-approves file reads, so an unattended run under it would read
+ * `.env` / `id_rsa` with nothing gating it. The in-process providers this engine
+ * fires at do apply permission-manager's protected-path floor to those reads, but
+ * the hook path does NOT — hooks/permission-hook.sh:262-271 allows
+ * Read|Write|Edit|NotebookEdit|Glob|Grep outright with no protected-path check
+ * (tracked as #7004). Today posture (4) refuses hook-routed providers outright, so
+ * that gap is not reachable from here; keeping the clamp means it stays unreachable
+ * if #7003 ever widens provider support.
  */
 const SCHEDULED_ALLOWED_PERMISSION_MODES = new Set([SCHEDULED_PERMISSION_MODE, 'plan'])
+
+/**
+ * The `lastRun.status` recorded when the engine REFUSED to start a run at all:
+ * an unsupported (hook-routed) provider, a disallowed cwd, or a permission mode
+ * it could not verify. Deliberately its OWN status rather than `error` (which
+ * means "the run happened and went wrong") or `skipped` (which means "the slot
+ * passed"), so #6868/#6871 can tell an operator that nothing ran AND why — a
+ * refused task is a misconfiguration to fix, not a transient failure to retry.
+ *
+ * NOTHING coerces to `success`: a refused run never touched a provider.
+ */
+export const REFUSED_STATUS = 'refused'
+
+/** Statuses `_fire` passes through verbatim; everything else becomes `error`. */
+const PASSTHROUGH_STATUSES = new Set(['success', 'timeout', 'skipped', REFUSED_STATUS])
+
+/**
+ * Thrown internally when a run must be refused after the executor was entered
+ * (currently: the per-fire permission-mode re-assertion). Carries no data beyond
+ * its message — the caller turns it into a `refused` outcome.
+ */
+class ScheduledRunRefusedError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'ScheduledRunRefusedError'
+  }
+}
+
+/**
+ * The provider ids a scheduled task MAY currently target: every registered,
+ * non-hidden provider that answers permissions in-process. Derived from the
+ * registry rather than hardcoded, so it follows both new providers and the
+ * runtime driver swap (`codex` resolves to the app-server driver unless
+ * CHROXY_CODEX_APPSERVER=0 downgrades it to the unsupported exec driver) instead
+ * of going stale in a doc string.
+ *
+ * @param {() => Array<{name: string, capabilities?: object}>} [list=listProviders] - registry seam
+ * @returns {string[]} sorted provider ids
+ */
+export function listSchedulableProviders(list = listProviders) {
+  try {
+    return list()
+      .filter((p) => p?.capabilities?.inProcessPermissions === true)
+      .map((p) => p.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Why an unattended run may NOT be fired at this provider, or null when it may.
+ *
+ * The engine's whole permission story (deny-the-prompt, fail visibly) depends on
+ * observing `session_event: permission_request` and answering via
+ * `session.respondToPermission`. Both exist only where
+ * `capabilities.inProcessPermissions === true`. A hook-routed provider instead
+ * shells out to hooks/permission-hook.sh → POST /permission → ws-permissions.js,
+ * which emits nothing observable and auto-denies after 300s — so an unattended
+ * run there would stall five minutes per gated tool call and then look
+ * successful. Refusing is the honest outcome; #7003 tracks giving hook-routed
+ * providers a programmatic answering surface so support can widen.
+ *
+ * @param {string} providerName - the provider the run would actually use
+ * @param {(name: string) => Function} [getProviderClass=getProvider] - registry seam
+ * @returns {string|null} refusal reason, or null when the provider is supported
+ */
+export function scheduledProviderRefusalReason(providerName, getProviderClass = getProvider) {
+  if (typeof providerName !== 'string' || providerName.length === 0) {
+    return 'no provider could be resolved for this scheduled task — refusing to fire an unattended run at an unknown provider'
+  }
+  let ProviderClass = null
+  try {
+    ProviderClass = getProviderClass(providerName)
+  } catch (err) {
+    return `unknown provider '${providerName}': ${err?.message || err}`
+  }
+  if (ProviderClass?.capabilities?.inProcessPermissions === true) return null
+  // Kept under the 500-char cap _recordRefusal applies, so the #7003 pointer and
+  // the supported-provider list survive into the registry rather than being cut.
+  const supported = listSchedulableProviders()
+  const isDefault = providerName === DEFAULT_PROVIDER
+  return `provider '${providerName}' routes permission prompts through the permission hook (POST /permission), which the scheduler cannot answer — an unattended run would stall on every gated tool call until the 300s auto-deny, then report a turn whose tool calls were all silently refused.${isDefault ? ` It is also the daemon DEFAULT, so a task with no target.provider lands here.` : ''} Set target.provider to one of: ${supported.length ? supported.join(', ') : '(none)'}. Hook-routed support: #7003.`
+}
 
 /** setTimeout that never keeps the event loop alive (self-exit safety, #6933). */
 function unrefTimer(fn, ms) {
@@ -153,6 +284,10 @@ export function resolveScheduledPermissionMode(requested) {
  *   - 'run-start' { taskId, at, sessionId? }
  *   - 'run-end'   { taskId, at, status, sessionId?, error? }
  *   - 'run-skip'  { taskId, at, reason }
+ *   - 'task-quarantined' { taskId, at, reason }
+ *
+ * A REFUSED task (unsupported provider / disallowed cwd) emits `run-end` with
+ * status `refused` and NO `run-start`: nothing was started, so nothing started.
  */
 export class SchedulerEngine extends EventEmitter {
   /**
@@ -164,6 +299,10 @@ export class SchedulerEngine extends EventEmitter {
    *   defaults to the SessionManager+TurnDriver headless runner. This seam keeps
    *   tests hermetic — no provider is ever spawned under test (#6933).
    * @param {() => number} [options.now=Date.now] - clock seam
+   * @param {(cwd: string) => (string|null)} [options.validateCwd] - cwd allowlist seam;
+   *   defaults to the SAME `validateCwdAllowed` the WS handlers use, wired the way
+   *   orchestration/build-manager.js:38 wires it. Returns an error STRING (falsy = allowed).
+   * @param {(name: string) => Function} [options.getProviderClass=getProvider] - provider-registry seam
    * @param {Function} [options.setTimer] - injectable setTimeout (unref'd by default)
    * @param {Function} [options.clearTimer=clearTimeout] - injectable clearTimeout
    * @param {number} [options.maxConcurrentRuns]
@@ -178,6 +317,8 @@ export class SchedulerEngine extends EventEmitter {
     config = null,
     runTask = null,
     now = Date.now,
+    validateCwd = null,
+    getProviderClass = getProvider,
     setTimer = unrefTimer,
     clearTimer = clearTimeout,
     maxConcurrentRuns = DEFAULT_MAX_CONCURRENT_RUNS,
@@ -194,6 +335,13 @@ export class SchedulerEngine extends EventEmitter {
     this._config = config
     this._injectedRunTask = typeof runTask === 'function' ? runTask : null
     this._now = now
+    // The cwd allowlist. Default wires the SAME exported validateCwdAllowed the WS
+    // handlers call, against this daemon's config (workspaceRoots etc.) — mirroring
+    // orchestration/build-manager.js:38. Not reimplemented, not approximated.
+    this._validateCwd = typeof validateCwd === 'function'
+      ? validateCwd
+      : (cwd) => validateCwdAllowed(cwd, this._config)
+    this._getProviderClass = typeof getProviderClass === 'function' ? getProviderClass : getProvider
     this._setTimer = setTimer
     this._clearTimer = clearTimer
     this._maxConcurrentRuns = Math.max(1, Math.floor(maxConcurrentRuns) || 1)
@@ -235,6 +383,17 @@ export class SchedulerEngine extends EventEmitter {
   /** Task ids currently mid-run (test/observability aid). */
   get runningTaskIds() {
     return new Set(this._running)
+  }
+
+  /**
+   * Task ids this process has quarantined (their outcome could not be persisted,
+   * so they have STOPPED firing until the daemon restarts). Part of the engine's
+   * gate state that #6868/#6871 read: a quarantined task's registry entry may
+   * still show an old healthy-looking lastRun, so this is the authoritative
+   * "why has this task gone quiet?" signal alongside the `task-quarantined` event.
+   */
+  get quarantinedTaskIds() {
+    return new Set(this._quarantined)
   }
 
   /** Whether a timer is currently armed (test/observability aid). */
@@ -395,15 +554,28 @@ export class SchedulerEngine extends EventEmitter {
    * run it, then record the outcome and re-arm. Never rejects.
    */
   async _fire(task, at) {
-    this._running.add(task.id)
-    this.emit('run-start', { taskId: task.id, at })
-    this._log.info(`Firing scheduled task ${task.id}${task.name ? ` (${task.name})` : ''}`)
-
     const ctx = {
       at,
       permissionMode: resolveScheduledPermissionMode(task.target?.permissionMode),
       runTimeoutMs: this._runTimeoutMs,
     }
+
+    // ── PREFLIGHT: refuse before firing ──────────────────────────────────────
+    // Runs BEFORE the overlap guard, BEFORE `run-start`, and BEFORE any session
+    // exists — a refused task never spawns a session and is never reported as a
+    // run that started. Placed here (the single chokepoint every run passes
+    // through) rather than inside the default executor so a future second
+    // executor cannot bypass it: a check that lives on only one path is exactly
+    // the class of bug this fixes (validateCwdAllowed was handler-only).
+    const refusal = this._preflightRefusal(task)
+    if (refusal) {
+      this._recordRefusal(task, at, refusal)
+      return
+    }
+
+    this._running.add(task.id)
+    this.emit('run-start', { taskId: task.id, at })
+    this._log.info(`Firing scheduled task ${task.id}${task.name ? ` (${task.name})` : ''}`)
 
     let outcome
     try {
@@ -418,7 +590,7 @@ export class SchedulerEngine extends EventEmitter {
     const status = outcome?.status
     const result = {
       at,
-      status: status === 'success' || status === 'timeout' || status === 'skipped' ? status : 'error',
+      status: PASSTHROUGH_STATUSES.has(status) ? status : 'error',
       ...(outcome?.sessionId ? { sessionId: outcome.sessionId } : {}),
       ...(outcome?.error ? { error: String(outcome.error).slice(0, 500) } : {}),
     }
@@ -434,6 +606,78 @@ export class SchedulerEngine extends EventEmitter {
   }
 
   /**
+   * @private — the pre-fire safety gate: everything that must hold BEFORE an
+   * unattended turn is allowed to exist. Returns a refusal reason, or null to
+   * proceed. Both checks are things the engine cannot recover from by retrying —
+   * they are misconfigurations in the stored task definition.
+   */
+  _preflightRefusal(task) {
+    // (a) Can we actually govern this provider's permission prompts? (#7003)
+    const providerRefusal = scheduledProviderRefusalReason(this._resolveProviderName(task), this._getProviderClass)
+    if (providerRefusal) return providerRefusal
+
+    // (b) Is the cwd one a session may be created in at all? The registry is a
+    // user-writable JSON file, so `target.cwd` is untrusted input — and neither
+    // the store (trims the string) nor createSession (statSync only) applies the
+    // real allowlist. Validate the EFFECTIVE cwd: the task's own, else whatever
+    // createSession would default to. (#7005 moves this into createSession.)
+    const cwd = this._resolveTaskCwd(task)
+    if (cwd) {
+      let cwdError
+      try {
+        cwdError = this._validateCwd(cwd)
+      } catch (err) {
+        // A throwing validator must fail CLOSED, never fall through to allowed.
+        return `working directory ${cwd} could not be validated for a scheduled run: ${err?.message || err}`
+      }
+      if (cwdError) {
+        return `working directory ${cwd} is not allowed for a scheduled run: ${cwdError}`
+      }
+    }
+    return null
+  }
+
+  /**
+   * @private — the provider a run would ACTUALLY use, resolved the same way
+   * SessionManager.createSession resolves it (`provider || this._providerType`),
+   * so the capability gate judges the real provider rather than the stored field.
+   * Falls back to DEFAULT_PROVIDER when no manager is wired.
+   */
+  _resolveProviderName(task) {
+    const explicit = task.target?.provider
+    if (typeof explicit === 'string' && explicit.length > 0) return explicit
+    const managerDefault = this._sm?.providerType
+    if (typeof managerDefault === 'string' && managerDefault.length > 0) return managerDefault
+    return DEFAULT_PROVIDER
+  }
+
+  /**
+   * @private — the cwd a run would ACTUALLY use: the task's own, else the
+   * manager's default (what createSession falls back to). Null when neither is
+   * knowable, in which case there is no manager and the run fails anyway.
+   */
+  _resolveTaskCwd(task) {
+    const explicit = task.target?.cwd
+    if (typeof explicit === 'string' && explicit.length > 0) return explicit
+    const managerDefault = this._sm?.defaultCwd
+    if (typeof managerDefault === 'string' && managerDefault.length > 0) return managerDefault
+    return null
+  }
+
+  /**
+   * @private — record a run the engine refused to start. A VISIBLE, explicit
+   * non-success outcome: never `success`, and distinguishable from both `error`
+   * (the run happened and failed) and `skipped` (the slot passed) by its own
+   * status, so #6868/#6871 can tell the operator nothing ran and why.
+   */
+  _recordRefusal(task, at, reason) {
+    this._log.error(`Scheduled task ${task.id} REFUSED — nothing was run: ${reason}`)
+    const result = { at, status: REFUSED_STATUS, error: String(reason).slice(0, 500) }
+    this._recordRun(task, result)
+    this.emit('run-end', { taskId: task.id, ...result })
+  }
+
+  /**
    * @private — persist a lastRun result. The store recomputes nextRun off the
    * cadence on update(), which is what retires a one-time task (computeNextRun
    * returns null for a `once` cadence that has a lastRun) and advances a recurring
@@ -443,13 +687,37 @@ export class SchedulerEngine extends EventEmitter {
     try {
       this._store.update(task.id, { lastRun: result })
     } catch (err) {
-      // A task removed mid-run (update() returns null — not a throw) or a rejected
-      // result value must not take the engine down. It must ALSO not be retried
-      // forever: without a recorded run its nextRun never advances, so quarantine
-      // it for this process rather than re-firing it every tick.
-      this._quarantined.add(task.id)
-      this._log.error(`Failed to record run for scheduled task ${task.id} — quarantining it until restart: ${err?.message || err}`)
+      // A rejected result value or a storage fault must not take the engine down.
+      // It must ALSO not be retried forever: without a recorded run its nextRun
+      // never advances, so quarantine it for this process rather than re-firing it
+      // every tick.
+      this._quarantine(task, result?.at ?? this._now(), `its run outcome could not be recorded: ${err?.message || err}`)
     }
+  }
+
+  /**
+   * @private — stop firing a task for the rest of this process, and make that
+   * VISIBLE. Quarantine used to be a log line only, so a task that had
+   * permanently stopped firing still showed its last healthy `lastRun` to every
+   * registry-reading surface — indistinguishable from a task that is fine. Now
+   * the engine (a) best-effort writes the quarantine onto the task itself, (b)
+   * emits `task-quarantined`, and (c) exposes it on `quarantinedTaskIds`. The
+   * write is best-effort ON PURPOSE: the usual reason to quarantine is that the
+   * store itself is failing, so (b) and (c) are the fallbacks that always work.
+   *
+   * Quarantine stays process-scoped (a restart re-reads the file), so the task is
+   * NOT disabled in the registry.
+   */
+  _quarantine(task, at, reason) {
+    const firstTime = !this._quarantined.has(task.id)
+    this._quarantined.add(task.id)
+    this._log.error(`Scheduled task ${task.id} QUARANTINED until daemon restart — it will not fire again: ${reason}`)
+    try {
+      this._store.update(task.id, {
+        lastRun: { at, status: REFUSED_STATUS, error: `quarantined until daemon restart: ${reason}`.slice(0, 500) },
+      })
+    } catch { /* the store is usually the thing that's broken — the event + getter carry the signal */ }
+    if (firstTime) this.emit('task-quarantined', { taskId: task.id, at, reason })
   }
 
   // ── the default (production) executor ──────────────────────────────────────
@@ -463,7 +731,15 @@ export class SchedulerEngine extends EventEmitter {
    * task to ONE session instead of one per fire, keeps the recorded `sessionId`
    * meaningful (the operator can open it and read what the run actually did), and
    * gives a recurring task continuity across runs. Sessions are NOT auto-destroyed
-   * afterwards — they are ordinary sessions the operator can inspect and close.
+   * afterwards — they are ordinary sessions the operator can inspect and close
+   * (never reaping them is tracked in #7006).
+   *
+   * Because they are ordinary sessions, the operator can also change their
+   * permission mode. That makes reuse an escalation vector, so the clamped mode is
+   * re-asserted and verified on EVERY fire — see _assertPermissionMode. The
+   * interactive mode switch is deliberately left working (an operator inspecting a
+   * scheduled session may legitimately want to drive it by hand); what is
+   * guaranteed is that their change cannot survive into the next unattended fire.
    */
   async _runViaSessionManager(task, ctx) {
     if (!this._sm) return { status: 'error', error: 'no sessionManager wired — cannot run scheduled task' }
@@ -472,6 +748,7 @@ export class SchedulerEngine extends EventEmitter {
     try {
       sessionId = this._resolveSession(task, ctx)
     } catch (err) {
+      if (err instanceof ScheduledRunRefusedError) return { status: REFUSED_STATUS, error: err.message }
       return { status: 'error', error: `session create failed: ${err?.message || err}` }
     }
     if (!sessionId) return { status: 'error', error: 'session create failed (no sessionId)' }
@@ -488,8 +765,15 @@ export class SchedulerEngine extends EventEmitter {
         label: `scheduled:${task.id}`,
         timeoutMs: ctx.runTimeoutMs,
       })
-      // A denied permission usually lets the agent finish "successfully" with the
-      // tool call refused. That is NOT a successful scheduled run — surface it.
+      // `success` is the NARROWEST outcome, asserted positively: the turn
+      // completed AND no permission prompt was ever raised on this run. Any
+      // permission activity at all sets `runState.blocked` (set before any other
+      // decision in _handleSessionEvent, so a malformed prompt we could not even
+      // answer still counts), because a denied permission usually lets the agent
+      // finish "successfully" with the tool call refused — which is NOT a
+      // successful scheduled run. Reporting success for a run whose every tool
+      // call was refused is the worst failure mode this engine has, so the
+      // default here is to disbelieve success.
       if (runState.blocked) return this._blockedOutcome(runState, sessionId)
       return { status: 'success', sessionId }
     } catch (err) {
@@ -513,10 +797,29 @@ export class SchedulerEngine extends EventEmitter {
     }
   }
 
-  /** @private — reuse this task's still-live session, else create a fresh one. */
+  /**
+   * @private — reuse this task's still-live session, else create a fresh one.
+   * EITHER WAY the clamped permission mode is asserted before the caller drives a
+   * turn: createSession is passed it, and a reused session has it re-asserted and
+   * verified. A session that cannot be brought to the clamped mode is refused.
+   */
   _resolveSession(task, ctx) {
     const existing = this._sessionByTask.get(task.id)
-    if (existing && this._sm.getSession?.(existing)) return existing
+    if (existing) {
+      const entry = this._sm.getSession?.(existing)
+      if (entry?.session) {
+        // THE ESCALATION VECTOR (#6997 review C3): scheduled sessions are kept
+        // alive and reused, and an operator can flip any session to `auto` from
+        // the dashboard — even mid-turn. Without re-asserting here, one manual
+        // flip would silently put every future unattended fire of this task into
+        // bypass, forever, each recorded as a clean success.
+        this._assertPermissionMode(entry.session, ctx.permissionMode, existing)
+        return existing
+      }
+      // The session is gone (operator closed it) — drop the stale mapping so a
+      // fresh one is created below rather than resumed by id.
+      this._sessionByTask.delete(task.id)
+    }
 
     const target = task.target || {}
     const sessionId = this._sm.createSession({
@@ -531,8 +834,44 @@ export class SchedulerEngine extends EventEmitter {
       skipPermissions: false,
       metadata: { scheduledTaskId: task.id },
     })
+    // Trust nothing: verify the freshly-created session really came up at the
+    // clamped mode rather than assuming createSession honoured the option.
+    const created = this._sm.getSession?.(sessionId)
+    if (created?.session) this._assertPermissionMode(created.session, ctx.permissionMode, sessionId)
     this._sessionByTask.set(task.id, sessionId)
     return sessionId
+  }
+
+  /**
+   * @private — force `mode` onto a session and PROVE it took, or throw. The
+   * invariant this exists to hold: **a scheduled fire runs at the clamped mode,
+   * or it does not run.**
+   *
+   * Read-back is the only evidence accepted. `setPermissionMode` returns false
+   * both for a harmless no-op (already in that mode) and for a REFUSED change (a
+   * session mid-turn rejects every non-`auto` switch — base-session.js:1115-1133),
+   * so its return value cannot distinguish "fine" from "escalated and stuck".
+   * Only the value the session reports afterwards can.
+   *
+   * @throws {ScheduledRunRefusedError} when the mode cannot be verified
+   */
+  _assertPermissionMode(session, mode, sessionId) {
+    const read = () => (typeof session.permissionMode === 'string' ? session.permissionMode : null)
+    if (read() !== mode) {
+      try {
+        session.setPermissionMode?.(mode)
+      } catch (err) {
+        throw new ScheduledRunRefusedError(
+          `could not re-assert the '${mode}' permission mode on scheduled session ${sessionId}: ${err?.message || err} — refusing to fire an unattended run at an unverified permission mode`
+        )
+      }
+    }
+    const actual = read()
+    if (actual !== mode) {
+      throw new ScheduledRunRefusedError(
+        `scheduled session ${sessionId} reports permission mode '${actual ?? 'unknown'}' and could not be re-clamped to '${mode}' (the session is mid-turn, or its provider ignores the setter) — refusing to fire an unattended run at an unverified permission mode`
+      )
+    }
   }
 
   /** @private — build the TurnDriver on first real run. */
@@ -573,9 +912,18 @@ export class SchedulerEngine extends EventEmitter {
     if (!runState) return // never answer a session this engine does not own
     const requestId = data?.requestId ?? data?.id ?? null
     const toolName = data?.toolName ?? data?.tool ?? ''
-    if (requestId == null) return
+    // Mark the run blocked FIRST, before any other decision. A prompt was raised
+    // on an unattended run: that alone disqualifies the run from `success`,
+    // whether or not we manage to answer it. Bailing out on a malformed payload
+    // BEFORE this (the previous order) left `blocked` unset, so a prompt carrying
+    // no requestId went unanswered AND the run still reported success — the exact
+    // false-success this engine must never produce.
     if (!runState.blocked) runState.blocked = { toolName }
     this._log.warn(`Scheduled task ${runState.taskId} requested permission for ${toolName || 'a tool'} with no client connected — denying`)
+    if (requestId == null) {
+      this._log.warn(`Scheduled task ${runState.taskId} permission request carried no requestId — cannot answer it; the run is recorded as blocked`)
+      return
+    }
 
     const entry = this._sm.getSession?.(sessionId)
     const session = entry?.session

--- a/packages/server/src/scheduler.js
+++ b/packages/server/src/scheduler.js
@@ -43,8 +43,12 @@
 //    actually reaches a prompt has no human to answer it, so this engine answers
 //    `deny` through the same door a human clicks (`session.respondToPermission`,
 //    mirroring orchestration/permission-gate.js), interrupts the turn, and
-//    records the run as a VISIBLE failure. It never waits out the 5-minute
-//    permission timeout, and it never auto-approves anything.
+//    records the run as a VISIBLE failure. The prompt is answered at once (never
+//    left to sit out a permission timeout) and nothing is ever auto-approved.
+//    Note the interrupted turn's PROMISE may still not settle until the run
+//    timeout — TurnDriver does not treat `stopped` as terminal (#7009) — so the
+//    concurrency slot can be held for that window. The outcome is decided
+//    immediately either way; see _handleSessionEvent.
 // 4. SUPPORTED PROVIDERS ONLY — the engine REFUSES what it cannot govern. The
 //    deny mechanism in (3) rides `session_event: permission_request` +
 //    `session.respondToPermission`, which exist ONLY on providers whose
@@ -902,9 +906,21 @@ export class SchedulerEngine extends EventEmitter {
 
   /**
    * @private — a permission prompt reached a scheduled run, which means no rule
-   * settled it and there is no human to answer. DENY it through the normal door
-   * and interrupt the turn so the run fails fast and visibly rather than burning
-   * five minutes on the permission timeout (or, worse, being auto-approved).
+   * settled it and there is no human to answer. DENY it through the normal door,
+   * mark the run blocked, and interrupt the turn: the prompt is answered
+   * immediately (never left to sit out a permission timeout) and the run's outcome
+   * is decided immediately (a visible failure, never an auto-approval).
+   *
+   * CAVEAT on how fast the SLOT frees (#7009): deciding the outcome is not the
+   * same as settling the driving promise. TurnDriver only treats `result` /
+   * `error` / `session_destroyed` as terminal for a live turn, while SdkSession's
+   * interrupt path emits `stopped` (sdk-session.js ~1204, #4881) — which
+   * TurnDriver ignores outside its post-timeout drain. So `driveTurn` can stay
+   * pending until `runTimeoutMs` even though we already know the answer, holding
+   * the concurrency slot. The recorded outcome is unaffected (blocked ⇒ failure,
+   * never success); it is a liveness cost only. Fixing it means making `stopped`
+   * terminal in TurnDriver, which touches the shared orchestration harness and so
+   * is tracked separately as #7009 rather than done here.
    */
   _handleSessionEvent({ sessionId, event, data } = {}) {
     if (event !== 'permission_request') return

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -49,6 +49,7 @@ import { getRegistryForProvider, watchModelsOverlay } from './models.js'
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
 import { resolveSkipPermissions, buildEnvironmentBackend, isUserShellEnabled, getAllowAnyModelProviders, isSemanticTitlesEnabled, resolveSemanticTitleModel, resolveSemanticTitleTimeoutMs, resolveBinaryProvenanceMode, isBinarySignatureGateEnabled } from './config.js'
 import { buildOrchestrationManager } from './orchestration/build-manager.js'
+import { buildSchedulerEngine } from './scheduler.js'
 import { parseDuration } from './duration.js'
 import { createSessionTokenStore } from './session-token-store.js'
 import { StatusLineManager } from './statusline.js'
@@ -1017,6 +1018,12 @@ export async function startCliServer(config) {
   // construction fails — never a throw, so it can't break daemon boot).
   const orchestrationManager = buildOrchestrationManager({ sessionManager, config, chroxyDir, log })
 
+  // #6865: the headless scheduler engine — fires due scheduled tasks (#6862)
+  // into a session with no client connected. null unless the operator opted in
+  // (`features.scheduler` / CHROXY_ENABLE_SCHEDULER=1), so a default daemon arms
+  // no timers and spawns nothing.
+  const schedulerEngine = buildSchedulerEngine({ sessionManager, config, logger: log })
+
   wsServer = new WsServer({
     port: PORT,
     apiToken: API_TOKEN,
@@ -1324,6 +1331,7 @@ export async function startCliServer(config) {
     pushManager,
     billingCanaryMonitor,
     orchestrationManager,
+    schedulerEngine,
     modelsOverlayWatcher,
     getWorktreeReapTimer: () => worktreeReapTimer,
     emergencyCleanupSync,

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -34,6 +34,7 @@ export class ServerOrchestrator {
     pushManager = null,
     billingCanaryMonitor = null,
     orchestrationManager = null,
+    schedulerEngine = null,
     modelsOverlayWatcher = null,
     getWorktreeReapTimer,
     emergencyCleanupSync,
@@ -57,6 +58,7 @@ export class ServerOrchestrator {
     // Disposed on shutdown: unhooks its SessionManager listeners (permission
     // gate + turn driver) and flushes the run ledger's pending snapshot writes.
     this._orchestrationManager = orchestrationManager
+    this._schedulerEngine = schedulerEngine
     // #5932: the models.json overlay fs-watcher handle (or null when watching
     // couldn't be established). Closed on shutdown so the watch doesn't outlive
     // the daemon.
@@ -120,6 +122,14 @@ export class ServerOrchestrator {
     if (this._orchestrationManager) {
       try { this._orchestrationManager.dispose() } catch (err) {
         log.warn(`Orchestration engine dispose failed: ${err?.message || err}`)
+      }
+    }
+    // #6865: stop the scheduler BEFORE destroying sessions — destroy() clears its
+    // armed timer and detaches its permission answerer, so no scheduled task can
+    // fire (or start a session) while the daemon is tearing down.
+    if (this._schedulerEngine) {
+      try { this._schedulerEngine.destroy() } catch (err) {
+        log.warn(`Scheduler engine destroy failed: ${err?.message || err}`)
       }
     }
     // Persist sessions before destroying (enables restore on restart)

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2338,6 +2338,20 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
+   * The provider id createSession falls back to when its `provider` option is
+   * omitted (i.e. this daemon's configured default, DEFAULT_PROVIDER unless the
+   * operator changed it). Exposed so callers that must reason about the provider a
+   * session WOULD use — before creating it — resolve it the same way createSession
+   * does instead of guessing. The scheduler's provider-capability gate (#6865)
+   * needs exactly this: it refuses to fire an unattended run on a provider whose
+   * permission prompts it cannot answer.
+   * @returns {string}
+   */
+  get providerType() {
+    return this._providerType
+  }
+
+  /**
    * Current max messages per session (from SessionMessageHistory).
    * @returns {number}
    */

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -4,13 +4,19 @@ import { EventEmitter } from 'events'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { mkdirSync } from 'fs'
 import { ScheduledTaskStore } from '../src/scheduled-task-store.js'
 import {
   SchedulerEngine,
   buildSchedulerEngine,
   resolveScheduledPermissionMode,
+  scheduledProviderRefusalReason,
+  listSchedulableProviders,
   SCHEDULED_PERMISSION_MODE,
+  REFUSED_STATUS,
 } from '../src/scheduler.js'
+import { validateCwdAllowed } from '../src/handler-utils.js'
+import { DEFAULT_PROVIDER } from '../src/providers.js'
 import { isSchedulerEnabled } from '../src/config.js'
 
 /**
@@ -29,6 +35,15 @@ import { isSchedulerEnabled } from '../src/config.js'
 
 const silentLog = { info() {}, warn() {}, error() {}, debug() {} }
 const MINUTE = 60 * 1000
+
+/**
+ * A provider the engine will agree to fire at: one whose
+ * `capabilities.inProcessPermissions` is true, so the engine can actually observe
+ * and answer its permission prompts. The daemon DEFAULT (claude-tui) is NOT one —
+ * see the 'unsupported provider' block below — so every task that is expected to
+ * RUN has to name one explicitly.
+ */
+const SCHEDULABLE_PROVIDER = 'claude-sdk'
 
 /** A deterministic timer seam: nothing runs until the test fires it. */
 function makeTimers() {
@@ -73,14 +88,24 @@ describe('#6865 SchedulerEngine', () => {
   let store
   let timers
   let engines
+  let fakeHome
+  let allowedCwd
+  let enabledConfig
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'chroxy-scheduler-'))
     filePath = join(dir, 'scheduled-tasks.json')
+    // A hermetic fake $HOME for the cwd allowlist, the pattern validateCwdAllowed's
+    // own JSDoc documents (`config.homeOverride`) — so the cwd tests exercise the
+    // REAL deny-list against throwaway directories instead of the user's home.
+    fakeHome = join(dir, 'home')
+    allowedCwd = join(fakeHome, 'project')
+    mkdirSync(allowedCwd, { recursive: true })
     clock = 1000
     store = new ScheduledTaskStore({ filePath, logger: silentLog, now: () => clock })
     timers = makeTimers()
     engines = []
+    enabledConfig = { features: { scheduler: true }, homeOverride: fakeHome }
   })
 
   afterEach(() => {
@@ -90,8 +115,6 @@ describe('#6865 SchedulerEngine', () => {
     rmSync(dir, { recursive: true, force: true })
     delete process.env.CHROXY_ENABLE_SCHEDULER
   })
-
-  const enabledConfig = { features: { scheduler: true } }
 
   /** Build an engine with the injected timer seam; auto-destroyed in afterEach. */
   const newEngine = (opts = {}) => {
@@ -107,6 +130,17 @@ describe('#6865 SchedulerEngine', () => {
     engines.push(engine)
     return engine
   }
+
+  /**
+   * Add a task the engine is willing to fire. The provider gate refuses any task
+   * whose RESOLVED provider cannot answer permissions in-process, and the daemon
+   * default is such a provider — so a task that is meant to run must name a
+   * supported one. Tests of the refusal itself call `store.add` directly.
+   */
+  const addTask = (input = {}) => store.add({
+    ...input,
+    target: { provider: SCHEDULABLE_PROVIDER, ...(input.target || {}) },
+  })
 
   // ── the enable gate ────────────────────────────────────────────────────────
 
@@ -135,7 +169,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('a disabled engine arms NO timer and fires NOTHING', async () => {
-      store.add({ prompt: 'do it', cadence: { kind: 'once', at: 1000 } })
+      addTask({ prompt: 'do it', cadence: { kind: 'once', at: 1000 } })
       const runTask = mockRunner()
       const engine = newEngine({ config: { features: { scheduler: false } }, runTask: runTask.fn })
 
@@ -173,8 +207,8 @@ describe('#6865 SchedulerEngine', () => {
 
   describe('due-time firing', () => {
     it('fires a task whose nextRun has arrived, and not one in the future', async () => {
-      const due = store.add({ prompt: 'due now', cadence: { kind: 'once', at: 2000 } })
-      const later = store.add({ prompt: 'much later', cadence: { kind: 'once', at: 90_000 } })
+      const due = addTask({ prompt: 'due now', cadence: { kind: 'once', at: 2000 } })
+      const later = addTask({ prompt: 'much later', cadence: { kind: 'once', at: 90_000 } })
       const runTask = mockRunner()
       const engine = newEngine({ runTask: runTask.fn })
       engine.start()
@@ -187,7 +221,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('does not fire a disabled (paused) task', async () => {
-      store.add({ prompt: 'paused', cadence: { kind: 'once', at: 2000 }, enabled: false })
+      addTask({ prompt: 'paused', cadence: { kind: 'once', at: 2000 }, enabled: false })
       const runTask = mockRunner()
       const engine = newEngine({ runTask: runTask.fn })
       engine.start()
@@ -198,7 +232,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('arms the timer for the earliest nextRun, clamped to maxSleepMs', () => {
-      store.add({ prompt: 'soon', cadence: { kind: 'once', at: 6000 } })
+      addTask({ prompt: 'soon', cadence: { kind: 'once', at: 6000 } })
       const engine = newEngine()
       engine.start()
       // clock=1000, earliest=6000 → 5000ms away, under the 60s cap.
@@ -206,14 +240,14 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('clamps a far-future task to maxSleepMs so registry edits are noticed', () => {
-      store.add({ prompt: 'next week', cadence: { kind: 'once', at: clock + 7 * 24 * 3600 * 1000 } })
+      addTask({ prompt: 'next week', cadence: { kind: 'once', at: clock + 7 * 24 * 3600 * 1000 } })
       const engine = newEngine({ maxSleepMs: MINUTE })
       engine.start()
       assert.equal(timers.armedDelay, MINUTE)
     })
 
     it('a recurring task advances its nextRun after a run (no backfill)', async () => {
-      const task = store.add({ prompt: 'every minute', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const task = addTask({ prompt: 'every minute', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       assert.equal(task.nextRun, 61_000)
 
       const runTask = mockRunner()
@@ -230,7 +264,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('a one-time task fires once and marks itself done', async () => {
-      const task = store.add({ prompt: 'just once', cadence: { kind: 'once', at: 2000 } })
+      const task = addTask({ prompt: 'just once', cadence: { kind: 'once', at: 2000 } })
       const runTask = mockRunner()
       const engine = newEngine({ runTask: runTask.fn })
       engine.start()
@@ -252,7 +286,7 @@ describe('#6865 SchedulerEngine', () => {
 
   describe('last-run recording', () => {
     const fireWith = async (outcome) => {
-      const task = store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const task = addTask({ prompt: 'p', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       const engine = newEngine({ runTask: async () => outcome })
       engine.start()
       clock = 61_000
@@ -296,7 +330,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('emits run-start and run-end for each fire', async () => {
-      const task = store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      const task = addTask({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
       const engine = newEngine({ runTask: async () => ({ status: 'success', sessionId: 'x' }) })
       const events = []
       engine.on('run-start', (e) => events.push(['start', e.taskId]))
@@ -312,7 +346,7 @@ describe('#6865 SchedulerEngine', () => {
 
   describe('overlap and thundering-herd guards', () => {
     it('never fires the same task twice concurrently', async () => {
-      store.add({ prompt: 'slow', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      addTask({ prompt: 'slow', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       let release
       const gate = new Promise((r) => { release = r })
       const runTask = mockRunner(() => gate)
@@ -337,9 +371,9 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('sheds a burst beyond maxConcurrentRuns without persisting a skip', async () => {
-      const a = store.add({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
-      const b = store.add({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
-      const c = store.add({ prompt: 'c', cadence: { kind: 'once', at: 2000 } })
+      const a = addTask({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
+      const b = addTask({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
+      const c = addTask({ prompt: 'c', cadence: { kind: 'once', at: 2000 } })
       let release
       const gate = new Promise((r) => { release = r })
       const runTask = mockRunner(() => gate)
@@ -369,8 +403,8 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('does not busy-spin while at capacity with a task still due', async () => {
-      store.add({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
-      store.add({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
       let release
       const gate = new Promise((r) => { release = r })
       const engine = newEngine({ runTask: async () => gate, maxConcurrentRuns: 1 })
@@ -391,7 +425,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('quarantines a task whose outcome cannot be recorded instead of re-firing it', async () => {
-      const task = store.add({ prompt: 'unrecordable', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const task = addTask({ prompt: 'unrecordable', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       // Simulate a storage fault: the run happens but its result never persists,
       // so nextRun would never advance and the task would stay due forever.
       store.update = () => { throw new Error('disk on fire') }
@@ -413,9 +447,9 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('honours a higher concurrency cap', async () => {
-      store.add({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
-      store.add({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
-      store.add({ prompt: 'c', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'c', cadence: { kind: 'once', at: 2000 } })
       let release
       const gate = new Promise((r) => { release = r })
       const runTask = mockRunner(() => gate)
@@ -433,7 +467,7 @@ describe('#6865 SchedulerEngine', () => {
 
   describe('overdue grace (daemon was down)', () => {
     it('fires a task overdue within the grace window', async () => {
-      store.add({ prompt: 'slightly late', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'slightly late', cadence: { kind: 'once', at: 2000 } })
       const runTask = mockRunner()
       const engine = newEngine({ runTask: runTask.fn, overdueGraceMs: 60 * MINUTE })
       engine.start()
@@ -443,7 +477,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('skips (and retires) a task staler than the grace window instead of firing', async () => {
-      const task = store.add({ prompt: 'ancient', cadence: { kind: 'once', at: 2000 } })
+      const task = addTask({ prompt: 'ancient', cadence: { kind: 'once', at: 2000 } })
       const runTask = mockRunner()
       const engine = newEngine({ runTask: runTask.fn, overdueGraceMs: 60 * MINUTE })
       const skips = []
@@ -466,7 +500,7 @@ describe('#6865 SchedulerEngine', () => {
 
   describe('shutdown', () => {
     it('destroy() clears every timer and stops firing', async () => {
-      store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      addTask({ prompt: 'p', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       const runTask = mockRunner()
       const engine = newEngine({ runTask: runTask.fn })
       engine.start()
@@ -521,10 +555,10 @@ describe('#6865 SchedulerEngine', () => {
 
     it('creates the run with the clamped mode and an explicit skipPermissions:false', async () => {
       const sm = new FakeSessionManager()
-      const task = store.add({
+      const task = addTask({
         prompt: 'do the thing',
         cadence: { kind: 'once', at: 2000 },
-        target: { permissionMode: 'auto', cwd: '/tmp/project', provider: 'claude-sdk', model: 'sonnet' },
+        target: { permissionMode: 'auto', cwd: allowedCwd, provider: 'claude-sdk', model: 'sonnet' },
       })
       const engine = newEngine({ sessionManager: sm })
       engine.start()
@@ -536,7 +570,7 @@ describe('#6865 SchedulerEngine', () => {
       assert.equal(opts.permissionMode, 'approve', 'a task asking for auto must be clamped to approve')
       assert.equal(opts.skipPermissions, false, 'must never inherit the server-wide skip-permissions default')
       // Per-task scoping is honoured from the stored definition.
-      assert.equal(opts.cwd, '/tmp/project')
+      assert.equal(opts.cwd, allowedCwd)
       assert.equal(opts.provider, 'claude-sdk')
       assert.equal(opts.model, 'sonnet')
       assert.equal(opts.metadata.scheduledTaskId, task.id)
@@ -545,7 +579,7 @@ describe('#6865 SchedulerEngine', () => {
 
     it('DENIES a permission prompt with no client connected and records the failure', async () => {
       const sm = new FakeSessionManager({ permissionRequest: { requestId: 'req-1', toolName: 'Bash' } })
-      const task = store.add({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
+      const task = addTask({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
       const engine = newEngine({ sessionManager: sm })
       engine.start()
 
@@ -566,7 +600,7 @@ describe('#6865 SchedulerEngine', () => {
 
     it('never answers a permission prompt for a session it does not own', async () => {
       const sm = new FakeSessionManager()
-      store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      addTask({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
       const engine = newEngine({ sessionManager: sm })
       engine.start()
       clock = 2000
@@ -582,7 +616,7 @@ describe('#6865 SchedulerEngine', () => {
     })
 
     it('reports an error (not a crash) when no sessionManager is wired', async () => {
-      const task = store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      const task = addTask({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
       const engine = newEngine({ sessionManager: null })
       engine.start()
       clock = 2000
@@ -597,7 +631,7 @@ describe('#6865 SchedulerEngine', () => {
   describe('session reuse', () => {
     it('resumes the same session across runs of one task', async () => {
       const sm = new FakeSessionManager()
-      store.add({ prompt: 'daily', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      addTask({ prompt: 'daily', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       const engine = newEngine({ sessionManager: sm })
       engine.start()
 
@@ -612,7 +646,7 @@ describe('#6865 SchedulerEngine', () => {
 
     it('creates a fresh session when the previous one is gone', async () => {
       const sm = new FakeSessionManager()
-      store.add({ prompt: 'daily', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      addTask({ prompt: 'daily', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
       const engine = newEngine({ sessionManager: sm })
       engine.start()
 
@@ -623,6 +657,470 @@ describe('#6865 SchedulerEngine', () => {
       await timers.tick()
 
       assert.equal(sm.created.length, 2)
+    })
+  })
+
+  // ── SECURITY C1: the engine refuses providers it cannot govern ─────────────
+  //
+  // The deny mechanism above rides `session_event: permission_request` +
+  // `session.respondToPermission`, which exist ONLY where
+  // capabilities.inProcessPermissions is true. A hook-routed provider (incl. the
+  // daemon DEFAULT) instead goes through hooks/permission-hook.sh → POST
+  // /permission → ws-permissions.js, which emits nothing observable and
+  // auto-denies after 300s. Firing there would stall five minutes per gated tool
+  // call and then record SUCCESS for a turn whose every tool call was refused.
+
+  describe('unsupported (hook-routed) provider is REFUSED', () => {
+    /** Fire one task and hand back its stored record. */
+    const fireTask = async (input, smOpts = {}) => {
+      const sm = new FakeSessionManager(smOpts)
+      const task = store.add({ prompt: 'do it', cadence: { kind: 'once', at: 2000 }, ...input })
+      const engine = newEngine({ sessionManager: sm })
+      const events = []
+      engine.on('run-start', (e) => events.push(['start', e.taskId]))
+      engine.on('run-end', (e) => events.push(['end', e.status]))
+      engine.start()
+      clock = 2000
+      await timers.tick()
+      return { sm, task, record: store.get(task.id), events }
+    }
+
+    it('the daemon default provider is NOT schedulable (the premise of this whole block)', () => {
+      assert.equal(DEFAULT_PROVIDER, 'claude-tui')
+      assert.ok(scheduledProviderRefusalReason(DEFAULT_PROVIDER), 'the default provider must be refused')
+      const schedulable = listSchedulableProviders()
+      assert.ok(!schedulable.includes(DEFAULT_PROVIDER))
+      assert.ok(schedulable.includes(SCHEDULABLE_PROVIDER), 'the fixture provider must be schedulable')
+    })
+
+    it('refuses an explicitly hook-routed provider and creates NO session', async () => {
+      const { sm, record, events } = await fireTask({ target: { provider: 'claude-tui' } })
+
+      assert.equal(sm.created.length, 0, 'a refused task must never create a session')
+      assert.equal(sm.sends.length, 0, 'and must never drive a turn')
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.notEqual(record.lastRun.status, 'success')
+      assert.match(record.lastRun.error, /claude-tui/)
+      assert.match(record.lastRun.error, /permission hook/)
+      assert.match(record.lastRun.error, /#7003/, 'the operator needs the pointer to the widening issue')
+      // Nothing started, so no run-start — only a refused run-end.
+      assert.deepEqual(events, [['end', REFUSED_STATUS]])
+    })
+
+    it('refuses a task with NO explicit provider, because the default is hook-routed', async () => {
+      const { sm, record } = await fireTask({ target: { model: 'sonnet' } })
+      assert.equal(sm.created.length, 0)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.notEqual(record.lastRun.status, 'success')
+      assert.match(record.lastRun.error, /daemon DEFAULT/)
+    })
+
+    it('refuses a task with no target at all', async () => {
+      const { sm, record } = await fireTask({})
+      assert.equal(sm.created.length, 0)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+    })
+
+    it('refuses an unknown provider name rather than crashing', async () => {
+      const { sm, record } = await fireTask({ target: { provider: 'not-a-real-provider' } })
+      assert.equal(sm.created.length, 0)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.match(record.lastRun.error, /unknown provider/)
+    })
+
+    // createSession resolves the provider as `provider || this._providerType`, so a
+    // task with no provider must be judged against the DAEMON's configured default,
+    // not against the compiled-in one.
+
+    it('fires a provider-less task when the MANAGER default is supported', async () => {
+      const { sm, record } = await fireTask({ target: {} }, { providerType: SCHEDULABLE_PROVIDER })
+      assert.equal(record.lastRun.status, 'success')
+      assert.equal(sm.created.length, 1)
+    })
+
+    it('refuses a provider-less task when the MANAGER default is hook-routed', async () => {
+      const { sm, record } = await fireTask({ target: {} }, { providerType: 'gemini' })
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.match(record.lastRun.error, /gemini/)
+      assert.equal(sm.created.length, 0)
+    })
+
+    it('a refused recurring task advances instead of hot-looping every tick', async () => {
+      const sm = new FakeSessionManager()
+      const task = store.add({
+        prompt: 'hourly',
+        cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 },
+        target: { provider: 'claude-tui' },
+      })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      assert.equal(store.get(task.id).lastRun.status, REFUSED_STATUS)
+      assert.equal(store.get(task.id).nextRun, 121_000, 'the refusal advances the schedule')
+      assert.equal(timers.armedDelay, MINUTE, 'and does not arm a 0ms spin')
+      assert.equal(sm.created.length, 0)
+    })
+
+    it('scheduledProviderRefusalReason: supported providers pass, everything else is named', () => {
+      assert.equal(scheduledProviderRefusalReason('claude-sdk'), null)
+      assert.equal(scheduledProviderRefusalReason('claude-byok'), null)
+      for (const hookRouted of ['claude-tui', 'claude-cli', 'gemini']) {
+        const reason = scheduledProviderRefusalReason(hookRouted)
+        assert.ok(reason, `${hookRouted} must be refused`)
+        assert.match(reason, new RegExp(hookRouted))
+      }
+      assert.match(scheduledProviderRefusalReason(''), /no provider could be resolved/)
+      assert.match(scheduledProviderRefusalReason(null), /no provider could be resolved/)
+      assert.match(scheduledProviderRefusalReason(undefined), /no provider could be resolved/)
+      // Reads the capability off the registry, not a hardcoded name list.
+      const fake = () => ({ capabilities: { inProcessPermissions: true } })
+      assert.equal(scheduledProviderRefusalReason('anything', fake), null)
+    })
+
+    it('the refusal reason fits the 500-char record cap, pointer and all', () => {
+      const reason = scheduledProviderRefusalReason(DEFAULT_PROVIDER)
+      assert.ok(reason.length <= 500, `refusal reason is ${reason.length} chars — it would be truncated`)
+    })
+  })
+
+  // ── SECURITY C1b: `success` is never reported for a run that did not run ───
+
+  describe('no false success', () => {
+    it('a run whose tool call was denied is NOT success', async () => {
+      const sm = new FakeSessionManager({ permissionRequest: { requestId: 'req-1', toolName: 'Bash' } })
+      const task = addTask({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      const record = store.get(task.id)
+      assert.notEqual(record.lastRun.status, 'success', 'a blocked run must never report success')
+      assert.equal(record.lastRun.status, 'error')
+      assert.deepEqual(sm.responded, [['req-1', 'deny']])
+    })
+
+    it('a permission prompt we could not even ANSWER still fails the run', async () => {
+      // A prompt with no requestId cannot be answered. The engine used to bail out
+      // of the handler before marking the run blocked, so the prompt went
+      // unanswered AND the run reported success — the worst failure mode here.
+      const sm = new FakeSessionManager({ permissionRequest: { toolName: 'Bash' } })
+      const task = addTask({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.deepEqual(sm.responded, [], 'there was no requestId to answer')
+      const record = store.get(task.id)
+      assert.notEqual(record.lastRun.status, 'success', 'an unanswerable prompt must not read as success')
+      assert.equal(record.lastRun.status, 'error')
+      assert.match(record.lastRun.error, /permission required/)
+    })
+
+    it('only the four real outcomes and `refused` survive; anything else is error', async () => {
+      const statuses = []
+      for (const outcome of [
+        { status: 'success' }, { status: 'timeout' }, { status: 'skipped' },
+        { status: REFUSED_STATUS }, { status: 'weird' }, {}, null,
+      ]) {
+        const task = addTask({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+        const engine = newEngine({ runTask: async () => outcome })
+        engine.start()
+        clock = 2000
+        await timers.tick()
+        statuses.push(store.get(task.id).lastRun.status)
+        engine.destroy()
+      }
+      assert.deepEqual(statuses, ['success', 'timeout', 'skipped', REFUSED_STATUS, 'error', 'error', 'error'])
+    })
+  })
+
+  // ── SECURITY C2: cwd confinement is enforced ON THIS PATH ──────────────────
+  //
+  // The store only trims the cwd string and createSession only statSync's it, so
+  // the real allowlist (validateCwdAllowed) is handler-only. A task definition is
+  // a user-writable JSON file, so without this gate a hand-edited target.cwd
+  // reaches a session the dashboard would have rejected. (#7005 moves the check
+  // into createSession centrally; here it is wired the way build-manager.js does.)
+
+  describe('cwd allowlist', () => {
+    /** Fire one task at `cwd` with the DEFAULT (real) validator wiring. */
+    const fireWithCwd = async (cwd) => {
+      const sm = new FakeSessionManager()
+      const task = store.add({
+        prompt: 'read secrets',
+        cadence: { kind: 'once', at: 2000 },
+        target: { provider: SCHEDULABLE_PROVIDER, cwd },
+      })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+      return { sm, record: store.get(task.id) }
+    }
+
+    it('refuses the filesystem root', async () => {
+      const { sm, record } = await fireWithCwd('/')
+      assert.equal(sm.created.length, 0, 'no session may be created for a disallowed cwd')
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.notEqual(record.lastRun.status, 'success')
+      assert.match(record.lastRun.error, /working directory \/ is not allowed/)
+    })
+
+    it('refuses a credential directory (~/.ssh)', async () => {
+      const ssh = join(fakeHome, '.ssh')
+      mkdirSync(ssh, { recursive: true })
+      const { sm, record } = await fireWithCwd(ssh)
+      assert.equal(sm.created.length, 0)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.match(record.lastRun.error, /credential\/config directories/)
+    })
+
+    it("refuses chroxy's own state directory (~/.chroxy)", async () => {
+      const chroxy = join(fakeHome, '.chroxy')
+      mkdirSync(chroxy, { recursive: true })
+      const { sm, record } = await fireWithCwd(chroxy)
+      assert.equal(sm.created.length, 0)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.match(record.lastRun.error, /credential\/config directories/)
+    })
+
+    it('refuses a cwd that does not exist', async () => {
+      const { sm, record } = await fireWithCwd(join(fakeHome, 'nope', 'gone'))
+      assert.equal(sm.created.length, 0)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+    })
+
+    it('still fires for an allowed cwd', async () => {
+      const { sm, record } = await fireWithCwd(allowedCwd)
+      assert.equal(sm.created.length, 1, 'an allowed cwd must not be blocked')
+      assert.equal(sm.created[0].opts.cwd, allowedCwd)
+      assert.equal(record.lastRun.status, 'success')
+    })
+
+    it('consults validateCwdAllowed itself (not a private re-implementation)', async () => {
+      // The spy DELEGATES to the real exported function, so this asserts both that
+      // the engine consults the check and that the check it consults is the real one.
+      const seen = []
+      const sm = new FakeSessionManager()
+      const denied = store.add({
+        prompt: 'p', cadence: { kind: 'once', at: 2000 },
+        target: { provider: SCHEDULABLE_PROVIDER, cwd: join(fakeHome, '.aws') },
+      })
+      mkdirSync(join(fakeHome, '.aws'), { recursive: true })
+      const engine = newEngine({
+        sessionManager: sm,
+        validateCwd: (cwd) => {
+          seen.push(cwd)
+          return validateCwdAllowed(cwd, enabledConfig)
+        },
+      })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.deepEqual(seen, [join(fakeHome, '.aws')], 'the engine must consult the validator with the task cwd')
+      assert.equal(store.get(denied.id).lastRun.status, REFUSED_STATUS)
+      assert.equal(sm.created.length, 0)
+    })
+
+    it('validates the cwd createSession would DEFAULT to when the task sets none', async () => {
+      const sm = new FakeSessionManager({ providerType: SCHEDULABLE_PROVIDER, defaultCwd: '/' })
+      const task = store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 }, target: {} })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.equal(sm.created.length, 0, 'a disallowed DEFAULT cwd must be caught too')
+      assert.equal(store.get(task.id).lastRun.status, REFUSED_STATUS)
+      assert.match(store.get(task.id).lastRun.error, /working directory \//)
+    })
+
+    it('fails CLOSED when the validator itself throws', async () => {
+      const sm = new FakeSessionManager()
+      const task = store.add({
+        prompt: 'p', cadence: { kind: 'once', at: 2000 },
+        target: { provider: SCHEDULABLE_PROVIDER, cwd: allowedCwd },
+      })
+      const engine = newEngine({
+        sessionManager: sm,
+        validateCwd: () => { throw new Error('stat exploded') },
+      })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.equal(sm.created.length, 0, 'a throwing validator must not fall through to allowed')
+      assert.equal(store.get(task.id).lastRun.status, REFUSED_STATUS)
+      assert.match(store.get(task.id).lastRun.error, /could not be validated/)
+    })
+  })
+
+  // ── SECURITY C3: the clamp is re-asserted on a REUSED session ──────────────
+  //
+  // Scheduled sessions are deliberately kept alive and reused, and
+  // set_permission_mode accepts `auto` on any session — even mid-turn. Without
+  // re-asserting per fire, ONE manual flip to Auto would put every subsequent
+  // unattended fire of that task into bypass, indefinitely, each recorded success.
+
+  describe('permission mode re-clamped on session reuse', () => {
+    const recurring = { cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } }
+
+    it('re-clamps a session an operator flipped to auto, before the next fire', async () => {
+      const sm = new FakeSessionManager()
+      const task = addTask({ prompt: 'daily', ...recurring })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      const sessionId = sm.created[0].id
+      const session = sm.getSession(sessionId).session
+      assert.equal(session.permissionMode, 'approve')
+
+      // The operator opens the kept-alive scheduled session and flips it to Auto.
+      session.permissionMode = 'auto'
+
+      clock = 121_000
+      await timers.tick()
+
+      assert.equal(sm.created.length, 1, 'the session is still reused')
+      assert.equal(session.permissionMode, 'approve', 'the flip must not survive into the next fire')
+      assert.deepEqual(sm.modeSets, [[sessionId, 'approve']], 're-asserted through the provider setter')
+      assert.equal(sm.sends.length, 2)
+      assert.equal(sm.sends[1].permissionMode, 'approve', 'the second turn ran at the clamped mode, not bypass')
+      assert.equal(store.get(task.id).lastRun.status, 'success')
+    })
+
+    it('REFUSES the fire when the clamp cannot be asserted', async () => {
+      // A session that rejects the switch (BaseSession refuses a non-`auto` change
+      // mid-turn) must not be driven: better a visible refusal than an unattended
+      // turn at an unverified permission mode.
+      const sm = new FakeSessionManager()
+      const task = addTask({ prompt: 'daily', ...recurring })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      const session = sm.getSession(sm.created[0].id).session
+      assert.equal(sm.sends.length, 1)
+
+      // Flipped to auto AND now refusing to change back.
+      session.permissionMode = 'auto'
+      sm._refuseModeChange = true
+
+      clock = 121_000
+      await timers.tick()
+
+      assert.equal(sm.sends.length, 1, 'the fire must be SKIPPED, not run in bypass')
+      assert.equal(session.permissionMode, 'auto', 'and the mode was genuinely not re-clampable')
+      const record = store.get(task.id)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.notEqual(record.lastRun.status, 'success')
+      assert.match(record.lastRun.error, /could not be re-clamped to 'approve'/)
+      assert.match(record.lastRun.error, /unverified permission mode/)
+    })
+
+    it('a task pinned to plan stays on plan across reuse', async () => {
+      const sm = new FakeSessionManager()
+      addTask({ prompt: 'review', ...recurring, target: { provider: SCHEDULABLE_PROVIDER, permissionMode: 'plan' } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      const session = sm.getSession(sm.created[0].id).session
+      assert.equal(session.permissionMode, 'plan')
+      session.permissionMode = 'auto'
+
+      clock = 121_000
+      await timers.tick()
+      assert.equal(session.permissionMode, 'plan', 're-clamped to the task\'s own allowed mode')
+      assert.equal(sm.sends[1].permissionMode, 'plan')
+    })
+
+    it('verifies the mode on a freshly created session too', async () => {
+      // A provider that ignores the createSession permissionMode option must not
+      // get an unattended turn either.
+      const sm = new FakeSessionManager({ refuseModeChange: true })
+      const originalCreate = sm.createSession.bind(sm)
+      sm.createSession = (opts) => {
+        const id = originalCreate({ ...opts, permissionMode: 'auto' }) // provider ignores the clamp
+        return id
+      }
+      const task = addTask({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.equal(sm.sends.length, 0, 'no turn may be driven at an unverified mode')
+      assert.equal(store.get(task.id).lastRun.status, REFUSED_STATUS)
+    })
+  })
+
+  // ── quarantine is VISIBLE ──────────────────────────────────────────────────
+
+  describe('quarantine visibility', () => {
+    it('records the quarantine on the task, emits it, and exposes it', async () => {
+      const task = addTask({ prompt: 'unrecordable', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      // The run's own outcome fails to persist (a storage blip), but the
+      // quarantine write that follows succeeds.
+      const realUpdate = store.update.bind(store)
+      let calls = 0
+      store.update = (id, patch) => {
+        calls += 1
+        if (calls === 1) throw new Error('disk on fire')
+        return realUpdate(id, patch)
+      }
+
+      const engine = newEngine({ runTask: async () => ({ status: 'success' }) })
+      const quarantines = []
+      engine.on('task-quarantined', (e) => quarantines.push(e))
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+
+      // Visible on the ENGINE...
+      assert.deepEqual([...engine.quarantinedTaskIds], [task.id])
+      assert.equal(quarantines.length, 1)
+      assert.equal(quarantines[0].taskId, task.id)
+      assert.match(quarantines[0].reason, /could not be recorded/)
+      // ...and on the TASK, so a registry reader no longer sees a stale healthy run.
+      const record = store.get(task.id)
+      assert.equal(record.lastRun.status, REFUSED_STATUS)
+      assert.match(record.lastRun.error, /quarantined until daemon restart/)
+      assert.notEqual(record.lastRun.status, 'success')
+    })
+
+    it('still surfaces the quarantine when the store is entirely unwritable', async () => {
+      const task = addTask({ prompt: 'unrecordable', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      store.update = () => { throw new Error('disk on fire') }
+
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      const quarantines = []
+      engine.on('task-quarantined', (e) => quarantines.push(e))
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+
+      assert.equal(runTask.calls.length, 1)
+      assert.deepEqual([...engine.quarantinedTaskIds], [task.id])
+      assert.equal(quarantines.length, 1, 'the event is the fallback when nothing can be written')
+
+      // ...and it does not hot-loop or re-emit.
+      await timers.tick()
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1)
+      assert.equal(quarantines.length, 1)
     })
   })
 })
@@ -645,26 +1143,51 @@ function mockRunner(impl) {
  * sessions script the turn's events. No provider, no subprocess, no PTY.
  */
 class FakeSessionManager extends EventEmitter {
-  constructor({ permissionRequest = null } = {}) {
+  /**
+   * @param {object} [opts]
+   * @param {object} [opts.permissionRequest] - a permission_request payload to emit mid-turn
+   * @param {string} [opts.providerType] - the daemon default provider (what createSession falls back to)
+   * @param {string} [opts.defaultCwd] - the cwd createSession falls back to
+   * @param {boolean} [opts.refuseModeChange] - model a session that REJECTS setPermissionMode
+   *   (what BaseSession does for a non-`auto` switch while a turn is in flight): the
+   *   setter is a no-op and `permissionMode` keeps its old value.
+   */
+  constructor({ permissionRequest = null, providerType = undefined, defaultCwd = undefined, refuseModeChange = false } = {}) {
     super()
     this.sessions = new Map()
     this.created = []
     this.sends = []
     this.responded = []
     this.interrupted = []
+    this.modeSets = []
     this.scheduledTaskStore = null
     this._permissionRequest = permissionRequest
+    this._refuseModeChange = refuseModeChange
     this._seq = 0
+    if (providerType !== undefined) this.providerType = providerType
+    if (defaultCwd !== undefined) this.defaultCwd = defaultCwd
   }
 
   createSession(opts) {
     const id = `sess-${++this._seq}`
     this.created.push({ id, opts })
     const session = {
+      // BaseSession exposes the live mode on the public `permissionMode` field and
+      // seeds it from the ctor opt (base-session.js:313) — the fake mirrors that,
+      // because the engine's re-clamp proves the mode by READING it back.
+      permissionMode: opts?.permissionMode || 'approve',
+      setPermissionMode: (mode) => {
+        this.modeSets.push([id, mode])
+        // BaseSession returns false (and changes nothing) when the switch is
+        // refused; the engine must not treat the call as evidence.
+        if (this._refuseModeChange) return false
+        session.permissionMode = mode
+        return true
+      },
       respondToPermission: (requestId, decision) => { this.responded.push([requestId, decision]) },
       interrupt: async () => { this.interrupted.push(id) },
       sendMessage: async (prompt) => {
-        this.sends.push({ id, prompt })
+        this.sends.push({ id, prompt, permissionMode: session.permissionMode })
         // TurnDriver registers its accumulator synchronously before sendMessage,
         // so emitting inline is safe.
         if (this._permissionRequest) {

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -1,0 +1,683 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'events'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ScheduledTaskStore } from '../src/scheduled-task-store.js'
+import {
+  SchedulerEngine,
+  buildSchedulerEngine,
+  resolveScheduledPermissionMode,
+  SCHEDULED_PERMISSION_MODE,
+} from '../src/scheduler.js'
+import { isSchedulerEnabled } from '../src/config.js'
+
+/**
+ * #6865 — the headless scheduler engine. Covers the enable gate (off by default:
+ * nothing armed, nothing spawned), due-time firing, next-run advancement,
+ * last-run recording for every outcome, the overlap + thundering-herd guards, the
+ * overdue-grace skip, timer cleanup on shutdown, and the SECURITY crux: an
+ * unattended run is pinned to the safest permission mode, never inherits a global
+ * skip-permissions, and a permission prompt with no client connected is DENIED
+ * and recorded as a visible failure.
+ *
+ * Every timer is injected and every session is a fake — no wall-clock waits, and
+ * NO provider process is ever spawned (the #6933 leaked-handle lesson). The suite
+ * must exit 0 on its own with no --test-force-exit.
+ */
+
+const silentLog = { info() {}, warn() {}, error() {}, debug() {} }
+const MINUTE = 60 * 1000
+
+/** A deterministic timer seam: nothing runs until the test fires it. */
+function makeTimers() {
+  let seq = 0
+  const pending = new Map()
+  return {
+    cleared: [],
+    setTimer(fn, ms) {
+      const id = ++seq
+      pending.set(id, { fn, ms })
+      return id
+    },
+    clearTimer(id) {
+      if (pending.delete(id)) this.cleared.push(id)
+    },
+    get size() {
+      return pending.size
+    },
+    /** Delay the single armed timer (the engine keeps exactly one). */
+    get armedDelay() {
+      const [entry] = [...pending.values()]
+      return entry ? entry.ms : null
+    },
+    /** Fire every currently-armed timer once, awaiting async handlers. */
+    async tick() {
+      const batch = [...pending.entries()]
+      for (const [id, entry] of batch) {
+        pending.delete(id)
+        await entry.fn()
+      }
+      // Let any promise chains the handler kicked off settle.
+      await new Promise((r) => setImmediate(r))
+      await new Promise((r) => setImmediate(r))
+    },
+  }
+}
+
+describe('#6865 SchedulerEngine', () => {
+  let dir
+  let filePath
+  let clock
+  let store
+  let timers
+  let engines
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-scheduler-'))
+    filePath = join(dir, 'scheduled-tasks.json')
+    clock = 1000
+    store = new ScheduledTaskStore({ filePath, logger: silentLog, now: () => clock })
+    timers = makeTimers()
+    engines = []
+  })
+
+  afterEach(() => {
+    for (const e of engines) {
+      try { e.destroy() } catch { /* ignore */ }
+    }
+    rmSync(dir, { recursive: true, force: true })
+    delete process.env.CHROXY_ENABLE_SCHEDULER
+  })
+
+  const enabledConfig = { features: { scheduler: true } }
+
+  /** Build an engine with the injected timer seam; auto-destroyed in afterEach. */
+  const newEngine = (opts = {}) => {
+    const engine = new SchedulerEngine({
+      store,
+      config: enabledConfig,
+      now: () => clock,
+      setTimer: (fn, ms) => timers.setTimer(fn, ms),
+      clearTimer: (id) => timers.clearTimer(id),
+      logger: silentLog,
+      ...opts,
+    })
+    engines.push(engine)
+    return engine
+  }
+
+  // ── the enable gate ────────────────────────────────────────────────────────
+
+  describe('enable gate (off by default)', () => {
+    it('isSchedulerEnabled is false with no config and no env', () => {
+      assert.equal(isSchedulerEnabled(undefined), false)
+      assert.equal(isSchedulerEnabled({}), false)
+      assert.equal(isSchedulerEnabled({ features: {} }), false)
+      assert.equal(isSchedulerEnabled({ features: { scheduler: false } }), false)
+      // Truthy-but-not-true must NOT enable (fail-closed).
+      assert.equal(isSchedulerEnabled({ features: { scheduler: 'yes' } }), false)
+      assert.equal(isSchedulerEnabled({ features: { scheduler: 1 } }), false)
+    })
+
+    it('is enabled by features.scheduler === true', () => {
+      assert.equal(isSchedulerEnabled({ features: { scheduler: true } }), true)
+    })
+
+    it('is enabled by CHROXY_ENABLE_SCHEDULER=1 only (not other truthy values)', () => {
+      process.env.CHROXY_ENABLE_SCHEDULER = '1'
+      assert.equal(isSchedulerEnabled(null), true)
+      process.env.CHROXY_ENABLE_SCHEDULER = 'true'
+      assert.equal(isSchedulerEnabled(null), false)
+      process.env.CHROXY_ENABLE_SCHEDULER = '0'
+      assert.equal(isSchedulerEnabled(null), false)
+    })
+
+    it('a disabled engine arms NO timer and fires NOTHING', async () => {
+      store.add({ prompt: 'do it', cadence: { kind: 'once', at: 1000 } })
+      const runTask = mockRunner()
+      const engine = newEngine({ config: { features: { scheduler: false } }, runTask: runTask.fn })
+
+      assert.equal(engine.start(), false)
+      assert.equal(engine.enabled, false)
+      assert.equal(engine.armed, false)
+      assert.equal(timers.size, 0, 'no timer may be armed while disabled')
+
+      // Even if a tick were somehow driven, nothing fires.
+      await timers.tick()
+      assert.equal(runTask.calls.length, 0)
+      assert.equal(store.get(store.list()[0].id).lastRun, null)
+    })
+
+    it('buildSchedulerEngine returns null (and spawns nothing) when disabled', () => {
+      const sm = new FakeSessionManager()
+      sm.scheduledTaskStore = store
+      assert.equal(buildSchedulerEngine({ sessionManager: sm, config: null, logger: silentLog }), null)
+      assert.equal(buildSchedulerEngine({ sessionManager: sm, config: { features: {} }, logger: silentLog }), null)
+      assert.equal(sm.created.length, 0, 'no session may be created by a disabled scheduler')
+    })
+
+    it('an enabled engine arms a timer on start()', () => {
+      const engine = newEngine()
+      assert.equal(engine.start(), true)
+      assert.equal(engine.armed, true)
+      assert.equal(timers.size, 1)
+      // start() is idempotent — it must not stack a second timer.
+      engine.start()
+      assert.equal(timers.size, 1)
+    })
+  })
+
+  // ── firing + next-run ──────────────────────────────────────────────────────
+
+  describe('due-time firing', () => {
+    it('fires a task whose nextRun has arrived, and not one in the future', async () => {
+      const due = store.add({ prompt: 'due now', cadence: { kind: 'once', at: 2000 } })
+      const later = store.add({ prompt: 'much later', cadence: { kind: 'once', at: 90_000 } })
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+
+      assert.deepEqual(runTask.calls.map((c) => c.task.id), [due.id])
+      assert.equal(store.get(later.id).lastRun, null)
+    })
+
+    it('does not fire a disabled (paused) task', async () => {
+      store.add({ prompt: 'paused', cadence: { kind: 'once', at: 2000 }, enabled: false })
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+
+      clock = 50_000
+      await timers.tick()
+      assert.equal(runTask.calls.length, 0)
+    })
+
+    it('arms the timer for the earliest nextRun, clamped to maxSleepMs', () => {
+      store.add({ prompt: 'soon', cadence: { kind: 'once', at: 6000 } })
+      const engine = newEngine()
+      engine.start()
+      // clock=1000, earliest=6000 → 5000ms away, under the 60s cap.
+      assert.equal(timers.armedDelay, 5000)
+    })
+
+    it('clamps a far-future task to maxSleepMs so registry edits are noticed', () => {
+      store.add({ prompt: 'next week', cadence: { kind: 'once', at: clock + 7 * 24 * 3600 * 1000 } })
+      const engine = newEngine({ maxSleepMs: MINUTE })
+      engine.start()
+      assert.equal(timers.armedDelay, MINUTE)
+    })
+
+    it('a recurring task advances its nextRun after a run (no backfill)', async () => {
+      const task = store.add({ prompt: 'every minute', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      assert.equal(task.nextRun, 61_000)
+
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+
+      const after = store.get(task.id)
+      assert.equal(after.lastRun.status, 'success')
+      assert.equal(after.lastRun.at, 61_000)
+      assert.equal(after.nextRun, 121_000, 'advances one interval, does not backfill missed slots')
+    })
+
+    it('a one-time task fires once and marks itself done', async () => {
+      const task = store.add({ prompt: 'just once', cadence: { kind: 'once', at: 2000 } })
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1)
+      assert.equal(store.get(task.id).nextRun, null, 'a fired one-time task has no next run')
+
+      // Later ticks must not re-fire it.
+      clock = 500_000
+      await timers.tick()
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1)
+    })
+  })
+
+  // ── last-run recording ─────────────────────────────────────────────────────
+
+  describe('last-run recording', () => {
+    const fireWith = async (outcome) => {
+      const task = store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const engine = newEngine({ runTask: async () => outcome })
+      engine.start()
+      clock = 61_000
+      await timers.tick()
+      return store.get(task.id)
+    }
+
+    it('records success with the session id', async () => {
+      const t = await fireWith({ status: 'success', sessionId: 'sess-1' })
+      assert.equal(t.lastRun.status, 'success')
+      assert.equal(t.lastRun.sessionId, 'sess-1')
+      assert.equal(t.lastRun.at, 61_000)
+    })
+
+    it('records an error with its message', async () => {
+      const t = await fireWith({ status: 'error', sessionId: 'sess-1', error: 'provider exploded' })
+      assert.equal(t.lastRun.status, 'error')
+      assert.equal(t.lastRun.error, 'provider exploded')
+    })
+
+    it('records a timeout', async () => {
+      const t = await fireWith({ status: 'timeout', error: 'run exceeded 1000ms' })
+      assert.equal(t.lastRun.status, 'timeout')
+    })
+
+    it('records a permission-denied run as a visible failure', async () => {
+      const t = await fireWith({ status: 'error', sessionId: 's1', error: 'permission required for Bash but no client is connected' })
+      assert.equal(t.lastRun.status, 'error')
+      assert.match(t.lastRun.error, /permission required/)
+    })
+
+    it('an executor that THROWS is recorded as an error, not lost', async () => {
+      const t = await fireWith(Promise.reject(new Error('boom')).catch((e) => { throw e }))
+      assert.equal(t.lastRun.status, 'error')
+      assert.match(t.lastRun.error, /boom/)
+    })
+
+    it('an unknown status is coerced to error (never silently "success")', async () => {
+      const t = await fireWith({ status: 'weird-made-up-status' })
+      assert.equal(t.lastRun.status, 'error')
+    })
+
+    it('emits run-start and run-end for each fire', async () => {
+      const task = store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ runTask: async () => ({ status: 'success', sessionId: 'x' }) })
+      const events = []
+      engine.on('run-start', (e) => events.push(['start', e.taskId]))
+      engine.on('run-end', (e) => events.push(['end', e.taskId, e.status]))
+      engine.start()
+      clock = 2000
+      await timers.tick()
+      assert.deepEqual(events, [['start', task.id], ['end', task.id, 'success']])
+    })
+  })
+
+  // ── overlap + herd guards ──────────────────────────────────────────────────
+
+  describe('overlap and thundering-herd guards', () => {
+    it('never fires the same task twice concurrently', async () => {
+      store.add({ prompt: 'slow', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      let release
+      const gate = new Promise((r) => { release = r })
+      const runTask = mockRunner(() => gate)
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1)
+      assert.equal(engine.runningTaskIds.size, 1)
+
+      // Several more ticks while the first run is still in flight.
+      clock = 200_000
+      await timers.tick()
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1, 'the in-flight task must not be re-fired')
+
+      release({ status: 'success' })
+      await new Promise((r) => setImmediate(r))
+      await new Promise((r) => setImmediate(r))
+      assert.equal(engine.runningTaskIds.size, 0)
+    })
+
+    it('sheds a burst beyond maxConcurrentRuns without persisting a skip', async () => {
+      const a = store.add({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
+      const b = store.add({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
+      const c = store.add({ prompt: 'c', cadence: { kind: 'once', at: 2000 } })
+      let release
+      const gate = new Promise((r) => { release = r })
+      const runTask = mockRunner(() => gate)
+      const engine = newEngine({ runTask: runTask.fn, maxConcurrentRuns: 1 })
+      const skips = []
+      engine.on('run-skip', (e) => skips.push(e.taskId))
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+
+      assert.equal(runTask.calls.length, 1, 'only one run may start under a cap of 1')
+      assert.deepEqual(skips.sort(), [b.id, c.id].sort())
+      // A shed task stays due — its lastRun is untouched so it fires on a later tick.
+      assert.equal(store.get(b.id).lastRun, null)
+      assert.equal(store.get(c.id).lastRun, null)
+      assert.notEqual(store.get(b.id).nextRun, null)
+
+      release({ status: 'success' })
+      await new Promise((r) => setImmediate(r))
+      await new Promise((r) => setImmediate(r))
+      assert.equal(store.get(a.id).lastRun.status, 'success')
+
+      // With the slot free, the shed tasks now fire.
+      await timers.tick()
+      assert.equal(runTask.calls.length, 2)
+    })
+
+    it('does not busy-spin while at capacity with a task still due', async () => {
+      store.add({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
+      store.add({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
+      let release
+      const gate = new Promise((r) => { release = r })
+      const engine = newEngine({ runTask: async () => gate, maxConcurrentRuns: 1 })
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+
+      // `b` is still due, but no slot is free — re-arming off its (past) nextRun
+      // would give a 0ms delay and spin the CPU until `a` finished.
+      assert.equal(timers.armedDelay, MINUTE, 'must sleep the full cadence while at capacity')
+
+      release({ status: 'success' })
+      await new Promise((r) => setImmediate(r))
+      await new Promise((r) => setImmediate(r))
+      // A freed slot re-arms immediately for the still-due task.
+      assert.equal(timers.armedDelay, 0)
+    })
+
+    it('quarantines a task whose outcome cannot be recorded instead of re-firing it', async () => {
+      const task = store.add({ prompt: 'unrecordable', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      // Simulate a storage fault: the run happens but its result never persists,
+      // so nextRun would never advance and the task would stay due forever.
+      store.update = () => { throw new Error('disk on fire') }
+
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1)
+
+      // Subsequent ticks must NOT re-fire the still-due task.
+      await timers.tick()
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1, 'an unrecordable task must not hot-loop')
+      assert.equal(timers.armedDelay, MINUTE, 'and must not arm a 0ms spin')
+      assert.ok(task.id)
+    })
+
+    it('honours a higher concurrency cap', async () => {
+      store.add({ prompt: 'a', cadence: { kind: 'once', at: 2000 } })
+      store.add({ prompt: 'b', cadence: { kind: 'once', at: 2000 } })
+      store.add({ prompt: 'c', cadence: { kind: 'once', at: 2000 } })
+      let release
+      const gate = new Promise((r) => { release = r })
+      const runTask = mockRunner(() => gate)
+      const engine = newEngine({ runTask: runTask.fn, maxConcurrentRuns: 2 })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+      assert.equal(runTask.calls.length, 2)
+      release({ status: 'success' })
+      await new Promise((r) => setImmediate(r))
+    })
+  })
+
+  // ── overdue grace ──────────────────────────────────────────────────────────
+
+  describe('overdue grace (daemon was down)', () => {
+    it('fires a task overdue within the grace window', async () => {
+      store.add({ prompt: 'slightly late', cadence: { kind: 'once', at: 2000 } })
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn, overdueGraceMs: 60 * MINUTE })
+      engine.start()
+      clock = 2000 + 30 * MINUTE
+      await timers.tick()
+      assert.equal(runTask.calls.length, 1)
+    })
+
+    it('skips (and retires) a task staler than the grace window instead of firing', async () => {
+      const task = store.add({ prompt: 'ancient', cadence: { kind: 'once', at: 2000 } })
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn, overdueGraceMs: 60 * MINUTE })
+      const skips = []
+      engine.on('run-skip', (e) => skips.push(e))
+      engine.start()
+
+      clock = 2000 + 61 * MINUTE
+      await timers.tick()
+
+      assert.equal(runTask.calls.length, 0, 'a stale task must not spawn a surprise session')
+      assert.equal(skips.length, 1)
+      assert.match(skips[0].reason, /overdue by/)
+      const after = store.get(task.id)
+      assert.equal(after.lastRun.status, 'skipped')
+      assert.equal(after.nextRun, null, 'the skip retires the one-time task rather than re-skipping forever')
+    })
+  })
+
+  // ── shutdown ───────────────────────────────────────────────────────────────
+
+  describe('shutdown', () => {
+    it('destroy() clears every timer and stops firing', async () => {
+      store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const runTask = mockRunner()
+      const engine = newEngine({ runTask: runTask.fn })
+      engine.start()
+      assert.equal(timers.size, 1)
+
+      engine.destroy()
+      assert.equal(timers.size, 0, 'no timer may survive destroy()')
+      assert.equal(engine.armed, false)
+      assert.ok(timers.cleared.length >= 1)
+
+      clock = 61_000
+      await timers.tick()
+      assert.equal(runTask.calls.length, 0, 'a destroyed engine fires nothing')
+    })
+
+    it('destroy() is idempotent and start() after destroy is a no-op', () => {
+      const engine = newEngine()
+      engine.start()
+      engine.destroy()
+      engine.destroy()
+      assert.equal(engine.start(), false)
+      assert.equal(timers.size, 0)
+    })
+
+    it('refresh() re-arms without stacking timers', () => {
+      const engine = newEngine()
+      engine.start()
+      engine.refresh()
+      engine.refresh()
+      assert.equal(timers.size, 1)
+    })
+  })
+
+  // ── SECURITY: the permission floor ─────────────────────────────────────────
+
+  describe('permission floor', () => {
+    it('clamps every auto-approve mode down to the safe floor', () => {
+      assert.equal(SCHEDULED_PERMISSION_MODE, 'approve')
+      // The bypass mode and the partial auto-approve mode are both refused.
+      assert.equal(resolveScheduledPermissionMode('auto'), 'approve')
+      assert.equal(resolveScheduledPermissionMode('acceptEdits'), 'approve')
+      // Absent / unknown / non-string all fall back to the floor.
+      assert.equal(resolveScheduledPermissionMode(undefined), 'approve')
+      assert.equal(resolveScheduledPermissionMode(null), 'approve')
+      assert.equal(resolveScheduledPermissionMode('bypassPermissions'), 'approve')
+      assert.equal(resolveScheduledPermissionMode('nonsense'), 'approve')
+      assert.equal(resolveScheduledPermissionMode(42), 'approve')
+      // 'approve' and the stricter 'plan' pass through.
+      assert.equal(resolveScheduledPermissionMode('approve'), 'approve')
+      assert.equal(resolveScheduledPermissionMode('plan'), 'plan')
+    })
+
+    it('creates the run with the clamped mode and an explicit skipPermissions:false', async () => {
+      const sm = new FakeSessionManager()
+      const task = store.add({
+        prompt: 'do the thing',
+        cadence: { kind: 'once', at: 2000 },
+        target: { permissionMode: 'auto', cwd: '/tmp/project', provider: 'claude-sdk', model: 'sonnet' },
+      })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.equal(sm.created.length, 1)
+      const opts = sm.created[0].opts
+      assert.equal(opts.permissionMode, 'approve', 'a task asking for auto must be clamped to approve')
+      assert.equal(opts.skipPermissions, false, 'must never inherit the server-wide skip-permissions default')
+      // Per-task scoping is honoured from the stored definition.
+      assert.equal(opts.cwd, '/tmp/project')
+      assert.equal(opts.provider, 'claude-sdk')
+      assert.equal(opts.model, 'sonnet')
+      assert.equal(opts.metadata.scheduledTaskId, task.id)
+      assert.equal(store.get(task.id).lastRun.status, 'success')
+    })
+
+    it('DENIES a permission prompt with no client connected and records the failure', async () => {
+      const sm = new FakeSessionManager({ permissionRequest: { requestId: 'req-1', toolName: 'Bash' } })
+      const task = store.add({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+
+      // Answered through the same door a human clicks — and answered DENY.
+      assert.deepEqual(sm.responded, [['req-1', 'deny']])
+      // The turn is aborted rather than left to burn the 5-minute timeout.
+      assert.equal(sm.interrupted.length, 1)
+      // ...and the run is a VISIBLE failure, not a silent success.
+      const after = store.get(task.id)
+      assert.equal(after.lastRun.status, 'error')
+      assert.match(after.lastRun.error, /permission required for Bash/)
+      assert.match(after.lastRun.error, /no client is connected/)
+      assert.equal(after.lastRun.sessionId, 'sess-1')
+    })
+
+    it('never answers a permission prompt for a session it does not own', async () => {
+      const sm = new FakeSessionManager()
+      store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      // A prompt on somebody else's session, after our run finished.
+      sm.emit('session_event', {
+        sessionId: 'a-users-own-session',
+        event: 'permission_request',
+        data: { requestId: 'req-x', toolName: 'Bash' },
+      })
+      assert.deepEqual(sm.responded, [], 'the scheduler must never answer a user session')
+    })
+
+    it('reports an error (not a crash) when no sessionManager is wired', async () => {
+      const task = store.add({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: null })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+      assert.equal(store.get(task.id).lastRun.status, 'error')
+      assert.match(store.get(task.id).lastRun.error, /no sessionManager/)
+    })
+  })
+
+  // ── session reuse ──────────────────────────────────────────────────────────
+
+  describe('session reuse', () => {
+    it('resumes the same session across runs of one task', async () => {
+      const sm = new FakeSessionManager()
+      store.add({ prompt: 'daily', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      clock = 121_000
+      await timers.tick()
+
+      assert.equal(sm.created.length, 1, 'a recurring task reuses its session instead of leaking one per fire')
+      assert.equal(sm.sends.length, 2)
+    })
+
+    it('creates a fresh session when the previous one is gone', async () => {
+      const sm = new FakeSessionManager()
+      store.add({ prompt: 'daily', cadence: { kind: 'interval', everyMs: MINUTE, anchor: 1000 } })
+      const engine = newEngine({ sessionManager: sm })
+      engine.start()
+
+      clock = 61_000
+      await timers.tick()
+      sm.sessions.clear() // the operator closed it
+      clock = 121_000
+      await timers.tick()
+
+      assert.equal(sm.created.length, 2)
+    })
+  })
+})
+
+/** Records each call; optional impl supplies the outcome. */
+function mockRunner(impl) {
+  const calls = []
+  return {
+    calls,
+    fn: async (task, ctx) => {
+      calls.push({ task, ctx })
+      if (typeof impl === 'function') return await impl(task, ctx)
+      return { status: 'success' }
+    },
+  }
+}
+
+/**
+ * A fake SessionManager: an EventEmitter with createSession/getSession, whose
+ * sessions script the turn's events. No provider, no subprocess, no PTY.
+ */
+class FakeSessionManager extends EventEmitter {
+  constructor({ permissionRequest = null } = {}) {
+    super()
+    this.sessions = new Map()
+    this.created = []
+    this.sends = []
+    this.responded = []
+    this.interrupted = []
+    this.scheduledTaskStore = null
+    this._permissionRequest = permissionRequest
+    this._seq = 0
+  }
+
+  createSession(opts) {
+    const id = `sess-${++this._seq}`
+    this.created.push({ id, opts })
+    const session = {
+      respondToPermission: (requestId, decision) => { this.responded.push([requestId, decision]) },
+      interrupt: async () => { this.interrupted.push(id) },
+      sendMessage: async (prompt) => {
+        this.sends.push({ id, prompt })
+        // TurnDriver registers its accumulator synchronously before sendMessage,
+        // so emitting inline is safe.
+        if (this._permissionRequest) {
+          this.emit('session_event', { sessionId: id, event: 'permission_request', data: this._permissionRequest })
+        }
+        this.emit('session_event', { sessionId: id, event: 'result', data: { cost: 0, duration: 1 } })
+      },
+    }
+    this.sessions.set(id, { session, name: opts?.name, cwd: opts?.cwd, createdAt: Date.now() })
+    return id
+  }
+
+  getSession(id) {
+    return this.sessions.get(id) || null
+  }
+}


### PR DESCRIPTION
Closes #6865.

The keystone slice of epic #6784: the engine that fires a persisted scheduled task (#6862) into a real agent session at its due time, **with no client connected**, and records the run's outcome back into the registry. #6868 (CLI) and #6871 (dashboard panel) build on this — they read the registry and this engine's gate state.

## What lands

- `packages/server/src/scheduler.js` — `SchedulerEngine` + `buildSchedulerEngine()`
- `isSchedulerEnabled()` in `config.js` (alongside `isIdeFeatureEnabled` / `isOrchestrationEnabled`)
- Wired in `server-cli.js` next to `buildOrchestrationManager`, torn down by `ServerOrchestrator` **before** session teardown
- 36 unit tests; a `features` section in `packages/server/CONFIG.md`

Turn driving **reuses `TurnDriver`** (`orchestration/turn-driver.js`, the repo's single "drive one turn and get its result" primitive) rather than reimplementing turn-awaiting, so completion/error/timeout semantics match the existing headless path exactly.

## Enable gate — off by default

`features.scheduler: true` in config, or `CHROXY_ENABLE_SCHEDULER=1`. Fail-closed and strict, matching the existing convention: only a literal boolean `true`, or the literal env string `"1"` (`"yes"`, `1`, `"true"` do **not** enable it).

With the gate closed, `buildSchedulerEngine` returns `null` before an engine is even constructed: **no timer is armed and no session is created**. Existing installs are byte-identical to pre-#6865. Tested explicitly (`a disabled engine arms NO timer and fires NOTHING`, `buildSchedulerEngine returns null (and spawns nothing) when disabled`).

## Permission behaviour with nobody watching

This is the crux, so it is worth being explicit about what the code does and why.

**Ground truth in today's pipeline:** `PermissionManager` has no notion of "no client connected". It emits `permission_request` and starts a fixed 5-minute timer, after which it auto-denies (`permission-manager.js:1073-1084`). So an unattended turn hitting a prompt would hang for five minutes per tool call before failing.

**What this engine does instead** — the safe design named in the issue, implemented by *integrating* rather than bypassing:

1. **Pinned to the safest mode.** The run gets `permissionMode: 'approve'` (Chroxy's modes are `approve` / `acceptEdits` / `auto` / `plan`). A task whose stored `target.permissionMode` is `auto` (Chroxy's bypass — it maps to the SDK's `bypassPermissions`) or `acceptEdits` (auto-approves Read/Write/Edit/NotebookEdit) is **clamped down** to `approve`. A stored task definition can never escalate itself. Only the stricter `plan` passes through unchanged.
2. **No inherited bypass.** The session is created with an explicit `skipPermissions: false`. Because `session-manager.js:1473` only falls back to the server-wide default when the option is absent, passing it explicitly means a global `dangerouslySkipPermissions` a human opted into for their own interactive TUI use **does not silently extend to unattended runs**.
3. **A prompt with nobody to answer is denied, and the run fails visibly.** The engine registers as a scoped answerer for the sessions it owns — mirroring `orchestration/permission-gate.js`, the established in-pipeline pattern — and answers through the same door a human clicks (`session.respondToPermission(requestId, 'deny')`), then `interrupt()`s the turn. The run is recorded as an `error` naming the tool and the reason. It never auto-approves, never waits out the 5-minute timeout, and never answers a session it does not own (tested).
4. **The auditable escalation path stays the permission rules.** Rules short-circuit *before* a prompt is emitted, so an explicit operator-authored allow-rule remains the one way to let a scheduled task actually perform a gated operation — a human decision recorded in the rule store, not a scheduler flag. The protected-path / secret-read floor is untouched and still cannot be escaped by such a rule.

**Risk flagged, per the brief:** clamping `acceptEdits` down to `approve` is deliberately *stricter* than "the same preset a manual session would allow" (a human running with `acceptEdits` does get unprompted edits). It still satisfies the issue's AC — the floor cannot *exceed* a manual equivalent — and it follows the stronger rule that an unattended turn must not run in any auto-approve posture. The practical consequence is that a useful scheduled task needs explicit allow-rules; that is intended, and it is the visible-failure path rather than a silent-escalation path.

**Per-task scoping:** the run uses the task's own stored `cwd` / `provider` / `model`. No new path check is invented — cwd confinement and the protected-path floor stay exactly where they already live.

## Overlap, herd, and resource safety (#6933 lesson)

- **One** self-rescheduling timer (never `setInterval`), injectable via `setTimer`/`clearTimer` and `.unref()`'d by default; `destroy()` clears it, disposes the TurnDriver, detaches listeners, and is idempotent.
- **Overlap:** a task is never re-fired while its previous run is in flight.
- **Herd:** simultaneously-due tasks are serialized under a concurrency cap (default 1 — each run drives a whole agent session), and shed tasks re-fire on a later tick without a persisted skip.
- **No busy-spin:** a shed task stays due, so re-arming off its past `nextRun` would compute a 0 ms delay and spin the CPU until the in-flight run finished. At capacity the engine sleeps its full cadence instead and re-arms the moment a slot frees. Likewise a task whose outcome cannot be persisted (its `nextRun` would never advance) is quarantined rather than re-fired every tick. Both are tested.
- **Overdue grace:** a task more than an hour late is recorded `skipped` instead of fired, so a daemon that was down does not come back to a burst of late unattended sessions. Recurring cadences never backfill — `nextRun` is recomputed forward.
- **Session reuse:** a recurring task resumes its own session (the issue's "spins up (or resumes)") rather than leaking one session per fire, which also keeps the recorded `sessionId` meaningful for inspection.

## Outcome recording

Every fire attempt is recorded: `success`, `error` (including permission-denied, with the reason), `timeout`, and `skipped`. This reuses the store's existing `lastRun` enum — no schema change — so #6868/#6871 can surface runs as-is. Recording is what retires a one-time task (`computeNextRun` returns `null` for a `once` cadence with a `lastRun`) and advances a recurring one.

## `scheduled_task_fire` — investigated, not used

The epic asked whether the `claude` CLI's own `scheduled_task_fire` system subtype could be leveraged instead of reinventing timing. It appears nowhere in this repo today (it lands in the generic system-event log at `sdk-session.js:920`). Rejected as a timing source: it is a *notification* that the CLI's internal scheduler fired, not a programmable API — there is no way to register a standing cadence with it, no wire message to drive it, and it would only ever cover the one `claude` provider, so it cannot serve a multi-provider registry. The daemon owns timing; reasoning recorded in the module header.

## Scope

No wire message — this slice is deliberately server-internal, exposing `run-start` / `run-end` / `run-skip` events for #6871 to layer a wire surface on. So: no protocol/store-core changes, no coverage-guard or dist rebuild. `ScheduleWakeup` (`transcript-tasks.js`) is untouched — it is a passive transcript observer and stays the mid-turn self-resume.

## Verification

- `tests/scheduler.test.js` — 36 tests: enable gate (incl. env strictness), due-time firing, next-run advancement, one-time retirement, last-run recording for every status, overlap guard, herd shed, both anti-spin guards, overdue grace, timer cleanup on shutdown, and the security cases (mode clamping, `skipPermissions: false`, deny-and-record, never answering a foreign session).
- Fully hermetic: injected timers (no wall-clock waits) and a fake SessionManager — **no provider process is ever spawned**.
- Affected suites (scheduler, scheduled-task-store, schedule-parser, session-manager store wiring, server-orchestrator, all `config*`, permission-manager, permission-rule-store, orchestration-permission-gate): **415 pass, 0 fail**, and the run **exits 0 on its own with no `--test-force-exit`** (proof of no leaked handle).
- All 5 server custom lints rc=0; `eslint src/` 0 errors (the 8 warnings are pre-existing, in unrelated files).