### PR TITLE
test(server): pin outbound schema coverage with a derived frame registry

### DIFF
--- a/packages/server/src/ws-outbound-schemas.js
+++ b/packages/server/src/ws-outbound-schemas.js
@@ -1,0 +1,104 @@
+/**
+ * #7085 — the outbound (server → client) schema registry, DERIVED not declared.
+ *
+ * The 243-field wire-cap audit found 8 "store-legal / wire-illegal" fields: the
+ * server held a value its outbound schema rejects, so a client's `safeParse` of the
+ * whole snapshot failed and a panel rendered nothing while N live items existed.
+ * Every one of them would have been caught by validating outbound messages. The
+ * server does not: `ws-server.js`'s only `safeParse` calls are INBOUND, and
+ * `event-normalizer.js` says outright that outgoing messages are not validated.
+ *
+ * A gate needs to know which schema governs a given message. There is no union to
+ * ask — despite the name, `ServerMessageSchema` is the schema for a single
+ * `type: 'message'` frame, and no discriminated union over server messages exists.
+ *
+ * So the registry is built by INTROSPECTION: every `Server*Schema` export whose
+ * shape carries a `type: z.literal(...)` registers itself under that literal. This
+ * is deliberate rather than a convenience — a hand-maintained 151-entry map is
+ * exactly the kind of parallel list this codebase has repeatedly watched drift out
+ * of sync with its source of truth (see the BASE_SESSION_OPT_KEYS lint, the
+ * protocol handler-coverage lint, and the `clampWire` caps that were retyped in
+ * three loaders). A derived map cannot drift, and a frame with no schema is
+ * detectable by ABSENCE rather than by someone remembering to add an arm.
+ *
+ * Schemas WITHOUT a `type` literal are correctly excluded: they are sub-objects
+ * (`ServerSessionListEntrySchema`, `ServerPermissionAuditEntrySchema`, …) reached
+ * through a parent frame, not frames in their own right.
+ *
+ * A type may map to MORE THAN ONE schema. `type: 'error'` is claimed by both
+ * `ServerErrorEnvelopeSchema` and `ServerSkillTrustGrantInvalidAuthorSchema`, so the
+ * registry stores a list per type and a message is valid if ANY arm accepts it.
+ * Keying one-schema-per-type would silently validate half the `error` frames against
+ * the wrong shape.
+ */
+
+import * as protocol from '@chroxy/protocol'
+
+/** Pull the `type` literal out of a Zod object schema, or null if it has none. */
+function typeLiteralOf(schema) {
+  // Zod exposes `.shape` on object schemas; older/inner forms keep it on `_def`.
+  const shape = schema?.shape ?? schema?._def?.shape
+  const value = shape?.type?.value
+  return typeof value === 'string' ? value : null
+}
+
+function buildRegistry() {
+  /** @type {Map<string, Array<{ name: string, schema: object }>>} */
+  const byType = new Map()
+  const nonFrame = []
+  for (const [name, schema] of Object.entries(protocol)) {
+    if (!name.startsWith('Server') || !name.endsWith('Schema')) continue
+    const type = typeLiteralOf(schema)
+    if (type === null) {
+      nonFrame.push(name)
+      continue
+    }
+    if (!byType.has(type)) byType.set(type, [])
+    byType.get(type).push({ name, schema })
+  }
+  return { byType, nonFrame }
+}
+
+const { byType: REGISTRY, nonFrame: NON_FRAME_SCHEMAS } = buildRegistry()
+
+/** Every outbound message `type` that has at least one schema. */
+export const SCHEMA_BACKED_OUTBOUND_TYPES = Object.freeze([...REGISTRY.keys()].sort())
+
+/** `Server*Schema` exports with no `type` literal — sub-objects, not frames. */
+export const NON_FRAME_SCHEMA_NAMES = Object.freeze([...NON_FRAME_SCHEMAS].sort())
+
+/**
+ * Schemas governing a message `type`, or an empty array when the type is unknown
+ * to the protocol package.
+ *
+ * An empty array is the signal a gate must NOT treat as "valid": it means nothing
+ * describes this frame, which is the vacuous-pass failure mode.
+ *
+ * @param {string} type
+ * @returns {Array<{ name: string, schema: object }>}
+ */
+export function outboundSchemasForType(type) {
+  return REGISTRY.get(type) ?? []
+}
+
+/**
+ * Validate an outbound message against its registered schema(s).
+ *
+ * @param {unknown} message
+ * @returns {{ ok: true } | { ok: false, reason: 'no-type' | 'no-schema' | 'invalid', type?: string, schema?: string, issue?: object }}
+ */
+export function validateOutbound(message) {
+  const type = message && typeof message === 'object' ? message.type : undefined
+  if (typeof type !== 'string') return { ok: false, reason: 'no-type' }
+  const arms = outboundSchemasForType(type)
+  if (arms.length === 0) return { ok: false, reason: 'no-schema', type }
+  let first = null
+  for (const { name, schema } of arms) {
+    const result = schema.safeParse(message)
+    if (result.success) return { ok: true }
+    // Report the FIRST arm's complaint. With multiple arms the others' errors are
+    // noise — a message is meant to match exactly one shape.
+    if (!first) first = { schema: name, issue: result.error.issues[0] }
+  }
+  return { ok: false, reason: 'invalid', type, ...first }
+}

