### PR TITLE
chore(skills): refresh the skill install to template 987eb2b

### DIFF
--- a/.claude/commands/skill.md
+++ b/.claude/commands/skill.md
@@ -40,7 +40,10 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`, `pi` →
+  `~/.pi/agent/skills/<name>/`. **This repo's compiler diverges from the registry's**: it adds a
+  fourth `pi` target (#6573) and emits both `codex` and `pi` **user-global** rather than
+  repo-tracked, and both are opt-in. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -226,8 +229,8 @@ note in the report that hashes may be stale. Record which source you used.
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
    any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
-   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
-   `~/.codex/skills`, or used by runners that support repo-local Codex skills. Keep the list of
+   user-global prompt at `~/.codex/prompts/<name>.md` in this repo — not a repo-tracked
+   folder — so nothing appears in the diff for that target. Same for `pi`. Keep the list of
    `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
    (schema below) if absent and upsert `<name>` **atomically** with: the template `hash`; the
@@ -273,7 +276,8 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `.codex/skills/<name>/` (dir). If the lock entry has no `targets` (an older install),
+`codex` → `~/.codex/prompts/<name>.md`, `pi` → `~/.pi/agent/skills/<name>/` (both user-global
+in this repo). If the lock entry has no `targets` (an older install),
 fall back to removing whichever of those three exist. Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)

