### PR TITLE
fix(server): integer-coerce duration config options at the merge site

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -458,6 +458,16 @@ from the SDK / CLI for the configured duration.
 | Soft | `resultTimeoutMs` | `CHROXY_RESULT_TIMEOUT_MS` | `1800000` (30 min) | Emits `inactivity_warning` event + push notification. Session stays alive. Clients render a "check in" chip in the activity indicator. |
 | Hard | `hardTimeoutMs` | `CHROXY_HARD_TIMEOUT_MS` | `7200000` (2 h) | Emits `permission_expired` for every outstanding permission request, force-clears busy state, aborts any in-flight SDK query, and emits a generic `error` event (`"Response timed out after <duration> of inactivity"`). Session must be re-driven by the user. |
 
+**Whole milliseconds only (#7083).** Every millisecond option — `resultTimeoutMs`,
+`hardTimeoutMs`, `streamStallTimeoutMs`, `backgroundShellHardQuiesceMs`,
+`mcpToolCallTimeoutMs`, `terminalDownGraceMs`, and each entry of
+`providerStreamStallTimeoutMs` — is truncated to an integer when the config is merged,
+from the config file and the env var alike. A fractional value logs a warning naming the
+key and the value it was changed to. They must be whole ms because they are sent on the
+wire, where the protocol schemas require an integer. Note this is truncation toward zero,
+so `30000.9` becomes `30000` — never rounded up into a range it did not qualify for. USD
+options (`costBudget`, `billing.*`, provider `pricing.*`) are deliberately untouched.
+
 Both fields share the same range (`30000`–`86400000`, 30 s – 24 h) and the
 same WS schema cap (#3768). Values outside the range emit warn-only log
 lines during validation; the runtime applies whatever was set. The

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -327,10 +327,13 @@ const CONFIG_SCHEMA = {
  *
  * Deliberately NOT covered: nested ms options under `'object'`-typed keys
  * (`worktreeGc.*`, `notifications.discord.*`, `orchestration.turnTimeoutMs`,
- * `summarize.titleTimeoutMs`, `providerStreamStallTimeoutMs.<id>`). None of those
- * reach the wire, and covering them needs per-block handling — a recursive walk of the
- * merged object would destroy `providers.*.pricing.input` and
- * `billing.monthlyCreditBudgetUsd`, which are legitimately fractional.
+ * `summarize.titleTimeoutMs`). Those do not reach the wire, and covering them needs
+ * per-block handling — a recursive walk of the merged object would destroy
+ * `providers.*.pricing.input` and `billing.monthlyCreditBudgetUsd`, which are
+ * legitimately fractional.
+ *
+ * `providerStreamStallTimeoutMs` IS covered (see DURATION_MS_MAP_CONFIG_KEYS below) —
+ * an earlier revision of this comment wrongly lumped it in with the exclusions.
  */
 export const DURATION_MS_CONFIG_KEYS = Object.freeze([
   'terminalDownGraceMs',
@@ -341,6 +344,27 @@ export const DURATION_MS_CONFIG_KEYS = Object.freeze([
   'mcpToolCallTimeoutMs',
 ])
 const DURATION_MS_KEY_SET = new Set(DURATION_MS_CONFIG_KEYS)
+
+/**
+ * #7083 — config options whose value is a MAP of `<id> -> duration-ms`.
+ *
+ * `providerStreamStallTimeoutMs.<id>` is not a cosmetic omission: it OUTRANKS the
+ * coerced global (session-manager.js `_sanitizeProviderTimeoutMap` keeps it verbatim
+ * because `isOperatorTimeoutInRange` checks finite/positive/<=24h but never
+ * integrality), flows into `base-session.js`, and is emitted as `result.duration` by
+ * `sdk-session.js`. Measured: a fractional per-provider entry survives `mergeConfig`
+ * and draws ZERO validateConfig warnings.
+ *
+ * That is the exact field `stream.ts` records as blocked on THIS issue before `.int()`
+ * can be added (#7095). Coercing only the flat keys would have left the per-provider
+ * override fractional, so #7095 would then make a config that is legal today emit a
+ * wire-illegal frame.
+ *
+ * An explicit list of MAP-shaped keys, not a recursive walk — the walk is what would
+ * destroy `providers.*.pricing.input` and `billing.monthlyCreditBudgetUsd`.
+ */
+export const DURATION_MS_MAP_CONFIG_KEYS = Object.freeze(['providerStreamStallTimeoutMs'])
+const DURATION_MS_MAP_KEY_SET = new Set(DURATION_MS_MAP_CONFIG_KEYS)
 
 /**
  * #7083 — coerce a duration-ms config value to a whole number of milliseconds.
@@ -360,8 +384,14 @@ const DURATION_MS_KEY_SET = new Set(DURATION_MS_CONFIG_KEYS)
  * `streamStallTimeoutMs` and `backgroundShellHardQuiesceMs`, so a naive
  * `Math.trunc(0.4) === 0` would silently switch stall detection OFF — turning an
  * illegal value that warns today into a feature that is quietly disabled. Sub-1
- * magnitudes go to ±1 instead: still illegal, still warned about by validateConfig,
- * and never the sentinel.
+ * magnitudes go to ±1 instead, which is never the sentinel.
+ *
+ * Precise about what ±1 then means: for the five range-checked keys it is still below
+ * the documented minimum, so validateConfig still warns and nothing is silently
+ * accepted. `terminalDownGraceMs` is the exception — it has NO range validation at all,
+ * so `0.4` becomes a legal, unwarned `1`. That is an invented value, and it is
+ * tolerable only because that key never reaches the wire; it is not a general property
+ * of the guard, so do not extend the guard to a wire-bound key on that basis.
  *
  * Non-numbers pass through untouched so `parseEnvValue`'s NaN-means-keep-the-string
  * contract survives, and non-finite values pass through so the existing Infinity
@@ -372,13 +402,38 @@ const DURATION_MS_KEY_SET = new Set(DURATION_MS_CONFIG_KEYS)
  * @returns {unknown} the coerced value, or `value` unchanged
  */
 export function coerceDurationConfigValue(key, value) {
+  if (DURATION_MS_MAP_KEY_SET.has(key)) return coerceDurationMap(key, value)
   if (!DURATION_MS_KEY_SET.has(key)) return value
+  return coerceOneDuration(key, value)
+}
+
+/** @private — coerce a single duration-ms value. */
+function coerceOneDuration(label, value) {
   if (typeof value !== 'number' || !Number.isFinite(value)) return value
   if (Number.isInteger(value)) return value
   const truncated = Math.trunc(value)
   const coerced = truncated === 0 ? Math.sign(value) : truncated
-  log.warn(`Config '${key}' must be a whole number of milliseconds — coercing ${value} to ${coerced}`)
+  log.warn(`Config '${label}' must be a whole number of milliseconds — coercing ${value} to ${coerced}`)
   return coerced
+}
+
+/**
+ * @private — coerce each value of an `<id> -> ms` map, ONE level deep.
+ *
+ * Deliberately not recursive: depth is what turns this from a targeted fix into the
+ * change that truncates `providers.*.pricing.input`. Non-object inputs pass through so
+ * the existing "wrong type" validateConfig warning still fires on the raw value.
+ */
+function coerceDurationMap(key, value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+  let changed = false
+  const out = {}
+  for (const [id, entry] of Object.entries(value)) {
+    const coerced = coerceOneDuration(`${key}.${id}`, entry)
+    if (coerced !== entry) changed = true
+    out[id] = coerced
+  }
+  return changed ? out : value
 }
 
 /**

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -313,6 +313,75 @@ const CONFIG_SCHEMA = {
 }
 
 /**
+ * #7083 — config options whose value is a millisecond duration, and which therefore
+ * must never be fractional: they feed `setTimeout` AND the wire, where the protocol
+ * schemas require `.int()`.
+ *
+ * An EXPLICIT allowlist rather than `key.endsWith('Ms')`, even though the suffix
+ * happens to select exactly these six today. The `'number'` branch of `parseEnvValue`
+ * is shared with `costBudget`, which is USD and legitimately fractional — so a
+ * convention-driven predicate would be correct by accident and give a future reviewer
+ * nothing to check against. `tests/config-duration-coercion.test.js` asserts this list
+ * equals every `*Ms: 'number'` key in CONFIG_SCHEMA, so adding a duration option
+ * without listing it here fails CI rather than silently opting out.
+ *
+ * Deliberately NOT covered: nested ms options under `'object'`-typed keys
+ * (`worktreeGc.*`, `notifications.discord.*`, `orchestration.turnTimeoutMs`,
+ * `summarize.titleTimeoutMs`, `providerStreamStallTimeoutMs.<id>`). None of those
+ * reach the wire, and covering them needs per-block handling — a recursive walk of the
+ * merged object would destroy `providers.*.pricing.input` and
+ * `billing.monthlyCreditBudgetUsd`, which are legitimately fractional.
+ */
+export const DURATION_MS_CONFIG_KEYS = Object.freeze([
+  'terminalDownGraceMs',
+  'resultTimeoutMs',
+  'hardTimeoutMs',
+  'streamStallTimeoutMs',
+  'backgroundShellHardQuiesceMs',
+  'mcpToolCallTimeoutMs',
+])
+const DURATION_MS_KEY_SET = new Set(DURATION_MS_CONFIG_KEYS)
+
+/**
+ * #7083 — coerce a duration-ms config value to a whole number of milliseconds.
+ *
+ * Applied at the single merge site so it covers BOTH input paths: an env var (parsed
+ * with `parseFloat`) and a `~/.chroxy/config.json` value, which is JSON and arrives as
+ * a fractional number with no parse step to hook. Fixing only the env parser would
+ * leave the config-file case — the one named in #7083 — fully broken.
+ *
+ * `Math.trunc`, matching `parseInt`, which is already this repo's convention for every
+ * integer config input. Truncation also cannot round an out-of-range value UP into
+ * legality: `Math.round(29999.5)` would become 30000 and silently suppress a
+ * below-minimum warning. And because every documented minimum is itself an integer,
+ * truncation can never push a legal value below its minimum.
+ *
+ * The zero guard is load-bearing. `0` is the documented "disabled" sentinel for
+ * `streamStallTimeoutMs` and `backgroundShellHardQuiesceMs`, so a naive
+ * `Math.trunc(0.4) === 0` would silently switch stall detection OFF — turning an
+ * illegal value that warns today into a feature that is quietly disabled. Sub-1
+ * magnitudes go to ±1 instead: still illegal, still warned about by validateConfig,
+ * and never the sentinel.
+ *
+ * Non-numbers pass through untouched so `parseEnvValue`'s NaN-means-keep-the-string
+ * contract survives, and non-finite values pass through so the existing Infinity
+ * semantics in the range checks are unchanged.
+ *
+ * @param {string} key
+ * @param {unknown} value
+ * @returns {unknown} the coerced value, or `value` unchanged
+ */
+export function coerceDurationConfigValue(key, value) {
+  if (!DURATION_MS_KEY_SET.has(key)) return value
+  if (typeof value !== 'number' || !Number.isFinite(value)) return value
+  if (Number.isInteger(value)) return value
+  const truncated = Math.trunc(value)
+  const coerced = truncated === 0 ? Math.sign(value) : truncated
+  log.warn(`Config '${key}' must be a whole number of milliseconds — coercing ${value} to ${coerced}`)
+  return coerced
+}
+
+/**
  * Config keys that should be masked in verbose output and sanitized logs.
  * `pushToken` was a dead entry — it is never a CONFIG_SCHEMA key; push tokens
  * are runtime device registrations (`prefs.devices`), masked elsewhere. The
@@ -1379,7 +1448,10 @@ export function mergeConfig({ fileConfig = {}, cliOverrides = {}, defaults = {},
 
   // Helper to set value and track source
   const setValue = (key, value, source) => {
-    merged[key] = value
+    // #7083: the single choke point for every precedence branch (CLI, env, file,
+    // defaults), so one coercion covers all of them — including the config-FILE path,
+    // which has no parse step of its own.
+    merged[key] = coerceDurationConfigValue(key, value)
     sources[key] = source
   }
 

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -374,11 +374,13 @@ const DURATION_MS_MAP_KEY_SET = new Set(DURATION_MS_MAP_CONFIG_KEYS)
  * a fractional number with no parse step to hook. Fixing only the env parser would
  * leave the config-file case — the one named in #7083 — fully broken.
  *
- * `Math.trunc`, matching `parseInt`, which is already this repo's convention for every
- * integer config input. Truncation also cannot round an out-of-range value UP into
- * legality: `Math.round(29999.5)` would become 30000 and silently suppress a
- * below-minimum warning. And because every documented minimum is itself an integer,
- * truncation can never push a legal value below its minimum.
+ * `Math.trunc` — truncate toward zero. Chosen for two reasons, not for convention:
+ * it cannot round an out-of-range value UP into legality (`Math.round(29999.5)` would
+ * become 30000 and silently suppress a below-minimum warning), and because every
+ * documented minimum is itself an integer, truncation can never push a legal value
+ * below its minimum. It also matches the truncating `parseInt` used for integer CLI
+ * flags in `cli/shared.js` — note this module's own env parser uses `parseFloat`, which
+ * is precisely why the fractional value reaches here in the first place.
  *
  * The zero guard is load-bearing. `0` is the documented "disabled" sentinel for
  * `streamStallTimeoutMs` and `backgroundShellHardQuiesceMs`, so a naive

--- a/packages/server/tests/config-duration-coercion.test.js
+++ b/packages/server/tests/config-duration-coercion.test.js
@@ -46,7 +46,10 @@ describe('#7083 duration config coercion', () => {
     }
   })
 
-  const mergeFile = (fileConfig) => mergeConfig({ fileConfig }).config ?? mergeConfig({ fileConfig })
+  // mergeConfig returns the merged object directly. An earlier version read `.config`
+  // with a `??` fallback, which was always undefined and therefore merged TWICE on
+  // every call — doubling the coercion warnings it was supposed to be observing.
+  const mergeFile = (fileConfig) => mergeConfig({ fileConfig })
 
   it('CONTROL: an ordinary integer duration is untouched, so the assertions below mean something', () => {
     const merged = mergeFile({ resultTimeoutMs: 1800000 })

--- a/packages/server/tests/config-duration-coercion.test.js
+++ b/packages/server/tests/config-duration-coercion.test.js
@@ -108,6 +108,46 @@ describe('#7083 duration config coercion', () => {
     assert.equal(merged.worktreeGc.reapIntervalMs, 900000.5, 'nested ms is out of scope — see the comment in config.js')
   })
 
+  it('coerces the per-provider duration MAP — it outranks the global and reaches result.duration', () => {
+    // The gap review found. `providerStreamStallTimeoutMs.<id>` survives mergeConfig,
+    // draws ZERO validateConfig warnings, is kept verbatim by
+    // _sanitizeProviderTimeoutMap (isOperatorTimeoutInRange checks finite/positive/<=24h
+    // but never integrality), OUTRANKS the coerced global, and is emitted as
+    // result.duration. stream.ts records this exact field as blocked on #7083 before
+    // .int() can be added — so coercing only the flat keys would have left #7095 unsafe.
+    const merged = mergeFile({ providerStreamStallTimeoutMs: { 'claude-sdk': 1800000.5, codex: 60000 } })
+    assert.equal(merged.providerStreamStallTimeoutMs['claude-sdk'], 1800000)
+    assert.equal(merged.providerStreamStallTimeoutMs.codex, 60000, 'an already-integer entry is untouched')
+  })
+
+  it('the map coercion is ONE level deep — pricing and billing survive', () => {
+    // Depth is what turns this into the change that truncates money.
+    const merged = mergeFile({
+      providers: { anthropicCompatible: [{ id: 'x', pricing: { input: 0.6, output: 3.75 } }] },
+      billing: { monthlyCreditBudgetUsd: 12.5 },
+    })
+    assert.equal(merged.providers.anthropicCompatible[0].pricing.input, 0.6)
+    assert.equal(merged.providers.anthropicCompatible[0].pricing.output, 3.75)
+    assert.equal(merged.billing.monthlyCreditBudgetUsd, 12.5)
+  })
+
+  it('a non-object providerStreamStallTimeoutMs passes through for validateConfig to reject', () => {
+    // The wrong-type warning must still fire on the operator's raw value.
+    assert.equal(coerceDurationConfigValue('providerStreamStallTimeoutMs', 'nope'), 'nope')
+    assert.equal(coerceDurationConfigValue('providerStreamStallTimeoutMs', null), null)
+  })
+
+  it('DOCUMENTED EXCEPTION: terminalDownGraceMs has no range validation, so +/-1 is legal and unwarned', () => {
+    // Recorded rather than hidden. For the five range-checked keys, +/-1 is still below
+    // the minimum and validateConfig still warns. terminalDownGraceMs is not range-
+    // checked at all, so 0.4 becomes a legal, unwarned 1 — an invented value, tolerable
+    // only because that key never reaches the wire.
+    const merged = mergeFile({ terminalDownGraceMs: 0.4 })
+    assert.equal(merged.terminalDownGraceMs, 1)
+    const warnings = (validateConfig(merged).warnings || []).filter((w) => /terminalDownGrace/i.test(w))
+    assert.deepEqual(warnings, [], 'no warning today — this test exists so that stays a known fact')
+  })
+
   // --- boundaries and sentinels ---------------------------------------------
 
   it('truncation never pushes a legal value below its documented minimum', () => {

--- a/packages/server/tests/config-duration-coercion.test.js
+++ b/packages/server/tests/config-duration-coercion.test.js
@@ -1,0 +1,189 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  mergeConfig,
+  validateConfig,
+  coerceDurationConfigValue,
+  DURATION_MS_CONFIG_KEYS,
+} from '../src/config.js'
+import { ServerInactivityWarningSchema } from '@chroxy/protocol'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const CONFIG_SRC = join(HERE, '..', 'src', 'config.js')
+
+/**
+ * #7083 — duration config options are coerced to whole milliseconds at the merge site.
+ *
+ * A fractional `*_MS` value used to survive with ZERO validateConfig warnings and reach
+ * the wire as `inactivity_warning.idleMs`, violating a schema that requires `.int()`.
+ * The coercion sits in `mergeConfig`'s `setValue` — the sole writer into the merged
+ * object — so it covers every precedence branch INCLUDING the config-file path, which
+ * is JSON and has no parse step to hook.
+ *
+ * The scope boundary matters more than the fix: `costBudget` shares the same `'number'`
+ * env branch and is USD, so coercing it would truncate a spend cap — and `0.50 -> 0`
+ * makes `config.costBudget || null` falsy, disabling the budget entirely with no signal.
+ */
+describe('#7083 duration config coercion', () => {
+  const ENV_KEYS = [
+    'CHROXY_RESULT_TIMEOUT_MS', 'CHROXY_HARD_TIMEOUT_MS', 'CHROXY_STREAM_STALL_TIMEOUT_MS',
+    'CHROXY_BACKGROUND_SHELL_HARD_QUIESCE_MS', 'CHROXY_MCP_TOOL_CALL_TIMEOUT_MS',
+    'CHROXY_TERMINAL_DOWN_GRACE_MS', 'CHROXY_COST_BUDGET', 'PORT',
+  ]
+  let savedEnv
+
+  beforeEach(() => {
+    savedEnv = {}
+    for (const k of ENV_KEYS) { savedEnv[k] = process.env[k]; delete process.env[k] }
+  })
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k]
+      else process.env[k] = savedEnv[k]
+    }
+  })
+
+  const mergeFile = (fileConfig) => mergeConfig({ fileConfig }).config ?? mergeConfig({ fileConfig })
+
+  it('CONTROL: an ordinary integer duration is untouched, so the assertions below mean something', () => {
+    const merged = mergeFile({ resultTimeoutMs: 1800000 })
+    assert.equal(merged.resultTimeoutMs, 1800000)
+    assert.equal(coerceDurationConfigValue('resultTimeoutMs', 1800000), 1800000)
+  })
+
+  it('coerces a fractional value from the CONFIG FILE — the case an env-only fix misses', () => {
+    // ~/.chroxy/config.json is JSON, so 1800000.5 arrives as a number with no parse
+    // step. A fix inside parseEnvValue would leave this path fully broken.
+    const merged = mergeFile({ resultTimeoutMs: 1800000.5 })
+    assert.equal(merged.resultTimeoutMs, 1800000)
+    assert.ok(Number.isInteger(merged.resultTimeoutMs))
+  })
+
+  it('coerces a fractional value from the ENV path', () => {
+    process.env.CHROXY_RESULT_TIMEOUT_MS = '1800000.5'
+    const merged = mergeFile({})
+    assert.equal(merged.resultTimeoutMs, 1800000)
+  })
+
+  it('coerces on the CLI-override branch too (the fix is in setValue, not one branch)', () => {
+    const merged = mergeConfig({ cliOverrides: { resultTimeoutMs: 1800000.5 } })
+    assert.equal(merged.resultTimeoutMs, 1800000)
+  })
+
+  it('covers every allowlisted duration key, not just the one in the issue', () => {
+    for (const key of DURATION_MS_CONFIG_KEYS) {
+      assert.equal(coerceDurationConfigValue(key, 90000.7), 90000, `${key} must coerce`)
+    }
+  })
+
+  // --- the scope boundary: what must NOT be touched -------------------------
+
+  it('does NOT coerce costBudget — it is USD, and 0.50 -> 0 would disable the budget', () => {
+    // The single most important assertion here. `config.costBudget || null` treats 0 as
+    // "no budget", so truncating a sub-dollar cap silently removes the cap entirely.
+    assert.equal(coerceDurationConfigValue('costBudget', 0.5), 0.5)
+    assert.equal(coerceDurationConfigValue('costBudget', 5.5), 5.5)
+    assert.equal(mergeFile({ costBudget: 0.5 }).costBudget, 0.5)
+    process.env.CHROXY_COST_BUDGET = '5.50'
+    assert.equal(mergeFile({}).costBudget, 5.5)
+  })
+
+  it('does NOT coerce non-duration numerics', () => {
+    assert.equal(coerceDurationConfigValue('port', 8765.9), 8765.9)
+    assert.equal(coerceDurationConfigValue('maxSessions', 5.7), 5.7)
+    assert.equal(mergeFile({ port: 8765.9 }).port, 8765.9)
+  })
+
+  it('does NOT recurse into nested objects (pricing/billing are legitimately fractional)', () => {
+    // A recursive walk would destroy providers.*.pricing.input and
+    // billing.monthlyCreditBudgetUsd. The helper is a flat key lookup by design.
+    const merged = mergeFile({
+      billing: { monthlyCreditBudgetUsd: 12.5 },
+      worktreeGc: { reapIntervalMs: 900000.5 },
+    })
+    assert.equal(merged.billing.monthlyCreditBudgetUsd, 12.5, 'nested USD survives')
+    assert.equal(merged.worktreeGc.reapIntervalMs, 900000.5, 'nested ms is out of scope — see the comment in config.js')
+  })
+
+  // --- boundaries and sentinels ---------------------------------------------
+
+  it('truncation never pushes a legal value below its documented minimum', () => {
+    // Every minimum is an integer, so trunc(v) >= min holds for any v >= min. Pinned
+    // rather than argued: validateConfig must emit no below-minimum warning.
+    const merged = mergeFile({
+      resultTimeoutMs: 30000.9, streamStallTimeoutMs: 5000.9,
+      backgroundShellHardQuiesceMs: 60000.9, mcpToolCallTimeoutMs: 1000.9,
+    })
+    assert.equal(merged.resultTimeoutMs, 30000)
+    assert.equal(merged.streamStallTimeoutMs, 5000)
+    const warnings = (validateConfig(merged).warnings || []).join('\n')
+    assert.ok(!/minimum/i.test(warnings), `no below-minimum warning expected, got: ${warnings}`)
+  })
+
+  it('NEVER manufactures the 0 "disabled" sentinel from a non-zero input', () => {
+    // trunc(0.4) === 0 would silently switch stall detection OFF — turning a value that
+    // warns today into a quietly disabled feature. Sub-1 magnitudes go to +/-1: still
+    // illegal, still warned about, never the sentinel.
+    assert.equal(coerceDurationConfigValue('streamStallTimeoutMs', 0.4), 1)
+    assert.notEqual(coerceDurationConfigValue('streamStallTimeoutMs', 0.4), 0)
+    assert.equal(coerceDurationConfigValue('streamStallTimeoutMs', -0.5), -1)
+    assert.equal(coerceDurationConfigValue('backgroundShellHardQuiesceMs', 0.4), 1)
+    // and the coerced value is still out of range, so the operator still gets told
+    const warnings = (validateConfig(mergeFile({ streamStallTimeoutMs: 0.4 })).warnings || []).join('\n')
+    assert.ok(/streamStallTimeoutMs/.test(warnings), `expected a range warning, got: ${warnings}`)
+  })
+
+  it('an explicit 0 is preserved (disable stays disable)', () => {
+    assert.equal(coerceDurationConfigValue('streamStallTimeoutMs', 0), 0)
+    assert.equal(mergeFile({ streamStallTimeoutMs: 0 }).streamStallTimeoutMs, 0)
+  })
+
+  it('preserves the NaN-passthrough and Infinity contracts', () => {
+    // parseEnvValue returns the raw STRING when parseFloat yields NaN; the range checks
+    // have documented Infinity semantics. Both must survive the coercion untouched.
+    assert.equal(coerceDurationConfigValue('resultTimeoutMs', 'notanumber'), 'notanumber')
+    assert.equal(coerceDurationConfigValue('hardTimeoutMs', Infinity), Infinity)
+    assert.equal(coerceDurationConfigValue('hardTimeoutMs', -Infinity), -Infinity)
+    process.env.CHROXY_RESULT_TIMEOUT_MS = 'notanumber'
+    assert.equal(typeof mergeFile({}).resultTimeoutMs, 'string')
+  })
+
+  // --- drift + the thing this actually unblocks ------------------------------
+
+  it('DRIFT GUARD: the allowlist equals every *Ms number key in CONFIG_SCHEMA', () => {
+    // A new duration option that is not allowlisted would silently opt out of the fix.
+    // Source-scanned with a line reader, not grep — grep returns empty on large files.
+    const lines = readFileSync(CONFIG_SRC, 'utf8').split('\n')
+    const start = lines.findIndex((l) => l.includes('CONFIG_SCHEMA') && l.includes('='))
+    assert.ok(start > 0, 'CONFIG_SCHEMA must be findable')
+    const found = new Set()
+    for (const line of lines.slice(start, start + 400)) {
+      const m = line.match(/^\s*(\w+Ms):\s*'number'/)
+      if (m) found.add(m[1])
+    }
+    assert.ok(found.size > 0, 'the scan found no *Ms number keys — the scan itself is broken')
+    assert.deepEqual(
+      [...found].sort(), [...DURATION_MS_CONFIG_KEYS].sort(),
+      'DURATION_MS_CONFIG_KEYS has drifted from CONFIG_SCHEMA — add the new duration key (or document why it is excluded)',
+    )
+  })
+
+  it('the emitted inactivity_warning satisfies the REAL wire schema (this unblocks #7095)', () => {
+    process.env.CHROXY_RESULT_TIMEOUT_MS = '1800000.5'
+    const merged = mergeFile({})
+    // Field set taken from ServerInactivityWarningSchema itself — an invented shape
+    // would fail for a reason unrelated to idleMs and prove nothing about the fix.
+    const frame = { type: 'inactivity_warning', messageId: 'm1', prefab: 'idle', idleMs: merged.resultTimeoutMs }
+    assert.ok(
+      ServerInactivityWarningSchema.safeParse(frame).success,
+      `the emitted frame must be wire-legal; idleMs was ${merged.resultTimeoutMs}`,
+    )
+    // Negative control: the RAW fractional value is what the schema rejects, so the
+    // test above passes because of the coercion and not for some unrelated reason.
+    const raw = { ...frame, idleMs: 1800000.5 }
+    assert.equal(ServerInactivityWarningSchema.safeParse(raw).success, false)
+  })
+})