--- a/packages/server/src/ws-outbound-schemas.js
+++ b/packages/server/src/ws-outbound-schemas.js
@@ -14,7 +14,7 @@
  *
  * So the registry is built by INTROSPECTION: every `Server*Schema` export whose
  * shape carries a `type: z.literal(...)` registers itself under that literal. This
- * is deliberate rather than a convenience — a hand-maintained 151-entry map is
+ * is deliberate rather than a convenience — a hand-maintained 153-entry map is
  * exactly the kind of parallel list this codebase has repeatedly watched drift out
  * of sync with its source of truth (see the BASE_SESSION_OPT_KEYS lint, the
  * protocol handler-coverage lint, and the `clampWire` caps that were retyped in
@@ -74,10 +74,22 @@ export function typeLiteralsOf(schema) {
   }
   const type = shapeOf(schema)?.type
   if (!type) return out
-  // A literal exposes `.value`; some versions expose a `values` collection instead.
-  if (typeof type.value === 'string') out.add(type.value)
+  // `values` FIRST, deliberately. On a multi-value literal (`z.literal(['a','b'])`)
+  // reading `.value` THROWS — and this runs inside a top-level buildRegistry(), so
+  // that would be a module-load crash, not a silent miss. `_def.values` is populated
+  // for the single-value case too (`z.literal('a')._def.values === ['a']`), so
+  // values-first covers both and `.value` is only a fallback for older shapes.
   const values = type?._def?.values ?? type?.options
-  if (values) for (const v of values) if (typeof v === 'string') out.add(v)
+  if (values) {
+    for (const v of values) if (typeof v === 'string') out.add(v)
+    if (out.size > 0) return out
+  }
+  try {
+    if (typeof type.value === 'string') out.add(type.value)
+  } catch {
+    // A throwing accessor means we could not read it — leave `out` empty so the
+    // caller files this under UNREADABLE rather than treating it as a non-frame.
+  }
   return out
 }
 
