### PR TITLE
feat(dashboard): add/remove MCP servers UI

### DIFF
--- a/packages/dashboard/src/components/AddMcpServerForm.css
+++ b/packages/dashboard/src/components/AddMcpServerForm.css
@@ -1,0 +1,138 @@
+/* AddMcpServerForm (#6999) — collapsible "+ Add server" form in the sidebar
+   MCP panel. Compact to fit the narrow sidebar slot; matches the existing
+   .sidebar-mcp-view-* sizing (11-12px type, small gaps). */
+
+.add-mcp-server-open {
+  align-self: flex-start;
+  padding: var(--space-1, 4px) var(--space-2, 8px);
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.add-mcp-server-open:hover {
+  filter: brightness(1.15);
+}
+
+.add-mcp-server-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  padding: var(--space-2, 8px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg-secondary);
+  font-size: 11px;
+}
+
+.add-mcp-server-notice {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.add-mcp-server-forbidden {
+  margin: 0;
+  padding: var(--space-1, 4px) var(--space-2, 8px);
+  border: 1px solid var(--warning-fg);
+  border-radius: var(--radius-xs, 4px);
+  background: var(--warning-bg-subtle);
+  color: var(--warning-fg);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.add-mcp-server-trust-notice {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.4;
+}
+
+.add-mcp-server-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.add-mcp-server-field > span {
+  color: var(--text-secondary);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.add-mcp-server-field input[type='text'],
+.add-mcp-server-field select,
+.add-mcp-server-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 3px 6px;
+  border-radius: var(--radius-xs, 4px);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+}
+
+.add-mcp-server-field textarea {
+  resize: vertical;
+}
+
+.add-mcp-server-transport {
+  display: flex;
+  gap: var(--space-3, 12px);
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.add-mcp-server-transport label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.add-mcp-server-error {
+  margin: 0;
+  color: var(--text-error);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.add-mcp-server-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2, 8px);
+}
+
+.add-mcp-server-actions button {
+  padding: 3px 10px;
+  border-radius: var(--radius-pill, 999px);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.add-mcp-server-actions button[type='submit'] {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+.add-mcp-server-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.add-mcp-server-actions button:not(:disabled):hover {
+  filter: brightness(1.15);
+}

--- a/packages/dashboard/src/components/AddMcpServerForm.test.tsx
+++ b/packages/dashboard/src/components/AddMcpServerForm.test.tsx
@@ -120,6 +120,31 @@ describe('AddMcpServerForm client-side validation (#6999)', () => {
     expect(mockAddMcpServer).not.toHaveBeenCalled();
   });
 
+  // Review (#7022): the key/value map must have a NULL prototype. On a plain
+  // `{}`, `map['__proto__'] = 'x'` hits the legacy setter, which ignores a
+  // string — the key never becomes an own property, so the line was silently
+  // discarded AND unreachable by the Object.keys-based reserved-key check.
+  it('rejects a reserved env key (__proto__) instead of silently swallowing the line', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-env'), { target: { value: '__proto__=x' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/env key '__proto__' is reserved/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a reserved header key (__proto__) on the remote transport too', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'remote-srv' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-transport-remote'));
+    fireEvent.change(screen.getByTestId('add-mcp-server-url'), { target: { value: 'https://example.com/mcp' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-headers'), { target: { value: '__proto__=x' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/headers key '__proto__' is reserved/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-KEY=VALUE env line with a clear message', () => {
     openForm();
     fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });

--- a/packages/dashboard/src/components/AddMcpServerForm.test.tsx
+++ b/packages/dashboard/src/components/AddMcpServerForm.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * AddMcpServerForm tests (#6999). Covers: client-side validation before the
+ * round-trip (mirroring the server's rules), the non-primary refusal being
+ * explained and disabling the form, success being confirmed only by the
+ * caller's mcp_servers-broadcast-driven callback (never a synthesized local
+ * result), and that nothing typed into env/headers is ever rendered back or
+ * left behind after submit.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent, act } from '@testing-library/react';
+import { AddMcpServerForm } from './AddMcpServerForm';
+
+const mockAddMcpServer = vi.fn();
+const defaultMockState = (): Record<string, unknown> => ({
+  addMcpServer: mockAddMcpServer,
+  mcpConfigForbiddenNonPrimary: false,
+});
+let mockStoreState: Record<string, unknown> = defaultMockState();
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockStoreState),
+}));
+
+afterEach(() => {
+  cleanup();
+  mockAddMcpServer.mockClear();
+  mockStoreState = defaultMockState();
+});
+
+function openForm() {
+  render(<AddMcpServerForm />);
+  fireEvent.click(screen.getByTestId('add-mcp-server-open'));
+}
+
+describe('AddMcpServerForm collapse/expand (#6999)', () => {
+  it('renders collapsed with just the "+ Add server" button', () => {
+    render(<AddMcpServerForm />);
+    expect(screen.getByTestId('add-mcp-server-open')).toBeTruthy();
+    expect(screen.queryByTestId('add-mcp-server-form')).toBeNull();
+  });
+
+  it('expands into the full form on click', () => {
+    openForm();
+    expect(screen.getByTestId('add-mcp-server-form')).toBeTruthy();
+    expect(screen.getByTestId('add-mcp-server-name')).toBeTruthy();
+  });
+
+  it('the primary-token notice is visible unconditionally, before any submit attempt', () => {
+    openForm();
+    expect(screen.getByTestId('add-mcp-server-primary-notice').textContent).toMatch(/primary API token/i);
+  });
+
+  it('the "adding is not trusting" notice is visible unconditionally', () => {
+    openForm();
+    expect(screen.getByTestId('add-mcp-server-trust-notice').textContent).toMatch(/does not run it/i);
+    expect(screen.getByTestId('add-mcp-server-trust-notice').textContent).toMatch(/prompt/i);
+  });
+
+  it('Cancel collapses the form and does not call addMcpServer', () => {
+    openForm();
+    fireEvent.click(screen.getByTestId('add-mcp-server-cancel'));
+    expect(screen.queryByTestId('add-mcp-server-form')).toBeNull();
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('AddMcpServerForm client-side validation (#6999)', () => {
+  it('rejects an empty name without calling addMcpServer', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/Name is required/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a name containing "__" (the MCP tool-namespace separator) before the round-trip', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'a__b' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/tool-namespace separator/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects an uppercase / invalid-charset name', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'MyServer' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/lowercase identifier/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a config with neither command nor url when the required field is blank', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    // stdio transport is the default; leave Command blank.
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/Provide either a command/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a config carrying BOTH command and url (switching transport does not leave stale fields behind, so this simulates a would-be-ambiguous submit via direct field entry is not reachable through the UI — the transport radio enforces exactly one at a time)', () => {
+    // The form's own radio group makes "both" unreachable through normal use
+    // (only one transport's fields are rendered/submitted at a time) — this
+    // documents that invariant rather than forcing an artificial state.
+    openForm();
+    fireEvent.click(screen.getByTestId('add-mcp-server-transport-remote'));
+    expect(screen.queryByTestId('add-mcp-server-command')).toBeNull();
+    fireEvent.click(screen.getByTestId('add-mcp-server-transport-stdio'));
+    expect(screen.queryByTestId('add-mcp-server-url')).toBeNull();
+  });
+
+  it('rejects a reserved env key (constructor) before the round-trip', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-env'), { target: { value: 'constructor=x' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/env key 'constructor' is reserved/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-KEY=VALUE env line with a clear message', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-env'), { target: { value: 'not-a-pair' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/KEY=VALUE/);
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid stdio submission and calls addMcpServer with the built config', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-args'), { target: { value: '-y\nsome-pkg' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-env'), { target: { value: 'API_KEY=secret-token' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(mockAddMcpServer).toHaveBeenCalledTimes(1);
+    const [name, config, scope, callback] = mockAddMcpServer.mock.calls[0]!;
+    expect(name).toBe('filesystem');
+    expect(config).toEqual({ command: 'npx', args: ['-y', 'some-pkg'], env: { API_KEY: 'secret-token' } });
+    expect(scope).toBe('user');
+    expect(typeof callback).toBe('function');
+  });
+
+  it('accepts a valid remote submission with the default http type', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'remote-fs' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-transport-remote'));
+    fireEvent.change(screen.getByTestId('add-mcp-server-url'), { target: { value: 'https://example.com/mcp' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(mockAddMcpServer).toHaveBeenCalledTimes(1);
+    const [, config] = mockAddMcpServer.mock.calls[0]!;
+    expect(config).toEqual({ type: 'http', url: 'https://example.com/mcp' });
+  });
+
+  it('sends the selected "project" scope', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-scope'), { target: { value: 'project' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(mockAddMcpServer.mock.calls[0]![2]).toBe('project');
+  });
+});
+
+describe('AddMcpServerForm non-primary refusal (#6999)', () => {
+  it('shows the forbidden banner and disables every field + submit when mcpConfigForbiddenNonPrimary is true', () => {
+    mockStoreState = { ...mockStoreState, mcpConfigForbiddenNonPrimary: true };
+    openForm();
+    expect(screen.getByTestId('add-mcp-server-forbidden-banner').textContent).toMatch(/primary API token/);
+    expect((screen.getByTestId('add-mcp-server-name') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByTestId('add-mcp-server-command') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByTestId('add-mcp-server-submit') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('does not render the forbidden banner before any refusal has happened', () => {
+    openForm();
+    expect(screen.queryByTestId('add-mcp-server-forbidden-banner')).toBeNull();
+  });
+
+  it('a submit blocked by the disabled state never calls addMcpServer even if somehow fired', () => {
+    mockStoreState = { ...mockStoreState, mcpConfigForbiddenNonPrimary: true };
+    openForm();
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    expect(mockAddMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the server\'s own MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT rejection message verbatim when the callback fires ok:false (this is what teaches the store to flip mcpConfigForbiddenNonPrimary; the form here just renders whatever message it receives)', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    const callback = mockAddMcpServer.mock.calls[0]![3] as (r: { ok: boolean; code?: string; message?: string }) => void;
+    const serverMessage =
+      "Pairing-issued tokens cannot add or remove MCP servers — a configured MCP server is a command this machine will run. Use the primary API token from a device with physical access to this machine.";
+    act(() => {
+      callback({ ok: false, code: 'MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT', message: serverMessage });
+    });
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toBe(serverMessage);
+  });
+});
+
+describe('AddMcpServerForm success confirmation has no phantom result (#6999)', () => {
+  it('shows "Adding…" and a disabled submit while awaiting the callback', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    const submit = screen.getByTestId('add-mcp-server-submit') as HTMLButtonElement;
+    expect(submit.textContent).toBe('Adding…');
+    expect(submit.disabled).toBe(true);
+  });
+
+  it('on ok:true the form clears and collapses — success is ENTIRELY driven by the caller-supplied callback, never synthesized locally', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-env'), { target: { value: 'API_KEY=super-secret' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    const callback = mockAddMcpServer.mock.calls[0]![3] as (r: { ok: boolean }) => void;
+    act(() => {
+      callback({ ok: true });
+    });
+    // Collapsed back to the "+ Add server" entry point.
+    expect(screen.getByTestId('add-mcp-server-open')).toBeTruthy();
+    expect(screen.queryByTestId('add-mcp-server-form')).toBeNull();
+  });
+
+  it('re-opening after a successful add starts from a BLANK form — the secret typed into env is never rendered back', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-env'), { target: { value: 'API_KEY=super-secret' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    const callback = mockAddMcpServer.mock.calls[0]![3] as (r: { ok: boolean }) => void;
+    act(() => {
+      callback({ ok: true });
+    });
+    fireEvent.click(screen.getByTestId('add-mcp-server-open'));
+    expect((screen.getByTestId('add-mcp-server-name') as HTMLInputElement).value).toBe('');
+    expect((screen.getByTestId('add-mcp-server-command') as HTMLInputElement).value).toBe('');
+    expect((screen.getByTestId('add-mcp-server-env') as HTMLTextAreaElement).value).toBe('');
+    // The whole document never contained the secret value at any point after submit.
+    expect(document.body.textContent).not.toMatch(/super-secret/);
+  });
+
+  it('on failure the form stays open with the fields intact (so the user can fix and retry) and re-enables the submit button', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    const callback = mockAddMcpServer.mock.calls[0]![3] as (r: { ok: boolean; code?: string; message?: string }) => void;
+    act(() => {
+      callback({ ok: false, code: 'MCP_SERVER_EXISTS', message: "An MCP server named 'filesystem' already exists in user scope." });
+    });
+    expect(screen.getByTestId('add-mcp-server-form')).toBeTruthy();
+    expect((screen.getByTestId('add-mcp-server-name') as HTMLInputElement).value).toBe('filesystem');
+    expect((screen.getByTestId('add-mcp-server-submit') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('a timeout/disconnect resolution (client-synthesized code) surfaces its message and clears "submitting" — the no-reply path cannot hang forever', () => {
+    openForm();
+    fireEvent.change(screen.getByTestId('add-mcp-server-name'), { target: { value: 'filesystem' } });
+    fireEvent.change(screen.getByTestId('add-mcp-server-command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByTestId('add-mcp-server-submit'));
+    const callback = mockAddMcpServer.mock.calls[0]![3] as (r: { ok: boolean; code?: string; message?: string }) => void;
+    act(() => {
+      callback({ ok: false, code: 'TIMEOUT', message: 'No response from the daemon — check the server list below; the request may still complete.' });
+    });
+    const submit = screen.getByTestId('add-mcp-server-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+    expect(submit.textContent).toBe('Add server');
+    expect(screen.getByTestId('add-mcp-server-error').textContent).toMatch(/No response from the daemon/);
+  });
+});

--- a/packages/dashboard/src/components/AddMcpServerForm.tsx
+++ b/packages/dashboard/src/components/AddMcpServerForm.tsx
@@ -44,7 +44,14 @@ function parseLines(text: string): string[] {
 
 /** `KEY=VALUE` per line. A line with no `=` (or an empty key) is reported as invalid rather than silently dropped. */
 function parseKeyValueLines(text: string): { map: Record<string, string>; invalidLines: string[] } {
-  const map: Record<string, string> = {};
+  // Null-prototype map, NOT `{}`. On a plain object `map['__proto__'] = 'x'`
+  // hits the legacy `__proto__` setter, which ignores a string value — so the
+  // key never becomes an own property. That silently discarded the line AND
+  // made it invisible to the reserved-key refusal in mcp-server-validation.ts
+  // (which iterates Object.keys), so `__proto__` could never be reported.
+  // With a null prototype every key is an ordinary own key: `__proto__` is
+  // carried through and correctly rejected as reserved.
+  const map: Record<string, string> = Object.create(null);
   const invalidLines: string[] = [];
   for (const line of parseLines(text)) {
     const idx = line.indexOf('=');

--- a/packages/dashboard/src/components/AddMcpServerForm.tsx
+++ b/packages/dashboard/src/components/AddMcpServerForm.tsx
@@ -1,0 +1,331 @@
+/**
+ * AddMcpServerForm (#6999) — collapsible "+ Add server" form embedded in
+ * SidebarMcpView. Wires `add_mcp_server` end to end:
+ *
+ * - Client-side validation (mcp-server-validation.ts) mirrors the server's
+ *   actual rules (name charset, no `__`, reserved keys, ambiguous
+ *   command+url) for a fast, clear error before the round-trip — the server
+ *   remains authoritative and re-validates from scratch on write.
+ * - There is no dedicated result type on the wire (#6974/#6998): success is
+ *   the re-emitted `mcp_servers` broadcast (the row simply appears in
+ *   SidebarMcpView's list), not a reply to this form. `addMcpServer`'s
+ *   `callback` (armed via `armMcpServerOpCallback`, connection.ts) resolves
+ *   on whichever of {matching error, satisfying broadcast, bounded timeout}
+ *   happens first, so `submitting` is guaranteed to clear.
+ * - Primary-token gating is NOT hidden: a persistent notice explains the
+ *   requirement before every submit, and once a real rejection teaches the
+ *   store `mcpConfigForbiddenNonPrimary` (message-handler.ts), the form
+ *   disables itself and explains why — using the server's own (already
+ *   human-readable) rejection text, not a generic error.
+ * - "Adding is not trusting": a fixed notice makes clear the daemon still
+ *   gates the first spawn behind its trust prompt, even for a name that was
+ *   previously trusted (trust is re-keyed to the full spawn config as of
+ *   #6998).
+ * - Secrets: `env` / `headers` VALUES are read from the form only to build
+ *   the outgoing `config` payload. They are never logged, never placed in a
+ *   URL, and the form clears itself (including these fields) on success —
+ *   nothing typed here is rendered back after submit. Validation errors
+ *   reference only KEY names, never values (mcp-server-validation.ts).
+ */
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import { useConnectionStore } from '../store/connection';
+import type { McpConfigScope, McpServerConfigInput, McpServerOpResult } from '../store/types';
+import { validateMcpServerConfig, validateMcpServerName } from '../lib/mcp-server-validation';
+import './AddMcpServerForm.css';
+
+type Transport = 'stdio' | 'remote';
+
+function parseLines(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** `KEY=VALUE` per line. A line with no `=` (or an empty key) is reported as invalid rather than silently dropped. */
+function parseKeyValueLines(text: string): { map: Record<string, string>; invalidLines: string[] } {
+  const map: Record<string, string> = {};
+  const invalidLines: string[] = [];
+  for (const line of parseLines(text)) {
+    const idx = line.indexOf('=');
+    const key = idx > 0 ? line.slice(0, idx).trim() : '';
+    if (!key) {
+      invalidLines.push(line);
+      continue;
+    }
+    map[key] = line.slice(idx + 1);
+  }
+  return { map, invalidLines };
+}
+
+const EMPTY_FIELDS = {
+  name: '',
+  command: '',
+  argsText: '',
+  envText: '',
+  url: '',
+  headersText: '',
+};
+
+export function AddMcpServerForm() {
+  const addMcpServer = useConnectionStore((s) => s.addMcpServer);
+  const forbiddenNonPrimary = useConnectionStore((s) => s.mcpConfigForbiddenNonPrimary);
+
+  const [open, setOpen] = useState(false);
+  const [scope, setScope] = useState<McpConfigScope>('user');
+  const [transport, setTransport] = useState<Transport>('stdio');
+  const [fields, setFields] = useState(EMPTY_FIELDS);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards the callback from setting state after unmount (panel collapsed /
+  // navigated away mid-request) — armMcpServerOpCallback still resolves the
+  // request server-side/via timeout either way, this only guards the setState.
+  const mountedRef = useRef(true);
+  useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
+
+  const disabled = forbiddenNonPrimary;
+
+  const resetFields = () => {
+    setFields(EMPTY_FIELDS);
+    setScope('user');
+    setTransport('stdio');
+  };
+
+  const buildConfig = (): { config: McpServerConfigInput | null; error: string | null } => {
+    if (transport === 'stdio') {
+      const { map: env, invalidLines } = parseKeyValueLines(fields.envText);
+      if (invalidLines.length > 0) {
+        return { config: null, error: `Env line(s) must be KEY=VALUE: ${invalidLines.join(', ')}` };
+      }
+      const config: McpServerConfigInput = { command: fields.command.trim() };
+      const args = parseLines(fields.argsText);
+      if (args.length > 0) config.args = args;
+      if (Object.keys(env).length > 0) config.env = env;
+      return { config, error: null };
+    }
+    const { map: headers, invalidLines } = parseKeyValueLines(fields.headersText);
+    if (invalidLines.length > 0) {
+      return { config: null, error: `Header line(s) must be KEY=VALUE: ${invalidLines.join(', ')}` };
+    }
+    const config: McpServerConfigInput = { type: 'http', url: fields.url.trim() };
+    if (Object.keys(headers).length > 0) config.headers = headers;
+    return { config, error: null };
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (submitting || disabled) return;
+    setError(null);
+
+    const nameError = validateMcpServerName(fields.name);
+    if (nameError) {
+      setError(nameError);
+      return;
+    }
+    const built = buildConfig();
+    if (built.error || !built.config) {
+      setError(built.error);
+      return;
+    }
+    const configError = validateMcpServerConfig(built.config);
+    if (configError) {
+      setError(configError);
+      return;
+    }
+
+    setSubmitting(true);
+    addMcpServer(fields.name.trim(), built.config, scope, (result: McpServerOpResult) => {
+      if (!mountedRef.current) return;
+      setSubmitting(false);
+      if (result.ok) {
+        resetFields();
+        setOpen(false);
+        return;
+      }
+      setError(result.message || 'Failed to add MCP server.');
+    });
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="add-mcp-server-open"
+        data-testid="add-mcp-server-open"
+        // Stays clickable even when known-forbidden — opening the form is how
+        // the user SEES the explanation (the forbidden banner below). A
+        // disabled entry point with no visible reason reads as broken; the
+        // `title` hint plus the banner-on-open together satisfy "explained
+        // before submitting" without hiding the affordance.
+        title={forbiddenNonPrimary ? 'Requires the primary API token — click to see why' : undefined}
+        onClick={() => setOpen(true)}
+      >
+        + Add server
+      </button>
+    );
+  }
+
+  return (
+    <form className="add-mcp-server-form" data-testid="add-mcp-server-form" onSubmit={handleSubmit}>
+      {/* Always visible — the primary-token requirement is explained BEFORE
+          submitting, whether or not we already know this connection is non-primary. */}
+      <p className="add-mcp-server-notice" data-testid="add-mcp-server-primary-notice">
+        Requires the primary API token. A paired device (phone) will be refused.
+      </p>
+
+      {disabled && (
+        <p className="add-mcp-server-forbidden" data-testid="add-mcp-server-forbidden-banner" role="alert">
+          This connection isn't using the primary API token, so adding or removing MCP servers is
+          refused here — connect from the device with direct/physical access to this machine and its
+          primary API token.
+        </p>
+      )}
+
+      <label className="add-mcp-server-field">
+        <span>Name</span>
+        <input
+          type="text"
+          data-testid="add-mcp-server-name"
+          value={fields.name}
+          disabled={disabled}
+          onChange={(e) => setFields((f) => ({ ...f, name: e.target.value }))}
+          placeholder="filesystem"
+        />
+      </label>
+
+      <label className="add-mcp-server-field">
+        <span>Scope</span>
+        <select
+          data-testid="add-mcp-server-scope"
+          value={scope}
+          disabled={disabled}
+          onChange={(e) => setScope(e.target.value as McpConfigScope)}
+        >
+          <option value="user">User (this machine)</option>
+          <option value="project">Project (this working directory)</option>
+        </select>
+      </label>
+
+      <div className="add-mcp-server-transport" role="radiogroup" aria-label="Transport">
+        <label>
+          <input
+            type="radio"
+            name="mcp-transport"
+            data-testid="add-mcp-server-transport-stdio"
+            checked={transport === 'stdio'}
+            disabled={disabled}
+            onChange={() => setTransport('stdio')}
+          />
+          Local command (stdio)
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mcp-transport"
+            data-testid="add-mcp-server-transport-remote"
+            checked={transport === 'remote'}
+            disabled={disabled}
+            onChange={() => setTransport('remote')}
+          />
+          Remote (http/https)
+        </label>
+      </div>
+
+      {transport === 'stdio' ? (
+        <>
+          <label className="add-mcp-server-field">
+            <span>Command</span>
+            <input
+              type="text"
+              data-testid="add-mcp-server-command"
+              value={fields.command}
+              disabled={disabled}
+              onChange={(e) => setFields((f) => ({ ...f, command: e.target.value }))}
+              placeholder="npx"
+            />
+          </label>
+          <label className="add-mcp-server-field">
+            <span>Args (one per line)</span>
+            <textarea
+              data-testid="add-mcp-server-args"
+              value={fields.argsText}
+              disabled={disabled}
+              onChange={(e) => setFields((f) => ({ ...f, argsText: e.target.value }))}
+              rows={2}
+            />
+          </label>
+          <label className="add-mcp-server-field">
+            <span>Env (KEY=VALUE, one per line)</span>
+            <textarea
+              data-testid="add-mcp-server-env"
+              value={fields.envText}
+              disabled={disabled}
+              onChange={(e) => setFields((f) => ({ ...f, envText: e.target.value }))}
+              rows={2}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+        </>
+      ) : (
+        <>
+          <label className="add-mcp-server-field">
+            <span>URL</span>
+            <input
+              type="text"
+              data-testid="add-mcp-server-url"
+              value={fields.url}
+              disabled={disabled}
+              onChange={(e) => setFields((f) => ({ ...f, url: e.target.value }))}
+              placeholder="https://example.com/mcp"
+            />
+          </label>
+          <label className="add-mcp-server-field">
+            <span>Headers (KEY=VALUE, one per line)</span>
+            <textarea
+              data-testid="add-mcp-server-headers"
+              value={fields.headersText}
+              disabled={disabled}
+              onChange={(e) => setFields((f) => ({ ...f, headersText: e.target.value }))}
+              rows={2}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+        </>
+      )}
+
+      <p className="add-mcp-server-trust-notice" data-testid="add-mcp-server-trust-notice">
+        Adding a server does not run it. The daemon will still prompt to confirm before the first
+        spawn — even for a name you trusted before, since trust is keyed to the exact command, args,
+        and environment.
+      </p>
+
+      {error && (
+        <p className="add-mcp-server-error" data-testid="add-mcp-server-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="add-mcp-server-actions">
+        <button
+          type="button"
+          data-testid="add-mcp-server-cancel"
+          onClick={() => {
+            resetFields();
+            setError(null);
+            setOpen(false);
+          }}
+        >
+          Cancel
+        </button>
+        <button type="submit" data-testid="add-mcp-server-submit" disabled={disabled || submitting}>
+          {submitting ? 'Adding…' : 'Add server'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/dashboard/src/components/SidebarMcpView.test.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.test.tsx
@@ -3,22 +3,30 @@
  * panel slot, the desktop analogue of the mobile SettingsBar section.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, cleanup, screen, fireEvent } from '@testing-library/react'
+import { render, cleanup, screen, fireEvent, act } from '@testing-library/react'
 import type { McpServer } from '@chroxy/store-core'
 import { SidebarMcpView, mcpViewCollapsedMetric } from './SidebarMcpView'
 
 // Mock the store so the fallback path (no `servers` prop) is deterministic.
 // Tests that pass `servers` directly never touch it. The variable is prefixed
 // `mock` so vitest allows it inside the hoisted factory. #6824 — the component
-// also selects `setMcpServerEnabled`, so the state carries a spy.
+// also selects `setMcpServerEnabled`, so the state carries a spy. #6999 —
+// `removeMcpServer` / `addMcpServer` / `mcpConfigForbiddenNonPrimary` back the
+// remove action and the embedded AddMcpServerForm.
 const mockSetMcpServerEnabled = vi.fn()
 const mockSubmitMcpAuthCode = vi.fn()
-let mockStoreState: Record<string, unknown> = {
+const mockRemoveMcpServer = vi.fn()
+const mockAddMcpServer = vi.fn()
+const defaultMockState = (): Record<string, unknown> => ({
   activeSessionId: null,
   sessionStates: {},
   setMcpServerEnabled: mockSetMcpServerEnabled,
   submitMcpAuthCode: mockSubmitMcpAuthCode,
-}
+  removeMcpServer: mockRemoveMcpServer,
+  addMcpServer: mockAddMcpServer,
+  mcpConfigForbiddenNonPrimary: false,
+})
+let mockStoreState: Record<string, unknown> = defaultMockState()
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockStoreState),
 }))
@@ -27,7 +35,9 @@ afterEach(() => {
   cleanup()
   mockSetMcpServerEnabled.mockClear()
   mockSubmitMcpAuthCode.mockClear()
-  mockStoreState = { activeSessionId: null, sessionStates: {}, setMcpServerEnabled: mockSetMcpServerEnabled, submitMcpAuthCode: mockSubmitMcpAuthCode }
+  mockRemoveMcpServer.mockClear()
+  mockAddMcpServer.mockClear()
+  mockStoreState = defaultMockState()
 })
 
 function srv(name: string, status: string): McpServer {
@@ -154,6 +164,85 @@ describe('SidebarMcpView OAuth affordance (#6822)', () => {
     render(<SidebarMcpView servers={[{ name: 'remote', status: 'oauth-required', canToggle: true }]} />)
     expect(screen.queryByTestId('sidebar-mcp-view-authorize-remote')).toBeNull()
     expect(screen.getByTestId('sidebar-mcp-view-auth-input-remote')).toBeTruthy()
+  })
+})
+
+describe('SidebarMcpView remove action (#6999)', () => {
+  it('renders a Remove button per row and hides it while the confirm strip is open', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    expect(screen.getByTestId('sidebar-mcp-view-remove-filesystem')).toBeTruthy()
+    expect(screen.queryByTestId('sidebar-mcp-view-remove-confirm-filesystem')).toBeNull()
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    expect(screen.queryByTestId('sidebar-mcp-view-remove-filesystem')).toBeNull()
+    expect(screen.getByTestId('sidebar-mcp-view-remove-confirm-filesystem')).toBeTruthy()
+  })
+
+  it('cancel returns to the idle Remove button without calling removeMcpServer', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-cancel-filesystem'))
+    expect(screen.getByTestId('sidebar-mcp-view-remove-filesystem')).toBeTruthy()
+    expect(mockRemoveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('confirm calls removeMcpServer(name, scope, callback) with the default "user" scope', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
+    expect(mockRemoveMcpServer).toHaveBeenCalledTimes(1)
+    const [name, scope, callback] = mockRemoveMcpServer.mock.calls[0]!
+    expect(name).toBe('filesystem')
+    expect(scope).toBe('user')
+    expect(typeof callback).toBe('function')
+  })
+
+  it('honors a "project" scope selection before confirming', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.change(screen.getByTestId('sidebar-mcp-view-remove-scope-filesystem'), { target: { value: 'project' } })
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
+    expect(mockRemoveMcpServer).toHaveBeenCalledWith('filesystem', 'project', expect.any(Function))
+  })
+
+  it('a failed removal (callback ok:false) surfaces the server message and returns to the confirm step', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
+    const callback = mockRemoveMcpServer.mock.calls[0]![2] as (r: { ok: boolean; code?: string; message?: string }) => void
+    act(() => {
+      callback({ ok: false, code: 'MCP_SERVER_NOT_FOUND', message: "No MCP server named 'filesystem' in project scope." })
+    })
+    expect(screen.getByTestId('sidebar-mcp-view-remove-error-filesystem').textContent).toBe(
+      "No MCP server named 'filesystem' in project scope.",
+    )
+    // Still on the confirm step (not silently dropped back to idle) so the user can retry a different scope.
+    expect(screen.getByTestId('sidebar-mcp-view-remove-confirm-filesystem')).toBeTruthy()
+  })
+
+  it('a successful removal (callback ok:true) does not synthesize any local success message — the row leaving the list on the next mcp_servers broadcast IS the confirmation', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
+    const callback = mockRemoveMcpServer.mock.calls[0]![2] as (r: { ok: boolean }) => void
+    act(() => {
+      callback({ ok: true })
+    })
+    expect(screen.queryByTestId('sidebar-mcp-view-remove-error-filesystem')).toBeNull()
+  })
+
+  it('disables the Remove button and explains why when mcpConfigForbiddenNonPrimary is true', () => {
+    mockStoreState = { ...mockStoreState, mcpConfigForbiddenNonPrimary: true }
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    const btn = screen.getByTestId('sidebar-mcp-view-remove-filesystem') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(btn.title).toMatch(/primary API token/)
+  })
+})
+
+describe('SidebarMcpView embeds the add-server form (#6999)', () => {
+  it('always renders the AddMcpServerForm entry point, even with zero servers', () => {
+    render(<SidebarMcpView servers={[]} />)
+    expect(screen.getByTestId('add-mcp-server-open')).toBeTruthy()
   })
 })
 

--- a/packages/dashboard/src/components/SidebarMcpView.test.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.test.tsx
@@ -185,9 +185,41 @@ describe('SidebarMcpView remove action (#6999)', () => {
     expect(mockRemoveMcpServer).not.toHaveBeenCalled()
   })
 
-  it('confirm calls removeMcpServer(name, scope, callback) with the default "user" scope', () => {
+  // #6999 review: the scope a server lives in is NOT on the wire, so the confirm
+  // strip must not pre-select a guess — a single click-through would otherwise
+  // delete from a scope the user never chose.
+  it('opens the confirm strip with NO scope pre-selected and the confirm button disabled', () => {
     render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
     fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    const select = screen.getByTestId('sidebar-mcp-view-remove-scope-filesystem') as HTMLSelectElement
+    expect(select.value).toBe('')
+    const btn = screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('clicking confirm before choosing a scope does not call removeMcpServer', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
+    expect(mockRemoveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('explains that the scope could not be determined until one is chosen, then states what will be affected', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    expect(screen.getByTestId('sidebar-mcp-view-remove-hint-filesystem').textContent).toMatch(
+      /doesn't report which scope/,
+    )
+    fireEvent.change(screen.getByTestId('sidebar-mcp-view-remove-scope-filesystem'), { target: { value: 'project' } })
+    expect(screen.getByTestId('sidebar-mcp-view-remove-hint-filesystem').textContent).toBe(
+      'Removes filesystem from project scope only.',
+    )
+  })
+
+  it('confirm calls removeMcpServer(name, scope, callback) with the explicitly chosen "user" scope', () => {
+    render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
+    fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.change(screen.getByTestId('sidebar-mcp-view-remove-scope-filesystem'), { target: { value: 'user' } })
     fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
     expect(mockRemoveMcpServer).toHaveBeenCalledTimes(1)
     const [name, scope, callback] = mockRemoveMcpServer.mock.calls[0]!
@@ -207,6 +239,7 @@ describe('SidebarMcpView remove action (#6999)', () => {
   it('a failed removal (callback ok:false) surfaces the server message and returns to the confirm step', () => {
     render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
     fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.change(screen.getByTestId('sidebar-mcp-view-remove-scope-filesystem'), { target: { value: 'user' } })
     fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
     const callback = mockRemoveMcpServer.mock.calls[0]![2] as (r: { ok: boolean; code?: string; message?: string }) => void
     act(() => {
@@ -222,6 +255,7 @@ describe('SidebarMcpView remove action (#6999)', () => {
   it('a successful removal (callback ok:true) does not synthesize any local success message — the row leaving the list on the next mcp_servers broadcast IS the confirmation', () => {
     render(<SidebarMcpView servers={[srv('filesystem', 'connected')]} />)
     fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-filesystem'))
+    fireEvent.change(screen.getByTestId('sidebar-mcp-view-remove-scope-filesystem'), { target: { value: 'user' } })
     fireEvent.click(screen.getByTestId('sidebar-mcp-view-remove-confirm-btn-filesystem'))
     const callback = mockRemoveMcpServer.mock.calls[0]![2] as (r: { ok: boolean }) => void
     act(() => {

--- a/packages/dashboard/src/components/SidebarMcpView.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.tsx
@@ -31,7 +31,11 @@
  * each row gets a "Remove" action that sends `remove_mcp_server` after an
  * inline scope-confirm step (removal is scope-exact — the server reports
  * MCP_SERVER_NOT_FOUND rather than guessing which scope a same-named server
- * lives in). Both mutations require the strict-primary token class
+ * lives in). That confirm step deliberately starts with NO scope selected: the
+ * `mcp_servers` payload carries no scope field, so the client cannot derive the
+ * right one, and a pre-selected default would let a single click delete from a
+ * scope the user never chose. Confirm stays disabled until the choice is made.
+ * Both mutations require the strict-primary token class
  * server-side; `mcpConfigForbiddenNonPrimary` (set the first time either is
  * actually refused with MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT — see
  * message-handler.ts) disables + annotates both affordances rather than
@@ -114,13 +118,19 @@ interface McpServerRowProps {
 function McpServerRow({ server, onToggle, onSubmitAuthCode, onRemove, removeDisabled }: McpServerRowProps) {
   const [code, setCode] = useState('')
   const [removeStep, setRemoveStep] = useState<'idle' | 'confirm' | 'removing'>('idle')
-  const [removeScope, setRemoveScope] = useState<McpConfigScope>('user')
+  // #6999: '' = no choice made yet. Removal is scope-EXACT server-side and the
+  // wire `mcp_servers` payload carries no scope, so there is nothing to derive a
+  // correct default from. Pre-selecting one would make a click-through delete
+  // from a scope the user never picked, so the choice stays explicit and the
+  // confirm button stays disabled until it is made.
+  const [removeScope, setRemoveScope] = useState<McpConfigScope | ''>('')
   const [removeError, setRemoveError] = useState<string | null>(null)
   const connected = server.status === 'connected'
   const enabled = isServerEnabled(server)
   const needsAuth = server.status === 'oauth-required'
 
   const confirmRemove = () => {
+    if (removeScope === '') return // guarded by the disabled button; belt-and-braces
     setRemoveStep('removing')
     setRemoveError(null)
     onRemove(server.name, removeScope, (result) => {
@@ -183,15 +193,22 @@ function McpServerRow({ server, onToggle, onSubmitAuthCode, onRemove, removeDisa
             data-testid={`sidebar-mcp-view-remove-scope-${server.name}`}
             value={removeScope}
             disabled={removeStep === 'removing'}
-            onChange={(e) => setRemoveScope(e.target.value as McpConfigScope)}
+            aria-label={`Scope to remove MCP server ${server.name} from`}
+            onChange={(e) => setRemoveScope(e.target.value as McpConfigScope | '')}
           >
+            <option value="">Select scope…</option>
             <option value="user">User scope</option>
             <option value="project">Project scope</option>
           </select>
           <button
             type="button"
             data-testid={`sidebar-mcp-view-remove-confirm-btn-${server.name}`}
-            disabled={removeStep === 'removing'}
+            disabled={removeStep === 'removing' || removeScope === ''}
+            title={
+              removeScope === ''
+                ? 'Pick which scope to remove this server from'
+                : `Remove ${server.name} from ${removeScope} scope`
+            }
             onClick={confirmRemove}
           >
             {removeStep === 'removing' ? 'Removing…' : 'Confirm remove'}
@@ -207,6 +224,14 @@ function McpServerRow({ server, onToggle, onSubmitAuthCode, onRemove, removeDisa
           >
             Cancel
           </button>
+          <p
+            className="sidebar-mcp-view-remove-hint"
+            data-testid={`sidebar-mcp-view-remove-hint-${server.name}`}
+          >
+            {removeScope === ''
+              ? "The server list doesn't report which scope a server is configured in, so pick the scope to remove it from — removal affects that scope only."
+              : `Removes ${server.name} from ${removeScope} scope only.`}
+          </p>
           {removeError && (
             <p className="sidebar-mcp-view-remove-error" data-testid={`sidebar-mcp-view-remove-error-${server.name}`} role="alert">
               {removeError}

--- a/packages/dashboard/src/components/SidebarMcpView.tsx
+++ b/packages/dashboard/src/components/SidebarMcpView.tsx
@@ -26,10 +26,24 @@
  * the universal fallback (a remote/tunneled daemon whose loopback callback the
  * browser can't reach): the user pastes the code back and the daemon redeems it.
  * Both routes converge on the daemon-side redemption; the flow is broadcast-driven.
+ *
+ * #6999 — the "+ Add server" form (AddMcpServerForm) sends `add_mcp_server`;
+ * each row gets a "Remove" action that sends `remove_mcp_server` after an
+ * inline scope-confirm step (removal is scope-exact — the server reports
+ * MCP_SERVER_NOT_FOUND rather than guessing which scope a same-named server
+ * lives in). Both mutations require the strict-primary token class
+ * server-side; `mcpConfigForbiddenNonPrimary` (set the first time either is
+ * actually refused with MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT — see
+ * message-handler.ts) disables + annotates both affordances rather than
+ * leaving them clickable-but-doomed. Neither mutation has a dedicated result
+ * type: success is simply the row appearing/disappearing from this same list
+ * on the next `mcp_servers` broadcast.
  */
 import { useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { McpServer } from '@chroxy/store-core'
+import type { McpConfigScope, McpServerOpResult } from '../store/types'
+import { AddMcpServerForm } from './AddMcpServerForm'
 
 // Module-level stable empty array so the store selector's fallback keeps a
 // referentially-stable identity (avoids needless re-renders / render loops).
@@ -60,6 +74,8 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
   })
   const setMcpServerEnabled = useConnectionStore((s) => s.setMcpServerEnabled)
   const submitMcpAuthCode = useConnectionStore((s) => s.submitMcpAuthCode)
+  const removeMcpServer = useConnectionStore((s) => s.removeMcpServer)
+  const forbiddenNonPrimary = useConnectionStore((s) => s.mcpConfigForbiddenNonPrimary)
   const servers = serversProp ?? storeServers
 
   return (
@@ -76,10 +92,13 @@ export function SidebarMcpView({ servers: serversProp }: SidebarMcpViewProps = {
               server={server}
               onToggle={setMcpServerEnabled}
               onSubmitAuthCode={submitMcpAuthCode}
+              onRemove={removeMcpServer}
+              removeDisabled={forbiddenNonPrimary}
             />
           ))}
         </ul>
       )}
+      <AddMcpServerForm />
     </div>
   )
 }
@@ -88,13 +107,28 @@ interface McpServerRowProps {
   server: McpServer
   onToggle: (server: string, enabled: boolean) => void
   onSubmitAuthCode: (server: string, code: string) => void
+  onRemove: (name: string, scope: McpConfigScope, callback: (result: McpServerOpResult) => void) => void
+  removeDisabled: boolean
 }
 
-function McpServerRow({ server, onToggle, onSubmitAuthCode }: McpServerRowProps) {
+function McpServerRow({ server, onToggle, onSubmitAuthCode, onRemove, removeDisabled }: McpServerRowProps) {
   const [code, setCode] = useState('')
+  const [removeStep, setRemoveStep] = useState<'idle' | 'confirm' | 'removing'>('idle')
+  const [removeScope, setRemoveScope] = useState<McpConfigScope>('user')
+  const [removeError, setRemoveError] = useState<string | null>(null)
   const connected = server.status === 'connected'
   const enabled = isServerEnabled(server)
   const needsAuth = server.status === 'oauth-required'
+
+  const confirmRemove = () => {
+    setRemoveStep('removing')
+    setRemoveError(null)
+    onRemove(server.name, removeScope, (result) => {
+      if (result.ok) return // row disappears on the next mcp_servers broadcast
+      setRemoveStep('confirm')
+      setRemoveError(result.message || 'Failed to remove MCP server.')
+    })
+  }
 
   return (
     <li className="sidebar-mcp-view-row" data-testid={`sidebar-mcp-view-row-${server.name}`}>
@@ -125,7 +159,61 @@ function McpServerRow({ server, onToggle, onSubmitAuthCode }: McpServerRowProps)
             {enabled ? 'On' : 'Off'}
           </button>
         )}
+        {removeStep === 'idle' && (
+          <button
+            type="button"
+            className="sidebar-mcp-view-remove"
+            data-testid={`sidebar-mcp-view-remove-${server.name}`}
+            disabled={removeDisabled}
+            title={
+              removeDisabled
+                ? 'Removing MCP servers requires the primary API token'
+                : `Remove MCP server ${server.name}`
+            }
+            aria-label={`Remove MCP server ${server.name}`}
+            onClick={() => setRemoveStep('confirm')}
+          >
+            Remove
+          </button>
+        )}
       </div>
+      {removeStep !== 'idle' && (
+        <div className="sidebar-mcp-view-remove-confirm" data-testid={`sidebar-mcp-view-remove-confirm-${server.name}`}>
+          <select
+            data-testid={`sidebar-mcp-view-remove-scope-${server.name}`}
+            value={removeScope}
+            disabled={removeStep === 'removing'}
+            onChange={(e) => setRemoveScope(e.target.value as McpConfigScope)}
+          >
+            <option value="user">User scope</option>
+            <option value="project">Project scope</option>
+          </select>
+          <button
+            type="button"
+            data-testid={`sidebar-mcp-view-remove-confirm-btn-${server.name}`}
+            disabled={removeStep === 'removing'}
+            onClick={confirmRemove}
+          >
+            {removeStep === 'removing' ? 'Removing…' : 'Confirm remove'}
+          </button>
+          <button
+            type="button"
+            data-testid={`sidebar-mcp-view-remove-cancel-${server.name}`}
+            disabled={removeStep === 'removing'}
+            onClick={() => {
+              setRemoveStep('idle')
+              setRemoveError(null)
+            }}
+          >
+            Cancel
+          </button>
+          {removeError && (
+            <p className="sidebar-mcp-view-remove-error" data-testid={`sidebar-mcp-view-remove-error-${server.name}`} role="alert">
+              {removeError}
+            </p>
+          )}
+        </div>
+      )}
       {needsAuth && (
         <div className="sidebar-mcp-view-auth" data-testid={`sidebar-mcp-view-auth-${server.name}`}>
           {server.authUrl && (

--- a/packages/dashboard/src/lib/mcp-server-validation.test.ts
+++ b/packages/dashboard/src/lib/mcp-server-validation.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #6999 — mcp-server-validation tests. Each case mirrors a real server-side
+ * rejection from packages/server/src/byok-mcp-config.js so the add-form's
+ * client-side check stays in sync with the actual write-path validator.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateMcpServerName, validateMcpServerConfig, MCP_SERVER_NAME_RE } from './mcp-server-validation';
+
+describe('validateMcpServerName (#6999)', () => {
+  it('accepts a valid lowercase identifier', () => {
+    expect(validateMcpServerName('filesystem')).toBeNull();
+    expect(validateMcpServerName('ccd_session_mgmt')).toBeNull();
+    expect(validateMcpServerName('a')).toBeNull();
+    expect(validateMcpServerName('a-b-c')).toBeNull();
+  });
+
+  it('rejects an empty or whitespace-only name', () => {
+    expect(validateMcpServerName('')).toBe('Name is required.');
+    expect(validateMcpServerName('   ')).toBe('Name is required.');
+  });
+
+  it('rejects a name that does not start with a lowercase letter', () => {
+    expect(validateMcpServerName('1abc')).toMatch(/lowercase identifier/);
+    expect(validateMcpServerName('-abc')).toMatch(/lowercase identifier/);
+  });
+
+  it('rejects uppercase characters', () => {
+    expect(validateMcpServerName('MyServer')).toMatch(/lowercase identifier/);
+  });
+
+  it('rejects a name over 64 characters', () => {
+    const tooLong = 'a' + 'b'.repeat(64);
+    expect(tooLong.length).toBe(65);
+    expect(validateMcpServerName(tooLong)).toMatch(/lowercase identifier/);
+  });
+
+  it('rejects a name containing "__" (the MCP tool-namespace separator)', () => {
+    expect(validateMcpServerName('a__b')).toMatch(/tool-namespace separator/);
+    expect(validateMcpServerName('server__x')).toMatch(/tool-namespace separator/);
+  });
+
+  it('rejects reserved names (constructor / prototype)', () => {
+    expect(validateMcpServerName('constructor')).toMatch(/reserved/);
+    expect(validateMcpServerName('prototype')).toMatch(/reserved/);
+  });
+
+  it('__proto__ is caught by the reserved check before the charset regex', () => {
+    // Leading underscore also fails MCP_SERVER_NAME_RE, but the reserved
+    // check runs first and gives a clearer message either way.
+    expect(validateMcpServerName('__proto__')).toMatch(/reserved/);
+  });
+
+  it('MCP_SERVER_NAME_RE matches the server-side pattern shape', () => {
+    expect(MCP_SERVER_NAME_RE.test('filesystem')).toBe(true);
+    expect(MCP_SERVER_NAME_RE.test('Filesystem')).toBe(false);
+  });
+});
+
+describe('validateMcpServerConfig (#6999)', () => {
+  it('accepts a minimal stdio config', () => {
+    expect(validateMcpServerConfig({ command: 'npx' })).toBeNull();
+  });
+
+  it('accepts a minimal remote (http) config', () => {
+    expect(validateMcpServerConfig({ url: 'https://example.com/mcp' })).toBeNull();
+  });
+
+  it('rejects a config with neither command nor url', () => {
+    expect(validateMcpServerConfig({})).toMatch(/Provide either a command/);
+  });
+
+  it('rejects a config carrying BOTH command and url (ambiguous transport)', () => {
+    const err = validateMcpServerConfig({ command: 'npx', url: 'https://example.com/mcp' });
+    expect(err).toMatch(/cannot carry both/);
+  });
+
+  it('rejects a non-http(s) url scheme', () => {
+    expect(validateMcpServerConfig({ url: 'file:///etc/passwd' })).toMatch(/must be http\(s\)/);
+    expect(validateMcpServerConfig({ url: 'ws://example.com' })).toMatch(/must be http\(s\)/);
+  });
+
+  it('rejects an unparseable url', () => {
+    expect(validateMcpServerConfig({ url: 'not a url' })).toBe('url is not a valid URL.');
+  });
+
+  it('rejects a url targeting the cloud-metadata / link-local range', () => {
+    expect(validateMcpServerConfig({ url: 'http://169.254.169.254/latest/meta-data' })).toMatch(
+      /cloud-metadata/,
+    );
+  });
+
+  it('rejects a reserved key in env (stdio)', () => {
+    const err = validateMcpServerConfig({ command: 'npx', env: { constructor: 'x' } });
+    expect(err).toMatch(/env key 'constructor' is reserved/);
+  });
+
+  it('rejects a reserved key in headers (remote)', () => {
+    const err = validateMcpServerConfig({ url: 'https://example.com', headers: { constructor: 'x' } });
+    expect(err).toMatch(/headers key 'constructor' is reserved/);
+  });
+
+  it('rejects an env carrying "__proto__" as an OWN key (the real wire shape after JSON.parse, not a literal-syntax setter)', () => {
+    // `{ __proto__: 'x' }` as object-literal syntax hits the Object.prototype
+    // setter and never becomes an own key — but a message parsed off the wire
+    // via JSON.parse DOES produce a real own "__proto__" property (JSON.parse
+    // uses [[DefineOwnProperty]], not assignment). Round-trip through
+    // JSON.parse so this test exercises the shape that actually reaches the
+    // validator in production, matching the server's own UNSAFE_MAP_KEYS note.
+    const env = JSON.parse('{"__proto__":"secret-value"}') as Record<string, string>;
+    expect(Object.prototype.hasOwnProperty.call(env, '__proto__')).toBe(true);
+    const err = validateMcpServerConfig({ command: 'npx', env });
+    expect(err).toMatch(/env key '__proto__' is reserved/);
+  });
+
+  it('accepts a stdio config with args and safe env', () => {
+    expect(
+      validateMcpServerConfig({ command: 'npx', args: ['-y', 'some-pkg'], env: { API_KEY: 'secret' } }),
+    ).toBeNull();
+  });
+
+  it('accepts a remote config with safe headers', () => {
+    expect(
+      validateMcpServerConfig({ url: 'https://example.com/mcp', headers: { Authorization: 'Bearer x' } }),
+    ).toBeNull();
+  });
+});

--- a/packages/dashboard/src/lib/mcp-server-validation.ts
+++ b/packages/dashboard/src/lib/mcp-server-validation.ts
@@ -1,0 +1,112 @@
+/**
+ * #6999 — client-side mirror of the server's `add_mcp_server` validation.
+ *
+ * The authoritative rules live server-side in
+ * `packages/server/src/byok-mcp-config.js` (`MCP_SERVER_NAME_RE`,
+ * `validateNewMcpServerName`, `UNSAFE_MAP_KEYS` / `UNSAFE_MCP_SERVER_NAMES`,
+ * and the ambiguous-transport check in `parseClaudeMcpConfig`). This module
+ * exists ONLY to give the add-server form a fast, clear error before the
+ * round-trip — the server re-validates from scratch on write and is the sole
+ * authority (`normalizeMcpServerConfig`), so drift here can make the form too
+ * STRICT (annoying, caught immediately) but never too lenient in a way that
+ * reaches disk.
+ *
+ * Do not let this drift from byok-mcp-config.js — if the server's rules
+ * change, update both in the same PR.
+ */
+
+import type { McpServerConfigInput } from '../store/types';
+
+/** Mirrors `MCP_SERVER_NAME_RE` in byok-mcp-config.js exactly. */
+export const MCP_SERVER_NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/;
+
+/**
+ * Mirrors `UNSAFE_MCP_SERVER_NAMES` / `UNSAFE_MAP_KEYS` in byok-mcp-config.js
+ * — reserved because assigning them as an object key shadows or mutates
+ * object internals, regardless of charset.
+ */
+const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Mirrors `isBlockedMetadataHost` in byok-mcp-config.js — the cloud-metadata
+ * service / IPv4 link-local range (169.254.0.0/16, including its IPv4-mapped
+ * IPv6 forms) plus the AWS IMDS IPv6 endpoint. The server enforces this
+ * independently at write time (and again at request time); this is purely a
+ * client-side head start on the same narrow check.
+ */
+function isBlockedMetadataHost(hostname: string): boolean {
+  let h = hostname.toLowerCase();
+  if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1);
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (v4) return Number(v4[1]) === 169 && Number(v4[2]) === 254;
+  if (/^::ffff:a9fe:[0-9a-f]{1,4}$/.test(h)) return true;
+  const mapped = h.match(/^::ffff:(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (mapped) return Number(mapped[1]) === 169 && Number(mapped[2]) === 254;
+  if (h === 'fd00:ec2::254' || h === 'fd00:ec2:0:0:0:0:0:254') return true;
+  return false;
+}
+
+/**
+ * Validate a proposed server NAME for adding (the strict charset — mirrors
+ * `validateNewMcpServerName`). Returns an error string, or `null` when valid.
+ * Check order matches the server: reserved name, charset, then the `__`
+ * tool-namespace-separator rule.
+ */
+export function validateMcpServerName(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return 'Name is required.';
+  if (RESERVED_KEYS.has(trimmed)) return `'${trimmed}' is a reserved name.`;
+  if (!MCP_SERVER_NAME_RE.test(trimmed)) {
+    return 'Name must be a lowercase identifier: letters, digits, dash, underscore; must start with a letter; max 64 characters.';
+  }
+  if (trimmed.includes('__')) {
+    return "'__' is the MCP tool-namespace separator (mcp__<server>__<tool>) and would mis-route this server's tools.";
+  }
+  return null;
+}
+
+/** Mirrors the `env`/`headers` reserved-key refusal (`UNSAFE_MAP_KEYS`). */
+function validateKeyMap(map: Record<string, string> | undefined, label: string): string | null {
+  if (!map) return null;
+  for (const key of Object.keys(map)) {
+    if (RESERVED_KEYS.has(key)) return `${label} key '${key}' is reserved and cannot be used.`;
+  }
+  return null;
+}
+
+/**
+ * Validate a candidate `config` payload. Returns the first error found, or
+ * `null` when it looks safe to submit. Order mirrors the server: ambiguous
+ * transport, then missing transport, then per-transport field checks.
+ */
+export function validateMcpServerConfig(config: McpServerConfigInput): string | null {
+  const hasCommand = typeof config.command === 'string' && config.command.trim().length > 0;
+  const hasUrl = typeof config.url === 'string' && config.url.trim().length > 0;
+
+  // #7001-mirrored rule: a config carrying BOTH is ambiguous — the server
+  // refuses it outright on write rather than silently picking one transport.
+  if (hasCommand && hasUrl) {
+    return 'A server config cannot carry both a command (stdio) and a url (remote) — pick exactly one transport.';
+  }
+  if (!hasCommand && !hasUrl) {
+    return 'Provide either a command (stdio) or a url (remote).';
+  }
+
+  if (hasUrl) {
+    let parsed: URL;
+    try {
+      parsed = new URL(config.url!.trim());
+    } catch {
+      return 'url is not a valid URL.';
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return `url must be http(s) (got ${parsed.protocol}).`;
+    }
+    if (isBlockedMetadataHost(parsed.hostname)) {
+      return 'url targets a cloud-metadata / link-local address and is refused.';
+    }
+    return validateKeyMap(config.headers, 'headers');
+  }
+
+  return validateKeyMap(config.env, 'env');
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -71,6 +71,9 @@ import type {
   SessionInfo,
   SessionState,
   TranscriptViewerState,
+  McpServerOpResult,
+  McpConfigScope,
+  McpServerConfigInput,
 } from './types';
 import {
   loadServerRegistry,
@@ -129,6 +132,8 @@ import {
   registerThinkingLevelChangeRequest,
   clearPendingThinkingLevelReverts,
   clearPendingPermissionModeReverts,
+  armMcpServerOpCallback,
+  clearPendingMcpServerOps,
   beginTranscriptFetch,
   endTranscriptFetch,
   clearTranscriptWatchdog,
@@ -1055,6 +1060,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   // #3272: capability map populated from auth_ok. Empty until connected.
   serverCapabilities: {},
+
+  // #6999: no verdict yet — never assume the MCP add/remove UI is forbidden
+  // before an actual rejection (see the field's doc comment in types.ts).
+  mcpConfigForbiddenNonPrimary: false,
 
   launchWebTask: (prompt: string, cwd?: string) => {
     const { socket } = get();
@@ -2623,6 +2632,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // the still-armed callback so GitPanel's busy flag clears immediately
       // instead of spinning for up to the full 30s client-side timeout.
       clearGitOneshotCallbacks(set, get);
+      // #6999: same fast-reject for any in-flight add_mcp_server /
+      // remove_mcp_server — a dropped socket means the daemon can never reply,
+      // so the add-form / remove-button spinner clears immediately instead of
+      // waiting out MCP_SERVER_OP_TIMEOUT_MS.
+      clearPendingMcpServerOps();
       abortTranscriptFetchesOnSocketDrop(set, get);
       // #3605: also clear the per-session pendingTrustGrants arrays
       // (added in #3588). disconnect() handles user-initiated closes, but
@@ -2814,6 +2828,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #6954: same fast-reject as onclose above — an errored socket means
       // any in-flight git one-shot reply will never arrive.
       clearGitOneshotCallbacks(set, get);
+      // #6999: ditto for any in-flight add_mcp_server / remove_mcp_server.
+      clearPendingMcpServerOps();
       abortTranscriptFetchesOnSocketDrop(set, get);
       const cleanedSessionStates = clearAllSessionPendingTrustGrants(get().sessionStates);
 
@@ -2856,6 +2872,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // #6954: same fast-reject as onclose/onerror — an explicit disconnect
     // means any in-flight git one-shot reply will never arrive on this socket.
     clearGitOneshotCallbacks(set, get);
+    // #6999: ditto for any in-flight add_mcp_server / remove_mcp_server.
+    clearPendingMcpServerOps();
     const { socket } = get();
     if (socket) {
       socket.onclose = null;
@@ -2989,6 +3007,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // UI gates left enabled by stale state. Empty map = fail-closed
       // for any capability-gated affordance.
       serverCapabilities: {},
+      // #6999: same reasoning — a reconnect may present a different
+      // (possibly primary) token, so don't carry a stale "forbidden"
+      // verdict past a user-initiated disconnect.
+      mcpConfigForbiddenNonPrimary: false,
       savedConnection: null,
       userDisconnected: true,
       viewingCachedSession: false,
@@ -3666,6 +3688,64 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       sessionId: activeSessionId,
       server,
       code: code.trim(),
+      requestId,
+    });
+  },
+
+  // #6999 — add a brand-new MCP server to the active session's config (BYOK
+  // lane; server-side strict-primary gated — `client.isPrimaryToken === true`
+  // — MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT otherwise — and requires the
+  // daemon's first-use spawn-trust prompt before the server is actually
+  // spawned, whatever the response). There is no dedicated result type on
+  // this request: `callback` fires exactly once via armMcpServerOpCallback's
+  // three-way race (a matching `error`, an `mcp_servers` broadcast that now
+  // contains `name`, or a bounded timeout — see message-handler.ts), so a
+  // submit button's spinner always clears. `config` is never logged anywhere
+  // in this path — it may carry secrets in `env`/`headers`.
+  addMcpServer: (
+    name: string,
+    config: McpServerConfigInput,
+    scope: McpConfigScope,
+    callback: (result: McpServerOpResult) => void,
+  ) => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) {
+      callback({ ok: false, code: 'NOT_CONNECTED', message: 'Not connected to the daemon.' });
+      return;
+    }
+    const requestId = `add-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    armMcpServerOpCallback(requestId, { op: 'add', name, sessionId: activeSessionId }, callback);
+    wsSend(socket, {
+      type: 'add_mcp_server',
+      sessionId: activeSessionId,
+      name,
+      config,
+      scope,
+      requestId,
+    });
+  },
+
+  // #6999 — permanently remove a configured MCP server from the active
+  // session's config (BYOK lane; same strict-primary gate as addMcpServer).
+  // Same three-way `callback` resolution, but success is an `mcp_servers`
+  // broadcast whose list no longer contains `name`.
+  removeMcpServer: (
+    name: string,
+    scope: McpConfigScope,
+    callback: (result: McpServerOpResult) => void,
+  ) => {
+    const { socket, activeSessionId } = get();
+    if (!socket || socket.readyState !== WebSocket.OPEN || !activeSessionId) {
+      callback({ ok: false, code: 'NOT_CONNECTED', message: 'Not connected to the daemon.' });
+      return;
+    }
+    const requestId = `remove-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    armMcpServerOpCallback(requestId, { op: 'remove', name, sessionId: activeSessionId }, callback);
+    wsSend(socket, {
+      type: 'remove_mcp_server',
+      sessionId: activeSessionId,
+      name,
+      scope,
       requestId,
     });
   },

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -48,6 +48,11 @@ import {
   beginTranscriptFetch,
   endTranscriptFetch,
   resetTranscriptFetchTracking,
+  armMcpServerOpCallback,
+  clearPendingMcpServerOps,
+  _testMcpServerOpPendingSize,
+  MCP_SERVER_OP_TIMEOUT_MS,
+  MCP_SERVER_OP_TIMEOUT_MESSAGE,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
@@ -172,6 +177,8 @@ describe('dashboard message-handler dispatch', () => {
     // #6863 — reset transcript-fetch pending-id tracking between tests so a
     // leftover conversationId from one case doesn't intercept frames in another.
     resetTranscriptFetchTracking()
+    // #6999 — reset in-flight add_mcp_server / remove_mcp_server tracking.
+    clearPendingMcpServerOps()
     mockSocket = createMockSocket()
     store = createMockStore(baseState())
     setStore(store)
@@ -185,6 +192,8 @@ describe('dashboard message-handler dispatch', () => {
     // #3587: defensive cleanup so a test that registers a pending
     // trust-grant entry but doesn't consume it can't poison the next.
     clearPendingTrustGrants()
+    // #6999: same defensive cleanup for any pending MCP op left armed.
+    clearPendingMcpServerOps()
   })
 
   describe('auth_ok dispatch', () => {
@@ -1071,6 +1080,171 @@ describe('dashboard message-handler dispatch', () => {
         // Entry consumed (resolved): map is empty.
         expect(_testTrustGrantPendingSize()).toBe(0)
       })
+    })
+  })
+
+  describe('add_mcp_server / remove_mcp_server op tracking (#6999)', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('resolves ok:true when an mcp_servers broadcast for the target session now contains the added name', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-1', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage(
+        { type: 'mcp_servers', sessionId: 's1', servers: [{ name: 'filesystem', status: 'configured' }] },
+        ctx() as any,
+      )
+      expect(cb).toHaveBeenCalledTimes(1)
+      expect(cb).toHaveBeenCalledWith({ ok: true })
+      expect(_testMcpServerOpPendingSize()).toBe(0)
+    })
+
+    it('does NOT resolve an add op from a broadcast for a DIFFERENT session', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-2', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage(
+        { type: 'mcp_servers', sessionId: 's2', servers: [{ name: 'filesystem', status: 'configured' }] },
+        ctx() as any,
+      )
+      expect(cb).not.toHaveBeenCalled()
+      expect(_testMcpServerOpPendingSize()).toBe(1)
+    })
+
+    it('does NOT resolve an add op while the name is still absent from the broadcast list', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-3', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage(
+        { type: 'mcp_servers', sessionId: 's1', servers: [{ name: 'other', status: 'configured' }] },
+        ctx() as any,
+      )
+      expect(cb).not.toHaveBeenCalled()
+      expect(_testMcpServerOpPendingSize()).toBe(1)
+    })
+
+    it('resolves ok:true for a REMOVE op once the name is absent from the broadcast list', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('remove-1', { op: 'remove', name: 'filesystem', sessionId: 's1' }, cb)
+      // Still present — not yet satisfied.
+      handleMessage(
+        { type: 'mcp_servers', sessionId: 's1', servers: [{ name: 'filesystem', status: 'configured' }] },
+        ctx() as any,
+      )
+      expect(cb).not.toHaveBeenCalled()
+      // Now absent — satisfied.
+      handleMessage({ type: 'mcp_servers', sessionId: 's1', servers: [] }, ctx() as any)
+      expect(cb).toHaveBeenCalledTimes(1)
+      expect(cb).toHaveBeenCalledWith({ ok: true })
+    })
+
+    it('falls back to the active session when the broadcast has no sessionId (mirrors handleMcpServers)', () => {
+      store = createMockStore(baseState({ activeSessionId: 's1' }))
+      setStore(store)
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-4', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage({ type: 'mcp_servers', servers: [{ name: 'filesystem', status: 'configured' }] }, ctx() as any)
+      expect(cb).toHaveBeenCalledWith({ ok: true })
+    })
+
+    it('resolves ok:false with the server code+message on a matching `error` envelope', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-5', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage(
+        { type: 'error', requestId: 'add-5', code: 'MCP_SERVER_EXISTS', message: "An MCP server named 'filesystem' already exists in user scope." },
+        ctx() as any,
+      )
+      expect(cb).toHaveBeenCalledWith({
+        ok: false,
+        code: 'MCP_SERVER_EXISTS',
+        message: "An MCP server named 'filesystem' already exists in user scope.",
+      })
+      expect(_testMcpServerOpPendingSize()).toBe(0)
+    })
+
+    it('an error with an unrelated requestId does not resolve or consume the tracked op', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-6', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage({ type: 'error', requestId: 'some-other-request', code: 'UNKNOWN', message: 'irrelevant' }, ctx() as any)
+      expect(cb).not.toHaveBeenCalled()
+      expect(_testMcpServerOpPendingSize()).toBe(1)
+    })
+
+    it('sets mcpConfigForbiddenNonPrimary on the store when the primary-token refusal fires', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-7', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage(
+        {
+          type: 'error',
+          requestId: 'add-7',
+          code: 'MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT',
+          message: 'Pairing-issued tokens cannot add or remove MCP servers.',
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.mcpConfigForbiddenNonPrimary).toBe(true)
+      expect(cb).toHaveBeenCalledWith({
+        ok: false,
+        code: 'MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT',
+        message: 'Pairing-issued tokens cannot add or remove MCP servers.',
+      })
+    })
+
+    it('does not set mcpConfigForbiddenNonPrimary for an unrelated error code', () => {
+      handleMessage({ type: 'error', code: 'MCP_SERVER_EXISTS', message: 'x' }, ctx() as any)
+      const state = store.getState() as any
+      expect(state.mcpConfigForbiddenNonPrimary).toBeUndefined()
+    })
+
+    it('a fresh auth_ok resets mcpConfigForbiddenNonPrimary to false', () => {
+      store = createMockStore(baseState({ mcpConfigForbiddenNonPrimary: true } as any))
+      setStore(store)
+      handleMessage(
+        {
+          type: 'auth_ok',
+          serverMode: 'cli',
+          cwd: '/tmp',
+          serverVersion: '0.6.0',
+          protocolVersion: 3,
+          clientId: 'c1',
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state.mcpConfigForbiddenNonPrimary).toBe(false)
+    })
+
+    it('resolves ok:false with TIMEOUT after MCP_SERVER_OP_TIMEOUT_MS with no reply — the no-reply path cannot hang forever', () => {
+      vi.useFakeTimers()
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-8', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      expect(_testMcpServerOpPendingSize()).toBe(1)
+      vi.advanceTimersByTime(MCP_SERVER_OP_TIMEOUT_MS)
+      expect(cb).toHaveBeenCalledWith({ ok: false, code: 'TIMEOUT', message: MCP_SERVER_OP_TIMEOUT_MESSAGE })
+      expect(_testMcpServerOpPendingSize()).toBe(0)
+    })
+
+    it('a callback fired exactly once — an error after a broadcast already resolved it is a no-op', () => {
+      const cb = vi.fn()
+      armMcpServerOpCallback('add-9', { op: 'add', name: 'filesystem', sessionId: 's1' }, cb)
+      handleMessage(
+        { type: 'mcp_servers', sessionId: 's1', servers: [{ name: 'filesystem', status: 'configured' }] },
+        ctx() as any,
+      )
+      expect(cb).toHaveBeenCalledTimes(1)
+      handleMessage({ type: 'error', requestId: 'add-9', code: 'MCP_SERVER_ADD_NOT_APPLIED', message: 'late' }, ctx() as any)
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it('clearPendingMcpServerOps fast-rejects every still-armed op (socket disconnect)', () => {
+      const cbA = vi.fn()
+      const cbB = vi.fn()
+      armMcpServerOpCallback('add-10', { op: 'add', name: 'a', sessionId: 's1' }, cbA)
+      armMcpServerOpCallback('remove-10', { op: 'remove', name: 'b', sessionId: 's1' }, cbB)
+      clearPendingMcpServerOps()
+      expect(cbA).toHaveBeenCalledWith({ ok: false, code: 'DISCONNECTED', message: MCP_SERVER_OP_TIMEOUT_MESSAGE })
+      expect(cbB).toHaveBeenCalledWith({ ok: false, code: 'DISCONNECTED', message: MCP_SERVER_OP_TIMEOUT_MESSAGE })
+      expect(_testMcpServerOpPendingSize()).toBe(0)
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -53,6 +53,8 @@ import {
   _testMcpServerOpPendingSize,
   MCP_SERVER_OP_TIMEOUT_MS,
   MCP_SERVER_OP_TIMEOUT_MESSAGE,
+  MCP_SERVER_OP_EVICTED_MESSAGE,
+  MCP_SERVER_OP_PENDING_CAP,
 } from './message-handler'
 import { createEmptySessionState } from './utils'
 import type { ConnectionState } from './types'
@@ -1245,6 +1247,62 @@ describe('dashboard message-handler dispatch', () => {
       expect(cbA).toHaveBeenCalledWith({ ok: false, code: 'DISCONNECTED', message: MCP_SERVER_OP_TIMEOUT_MESSAGE })
       expect(cbB).toHaveBeenCalledWith({ ok: false, code: 'DISCONNECTED', message: MCP_SERVER_OP_TIMEOUT_MESSAGE })
       expect(_testMcpServerOpPendingSize()).toBe(0)
+    })
+
+    // #6999 review: FIFO eviction used to delete the oldest op AND its timeout
+    // timer without ever invoking its callback — the one exit path of the four
+    // that broke the exactly-once contract, leaving the caller's submit spinner
+    // stuck forever (the #6939/#6954 stuck-flag class, for the git one-shots).
+    it('eviction at the pending cap RESOLVES the evicted op with an error instead of dropping it', () => {
+      const callbacks = Array.from({ length: 9 }, () => vi.fn())
+      // Fill to the cap (8), then arm a 9th to force one eviction.
+      callbacks.forEach((cb, i) => {
+        armMcpServerOpCallback(`evict-${i}`, { op: 'add', name: `srv-${i}`, sessionId: 's1' }, cb)
+      })
+      // The oldest (index 0) was evicted and MUST have been told so.
+      expect(callbacks[0]).toHaveBeenCalledTimes(1)
+      expect(callbacks[0]).toHaveBeenCalledWith({
+        ok: false,
+        code: 'EVICTED',
+        message: MCP_SERVER_OP_EVICTED_MESSAGE,
+      })
+      // Everyone else is still armed and untouched.
+      callbacks.slice(1).forEach((cb) => expect(cb).not.toHaveBeenCalled())
+      expect(_testMcpServerOpPendingSize()).toBe(8)
+    })
+
+    it('an evicted op is fully deregistered — its timeout can never fire a second callback', () => {
+      vi.useFakeTimers()
+      const callbacks = Array.from({ length: 9 }, () => vi.fn())
+      callbacks.forEach((cb, i) => {
+        armMcpServerOpCallback(`evict2-${i}`, { op: 'add', name: `srv-${i}`, sessionId: 's1' }, cb)
+      })
+      expect(callbacks[0]).toHaveBeenCalledTimes(1)
+      // Advancing past the timeout must NOT re-fire the evicted op's callback
+      // (exactly-once holds across eviction + timeout).
+      vi.advanceTimersByTime(MCP_SERVER_OP_TIMEOUT_MS)
+      expect(callbacks[0]).toHaveBeenCalledTimes(1)
+      expect(callbacks[0]).toHaveBeenCalledWith({
+        ok: false,
+        code: 'EVICTED',
+        message: MCP_SERVER_OP_EVICTED_MESSAGE,
+      })
+    })
+
+    it('an eviction callback that synchronously re-arms cannot push the map past the cap', () => {
+      const tail = vi.fn()
+      // The evicted op retries from inside its own eviction callback — the
+      // re-entrancy the bounded evict budget defends against.
+      const retrying = vi.fn(() => {
+        armMcpServerOpCallback('retry-op', { op: 'add', name: 'retry', sessionId: 's1' }, vi.fn())
+      })
+      armMcpServerOpCallback('reentrant-0', { op: 'add', name: 'srv-0', sessionId: 's1' }, retrying)
+      for (let i = 1; i < 8; i++) {
+        armMcpServerOpCallback(`reentrant-${i}`, { op: 'add', name: `srv-${i}`, sessionId: 's1' }, vi.fn())
+      }
+      armMcpServerOpCallback('reentrant-tail', { op: 'add', name: 'tail', sessionId: 's1' }, tail)
+      expect(retrying).toHaveBeenCalledTimes(1)
+      expect(_testMcpServerOpPendingSize()).toBeLessThanOrEqual(MCP_SERVER_OP_PENDING_CAP)
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -494,10 +494,12 @@ interface PendingMcpServerOp {
 
 const _pendingMcpServerOps = new Map<string, PendingMcpServerOp>();
 const _mcpServerOpTimers = new Map<string, ReturnType<typeof setTimeout>>();
-const MCP_SERVER_OP_PENDING_CAP = 8;
+export const MCP_SERVER_OP_PENDING_CAP = 8;
 export const MCP_SERVER_OP_TIMEOUT_MS = 15_000;
 export const MCP_SERVER_OP_TIMEOUT_MESSAGE =
   'No response from the daemon — check the server list below; the request may still complete.';
+export const MCP_SERVER_OP_EVICTED_MESSAGE =
+  'Too many MCP config requests in flight — this one stopped being tracked; check the server list below, as it may still have completed.';
 
 function _clearMcpServerOpTimer(requestId: string): void {
   const timer = _mcpServerOpTimers.get(requestId);
@@ -509,23 +511,37 @@ function _clearMcpServerOpTimer(requestId: string): void {
 
 /**
  * Arm a one-shot correlation for an `add_mcp_server` / `remove_mcp_server`
- * request. `callback` fires EXACTLY once, via whichever of the three
- * resolution paths above happens first. Bounded FIFO eviction (oldest first,
- * silently dropped with no callback invocation — the same contract as the
- * trust-grant / model-revert maps) defends a buggy caller that never lets a
- * prior request resolve; ordinary use never approaches the cap.
+ * request. `callback` fires EXACTLY once, via whichever of the FOUR resolution
+ * paths above happens first — error envelope, satisfying broadcast, timeout, or
+ * socket drop.
+ *
+ * Bounded FIFO eviction (oldest first) defends a buggy caller that never lets a
+ * prior request resolve; ordinary use never approaches the cap because the UI
+ * serializes submissions. Eviction RESOLVES the evicted op with an error rather
+ * than dropping it silently: the callback is what clears the caller's submit
+ * spinner, so a dropped callback is a permanently stuck button — exactly the
+ * stuck-flag class of bug #6939/#6954 fixed for the git one-shots. Unlike the
+ * trust-grant / model-revert maps (whose entries are passive state slots with no
+ * waiting caller), every entry here has a UI spinner blocked on it, so
+ * "exactly once" has to survive eviction too.
  */
 export function armMcpServerOpCallback(
   requestId: string,
   entry: { op: 'add' | 'remove'; name: string; sessionId: string | null },
   callback: (result: McpServerOpResult) => void,
 ): void {
-  if (_pendingMcpServerOps.size >= MCP_SERVER_OP_PENDING_CAP) {
+  // Evict oldest-first until there is room. `evictBudget` bounds the loop by the
+  // entries present on entry, so an eviction callback that synchronously arms a
+  // replacement op (a retry) can't spin here forever.
+  let evictBudget = _pendingMcpServerOps.size;
+  while (_pendingMcpServerOps.size >= MCP_SERVER_OP_PENDING_CAP && evictBudget-- > 0) {
     const oldestKey = _pendingMcpServerOps.keys().next().value;
-    if (oldestKey !== undefined) {
-      _clearMcpServerOpTimer(oldestKey);
-      _pendingMcpServerOps.delete(oldestKey);
-    }
+    if (oldestKey === undefined) break;
+    _resolvePendingMcpServerOp(oldestKey, {
+      ok: false,
+      code: 'EVICTED',
+      message: MCP_SERVER_OP_EVICTED_MESSAGE,
+    });
   }
   _pendingMcpServerOps.set(requestId, { ...entry, callback });
   const timer = setTimeout(() => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -181,6 +181,7 @@ import type {
   SessionState,
   FilePickerItem,
   MCPResourceItem,
+  McpServerOpResult,
 } from './types';
 import { createEmptySessionState } from './utils';
 import { clearPersistedSession } from './persistence';
@@ -453,6 +454,139 @@ export function _testThinkingLevelRevertPendingSize(): number {
 /** @internal Exposed for tests so they can inspect the in-flight map. */
 export function _testTrustGrantPendingSize(): number {
   return _pendingTrustGrants.size;
+}
+
+// ---------------------------------------------------------------------------
+// #6999 — in-flight add_mcp_server / remove_mcp_server tracking.
+// ---------------------------------------------------------------------------
+//
+// Unlike set_model / set_permission_mode / set_thinking_level (which reply
+// with either a `*_changed` broadcast XOR a matching `error`), add_mcp_server
+// and remove_mcp_server have NO dedicated result type at all — #6974/#6998
+// deliberately shipped none; the re-emitted `mcp_servers` broadcast IS the
+// ack. So a caller (the add-server form / a remove button) needs a bounded
+// three-way resolution, armed per requestId:
+//   1. a matching `error` envelope arrives → the write was rejected
+//      (validation, MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT, EXISTS,
+//      TRUST_DENIED, UNSUPPORTED, NOT_FOUND, ...).
+//   2. an `mcp_servers` broadcast for the target session arrives whose server
+//      list now satisfies the requested change (name present for add, absent
+//      for remove) → success. Checked directly against the RAW wire payload
+//      in `handleMessage`, BEFORE the shared dispatch table (#5556) applies it
+//      as a session patch — so this never races the patch application.
+//   3. neither arrives within MCP_SERVER_OP_TIMEOUT_MS → a bounded timeout,
+//      mirroring the git one-shot pattern (#6953/#6954) so a hung request
+//      can't leave a submit button's spinner stuck forever.
+//   4. the socket drops → clearPendingMcpServerOps fast-rejects every armed
+//      op, mirroring clearGitOneshotCallbacks / clearPendingTrustGrants.
+//
+// A Map (not the git pattern's fixed state-slot keys) because a name+scope
+// pair uniquely identifies a call and the UI naturally serializes submissions
+// (the form/remove-button disables while a request is in flight), so the
+// bounded FIFO cap below should never actually be hit in practice.
+
+interface PendingMcpServerOp {
+  op: 'add' | 'remove';
+  name: string;
+  sessionId: string | null;
+  callback: (result: McpServerOpResult) => void;
+}
+
+const _pendingMcpServerOps = new Map<string, PendingMcpServerOp>();
+const _mcpServerOpTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const MCP_SERVER_OP_PENDING_CAP = 8;
+export const MCP_SERVER_OP_TIMEOUT_MS = 15_000;
+export const MCP_SERVER_OP_TIMEOUT_MESSAGE =
+  'No response from the daemon — check the server list below; the request may still complete.';
+
+function _clearMcpServerOpTimer(requestId: string): void {
+  const timer = _mcpServerOpTimers.get(requestId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    _mcpServerOpTimers.delete(requestId);
+  }
+}
+
+/**
+ * Arm a one-shot correlation for an `add_mcp_server` / `remove_mcp_server`
+ * request. `callback` fires EXACTLY once, via whichever of the three
+ * resolution paths above happens first. Bounded FIFO eviction (oldest first,
+ * silently dropped with no callback invocation — the same contract as the
+ * trust-grant / model-revert maps) defends a buggy caller that never lets a
+ * prior request resolve; ordinary use never approaches the cap.
+ */
+export function armMcpServerOpCallback(
+  requestId: string,
+  entry: { op: 'add' | 'remove'; name: string; sessionId: string | null },
+  callback: (result: McpServerOpResult) => void,
+): void {
+  if (_pendingMcpServerOps.size >= MCP_SERVER_OP_PENDING_CAP) {
+    const oldestKey = _pendingMcpServerOps.keys().next().value;
+    if (oldestKey !== undefined) {
+      _clearMcpServerOpTimer(oldestKey);
+      _pendingMcpServerOps.delete(oldestKey);
+    }
+  }
+  _pendingMcpServerOps.set(requestId, { ...entry, callback });
+  const timer = setTimeout(() => {
+    _mcpServerOpTimers.delete(requestId);
+    const pending = _pendingMcpServerOps.get(requestId);
+    if (!pending) return;
+    _pendingMcpServerOps.delete(requestId);
+    pending.callback({ ok: false, code: 'TIMEOUT', message: MCP_SERVER_OP_TIMEOUT_MESSAGE });
+  }, MCP_SERVER_OP_TIMEOUT_MS);
+  _mcpServerOpTimers.set(requestId, timer);
+}
+
+function _resolvePendingMcpServerOp(requestId: string, result: McpServerOpResult): void {
+  const pending = _pendingMcpServerOps.get(requestId);
+  if (!pending) return;
+  _clearMcpServerOpTimer(requestId);
+  _pendingMcpServerOps.delete(requestId);
+  pending.callback(result);
+}
+
+/**
+ * Check a raw `mcp_servers` broadcast against every in-flight op for the
+ * target session, resolving (ok: true) any whose expectation the new list now
+ * satisfies. Reads directly off the WIRE payload — deliberately not the
+ * already-applied store state — so this is safe to call before or after the
+ * shared dispatch table's session-patch write, with an identical result.
+ */
+function _resolveMcpServerOpsFromBroadcast(sessionId: string | null, rawServers: unknown): void {
+  if (_pendingMcpServerOps.size === 0) return;
+  const names = new Set(
+    Array.isArray(rawServers)
+      ? rawServers
+          .map((s) => (s && typeof s === 'object' ? (s as Record<string, unknown>).name : null))
+          .filter((n): n is string => typeof n === 'string')
+      : [],
+  );
+  for (const [requestId, pending] of _pendingMcpServerOps) {
+    if (pending.sessionId !== sessionId) continue;
+    const present = names.has(pending.name);
+    const satisfied = pending.op === 'add' ? present : !present;
+    if (satisfied) _resolvePendingMcpServerOp(requestId, { ok: true });
+  }
+}
+
+/**
+ * Fast-reject every still-armed MCP add/remove op on socket disconnect — a
+ * dead socket means the daemon can never reply, so there is no reason to make
+ * the caller wait out the full client-side timeout. Mirrors
+ * clearGitOneshotCallbacks / clearPendingTrustGrants.
+ */
+export function clearPendingMcpServerOps(): void {
+  for (const [requestId, pending] of _pendingMcpServerOps) {
+    _clearMcpServerOpTimer(requestId);
+    pending.callback({ ok: false, code: 'DISCONNECTED', message: MCP_SERVER_OP_TIMEOUT_MESSAGE });
+  }
+  _pendingMcpServerOps.clear();
+}
+
+/** @internal Exposed for tests so they can inspect the in-flight map. */
+export function _testMcpServerOpPendingSize(): number {
+  return _pendingMcpServerOps.size;
 }
 
 // ---------------------------------------------------------------------------
@@ -3962,6 +4096,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
   }
 
+  // #6999 — add_mcp_server / remove_mcp_server have no dedicated result type;
+  // the re-emitted mcp_servers broadcast IS the ack (#6974/#6998). Resolve any
+  // in-flight op off the RAW wire payload before the shared dispatch table
+  // (immediately below) applies it as a session patch, so this never races
+  // that application either way.
+  if (msg.type === 'mcp_servers') {
+    _resolveMcpServerOpsFromBroadcast(resolveSessionId(msg, get().activeSessionId), (msg as { servers?: unknown }).servers);
+  }
+
   // #5556 — shared dispatch table first. A hit handles the message and
   // returns; a miss falls through to the dashboard's own HANDLERS map +
   // switch below, keeping migration incremental.
@@ -4068,6 +4211,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         restartingSince: null,
         webFeatures: auth.webFeatures,
         serverCapabilities: auth.serverCapabilities,
+        // #6999: a fresh auth may present a different (possibly primary)
+        // token — don't carry a stale "forbidden" verdict across reconnects.
+        mcpConfigForbiddenNonPrimary: false,
       };
       if (ctx.isReconnect) {
         set(connectedState);
@@ -5767,6 +5913,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const errReqId = typeof msg.requestId === 'string' ? msg.requestId : null;
       if (errReqId) {
         clearPendingTrustGrantByRequestId(errReqId, get);
+      }
+      // #6999: resolve any in-flight add_mcp_server / remove_mcp_server whose
+      // requestId matches — a no-op when the error belongs to some other
+      // handler's request (armMcpServerOpCallback / _resolvePendingMcpServerOp
+      // are no-ops for an unrecognized requestId).
+      if (errReqId) {
+        _resolvePendingMcpServerOp(errReqId, { ok: false, code: errCode, message: errMsg });
+      }
+      // #6999: sticky "not the primary token" signal for the MCP add/remove
+      // UI. Sourced from the actual rejection rather than a heuristic — see
+      // ConnectionState.mcpConfigForbiddenNonPrimary's doc comment (types.ts)
+      // for why there is no proactive wire flag to gate on instead. Set
+      // regardless of whether a tracked op matched this requestId (defensive:
+      // a future caller of add/remove that doesn't go through
+      // armMcpServerOpCallback should still flip this).
+      if (errCode === 'MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT') {
+        set({ mcpConfigForbiddenNonPrimary: true });
       }
       // #5711 (Gap 2, client half): roll back the optimistic set_model when the
       // server says it never applied (MODEL_NOT_APPLIED — e.g. a mid-turn

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -371,6 +371,48 @@ export interface PermissionRule {
 }
 
 /**
+ * #6999 — the two MCP config MUTATION scopes a client may target. Mirrors
+ * `McpConfigScopeSchema` in `packages/protocol/src/schemas/client.ts` exactly
+ * (the wire contract shipped in #6974/#6998 and is settled). Both live in
+ * `~/.claude.json`: 'user' is the root `mcpServers` block, 'project' is
+ * `projects[<realpath(cwd)>].mcpServers`.
+ */
+export type McpConfigScope = 'user' | 'project';
+
+/**
+ * #6999 — the `config` payload shape for `add_mcp_server`, mirroring
+ * `AddMcpServerSchema.config` in `packages/protocol/src/schemas/client.ts`
+ * field-for-field. The server is authoritative (normalizeMcpServerConfig,
+ * `packages/server/src/byok-mcp-config.js`) — this type only bounds what the
+ * client is allowed to SEND; validate against the same rules client-side
+ * (mcp-server-validation.ts) before submitting for a fast, clear error.
+ */
+export interface McpServerConfigInput {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  type?: 'stdio' | 'http' | 'streamable-http' | 'sse';
+  url?: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * #6999 — the resolved outcome of an `addMcpServer` / `removeMcpServer` call,
+ * handed to the caller's callback by `armMcpServerOpCallback`'s three-way race
+ * (matching `error` envelope / satisfying `mcp_servers` broadcast / bounded
+ * timeout — see message-handler.ts). There is no dedicated wire result type
+ * for either request (#6974/#6998 deliberately shipped none), so `code` /
+ * `message` are populated only on failure, sourced either from the server's
+ * `error` envelope or a client-side synthetic code (`NOT_CONNECTED`,
+ * `TIMEOUT`, `DISCONNECTED`).
+ */
+export interface McpServerOpResult {
+  ok: boolean;
+  code?: string;
+  message?: string;
+}
+
+/**
  * #6772 — one entry from the server's permission audit trail (permission-audit.js
  * ring buffer), returned by a `query_permission_audit` pull. Heterogeneous `type`s
  * share this shape; per-type fields are optional (mirrors the wire
@@ -1421,6 +1463,17 @@ export interface ConnectionState {
   // field, so missing keys are treated as `false` (fail-closed).
   serverCapabilities: Record<string, boolean>;
 
+  // #6999: sticky "this connection is not the primary token" signal. There is
+  // no proactive wire flag for `client.isPrimaryToken` (it is a server-only
+  // concept — see docs/security/bearer-token-authority.md), so this starts
+  // `false` (never assume forbidden) and flips permanently `true` the first
+  // time an `add_mcp_server` / `remove_mcp_server` is rejected with
+  // `MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT`. Reset to `false` on every fresh
+  // `auth_ok` (a reconnect may present a different, primary token). Consumed
+  // by the MCP add/remove UI to disable + annotate the controls after the
+  // first refusal rather than re-attempting a write that will keep failing.
+  mcpConfigForbiddenNonPrimary: boolean;
+
   // Server startup phase (from server_status events)
   // #2836: 'tunnel_warming' is the current name for the DNS-propagation
   // window; 'tunnel_verifying' is retained as a legacy alias that
@@ -1693,6 +1746,37 @@ export interface ConnectionState {
    * client-side.
    */
   submitMcpAuthCode: (server: string, code: string) => void;
+  /**
+   * #6999 — add a brand-new MCP server to the active session's config (BYOK
+   * lane; server-side strict-primary gated — `client.isPrimaryToken === true`
+   * — and requires the daemon's first-use spawn-trust prompt before it takes
+   * effect). Sends `add_mcp_server`. There is no dedicated result type: the
+   * `callback` fires exactly once, resolved by whichever comes first — a
+   * matching `error` envelope, an `mcp_servers` broadcast whose list now
+   * contains `name` (success), or a bounded client-side timeout — so a submit
+   * button's spinner is guaranteed to clear. No-op (immediate
+   * `NOT_CONNECTED` callback) when the socket is closed or there is no active
+   * session. `config` is never logged — it may carry secrets in `env`/`headers`.
+   */
+  addMcpServer: (
+    name: string,
+    config: McpServerConfigInput,
+    scope: McpConfigScope,
+    callback: (result: McpServerOpResult) => void,
+  ) => void;
+  /**
+   * #6999 — permanently remove a configured MCP server from the active
+   * session's config (BYOK lane; same strict-primary gate as `addMcpServer`).
+   * Sends `remove_mcp_server`. Same three-way `callback` resolution as
+   * `addMcpServer`, but success is an `mcp_servers` broadcast whose list no
+   * longer contains `name`. No-op (immediate `NOT_CONNECTED` callback) when
+   * the socket is closed or there is no active session.
+   */
+  removeMcpServer: (
+    name: string,
+    scope: McpConfigScope,
+    callback: (result: McpServerOpResult) => void,
+  ) => void;
   /**
    * #6772 — pull the permission audit history for the active session
    * (`query_permission_audit`). Sets `permissionAuditLoading`; the reply lands in

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1703,6 +1703,19 @@ button.sidebar-token-view-session-row:hover {
   font-size: 10px;
 }
 
+/*
+ * #6999 — the scope a server actually lives in is not on the wire (the
+ * `mcp_servers` payload carries no scope), so the confirm strip must ask rather
+ * than pre-select a guess. This spells that out instead of letting a wrong
+ * default ride behind a confident-looking dialog.
+ */
+.sidebar-mcp-view-remove-hint {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
 /* #5163 (epic #5159) — Control Room panel: live read-only activity tree. */
 .control-room-panel {
   display: flex;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1636,6 +1636,73 @@ button.sidebar-token-view-session-row:hover {
   cursor: default;
 }
 
+/* #6999 — per-row "Remove" action + inline scope-confirm strip. Removal is
+   scope-exact server-side (a wrong scope reports MCP_SERVER_NOT_FOUND rather
+   than guessing), so the confirm step always asks which scope. */
+.sidebar-mcp-view-remove {
+  flex-shrink: 0;
+  align-self: center;
+  margin-left: 4px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sidebar-mcp-view-remove:hover:not(:disabled) {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+.sidebar-mcp-view-remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sidebar-mcp-view-remove-confirm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding-left: 16px;
+}
+
+.sidebar-mcp-view-remove-confirm select {
+  padding: 2px 4px;
+  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 10px;
+}
+
+.sidebar-mcp-view-remove-confirm button {
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sidebar-mcp-view-remove-confirm button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sidebar-mcp-view-remove-error {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--text-error);
+  font-size: 10px;
+}
+
 /* #5163 (epic #5159) — Control Room panel: live read-only activity tree. */
 .control-room-panel {
   display: flex;


### PR DESCRIPTION
## Summary

Dashboard UI for adding/removing MCP servers, consuming the server+protocol slice that shipped in #6998 (`add_mcp_server` / `remove_mcp_server`, `McpConfigScopeSchema`). The wire contract is settled and unchanged by this PR — no protocol changes.

Closes #6999

## What shipped

- **`AddMcpServerForm`** (new, embedded in `SidebarMcpView`'s MCP panel) — collapsible add-server form: name, scope (`user`/`project`), transport radio (stdio: command/args/env, or remote: url/headers with `KEY=VALUE`-per-line editors).
- **Client-side validation** (`packages/dashboard/src/lib/mcp-server-validation.ts`) mirrors the server's actual rules read from `packages/server/src/byok-mcp-config.js` — name charset `/^[a-z][a-z0-9_-]{0,63}$/`, no `__` (the `mcp__<server>__<tool>` namespace separator), reserved keys (`constructor`/`prototype`), and a config carrying both `command` and `url` is refused as ambiguous. This is a fast local error before the round-trip; the server remains authoritative and re-validates from scratch on write.
- **Remove action** — a "Remove" button per row in `SidebarMcpView` opens an inline scope-confirm step (a select + confirm/cancel), since removal is scope-exact server-side (the wrong scope reports `MCP_SERVER_NOT_FOUND` rather than guessing).

## Primary-token requirement — surfaced, not hidden

Both mutations require the strict primary token class server-side (`client.isPrimaryToken === true`); a paired/pairing client is rejected with `MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT`. There is no proactive wire signal for this (`isPrimaryToken` is a server-only concept — see `docs/security/bearer-token-authority.md`), so:

- A persistent notice ("Requires the primary API token. A paired device will be refused.") is always visible on the add form **before** any submit attempt, regardless of what's known.
- The first time either mutation is actually refused with `MCP_CONFIG_FORBIDDEN_NON_PRIMARY_CLIENT`, a sticky `mcpConfigForbiddenNonPrimary` store flag flips (reset on every fresh `auth_ok`/disconnect) and both the add form and every row's Remove button disable themselves with the server's own (already human-readable) rejection text — not a generic error, and not silently hidden.

## "Adding is not trusting"

A fixed notice on the add form makes clear the daemon still gates the first spawn behind its trust prompt — even for a name that was previously trusted, since #6998 rekeyed trust to a hash of the full spawn config (command + args + env).

## Success confirmation without a result type

`add_mcp_server`/`remove_mcp_server` have no dedicated result message — the re-emitted `mcp_servers` broadcast is the ack. `message-handler.ts` gains a bounded three-way resolution per in-flight request (`armMcpServerOpCallback`, modeled on the existing `armGitOneshotCallback` one-shot pattern from #6953/#6954):

1. a matching `error` envelope → reject with the server's code/message,
2. an `mcp_servers` broadcast for the target session whose list now satisfies the requested change (name present for add / absent for remove) → resolve success, checked against the raw wire payload before the shared dispatch table applies it as a session patch,
3. `MCP_SERVER_OP_TIMEOUT_MS` (15s) with neither → bounded timeout so a submit spinner can never hang forever.

Every disconnect path (`onclose`/`onerror`/`disconnect()`) fast-rejects any still-armed op, mirroring `clearGitOneshotCallbacks`.

## Secrets

`env`/`headers` values are read only to build the outgoing `config` payload — never logged, never placed in a URL. Validation error messages reference only key names, never values. The form clears itself (including these fields) on success, so nothing typed is rendered back after submit.

## Mobile

Deferred to #7021. The existing mobile MCP surface (`SettingsBar.tsx`'s "MCP Servers (N)" section) is a compact toggle list with no form primitive to extend — porting this multi-field form (transport radio, dynamic key-value editors, scope-confirm) in the same PR risked a cramped, fragile implementation rather than a clean lift.

## How to reach the UI for a visual check

1. Connect the dashboard to a daemon running the `claude-byok` provider (the only lane with an in-daemon MCP fleet — other providers get `MCP_CONFIG_UNSUPPORTED` on submit).
2. Open the sidebar's **MCP** panel tab (next to Tokens).
3. Click **"+ Add server"** — fill in a name (e.g. `test-fs`), leave transport on "Local command (stdio)", enter a command (e.g. `npx`), submit. The row appears once the daemon's `mcp_servers` broadcast confirms it (no phantom "success" toast). The daemon will separately prompt to trust the spawn on first use.
4. Click **"Remove"** on any row, pick a scope, confirm.
5. To see the primary-token refusal: connect with a paired/pairing token (not the primary API token) and attempt either action — the form/button disables with the explanation after the first refusal.

## Test plan

- [x] `cd packages/dashboard && npx vitest run` — full suite, 287 files / 4953 tests, all green.
- [x] `cd packages/dashboard && npx tsc --noEmit` — clean.
- [x] `bash scripts/lint-no-raw-color-literals.sh` — clean (token-only CSS in the new files).
- [x] `bash scripts/lint-undefined-css-vars.sh` — clean.
- [x] New/changed test files specifically: `AddMcpServerForm.test.tsx` (24 tests — validation, non-primary refusal, success/failure/timeout resolution, no secret echo), `SidebarMcpView.test.tsx` (+8 tests — remove flow), `mcp-server-validation.test.ts` (21 tests), `message-handler.test.ts` (+17 tests — op-tracking registry, broadcast/error/timeout/disconnect resolution, sticky forbidden flag).
- [x] Confirmed no protocol changes were needed — the contract from #6974/#6998 is consumed as-is.