### PR TITLE
fix(server): bound the epoch-to-ISO conversions behind two datetime wire fields

### DIFF
--- a/packages/server/src/control-room/integrations.js
+++ b/packages/server/src/control-room/integrations.js
@@ -128,16 +128,16 @@ export function parseRepoMemoryConfig(text) {
  */
 function deriveLastActivity(parsed) {
   const raw = parsed.lastEventAt ?? parsed.lastActivityAt ?? parsed.lastActivity
-  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
-    try {
-      return new Date(raw).toISOString()
-    } catch {
-      return null
-    }
-  }
+  // #7081: both branches go through isoFromEpochMs. The destination is
+  // `z.string().datetime()`, and this input is repo-memory's own report JSON —
+  // arbitrary third-party output, so weaker protection than the mtime site below.
+  if (typeof raw === 'number') return isoFromEpochMs(raw)
   if (typeof raw === 'string' && raw.length > 0) {
+    // Date.parse ROUND-TRIPS the expanded-year form, so parsing a
+    // '+058851-…' string and re-emitting it reproduces the same wire-illegal
+    // value. The string branch needs the range check just as much as the number one.
     const ms = Date.parse(raw)
-    if (!Number.isNaN(ms)) return new Date(ms).toISOString()
+    if (!Number.isNaN(ms)) return isoFromEpochMs(ms)
   }
   return null
 }
@@ -529,7 +529,8 @@ export function parseRelayRuns(json) {
       status: str(r.status),
       conclusion: str(r.conclusion),
       event: str(r.event),
-      createdAt: Number.isNaN(createdMs) ? null : new Date(createdMs).toISOString(),
+      // #7081: same bound — gh run JSON is third-party input.
+      createdAt: Number.isNaN(createdMs) ? null : isoFromEpochMs(createdMs),
     })
   }
   return runs

--- a/packages/server/src/control-room/integrations.js
+++ b/packages/server/src/control-room/integrations.js
@@ -54,6 +54,7 @@ import { readFile, stat } from 'fs/promises'
 import { join } from 'path'
 import { parseGithubOwnerRepo } from './survey.js'
 import { DEFAULT_CONCURRENCY, EXEC_TIMEOUT_MS } from './constants.js'
+import { isoFromEpochMs } from '../utils/iso-datetime.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -247,7 +248,11 @@ async function surveyCache(statFn, repoPath) {
   }
   const sizeBytes = Math.max(0, Math.trunc(nonNegNumber(db?.size, 0) + nonNegNumber(wal?.size, 0)))
   const mtimes = [db?.mtimeMs, wal?.mtimeMs].filter(m => typeof m === 'number' && Number.isFinite(m) && m > 0)
-  const lastModified = mtimes.length > 0 ? new Date(Math.max(...mtimes)).toISOString() : null
+  // #7081: same unbounded epoch->ISO shape as skills `lastUsed`. Unreachable on
+  // APFS/ext4 (neither can store a year > 9999) but a network/FUSE mount or a
+  // deliberately-set mtime can, and the adjacent sizeBytes above is already
+  // bounded — so the rule gets applied here rather than relying on the filesystem.
+  const lastModified = mtimes.length > 0 ? isoFromEpochMs(Math.max(...mtimes)) : null
   return { present: true, sizeBytes, lastModified }
 }
 

