### PR TITLE
test(server): drive the real token onPersist callback, both limbs (#7055)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -103,6 +103,70 @@ export function persistTokenToConfigFile(configFile, newToken, { durable = false
   }
 }
 
+/**
+ * #7055 — build the `TokenManager({ onPersist })` callback.
+ *
+ * Extracted from `startServer`'s inline closure so BOTH limbs are drivable by a
+ * test. It is load-bearing for a security guarantee (#6965 gates the revoke ack
+ * on it settling; #7045 made it rethrow so a failed write cannot masquerade as a
+ * durable revoke) yet nothing executed it: the gate tests supply a synthetic
+ * `onPersist`, and every local/CI run disables the keychain.
+ *
+ * The keychain seam matters more than it looks. `setToken()` re-checks
+ * availability itself and RETURNS SILENTLY when the keychain is unavailable — no
+ * throw, no boolean. The outer `_isKeychainAvailable()` guard is the only thing
+ * stopping that from becoming a persist that writes nothing anywhere and still
+ * reports success, i.e. a revoke acked for a write that never happened.
+ *
+ * @param {object} opts
+ * @param {string} opts.configFile - path to `~/.chroxy/config.json`
+ * @param {{ error: Function }} [opts.logger]
+ * @param {Function} [opts._isKeychainAvailable] - test seam
+ * @param {Function} [opts._setToken] - test seam
+ * @param {Function} [opts._write] - test seam, forwarded to persistTokenToConfigFile
+ * @returns {(newToken: string, ctx?: { reason?: string }) => void}
+ */
+export function buildTokenPersistCallback({
+  configFile,
+  logger = log,
+  _isKeychainAvailable = isKeychainAvailable,
+  _setToken = setToken,
+  _write = writeFileRestricted,
+} = {}) {
+  return (newToken, { reason } = {}) => {
+    // #6927 — a 'revoke' is the operator panic button (a compromised primary
+    // token killed NOW). Persist it DURABLY so a power loss within the OS
+    // writeback window can't roll config.json back to the compromised token and
+    // resurrect it on the next daemon start. A routine 'scheduled' rotation is
+    // fail-safe (the old token keeps working through its grace window), so it
+    // stays non-durable. Only the file fallback is fsync-controllable here; the
+    // keychain path's durability is the OS keychain's responsibility.
+    const durable = reason === 'revoke'
+    const persistToFile = () => persistTokenToConfigFile(configFile, newToken, { durable, _write })
+    try {
+      if (_isKeychainAvailable()) {
+        try {
+          _setToken(newToken)
+        } catch {
+          // Keychain write failed — fall back to config file
+          persistToFile()
+        }
+      } else {
+        persistToFile()
+      }
+    } catch (err) {
+      logger.error(`Failed to persist token: ${err.message}`)
+      // #6965 — RETHROW. The revoke ack is now gated on this callback resolving,
+      // so swallowing the error here would report a durable revoke that never
+      // reached the disk (the exact false-safety this closes). TokenManager logs
+      // the rejection too, and for a revoke WsServer sends an explicit
+      // REVOKE_NOT_DURABLE error FIRST and then the token-less revoke transition
+      // anyway — the client must still re-authenticate.
+      throw err
+    }
+  }
+}
+
 export function buildTunnelWarmingStatus({ tunnelMode, tunnelUrl, attempt, maxAttempts }) {
   const base = {
     type: 'server_status',
@@ -910,38 +974,9 @@ export async function startCliServer(config) {
   const tokenManager = NO_AUTH ? null : new TokenManager({
     token: API_TOKEN,
     tokenExpiry: config.tokenExpiry || null,
-    onPersist: (newToken, { reason } = {}) => {
-      // #6927 — a 'revoke' is the operator panic button (a compromised primary
-      // token killed NOW). Persist it DURABLY so a power loss within the OS
-      // writeback window can't roll config.json back to the compromised token and
-      // resurrect it on the next daemon start. A routine 'scheduled' rotation is
-      // fail-safe (the old token keeps working through its grace window), so it
-      // stays non-durable. Only the file fallback is fsync-controllable here; the
-      // keychain path's durability is the OS keychain's responsibility.
-      const durable = reason === 'revoke'
-      const persistToFile = () => persistTokenToConfigFile(configFile, newToken, { durable })
-      try {
-        if (isKeychainAvailable()) {
-          try {
-            setToken(newToken)
-          } catch {
-            // Keychain write failed — fall back to config file
-            persistToFile()
-          }
-        } else {
-          persistToFile()
-        }
-      } catch (err) {
-        log.error(`Failed to persist token: ${err.message}`)
-        // #6965 — RETHROW. The revoke ack is now gated on this callback resolving,
-        // so swallowing the error here would report a durable revoke that never
-        // reached the disk (the exact false-safety this closes). TokenManager logs
-        // the rejection too, and for a revoke WsServer sends an explicit
-        // REVOKE_NOT_DURABLE error FIRST and then the token-less revoke transition
-        // anyway — the client must still re-authenticate.
-        throw err
-      }
-    },
+    // #7055 — the callback body lives in `buildTokenPersistCallback` (above) so
+    // both its limbs are testable; as an inline closure nothing could drive it.
+    onPersist: buildTokenPersistCallback({ configFile }),
   })
   if (tokenManager) tokenManager.start()
 

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -155,7 +155,12 @@ export function buildTokenPersistCallback({
         persistToFile()
       }
     } catch (err) {
-      logger.error(`Failed to persist token: ${err.message}`)
+      // `err?.message || String(err)` (the platform.js idiom), not `err.message`:
+      // a thrown `null`/`undefined` would make the LOG LINE throw a TypeError,
+      // which then replaces the original failure on its way to the ack gate —
+      // the operator would be told the persist failed for the wrong reason and
+      // never see a `Failed to persist token` line at all.
+      logger.error(`Failed to persist token: ${err?.message || String(err)}`)
       // #6965 — RETHROW. The revoke ack is now gated on this callback resolving,
       // so swallowing the error here would report a durable revoke that never
       // reached the disk (the exact false-safety this closes). TokenManager logs

--- a/packages/server/tests/token-persist-callback.test.js
+++ b/packages/server/tests/token-persist-callback.test.js
@@ -237,7 +237,7 @@ describe('token onPersist callback (#7055)', () => {
     // daemon really runs: `onPersist: buildTokenPersistCallback({ configFile })`
     // takes every default. A typo in a default — `_write` bound to a writer that
     // skips the 0600 temp+rename, `_isKeychainAvailable` stuck at `() => true` —
-    // would leave all eleven of those tests green while the daemon persisted the
+    // would leave every one of those tests green while the daemon persisted the
     // rotated token nowhere. Swapping each default for a broken stand-in was
     // confirmed to change no result, which is exactly the false-safety #7055
     // exists to close, so these two drive the defaults directly.

--- a/packages/server/tests/token-persist-callback.test.js
+++ b/packages/server/tests/token-persist-callback.test.js
@@ -1,0 +1,209 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildTokenPersistCallback } from '../src/server-cli.js'
+import { TokenManager } from '../src/token-manager.js'
+
+/**
+ * #7055 — the primary-token `onPersist` callback, both limbs.
+ *
+ * This callback is load-bearing for a security guarantee: #6965 gates the
+ * revoke ACK on it settling, and #7045 made it RETHROW so a failed write cannot
+ * masquerade as a durable revoke. Until now nothing drove the real thing —
+ * #6965's gate tests supply a synthetic `onPersist`, and every local/CI run sets
+ * `CHROXY_CRED_DISABLE_KEYCHAIN=1`, so the keychain limb executed NOWHERE.
+ *
+ * Two couplings are pinned here that no other test can see:
+ *
+ *   1. `reason` → durability. `'revoke'` is the operator panic button and must
+ *      reach `writeFileRestricted` with `durable: true`; a routine `'scheduled'`
+ *      rotation is fail-safe and must stay non-durable.
+ *
+ *   2. The outer `isKeychainAvailable()` guard. `keychain.setToken()` RETURNS
+ *      SILENTLY when the keychain is unavailable (keychain.js: `if
+ *      (!isKeychainAvailable()) return`) — no throw, no boolean. Without the
+ *      outer guard the callback would call it, write NOTHING anywhere, and
+ *      resolve as success: a revoke acked for a write that never happened. The
+ *      keychain stub below reproduces that silent-return contract exactly, so
+ *      deleting the guard makes these tests go red instead of staying green.
+ */
+
+/** Records every write the callback performs, by destination. */
+function spies({ keychainAvailable, setTokenBehaviour = 'ok', writeResult = { durabilityUnconfirmed: null }, writeThrows = null } = {}) {
+  const keychainWrites = []
+  const fileWrites = []
+  const logged = []
+  const available = () => keychainAvailable
+
+  return {
+    keychainWrites,
+    fileWrites,
+    logged,
+    seams: {
+      logger: { error: (msg) => logged.push(msg) },
+      _isKeychainAvailable: available,
+      // Mirror of keychain.js `setToken`: it re-checks availability ITSELF and
+      // returns silently when unavailable. A stub that always records would
+      // hide the very defect this file exists to pin.
+      _setToken: (token) => {
+        if (setTokenBehaviour === 'throw') throw new Error('keychain add-generic-password failed')
+        if (!available()) return
+        keychainWrites.push(token)
+      },
+      _write: (file, body, opts) => {
+        if (writeThrows) throw new Error(writeThrows)
+        fileWrites.push({ file, body, opts })
+        return writeResult
+      },
+    },
+  }
+}
+
+describe('token onPersist callback (#7055)', () => {
+  let dir, configFile
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-onpersist-'))
+    configFile = join(dir, 'config.json')
+    writeFileSync(configFile, JSON.stringify({ apiToken: 'old-token', port: 8765 }, null, 2))
+  })
+  afterEach(() => { try { rmSync(dir, { recursive: true, force: true }) } catch { /* */ } })
+
+  describe('reason → durability', () => {
+    it("a 'revoke' reaches writeFileRestricted with durable: true", () => {
+      const s = spies({ keychainAvailable: false })
+      buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' })
+
+      assert.equal(s.fileWrites.length, 1, 'the panic button must write the config file')
+      assert.equal(s.fileWrites[0].opts.durable, true,
+        'a revoke must be fsynced — a power loss inside the writeback window would otherwise resurrect the compromised token')
+      assert.equal(JSON.parse(s.fileWrites[0].body).apiToken, 'new-token')
+    })
+
+    it("a 'scheduled' rotation stays non-durable", () => {
+      const s = spies({ keychainAvailable: false })
+      buildTokenPersistCallback({ configFile, ...s.seams })('rotated', { reason: 'scheduled' })
+
+      assert.equal(s.fileWrites.length, 1)
+      assert.equal(s.fileWrites[0].opts.durable, false,
+        'a scheduled rotation is fail-safe (the old token survives its grace window) — it must not pay the fsync')
+    })
+
+    it('an absent reason defaults to non-durable', () => {
+      const s = spies({ keychainAvailable: false })
+      buildTokenPersistCallback({ configFile, ...s.seams })('rotated')
+
+      assert.equal(s.fileWrites.length, 1)
+      assert.equal(s.fileWrites[0].opts.durable, false)
+    })
+  })
+
+  describe('keychain limb', () => {
+    it('an available keychain takes the token and the config file is left alone', () => {
+      const s = spies({ keychainAvailable: true })
+      buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' })
+
+      assert.deepEqual(s.keychainWrites, ['new-token'])
+      assert.equal(s.fileWrites.length, 0, 'the keychain owns the token when it is available')
+      assert.equal(JSON.parse(readFileSync(configFile, 'utf-8')).apiToken, 'old-token',
+        'and config.json is not rewritten behind the keychain')
+    })
+
+    it('a keychain write FAILURE falls back to the config file and still reports success', () => {
+      const s = spies({ keychainAvailable: true, setTokenBehaviour: 'throw' })
+      assert.doesNotThrow(
+        () => buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' }),
+        'the file fallback is a real persist — it must not surface as a failed revoke',
+      )
+
+      assert.equal(s.keychainWrites.length, 0)
+      assert.equal(s.fileWrites.length, 1, 'the fallback must actually write')
+      assert.equal(s.fileWrites[0].opts.durable, true, 'the fallback keeps the revoke durable')
+      assert.equal(JSON.parse(s.fileWrites[0].body).apiToken, 'new-token')
+    })
+
+    it('an UNAVAILABLE keychain never resolves on a write that went nowhere', () => {
+      // The whole point: `_setToken` here silently no-ops when unavailable, just
+      // like the real one. If the outer availability guard is removed, the
+      // callback calls it, nothing is stored ANYWHERE, and it still returns
+      // cleanly — a revoke acked for a write that never happened.
+      const s = spies({ keychainAvailable: false })
+      buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' })
+
+      assert.equal(s.keychainWrites.length, 0, 'nothing can reach an unavailable keychain')
+      assert.equal(
+        s.keychainWrites.length + s.fileWrites.length, 1,
+        'a callback that returns successfully MUST have stored the token somewhere',
+      )
+      assert.equal(JSON.parse(s.fileWrites[0].body).apiToken, 'new-token')
+    })
+  })
+
+  describe('failure surfaces (the #7045 rethrow)', () => {
+    it('a config-file write failure THROWS rather than returning', () => {
+      const s = spies({ keychainAvailable: false, writeThrows: 'EROFS: read-only file system' })
+      assert.throws(
+        () => buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' }),
+        /EROFS/,
+        'swallowing this reports a durable revoke that never reached the disk',
+      )
+      assert.ok(s.logged.some((m) => /Failed to persist token/.test(m)), 'and it is logged for the operator')
+    })
+
+    it('a landed-but-durability-unconfirmed revoke THROWS (#7067 caveat reaches the ack gate)', () => {
+      const s = spies({ keychainAvailable: false, writeResult: { durabilityUnconfirmed: 'simulated dir fsync EIO' } })
+      assert.throws(
+        () => buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' }),
+        /could not be fsynced|simulated dir fsync/,
+      )
+    })
+
+    it('a keychain fallback whose FILE write also fails throws too', () => {
+      const s = spies({ keychainAvailable: true, setTokenBehaviour: 'throw', writeThrows: 'ENOSPC' })
+      assert.throws(
+        () => buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' }),
+        /ENOSPC/,
+        'the inner keychain catch must not swallow the fallback failure',
+      )
+    })
+  })
+
+  describe('wired into TokenManager (the real revoke path)', () => {
+    const managers = []
+    afterEach(() => { for (const m of managers.splice(0)) m.destroy() })
+
+    it("revoke()'s `persisted` promise resolves only when the durable write landed", async () => {
+      const s = spies({ keychainAvailable: false })
+      const manager = new TokenManager({
+        token: 'old-token',
+        onPersist: buildTokenPersistCallback({ configFile, ...s.seams }),
+      })
+      managers.push(manager)
+      const events = []
+      manager.on('token_rotated', (e) => events.push(e))
+
+      const newToken = manager.revoke()
+      await events[0].persisted
+
+      assert.equal(s.fileWrites.length, 1)
+      assert.equal(s.fileWrites[0].opts.durable, true)
+      assert.equal(JSON.parse(s.fileWrites[0].body).apiToken, newToken)
+    })
+
+    it("revoke()'s `persisted` promise REJECTS when the write fails", async () => {
+      const s = spies({ keychainAvailable: false, writeThrows: 'EIO' })
+      const manager = new TokenManager({
+        token: 'old-token',
+        onPersist: buildTokenPersistCallback({ configFile, ...s.seams }),
+      })
+      managers.push(manager)
+      const events = []
+      manager.on('token_rotated', (e) => events.push(e))
+
+      manager.revoke()
+      await assert.rejects(events[0].persisted, /EIO/,
+        'a rejected persist is what makes WsServer send REVOKE_NOT_DURABLE instead of the success ack')
+    })
+  })
+})

--- a/packages/server/tests/token-persist-callback.test.js
+++ b/packages/server/tests/token-persist-callback.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { buildTokenPersistCallback } from '../src/server-cli.js'
@@ -15,7 +15,7 @@ import { TokenManager } from '../src/token-manager.js'
  * #6965's gate tests supply a synthetic `onPersist`, and every local/CI run sets
  * `CHROXY_CRED_DISABLE_KEYCHAIN=1`, so the keychain limb executed NOWHERE.
  *
- * Two couplings are pinned here that no other test can see:
+ * Three couplings are pinned here that no other test can see:
  *
  *   1. `reason` → durability. `'revoke'` is the operator panic button and must
  *      reach `writeFileRestricted` with `durable: true`; a routine `'scheduled'`
@@ -28,10 +28,14 @@ import { TokenManager } from '../src/token-manager.js'
  *      resolve as success: a revoke acked for a write that never happened. The
  *      keychain stub below reproduces that silent-return contract exactly, so
  *      deleting the guard makes these tests go red instead of staying green.
+ *
+ *   3. The seams' DEFAULTS. Injecting all of them pins the callback's shape and
+ *      none of the wiring `startServer` actually runs, so the last block drives
+ *      `buildTokenPersistCallback({ configFile })` with nothing injected.
  */
 
 /** Records every write the callback performs, by destination. */
-function spies({ keychainAvailable, setTokenBehaviour = 'ok', writeResult = { durabilityUnconfirmed: null }, writeThrows = null } = {}) {
+function spies({ keychainAvailable, setTokenBehaviour = 'ok', writeResult = { durabilityUnconfirmed: null }, writeThrows = null, writeThrowsRaw = null } = {}) {
   const keychainWrites = []
   const fileWrites = []
   const logged = []
@@ -53,6 +57,9 @@ function spies({ keychainAvailable, setTokenBehaviour = 'ok', writeResult = { du
         keychainWrites.push(token)
       },
       _write: (file, body, opts) => {
+        // Boxed so a FALSY non-Error (`null`, `undefined`, `''`) is expressible —
+        // those are precisely the values that break a bare `err.message`.
+        if (writeThrowsRaw) throw writeThrowsRaw.value
         if (writeThrows) throw new Error(writeThrows)
         fileWrites.push({ file, body, opts })
         return writeResult
@@ -159,6 +166,23 @@ describe('token onPersist callback (#7055)', () => {
       )
     })
 
+    it('a NON-Error failure rethrows the original value instead of a TypeError from the log line', () => {
+      // A bare `err.message` on a thrown `null`/`undefined` throws a TypeError
+      // from inside the catch: the `Failed to persist token` line never reaches
+      // the operator, and the ack gate rejects with a bogus "Cannot read
+      // properties of null" instead of the real persist failure.
+      const s = spies({ keychainAvailable: false, writeThrowsRaw: { value: null } })
+      let thrown = 'nothing was thrown'
+      try {
+        buildTokenPersistCallback({ configFile, ...s.seams })('new-token', { reason: 'revoke' })
+      } catch (err) {
+        thrown = err
+      }
+
+      assert.equal(thrown, null, 'the ORIGINAL failure must reach the revoke ack gate, not the log line’s own TypeError')
+      assert.ok(s.logged.some((m) => /Failed to persist token/.test(m)), 'and the operator still gets the line')
+    })
+
     it('a keychain fallback whose FILE write also fails throws too', () => {
       const s = spies({ keychainAvailable: true, setTokenBehaviour: 'throw', writeThrows: 'ENOSPC' })
       assert.throws(
@@ -204,6 +228,66 @@ describe('token onPersist callback (#7055)', () => {
       manager.revoke()
       await assert.rejects(events[0].persisted, /EIO/,
         'a rejected persist is what makes WsServer send REVOKE_NOT_DURABLE instead of the success ack')
+    })
+  })
+
+  describe('production defaults (the seams as `startServer` actually builds them)', () => {
+    // Every test above injects ALL of `_isKeychainAvailable`, `_setToken` and
+    // `_write`, so it pins the callback's SHAPE and nothing about the wiring the
+    // daemon really runs: `onPersist: buildTokenPersistCallback({ configFile })`
+    // takes every default. A typo in a default — `_write` bound to a writer that
+    // skips the 0600 temp+rename, `_isKeychainAvailable` stuck at `() => true` —
+    // would leave all eleven of those tests green while the daemon persisted the
+    // rotated token nowhere. Swapping each default for a broken stand-in was
+    // confirmed to change no result, which is exactly the false-safety #7055
+    // exists to close, so these two drive the defaults directly.
+    //
+    // `tests/_setup.mjs` sets `CHROXY_DISABLE_KEYCHAIN=1` process-wide and
+    // keychain.js reads it lazily; each test re-asserts it so it can never shell
+    // out to the developer's real `security`/`secret-tool` even if the harness
+    // stops setting it.
+    let restoreKeychainEnv
+    beforeEach(() => {
+      restoreKeychainEnv = process.env.CHROXY_DISABLE_KEYCHAIN
+      process.env.CHROXY_DISABLE_KEYCHAIN = '1'
+    })
+    afterEach(() => {
+      if (restoreKeychainEnv === undefined) delete process.env.CHROXY_DISABLE_KEYCHAIN
+      else process.env.CHROXY_DISABLE_KEYCHAIN = restoreKeychainEnv
+    })
+
+    it('with NO seams injected the real writer lands the token in the real config file', () => {
+      buildTokenPersistCallback({ configFile })('defaulted-token', { reason: 'revoke' })
+
+      const cfg = JSON.parse(readFileSync(configFile, 'utf-8'))
+      assert.equal(cfg.apiToken, 'defaulted-token',
+        'the daemon builds this callback with no seams at all — if the defaults are not the real keychain probe and the real restricted writer, a rotation persists nowhere')
+      assert.equal(cfg.port, 8765, 'and the rest of config.json survives the rewrite')
+      if (process.platform !== 'win32') {
+        assert.equal(statSync(configFile).mode & 0o777, 0o600,
+          'the default writer must be writeFileRestricted — config.json holds the primary bearer token')
+      }
+    })
+
+    it('a defaulted keychain limb returns SILENTLY and stores nothing when the keychain is unavailable', () => {
+      // Force the availability probe true while leaving `_setToken` defaulted:
+      // the REAL setToken re-checks availability itself and returns without
+      // throwing and without storing anything. That silent-return is the premise
+      // the stub at the top of this file encodes and the reason the outer guard
+      // exists; assert it against the real function so the stub cannot drift
+      // from it unnoticed.
+      //
+      // Honest limit: with the keychain unavailable this cannot tell the real
+      // `setToken` apart from any other silent no-op — the available branch
+      // needs an actual OS keychain, which is `keychain.test.js`'s opt-in
+      // `CHROXY_TEST_REAL_KEYCHAIN=1` territory and must never run by default
+      // (it pollutes the developer's login keychain and can pop a modal).
+      assert.doesNotThrow(
+        () => buildTokenPersistCallback({ configFile, _isKeychainAvailable: () => true })('never-stored', { reason: 'revoke' }),
+        'the real setToken does not signal failure — no throw, no boolean',
+      )
+      assert.equal(JSON.parse(readFileSync(configFile, 'utf-8')).apiToken, 'old-token',
+        'nothing reached the keychain and nothing reached the file: a revoke that would have acked a write that never happened, which is what the outer guard prevents')
     })
   })
 })


### PR DESCRIPTION
## The defect

`server-cli.js` handed `TokenManager` an **inline** `onPersist` closure:

```js
onPersist: (newToken, { reason } = {}) => {
  const durable = reason === 'revoke'
  ...
  if (isKeychainAvailable()) { try { setToken(newToken) } catch { persistToFile() } }
  else { persistToFile() }
  ...
}
```

Nothing could execute it. `grep -rn onPersist packages/server/tests/` returns only
*synthetic* callbacks — #6965's gate tests (`token-revoke-durable-ack.test.js`) supply
their own `onPersist`, and every local/CI run sets `CHROXY_CRED_DISABLE_KEYCHAIN=1`,
so the keychain limb executed **nowhere**.

That is untested code carrying a security guarantee: #6965 gates the revoke ack on
this callback settling, and #7045 made it **rethrow** so a failed write cannot
masquerade as a durable revoke.

The sharpest unasserted coupling is the outer availability guard.
`keychain.setToken()` re-checks availability *itself* and **returns silently** when
the keychain is unavailable (`keychain.js`: `if (!isKeychainAvailable()) return`) — no
throw, no boolean. Without the outer `if (isKeychainAvailable())` guard the callback
would call it, store the token in **neither** the keychain nor the file, and still
return cleanly: a revoke acked for a write that never happened.

`persistTokenToConfigFile` was already extracted with a `_write` seam (#7067), so the
file-writer leaf was covered; the `reason` → `durable` mapping and the whole keychain
limb were not.

## The fix

Extract the closure body into an exported `buildTokenPersistCallback({ configFile })`
with seams for the keychain probe, `setToken`, and the leaf `writeFileRestricted`.
Every seam defaults to the production function, so behaviour at the call site is
unchanged — the call site is now `onPersist: buildTokenPersistCallback({ configFile })`.

11 new tests in `packages/server/tests/token-persist-callback.test.js`:

- `reason: 'revoke'` reaches `writeFileRestricted` with `durable: true`; `'scheduled'`
  and an absent reason with `durable: false`
- an available keychain takes the token and `config.json` is left alone
- a keychain write **failure** falls back to the file and still reports success
- an **unavailable** keychain never returns successfully having written nowhere
- a file write failure — and a landed-but-durability-unconfirmed revoke — **throw**
  rather than returning; the failure is logged for the operator
- wired into the real `TokenManager`, `revoke()`'s `persisted` promise resolves only
  on the durable write and **rejects** when it fails

The keychain stub deliberately mirrors the real `setToken`'s contract (it re-checks
availability itself and returns silently), so the guard test cannot pass vacuously.

## Verification

**Red first** — the test file imports a seam that did not exist, which *is* the defect
("extract the callback so both limbs are testable"):

```
SyntaxError: The requested module '../src/server-cli.js' does not provide an export
named 'buildTokenPersistCallback'
ℹ tests 1  ℹ pass 0  ℹ fail 1
```

Green after the extraction: `ℹ tests 11  ℹ pass 11  ℹ fail 0`.

**Mutation checks** (one mutation per run, source restored after each):

| # | Mutation | Result |
|---|----------|--------|
| M1 | `const durable = reason === 'revoke'` → `const durable = false` | **4 red** (revoke durability, fallback durability, #7067 caveat, TokenManager revoke) |
| M2 | drop the outer `if (_isKeychainAvailable())` guard | **8 red**, incl. the guard test: `AssertionError: a callback that returns successfully MUST have stored the token somewhere — 0 !== 1` |
| M3 | delete the `throw err` rethrow (#7045) | **4 red** (all three throw cases + the `persisted` rejection) |
| M4 | drop the keychain-failure file fallback | **2 red** |

M2 reproduces the exact false-safety the issue describes: zero writes anywhere, and
the callback still resolves.

**Suites run:**

- `token-persist-callback` + `token-persist-durability` + `token-revoke-durable-ack` +
  `token-manager` → 58 tests, 58 pass, 0 fail
- all 23 test files importing `server-cli.js` → 661 tests, 656 pass, 0 fail, 5 skipped
- `npx eslint src/server-cli.js` → clean
- `lint-tests-state-file-path.sh`, `lint-logger-session-scoping.sh`,
  `lint-session-opt-forwarding.sh`, `lint-ws-index-mutations.sh`,
  `lint-claude-family-explicit.sh` → all OK

Closes #7055.


---

## Review round (post-review commits)

**Gap found: the seams' own defaults were unpinned.** All 11 tests injected all four
seams, which pins the callback's shape and nothing about the wiring `startCliServer`
actually runs (`buildTokenPersistCallback({ configFile })` takes every default).
Replacing each default with a broken stand-in left every test green:

| Mutation | Before | After |
|---|---|---|
| default `_isKeychainAvailable` → `() => true` | 0 red | **1 red** |
| default `_write` → no-op | 0 red | **1 red** |
| default `_write` → plain `writeFileSync` (no atomic temp+rename, mode 0644) | 0 red | **1 red** |

Two tests now drive the builder with nothing injected: the real `writeFileRestricted`
must land the token in the real file at 0600 with the rest of `config.json` intact, and
the defaulted keychain limb must return silently and store nothing when the keychain is
unavailable. `tests/_setup.mjs` sets `CHROXY_DISABLE_KEYCHAIN=1` process-wide and the new
block re-asserts it per test, so it can never reach a developer's real
`security`/`secret-tool`. Residual, documented in the test rather than hidden: with the
keychain unavailable the real `setToken` is indistinguishable from any silent no-op, so
the default `_setToken` stays unpinned — the available branch needs `keychain.test.js`'s
opt-in `CHROXY_TEST_REAL_KEYCHAIN=1`.

**Copilot's comment (fixed, not waved through).** The catch block logged `err.message`
unguarded. That block feeds the revoke ack gate, so a thrown `null`/`undefined` makes the
LOG LINE throw a `TypeError`, which replaces the original failure on the way to the gate
and suppresses the `Failed to persist token` line entirely. Now uses the
`err?.message || String(err)` idiom already in `platform.js`, pinned by a test that throws
a raw `null` through the `_write` seam. Red first:

```
not ok 3 - a NON-Error failure rethrows the original value instead of a TypeError from the log line
    + TypeError: Cannot read properties of null (reading 'message')
# tests 14  # pass 13  # fail 1
```

**Extraction re-verified independently.** Pure move; `configFile` is a `const` on the line
above the call site so hoisting the capture changes nothing; `onPersist` has exactly one
production site (no adjacent-site drift). Mutation matrix re-run one-at-a-time: durable
mapping 4 red, outer guard 10 red, `throw err` 5 red, keychain fallback 2 red.

**Suites:** token-persist-callback + token-manager + token-revoke-durable-ack +
token-persist-durability → 61/61 pass. All 24 test files importing `server-cli.js` →
704 tests, 698 pass, 0 fail, 6 skipped. `eslint src/server-cli.js` clean; all five
`scripts/lint-*.sh` OK.
