### PR TITLE
test(server): catch an omitted CLI health case and prove a shed task fires after an interrupt

### DIFF
--- a/packages/server/tests/scheduled-task-health-parity.test.js
+++ b/packages/server/tests/scheduled-task-health-parity.test.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import {
   SCHEDULED_TASK_HEALTH_TAGS,
+  SCHEDULED_TASK_LAST_RUN_STATUSES,
   deriveScheduledTaskHealth,
   deriveScheduledTaskHealthTag,
 } from '@chroxy/protocol'
@@ -122,6 +123,74 @@ describe('scheduled-task health — only OK is healthy', () => {
   })
 })
 
+/**
+ * The `lastRun.status` values the CLI is required to declare an EXPLICIT `case`
+ * for, DERIVED from the shared status list rather than written out longhand.
+ *
+ * Derivation is the point. A status added to `SCHEDULED_TASK_LAST_RUN_STATUSES`
+ * lands in this set automatically, so the CLI cannot quietly leave it to the
+ * `default:` arm and report `ERROR` for something the dashboard reports by name.
+ *
+ * `error` is the ONE deliberate exception: the CLI routes it through `default:`,
+ * which returns `'ERROR'` anyway, so declaring a case for it would be noise.
+ *
+ * ── ADDING A NEW ENGINE STATUS (e.g. #7038) ──────────────────────────────────
+ * Adding a status to `SCHEDULED_TASK_LAST_RUN_STATUSES` will turn the parity
+ * test below RED **on purpose**, and the failure message names the missing
+ * status. There are exactly two correct responses, both one-line and both
+ * deliberate:
+ *   1. Teach the CLI `case '<status>': return '<TAG>'` (and add a GOLDEN row
+ *      above) — the normal case for a status that deserves its own tag; or
+ *   2. Add the status to `CLI_DEFAULT_ARM_STATUSES` below, with a comment
+ *      saying why it rides the `default:` arm.
+ * Neither is a mystery failure: the red is the guard asking which of the two you
+ * meant, which is precisely the decision #7024 wanted put on the record instead
+ * of left to an omission nobody notices.
+ */
+const CLI_DEFAULT_ARM_STATUSES = new Set([
+  // Handled by the CLI's `default: return 'ERROR'` — same tag, no case needed.
+  'error',
+])
+
+const CLI_REQUIRED_CASE_STATUSES = [...SCHEDULED_TASK_LAST_RUN_STATUSES]
+  .filter((status) => !CLI_DEFAULT_ARM_STATUSES.has(status))
+  .sort()
+
+/**
+ * The source scrape the parity check runs on the CLI, factored out of the test
+ * so a self-test can prove it actually DISCRIMINATES.
+ *
+ * A source-scraping guard that silently matches nothing is worse than no guard
+ * at all, and a green run cannot tell the two apart — so the extraction has to
+ * be exercised against a known-good and a known-drifted fixture, not only
+ * against whatever the real file happens to contain today.
+ *
+ * @param {string} src
+ * @returns {{found: boolean, delimited: boolean, body: string, pairs: string[][], statuses: string[], returned: Set<string>}}
+ */
+function extractHealthTagCases(src) {
+  const empty = { found: false, delimited: false, body: '', pairs: [], statuses: [], returned: new Set() }
+  const fnStart = src.indexOf('function healthTag')
+  if (fnStart === -1) return empty
+  const fn = src.slice(fnStart)
+  // A real extraction guard. `assert.ok(fn.length > 0)` could never fire (a
+  // slice from a found index is always non-empty), so it asserted nothing —
+  // this checks the thing that actually has to hold for the regexes below to
+  // mean anything: that the function body was delimited at all.
+  const bodyEnd = fn.indexOf('\n}\n')
+  if (bodyEnd <= 0) return { ...empty, found: true }
+  const body = fn.slice(0, bodyEnd + 1)
+  const pairs = [...body.matchAll(/case '([a-z]+)':\s*\n\s*return '([^']+)'/g)].map((m) => [m[1], m[2]])
+  return {
+    found: true,
+    delimited: true,
+    body,
+    pairs,
+    statuses: pairs.map(([status]) => status),
+    returned: new Set([...body.matchAll(/return '([^']+)'/g)].map((m) => m[1])),
+  }
+}
+
 describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () => {
   it('the CLI healthTag() maps the same statuses to the same tags', (t) => {
     if (!existsSync(CLI_PATH)) {
@@ -154,21 +223,11 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
       return
     }
 
-    const fn = src.slice(fnStart)
-    // A real extraction guard. `assert.ok(fn.length > 0)` could never fire (a
-    // slice from a found index is always non-empty), so it asserted nothing —
-    // this checks the thing that actually has to hold for the regexes below to
-    // mean anything: that the function body was delimited at all.
-    const bodyEnd = fn.indexOf('\n}\n')
+    const { delimited, body, pairs, statuses, returned } = extractHealthTagCases(src)
     assert.ok(
-      bodyEnd > 0,
+      delimited,
       'could not find the end of the CLI healthTag() body — the status/tag extraction below would silently match nothing and pass vacuously',
     )
-    const body = fn.slice(0, bodyEnd + 1)
-
-    // Extract the tags the CLI can return, and the status→tag pairs it declares.
-    const returned = new Set([...body.matchAll(/return '([^']+)'/g)].map((m) => m[1]))
-    const pairs = [...body.matchAll(/case '([a-z]+)':\s*\n\s*return '([^']+)'/g)]
 
     // 1. The CLI's tag vocabulary must be a subset of the shared declared set —
     //    a tag the shared helper does not know about is drift.
@@ -179,9 +238,36 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
       )
     }
 
-    // 2. Every status→tag case in the CLI must agree with the shared helper.
-    assert.ok(pairs.length >= 4, `expected the CLI's status switch to be parseable, got ${pairs.length} pairs`)
-    for (const [, status, tag] of pairs) {
+    // 2. The CLI must declare an explicit `case` for EXACTLY the statuses that
+    //    need one — no more, no fewer. (#7024)
+    //
+    //    `assert.ok(pairs.length >= 4)` stood here, and a count cannot express
+    //    this. It catches a MISMATCHED mapping but not an OMITTED one: swap
+    //    `case 'refused'` for a perfectly correct `case 'error'` and the count
+    //    still reads 4, every surviving pair still agrees with the shared helper
+    //    below, and the CLI silently reports ERROR for a refused task while the
+    //    dashboard reports REFUSED — exactly the one-directional drift this file
+    //    exists to catch, waved straight through.
+    //
+    //    See CLI_REQUIRED_CASE_STATUSES for what to do when this goes red after
+    //    a new engine status is added: it is a two-option, one-line decision,
+    //    not a mystery failure.
+    assert.deepEqual(
+      [...statuses].sort(),
+      CLI_REQUIRED_CASE_STATUSES,
+      `the CLI's healthTag() must declare an explicit case for exactly [${CLI_REQUIRED_CASE_STATUSES.join(', ')}] ` +
+        `(the engine's SCHEDULED_TASK_LAST_RUN_STATUSES minus the ones routed through its default arm: ` +
+        `[${[...CLI_DEFAULT_ARM_STATUSES].join(', ')}]). A status missing here falls through to 'ERROR' while the ` +
+        `shared helper reports its own tag — silent, one-directional drift.`,
+    )
+    assert.equal(
+      pairs.length,
+      CLI_REQUIRED_CASE_STATUSES.length,
+      `expected exactly ${CLI_REQUIRED_CASE_STATUSES.length} status cases in the CLI switch, got ${pairs.length} (a duplicate case?)`,
+    )
+
+    // 3. Every status→tag case in the CLI must agree with the shared helper.
+    for (const [status, tag] of pairs) {
       assert.equal(
         deriveScheduledTaskHealthTag({ enabled: true, lastRun: { status } }),
         tag,
@@ -189,11 +275,79 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
       )
     }
 
-    // 3. The precedence the CLI encodes must match: paused first, then never-run.
+    // 4. The precedence the CLI encodes must match: paused first, then never-run.
     assert.match(body, /!task\.enabled\)\s*return 'PAUSED'/, "CLI must check !enabled → PAUSED first")
     assert.match(body, /!task\.lastRun\)\s*return 'NEVER RUN'/, "CLI must check !lastRun → NEVER RUN second")
 
-    // 4. The CLI's default arm must be ERROR (never a friendlier fallback).
+    // 5. The CLI's default arm must be ERROR (never a friendlier fallback).
     assert.match(body, /default:\s*\n\s*return 'ERROR'/, "CLI's default arm must be ERROR")
+  })
+
+  // POSITIVE CONTROL for the scrape above (#7024).
+  //
+  // The parity check is only as good as its extraction, and "it passed" is the
+  // same observation whether the guard verified the CLI or matched nothing at
+  // all. So run the SAME extractor over two fixtures whose verdicts must differ,
+  // and pin the difference. This is what makes the green above mean something.
+  it('the extractor discriminates: a dropped case is caught, and the old count guard would not have caught it', () => {
+    const COMPLETE = `function healthTag(task) {
+  if (!task.enabled) return 'PAUSED'
+  if (!task.lastRun) return 'NEVER RUN'
+  switch (task.lastRun.status) {
+    case 'success':
+      return 'OK'
+    case 'refused':
+      return 'REFUSED'
+    case 'skipped':
+      return 'SKIPPED'
+    case 'timeout':
+      return 'TIMEOUT'
+    default:
+      return 'ERROR'
+  }
+}
+`
+    // The drift #7024 describes, in its ONLY form that survives a count check:
+    // `refused` loses its case, and a legitimate explicit `error` case replaces
+    // it. Same number of cases, every remaining mapping correct — and a refused
+    // task now tags ERROR in the CLI while the dashboard says REFUSED.
+    const DRIFTED = COMPLETE.replace("    case 'refused':\n      return 'REFUSED'\n", "    case 'error':\n      return 'ERROR'\n")
+    assert.notEqual(DRIFTED, COMPLETE, 'the drift fixture must actually differ, or this control proves nothing')
+
+    const good = extractHealthTagCases(COMPLETE)
+    const bad = extractHealthTagCases(DRIFTED)
+
+    // (a) The extractor finds a delimited body and real cases in BOTH — it is
+    //     not silently matching nothing, which is the failure mode that would
+    //     make every assertion here vacuous.
+    assert.ok(good.delimited && bad.delimited, 'the extractor must delimit both fixtures')
+    assert.ok(good.pairs.length > 0 && bad.pairs.length > 0, 'the extractor must find cases in both fixtures')
+
+    // (b) The known-GOOD fixture satisfies the tightened assertion.
+    assert.deepEqual([...good.statuses].sort(), CLI_REQUIRED_CASE_STATUSES)
+
+    // (c) The known-DRIFTED fixture is caught by the tightened assertion...
+    assert.notDeepEqual([...bad.statuses].sort(), CLI_REQUIRED_CASE_STATUSES)
+    assert.ok(!bad.statuses.includes('refused'), 'the drifted fixture must be missing the refused case')
+
+    // (d) ...but sails past BOTH of the checks that used to stand here: the
+    //     count is unchanged, and every declared mapping still agrees with the
+    //     shared helper. That is the whole defect, demonstrated rather than
+    //     asserted.
+    assert.equal(bad.pairs.length, good.pairs.length, 'the drift must be count-neutral, or it is not the gap #7024 describes')
+    assert.ok(bad.pairs.length >= 4, 'the old `pairs.length >= 4` guard would have passed on the drifted source')
+    for (const [status, tag] of bad.pairs) {
+      assert.equal(
+        deriveScheduledTaskHealthTag({ enabled: true, lastRun: { status } }),
+        tag,
+        `the drifted fixture's surviving mappings must all still agree with the shared helper — '${status}' does not`,
+      )
+    }
+
+    // (e) And the user-visible consequence the guard now prevents: the drifted
+    //     CLI would tag a refused task ERROR where the shared helper says
+    //     REFUSED.
+    assert.equal(deriveScheduledTaskHealthTag({ enabled: true, lastRun: { status: 'refused' } }), 'REFUSED')
+    assert.match(bad.body, /default:\s*\n\s*return 'ERROR'/, 'a refused task in the drifted CLI falls through to this ERROR arm')
   })
 })

