### PR TITLE
fix(server): enforce the thinking/response distinct-messageId invariant in the delta buffer

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -1045,15 +1045,25 @@ export class EventNormalizer {
     // oldest token in a flush spent inside the server (coalescing + forwarding)
     // — a true monotonic duration, same process both ends.
     this._deltaEmitMono = new Map()
-    // #6818: key -> true when this buffer key holds THINKING deltas (reasoning
+    // #6818: key -> whether this buffer key holds THINKING deltas (reasoning
     // content) rather than response text. A thinking stream uses a DISTINCT
     // messageId (`<turnId>-thinking-<n>`, see #6756), so it never shares a key
-    // with the response text — this map simply carries the `thinking: true` flag
+    // with the response text — this map carries the `thinking: true` flag
     // alongside the coalesced text so each flushed entry can be reconstructed as
-    // a thinking stream_delta instead of a bare response delta. Only thinking
-    // keys are recorded (response keys stay absent), and it is pruned in every
+    // a thinking stream_delta instead of a bare response delta. Pruned in every
     // flush/clear path in lockstep with _deltaBuffer.
+    // #6962: response keys are recorded too, as `false`, so bufferDelta can tell
+    // "never seen" (undefined) apart from "seen as response" and DETECT a
+    // same-key flag conflict. Every flush site reads `=== true`, so a stored
+    // `false` is indistinguishable from an absent key on the wire — response
+    // entries stay byte-identical to pre-#6818.
     this._deltaThinking = new Map()
+    // #6962: one-shot latch for the key-collision WARN. A provider violating the
+    // distinct-messageId invariant would trip the guard on EVERY delta, so the
+    // WARN is deduped to once per normalizer (one per daemon in production)
+    // rather than tracked per key — a per-key Set would grow unbounded over a
+    // long-lived daemon for no extra signal.
+    this._warnedThinkingKeyCollision = false
     this._deltaFlushTimer = null
     // #5516: monotonic deadline (performance.now ms) the pending flush timer is
     // scheduled to fire at. Lets a later single-client buffer SHORTEN an
@@ -1148,10 +1158,42 @@ export class EventNormalizer {
    *   (extended-thinking) delta. Recorded per key so the flushed entry carries
    *   the `thinking` flag and the caller reconstructs a thinking stream_delta.
    *   Thinking uses a distinct messageId (#6756), so the flag is constant per
-   *   key — first-write-wins, mirroring emitMonoMs.
+   *   key. #6962: that constancy is now ENFORCED here rather than assumed — a
+   *   same-key flag conflict WARNs and splits the frame (see below).
    */
   bufferDelta(sessionId, messageId, delta, emitMonoMs, thinking) {
     const key = sessionId ? `${sessionId}:${messageId}` : messageId
+    // #6962: enforce the distinct-messageId invariant #6818 rests on. Thinking
+    // deltas and response text of the same turn must never share a buffer key —
+    // every provider today builds the thinking messageId as
+    // `<turnId>-thinking-<n>` (#6756), but that is an unenforced CROSS-FILE
+    // convention, exactly the shape of bug the BaseSession opt-forwarding trap
+    // (#4797/#5367) turned out to be. A future provider reusing the bare
+    // response messageId for a thinking delta would otherwise concatenate
+    // reasoning into the answer and ship it under one (necessarily wrong) flag,
+    // silently. So: detect the conflict BEFORE touching any buffer state, WARN
+    // once, and CONTAIN it by force-flushing what is already buffered under its
+    // ORIGINAL flag. The conflicting delta then re-buffers fresh behind it with
+    // its own flag — same order-preserving mechanism the #5555 residency caps
+    // use — so no frame ever mixes reasoning and response text. We warn rather
+    // than throw because bufferDelta runs synchronously under the provider's
+    // event emit; a throw here escapes into that emit and can take the daemon
+    // down over one malformed stream (same reasoning as the onFlush containment
+    // in _flushDeltas).
+    const isThinking = thinking === true
+    const priorThinking = this._deltaThinking.get(key)
+    if (priorThinking !== undefined && priorThinking !== isThinking) {
+      if (!this._warnedThinkingKeyCollision) {
+        this._warnedThinkingKeyCollision = true
+        log.warn(
+          `Delta buffer invariant violation (#6962): key '${key}' received a thinking=${isThinking} delta ` +
+          `after thinking=${priorThinking}. Thinking and response deltas of one turn MUST use distinct ` +
+          `messageIds (\`<turnId>-thinking-<n>\`, #6756). Splitting the frame so the coalesced text is not ` +
+          `corrupted; fix the provider emitting this messageId. Further collisions are not logged.`
+        )
+      }
+      this._forceFlushKey(key)
+    }
     // #5555: coerce a non-string delta to its string form ONCE and use that for
     // both the buffer concat AND the byte count. A bare `existing + delta` would
     // string-coerce a non-string into the buffer (real residency) while a
@@ -1166,10 +1208,12 @@ export class EventNormalizer {
       this._deltaEmitMono.set(key, emitMonoMs)
     }
     // #6818: record the thinking flag once per key (constant per key — thinking
-    // uses a distinct messageId). Only thinking keys are stored; response keys
-    // stay absent so their flushed entries are byte-identical to pre-#6818.
-    if (thinking === true && !this._deltaThinking.has(key)) {
-      this._deltaThinking.set(key, true)
+    // uses a distinct messageId). #6962: response keys are recorded as `false`
+    // instead of left absent so the conflict check above can distinguish them
+    // from an unseen key; every flush site tests `=== true`, so a stored `false`
+    // still produces an entry byte-identical to pre-#6818.
+    if (!this._deltaThinking.has(key)) {
+      this._deltaThinking.set(key, isThinking)
     }
     // #5555: maintain byte-size counters incrementally (UTF-8) — no
     // re-serialization on the hot path. `text` is the only new content, so its

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1573,6 +1573,115 @@ describe('EventNormalizer', () => {
       assert.ok(!('thinking' in second[0]), 'stale thinking flag must not survive the flush')
     })
   })
+
+  // ---- #6962: the distinct-messageId invariant is ENFORCED, not assumed ----
+  //
+  // #6818's correctness rests on thinking deltas never sharing a buffer key with
+  // the response text of the same turn. Today that holds only by convention —
+  // every provider builds the thinking messageId as `<turnId>-thinking-<n>`
+  // (#6756). A future provider that reuses the bare response messageId for a
+  // thinking delta would silently concatenate reasoning into the answer under a
+  // single (wrong) flag. These pin the guard: the conflict is detected, WARNed,
+  // and CONTAINED by splitting the frame so no mixed-flag frame ever ships.
+  describe('thinking/response key-collision guard (#6962)', () => {
+    // Capture logger WARN lines (the logger routes level=warn to console.warn).
+    function withWarnCapture(fn) {
+      const warnings = []
+      const orig = console.warn
+      console.warn = (msg) => { warnings.push(String(msg)) }
+      try {
+        return fn(warnings)
+      } finally {
+        console.warn = orig
+      }
+    }
+
+    it('WARNs when the same key gets a response delta then a thinking delta', () => {
+      withWarnCapture((warnings) => {
+        normalizer.bufferDelta('sess-1', 'm1', 'visible answer', 1000, false)
+        normalizer.bufferDelta('sess-1', 'm1', 'reasoning', 1005, true)
+        const hit = warnings.filter((w) => /thinking/i.test(w) && /sess-1:m1/.test(w))
+        assert.equal(hit.length, 1, `expected exactly one conflict WARN naming the key, got: ${JSON.stringify(warnings)}`)
+        assert.match(hit[0], /#6962|#6818|invariant|messageId/i)
+      })
+    })
+
+    it('WARNs in the reverse direction too (thinking key reused for response text)', () => {
+      withWarnCapture((warnings) => {
+        normalizer.bufferDelta('sess-1', 'm1', 'reasoning', 1000, true)
+        normalizer.bufferDelta('sess-1', 'm1', 'visible answer', 1005, false)
+        const hit = warnings.filter((w) => /thinking/i.test(w) && /sess-1:m1/.test(w))
+        assert.equal(hit.length, 1, `expected exactly one conflict WARN naming the key, got: ${JSON.stringify(warnings)}`)
+      })
+    })
+
+    it('does NOT merge the conflicting halves into one frame — response flushes first, unflagged', () => {
+      const flushed = []
+      normalizer.onFlush = (entries) => { flushed.push(...entries) }
+      withWarnCapture(() => {
+        normalizer.bufferDelta('sess-1', 'm1', 'visible answer', 1000, false)
+        normalizer.bufferDelta('sess-1', 'm1', 'reasoning', 1005, true)
+      })
+      // The already-buffered response half goes out immediately under its own
+      // (absent) flag; the thinking half re-buffers fresh behind it.
+      assert.equal(flushed.length, 1, 'the response half force-flushes on the conflict')
+      assert.equal(flushed[0].delta, 'visible answer', 'response frame must not carry the reasoning text')
+      assert.ok(!('thinking' in flushed[0]), 'response frame must not inherit the thinking flag')
+      const rest = normalizer.flushSession('sess-1')
+      assert.equal(rest.length, 1)
+      assert.equal(rest[0].delta, 'reasoning', 'thinking frame must not carry the answer text')
+      assert.equal(rest[0].thinking, true, 'thinking frame keeps its own flag')
+    })
+
+    it('splits in the reverse direction too (thinking flushes first, flagged)', () => {
+      const flushed = []
+      normalizer.onFlush = (entries) => { flushed.push(...entries) }
+      withWarnCapture(() => {
+        normalizer.bufferDelta('sess-1', 'm1', 'reasoning', 1000, true)
+        normalizer.bufferDelta('sess-1', 'm1', 'visible answer', 1005, false)
+      })
+      assert.equal(flushed.length, 1, 'the thinking half force-flushes on the conflict')
+      assert.equal(flushed[0].delta, 'reasoning')
+      assert.equal(flushed[0].thinking, true)
+      const rest = normalizer.flushSession('sess-1')
+      assert.equal(rest.length, 1)
+      assert.equal(rest[0].delta, 'visible answer')
+      assert.ok(!('thinking' in rest[0]), 'response half must not inherit the stale thinking flag')
+    })
+
+    it('WARNs only once per normalizer even if a violating provider keeps alternating', () => {
+      withWarnCapture((warnings) => {
+        normalizer.bufferDelta('sess-1', 'm1', 'a', 1000, false)
+        normalizer.bufferDelta('sess-1', 'm1', 'b', 1001, true)
+        normalizer.bufferDelta('sess-1', 'm1', 'c', 1002, false)
+        normalizer.bufferDelta('sess-1', 'm1', 'd', 1003, true)
+        const hit = warnings.filter((w) => /thinking/i.test(w) && /sess-1:m1/.test(w))
+        assert.equal(hit.length, 1, 'the WARN is deduped — a long violating stream cannot spam the daemon log')
+      })
+    })
+
+    // Positive control for the negative assertions above: the SAME capture
+    // harness that caught a WARN in the conflict tests must stay silent here,
+    // and the coalescing must be byte-identical to pre-#6962.
+    it('stays silent and unchanged for the (universal) non-conflicting case', () => {
+      withWarnCapture((warnings) => {
+        normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'Let me ', 1000, true)
+        normalizer.bufferDelta('sess-1', 'm1-thinking-0', 'reason', 1005, true)
+        normalizer.bufferDelta('sess-1', 'm1', 'answer ', 1010, false)
+        normalizer.bufferDelta('sess-1', 'm1', 'text', 1015, false)
+        normalizer.bufferDelta('sess-1', 'm2', 'no flag at all', 1020)
+        assert.deepEqual(warnings.filter((w) => /thinking/i.test(w)), [], 'no WARN for the conventional layout')
+        const entries = normalizer.flushSession('sess-1')
+        assert.equal(entries.length, 3, 'no spurious split')
+        assert.equal(entries[0].delta, 'Let me reason')
+        assert.equal(entries[0].thinking, true)
+        assert.equal(entries[1].delta, 'answer text')
+        assert.ok(!('thinking' in entries[1]))
+        assert.equal(entries[2].delta, 'no flag at all')
+        assert.ok(!('thinking' in entries[2]))
+      })
+    })
+  })
 })
 
 // ---- #5516 (epic #5514): adaptive single-client coalescing window ----

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventNormalizer, EVENT_MAP } from '../src/event-normalizer.js'
+import { getLogLevel, setLogLevel } from '../src/logger.js'
 import { ServerSkillChangedSchema, MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 
 // -- Helper to create a standard multi-session context --
@@ -1584,6 +1585,22 @@ describe('EventNormalizer', () => {
   // single (wrong) flag. These pin the guard: the conflict is detected, WARNed,
   // and CONTAINED by splitting the frame so no mixed-flag frame ever ships.
   describe('thinking/response key-collision guard (#6962)', () => {
+    // Pin the log level for this block. `_logLevel` in logger.js is a module
+    // global seeded from `process.env.LOG_LEVEL`, so a runner (or a developer
+    // shell) with LOG_LEVEL=error gates `log.warn` before it ever reaches
+    // console.warn — the three WARN assertions below would go red for a reason
+    // that has nothing to do with the invariant, and worse, the "stays silent"
+    // POSITIVE CONTROL would pass for free because nothing can warn at all.
+    // Same pin as session-manager-unknown-opts.test.js (#6944).
+    let _origLevel
+    beforeEach(() => {
+      _origLevel = getLogLevel()
+      setLogLevel('debug')
+    })
+    afterEach(() => {
+      setLogLevel(_origLevel)
+    })
+
     // Capture logger WARN lines (the logger routes level=warn to console.warn).
     function withWarnCapture(fn) {
       const warnings = []


### PR DESCRIPTION
## The defect

`EventNormalizer`'s delta-coalescing buffer keys on `sessionId:messageId`. Since #6818 it also carries a per-key `thinking` flag through flush, so extended-thinking deltas coalesce like response text. That is only correct because a thinking stream uses a messageId **distinct** from the response text of the same turn (`` `${messageId}-thinking-${idx}` ``, #6756) — the two never share a key.

That distinctness was an unenforced **cross-file convention**, not a runtime invariant. `bufferDelta` recorded the flag exactly once per key:

```js
if (thinking === true && !this._deltaThinking.has(key)) {
  this._deltaThinking.set(key, true)
}
```

`_deltaThinking` never stored anything for response keys, so there was no way to tell "never seen" from "seen as response" — and therefore no conflict path at all. A future provider (Codex app-server thinking support, a new BYOK-style provider) that emitted a `thinking: true` delta under the *same* messageId as its response text would have concatenated reasoning into the answer and shipped the merged text under one, necessarily wrong, flag. Silently.

Same shape as the `BaseSession` opt-forwarding "middle-layer trap" (#4797/#5367): an unenforced assumption about how a provider must behave, invisible until someone notices garbled output in production.

## The fix

- **Detect.** `_deltaThinking` now records response keys as `false` rather than leaving them absent, so `bufferDelta` can distinguish "unseen" (`undefined`) from "seen as response" (`false`) and compare against the incoming flag. Every flush site (`_forceFlushKey`, both `flushSession` branches, `_flushDeltas`) already reads `=== true`, so a stored `false` is indistinguishable from an absent key on the wire — response entries stay byte-identical to pre-#6818.
- **Surface.** A conflict logs one `WARN` naming the key, both flags, and the invariant, latched per normalizer (one per daemon in production) so a violating stream cannot spam the daemon log. A per-key `Set` would grow unbounded over a long-lived daemon for no extra signal.
- **Contain.** The check runs *before* any buffer mutation and force-flushes the already-buffered half under its **original** flag, reusing the order-preserving `_forceFlushKey` path the #5555 residency caps already use. The conflicting delta re-buffers fresh behind it with its own flag, so no frame ever mixes reasoning and response text — the guard prevents the corruption rather than only reporting it after the fact.

WARN rather than throw, deliberately: `bufferDelta` runs synchronously under the provider's event emit, where a throw escapes into that emit and can take the daemon down over one malformed stream — the same reasoning as the existing `onFlush` containment in `_flushDeltas`. Gating a throw on `NODE_ENV === 'test'` was also ruled out: per the #6952 note in `session-manager.js`, nothing in this harness/CI ever sets it, so that safety net never fires.

**No behavior change for the current, universal non-conflicting case.** The only two producers of thinking messageIds (`byok-session.js:1116`, `sdk-session.js:964/1009/1078`) all build `` `${messageId}-thinking-${idx}` ``, and both `bufferDelta` call sites in `ws-forwarding.js` pass a strict `result.thinking === true`.

## Verification

**RED first** — the six new tests against unfixed `main`:

```
# tests 6
# pass 1
# fail 5

✖ WARNs when the same key gets a response delta then a thinking delta
  AssertionError: expected exactly one conflict WARN naming the key, got: []
  0 !== 1
✖ WARNs in the reverse direction too (thinking key reused for response text)
  AssertionError: expected exactly one conflict WARN naming the key, got: []
  0 !== 1
✖ does NOT merge the conflicting halves into one frame — response flushes first, unflagged
  AssertionError: the response half force-flushes on the conflict
  0 !== 1
✖ splits in the reverse direction too (thinking flushes first, flagged)
  AssertionError: the thinking half force-flushes on the conflict
  0 !== 1
✖ WARNs only once per normalizer even if a violating provider keeps alternating
  AssertionError: the WARN is deduped — a long violating stream cannot spam the daemon log
  0 !== 1
```

The one test that passed pre-fix is the deliberate **positive control** ("stays silent and unchanged for the non-conflicting case") — it shares the `console.warn` capture harness with the five failing ones, so its silence is evidence rather than a free pass.

**GREEN after:** `# tests 6 / # pass 6 / # fail 0`.

**Mutation checks** (each applied to the fixed source, then reverted):

| Mutation | Expected | Result |
|---|---|---|
| Drop only the `_forceFlushKey(key)` containment call, keep the WARN | the two split tests go red, WARN tests stay green | 4 pass / 2 fail — exactly the two split tests |
| Revert flag recording to `if (isThinking && !has(key))` (thinking-only, i.e. the pre-fix behaviour) | the response→thinking direction becomes undetectable | 4 pass / 2 fail — the response-first WARN + split tests. The reverse direction still fires there, since `_deltaThinking.get(key)` is `true` — confirming the `false` recording is precisely what catches the response-first case |

**Suites:**
- `packages/server/tests/event-normalizer.test.js` — 165/165 pass (159 pre-existing + 6 new)
- `packages/server/tests/ws-forwarding.test.js` — 68/68 pass (covers the two `bufferDelta` call sites)

**Lints** — all five custom "CI Server Lint" shell scripts, plus eslint:
`lint-tests-state-file-path.sh` OK · `lint-session-opt-forwarding.sh` OK · `lint-logger-session-scoping.sh` OK · `lint-ws-index-mutations.sh` OK · `lint-claude-family-explicit.sh` OK · `eslint src/event-normalizer.js` clean.

`assert-test-count.mjs` uses a lower-bound floor (9700), so six added tests need no count bump.

Closes #6962


---

## Review follow-up (b183bde03)

Copilot flagged that the six new tests assert on `log.warn` reaching `console.warn` without pinning the logger level. Reproduced rather than assumed:

- `LOG_LEVEL=error` + fixed source → **3 pass / 3 fail** — `_logLevel` in `logger.js` is a module global seeded from `process.env.LOG_LEVEL`, so `log.warn` is gated before it reaches the console.
- Worse, in that environment the `stays silent for the non-conflicting case` test — which exists as the **positive control** for the negative assertions — passes for free, because nothing can warn at all. A control that cannot fail is not a control.

Fixed by pinning the level for the block (`getLogLevel()` / `setLogLevel('debug')` in `beforeEach`, restored in `afterEach`), matching `session-manager-unknown-opts.test.js` (#6944).

Post-fix verification:

| Run | Result |
|---|---|
| `LOG_LEVEL=error`, fixed source | 6 pass / 0 fail (was 3/3) |
| `LOG_LEVEL=error`, source reverted to `main` | 5 fail / 1 pass — red-first evidence survives the pin |
| default env, whole file | 165 / 165 |

### Independent review verification

- **RED-first re-confirmed from scratch**: `git checkout dfe71c88b -- packages/server/src/event-normalizer.js` with the PR's tests → `# tests 6 / # pass 1 / # fail 5`. The one pass is the positive control.
- **Containment mutation**: deleting only the `this._forceFlushKey(key)` call while keeping the WARN → `# pass 4 / # fail 2`, and exactly the two split tests fail. The containment half is genuinely pinned, not just the logging half.
- **`_deltaThinking` reader roster enumerated** — all four sites (`_forceFlushKey`, both `flushSession` branches, `_flushDeltas`) test `=== true`, so a stored `false` is wire-indistinguishable from an absent key. All six prune sites stay in lockstep with `_deltaBuffer`; a normal flush leaves the map empty (probed).
- **Edge cases probed** beyond the suite: legacy mode (`sessionId === null`) splits correctly; a conflict on one key does not disturb other buffered keys; `_deltaTotalBytes` / `_deltaKeyBytes` accounting is exact after the split; no stale-flag leak.
- Both production `bufferDelta` call sites (`ws-forwarding.js:233`, `:393`) pass a strict `result.thinking === true`, so neither can produce a spurious conflict.
