### PR TITLE
feat(server,cli): chroxy schedule command group (CRUD + last-run)

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -28,6 +28,7 @@ import { registerPagesCommands } from './cli/pages-cmd.js'
 import { registerShellApprovalCommand } from './cli/shell-cmd.js'
 import { registerIdentityCommand } from './cli/identity-cmd.js'
 import { registerTokensCommand } from './cli/tokens-cmd.js'
+import { registerScheduleCommands } from './cli/schedule-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -58,5 +59,6 @@ registerPagesCommands(program)
 registerShellApprovalCommand(program)
 registerIdentityCommand(program)
 registerTokensCommand(program)
+registerScheduleCommands(program)
 
 program.parse()

--- a/packages/server/src/cli/schedule-cmd.js
+++ b/packages/server/src/cli/schedule-cmd.js
@@ -74,18 +74,22 @@ function getDefaultStore() {
  * see tests/schedule-cli.test.js.
  */
 function buildDeps(overrides = {}) {
+  const config = readConfigSoft(CONFIG_FILE)
   return {
     store: overrides.store || getDefaultStore(),
     write: overrides.write || console.log,
     // The provider a task would ACTUALLY run against when none is set
-    // explicitly — mirrors DEFAULT_PROVIDER, the daemon's out-of-the-box
-    // default (scheduler.js's own fallback also considers a live
-    // sessionManager's configured default, which this offline CLI cannot
-    // see; DEFAULT_PROVIDER is the closest available approximation).
-    defaultProviderName: overrides.defaultProviderName || DEFAULT_PROVIDER,
+    // explicitly — mirrors the daemon's own resolution, `config.provider ||
+    // DEFAULT_PROVIDER` (server-cli.js's `providerType` wiring; scheduler.js's
+    // live `_resolveProviderName` falls back to the wired SessionManager's
+    // `providerType`, which IS this same expression). Reading config.provider
+    // here (not just hardcoding DEFAULT_PROVIDER) matters: if the operator's
+    // configured default ever diverges from DEFAULT_PROVIDER, this warning
+    // must track what will actually run, not the out-of-the-box default.
+    defaultProviderName: overrides.defaultProviderName || config.provider || DEFAULT_PROVIDER,
     checkProviderRefusal: overrides.checkProviderRefusal || ((name) => scheduledProviderRefusalReason(name)),
     resolvePermissionMode: overrides.resolvePermissionMode || resolveScheduledPermissionMode,
-    checkSchedulerEnabled: overrides.checkSchedulerEnabled || (() => isSchedulerEnabled(readConfigSoft(CONFIG_FILE))),
+    checkSchedulerEnabled: overrides.checkSchedulerEnabled || (() => isSchedulerEnabled(config)),
   }
 }
 

--- a/packages/server/src/cli/schedule-cmd.js
+++ b/packages/server/src/cli/schedule-cmd.js
@@ -1,0 +1,711 @@
+/**
+ * `chroxy schedule` — CRUD against the persisted scheduled-task registry
+ * (#6868, consumer slice of epic #6784).
+ *
+ * This CLI operates purely on the on-disk registry (#6862,
+ * `scheduled-task-store.js`) via the store's own API — it never hand-writes
+ * the JSON file, and it never re-implements cadence parsing: every cadence
+ * (`--at` / `--cron`) is validated by the store, which itself calls
+ * `schedule-parser.js`'s `parseCron`/`computeNextRun`. Nothing here requires
+ * the headless engine (#6865, `scheduler.js`) to be running — create/list/
+ * edit/pause/resume/delete/last-run all just read and write the registry
+ * file.
+ *
+ * What IS reused from the engine, deliberately (rather than re-derived), is
+ * its judgment about whether a task can actually fire:
+ *   - `scheduledProviderRefusalReason` — the exact "will this provider be
+ *     refused?" check `scheduler.js` runs before every fire. A task whose
+ *     target provider has no in-process permission answering (including the
+ *     daemon DEFAULT `claude-tui`) gets a clear warning at create/edit time
+ *     instead of silently sitting dead until an operator notices `refused`
+ *     outcomes days later.
+ *   - `resolveScheduledPermissionMode` — the exact clamp the engine applies
+ *     per fire. A task that asks for a permission mode above `approve`/`plan`
+ *     is warned that it will be silently de-escalated, not rejected (the
+ *     store itself allows any `ALLOWED_PERMISSION_MODE_IDS` value — only the
+ *     engine's floor is stricter).
+ *   - `isSchedulerEnabled` — the same default-off gate the daemon checks.
+ *     `create`/`edit` still succeed with the gate closed (the task is a
+ *     legitimate standing definition even before the operator opts in), but
+ *     say plainly that nothing will fire yet.
+ *
+ * `list` and `last-run` render a task's `lastRun` status verbatim (never
+ * papered over): `refused` and a best-effort-persisted quarantine message
+ * both show up as an unhealthy `[REFUSED]`/`[ERROR]` tag, and a task that has
+ * never fired is always labelled `[NEVER RUN]` rather than left blank —
+ * nothing here is allowed to *look* healthy when it isn't.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { CONFIG_DIR, CONFIG_FILE } from './shared.js'
+import {
+  ScheduledTaskStore,
+  ScheduledTaskValidationError,
+  defaultScheduledTasksPath,
+} from '../scheduled-task-store.js'
+import { isSchedulerEnabled } from '../config.js'
+import { scheduledProviderRefusalReason, resolveScheduledPermissionMode } from '../scheduler.js'
+import { DEFAULT_PROVIDER } from '../providers.js'
+
+// -- default wiring (production) ---------------------------------------------
+
+/** Read config.json best-effort — never throws, never exits (mirrors worktree-gc-cmd.js). */
+function readConfigSoft(configPath) {
+  try {
+    if (!existsSync(configPath)) return {}
+    return JSON.parse(readFileSync(configPath, 'utf-8')) || {}
+  } catch {
+    return {}
+  }
+}
+
+/** The registry file this daemon would load — a sibling of session-state.json. */
+function getDefaultStore() {
+  const stateFilePath = join(CONFIG_DIR, 'session-state.json')
+  const store = new ScheduledTaskStore({ filePath: defaultScheduledTasksPath(stateFilePath) })
+  store.load()
+  return store
+}
+
+/**
+ * Build the dependency bag every exported command function runs against.
+ * Every dependency is overridable so tests never touch the real
+ * `~/.chroxy/` tree and never need a live provider registry or config file —
+ * see tests/schedule-cli.test.js.
+ */
+function buildDeps(overrides = {}) {
+  return {
+    store: overrides.store || getDefaultStore(),
+    write: overrides.write || console.log,
+    // The provider a task would ACTUALLY run against when none is set
+    // explicitly — mirrors DEFAULT_PROVIDER, the daemon's out-of-the-box
+    // default (scheduler.js's own fallback also considers a live
+    // sessionManager's configured default, which this offline CLI cannot
+    // see; DEFAULT_PROVIDER is the closest available approximation).
+    defaultProviderName: overrides.defaultProviderName || DEFAULT_PROVIDER,
+    checkProviderRefusal: overrides.checkProviderRefusal || ((name) => scheduledProviderRefusalReason(name)),
+    resolvePermissionMode: overrides.resolvePermissionMode || resolveScheduledPermissionMode,
+    checkSchedulerEnabled: overrides.checkSchedulerEnabled || (() => isSchedulerEnabled(readConfigSoft(CONFIG_FILE))),
+  }
+}
+
+// -- formatting helpers --------------------------------------------------
+
+/** Deterministic UTC rendering (no locale/timezone dependence) — easy to test, unambiguous to read. */
+function formatEpoch(ms) {
+  if (!Number.isFinite(ms)) return '—'
+  return new Date(ms).toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, 'Z')
+}
+
+function formatDurationMs(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return 'unknown'
+  const sec = Math.floor(ms / 1000)
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h`
+  return `${Math.floor(hr / 24)}d`
+}
+
+function describeCadence(cadence) {
+  if (!cadence || typeof cadence !== 'object') return '(invalid cadence)'
+  switch (cadence.kind) {
+    case 'once':
+      return `once @ ${formatEpoch(cadence.at)}`
+    case 'interval':
+      return `every ${formatDurationMs(cadence.everyMs)}`
+    case 'cron':
+      return `cron "${cadence.expression}"`
+    default:
+      return `(unknown cadence: ${cadence.kind})`
+  }
+}
+
+/**
+ * A task's honest at-a-glance health. `PAUSED` takes priority (an operator
+ * turned it off on purpose); otherwise a task that has never fired is always
+ * `NEVER RUN` — never blank, never mistaken for healthy — and every recorded
+ * `lastRun.status` maps to its own tag so `refused` (and a best-effort
+ * quarantine write, which persists as `refused`) is never confused with
+ * `success`.
+ */
+function healthTag(task) {
+  if (!task.enabled) return 'PAUSED'
+  if (!task.lastRun) return 'NEVER RUN'
+  switch (task.lastRun.status) {
+    case 'success':
+      return 'OK'
+    case 'refused':
+      return 'REFUSED'
+    case 'skipped':
+      return 'SKIPPED'
+    case 'timeout':
+      return 'TIMEOUT'
+    default:
+      return 'ERROR'
+  }
+}
+
+function describeLastRun(lastRun) {
+  if (!lastRun) return 'never run'
+  let line = `${lastRun.status} @ ${formatEpoch(lastRun.at)}`
+  if (lastRun.sessionId) line += ` (session ${lastRun.sessionId})`
+  if (lastRun.error) line += ` — ${lastRun.error}`
+  return line
+}
+
+// -- input parsing ---------------------------------------------------------
+
+/** Parse `--at` into epoch-ms: bare digits are epoch-ms, else Date.parse (ISO-8601). */
+function parseAtValue(raw) {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return { error: '--at requires a value' }
+  }
+  const trimmed = raw.trim()
+  if (/^\d+$/.test(trimmed)) {
+    const ms = Number(trimmed)
+    return Number.isFinite(ms)
+      ? { at: ms }
+      : { error: `--at '${raw}' is not a valid epoch-ms timestamp` }
+  }
+  const parsed = Date.parse(trimmed)
+  if (Number.isNaN(parsed)) {
+    return {
+      error: `--at '${raw}' could not be parsed — use an ISO-8601 timestamp `
+        + '(e.g. 2026-08-01T09:00:00) or epoch milliseconds',
+    }
+  }
+  return { at: parsed }
+}
+
+/** Build a brand-new cadence for `create` — exactly one of --at/--cron is required. */
+function buildCadenceForCreate(options) {
+  const hasAt = options.at !== undefined
+  const hasCron = options.cron !== undefined
+  if (hasAt && hasCron) return { error: '--at and --cron are mutually exclusive — pick one cadence' }
+  if (!hasAt && !hasCron) {
+    return { error: 'specify a cadence: --at <when> for a one-time run, or --cron <expr> for a recurring one' }
+  }
+  if (hasCron) {
+    if (typeof options.cron !== 'string' || options.cron.trim().length === 0) {
+      return { error: '--cron requires a 5-field crontab expression' }
+    }
+    return { cadence: { kind: 'cron', expression: options.cron } }
+  }
+  const parsed = parseAtValue(options.at)
+  if (parsed.error) return { error: parsed.error }
+  return { cadence: { kind: 'once', at: parsed.at } }
+}
+
+/** Build a cadence PATCH for `edit` — absent when neither flag is given (no change). */
+function buildCadencePatch(options) {
+  const hasAt = options.at !== undefined
+  const hasCron = options.cron !== undefined
+  if (!hasAt && !hasCron) return {}
+  if (hasAt && hasCron) return { error: '--at and --cron are mutually exclusive — pick one cadence' }
+  return buildCadenceForCreate(options)
+}
+
+/** Collect only the target fields the caller actually passed. */
+function buildTargetFields(options) {
+  const target = {}
+  if (options.provider !== undefined) target.provider = options.provider
+  if (options.model !== undefined) target.model = options.model
+  if (options.cwd !== undefined) target.cwd = options.cwd
+  if (options.permissionMode !== undefined) target.permissionMode = options.permissionMode
+  return target
+}
+
+/** Resolve a caller-supplied id or unique id-prefix to a stored task. */
+function resolveTaskId(store, idOrPrefix) {
+  if (typeof idOrPrefix !== 'string' || idOrPrefix.trim().length === 0) {
+    return { error: 'A task id (or unique id-prefix) is required.', errorCode: 'no-target' }
+  }
+  const target = idOrPrefix.trim()
+  const all = store.list()
+  const exact = all.find((t) => t.id === target)
+  if (exact) return { task: exact }
+  const matches = all.filter((t) => t.id.startsWith(target))
+  if (matches.length === 0) {
+    return { error: `No scheduled task matches "${target}". Run: chroxy schedule list`, errorCode: 'no-match' }
+  }
+  if (matches.length > 1) {
+    return {
+      error: `"${target}" matches ${matches.length} tasks — use a longer id prefix to disambiguate.`,
+      errorCode: 'ambiguous',
+      matches: matches.length,
+    }
+  }
+  return { task: matches[0] }
+}
+
+/**
+ * The honesty layer: warnings surfaced at create/edit time so a task's
+ * problems are visible up front rather than discovered later in `list`.
+ * Every check here reuses an engine-owned function — nothing is
+ * re-implemented — per the module doc above.
+ */
+function computeWarnings(task, deps) {
+  const warnings = []
+  const providerName = task.target?.provider || deps.defaultProviderName
+  const refusal = deps.checkProviderRefusal(providerName)
+  if (refusal) {
+    warnings.push(`provider '${providerName}' will be REFUSED when this task is due — nothing will run: ${refusal}`)
+  }
+  const requestedMode = task.target?.permissionMode
+  if (requestedMode) {
+    const resolvedMode = deps.resolvePermissionMode(requestedMode)
+    if (resolvedMode !== requestedMode) {
+      warnings.push(
+        `permission mode '${requestedMode}' will be clamped to '${resolvedMode}' when this task fires `
+          + '— unattended runs can never use a more permissive mode',
+      )
+    }
+  }
+  if (!deps.checkSchedulerEnabled()) {
+    warnings.push(
+      'scheduled execution is currently DISABLED on this daemon — this task is saved but will NOT fire '
+        + 'until enabled (set features.scheduler: true in config.json or CHROXY_ENABLE_SCHEDULER=1, then restart the daemon)',
+    )
+  }
+  return warnings
+}
+
+// -- command implementations (pure aside from injected deps) ---------------
+
+/**
+ * `chroxy schedule create` — validates + persists via `store.add()` (which
+ * itself validates the cadence through schedule-parser.js), then surfaces
+ * the computed next-run and any create-time warnings.
+ * @returns {{created:boolean, task?:object, warnings?:string[], error?:string, message?:string, field?:string}}
+ */
+export function runScheduleCreate(options = {}, depsOverride = {}) {
+  const deps = buildDeps(depsOverride)
+  const out = deps.write
+
+  if (typeof options.prompt !== 'string' || options.prompt.trim().length === 0) {
+    out('A --prompt is required (the instructions the scheduled run executes).')
+    return { created: false, error: 'missing-prompt' }
+  }
+
+  const cadenceResult = buildCadenceForCreate(options)
+  if (cadenceResult.error) {
+    out(cadenceResult.error)
+    return { created: false, error: 'invalid-cadence', message: cadenceResult.error }
+  }
+
+  const target = buildTargetFields(options)
+
+  let task
+  try {
+    task = deps.store.add({
+      name: options.name,
+      prompt: options.prompt,
+      cadence: cadenceResult.cadence,
+      target,
+      enabled: !options.paused,
+    })
+  } catch (err) {
+    if (err instanceof ScheduledTaskValidationError) {
+      out(`Invalid schedule: ${err.field ? `${err.field} — ` : ''}${err.message}`)
+      return { created: false, error: 'validation', field: err.field, message: err.message }
+    }
+    out(`Failed to create scheduled task: ${err?.message || err}`)
+    return { created: false, error: 'store-error', message: err?.message || String(err) }
+  }
+
+  const warnings = computeWarnings(task, deps)
+
+  if (options.json) {
+    out(JSON.stringify({ task, warnings }, null, 2))
+  } else {
+    out(`Created scheduled task ${task.id}${task.name ? ` (${task.name})` : ''}`)
+    out(`  cadence:  ${describeCadence(task.cadence)}`)
+    out(`  next run: ${task.enabled ? formatEpoch(task.nextRun) : `— (paused; resume with: chroxy schedule resume ${task.id})`}`)
+    for (const w of warnings) out(`  WARNING: ${w}`)
+  }
+  return { created: true, task, warnings }
+}
+
+/**
+ * `chroxy schedule list` — every task with its honest health tag, next-run,
+ * and last-run, plus the daemon's global enable-gate state up top.
+ * @returns {{schedulerEnabled:boolean, tasks:Array<{task:object,health:string,providerRefusal:string|null}>}}
+ */
+export function runScheduleList(options = {}, depsOverride = {}) {
+  const deps = buildDeps(depsOverride)
+  const out = deps.write
+  const tasks = deps.store.list()
+  const schedulerEnabled = deps.checkSchedulerEnabled()
+
+  const rows = tasks.map((task) => {
+    const providerName = task.target?.provider || deps.defaultProviderName
+    return { task, health: healthTag(task), providerRefusal: deps.checkProviderRefusal(providerName) }
+  })
+
+  if (options.json) {
+    out(JSON.stringify({
+      schedulerEnabled,
+      tasks: rows.map((r) => ({ ...r.task, health: r.health, providerRefusal: r.providerRefusal })),
+    }, null, 2))
+    return { schedulerEnabled, tasks: rows }
+  }
+
+  out(schedulerEnabled
+    ? 'Scheduled execution: ENABLED'
+    : 'Scheduled execution: DISABLED — tasks below are saved but will NOT fire. '
+      + 'Enable via features.scheduler: true in config.json or CHROXY_ENABLE_SCHEDULER=1, then restart the daemon.')
+  out('')
+
+  if (rows.length === 0) {
+    out('No scheduled tasks. Create one: chroxy schedule create --prompt "..." --cron "0 9 * * *"')
+    return { schedulerEnabled, tasks: [] }
+  }
+
+  out(`${rows.length} scheduled task(s):`)
+  out('')
+  let enabledCount = 0
+  let pausedCount = 0
+  let refusedCount = 0
+  let neverRunCount = 0
+  for (const { task, health, providerRefusal } of rows) {
+    if (task.enabled) enabledCount++
+    else pausedCount++
+    if (!task.lastRun) neverRunCount++
+    else if (task.lastRun.status === 'refused') refusedCount++
+
+    const label = task.name || '(unnamed)'
+    out(`[${health}] ${label}  (${task.id})`)
+    out(`  cadence:  ${describeCadence(task.cadence)}`)
+    out(`  next run: ${task.enabled ? formatEpoch(task.nextRun) : '— (paused)'}`)
+    out(`  last run: ${describeLastRun(task.lastRun)}`)
+    if (providerRefusal) {
+      const providerName = task.target?.provider || deps.defaultProviderName
+      out(`  provider check: '${providerName}' will be REFUSED when due — ${providerRefusal}`)
+    }
+    out('')
+  }
+
+  const bits = [`${enabledCount} enabled`, `${pausedCount} paused`]
+  if (refusedCount > 0) bits.push(`${refusedCount} refused`)
+  if (neverRunCount > 0) bits.push(`${neverRunCount} never run`)
+  out(`Summary: ${bits.join(', ')}.`)
+
+  return { schedulerEnabled, tasks: rows }
+}
+
+/**
+ * `chroxy schedule edit <id>` — patches only the fields the caller passed.
+ * `target` fields are merged onto the EXISTING target (store.update replaces
+ * the whole object, so a partial `--model` edit must not drop `--provider`).
+ * @returns {{updated:boolean, task?:object, warnings?:string[], error?:string, message?:string, field?:string}}
+ */
+export function runScheduleEdit(idOrPrefix, options = {}, depsOverride = {}) {
+  const deps = buildDeps(depsOverride)
+  const out = deps.write
+  const resolved = resolveTaskId(deps.store, idOrPrefix)
+  if (resolved.error) {
+    out(resolved.error)
+    return { updated: false, error: resolved.errorCode || 'not-found', message: resolved.error }
+  }
+  const existing = resolved.task
+
+  const patch = {}
+  if (options.prompt !== undefined) patch.prompt = options.prompt
+  if (options.name !== undefined) patch.name = options.name
+
+  const cadenceResult = buildCadencePatch(options)
+  if (cadenceResult.error) {
+    out(cadenceResult.error)
+    return { updated: false, error: 'invalid-cadence', message: cadenceResult.error }
+  }
+  if (cadenceResult.cadence) patch.cadence = cadenceResult.cadence
+
+  const targetFields = buildTargetFields(options)
+  if (Object.keys(targetFields).length > 0) {
+    patch.target = { ...existing.target, ...targetFields }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    out('Nothing to edit — pass at least one of --prompt, --name, --at/--cron, --provider, --model, --cwd, --permission-mode.')
+    return { updated: false, error: 'no-changes' }
+  }
+
+  let task
+  try {
+    task = deps.store.update(existing.id, patch)
+  } catch (err) {
+    if (err instanceof ScheduledTaskValidationError) {
+      out(`Invalid schedule: ${err.field ? `${err.field} — ` : ''}${err.message}`)
+      return { updated: false, error: 'validation', field: err.field, message: err.message }
+    }
+    out(`Failed to update scheduled task: ${err?.message || err}`)
+    return { updated: false, error: 'store-error', message: err?.message || String(err) }
+  }
+  if (!task) {
+    out(`No scheduled task with id ${existing.id} (it may have just been deleted).`)
+    return { updated: false, error: 'not-found' }
+  }
+
+  const warnings = computeWarnings(task, deps)
+  if (options.json) {
+    out(JSON.stringify({ task, warnings }, null, 2))
+  } else {
+    out(`Updated scheduled task ${task.id}${task.name ? ` (${task.name})` : ''}`)
+    out(`  cadence:  ${describeCadence(task.cadence)}`)
+    out(`  next run: ${task.enabled ? formatEpoch(task.nextRun) : '— (paused)'}`)
+    for (const w of warnings) out(`  WARNING: ${w}`)
+  }
+  return { updated: true, task, warnings }
+}
+
+/**
+ * @private — shared body for pause/resume: both are a plain `enabled` flip.
+ * Neither requires `--yes` (unlike `delete`): pausing is fully reversible via
+ * its counterpart, so the confirmation gate the repo reserves for genuinely
+ * destructive/irreversible actions (delete, `tokens revoke --all`, `identity
+ * rotate`) does not apply here.
+ */
+function setEnabled(idOrPrefix, enabled, options, depsOverride, verb) {
+  const deps = buildDeps(depsOverride)
+  const out = deps.write
+  const resolved = resolveTaskId(deps.store, idOrPrefix)
+  if (resolved.error) {
+    out(resolved.error)
+    return { changed: false, error: resolved.errorCode || 'not-found', message: resolved.error }
+  }
+
+  let task
+  try {
+    task = deps.store.update(resolved.task.id, { enabled })
+  } catch (err) {
+    out(`Failed to ${verb} scheduled task: ${err?.message || err}`)
+    return { changed: false, error: 'store-error', message: err?.message || String(err) }
+  }
+  if (!task) {
+    out(`No scheduled task with id ${resolved.task.id}.`)
+    return { changed: false, error: 'not-found' }
+  }
+
+  if (options.json) {
+    out(JSON.stringify({ task }, null, 2))
+  } else {
+    out(`Task ${task.id}${task.name ? ` (${task.name})` : ''} ${verb === 'pause' ? 'paused' : 'resumed'}.`)
+    if (enabled) {
+      out(`  next run: ${formatEpoch(task.nextRun)}`)
+      for (const w of computeWarnings(task, deps)) out(`  WARNING: ${w}`)
+    } else {
+      out(`  will not fire again until resumed: chroxy schedule resume ${task.id}`)
+    }
+  }
+  return { changed: true, task }
+}
+
+/** `chroxy schedule pause <id>` */
+export function runSchedulePause(idOrPrefix, options = {}, depsOverride = {}) {
+  return setEnabled(idOrPrefix, false, options, depsOverride, 'pause')
+}
+
+/** `chroxy schedule resume <id>` */
+export function runScheduleResume(idOrPrefix, options = {}, depsOverride = {}) {
+  return setEnabled(idOrPrefix, true, options, depsOverride, 'resume')
+}
+
+/**
+ * `chroxy schedule delete <id>` — destructive and irreversible (removes the
+ * task definition AND its run history), so it follows the repo's `--yes`
+ * confirmation convention (`tokens revoke --all`, `identity rotate`):
+ * without `--yes` it only explains what would be removed and changes
+ * nothing.
+ * @returns {{deleted:boolean, confirmed?:boolean, task?:object, error?:string, message?:string}}
+ */
+export function runScheduleDelete(idOrPrefix, options = {}, depsOverride = {}) {
+  const deps = buildDeps(depsOverride)
+  const out = deps.write
+  const resolved = resolveTaskId(deps.store, idOrPrefix)
+  if (resolved.error) {
+    out(resolved.error)
+    return { deleted: false, error: resolved.errorCode || 'not-found', message: resolved.error }
+  }
+  const task = resolved.task
+
+  if (!options.yes) {
+    out([
+      `chroxy schedule delete ${task.id}${task.name ? ` (${task.name})` : ''} — this permanently removes `
+        + 'the task definition and its run history.',
+      `  cadence: ${describeCadence(task.cadence)}`,
+      `  prompt:  ${task.prompt.length > 80 ? `${task.prompt.slice(0, 80)}…` : task.prompt}`,
+      '',
+      'This cannot be undone — re-run with --yes to confirm:',
+      `  chroxy schedule delete ${task.id} --yes`,
+    ].join('\n'))
+    return { deleted: false, confirmed: false, task }
+  }
+
+  const removed = deps.store.remove(task.id)
+  if (!removed) {
+    out(`No scheduled task with id ${task.id} (it may have already been deleted).`)
+    return { deleted: false, error: 'not-found' }
+  }
+  out(`Deleted scheduled task ${task.id}${task.name ? ` (${task.name})` : ''}.`)
+  return { deleted: true, confirmed: true, task }
+}
+
+/**
+ * `chroxy schedule last-run <id>` — the per-task detail view. A task that has
+ * never fired says so explicitly (`never run`, tag `[NEVER RUN]`) rather than
+ * showing a blank/empty field that could be mistaken for "nothing to report".
+ * @returns {{found:boolean, task?:object, health?:string, error?:string, message?:string}}
+ */
+export function runScheduleLastRun(idOrPrefix, options = {}, depsOverride = {}) {
+  const deps = buildDeps(depsOverride)
+  const out = deps.write
+  const resolved = resolveTaskId(deps.store, idOrPrefix)
+  if (resolved.error) {
+    out(resolved.error)
+    return { found: false, error: resolved.errorCode || 'not-found', message: resolved.error }
+  }
+  const task = resolved.task
+  const health = healthTag(task)
+
+  if (options.json) {
+    out(JSON.stringify({ task, health }, null, 2))
+    return { found: true, task, health }
+  }
+
+  out(`${task.name ? `${task.name} ` : ''}(${task.id})`)
+  out(`  state:    ${task.enabled ? 'enabled' : 'paused'}`)
+  out(`  cadence:  ${describeCadence(task.cadence)}`)
+  out(`  next run: ${task.enabled ? formatEpoch(task.nextRun) : '— (paused)'}`)
+  out(`  last run: [${health}] ${describeLastRun(task.lastRun)}`)
+  if (!task.lastRun) {
+    out(`  This task has never fired.${task.enabled ? '' : ' It is also currently paused.'}`)
+  }
+  if (!deps.checkSchedulerEnabled()) {
+    out('  NOTE: scheduled execution is DISABLED on this daemon — nothing will fire (including this task) until it is enabled.')
+  }
+  return { found: true, task, health }
+}
+
+// -- commander wiring --------------------------------------------------------
+
+export function registerScheduleCommands(program) {
+  const schedule = program
+    .command('schedule')
+    .description('Manage scheduled tasks (create/list/edit/pause/resume/delete/last-run) — #6868')
+
+  schedule
+    .command('create')
+    .description('Create a scheduled task')
+    .requiredOption('-p, --prompt <text>', 'Instructions the scheduled run executes')
+    .option('-n, --name <name>', 'Optional human-readable label')
+    .option('--at <when>', 'One-time cadence: ISO-8601 timestamp or epoch-ms (mutually exclusive with --cron)')
+    .option('--cron <expression>', '5-field crontab expression, e.g. "0 9 * * *" (mutually exclusive with --at)')
+    .option('--provider <name>', 'Target provider (default: the daemon default provider)')
+    .option('--model <name>', 'Target model')
+    .option('--cwd <path>', 'Target working directory')
+    .option('--permission-mode <mode>', 'Target permission mode: approve, acceptEdits, auto, plan (unattended runs are always clamped to approve/plan)')
+    .option('--paused', 'Create the task paused (enabled: false) — will not fire until resumed')
+    .option('--json', 'Output machine-readable JSON')
+    .action((options) => {
+      try {
+        const res = runScheduleCreate(options)
+        if (!res.created) process.exitCode = 1
+      } catch (err) {
+        console.error(`schedule create failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  schedule
+    .command('list')
+    .description('List scheduled tasks — enabled/paused state, next run, and last-run outcome')
+    .option('--json', 'Output machine-readable JSON')
+    .action((options) => {
+      try {
+        runScheduleList(options)
+      } catch (err) {
+        console.error(`schedule list failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  schedule
+    .command('edit <id>')
+    .description('Edit a scheduled task (id or unique id-prefix); pass an empty string to clear an optional field')
+    .option('-p, --prompt <text>', 'Replace the prompt')
+    .option('-n, --name <name>', 'Replace the label')
+    .option('--at <when>', 'Replace the cadence with a one-time run (mutually exclusive with --cron)')
+    .option('--cron <expression>', 'Replace the cadence with a recurring cron expression (mutually exclusive with --at)')
+    .option('--provider <name>', 'Replace the target provider')
+    .option('--model <name>', 'Replace the target model')
+    .option('--cwd <path>', 'Replace the target working directory')
+    .option('--permission-mode <mode>', 'Replace the target permission mode')
+    .option('--json', 'Output machine-readable JSON')
+    .action((id, options) => {
+      try {
+        const res = runScheduleEdit(id, options)
+        if (!res.updated) process.exitCode = 1
+      } catch (err) {
+        console.error(`schedule edit failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  schedule
+    .command('pause <id>')
+    .description('Pause a scheduled task (enabled: false) — reversible via `resume`')
+    .option('--json', 'Output machine-readable JSON')
+    .action((id, options) => {
+      try {
+        const res = runSchedulePause(id, options)
+        if (!res.changed) process.exitCode = 1
+      } catch (err) {
+        console.error(`schedule pause failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  schedule
+    .command('resume <id>')
+    .description('Resume a paused scheduled task (enabled: true)')
+    .option('--json', 'Output machine-readable JSON')
+    .action((id, options) => {
+      try {
+        const res = runScheduleResume(id, options)
+        if (!res.changed) process.exitCode = 1
+      } catch (err) {
+        console.error(`schedule resume failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  schedule
+    .command('delete <id>')
+    .description('Permanently delete a scheduled task (id or unique id-prefix)')
+    .option('--yes', 'Confirm the delete (without it, the command only explains what it would remove)')
+    .action((id, options) => {
+      try {
+        const res = runScheduleDelete(id, options)
+        if (res.error) process.exitCode = 1
+      } catch (err) {
+        console.error(`schedule delete failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  schedule
+    .command('last-run <id>')
+    .description('View the last recorded run outcome for a scheduled task (or "never run")')
+    .option('--json', 'Output machine-readable JSON')
+    .action((id, options) => {
+      try {
+        const res = runScheduleLastRun(id, options)
+        if (!res.found) process.exitCode = 1
+      } catch (err) {
+        console.error(`schedule last-run failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+}

--- a/packages/server/src/cli/schedule-cmd.js
+++ b/packages/server/src/cli/schedule-cmd.js
@@ -59,10 +59,49 @@ function readConfigSoft(configPath) {
   }
 }
 
-/** The registry file this daemon would load — a sibling of session-state.json. */
+/**
+ * The registry file THIS DAEMON would load — a sibling of session-state.json.
+ *
+ * Deliberately rooted at `homedir()/.chroxy` (shared.js's `CONFIG_DIR`) and
+ * deliberately NOT at `$CHROXY_CONFIG_DIR`, because the daemon's own registry
+ * path is home-rooted at every hop:
+ *
+ *   1. `server-cli.js` constructs its `SessionManager` withOUT a
+ *      `stateFilePath` (the string does not appear in that file at all), so the
+ *      manager falls back to `session-manager.js`'s `DEFAULT_STATE_FILE` =
+ *      `join(homedir(), '.chroxy', 'session-state.json')`.
+ *   2. `session-manager.js` then derives `this.scheduledTaskStore` from that
+ *      path via `defaultScheduledTasksPath()` — i.e. the live scheduler
+ *      (#6865) reads `~/.chroxy/scheduled-tasks.json`.
+ *
+ * Neither hop consults `CHROXY_CONFIG_DIR`. Plenty of OTHER subsystems do
+ * (models.js, connection-info.js, doctor.js, device-preferences.js, …), so the
+ * convention genuinely is inconsistent — that split is tracked in #7052, and
+ * fixing it means moving the WRITERS, not just this reader. Honouring the env var *here*
+ * would point this CLI at a file the running scheduler never opens, and
+ * `schedule create` would print "Created scheduled task …" for a task that can
+ * never fire while `schedule list` showed an empty registry. That is precisely
+ * the report-success-while-silently-wrong failure this module's doc block
+ * exists to prevent, so matching the daemon beats matching the convention.
+ *
+ * The same reasoning applies to `CONFIG_FILE` below: `server-cli-child.js`
+ * reads `join(homedir(), '.chroxy', 'config.json')`, so reading config from the
+ * home-rooted path is what makes `config.provider` / `features.scheduler` here
+ * agree with what the daemon resolved.
+ *
+ * Pinned from both sides by tests: a spawn test asserts the registry does NOT
+ * follow `CHROXY_CONFIG_DIR` (tests/cli/schedule-cmd.test.js), and a drift
+ * guard asserts the daemon-side path this mirrors is still home-rooted
+ * (tests/schedule-cli.test.js). If the session-state family is ever migrated
+ * onto `CHROXY_CONFIG_DIR` (#7052), the drift guard goes red and this resolver
+ * must move with it.
+ */
+export function defaultScheduleRegistryPath() {
+  return defaultScheduledTasksPath(join(CONFIG_DIR, 'session-state.json'))
+}
+
 function getDefaultStore() {
-  const stateFilePath = join(CONFIG_DIR, 'session-state.json')
-  const store = new ScheduledTaskStore({ filePath: defaultScheduledTasksPath(stateFilePath) })
+  const store = new ScheduledTaskStore({ filePath: defaultScheduleRegistryPath() })
   store.load()
   return store
 }
@@ -161,7 +200,17 @@ function describeLastRun(lastRun) {
 
 // -- input parsing ---------------------------------------------------------
 
-/** Parse `--at` into epoch-ms: bare digits are epoch-ms, else Date.parse (ISO-8601). */
+/**
+ * Parse `--at` into epoch-ms: bare digits are epoch-ms, else Date.parse (ISO-8601).
+ *
+ * Timezone handling is `Date.parse`'s, unchanged and on purpose: a date-time
+ * string with no offset (`2026-08-01T09:00:00`) is interpreted in the HOST's
+ * local timezone, while everything this CLI prints is UTC (`formatEpoch`).
+ * Re-interpreting an offset-less string as UTC would silently move every
+ * already-scripted `--at` invocation by the operator's UTC offset, so the fix
+ * for the mismatch is to make the hint and the `--at` help text say which is
+ * which — not to change what a given string means. See #7015.
+ */
 function parseAtValue(raw) {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return { error: '--at requires a value' }
@@ -177,7 +226,9 @@ function parseAtValue(raw) {
   if (Number.isNaN(parsed)) {
     return {
       error: `--at '${raw}' could not be parsed — use an ISO-8601 timestamp `
-        + '(e.g. 2026-08-01T09:00:00) or epoch milliseconds',
+        + '(e.g. 2026-08-01T09:00:00Z) or epoch milliseconds. Times are displayed in UTC; '
+        + 'a timestamp with no timezone is read as LOCAL time, so add a trailing Z '
+        + '(or a ±hh:mm offset) to say exactly which instant you mean',
     }
   }
   return { at: parsed }
@@ -604,7 +655,7 @@ export function registerScheduleCommands(program) {
     .description('Create a scheduled task')
     .requiredOption('-p, --prompt <text>', 'Instructions the scheduled run executes')
     .option('-n, --name <name>', 'Optional human-readable label')
-    .option('--at <when>', 'One-time cadence: ISO-8601 timestamp or epoch-ms (mutually exclusive with --cron)')
+    .option('--at <when>', 'One-time cadence: ISO-8601 timestamp (e.g. 2026-08-01T09:00:00Z — no timezone means LOCAL time; times are displayed in UTC) or epoch-ms (mutually exclusive with --cron)')
     .option('--cron <expression>', '5-field crontab expression, e.g. "0 9 * * *" (mutually exclusive with --at)')
     .option('--provider <name>', 'Target provider (default: the daemon default provider)')
     .option('--model <name>', 'Target model')
@@ -640,7 +691,7 @@ export function registerScheduleCommands(program) {
     .description('Edit a scheduled task (id or unique id-prefix); pass an empty string to clear an optional field')
     .option('-p, --prompt <text>', 'Replace the prompt')
     .option('-n, --name <name>', 'Replace the label')
-    .option('--at <when>', 'Replace the cadence with a one-time run (mutually exclusive with --cron)')
+    .option('--at <when>', 'Replace the cadence with a one-time run: ISO-8601 timestamp (add a trailing Z for UTC — no timezone means LOCAL time) or epoch-ms (mutually exclusive with --cron)')
     .option('--cron <expression>', 'Replace the cadence with a recurring cron expression (mutually exclusive with --at)')
     .option('--provider <name>', 'Replace the target provider')
     .option('--model <name>', 'Replace the target model')

--- a/packages/server/tests/cli/schedule-cmd.test.js
+++ b/packages/server/tests/cli/schedule-cmd.test.js
@@ -7,7 +7,16 @@
  */
 import { describe, it, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
 import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+/** Write `~/.chroxy/config.json` with the given `provider` into a temp HOME. */
+function writeConfig(home, config) {
+  const dir = join(home, '.chroxy')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'config.json'), JSON.stringify(config, null, 2))
+}
 
 // The store logs an INFO line ("Loaded N scheduled task(s)") to stdout ahead
 // of --json output on any non-empty load — strip to the first `{` so this
@@ -97,6 +106,46 @@ describe('chroxy schedule — CLI wiring (#6868)', () => {
     const r = await runCli(['schedule', 'create', '--prompt', 'x', '--cron', 'garbage'])
     assert.notEqual(r.code, 0)
     assert.match(r.stdout, /Invalid schedule/)
+  })
+
+  // #7014 — the provider-refusal warning must follow the daemon's OWN
+  // resolution of "the effective default provider" (config.provider ||
+  // DEFAULT_PROVIDER, mirroring server-cli.js), not a hardcoded
+  // DEFAULT_PROVIDER constant. These two cases prove the warning tracks
+  // config.json rather than the constant: a configured provider that IS
+  // schedulable (in-process permissions) must NOT warn even though
+  // DEFAULT_PROVIDER (claude-tui) would; a configured provider that is
+  // hook-routed must warn even without any --provider flag.
+  describe('provider-refusal warning follows config.provider, not the DEFAULT_PROVIDER constant (#7014)', () => {
+    it('does not warn when config.provider is a schedulable (in-process-permissions) provider', async () => {
+      const { home, cleanup } = makeTempHome()
+      try {
+        writeConfig(home, { provider: 'claude-sdk' })
+        const r = await runCli(
+          ['schedule', 'create', '--prompt', 'x', '--cron', '0 9 * * *'],
+          { home },
+        )
+        assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+        assert.doesNotMatch(r.stdout, /will be REFUSED/)
+      } finally {
+        cleanup()
+      }
+    })
+
+    it('warns when config.provider is a hook-routed provider, with no --provider flag given', async () => {
+      const { home, cleanup } = makeTempHome()
+      try {
+        writeConfig(home, { provider: 'claude-tui' })
+        const r = await runCli(
+          ['schedule', 'create', '--prompt', 'x', '--cron', '0 9 * * *'],
+          { home },
+        )
+        assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+        assert.match(r.stdout, /WARNING:.*will be REFUSED/)
+      } finally {
+        cleanup()
+      }
+    })
   })
 
   it('pause/resume/edit/delete on an unknown id exit non-zero with a clear message', async () => {

--- a/packages/server/tests/cli/schedule-cmd.test.js
+++ b/packages/server/tests/cli/schedule-cmd.test.js
@@ -7,8 +7,9 @@
  */
 import { describe, it, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
+import { tmpdir } from 'os'
 import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
 
 /** Write `~/.chroxy/config.json` with the given `provider` into a temp HOME. */
@@ -146,6 +147,50 @@ describe('chroxy schedule — CLI wiring (#6868)', () => {
         cleanup()
       }
     })
+  })
+
+  // #7015 — `chroxy schedule` must read/write the registry the RUNNING daemon
+  // reads. That path is home-rooted at every hop: server-cli.js constructs its
+  // SessionManager with no stateFilePath, so the manager falls back to
+  // ~/.chroxy/session-state.json and derives ~/.chroxy/scheduled-tasks.json
+  // from it. Neither hop consults CHROXY_CONFIG_DIR, even though other
+  // subsystems (models.js, doctor.js, connection-info.js) do. If this CLI
+  // followed the env var instead, `create` would report "Created scheduled
+  // task" into a file the scheduler never opens and `list` would come back
+  // empty — a task that silently never fires. Point CHROXY_CONFIG_DIR at a
+  // DIFFERENT directory and prove the registry stays where the daemon looks.
+  it('keeps the registry under $HOME/.chroxy when CHROXY_CONFIG_DIR points elsewhere', async () => {
+    const { home, cleanup } = makeTempHome()
+    const elsewhere = mkdtempSync(join(tmpdir(), 'chroxy-cfgdir-'))
+    try {
+      const created = await runCli(
+        ['schedule', 'create', '--prompt', 'x', '--cron', '0 9 * * *', '--name', 'EnvProbe'],
+        { home, env: { CHROXY_CONFIG_DIR: elsewhere } },
+      )
+      assert.equal(created.code, 0, `stderr: ${created.stderr}`)
+
+      assert.ok(
+        existsSync(join(home, '.chroxy', 'scheduled-tasks.json')),
+        'registry must land beside the session-state file the daemon actually loads',
+      )
+      assert.ok(
+        !existsSync(join(elsewhere, 'scheduled-tasks.json')),
+        'registry must NOT follow CHROXY_CONFIG_DIR — the daemon scheduler never reads it there',
+      )
+
+      // Same resolution on the read side, so create and list can't disagree.
+      const listed = await runCli(
+        ['schedule', 'list', '--json'],
+        { home, env: { CHROXY_CONFIG_DIR: elsewhere } },
+      )
+      assert.equal(listed.code, 0, `stderr: ${listed.stderr}`)
+      const { tasks } = parseJsonStdout(listed.stdout)
+      assert.equal(tasks.length, 1, 'list must find the task create just wrote')
+      assert.equal(tasks[0].name, 'EnvProbe')
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true })
+      cleanup()
+    }
   })
 
   it('pause/resume/edit/delete on an unknown id exit non-zero with a clear message', async () => {

--- a/packages/server/tests/cli/schedule-cmd.test.js
+++ b/packages/server/tests/cli/schedule-cmd.test.js
@@ -1,0 +1,115 @@
+/**
+ * E2E coverage for `chroxy schedule` — spawns the real CLI binary (via
+ * runCli, which isolates HOME/CHROXY_CONFIG_DIR per child process) so the
+ * commander wiring in src/cli.js -> registerScheduleCommands is exercised
+ * end-to-end, not just the pure functions in src/cli/schedule-cmd.js
+ * (covered in depth by tests/schedule-cli.test.js).
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+// The store logs an INFO line ("Loaded N scheduled task(s)") to stdout ahead
+// of --json output on any non-empty load — strip to the first `{` so this
+// suite doesn't couple to that logger's exact format.
+function parseJsonStdout(stdout) {
+  return JSON.parse(stdout.slice(stdout.indexOf('{')))
+}
+
+describe('chroxy schedule — CLI wiring (#6868)', () => {
+  it('registers the schedule command group with all subcommands', async () => {
+    const r = await runCli(['schedule', '--help'])
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /Manage scheduled tasks/)
+    for (const cmd of ['create', 'list', 'edit', 'pause', 'resume', 'delete', 'last-run']) {
+      assert.match(r.stdout, new RegExp(cmd), `missing "${cmd}" in --help output`)
+    }
+  })
+
+  it('schedule create --help lists the cadence and target flags', async () => {
+    const r = await runCli(['schedule', 'create', '--help'])
+    assert.equal(r.code, 0)
+    assert.match(r.stdout, /--prompt/)
+    assert.match(r.stdout, /--at/)
+    assert.match(r.stdout, /--cron/)
+    assert.match(r.stdout, /--provider/)
+    assert.match(r.stdout, /--permission-mode/)
+  })
+
+  describe('create -> list -> last-run -> delete round trip', () => {
+    const { home, cleanup } = makeTempHome()
+    after(cleanup)
+
+    it('create persists a task and reports the default-off scheduler + provider-refusal warnings', async () => {
+      const r = await runCli(
+        ['schedule', 'create', '--prompt', 'say hi', '--cron', '0 9 * * *', '--name', 'Morning'],
+        { home },
+      )
+      assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+      assert.match(r.stdout, /Created scheduled task/)
+      // No config.json / CHROXY_ENABLE_SCHEDULER in this temp HOME -> gate closed.
+      assert.match(r.stdout, /WARNING:.*DISABLED/)
+      // No target.provider given -> falls back to the daemon default
+      // (claude-tui), which the engine refuses (no in-process permissions).
+      assert.match(r.stdout, /WARNING:.*will be REFUSED/)
+    })
+
+    it('list shows the task as [NEVER RUN], never healthy-looking', async () => {
+      const r = await runCli(['schedule', 'list'], { home })
+      assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+      assert.match(r.stdout, /Scheduled execution: DISABLED/)
+      assert.match(r.stdout, /\[NEVER RUN\] Morning/)
+    })
+
+    it('last-run reports "never run" honestly for the fresh task', async () => {
+      const listRes = await runCli(['schedule', 'list', '--json'], { home })
+      const { tasks } = parseJsonStdout(listRes.stdout)
+      const id = tasks[0].id
+
+      const r = await runCli(['schedule', 'last-run', id], { home })
+      assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+      assert.match(r.stdout, /\[NEVER RUN\] never run/)
+      assert.match(r.stdout, /This task has never fired/)
+    })
+
+    it('delete without --yes explains and removes nothing; with --yes removes it', async () => {
+      const listRes = await runCli(['schedule', 'list', '--json'], { home })
+      const { tasks } = parseJsonStdout(listRes.stdout)
+      const id = tasks[0].id
+
+      const dry = await runCli(['schedule', 'delete', id], { home })
+      assert.equal(dry.code, 0)
+      assert.match(dry.stdout, /re-run with --yes/)
+
+      const stillThere = await runCli(['schedule', 'list', '--json'], { home })
+      assert.equal(parseJsonStdout(stillThere.stdout).tasks.length, 1, 'not deleted without --yes')
+
+      const confirmed = await runCli(['schedule', 'delete', id, '--yes'], { home })
+      assert.equal(confirmed.code, 0)
+      assert.match(confirmed.stdout, /Deleted scheduled task/)
+
+      const gone = await runCli(['schedule', 'list', '--json'], { home })
+      assert.equal(parseJsonStdout(gone.stdout).tasks.length, 0)
+    })
+  })
+
+  it('create rejects an invalid cron expression and exits non-zero', async () => {
+    const r = await runCli(['schedule', 'create', '--prompt', 'x', '--cron', 'garbage'])
+    assert.notEqual(r.code, 0)
+    assert.match(r.stdout, /Invalid schedule/)
+  })
+
+  it('pause/resume/edit/delete on an unknown id exit non-zero with a clear message', async () => {
+    const { home, cleanup } = makeTempHome()
+    try {
+      const pause = await runCli(['schedule', 'pause', 'does-not-exist'], { home })
+      assert.notEqual(pause.code, 0)
+      assert.match(pause.stdout, /No scheduled task matches/)
+
+      const del = await runCli(['schedule', 'delete', 'does-not-exist', '--yes'], { home })
+      assert.notEqual(del.code, 0)
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/packages/server/tests/schedule-cli.test.js
+++ b/packages/server/tests/schedule-cli.test.js
@@ -1,0 +1,521 @@
+// `chroxy schedule` command handlers (#6868). Exercises the pure exported
+// functions in src/cli/schedule-cmd.js directly against a REAL
+// ScheduledTaskStore pointed at a per-test temp file — never the real
+// ~/.chroxy/ tree (the sandbox guard in tests/_setup.mjs would throw loudly
+// if we tried). Using the real store means cadence validation and nextRun
+// computation run through the actual schedule-parser.js code path, not a
+// re-implemented fake.
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { ScheduledTaskStore } from '../src/scheduled-task-store.js'
+import {
+  runScheduleCreate,
+  runScheduleList,
+  runScheduleEdit,
+  runSchedulePause,
+  runScheduleResume,
+  runScheduleDelete,
+  runScheduleLastRun,
+} from '../src/cli/schedule-cmd.js'
+
+const NOW = 1_800_000_000_000 // fixed clock so nextRun/formatted timestamps are deterministic
+
+function makeStore(now = NOW) {
+  const dir = mkdtempSync(join(tmpdir(), 'schedule-cli-test-'))
+  const store = new ScheduledTaskStore({ filePath: join(dir, 'scheduled-tasks.json'), now: () => now })
+  store.load()
+  return store
+}
+
+function cap() {
+  const lines = []
+  return { write: (s) => lines.push(String(s)), lines, text: () => lines.join('\n') }
+}
+
+/** Deps with every engine-reuse seam stubbed to a harmless default; override per test. */
+function baseDeps(store, w, overrides = {}) {
+  return {
+    store,
+    write: w,
+    defaultProviderName: 'claude-tui',
+    checkProviderRefusal: () => null,
+    resolvePermissionMode: (mode) => mode,
+    checkSchedulerEnabled: () => true,
+    ...overrides,
+  }
+}
+
+describe('chroxy schedule create (#6868)', () => {
+  it('creates a recurring task from --cron and persists via the store (computed nextRun surfaced)', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate(
+      { prompt: 'summarize the inbox', cron: '0 9 * * *', name: 'Morning summary' },
+      baseDeps(store, w.write),
+    )
+    assert.equal(res.created, true)
+    assert.equal(res.task.name, 'Morning summary')
+    assert.deepEqual(res.task.cadence, { kind: 'cron', expression: '0 9 * * *' })
+    assert.equal(typeof res.task.nextRun, 'number')
+    assert.equal(store.list().length, 1, 'persisted to the store')
+    assert.match(w.text(), /Created scheduled task/)
+    assert.match(w.text(), /cron "0 9 \* \* \*"/)
+  })
+
+  it('creates a one-time task from an ISO --at and from an epoch-ms --at', () => {
+    const store = makeStore()
+    const w = cap()
+    const iso = runScheduleCreate({ prompt: 'once', at: '2099-01-01T00:00:00Z' }, baseDeps(store, w.write))
+    assert.equal(iso.created, true)
+    assert.deepEqual(iso.task.cadence, { kind: 'once', at: Date.parse('2099-01-01T00:00:00Z') })
+
+    const epoch = runScheduleCreate({ prompt: 'once2', at: '4102444800000' }, baseDeps(store, w.write))
+    assert.equal(epoch.created, true)
+    assert.deepEqual(epoch.task.cadence, { kind: 'once', at: 4102444800000 })
+  })
+
+  it('rejects an invalid cron expression via schedule-parser.js and persists nothing', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate({ prompt: 'bad', cron: 'not a cron' }, baseDeps(store, w.write))
+    assert.equal(res.created, false)
+    assert.equal(res.error, 'validation')
+    assert.equal(res.field, 'cadence.expression')
+    assert.match(res.message, /invalid cron expression/)
+    assert.equal(store.list().length, 0, 'nothing persisted on validation failure')
+    assert.match(w.text(), /Invalid schedule/)
+  })
+
+  it('rejects an unparseable --at and persists nothing', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate({ prompt: 'bad', at: 'not-a-date' }, baseDeps(store, w.write))
+    assert.equal(res.created, false)
+    assert.equal(res.error, 'invalid-cadence')
+    assert.equal(store.list().length, 0)
+  })
+
+  it('requires exactly one of --at / --cron', () => {
+    const store = makeStore()
+    const neither = runScheduleCreate({ prompt: 'x' }, baseDeps(store, cap().write))
+    assert.equal(neither.error, 'invalid-cadence')
+    assert.match(neither.message, /specify a cadence/)
+
+    const both = runScheduleCreate({ prompt: 'x', at: '2099-01-01T00:00:00Z', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    assert.equal(both.error, 'invalid-cadence')
+    assert.match(both.message, /mutually exclusive/)
+    assert.equal(store.list().length, 0)
+  })
+
+  it('requires a non-empty prompt', () => {
+    const store = makeStore()
+    const res = runScheduleCreate({ cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    assert.equal(res.error, 'missing-prompt')
+    assert.equal(store.list().length, 0)
+  })
+
+  it('--paused creates the task disabled with no next run', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', paused: true }, baseDeps(store, w.write))
+    assert.equal(res.task.enabled, false)
+    assert.equal(res.task.nextRun, null)
+    assert.match(w.text(), /paused; resume with/)
+  })
+
+  // The core honesty requirement: a task whose target provider the engine
+  // would REFUSE (e.g. the daemon default claude-tui — no in-process
+  // permission answering) must warn AT CREATE TIME, using the engine's own
+  // check (injected here as checkProviderRefusal) rather than a re-derived rule.
+  it('warns at create time when the target provider would be refused by the engine', () => {
+    const store = makeStore()
+    const w = cap()
+    const reason = "provider 'claude-tui' routes permission prompts through the permission hook..."
+    const res = runScheduleCreate(
+      { prompt: 'x', cron: '0 9 * * *' },
+      baseDeps(store, w.write, { checkProviderRefusal: (name) => (name === 'claude-tui' ? reason : null) }),
+    )
+    assert.equal(res.created, true, 'the task is still created — a warning, not a hard error')
+    assert.ok(res.warnings.some((msg) => msg.includes('will be REFUSED') && msg.includes(reason)))
+    assert.match(w.text(), /WARNING:.*will be REFUSED/)
+  })
+
+  it('does not warn about the provider when the engine reports it schedulable', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate(
+      { prompt: 'x', cron: '0 9 * * *', provider: 'claude-sdk' },
+      baseDeps(store, w.write, { checkProviderRefusal: () => null }),
+    )
+    assert.equal(res.warnings.length, 0)
+    assert.doesNotMatch(w.text(), /REFUSED/)
+  })
+
+  // The scheduler is default-off: create must still succeed but say plainly
+  // that nothing will fire until the gate is opened.
+  it('warns plainly when the scheduler is globally disabled, but still creates the task', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate(
+      { prompt: 'x', cron: '0 9 * * *' },
+      baseDeps(store, w.write, { checkSchedulerEnabled: () => false }),
+    )
+    assert.equal(res.created, true)
+    assert.ok(res.warnings.some((msg) => /DISABLED/.test(msg) && /features\.scheduler/.test(msg)))
+    assert.match(w.text(), /WARNING:.*DISABLED/)
+  })
+
+  it('does not warn about the scheduler gate when it is enabled', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, w.write, { checkSchedulerEnabled: () => true }))
+    assert.equal(res.warnings.length, 0)
+  })
+
+  it('warns when the requested permission mode will be clamped by the engine', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate(
+      { prompt: 'x', cron: '0 9 * * *', permissionMode: 'auto' },
+      baseDeps(store, w.write, { resolvePermissionMode: () => 'approve' }),
+    )
+    assert.ok(res.warnings.some((msg) => msg.includes("clamped to 'approve'")))
+  })
+
+  it('rejects a malformed permission mode via the store\'s own validation', () => {
+    const store = makeStore()
+    const res = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', permissionMode: 'godmode' }, baseDeps(store, cap().write))
+    assert.equal(res.error, 'validation')
+    assert.equal(res.field, 'target.permissionMode')
+  })
+})
+
+describe('chroxy schedule list (#6868)', () => {
+  it('reports the scheduler enable-gate state up top', () => {
+    const store = makeStore()
+    const wOn = cap()
+    runScheduleList({}, baseDeps(store, wOn.write, { checkSchedulerEnabled: () => true }))
+    assert.match(wOn.text(), /Scheduled execution: ENABLED/)
+
+    const wOff = cap()
+    runScheduleList({}, baseDeps(store, wOff.write, { checkSchedulerEnabled: () => false }))
+    assert.match(wOff.text(), /Scheduled execution: DISABLED/)
+  })
+
+  it('a never-fired task renders as [NEVER RUN], never blank or healthy-looking', () => {
+    const store = makeStore()
+    runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'Fresh' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runScheduleList({}, baseDeps(store, w.write))
+    assert.equal(res.tasks[0].health, 'NEVER RUN')
+    assert.match(w.text(), /\[NEVER RUN\] Fresh/)
+    assert.match(w.text(), /last run: never run/)
+  })
+
+  it('a refused-outcome task renders as [REFUSED] with the reason visible, never as healthy', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'Nightly' }, baseDeps(store, cap().write))
+    store.update(created.task.id, {
+      lastRun: { at: NOW - 1000, status: 'refused', error: "provider 'claude-tui' routes permission prompts..." },
+    })
+    const w = cap()
+    const res = runScheduleList({}, baseDeps(store, w.write))
+    const row = res.tasks.find((r) => r.task.id === created.task.id)
+    assert.equal(row.health, 'REFUSED')
+    assert.match(w.text(), /\[REFUSED\] Nightly/)
+    assert.match(w.text(), /last run: refused @ .* — provider 'claude-tui'/)
+  })
+
+  // Quarantine (scheduler.js's `_quarantine`) is process-scoped and has no
+  // dedicated persisted field — its only durable trace is a best-effort
+  // lastRun write of status `refused` with a "quarantined until daemon
+  // restart" message. `list` must render that exactly as unhealthy as any
+  // other refusal — it must NEVER look like a clean/successful task just
+  // because the underlying status enum only has `refused`.
+  it('a quarantined task (persisted as refused + quarantine message) never looks healthy', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'Quarantined one' }, baseDeps(store, cap().write))
+    store.update(created.task.id, {
+      lastRun: {
+        at: NOW - 1000,
+        status: 'refused',
+        error: 'quarantined until daemon restart: its run outcome could not be recorded: disk full',
+      },
+    })
+    const w = cap()
+    const res = runScheduleList({}, baseDeps(store, w.write))
+    const row = res.tasks.find((r) => r.task.id === created.task.id)
+    assert.equal(row.health, 'REFUSED', 'quarantine surfaces as REFUSED, never OK')
+    assert.notEqual(row.health, 'OK')
+    assert.match(w.text(), /\[REFUSED\] Quarantined one/)
+    assert.match(w.text(), /quarantined until daemon restart/)
+  })
+
+  it('a paused task renders as [PAUSED] with no next run', () => {
+    const store = makeStore()
+    runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'Off', paused: true }, baseDeps(store, cap().write))
+    const w = cap()
+    runScheduleList({}, baseDeps(store, w.write))
+    assert.match(w.text(), /\[PAUSED\] Off/)
+    assert.match(w.text(), /next run: — \(paused\)/)
+  })
+
+  it('a successfully-run task renders as [OK]', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'Healthy' }, baseDeps(store, cap().write))
+    store.update(created.task.id, { lastRun: { at: NOW - 1000, status: 'success', sessionId: 'sess-1' } })
+    const w = cap()
+    const res = runScheduleList({}, baseDeps(store, w.write))
+    assert.equal(res.tasks.find((r) => r.task.id === created.task.id).health, 'OK')
+    assert.match(w.text(), /\[OK\] Healthy/)
+    assert.match(w.text(), /session sess-1/)
+  })
+
+  it('--json emits the same data machine-readably, including health and providerRefusal', () => {
+    const store = makeStore()
+    runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'J' }, baseDeps(store, cap().write))
+    const w = cap()
+    runScheduleList({ json: true }, baseDeps(store, w.write, { checkProviderRefusal: () => 'nope' }))
+    const parsed = JSON.parse(w.text())
+    assert.equal(parsed.schedulerEnabled, true)
+    assert.equal(parsed.tasks.length, 1)
+    assert.equal(parsed.tasks[0].health, 'NEVER RUN')
+    assert.equal(parsed.tasks[0].providerRefusal, 'nope')
+  })
+
+  it('an empty registry says so instead of printing nothing', () => {
+    const store = makeStore()
+    const w = cap()
+    runScheduleList({}, baseDeps(store, w.write))
+    assert.match(w.text(), /No scheduled tasks/)
+  })
+})
+
+describe('chroxy schedule edit (#6868)', () => {
+  it('updates the prompt in place', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'old', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runScheduleEdit(created.task.id, { prompt: 'new prompt' }, baseDeps(store, w.write))
+    assert.equal(res.updated, true)
+    assert.equal(res.task.prompt, 'new prompt')
+  })
+
+  it('replaces the cadence via --cron and recomputes nextRun', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', at: '2099-01-01T00:00:00Z' }, baseDeps(store, cap().write))
+    const res = runScheduleEdit(created.task.id, { cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    assert.equal(res.updated, true)
+    assert.deepEqual(res.task.cadence, { kind: 'cron', expression: '0 9 * * *' })
+  })
+
+  it('rejects mutually-exclusive --at and --cron on edit', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const res = runScheduleEdit(created.task.id, { at: '2099-01-01T00:00:00Z', cron: '0 8 * * *' }, baseDeps(store, cap().write))
+    assert.equal(res.error, 'invalid-cadence')
+  })
+
+  it('rejects an invalid cron on edit without mutating the stored task', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const res = runScheduleEdit(created.task.id, { cron: 'garbage' }, baseDeps(store, cap().write))
+    assert.equal(res.updated, false)
+    assert.equal(res.error, 'validation')
+    assert.deepEqual(store.get(created.task.id).cadence, { kind: 'cron', expression: '0 9 * * *' }, 'unchanged')
+  })
+
+  // store.update() REPLACES the whole target object on a `target` patch key,
+  // so editing just --model must not silently drop an existing --provider.
+  it('merges a single target field onto the EXISTING target rather than replacing it wholesale', () => {
+    const store = makeStore()
+    const created = runScheduleCreate(
+      { prompt: 'x', cron: '0 9 * * *', provider: 'claude-sdk', cwd: '/work' },
+      baseDeps(store, cap().write),
+    )
+    const res = runScheduleEdit(created.task.id, { model: 'sonnet' }, baseDeps(store, cap().write))
+    assert.equal(res.task.target.provider, 'claude-sdk', 'provider survives an unrelated --model edit')
+    assert.equal(res.task.target.cwd, '/work', 'cwd survives an unrelated --model edit')
+    assert.equal(res.task.target.model, 'sonnet')
+  })
+
+  it('rejects editing an unknown id', () => {
+    const store = makeStore()
+    const res = runScheduleEdit('does-not-exist', { name: 'x' }, baseDeps(store, cap().write))
+    assert.equal(res.updated, false)
+    assert.equal(res.error, 'no-match')
+  })
+
+  it('is a no-op (and says so) when no fields are passed', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runScheduleEdit(created.task.id, {}, baseDeps(store, w.write))
+    assert.equal(res.updated, false)
+    assert.equal(res.error, 'no-changes')
+    assert.match(w.text(), /Nothing to edit/)
+  })
+
+  it('surfaces the same create-time-style warnings after an edit (e.g. a provider swap into a refused one)', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', provider: 'claude-sdk' }, baseDeps(store, cap().write))
+    const res = runScheduleEdit(
+      created.task.id,
+      { provider: 'claude-tui' },
+      baseDeps(store, cap().write, { checkProviderRefusal: (name) => (name === 'claude-tui' ? 'nope' : null) }),
+    )
+    assert.ok(res.warnings.some((m) => m.includes('will be REFUSED')))
+  })
+})
+
+describe('chroxy schedule pause / resume (#6868)', () => {
+  it('pause sets enabled=false and clears nextRun', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runSchedulePause(created.task.id, {}, baseDeps(store, w.write))
+    assert.equal(res.changed, true)
+    assert.equal(res.task.enabled, false)
+    assert.equal(res.task.nextRun, null)
+    assert.match(w.text(), /paused/)
+  })
+
+  it('resume sets enabled=true and recomputes nextRun', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', paused: true }, baseDeps(store, cap().write))
+    assert.equal(created.task.nextRun, null)
+    const w = cap()
+    const res = runScheduleResume(created.task.id, {}, baseDeps(store, w.write))
+    assert.equal(res.task.enabled, true)
+    assert.equal(typeof res.task.nextRun, 'number')
+    assert.match(w.text(), /resumed/)
+  })
+
+  it('pausing an unknown id fails clearly without touching the store', () => {
+    const store = makeStore()
+    const res = runSchedulePause('nope', {}, baseDeps(store, cap().write))
+    assert.equal(res.changed, false)
+    assert.equal(res.error, 'no-match')
+  })
+
+  it('pause does not require --yes (fully reversible via resume)', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const res = runSchedulePause(created.task.id, {}, baseDeps(store, cap().write))
+    assert.equal(res.changed, true)
+  })
+})
+
+describe('chroxy schedule delete (#6868)', () => {
+  it('without --yes explains what would be removed and deletes nothing', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'ToDelete' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runScheduleDelete(created.task.id, {}, baseDeps(store, w.write))
+    assert.equal(res.deleted, false)
+    assert.equal(res.confirmed, false)
+    assert.equal(store.list().length, 1, 'nothing removed without --yes')
+    assert.match(w.text(), /re-run with --yes/)
+    assert.match(w.text(), /cannot be undone/)
+  })
+
+  it('with --yes permanently deletes the task', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runScheduleDelete(created.task.id, { yes: true }, baseDeps(store, w.write))
+    assert.equal(res.deleted, true)
+    assert.equal(store.list().length, 0)
+    assert.match(w.text(), /Deleted scheduled task/)
+  })
+
+  it('deleting an unknown id fails clearly', () => {
+    const store = makeStore()
+    const res = runScheduleDelete('nope', { yes: true }, baseDeps(store, cap().write))
+    assert.equal(res.deleted, false)
+    assert.equal(res.error, 'no-match')
+  })
+
+  it('resolves a unique id prefix for delete', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const prefix = created.task.id.slice(0, 8)
+    const res = runScheduleDelete(prefix, { yes: true }, baseDeps(store, cap().write))
+    assert.equal(res.deleted, true)
+  })
+})
+
+describe('chroxy schedule last-run (#6868)', () => {
+  it('a never-run task is reported honestly, not blank or omitted', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *', name: 'Fresh' }, baseDeps(store, cap().write))
+    const w = cap()
+    const res = runScheduleLastRun(created.task.id, {}, baseDeps(store, w.write))
+    assert.equal(res.found, true)
+    assert.equal(res.health, 'NEVER RUN')
+    assert.match(w.text(), /\[NEVER RUN\] never run/)
+    assert.match(w.text(), /This task has never fired/)
+  })
+
+  it('a refused task shows the refusal reason, tagged unhealthy', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    store.update(created.task.id, { lastRun: { at: NOW, status: 'refused', error: 'bad cwd' } })
+    const w = cap()
+    const res = runScheduleLastRun(created.task.id, {}, baseDeps(store, w.write))
+    assert.equal(res.health, 'REFUSED')
+    assert.match(w.text(), /\[REFUSED\] refused @ .* — bad cwd/)
+  })
+
+  it('notes when the scheduler is globally disabled even for a healthy-looking task', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    store.update(created.task.id, { lastRun: { at: NOW, status: 'success' } })
+    const w = cap()
+    runScheduleLastRun(created.task.id, {}, baseDeps(store, w.write, { checkSchedulerEnabled: () => false }))
+    assert.match(w.text(), /scheduled execution is DISABLED/)
+  })
+
+  it('an unknown id fails clearly', () => {
+    const store = makeStore()
+    const res = runScheduleLastRun('nope', {}, baseDeps(store, cap().write))
+    assert.equal(res.found, false)
+    assert.equal(res.error, 'no-match')
+  })
+})
+
+describe('chroxy schedule — id / id-prefix resolution (#6868)', () => {
+  it('an ambiguous id prefix is rejected without acting on either task', () => {
+    const store = makeStore()
+    const a = runScheduleCreate({ prompt: 'a', cron: '0 9 * * *' }, baseDeps(store, cap().write)).task
+    // Force a shared prefix by editing nothing — instead, resolve using the
+    // shortest common prefix of the two real ids (UUIDs collide on a 1-char
+    // prefix with overwhelming probability across enough attempts is not
+    // practical to assert on directly, so exercise the ambiguity path via a
+    // deliberately short, near-certain-to-match single hex character).
+    const b = runScheduleCreate({ prompt: 'b', cron: '0 9 * * *' }, baseDeps(store, cap().write)).task
+    let sharedPrefixLen = 0
+    while (sharedPrefixLen < a.id.length && a.id[sharedPrefixLen] === b.id[sharedPrefixLen]) sharedPrefixLen++
+    if (sharedPrefixLen === 0) {
+      // Extremely unlikely for two random UUIDs, but if it happens this test
+      // has nothing to assert — skip gracefully rather than flake.
+      return
+    }
+    const prefix = a.id.slice(0, sharedPrefixLen)
+    const res = runScheduleEdit(prefix, { name: 'x' }, baseDeps(store, cap().write))
+    assert.equal(res.error, 'ambiguous')
+    assert.equal(store.get(a.id).name, null)
+    assert.equal(store.get(b.id).name, null)
+  })
+
+  it('a unique id prefix resolves correctly for last-run', () => {
+    const store = makeStore()
+    const created = runScheduleCreate({ prompt: 'x', cron: '0 9 * * *' }, baseDeps(store, cap().write))
+    const res = runScheduleLastRun(created.task.id.slice(0, 12), {}, baseDeps(store, cap().write))
+    assert.equal(res.found, true)
+    assert.equal(res.task.id, created.task.id)
+  })
+})

