### PR TITLE
test(server): assert the outbound seq ADVANCES after a broadcast

### DIFF
--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1128,6 +1128,12 @@ describe('outbound message sequence numbers', () => {
     await waitForMessage(messages2, 'status')
     // Wait for client_joined on client1 from client2's connection
     await waitForMessage(messages1, 'client_joined')
+    // #5555: the connect-time auth_bootstrap burst is fire-and-forget, so it can
+    // land AFTER the broadcast. Settle it on BOTH clients first, otherwise a late
+    // burst frame lands between `discovered_sessions` and the post-broadcast ping
+    // below and the seq assertions race it.
+    await waitForMessage(messages1, 'auth_bootstrap', 1000)
+    await waitForMessage(messages2, 'auth_bootstrap', 1000)
 
     // Broadcast a message — each client gets their own seq
     server.broadcast({ type: 'discovered_sessions', tmux: [] })
@@ -1158,6 +1164,28 @@ describe('outbound message sequence numbers', () => {
       'Client 1 broadcast seq should be its own position in its own stream')
     assert.equal(disc2.seq, messages2.indexOf(disc2) + 1,
       'Client 2 broadcast seq should be its own position in its own stream')
+
+    // #7063: everything above observes the stream only UP TO the broadcast, so a
+    // regression that STAMPS seq without ADVANCING the counter (`client._seq + 1`
+    // instead of `client._seq++` in ws-client-sender.js) still produces a
+    // correct-looking broadcast seq — it only shows up as a DUPLICATE on the next
+    // frame, which nothing here was watching for. Send one more frame per client
+    // and assert the counter actually moved.
+    send(ws1, { type: 'ping' })
+    const pong1 = await waitForMessage(messages1, 'pong')
+    assert.ok(pong1.seq > disc1.seq,
+      `Client 1 seq must ADVANCE past the broadcast, not just be stamped: pong seq ${pong1.seq} vs broadcast seq ${disc1.seq}`)
+    assert.equal(pong1.seq, messages1.indexOf(pong1) + 1,
+      'Client 1 post-broadcast frame should continue its own contiguous run')
+
+    // The same client-independence invariant, verified AFTER the broadcast:
+    // client1's extra frame must not consume a seq from client2's counter.
+    send(ws2, { type: 'ping' })
+    const pong2 = await waitForMessage(messages2, 'pong')
+    assert.ok(pong2.seq > disc2.seq,
+      `Client 2 seq must ADVANCE past the broadcast, not just be stamped: pong seq ${pong2.seq} vs broadcast seq ${disc2.seq}`)
+    assert.equal(pong2.seq, messages2.indexOf(pong2) + 1,
+      'Client 2 post-broadcast frame should continue its own contiguous run')
 
     ws1.close()
     ws2.close()


### PR DESCRIPTION
## Defect

`packages/server/tests/ws-server.test.js` → `outbound message sequence numbers` →
`assigns independent seq per client on broadcast` observed each client's stream only **up to and
including** the broadcast frame. It swept `msgs.forEach((m, i) => assert.equal(m.seq, i + 1))` over
what had arrived, then asserted the broadcast's own position — and stopped.

A regression that **stamps `seq` without advancing the counter** — `client._seq + 1` instead of
`client._seq++` at `packages/server/src/ws-client-sender.js:67-68` — therefore still produces a
*correct-looking* broadcast seq. The fault only manifests as a **duplicate seq on the next frame**,
which nothing in the suite deterministically observed. That is this repo's worst defect shape: a
green signal that verifies nothing going forward.

## Fix

Test-only. After the existing broadcast assertions, ping each client and assert its counter
actually moved:

- `pong.seq > disc.seq` — the counter must **advance**, not merely be stamped.
- `pong.seq === messages.indexOf(pong) + 1` — the post-broadcast frame continues that client's own
  contiguous 1..N run.

Both clients are pinged, so the per-client independence invariant is also re-verified *after* the
broadcast (client 1's extra frame must not consume a seq from client 2's counter).

Also settles the fire-and-forget `auth_bootstrap` burst on both clients **before** the broadcast
(the pattern the sibling `continues seq across different message types` test already uses). This is
load-bearing, not cosmetic: without it a late burst frame can land between the broadcast and the
post-broadcast ping and absorb the duplicate seq, which makes the `>` assertion pass by accident.
It is also the in-flight race that caused the #7059 flake.

No production code changed.

## Verification

Baseline on the unmodified source — 5/5 green, and **50/50 green** over repeated runs (no flake
introduced).

**Mutation 1 — the one literally named in the issue** (`client._seq++` + stamp replaced with
`seq: client._seq + 1` for *every* frame). This does **not** isolate the gap: dropping the
increment entirely freezes `_seq` at 0, so every frame is stamped `1` and the pre-existing
assertions already catch it:

```
not ok 1 - includes monotonically increasing seq on all messages
not ok 2 - continues seq across different message types
ok 3 - resets seq on new connection
not ok 4 - assigns independent seq per client on broadcast
not ok 5 - includes seq in history replay messages
# pass 1  # fail 4
```

Reporting that honestly, because a mutation the old test already catches proves nothing about the
new assertions.

**Mutation 2 — the shape the issue actually describes**: stamp-without-increment for the broadcast
frame only, so the broadcast seq looks right and the *next* frame duplicates it.

```js
if (client) {
  if (message?.type === 'discovered_sessions') {
    message = { ...message, seq: client._seq + 1 }   // stamp, do not advance
  } else {
    client._seq++
    message = { ...message, seq: client._seq }
  }
}
```

Run 10× against the **pre-PR** test file and 10× against **this** one, same mutation, same machine:

| test file | `assigns independent seq per client on broadcast` under mutation 2 |
|---|---|
| pre-PR (`origin/main`) | **RED 4/10** — a *flaky* detector |
| this PR | **RED 10/10** — deterministic |

The pre-PR test was not blind to the bug so much as **unreliably sighted**: it only tripped when a
late `auth_bootstrap` burst frame happened to land after the broadcast and land inside the swept
window. Six runs in ten it reported green on genuinely broken source — false safety, which is worse
than a clean miss. Settling the burst removes that coin-flip and the new post-broadcast assertions
replace it with a deterministic signal, failing on the first new assertion:

```
ok 1 - includes monotonically increasing seq on all messages
ok 2 - continues seq across different message types
ok 3 - resets seq on new connection
not ok 4 - assigns independent seq per client on broadcast
  error: 'Client 1 seq must ADVANCE past the broadcast, not just be stamped: pong seq 11 vs broadcast seq 11'
ok 5 - includes seq in history replay messages
# pass 4  # fail 1
```

Mutation reverted; `git status` clean on `src/`.

**Green after revert** — `outbound message sequence numbers` 5/5, and the full file:

```
# tests 122  # suites 31  # pass 122  # fail 0
```

Custom server lints (CI "Server Lint", not eslint) all pass:
`lint-tests-state-file-path.sh`, `lint-ws-index-mutations.sh`, `lint-session-opt-forwarding.sh`,
`lint-logger-session-scoping.sh`, `lint-claude-family-explicit.sh`.

No new `it()` block, so the `assert-test-count.mjs` floor is unaffected.

Closes #7063.
