### PR TITLE
fix(server,security): make the credential clear path durable

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -637,25 +637,58 @@ export function setStoredField(field, rawValue, { validate, durable = false } = 
  * the file entirely when it would be left empty. Mirrors `deleteStoredCredential`
  * for the non-provider-key case.
  *
+ * #7056 — `durable` opts the CLEAR path into the same durability guarantee
+ * `setStoredField` got in #6964. Clearing a shared secret is as acute as rotating
+ * it: an operator clears precisely because they believe the value leaked, so a
+ * clear that is acked but not on disk can resurrect the leaked secret on the next
+ * start after a power loss.
+ *
+ * The two limbs need different fsyncs:
+ *   - REWRITE (siblings survive) — the ordinary atomic temp-file + rename, so it
+ *     delegates to `writeStoreAtomically({ durable })` unchanged.
+ *   - UNLINK (the field was the last key) — there is no new file to fsync. The
+ *     removal lives entirely in the containing DIRECTORY's entry, so only that
+ *     directory is fsynced, and only AFTER the unlink. As with a post-rename
+ *     failure, a failed fsync here is NOT a failed clear: the secret is already
+ *     gone from the live filesystem, so it is reported as `durabilityUnconfirmed`
+ *     rather than thrown (throwing would send the operator to re-clear a secret
+ *     that is already cleared).
+ *
  * @param {string} field
+ * @param {{ durable?: boolean }} [opts]
+ * @returns {{ durabilityUnconfirmed: string | null }}
  */
-export function deleteStoredField(field) {
+export function deleteStoredField(field, { durable = false } = {}) {
   if (typeof field !== 'string' || field.length === 0) throw new Error('field is required')
   const target = credentialsFilePath()
   const { data, fileExists, error } = readStore()
-  if (!fileExists) return
+  if (!fileExists) return { durabilityUnconfirmed: null }
   if (error) throw new Error(error)
-  if (!(field in data)) return
+  if (!(field in data)) return { durabilityUnconfirmed: null }
 
   const next = { ...data }
   delete next[field]
 
   if (Object.keys(next).length === 0) {
     try { unlinkSync(target) } catch (err) { if (err.code !== 'ENOENT') throw err }
-    return
+    // POSIX only — Windows has no directory fsync (and no equivalent need here).
+    if (durable && process.platform !== 'win32') {
+      try {
+        _durabilityFsync(dirname(target), { isDir: true })
+      } catch (err) {
+        const durabilityUnconfirmed = err?.message || String(err)
+        _log.error(
+          `credentials: ${target} was removed but its directory entry could not be fsynced ` +
+          `(${durabilityUnconfirmed}) — a power loss could roll the removal back and restore the ` +
+          `cleared value. The value IS gone; treat the removal's durability as unconfirmed.`,
+        )
+        return { durabilityUnconfirmed }
+      }
+    }
+    return { durabilityUnconfirmed: null }
   }
 
-  writeStoreAtomically(target, next)
+  return writeStoreAtomically(target, next, { durable })
 }
 
 /**

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -784,11 +784,21 @@ export function setStoredCredential(key, rawValue) {
 }
 
 /**
- * Remove a single credential from the store. No-op when absent. Rewrites the
- * file atomically with the remaining keys (and removes the legacy alias too).
- * Deletes the file entirely when it would be left empty.
+ * Remove a single credential from the store. No-op when the file or the key is
+ * genuinely absent. Rewrites the file atomically with the remaining keys (and
+ * removes the legacy alias too). Deletes the file entirely when it would be
+ * left empty.
+ *
+ * Throws rather than returning quietly when the store cannot be READ (#7056) —
+ * an unreadable file is not an absent one, and acking a deletion that could not
+ * be performed would leave the credential on disk while the caller believes it
+ * is gone. Callers surface this as a clear/delete failure.
+ *
+ * Durability: this path is NOT durable-capable yet — see #7062. Its sibling
+ * `deleteStoredField` takes `{ durable }`; do not assume parity.
  *
  * @param {string} key
+ * @throws {Error} when the credentials file exists but cannot be read
  */
 export function deleteStoredCredential(key) {
   if (!isKnownCredentialKey(key)) throw new Error(`Unknown credential key: ${key}`)

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -632,6 +632,39 @@ export function setStoredField(field, rawValue, { validate, durable = false } = 
 }
 
 /**
+ * #7056 — confirm that a REMOVAL (or a no-op standing in for one) is durable.
+ *
+ * A file's bytes and its directory entry are separate durability concerns: an
+ * `unlink` changes only the entry, so there is no file to fsync — the containing
+ * directory is the only thing that can confirm it. Never throws: by the time this
+ * runs the live filesystem already reflects the removal, so a failure means the
+ * effect is real but its crash-durability is unproven, which is reported rather
+ * than raised (throwing would send the operator to re-clear an already-cleared
+ * value — and that retry would itself no-op).
+ *
+ * Windows has no directory-fsync primitive reachable from Node (`FlushFileBuffers`
+ * on a directory needs FILE_FLAG_BACKUP_SEMANTICS, which `fs.openSync` cannot
+ * request), so the confirmation is skipped there — matching #6964's posture.
+ *
+ * @returns {{ durabilityUnconfirmed: string | null }}
+ */
+function _confirmDirDurability(target, durable) {
+  if (!durable || process.platform === 'win32') return { durabilityUnconfirmed: null }
+  try {
+    _durabilityFsync(dirname(target), { isDir: true })
+    return { durabilityUnconfirmed: null }
+  } catch (err) {
+    const durabilityUnconfirmed = err?.message || String(err)
+    _log.error(
+      `credentials: the directory entry for ${target} could not be fsynced ` +
+      `(${durabilityUnconfirmed}) — a power loss could roll the removal back and restore the ` +
+      `cleared value. The value IS gone; treat the removal's durability as unconfirmed.`,
+    )
+    return { durabilityUnconfirmed }
+  }
+}
+
+/**
  * #6540 — remove an arbitrary NON-`KNOWN_CREDENTIALS` field written by
  * `setStoredField`. No-op when the field (or the whole file) is absent. Deletes
  * the file entirely when it would be left empty. Mirrors `deleteStoredCredential`
@@ -662,30 +695,27 @@ export function deleteStoredField(field, { durable = false } = {}) {
   if (typeof field !== 'string' || field.length === 0) throw new Error('field is required')
   const target = credentialsFilePath()
   const { data, fileExists, error } = readStore()
-  if (!fileExists) return { durabilityUnconfirmed: null }
+  // #7056: `error` MUST be checked before `fileExists`. readStore() reports a
+  // non-ENOENT stat failure (EACCES/EIO/ELOOP) as `{ fileExists: false, error }`,
+  // so testing `fileExists` first turned an unreadable credentials file into a
+  // silent no-op SUCCESS — the caller acked a clear that cleared nothing while
+  // the secret was still on disk. ENOENT keeps `error: null`, so a genuinely
+  // absent file still takes the no-op path below.
   if (error) throw new Error(error)
-  if (!(field in data)) return { durabilityUnconfirmed: null }
+  // A durable no-op still confirms: the retry after an unconfirmed clear lands
+  // on exactly these two branches (an unlinked file -> !fileExists, a rewritten
+  // one -> !(field in data)), and in both the outstanding doubt is the
+  // containing DIRECTORY's entry. Acking for free here would convert
+  // "unconfirmed" into false comfort.
+  if (!fileExists) return _confirmDirDurability(target, durable)
+  if (!(field in data)) return _confirmDirDurability(target, durable)
 
   const next = { ...data }
   delete next[field]
 
   if (Object.keys(next).length === 0) {
     try { unlinkSync(target) } catch (err) { if (err.code !== 'ENOENT') throw err }
-    // POSIX only — Windows has no directory fsync (and no equivalent need here).
-    if (durable && process.platform !== 'win32') {
-      try {
-        _durabilityFsync(dirname(target), { isDir: true })
-      } catch (err) {
-        const durabilityUnconfirmed = err?.message || String(err)
-        _log.error(
-          `credentials: ${target} was removed but its directory entry could not be fsynced ` +
-          `(${durabilityUnconfirmed}) — a power loss could roll the removal back and restore the ` +
-          `cleared value. The value IS gone; treat the removal's durability as unconfirmed.`,
-        )
-        return { durabilityUnconfirmed }
-      }
-    }
-    return { durabilityUnconfirmed: null }
+    return _confirmDirDurability(target, durable)
   }
 
   return writeStoreAtomically(target, next, { durable })

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -794,10 +794,15 @@ export function deleteStoredCredential(key) {
   if (!isKnownCredentialKey(key)) throw new Error(`Unknown credential key: ${key}`)
   const target = credentialsFilePath()
   const { data, fileExists, error } = readStore()
-  if (!fileExists) return
   // A bad-mode/JSON file can't be safely rewritten without risking clobber of
-  // unknown content; surface the error rather than guess.
+  // unknown content; surface the error rather than guess. #7056: this MUST come
+  // before the `fileExists` test — readStore() reports a non-ENOENT stat failure
+  // (EACCES/EIO/ELOOP) as { fileExists: false, error }, so checking `fileExists`
+  // first turned an unreadable store into a silent no-op SUCCESS while the
+  // credential was still on disk. ENOENT keeps `error: null`, so a genuinely
+  // absent file still no-ops below.
   if (error) throw new Error(error)
+  if (!fileExists) return
 
   const legacyField = LEGACY_FIELD_BY_KEY[key]
   if (!(key in data) && !(legacyField && legacyField in data)) return // nothing to remove

--- a/packages/server/src/handlers/github-webhook-handlers.js
+++ b/packages/server/src/handlers/github-webhook-handlers.js
@@ -161,8 +161,13 @@ function handleGithubWebhookSetSecret(ws, client, msg, ctx) {
 
 function handleGithubWebhookClearSecret(ws, client, msg, ctx) {
   if (rejectWebhookSecretWriteIfBound(ws, client, msg, ctx)) return
+  let outcome
   try {
-    deleteStoredField(WEBHOOK_SECRET_FIELD)
+    // #7056: durable, for the same reason the rotation is. An operator clears a
+    // shared secret precisely because they believe it leaked — a clear that is
+    // acked but still sitting in the OS writeback window can restore the leaked
+    // value on the next start after a power loss.
+    outcome = deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
   } catch (err) {
     sendError(ws, msg?.requestId, 'WEBHOOK_SECRET_CLEAR_FAILED', err?.message || 'clear failed', undefined, ctx)
     return
@@ -171,7 +176,25 @@ function handleGithubWebhookClearSecret(ws, client, msg, ctx) {
   if (typeof ctx?.services?.setWebhookSecretCache === 'function') {
     ctx.services.setWebhookSecretCache(null)
   }
+  // The reply is the success config: the secret IS cleared. Reporting a failure for
+  // a clear that landed would send the operator to re-clear an already-cleared value.
   sendWebhookConfig(ws, ctx, msg?.requestId)
+  if (outcome?.durabilityUnconfirmed) {
+    // ...but the operator still learns the fsync failed. Deliberately requestId-LESS,
+    // mirroring the rotation path: the config above is this request's reply, and a
+    // client correlating an error to its in-flight requestId must not read this as
+    // the clear's verdict.
+    sendError(
+      ws,
+      null,
+      'WEBHOOK_SECRET_DURABILITY_UNCONFIRMED',
+      'The webhook secret is cleared, but the filesystem could not confirm the removal is durable ' +
+      `(${outcome.durabilityUnconfirmed}) — a power loss could restore the cleared secret. ` +
+      'Resolve the storage error, then re-check the configured secret after the next restart.',
+      undefined,
+      ctx,
+    )
+  }
 }
 
 export const githubWebhookHandlers = {

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -295,4 +295,109 @@ describe('credential-store durable-write seam (#6964)', () => {
     credStore._setCredentialDurabilityForTests(null)
     assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, 'whsec-original-value-0001')
   })
+
+  // ---------------------------------------------------------------------------
+  // #7056 — the CLEAR path. Clearing a shared secret is as acute as rotating it:
+  // an operator clears precisely because they believe the value leaked. A
+  // non-durable clear can report success and then resurrect the leaked secret
+  // after a power loss. The clear has TWO limbs, and the second one is the
+  // interesting one: when the field was the last key the file is UNLINKED, and an
+  // unlink's durability lives in the containing DIRECTORY's entry, not in any
+  // file fsync.
+  // ---------------------------------------------------------------------------
+
+  it('does NOT fsync on an ordinary (non-durable) delete — the default stays off', () => {
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-ordinary-value-0001')
+    credStore.setStoredField('otherField', 'keep-me-around-0001')
+    calls = []
+    credStore.deleteStoredField(WEBHOOK_SECRET_FIELD)
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, null)
+    assert.deepEqual(calls, [], 'a default delete must add no fsync to the write path')
+  })
+
+  it('durable delete (siblings survive) fsyncs the temp file BEFORE the rename and the directory AFTER', () => {
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-durable-value-0001')
+    credStore.setStoredField('otherField', 'keep-me-around-0001')
+    calls = []
+
+    credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
+
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, null, 'the field is gone')
+    assert.equal(credStore.readStoredField('otherField').value, 'keep-me-around-0001', 'siblings survive')
+
+    assert.ok(calls.length >= 1, 'durable delete must fsync the temp file')
+    const [fileCall] = calls
+    assert.equal(fileCall.isDir, false, 'first fsync is the temp FILE')
+    assert.equal(fileCall.targetExists, true, 'the live file still exists pre-rename on a rewrite delete')
+
+    if (IS_WINDOWS) {
+      assert.equal(calls.length, 1, 'Windows has no directory fsync')
+      return
+    }
+    assert.equal(calls.length, 2, 'POSIX durable rewrite-delete = temp-file fsync + directory fsync')
+    assert.equal(calls[1].isDir, true, 'second fsync is the containing DIRECTORY')
+    assert.equal(calls[1].target, credDir)
+  })
+
+  it('durable delete of the LAST field unlinks the file and fsyncs the directory AFTER the unlink', () => {
+    if (IS_WINDOWS) return // no directory fsync on Windows
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-last-field-0001')
+    calls = []
+
+    credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
+
+    assert.equal(existsSync(credFile), false, 'the file is removed when it would be left empty')
+    assert.equal(calls.length, 1, 'an unlink has no temp file — only the containing directory is fsynced')
+    assert.equal(calls[0].isDir, true, 'the unlink limb must fsync the DIRECTORY, not a file')
+    assert.equal(calls[0].target, credDir)
+    assert.equal(
+      calls[0].targetExists, false,
+      'the directory fsync must happen AFTER the unlink — otherwise it proves nothing about the removal',
+    )
+  })
+
+  it('a directory-fsync failure on the UNLINK limb does NOT throw — the secret is already gone, only durability is unproven', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-last-field-0001')
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    let outcome
+    assert.doesNotThrow(() => {
+      outcome = credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
+    }, 'the unlink already removed the secret — reporting a failed clear would be factually wrong')
+    credStore._setCredentialDurabilityForTests(null)
+
+    assert.equal(existsSync(credFile), false, 'the secret IS gone from the live filesystem')
+    assert.equal(
+      typeof outcome?.durabilityUnconfirmed, 'string',
+      'the clear must report unconfirmed durability rather than silently acking it',
+    )
+    assert.match(outcome.durabilityUnconfirmed, /EIO|simulated directory fsync/)
+  })
+
+  it('the webhook CLEAR handler opts into durability and surfaces an unconfirmed clear', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-to-be-cleared-0001')
+    const cache = { value: 'stale' }
+    const ws = makeWs()
+    const ctx = makeCtx(cache)
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    githubWebhookHandlers.github_webhook_clear_secret(ws, {}, { requestId: 'req-clear-1' }, ctx)
+    credStore._setCredentialDurabilityForTests(null)
+
+    assert.ok(calls.some((c) => c.isDir), 'the clear path must have opted into the durable write')
+    assert.equal(credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, null, 'the secret is cleared')
+    assert.equal(cache.value, null, 'the hot cache is dropped so the next delivery re-resolves')
+
+    const replies = allReplies(ws, ctx)
+    const unconfirmed = replies.find((r) => r?.code === 'WEBHOOK_SECRET_DURABILITY_UNCONFIRMED')
+    assert.ok(unconfirmed, `expected a durability-unconfirmed error frame, got ${JSON.stringify(replies.map((r) => r?.type || r?.code))}`)
+    assert.equal(
+      unconfirmed.requestId ?? null, null,
+      'the durability warning must be requestId-LESS so a client cannot read it as the clear\'s verdict',
+    )
+  })
 })

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -449,4 +449,39 @@ describe('credential-store durable-write seam (#6964)', () => {
     assert.equal(outcome.durabilityUnconfirmed, null)
     assert.deepEqual(calls, [], 'the default path must add no fsync')
   })
+
+  it('a durable clear of an absent field with SIBLINGS present still confirms the directory', () => {
+    if (IS_WINDOWS) return
+    // Distinct from the retry test above: there the store was unlinked, so the
+    // retry hit !fileExists. Here the FILE SURVIVES (a sibling keeps it alive)
+    // and the retry hits the !(field in data) limb, which needs its own pin —
+    // mutating that one line alone otherwise leaves the suite green.
+    credStore.setStoredField('otherField', 'keep-me-0001')
+    calls = []
+
+    const outcome = credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
+
+    assert.equal(existsSync(credFile), true, 'the sibling keeps the store file alive')
+    assert.equal(outcome.durabilityUnconfirmed, null)
+    assert.equal(calls.length, 1, 'the !(field in data) durable limb must fsync the directory too')
+    assert.equal(calls[0].isDir, true)
+    assert.equal(calls[0].target, credDir)
+  })
+
+  it('#7056: deleteStoredCredential also surfaces an unreadable store instead of acking', () => {
+    if (IS_WINDOWS) return
+    if (process.getuid && process.getuid() === 0) return
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-still-here-0001')
+    chmodSync(credDir, 0o000)
+    try {
+      assert.throws(
+        () => credStore.deleteStoredCredential('ANTHROPIC_API_KEY'),
+        /unable to stat/,
+        'the API-key delete must not ack a deletion it could not perform',
+      )
+    } finally {
+      chmodSync(credDir, 0o700)
+    }
+    assert.equal(credStore.getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-still-here-0001')
+  })
 })

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs'
+import { mkdtempSync, rmSync, existsSync, readdirSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as credStore from '../src/credential-store.js'
@@ -399,5 +399,54 @@ describe('credential-store durable-write seam (#6964)', () => {
       unconfirmed.requestId ?? null, null,
       'the durability warning must be requestId-LESS so a client cannot read it as the clear\'s verdict',
     )
+  })
+
+  // --- review follow-ups on #7056 -------------------------------------------
+
+  it('an UNREADABLE store throws instead of acking a clear that cleared nothing', () => {
+    if (IS_WINDOWS) return // POSIX dir-permission semantics
+    if (process.getuid && process.getuid() === 0) return // root ignores mode bits
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-still-on-disk-0001')
+    // Make statSync fail with EACCES (NOT ENOENT): readStore reports that as
+    // { fileExists: false, error }, which a fileExists-first guard would treat
+    // as "nothing to clear" and ack — while the secret is still on disk.
+    chmodSync(credDir, 0o000)
+    try {
+      assert.throws(
+        () => credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true }),
+        /unable to stat/,
+        'an unreadable store must surface, never report a successful clear',
+      )
+    } finally {
+      chmodSync(credDir, 0o700)
+    }
+    assert.equal(
+      credStore.readStoredField(WEBHOOK_SECRET_FIELD).value, 'whsec-still-on-disk-0001',
+      'the secret is demonstrably still there — acking the clear would have been a lie',
+    )
+  })
+
+  it('a durable clear of an ALREADY-absent field still confirms the directory (retries can confirm)', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredField(WEBHOOK_SECRET_FIELD, 'whsec-gone-0001')
+    credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
+    calls = []
+
+    // The operator's natural move after an unconfirmed clear is to re-run it.
+    // That retry must be able to CONFIRM durability, not ack for free.
+    const outcome = credStore.deleteStoredField(WEBHOOK_SECRET_FIELD, { durable: true })
+
+    assert.equal(outcome.durabilityUnconfirmed, null)
+    assert.equal(calls.length, 1, 'a durable no-op must still fsync the containing directory')
+    assert.equal(calls[0].isDir, true)
+    assert.equal(calls[0].target, credDir)
+  })
+
+  it('a NON-durable clear of an absent field stays a free no-op', () => {
+    credStore.setStoredField('otherField', 'keep-me-0001')
+    calls = []
+    const outcome = credStore.deleteStoredField(WEBHOOK_SECRET_FIELD)
+    assert.equal(outcome.durabilityUnconfirmed, null)
+    assert.deepEqual(calls, [], 'the default path must add no fsync')
   })
 })


### PR DESCRIPTION
## The hole

`deleteStoredField` — the path an operator takes **because they believe a secret leaked** — had two non-durable limbs. #6964 made *rotation* durable and deliberately left *clear* out of scope. But a clear that is acked while still sitting in the OS writeback window can **restore the leaked secret** on the next daemon start after a power loss. Same threat model, same acuteness.

## The two limbs need different fsyncs

| Limb | When | Fix |
|---|---|---|
| **Rewrite** (siblings survive) | other fields remain | thread `{ durable }` into `writeStoreAtomically`, which already does temp-file fsync → rename → directory fsync |
| **Unlink** (field was the last key) | file removed entirely | **there is no new file to fsync.** The removal lives entirely in the containing **directory's** entry, so only that directory is fsynced — and only *after* the unlink |

That second limb is the subtle one, and it's why #7045 explicitly deferred this: an `unlink` needs directory-fsync handling, not the file-fsync path the rewrite uses.

## Failure semantics

A directory-fsync failure on the unlink limb **does not throw**. The secret is already gone from the live filesystem, so the clear succeeded; only its durability is unproven. It returns `durabilityUnconfirmed`, mirroring the post-rename precedent set by rotation. Throwing would send the operator off to re-clear a value that is already cleared.

The webhook clear handler opts in and surfaces the unconfirmed case as a **requestId-LESS** `WEBHOOK_SECRET_DURABILITY_UNCONFIRMED` — identical to the rotation path, so a client correlating an error against its in-flight `requestId` cannot misread it as the clear's verdict.

## Verification — tests written first, and confirmed red for the right reasons

Before any implementation, 4 of the 5 new tests failed with `must fsync the temp file` and `must have opted into the durable write` (the 5th — "no fsync by default" — passed already, since delete never fsynced at all).

The unlink-limb test asserts **`targetExists === false` at fsync time**, which proves the directory fsync happens *after* the removal rather than merely proving the hook was called. That distinction is the whole point of the limb.

| Check | Result |
|---|---|
| `credential-*` + `byok-credentials` + webhook suites | **189/189**, 0 skipped |
| `packages/server/scripts/lint-*.sh` | 5/5 pass |
| Non-test callers of `deleteStoredField` | exactly 1 (the handler updated here); the added return value is additive |

## Noted, not fixed here

`deleteStoredCredential` (the provider-API-key delete) has the **identical** shape — same unlink limb, same non-durable `writeStoreAtomically`. Deliberately out of scope: no caller opts in yet, so adding the parameter there today would be dead weight, and the duplication itself is what #7054 exists to collapse. Filed separately rather than widened silently.

Closes #7056