### PR TITLE
fix(server): bound the scheduled-task id to its wire cap

### DIFF
--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -57,11 +57,25 @@ const MAX_CRON_EXPRESSION_LENGTH = 256
  * Generated ids are uuids (36 chars), and no writer supplies one: the WS path
  * cannot (`ScheduledTaskInputSchema` has no `id` field and `z.object` strips
  * unknown keys, so `ws-server.js` dispatches a payload without it) and the CLI
- * omits it. The reachable path is therefore a hand-edited registry file — and
- * since #7050 a refused entry is PRESERVED on disk rather than erased, so
- * refusing here is what lets the operator correct it.
+ * omits it. The reachable path is therefore a hand-edited registry file.
+ *
+ * Since #7050 a refused entry is PRESERVED on disk rather than erased, so
+ * refusing here does not destroy the operator's task. It does NOT yet mean they
+ * can repair it in-product: an over-cap id is unaddressable at the wire
+ * (`ScheduledTaskActionSchema.taskId` is capped too) and absent from
+ * `store.list()`, so today the only remediation is hand-editing the same file.
+ * Closing that loop is #7079.
  */
 const MAX_WIRE_ID_LENGTH = 256
+
+// Audited alongside #7074: every OTHER capped field on `ScheduledTaskSchema` is
+// already clamped before send by `projectTask`/`projectTarget`/`projectLastRun`
+// in handlers/scheduler-handlers.js (name, target.*, lastRun.*, providerRefusal,
+// effectiveProvider, effectivePermissionMode), and `prompt` is `z.string()` with
+// NO wire cap, so it is symmetric and has nothing to violate. If a cap is ever
+// added to `prompt` on the wire, it needs a bound HERE too — otherwise it
+// becomes the next #7051.
+
 
 /**
  * Throw unless `id` fits the wire cap. Shared by `add()` and

--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -44,6 +44,42 @@ const CADENCE_KINDS = new Set(['once', 'interval', 'cron'])
 const MAX_CRON_EXPRESSION_LENGTH = 256
 
 /**
+ * #7074 — the wire cap on a task `id`, mirroring `ScheduledTaskSchema.id`
+ * (max 256) in @chroxy/protocol. Pinned by a test that safeParses the REAL
+ * schema at the boundary, so the two cannot drift silently.
+ *
+ * Rejected, NOT clamped — and unlike the other capped strings the reason is not
+ * cosmetic: `id` is the MUTATION KEY, so a truncated id would make
+ * pause/update/delete address the wrong record, or nothing. `projectTask` in
+ * scheduler-handlers.js deliberately leaves `id` unclamped for exactly this
+ * reason, which leaves refusing at the store boundary as the only safe option.
+ *
+ * Generated ids are uuids (36 chars), and no writer supplies one: the WS path
+ * cannot (`ScheduledTaskInputSchema` has no `id` field and `z.object` strips
+ * unknown keys, so `ws-server.js` dispatches a payload without it) and the CLI
+ * omits it. The reachable path is therefore a hand-edited registry file — and
+ * since #7050 a refused entry is PRESERVED on disk rather than erased, so
+ * refusing here is what lets the operator correct it.
+ */
+const MAX_WIRE_ID_LENGTH = 256
+
+/**
+ * Throw unless `id` fits the wire cap. Shared by `add()` and
+ * `_normalizeStoredTask()` so the client path and the load path cannot diverge
+ * — the split that made #7051 reachable through the file after add() was fixed.
+ * @param {string} id - an already-trimmed, non-empty id
+ */
+function requireIdWithinWireCap(id) {
+  if (id.length > MAX_WIRE_ID_LENGTH) {
+    throw new ScheduledTaskValidationError(
+      `task id must be <= ${MAX_WIRE_ID_LENGTH} characters (got ${id.length}) — ` +
+      'a longer id cannot be carried on the wire and would make the whole scheduled-tasks snapshot unparseable',
+      'id',
+    )
+  }
+}
+
+/**
  * The largest absolute epoch-ms a JS `Date` can represent (±8.64e15, i.e. ±100M
  * days around the epoch — year ±275760). Beyond it `new Date(ms)` is an Invalid
  * Date and `.toISOString()` THROWS `RangeError`.
@@ -380,6 +416,7 @@ export class ScheduledTaskStore {
         throw new ScheduledTaskValidationError('id must be a non-empty string', 'id')
       }
       id = id.trim()
+      requireIdWithinWireCap(id)
       // #7050: preserved (unreadable) ids count as taken. They are on disk, so
       // reusing one would put two entries with the same id in the file.
       if (this._tasks.has(id) || this._unreadable.some((u) => u.id === id)) {
@@ -526,6 +563,7 @@ export class ScheduledTaskStore {
     if (typeof entry.id !== 'string' || entry.id.trim().length === 0) {
       throw new ScheduledTaskValidationError('task id must be a non-empty string', 'id')
     }
+    requireIdWithinWireCap(entry.id.trim())
     const createdAt = Number.isFinite(entry.createdAt) ? entry.createdAt : this._now()
     const updatedAt = Number.isFinite(entry.updatedAt) ? entry.updatedAt : createdAt
     const record = {

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -43,16 +43,6 @@ describe('#6862 ScheduledTaskStore', () => {
     assert.throws(() => new ScheduledTaskStore({}), /requires a filePath/)
   })
 
-  // #7051 — a cron expression the WIRE cannot carry must never enter the
-  // registry. ScheduledTaskCadenceCronSchema caps `expression` at 256; the store
-  // had no cap at all, so a longer-but-valid cron was store-legal and
-  // wire-ILLEGAL. Blast radius is the whole panel, not one row: the dashboard
-  // safeParses the entire `scheduled_tasks` snapshot, so ONE such task makes it
-  // render zero tasks (plus "may be out of date") while N are armed and firing.
-  //
-  // REJECT rather than clamp, unlike the string fields projectTask truncates:
-  // truncating a cron silently CHANGES THE SCHEDULE, which is worse than
-  // refusing it.
   describe('#7074 task id wire cap', () => {
     // Companion to #7051. `ScheduledTaskSchema.id` is max(256) but neither add()
     // nor _normalizeStoredTask bounded it, so an over-cap id loaded clean and then
@@ -102,7 +92,7 @@ describe('#6862 ScheduledTaskStore', () => {
       assert.deepEqual(store.list(), [], 'an unrepresentable task must not reach the wire')
     })
 
-    it('and #7076 preserves it, so the operator can still fix it', () => {
+    it('and #7050 preserves it on disk rather than erasing it', () => {
       const store = writeRegistryWithId(overCapId)
       assert.equal(store.unreadableCount(), 1, 'refusing must not mean erasing')
       store.add({ prompt: 'unrelated', cadence: { kind: 'cron', expression: '0 9 * * *' } })
@@ -123,7 +113,15 @@ describe('#6862 ScheduledTaskStore', () => {
         let storeOk = true
         try {
           newStore(() => 1000).add({ id, prompt: 'x', cadence: { kind: 'cron', expression: '*/5 * * * *' } })
