### PR TITLE
fix(server,docs): clamp the codex reconnect deadline to its supported window

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -416,16 +416,24 @@ shadowing it:
 |---|---|
 | _unset_ | Default. The deadline is 5 minutes. |
 | `120001`–`1799999` | The supported window: the deadline is set to that many ms. |
-| Anything else | Logs a warning and falls back to the 5-minute default. |
+| A number outside that window (including above the shared 24-hour sanity ceiling) | Logs a warning naming the window, then falls back to the 5-minute default. |
+| Not a positive number at all — `abc`, `5m`, `0`, `-1` | Falls back to the 5-minute default **silently, with no warning**. |
+
+That last row is worth knowing before you debug a deadline that "did not take":
+the quiet reject for unparseable input is the shared behaviour of every
+`CHROXY_*` timeout var (they all run through the same `isOperatorTimeoutInRange`
+guard, which only warns on the over-ceiling case), so a mistyped value looks
+exactly like an unset one. Note in particular that `5m` is **not** accepted here
+— this var is plain milliseconds, not one of Chroxy's duration strings. If the
+deadline is not what you set, check the spelling and units first.
 
 The window is deliberately narrow and both ends are exclusive. It must stay
 **above the 2-minute silence watchdog** — below it the deadline would beat the
 silence path to every wedge, and it would also start killing turns inside
 codex's own bounded retry burst — and **below the 30-minute default result
 timeout**, since being a strictly-shorter bound than that timeout is the whole
