### PR TITLE
fix(server): write MCP config through a symlink instead of replacing it

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -9,6 +9,7 @@
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   readFileSync,
   realpathSync,
   renameSync,
@@ -909,6 +910,120 @@ export function readClaudeConfigForMutation(filePath) {
 }
 
 /**
+ * #7002 — resolve the path the atomic write must actually LAND on.
+ *
+ * The write is `writeFileSync(tmp)` → `renameSync(tmp, dest)`, and `rename(2)`
+ * replaces the FINAL PATH COMPONENT itself. If that component is a symlink — the
+ * common dotfiles-repo arrangement, `~/.claude.json` → `~/dotfiles/claude.json` —
+ * the rename destroys the LINK and leaves a regular file in its place: the user's
+ * dotfiles link silently disappears and their real config stops receiving
+ * updates. (The read path follows the link, so nothing complains.) So a symlinked
+ * destination must be resolved to its target and written THERE.
+ *
+ * TRUST ASSUMPTION, stated plainly: `~/.claude.json` and any link the user has
+ * put in its place are USER-OWNED, USER-AUTHORED configuration. We follow the
+ * link because a user who symlinked their own config meant it. What we do NOT do
+ * is follow it blindly — resolving a symlink and writing to whatever it points at
+ * is precisely how a planted link turns "write my config" into "write an arbitrary
+ * file", so the resolved target must satisfy all of:
+ *
+ *   - it resolves at all (a DANGLING link is refused, not materialized — creating
+ *     the missing target would be us inventing a file at an attacker-chosen path)
+ *   - it is a REGULAR file (no directory, fifo, socket or device)
+ *   - it is owned by the uid we run as (a link into another user's file is refused)
+ *
+ * RACE HONESTY: resolution happens ONCE, and the subsequent `rename` re-walks the
+ * path by name, so an attacker who can replace the link between the two syscalls
+ * can still redirect the write (classic TOCTOU). This is NOT closed here — POSIX
+ * offers no "rename onto this exact inode" primitive to close it with. The
+ * residual exposure requires write access to the user's own `$HOME`, which is
+ * already game over for a config the daemon reads and executes commands from;
+ * see the follow-up issue referenced in the PR for a fully race-free design.
+ *
+ * @param {string} filePath
+ * @returns {{ ok: true, path: string, viaSymlink: boolean } | { ok: false, error: string }}
+ */
+export function resolveClaudeConfigWritePath(filePath) {
+  let link
+  try {
+    link = lstatSync(filePath)
+  } catch {
+    // Missing (the first-write case) or unstattable — write the path as given,
+    // exactly as before this fix.
+    return { ok: true, path: filePath, viaSymlink: false }
+  }
+  if (!link.isSymbolicLink()) return { ok: true, path: filePath, viaSymlink: false }
+
+  let resolved
+  try {
+    resolved = realpathSync(filePath)
+  } catch (err) {
+    return {
+      ok: false,
+      error: `${filePath} is a symlink whose target cannot be resolved (${err?.code || err?.message || String(err)}); refusing to replace the link with a regular file. Fix or remove the link, then retry.`,
+    }
+  }
+  let target
+  try {
+    target = lstatSync(resolved)
+  } catch (err) {
+    return {
+      ok: false,
+      error: `${filePath} is a symlink to ${resolved}, which cannot be stat'd (${err?.code || err?.message || String(err)}); refusing to write through it.`,
+    }
+  }
+  if (!target.isFile()) {
+    return {
+      ok: false,
+      error: `${filePath} is a symlink to ${resolved}, which is not a regular file; refusing to write through it.`,
+    }
+  }
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  if (uid !== null && target.uid !== uid) {
+    return {
+      ok: false,
+      error: `${filePath} is a symlink to ${resolved}, which is owned by uid ${target.uid} rather than uid ${uid}; refusing to write through it.`,
+    }
+  }
+  return { ok: true, path: resolved, viaSymlink: true }
+}
+
+/**
+ * #7002 — the residual risk of PRESERVING a destination's mode.
+ *
+ * `writeClaudeConfigAtomic` deliberately does not force 0600 on a file the user
+ * (or Claude Code) already owns. That is the right call for permissions, but it
+ * leaves one case where Chroxy is the party making things worse: an existing
+ * config that is group/world-readable, plus a new entry carrying `env` or
+ * `headers` — the two fields that routinely hold API tokens. We do not silently
+ * re-permission the file; we say so loudly instead, naming the file and its mode,
+ * so the user can tighten it themselves.
+ *
+ * Returns `null` when there is nothing to warn about (owner-only mode, no
+ * secret-bearing field, or a file WE created — those get 0600). The message never
+ * echoes a secret VALUE, only the field names.
+ *
+ * @param {{ filePath: string, mode: number|null|undefined, entry: object }} args
+ * @returns {string|null}
+ */
+export function describeConfigModeSecretWarning({ filePath, mode, entry } = {}) {
+  if (mode === null || mode === undefined) return null
+  const otherBits = mode & 0o077
+  if (otherBits === 0) return null
+  const fields = ['env', 'headers'].filter((key) => {
+    const value = entry?.[key]
+    return value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0
+  })
+  if (fields.length === 0) return null
+  const octal = (mode & 0o777).toString(8).padStart(3, '0')
+  return (
+    `${filePath} is mode ${octal} (readable beyond its owner) and the MCP server entry just added carries ` +
+    `${fields.join(' and ')}, which commonly hold API tokens. Chroxy preserved the file's existing permissions ` +
+    `rather than changing them — tighten it yourself with: chmod 600 ${filePath}`
+  )
+}
+
+/**
  * Atomically write the mutated config back.
  *
  * temp file → exact mode → fsync(file) → rename → fsync(parent dir), the same
@@ -925,16 +1040,27 @@ export function readClaudeConfigForMutation(filePath) {
  * path because one code path is cheaper to keep correct than two, and the cost
  * (one fsync of a few KB, on an operation a user performs rarely) is noise.
  *
+ * A SYMLINKED destination is written THROUGH (the link survives, its target gets
+ * the bytes) or refused — never replaced. See `resolveClaudeConfigWritePath` for
+ * the trust assumption and the race caveat (#7002).
+ *
  * @param {string} filePath
  * @param {object} value — the full config object to serialize
  * @param {{ mode: number|null }} opts — `null` mode = new file, use 0600
  */
 export function writeClaudeConfigAtomic(filePath, value, { mode }) {
+  const resolved = resolveClaudeConfigWritePath(filePath)
+  if (!resolved.ok) throw new Error(resolved.error)
+  // Everything below targets the RESOLVED path: the sidecar has to live in the
+  // target's directory (rename is only atomic within one filesystem, and a
+  // dotfiles target is frequently on a different one from $HOME), and the
+  // dir-fsync has to be the target's directory too.
+  const destPath = resolved.path
   const payload = `${JSON.stringify(value, null, 2)}\n`
   const targetMode = mode === null || mode === undefined ? 0o600 : mode
   // Per-call random suffix, NOT process.pid: concurrent sessions in one daemon
   // share a pid and would race for the same sidecar path (#3922).
-  const tmpPath = `${filePath}.chroxy.${randomUUID()}.tmp`
+  const tmpPath = `${destPath}.chroxy.${randomUUID()}.tmp`
   try {
     // `mode` is only honoured on create, and umask can strip bits from it — so
     // restate the exact mode afterwards. The intermediate mode can only ever be
@@ -954,13 +1080,13 @@ export function writeClaudeConfigAtomic(filePath, value, { mode }) {
   // ORIGINAL rename error, not a cleanup-side ENOENT. Same shape as the #4463 fix
   // in byok-mcp-trust.js `recordTrust`.
   try {
-    renameSync(tmpPath, filePath)
+    renameSync(tmpPath, destPath)
   } catch (err) {
     try { unlinkSync(tmpPath) } catch { /* may already be gone */ }
     throw err
   }
   // Make the rename itself durable, not just the bytes it points at.
-  fsyncForDurability(dirname(filePath), { isDir: true })
+  fsyncForDurability(dirname(destPath), { isDir: true })
 }
 
 /**
@@ -1110,14 +1236,24 @@ export function planAddMcpServerToConfig(opts = {}) {
  * @param {'user'|'project'} [opts.scope]
  * @param {string} [opts.cwd] — required for scope 'project'
  * @param {string} [opts.configPath]
- * @returns {{ ok: true, entry: object, scope: string } | { ok: false, error: string, code?: string }}
+ * @returns {{ ok: true, entry: object, scope: string, warning?: string } | { ok: false, error: string, code?: string }}
  */
 export function addMcpServerToConfig(opts = {}) {
   const prepared = prepareAddMcpServer(opts)
   if (!prepared.ok) return prepared.code ? { ok: false, error: prepared.error, code: prepared.code } : { ok: false, error: prepared.error }
   prepared.block[prepared.name] = prepared.entry
   writeClaudeConfigAtomic(prepared.configPath, prepared.raw, { mode: prepared.mode })
-  return { ok: true, entry: prepared.entry, scope: prepared.scope }
+  // #7002: computed from the mode we just PRESERVED and the entry we just wrote,
+  // so it only fires when Chroxy is the party that put secret material into a
+  // group/world-readable file. Advisory — we still do not re-permission the file.
+  const warning = describeConfigModeSecretWarning({
+    filePath: prepared.configPath,
+    mode: prepared.mode,
+    entry: prepared.entry,
+  })
+  const result = { ok: true, entry: prepared.entry, scope: prepared.scope }
+  if (warning) result.warning = warning
+  return result
 }
 
 /**

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -1015,6 +1015,13 @@ export function resolveClaudeConfigWritePath(filePath) {
  */
 export function describeConfigModeSecretWarning({ filePath, mode, entry } = {}) {
   if (mode === null || mode === undefined) return null
+  // The trigger is the WHOLE `0o077` superset, not just the read bits, and the
+  // wording says "accessible" rather than "readable" to match it (review of
+  // #7040). Group/other WRITE is the sharper edge, not a lesser one: another
+  // local user who can rewrite `~/.claude.json` substitutes MCP server commands
+  // the daemon then spawns. Including the (meaningless-on-a-JSON-file) execute
+  // bit costs at most a harmless false positive on a pathological mode like
+  // 0o611, which is the right side to err on for a security advisory.
   const otherBits = mode & 0o077
   if (otherBits === 0) return null
   const fields = ['env', 'headers'].filter((key) => {
@@ -1024,7 +1031,7 @@ export function describeConfigModeSecretWarning({ filePath, mode, entry } = {}) 
   if (fields.length === 0) return null
   const octal = (mode & 0o777).toString(8).padStart(3, '0')
   return (
-    `${filePath} is mode ${octal} (readable beyond its owner) and the MCP server entry just added carries ` +
+    `${filePath} is mode ${octal} (accessible beyond its owner) and the MCP server entry just added carries ` +
     `${fields.join(' and ')}, which commonly hold API tokens. Chroxy preserved the file's existing permissions ` +
     `rather than changing them — tighten it yourself with: chmod 600 ${filePath}`
   )

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -4,6 +4,13 @@
  * Foundation only for #4048/#4076: parse Claude-style mcpServers blocks and
  * expose safe read-only metadata. This module deliberately does not spawn MCP
  * children or wire tools.
+ *
+ * NOT byok-only despite the filename: `resolveClaudeConfigWritePath` +
+ * `writeClaudeConfigAtomic` are the SINGLE writer for `~/.claude.json` across the
+ * whole server, and `claude-tui/pty-driver.js`'s `ensureCwdTrusted` goes through
+ * them too (#7046). A second hand-rolled `writeFileSync(tmp)` → `renameSync(tmp,
+ * config)` over this file is how the symlink-destroying / mode-widening defect
+ * came to exist in two places at once — add callers here, not copies.
  */
 
 import {
@@ -1043,6 +1050,12 @@ export function describeConfigModeSecretWarning({ filePath, mode, entry } = {}) 
  * A SYMLINKED destination is written THROUGH (the link survives, its target gets
  * the bytes) or refused — never replaced. See `resolveClaudeConfigWritePath` for
  * the trust assumption and the race caveat (#7002).
+ *
+ * SHARED, not byok-local: `claude-tui/pty-driver.js`'s `ensureCwdTrusted` (the
+ * DEFAULT provider's trust pre-write, which runs on far more start()s than any
+ * MCP mutation) commits through this function too (#7046). Callers that need
+ * "best effort" — a refusal must not fail session start — catch and log; callers
+ * that owe the user an answer surface the error.
  *
  * @param {string} filePath
  * @param {object} value — the full config object to serialize

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -835,6 +835,13 @@ export class ClaudeByokSession extends BaseSession {
     }
     if (!written.ok) return { ok: false, error: written.error, code: written.code }
 
+    // #7002: the config's existing mode is PRESERVED by design, so a
+    // group/world-readable `~/.claude.json` that just received `env`/`headers`
+    // (routinely API tokens) is a case where we are the party making things
+    // worse. Say so loudly in the daemon log — it never echoes a secret value —
+    // and hand it to the caller so a client can surface it too.
+    if (written.warning) log.warn(`BYOK MCP: ${written.warning}`)
+
     // Mirror the persisted entry into the in-memory config list. `entry` is the
     // NORMALIZED object that was actually written, so memory and disk cannot
     // diverge. Normalization is pure over (name, config), so this is structurally
@@ -854,7 +861,9 @@ export class ClaudeByokSession extends BaseSession {
     // the entry is persisted and `start()` will pick it up. Spinning a fleet up
     // here would duplicate start()'s wiring for no gain.
     this._emitMcpServers()
-    return { ok: true, status }
+    const result = { ok: true, status }
+    if (written.warning) result.warning = written.warning
+    return result
   }
 
   /**

--- a/packages/server/src/claude-tui/pty-driver.js
+++ b/packages/server/src/claude-tui/pty-driver.js
@@ -8,13 +8,18 @@
 // methods live on `PtyDriverMixin` and are copied onto ClaudeTuiSession.prototype
 // via applyMixin() in claude-tui-session.js, so `this` still refers to the
 // session instance and every `this._*` / static reference resolves as before.
-import { existsSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { randomUUID } from 'crypto'
 import { resolveBinary } from '../utils/resolve-binary.js'
 import { createLogger } from '../logger.js'
+// #7002/#7046 — the ONE writer for `~/.claude.json`. Deliberately shared with the
+// BYOK MCP add/remove path rather than re-implemented here: a second hand-rolled
+// `writeFileSync(tmp)` → `renameSync(tmp, ~/.claude.json)` is exactly how the
+// symlink-destroying, mode-widening bug survived in two places at once. Any new
+// caller that writes this file MUST come through here too.
+import { writeClaudeConfigAtomic } from '../byok-mcp-config.js'
 // Imported at call-time only (circular-safe): the writer methods read the
 // PROMPT_CHAR_DELAY_MS / MAX_THROTTLED_CHARS static getters off the class.
 import { ClaudeTuiSession } from '../claude-tui-session.js'
@@ -137,13 +142,27 @@ export const AUTH_REQUIRED_MESSAGE = 'Claude is not logged in (or the subscripti
 // block headless spawn. The dialog is interactive-only — without this, the
 // PTY would render "Is this a project you trust?" and wait for Enter.
 // Idempotent: if already trusted, no write.
+//
+// NOTE the path is `homedir()/.claude.json`, NOT `defaultClaudeConfigPath()`:
+// the point of this write is to be read by the `claude` binary we are about to
+// spawn, and it only ever reads `$HOME/.claude.json`. `CHROXY_CLAUDE_CONFIG`
+// redirects chroxy's own MCP-config reads, so honouring it here would silently
+// send the trust flags to a file claude never opens.
 export function ensureCwdTrusted(cwd) {
   const realCwd = realpathSync(cwd)
   const claudeConfig = join(homedir(), '.claude.json')
   let config = {}
+  // #7046: PRESERVE the destination's permissions. This write used to call
+  // `writeFileSync(tmp, ...)` with no `mode` and never chmod the sidecar, so the
+  // rename left `0666 & ~umask` (0644 under the usual umask) on a file that holds
+  // OAuth material — chroxy actively WIDENING a 0600 config on every start() that
+  // pre-trusts a cwd. `null` means "we are creating the file", and the shared
+  // writer then uses 0600.
+  let mode = null
   if (existsSync(claudeConfig)) {
     try {
       config = JSON.parse(readFileSync(claudeConfig, 'utf8'))
+      mode = statSync(claudeConfig).mode & 0o777
     } catch (err) {
       log.warn(`~/.claude.json unreadable, skipping trust pre-write: ${err.message}`)
       return
@@ -170,16 +189,24 @@ export function ensureCwdTrusted(cwd) {
     hasCompletedProjectOnboarding: true,
     projectOnboardingSeenCount: existing?.projectOnboardingSeenCount ?? 0,
   }
-  // Atomic write via temp + rename. Use a per-call random suffix rather
-  // than process.pid — concurrent ClaudeTuiSessions in the same chroxy
-  // server share the pid, so two start()s racing for a different cwd
-  // would clobber each other's temp file (#3922). The realpathSync()
-  // earlier in this function still means each session writes a
-  // different *target* path, but the temp file is global and needs to
-  // be unique per write.
-  const tmp = `${claudeConfig}.chroxy.${randomUUID()}.tmp`
-  writeFileSync(tmp, JSON.stringify(config, null, 2))
-  renameSync(tmp, claudeConfig)
+  // #7046: through the SHARED atomic writer, which (a) writes THROUGH a symlinked
+  // `~/.claude.json` instead of replacing the user's dotfiles link with a regular
+  // file, (b) preserves the mode we captured above rather than widening it, (c)
+  // still uses a per-call random sidecar suffix — concurrent ClaudeTuiSessions in
+  // one daemon share a pid and would race for the same temp path (#3922) — and
+  // (d) unlinks that sidecar if the rename throws, so a failed write cannot leave
+  // a full credential-bearing copy of the config lying in $HOME (#4463).
+  //
+  // Best-effort, like the unreadable-config branch above: a REFUSAL (a link we
+  // will not follow — dangling, non-regular, foreign-uid) or an I/O failure warns
+  // and skips the pre-write instead of failing session start. The degraded outcome
+  // is claude rendering its trust dialog; the alternative — destroying the link —
+  // is strictly worse.
+  try {
+    writeClaudeConfigAtomic(claudeConfig, config, { mode })
+  } catch (err) {
+    log.warn(`~/.claude.json not written, skipping trust pre-write: ${err.message}`)
+  }
 }
 
 // Build a settings.json that registers Stop + tool hooks. Claude pipes the

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -1200,6 +1200,11 @@ async function handleAddMcpServer(ws, client, msg, ctx) {
     sessionLogger(sessionId).info(
       `MCP server '${name}' added in ${scope} scope by ${client.id} on session ${sessionId} (status=${result.status})`,
     )
+    // #7002: a group/world-readable MCP config that just received env/headers.
+    // Operator-visible warning only — the message names the file and its mode and
+    // never echoes a secret value, and the add itself succeeded, so this must not
+    // turn into an error frame.
+    if (result.warning) sessionLogger(sessionId).warn(`MCP config permissions: ${result.warning}`)
   } catch (err) {
     sendError(ws, requestId, 'MCP_SERVER_ADD_NOT_APPLIED',
       `Failed to add MCP server '${name}': ${err?.message || String(err)}`, undefined, ctx)

--- a/packages/server/tests/byok-mcp-config-symlink-write.test.js
+++ b/packages/server/tests/byok-mcp-config-symlink-write.test.js
@@ -208,6 +208,22 @@ describe('#7002 group/world-readable config + newly written secrets', () => {
     assert.ok(!warning.includes('sk-secret'), 'the warning must never echo the secret value')
   })
 
+  it('warns on a group/other WRITE bit too, and the wording matches the trigger', () => {
+    // `mode & 0o077` covers write, not just read — and group/other write is the
+    // sharper edge: another local user who can rewrite the config substitutes MCP
+    // server commands the daemon spawns. The message must not claim "readable" for
+    // a mode that is write-only beyond the owner (review of #7040).
+    const warning = describeConfigModeSecretWarning({
+      filePath: '/home/u/.claude.json',
+      mode: 0o620,
+      entry: { command: 'node', env: { API_TOKEN: 't' } },
+    })
+    assert.ok(warning, 'a config another local user can REWRITE must warn')
+    assert.match(warning, /620/)
+    assert.match(warning, /accessible beyond its owner/)
+    assert.ok(!warning.includes('readable beyond its owner'), 'a 0620 config is not readable beyond its owner')
+  })
+
   it('warns for headers on a remote server entry', () => {
     const warning = describeConfigModeSecretWarning({
       filePath: '/home/u/.claude.json',

--- a/packages/server/tests/byok-mcp-config-symlink-write.test.js
+++ b/packages/server/tests/byok-mcp-config-symlink-write.test.js
@@ -30,6 +30,7 @@ import {
   readFileSync,
   readdirSync,
   readlinkSync,
+  realpathSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -41,6 +42,7 @@ import {
   addMcpServerToConfig,
   describeConfigModeSecretWarning,
   removeMcpServerFromConfig,
+  resolveClaudeConfigWritePath,
   writeClaudeConfigAtomic,
 } from '../src/byok-mcp-config.js'
 
@@ -106,10 +108,38 @@ describe('#7002 symlinked config: the write follows the link', () => {
     assert.deepEqual(sidecars(dotfilesDir), [])
   })
 
-  it('preserves the TARGET’s mode, not a fresh-file default', () => {
+  it('preserves the TARGET’s mode ON THE TARGET, with the link intact', () => {
     linkedConfig({ mcpServers: {} }, { mode: 0o640 })
-    addMcpServerToConfig({ name: 'srv', config: { command: 'node' }, configPath: linkPath })
-    assert.equal(statSync(targetPath).mode & 0o777, 0o640)
+
+    const res = addMcpServerToConfig({ name: 'srv', config: { command: 'node' }, configPath: linkPath })
+    assert.equal(res.ok, true, res.error)
+
+    // The mode assertion ALONE is vacuous and was: pre-fix the write landed on the
+    // LINK path and never touched `targetPath`, so the target trivially kept 0640
+    // while the user's link was being destroyed. What makes the mode claim mean
+    // anything is that the bytes went to the target and the link survived — so
+    // the preserved mode belongs to the file we actually wrote.
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true, 'the link must survive the write')
+    assert.ok(JSON.parse(readFileSync(targetPath, 'utf8')).mcpServers.srv, 'the entry landed in the TARGET')
+    assert.equal(statSync(targetPath).mode & 0o777, 0o640, 'and the target kept the mode the user chose')
+  })
+
+  it('reports viaSymlink so a caller can tell a resolved write from a direct one', () => {
+    // `viaSymlink` is part of the resolver's documented contract (#7039 wants the
+    // "writing through X → Y" operator signal built on it). Pinned here so it
+    // cannot silently change shape while no production caller reads it yet.
+    linkedConfig({ mcpServers: {} })
+    const viaLink = resolveClaudeConfigWritePath(linkPath)
+    // `realpathSync(targetPath)`, not `targetPath`: on macOS a mkdtemp path
+    // resolves through /private, and the resolver returns the realpath.
+    assert.deepEqual(viaLink, { ok: true, path: realpathSync(targetPath), viaSymlink: true })
+
+    const plain = join(homeDir, 'plain.json')
+    writeFileSync(plain, '{}', { mode: 0o600 })
+    assert.deepEqual(resolveClaudeConfigWritePath(plain), { ok: true, path: plain, viaSymlink: false })
+
+    const missing = join(homeDir, 'nope.json')
+    assert.deepEqual(resolveClaudeConfigWritePath(missing), { ok: true, path: missing, viaSymlink: false })
   })
 
   it('a chain of symlinks resolves to the final regular file', () => {

--- a/packages/server/tests/byok-mcp-config-symlink-write.test.js
+++ b/packages/server/tests/byok-mcp-config-symlink-write.test.js
@@ -1,0 +1,246 @@
+/**
+ * #7002 — write fidelity of the MCP config mutation path.
+ *
+ * Two distinct gaps in the first write path into `~/.claude.json`
+ * (`writeClaudeConfigAtomic`, added by #6998/#6974):
+ *
+ *  1. SYMLINK DESTRUCTION. `writeFileSync(tmp)` → `renameSync(tmp, filePath)`
+ *     replaces the SYMLINK at `filePath` with a regular file. A dotfiles-repo
+ *     arrangement (`~/.claude.json` → `~/dotfiles/claude.json`) silently loses
+ *     its link and the real file stops receiving updates. The write must land on
+ *     the link TARGET, atomically, with the link intact — and must refuse rather
+ *     than guess when the link does not resolve to a plain user-owned file.
+ *
+ *  2. PRESERVED MODE + NEW SECRETS. The writer deliberately preserves the
+ *     destination's mode instead of forcing 0600. When that mode is
+ *     group/world-readable AND the entry being added carries `env`/`headers`
+ *     (which routinely hold API tokens), Chroxy is the party introducing secret
+ *     material into a widely-readable file, so it must say so loudly.
+ *
+ * Every test writes to a mkdtemp path — never the real `~/.claude.json`.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  addMcpServerToConfig,
+  describeConfigModeSecretWarning,
+  removeMcpServerFromConfig,
+  writeClaudeConfigAtomic,
+} from '../src/byok-mcp-config.js'
+
+let dir
+let homeDir
+let dotfilesDir
+let linkPath
+let targetPath
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-symlink-'))
+  homeDir = join(dir, 'home')
+  dotfilesDir = join(dir, 'dotfiles')
+  mkdirSync(homeDir)
+  mkdirSync(dotfilesDir)
+  linkPath = join(homeDir, '.claude.json')
+  targetPath = join(dotfilesDir, 'claude.json')
+})
+
+afterEach(() => {
+  try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ }
+})
+
+const sidecars = (d) => readdirSync(d).filter((f) => f.includes('.chroxy.') && f.endsWith('.tmp'))
+
+const linkedConfig = (obj, { mode = 0o600 } = {}) => {
+  writeFileSync(targetPath, JSON.stringify(obj, null, 2), { mode })
+  chmodSync(targetPath, mode)
+  symlinkSync(targetPath, linkPath)
+}
+
+describe('#7002 symlinked config: the write follows the link', () => {
+  it('add writes THROUGH the symlink and leaves the link in place', () => {
+    linkedConfig({ numStartups: 4, mcpServers: { keep: { command: 'k' } } })
+
+    const res = addMcpServerToConfig({ name: 'repo-memory', config: { command: 'node' }, configPath: linkPath })
+    assert.equal(res.ok, true, res.error)
+
+    const link = lstatSync(linkPath)
+    assert.equal(link.isSymbolicLink(), true, 'the user’s dotfiles symlink must survive the write')
+    assert.equal(readlinkSync(linkPath), targetPath, 'the link still points at the same target')
+
+    const persisted = JSON.parse(readFileSync(targetPath, 'utf8'))
+    assert.ok(persisted.mcpServers['repo-memory'], 'the entry landed in the link TARGET')
+    assert.ok(persisted.mcpServers.keep, 'unrelated keys survive')
+    assert.equal(persisted.numStartups, 4)
+
+    assert.deepEqual(sidecars(homeDir), [], 'no sidecar left beside the link')
+    assert.deepEqual(sidecars(dotfilesDir), [], 'no sidecar left beside the target')
+  })
+
+  it('remove writes THROUGH the symlink and leaves the link in place', () => {
+    linkedConfig({ mcpServers: { gone: { command: 'g' }, keep: { command: 'k' } } })
+
+    const res = removeMcpServerFromConfig({ name: 'gone', configPath: linkPath })
+    assert.equal(res.ok, true, res.error)
+    assert.equal(res.found, true)
+
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true, 'remove must not replace the link either')
+    const persisted = JSON.parse(readFileSync(targetPath, 'utf8'))
+    assert.equal(persisted.mcpServers.gone, undefined)
+    assert.ok(persisted.mcpServers.keep)
+    assert.deepEqual(sidecars(dotfilesDir), [])
+  })
+
+  it('preserves the TARGET’s mode, not a fresh-file default', () => {
+    linkedConfig({ mcpServers: {} }, { mode: 0o640 })
+    addMcpServerToConfig({ name: 'srv', config: { command: 'node' }, configPath: linkPath })
+    assert.equal(statSync(targetPath).mode & 0o777, 0o640)
+  })
+
+  it('a chain of symlinks resolves to the final regular file', () => {
+    const middle = join(dir, 'middle.json')
+    writeFileSync(targetPath, JSON.stringify({ mcpServers: {} }, null, 2), { mode: 0o600 })
+    symlinkSync(targetPath, middle)
+    symlinkSync(middle, linkPath)
+
+    const res = addMcpServerToConfig({ name: 'srv', config: { command: 'node' }, configPath: linkPath })
+    assert.equal(res.ok, true, res.error)
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true)
+    assert.equal(lstatSync(middle).isSymbolicLink(), true)
+    assert.ok(JSON.parse(readFileSync(targetPath, 'utf8')).mcpServers.srv)
+  })
+
+  it('refuses a DANGLING symlink instead of materializing a regular file over it', () => {
+    symlinkSync(join(dotfilesDir, 'missing.json'), linkPath)
+
+    assert.throws(
+      () => writeClaudeConfigAtomic(linkPath, { mcpServers: {} }, { mode: null }),
+      /symlink/i,
+      'a link we cannot resolve must be refused, loudly',
+    )
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true, 'the dangling link is left exactly as found')
+    assert.deepEqual(sidecars(homeDir), [])
+  })
+
+  it('refuses a symlink pointing at a DIRECTORY', () => {
+    symlinkSync(dotfilesDir, linkPath)
+    assert.throws(
+      () => writeClaudeConfigAtomic(linkPath, { mcpServers: {} }, { mode: null }),
+      /symlink/i,
+    )
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true)
+  })
+
+  it('a plain (non-symlink) path is written exactly as before', () => {
+    const plain = join(homeDir, 'plain.json')
+    writeFileSync(plain, JSON.stringify({ mcpServers: {} }, null, 2), { mode: 0o600 })
+    writeClaudeConfigAtomic(plain, { mcpServers: { s: { command: 'node' } } }, { mode: 0o600 })
+    assert.equal(lstatSync(plain).isSymbolicLink(), false)
+    assert.ok(JSON.parse(readFileSync(plain, 'utf8')).mcpServers.s)
+    assert.equal(statSync(plain).mode & 0o777, 0o600)
+    assert.deepEqual(sidecars(homeDir), [])
+  })
+
+  it('a MISSING path is still created (first write), no symlink handling needed', () => {
+    const fresh = join(homeDir, 'fresh.json')
+    writeClaudeConfigAtomic(fresh, { mcpServers: {} }, { mode: null })
+    assert.equal(existsSync(fresh), true)
+    assert.equal(statSync(fresh).mode & 0o777, 0o600)
+  })
+})
+
+describe('#7002 group/world-readable config + newly written secrets', () => {
+  it('warns when the preserved mode is group-readable and the entry carries env', () => {
+    const warning = describeConfigModeSecretWarning({
+      filePath: '/home/u/.claude.json',
+      mode: 0o644,
+      entry: { command: 'node', args: [], env: { API_TOKEN: 'sk-secret' } },
+    })
+    assert.ok(warning, 'a 0644 config receiving env must warn')
+    assert.match(warning, /\/home\/u\/\.claude\.json/)
+    assert.match(warning, /644/)
+    assert.match(warning, /env/)
+    assert.ok(!warning.includes('sk-secret'), 'the warning must never echo the secret value')
+  })
+
+  it('warns for headers on a remote server entry', () => {
+    const warning = describeConfigModeSecretWarning({
+      filePath: '/home/u/.claude.json',
+      mode: 0o604,
+      entry: { url: 'https://x/y', headers: { Authorization: 'Bearer t' } },
+    })
+    assert.ok(warning)
+    assert.match(warning, /headers/)
+    assert.ok(!warning.includes('Bearer t'))
+  })
+
+  it('stays quiet for an owner-only mode', () => {
+    assert.equal(describeConfigModeSecretWarning({
+      filePath: '/home/u/.claude.json',
+      mode: 0o600,
+      entry: { command: 'node', env: { API_TOKEN: 't' } },
+    }), null)
+  })
+
+  it('stays quiet when the entry carries no secret-bearing field', () => {
+    assert.equal(describeConfigModeSecretWarning({
+      filePath: '/home/u/.claude.json',
+      mode: 0o644,
+      entry: { command: 'node', args: ['x'], env: {} },
+    }), null)
+  })
+
+  it('stays quiet for a file WE created (mode null → 0600)', () => {
+    assert.equal(describeConfigModeSecretWarning({
+      filePath: '/home/u/.claude.json',
+      mode: null,
+      entry: { command: 'node', env: { API_TOKEN: 't' } },
+    }), null)
+  })
+
+  it('addMcpServerToConfig returns the warning on a 0644 config carrying env', () => {
+    const plain = join(homeDir, '.claude.json')
+    writeFileSync(plain, JSON.stringify({ mcpServers: {} }, null, 2), { mode: 0o644 })
+    chmodSync(plain, 0o644)
+
+    const res = addMcpServerToConfig({
+      name: 'srv',
+      config: { command: 'node', env: { API_TOKEN: 'sk-secret' } },
+      configPath: plain,
+    })
+    assert.equal(res.ok, true, res.error)
+    assert.ok(res.warning, 'the mode/secrets warning must reach the caller')
+    assert.match(res.warning, /644/)
+    assert.ok(!res.warning.includes('sk-secret'))
+    // The warning is advisory only — we still do NOT re-permission the user's file.
+    assert.equal(statSync(plain).mode & 0o777, 0o644)
+  })
+
+  it('addMcpServerToConfig omits the warning for an owner-only config', () => {
+    const plain = join(homeDir, '.claude.json')
+    writeFileSync(plain, JSON.stringify({ mcpServers: {} }, null, 2), { mode: 0o600 })
+    chmodSync(plain, 0o600)
+    const res = addMcpServerToConfig({
+      name: 'srv',
+      config: { command: 'node', env: { API_TOKEN: 'sk-secret' } },
+      configPath: plain,
+    })
+    assert.equal(res.ok, true, res.error)
+    assert.equal(res.warning, undefined)
+  })
+})

--- a/packages/server/tests/byok-mcp-trust-spawn-config.test.js
+++ b/packages/server/tests/byok-mcp-trust-spawn-config.test.js
@@ -23,9 +23,10 @@
  */
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 import {
   TRUST_KEY_VERSION,
   isTrusted,
@@ -51,6 +52,10 @@ const INJECTED_ENV = {
 
 let tmpDir
 let storePath
+// Registered by the #7002 surfacing suite; declared here so the top-level
+// afterEach can guarantee it is detached even if a test throws mid-way (a leaked
+// log listener would follow the process into every later test file's output).
+let logListener = null
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-mcp-trust-7001-'))
@@ -58,6 +63,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (logListener) {
+    removeLogListener(logListener)
+    logListener = null
+  }
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
@@ -449,5 +458,103 @@ describe('#7001 deny-before-write (ClaudeByokSession.addMcpServer)', () => {
     assert.equal(calls[0].command, 'node')
     assert.deepEqual(calls[0].args, ['s.js'])
     assert.equal('bogusKey' in calls[0], false)
+  })
+})
+
+/**
+ * #7002 — the mode/secrets warning must be SURFACED, not merely computed.
+ *
+ * `addMcpServerToConfig` returning `result.warning` is only half the fix; the
+ * session has to (a) log it for the operator and (b) pass it back on its OWN
+ * result, because that field is the API a client-visible surface will read
+ * (#7039). Both directions are asserted here — present when the write reports a
+ * warning, ABSENT when it does not — so neither the pass-through nor the
+ * condition guarding it can be deleted without a failure.
+ */
+describe('#7002 ClaudeByokSession.addMcpServer surfaces the mode/secrets warning', () => {
+  let configPath
+  let prevTrustPath
+  let logged
+
+  beforeEach(() => {
+    configPath = join(tmpDir, 'claude.json')
+    prevTrustPath = process.env.CHROXY_MCP_TRUST_PATH
+    process.env.CHROXY_MCP_TRUST_PATH = storePath
+    logged = []
+    logListener = (entry) => logged.push(entry)
+    addLogListener(logListener)
+  })
+
+  afterEach(() => {
+    if (logListener) removeLogListener(logListener)
+    logListener = null
+    if (prevTrustPath === undefined) delete process.env.CHROXY_MCP_TRUST_PATH
+    else process.env.CHROXY_MCP_TRUST_PATH = prevTrustPath
+  })
+
+  // The mode has to be pinned with an explicit chmod: `writeFileSync`'s default is
+  // `0666 & ~umask`, so a host with a tight umask would otherwise silently make
+  // the "group-readable" fixture owner-only and the warning would never fire.
+  function seedConfig(mode) {
+    writeFileSync(configPath, JSON.stringify({ mcpServers: {} }, null, 2))
+    chmodSync(configPath, mode)
+  }
+
+  function makeSession() {
+    const session = new ClaudeByokSession({ cwd: tmpDir, mcpConfigPath: configPath })
+    session._permissions = { async requestMcpTrust() { return true } }
+    session._mcpFleet = null
+    session._emitMcpServers = () => {}
+    return session
+  }
+
+  const warnLines = () => logged
+    .filter((e) => e.level === 'warn' && e.component === 'byok-session')
+    .map((e) => e.message)
+
+  it('returns result.warning when the config is group/world-readable and the entry carries env', async () => {
+    seedConfig(0o644)
+    const session = makeSession()
+
+    const res = await session.addMcpServer('srv', { command: 'node', env: { API_TOKEN: 'sk-secret' } })
+
+    assert.equal(res.ok, true, res.error)
+    assert.ok(res.warning, 'the warning must reach the caller — #7039 builds a client-visible field on this field')
+    assert.match(res.warning, /644/, 'it names the octal mode the operator has to fix')
+    assert.match(res.warning, /env/, 'and the secret-bearing field that triggered it')
+    assert.ok(!res.warning.includes('sk-secret'), 'it must never echo the secret value')
+  })
+
+  it('logs the warning once for the operator, naming the octal mode', async () => {
+    seedConfig(0o644)
+    const session = makeSession()
+
+    await session.addMcpServer('srv', { command: 'node', env: { API_TOKEN: 'sk-secret' } })
+
+    const warned = warnLines().filter((m) => /644/.test(m))
+    assert.equal(warned.length, 1, `exactly one operator warning naming the mode, got: ${JSON.stringify(warnLines())}`)
+    assert.match(warned[0], /BYOK MCP/, 'tagged so it is greppable in the daemon log')
+    assert.ok(!warned[0].includes('sk-secret'), 'the daemon log must not gain the secret')
+  })
+
+  it('omits result.warning — and logs no warning — for an owner-only config', async () => {
+    seedConfig(0o600)
+    const session = makeSession()
+
+    const res = await session.addMcpServer('srv', { command: 'node', env: { API_TOKEN: 'sk-secret' } })
+
+    assert.equal(res.ok, true, res.error)
+    assert.equal(res.warning, undefined, 'a 0600 config is not something to nag about')
+    assert.deepEqual(warnLines().filter((m) => /mode \d{3}/.test(m)), [])
+  })
+
+  it('omits result.warning when the entry carries no secret-bearing field', async () => {
+    seedConfig(0o644)
+    const session = makeSession()
+
+    const res = await session.addMcpServer('srv', { command: 'node', args: ['s.js'] })
+
+    assert.equal(res.ok, true, res.error)
+    assert.equal(res.warning, undefined, 'a loose mode alone is the user’s own choice — we only speak up when WE added secrets')
   })
 })

--- a/packages/server/tests/claude-tui-ensure-cwd-trusted-write.test.js
+++ b/packages/server/tests/claude-tui-ensure-cwd-trusted-write.test.js
@@ -1,0 +1,198 @@
+/**
+ * #7046 — write fidelity of `ensureCwdTrusted`, the DEFAULT provider's
+ * `~/.claude.json` writer.
+ *
+ * `claude-tui` is DEFAULT_PROVIDER, and `ClaudeTuiSession.start()` calls
+ * `ensureCwdTrusted(cwd)` on every start where the cwd is not already
+ * trusted+onboarded — so this path rewrites `~/.claude.json` far more often than
+ * the BYOK `add_mcp_server` path #7002 hardened. It had the SAME two defects, one
+ * of them worse:
+ *
+ *  1. SYMLINK DESTRUCTION. `writeFileSync(tmp)` → `renameSync(tmp, claudeConfig)`
+ *     replaces the final path component, so a dotfiles-repo
+ *     `~/.claude.json -> ~/dotfiles/claude.json` was converted into a regular
+ *     file: the user's link vanished and their real config stopped receiving
+ *     updates.
+ *  2. PERMISSION WIDENING. The sidecar was written with NO `mode` and never
+ *     chmod'd, so the rename left `0666 & ~umask` — dropping a 0600 config
+ *     holding OAuth material to 0644. (The MCP writer at least PRESERVED the
+ *     mode; this one actively loosened it.)
+ *
+ * Every test points HOME at a mkdtemp dir — the real `~/.claude.json` is a
+ * PROTECTED_FILE in `_setup.mjs`, so a regression that escaped the temp home
+ * would trip the sandbox guard rather than touch the developer's config.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+// `claude-tui-session.js` and `claude-tui/pty-driver.js` are a deliberate import
+// CYCLE (the session imports `PtyDriverMixin`; the driver imports the class for
+// its static tuning getters), and the mixin is applied at
+// claude-tui-session.js's top level. Entering the cycle at the DRIVER therefore
+// hits `applyMixin(ClaudeTuiSession, PtyDriverMixin)` while `PtyDriverMixin` is
+// still in TDZ → `ReferenceError: Cannot access 'PtyDriverMixin' before
+// initialization`. Pre-existing, and unrelated to what this file tests: importing
+// the session module first fixes the evaluation order, which is also the order
+// production uses (nothing imports the driver as an entry point).
+import '../src/claude-tui-session.js'
+import { ensureCwdTrusted } from '../src/claude-tui/pty-driver.js'
+
+let dir
+let fakeHome
+let dotfilesDir
+let projectDir
+let realProjectDir
+let linkPath
+let targetPath
+let origHome
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'chroxy-tui-trust-'))
+  fakeHome = join(dir, 'home')
+  dotfilesDir = join(dir, 'dotfiles')
+  projectDir = join(dir, 'project')
+  mkdirSync(fakeHome)
+  mkdirSync(dotfilesDir)
+  mkdirSync(projectDir)
+  // ensureCwdTrusted keys the projects map by realpathSync(cwd), and on macOS a
+  // mkdtemp path resolves through /private — key the assertions the same way.
+  realProjectDir = realpathSync(projectDir)
+  linkPath = join(fakeHome, '.claude.json')
+  targetPath = join(dotfilesDir, 'claude.json')
+  origHome = process.env.HOME
+  process.env.HOME = fakeHome
+})
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.HOME
+  else process.env.HOME = origHome
+  try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ }
+})
+
+const sidecars = (d) => readdirSync(d).filter((f) => f.includes('.chroxy.') && f.endsWith('.tmp'))
+
+// An UNTRUSTED cwd — ensureCwdTrusted early-returns without writing when the
+// project is already `hasTrustDialogAccepted && hasCompletedProjectOnboarding`,
+// so every fixture below must leave the write to happen.
+const UNTRUSTED = { numStartups: 7, projects: {} }
+
+const writeConfig = (path, obj, mode) => {
+  writeFileSync(path, JSON.stringify(obj, null, 2), { mode })
+  chmodSync(path, mode)
+}
+
+describe('#7046 ensureCwdTrusted: a symlinked ~/.claude.json is written THROUGH', () => {
+  it('leaves the dotfiles link in place and lands the trust flags in the TARGET', () => {
+    writeConfig(targetPath, UNTRUSTED, 0o600)
+    symlinkSync(targetPath, linkPath)
+
+    ensureCwdTrusted(projectDir)
+
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true,
+      'the user’s dotfiles symlink must survive the trust pre-write')
+    assert.equal(readlinkSync(linkPath), targetPath, 'the link still points at the same target')
+
+    const persisted = JSON.parse(readFileSync(targetPath, 'utf8'))
+    const entry = persisted.projects?.[realProjectDir]
+    assert.ok(entry,
+      `the trust entry landed in the link TARGET (projects: ${Object.keys(persisted.projects || {}).join(', ')})`)
+    assert.equal(entry.hasTrustDialogAccepted, true)
+    assert.equal(entry.hasCompletedProjectOnboarding, true)
+    assert.equal(persisted.numStartups, 7, 'unrelated keys in the real config survive')
+
+    assert.deepEqual(sidecars(fakeHome), [], 'no sidecar left beside the link')
+    assert.deepEqual(sidecars(dotfilesDir), [], 'no sidecar left beside the target')
+  })
+
+  it('refuses a DANGLING link instead of materializing a regular file over it', () => {
+    const missing = join(dotfilesDir, 'missing.json')
+    symlinkSync(missing, linkPath)
+
+    // Best-effort by contract: the trust pre-write is skipped with a warning
+    // rather than throwing, so session start still proceeds (claude may render
+    // its trust dialog). What must NOT happen is the link being replaced.
+    ensureCwdTrusted(projectDir)
+
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true, 'the dangling link is left exactly as found')
+    assert.equal(existsSync(missing), false, 'we never invent a file at the link’s chosen target')
+    assert.deepEqual(sidecars(fakeHome), [])
+    assert.deepEqual(sidecars(dotfilesDir), [])
+  })
+
+  // NOTE deliberately no "link to a directory / to another uid's file" case here.
+  // Those refusals belong to `resolveClaudeConfigWritePath` and are pinned where
+  // it lives (`byok-mcp-config-symlink-write.test.js`). Through THIS entry point a
+  // directory link never reaches the writer at all — `readFileSync` fails with
+  // EISDIR first and the function returns on its unreadable-config branch — so a
+  // test here would pass identically with and without the fix, i.e. verify
+  // nothing. The dangling case above is the one that genuinely reached the write.
+})
+
+describe('#7046 ensureCwdTrusted: the config’s mode is PRESERVED, never widened', () => {
+  // Asserted over TWO distinct modes deliberately. The pre-fix write produced
+  // `0666 & ~umask` — a single value on any given host — so a one-mode assertion
+  // could pass by coincidence under some umask. No umask maps to both 0600 and
+  // 0640, so this pair fails pre-fix on every host.
+  for (const mode of [0o600, 0o640]) {
+    it(`a 0${mode.toString(8)} config is still 0${mode.toString(8)} after the trust pre-write`, () => {
+      writeConfig(linkPath, UNTRUSTED, mode)
+
+      ensureCwdTrusted(projectDir)
+
+      assert.equal(statSync(linkPath).mode & 0o777, mode,
+        'the trust pre-write must not re-permission a file that holds OAuth material')
+      const persisted = JSON.parse(readFileSync(linkPath, 'utf8'))
+      assert.ok(persisted.projects?.[realProjectDir]?.hasTrustDialogAccepted, 'the write actually happened')
+      assert.equal(persisted.numStartups, 7, 'the existing config was preserved, not clobbered')
+    })
+  }
+
+  it('a 0600 symlink TARGET keeps 0600 (the mode is read through the link)', () => {
+    writeConfig(targetPath, UNTRUSTED, 0o600)
+    symlinkSync(targetPath, linkPath)
+
+    ensureCwdTrusted(projectDir)
+
+    assert.equal(statSync(targetPath).mode & 0o777, 0o600)
+    assert.equal(lstatSync(linkPath).isSymbolicLink(), true)
+  })
+
+  it('a config we CREATE is 0600, not umask-derived', () => {
+    assert.equal(existsSync(linkPath), false)
+    ensureCwdTrusted(projectDir)
+    assert.equal(existsSync(linkPath), true, 'the first-write case still creates the file')
+    assert.equal(statSync(linkPath).mode & 0o777, 0o600)
+    assert.deepEqual(sidecars(fakeHome), [])
+  })
+
+  it('is still idempotent — an already trusted+onboarded cwd is not rewritten', () => {
+    writeConfig(linkPath, {
+      projects: { [realProjectDir]: { hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true } },
+    }, 0o640)
+
+    ensureCwdTrusted(projectDir)
+
+    // A rewrite would normalize the entry (adding projectOnboardingSeenCount);
+    // an untouched file still has exactly the two keys it started with.
+    const persisted = JSON.parse(readFileSync(linkPath, 'utf8'))
+    assert.deepEqual(Object.keys(persisted.projects[realProjectDir]).sort(),
+      ['hasCompletedProjectOnboarding', 'hasTrustDialogAccepted'],
+      'no write when the cwd is already trusted+onboarded')
+  })
+})

