### PR TITLE
fix(server): stop dropping cache tokens on the legacy codex exec path

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -9,6 +9,7 @@ import {
   getRatchetCap,
   maybeRatchetContextWindow,
 } from './utils/context-window-learn.js'
+import { nonNegInt } from './usage-normalize.js'
 import { BILLING_CLASSES } from './billing-class.js'
 import { hasCodexOAuthCreds } from './auth-probes.js'
 import {
@@ -36,6 +37,10 @@ import {
  *   tool_start   { messageId, toolUseId, tool, input }
  *   tool_result  { toolUseId, result }
  *   result       { cost, duration, usage, sessionId }
+ *                usage is the DISJOINT split (#6718): the wire's
+ *                `cached_input_tokens` is a subset of `input_tokens`, so it is
+ *                re-emitted as `cache_read_input_tokens` with input reduced by
+ *                that amount. See _mapUsage().
  *   error        { message }
  */
 
@@ -614,8 +619,12 @@ export class CodexSession extends JsonlSubprocessSession {
           ctx.didStreamStart = false
         }
         const usage = event.usage || {}
-        const inputTokens = usage.input_tokens || 0
-        const outputTokens = usage.output_tokens || 0
+        // #6718: the ratchet below keys off the INCLUSIVE prompt size — codex
+        // reports `input_tokens` as the whole prompt with `cached_input_tokens`
+        // as a SUBSET of it, and a cache-heavy turn still occupies that much
+        // context window. The emitted usage uses the DISJOINT split instead
+        // (see _mapUsage); the two must not be conflated.
+        const inputTokens = nonNegInt(usage.input_tokens)
         // #3857 learn-loop: when Codex reports an `input_tokens` value that
         // exceeds the registered context window for the active model, the
         // static window is stale (this is exactly how we found the original
@@ -636,10 +645,7 @@ export class CodexSession extends JsonlSubprocessSession {
         this.emit('result', {
           cost: null,
           duration: null,
-          usage: {
-            input_tokens: inputTokens,
-            output_tokens: outputTokens,
-          },
+          usage: this._mapUsage(usage),
           sessionId: this.resumeSessionId,
         })
         break
@@ -647,6 +653,50 @@ export class CodexSession extends JsonlSubprocessSession {
 
       default:
         break
+    }
+  }
+
+  /**
+   * #6718 — map a `turn.completed` usage payload onto chroxy's accounting keys.
+   *
+   * Codex reports cached tokens as a SUBSET of `input_tokens` (OpenAI's
+   * `prompt_tokens_details` convention; corroborated in-repo by the context
+   * ratchet above, which treats `input_tokens` as the full prompt). Chroxy's
+   * accumulator keys are ADDITIVE (Anthropic shape: input EXCLUDES cache
+   * reads), so split into uncached input + cache_read. The subtraction is
+   * clamped, so a future codex build that switched to additive reporting would
+   * undercount input rather than go negative.
+   *
+   * Before this fix the exec path emitted only `input_tokens`/`output_tokens`
+   * and dropped the cached count entirely — session-manager `_trackUsage`
+   * reads `cache_read_input_tokens`, so codex-exec cache tokens never reached
+   * `cumulativeUsage`. The app-server path got the same fix in #6717/#6692;
+   * this is the deliberate mirror of `CodexAppServerSession._mapUsage`, and
+   * the two splits must stay identical — a divergent split between the default
+   * and the `CHROXY_CODEX_APPSERVER=0` opt-out is worse than no split at all.
+   *
+   * Extracted as a method (rather than inlined) so the mapping is directly
+   * unit-testable without spawning a subprocess — the reason #6717 could not
+   * safely fix this path (the old shim harness reimplemented the parse loop).
+   *
+   * @param {object} usage  raw `turn.completed` usage object (may be empty)
+   * @returns {{input_tokens:number,output_tokens:number,cache_read_input_tokens:number,cached_input_tokens:number}}
+   */
+  _mapUsage(usage) {
+    const u = usage || {}
+    // Snake_case is the `codex exec --json` wire shape; camelCase is accepted
+    // as a fallback purely so this stays interchangeable with the app-server
+    // `_mapUsage`, whose JSON-RPC wire is camel.
+    const rawInput = nonNegInt(u.input_tokens ?? u.inputTokens)
+    const cached = nonNegInt(u.cached_input_tokens ?? u.cachedInputTokens)
+    return {
+      input_tokens: nonNegInt(rawInput - cached),
+      output_tokens: nonNegInt(u.output_tokens ?? u.outputTokens),
+      cache_read_input_tokens: cached,
+      // Deprecated duplicate of cache_read_input_tokens — mirrors the
+      // app-server payload for one release so any external reader of the raw
+      // result sees the same shape on both codex paths (#6692).
+      cached_input_tokens: cached,
     }
   }
 }

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -685,13 +685,18 @@ export class CodexSession extends JsonlSubprocessSession {
   _mapUsage(usage) {
     const u = usage || {}
     // Snake_case is the `codex exec --json` wire shape; camelCase is accepted
-    // as a fallback purely so this stays interchangeable with the app-server
-    // `_mapUsage`, whose JSON-RPC wire is camel.
-    const rawInput = nonNegInt(u.input_tokens ?? u.inputTokens)
-    const cached = nonNegInt(u.cached_input_tokens ?? u.cachedInputTokens)
+    // purely so this stays interchangeable with the app-server `_mapUsage`,
+    // whose JSON-RPC wire is camel. Key PRECEDENCE is deliberately identical
+    // to the app-server mirror (camel first) rather than "native wire first":
+    // both orders behave the same on either real wire (the other casing is
+    // absent), but a payload carrying BOTH casings would otherwise be split
+    // differently by the two codex drivers — the exact divergence the
+    // "must stay identical" rule above exists to prevent.
+    const rawInput = nonNegInt(u.inputTokens ?? u.input_tokens)
+    const cached = nonNegInt(u.cachedInputTokens ?? u.cached_input_tokens)
     return {
       input_tokens: nonNegInt(rawInput - cached),
-      output_tokens: nonNegInt(u.output_tokens ?? u.outputTokens),
+      output_tokens: nonNegInt(u.outputTokens ?? u.output_tokens),
       cache_read_input_tokens: cached,
       // Deprecated duplicate of cache_read_input_tokens — mirrors the
       // app-server payload for one release so any external reader of the raw

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -98,11 +98,15 @@ class ShimmedCodexSession extends CodexSession {
 
     this._process = proc
     // Same mutable per-turn context JsonlSubprocessSession.sendMessage() passes
-    // to _processJsonlLine() / _emitFallbackResult().
+    // to _processJsonlLine() / _emitFallbackResult() — including `proc`, which
+    // the base exposes "for rare edge cases". No codex handler reads it today,
+    // but omitting it is exactly the kind of harness/production drift this
+    // block was rewritten to eliminate.
     const ctx = {
       messageId: this._currentMessageId,
       didStreamStart: false,
       didEmitResult: false,
+      proc,
     }
 
     const rl = createInterface({ input: proc.stdout })
@@ -1856,6 +1860,27 @@ describe('CodexSession', () => {
         cache_read_input_tokens: 0,
         cached_input_tokens: 0,
       })
+    })
+
+    // Review (#7128): both codex `_mapUsage` implementations accept snake_case
+    // AND camelCase, and each real wire carries only one casing — so precedence
+    // is unobservable in production and free to drift. It must still be pinned:
+    // a payload carrying BOTH casings has to split identically on both drivers,
+    // or the "must stay identical" invariant is only true by luck. The
+    // app-server mirror reads camel first, so this one does too.
+    it('_mapUsage prefers camelCase over snake_case, matching the app-server mirror', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const mapped = session._mapUsage({
+        inputTokens: 1000, input_tokens: 10,
+        outputTokens: 42, output_tokens: 7,
+        cachedInputTokens: 600, cached_input_tokens: 2,
+      })
+      assert.deepEqual(mapped, {
+        input_tokens: 400,
+        output_tokens: 42,
+        cache_read_input_tokens: 600,
+        cached_input_tokens: 600,
+      }, 'a both-casings payload must split the same on codex-exec as on codex app-server')
     })
 
     it('the REAL turn.completed handler emits cache_read_input_tokens with a disjoint input split', () => {

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -59,8 +59,19 @@ function cleanupShim() {
 
 /**
  * Subclass of CodexSession that uses a shim binary instead of the real
- * `codex` CLI.  It mirrors the sendMessage() logic exactly so that the full
- * readline → event pipeline is exercised without needing the real binary.
+ * `codex` CLI, so the full spawn → readline → event pipeline is exercised
+ * without needing the real binary.
+ *
+ * #6718: `sendMessage()` here used to REIMPLEMENT the per-line switch inline —
+ * a hand-copied clone of `CodexSession._processJsonlLine()`. That made every
+ * test in this block assert against the copy, not against production: the copy
+ * silently drifted (it emitted `sessionId: null` where the real handler emits
+ * the captured thread id, and it never ran the context-window ratchet), and it
+ * is the documented reason #6717 could not safely land the codex-exec
+ * cache-token fix. The spawn/lifecycle scaffolding below is still local
+ * (that is the point of the harness), but EVERY parsed line is now handed to
+ * the REAL `_processJsonlLine()` with the same mutable `ctx` shape
+ * `JsonlSubprocessSession.sendMessage()` builds. Do not reintroduce a copy.
  */
 class ShimmedCodexSession extends CodexSession {
   constructor(opts, shimBin) {
@@ -86,63 +97,21 @@ class ShimmedCodexSession extends CodexSession {
     })
 
     this._process = proc
-    let didStreamStart = false
-    let didEmitResult = false
+    // Same mutable per-turn context JsonlSubprocessSession.sendMessage() passes
+    // to _processJsonlLine() / _emitFallbackResult().
+    const ctx = {
+      messageId: this._currentMessageId,
+      didStreamStart: false,
+      didEmitResult: false,
+    }
 
     const rl = createInterface({ input: proc.stdout })
 
     rl.on('line', (line) => {
       if (this._destroying) return
       const event = this._parseJsonLine(line)
-      if (!event || !event.type) return
-
-      switch (event.type) {
-        case 'item.completed': {
-          const item = event.item
-          if (!item) break
-          if (item.type === 'agent_message' && item.text) {
-            if (!didStreamStart) {
-              this.emit('stream_start', { messageId: this._currentMessageId })
-              didStreamStart = true
-            }
-            this.emit('stream_delta', { messageId: this._currentMessageId, delta: item.text })
-          } else if (item.type === 'tool_call') {
-            const toolMessageId = `codex-tool-${++this._messageCounter}`
-            this.emit('tool_start', {
-              messageId: toolMessageId,
-              toolUseId: item.id || toolMessageId,
-              tool: item.name || 'unknown',
-              input: item.arguments || item.input || {},
-            })
-          } else if (item.type === 'tool_output') {
-            this.emit('tool_result', {
-              toolUseId: item.call_id || item.id || `codex-tool-${this._messageCounter}`,
-              result: item.output || item.text || '',
-            })
-          }
-          break
-        }
-        case 'turn.completed': {
-          didEmitResult = true
-          if (didStreamStart) {
-            this.emit('stream_end', { messageId: this._currentMessageId })
-            didStreamStart = false
-          }
-          const usage = event.usage || {}
-          this.emit('result', {
-            cost: null,
-            duration: null,
-            usage: {
-              input_tokens: usage.input_tokens || 0,
-              output_tokens: usage.output_tokens || 0,
-            },
-            sessionId: null,
-          })
-          break
-        }
-        default:
-          break
-      }
+      if (!event) return
+      this._processJsonlLine(event, ctx)
     })
 
     proc.stderr.on('data', () => {})
@@ -151,13 +120,13 @@ class ShimmedCodexSession extends CodexSession {
       this._process = null
       this._isBusy = false
       if (this._destroying) return
-      if (didStreamStart) {
-        this.emit('stream_end', { messageId: this._currentMessageId })
+      if (ctx.didStreamStart) {
+        this.emit('stream_end', { messageId: ctx.messageId })
       }
       if (code !== 0 && code !== null) {
         this.emit('error', { message: `Codex process exited with code ${code}` })
       }
-      if (!didEmitResult) {
+      if (!ctx.didEmitResult) {
         this.emit('result', { cost: null, duration: null, usage: null, sessionId: null })
       }
     })
@@ -1475,6 +1444,31 @@ describe('CodexSession', () => {
       assert.equal(result.usage.output_tokens, 4)
     })
 
+    // #6718 — the same disjoint split the direct-handler tests pin, but proved
+    // through the REAL spawn → readline → _processJsonlLine pipeline, so a
+    // future refactor that reroutes stdout parsing can't silently drop cache
+    // tokens again.
+    it('#6718: cache tokens survive the full spawn pipeline as cache_read_input_tokens', async () => {
+      writeBaseShimJsonl([
+        { type: 'turn.completed', usage: { input_tokens: 1000, output_tokens: 42, cached_input_tokens: 600 } },
+      ])
+
+      const session = makeSession()
+      session._processReady = true
+      const results = []
+      session.on('result', (d) => results.push(d))
+
+      await session.sendMessage('hello')
+      await waitFor(() => results.length >= 1, { label: 'result event' })
+
+      // positive control — passes on unmodified source: the shim's usage
+      // payload really did reach the handler through the spawn pipeline.
+      assert.equal(results[0].usage.output_tokens, 42)
+      // the #6718 regression
+      assert.equal(results[0].usage.cache_read_input_tokens, 600)
+      assert.equal(results[0].usage.input_tokens, 400)
+    })
+
     it('abort mid-stream: interrupt() kills the subprocess and clears busy', async () => {
       // Long-lived shim — emits one chunk then sleeps so we have time to interrupt.
       writeBaseShim([
@@ -1813,5 +1807,164 @@ describe('CodexSession', () => {
         assert.equal(emitted.length, 0)
       })
     }
+  })
+
+  // ---------------------------------------------------------------------------
+  // #6718 — cache-token accounting on the LEGACY `codex exec` path
+  // (CHROXY_CODEX_APPSERVER=0). The app-server path got this in #6717/#6692;
+  // this path emitted only `input_tokens`/`output_tokens` and dropped the
+  // cached count entirely, so codex-exec cache tokens never reached
+  // `cumulativeUsage` (session-manager `_trackUsage` reads only
+  // `cache_read_input_tokens`).
+  //
+  // Every test here drives the REAL `CodexSession._processJsonlLine()` — NOT
+  // the `ShimmedCodexSession` copy of the parse loop above. A test through a
+  // reimplemented handler proves nothing about production (that is precisely
+  // why #6717 left this path unfixed).
+  // ---------------------------------------------------------------------------
+  describe('#6718 turn.completed usage mapping (legacy codex exec)', () => {
+    function freshCtx() {
+      return { messageId: 'codex-msg-x-1', didStreamStart: false, didEmitResult: false }
+    }
+
+    it('_mapUsage splits subset-cached input into uncached input + cache_read', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      assert.deepEqual(
+        session._mapUsage({ input_tokens: 1000, output_tokens: 42, cached_input_tokens: 600 }),
+        {
+          input_tokens: 400,
+          output_tokens: 42,
+          cache_read_input_tokens: 600,
+          cached_input_tokens: 600, // deprecated duplicate, one release (#6692)
+        },
+        'must match the app-server _mapUsage split exactly — a divergent split is worse than none',
+      )
+    })
+
+    it('_mapUsage clamps instead of going negative when cached exceeds input', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      const mapped = session._mapUsage({ input_tokens: 100, output_tokens: 1, cached_input_tokens: 600 })
+      assert.equal(mapped.input_tokens, 0, 'a future additive-reporting codex undercounts, never goes negative')
+      assert.equal(mapped.cache_read_input_tokens, 600)
+    })
+
+    it('_mapUsage zero-fills a usage-less turn (unchanged pre-#6718 behavior)', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      assert.deepEqual(session._mapUsage({}), {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cached_input_tokens: 0,
+      })
+    })
+
+    it('the REAL turn.completed handler emits cache_read_input_tokens with a disjoint input split', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      session.resumeSessionId = 't-cache'
+      const results = []
+      session.on('result', (d) => results.push(d))
+
+      const ctx = freshCtx()
+      session._processJsonlLine(
+        { type: 'turn.completed', usage: { input_tokens: 1000, output_tokens: 42, cached_input_tokens: 600 } },
+        ctx,
+      )
+
+      // --- positive control: these pass on UNMODIFIED source, proving the
+      // fixture actually reached the real handler (not a silently-skipped test).
+      assert.equal(results.length, 1, 'positive control: real handler emitted exactly one result')
+      assert.equal(ctx.didEmitResult, true, 'positive control: real handler flipped ctx.didEmitResult')
+      assert.equal(results[0].output_tokens, undefined, 'positive control: tokens live under result.usage')
+      assert.equal(results[0].usage.output_tokens, 42, 'positive control: fixture usage reached the handler')
+      assert.equal(results[0].sessionId, 't-cache', 'positive control: handler read the live resumeSessionId')
+
+      // --- the #6718 regression
+      assert.equal(results[0].usage.cache_read_input_tokens, 600,
+        'codex-exec cache tokens must be emitted under the key _trackUsage reads')
+      assert.equal(results[0].usage.input_tokens, 400,
+        'input must be the DISJOINT remainder (total - cached), matching the app-server path')
+    })
+
+    it('the ratchet still keys off the INCLUSIVE input, not the disjoint split', () => {
+      // gpt-5-codex ships a 400k window. A 500k turn that was 450k cache reads
+      // still occupied 500k of context — the disjoint 50k must not be what the
+      // learn-loop sees, or a cache-heavy session would never ratchet.
+      const tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-6718-ratchet-'))
+      const savedConfigDir = process.env.CHROXY_CONFIG_DIR
+      process.env.CHROXY_CONFIG_DIR = tmpDir
+      try {
+        const registry = getRegistryForProvider('codex')
+        registry.resetModels()
+
+        const session = new CodexSession({ cwd: '/tmp', model: 'gpt-5-codex' })
+        const updates = []
+        session.on('models_updated', (d) => updates.push(d))
+        session.on('result', () => {})
+
+        session._processJsonlLine(
+          { type: 'turn.completed', usage: { input_tokens: 500_000, output_tokens: 10, cached_input_tokens: 450_000 } },
+          freshCtx(),
+        )
+
+        assert.equal(updates.length, 1, 'a 500k inclusive prompt must ratchet the 400k window')
+        const m = registry.getModels().find((x) => x.fullId === 'gpt-5-codex')
+        assert.ok(m.contextWindow >= 500_000 * CODEX_CONTEXT_WINDOW_HEADROOM,
+          `expected the ratchet to key off the inclusive 500k, got window ${m.contextWindow}`)
+      } finally {
+        if (savedConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+        else process.env.CHROXY_CONFIG_DIR = savedConfigDir
+        getRegistryForProvider('codex').resetModels()
+        try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best effort */ }
+      }
+    })
+
+    it('codex-exec cache tokens land in cumulativeUsage (end-to-end through SessionManager)', async () => {
+      const { SessionManager } = await import('../src/session-manager.js')
+      const tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-6718-sm-'))
+      const mgr = new SessionManager({
+        skipPreflight: true,
+        maxSessions: 5,
+        stateFilePath: join(tmpDir, 'session-state.json'),
+      })
+      try {
+        // A REAL CodexSession wired into the manager the way createSession does,
+        // so the whole chain under test is production code: codex JSONL →
+        // CodexSession._processJsonlLine → `result` → _trackUsage → cumulativeUsage.
+        const session = new CodexSession({ cwd: '/tmp' })
+        session.resumeSessionId = 't-sm'
+        mgr._sessions.set('s-codex', {
+          session,
+          name: 'Codex',
+          cwd: '/tmp',
+          provider: 'codex',
+          createdAt: Date.now(),
+          cumulativeUsage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            costUsd: 0,
+            turnsBilled: 0,
+          },
+        })
+        mgr._wireSessionEvents('s-codex', session)
+
+        session._processJsonlLine(
+          { type: 'turn.completed', usage: { input_tokens: 1000, output_tokens: 42, cached_input_tokens: 600 } },
+          freshCtx(),
+        )
+
+        const acc = mgr.getCumulativeUsage('s-codex')
+        // positive control — passes on unmodified source: the wiring is live.
+        assert.equal(acc.turnsBilled, 1, 'positive control: the result reached _trackUsage')
+        assert.equal(acc.outputTokens, 42, 'positive control: token deltas accumulated')
+        // the #6718 regression
+        assert.equal(acc.cacheReadTokens, 600, 'codex-exec cache reads must reach cumulativeUsage')
+        assert.equal(acc.inputTokens, 400, 'input accumulates the disjoint remainder')
+      } finally {
+        try { mgr.destroyAll() } catch { /* best effort */ }
+        try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best effort */ }
+      }
+    })
   })
 })


### PR DESCRIPTION
## The defect

`codex exec --json` reports cached tokens as a **subset** of `input_tokens`
(OpenAI's `prompt_tokens_details` convention). `CodexSession`'s
`turn.completed` handler read only two fields:

```js
const inputTokens = usage.input_tokens || 0
const outputTokens = usage.output_tokens || 0
…
usage: { input_tokens: inputTokens, output_tokens: outputTokens },
```

`cached_input_tokens` is documented in this file's own event-shape JSDoc
(`codex-session.js:29`) but was never read, and `cache_read_input_tokens` —
the only cache key `session-manager._trackUsage` accumulates — appeared
nowhere in the file. So on the legacy `CHROXY_CODEX_APPSERVER=0` path, every
cache read was silently dropped from `cumulativeUsage`. The default
app-server driver had the identical bug until #6717/#6692.

## The fix

- **`CodexSession._mapUsage()`** — extracted as a callable method and written
  as a deliberate mirror of `CodexAppServerSession._mapUsage()`: disjoint
  split into uncached `input_tokens` (clamped, so a hypothetical
  additive-reporting codex undercounts rather than going negative) plus
  `cache_read_input_tokens`, and the deprecated `cached_input_tokens`
  duplicate the app-server payload already carries. The two splits must stay
  identical — a divergent split between the default driver and its opt-out is
  worse than no split at all.
- **Ratchet unchanged.** The #3857 context-window learn-loop still keys off the
  **inclusive** `input_tokens`: a cache-heavy turn still occupies the whole
  prompt window, so ratcheting on the disjoint remainder would stop a
  cache-heavy session from ever correcting a stale window. The two quantities
  now sit next to each other, so there is a comment saying so and a test
  pinning it.
- **The shim harness no longer reimplements the parse loop.**
  `ShimmedCodexSession.sendMessage()` contained a hand-copied clone of
  `_processJsonlLine()`. That clone had already drifted from production (it
  emitted `sessionId: null` where the real handler emits the captured thread
  id, and it never ran the ratchet), and it is the reason #6717 judged this
  path untestable and tracked it here instead. The spawn/lifecycle scaffolding
  stays local — that is the point of the harness — but every parsed line is now
  handed to the **real** `_processJsonlLine()` with the same mutable `ctx`
  shape `JsonlSubprocessSession.sendMessage()` builds.

No wire-schema change: `ServerResultSchema.usage` is `z.any().optional()`, and
store-core's `handleResult` reads exactly the four additive keys. Because the
split is disjoint, `input_tokens + cache_read_input_tokens` equals the old
`input_tokens`, so no client-side total changes — only the previously-invisible
cache column now has a value.

## Verification

### Red first (on unmodified source)

```
ℹ tests 6
ℹ pass 1
ℹ fail 5

✖ _mapUsage splits subset-cached input into uncached input + cache_read
  TypeError: session._mapUsage is not a function
✖ _mapUsage clamps instead of going negative when cached exceeds input
  TypeError: session._mapUsage is not a function
✖ _mapUsage zero-fills a usage-less turn (unchanged pre-#6718 behavior)
  TypeError: session._mapUsage is not a function
✖ the REAL turn.completed handler emits cache_read_input_tokens with a disjoint input split
  AssertionError: codex-exec cache tokens must be emitted under the key _trackUsage reads
  undefined !== 600
✖ codex-exec cache tokens land in cumulativeUsage (end-to-end through SessionManager)
  AssertionError: codex-exec cache reads must reach cumulativeUsage
  0 !== 600
```

The one pre-existing pass is `the ratchet still keys off the INCLUSIVE input`
— by design: it guards behavior the fix must **not** change.

### Positive controls

Each regression test asserts, *before* its failing assertion, facts that hold on
unmodified source — so a fixture that never reached the real handler would fail
loudly rather than pass vacuously:

- direct-handler test: `results.length === 1`, `ctx.didEmitResult === true`,
  `results[0].usage.output_tokens === 42`, `results[0].sessionId === 't-cache'`
  (proves it read the live `resumeSessionId`). All four passed on the red run;
  the failure was isolated to the cache key at line 1888.
- SessionManager end-to-end: `turnsBilled === 1` and `outputTokens === 42`
  passed on the red run (the wiring is live); only `cacheReadTokens` failed.
- spawn-pipeline test: `usage.output_tokens === 42` passes pre-fix.

### Mutation testing (one line per run, reverted after each)

| Mutation | Result |
|---|---|
| `input_tokens: nonNegInt(rawInput - cached)` → `input_tokens: rawInput` (divergent/inclusive split) | **5 fail** — all three `_mapUsage` tests, the direct-handler test, the spawn-pipeline test, the SessionManager end-to-end |
| ratchet source `nonNegInt(usage.input_tokens)` → `this._mapUsage(usage).input_tokens` (ratchet on the disjoint split) | **1 fail** — `the ratchet still keys off the INCLUSIVE input, not the disjoint split` |

Both reverted; suite back to green.

### Green

- `tests/codex-session.test.js` — **126 pass / 0 fail** (was 119 before this PR;
  +7, and all 119 pre-existing tests still pass through the now-real shim path).
- `codex-app-server-session.test.js` 106, `usage-normalize.test.js` 18,
  `session-manager-codex-sandbox.test.js` 11, `codex-ratchet-persistence.test.js` 8,
  `codex-session-env.test.js` 6 — all pass.
- `session-manager.test.js` — 204 pass / 0 fail.
- `jsonl-subprocess-intentional-stop`, `providers`, `base-session`, `ws-schemas`,
  `lint-session-opt-forwarding`, `models-per-provider` — 485 pass / 0 fail.
- `skills-integration` 11, `provider-data-dirs` 19 — pass.
- `tests/integration/codex-spawn-argv.integration.test.js` has one failure
  (`sanity check: a deliberately-broken argv IS rejected by clap`) that is
  **pre-existing** — reproduced identically with this branch's changes stashed,
  i.e. on unmodified `origin/main`. It needs a real `codex` binary of a
  particular version; not touched by this PR.

### Lints

`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`,
`lint-logger-session-scoping.sh`, `lint-claude-family-explicit.sh`,
`lint-ws-index-mutations.sh`, `lint-no-nul-bytes.sh` — all OK.
`eslint src/codex-session.js` clean.

## Out of scope (noted, not done)

- The exec path still emits no `modelUsage`, while the app-server path stamps
  `synthesizeModelUsage(...)` in `_finishTurn`. Not part of this issue's ACs.
- `docs/design/orchestration/engine.md:341` and `metering.md:9,67` describe
  codex cache loss as current behavior and list the app-server `_mapUsage`
  change as pending. Those were already stale on `main` after #6717; they are an
  epic-#6691 design-law surface, so correcting them across both codex drivers is
  left as a separate change rather than folded in silently here.

Closes #6718.
