### PR TITLE
fix(server): integer-coerce persisted usage counters to match their wire caps

### DIFF
--- a/packages/server/src/billing-budget.js
+++ b/packages/server/src/billing-budget.js
@@ -17,6 +17,7 @@
 
 import { readFileSync, writeFileSync, renameSync, mkdirSync, rmSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { toWireCount } from './utils/wire-counters.js'
 
 /** Per-tier monthly programmatic-credit caps (USD), per Anthropic's 2026-06-15 change. */
 export const CREDIT_TIER_BUDGETS_USD = Object.freeze({
@@ -101,7 +102,10 @@ export class MonthlyProgrammaticBudgetManager {
         this._state = {
           month: raw.month,
           spentUsd: Number.isFinite(raw.spentUsd) ? raw.spentUsd : 0,
-          turnsBilled: Number.isFinite(raw.turnsBilled) && raw.turnsBilled >= 0 ? raw.turnsBilled : 0,
+          // #7082: `.int().nonnegative()` on the wire — the finite+sign guard let a
+          // fractional or past-2^53 value through from a hand-edited state file.
+          // `spentUsd` above is deliberately untouched: USD, no `.int()`.
+          turnsBilled: toWireCount(raw.turnsBilled),
           warnNotified: raw.warnNotified === true,
           exceededNotified: raw.exceededNotified === true,
         }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -3405,7 +3405,7 @@ export class SessionManager extends EventEmitter {
     // criteria and #4088.
     //
     // Per-field coercion mirrors the restore-time clamp (restoreState's
-    // `nonNegFinite`) and CumulativeUsageSchema (@chroxy/protocol):
+    // `toWireCount`) and CumulativeUsageSchema (@chroxy/protocol):
     //   - Token fields are monotonic NON-NEGATIVE integer counters. A
     //     negative provider delta (bug) would drive them below zero and
     //     violate the schema's `.nonnegative()` contract, so drop any delta

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -37,6 +37,7 @@ import { metrics } from './metrics.js'
 import { auditShellDestroy } from './shell-audit.js'
 import { recordShell, forgetShell, reapOrphanShells } from './user-shell-registry.js'
 import { getErrorMessage } from './utils/error-message.js'
+import { toWireCount } from './utils/wire-counters.js'
 import {
   forwardPerSessionSettingsToProviderOpts,
   serializePerSessionSettings,
@@ -2645,17 +2646,21 @@ export class SessionManager extends EventEmitter {
         //   - costUsd accepts negatives per #4099 (refund / credit
         //     adjustments). Only non-finite values fall back to 0.
         const restoredEntry = this._sessions.get(sessionId)
-        const nonNegFinite = (v) => (Number.isFinite(v) && v >= 0 ? v : 0)
+        // #7082: the restore path reads ~/.chroxy/session-state.json, so a hand-edited
+        // or corrupt file can carry a fractional / past-2^53 / negative counter straight
+        // into the live snapshot. Same coercion as the accumulate path above.
         if (restoredEntry) {
           if (saved.cumulativeUsage && typeof saved.cumulativeUsage === 'object') {
             const u = saved.cumulativeUsage
             restoredEntry.cumulativeUsage = {
-              inputTokens: nonNegFinite(u.inputTokens),
-              outputTokens: nonNegFinite(u.outputTokens),
-              cacheReadTokens: nonNegFinite(u.cacheReadTokens),
-              cacheCreationTokens: nonNegFinite(u.cacheCreationTokens),
+              inputTokens: toWireCount(u.inputTokens),
+              outputTokens: toWireCount(u.outputTokens),
+              cacheReadTokens: toWireCount(u.cacheReadTokens),
+              cacheCreationTokens: toWireCount(u.cacheCreationTokens),
+              // costUsd is NOT coerced: `z.number().finite()` with no `.int()`, and
+              // legitimately negative for a refund / credit adjustment (#4099).
               costUsd: Number.isFinite(u.costUsd) ? u.costUsd : 0,
-              turnsBilled: nonNegFinite(u.turnsBilled),
+              turnsBilled: toWireCount(u.turnsBilled),
             }
           }
           if (saved.costThresholdNotified === true) {
@@ -3408,14 +3413,18 @@ export class SessionManager extends EventEmitter {
     //   - costUsd is finite but intentionally SIGNED — a refund / credit
     //     adjustment turn (#4099) legitimately subtracts — so only reject
     //     a non-finite cost.
-    const tokenDelta = (x) => (Number.isFinite(x) && x >= 0 ? x : 0)
+    // #7082: `toWireCount` adds the `.int()` half these comments always claimed to
+    // mirror — the guards enforced finite + non-negative and let a fractional or
+    // past-2^53 value through, both of which the schema refuses. Applied to the RUNNING
+    // TOTAL, not just the delta: integer deltas keep the sum integral, but a long-lived
+    // session can still accumulate past the safe-integer ceiling.
     const finiteCost = (x) => (Number.isFinite(x) ? x : 0)
-    acc.inputTokens += tokenDelta(Number(u.input_tokens))
-    acc.outputTokens += tokenDelta(Number(u.output_tokens))
-    acc.cacheReadTokens += tokenDelta(Number(u.cache_read_input_tokens))
-    acc.cacheCreationTokens += tokenDelta(Number(u.cache_creation_input_tokens))
+    acc.inputTokens = toWireCount(acc.inputTokens + toWireCount(u.input_tokens))
+    acc.outputTokens = toWireCount(acc.outputTokens + toWireCount(u.output_tokens))
+    acc.cacheReadTokens = toWireCount(acc.cacheReadTokens + toWireCount(u.cache_read_input_tokens))
+    acc.cacheCreationTokens = toWireCount(acc.cacheCreationTokens + toWireCount(u.cache_creation_input_tokens))
     acc.costUsd += finiteCost(Number(resultData?.cost))
-    acc.turnsBilled += 1
+    acc.turnsBilled = toWireCount(acc.turnsBilled + 1)
     // #5630/#5629: carry the per-session billing class on the live usage
     // event so a client that joined before the first session_list (or after a
     // mid-session era flip) labels the cost row correctly without a refetch.

--- a/packages/server/src/utils/wire-counters.js
+++ b/packages/server/src/utils/wire-counters.js
@@ -1,0 +1,48 @@
+/**
+ * #7082 — coerce a counter to what its wire schema accepts.
+ *
+ * Several counters are `z.number().int().nonnegative()` on the wire —
+ * `CumulativeUsageSchema`'s four token counts and `turnsBilled`, and
+ * `monthly_budget.turnsBilled` — while the server guarded them only for finiteness
+ * and sign. Measured against the built schemas, three shapes are refused:
+ *
+ *   1234.5   -> invalid_type   (fractional)
+ *   2**53    -> too_big        (`.int()` enforces the SAFE-integer range, not just
+ *                               integrality — the #7095 lesson)
+ *   -1       -> too_small
+ *
+ * Both server sites carried comments claiming to mirror the schema; they mirrored the
+ * `.nonnegative()` half and not the `.int()` half.
+ *
+ * CLAMPS rather than nulls, because unlike `result.duration` or a skills `lastUsed`
+ * these fields are NOT nullable — there is no "unknown" to fall back to, so the
+ * representable extreme is the only option left. A count past 2^53 is ~9 quadrillion
+ * tokens, i.e. already garbage; pinning it at MAX_SAFE_INTEGER keeps the snapshot
+ * parseable instead of blanking the whole session list.
+ *
+ * `Math.trunc`, matching #7083's choice for counts: these are quantities, not measured
+ * elapsed times, and truncation cannot round a value up across a boundary.
+ *
+ * DELIBERATELY NOT for money. `costUsd` (`z.number().finite()`) and `spentUsd`
+ * (`.finite().nonnegative()`) carry no `.int()`, are legitimately fractional, and
+ * `costUsd` is legitimately NEGATIVE — a refund / credit-adjustment turn subtracts
+ * (#4099). Coercing either would silently corrupt a billing figure, which is the same
+ * trap `costBudget` presented in #7083.
+ */
+
+/** Largest value the `.int()` wire constraint accepts. */
+export const MAX_WIRE_COUNT = Number.MAX_SAFE_INTEGER
+
+/**
+ * Coerce a value to a non-negative safe integer suitable for an `.int().nonnegative()`
+ * wire field.
+ *
+ * @param {unknown} value
+ * @returns {number} a non-negative safe integer; 0 for anything non-numeric or non-finite
+ */
+export function toWireCount(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n) || n <= 0) return 0
+  if (n >= MAX_WIRE_COUNT) return MAX_WIRE_COUNT
+  return Math.trunc(n)
+}

--- a/packages/server/tests/wire-counters.test.js
+++ b/packages/server/tests/wire-counters.test.js
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { CumulativeUsageSchema, ServerMonthlyBudgetSchema } from '@chroxy/protocol'
+import { toWireCount, MAX_WIRE_COUNT } from '../src/utils/wire-counters.js'
+
+/**
+ * #7082 — usage counters are `z.number().int().nonnegative()` on the wire, but the
+ * server guarded them only for finiteness and sign. Both server sites carried comments
+ * claiming to mirror the schema; they mirrored the `.nonnegative()` half and not the
+ * `.int()` half.
+ *
+ * The exclusions matter more than the coercion: `costUsd` and `spentUsd` are money,
+ * carry no `.int()`, and `costUsd` is legitimately NEGATIVE for a refund (#4099).
+ */
+describe('#7082 toWireCount', () => {
+  it('CONTROL: an ordinary count passes through untouched', () => {
+    assert.equal(toWireCount(1234), 1234)
+    assert.equal(toWireCount(0), 0)
+  })
+
+  it('truncates a fractional count', () => {
+    // Measured: a fractional token count is `invalid_type` on the wire.
+    assert.equal(toWireCount(1234.5), 1234)
+    assert.equal(toWireCount(0.9), 0)
+  })
+
+  it('clamps past the SAFE-integer ceiling, not merely the integer one', () => {
+    // Zod's `.int()` enforces the safe range — the #7095 lesson. `2**53` is an integer
+    // and is still `too_big`.
+    assert.equal(toWireCount(2 ** 53), MAX_WIRE_COUNT)
+    assert.equal(toWireCount(1e300), MAX_WIRE_COUNT)
+    assert.equal(toWireCount(Number.MAX_SAFE_INTEGER), MAX_WIRE_COUNT)
+  })
+
+  it('CLAMPS rather than nulls, because these fields are not nullable', () => {
+    // Unlike result.duration (#7095) or skills lastUsed (#7081), there is no "unknown"
+    // to fall back to — nulling would make the frame fail a different way.
+    assert.equal(typeof toWireCount(2 ** 53), 'number')
+    assert.notEqual(toWireCount(2 ** 53), null)
+  })
+
+  it('floors a negative count at 0', () => {
+    assert.equal(toWireCount(-1), 0)
+    assert.equal(toWireCount(-1e300), 0)
+  })
+
+  it('yields 0 for non-numeric and non-finite input', () => {
+    for (const bad of [undefined, null, 'x', {}, [], Number.NaN, Infinity, -Infinity]) {
+      assert.equal(toWireCount(bad), 0, `${String(bad)} must yield 0`)
+    }
+  })
+
+  it('CONTRACT: every output satisfies the REAL wire schema', () => {
+    // Asserted against the actual schema rather than a hand-rolled predicate, so a cap
+    // change in @chroxy/protocol fails here.
+    const base = {
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+      cacheCreationTokens: 0, costUsd: 0, turnsBilled: 0,
+    }
+    for (const input of [0, 1234, 1234.5, -1, 2 ** 53, 1e300, Number.NaN, Infinity, 'x']) {
+      const v = toWireCount(input)
+      const r = CumulativeUsageSchema.safeParse({ ...base, inputTokens: v, turnsBilled: v })
+      assert.ok(r.success, `input ${String(input)} produced ${v}, which the wire refuses`)
+    }
+  })
+
+  it('the values it refuses are exactly the ones the schema refuses (not over-eager)', () => {
+    // Guards the other direction: everything coerced was genuinely illegal, so the
+    // helper is not quietly rewriting values the wire would have accepted.
+    const base = {
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+      cacheCreationTokens: 0, costUsd: 0, turnsBilled: 0,
+    }
+    for (const raw of [1234.5, -1, 2 ** 53]) {
+      const r = CumulativeUsageSchema.safeParse({ ...base, inputTokens: raw })
+      assert.equal(r.success, false, `${raw} should have been wire-illegal to begin with`)
+      assert.notEqual(toWireCount(raw), raw, `${raw} must actually be changed`)
+    }
+    // …and a legal value is left alone.
+    assert.equal(toWireCount(999999), 999999)
+  })
+
+  it('MONEY IS NOT A COUNT: costUsd and spentUsd stay fractional and signed', () => {
+    // The most important assertion here. costUsd is `z.number().finite()` with no
+    // `.int()`, and a refund turn legitimately subtracts (#4099). Coercing either
+    // field would silently corrupt a billing figure — the costBudget trap from #7083.
+    const usage = {
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+      cacheCreationTokens: 0, costUsd: -1.25, turnsBilled: 0,
+    }
+    assert.ok(CumulativeUsageSchema.safeParse(usage).success, 'a negative fractional costUsd is legal')
+    assert.ok(CumulativeUsageSchema.safeParse({ ...usage, costUsd: 3.75 }).success)
+
+    // Field set taken from ServerMonthlyBudgetSchema itself — an invented shape would
+    // fail for reasons unrelated to spentUsd and prove nothing.
+    const budget = {
+      type: 'monthly_budget', month: '2026-08', spentUsd: 12.34, turnsBilled: 5,
+      budgetUsd: 100, warningPercent: 80, percent: 12.34, warning: false, exceeded: false,
+    }
+    assert.ok(ServerMonthlyBudgetSchema.safeParse(budget).success, 'a fractional spentUsd is legal')
+    // If either were ever routed through toWireCount, these would become 0/3/12.
+    assert.notEqual(toWireCount(-1.25), -1.25)
+    assert.notEqual(toWireCount(12.34), 12.34)
+  })
+})

--- a/packages/server/tests/wire-counters.test.js
+++ b/packages/server/tests/wire-counters.test.js
@@ -1,7 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { CumulativeUsageSchema, ServerMonthlyBudgetSchema } from '@chroxy/protocol'
+import { CumulativeUsageSchema } from '@chroxy/protocol'
 import { toWireCount, MAX_WIRE_COUNT } from '../src/utils/wire-counters.js'
+import { MonthlyProgrammaticBudgetManager, monthKeyUtc } from '../src/billing-budget.js'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 /**
  * #7082 — usage counters are `z.number().int().nonnegative()` on the wire, but the
@@ -30,13 +34,6 @@ describe('#7082 toWireCount', () => {
     assert.equal(toWireCount(2 ** 53), MAX_WIRE_COUNT)
     assert.equal(toWireCount(1e300), MAX_WIRE_COUNT)
     assert.equal(toWireCount(Number.MAX_SAFE_INTEGER), MAX_WIRE_COUNT)
-  })
-
-  it('CLAMPS rather than nulls, because these fields are not nullable', () => {
-    // Unlike result.duration (#7095) or skills lastUsed (#7081), there is no "unknown"
-    // to fall back to — nulling would make the frame fail a different way.
-    assert.equal(typeof toWireCount(2 ** 53), 'number')
-    assert.notEqual(toWireCount(2 ** 53), null)
   })
 
   it('floors a negative count at 0', () => {
@@ -80,26 +77,38 @@ describe('#7082 toWireCount', () => {
     assert.equal(toWireCount(999999), 999999)
   })
 
-  it('MONEY IS NOT A COUNT: costUsd and spentUsd stay fractional and signed', () => {
-    // The most important assertion here. costUsd is `z.number().finite()` with no
-    // `.int()`, and a refund turn legitimately subtracts (#4099). Coercing either
-    // field would silently corrupt a billing figure — the costBudget trap from #7083.
+  it('MONEY IS NOT A COUNT: the real LOADERS leave costUsd and spentUsd alone', () => {
+    // Drives the actual call sites, not the schema. The first version of this test
+    // asserted only schema facts and helper facts — routing `spentUsd` through
+    // toWireCount left all 226 tests green, so the exclusion this test exists to
+    // protect was entirely unpinned.
+    const dir = mkdtempSync(join(tmpdir(), 'wc-'))
+
+    // billing-budget loader: a fractional spentUsd must survive verbatim.
+    const statePath = join(dir, 'budget.json')
+    writeFileSync(statePath, JSON.stringify({
+      month: monthKeyUtc(Date.now()), spentUsd: 12.34, turnsBilled: 5.7,
+      warnNotified: false, exceededNotified: false,
+    }))
+    const mgr = new MonthlyProgrammaticBudgetManager({ statePath })
+    assert.equal(mgr._state.spentUsd, 12.34, 'spentUsd is USD and must NOT be truncated')
+    assert.equal(mgr._state.turnsBilled, 5, 'turnsBilled IS a count and must be truncated')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('MONEY IS NOT A COUNT: a negative costUsd survives restore (refunds, #4099)', () => {
+    // costUsd is `z.number().finite()` — no `.int()`, and legitimately negative for a
+    // refund / credit adjustment. Asserted against the real schema so the exclusion is
+    // justified by the contract rather than by convention.
     const usage = {
       inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
       cacheCreationTokens: 0, costUsd: -1.25, turnsBilled: 0,
     }
     assert.ok(CumulativeUsageSchema.safeParse(usage).success, 'a negative fractional costUsd is legal')
     assert.ok(CumulativeUsageSchema.safeParse({ ...usage, costUsd: 3.75 }).success)
-
-    // Field set taken from ServerMonthlyBudgetSchema itself — an invented shape would
-    // fail for reasons unrelated to spentUsd and prove nothing.
-    const budget = {
-      type: 'monthly_budget', month: '2026-08', spentUsd: 12.34, turnsBilled: 5,
-      budgetUsd: 100, warningPercent: 80, percent: 12.34, warning: false, exceeded: false,
-    }
-    assert.ok(ServerMonthlyBudgetSchema.safeParse(budget).success, 'a fractional spentUsd is legal')
-    // If either were ever routed through toWireCount, these would become 0/3/12.
-    assert.notEqual(toWireCount(-1.25), -1.25)
-    assert.notEqual(toWireCount(12.34), 12.34)
+    // And the helper would destroy both, which is why costUsd is not routed through it.
+    assert.equal(toWireCount(-1.25), 0)
+    assert.equal(toWireCount(3.75), 3)
   })
 })


### PR DESCRIPTION
Closes #7082

## Problem

`CumulativeUsageSchema`'s four token counts and `turnsBilled`, plus `monthly_budget.turnsBilled`, are `z.number().int().nonnegative()`. The server guarded them for finiteness and sign only. Measured against the built schemas:

| value | verdict |
|---|---|
| `1234.5` | `invalid_type` |
| `2**53` | `too_big` — `.int()` enforces the **safe**-integer range (#7095) |
| `-1` | `too_small` |

Both server sites carried comments claiming to mirror the schema. **They mirrored the `.nonnegative()` half and not the `.int()` half** — which is the entire issue, and the reason a comment isn't a guard.

## Money is excluded, and that matters more than the coercion

`costUsd` is `z.number().finite()` with **no `.int()`**, and is legitimately **negative** — a refund or credit-adjustment turn subtracts (#4099). `spentUsd` is `.finite().nonnegative()`.

Coercing either would silently corrupt a billing figure. That's the same trap `costBudget` presented in #7083, and it's why this uses an explicit helper applied to named fields rather than a sweep over the usage object.

Verified both directions: a `costUsd` of `-1.25` and `3.75` are accepted by the real schema, and a test asserts they'd be changed if ever routed through the helper.

## Design notes

- **One shared helper**, not three copies — #7054's lesson. Applied at the accumulate path, the `restoreState` path (which reads `~/.chroxy/session-state.json`, so a hand-edited file lands straight in the live snapshot), and `billing-budget`'s loader.
- **Applied to the running total, not just each delta.** Integer deltas keep the sum integral, but a long-lived session can still accumulate past 2^53. Verified end-to-end: after a hostile delta sequence (`1234.5`, `-50`, `2**53`, `1e300`, `NaN`) the accumulated object still satisfies the real schema, with `costUsd: -1.25` untouched.
- **Clamps rather than nulls**, unlike #7095 and #7081. These fields are **not nullable** — there's no "unknown" to fall back to, and nulling would fail the frame a different way. A count past 2^53 is ~9 quadrillion tokens, already garbage.

## Verification

226 tests across `wire-counters`, `session-manager`, `billing-budget`. 5/5 custom lints.

| Mutation (applied alone) | Tests reddened |
|---|---|
| no truncation | 4 |
| no safe-integer cap | 4 |
| no negative floor | 4 |

Beyond the CONTROL, two tests are worth a reviewer's eye:

- **CONTRACT** — every output is validated against the **real** `CumulativeUsageSchema`, not a hand-rolled predicate, so a cap change in `@chroxy/protocol` fails here.
- **Not over-eager** — asserts every value the helper changes was *genuinely wire-illegal to begin with*, so it can't be quietly rewriting values the wire would have accepted. That direction is easy to skip and is where an over-broad coercion would hide.