### PR TITLE
ci: route the Linux pool on the chroxy-linux label, not ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ permissions:
 # exposes it as a JSON-string output (`needs.runner-target.outputs.runner`).
 # Jobs that opt into the routing declare `needs: runner-target` and
 # `runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}`. This routes
-# them to the self-hosted Linux runner pool (Docker-based, labels
-# self-hosted,Linux,ARM64) for SAME-REPO pushes and PRs, keeping them off the
+# them to the self-hosted Linux runner pool (labels self-hosted,Linux,chroxy-linux
+# — deliberately NOT arch-pinned, so both the ARM64 Docker members on the Mac and
+# the x86_64 Hyper-V member on winbox can serve) for SAME-REPO pushes and PRs,
+# keeping them off the
 # GitHub-hosted bill. If no self-hosted Linux runner is online, those jobs queue
 # until one appears. FORK PRs fall back to `ubuntu-24.04` (GitHub-hosted) so
 # untrusted contributor code never executes on the self-hosted machine, while
@@ -71,11 +73,11 @@ jobs:
       - id: resolve
         # The condition is the same routing predicate the per-job ternary used:
         # push events and same-repo PRs are trusted; fork PRs are not.
-        #   * runner    — Linux pool (self-hosted ARM64) / ubuntu-24.04 for forks
+        #   * runner    — Linux pool (label `chroxy-linux`) / ubuntu-24.04 for forks
         #   * winrunner — Windows pool (self-hosted chroxy-win) / windows-latest for forks
         run: |
           if [ "${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}" = "true" ]; then
-            echo 'runner=["self-hosted", "Linux", "ARM64"]' >> "$GITHUB_OUTPUT"
+            echo 'runner=["self-hosted", "Linux", "chroxy-linux"]' >> "$GITHUB_OUTPUT"
             echo 'winrunner=["self-hosted", "Windows", "X64", "chroxy-win"]' >> "$GITHUB_OUTPUT"
           else
             echo 'runner="ubuntu-24.04"' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ permissions:
 # exposes it as a JSON-string output (`needs.runner-target.outputs.runner`).
 # Jobs that opt into the routing declare `needs: runner-target` and
 # `runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}`. This routes
-# them to the self-hosted Linux runner pool (labels self-hosted,Linux,chroxy-linux
-# — deliberately NOT arch-pinned, so both the ARM64 Docker members on the Mac and
-# the x86_64 Hyper-V member on winbox can serve) for SAME-REPO pushes and PRs,
-# keeping them off the
-# GitHub-hosted bill. If no self-hosted Linux runner is online, those jobs queue
+# them to the self-hosted Linux runner pool (labels
+# self-hosted,Linux,chroxy-linux) for SAME-REPO pushes and PRs, keeping them off
+# the GitHub-hosted bill. The selector is deliberately NOT arch-pinned: the pool
+# is MIXED — ARM64 Docker members on the Mac plus an x86_64 Hyper-V VM member on
+# the always-on Windows host. If no self-hosted Linux runner is online, those jobs queue
 # until one appears. FORK PRs fall back to `ubuntu-24.04` (GitHub-hosted) so
 # untrusted contributor code never executes on the self-hosted machine, while
 # external contributors still get full CI.
@@ -57,8 +57,9 @@ jobs:
     # Tiny hosted gate job that resolves the SELF_HOSTED_OR_HOSTED routing once
     # and exposes it as a JSON-string output, consumed downstream via
     # `runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}`:
-    #   * SAME-REPO push or PR -> the JSON array ["self-hosted","Linux","ARM64"]
-    #     (fromJSON yields a label array -> self-hosted Linux pool).
+    #   * SAME-REPO push or PR -> the JSON array
+    #     ["self-hosted","Linux","chroxy-linux"] (fromJSON yields a label array
+    #     -> self-hosted Linux pool; NOT arch-pinned, the pool is mixed).
     #   * FORK PR              -> the JSON string "ubuntu-24.04"
     #     (fromJSON yields the plain string -> GitHub-hosted).
     # MUST stay GitHub-hosted: a fork PR has to be able to resolve the target