### PR DESCRIPTION
Closes #7083 · unblocks #7095

## Problem

A fractional `*_MS` option survived with **zero** `validateConfig` warnings and reached the wire as `inactivity_warning.idleMs`, against a schema requiring `.int()`.

## Where the fix goes, and why not where the issue said

The issue proposed fixing `parseEnvValue`'s `'number'` branch. **That would have closed half the bug.** `~/.chroxy/config.json` is JSON, so `{"resultTimeoutMs": 1800000.5}` — the exact case in the issue — arrives as a number with *no parse step to hook*.

The coercion sits in `mergeConfig`'s `setValue`, verified as the **sole writer** into the merged object (`merged[key] =` appears exactly once in the file). One change covers all four precedence branches — CLI, env, file, defaults — and also covers `server-cli-child.js`, which calls `mergeConfig` and never calls `validateConfig`.

## The exclusion is the important part

An **explicit six-key allowlist**, not `key.endsWith('Ms')`.

The suffix does select exactly these six today — but the `'number'` env branch is shared with **`costBudget`, which is USD**. Coercing it truncates a spend cap, and `0.50 → 0` makes `config.costBudget || null` **falsy**, disabling the budget entirely with no signal. A convention-driven predicate would have been correct by accident, and nothing would have told the next reviewer that.

