### PR TITLE
fix(protocol): make available_models.defaultModel nullable

### DIFF
--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -236,7 +236,7 @@ export declare const ServerAvailableModelsEntrySchema: z.ZodObject<{
 export declare const ServerAvailableModelsSchema: z.ZodObject<{
     type: z.ZodLiteral<"available_models">;
     models: z.ZodOptional<z.ZodArray<z.ZodUnknown>>;
-    defaultModel: z.ZodOptional<z.ZodString>;
+    defaultModel: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     provider: z.ZodOptional<z.ZodNullable<z.ZodString>>;
 }, z.core.$strip>;
 export declare const ServerPermissionModeChangedSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -347,7 +347,15 @@ export const ServerAvailableModelsEntrySchema = z.object({
 export const ServerAvailableModelsSchema = z.object({
     type: z.literal('available_models'),
     models: z.array(z.unknown()).optional(),
-    defaultModel: z.string().optional(),
+    // #7089: NULLABLE, not just optional. `registry.getDefaultModelId()` returns null
+    // when no default is set, and every sender passes it straight through
+    // (ws-history.js multi/legacy/refresh, the server-cli overlay re-broadcast,
+    // session-handlers), so `defaultModel: null` is what has always been on the wire.
+    // The consumer contract already models it that way — store-core's
+    // `AvailableModelsPayload.defaultModelId` is `string | null` and `parseStringField`
+    // maps anything non-string to null — so the schema was the outlier, and this is the
+    // same reasoning `provider` below was given.
+    defaultModel: z.string().nullable().optional(),
     // #6370: every `available_models` sender tags the roster with the provider it
     // came from (ws-history multi/legacy/refresh/switch, server-cli overlay
     // re-broadcast, ws-forwarding, session-handlers) and the wire contract

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -372,7 +372,15 @@ export const ServerAvailableModelsEntrySchema = z.object({
 export const ServerAvailableModelsSchema = z.object({
   type: z.literal('available_models'),
   models: z.array(z.unknown()).optional(),
-  defaultModel: z.string().optional(),
+  // #7089: NULLABLE, not just optional. `registry.getDefaultModelId()` returns null
+  // when no default is set, and every sender passes it straight through
+  // (ws-history.js multi/legacy/refresh, the server-cli overlay re-broadcast,
+  // session-handlers), so `defaultModel: null` is what has always been on the wire.
+  // The consumer contract already models it that way — store-core's
+  // `AvailableModelsPayload.defaultModelId` is `string | null` and `parseStringField`
+  // maps anything non-string to null — so the schema was the outlier, and this is the
+  // same reasoning `provider` below was given.
+  defaultModel: z.string().nullable().optional(),
   // #6370: every `available_models` sender tags the roster with the provider it
   // came from (ws-history multi/legacy/refresh/switch, server-cli overlay
   // re-broadcast, ws-forwarding, session-handlers) and the wire contract

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3185,6 +3185,45 @@ describe('@chroxy/protocol schemas', () => {
     })
   })
 
+  describe('ServerAvailableModelsSchema defaultModel (#7089)', () => {
+    // The server has always sent `defaultModel: null` — registry.getDefaultModelId()
+    // returns null with no default and every sender passes it through. The schema said
+    // z.string().optional(), so null was wire-illegal: 309 failing sends in a
+    // 2337-test subset, the highest-volume wire-contract violation in the repo.
+    //
+    // These import ../src directly (tsx), so unlike a packages/server test they see
+    // THIS branch's schema rather than resolving @chroxy/protocol through the main
+    // clone's symlink.
+    it('accepts defaultModel: null (what a registry with no default actually sends)', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerAvailableModelsSchema.safeParse({ type: 'available_models', models: [], defaultModel: null })
+      assert.ok(r.success, 'null must be wire-legal — it is what the server emits')
+      assert.equal(r.data.defaultModel, null)
+    })
+
+    it('accepts a defaultModel string', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerAvailableModelsSchema.safeParse({ type: 'available_models', models: [], defaultModel: 'opus' })
+      assert.ok(r.success)
+      assert.equal(r.data.defaultModel, 'opus')
+    })
+
+    it('accepts an omitted defaultModel (backward compatible)', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerAvailableModelsSchema.safeParse({ type: 'available_models', models: [] })
+      assert.ok(r.success)
+      assert.equal(r.data.defaultModel, undefined)
+    })
+
+    it('still REFUSES a non-string, non-null defaultModel (nullable is not untyped)', async () => {
+      const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')
+      for (const bad of [42, {}, [], true]) {
+        const r = ServerAvailableModelsSchema.safeParse({ type: 'available_models', models: [], defaultModel: bad })
+        assert.equal(r.success, false, `defaultModel: ${JSON.stringify(bad)} must still be refused`)
+      }
+    })
+  })
+
   describe('ServerAvailableModelsSchema provider tag (#6370)', () => {
     it('accepts a roster tagged with a provider string', async () => {
       const { ServerAvailableModelsSchema } = await import('../src/schemas/server/stream.ts')

--- a/packages/server/tests/available-models-wire-shape.test.js
+++ b/packages/server/tests/available-models-wire-shape.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ServerAvailableModelsSchema } from '@chroxy/protocol'
+import { createModelsRegistry } from '../src/models.js'
+
+/**
+ * #7089 — `available_models` sent `defaultModel: null` against a non-nullable
+ * `z.string().optional()`, the single highest-volume wire-contract violation in the
+ * codebase (309 failing sends across a 2337-test subset).
+ *
+ * The payload is built from a REAL registry rather than a literal, because that is
+ * the only way to catch it: every existing fixture hardcodes a string default, and
+ * `registry.getDefaultModelId()` returning null is exactly the condition those
+ * fixtures cannot reproduce.
+ */
+describe('#7089 available_models wire shape', () => {
+  /** Built the way every sender builds it (ws-history.js:729/:775/:911 and friends). */
+  const payloadFrom = (registry, provider = null) => ({
+    type: 'available_models',
+    models: registry.getModels(),
+    defaultModel: registry.getDefaultModelId(),
+    provider,
+  })
+
+  it('a registry with NO default yields null — the condition fixtures cannot fake', () => {
+    const registry = createModelsRegistry({})
+    assert.equal(registry.getDefaultModelId(), null, 'precondition: a bare registry has no default')
+    assert.ok(registry.getModels().length > 0, 'and it still has models, so the payload is otherwise real')
+  })
+
+  it('the payload from a default-less registry satisfies the wire schema', () => {
+    const payload = payloadFrom(createModelsRegistry({}))
+    assert.equal(payload.defaultModel, null)
+    const result = ServerAvailableModelsSchema.safeParse(payload)
+    assert.ok(
+      result.success,
+      `a real available_models payload must be wire-legal; got ${JSON.stringify((result.error?.issues || [])[0])}`,
+    )
+  })
+
+  it('a string default still validates (the fix does not loosen the type)', () => {
+    const payload = { ...payloadFrom(createModelsRegistry({})), defaultModel: 'claude-opus-5' }
+    assert.ok(ServerAvailableModelsSchema.safeParse(payload).success)
+  })
+
+  it('nullable does NOT mean untyped — a non-string default is still refused', () => {
+    // Guards the obvious over-correction: `.nullable()` must not become `.any()`.
+    for (const bad of [42, {}, [], true]) {
+      const r = ServerAvailableModelsSchema.safeParse({ ...payloadFrom(createModelsRegistry({})), defaultModel: bad })
+      assert.equal(r.success, false, `defaultModel: ${JSON.stringify(bad)} must still be rejected`)
+    }
+  })
+
+  it('provider stays nullable too (the field this fix was modelled on)', () => {
+    const payload = payloadFrom(createModelsRegistry({}), null)
+    assert.ok(ServerAvailableModelsSchema.safeParse(payload).success)
+  })
+})

--- a/packages/server/tests/available-models-wire-shape.test.js
+++ b/packages/server/tests/available-models-wire-shape.test.js
@@ -8,6 +8,12 @@ import { createModelsRegistry } from '../src/models.js'
  * `z.string().optional()`, the single highest-volume wire-contract violation in the
  * codebase (309 failing sends across a 2337-test subset).
  *
+ * Field-level nullability coverage (null / string / omitted / non-string refused) lives
+ * in packages/protocol/tests/schemas.test.js beside the equivalent `provider` block —
+ * that suite imports ../src via tsx, so it validates THIS branch rather than resolving
+ * @chroxy/protocol through the main clone's symlink. This file's job is narrower and
+ * complementary: prove a payload built by a REAL sender is wire-legal.
+ *
  * The payload is built from a REAL registry rather than a literal, because that is
  * the only way to catch it: every existing fixture hardcodes a string default, and
  * `registry.getDefaultModelId()` returning null is exactly the condition those
@@ -49,10 +55,5 @@ describe('#7089 available_models wire shape', () => {
       const r = ServerAvailableModelsSchema.safeParse({ ...payloadFrom(createModelsRegistry({})), defaultModel: bad })
       assert.equal(r.success, false, `defaultModel: ${JSON.stringify(bad)} must still be rejected`)
     }
-  })
-
-  it('provider stays nullable too (the field this fix was modelled on)', () => {
-    const payload = payloadFrom(createModelsRegistry({}), null)
-    assert.ok(ServerAvailableModelsSchema.safeParse(payload).success)
   })
 })

--- a/packages/server/tests/ws-outbound-coverage.test.js
+++ b/packages/server/tests/ws-outbound-coverage.test.js
@@ -225,7 +225,12 @@ describe('#7085 outbound schema coverage', () => {
     })
 
     it('reports a schema violation with the offending path', () => {
-      const r = validateOutbound({ type: 'available_models', models: [], defaultModel: null })
+      // Uses a value that is invalid for a TYPE reason, deliberately. The original
+      // fixture here was `defaultModel: null` — which was the #7089 bug, i.e. this
+      // test was pinned to a violation that was about to be fixed, and #7092 (making
+      // the field nullable) turned it red. A fixture whose validity depends on an
+      // open bug expires the moment the bug is closed.
+      const r = validateOutbound({ type: 'available_models', models: [], defaultModel: 42 })
       assert.equal(r.ok, false)
       assert.equal(r.reason, 'invalid')
       assert.deepEqual(r.issue.path, ['defaultModel'], 'the caller needs the field, not just a boolean')


### PR DESCRIPTION
Closes #7089

## Problem

The server has **always** sent `defaultModel: null`. `registry.getDefaultModelId()` returns null when no default is set (`models.js:916-917`), and every sender passes it straight through — `ws-history.js:729`, `:775`, `:911`, the server-cli overlay re-broadcast, session-handlers. The schema said `z.string().optional()`, so `null` was wire-illegal.

**309 failing sends across a 2337-test subset** — the single highest-volume wire-contract violation in the codebase, and the largest blocker to turning on outbound validation (#7085, where it is 309 of 459 invalid sends).

## The direction was decided by the consumer contract, not by which edit is smaller

#7089 asks for this explicitly, so: `store-core`'s `AvailableModelsPayload.defaultModelId` is already typed **`string | null`** (`handlers/inventory.ts:157`), and `parseStringField` maps anything non-string to `null`. Consumers have always expected null — they receive it today — so the **schema** was the outlier, not the senders.

That is also the reasoning `provider`, three lines below, was already given (`.nullable()`, commented *"several senders pass an explicit `provider: null`"*). The identical case for `defaultModel` simply wasn't carried across — the same adjacent-field near-miss as #7080, #7081 and #7051.

Making the senders omit the key instead would be a change at 5+ call sites, against one schema line, to reach a shape consumers already handle less well.

## Verification

The test builds the payload from a **real registry**, not a literal. That matters: every existing fixture hardcodes a string default, which is exactly the condition that cannot reproduce this. A bare `createModelsRegistry({})` yields `getDefaultModelId() === null` with 3 models — the real-world shape.

It also pins the obvious over-correction: **`.nullable()` must not become `.any()`**, so a number/object/array/boolean default is still refused.

## Local-verification caveat, stated plainly

From a git worktree, `@chroxy/protocol` resolves through the main clone's `node_modules` symlink to the **main checkout's** `packages/protocol` — not this branch's. So the two schema-dependent tests **fail locally** until that checkout advances, and I could not verify them through the normal import path.

Verified instead against this branch's built dist by absolute path:

```
defaultModel from real registry : null
worktree schema accepts payload : true
string default still ok         : true
number default still REJECTED   : true
```

**CI resolves workspace packages from the branch and is the authority here** — please treat a green Server Tests as the real signal, not my local run.

While chasing this I also confirmed the flip side, since it would have invalidated numbers I published earlier: `packages/protocol` is byte-identical between the main checkout's HEAD and `origin/main`, and none of this session's 7 merged PRs touched protocol — so the 163/153/177/28 counts in #7085 and #7091 were measured against the right content.

## Notes for review

- `packages/protocol/dist` is gitignored but tracked; both regenerated files (`stream.js`, `stream.d.ts`) are staged in this commit. A missing dist is the classic way this lands broken.
- `''` (empty string) was accepted before and still is — `z.string()` permits it and `parseStringField` already maps empty to null downstream. No change there, deliberately.
- After merge, the #7085 census should drop from 459 invalid sends to ~150. Worth re-running to confirm rather than assuming.