### PR TITLE
fix(server): settle a driven turn on `stopped` instead of waiting out the turn timeout

### DIFF
--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -9,27 +9,51 @@
  *   so at most one driven turn runs per session (committee reviews serialize on
  *   the architect session).
  * - Epoch guard: events that arrive before our send, or a stray `result` with
- *   no active turn, are ignored.
+ *   no active turn, are ignored. That guard only protects a QUEUED turn because
+ *   the mutex handoff is deferred past the end of the current synchronous frame —
+ *   see _scheduleNext.
  * - Text is accumulated live from `stream_delta` (per messageId) + non-streamed
  *   `message {type:'response'}` events, bounded to MAX_ACCUM_BYTES with an
  *   explicit truncation marker (the decision parser scans from the tail).
  * - SUCCESS keys ONLY off the `result` event (isRunning can stay true on
  *   pending background shells). `error` is turn-terminal → TurnError.
- * - `stopped` is turn-terminal too → TURN_STOPPED (#7009). Every provider emits
- *   it exclusively on its intentional-stop path (`wasIntentionalStop`: see
- *   sdk-session.js, cli-session.js, jsonl-subprocess-session.js,
- *   codex-app-server-session.js — #4881), i.e. someone called interrupt(). Such a
- *   turn produces NO `result` and NO `error`, so without this the caller's promise
- *   hung until the watchdog fired. It gets its OWN code, never a success: an
- *   interrupted turn did not do the work it was asked to do.
- *   CAVEAT: this only helps providers that emit `stopped` INSTEAD of a result.
- *   CliSession's intentional-stop close emits a synthetic `result` (cost:null, to
- *   clear the dashboard's spinner) BEFORE `stopped`, so a claude-cli turn would
- *   settle as a success on that synthetic result and never reach this case.
- *   claude-cli is not reachable through either TurnDriver consumer today (the
- *   scheduler requires capabilities.inProcessPermissions; orchestration workers
- *   are restricted to claude-sdk/claude-byok/codex), but an orchestration
- *   ARCHITECT role is not provider-restricted — tracked separately.
+ * - `stopped` is turn-terminal too → TURN_STOPPED (#7009). Every provider that
+ *   emits `stopped` does so ONLY on its intentional-stop path (`wasIntentionalStop`:
+ *   see sdk-session.js, cli-session.js, jsonl-subprocess-session.js,
+ *   codex-app-server-session.js — #4881), i.e. someone called interrupt();
+ *   claude-tui and claude-byok never emit it at all. Such a turn produces NO
+ *   `result` and NO `error`, so without this the caller's promise hung until the
+ *   watchdog fired. It gets its OWN code, never a success: an interrupted turn did
+ *   not do the work it was asked to do.
+ *   This settle deliberately does NOT drain, unlike the timeout path: `stopped` is
+ *   the very event _endDrain keys off, so draining on it would always burn the full
+ *   drainTimeoutMs. Trailing events are handled by dropping the ctx from `_active`
+ *   at once and deferring the handoff instead (next bullet).
+ * - Mutex handoff crosses a tick. A queued turn is NEVER started from inside a
+ *   session-event callback (_scheduleNext). Providers emit a turn's terminal
+ *   events from ONE synchronous frame — CliSession._handleChildClose emits
+ *   `stream_end` + a synthetic `result` and THEN `stopped`; _handleHardTimeout /
+ *   _handleStreamStall emit `result` then `error`; jsonl-subprocess's child-close
+ *   and codex's _failTurn are the same shape — so starting the queued turn
+ *   synchronously on the FIRST of them handed the rest of that frame to the wrong
+ *   turn: the epoch guard could not drop those events because a fresh live ctx was
+ *   already registered. That is #6723's cross-turn misattribution through the door
+ *   the post-timeout drain does not cover (it is the result/error/stopped path that
+ *   releases the mutex, not the timeout path).
+ *   RESIDUAL: `stopped` carries no turn id, so a provider that emitted a turn's
+ *   terminal event and THEN `stopped` in a LATER macrotask would still settle the
+ *   following turn. No in-tree provider does that (every emit site listed above is
+ *   a single synchronous frame); closing it by construction needs a provider-side
+ *   turn id on the event payload.
+ * - NOT closed here (#7036): CliSession's synthetic interrupted `result`
+ *   (cost:null, load-bearing for clearing the dashboard spinner) is emitted BEFORE
+ *   `stopped`, so a claude-cli turn settles as a SUCCESS on it and never reaches
+ *   the `stopped` case. The trailing `stopped` no longer harms the next queued turn,
+ *   but the interrupted turn itself is still reported as completed. claude-cli is
+ *   unreachable through the scheduler (requires capabilities.inProcessPermissions)
+ *   and through the orchestration WORKER roles (AUDIT/IMPLEMENT_ELIGIBLE_PROVIDERS
+ *   = claude-sdk/claude-byok/codex); the orchestration ARCHITECT role is not
+ *   provider-restricted, which is what #7036 closes.
  * - Watchdog: on timeout, interrupt() the session and reject TURN_TIMEOUT.
  * - `session_destroyed` mid-turn → SESSION_GONE.
  */
@@ -68,6 +92,7 @@ export class TurnDriver {
     this._active = new Map() // sessionId -> active turn context
     this._occupied = new Set() // sessionId -> has a turn running or reserved
     this._waiters = new Map() // sessionId -> FIFO array of { start, reject }
+    this._handoff = new Set() // sessionId -> a deferred _startNext is already queued
     this._onSessionEvent = this._handleSessionEvent.bind(this)
     this._onSessionDestroyed = this._handleSessionDestroyed.bind(this)
     this._sm.on('session_event', this._onSessionEvent)
@@ -86,6 +111,7 @@ export class TurnDriver {
     this._waiters.clear()
     this._active.clear()
     this._occupied.clear()
+    this._handoff.clear()
     for (const w of waiters) {
       try { w.reject(new TurnError('SESSION_GONE', 'TurnDriver disposed')) } catch { /* ignore */ }
     }
@@ -100,10 +126,11 @@ export class TurnDriver {
 
   /**
    * Drive one turn: send `prompt`, accumulate output, resolve on `result`.
-   * The turn's context is registered SYNCHRONOUSLY when the per-session mutex is
-   * free, so no event can arrive before the accumulator exists (a fast provider
-   * can emit before the returned promise is even awaited). Contended turns queue
-   * FIFO and start synchronously when the prior turn releases.
+   * The turn's context is registered SYNCHRONOUSLY with its send, so no event can
+   * arrive before the accumulator exists (a fast provider can emit before the
+   * returned promise is even awaited). Contended turns queue FIFO and start on the
+   * tick after the prior turn releases — never inside the frame that released it
+   * (_scheduleNext).
    * @returns {Promise<{ text: string, result: { cost, duration, usage, modelUsage, model, numTurns, apiDurationMs } }>}
    * @throws {TurnError}
    */
@@ -131,7 +158,7 @@ export class TurnDriver {
     const entry = this._sm.getSession?.(sessionId)
     if (!entry || !entry.session) {
       reject(new TurnError('SESSION_GONE', `session ${sessionId} gone before its turn started`))
-      this._startNext(sessionId)
+      this._scheduleNext(sessionId)
       return
     }
     const ctx = {
@@ -173,6 +200,31 @@ export class TurnDriver {
     } catch (err) {
       this._finishTurn(ctx, () => ctx.reject(new TurnError('SEND_FAILED', (err && err.message) || 'sendMessage threw', { partialText: ctx.text() })))
     }
+  }
+
+  /**
+   * Hand the per-session mutex to the next queued turn — but never from inside the
+   * frame that released it. A provider emits a turn's terminal events (`stream_end`
+   * + a synthetic `result` + `stopped`, or `result` + `error`) from ONE synchronous
+   * frame; starting the queued turn on the first of them registered a live ctx that
+   * the REST of the frame then landed on, which is how a finished turn's trailing
+   * `stopped` came to reject the next turn (#7033 review). Deferring to
+   * process.nextTick puts the ctx removal in _finishTurn and the next ctx's
+   * registration on opposite sides of the frame boundary, so the epoch guard in
+   * _handleSessionEvent drops those trailing events instead of misattributing them.
+   *
+   * `_occupied` stays set across the gap, so a driveTurn() landing inside it queues
+   * rather than racing ahead. At most ONE handoff may be pending per session: two
+   * would each shift a waiter off the FIFO and start it, breaking the mutex.
+   */
+  _scheduleNext(sessionId) {
+    if (this._handoff.has(sessionId)) return
+    this._handoff.add(sessionId)
+    process.nextTick(() => {
+      this._handoff.delete(sessionId)
+      if (this._disposed) return
+      this._startNext(sessionId)
+    })
   }
 
   _startNext(sessionId) {
@@ -247,6 +299,13 @@ export class TurnDriver {
         // is over but its work did not complete, and resolving here would report
         // an interrupted turn as a finished one. partialText carries whatever the
         // turn managed to produce so the caller can still inspect it.
+        //
+        // This can only be THIS turn's `stopped`: a `stopped` trailing a turn that
+        // already settled arrives in the same synchronous frame as that settle, and
+        // the queued turn is not started until the next tick (_scheduleNext), so it
+        // hits the epoch guard with no active ctx. No drain here — `stopped` is the
+        // event _endDrain waits for, so draining on it would burn drainTimeoutMs
+        // every time.
         this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_STOPPED', 'turn interrupted before completing', { partialText: this._assembleText(ctx) })))
         break
       }
@@ -309,8 +368,10 @@ export class TurnDriver {
       ctx.drainTimer = setTimeout(() => this._endDrain(ctx), this._drainTimeoutMs)
       if (typeof ctx.drainTimer.unref === 'function') ctx.drainTimer.unref()
     } else {
+      // Drop the ctx NOW so every remaining event in this frame hits the epoch
+      // guard, and hand the mutex over on the next tick (see _scheduleNext).
       this._active.delete(ctx.sessionId)
-      this._startNext(ctx.sessionId)
+      this._scheduleNext(ctx.sessionId)
     }
   }
 
@@ -318,7 +379,7 @@ export class TurnDriver {
     if (ctx.drainTimer) { clearTimeout(ctx.drainTimer); ctx.drainTimer = null }
     if (this._active.get(ctx.sessionId) === ctx) {
       this._active.delete(ctx.sessionId)
-      this._startNext(ctx.sessionId)
+      this._scheduleNext(ctx.sessionId)
     }
   }
 }

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -13,8 +13,23 @@
  * - Text is accumulated live from `stream_delta` (per messageId) + non-streamed
  *   `message {type:'response'}` events, bounded to MAX_ACCUM_BYTES with an
  *   explicit truncation marker (the decision parser scans from the tail).
- * - Completion keys ONLY off the `result` event (isRunning can stay true on
+ * - SUCCESS keys ONLY off the `result` event (isRunning can stay true on
  *   pending background shells). `error` is turn-terminal → TurnError.
+ * - `stopped` is turn-terminal too → TURN_STOPPED (#7009). Every provider emits
+ *   it exclusively on its intentional-stop path (`wasIntentionalStop`: see
+ *   sdk-session.js, cli-session.js, jsonl-subprocess-session.js,
+ *   codex-app-server-session.js — #4881), i.e. someone called interrupt(). Such a
+ *   turn produces NO `result` and NO `error`, so without this the caller's promise
+ *   hung until the watchdog fired. It gets its OWN code, never a success: an
+ *   interrupted turn did not do the work it was asked to do.
+ *   CAVEAT: this only helps providers that emit `stopped` INSTEAD of a result.
+ *   CliSession's intentional-stop close emits a synthetic `result` (cost:null, to
+ *   clear the dashboard's spinner) BEFORE `stopped`, so a claude-cli turn would
+ *   settle as a success on that synthetic result and never reach this case.
+ *   claude-cli is not reachable through either TurnDriver consumer today (the
+ *   scheduler requires capabilities.inProcessPermissions; orchestration workers
+ *   are restricted to claude-sdk/claude-byok/codex), but an orchestration
+ *   ARCHITECT role is not provider-restricted — tracked separately.
  * - Watchdog: on timeout, interrupt() the session and reject TURN_TIMEOUT.
  * - `session_destroyed` mid-turn → SESSION_GONE.
  */
@@ -32,7 +47,7 @@ export class TurnError extends Error {
   constructor(code, message, { partialText = '' } = {}) {
     super(message || code)
     this.name = 'TurnError'
-    this.code = code // TURN_ERROR | TURN_TIMEOUT | SESSION_GONE | SEND_FAILED
+    this.code = code // TURN_ERROR | TURN_TIMEOUT | TURN_STOPPED | SESSION_GONE | SEND_FAILED
     this.partialText = partialText
   }
 }
@@ -219,6 +234,20 @@ export class TurnDriver {
       }
       case 'error': {
         this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_ERROR', (data && data.message) || 'session error', { partialText: this._assembleText(ctx) })))
+        break
+      }
+      case 'stopped': {
+        // #7009 — someone interrupted this turn (the scheduler denying a
+        // permission prompt, an operator pressing Stop, an orchestration cancel).
+        // Providers emit `stopped` INSTEAD of `result`/`error` on that path
+        // (#4881), so ignoring it left driveTurn pending until the watchdog —
+        // 15 minutes of a held concurrency slot in the scheduler.
+        //
+        // Deliberately a REJECTION with its own code, never a resolve: the turn
+        // is over but its work did not complete, and resolving here would report
+        // an interrupted turn as a finished one. partialText carries whatever the
+        // turn managed to produce so the caller can still inspect it.
+        this._finishTurn(ctx, () => ctx.reject(new TurnError('TURN_STOPPED', 'turn interrupted before completing', { partialText: this._assembleText(ctx) })))
         break
       }
       default:

--- a/packages/server/src/scheduler.js
+++ b/packages/server/src/scheduler.js
@@ -44,11 +44,10 @@
 //    `deny` through the same door a human clicks (`session.respondToPermission`,
 //    mirroring orchestration/permission-gate.js), interrupts the turn, and
 //    records the run as a VISIBLE failure. The prompt is answered at once (never
-//    left to sit out a permission timeout) and nothing is ever auto-approved.
-//    Note the interrupted turn's PROMISE may still not settle until the run
-//    timeout — TurnDriver does not treat `stopped` as terminal (#7009) — so the
-//    concurrency slot can be held for that window. The outcome is decided
-//    immediately either way; see _handleSessionEvent.
+//    left to sit out a permission timeout), the interrupted turn settles at once
+//    (TurnDriver treats the provider's `stopped` as terminal → TURN_STOPPED,
+//    #7009) so the concurrency slot frees immediately, and nothing is ever
+//    auto-approved. See _handleSessionEvent.
 // 4. SUPPORTED PROVIDERS ONLY — the engine REFUSES what it cannot govern. The
 //    deny mechanism in (3) rides `session_event: permission_request` +
 //    `session.respondToPermission`, which exist ONLY on providers whose
@@ -913,16 +912,13 @@ export class SchedulerEngine extends EventEmitter {
    * immediately (never left to sit out a permission timeout) and the run's outcome
    * is decided immediately (a visible failure, never an auto-approval).
    *
-   * CAVEAT on how fast the SLOT frees (#7009): deciding the outcome is not the
-   * same as settling the driving promise. TurnDriver only treats `result` /
-   * `error` / `session_destroyed` as terminal for a live turn, while SdkSession's
-   * interrupt path emits `stopped` (sdk-session.js ~1204, #4881) — which
-   * TurnDriver ignores outside its post-timeout drain. So `driveTurn` can stay
-   * pending until `runTimeoutMs` even though we already know the answer, holding
-   * the concurrency slot. The recorded outcome is unaffected (blocked ⇒ failure,
-   * never success); it is a liveness cost only. Fixing it means making `stopped`
-   * terminal in TurnDriver, which touches the shared orchestration harness and so
-   * is tracked separately as #7009 rather than done here.
+   * The SLOT frees immediately too (#7009): SdkSession's interrupt path emits
+   * `stopped` rather than a result/error (sdk-session.js, #4881), and TurnDriver
+   * treats that as terminal → `driveTurn` rejects TURN_STOPPED right away instead
+   * of sitting out `runTimeoutMs`. The recorded outcome does not depend on which
+   * way the turn settled: `runState.blocked` is already set, so _runViaSessionManager
+   * reports the blocked failure whether the promise rejects or (on a provider that
+   * lets the turn finish with the tool call refused) resolves. Never `success`.
    */
   _handleSessionEvent({ sessionId, event, data } = {}) {
     if (event !== 'permission_request') return

--- a/packages/server/tests/orchestration-turn-driver.test.js
+++ b/packages/server/tests/orchestration-turn-driver.test.js
@@ -211,6 +211,97 @@ describe('TurnDriver — failure modes', () => {
   })
 })
 
+describe('TurnDriver — interrupt (`stopped`) is terminal (#7009)', () => {
+  // Race the turn's own settlement against a short wall-clock timer. `kind` is
+  // 'pending' ONLY if the driver left the promise hanging.
+  const settleOrPending = (p, ms = 100) => Promise.race([
+    p.then((value) => ({ kind: 'resolved', value }), (err) => ({ kind: 'rejected', err })),
+    new Promise((r) => setTimeout(() => r({ kind: 'pending' }), ms)),
+  ])
+
+  it('rejects TURN_STOPPED promptly on interrupt instead of waiting out timeoutMs', async () => {
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    // A LONG turn timeout: if `stopped` is not terminal for a live turn, this
+    // promise stays pending for the whole window (#7009 — 15 min in the
+    // scheduler), and the race below reports 'pending'.
+    const p = driver.driveTurn('s1', 'go', { timeoutMs: 60_000 })
+    p.catch(() => {}) // never leave the rejection unhandled while we race it
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'half a thought' })
+    // SdkSession.interrupt() emits `stopped` — deliberately NOT `result` and NOT
+    // `error` (sdk-session.js, #4881). Same for CliSession/JsonlSubprocessSession
+    // and the Codex app-server driver: every `stopped` emit is gated on
+    // wasIntentionalStop, so `stopped` always means "the user/engine stopped it".
+    sm.ev('s1', 'stopped', {})
+    const outcome = await settleOrPending(p)
+    assert.notEqual(outcome.kind, 'pending', 'an interrupted turn must settle promptly, not wait out timeoutMs')
+    // The success/interrupt distinction: an interrupted turn must NEVER look like
+    // a completed one to the caller.
+    assert.notEqual(outcome.kind, 'resolved', 'an interrupted turn must never report a completed turn')
+    assert.ok(outcome.err instanceof TurnError)
+    assert.equal(outcome.err.code, 'TURN_STOPPED', 'interrupt gets its OWN code, distinct from TURN_TIMEOUT/TURN_ERROR')
+    assert.equal(outcome.err.partialText, 'half a thought', 'partial output is preserved for the caller')
+  })
+
+  it('releases the mutex on a stopped turn so the next queued turn starts', async () => {
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first', { timeoutMs: 60_000 })
+    p1.catch(() => {})
+    const p2 = driver.driveTurn('s1', 'second', { timeoutMs: 60_000 })
+    assert.equal(s.sent.length, 1)
+    sm.ev('s1', 'stopped', {})
+    const o1 = await settleOrPending(p1)
+    assert.equal(o1.kind, 'rejected')
+    assert.equal(o1.err.code, 'TURN_STOPPED')
+    // the concurrency slot is free again — turn-2 sent without waiting on a drain
+    assert.equal(s.sent.length, 2, 'stopped turn released the per-session mutex')
+    assert.equal(s.sent[1].prompt, 'second')
+    sm.ev('s1', 'result', { cost: 3, duration: 3, usage: {} })
+    const o2 = await settleOrPending(p2)
+    assert.equal(o2.kind, 'resolved', 'the follow-up turn still completes normally')
+    assert.equal(o2.value.result.cost, 3)
+  })
+
+  it('a completed turn still resolves success even if a trailing `stopped` arrives', async () => {
+    // The inverse guard: making `stopped` terminal must not downgrade a turn that
+    // genuinely finished. `result` settles first; the late `stopped` is dropped by
+    // the epoch guard.
+    const { sm, addSession } = mkStub()
+    addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p = driver.driveTurn('s1', 'go', { timeoutMs: 60_000 })
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'all done' })
+    sm.ev('s1', 'result', { cost: 0.5, duration: 4, usage: { input_tokens: 1 } })
+    sm.ev('s1', 'stopped', {})
+    const outcome = await settleOrPending(p)
+    assert.equal(outcome.kind, 'resolved', 'a genuinely completed turn reports success')
+    assert.equal(outcome.value.text, 'all done')
+    assert.equal(outcome.value.result.cost, 0.5)
+  })
+
+  it('`stopped` during the post-timeout drain still only ends the drain', async () => {
+    // Regression guard on the pre-existing drain path: a timed-out turn is already
+    // settled as TURN_TIMEOUT, and its trailing `stopped` must not be re-settled
+    // as TURN_STOPPED — it just releases the mutex.
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first', { timeoutMs: 10 })
+    const p2 = driver.driveTurn('s1', 'second', { timeoutMs: 60_000 })
+    p2.catch(() => {})
+    const o1 = await settleOrPending(p1, 500)
+    assert.equal(o1.kind, 'rejected')
+    assert.equal(o1.err.code, 'TURN_TIMEOUT', 'timeout keeps its own code, not TURN_STOPPED')
+    assert.equal(s.interrupted, 1)
+    sm.ev('s1', 'stopped', {}) // the interrupted session confirming it stopped
+    await Promise.resolve()
+    assert.equal(s.sent.length, 2, 'trailing stopped ended the drain and released the mutex')
+  })
+})
+
 describe('TurnDriver — post-timeout drain (no cross-turn misattribution)', () => {
   it('swallows a timed-out turn\'s trailing events; the next turn keeps its own', async () => {
     const { sm, addSession } = mkStub()

--- a/packages/server/tests/orchestration-turn-driver.test.js
+++ b/packages/server/tests/orchestration-turn-driver.test.js
@@ -33,6 +33,18 @@ function mkStub() {
 let driver
 afterEach(() => { driver?.dispose(); driver = null })
 
+// Race a turn's own settlement against a short wall-clock timer. `kind` is
+// 'pending' ONLY if the driver left the promise hanging.
+const settleOrPending = (p, ms = 100) => Promise.race([
+  p.then((value) => ({ kind: 'resolved', value }), (err) => ({ kind: 'rejected', err })),
+  new Promise((r) => setTimeout(() => r({ kind: 'pending' }), ms)),
+])
+
+// Let the event loop turn over once: the driver hands the per-session mutex to a
+// queued turn across a process.nextTick boundary (see _scheduleNext), so a test
+// that inspects "did the next turn start?" must yield first.
+const flush = () => new Promise((r) => setImmediate(r))
+
 describe('TurnDriver — happy path', () => {
   it('accumulates streamed deltas and resolves on result', async () => {
     const { sm, addSession } = mkStub()
@@ -124,8 +136,9 @@ describe('TurnDriver — epoch guard + mutex', () => {
     sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'A' })
     sm.ev('s1', 'result', { cost: 0, duration: 0, usage: {} })
     assert.equal((await p1).text, 'A')
-    // now the second turn runs
-    await Promise.resolve()
+    // now the second turn runs (one tick later — the handoff never happens inside
+    // the frame that released the mutex; see _scheduleNext)
+    await flush()
     assert.equal(s.sent.length, 2)
     assert.equal(s.sent[1].prompt, 'second')
     sm.ev('s1', 'stream_delta', { messageId: 'm2', delta: 'B' })
@@ -212,13 +225,6 @@ describe('TurnDriver — failure modes', () => {
 })
 
 describe('TurnDriver — interrupt (`stopped`) is terminal (#7009)', () => {
-  // Race the turn's own settlement against a short wall-clock timer. `kind` is
-  // 'pending' ONLY if the driver left the promise hanging.
-  const settleOrPending = (p, ms = 100) => Promise.race([
-    p.then((value) => ({ kind: 'resolved', value }), (err) => ({ kind: 'rejected', err })),
-    new Promise((r) => setTimeout(() => r({ kind: 'pending' }), ms)),
-  ])
-
   it('rejects TURN_STOPPED promptly on interrupt instead of waiting out timeoutMs', async () => {
     const { sm, addSession } = mkStub()
     addSession('s1')
@@ -257,6 +263,7 @@ describe('TurnDriver — interrupt (`stopped`) is terminal (#7009)', () => {
     assert.equal(o1.kind, 'rejected')
     assert.equal(o1.err.code, 'TURN_STOPPED')
     // the concurrency slot is free again — turn-2 sent without waiting on a drain
+    await flush()
     assert.equal(s.sent.length, 2, 'stopped turn released the per-session mutex')
     assert.equal(s.sent[1].prompt, 'second')
     sm.ev('s1', 'result', { cost: 3, duration: 3, usage: {} })
@@ -265,10 +272,12 @@ describe('TurnDriver — interrupt (`stopped`) is terminal (#7009)', () => {
     assert.equal(o2.value.result.cost, 3)
   })
 
-  it('a completed turn still resolves success even if a trailing `stopped` arrives', async () => {
+  it('a completed turn still resolves success even if a trailing `stopped` arrives (nothing queued)', async () => {
     // The inverse guard: making `stopped` terminal must not downgrade a turn that
     // genuinely finished. `result` settles first; the late `stopped` is dropped by
-    // the epoch guard.
+    // the epoch guard. NOTE: this is the NO-QUEUED-TURN variant — the queued-turn
+    // variant, where the epoch guard only holds because the mutex handoff is
+    // deferred, is covered in its own describe block below.
     const { sm, addSession } = mkStub()
     addSession('s1')
     driver = new TurnDriver({ sessionManager: sm })
@@ -297,8 +306,140 @@ describe('TurnDriver — interrupt (`stopped`) is terminal (#7009)', () => {
     assert.equal(o1.err.code, 'TURN_TIMEOUT', 'timeout keeps its own code, not TURN_STOPPED')
     assert.equal(s.interrupted, 1)
     sm.ev('s1', 'stopped', {}) // the interrupted session confirming it stopped
-    await Promise.resolve()
+    await flush()
     assert.equal(s.sent.length, 2, 'trailing stopped ended the drain and released the mutex')
+  })
+})
+
+describe('TurnDriver — a settled turn\'s trailing events never reach the QUEUED turn', () => {
+  // The #6723 cross-turn-misattribution class, through the door the post-timeout
+  // drain does not cover: it is the `result`/`error`/`stopped` path that releases
+  // the mutex. Every provider emits a turn's terminal events from ONE synchronous
+  // frame, so starting the queued turn synchronously on the first of them handed
+  // the REST of that frame to the wrong turn.
+
+  it('a trailing `stopped` after a real `result` does not settle the next queued turn', async () => {
+    // Replays CliSession._handleChildClose's real emit order on an intentional
+    // stop (cli-session.js ~1646/1654): _emitInterruptedTurnResult() emits
+    // `stream_end` + a synthetic `result`, THEN emit('stopped', { code }) — all in
+    // one synchronous frame. With the handoff running inside that frame, turn-2's
+    // prompt was already sent and the trailing `stopped` then rejected it
+    // TURN_STOPPED, abandoning a turn the provider is actively working on.
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first', { timeoutMs: 60_000 })
+    const p2 = driver.driveTurn('s1', 'second', { timeoutMs: 60_000 })
+    p1.catch(() => {})
+    p2.catch(() => {})
+    assert.equal(s.sent.length, 1, 'turn-2 starts queued behind the mutex')
+
+    sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'turn-1 output' })
+    sm.ev('s1', 'stream_end', { messageId: 'm1' })
+    sm.ev('s1', 'result', { cost: 0.5, duration: 4, usage: { input_tokens: 1 } })
+    sm.ev('s1', 'stopped', { code: 130 })
+
+    // turn-1 completed — assert that POSITIVELY (resolved + its own payload),
+    // never by absence of an error.
+    const o1 = await settleOrPending(p1)
+    assert.equal(o1.kind, 'resolved', 'turn-1 finished on its own result')
+    assert.equal(o1.value.text, 'turn-1 output')
+    assert.equal(o1.value.result.cost, 0.5)
+
+    // turn-2 must be neither settled nor abandoned by turn-1's trailing stop.
+    await flush()
+    assert.equal(s.sent.length, 2, 'turn-2 got its prompt')
+    assert.equal(s.sent[1].prompt, 'second')
+    const early = await settleOrPending(p2, 50)
+    assert.equal(early.kind, 'pending', 'a previous turn\'s `stopped` must not settle turn-2')
+
+    sm.ev('s1', 'stream_delta', { messageId: 'm2', delta: 'turn-2 output' })
+    sm.ev('s1', 'result', { cost: 2, duration: 2, usage: {} })
+    const o2 = await settleOrPending(p2)
+    assert.equal(o2.kind, 'resolved', 'turn-2 ran to completion')
+    assert.equal(o2.value.text, 'turn-2 output', 'turn-2 kept its own output')
+    assert.equal(o2.value.result.cost, 2, 'turn-2 kept its own result payload')
+  })
+
+  it('a trailing `error` after a synthetic `result` does not settle the next queued turn', async () => {
+    // Same frame shape, different tail: CliSession._handleHardTimeout and
+    // _handleStreamStall both call _emitInterruptedTurnResult() (→ `stream_end` +
+    // `result`) and THEN emit('error', …) synchronously (cli-session.js ~877/894).
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first', { timeoutMs: 60_000 })
+    const p2 = driver.driveTurn('s1', 'second', { timeoutMs: 60_000 })
+    p1.catch(() => {})
+    p2.catch(() => {})
+
+    sm.ev('s1', 'stream_end', { messageId: 'm1' })
+    sm.ev('s1', 'result', { cost: null, duration: 0, usage: null })
+    sm.ev('s1', 'error', { message: 'Response timed out after 15m' })
+
+    const o1 = await settleOrPending(p1)
+    assert.equal(o1.kind, 'resolved', 'turn-1 settled on the result that arrived first')
+    await flush()
+    assert.equal(s.sent.length, 2, 'turn-2 got its prompt')
+    const early = await settleOrPending(p2, 50)
+    assert.equal(early.kind, 'pending', 'a previous turn\'s `error` must not fail turn-2')
+
+    sm.ev('s1', 'result', { cost: 1, duration: 1, usage: {} })
+    const o2 = await settleOrPending(p2)
+    assert.equal(o2.kind, 'resolved', 'turn-2 settles only on its OWN result')
+    assert.equal(o2.value.result.cost, 1)
+  })
+
+  it('turn-1\'s late trailing events cannot settle turn-2 (duplicate `stopped` + late `result`)', async () => {
+    // turn-1 is genuinely interrupted, so `stopped` settles it. Anything the
+    // provider still emits in that frame belongs to turn-1: a duplicate `stopped`
+    // must not reject turn-2, and a late `result` must not resolve turn-2 as a
+    // success carrying turn-1's payload.
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const p1 = driver.driveTurn('s1', 'first', { timeoutMs: 60_000 })
+    const p2 = driver.driveTurn('s1', 'second', { timeoutMs: 60_000 })
+    p1.catch(() => {})
+    p2.catch(() => {})
+
+    sm.ev('s1', 'stopped', {})
+    sm.ev('s1', 'stopped', {})
+    sm.ev('s1', 'result', { cost: 99, duration: 99, usage: { input_tokens: 999 } })
+
+    const o1 = await settleOrPending(p1)
+    assert.equal(o1.kind, 'rejected')
+    assert.equal(o1.err.code, 'TURN_STOPPED', 'turn-1 kept the interrupt outcome')
+    await flush()
+    assert.equal(s.sent.length, 2, 'turn-2 got its prompt')
+    const early = await settleOrPending(p2, 50)
+    assert.equal(early.kind, 'pending', 'turn-1\'s trailing events must not settle turn-2')
+
+    sm.ev('s1', 'result', { cost: 7, duration: 7, usage: {} })
+    const o2 = await settleOrPending(p2)
+    assert.equal(o2.kind, 'resolved', 'turn-2 settles only on its OWN result')
+    assert.equal(o2.value.result.cost, 7, 'turn-2 did not absorb turn-1\'s result payload')
+  })
+
+  it('a third turn queued behind two still runs (one handoff per release)', async () => {
+    // Guard on the deferred handoff itself: exactly ONE queued turn may be started
+    // per release. A double-scheduled handoff would shift two waiters off the FIFO
+    // and run them concurrently, breaking the per-session mutex.
+    const { sm, addSession } = mkStub()
+    const s = addSession('s1')
+    driver = new TurnDriver({ sessionManager: sm })
+    const ps = ['a', 'b', 'c'].map((n) => driver.driveTurn('s1', n, { timeoutMs: 60_000 }))
+    for (const p of ps) p.catch(() => {})
+    assert.equal(s.sent.length, 1)
+    for (const [i, prompt] of ['a', 'b', 'c'].entries()) {
+      await flush()
+      assert.equal(s.sent.length, i + 1, `only turn ${prompt} is in flight`)
+      assert.equal(s.sent[i].prompt, prompt)
+      sm.ev('s1', 'result', { cost: i, duration: 1, usage: {} })
+      const o = await settleOrPending(ps[i])
+      assert.equal(o.kind, 'resolved', `turn ${prompt} completed`)
+      assert.equal(o.value.result.cost, i)
+    }
   })
 })
 
@@ -316,7 +457,7 @@ describe('TurnDriver — post-timeout drain (no cross-turn misattribution)', () 
     sm.ev('s1', 'stream_delta', { messageId: 'm1', delta: 'STALE-from-turn-1' })
     sm.ev('s1', 'result', { cost: 99, duration: 99, usage: { input_tokens: 999 } }) // ends the drain
     // now turn-2 runs and gets ITS output
-    await Promise.resolve()
+    await flush()
     sm.ev('s1', 'stream_delta', { messageId: 'm2', delta: 'fresh-turn-2' })
     sm.ev('s1', 'result', { cost: 2, duration: 2, usage: { input_tokens: 2 } })
     const r2 = await p2

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -838,6 +838,69 @@ describe('#6865 SchedulerEngine', () => {
     })
   })
 
+  // ── #7009: a denied permission frees the concurrency slot IMMEDIATELY ───────
+
+  describe('interrupted turn settles promptly (#7009)', () => {
+    it('a denied permission finishes the run at once instead of burning runTimeoutMs', async () => {
+      // The real abort surface: interrupt() emits `stopped`, never a result/error.
+      // Before TurnDriver treated `stopped` as terminal, driveTurn stayed pending
+      // for the whole runTimeoutMs window (15 min in production), holding the
+      // single concurrency slot even though the outcome was already decided.
+      const sm = new FakeSessionManager({
+        permissionRequest: { requestId: 'req-1', toolName: 'Bash' },
+        interruptEmitsStopped: true,
+      })
+      const task = addTask({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
+      // A real-timer watchdog well above the wall-clock budget asserted below.
+      const engine = newEngine({ sessionManager: sm, runTimeoutMs: 5_000 })
+      engine.start()
+
+      const startedAt = Date.now()
+      clock = 2000
+      await timers.tick()
+      const elapsedMs = Date.now() - startedAt
+
+      assert.deepEqual(sm.responded, [['req-1', 'deny']])
+      assert.equal(sm.interrupted.length, 1)
+      // THE liveness assertion: the outcome is already RECORDED. With `stopped`
+      // ignored, driveTurn is still pending here and lastRun stays null until the
+      // watchdog fires — the slot held for the whole window.
+      const record = store.get(task.id)
+      assert.ok(record.lastRun, 'the interrupted run must be recorded already, not left pending until runTimeoutMs')
+      assert.ok(elapsedMs < 2_000, `settling must not block on runTimeoutMs (took ${elapsedMs}ms of a 5000ms window)`)
+      // ...and the outcome is still the VISIBLE blocked failure. Settling faster
+      // must never turn an interrupted run into a completed one.
+      assert.notEqual(record.lastRun.status, 'success', 'an interrupted run must never report success')
+      assert.equal(record.lastRun.status, 'error')
+      assert.match(record.lastRun.error, /permission required for Bash/)
+      assert.equal(record.lastRun.sessionId, 'sess-1')
+    })
+
+    it('an operator Stop on a scheduled run is an error, never a success', async () => {
+      // No permission prompt at all — the turn is simply interrupted (what a Stop
+      // from the dashboard does). `runState.blocked` is unset here, so the outcome
+      // rides entirely on TurnDriver's TURN_STOPPED rejection. If `stopped` were
+      // treated as a normal completion this would read as `success`.
+      const sm = new FakeSessionManager({ interruptEmitsStopped: true, stopAfterSend: true })
+      const task = addTask({ prompt: 'long job', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm, runTimeoutMs: 5_000 })
+      engine.start()
+
+      const startedAt = Date.now()
+      clock = 2000
+      await timers.tick()
+      const elapsedMs = Date.now() - startedAt
+
+      assert.equal(sm.interrupted.length, 1)
+      const record = store.get(task.id)
+      assert.ok(record.lastRun, 'the stopped run must be recorded already, not left pending until runTimeoutMs')
+      assert.ok(elapsedMs < 2_000, `settling must not block on runTimeoutMs (took ${elapsedMs}ms of a 5000ms window)`)
+      assert.notEqual(record.lastRun.status, 'success', 'a stopped run did not do the work — never success')
+      assert.equal(record.lastRun.status, 'error')
+      assert.match(record.lastRun.error, /interrupted/)
+    })
+  })
+
   // ── SECURITY C2: cwd confinement is enforced ON THIS PATH ──────────────────
   //
   // The store only trims the cwd string and createSession only statSync's it, so
@@ -1151,8 +1214,16 @@ class FakeSessionManager extends EventEmitter {
    * @param {boolean} [opts.refuseModeChange] - model a session that REJECTS setPermissionMode
    *   (what BaseSession does for a non-`auto` switch while a turn is in flight): the
    *   setter is a no-op and `permissionMode` keeps its old value.
+   * @param {boolean} [opts.interruptEmitsStopped] - model SdkSession's REAL interrupt
+   *   path (#4881/#7009): the turn is left live by sendMessage, and `interrupt()`
+   *   ends it with `stopped` — never a `result` and never an `error`. The default
+   *   fake instead completes every turn with a `result`, which cannot exercise the
+   *   interrupted-turn settle at all.
+   * @param {boolean} [opts.stopAfterSend] - model an OPERATOR Stop landing on a
+   *   scheduled turn: the session interrupts itself right after the send, with no
+   *   permission prompt involved.
    */
-  constructor({ permissionRequest = null, providerType = undefined, defaultCwd = undefined, refuseModeChange = false } = {}) {
+  constructor({ permissionRequest = null, providerType = undefined, defaultCwd = undefined, refuseModeChange = false, interruptEmitsStopped = false, stopAfterSend = false } = {}) {
     super()
     this.sessions = new Map()
     this.created = []
@@ -1163,6 +1234,8 @@ class FakeSessionManager extends EventEmitter {
     this.scheduledTaskStore = null
     this._permissionRequest = permissionRequest
     this._refuseModeChange = refuseModeChange
+    this._interruptEmitsStopped = interruptEmitsStopped
+    this._stopAfterSend = stopAfterSend
     this._seq = 0
     if (providerType !== undefined) this.providerType = providerType
     if (defaultCwd !== undefined) this.defaultCwd = defaultCwd
@@ -1185,7 +1258,13 @@ class FakeSessionManager extends EventEmitter {
         return true
       },
       respondToPermission: (requestId, decision) => { this.responded.push([requestId, decision]) },
-      interrupt: async () => { this.interrupted.push(id) },
+      interrupt: async () => {
+        this.interrupted.push(id)
+        // The real SDK abort surface: `stopped`, with no result and no error.
+        if (this._interruptEmitsStopped) {
+          this.emit('session_event', { sessionId: id, event: 'stopped', data: {} })
+        }
+      },
       sendMessage: async (prompt) => {
         this.sends.push({ id, prompt, permissionMode: session.permissionMode })
         // TurnDriver registers its accumulator synchronously before sendMessage,
@@ -1193,6 +1272,12 @@ class FakeSessionManager extends EventEmitter {
         if (this._permissionRequest) {
           this.emit('session_event', { sessionId: id, event: 'permission_request', data: this._permissionRequest })
         }
+        // Leave the turn LIVE when interrupt() is the thing that ends it — the
+        // synchronous permission_request above already triggered the deny +
+        // interrupt, so emitting a result here would settle a turn the engine has
+        // already aborted.
+        if (this._stopAfterSend) { session.interrupt(); return }
+        if (this._interruptEmitsStopped) return
         this.emit('session_event', { sessionId: id, event: 'result', data: { cost: 0, duration: 1 } })
       },
     }

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -867,6 +867,9 @@ describe('#6865 SchedulerEngine', () => {
       // watchdog fires — the slot held for the whole window.
       const record = store.get(task.id)
       assert.ok(record.lastRun, 'the interrupted run must be recorded already, not left pending until runTimeoutMs')
+      // Belt-and-braces only — `runTimeoutMs` rides the FAKE clock, so this
+      // wall-clock bound can never be what fails. `record.lastRun` above is the
+      // load-bearing assertion.
       assert.ok(elapsedMs < 2_000, `settling must not block on runTimeoutMs (took ${elapsedMs}ms of a 5000ms window)`)
       // ...and the outcome is still the VISIBLE blocked failure. Settling faster
       // must never turn an interrupted run into a completed one.
@@ -894,6 +897,7 @@ describe('#6865 SchedulerEngine', () => {
       assert.equal(sm.interrupted.length, 1)
       const record = store.get(task.id)
       assert.ok(record.lastRun, 'the stopped run must be recorded already, not left pending until runTimeoutMs')
+      // Belt-and-braces only (fake clock) — see the previous test.
       assert.ok(elapsedMs < 2_000, `settling must not block on runTimeoutMs (took ${elapsedMs}ms of a 5000ms window)`)
       assert.notEqual(record.lastRun.status, 'success', 'a stopped run did not do the work — never success')
       assert.equal(record.lastRun.status, 'error')
@@ -1276,7 +1280,7 @@ class FakeSessionManager extends EventEmitter {
         // synchronous permission_request above already triggered the deny +
         // interrupt, so emitting a result here would settle a turn the engine has
         // already aborted.
-        if (this._stopAfterSend) { session.interrupt(); return }
+        if (this._stopAfterSend) { await session.interrupt(); return }
         if (this._interruptEmitsStopped) return
         this.emit('session_event', { sessionId: id, event: 'result', data: { cost: 0, duration: 1 } })
       },


### PR DESCRIPTION
## The bug

`TurnDriver._handleSessionEvent` treated only `result`, `error` and
`session_destroyed` as terminal for a **live** turn. `stopped` was handled *only*
inside the `if (ctx.draining)` branch (the post-timeout drain).

But every provider that emits `stopped` does so **only** on its intentional-stop
path, and deliberately emits neither a `result` nor an `error` there (#4881, so a
user Stop doesn't render as a loud error):

- `sdk-session.js` — `wasIntentionalStop` → `this.emit('stopped', {})`
- `jsonl-subprocess-session.js`, `cli-session.js` — same, on the child's close
- `codex-app-server-session.js` — `_failTurn` → `if (wasIntentional) emit('stopped')`
- (`claude-tui` and `claude-byok` never emit it at all.)

So anything that called `session.interrupt()` on a turn TurnDriver was driving got
**no settle at all**. `driveTurn` stayed pending until TurnDriver's own watchdog
fired, at which point it interrupted again and rejected `TURN_TIMEOUT`.

The concrete cost: the scheduler engine (#6865) denies a permission prompt on an
unattended run and interrupts the turn, precisely so it fails fast. In practice the
run's single concurrency slot was then held for the remaining `runTimeoutMs` —
**15 minutes by default** — blocking every other scheduled task. The recorded
*outcome* was always correct (`runState.blocked` ⇒ a visible failure, never
`success`); this was a liveness bug.

## What changed

### 1. `stopped` is turn-terminal → `TURN_STOPPED`

`packages/server/src/orchestration/turn-driver.js`

- New `case 'stopped'` for a live turn → `_finishTurn` rejecting a **new
  `TURN_STOPPED`** `TurnError` with the accumulated `partialText`.
- **The success/interrupt distinction is preserved deliberately.** `stopped` gets
  its *own* code and is a **rejection**, never a resolve: the turn is genuinely
  over, but it did not do the work it was asked to do, so it must not be reported
  as a completed turn. Success still keys **only** off `result`.
- `stopped` during the post-timeout drain keeps its existing meaning (the
  interrupted session confirming it stopped → end the drain, release the mutex, no
  second settle).

### 2. The mutex handoff now crosses a tick — fixing the regression review found

The first revision claimed *"a late `stopped` after a real `result` is still dropped
by the epoch guard, so a completed turn cannot be downgraded."* **That only held
when no turn was queued**, and shipping it would have introduced a cross-turn
misattribution of the #6723 class:

`_finishTurn` on the `result` path does not drain, so it deleted the ctx and
`_startNext()` registered the **queued** turn's ctx *synchronously* — still inside
the provider's own emit frame. A trailing `stopped` in that frame then landed on the
**new live ctx** and rejected it `TURN_STOPPED`, abandoning a turn whose prompt had
already been sent to the provider.

That ordering is what `CliSession` actually emits on an intentional stop
(`_handleChildClose` → `_emitInterruptedTurnResult()` → `stream_end` + a synthetic
`result`, then `emit('stopped', { code })` — one synchronous frame), and
`_resolveRoles` accepts `roles.architect.provider = 'claude-cli'`. TurnDriver's own
header notes that committee reviews serialize on the architect session, so a queued
turn there is the normal case, not an edge case.

**Mechanism chosen: the mutex handoff never happens inside a session-event
callback.** `_finishTurn` drops the ctx from `_active` immediately and hands the slot
to the next queued turn via `_scheduleNext` → `process.nextTick`. Ctx removal and the
next ctx's registration therefore sit on opposite sides of the frame boundary, so
every remaining event in the provider's frame hits the **epoch guard with no active
ctx** and is dropped instead of being attributed to a turn it does not belong to.
Ownership of the session's event stream stays with the turn that owned it for the
whole frame.

Why this mechanism rather than a `stopped`-specific guard:

- **It is the existing design's own answer.** The drain exists for exactly this
  hazard ("a late event from the interrupted turn can't be misattributed to the next
  turn", #6723) — it just only covered the *timeout* release path. The regression came
  in through the `result`/`error`/`stopped` release path. This closes that path with
  the same intent and no new concept.
- **`stopped` carries no correlation token**, so there is no per-event turn id to
  match on. What *is* structurally true is that a provider cannot both be finishing
  its emit burst for turn N and have started emitting for turn N+1 within one
  synchronous stack — so "turn N owns the stream until that frame ends" is a sound
  ownership rule, not a timing heuristic.
- **It does not drain on `stopped`.** As the review notes, `stopped` is the very
  event `_endDrain` keys off, so `{ drain: true }` there would burn the full
  `drainTimeoutMs` on every interrupt. Dropping the ctx at once costs nothing, and
  the doc-block now records *why* the asymmetry with the timeout path is deliberate.
- **It fixes the whole class, not just the new case** — including a *pre-existing*
  variant: `CliSession._handleHardTimeout` / `_handleStreamStall` emit
  `_emitInterruptedTurnResult()` (`stream_end` + `result`) and **then**
  `emit('error', …)` in the same frame, so a trailing `error` rejected the next queued
  turn `TURN_ERROR`. That is red against pre-PR `main` (`23e6687bc`) too, and is now
  green. It also closes the review's latent probe (a late `result` after `stopped`
  resolving turn 2 as a success carrying turn 1's payload).
- **`_occupied` stays set across the tick gap**, so a `driveTurn()` landing inside it
  queues rather than racing ahead, and at most one handoff may be pending per session
  (two would each shift a waiter off the FIFO and run them concurrently).

**Residual, stated plainly:** because `stopped` has no turn id, a provider that
emitted a turn's terminal event and *then* `stopped` in a **later macrotask** could
still settle the following turn. No in-tree provider does that — every emit site is a
single synchronous frame (`cli-session.js` `_handleChildClose` / `_handleHardTimeout`
/ `_handleStreamStall`, `jsonl-subprocess-session.js`'s child-close, `sdk-session.js`'s
catch block, `codex-app-server-session.js` `_failTurn`). Closing it *by construction*
needs a provider-side turn id on the event payload; the doc-block records this rather
than claiming a guarantee the code does not implement.

### 3. Still not closed here (flagged, tracked)

`CliSession` emits that **synthetic `result` before `stopped`**, so a `claude-cli`
turn settles as a **success** on it and never reaches the `stopped` case — the
interrupted turn is reported as completed. The trailing `stopped` no longer harms the
*next* turn, but this false-success remains. It is unreachable through the scheduler
(requires `capabilities.inProcessPermissions`, which `cli-session.js` sets false) and
through the orchestration **worker** roles
(`AUDIT_ELIGIBLE_PROVIDERS`/`IMPLEMENT_ELIGIBLE_PROVIDERS` = claude-sdk / claude-byok /
codex); the orchestration **architect** role is not provider-restricted, which is what
**#7036** closes — deliberately out of scope here. Fixing it inside TurnDriver would
need a provider-side signal distinguishing a synthetic interrupted `result` from a real
one, which touches the client wire.

Also deliberately unchanged: no consumer maps `TURN_STOPPED` to a distinct outcome
(**#7038**). The scheduler reports the blocked failure via `runState.blocked`, and an
un-blocked `TURN_STOPPED` falls through to `status: 'error'`. Scheduler-side proof that
a *second* due task actually fires after an interrupted run is **#7037**.

`packages/server/src/scheduler.js` — comments only. The two blocks that documented the
real (weaker) behaviour are restored to their stronger form: a denied permission now
frees the slot immediately as well as deciding the outcome immediately.

## How it was verified

### Pre-fix RED — the regression tests

New suite `TurnDriver — a settled turn's trailing events never reach the QUEUED turn`,
run against this PR's own pre-fix `turn-driver.js` (`ddc0d04`):

```
# Subtest: TurnDriver — a settled turn's trailing events never reach the QUEUED turn
not ok 1 - a trailing `stopped` after a real `result` does not settle the next queued turn
  error: |-
    a previous turn's `stopped` must not settle turn-2
    + actual - expected
    + 'rejected'
    - 'pending'
not ok 2 - a trailing `error` after a synthetic `result` does not settle the next queued turn
  error: |-
    a previous turn's `error` must not fail turn-2
    + 'rejected'   - 'pending'
not ok 3 - turn-1's late trailing events cannot settle turn-2 (duplicate `stopped` + late `result`)
  error: |-
    turn-1's trailing events must not settle turn-2
    + 'rejected'   - 'pending'
# tests 22 / # pass 19 / # fail 3
```

Test 2 is *also* red against pre-PR `main` (`23e6687bc`) — the pre-existing
`error`-after-synthetic-`result` variant, not something this PR introduced:

```
not ok 1 - a trailing `error` after a synthetic `result` does not settle the next queued turn
  expected: 'pending'   actual: 'rejected'
# tests 1 / # pass 0 / # fail 1
```

Each test asserts the surviving turn **positively** — turn 2 resolves and carries
**its own** text and result payload — never merely "no error". Test 1 replays
`CliSession._handleChildClose`'s real emit order (`stream_delta`, `stream_end`,
synthetic `result`, `stopped { code: 130 }`).

A fourth test (`a third turn queued behind two still runs`) is a guard on the new
handoff rather than a regression test — green both before and after, and there so a
future double-`_scheduleNext` that ran two queued turns concurrently would fail.

The original #7009 coverage is unchanged and still red pre-fix: interrupt settles
promptly with `TURN_STOPPED` and never resolves; the mutex is released so the next
queued turn runs; `stopped` during a drain only ends the drain. The
`a completed turn still resolves success even if a trailing stopped arrives` case is
now explicitly labelled the **no-queued-turn** variant, with the queued variant
covered by the new suite.

### Pre-fix RED — scheduler end-to-end

`tests/scheduler.test.js` — 2 cases. `FakeSessionManager` gained an
`interruptEmitsStopped` mode that models the real abort surface (`interrupt()` emits
`stopped`, the turn is never completed with a `result`); the default fake always
emitted a `result`, so it could not exercise this path at all. Case 1: a denied
permission has its outcome **recorded** by the time the fire settles, still as the
visible blocked failure and never `success`. Case 2 (via `stopAfterSend`): an operator
Stop with **no** permission prompt — `runState.blocked` is unset, so the outcome rides
entirely on the `TURN_STOPPED` rejection.

```
not ok 1 - a denied permission finishes the run at once instead of burning runTimeoutMs
  error: 'the interrupted run must be recorded already, not left pending until runTimeoutMs'
not ok 2 - an operator Stop on a scheduled run is an error, never a success
  error: 'the stopped run must be recorded already, not left pending until runTimeoutMs'
# tests 65 / # pass 63 / # fail 2
```

### Post-fix gates

- `tests/orchestration-turn-driver.test.js` → **22/22, exit 0**.
- Consumers — `scheduler.test.js`, `orchestration-manager.test.js`,
  `orchestration-manager-implement.test.js`, `orchestration-handlers.test.js`,
  `orchestration-permission-gate.test.js`, `server-orchestrator.test.js` →
  **128/128, exit 0**.
- Full `packages/server` suite (`CHROXY_CRED_DISABLE_KEYCHAIN=1 npm test`) →
  **12646 tests, 12628 pass, 5 fail**. All five are in environment-dependent suites
  that do not import `turn-driver.js` at all: `doctor.test.js` (`codex provider
  reports credential status via OPENAI_API_KEY` — no key in env),
  `integration/codex-spawn-argv.integration.test.js` (needs a real `codex` binary),
  and `tunnel.integration.test.js` ×3 (`requires cloudflared`; the log shows
  `failed to unmarshal quick Tunnel` retries from Cloudflare's own API).
- All five `packages/server/scripts/lint-*.sh` → OK. `eslint src/` on the changed
  source → clean.
- **Force-exit trap:** `c8 node --import ./tests/_setup.mjs
  --experimental-test-module-mocks --test ./tests/orchestration-turn-driver.test.js
  ./tests/scheduler.test.js` with **no** `--test-force-exit` → **87/87, exit 0,
  601 ms**. No leaked hard handle: `process.nextTick` holds no handle, `ctx.timer` is
  still cleared on every settle, and the fix removes the case where a 15-minute
  non-unref'd watchdog stayed armed after an interrupt.

### Review nitpicks folded in

- `scheduler.test.js`: `await session.interrupt()` (was a floating promise).
- A comment marking the `elapsedMs < 2_000` asserts as belt-and-braces — they measure
  wall clock inside a fake-timer `tick()`, so `record.lastRun` is the load-bearing
  assertion.
- Doc-block: "Every provider **that emits** `stopped` does so **only** on its
  intentional-stop path" (claude-tui / claude-byok never emit it).
- Tests no longer use `await Promise.resolve()` to observe the handoff — a shared
  `flush()` (`setImmediate`) keeps them agnostic to the exact boundary.

Closes #7009
