### PR TITLE
fix(server): wire the run-model transition guards into the orchestration status writes

### DIFF
--- a/docs/design/orchestration/engine.md
+++ b/docs/design/orchestration/engine.md
@@ -188,7 +188,10 @@ Terminal: done | skipped | failed | cancelled
 - The iteration cap is evaluated at the TOP of the committee loop, i.e. *after* a `redelegate` has already re-spawned the worker, so a forced escalation can fire from `spawning`.
 - `escalated ── retry ──▶ spawning ──▶ briefing`: a user retry hands the subtask to a fresh worker, so it re-enters through the spawn step.
 
-The error terminals (`failed`, `cancelled`, `cancelling`, `interrupted`, `suspended`) are legal from any non-terminal state and are not enumerated per row — the transition rows describe forward progress only, so a fail-closed guard can never wedge a teardown path.
+The transition rows describe FORWARD PROGRESS only; the error/teardown targets below are legal from any non-terminal state and are not enumerated per row, so a fail-closed guard can never wedge a teardown path. The two machines have different vocabularies, and the escape hatch is per-machine — `cancelling`/`suspended` are run statuses only, `interrupted` is a subtask status only:
+
+- **run** (`assertRunTransition`): `cancelling`, `suspended`, `failed`. Note `cancelled` is NOT in this set — a run reaches it only via `cancelling`, which is exactly why `cancelRun` journals the intermediate state.
+- **subtask** (`assertNodeTransition`): `cancelled`, `interrupted`, `failed`.
 
 ---
 

--- a/docs/design/orchestration/engine.md
+++ b/docs/design/orchestration/engine.md
@@ -182,6 +182,14 @@ Terminal: done | skipped | failed | cancelled
 
 **Committee iteration budget**: `committee.iterations` counts every `revise` and `redelegate` across both gates for that subtask. Default cap 4. Exceeding forces `escalated` — the architect can never spin unbounded worker spend.
 
