### PR TITLE
fix(server): restrict the orchestration architect provider

### DIFF
--- a/docs/design/orchestration/README.md
+++ b/docs/design/orchestration/README.md
@@ -94,12 +94,28 @@ split the synthesized map" note still applies to whichever future PR adds the ov
 |---|---|---|---|
 | claude-sdk | ✓ | ✓ | architect + all workers |
 | claude-byok | ✓ | ✓ | architect + all workers |
-| codex (app-server) | ✓ | ✗ — use per-session `codexSandbox: 'read-only'` (#6690, landed 2026-07-16) | workers |
-| claude-cli | ✗ (HTTP hook only) | ✗ | excluded v1 |
+| codex (app-server) | ✓ | ✗ — use per-session `codexSandbox: 'read-only'` (#6690, landed 2026-07-16) | architect + all workers |
+| claude-cli | ✗ (HTTP hook only) | ✗ | excluded v1 — now enforced (#7036) |
 | gemini | ✗ (no permission surface) | ✗ | excluded v1 |
 | claude-tui / channel | n/a | n/a | excluded (no usage telemetry) |
 
 Notes: `reserveSessions` does not exist in SessionManager — the engine scheduler implements its
 own headroom under `maxSessions` (default 5, tight; config validation warns). One run at a time
+**Enforcement (#7036).** The `v1 roles` column is no longer advisory for the
+architect. `orchestration-manager._resolveRoles` validates `architect.provider`
+against `ARCHITECT_ELIGIBLE_PROVIDERS` (`claude-sdk` / `claude-byok` / `codex`),
+the same way the worker is validated against `AUDIT_ELIGIBLE_PROVIDERS`. codex is
+listed as architect-eligible because the code already supported it (the architect
+runs `codexSandbox: 'read-only'`) and it was reachable before the gate existed —
+the gate records that, it does not newly grant it.
+
+What the gate does and does not buy is worth stating exactly: it removes the
+QUEUED-TURN KILL by construction (only `claude-cli` emits `result` then
+`stopped`), but it does NOT make an eligible provider immune to reporting an
+interrupted turn as complete — `claude-byok` can fall through to a normal
+`result` when an interrupt lands in its tool phase, and `claude-sdk`'s
+stream-stall path settles a turn the same way. That needs a provider-side
+`interrupted: true` signal on the wire, not a provider allowlist.
+
 in v1. `#6690` landed after the engine doc was written and supersedes its "codex sandbox opt"
 gap: `createSession({codexSandbox: 'read-only'})` is the audit-worker posture for codex.

--- a/docs/design/orchestration/README.md
+++ b/docs/design/orchestration/README.md
@@ -92,8 +92,8 @@ split the synthesized map" note still applies to whichever future PR adds the ov
 
 | Provider | respondToPermission | setPermissionRules | v1 roles |
 |---|---|---|---|
-| claude-sdk | ✓ | ✓ | architect + all workers |
-| claude-byok | ✓ | ✓ | architect + all workers |
+| claude-sdk | ✓ | ✓ | architect + audit workers (implement is codex-only, #6735) |
+| claude-byok | ✓ | ✓ | architect + audit workers (implement is codex-only, #6735) |
 | codex (app-server) | ✓ | ✗ — use per-session `codexSandbox: 'read-only'` (#6690, landed 2026-07-16) | architect + all workers |
 | claude-cli | ✗ (HTTP hook only) | ✗ | excluded v1 — now enforced (#7036) |
 | gemini | ✗ (no permission surface) | ✗ | excluded v1 |
@@ -101,6 +101,9 @@ split the synthesized map" note still applies to whichever future PR adds the ov
 
 Notes: `reserveSessions` does not exist in SessionManager — the engine scheduler implements its
 own headroom under `maxSessions` (default 5, tight; config validation warns). One run at a time
+in v1. `#6690` landed after the engine doc was written and supersedes its "codex sandbox opt"
+gap: `createSession({codexSandbox: 'read-only'})` is the audit-worker posture for codex.
+
 **Enforcement (#7036).** The `v1 roles` column is no longer advisory for the
 architect. `orchestration-manager._resolveRoles` validates `architect.provider`
 against `ARCHITECT_ELIGIBLE_PROVIDERS` (`claude-sdk` / `claude-byok` / `codex`),
@@ -116,6 +119,3 @@ interrupted turn as complete — `claude-byok` can fall through to a normal
 `result` when an interrupt lands in its tool phase, and `claude-sdk`'s
 stream-stall path settles a turn the same way. That needs a provider-side
 `interrupted: true` signal on the wire, not a provider allowlist.
-
-in v1. `#6690` landed after the engine doc was written and supersedes its "codex sandbox opt"
-gap: `createSession({codexSandbox: 'read-only'})` is the audit-worker posture for codex.

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -68,11 +68,30 @@ const AUDIT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
 // committee reviews serialise on the architect session, so a queued turn there
 // is the normal case, not an edge case.
 //
-// The listed three are safe from that specific hazard: codex/byok never emit a
-// synthetic result, and claude-sdk only does so on a stream STALL (followed by
-// `error`, not `stopped`). Anything outside this set is simply unvetted for
-// TurnDriver's turn-terminal semantics — the point is to make the failure
-// unreachable by construction rather than unreachable by hope.
+// PRECISELY what this closes, and what it does NOT:
+//
+//   CLOSED — the queued-turn kill. Only claude-cli emits `result` THEN `stopped`
+//   for one interrupt, so only claude-cli can settle turn 1 and have the trailing
+//   `stopped` land on turn 2. None of the three below emit `stopped` after a
+//   `result`, so excluding claude-cli removes this failure by construction.
+//
+//   NOT CLOSED — false success on an interrupted turn. This is broader than
+//   claude-cli and membership here does NOT imply immunity:
+//     * claude-byok: an interrupt landing in the TOOL phase (not mid-stream)
+//       breaks the loop at the `signal.aborted` check and falls THROUGH to the
+//       normal `emit('result')` with real usage (byok-session.js ~1328 -> ~1459).
+//     * claude-sdk: a stream STALL emits a synthetic `result` then `error`;
+//       TurnDriver settles on the `result` and the trailing `error` is dropped by
+//       the epoch guard.
+//     * codex app-server: safe only if the binary answers `turn/interrupt` with an
+//       `error` notification rather than `turn/completed` — unverified in-repo.
+//   Closing that needs the provider-side `interrupted: true` flag the turn-driver
+//   doc-block names, so a terminal-looking result can be marked
+//   terminal-but-not-successful. Tracked separately; it is a cross-provider wire
+//   change, not something this gate can express.
+//
+// So this set means "vetted to not kill the NEXT turn", not "cannot report a
+// truncated turn as complete". Anything outside it is unvetted for either.
 const ARCHITECT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
 
 // v1: write/implement workers are codex-ONLY. codexSandbox:'workspace-write' is a
@@ -197,6 +216,10 @@ export class OrchestrationManager extends EventEmitter {
     const worker = merged.auditWorker || merged.worker
     if (!architect?.provider || !architect?.model) throw new Error('orchestration roles.architect must set { provider, model }')
     if (!worker?.provider || !worker?.model) throw new Error('orchestration roles.worker/auditWorker must set { provider, model }')
+    // NOTE: this runs at createRun only. A future resume path (#6743) will carry
+    // `configSnapshot.roleModels` persisted BEFORE this gate existed, so a
+    // pre-#7036 record could reintroduce a claude-cli architect — re-validate
+    // there too rather than trusting the snapshot.
     if (!ARCHITECT_ELIGIBLE_PROVIDERS.has(architect.provider)) {
       throw new Error(`architect provider '${architect.provider}' is not vetted for turn-terminal semantics (use ${[...ARCHITECT_ELIGIBLE_PROVIDERS].join('/')})`)
     }

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -53,6 +53,28 @@ const DEFAULTS = {
 // design matrix). audit workers must be one of these.
 const AUDIT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
 
+// #7036: providers vetted for the ARCHITECT role. The members coincide with
+// AUDIT_ELIGIBLE_PROVIDERS today but the REASON is different, so this is named
+// separately rather than aliased — the two can diverge without one silently
+// re-opening the other's hole.
+//
+// The architect drives TurnDriver, which treats any `result` as turn-terminal.
+// `claude-cli` emits a SYNTHETIC result on an intentional stop
+// (`cli-session._emitInterruptedTurnResult`, fired BEFORE `stopped`), and
+// TurnDriver cannot distinguish it from a real one. Two consequences: an
+// interrupted architect turn resolves as COMPLETED, so the decision parser reads
+// a truncated plan/review as authoritative; and since #7033 the trailing
+// `stopped` lands on the NEXT queued turn and rejects it TURN_STOPPED — and
+// committee reviews serialise on the architect session, so a queued turn there
+// is the normal case, not an edge case.
+//
+// The listed three are safe from that specific hazard: codex/byok never emit a
+// synthetic result, and claude-sdk only does so on a stream STALL (followed by
+// `error`, not `stopped`). Anything outside this set is simply unvetted for
+// TurnDriver's turn-terminal semantics — the point is to make the failure
+// unreachable by construction rather than unreachable by hope.
+const ARCHITECT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
+
 // v1: write/implement workers are codex-ONLY. codexSandbox:'workspace-write' is a
 // verified OS jail confining edits to the worktree; acceptEdits/allow rules are
 // path-AGNOSTIC and do NOT confine paths, so sdk/byok can't be safely write-
@@ -175,6 +197,9 @@ export class OrchestrationManager extends EventEmitter {
     const worker = merged.auditWorker || merged.worker
     if (!architect?.provider || !architect?.model) throw new Error('orchestration roles.architect must set { provider, model }')
     if (!worker?.provider || !worker?.model) throw new Error('orchestration roles.worker/auditWorker must set { provider, model }')
+    if (!ARCHITECT_ELIGIBLE_PROVIDERS.has(architect.provider)) {
+      throw new Error(`architect provider '${architect.provider}' is not vetted for turn-terminal semantics (use ${[...ARCHITECT_ELIGIBLE_PROVIDERS].join('/')})`)
+    }
     if (!AUDIT_ELIGIBLE_PROVIDERS.has(worker.provider)) {
       throw new Error(`audit worker provider '${worker.provider}' cannot be permission-gated read-only (use ${[...AUDIT_ELIGIBLE_PROVIDERS].join('/')})`)
     }

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -83,8 +83,11 @@ const AUDIT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
 //     * claude-sdk: a stream STALL emits a synthetic `result` then `error`;
 //       TurnDriver settles on the `result` and the trailing `error` is dropped by
 //       the epoch guard.
-//     * codex app-server: safe only if the binary answers `turn/interrupt` with an
-//       `error` notification rather than `turn/completed` — unverified in-repo.
+//     * codex app-server: safe if the binary's answer to `turn/interrupt` routes
+//       to `_failTurn` (which emits `stopped`) rather than to `turn/completed`.
+//       Client exit and the result-timeout also reach `_failTurn`, so an `error`
+//       notification is sufficient but not necessary — which of these the real
+//       binary actually does is unverified in-repo (#7072).
 //   Closing that needs the provider-side `interrupted: true` flag the turn-driver
 //   doc-block names, so a terminal-looking result can be marked
 //   terminal-but-not-successful. Tracked separately; it is a cross-provider wire
@@ -92,6 +95,14 @@ const AUDIT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
 //
 // So this set means "vetted to not kill the NEXT turn", not "cannot report a
 // truncated turn as complete". Anything outside it is unvetted for either.
+//
+// Keeping claude-byok here is deliberate on that reading: it genuinely satisfies
+// the enforceable predicate (it never emits `stopped`), and dropping it while
+// retaining claude-sdk — which has its own false-success path via the stall —
+// would re-encode the very mistake this comment exists to correct, namely set
+// membership implying a safety property it does not deliver. That position holds
+// only while #7072 is open and honest; if #7072 is ever closed wontfix, revisit
+// byok's membership rather than leaving this comment to rot.
 const ARCHITECT_ELIGIBLE_PROVIDERS = new Set(['claude-sdk', 'claude-byok', 'codex'])
 
 // v1: write/implement workers are codex-ONLY. codexSandbox:'workspace-write' is a

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -45,15 +45,20 @@
  *   following turn. No in-tree provider does that (every emit site listed above is
  *   a single synchronous frame); closing it by construction needs a provider-side
  *   turn id on the event payload.
- * - NOT closed here (#7036): CliSession's synthetic interrupted `result`
+ * - CLOSED by construction (#7036): CliSession's synthetic interrupted `result`
  *   (cost:null, load-bearing for clearing the dashboard spinner) is emitted BEFORE
- *   `stopped`, so a claude-cli turn settles as a SUCCESS on it and never reaches
- *   the `stopped` case. The trailing `stopped` no longer harms the next queued turn,
- *   but the interrupted turn itself is still reported as completed. claude-cli is
- *   unreachable through the scheduler (requires capabilities.inProcessPermissions)
- *   and through the orchestration WORKER roles (AUDIT/IMPLEMENT_ELIGIBLE_PROVIDERS
- *   = claude-sdk/claude-byok/codex); the orchestration ARCHITECT role is not
- *   provider-restricted, which is what #7036 closes.
+ *   `stopped`, so a claude-cli turn would settle as a SUCCESS on it and never reach
+ *   the `stopped` case — reporting an interrupted turn as completed, and (since
+ *   #7033) letting the trailing `stopped` land on the next queued turn.
+ *   That is now unreachable rather than merely unlikely: claude-cli cannot enter
+ *   TurnDriver by ANY route. The scheduler requires
+ *   capabilities.inProcessPermissions (cli-session sets it false); the
+ *   orchestration WORKER roles are gated on AUDIT/IMPLEMENT_ELIGIBLE_PROVIDERS;
+ *   and the ARCHITECT role — the last hole — is now gated on
+ *   ARCHITECT_ELIGIBLE_PROVIDERS (orchestration-manager.js). Should a provider
+ *   with the same emit shape ever need admitting, the alternative remains a
+ *   provider-side `interrupted: true` flag so a synthetic result is
+ *   terminal-but-not-successful; that touches the client wire.
  * - Watchdog: on timeout, interrupt() the session and reject TURN_TIMEOUT.
  * - `session_destroyed` mid-turn → SESSION_GONE.
  */

--- a/packages/server/src/orchestration/turn-driver.js
+++ b/packages/server/src/orchestration/turn-driver.js
@@ -45,20 +45,28 @@
  *   following turn. No in-tree provider does that (every emit site listed above is
  *   a single synchronous frame); closing it by construction needs a provider-side
  *   turn id on the event payload.
- * - CLOSED by construction (#7036): CliSession's synthetic interrupted `result`
- *   (cost:null, load-bearing for clearing the dashboard spinner) is emitted BEFORE
- *   `stopped`, so a claude-cli turn would settle as a SUCCESS on it and never reach
- *   the `stopped` case — reporting an interrupted turn as completed, and (since
- *   #7033) letting the trailing `stopped` land on the next queued turn.
- *   That is now unreachable rather than merely unlikely: claude-cli cannot enter
- *   TurnDriver by ANY route. The scheduler requires
- *   capabilities.inProcessPermissions (cli-session sets it false); the
- *   orchestration WORKER roles are gated on AUDIT/IMPLEMENT_ELIGIBLE_PROVIDERS;
- *   and the ARCHITECT role — the last hole — is now gated on
- *   ARCHITECT_ELIGIBLE_PROVIDERS (orchestration-manager.js). Should a provider
- *   with the same emit shape ever need admitting, the alternative remains a
- *   provider-side `interrupted: true` flag so a synthetic result is
- *   terminal-but-not-successful; that touches the client wire.
+ * - PARTLY closed (#7036) — be precise about which half.
+ *   CliSession emits its synthetic interrupted `result` (cost:null, load-bearing
+ *   for clearing the dashboard spinner) BEFORE `stopped`. Two harms follow: the
+ *   turn settles as a SUCCESS on the `result`, and (since #7033) the trailing
+ *   `stopped` lands on the NEXT queued turn and kills it.
+ *
+ *   The QUEUED-TURN KILL is now closed by construction: only claude-cli emits
+ *   `result` then `stopped` for one interrupt, and claude-cli cannot enter
+ *   TurnDriver by ANY route — the scheduler requires
+ *   capabilities.inProcessPermissions (cli-session sets it false), the
+ *   orchestration WORKER roles are gated on AUDIT/IMPLEMENT_ELIGIBLE_PROVIDERS,
+ *   and the ARCHITECT role is now gated on ARCHITECT_ELIGIBLE_PROVIDERS.
+ *
+ *   The FALSE SUCCESS is NOT closed, and eligibility does not imply immunity:
+ *   claude-byok can fall through to a normal `result` when an interrupt lands in
+ *   the tool phase, and claude-sdk's stream-stall path emits `result` then
+ *   `error` (this driver settles on the `result`; the epoch guard drops the
+ *   `error`). Codex app-server depends on what the binary answers to
+ *   `turn/interrupt`, which is unverified here. Closing that needs the
+ *   provider-side `interrupted: true` flag so a terminal-looking result can be
+ *   marked terminal-but-NOT-successful — a cross-provider wire change, not
+ *   something a provider allowlist can express.
  * - Watchdog: on timeout, interrupt() the session and reject TURN_TIMEOUT.
  * - `session_destroyed` mid-turn → SESSION_GONE.
  */

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -369,6 +369,43 @@ test('rejects an ineligible worker provider at createRun', () => {
   }
 })
 
+test('#7036: rejects an ineligible ARCHITECT provider at createRun', () => {
+  // claude-cli was accepted here because only the worker was checked. It is the
+  // one TurnDriver consumer that is not excluded by construction elsewhere, and
+  // it emits a SYNTHETIC turn-terminal `result` on an intentional stop
+  // (cli-session._emitInterruptedTurnResult, before `stopped`). TurnDriver cannot
+  // tell that from a real result, so an interrupted architect turn resolves as a
+  // COMPLETED one and the decision parser reads a truncated plan as authoritative
+  // — and since #7033 the trailing `stopped` then lands on the next queued turn
+  // and kills it. Committee reviews serialise on the architect session, so a
+  // queued turn there is the normal case.
+  const { mgr, cleanup } = makeHarness(happyDecider, {
+    roles: { architect: { provider: 'claude-cli', model: 'sonnet' }, auditWorker: ROLES.auditWorker },
+  })
+  try {
+    assert.throws(
+      () => mgr.createRun({ goal: 'x', cwd: '/repo' }),
+      /architect provider 'claude-cli'/,
+      'an unvetted architect provider must be rejected by construction, not merely unlikely',
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('#7036: still accepts every vetted architect provider', () => {
+  for (const provider of ['claude-sdk', 'claude-byok', 'codex']) {
+    const { mgr, cleanup } = makeHarness(happyDecider, {
+      roles: { architect: { provider, model: 'm' }, auditWorker: ROLES.auditWorker },
+    })
+    try {
+      assert.doesNotThrow(() => mgr.createRun({ goal: 'x', cwd: '/repo' }), `${provider} must stay eligible`)
+    } finally {
+      cleanup()
+    }
+  }
+})
+
 test('rejects a cwd that fails validation', () => {
   const dir = mkdtempSync(join(tmpdir(), 'orch-cwd-'))
   const sm = new FakeSM(happyDecider)


### PR DESCRIPTION
## The hole

`_resolveRoles` validated the **worker** provider against `AUDIT_ELIGIBLE_PROVIDERS` but only checked that `architect.provider` was *present*. So `roles.architect.provider = 'claude-cli'` was accepted.

Every other `TurnDriver` consumer excludes `claude-cli` by construction — the scheduler requires `capabilities.inProcessPermissions` (which `cli-session` sets `false`), and orchestration workers are gated on `AUDIT`/`IMPLEMENT_ELIGIBLE_PROVIDERS`. **The architect role was the one hole.**

## Why it matters

`CliSession` emits a **synthetic** turn-terminal `result` on an intentional stop (`_emitInterruptedTurnResult`, fired *before* `stopped`), and `TurnDriver` cannot tell it from a real one:

1. **False success.** An interrupted architect turn resolves as *completed*, so the decision parser reads a truncated plan or review as authoritative.
2. **The next queued turn dies.** Since #7033, the trailing `stopped` lands on the next queued turn and rejects it `TURN_STOPPED`. `turn-driver.js`'s own header notes committee reviews serialise on the architect session — so a queued turn there is the *normal* case, not an edge case.

## The fix, and one judgement call

Added `ARCHITECT_ELIGIBLE_PROVIDERS` and validated against it.

**Named separately rather than aliasing `AUDIT_ELIGIBLE_PROVIDERS`,** even though the members coincide today. The *reasons* differ — turn-terminal semantics here, permission-gated read-only there — and aliasing would let a future edit to one set silently reopen the other's hole. That is exactly the drift #7054 was about.

**I checked the vetted three are actually safe from this specific hazard** rather than assuming set membership implies it:

| Provider | Synthetic `result`? |
|---|---|
| `codex`, `codex-app-server`, `byok` | never |
| `claude-sdk` | only on a stream **stall**, followed by `error` — not `stopped` |
| `claude-cli` | **on intentional stop, before `stopped`** ← the hazard |

## Doc-block caveat closed

`turn-driver.js` said: *"NOT closed here (#7036) … the ARCHITECT role is not provider-restricted, which is what #7036 closes."*

It now records that `claude-cli` cannot enter `TurnDriver` by **any** route, and keeps the alternative on record (a provider-side `interrupted: true` flag making a synthetic result terminal-but-not-successful) for whenever a provider with that emit shape must be admitted. The point is that the failure is now unreachable *by construction* rather than unreachable by hope.

## Verification

Test written first and confirmed red. Mutation-verified: disabling the check reds exactly the new rejection test. A companion test pins that all three vetted providers still pass, so the guard cannot be over-tightened silently either.

299/299 across orchestration / turn / scheduler suites; 5/5 `packages/server/scripts/lint-*.sh`.

Closes #7036