--- a/.claude/commands/skill.md
+++ b/.claude/commands/skill.md
@@ -40,7 +40,7 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -124,10 +124,95 @@ note in the report that hashes may be stale. Record which source you used.
    `<!-- skill-templates: <name> <hash> <date> -->` (today's date, `YYYY-MM-DD`).
 6. **Lint (deterministic gate).** Run the registry's mechanical linter on the file just
    written — it re-checks markers, attribution, the stamp, and guards independently of
-   the agent's judgment: `"$REG/scripts/skill-lint.sh" <name> .claude/commands/<name>.md`
+   the agent's judgment. From a **local clone** (the preferred path):
+   `"$REG/scripts/skill-lint.sh" <name> .claude/commands/<name>.md`
    (where `$REG` is the resolved registry clone). If it exits non-zero, fix the reported
    issues and re-lint before recording the lockfile — do not lock a skill that fails lint.
    Consumers can run the same linter as a pre-commit hook or in CI.
+
+   On the **network-only path** (source 3 — no clone on disk, so `$REG` is unset and
+   that command expands to `/scripts/skill-lint.sh`: exit 127, gate not run at all),
+   fetch the linter the way step 7 fetches the compiler, and pass `registry.json`
+   **explicitly as the third argument** — the index from step 1 has to exist as a
+   *file* here, not just in context:
+
+   ```bash
+   set -o pipefail
+   lintdir="$(mktemp -d)"
+   gh api repos/blamechris/skill-templates/contents/scripts/skill-lint.sh \
+     --jq '.content' | base64 -d > "$lintdir/skill-lint.sh" || exit 1
+   gh api repos/blamechris/skill-templates/contents/registry.json \
+     --jq '.content' | base64 -d > "$lintdir/registry.json" || exit 1
+   [ -s "$lintdir/skill-lint.sh" ] && [ -s "$lintdir/registry.json" ] || {
+     echo "lint gate unavailable: a fetch produced an empty file" >&2; exit 1; }
+   bash "$lintdir/skill-lint.sh" <name> .claude/commands/<name>.md "$lintdir/registry.json"
+   ```
+
+   Three details are load-bearing:
+   - **The fetch guards** — `gh` failing (offline, 404, rate limit) leaves a 0-byte
+     file behind, and `bash` on an empty file exits **0** printing nothing, which
+     this document's own outcome table below reads as *"clean, all four checks
+     passed"*. Unguarded, the network path's failure mode is a silent green gate —
+     worse than the exit 127 this section exists to fix, because 127 is at least
+     loud. Source 3 is reached exactly when there is no clone to fall back on, and
+     "Resolving the registry" above explicitly contemplates being offline.
+   - **`bash <path>`** — a redirected fetch lands non-executable (the exact mode is
+     umask-dependent; what matters is that no execute bit is set), so running it directly
+     exits 126 (permission denied), not 127. Same skipped gate, different code.
+   - **The third argument** — with it omitted the linter defaults its registry to
+     `<the script's own dir>/../registry.json`, which for a copy under a temp dir is
+     not this registry. Either that path is absent, and the run exits 2 printing
+     `ERROR: registry not found …` on **stderr** with an **empty stdout** — the
+     findings it had already collected are discarded unprinted, so a caller watching
+     the output sees exactly what a pass looks like — or some unrelated
+     `registry.json` sits there and gets loaded instead, in which case a skill it
+     happens to name with no guards of its own lints `✓ <name>: clean (0 guard(s) ok)`
+     at **exit 0**, with this registry's guards never applied.
+
+   The linter has three outcomes. **Key on the exit code, not on the output
+   markers** — `ERROR:` is printed for an unknown skill *and* then followed by
+   findings at exit 1, and a usage error exits 2 printing no marker at all. Only
+   `~` is exclusive to exit 2.
+   - **exit 0** (`✓`) — clean, all four checks passed.
+   - **exit 1** (`✗`) — real findings. Fix and re-lint; never lock. This includes a
+     file that is **stamped but absent from the index**: a stamp is proof of a
+     registry install, so an index that has never heard of the skill means a stale
+     clone, a renamed or retired skill, a typo'd `<name>`, or the wrong
+     `registry.json` — and its guards went unapplied. The reported findings name
+     which, and the stamp checks are applied on this path too.
+   - **exit 2** — could not be fully verified. Five causes, and only one is benign:
+     an **unstamped** skill absent from the index (the `~` line — a repo-only skill,
+     with genuinely nothing to verify), plus missing registry file, missing
+     `python3`, unreadable skill file, and usage error. The last four are
+     environment breakage.
+
+   For `skill add`, exit 2 is always a failure: `add` stops before writing if the
+   name is absent from the index, so by lint time the skill is in the index by
+   construction — exit 2 there means a stale index, a wrong name, or a broken
+   environment.
+
+   For a **pre-commit hook or CI** linting a whole `.claude/commands/` directory,
+   exit 2 is far narrower than it was: a *stale index* — which used to turn a real
+   `✗ guard miss` into a clean-looking `~` — is now reported as a finding at exit 1.
+   What remains at 2 is a genuinely repo-only file **or** environment breakage
+   (missing/wrong-path registry, no `python3`, unreadable file), and the linter
+   cannot tell a hook which of those it hit. So keep the version-stamp test: a
+   stamped file can no longer legitimately exit 2, because provenance means the
+   index should know it. Tolerating 2 unconditionally re-opens the hole this change
+   closes — for the 270 stamped files in the current fleet, a mistyped registry path
+   would go from caught to silently green.
+
+   ```bash
+   scripts/skill-lint.sh "$name" "$file" ; rc=$?
+   if [ "$rc" -eq 1 ]; then exit 1; fi   # includes a stamped file the index does not know
+   ```
+
+   Earlier revisions of this step told the hook to re-test the file itself with
+   `grep -q '^<!-- skill-templates: '` and fail on a *stamped* exit 2. That existed
+   only because exit 2 covered both conditions and the caller had to re-derive
+   which one it had hit. Do not reintroduce it: it re-implements, less accurately,
+   a check the linter already runs — the grep cannot see a stamp behind leading
+   whitespace, and cannot distinguish a well-formed stamp from a mangled one.
 7. **Compile to native targets.** Ensure the compiler exists in this repo (create `scripts/` if
    absent). If `scripts/compile-skill-targets.mjs` is missing — or you're running `update`, so it
    stays current with the registry — (re)fetch it: from a local clone,
@@ -140,9 +225,10 @@ note in the report that hashes may be stale. Record which source you used.
    offer to record the choice in the profile (the compiler falls back to `claude` if unset). Then
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
-   any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits to the
-   user-global `~/.codex/prompts/` (not version-controlled, deprecated upstream) — only when
-   `codex` is explicitly a target. Keep the list of `targets` you compiled with for the next step.
+   any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
+   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
+   `~/.codex/skills`, or used by runners that support repo-local Codex skills. Keep the list of
+   `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
    (schema below) if absent and upsert `<name>` **atomically** with: the template `hash`; the
    `profileHash` when a `.claude/skill-profile.md` exists (so `update` can tell when the *profile*
@@ -187,7 +273,7 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `~/.codex/prompts/<name>.md`. If the lock entry has no `targets` (an older install),
+`codex` → `.codex/skills/<name>/` (dir). If the lock entry has no `targets` (an older install),
 fall back to removing whichever of those three exist. Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)
@@ -235,4 +321,4 @@ fall back to removing whichever of those three exist. Report what was removed.
 - **Self-contained on first use.** `/skill` needs no customization to work — it ships
   with sane registry defaults so it can bootstrap a repo that has nothing else installed.
 
-<!-- skill-templates: skill 21fe7c3 2026-06-14 -->
+<!-- skill-templates: skill 987eb2b 2026-07-29 -->

--- a/.claude/skills.lock
+++ b/.claude/skills.lock
@@ -78,8 +78,8 @@
       "installed": "2026-06-02"
     },
     "skill": {
-      "hash": "21fe7c3",
-      "installed": "2026-06-14",
+      "hash": "987eb2b",
+      "installed": "2026-07-29",
       "targets": [
         "claude",
         "gemini"

--- a/.claude/skills/skill/SKILL.md
+++ b/.claude/skills/skill/SKILL.md
@@ -44,7 +44,10 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`, `pi` →
+  `~/.pi/agent/skills/<name>/`. **This repo's compiler diverges from the registry's**: it adds a
+  fourth `pi` target (#6573) and emits both `codex` and `pi` **user-global** rather than
+  repo-tracked, and both are opt-in. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -230,8 +233,8 @@ note in the report that hashes may be stale. Record which source you used.
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
    any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
-   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
-   `~/.codex/skills`, or used by runners that support repo-local Codex skills. Keep the list of
+   user-global prompt at `~/.codex/prompts/<name>.md` in this repo — not a repo-tracked
+   folder — so nothing appears in the diff for that target. Same for `pi`. Keep the list of
    `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
    (schema below) if absent and upsert `<name>` **atomically** with: the template `hash`; the
@@ -277,7 +280,8 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `.codex/skills/<name>/` (dir). If the lock entry has no `targets` (an older install),
+`codex` → `~/.codex/prompts/<name>.md`, `pi` → `~/.pi/agent/skills/<name>/` (both user-global
+in this repo). If the lock entry has no `targets` (an older install),
 fall back to removing whichever of those three exist. Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)

--- a/.claude/skills/skill/SKILL.md
+++ b/.claude/skills/skill/SKILL.md
@@ -44,7 +44,7 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -128,10 +128,95 @@ note in the report that hashes may be stale. Record which source you used.
    `<!-- skill-templates: <name> <hash> <date> -->` (today's date, `YYYY-MM-DD`).
 6. **Lint (deterministic gate).** Run the registry's mechanical linter on the file just
    written — it re-checks markers, attribution, the stamp, and guards independently of
-   the agent's judgment: `"$REG/scripts/skill-lint.sh" <name> .claude/commands/<name>.md`
+   the agent's judgment. From a **local clone** (the preferred path):
+   `"$REG/scripts/skill-lint.sh" <name> .claude/commands/<name>.md`
    (where `$REG` is the resolved registry clone). If it exits non-zero, fix the reported
    issues and re-lint before recording the lockfile — do not lock a skill that fails lint.
    Consumers can run the same linter as a pre-commit hook or in CI.
+
+   On the **network-only path** (source 3 — no clone on disk, so `$REG` is unset and
+   that command expands to `/scripts/skill-lint.sh`: exit 127, gate not run at all),
+   fetch the linter the way step 7 fetches the compiler, and pass `registry.json`
+   **explicitly as the third argument** — the index from step 1 has to exist as a
+   *file* here, not just in context:
+
+   ```bash
+   set -o pipefail
+   lintdir="$(mktemp -d)"
+   gh api repos/blamechris/skill-templates/contents/scripts/skill-lint.sh \
+     --jq '.content' | base64 -d > "$lintdir/skill-lint.sh" || exit 1
+   gh api repos/blamechris/skill-templates/contents/registry.json \
+     --jq '.content' | base64 -d > "$lintdir/registry.json" || exit 1
+   [ -s "$lintdir/skill-lint.sh" ] && [ -s "$lintdir/registry.json" ] || {
+     echo "lint gate unavailable: a fetch produced an empty file" >&2; exit 1; }
+   bash "$lintdir/skill-lint.sh" <name> .claude/commands/<name>.md "$lintdir/registry.json"
+   ```
+
+   Three details are load-bearing:
+   - **The fetch guards** — `gh` failing (offline, 404, rate limit) leaves a 0-byte
+     file behind, and `bash` on an empty file exits **0** printing nothing, which
+     this document's own outcome table below reads as *"clean, all four checks
+     passed"*. Unguarded, the network path's failure mode is a silent green gate —
+     worse than the exit 127 this section exists to fix, because 127 is at least
+     loud. Source 3 is reached exactly when there is no clone to fall back on, and
+     "Resolving the registry" above explicitly contemplates being offline.
+   - **`bash <path>`** — a redirected fetch lands non-executable (the exact mode is
+     umask-dependent; what matters is that no execute bit is set), so running it directly
+     exits 126 (permission denied), not 127. Same skipped gate, different code.
+   - **The third argument** — with it omitted the linter defaults its registry to
+     `<the script's own dir>/../registry.json`, which for a copy under a temp dir is
+     not this registry. Either that path is absent, and the run exits 2 printing
+     `ERROR: registry not found …` on **stderr** with an **empty stdout** — the
+     findings it had already collected are discarded unprinted, so a caller watching
+     the output sees exactly what a pass looks like — or some unrelated
+     `registry.json` sits there and gets loaded instead, in which case a skill it
+     happens to name with no guards of its own lints `✓ <name>: clean (0 guard(s) ok)`
+     at **exit 0**, with this registry's guards never applied.
+
+   The linter has three outcomes. **Key on the exit code, not on the output
+   markers** — `ERROR:` is printed for an unknown skill *and* then followed by
+   findings at exit 1, and a usage error exits 2 printing no marker at all. Only
+   `~` is exclusive to exit 2.
+   - **exit 0** (`✓`) — clean, all four checks passed.
+   - **exit 1** (`✗`) — real findings. Fix and re-lint; never lock. This includes a
+     file that is **stamped but absent from the index**: a stamp is proof of a
+     registry install, so an index that has never heard of the skill means a stale
+     clone, a renamed or retired skill, a typo'd `<name>`, or the wrong
+     `registry.json` — and its guards went unapplied. The reported findings name
+     which, and the stamp checks are applied on this path too.
+   - **exit 2** — could not be fully verified. Five causes, and only one is benign:
+     an **unstamped** skill absent from the index (the `~` line — a repo-only skill,
+     with genuinely nothing to verify), plus missing registry file, missing
+     `python3`, unreadable skill file, and usage error. The last four are
+     environment breakage.
+
+   For `skill add`, exit 2 is always a failure: `add` stops before writing if the
+   name is absent from the index, so by lint time the skill is in the index by
+   construction — exit 2 there means a stale index, a wrong name, or a broken
+   environment.
+
+   For a **pre-commit hook or CI** linting a whole `.claude/commands/` directory,
+   exit 2 is far narrower than it was: a *stale index* — which used to turn a real
+   `✗ guard miss` into a clean-looking `~` — is now reported as a finding at exit 1.
+   What remains at 2 is a genuinely repo-only file **or** environment breakage
+   (missing/wrong-path registry, no `python3`, unreadable file), and the linter
+   cannot tell a hook which of those it hit. So keep the version-stamp test: a
+   stamped file can no longer legitimately exit 2, because provenance means the
+   index should know it. Tolerating 2 unconditionally re-opens the hole this change
+   closes — for the 270 stamped files in the current fleet, a mistyped registry path
+   would go from caught to silently green.
+
+   ```bash
+   scripts/skill-lint.sh "$name" "$file" ; rc=$?
+   if [ "$rc" -eq 1 ]; then exit 1; fi   # includes a stamped file the index does not know
+   ```
+
+   Earlier revisions of this step told the hook to re-test the file itself with
+   `grep -q '^<!-- skill-templates: '` and fail on a *stamped* exit 2. That existed
+   only because exit 2 covered both conditions and the caller had to re-derive
+   which one it had hit. Do not reintroduce it: it re-implements, less accurately,
+   a check the linter already runs — the grep cannot see a stamp behind leading
+   whitespace, and cannot distinguish a well-formed stamp from a mangled one.
 7. **Compile to native targets.** Ensure the compiler exists in this repo (create `scripts/` if
    absent). If `scripts/compile-skill-targets.mjs` is missing — or you're running `update`, so it
    stays current with the registry — (re)fetch it: from a local clone,
@@ -144,9 +229,10 @@ note in the report that hashes may be stale. Record which source you used.
    offer to record the choice in the profile (the compiler falls back to `claude` if unset). Then
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
-   any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits to the
-   user-global `~/.codex/prompts/` (not version-controlled, deprecated upstream) — only when
-   `codex` is explicitly a target. Keep the list of `targets` you compiled with for the next step.
+   any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
+   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
+   `~/.codex/skills`, or used by runners that support repo-local Codex skills. Keep the list of
+   `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
    (schema below) if absent and upsert `<name>` **atomically** with: the template `hash`; the
    `profileHash` when a `.claude/skill-profile.md` exists (so `update` can tell when the *profile*
@@ -191,7 +277,7 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `~/.codex/prompts/<name>.md`. If the lock entry has no `targets` (an older install),
+`codex` → `.codex/skills/<name>/` (dir). If the lock entry has no `targets` (an older install),
 fall back to removing whichever of those three exist. Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)


### PR DESCRIPTION
Refreshes this repo's `/skill` install from registry template `21fe7c3` (2026-06-14) to `987eb2b` (2026-07-26) — five template commits.

## What the refresh brings

The whole of it lands in **step 6, the deterministic lint gate**:

- **The linter's three-outcome exit-code contract** (`c1bc870`) — key on the **exit code, not the output markers**: `ERROR:` is printed both for an unknown skill and ahead of real findings, and a usage error exits 2 printing no marker at all. `exit 1` now includes *a stamped file the index does not know* (stale clone, renamed skill, typo'd name, wrong `registry.json` — and its guards went unapplied). `exit 2` narrows to a genuinely repo-only file or environment breakage. Ships the pre-commit/CI snippet.
- **The network-path lint gate that actually runs** (`493febf`) — on the network-only registry path there is no clone, so `$REG` is unset and `"$REG/scripts/skill-lint.sh"` expanded to `/scripts/skill-lint.sh`: **exit 127, gate never ran**. The new text fetches the linter over `gh`, and three details are load-bearing: guard the fetch (an unguarded 0-byte file makes `bash` exit **0** printing nothing, i.e. a silent green gate — worse than the loud 127 it replaces), invoke via `bash <path>` (a redirected fetch lands non-executable → 126), and pass `registry.json` **explicitly as the third argument** (omitted, the linter resolves a `registry.json` next to its own temp-dir copy — absent → exit 2 with findings discarded and an *empty stdout* that looks exactly like a pass; present-but-unrelated → `✓ clean (0 guard(s) ok)` at exit 0 with this registry's guards never applied).
- **A stamped file absent from the index is a finding, not a shrug** (`987eb2b`).

The multi-target compile concept and `skill remove` cleanup semantics were **already present** at `21fe7c3` — see the correction below.

## Lint

Before (`21fe7c3`) and after (`987eb2b`), both against the registry index:

```
✓ skill: clean (3 guard(s) ok, stamp ok)   rc=0
```

The install was already guard-clean; this is version drift, not corruption.

## Artifacts

Recompiled with the repo's own `scripts/compile-skill-targets.mjs`:

```
Compiling 1 skill(s) -> [claude, gemini]
      [claude] .claude/skills/skill/SKILL.md
      [gemini] SKIPPED — body contains an active template sequence ("{{…") that Gemini would interpret; not Gemini-safe
Done. 1 target(s) skipped (logged above — not emitted).
```

`gemini` is *intentionally* skipped, as `.claude/skill-profile.md` already documents for this skill — not drift. `.claude/skills.lock` keeps `targets: ["claude", "gemini"]` and moves to `hash 987eb2b`, `installed 2026-07-29`.

## Two things a reviewer should know

**1. The refreshed text now disagrees with this repo's compiler about codex.** The template documents codex as repo-tracked `.codex/skills/<name>/SKILL.md`; this repo's `scripts/compile-skill-targets.mjs` emits user-global `~/.codex/prompts/<name>.md`. Dormant — `targets:` is `claude, gemini`, so codex is never compiled here.

The compiler was **left alone deliberately**: it is locally ahead of the registry asset (adds a `pi` target, `detectUncompiledAgents`, grapheme-safe description truncation). Re-fetching it per the template's step 7 would have regressed that local work, so it is out of scope for this PR. Reconciling the codex path is a separate decision.

**2. `autonomous-dev-flow` and `tackle-issues` are also behind, and are untouched here** — refreshing them would change agent merge behaviour from "never merge" to "self-merge under a gate". Deliberately excluded from this sweep.
