### PR TITLE
fix(server,security): close three fail-open edges on the hook floor probe

### DIFF
--- a/docs/security/permission-floor.md
+++ b/docs/security/permission-floor.md
@@ -85,7 +85,7 @@ HOOK-ROUTED (claude-tui = the DEFAULT provider, cli-session)
 | Auth | the **per-session hook secret**, same class and same validator as `POST /permission` (see [`bearer-token-authority.md` §5](bearer-token-authority.md#5-per-session-hook-secrets)) |
 | Request | the PreToolUse payload the hook already holds (`tool_name`, `tool_input`, `cwd`), capped at 1 MiB (`MAX_FLOOR_BODY` in `ws-permissions.js`) — deliberately much larger than `/permission`'s 64 KB, see §5 |
 | Response | `{ "floor": true \| false }` — nothing else; no requestId, no pending request, no broadcast, no push |
-| cwd basis | the **owning session's `cwd`** (resolved from the presented hook secret) — identical to what `PermissionManager` is constructed with; the payload's own `cwd` is used only when the session is not resolvable, and there is no `process.cwd()` fallback |
+| cwd basis | the **owning session's `cwd`** (resolved from the presented hook secret) and nothing else — identical to what `PermissionManager` is constructed with. There is no `process.cwd()` fallback and (#7020) no fallback to the payload's own `cwd`: a caller-chosen resolution base can UNDER-floor (naming `/repo/.git` as the base makes the relative scan of `/repo/.git/config` see only `config`). An unresolvable session answers `floor: true` |
 | Rate limit | its own limiter with a much larger budget than `/permission` (600/min, burst 200): this fires once per **tool call**, not once per human decision |
 
 **The hook treats only an explicit `"floor":false` as clearance.** Floored, `4xx`,
@@ -111,7 +111,12 @@ inputs from the SDK rather than parsing an untrusted HTTP body.
    naming **no** path field skips the round trip — such an input provably cannot be
    floored, so a path-less tool keeps its exact pre-#7004 behaviour. It is a
    *narrowing* filter, and the same test asserts it covers every field the floor
-   scans, so drift fails CI rather than silently under-flooring.
+   scans, so drift fails CI rather than silently under-flooring. #7020 restored the
+   two premises that argument rests on, both resolving toward the probe: the payload
+   must look **complete** (end in `}` — an empty or truncated body proves nothing and
+   leaves the auto-allow path directly), and a payload containing a `\u` escape is
+   probed because `\uXXXX` is the only JSON escape that can spell one of these keys,
+   which a byte-level scan would miss and the server's semantic lookup would not.
 3. **Keep the parity matrix honest.** `tests/permission-hook-floor.test.js` runs a
    `(tool, target)` matrix through both pipelines and asserts they agree.
 

--- a/docs/security/permission-floor.md
+++ b/docs/security/permission-floor.md
@@ -84,7 +84,7 @@ HOOK-ROUTED (claude-tui = the DEFAULT provider, cli-session)
 |---|---|
 | Auth | the **per-session hook secret**, same class and same validator as `POST /permission` (see [`bearer-token-authority.md` §5](bearer-token-authority.md#5-per-session-hook-secrets)) |
 | Request | the PreToolUse payload the hook already holds (`tool_name`, `tool_input`, `cwd`), capped at 1 MiB (`MAX_FLOOR_BODY` in `ws-permissions.js`) — deliberately much larger than `/permission`'s 64 KB, see §5 |
-| Response | `{ "floor": true \| false }` — nothing else; no requestId, no pending request, no broadcast, no push |
+| Response | `200` is exactly `{ "floor": true \| false }` — the top-level `floor` key is the only thing the hook reads, and the only status that can ever carry `false`. The error statuses are fail-closed by construction: `400` (unparseable body / request-stream error) and `413` (oversize) → `{ floor: true }`, `429` → `{ error, floor: true, retryAfterMs }`, `500` → `{ error, floor: true }`, and `403` (bad hook secret) → `{ error: 'unauthorized' }` with **no** `floor` key at all, which the hook treats the same way it treats every non-`false` answer: prompt. No requestId, no pending request, no broadcast, no push on any of them |
 | cwd basis | the **owning session's `cwd`** (resolved from the presented hook secret) and nothing else — identical to what `PermissionManager` is constructed with. There is no `process.cwd()` fallback and (#7020) no fallback to the payload's own `cwd`: a caller-chosen resolution base can UNDER-floor (naming `/repo/.git` as the base makes the relative scan of `/repo/.git/config` see only `config`). An unresolvable session answers `floor: true` |
 | Rate limit | its own limiter with a much larger budget than `/permission` (600/min, burst 200): this fires once per **tool call**, not once per human decision |
 
@@ -111,12 +111,27 @@ inputs from the SDK rather than parsing an untrusted HTTP body.
    naming **no** path field skips the round trip — such an input provably cannot be
    floored, so a path-less tool keeps its exact pre-#7004 behaviour. It is a
    *narrowing* filter, and the same test asserts it covers every field the floor
-   scans, so drift fails CI rather than silently under-flooring. #7020 restored the
-   two premises that argument rests on, both resolving toward the probe: the payload
-   must look **complete** (end in `}` — an empty or truncated body proves nothing and
-   leaves the auto-allow path directly), and a payload containing a `\u` escape is
-   probed because `\uXXXX` is the only JSON escape that can spell one of these keys,
-   which a byte-level scan would miss and the server's semantic lookup would not.
+   scans, so drift fails CI rather than silently under-flooring. #7020 narrowed the
+   two premises that argument rests on, both resolving toward the probe. Each guard
+   proves exactly this much, and no more:
+   - **Last-byte shape check.** A payload whose last non-whitespace byte is not `}`
+     is definitely not a JSON object, so it proves nothing about path fields and
+     leaves the auto-allow path directly (no probe, so the guard holds even when the
+     daemon is unreachable). That catches an empty body and a prefix truncation. It
+     is **not** a completeness check: a truncation that happens to land on a `}`
+     (`…,"permission_suggestions":{}`) still looks complete and still skips the
+     probe — the residual is tracked in **#7043**. Trailing whitespace is trimmed
+     before the check because `REQUEST=$(cat -)` strips trailing *newlines* only,
+     and a `}\r\n`-terminated payload would otherwise route every `auto` /
+     `acceptEdits` call to a phone prompt.
+   - **`\u` escape → probe.** `\uXXXX` is the only *valid* JSON escape that can
+     spell one of these keys, which a byte-level scan would miss and the server's
+     semantic lookup would not — so this closes the **valid-escape key-spelling**
+     gap. An *invalid* escape (`\U`, `\x`) is not covered: it matches neither the
+     key literals nor this arm, so the pre-filter still skips and the daemon is
+     never asked. Such a body parses nowhere, so it is not model- or
+     remote-reachable, but the byte-scan-vs-semantic-lookup divergence does survive
+     there — also #7043.
 3. **Keep the parity matrix honest.** `tests/permission-hook-floor.test.js` runs a
    `(tool, target)` matrix through both pipelines and asserts they agree.
 
@@ -135,6 +150,14 @@ inputs from the SDK rather than parsing an untrusted HTTP body.
   prompt. Ordinary (non-floored) large writes are unaffected — they never leave the
   fast path. This is the pre-#7004 oversize rule, unchanged; a fix belongs with that
   cap, not with the floor.
+- **The hook pre-filter's completeness guard is a heuristic (#7043).** It rejects a
+  payload whose last non-whitespace byte is not `}`, which catches an empty body and
+  a prefix truncation but not a truncation landing on a brace; and it probes on `\u`,
+  which covers every *valid* JSON escape that can spell a path key but not an invalid
+  one (`\U`, `\x`) — for those the daemon is never asked. Both residuals need a
+  producer that emits a truncated or non-JSON payload, so neither is model- or
+  remote-reachable; #7043 carries the candidate fixes (probe on any backslash, or a
+  real structural check).
 - **Command-shaped access is out of scope.** `Bash` can read `.env` — the floor
   guards *path fields*, and `Bash` is in `NEVER_AUTO_ALLOW` (never rule-whitelisted)
   but IS auto-approved under `auto`. Flipping a session to `auto` remains a

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -308,9 +308,41 @@ EOF
 # tests/permission-hook-floor.test.js asserts this pattern covers every
 # PROTECTED_PATH_INPUT_FIELDS entry, so extending the floor's field list without
 # updating this line fails CI.
+#
+# #7020 — the pre-filter's soundness argument ("naming no path field provably
+# cannot be floored") holds only over a COMPLETE, escape-free payload. Two
+# guards below restore that premise before the negative filter is trusted; both
+# resolve toward the PROBE (fail closed), never toward the skip:
+#   1. COMPLETENESS. An empty or truncated body used to take the same `return 1`
+#      and auto-allow, even though the "no path field" claim can only be read off
+#      a COMPLETE payload. A PreToolUse payload is always a JSON object, and
+#      `REQUEST=$(cat -)` strips trailing newlines, so a complete one always ends
+#      in `}`. Anything else leaves the auto-allow path immediately — no probe,
+#      because an unusable body proves nothing and this way the guard holds even
+#      when the daemon is unreachable. (`route_to_phone` then POSTs it to
+#      /permission, which cannot parse it either and answers its 400 deny.)
+#   2. UNICODE ESCAPES. The pre-filter is a BYTE-level substring scan while the
+#      daemon does a JSON-SEMANTIC field lookup, so a path-naming key spelled with
+#      an escape parses to file_path server-side yet never matches the pattern
+#      below. A `u`-escape of the letter f (byte sequence backslash-u-0-0-6-6,
+#      followed by `ile_path`) is such a key. `\uXXXX` is the ONLY JSON escape
+#      that can spell one of these keys — the rest of the grammar
+#      (`\" \\ \/ \b \f \n \r \t`) yields none of `[a-z_]` — so probing whenever
+#      the raw body contains `\u` closes the gap completely, and does so on the
+#      floor's own semantics rather than on an assumption about the producer's
+#      serializer. Any other malformed escape (`\U`, `\x`) makes the body
+#      unparseable, which the daemon already answers `floor:true`. Over-probing
+#      here is harmless; a `\n` / `\"`-only payload keeps the no-round-trip path.
 floor_forces_prompt() {
+  # (1) completeness — an incomplete body cannot prove "cannot be floored".
+  case "$REQUEST" in
+    *'}') ;;
+    *) return 0 ;;
+  esac
   case "$REQUEST" in
     *'"file_path"'*|*'"path"'*|*'"notebook_path"'*|*'"changes"'*) ;;
+    # (2) a \uXXXX escape may hide a path-naming key from the byte scan.
+    *'\u'*) ;;
     # No path-naming field anywhere in the payload — the floor cannot apply.
     *) return 1 ;;
   esac

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -310,32 +310,47 @@ EOF
 # updating this line fails CI.
 #
 # #7020 — the pre-filter's soundness argument ("naming no path field provably
