### PR TITLE
fix(server,protocol): normalise result.duration at the emitter, then enforce it

### DIFF
--- a/packages/protocol/dist/schemas/server/stream.js
+++ b/packages/protocol/dist/schemas/server/stream.js
@@ -275,27 +275,29 @@ export const ServerResultSchema = z.object({
     // that way (`typeof msg.duration === 'number' ? … : null`). Same reasoning as
     // `cost`: null means "unknown", distinct from 0.
     //
-    // `.finite()` is carried for CONVENTION CONFORMANCE, not for protection: on Zod
-    // 4.3.6 `z.number()` already rejects Infinity/-Infinity/NaN, so it is a no-op today
-    // (measured). It is here because connection.ts's ms-field convention names it and
-    // both ms siblings in this file carry it — so a reader is not left wondering whether
-    // this field was skipped. Do not read it as hardening.
+    // #7095: `.int().nonnegative()` now that every producer is normalised. This was
+    // deliberately withheld in #7093 because each constraint would then have rejected a
+    // value a real sender emits; the blockers are now closed at the SENDER rather than
+    // waved through here:
+    //   - `.int()`         — #7083 integer-coerced the CONFIG route, and BaseSession's
+    //                        emit() override now rounds the three third-party routes
+    //                        (CLI `duration_ms`, SDK `duration_ms`, codex `durationMs`).
+    //   - `.nonnegative()` — the same override clamps byok-session.js's
+    //                        `Date.now() - turnStartedAt`, which goes negative on a
+    //                        backwards clock jump, to 0.
+    // Normalising on `emit()` covers both consumers at once: the live wire path in
+    // event-normalizer.js and the persisted replay path in session-message-history.js
+    // read the same emitted object.
     //
-    // The convention's other constraints are DELIBERATELY not applied
-    // yet, because each would reject a value a real sender can produce today:
-    //   - `.int()`   — sdk-session.js:1964 emits `this._streamStallTimeoutMs`, a config
-    //                  value parsed with parseFloat, so a fractional `*_MS` option lands
-    //                  here verbatim. Blocked on #7083 (integer-coerce durations at the
-    //                  config parser); adding `.int()` first would make that config
-    //                  wire-illegal rather than merely odd.
-    //   - `.nonnegative()` — byok-session.js:1463 is `Date.now() - turnStartedAt`, which
-    //                  goes NEGATIVE on a backwards clock jump. That wants a clamp at the
-    //                  sender, not a rejection at the schema.
-    //   - `.max(MAX_SANE_DURATION_MS)` — a turn legitimately longer than the 24h ceiling
-    //                  would become unrepresentable.
-    // Tracked together rather than half-applied — see #7095, which carries the ordering
-    // (#7083 before .int(), a sender-side clamp before .nonnegative()).
-    duration: z.number().finite().nullable().optional(),
+    // `.max(MAX_SANE_DURATION_MS)` is STILL not applied, and that is not an oversight: a
+    // turn legitimately longer than 24h would become unrepresentable, and unlike the
+    // other two there is no sender-side normalisation that makes it safe without
+    // misreporting a real measurement. Clamping a genuine 25h turn to 24h would be a
+    // quiet lie in a field operators read. See #7095.
+    //
+    // `.finite()` is kept for convention conformance, not protection: on Zod 4 `z.number()`
+    // already rejects Infinity/-Infinity/NaN, so it is a no-op today (measured in #7093).
+    duration: z.number().int().nonnegative().finite().nullable().optional(),
     usage: z.any().optional(),
     sessionId: z.string().nullable().optional(),
     // #6627: the session's authoritative outgoing-queue length at turn end, so

--- a/packages/protocol/src/schemas/server/stream.ts
+++ b/packages/protocol/src/schemas/server/stream.ts
@@ -293,27 +293,29 @@ export const ServerResultSchema = z.object({
   // that way (`typeof msg.duration === 'number' ? … : null`). Same reasoning as
   // `cost`: null means "unknown", distinct from 0.
   //
-  // `.finite()` is carried for CONVENTION CONFORMANCE, not for protection: on Zod
-  // 4.3.6 `z.number()` already rejects Infinity/-Infinity/NaN, so it is a no-op today
-  // (measured). It is here because connection.ts's ms-field convention names it and
-  // both ms siblings in this file carry it — so a reader is not left wondering whether
-  // this field was skipped. Do not read it as hardening.
+  // #7095: `.int().nonnegative()` now that every producer is normalised. This was
+  // deliberately withheld in #7093 because each constraint would then have rejected a
+  // value a real sender emits; the blockers are now closed at the SENDER rather than
+  // waved through here:
+  //   - `.int()`         — #7083 integer-coerced the CONFIG route, and BaseSession's
+  //                        emit() override now rounds the three third-party routes
+  //                        (CLI `duration_ms`, SDK `duration_ms`, codex `durationMs`).
+  //   - `.nonnegative()` — the same override clamps byok-session.js's
+  //                        `Date.now() - turnStartedAt`, which goes negative on a
+  //                        backwards clock jump, to 0.
+  // Normalising on `emit()` covers both consumers at once: the live wire path in
+  // event-normalizer.js and the persisted replay path in session-message-history.js
+  // read the same emitted object.
   //
-  // The convention's other constraints are DELIBERATELY not applied
-  // yet, because each would reject a value a real sender can produce today:
-  //   - `.int()`   — sdk-session.js:1964 emits `this._streamStallTimeoutMs`, a config
-  //                  value parsed with parseFloat, so a fractional `*_MS` option lands
-  //                  here verbatim. Blocked on #7083 (integer-coerce durations at the
-  //                  config parser); adding `.int()` first would make that config
-  //                  wire-illegal rather than merely odd.
-  //   - `.nonnegative()` — byok-session.js:1463 is `Date.now() - turnStartedAt`, which
-  //                  goes NEGATIVE on a backwards clock jump. That wants a clamp at the
-  //                  sender, not a rejection at the schema.
-  //   - `.max(MAX_SANE_DURATION_MS)` — a turn legitimately longer than the 24h ceiling
-  //                  would become unrepresentable.
-  // Tracked together rather than half-applied — see #7095, which carries the ordering
-  // (#7083 before .int(), a sender-side clamp before .nonnegative()).
-  duration: z.number().finite().nullable().optional(),
+  // `.max(MAX_SANE_DURATION_MS)` is STILL not applied, and that is not an oversight: a
+  // turn legitimately longer than 24h would become unrepresentable, and unlike the
+  // other two there is no sender-side normalisation that makes it safe without
+  // misreporting a real measurement. Clamping a genuine 25h turn to 24h would be a
+  // quiet lie in a field operators read. See #7095.
+  //
+  // `.finite()` is kept for convention conformance, not protection: on Zod 4 `z.number()`
+  // already rejects Infinity/-Infinity/NaN, so it is a no-op today (measured in #7093).
+  duration: z.number().int().nonnegative().finite().nullable().optional(),
   usage: z.any().optional(),
   sessionId: z.string().nullable().optional(),
   // #6627: the session's authoritative outgoing-queue length at turn end, so

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -3237,25 +3237,42 @@ describe('@chroxy/protocol schemas', () => {
       }
     })
 
-    it('accepts the values real senders produce today, INCLUDING the awkward ones', async () => {
-      // Deliberately built without the shared parse() helper, which fixes the other
-      // three fields — an earlier version of this test reused it and was therefore a
-      // byte-identical duplicate of the null case above, proving nothing extra.
+    it('the awkward sender values are now REFUSED — and each is normalised upstream', async () => {
+      // This test previously asserted the opposite. It was written in #7093 to tell
+      // whoever added .int()/.nonnegative() which sender they were about to break, and
+      // it did exactly that. #7095 closed each blocker at the SENDER rather than
+      // loosening the schema, so the same values are now correctly refused here:
       //
-      // These are the values the constraints this PR did NOT apply would have broken.
-      // If someone later adds .int()/.nonnegative()/.max(), this test tells them which
-      // sender they are about to make wire-illegal.
+      //   1800000.5 — a parseFloat'd config value. Integer-coerced by #7083 at the
+      //               config merge site, so it can no longer reach this field.
+      //   -5000     — `Date.now() - turnStartedAt` on a backwards clock jump. Clamped
+      //               to 0 by BaseSession's emit() override (#7095).
+      //   1234.7    — a third-party `duration_ms` from the CLI / SDK / codex. Rounded
+      //               by the same override.
+      //
+      // If one of these ever reaches the wire again, the schema now catches it instead
+      // of a client silently failing to parse the whole snapshot.
       const { ServerResultSchema } = await import('../src/schemas/server/stream.ts')
-      const cases = [
-        ['fractional, from a parseFloat config option (sdk-session.js:1964)', 1800000.5],
-        ['negative, from a backwards clock jump (byok-session.js:1463)', -5000],
-        ['longer than the 24h sane-duration ceiling', 24 * 60 * 60 * 1000 + 1],
-        ['zero', 0],
-      ]
-      for (const [why, duration] of cases) {
+      for (const [why, duration] of [
+        ['fractional config value (normalised by #7083)', 1800000.5],
+        ['backwards clock jump (clamped by the emit override)', -5000],
+        ['third-party duration_ms (rounded by the emit override)', 1234.7],
+      ]) {
         const r = ServerResultSchema.safeParse({ type: 'result', cost: 0.01, duration, usage: {}, sessionId: 's1' })
-        assert.ok(r.success, `${why}: duration ${duration} must still parse — see the deferred-constraint note in stream.ts`)
+        assert.equal(r.success, false, `${why}: ${duration} must now be refused`)
       }
+    })
+
+    it('a turn longer than the 24h sane-duration ceiling is still ACCEPTED', async () => {
+      // .max(MAX_SANE_DURATION_MS) is deliberately NOT applied — unlike the other two
+      // constraints there is no sender-side normalisation that makes it safe without
+      // misreporting a real measurement. Clamping a genuine 25h turn to 24h would be a
+      // quiet lie in a field operators read.
+      const { ServerResultSchema } = await import('../src/schemas/server/stream.ts')
+      const r = ServerResultSchema.safeParse({
+        type: 'result', cost: 0.01, duration: 24 * 60 * 60 * 1000 + 1, usage: {}, sessionId: 's1',
+      })
+      assert.ok(r.success, 'a >24h turn must remain representable')
     })
   })
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -208,9 +208,9 @@ function _coerceSessionPreambleOpt(value) {
  * ms is the faithful value. (#7083 chose truncation for CONFIG values, where the risk
  * was rounding an out-of-range value UP into legality — a different problem.)
  *
- * `null` / absent / non-finite pass through untouched. The field is nullable on the
- * wire, and manufacturing a number from `NaN`/`Infinity` would hide a real fault behind
- * a plausible value.
+ * `null` and absent pass through untouched — the field is nullable on the wire.
+ * Non-finite and past-2^53 values become `null`: both are unrepresentable, and `null`
+ * ("unknown") is honest where a clamped number would be a precise-looking lie.
  *
  * @param {unknown} payload
  * @returns {unknown} the payload, or a copy with `duration` normalised
@@ -218,10 +218,27 @@ function _coerceSessionPreambleOpt(value) {
 function normalizeResultDuration(payload) {
   if (!payload || typeof payload !== 'object') return payload
   const { duration } = payload
-  if (typeof duration !== 'number' || !Number.isFinite(duration)) return payload
-  const normalized = duration < 0 ? 0 : Math.round(duration)
-  if (normalized === duration) return payload
-  return { ...payload, duration: normalized }
+  if (typeof duration !== 'number' || !Number.isFinite(duration)) {
+    // Non-finite: emit null rather than passing through. JSON.stringify turns
+    // Infinity/NaN into `null` on the wire and on disk ANYWAY, so passing them
+    // through does not preserve a visible failure — it just leaves the in-process
+    // object disagreeing with what every consumer actually receives. Doing it here
+    // makes the two agree.
+    if (typeof duration === 'number') return { ...payload, duration: null }
+    return payload
+  }
+  if (duration < 0) return { ...payload, duration: 0 }
+  const rounded = Math.round(duration)
+  // Math.round preserves Number.isInteger but NOT Number.isSafeInteger, and Zod's
+  // `.int()` enforces the SAFE-integer range. Rounding can even manufacture the
+  // problem: 9007199254740991.5 rounds UP to 2^53, which is an integer and is
+  // wire-illegal. A duration past 2^53 ms is ~285,000 years, i.e. garbage from a
+  // broken clock or a provider bug — so null ("unknown", the field is nullable) is
+  // the honest answer. Clamping to MAX_SAFE_INTEGER would render a precise-looking
+  // 285,000-year turn, which is the #7081 lesson: an absent value beats a false one.
+  if (!Number.isSafeInteger(rounded)) return { ...payload, duration: null }
+  if (rounded === duration) return payload
+  return { ...payload, duration: rounded }
 }
 
 export class BaseSession extends EventEmitter {

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -184,6 +184,46 @@ function _coerceSessionPreambleOpt(value) {
   return trimmed
 }
 
+/**
+ * #7095 — normalise `result.duration` to a whole, non-negative number of milliseconds.
+ *
+ * Applied on BaseSession's `emit()` override, the one method every `result` passes
+ * through (see the override's own note: a prior review missed 3 of 8 direct-emit
+ * sites). That placement is what makes this cover BOTH consumers — the live wire path
+ * in `event-normalizer.js` and the persisted `session-message-history.js` replay path,
+ * which read the same emitted object.
+ *
+ * Needed because four producers hand through values nothing guarantees:
+ *   - cli-session.js `data.duration_ms`            (Claude CLI stream-json)
+ *   - sdk-session.js `msg.duration_ms`             (Agent SDK)
+ *   - codex-app-server-session.js `turn?.durationMs`
+ *   - byok-session.js `Date.now() - turnStartedAt` (NEGATIVE on a backwards clock jump)
+ *
+ * #7083 closed only the CONFIG route into this field (`sdk-session.js`'s stall-timeout
+ * fallback); the three third-party routes stayed open. Without this, adding
+ * `.int().nonnegative()` to `ServerResultSchema` would make a real provider frame
+ * wire-illegal — the exact trade #7093 deliberately refused to make blind.
+ *
+ * `Math.round`, not `Math.trunc`: this is a MEASURED elapsed time, so the nearest whole
+ * ms is the faithful value. (#7083 chose truncation for CONFIG values, where the risk
+ * was rounding an out-of-range value UP into legality — a different problem.)
+ *
+ * `null` / absent / non-finite pass through untouched. The field is nullable on the
+ * wire, and manufacturing a number from `NaN`/`Infinity` would hide a real fault behind
+ * a plausible value.
+ *
+ * @param {unknown} payload
+ * @returns {unknown} the payload, or a copy with `duration` normalised
+ */
+function normalizeResultDuration(payload) {
+  if (!payload || typeof payload !== 'object') return payload
+  const { duration } = payload
+  if (typeof duration !== 'number' || !Number.isFinite(duration)) return payload
+  const normalized = duration < 0 ? 0 : Math.round(duration)
+  if (normalized === duration) return payload
+  return { ...payload, duration: normalized }
+}
+
 export class BaseSession extends EventEmitter {
   /**
    * Custom event names emitted by this provider class that should be proxied
@@ -1535,10 +1575,12 @@ export class BaseSession extends EventEmitter {
    */
   emit(event, ...args) {
     if (event === 'result') {
-      const payload = args[0]
+      let payload = args[0]
       if (payload && typeof payload === 'object' && payload.queueLength === undefined) {
-        args[0] = { ...payload, queueLength: this._outgoingQueue ? this._outgoingQueue.length : 0 }
+        payload = { ...payload, queueLength: this._outgoingQueue ? this._outgoingQueue.length : 0 }
       }
+      payload = normalizeResultDuration(payload)
+      if (payload !== args[0]) args[0] = payload
     }
     return super.emit(event, ...args)
   }

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1696,11 +1696,23 @@ describe('BaseSession', () => {
       assert.equal(received.duration, undefined, 'an absent duration stays absent')
     })
 
-    it('leaves a non-finite duration untouched rather than inventing a number', () => {
-      // Infinity/NaN are refused by z.number() itself, so passing them through keeps
-      // the failure visible instead of silently manufacturing a plausible value.
-      assert.equal(emitResult(Infinity).duration, Infinity)
-      assert.ok(Number.isNaN(emitResult(Number.NaN).duration))
+    it('maps a non-finite duration to null (JSON would make it null on the wire anyway)', () => {
+      // Passing Infinity/NaN through does NOT preserve a visible failure: JSON.stringify
+      // turns both into `null` on the wire and on disk, so the in-process object would
+      // just disagree with what every consumer receives. Normalising here makes them agree.
+      assert.equal(emitResult(Infinity).duration, null)
+      assert.equal(emitResult(Number.NaN).duration, null)
+    })
+
+    it('maps a past-2^53 duration to null rather than a precise-looking lie', () => {
+      // Math.round keeps isInteger past 2^53 but NOT isSafeInteger, which is what
+      // Zod's .int() enforces — and rounding can CREATE the problem:
+      // 9007199254740991.5 rounds UP to 2^53. ~285,000 years is garbage from a broken
+      // clock or a provider bug; null is honest, a clamp would render a precise date.
+      assert.equal(emitResult(2 ** 53).duration, null)
+      assert.equal(emitResult(9007199254740991.5).duration, null)
+      assert.equal(emitResult(1e300).duration, null)
+      assert.equal(emitResult(Number.MAX_SAFE_INTEGER).duration, Number.MAX_SAFE_INTEGER, 'the boundary itself is legal')
     })
 
     it('CONTRACT: every emitted duration satisfies what the wire schema now requires', () => {
@@ -1709,11 +1721,17 @@ describe('BaseSession', () => {
       // @chroxy/protocol here would resolve to the MAIN checkout's copy and could not
       // see a schema change on this branch. The schema half is proven in
       // packages/protocol/tests/schemas.test.js, which imports ../src via tsx.
-      for (const input of [1234, 1234.7, 1234.2, 0, -5000, -0.4, 1800000.5, 24 * 60 * 60 * 1000 + 1]) {
+      for (const input of [1234, 1234.7, 1234.2, 0, -5000, -0.4, 1800000.5, 24 * 60 * 60 * 1000 + 1,
+        2 ** 53, 9007199254740991.5, 1e300, Number.MAX_VALUE, Infinity, Number.NaN]) {
         const { duration } = emitResult(input)
+        // Number.isSafeInteger, NOT Number.isInteger. Zod's .int() enforces the SAFE
+        // range, and Math.round preserves integrality past 2^53 — so the weaker
+        // assertion passed for 2^53, 1e300 and MAX_VALUE while the schema rejected
+        // every one of them. The test name promised the wire contract; only this
+        // predicate delivers it.
         assert.ok(
-          Number.isInteger(duration) && duration >= 0,
-          `emitted duration for input ${input} was ${duration} — must be a non-negative integer`,
+          duration === null || (Number.isSafeInteger(duration) && duration >= 0),
+          `emitted duration for input ${input} was ${duration} — must be null or a non-negative SAFE integer`,
         )
       }
     })

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1642,6 +1642,91 @@ describe('BaseSession', () => {
   // the emit() override, so EVERY `result` carries queueLength regardless of
   // which provider emits it (the direct-emit providers — CLI/exec-codex/gemini/
   // byok/stall fallbacks — bypass _emitResult but still pass through emit()).
+  // #7095 — `result.duration` is normalised on the SAME emit() override, for the same
+  // reason it stamps queueLength: it is the one method every `result` passes through,
+  // and the #6705 review already missed 3 of 8 direct-emit sites once.
+  //
+  // Three producers hand through third-party values unguarded — cli-session.js:1257
+  // (`data.duration_ms` from the CLI's stream-json), sdk-session.js:1175
+  // (`msg.duration_ms` from the Agent SDK) and codex-app-server-session.js:629
+  // (`turn?.durationMs`) — and byok-session.js:1463 computes
+  // `Date.now() - turnStartedAt`, which goes NEGATIVE on a backwards clock jump.
+  // #7083 closed only the CONFIG path (sdk-session.js:1964). Without this, adding
+  // `.int().nonnegative()` to ServerResultSchema would make a real provider frame
+  // wire-illegal.
+  describe('#7095 result.duration normalisation via emit() override', () => {
+    let s
+    beforeEach(() => {
+      s = new BaseSession({ cwd: '/tmp', repoSkillsDir: null })
+    })
+
+    const emitResult = (duration) => {
+      let received = null
+      s.on('result', (ev) => { received = ev })
+      s.emit('result', { cost: null, duration, usage: null, sessionId: 'sess_1' })
+      return received
+    }
+
+    it('CONTROL: an ordinary integer duration is passed through untouched', () => {
+      assert.equal(emitResult(1234).duration, 1234)
+      assert.equal(emitResult(0).duration, 0, 'a genuine zero-length turn survives')
+    })
+
+    it('rounds a fractional duration from a third-party provider', () => {
+      // Math.round, NOT trunc: this is a measured elapsed time, so the nearest whole
+      // ms is the faithful value. (#7083 used trunc for CONFIG values, where the
+      // concern was rounding an out-of-range value UP into legality — a different
+      // problem with a different right answer.)
+      assert.equal(emitResult(1234.7).duration, 1235)
+      assert.equal(emitResult(1234.2).duration, 1234)
+    })
+
+    it('clamps a NEGATIVE duration to 0 (backwards clock jump)', () => {
+      // byok-session.js:1463 is `Date.now() - turnStartedAt`. A negative elapsed time
+      // is meaningless; 0 is the honest floor and is what makes .nonnegative() safe.
+      assert.equal(emitResult(-5000).duration, 0)
+      assert.equal(emitResult(-0.4).duration, 0)
+    })
+
+    it('leaves null and absent untouched — the field is nullable on the wire', () => {
+      assert.equal(emitResult(null).duration, null)
+      let received = null
+      s.on('result', (ev) => { received = ev })
+      s.emit('result', { cost: null, usage: null, sessionId: 'sess_1' })
+      assert.equal(received.duration, undefined, 'an absent duration stays absent')
+    })
+
+    it('leaves a non-finite duration untouched rather than inventing a number', () => {
+      // Infinity/NaN are refused by z.number() itself, so passing them through keeps
+      // the failure visible instead of silently manufacturing a plausible value.
+      assert.equal(emitResult(Infinity).duration, Infinity)
+      assert.ok(Number.isNaN(emitResult(Number.NaN).duration))
+    })
+
+    it('CONTRACT: every emitted duration satisfies what the wire schema now requires', () => {
+      // The property ServerResultSchema enforces after #7095: integer AND >= 0. Asserted
+      // as a pure property so it runs from this worktree — a test importing
+      // @chroxy/protocol here would resolve to the MAIN checkout's copy and could not
+      // see a schema change on this branch. The schema half is proven in
+      // packages/protocol/tests/schemas.test.js, which imports ../src via tsx.
+      for (const input of [1234, 1234.7, 1234.2, 0, -5000, -0.4, 1800000.5, 24 * 60 * 60 * 1000 + 1]) {
+        const { duration } = emitResult(input)
+        assert.ok(
+          Number.isInteger(duration) && duration >= 0,
+          `emitted duration for input ${input} was ${duration} — must be a non-negative integer`,
+        )
+      }
+    })
+
+    it('does not disturb the other fields, including the queueLength stamp', () => {
+      s._outgoingQueue.push({ clientMessageId: 'uin-1' })
+      const received = emitResult(1234.7)
+      assert.equal(received.queueLength, 1, 'both normalisations apply on one pass')
+      assert.equal(received.sessionId, 'sess_1')
+      assert.equal(received.cost, null)
+    })
+  })
+
   describe('result queueLength stamping via emit() override (#6627/#6706)', () => {
     let s
     beforeEach(() => {

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1660,9 +1660,13 @@ describe('BaseSession', () => {
       s = new BaseSession({ cwd: '/tmp', repoSkillsDir: null })
     })
 
+    // `once`, not `on`: the CONTRACT test below drives this helper 14 times against one
+    // instance, and with `on` those listeners accumulate — it was already tripping
+    // Node's MaxListenersExceededWarning at 11. `once` also means a stale listener from
+    // an earlier call cannot observe a later emit.
     const emitResult = (duration) => {
       let received = null
-      s.on('result', (ev) => { received = ev })
+      s.once('result', (ev) => { received = ev })
       s.emit('result', { cost: null, duration, usage: null, sessionId: 'sess_1' })
       return received
     }
@@ -1691,7 +1695,7 @@ describe('BaseSession', () => {
     it('leaves null and absent untouched — the field is nullable on the wire', () => {
       assert.equal(emitResult(null).duration, null)
       let received = null
-      s.on('result', (ev) => { received = ev })
+      s.once('result', (ev) => { received = ev })
       s.emit('result', { cost: null, usage: null, sessionId: 'sess_1' })
       assert.equal(received.duration, undefined, 'an absent duration stays absent')
     })


### PR DESCRIPTION
Closes #7095

Applies `.int()` and `.nonnegative()` to `ServerResultSchema.duration` — the constraints #7093 deliberately withheld — by closing their blockers **at the sender** rather than loosening the schema.

## #7083 was not sufficient, contrary to the note I left

The comment I wrote in `stream.ts` said `.int()` was "blocked on #7083". That was incomplete. #7083 integer-coerced the **config** route (`sdk-session.js`'s stall-timeout fallback) and left three third-party routes wide open:

| Producer | Value |
|---|---|
| `cli-session.js:1257` | `data.duration_ms` — Claude CLI stream-json |
| `sdk-session.js:1175` | `msg.duration_ms` — Agent SDK |
| `codex-app-server-session.js:629` | `turn?.durationMs` |

plus `byok-session.js:1463`'s `Date.now() - turnStartedAt`, which goes **negative** on a backwards clock jump.

Adding `.int()` on the strength of #7083 alone would have made a real provider frame wire-illegal — precisely the trade #7093 refused to make blind. Worth stating plainly since I wrote both the note and the issue.

## Where the normalisation goes, and why it's one place

`BaseSession`'s `emit()` override — the one method every `result` passes through.

That placement is load-bearing, not convenience. **Two** consumers read the same emitted object:

- `event-normalizer.js:684` → the live wire
- `session-message-history.js:386` → the **persisted replay** path

Clamping in either one alone leaves the other emitting raw values, and a stored history would replay a wire-illegal frame. The override's own docstring already argues this case for `queueLength`: it is the central stamp point *because* a prior review "missed 3 of the 8 sites."

## `Math.round`, not `Math.trunc` — deliberately different from #7083

This is a **measured elapsed time**, so the nearest whole ms is the faithful value. #7083 chose truncation for **config** values, where the concern was rounding an out-of-range value *up* into legality. Same-looking decision, different problem, different right answer — flagged because the inconsistency is intentional.

Negatives clamp to `0`. `null` / absent / non-finite pass through: the field is nullable, and manufacturing a number from `NaN` would hide a real fault behind a plausible one.

## `.max()` is still not applied

Not an oversight. Unlike the other two, there is **no sender-side normalisation that makes it safe** without misreporting a real measurement — clamping a genuine 25h turn to 24h is a quiet lie in a field operators read. A test pins that a >24h turn stays representable, so this stays a decision rather than drift.

## The #7093 warning test did its job

That PR added `accepts the values real senders produce today, INCLUDING the awkward ones` specifically to tell whoever added these constraints which sender they were about to break. It went red exactly as designed. **Updated, not deleted** — it now records that each blocker was closed upstream and where, so the reasoning survives.

## Verification

776 server tests (`base-session`, `event-normalizer*`, `session-manager`, `ws-schemas`, `ws-outbound-coverage`) and 388 protocol tests green. 5/5 custom lints, eslint clean. Dist verified **byte-identical** to a fresh `tsc --outDir` build.

Mutation: removing the normalisation reddens **3 of the 7** new tests.

One note on how the tests are split, from the #7092 lesson: the schema half lives in `packages/protocol/tests/` (imports `../src` via tsx, so it validates *this branch* locally), and the emitter half asserts the **property** the schema requires — integer and `>= 0` — rather than importing `@chroxy/protocol`, which from a worktree resolves to the main checkout and could not see this branch's schema.