### PR TITLE
fix(server,security): make the provider API-key delete durable

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -781,13 +781,28 @@ export function setStoredCredential(key, rawValue) {
  * be performed would leave the credential on disk while the caller believes it
  * is gone. Callers surface this as a clear/delete failure.
  *
- * Durability: this path is NOT durable-capable yet — see #7062. Its sibling
- * `deleteStoredField` takes `{ durable }`; do not assume parity.
+ * #7062 — `durable` opts this path into the same guarantee `deleteStoredField`
+ * got in #7056, and for the same reason: an operator deletes a provider API key
+ * precisely because they believe it leaked, so a delete that is acked but still
+ * sitting in the OS writeback window can restore the leaked key on the next
+ * start after a power loss.
+ *
+ * The two limbs need different fsyncs:
+ *   - REWRITE (siblings survive) — the ordinary atomic temp-file + rename, so it
+ *     delegates to `writeStoreAtomically({ durable })` unchanged.
+ *   - UNLINK (this was the last key) — there is no new file to fsync. The removal
+ *     lives entirely in the containing DIRECTORY's entry, so only that directory
+ *     is fsynced, and only AFTER the unlink. A failed fsync here is NOT a failed
+ *     delete: the key is already gone from the live filesystem, so it is reported
+ *     as `durabilityUnconfirmed` rather than thrown (throwing would send the
+ *     operator to re-delete a key that is already deleted).
  *
  * @param {string} key
+ * @param {{ durable?: boolean }} [opts]
+ * @returns {{ durabilityUnconfirmed: string | null }}
  * @throws {Error} when the credentials file exists but cannot be read
  */
-export function deleteStoredCredential(key) {
+export function deleteStoredCredential(key, { durable = false } = {}) {
   if (!isKnownCredentialKey(key)) throw new Error(`Unknown credential key: ${key}`)
   const target = credentialsFilePath()
   const { data, fileExists, error } = readStore()
@@ -799,10 +814,16 @@ export function deleteStoredCredential(key) {
   // credential was still on disk. ENOENT keeps `error: null`, so a genuinely
   // absent file still no-ops below.
   if (error) throw new Error(error)
-  if (!fileExists) return
+  // A durable no-op still confirms. The retry after an unconfirmed delete lands
+  // on exactly these two branches (an unlinked file -> !fileExists, a rewritten
+  // one -> the key already absent), and in both the outstanding doubt is the
+  // containing DIRECTORY's entry. Acking for free here would convert
+  // "unconfirmed" into false comfort.
+  if (!fileExists) return _confirmDirDurability(target, durable)
 
   const legacyField = LEGACY_FIELD_BY_KEY[key]
-  if (!(key in data) && !(legacyField && legacyField in data)) return // nothing to remove
+  // nothing to remove
+  if (!(key in data) && !(legacyField && legacyField in data)) return _confirmDirDurability(target, durable)
 
   const next = { ...data }
   delete next[key]
@@ -811,10 +832,10 @@ export function deleteStoredCredential(key) {
   // If the store is now empty, remove the file entirely.
   if (Object.keys(next).length === 0) {
     try { unlinkSync(target) } catch (err) { if (err.code !== 'ENOENT') throw err }
-    return
+    return _confirmDirDurability(target, durable)
   }
 
-  writeStoreAtomically(target, next)
+  return writeStoreAtomically(target, next, { durable })
 }
 
 /**

--- a/packages/server/src/handlers/credential-handlers.js
+++ b/packages/server/src/handlers/credential-handlers.js
@@ -116,18 +116,41 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
 
 function handleByokClearCredentials(ws, client, msg, ctx) {
   if (rejectCredentialWriteIfBound(ws, client, msg, ctx)) return
+  let outcome
   try {
     // Remove only the Anthropic key from the canonical store — siblings (and
     // the encrypted envelope) survive; the file is unlinked only when empty.
-    deleteStoredCredential('ANTHROPIC_API_KEY')
+    //
+    // #7062: durable. An operator clears a BYOK key precisely because they
+    // believe it leaked — a clear that is acked but still in the OS writeback
+    // window can restore the leaked key on the next start after a power loss.
+    outcome = deleteStoredCredential('ANTHROPIC_API_KEY', { durable: true })
   } catch (err) {
     sendError(ws, msg?.requestId, 'CREDENTIALS_CLEAR_FAILED', err?.message || 'clear failed', undefined, ctx)
     return
   }
+  // The reply is the success status: the key IS cleared. Reporting a failure for
+  // a clear that landed would send the operator to re-clear an already-cleared key.
   const status = getAnthropicApiKeyStatus()
   ctx.transport.send(ws, { type: 'byok_credentials_status', requestId: msg?.requestId, ...status })
   if (typeof ctx.transport.broadcast === 'function') {
     ctx.transport.broadcast({ type: 'byok_credentials_status', ...status })
+  }
+  if (outcome?.durabilityUnconfirmed) {
+    // ...but the operator still learns the fsync failed. Deliberately requestId-LESS,
+    // mirroring the webhook clear: the status above is this request's reply, and a
+    // client correlating an error to its in-flight requestId must not read this as
+    // the clear's verdict.
+    sendError(
+      ws,
+      null,
+      'CREDENTIAL_DELETE_DURABILITY_UNCONFIRMED',
+      'The API key is cleared, but the filesystem could not confirm the removal is durable ' +
+      `(${outcome.durabilityUnconfirmed}) — a power loss could restore the cleared key. ` +
+      'Resolve the storage error, then re-check the stored credentials after the next restart.',
+      undefined,
+      ctx,
+    )
   }
 }
 
@@ -201,13 +224,31 @@ function handleDeleteCredential(ws, client, msg, ctx) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`, undefined, ctx)
     return
   }
+  let outcome
   try {
-    deleteStoredCredential(key)
+    // #7062: durable — see handleByokClearCredentials for the reasoning. A
+    // deleted provider key that comes back after a power loss is exactly the
+    // failure the operator was trying to prevent.
+    outcome = deleteStoredCredential(key, { durable: true })
   } catch (err) {
     sendError(ws, msg?.requestId, 'CREDENTIAL_CLEAR_FAILED', err?.message || 'clear failed', undefined, ctx)
     return
   }
+  // The reply is the success status: the key IS deleted.
   _sendCredentialsStatus(ctx, ws, msg?.requestId)
+  if (outcome?.durabilityUnconfirmed) {
+    // requestId-LESS, for the same reason as the clear path above.
+    sendError(
+      ws,
+      null,
+      'CREDENTIAL_DELETE_DURABILITY_UNCONFIRMED',
+      `The ${key} credential is deleted, but the filesystem could not confirm the removal is durable ` +
+      `(${outcome.durabilityUnconfirmed}) — a power loss could restore the deleted key. ` +
+      'Resolve the storage error, then re-check the stored credentials after the next restart.',
+      undefined,
+      ctx,
+    )
+  }
 }
 
 async function handleTestCredential(ws, client, msg, ctx) {

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as credStore from '../src/credential-store.js'
 import { githubWebhookHandlers } from '../src/handlers/github-webhook-handlers.js'
+import { credentialHandlers } from '../src/handlers/credential-handlers.js'
 import { WEBHOOK_SECRET_FIELD } from '../src/github-webhook.js'
 import { nsCtx } from './test-helpers.js'
 
@@ -483,5 +484,118 @@ describe('credential-store durable-write seam (#6964)', () => {
       chmodSync(credDir, 0o700)
     }
     assert.equal(credStore.getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-still-here-0001')
+  })
+
+  // --- #7062: the API-key delete ---------------------------------------------
+  // `deleteStoredCredential` is the sibling of the field clear above and had the
+  // identical non-durable shape: neither limb forced anything to disk. Same
+  // threat model — an operator deletes a provider key precisely because they
+  // believe it leaked, and a delete that is acked but still in the OS writeback
+  // window can bring the key back on the next start after a power loss.
+
+  it('#7062: does NOT fsync on an ordinary (non-durable) credential delete', () => {
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-ordinary-0001')
+    credStore.setStoredCredential('OPENAI_API_KEY', 'sk-keep-me-0001')
+    calls = []
+    credStore.deleteStoredCredential('ANTHROPIC_API_KEY')
+    assert.equal(credStore.getStoredCredential('ANTHROPIC_API_KEY'), null)
+    assert.deepEqual(calls, [], 'a default credential delete must add no fsync to the write path')
+  })
+
+  it('#7062: durable credential delete (siblings survive) fsyncs the temp file BEFORE the rename and the directory AFTER', () => {
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-durable-0001')
+    credStore.setStoredCredential('OPENAI_API_KEY', 'sk-keep-me-0001')
+    calls = []
+
+    credStore.deleteStoredCredential('ANTHROPIC_API_KEY', { durable: true })
+
+    assert.equal(credStore.getStoredCredential('ANTHROPIC_API_KEY'), null, 'the key is gone')
+    assert.equal(credStore.getStoredCredential('OPENAI_API_KEY'), 'sk-keep-me-0001', 'siblings survive')
+
+    assert.ok(calls.length >= 1, 'durable delete must fsync the temp file')
+    const [fileCall] = calls
+    assert.equal(fileCall.isDir, false, 'first fsync is the temp FILE')
+    assert.equal(fileCall.targetExists, true, 'the live file still exists pre-rename on a rewrite delete')
+
+    if (IS_WINDOWS) {
+      assert.equal(calls.length, 1, 'Windows has no directory fsync')
+      return
+    }
+    assert.equal(calls.length, 2, 'POSIX durable rewrite-delete = temp-file fsync + directory fsync')
+    assert.equal(calls[1].isDir, true, 'second fsync is the containing DIRECTORY')
+    assert.equal(calls[1].target, credDir)
+  })
+
+  it('#7062: durable delete of the LAST credential unlinks the file and fsyncs the directory AFTER the unlink', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-last-key-0001')
+    calls = []
+
+    credStore.deleteStoredCredential('ANTHROPIC_API_KEY', { durable: true })
+
+    assert.equal(existsSync(credFile), false, 'the file is removed when it would be left empty')
+    assert.equal(calls.length, 1, 'an unlink has no temp file — only the containing directory is fsynced')
+    assert.equal(calls[0].isDir, true, 'the unlink limb must fsync the DIRECTORY, not a file')
+    assert.equal(calls[0].target, credDir)
+    assert.equal(
+      calls[0].targetExists, false,
+      'the directory fsync must happen AFTER the unlink — otherwise it proves nothing about the removal',
+    )
+  })
+
+  it('#7062: a directory-fsync failure on the credential UNLINK limb does NOT throw — the key is already gone', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-last-key-0001')
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    let outcome
+    assert.doesNotThrow(() => {
+      outcome = credStore.deleteStoredCredential('ANTHROPIC_API_KEY', { durable: true })
+    }, 'the unlink already removed the key — reporting a failed delete would be factually wrong')
+    credStore._setCredentialDurabilityForTests(null)
+
+    assert.equal(existsSync(credFile), false, 'the key IS gone from the live filesystem')
+    assert.equal(
+      typeof outcome?.durabilityUnconfirmed, 'string',
+      'the delete must report unconfirmed durability rather than silently acking it',
+    )
+    assert.match(outcome.durabilityUnconfirmed, /EIO|simulated directory fsync/)
+  })
+
+  it('#7062: a durable credential delete of an ALREADY-absent key still confirms the directory', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredCredential('OPENAI_API_KEY', 'sk-sibling-0001')
+    calls = []
+    // The retry after an unconfirmed delete lands exactly here: the key is
+    // already gone, and the outstanding doubt is the directory entry.
+    const outcome = credStore.deleteStoredCredential('ANTHROPIC_API_KEY', { durable: true })
+    assert.equal(outcome?.durabilityUnconfirmed, null)
+    assert.equal(calls.length, 1, 'the already-absent durable limb must fsync the directory too')
+    assert.equal(calls[0].isDir, true)
+    assert.equal(calls[0].target, credDir)
+  })
+
+  it('#7062: the delete_credential handler opts into durability and surfaces an unconfirmed delete', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-to-be-deleted-01')
+    const ws = makeWs()
+    const ctx = makeCtx()
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    credentialHandlers.delete_credential(ws, {}, { requestId: 'req-del-1', key: 'ANTHROPIC_API_KEY' }, ctx)
+    credStore._setCredentialDurabilityForTests(null)
+
+    assert.ok(calls.some((c) => c.isDir), 'the delete path must have opted into the durable write')
+    assert.equal(credStore.getStoredCredential('ANTHROPIC_API_KEY'), null, 'the key is deleted')
+
+    const replies = allReplies(ws, ctx)
+    const unconfirmed = replies.find((r) => r?.code === 'CREDENTIAL_DELETE_DURABILITY_UNCONFIRMED')
+    assert.ok(unconfirmed, `expected a durability-unconfirmed error frame, got ${JSON.stringify(replies.map((r) => r?.type || r?.code))}`)
+    assert.equal(
+      unconfirmed.requestId ?? null, null,
+      'the durability warning must be requestId-LESS so a client cannot read it as the delete\'s verdict',
+    )
   })
 })

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -598,4 +598,46 @@ describe('credential-store durable-write seam (#6964)', () => {
       'the durability warning must be requestId-LESS so a client cannot read it as the delete\'s verdict',
     )
   })
+
+  // --- review follow-ups on #7062 --------------------------------------------
+  // Both added because the mutation that removes the guard left the suite green:
+  // an unpinned opt-in is how #7062 happened in the first place (the durable fix
+  // landed on one sibling and skipped the other), so each opt-in gets its own test.
+
+  it('#7062: the BYOK CLEAR handler also opts into durability and surfaces an unconfirmed clear', () => {
+    if (IS_WINDOWS) return
+    credStore.setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-byok-clear-0001')
+    const ws = makeWs()
+    const ctx = makeCtx()
+    calls = []
+    credStore._setCredentialDurabilityForTests(throwOnDirFsync(calls))
+
+    credentialHandlers.byok_clear_credentials(ws, {}, { requestId: 'req-byok-clear-1' }, ctx)
+    credStore._setCredentialDurabilityForTests(null)
+
+    assert.ok(calls.some((c) => c.isDir), 'the BYOK clear path must have opted into the durable write')
+    assert.equal(credStore.getStoredCredential('ANTHROPIC_API_KEY'), null, 'the key is cleared')
+
+    const replies = allReplies(ws, ctx)
+    const unconfirmed = replies.find((r) => r?.code === 'CREDENTIAL_DELETE_DURABILITY_UNCONFIRMED')
+    assert.ok(unconfirmed, `expected a durability-unconfirmed error frame, got ${JSON.stringify(replies.map((r) => r?.type || r?.code))}`)
+    assert.equal(
+      unconfirmed.requestId ?? null, null,
+      'the durability warning must be requestId-LESS so a client cannot read it as the clear\'s verdict',
+    )
+  })
+
+  it('#7062: a durable credential delete with NO store file at all still confirms the directory', () => {
+    if (IS_WINDOWS) return
+    // The !fileExists limb. A retry after an unconfirmed delete that unlinked the
+    // last key lands exactly here, and the outstanding doubt is still the
+    // directory entry — acking for free would turn "unconfirmed" into false comfort.
+    assert.equal(existsSync(credFile), false, 'precondition: no credentials file')
+    calls = []
+    const outcome = credStore.deleteStoredCredential('ANTHROPIC_API_KEY', { durable: true })
+    assert.equal(outcome?.durabilityUnconfirmed, null)
+    assert.equal(calls.length, 1, 'the !fileExists durable limb must fsync the directory too')
+    assert.equal(calls[0].isDir, true)
+    assert.equal(calls[0].target, credDir)
+  })
 })


### PR DESCRIPTION
Closes #7062

## Problem

`deleteStoredCredential` — the path that removes a stored provider API key —
was the last non-durable removal in the credential store. Neither limb forced
anything to disk:

```js
if (Object.keys(next).length === 0) {
  try { unlinkSync(target) } catch (err) { if (err.code !== 'ENOENT') throw err }
  return                      // <- no directory fsync
}
writeStoreAtomically(target, next)   // <- no { durable }
```

An operator deletes an API key *because they believe it leaked*, gets a
success, and a power loss inside the OS writeback window can bring the key
back on the next daemon start.

Identical to #7056 (the shared webhook secret). This is the same fix, made
cheap by #7054 having collapsed the durable-write recipe onto one
implementation — so this is an opt-in, not a third hand-rolled fsync dance.

## Change

- **REWRITE limb** (siblings survive) → `writeStoreAtomically(target, next, { durable })`.
- **UNLINK limb** (last key) → no new file exists to fsync; an unlink's durability
  lives in the containing **directory's** entry, so the directory is fsynced,
  **after** the unlink.
- A directory-fsync failure on the unlink limb reports `durabilityUnconfirmed`
  instead of throwing — the key is *already gone*, and throwing would send the
  operator to re-delete an already-deleted key.
- The two durable **no-op** branches (file absent / key already absent) still
  confirm the directory. That is what makes the retry after an unconfirmed
  delete meaningful rather than a free ack.

## Not a dead parameter

#7062 explicitly asked that a real caller opt in, so both operator-facing paths do:

| Handler | Path |
|---|---|
| `delete_credential` | dashboard → delete a provider credential |
| `byok_clear_credentials` | dashboard → clear the BYOK Anthropic key |

Each surfaces a **requestId-LESS** `CREDENTIAL_DELETE_DURABILITY_UNCONFIRMED`
frame, mirroring the webhook rotate/clear precedent: the success status is
*this request's* reply, and a client correlating an error to its in-flight
requestId must not read the durability warning as the delete's verdict.

## Verification

868 tests across `credential*`, `byok*`, `github-webhook*` — 866 pass, 0 fail.
All 5 custom server lints pass.

Six new tests, and **each limb was mutation-verified on its own** (a grouped
mutation would only prove the group):

| Mutation (applied alone) | Tests reddened |
|---|---|
| unlink limb loses its directory fsync | 3 — incl. the ordering assertion |
| rewrite limb loses `{ durable }` | 1 — siblings-survive |
| already-absent limb stops confirming | 1 — its own |
| `delete_credential` stops opting in | 1 — the handler test |
| *(restored)* | 6/6 green |

The ordering test asserts `targetExists === false` at fsync time, proving the
directory fsync happens **after** the unlink — not merely that a hook fired.