-# cannot be floored") holds only over a COMPLETE, escape-free payload. Two
-# guards below restore that premise before the negative filter is trusted; both
-# resolve toward the PROBE (fail closed), never toward the skip:
-#   1. COMPLETENESS. An empty or truncated body used to take the same `return 1`
-#      and auto-allow, even though the "no path field" claim can only be read off
-#      a COMPLETE payload. A PreToolUse payload is always a JSON object, and
-#      `REQUEST=$(cat -)` strips trailing newlines, so a complete one always ends
-#      in `}`. Anything else leaves the auto-allow path immediately — no probe,
-#      because an unusable body proves nothing and this way the guard holds even
-#      when the daemon is unreachable. (`route_to_phone` then POSTs it to
-#      /permission, which cannot parse it either and answers its 400 deny.)
+# cannot be floored") holds only over a COMPLETE, escape-free payload. Two guards
+# below narrow that premise before the negative filter is trusted; both resolve
+# toward the PROBE (fail closed), never toward the skip. Each guard states exactly
+# what it PROVES — neither is a completeness proof, and #7043 tracks the residual:
+#   1. LAST-BYTE SHAPE CHECK. A PreToolUse payload is always a JSON object, so a
+#      complete one ends in `}` once trailing whitespace is discarded. A body that
+#      does NOT is definitely unusable, and an unusable body proves nothing about
+#      path fields, so it leaves the auto-allow path immediately — no probe,
+#      because that way the guard holds even when the daemon is unreachable.
+#      (`route_to_phone` then POSTs it to /permission, which cannot parse it
+#      either and answers its 400 deny.) This catches the shapes that motivated
+#      the guard — an EMPTY body and a PREFIX truncation (`{"tool_name":"Read"` …)
+#      — and nothing more. It is a cheap heuristic, NOT a completeness check: a
+#      truncation that happens to land on a `}` (`…,"permission_suggestions":{}`)
+#      still looks complete here and still skips the probe. Tracked in #7043.
+#      Trailing whitespace is trimmed first: `REQUEST=$(cat -)` strips trailing
+#      NEWLINES only, so a `}\r\n`- or `} `-terminated payload would otherwise
+#      fail this check and route EVERY auto/acceptEdits call to a phone prompt —
+#      fail-closed, but it would destroy the lenient modes.
 #   2. UNICODE ESCAPES. The pre-filter is a BYTE-level substring scan while the
 #      daemon does a JSON-SEMANTIC field lookup, so a path-naming key spelled with
 #      an escape parses to file_path server-side yet never matches the pattern
 #      below. A `u`-escape of the letter f (byte sequence backslash-u-0-0-6-6,
-#      followed by `ile_path`) is such a key. `\uXXXX` is the ONLY JSON escape
-#      that can spell one of these keys — the rest of the grammar
+#      followed by `ile_path`) is such a key. `\uXXXX` is the ONLY escape in the
+#      JSON grammar that can spell one of these keys — the rest
 #      (`\" \\ \/ \b \f \n \r \t`) yields none of `[a-z_]` — so probing whenever
-#      the raw body contains `\u` closes the gap completely, and does so on the
+#      the raw body contains `\u` closes the VALID-ESCAPE key-spelling gap on the
 #      floor's own semantics rather than on an assumption about the producer's
