### PR TITLE
test(app): pin the compaction-marker timestamp tie-break and fix a dangling doc ref

### DIFF
--- a/packages/app/src/components/__tests__/CompactionMarker.test.tsx
+++ b/packages/app/src/components/__tests__/CompactionMarker.test.tsx
@@ -73,8 +73,11 @@ describe('CompactionMarker (#6972)', () => {
     const text = collectVisibleText(tree.root);
     expect(text).toContain('Context compacted');
     // Locale-agnostic — assert against the runtime's own toLocaleString()
-    // rather than a hard-coded "128,000" (a prior PR was bitten by this,
-    // see CLAUDE.md's "Numbers" testing convention).
+    // rather than a hard-coded "128,000" (grouping separators vary by
+    // locale: comma in en-US, period in de-DE, space in fr-FR). Mirrors the
+    // `localeNum` helper in the dashboard sibling,
+    // packages/dashboard/src/components/CompactionMarker.test.tsx, which was
+    // bitten by exactly this hard-coded assumption during #6970.
     expect(text).toContain(`${(128_000).toLocaleString()} → ${(12_000).toLocaleString()} tokens`);
     expect(text).toContain('2s');
     expect(text).toContain('auto');

--- a/packages/app/src/components/__tests__/insertCompactionMarkers.test.ts
+++ b/packages/app/src/components/__tests__/insertCompactionMarkers.test.ts
@@ -25,6 +25,19 @@ function singleGroup(message: ChatMessage): DisplayGroup {
   return { type: 'single', message };
 }
 
+function activityGroup(messages: ChatMessage[]): DisplayGroup {
+  return {
+    type: 'activity',
+    messages,
+    isActive: false,
+    key: `activity-${messages[0].id}`,
+  };
+}
+
+function ids(groups: DisplayGroup[]): string[] {
+  return groups.map((g) => (g.type === 'single' ? g.message.id : g.key));
+}
+
 describe('insertCompactionMarkers (#6972)', () => {
   it('returns the base groups unchanged when no message carries compactMetadata', () => {
     const messages: ChatMessage[] = [
@@ -104,5 +117,77 @@ describe('insertCompactionMarkers (#6972)', () => {
       'u1',
       'sysB',
     ]);
+  });
+
+  // #6993 — the timestamp tie-break. Placement scans for the first group
+  // whose timestamp is STRICTLY greater than the marker's, so a marker that
+  // ties with an existing row lands immediately AFTER that row. Timestamps
+  // collide in practice (same-millisecond emission), and "after" is the
+  // right answer: the compaction boundary happened once that row existed.
+  // Every other fixture in this file uses distinct timestamps, so these are
+  // the only cases pinning the `>` (rather than `>=`) comparison.
+  describe('equal timestamps (tie-break)', () => {
+    const tieMeta: ChatMessage['compactMetadata'] = {
+      trigger: 'auto',
+      preTokens: 100,
+      postTokens: 10,
+      durationMs: 50,
+    };
+
+    it('places a marker AFTER an existing row sharing its exact timestamp', () => {
+      const tied = msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 5 });
+      const later = msg({ id: 'r1', type: 'response', content: 'hello', timestamp: 10 });
+      const marker = msg({
+        id: 'sys1',
+        type: 'system',
+        content: 'Context compacted',
+        timestamp: 5,
+        compactMetadata: tieMeta,
+      });
+      const out = insertCompactionMarkers(
+        [singleGroup(tied), singleGroup(later)],
+        [tied, marker, later],
+      );
+      // NOT ['sys1', 'u1', 'r1'] — the tied row keeps its place ahead of the marker.
+      expect(ids(out)).toEqual(['u1', 'sys1', 'r1']);
+    });
+
+    it('places a marker AFTER the last row when it ties with that row', () => {
+      const early = msg({ id: 'u1', type: 'user_input', content: 'hi', timestamp: 1 });
+      const tiedLast = msg({ id: 'r1', type: 'response', content: 'hello', timestamp: 7 });
+      const marker = msg({
+        id: 'sys1',
+        type: 'system',
+        content: 'Context compacted',
+        timestamp: 7,
+        compactMetadata: tieMeta,
+      });
+      const out = insertCompactionMarkers(
+        [singleGroup(early), singleGroup(tiedLast)],
+        [early, tiedLast, marker],
+      );
+      expect(ids(out)).toEqual(['u1', 'r1', 'sys1']);
+    });
+
+    it('ties against an activity group using its FIRST message timestamp, landing after the whole group', () => {
+      // groupTimestamp() reads messages[0] for an activity group, so a marker
+      // tying with the group's opening tool_use lands after the entire group —
+      // never spliced into the middle of a tool run.
+      const toolA = msg({ id: 't1', type: 'tool_use', content: 'Read', timestamp: 4 });
+      const toolB = msg({ id: 't2', type: 'tool_use', content: 'Grep', timestamp: 9 });
+      const later = msg({ id: 'r1', type: 'response', content: 'done', timestamp: 12 });
+      const marker = msg({
+        id: 'sys1',
+        type: 'system',
+        content: 'Context compacted',
+        timestamp: 4,
+        compactMetadata: tieMeta,
+      });
+      const out = insertCompactionMarkers(
+        [activityGroup([toolA, toolB]), singleGroup(later)],
+        [toolA, toolB, marker, later],
+      );
+      expect(ids(out)).toEqual(['activity-t1', 'sys1', 'r1']);
+    });
   });
 });


### PR DESCRIPTION
## Defect

Two gaps flagged during review of PR #6990.

**1. Untested tie-break.** `packages/app/src/components/insertCompactionMarkers.ts:53` positions a
marker with `groupTimestamp(merged[i]) > marker.timestamp` — a **strict** `>`. A marker whose
timestamp exactly equals an existing display-group row's therefore lands immediately **after** that
row. That is a reasonable, deterministic choice, but every existing fixture used distinct
timestamps (1/2, 1/2, 1/2/3, 1/5/10, 2/5/8), so nothing pinned it. Same-millisecond emission makes
the tie a real case, not a hypothetical.

**2. Dangling doc reference.** `CompactionMarker.test.tsx` cited *CLAUDE.md's "Numbers" testing
convention*. No such section exists.

## Fix

**Tie-break** — three characterization tests in a new `equal timestamps (tie-break)` block:

- a tie mid-list → marker lands after the tied row, before the next one
- a tie with the **last** row → marker lands at the tail
- a tie against an **activity group** → `groupTimestamp()` reads `messages[0]`, so the marker lands
  after the whole group rather than being spliced into the middle of a tool run

No source change. `insertCompactionMarkers.ts` is untouched by this PR — these pin current
behaviour. Per #6993 this deliberately does **not** generalize the module (#6992 proposes that and
is recommended for closure).

