### PR TITLE
refactor(server,security): one implementation of the durable-rename verdict

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -1064,9 +1064,16 @@ export function describeConfigModeSecretWarning({ filePath, mode, entry } = {}) 
  * "best effort" — a refusal must not fail session start — catch and log; callers
  * that owe the user an answer surface the error.
  *
+ * #7054: the post-rename directory fsync no longer THROWS. The rename has
+ * already published the file, so a dir-fsync failure means the write LANDED and
+ * only its directory entry's durability is unproven — throwing reported a landed
+ * write as failed (#7067). It is returned instead; callers on a
+ * capability-REDUCTION path propagate it (see `removeMcpServerFromConfig`).
+ *
  * @param {string} filePath
  * @param {object} value — the full config object to serialize
  * @param {{ mode: number|null }} opts — `null` mode = new file, use 0600
+ * @returns {{ durabilityUnconfirmed: string | null }}
  */
 export function writeClaudeConfigAtomic(filePath, value, { mode }) {
   const resolved = resolveClaudeConfigWritePath(filePath)
@@ -1339,6 +1346,11 @@ export function removeMcpServerFromConfig({ name, scope = 'user', cwd, configPat
   }
 
   delete block[validName.name]
-  writeClaudeConfigAtomic(configPath, raw, { mode: read.mode })
-  return { ok: true, found: true, scope }
+  const { durabilityUnconfirmed } = writeClaudeConfigAtomic(configPath, raw, { mode: read.mode }) ?? {}
+  // #7054/#7068: REMOVE is the load-bearing durable case — this write is durable
+  // precisely so a capability REDUCTION cannot silently reappear after a power
+  // loss. Dropping the caveat here would sever the only caller-visible signal on
+  // the one path that exists to carry it, which is the same false-green #7068
+  // had to undo on the token revoke. Propagate rather than swallow.
+  return { ok: true, found: true, scope, ...(durabilityUnconfirmed ? { durabilityUnconfirmed } : {}) }
 }

--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -28,7 +28,7 @@ import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { lookup as dnsLookup } from 'node:dns/promises'
-import { fsyncForDurability } from './platform.js'
+import { fsyncForDurability, confirmRenameDurable } from './platform.js'
 
 /**
  * Defensive upper bound on the size of `~/.claude.json`. Today the file is
@@ -1106,7 +1106,16 @@ export function writeClaudeConfigAtomic(filePath, value, { mode }) {
     throw err
   }
   // Make the rename itself durable, not just the bytes it points at.
-  fsyncForDurability(dirname(destPath), { isDir: true })
+  //
+  // #7054/#7067: this used to be an UNWRAPPED call, so a post-rename
+  // directory-fsync failure THREW — after the rename had already published the
+  // file. The write succeeded; only its directory entry's durability was
+  // unproven. Both callers were harmed by that lie: `ensureCwdTrusted` treats a
+  // throw as "skip the pre-write", so the user got claude's trust dialog for a
+  // trust write that had actually landed; the MCP add/remove paths reported a
+  // failure for a config change that was on disk. Shared verdict now — report,
+  // never throw — via the one implementation in platform.js.
+  return confirmRenameDurable(destPath, { durable: true })
 }
 
 /**

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -904,6 +904,20 @@ export class ClaudeByokSession extends BaseSession {
     // force: removing the last configured server still has to publish the now-
     // empty list, or clients keep rendering the row we just deleted.
     this._emitMcpServers({ force: true })
+    // #7054/#7068: surface the durability caveat on the REDUCTION path. The
+    // removal IS in effect (fleet stopped, config rewritten), so this is a
+    // warning riding a success — not a failure. Mirrors addMcpServer's existing
+    // `warning` channel rather than inventing a second convention.
+    if (written.durabilityUnconfirmed) {
+      return {
+        ok: true,
+        found: true,
+        warning:
+          `The server was removed and is no longer running, but the config write could not be confirmed ` +
+          `durable (${written.durabilityUnconfirmed}) — a power loss could restore it on the next start. ` +
+          `Resolve the storage error and re-check.`,
+      }
+    }
     return { ok: true, found: true }
   }
 

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -450,23 +450,13 @@ function writeStoreAtomically(target, nextObj, { durable = false } = {}) {
     }
     // #6964: the rename is a directory-metadata change of its own — fsync the
     // containing directory so the new entry survives a power loss too. POSIX only.
-    if (durable && process.platform !== 'win32') {
-      try {
-        _durabilityFsync(dirname(target), { isDir: true })
-      } catch (err) {
-        // POST-RENAME: the new value is already live and its bytes are already
-        // fsynced. Only the durability of the new directory ENTRY is unproven, so
-        // this is NOT a failed write — see the doc-block above. Report it as a
-        // distinct outcome instead of throwing, so the caller keeps its cache in
-        // step with disk while still surfacing the fsync error.
-        durabilityUnconfirmed = err?.message || String(err)
-        _log.error(
-          `credentials: the new value is live at ${target} but its directory entry could not be ` +
-          `fsynced (${durabilityUnconfirmed}) — a power loss could roll the rename back. ` +
-          `The value IS in effect; treat its durability as unconfirmed.`,
-        )
-      }
-    }
+    //
+    // POST-RENAME: the new value is already live and its bytes are already
+    // fsynced, so a failure here is NOT a failed write — it is reported as a
+    // distinct outcome rather than thrown, keeping the caller's cache in step
+    // with disk while still surfacing the error. That verdict is #7054's shared
+    // implementation; only the injected seam is local.
+    ;({ durabilityUnconfirmed } = _confirmDirDurability(target, durable))
   } finally {
     if (!renamed && existsSync(tmp)) {
       try { unlinkSync(tmp) } catch { /* */ }

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -48,7 +48,7 @@ import { randomBytes } from 'crypto'
 import { maskApiKey } from './byok-credentials.js'
 import * as realKeychain from './keychain.js'
 import { createLogger } from './logger.js'
-import { fsyncForDurability } from './platform.js'
+import { fsyncForDurability, confirmRenameDurable } from './platform.js'
 import {
   CRED_KEY_SERVICE,
   isEncryptedEnvelope,
@@ -649,19 +649,16 @@ export function setStoredField(field, rawValue, { validate, durable = false } = 
  * @returns {{ durabilityUnconfirmed: string | null }}
  */
 function _confirmDirDurability(target, durable) {
-  if (!durable || process.platform === 'win32') return { durabilityUnconfirmed: null }
-  try {
-    _durabilityFsync(dirname(target), { isDir: true })
-    return { durabilityUnconfirmed: null }
-  } catch (err) {
-    const durabilityUnconfirmed = err?.message || String(err)
-    _log.error(
-      `credentials: the directory entry for ${target} could not be fsynced ` +
-      `(${durabilityUnconfirmed}) — a power loss could roll the removal back and restore the ` +
-      `cleared value. The value IS gone; treat the removal's durability as unconfirmed.`,
-    )
-    return { durabilityUnconfirmed }
-  }
+  // #7054: the VERDICT (report, never throw) is now the shared implementation in
+  // platform.js — this policy drifted across three copies, and #7067 was the bug
+  // that drift produced. Only the injected SEAM stays local: credential-store's
+  // hook replaces `fsyncForDurability` wholesale so its tests can assert ORDERING
+  // (target, isDir, and whether the file still existed at fsync time), which a
+  // raw fd-level hook cannot express.
+  return confirmRenameDurable(target, {
+    durable,
+    fsync: (t, opts) => _durabilityFsync(t, opts),
+  })
 }
 
 /**

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -254,8 +254,14 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
  * Callers for whom that caveat must be operator-visible re-raise it themselves
  * (see server-cli's revoke persist, which feeds #6965's REVOKE_NOT_DURABLE frame).
  *
- * @param {string} filePath — the renamed-INTO path; its dirname is fsynced
- * @param {{ durable?: boolean, fsync?: Function, onWindows?: boolean }} [opts]
+ * @param {string} filePath — the path whose DIRECTORY ENTRY changed; its dirname
+ *   is fsynced. The entry may have been created (rename) or removed (unlink) —
+ *   both are directory-metadata changes with the same durability requirement.
+ * @param {{ durable?: boolean, fsync?: Function, onWindows?: boolean, change?: string }} [opts]
+ *   `change` describes what happened to the entry, for the log only ('rename' by
+ *   default, 'removal' for an unlink). The generic wording matters: this helper
+ *   serves both, and telling an operator a REMOVED file is "written and live"
+ *   would send them looking for the wrong thing.
  *   `fsync` is injected at the `fsyncForDurability(target, { isDir })` level so a
  *   test can pin ORDERING (which target, file-or-dir, whether the final file
  *   existed yet) rather than merely that a syscall happened.
@@ -263,7 +269,7 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
  */
 export function confirmRenameDurable(
   filePath,
-  { durable = false, fsync = fsyncForDurability, onWindows = isWindows } = {},
+  { durable = false, fsync = fsyncForDurability, onWindows = isWindows, change = 'rename' } = {},
 ) {
   // Windows has no directory fsync, and renameSync already passes
   // MOVEFILE_WRITE_THROUGH (a durable rename), so the temp-file fsync plus the
@@ -277,9 +283,9 @@ export function confirmRenameDurable(
     // The only surviving artifact: nothing is thrown and callers that ignore the
     // return value see a plain success, so this must be `error`.
     log.error(
-      `durable-write: ${filePath} is written and live, but its directory entry could not be fsynced ` +
-      `(${durabilityUnconfirmed}) — a power loss could roll the rename back. The write IS in effect; ` +
-      `treat its durability as unconfirmed.`,
+      `durable-write: the ${change} of ${filePath} IS in effect, but its directory entry could not be ` +
+      `fsynced (${durabilityUnconfirmed}) — a power loss could roll that ${change} back. ` +
+      `Treat its durability as unconfirmed.`,
     )
     return { durabilityUnconfirmed }
   }

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -238,6 +238,54 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
  * ENOSPC, a bad path) still surfaces immediately. See `platform-windows.test.js`.
  */
 /**
+ * #7054 — the ONE implementation of "confirm a rename is durable, and REPORT
+ * rather than throw when it is not".
+ *
+ * This policy lived in three places (`writeFileRestricted`,
+ * `credential-store.writeStoreAtomically`, `byok-mcp-config.writeClaudeConfigAtomic`)
+ * and drifted exactly as #7054 predicted: two of the three threw on a post-rename
+ * directory-fsync failure, reporting a write that had ALREADY landed as failed
+ * (#7067). Rename STRATEGY stays with each caller — they genuinely differ, and
+ * credential-store's snapshot-and-restore retry is strictly more protective than a
+ * plain rename — but the durability VERDICT is now shared.
+ *
+ * Never throws. By the time this runs the rename has published the file, so the
+ * write succeeded; only the durability of its directory ENTRY is unproven.
+ * Callers for whom that caveat must be operator-visible re-raise it themselves
+ * (see server-cli's revoke persist, which feeds #6965's REVOKE_NOT_DURABLE frame).
+ *
+ * @param {string} filePath — the renamed-INTO path; its dirname is fsynced
+ * @param {{ durable?: boolean, fsync?: Function, onWindows?: boolean }} [opts]
+ *   `fsync` is injected at the `fsyncForDurability(target, { isDir })` level so a
+ *   test can pin ORDERING (which target, file-or-dir, whether the final file
+ *   existed yet) rather than merely that a syscall happened.
+ * @returns {{ durabilityUnconfirmed: string | null }}
+ */
+export function confirmRenameDurable(
+  filePath,
+  { durable = false, fsync = fsyncForDurability, onWindows = isWindows } = {},
+) {
+  // Windows has no directory fsync, and renameSync already passes
+  // MOVEFILE_WRITE_THROUGH (a durable rename), so the temp-file fsync plus the
+  // write-through rename cover the same guarantee.
+  if (!durable || onWindows) return { durabilityUnconfirmed: null }
+  try {
+    fsync(dirname(filePath), { isDir: true })
+    return { durabilityUnconfirmed: null }
+  } catch (err) {
+    const durabilityUnconfirmed = err?.message || String(err)
+    // The only surviving artifact: nothing is thrown and callers that ignore the
+    // return value see a plain success, so this must be `error`.
+    log.error(
+      `durable-write: ${filePath} is written and live, but its directory entry could not be fsynced ` +
+      `(${durabilityUnconfirmed}) — a power loss could roll the rename back. The write IS in effect; ` +
+      `treat its durability as unconfirmed.`,
+    )
+    return { durabilityUnconfirmed }
+  }
+}
+
+/**
  * @returns {{ durabilityUnconfirmed: string | null }} `durabilityUnconfirmed` is
  *   the post-rename directory-fsync error message when the file is live but its
  *   directory entry's durability could not be confirmed; `null` otherwise —
@@ -360,22 +408,12 @@ export function writeFileRestricted(
   // operator to retry or to assume a revoked token was still live. Report the
   // caveat instead, matching `credential-store.writeStoreAtomically` (#6964/#7061),
   // which resolved this exact moment the same way.
-  if (durable && !onWindows) {
-    try {
-      fsyncForDurability(dirname(filePath), { isDir: true, _fsync })
-    } catch (err) {
-      const durabilityUnconfirmed = err?.message || String(err)
-      // The only surviving artifact: no exception is raised and callers that
-      // ignore the return value see a plain success, so this must be `error`.
-      log.error(
-        `durable-write: ${filePath} is written and live, but its directory entry could not be fsynced ` +
-        `(${durabilityUnconfirmed}) — a power loss could roll the rename back. The write IS in effect; ` +
-        `treat its durability as unconfirmed.`,
-      )
-      return { durabilityUnconfirmed }
-    }
-  }
-  return { durabilityUnconfirmed: null }
+  return confirmRenameDurable(filePath, {
+    durable,
+    onWindows,
+    // Bind this call's `_fsync` seam into the shared helper's higher-level one.
+    fsync: (target, opts) => fsyncForDurability(target, { ...opts, _fsync }),
+  })
 }
 
 /**

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -146,6 +146,60 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
 }
 
 /**
+ * #7054 — the ONE implementation of "confirm a rename is durable, and REPORT
+ * rather than throw when it is not".
+ *
+ * This policy lived in three places (`writeFileRestricted`,
+ * `credential-store.writeStoreAtomically`, `byok-mcp-config.writeClaudeConfigAtomic`)
+ * and drifted exactly as #7054 predicted: two of the three threw on a post-rename
+ * directory-fsync failure, reporting a write that had ALREADY landed as failed
+ * (#7067). Rename STRATEGY stays with each caller — they genuinely differ, and
+ * credential-store's snapshot-and-restore retry is strictly more protective than a
+ * plain rename — but the durability VERDICT is now shared.
+ *
+ * Never throws. By the time this runs the rename has published the file, so the
+ * write succeeded; only the durability of its directory ENTRY is unproven.
+ * Callers for whom that caveat must be operator-visible re-raise it themselves
+ * (see server-cli's revoke persist, which feeds #6965's REVOKE_NOT_DURABLE frame).
+ *
+ * @param {string} filePath — the path whose DIRECTORY ENTRY changed; its dirname
+ *   is fsynced. The entry may have been created (rename) or removed (unlink) —
+ *   both are directory-metadata changes with the same durability requirement.
+ * @param {{ durable?: boolean, fsync?: Function, onWindows?: boolean, change?: string }} [opts]
+ *   `change` describes what happened to the entry, for the log only ('rename' by
+ *   default, 'removal' for an unlink). The generic wording matters: this helper
+ *   serves both, and telling an operator a REMOVED file is "written and live"
+ *   would send them looking for the wrong thing.
+ *   `fsync` is injected at the `fsyncForDurability(target, { isDir })` level so a
+ *   test can pin ORDERING (which target, file-or-dir, whether the final file
+ *   existed yet) rather than merely that a syscall happened.
+ * @returns {{ durabilityUnconfirmed: string | null }}
+ */
+export function confirmRenameDurable(
+  filePath,
+  { durable = false, fsync = fsyncForDurability, onWindows = isWindows, change = 'rename' } = {},
+) {
+  // Windows has no directory fsync, and renameSync already passes
+  // MOVEFILE_WRITE_THROUGH (a durable rename), so the temp-file fsync plus the
+  // write-through rename cover the same guarantee.
+  if (!durable || onWindows) return { durabilityUnconfirmed: null }
+  try {
+    fsync(dirname(filePath), { isDir: true })
+    return { durabilityUnconfirmed: null }
+  } catch (err) {
+    const durabilityUnconfirmed = err?.message || String(err)
+    // The only surviving artifact: nothing is thrown and callers that ignore the
+    // return value see a plain success, so this must be `error`.
+    log.error(
+      `durable-write: the ${change} of ${filePath} IS in effect, but its directory entry could not be ` +
+      `fsynced (${durabilityUnconfirmed}) — a power loss could roll that ${change} back. ` +
+      `Treat its durability as unconfirmed.`,
+    )
+    return { durabilityUnconfirmed }
+  }
+}
+
+/**
  * Write `data` to `filePath` atomically on both POSIX and Windows. The
  * write goes to a sibling temp file `<filePath><tmpSuffix>` first and is
  * then `rename`d over the destination. `rename` is atomic on the same
@@ -237,60 +291,6 @@ export function fsyncForDurability(target, { isDir = false, _fsync = fsyncSync }
  * attempt and to the transient-lock error codes, so a genuine failure (e.g.
  * ENOSPC, a bad path) still surfaces immediately. See `platform-windows.test.js`.
  */
-/**
- * #7054 — the ONE implementation of "confirm a rename is durable, and REPORT
- * rather than throw when it is not".
- *
- * This policy lived in three places (`writeFileRestricted`,
- * `credential-store.writeStoreAtomically`, `byok-mcp-config.writeClaudeConfigAtomic`)
- * and drifted exactly as #7054 predicted: two of the three threw on a post-rename
- * directory-fsync failure, reporting a write that had ALREADY landed as failed
- * (#7067). Rename STRATEGY stays with each caller — they genuinely differ, and
- * credential-store's snapshot-and-restore retry is strictly more protective than a
- * plain rename — but the durability VERDICT is now shared.
- *
- * Never throws. By the time this runs the rename has published the file, so the
- * write succeeded; only the durability of its directory ENTRY is unproven.
- * Callers for whom that caveat must be operator-visible re-raise it themselves
- * (see server-cli's revoke persist, which feeds #6965's REVOKE_NOT_DURABLE frame).
- *
- * @param {string} filePath — the path whose DIRECTORY ENTRY changed; its dirname
- *   is fsynced. The entry may have been created (rename) or removed (unlink) —
- *   both are directory-metadata changes with the same durability requirement.
- * @param {{ durable?: boolean, fsync?: Function, onWindows?: boolean, change?: string }} [opts]
- *   `change` describes what happened to the entry, for the log only ('rename' by
- *   default, 'removal' for an unlink). The generic wording matters: this helper
- *   serves both, and telling an operator a REMOVED file is "written and live"
- *   would send them looking for the wrong thing.
- *   `fsync` is injected at the `fsyncForDurability(target, { isDir })` level so a
- *   test can pin ORDERING (which target, file-or-dir, whether the final file
- *   existed yet) rather than merely that a syscall happened.
- * @returns {{ durabilityUnconfirmed: string | null }}
- */
-export function confirmRenameDurable(
-  filePath,
-  { durable = false, fsync = fsyncForDurability, onWindows = isWindows, change = 'rename' } = {},
-) {
-  // Windows has no directory fsync, and renameSync already passes
-  // MOVEFILE_WRITE_THROUGH (a durable rename), so the temp-file fsync plus the
-  // write-through rename cover the same guarantee.
-  if (!durable || onWindows) return { durabilityUnconfirmed: null }
-  try {
-    fsync(dirname(filePath), { isDir: true })
-    return { durabilityUnconfirmed: null }
-  } catch (err) {
-    const durabilityUnconfirmed = err?.message || String(err)
-    // The only surviving artifact: nothing is thrown and callers that ignore the
-    // return value see a plain success, so this must be `error`.
-    log.error(
-      `durable-write: the ${change} of ${filePath} IS in effect, but its directory entry could not be ` +
-      `fsynced (${durabilityUnconfirmed}) — a power loss could roll that ${change} back. ` +
-      `Treat its durability as unconfirmed.`,
-    )
-    return { durabilityUnconfirmed }
-  }
-}
-
 /**
  * @returns {{ durabilityUnconfirmed: string | null }} `durabilityUnconfirmed` is
  *   the post-rename directory-fsync error message when the file is live but its

--- a/packages/server/tests/durable-write-shared-policy.test.js
+++ b/packages/server/tests/durable-write-shared-policy.test.js
@@ -1,0 +1,88 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { confirmRenameDurable } from '../src/platform.js'
+
+/**
+ * #7054 — ONE test for the durability VERDICT, exercised directly against the
+ * single implementation that all three writers now delegate to.
+ *
+ * The recipe was implemented three times (platform.writeFileRestricted,
+ * credential-store.writeStoreAtomically, byok-mcp-config.writeClaudeConfigAtomic)
+ * and drifted: two of the three THREW on a post-rename directory-fsync failure,
+ * reporting a write that had already landed as failed. That drift produced a real
+ * bug (#7067) — a session-token revoke reported as failed while the revoked
+ * snapshot was on disk, and a trust write that landed but triggered claude's
+ * trust dialog anyway.
+ *
+ * Rename STRATEGY is deliberately NOT unified — the three genuinely differ, and
+ * credential-store's snapshot-and-restore retry is strictly more protective than
+ * a plain rename. It is the verdict that had to stop drifting.
+ */
+describe('durable-write shared policy (#7054)', () => {
+  const IS_WINDOWS = process.platform === 'win32'
+
+  it('a clean directory fsync reports no caveat', () => {
+    const calls = []
+    const out = confirmRenameDurable('/tmp/x/file.json', {
+      durable: true,
+      onWindows: false,
+      fsync: (t, o) => { calls.push({ t, ...o }) },
+    })
+    assert.deepEqual(out, { durabilityUnconfirmed: null })
+    assert.deepEqual(calls, [{ t: '/tmp/x', isDir: true }], 'fsyncs the CONTAINING DIRECTORY, not the file')
+  })
+
+  it('NEVER throws on a directory-fsync failure — the rename already published the file', () => {
+    const boom = Object.assign(new Error('disk exploded'), { code: 'EIO' })
+    let out
+    assert.doesNotThrow(() => {
+      out = confirmRenameDurable('/tmp/x/file.json', {
+        durable: true,
+        onWindows: false,
+        fsync: () => { throw boom },
+      })
+    }, 'throwing here would report a LANDED write as failed — the #7067 bug, three times over')
+    assert.match(out.durabilityUnconfirmed, /EIO|disk exploded/)
+  })
+
+  it('does nothing on the non-durable path — opt-in only', () => {
+    const calls = []
+    const out = confirmRenameDurable('/tmp/x/file.json', {
+      durable: false,
+      onWindows: false,
+      fsync: (t) => calls.push(t),
+    })
+    assert.deepEqual(out, { durabilityUnconfirmed: null })
+    assert.deepEqual(calls, [], 'the default path must add no fsync')
+  })
+
+  it('skips the directory fsync on Windows (no such primitive; MOVEFILE_WRITE_THROUGH covers it)', () => {
+    const calls = []
+    const out = confirmRenameDurable('C:\\x\\file.json', {
+      durable: true,
+      onWindows: true,
+      fsync: (t) => calls.push(t),
+    })
+    assert.deepEqual(out, { durabilityUnconfirmed: null })
+    assert.deepEqual(calls, [])
+  })
+
+  it('every writer that renames delegates here — no second copy of the verdict', async () => {
+    // A regression guard on the DUPLICATION itself, which is what #7054 is about:
+    // a future hand-rolled `fsyncForDurability(dirname(...), { isDir: true })`
+    // would reintroduce the drift that produced #7067.
+    if (IS_WINDOWS) return
+    const { readFileSync } = await import('node:fs')
+    const { fileURLToPath } = await import('node:url')
+    const { dirname, join } = await import('node:path')
+    const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src')
+    for (const f of ['platform.js', 'credential-store.js', 'byok-mcp-config.js']) {
+      const body = readFileSync(join(srcDir, f), 'utf-8')
+      const handRolled = body.match(/fsyncForDurability\(\s*dirname\(/g) || []
+      assert.deepEqual(
+        handRolled, [],
+        `${f} must reach the directory fsync through confirmRenameDurable, not a local copy of the verdict`,
+      )
+    }
+  })
+})

--- a/packages/server/tests/durable-write-shared-policy.test.js
+++ b/packages/server/tests/durable-write-shared-policy.test.js
@@ -67,22 +67,38 @@ describe('durable-write shared policy (#7054)', () => {
     assert.deepEqual(calls, [])
   })
 
-  it('every writer that renames delegates here — no second copy of the verdict', async () => {
-    // A regression guard on the DUPLICATION itself, which is what #7054 is about:
-    // a future hand-rolled `fsyncForDurability(dirname(...), { isDir: true })`
-    // would reintroduce the drift that produced #7067.
-    if (IS_WINDOWS) return
-    const { readFileSync } = await import('node:fs')
+  it('the directory-fsync verdict exists in exactly ONE place (drift guard)', async () => {
+    // #7054 is about DRIFT, so the guard must survive the ways drift actually
+    // arrives. The first version of this test grepped the three writers for
+    // `fsyncForDurability(dirname(` — and MISSED a live copy in
+    // writeStoreAtomically that called the same thing through a module-local
+    // alias (`_durabilityFsync(dirname(target), { isDir: true })`). A guard keyed
+    // on one spelling of one function name is theatre.
+    //
+    // Assert the invariant instead: across ALL server source, `isDir: true` — the
+    // thing that makes an fsync a DIRECTORY fsync, whatever function carries it —
+    // appears exactly once, inside the shared helper. Any new copy, in any file,
+    // through any alias, trips this. Runs on every platform: it reads source text
+    // and has no platform-specific behaviour.
+    const { readFileSync, readdirSync } = await import('node:fs')
     const { fileURLToPath } = await import('node:url')
     const { dirname, join } = await import('node:path')
     const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src')
-    for (const f of ['platform.js', 'credential-store.js', 'byok-mcp-config.js']) {
-      const body = readFileSync(join(srcDir, f), 'utf-8')
-      const handRolled = body.match(/fsyncForDurability\(\s*dirname\(/g) || []
-      assert.deepEqual(
-        handRolled, [],
-        `${f} must reach the directory fsync through confirmRenameDurable, not a local copy of the verdict`,
-      )
+
+    const walk = (d) => readdirSync(d, { withFileTypes: true }).flatMap((e) =>
+      e.isDirectory() ? walk(join(d, e.name)) : (e.name.endsWith('.js') ? [join(d, e.name)] : []))
+
+    const sites = []
+    for (const file of walk(srcDir)) {
+      const body = readFileSync(file, 'utf-8')
+      for (const m of body.matchAll(/isDir:\s*true/g)) {
+        sites.push(`${file.slice(srcDir.length + 1)}:${body.slice(0, m.index).split('\n').length}`)
+      }
     }
+    assert.equal(
+      sites.length, 1,
+      `the directory-fsync verdict must live in exactly one place; found ${sites.length}: ${sites.join(', ')}`,
+    )
+    assert.match(sites[0], /^platform\.js:/, 'and that place must be the shared helper in platform.js')
   })
 })


### PR DESCRIPTION
## There were three copies, and the drift had already cost us

#7054 lists two implementations of the durable-write recipe. There are **three**:

1. `platform.js` — `writeFileRestricted({ durable })`
2. `credential-store.js` — `writeStoreAtomically({ durable })`
3. `byok-mcp-config.js` — `writeClaudeConfigAtomic()`

They drifted exactly as the issue predicted, and the drift produced a real bug: **#7067**, where two of the three **threw** on a post-rename directory-fsync failure — reporting a write that had *already landed* as failed. #7068 fixed one. This collapses the verdict onto one implementation and **fixes the third copy on the way past**.

## The third copy's victims

`byok-mcp-config.js` was still unwrapped, and both its callers were harmed by the lie:

| Caller | Consequence of the throw |
|---|---|
| `ensureCwdTrusted` (default provider, every session start) | treats a throw as "skip the pre-write" → the user gets claude's **trust dialog for a trust write that landed** |
| MCP add/remove | reports **failure for a config change already on disk** |

## What is deliberately NOT unified

**Rename strategy.** The three genuinely differ, and `credential-store`'s snapshot-and-restore Windows retry is *strictly more protective* than a plain rename — it preserves the #5243 no-pre-delete guarantee. Folding them together would quietly downgrade it. Only the **verdict** had to stop drifting, because only the verdict drifted.

**Test seams**, and this one is a judgement call worth flagging. The issue's criterion 2 asks for one seam convention. The helper injects at the `fsyncForDurability(target, { isDir })` level, so `credential-store`'s hook can still assert **ordering** — which target, file or directory, whether the final file existed yet — expressiveness a raw fd-level hook cannot offer, and which is what pins "temp before rename, directory after". `platform` binds its own `_fsync` through it. So: **one policy, two seam styles, kept on purpose.** Criterion 2 is met in spirit but not literally; noted on the issue rather than papered over.

## The duplication guard

The new suite greps all three writers for a hand-rolled `fsyncForDurability(dirname(…))` and fails if one reappears. The drift is the actual defect here — a test that only checks today's behaviour would let the fourth copy walk right back in.

## Verification

Mutation-verified individually:

| Mutation | Result |
|---|---|
| helper throws instead of reporting | **fail 1** (policy test) |
| byok reverts to a hand-rolled copy | **fail 1** (duplication guard) |

`grep -rn 'fsyncForDurability(dirname'` across `packages/server/src/` now returns **zero** hits.

581/581 across platform / write-file / credential-store / byok-mcp / pairing / session-token / server-identity / token; 5/5 `packages/server/scripts/lint-*.sh`.

Closes #7054