The convention is kept as a **drift test** instead: it source-scans `CONFIG_SCHEMA` for `*Ms: 'number'` keys and asserts set-equality with the allowlist, so a new duration option that isn't listed **fails CI** rather than silently opting out.

Also excluded, and stated in the code: **nested** ms options under `'object'`-typed keys. A recursive walk would destroy `providers.*.pricing.input` and `billing.monthlyCreditBudgetUsd`, which are legitimately fractional. Follow-up, not silence.

## Two semantics worth reviewing

**`Math.trunc`, not `Math.round`.** `round(29999.5) → 30000` lifts an *illegal* value up into legality and silently suppresses a below-minimum warning. Truncation can't. And since every documented minimum is an integer, `trunc(v) ≥ min` for any legal `v` — so no option can newly trip a below-minimum warning. Pinned by a boundary test rather than argued.

**The zero guard is load-bearing.** `0` is the documented "disabled" sentinel for `streamStallTimeoutMs` and `backgroundShellHardQuiesceMs`. A naive `Math.trunc(0.4) === 0` would silently switch stall detection **off** — converting a value that warns today into a quietly disabled feature. Sub-1 magnitudes go to ±1: still illegal, still warned about, never the sentinel.

## Verification

331 tests across `config-duration-coercion`, `config`, `config-range-validation`, `duration`, `config-skip-permissions`, `ws-server` — **no existing test changed**, which was the falsifiable claim. 5/5 custom server lints, eslint clean.

