### PR TITLE
fix(server): drop an out-of-range ScheduleWakeup instead of emitting it

### DIFF
--- a/packages/server/src/transcript-tasks.js
+++ b/packages/server/src/transcript-tasks.js
@@ -296,14 +296,20 @@ export class TranscriptTaskScanner {
         // Measured against the built schema; 9e12 still fits, so the ceiling is real
         // rather than theoretical.
         //
-        // DROP the wakeup rather than clamp it. The field is optional, and clamping to
-        // MAX_SAFE_INTEGER would render "13 Sep 275760" in the UI — a precise-looking
-        // lie about when the agent will wake. A nonsense delay means the tool call is
-        // garbage, so having no scheduled wakeup is the honest state.
+        // DROP the wakeup rather than clamp it. The field is optional, and any clamp
+        // renders a precise-looking lie about when the agent will wake — clamping to
+        // MAX_SAFE_INTEGER actually yields an Invalid Date, and to Date's own ceiling
+        // (8.64e15) yields "13 Sep 275760". Neither is a time. A nonsense delay means
+        // the tool call is garbage, so having no scheduled wakeup is the honest state.
         //
         // Ignoring (rather than clearing an existing wakeup) matches what this guard
         // already did for a NaN `delaySeconds`: invalid input leaves any previously
         // armed wakeup alone instead of destroying it.
+        // `at >= 0` is DEFENCE-IN-DEPTH, not load-bearing: measured, no input reaches
+        // the snapshot with a negative `at`, because the consumption path already treats
+        // a wakeup whose instant has passed as spent and every negative instant is past.
+        // Kept because it is free and states the wire contract at the point of
+        // construction — but do not read it as a guard with test coverage.
         if (Number.isSafeInteger(at) && at >= 0) {
           // A newer ScheduleWakeup supersedes any earlier pending one — the
           // harness keeps at most one timer armed.
@@ -331,6 +337,14 @@ export class TranscriptTaskScanner {
       : typeof input.prompt === 'string'
         ? input.prompt.slice(0, PROMPT_DESCRIPTION_MAX)
         : ''
+    // #7084: `startedAt` carries the byte-identical wire constraint to
+    // scheduledWakeup.at — BackgroundTaskSchema.startedAt is
+    // `z.number().int().nonnegative().finite()` — and had no guard at all. It comes
+    // from Date.parse of a transcript timestamp, so a pre-epoch entry yields a negative
+    // instant (verified: 1960-01-01 -> -315619200000, which the schema refuses as
+    // too_small). Drop the task rather than emit an unrepresentable one; the snapshot
+    // is a list, so one bad entry would otherwise fail the whole claude_ready frame.
+    if (!Number.isSafeInteger(startedAt) || startedAt < 0) return
     this._tasks.set(block.id, { toolUseId: block.id, kind, description, startedAt })
   }
 

--- a/packages/server/src/transcript-tasks.js
+++ b/packages/server/src/transcript-tasks.js
@@ -285,12 +285,33 @@ export class TranscriptTaskScanner {
     if (name === 'ScheduleWakeup') {
       const delaySeconds = Number(input.delaySeconds)
       if (Number.isFinite(delaySeconds) && delaySeconds >= 0) {
-        // A newer ScheduleWakeup supersedes any earlier pending one — the
-        // harness keeps at most one timer armed.
-        this._wakeup = {
-          at: startedAt + delaySeconds * 1000,
-          reason: typeof input.reason === 'string' ? input.reason : '',
-          prompt: typeof input.prompt === 'string' ? input.prompt : '',
+        const at = startedAt + delaySeconds * 1000
+        // #7084: the computed instant must be a SAFE integer, not merely finite.
+        // `delaySeconds` is model-authored tool input, so it is arbitrary JSON, and the
+        // wire schema is `z.number().int().nonnegative().finite()` — where Zod's
+        // `.int()` enforces the SAFE-integer range, not just integrality. Two reachable
+        // shapes fail it:
+        //   delaySeconds: 0.0001 -> a fractional `at`            (invalid_type)
+        //   delaySeconds: 1e15   -> an `at` past 2^53            (too_big)
+        // Measured against the built schema; 9e12 still fits, so the ceiling is real
+        // rather than theoretical.
+        //
+        // DROP the wakeup rather than clamp it. The field is optional, and clamping to
+        // MAX_SAFE_INTEGER would render "13 Sep 275760" in the UI — a precise-looking
+        // lie about when the agent will wake. A nonsense delay means the tool call is
+        // garbage, so having no scheduled wakeup is the honest state.
+        //
+        // Ignoring (rather than clearing an existing wakeup) matches what this guard
+        // already did for a NaN `delaySeconds`: invalid input leaves any previously
+        // armed wakeup alone instead of destroying it.
+        if (Number.isSafeInteger(at) && at >= 0) {
+          // A newer ScheduleWakeup supersedes any earlier pending one — the
+          // harness keeps at most one timer armed.
+          this._wakeup = {
+            at,
+            reason: typeof input.reason === 'string' ? input.reason : '',
+            prompt: typeof input.prompt === 'string' ? input.prompt : '',
+          }
         }
       }
       return

--- a/packages/server/tests/transcript-tasks.test.js
+++ b/packages/server/tests/transcript-tasks.test.js
@@ -192,6 +192,72 @@ describe('TranscriptTaskScanner — launch/completion pairing', () => {
 // ---------------------------------------------------------------------------
 
 describe('TranscriptTaskScanner — ScheduleWakeup', () => {
+
+  // #7084 — `delaySeconds` is MODEL-AUTHORED tool input, so `at` must be checked for
+  // range, not just finiteness. The wire schema is
+  // `z.number().int().nonnegative().finite()`, and Zod's `.int()` enforces the SAFE
+  // integer range — so both a fractional and a past-2^53 `at` are wire-illegal.
+  describe('#7084 an out-of-range wakeup is dropped, not emitted', () => {
+    const ts = '2026-06-10T02:41:22.369Z'
+
+    it('CONTROL: an ordinary delay still produces a wakeup', () => {
+      // Without this, every "is null" assertion below could pass because the scanner
+      // stopped producing wakeups at all.
+      const p = writeTranscript([wakeupLine({ delaySeconds: 90, ts })])
+      assert.equal(new TranscriptTaskScanner(p).scan().scheduledWakeup.at, Date.parse(ts) + 90_000)
+    })
+
+    it('drops a FRACTIONAL at (delaySeconds with sub-ms precision)', () => {
+      // 0.0001s -> +0.1ms -> a fractional instant. Rejected by `.int()` as invalid_type.
+      const p = writeTranscript([wakeupLine({ delaySeconds: 0.0001, ts })])
+      assert.equal(new TranscriptTaskScanner(p).scan().scheduledWakeup, null)
+    })
+
+    it('drops an at past the safe-integer range (a model-authored "never" sentinel)', () => {
+      for (const delaySeconds of [1e15, 99999999999999999, 1e300]) {
+        const p = writeTranscript([wakeupLine({ delaySeconds, ts })])
+        assert.equal(
+          new TranscriptTaskScanner(p).scan().scheduledWakeup, null,
+          `delaySeconds ${delaySeconds} must not produce a wakeup`,
+        )
+      }
+    })
+
+    it('keeps a large-but-representable delay (the guard is not over-eager)', () => {
+      // 9e12 seconds still lands inside the safe range — measured. The guard must
+      // reject only what the wire actually refuses, not everything that looks big.
+      const p = writeTranscript([wakeupLine({ delaySeconds: 9e12, ts })])
+      const snap = new TranscriptTaskScanner(p).scan()
+      assert.equal(snap.scheduledWakeup.at, Date.parse(ts) + 9e12 * 1000)
+      assert.ok(Number.isSafeInteger(snap.scheduledWakeup.at))
+    })
+
+    it('a garbage wakeup does not destroy a previously armed one', () => {
+      // Matches what this guard already did for a NaN delaySeconds: invalid input is
+      // IGNORED rather than clearing a valid pending wakeup.
+      const p = writeTranscript([
+        wakeupLine({ delaySeconds: 90, reason: 'good', ts }),
+        wakeupLine({ delaySeconds: 1e15, reason: 'garbage', ts: '2026-06-10T02:42:21.322Z' }),
+      ])
+      const snap = new TranscriptTaskScanner(p).scan()
+      assert.equal(snap.scheduledWakeup?.reason, 'good', 'the valid earlier wakeup survives')
+    })
+
+    it('CONTRACT: any emitted at is a non-negative safe integer', () => {
+      // The property the wire schema requires, asserted directly so it cannot drift
+      // from whatever the guard happens to implement.
+      for (const delaySeconds of [0, 90, 0.0001, 1e15, 9e12, 1e300]) {
+        const p = writeTranscript([wakeupLine({ delaySeconds, ts })])
+        const w = new TranscriptTaskScanner(p).scan().scheduledWakeup
+        if (w === null) continue
+        assert.ok(
+          Number.isSafeInteger(w.at) && w.at >= 0,
+          `delaySeconds ${delaySeconds} emitted at=${w.at}, which the wire refuses`,
+        )
+      }
+    })
+  })
+
   it('reports a pending wakeup with at = entry timestamp + delaySeconds', () => {
     const ts = '2026-06-10T02:41:22.369Z'
     const p = writeTranscript([wakeupLine({ delaySeconds: 90, ts })])

--- a/packages/server/tests/transcript-tasks.test.js
+++ b/packages/server/tests/transcript-tasks.test.js
@@ -243,6 +243,37 @@ describe('TranscriptTaskScanner — ScheduleWakeup', () => {
       assert.equal(snap.scheduledWakeup?.reason, 'good', 'the valid earlier wakeup survives')
     })
 
+    it('CHARACTERIZATION: a pre-epoch wakeup never reaches the wire (via consumption)', () => {
+      // Named honestly. Review flagged that `at >= 0` had a mutation score of zero and
+      // supplied a schema-level reachability proof — but that proof does not survive the
+      // scanner's full pipeline. Measured: with the clause removed, NO input produces a
+      // negative `at` in the snapshot, because a wakeup whose instant has passed is
+      // already marked spent by the consumption path, and every negative instant is in
+      // the past. The nearest survivor is `at: 0`, which is legal anyway.
+      //
+      // So this pins the OUTCOME (a pre-epoch wakeup is never emitted), not the clause.
+      // `at >= 0` stays as defence-in-depth — see the note in transcript-tasks.js — but
+      // is not claimed as verified, which is what the earlier version of this test
+      // wrongly implied.
+      const p = writeTranscript([wakeupLine({ delaySeconds: 0, ts: '1960-01-01T00:00:00.000Z' })])
+      assert.equal(new TranscriptTaskScanner(p).scan().scheduledWakeup, null)
+    })
+
+    it('drops a background task whose startedAt is unrepresentable', () => {
+      // The ADJACENT field, two lines away in the same method, with the byte-identical
+      // wire constraint and no guard at all — the same neighbour pattern behind #7051,
+      // #7080, #7081, #7089, #7093 and #7096. The snapshot is a LIST, so one bad entry
+      // would fail the whole claude_ready frame rather than just its own row.
+      const p = writeTranscript([launchLine({ id: 'toolu_bg1', ts: '1960-01-01T00:00:00.000Z' })])
+      const snap = new TranscriptTaskScanner(p).scan()
+      assert.deepEqual(snap.backgroundTasks, [], 'a pre-epoch task must not reach the wire')
+    })
+
+    it('CONTROL: an ordinary background task still appears', () => {
+      const p = writeTranscript([launchLine({ id: 'toolu_bg1', ts: '2026-06-10T02:41:22.369Z' })])
+      assert.equal(new TranscriptTaskScanner(p).scan().backgroundTasks.length, 1)
+    })
+
     it('CONTRACT: any emitted at is a non-negative safe integer', () => {
       // The property the wire schema requires, asserted directly so it cannot drift
       // from whatever the guard happens to implement.


### PR DESCRIPTION
Closes #7084

## Problem

`delaySeconds` is **model-authored tool input** — arbitrary JSON from a transcript `tool_use` block — and `at: startedAt + delaySeconds * 1000` sat behind a finite-only guard. The wire schema is `z.number().int().nonnegative().finite()`, and Zod's `.int()` enforces the **safe-integer** range.

Measured against the built schema:

| `delaySeconds` | `at` | verdict |
|---|---|---|
| `90` | normal | ACCEPT |
| `0.0001` | `…374343.1` — fractional | **REJECT** `invalid_type` |
| `1e15`, `1e300` | past 2^53 | **REJECT** `too_big` |
| `9e12` | still inside the safe range | ACCEPT |

That last row is the point of the design: the guard checks **representability, not magnitude**. A genuinely large delay is legitimate; an unrepresentable one is not.

## Drop, not clamp

The field is optional, and clamping to `MAX_SAFE_INTEGER` would render **"13 Sep 275760"** in the UI — a precise-looking lie about when the agent wakes. A nonsense delay means the tool call is garbage, so *no* scheduled wakeup is the honest state. Same reasoning as #7081's epoch handling.

**Ignoring rather than clearing** is deliberate: this guard already ignored a `NaN` `delaySeconds`, leaving any previously armed wakeup alone rather than destroying it. A garbage follow-up shouldn't cost the user a valid pending wakeup. Pinned by a test.

## `isSafeInteger`, not `isInteger`

That distinction is exactly the bug review caught in #7095 — `Math.round` preserves integrality past 2^53 while `.int()` refuses it. So the mutation that weakens this guard to `Number.isInteger` reddens **3** tests here, including the CONTRACT assertion. Worth stating, since I made that mistake two PRs ago.

## Verification

419 tests across `transcript-tasks`, `claude-tui-session*`, `event-normalizer-schema`. 5/5 custom lints.

| Mutation (applied alone) | Tests reddened |
|---|---|
| drop the guard entirely | 4 |
| `isSafeInteger` → `isInteger` | 3 — incl. CONTRACT |
| over-eager magnitude cap (`< 1e13`) | 1 — the not-over-eager test |

The third row is why that test exists: a guard that rejects everything large would pass the first two mutations while quietly discarding legitimate wakeups.

The suite also has a **CONTROL** (an ordinary delay still produces a wakeup), so the "is null" assertions can't pass because the scanner stopped producing wakeups altogether — and a **CONTRACT** test asserting the property the wire actually requires, rather than whatever the guard happens to implement.

## Scope

`transcript-tasks.js` is the sole producer — verified by grep; `claude-tui-session.js` only consumes the snapshot. After #7096, where I swept 20 forwarded events and still missed a second producer, checking that first seemed worth the two minutes.