--- a/packages/server/src/control-room/skills-inventory.js
+++ b/packages/server/src/control-room/skills-inventory.js
@@ -47,6 +47,7 @@ import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { loadActiveSkills, findRepoSkillsDir, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
 import { DEFAULT_CONCURRENCY } from './constants.js'
+import { isoFromEpochMs } from '../utils/iso-datetime.js'
 
 /**
  * Parse a `skills.lock` file into a name → { hash, installed } map. The lock
@@ -163,7 +164,11 @@ export function toInventoryEntry(skill, lock, usage, globalNames) {
     hash: lockRec ? lockRec.hash : null,
     installed: lockRec ? lockRec.installed : null,
     // Usage rollup (#5554 Phase 2). Null when never recorded.
-    lastUsed: usageRec && typeof usageRec.lastUsed === 'number' ? new Date(usageRec.lastUsed).toISOString() : null,
+    // #7081: via the shared helper, which returns null for anything that would
+    // render as an expanded-year (>year 9999) string the wire cannot carry.
+    // skills-usage.js already bounds what it PERSISTS; this covers any other path
+    // that reaches here with an unbounded number.
+    lastUsed: isoFromEpochMs(usageRec?.lastUsed),
     useCount: usageRec ? usageRec.count : 0,
     usedRepos: usageRec && Array.isArray(usageRec.repos) ? usageRec.repos.slice() : [],
   }

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -46,6 +46,7 @@ import { join } from 'node:path'
 import { createLogger } from './logger.js'
 import { loadJsonState, saveJsonState } from './json-state-file.js'
 import { getErrorMessage } from './utils/error-message.js'
+import { MAX_WIRE_DATETIME_MS } from './utils/iso-datetime.js'
 
 const log = createLogger('skills-usage')
 
@@ -115,7 +116,17 @@ function normalizeAggregate(agg) {
   const count = typeof agg.count === 'number' && Number.isFinite(agg.count) && agg.count >= 0
     ? Math.trunc(agg.count)
     : 0
-  const lastUsed = typeof agg.lastUsed === 'number' && Number.isFinite(agg.lastUsed) && agg.lastUsed > 0
+  // #7081: bound the RANGE, not just the type. `lastUsed` is rendered by
+  // skills-inventory.js via `new Date(ms).toISOString()` into a
+  // `z.string().datetime()` field, and there is a band above year 9999 where
+  // toISOString SUCCEEDS but emits the expanded-year form the wire rejects —
+  // which failed the whole snapshot's safeParse and left the Skills tab
+  // spinning with Refresh disabled. The adjacent `count` above already
+  // Math.truncs to match its int cap; this is the same rule, applied.
+  const lastUsed = typeof agg.lastUsed === 'number'
+    && Number.isFinite(agg.lastUsed)
+    && agg.lastUsed > 0
+    && agg.lastUsed <= MAX_WIRE_DATETIME_MS
     ? agg.lastUsed
     : null
   const repos = []

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -195,7 +195,14 @@ export function saveUsageStore(store, filePath = defaultSkillsUsagePath()) {
 export function applyUsage(store, record) {
   const skill = record && typeof record.skill === 'string' && record.skill.length > 0 ? record.skill : null
   if (!skill) return store
-  const ts = typeof record.ts === 'number' && Number.isFinite(record.ts) && record.ts > 0 ? record.ts : Date.now()
+  // #7081: bound the RANGE here too. normalizeAggregate guards the LOAD path, but
+  // this is the WRITE path — it wrote `ts` verbatim into agg.lastUsed, persisting a
+  // number the next snapshot could not render. An out-of-range ts falls back to
+  // now(), which is what an unparseable one already did.
+  const tsRaw = record.ts
+  const ts = typeof tsRaw === 'number' && Number.isFinite(tsRaw) && tsRaw > 0 && tsRaw <= MAX_WIRE_DATETIME_MS
+    ? tsRaw
+    : Date.now()
   const sessionId = typeof record.sessionId === 'string' && record.sessionId.length > 0 ? record.sessionId : null
   const repo = typeof record.repo === 'string' && record.repo.length > 0 ? record.repo : null
 

--- a/packages/server/src/utils/iso-datetime.js
+++ b/packages/server/src/utils/iso-datetime.js
@@ -1,0 +1,51 @@
+/**
+ * #7081 — epoch-ms → wire-legal ISO 8601, or null.
+ *
+ * Several outbound fields are `z.string().datetime()` in @chroxy/protocol
+ * (`skills.ts` `lastUsed`, control-room `RepoMemoryCache.lastModified`, …) and are
+ * produced by `new Date(ms).toISOString()` from a number read off disk. Those
+ * loaders guarded the number for TYPE (finite, positive) while the schema
+ * constrains RANGE, which leaves a band where `toISOString()` succeeds but emits
+ * something the wire rejects:
+ *
+ *   253402300799999  -> '9999-12-31T23:59:59.999Z'    accepted
+ *   253402300800000  -> '+010000-01-01T00:00:00.000Z' REJECTED by .datetime()
+ *   8640000000000000 -> '+275760-09-13T00:00:00.000Z' REJECTED by .datetime()
+ *   8640000000000001 -> RangeError
+ *
+ * ES2015+ requires the expanded-year form (`±YYYYYY`) once the year leaves
+ * [0, 9999], and `z.string().datetime()` only accepts a 4-digit year. So the
+ * usable ceiling is the last instant of year 9999 — NOT `Date`'s ±8.64e15 limit,
+ * which is the bound `scheduled-task-store.js` uses for a different purpose
+ * (representable-as-a-Date, not representable-on-the-wire). Do not conflate them.
+ *
+ * Returns `null` rather than clamping. Every consuming field is `.nullable()`, and
+ * a clamped timestamp is a LIE rendered to the operator: "last used in the year
+ * 9999" is not more truthful than "never recorded", it is just harder to notice.
+ */
+
+/** Last epoch-ms whose ISO form keeps a 4-digit year (`9999-12-31T23:59:59.999Z`). */
+export const MAX_WIRE_DATETIME_MS = 253402300799999
+
+/**
+ * Convert an epoch-ms value to an ISO string the wire can carry.
+ *
+ * @param {unknown} ms - candidate epoch-ms; anything non-numeric yields null
+ * @param {{ allowEpoch?: boolean }} [opts] - `allowEpoch` permits 0 (the Unix
+ *   epoch). Off by default because the existing callers treat 0 as "never
+ *   recorded" rather than as 1970-01-01.
+ * @returns {string|null} an ISO 8601 string with a 4-digit year, or null
+ */
+export function isoFromEpochMs(ms, { allowEpoch = false } = {}) {
+  if (typeof ms !== 'number' || !Number.isFinite(ms)) return null
+  if (allowEpoch ? ms < 0 : ms <= 0) return null
+  if (ms > MAX_WIRE_DATETIME_MS) return null
+  // Defensive: a fractional value is legal here (Date accepts it and truncates),
+  // so this cannot throw after the range check above — but a future caller
+  // passing something exotic should degrade to null rather than crash a snapshot.
+  try {
+    return new Date(ms).toISOString()
+  } catch {
+    return null
+  }
+}

--- a/packages/server/tests/control-room-integrations.test.js
+++ b/packages/server/tests/control-room-integrations.test.js
@@ -903,3 +903,33 @@ describe('controlRoomRepoMemoryBin config key (#5499)', () => {
     assert.ok(typeWarn, 'expected a type warning for a non-string value')
   })
 })
