### PR TITLE
fix(server): refuse to overwrite a malformed config.json instead of replacing it wholesale

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -9,6 +9,7 @@
  */
 
 import { readFileSync, existsSync, mkdirSync, copyFileSync, constants as fsConstants } from 'fs'
+import { createHash } from 'crypto'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
 import { writeFileRestricted } from './platform.js'
@@ -1916,24 +1917,38 @@ export function readReposFromConfig(configPath = DEFAULT_CONFIG_PATH) {
 }
 
 /**
- * Copy an unreadable/unparseable config aside before refusing to write over it,
- * so the operator can recover their settings by hand (#7027).
+ * Copy an unparseable config aside before refusing to write over it, so the
+ * operator can recover their settings by hand (#7027).
  *
  * Best effort by design: the REFUSAL is what protects the file, the backup is a
  * courtesy. `COPYFILE_EXCL` means an existing backup is never clobbered — that
  * would be this very bug in miniature.
  *
+ * The name is derived from the CONTENT, not the wall clock, because the refusal
+ * is per-attempt and every caller is a button the operator can press again:
+ *  - identical content collapses onto one file, so a repeatedly-retried toggle
+ *    cannot pile up an unbounded set of full copies of config.json (API token
+ *    included) in ~/.chroxy. A duplicate of content already saved carries no
+ *    extra recovery value.
+ *  - genuinely different damage still gets its own file, which a timestamp
+ *    could NOT guarantee: two different corrupt versions refused inside the
+ *    same millisecond collided, and the reported path then named a backup
+ *    holding somebody else's content.
+ * The file's mtime still carries the "when".
+ *
  * @param {string} configPath
+ * @param {string} raw - The exact bytes read back, used to key the backup.
  * @returns {string|null} the backup path, or null if none could be made.
  */
-function backUpMalformedConfig(configPath) {
-  const backup = `${configPath}.corrupt-${new Date().toISOString().replace(/[:.]/g, '-')}`
+function backUpMalformedConfig(configPath, raw) {
+  const digest = createHash('sha256').update(raw).digest('hex').slice(0, 16)
+  const backup = `${configPath}.corrupt-${digest}`
   try {
     copyFileSync(configPath, backup, fsConstants.COPYFILE_EXCL)
     return backup
   } catch (err) {
-    // EEXIST means a backup from this same millisecond is already there — still
-    // a valid recovery pointer for the operator.
+    // EEXIST means this exact content was already saved aside by an earlier
+    // attempt — that file IS the recovery pointer, so keep naming it.
     return err?.code === 'EEXIST' ? backup : null
   }
 }
@@ -1983,11 +1998,11 @@ export function readConfigForMerge(configPath) {
   try {
     parsed = JSON.parse(raw)
   } catch (err) {
-    throw refuseMalformedConfig(configPath, `it is not valid JSON (${err.message})`)
+    throw refuseMalformedConfig(configPath, `it is not valid JSON (${err.message})`, raw)
   }
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     const found = parsed === null ? 'null' : (Array.isArray(parsed) ? 'an array' : `a ${typeof parsed}`)
-    throw refuseMalformedConfig(configPath, `it does not contain a JSON object (found ${found})`)
+    throw refuseMalformedConfig(configPath, `it does not contain a JSON object (found ${found})`, raw)
   }
   return parsed
 }
