### PR TITLE
fix(server,security): bound the panic-revoke ack gate with a timeout

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1438,7 +1438,15 @@ export class WsServer {
             (err) => {
               const message = err?.message || String(err)
               if (settled) {
-                log.warn(`Token REVOKE persist failed (${message}) AFTER the durability bound had already been reported as unknown.`)
+                // error, not warn: this is a CONFIRMED non-durable write — strictly
+                // worse than the "unknown" the operator was already told — and no
+                // client frame is sent for it (that would double-send), so this
+                // line is the only surviving artifact. It must not rank below the
+                // on-time failure in alerting.
+                log.error(
+                  `Token REVOKE persist FAILED (${message}) after the durability bound had already reported unknown — ` +
+                  `the write is now known NOT to be durable. Fix the storage error and revoke again.`,
+                )
                 return
               }
               settled = true

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -184,6 +184,13 @@ export const TUNNEL_STATUS_MIN_PROTOCOL_VERSION = 2
 let _latestVersionCache = { version: null, checkedAt: 0 }
 const VERSION_CHECK_TTL = 3600_000 // 1 hour
 
+// #7053: how long the panic-revoke ack waits on its durable-write persist before
+// reporting the outcome as UNKNOWN. Long enough that a slow-but-working fsync or
+// keychain call still reports the truthful result, short enough that an operator
+// who just hit the panic button is not left staring at nothing. Overridable per
+// instance via `_revokeAckTimeoutMs` (tests use a few ms).
+const REVOKE_ACK_TIMEOUT_MS = 10_000
+
 // #5555.6 — keepalive sweep cadence. Previously 30s, which (with the
 // two-phase mark-then-terminate cycle) held a zombie client up to ~60s — ~6×
 // longer than a client holds a zombie server (15s ping + 5s pong timeout =
@@ -413,7 +420,7 @@ function _isSecureRequest(req) {
  *   { type: 'session_role', sessionId, primaryClientId } — #5589/#5281: explicit primary-ownership; client derives its role (primary iff primaryClientId === own clientId, observer if another holds it, null = unclaimed)
  *   { type: 'pong' }                                    — heartbeat response
  *   { type: 'permission_expired', requestId, sessionId, message }  — permission response could not be routed (expired/handled)
- *   { type: 'token_rotated', token?, expiresAt, reason? } — API token changed. Scheduled rotation carries the new `token` to encrypted clients (transparent re-key, sessions survive). A `reason: 'revoke'` (#6006) carries NO token: the operator revoked, so the server severed user-shell sessions and cleared this connection's auth — the client must re-authenticate with the current token (obtained out-of-band). #6965: for a revoke this message is WITHHELD until the daemon's token persist reports success, so the ack can never precede the revocation being stored — that persist is an fsync of the temp file + containing directory on the `config.json` fallback, while on the OS-keychain path (the macOS/libsecret default) durability is delegated to the keychain and no fsync is performed here. If the persist FAILS the connection receives an `error` with `code: 'REVOKE_NOT_DURABLE'` FIRST and then this message anyway: enforcement already ran unconditionally, so the client must still re-authenticate — the message carries no token and makes no durability claim, and the caveat rides the error.
+ *   { type: 'token_rotated', token?, expiresAt, reason? } — API token changed. Scheduled rotation carries the new `token` to encrypted clients (transparent re-key, sessions survive). A `reason: 'revoke'` (#6006) carries NO token: the operator revoked, so the server severed user-shell sessions and cleared this connection's auth — the client must re-authenticate with the current token (obtained out-of-band). #6965: for a revoke this message is WITHHELD until the daemon's token persist reports success, so the ack can never precede the revocation being stored — that persist is an fsync of the temp file + containing directory on the `config.json` fallback, while on the OS-keychain path (the macOS/libsecret default) durability is delegated to the keychain and no fsync is performed here. If the persist FAILS the connection receives an `error` with `code: 'REVOKE_NOT_DURABLE'` FIRST and then this message anyway: enforcement already ran unconditionally, so the client must still re-authenticate — the message carries no token and makes no durability claim, and the caveat rides the error. #7053: the wait is BOUNDED (`REVOKE_ACK_TIMEOUT_MS`), because an `onPersist` that never settles would otherwise emit nothing at all and make the panic button look like a no-op; on timeout the connection gets `code: 'REVOKE_DURABILITY_UNKNOWN'` — deliberately NOT `REVOKE_NOT_DURABLE`, since a timeout means the outcome is unknown and may still land, not that the write is known to have failed — followed by this message on the same reasoning.
  *   { type: 'session_warning', sessionId, name, reason, message, remainingMs } — session about to timeout
  *   { type: 'session_timeout', sessionId, name, idleMs }         — session destroyed due to idle timeout
  *   { type: 'statusline_output', sessionId, text, active?, truncated? } — #6791: rendered stdout of the user's own Claude Code statusLine script (active:false + empty text clears it)
@@ -1368,13 +1375,74 @@ export class WsServer {
             sendRevokeAck()
             return
           }
-          this._lastRevokeAck = persisted.then(
+          // #7053: BOUND the gate. Waiting on `persisted` is right, but waiting
+          // FOREVER is its own false safety: a persist that never settles emits
+          // no ack and no error, so the operator sees a panic-revoke that appears
+          // to do nothing — while enforcement above has already run. Today's
+          // `onPersist` (server-cli) is synchronous, so this is latent rather
+          // than live; the moment it becomes async, an unbounded gate turns the
+          // most consequential control in the daemon into a silent no-op.
+          //
+          // A timeout is NOT the same verdict as a rejection: a rejection means
+          // the write is KNOWN to have failed, a timeout means the outcome is
+          // UNKNOWN and may still land. It gets its own code so the operator is
+          // not told something the daemon does not know.
+          let settled = false
+          let resolveAck
+          const ackSettled = new Promise((res) => { resolveAck = res })
+          this._lastRevokeAck = ackSettled
+          const timeoutMs = this._revokeAckTimeoutMs ?? REVOKE_ACK_TIMEOUT_MS
+          const timer = setTimeout(() => {
+            if (settled) return
+            settled = true
+            log.error(
+              `Token REVOKE persist did not report within ${timeoutMs}ms — the revoke HOLDS in this process, ` +
+              `but whether it reached disk is UNKNOWN. Check the storage layer; re-revoke after a restart to be sure.`,
+            )
+            // Same ordering as the rejection branch, and for the same reason: the
+            // diagnostic first, then the state transition (which tears the socket
+            // down client-side, so a frame queued after it can be lost).
+            for (const ws of forcedSockets) {
+              if (ws.readyState !== 1) continue
+              this._send(ws, {
+                type: 'error',
+                code: 'REVOKE_DURABILITY_UNKNOWN',
+                message:
+                  `Token revoke is enforced for the running daemon, but its write did not report within ${timeoutMs}ms — ` +
+                  'whether it reached disk is unknown. After a restart the daemon may come back on either token. ' +
+                  'Check the storage layer and revoke again to be certain.',
+              })
+            }
+            // Still send the transition. It carries no token and claims no
+            // durability; it is the client's ONLY automatic trigger to drop the
+            // now-dead credential and re-authenticate. Withholding it would leave
+            // every device "connected" holding a revoked token.
+            sendRevokeAck()
+            resolveAck({ ok: false, timedOut: true })
+          }, timeoutMs)
+          // Never let the bound hold the event loop open (a pending timer here
+          // would keep the process — and the test runner — alive).
+          timer.unref?.()
+
+          persisted.then(
             () => {
+              if (settled) {
+                log.warn('Token REVOKE persist landed AFTER the durability bound had already been reported as unknown.')
+                return
+              }
+              settled = true
+              clearTimeout(timer)
               sendRevokeAck()
-              return { ok: true }
+              resolveAck({ ok: true })
             },
             (err) => {
               const message = err?.message || String(err)
+              if (settled) {
+                log.warn(`Token REVOKE persist failed (${message}) AFTER the durability bound had already been reported as unknown.`)
+                return
+              }
+              settled = true
+              clearTimeout(timer)
               log.error(
                 `Token REVOKE could not be confirmed durable (${message}) — the revoke HOLDS in this process, ` +
                 `but a restart is not guaranteed to come back on the new token. Fix the storage error and revoke again.`,
@@ -1411,7 +1479,7 @@ export class WsServer {
                 })
               }
               sendRevokeAck()
-              return { ok: false, error: message }
+              resolveAck({ ok: false, error: message })
             },
           )
           return

--- a/packages/server/tests/token-revoke-durable-ack.test.js
+++ b/packages/server/tests/token-revoke-durable-ack.test.js
@@ -183,4 +183,74 @@ describe('primary-token revoke: durable-write ack gating (#6965)', () => {
     assert.equal(sent[0].msg.reason, 'scheduled')
     gate.resolve()
   })
+
+  // ---------------------------------------------------------------------------
+  // #7053 — the gate must be BOUNDED. Contract 2 above ("ack strictly after the
+  // persist settles") has a failure mode of its own: if the persist NEVER
+  // settles, the operator gets nothing at all — no ack, no error — while
+  // enforcement has silently already happened in-process. A panic button that
+  // appears to do nothing is its own kind of false safety.
+  // ---------------------------------------------------------------------------
+
+  it('a never-settling onPersist still produces a client-facing message (bounded gate)', async () => {
+    const manager = track(new TokenManager({ token: 'token-old', onPersist: () => new Promise(() => {}) }))
+    const { server, sent } = makeServer(manager)
+    server._revokeAckTimeoutMs = 40 // keep the test fast; production default is seconds
+
+    manager.revoke()
+    await drain()
+    assert.deepEqual(sent.map((s) => s.msg.type), [], 'nothing before the bound elapses — the gate still gates')
+
+    await new Promise((r) => setTimeout(r, 80))
+    await drain()
+
+    const types = sent.map((s) => s.msg.type)
+    assert.ok(types.length > 0, 'a hung persist must NOT swallow the revoke silently')
+
+    // Same shape as the rejection branch: diagnostic first, then the transition.
+    assert.equal(sent[0].msg.type, 'error')
+    assert.equal(
+      sent[0].msg.code, 'REVOKE_DURABILITY_UNKNOWN',
+      'a timeout is UNKNOWN, not known-failed — it must not claim REVOKE_NOT_DURABLE',
+    )
+    assert.match(sent[0].msg.message, /did not report|timed out|unknown/i)
+
+    const transition = sent.find((s) => s.msg.type === 'token_rotated')
+    assert.ok(transition, 'the revoke transition must still be sent — it is the client\'s only trigger to drop the dead token')
+    assert.equal(transition.msg.reason, 'revoke')
+    assert.equal(transition.msg.token, undefined, 'the transition carries NO token and makes no durability claim')
+  })
+
+  it('a persist that settles AFTER the timeout does not double-send', async () => {
+    const gate = deferred()
+    const manager = track(new TokenManager({ token: 'token-old', onPersist: () => gate.promise }))
+    const { server, sent } = makeServer(manager)
+    server._revokeAckTimeoutMs = 40
+
+    manager.revoke()
+    await new Promise((r) => setTimeout(r, 80))
+    await drain()
+    const afterTimeout = sent.length
+    assert.ok(afterTimeout > 0, 'the timeout path fired')
+
+    gate.resolve() // the storage layer finally comes back
+    await drain()
+
+    assert.equal(sent.length, afterTimeout, 'a late persist must not emit a second ack or error')
+  })
+
+  it('a persist that settles BEFORE the bound behaves exactly as before (no timeout frame)', async () => {
+    const gate = deferred()
+    const manager = track(new TokenManager({ token: 'token-old', onPersist: () => gate.promise }))
+    const { server, sent } = makeServer(manager)
+    server._revokeAckTimeoutMs = 5000
+
+    manager.revoke()
+    await drain()
+    gate.resolve()
+    await drain()
+
+    assert.deepEqual(sent.map((s) => s.msg.type), ['token_rotated'], 'success path is unchanged: the ack only')
+    assert.equal(sent.filter((s) => s.msg.code === 'REVOKE_DURABILITY_UNKNOWN').length, 0)
+  })
 })


### PR DESCRIPTION
## The hazard

#6965 made the revoke ack wait for its durable-write persist — correct, and it closed a real hole. But the wait is **unbounded**. If `onPersist` returns a promise that never settles, the client gets **no ack and no error**: the operator presses the highest-authority control in the daemon and sees nothing happen, while enforcement has already run in-process.

Waiting forever is its own false safety. It replaces "told too early" with "never told at all".

**Latent, not live:** `server-cli.js`'s `onPersist` is synchronous today (`execFileSync` for keychain, `writeFileSync` + fsync for the config fallback), so a stall blocks the event loop rather than leaving a pending promise. It becomes live the moment that callback goes async or another deployment wires an async persist.

## The fix

Race the gate against a bounded timer (`REVOKE_ACK_TIMEOUT_MS`, 10s; overridable per instance for tests).

### A timeout is not a rejection — and gets its own code

| Outcome | Meaning | Code |
|---|---|---|
| `persisted` rejects | the write is **known** to have failed | `REVOKE_NOT_DURABLE` (unchanged) |
| `persisted` never settles | the outcome is **unknown**, and may still land | **`REVOKE_DURABILITY_UNKNOWN`** (new) |

Reusing `REVOKE_NOT_DURABLE` for a timeout would tell the operator something the daemon does not know — the same species of lie this gate exists to prevent. (Error codes are free-form strings in the generic `error` frame, so this adds no protocol surface and trips no coverage guard.)

### The transition is still sent

Deliberately, matching the rejection branch and for the reason spelled out there: `token_rotated{reason:'revoke'}` carries **no token** and makes **no durability claim**, and it is the client's *only* automatic trigger to clear the dead credential and re-authenticate. Withholding it would leave every connected device "connected" while holding a revoked token whose server-side authority is already stripped.

A persist that settles *after* the bound logs and is dropped rather than double-sending.

### Timer hygiene

The timer is `unref`'d, so a pending bound can never hold the process — or the test runner — open. Verified by a clean exit with **no `--test-force-exit`**, which this repo treats as a masking flag rather than a fix.

## Verification — each behaviour pinned individually

Tests written first and confirmed red (the never-settling case, and the late-settle case). Then each behaviour was mutated **on its own**, not as a group:

| Mutation | Result |
|---|---|
| remove the timeout entirely | **fail 2** |
| timeout emits `REVOKE_NOT_DURABLE` | **fail 1** |
| timeout withholds the transition | **fail 1** |
| late settle double-sends | **fail 1** |

The success path is pinned too: a persist that settles inside the bound emits the ack alone, with no timeout frame.

165/165 across the revoke / token-manager / ws-server suites; 5/5 `packages/server/scripts/lint-*.sh`. The wire doc-block now describes the bound and the new code.

Closes #7053