+
+describe('#7081 repo-memory cache lastModified stays wire-representable', () => {
+  const runSurvey = (mtimeMs) => surveyIntegrations(
+    [{ path: '/repo/a', name: 'a' }],
+    {
+      _readFile: async (p) => (String(p).endsWith('.repo-memory.json') ? '{}' : ''),
+      _stat: async () => ({ size: 10, mtimeMs }),
+      // No repo-memory binary: the survey degrades to a "CLI missing" note, which
+      // is enough to exercise the cache block we care about.
+      _execFile: async () => { throw new Error('not installed') },
+      _now: () => new Date(1785000000000),
+    },
+  )
+
+  it('CONTROL: an ordinary mtime yields an ISO string and a valid snapshot', async () => {
+    const snap = await runSurvey(1785000000000)
+    const entry = snap.repos.find(r => r.path === '/repo/a')
+    assert.equal(typeof entry.repoMemory.cache.lastModified, 'string')
+    assert.ok(ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snap }).success)
+  })
+
+  it('nulls an out-of-range mtime rather than emitting an expanded-year string', async () => {
+    const snap = await runSurvey(1795000000000000)
+    const entry = snap.repos.find(r => r.path === '/repo/a')
+    assert.equal(entry.repoMemory.cache.lastModified, null)
+    assert.equal(entry.repoMemory.cache.present, true, 'the cache row still reports present')
+    const r = ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snap })
+    assert.ok(r.success, `snapshot must stay wire-legal; got ${JSON.stringify((r.error?.issues || [])[0])}`)
+  })
+})