-        } catch { storeOk = false }
+        } catch (err) {
+          // Assert WHICH error: a bare catch would let an unrelated throw count as
+          // "the cap rejected it", so half this comparison would prove nothing.
+          assert.ok(
+            err instanceof ScheduledTaskValidationError && err.field === 'id',
+            `expected an id-cap rejection at ${len} chars, got ${err?.message}`,
+          )
+          storeOk = false
+        }
         assert.equal(storeOk, wireOk, `at ${len} chars the store and ScheduledTaskSchema disagree — the id cap has drifted`)
       }
     })
@@ -261,6 +259,16 @@ describe('#6862 ScheduledTaskStore', () => {
     })
   })
 
+  // #7051 — a cron expression the WIRE cannot carry must never enter the
+  // registry. ScheduledTaskCadenceCronSchema caps `expression` at 256; the store
+  // had no cap at all, so a longer-but-valid cron was store-legal and
+  // wire-ILLEGAL. Blast radius is the whole panel, not one row: the dashboard
+  // safeParses the entire `scheduled_tasks` snapshot, so ONE such task makes it
+  // render zero tasks (plus "may be out of date") while N are armed and firing.
+  //
+  // REJECT rather than clamp, unlike the string fields projectTask truncates:
+  // truncating a cron silently CHANGES THE SCHEDULE, which is worse than
+  // refusing it.
   describe('#7051 cron expression wire cap', () => {
     // Fully enumerated minute/hour/day-of-month lists — 319 chars, and every
     // field is legal, so LENGTH is the only thing that can reject it. The
@@ -346,7 +354,11 @@ describe('#6862 ScheduledTaskStore', () => {
         let storeOk = true
         try {
           store.add({ prompt: 'x', cadence: { kind: 'cron', expression } })
-        } catch {
+        } catch (err) {
+          assert.ok(
+            err instanceof ScheduledTaskValidationError && err.field === 'cadence.expression',
+            `expected a cron-cap rejection at ${len} chars, got ${err?.message}`,
+          )
           storeOk = false
         }
         assert.equal(

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { ScheduledTaskCadenceCronSchema } from '@chroxy/protocol'
+import { ScheduledTaskCadenceCronSchema, ScheduledTaskSchema } from '@chroxy/protocol'
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync, readdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { parseCron } from '../src/schedule-parser.js'
@@ -53,6 +53,82 @@ describe('#6862 ScheduledTaskStore', () => {
   // REJECT rather than clamp, unlike the string fields projectTask truncates:
   // truncating a cron silently CHANGES THE SCHEDULE, which is worse than
   // refusing it.
+  describe('#7074 task id wire cap', () => {
+    // Companion to #7051. `ScheduledTaskSchema.id` is max(256) but neither add()
+    // nor _normalizeStoredTask bounded it, so an over-cap id loaded clean and then
+    // failed the dashboard's safeParse — which yields `snapshot === null`, losing
+    // the task list AND the armed state.
+    //
+    // NOT reachable from a client message: ScheduledTaskInputSchema has no `id`
+    // field and z.object strips unknown keys, so ws-server dispatches a payload
+    // with no id at all. The reachable path is a hand-edited registry.
+    const overCapId = 'a'.repeat(257)
+
+    it('add() rejects an id longer than the wire cap', () => {
+      const store = newStore(() => 1000)
+      assert.throws(
+        () => store.add({ id: overCapId, prompt: 'x', cadence: { kind: 'cron', expression: '*/5 * * * *' } }),
+        (err) => err instanceof ScheduledTaskValidationError && err.field === 'id',
+      )
+    })
+
+    it('accepts an id of exactly the cap length (the bound is inclusive)', () => {
+      const store = newStore(() => 1000)
+      const atCap = 'b'.repeat(256)
+      const t = store.add({ id: atCap, prompt: 'x', cadence: { kind: 'cron', expression: '*/5 * * * *' } })
+      assert.equal(t.id, atCap)
+    })
+
+    it('a generated id is far below the cap, so this can never fire for normal use', () => {
+      const store = newStore(() => 1000)
+      const t = store.add({ prompt: 'x', cadence: { kind: 'cron', expression: '*/5 * * * *' } })
+      assert.ok(t.id.length < 64, `a generated id should be a uuid, got ${t.id.length} chars`)
+    })
+
+    const writeRegistryWithId = (id) => {
+      writeFileSync(filePath, JSON.stringify({
+        version: 1,
+        tasks: [{ id, prompt: 'operator task', cadence: { kind: 'cron', expression: '*/5 * * * *' }, createdAt: 1, updatedAt: 1 }],
+      }))
+      return newStore(() => 1000).load()
+    }
+
+    it('CONTROL: the registry fixture loads with a normal id (so the refusal below means something)', () => {
+      assert.equal(writeRegistryWithId('normal-id').list().length, 1)
+    })
+
+    it('a hand-edited registry with an over-cap id is refused on load, not served', () => {
+      const store = writeRegistryWithId(overCapId)
+      assert.deepEqual(store.list(), [], 'an unrepresentable task must not reach the wire')
+    })
+
+    it('and #7076 preserves it, so the operator can still fix it', () => {
+      const store = writeRegistryWithId(overCapId)
+      assert.equal(store.unreadableCount(), 1, 'refusing must not mean erasing')
+      store.add({ prompt: 'unrelated', cadence: { kind: 'cron', expression: '0 9 * * *' } })
+      const onDisk = JSON.parse(readFileSync(filePath, 'utf-8')).tasks.map((t) => t.id)
+      assert.ok(onDisk.includes(overCapId), 'the over-cap entry survives an unrelated write')
+    })
+
+    it('the store cap and the wire schema agree at the boundary (drift guard)', () => {
+      for (const len of [256, 257]) {
+        const id = 'c'.repeat(len)
+        const wireOk = ScheduledTaskSchema.safeParse({
+          id, name: null, enabled: true, prompt: 'x', target: {},
+          cadence: { kind: 'cron', expression: '*/5 * * * *' },
+          nextRun: null, lastRun: null, createdAt: 1, updatedAt: 1,
+          providerRefusal: null, effectiveProvider: null, effectivePermissionMode: 'default',
+          permissionModeClamped: false, quarantined: false,
+        }).success
+        let storeOk = true
+        try {
+          newStore(() => 1000).add({ id, prompt: 'x', cadence: { kind: 'cron', expression: '*/5 * * * *' } })
+        } catch { storeOk = false }
+        assert.equal(storeOk, wireOk, `at ${len} chars the store and ScheduledTaskSchema disagree — the id cap has drifted`)
+      }
+    })
+  })
+
   describe('#7050 a load-refused task is preserved, not erased', () => {
     // load() drops any entry _normalizeStoredTask refuses. _persist() then wrote
     // only the SURVIVORS, so the next unrelated mutation erased the operator's


### PR DESCRIPTION
Closes #7074

## Problem

`ScheduledTaskSchema.id` is `max(256)` (`packages/protocol/src/schemas/server/scheduler.ts:132`)
but neither `add()` nor `_normalizeStoredTask()` bounded it. An over-cap id was
**store-legal and wire-illegal**.

The dashboard `safeParse`s the *whole* `scheduled_tasks` snapshot, and a failure
yields `snapshot === null` — which `ScheduledTasksSection.tsx:725-734` documents as
losing not just the list but the **armed state**, so the panel cannot say whether
the scheduler is firing.

## Correction to the issue: this is NOT reachable over the wire

The issue (which I filed) claimed it was reachable from a client message with no
hand-editing. **That was wrong**, and I've corrected it on #7074. Verified:

```
ScheduledTaskActionSchema.safeParse({ action:'create',
  task:{ id:'a'.repeat(300), prompt:'x', cadence:{...} }})
-> success: true, parsed task keys: prompt,cadence   # `id` STRIPPED
```

`ScheduledTaskInputSchema` (`client.ts:447`) has no `id` field and `z.object`
strips unknown keys; `ws-server.js:2479` dispatches `parsed.data`. `cli/schedule-cmd.js:357`
omits `id` too, and there's no `--id` flag — ids are always `randomUUID()`.

So the reachable path is a **hand-edited registry**, and the existing `projectTask`
docstring ("Store ids are generated, so an over-cap id means a hand-edited registry")
was correct. Severity is medium, not high. Still worth fixing: the store enforces
its wire contract for `cadence.cron.expression` (#7051) and not for `id`, which is
the same class left inconsistent.

## Change

`MAX_WIRE_ID_LENGTH = 256`, enforced at **both** entry points via one shared
`requireIdWithinWireCap()`. Both, because that exact split is what left #7051
reachable through the file after `add()` was fixed — and the two are mutation-pinned
**independently**, so neither can regress behind the other.

**Reject, not clamp** — and here the reason isn't cosmetic like `name`/`provider`:
`id` is the *mutation key*, so a truncated id would make pause/update/delete address
the wrong record. `projectTask` deliberately leaves `id` unclamped for that reason,
which leaves refusing at the store boundary as the only safe option.

**Composes with #7050:** refusing at load now *preserves* the entry on disk instead
of erasing it, so the operator can correct it. Before #7050 landed, refusing would
have deleted their task. A test asserts that.

## Also audited (no change needed)

While here I checked every capped field in `scheduler.ts` rather than trusting the
earlier "id is the only remaining gap" claim:

| Field | Status |
|---|---|
| `name`, `target.{provider,model,cwd,permissionMode}` | clamped in `projectTarget`/`projectTask` |
| `lastRun.{status,sessionId,error}` | clamped in `projectLastRun` |
| `providerRefusal`, `effectiveProvider`, `effectivePermissionMode` | clamped |
| `prompt` | `z.string()` — **no wire cap**, so symmetric, nothing to violate |
| `id` | **this PR** |

## Verification

246/246 scheduler tests (238 before + 8 new), 5/5 custom server lints, eslint clean.

| Mutation (applied alone) | Tests reddened |
|---|---|
| `add()` stops enforcing | 2 — add-reject + drift guard |
| **load path** stops enforcing | 2 — both load tests |
| cap drifts to 512 | 4 |
| cap drifts to 255 (off-by-one) | 2 — at-cap + drift guard |
| *(restored)* | 7/7 green |

Includes a **CONTROL** (the fixture loads with a normal id, so the refusal means
something), a guard that a generated uuid is far below the cap (this can never fire
in normal use), and a **drift guard** that safeParses the real `ScheduledTaskSchema`
at 256/257 — catching drift in either direction.