-#      serializer. Any other malformed escape (`\U`, `\x`) makes the body
-#      unparseable, which the daemon already answers `floor:true`. Over-probing
-#      here is harmless; a `\n` / `\"`-only payload keeps the no-round-trip path.
+#      serializer. That is the whole of what it proves. An INVALID escape (`\U`,
+#      `\x`) is not covered: it does not match this arm, so the pre-filter takes
+#      `return 1` and the daemon is never asked — the byte-scan-vs-semantic-lookup
+#      divergence remains for bodies no JSON parser would accept. Also #7043
+#      (which lists the candidate fixes: probe on any backslash, or a real
+#      structural check). Over-probing here is harmless; a `\n` / `\"`-only
+#      payload keeps the no-round-trip path.
 floor_forces_prompt() {
-  # (1) completeness — an incomplete body cannot prove "cannot be floored".
-  case "$REQUEST" in
+  # (1) last-byte shape check — an unusable body cannot prove "cannot be floored".
+  # Trim the trailing whitespace run first (two expansions, no loop, bash 3.2-safe:
+  # `##*[![:space:]]` leaves exactly that run, which `%` then strips off the end).
+  REQUEST_TRIMMED=${REQUEST%"${REQUEST##*[![:space:]]}"}
+  case "$REQUEST_TRIMMED" in
     *'}') ;;
     *) return 0 ;;
   esac

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -51,10 +51,19 @@ const MAX_FLOOR_BODY = 1_048_576
  * rather than parsing an HTTP body.
  *
  * The cwd basis is the OWNING SESSION's cwd (`session.cwd` — exactly what
- * `PermissionManager` is constructed with, `cwd: this.cwd`), falling back to the
- * payload's own `cwd` only when the session is not resolvable (legacy/unit-test
- * shapes). It never falls back to the daemon's `process.cwd()`: resolving a
- * relative target against the wrong root could UNDER-floor.
+ * `PermissionManager` is constructed with, `cwd: this.cwd`) and NOTHING ELSE. It
+ * never falls back to the daemon's `process.cwd()`, and (#7020) never to the
+ * payload's own `cwd`: both are resolution bases the floor did not choose, and
+ * resolving a target against the wrong root UNDER-floors. The payload case is the
+ * sharper of the two because it is CALLER-chosen — naming the protected directory
+ * itself as the base makes the relative scan see nothing protected (target
+ * `/repo/.git/config` with `cwd: "/repo/.git"` scans just `config` → `floor:
+ * false`). `session.cwd` is always a real string (`BaseSession` sets
+ * `cwd || process.cwd()`), including in legacy single-session mode where
+ * `_findSessionByHookSecret` returns `{ session, sessionId: null }`, so the only
+ * shape this rejects is one where the owning session genuinely cannot be
+ * resolved — e.g. `_validateHookAuth` taking its primary-token fallback with no
+ * hook secrets registered. That answers `floor: true` (one prompt), not `false`.
  *
  * @param {*} hookData  the parsed PreToolUse payload (untrusted)
  * @param {string|null} sessionCwd  the owning session's cwd, when resolvable
@@ -72,9 +81,9 @@ export function evaluateHookFloorRequest(hookData, sessionCwd) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return { floor: true, reason: 'missing or non-object tool_input' }
   }
-  const cwd = (typeof sessionCwd === 'string' && sessionCwd.length > 0)
-    ? sessionCwd
-    : ((typeof hookData.cwd === 'string' && hookData.cwd.length > 0) ? hookData.cwd : null)
+  // #7020 — the OWNING SESSION's cwd is the only accepted resolution base. Never
+  // `hookData.cwd` (caller-chosen → under-floors), never `process.cwd()`.
+  const cwd = (typeof sessionCwd === 'string' && sessionCwd.length > 0) ? sessionCwd : null
   if (!cwd) {
     return { floor: true, reason: 'no resolvable session cwd' }
   }
@@ -229,8 +238,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     let body = ''
     let bodyBytes = 0
     let oversized = false
+    let streamFailed = false
     req.on('data', (chunk) => {
-      if (oversized) return
+      if (oversized || streamFailed) return
       bodyBytes += Buffer.byteLength(chunk, 'utf8')
       if (bodyBytes > MAX_BODY) {
         oversized = true
@@ -244,6 +254,17 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       }
       body += chunk
     })