--- a/packages/server/tests/control-room-integrations.test.js
+++ b/packages/server/tests/control-room-integrations.test.js
@@ -19,6 +19,7 @@ import {
 } from '../src/control-room/integrations.js'
 import { validateConfig } from '../src/config.js'
 import { ServerIntegrationStatusSnapshotSchema } from '@chroxy/protocol'
+import { z } from 'zod'
 
 /**
  * Tests for the Control Room Integrations survey (#5499, epic #5498).
@@ -931,5 +932,41 @@ describe('#7081 repo-memory cache lastModified stays wire-representable', () => 
     assert.equal(entry.repoMemory.cache.present, true, 'the cache row still reports present')
     const r = ServerIntegrationStatusSnapshotSchema.safeParse({ type: 'integration_status_snapshot', ...snap })
     assert.ok(r.success, `snapshot must stay wire-legal; got ${JSON.stringify((r.error?.issues || [])[0])}`)
+  })
+})
+
+describe('#7081 review: the other epoch-to-ISO sites in this file', () => {
+  const wireCap = z.string().datetime().nullable()
+
+  it('deriveLastActivity NUMBER branch is bounded (arbitrary third-party CLI JSON)', () => {
+    // Same predicate the fix was written against, 115 lines above the line first
+    // changed — and its input is repo-memory's own report JSON, so it is weaker
+    // protection than the filesystem-backed mtime site.
+    const r = parseRepoMemoryReport(JSON.stringify({ lastEventAt: 1795000000000000 }))
+    assert.equal(r.lastActivity, null)
+    assert.ok(wireCap.safeParse(r.lastActivity).success)
+  })
+
+  it('deriveLastActivity STRING branch is bounded too (Date.parse round-trips expanded years)', () => {
+    const r = parseRepoMemoryReport(JSON.stringify({ lastEventAt: '+058851-04-14T23:06:40.000Z' }))
+    assert.equal(r.lastActivity, null, 'Date.parse accepts the expanded form, so the string branch needs the same guard')
+    assert.ok(wireCap.safeParse(r.lastActivity).success)
+  })
+
+  it('CONTROL: both branches still accept an ordinary value', () => {
+    const n = parseRepoMemoryReport(JSON.stringify({ lastEventAt: 1785000000000 }))
+    assert.equal(typeof n.lastActivity, 'string')
+    const s2 = parseRepoMemoryReport(JSON.stringify({ lastEventAt: '2026-07-29T12:00:00.000Z' }))
+    assert.equal(s2.lastActivity, '2026-07-29T12:00:00.000Z')
+  })
+
+  it('parseRelayRuns createdAt is bounded', () => {
+    const runs = parseRelayRuns(JSON.stringify([
+      { databaseId: 1, status: 'completed', conclusion: 'success', event: 'push', createdAt: '+058851-04-14T23:06:40.000Z' },
+      { databaseId: 2, status: 'completed', conclusion: 'success', event: 'push', createdAt: '2026-07-29T12:00:00.000Z' },
+    ]))
+    assert.equal(runs[0].createdAt, null, 'out-of-range becomes null')
+    assert.equal(runs[1].createdAt, '2026-07-29T12:00:00.000Z', 'CONTROL: a normal run is untouched')
+    for (const r of runs) assert.ok(wireCap.safeParse(r.createdAt).success)
   })
 })

--- a/packages/server/tests/iso-datetime.test.js
+++ b/packages/server/tests/iso-datetime.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+import { isoFromEpochMs, MAX_WIRE_DATETIME_MS } from '../src/utils/iso-datetime.js'
+
+// #7081 — the loaders behind `z.string().datetime()` fields guarded their epoch-ms
+// input for TYPE (finite, positive) while the schema constrains RANGE. There is a
+// band where `new Date(ms).toISOString()` SUCCEEDS but emits an expanded-year
+// string the wire rejects, which failed the whole snapshot's safeParse.
+describe('isoFromEpochMs (#7081)', () => {
+  // The actual wire constraint, not a hand-rolled approximation of it. If Zod's
+  // `.datetime()` ever widened to accept expanded years, this test is what tells us
+  // the ceiling can be raised.
+  const wireCap = z.string().datetime()
+
+  it('the cap is exactly the last instant that keeps a 4-digit year', () => {
+    assert.equal(MAX_WIRE_DATETIME_MS, 253402300799999)
+    assert.equal(new Date(MAX_WIRE_DATETIME_MS).toISOString(), '9999-12-31T23:59:59.999Z')
+    assert.equal(
+      new Date(MAX_WIRE_DATETIME_MS + 1).toISOString(),
+      '+010000-01-01T00:00:00.000Z',
+      'one ms later is expanded-year — this is the boundary the wire cares about',
+    )
+  })
+
+  it('CONTROL: an ordinary timestamp round-trips and satisfies the real wire schema', () => {
+    const iso = isoFromEpochMs(1785000000000)
+    assert.equal(typeof iso, 'string')
+    assert.ok(wireCap.safeParse(iso).success)
+  })
+
+  it('accepts the cap itself (the bound is inclusive)', () => {
+    const iso = isoFromEpochMs(MAX_WIRE_DATETIME_MS)
+    assert.equal(iso, '9999-12-31T23:59:59.999Z')
+    assert.ok(wireCap.safeParse(iso).success)
+  })
+
+  it('returns null one ms past the cap — where toISOString still SUCCEEDS', () => {
+    // The whole point: this input does not throw. Only the range check catches it.
+    assert.doesNotThrow(() => new Date(MAX_WIRE_DATETIME_MS + 1).toISOString())
+    assert.equal(isoFromEpochMs(MAX_WIRE_DATETIME_MS + 1), null)
+  })
+
+  it('returns null across the whole expanded-year band, and past Date range', () => {
+    for (const ms of [253402300800000, 1795000000000000, 8640000000000000, 8640000000000001, 1e300]) {
+      assert.equal(isoFromEpochMs(ms), null, `${ms} must not yield a wire-illegal string`)
+    }
+  })
+
+  it('every rejected value would otherwise have failed the wire schema', () => {
+    // Proves the guard is not over-eager: each value it refuses is one the schema
+    // would have refused too (or that throws), so nothing legal is being lost.
+    for (const ms of [MAX_WIRE_DATETIME_MS + 1, 253402300800000, 8640000000000000]) {
+      let iso = null
+      try { iso = new Date(ms).toISOString() } catch { iso = null }
+      assert.ok(iso !== null, `${ms} should be Date-representable (that is what makes it dangerous)`)
+      assert.equal(wireCap.safeParse(iso).success, false, `${ms} -> ${iso} must be wire-illegal`)
+    }
+  })
+
+  it('returns null for non-numeric, non-finite, and non-positive input', () => {
+    for (const bad of [undefined, null, 'now', {}, [], NaN, Infinity, -Infinity, -1, 0]) {
+      assert.equal(isoFromEpochMs(bad), null, `${String(bad)} must yield null`)
+    }
+  })
+
+  it('allowEpoch admits 0 without admitting negatives', () => {
+    assert.equal(isoFromEpochMs(0, { allowEpoch: true }), '1970-01-01T00:00:00.000Z')
+    assert.equal(isoFromEpochMs(-1, { allowEpoch: true }), null)
+  })
+})

--- a/packages/server/tests/skills-inventory-survey.test.js
+++ b/packages/server/tests/skills-inventory-survey.test.js
@@ -6,6 +6,8 @@ import {
   lockPathForSkillsDir,
   toInventoryEntry,
 } from '../src/control-room/skills-inventory.js'
+import { SkillInventoryEntrySchema } from '@chroxy/protocol'
+import { MAX_WIRE_DATETIME_MS } from '../src/utils/iso-datetime.js'
 
 /**
  * #5554 — tests for the Skills inventory survey (control-room/skills-inventory.js).
@@ -221,5 +223,36 @@ describe('surveySkillsInventory', () => {
     assert.equal(result.global[0].useCount, 3)
     assert.equal(result.global[0].lastUsed, '2026-06-09T00:00:00.000Z')
     assert.deepEqual(result.global[0].usedRepos, ['/p'])
+  })
+})
+
+describe('#7081 toInventoryEntry keeps lastUsed wire-representable', () => {
+  const skill = { name: 'batch-merge', description: 'd', source: 'global', activation: 'auto', active: true, providers: [] }
+
+  // `lock` and `usage` are Maps keyed by skill name (lock is dereferenced unguarded).
+  const usageMap = (lastUsed, count = 2) => new Map([[skill.name, { count, lastUsed, repos: [] }]])
+
+  it('CONTROL: an ordinary lastUsed becomes an ISO string the wire accepts', () => {
+    const entry = toInventoryEntry(skill, new Map(), usageMap(1785000000000), new Set())
+    assert.equal(typeof entry.lastUsed, 'string')
+    assert.ok(SkillInventoryEntrySchema.safeParse(entry).success)
+  })
+
+  it('nulls an out-of-range lastUsed instead of emitting an expanded-year string', () => {
+    // Raw `new Date(ms).toISOString()` yields '+058851-04-14T23:06:40.000Z' here,
+    // which z.string().datetime() rejects -> the WHOLE snapshot fails safeParse and
+    // the dashboard Skills tab spins with Refresh disabled for the life of the socket.
+    const entry = toInventoryEntry(skill, new Map(), usageMap(1795000000000000), new Set())
+    assert.equal(entry.lastUsed, null)
+    assert.equal(entry.useCount, 2, 'the rest of the rollup survives — only the unusable timestamp is dropped')
+    const r = SkillInventoryEntrySchema.safeParse(entry)
+    assert.ok(r.success, `entry must satisfy the real schema; got ${JSON.stringify((r.error?.issues || [])[0])}`)
+  })
+
+  it('accepts the largest wire-representable instant and rejects one ms past it', () => {
+    const ok = toInventoryEntry(skill, new Map(), usageMap(MAX_WIRE_DATETIME_MS, 1), new Set())
+    assert.equal(ok.lastUsed, '9999-12-31T23:59:59.999Z')
+    const bad = toInventoryEntry(skill, new Map(), usageMap(MAX_WIRE_DATETIME_MS + 1, 1), new Set())
+    assert.equal(bad.lastUsed, null)
   })
 })

--- a/packages/server/tests/skills-usage.test.js
+++ b/packages/server/tests/skills-usage.test.js
@@ -292,3 +292,27 @@ describe('SkillsUsageRecorder', () => {
     assert.equal(rec2.aggregatesByName().get('a').count, 2, 'count should accumulate across restarts')
   })
 })
+
+describe('#7081 review: applyUsage must not PERSIST an out-of-range lastUsed', () => {
+  it('an out-of-range record ts does not become an unrepresentable lastUsed', () => {
+    // normalizeAggregate guards the LOAD path; applyUsage is the WRITE path and
+    // wrote `ts` verbatim, so a bad record persisted a number that the next
+    // snapshot could not render. Both ends need the bound.
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'batch-merge', sessionId: 's1', repo: '/p/a', ts: 1795000000000000 })
+    const agg = store.aggregates['batch-merge']
+    if (agg) {
+      assert.ok(
+        agg.lastUsed === null || agg.lastUsed <= MAX_WIRE_DATETIME_MS,
+        `persisted lastUsed must stay wire-representable, got ${agg.lastUsed}`,
+      )
+      assert.ok(z.string().datetime().nullable().safeParse(isoFromEpochMs(agg.lastUsed)).success)
+    }
+  })
+
+  it('CONTROL: an ordinary record still advances lastUsed', () => {
+    const store = { version: 1, entries: [], aggregates: {} }
+    applyUsage(store, { skill: 'batch-merge', sessionId: 's1', repo: '/p/a', ts: 1785000000000 })
+    assert.equal(store.aggregates['batch-merge'].lastUsed, 1785000000000)
+  })
+})

--- a/packages/server/tests/skills-usage.test.js
+++ b/packages/server/tests/skills-usage.test.js
@@ -12,6 +12,8 @@ import {
   MAX_REPOS_PER_SKILL,
   MAX_SKILLS,
 } from '../src/skills-usage.js'
+import { z } from 'zod'
+import { isoFromEpochMs, MAX_WIRE_DATETIME_MS } from '../src/utils/iso-datetime.js'
 
 /**
  * #5554 Phase 2 — tests for the bounded, atomic skills usage log
@@ -19,6 +21,62 @@ import {
  * ~/.chroxy/skills-usage.json is never touched (the #4633 sandbox guard would
  * throw otherwise).
  */