@@ -96,14 +97,20 @@ jobs:
     #
     # RUNNER CONTRACT (#6094): this job has NO `container:` key, so its uid/image
     # come from how the self-hosted Linux runner agent is configured, OUT OF BAND
-    # from this repo. The portability story above ASSUMES it runs as ROOT in
-    # node:22-bookworm: POSIX_PERM_SKIP (packages/server/tests/test-helpers.js)
-    # only skips the four chmod-denial asserts when `process.getuid() === 0`. If a
-    # future runner reconfig runs jobs as a NON-root user, those four tests run
-    # again and may fail on container fs semantics — investigate the runner's
-    # uid/image first, not the tests. (Pinning `container: node:22-bookworm` here
-    # would make this reproducible, but the other self-hosted Linux consumers are
-    # container-less too, so that's a pool-wide decision — left for a follow-up.)
+    # from this repo. The pool is now HETEROGENEOUS in uid, not just arch:
+    #   * Mac Docker members — ROOT (uid 0) in node:22-bookworm, ARM64
+    #   * winbox member      — NON-root (uid 1001) on an Ubuntu VM, x86_64
+    # POSIX_PERM_SKIP (packages/server/tests/test-helpers.js) skips the four
+    # chmod-denial asserts only when `process.getuid() === 0`, so those four RUN
+    # on the winbox member and SKIP on the Docker members. That is fine and was
+    # verified empirically before the pool went mixed: the four permission-guarded
+    # suites were run on the winbox VM as uid 1001 — 77/77 pass, 0 skipped (real
+    # ext4 enforces mode bits, which is exactly what the asserts expect; it is
+    # root-in-container that bypasses them). If they ever fail there, investigate
+    # the runner's uid/image and filesystem first, not the tests. (Pinning
+    # `container: node:22-bookworm` would make this uniform, but the other
+    # self-hosted Linux consumers are container-less too — pool-wide decision,
+    # left for a follow-up.)
     needs: runner-target
     runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}  # SELF_HOSTED_OR_HOSTED (see header)
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

The `runner-target` gate pinned same-repo Linux jobs to `["self-hosted","Linux","ARM64"]`. That silently made **Apple-Silicon hardware a requirement**, so the pool could only ever be the two Docker members on the MacBook — which go offline whenever Docker Desktop isn't running (the cause of past CI stalls, and the Linux analogue of #7057).

This routes on the pool's own label instead:

```diff
-            echo 'runner=["self-hosted", "Linux", "ARM64"]' >> "$GITHUB_OUTPUT"
+            echo 'runner=["self-hosted", "Linux", "chroxy-linux"]' >> "$GITHUB_OUTPUT"
```

## Why this is safe

**No-op for the existing members.** Both already carry the label — verified live:

| Runner | Labels | Matches new selector |
|---|---|---|
| `chroxy-linux-0ca56d3576e2` | `self-hosted,ARM64,Linux,chroxy-linux` | ✅ |
| `chroxy-linux-9ca9e00142fe` | `self-hosted,ARM64,Linux,chroxy-linux` | ✅ |
| `chroxy-linux-winbox-01` *(new)* | `self-hosted,Linux,chroxy-linux,X64` | ✅ |

The selector is also **more specific**, not less: `chroxy-linux` is a bespoke label only these three carry, whereas `ARM64` is a generic arch label. Dropping the arch pin is the point — it lets an x86_64 member join.

## What the new member is

`chroxy-linux-winbox-01` is an Ubuntu 24.04 VM on the always-on Windows host, provisioned via cloud-init. It runs under **Hyper-V, whose `vmms` system service auto-starts the VM at host boot** — so unlike a Docker-Desktop-backed or WSL-backed runner, it survives unattended reboots with nobody logged in. (WSL2 was evaluated first and rejected: it refuses to run in a SYSTEM context, `WSL_E_LOCAL_SYSTEM_NOT_SUPPORTED`, which would have reintroduced exactly the silently-offline-runner failure #7057 just fixed.)

Host details are documented in `blamechris/github-runners` → `hosts/chrisdev-winbox.md`.

## Unchanged

Fork-PR routing is untouched — forks still fall back to `ubuntu-24.04`, so untrusted contributor code never lands on self-hosted hardware. The `winrunner` (Windows) branch is untouched.

Related to #7057