### PR TITLE
fix(server,security): make the floor pre-filter prove completeness before skipping

### DIFF
--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -346,20 +346,57 @@ EOF
 #      structural check). Over-probing here is harmless; a `\n` / `\"`-only
 #      payload keeps the no-round-trip path.
 floor_forces_prompt() {
-  # (1) last-byte shape check — an unusable body cannot prove "cannot be floored".
-  # Trim the trailing whitespace run first (two expansions, no loop, bash 3.2-safe:
-  # `##*[![:space:]]` leaves exactly that run, which `%` then strips off the end).
-  REQUEST_TRIMMED=${REQUEST%"${REQUEST##*[![:space:]]}"}
-  case "$REQUEST_TRIMMED" in
-    *'}') ;;
-    *) return 0 ;;
-  esac
   case "$REQUEST" in
     *'"file_path"'*|*'"path"'*|*'"notebook_path"'*|*'"changes"'*) ;;
-    # (2) a \uXXXX escape may hide a path-naming key from the byte scan.
+    # (1) a \uXXXX escape may spell a path-naming key the byte scan cannot see.
     *'\u'*) ;;
-    # No path-naming field anywhere in the payload — the floor cannot apply.
-    *) return 1 ;;
+    # (2) #7043: an INVALID escape can hide one too, and never reaches the
+    # daemon's fail-closed parse because this pre-filter short-circuits first.
+    # `\U0066ile_path` is the worked example: the `\u` arm above is
+    # case-SENSITIVE, so it missed. Rather than enumerate malformed escapes,
+    # match "a backslash NOT starting one of JSON's valid non-unicode escapes"
+    # (`" \ / b f n r t`). That covers `\U`, `\x` and every other invalid form,
+    # while deliberately KEEPING the `\n` / `\"` fast path the Bash tool relies
+    # on - those cannot spell a key, and #7035 pinned that they stay fast.
+    *'\'[!\"\\/bfnrt]*) ;;
+    *)
+      # Fast-path candidate. ONLY here is a completeness proof load-bearing, so
+      # only here is it paid for - running it earlier would scan large payloads
+      # that were going to probe anyway (a 200KB Write blew the hook's timeout
+      # and got SIGKILLed, which is a dead hook, not a slow one).
+      #
+      # The pre-filter's justification is that a payload naming no path field
+      # PROVABLY cannot be floored. That proof needs all the bytes, and #7043
+      # showed a last-byte `}` test does not establish it: a truncation can land
+      # on `}` (`..."permission_suggestions":{}`), carry no key literal, and take
+      # the skip. Shape + brace balance instead.
+      REQUEST_TRIMMED=${REQUEST%"${REQUEST##*[![:space:]]}"}
+      case "$REQUEST_TRIMMED" in
+        '{'*'}') ;;
+        *) return 0 ;;
+      esac
+      # Bash pattern substitution is superlinear on long strings, so the scan is
+      # size-bounded. Past the bound the proof is simply not attempted and the
+      # call falls through to a prompt - declining to claim a proof is the whole
+      # point. A >64KB payload naming no path field is rare; a dead hook is not
+      # an acceptable price for auto-allowing one.
+      if [ ${#REQUEST_TRIMMED} -gt 65536 ]; then
+        return 0
+      fi
+      # Counts braces inside strings too, so `awk '{print}'` is judged on its
+      # literal braces rather than its structure. That is an over-approximation
+      # in the SAFE direction: a miscount can only ever ADD a probe/prompt, never
+      # skip one. RESIDUAL, precisely: this is not a parse. A truncation whose
+      # literal brace counts happen to balance is still not detected; closing
+      # that needs a structural walk costing about what the probe costs (#7043).
+      FLOOR_OPEN=${REQUEST_TRIMMED//[!\{]/}
+      FLOOR_CLOSE=${REQUEST_TRIMMED//[!\}]/}
+      if [ ${#FLOOR_OPEN} -ne ${#FLOOR_CLOSE} ]; then
+        return 0
+      fi
+      # A COMPLETE, escape-clean payload naming no path field: the floor cannot apply.
+      return 1
+      ;;
   esac
   # Payload over STDIN, not argv — see route_to_phone's note on MAX_ARG_STRLEN.
   # Here it matters doubly: an argv failure on a large `Write` would fail closed

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -349,6 +349,8 @@ floor_forces_prompt() {
   case "$REQUEST" in
     *'"file_path"'*|*'"path"'*|*'"notebook_path"'*|*'"changes"'*) ;;
     # (1) a \uXXXX escape may spell a path-naming key the byte scan cannot see.
+    # Kept explicit for readability though arm (2) now subsumes it (`u` is not in
+    # that arm's negated set), so a `\u` body probes either way.
     *'\u'*) ;;
     # (2) #7043: an INVALID escape can hide one too, and never reaches the
     # daemon's fail-closed parse because this pre-filter short-circuits first.
@@ -358,42 +360,55 @@ floor_forces_prompt() {
     # (`" \ / b f n r t`). That covers `\U`, `\x` and every other invalid form,
     # while deliberately KEEPING the `\n` / `\"` fast path the Bash tool relies
     # on - those cannot spell a key, and #7035 pinned that they stay fast.
+    # NOT kept fast: an ESCAPED backslash followed by a non-set char (`\\U`,
+    # `\\d`, `\\.`) — so a Windows cwd (`C:\\Users\\...`) or a regex-carrying
+    # Grep/Bash payload now probes. Distinguishing those needs escape-state
+    # tracking, i.e. a parse; over-probing is the price of not doing one, and it
+    # errs safe.
     *'\'[!\"\\/bfnrt]*) ;;
     *)
       # Fast-path candidate. ONLY here is a completeness proof load-bearing, so
-      # only here is it paid for - running it earlier would scan large payloads
-      # that were going to probe anyway (a 200KB Write blew the hook's timeout
-      # and got SIGKILLed, which is a dead hook, not a slow one).
+      # only here is it paid for - running it before the path-key arm scanned
+      # payloads that were going to probe anyway, and a 200KB Write blew the
+      # hook's timeout and got SIGKILLed (a dead hook, not a slow one).
       #
       # The pre-filter's justification is that a payload naming no path field
       # PROVABLY cannot be floored. That proof needs all the bytes, and #7043
       # showed a last-byte `}` test does not establish it: a truncation can land
       # on `}` (`..."permission_suggestions":{}`), carry no key literal, and take
       # the skip. Shape + brace balance instead.
+      #
+      # Whitespace is trimmed at BOTH ends. JSON.parse accepts leading
+      # whitespace and `cat -` preserves it, so anchoring the shape check on the
+      # raw first byte would send every call from a producer that emits a
+      # leading newline to a phone prompt - destroying the lenient modes for a
+      # formatting detail.
       REQUEST_TRIMMED=${REQUEST%"${REQUEST##*[![:space:]]}"}
+      REQUEST_TRIMMED=${REQUEST_TRIMMED#"${REQUEST_TRIMMED%%[![:space:]]*}"}
       case "$REQUEST_TRIMMED" in
         '{'*'}') ;;
         *) return 0 ;;
       esac
-      # Bash pattern substitution is superlinear on long strings, so the scan is
-      # size-bounded. Past the bound the proof is simply not attempted and the
-      # call falls through to a prompt - declining to claim a proof is the whole
-      # point. A >64KB payload naming no path field is rare; a dead hook is not
-      # an acceptable price for auto-allowing one.
-      if [ ${#REQUEST_TRIMMED} -gt 65536 ]; then
-        return 0
-      fi
-      # Counts braces inside strings too, so `awk '{print}'` is judged on its
-      # literal braces rather than its structure. That is an over-approximation
-      # in the SAFE direction: a miscount can only ever ADD a probe/prompt, never
-      # skip one. RESIDUAL, precisely: this is not a parse. A truncation whose
-      # literal brace counts happen to balance is still not detected; closing
-      # that needs a structural walk costing about what the probe costs (#7043).
-      FLOOR_OPEN=${REQUEST_TRIMMED//[!\{]/}
-      FLOOR_CLOSE=${REQUEST_TRIMMED//[!\}]/}
+      # Brace balance, counted by `tr` rather than bash pattern substitution.
+      # That is not a style choice: `${VAR//[!\{]/}` is ~O(n^3) on bash 3.2,
+      # which is macOS's /bin/bash and this file's shebang. Measured there:
+      # 0.68s at 4KB, 28.7s at 16KB - so a mid-size path-less body (a Bash
+      # heredoc, a Task prompt) would stall or be killed outright, which is the
+      # very failure this guard is supposed to prevent. `tr -cd` is O(n) and
+      # reduces the body to just its braces (0.00s at 16KB); the two
+      # substitutions below then run on that tiny result. LC_ALL=C keeps it
+      # byte-oriented so a multibyte payload cannot change the count.
+      FLOOR_BRACES=$(printf '%s' "$REQUEST_TRIMMED" | LC_ALL=C tr -cd '{}')
+      FLOOR_OPEN=${FLOOR_BRACES//\}/}
+      FLOOR_CLOSE=${FLOOR_BRACES//\{/}
       if [ ${#FLOOR_OPEN} -ne ${#FLOOR_CLOSE} ]; then
         return 0
       fi
+      # Counting braces inside strings too is an over-approximation in the SAFE
+      # direction: a miscount can only ever ADD a probe/prompt, never skip one.
+      # RESIDUAL, precisely: this is not a parse. A truncation whose literal
+      # brace counts happen to balance is still undetected; closing that needs a
+      # structural walk costing about what the probe it avoids costs (#7043).
       # A COMPLETE, escape-clean payload naming no path field: the floor cannot apply.
       return 1
       ;;

--- a/packages/server/tests/permission-hook-floor.test.js
+++ b/packages/server/tests/permission-hook-floor.test.js
@@ -422,6 +422,77 @@ describe('permission-hook.sh: the floor forces a PROMPT under auto/acceptEdits (
     assert.equal(daemon.stats.permissionRequests, 0)
   })
 
+  // -- #7043: the pre-filter's completeness guard --
+  //
+  // The negative pre-filter's justification is "a payload naming no path field
+  // PROVABLY cannot be floored". That proof needs the body to be the complete
+  // tool input. A last-byte `}` check does not establish that, and two shapes
+  // slipped through it into a silent auto-allow. Both are producer-side defects
+  // (a model cannot influence them), so this is invariant hygiene — but the
+  // pre-filter must not claim a proof it does not have.
+
+  it('#7043: a TRUNCATED body that happens to end in `}` still probes (braces unbalanced)', async () => {
+    daemon = await startRealDaemon()
+    // Ends in `}`, carries none of the four path-key literals, and the tool_input
+    // path key never made it into the body. Under a last-byte check this took the
+    // fast path and auto-allowed.
+    const raw = '{"session_id":"s","hook_event_name":"PreToolUse","permission_suggestions":{}'
+    const { stdout } = await runHook({ payload: raw, port: daemon.port, mode: 'auto' })
+    // Assert the SECURITY PROPERTY, not the mechanism: an incomplete body must not
+    // be silently auto-allowed. Forcing the prompt without a probe is the better
+    // outcome (fail closed, no round trip) — either route is acceptable, a silent
+    // allow is not.
+    assert.notEqual(
+      decisionOf(stdout).permissionDecision, 'allow',
+      'an incomplete body cannot prove "no path field", so it must never take the silent auto-allow',
+    )
+    assert.ok(
+      daemon.stats.floorRequests + daemon.stats.permissionRequests >= 1,
+      'it must be checked somewhere — prompt or probe — rather than short-circuited',
+    )
+  })
+
+  it('#7043: an INVALID escape (\\U, uppercase) still probes — the guard must not be case-sensitive about escapes', async () => {
+    daemon = await startRealDaemon()
+    // `\U0066ile_path` hides `file_path` from the byte scan. The old guard only
+    // matched a lowercase `\u`, so this took the fast path and auto-allowed.
+    const raw = '{"session_id":"s","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"\\U0066ile_path":".env"},"cwd":"' + CWD + '"}'
+    const { stdout } = await runHook({ payload: raw, port: daemon.port, mode: 'auto' })
+    assert.notEqual(
+      decisionOf(stdout).permissionDecision, 'allow',
+      'an escape can hide a path-naming key from a byte scan — it must not be silently allowed',
+    )
+    assert.ok(
+      daemon.stats.floorRequests >= 1,
+      'a complete body with an escape is probe-able, so it should reach the daemon rather than blind-prompt',
+    )
+  })
+
+  it('#7043: a complete, escape-free path-LESS payload still takes the fast path (no regression)', async () => {
+    daemon = await startRealDaemon()
+    const { stdout } = await runHook({
+      payload: { tool_name: 'Bash', tool_input: { command: 'ls -la' }, cwd: CWD },
+      port: daemon.port,
+      mode: 'auto',
+    })
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow')
+    assert.equal(daemon.stats.floorRequests, 0, 'the whole point of the pre-filter must survive the hardening')
+  })
+
+  it('#7043: a LARGE path-LESS payload does not hang the hook (the completeness scan is size-bounded)', async () => {
+    daemon = await startRealDaemon()
+    // No path key, so this is a fast-path CANDIDATE and does reach the completeness
+    // scan — unlike a large Write, which takes the path-key arm long before it.
+    // Bash pattern substitution is superlinear, and an unbounded scan here killed
+    // the hook outright (SIGKILL on the 15s timeout) rather than merely slowing it.
+    const payload = { tool_name: 'Bash', tool_input: { command: `echo ${'x'.repeat(200_000)}` }, cwd: CWD }
+    const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto', timeout: 15000 })
+    // The hook must SURVIVE and emit a decision. Which decision is a policy call
+    // (past the bound the proof is declined, so it prompts rather than skipping);
+    // the property pinned here is that it answers at all.
+    assert.ok(decisionOf(stdout).permissionDecision, 'the hook must return a decision, not be killed')
+  })
+
   // -- the other modes are untouched --
 
   it('approve mode never probes the floor (it already prompts for everything)', async () => {

--- a/packages/server/tests/permission-hook-floor.test.js
+++ b/packages/server/tests/permission-hook-floor.test.js
@@ -479,7 +479,25 @@ describe('permission-hook.sh: the floor forces a PROMPT under auto/acceptEdits (
     assert.equal(daemon.stats.floorRequests, 0, 'the whole point of the pre-filter must survive the hardening')
   })
 
-  it('#7043: a LARGE path-LESS payload does not hang the hook (the completeness scan is size-bounded)', async () => {
+  it('#7043: a MID-SIZE path-LESS payload completes fast (the scan must be O(n), not bash substitution)', async () => {
+    daemon = await startRealDaemon()
+    // THE REGRESSION WINDOW. `${VAR//[!\{]/}` is ~O(n^3) on bash 3.2 — macOS's
+    // /bin/bash and this hook's shebang — measured at 0.68s/4KB and 28.7s/16KB.
+    // A path-less body in this range is a Bash heredoc or a Task prompt: utterly
+    // ordinary. The earlier tests probed only tiny and 200KB bodies, so both
+    // dodged this window and CI (Linux bash 5.2, instant) stayed green while the
+    // primary platform stalled or SIGKILLed. Pinned with a tight timeout so a
+    // regression fails loudly instead of merely being slow.
+    const payload = { tool_name: 'Bash', tool_input: { command: `echo ${'x'.repeat(24_000)}` }, cwd: CWD }
+    const started = Date.now()
+    const { stdout } = await runHook({ payload, port: daemon.port, mode: 'auto', timeout: 10_000 })
+    const elapsed = Date.now() - started
+    assert.equal(decisionOf(stdout).permissionDecision, 'allow', 'a complete path-less body is still proven un-floorable')
+    assert.equal(daemon.stats.floorRequests, 0, 'and still takes the fast path')
+    assert.ok(elapsed < 5_000, `the completeness scan must be linear; took ${elapsed}ms`)
+  })
+
+  it('#7043: a LARGE path-LESS payload does not hang the hook', async () => {
     daemon = await startRealDaemon()
     // No path key, so this is a fast-path CANDIDATE and does reach the completeness
     // scan — unlike a large Write, which takes the path-key arm long before it.


### PR DESCRIPTION
## The gap

The negative pre-filter's whole justification is that a payload naming no path field **provably** cannot be floored. #7035 guarded that with a **last-byte `}`** test — which is not a completeness check. Two shapes still took the skip straight into a silent auto-allow under `auto`/`acceptEdits`:

| # | Body | Why it slipped |
|---|---|---|
| 1 | `{"session_id":"s",…,"permission_suggestions":{}` | Ends in `}`, names no path key, and the `tool_input` path key never made it into the body at all |
| 2 | `{"tool_input":{"\U0066ile_path":".env"}}` | `\U0066ile_path` hides `file_path` from the byte scan; the `\u` arm is case-**sensitive** so it missed |

Case 2 is worth dwelling on: #7035's own comment asserted the daemon would answer `floor:true` for such a body. It never gets the chance — the pre-filter short-circuits before the probe.

Both are producer-side (a model cannot influence them), so this is invariant hygiene, not a live exploit. But the pre-filter must not claim a proof it doesn't have.

## Escapes — closing the hole without losing the fast path

Rather than enumerate malformed escapes, match **a backslash not starting one of JSON's valid non-unicode escapes** (`" \ / b f n r t`):

```sh
*'\'[!\"\\/bfnrt]*) ;;
```

That covers `\U`, `\x` and every other invalid form, while **deliberately keeping the `\n` / `\"` fast path** that #7035 pinned for Bash — those cannot spell a key. Probing on *any* backslash (the issue's cheapest option) would have closed the hole too, but it contradicts an existing test that encodes that decision on purpose.

## Completeness — shape plus brace balance

Counting braces inside strings is an over-approximation in the **safe** direction: a miscount can only ever *add* a probe, never skip one.

## Order matters — and the tests caught me getting it wrong

My first attempt ran the scan **before** the path-key check. That scanned payloads that were going to probe anyway, and bash pattern substitution is superlinear: a 200 KB `Write` blew the hook's 15s timeout and got **`SIGKILL`ed**. That is a *dead hook*, not a slow one — strictly worse than the bug being fixed.

The proof is now paid for only on fast-path candidates, and is size-bounded. Past the bound the proof is **declined** rather than faked (falls through to a prompt).

## Residual, stated rather than papered over

This is not a parse. A truncation whose literal brace counts happen to balance is still undetected. Closing that needs a structural walk costing about what the probe it avoids costs — so the comment says so, instead of implying the gap is fully closed.

## Verification

Tests written first; both holes reproduced red before the fix. Assertions pin the **security property** (never a silent auto-allow) rather than the mechanism — forcing a prompt without a probe is an equally acceptable outcome, and asserting `floorRequests >= 1` would have wrongly failed that.

Each guard mutation-verified **individually**:

| Mutation | Result |
|---|---|
| drop the invalid-escape arm | **fail 1** |
| drop the brace-balance check | **fail 1** |
| drop the size bound | **fail 1** |

237/237 across the hook + ws-permissions suites; 5/5 `packages/server/scripts/lint-*.sh`. The `\n`/`\"` fast-path test and both large-Write tests still pass unchanged.

Closes #7043