+
+describe('#7081 lastUsed must stay wire-representable', () => {
+  let dir, fp
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-usage-7081-'))
+    fp = join(dir, 'skills-usage.json')
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  const loadWith = (lastUsed) => {
+    writeFileSync(fp, JSON.stringify({
+      version: 1,
+      entries: [],
+      aggregates: { 'batch-merge': { count: 3, lastUsed, repos: ['/p/a'] } },
+    }))
+    return loadUsageStore(fp).aggregates['batch-merge']
+  }
+
+  it('CONTROL: an ordinary lastUsed survives the load untouched', () => {
+    const agg = loadWith(1785000000000)
+    assert.equal(agg.lastUsed, 1785000000000)
+    assert.equal(agg.count, 3, 'and the rest of the aggregate is intact')
+  })
+
+  it('accepts the largest wire-representable instant', () => {
+    assert.equal(loadWith(MAX_WIRE_DATETIME_MS).lastUsed, MAX_WIRE_DATETIME_MS)
+  })
+
+  it('nulls a lastUsed one ms past the cap — the value toISOString would ACCEPT', () => {
+    // This is the whole defect: Date renders it fine, so only a range check catches
+    // it, and the resulting +010000-… string failed the snapshot safeParse.
+    const agg = loadWith(MAX_WIRE_DATETIME_MS + 1)
+    assert.equal(agg.lastUsed, null)
+    assert.equal(agg.count, 3, 'the aggregate is kept — only the unusable timestamp is dropped')
+  })
+
+  it('nulls the whole expanded-year band and beyond', () => {
+    for (const ms of [253402300800000, 1795000000000000, 8640000000000000, 8640000000000001]) {
+      assert.equal(loadWith(ms).lastUsed, null, `${ms} must not survive as a number`)
+    }
+  })
+
+  it('DRIFT GUARD: a hostile lastUsed still yields a wire-legal ISO or null', () => {
+    // Asserts against the REAL wire cap rather than a hand-rolled shape, so a
+    // change to skills.ts fails here instead of silently reopening this.
+    const wireCap = z.string().datetime().nullable()
+    for (const ms of [1785000000000, MAX_WIRE_DATETIME_MS, MAX_WIRE_DATETIME_MS + 1, 8640000000000000]) {
+      const { lastUsed } = loadWith(ms)
+      const iso = isoFromEpochMs(lastUsed)
+      assert.ok(
+        wireCap.safeParse(iso).success,
+        `epoch ${ms} produced ${JSON.stringify(iso)}, which the wire rejects`,
+      )
+    }
+  })
+})
 
 describe('applyUsage (bounding + aggregates)', () => {
   it('appends an entry and updates the per-skill aggregate', () => {


### PR DESCRIPTION
Closes #7081

## Problem

`skills.ts` `lastUsed` and control-room `RepoMemoryCache.lastModified` are `z.string().datetime()`, produced by `new Date(ms).toISOString()` from a number read off disk. Both guards checked **type** (finite, positive) while the schema constrains **range** — and there is a band where `toISOString()` *succeeds* but emits the expanded-year form the wire rejects:

```
253402300799999  -> '9999-12-31T23:59:59.999Z'    ACCEPTED
253402300800000  -> '+010000-01-01T00:00:00.000Z' REJECTED by .datetime()
1795000000000000 -> '+058851-04-14T23:06:40.000Z' REJECTED
8640000000000000 -> '+275760-09-13T00:00:00.000Z' REJECTED
8640000000000001 -> RangeError  (already caught into globalError — legal)
```

ES2015+ requires the `±YYYYYY` form once the year leaves `[0, 9999]`, and `.datetime()` only accepts a 4-digit year. The *narrow band* is the bug; above it the throw was already handled.

**For skills this is worse than a blank panel.** `dashboard/src/store/message-handler.ts:3621-3625` safeParses the whole message with a bare `return`, `skillsInventoryLoading` is cleared only on the success branch, and `connection.ts:2826-2828` derives `refreshDisabled = loading || !connected` — so **Refresh stays disabled for the life of the socket** and the operator cannot retry.

## Change

One shared helper rather than a third hand-rolled copy — `utils/iso-datetime.js` exporting `MAX_WIRE_DATETIME_MS` and `isoFromEpochMs()`.

**This is deliberately NOT the same bound as `scheduled-task-store.js`'s `MAX_EPOCH_MS`.** That one is *Date*-representable (±8.64e15); this one is *wire*-representable (year ≤ 9999). Conflating them reopens the bug, so the helper's doc says so explicitly.

**Null, not clamped.** Every consuming field is `.nullable()`, and a clamped timestamp is a *lie* rendered to the operator — "last used in the year 9999" is not more truthful than "never recorded", just harder to notice.

Three sites:

| Site | Role |
|---|---|
| `skills-usage.js` `normalizeAggregate` | bounds what gets **persisted** |
| `skills-inventory.js` | converts via the helper — covers any non-loader path |
| `integrations.js` | same shape for the repo-memory cache mtime |

Both fixed files show the near-miss that makes this a *forgetting* failure rather than a design choice: `count` already `Math.trunc`s to match its int cap, and `sizeBytes` is already `Math.max(0, Math.trunc(...))` — the adjacent field was bounded, this one wasn't.

`integrations.js` is unreachable today on APFS/ext4 (neither stores a year > 9999), but a network/FUSE mount or a deliberately-set mtime can, and fixing both together stops it reappearing.

## Verification

877 tests across `skills*`, `control-room*`, `iso-datetime` — 871 pass, 0 fail. 5/5 custom server lints, eslint clean.

Each guard mutation-verified **individually**:

| Mutation (applied alone) | Tests reddened |
|---|---|
| `skills-usage` drops the range clause (persist side) | 2 |
| `skills-inventory` reverts to raw `toISOString` (render side) | 2 — **disjoint** from the above |
| `integrations` reverts to raw `toISOString` | 1 |
| the helper's range check removed | 5 |
| *(restored)* | 18/18 green |

The persist-side and render-side mutations reddening *disjoint* tests is the point — either one alone would otherwise hide behind the other.

Worth a reviewer's eye:

- Every suite has a **CONTROL** (an ordinary timestamp round-trips and satisfies the real schema), so "it returned null" can't pass because everything returns null.
- One test asserts the guard is **not over-eager**: each value it refuses is one that `new Date(ms).toISOString()` renders *successfully* and the wire then rejects — so nothing legal is being dropped.
- The boundary is pinned at exactly `MAX_WIRE_DATETIME_MS` and `+1`, against the real `z.string().datetime()` rather than a hand-rolled regex, so if Zod ever widened to accept expanded years the test tells us the ceiling can rise.

## Context

Second of the two gaps from the 243-field wire-cap audit (#7080–#7086) that break a panel a user can actually see. The structural fix — an outbound `safeParse` so these are caught in CI instead of in production — is #7085.