### PR TITLE
fix(server,security): a landed durable write must not report failure

### DIFF
--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -198,10 +198,16 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
  *     REVOKE snapshot (`_persistSessionTokensSnapshot` in `pairing.js`), where
  *     a power loss / kernel panic within the OS writeback window could
  *     otherwise resurrect a revoked token AFTER the operator was told the
- *     revoke succeeded. A genuine fsync failure (EIO / ENOSPC) is re-thrown so
- *     that caller reports the failure; a benign one (EINVAL / ENOTSUP on a FS
- *     that cannot sync — see `BENIGN_FSYNC_CODES`) is logged and the write
- *     still succeeds. On Windows the directory fsync is skipped: there is no
+ *     revoke succeeded. A genuine PRE-rename fsync failure (EIO / ENOSPC) is
+ *     re-thrown so that caller reports the failure — nothing was published, so
+ *     "the write failed" is true. A POST-rename DIRECTORY-fsync failure is NOT
+ *     thrown (#7067): the rename already published the file, so the write
+ *     SUCCEEDED and only its directory entry's durability is unproven; it is
+ *     returned as `durabilityUnconfirmed` and logged at error. Callers for whom
+ *     that caveat must be operator-visible re-raise it themselves — see
+ *     server-cli's revoke persist, which feeds #6965's REVOKE_NOT_DURABLE frame.
+ *     A benign fsync failure (EINVAL / ENOTSUP on a FS that cannot sync — see
+ *     `BENIGN_FSYNC_CODES`) is logged and the write still succeeds. On Windows the directory fsync is skipped: there is no
  *     directory-fsync, and `renameSync` already passes `MOVEFILE_WRITE_THROUGH`
  *     (a durable rename), so the temp-file fsync plus the write-through rename
  *     cover the same guarantee.
@@ -230,6 +236,13 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
  * (a keychain write with no outer retry). The retry is bounded to a single extra
  * attempt and to the transient-lock error codes, so a genuine failure (e.g.
  * ENOSPC, a bad path) still surfaces immediately. See `platform-windows.test.js`.
+ */
+/**
+ * @returns {{ durabilityUnconfirmed: string | null }} `durabilityUnconfirmed` is
+ *   the post-rename directory-fsync error message when the file is live but its
+ *   directory entry's durability could not be confirmed; `null` otherwise —
+ *   including every non-durable write, which makes no durability claim at all.
+ *   Mirrors `credential-store.writeStoreAtomically`'s contract (#7067).
  */
 export function writeFileRestricted(
   filePath,

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -317,7 +317,7 @@ export function writeFileRestricted(
         // Windows-only branch: no directory fsync (Windows has none; the durable
         // rename comes from MOVEFILE_WRITE_THROUGH). The temp file was already
         // fsynced above when `durable`.
-        return
+        return { durabilityUnconfirmed: null }
       } catch {
         // fall through to cleanup + rethrow the original error below
       }
@@ -337,9 +337,32 @@ export function writeFileRestricted(
   // the old inode. POSIX-only: Windows has no directory fsync, and its renameSync
   // already passes MOVEFILE_WRITE_THROUGH (a durable rename), so the temp-file
   // fsync above plus the write-through rename cover the same guarantee.
+  //
+  // #7067: this failure does NOT throw, unlike the PRE-rename fsync above. The
+  // asymmetry is the point. Before the rename nothing is published, so "the write
+  // failed" is TRUE and throwing is right. After it, the file is already live and
+  // only the durability of its directory ENTRY is unproven — throwing there told
+  // the caller a landed write had failed, and `pairing.js` turned that into "the
+  // session-token revoke failed" for a revoke already on disk, sending the
+  // operator to retry or to assume a revoked token was still live. Report the
+  // caveat instead, matching `credential-store.writeStoreAtomically` (#6964/#7061),
+  // which resolved this exact moment the same way.
   if (durable && !onWindows) {
-    fsyncForDurability(dirname(filePath), { isDir: true, _fsync })
+    try {
+      fsyncForDurability(dirname(filePath), { isDir: true, _fsync })
+    } catch (err) {
+      const durabilityUnconfirmed = err?.message || String(err)
+      // The only surviving artifact: no exception is raised and callers that
+      // ignore the return value see a plain success, so this must be `error`.
+      log.error(
+        `durable-write: ${filePath} is written and live, but its directory entry could not be fsynced ` +
+        `(${durabilityUnconfirmed}) — a power loss could roll the rename back. The write IS in effect; ` +
+        `treat its durability as unconfirmed.`,
+      )
+      return { durabilityUnconfirmed }
+    }
   }
+  return { durabilityUnconfirmed: null }
 }
 
 /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -75,6 +75,34 @@ const SERVER_VERSION = packageJson.version
  * @param {{ tunnelMode: string, tunnelUrl: string, attempt?: number, maxAttempts?: number }} args
  * @returns {object} WS message envelope
  */
+/**
+ * #6927/#7067 — write the (possibly rotated) primary token into config.json.
+ *
+ * Exported and `_write`-injectable so the DURABILITY limb is testable: #7067
+ * made `writeFileRestricted` REPORT a post-rename directory-fsync failure rather
+ * than throw, which is right for callers where a landed write must not be
+ * reported as failed. This caller is the deliberate exception — #6965 built an
+ * operator-visible `REVOKE_NOT_DURABLE` frame for exactly this outcome and the
+ * revoke ack is gated on this callback, so swallowing the caveat would trade the
+ * old false-FAILURE for a false SUCCESS on the panic button. Re-raise it and let
+ * #6965's existing path surface it.
+ *
+ * @param {string} configFile
+ * @param {string} newToken
+ * @param {{ durable?: boolean, _write?: Function }} [opts]
+ */
+export function persistTokenToConfigFile(configFile, newToken, { durable = false, _write = writeFileRestricted } = {}) {
+  const raw = existsSync(configFile) ? readFileSync(configFile, 'utf-8') : '{}'
+  const cfg = JSON.parse(raw)
+  cfg.apiToken = newToken
+  const outcome = _write(configFile, JSON.stringify(cfg, null, 2), { durable })
+  if (durable && outcome?.durabilityUnconfirmed) {
+    throw new Error(
+      `token written but its directory entry could not be fsynced (${outcome.durabilityUnconfirmed})`,
+    )
+  }
+}
+
 export function buildTunnelWarmingStatus({ tunnelMode, tunnelUrl, attempt, maxAttempts }) {
   const base = {
     type: 'server_status',
@@ -891,12 +919,7 @@ export async function startCliServer(config) {
       // stays non-durable. Only the file fallback is fsync-controllable here; the
       // keychain path's durability is the OS keychain's responsibility.
       const durable = reason === 'revoke'
-      const persistToFile = () => {
-        const raw = existsSync(configFile) ? readFileSync(configFile, 'utf-8') : '{}'
-        const cfg = JSON.parse(raw)
-        cfg.apiToken = newToken
-        writeFileRestricted(configFile, JSON.stringify(cfg, null, 2), { durable })
-      }
+      const persistToFile = () => persistTokenToConfigFile(configFile, newToken, { durable })
       try {
         if (isKeychainAvailable()) {
           try {

--- a/packages/server/tests/paired-devices-live-revoke.test.js
+++ b/packages/server/tests/paired-devices-live-revoke.test.js
@@ -273,26 +273,6 @@ describe('#6914 revoke opts into a durable store write; mint does not', () => {
     pm.destroy()
   })
 
-  it('#7067: a revoke whose snapshot LANDED is not reported as failed (post-rename fsync caveat)', () => {
-    // The split-brain: writeFileRestricted used to THROW when the post-rename
-    // directory fsync failed — after the rename had already published the
-    // revoked-out snapshot. session-token-store caught it, returned false, and
-    // pairing reported the revoke as failed for a revoke that is on disk. The
-    // operator then retries, or assumes a revoked token is still live.
-    //
-    // A store whose save() SUCCEEDS (as it now does — the write landed, only the
-    // directory entry's durability is unproven) must be reported as a success.
-    const store = makeDurabilityRecordingStore()
-    const pm = new PairingManager({ sessionTokenTtlMs: 60_000, sessionTokenStore: store })
-    const [t1] = mintTokens(pm, 1)
-    store.calls.length = 0
-
-    const result = pm.revokeSessionTokenById(pm._deviceIdForToken(t1))
-    assert.deepEqual(result, { revoked: 1 }, 'a landed revoke reports success')
-    assert.equal(result.persistFailed, undefined, 'and carries no persist-failure flag')
-    pm.destroy()
-  })
-
   it('revokeAllSessionTokens persists with { durable: true }', () => {
     const store = makeDurabilityRecordingStore()
     const pm = new PairingManager({ sessionTokenTtlMs: 60_000, sessionTokenStore: store })

--- a/packages/server/tests/paired-devices-live-revoke.test.js
+++ b/packages/server/tests/paired-devices-live-revoke.test.js
@@ -273,6 +273,26 @@ describe('#6914 revoke opts into a durable store write; mint does not', () => {
     pm.destroy()
   })
 
+  it('#7067: a revoke whose snapshot LANDED is not reported as failed (post-rename fsync caveat)', () => {
+    // The split-brain: writeFileRestricted used to THROW when the post-rename
+    // directory fsync failed — after the rename had already published the
+    // revoked-out snapshot. session-token-store caught it, returned false, and
+    // pairing reported the revoke as failed for a revoke that is on disk. The
+    // operator then retries, or assumes a revoked token is still live.
+    //
+    // A store whose save() SUCCEEDS (as it now does — the write landed, only the
+    // directory entry's durability is unproven) must be reported as a success.
+    const store = makeDurabilityRecordingStore()
+    const pm = new PairingManager({ sessionTokenTtlMs: 60_000, sessionTokenStore: store })
+    const [t1] = mintTokens(pm, 1)
+    store.calls.length = 0
+
+    const result = pm.revokeSessionTokenById(pm._deviceIdForToken(t1))
+    assert.deepEqual(result, { revoked: 1 }, 'a landed revoke reports success')
+    assert.equal(result.persistFailed, undefined, 'and carries no persist-failure flag')
+    pm.destroy()
+  })
+
   it('revokeAllSessionTokens persists with { durable: true }', () => {
     const store = makeDurabilityRecordingStore()
     const pm = new PairingManager({ sessionTokenTtlMs: 60_000, sessionTokenStore: store })

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -569,6 +569,42 @@ try {
         assert.strictEqual(existsSync(`${filePath}.tmp`), false)
       })
 
+      it('#7067: a POST-RENAME directory-fsync failure does NOT throw — the write already landed', () => {
+        // The rename has already published the file, so the write SUCCEEDED; only
+        // the durability of its directory entry is unproven. Throwing here told the
+        // caller the write failed, and pairing.js turned that into "the session-token
+        // revoke failed" for a revoke whose snapshot was already on disk — the
+        // operator then retries or assumes the token is still live. Mirrors the
+        // credential-store precedent (#6964/#7061), which reports rather than throws.
+        if (isWindows) return // no directory fsync on Windows
+        const filePath = join(tmpDir, 'session-tokens.json')
+        const hard = Object.assign(new Error('dir fsync exploded'), { code: 'EIO' })
+        let calls = 0
+        let outcome
+        assert.doesNotThrow(() => {
+          outcome = writeFileRestricted(filePath, 'revoked-snapshot', {
+            durable: true,
+            // 1st call = the temp FILE (pre-rename) and must succeed; 2nd = the
+            // containing DIRECTORY (post-rename) and is the limb under test.
+            _fsync: (fd) => { calls++; if (calls === 1) return fsyncSync(fd); throw hard },
+          })
+        }, 'the file is on disk — reporting a failed write would be factually wrong')
+        assert.strictEqual(calls, 2, 'both limbs ran: temp-file fsync then directory fsync')
+        assert.strictEqual(readFileSync(filePath, 'utf-8'), 'revoked-snapshot', 'the write DID land')
+        assert.strictEqual(existsSync(`${filePath}.tmp`), false, 'no orphaned sidecar')
+        assert.strictEqual(
+          typeof outcome?.durabilityUnconfirmed, 'string',
+          'the caveat must be reported, not swallowed — the caller needs to distinguish it from a clean write',
+        )
+        assert.match(outcome.durabilityUnconfirmed, /EIO|dir fsync exploded/)
+      })
+
+      it('#7067: a clean durable write reports durabilityUnconfirmed: null', () => {
+        const filePath = join(tmpDir, 'clean.json')
+        const outcome = writeFileRestricted(filePath, 'ok', { durable: true })
+        assert.strictEqual(outcome?.durabilityUnconfirmed, null, 'a clean write makes no caveat')
+      })
+
       it('propagates a GENUINE fsync failure (EIO) and cleans up the temp — the durable caller reports failure', () => {
         // A real I/O error means we cannot promise durability, so the durable path
         // must surface it (→ session-token store save() returns false → revoke

--- a/packages/server/tests/token-persist-durability.test.js
+++ b/packages/server/tests/token-persist-durability.test.js
@@ -1,0 +1,70 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { persistTokenToConfigFile } from '../src/server-cli.js'
+
+/**
+ * #7067 — the primary-token persist must keep #6965's operator-visible surface.
+ *
+ * #7067 changed `writeFileRestricted` so a POST-rename directory-fsync failure
+ * REPORTS (`durabilityUnconfirmed`) instead of throwing: the rename already
+ * published the file, so telling most callers "the write failed" is a lie.
+ *
+ * This caller is the deliberate exception. The revoke ack is gated on this
+ * callback, and #6965 built a `REVOKE_NOT_DURABLE` frame for exactly this
+ * outcome. If the caveat were swallowed here, the panic-button revoke would
+ * report a CLEAN durable success while the new token's directory entry might not
+ * survive a power loss — trading the old false-FAILURE for a false SUCCESS on the
+ * single most consequential control in the daemon.
+ */
+describe('persistTokenToConfigFile durability (#7067)', () => {
+  let dir, configFile
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-token-persist-'))
+    configFile = join(dir, 'config.json')
+    writeFileSync(configFile, JSON.stringify({ apiToken: 'old', port: 8765 }, null, 2))
+  })
+  afterEach(() => { try { rmSync(dir, { recursive: true, force: true }) } catch { /* */ } })
+
+  it('a REVOKE whose write landed but is durability-unconfirmed RE-RAISES (so REVOKE_NOT_DURABLE fires)', () => {
+    const write = (file, body) => {
+      writeFileSync(file, body) // the write really lands — that is the whole point
+      return { durabilityUnconfirmed: 'simulated dir fsync EIO' }
+    }
+    assert.throws(
+      () => persistTokenToConfigFile(configFile, 'new-token', { durable: true, _write: write }),
+      /could not be fsynced|simulated dir fsync/,
+      'the caveat must reach #6965s rethrow, not die in a log line',
+    )
+    assert.equal(
+      JSON.parse(readFileSync(configFile, 'utf-8')).apiToken, 'new-token',
+      'and the token IS on disk — the throw is a durability caveat, not a failed write',
+    )
+  })
+
+  it('a clean REVOKE persist does not throw', () => {
+    const write = (file, body) => { writeFileSync(file, body); return { durabilityUnconfirmed: null } }
+    assert.doesNotThrow(() => persistTokenToConfigFile(configFile, 'new-token', { durable: true, _write: write }))
+    assert.equal(JSON.parse(readFileSync(configFile, 'utf-8')).apiToken, 'new-token')
+  })
+
+  it('a NON-durable (scheduled) rotation ignores the caveat — only the revoke opts in', () => {
+    const write = (file, body) => {
+      writeFileSync(file, body)
+      return { durabilityUnconfirmed: 'should be ignored on the fail-safe path' }
+    }
+    assert.doesNotThrow(
+      () => persistTokenToConfigFile(configFile, 'rotated', { durable: false, _write: write }),
+      'a scheduled rotation is fail-safe: the old token works through its grace window',
+    )
+    assert.equal(JSON.parse(readFileSync(configFile, 'utf-8')).apiToken, 'rotated')
+  })
+
+  it('preserves the rest of config.json', () => {
+    const write = (file, body) => { writeFileSync(file, body); return { durabilityUnconfirmed: null } }
+    persistTokenToConfigFile(configFile, 'tok', { durable: true, _write: write })
+    assert.equal(JSON.parse(readFileSync(configFile, 'utf-8')).port, 8765)
+  })
+})


### PR DESCRIPTION
## The bug

`writeFileRestricted`'s post-rename directory fsync was not wrapped:

```js
if (durable && !onWindows) {
  fsyncForDurability(dirname(filePath), { isDir: true, _fsync })   // <- throws
}
```

A failure there throws **after the rename has already published the file**. The write *succeeded*; only the durability of its directory **entry** is unproven. Throwing tells the caller a landed write failed.

## That lie had a caller

`session-token-store.save()` catches the throw and returns `false`. `pairing.js:612-625` turns `false` into a failed persist — its own comment reads *"report it so the revoke reports failure."*

So an operator revoking a session token is told **the revoke failed**, while the revoked-out snapshot is already on disk. They retry, or assume a revoked token is still live. `server-identity.js` rides the same path.

## The fix — and why the asymmetry is deliberate

| Limb | State of the world | Behaviour |
|---|---|---|
| **Pre-rename** fsync fails | nothing published | **throws** — "the write failed" is TRUE |
| **Post-rename** dir fsync fails | file is live | **reports** `durabilityUnconfirmed` |

`writeFileRestricted` now returns `{ durabilityUnconfirmed: string \| null }`. That is additive — no caller read the previous `undefined` — and it logs at `error`, because callers that ignore the return value see a plain success, making the log the only surviving artifact of the caveat.

This is precisely the resolution `credential-store.writeStoreAtomically` already reached for the identical moment (#6964, reinforced in #7061). **`platform.js` was the copy that never got it** — the exact drift #7054 predicts when one security invariant has two implementations, "and the second copy is the one nobody re-audits."

## Verification

Tests written first, both red. Each limb is pinned **separately**, and each mutation reds on its own:

| Mutation | Result |
|---|---|
| post-rename throws again (restore the bug) | **fail 1** |
| pre-rename stops throwing | **fail 1** |

Worth naming why this survived: **the pre-existing suite could not have caught it.** Its EIO test injects a hook that throws on the *first* fsync — the temp file, pre-rename — so it never reached the post-rename limb at all. The gap wasn't a missing assertion, it was a fixture that structurally couldn't get there.

Also pinned end-to-end at the layer that was lying: a revoke whose snapshot landed now reports `{ revoked: 1 }` with no persist-failure flag.

276/276 across platform / write-file / pairing / session-token / credential-store / server-identity; 5/5 `packages/server/scripts/lint-*.sh`.

## Note for #7054

This settles the throw-vs-report divergence, so the three-way unification tracked there becomes a mechanical extraction of an agreed core rather than a refactor that has to arbitrate behaviour mid-flight.

Closes #7067