### PR TITLE
docs(server): correct the stale maxLockAgeMs default in planRepoGc's comment

### DIFF
--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -163,7 +163,9 @@ export function planRepoGc(repoPath, deps = {}) {
     readLockReason = (wtPath) => readLockReasonFromAdmin(wtPath),
     // #5706: age-fallback seams. `now`/`mtimeMs` are injectable for tests.
     // `maxLockAgeMs` defaults to 0 — i.e. OFF; any value <= 0 disables the
-    // fallback. See DEFAULT_MAX_LOCK_AGE_MS above for why it's opt-in.
+    // fallback. When on, it fires only STRICTLY past the threshold: an age of
+    // exactly `maxLockAgeMs` is still skipped. See DEFAULT_MAX_LOCK_AGE_MS
+    // above for why it's opt-in.
     now = () => Date.now(),
     mtimeMs = (p) => { try { return statSync(p).mtimeMs } catch { return null } },
     maxLockAgeMs = DEFAULT_MAX_LOCK_AGE_MS,

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -162,7 +162,8 @@ export function planRepoGc(repoPath, deps = {}) {
     exists = existsSync,
     readLockReason = (wtPath) => readLockReasonFromAdmin(wtPath),
     // #5706: age-fallback seams. `now`/`mtimeMs` are injectable for tests.
-    // `maxLockAgeMs` defaults to 30d; 0 (or negative) disables the fallback.
+    // `maxLockAgeMs` defaults to 0 — i.e. OFF; any value <= 0 disables the
+    // fallback. See DEFAULT_MAX_LOCK_AGE_MS above for why it's opt-in.
     now = () => Date.now(),
     mtimeMs = (p) => { try { return statSync(p).mtimeMs } catch { return null } },
     maxLockAgeMs = DEFAULT_MAX_LOCK_AGE_MS,

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -287,10 +287,26 @@ describe('worktree-gc integration (real git repo)', () => {
       assert.match(item.skipReason, /uncommitted/)
     })
 
-    it('maxLockAgeMs=0 disables the fallback — a stale live pid is still skipped', () => {
-      addWorktree('live-stale-disabled', { lockReason: `claude agent a4 (pid ${LIVE_PID})` })
-      const item = planRepoGc(repo, { kill: fakeKill, now: () => 1_000_000, mtimeMs: () => 0, maxLockAgeMs: 0 })
-        .items.find((i) => i.path.endsWith('/live-stale-disabled'))
+    it('maxLockAgeMs <= 0 disables the fallback — a stale live pid is still skipped', () => {
+      // Both the default (0) and a negative must fail SAFE (fallback off), never
+      // "every worktree looks stale". config.js warns on negatives but does not
+      // hard-reject them, so this guard is the last line of defence.
+      for (const maxLockAgeMs of [0, -1]) {
+        const name = `live-stale-off-${maxLockAgeMs < 0 ? 'neg' : 'zero'}`
+        addWorktree(name, { lockReason: `claude agent a4 (pid ${LIVE_PID})` })
+        const item = planRepoGc(repo, { kill: fakeKill, now: () => 1_000_000, mtimeMs: () => 0, maxLockAgeMs })
+          .items.find((i) => i.path.endsWith(`/${name}`))
+        assert.equal(item.action, 'skip', `maxLockAgeMs=${maxLockAgeMs} must disable the fallback`)
+        assert.match(item.skipReason, /live process/)
+      }
+    })
+
+    it('fires only STRICTLY past the threshold — an age of exactly maxLockAgeMs is skipped', () => {
+      // The guard is `ageMs <= maxLockAgeMs` -> skip, so the boundary itself is
+      // NOT reclaimed. Pins the exclusivity claim in planRepoGc's dep comment.
+      addWorktree('live-boundary', { lockReason: `claude agent a5 (pid ${LIVE_PID})` })
+      const item = planRepoGc(repo, { kill: fakeKill, now: () => 1_000_000, mtimeMs: () => 999_000, maxLockAgeMs: 1000 })
+        .items.find((i) => i.path.endsWith('/live-boundary'))
       assert.equal(item.action, 'skip')
       assert.match(item.skipReason, /live process/)
     })


### PR DESCRIPTION
## Summary

The inline comment above `planRepoGc`'s `maxLockAgeMs` destructure in `packages/server/src/worktree-gc.js` claimed the option **"defaults to 30d"**. That contradicts the actual default — `DEFAULT_MAX_LOCK_AGE_MS = 0` — and the block comment a hundred lines above it that states **"DEFAULT IS 0 (DISABLED)"**.

A reader landing on `planRepoGc` (the function that actually consumes the value) would come away believing the age-based lock fallback is on by default with a 30-day threshold. It is off by default and opt-in via `config.worktreeGc.maxLockAgeMs`.

## Changes

**1. Correct the comment** (`src/worktree-gc.js`)

```diff
     // #5706: age-fallback seams. `now`/`mtimeMs` are injectable for tests.
-    // `maxLockAgeMs` defaults to 30d; 0 (or negative) disables the fallback.
+    // `maxLockAgeMs` defaults to 0 — i.e. OFF; any value <= 0 disables the
+    // fallback. When on, it fires only STRICTLY past the threshold: an age of
+    // exactly `maxLockAgeMs` is still skipped. See DEFAULT_MAX_LOCK_AGE_MS
+    // above for why it's opt-in.
```

It points at `DEFAULT_MAX_LOCK_AGE_MS` rather than restating the rationale, so the two comments can't drift apart again — a pointer cannot drift, a second copy of the number can.

**2. Pin the documented semantics with tests** (`tests/worktree-gc.test.js`)

The comment now states two things nothing asserted, so both are now covered:

| Claim | Test | Was it covered before? |
|---|---|---|
| any value `<= 0` disables the fallback | `maxLockAgeMs <= 0 disables…` now loops `[0, -1]` | Only `0`. The negative half rested on the guard alone — `config.js:1276` *warns* on a negative but does not hard-reject, so `planRepoGc` is the last line of defence. |
| fires only **strictly** past the threshold | new `fires only STRICTLY past the threshold…` | No. An age of exactly `maxLockAgeMs` is skipped (`ageMs <= maxLockAgeMs` → skip). |

## Verification

- **Behavior is unchanged.** The `src/` diff touches no executable lines — it is comment text only. The new tests pin pre-existing behavior; they do not change it.
- **Both new assertions were mutation-tested** (a test that cannot fail is worthless):
  - flipping `<=` to `<` in the guard → reds *only* the boundary test
  - treating just `0` (rather than `<= 0`) as disabled → reds *only* the negative case, failing with `maxLockAgeMs=-1 must disable the fallback`
- **39/39 pass**, exit 0 with **no `--test-force-exit`**, so no leaked handles.
- All 5 `packages/server/scripts/lint-*.sh` pass (the actual "Server Lint" CI gate).

## Docs — already correct, no change needed

`packages/server/CONFIG.md:116` already documents `` `0` (the default) disables it ``. A sweep of all 8 files referencing `maxLockAgeMs` found line 165 was the sole offender; the rest (`config.js`, `worktree-reaper.js`, `cli/worktree-gc-cmd.js`, three test files, and the `DEFAULT_MAX_LOCK_AGE_MS` block comment) all agree the default is 0. Grepping for `30d`/`2592000000` stated *without* the identifier turned up only unrelated options (`sessionTokenTtl`, the failed-restore prune TTL, the device-prefs stale grace).

Note `worktree-gc.js:48` still reads "14–30 days" — that is the *suggested operator threshold*, not a default, and is correctly left alone. It is almost certainly where the bogus "30d default" came from.

Noticed during an accuracy review of #7010 (the CONFIG.md doc audit) — the doc was right, only the in-code comment was wrong.

Related to #7010