@@ -1997,10 +2012,11 @@ export function readConfigForMerge(configPath) {
  * backing the bad file up first (#7027).
  * @param {string} configPath
  * @param {string} reason - Why it could not be merged, in sentence-fragment form.
+ * @param {string} raw - The exact bytes read back, used to key the backup.
  * @returns {Error}
  */
-function refuseMalformedConfig(configPath, reason) {
-  const backup = backUpMalformedConfig(configPath)
+function refuseMalformedConfig(configPath, reason, raw) {
+  const backup = backUpMalformedConfig(configPath, raw)
   return new Error(
     `Refusing to overwrite ${configPath}: ${reason}. ` +
     (backup ? `A copy was saved to ${backup}. ` : '') +

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -8,7 +8,7 @@
  * 4. Defaults
  */
 
-import { readFileSync, existsSync, mkdirSync } from 'fs'
+import { readFileSync, existsSync, mkdirSync, copyFileSync, constants as fsConstants } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
 import { writeFileRestricted } from './platform.js'
@@ -1916,19 +1916,109 @@ export function readReposFromConfig(configPath = DEFAULT_CONFIG_PATH) {
 }
 
 /**
+ * Copy an unreadable/unparseable config aside before refusing to write over it,
+ * so the operator can recover their settings by hand (#7027).
+ *
+ * Best effort by design: the REFUSAL is what protects the file, the backup is a
+ * courtesy. `COPYFILE_EXCL` means an existing backup is never clobbered — that
+ * would be this very bug in miniature.
+ *
+ * @param {string} configPath
+ * @returns {string|null} the backup path, or null if none could be made.
+ */
+function backUpMalformedConfig(configPath) {
+  const backup = `${configPath}.corrupt-${new Date().toISOString().replace(/[:.]/g, '-')}`
+  try {
+    copyFileSync(configPath, backup, fsConstants.COPYFILE_EXCL)
+    return backup
+  } catch (err) {
+    // EEXIST means a backup from this same millisecond is already there — still
+    // a valid recovery pointer for the operator.
+    return err?.code === 'EEXIST' ? backup : null
+  }
+}
+
+/**
+ * Read an existing config.json for a read-modify-write, refusing to continue on
+ * anything that would silently destroy it (#7027).
+ *
+ * Every `write*ToConfig` helper below is a read-modify-write over the operator's
+ * ENTIRE config, and its next act is
+ * `writeFileRestricted(configPath, JSON.stringify(existing))`. These all used to
+ * open with `try { ... } catch { /* start fresh *\/ }`, so a config.json with a
+ * hand-edited trailing comma, one truncated by an earlier crash, or one hit by a
+ * transient read error turned an unrelated Control Room toggle into a WHOLESALE
+ * overwrite: tunnel config, providers, features and permission rules replaced by
+ * a single-key object, with no warning to the operator.
+ *
+ * So only ONE case starts fresh — the file genuinely not existing, which is the
+ * legitimate first-run path. Every other outcome throws, and all three callers
+ * already have an honest failure path for it (repo-handlers' `Failed to
+ * add/remove repo`, the preset drawer's write-failure error, and the scheduler
+ * handler's `SCHEDULER_GATE_FAILED`).
+ *
+ * A file that PARSES but is not a plain object (`null`, an array, a bare string)
+ * is refused the same way: coercing it to `{}` and writing is the same wholesale
+ * replacement wearing a different hat.
+ *
+ * @param {string} configPath - Path to config.json.
+ * @returns {object} The parsed config object, or `{}` when the file is absent.
+ * @throws {Error} When the file exists but cannot be read or parsed into an object.
+ */
+export function readConfigForMerge(configPath) {
+  let raw
+  try {
+    raw = readFileSync(configPath, 'utf-8')
+  } catch (err) {
+    // Absent → legitimately start fresh. Anything else (EACCES, EISDIR, EIO) is
+    // a read we cannot trust, and overwriting on the back of it loses the file.
+    if (err?.code === 'ENOENT') return {}
+    throw new Error(
+      `Refusing to write ${configPath}: the existing config could not be read (${err.message}). ` +
+      'Overwriting it would discard every other setting.',
+    )
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw refuseMalformedConfig(configPath, `it is not valid JSON (${err.message})`)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    const found = parsed === null ? 'null' : (Array.isArray(parsed) ? 'an array' : `a ${typeof parsed}`)
+    throw refuseMalformedConfig(configPath, `it does not contain a JSON object (found ${found})`)
+  }
+  return parsed
+}
+
+/**
+ * Build the refusal for a config.json that exists but cannot be merged into,
+ * backing the bad file up first (#7027).
+ * @param {string} configPath
+ * @param {string} reason - Why it could not be merged, in sentence-fragment form.
+ * @returns {Error}
+ */
+function refuseMalformedConfig(configPath, reason) {
+  const backup = backUpMalformedConfig(configPath)
+  return new Error(
+    `Refusing to overwrite ${configPath}: ${reason}. ` +
+    (backup ? `A copy was saved to ${backup}. ` : '') +
+    'Repair or move the file and retry — writing would have replaced every other setting.',
+  )
+}
+
+/**
  * Write the repos array to a config file, preserving other fields.
+ *
+ * Throws rather than starting fresh when an existing config.json is unreadable
+ * or malformed (#7027) — see readConfigForMerge.
+ *
  * @param {Array<{ path: string, name?: string }>} repos - Repos array to write.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
 export function writeReposToConfig(repos, configPath = DEFAULT_CONFIG_PATH) {
-  let existing = {}
-  try {
-    if (existsSync(configPath)) {
-      existing = JSON.parse(readFileSync(configPath, 'utf-8'))
-    }
-  } catch {
-    // Start fresh if parse fails
-  }
+  const existing = readConfigForMerge(configPath)
   existing.repos = repos
   const dir = dirname(configPath)
   mkdirSync(dir, { recursive: true })
@@ -1943,20 +2033,15 @@ export function writeReposToConfig(repos, configPath = DEFAULT_CONFIG_PATH) {
  * the operator can configure an override for a repo that isn't otherwise
  * registered. Other config fields and repo entries are preserved.
  *
+ * Throws rather than starting fresh when an existing config.json is unreadable
+ * or malformed (#7027) — see readConfigForMerge.
+ *
  * @param {string} repoPath - The repo path to key the override by.
  * @param {object|null} preset - The preset object ({ preamble?, seed?, enabled? }) or null to clear.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
 export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath = DEFAULT_CONFIG_PATH) {
-  let existing = {}
-  try {
-    if (existsSync(configPath)) {
-      existing = JSON.parse(readFileSync(configPath, 'utf-8'))
-    }
-  } catch {
-    // Start fresh if parse fails
-  }
-  if (!existing || typeof existing !== 'object') existing = {}
+  const existing = readConfigForMerge(configPath)
   if (!Array.isArray(existing.repos)) existing.repos = []
 
   const idx = existing.repos.findIndex(
@@ -1999,19 +2084,18 @@ export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath 
  * checks the env first), so writing `false` while that env var is set leaves the
  * gate open; the handler refuses that combination instead of writing a lie.
  *
+ * Throws rather than starting fresh when an existing config.json is unreadable
+ * or malformed (#7027) — see readConfigForMerge. The handler already reports
+ * that as SCHEDULER_GATE_FAILED.
+ *
  * @param {boolean} enabled - the new gate value.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
 export function writeSchedulerEnabledToConfig(enabled, configPath = DEFAULT_CONFIG_PATH) {
-  let existing = {}
-  try {
-    if (existsSync(configPath)) {
-      existing = JSON.parse(readFileSync(configPath, 'utf-8'))
-    }
-  } catch {
-    // Start fresh if parse fails
-  }
-  if (!existing || typeof existing !== 'object') existing = {}
+  const existing = readConfigForMerge(configPath)
+  // A non-object `features` is a single stray FIELD, not the whole config, so it
+  // is repaired in place rather than refused — the operator's other settings
+  // still survive the write.
   if (!existing.features || typeof existing.features !== 'object' || Array.isArray(existing.features)) {
     existing.features = {}
   }
@@ -2039,18 +2123,15 @@ export function readControlRoomRootFromConfig(configPath = DEFAULT_CONFIG_PATH) 
 /**
  * Write the Control Room discovery root to a config file, preserving other
  * fields (#5172).
+ *
+ * Throws rather than starting fresh when an existing config.json is unreadable
+ * or malformed (#7027) — see readConfigForMerge.
+ *
  * @param {string} root - Absolute path to the discovery root.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
 export function writeControlRoomRootToConfig(root, configPath = DEFAULT_CONFIG_PATH) {
-  let existing = {}
-  try {
-    if (existsSync(configPath)) {
-      existing = JSON.parse(readFileSync(configPath, 'utf-8'))
-    }
-  } catch {
-    // Start fresh if parse fails
-  }
+  const existing = readConfigForMerge(configPath)
   existing.controlRoomRoot = root
   const dir = dirname(configPath)
   mkdirSync(dir, { recursive: true })

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -1937,11 +1937,11 @@ export function readReposFromConfig(configPath = DEFAULT_CONFIG_PATH) {
  * The file's mtime still carries the "when".
  *
  * @param {string} configPath
- * @param {string} raw - The exact bytes read back, used to key the backup.
+ * @param {Buffer} bytes - The raw bytes read back, used to key the backup.
  * @returns {string|null} the backup path, or null if none could be made.
  */
-function backUpMalformedConfig(configPath, raw) {
-  const digest = createHash('sha256').update(raw).digest('hex').slice(0, 16)
+function backUpMalformedConfig(configPath, bytes) {
+  const digest = createHash('sha256').update(bytes).digest('hex').slice(0, 16)
   const backup = `${configPath}.corrupt-${digest}`
   try {
     copyFileSync(configPath, backup, fsConstants.COPYFILE_EXCL)
@@ -1981,9 +1981,14 @@ function backUpMalformedConfig(configPath, raw) {
  * @throws {Error} When the file exists but cannot be read or parsed into an object.
  */
 export function readConfigForMerge(configPath) {
-  let raw
+  // Read as BYTES and decode separately: the backup is keyed off the raw bytes,
+  // and a crash-truncated config can be cut mid multi-byte character, so two
+  // byte-different files can decode to the same U+FFFD-bearing string. Keying
+  // off the decoded text would collapse those onto one backup and then name it
+  // in the refusal for the version it does NOT hold.
+  let bytes
   try {
-    raw = readFileSync(configPath, 'utf-8')
+    bytes = readFileSync(configPath)
   } catch (err) {
     // Absent → legitimately start fresh. Anything else (EACCES, EISDIR, EIO) is
     // a read we cannot trust, and overwriting on the back of it loses the file.
@@ -1996,13 +2001,13 @@ export function readConfigForMerge(configPath) {
 
   let parsed
   try {
-    parsed = JSON.parse(raw)
+    parsed = JSON.parse(bytes.toString('utf-8'))
   } catch (err) {
-    throw refuseMalformedConfig(configPath, `it is not valid JSON (${err.message})`, raw)
+    throw refuseMalformedConfig(configPath, `it is not valid JSON (${err.message})`, bytes)
   }
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     const found = parsed === null ? 'null' : (Array.isArray(parsed) ? 'an array' : `a ${typeof parsed}`)
-    throw refuseMalformedConfig(configPath, `it does not contain a JSON object (found ${found})`, raw)
+    throw refuseMalformedConfig(configPath, `it does not contain a JSON object (found ${found})`, bytes)
   }
   return parsed
 }
@@ -2012,11 +2017,11 @@ export function readConfigForMerge(configPath) {
  * backing the bad file up first (#7027).
  * @param {string} configPath
  * @param {string} reason - Why it could not be merged, in sentence-fragment form.
- * @param {string} raw - The exact bytes read back, used to key the backup.
+ * @param {Buffer} bytes - The raw bytes read back, used to key the backup.
  * @returns {Error}
  */
-function refuseMalformedConfig(configPath, reason, raw) {
-  const backup = backUpMalformedConfig(configPath, raw)
+function refuseMalformedConfig(configPath, reason, bytes) {
+  const backup = backUpMalformedConfig(configPath, bytes)
   return new Error(
     `Refusing to overwrite ${configPath}: ${reason}. ` +
     (backup ? `A copy was saved to ${backup}. ` : '') +

--- a/packages/server/tests/config-malformed-overwrite.test.js
+++ b/packages/server/tests/config-malformed-overwrite.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -115,7 +115,10 @@ describe('#7027 write*ToConfig refuses to overwrite a malformed config', () => {
         for (const bad of ['[1, 2, 3]', '"just a string"', 'null', '42']) {
           const p = join(tmp, `not-an-object-${Buffer.from(bad).toString('hex')}.json`)
           writeFileSync(p, bad)
-          assert.throws(() => write(p), undefined, `expected a refusal for ${bad}`)
+          // Pin the REFUSAL, not merely "something threw" — a bare
+          // assert.throws() here would also be satisfied by an incidental
+          // TypeError from mutating a non-object, which is not the guarantee.
+          assert.throws(() => write(p), /Refusing to overwrite/, `expected a refusal for ${bad}`)
           assert.equal(readFileSync(p, 'utf-8'), bad, `${bad} must be left untouched`)
         }
       })
@@ -147,4 +150,59 @@ describe('#7027 write*ToConfig refuses to overwrite a malformed config', () => {
       })
     })
   }
+})
+
+/** Spin to the next millisecond, so a timestamp-named backup would differ. */
+function nextMillisecond() {
+  const t = Date.now()
+  while (Date.now() === t) { /* deliberate: the clock must actually advance */ }
+}
+
+describe('#7027 the corrupt-config backup does not multiply', () => {
+  it('keeps ONE backup however many times the failing write is retried', () => {
+    writeFileSync(configPath, OPERATOR_CONFIG_WITH_TRAILING_COMMA)
+
+    // The refusal is per-ATTEMPT, and every one of these actions is a button the
+    // operator can press again while working out why it fails. A backup named by
+    // wall-clock time gave each retry its own file, so a confused operator ended
+    // up with an unbounded pile of full copies of config.json — API token and all
+    // — sitting in ~/.chroxy forever. Identical content has no extra recovery
+    // value, so it must collapse onto the one backup.
+    for (let i = 0; i < 3; i++) {
+      for (const { write } of WRITERS) assert.throws(() => write(configPath))
+      nextMillisecond()
+    }
+
+    const backups = backupsOf(configPath)
+    assert.equal(backups.length, 1, `retries must reuse the one backup, got ${JSON.stringify(backups)}`)
+    assert.equal(readFileSync(join(tmp, backups[0]), 'utf-8'), OPERATOR_CONFIG_WITH_TRAILING_COMMA)
+  })
+
+  it('still keeps a SEPARATE backup when the corrupt content actually differs', () => {
+    // Collapsing retries must not collapse genuinely different damage: the
+    // operator's half-repaired second attempt is its own recoverable content.
+    writeFileSync(configPath, OPERATOR_CONFIG_WITH_TRAILING_COMMA)
+    assert.throws(() => writeReposToConfig([{ path: '/x' }], configPath))
+
+    writeFileSync(configPath, '{ "port": 9999, "providers": ')
+    assert.throws(() => writeReposToConfig([{ path: '/x' }], configPath))
+
+    const backups = backupsOf(configPath)
+    assert.equal(backups.length, 2, `distinct content must not collapse, got ${JSON.stringify(backups)}`)
+    assert.deepEqual(
+      backups.map(f => readFileSync(join(tmp, f), 'utf-8')).sort(),
+      [OPERATOR_CONFIG_WITH_TRAILING_COMMA, '{ "port": 9999, "providers": '].sort(),
+    )
+  })
+
+  it('refuses WITHOUT inventing a backup when the config cannot be READ at all', () => {
+    // A directory where config.json should be: EISDIR, not ENOENT. There is
+    // nothing to copy aside, but "start fresh" is still wrong — this is the
+    // read-error limb, which is the one that has no backup to name.
+    const p = join(tmp, 'as-a-dir', 'config.json')
+    mkdirSync(p, { recursive: true })
+
+    assert.throws(() => writeReposToConfig([{ path: '/x' }], p), /could not be read/)
+    assert.deepEqual(backupsOf(p), [], 'an unreadable file cannot be copied aside')
+  })
 })

--- a/packages/server/tests/config-malformed-overwrite.test.js
+++ b/packages/server/tests/config-malformed-overwrite.test.js
@@ -206,3 +206,25 @@ describe('#7027 the corrupt-config backup does not multiply', () => {
     assert.deepEqual(backupsOf(p), [], 'an unreadable file cannot be copied aside')
   })
 })
+
+describe('#7027 backup keying survives a config truncated mid-character', () => {
+  it('keeps distinct backups for byte-different configs that DECODE the same', () => {
+    // A write truncated by a crash — the scenario this refusal exists for — can
+    // cut a multi-byte UTF-8 sequence in half. Two such files differ in their
+    // bytes but both decode to the same U+FFFD replacement, so keying the
+    // backup off the DECODED text silently collapses them and the refusal then
+    // names a backup holding the other truncation's content.
+    const a = Buffer.from([0x7b, 0x22, 0x61, 0x22, 0x3a, 0xff])  // {"a": <bad>
+    const b = Buffer.from([0x7b, 0x22, 0x61, 0x22, 0x3a, 0xfe])  // {"a": <different bad>
+    assert.notDeepEqual(a, b, 'fixture must differ in bytes')
+    assert.equal(a.toString('utf-8'), b.toString('utf-8'), 'fixture must decode identically')
+
+    writeFileSync(configPath, a)
+    assert.throws(() => writeReposToConfig([{ path: '/x' }], configPath))
+    writeFileSync(configPath, b)
+    assert.throws(() => writeReposToConfig([{ path: '/x' }], configPath))
+
+    const backups = backupsOf(configPath)
+    assert.equal(backups.length, 2, `byte-distinct damage must not collapse, got ${JSON.stringify(backups)}`)
+  })
+})

--- a/packages/server/tests/config-malformed-overwrite.test.js
+++ b/packages/server/tests/config-malformed-overwrite.test.js
@@ -1,0 +1,150 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  writeReposToConfig,
+  writeSessionPresetOverrideToConfig,
+  writeSchedulerEnabledToConfig,
+  writeControlRoomRootToConfig,
+} from '../src/config.js'
+
+/**
+ * #7027 — every `write*ToConfig` helper in config.js is a read-modify-write over
+ * the operator's whole `~/.chroxy/config.json`. All four used to swallow a parse
+ * failure (`catch { /* start fresh *\/ }`) and then write the merged object
+ * anyway, so a config with a trailing comma — or one truncated by a previous
+ * crash — was REPLACED WHOLESALE by a single-key object the first time anyone
+ * toggled an unrelated Control Room setting. Tunnel config, providers, features
+ * and permission rules, gone, with no warning.
+ *
+ * These tests are table-driven over EVERY writer on purpose: this repo has a
+ * long history of fixing three of four adjacent sites and walking past the last
+ * one, so `enumerates every write*ToConfig helper` below fails if a writer is
+ * added to config.js without an entry here.
+ *
+ * Every case points at a temp path — never the real ~/.chroxy/config.json (the
+ * sandbox guard in _setup.mjs would throw, and clobbering the operator's real
+ * config is precisely what must not happen).
+ */
+
+// A realistic config the operator would be furious to lose, plus the syntax
+// error that used to trigger the loss (a trailing comma after `features`).
+const OPERATOR_CONFIG_WITH_TRAILING_COMMA = `{
+  "port": 8765,
+  "tunnel": { "mode": "named", "hostname": "chroxy.example.com" },
+  "providers": { "default": "claude-tui" },
+  "features": { "ide": true, "scheduler": true },
+}`
+
+const WRITERS = [
+  {
+    name: 'writeReposToConfig',
+    write: (p) => writeReposToConfig([{ path: '/tmp/repo', name: 'repo' }], p),
+    assertApplied: (cfg) => assert.deepEqual(cfg.repos, [{ path: '/tmp/repo', name: 'repo' }]),
+  },
+  {
+    name: 'writeSessionPresetOverrideToConfig',
+    write: (p) => writeSessionPresetOverrideToConfig('/repo/a', { enabled: true }, p),
+    assertApplied: (cfg) => assert.deepEqual(cfg.repos, [{ path: '/repo/a', sessionPreset: { enabled: true } }]),
+  },
+  {
+    name: 'writeSchedulerEnabledToConfig',
+    write: (p) => writeSchedulerEnabledToConfig(true, p),
+    assertApplied: (cfg) => assert.equal(cfg.features.scheduler, true),
+  },
+  {
+    name: 'writeControlRoomRootToConfig',
+    write: (p) => writeControlRoomRootToConfig('/work/root', p),
+    assertApplied: (cfg) => assert.equal(cfg.controlRoomRoot, '/work/root'),
+  },
+]
+
+let tmp
+let configPath
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'chroxy-config-malformed-'))
+  configPath = join(tmp, 'config.json')
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+const backupsOf = (p) => readdirSync(dirname(p)).filter(f => f.startsWith(`${basename(p)}.corrupt-`))
+
+describe('#7027 write*ToConfig refuses to overwrite a malformed config', () => {
+  it('enumerates every write*ToConfig helper in config.js', () => {
+    // Structural guard: the fix must cover ALL the sibling writers, not most of
+    // them. If a new `write*ToConfig` lands without a row in WRITERS, this fails.
+    const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'config.js'), 'utf-8')
+    const found = [...src.matchAll(/^export function (write\w*ToConfig)\b/gm)].map(m => m[1]).sort()
+    assert.deepEqual(found, WRITERS.map(w => w.name).sort())
+  })
+
+  for (const { name, write, assertApplied } of WRITERS) {
+    describe(name, () => {
+      it('THROWS and leaves the file byte-identical when the existing config is unparseable', () => {
+        writeFileSync(configPath, OPERATOR_CONFIG_WITH_TRAILING_COMMA)
+        const before = readFileSync(configPath, 'utf-8')
+
+        assert.throws(() => write(configPath), /config\.json/)
+
+        assert.equal(
+          readFileSync(configPath, 'utf-8'),
+          before,
+          'the operator config must survive untouched — no wholesale overwrite',
+        )
+      })
+
+      it('backs the unparseable config up before refusing', () => {
+        writeFileSync(configPath, OPERATOR_CONFIG_WITH_TRAILING_COMMA)
+        assert.throws(() => write(configPath))
+
+        const backups = backupsOf(configPath)
+        assert.equal(backups.length, 1, `expected one config.json.corrupt-* backup, got ${JSON.stringify(backups)}`)
+        assert.equal(readFileSync(join(tmp, backups[0]), 'utf-8'), OPERATOR_CONFIG_WITH_TRAILING_COMMA)
+      })
+
+      it('THROWS when the config parses to something that is not a JSON object', () => {
+        // Coercing these to `{}` and writing is the same wholesale replacement
+        // wearing a different hat — the content is still destroyed.
+        for (const bad of ['[1, 2, 3]', '"just a string"', 'null', '42']) {
+          const p = join(tmp, `not-an-object-${Buffer.from(bad).toString('hex')}.json`)
+          writeFileSync(p, bad)
+          assert.throws(() => write(p), undefined, `expected a refusal for ${bad}`)
+          assert.equal(readFileSync(p, 'utf-8'), bad, `${bad} must be left untouched`)
+        }
+      })
+
+      it('still starts fresh when the config file is genuinely ABSENT (first run)', () => {
+        // Positive control: the refusal must not break the legitimate
+        // create-on-first-write path, including creating parent directories.
+        const p = join(tmp, 'nested', 'deeper', 'config.json')
+        assert.equal(existsSync(p), false)
+        write(p)
+        assertApplied(JSON.parse(readFileSync(p, 'utf-8')))
+        assert.deepEqual(backupsOf(p), [], 'an absent file is not corrupt — nothing to back up')
+      })
+
+      it('still merges into a VALID existing config, preserving every other field', () => {
+        // Positive control for the fixtures above: proves each writer really is
+        // reached and really does write, so the throw cases are meaningful.
+        writeFileSync(configPath, JSON.stringify({
+          port: 8765,
+          tunnel: { mode: 'named' },
+          permissionRules: [{ tool: 'Bash', action: 'ask' }],
+        }))
+        write(configPath)
+        const cfg = JSON.parse(readFileSync(configPath, 'utf-8'))
+        assert.equal(cfg.port, 8765)
+        assert.deepEqual(cfg.tunnel, { mode: 'named' })
+        assert.deepEqual(cfg.permissionRules, [{ tool: 'Bash', action: 'ask' }])
+        assertApplied(cfg)
+      })
+    })
+  }
+})

--- a/packages/server/tests/config-persistence-coverage.test.js
+++ b/packages/server/tests/config-persistence-coverage.test.js
@@ -75,11 +75,16 @@ describe('writeSessionPresetOverrideToConfig (#6201)', () => {
     assert.deepEqual(cfg.repos.find((r) => r.path === '/repo/a'), { path: '/repo/a', sessionPreset: { enabled: true } })
   })
 
-  it('starts fresh when the existing config is corrupt JSON', () => {
+  it('REFUSES to write when the existing config is corrupt JSON (#7027)', () => {
+    // Used to "start fresh", which replaced the operator's whole config with a
+    // single repos entry. The write now throws and the file is left alone; the
+    // preset handler turns that into a visible error.
     writeFileSync(configPath, '{ not valid json')
-    writeSessionPresetOverrideToConfig('/repo/a', { enabled: true }, configPath)
-    const cfg = readJson()
-    assert.deepEqual(cfg.repos, [{ path: '/repo/a', sessionPreset: { enabled: true } }])
+    assert.throws(
+      () => writeSessionPresetOverrideToConfig('/repo/a', { enabled: true }, configPath),
+      /Refusing to overwrite/,
+    )
+    assert.equal(readFileSync(configPath, 'utf-8'), '{ not valid json')
   })
 })
 

--- a/packages/server/tests/config-scheduler-gate.test.js
+++ b/packages/server/tests/config-scheduler-gate.test.js
@@ -69,11 +69,14 @@ describe('#6871 writeSchedulerEnabledToConfig', () => {
     }
   })
 
-  it('starts fresh on unparseable JSON instead of throwing', () => {
+  it('THROWS on unparseable JSON instead of starting fresh (#7027)', () => {
+    // "Start fresh" here meant replacing the operator's entire config with
+    // `{ features: { scheduler: true } }`. The handler reports the throw as
+    // SCHEDULER_GATE_FAILED rather than silently destroying the file.
     const p = cfgPath()
     writeFileSync(p, '{ not json')
-    writeSchedulerEnabledToConfig(true, p)
-    assert.equal(read(p).features.scheduler, true)
+    assert.throws(() => writeSchedulerEnabledToConfig(true, p), /Refusing to overwrite/)
+    assert.equal(readFileSync(p, 'utf-8'), '{ not json')
   })
 
   it('writes with restricted (0600) permissions', () => {

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -734,12 +734,15 @@ describe('writeReposToConfig', () => {
     assert.deepEqual(result.repos, [{ path: '/tmp' }])
   })
 
-  it('handles malformed existing config gracefully', () => {
+  it('refuses to overwrite a malformed existing config (#7027)', () => {
+    // Previously "handled gracefully" by discarding it: the operator's tunnel
+    // config, providers and permission rules were replaced by a lone repos key
+    // because of one bad character. The add/remove-repo handlers surface the
+    // throw as `Failed to add repo: …`.
     const configPath = join(tempDir, 'config.json')
     writeFileSync(configPath, 'NOT JSON')
-    writeReposToConfig([{ path: '/tmp' }], configPath)
-    const result = JSON.parse(readFileSync(configPath, 'utf-8'))
-    assert.deepEqual(result.repos, [{ path: '/tmp' }])
+    assert.throws(() => writeReposToConfig([{ path: '/tmp' }], configPath), /Refusing to overwrite/)
+    assert.equal(readFileSync(configPath, 'utf-8'), 'NOT JSON')
   })
 })
 


### PR DESCRIPTION
## The defect

`packages/server/src/config.js` had **four** read-modify-write helpers over the operator's whole `~/.chroxy/config.json`, each opening with an identical swallow:

```js
try { if (existsSync(configPath)) existing = JSON.parse(readFileSync(configPath, 'utf-8')) }
catch { /* start fresh */ }
...
writeFileRestricted(configPath, JSON.stringify(existing, null, 2))
```

- `writeReposToConfig`
- `writeSessionPresetOverrideToConfig`
- `writeSchedulerEnabledToConfig`
- `writeControlRoomRootToConfig`

If `config.json` exists but does not parse — a hand-edit with a trailing comma, a file truncated by an earlier crash, a transient read error — `existing` stayed `{}` and the write **replaced the operator's entire config with a single-key object**. Tunnel config, providers, features, permission rules: gone, on an unrelated Control Room toggle, with no warning.

Two of the four also did `if (!existing || typeof existing !== 'object') existing = {}`, which is the same wholesale replacement for a config that parses to `null`, an array, or a bare string.

## The fix

One shared `readConfigForMerge(configPath)` behind all four sites:

- **ENOENT still starts fresh** — a genuinely absent file is the legitimate first-run path, and the only case that returns `{}`.
- **Everything else throws**: any other read error (EACCES, EISDIR, EIO), a JSON syntax error, or a parse result that is not a plain object.
- **The bad file is backed up first** to `config.json.corrupt-<ISO-ts>` via `copyFileSync` with `COPYFILE_EXCL` (an existing backup is never clobbered — that would be this bug in miniature), and the thrown message names the backup so the operator can recover by hand.

A non-object `features` is still repaired in place rather than refused: that is a single stray *field*, not the whole config, so the operator's other settings survive the write.

All three production callers already had an honest failure path for a throw, so no caller changes were needed:

| caller | surfaces as |
|---|---|
| `handlers/repo-handlers.js` (add/remove) | `Failed to add repo: …` / `Failed to remove repo: …` |
| `handlers/repo-handlers.js` (session preset) | `Failed to write session preset override: …` |
| `handlers/scheduler-handlers.js` | `SCHEDULER_GATE_FAILED` |

`writeControlRoomRootToConfig` currently has no production caller but is exported and carried the same hazard, so it is fixed too.

## Verification

**RED first.** New table-driven suite `packages/server/tests/config-malformed-overwrite.test.js` run against unmodified `config.js`:

```
ℹ tests 21
ℹ pass 9
ℹ fail 12

✖ THROWS and leaves the file byte-identical when the existing config is unparseable
  AssertionError: Missing expected exception.  expected: /config\.json/
✖ backs the unparseable config up before refusing
✖ THROWS when the config parses to something that is not a JSON object
  AssertionError: Missing expected exception: expected a refusal for [1, 2, 3]
   … (the same three, once per writer — 3 × 4 = 12)
```

The 9 that passed pre-fix are the two positive controls per writer (a valid config still merges; an absent file still creates) plus the enumeration guard — so the fixtures provably reach each writer and the refusal assertions are not passing for free.

After the fix: `21/21 pass`.

**Mutation checks** (both reverted afterwards):

1. Restored the old swallow-and-overwrite in **only** `writeControlRoomRootToConfig` → `21 tests, 18 pass, 3 fail`, all three failures isolated to that writer. The table structure catches a fix that covers three of four sites.
2. Broke the `ENOENT` branch so a missing file no longer starts fresh → `4 fail`, exactly the "still starts fresh when the config file is genuinely ABSENT (first run)" control on all four writers. The first-run control is load-bearing, not decorative.

**Three existing characterization tests pinned the destructive behavior and were inverted:**

- `config.test.js` — "handles malformed existing config gracefully" → "refuses to overwrite a malformed existing config"
- `config-persistence-coverage.test.js` — "starts fresh when the existing config is corrupt JSON" → "REFUSES to write …"
- `config-scheduler-gate.test.js` — "starts fresh on unparseable JSON instead of throwing" → "THROWS on unparseable JSON instead of starting fresh"

Each now also asserts the file on disk is **byte-identical** afterwards.

**Suites run** (`node --import ./tests/_setup.mjs --test --test-force-exit`):

- the four config files + `repo-handlers-preset` + `scheduler-handlers`: `188/188 pass`
- `tests/config-*` + `tests/control-room-*` + `tests/scheduler*` + `repo-handlers-preset`: `955/955 pass`

**Lints:** all five `packages/server/scripts/lint-*.sh` green (`lint-tests-state-file-path`, `lint-session-opt-forwarding`, `lint-logger-session-scoping`, `lint-ws-index-mutations`, `lint-claude-family-explicit`); `eslint src/config.js` clean.

## Deliberately out of scope

- `readReposFromConfig` / `readControlRoomRootFromConfig` still degrade to a default on a corrupt file. They are read-only, so they destroy nothing — and `handleAddRepo` reads-then-writes, so the write now throws and the operator gets a visible error instead of a silent loss.
- `billing-budget.js` and the Discord sinks have a similar "missing or corrupt → start fresh" comment, but those are daemon-owned state files that the daemon rewrites, not the operator's hand-edited config.
- `server-cli.js`'s two `config.json` writers were audited: `persistTokenToConfigFile` already lets `JSON.parse` throw, and the keychain-migration block skips the write on a parse failure. Neither has this shape.

Closes #7027.


---

## Review follow-up (commits 2–3)

Adversarial review of the above found one defect in the backup naming, and self-review of that fix found a second. Both are fixed here; full evidence in the PR comments.

**`config.json.corrupt-<timestamp>` was wrong in both directions.** The refusal is per-*attempt*, and every caller is a button the operator can press again:

- retrying a failing write dropped **another full copy of `config.json`** — API token included — so a confused operator accumulated an unbounded pile of identical secret-bearing files in `~/.chroxy` (measured: 5 retries → 5 files);
- two *different* corrupt versions refused inside the same millisecond collided on `COPYFILE_EXCL`, and the refusal then named a backup holding the other version's content.

The backup is now keyed by a sha256 prefix of the **raw bytes**: identical content collapses onto one file, distinct damage always gets its own.

Hashing the *decoded* text (the first attempt at this) still collided, because a config truncated mid multi-byte UTF-8 sequence — the crash case this refusal exists for — decodes to the same `U+FFFD`-bearing string from different bytes. Reading as a `Buffer` and decoding separately removes that.

**Test hardening.** The not-an-object cases asserted only that *something* threw, which an incidental `TypeError` from mutating a non-object would satisfy — now pinned to `/Refusing to overwrite/`. Added the read-error limb (`EISDIR`), the one path with no backup to name, which had no coverage. Copilot's note about the `backUpMalformedConfig` JSDoc claiming "unreadable" is resolved by that same change.

Every mutation fails exactly the test that claims to cover it: whole fix reverted → 15 fail; read limb → 1; clock-keyed backup → 3; a fifth `write*ToConfig` → 1 (the enumeration guard); baseline 25/25.
