### PR TITLE
fix(server): bound the notification-prefs loader to its wire caps

### DIFF
--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -119,6 +119,26 @@ export const CATEGORY_DEFAULTS = Object.freeze(
  */
 export const DEFAULT_BYPASS_CATEGORIES = Object.freeze(['permission', 'activity_error'])
 
+/**
+ * #7080 — wire bounds mirroring `ServerNotificationPrefsSchema` in @chroxy/protocol
+ * (schemas/server/billing.ts): a bypass entry is `min(1).max(64)`, the list is
+ * `.max(64)` items, and a device token is a record key of `min(1).max(512)`.
+ *
+ * The loader used to enforce TYPE only (`typeof s === 'string' && s.length > 0`)
+ * while the schema constrains RANGE, so a hand-edited prefs file produced a
+ * message the clients could not parse. The failure is unusually bad for a
+ * "cosmetic" cap: the client safeParses the WHOLE message, so `notificationPrefs`
+ * stays null and the dashboard renders "Loading preferences…" indefinitely on both
+ * clients — and `push.js` re-persists the offending value on the next patch, so it
+ * never self-heals. Refusing the value here is what keeps the panel alive.
+ *
+ * Pinned by a test that safeParses the REAL schema, so these cannot drift silently.
+ * (#7085 tracks exporting these from @chroxy/protocol so loaders stop retyping them.)
+ */
+const MAX_BYPASS_CATEGORY_CHARS = 64
+const MAX_BYPASS_CATEGORIES = 64
+const MAX_DEVICE_TOKEN_CHARS = 512
+
 const _ALL_CATEGORIES_SET = new Set(ALL_CATEGORIES)
 // Two-digit zero-padded HH:MM with HH in 00-23 and MM in 00-59 (#4566).
 // The narrower regex replaces the older `/^\d{2}:\d{2}$/`, which accepted
@@ -179,6 +199,14 @@ function sanitizeDevices(raw, { log } = {}) {
   const out = {}
   for (const [token, entry] of Object.entries(raw)) {
     if (typeof token !== 'string' || token.length === 0) continue
+    // #7080: DROP an over-cap token, symmetric with the non-string/empty cases
+    // above. A push token is an ADDRESS: truncating it to 512 yields a token that
+    // addresses nothing and is then re-persisted by the next patch, permanently
+    // corrupting the file. Dropping self-heals on the next register_push_token.
+    if (token.length > MAX_DEVICE_TOKEN_CHARS) {
+      log?.warn?.(`notification-prefs: dropped a device entry whose token exceeds ${MAX_DEVICE_TOKEN_CHARS} chars (unrepresentable on the wire)`)
+      continue
+    }
     if (!entry || typeof entry !== 'object') continue
     const cleaned = { categories: sanitizeCategoryMap(entry.categories) }
     // Tri-state: present-as-null means "explicitly disable muting on this
@@ -196,7 +224,7 @@ function sanitizeDevices(raw, { log } = {}) {
       }
     }
     if (Object.prototype.hasOwnProperty.call(entry, 'bypassCategories')) {
-      const bypass = sanitizeBypassList(entry.bypassCategories)
+      const bypass = sanitizeBypassList(entry.bypassCategories, { log, context: `device ${token} bypassCategories` })
       if (bypass !== null) cleaned.bypassCategories = bypass
     }
     // #4587: non-critical metadata for the per-device list UI. Operators
@@ -260,17 +288,38 @@ function sanitizeQuietHours(raw) {
  * (older binary, newer prefs file mentioning a category the binary hasn't
  * shipped yet) preserves the stored value.
  */
-function sanitizeBypassList(raw) {
+function sanitizeBypassList(raw, { log, context = 'bypassCategories' } = {}) {
   if (raw == null) return null
   if (!Array.isArray(raw)) return []
   const seen = new Set()
+  let droppedLong = 0
   for (const item of raw) {
     if (typeof item !== 'string') continue
     const trimmed = item.trim()
     if (trimmed.length === 0) continue
+    // #7080: REJECT the element rather than truncating it. A category name is an
+    // identifier matched against ALL_CATEGORIES, so a truncated name matches
+    // nothing AND gets re-persisted — strictly worse than dropping it. This does
+    // narrow the forward-compat intent above: a future category longer than the
+    // wire cap will not be preserved by an older binary. That trade is
+    // deliberate — one un-bypassed category beats a dead notification panel.
+    if (trimmed.length > MAX_BYPASS_CATEGORY_CHARS) {
+      droppedLong += 1
+      continue
+    }
     seen.add(trimmed)
   }
-  return [...seen]
+  if (droppedLong > 0) {
+    log?.warn?.(`notification-prefs: dropped ${droppedLong} ${context} entr${droppedLong === 1 ? 'y' : 'ies'} longer than ${MAX_BYPASS_CATEGORY_CHARS} chars (unrepresentable on the wire)`)
+  }
+  const list = [...seen]
+  // CLAMP the length: at most a handful of real categories exist, so an
+  // over-long list is garbage, and truncating a SET corrupts no identifier.
+  if (list.length > MAX_BYPASS_CATEGORIES) {
+    log?.warn?.(`notification-prefs: ${context} had ${list.length} entries; keeping the first ${MAX_BYPASS_CATEGORIES}`)
+    return list.slice(0, MAX_BYPASS_CATEGORIES)
+  }
+  return list
 }
 
 /**
@@ -289,7 +338,7 @@ export function loadPrefs(filePath = defaultNotificationPrefsPath(), { log } = {
     // coerced to defaults so the gate never misbehaves.
     let bypass = base.bypassCategories
     if (Object.prototype.hasOwnProperty.call(raw ?? {}, 'bypassCategories')) {
-      const cleaned = sanitizeBypassList(raw.bypassCategories)
+      const cleaned = sanitizeBypassList(raw.bypassCategories, { log })
       bypass = cleaned ?? [...DEFAULT_BYPASS_CATEGORIES]
     }
     const cleanedQuietHours = sanitizeQuietHours(raw?.quietHours)

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -204,7 +204,15 @@ function sanitizeDevices(raw, { log } = {}) {
     // addresses nothing and is then re-persisted by the next patch, permanently
     // corrupting the file. Dropping self-heals on the next register_push_token.
     if (token.length > MAX_DEVICE_TOKEN_CHARS) {
-      log?.warn?.(`notification-prefs: dropped a device entry whose token exceeds ${MAX_DEVICE_TOKEN_CHARS} chars (unrepresentable on the wire)`)
+      // NOTE this is DESTRUCTIVE on the next write: loadPrefs' output is also what
+      // savePrefs persists, and push.js `touchDevice` re-persists the whole
+      // sanitized object on every register_push_token — so one phone reconnecting
+      // erases this entry from disk. Accepted deliberately: a >512-char key cannot
+      // be a real push token, so nothing addressable is lost, and the alternative
+      // (preserving it) needs a load-for-wire / load-for-persistence split that
+      // does not exist here. Unlike a scheduled task (#7050), there is no operator
+      // data in an unrouteable token worth keeping.
+      log?.warn?.(`notification-prefs: dropped a device entry whose token exceeds ${MAX_DEVICE_TOKEN_CHARS} chars (unrepresentable on the wire; it will not survive the next save)`)
       continue
     }
     if (!entry || typeof entry !== 'object') continue
@@ -313,13 +321,22 @@ function sanitizeBypassList(raw, { log, context = 'bypassCategories' } = {}) {
     log?.warn?.(`notification-prefs: dropped ${droppedLong} ${context} entr${droppedLong === 1 ? 'y' : 'ies'} longer than ${MAX_BYPASS_CATEGORY_CHARS} chars (unrepresentable on the wire)`)
   }
   const list = [...seen]
-  // CLAMP the length: at most a handful of real categories exist, so an
-  // over-long list is garbage, and truncating a SET corrupts no identifier.
-  if (list.length > MAX_BYPASS_CATEGORIES) {
-    log?.warn?.(`notification-prefs: ${context} had ${list.length} entries; keeping the first ${MAX_BYPASS_CATEGORIES}`)
-    return list.slice(0, MAX_BYPASS_CATEGORIES)
-  }
-  return list
+  if (list.length <= MAX_BYPASS_CATEGORIES) return list
+  // CLAMP the length — but NOT positionally. A plain slice(0, N) drops whatever
+  // sits past the cap, which can be a REAL category: losing `permission` from the
+  // bypass list suppresses a blocking permission prompt during quiet hours and the
+  // agent stalls indefinitely (the #4544 rationale above). That is a worse failure
+  // than the unparseable snapshot this bound exists to prevent.
+  //
+  // So keep every RECOGNISED category first, then fill the remaining slots with
+  // unrecognised ones (preserving their relative order). This also serves the
+  // forward-compat intent better than a slice: the entries at risk of being
+  // dropped are now exactly the ones this binary cannot act on anyway.
+  const known = list.filter((c) => ALL_CATEGORIES.includes(c))
+  const unknown = list.filter((c) => !ALL_CATEGORIES.includes(c))
+  const kept = [...known, ...unknown].slice(0, MAX_BYPASS_CATEGORIES)
+  log?.warn?.(`notification-prefs: ${context} had ${list.length} entries; keeping ${kept.length} (recognised categories first, ${list.length - kept.length} unrecognised dropped)`)
+  return kept
 }
 
 /**

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -299,8 +299,15 @@ function sanitizeQuietHours(raw) {
 function sanitizeBypassList(raw, { log, context = 'bypassCategories' } = {}) {
   if (raw == null) return null
   if (!Array.isArray(raw)) return []
-  const seen = new Set()
+  // Retain KNOWN categories (a fixed set of ALL_CATEGORIES.length) and at most
+  // MAX_BYPASS_CATEGORIES unknowns, so a hostile file with a huge array cannot make
+  // the loader hold the whole thing. Deliberately NOT "keep the first N while
+  // iterating": that bounds memory but is positional, which is exactly what dropped
+  // a real `permission` entry past the cap (see the clamp comment below).
+  const knownSeen = new Set()
+  const unknownSeen = new Set()
   let droppedLong = 0
+  let droppedOverflow = 0
   for (const item of raw) {
     if (typeof item !== 'string') continue
     const trimmed = item.trim()
@@ -315,13 +322,23 @@ function sanitizeBypassList(raw, { log, context = 'bypassCategories' } = {}) {
       droppedLong += 1
       continue
     }
-    seen.add(trimmed)
+    if (ALL_CATEGORIES.includes(trimmed)) {
+      knownSeen.add(trimmed)
+      continue
+    }
+    // Unknowns are the only unbounded input, so they are the only thing capped
+    // during iteration. A known category can never be lost this way.
+    if (unknownSeen.size >= MAX_BYPASS_CATEGORIES) {
+      droppedOverflow += 1
+      continue
+    }
+    unknownSeen.add(trimmed)
   }
   if (droppedLong > 0) {
     log?.warn?.(`notification-prefs: dropped ${droppedLong} ${context} entr${droppedLong === 1 ? 'y' : 'ies'} longer than ${MAX_BYPASS_CATEGORY_CHARS} chars (unrepresentable on the wire)`)
   }
-  const list = [...seen]
-  if (list.length <= MAX_BYPASS_CATEGORIES) return list
+  const list = [...knownSeen, ...unknownSeen]
+  if (list.length <= MAX_BYPASS_CATEGORIES && droppedOverflow === 0) return list
   // CLAMP the length — but NOT positionally. A plain slice(0, N) drops whatever
   // sits past the cap, which can be a REAL category: losing `permission` from the
   // bypass list suppresses a blocking permission prompt during quiet hours and the
@@ -332,10 +349,9 @@ function sanitizeBypassList(raw, { log, context = 'bypassCategories' } = {}) {
   // unrecognised ones (preserving their relative order). This also serves the
   // forward-compat intent better than a slice: the entries at risk of being
   // dropped are now exactly the ones this binary cannot act on anyway.
-  const known = list.filter((c) => ALL_CATEGORIES.includes(c))
-  const unknown = list.filter((c) => !ALL_CATEGORIES.includes(c))
-  const kept = [...known, ...unknown].slice(0, MAX_BYPASS_CATEGORIES)
-  log?.warn?.(`notification-prefs: ${context} had ${list.length} entries; keeping ${kept.length} (recognised categories first, ${list.length - kept.length} unrecognised dropped)`)
+  const kept = list.slice(0, MAX_BYPASS_CATEGORIES)
+  const dropped = (list.length - kept.length) + droppedOverflow
+  log?.warn?.(`notification-prefs: ${context} exceeded ${MAX_BYPASS_CATEGORIES} entries; keeping ${kept.length} (recognised categories first, ${dropped} unrecognised dropped)`)
   return kept
 }
 

--- a/packages/server/tests/notification-prefs.test.js
+++ b/packages/server/tests/notification-prefs.test.js
@@ -158,6 +158,19 @@ describe('notification-prefs', () => {
       )
     })
 
+    it('a huge array stays memory-bounded WITHOUT dropping a real category at the end', () => {
+      // Guards both halves at once: the loader must not retain the whole array, and
+      // the bound must not be positional — "keep the first 64 while iterating" would
+      // bound memory but re-break the quiet-hours gate (see the CRITICAL test above).
+      const huge = [...Array.from({ length: 50000 }, (_, i) => `junk${i}`), 'permission']
+      const prefs = load({ bypassCategories: huge })
+      assert.equal(prefs.bypassCategories.length, 64, 'clamped to the wire cap')
+      assert.ok(
+        prefs.bypassCategories.includes('permission'),
+        'the real category is at index 50000 and must still survive',
+      )
+    })
+
     it('boundary: exactly-at-cap values are accepted, one-over is refused', () => {
       // Pins the inclusive bound in all three guards — a `>` that became `>=`
       // (or vice versa) otherwise passes every other test in this block.

--- a/packages/server/tests/notification-prefs.test.js
+++ b/packages/server/tests/notification-prefs.test.js
@@ -142,6 +142,46 @@ describe('notification-prefs', () => {
       assert.equal(prefs.bypassCategories.length, 64)
     })
 
+    it('CRITICAL: clamping never drops a REAL category in favour of junk', () => {
+      // A positional slice(0, 64) drops whatever sits at index >= 64 — including a
+      // functional category. Dropping `permission` from the bypass list means a
+      // blocking permission prompt is SUPPRESSED during quiet hours and the agent
+      // stalls indefinitely (the #4544 rationale this file documents). That would be
+      // a worse bug than the unparseable snapshot this fix exists to prevent, so
+      // known categories are kept ahead of unrecognised ones.
+      const junk = Array.from({ length: 64 }, (_, i) => `junk${i}`)
+      const prefs = load({ bypassCategories: [...junk, 'permission'] })
+      assert.equal(prefs.bypassCategories.length, 64, 'still clamped to the wire cap')
+      assert.ok(
+        prefs.bypassCategories.includes('permission'),
+        'a real category must survive the clamp regardless of its position on disk',
+      )
+    })
+
+    it('boundary: exactly-at-cap values are accepted, one-over is refused', () => {
+      // Pins the inclusive bound in all three guards — a `>` that became `>=`
+      // (or vice versa) otherwise passes every other test in this block.
+      const atCapCat = 'c'.repeat(64)
+      const atCapToken = 't'.repeat(512)
+      const prefs = load({
+        bypassCategories: [atCapCat, 'c'.repeat(65)],
+        devices: { [atCapToken]: { platform: 'ios' }, ['t'.repeat(513)]: { platform: 'ios' } },
+      })
+      assert.deepEqual(prefs.bypassCategories, [atCapCat], 'a 64-char name is legal, 65 is not')
+      assert.deepEqual(Object.keys(prefs.devices), [atCapToken], 'a 512-char token is legal, 513 is not')
+
+      // Exactly 64 entries must not be clamped — and must not WARN that they were.
+      // The clamp is output-identical at the cap, so only the absent warn
+      // distinguishes `<=` from `<` here.
+      const warned = []
+      const exact = load(
+        { bypassCategories: Array.from({ length: 64 }, (_, i) => `cat${i}`) },
+        { warn: (m) => warned.push(m) },
+      )
+      assert.equal(exact.bypassCategories.length, 64)
+      assert.deepEqual(warned, [], 'a list exactly at the cap is untouched, so nothing should be reported')
+    })
+
     it('drops a device whose token key exceeds the wire cap', () => {
       const good = 'ExponentPushToken[ok]'
       const prefs = load({ devices: { [LONG_TOKEN]: { platform: 'ios' }, [good]: { platform: 'android' } } })

--- a/packages/server/tests/notification-prefs.test.js
+++ b/packages/server/tests/notification-prefs.test.js
@@ -13,6 +13,7 @@ import {
   CATEGORY_DEFAULTS,
   ALL_CATEGORIES,
 } from '../src/notification-prefs.js'
+import { ServerNotificationPrefsSchema } from '@chroxy/protocol'
 
 let tmpDir
 let prefsPath
@@ -102,6 +103,89 @@ describe('notification-prefs', () => {
       const prefs = loadPrefs(prefsPath)
       assert.equal(prefs.categories.bogus_category, undefined)
       assert.equal(prefs.categories.result, false)
+    })
+  })
+
+  // #7080 — the loader accepted values ServerNotificationPrefsSchema rejects, so a
+  // hand-edited prefs file wedged the notification panel on BOTH clients: the
+  // whole-message safeParse fails -> notificationPrefs stays null -> the dashboard
+  // renders "Loading preferences..." forever, and push.js re-persists the bad value
+  // on the next patch so it never self-heals.
+  describe('#7080 wire bounds on the prefs loader', () => {
+    const LONG_CATEGORY = 'c'.repeat(65)   // cap is 64
+    const LONG_TOKEN = 't'.repeat(513)     // cap is 512
+    const quiet = { warn: () => {} }
+
+    const load = (obj, log = quiet) => {
+      writeFileSync(prefsPath, JSON.stringify(obj))
+      return loadPrefs(prefsPath, { log })
+    }
+
+    it('CONTROL: legal values survive untouched (so the drops below mean something)', () => {
+      const token = 'ExponentPushToken[abc123]'
+      const prefs = load({
+        bypassCategories: ['permission', 'activity_error'],
+        devices: { [token]: { platform: 'ios', bypassCategories: ['permission'] } },
+      })
+      assert.deepEqual(prefs.bypassCategories, ['permission', 'activity_error'])
+      assert.deepEqual(Object.keys(prefs.devices), [token])
+      assert.deepEqual(prefs.devices[token].bypassCategories, ['permission'])
+    })
+
+    it('drops an over-cap bypass category but keeps the legal siblings', () => {
+      const prefs = load({ bypassCategories: ['permission', LONG_CATEGORY, 'activity_error'] })
+      assert.deepEqual(prefs.bypassCategories, ['permission', 'activity_error'])
+    })
+
+    it('caps the bypass list length', () => {
+      const prefs = load({ bypassCategories: Array.from({ length: 70 }, (_, i) => `cat${i}`) })
+      assert.equal(prefs.bypassCategories.length, 64)
+    })
+
+    it('drops a device whose token key exceeds the wire cap', () => {
+      const good = 'ExponentPushToken[ok]'
+      const prefs = load({ devices: { [LONG_TOKEN]: { platform: 'ios' }, [good]: { platform: 'android' } } })
+      assert.deepEqual(Object.keys(prefs.devices), [good], 'the over-cap device is dropped, the legal one survives')
+    })
+
+    it('bounds the PER-DEVICE bypass list too, and names the device in the warn', () => {
+      // Two call sites share sanitizeBypassList; fixing only loadPrefs leaves this broken.
+      const token = 'ExponentPushToken[dev]'
+      const warned = []
+      const prefs = load(
+        { devices: { [token]: { bypassCategories: ['permission', LONG_CATEGORY] } } },
+        { warn: (m) => warned.push(m) },
+      )
+      assert.deepEqual(prefs.devices[token].bypassCategories, ['permission'])
+      // Attribution matters: with several devices, an unattributed warn cannot tell
+      // the operator which entry to repair.
+      assert.ok(
+        warned.some((m) => m.includes(token)),
+        `expected the warn to name the device, got ${JSON.stringify(warned)}`,
+      )
+    })
+
+    it('warns so the operator can tell a value was refused', () => {
+      const warned = []
+      load({ bypassCategories: ['permission', LONG_CATEGORY] }, { warn: (m) => warned.push(m) })
+      assert.ok(warned.some((m) => /bypass/i.test(m)), `expected a bypass warn, got ${JSON.stringify(warned)}`)
+    })
+
+    it('DRIFT GUARD: a hostile file still loads to something the real wire schema accepts', () => {
+      // The point of the whole fix. Asserts against the REAL schema rather than a
+      // hand-rolled shape, so a cap change in @chroxy/protocol fails here.
+      const prefs = load({
+        bypassCategories: [...Array.from({ length: 70 }, (_, i) => `cat${i}`), LONG_CATEGORY],
+        devices: {
+          [LONG_TOKEN]: { platform: 'ios', bypassCategories: [LONG_CATEGORY] },
+          'ExponentPushToken[ok]': { platform: 'android', bypassCategories: [LONG_CATEGORY, 'permission'] },
+        },
+      })
+      const r = ServerNotificationPrefsSchema.safeParse({ type: 'notification_prefs', prefs })
+      assert.ok(
+        r.success,
+        `loaded prefs must satisfy the wire schema; got ${JSON.stringify((r.error?.issues || []).slice(0, 3).map((i) => ({ code: i.code, path: i.path })))}`,
+      )
     })
   })
 


### PR DESCRIPTION
Closes #7080

## Problem

`notification-prefs.js` enforced **type** where `ServerNotificationPrefsSchema` constrains **range**:

| Site | Guard | Wire cap violated |
|---|---|---|
| `sanitizeDevices` | `typeof token !== 'string' \|\| token.length === 0` | record key `min(1).max(512)` |
| `sanitizeBypassList` | non-empty trimmed string | element `min(1).max(64)` |
| same | none | list `.max(64)` items |

Verified before fixing — a 70-char category and a 619-char device token both survive `loadPrefs`, and the result fails the **real** schema:

```
over-64 category survived load? -> true | longest = 70
over-512 device key survived?   -> true | longest = 619
wire safeParse -> REJECTS
    invalid_key ["prefs","devices","tttt…"]
    too_big     ["prefs","bypassCategories",1]  expected string to have <=64 characters
70-entry list loaded as -> 70 entries
```

## Why this is worse than a shortened label

The client safeParses the **whole message**, so one bad entry means:

- `store-core/src/handlers/alerts.ts:106` → `notificationPrefs: null`
- the dashboard renders "Loading preferences…" **indefinitely** (`SettingsPanel.tsx:1931`); mobile shares the handler
- **it never self-heals** — `push.js:248-249` re-persists the offending value on the next patch
- for the device key there is **no in-UI recovery**: the Clear sentinel `{[token]: null}` cannot carry a >512-char key because inbound rejects it, so the row never renders and optimistic writes no-op while `notificationPrefs` is null

Not reachable from a client message (inbound already caps token at 512 and the list at 64; `touchDevice` only mutates existing entries) — the trigger is a hand-edited or externally-written state file.

## Reject vs clamp, per field

- **Bypass element → REJECT.** A category name is an identifier matched against `ALL_CATEGORIES`; a truncated name matches nothing *and* gets re-persisted. Worse than dropping.
- **Device key → REJECT.** A push token is an *address*. Truncating yields one that addresses nothing and corrupts the file on the next patch. Dropping is symmetric with the existing non-string/empty handling and self-heals on the next `register_push_token`.
- **List length → CLAMP.** At most a handful of real categories exist, so an over-long list is garbage, and truncating a *set* corrupts no identifier.

**This does narrow a documented intent** — `sanitizeBypassList`'s comment deliberately avoided whitelisting so an older binary would preserve a newer category it hadn't shipped. A >64-char future category is no longer preserved. That trade is now stated in the code: one un-bypassed category beats a dead notification panel.

**Both call sites** are fixed — the global list in `loadPrefs` and the per-device list in `sanitizeDevices`. Fixing only the first leaves the panel just as dead, and the per-device warn names the offending device so a multi-device file is actionable.

## Verification

287 tests across `notification*`, `push*`, `ready-notification-body` — 286 pass, 0 fail. 5/5 custom server lints, eslint clean.

Each guard mutation-verified **individually**:

| Mutation (applied alone) | Tests reddened |
|---|---|
| element-length guard removed | 4 |
| list-length clamp removed | 2 |
| device-key guard removed | 2 |
| per-device call site drops log/context | 1 — the attribution test |
| *(restored)* | 7/7 green |

Two things I'd point a reviewer at:

- The suite includes a **CONTROL** asserting legal values survive untouched, so "the bad one was dropped" can't pass because everything was dropped.
- The **drift guard** loads a hostile file and safeParses the result against the real `ServerNotificationPrefsSchema` rather than a hand-rolled shape — a cap change in `@chroxy/protocol` fails here instead of silently reopening this.

## Context

Found by a systematic audit of **243 capped outbound fields** across every server schema (8 confirmed gaps, filed as #7080–#7086). Notably **0 of 243 were reachable from a client message** — the WS boundary is structurally defended; every other door is guarded by hand.

The audit's structural finding is #7085: nothing validates outbound messages, which is why all 8 reached main. That issue is the one that makes these the last of their kind; this PR is the highest-severity instance.