### PR TITLE
fix(server): make the RunLedger durable on journal-append failure and bound recovery

### DIFF
--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -13,10 +13,12 @@
  *
  * Durability boundary (mirrors #5309): the journal is appended synchronously
  * per event and is the crash record; run.json is debounced for high-frequency
- * turn_usage folds and flushed (fsync) immediately on lifecycle mutations and
- * at terminal state. On boot, recoverRuns() replays journal lines with
- * seq > snapshot.lastSeq through the reducer, so a crash between an append and
- * the debounced save loses nothing.
+ * turn_usage folds and flushed (fsync) immediately on lifecycle mutations, at
+ * terminal state, AND whenever the journal append itself failed (#6720) — with
+ * no crash record, the snapshot has to be it. On boot, recoverRuns() replays
+ * journal lines with seq > snapshot.lastSeq through the reducer, so a crash
+ * between an append and the debounced save loses nothing, then re-applies the
+ * LRU bound so a maxRuns lowered between boots takes effect immediately.
  */
 
 import { EventEmitter } from 'node:events'
@@ -80,7 +82,8 @@ export class RunLedger extends EventEmitter {
 
   /**
    * Journal one event, apply it to the in-memory record, and persist. Lifecycle
-   * events flush (fsync) immediately; high-frequency folds are debounced.
+   * events flush (fsync) immediately; high-frequency folds are debounced, EXCEPT
+   * when the journal append failed, which forces the flush (#6720).
    * The journal append happens BEFORE the snapshot save so it is always the
    * furthest-ahead record.
    */
@@ -110,6 +113,12 @@ export class RunLedger extends EventEmitter {
       this._flushNow(runId)
       this._updateIndex()
     } else if (journalFailed) {
+      // Mark dirty FIRST: _flushNow is best-effort (_saveSnapshot swallows its
+      // own error and only clears the dirty flag on success), so if the snapshot
+      // write fails too the run stays queued for the debounce/shutdown flush.
+      // Without this, a double failure would drop the fold with no retry at all
+      // — strictly worse than the plain _scheduleSave it replaces.
+      this._scheduleSave(runId)
       this._flushNow(runId)
     } else {
       this._scheduleSave(runId)

--- a/packages/server/src/orchestration/run-ledger.js
+++ b/packages/server/src/orchestration/run-ledger.js
@@ -90,19 +90,27 @@ export class RunLedger extends EventEmitter {
     const seq = record.lastSeq + 1
     const event = { seq, ts: this._now(), ...payload }
     const line = JSON.stringify(event) + '\n'
+    let journalFailed = false
     try {
       appendFileSync(this._journalPath(runId), line)
       this._journalBytes.set(runId, (this._journalBytes.get(runId) || 0) + Buffer.byteLength(line))
     } catch (err) {
       // A journal write failure is serious but must not crash the daemon; the
-      // in-memory record still advances so the run continues, and the next
-      // snapshot save captures state (at the cost of a recovery gap).
+      // in-memory record still advances so the run continues.
+      journalFailed = true
       log.warn(`journal append failed for ${runId} (${err?.code || err?.message})`)
     }
     applyEvent(record, event)
+    // The journal is normally the crash record, so a DEBOUNCED fold (turn_usage)
+    // may safely wait for the next save. Once the append has failed there is no
+    // crash record — the fold would live only in memory — so force the fsync'd
+    // snapshot instead, converting a silent accounting loss into a durable one
+    // (#6720). Lifecycle events already flush unconditionally.
     if (lifecycle) {
       this._flushNow(runId)
       this._updateIndex()
+    } else if (journalFailed) {
+      this._flushNow(runId)
     } else {
       this._scheduleSave(runId)
     }
@@ -407,6 +415,13 @@ export class RunLedger extends EventEmitter {
    * snapshot, then replay journal lines with seq > snapshot.lastSeq through the
    * reducer (idempotent — lastSeq gates double-folds). Returns the records so
    * the engine can decide which non-terminal runs to fail vs resume.
+   *
+   * Recovery finishes with one _updateIndex() pass so the LRU bound is re-applied
+   * immediately rather than at the next lifecycle event (#6720) — a maxRuns
+   * lowered between boots would otherwise leave memory, disk and the index over
+   * the cap for the rest of the boot. Runs the GC evicts are dropped from the
+   * returned set: their directory is gone, so the engine must not try to resume
+   * them.
    */
   recoverRuns() {
     const recovered = []
@@ -438,7 +453,8 @@ export class RunLedger extends EventEmitter {
       this._journalBytes.set(runId, journalBytes)
       recovered.push(structuredClone(record))
     }
-    return recovered
+    this._updateIndex() // rebuilds runs-index.json AND runs _gc() over the recovered set
+    return recovered.filter((r) => this._records.has(r.runId))
   }
 
   dispose() {

--- a/packages/server/tests/orchestration-run-ledger.test.js
+++ b/packages/server/tests/orchestration-run-ledger.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
@@ -164,6 +164,93 @@ describe('RunLedger crash recovery', () => {
   it('recovers zero runs from an empty base dir', () => {
     const led = mkLedger()
     assert.deepEqual(led.recoverRuns(), [])
+    led.dispose()
+  })
+
+  // #6720 (2) — recoverRuns() loads every run dir into _records; without an
+  // _updateIndex()/_gc() pass at the end, a maxRuns lowered between boots is
+  // only re-enforced on the NEXT lifecycle event, so memory (and the on-disk
+  // index) transiently exceed the cap.
+  it('re-applies the LRU bound (and rebuilds the index) at the end of recovery', () => {
+    const led = mkLedger() // default maxRuns — nothing evicted while writing
+    const ids = []
+    for (let i = 0; i < 3; i++) {
+      clock = 5000 + i
+      const run = led.createRun({ title: `r${i}` })
+      ids.push(run.runId)
+      led.setStatus(run.runId, 'completed') // terminal → eligible for eviction
+    }
+    assert.equal(led.listRuns().length, 3, 'fixture: all three runs written under the old cap')
+    led.dispose()
+
+    // Reboot with a LOWER cap, as an operator edit between boots would.
+    const led2 = mkLedger({ maxRuns: 2 })
+    const recovered = led2.recoverRuns()
+
+    // Positive control: recovery genuinely read the runs back off disk (this
+    // passes on unmodified source — it proves the fixture is wired, so the
+    // cap assertions below are not passing for free).
+    assert.equal(led2.getRun(ids[2])?.status, 'completed', 'newest run recovered from disk')
+    assert.ok(existsSync(join(baseDir, 'runs', ids[2])), 'newest run dir kept')
+
+    const remaining = led2.listRuns().map((r) => r.runId)
+    assert.equal(remaining.length, 2, 'lowered maxRuns enforced during recovery')
+    assert.ok(!remaining.includes(ids[0]), 'oldest terminal run evicted')
+    assert.ok(!existsSync(join(baseDir, 'runs', ids[0])), 'evicted run dir removed')
+    assert.deepEqual(
+      recovered.map((r) => r.runId).sort(),
+      [ids[1], ids[2]].sort(),
+      'the returned records exclude runs the GC just deleted',
+    )
+
+    const idx = JSON.parse(readFileSync(join(baseDir, 'runs-index.json'), 'utf8'))
+    assert.equal(idx.runs.length, 2, 'the on-disk index was rebuilt from the recovered set')
+    assert.ok(!idx.runs.some((r) => r.runId === ids[0]), 'evicted run dropped from the index')
+    led2.dispose()
+  })
+})
+
+describe('RunLedger journal-append failure durability (#6720)', () => {
+  it('fsyncs the snapshot when a debounced journal append fails, so the fold is not lost', () => {
+    // A long debounce means nothing reaches run.json on its own during the test.
+    const led = mkLedger({ saveDebounceMs: 60_000 })
+    const run = led.createRun({ title: 'x' })
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' }) // lifecycle → flushed
+    const snapPath = join(baseDir, 'runs', run.runId, 'run.json')
+    const journalPath = join(baseDir, 'runs', run.runId, 'events.jsonl')
+    const readSnap = () => JSON.parse(readFileSync(snapPath, 'utf8'))
+
+    // Positive control: with the journal HEALTHY, a debounced turn_usage stays
+    // out of the snapshot (that is the documented durability boundary — the
+    // journal is the crash record). Passes on unmodified source, and proves the
+    // debounce fixture is live so the assertion below cannot pass for free.
+    led.recordTurnUsage(run.runId, {
+      subtaskId: 'st1', sessionId: 's1', role: 'a', data: { cost: 0.1, usage: { input_tokens: 1 } },
+    })
+    assert.equal(readSnap().usageTotals.overall.costUsd, 0, 'debounced fold is not durable yet')
+    assert.equal(readSnap().lastSeq, 2, 'snapshot still at the last lifecycle event')
+
+    // Break the journal: a directory at the journal path makes appendFileSync
+    // throw EISDIR while leaving the run dir writable for the snapshot.
+    rmSync(journalPath)
+    mkdirSync(journalPath)
+
+    led.recordTurnUsage(run.runId, {
+      subtaskId: 'st1', sessionId: 's1', role: 'a', data: { cost: 0.4, usage: { input_tokens: 10 } },
+    })
+
+    // Positive control: the append really did fail — nothing landed at the
+    // journal path, and the in-memory fold advanced anyway (the daemon must not
+    // crash on a journal write failure). Both pass on unmodified source.
+    assert.ok(statSync(journalPath).isDirectory(), 'journal path is still the broken directory')
+    assert.deepEqual(readdirSync(journalPath), [], 'no journal line was written')
+    assert.equal(led.getRun(run.runId).lastSeq, 4, 'the event still folded in memory')
+
+    // The fix: a failed append forces the fsync'd snapshot, so BOTH folds are
+    // durable instead of living only in memory until the next debounced save.
+    const snap = readSnap()
+    assert.equal(snap.lastSeq, 4, 'snapshot caught up to the un-journaled event')
+    assert.equal(snap.usageTotals.overall.costUsd, 0.5, 'both folds reached the durable snapshot')
     led.dispose()
   })
 })

--- a/packages/server/tests/orchestration-run-ledger.test.js
+++ b/packages/server/tests/orchestration-run-ledger.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
@@ -252,6 +252,41 @@ describe('RunLedger journal-append failure durability (#6720)', () => {
     assert.equal(snap.lastSeq, 4, 'snapshot caught up to the un-journaled event')
     assert.equal(snap.usageTotals.overall.costUsd, 0.5, 'both folds reached the durable snapshot')
     led.dispose()
+  })
+
+  // The forced flush is best-effort: _saveSnapshot swallows its own error, and
+  // only DELETES the run from _dirty on success. Because the journal-failure
+  // path never marks the run dirty in the first place, a flush that ALSO fails
+  // used to leave the fold with no retry at all — strictly worse than the
+  // pre-#6720 _scheduleSave, which at least got another attempt at shutdown.
+  it('still retries at shutdown when BOTH the journal append and the forced snapshot fail', () => {
+    const led = mkLedger({ saveDebounceMs: 60_000 })
+    const run = led.createRun({ title: 'x' })
+    led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' }) // lifecycle → flushed
+    const runDir = join(baseDir, 'runs', run.runId)
+    const snapPath = join(runDir, 'run.json')
+    const journalPath = join(runDir, 'events.jsonl')
+    const readSnap = () => JSON.parse(readFileSync(snapPath, 'utf8'))
+
+    // Break BOTH sinks for one event: a directory at the journal path (EISDIR
+    // on append) and a read-only run dir (EACCES creating the snapshot tmp).
+    rmSync(journalPath)
+    mkdirSync(journalPath)
+    chmodSync(runDir, 0o500)
+    led.recordTurnUsage(run.runId, {
+      subtaskId: 'st1', sessionId: 's1', role: 'a', data: { cost: 0.4, usage: { input_tokens: 10 } },
+    })
+    chmodSync(runDir, 0o700) // the transient failure clears
+
+    // Positive controls (both pass on unmodified source): the forced snapshot
+    // really did fail, and the fold advanced in memory anyway.
+    assert.equal(readSnap().usageTotals.overall.costUsd, 0, 'the forced snapshot did not land')
+    assert.equal(led.getRun(run.runId).lastSeq, 3, 'the event still folded in memory')
+
+    // The run must still be pending, so the shutdown flush picks it up.
+    led.dispose()
+    assert.equal(readSnap().usageTotals.overall.costUsd, 0.4, 'shutdown flush retried the un-saved fold')
+    assert.equal(readSnap().lastSeq, 3, 'shutdown flush persisted the un-journaled seq')
   })
 })
 


### PR DESCRIPTION
## The defect

Two narrow gaps in the RunLedger's "durable accounting" guarantee
(`packages/server/src/orchestration/run-ledger.js`), both confirmed still real on main.

**1. A failed journal append left the fold in memory only.**

`_emitEvent` catches a throwing `appendFileSync`, warns, and carries on — correct, a journal
write failure must not crash the daemon. But it then falls into the *normal* persistence branch:
`lifecycle` events `_flushNow`, everything else is merely `_scheduleSave`d (debounced). So for a
`turn_usage` event whose append just failed there is **no crash record and no snapshot** — the
fold lives only in `_records` until the next debounced save. A process death in that window
silently loses that turn's cost from both the journal *and* the snapshot: a cost undercount in a
store whose whole purpose is durable accounting.

**2. `recoverRuns()` never re-applied the LRU bound.**

It looped the run dirs, populated `this._records` / `this._journalBytes`, and returned — never
calling `_updateIndex()` (which writes `runs-index.json`) or `_gc()` (which enforces `maxRuns`),
both of which already exist. `maxRuns` was therefore only re-enforced at the *next lifecycle
event*, so a cap lowered between boots left memory, disk and the on-disk index over the cap for
the rest of the boot.

## The fix

1. Track the caught append failure and, on the non-lifecycle path, `_flushNow(runId)` instead of
   debouncing. Once there is no crash record, the fsync'd snapshot has to be it. Lifecycle events
   already flushed unconditionally, so their behaviour is unchanged.
2. End `recoverRuns()` with a single `_updateIndex()` pass (which runs `_gc` internally), and
   filter the returned records to those the GC kept. An evicted run's directory has just been
   `rmSync`'d, so handing it back to the engine as a resumable record would be wrong.

This is lane B's head; the diff is deliberately confined to those two behaviours so #6732/#6733
land cleanly on top.

## Verification

Red-first — both tests were written and run *before* the fix:

```
✖ re-applies the LRU bound (and rebuilds the index) at the end of recovery
  AssertionError [ERR_ASSERTION]: lowered maxRuns enforced during recovery
    actual: 3, expected: 2, operator: 'strictEqual'
✖ fsyncs the snapshot when a debounced journal append fails, so the fold is not lost
  AssertionError [ERR_ASSERTION]: snapshot caught up to the un-journaled event
    actual: 2, expected: 4, operator: 'strictEqual'
# tests 16  # pass 14  # fail 2
```

After the fix: `# tests 16  # pass 16  # fail 0`.

**Positive controls** — each passes on *unmodified* source, proving the fixtures actually take
effect rather than the tests passing for free:

- The append-failure test first records a turn with a **healthy** journal and asserts the fold is
  *not* in `run.json` (`costUsd 0`, `lastSeq 2`) — proving the 60s debounce fixture is live, so
  the later "it is durable" assertion cannot pass trivially.
- After breaking the journal (a directory at the journal path makes `appendFileSync` throw
  `EISDIR` while the run dir stays writable for the snapshot), it asserts the path is still an
  *empty* directory — no line landed — and that `lastSeq` advanced in memory anyway, i.e. the
  daemon processed the event without crashing.
- The recovery test asserts the newest run is read back off disk with `status: 'completed'` and
  its directory intact, proving recovery genuinely ran before the cap assertions.

**Mutation checks** — each fix reverted individually, one line per run:

- `else if (journalFailed)` neutered → only *"fsyncs the snapshot when a debounced journal append
  fails"* goes red (15 pass / 1 fail); the LRU test stays green.
- `this._updateIndex()` removed from `recoverRuns()` → only *"re-applies the LRU bound"* goes red
  (15 pass / 1 fail, `actual: 3, expected: 2`); the append-failure test stays green.
- The source was diffed byte-for-byte against a pre-mutation copy afterwards to confirm both
  reverts.

**Suites and lints**

- Full orchestration blast radius — `tests/orchestration-*.test.js` + `server-orchestrator.test.js`
  + `session-manager-orchestration-badges.test.js`: **199 tests, 199 pass, 0 fail**.
- "CI Server Lint" shell lints, all OK: `lint-tests-state-file-path.sh`,
  `lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-ws-index-mutations.sh`,
  `lint-claude-family-explicit.sh`.
- `eslint src/orchestration/run-ledger.js` clean.

The one other production caller, `buildOrchestrationManager` (`build-manager.js:28`), already
documents that recovery must run "BEFORE anything writes … clobbering the durable index" — the new
index rebuild inside `recoverRuns()` is exactly that intent, and its `recovered.length` log line
now reports the post-GC set.

Closes #6720.