**Doc reference** — repointed at pointers that actually resolve: the dashboard sibling's
`localeNum` helper in `packages/dashboard/src/components/CompactionMarker.test.tsx` and #6970. The
original comment cited commit `b4926ae84`'s change, but that SHA is *not* an ancestor of `main` —
it was squashed into `91100fc84 (#6970)` — so citing it would have swapped one dangling pointer for
another. A file path plus a PR number survives squash-merge.

## Verification

**Red-first, by mutation.** Flipped line 53 `>` → `>=`, then ran the suite:

```
● equal timestamps (tie-break) › places a marker AFTER an existing row sharing its exact timestamp
    - Expected  - 1
    + Received  + 1
      Array [
    -   "u1",
        "sys1",
    +   "u1",
        "r1",
      ]

● equal timestamps (tie-break) › places a marker AFTER the last row when it ties with that row
      Array [
        "u1",
    -   "r1",
        "sys1",
    +   "r1",
      ]

● equal timestamps (tie-break) › ties against an activity group using its FIRST message timestamp
      Array [
    -   "activity-t1",
        "sys1",
    +   "activity-t1",
        "r1",
      ]

Tests:       3 failed, 5 passed, 8 total
```

All three new cases go red; **the five pre-existing tests stay green** — which is the point, and
direct evidence the coverage gap was real rather than assumed. Mutation reverted (`git diff` on the
source is empty) and the suite returns 8/8 green.

**Dangling-ref claim, with a positive control** (the Grep tool silently skips NUL-byte files, so
this was re-run with `command grep`):

```
$ command grep -n "Numbers" CLAUDE.md            → rc=1  (no match)
$ command grep -ni "number" CLAUDE.md            → rc=1  (no match, case-insensitive)
$ command grep -n "Testing Conventions" CLAUDE.md → 231:## Testing Conventions   (control matches)
```

`find . -name 'CLAUDE.md'` confirms there is only one CLAUDE.md in the monorepo, so the citation
had no other candidate file to resolve against.

**Gates:**
- `npx jest src/components/__tests__/insertCompactionMarkers.test.ts src/components/__tests__/CompactionMarker.test.tsx` → 13/13 pass
- Full app suite (both jest roots) → **180 suites, 2327 tests, all pass**
- `npx tsc --noEmit` (packages/app) → clean
- All 5 `packages/server/scripts/lint-*.sh` → OK (Server Lint is not eslint)

## Noticed in passing, not fixed

`packages/app/src/components/SettingsBar.tsx:1376` cites a "CLAUDE.md 44pt minimum tappable target"
that is also absent from CLAUDE.md (verified with the same positive-control method) — same defect
class, different file, outside this issue's scope. Filed as a follow-on rather than folded in:
**#7124** (the review pass found no GitHub issue had actually been opened for it, and filed one —
it also audited the remaining `git grep -n "CLAUDE\.md" -- packages` citations, which all resolve,
so `SettingsBar.tsx:1376` is the last dangling pointer in the source tree).

Closes #6993.