@@ -96,11 +108,23 @@ export function typeLiteralsOf(schema) {
 function looksLikeNonFrame(schema) {
   const arms = unionArmsOf(schema)
   if (arms) return arms.every((arm) => looksLikeNonFrame(arm))
+
+  // FAIL LOUD BY DEFAULT. Only a plain object can be a legitimate sub-object. Any
+  // other combinator — intersection, pipe, transform, catch, default, optional,
+  // nullable, readonly, lazy — hides `.shape`, so keying "non-frame" off a missing
+  // shape would file every one of them as legitimately excluded and the invariant
+  // would defend the union case and nothing else. Reporting them instead means a
+  // frame wrapped in a combinator surfaces as UNREADABLE rather than vanishing.
+  const kind = schema?._def?.type ?? schema?._def?.typeName
+  if (kind !== 'object' && kind !== 'ZodObject') return false
+
   const type = shapeOf(schema)?.type
   if (type === undefined) return true
-  const kind = type?._def?.type ?? type?._def?.typeName
-  // Only a literal (or an enum of literals) can discriminate a frame.
-  return kind !== 'literal' && kind !== 'ZodLiteral' && kind !== 'enum' && kind !== 'ZodEnum'
+  const typeKind = type?._def?.type ?? type?._def?.typeName
+  // Only a literal (or an enum of literals) can discriminate a frame; a `type` that
+  // is ordinary data (ServerPermissionAuditEntrySchema.type is z.string(), naming the
+  // audited tool) does not make its owner a frame.
+  return typeKind !== 'literal' && typeKind !== 'ZodLiteral' && typeKind !== 'enum' && typeKind !== 'ZodEnum'
 }
 
 function buildRegistry() {
@@ -125,6 +149,9 @@ function buildRegistry() {
   }
   return { byType, nonFrame, unreadable }
 }
+
+/** Exposed for the coverage test — the classifier's bias is the invariant's whole value. */
+export const looksLikeNonFrameForTests = looksLikeNonFrame
 
 const { byType: REGISTRY, nonFrame: NON_FRAME_SCHEMAS, unreadable: UNREADABLE_SCHEMAS } = buildRegistry()
 

--- a/packages/server/src/ws-outbound-schemas.js
+++ b/packages/server/src/ws-outbound-schemas.js
@@ -34,32 +34,108 @@
 
 import * as protocol from '@chroxy/protocol'
 
-/** Pull the `type` literal out of a Zod object schema, or null if it has none. */
-function typeLiteralOf(schema) {
-  // Zod exposes `.shape` on object schemas; older/inner forms keep it on `_def`.
+/** Zod object shape, whichever way this version exposes it. */
+function shapeOf(schema) {
   const shape = schema?.shape ?? schema?._def?.shape
-  const value = shape?.type?.value
-  return typeof value === 'string' ? value : null
+  // A shape can be lazily defined as a getter/thunk.
+  return typeof shape === 'function' ? shape() : shape
+}
+
+/** The union arms of a schema, or null when it is not a union. */
+function unionArmsOf(schema) {
+  const def = schema?._def
+  const kind = def?.type ?? def?.typeName
+  if (kind !== 'union' && kind !== 'discriminatedUnion' && kind !== 'ZodUnion' && kind !== 'ZodDiscriminatedUnion') return null
+  const options = def?.options ?? schema?.options
+  return options ? [...options] : null
+}
+
+/**
+ * Every `type` literal a schema can produce.
+ *
+ * Returns a Set because a UNION is still one frame schema but reaches the
+ * registry through each arm's literal. Missing this is not a cosmetic gap: a
+ * union-shaped frame schema has no top-level `.shape`, so a naive
+ * `shape.type.value` lookup drops it SILENTLY and the frame then looks
+ * schema-less. That is exactly what happened to `evaluate_draft_result`
+ * (ServerEvaluateDraftResultSchema) and `permission_input`
+ * (ServerPermissionInputSchema) — both real frames, both briefly recorded as
+ * uncovered because of it.
+ *
+ * @param {object} schema
+ * @returns {Set<string>}
+ */
+export function typeLiteralsOf(schema) {
+  const out = new Set()
+  const arms = unionArmsOf(schema)
+  if (arms) {
+    for (const arm of arms) for (const t of typeLiteralsOf(arm)) out.add(t)
+    return out
+  }
+  const type = shapeOf(schema)?.type
+  if (!type) return out
+  // A literal exposes `.value`; some versions expose a `values` collection instead.
+  if (typeof type.value === 'string') out.add(type.value)
+  const values = type?._def?.values ?? type?.options
+  if (values) for (const v of values) if (typeof v === 'string') out.add(v)
+  return out
+}
+
+/**
+ * True when a schema is a sub-object rather than a frame.
+ *
+ * A frame is discriminated by a `type` LITERAL. A schema whose `type` is ordinary
+ * data — `ServerPermissionAuditEntrySchema.type` is `z.string()`, naming the audited
+ * tool — is not a frame, and neither is one with no `type` at all.
+ *
+ * Classifying on "has a type field" instead of "has a type LITERAL" is too crude and
+ * flagged that audit-entry schema as unreadable. The distinction that matters is
+ * between a legitimate exclusion and a SILENT DROP, so the rule is: no literal to
+ * read is fine; a literal we failed to read is not.
+ */
+function looksLikeNonFrame(schema) {
+  const arms = unionArmsOf(schema)
+  if (arms) return arms.every((arm) => looksLikeNonFrame(arm))
+  const type = shapeOf(schema)?.type
+  if (type === undefined) return true
+  const kind = type?._def?.type ?? type?._def?.typeName
+  // Only a literal (or an enum of literals) can discriminate a frame.
+  return kind !== 'literal' && kind !== 'ZodLiteral' && kind !== 'enum' && kind !== 'ZodEnum'
 }
 
 function buildRegistry() {
   /** @type {Map<string, Array<{ name: string, schema: object }>>} */
   const byType = new Map()
   const nonFrame = []
+  const unreadable = []
   for (const [name, schema] of Object.entries(protocol)) {
     if (!name.startsWith('Server') || !name.endsWith('Schema')) continue
-    const type = typeLiteralOf(schema)
-    if (type === null) {
-      nonFrame.push(name)
+    const types = typeLiteralsOf(schema)
+    if (types.size === 0) {
+      // No literal extracted. Either it genuinely has no `type` field (fine), or it
+      // has one this code could not read (NOT fine — that is the silent drop).
+      if (looksLikeNonFrame(schema)) nonFrame.push(name)
+      else unreadable.push(name)
       continue
     }
-    if (!byType.has(type)) byType.set(type, [])
-    byType.get(type).push({ name, schema })
+    for (const type of types) {
+      if (!byType.has(type)) byType.set(type, [])
+      byType.get(type).push({ name, schema })
+    }
   }
-  return { byType, nonFrame }
+  return { byType, nonFrame, unreadable }
 }
 
-const { byType: REGISTRY, nonFrame: NON_FRAME_SCHEMAS } = buildRegistry()
+const { byType: REGISTRY, nonFrame: NON_FRAME_SCHEMAS, unreadable: UNREADABLE_SCHEMAS } = buildRegistry()
+
+/**
+ * Schemas that DO carry a `type` field whose literal could not be extracted.
+ *
+ * Must always be empty. A non-empty list means the derivation silently dropped a
+ * frame and the coverage numbers are understated — so the test asserts on it
+ * rather than leaving it to be noticed.
+ */
+export const UNREADABLE_FRAME_SCHEMA_NAMES = Object.freeze([...UNREADABLE_SCHEMAS].sort())
 
 /** Every outbound message `type` that has at least one schema. */
 export const SCHEMA_BACKED_OUTBOUND_TYPES = Object.freeze([...REGISTRY.keys()].sort())

--- a/packages/server/tests/ws-outbound-coverage.test.js
+++ b/packages/server/tests/ws-outbound-coverage.test.js
@@ -1,0 +1,157 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  SCHEMA_BACKED_OUTBOUND_TYPES,
+  NON_FRAME_SCHEMA_NAMES,
+  outboundSchemasForType,
+  validateOutbound,
+} from '../src/ws-outbound-schemas.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const WS_SERVER = join(HERE, '..', 'src', 'ws-server.js')
+
+/**
+ * #7085 — outbound schema COVERAGE.
+ *
+ * The server does not validate what it sends, which is how 8 wire-illegal fields
+ * reached main (the #7080-#7086 audit). Before a runtime gate can be switched on,
+ * every frame the server sends needs a schema — otherwise the gate passes
+ * vacuously on exactly the frames nothing describes.
+ *
+ * This suite does NOT gate sends. It pins coverage, so a NEW undocumented-by-schema
+ * frame fails CI the day it is added rather than years later.
+ *
+ * UNSCHEMAD is a SHRINKING allowlist. Two assertions keep it honest:
+ *   - a roster type that is neither schema-backed nor allowlisted FAILS (no growth)
+ *   - an allowlisted type that HAS gained a schema FAILS until removed (no rot)
+ * The second is the one that matters: without it the list would still be 30 entries
+ * long after the schemas landed, and nobody would notice.
+ */
+
+// The 30 frames the server documents sending that have no outbound schema, measured
+// against the roster in ws-server.js. Delete entries as schemas land — the test
+// below fails if you forget.
+const UNSCHEMAD = new Set([
+  'agent_list',
+  'available_permission_modes',
+  'confirm_permission_mode',
+  'dev_preview',
+  'dev_preview_stopped',
+  'discovered_sessions',
+  'encrypted',
+  'evaluate_draft_result',
+  'file_list',
+  'file_listing',
+  'git_commit_result',
+  'git_stage_result',
+  'git_unstage_result',
+  'history_replay_end',
+  'history_replay_start',
+  'log_entry',
+  'pairing_refreshed',
+  'permission_input',
+  'permission_rules_updated',
+  'primary_changed',
+  'server_mode',
+  'server_status',
+  'session_context',
+  'session_created',
+  'session_destroyed',
+  'session_role',
+  'session_switched',
+  'slash_commands',
+  'status',
+  'token_rotated',
+])
+
+/** Outbound types the server documents in ws-server.js's `Server -> Client:` roster. */
+function rosterTypes() {
+  const lines = readFileSync(WS_SERVER, 'utf8').split('\n')
+  const start = lines.findIndex((l) => l.includes('Server -> Client:'))
+  assert.ok(start > 0, 'the Server -> Client roster must exist in ws-server.js')
+  const found = new Set()
+  for (const line of lines.slice(start + 1)) {
+    // The roster is one JSDoc block; the first non-`*` line ends it.
+    if (!line.trimStart().startsWith('*')) break
+    for (const m of line.matchAll(/\{\s*type:\s*'([a-z0-9_]+)'/g)) found.add(m[1])
+  }
+  return [...found].sort()
+}
+
+describe('#7085 outbound schema coverage', () => {
+  it('CONTROL: the registry and the roster are both non-trivially populated', () => {
+    // Guards against the whole suite passing because a parse silently yielded
+    // nothing — every assertion below is vacuously true on an empty set.
+    assert.ok(SCHEMA_BACKED_OUTBOUND_TYPES.length > 100, `registry looks empty: ${SCHEMA_BACKED_OUTBOUND_TYPES.length}`)
+    assert.ok(rosterTypes().length > 100, `roster parse looks empty: ${rosterTypes().length}`)
+  })
+
+  it('every documented outbound type has a schema, or is a known gap', () => {
+    const gaps = rosterTypes().filter((t) => !outboundSchemasForType(t).length && !UNSCHEMAD.has(t))
+    assert.deepEqual(
+      gaps, [],
+      `new outbound frame(s) with no schema in @chroxy/protocol: ${gaps.join(', ')}. ` +
+      'Add a Server<Name>Schema with a  literal (it registers itself), or — only ' +
+      'if the frame genuinely cannot be described — add it to UNSCHEMAD with a reason.',
+    )
+  })
+
+  it('the allowlist only shrinks: no entry may still be listed once it has a schema', () => {
+    const fixed = [...UNSCHEMAD].filter((t) => outboundSchemasForType(t).length > 0)
+    assert.deepEqual(
+      fixed, [],
+      `these now HAVE schemas and must be deleted from UNSCHEMAD: ${fixed.join(', ')}`,
+    )
+  })
+
+  it('every allowlisted type is really one the server documents sending', () => {
+    // Stops the list accumulating entries for frames that no longer exist.
+    const roster = new Set(rosterTypes())
+    const stale = [...UNSCHEMAD].filter((t) => !roster.has(t))
+    assert.deepEqual(stale, [], `UNSCHEMAD entries not in the roster (stale): ${stale.join(', ')}`)
+  })
+
+  it('a type claimed by two schemas keeps BOTH arms', () => {
+    // `error` is claimed by ServerErrorEnvelopeSchema and
+    // ServerSkillTrustGrantInvalidAuthorSchema. Keying one-schema-per-type would
+    // validate half the error frames against the wrong shape.
+    const arms = outboundSchemasForType('error')
+    assert.ok(arms.length >= 2, `expected >= 2 arms for 'error', got ${arms.map((a) => a.name).join(', ')}`)
+  })
+
+  it('sub-object schemas are excluded from the frame registry', () => {
+    // These are reached THROUGH a frame, so registering them would invent frame
+    // types that no sender ever emits.
+    assert.ok(NON_FRAME_SCHEMA_NAMES.includes('ServerSessionListEntrySchema'))
+    assert.equal(outboundSchemasForType('').length, 0)
+  })
+
+  describe('validateOutbound', () => {
+    it('accepts a well-formed frame', () => {
+      const r = validateOutbound({ type: 'available_models', models: [], defaultModel: 'm', provider: null })
+      assert.equal(r.ok, true, `expected valid, got ${JSON.stringify(r)}`)
+    })
+
+    it('reports an unknown type as no-schema rather than valid', () => {
+      // The vacuous-pass failure mode this whole exercise exists to prevent.
+      const r = validateOutbound({ type: 'definitely_not_a_real_frame' })
+      assert.equal(r.ok, false)
+      assert.equal(r.reason, 'no-schema')
+    })
+
+    it('reports a schema violation with the offending path', () => {
+      const r = validateOutbound({ type: 'available_models', models: [], defaultModel: null })
+      assert.equal(r.ok, false)
+      assert.equal(r.reason, 'invalid')
+      assert.deepEqual(r.issue.path, ['defaultModel'], 'the caller needs the field, not just a boolean')
+    })
+
+    it('reports a message with no type at all', () => {
+      assert.equal(validateOutbound({ nope: 1 }).reason, 'no-type')
+      assert.equal(validateOutbound(null).reason, 'no-type')
+    })
+  })
+})

--- a/packages/server/tests/ws-outbound-coverage.test.js
+++ b/packages/server/tests/ws-outbound-coverage.test.js
@@ -3,8 +3,12 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
+import { z } from 'zod'
+import * as protocol from '@chroxy/protocol'
 import {
   SCHEMA_BACKED_OUTBOUND_TYPES,
+  typeLiteralsOf,
+  looksLikeNonFrameForTests,
   NON_FRAME_SCHEMA_NAMES,
   UNREADABLE_FRAME_SCHEMA_NAMES,
   outboundSchemasForType,
@@ -32,13 +36,20 @@ const WS_SERVER = join(HERE, '..', 'src', 'ws-server.js')
  * long after the schemas landed, and nobody would notice.
  */
 
-// The 28 frames the server documents sending that have no outbound schema, measured
+/**
+ * Frames excluded from the coverage requirement because they are TRANSPORT rather than
+ * semantic frames — and the exclusion is CHECKED, not merely asserted in prose.
+ *
+ * `encrypted` is the E2E envelope. It DOES have a schema (`EncryptedEnvelopeSchema`),
+ * just under a name the registry's `Server*` filter cannot see — so it was sitting in
+ * UNSCHEMAD where the shrink guard could never fire for it: permanent rot in exactly
+ * the form that assertion is blind to.
+ */
+const TRANSPORT_FRAMES = new Map([['encrypted', 'EncryptedEnvelopeSchema']])
+
+// The 27 frames the server documents sending that have no outbound schema, measured
 // against the roster in ws-server.js. Delete entries as schemas land — the test
 // below fails if you forget.
-//
-// `encrypted` is arguably a legitimate permanent entry (it is the E2E envelope
-// wrapper, not a semantic frame) — left in the list rather than special-cased so
-// the decision is made deliberately when someone gets to it.
 const UNSCHEMAD = new Set([
   'agent_list',
   'available_permission_modes',
@@ -46,7 +57,6 @@ const UNSCHEMAD = new Set([
   'dev_preview',
   'dev_preview_stopped',
   'discovered_sessions',
-  'encrypted',
   'file_list',
   'file_listing',
   'git_commit_result',
@@ -88,12 +98,23 @@ describe('#7085 outbound schema coverage', () => {
   it('CONTROL: the registry and the roster are both non-trivially populated', () => {
     // Guards against the whole suite passing because a parse silently yielded
     // nothing — every assertion below is vacuously true on an empty set.
-    assert.ok(SCHEMA_BACKED_OUTBOUND_TYPES.length > 100, `registry looks empty: ${SCHEMA_BACKED_OUTBOUND_TYPES.length}`)
-    assert.ok(rosterTypes().length > 100, `roster parse looks empty: ${rosterTypes().length}`)
+    // Floors are TIGHT on purpose. A loose `> 100` let a roster truncation losing 72 of
+    // 177 types (41%) pass the whole suite green, and the incidental thing that saved it
+    // (two allowlist entries near the block's end tripping the stale guard) disappears
+    // precisely as UNSCHEMAD shrinks to zero — which is the plan. Raise these when the
+    // real counts grow; never lower them.
+    assert.ok(
+      SCHEMA_BACKED_OUTBOUND_TYPES.length >= 150,
+      `registry undercounts: ${SCHEMA_BACKED_OUTBOUND_TYPES.length} (expected >= 150)`,
+    )
+    assert.ok(
+      rosterTypes().length >= 175,
+      `roster parse undercounts: ${rosterTypes().length} (expected >= 175) — did the JSDoc block move or its quoting change?`,
+    )
   })
 
   it('every documented outbound type has a schema, or is a known gap', () => {
-    const gaps = rosterTypes().filter((t) => !outboundSchemasForType(t).length && !UNSCHEMAD.has(t))
+    const gaps = rosterTypes().filter((t) => !outboundSchemasForType(t).length && !UNSCHEMAD.has(t) && !TRANSPORT_FRAMES.has(t))
     assert.deepEqual(
       gaps, [],
       `new outbound frame(s) with no schema in @chroxy/protocol: ${gaps.join(', ')}. ` +
@@ -160,6 +181,34 @@ describe('#7085 outbound schema coverage', () => {
     // flagged it as an unreadable frame.
     assert.ok(NON_FRAME_SCHEMA_NAMES.includes('ServerPermissionAuditEntrySchema'))
     assert.equal(UNREADABLE_FRAME_SCHEMA_NAMES.includes('ServerPermissionAuditEntrySchema'), false)
+  })
+
+  it('a transport frame is excluded only because its schema really exists', () => {
+    for (const [type, schemaName] of TRANSPORT_FRAMES) {
+      assert.equal(typeof protocol[schemaName]?.safeParse, 'function', `${schemaName} must exist to justify excluding '${type}'`)
+      assert.equal(UNSCHEMAD.has(type), false, `'${type}' has a schema and must not also be allowlisted`)
+    }
+  })
+
+  it('a frame hidden behind a WRAPPER is reported, not silently excluded', () => {
+    // The invariant defended unions and nothing else: every other combinator
+    // (.optional/.nullable/.default/.catch/.pipe/.transform/.readonly/intersection/
+    // z.lazy) hides `.shape`, so keying "non-frame" off a missing shape filed all of
+    // them as legitimate sub-objects. Anything that is not a plain object and yields no
+    // literal is now surfaced instead.
+    const wrapped = z.object({ type: z.literal('a_wrapped_frame'), x: z.string() }).optional()
+    assert.equal(typeLiteralsOf(wrapped).size, 0, 'precondition: the wrapper hides the literal')
+    assert.equal(
+      looksLikeNonFrameForTests(wrapped), false,
+      'a wrapped schema must be reported as unreadable, not excluded as a sub-object',
+    )
+  })
+
+  it('a multi-value literal does not crash the derivation', () => {
+    // `z.literal(['a','b']).value` THROWS and the registry is built at module load, so
+    // reading `.value` before `_def.values` would have been a module-load crash.
+    const multi = z.object({ type: z.literal(['m_one', 'm_two']) })
+    assert.deepEqual([...typeLiteralsOf(multi)].sort(), ['m_one', 'm_two'])
   })
 
   describe('validateOutbound', () => {

--- a/packages/server/tests/ws-outbound-coverage.test.js
+++ b/packages/server/tests/ws-outbound-coverage.test.js
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path'
 import {
   SCHEMA_BACKED_OUTBOUND_TYPES,
   NON_FRAME_SCHEMA_NAMES,
+  UNREADABLE_FRAME_SCHEMA_NAMES,
   outboundSchemasForType,
   validateOutbound,
 } from '../src/ws-outbound-schemas.js'
@@ -31,9 +32,13 @@ const WS_SERVER = join(HERE, '..', 'src', 'ws-server.js')
  * long after the schemas landed, and nobody would notice.
  */
 
-// The 30 frames the server documents sending that have no outbound schema, measured
+// The 28 frames the server documents sending that have no outbound schema, measured
 // against the roster in ws-server.js. Delete entries as schemas land — the test
 // below fails if you forget.
+//
+// `encrypted` is arguably a legitimate permanent entry (it is the E2E envelope
+// wrapper, not a semantic frame) — left in the list rather than special-cased so
+// the decision is made deliberately when someone gets to it.
 const UNSCHEMAD = new Set([
   'agent_list',
   'available_permission_modes',
@@ -42,7 +47,6 @@ const UNSCHEMAD = new Set([
   'dev_preview_stopped',
   'discovered_sessions',
   'encrypted',
-  'evaluate_draft_result',
   'file_list',
   'file_listing',
   'git_commit_result',
@@ -52,7 +56,6 @@ const UNSCHEMAD = new Set([
   'history_replay_start',
   'log_entry',
   'pairing_refreshed',
-  'permission_input',
   'permission_rules_updated',
   'primary_changed',
   'server_mode',
@@ -127,6 +130,36 @@ describe('#7085 outbound schema coverage', () => {
     // types that no sender ever emits.
     assert.ok(NON_FRAME_SCHEMA_NAMES.includes('ServerSessionListEntrySchema'))
     assert.equal(outboundSchemasForType('').length, 0)
+  })
+
+  it('a UNION-shaped frame schema is registered under its arms\' literal', () => {
+    // ServerEvaluateDraftResultSchema and ServerPermissionInputSchema are unions, so
+    // they have no top-level `.shape` and a naive `shape.type.value` lookup dropped
+    // them SILENTLY — both were briefly recorded as uncovered frames because of it.
+    for (const type of ['evaluate_draft_result', 'permission_input']) {
+      const arms = outboundSchemasForType(type)
+      assert.ok(arms.length > 0, `union-shaped frame '${type}' must be registered, got none`)
+    }
+  })
+
+  it('INVARIANT: no schema carries a type literal the derivation cannot read', () => {
+    // The whole point of deriving rather than declaring: a schema that HAS a
+    // discriminating literal but whose literal cannot be extracted is a SILENT DROP,
+    // which understates coverage and lets a real frame look schema-less. This must
+    // stay empty for any Zod version — if it fires, fix typeLiteralsOf, do not
+    // suppress it.
+    assert.deepEqual(
+      UNREADABLE_FRAME_SCHEMA_NAMES, [],
+      'these have a type literal that could not be read — the registry is understating coverage',
+    )
+  })
+
+  it('a `type` field that is DATA, not a literal, is not mistaken for a frame', () => {
+    // ServerPermissionAuditEntrySchema.type is z.string() (it names the audited tool).
+    // Classifying on "has a type field" instead of "has a type LITERAL" wrongly
+    // flagged it as an unreadable frame.
+    assert.ok(NON_FRAME_SCHEMA_NAMES.includes('ServerPermissionAuditEntrySchema'))
+    assert.equal(UNREADABLE_FRAME_SCHEMA_NAMES.includes('ServerPermissionAuditEntrySchema'), false)
   })
 
   describe('validateOutbound', () => {


### PR DESCRIPTION
Groundwork for #7085. **No runtime behaviour change** — this lands the registry and the coverage assertion only.

## First: the premise in #7085 was wrong, and I wrote it

#7085 proposes "a dev/CI-gated `ServerMessageSchema.safeParse` at the send choke point". `packages/protocol/src/schemas/server/stream.ts:138`:

```js
export const ServerMessageSchema = z.object({
  type: z.literal('message'),   // <- ONE frame, not a union
```

It's the schema for a single `type: 'message'` frame. **No discriminated union over server messages exists anywhere** — the only two under `schemas/server/` are `ScheduledTaskCadenceSchema` and `ServerPermissionInputSchema`, and `messages.ts` is purely `z.infer` aliases. There was nothing for the proposed safeParse to validate against. Full recon is on #7085.

## The registry is DERIVED, not declared

Every frame schema already carries its own `type: z.literal(...)`, so the map builds itself by introspection: **163** `Server*Schema` exports → **151** distinct types; the **11** without a `type` literal are sub-objects (`ServerSessionListEntrySchema`, …) and are correctly excluded.

That choice is deliberate, not convenient. A hand-maintained 151-entry map is the same parallel list that `BASE_SESSION_OPT_KEYS`, the protocol handler-coverage lint, and the thrice-retyped `clampWire` caps all needed *lints* to keep honest. A derived map cannot drift, and a frame with no schema is detectable by **absence** rather than by someone remembering to add an arm.

**One type has two schemas:** `error` is claimed by both `ServerErrorEnvelopeSchema` and `ServerSkillTrustGrantInvalidAuthorSchema`. The registry stores a *list* per type and passes if any arm accepts — keying one-per-type would validate half the `error` frames against the wrong shape.

## Measured coverage

| | |
|---|---|
| roster in `ws-server.js` documents | **177** outbound types |
| have a schema | **151** |
| **do not** | **30** |

A runtime census (I instrumented `_send`, ran 2337 tests, restored byte-exact with sha verification) caught 24 of those 30 — the subset simply didn't exercise the rest, which is why the static roster diff is the better authority. It also found 459 sends that *have* a schema and fail it, from only 8 distinct causes; the largest is filed as #7089 (a real violation — `available_models` sends `defaultModel: null` against `z.string().optional()`, while `provider` three lines below was deliberately made `.nullable()` for exactly that reason).

## Why coverage first, not the gate

Switching on a runtime gate today would mean shipping it with a 32-entry suppression list — the "gate nothing tests" failure mode wearing a different hat. Coverage first is the cheapest thing that stops the bleeding: **a new unschema'd frame fails CI the day it is added.**

`UNSCHEMAD` is a **shrinking** allowlist, kept honest by three assertions:

| Assertion | Prevents |
|---|---|
| a roster type neither schema-backed nor allowlisted fails | the list **growing** |
| an allowlisted type that HAS gained a schema fails until deleted | the list **rotting** |
| an allowlisted type absent from the roster fails | **stale** entries |

The second matters most — without it the list would still read 30 entries long after the schemas landed and nobody would notice.

## Verification

10/10 new tests; 1322 `ws-*` tests still green; 5/5 custom server lints; eslint clean.

All five guards mutation-verified **individually**:

| Mutation | Tests reddened |
|---|---|
| drop an entry from `UNSCHEMAD` (a new unschema'd frame) | 1 — the growth guard |
| leave a *fixed* type in `UNSCHEMAD` (rot) | 1 — the shrink guard |
| add a type the roster lacks (stale) | 1 — the stale guard |
| registry keeps only one schema per type | 1 — the `error` dupe test |
| roster parse returns nothing | **2** — incl. the CONTROL |

That last row is why the CONTROL exists: a silently-empty roster parse would make three of these assertions vacuously true, so it asserts both sets are non-trivially populated before anything else runs.

## What comes next (separate PRs)

1. Add the 30 missing schemas, shrinking `UNSCHEMAD` to zero — splittable by domain.
2. Fix the 8 invalid causes (#7089 is the first).
3. **Only then** turn on the runtime gate: throw in tests, off-or-sampled-warn in production, never drop a message.