### PR TITLE
fix(server): stop erasing scheduled tasks the loader could not read

### DIFF
--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -272,6 +272,11 @@ export class ScheduledTaskStore {
     this._now = typeof now === 'function' ? now : Date.now
     // id -> normalized task record
     this._tasks = new Map()
+    // #7050 — raw entries the loader REFUSED, kept verbatim so `_persist()` cannot
+    // erase them. Shape: `{ raw, id, reason }`. These are never served as live
+    // tasks; they exist so an operator's unreadable task survives the next
+    // unrelated mutation instead of being silently deleted from disk.
+    this._unreadable = []
     this._loaded = false
   }
 
@@ -319,16 +324,23 @@ export class ScheduledTaskStore {
     }
     const tasks = parsed.tasks
     if (!Array.isArray(tasks)) return this
-    for (const entry of tasks) {
+    this._unreadable = []
+    for (const [i, entry] of tasks.entries()) {
       if (this._tasks.size >= MAX_TASKS) {
-        this._log.warn(`Scheduled-tasks file exceeds cap (${MAX_TASKS}) — dropping the rest`)
+        // #7050: the remainder is never even examined, so it would be erased on
+        // the next write. Preserve it verbatim — these are valid tasks losing a
+        // race with a cap, which is the least defensible thing to delete.
+        const rest = tasks.slice(i)
+        this._log.warn(`Scheduled-tasks file exceeds cap (${MAX_TASKS}) — ${rest.length} entr(ies) not loaded (preserved on disk)`)
+        for (const skipped of rest) this._preserveUnreadable(skipped, `store cap (${MAX_TASKS}) reached`)
         break
       }
       let record
       try {
         record = this._normalizeStoredTask(entry)
       } catch (err) {
-        this._log.warn(`Dropping malformed scheduled task on load: ${err.message}`)
+        this._log.warn(`Refusing malformed scheduled task on load (preserved on disk): ${err.message}`)
+        this._preserveUnreadable(entry, err.message)
         continue
       }
       if (this._tasks.has(record.id)) {
@@ -439,10 +451,44 @@ export class ScheduledTaskStore {
    * @returns {boolean}
    */
   remove(id) {
-    if (!this._tasks.has(id)) return false
-    this._tasks.delete(id)
+    if (this._tasks.has(id)) {
+      this._tasks.delete(id)
+      this._persist()
+      return true
+    }
+    // #7050: a preserved (unreadable) entry must stay deletable — otherwise
+    // refusing to erase it would trade silent data loss for an undeletable
+    // record the operator has no way to clear.
+    const before = this._unreadable.length
+    this._unreadable = this._unreadable.filter((u) => u.id !== id)
+    if (this._unreadable.length === before) return false
     this._persist()
     return true
+  }
+
+  /**
+   * #7050 — how many stored entries the loader could not read. Non-zero means
+   * `list()` is SHORTER than what is on disk, which the panel should say out
+   * loud rather than rendering a silently short list.
+   * @returns {number}
+   */
+  unreadableCount() {
+    return this._unreadable.length
+  }
+
+  /**
+   * #7050 — the refused entries' ids and reasons (never their raw contents, which
+   * may be any shape). `id` is null when the entry had no usable string id.
+   * @returns {{ id: string|null, reason: string }[]}
+   */
+  listUnreadable() {
+    return this._unreadable.map(({ id, reason }) => ({ id, reason }))
+  }
+
+  /** @private — keep a refused raw entry so `_persist()` cannot erase it (#7050). */
+  _preserveUnreadable(raw, reason) {
+    const id = typeof raw?.id === 'string' && raw.id.trim().length > 0 ? raw.id.trim() : null
+    this._unreadable.push({ raw, id, reason: String(reason) })
   }
 
   /** @private — require a non-empty string prompt. */
@@ -500,7 +546,14 @@ export class ScheduledTaskStore {
     try {
       const dir = dirname(this._filePath)
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-      const state = { version: STORE_VERSION, tasks: Array.from(this._tasks.values()) }
+      // #7050: the preserved raw entries ride along so an unrelated mutation
+      // cannot erase a task the loader merely could not READ. They are appended
+      // (never re-serialized from a normalized record) so nothing is lost in a
+      // round trip through a shape this version does not understand.
+      const state = {
+        version: STORE_VERSION,
+        tasks: [...this._tasks.values(), ...this._unreadable.map((u) => u.raw)],
+      }
       writeFileRestricted(this._filePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
     } catch (err) {
       // Best-effort: a failed persist leaves the in-memory set intact for this

--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -299,6 +299,12 @@ export class ScheduledTaskStore {
     // Reset FIRST — every early return below must leave the store EMPTY, not
     // holding the previous load's (now unbacked) tasks.
     this._tasks.clear()
+    // #7050: reset with `_tasks`, NOT after the early returns below. Every early
+    // return must leave the store EMPTY — a reload that hits ENOENT / bad JSON /
+    // the version gate would otherwise keep the PREVIOUS load's preserved entries
+    // and `_persist()` would write them back into a file that no longer has them,
+    // resurrecting records the operator deleted.
+    this._unreadable = []
     let raw
     try {
       raw = fs.readFileSync(this._filePath, 'utf-8')
@@ -324,14 +330,13 @@ export class ScheduledTaskStore {
     }
     const tasks = parsed.tasks
     if (!Array.isArray(tasks)) return this
-    this._unreadable = []
     for (const [i, entry] of tasks.entries()) {
       if (this._tasks.size >= MAX_TASKS) {
         // #7050: the remainder is never even examined, so it would be erased on
         // the next write. Preserve it verbatim — these are valid tasks losing a
         // race with a cap, which is the least defensible thing to delete.
         const rest = tasks.slice(i)
-        this._log.warn(`Scheduled-tasks file exceeds cap (${MAX_TASKS}) — ${rest.length} entr(ies) not loaded (preserved on disk)`)
+        this._log.warn(`Scheduled-tasks file exceeds cap (${MAX_TASKS}) — ${rest.length} ${rest.length === 1 ? 'entry' : 'entries'} not loaded (preserved on disk)`)
         for (const skipped of rest) this._preserveUnreadable(skipped, `store cap (${MAX_TASKS}) reached`)
         break
       }
@@ -375,7 +380,11 @@ export class ScheduledTaskStore {
         throw new ScheduledTaskValidationError('id must be a non-empty string', 'id')
       }
       id = id.trim()
-      if (this._tasks.has(id)) throw new ScheduledTaskValidationError(`task id ${id} already exists`, 'id')
+      // #7050: preserved (unreadable) ids count as taken. They are on disk, so
+      // reusing one would put two entries with the same id in the file.
+      if (this._tasks.has(id) || this._unreadable.some((u) => u.id === id)) {
+        throw new ScheduledTaskValidationError(`task id ${id} already exists`, 'id')
+      }
     }
 
     const now = this._now()
@@ -459,6 +468,12 @@ export class ScheduledTaskStore {
     // #7050: a preserved (unreadable) entry must stay deletable — otherwise
     // refusing to erase it would trade silent data loss for an undeletable
     // record the operator has no way to clear.
+    //
+    // Guard the id: preserved entries with no usable id carry `id: null`, so a
+    // `remove(null)` (or any non-string) would match and delete ALL of them at
+    // once and report success. `listUnreadable()` publicly emits those null rows,
+    // so this is reachable the moment a caller forwards one back.
+    if (typeof id !== 'string' || id.length === 0) return false
     const before = this._unreadable.length
     this._unreadable = this._unreadable.filter((u) => u.id !== id)
     if (this._unreadable.length === before) return false

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -53,6 +53,91 @@ describe('#6862 ScheduledTaskStore', () => {
   // REJECT rather than clamp, unlike the string fields projectTask truncates:
   // truncating a cron silently CHANGES THE SCHEDULE, which is worse than
   // refusing it.
+  describe('#7050 a load-refused task is preserved, not erased', () => {
+    // load() drops any entry _normalizeStoredTask refuses. _persist() then wrote
+    // only the SURVIVORS, so the next unrelated mutation erased the operator's
+    // named task from disk permanently, with only a daemon-log warn as a trace.
+    const TYPO_EPOCH = 1795000000000000000 // ns-vs-ms typo: past MAX_EPOCH_MS
+
+    const writeMixedRegistry = () => {
+      writeFileSync(filePath, JSON.stringify({
+        version: 1,
+        tasks: [
+          { id: 'good', prompt: 'keep me', cadence: { kind: 'cron', expression: '*/5 * * * *' }, createdAt: 1, updatedAt: 1 },
+          { id: 'typo', prompt: 'operator named task', cadence: { kind: 'once', at: TYPO_EPOCH }, createdAt: 1, updatedAt: 1 },
+        ],
+      }))
+      return newStore(() => 1000).load()
+    }
+
+    const onDiskIds = () => JSON.parse(readFileSync(filePath, 'utf-8')).tasks.map((t) => t.id).sort()
+
+    it('CONTROL: the refused entry really is refused (it is not silently loading)', () => {
+      const store = writeMixedRegistry()
+      assert.deepEqual(store.list().map((t) => t.id), ['good'], 'only the good task loads')
+      assert.deepEqual(onDiskIds(), ['good', 'typo'], 'both are still on disk before any mutation')
+    })
+
+    it('an unrelated mutation does NOT erase the refused entry from disk', () => {
+      const store = writeMixedRegistry()
+      store.add({ prompt: 'unrelated', cadence: { kind: 'cron', expression: '0 9 * * *' } })
+      assert.ok(onDiskIds().includes('typo'), 'the operator\'s unreadable task must survive an unrelated write')
+    })
+
+    it('remove() of a live task also does not erase it', () => {
+      const store = writeMixedRegistry()
+      assert.equal(store.remove('good'), true)
+      assert.deepEqual(onDiskIds(), ['typo'], 'the refused entry is all that is left, and it is still there')
+    })
+
+    it('reports how many stored entries could not be read', () => {
+      const store = writeMixedRegistry()
+      assert.equal(store.unreadableCount(), 1)
+      const [only] = store.listUnreadable()
+      assert.equal(only.id, 'typo', 'the id is surfaced so the panel can name what is missing')
+      assert.match(only.reason, /epoch|representable/i, 'and why')
+    })
+
+    it('the refused entry is NOT served as a live task', () => {
+      const store = writeMixedRegistry()
+      assert.equal(store.get('typo'), null)
+      assert.ok(!store.list().some((t) => t.id === 'typo'))
+    })
+
+    it('round-trips stably: reloading does not duplicate or resurrect it', () => {
+      writeMixedRegistry().add({ prompt: 'x', cadence: { kind: 'cron', expression: '0 9 * * *' } })
+      const reloaded = newStore(() => 1000).load()
+      assert.equal(reloaded.unreadableCount(), 1, 'still exactly one unreadable entry after a round trip')
+      assert.equal(onDiskIds().filter((id) => id === 'typo').length, 1, 'and exactly one copy on disk')
+    })
+
+    it('entries past the store cap are preserved too, not silently dropped and erased', () => {
+      // The over-cap remainder is never even examined by the loader, so before
+      // #7050 it was erased on the next write — valid tasks deleted for losing a
+      // race with a cap.
+      const many = Array.from({ length: 505 }, (_, i) => ({
+        id: `t${i}`, prompt: 'p', cadence: { kind: 'cron', expression: '*/5 * * * *' }, createdAt: 1, updatedAt: 1,
+      }))
+      writeFileSync(filePath, JSON.stringify({ version: 1, tasks: many }))
+      const store = newStore(() => 1000).load()
+
+      assert.equal(store.list().length, 500, 'the cap still bounds what is LOADED')
+      assert.equal(store.unreadableCount(), 5, 'the remainder is preserved rather than dropped')
+
+      store.remove('t0') // any unrelated mutation triggers a persist
+      const onDisk = JSON.parse(readFileSync(filePath, 'utf-8')).tasks.map((t) => t.id)
+      assert.ok(onDisk.includes('t504'), 'an over-cap entry must survive the write')
+      assert.equal(onDisk.length, 504, '505 minus the one actually removed')
+    })
+
+    it('an operator can delete an unreadable entry (it must not be undeletable)', () => {
+      const store = writeMixedRegistry()
+      assert.equal(store.remove('typo'), true, 'remove() must reach preserved entries too')
+      assert.equal(store.unreadableCount(), 0)
+      assert.deepEqual(onDiskIds(), ['good'])
+    })
+  })
+
   describe('#7051 cron expression wire cap', () => {
     // Fully enumerated minute/hour/day-of-month lists — 319 chars, and every
     // field is legal, so LENGTH is the only thing that can reject it. The

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -130,6 +130,53 @@ describe('#6862 ScheduledTaskStore', () => {
       assert.equal(onDisk.length, 504, '505 minus the one actually removed')
     })
 
+    it('a RELOAD that hits an early return clears preserved entries too (they must not leak forward)', () => {
+      // load() clears _tasks FIRST precisely so every early return below leaves
+      // the store empty. The preserved set must follow the same rule: otherwise a
+      // second load() that hits ENOENT / bad JSON / the version gate keeps the
+      // PREVIOUS load's raw entries, and the next add() writes them back into a
+      // file that no longer contains them — resurrecting deleted records.
+      const store = writeMixedRegistry()
+      assert.equal(store.unreadableCount(), 1, 'precondition: one entry preserved')
+
+      rmSync(filePath) // registry goes away (operator wiped it / fresh machine)
+      store.load()     // early return: ENOENT
+
+      assert.equal(store.unreadableCount(), 0, 'an emptied store must not retain the old preserved entries')
+      store.add({ prompt: 'fresh', cadence: { kind: 'cron', expression: '0 9 * * *' } })
+      const onDisk = JSON.parse(readFileSync(filePath, 'utf-8')).tasks.map((t) => t.id)
+      assert.ok(!onDisk.includes('typo'), `a wiped registry must not resurrect 'typo', got ${JSON.stringify(onDisk)}`)
+    })
+
+    it('remove() with a non-string id does not mass-delete the id-less preserved entries', () => {
+      // Entries with no usable id are preserved as `{ id: null }`, and
+      // listUnreadable() emits those rows publicly — so a caller forwarding one
+      // back as remove(null) must not wipe every one of them and report success.
+      writeFileSync(filePath, JSON.stringify({
+        version: 1,
+        tasks: [
+          { prompt: 'no id at all', cadence: { kind: 'cron', expression: '*/5 * * * *' } },
+          { id: 42, prompt: 'numeric id', cadence: { kind: 'cron', expression: '*/5 * * * *' } },
+        ],
+      }))
+      const store = newStore(() => 1000).load()
+      assert.equal(store.unreadableCount(), 2, 'both are unreadable and id-less')
+      assert.equal(store.remove(null), false, 'a null id must not match the null-id rows')
+      assert.equal(store.remove(''), false)
+      assert.equal(store.unreadableCount(), 2, 'nothing was deleted')
+    })
+
+    it('add() refuses an id that a preserved entry already occupies', () => {
+      // The preserved entry is ON DISK, so minting a live task with the same id
+      // would put two entries with that id in the file.
+      const store = writeMixedRegistry()
+      assert.throws(
+        () => store.add({ id: 'typo', prompt: 'collide', cadence: { kind: 'cron', expression: '0 9 * * *' } }),
+        (err) => err instanceof ScheduledTaskValidationError && err.field === 'id',
+        'a preserved id is taken, not free',
+      )
+    })
+
     it('an operator can delete an unreadable entry (it must not be undeletable)', () => {
       const store = writeMixedRegistry()
       assert.equal(store.remove('typo'), true, 'remove() must reach preserved entries too')


### PR DESCRIPTION
Closes #7050

## Problem

`load()` drops any entry `_normalizeStoredTask` refuses, with only a daemon-log
`warn`. `_persist()` then serialized `this._tasks` — the **survivors** — so the
next unrelated mutation erased the refused record from disk *permanently*.

Reproduced in the issue with a two-task registry:

```
WARN: Dropping malformed scheduled task on load: once cadence `at` must be a
      representable epoch-ms instant; got 1795000000000000000
loaded ids = [ 'good' ]
on-disk still has typo?                              true
AFTER one unrelated mutation, on-disk has typo?      false
```

The operator's named task is gone, and the only trace is a daemon log line.
`MAX_EPOCH_MS` (new in #7023) widened what falls into this path.

## Change

The loader keeps refused entries **verbatim** and `_persist()` appends them back.
They are never served as live tasks — `list()` / `get()` are unchanged.

Two refusal paths are preserved:

1. an entry `_normalizeStoredTask` rejects, and
2. **the remainder past `MAX_TASKS`**, which the loader never even examines.
   Those are *valid* tasks losing a race with a cap — the least defensible thing
   to delete silently. (Not called out in the issue; found while writing the fix.)

A **duplicate id is deliberately not preserved**: that id is already represented
by the entry that won, so a shadow copy would grow the file without giving the
operator anything to act on.

`remove()` reaches preserved entries, so refusing to erase them doesn't trade
silent data loss for an **undeletable** record.

`unreadableCount()` / `listUnreadable()` expose the count and reasons.

## Scope — the snapshot half is deliberately not here

The issue also asks that the count be surfaced on the `scheduled_tasks` snapshot
so the panel can say "N stored tasks could not be read". That crosses the
protocol and dashboard coverage guards and deserves its own PR; the store-side
accessors this PR adds are what it will consume. **The data-loss half — the part
that destroys an operator's task — is fixed here.**

## Verification

236/236 scheduler tests (228 before + 8 new), all 5 custom server lints, eslint clean.

Each limb mutation-verified **individually**:

| Mutation (applied alone) | Tests reddened |
|---|---|
| `_persist()` writes survivors only (the original bug) | 4 |
| malformed entry not preserved | 5 |
| over-cap remainder not preserved | 1 — its own |
| `remove()` reverts to live-tasks-only | 1 — its own |
| *(restored)* | 8/8 green |

The suite includes a **CONTROL** asserting the refused entry really is refused
and really is on disk before any mutation — otherwise "it survived" could pass
because nothing ever happened.