+    // #7020 — same omission the floor route had: an 'error' on a stream with no
+    // listener rethrows into uncaughtException. A mid-body abort answers a DENY,
+    // so this route's fail-closed contract holds on the torn-down path too.
+    req.on('error', (err) => {
+      streamFailed = true
+      log.warn(`POST /permission request stream error: ${err?.message || err}`)
+      try {
+        if (!res.headersSent) sendJson(res, 400, { decision: 'deny' })
+        else res.end()
+      } catch { /* socket already torn down */ }
+    })
     req.on('end', () => {
       // #5313 (WP-1.3): this callback fires on a later tick, after the HTTP
       // dispatch that registered it has already returned — so a throw here is
@@ -254,7 +275,8 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       // throw is contained and returns a 500 to the client when possible.
       try {
       // #5433: the 413 deny was already sent from the 'data' handler.
-      if (oversized) return
+      // #7020: ditto the 400 deny from the 'error' handler.
+      if (oversized || streamFailed) return
 
       let hookData
       try {
@@ -459,8 +481,9 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     let body = ''
     let bodyBytes = 0
     let oversized = false
+    let streamFailed = false
     req.on('data', (chunk) => {
-      if (oversized) return
+      if (oversized || streamFailed) return
       bodyBytes += Buffer.byteLength(chunk, 'utf8')
       if (bodyBytes > MAX_FLOOR_BODY) {
         oversized = true
@@ -469,12 +492,25 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       }
       body += chunk
     })
+    // #7020 — a client that aborts mid-body emits 'error' on the request stream,
+    // and an 'error' with NO listener is an unhandled 'error' event (it rethrows,
+    // escaping to uncaughtException). mailbox-route.js and github-webhook.js both
+    // attach one; match that. Answers `floor: true` so even a torn-down request
+    // fails CLOSED, and flags the read so a late 'end' cannot double-respond.
+    req.on('error', (err) => {
+      streamFailed = true
+      log.warn(`POST /permission-floor request stream error: ${err?.message || err}`)
+      try {
+        if (!res.headersSent) sendJson(res, 400, { floor: true })
+        else res.end()
+      } catch { /* socket already torn down */ }
+    })
     req.on('end', () => {
       // #5313 (WP-1.3): this fires on a later tick, so a throw here escapes the
       // route wrapper straight to uncaughtException. Contain it — and answer
       // `floor: true` so even a crash-path response fails closed.
       try {
-        if (oversized) return
+        if (oversized || streamFailed) return
 
         let hookData
         try {

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -239,6 +239,7 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     let bodyBytes = 0
     let oversized = false
     let streamFailed = false
+    let ended = false
     req.on('data', (chunk) => {
       if (oversized || streamFailed) return
       bodyBytes += Buffer.byteLength(chunk, 'utf8')
@@ -257,15 +258,31 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     // #7020 — same omission the floor route had: an 'error' on a stream with no
     // listener rethrows into uncaughtException. A mid-body abort answers a DENY,
     // so this route's fail-closed contract holds on the torn-down path too.
+    //
+    // ONLY while the body is still being read. Unlike every other capped reader in
+    // this file, THIS route's 'end' handler does not respond — it registers a
+    // `pendingPermissions` entry and DEFERS the response for up to five minutes
+    // while the prompt sits on the user's phone. So a post-'end' 'error' must be a
+    // no-op on both counts: answering a 400 there would (a) send a second response
+    // on a socket the pending entry still owns — the later `resolve()` then throws
+    // ERR_HTTP_HEADERS_SENT on the #5313 tick that reaches uncaughtException — and
+    // (b) DENY, from a transient stream error, a request the user is still looking
+    // at, while leaving the pending entry alive. Teardown after 'end' belongs to
+    // the existing `req 'aborted'` / `res 'close'` → onClose path, which cleans the
+    // map up and leaves `closed` set so nothing responds twice.
     req.on('error', (err) => {
       streamFailed = true
       log.warn(`POST /permission request stream error: ${err?.message || err}`)
+      if (ended) return
       try {
         if (!res.headersSent) sendJson(res, 400, { decision: 'deny' })
         else res.end()
       } catch { /* socket already torn down */ }
     })
     req.on('end', () => {
+      // Claim the response BEFORE anything below can defer it (see the 'error'
+      // listener above) — this must hold even on the paths that return early.
+      ended = true
       // #5313 (WP-1.3): this callback fires on a later tick, after the HTTP
       // dispatch that registered it has already returned — so a throw here is
       // NOT caught by the route handler's wrapper and escapes to
@@ -497,6 +514,12 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
     // escaping to uncaughtException). mailbox-route.js and github-webhook.js both
     // attach one; match that. Answers `floor: true` so even a torn-down request
     // fails CLOSED, and flags the read so a late 'end' cannot double-respond.
+    //
+    // No post-'end' guard is needed here (unlike /permission's, which has one):
+    // this route's 'end' handler answers SYNCHRONOUSLY on every branch — 200,
+    // the 400 on an unparseable body, or the 500 from its catch — so once it has
+    // run `res.headersSent` is already true and a later 'error' takes the
+    // `res.end()` no-op arm. There is no deferred-response window to protect.
     req.on('error', (err) => {
       streamFailed = true
       log.warn(`POST /permission-floor request stream error: ${err?.message || err}`)

--- a/packages/server/tests/permission-hook-floor.test.js
+++ b/packages/server/tests/permission-hook-floor.test.js
@@ -565,7 +565,7 @@ describe('permission-hook.sh: floor clearance is a real JSON parse, not a substr
 // 3c. #7020 — the three remaining fail-OPEN edges on the floor probe
 // ---------------------------------------------------------------------------
 
-describe('permission-hook.sh: the pre-filter only skips the probe on a COMPLETE payload (#7020)', () => {
+describe('permission-hook.sh: an obviously unusable payload does not skip the probe (#7020)', () => {
   let daemon
 
   afterEach(async () => {
@@ -577,6 +577,10 @@ describe('permission-hook.sh: the pre-filter only skips the probe on a COMPLETE 
   // provably cannot be floored") holds only for a payload that is actually
   // COMPLETE. An empty or truncated body used to take the same `return 1` and
   // auto-allow under `auto` — the one place the negative filter could fail OPEN.
+  // The guard is a last-byte shape check, so what it PROVABLY catches is these
+  // two shapes: an empty body, and a truncation that does not land on a `}`. A
+  // truncation that does land on one still looks complete to it — tracked in
+  // #7043, not pinned here, because these tests state only what holds.
   const incompletePayloads = [
     ['an EMPTY payload', ''],
     ['a payload truncated before the path key', '{"tool_name":"Read","tool_in'],
@@ -587,9 +591,10 @@ describe('permission-hook.sh: the pre-filter only skips the probe on a COMPLETE 
     it(`auto + ${label} → routes to a PROMPT, never a silent allow`, async () => {
       daemon = await startRealDaemon({ promptDecision: 'allow' })
       const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto' })
-      // No probe is needed: a body that is not a complete JSON object carries no
-      // proof of anything, so the hook leaves the auto-allow path directly. That
-      // is strictly stronger than probing — it holds even if the daemon is down.
+      // No probe is needed: a body whose last non-whitespace byte is not `}` is
+      // definitely not a JSON object, so it proves nothing about path fields and
+      // the hook leaves the auto-allow path directly. That is strictly stronger
+      // than probing — it holds even if the daemon is down.
       assert.equal(daemon.stats.permissionRequests, 1, 'an incomplete payload must leave the auto-allow path')
       // /permission cannot parse it either, so it answers a 400 deny — the tool
       // is BLOCKED. The one thing that must never happen is a silent allow.
@@ -597,10 +602,12 @@ describe('permission-hook.sh: the pre-filter only skips the probe on a COMPLETE 
     })
   }
 
-  // A `\uXXXX` escape is the ONLY JSON escape that can spell a path-field key
+  // A `\uXXXX` escape is the only VALID JSON escape that can spell a path-field key
   // (`"\u0066ile_path"` parses to `file_path`), so the byte-level pre-filter
   // misses what the server's JSON-semantic lookup finds. This payload IS complete
-  // and well-formed, so only the daemon can answer it — the hook must probe.
+  // and well-formed, so only the daemon can answer it — the hook must probe. An
+  // INVALID escape (`\U`, `\x`) is out of scope: nothing parses such a body, and
+  // the pre-filter does not consult the daemon about it either (#7043).
   it('auto + a \\u-escaped path key → PROBES and routes to a PROMPT, never a silent allow', async () => {
     daemon = await startRealDaemon({ promptDecision: 'allow' })
     const payload = '{"tool_name":"Read","tool_input":{"\\u0066ile_path":".env"},"cwd":"/work/project"}'
@@ -608,6 +615,37 @@ describe('permission-hook.sh: the pre-filter only skips the probe on a COMPLETE 
     assert.equal(daemon.stats.floorRequests, 1, 'a byte-level miss must not be read as "cannot be floored"')
     assert.equal(daemon.stats.permissionRequests, 1, 'and the escaped .env read must reach the user')
     assert.equal(decisionOf(stdout).permissionDecision, 'allow', 'the user then answered')
+  })
+
+  // The completeness guard is a LAST-BYTE check and `REQUEST=$(cat -)` strips
+  // trailing NEWLINES only, so `}\r\n` / `} ` would leave a non-`}` last byte and
+  // send EVERY auto/acceptEdits tool call to a phone prompt. Fail-closed, but it
+  // would destroy the lenient modes for a CRLF-emitting producer — so the guard
+  // trims the trailing whitespace run before looking at the last byte.
+  const trailingWhitespacePayloads = [
+    ['CRLF', '\r\n'],
+    ['a trailing space', ' '],
+    ['a tab + CRLF', '\t\r\n'],
+  ]
+
+  for (const [label, suffix] of trailingWhitespacePayloads) {
+    it(`auto + an ordinary path-less call terminated by ${label} is still auto-allowed with no round trip`, async () => {
+      daemon = await startRealDaemon()
+      const payload = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' }, cwd: CWD }) + suffix
+      const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto' })
+      assert.equal(decisionOf(stdout).permissionDecision, 'allow')
+      assert.equal(daemon.stats.floorRequests, 0, 'trailing whitespace is not incompleteness')
+      assert.equal(daemon.stats.permissionRequests, 0, 'an ordinary tool call must not be routed to the phone')
+    })
+  }
+
+  it('trimming trailing whitespace does not skip the probe for a payload that DOES name a path', async () => {
+    daemon = await startRealDaemon()
+    const payload = JSON.stringify(readPayload('src/index.js')) + '\r\n'
+    const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto' })
+    assert.equal(daemon.stats.floorRequests, 1, 'the path-field scan still runs on the raw payload')
+    assert.equal(daemon.stats.permissionRequests, 0)
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow')
   })
 
   it('a WELL-FORMED path-less payload still skips the probe (no new latency on the fast path)', async () => {
@@ -653,16 +691,16 @@ describe('POST /permission-floor: the cwd basis is the OWNING SESSION only (#702
   })
 })
 
-describe('POST /permission-floor: a request-stream error is handled, not thrown (#7020)', () => {
+describe('POST /permission + /permission-floor: a request-stream error is handled, not thrown (#7020)', () => {
   /** The handler under test with nothing but the plumbing it actually touches. */
-  function makeHandler() {
+  function makeHandler({ pendingPermissions = new Map() } = {}) {
     return createPermissionHandler({
       sendFn: () => {},
       broadcastFn: () => {},
       validateBearerAuth: () => true,
       validateHookAuth: () => true,
       pushManager: null,
-      pendingPermissions: new Map(),
+      pendingPermissions,
       permissionSessionMap: new Map(),
       getSessionManager: () => null,
       pairingManager: null,
@@ -677,13 +715,32 @@ describe('POST /permission-floor: a request-stream error is handled, not thrown 
     return req
   }
 
+  /**
+   * `writeHead` THROWS on a second call, exactly as a real `ServerResponse` does
+   * (`ERR_HTTP_HEADERS_SENT`). Without that, a fixture silently accepts a double
+   * response and cannot observe the defect at all — which is how the post-`end`
+   * ordering below stayed invisible. `writeHeadCalls` counts responses so
+   * "exactly one" is asserted directly rather than inferred from a status code.
+   * `on()` is a no-op registrar: `handlePermissionRequest`'s end handler attaches
+   * `res.on('close')`, and these tests exercise the window before it fires.
+   */
   function fakeRes() {
     return {
       statusCode: null,
       headersSent: false,
       body: '',
-      writeHead(status) { this.statusCode = status; this.headersSent = true; return this },
+      writeHeadCalls: 0,
+      writeHead(status) {
+        if (this.headersSent) {
+          throw Object.assign(new Error('Cannot write headers after they are sent to the client'), { code: 'ERR_HTTP_HEADERS_SENT' })
+        }
+        this.writeHeadCalls++
+        this.statusCode = status
+        this.headersSent = true
+        return this
+      },
       end(chunk) { if (chunk) this.body += chunk; return this },
+      on() { return this },
     }
   }
 
@@ -713,11 +770,56 @@ describe('POST /permission-floor: a request-stream error is handled, not thrown 
         // A late 'end' after the error must not produce a second response.
         req.emit('end')
         assert.equal(res.statusCode, 400, 'no double response')
+        assert.equal(res.writeHeadCalls, 1, 'exactly one response was written')
       } finally {
         handler.destroy()
       }
     })
   }
+
+  // The OTHER ordering, and the one that matters on /permission: the body ends
+  // normally, so the end handler registers a pendingPermissions entry and DEFERS
+  // the response for up to five minutes while the prompt sits on the user's phone
+  // — and THEN the request stream errors. Answering a 400 deny there would send a
+  // second response on a socket the pending entry still owns (the later resolve()
+  // throws ERR_HTTP_HEADERS_SENT on the #5313 tick that reaches uncaughtException)
+  // AND deny, from a transient stream error, a request the user is still looking
+  // at. Post-'end' teardown belongs to req 'aborted' / res 'close' → onClose.
+  it('/permission ignores a stream error that arrives AFTER the body ended (the pending prompt owns the response)', async () => {
+    const pendingPermissions = new Map()
+    const handler = makeHandler({ pendingPermissions })
+    try {
+      const req = fakeReq()
+      const res = fakeRes()
+      handler.handlePermissionRequest(req, res)
+      // A COMPLETE body this time, delivered and ended through the real stream so
+      // the handler's own 'end' listener runs before this test continues.
+      const ended = new Promise((resolve) => req.on('end', resolve))
+      req.end(JSON.stringify({ tool_name: 'Read', tool_input: { file_path: 'src/index.js' }, cwd: CWD }))
+      await ended
+
+      assert.equal(pendingPermissions.size, 1, 'the body ended cleanly, so a permission is pending')
+      assert.equal(res.writeHeadCalls, 0, 'and its response is deferred until the user answers')
+
+      assert.doesNotThrow(
+        () => req.emit('error', Object.assign(new Error('aborted by peer'), { code: 'ECONNRESET' })),
+        'a post-end stream error must not throw',
+      )
+      assert.equal(res.writeHeadCalls, 0, 'and must NOT answer — the pending prompt still owns this response')
+      assert.equal(pendingPermissions.size, 1, 'nor abandon the pending entry')
+
+      // The user then answers on their phone: still exactly ONE response, and it
+      // is their decision — not a deny synthesised from the stream error.
+      const [requestId] = [...pendingPermissions.keys()]
+      assert.doesNotThrow(() => handler.resolvePermission(requestId, 'allow'), 'resolving must not double-respond')
+      assert.equal(res.writeHeadCalls, 1, 'exactly one response')
+      assert.equal(res.statusCode, 200)
+      assert.deepEqual(JSON.parse(res.body), { decision: 'allow' })
+      assert.equal(pendingPermissions.size, 0, 'and the entry is cleaned up')
+    } finally {
+      handler.destroy()
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/server/tests/permission-hook-floor.test.js
+++ b/packages/server/tests/permission-hook-floor.test.js
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
 import { createServer } from 'node:http'
+import { PassThrough } from 'node:stream'
 
 import { createPermissionHandler, evaluateHookFloorRequest } from '../src/ws-permissions.js'
 import { PermissionManager } from '../src/permission-manager.js'
@@ -93,7 +94,7 @@ function decisionOf(stdout) {
  * serving both routes the hook talks to. `promptDecision` is what the "user on
  * their phone" answers when a prompt is raised.
  */
-async function startRealDaemon({ promptDecision = 'allow', sessionCwd = CWD } = {}) {
+async function startRealDaemon({ promptDecision = 'allow', sessionCwd = CWD, resolveSession = true } = {}) {
   const stats = { floorRequests: 0, permissionRequests: 0, prompts: [] }
   const pendingPermissions = new Map()
   let handler
@@ -114,8 +115,11 @@ async function startRealDaemon({ promptDecision = 'allow', sessionCwd = CWD } = 
     getSessionManager: () => null,
     pairingManager: null,
     // The cwd basis: the owning session, exactly like the production lookup.
+    // `resolveSession: false` models the one production shape where the lookup
+    // CANNOT succeed — _validateHookAuth's primary-token fallback (no hook
+    // secrets registered) — which is the #7020 under-floor window.
     findSessionByHookSecret: (secret) => (
-      secret === HOOK_SECRET ? { session: { cwd: sessionCwd }, sessionId: 'sess-1' } : null
+      (resolveSession && secret === HOOK_SECRET) ? { session: { cwd: sessionCwd }, sessionId: 'sess-1' } : null
     ),
   })
   const server = createServer((req, res) => {
@@ -253,11 +257,27 @@ describe('evaluateHookFloorRequest — the hook path\'s floor verdict (#7004)', 
 
   it('FAILS CLOSED when no cwd can be resolved (never falls back to the daemon cwd)', () => {
     const payload = { tool_name: 'Read', tool_input: { file_path: 'src/a.js' } }
-    assert.equal(evaluateHookFloorRequest(payload, null).floor, true, 'no session cwd + no payload cwd → prompt')
-    // The payload's own cwd is the documented fallback when the session is not
-    // resolvable, and it must actually be used (not ignored).
-    assert.equal(evaluateHookFloorRequest({ ...payload, cwd: CWD }, null).floor, false)
-    assert.equal(evaluateHookFloorRequest({ ...payload, cwd: CWD, tool_input: { file_path: '.env' } }, null).floor, true)
+    assert.equal(evaluateHookFloorRequest(payload, null).floor, true, 'no session cwd → prompt')
+  })
+
+  // #7020 — the payload's own `cwd` used to be the documented fallback when the
+  // owning session was not resolvable. It is a CALLER-CHOSEN resolution base, so
+  // it can UNDER-floor in exactly the way the (deliberately absent)
+  // `process.cwd()` fallback would: point it AT the protected directory and the
+  // relative scan sees nothing protected.
+  it('IGNORES the payload cwd entirely — a caller-chosen base cannot un-floor a target (#7020)', () => {
+    // The concrete under-floor from the #7016 security review: the target sits
+    // inside `.git`, but the payload names `.git` itself as the resolution base,
+    // so the relative scan only ever sees `config`.
+    const underFloor = { tool_name: 'Read', tool_input: { file_path: '/repo/.git/config' }, cwd: '/repo/.git' }
+    assert.equal(
+      evaluateHookFloorRequest(underFloor, null).floor,
+      true,
+      'a payload-chosen cwd must not clear a target inside .git',
+    )
+    // The generic form: no resolvable session → prompt, whatever cwd the caller sent.
+    const ordinary = { tool_name: 'Read', tool_input: { file_path: 'src/a.js' }, cwd: CWD }
+    assert.equal(evaluateHookFloorRequest(ordinary, null).floor, true, 'unresolvable session → prompt')
   })
 
   it('prefers the SESSION cwd over the payload cwd (same basis as the in-process path)', () => {
@@ -542,7 +562,166 @@ describe('permission-hook.sh: floor clearance is a real JSON parse, not a substr
 })
 
 // ---------------------------------------------------------------------------
-// 3c. Reaching the daemon from a container
+// 3c. #7020 — the three remaining fail-OPEN edges on the floor probe
+// ---------------------------------------------------------------------------
+
+describe('permission-hook.sh: the pre-filter only skips the probe on a COMPLETE payload (#7020)', () => {
+  let daemon
+
+  afterEach(async () => {
+    if (daemon) await daemon.close()
+    daemon = null
+  })
+
+  // The pre-filter's soundness argument ("a payload naming no path field
+  // provably cannot be floored") holds only for a payload that is actually
+  // COMPLETE. An empty or truncated body used to take the same `return 1` and
+  // auto-allow under `auto` — the one place the negative filter could fail OPEN.
+  const incompletePayloads = [
+    ['an EMPTY payload', ''],
+    ['a payload truncated before the path key', '{"tool_name":"Read","tool_in'],
+    ['a payload truncated mid-object', '{"tool_name":"Read","tool_input":{"fi'],
+  ]
+
+  for (const [label, payload] of incompletePayloads) {
+    it(`auto + ${label} → routes to a PROMPT, never a silent allow`, async () => {
+      daemon = await startRealDaemon({ promptDecision: 'allow' })
+      const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto' })
+      // No probe is needed: a body that is not a complete JSON object carries no
+      // proof of anything, so the hook leaves the auto-allow path directly. That
+      // is strictly stronger than probing — it holds even if the daemon is down.
+      assert.equal(daemon.stats.permissionRequests, 1, 'an incomplete payload must leave the auto-allow path')
+      // /permission cannot parse it either, so it answers a 400 deny — the tool
+      // is BLOCKED. The one thing that must never happen is a silent allow.
+      assert.equal(decisionOf(stdout).permissionDecision, 'deny', 'and an unparseable payload is denied, never allowed')
+    })
+  }
+
+  // A `\uXXXX` escape is the ONLY JSON escape that can spell a path-field key
+  // (`"\u0066ile_path"` parses to `file_path`), so the byte-level pre-filter
+  // misses what the server's JSON-semantic lookup finds. This payload IS complete
+  // and well-formed, so only the daemon can answer it — the hook must probe.
+  it('auto + a \\u-escaped path key → PROBES and routes to a PROMPT, never a silent allow', async () => {
+    daemon = await startRealDaemon({ promptDecision: 'allow' })
+    const payload = '{"tool_name":"Read","tool_input":{"\\u0066ile_path":".env"},"cwd":"/work/project"}'
+    const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto' })
+    assert.equal(daemon.stats.floorRequests, 1, 'a byte-level miss must not be read as "cannot be floored"')
+    assert.equal(daemon.stats.permissionRequests, 1, 'and the escaped .env read must reach the user')
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow', 'the user then answered')
+  })
+
+  it('a WELL-FORMED path-less payload still skips the probe (no new latency on the fast path)', async () => {
+    daemon = await startRealDaemon()
+    // Carries `\n` and `\"` escapes — the common Bash shapes. Neither can spell a
+    // path-field key, so the fast path must be preserved for them: only `\u` probes.
+    const { stdout } = await runHook({
+      payload: { tool_name: 'Bash', tool_input: { command: 'printf "a\nb"\nls -la' }, cwd: CWD },
+      port: daemon.port,
+      mode: 'auto',
+    })
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow')
+    assert.equal(daemon.stats.floorRequests, 0, 'a complete path-less payload is still proven un-floorable')
+    assert.equal(daemon.stats.permissionRequests, 0)
+  })
+})
+
+describe('POST /permission-floor: the cwd basis is the OWNING SESSION only (#7020)', () => {
+  let daemon
+
+  afterEach(async () => {
+    if (daemon) await daemon.close()
+    daemon = null
+  })
+
+  it('auto + an unresolvable owning session → PROMPTS (the payload cwd is not a resolution base)', async () => {
+    // Models _validateHookAuth's primary-token fallback: auth passes, but the
+    // hook-secret → session lookup necessarily returns nothing, so the handler
+    // used to fall back to the payload's own `cwd` — a caller-chosen base.
+    daemon = await startRealDaemon({ resolveSession: false, promptDecision: 'allow' })
+    const { stdout } = await runHook({ payload: readPayload('src/index.js'), port: daemon.port, mode: 'auto' })
+    assert.equal(daemon.stats.floorRequests, 1)
+    assert.equal(daemon.stats.permissionRequests, 1, 'no resolvable session cwd must fail CLOSED')
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow', 'the user then answered')
+  })
+
+  it('a resolvable owning session still clears an ordinary file with zero prompts', async () => {
+    daemon = await startRealDaemon()
+    const { stdout } = await runHook({ payload: readPayload('src/index.js'), port: daemon.port, mode: 'auto' })
+    assert.equal(daemon.stats.floorRequests, 1)
+    assert.equal(daemon.stats.permissionRequests, 0)
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow')
+  })
+})
+
+describe('POST /permission-floor: a request-stream error is handled, not thrown (#7020)', () => {
+  /** The handler under test with nothing but the plumbing it actually touches. */
+  function makeHandler() {
+    return createPermissionHandler({
+      sendFn: () => {},
+      broadcastFn: () => {},
+      validateBearerAuth: () => true,
+      validateHookAuth: () => true,
+      pushManager: null,
+      pendingPermissions: new Map(),
+      permissionSessionMap: new Map(),
+      getSessionManager: () => null,
+      pairingManager: null,
+      findSessionByHookSecret: () => ({ session: { cwd: CWD }, sessionId: 'sess-1' }),
+    })
+  }
+
+  function fakeReq() {
+    const req = new PassThrough()
+    req.headers = { authorization: `Bearer ${HOOK_SECRET}` }
+    req.socket = { remoteAddress: '203.0.113.7' }
+    return req
+  }
+
+  function fakeRes() {
+    return {
+      statusCode: null,
+      headersSent: false,
+      body: '',
+      writeHead(status) { this.statusCode = status; this.headersSent = true; return this },
+      end(chunk) { if (chunk) this.body += chunk; return this },
+    }
+  }
+
+  // An `error` event on a stream with NO listener is an unhandled 'error' —
+  // `emit` rethrows it, which on the real server escapes to uncaughtException.
+  // mailbox-route.js and github-webhook.js both attach one; these two capped
+  // readers did not.
+  for (const [label, route] of [['/permission-floor', 'handlePermissionFloorCheck'], ['/permission', 'handlePermissionRequest']]) {
+    it(`${label} attaches an error listener and answers fail-closed on a mid-body abort`, () => {
+      const handler = makeHandler()
+      try {
+        const req = fakeReq()
+        const res = fakeRes()
+        handler[route](req, res)
+        req.write('{"tool_name":"Read","tool_i')
+        assert.doesNotThrow(
+          () => req.emit('error', Object.assign(new Error('aborted by peer'), { code: 'ECONNRESET' })),
+          'an aborted request body must not throw an unhandled stream error',
+        )
+        assert.equal(res.statusCode, 400, 'the aborted request gets a fail-closed response')
+        const parsed = JSON.parse(res.body)
+        if (route === 'handlePermissionFloorCheck') {
+          assert.equal(parsed.floor, true, 'a stream error answers floor:true (prompt), never floor:false')
+        } else {
+          assert.equal(parsed.decision, 'deny', 'a stream error denies, never allows')
+        }
+        // A late 'end' after the error must not produce a second response.
+        req.emit('end')
+        assert.equal(res.statusCode, 400, 'no double response')
+      } finally {
+        handler.destroy()
+      }
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// 3d. Reaching the daemon from a container
 // ---------------------------------------------------------------------------
 
 describe('permission-hook.sh: the callback host is not hardcoded to localhost (#7004)', () => {


### PR DESCRIPTION
Three narrow edges on the #7016/#7017 hook-routed permission floor where the path resolved toward "allow" (or toward an unhandled stream error) instead of the fail-closed default the rest of the design uses. None was reachable by a model or a remote client; the point is that the invariant — *any ambiguity, error, empty response, or unparseable response fails CLOSED* — should hold on its own semantics, not on assumptions about a producer or a caller.

The #7017 clearance design is untouched: `floor_forces_prompt` still counts `"floor"` occurrences and rejects unless there is **exactly one before parsing**, then parses via `node -e`, requires a plain object, and requires `parsed.floor === false`.

## 1. `hooks/permission-hook.sh` — the negative pre-filter needs a complete, escape-free payload

The pre-filter is sound only over a payload that is actually complete and unescaped:

- **Empty / truncated body.** An empty `$REQUEST`, or one truncated before the path key, took the same `return 1` ("cannot be floored") and auto-allowed under `auto`.
- **Escaped path key.** The pre-filter is a **byte-level substring scan** while the daemon does a **JSON-semantic** field lookup. A key spelled with a `\u` escape of `f` (`f` + `ile_path`) parses to `file_path` server-side but never matches `*'"file_path"'*`, so the probe was skipped and the target auto-allowed.

Two guards, both resolving toward fail-closed. **What each one proves — and only that:**

1. **Last-byte shape check.** A payload whose last non-whitespace byte is not `}` is definitely not a JSON object, so it proves nothing about path fields and leaves the auto-allow path **directly** — no probe, so the guard holds even when the daemon is unreachable. (`route_to_phone` then POSTs it to `/permission`, which cannot parse it either and answers its own 400 deny — the tool is blocked.) That catches the two shapes that motivated the guard: an **empty** body and a **prefix** truncation. It is **not** a completeness check — a truncation that happens to land on a `}` (`…,"permission_suggestions":{}`) still looks complete to it and still skips the probe. Residual tracked in **#7043**.
   Trailing whitespace is trimmed before the check, because `REQUEST=$(cat -)` strips trailing *newlines* only: a `}\r\n`- or `} `-terminated payload would otherwise fail the check and route **every** `auto` / `acceptEdits` call to a phone prompt. Fail-closed, but it would destroy the lenient modes — now pinned by tests.
2. **`\u` escape → probe.** `\uXXXX` is the only **valid** JSON escape that can spell one of these keys — the rest of the grammar (`\" \\ \/ \b \f \n \r \t`) yields none of `[a-z_]` — so probing on `\u` closes the **valid-escape key-spelling** gap on the floor's own semantics rather than on an assumption that the producer's serializer leaves ASCII keys unescaped. An **invalid** escape (`\U`, `\x`) is *not* covered: it matches neither the key literals nor this arm, so the pre-filter still takes `return 1` and the daemon is never asked. The byte-scan-vs-semantic-lookup divergence therefore survives for bodies no JSON parser would accept. Also **#7043**.

Both residuals need a producer that emits a truncated or non-JSON payload, so neither is model- or remote-reachable — the same class as everything else here. They are now recorded as limits in `docs/security/permission-floor.md` §5 instead of being claimed as closed.

A `\n` / `\"`-only payload (the common `Bash` shape) keeps the no-round-trip fast path — pinned by a test.

## 2. `evaluateHookFloorRequest` — drop the payload-`cwd` fallback

The doc block correctly explained why there is no `process.cwd()` fallback ("resolving a relative target against the wrong root could UNDER-floor") — but the payload-supplied `cwd` is a **caller-chosen** resolution base and under-floors in exactly the same way. Naming the protected directory itself as the base makes the relative segment scan see nothing protected: target `/repo/.git/config` with `cwd: "/repo/.git"` scans just `config` and answers `floor: false`.

The owning session's `cwd` is now the only accepted basis; an unresolvable session answers `{ floor: true, reason: 'no resolvable session cwd' }`.

Nothing legitimate loses a basis. `session.cwd` is always a real string (`BaseSession` sets `cwd || process.cwd()`), including legacy single-session mode where `_findSessionByHookSecret` returns `{ session, sessionId: null }`. The only shape this now rejects is the one the issue identified: `_validateHookAuth` taking its **primary-token fallback** (no hook secrets registered), where the hook-secret lookup necessarily fails and the payload's `cwd` was then trusted.

## 3. `req.on('error')` on the capped body readers

`handlePermissionFloorCheck` attached `data` and `end` but no `error`. An `error` event on a stream with **no** listener rethrows, escaping to `uncaughtException` — a crash risk on a mid-body client abort. `handlePermissionRequest` had the same omission, so both now match the pattern `mailbox-route.js` and `github-webhook.js` already use: the floor route answers `{ floor: true }`, `/permission` answers a deny, and a `streamFailed` flag stops a late `end` from double-responding.

**`/permission` also guards the reverse ordering.** That route's `end` handler is the one capped reader that does *not* respond: it registers a `pendingPermissions` entry and **defers** the response for up to five minutes while the prompt sits on the user's phone. So an `error` arriving *after* `end` must be a no-op — otherwise it (a) sends a second response on a socket the pending entry still owns, and the later `resolve()` throws `ERR_HTTP_HEADERS_SENT` on the #5313 tick that reaches `uncaughtException`, and (b) **denies**, from a transient stream error, a request the user is still looking at, while leaving the pending entry alive. An `ended` flag set at the top of the `end` handler hands post-body teardown back to the existing `req 'aborted'` / `res 'close'` → `onClose` path.

`handlePermissionFloorCheck` needs no such flag, and that was verified rather than assumed: its `end` handler answers **synchronously** on every branch (200, the 400 on an unparseable body, the 500 from its catch), so once it has run `res.headersSent` is already true and a later `error` takes the `res.end()` no-op arm. A comment records the asymmetry so it is not read as an omission.

## Verification

Every test was proven RED against the pre-fix source (revert the source, watch it fail, restore) — no source change, no green test.

`packages/server/tests/permission-hook-floor.test.js`: **93/93 pass** post-fix.

**Pre-fix RED — the `ended` guard.** Reverting only that guard in `handlePermissionRequest`:

```
not ok 3 - /permission ignores a stream error that arrives AFTER the body ended (the pending prompt owns the response)
  error: 'and must NOT answer — the pending prompt still owns this response'
  1 !== 0
# tests 93 / # pass 92 / # fail 1
```

The same revert, driven directly against the real handler, shows the full cascade the test now blocks:

```
after end:    pending=1 writeHeadCalls=0 statusCode=null
after error:  pending=1 writeHeadCalls=1 statusCode=400 body={"decision":"deny"}
resolve() THREW: ERR_HTTP_HEADERS_SENT — Cannot write headers after they are sent  (DOUBLE RESPONSE)
```

Post-fix, same script: `after error: writeHeadCalls=0 statusCode=null` → `after resolve: writeHeadCalls=1 statusCode=200 body={"decision":"allow"} pending=0 (no throw)`.

The fixture had to be fixed before it could see any of that: `fakeRes().writeHead` now **throws on a second call**, exactly as a real `ServerResponse` does, and counts responses (`writeHeadCalls`) so "exactly one response" is asserted directly rather than inferred from a status code. The previous fixture accepted a double response silently and only ever emitted `'error'` *before* `end`, so it was blind to this ordering.

**Pre-fix RED — the trailing-whitespace trim.** Reverting only the trim in the hook:

```
not ok 5 - auto + an ordinary path-less call terminated by CRLF is still auto-allowed with no round trip
not ok 6 - auto + an ordinary path-less call terminated by a trailing space is still auto-allowed with no round trip
not ok 7 - auto + an ordinary path-less call terminated by a tab + CRLF is still auto-allowed with no round trip
not ok 8 - trimming trailing whitespace does not skip the probe for a payload that DOES name a path
# tests 93 / # pass 89 / # fail 4
```

Driven against the real hook + real handler, a `}\r\n`-terminated ordinary `Bash ls` went from `floorRequests=0, permissionRequests=1` (a full round trip to the phone for every lenient-mode tool call) to `floorRequests=0, permissionRequests=0`.

**Pre-fix RED — the original three edges** (whole change reverted, 8 failing subtests):

```
not ok 9 - IGNORES the payload cwd entirely — a caller-chosen base cannot un-floor a target (#7020)
not ok 1 - auto + an EMPTY payload → routes to a PROMPT, never a silent allow
not ok 2 - auto + a payload truncated before the path key → routes to a PROMPT, never a silent allow
not ok 3 - auto + a payload truncated mid-object → routes to a PROMPT, never a silent allow
not ok 4 - auto + a \u-escaped path key → PROBES and routes to a PROMPT, never a silent allow
not ok 1 - auto + an unresolvable owning session → PROMPTS (the payload cwd is not a resolution base)
not ok 1 - /permission-floor attaches an error listener and answers fail-closed on a mid-body abort
not ok 2 - /permission attaches an error listener and answers fail-closed on a mid-body abort
```

Isolated per edge: reverting *only* `hooks/permission-hook.sh` fails exactly the 4 pre-filter tests; reverting *only* `src/ws-permissions.js` fails exactly the cwd + stream tests. Pre-fix the stream test fails *because `req.emit('error', …)` throws* — `assert.doesNotThrow` reports `error: 'aborted by peer'` — which is the defect itself, not a proxy for it.

**Residuals re-verified against this head, and NOT claimed as fixed** (real hook → real handler):

```
{"tool_name":"Read","tool_input":{"\U0066ile_path":".env"},...}                 → allow, floorRequests=0, permissionRequests=0
{"session_id":"s","hook_event_name":"PreToolUse","permission_suggestions":{}    → allow, floorRequests=0, permissionRequests=0
```

Both are **#7043**. The hook comment, `docs/security/permission-floor.md` (§4 rule 2, plus a new §5 limit) and this body now describe exactly what the guards prove.

**Existing behaviour that had to change.** One pre-existing assertion asserted the payload-`cwd` fallback *was* used (`evaluateHookFloorRequest({ ...payload, cwd: CWD }, null).floor === false`). That is the fail-open behaviour being fixed, so it is now inverted, and the surrounding case is covered by the new under-floor test.

**No over-blocking regression.** Retained/added green assertions: an ordinary file with a resolvable session still clears with **zero prompts**; a complete path-less payload (with `\n` and `\"` escapes) still skips the probe entirely; a `}\r\n` / `} ` / `}\t\r\n`-terminated ordinary call still auto-allows with no round trip; a path-naming payload with a trailing CRLF still probes; and the full #7004/#7017 fail-closed and parity suites are unchanged.

**Doc contract corrected** (Copilot review): the `POST /permission-floor` response row now lists the real shapes — `200` is exactly `{ "floor": true|false }` and the only status that can carry `false`; `400`/`413` → `{ floor: true }`, `429` → `{ error, floor: true, retryAfterMs }`, `500` → `{ error, floor: true }`, and `403` → `{ error: 'unauthorized' }` with no `floor` key at all, which the hook treats like every other non-`false` answer: prompt.

**Commands a reviewer can re-run** (from `packages/server`):

```bash
PATH="/opt/homebrew/opt/node@22/bin:$PATH" CHROXY_CRED_DISABLE_KEYCHAIN=1 \
  node --import ./tests/_setup.mjs --test-force-exit --test ./tests/permission-hook-floor.test.js

# c8 force-exit trap: must self-exit WITHOUT --test-force-exit
PATH="/opt/homebrew/opt/node@22/bin:$PATH" CHROXY_CRED_DISABLE_KEYCHAIN=1 \
  node --import ./tests/_setup.mjs --experimental-test-module-mocks --test ./tests/permission-hook-floor.test.js
# → exit 0 in ~4s, no leaked handle

for f in scripts/lint-*.sh; do bash "$f"; done   # all 5 OK
bash -n hooks/permission-hook.sh                 # syntax OK
npx eslint src/ws-permissions.js                 # clean
```

**Full `packages/server` suite.** Run at this head and at the pre-review-fix commit on the same machine: **identical** failing-file lists (117 files, `diff`-clean) and 203 failing subtests both times; test count 9689 → 9694 (the 5 new tests). `permission-hook-floor.test.js` is not among the failures — its suites are green in both runs. Those failures are the known local environment gap — `@anthropic-ai/claude-agent-sdk` is not installed here, so files importing `sdk-session.js` fail to *load* with `ERR_MODULE_NOT_FOUND` — not a code regression. CI has the dependency and is the authority on the suite being green.

Closes #7020
