### PR TITLE
test(server): assert the seq invariant per client instead of a stale count

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1129,9 +1129,6 @@ describe('outbound message sequence numbers', () => {
     // Wait for client_joined on client1 from client2's connection
     await waitForMessage(messages1, 'client_joined')
 
-    const client1CountBefore = messages1.length
-    const client2CountBefore = messages2.length
-
     // Broadcast a message — each client gets their own seq
     server.broadcast({ type: 'discovered_sessions', tmux: [] })
 
@@ -1140,16 +1137,27 @@ describe('outbound message sequence numbers', () => {
     assert.ok(disc1, 'Client 1 should receive broadcast')
     assert.ok(disc2, 'Client 2 should receive broadcast')
 
-    // Client 1 connected first and received more messages before the broadcast,
-    // plus it got a client_joined when client 2 connected
-    assert.equal(disc1.seq, client1CountBefore + 1,
-      'Client 1 broadcast seq should continue from its own counter')
-    assert.equal(disc2.seq, client2CountBefore + 1,
-      'Client 2 broadcast seq should continue from its own counter')
+    // #7059: assert the INVARIANT — each client's seq is its own contiguous run
+    // from 1 — rather than comparing against a `messages.length` snapshot taken
+    // before the broadcast. Any server message still in flight at snapshot time
+    // made that comparison off by one, which is what flaked in CI (10 !== 9).
+    // This is the same sweep the monotonic-seq test above uses, applied per
+    // client, and it proves independence more directly than the old assertion:
+    // a single SHARED counter would leave gaps in at least one client's run.
+    for (const [label, msgs] of [['Client 1', messages1], ['Client 2', messages2]]) {
+      assert.ok(msgs.length > 0, `${label} should have received messages`)
+      msgs.forEach((m, i) => {
+        assert.equal(m.seq, i + 1,
+          `${label} message ${i} (type: ${m.type}) should have seq ${i + 1}, got ${m.seq}`)
+      })
+    }
 
-    // The seq values should differ since the clients have different message counts
-    assert.notEqual(disc1.seq, disc2.seq,
-      'Different clients should have different seq values for the same broadcast')
+    // Each client numbered the SAME broadcast off its OWN counter, so the seq it
+    // landed on is that client's own position — not a shared global value.
+    assert.equal(disc1.seq, messages1.indexOf(disc1) + 1,
+      'Client 1 broadcast seq should be its own position in its own stream')
+    assert.equal(disc2.seq, messages2.indexOf(disc2) + 1,
+      'Client 2 broadcast seq should be its own position in its own stream')
 
     ws1.close()
     ws2.close()


### PR DESCRIPTION
## The flake

`assigns independent seq per client on broadcast` snapshotted `messages2.length`, then asserted the broadcast's `seq` equalled that + 1:

```js
const client2CountBefore = messages2.length
server.broadcast({ type: 'discovered_sessions', tmux: [] })
const disc2 = await waitForMessage(messages2, 'discovered_sessions')
assert.equal(disc2.seq, client2CountBefore + 1, ...)
```

That only holds if **no other server message reaches that client between the snapshot and the broadcast**. The test carefully quiesces client 1 (`await waitForMessage(messages1, 'client_joined')`) but never does the same for client 2, so one in-flight message makes it off by one. It flaked in CI as `10 !== 9` on an unrelated PR (#7058) — in a **required** check, which is the expensive part: random red on `Server Tests` trains everyone to reflex-rerun, and that is how a real failure eventually gets waved through.

## The fix

Assert the invariant the suite is actually named for — **each client's `seq` is its own contiguous run from 1**:

```js
for (const [label, msgs] of [['Client 1', messages1], ['Client 2', messages2]]) {
  msgs.forEach((m, i) => assert.equal(m.seq, i + 1, ...))
}
```

Why this is better, not merely quieter:

- **Race-immune by construction.** Extra traffic just makes the run longer; it can't shift a comparison.
- **Tests independence more directly.** A single *shared* counter would leave gaps in at least one client's run — this catches that. The old assertion could not.
- **Consistent with the suite.** This is the same sweep the sibling `includes monotonically increasing seq on all messages` test at `ws-server.test.js:1012` already uses.

Also drops `assert.notEqual(disc1.seq, disc2.seq)`. The two clients differ only because client 1 happens to receive an extra `client_joined` — that is timing, not contract, and asserting it invites the next flake.

## Verification — the race was made deterministic, not waited out

A flake fix that is only ever observed passing proves nothing, so the race was reproduced on demand:

| Step | Result |
|---|---|
| Baseline, clean suite | 5/5 pass |
| **Inject one extra broadcast** before the assertion (simulating the in-flight message) | **old assertion fails: `expected 11, actual 12`** — same shape as CI's `10 !== 9` |
| Apply the new assertion, **injection still in place** | **passes** |
| Remove injection, repeat-run ×12 | 12/12 clean |
| Full `ws-server.test.js` | 122/122, 0 skipped |

All five `packages/server/scripts/lint-*.sh` pass.

Closes #7059