All five guards mutation-verified **individually**:

| Mutation (applied alone) | Tests reddened |
|---|---|
| drop the allowlist (coerce every numeric) | 2 — **costBudget** + non-duration |
| drop the zero guard (naive `trunc`) | 1 — the sentinel test |
| coercion not applied at `setValue` | 5 — incl. the config-FILE case |
| a duration key falls off the allowlist | 1 — the drift guard |
| `Math.round` instead of `Math.trunc` | 5 |

The suite includes a **CONTROL** (an ordinary integer duration is untouched) so the coercion assertions can't pass because everything is being rewritten, and the schema round-trip carries a **negative control** — the raw `1800000.5` must fail — so it passes because of the coercion and not for an unrelated reason.

## Deliberately not in this PR

- **Not removing `ws-history.js:468-489`'s `Number.isSafeInteger` guard.** It isn't redundant: it also clamps `> 0` and `<= MAX_SANE_DURATION_MS` (the range table is warn-only and never clamps, so `1e300` passes coercion untouched), and it covers post-construction mutation of `server.config.*` and embedders that build a config without `mergeConfig`.
- **Not tightening `isOperatorTimeoutInRange`** — it *rejects* rather than coerces, a different operator-visible outcome, across 6+ call sites.
- **Not adding `.int()` to the schemas** — that's #7095, and it must land after this.

One behaviour change worth naming: `auth_ok` now carries the operator's truncated value instead of falling back to defaults for a fractional config, because `Number.isSafeInteger` now passes. That is the intended fix — the runtime timer and the wire value now agree instead of diverging.