+**Enforcement (#6732)**: both diagrams above are enforced at runtime — `OrchestrationManager` journals every run/subtask status through `_setRunStatus` / `_setSubtaskStatus`, which call `assertRunTransition` / `assertNodeTransition` first and throw `TransitionError` (`ILLEGAL_TRANSITION`) rather than writing an illegal transition. Nothing else in the manager may call `ledger.setStatus` / `ledger.updateSubtask`. Three points where the shipped engine is narrower or wider than the prose above, and which the tables in `run-model.js` therefore encode:
+
+- `result_review ── revise ──▶ briefing`, not `executing`: the engine re-drives the FULL committee cycle (fresh plan-of-attack + PoA review) with the architect's feedback attached to the later execute turn, rather than re-prompting the same session in place.
+- The iteration cap is evaluated at the TOP of the committee loop, i.e. *after* a `redelegate` has already re-spawned the worker, so a forced escalation can fire from `spawning`.
+- `escalated ── retry ──▶ spawning ──▶ briefing`: a user retry hands the subtask to a fresh worker, so it re-enters through the spawn step.
+
+The error terminals (`failed`, `cancelled`, `cancelling`, `interrupted`, `suspended`) are legal from any non-terminal state and are not enumerated per row — the transition rows describe forward progress only, so a fail-closed guard can never wedge a teardown path.
+
 ---
 
 ## 4. Sessions per role and turn driving

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -29,7 +29,7 @@
 import { EventEmitter } from 'node:events'
 import { randomBytes } from 'node:crypto'
 import { extractDecision, DecisionParseError, buildRepairPrompt } from './decision-contract.js'
-import { makeGate, resolveGate as resolveGateModel, nextGateId } from './run-model.js'
+import { makeGate, resolveGate as resolveGateModel, nextGateId, assertRunTransition, assertNodeTransition } from './run-model.js'
 import {
   architectPreamble, auditWorkerPreamble, implementWorkerPreamble, presetFor,
   buildPlanPrompt, buildPoaPrompt, buildPoaReviewPrompt,
@@ -172,6 +172,42 @@ export class OrchestrationManager extends EventEmitter {
     this._gate?.dispose?.()
   }
 
+  // --- status writes: the FSM choke point (#6732) --------------------------
+  //
+  // EVERY run/subtask status the engine journals goes through one of these two
+  // methods, and nothing else in this file may call `this._ledger.setStatus` /
+  // `this._ledger.updateSubtask` directly. run-model's transition tables are the
+  // contract; before #6732 they were exported but never invoked, so an engine
+  // bug that produced e.g. `planning -> synthesizing` or `pending -> done` was
+  // journaled silently. A guard wired into only SOME write paths is worse than
+  // none — it advertises coverage it does not have — hence the single choke
+  // point (asserted by orchestration-transition-guards.test.js, which fails if a
+  // second raw call site appears).
+  //
+  // Posture is FAIL-CLOSED: an illegal transition throws TransitionError
+  // (code ILLEGAL_TRANSITION) and nothing is written. The transition tables
+  // enumerate FORWARD PROGRESS only; the error terminals (`failed`, `cancelled`,
+  // `cancelling`, `interrupted`, `suspended`) are legal from any non-terminal
+  // state, so a teardown path can never be wedged by the guard it just tripped.
+
+  /** Journal a run status change, asserting the transition first. Also advances
+   *  the engine's `run.phase` mirror so the two can't drift. */
+  _setRunStatus(run, next, reason = null) {
+    const record = this._ledger.getRun(run.runId)
+    // No record (evicted/never created) → the ledger write is a no-op, so there
+    // is no transition to validate and nothing to journal.
+    if (record) assertRunTransition(record.status, next)
+    run.phase = next
+    return this._ledger.setStatus(run.runId, next, reason)
+  }
+
+  /** Journal a subtask status change, asserting the transition first. */
+  _setSubtaskStatus(run, subtaskId, next) {
+    const st = this._ledger.getRun(run.runId)?.subtasks?.find((s) => s.subtaskId === subtaskId)
+    if (st) assertNodeTransition(st.status, next)
+    return this._ledger.updateSubtask(run.runId, subtaskId, { status: next })
+  }
+
   // --- run creation --------------------------------------------------------
 
   createRun({ title = '', goal = null, cwd, preset = null, budgetUsd = null, autoApprovePlan = false, roleOverrides = null } = {}) {
@@ -245,8 +281,7 @@ export class OrchestrationManager extends EventEmitter {
   async startRun(runId) {
     const run = this._get(runId)
     if (run.phase !== 'created') throw new Error(`run ${runId} already started (phase ${run.phase})`)
-    run.phase = 'planning'
-    this._ledger.setStatus(runId, 'planning')
+    this._setRunStatus(run, 'planning')
     let plan
     try {
       plan = await this._plan(run)
@@ -274,8 +309,7 @@ export class OrchestrationManager extends EventEmitter {
     }
     // open the epic_plan user gate — the spend gate
     const gate = this._openGate(run, { kind: 'epic_plan', summary: `Approve the ${run.subtasks.size}-subtask audit plan`, detail: plan.summary ?? null })
-    run.phase = 'plan_review'
-    this._ledger.setStatus(runId, 'plan_review')
+    this._setRunStatus(run, 'plan_review')
     this.emit('gate_opened', { runId, gate })
     this._emitRunDelta(run, { gate })
     return { runId, phase: 'plan_review', gateId: gate.gateId }
@@ -322,8 +356,7 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   _beginExecuting(run) {
-    run.phase = 'executing'
-    this._ledger.setStatus(run.runId, 'executing')
+    this._setRunStatus(run, 'executing')
     this._schedule(run)
     return { runId: run.runId, phase: 'executing' }
   }
@@ -370,13 +403,14 @@ export class OrchestrationManager extends EventEmitter {
       if (st.iterations >= this._cfg.maxCommitteeIterations) {
         return this._escalateSubtask(run, subtaskId, 'committee iteration cap exceeded')
       }
-      // 1) plan-of-attack
-      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
+      // 1) plan-of-attack. This is also the loop's re-entry point after a revise
+      // or a redelegate, so it owns the `briefing` write for every path.
+      this._setSubtaskStatus(run, subtaskId, 'briefing')
       const poa = await this._driveDecision(run, sessionId, buildPoaPrompt({ subtask: st.spec }), 'plan_of_attack', 'poa', subtaskId).then((r) => r.decision)
       st.poa = poa
       // 2) architect reviews the PoA (usage attributed to architect.review, NOT
       // the subtask cell — see _architectReview)
-      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'poa_review' })
+      this._setSubtaskStatus(run, subtaskId, 'poa_review')
       const poaReview = await this._architectReview(run, buildPoaReviewPrompt({ subtask: st.spec, poa }), 'poa_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'plan', verdict: poaReview.verdict, reviewerSessionId: run.architectSessionId, notes: poaReview.feedback ?? '' })
       this._appendTimeline(run, { kind: 'committee_review', nodeId: subtaskId, verdict: poaReview.verdict, summary: `plan-of-attack ${poaReview.verdict}`, detail: poaReview.feedback ?? null })
@@ -388,14 +422,14 @@ export class OrchestrationManager extends EventEmitter {
         continue
       }
       // 3) execute
-      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'executing' })
+      this._setSubtaskStatus(run, subtaskId, 'executing')
       const result = await this._driveDecision(run, sessionId, buildExecutePrompt({ subtask: st.spec, feedback }), 'work_result', 'execute', subtaskId).then((r) => r.decision)
       st.result = result
       // 3b) implement subtasks: commit the worktree and compute a review diff so
       // the architect reviews the ACTUAL change, not just the worker's summary.
       const diff = st.spec.role === 'implement' ? await this._commitAndDiff(run, subtaskId, sessionId) : null
       // 4) architect reviews the result (+ diff for implement)
-      this._ledger.updateSubtask(run.runId, subtaskId, { status: 'result_review' })
+      this._setSubtaskStatus(run, subtaskId, 'result_review')
       const resultReview = await this._architectReview(run, buildResultReviewPrompt({ subtask: st.spec, result, diff }), 'result_review')
       this._ledger.recordCommitteeReview(run.runId, subtaskId, { phase: 'result', verdict: resultReview.verdict, reviewerSessionId: run.architectSessionId, notes: resultReview.feedback ?? '' })
       this._appendTimeline(run, { kind: 'committee_review', nodeId: subtaskId, verdict: resultReview.verdict, summary: `result ${resultReview.verdict}`, detail: resultReview.feedback ?? null })
@@ -417,9 +451,14 @@ export class OrchestrationManager extends EventEmitter {
   async _spawnWorker(run, subtaskId) {
     const st = run.subtasks.get(subtaskId)
     const role = st.spec.role === 'implement' ? 'implement' : 'audit'
+    // `spawning` (design §3.3: pending -> spawning -> briefing) — the worker
+    // session does not exist yet, so this state, not `briefing`, is what the
+    // subtask is actually in while createSession + worktree setup run (and it is
+    // what a SessionLimitError throw leaves behind). `briefing` is written by
+    // the committee loop's first step, immediately after this returns.
+    this._setSubtaskStatus(run, subtaskId, 'spawning')
     const sessionId = this._spawnSession(run, { role, subtaskId })
     run.ownedSessions.set(sessionId, { role, subtaskId })
-    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'briefing' })
     if (role === 'implement') {
       // The write worker got an isolated worktree (worktree:true) — put it on a
       // named branch and record the branch-point so the review diff + merge are
@@ -450,7 +489,7 @@ export class OrchestrationManager extends EventEmitter {
   // redelegate: tear down the current worker and hand the subtask to a fresh one.
   async _respawnWorker(run, subtaskId, oldSessionId) {
     await this._destroySession(run, oldSessionId)
-    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'respawning' })
+    this._setSubtaskStatus(run, subtaskId, 'respawning')
     return this._spawnWorker(run, subtaskId)
   }
 
@@ -466,7 +505,7 @@ export class OrchestrationManager extends EventEmitter {
     if (run.cancelled || !this._runs.has(run.runId)) return
     const st = run.subtasks.get(subtaskId)
     if (st) st.state = status
-    this._ledger.updateSubtask(run.runId, subtaskId, { status })
+    this._setSubtaskStatus(run, subtaskId, status)
     await this._releaseSubtaskSessions(run, subtaskId)
     this._schedule(run)
   }
@@ -474,7 +513,7 @@ export class OrchestrationManager extends EventEmitter {
   async _escalateSubtask(run, subtaskId, reason) {
     const st = run.subtasks.get(subtaskId)
     if (st) st.state = 'escalated'
-    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'escalated' })
+    this._setSubtaskStatus(run, subtaskId, 'escalated')
     // Free this subtask's worker so a pending sibling can take the slot while
     // the user resolves the escalation gate (auto-commits implement work first).
     await this._releaseSubtaskSessions(run, subtaskId)
@@ -499,8 +538,7 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   async _synthesize(run) {
-    run.phase = 'synthesizing'
-    this._ledger.setStatus(run.runId, 'synthesizing')
+    this._setRunStatus(run, 'synthesizing')
     const { decision } = await this._driveDecision(run, run.architectSessionId, buildSynthesisPrompt({ goal: run.goal, results: run.results }), 'synthesis', 'synthesis', null)
     // Keep the architect's narrative in memory (it feeds the persisted report).
     this._rememberReport(run.runId, decision.reportMarkdown)
@@ -508,8 +546,7 @@ export class OrchestrationManager extends EventEmitter {
     // Remove the integration worktree; its branch (the run's output) is kept.
     const integrationBranch = run.integration?.branch ?? null
     await this._cleanupIntegration(run)
-    run.phase = 'completed'
-    this._ledger.setStatus(run.runId, 'completed')
+    this._setRunStatus(run, 'completed')
     // M-4: derive + persist report.{json,md} (metrics report with the synthesis
     // narrative prepended) so the artifact survives restarts.
     this._buildAndPersistReport(run.runId)
@@ -560,7 +597,7 @@ export class OrchestrationManager extends EventEmitter {
   // conflict → abort + escalate (the automated fixup worker is E-3 part 3).
   async _acceptImplement(run, subtaskId, sessionId, result) {
     const st = run.subtasks.get(subtaskId)
-    this._ledger.updateSubtask(run.runId, subtaskId, { status: 'merging' })
+    this._setSubtaskStatus(run, subtaskId, 'merging')
     await this._destroySession(run, sessionId)
     if (!st.branch || !st.baseSha) return this._escalateSubtask(run, subtaskId, 'no branch/worktree to merge')
     return this._withMergeLock(run, () => this._mergeAccepted(run, subtaskId, result))
@@ -746,8 +783,7 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   _pauseForBudget(run) {
-    run.phase = 'budget_paused'
-    this._ledger.setStatus(run.runId, 'budget_paused')
+    this._setRunStatus(run, 'budget_paused')
     this.emit('run_budget_paused', { runId: run.runId })
     this._emitRunDelta(run)
   }
@@ -763,8 +799,7 @@ export class OrchestrationManager extends EventEmitter {
     // terminal 'cancelled' status with 'failed' (or double-emit lifecycle
     // events) when an in-flight turn rejects SESSION_GONE on the next tick.
     if (run.cancelled || !this._runs.has(run.runId)) return { runId: run.runId, phase: run.phase }
-    run.phase = 'failed'
-    this._ledger.setStatus(run.runId, 'failed', code)
+    this._setRunStatus(run, 'failed', code)
     // tear down any owned sessions (auto-commits implement worktrees first)
     for (const sid of [...run.ownedSessions.keys()]) await this._destroySession(run, sid)
     await this._cleanupIntegration(run)
@@ -779,6 +814,14 @@ export class OrchestrationManager extends EventEmitter {
     const run = this._runs.get(runId)
     if (!run) return null
     run.cancelled = true
+    // `cancelling` is the teardown-in-progress state (design §3.2:
+    // "any state --cancelRun--> cancelling --> cancelled"). Journaling it BEFORE
+    // the awaits — rather than jumping straight to `cancelled` — is what makes
+    // the FSM's intermediate state real: an observer polling during a slow
+    // teardown (interrupt + auto-commit of every implement worktree) sees
+    // `cancelling`, and a teardown that throws leaves a truthful non-terminal
+    // status instead of a `cancelled` run that was never torn down.
+    this._setRunStatus(run, 'cancelling', reason)
     // interrupt every in-flight owned session, then release (auto-commit → destroy)
     // so no implement worker's uncommitted work is lost.
     for (const sid of [...run.ownedSessions.keys()]) {
@@ -786,7 +829,7 @@ export class OrchestrationManager extends EventEmitter {
     }
     for (const sid of [...run.ownedSessions.keys()]) await this._destroySession(run, sid)
     await this._cleanupIntegration(run)
-    this._ledger.setStatus(runId, 'cancelled', reason)
+    this._setRunStatus(run, 'cancelled', reason)
     this.emit('run_cancelled', { runId, reason })
     this._emitRunDelta(run)
     this._cacheCompletedSnapshot(run)

--- a/packages/server/src/orchestration/run-model.js
+++ b/packages/server/src/orchestration/run-model.js
@@ -32,9 +32,10 @@ const NODE_STATUSES = new Set(RUN_NODE_STATUS_VALUES)
 export const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed', 'cancelled'])
 export const TERMINAL_NODE_STATUSES = new Set(['done', 'skipped', 'failed', 'cancelled', 'interrupted'])
 
-// Legal run-state transitions. `cancelling` and `suspended` are reachable from
-// any non-terminal state (cancel request / daemon restart), handled specially
-// in assertRunTransition rather than enumerated on every row.
+// Legal run-state transitions. `cancelling`, `suspended` and `failed` are
+// reachable from any non-terminal state (cancel request / daemon restart /
+// unrecoverable error), handled specially in assertRunTransition rather than
+// enumerated on every row. Rows therefore describe FORWARD PROGRESS only.
 const RUN_TRANSITIONS = {
   created: ['planning'],
   planning: ['plan_review', 'executing', 'failed'], // executing when autoApprovePlan skips the gate
@@ -50,19 +51,29 @@ const RUN_TRANSITIONS = {
   cancelled: [],
 }
 
-// Legal subtask transitions (the committee loop). `respawning` re-enters
-// `briefing`; a revise loops back to `briefing` (poa) or `executing` (result).
+// Legal subtask transitions (the committee loop). `cancelled`, `interrupted`
+// and `failed` are reachable from any non-terminal state and are handled
+// specially in assertNodeTransition rather than enumerated on every row.
+// `respawning` re-enters `spawning`; a revise loops back to `briefing`.
 const NODE_TRANSITIONS = {
   pending: ['spawning', 'skipped', 'cancelled'],
-  spawning: ['briefing', 'failed', 'respawning'],
+  // The committee-iteration cap is evaluated at the TOP of the loop — i.e. after
+  // a `redelegate` has already re-spawned the worker — so a forced escalation
+  // can fire while the subtask sits in `spawning`.
+  spawning: ['briefing', 'escalated', 'failed', 'respawning'],
   briefing: ['poa_review', 'failed'],
   poa_review: ['executing', 'briefing', 'respawning', 'escalated', 'failed'],
   executing: ['result_review', 'failed'],
-  result_review: ['merging', 'done', 'executing', 'respawning', 'escalated', 'failed'],
+  // `briefing`: the engine re-drives the FULL committee cycle on a result
+  // `revise` (it loops back to the top with the architect's feedback attached to
+  // the later execute turn) rather than re-prompting the same session in place.
+  result_review: ['merging', 'done', 'executing', 'briefing', 'respawning', 'escalated', 'failed'],
   respawning: ['briefing', 'spawning', 'failed'],
   merging: ['done', 'conflict_fixup', 'escalated', 'failed'],
   conflict_fixup: ['merging', 'escalated', 'failed'],
-  escalated: ['briefing', 'done', 'skipped', 'failed'],
+  // `spawning`: a user retry ("retry-with-note") hands the subtask to a FRESH
+  // worker, so it re-enters through the spawn step.
+  escalated: ['briefing', 'spawning', 'done', 'skipped', 'failed'],
   done: [],
   skipped: [],
   failed: [],
@@ -80,24 +91,30 @@ export class TransitionError extends Error {
   }
 }
 
-/** Throw unless `from -> to` is a legal RUN transition. cancelling/suspended are
- *  reachable from any non-terminal state; a self-loop on executing is allowed. */
+/** Throw unless `from -> to` is a legal RUN transition. cancelling/suspended/
+ *  failed are reachable from any non-terminal state; a self-loop on executing is
+ *  allowed. */
 export function assertRunTransition(from, to) {
   if (!RUN_STATUSES.has(from)) throw new TransitionError('run', `${from} (unknown state)`, to)
   if (!RUN_STATUSES.has(to)) throw new TransitionError('run', from, `${to} (unknown state)`)
   if (from === to && to === 'executing') return true
-  if ((to === 'cancelling' || to === 'suspended') && !TERMINAL_RUN_STATUSES.has(from)) return true
+  // `failed` is an ERROR terminal, not forward progress: an unrecoverable engine
+  // error (or a user rejecting the plan / an escalation) can end a run from any
+  // non-terminal state. Enumerating it per-row would leave whichever row was
+  // missed as a fail-closed landmine that wedges a live run.
+  if ((to === 'cancelling' || to === 'suspended' || to === 'failed') && !TERMINAL_RUN_STATUSES.has(from)) return true
   const allowed = RUN_TRANSITIONS[from]
   if (!allowed || !allowed.includes(to)) throw new TransitionError('run', from, to)
   return true
 }
 
-/** Throw unless `from -> to` is a legal SUBTASK transition. cancelled/interrupted
- *  are reachable from any non-terminal state (run cancel / restart). */
+/** Throw unless `from -> to` is a legal SUBTASK transition. cancelled/interrupted/
+ *  failed are reachable from any non-terminal state (run cancel / restart /
+ *  unrecoverable error). */
 export function assertNodeTransition(from, to) {
   if (!NODE_STATUSES.has(from)) throw new TransitionError('node', `${from} (unknown state)`, to)
   if (!NODE_STATUSES.has(to)) throw new TransitionError('node', from, `${to} (unknown state)`)
-  if ((to === 'cancelled' || to === 'interrupted') && !TERMINAL_NODE_STATUSES.has(from)) return true
+  if ((to === 'cancelled' || to === 'interrupted' || to === 'failed') && !TERMINAL_NODE_STATUSES.has(from)) return true
   const allowed = NODE_TRANSITIONS[from]
   if (!allowed || !allowed.includes(to)) throw new TransitionError('node', from, to)
   return true

--- a/packages/server/tests/orchestration-transition-guards.test.js
+++ b/packages/server/tests/orchestration-transition-guards.test.js
@@ -1,0 +1,329 @@
+// #6732 — the run-model FSM guards must be WIRED into the engine's status
+// writes, not merely exported.
+//
+// Two independent properties are covered here, because either one alone is a
+// false green:
+//   1. CONFORMANCE — every status the engine actually journals is a legal
+//      transition from the status the ledger currently holds. (A guard wired
+//      into an engine that emits illegal transitions just breaks the engine.)
+//   2. WIRING — an illegal transition offered to the engine's write choke point
+//      is REJECTED and never journaled, and there is no second, unguarded write
+//      path in the manager. (A legal engine with an unwired guard is #6732.)
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { EventEmitter } from 'node:events'
+
+import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
+import { RunLedger } from '../src/orchestration/run-ledger.js'
+import { TurnDriver } from '../src/orchestration/turn-driver.js'
+import { assertRunTransition, assertNodeTransition, TransitionError } from '../src/orchestration/run-model.js'
+
+const MANAGER_SRC = fileURLToPath(new URL('../src/orchestration/orchestration-manager.js', import.meta.url))
+
+// --- fakes (a trimmed copy of the orchestration-manager harness) ------------
+
+const KIND_RE = /kind "([a-z_]+)"/
+
+function fenced(obj) {
+  return 'Here is my decision.\n\n```chroxy-decision\n' + JSON.stringify(obj) + '\n```'
+}
+
+class FakeSession extends EventEmitter {
+  constructor(sessionId, sm, opts, decide, model) {
+    super()
+    this.sessionId = sessionId
+    this._sm = sm
+    this.opts = opts
+    this._decide = decide
+    this._model = model
+    this.role = opts.metadata?.orchestrationRole ?? null
+    this.destroyed = false
+    this.lastKind = null
+    this.kindCalls = Object.create(null)
+  }
+  setPermissionRules() {}
+  interrupt() {}
+  sendMessage(prompt) {
+    const m = String(prompt).match(KIND_RE)
+    const kind = m ? m[1] : this.lastKind
+    this.lastKind = kind
+    this.kindCalls[kind] = (this.kindCalls[kind] || 0) + 1
+    queueMicrotask(() => {
+      if (this.destroyed) return
+      const out = this._decide({ role: this.role, kind, n: this.kindCalls[kind] })
+      if (out == null) return // sentinel: hang this turn
+      this._sm.emit('session_event', { sessionId: this.sessionId, event: 'stream_delta', data: { messageId: 'm1', delta: fenced(out) } })
+      this._sm.emit('session_event', {
+        sessionId: this.sessionId,
+        event: 'result',
+        data: { model: this._model, cost: 0.01, duration: 5, apiDurationMs: 4, numTurns: 1, usage: { input_tokens: 10, output_tokens: 4 } },
+      })
+    })
+    return Promise.resolve()
+  }
+}
+
+class FakeSM extends EventEmitter {
+  constructor(decide) {
+    super()
+    this.setMaxListeners(0)
+    this._decide = decide
+    this._sessions = new Map()
+    this._n = 0
+  }
+  createSession(opts) {
+    const sessionId = `sess_${++this._n}`
+    const model = opts.metadata?.orchestrationRole === 'architect' ? 'fable-hi' : 'haiku'
+    this._sessions.set(sessionId, new FakeSession(sessionId, this, opts, this._decide, model))
+    return sessionId
+  }
+  getSession(id) { const s = this._sessions.get(id); return s ? { session: s } : null }
+  destroySession(id) {
+    const s = this._sessions.get(id)
+    if (!s) return
+    s.destroyed = true
+    this._sessions.delete(id)
+    this.emit('session_destroyed', { sessionId: id })
+  }
+  listSessions() { return [...this._sessions.keys()] }
+}
+
+const ROLES = {
+  architect: { provider: 'claude-sdk', model: 'fable-hi' },
+  auditWorker: { provider: 'claude-sdk', model: 'haiku' },
+}
+
+// Record every (from -> to) pair the engine journals, WITHOUT validating it
+// inline — a wrapper that threw here would abort the run and hide the rest of
+// the sequence. The recorded trace is validated after the run instead.
+function makeHarness(decide) {
+  const dir = mkdtempSync(join(tmpdir(), 'orch-fsm-'))
+  const sm = new FakeSM(decide)
+  const ledger = new RunLedger({ baseDir: dir })
+  const runTrace = []
+  const nodeTrace = []
+  const origSetStatus = ledger.setStatus.bind(ledger)
+  const origUpdateSubtask = ledger.updateSubtask.bind(ledger)
+  ledger.setStatus = (runId, status, reason = null) => {
+    runTrace.push({ from: ledger.getRun(runId)?.status ?? null, to: status })
+    return origSetStatus(runId, status, reason)
+  }
+  ledger.updateSubtask = (runId, subtaskId, patch) => {
+    const st = ledger.getRun(runId)?.subtasks?.find((s) => s.subtaskId === subtaskId)
+    nodeTrace.push({ subtaskId, from: st?.status ?? null, to: patch?.status })
+    return origUpdateSubtask(runId, subtaskId, patch)
+  }
+  const driver = new TurnDriver({ sessionManager: sm })
+  const mgr = new OrchestrationManager({ sessionManager: sm, ledger, turnDriver: driver, roles: ROLES })
+  const cleanup = () => {
+    mgr.dispose()
+    driver.dispose()
+    ledger.dispose?.()
+    rmSync(dir, { recursive: true, force: true })
+  }
+  return { sm, ledger, mgr, cleanup, runTrace, nodeTrace }
+}
+
+function happyDecider({ role, kind }) {
+  if (role === 'architect') {
+    if (kind === 'epic_plan') {
+      return { kind: 'epic_plan', summary: 'One-area audit', subtasks: [{ title: 'Audit auth', goal: 'Review auth', role: 'audit' }] }
+    }
+    if (kind === 'poa_review') return { kind: 'poa_review', verdict: 'approve' }
+    if (kind === 'result_review') return { kind: 'result_review', verdict: 'approve' }
+    if (kind === 'synthesis') return { kind: 'synthesis', reportMarkdown: '# Report' }
+  }
+  if (kind === 'plan_of_attack') return { kind: 'plan_of_attack', plan: 'Read + grep.', summary: 'PoA' }
+  if (kind === 'work_result') return { kind: 'work_result', summary: 'Found 2 issues.' }
+  throw new Error(`unexpected turn role=${role} kind=${kind}`)
+}
+
+function waitFor(mgr, events, { timeoutMs = 5000 } = {}) {
+  const wanted = new Set(events)
+  const all = new Set([...wanted, 'run_failed'])
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { off(); reject(new Error(`timed out waiting for ${[...wanted].join('|')}`)) }, timeoutMs)
+    const handlers = []
+    const off = () => { clearTimeout(timer); for (const [e, h] of handlers) mgr.off(e, h) }
+    for (const e of all) {
+      const h = (payload) => {
+        if (!wanted.has(e)) { off(); reject(new Error(`unexpected ${e}: ${payload?.code ?? ''} ${payload?.message ?? ''}`)); return }
+        off(); resolve({ event: e, payload })
+      }
+      handlers.push([e, h])
+      mgr.on(e, h)
+    }
+  })
+}
+
+// Replay a recorded trace through the FSM guards; return the first illegal pair.
+function firstIllegal(trace, assertFn) {
+  for (const step of trace) {
+    try { assertFn(step.from, step.to) } catch (err) { return { step, err } }
+  }
+  return null
+}
+
+// --- 1. conformance --------------------------------------------------------
+
+test('#6732 every run status the engine journals on a full audit run is a legal FSM transition', async () => {
+  const { mgr, cleanup, runTrace } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'approve' })
+    await done
+
+    // POSITIVE CONTROL: the wrapper really observed the engine's writes.
+    // (Passes on unmodified source — proves the fixture takes effect.)
+    assert.ok(runTrace.length >= 4, `expected the run trace to be populated, got ${JSON.stringify(runTrace)}`)
+    assert.deepEqual(runTrace[0], { from: 'created', to: 'planning' })
+    assert.deepEqual(runTrace.at(-1), { from: 'synthesizing', to: 'completed' })
+
+    const bad = firstIllegal(runTrace, assertRunTransition)
+    assert.equal(bad, null, `engine journaled an illegal RUN transition: ${bad?.err?.message}`)
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6732 every subtask status the engine journals on a full audit run is a legal FSM transition', async () => {
+  const { mgr, cleanup, nodeTrace } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+
+    // POSITIVE CONTROL: the subtask wrapper really observed the engine's writes.
+    assert.ok(nodeTrace.length >= 4, `expected the node trace to be populated, got ${JSON.stringify(nodeTrace)}`)
+    assert.equal(nodeTrace[0].from, 'pending')
+    assert.deepEqual(nodeTrace.at(-1).to, 'done')
+
+    const bad = firstIllegal(nodeTrace, assertNodeTransition)
+    assert.equal(bad, null, `engine journaled an illegal NODE transition: ${bad?.err?.message}`)
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6732 the redelegate + committee-cap path journals only legal subtask transitions', async () => {
+  // Every poa_review comes back `redelegate`, so the subtask cycles
+  // briefing -> poa_review -> respawning -> ... until the iteration cap forces
+  // an escalation — the loop shape most likely to produce an illegal write.
+  const decide = ({ role, kind }) => {
+    if (role === 'architect' && kind === 'epic_plan') {
+      return { kind: 'epic_plan', summary: 'x', subtasks: [{ title: 'A', goal: 'g', role: 'audit' }] }
+    }
+    if (role === 'architect' && kind === 'poa_review') return { kind: 'poa_review', verdict: 'redelegate', feedback: 'again' }
+    return happyDecider({ role, kind })
+  }
+  const { mgr, cleanup, nodeTrace } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    await gated
+
+    // POSITIVE CONTROL: the redelegate loop really ran (respawning + escalated).
+    const seen = nodeTrace.map((s) => s.to)
+    assert.ok(seen.includes('respawning'), `expected a respawning write, got ${seen.join(',')}`)
+    assert.ok(seen.includes('escalated'), `expected an escalated write, got ${seen.join(',')}`)
+
+    const bad = firstIllegal(nodeTrace, assertNodeTransition)
+    assert.equal(bad, null, `engine journaled an illegal NODE transition: ${bad?.err?.message}`)
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6732 cancelRun journals only legal run transitions', async () => {
+  const decide = ({ role, kind }) => (kind === 'epic_plan' ? null : happyDecider({ role, kind })) // hang the plan turn
+  const { mgr, cleanup, runTrace } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const startP = mgr.startRun(rec.runId)
+    await new Promise((r) => setTimeout(r, 10))
+    await mgr.cancelRun(rec.runId)
+    await startP
+
+    // POSITIVE CONTROL: the cancel really landed terminal.
+    assert.equal(runTrace.at(-1).to, 'cancelled')
+
+    const bad = firstIllegal(runTrace, assertRunTransition)
+    assert.equal(bad, null, `engine journaled an illegal RUN transition: ${bad?.err?.message}`)
+  } finally {
+    cleanup()
+  }
+})
+
+// --- 2. wiring (fail-closed) ------------------------------------------------
+
+test('#6732 an illegal RUN transition is rejected fail-closed and never journaled', async () => {
+  const { mgr, ledger, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo' })
+    const run = mgr._runs.get(rec.runId)
+    assert.equal(ledger.getRun(rec.runId).status, 'created') // positive control
+
+    assert.throws(() => mgr._setRunStatus(run, 'completed'), (err) => {
+      assert.ok(err instanceof TransitionError, `expected TransitionError, got ${err?.name}: ${err?.message}`)
+      assert.equal(err.code, 'ILLEGAL_TRANSITION')
+      return true
+    })
+    assert.equal(ledger.getRun(rec.runId).status, 'created', 'the illegal status must NOT be journaled')
+    assert.equal(run.phase, 'created', 'the engine mirror must not advance either')
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6732 an illegal SUBTASK transition is rejected fail-closed and never journaled', async () => {
+  const { mgr, ledger, cleanup } = makeHarness(happyDecider)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: false })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    await gated
+    const run = mgr._runs.get(rec.runId)
+    const subtaskId = [...run.subtasks.keys()][0]
+    assert.equal(ledger.getRun(rec.runId).subtasks[0].status, 'pending') // positive control
+
+    assert.throws(() => mgr._setSubtaskStatus(run, subtaskId, 'done'), (err) => {
+      assert.ok(err instanceof TransitionError, `expected TransitionError, got ${err?.name}: ${err?.message}`)
+      assert.equal(err.code, 'ILLEGAL_TRANSITION')
+      return true
+    })
+    assert.equal(ledger.getRun(rec.runId).subtasks[0].status, 'pending', 'the illegal status must NOT be journaled')
+  } finally {
+    cleanup()
+  }
+})
+
+// --- 3. no second, unguarded write path ------------------------------------
+
+test('#6732 the manager has exactly one guarded run-status and one guarded subtask-status write path', () => {
+  const src = readFileSync(MANAGER_SRC, 'utf8')
+  // POSITIVE CONTROL: the file was read and the patterns are not phantoms.
+  assert.ok(src.length > 1000, 'orchestration-manager.js should be non-trivial')
+  assert.ok(src.includes('_ledger.setStatus('), 'sanity: the setStatus pattern must match somewhere')
+  assert.ok(src.includes('_ledger.updateSubtask('), 'sanity: the updateSubtask pattern must match somewhere')
+
+  const lines = src.split('\n')
+  const setStatusLines = lines.filter((l) => l.includes('_ledger.setStatus('))
+  const updateLines = lines.filter((l) => l.includes('_ledger.updateSubtask('))
+  assert.equal(setStatusLines.length, 1, `every run-status write must go through _setRunStatus; found ${setStatusLines.length} raw _ledger.setStatus( call sites:\n${setStatusLines.join('\n')}`)
+  assert.equal(updateLines.length, 1, `every subtask-status write must go through _setSubtaskStatus; found ${updateLines.length} raw _ledger.updateSubtask( call sites:\n${updateLines.join('\n')}`)
+
+  // and those single sites must be the asserting helpers
+  assert.match(src, /_setRunStatus\s*\([^)]*\)\s*\{[\s\S]{0,600}?assertRunTransition\(/, '_setRunStatus must call assertRunTransition')
+  assert.match(src, /_setSubtaskStatus\s*\([^)]*\)\s*\{[\s\S]{0,600}?assertNodeTransition\(/, '_setSubtaskStatus must call assertNodeTransition')
+})

--- a/packages/server/tests/orchestration-transition-guards.test.js
+++ b/packages/server/tests/orchestration-transition-guards.test.js
@@ -265,6 +265,72 @@ test('#6732 cancelRun journals only legal run transitions', async () => {
   }
 })
 
+// The two remaining table reconciliations (`result_review -> briefing` on a
+// result revise, `escalated -> spawning` on a user retry) are LOAD-BEARING under
+// the fail-closed posture: drop either row and the corresponding live run dies
+// with a TransitionError mid-flight. Neither is reachable from the happy path,
+// the redelegate loop or the cancel path above, so each gets its own driven run
+// — otherwise the whole suite stays green while the row rots.
+
+test('#6732 a result-review revise re-drives briefing and journals only legal subtask transitions', async () => {
+  // First result_review comes back `revise`, so the committee loop returns to
+  // the TOP of the cycle (fresh plan-of-attack) rather than re-prompting in
+  // place: result_review -> briefing. Second time it approves so the run ends.
+  const decide = ({ role, kind, n }) => {
+    if (role === 'architect' && kind === 'result_review' && n === 1) {
+      return { kind: 'result_review', verdict: 'revise', feedback: 'tighten it' }
+    }
+    return happyDecider({ role, kind })
+  }
+  const { mgr, cleanup, nodeTrace } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+
+    // POSITIVE CONTROL: the revise really re-entered briefing from result_review.
+    const pairs = nodeTrace.map((s) => `${s.from} -> ${s.to}`)
+    assert.ok(pairs.includes('result_review -> briefing'), `expected a result_review -> briefing write, got:\n${pairs.join('\n')}`)
+
+    const bad = firstIllegal(nodeTrace, assertNodeTransition)
+    assert.equal(bad, null, `engine journaled an illegal NODE transition: ${bad?.err?.message}`)
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6732 an escalation retry re-spawns from escalated and journals only legal subtask transitions', async () => {
+  // First poa_review escalates; the user approves the escalation gate, which
+  // hands the subtask to a FRESH worker — so it re-enters through the spawn
+  // step: escalated -> spawning. Second poa_review approves so the run ends.
+  const decide = ({ role, kind, n }) => {
+    if (role === 'architect' && kind === 'poa_review' && n === 1) {
+      return { kind: 'poa_review', verdict: 'escalate', feedback: 'needs a human' }
+    }
+    return happyDecider({ role, kind })
+  }
+  const { mgr, cleanup, nodeTrace } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const gated = waitFor(mgr, ['gate_opened'])
+    await mgr.startRun(rec.runId)
+    const { payload } = await gated
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.resolveGate(rec.runId, payload.gate.gateId, { decision: 'approve' })
+    await done
+
+    // POSITIVE CONTROL: the retry really re-spawned out of `escalated`.
+    const pairs = nodeTrace.map((s) => `${s.from} -> ${s.to}`)
+    assert.ok(pairs.includes('escalated -> spawning'), `expected an escalated -> spawning write, got:\n${pairs.join('\n')}`)
+
+    const bad = firstIllegal(nodeTrace, assertNodeTransition)
+    assert.equal(bad, null, `engine journaled an illegal NODE transition: ${bad?.err?.message}`)
+  } finally {
+    cleanup()
+  }
+})
+
 // --- 2. wiring (fail-closed) ------------------------------------------------
 
 test('#6732 an illegal RUN transition is rejected fail-closed and never journaled', async () => {


### PR DESCRIPTION
## Defect

`run-model.js` exports `assertRunTransition` / `assertNodeTransition` with full
legal-transition tables — and **nothing called them**. Verified on main with
`command grep` (plus a positive control that the pattern matches at all): three
hits, all inside the definition file itself (a comment on :37 and the two
`export function` lines on :85/:97), zero call sites in `orchestration-manager.js`
or `run-ledger.js`. The FSM was documentation, not enforcement — an engine bug
producing `planning -> synthesizing` or `pending -> done` was journaled silently.

Worse, once the guards are actually run against the live write path, the engine
turns out to violate its own FSM today:

- `pending -> briefing` — `_spawnWorker` skipped the `spawning` hop the design
  mandates (§3.3 `pending -> spawning -> briefing`), and wrote `briefing` a
  second time immediately before the committee loop wrote it again.
- `<any> -> cancelled` — `cancelRun` jumped straight to the terminal status,
  never journaling the `cancelling` teardown state (§3.2
  `any state --cancelRun--> cancelling --> cancelled`).

## Every status-write call site (all 17), and where each now goes

Wiring a guard into *some* write paths is worse than none — it advertises
coverage it does not have — so every site was enumerated first and all 17 now
route through exactly two choke-point helpers.

`ledger.setStatus` (8) -> `_setRunStatus(run, next, reason)`:

| site | transition |
|---|---|
| `startRun` | `created -> planning` |
| `startRun` (gate opened) | `planning -> plan_review` |
| `_beginExecuting` | `planning`/`plan_review` -> `executing` |
| `_synthesize` | `executing -> synthesizing` |
| `_synthesize` | `synthesizing -> completed` |
| `_pauseForBudget` | `executing -> budget_paused` |
| `_failRun` | `<non-terminal> -> failed` |
| `cancelRun` | `<non-terminal> -> cancelling -> cancelled` (now two writes) |

`ledger.updateSubtask` (9) -> `_setSubtaskStatus(run, subtaskId, next)`:

| site | transition |
|---|---|
| `_spawnWorker` | `pending`/`respawning`/`escalated` -> `spawning` (was `briefing`) |
| `_runSubtask` step 1 | `spawning`/`poa_review`/`result_review` -> `briefing` |
| `_runSubtask` step 2 | `briefing -> poa_review` |
| `_runSubtask` step 3 | `poa_review -> executing` |
| `_runSubtask` step 4 | `executing -> result_review` |
| `_respawnWorker` | `poa_review`/`result_review` -> `respawning` |
| `_finishSubtask` | `<any> -> done`/`failed`/`skipped` |
| `_escalateSubtask` | `<any> -> escalated` |
| `_acceptImplement` | `result_review -> merging` |

## Fix

- **Two guarded helpers** assert against the ledger's *current* status (the
  journal is ground truth, not the engine's `run.phase` mirror) and throw
  `TransitionError` / `ILLEGAL_TRANSITION` **before** journaling anything.
  `_setRunStatus` also owns the `run.phase` assignment, so the mirror and the
  journal can no longer drift.
- **Engine fixes** for the two divergences above: `_spawnWorker` journals
  `spawning` before `createSession` (which is also what a `SessionLimitError`
  now leaves behind, instead of a lie), and `cancelRun` journals `cancelling`
  before its teardown awaits — so a slow teardown is observable and one that
  throws leaves a truthful non-terminal status rather than a `cancelled` run
  that was never torn down.
- **Table reconciliation** for three places where the shipped engine is
  legitimately wider than the design prose (each commented in `run-model.js`
  and recorded in `docs/design/orchestration/engine.md`): the committee cap is
  checked at the *top* of the loop so an escalation can fire from `spawning`; a
  result `revise` re-drives the full cycle (`result_review -> briefing`) rather
  than re-prompting in place; a user retry re-spawns (`escalated -> spawning`).
- **`failed` is now global**, like `cancelled`/`cancelling`/`interrupted`/
  `suspended`: legal from any non-terminal state. Rows describe forward progress
  only. Enumerating `failed` per row would leave whichever row was missed as a
  fail-closed landmine that wedges a live run mid-teardown (`plan_review` and
  `budget_paused` were both already reachable and both lacked it).

## Verification

New `packages/server/tests/orchestration-transition-guards.test.js` (7 tests)
covers the two properties that are each a false green alone — a legal engine
with an unwired guard is exactly #6732, and a wired guard on a non-conforming
engine just breaks the engine:

1. **Conformance** (4 tests) — drive real runs (happy path, redelegate +
   committee-cap, cancel) with the ledger wrapped to *record* every
   `(from -> to)` pair, then replay the trace through the guards.
2. **Wiring / fail-closed** (2 tests) — an illegal transition offered to each
   helper throws `TransitionError`, is **not** journaled, and does not advance
   the engine mirror.
3. **No second write path** (1 test) — source-asserts exactly one raw
   `_ledger.setStatus(` / `_ledger.updateSubtask(` call site in the manager, and
   that each is the asserting helper. This is what keeps a later change (e.g.
   #6733, same files) from re-introducing an unguarded path.

**RED first**, on unmodified source — 6 of 7 failed:

```
not ok 2 - engine journaled an illegal NODE transition: illegal node transition: pending -> briefing
not ok 3 - engine journaled an illegal NODE transition: illegal node transition: pending -> briefing
not ok 4 - engine journaled an illegal RUN transition: illegal run transition: planning -> cancelled
not ok 5 - expected TransitionError, got TypeError: mgr._setRunStatus is not a function
not ok 6 - expected TransitionError, got TypeError: mgr._setSubtaskStatus is not a function
not ok 7 - every run-status write must go through _setRunStatus; found 8 raw
           _ledger.setStatus( call sites: [...]  8 !== 1
# tests 7 / # pass 1 / # fail 6
```

**Positive control** — test 1 (run-status conformance on the happy path) *passed*
on unmodified source, proving the ledger-wrapping fixture actually took effect
rather than the harness silently never running. Each conformance test also
asserts its trace is populated and hit the expected states (`respawning` +
`escalated` for the redelegate loop, `cancelled` for the cancel path) before
checking legality, so an empty trace cannot pass for free.

**Mutation checks** — two independent mutations, each confirmed red, then reverted:

- removed the `assertRunTransition` call from `_setRunStatus` -> tests 5 and 7 red.
- removed the `spawning` write from `_spawnWorker` -> tests 2 and 3 red.

**Suites:** `tests/orchestration-*.test.js` — 193/193 pass (was 186 before; the
whole existing orchestration suite is unchanged and green, including the
`PLAN_REJECTED -> failed` and cancel tests).

**Lints:** all five `packages/server/scripts/lint-*.sh` pass
(tests-state-file-path, session-opt-forwarding, logger-session-scoping,
ws-index-mutations, claude-family-explicit); eslint clean on the two changed
source files.

Closes #6732.