--- a/packages/server/tests/settings-handlers-mcp-config.test.js
+++ b/packages/server/tests/settings-handlers-mcp-config.test.js
@@ -236,6 +236,22 @@ describe('handleAddMcpServer (#6974)', () => {
     assert.equal(ctx.transport.send.mock.callCount(), 0, 'a successful mutation must send NO error frame')
   })
 
+  it('a success carrying the #7002 mode warning still sends NO error frame', async () => {
+    // The permissions warning is advisory: the add SUCCEEDED, the file was left
+    // at the mode the user chose, and the operator log is where it belongs. A
+    // client must not see this as a failed mutation.
+    const session = makeSession({
+      addMcpServer: mock.fn(async () => ({
+        ok: true,
+        status: 'connected',
+        warning: '/home/u/.claude.json is mode 644 (readable beyond its owner) …',
+      })),
+    })
+    const ctx = makeCtx({ 'sess-1': { session } })
+    await addHandler(WS, { ...PRIMARY }, { ...VALID_ADD, requestId: 'r' }, ctx)
+    assert.equal(ctx.transport.send.mock.callCount(), 0, 'a warning is not an error frame')
+  })
+
   it('a duplicate name surfaces as MCP_SERVER_EXISTS', async () => {
     const session = makeSession({
       addMcpServer: mock.fn(async () => ({ ok: false, code: 'EXISTS', error: 'already exists' })),

--- a/packages/server/tests/settings-handlers-mcp-config.test.js
+++ b/packages/server/tests/settings-handlers-mcp-config.test.js
@@ -25,7 +25,27 @@
 import { describe, it, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { settingsHandlers } from '../src/handlers/settings-handlers.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 import { nsCtx } from './test-helpers.js'
+
+/**
+ * Capture the structured log entries emitted while `fn` runs. The listener is
+ * detached in a `finally`, so a throwing assertion cannot leak it into later
+ * tests in this process (a leaked listener silently accumulates every subsequent
+ * line). Used to assert the OPERATOR-VISIBLE side of a handler, which is the only
+ * observable for a warning that deliberately does not produce a WS frame (#7002).
+ */
+async function captureLogs(fn) {
+  const entries = []
+  const listener = (entry) => entries.push(entry)
+  addLogListener(listener)
+  try {
+    await fn()
+  } finally {
+    removeLogListener(listener)
+  }
+  return entries
+}
 
 const addHandler = settingsHandlers['add_mcp_server']
 const removeHandler = settingsHandlers['remove_mcp_server']
@@ -236,20 +256,42 @@ describe('handleAddMcpServer (#6974)', () => {
     assert.equal(ctx.transport.send.mock.callCount(), 0, 'a successful mutation must send NO error frame')
   })
 
-  it('a success carrying the #7002 mode warning still sends NO error frame', async () => {
-    // The permissions warning is advisory: the add SUCCEEDED, the file was left
-    // at the mode the user chose, and the operator log is where it belongs. A
-    // client must not see this as a failed mutation.
+  it('a success carrying the #7002 mode warning is LOGGED once and sends NO error frame', async () => {
+    // Two assertions, deliberately: that the warning is SURFACED (an
+    // `assert.callCount(send) === 0` alone is equally true when the surfacing line
+    // does not exist — a "no error frame" test, not a "the warning was reported"
+    // test), and that surfacing it did not turn a successful mutation into a
+    // failure. `result.warning` is also the field #7039 will render client-side.
+    const warning = '/home/u/.claude.json is mode 644 (readable beyond its owner) and the MCP server entry ' +
+      'just added carries env, which commonly hold API tokens.'
     const session = makeSession({
-      addMcpServer: mock.fn(async () => ({
-        ok: true,
-        status: 'connected',
-        warning: '/home/u/.claude.json is mode 644 (readable beyond its owner) …',
-      })),
+      addMcpServer: mock.fn(async () => ({ ok: true, status: 'connected', warning })),
     })
     const ctx = makeCtx({ 'sess-1': { session } })
-    await addHandler(WS, { ...PRIMARY }, { ...VALID_ADD, requestId: 'r' }, ctx)
+
+    const entries = await captureLogs(() => addHandler(WS, { ...PRIMARY }, { ...VALID_ADD, requestId: 'r' }, ctx))
+
+    const warns = entries.filter((e) => e.level === 'warn' && /MCP config permissions/.test(e.message))
+    assert.equal(warns.length, 1,
+      `the warning must be surfaced exactly once, saw: ${JSON.stringify(entries.map((e) => [e.level, e.message]))}`)
+    assert.match(warns[0].message, /644/, 'the operator cannot act on it without the octal mode')
+    assert.equal(warns[0].sessionId, 'sess-1',
+      'scoped via sessionLogger to the session that changed the config, not fanned out globally')
+    // The permissions warning is advisory: the add SUCCEEDED and the file was left
+    // at the mode the user chose, so a client must not see this as a failed
+    // mutation.
     assert.equal(ctx.transport.send.mock.callCount(), 0, 'a warning is not an error frame')
+  })
+
+  it('a success with no warning logs no permissions line (the guard, not the log, is unconditional)', async () => {
+    const session = makeSession() // default result: { ok: true, status: 'connected' }
+    const ctx = makeCtx({ 'sess-1': { session } })
+
+    const entries = await captureLogs(() => addHandler(WS, { ...PRIMARY }, { ...VALID_ADD, requestId: 'r' }, ctx))
+
+    assert.deepEqual(entries.filter((e) => /MCP config permissions/.test(e.message)).map((e) => e.message), [],
+      'nothing to warn about must produce no warning')
+    assert.equal(ctx.transport.send.mock.callCount(), 0)
   })
 
   it('a duplicate name surfaces as MCP_SERVER_EXISTS', async () => {


### PR DESCRIPTION
## What

Write-fidelity defects in **both** places the server rewrites `~/.claude.json`. All were confirmed still present on `main` at `23e6687bc` before any code was written.

### 1. A symlinked `~/.claude.json` was destroyed by the rename

Both writers did `writeFileSync(tmp)` → `renameSync(tmp, filePath)`. `rename(2)` replaces the **final path component itself**, so when `~/.claude.json` is a symlink (a dotfiles repo linking `~/dotfiles/claude.json` into `$HOME`) the rename replaced the *link* with a regular file: the link silently vanished and the real config stopped receiving updates. The read path follows the link, so nothing complained. In `byok-mcp-config.js` both `addMcpServerToConfig` and `removeMcpServerFromConfig` were affected.

New `resolveClaudeConfigWritePath(filePath)`:

- `lstat` the destination. Not a symlink, or missing (the first-write case) → identical behaviour to before this PR.
- A symlink → `realpathSync` and write to the **target**: the temp file is created in the target's directory (so the rename stays atomic within one filesystem — a dotfiles target is frequently on a different one from `$HOME`) and the durability `fsync` is that directory. The link is left untouched. A chain of links resolves to the final regular file.
- The resolution is guarded, not blind:
  - a **dangling** link is refused, never materialized (creating the missing target would be inventing a file at a path we did not choose)
  - a link to anything that is **not a regular file** (directory, fifo, socket, device) is refused
  - a link to a file **owned by another uid** is refused

### 2. Preserved mode + newly written secrets

`writeClaudeConfigAtomic` deliberately preserves the destination's mode instead of forcing `0600` (re-permissioning a user's file as a side effect of "add an MCP server" is not ours to do; files we *create* still get `0600`). That leaves one case where Chroxy is the party making things worse: an existing `0644` config plus a new entry carrying `env`/`headers` — the two fields that routinely hold API tokens.

New `describeConfigModeSecretWarning({ filePath, mode, entry })` returns a warning when `mode & 0o077` is non-zero **and** the entry carries a non-empty `env`/`headers`. It names the file, its octal mode and the offending field names, never a secret value, and suggests `chmod 600`. It is wired to:

- `addMcpServerToConfig` → `result.warning`
- `ClaudeByokSession.addMcpServer` → `log.warn` (the loud operator warning) and pass-through on the result
- `handleAddMcpServer` → `sessionLogger(...).warn`; the add still succeeds and still sends no error frame

The file's permissions are **not** changed.

The trigger is deliberately the whole `0o077` superset rather than only the read bits, and the message says **"accessible** beyond its owner" to match it: group/other **write** is the sharper edge of the two, not a lesser one — another local user who can rewrite `~/.claude.json` substitutes MCP server commands the daemon then spawns. Including the (meaningless-on-a-JSON-file) execute bit costs at most a harmless false positive on a pathological mode like `0o611`, which is the right side to err on for a security advisory. A regression test pins that a `0o620` config warns and that the message does not claim it is *readable*.

### 3. `ensureCwdTrusted` — the DEFAULT provider had defect 1 too, and *widened* the mode (#7046)

`ensureCwdTrusted()` in `packages/server/src/claude-tui/pty-driver.js` is the second writer of `~/.claude.json`, called from `claude-tui-session.js:1294` on every `start()` where the cwd is not already trusted+onboarded. `claude-tui` is `DEFAULT_PROVIDER`, so it runs far more often than `add_mcp_server`. It had the identical `writeFileSync(tmp)` → `renameSync(tmp, ~/.claude.json)` — **and** it passed no `mode` and never `chmod`ed, so the replacement file got `0666 & ~umask`: a `0600` config holding OAuth material dropped to `0644` on every trust pre-write. A failed rename also left a full credential-bearing copy of the config at a `.chroxy.*.tmp` path in `$HOME` (no #4463 cleanup). So the headline outcome of this PR would otherwise have held only for the BYOK MCP path, and #7002 could not honestly be read as closed.

Fixed by routing it through the **same** writer rather than adding a third hand-rolled tmp+rename over the same file — three copies of this logic is how the second one got missed:

- `ensureCwdTrusted` now captures `statSync(claudeConfig).mode & 0o777` and commits via `writeClaudeConfigAtomic(claudeConfig, config, { mode })`, inheriting symlink-through, mode preservation, the per-call random sidecar suffix (#3922) and the #4463 sidecar unlink on rename failure. A file we *create* is `0600` rather than umask-derived.
- A **refusal** (a link we will not follow) or an I/O failure is caught and logged, and the pre-write is skipped — matching the existing "unreadable config → warn and skip" contract in the same function. The degraded outcome is claude rendering its trust dialog; destroying the user's link is strictly worse.
- The path stays `homedir()/.claude.json`, deliberately **not** `defaultClaudeConfigPath()`: the whole point of the write is to be read by the `claude` binary about to be spawned, and it only reads `$HOME/.claude.json`. Honouring `CHROXY_CLAUDE_CONFIG` here would silently send trust flags to a file claude never opens. Called out in a comment so nobody "fixes" it later.
- No new module-graph edge: `claude-tui-session.js` already imports `byok-mcp-config.js`. Its module doc-block now states that it is the single writer for this file despite the byok-flavoured filename, so the next caller adds a call site rather than a copy.

## Security posture — stated explicitly

**Trust assumption:** `~/.claude.json`, and any symlink the user has put in its place, is user-owned, user-authored configuration. We follow the link because a user who symlinked their own config meant it. The guards above exist because resolving a symlink and writing to its target is exactly how a *planted* link turns "write my config" into "write an arbitrary file".

**Race honesty:** resolution happens **once**, and the subsequent `rename` re-walks the path by name, so an attacker who can replace the link between the two syscalls can still redirect the write (classic TOCTOU). **This is not closed here** — POSIX has no "rename onto this exact inode" primitive. The residual exposure requires write access inside the user's own `$HOME`, which already implies control over a config the daemon reads and executes commands from, so it is not a new capability; but it is not race-free and is not claimed to be. Documented in the function's doc comment and filed as a follow-up: #7039 (which also tracks surfacing the mode warning to a client UI and the optional `chroxy doctor` check).

## How verified

Every claim below is a **mutation** result: the named production line was deleted (or reverted to its pre-fix form), the suite was re-run, the listed tests failed, and the line was restored. A test that survives its own mutation verifies nothing, so it is not counted as verification here.

### Symlink-through + refusals (`writeClaudeConfigAtomic`)

`tests/byok-mcp-config-symlink-write.test.js` (17 tests). Mutation: `const destPath = resolved.path` → `filePath` (resolver bypassed):

```
# tests 16 / pass 12 / fail 4   (run before the 17th, wording, test was added)
not ok 1 - add writes THROUGH the symlink and leaves the link in place
not ok 2 - remove writes THROUGH the symlink and leaves the link in place
not ok 3 - preserves the TARGET’s mode ON THE TARGET, with the link intact
not ok 5 - a chain of symlinks resolves to the final regular file
```

plus the dangling / non-regular refusals, which are red against the pre-fix source (`Missing expected exception: a link we cannot resolve must be refused, loudly`).

**Test 3 was rewritten** because its previous form (`preserves the TARGET's mode, not a fresh-file default`) **passed with the fix neutered**: pre-fix the write landed on the *link* path and never touched `targetPath`, so the mode assertion was vacuous. It now also asserts the link survived and that the entry landed in the target, which is what makes the mode claim mean anything — and it is red under the mutation above (`the link must survive the write / false !== true`).

The remaining tests in that file are deliberate **controls**, labelled as such: `a plain (non-symlink) path is written exactly as before`, `a MISSING path is still created`, and the four `stays quiet` / `omits the warning` negative-direction cases. They pass both pre- and post-fix by design — that is their job, and they are not cited as evidence the fix works.

`reports viaSymlink ...` is new: it pins the resolver's return shape, which no production caller reads yet (#7039 builds the "writing through X → Y" operator signal on it), so it could otherwise drift unnoticed.

`warns on a group/other WRITE bit too, and the wording matches the trigger` is new and red under its own mutation (`accessible` → `readable`): `The input did not match /accessible beyond its owner/. Input: "… is mode 620 (readable beyond its owner) …"`.

### The mode/secrets warning WIRING (previously untested — all three lines could be deleted with 49/49 still green)

Three separate production lines, each mutated independently:

| Deleted production line | Test that went red |
|---|---|
| `byok-session.js` — `if (written.warning) log.warn(\`BYOK MCP: ${written.warning}\`)` | `logs the warning once for the operator, naming the octal mode` → `exactly one operator warning naming the mode, got: []` / `0 !== 1` |
| `byok-session.js` — `if (written.warning) result.warning = written.warning` | `returns result.warning when the config is group/world-readable and the entry carries env` → `the warning must reach the caller` |
| `settings-handlers.js` — `if (result.warning) sessionLogger(sessionId).warn(...)` | `a success carrying the #7002 mode warning is LOGGED once and sends NO error frame` → `saw: [["info","MCP server 'my-server' added in user scope …"]]` / `0 !== 1` |

The previous handler test asserted only `ctx.transport.send.mock.callCount() === 0`, which is equally true when the surfacing line does not exist — a "no error frame" test, not a "the warning was reported" test. It now observes the surfacing through a scoped log listener, and additionally asserts the entry is `sessionId`-scoped (`sessionLogger`, not a global fan-out). A sibling test asserts a success with **no** warning logs no permissions line, so the guard cannot be dropped either.

The `ClaudeByokSession.addMcpServer` cases (in `tests/byok-mcp-trust-spawn-config.test.js`) drive the **real** session against a real temp config file — not a stubbed `addMcpServer` — so the field a client surface will read (#7039) is pinned end to end, in both directions: present on a `0644` config carrying `env`, absent on `0600`, absent when the entry carries no secret-bearing field. Fixture modes are set with an explicit `chmodSync`, because `writeFileSync`'s default is `0666 & ~umask` and a tight-umask host would otherwise make the "group-readable" fixture owner-only and the warning would never fire.

### `ensureCwdTrusted` (#7046)

New file `tests/claude-tui-ensure-cwd-trusted-write.test.js` (7 tests). Mutation: the `writeClaudeConfigAtomic(...)` call reverted to the original `writeFileSync(tmp)` + `renameSync(tmp, claudeConfig)`:

```
# tests 7 / pass 1 / fail 6
not ok 1 - leaves the dotfiles link in place and lands the trust flags in the TARGET
not ok 2 - refuses a DANGLING link instead of materializing a regular file over it
not ok 1 - a 0600 config is still 0600 after the trust pre-write
not ok 2 - a 0640 config is still 0640 after the trust pre-write
not ok 3 - a 0600 symlink TARGET keeps 0600 (the mode is read through the link)
not ok 4 - a config we CREATE is 0600, not umask-derived
```

The mode is asserted over **two** distinct modes on purpose: the pre-fix write produced `0666 & ~umask`, a single value on any given host, so a one-mode assertion could pass by coincidence under some umask. No umask maps to both 0600 and 0640, so the pair is red on every host.

The one test that is not a regression test (`is still idempotent — an already trusted+onboarded cwd is not rewritten`) is a control guarding against "fix it by always writing". A `link → directory` case was deliberately **not** added here and the reason is in a comment: through this entry point `readFileSync` fails with `EISDIR` first and the function returns on its unreadable-config branch, so such a test would pass identically with and without the fix. That refusal is pinned where the resolver lives instead.

Every test writes to `mkdtemp` paths only, with `HOME` repointed for the `ensureCwdTrusted` cases — the real `~/.claude.json` is a `PROTECTED_FILE` in `tests/_setup.mjs`, and the sandbox guard was armed for every run above.

### Suites, lints, force-exit

```
cd packages/server
node --import ./tests/_setup.mjs --experimental-test-module-mocks --test \
  ./tests/byok-mcp-config-symlink-write.test.js ./tests/byok-mcp-config-mutation.test.js \
  ./tests/settings-handlers-mcp-config.test.js ./tests/byok-mcp-trust-spawn-config.test.js \
  ./tests/claude-tui-ensure-cwd-trusted-write.test.js ./tests/claude-tui-session.test.js
# tests 459 / pass 459 / fail 0
```

Full server suite (`CHROXY_CRED_DISABLE_KEYCHAIN=1 npm test`): **12665 tests, 12647 pass, 5 fail, 13 skipped** (run before the final one-word wording commit, which adds one test) — the same five pre-existing, environmental failures this machine has on `main`, none in a touched module:

- `doctor.test.js` → `codex provider reports credential status via OPENAI_API_KEY` (local codex env)
- `codex-spawn-argv.integration.test.js` → `sanity check: a deliberately-broken argv IS rejected by clap` (local `@openai/codex` vendor binary ENOENT)
- `tunnel.integration.test.js` → three tunnel tests (cloudflared quick-tunnel `failed to unmarshal quick Tunnel`, i.e. rate-limited)

Custom server shell lints, all five green:

```
OK: scripts/lint-claude-family-explicit.sh
OK: scripts/lint-logger-session-scoping.sh
OK: scripts/lint-session-opt-forwarding.sh
OK: scripts/lint-tests-state-file-path.sh
OK: scripts/lint-ws-index-mutations.sh
```

`eslint src/` → 0 errors (8 pre-existing warnings, none on a line this PR touches).

Force-exit trap: every touched test file self-exits with **no** `--test-force-exit`, both bare and under `c8` with a piped stdout (the shape that wedges CI):

```
./tests/claude-tui-ensure-cwd-trusted-write.test.js -> bare_rc=0 c8_piped_rc=0
./tests/byok-mcp-config-symlink-write.test.js       -> bare_rc=0 c8_piped_rc=0
./tests/byok-mcp-trust-spawn-config.test.js         -> bare_rc=0 c8_piped_rc=0
./tests/settings-handlers-mcp-config.test.js        -> bare_rc=0 c8_piped_rc=0
```

## Follow-ups (not in this diff)

- #7039 — a TOCTOU-free design, plus surfacing the mode warning to a client UI and a `chroxy doctor` check. `result.warning`, now pinned in both directions, is the API it builds on.
- #7047 — `planAddMcpServerToConfig` should run the new resolver inside the shared `prepareAddMcpServer`, so a refusal precedes the spawn-trust prompt instead of the prompt being spent on an operation that cannot succeed (and a trust grant outliving a server that was never added).
- #7048 — `geteuid` rather than `getuid`; skip the uid comparison when the effective uid is 0 (root-in-container with a bind-mounted host home, which chroxy supports); name the existing `CHROXY_CLAUDE_CONFIG` escape hatch in the refusal messages; narrow the resolver's first `lstatSync` catch to `ENOENT` so the "written THROUGH … or refused — never replaced" guarantee is enforced rather than incidental.

Closes #7002
Closes #7046
