### PR TITLE
fix(server): omit sessionId on forwarded permission_expired instead of stamping null

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -780,7 +780,15 @@ Object.assign(EVENT_MAP, {
       msg: {
         type: 'permission_expired',
         requestId: data.requestId,
-        sessionId: ctx.sessionId,
+        // #7096: OMIT when absent — do not stamp null. The wire field is
+        // `z.string().optional()`, so `undefined` is legal and `null` is not, and the
+        // legacy-cli forwarder (ws-forwarding.js) normalises with `sessionId: null`
+        // while `permission_expired` IS in its FORWARDED_EVENTS. This mirrors the
+        // guarded stamp `mcp_servers` already uses 240 lines above; the unguarded form
+        // here was the odd one out among the frames that path can carry.
+        ...(typeof ctx.sessionId === 'string' && ctx.sessionId.length > 0
+          ? { sessionId: ctx.sessionId }
+          : {}),
         message: data.message,
       },
     }],

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -512,7 +512,17 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   }
 
   if (result.kind === 'expired' || result.kind === 'not_found') {
-    ctx.transport.send(ws, { type: 'permission_expired', requestId, sessionId: originSessionId, message: 'This permission request has expired or was already handled' })
+    // #7096: OMIT sessionId when it is not a real id. `originSessionId` resolves to
+    // `client.activeSessionId`, which defaults to null (ws-server.js), so the
+    // expired/not_found branch could stamp null — and the wire field is
+    // `z.string().optional()`, where undefined is legal and null is not. This is the
+    // SECOND producer of this frame; the normalizer's mapping is the other.
+    ctx.transport.send(ws, {
+      type: 'permission_expired',
+      requestId,
+      ...(typeof originSessionId === 'string' && originSessionId.length > 0 ? { sessionId: originSessionId } : {}),
+      message: 'This permission request has expired or was already handled',
+    })
     return
   }
 

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -346,6 +346,13 @@ function setupCliForwarding(normalizer, ctx) {
   // session-manager.js `_wireSessionEvents` builtinTransient) so the legacy
   // single-CLI path also surfaces the user-initiated Stop confirmation via
   // the normalizer's `session_stopped` wire message.
+  // #7096 HAZARD: this path normalises with `sessionId: null` (see normCtx below), and
+  // several server schemas declare `sessionId: z.string().optional()` — so `undefined`
+  // is legal but `null` is NOT. Before adding an event here, check that its normalizer
+  // mapping either omits `sessionId` when absent (the `mcp_servers` / `permission_expired`
+  // pattern) or that its schema accepts null (`result`, `skill_changed`,
+  // `skill_trust_request` do). An unguarded `sessionId: ctx.sessionId` stamp on a
+  // null-rejecting schema makes every frame on this path wire-illegal.
   const FORWARDED_EVENTS = [
     'ready', 'stream_start', 'stream_delta', 'stream_end',
     'message', 'tool_start', 'tool_result', 'result', 'error',

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -78,6 +78,22 @@ function safeForward(label, fn) {
  * @param {Function} ctx.broadcast - (message, filter?) => void
  * @param {Function} ctx.broadcastToSession - (sessionId, message, filter?) => void
  */
+/**
+ * Events the LEGACY single-CLI path forwards through the normalizer.
+ *
+ * Exported so tests can iterate the real list rather than a copy — a hand-maintained
+ * duplicate in a test cannot fail when this list grows, which is exactly the false
+ * assurance #7096's first attempt shipped.
+ */
+export const FORWARDED_CLI_EVENTS = Object.freeze([
+    'ready', 'stream_start', 'stream_delta', 'stream_end',
+    'message', 'tool_start', 'tool_result', 'result', 'error',
+    'user_question', 'agent_spawned', 'agent_completed',
+    'plan_started', 'plan_ready', 'mcp_servers',
+    'permission_expired', 'skill_changed', 'skill_trust_request', 'skill_trust_granted',
+    'stopped',
+  ])
+
 export function setupForwarding(ctx) {
   const {
     normalizer,
@@ -353,14 +369,7 @@ function setupCliForwarding(normalizer, ctx) {
   // pattern) or that its schema accepts null (`result`, `skill_changed`,
   // `skill_trust_request` do). An unguarded `sessionId: ctx.sessionId` stamp on a
   // null-rejecting schema makes every frame on this path wire-illegal.
-  const FORWARDED_EVENTS = [
-    'ready', 'stream_start', 'stream_delta', 'stream_end',
-    'message', 'tool_start', 'tool_result', 'result', 'error',
-    'user_question', 'agent_spawned', 'agent_completed',
-    'plan_started', 'plan_ready', 'mcp_servers',
-    'permission_expired', 'skill_changed', 'skill_trust_request', 'skill_trust_granted',
-    'stopped',
-  ]
+  const FORWARDED_EVENTS = FORWARDED_CLI_EVENTS
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {
       // #5313 (WP-1.3): same crash shape as the multi-session listener — a

--- a/packages/server/tests/event-normalizer-schema.test.js
+++ b/packages/server/tests/event-normalizer-schema.test.js
@@ -43,6 +43,7 @@ import {
   ServerSessionStoppedSchema,
   ServerStdinDroppedTotalsSchema,
 } from '@chroxy/protocol'
+import { FORWARDED_CLI_EVENTS } from '../src/ws-forwarding.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // #6841 — event-normalizer serialization-boundary drift guard.
@@ -414,4 +415,44 @@ describe('negative meta-test: the round-trip harness catches real drift (#6892)'
         'the corrupted message; a silent pass here means the harness itself has been short-circuited',
     )
   })
+})
+
+// #7096 — the same emitters, re-run with the LEGACY-CLI context (sessionId: null).
+//
+// The existing pass above only ever sees `makeCtx()`'s hardcoded `sessionId: 'sess-1'`,
+// so a mapping that stamps `sessionId: ctx.sessionId` unguarded looked fine while
+// emitting a wire-illegal `null` on the legacy path. That is how #7096 reached main.
+//
+// Iterates the REAL exported FORWARDED_CLI_EVENTS, not a copy: a hand-maintained list
+// in a test cannot fail when the production list grows, which is the false assurance
+// the first attempt at this shipped. Adding an event to FORWARDED_CLI_EVENTS whose
+// mapping stamps sessionId unguarded now fails here automatically.
+describe('#7096 forwarded emitters under the legacy-cli context', () => {
+  const legacyCtx = (base) => ({ ...base, sessionId: null, mode: 'legacy-cli' })
+  const forwarded = new Set(FORWARDED_CLI_EVENTS)
+  const covered = FIXTURES.filter(([event]) => forwarded.has(event))
+
+  it('CONTROL: the fixture table actually covers the forwarded events', () => {
+    // Without this, the loop below could silently iterate nothing.
+    const missing = [...forwarded].filter((e) => !FIXTURES.some(([ev]) => ev === e))
+    assert.ok(
+      covered.length >= 10,
+      `expected most forwarded events to have fixtures, got ${covered.length} (missing: ${missing.join(', ')})`,
+    )
+  })
+
+  for (const [event, data, ctx] of FIXTURES) {
+    if (!forwarded.has(event)) continue
+    it(`${event}: emits wire-legal messages when sessionId is null`, () => {
+      const normalizer = new EventNormalizer({ flushIntervalMs: 10 })
+      try {
+        const result = normalizer.normalize(event, data, legacyCtx(ctx))
+        for (const entry of (result?.messages ?? [])) {
+          validateMessage(event, entry.msg)
+        }
+      } finally {
+        normalizer.destroy?.()
+      }
+    })
+  }
 })

--- a/packages/server/tests/permission-response-parity.test.js
+++ b/packages/server/tests/permission-response-parity.test.js
@@ -223,3 +223,29 @@ describe('#5373 invariant G — the WS unbound-subscription guard is WS-ONLY', (
     assert.equal(ws.mapStillHas, true, 'WS leaves the mapping intact for the legitimate subscribed client')
   })
 })
+
+// #7096 — the SECOND producer of `permission_expired`. The normalizer mapping was fixed
+// first; this one sends the frame directly via ctx.transport.send, so that fix never
+// touched it. `originSessionId` resolves to `client.activeSessionId`, which defaults to
+// null, and the wire field is `z.string().optional()` — undefined legal, null not.
+describe('#7096 permission_expired never carries sessionId: null', () => {
+  it('CONTROL: the expired branch really does emit the frame', () => {
+    // Without this, "no null sessionId" passes when nothing is emitted at all — which
+    // is exactly how the first version of this fix's sweep fooled itself.
+    const { expired } = runWs({ requestId: 'req-missing', decision: 'allow' })
+    assert.ok(expired, 'expected a permission_expired frame on the not_found branch')
+    assert.equal(expired.requestId, 'req-missing')
+  })
+
+  it('omits sessionId when the client has no active session', () => {
+    const { expired } = runWs({ requestId: 'req-missing', decision: 'allow', activeSessionId: null })
+    assert.equal('sessionId' in expired, false, `sessionId must be ABSENT, got ${JSON.stringify(expired.sessionId)}`)
+  })
+
+  it('still carries a real sessionId when the client has one', () => {
+    // The guard must suppress only the null case — dropping it always would cost the
+    // dashboard its routing key.
+    const { expired } = runWs({ requestId: 'req-missing', decision: 'allow', activeSessionId: 'sess-9' })
+    assert.equal(expired.sessionId, 'sess-9')
+  })
+})

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -98,40 +98,11 @@ describe('setupForwarding', () => {
       assert.equal(msg.sessionId, 'sess-42')
     })
 
-    it('a forwarded frame carries sessionId: null ONLY where its schema accepts null', () => {
-      // Not "never null" — that was too strong and this test caught it. Three frames
-      // deliberately ship null on this path and their schemas are `.nullable()` for
-      // exactly that reason (see the #3240 note in ws-forwarding.js: null means
-      // "applies to whatever CLI is connected"). Verified against the built schemas:
-      // result / skill_changed / skill_trust_request accept null; permission_expired
-      // and mcp_servers declare `z.string().optional()` and refuse it.
-      //
-      // So the invariant is conditional, and a NEW event added to FORWARDED_EVENTS whose
-      // normalizer stamps sessionId unguarded fails here unless it is listed — which
-      // forces whoever adds it to check their schema.
-      const NULL_ALLOWED = new Set(['result', 'skill_changed', 'skill_trust_request'])
-      const events = [
-        ['permission_expired', { requestId: 'r', message: 'm' }],
-        ['result', { cost: null, duration: 1, usage: null, sessionId: null }],
-        ['skill_changed', { name: 'x' }],
-        ['mcp_servers', { servers: [] }],
-        ['plan_started', {}],
-        ['stopped', {}],
-        ['skill_trust_request', { name: 'x' }],
-      ]
-      for (const [event, payload] of events) {
-        for (const frame of driveLegacy(event, payload)) {
-          if (!frame || typeof frame !== 'object' || !('sessionId' in frame)) continue
-          if (frame.sessionId !== null) continue
-          assert.ok(
-            NULL_ALLOWED.has(frame.type),
-            `${event} -> ${frame.type} ships sessionId: null, but its schema does not accept null. ` +
-            'Either omit the field when absent (the permission_expired/mcp_servers pattern) ' +
-            'or make the schema nullable and add it to NULL_ALLOWED.',
-          )
-        }
-      }
-    })
+    // NOTE: the exhaustive sweep that used to live here has moved to
+    // event-normalizer-schema.test.js, which re-runs EVERY emitter against the real
+    // schemas under a legacy-cli context and iterates the exported FORWARDED_CLI_EVENTS.
+    // The version here iterated a hardcoded 7-event copy of that list, so it could not
+    // fail when the production list grew — it asserted protection it did not provide.
   })
 
   describe('normalizer flush wiring', () => {

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -49,6 +49,91 @@ function makeCtx(overrides = {}) {
 }
 
 describe('setupForwarding', () => {
+
+  // #7096 — the legacy-cli forwarder normalises with `sessionId: null`, and several
+  // server schemas declare `sessionId: z.string().optional()` where `undefined` is legal
+  // but `null` is NOT. `permission_expired` stamped it unguarded, so every frame it
+  // forwarded on this path was wire-illegal.
+  //
+  // Driven through the REAL setupForwarding + EventNormalizer rather than a hand-built
+  // payload — a literal frame would prove nothing about what this path actually emits.
+  describe('#7096 forwarded frames must not carry sessionId: null', () => {
+    const driveLegacy = (event, payload) => {
+      // sessionManager MUST be null: setupForwarding wires the legacy CLI path only in
+      // the `else if (cliSession)` branch, so leaving the default manager in place
+      // silently exercises the multi-session path instead — which is what the CONTROL
+      // below caught on the first run.
+      const cliSession = new EventEmitter()
+      const ctx = makeCtx({ cliSession, sessionManager: null })
+      setupForwarding(ctx)
+      cliSession.emit(event, payload)
+      const calls = [...ctx.broadcast.mock.calls, ...ctx.broadcastToSession.mock.calls]
+      return calls.map((c) => (c.arguments.length > 1 ? c.arguments[1] : c.arguments[0]))
+    }
+
+    it('CONTROL: the legacy path really does forward permission_expired', () => {
+      // Without this, "no null sessionId" would pass because nothing was emitted at all.
+      const frames = driveLegacy('permission_expired', { requestId: 'req-1', message: 'expired' })
+      const frame = frames.find((f) => f?.type === 'permission_expired')
+      assert.ok(frame, `expected a permission_expired frame, got ${JSON.stringify(frames.map((f) => f?.type))}`)
+      assert.equal(frame.requestId, 'req-1', 'and it carries the real payload')
+    })
+
+    it('omits sessionId rather than stamping null', () => {
+      const frame = driveLegacy('permission_expired', { requestId: 'req-1', message: 'expired' })
+        .find((f) => f?.type === 'permission_expired')
+      assert.equal('sessionId' in frame, false, `sessionId must be ABSENT, got ${JSON.stringify(frame.sessionId)}`)
+    })
+
+    it('still carries sessionId on the multi-session path (the guard is not a removal)', () => {
+      // The guard must only suppress the null case — a real session id still ships, or
+      // the dashboard loses the routing key it needs.
+      const normalizer = new EventNormalizer()
+      const out = normalizer.normalize(
+        'permission_expired',
+        { requestId: 'req-1', message: 'expired' },
+        { sessionId: 'sess-42', mode: 'multi', getSessionEntry: () => ({ session: {} }) },
+      )
+      const msg = out.messages[0].msg
+      assert.equal(msg.sessionId, 'sess-42')
+    })
+
+    it('a forwarded frame carries sessionId: null ONLY where its schema accepts null', () => {
+      // Not "never null" — that was too strong and this test caught it. Three frames
+      // deliberately ship null on this path and their schemas are `.nullable()` for
+      // exactly that reason (see the #3240 note in ws-forwarding.js: null means
+      // "applies to whatever CLI is connected"). Verified against the built schemas:
+      // result / skill_changed / skill_trust_request accept null; permission_expired
+      // and mcp_servers declare `z.string().optional()` and refuse it.
+      //
+      // So the invariant is conditional, and a NEW event added to FORWARDED_EVENTS whose
+      // normalizer stamps sessionId unguarded fails here unless it is listed — which
+      // forces whoever adds it to check their schema.
+      const NULL_ALLOWED = new Set(['result', 'skill_changed', 'skill_trust_request'])
+      const events = [
+        ['permission_expired', { requestId: 'r', message: 'm' }],
+        ['result', { cost: null, duration: 1, usage: null, sessionId: null }],
+        ['skill_changed', { name: 'x' }],
+        ['mcp_servers', { servers: [] }],
+        ['plan_started', {}],
+        ['stopped', {}],
+        ['skill_trust_request', { name: 'x' }],
+      ]
+      for (const [event, payload] of events) {
+        for (const frame of driveLegacy(event, payload)) {
+          if (!frame || typeof frame !== 'object' || !('sessionId' in frame)) continue
+          if (frame.sessionId !== null) continue
+          assert.ok(
+            NULL_ALLOWED.has(frame.type),
+            `${event} -> ${frame.type} ships sessionId: null, but its schema does not accept null. ` +
+            'Either omit the field when absent (the permission_expired/mcp_servers pattern) ' +
+            'or make the schema nullable and add it to NULL_ALLOWED.',
+          )
+        }
+      }
+    })
+  })
+
   describe('normalizer flush wiring', () => {
     it('wires onFlush to broadcastToSession for session deltas', () => {
       const ctx = makeCtx()

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -67,8 +67,14 @@ describe('setupForwarding', () => {
       const ctx = makeCtx({ cliSession, sessionManager: null })
       setupForwarding(ctx)
       cliSession.emit(event, payload)
-      const calls = [...ctx.broadcast.mock.calls, ...ctx.broadcastToSession.mock.calls]
-      return calls.map((c) => (c.arguments.length > 1 ? c.arguments[1] : c.arguments[0]))
+      // Extract per SOURCE, not by arity. `broadcast` is (msg) or (msg, filter) and
+      // `broadcastToSession` is (sessionId, msg) — an arity test returns the FILTER
+      // function for a filtered broadcast, so a frame would be silently skipped rather
+      // than asserted on.
+      return [
+        ...ctx.broadcast.mock.calls.map((c) => c.arguments[0]),
+        ...ctx.broadcastToSession.mock.calls.map((c) => c.arguments[1]),
+      ]
     }
 
     it('CONTROL: the legacy path really does forward permission_expired', () => {


### PR DESCRIPTION
Closes #7096

## Problem

The legacy-cli forwarder normalises with `sessionId: null` (`ws-forwarding.js`), and `ServerPermissionExpiredSchema.sessionId` is `z.string().optional()` — so **`undefined` is legal and `null` is not**. `permission_expired` is in `FORWARDED_EVENTS`, so every frame it forwarded on that path was wire-illegal.

Fixed by guarding the stamp, matching the pattern **`mcp_servers` already uses 240 lines above in the same file**. Omission is what `.optional()` was always expressing; null was never the intent.

## I swept all 20 forwarded events rather than fixing the one named

The issue named `permission_expired`, and the review that found it warned that "six more frames are one `FORWARDED_EVENTS` entry away." So I checked every event on that path against its schema instead of trusting the single report.

| Frame | Ships null? | Schema | Verdict |
|---|---|---|---|
| `result` | yes | `.nullable()` | **fine — deliberate** |
| `skill_changed` | yes | `.nullable()` | **fine — deliberate** |
| `skill_trust_request` | yes | `.nullable()` | **fine — deliberate** |
| `mcp_servers` | no — guarded | rejects null | fine |
| `skill_trust_granted` | — | — | no normalizer mapping at all |
| **`permission_expired`** | **yes — unguarded** | **rejects null** | **the bug** |

The three that ship null are `.nullable()` *precisely because* null means "applies to whatever CLI is connected" (#3240, documented in `ws-forwarding.js`). So `permission_expired` was the only genuine gap — the issue was right, and now that's established rather than assumed.

## Two things that shaped the tests

Both worth calling out, because in each case the test caught me rather than the code:

**The CONTROL caught my own harness.** `setupForwarding` wires the CLI path only in the `else if (cliSession)` branch, so leaving `makeCtx`'s default `sessionManager` in place silently exercised the *multi-session* path and nothing was forwarded at all. Without a CONTROL asserting the frame actually arrives, "no null sessionId" would have passed vacuously — the exact shape that has bitten this repo repeatedly.

**The sweep assertion was too strong and the test told me.** It started as "no forwarded frame carries `sessionId: null`", which failed — because it forbade the three deliberate cases above. It's now conditional: null is allowed only where the schema accepts it. That's the real invariant, and it means a **new** event added to `FORWARDED_EVENTS` with an unguarded stamp fails unless someone explicitly lists it — which forces them to check their schema.

I also documented the hazard on `FORWARDED_EVENTS` itself, since that list is where the next one gets added.

## Verification

570 tests across `ws-forwarding`, `event-normalizer*`, `ws-permissions*`, `session-manager`. 5/5 custom lints.

Mutation-verified in **both** directions — the guard can neither regress nor over-correct:

| Mutation | Tests reddened |
|---|---|
| revert to the unguarded stamp | 2 — omit test + sweep |
| guard drops the field even for a real session id | 1 — the multi-session test |

That second row matters: a naive "just don't send it" fix would strip the routing key the dashboard needs on the normal path, and only that test catches it.

## Scope note

`event-normalizer.js` currently stamps `sessionId` five different ways — unguarded, guarded-omit, `|| null`, `?? null`, and a conditional spread. Only the forwarded ∩ unguarded ∩ rejects-null intersection is a bug, which is why this PR touches one site. Consolidating the five idioms is a separate change and would widen the diff without fixing anything.