### PR TITLE
fix(server): reject over-cap cron expressions at the scheduled-task boundary

### DIFF
--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -21,6 +21,29 @@ const MAX_TASKS = 500
 const CADENCE_KINDS = new Set(['once', 'interval', 'cron'])
 
 /**
+ * #7051 — the wire cap on `cadence.cron.expression`, mirroring
+ * `ScheduledTaskCadenceCronSchema` in @chroxy/protocol
+ * (schemas/server/scheduler.ts). Kept as a local constant rather than imported
+ * so this module stays dependency-light, and pinned by a test that safeParses
+ * the REAL schema at the boundary — a comment cannot stop the two drifting, a
+ * failing test can.
+ *
+ * Rejected, NOT clamped. `projectTask` truncates the other capped strings
+ * (name, provider, model, ...) because a truncated label is merely ugly.
+ * Truncating a cron expression silently CHANGES THE SCHEDULE — `0,30 * * * *`
+ * cut to `0,3` is a different, still-valid schedule that fires at the wrong
+ * time forever. Refusing at the store boundary is the only safe option, the
+ * same reasoning as the unrepresentable-epoch check below.
+ *
+ * The blast radius is why this matters at all: the dashboard safeParses the
+ * WHOLE `scheduled_tasks` snapshot, so ONE over-cap task makes the panel render
+ * zero tasks (plus "the list below may be out of date") while N tasks are armed
+ * and firing — the store-legal / wire-illegal asymmetry the clamping in
+ * `scheduler-handlers.js` was added to eliminate.
+ */
+const MAX_CRON_EXPRESSION_LENGTH = 256
+
+/**
  * The largest absolute epoch-ms a JS `Date` can represent (±8.64e15, i.e. ±100M
  * days around the epoch — year ±275760). Beyond it `new Date(ms)` is an Invalid
  * Date and `.toISOString()` THROWS `RangeError`.
@@ -156,14 +179,27 @@ function normalizeCadence(cadence) {
       if (typeof cadence.expression !== 'string') {
         throw new ScheduledTaskValidationError('cron cadence requires a string `expression`', 'cadence.expression')
       }
+      // Measure the TRIMMED form, because that is what gets stored and sent
+      // (see the return below) — padding must not count against the cap, and
+      // must not sneak past it either.
+      const expression = cadence.expression.trim()
+      // #7051: length BEFORE parse — a 300-char expression can be perfectly valid
+      // cron, so parseCron will happily accept a value the wire cannot carry.
+      if (expression.length > MAX_CRON_EXPRESSION_LENGTH) {
+        throw new ScheduledTaskValidationError(
+          `cron expression must be <= ${MAX_CRON_EXPRESSION_LENGTH} characters (got ${expression.length}) — ` +
+          'longer expressions cannot be carried on the wire and would make the whole scheduled-tasks snapshot unparseable',
+          'cadence.expression',
+        )
+      }
       // parseCron throws CronParseError on a malformed field — re-surface it as a
       // validation error so callers get one error type off add()/update().
       try {
-        parseCron(cadence.expression)
+        parseCron(expression)
       } catch (err) {
         throw new ScheduledTaskValidationError(`invalid cron expression: ${err.message}`, 'cadence.expression')
       }
-      return { kind: 'cron', expression: cadence.expression.trim() }
+      return { kind: 'cron', expression }
     }
     default:
       // Unreachable — CADENCE_KINDS gates kind above.

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -1,7 +1,9 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { ScheduledTaskCadenceCronSchema } from '@chroxy/protocol'
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync, readdirSync } from 'fs'
 import { tmpdir } from 'os'
+import { parseCron } from '../src/schedule-parser.js'
 import { join } from 'path'
 import {
   ScheduledTaskStore,
@@ -39,6 +41,138 @@ describe('#6862 ScheduledTaskStore', () => {
 
   it('requires a filePath', () => {
     assert.throws(() => new ScheduledTaskStore({}), /requires a filePath/)
+  })
+
+  // #7051 — a cron expression the WIRE cannot carry must never enter the
+  // registry. ScheduledTaskCadenceCronSchema caps `expression` at 256; the store
+  // had no cap at all, so a longer-but-valid cron was store-legal and
+  // wire-ILLEGAL. Blast radius is the whole panel, not one row: the dashboard
+  // safeParses the entire `scheduled_tasks` snapshot, so ONE such task makes it
+  // render zero tasks (plus "may be out of date") while N are armed and firing.
+  //
+  // REJECT rather than clamp, unlike the string fields projectTask truncates:
+  // truncating a cron silently CHANGES THE SCHEDULE, which is worse than
+  // refusing it.
+  describe('#7051 cron expression wire cap', () => {
+    // Fully enumerated minute/hour/day-of-month lists — 319 chars, and every
+    // field is legal, so LENGTH is the only thing that can reject it. The
+    // self-check below pins that: a fixture that quietly fell under the cap
+    // would make the rejection tests fail for an unrelated reason.
+    const LONG_VALID_CRON = [
+      Array.from({ length: 60 }, (_, i) => i).join(','),
+      Array.from({ length: 24 }, (_, i) => i).join(','),
+      Array.from({ length: 31 }, (_, i) => i + 1).join(','),
+      '*',
+      '*',
+    ].join(' ')
+
+    it('the fixture is a VALID cron that is merely too long (length is the only defect)', () => {
+      assert.ok(LONG_VALID_CRON.length > 256, `fixture must exceed the cap, got ${LONG_VALID_CRON.length}`)
+      assert.doesNotThrow(() => parseCron(LONG_VALID_CRON), 'fixture must parse — otherwise the test proves nothing about the cap')
+    })
+
+    it('add() rejects a cron expression longer than the wire cap', () => {
+      const store = newStore(() => 1000)
+      assert.throws(
+        () => store.add({ prompt: 'x', cadence: { kind: 'cron', expression: LONG_VALID_CRON } }),
+        (err) => err instanceof ScheduledTaskValidationError && err.field === 'cadence.expression',
+        'a store-legal / wire-illegal cron must be refused at the boundary',
+      )
+    })
+
+    it('accepts a cron expression exactly AT the cap', () => {
+      const store = newStore(() => 1000)
+      // '*/2 * * * *' padded with trailing spaces trims back under the cap, so
+      // build an exactly-256 expression instead of relying on trimming.
+      const atCap = [Array.from({ length: 60 }, (_, i) => i).join(','), '*', '*', '*', '*'].join(' ')
+      assert.ok(atCap.length <= 256 && atCap.length > 160, `at-cap fixture should sit just under the cap, got ${atCap.length}`)
+      assert.doesNotThrow(() => store.add({ prompt: 'x', cadence: { kind: 'cron', expression: atCap } }))
+    })
+
+    // The reachable path today: ~/.chroxy/scheduled-tasks.json edited by hand,
+    // or a non-WS writer. _normalizeStoredTask must refuse it too, or the
+    // snapshot breaks for every client despite add() being guarded.
+    //
+    // These two cases share one fixture writer and differ ONLY in the cron, so
+    // the control below is what gives the drop case its meaning. The first
+    // version of this test wrote `{ v: 1 }` instead of `{ version: 1 }`; the
+    // store's version gate then ignored the whole file, `list()` was empty for
+    // a reason that had nothing to do with the cap, and the test passed with
+    // the cap guard deleted. The control fails loudly on that mistake.
+    const writeRegistryWithCron = (expression) => {
+      writeFileSync(filePath, JSON.stringify({
+        version: 1,
+        tasks: [{ id: 'a', prompt: 'x', cadence: { kind: 'cron', expression }, createdAt: 1, updatedAt: 1 }],
+      }))
+      // .load() is explicit — the constructor does NOT read the file.
+      return newStore(() => 1000).load()
+    }
+
+    // Drift guard. The store's cap is a HAND-COPIED constant; the wire schema is
+    // the real authority. This asserts the two boundaries coincide by comparing
+    // behaviour at exactly 256 and exactly 257 chars, so raising/lowering
+    // ScheduledTaskCadenceCronSchema without touching MAX_CRON_EXPRESSION_LENGTH
+    // (or vice versa) fails here rather than silently reopening the bug.
+    const cronOfExactLength = (target) => {
+      // '<minute-list> * * * *' — the tail is 8 chars, so the list carries the
+      // rest. Mixing 1- and 2-digit entries hits any length exactly.
+      const want = target - 8
+      for (let k = 1; k < 400; k++) {
+        for (let j = 0; j <= k; j++) {
+          if (3 * k - j - 1 === want) {
+            return [...Array(k)].map((_, i) => (i < j ? '1' : '59')).join(',') + ' * * * *'
+          }
+        }
+      }
+      throw new Error(`cannot build a cron of length ${target}`)
+    }
+
+    it('the store cap and the wire schema agree at the boundary (drift guard)', () => {
+      const store = newStore(() => 1000)
+      for (const len of [256, 257]) {
+        const expression = cronOfExactLength(len)
+        assert.equal(expression.length, len, 'builder must hit the length exactly')
+        assert.doesNotThrow(() => parseCron(expression), `len ${len} must be a valid cron`)
+
+        const wireOk = ScheduledTaskCadenceCronSchema.safeParse({ kind: 'cron', expression }).success
+        let storeOk = true
+        try {
+          store.add({ prompt: 'x', cadence: { kind: 'cron', expression } })
+        } catch {
+          storeOk = false
+        }
+        assert.equal(
+          storeOk,
+          wireOk,
+          `at ${len} chars the store (${storeOk ? 'accepts' : 'rejects'}) and the wire schema ` +
+          `(${wireOk ? 'accepts' : 'rejects'}) disagree — MAX_CRON_EXPRESSION_LENGTH has drifted ` +
+          'from ScheduledTaskCadenceCronSchema',
+        )
+      }
+    })
+
+    it('CONTROL: the registry fixture loads when the cron is short (so the drop below means something)', () => {
+      assert.equal(writeRegistryWithCron('*/5 * * * *').list().length, 1)
+    })
+
+    it('padding is not counted against the cap, and cannot sneak past it', () => {
+      const store = newStore(() => 1000)
+      // Whitespace is stripped before storing, so an at-cap expression stays
+      // legal however it is padded...
+      const atCap = cronOfExactLength(256)
+      const t = store.add({ prompt: 'x', cadence: { kind: 'cron', expression: `   ${atCap}   ` } })
+      assert.equal(t.cadence.expression, atCap, 'the stored expression must be the trimmed one')
+      // ...and padding an over-cap expression does not make it legal either.
+      assert.throws(
+        () => store.add({ prompt: 'x', cadence: { kind: 'cron', expression: `  ${cronOfExactLength(257)}  ` } }),
+        (err) => err instanceof ScheduledTaskValidationError && err.field === 'cadence.expression',
+      )
+    })
+
+    it('a hand-edited registry file with an over-cap cron is rejected on load, not served', () => {
+      const store = writeRegistryWithCron(LONG_VALID_CRON)
+      assert.deepEqual(store.list(), [], 'an unrepresentable task must be dropped on load rather than served to clients')
+    })
   })
 
   // #6871 review (C3) — an epoch outside the representable Date range is finite,

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -66,6 +66,20 @@ describe('#6862 ScheduledTaskStore', () => {
       '*',
     ].join(' ')
 
+    const cronOfExactLength = (target) => {
+      // '<minute-list> * * * *' — the tail is 8 chars, so the list carries the
+      // rest. Mixing 1- and 2-digit entries hits any length exactly.
+      const want = target - 8
+      for (let k = 1; k < 400; k++) {
+        for (let j = 0; j <= k; j++) {
+          if (3 * k - j - 1 === want) {
+            return [...Array(k)].map((_, i) => (i < j ? '1' : '59')).join(',') + ' * * * *'
+          }
+        }
+      }
+      throw new Error(`cannot build a cron of length ${target}`)
+    }
+
     it('the fixture is a VALID cron that is merely too long (length is the only defect)', () => {
       assert.ok(LONG_VALID_CRON.length > 256, `fixture must exceed the cap, got ${LONG_VALID_CRON.length}`)
       assert.doesNotThrow(() => parseCron(LONG_VALID_CRON), 'fixture must parse — otherwise the test proves nothing about the cap')
@@ -80,12 +94,12 @@ describe('#6862 ScheduledTaskStore', () => {
       )
     })
 
-    it('accepts a cron expression exactly AT the cap', () => {
+    it('accepts a cron expression of exactly the cap length (the bound is inclusive)', () => {
       const store = newStore(() => 1000)
-      // '*/2 * * * *' padded with trailing spaces trims back under the cap, so
-      // build an exactly-256 expression instead of relying on trimming.
-      const atCap = [Array.from({ length: 60 }, (_, i) => i).join(','), '*', '*', '*', '*'].join(' ')
-      assert.ok(atCap.length <= 256 && atCap.length > 160, `at-cap fixture should sit just under the cap, got ${atCap.length}`)
+      const atCap = cronOfExactLength(256)
+      // Assert the EXACT length: a fixture that drifted shorter would still pass
+      // the add() below while no longer testing the boundary at all.
+      assert.equal(atCap.length, 256)
       assert.doesNotThrow(() => store.add({ prompt: 'x', cadence: { kind: 'cron', expression: atCap } }))
     })
 
@@ -113,20 +127,6 @@ describe('#6862 ScheduledTaskStore', () => {
     // behaviour at exactly 256 and exactly 257 chars, so raising/lowering
     // ScheduledTaskCadenceCronSchema without touching MAX_CRON_EXPRESSION_LENGTH
     // (or vice versa) fails here rather than silently reopening the bug.
-    const cronOfExactLength = (target) => {
-      // '<minute-list> * * * *' — the tail is 8 chars, so the list carries the
-      // rest. Mixing 1- and 2-digit entries hits any length exactly.
-      const want = target - 8
-      for (let k = 1; k < 400; k++) {
-        for (let j = 0; j <= k; j++) {
-          if (3 * k - j - 1 === want) {
-            return [...Array(k)].map((_, i) => (i < j ? '1' : '59')).join(',') + ' * * * *'
-          }
-        }
-      }
-      throw new Error(`cannot build a cron of length ${target}`)
-    }
-
     it('the store cap and the wire schema agree at the boundary (drift guard)', () => {
       const store = newStore(() => 1000)
       for (const len of [256, 257]) {


### PR DESCRIPTION
Closes #7051

## Problem

`cadence.cron.expression` is capped at 256 by the wire schema
(`ScheduledTaskCadenceCronSchema`, `packages/protocol/src/schemas/server/scheduler.ts:79`)
but the store enforced no bound at all. A longer-but-still-valid cron was
**store-legal and wire-illegal**.

That asymmetry is not contained to the offending task: the dashboard
`safeParse`s the entire `scheduled_tasks` snapshot, so **one** over-cap task
makes the panel render **zero** tasks while N tasks are armed and firing —
a silent, whole-panel failure.

## Approach: reject, don't clamp

The other capped strings (`name`, `provider`, `model`) are truncated in
`projectTask` because a shortened label is merely cosmetic. A cron is not:
truncating `0,30 * * * *` to `0,3` yields a *different, still-valid* schedule
that fires at the wrong time indefinitely. Refusing at the boundary is the
only safe option — same reasoning as the existing unrepresentable-epoch check.

## Change

- `MAX_CRON_EXPRESSION_LENGTH = 256` in `scheduled-task-store.js`.
- Checked in `normalizeCadence`, so it covers `add()`, `update()` **and** the
  load path — a hand-edited `~/.chroxy/scheduled-tasks.json` is dropped on load
  rather than served to every client.
- Runs **before** `parseCron` (a 300-char expression parses fine, so the parser
  never rejects it) and measures the **trimmed** form, which is what actually
  gets stored and sent.

## Verification

228/228 across all 8 scheduler suites; all 5 server lints pass.

Each guard was mutation-verified **individually**:

| Mutation | Expected red | Result |
|---|---|---|
| cap check disabled | `add()` reject + load-drop | both red |
| cap drifted to 512 | those two + drift guard | all three red |

Two things worth calling out in review, because both are cases where a test
initially passed while proving nothing:

- The over-cap fixture is asserted to be **valid cron** and **>256 chars**, so
  the rejection tests cannot pass because the fixture is malformed or short.
- The load-path test ships with an explicit **CONTROL** that the same fixture
  loads with a short cron. Without it the assertion was vacuous — the first
  version wrote `{ v: 1 }` instead of `{ version: 1 }`, so the store's version
  gate ignored the whole file and `list()` was empty for a reason unrelated to
  the cap. It passed with the guard deleted.
- A **drift guard** compares store accept/reject against `safeParse` of the real
  `ScheduledTaskCadenceCronSchema` at exactly 256 and 257 chars, so changing
  either cap without the other fails here instead of quietly reopening this.