--- a/packages/server/tests/scheduled-task-health-parity.test.js
+++ b/packages/server/tests/scheduled-task-health-parity.test.js
@@ -131,26 +131,34 @@ describe('scheduled-task health — only OK is healthy', () => {
  * lands in this set automatically, so the CLI cannot quietly leave it to the
  * `default:` arm and report `ERROR` for something the dashboard reports by name.
  *
- * `error` is the ONE deliberate exception: the CLI routes it through `default:`,
- * which returns `'ERROR'` anyway, so declaring a case for it would be noise.
+ * A status may be excused from an explicit CLI case for exactly ONE reason: the
+ * SHARED HELPER also routes it to `'ERROR'`, so the CLI's `default: return
+ * 'ERROR'` already agrees with it and a case would be pure noise. That is why
+ * the exemption is COMPUTED off `deriveScheduledTaskHealthTag` rather than kept
+ * as a hand-written allowlist — today it resolves to exactly `{error}`.
+ *
+ * A hand-maintained exemption list would be a hole in this guard, not a
+ * convenience. It hands a maintainer a one-line way to make a red go away
+ * WITHOUT teaching the CLI anything, and if the shared helper gives the new
+ * status its own tag, that one line reinstates #7024 verbatim — the CLI reports
+ * `ERROR` while the dashboard reports the real tag, and this guard reports
+ * green. Deriving the exemption makes that impossible to express: a status can
+ * only ride the `default:` arm when both surfaces land on the same tag anyway.
  *
  * ── ADDING A NEW ENGINE STATUS (e.g. #7038) ──────────────────────────────────
- * Adding a status to `SCHEDULED_TASK_LAST_RUN_STATUSES` will turn the parity
- * test below RED **on purpose**, and the failure message names the missing
- * status. There are exactly two correct responses, both one-line and both
- * deliberate:
- *   1. Teach the CLI `case '<status>': return '<TAG>'` (and add a GOLDEN row
- *      above) — the normal case for a status that deserves its own tag; or
- *   2. Add the status to `CLI_DEFAULT_ARM_STATUSES` below, with a comment
- *      saying why it rides the `default:` arm.
- * Neither is a mystery failure: the red is the guard asking which of the two you
- * meant, which is precisely the decision #7024 wanted put on the record instead
- * of left to an omission nobody notices.
+ * Adding a status to `SCHEDULED_TASK_LAST_RUN_STATUSES` and giving it its own
+ * tag in `deriveScheduledTaskHealthTag` turns the parity test below RED **on
+ * purpose**, and the failure message names the missing status. There is exactly
+ * ONE correct response: teach the CLI `case '<status>': return '<TAG>'` (and add
+ * a GOLDEN row above). A status the shared helper deliberately leaves on its own
+ * `default:` arm needs no CLI change and goes green on its own — the derivation
+ * below already excuses it, so that case is not even a red.
  */
-const CLI_DEFAULT_ARM_STATUSES = new Set([
-  // Handled by the CLI's `default: return 'ERROR'` — same tag, no case needed.
-  'error',
-])
+const CLI_DEFAULT_ARM_STATUSES = new Set(
+  [...SCHEDULED_TASK_LAST_RUN_STATUSES].filter(
+    (status) => deriveScheduledTaskHealthTag({ enabled: true, lastRun: { status } }) === 'ERROR',
+  ),
+)
 
 const CLI_REQUIRED_CASE_STATUSES = [...SCHEDULED_TASK_LAST_RUN_STATUSES]
   .filter((status) => !CLI_DEFAULT_ARM_STATUSES.has(status))
@@ -250,8 +258,22 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
     //    exists to catch, waved straight through.
     //
     //    See CLI_REQUIRED_CASE_STATUSES for what to do when this goes red after
-    //    a new engine status is added: it is a two-option, one-line decision,
-    //    not a mystery failure.
+    //    a new engine status is added: teach the CLI a case, one line, not a
+    //    mystery failure.
+    //
+    //    A DUPLICATE case is named first and on its own. The set comparison
+    //    below sorts and compares, so a duplicate reaches it as an unreadable
+    //    array diff (`[refused, success, success, timeout]` vs the expected
+    //    four) rather than as "you declared 'success' twice" — and an assertion
+    //    that can only ever fire *after* another one has already failed is not
+    //    an assertion at all, which is exactly the `assert.ok(fn.length > 0)`
+    //    mistake this file just finished removing.
+    const duplicates = [...new Set(statuses.filter((s, i) => statuses.indexOf(s) !== i))]
+    assert.deepEqual(
+      duplicates,
+      [],
+      `the CLI's healthTag() declares duplicate case(s) for [${duplicates.join(', ')}] — the second is dead code and the switch does not mean what it reads like`,
+    )
     assert.deepEqual(
       [...statuses].sort(),
       CLI_REQUIRED_CASE_STATUSES,
@@ -259,11 +281,6 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
         `(the engine's SCHEDULED_TASK_LAST_RUN_STATUSES minus the ones routed through its default arm: ` +
         `[${[...CLI_DEFAULT_ARM_STATUSES].join(', ')}]). A status missing here falls through to 'ERROR' while the ` +
         `shared helper reports its own tag — silent, one-directional drift.`,
-    )
-    assert.equal(
-      pairs.length,
-      CLI_REQUIRED_CASE_STATUSES.length,
-      `expected exactly ${CLI_REQUIRED_CASE_STATUSES.length} status cases in the CLI switch, got ${pairs.length} (a duplicate case?)`,
     )
 
     // 3. Every status→tag case in the CLI must agree with the shared helper.
@@ -324,7 +341,11 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
     assert.ok(good.pairs.length > 0 && bad.pairs.length > 0, 'the extractor must find cases in both fixtures')
 
     // (b) The known-GOOD fixture satisfies the tightened assertion.
-    assert.deepEqual([...good.statuses].sort(), CLI_REQUIRED_CASE_STATUSES)
+    assert.deepEqual(
+      [...good.statuses].sort(),
+      CLI_REQUIRED_CASE_STATUSES,
+      "the known-good fixture no longer matches CLI_REQUIRED_CASE_STATUSES — if a status was just added to SCHEDULED_TASK_LAST_RUN_STATUSES, teach the COMPLETE fixture above the same `case` you are teaching the real CLI, or this control stops controlling anything",
+    )
 
     // (c) The known-DRIFTED fixture is caught by the tightened assertion...
     assert.notDeepEqual([...bad.statuses].sort(), CLI_REQUIRED_CASE_STATUSES)

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -997,8 +997,14 @@ describe('#6865 SchedulerEngine', () => {
       assert.deepEqual([...new Set(skips)], [second.id], 'only the second task is shed')
       assert.ok(skips.length >= 2, `the second task must be re-shed on every tick while the slot is held (got ${skips.length})`)
       assert.equal(store.get(second.id).lastRun, null, 'a starved task never records a run at all')
-      assert.equal(engine.runningTaskIds.size, 1, 'the first run is still holding the only slot')
-      assert.ok(first.id)
+      // ...and it is FIRST that holds it. `assert.ok(first.id)` stood here, which
+      // is true of every task the store ever returns and so could not fail — the
+      // same never-fires assertion this PR removed from the parity guard. Naming
+      // the holder is the claim actually worth pinning: it rules out the mirror
+      // world where `second` won the slot and `first` was the one shed, which
+      // every other assertion above is equally happy with.
+      assert.deepEqual([...engine.runningTaskIds], [first.id], 'the FIRST run is the one holding the only slot')
+      assert.equal(runTask.calls[0].task.id, first.id, 'and it is the run that was actually started')
 
       // Release it and the starvation ends on the next tick — the same
       // transition the interrupted run must make on its own.

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -903,6 +903,113 @@ describe('#6865 SchedulerEngine', () => {
       assert.equal(record.lastRun.status, 'error')
       assert.match(record.lastRun.error, /interrupted/)
     })
+
+    // ── #7037: the SYMPTOM, not the proxy ────────────────────────────────────
+    //
+    // Both tests above assert `record.lastRun` is non-null by the time the fire
+    // settles. That is a good proxy for "the concurrency slot was released", but
+    // it is only a proxy: a change that settled the promise while leaving the
+    // run registered in `_running` keeps both of them green and reintroduces the
+    // reported bug verbatim.
+    //
+    // The user-visible #7009 symptom was starvation — `_running.size >=
+    // _maxConcurrentRuns` shedding every other due task with `concurrency cap
+    // reached (…)` for the whole `runTimeoutMs` window (15 min in production)
+    // after ONE denied permission. These two tests pin that directly: the first
+    // proves a second due task fires once the interrupted run settles, and the
+    // second proves the counterfactual — that it genuinely starves when the slot
+    // is not released, so the first test cannot pass for free.
+
+    it('a SECOND due task fires once the interrupted run frees the slot', async () => {
+      const sm = new FakeSessionManager({
+        permissionRequest: { requestId: 'req-1', toolName: 'Bash' },
+        interruptEmitsStopped: true,
+      })
+      const first = addTask({ prompt: 'first', cadence: { kind: 'once', at: 2000 } })
+      const second = addTask({ prompt: 'second', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm, runTimeoutMs: 5_000, maxConcurrentRuns: 1 })
+      const skips = []
+      engine.on('run-skip', (e) => skips.push(e))
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+
+      // POSITIVE CONTROL. The cap really did engage on this tick, and `second`
+      // really was shed by it. Without these four assertions the test would pass
+      // for free in every world that never exercises slot RELEASE at all: a cap
+      // that was ignored, two tasks that were not due together, or a `second`
+      // that simply ran in parallel would each still leave `second.lastRun`
+      // populated at the end.
+      assert.deepEqual(skips.map((e) => e.taskId), [second.id], 'the second task must be shed by the cap on this tick')
+      assert.match(skips[0].reason, /concurrency cap reached/)
+      assert.equal(store.get(second.id).lastRun, null, 'a shed task persists nothing — it is still due')
+      assert.equal(sm.created.length, 1, 'only one session may exist under a cap of 1')
+
+      // The interrupted run settled AND gave the slot back. `armedDelay === 0`
+      // is the direct read on `_running`: while a run is still registered,
+      // _armNextTick skips the due-scan entirely and sleeps the full max-sleep
+      // (the `does not busy-spin while at capacity` test pins that behaviour).
+      assert.equal(store.get(first.id).lastRun.status, 'error')
+      assert.equal(engine.runningTaskIds.size, 0, 'the interrupted run must not stay registered as in-flight')
+      assert.equal(timers.armedDelay, 0, 'a freed slot must re-arm immediately for the still-due second task')
+
+      // THE assertion #7037 asks for: the second task actually FIRES, in the
+      // same evaluation window, rather than being shed again.
+      await timers.tick()
+
+      const secondRecord = store.get(second.id)
+      assert.ok(secondRecord.lastRun, 'the second due task must fire once the slot frees, not starve for runTimeoutMs')
+      assert.notEqual(secondRecord.lastRun.status, 'skipped', 'it must be a real run, not a persisted skip')
+      assert.ok(
+        !/concurrency cap/.test(secondRecord.lastRun.error || ''),
+        `the second task was recorded as a cap skip instead of running: ${secondRecord.lastRun.error}`,
+      )
+      // ...and it drove a turn of its very own, rather than being credited with
+      // the first task's session.
+      assert.equal(sm.created.length, 2, 'the second task must get its own session')
+      assert.deepEqual(sm.sends.map((s) => s.prompt), ['first', 'second'])
+      assert.notEqual(secondRecord.lastRun.sessionId, store.get(first.id).lastRun.sessionId)
+    })
+
+    it('...and starves indefinitely while the slot is NOT released (the counterfactual)', async () => {
+      // Hold the slot open and the second task is re-shed on every tick with
+      // `lastRun` never written — exactly the state one denied permission left
+      // the engine in before #7033, and exactly what the previous test's final
+      // assertions would be reading if the slot were not released. This is what
+      // makes that test's green mean something.
+      const first = addTask({ prompt: 'first', cadence: { kind: 'once', at: 2000 } })
+      const second = addTask({ prompt: 'second', cadence: { kind: 'once', at: 2000 } })
+      let release
+      const gate = new Promise((r) => { release = r })
+      const runTask = mockRunner(() => gate)
+      const engine = newEngine({ runTask: runTask.fn, maxConcurrentRuns: 1 })
+      const skips = []
+      engine.on('run-skip', (e) => skips.push(e.taskId))
+      engine.start()
+
+      clock = 2000
+      await timers.tick()
+      await timers.tick()
+      await timers.tick()
+
+      assert.equal(runTask.calls.length, 1, 'a held slot admits nobody else')
+      assert.deepEqual([...new Set(skips)], [second.id], 'only the second task is shed')
+      assert.ok(skips.length >= 2, `the second task must be re-shed on every tick while the slot is held (got ${skips.length})`)
+      assert.equal(store.get(second.id).lastRun, null, 'a starved task never records a run at all')
+      assert.equal(engine.runningTaskIds.size, 1, 'the first run is still holding the only slot')
+      assert.ok(first.id)
+
+      // Release it and the starvation ends on the next tick — the same
+      // transition the interrupted run must make on its own.
+      release({ status: 'success' })
+      await new Promise((r) => setImmediate(r))
+      await new Promise((r) => setImmediate(r))
+      assert.equal(timers.armedDelay, 0, 'the freed slot re-arms for the still-due task')
+      await timers.tick()
+      assert.equal(runTask.calls.length, 2, 'and the second task fires the instant the slot frees')
+      assert.ok(store.get(second.id).lastRun, 'its outcome is recorded once it actually runs')
+    })
   })
 
   // ── SECURITY C2: cwd confinement is enforced ON THIS PATH ──────────────────


### PR DESCRIPTION
Closes #7024. Closes #7037.

Two test-only guards that were green for the wrong reason. Both are single-file changes under `packages/server/tests/`, so they ship as one review cycle.

---

## #7024 — an OMITTED CLI health case was not caught

**Defect.** `packages/server/tests/scheduled-task-health-parity.test.js` source-scrapes the `chroxy schedule` CLI's `healthTag()` and compares each extracted `status -> tag` pair against the shared `deriveScheduledTaskHealthTag`. Its extraction guard was `assert.ok(pairs.length >= 4)`. A count catches a **mismatched** mapping but cannot express *"these exact statuses must be declared"*, so it cannot catch an **omitted** one.

The guard is now live — the issue's *"only becomes live once #6868/PR #7013 lands"* caveat has expired. `src/cli/schedule-cmd.js:176` is on main with a local `healthTag()` declaring four cases plus `default: return 'ERROR'`, so the `existsSync` skip no longer fires.

**The drift that walks straight through it** (verified on main, see Verification below): swap `case 'refused'` for a perfectly legitimate `case 'error'`. The count still reads 4, every surviving mapping still agrees with the shared helper, the default arm is still `ERROR` — and the CLI now reports `ERROR` for a refused task while the dashboard reports `REFUSED`. That is exactly the silent, one-directional drift this module exists to prevent.

**Fix.**
- Replace the count with an **exact set** assertion. The expected set is *derived* — `SCHEDULED_TASK_LAST_RUN_STATUSES` minus a named `CLI_DEFAULT_ARM_STATUSES` (`error`, which the CLI deliberately routes through `default:`) — not written out longhand, so a status added to the shared list cannot be silently ignored by the CLI.
- Keep an exact-count assertion alongside it to name a duplicate case distinctly.
- Factor the scrape into `extractHealthTagCases()` and add a **self-test** that runs it over a known-good and a known-drifted fixture. A source-scraping guard that silently matches nothing is worse than no guard, and "it passed" cannot tell the two apart.

**On #7038** (which adds a fifth status literal): this guard is load-bearing for it, and the design makes that a deliberate edit rather than a mystery failure. Adding a status to `SCHEDULED_TASK_LAST_RUN_STATUSES` turns the parity test red **on purpose**, and the message names the missing status and the two correct responses — teach the CLI a `case`, or add the status to `CLI_DEFAULT_ARM_STATUSES` with a comment. The `CLI_REQUIRED_CASE_STATUSES` doc block spells this out explicitly.

## #7037 — a second due task firing after an interrupt was only covered by proxy

**Defect.** `describe('interrupted turn settles promptly (#7009)')` had two single-task tests, both asserting only that `record.lastRun` is non-null. That is a *proxy* for "the concurrency slot was released". The user-visible #7009 symptom was **starvation**: `_running.size >= _maxConcurrentRuns` shedding every other due task with `concurrency cap reached (...)` (`scheduler.js:513`) for the whole `runTimeoutMs` window (15 min default) after one denied permission. The existing concurrency tests are disjoint from the interrupt path and none uses `interruptEmitsStopped`.

A change that settled the promise while leaving the run registered in `_running` keeps both existing assertions green and reintroduces the reported bug verbatim.

**Fix.** Two tasks due at the same tick under `maxConcurrentRuns: 1`, the first interrupted, asserting the second's `lastRun` is populated by a real run rather than shed — plus the counterfactual test that it starves indefinitely while the slot is held.

---

## Verification

### #7024 — red-first (the defect demonstrated on main)

Mutation A, applied to `src/cli/schedule-cmd.js` — `case 'refused': return 'REFUSED'` replaced by `case 'error': return 'ERROR'` (count-neutral, mapping-correct drift):

| guard | verdict |
|---|---|
| **existing** `pairs.length >= 4` | **10/10 PASS** — the drift is waved through |
| **tightened** (this PR) | **FAIL**, naming the missing status |

```
AssertionError [ERR_ASSERTION]: the CLI's healthTag() must declare an explicit case
for exactly [refused, skipped, success, timeout] (the engine's
SCHEDULED_TASK_LAST_RUN_STATUSES minus the ones routed through its default arm:
[error]). A status missing here falls through to 'ERROR' while the shared helper
reports its own tag — silent, one-directional drift.
```

Mutation B (the brief's named check) — `case 'refused':` deleted outright. The tightened guard fails **for the right reason**: the set assertion above names the missing status. Worth noting the old guard also went red here, but with `expected the CLI's status switch to be parseable, got 3 pairs` — a count message that misdiagnoses real drift as an unparseable file.

Mutation E — a fifth status (`cancelled`) added to `SCHEDULED_TASK_LAST_RUN_STATUSES`, simulating #7038. Red as designed, with `cancelled` named in the expected set.

All mutations reverted; tree verified clean before commit.

### #7037 — red-first

Mutation C, applied to `src/scheduler.js` `_fire()` — drop `this._running.delete(task.id)` from the `finally`, i.e. settle and record the outcome but leave the run registered. This is the exact regression the issue describes:

```
✔ a denied permission finishes the run at once instead of burning runTimeoutMs
✔ an operator Stop on a scheduled run is an error, never a success
✖ a SECOND due task fires once the interrupted run frees the slot
✖ ...and starves indefinitely while the slot is NOT released (the counterfactual)
```

```
AssertionError [ERR_ASSERTION]: the interrupted run must not stay registered as in-flight
1 !== 0
```

**The two pre-existing proxy tests stay green while both new tests go red** — that is the precise proof the new coverage is not redundant.

Mutation D — pre-#7033 turn-driver (`case 'stopped'` ignored in `orchestration/turn-driver.js`): the new fires-after-interrupt test is red alongside the two existing ones. The counterfactual test correctly stays green under D (it drives an injected `runTask`, not the turn-driver path), which is what a pure control should do.

### Positive controls

Neither new assertion can pass for free.

- **#7024** — the extractor self-test runs the *same* `extractHealthTagCases()` over a known-good and a known-drifted fixture and pins that their verdicts differ: both fixtures delimit and yield cases (so the scrape is not silently matching nothing), the good one satisfies the tightened assertion, the drifted one violates it — while still passing both checks that used to stand there (`pairs.length >= 4`, and every declared mapping agreeing with the shared helper). The defect is demonstrated, not merely asserted.
- **#7037** — before the release assertion, the test pins that the cap *genuinely engaged on that tick*: exactly one `run-skip` for the second task with reason `concurrency cap reached`, its `lastRun` still `null`, and exactly one session created. Without these, the test would pass for free in every world that never exercises slot release — a cap that was ignored, two tasks not due together, or a second task that simply ran in parallel would each still leave `lastRun` populated at the end. `timers.armedDelay === 0` is then the direct read on `_running`: while a run is still registered, `_armNextTick` skips the due-scan entirely and sleeps the full max-sleep.

### Tests and lints

- `tests/scheduler.test.js`, `tests/scheduled-task-health-parity.test.js`, `tests/schedule-cli.test.js`, `tests/cli/schedule-cmd.test.js` — **139 pass, 0 fail, 0 skipped**
- `packages/protocol` full suite — **388 pass, 0 fail** (the shared helper's own package)
- All five `packages/server/scripts/lint-*.sh` (the actual "CI Server Lint") — pass
- eslint: both files are covered by the repo's test ignore pattern

No production code is changed by this PR — the mutations above were applied and reverted purely to establish red.
