### PR TITLE
feat(dashboard): read-only transcript viewer (View alongside Resume)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -221,6 +221,11 @@ vi.mock('./store/connection', () => {
     conversationHistory: [],
     fetchConversationHistory: vi.fn(),
     resumeConversation: vi.fn(),
+    // #6863 — read-only transcript viewer store slice + actions. Mirror the
+    // real store's idle default so App/AppModals render without crashing.
+    transcriptViewer: { conversationId: null, status: 'idle', messages: [], error: null },
+    requestConversationTranscript: vi.fn(),
+    closeTranscriptViewer: vi.fn(),
     connectedClients: [],
     // #5510 — pairing-approval primitive: host-level pending pair-request banner
     // slice + actions. Mirror the real store defaults so App renders the

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -637,6 +637,10 @@ export function App() {
   const conversationHistory = useConnectionStore(s => s.conversationHistory)
   const fetchConversationHistory = useConnectionStore(s => s.fetchConversationHistory)
   const resumeConversation = useConnectionStore(s => s.resumeConversation)
+  // #6863 — read-only transcript viewer.
+  const transcriptViewer = useConnectionStore(s => s.transcriptViewer)
+  const requestConversationTranscript = useConnectionStore(s => s.requestConversationTranscript)
+  const closeTranscriptViewer = useConnectionStore(s => s.closeTranscriptViewer)
   const sendUserQuestionResponse = useConnectionStore(s => s.sendUserQuestionResponse)
   const markPromptAnswered = useConnectionStore(s => s.markPromptAnswered)
   const fetchFileList = useConnectionStore(s => s.fetchFileList)
@@ -964,6 +968,7 @@ export function App() {
       isTauri: isTauri(),
       createSession,
       resumeConversation,
+      viewConversation: requestConversationTranscript,
       revealInFinder,
       onRevealError: (message) => {
         useConnectionStore.getState().addServerError(message)
@@ -1003,6 +1008,7 @@ export function App() {
     conversationHistory,
     createSession,
     resumeConversation,
+    requestConversationTranscript,
     handleCloseSession,
     openCreateSession,
     handleCopySessionTranscript,
@@ -2255,6 +2261,7 @@ export function App() {
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
           onResumeSession={resumeConversation}
+          onViewConversation={requestConversationTranscript}
           onOpenControlRoom={openControlRoom}
           onNewSession={(cwd) => openCreateSession({ cwd: cwd || null })}
           onToggle={() => setSidebarOpen(prev => !prev)}
@@ -2774,6 +2781,9 @@ export function App() {
         sidebarContextMenu={sidebarContextMenu}
         sidebarContextMenuItems={sidebarContextMenuItems}
         onDismissSidebarContextMenu={dismissSidebarContextMenu}
+        transcriptViewer={transcriptViewer}
+        onTranscriptViewerClose={closeTranscriptViewer}
+        onTranscriptViewerRetry={requestConversationTranscript}
         showCreateSession={showCreateSession}
         onCreateSessionClose={() => { setShowCreateSession(false); setIsCreatingSession(false); setSessionCreateError(null); pendingSeedPromptRef.current = null }}
         onCreateSession={handleCreateSession}

--- a/packages/dashboard/src/components/AppModals.tsx
+++ b/packages/dashboard/src/components/AppModals.tsx
@@ -1,5 +1,7 @@
 import type { ComponentProps } from 'react'
+import type { TranscriptViewerState } from '../store/types'
 import { SettingsPanel } from './SettingsPanel'
+import { TranscriptViewer } from './TranscriptViewer'
 import { ShortcutHelp } from './ShortcutHelp'
 import { PastedTextModal } from './PastedTextModal'
 import { QrModal } from './QrModal'
@@ -67,6 +69,12 @@ export interface AppModalsProps {
   sidebarContextMenu: { x: number; y: number } | null
   sidebarContextMenuItems: ComponentProps<typeof SessionContextMenu>['items']
   onDismissSidebarContextMenu: () => void
+  // #6863 (epic #6765) — read-only transcript viewer. `transcriptViewer` is
+  // the store's `TranscriptViewerState` verbatim; rendered only while
+  // `conversationId` is non-null.
+  transcriptViewer: TranscriptViewerState
+  onTranscriptViewerClose: () => void
+  onTranscriptViewerRetry: (conversationId: string) => void
   // Create-session modal
   showCreateSession: boolean
   onCreateSessionClose: () => void
@@ -169,6 +177,26 @@ export function AppModals(props: AppModalsProps) {
           y={props.sidebarContextMenu.y}
           items={props.sidebarContextMenuItems}
           onDismiss={props.onDismissSidebarContextMenu}
+        />
+      )}
+
+      {/* #6863 — read-only transcript viewer. Rendered only while a
+          conversationId is open; unmounts (resetting all local viewer
+          state — search bar, tool-group expand, scroll position) when
+          closed. Status/messages/error come straight from the store slice;
+          onRetry re-sends the SAME request for the same conversationId. */}
+      {props.transcriptViewer.conversationId && (
+        <TranscriptViewer
+          conversationId={props.transcriptViewer.conversationId}
+          status={props.transcriptViewer.status}
+          messages={props.transcriptViewer.messages}
+          error={props.transcriptViewer.error}
+          onClose={props.onTranscriptViewerClose}
+          onRetry={() => {
+            if (props.transcriptViewer.conversationId) {
+              props.onTranscriptViewerRetry(props.transcriptViewer.conversationId)
+            }
+          }}
         />
       )}
 

--- a/packages/dashboard/src/components/ConversationSearch.test.tsx
+++ b/packages/dashboard/src/components/ConversationSearch.test.tsx
@@ -7,6 +7,7 @@ describe('ConversationSearch (#1077)', () => {
   const mockSearchConversations = vi.fn()
   const mockClearSearchResults = vi.fn()
   const mockOnResumeSession = vi.fn()
+  const mockOnViewConversation = vi.fn()
 
   const sampleResults: SearchResult[] = [
     {
@@ -47,6 +48,7 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
     expect(screen.getByPlaceholderText('Search conversations...')).toBeInTheDocument()
@@ -62,6 +64,7 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
 
@@ -87,6 +90,7 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
 
@@ -111,6 +115,7 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
 
@@ -128,6 +133,7 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
 
@@ -143,11 +149,93 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
 
     fireEvent.click(screen.getByText('Fix authentication bug'))
     expect(mockOnResumeSession).toHaveBeenCalledWith('conv-1', '/home/user/my-project')
+    expect(mockOnViewConversation).not.toHaveBeenCalled()
+  })
+
+  // #6863 — regression guard: each result row must expose BOTH a View and a
+  // Resume action, and each must call the RIGHT handler without also
+  // triggering the other. This is the exact risk the issue calls out: a
+  // mis-wire that turns a Resume click into a View (or vice versa).
+  describe('View action (#6863)', () => {
+    it('renders a View button and a Resume button for each result', () => {
+      render(
+        <ConversationSearch
+          searchResults={sampleResults}
+          searchLoading={false}
+          searchQuery="auth"
+          searchConversations={mockSearchConversations}
+          clearSearchResults={mockClearSearchResults}
+          onResumeSession={mockOnResumeSession}
+          onViewConversation={mockOnViewConversation}
+        />,
+      )
+
+      expect(screen.getByTestId('conversation-search-view-conv-1')).toBeInTheDocument()
+      expect(screen.getByTestId('conversation-search-resume-conv-1')).toBeInTheDocument()
+      expect(screen.getByTestId('conversation-search-view-conv-2')).toBeInTheDocument()
+      expect(screen.getByTestId('conversation-search-resume-conv-2')).toBeInTheDocument()
+    })
+
+    it('clicking View calls onViewConversation with the conversationId + cwd, and does NOT resume', () => {
+      render(
+        <ConversationSearch
+          searchResults={sampleResults}
+          searchLoading={false}
+          searchQuery="auth"
+          searchConversations={mockSearchConversations}
+          clearSearchResults={mockClearSearchResults}
+          onResumeSession={mockOnResumeSession}
+          onViewConversation={mockOnViewConversation}
+        />,
+      )
+
+      fireEvent.click(screen.getByTestId('conversation-search-view-conv-1'))
+      expect(mockOnViewConversation).toHaveBeenCalledWith('conv-1', '/home/user/my-project')
+      expect(mockOnResumeSession).not.toHaveBeenCalled()
+    })
+
+    it('clicking the Resume button calls onResumeSession, and does NOT view', () => {
+      render(
+        <ConversationSearch
+          searchResults={sampleResults}
+          searchLoading={false}
+          searchQuery="auth"
+          searchConversations={mockSearchConversations}
+          clearSearchResults={mockClearSearchResults}
+          onResumeSession={mockOnResumeSession}
+          onViewConversation={mockOnViewConversation}
+        />,
+      )
+
+      fireEvent.click(screen.getByTestId('conversation-search-resume-conv-2'))
+      expect(mockOnResumeSession).toHaveBeenCalledWith('conv-2', '/home/user/other-project')
+      expect(mockOnViewConversation).not.toHaveBeenCalled()
+    })
+
+    it('Enter on a focused result still resumes (unchanged) and does not view', () => {
+      render(
+        <ConversationSearch
+          searchResults={sampleResults}
+          searchLoading={false}
+          searchQuery="auth"
+          searchConversations={mockSearchConversations}
+          clearSearchResults={mockClearSearchResults}
+          onResumeSession={mockOnResumeSession}
+          onViewConversation={mockOnViewConversation}
+        />,
+      )
+
+      const option = screen.getAllByRole('option')[0]!
+      fireEvent.keyDown(option, { key: 'Enter' })
+      expect(mockOnResumeSession).toHaveBeenCalledWith('conv-1', '/home/user/my-project')
+      expect(mockOnViewConversation).not.toHaveBeenCalled()
+    })
   })
 
   it('shows "no results" when search returns empty', () => {
@@ -159,6 +247,7 @@ describe('ConversationSearch (#1077)', () => {
         searchConversations={mockSearchConversations}
         clearSearchResults={mockClearSearchResults}
         onResumeSession={mockOnResumeSession}
+        onViewConversation={mockOnViewConversation}
       />,
     )
 

--- a/packages/dashboard/src/components/ConversationSearch.tsx
+++ b/packages/dashboard/src/components/ConversationSearch.tsx
@@ -8,6 +8,14 @@ export interface ConversationSearchProps {
   searchConversations: (query: string) => void
   clearSearchResults: () => void
   onResumeSession: (conversationId: string, cwd: string) => void
+  /**
+   * #6863 (epic #6765) — open a read-only transcript viewer for this
+   * conversation instead of resuming it. NEVER calls `createSession` /
+   * spawns a provider — reading is the entire contract, unlike
+   * `onResumeSession`. Additive: the row's existing click/Enter → Resume
+   * behavior is unchanged; View is only reachable via its own button.
+   */
+  onViewConversation: (conversationId: string, cwd: string) => void
 }
 
 const DEBOUNCE_MS = 300
@@ -19,6 +27,7 @@ export function ConversationSearch({
   searchConversations,
   clearSearchResults,
   onResumeSession,
+  onViewConversation,
 }: ConversationSearchProps) {
   const [inputValue, setInputValue] = useState('')
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -130,6 +139,34 @@ export function ConversationSearch({
               </div>
               <div className="conversation-search-result-meta">
                 {result.projectName} &middot; {result.matchCount} match{result.matchCount !== 1 ? 'es' : ''}
+              </div>
+              {/* #6863 — View / Resume actions, additive alongside the row's
+                  existing click/Enter → Resume behavior above. stopPropagation
+                  on both so a button click doesn't ALSO fire the row's onClick
+                  (which would double-dispatch a resume). */}
+              <div className="conversation-search-result-actions">
+                <button
+                  type="button"
+                  className="conversation-search-result-action conversation-search-result-action-view"
+                  data-testid={`conversation-search-view-${result.conversationId}`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onViewConversation(result.conversationId, result.cwd ?? '')
+                  }}
+                >
+                  View
+                </button>
+                <button
+                  type="button"
+                  className="conversation-search-result-action conversation-search-result-action-resume"
+                  data-testid={`conversation-search-resume-${result.conversationId}`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onResumeSession(result.conversationId, result.cwd ?? '')
+                  }}
+                >
+                  Resume
+                </button>
               </div>
             </li>
           ))}

--- a/packages/dashboard/src/components/ConversationSearch.tsx
+++ b/packages/dashboard/src/components/ConversationSearch.tsx
@@ -66,6 +66,17 @@ export function ConversationSearch({
   }, [searchResults.length])
 
   const handleOptionKeyDown = useCallback((e: React.KeyboardEvent, index: number, result: SearchResult) => {
+    // #6863 — handle only keys that originated on the row ITSELF. The row's
+    // action buttons (View / Resume) are tabbable children and keydown
+    // bubbles, so without this guard Enter/Space on the *View* button fell
+    // into the Enter case below and dispatched a RESUME — a real provider
+    // spawn — and its `preventDefault()` additionally suppressed the button's
+    // own native Enter → click activation, so View never fired at all.
+    // A native <button> already implements its own keyboard activation (Enter
+    // on keydown, Space on keyup, both dispatching a click that runs the
+    // button's onClick), so bowing out here is all that's needed — there is
+    // nothing to hand-roll.
+    if (e.target !== e.currentTarget) return
     switch (e.key) {
       case 'ArrowDown': {
         e.preventDefault()

--- a/packages/dashboard/src/components/ConversationSearchKeyboard.test.tsx
+++ b/packages/dashboard/src/components/ConversationSearchKeyboard.test.tsx
@@ -40,6 +40,7 @@ const sampleResults: SearchResult[] = [
 
 function renderSearch(results = sampleResults) {
   const onResume = vi.fn()
+  const onView = vi.fn()
   const ret = render(
     <ConversationSearch
       searchResults={results}
@@ -48,9 +49,10 @@ function renderSearch(results = sampleResults) {
       searchConversations={vi.fn()}
       clearSearchResults={vi.fn()}
       onResumeSession={onResume}
+      onViewConversation={onView}
     />,
   )
-  return { ...ret, onResume }
+  return { ...ret, onResume, onView }
 }
 
 describe('ConversationSearch keyboard navigation (#1407)', () => {
@@ -99,10 +101,12 @@ describe('ConversationSearch keyboard navigation (#1407)', () => {
   })
 
   it('Enter on focused result calls onResumeSession', () => {
-    const { onResume } = renderSearch()
+    const { onResume, onView } = renderSearch()
     const options = screen.getAllByRole('option')
     options[1]!.focus()
     fireEvent.keyDown(options[1]!, { key: 'Enter' })
     expect(onResume).toHaveBeenCalledWith('conv-2', '/home/user/project-b')
+    // #6863 — Enter must keep resuming only; it must never fire View.
+    expect(onView).not.toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/components/ConversationSearchKeyboard.test.tsx
+++ b/packages/dashboard/src/components/ConversationSearchKeyboard.test.tsx
@@ -110,3 +110,92 @@ describe('ConversationSearch keyboard navigation (#1407)', () => {
     expect(onView).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * #7000 CRITICAL 2 — the row's keydown handler must not swallow keys aimed at
+ * its action buttons.
+ *
+ * The View / Resume buttons are tabbable children of the `role="option"` row,
+ * and keydown bubbles. With an unscoped row handler, Enter on **View** ran the
+ * row's Enter case: it dispatched a RESUME (a real provider spawn, the exact
+ * opposite of the read-only action the user asked for) and its
+ * `preventDefault()` also cancelled the button's own native Enter → click
+ * activation, so View never fired. The pre-existing tests only ever fired
+ * keydown on the row, which is why this passed.
+ */
+describe('ConversationSearch row keydown scoping (#7000 C2)', () => {
+  /**
+   * Models a real browser's handling of an activation key: dispatch keydown
+   * (Space additionally keyup), and — only if nothing called
+   * `preventDefault()` — perform the default action a native <button> takes,
+   * i.e. activation → click. jsdom's `fireEvent` synthesizes neither the
+   * activation nor the cancellation, so both halves are applied here; that is
+   * precisely what makes the regression observable, since the old row handler
+   * cancelled the event.
+   */
+  function pressActivationKey(el: HTMLElement, key: 'Enter' | ' ') {
+    const notPrevented = fireEvent.keyDown(el, { key })
+    if (key === ' ') fireEvent.keyUp(el, { key })
+    if (notPrevented && el.tagName === 'BUTTON') fireEvent.click(el)
+    return notPrevented
+  }
+
+  for (const key of ['Enter', ' '] as const) {
+    const label = key === ' ' ? 'Space' : 'Enter'
+
+    it(`${label} on the View button activates View and never resumes`, () => {
+      const { onResume, onView } = renderSearch()
+      const view = screen.getByTestId('conversation-search-view-conv-2')
+      view.focus()
+
+      pressActivationKey(view, key)
+
+      expect(onView).toHaveBeenCalledTimes(1)
+      expect(onView).toHaveBeenCalledWith('conv-2', '/home/user/project-b')
+      // The whole point: no provider spawn.
+      expect(onResume).not.toHaveBeenCalled()
+    })
+
+    it(`${label} on the Resume button resumes exactly once`, () => {
+      const { onResume, onView } = renderSearch()
+      const resume = screen.getByTestId('conversation-search-resume-conv-3')
+      resume.focus()
+
+      pressActivationKey(resume, key)
+
+      expect(onResume).toHaveBeenCalledTimes(1)
+      expect(onResume).toHaveBeenCalledWith('conv-3', '/home/user/project-c')
+      expect(onView).not.toHaveBeenCalled()
+    })
+  }
+
+  it('the row itself still resumes on Enter (unchanged behavior)', () => {
+    const { onResume, onView } = renderSearch()
+    const row = screen.getAllByRole('option')[0]!
+    row.focus()
+
+    // Still cancelled on the row (it owns Enter/Space there).
+    expect(pressActivationKey(row, 'Enter')).toBe(false)
+    expect(onResume).toHaveBeenCalledTimes(1)
+    expect(onResume).toHaveBeenCalledWith('conv-1', '/home/user/project-a')
+    expect(onView).not.toHaveBeenCalled()
+  })
+
+  it('the row itself still resumes on Space (unchanged behavior)', () => {
+    const { onResume, onView } = renderSearch()
+    const row = screen.getAllByRole('option')[1]!
+    row.focus()
+
+    pressActivationKey(row, ' ')
+    expect(onResume).toHaveBeenCalledTimes(1)
+    expect(onResume).toHaveBeenCalledWith('conv-2', '/home/user/project-b')
+    expect(onView).not.toHaveBeenCalled()
+  })
+
+  it('a click on View does not also fire the row click (no double dispatch)', () => {
+    const { onResume, onView } = renderSearch()
+    fireEvent.click(screen.getByTestId('conversation-search-view-conv-1'))
+    expect(onView).toHaveBeenCalledTimes(1)
+    expect(onResume).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -88,6 +88,14 @@ export interface SidebarProps {
   onFilterChange: (value: string) => void
   onSessionClick: (sessionId: string) => void
   onResumeSession: (conversationId: string, cwd?: string) => void
+  /**
+   * #6863 (epic #6765) — open a read-only transcript viewer for a search
+   * result instead of resuming it. Optional (like `searchConversations` /
+   * `clearSearchResults`) so existing callers/tests that don't exercise
+   * search don't need to wire it; when omitted, ConversationSearch's View
+   * button (which requires a handler) gets a no-op.
+   */
+  onViewConversation?: (conversationId: string, cwd?: string) => void
   onNewSession: (cwd: string) => void
   onToggle: () => void
   onContextMenu: (target: ContextMenuTarget, event: React.MouseEvent) => void
@@ -149,6 +157,7 @@ export function Sidebar({
   onFilterChange,
   onSessionClick,
   onResumeSession,
+  onViewConversation,
   onNewSession,
   onToggle,
   onContextMenu,
@@ -706,6 +715,7 @@ export function Sidebar({
               searchConversations={searchConversations}
               clearSearchResults={clearSearchResults}
               onResumeSession={(convId, cwd) => onResumeSession(convId, cwd)}
+              onViewConversation={(convId, cwd) => onViewConversation?.(convId, cwd)}
             />
           )}
 

--- a/packages/dashboard/src/components/TranscriptViewer.css
+++ b/packages/dashboard/src/components/TranscriptViewer.css
@@ -1,0 +1,54 @@
+/* TranscriptViewer — read-only conversation transcript (#6863). */
+
+.transcript-viewer-readonly-badge {
+  margin: 0 0 var(--space-2) 0;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+}
+
+.transcript-viewer-body {
+  display: flex;
+  flex-direction: column;
+  height: min(70vh, 640px);
+  min-height: 240px;
+  background: var(--bg-primary, var(--bg-secondary));
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.transcript-viewer-status {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  text-align: center;
+  color: var(--text-dim);
+  font-size: var(--text-md);
+}
+
+.transcript-viewer-status.transcript-viewer-error {
+  color: var(--text-error);
+}
+
+.transcript-viewer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.transcript-viewer-button {
+  background: transparent;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-sm);
+  padding: 6px 12px;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-primary);
+}
+
+.transcript-viewer-button:hover {
+  border-color: var(--border-focus);
+}

--- a/packages/dashboard/src/components/TranscriptViewer.test.tsx
+++ b/packages/dashboard/src/components/TranscriptViewer.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * TranscriptViewer tests (#6863, epic #6765).
+ *
+ * Covers the loading/empty/error/ready states, the structural read-only
+ * guarantee (no composer/input rendered anywhere), and that a fetched
+ * transcript renders through the shared ChatView renderer.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { TranscriptViewer } from './TranscriptViewer'
+import type { ChatMessage } from '@chroxy/store-core'
+
+afterEach(cleanup)
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'm1',
+    type: 'response',
+    content: 'Hello from the transcript',
+    timestamp: Date.parse('2026-03-01T12:00:00Z'),
+    ...overrides,
+  }
+}
+
+describe('TranscriptViewer (#6863)', () => {
+  it('shows a loading indicator while status is loading', () => {
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="loading"
+        messages={[]}
+        error={null}
+        onClose={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('transcript-viewer-loading')).toBeInTheDocument()
+    expect(screen.queryByTestId('transcript-viewer-error')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('transcript-viewer-empty')).not.toBeInTheDocument()
+  })
+
+  it('shows an empty state when the transcript has no messages', () => {
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="ready"
+        messages={[]}
+        error={null}
+        onClose={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('transcript-viewer-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-view')).not.toBeInTheDocument()
+  })
+
+  it('shows a clear error state without crashing, and offers Retry', () => {
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="error"
+        messages={[]}
+        error="Conversation not found: conv-1"
+        onClose={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+    const errorEl = screen.getByTestId('transcript-viewer-error')
+    expect(errorEl).toHaveTextContent('Conversation not found: conv-1')
+    expect(screen.getByTestId('transcript-viewer-retry')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic error message when none is provided', () => {
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="error"
+        messages={[]}
+        error={null}
+        onClose={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('transcript-viewer-error')).toHaveTextContent('Failed to load transcript.')
+  })
+
+  it('clicking Retry calls onRetry', () => {
+    const onRetry = vi.fn()
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="error"
+        messages={[]}
+        error="boom"
+        onClose={vi.fn()}
+        onRetry={onRetry}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('transcript-viewer-retry'))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a fetched transcript using the shared chat renderer', () => {
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="ready"
+        messages={[
+          makeMessage({ id: 'u1', type: 'user_input', content: 'What does this function do?' }),
+          makeMessage({ id: 'r1', type: 'response', content: 'It reads a file.' }),
+        ]}
+        error={null}
+        onClose={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('chat-view')).toBeInTheDocument()
+    expect(screen.getByText('What does this function do?')).toBeInTheDocument()
+    expect(screen.getByText('It reads a file.')).toBeInTheDocument()
+  })
+
+  it('clicking Close calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <TranscriptViewer
+        conversationId="conv-1"
+        status="ready"
+        messages={[]}
+        error={null}
+        onClose={onClose}
+        onRetry={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('transcript-viewer-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('carries the conversationId onto the transcript body for correlation', () => {
+    render(
+      <TranscriptViewer
+        conversationId="conv-abc-123"
+        status="ready"
+        messages={[]}
+        error={null}
+        onClose={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('transcript-viewer-body')).toHaveAttribute('data-conversation-id', 'conv-abc-123')
+  })
+
+  // Structural read-only guarantee: NO composer/input control anywhere in
+  // this component's tree, in any status — not just "the button is hidden".
+  describe('read-only structural guarantee', () => {
+    const statuses: Array<{ status: 'loading' | 'ready' | 'error'; messages: ChatMessage[]; error: string | null }> = [
+      { status: 'loading', messages: [], error: null },
+      { status: 'ready', messages: [makeMessage()], error: null },
+      { status: 'error', messages: [], error: 'boom' },
+    ]
+
+    for (const { status, messages, error } of statuses) {
+      it(`renders no composer/input-bar or textarea while status is ${status}`, () => {
+        render(
+          <TranscriptViewer
+            conversationId="conv-1"
+            status={status}
+            messages={messages}
+            error={error}
+            onClose={vi.fn()}
+            onRetry={vi.fn()}
+          />,
+        )
+        expect(screen.queryByTestId('input-bar')).not.toBeInTheDocument()
+        expect(document.querySelector('textarea')).toBeNull()
+      })
+    }
+
+    it('renders no permission/question prompt approve-or-answer controls for an unresolved prompt entry', () => {
+      // A permission-request-shaped entry (requestId + expiresAt + unanswered)
+      // — in the live view this would render the INTERACTIVE PermissionPrompt
+      // with an onRespond wired to a real decision. The transcript viewer must
+      // never wire that; it's expected to fall back to a plain read-only bubble.
+      render(
+        <TranscriptViewer
+          conversationId="conv-1"
+          status="ready"
+          messages={[
+            makeMessage({
+              id: 'p1',
+              type: 'prompt',
+              content: 'Bash: rm -rf /tmp/scratch',
+              requestId: 'req-1',
+              tool: 'Bash',
+            }),
+          ]}
+          error={null}
+          onClose={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+      )
+      // No approve/deny/allow control of any kind should be present.
+      expect(screen.queryByRole('button', { name: /allow/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /deny/i })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/dashboard/src/components/TranscriptViewer.tsx
+++ b/packages/dashboard/src/components/TranscriptViewer.tsx
@@ -1,0 +1,172 @@
+/**
+ * TranscriptViewer — read-only viewer for a closed conversation's transcript
+ * (#6863, epic #6765).
+ *
+ * Opened via the "View" action added alongside "Resume" in
+ * `ConversationSearch` and the sidebar's `resumable` right-click menu
+ * (`sidebarContextMenuItems.ts`). The transcript itself comes from the
+ * read-only `request_conversation_transcript` endpoint (#6860) — reading a
+ * CLOSED conversation straight off disk, with NO `SessionManager` entry and
+ * NO provider process spawned on either side of the wire. Works uniformly
+ * for conversations from providers whose `capabilities.resume === false`
+ * (BYOK, Codex, Gemini, user-shell), for which Resume is refused outright.
+ *
+ * Read-only is structural, not just visual:
+ *  - No composer/input is rendered anywhere in this component tree.
+ *  - `ChatView` is driven with `renderMessage={transcriptRenderMessage}`,
+ *    which reuses only the PRESENTATIONAL branches of the live chat renderer
+ *    (`useMessageRenderer` — tool groups/bubbles, compaction/evaluator/MCP
+ *    markers). It deliberately OMITS the interactive branches
+ *    (`PermissionPrompt`/`QuestionPrompt`, whose `onRespond`/`onSelect` send
+ *    live decisions, and the stall chips' `onRetry`, which resends a
+ *    message) — anything transcriptRenderMessage doesn't handle falls back
+ *    to ChatView's default row (a plain markdown/text bubble), never an
+ *    interactive control.
+ *  - The messages themselves live in the store's dedicated `transcriptViewer`
+ *    slice, never `sessionStates` — see message-handler.ts's
+ *    `applyTranscriptFrame` for how the wire frames are kept out of the
+ *    live-session path entirely.
+ *  - There is no callback prop here that can send input, respond to a
+ *    prompt, or spawn a session — only `onClose` and `onRetry` (re-fetch).
+ */
+import { useCallback } from 'react'
+import type { ChatMessage } from '@chroxy/store-core'
+import { Modal } from './Modal'
+import { ChatView, type ChatViewMessage } from './ChatView'
+import { ToolGroup } from './ToolGroup'
+import { ToolBubble } from './ToolBubble'
+import { CompactionMarker } from './CompactionMarker'
+import { EvaluatorRewriteBanner } from './EvaluatorPrompts'
+import { McpPromptExpansionMarker } from './McpPromptExpansionMarker'
+import { useChatMessages } from '../hooks/useChatMessages'
+import type { TranscriptViewerState } from '../store/types'
+import './TranscriptViewer.css'
+
+export interface TranscriptViewerProps {
+  conversationId: string
+  status: TranscriptViewerState['status']
+  messages: ChatMessage[]
+  error: string | null
+  onClose: () => void
+  onRetry: () => void
+}
+
+/**
+ * Presentational-only reuse of `useMessageRenderer`'s tool-group / tool-bubble
+ * / marker branches — see the module doc above for why the interactive
+ * branches are intentionally left out. Exported for direct unit testing.
+ */
+export function transcriptRenderMessage(
+  msg: ChatViewMessage,
+  chatToolGroupPayloads: Map<string, { messages: ChatMessage[]; isActive: boolean }>,
+  chatTailMessageId: string | null,
+  storeMsgMap: Map<string, ChatMessage>,
+) {
+  if (msg.type === 'tool_group') {
+    const payload = chatToolGroupPayloads.get(msg.id)
+    if (!payload) return null
+    // A closed conversation has no in-flight activity — always inactive.
+    return <ToolGroup messages={payload.messages} isActive={false} isTail={msg.id === chatTailMessageId} />
+  }
+  const storeMsg = storeMsgMap.get(msg.id)
+  if (!storeMsg) return null
+
+  if (storeMsg.type === 'tool_use' && storeMsg.toolUseId) {
+    return (
+      <ToolBubble
+        toolName={storeMsg.tool || 'Tool'}
+        toolUseId={storeMsg.toolUseId}
+        input={storeMsg.toolInput}
+        inputPartial={storeMsg.toolInputPartial}
+        result={storeMsg.toolResult}
+        serverName={storeMsg.serverName}
+        isTail={msg.id === chatTailMessageId}
+        resultImages={storeMsg.toolResultImages}
+        childAgentEvents={storeMsg.childAgentEvents}
+      />
+    )
+  }
+  if (storeMsg.type === 'system' && storeMsg.compactMetadata) {
+    return <CompactionMarker meta={storeMsg.compactMetadata} />
+  }
+  if (storeMsg.type === 'system' && storeMsg.evaluator?.kind === 'rewrite') {
+    return <EvaluatorRewriteBanner meta={storeMsg.evaluator} />
+  }
+  if (storeMsg.type === 'system' && storeMsg.mcpPromptExpansion) {
+    return <McpPromptExpansionMarker meta={storeMsg.mcpPromptExpansion} />
+  }
+  // Permission prompts, question prompts, error chips, etc. all fall through
+  // to ChatView's plain default row — content is still visible (the prompt's
+  // text, the resolved answer summary if one was recorded), just without any
+  // interactive control.
+  return null
+}
+
+export function TranscriptViewer({ conversationId, status, messages, error, onClose, onRetry }: TranscriptViewerProps) {
+  // Same pure pipeline the live session view uses (filter system events,
+  // group contiguous tool runs, flatten) — reuse, not a fork.
+  const { chatMessages, chatToolGroupPayloads, chatTailMessageId, storeMsgMap } = useChatMessages({
+    storeMessages: messages,
+    streamingMessageId: null,
+  })
+
+  const renderMessage = useCallback(
+    (msg: ChatViewMessage) => transcriptRenderMessage(msg, chatToolGroupPayloads, chatTailMessageId, storeMsgMap),
+    [chatToolGroupPayloads, chatTailMessageId, storeMsgMap],
+  )
+
+  return (
+    <Modal open onClose={onClose} title="Conversation transcript" maxWidth="900px">
+      <p className="transcript-viewer-readonly-badge" data-testid="transcript-viewer-readonly-badge">
+        Read-only — viewing does not resume this conversation.
+      </p>
+      <div
+        className="transcript-viewer-body"
+        data-testid="transcript-viewer-body"
+        data-conversation-id={conversationId}
+      >
+        {status === 'loading' && (
+          <div className="transcript-viewer-status" data-testid="transcript-viewer-loading">
+            Loading transcript…
+          </div>
+        )}
+        {status === 'error' && (
+          <div className="transcript-viewer-status transcript-viewer-error" data-testid="transcript-viewer-error">
+            {error || 'Failed to load transcript.'}
+          </div>
+        )}
+        {status === 'ready' && chatMessages.length === 0 && (
+          <div className="transcript-viewer-status" data-testid="transcript-viewer-empty">
+            No messages in this conversation.
+          </div>
+        )}
+        {status === 'ready' && chatMessages.length > 0 && (
+          // ChatView windows/virtualizes above its own row-count threshold
+          // (#5561) — a very large transcript renders exactly like a long
+          // live session and never locks the UI.
+          <ChatView messages={chatMessages} isStreaming={false} renderMessage={renderMessage} />
+        )}
+      </div>
+      <div className="transcript-viewer-footer">
+        {status === 'error' && (
+          <button
+            type="button"
+            className="transcript-viewer-button"
+            data-testid="transcript-viewer-retry"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        )}
+        <button
+          type="button"
+          className="transcript-viewer-button"
+          data-testid="transcript-viewer-close"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/packages/dashboard/src/sidebarContextMenuItems.test.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.test.ts
@@ -62,6 +62,7 @@ function makeArgs(
     isTauri: false,
     createSession: vi.fn(),
     resumeConversation: vi.fn(),
+    viewConversation: vi.fn(),
     revealInFinder: vi.fn(() => Promise.resolve()),
     onRevealError: vi.fn(),
     copyToClipboard: vi.fn(),
@@ -85,12 +86,63 @@ describe('buildSidebarContextMenuItems', () => {
       expect(visible.length).toBeGreaterThan(0)
     })
 
-    it('includes Resume Conversation, Copy Conversation ID, and Open in Finder', () => {
+    it('includes Resume Conversation, View Conversation, Copy Conversation ID, and Open in Finder', () => {
       const items = buildSidebarContextMenuItems(makeArgs({ isTauri: true }))
       const labels = items.map(i => i.label)
       expect(labels).toContain('Resume Conversation')
+      expect(labels).toContain('View Conversation')
       expect(labels).toContain('Copy Conversation ID')
       expect(labels).toContain('Open in Finder')
+    })
+
+    // #6863 — View Conversation must be present alongside Resume and must
+    // call the RIGHT handler (viewConversation, never resumeConversation).
+    it('View calls viewConversation with the conversationId and cwd from history, not resumeConversation', () => {
+      const viewConversation = vi.fn()
+      const resumeConversation = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'conv-123' },
+          conversationHistory: [makeConversation({ cwd: '/home/user/projects/web' })],
+          viewConversation,
+          resumeConversation,
+        }),
+      )
+      const view = items.find(i => i.id === 'view')
+      expect(view?.label).toBe('View Conversation')
+      view?.onClick?.()
+      expect(viewConversation).toHaveBeenCalledWith('conv-123', '/home/user/projects/web')
+      expect(resumeConversation).not.toHaveBeenCalled()
+    })
+
+    it('Resume does not call viewConversation', () => {
+      const viewConversation = vi.fn()
+      const resumeConversation = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'conv-123' },
+          viewConversation,
+          resumeConversation,
+        }),
+      )
+      items.find(i => i.id === 'resume')?.onClick?.()
+      expect(resumeConversation).toHaveBeenCalled()
+      expect(viewConversation).not.toHaveBeenCalled()
+    })
+
+    it('View is enabled even without a resolvable cwd (works for capabilities.resume===false providers)', () => {
+      const viewConversation = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'unknown-conv' },
+          conversationHistory: [],
+          viewConversation,
+        }),
+      )
+      const view = items.find(i => i.id === 'view')
+      expect(typeof view?.onClick).toBe('function')
+      view?.onClick?.()
+      expect(viewConversation).toHaveBeenCalledWith('unknown-conv', undefined)
     })
 
     it('Resume calls resumeConversation with the conversationId and cwd from history', () => {

--- a/packages/dashboard/src/sidebarContextMenuItems.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.ts
@@ -11,10 +11,11 @@
  *   - `repo`    — New Session Here, Summarize & start new session targeting the
  *     group's most-recent session (or one item per live session when several,
  *     #5547), Open in Finder (Tauri)
- *   - `resumable` (#4249) — Resume Conversation, Copy Conversation ID,
- *     Open in Finder (Tauri+cwd). cwd is looked up from `conversationHistory`
- *     so the resume + reveal actions point at the same project the
- *     conversation lived in.
+ *   - `resumable` (#4249) — Resume Conversation, View Conversation (#6863,
+ *     read-only — see viewConversation), Copy Conversation ID, Open in Finder
+ *     (Tauri+cwd). cwd is looked up from `conversationHistory` so the resume
+ *     + view + reveal actions point at the same project the conversation
+ *     lived in.
  *
  * Capability-gated items use a falsy `onClick` so `SessionContextMenu`
  * filters them at render time (no caller-side filtering needed).
@@ -47,6 +48,13 @@ export interface BuildSidebarContextMenuItemsArgs {
     skipPermissions?: boolean
   }) => void
   resumeConversation: (conversationId: string, cwd?: string) => void
+  /**
+   * #6863 (epic #6765) — open a read-only transcript viewer instead of
+   * resuming. NEVER calls `createSession` / spawns a provider; works even
+   * for conversations whose provider has `capabilities.resume === false`
+   * (BYOK, Codex, Gemini, user-shell), for which Resume is refused outright.
+   */
+  viewConversation: (conversationId: string, cwd?: string) => void
   revealInFinder: (path: string) => Promise<unknown>
   /** Surface a Rust-side reveal failure as a toast (matches App.tsx pattern). */
   onRevealError: (message: string) => void
@@ -84,6 +92,7 @@ export function buildSidebarContextMenuItems(
     isTauri,
     createSession,
     resumeConversation,
+    viewConversation,
     revealInFinder,
     onRevealError,
     copyToClipboard,
@@ -223,6 +232,15 @@ export function buildSidebarContextMenuItems(
         id: 'resume',
         label: 'Resume Conversation',
         onClick: () => resumeConversation(conversationId, cwd),
+      },
+      {
+        // #6863 — read-only viewer, additive alongside Resume. Always
+        // enabled (unlike Resume, which the server can refuse for a
+        // capability-gated provider) since the endpoint it drives reads
+        // straight off disk and works for every provider.
+        id: 'view',
+        label: 'View Conversation',
+        onClick: () => viewConversation(conversationId, cwd),
       },
       {
         id: 'copy-id',

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -49,6 +49,7 @@ export type {
   SearchResult,
   ConnectionState,
   RestoreCheckpointMode,
+  TranscriptViewerState,
 } from './types';
 
 // Re-export utility functions for backward compatibility
@@ -69,6 +70,7 @@ import type {
   ServerEntry,
   SessionInfo,
   SessionState,
+  TranscriptViewerState,
 } from './types';
 import {
   loadServerRegistry,
@@ -127,6 +129,9 @@ import {
   registerThinkingLevelChangeRequest,
   clearPendingThinkingLevelReverts,
   clearPendingPermissionModeReverts,
+  beginTranscriptFetch,
+  endTranscriptFetch,
+  resetTranscriptFetchTracking,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
 import { CLIENT_CAPABILITIES, DEFAULT_PROVIDER } from '@chroxy/protocol';
@@ -404,6 +409,20 @@ export const selectShowSession = (s: ConnectionState): boolean =>
 // Search request tracking — prevents stale timeout/response races
 let searchNonce = 0;
 let searchTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+// #6863 — read-only transcript viewer. `request_conversation_transcript`
+// (#6860) has no dedicated failure echo (a rejection arrives as a generic
+// `session_error{message}` with no correlating id), so — mirroring the
+// `searchTimeoutId` watchdog above — a fetch that's still `loading` after
+// this window surfaces a timeout error instead of spinning forever.
+let transcriptTimeoutId: ReturnType<typeof setTimeout> | undefined;
+const TRANSCRIPT_FETCH_TIMEOUT_MS = 15000;
+const EMPTY_TRANSCRIPT_VIEWER: TranscriptViewerState = {
+  conversationId: null,
+  status: 'idle',
+  messages: [],
+  error: null,
+};
 
 // #6502 — monotonic read_file request nonce. The server echoes it back on the
 // `file_content` reply so the file browser can drop replies from superseded
@@ -871,6 +890,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   _diffCallback: null,
   conversationHistory: [],
   conversationHistoryLoading: false,
+  transcriptViewer: EMPTY_TRANSCRIPT_VIEWER,
   searchResults: [],
   searchLoading: false,
   searchQuery: '',
@@ -2810,6 +2830,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     // Reset replay flags in case disconnect happened mid-replay
     resetReplayFlags();
+    // #6863 — drop any in-flight transcript fetch tracking so a stale
+    // conversationId from before the disconnect can't intercept frames on a
+    // later, unrelated connection.
+    resetTranscriptFetchTracking();
+    clearTimeout(transcriptTimeoutId);
     // #5555.3/.4 — explicit disconnect is a hard reset: drop the replay
     // baseline AND the history cursors so a later connect (possibly to a
     // different server) starts from a full replay rather than presenting a
@@ -2926,6 +2951,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       viewingCachedSession: false,
       conversationHistory: [],
       conversationHistoryLoading: false,
+      transcriptViewer: EMPTY_TRANSCRIPT_VIEWER,
       searchResults: [],
       searchLoading: false,
       searchQuery: '',
@@ -4626,6 +4652,66 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (cwd) payload.cwd = cwd;
       wsSend(socket, payload);
     }
+  },
+
+  // #6863 (epic #6765) — read-only transcript viewer. Sends
+  // `request_conversation_transcript` (#6860): the server reads a CLOSED
+  // conversation's history straight off disk and streams it back via the
+  // shared history-replay frames — no SessionManager entry, no provider
+  // spawn. `beginTranscriptFetch` registers the conversationId BEFORE the
+  // send so message-handler.ts's interception guard is armed the instant a
+  // reply could arrive (see applyTranscriptFrame's doc comment there).
+  requestConversationTranscript: (conversationId: string, cwd?: string) => {
+    const { socket } = get();
+    set({
+      transcriptViewer: {
+        conversationId,
+        status: 'loading',
+        messages: [],
+        error: null,
+      },
+    });
+    beginTranscriptFetch(conversationId);
+    const isOpen = !!socket && socket.readyState === WebSocket.OPEN;
+    const payload: Record<string, unknown> = { type: 'request_conversation_transcript', conversationId };
+    if (cwd) payload.cwd = cwd;
+    // #6308/#6309 — wsSend's return value MUST be checked at every
+    // side-effecting call site; a false result (queued/dropped, not an open
+    // socket write) must not leave the viewer stuck in `loading`.
+    const sent = isOpen && socket ? wsSend(socket, payload) : false;
+    if (!sent) {
+      endTranscriptFetch(conversationId);
+      if (get().transcriptViewer.conversationId === conversationId) {
+        set(state => ({
+          transcriptViewer: { ...state.transcriptViewer, status: 'error', error: 'Not connected to server.' },
+        }));
+      }
+      return;
+    }
+    // request_conversation_transcript has no dedicated failure echo (a
+    // rejection — missing/invalid id, not authorized, not found — arrives as
+    // a generic `session_error{message}` with no correlating id we can match
+    // against this specific fetch). Mirror searchConversations' watchdog: if
+    // still `loading` after the window, surface a timeout rather than
+    // spinning forever. Any session_error DOES still reach the generic
+    // handler in the meantime and shows its own toast.
+    clearTimeout(transcriptTimeoutId);
+    transcriptTimeoutId = setTimeout(() => {
+      endTranscriptFetch(conversationId);
+      const state = get();
+      if (state.transcriptViewer.conversationId === conversationId && state.transcriptViewer.status === 'loading') {
+        set({
+          transcriptViewer: { ...state.transcriptViewer, status: 'error', error: 'Timed out loading transcript.' },
+        });
+      }
+    }, TRANSCRIPT_FETCH_TIMEOUT_MS);
+  },
+
+  closeTranscriptViewer: () => {
+    const current = get().transcriptViewer;
+    if (current.conversationId) endTranscriptFetch(current.conversationId);
+    clearTimeout(transcriptTimeoutId);
+    set({ transcriptViewer: EMPTY_TRANSCRIPT_VIEWER });
   },
 
   searchConversations: (query: string) => {

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -131,6 +131,7 @@ import {
   clearPendingPermissionModeReverts,
   beginTranscriptFetch,
   endTranscriptFetch,
+  clearTranscriptWatchdog,
   resetTranscriptFetchTracking,
 } from './message-handler';
 import type { EvaluatorResultPayload } from './types';
@@ -412,11 +413,12 @@ let searchTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
 // #6863 — read-only transcript viewer. `request_conversation_transcript`
 // (#6860) has no dedicated failure echo (a rejection arrives as a generic
-// `session_error{message}` with no correlating id), so — mirroring the
-// `searchTimeoutId` watchdog above — a fetch that's still `loading` after
-// this window surfaces a timeout error instead of spinning forever.
-let transcriptTimeoutId: ReturnType<typeof setTimeout> | undefined;
-const TRANSCRIPT_FETCH_TIMEOUT_MS = 15000;
+// `session_error{message}` with no correlating id — a per-request correlation
+// id needs a protocol change, tracked in #7007), so a fetch that goes SILENT
+// surfaces a timeout error instead of spinning forever. The timer itself lives
+// in message-handler.ts next to the frame path, because it is an INACTIVITY
+// window that every arriving frame re-arms (armed here via
+// `beginTranscriptFetch`'s callback, disarmed via `clearTranscriptWatchdog`).
 const EMPTY_TRANSCRIPT_VIEWER: TranscriptViewerState = {
   conversationId: null,
   status: 'idle',
@@ -631,6 +633,28 @@ function clearGitOneshotCallbacks(
     base: null,
     error: GIT_ONESHOT_TIMEOUT_ERROR,
   });
+}
+
+// #6863 — a dropped socket is the other terminal condition for an armed
+// transcript fetch: the frames still owed to it (including its
+// `history_replay_end`) can never arrive on this socket, so its interception
+// tracking and inactivity watchdog are dropped here. A viewer still showing
+// `loading` is failed explicitly rather than left to spin — the watchdog that
+// would otherwise have surfaced it is gone with the tracking.
+function abortTranscriptFetchesOnSocketDrop(
+  set: (partial: Partial<ConnectionState> | ((s: ConnectionState) => Partial<ConnectionState>)) => void,
+  get: () => ConnectionState,
+): void {
+  resetTranscriptFetchTracking();
+  if (get().transcriptViewer.status === 'loading') {
+    set(state => ({
+      transcriptViewer: {
+        ...state.transcriptViewer,
+        status: 'error',
+        error: 'Connection lost before the transcript finished loading.',
+      },
+    }));
+  }
 }
 
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
@@ -2592,6 +2616,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // the still-armed callback so GitPanel's busy flag clears immediately
       // instead of spinning for up to the full 30s client-side timeout.
       clearGitOneshotCallbacks(set, get);
+      abortTranscriptFetchesOnSocketDrop(set, get);
       // #3605: also clear the per-session pendingTrustGrants arrays
       // (added in #3588). disconnect() handles user-initiated closes, but
       // an unexpected drop here would otherwise leave the SkillsPanel
@@ -2782,6 +2807,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6954: same fast-reject as onclose above — an errored socket means
       // any in-flight git one-shot reply will never arrive.
       clearGitOneshotCallbacks(set, get);
+      abortTranscriptFetchesOnSocketDrop(set, get);
       const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
       set({ socket: null, sessionStates: cleanedSessionStates });
@@ -2830,11 +2856,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     // Reset replay flags in case disconnect happened mid-replay
     resetReplayFlags();
-    // #6863 — drop any in-flight transcript fetch tracking so a stale
-    // conversationId from before the disconnect can't intercept frames on a
-    // later, unrelated connection.
+    // #6863 — drop any in-flight transcript fetch tracking (and its watchdog)
+    // so a stale conversationId from before the disconnect can't intercept
+    // frames on a later, unrelated connection.
     resetTranscriptFetchTracking();
-    clearTimeout(transcriptTimeoutId);
     // #5555.3/.4 — explicit disconnect is a hard reset: drop the replay
     // baseline AND the history cursors so a later connect (possibly to a
     // different server) starts from a full replay rather than presenting a
@@ -4671,7 +4696,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         error: null,
       },
     });
-    beginTranscriptFetch(conversationId);
+    // The inactivity watchdog is armed by the same call that arms
+    // interception, and every arriving frame restarts its window (see
+    // message-handler.ts). It fires ONLY when the stream is genuinely silent,
+    // so a large transcript that legitimately takes longer than the window to
+    // finish streaming is never mislabeled an error. Note this callback does
+    // NOT end the fetch: a timed-out id stays armed so any frames still on the
+    // wire keep being intercepted instead of leaking into live session state.
+    beginTranscriptFetch(conversationId, (timedOutId: string) => {
+      const state = get();
+      if (state.transcriptViewer.conversationId === timedOutId && state.transcriptViewer.status === 'loading') {
+        set({
+          transcriptViewer: { ...state.transcriptViewer, status: 'error', error: 'Timed out loading transcript.' },
+        });
+      }
+    });
     const isOpen = !!socket && socket.readyState === WebSocket.OPEN;
     const payload: Record<string, unknown> = { type: 'request_conversation_transcript', conversationId };
     if (cwd) payload.cwd = cwd;
@@ -4680,7 +4719,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // socket write) must not leave the viewer stuck in `loading`.
     const sent = isOpen && socket ? wsSend(socket, payload) : false;
     if (!sent) {
+      // Nothing reached the wire, so nothing can arrive for this request —
+      // this is the one path that may safely settle the fetch and disarm the
+      // watchdog immediately.
       endTranscriptFetch(conversationId);
+      clearTranscriptWatchdog(conversationId);
       if (get().transcriptViewer.conversationId === conversationId) {
         set(state => ({
           transcriptViewer: { ...state.transcriptViewer, status: 'error', error: 'Not connected to server.' },
@@ -4688,29 +4731,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       }
       return;
     }
-    // request_conversation_transcript has no dedicated failure echo (a
-    // rejection — missing/invalid id, not authorized, not found — arrives as
-    // a generic `session_error{message}` with no correlating id we can match
-    // against this specific fetch). Mirror searchConversations' watchdog: if
-    // still `loading` after the window, surface a timeout rather than
-    // spinning forever. Any session_error DOES still reach the generic
-    // handler in the meantime and shows its own toast.
-    clearTimeout(transcriptTimeoutId);
-    transcriptTimeoutId = setTimeout(() => {
-      endTranscriptFetch(conversationId);
-      const state = get();
-      if (state.transcriptViewer.conversationId === conversationId && state.transcriptViewer.status === 'loading') {
-        set({
-          transcriptViewer: { ...state.transcriptViewer, status: 'error', error: 'Timed out loading transcript.' },
-        });
-      }
-    }, TRANSCRIPT_FETCH_TIMEOUT_MS);
   },
 
   closeTranscriptViewer: () => {
+    // Closing stops RENDERING, not INTERCEPTING. The conversationId stays in
+    // message-handler.ts's pending set until its own `history_replay_end`
+    // (or a socket drop / reset), because frames that arrive after a
+    // mid-stream disarm are NOT inert — a `message` would land in the flat
+    // `messages` list as live chat, and a late `history_replay_start` would
+    // wipe the live session's `activeAgents` and cancel a pending plan
+    // approval (`isPlanPending` / `planAllowedPrompts`). With the id still
+    // armed, `applyTranscriptFrame` sees no matching displayed viewer and
+    // discards the frame. The watchdog IS disarmed: no error may surface for
+    // a viewer the user has already closed.
     const current = get().transcriptViewer;
-    if (current.conversationId) endTranscriptFetch(current.conversationId);
-    clearTimeout(transcriptTimeoutId);
+    if (current.conversationId) clearTranscriptWatchdog(current.conversationId);
     set({ transcriptViewer: EMPTY_TRANSCRIPT_VIEWER });
   },
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -45,6 +45,9 @@ import {
   clearPendingThinkingLevelReverts,
   _testThinkingLevelRevertPendingSize,
   setDeltaFlushIntervalOverride,
+  beginTranscriptFetch,
+  endTranscriptFetch,
+  resetTranscriptFetchTracking,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
@@ -166,6 +169,9 @@ describe('dashboard message-handler dispatch', () => {
     // #3587: reset the in-flight skill_trust_grant tracking map between
     // tests so a leftover entry from one case doesn't leak into another.
     clearPendingTrustGrants()
+    // #6863 — reset transcript-fetch pending-id tracking between tests so a
+    // leftover conversationId from one case doesn't intercept frames in another.
+    resetTranscriptFetchTracking()
     mockSocket = createMockSocket()
     store = createMockStore(baseState())
     setStore(store)
@@ -3314,6 +3320,142 @@ describe('dashboard message-handler dispatch', () => {
       )
       const msgs = (store.getState() as any).sessionStates.s1.messages
       expect(msgs).toHaveLength(0)
+    })
+  })
+
+  // #6863 (epic #6765) — read-only transcript viewer. The server's
+  // request_conversation_transcript handler (#6860) reuses the EXACT SAME
+  // history_replay_start/message/history_replay_end frames a live session's
+  // replay uses, distinguished only by sessionId carrying a conversationId
+  // with no matching live session. These tests pin the interception that
+  // keeps those frames OUT of sessionStates/addMessage entirely — the main
+  // risk this feature introduces (see applyTranscriptFrame's doc comment in
+  // message-handler.ts).
+  describe('transcript viewer frame interception (#6863)', () => {
+    const TRANSCRIPT_ID = 'conv-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+    function emptyTranscriptViewer() {
+      return { conversationId: null, status: 'idle' as const, messages: [], error: null }
+    }
+
+    // Seeds a LIVE session so the dangerous fallback path
+    // (`get().addMessage`) has somewhere to corrupt if interception fails,
+    // plus a top-level `messages`/`addMessage` pair to catch the flat-state
+    // fallback too.
+    function seedWithLiveSessionAndPendingTranscript(viewerOverrides: Record<string, unknown> = {}) {
+      const flatMessages: unknown[] = []
+      const seeded = baseState({
+        activeSessionId: 'live-1',
+        sessions: [{ sessionId: 'live-1', name: 'Live' } as any],
+        sessionStates: { 'live-1': createEmptySessionState() },
+      }) as Record<string, unknown>
+      seeded.messages = flatMessages
+      seeded.transcriptViewer = { ...emptyTranscriptViewer(), ...viewerOverrides }
+      seeded.addMessage = (m: unknown) => {
+        const s = store.getState() as { messages: unknown[] }
+        ;(store as { setState: (p: Record<string, unknown>) => void }).setState({
+          messages: [...s.messages, m],
+        })
+      }
+      store = createMockStore(seeded)
+      setStore(store)
+      beginTranscriptFetch(TRANSCRIPT_ID)
+    }
+
+    afterEach(() => {
+      endTranscriptFetch(TRANSCRIPT_ID)
+    })
+
+    it('routes history_replay_start/message/history_replay_end into transcriptViewer, never sessionStates or addMessage', () => {
+      seedWithLiveSessionAndPendingTranscript({ conversationId: TRANSCRIPT_ID, status: 'loading' })
+
+      handleMessage({ type: 'history_replay_start', sessionId: TRANSCRIPT_ID, conversationId: TRANSCRIPT_ID }, ctx() as any)
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'user_input',
+          content: 'what does this do',
+          sessionId: TRANSCRIPT_ID,
+          timestamp: 100,
+        },
+        ctx() as any,
+      )
+      handleMessage(
+        {
+          type: 'message',
+          messageType: 'response',
+          content: 'it reads a file',
+          sessionId: TRANSCRIPT_ID,
+          timestamp: 200,
+        },
+        ctx() as any,
+      )
+      handleMessage({ type: 'history_replay_end', sessionId: TRANSCRIPT_ID }, ctx() as any)
+
+      const state = store.getState() as any
+      // The live session and the flat fallback must be completely untouched.
+      expect(state.sessionStates['live-1'].messages).toHaveLength(0)
+      expect(state.messages).toHaveLength(0)
+      // The transcript viewer got everything instead.
+      expect(state.transcriptViewer.status).toBe('ready')
+      expect(state.transcriptViewer.messages).toHaveLength(2)
+      expect(state.transcriptViewer.messages[0].content).toBe('what does this do')
+      expect(state.transcriptViewer.messages[1].content).toBe('it reads a file')
+    })
+
+    it('a normal live-session replay for an UNRELATED sessionId is unaffected by transcript tracking', () => {
+      seedWithLiveSessionAndPendingTranscript({ conversationId: TRANSCRIPT_ID, status: 'loading' })
+
+      // live-1's OWN replay, interleaved with the transcript fetch above —
+      // must still land in sessionStates exactly as before this feature.
+      handleMessage({ type: 'history_replay_start', sessionId: 'live-1' }, ctx() as any)
+      handleMessage(
+        { type: 'message', messageType: 'user_input', content: 'live message', sessionId: 'live-1', timestamp: 50 },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.sessionStates['live-1'].messages).toHaveLength(1)
+      expect(state.sessionStates['live-1'].messages[0].content).toBe('live message')
+      // The transcript viewer wasn't touched by live-1's replay.
+      expect(state.transcriptViewer.messages).toHaveLength(0)
+    })
+
+    it('discards late frames from a SUPERSEDED fetch instead of misfiling them into the live session or the newly-displayed viewer', () => {
+      const OTHER_ID = 'conv-11111111-2222-3333-4444-555555555555'
+      seedWithLiveSessionAndPendingTranscript({ conversationId: OTHER_ID, status: 'ready' })
+      // TRANSCRIPT_ID's fetch is still "pending" (begun in the seed helper)
+      // even though the viewer has moved on to display OTHER_ID.
+
+      handleMessage({ type: 'history_replay_start', sessionId: TRANSCRIPT_ID, conversationId: TRANSCRIPT_ID }, ctx() as any)
+      handleMessage(
+        { type: 'message', messageType: 'response', content: 'stale reply', sessionId: TRANSCRIPT_ID, timestamp: 10 },
+        ctx() as any,
+      )
+      handleMessage({ type: 'history_replay_end', sessionId: TRANSCRIPT_ID }, ctx() as any)
+
+      const state = store.getState() as any
+      // Swallowed entirely — never reached sessionStates/addMessage...
+      expect(state.sessionStates['live-1'].messages).toHaveLength(0)
+      expect(state.messages).toHaveLength(0)
+      // ...and never leaked into the viewer that's actually displayed.
+      expect(state.transcriptViewer.conversationId).toBe(OTHER_ID)
+      expect(state.transcriptViewer.messages).toHaveLength(0)
+    })
+
+    it('endTranscriptFetch stops interception — a later frame for the same id falls through normally', () => {
+      seedWithLiveSessionAndPendingTranscript({ conversationId: TRANSCRIPT_ID, status: 'ready' })
+      endTranscriptFetch(TRANSCRIPT_ID)
+
+      // No live session with this id and no pending tracking — the frame now
+      // falls through to the ordinary switch, where the 'message' case's
+      // flat-fallback (`get().addMessage`) is expected, pre-existing
+      // behavior (NOT a #6863 regression) for an unrecognized sessionId.
+      handleMessage(
+        { type: 'message', messageType: 'response', content: 'post-fetch', sessionId: TRANSCRIPT_ID, timestamp: 10 },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.transcriptViewer.messages).toHaveLength(0)
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -694,6 +694,97 @@ export function resetReplayFlags(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Read-only transcript viewer (#6863, epic #6765)
+// ---------------------------------------------------------------------------
+// The server's `request_conversation_transcript` handler (#6860) streams a
+// CLOSED conversation's history back using the EXACT SAME `history_replay_start`
+// / `message` / `history_replay_end` wire frames a live session's replay uses —
+// the only difference is `sessionId` carries a conversationId with no matching
+// entry in `sessionStates` (the conversation has no live session; nothing was
+// spawned). Routing those frames through the switch below unmodified would
+// silently misfile them: the `'message'` case falls back to
+// `get().addMessage(newMsg)` — appending into whatever session IS currently
+// active — whenever `sessionStates[targetId]` doesn't exist. A transcript fetch
+// must never touch `sessionStates`, the replay dedup cache, or
+// `_replayingSessions`, so a matching frame is diverted at the top of
+// `handleMessage` into the dedicated `transcriptViewer` store slice instead
+// (see the interception guard there and `applyTranscriptFrame` below).
+//
+// Membership in `_pendingTranscriptIds` — NOT whether the id equals the
+// store's CURRENTLY DISPLAYED `transcriptViewer.conversationId` — decides
+// whether a frame gets diverted here at all. The viewer can move on to a
+// DIFFERENT conversation (View A, close, View B) before A's fetch finishes;
+// using only "currently displayed" as the interception key would let A's late
+// frames fall through into the live-session switch once B is displayed. Every
+// conversationId this client has ever sent `request_conversation_transcript`
+// for — and not yet seen `history_replay_end` for — stays in this set, so its
+// frames are ALWAYS diverted; `applyTranscriptFrame` separately decides
+// whether to apply them to visible state (id matches the displayed viewer) or
+// just discard them (a superseded fetch).
+const _pendingTranscriptIds = new Set<string>();
+
+/** Start tracking a transcript fetch — call right before sending the request. */
+export function beginTranscriptFetch(conversationId: string): void {
+  _pendingTranscriptIds.add(conversationId);
+}
+
+/** Stop tracking a transcript fetch — call on completion, close, or timeout. */
+export function endTranscriptFetch(conversationId: string): void {
+  _pendingTranscriptIds.delete(conversationId);
+}
+
+function isTranscriptFramePending(sessionId: string): boolean {
+  return _pendingTranscriptIds.has(sessionId);
+}
+
+/** Full reset — mirrors `resetReplayFlags` on a hard disconnect. */
+export function resetTranscriptFetchTracking(): void {
+  _pendingTranscriptIds.clear();
+}
+
+/**
+ * Apply a diverted `history_replay_start` / `message` / `history_replay_end`
+ * frame to the `transcriptViewer` store slice — NEVER to `sessionStates`, the
+ * replay dedup cache, or `_replayingSessions`. See the `_pendingTranscriptIds`
+ * doc above for why this is reached via the pending set, not the displayed
+ * conversationId.
+ */
+function applyTranscriptFrame(msg: Record<string, unknown>, get: MsgGet, set: MsgSet): void {
+  const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+  // The fetch completed — stop tracking it regardless of whether it's still
+  // the displayed viewer (a superseded fetch's end frame must also clear its
+  // pending entry, or it would wedge `_pendingTranscriptIds` forever).
+  if (msg.type === 'history_replay_end' && sessionId) endTranscriptFetch(sessionId);
+
+  const viewer = get().transcriptViewer;
+  // Not the conversation currently displayed (either a superseded fetch, or a
+  // malformed frame with no sessionId) — swallow it here rather than falling
+  // through to the live-session switch, but don't touch visible state.
+  if (!sessionId || viewer.conversationId !== sessionId) return;
+
+  if (msg.type === 'history_replay_start') {
+    set({ transcriptViewer: { ...viewer, status: 'loading', messages: [], error: null } });
+    return;
+  }
+  if (msg.type === 'history_replay_end') {
+    set({ transcriptViewer: { ...viewer, status: 'ready' } });
+    return;
+  }
+  // msg.type === 'message' — reuse the same pure parser live messages use.
+  // receivingHistoryReplay=true applies the same dedup-against-cache logic a
+  // live replay gets; activeSessionId is irrelevant here (unused by the
+  // parser) so null is passed.
+  const result = sharedMessageHandler(msg, null, true, viewer.messages);
+  if (!result.shouldDispatch) return;
+  set({
+    transcriptViewer: {
+      ...viewer,
+      messages: [...viewer.messages, result.chatMessage],
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Permission boundary message splitting (#554)
 // ---------------------------------------------------------------------------
 const _postPermissionSplits = new Set<string>();
@@ -3647,6 +3738,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   const get = () => getStore().getState();
   const set: (s: Partial<ConnectionState> | ((state: ConnectionState) => Partial<ConnectionState>)) => void =
     (s) => getStore().setState(s as ConnectionState);
+
+  // #6863 — read-only transcript viewer interception. MUST run before the
+  // activity-bump block, runDispatch, and the HANDLERS map/switch below —
+  // every one of those keys off `sessionStates`, which a transcript's
+  // conversationId never has an entry in. See `applyTranscriptFrame`'s doc
+  // comment (near `_pendingTranscriptIds`, above) for the full rationale.
+  if (
+    (msg.type === 'history_replay_start' || msg.type === 'message' || msg.type === 'history_replay_end') &&
+    typeof msg.sessionId === 'string' &&
+    isTranscriptFramePending(msg.sessionId)
+  ) {
+    applyTranscriptFrame(msg, get, set);
+    return;
+  }
 
   // #3758 — bump lastClientActivityAt for activity-bearing events BEFORE
   // any per-case handler runs. Doing it here keeps the bump in one place

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -710,36 +710,149 @@ export function resetReplayFlags(): void {
 // `handleMessage` into the dedicated `transcriptViewer` store slice instead
 // (see the interception guard there and `applyTranscriptFrame` below).
 //
-// Membership in `_pendingTranscriptIds` — NOT whether the id equals the
+// Membership in `_pendingTranscriptFetches` — NOT whether the id equals the
 // store's CURRENTLY DISPLAYED `transcriptViewer.conversationId` — decides
 // whether a frame gets diverted here at all. The viewer can move on to a
 // DIFFERENT conversation (View A, close, View B) before A's fetch finishes;
 // using only "currently displayed" as the interception key would let A's late
-// frames fall through into the live-session switch once B is displayed. Every
-// conversationId this client has ever sent `request_conversation_transcript`
-// for — and not yet seen `history_replay_end` for — stays in this set, so its
-// frames are ALWAYS diverted; `applyTranscriptFrame` separately decides
-// whether to apply them to visible state (id matches the displayed viewer) or
-// just discard them (a superseded fetch).
-const _pendingTranscriptIds = new Set<string>();
+// frames fall through into the live-session switch once B is displayed.
+// `applyTranscriptFrame` separately decides whether to apply a diverted frame
+// to visible state (id matches the displayed viewer) or just discard it (a
+// superseded fetch, or a fetch whose viewer has since been closed).
+//
+// ARMING LIFETIME — an id stays armed from the moment its request is sent
+// until its OWN `history_replay_end` arrives (or the socket drops / an
+// explicit reset). Closing the viewer, the watchdog firing, and Retry must
+// NOT disarm it mid-stream: frames arriving after a disarm are not inert.
+// A `message` frame would fall through the switch below to its flat
+// `get().addMessage(...)` fallback (transcript text rendered as live chat),
+// and a late `history_replay_start` would reach `updateActiveSession`, which
+// WIPES the live session's `activeAgents` and cancels `isPlanPending` /
+// `planAllowedPrompts` — i.e. opening and closing the read-only viewer could
+// silently drop a pending plan approval. So: closing the viewer stops
+// RENDERING, never INTERCEPTING.
+//
+// Arming is REFCOUNTED per id because Retry re-requests the SAME
+// conversationId while stream 1 may still be on the wire — stream 1's
+// `history_replay_end` must not disarm an id the retry still has an
+// outstanding request for. The map is insertion-ordered and capped
+// (`TRANSCRIPT_PENDING_CAP`) so a fetch that never sees an end frame (a
+// server-side rejection, a mid-stream drop) can't accumulate unbounded.
+//
+// NAMESPACE DISJOINTNESS (invariant this interception relies on) — the
+// interception key is the frame's `sessionId`, which carries a conversationId
+// for a transcript fetch and a live session id for a replay. That is only
+// safe because the two namespaces cannot collide: the server mints live
+// session ids as 32-char hex (`session-manager.js` — `randomBytes(16)
+// .toString('hex')`), while conversationIds are the dashed UUIDs it reads off
+// disk. Two defensive checks keep a future id-format change failing SAFE
+// (toward live state, the direction that can't corrupt a session) instead of
+// silently cross-wiring: an id shaped like a live session id is never treated
+// as a transcript id (`isTranscriptFramePending` below), and `handleMessage`
+// additionally refuses to divert any frame whose sessionId HAS a live
+// `sessionStates` entry.
+const _pendingTranscriptFetches = new Map<string, number>();
+const TRANSCRIPT_PENDING_CAP = 32;
+/** Live session ids are 32-char hex; a conversationId never is. */
+const LIVE_SESSION_ID_SHAPE = /^[0-9a-f]{32}$/i;
 
-/** Start tracking a transcript fetch — call right before sending the request. */
-export function beginTranscriptFetch(conversationId: string): void {
-  _pendingTranscriptIds.add(conversationId);
+// Inactivity watchdog. `request_conversation_transcript` has no dedicated
+// failure echo (a rejection arrives as a generic `session_error{message}`
+// with no correlating id — a per-request correlation id / dedicated failure
+// echo needs a protocol change, tracked in #7007), so a fetch that goes
+// SILENT is surfaced as an error instead of spinning forever. It is an
+// INACTIVITY timer, not a deadline: every diverted frame for the id re-arms
+// it, so a healthy large transcript streaming for longer than the window is
+// never mislabeled an error. Cleared on `history_replay_end` (success), on
+// close, on a failed send, and on reset — no path leaves it armed (#6933).
+const TRANSCRIPT_INACTIVITY_MS = 15000;
+let _transcriptWatchdog: {
+  conversationId: string;
+  timer: ReturnType<typeof setTimeout>;
+  onTimeout: (conversationId: string) => void;
+} | null = null;
+
+function armTranscriptWatchdog(conversationId: string, onTimeout: (conversationId: string) => void): void {
+  clearTranscriptWatchdog();
+  _transcriptWatchdog = {
+    conversationId,
+    onTimeout,
+    timer: setTimeout(() => {
+      _transcriptWatchdog = null;
+      onTimeout(conversationId);
+    }, TRANSCRIPT_INACTIVITY_MS),
+  };
 }
 
-/** Stop tracking a transcript fetch — call on completion, close, or timeout. */
+/**
+ * Frame arrived for `conversationId` — restart its inactivity window. No-op
+ * for any other id (a superseded fetch's frames must not keep the current
+ * fetch's watchdog alive).
+ */
+function touchTranscriptWatchdog(conversationId: string): void {
+  const current = _transcriptWatchdog;
+  if (!current || current.conversationId !== conversationId) return;
+  armTranscriptWatchdog(conversationId, current.onTimeout);
+}
+
+/**
+ * Disarm the watchdog (optionally only if it belongs to `conversationId`).
+ * Exported so connection.ts can stop it on close — which must stop the error
+ * timer WITHOUT disarming interception.
+ */
+export function clearTranscriptWatchdog(conversationId?: string): void {
+  if (!_transcriptWatchdog) return;
+  if (conversationId && _transcriptWatchdog.conversationId !== conversationId) return;
+  clearTimeout(_transcriptWatchdog.timer);
+  _transcriptWatchdog = null;
+}
+
+/**
+ * Start tracking a transcript fetch — call right before sending the request.
+ * `onInactivityTimeout` (if given) fires when no frame for this id has
+ * arrived for `TRANSCRIPT_INACTIVITY_MS`.
+ */
+export function beginTranscriptFetch(
+  conversationId: string,
+  onInactivityTimeout?: (conversationId: string) => void,
+): void {
+  const outstanding = _pendingTranscriptFetches.get(conversationId);
+  _pendingTranscriptFetches.set(conversationId, (outstanding ?? 0) + 1);
+  if (outstanding === undefined) {
+    // Bounded: drop the oldest still-armed ids (insertion order) rather than
+    // growing forever when a fetch never gets its end frame.
+    while (_pendingTranscriptFetches.size > TRANSCRIPT_PENDING_CAP) {
+      const oldest = _pendingTranscriptFetches.keys().next();
+      if (oldest.done || oldest.value === conversationId) break;
+      _pendingTranscriptFetches.delete(oldest.value);
+    }
+  }
+  if (onInactivityTimeout) armTranscriptWatchdog(conversationId, onInactivityTimeout);
+}
+
+/**
+ * One outstanding request for this id has concluded — its `history_replay_end`
+ * arrived, or the send failed so nothing is coming. Refcounted: the id stays
+ * armed while a retry's request is still outstanding.
+ */
 export function endTranscriptFetch(conversationId: string): void {
-  _pendingTranscriptIds.delete(conversationId);
+  const outstanding = _pendingTranscriptFetches.get(conversationId);
+  if (outstanding === undefined) return;
+  if (outstanding <= 1) _pendingTranscriptFetches.delete(conversationId);
+  else _pendingTranscriptFetches.set(conversationId, outstanding - 1);
 }
 
 function isTranscriptFramePending(sessionId: string): boolean {
-  return _pendingTranscriptIds.has(sessionId);
+  // Shape check is defensive, not the discriminator — see the namespace
+  // disjointness note above.
+  if (LIVE_SESSION_ID_SHAPE.test(sessionId)) return false;
+  return _pendingTranscriptFetches.has(sessionId);
 }
 
-/** Full reset — mirrors `resetReplayFlags` on a hard disconnect. */
+/** Full reset — mirrors `resetReplayFlags` on a hard disconnect / socket drop. */
 export function resetTranscriptFetchTracking(): void {
-  _pendingTranscriptIds.clear();
+  _pendingTranscriptFetches.clear();
+  clearTranscriptWatchdog();
 }
 
 /**
@@ -751,15 +864,31 @@ export function resetTranscriptFetchTracking(): void {
  */
 function applyTranscriptFrame(msg: Record<string, unknown>, get: MsgGet, set: MsgSet): void {
   const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
-  // The fetch completed — stop tracking it regardless of whether it's still
-  // the displayed viewer (a superseded fetch's end frame must also clear its
-  // pending entry, or it would wedge `_pendingTranscriptIds` forever).
-  if (msg.type === 'history_replay_end' && sessionId) endTranscriptFetch(sessionId);
+  if (sessionId) {
+    if (msg.type === 'history_replay_end') {
+      // The fetch completed — drop one outstanding request regardless of
+      // whether it's still the displayed viewer (a superseded fetch's end
+      // frame must also settle, or it would wedge `_pendingTranscriptFetches`
+      // forever).
+      endTranscriptFetch(sessionId);
+      // Success clears the watchdog explicitly — unless a Retry has another
+      // request for the same id still outstanding, in which case this end
+      // frame is just activity and the window restarts for stream 2.
+      if (_pendingTranscriptFetches.has(sessionId)) touchTranscriptWatchdog(sessionId);
+      else clearTranscriptWatchdog(sessionId);
+    } else {
+      // Any frame is proof of life — restart the inactivity window so a
+      // healthy large transcript is never mislabeled a timeout.
+      touchTranscriptWatchdog(sessionId);
+    }
+  }
 
   const viewer = get().transcriptViewer;
-  // Not the conversation currently displayed (either a superseded fetch, or a
-  // malformed frame with no sessionId) — swallow it here rather than falling
-  // through to the live-session switch, but don't touch visible state.
+  // Not the conversation currently displayed — a superseded fetch, a fetch
+  // whose viewer the user has since CLOSED, or a malformed frame with no
+  // sessionId. Swallow it here rather than falling through to the
+  // live-session switch, but don't touch visible state. This is what makes
+  // "keep intercepting after close" inert instead of merely quiet.
   if (!sessionId || viewer.conversationId !== sessionId) return;
 
   if (msg.type === 'history_replay_start') {
@@ -3743,11 +3872,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // activity-bump block, runDispatch, and the HANDLERS map/switch below —
   // every one of those keys off `sessionStates`, which a transcript's
   // conversationId never has an entry in. See `applyTranscriptFrame`'s doc
-  // comment (near `_pendingTranscriptIds`, above) for the full rationale.
+  // comment (near `_pendingTranscriptFetches`, above) for the full rationale,
+  // including the id-namespace invariant the `!get().sessionStates[...]`
+  // fail-safe below defends: a frame for a KNOWN LIVE session is never
+  // diverted, whatever the pending set says.
   if (
     (msg.type === 'history_replay_start' || msg.type === 'message' || msg.type === 'history_replay_end') &&
     typeof msg.sessionId === 'string' &&
-    isTranscriptFramePending(msg.sessionId)
+    isTranscriptFramePending(msg.sessionId) &&
+    !get().sessionStates[msg.sessionId]
   ) {
     applyTranscriptFrame(msg, get, set);
     return;

--- a/packages/dashboard/src/store/transcript-viewer-actions.test.ts
+++ b/packages/dashboard/src/store/transcript-viewer-actions.test.ts
@@ -176,3 +176,313 @@ describe('requestConversationTranscript / closeTranscriptViewer (#6863)', () => 
     expect(viewer.messages).toEqual([])
   })
 })
+
+/**
+ * #7000 CRITICAL 1 — the interception guard's LIFETIME.
+ *
+ * Frames arriving for a conversationId that is no longer armed are NOT inert:
+ * a `message` falls through to the switch's flat `addMessage` fallback
+ * (transcript text rendered as live chat) and a late `history_replay_start`
+ * reaches `updateActiveSession`, which wipes the live session's `activeAgents`
+ * and cancels `isPlanPending` / `planAllowedPrompts` — so a mid-stream disarm
+ * could silently DROP A PENDING PLAN APPROVAL. Closing the viewer, the
+ * watchdog firing, and Retry each used to disarm mid-stream; each of those
+ * three sequences is pinned below.
+ */
+describe('transcript frames stay intercepted until their own history_replay_end (#7000 C1)', () => {
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: undefined, isReconnect: false, silent: false })
+  const LIVE_ID = 'live-1'
+  const CONV_ID = 'conv-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    const { resetTranscriptFetchTracking } = await import('./message-handler')
+    resetTranscriptFetchTracking()
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    const { resetTranscriptFetchTracking } = await import('./message-handler')
+    resetTranscriptFetchTracking()
+  })
+
+  /**
+   * A live session mid-turn with a sub-agent running AND a plan approval
+   * awaiting the user — i.e. exactly the state a leaked frame destroys.
+   */
+  async function seedLiveSessionWithPendingPlan() {
+    const { useConnectionStore, createEmptySessionState } = await import('./connection')
+    const { handleMessage } = await import('./message-handler')
+    const socket = createMockSocket()
+    useConnectionStore.setState({
+      socket,
+      activeSessionId: LIVE_ID,
+      sessions: [{ sessionId: LIVE_ID, name: 'Live' }],
+      sessionStates: {
+        [LIVE_ID]: {
+          ...createEmptySessionState(),
+          activeAgents: [{ toolUseId: 'agent-1', description: 'sub-agent', startedAt: 1 }],
+          isPlanPending: true,
+          planAllowedPrompts: [{ tool: 'ExitPlanMode', prompt: 'ship it' }],
+        },
+      },
+      messages: [],
+      transcriptViewer: { conversationId: null, status: 'idle', messages: [], error: null },
+    } as never)
+    return { useConnectionStore, handleMessage }
+  }
+
+  /** The two frame kinds that can do damage, delivered AFTER the trigger. */
+  function deliverLateFrames(handleMessage: (raw: unknown, ctxOverride?: never) => void) {
+    handleMessage(
+      { type: 'message', messageType: 'response', content: 'late transcript line', sessionId: CONV_ID, timestamp: 99 },
+      ctx() as never,
+    )
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+  }
+
+  function expectLiveStateUntouched(store: { getState: () => Record<string, never> }) {
+    const state = store.getState() as unknown as {
+      messages: unknown[]
+      sessionStates: Record<string, { messages: unknown[]; activeAgents: unknown[]; isPlanPending: boolean; planAllowedPrompts: unknown[] }>
+    }
+    // Flat fallback (`addMessage`) never fired...
+    expect(state.messages).toHaveLength(0)
+    const ss = state.sessionStates[LIVE_ID]!
+    expect(ss.messages).toHaveLength(0)
+    // ...and the live session's transient state survived intact. The plan
+    // fields are the user-visible harm: a dropped approval leaves the user
+    // with no way to answer a plan the agent is still blocked on.
+    expect(ss.activeAgents).toHaveLength(1)
+    expect(ss.isPlanPending).toBe(true)
+    expect(ss.planAllowedPrompts).toHaveLength(1)
+  }
+
+  it('close mid-stream: late frames are still intercepted, live session + pending plan untouched', async () => {
+    const { useConnectionStore, handleMessage } = await seedLiveSessionWithPendingPlan()
+
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+    handleMessage(
+      { type: 'message', messageType: 'response', content: 'first line', sessionId: CONV_ID, timestamp: 1 },
+      ctx() as never,
+    )
+
+    // User closes the viewer while the server is still streaming.
+    useConnectionStore.getState().closeTranscriptViewer()
+    deliverLateFrames(handleMessage)
+
+    expectLiveStateUntouched(useConnectionStore as never)
+    // Closing stops RENDERING: the closed viewer is not re-populated either.
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.conversationId).toBeNull()
+    expect(viewer.status).toBe('idle')
+    expect(viewer.messages).toEqual([])
+  })
+
+  it('opening and closing the viewer can no longer drop a pending plan approval', async () => {
+    // The narrowest statement of the user-visible harm, asserted on its own
+    // (the broader sequences above trip on the flat-message leak first): a
+    // single late history_replay_start reaches updateActiveSession, which
+    // cancels isPlanPending / planAllowedPrompts for the ACTIVE session —
+    // leaving the user unable to answer a plan the agent is still blocked on.
+    const { useConnectionStore, handleMessage } = await seedLiveSessionWithPendingPlan()
+
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    useConnectionStore.getState().closeTranscriptViewer()
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+
+    const ss = useConnectionStore.getState().sessionStates[LIVE_ID]!
+    expect(ss.isPlanPending).toBe(true)
+    expect(ss.planAllowedPrompts).toHaveLength(1)
+    expect(ss.activeAgents).toHaveLength(1)
+  })
+
+  it('watchdog fires mid-stream: late frames are still intercepted, live session + pending plan untouched', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore, handleMessage } = await seedLiveSessionWithPendingPlan()
+
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+
+    // Stream stalls long enough for the watchdog to surface an error...
+    vi.advanceTimersByTime(15_000)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('error')
+
+    // ...then the server's frames finally show up.
+    deliverLateFrames(handleMessage)
+
+    expectLiveStateUntouched(useConnectionStore as never)
+    vi.useRealTimers()
+  })
+
+  it('retry mid-stream: the first stream\'s end frame does not disarm the retry, live session + pending plan untouched', async () => {
+    const { useConnectionStore, handleMessage } = await seedLiveSessionWithPendingPlan()
+
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+
+    // Retry re-requests the SAME id while stream 1 is still on the wire.
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    // Stream 1's end frame arrives — it must settle only ITS request, leaving
+    // the retry's request armed (refcounted arming).
+    handleMessage({ type: 'history_replay_end', sessionId: CONV_ID }, ctx() as never)
+
+    // Stream 2's frames, still owed. Delivered one at a time so both the
+    // "still intercepted" and "live state untouched" halves are visible: the
+    // message lands in the VIEWER (not the flat list), and the late
+    // history_replay_start restarts the viewer instead of wiping the live
+    // session's transient state.
+    handleMessage(
+      { type: 'message', messageType: 'response', content: 'late transcript line', sessionId: CONV_ID, timestamp: 99 },
+      ctx() as never,
+    )
+    expect(useConnectionStore.getState().transcriptViewer.messages.map(m => m.content)).toEqual([
+      'late transcript line',
+    ])
+    expectLiveStateUntouched(useConnectionStore as never)
+
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+
+    expectLiveStateUntouched(useConnectionStore as never)
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.conversationId).toBe(CONV_ID)
+    expect(viewer.status).toBe('loading')
+    expect(viewer.messages).toEqual([])
+  })
+
+  it('a live session id is never treated as a transcript id, even if armed (namespace fail-safe)', async () => {
+    const { useConnectionStore, handleMessage } = await seedLiveSessionWithPendingPlan()
+    const { beginTranscriptFetch } = await import('./message-handler')
+
+    // Pathological: the live session's id somehow lands in the pending set.
+    beginTranscriptFetch(LIVE_ID)
+    useConnectionStore.setState({
+      transcriptViewer: { conversationId: LIVE_ID, status: 'loading', messages: [], error: null },
+    } as never)
+
+    handleMessage(
+      { type: 'message', messageType: 'response', content: 'live reply', sessionId: LIVE_ID, timestamp: 5 },
+      ctx() as never,
+    )
+
+    // The live session — not the viewer — received it.
+    const state = useConnectionStore.getState()
+    expect(state.sessionStates[LIVE_ID]!.messages).toHaveLength(1)
+    expect(state.transcriptViewer.messages).toHaveLength(0)
+  })
+})
+
+/**
+ * #7000 CRITICAL 3 — the watchdog is an INACTIVITY timer, not a deadline.
+ * The server streams a large transcript in one unchunked loop, so a fixed
+ * deadline mislabels a perfectly healthy large-transcript stream an error.
+ * (A per-request correlation id / dedicated failure echo would remove the
+ * need for a watchdog entirely — that needs a protocol change, tracked in
+ * #7007.)
+ */
+describe('transcript watchdog is inactivity-based (#7000 C3)', () => {
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: undefined, isReconnect: false, silent: false })
+  const CONV_ID = 'conv-77777777-8888-9999-aaaa-bbbbbbbbbbbb'
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    const { resetTranscriptFetchTracking } = await import('./message-handler')
+    resetTranscriptFetchTracking()
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    const { resetTranscriptFetchTracking } = await import('./message-handler')
+    resetTranscriptFetchTracking()
+  })
+
+  async function startFetch() {
+    const { useConnectionStore } = await import('./connection')
+    const { handleMessage } = await import('./message-handler')
+    useConnectionStore.setState({
+      socket: createMockSocket(),
+      transcriptViewer: { conversationId: null, status: 'idle', messages: [], error: null },
+    } as never)
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    return { useConnectionStore, handleMessage }
+  }
+
+  it('a big transcript streaming steadily past the window is NOT mislabeled an error', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore, handleMessage } = await startFetch()
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+
+    // 5 × 12s of steady progress = 60s total, well past the 15s window.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(12_000)
+      handleMessage(
+        { type: 'message', messageType: 'response', content: `line ${i}`, sessionId: CONV_ID, timestamp: i },
+        ctx() as never,
+      )
+      expect(useConnectionStore.getState().transcriptViewer.status).toBe('loading')
+      expect(useConnectionStore.getState().transcriptViewer.error).toBeNull()
+    }
+
+    handleMessage({ type: 'history_replay_end', sessionId: CONV_ID }, ctx() as never)
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.status).toBe('ready')
+    expect(viewer.messages).toHaveLength(5)
+    vi.useRealTimers()
+  })
+
+  it('genuine silence past the window DOES surface the timeout', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore, handleMessage } = await startFetch()
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+
+    vi.advanceTimersByTime(14_999)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('loading')
+    vi.advanceTimersByTime(1)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('error')
+    expect(useConnectionStore.getState().transcriptViewer.error).toMatch(/timed out/i)
+    vi.useRealTimers()
+  })
+
+  it('history_replay_end clears the timer — no late error can fire after success', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore, handleMessage } = await startFetch()
+    handleMessage({ type: 'history_replay_start', sessionId: CONV_ID, conversationId: CONV_ID }, ctx() as never)
+    handleMessage({ type: 'history_replay_end', sessionId: CONV_ID }, ctx() as never)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('ready')
+
+    vi.advanceTimersByTime(120_000)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('ready')
+    vi.useRealTimers()
+  })
+
+  it('closing the viewer clears the timer — no error fires for a viewer the user already closed', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore } = await startFetch()
+
+    useConnectionStore.getState().closeTranscriptViewer()
+    vi.advanceTimersByTime(120_000)
+
+    // No leaked timer (#6933) and no error state resurrected behind the user.
+    expect(vi.getTimerCount()).toBe(0)
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.status).toBe('idle')
+    expect(viewer.error).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('a failed send leaves no armed timer', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      socket: null,
+      transcriptViewer: { conversationId: null, status: 'idle', messages: [], error: null },
+    } as never)
+
+    useConnectionStore.getState().requestConversationTranscript(CONV_ID)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('error')
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+})

--- a/packages/dashboard/src/store/transcript-viewer-actions.test.ts
+++ b/packages/dashboard/src/store/transcript-viewer-actions.test.ts
@@ -1,0 +1,178 @@
+/**
+ * requestConversationTranscript / closeTranscriptViewer store actions
+ * (#6863, epic #6765).
+ *
+ * Covers the send-side of the read-only transcript viewer: the wire payload
+ * sent for `request_conversation_transcript` (#6860), the loading/error/timeout
+ * transitions, and the end-to-end flow through `handleMessage` (connection.ts
+ * wires message-handler.ts's module store to this same real Zustand store —
+ * see the `setStore(...)` call near the bottom of connection.ts — so driving
+ * `handleMessage` here exercises the exact same interception path production
+ * traffic takes).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+function createMockSocket() {
+  return {
+    readyState: WebSocket.OPEN,
+    send: vi.fn(),
+    close: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+describe('requestConversationTranscript / closeTranscriptViewer (#6863)', () => {
+  const ctx = () => ({ url: 'wss://t', token: 'tok', socket: undefined, isReconnect: false, silent: false })
+
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends request_conversation_transcript with the conversationId and opens the viewer in loading state', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = createMockSocket()
+    useConnectionStore.setState({
+      socket,
+      transcriptViewer: { conversationId: null, status: 'idle', messages: [], error: null },
+    })
+
+    useConnectionStore.getState().requestConversationTranscript('conv-1')
+
+    expect(socket.send).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse((socket.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string)
+    expect(payload.type).toBe('request_conversation_transcript')
+    expect(payload.conversationId).toBe('conv-1')
+    expect(payload.cwd).toBeUndefined()
+
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.conversationId).toBe('conv-1')
+    expect(viewer.status).toBe('loading')
+    expect(viewer.messages).toEqual([])
+    expect(viewer.error).toBeNull()
+  })
+
+  it('includes cwd on the wire payload when provided', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = createMockSocket()
+    useConnectionStore.setState({ socket })
+
+    useConnectionStore.getState().requestConversationTranscript('conv-2', '/home/user/project')
+
+    const payload = JSON.parse((socket.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string)
+    expect(payload.cwd).toBe('/home/user/project')
+  })
+
+  it('surfaces an immediate error (no crash) when the socket is not open — #6308/#6309 wsSend return-value check', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({ socket: null })
+
+    expect(() => useConnectionStore.getState().requestConversationTranscript('conv-3')).not.toThrow()
+
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.conversationId).toBe('conv-3')
+    expect(viewer.status).toBe('error')
+    expect(viewer.error).toBeTruthy()
+  })
+
+  it('closeTranscriptViewer resets to idle', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const socket = createMockSocket()
+    useConnectionStore.setState({ socket })
+    useConnectionStore.getState().requestConversationTranscript('conv-4')
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('loading')
+
+    useConnectionStore.getState().closeTranscriptViewer()
+
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.conversationId).toBeNull()
+    expect(viewer.status).toBe('idle')
+    expect(viewer.messages).toEqual([])
+    expect(viewer.error).toBeNull()
+  })
+
+  it('a fetch still loading after the watchdog window surfaces a timeout error instead of spinning forever', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore } = await import('./connection')
+    const socket = createMockSocket()
+    useConnectionStore.setState({ socket })
+
+    useConnectionStore.getState().requestConversationTranscript('conv-5')
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('loading')
+
+    vi.advanceTimersByTime(15_000)
+
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.status).toBe('error')
+    expect(viewer.error).toMatch(/timed out/i)
+    vi.useRealTimers()
+  })
+
+  it('a completed fetch before the watchdog window does NOT get overwritten by the timeout', async () => {
+    vi.useFakeTimers()
+    const { useConnectionStore } = await import('./connection')
+    const { handleMessage } = await import('./message-handler')
+    const socket = createMockSocket()
+    useConnectionStore.setState({ socket })
+
+    useConnectionStore.getState().requestConversationTranscript('conv-6')
+    handleMessage({ type: 'history_replay_start', sessionId: 'conv-6', conversationId: 'conv-6' }, ctx() as never)
+    handleMessage({ type: 'history_replay_end', sessionId: 'conv-6' }, ctx() as never)
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('ready')
+
+    vi.advanceTimersByTime(15_000)
+
+    // Still ready — the (cleared) watchdog must not clobber a completed fetch.
+    expect(useConnectionStore.getState().transcriptViewer.status).toBe('ready')
+    vi.useRealTimers()
+  })
+
+  it('end-to-end: request -> replay frames -> ready, with messages accumulated in order', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const { handleMessage } = await import('./message-handler')
+    const socket = createMockSocket()
+    useConnectionStore.setState({ socket })
+
+    useConnectionStore.getState().requestConversationTranscript('conv-7', '/home/user/proj')
+    handleMessage({ type: 'history_replay_start', sessionId: 'conv-7', conversationId: 'conv-7' }, ctx() as never)
+    handleMessage(
+      { type: 'message', messageType: 'user_input', content: 'hello', sessionId: 'conv-7', timestamp: 1 },
+      ctx() as never,
+    )
+    handleMessage(
+      { type: 'message', messageType: 'response', content: 'hi there', sessionId: 'conv-7', timestamp: 2 },
+      ctx() as never,
+    )
+    handleMessage({ type: 'history_replay_end', sessionId: 'conv-7' }, ctx() as never)
+
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.status).toBe('ready')
+    expect(viewer.messages.map(m => m.content)).toEqual(['hello', 'hi there'])
+  })
+
+  it('a subsequent View request for a DIFFERENT conversation resets messages (no bleed-through)', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const { handleMessage } = await import('./message-handler')
+    const socket = createMockSocket()
+    useConnectionStore.setState({ socket })
+
+    useConnectionStore.getState().requestConversationTranscript('conv-8')
+    handleMessage({ type: 'history_replay_start', sessionId: 'conv-8', conversationId: 'conv-8' }, ctx() as never)
+    handleMessage(
+      { type: 'message', messageType: 'response', content: 'first conversation', sessionId: 'conv-8', timestamp: 1 },
+      ctx() as never,
+    )
+    handleMessage({ type: 'history_replay_end', sessionId: 'conv-8' }, ctx() as never)
+    expect(useConnectionStore.getState().transcriptViewer.messages).toHaveLength(1)
+
+    useConnectionStore.getState().requestConversationTranscript('conv-9')
+    const viewer = useConnectionStore.getState().transcriptViewer
+    expect(viewer.conversationId).toBe('conv-9')
+    expect(viewer.status).toBe('loading')
+    expect(viewer.messages).toEqual([])
+  })
+})

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -515,6 +515,33 @@ export interface FilePickerItem {
 }
 
 /**
+ * #6863 (epic #6765) — read-only transcript viewer state, fed by the
+ * `request_conversation_transcript` endpoint (#6860). Distinct from
+ * `SessionState` on purpose: a transcript viewer never has a live session
+ * behind it (no SessionManager entry, no provider process), so it does not
+ * belong in `sessionStates` and must never be mistaken for one — see
+ * `applyTranscriptFrame` in message-handler.ts for the interception that
+ * keeps the two paths apart on the wire.
+ *
+ * `status`:
+ *  - `idle`    — no fetch in flight, nothing to show (viewer closed).
+ *  - `loading` — `request_conversation_transcript` sent, replay in progress.
+ *  - `ready`   — `history_replay_end` received; `messages` is the full
+ *                (possibly empty) transcript.
+ *  - `error`   — the fetch failed (rejected by the server) or timed out
+ *                waiting for a reply; `error` carries a human-readable reason.
+ */
+export interface TranscriptViewerState {
+  /** The conversation currently open, or null when the viewer is closed. */
+  conversationId: string | null;
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  /** Accumulated from `message` frames during replay; reset on each new fetch. */
+  messages: ChatMessage[];
+  /** Human-readable failure reason, set only when `status === 'error'`. */
+  error: string | null;
+}
+
+/**
  * #6823 — an MCP-server resource surfaced in the `@`-picker for BYOK sessions.
  * `server` routes a later read back to the owning MCP server; `uri` is that
  * server's own identifier for the resource.
@@ -1447,6 +1474,14 @@ export interface ConnectionState {
   searchLoading: boolean;
   searchQuery: string;
 
+  // #6863 (epic #6765) — read-only transcript viewer. Fed by the
+  // `request_conversation_transcript` endpoint (#6860): reads a CLOSED
+  // conversation's history straight off disk, with NO SessionManager entry
+  // and NO provider spawn. Deliberately a SEPARATE slice from `sessionStates`
+  // (see message-handler.ts's `applyTranscriptFrame` for why) — this is
+  // never a live session and must never be treated as one.
+  transcriptViewer: TranscriptViewerState;
+
   // Checkpoints for session rewind
   checkpoints: Checkpoint[];
 
@@ -1774,6 +1809,14 @@ export interface ConnectionState {
   // Conversation history (resume past conversations)
   fetchConversationHistory: () => void;
   resumeConversation: (conversationId: string, cwd?: string) => void;
+
+  // #6863 — read-only transcript viewer. `requestConversationTranscript`
+  // sends `request_conversation_transcript` (#6860) and opens the viewer in
+  // `loading` state; `closeTranscriptViewer` resets it to `idle` and discards
+  // any in-flight fetch's late frames (see message-handler.ts). NEVER calls
+  // `createSession` / spawns a provider — reading is the entire contract.
+  requestConversationTranscript: (conversationId: string, cwd?: string) => void;
+  closeTranscriptViewer: () => void;
 
   // Cross-session search
   searchConversations: (query: string) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -851,6 +851,16 @@ a.dev-preview-chip__link:focus-visible {
   color: var(--text-primary);
 }
 
+/* These buttons are reached by Tab (and are the only way to trigger View), so
+   they need a visible focus ring, not just a hover state — same
+   `--border-focus` outline the sidebar rows and session tabs use. */
+.conversation-search-result-action:focus-visible {
+  border-color: var(--border-focus);
+  color: var(--text-primary);
+  outline: 2px solid var(--border-focus);
+  outline-offset: 1px;
+}
+
 .sidebar-repo {
   margin-bottom: 2px;
 }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -829,6 +829,28 @@ a.dev-preview-chip__link:focus-visible {
   margin-top: 2px;
 }
 
+/* #6863 — View / Resume actions on a search result row. */
+.conversation-search-result-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: 4px;
+}
+
+.conversation-search-result-action {
+  background: transparent;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-xs);
+  padding: 2px 8px;
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.conversation-search-result-action:hover {
+  border-color: var(--border-focus);
+  color: var(--text-primary);
+}
+
 .sidebar-repo {
   margin-bottom: 2px;
 }


### PR DESCRIPTION
## Summary

Closes #6863. Adds a **"View"** action alongside **"Resume"** so a user can open a past conversation purely to read it — no resume, no provider spawn. Consumes the read-only `request_conversation_transcript` endpoint from #6860 (no protocol/server changes needed — that wire type already exists).

- `ConversationSearch.tsx` — each result row now has explicit **View** and **Resume** buttons (both `stopPropagation`, so clicking one never also triggers the other). The row's existing click/Enter → Resume behavior is unchanged.
- `sidebarContextMenuItems.ts` — the `resumable` right-click branch gets a new **"View Conversation"** item alongside **"Resume Conversation"**, **"Copy Conversation ID"**, and **"Open in Finder"**. View is always enabled (unlike Resume, which the server can refuse for a `capabilities.resume === false` provider) since it reads straight off disk.
- New `TranscriptViewer` component (`packages/dashboard/src/components/TranscriptViewer.tsx`) renders the fetched transcript in a `Modal`, reusing the existing `ChatView`/`useChatMessages` pipeline — same message grouping/markdown rendering as a live session, just with **no composer** and **no interactive renderer branches** (permission/question prompts fall back to plain read-only bubbles instead of the live `PermissionPrompt`/`QuestionPrompt`, which wire `onRespond`/`onSelect` into real decisions). Handles loading / empty / error states; a large transcript reuses `ChatView`'s existing virtualization, so there's no separate windowing to add.

### How read-only is enforced structurally (not just visually)

- `TranscriptViewer` never renders a composer/input control anywhere in its tree.
- Its `renderMessage` (`transcriptRenderMessage`, exported for direct testing) only reuses the *presentational* branches of the live chat renderer (tool groups/bubbles, compaction/evaluator/MCP markers) — never the interactive ones. Anything it doesn't explicitly handle falls back to `ChatView`'s default read-only bubble.
- The transcript's messages live in a dedicated `transcriptViewer` store slice, never `sessionStates`. The server reuses the exact same `history_replay_start`/`message`/`history_replay_end` wire frames for a live session's replay *and* a closed conversation's transcript (distinguished only by `sessionId` carrying a conversationId with no matching live session) — `message-handler.ts` now intercepts frames for any in-flight transcript fetch (tracked by conversationId, safe even across a rapid View A → close → View B sequence) *before* they reach the session-replay switch, so a transcript frame can never fall through and get appended into whatever session happens to be active.
- No dedicated failure echo exists for a rejected `request_conversation_transcript` (just a generic `session_error{message}`), so a 15s watchdog — mirroring the existing `searchConversations` pattern — surfaces a timeout error instead of leaving the viewer stuck spinning.

## Visual verification

1. Run the dashboard (`npx chroxy start` with Node 22, or `npm run dev` in `packages/dashboard`) against a daemon with at least one **closed** conversation in history (any past session works, including one whose provider doesn't support resume).
2. Open the sidebar's conversation search (type a few characters of a past conversation's content) — each result row now shows **View** and **Resume** buttons. Click **View**.
3. Alternatively: right-click a resumable row in the sidebar's session history tree → **View Conversation**.
4. Expect a modal titled "Conversation transcript" with a "Read-only — viewing does not resume this conversation" note, a loading spinner briefly, then the full transcript rendered read-only (no input box, no send button). Close via the **Close** button, Escape, or clicking the backdrop.
5. Confirm **Resume** still works exactly as before at both sites (spawns/resumes the session as usual).

## Test plan

- [x] `cd packages/dashboard && npx vitest run` — full suite green (282 files / 4839 tests)
- [x] `npx tsc --noEmit` — clean
- [x] `bash scripts/lint-no-raw-color-literals.sh` — clean (new `TranscriptViewer.css` is token-only)
- [x] `npx vite build` — production build succeeds
- [x] Dedicated regression-guard tests: `ConversationSearch.test.tsx` / `ConversationSearchKeyboard.test.tsx` (View vs Resume never cross-fire), `sidebarContextMenuItems.test.ts` (View Conversation item + handler), `TranscriptViewer.test.tsx` (loading/empty/error/ready states + no composer/interactive controls in any state), `message-handler.test.ts` (frame interception never touches `sessionStates`/`addMessage`, including the superseded-fetch race), `transcript-viewer-actions.test.ts` (store action wire payload, error/timeout handling, end-to-end request→replay→ready flow)
- [x] No protocol/server changes — `request_conversation_transcript` is an existing wire type from #6860; coverage guards untouched