### PR TITLE
test(server): assert parallel tool dispatch by in-flight count, not wall clock

### DIFF
--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -2447,23 +2447,41 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
-    it('executes parallel tool_use blocks concurrently — wall clock < sequential (#4062)', async () => {
-      // Three Read tool_use blocks in one assistant turn. Each executor
-      // sleeps 100ms. Sequential would take ~300ms; Promise.all should
-      // collapse to ~100ms + a small scheduler margin. Assert the total
-      // is comfortably under the sequential floor.
+    it('executes parallel tool_use blocks concurrently — every block dispatched before any resolves (#4062)', async () => {
+      // Three Read tool_use blocks in one assistant turn. The property
+      // under test is CONCURRENCY, not speed: phase 2 must dispatch
+      // every approved block before any of them settles.
+      //
+      // This is asserted with an in-flight counter plus an ordered
+      // event log — NOT a wall-clock bound. The original form measured
+      // elapsed real time against a fixed 250ms threshold, which
+      // false-red'd purely because the shared CI runner was loaded
+      // (#6994). The counter/log form is independent of host speed:
+      // the executor yields across macrotask turns with ZERO delay, so
+      // a sequential orchestrator drops in-flight back to 0 between
+      // blocks no matter how fast or slow the machine is.
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session.setPermissionMode('auto')
-      const SLEEP_MS = 100
-      const startTimes = []
-      const endTimes = []
+      // Number of zero-delay macrotask yields each executor parks on.
+      // Any value >= 1 is sufficient for a sequential orchestrator to
+      // fully drain one executor before the next enters; a handful
+      // gives the interleaving room to be observed.
+      const YIELD_TICKS = 5
+      const events = []
+      let inFlight = 0
+      let peakInFlight = 0
       session._executeToolBlock = async function ({ block, messageId, decision }) {
         // Sanity check: orchestrator passes the pre-resolved decision.
         assert.ok(decision, 'orchestrator must pass a pre-resolved decision into _executeToolBlock')
         assert.equal(decision.behavior, 'allow', 'auto mode resolves to allow')
-        startTimes.push(Date.now())
-        await new Promise((r) => setTimeout(r, SLEEP_MS))
-        endTimes.push(Date.now())
+        inFlight += 1
+        peakInFlight = Math.max(peakInFlight, inFlight)
+        events.push(`enter:${block.id}`)
+        for (let tick = 0; tick < YIELD_TICKS; tick += 1) {
+          await new Promise((r) => setImmediate(r))
+        }
+        inFlight -= 1
+        events.push(`exit:${block.id}`)
         this.emit('tool_result', {
           messageId,
           toolUseId: block.id,
@@ -2499,25 +2517,35 @@ describe('ClaudeByokSession', () => {
         },
       }
       await session.start()
-      const turnStart = Date.now()
       await session.sendMessage('parallel reads')
-      const turnTotal = Date.now() - turnStart
-      // Sequential would be 3 * 100ms = 300ms (minimum). Parallel should
-      // finish in ~100ms plus a generous CI scheduler margin. Tight
-      // upper bound at 250ms — proves concurrency without flakiness on
-      // overloaded runners.
-      assert.equal(startTimes.length, 3, 'all three executors fire')
-      assert.ok(
-        turnTotal < 250,
-        `expected parallel turn < 250ms, got ${turnTotal}ms — sequential floor is ~300ms`,
+      const log = events.join(' ')
+      assert.equal(
+        events.filter((e) => e.startsWith('enter:')).length,
+        3,
+        `all three executors fire — log: ${log}`,
       )
-      // Additional concurrency check: each executor's start should be
-      // within the lifetime of the others (overlap, not back-to-back).
-      const lastStart = Math.max(...startTimes)
-      const firstEnd = Math.min(...endTimes)
+      assert.equal(
+        events.filter((e) => e.startsWith('exit:')).length,
+        3,
+        `all three executors complete — log: ${log}`,
+      )
+      assert.equal(inFlight, 0, `no execution left in flight after the turn — log: ${log}`)
+      // The concurrency assertion: at some instant all three executions
+      // were simultaneously in flight. A sequential orchestrator peaks
+      // at 1.
+      assert.equal(
+        peakInFlight,
+        3,
+        `phase 2 must run tool blocks concurrently — peak in-flight was ${peakInFlight}, expected 3; log: ${log}`,
+      )
+      // Same property expressed as ordering: every dispatch happens
+      // before the first completion, so no two executions are
+      // back-to-back.
+      const lastEnterIdx = events.reduce((acc, e, i) => (e.startsWith('enter:') ? i : acc), -1)
+      const firstExitIdx = events.findIndex((e) => e.startsWith('exit:'))
       assert.ok(
-        lastStart < firstEnd,
-        `executors must overlap — last start (${lastStart}) should precede first end (${firstEnd})`,
+        lastEnterIdx < firstExitIdx,
+        `every block must be dispatched before any resolves — last enter at ${lastEnterIdx}, first exit at ${firstExitIdx}; log: ${log}`,
       )
       await session.destroy()
     })


### PR DESCRIPTION
## Problem

`packages/server/tests/byok-session.test.js` asserted phase-2 tool concurrency with an **absolute wall-clock bound**:

```js
const turnTotal = Date.now() - turnStart
assert.ok(turnTotal < 250, `expected parallel turn < 250ms, got ${turnTotal}ms — sequential floor is ~300ms`)
```

Three stub executors each slept 100ms, so "parallel" was inferred from elapsed real time staying under 250ms. On the shared 2-replica self-hosted runner pool that budget is blown by scheduler pressure alone — it false-red'd on app-only PR #6990 while sibling app-only PR #6988 passed `Server Tests` on the same base minutes earlier.

The intent was right; the mechanism was a timing measurement.

## What changed

The test now measures the property directly — **phase 2 dispatches every approved block before any of them settles** — with no clock involved:

- Each stub executor increments an in-flight counter, pushes `enter:<id>`, yields across a handful of **zero-delay** macrotask turns (`setImmediate`), then decrements and pushes `exit:<id>`.
- Assertions:
  - `peakInFlight === 3` — all three executions were simultaneously in flight (a sequential orchestrator peaks at **1**).
  - last `enter:` index < first `exit:` index — same property as ordering.
  - `inFlight === 0` after the turn — nothing left dangling.
  - all three enter and all three exit events fired.

No `Date.now()` and no `setTimeout` remain in the test. The threshold was **not** widened — it was removed. Host speed cannot change the outcome: a sequential `await` per block drains one executor (recording its exit, dropping in-flight to 0) before the next enters, however fast or slow the machine is.

Only the test file changes; `src/byok-session.js` is untouched.

## How this was verified

**The test still fails if dispatch is serialized.** The phase-2 fan-out in `src/byok-session.js` was temporarily replaced with a sequential `await` per block, and the test went red for exactly the right reason:

```
not ok 1 - executes parallel tool_use blocks concurrently — every block dispatched before any resolves (#4062)
  error: |-
    phase 2 must run tool blocks concurrently — peak in-flight was 1, expected 3;
    log: enter:tu_a exit:tu_a enter:tu_b exit:tu_b enter:tu_c exit:tu_c

    1 !== 3
  code: 'ERR_ASSERTION'
  expected: 3
  actual: 1
```

The probe was then reverted (`git status` confirms only the test file is modified).

Green after restore, and re-run 10x consecutively — 10/10 pass — while the full server suite was concurrently saturating the machine, i.e. under exactly the loaded-host condition that broke the old bound.

Re-runnable:

```bash
cd packages/server
# target test
PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --import ./tests/_setup.mjs \
  --experimental-test-module-mocks --test \
  --test-name-pattern "every block dispatched before any resolves" ./tests/byok-session.test.js
# whole file, and WITHOUT --test-force-exit (leaked-handle check) — 148/148 pass, self-exits
PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --import ./tests/_setup.mjs \
  --experimental-test-module-mocks --test ./tests/byok-session.test.js
# custom shell lints
for f in scripts/lint-*.sh; do bash "$f"; done
```

- `tests/byok-session.test.js` whole file: **148/148 pass**, and it **self-exits without `--test-force-exit`** when piped (real EOF wait), in ~66s — no leaked handle.
- All five `packages/server/scripts/lint-*.sh` pass.

## Caveat on the full-suite run (stated, not hidden)

The full `npm test` cannot go green in this local checkout: `@anthropic-ai/claude-agent-sdk` is not installed here, so whole test files fail to *load* (`ERR_MODULE_NOT_FOUND`). Measured both ways on the same tree to prove neutrality:

| tree | tests | fail |
|---|---|---|
| pristine base (`23e6687bc`) | 9679 | 203 |
| with this change | 9679 | 200 |

Identical test count, no added failures (the 3-test delta is pre-existing env flakiness in the same failing set). CI, which installs dependencies, is the authoritative signal for the full suite.

Closes #6994