-point. A value outside the window (or non-numeric, or above the shared 24-hour
-sanity ceiling) is rejected with a warning rather than refusing to start the
-server (#6967).
+point. An out-of-range value is rejected and logged rather than refusing to
+start the server (#6967).
 
 ## Gemini
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -395,6 +395,38 @@ the requested scope. Approve grants exactly that scope for the current turn,
 sandbox escalations can never be permanently rule-whitelisted — they always
 prompt.
 
+### `CHROXY_CODEX_RECONNECT_DEADLINE_MS` env override (#6856 / #6967)
+
+When codex's response stream drops mid-turn it emits `Reconnecting... N/5`
+errors, and Chroxy keeps the turn open so codex can recover rather than failing
+on a blip. Two backstops bound that wait: a 2-minute *silence* watchdog (codex
+went quiet mid-reconnect) and a 5-minute *hard deadline* on total time spent in
+the reconnect-suppressed state (codex reconnects forever without ever
+recovering). The deadline is armed once, on entering suppression, and is
+deliberately not pushed out by later reconnect ticks; when it fires the turn
+fails with `stream_stall` so the client shows its normal retry affordance.
+
+Set `CHROXY_CODEX_RECONNECT_DEADLINE_MS` on the server process to change that
+5-minute hard deadline. The `reconnectDeadlineMs` session opt is the
+programmatic equivalent and wins over the env var — but only when the opt is
+itself in range, so a bogus opt falls through to the env value rather than
+shadowing it:
+
+| Value | Effect |
+|---|---|
+| _unset_ | Default. The deadline is 5 minutes. |
+| `120001`–`1799999` | The supported window: the deadline is set to that many ms. |
+| Anything else | Logs a warning and falls back to the 5-minute default. |
+
+The window is deliberately narrow and both ends are exclusive. It must stay
+**above the 2-minute silence watchdog** — below it the deadline would beat the
+silence path to every wedge, and it would also start killing turns inside
+codex's own bounded retry burst — and **below the 30-minute default result
+timeout**, since being a strictly-shorter bound than that timeout is the whole
+point. A value outside the window (or non-numeric, or above the shared 24-hour
+sanity ceiling) is rejected with a warning rather than refusing to start the
+server (#6967).
+
 ## Gemini
 
 Google Gemini CLI.

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -194,9 +194,12 @@ export class CodexAppServerSession extends BaseSession {
     this._reconnectDeadline = null // #6856 — one-shot hard cap on total reconnect-suppression time
     // #6856/#6967 — configurable reconnect-suppression deadline (opt / env /
     // default), clamped to the window between the #6629 silence watchdog and the
-    // default result timeout. Warns through the session logger when present so an
-    // out-of-range override is attributable to the session that set it.
-    this._reconnectDeadlineMs = resolveReconnectDeadlineMs(opts.reconnectDeadlineMs, this._log || log)
+    // default result timeout. The out-of-range warning goes to the MODULE logger,
+    // not the usual `this._log || log`: `this._log` is the thread-scoped logger
+    // built in start() (it needs a thread id, which does not exist yet), so at
+    // construction that expression is unconditionally `log` and writing it would
+    // only imply a session scoping this warn can never have.
+    this._reconnectDeadlineMs = resolveReconnectDeadlineMs(opts.reconnectDeadlineMs)
     // #6856 — injectable timer seam (defaults to node globals) so the reconnect
     // deadline is unit-testable without wall-clock waits, mirroring the #6908/#6911
     // byok-mcp-config `setTimer`/`clearTimer` pattern. Only the deadline routes

--- a/packages/server/src/codex-app-server-session.js
+++ b/packages/server/src/codex-app-server-session.js
@@ -1,7 +1,8 @@
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join, basename, extname } from 'path'
-import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts, DEFAULT_RESULT_TIMEOUT_MS } from './base-session.js'
+import { isOperatorTimeoutInRange } from './duration.js'
 import { nonNegInt, synthesizeModelUsage } from './usage-normalize.js'
 import { CodexSession, resolveCodexSandbox } from './codex-session.js'
 import { CodexAppServerClient } from './codex-app-server-client.js'
@@ -59,15 +60,47 @@ const RECONNECT_WATCHDOG_MS = 2 * 60 * 1000
 // notification) or the turn ends. 5 min sits above codex's bounded N/5 retry
 // burst AND above the 2-min silence watchdog (so the faster silence path still
 // wins its own case), while capping the worst case 6x below the 30-min result
-// timeout. Override via `reconnectDeadlineMs` opt / CHROXY_CODEX_RECONNECT_DEADLINE_MS.
+// timeout. Override via `reconnectDeadlineMs` opt / CHROXY_CODEX_RECONNECT_DEADLINE_MS,
+// clamped to the window below (#6967) so an override can't break either invariant.
 const RECONNECT_DEADLINE_MS = 5 * 60 * 1000
 
-// #6856: resolve the reconnect-suppression deadline. Opt wins over the env var;
-// a non-finite / non-positive value (unset env → NaN, garbage → NaN, 0/negative)
-// falls back to the default. Returns ms.
-function resolveReconnectDeadlineMs(optValue) {
+// #6967: the operator override is CLAMPED to the window the #6856 design depends
+// on, not merely checked for finite/positive. Two invariants define that window:
+//
+//   FLOOR (exclusive) — the deadline must sit ABOVE the #6629 silence watchdog.
+//     Below it, the deadline would beat the silence path to every wedge and the
+//     watchdog's "codex went quiet" case could never win on its own; and above
+//     codex's bounded N/5 retry burst, a sub-watchdog deadline would kill turns
+//     codex was about to recover on its own. `CHROXY_CODEX_RECONNECT_DEADLINE_MS=1000`
+//     used to be accepted verbatim and fired near-instantly.
+//   CEILING (exclusive) — the deadline must sit BELOW the default result timeout.
+//     Its entire purpose is being a strictly-shorter bound than that timeout; at
+//     or past it the deadline is dead code (the result timeout fires first).
+//
+// `isOperatorTimeoutInRange` runs first so this shares the finite/positive/<=24h
+// guard rail (and its typo warning) with `resultTimeoutMs` & friends; the window
+// check then narrows it to this timer's own bounds.
+const RECONNECT_DEADLINE_FLOOR_MS = RECONNECT_WATCHDOG_MS
+const RECONNECT_DEADLINE_CEILING_MS = DEFAULT_RESULT_TIMEOUT_MS
+
+// #6856/#6967: resolve the reconnect-suppression deadline. The opt wins over the
+// env var, but only when it is itself VALID — an out-of-range opt falls through
+// to the env candidate rather than shadowing it. Anything outside the window
+// above (including a non-finite value: unset env → NaN, garbage → NaN, and
+// 0/negative) falls back to the default. Returns ms.
+function resolveReconnectDeadlineMs(optValue, logger = log) {
   for (const candidate of [optValue, Number(process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS)]) {
-    if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0) return candidate
+    if (!isOperatorTimeoutInRange(candidate, { name: 'reconnectDeadlineMs', log: logger })) continue
+    if (candidate > RECONNECT_DEADLINE_FLOOR_MS && candidate < RECONNECT_DEADLINE_CEILING_MS) return candidate
+    // Same defensive shape as isOperatorTimeoutInRange's own warn — a stubbed
+    // logger without .warn must not turn a rejected override into a throw.
+    if (logger && typeof logger.warn === 'function') {
+      logger.warn(
+        `reconnectDeadlineMs ${candidate} is outside the supported window ` +
+        `(${RECONNECT_DEADLINE_FLOOR_MS}ms < value < ${RECONNECT_DEADLINE_CEILING_MS}ms); ` +
+        `falling back to the ${RECONNECT_DEADLINE_MS}ms default`,
+      )
+    }
   }
   return RECONNECT_DEADLINE_MS
 }
@@ -159,8 +192,11 @@ export class CodexAppServerSession extends BaseSession {
     this._turnAbort = null // per-turn AbortController — cancels pending approvals
     this._reconnectWatchdog = null // #6629 — bounded backstop for a wedged reconnect
     this._reconnectDeadline = null // #6856 — one-shot hard cap on total reconnect-suppression time
-    // #6856 — configurable reconnect-suppression deadline (opt / env / default).
-    this._reconnectDeadlineMs = resolveReconnectDeadlineMs(opts.reconnectDeadlineMs)
+    // #6856/#6967 — configurable reconnect-suppression deadline (opt / env /
+    // default), clamped to the window between the #6629 silence watchdog and the
+    // default result timeout. Warns through the session logger when present so an
+    // out-of-range override is attributable to the session that set it.
+    this._reconnectDeadlineMs = resolveReconnectDeadlineMs(opts.reconnectDeadlineMs, this._log || log)
     // #6856 — injectable timer seam (defaults to node globals) so the reconnect
     // deadline is unit-testable without wall-clock waits, mirroring the #6908/#6911
     // byok-mcp-config `setTimer`/`clearTimer` pattern. Only the deadline routes

--- a/packages/server/tests/codex-app-server-session.test.js
+++ b/packages/server/tests/codex-app-server-session.test.js
@@ -673,7 +673,12 @@ describe('CodexAppServerSession — reconnect suppression deadline (#6856)', () 
     const { s, cleanup } = mkSession({
       setTimer: timers.setTimer,
       clearTimer: timers.clearTimer,
-      reconnectDeadlineMs: 60_000,
+      // #6967: 3 min — a NON-default value (so these still prove the opt is what
+      // arms the timer) that sits inside the supported window (above the 2-min
+      // silence watchdog, below the 30-min result timeout). The previous 60_000
+      // is now clamped away to the default and would silently stop testing the
+      // override.
+      reconnectDeadlineMs: 180_000,
       ...extraOpts,
     })
     return { s, cleanup, timers }
@@ -694,7 +699,7 @@ describe('CodexAppServerSession — reconnect suppression deadline (#6856)', () 
     s._onNotification({ method: 'error', params: reconnectParams(2, 5) })
     assert.ok(s._reconnectDeadline, 'deadline armed on the first transient reconnect')
     assert.equal(timers.scheduled.length, 1, 'exactly one deadline timer scheduled')
-    assert.equal(timers.scheduled[0].ms, 60_000, 'armed with the configured deadline ms')
+    assert.equal(timers.scheduled[0].ms, 180_000, 'armed with the configured deadline ms')
     assert.equal(timers.scheduled[0].cleared, false, 'the deadline is pending')
     s.destroy()
     cleanup()
@@ -750,7 +755,7 @@ describe('CodexAppServerSession — reconnect suppression deadline (#6856)', () 
     timers.fire()
     const err = ev.find(([e]) => e === 'error')
     assert.ok(err, 'the deadline fails the turn')
-    assert.match(err[1].message, /reconnect exceeded 60s/i, 'a clear "codex reconnect exceeded Ns" error')
+    assert.match(err[1].message, /reconnect exceeded 180s/i, 'a clear "codex reconnect exceeded Ns" error')
     assert.equal(err[1].code, 'stream_stall', 'carries stream_stall so the client shows its retry chip')
     assert.ok(ev.some(([e, p]) => e === 'tool_result' && p.toolUseId === 'shell-1'), 'the orphan in-flight shell tool_start is swept')
     assert.equal(s._isBusy, false, 'stale working state cleared')
@@ -776,8 +781,8 @@ describe('CodexAppServerSession — reconnect suppression deadline (#6856)', () 
   })
 
   it('the deadline is configurable via the opt (with a sensible default)', () => {
-    const custom = mkSession({ reconnectDeadlineMs: 90_000 })
-    assert.equal(custom.s._reconnectDeadlineMs, 90_000, 'opt overrides the default')
+    const custom = mkSession({ reconnectDeadlineMs: 240_000 })
+    assert.equal(custom.s._reconnectDeadlineMs, 240_000, 'opt overrides the default')
     custom.s.destroy(); custom.cleanup()
 
     const def = mkSession()
@@ -792,15 +797,88 @@ describe('CodexAppServerSession — reconnect suppression deadline (#6856)', () 
 
   it('the deadline is configurable via CHROXY_CODEX_RECONNECT_DEADLINE_MS', () => {
     const prev = process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
-    process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = '120000'
+    process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = '180000'
     try {
       const { s, cleanup } = mkSession()
-      assert.equal(s._reconnectDeadlineMs, 120_000, 'env var sets the deadline')
+      assert.equal(s._reconnectDeadlineMs, 180_000, 'env var sets the deadline')
       s.destroy(); cleanup()
     } finally {
       if (prev === undefined) delete process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
       else process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = prev
     }
+  })
+
+  // #6967 — the operator override is CLAMPED, not merely finite/positive. The
+  // whole #6856 design leans on the deadline sitting ABOVE the 2-min #6629
+  // silence watchdog (so the faster silence path still wins its own case) and
+  // BELOW the 30-min default result timeout (so it stays a strictly-shorter
+  // bound). A bespoke `> 0` check let an operator set 1000ms and fire it almost
+  // immediately, defeating both invariants.
+  describe('operator override clamping (#6967)', () => {
+    const DEFAULT = 5 * 60 * 1000
+    const WATCHDOG = 2 * 60 * 1000
+    const RESULT_TIMEOUT = 30 * 60 * 1000
+
+    const withEnv = (value, fn) => {
+      const prev = process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
+      if (value === undefined) delete process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
+      else process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = value
+      try { fn() } finally {
+        if (prev === undefined) delete process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS
+        else process.env.CHROXY_CODEX_RECONNECT_DEADLINE_MS = prev
+      }
+    }
+
+    it('an opt at or below the 2-min silence watchdog falls back to the default', () => {
+      for (const tooSmall of [1000, 60_000, WATCHDOG]) {
+        const { s, cleanup } = mkSession({ reconnectDeadlineMs: tooSmall })
+        assert.equal(s._reconnectDeadlineMs, DEFAULT, `${tooSmall}ms is not above the watchdog — falls back`)
+        s.destroy(); cleanup()
+      }
+    })
+
+    it('an opt at or above the 30-min result timeout falls back to the default', () => {
+      for (const tooBig of [RESULT_TIMEOUT, 60 * 60 * 1000, 25 * 60 * 60 * 1000]) {
+        const { s, cleanup } = mkSession({ reconnectDeadlineMs: tooBig })
+        assert.equal(s._reconnectDeadlineMs, DEFAULT, `${tooBig}ms is not below the result timeout — falls back`)
+        s.destroy(); cleanup()
+      }
+    })
+
+    it('CHROXY_CODEX_RECONNECT_DEADLINE_MS below the floor falls back to the default', () => {
+      withEnv('1000', () => {
+        const { s, cleanup } = mkSession()
+        assert.equal(s._reconnectDeadlineMs, DEFAULT, 'a near-instant env deadline is rejected')
+        s.destroy(); cleanup()
+      })
+    })
+
+    it('CHROXY_CODEX_RECONNECT_DEADLINE_MS above the ceiling falls back to the default', () => {
+      withEnv(String(2 * 60 * 60 * 1000), () => {
+        const { s, cleanup } = mkSession()
+        assert.equal(s._reconnectDeadlineMs, DEFAULT, 'an env deadline past the result timeout is rejected')
+        s.destroy(); cleanup()
+      })
+    })
+
+    it('an out-of-range opt does NOT shadow an in-range env value', () => {
+      // The opt is only preferred when it is itself VALID — an operator's
+      // in-range env var must still win over a bogus programmatic opt rather
+      // than both collapsing to the default.
+      withEnv('180000', () => {
+        const { s, cleanup } = mkSession({ reconnectDeadlineMs: 1000 })
+        assert.equal(s._reconnectDeadlineMs, 180_000, 'the in-range env value is used')
+        s.destroy(); cleanup()
+      })
+    })
+
+    it('in-range values on both edges of the window are honoured', () => {
+      for (const ok of [WATCHDOG + 1, 3 * 60 * 1000, RESULT_TIMEOUT - 1]) {
+        const { s, cleanup } = mkSession({ reconnectDeadlineMs: ok })
+        assert.equal(s._reconnectDeadlineMs, ok, `${ok}ms sits inside the window and is honoured`)
+        s.destroy(); cleanup()
+      }
+    })
   })
 })
 


### PR DESCRIPTION
## The defect (#6967)

`resolveReconnectDeadlineMs()` in `packages/server/src/codex-app-server-session.js` accepted
**any finite, positive number** for the `reconnectDeadlineMs` opt / `CHROXY_CODEX_RECONNECT_DEADLINE_MS`
env override:

```js
if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0) return candidate
```

The #6856 design depends on that deadline sitting inside a specific window:

- **above** the 2-min `RECONNECT_WATCHDOG_MS` silence watchdog — below it the deadline beats the
  silence path to every wedge (so the watchdog's "codex went quiet" case can never win on its own),
  and it starts killing turns *inside* codex's own bounded N/5 retry burst;
- **below** the 30-min `DEFAULT_RESULT_TIMEOUT_MS` — being a strictly-shorter bound than that
  timeout is the deadline's entire reason to exist; at or past it the timer is dead code.

`CHROXY_CODEX_RECONNECT_DEADLINE_MS=1000` defeated both and fired near-instantly. The sibling
`resultTimeoutMs` / `hardTimeoutMs` / `streamStallTimeoutMs` all already route through the shared
`isOperatorTimeoutInRange` helper for exactly this reason.

## The fix

- Both candidates (opt, then env) run through **`isOperatorTimeoutInRange`** — inheriting the same
  finite / positive / <=24h guard rail and its typo warning as `resultTimeoutMs` & friends — then
  through this timer's own **exclusive window**
  (`RECONNECT_WATCHDOG_MS < value < DEFAULT_RESULT_TIMEOUT_MS`). Out of range logs a warning naming
  the window and falls back to the 5-min `RECONNECT_DEADLINE_MS` default.
- An **out-of-range opt now falls through to the env candidate** instead of shadowing it, so an
  operator's in-range env var still wins over a bogus programmatic opt rather than both collapsing
  to the default.
- The warn goes through the **module** logger, guarded with the same `typeof logger.warn === 'function'`
  check `isOperatorTimeoutInRange` uses so a stubbed logger can't turn a rejected override into a
  throw. (Review follow-up `d8359d0b0` — an earlier revision passed `this._log || log` here to
  session-scope it, but `this._log` is built only in `start()`, from a thread id that does not
  exist at construction, so that expression was unconditionally the module logger.)

## Docs (#6968)

`CHROXY_CODEX_RECONNECT_DEADLINE_MS` was documented **nowhere** — it existed only in source.
Added a `### CHROXY_CODEX_RECONNECT_DEADLINE_MS env override` subsection to `docs/providers.md`'s
Codex app-server section, mirroring the format of the sibling `CHROXY_CODEX_SANDBOX` entry: what
the deadline is, the accepted window (`120001`-`1799999` ms), what an out-of-range value does, and
why both ends are exclusive.

Review follow-up `cb0bd097c`: the first revision of that table claimed *anything* out of range logs
a warning. Only the numeric-but-out-of-range path does — `isOperatorTimeoutInRange` rejects
unparseable and non-positive input silently — so `abc` / `5m` / `0` / `-1` fall back with no
diagnostic at all (measured, not inferred). The table now splits those two cases and calls out that
`5m` is not accepted, since this var is plain milliseconds rather than a duration string.

## Verification

**RED first.** The six new tests under `operator override clamping (#6967)` were written and run
against unmodified source — 5 of 6 failed:

```
✖ an opt at or below the 2-min silence watchdog falls back to the default
    AssertionError: 1000ms is not above the watchdog — falls back
    1000 !== 300000
✖ an opt at or above the 30-min result timeout falls back to the default
    actual: 1800000, expected: 300000
✖ CHROXY_CODEX_RECONNECT_DEADLINE_MS below the floor falls back to the default
    AssertionError: a near-instant env deadline is rejected
    1000 !== 300000
✖ CHROXY_CODEX_RECONNECT_DEADLINE_MS above the ceiling falls back to the default
    actual: 7200000, expected: 300000
✖ an out-of-range opt does NOT shadow an in-range env value
    AssertionError: the in-range env value is used
    1000 !== 180000
```

The sixth (`in-range values on both edges of the window are honoured`) passed before the fix by
design — it is the **positive control**, proving the fixture and the `_reconnectDeadlineMs` probe
actually take effect, so the five failures above are real rejections and not a broken harness.
It still passes after.

**Mutation checks** — each bound is independently pinned, one mutation per run:

| Mutation | Result |
|---|---|
| Drop the floor (`candidate < CEILING` only) | 3 RED: the two floor tests + the opt-shadowing test |
| Drop the ceiling (`candidate > FLOOR` only) | 2 RED: the two ceiling tests |

Both mutations reverted; source restored and re-run green.

**After the fix:**

- `tests/codex-app-server-session.test.js` — 106/106 pass
- adjacent files (`providers`, `session-manager-codex-sandbox`, `binary-spawn-backstop`,
  `duration`, + codex-app-server) — 226/226 pass
- `tests/base-session.test.js` — 164/164 pass
- `scripts/lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`,
  `lint-tests-state-file-path.sh`, `lint-ws-index-mutations.sh`,
  `lint-claude-family-explicit.sh` — all OK
- `npx eslint src/codex-app-server-session.js` — clean

## Note on the two touched existing tests

The pre-existing #6856 deadline tests pinned `60_000` / `90_000` / env `'120000'` — all of which
are *now clamped away* to the default. They move to in-window values (`180_000` / `240_000` /
`'180000'`), which keeps them proving the override is what arms the timer instead of silently
asserting the default. Two follow-on assertions moved with them
(`timers.scheduled[0].ms` and the `/reconnect exceeded 180s/` message match).

Closes #6967. Closes #6968.