--- a/packages/server/tests/schedule-cli.test.js
+++ b/packages/server/tests/schedule-cli.test.js
@@ -488,27 +488,60 @@ describe('chroxy schedule last-run (#6868)', () => {
 })
 
 describe('chroxy schedule — id / id-prefix resolution (#6868)', () => {
-  it('an ambiguous id prefix is rejected without acting on either task', () => {
+  // #7015 — the old version of this test derived its ambiguous prefix from
+  // two random UUIDs' *actual* shared leading characters, which only exist
+  // ~6% of the time (1/16 chance two random hex digits match); every other
+  // run silently returned early with nothing asserted. `resolveTaskId`
+  // guards every mutating command (`edit`/`pause`/`resume`/`delete`) against
+  // resolving an ambiguous prefix to the WRONG task — on `delete` that is a
+  // destructive/irreversible action, so this must be deterministic, not
+  // probabilistic. Seed two tasks via `store.add()`'s caller-supplied `id`
+  // (a real, store-supported input field, not a stub) with a fixed shared
+  // prefix, guaranteeing ambiguity on every run.
+  function seedTask(store, id) {
+    return store.add({ id, prompt: 'x', cadence: { kind: 'cron', expression: '0 9 * * *' } })
+  }
+
+  it('a prefix matching >1 task is rejected as ambiguous and resolves NO task on edit or delete', () => {
     const store = makeStore()
-    const a = runScheduleCreate({ prompt: 'a', cron: '0 9 * * *' }, baseDeps(store, cap().write)).task
-    // Force a shared prefix by editing nothing — instead, resolve using the
-    // shortest common prefix of the two real ids (UUIDs collide on a 1-char
-    // prefix with overwhelming probability across enough attempts is not
-    // practical to assert on directly, so exercise the ambiguity path via a
-    // deliberately short, near-certain-to-match single hex character).
-    const b = runScheduleCreate({ prompt: 'b', cron: '0 9 * * *' }, baseDeps(store, cap().write)).task
-    let sharedPrefixLen = 0
-    while (sharedPrefixLen < a.id.length && a.id[sharedPrefixLen] === b.id[sharedPrefixLen]) sharedPrefixLen++
-    if (sharedPrefixLen === 0) {
-      // Extremely unlikely for two random UUIDs, but if it happens this test
-      // has nothing to assert — skip gracefully rather than flake.
-      return
-    }
-    const prefix = a.id.slice(0, sharedPrefixLen)
-    const res = runScheduleEdit(prefix, { name: 'x' }, baseDeps(store, cap().write))
-    assert.equal(res.error, 'ambiguous')
-    assert.equal(store.get(a.id).name, null)
-    assert.equal(store.get(b.id).name, null)
+    const a = seedTask(store, 'ambig-0001-AAAA')
+    const b = seedTask(store, 'ambig-0002-BBBB')
+
+    const editRes = runScheduleEdit('ambig-000', { name: 'x' }, baseDeps(store, cap().write))
+    assert.equal(editRes.updated, false)
+    assert.equal(editRes.error, 'ambiguous')
+    assert.match(editRes.message, /matches 2 tasks/)
+    assert.equal(store.get(a.id).name, null, 'task A untouched by the ambiguous edit')
+    assert.equal(store.get(b.id).name, null, 'task B untouched by the ambiguous edit')
+
+    // The destructive command is the one that actually matters here: an
+    // ambiguous prefix must never delete the wrong (or any) task.
+    const delRes = runScheduleDelete('ambig-000', { yes: true }, baseDeps(store, cap().write))
+    assert.equal(delRes.deleted, false)
+    assert.equal(delRes.error, 'ambiguous')
+    assert.equal(store.list().length, 2, 'neither task was deleted')
+  })
+
+  it('a prefix matching exactly 1 task still resolves correctly', () => {
+    const store = makeStore()
+    const a = seedTask(store, 'ambig-0001-AAAA')
+    const b = seedTask(store, 'ambig-0002-BBBB')
+
+    // 'ambig-0001' is a prefix of only task A's id, even though both ids
+    // share the shorter 'ambig-000' prefix exercised above.
+    const res = runScheduleEdit('ambig-0001', { name: 'Edited A' }, baseDeps(store, cap().write))
+    assert.equal(res.updated, true)
+    assert.equal(res.task.id, a.id)
+    assert.equal(store.get(a.id).name, 'Edited A')
+    assert.equal(store.get(b.id).name, null, 'the other task is untouched')
+  })
+
+  it('a prefix matching 0 tasks errors as not-found and resolves nothing', () => {
+    const store = makeStore()
+    seedTask(store, 'ambig-0001-AAAA')
+    const res = runScheduleEdit('does-not-exist', { name: 'x' }, baseDeps(store, cap().write))
+    assert.equal(res.updated, false)
+    assert.equal(res.error, 'no-match')
   })
 
   it('a unique id prefix resolves correctly for last-run', () => {

--- a/packages/server/tests/schedule-cli.test.js
+++ b/packages/server/tests/schedule-cli.test.js
@@ -7,10 +7,11 @@
 // re-implemented fake.
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync } from 'fs'
+import { mkdtempSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { tmpdir } from 'os'
-import { ScheduledTaskStore } from '../src/scheduled-task-store.js'
+import { fileURLToPath } from 'url'
+import { tmpdir, homedir } from 'os'
+import { ScheduledTaskStore, defaultScheduledTasksPath } from '../src/scheduled-task-store.js'
 import {
   runScheduleCreate,
   runScheduleList,
@@ -19,6 +20,7 @@ import {
   runScheduleResume,
   runScheduleDelete,
   runScheduleLastRun,
+  defaultScheduleRegistryPath,
 } from '../src/cli/schedule-cmd.js'
 
 const NOW = 1_800_000_000_000 // fixed clock so nextRun/formatted timestamps are deterministic
@@ -96,6 +98,27 @@ describe('chroxy schedule create (#6868)', () => {
     assert.equal(res.created, false)
     assert.equal(res.error, 'invalid-cadence')
     assert.equal(store.list().length, 0)
+  })
+
+  // #7015 — the invalid-date hint has to be copy-pasteable without changing
+  // meaning. This CLI renders every timestamp in UTC (formatEpoch), but
+  // Date.parse reads an offset-less date-time as LOCAL time, so suggesting
+  // "2026-08-01T09:00:00" told the operator to write something that lands at a
+  // different instant than the one they then see echoed back. The parse
+  // behaviour is deliberately unchanged (that would move existing scripted
+  // invocations); the hint has to disclose it instead.
+  it('the unparseable --at hint carries an explicit timezone and names the local/UTC split', () => {
+    const store = makeStore()
+    const w = cap()
+    const res = runScheduleCreate({ prompt: 'bad', at: 'not-a-date' }, baseDeps(store, w.write))
+    assert.equal(res.created, false)
+    assert.match(res.message, /2026-08-01T09:00:00Z/, 'the suggested example must carry an explicit zone')
+    assert.match(res.message, /UTC/, 'must say times are displayed in UTC')
+    assert.match(res.message, /local time/i, 'must say an offset-less value is read as local time')
+    // Guard the regression directly: a bare, zone-less example must not come back.
+    assert.doesNotMatch(res.message, /2026-08-01T09:00:00(?![Z+])/)
+    // The operator sees the same hint on stdout, not just in the return value.
+    assert.match(w.text(), /2026-08-01T09:00:00Z/)
   })
 
   it('requires exactly one of --at / --cron', () => {
@@ -550,5 +573,57 @@ describe('chroxy schedule — id / id-prefix resolution (#6868)', () => {
     const res = runScheduleLastRun(created.task.id.slice(0, 12), {}, baseDeps(store, cap().write))
     assert.equal(res.found, true)
     assert.equal(res.task.id, created.task.id)
+  })
+})
+
+// #7015 — the registry file this CLI touches must be the one the RUNNING daemon
+// reads. `getDefaultStore()` was flagged in review for not honouring
+// `CHROXY_CONFIG_DIR` "like the rest of the server"; the daemon's registry path
+// is in fact home-rooted at every hop, so following the env var here would aim
+// the CLI at a file the scheduler never opens — `create` would report success
+// for a task that can never fire. These tests pin the agreement AND the premise
+// it rests on: if the session-state family is ever migrated onto
+// `CHROXY_CONFIG_DIR`, the premise checks fail loudly here rather than letting
+// the CLI silently desync. The behavioural half (registry does not follow the
+// env var end-to-end) lives in tests/cli/schedule-cmd.test.js.
+describe('chroxy schedule — registry path agrees with the daemon, not with CHROXY_CONFIG_DIR (#7015)', () => {
+  const srcDir = fileURLToPath(new URL('../src/', import.meta.url))
+  const readSrc = (rel) => readFileSync(join(srcDir, rel), 'utf-8')
+
+  it('resolves to the daemon-derived, home-rooted sibling of session-state.json', () => {
+    assert.equal(
+      defaultScheduleRegistryPath(),
+      defaultScheduledTasksPath(join(homedir(), '.chroxy', 'session-state.json')),
+    )
+  })
+
+  it('premise 1: server-cli.js passes no stateFilePath, so SessionManager falls back to its default', () => {
+    assert.ok(
+      !readSrc('server-cli.js').includes('stateFilePath'),
+      'server-cli.js now sets stateFilePath — re-derive defaultScheduleRegistryPath() from whatever it passes',
+    )
+  })
+
+  it('premise 2: SessionManager\'s default state file is home-rooted, ignoring CHROXY_CONFIG_DIR', () => {
+    const sm = readSrc('session-manager.js')
+    assert.match(
+      sm,
+      /const DEFAULT_STATE_FILE = join\(homedir\(\), '\.chroxy', 'session-state\.json'\)/,
+      'DEFAULT_STATE_FILE moved or changed shape — defaultScheduleRegistryPath() must follow it',
+    )
+    assert.doesNotMatch(
+      sm,
+      /DEFAULT_STATE_FILE\s*=[^\n]*CHROXY_CONFIG_DIR/,
+      'DEFAULT_STATE_FILE now honours CHROXY_CONFIG_DIR — schedule-cmd.js must honour it too, or the CLI '
+        + 'and the daemon scheduler will read different registries',
+    )
+  })
+
+  it('premise 3: SessionManager derives its registry from that state file', () => {
+    assert.match(
+      readSrc('session-manager.js'),
+      /new ScheduledTaskStore\(\{ filePath: defaultScheduledTasksPath\(this\._stateFilePath\) \}\)/,
+      'the daemon no longer derives its registry from the session-state path — re-check the CLI resolver',
+    )
   })
 })


### PR DESCRIPTION
## Summary

Adds the `chroxy schedule` CLI command group — CRUD against the persisted scheduled-task registry (#6862) plus a last-run view — closing #6868. Prerequisites #6862 (registry) and #6865 (engine, #6997) are both on `main`.

- `registerScheduleCommands(program)` in `packages/server/src/cli/schedule-cmd.js`, registered from `cli.js` next to `registerSessionCommands`/`registerTokensCommand`, following the house pattern (pure, dependency-injected command handlers + a thin commander wiring layer, mirroring `tokens-cmd.js`).
- Operates purely on the on-disk registry via the store's own API (`ScheduledTaskStore.add/list/update/remove`) — no hand-written JSON, no re-implemented cadence parsing. `--at`/`--cron` validation runs through `schedule-parser.js` via the store, and the computed `nextRun` is always surfaced back to the operator on create/edit.

### Command surface

```
$ chroxy schedule --help
Usage: chroxy schedule [options] [command]

Manage scheduled tasks (create/list/edit/pause/resume/delete/last-run) — #6868

Options:
  -h, --help               display help for command

Commands:
  create [options]         Create a scheduled task
  list [options]           List scheduled tasks — enabled/paused state, next
                           run, and last-run outcome
  edit [options] <id>      Edit a scheduled task (id or unique id-prefix); pass
                           an empty string to clear an optional field
  pause [options] <id>     Pause a scheduled task (enabled: false) — reversible
                           via `resume`
  resume [options] <id>    Resume a paused scheduled task (enabled: true)
  delete [options] <id>    Permanently delete a scheduled task (id or unique
                           id-prefix)
  last-run [options] <id>  View the last recorded run outcome for a scheduled
                           task (or "never run")
  help [command]           display help for command
```

```
$ chroxy schedule create --help
Usage: chroxy schedule create [options]

Create a scheduled task

Options:
  -p, --prompt <text>       Instructions the scheduled run executes
  -n, --name <name>         Optional human-readable label
  --at <when>               One-time cadence: ISO-8601 timestamp or epoch-ms
                            (mutually exclusive with --cron)
  --cron <expression>       5-field crontab expression, e.g. "0 9 * * *"
                            (mutually exclusive with --at)
  --provider <name>         Target provider (default: the daemon default
                            provider)
  --model <name>            Target model
  --cwd <path>              Target working directory
  --permission-mode <mode>  Target permission mode: approve, acceptEdits, auto,
                            plan (unattended runs are always clamped to
                            approve/plan)
  --paused                  Create the task paused (enabled: false) — will not
                            fire until resumed
  --json                    Output machine-readable JSON
  -h, --help                display help for command
```

### Honest surfacing of engine reality

- **Provider refusal.** `create`/`edit` reuse the engine's own `scheduledProviderRefusalReason` (scheduler.js) — not a re-derived rule — to warn when a task's target provider (including the daemon default `claude-tui`) has no in-process permission answering and will be refused at fire time. Example on `create` with no `--provider`:
  ```
  Created scheduled task 9d4887be-...
    cadence:  cron "0 9 * * *"
    next run: 2026-07-25 16:00:00Z
    WARNING: provider 'claude-tui' will be REFUSED when this task is due — nothing will run: ...
    WARNING: scheduled execution is currently DISABLED on this daemon — ...
  ```
- **Permission-mode clamp.** Also reuses `resolveScheduledPermissionMode` — if `--permission-mode` requests anything above `approve`/`plan`, a warning says it will be silently clamped on an unattended fire.
- **Default-off scheduler.** Reuses `isSchedulerEnabled` (config.js). `create`/`edit` still succeed with the gate closed (the task definition is legitimate even before the operator opts in) but say plainly nothing will fire until `features.scheduler: true` / `CHROXY_ENABLE_SCHEDULER=1` is set and the daemon restarts.
- **`list`/`last-run` never look healthy when they aren't.** Every task gets an honest `[OK]` / `[REFUSED]` / `[PAUSED]` / `[NEVER RUN]` / `[SKIPPED]` / `[TIMEOUT]` / `[ERROR]` tag derived straight from `lastRun.status` (or its absence). A quarantined task has no dedicated persisted field — the engine's `_quarantine()` best-effort-writes it as `lastRun: { status: 'refused', error: 'quarantined until daemon restart: ...' }` — and `list`/`last-run` render that exactly as unhealthy, never as `OK`. A never-fired task is always tagged `[NEVER RUN]`, never left blank.

### Other behaviors

- `delete` requires `--yes` (irreversible — removes the task definition and its run history), matching the repo's `tokens revoke --all` / `identity rotate` confirmation convention. `pause`/`resume` do not — they're fully reversible toggles of `enabled`.
- `edit` merges `--provider`/`--model`/`--cwd`/`--permission-mode` onto the **existing** target rather than replacing it wholesale (the store's `update()` replaces the whole `target` object on any patch), so a lone `--model` edit can't silently drop an existing `--provider`.
- id arguments accept a full id or a unique id-prefix (ambiguous prefixes are rejected without acting), mirroring `tokens revoke`'s handle-prefix UX.

## Test plan

- [x] `tests/schedule-cli.test.js` — pure command-handler coverage against a real `ScheduledTaskStore` on a temp file (never `~/.chroxy/`): create (valid cron/at, invalid cron, invalid at, missing prompt, mutual-exclusion, `--paused`, provider-refusal warning, scheduler-disabled warning, permission-mode-clamp warning, malformed permission mode), list (never-run, refused, **quarantined**, paused, success, `--json`, empty), edit (prompt/cadence/target-merge/unknown-id/no-op/re-surfaced warnings), pause/resume, delete (confirm gate, unknown id), last-run (never-run, refused, scheduler-disabled note, unknown id), id-prefix resolution (unique + ambiguous).
- [x] `tests/cli/schedule-cmd.test.js` — E2E through the real CLI binary (`cli.js` → `registerScheduleCommands`), isolated `HOME` per run: `--help` surfaces, full create → list → last-run → delete round trip, invalid-cron exit code, unknown-id exit codes.
- [x] Both suites: `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --import ./tests/_setup.mjs --experimental-test-module-mocks --test tests/schedule-cli.test.js tests/cli/schedule-cmd.test.js` → **51/51 pass, exit 0, no `--test-force-exit`**.
- [x] All 5 server lints (`lint-claude-family-explicit.sh`, `lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`, `lint-ws-index-mutations.sh`) → rc=0.
- [x] `eslint src/cli/schedule-cmd.js src/cli.js` → clean.

Closes #6868

Closes #7014
Closes #7015


---

## Review round 2 — Copilot thread triage (fae4629c8)

Three inline threads on `src/cli/schedule-cmd.js`. All three replied to inline and resolved.

### 1. `--at` invalid-date hint suggested a timezone-less timestamp — FIXED

`Date.parse` reads `2026-08-01T09:00:00` as **local** time while this CLI renders every timestamp in **UTC** (`formatEpoch`), so an operator copying the hint wrote one instant and saw a different one echoed back. The hint now uses `2026-08-01T09:00:00Z` and states the local/UTC split explicitly; the `--at` `.description()` on **both** `create` and `edit` says the same, since that's the surface an operator reads before making the mistake rather than after.

**Parsing behaviour is deliberately unchanged.** Reinterpreting an offset-less string as UTC would silently shift every already-scripted `--at` invocation by the host's UTC offset — a worse and less visible failure than an ambiguous hint. `parseAtValue`'s doc block now records that as a decision.

`grep -rn "2026-08-01T09:00:00" packages/ docs/` confirmed the example existed in exactly one place; no docs/README carried it.

### 2. `getDefaultStore()` ignores `CHROXY_CONFIG_DIR` — NOT changed, deliberately; documented + test-pinned

The change was requested on the premise that "the rest of the server honors `CHROXY_CONFIG_DIR` to relocate all persistent state". That holds for ~10 modules but **not for the session-state family that owns this registry**, so applying it would have *created* the false-safety bug it was meant to prevent:

- `server-cli.js` passes **no** `stateFilePath` (`grep -c stateFilePath src/server-cli.js` → `0`), so `SessionManager` falls back to `DEFAULT_STATE_FILE` = `join(homedir(), '.chroxy', 'session-state.json')` (`session-manager.js:47`).
- `session-manager.js:685` derives `scheduledTaskStore` from that path, so the live scheduler reads `~/.chroxy/scheduled-tasks.json` regardless of the env var.

The CLI already resolves to that same file — CLI and daemon **agree today**. Flipping only the reader desynchronises them: verified empirically that with `CONFIG_DIR` honouring the variable, `schedule create` writes `$CHROXY_CONFIG_DIR/scheduled-tasks.json`, reports success, and the scheduler never opens it.

**Blast radius of the rejected change** — every `cli/shared.js` importer of `CONFIG_DIR`/`CONFIG_FILE`:

| Command | Reads | Writer | Env var correct there? |
|---|---|---|---|
| `schedule` | `scheduled-tasks.json`, `config.json` | `session-manager.js` (home) | **No** — would desync from the scheduler |
| `session` | `session-state.json` | `session-manager.js` (home) | **No** — would read a file the daemon never writes |
| `deploy` | `supervisor.pid`, `update.lock`, `known-good-ref` | `supervisor.js:37,66` (home) | **No** — no caller passes `pidFilePath` |
| `init`, `tunnel`, `config`, `providers`, `worktree-gc`, `shared.js` `-c` default | `config.json` | `server-cli-child.js:24` (home) | Would be correct *only if* the writer moves too |

Three importers must stay home-rooted while the writers are home-rooted, so per the "even one" rule the shared constant was left alone.

**What landed instead:** `defaultScheduleRegistryPath()` — a named, exported resolver carrying the rationale — pinned from both sides:

- `tests/cli/schedule-cmd.test.js`: spawn test pointing `CHROXY_CONFIG_DIR` at a **different** directory, asserting the registry stays where the daemon looks. This is the **first test in the suite that can distinguish the two roots** — `spawn-cli.js:83` sets `CHROXY_CONFIG_DIR: join(home, '.chroxy')`, the same value home-rooting produces, so `session-cmd`/`config-cmd`/`deploy-cmd` all stay green either way.
- `tests/schedule-cli.test.js`: drift guard on the three daemon-side premises, so a future migration onto `CHROXY_CONFIG_DIR` fails loudly here and names the resolver that must move with it.

**#7052 filed** for the genuine underlying inconsistency: `CHROXY_CONFIG_DIR` relocates only half the daemon's state. Fixing it means moving the **writers** (`session-manager.js`, `supervisor.js`, `server-cli-child.js`) together with the readers.

### 3. `buildDeps` hardcodes `defaultProviderName` — ALREADY FIXED

Fixed in `96f4862c0`, after the commit that review round examined (`92a30c94f`). Head reads `overrides.defaultProviderName || config.provider || DEFAULT_PROVIDER`, and `tests/cli/schedule-cmd.test.js` covers the `config.provider` path in both directions (`claude-sdk` → no warning; `claude-tui` → warning) — a hardcoded constant cannot satisfy the first case.

### Verification (fae4629c8)

- [x] `tests/schedule-cli.test.js` + `tests/cli/schedule-cmd.test.js` → **61/61 pass**, exit 0, **no `--test-force-exit`** (c8-wedge check).
- [x] Both new tests confirmed **RED before the fix**: the hint test against the pre-fix string, and the registry test against the rejected one-line `CONFIG_DIR` change.
- [x] Full server suite: **12619 tests, 12601 pass, 5 fail** — all 5 pre-existing and environmental (3 × `TunnelManager Integration` requiring `cloudflared` + network, 2 × Codex requiring the `codex` binary / `OPENAI_API_KEY`). Confirmed identical 5 failures on head `e2eec9119` with these changes stashed.
- [x] All 5 custom server lints → rc=0. `eslint src/cli/schedule-cmd.js` → clean.

Related to #7052
