### PR TITLE
fix(server,security): gate the primary-token revoke ack on its durable write

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -394,12 +394,32 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
  * set/delete paths: an fsync per write would add blocking disk I/O for no security
  * gain when the pre-write state is harmless. Acute credential ROTATION opts in, so
  * an operator who is told a shared secret was rotated cannot lose that rotation to
- * a power loss inside the OS writeback window. A genuine fsync failure (EIO /
- * ENOSPC) propagates — the caller reports the failure rather than a false success —
- * and the orphaned temp file is cleaned up by the `finally` below; the benign
- * "this filesystem cannot sync" codes are swallowed inside `fsyncForDurability`.
- * On Windows the directory fsync is skipped (no such call; `replaceFileAtomically`'s
- * rename already goes through MOVEFILE_WRITE_THROUGH).
+ * a power loss inside the OS writeback window. The benign "this filesystem cannot
+ * sync" codes are swallowed inside `fsyncForDurability`.
+ *
+ * The two fsync limbs fail DIFFERENTLY, and conflating them was its own false report:
+ *
+ *  - PRE-RENAME (temp file): a genuine failure (EIO / ENOSPC) THROWS. Nothing was
+ *    published — the live target still holds the prior value — so "the write failed"
+ *    is exactly true, and the orphaned temp file is cleaned up by the `finally` below.
+ *  - POST-RENAME (containing directory): the rename has ALREADY published the new
+ *    value and its bytes are already fsynced; only the durability of the new
+ *    directory ENTRY is unproven (a power loss could roll the rename back). Throwing
+ *    here would report a failed write for a write that LANDED — the caller would
+ *    keep the OLD value in its in-process cache while the NEW value is live on disk
+ *    (split brain), and an operator told "rotation failed" would leave the old secret
+ *    configured at the far end. So it does NOT throw: it logs at error level and is
+ *    returned to the caller as `durabilityUnconfirmed`, a distinct outcome from a
+ *    failed write. The caller must adopt the new value (it IS the live one) and
+ *    surface the caveat.
+ *
+ * On Windows the directory fsync is skipped entirely (no such call;
+ * `replaceFileAtomically`'s rename already goes through MOVEFILE_WRITE_THROUGH).
+ *
+ * @returns {{ durabilityUnconfirmed: string | null }} `durabilityUnconfirmed` is the
+ *   post-rename fsync error message when the value is live but its directory entry's
+ *   durability could not be confirmed; `null` otherwise (including every non-durable
+ *   write, which makes no durability claim at all).
  */
 function writeStoreAtomically(target, nextObj, { durable = false } = {}) {
   const key = getOrCreateMasterKey(activeKeychain())
@@ -410,6 +430,7 @@ function writeStoreAtomically(target, nextObj, { durable = false } = {}) {
   // costs nothing here and matches the pattern in path-hash-trust-ledger.js.
   const tmp = `${target}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`
   let renamed = false
+  let durabilityUnconfirmed = null
   try {
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })
     if (process.platform !== 'win32') chmodSync(tmp, 0o600)
@@ -430,13 +451,28 @@ function writeStoreAtomically(target, nextObj, { durable = false } = {}) {
     // #6964: the rename is a directory-metadata change of its own — fsync the
     // containing directory so the new entry survives a power loss too. POSIX only.
     if (durable && process.platform !== 'win32') {
-      _durabilityFsync(dirname(target), { isDir: true })
+      try {
+        _durabilityFsync(dirname(target), { isDir: true })
+      } catch (err) {
+        // POST-RENAME: the new value is already live and its bytes are already
+        // fsynced. Only the durability of the new directory ENTRY is unproven, so
+        // this is NOT a failed write — see the doc-block above. Report it as a
+        // distinct outcome instead of throwing, so the caller keeps its cache in
+        // step with disk while still surfacing the fsync error.
+        durabilityUnconfirmed = err?.message || String(err)
+        _log.error(
+          `credentials: the new value is live at ${target} but its directory entry could not be ` +
+          `fsynced (${durabilityUnconfirmed}) — a power loss could roll the rename back. ` +
+          `The value IS in effect; treat its durability as unconfirmed.`,
+        )
+      }
     }
   } finally {
     if (!renamed && existsSync(tmp)) {
       try { unlinkSync(tmp) } catch { /* */ }
     }
   }
+  return { durabilityUnconfirmed }
 }
 
 /**
@@ -550,15 +586,26 @@ export function readStoredField(field) {
  * atomically. The raw value is NEVER logged.
  *
  * `durable: true` (#6964) makes the write power-loss durable (fsync of the temp
- * file before the rename + of the containing directory after it) and turns a
- * durability failure into a throw. Acute ROTATION of a shared secret opts in — the
- * operator is told the rotation succeeded, so it must not be recoverable to the old
- * value by a crash. Ordinary sets leave it off (no fsync in the hot path).
+ * file before the rename + of the containing directory after it). Acute ROTATION of
+ * a shared secret opts in — the operator is told the rotation succeeded, so it must
+ * not be recoverable to the old value by a crash. Ordinary sets leave it off (no
+ * fsync in the hot path).
+ *
+ * Durability failures split by limb (see `writeStoreAtomically`): a PRE-rename fsync
+ * failure THROWS (nothing was published, the prior value stands), while a POST-rename
+ * DIRECTORY fsync failure does NOT — the new value is already live, so it is returned
+ * as `durabilityUnconfirmed` and the caller must adopt the new value and surface the
+ * caveat rather than report a failed write.
  *
  * @param {string} field - the JSON field name (e.g. 'githubWebhookSecret')
  * @param {string} rawValue
  * @param {{ validate?: (v: string) => (string|null), durable?: boolean }} [opts]
- * @throws {Error} on empty field/value, validation failure, or a read/write/fsync error
+ * @returns {{ durabilityUnconfirmed: string | null }} the write outcome — see
+ *   `writeStoreAtomically`. `durabilityUnconfirmed` is non-null only for a
+ *   `durable: true` write whose value LANDED but whose directory entry could not be
+ *   fsynced; the value is in effect either way.
+ * @throws {Error} on empty field/value, validation failure, a read/write error, or a
+ *   PRE-rename fsync failure (in which case nothing was written)
  */
 export function setStoredField(field, rawValue, { validate, durable = false } = {}) {
   if (typeof field !== 'string' || field.length === 0) throw new Error('field is required')
@@ -581,7 +628,7 @@ export function setStoredField(field, rawValue, { validate, durable = false } = 
   // overwriting unknown content.
   const { data, error } = readStore()
   if (error) throw new Error(error)
-  writeStoreAtomically(target, { ...data, [field]: value }, { durable })
+  return writeStoreAtomically(target, { ...data, [field]: value }, { durable })
 }
 
 /**

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -48,6 +48,7 @@ import { randomBytes } from 'crypto'
 import { maskApiKey } from './byok-credentials.js'
 import * as realKeychain from './keychain.js'
 import { createLogger } from './logger.js'
+import { fsyncForDurability } from './platform.js'
 import {
   CRED_KEY_SERVICE,
   isEncryptedEnvelope,
@@ -135,6 +136,21 @@ function activeKeychain() {
  */
 export function _setCredentialKeychainForTests(keychain) {
   _keychainOverride = keychain || null
+}
+
+// #6964: the durable-write hook used by `writeStoreAtomically({ durable: true })`.
+// Defaults to platform.js's `fsyncForDurability` (the same helper #6914 gave
+// `writeFileRestricted`, including its benign-fsync-code handling). Injectable so
+// the durable + durability-FAILURE branches are testable without provoking a real
+// disk fault, and without mocking `fs` globally for the whole process.
+let _durabilityFsync = fsyncForDurability
+
+/**
+ * Test seam (#6964): inject the durability hook — `(target, { isDir }) => void` —
+ * or pass null to restore the real `fsyncForDurability`.
+ */
+export function _setCredentialDurabilityForTests(fn) {
+  _durabilityFsync = fn || fsyncForDurability
 }
 
 /**
@@ -370,8 +386,22 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
  * plaintext. Preserves the temp-file → chmod 0600 → rename crash-safety and the
  * post-write mode re-check (POSIX). `dir` is assumed to already exist (callers
  * mkdir it). Shared by the set/delete/migrate paths.
+ *
+ * `durable` (default `false`, #6964) mirrors `writeFileRestricted({ durable: true })`
+ * from #6914: fsync the temp file BEFORE the rename, and on POSIX fsync the
+ * containing DIRECTORY AFTER it (a rename is not durable until its directory entry
+ * is) — the standard atomic-durable-write recipe. It stays OFF for the ordinary
+ * set/delete paths: an fsync per write would add blocking disk I/O for no security
+ * gain when the pre-write state is harmless. Acute credential ROTATION opts in, so
+ * an operator who is told a shared secret was rotated cannot lose that rotation to
+ * a power loss inside the OS writeback window. A genuine fsync failure (EIO /
+ * ENOSPC) propagates — the caller reports the failure rather than a false success —
+ * and the orphaned temp file is cleaned up by the `finally` below; the benign
+ * "this filesystem cannot sync" codes are swallowed inside `fsyncForDurability`.
+ * On Windows the directory fsync is skipped (no such call; `replaceFileAtomically`'s
+ * rename already goes through MOVEFILE_WRITE_THROUGH).
  */
-function writeStoreAtomically(target, nextObj) {
+function writeStoreAtomically(target, nextObj, { durable = false } = {}) {
   const key = getOrCreateMasterKey(activeKeychain())
   const payload = key ? encryptJson(nextObj, key) : nextObj
 
@@ -383,6 +413,10 @@ function writeStoreAtomically(target, nextObj) {
   try {
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })
     if (process.platform !== 'win32') chmodSync(tmp, 0o600)
+    // #6964: force the new bytes to disk BEFORE the rename makes them the live
+    // credentials, so a crash can never publish a half-written envelope nor roll
+    // a reported-successful rotation back.
+    if (durable) _durabilityFsync(tmp, { isDir: false })
     // #5243: atomic replace — never unlink the live target first.
     replaceFileAtomically(tmp, target)
     renamed = true
@@ -392,6 +426,11 @@ function writeStoreAtomically(target, nextObj) {
         try { unlinkSync(target) } catch { /* */ }
         throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
       }
+    }
+    // #6964: the rename is a directory-metadata change of its own — fsync the
+    // containing directory so the new entry survives a power loss too. POSIX only.
+    if (durable && process.platform !== 'win32') {
+      _durabilityFsync(dirname(target), { isDir: true })
     }
   } finally {
     if (!renamed && existsSync(tmp)) {
@@ -510,12 +549,18 @@ export function readStoredField(field) {
  * store (a read error aborts rather than clobbering sibling fields) and writes
  * atomically. The raw value is NEVER logged.
  *
+ * `durable: true` (#6964) makes the write power-loss durable (fsync of the temp
+ * file before the rename + of the containing directory after it) and turns a
+ * durability failure into a throw. Acute ROTATION of a shared secret opts in — the
+ * operator is told the rotation succeeded, so it must not be recoverable to the old
+ * value by a crash. Ordinary sets leave it off (no fsync in the hot path).
+ *
  * @param {string} field - the JSON field name (e.g. 'githubWebhookSecret')
  * @param {string} rawValue
- * @param {{ validate?: (v: string) => (string|null) }} [opts]
- * @throws {Error} on empty field/value, validation failure, or a read/write error
+ * @param {{ validate?: (v: string) => (string|null), durable?: boolean }} [opts]
+ * @throws {Error} on empty field/value, validation failure, or a read/write/fsync error
  */
-export function setStoredField(field, rawValue, { validate } = {}) {
+export function setStoredField(field, rawValue, { validate, durable = false } = {}) {
   if (typeof field !== 'string' || field.length === 0) throw new Error('field is required')
   const value = typeof rawValue === 'string' ? rawValue.trim() : ''
   if (value.length === 0) throw new Error(`${field} is required (non-empty string)`)
@@ -536,7 +581,7 @@ export function setStoredField(field, rawValue, { validate } = {}) {
   // overwriting unknown content.
   const { data, error } = readStore()
   if (error) throw new Error(error)
-  writeStoreAtomically(target, { ...data, [field]: value })
+  writeStoreAtomically(target, { ...data, [field]: value }, { durable })
 }
 
 /**

--- a/packages/server/src/handlers/github-webhook-handlers.js
+++ b/packages/server/src/handlers/github-webhook-handlers.js
@@ -110,6 +110,7 @@ function handleGithubWebhookSetSecret(ws, client, msg, ctx) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', `secret must be at least ${MIN_SECRET_LENGTH} characters`, undefined, ctx)
     return
   }
+  let outcome
   try {
     // Encrypt-at-rest aware, atomic 0600 write into the credentials store — never
     // plaintext config.json. err.message is validation/file-mode text, never the value.
@@ -118,9 +119,10 @@ function handleGithubWebhookSetSecret(ws, client, msg, ctx) {
     // GitHub. The operator gets a success ack and then re-points the GitHub webhook
     // at the new secret, so losing the write to a power loss inside the OS writeback
     // window would leave the daemon verifying deliveries with the old secret and
-    // rejecting every real one. The fsync failure path throws and is reported below
-    // as WEBHOOK_SECRET_WRITE_FAILED rather than acked as configured.
-    setStoredField(WEBHOOK_SECRET_FIELD, secret, { durable: true })
+    // rejecting every real one. A THROW here means nothing was published (the write
+    // itself failed, or its PRE-rename fsync did) — the old secret still stands, so
+    // report WEBHOOK_SECRET_WRITE_FAILED and do not touch the cache.
+    outcome = setStoredField(WEBHOOK_SECRET_FIELD, secret, { durable: true })
   } catch (err) {
     sendError(ws, msg?.requestId, 'WEBHOOK_SECRET_WRITE_FAILED', err?.message || 'write failed', undefined, ctx)
     return
@@ -128,10 +130,33 @@ function handleGithubWebhookSetSecret(ws, client, msg, ctx) {
   // Update the in-process hot cache so live webhook deliveries pick up the new
   // secret without a keychain re-read (and so a rotate never serves the stale
   // lazily-cached value). Guarded — a minimal test ctx may omit it.
+  //
+  // This runs for `outcome.durabilityUnconfirmed` too, and must: that outcome means
+  // the new secret IS live on disk and only the durability of the rename is unproven.
+  // Skipping it would leave the running daemon verifying deliveries with the OLD
+  // secret while the NEW one is what a restart loads — a silent, delayed outage.
   if (typeof ctx?.services?.setWebhookSecretCache === 'function') {
     ctx.services.setWebhookSecretCache(secret)
   }
+  // The reply is the success config: the rotation took effect. Reporting a failure
+  // for a write that landed would send the operator to re-point GitHub back at the
+  // old secret that the daemon no longer accepts.
   sendWebhookConfig(ws, ctx, msg?.requestId)
+  if (outcome?.durabilityUnconfirmed) {
+    // ...but the operator still learns the fsync failed. Deliberately requestId-LESS:
+    // the config above is this request's reply, and a client correlating an error to
+    // its in-flight requestId must not read this as the rotation's verdict.
+    sendError(
+      ws,
+      null,
+      'WEBHOOK_SECRET_DURABILITY_UNCONFIRMED',
+      'The new webhook secret is saved and live, but the filesystem could not confirm the write is durable ' +
+      `(${outcome.durabilityUnconfirmed}) — a power loss could roll the rotation back. ` +
+      'Resolve the storage error, then re-check the configured secret after the next restart.',
+      undefined,
+      ctx,
+    )
+  }
 }
 
 function handleGithubWebhookClearSecret(ws, client, msg, ctx) {

--- a/packages/server/src/handlers/github-webhook-handlers.js
+++ b/packages/server/src/handlers/github-webhook-handlers.js
@@ -113,7 +113,14 @@ function handleGithubWebhookSetSecret(ws, client, msg, ctx) {
   try {
     // Encrypt-at-rest aware, atomic 0600 write into the credentials store — never
     // plaintext config.json. err.message is validation/file-mode text, never the value.
-    setStoredField(WEBHOOK_SECRET_FIELD, secret)
+    //
+    // #6964: `durable: true` — this is credential ROTATION of a secret SHARED with
+    // GitHub. The operator gets a success ack and then re-points the GitHub webhook
+    // at the new secret, so losing the write to a power loss inside the OS writeback
+    // window would leave the daemon verifying deliveries with the old secret and
+    // rejecting every real one. The fsync failure path throws and is reported below
+    // as WEBHOOK_SECRET_WRITE_FAILED rather than acked as configured.
+    setStoredField(WEBHOOK_SECRET_FIELD, secret, { durable: true })
   } catch (err) {
     sendError(ws, msg?.requestId, 'WEBHOOK_SECRET_WRITE_FAILED', err?.message || 'write failed', undefined, ctx)
     return

--- a/packages/server/src/handlers/token-handlers.js
+++ b/packages/server/src/handlers/token-handlers.js
@@ -8,10 +8,12 @@
  * gates the request and pulls the trigger.
  *
  * #6965: that broadcast is the revoke's ACK, and WsServer withholds it until the
- * new token's DURABLE write has fsynced — so a client is never told the primary
- * token is dead before the revocation is actually on disk. A durability failure
- * sends `{ type: 'error', code: 'REVOKE_NOT_DURABLE' }` instead of the ack (the
- * revoke still holds in the running process; it just may not survive a restart).
+ * new token's persist reports success — so a client is never told the primary token
+ * is dead before the revocation has been stored. A durability failure sends
+ * `{ type: 'error', code: 'REVOKE_NOT_DURABLE' }` FIRST and then the broadcast
+ * anyway: the revoke holds in the running process, so the client must still
+ * re-authenticate (that broadcast is its only automatic trigger for doing so), and
+ * the "may not survive a restart" caveat rides the error.
  */
 
 import { createLogger } from '../logger.js'

--- a/packages/server/src/handlers/token-handlers.js
+++ b/packages/server/src/handlers/token-handlers.js
@@ -6,6 +6,12 @@
  * sever-shells + force-re-auth behavior lives in WsServer's `token_rotated`
  * handler (fired by the `TokenManager.revoke()` event) — this handler only
  * gates the request and pulls the trigger.
+ *
+ * #6965: that broadcast is the revoke's ACK, and WsServer withholds it until the
+ * new token's DURABLE write has fsynced — so a client is never told the primary
+ * token is dead before the revocation is actually on disk. A durability failure
+ * sends `{ type: 'error', code: 'REVOKE_NOT_DURABLE' }` instead of the ack (the
+ * revoke still holds in the running process; it just may not survive a restart).
  */
 
 import { createLogger } from '../logger.js'
@@ -17,9 +23,10 @@ const log = createLogger('token-handlers')
  *
  * Gated on `client.isPrimaryToken === true` (the same class the user-shell
  * create/terminal gates use): a paired or pairing-bound client must NOT be able
- * to revoke the primary token. On success there is no explicit ack — the
+ * to revoke the primary token. On success there is no handler-local ack — the
  * requester is de-authed by the revoke and receives the token-less
- * `token_rotated{reason:'revoke'}` broadcast like every other connection.
+ * `token_rotated{reason:'revoke'}` broadcast (gated on the durable write, #6965)
+ * like every other connection.
  */
 function handleRevokeToken(ws, client, msg, ctx) {
   const correlationId = ctx.correlationId

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -913,8 +913,9 @@ export async function startCliServer(config) {
         // #6965 — RETHROW. The revoke ack is now gated on this callback resolving,
         // so swallowing the error here would report a durable revoke that never
         // reached the disk (the exact false-safety this closes). TokenManager logs
-        // the rejection too, and for a revoke WsServer turns it into an explicit
-        // REVOKE_NOT_DURABLE error instead of the success ack.
+        // the rejection too, and for a revoke WsServer sends an explicit
+        // REVOKE_NOT_DURABLE error FIRST and then the token-less revoke transition
+        // anyway — the client must still re-authenticate.
         throw err
       }
     },

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -910,6 +910,12 @@ export async function startCliServer(config) {
         }
       } catch (err) {
         log.error(`Failed to persist token: ${err.message}`)
+        // #6965 — RETHROW. The revoke ack is now gated on this callback resolving,
+        // so swallowing the error here would report a durable revoke that never
+        // reached the disk (the exact false-safety this closes). TokenManager logs
+        // the rejection too, and for a revoke WsServer turns it into an explicit
+        // REVOKE_NOT_DURABLE error instead of the success ack.
+        throw err
       }
     },
   })

--- a/packages/server/src/token-manager.js
+++ b/packages/server/src/token-manager.js
@@ -19,9 +19,11 @@ const log = createLogger('token-manager')
  *   token_rotated { oldToken, newToken, expiresAt, reason, persisted }
  *
  * `persisted` (#6965) is a Promise for the `onPersist` write (null when no persist
- * callback is configured). It settles when the write — including its fsync, for the
- * durable revoke path — has completed, and REJECTS if the write failed. It exists so
- * the revoke's client-facing ack can be gated on durability instead of racing it.
+ * callback is configured). It settles when whichever storage path ran has completed —
+ * including its fsync where the persist site performs one (the `config.json` fallback
+ * on a durable revoke; the OS keychain owns its own durability) — and REJECTS if the
+ * write failed. It exists so the revoke's client-facing ack can be gated on the write
+ * instead of racing it.
  *
  * `reason` distinguishes a scheduled/periodic rotation ('scheduled') from an
  * operator revoke ('revoke', via `revoke()`). A revoke is the panic button:
@@ -183,7 +185,7 @@ export class TokenManager extends EventEmitter {
       // Attach a handler unconditionally: the log line is the SCHEDULED path's only
       // report, and it also guarantees no unhandled rejection when nothing consumes
       // `persisted` (no WsServer wired, or a listener that ignores it).
-      persisted.catch(err => {
+      persisted.catch((err) => {
         log.error(`Failed to persist new token: ${err?.message || err}`)
       })
     }

--- a/packages/server/src/token-manager.js
+++ b/packages/server/src/token-manager.js
@@ -16,7 +16,12 @@ const log = createLogger('token-manager')
  * 4. Calls the persist callback to save the new token
  *
  * Events:
- *   token_rotated { oldToken, newToken, expiresAt, reason }
+ *   token_rotated { oldToken, newToken, expiresAt, reason, persisted }
+ *
+ * `persisted` (#6965) is a Promise for the `onPersist` write (null when no persist
+ * callback is configured). It settles when the write — including its fsync, for the
+ * durable revoke path — has completed, and REJECTS if the write failed. It exists so
+ * the revoke's client-facing ack can be gated on durability instead of racing it.
  *
  * `reason` distinguishes a scheduled/periodic rotation ('scheduled') from an
  * operator revoke ('revoke', via `revoke()`). A revoke is the panic button:
@@ -47,7 +52,9 @@ export class TokenManager extends EventEmitter {
    * @param {Function} opts.onPersist - Callback to save new token:
    *   `async (newToken, { reason }) => {}`. `reason` is 'scheduled' | 'revoke'
    *   (#6927) so the persist site can make the panic-button revoke DURABLE while
-   *   leaving the routine scheduled rotation non-durable.
+   *   leaving the routine scheduled rotation non-durable. #6965: it MUST reject (or
+   *   throw) when the write fails — the revoke ack is gated on it resolving, so a
+   *   swallowed error there is reported to the operator as a successful revoke.
    */
   constructor({ token, tokenExpiry, graceMs, onPersist } = {}) {
     super()
@@ -157,22 +164,38 @@ export class TokenManager extends EventEmitter {
       log.info(`Token rotated`)
     }
 
+    // Persist the new token. #6927 — forward `reason` so the persist site can
+    // fsync a 'revoke' (the operator panic button killing a compromised token)
+    // while leaving a routine 'scheduled' rotation non-durable.
+    //
+    // #6965 — the persist is STARTED before the event is emitted and the resulting
+    // promise rides the event as `persisted`, so the revoke's client-facing ACK can
+    // be gated on the durable write actually landing (see WsServer's `token_rotated`
+    // handler). Previously this was fire-and-forget emitted AFTER the ack: the
+    // operator could be told the highest-authority token was dead while a power loss
+    // in the writeback window brought the daemon back still honouring it.
+    // The async wrapper turns a SYNCHRONOUS throw from `onPersist` into a rejection,
+    // so a failing persist can never escape as an exception out of rotate() and can
+    // never masquerade as success.
+    let persisted = null
+    if (this._onPersist) {
+      persisted = (async () => this._onPersist(newToken, { reason }))()
+      // Attach a handler unconditionally: the log line is the SCHEDULED path's only
+      // report, and it also guarantees no unhandled rejection when nothing consumes
+      // `persisted` (no WsServer wired, or a listener that ignores it).
+      persisted.catch(err => {
+        log.error(`Failed to persist new token: ${err?.message || err}`)
+      })
+    }
+
     // Emit event for WsServer to broadcast to clients
     this.emit('token_rotated', {
       oldToken,
       newToken,
       expiresAt: this._expiresAt,
       reason,
+      persisted,
     })
-
-    // Persist the new token. #6927 — forward `reason` so the persist site can
-    // fsync a 'revoke' (the operator panic button killing a compromised token)
-    // while leaving a routine 'scheduled' rotation non-durable.
-    if (this._onPersist) {
-      Promise.resolve(this._onPersist(newToken, { reason })).catch(err => {
-        log.error(`Failed to persist new token: ${err.message}`)
-      })
-    }
 
     // Start grace period for the old token — scheduled rotations only. A revoke
     // killed the old token above and must not resurrect it via a grace window.

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1344,8 +1344,11 @@ export class WsServer {
           // panic-revoke's token write durable, but `onPersist` was fire-and-forget
           // and this ack raced it — so the operator could be told the highest-authority
           // token was dead while a power loss inside the OS writeback window brought the
-          // daemon back still honouring it. Wait for the write (fsync included), THEN
-          // ack. On failure the client ALSO gets an explicit error — see below.
+          // daemon back still honouring it. Wait for the persist to report success —
+          // an fsync of the temp file + containing directory on the `config.json`
+          // fallback, while the OS-keychain path delegates durability to the
+          // keychain and performs no fsync here — THEN ack. On failure the client
+          // ALSO gets an explicit error — see below.
           if (!persisted) {
             // Nothing to wait on (no persist callback configured — e.g. a test
             // TokenManager, or a deployment with no token persistence). Unchanged

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -410,7 +410,7 @@ function _isSecureRequest(req) {
  *   { type: 'session_role', sessionId, primaryClientId } — #5589/#5281: explicit primary-ownership; client derives its role (primary iff primaryClientId === own clientId, observer if another holds it, null = unclaimed)
  *   { type: 'pong' }                                    — heartbeat response
  *   { type: 'permission_expired', requestId, sessionId, message }  — permission response could not be routed (expired/handled)
- *   { type: 'token_rotated', token?, expiresAt, reason? } — API token changed. Scheduled rotation carries the new `token` to encrypted clients (transparent re-key, sessions survive). A `reason: 'revoke'` (#6006) carries NO token: the operator revoked, so the server severed user-shell sessions and cleared this connection's auth — the client must re-authenticate with the current token (obtained out-of-band).
+ *   { type: 'token_rotated', token?, expiresAt, reason? } — API token changed. Scheduled rotation carries the new `token` to encrypted clients (transparent re-key, sessions survive). A `reason: 'revoke'` (#6006) carries NO token: the operator revoked, so the server severed user-shell sessions and cleared this connection's auth — the client must re-authenticate with the current token (obtained out-of-band). #6965: for a revoke this message is WITHHELD until the daemon's durable token write has fsynced, so the ack can never precede the revocation actually being on disk; if that write FAILS the connection receives an `error` with `code: 'REVOKE_NOT_DURABLE'` instead (the revoke still holds in the running process).
  *   { type: 'session_warning', sessionId, name, reason, message, remainingMs } — session about to timeout
  *   { type: 'session_timeout', sessionId, name, idleMs }         — session destroyed due to idle timeout
  *   { type: 'statusline_output', sessionId, text, active?, truncated? } — #6791: rendered stdout of the user's own Claude Code statusLine script (active:false + empty text clears it)
@@ -1288,8 +1288,12 @@ export class WsServer {
 
     // Wire TokenManager rotation events — broadcast new token to all clients
     this._tokenRotatedHandler = null
+    // #6965: the in-flight revoke-ack gate (a promise resolving to
+    // `{ ok, error? }`), or null when the last revoke had nothing to wait on.
+    // Exposed so a test can await the gate deterministically.
+    this._lastRevokeAck = null
     if (this._tokenManager) {
-      this._tokenRotatedHandler = ({ newToken, expiresAt, reason }) => {
+      this._tokenRotatedHandler = ({ newToken, expiresAt, reason, persisted = null }) => {
         // Update our reference so subsequent auth checks use the new token
         this.apiToken = newToken
 
@@ -1313,7 +1317,11 @@ export class WsServer {
           } catch (err) {
             log.error(`Failed to sever user-shell sessions on revoke: ${err.message}`)
           }
-          let forced = 0
+          //
+          // ENFORCEMENT (severing above + stripping authority below) is immediate
+          // and unconditional — it must NEVER wait on, or be skipped because of,
+          // disk I/O. Only the client-facing ACK is gated on durability (#6965).
+          const forcedSockets = []
           for (const [ws, client] of this.clients) {
             // Skip connections still mid-handshake (not yet authenticated): they
             // hold no authority to strip and will fail their pending auth step
@@ -1321,10 +1329,55 @@ export class WsServer {
             if (!client.authenticated || ws.readyState !== 1) continue
             client.authenticated = false
             client.isPrimaryToken = false
-            this._send(ws, { type: 'token_rotated', expiresAt, reason: 'revoke' })
-            forced++
+            forcedSockets.push(ws)
           }
-          log.warn(`Token REVOKED — severed ${severed} user-shell session(s), forced re-auth on ${forced} connection(s)`)
+          log.warn(`Token REVOKED — severed ${severed} user-shell session(s), forced re-auth on ${forcedSockets.length} connection(s)`)
+
+          const sendRevokeAck = () => {
+            for (const ws of forcedSockets) {
+              if (ws.readyState !== 1) continue
+              this._send(ws, { type: 'token_rotated', expiresAt, reason: 'revoke' })
+            }
+          }
+
+          // #6965: the revoke ack must not precede its durable write. #6963 made the
+          // panic-revoke's token write durable, but `onPersist` was fire-and-forget
+          // and this ack raced it — so the operator could be told the highest-authority
+          // token was dead while a power loss inside the OS writeback window brought the
+          // daemon back still honouring it. Wait for the write (fsync included), THEN
+          // ack. On failure send an explicit error instead: never a silent success.
+          if (!persisted) {
+            // Nothing to wait on (no persist callback configured — e.g. a test
+            // TokenManager, or a deployment with no token persistence). Unchanged
+            // synchronous behaviour.
+            this._lastRevokeAck = null
+            sendRevokeAck()
+            return
+          }
+          this._lastRevokeAck = persisted.then(
+            () => {
+              sendRevokeAck()
+              return { ok: true }
+            },
+            (err) => {
+              const message = err?.message || String(err)
+              log.error(
+                `Token REVOKE could not be persisted durably (${message}) — the revoke HOLDS in this process, ` +
+                `but a restart may resurrect the previous token. Fix the storage error and revoke again.`,
+              )
+              for (const ws of forcedSockets) {
+                if (ws.readyState !== 1) continue
+                this._send(ws, {
+                  type: 'error',
+                  code: 'REVOKE_NOT_DURABLE',
+                  message:
+                    'Token revoke is enforced for the running daemon but could NOT be written durably to disk — ' +
+                    'the previous token may become valid again if the daemon restarts. Resolve the storage error and revoke again.',
+                })
+              }
+              return { ok: false, error: message }
+            },
+          )
           return
         }
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -410,7 +410,7 @@ function _isSecureRequest(req) {
  *   { type: 'session_role', sessionId, primaryClientId } — #5589/#5281: explicit primary-ownership; client derives its role (primary iff primaryClientId === own clientId, observer if another holds it, null = unclaimed)
  *   { type: 'pong' }                                    — heartbeat response
  *   { type: 'permission_expired', requestId, sessionId, message }  — permission response could not be routed (expired/handled)
- *   { type: 'token_rotated', token?, expiresAt, reason? } — API token changed. Scheduled rotation carries the new `token` to encrypted clients (transparent re-key, sessions survive). A `reason: 'revoke'` (#6006) carries NO token: the operator revoked, so the server severed user-shell sessions and cleared this connection's auth — the client must re-authenticate with the current token (obtained out-of-band). #6965: for a revoke this message is WITHHELD until the daemon's durable token write has fsynced, so the ack can never precede the revocation actually being on disk; if that write FAILS the connection receives an `error` with `code: 'REVOKE_NOT_DURABLE'` instead (the revoke still holds in the running process).
+ *   { type: 'token_rotated', token?, expiresAt, reason? } — API token changed. Scheduled rotation carries the new `token` to encrypted clients (transparent re-key, sessions survive). A `reason: 'revoke'` (#6006) carries NO token: the operator revoked, so the server severed user-shell sessions and cleared this connection's auth — the client must re-authenticate with the current token (obtained out-of-band). #6965: for a revoke this message is WITHHELD until the daemon's token persist reports success, so the ack can never precede the revocation being stored — that persist is an fsync of the temp file + containing directory on the `config.json` fallback, while on the OS-keychain path (the macOS/libsecret default) durability is delegated to the keychain and no fsync is performed here. If the persist FAILS the connection receives an `error` with `code: 'REVOKE_NOT_DURABLE'` FIRST and then this message anyway: enforcement already ran unconditionally, so the client must still re-authenticate — the message carries no token and makes no durability claim, and the caveat rides the error.
  *   { type: 'session_warning', sessionId, name, reason, message, remainingMs } — session about to timeout
  *   { type: 'session_timeout', sessionId, name, idleMs }         — session destroyed due to idle timeout
  *   { type: 'statusline_output', sessionId, text, active?, truncated? } — #6791: rendered stdout of the user's own Claude Code statusLine script (active:false + empty text clears it)
@@ -1345,7 +1345,7 @@ export class WsServer {
           // and this ack raced it — so the operator could be told the highest-authority
           // token was dead while a power loss inside the OS writeback window brought the
           // daemon back still honouring it. Wait for the write (fsync included), THEN
-          // ack. On failure send an explicit error instead: never a silent success.
+          // ack. On failure the client ALSO gets an explicit error — see below.
           if (!persisted) {
             // Nothing to wait on (no persist callback configured — e.g. a test
             // TokenManager, or a deployment with no token persistence). Unchanged
@@ -1362,19 +1362,41 @@ export class WsServer {
             (err) => {
               const message = err?.message || String(err)
               log.error(
-                `Token REVOKE could not be persisted durably (${message}) — the revoke HOLDS in this process, ` +
-                `but a restart may resurrect the previous token. Fix the storage error and revoke again.`,
+                `Token REVOKE could not be confirmed durable (${message}) — the revoke HOLDS in this process, ` +
+                `but a restart is not guaranteed to come back on the new token. Fix the storage error and revoke again.`,
               )
+              // Send the operator DIAGNOSTIC first, then the revoke transition.
+              //
+              // Both, deliberately. The `error` envelope is the operator's report that
+              // durability is unproven; `token_rotated{reason:'revoke'}` is the CLIENT
+              // STATE TRANSITION — for the mobile app it is the sole automatic trigger
+              // for clearing the now-dead credential and prompting re-auth (app
+              // message-handler `case 'token_rotated'` with no token →
+              // clearSavedConnection() + disconnect() + re-scan alert). `case 'error'`
+              // shows an alert and touches neither the socket nor secure storage, so
+              // withholding the transition left every connected device "connected" while
+              // holding a REVOKED token with its server-side authority already stripped:
+              // privileged ops failing opaquely, nothing prompting a re-pair.
+              //
+              // Sending it is not a false success: the message carries NO token and makes
+              // NO durability claim. It says "this connection's authority is gone, you must
+              // re-authenticate", which is TRUE here — enforcement above already ran,
+              // unconditionally. The durability caveat rides the error, not this message.
+              //
+              // Diagnostic first because the transition tears the socket down client-side;
+              // a frame queued after it can be dropped before the client reads it.
               for (const ws of forcedSockets) {
                 if (ws.readyState !== 1) continue
                 this._send(ws, {
                   type: 'error',
                   code: 'REVOKE_NOT_DURABLE',
                   message:
-                    'Token revoke is enforced for the running daemon but could NOT be written durably to disk — ' +
-                    'the previous token may become valid again if the daemon restarts. Resolve the storage error and revoke again.',
+                    'Token revoke is enforced for the running daemon but its write could NOT be confirmed durable on disk — ' +
+                    'after a restart the daemon may come back on either the new token or the previous one. ' +
+                    'Resolve the storage error and revoke again.',
                 })
               }
+              sendRevokeAck()
               return { ok: false, error: message }
             },
           )

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -19,8 +19,15 @@ import { nsCtx } from './test-helpers.js'
  *   - ON for the rotation path: temp file fsynced BEFORE the rename, containing
  *     directory fsynced AFTER it (a rename is not durable until its directory
  *     entry is),
- *   - a durability FAILURE throws instead of reporting success, and the prior
- *     value survives.
+ *   - a PRE-RENAME (temp file) durability failure throws instead of reporting
+ *     success, and the prior value survives — nothing was published,
+ *   - a POST-RENAME (directory) durability failure does NOT throw: the rename has
+ *     already published the new value, so only the durability of the new directory
+ *     ENTRY is unproven. Reporting a failed write there would be factually wrong
+ *     and would leave the in-process cache holding a value that is no longer on
+ *     disk (split brain). It reports a distinct `durabilityUnconfirmed` outcome,
+ *     the caller updates its cache to match disk, and the operator gets a
+ *     `WEBHOOK_SECRET_DURABILITY_UNCONFIRMED` diagnostic alongside the config ack.
  *
  * The durability hook is injected (`_setCredentialDurabilityForTests`) so the
  * assertions never depend on real fsync behaviour of the host filesystem.
@@ -45,6 +52,14 @@ function makeCtx(cache = { value: undefined }) {
   })
 }
 
+/** Every frame the handler produced, in order, across both send paths. */
+function allReplies(ws, ctx) {
+  const out = []
+  for (const call of ctx.transport.send.mock.calls) out.push(call.arguments[1])
+  for (const call of ws.send.mock.calls) out.push(JSON.parse(call.arguments[0]))
+  return out
+}
+
 function lastReply(ws, ctx) {
   if (ws.send.mock.callCount() > 0) {
     return JSON.parse(ws.send.mock.calls[ws.send.mock.calls.length - 1].arguments[0])
@@ -53,6 +68,18 @@ function lastReply(ws, ctx) {
     return ctx.transport.send.mock.calls[ctx.transport.send.mock.calls.length - 1].arguments[1]
   }
   return null
+}
+
+function throwOnDirFsync(calls) {
+  return (target, { isDir = false } = {}) => {
+    calls.push({ target, isDir })
+    // The temp-file fsync (pre-rename) SUCCEEDS — only the containing
+    // directory's fsync (post-rename, after the value is already live) fails.
+    if (!isDir) return
+    const err = new Error('simulated directory fsync I/O failure')
+    err.code = 'EIO'
+    throw err
+  }
 }
 
 describe('credential-store durable-write seam (#6964)', () => {
@@ -126,7 +153,7 @@ describe('credential-store durable-write seam (#6964)', () => {
     assert.equal(dirCall.targetExists, true, 'directory fsync must happen AFTER the rename')
   })
 
-  it('a durability failure throws and leaves the previously stored value intact', () => {
+  it('a PRE-RENAME (temp file) durability failure throws and leaves the previously stored value intact', () => {
     credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-original-value-0001')
     calls = []
     credStore._setCredentialDurabilityForTests(() => {
@@ -148,6 +175,34 @@ describe('credential-store durable-write seam (#6964)', () => {
     )
     const leftovers = readdirSync(credDir).filter((n) => n.includes('.tmp.'))
     assert.deepEqual(leftovers, [], 'the orphaned temp file must be cleaned up')
+  })
+
+  it('a POST-RENAME (directory) durability failure does NOT throw — the value is live, only its durability is unproven', () => {
+    if (IS_WINDOWS) return // no directory fsync on Windows (MOVEFILE_WRITE_THROUGH covers the rename)
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-original-value-0001')
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    let outcome
+    assert.doesNotThrow(() => {
+      outcome = credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-rotated-value-0002', { durable: true })
+    }, 'the rename already published the new value — reporting a failed write would be factually wrong')
+    credStore._setCredentialDurabilityForTests(null)
+
+    assert.equal(calls.length, 2, 'both limbs ran: temp-file fsync then directory fsync')
+    assert.equal(
+      credStore.readStoredField(WEBHOOK_SECRET_FIELD).value,
+      'whsec-rotated-value-0002',
+      'the new value IS on disk — the rename succeeded before the directory fsync failed',
+    )
+    assert.equal(
+      typeof outcome?.durabilityUnconfirmed,
+      'string',
+      'the caller must be told durability is UNCONFIRMED (distinct from the write failing)',
+    )
+    assert.match(outcome.durabilityUnconfirmed, /directory fsync/)
+    const leftovers = readdirSync(credDir).filter((n) => n.includes('.tmp.'))
+    assert.deepEqual(leftovers, [], 'no orphaned temp file')
   })
 
   it('the webhook-secret ROTATION path drives the durable write and acks only on success', () => {
@@ -173,7 +228,51 @@ describe('credential-store durable-write seam (#6964)', () => {
     }
   })
 
-  it('the rotation path reports a durability failure instead of acking success', () => {
+  it('the rotation path never reports a failed write for a rotation that LANDED, and the cache follows disk', () => {
+    if (IS_WINDOWS) return // no directory fsync on Windows
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-original-value-0001')
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    const ws = makeWs()
+    const cache = { value: undefined }
+    const ctx = makeCtx(cache)
+    githubWebhookHandlers.github_webhook_set_secret(
+      ws,
+      { id: 'c1', isPrimaryToken: true },
+      { type: 'github_webhook_set_secret', requestId: 'r3', secret: 'whsec-rotated-value-0002' },
+      ctx,
+    )
+    const replies = allReplies(ws, ctx)
+    credStore._setCredentialDurabilityForTests(null)
+
+    // The new secret is live on disk...
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, 'whsec-rotated-value-0002')
+    // ...so the reply must NOT claim the write failed (the operator would leave
+    // the OLD secret configured at GitHub while the daemon verifies with the new one).
+    assert.deepEqual(
+      replies.filter((r) => r.code === 'WEBHOOK_SECRET_WRITE_FAILED'),
+      [],
+      'a write that landed must never be reported as a failed write',
+    )
+    const config = replies.find((r) => r.type === 'github_webhook_config')
+    assert.ok(config, 'the reply is still the value-free config')
+    assert.equal(config.configured, true)
+    // ...and the in-process cache must never diverge from what is on disk.
+    assert.equal(
+      cache.value,
+      'whsec-rotated-value-0002',
+      'the hot cache must track disk — otherwise live deliveries verify with the OLD secret',
+    )
+    // ...while the operator still learns the durability of the write is unproven.
+    const caveat = replies.find((r) => r.code === 'WEBHOOK_SECRET_DURABILITY_UNCONFIRMED')
+    assert.ok(caveat, 'the fsync failure must still be surfaced to the operator')
+    assert.equal(caveat.type, 'error')
+    assert.match(caveat.message, /durab/i)
+    assert.match(caveat.message, /saved|live|stored/i)
+  })
+
+  it('the rotation path reports a PRE-RENAME durability failure instead of acking success', () => {
     credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-original-value-0001')
     credStore._setCredentialDurabilityForTests(() => {
       const err = new Error('simulated fsync I/O failure')

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -1,0 +1,199 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as credStore from '../src/credential-store.js'
+import { githubWebhookHandlers } from '../src/handlers/github-webhook-handlers.js'
+import { WEBHOOK_SECRET_FIELD } from '../src/github-webhook.js'
+import { nsCtx } from './test-helpers.js'
+
+/**
+ * #6964 — the credential store's durable-write seam.
+ *
+ * `writeStoreAtomically` predates #6914's `writeFileRestricted({ durable: true })`
+ * and had no way to force a credential rotation to disk: an operator could rotate
+ * a shared secret, be told it succeeded, and lose it to a power failure inside the
+ * OS writeback window. These tests pin the seam:
+ *   - OFF by default (no fsync on an ordinary set — no new blocking I/O),
+ *   - ON for the rotation path: temp file fsynced BEFORE the rename, containing
+ *     directory fsynced AFTER it (a rename is not durable until its directory
+ *     entry is),
+ *   - a durability FAILURE throws instead of reporting success, and the prior
+ *     value survives.
+ *
+ * The durability hook is injected (`_setCredentialDurabilityForTests`) so the
+ * assertions never depend on real fsync behaviour of the host filesystem.
+ * A temp HOME isolates the real credentials store; the test bootstrap sets
+ * CHROXY_CRED_DISABLE_KEYCHAIN=1, so writes land as 0600 plaintext and the
+ * encryption-at-rest path is untouched by this test.
+ */
+
+const IS_WINDOWS = process.platform === 'win32'
+
+function makeWs() {
+  return { readyState: 1, send: mock.fn() }
+}
+
+function makeCtx(cache = { value: undefined }) {
+  return nsCtx({
+    send: mock.fn(),
+    broadcast: mock.fn(),
+    webhookPayloadUrl: { url: 'https://x.trycloudflare.com/api/github/webhook', lanOnly: false, note: null },
+    repoWebhookDeliveries: null,
+    setWebhookSecretCache: mock.fn((v) => { cache.value = v }),
+  })
+}
+
+function lastReply(ws, ctx) {
+  if (ws.send.mock.callCount() > 0) {
+    return JSON.parse(ws.send.mock.calls[ws.send.mock.calls.length - 1].arguments[0])
+  }
+  if (ctx.transport.send.mock.callCount() > 0) {
+    return ctx.transport.send.mock.calls[ctx.transport.send.mock.calls.length - 1].arguments[1]
+  }
+  return null
+}
+
+describe('credential-store durable-write seam (#6964)', () => {
+  let tmpHome
+  let originalHome
+  let savedEnvSecret
+  let calls
+  let credFile
+  let credDir
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-durable-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+    savedEnvSecret = process.env.GITHUB_WEBHOOK_SECRET
+    delete process.env.GITHUB_WEBHOOK_SECRET
+    credDir = join(tmpHome, '.chroxy')
+    credFile = join(credDir, 'credentials.json')
+    calls = []
+    assert.equal(
+      typeof credStore._setCredentialDurabilityForTests,
+      'function',
+      'credential-store must expose the injectable durability seam (#6964)',
+    )
+    credStore._setCredentialDurabilityForTests((target, { isDir = false } = {}) => {
+      // Record whether the FINAL file already exists at fsync time — that is how
+      // we prove the temp-file fsync happens before the rename and the directory
+      // fsync after it, without reaching into the module internals.
+      calls.push({ target, isDir, targetExists: existsSync(credFile) })
+    })
+  })
+
+  afterEach(() => {
+    if (typeof credStore._setCredentialDurabilityForTests === 'function') {
+      credStore._setCredentialDurabilityForTests(null)
+    }
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    if (savedEnvSecret === undefined) delete process.env.GITHUB_WEBHOOK_SECRET
+    else process.env.GITHUB_WEBHOOK_SECRET = savedEnvSecret
+    try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  it('does NOT fsync on an ordinary (non-durable) set — the default stays off', () => {
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-ordinary-value-0001')
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, 'whsec-ordinary-value-0001')
+    assert.deepEqual(calls, [], 'a default set must add no fsync to the write path')
+  })
+
+  it('durable set fsyncs the temp file BEFORE the rename and the directory AFTER', () => {
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-durable-value-0001', { durable: true })
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, 'whsec-durable-value-0001')
+
+    assert.ok(calls.length >= 1, 'durable set must fsync the temp file')
+    const [fileCall] = calls
+    assert.equal(fileCall.isDir, false, 'first fsync is the temp FILE')
+    assert.ok(
+      fileCall.target.startsWith(credFile) && fileCall.target !== credFile,
+      `first fsync target should be the temp sibling of ${credFile}, got ${fileCall.target}`,
+    )
+    assert.equal(fileCall.targetExists, false, 'temp-file fsync must happen BEFORE the rename')
+
+    if (IS_WINDOWS) {
+      assert.equal(calls.length, 1, 'Windows has no directory fsync (MOVEFILE_WRITE_THROUGH covers the rename)')
+      return
+    }
+    assert.equal(calls.length, 2, 'POSIX durable write = temp-file fsync + containing-directory fsync')
+    const dirCall = calls[1]
+    assert.equal(dirCall.isDir, true, 'second fsync is the containing DIRECTORY')
+    assert.equal(dirCall.target, credDir)
+    assert.equal(dirCall.targetExists, true, 'directory fsync must happen AFTER the rename')
+  })
+
+  it('a durability failure throws and leaves the previously stored value intact', () => {
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-original-value-0001')
+    calls = []
+    credStore._setCredentialDurabilityForTests(() => {
+      const err = new Error('simulated fsync I/O failure')
+      err.code = 'EIO'
+      throw err
+    })
+
+    assert.throws(
+      () => credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-rotated-value-0002', { durable: true }),
+      /EIO|simulated fsync I\/O failure/,
+      'a genuine fsync failure must surface, never report success',
+    )
+    credStore._setCredentialDurabilityForTests(null)
+    assert.equal(
+      credStore.readStoredField(WEBHOOK_SECRET_FIELD).value,
+      'whsec-original-value-0001',
+      'the prior credential must survive a failed durable rotation',
+    )
+    const leftovers = readdirSync(credDir).filter((n) => n.includes('.tmp.'))
+    assert.deepEqual(leftovers, [], 'the orphaned temp file must be cleaned up')
+  })
+
+  it('the webhook-secret ROTATION path drives the durable write and acks only on success', () => {
+    const ws = makeWs()
+    const cache = { value: undefined }
+    const ctx = makeCtx(cache)
+    githubWebhookHandlers.github_webhook_set_secret(
+      ws,
+      { id: 'c1', isPrimaryToken: true },
+      { type: 'github_webhook_set_secret', requestId: 'r1', secret: 'whsec-rotated-by-operator' },
+      ctx,
+    )
+    const reply = lastReply(ws, ctx)
+    assert.equal(reply.type, 'github_webhook_config', 'success ack is the value-free config')
+    assert.equal(reply.configured, true)
+    assert.equal(cache.value, 'whsec-rotated-by-operator')
+    assert.ok(calls.length >= 1, 'the rotation path must reach the durable write')
+    assert.equal(calls[0].isDir, false)
+    assert.equal(calls[0].targetExists, false)
+    if (!IS_WINDOWS) {
+      assert.equal(calls.length, 2)
+      assert.equal(calls[1].isDir, true)
+    }
+  })
+
+  it('the rotation path reports a durability failure instead of acking success', () => {
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-original-value-0001')
+    credStore._setCredentialDurabilityForTests(() => {
+      const err = new Error('simulated fsync I/O failure')
+      err.code = 'EIO'
+      throw err
+    })
+    const ws = makeWs()
+    const cache = { value: undefined }
+    const ctx = makeCtx(cache)
+    githubWebhookHandlers.github_webhook_set_secret(
+      ws,
+      { id: 'c1', isPrimaryToken: true },
+      { type: 'github_webhook_set_secret', requestId: 'r2', secret: 'whsec-rotated-value-0002' },
+      ctx,
+    )
+    const reply = lastReply(ws, ctx)
+    assert.equal(reply.type, 'error', 'a non-durable rotation must NOT ack as configured')
+    assert.equal(reply.code, 'WEBHOOK_SECRET_WRITE_FAILED')
+    assert.equal(cache.value, undefined, 'the hot cache must not adopt a secret that never landed')
+    credStore._setCredentialDurabilityForTests(null)
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, 'whsec-original-value-0001')
+  })
+})

--- a/packages/server/tests/token-revoke-durable-ack.test.js
+++ b/packages/server/tests/token-revoke-durable-ack.test.js
@@ -1,0 +1,173 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { TokenManager } from '../src/token-manager.js'
+import { WsServer } from '../src/ws-server.js'
+
+/**
+ * #6965 — the primary-token revoke ack must not precede its durable write.
+ *
+ * #6963 made the panic-revoke's token write durable (`{ durable: true }`), but
+ * `onPersist` was fire-and-forget and the `token_rotated{reason:'revoke'}` ack
+ * was emitted BEFORE it. That is false safety of the most consequential kind: the
+ * operator is told the highest-authority token is dead while a power loss inside
+ * the OS writeback window brings the daemon back still honouring it.
+ *
+ * The contract pinned here:
+ *   1. ENFORCEMENT is immediate and unconditional — shells severed and every live
+ *      connection de-authed before any disk I/O is awaited (a slow or failing
+ *      fsync must never leave a compromised connection privileged).
+ *   2. The client-facing ACK is sent strictly AFTER the persist settles.
+ *   3. A durability FAILURE produces an explicit `REVOKE_NOT_DURABLE` error and
+ *      NEVER the success ack.
+ *   4. Scheduled rotations stay non-blocking (only the acute revoke is gated).
+ *
+ * No sockets are opened: `WsServer`'s constructor creates no handles, so the real
+ * `token_rotated` wiring is driven with a fake client map and a `_send` spy.
+ */
+
+function deferred() {
+  let resolve, reject
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+/** Let N rounds of microtasks (and one macrotask) drain. */
+async function drain(rounds = 5) {
+  for (let i = 0; i < rounds; i++) await Promise.resolve()
+  await new Promise((r) => setImmediate(r))
+}
+
+function makeServer(tokenManager) {
+  const server = new WsServer({
+    port: 0,
+    apiToken: 'token-old',
+    authRequired: true,
+    noEncrypt: true,
+    tokenManager,
+  })
+  const sent = []
+  server._send = (ws, msg) => { sent.push({ ws, msg }) }
+  const severed = []
+  server.sessionManager = {
+    destroyAllUserShellSessions: (reason) => { severed.push(reason); return 2 },
+  }
+  const ws = { readyState: 1 }
+  const client = { id: 'c1', authenticated: true, isPrimaryToken: true }
+  server.clients = new Map([[ws, client]])
+  return { server, sent, severed, ws, client }
+}
+
+describe('primary-token revoke: durable-write ack gating (#6965)', () => {
+  let managers = []
+  afterEach(() => {
+    for (const m of managers) m.destroy()
+    managers = []
+  })
+  function track(m) { managers.push(m); return m }
+
+  it('token_rotated carries an awaitable `persisted` promise for the persist', async () => {
+    const gate = deferred()
+    const manager = track(new TokenManager({ token: 'token-old', onPersist: () => gate.promise }))
+    const events = []
+    manager.on('token_rotated', (e) => events.push(e))
+
+    const newToken = manager.revoke()
+    assert.equal(manager.currentToken, newToken, 'revoke still returns the new token synchronously')
+    assert.equal(events.length, 1)
+    assert.ok(events[0].persisted && typeof events[0].persisted.then === 'function',
+      'the revoke event must expose the persist as an awaitable seam')
+
+    let settled = false
+    events[0].persisted.then(() => { settled = true })
+    await drain()
+    assert.equal(settled, false, 'persisted must not settle before the write does')
+    gate.resolve()
+    await events[0].persisted
+    assert.equal(settled, true)
+  })
+
+  it('a throwing onPersist becomes a rejected `persisted` (never a sync throw or a silent success)', async () => {
+    const manager = track(new TokenManager({
+      token: 'token-old',
+      onPersist: () => { const err = new Error('simulated fsync I/O failure'); err.code = 'EIO'; throw err },
+    }))
+    let event = null
+    manager.on('token_rotated', (e) => { event = e })
+    assert.doesNotThrow(() => manager.revoke())
+    await assert.rejects(event.persisted, /simulated fsync I\/O failure/)
+  })
+
+  it('carries a null `persisted` when no persist hook is configured', () => {
+    const manager = track(new TokenManager({ token: 'token-old' }))
+    let event = null
+    manager.on('token_rotated', (e) => { event = e })
+    manager.revoke()
+    assert.equal(event.persisted, null)
+  })
+
+  it('severs + de-auths immediately, but withholds the ack until the durable write lands', async () => {
+    const gate = deferred()
+    const manager = track(new TokenManager({ token: 'token-old', onPersist: () => gate.promise }))
+    const { server, sent, severed, client } = makeServer(manager)
+
+    manager.revoke()
+
+    // (1) enforcement is immediate — it must NOT wait on the disk.
+    assert.deepEqual(severed, ['revoked'], 'user-shell sessions severed at once')
+    assert.equal(client.authenticated, false, 'connection de-authed at once')
+    assert.equal(client.isPrimaryToken, false, 'primary authority stripped at once')
+
+    // (2) the ack is withheld while the durable write is in flight.
+    await drain()
+    assert.deepEqual(sent, [], 'no revoke ack may be sent before the durable write completes')
+
+    gate.resolve()
+    const outcome = await server._lastRevokeAck
+    assert.deepEqual(outcome, { ok: true })
+    assert.equal(sent.length, 1, 'exactly one ack per connection, after the write')
+    assert.deepEqual(sent[0].msg, { type: 'token_rotated', expiresAt: null, reason: 'revoke' })
+  })
+
+  it('a durability failure yields REVOKE_NOT_DURABLE and never the success ack', async () => {
+    const gate = deferred()
+    const manager = track(new TokenManager({ token: 'token-old', onPersist: () => gate.promise }))
+    const { server, sent, client } = makeServer(manager)
+
+    manager.revoke()
+    const err = new Error('simulated fsync I/O failure')
+    err.code = 'EIO'
+    gate.reject(err)
+    const outcome = await server._lastRevokeAck
+
+    assert.equal(outcome.ok, false)
+    assert.equal(client.authenticated, false, 'enforcement still holds in-process')
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].msg.type, 'error')
+    assert.equal(sent[0].msg.code, 'REVOKE_NOT_DURABLE')
+    assert.match(sent[0].msg.message, /durabl|restart/i)
+    assert.equal(
+      sent.filter((s) => s.msg.type === 'token_rotated').length,
+      0,
+      'a non-durable revoke must never report success',
+    )
+  })
+
+  it('sends the ack synchronously when no persist hook is configured (unchanged path)', () => {
+    const manager = track(new TokenManager({ token: 'token-old' }))
+    const { server, sent } = makeServer(manager)
+    manager.revoke()
+    assert.equal(sent.length, 1, 'nothing to wait for — ack stays synchronous')
+    assert.equal(sent[0].msg.reason, 'revoke')
+    assert.equal(server._lastRevokeAck, null)
+  })
+
+  it('does NOT gate a scheduled rotation on its persist (routine rotations stay non-blocking)', () => {
+    const gate = deferred()
+    const manager = track(new TokenManager({ token: 'token-old', graceMs: 50, onPersist: () => gate.promise }))
+    const { sent } = makeServer(manager)
+    manager.rotate() // scheduled
+    assert.equal(sent.length, 1, 'a scheduled rotation broadcasts immediately')
+    assert.equal(sent[0].msg.reason, 'scheduled')
+    gate.resolve()
+  })
+})

--- a/packages/server/tests/token-revoke-durable-ack.test.js
+++ b/packages/server/tests/token-revoke-durable-ack.test.js
@@ -128,7 +128,7 @@ describe('primary-token revoke: durable-write ack gating (#6965)', () => {
     assert.deepEqual(sent[0].msg, { type: 'token_rotated', expiresAt: null, reason: 'revoke' })
   })
 
-  it('a durability failure yields REVOKE_NOT_DURABLE and never the success ack', async () => {
+  it('a durability failure sends REVOKE_NOT_DURABLE *and* the revoke transition, in that order', async () => {
     const gate = deferred()
     const manager = track(new TokenManager({ token: 'token-old', onPersist: () => gate.promise }))
     const { server, sent, client } = makeServer(manager)
@@ -141,14 +141,27 @@ describe('primary-token revoke: durable-write ack gating (#6965)', () => {
 
     assert.equal(outcome.ok, false)
     assert.equal(client.authenticated, false, 'enforcement still holds in-process')
-    assert.equal(sent.length, 1)
+    assert.equal(sent.length, 2, 'the diagnostic AND the state transition, one of each per connection')
+
+    // The operator diagnostic goes FIRST: `token_rotated{reason:'revoke'}` makes the
+    // mobile client tear the socket down, so a frame queued after it can be lost.
     assert.equal(sent[0].msg.type, 'error')
     assert.equal(sent[0].msg.code, 'REVOKE_NOT_DURABLE')
     assert.match(sent[0].msg.message, /durabl|restart/i)
-    assert.equal(
-      sent.filter((s) => s.msg.type === 'token_rotated').length,
-      0,
-      'a non-durable revoke must never report success',
+
+    // ...and the transition is NOT withheld. It is this connection's ONLY automatic
+    // trigger for clearing the now-dead credential and prompting re-auth
+    // (packages/app/src/store/message-handler.ts `case 'token_rotated'` with no
+    // token → clearSavedConnection() + disconnect() + re-scan alert). The `error`
+    // envelope reaches neither the socket nor secure storage, so withholding this
+    // left every mobile client "connected" holding a REVOKED token with server-side
+    // authority already stripped — every privileged op failing opaquely, nothing
+    // prompting a re-pair. The message carries no token and makes no durability
+    // claim; "your authority is gone" is TRUE on this branch.
+    assert.deepEqual(
+      sent[1].msg,
+      { type: 'token_rotated', expiresAt: null, reason: 'revoke' },
+      'the revoke transition must still be delivered when the write was not durable',
     )
   })
 


### PR DESCRIPTION
## What

Two related durability gaps from the review of #6963, fixed together because the second consumes the first.

### #6965 — the primary-token revoke ack raced its durable write (false safety)

`TokenManager.rotate()` emitted `token_rotated` — which **is** the revoke's ack, and what drives every client onto its "must re-authenticate" path — and only *then* called `onPersist`, fire-and-forget. #6963 made that write durable (`{ durable: true }`), but nothing waited for it. So the operator could be told the **highest-authority token is dead** while a power loss inside the OS writeback window brought the daemon back still honouring it.

- **token-manager**: the persist now starts *before* the emit, and the resulting promise rides the event as `persisted` (`null` when no persist hook is configured). An `async` wrapper turns a synchronous `onPersist` throw into a rejection, so a failing write can never escape as an exception out of `rotate()` nor masquerade as success. **This also closes a pre-existing escape**: `Promise.resolve(this._onPersist(...))` evaluated the callback *before* wrapping it, so a synchronous throw propagated out of `rotate()` — including on the scheduled-rotation timer path, where nothing would have caught it. A `.catch` is always attached (the log line is the scheduled path's only report, and it prevents an unhandled rejection when nothing consumes the promise).
- **ws-server**: for `reason: 'revoke'`, **enforcement stays immediate and unconditional** — user-shell sessions severed and every live connection's `authenticated`/`isPrimaryToken` stripped before any disk I/O is awaited. Only the client-facing **ack** is gated: `token_rotated` is sent after `persisted` resolves. On rejection each affected connection receives `{ type: 'error', code: 'REVOKE_NOT_DURABLE' }` **and then the `token_rotated{reason:'revoke'}` transition anyway** — see "The not-durable branch sends both" below — plus an explicit `log.error`. Scheduled rotations are not gated.
- **server-cli**: the token `onPersist` now **rethrows** after logging. Swallowing the write error there would have satisfied the new gate and reported a durable revoke that never reached the disk — the same false safety one layer down.

No new wire type and no new wire field: the ack is the existing `token_rotated`, the failure is the existing free-form `error` envelope (`REVOKE_NOT_DURABLE`), so no protocol/store-core/client changes are needed. The `token_rotated` doc-block in `ws-server.js` records the new contract.

#### The not-durable branch sends both

The failure branch initially withheld `token_rotated` on the reasoning that a non-durable revoke must never look like a success. That was wrong, and the correction matters more than the original gate:

`token_rotated{reason:'revoke'}` is the mobile client's **only automatic trigger** for clearing the now-dead credential and prompting re-auth (`packages/app/src/store/message-handler.ts`, token-less `token_rotated` → `clearSavedConnection()` + `disconnect()` + a re-scan alert). The `error` envelope lands in `case 'error'`, which shows an alert and touches neither the socket nor secure storage. Withholding the transition therefore left every connected device "connected" while holding a **revoked** token with its server-side authority already stripped: privileged operations failing opaquely, nothing prompting a re-pair, recovery only on a manual reconnect.

It is also not a false success to send it: the message carries **no token** and makes **no durability claim**. It says "this connection's authority is gone, re-authenticate" — true on this branch, because enforcement ran unconditionally before any I/O was awaited. So both go out, **error first**: the transition tears the socket down client-side, so a frame queued after it can be dropped before the client reads it. The durability caveat rides the error.

### #6964 — a durable-write seam for the credential store

`credential-store.js`'s `writeStoreAtomically` is a separate writer from `writeFileRestricted` and had no `durable` option, so an operator rotating a shared secret got a success that a power loss could roll back.

- `writeStoreAtomically(target, obj, { durable })` fsyncs the temp file **before** the rename and, on POSIX, the containing **directory after** it (a rename is not durable until its directory entry is fsynced), mirroring `writeFileRestricted({ durable: true })` from #6914 and reusing its `fsyncForDurability` helper (so benign "this filesystem cannot sync" codes stay swallowed and genuine EIO/ENOSPC surfaces).
- Default stays **off** — no fsync added to the ordinary set/delete paths.
- `setStoredField(field, value, { durable: true })` threads it through; the **rotation** call site (`github_webhook_set_secret`) opts in.
- The durability hook is **injectable** (`_setCredentialDurabilityForTests`) — that seam is the point of #6964: the durable and durability-*failure* branches are testable without provoking a real disk fault and without mocking `fs` process-wide.
- The at-rest encryption path (macOS Keychain / libsecret / DPAPI) is untouched — the fsync sits between the existing write and rename, after the envelope is produced.

#### The two fsync limbs fail differently

A single exit for both limbs produced the inverse of the bug this PR closes — a **failure reported for a write that landed**:

- **PRE-rename** (temp file) failure **throws**. Nothing was published, the live target still holds the prior value, the orphaned temp file is cleaned up. "The write failed" is exactly true, and the caller reports `WEBHOOK_SECRET_WRITE_FAILED` without touching its cache.
- **POST-rename** (directory) failure does **not** throw. `replaceFileAtomically` has already published the new value and its bytes are already fsynced; only the durability of the new directory *entry* is unproven. Throwing there told the operator the rotation failed — so they would leave the old secret configured at GitHub — while the in-process cache kept the **old** secret and the **new** one was live on disk and would load on the next restart. A silent, delayed webhook outage with no error at the moment it breaks.

  So it logs at error level and returns `{ durabilityUnconfirmed: <message> }`, a distinct outcome from a failed write. The handler adopts the new value into its hot cache (it **is** what is on disk — that is what keeps cache and disk from diverging), replies with the success config, and sends a **requestId-less** `WEBHOOK_SECRET_DURABILITY_UNCONFIRMED` error so the operator still learns the fsync failed. RequestId-less deliberately: the config is that request's reply, and a client correlating an error to its in-flight requestId must not read the caveat as the rotation's verdict.

Rollback was considered and rejected: a rollback rename needs its own fsync of the same directory that just failed to fsync, so the failure path's failure path is the same failure — and it would mean un-publishing a value that is already live and already being verified against, for a durability guarantee the rollback cannot make either.

## Why

For the most consequential credential in the system, "we told you it's revoked" must mean "the revocation is stored". Anything less is the false-safety class: code reporting success while being silently wrong. Its mirror image counts too — reporting failure for work that actually happened is the same defect with the sign flipped, and it is what the naive durability-failure branch did.

## How verified

`packages/server/tests/token-revoke-durable-ack.test.js` (7 tests) and `packages/server/tests/credential-store-durable.test.js` (7 tests), all written first and confirmed RED against the pre-fix code.

**Pre-fix RED — #6965, the ordering defect** (6 of 7 failing):

```
not ok 4 - severs + de-auths immediately, but withholds the ack until the durable write lands
      error: |-
        no revoke ack may be sent before the durable write completes
        + [ { msg: { expiresAt: null, reason: 'revoke', type: 'token_rotated' } } ]
        - []
not ok 1 - token_rotated carries an awaitable `persisted` promise for the persist
      error: 'the revoke event must expose the persist as an awaitable seam'
# tests 7 / pass 1 / fail 6
```

The ack was sent while the persist promise was still pending — exactly the window the issue describes.

**Pre-fix RED — #6964, the missing seam** (5 of 5 failing):

```
not ok 5 - the rotation path reports a durability failure instead of acking success
      error: 'credential-store must expose the injectable durability seam (#6964)'
# tests 5 / pass 0 / fail 5
```

**Pre-fix RED — the two limbs conflated** (a hook that succeeds on the temp file and throws `EIO` only on the directory):

```
not ok 6 - the rotation path never reports a failed write for a rotation that LANDED, and the cache follows disk
      error: |-
        a write that landed must never be reported as a failed write
        + [ { code: 'WEBHOOK_SECRET_WRITE_FAILED', message: 'simulated directory fsync I/O failure',
        +     requestId: 'r3', type: 'error' } ]
        - []
not ok 4 - a POST-RENAME (directory) durability failure does NOT throw
      Actual message: "simulated directory fsync I/O failure"
```

**Pre-fix RED — the withheld transition**:

```
not ok 5 - a durability failure sends REVOKE_NOT_DURABLE *and* the revoke transition, in that order
      error: 'the diagnostic AND the state transition, one of each per connection\n\n1 !== 2\n'
```

**Post-fix**: both files 14/14 green. What the tests pin, positively:

- the ack is sent *strictly after* the persist resolves (asserted by holding the persist on a deferred, draining microtasks + a macrotask, and asserting **zero** sends — then resolving and asserting exactly one `token_rotated` per connection);
- severing and de-authing already happened while the write was still in flight;
- a rejected persist produces `REVOKE_NOT_DURABLE` **followed by** the `token_rotated{reason:'revoke'}` transition — one of each, in that order, per connection;
- no persist hook → unchanged synchronous ack; a scheduled rotation with a pending persist broadcasts immediately (no over-gating);
- the durable credential write fsyncs the temp file while the target does not yet exist (i.e. pre-rename) and the directory once it does (post-rename); an ordinary set fsyncs nothing;
- a PRE-rename fsync failure throws and leaves the *prior* value on disk with no orphaned temp file;
- a POST-rename directory fsync failure does not throw, reports `durabilityUnconfirmed`, leaves the **new** value live on disk, and drives the handler to a success config + an updated cache + a `WEBHOOK_SECRET_DURABILITY_UNCONFIRMED` diagnostic.

**Suites and lints** (Node 22, `CHROXY_CRED_DISABLE_KEYCHAIN=1`):

- full `packages/server` suite under c8: `# tests 12650 / pass 12632 / fail 5`. The 5 failures are pre-existing and environmental — reproduced identically with this PR's `src/` changes stashed (`doctor.test.js` provider-awareness, which reads a real `OPENAI_API_KEY` from the host env; `codex-spawn-argv.integration.test.js`, no codex binary; `tunnel.integration.test.js`, cloudflared quick tunnel unavailable).
- `packages/protocol`: 377/377 (includes the handler-coverage roster parsed out of the edited `ws-server.js` doc-block).
- `packages/store-core`: 2131/2131.
- all five `packages/server/scripts/lint-*.sh`: OK. `npm run lint`: 0 errors (8 pre-existing warnings, none in touched files).
- both new test files exit 0 without `--test-force-exit`, and the full c8 run completed rather than wedging.

## Notes / out of scope

- **What the gate actually guarantees.** On a host with a working OS keychain — the default on macOS and on Linux with libsecret — `server-cli.js`'s `onPersist` takes the `setToken(newToken)` keychain limb, and `durable` is only ever threaded into `persistToFile()`. **No fsync happens on that path**; the gate resolves when the keychain write returns. So the contract is "the ack waits for the persist to report success", which is an fsync of the temp file + containing directory on the `config.json` fallback and delegated durability on the keychain path. The `token_rotated` doc-block, `token-manager.js` and `token-handlers.js` all state it that way rather than claiming an unconditional fsync.
- `deleteStoredField` (the webhook-secret *clear*) is left non-durable — #6964's acceptance criteria scope this to rotation, and the delete path's file-removal case needs its own directory-fsync handling. Tracked in #7056.
- The token path's own post-rename limb still throws from inside `writeFileRestricted`, whose signature is shared by many callers. Its client-facing consequence is handled here (the transition is delivered, and the `REVOKE_NOT_DURABLE` text no longer asserts the previous token *will* come back — it says the daemon may come back on either token). Unifying the two implementations of the atomic-durable-write recipe, and with it that limb, is #7054.
- The gate is unbounded: an `onPersist` that never settles yields no message at all. Latent while the real callback is synchronous — #7053.
- The Windows arm of the credential test (`IS_WINDOWS` → one fsync, no directory fsync) does not execute in CI: the Windows runner is offline and the POSIX branch returns first. The green tick is not Windows coverage.
- Ordering nuance: with a synchronous `onPersist`, the write now completes just before the sever/de-auth instead of just after, still inside the same synchronous `rotate()` call.

Closes #6964

Closes #6965
