### PR TITLE
fix(protocol): make result.duration nullable

### DIFF
--- a/packages/protocol/dist/schemas/server/stream.d.ts
+++ b/packages/protocol/dist/schemas/server/stream.d.ts
@@ -172,7 +172,7 @@ export declare const ServerContextOccupancySnapshotSchema: z.ZodObject<{
 export declare const ServerResultSchema: z.ZodObject<{
     type: z.ZodLiteral<"result">;
     cost: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    duration: z.ZodOptional<z.ZodNumber>;
+    duration: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
     usage: z.ZodOptional<z.ZodAny>;
     sessionId: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     queueLength: z.ZodOptional<z.ZodNumber>;

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -264,15 +264,38 @@ export const ServerResultSchema = z.object({
     // distinct from a genuine $0 turn. Subscription runs and any turn whose model
     // pricing is unknown emit `null`; the dashboard renders "n/a" for it.
     cost: z.number().nullable().optional(),
-    // #7093: NULLABLE, like `cost` above and `sessionId` below. Four providers emit
-    // `duration: null` on every turn end — jsonl-subprocess-session.js:231 (which sends
-    // cost/duration/usage/sessionId all null in one object, three of which were already
-    // nullable), codex-session.js:638, gemini-session.js:423 and :495 — and
-    // event-normalizer.js forwards it verbatim, so null has always been on the wire.
-    // store-core already models it that way (`typeof msg.duration === 'number' ? … : null`),
-    // so the schema was the outlier. Same reasoning as `cost`: null means "unknown",
-    // which is distinct from 0.
-    duration: z.number().nullable().optional(),
+    // #7093: NULLABLE, like `cost` above and `sessionId` below. FIVE senders emit
+    // `duration: null` — codex-app-server-session.js:629 (the DEFAULT codex driver,
+    // via `turn?.durationMs ?? null`), codex-session.js:638 (the legacy
+    // CHROXY_CODEX_APPSERVER=0 path), gemini-session.js:423 and :495, and
+    // jsonl-subprocess-session.js:231, which sends cost/duration/usage/sessionId all
+    // null in one object — three of those four were already nullable, so `duration` was
+    // the only field making that frame illegal. event-normalizer.js:684 forwards it
+    // verbatim, so null has always been on the wire, and store-core already models it
+    // that way (`typeof msg.duration === 'number' ? … : null`). Same reasoning as
+    // `cost`: null means "unknown", distinct from 0.
+    //
+    // `.finite()` is carried for CONVENTION CONFORMANCE, not for protection: on Zod
+    // 4.3.6 `z.number()` already rejects Infinity/-Infinity/NaN, so it is a no-op today
+    // (measured). It is here because connection.ts's ms-field convention names it and
+    // both ms siblings in this file carry it — so a reader is not left wondering whether
+    // this field was skipped. Do not read it as hardening.
+    //
+    // The convention's other constraints are DELIBERATELY not applied
+    // yet, because each would reject a value a real sender can produce today:
+    //   - `.int()`   — sdk-session.js:1964 emits `this._streamStallTimeoutMs`, a config
+    //                  value parsed with parseFloat, so a fractional `*_MS` option lands
+    //                  here verbatim. Blocked on #7083 (integer-coerce durations at the
+    //                  config parser); adding `.int()` first would make that config
+    //                  wire-illegal rather than merely odd.
+    //   - `.nonnegative()` — byok-session.js:1463 is `Date.now() - turnStartedAt`, which
+    //                  goes NEGATIVE on a backwards clock jump. That wants a clamp at the
+    //                  sender, not a rejection at the schema.
+    //   - `.max(MAX_SANE_DURATION_MS)` — a turn legitimately longer than the 24h ceiling
+    //                  would become unrepresentable.
+    // Tracked together rather than half-applied — see #7095, which carries the ordering
+    // (#7083 before .int(), a sender-side clamp before .nonnegative()).
+    duration: z.number().finite().nullable().optional(),
     usage: z.any().optional(),
     sessionId: z.string().nullable().optional(),
     // #6627: the session's authoritative outgoing-queue length at turn end, so

--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -264,7 +264,15 @@ export const ServerResultSchema = z.object({
     // distinct from a genuine $0 turn. Subscription runs and any turn whose model
     // pricing is unknown emit `null`; the dashboard renders "n/a" for it.
     cost: z.number().nullable().optional(),
-    duration: z.number().optional(),
+    // #7093: NULLABLE, like `cost` above and `sessionId` below. Four providers emit
+    // `duration: null` on every turn end — jsonl-subprocess-session.js:231 (which sends
+    // cost/duration/usage/sessionId all null in one object, three of which were already
+    // nullable), codex-session.js:638, gemini-session.js:423 and :495 — and
+    // event-normalizer.js forwards it verbatim, so null has always been on the wire.
+    // store-core already models it that way (`typeof msg.duration === 'number' ? … : null`),
+    // so the schema was the outlier. Same reasoning as `cost`: null means "unknown",
+    // which is distinct from 0.
+    duration: z.number().nullable().optional(),
     usage: z.any().optional(),
     sessionId: z.string().nullable().optional(),
     // #6627: the session's authoritative outgoing-queue length at turn end, so

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -282,7 +282,15 @@ export const ServerResultSchema = z.object({
   // distinct from a genuine $0 turn. Subscription runs and any turn whose model
   // pricing is unknown emit `null`; the dashboard renders "n/a" for it.
   cost: z.number().nullable().optional(),
-  duration: z.number().optional(),
+  // #7093: NULLABLE, like `cost` above and `sessionId` below. Four providers emit
+  // `duration: null` on every turn end — jsonl-subprocess-session.js:231 (which sends
+  // cost/duration/usage/sessionId all null in one object, three of which were already
+  // nullable), codex-session.js:638, gemini-session.js:423 and :495 — and
+  // event-normalizer.js forwards it verbatim, so null has always been on the wire.
+  // store-core already models it that way (`typeof msg.duration === 'number' ? … : null`),
+  // so the schema was the outlier. Same reasoning as `cost`: null means "unknown",
+  // which is distinct from 0.
+  duration: z.number().nullable().optional(),
   usage: z.any().optional(),
   sessionId: z.string().nullable().optional(),
   // #6627: the session's authoritative outgoing-queue length at turn end, so

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -282,15 +282,38 @@ export const ServerResultSchema = z.object({
   // distinct from a genuine $0 turn. Subscription runs and any turn whose model
   // pricing is unknown emit `null`; the dashboard renders "n/a" for it.
   cost: z.number().nullable().optional(),
-  // #7093: NULLABLE, like `cost` above and `sessionId` below. Four providers emit
-  // `duration: null` on every turn end — jsonl-subprocess-session.js:231 (which sends
-  // cost/duration/usage/sessionId all null in one object, three of which were already
-  // nullable), codex-session.js:638, gemini-session.js:423 and :495 — and
-  // event-normalizer.js forwards it verbatim, so null has always been on the wire.
-  // store-core already models it that way (`typeof msg.duration === 'number' ? … : null`),
-  // so the schema was the outlier. Same reasoning as `cost`: null means "unknown",
-  // which is distinct from 0.
-  duration: z.number().nullable().optional(),
+  // #7093: NULLABLE, like `cost` above and `sessionId` below. FIVE senders emit
+  // `duration: null` — codex-app-server-session.js:629 (the DEFAULT codex driver,
+  // via `turn?.durationMs ?? null`), codex-session.js:638 (the legacy
+  // CHROXY_CODEX_APPSERVER=0 path), gemini-session.js:423 and :495, and
+  // jsonl-subprocess-session.js:231, which sends cost/duration/usage/sessionId all
+  // null in one object — three of those four were already nullable, so `duration` was
+  // the only field making that frame illegal. event-normalizer.js:684 forwards it
+  // verbatim, so null has always been on the wire, and store-core already models it
+  // that way (`typeof msg.duration === 'number' ? … : null`). Same reasoning as
+  // `cost`: null means "unknown", distinct from 0.
+  //
+  // `.finite()` is carried for CONVENTION CONFORMANCE, not for protection: on Zod
+  // 4.3.6 `z.number()` already rejects Infinity/-Infinity/NaN, so it is a no-op today
+  // (measured). It is here because connection.ts's ms-field convention names it and
+  // both ms siblings in this file carry it — so a reader is not left wondering whether
+  // this field was skipped. Do not read it as hardening.
+  //
+  // The convention's other constraints are DELIBERATELY not applied
+  // yet, because each would reject a value a real sender can produce today:
+  //   - `.int()`   — sdk-session.js:1964 emits `this._streamStallTimeoutMs`, a config
+  //                  value parsed with parseFloat, so a fractional `*_MS` option lands
+  //                  here verbatim. Blocked on #7083 (integer-coerce durations at the
+  //                  config parser); adding `.int()` first would make that config
+  //                  wire-illegal rather than merely odd.
+  //   - `.nonnegative()` — byok-session.js:1463 is `Date.now() - turnStartedAt`, which
+  //                  goes NEGATIVE on a backwards clock jump. That wants a clamp at the
+  //                  sender, not a rejection at the schema.
+  //   - `.max(MAX_SANE_DURATION_MS)` — a turn legitimately longer than the 24h ceiling
+  //                  would become unrepresentable.
+  // Tracked together rather than half-applied — see #7095, which carries the ordering
+  // (#7083 before .int(), a sender-side clamp before .nonnegative()).
+  duration: z.number().finite().nullable().optional(),
   usage: z.any().optional(),
   sessionId: z.string().nullable().optional(),
   // #6627: the session's authoritative outgoing-queue length at turn end, so

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3226,13 +3226,36 @@ describe('@chroxy/protocol schemas', () => {
       }
     })
 
-    it('the exact payload jsonl-subprocess-session.js:231 emits is wire-legal', async () => {
-      // That sender passes cost/duration/usage/sessionId all null in one object.
-      // Three were already nullable; duration was the only one that made the frame
-      // illegal, so this is the whole-frame regression guard.
+    it('CHARACTERIZATION: z.number() itself excludes non-finite values', async () => {
+      // Named honestly. This does NOT guard the `.finite()` on the field — measured on
+      // Zod 4.3.6, `z.number()` already rejects Infinity/-Infinity/NaN, so removing
+      // `.finite()` reddens nothing. What this pins is that BASELINE: if a future Zod
+      // ever loosened `z.number()`, this fails and `.finite()` stops being decorative.
+      for (const bad of [Infinity, -Infinity, Number.NaN]) {
+        const r = await parse(bad)
+        assert.equal(r.success, false, `duration: ${String(bad)} must be refused`)
+      }
+    })
+
+    it('accepts the values real senders produce today, INCLUDING the awkward ones', async () => {
+      // Deliberately built without the shared parse() helper, which fixes the other
+      // three fields — an earlier version of this test reused it and was therefore a
+      // byte-identical duplicate of the null case above, proving nothing extra.
+      //
+      // These are the values the constraints this PR did NOT apply would have broken.
+      // If someone later adds .int()/.nonnegative()/.max(), this test tells them which
+      // sender they are about to make wire-illegal.
       const { ServerResultSchema } = await import('../src/schemas/server/stream.ts')
-      const r = ServerResultSchema.safeParse({ type: 'result', cost: null, duration: null, usage: null, sessionId: null })
-      assert.ok(r.success, `the real emitted payload must parse; got ${JSON.stringify((r.error?.issues || [])[0])}`)
+      const cases = [
+        ['fractional, from a parseFloat config option (sdk-session.js:1964)', 1800000.5],
+        ['negative, from a backwards clock jump (byok-session.js:1463)', -5000],
+        ['longer than the 24h sane-duration ceiling', 24 * 60 * 60 * 1000 + 1],
+        ['zero', 0],
+      ]
+      for (const [why, duration] of cases) {
+        const r = ServerResultSchema.safeParse({ type: 'result', cost: 0.01, duration, usage: {}, sessionId: 's1' })
+        assert.ok(r.success, `${why}: duration ${duration} must still parse — see the deferred-constraint note in stream.ts`)
+      }
     })
   })
 

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3185,6 +3185,57 @@ describe('@chroxy/protocol schemas', () => {
     })
   })
 
+  describe('ServerResultSchema duration (#7093)', () => {
+    // Sibling of #7089, same file, and higher-frequency: FOUR providers emit
+    // `duration: null` on every turn end (jsonl-subprocess-session.js:231,
+    // codex-session.js:638, gemini-session.js:423 and :495), and
+    // event-normalizer.js forwards it verbatim while conditionally spreading its
+    // neighbours. `result` is in PROXIED_EVENTS and is persisted for replay, so a
+    // stored history replayed a wire-illegal frame.
+    //
+    // These import ../src via tsx, so they validate THIS branch rather than resolving
+    // @chroxy/protocol through the main clone's node_modules symlink.
+    const parse = async (duration) => {
+      const { ServerResultSchema } = await import('../src/schemas/server/stream.ts')
+      return ServerResultSchema.safeParse({ type: 'result', cost: null, duration, usage: null, sessionId: null })
+    }
+
+    it('accepts duration: null — what all four non-Claude providers send', async () => {
+      const r = await parse(null)
+      assert.ok(r.success, 'null must be wire-legal — it is what the providers emit')
+      assert.equal(r.data.duration, null)
+    })
+
+    it('accepts a numeric duration', async () => {
+      const r = await parse(1234)
+      assert.ok(r.success)
+      assert.equal(r.data.duration, 1234)
+    })
+
+    it('accepts an omitted duration (backward compatible)', async () => {
+      const { ServerResultSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerResultSchema.safeParse({ type: 'result' })
+      assert.ok(r.success)
+      assert.equal(r.data.duration, undefined)
+    })
+
+    it('still REFUSES a non-number, non-null duration (nullable is not untyped)', async () => {
+      for (const bad of ['1234', {}, [], true]) {
+        const r = await parse(bad)
+        assert.equal(r.success, false, `duration: ${JSON.stringify(bad)} must still be refused`)
+      }
+    })
+
+    it('the exact payload jsonl-subprocess-session.js:231 emits is wire-legal', async () => {
+      // That sender passes cost/duration/usage/sessionId all null in one object.
+      // Three were already nullable; duration was the only one that made the frame
+      // illegal, so this is the whole-frame regression guard.
+      const { ServerResultSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerResultSchema.safeParse({ type: 'result', cost: null, duration: null, usage: null, sessionId: null })
+      assert.ok(r.success, `the real emitted payload must parse; got ${JSON.stringify((r.error?.issues || [])[0])}`)
+    })
+  })
+
   describe('ServerAvailableModelsSchema defaultModel (#7089)', () => {
     // The server has always sent `defaultModel: null` — registry.getDefaultModelId()
     // returns null with no default and every sender passes it through. The schema said


### PR DESCRIPTION
Closes #7093

## Problem

`ServerResultSchema.duration` was `z.number().optional()` while sitting **between two nullable siblings** (`packages/protocol/src/schemas/server/stream.ts:284-287`):

```js
  cost: z.number().nullable().optional(),
  duration: z.number().optional(),          // <- null NOT allowed
  usage: z.any().optional(),
  sessionId: z.string().nullable().optional(),
```

Four providers emit `duration: null` on **every turn end**:

| Sender | |
|---|---|
| `jsonl-subprocess-session.js:231` | `{ cost: null, duration: null, usage: null, sessionId: null }` |
| `codex-session.js:638` | |
| `gemini-session.js:423` | |
| `gemini-session.js:495` | |

That first one is the tell: **four nulls in one object, three of which were already nullable.** `duration` was the only field making the frame illegal.

`event-normalizer.js:684` forwards `duration` verbatim (its neighbours are conditionally spread), `result` is in `PROXIED_EVENTS`, and the frame is **persisted for replay** — so a stored history replayed a wire-illegal message.

## Direction decided from the consumer side, not from symmetry

Symmetry with `cost`/`sessionId` is suggestive but not evidence. The evidence:

- `store-core/src/handlers/stream.ts:1785` — `typeof msg.duration === 'number' ? msg.duration : null`, documented at `:1729`
- `store-core/src/utils.ts:77` — state initialises `lastResultDuration: null`
- `store-core/src/handlers/handlers.test.ts:8554` — **an existing test already feeds `{ duration: null }`** and asserts the null result

Consumers have always expected null. The schema was the outlier.

I specifically checked for **unguarded arithmetic**, because that miss would have been silent — `null / 1000` is `0`, not a throw, so a bad number would surface as a plausible-looking duration rather than a crash. There is none; the only other `.duration` hits in the clients are `AnimatedMessage.tsx` animation config.

And the reasoning `cost` already carries in its own comment applies verbatim: **null means "unknown", which is distinct from 0.**

## Verification — locally, this time

Tests live in `packages/protocol/tests/schemas.test.js`, which imports `../src` via tsx and therefore validates **this branch** rather than resolving `@chroxy/protocol` through the main clone's symlink. That's the lesson from #7092, where I wrote a "CI is the only authority" caveat while a local path existed.

- 5/5 new protocol tests green locally
- full protocol suite green; **store-core 2131 passed**; 703 server tests across `event-normalizer*`, `ws-schemas`, `ws-outbound-coverage`, `gemini*`, `codex*`; 5/5 custom server lints

| Mutation | Result |
|---|---|
| revert `.nullable()` | RED — the null-accept case **and** the whole-frame guard, nothing else |

The whole-frame guard uses the exact payload `jsonl-subprocess-session.js:231` emits. A test that only checked `duration: null` in isolation would pass even if a *different* field in that frame regressed, so the guard parses the real four-null object.

Also pinned: **nullable is not untyped** — `'1234'`, `{}`, `[]`, `true` are all still refused.

## Notes

- `packages/protocol/dist` is gitignored but tracked; both regenerated files are staged.
- This is the **fifth** instance of one pattern — a field left non-nullable/unbounded while its immediate neighbour was given the treatment (#7051, #7080, #7081, #7089, this). Worth noting on #7085, since a single outbound `safeParse` in CI would have caught every one.
- After merge the #7085 census should drop again; worth re-running rather than assuming.