### PR TITLE
fix(dashboard): stop the scheduler panel presenting non-firing tasks as live

### DIFF
--- a/packages/dashboard/src/components/ScheduledTasksSection.test.tsx
+++ b/packages/dashboard/src/components/ScheduledTasksSection.test.tsx
@@ -754,3 +754,229 @@ describe('ScheduledTasksSection — a failed read is visible', () => {
     expect(screen.queryByTestId('sched-read-error')).toBeNull()
   })
 })
+
+/**
+ * #7026 — a task that CANNOT FIRE must not present as if it will.
+ *
+ * The shared health derivation answers "how did the last run go?", not "will
+ * this fire?". So a task whose `lastRun.status === 'success'` rendered a green
+ * `OK` chip and a live `next: <future timestamp>` while nothing was firing at
+ * all — the red gate banner above it was the only contradicting signal, and it
+ * is the one an operator skims past.
+ *
+ * The predicate is `engineArmed`, the RUNTIME truth, NOT the persisted `enabled`
+ * flag. Keying on the saved flag would repeat the C2 mistake in miniature: with
+ * the gate saved DISABLED on a still-armed engine the tasks below ARE about to
+ * fire, and blanking their next-run time would be false in exactly the
+ * dangerous direction.
+ */
+describe('ScheduledTasksSection — a task that cannot fire never reads as live (#7026)', () => {
+  const LIVE = new Date(1900000000000).toLocaleString()
+  const GATE_SAVED_OFF_STILL_ARMED = {
+    enabled: false, engineArmed: true, restartRequired: true, source: 'config' as const,
+  }
+  const GATE_SAVED_ON_NOT_ARMED = {
+    enabled: true, engineArmed: false, restartRequired: true, source: 'config' as const,
+  }
+
+  // POSITIVE CONTROL for the whole block: on the very same task, with the engine
+  // armed, the chip IS green and the next-run cell IS the live timestamp.
+  // Without it every "not ok" / "no timestamp" assertion below would pass for
+  // free on a fixture that never took effect.
+  it('POSITIVE CONTROL: with the engine armed the same task is green with a live next-run time', () => {
+    resetStore({ selectedScheduledTaskId: 'task-1', scheduledTasks: mkSnapshot({ scheduler: GATE_ON }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-health-task-1').getAttribute('data-accent')).toBe('ok')
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).toContain(LIVE)
+    expect(screen.getByTestId('sched-detail-next').textContent).toContain(LIVE)
+  })
+
+  it('does not style a successful task green while no engine is armed', () => {
+    resetStore({ selectedScheduledTaskId: 'task-1', scheduledTasks: mkSnapshot({ scheduler: GATE_OFF }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    const row = screen.getByTestId('sched-health-task-1')
+    expect(row.getAttribute('data-accent')).not.toBe('ok')
+    expect(screen.getByTestId('sched-detail-health').getAttribute('data-accent')).not.toBe('ok')
+    // The CLI-identical TAG is untouched — only the styling degrades, exactly
+    // the shape quarantine already uses.
+    expect(row.textContent).toContain('OK')
+  })
+
+  it('replaces the next-run timestamp with a reason in BOTH the row and the detail', () => {
+    resetStore({ selectedScheduledTaskId: 'task-1', scheduledTasks: mkSnapshot({ scheduler: GATE_OFF }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    for (const id of ['sched-row-next-task-1', 'sched-detail-next']) {
+      const cell = screen.getByTestId(id)
+      expect(cell.textContent, id).not.toContain(LIVE)
+      expect(cell.textContent, id).toContain('—')
+      expect(cell.textContent, id).toMatch(/scheduler .*not running/i)
+    }
+  })
+
+  it('says the same thing when the gate is SAVED ON but no engine is armed yet', () => {
+    // Nothing fires until the daemon restarts, so a live timestamp is just as
+    // false here as with the flag off.
+    resetStore({ selectedScheduledTaskId: 'task-1', scheduledTasks: mkSnapshot({ scheduler: GATE_SAVED_ON_NOT_ARMED }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).not.toContain(LIVE)
+    expect(screen.getByTestId('sched-health-task-1').getAttribute('data-accent')).not.toBe('ok')
+  })
+
+  it('KEEPS the live next-run time when the gate is saved OFF but the engine is STILL FIRING', () => {
+    // The dangerous state. These tasks really are about to run unattended;
+    // blanking the time (or greying the chip) would understate that.
+    resetStore({ selectedScheduledTaskId: 'task-1', scheduledTasks: mkSnapshot({ scheduler: GATE_SAVED_OFF_STILL_ARMED }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).toContain(LIVE)
+    expect(screen.getByTestId('sched-detail-next').textContent).toContain(LIVE)
+    expect(screen.getByTestId('sched-health-task-1').getAttribute('data-accent')).toBe('ok')
+  })
+
+  it('a REFUSED task shows no live next-run time and no green chip, even with the engine armed', () => {
+    const refusal = "provider 'claude-tui' routes permission prompts through the permission hook…"
+    resetStore({
+      selectedScheduledTaskId: 'task-1',
+      scheduledTasks: mkSnapshot({ tasks: [mkTask({ providerRefusal: refusal })] }),
+    })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).not.toContain(LIVE)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).toMatch(/will not fire/)
+    expect(screen.getByTestId('sched-health-task-1').getAttribute('data-accent')).not.toBe('ok')
+    expect(screen.getByTestId('sched-detail-next').textContent).toMatch(/will not fire/)
+  })
+
+  it('claims nothing about firing when the gate is UNKNOWN', () => {
+    // No snapshot gate = we have not read the daemon. Asserting "not running"
+    // here would be the same zero-data claim the banner refuses to make.
+    resetStore({ selectedScheduledTaskId: 'task-1', scheduledTasks: mkSnapshot({ scheduler: undefined }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).not.toMatch(/not running/i)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).toContain(LIVE)
+  })
+
+  it('a PAUSED task still says paused (the task-level reason wins)', () => {
+    resetStore({ scheduledTasks: mkSnapshot({ scheduler: GATE_OFF, tasks: [mkTask({ enabled: false })] }) })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).toMatch(/paused/)
+  })
+})
+
+/**
+ * #7049 — the edit form must send PATCH semantics, not a full round-trip of the
+ * snapshot it was seeded from.
+ *
+ * Two losses come out of the same shape. The store REPLACES `target` wholesale
+ * (`scheduled-task-store.js`: `if ('target' in patch) next.target = …`), so a
+ * complete `target` bag built by a form with no `permissionMode` input erased a
+ * stored one on ANY unrelated save. And every text field is seeded from the
+ * CLAMPED wire snapshot, so echoing it back persisted the shortened value.
+ *
+ * The fix is NOT a new input for `permissionMode` (that is a product decision,
+ * #6761) — it is to stop sending fields the operator did not touch.
+ */
+describe('ScheduledTasksSection — the edit form sends only what the operator changed (#7049)', () => {
+  const STORED_TARGET = { provider: 'claude-sdk', permissionMode: 'plan' }
+  const LONG_NAME = 'n'.repeat(256) // a >256-char stored name, as clampWire projects it
+
+  function openEdit(over: Record<string, unknown> = {}) {
+    resetStore({
+      selectedScheduledTaskId: 'task-1',
+      scheduledTasks: mkSnapshot({ tasks: [mkTask({ target: STORED_TARGET, ...over })] }),
+    })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    fireEvent.click(screen.getByTestId('sched-edit'))
+  }
+
+  const lastPatch = () => {
+    const calls = sendActionMock.mock.calls
+    const call = calls[calls.length - 1] as unknown as [string, Record<string, unknown>]
+    expect(call[0]).toBe('update')
+    return call[1].task as Record<string, unknown>
+  }
+
+  it('omits `target` entirely on an unrelated save, so a stored permissionMode survives', () => {
+    openEdit()
+    fireEvent.change(screen.getByTestId('sched-form-prompt'), { target: { value: 'a different prompt' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    const patch = lastPatch()
+    expect(patch.prompt).toBe('a different prompt')
+    expect('target' in patch).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: editing a target field DOES send target, carrying permissionMode through', () => {
+    // Without this the assertion above would also pass on a form that simply
+    // never sends `target` at all — a different bug.
+    openEdit()
+    fireEvent.change(screen.getByTestId('sched-form-model'), { target: { value: 'opus' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect(lastPatch().target).toEqual({ provider: 'claude-sdk', model: 'opus', permissionMode: 'plan' })
+  })
+
+  it('does not write a clamped name back truncated when the operator did not touch it', () => {
+    openEdit({ name: LONG_NAME })
+    fireEvent.change(screen.getByTestId('sched-form-prompt'), { target: { value: 'p2' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect('name' in lastPatch()).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: an edited name IS sent', () => {
+    openEdit({ name: LONG_NAME })
+    fireEvent.change(screen.getByTestId('sched-form-name'), { target: { value: 'renamed' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect(lastPatch().name).toBe('renamed')
+  })
+
+  it('omits an untouched prompt and an untouched cadence', () => {
+    openEdit()
+    fireEvent.change(screen.getByTestId('sched-form-name'), { target: { value: 'renamed' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    const patch = lastPatch()
+    expect('prompt' in patch).toBe(false)
+    expect('cadence' in patch).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: an edited cadence IS sent', () => {
+    openEdit()
+    fireEvent.change(screen.getByTestId('sched-form-cron'), { target: { value: '30 2 * * *' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect(lastPatch().cadence).toEqual({ kind: 'cron', expression: '30 2 * * *' })
+  })
+
+  it('preserves an interval `anchor` the form does not own', () => {
+    // Same defect class: a field the form cannot express must not be destroyed
+    // by a save that never mentioned it.
+    openEdit({ cadence: { kind: 'interval', everyMs: 3600000, anchor: 1700000000000 } })
+    fireEvent.change(screen.getByTestId('sched-form-name'), { target: { value: 'renamed' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect('cadence' in lastPatch()).toBe(false)
+
+    cleanup()
+    openEdit({ cadence: { kind: 'interval', everyMs: 3600000, anchor: 1700000000000 } })
+    fireEvent.change(screen.getByTestId('sched-form-interval'), { target: { value: '15' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect(lastPatch().cadence).toEqual({ kind: 'interval', everyMs: 900000, anchor: 1700000000000 })
+  })
+
+  it('clearing a target field still clears it', () => {
+    openEdit()
+    fireEvent.change(screen.getByTestId('sched-form-provider'), { target: { value: '' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect(lastPatch().target).toEqual({ permissionMode: 'plan' })
+  })
+
+  it('CREATE is unaffected — it still sends the complete payload it composed', () => {
+    resetStore({ scheduledTasks: mkSnapshot() })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    fireEvent.click(screen.getByTestId('sched-new'))
+    fireEvent.change(screen.getByTestId('sched-form-prompt'), { target: { value: 'do the thing' } })
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    expect(sendActionMock).toHaveBeenCalledWith('create', {
+      task: {
+        name: null,
+        prompt: 'do the thing',
+        cadence: { kind: 'cron', expression: '0 9 * * *' },
+        target: {},
+      },
+    })
+  })
+})

--- a/packages/dashboard/src/components/ScheduledTasksSection.test.tsx
+++ b/packages/dashboard/src/components/ScheduledTasksSection.test.tsx
@@ -859,6 +859,43 @@ describe('ScheduledTasksSection — a task that cannot fire never reads as live 
     render(<ScheduledTasksSection now={() => 1900000000000} />)
     expect(screen.getByTestId('sched-row-next-task-1').textContent).toMatch(/paused/)
   })
+
+  // The FOURTH way a listed task silently never runs, and the one the first cut
+  // of this fix missed. `_quarantine()` (scheduler.js) writes only `lastRun`; the
+  // store then RECOMPUTES `nextRun` from the cadence, so the record keeps a real
+  // future timestamp while `_tick()` skips the task on `_quarantined.has(id)`
+  // until the daemon restarts. The chip was already `bad` via the long-standing
+  // `quarantined` degrade — it is the next-run cell that kept claiming a fire
+  // time, which is precisely the presentation #7026 exists to stop.
+  it('a QUARANTINED task shows no live next-run time, in BOTH the row and the detail', () => {
+    resetStore({
+      selectedScheduledTaskId: 'task-1',
+      scheduledTasks: mkSnapshot({
+        scheduler: GATE_ON,
+        tasks: [mkTask({
+          quarantined: true,
+          lastRun: { at: 1800000000000, status: 'refused', error: 'quarantined until daemon restart: its run outcome could not be recorded' },
+        })],
+      }),
+    })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    // POSITIVE CONTROL: the fixture took effect — the quarantine degrade is live.
+    expect(screen.getByTestId('sched-health-task-1').getAttribute('data-accent')).toBe('bad')
+    for (const id of ['sched-row-next-task-1', 'sched-detail-next']) {
+      const cell = screen.getByTestId(id)
+      expect(cell.textContent, id).not.toContain(LIVE)
+      expect(cell.textContent, id).toMatch(/quarantined/i)
+    }
+  })
+
+  it('POSITIVE CONTROL: the same task un-quarantined keeps its live next-run time', () => {
+    resetStore({
+      selectedScheduledTaskId: 'task-1',
+      scheduledTasks: mkSnapshot({ scheduler: GATE_ON, tasks: [mkTask({ quarantined: false })] }),
+    })
+    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    expect(screen.getByTestId('sched-row-next-task-1').textContent).toContain(LIVE)
+  })
 })
 
 /**
@@ -876,15 +913,27 @@ describe('ScheduledTasksSection — a task that cannot fire never reads as live 
  */
 describe('ScheduledTasksSection — the edit form sends only what the operator changed (#7049)', () => {
   const STORED_TARGET = { provider: 'claude-sdk', permissionMode: 'plan' }
-  const LONG_NAME = 'n'.repeat(256) // a >256-char stored name, as clampWire projects it
+  // Exactly the wire cap: this is what `clampWire` PROJECTS a longer stored name
+  // down to, which is what the form is seeded with. The full stored value is
+  // longer and this surface can never see it.
+  const LONG_NAME = 'n'.repeat(256)
 
   function openEdit(over: Record<string, unknown> = {}) {
     resetStore({
       selectedScheduledTaskId: 'task-1',
       scheduledTasks: mkSnapshot({ tasks: [mkTask({ target: STORED_TARGET, ...over })] }),
     })
-    render(<ScheduledTasksSection now={() => 1900000000000} />)
+    view = render(<ScheduledTasksSection now={() => 1900000000000} />)
     fireEvent.click(screen.getByTestId('sched-edit'))
+  }
+
+  // Re-render the section in place (the modal is NOT remounted), so an open form
+  // sees a refreshed `task` prop exactly as it would when the daemon re-emits the
+  // snapshot. The mocked store is a plain object, so a bare mutation of it would
+  // never reach the tree — hence the explicit rerender.
+  let view: ReturnType<typeof render> | null = null
+  const rerenderSection = () => {
+    view?.rerender(<ScheduledTasksSection now={() => 1900000000000} />)
   }
 
   const lastPatch = () => {
@@ -978,5 +1027,44 @@ describe('ScheduledTasksSection — the edit form sends only what the operator c
         target: {},
       },
     })
+  })
+
+  /**
+   * The seed must survive a SNAPSHOT REFRESH landing while the modal is open.
+   *
+   * The daemon re-emits the whole `scheduled_tasks` snapshot after every accepted
+   * mutation from ANY client, so `selected` — and therefore this modal's `task`
+   * prop — is a fresh object mid-edit. Re-deriving the seed on that render points
+   * "did the operator change this?" at the NEW server value, and every field the
+   * operator never touched then differs from its seed and is sent: the exact
+   * whole-bag write-back, with a stale value, that patch semantics exists to
+   * stop. The seed has to be captured once for the LIFE of the modal.
+   */
+  it('keeps its seed across a snapshot refresh, so an untouched field is still omitted', () => {
+    openEdit({ name: LONG_NAME })
+    fireEvent.change(screen.getByTestId('sched-form-prompt'), { target: { value: 'p2' } })
+    // Another client renames the task; the daemon re-emits the snapshot.
+    storeState.scheduledTasks = mkSnapshot({
+      tasks: [mkTask({ target: STORED_TARGET, name: 'renamed elsewhere' })],
+    })
+    rerenderSection()
+    fireEvent.click(screen.getByTestId('sched-form-submit'))
+    const patch = lastPatch()
+    // POSITIVE CONTROL: the fixture took effect — the edit the operator DID make
+    // is in the patch, so an empty/absent patch cannot be why `name` is missing.
+    expect(patch.prompt).toBe('p2')
+    expect('name' in patch).toBe(false)
+    expect('target' in patch).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: the refreshed prop is genuinely delivered to the open modal', () => {
+    // Without this, the assertion above would also pass on a rerender that never
+    // reached the modal at all — a fixture that did nothing.
+    openEdit({ name: 'nightly sweep' })
+    storeState.scheduledTasks = mkSnapshot({
+      tasks: [mkTask({ target: STORED_TARGET, name: 'renamed elsewhere' })],
+    })
+    rerenderSection()
+    expect(screen.getByTestId('sched-detail-name').textContent).toBe('renamed elsewhere')
   })
 })

--- a/packages/dashboard/src/components/ScheduledTasksSection.tsx
+++ b/packages/dashboard/src/components/ScheduledTasksSection.tsx
@@ -18,6 +18,10 @@
  *    never fired, is paused, was refused, timed out, was skipped, or is
  *    quarantined can never render as healthy, and an unrecognized future status
  *    lands on `ERROR` rather than falling through to something friendlier.
+ *    A tag describes the last RUN, though, not whether the task will FIRE — so
+ *    a task this panel knows cannot fire (paused, refused, or no armed engine)
+ *    also loses the green tone and its next-run timestamp (#7026,
+ *    `whyTaskWillNotFire`). The tag itself stays CLI-identical.
  * 2. THE GATE IS SHOWN FIRST. Scheduled execution is OFF by default. A list of
  *    tasks presented without that fact is misleading — they are saved, and none
  *    of them will fire — so the banner is the first thing in the section, and it
@@ -40,7 +44,12 @@
  */
 import { useEffect, useMemo, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
-import type { ScheduledTask, ScheduledTaskCadence, ScheduledTaskInput } from '@chroxy/protocol'
+import type {
+  ScheduledTask,
+  ScheduledTaskCadence,
+  ScheduledTaskInput,
+  SchedulerGateState,
+} from '@chroxy/protocol'
 import { deriveScheduledTaskHealth } from '@chroxy/protocol'
 import { formatGeneratedAgo } from './ControlRoomSection'
 import { Modal } from './Modal'
@@ -142,12 +151,82 @@ function describeLastRun(task: ScheduledTask): string {
 }
 
 /**
+ * #7026 — WHY this task cannot fire, or null when nothing is stopping it.
+ *
+ * The shared health derivation answers "how did the last run go?"; this answers
+ * "will it fire?", which is a different question with a different input set (the
+ * snapshot's gate, not the task record). Keeping them separate is the point: the
+ * tag stays CLI-identical while the panel stops presenting a task as live.
+ *
+ * The gate half keys on `engineArmed`, the RUNTIME truth — NOT the persisted
+ * `enabled` flag. That distinction is the same one the banner makes (#6871 C2)
+ * and it matters in both directions:
+ *
+ *   - gate saved OFF but the engine STILL ARMED → the tasks below really are
+ *     about to run unattended. Blanking their next-run time would understate
+ *     the one state that endangers the operator, so `null` is returned.
+ *   - gate saved ON but NO engine armed → nothing fires until a daemon restart,
+ *     so a live timestamp would be just as false as with the flag off.
+ *
+ * A `null` gate is UNKNOWN (not read from the daemon), and this claims nothing
+ * there — the same posture as `GateBanner`'s UNKNOWN branch.
+ *
+ * Precedence runs most-specific first: a paused/refused task stays paused/refused
+ * even once the gate is fixed, so naming the durable reason is more useful than
+ * naming the global one — which the banner states at the top of the section
+ * anyway.
+ */
+type NoFireReason = 'paused' | 'refused' | 'engine-not-armed'
+
+function whyTaskWillNotFire(
+  task: ScheduledTask,
+  gate: SchedulerGateState | null,
+): NoFireReason | null {
+  if (!task.enabled) return 'paused'
+  if (task.providerRefusal) return 'refused'
+  if (gate && !gate.engineArmed) return 'engine-not-armed'
+  return null
+}
+
+/**
+ * The next-run cell. A task that cannot fire gets an em dash plus the reason —
+ * the same treatment `paused` already had, extended to the other two ways a
+ * listed task silently never runs (#7026).
+ */
+function describeNextRun(task: ScheduledTask, reason: NoFireReason | null): string {
+  switch (reason) {
+    case 'paused':
+      return '— (paused)'
+    case 'refused':
+      return '— (will not fire)'
+    // Deliberately NOT "scheduler disabled": this also covers the gate being
+    // saved ENABLED with no armed engine, where the flag is on and nothing is
+    // running. "Not running" is true of both.
+    case 'engine-not-armed':
+      return '— (scheduler not running)'
+    default:
+      return formatEpoch(task.nextRun)
+  }
+}
+
+/**
  * The health chip. `data-accent` is driven by the shared helper's `tone`, so
  * "looks healthy" and "is healthy" are the same decision — a renderer can't
  * accidentally style a REFUSED/PAUSED/NEVER RUN task green.
+ *
+ * `willNotFire` degrades the tone (never the tag) so a task the panel already
+ * knows cannot fire is not simultaneously advertised as green (#7026).
  */
-function HealthChip({ task, place = 'row' }: { task: ScheduledTask; place?: 'row' | 'detail' }) {
-  const health = deriveScheduledTaskHealth(task, { quarantined: task.quarantined })
+function HealthChip({
+  task,
+  willNotFire = false,
+  place = 'row',
+}: {
+  task: ScheduledTask
+  willNotFire?: boolean
+  place?: 'row' | 'detail'
+}) {
+  const health = deriveScheduledTaskHealth(task, { quarantined: task.quarantined, willNotFire })
   return (
     <span
       className="cr-tag"
@@ -297,13 +376,17 @@ function GateBanner({
 /** One row in the task list. */
 function TaskRow({
   task,
+  gate,
   selected,
   onSelect,
 }: {
   task: ScheduledTask
+  /** `null` = the gate is UNKNOWN; see `whyTaskWillNotFire`. */
+  gate: SchedulerGateState | null
   selected: boolean
   onSelect: (id: string) => void
 }) {
+  const noFire = whyTaskWillNotFire(task, gate)
   return (
     <li>
       <button
@@ -316,10 +399,10 @@ function TaskRow({
         <span className="cr-sched-row-name" data-testid={`sched-row-name-${task.id}`}>
           {task.name || task.id.slice(0, 8)}
         </span>
-        <HealthChip task={task} />
+        <HealthChip task={task} willNotFire={noFire !== null} />
         <span className="cr-dim cr-sched-row-cadence">{describeCadence(task.cadence)}</span>
         <span className="cr-dim cr-sched-row-next" data-testid={`sched-row-next-${task.id}`}>
-          next: {task.enabled ? formatEpoch(task.nextRun) : '— (paused)'}
+          next: {describeNextRun(task, noFire)}
         </span>
         {task.providerRefusal && (
           <span className="cr-tag" data-accent="bad" data-testid={`sched-row-refusal-${task.id}`}>
@@ -336,7 +419,7 @@ function TaskRow({
  * verbatim (`providerRefusal`, the clamped permission mode, quarantine) rather
  * than any locally-derived judgement.
  */
-function TaskDetail({ task }: { task: ScheduledTask }) {
+function TaskDetail({ task, gate }: { task: ScheduledTask; gate: SchedulerGateState | null }) {
   const sendAction = useConnectionStore((s) => s.sendScheduledTaskAction)
   const pending = useConnectionStore((s) => s.scheduledTaskPendingActions)
   const results = useConnectionStore((s) => s.scheduledTaskActionResults)
@@ -346,7 +429,11 @@ function TaskDetail({ task }: { task: ScheduledTask }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const inFlight = reqId != null && reqId in pending
   const result = reqId != null ? results[reqId] : undefined
-  const health = deriveScheduledTaskHealth(task, { quarantined: task.quarantined })
+  const noFire = whyTaskWillNotFire(task, gate)
+  const health = deriveScheduledTaskHealth(task, {
+    quarantined: task.quarantined,
+    willNotFire: noFire !== null,
+  })
 
   const act = (action: 'pause' | 'resume' | 'delete') => {
     const id = sendAction(action, { taskId: task.id })
@@ -360,7 +447,7 @@ function TaskDetail({ task }: { task: ScheduledTask }) {
           <h4 data-testid="sched-detail-name">{task.name || task.id}</h4>
           <span className="cr-mono cr-dim">{task.id}</span>
         </div>
-        <HealthChip task={task} place="detail" />
+        <HealthChip task={task} willNotFire={noFire !== null} place="detail" />
       </header>
 
       {task.quarantined && (
@@ -383,7 +470,7 @@ function TaskDetail({ task }: { task: ScheduledTask }) {
         <dt>Cadence</dt>
         <dd data-testid="sched-detail-cadence">{describeCadence(task.cadence)}</dd>
         <dt>Next run</dt>
-        <dd data-testid="sched-detail-next">{task.enabled ? formatEpoch(task.nextRun) : '— (paused)'}</dd>
+        <dd data-testid="sched-detail-next">{describeNextRun(task, noFire)}</dd>
         <dt>Last run</dt>
         <dd data-testid="sched-detail-last">
           [{health.tag}] {describeLastRun(task)}
@@ -481,12 +568,41 @@ function TaskDetail({ task }: { task: ScheduledTask }) {
   )
 }
 
+/** The `target` sub-fields this form has an input for. Everything else in a
+ *  stored target is carried through untouched — see `unownedTarget` below. */
+const OWNED_TARGET_KEYS = ['provider', 'model', 'cwd'] as const
+
+type FormTarget = NonNullable<ScheduledTaskInput['target']>
+
 /**
  * Create/edit form. Warns BEFORE saving when the chosen provider is one the
  * engine refuses — including the blank case, which resolves to the daemon
  * default. The refusal text comes from the server (`defaultProviderRefusal`) and
  * the supported set is the server's `schedulableProviders`; neither is computed
  * here.
+ *
+ * ── An EDIT sends a PATCH, never a round-trip of the snapshot (#7049) ─────────
+ * `create` composes the whole task; `update` sends ONLY the fields the operator
+ * actually changed. Echoing back everything the form was seeded with destroyed
+ * data twice over, and both losses were silent:
+ *
+ *  1. The store REPLACES `target` wholesale (`scheduled-task-store.js`:
+ *     `if ('target' in patch) next.target = normalizeTarget(patch.target)`), and
+ *     this form has no `permissionMode` input — so a full `target` bag deleted a
+ *     stored `permissionMode` on ANY unrelated save. (The fix is to preserve it,
+ *     NOT to add an input: whether that mode gets a control is #6761's call.)
+ *  2. Every text field is seeded from the CLAMPED wire projection
+ *     (`clampWire`, handlers/scheduler-handlers.js), so re-sending an untouched
+ *     `name` / `provider` / `model` / `cwd` persisted the shortened value. The
+ *     wire caps are the SAME numbers as the inputs' `maxLength`, so no surface
+ *     can send an over-cap value back — the only way to keep one is not to send
+ *     the field at all.
+ *
+ * "Changed" is measured against the SEED values below, not by re-deriving a
+ * payload and diffing it against the task. The difference is load-bearing for
+ * `once`: its instant round-trips through a `datetime-local` string, so a
+ * re-derived `at` can differ from the stored one with the operator having
+ * touched nothing.
  */
 function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () => void }) {
   const sendAction = useConnectionStore((s) => s.sendScheduledTaskAction)
@@ -497,26 +613,38 @@ function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () =>
   const inFlight = reqId != null && reqId in pending
   const result = reqId != null ? results[reqId] : undefined
 
-  const [name, setName] = useState(task?.name ?? '')
-  const [prompt, setPrompt] = useState(task?.prompt ?? '')
-  const [cadenceKind, setCadenceKind] = useState<'once' | 'interval' | 'cron'>(task?.cadence?.kind ?? 'cron')
-  const [cron, setCron] = useState(task?.cadence?.kind === 'cron' ? task.cadence.expression : '0 9 * * *')
-  const [everyMinutes, setEveryMinutes] = useState(
-    task?.cadence?.kind === 'interval' ? String(Math.round(task.cadence.everyMs / 60000)) : '60',
-  )
   // #6871 review (C3): guarded via the shared epoch guard. An out-of-Date-range
   // `at` used to throw RangeError out of this initializer and take the whole
   // dashboard down through the root error boundary.
   const storedOnceAt = task?.cadence?.kind === 'once' ? task.cadence.at : null
-  const [onceAt, setOnceAt] = useState(toDatetimeLocalValue(storedOnceAt))
+  // The SEED values: what each input starts as, captured once so "did the
+  // operator change this?" is a comparison against the same value the field was
+  // populated with (#7049 — see the block comment above).
+  const seed = {
+    name: task?.name ?? '',
+    prompt: task?.prompt ?? '',
+    cadenceKind: (task?.cadence?.kind ?? 'cron') as 'once' | 'interval' | 'cron',
+    cron: task?.cadence?.kind === 'cron' ? task.cadence.expression : '0 9 * * *',
+    everyMinutes: task?.cadence?.kind === 'interval' ? String(Math.round(task.cadence.everyMs / 60000)) : '60',
+    onceAt: toDatetimeLocalValue(storedOnceAt),
+    provider: task?.target?.provider ?? '',
+    model: task?.target?.model ?? '',
+    cwd: task?.target?.cwd ?? '',
+  }
+  const [name, setName] = useState(seed.name)
+  const [prompt, setPrompt] = useState(seed.prompt)
+  const [cadenceKind, setCadenceKind] = useState<'once' | 'interval' | 'cron'>(seed.cadenceKind)
+  const [cron, setCron] = useState(seed.cron)
+  const [everyMinutes, setEveryMinutes] = useState(seed.everyMinutes)
+  const [onceAt, setOnceAt] = useState(seed.onceAt)
   // The stored instant exists but cannot be represented — show the operator that
   // the value was dropped and must be re-entered, rather than silently
   // presenting an empty field as if the task had no scheduled time.
   const onceAtUnreadable =
     task?.cadence?.kind === 'once' && storedOnceAt != null && epochToDate(storedOnceAt) === null
-  const [provider, setProvider] = useState(task?.target?.provider ?? '')
-  const [model, setModel] = useState(task?.target?.model ?? '')
-  const [cwd, setCwd] = useState(task?.target?.cwd ?? '')
+  const [provider, setProvider] = useState(seed.provider)
+  const [model, setModel] = useState(seed.model)
+  const [cwd, setCwd] = useState(seed.cwd)
 
   // Close only once the SERVER confirmed the mutation (the re-emitted snapshot).
   useEffect(() => {
@@ -542,7 +670,15 @@ function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () =>
     if (cadenceKind === 'interval') {
       const mins = Number(everyMinutes)
       if (!Number.isFinite(mins) || mins <= 0) return null
-      return { kind: 'interval', everyMs: Math.round(mins * 60000) }
+      // #7049: `anchor` is a stored phase offset this form has no input for.
+      // Rebuilding the cadence without it would delete it — the same "clobber
+      // what the form does not own" shape as the target bag below.
+      const anchor = task?.cadence?.kind === 'interval' ? task.cadence.anchor : undefined
+      return {
+        kind: 'interval',
+        everyMs: Math.round(mins * 60000),
+        ...(anchor != null ? { anchor } : {}),
+      }
     }
     const at = Date.parse(onceAt)
     if (!Number.isFinite(at)) return null
@@ -552,21 +688,57 @@ function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () =>
   const cadence = buildCadence()
   const canSubmit = !inFlight && prompt.trim().length > 0 && cadence !== null
 
+  /**
+   * Everything in the stored `target` this form has no input for — today just
+   * `permissionMode`. Computed by EXCLUSION rather than by naming the fields to
+   * keep, so a target field added later is preserved by default instead of
+   * being silently dropped the next time someone saves the form.
+   */
+  const unownedTarget = Object.fromEntries(
+    Object.entries(task?.target ?? {}).filter(
+      ([k]) => !(OWNED_TARGET_KEYS as readonly string[]).includes(k),
+    ),
+  ) as FormTarget
+
   const submit = () => {
     if (!cadence) return
-    const payload: ScheduledTaskInput = {
-      name: name.trim() || null,
-      prompt: prompt.trim(),
-      cadence,
-      target: {
-        ...(provider.trim() ? { provider: provider.trim() } : {}),
-        ...(model.trim() ? { model: model.trim() } : {}),
-        ...(cwd.trim() ? { cwd: cwd.trim() } : {}),
-      },
+    const nextName = name.trim() || null
+    const nextPrompt = prompt.trim()
+    const nextTarget: FormTarget = {
+      ...unownedTarget,
+      ...(provider.trim() ? { provider: provider.trim() } : {}),
+      ...(model.trim() ? { model: model.trim() } : {}),
+      ...(cwd.trim() ? { cwd: cwd.trim() } : {}),
     }
-    const id = task
-      ? sendAction('update', { taskId: task.id, task: payload })
-      : sendAction('create', { task: payload })
+
+    if (!task) {
+      const id = sendAction('create', {
+        task: { name: nextName, prompt: nextPrompt, cadence, target: nextTarget },
+      })
+      if (id) setReqId(id)
+      return
+    }
+
+    // PATCH: only the fields whose input differs from what it was seeded with.
+    // An untouched field is left out entirely, which is the ONLY way to keep a
+    // value the wire cap cannot carry — and, for `target`, the only way to keep
+    // the sub-fields this form does not own.
+    const patch: ScheduledTaskInput = {}
+    if (name !== seed.name) patch.name = nextName
+    if (prompt !== seed.prompt) patch.prompt = nextPrompt
+    if (
+      cadenceKind !== seed.cadenceKind
+      || (cadenceKind === 'cron' && cron !== seed.cron)
+      || (cadenceKind === 'interval' && everyMinutes !== seed.everyMinutes)
+      || (cadenceKind === 'once' && onceAt !== seed.onceAt)
+    ) patch.cadence = cadence
+    if (provider !== seed.provider || model !== seed.model || cwd !== seed.cwd) {
+      patch.target = nextTarget
+    }
+    // An empty patch is still SENT: the mutation is not optimistic, so the
+    // server's echoed snapshot is what closes this modal. Not sending would
+    // leave a no-op "Save changes" click with no way out but Cancel.
+    const id = sendAction('update', { taskId: task.id, task: patch })
     if (id) setReqId(id)
   }
 
@@ -807,11 +979,11 @@ export function ScheduledTasksSection({ now = Date.now }: ScheduledTasksSectionP
         <div className="cr-sched-layout">
           <ul className="cr-sched-list" data-testid="sched-list">
             {tasks.map((t) => (
-              <TaskRow key={t.id} task={t} selected={t.id === selectedId} onSelect={(id) => selectTask(id)} />
+              <TaskRow key={t.id} task={t} gate={gate} selected={t.id === selectedId} onSelect={(id) => selectTask(id)} />
             ))}
           </ul>
           {selected ? (
-            <TaskDetail key={selected.id} task={selected} />
+            <TaskDetail key={selected.id} task={selected} gate={gate} />
           ) : (
             <p className="cr-dim" data-testid="sched-detail-empty">Select a task to inspect it.</p>
           )}

--- a/packages/dashboard/src/components/ScheduledTasksSection.tsx
+++ b/packages/dashboard/src/components/ScheduledTasksSection.tsx
@@ -19,8 +19,8 @@
  *    quarantined can never render as healthy, and an unrecognized future status
  *    lands on `ERROR` rather than falling through to something friendlier.
  *    A tag describes the last RUN, though, not whether the task will FIRE — so
- *    a task this panel knows cannot fire (paused, refused, or no armed engine)
- *    also loses the green tone and its next-run timestamp (#7026,
+ *    a task this panel knows cannot fire (paused, refused, quarantined, or no
+ *    armed engine) also loses the green tone and its next-run timestamp (#7026,
  *    `whyTaskWillNotFire`). The tag itself stays CLI-identical.
  * 2. THE GATE IS SHOWN FIRST. Scheduled execution is OFF by default. A list of
  *    tasks presented without that fact is misleading — they are saved, and none
@@ -171,12 +171,21 @@ function describeLastRun(task: ScheduledTask): string {
  * A `null` gate is UNKNOWN (not read from the daemon), and this claims nothing
  * there — the same posture as `GateBanner`'s UNKNOWN branch.
  *
- * Precedence runs most-specific first: a paused/refused task stays paused/refused
- * even once the gate is fixed, so naming the durable reason is more useful than
- * naming the global one — which the banner states at the top of the section
- * anyway.
+ * `quarantined` is the FOURTH blocker and belongs here for the same reason as the
+ * other three, even though the chip already handled it. The engine's `_tick()`
+ * skips a quarantined task until the daemon restarts, but `_quarantine()`
+ * (scheduler.js) writes only `lastRun` — the store then RECOMPUTES `nextRun` from
+ * the cadence, so the record still carries a real future instant. Reading the
+ * record alone, the task looks scheduled; only the process-scoped quarantine flag
+ * on the snapshot says otherwise.
+ *
+ * Precedence runs most-specific first, and within that, most DURABLE first: a
+ * paused/refused task stays paused/refused even once the gate is fixed, and a
+ * refusal survives the daemon restart that clears a quarantine. Naming the
+ * durable reason is more useful than naming the global one — which the banner
+ * states at the top of the section anyway.
  */
-type NoFireReason = 'paused' | 'refused' | 'engine-not-armed'
+type NoFireReason = 'paused' | 'refused' | 'quarantined' | 'engine-not-armed'
 
 function whyTaskWillNotFire(
   task: ScheduledTask,
@@ -184,13 +193,14 @@ function whyTaskWillNotFire(
 ): NoFireReason | null {
   if (!task.enabled) return 'paused'
   if (task.providerRefusal) return 'refused'
+  if (task.quarantined) return 'quarantined'
   if (gate && !gate.engineArmed) return 'engine-not-armed'
   return null
 }
 
 /**
  * The next-run cell. A task that cannot fire gets an em dash plus the reason —
- * the same treatment `paused` already had, extended to the other two ways a
+ * the same treatment `paused` already had, extended to the other three ways a
  * listed task silently never runs (#7026).
  */
 function describeNextRun(task: ScheduledTask, reason: NoFireReason | null): string {
@@ -199,6 +209,10 @@ function describeNextRun(task: ScheduledTask, reason: NoFireReason | null): stri
       return '— (paused)'
     case 'refused':
       return '— (will not fire)'
+    // The detail pane already explains quarantine at length; the row has no room,
+    // and the word alone is the searchable term that leads to that explanation.
+    case 'quarantined':
+      return '— (quarantined)'
     // Deliberately NOT "scheduler disabled": this also covers the gate being
     // saved ENABLED with no armed engine, where the flag is on and nothing is
     // running. "Not running" is true of both.
@@ -617,10 +631,20 @@ function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () =>
   // `at` used to throw RangeError out of this initializer and take the whole
   // dashboard down through the root error boundary.
   const storedOnceAt = task?.cadence?.kind === 'once' ? task.cadence.at : null
-  // The SEED values: what each input starts as, captured once so "did the
-  // operator change this?" is a comparison against the same value the field was
-  // populated with (#7049 — see the block comment above).
-  const seed = {
+  // The SEED values: what each input started as, captured ONCE for the life of
+  // the modal (#7049 — see the block comment above), so "did the operator change
+  // this?" is a comparison against the value the field was actually populated
+  // with.
+  //
+  // The lazy `useState` is load-bearing, not a micro-optimisation. `task` is
+  // `tasks.find(...)` off the store snapshot, and the daemon re-emits the WHOLE
+  // snapshot after every accepted mutation from ANY client — so this component
+  // re-renders mid-edit with a fresh `task` object. A plain `const` would then
+  // re-derive the seed from the NEW server values, every field the operator never
+  // touched would differ from its seed, and the patch would grow back into the
+  // whole-bag write-back (carrying the operator's now-stale values) that this
+  // block exists to prevent.
+  const [seed] = useState(() => ({
     name: task?.name ?? '',
     prompt: task?.prompt ?? '',
     cadenceKind: (task?.cadence?.kind ?? 'cron') as 'once' | 'interval' | 'cron',
@@ -630,7 +654,7 @@ function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () =>
     provider: task?.target?.provider ?? '',
     model: task?.target?.model ?? '',
     cwd: task?.target?.cwd ?? '',
-  }
+  }))
   const [name, setName] = useState(seed.name)
   const [prompt, setPrompt] = useState(seed.prompt)
   const [cadenceKind, setCadenceKind] = useState<'once' | 'interval' | 'cron'>(seed.cadenceKind)
@@ -692,7 +716,17 @@ function TaskFormModal({ task, onClose }: { task?: ScheduledTask; onClose: () =>
    * Everything in the stored `target` this form has no input for — today just
    * `permissionMode`. Computed by EXCLUSION rather than by naming the fields to
    * keep, so a target field added later is preserved by default instead of
-   * being silently dropped the next time someone saves the form.
+   * being silently dropped the next time someone saves the form. (It must also
+   * be added to `ScheduledTaskInputSchema.target`, or Zod strips it off the wire
+   * on the way back — the read and write shapes are separate objects.)
+   *
+   * Deliberately read LIVE off `task`, the opposite choice from `seed` above, and
+   * for the same underlying reason. `seed` answers "what did the operator start
+   * from?", which must not move. This answers "what does the server hold for the
+   * fields nobody here owns?", and the freshest answer is the correct one: if
+   * another client set a `permissionMode` while this modal was open, carrying
+   * that through is right and re-writing a stale one is not. Same for the
+   * interval `anchor` in `buildCadence`.
    */
   const unownedTarget = Object.fromEntries(
     Object.entries(task?.target ?? {}).filter(

--- a/packages/protocol/dist/scheduled-task-health.d.ts
+++ b/packages/protocol/dist/scheduled-task-health.d.ts
@@ -57,7 +57,8 @@ export interface ScheduledTaskHealth {
     readonly quarantined: boolean;
     /**
      * The ONLY flag a surface may treat as "this schedule is fine". True only for
-     * a successful last run on a task that is neither paused nor quarantined.
+     * a successful last run on a task that is neither paused nor quarantined, and
+     * that the caller has not reported as unable to fire (see `willNotFire`).
      */
     readonly isHealthy: boolean;
 }
@@ -85,7 +86,17 @@ export declare function scheduledTaskHealthTone(tag: ScheduledTaskHealthTag): Sc
  * task can never present as healthy even if its stored `lastRun` still says
  * `success` (the engine's best-effort quarantine write may not have landed —
  * the usual reason to quarantine is that the store is failing).
+ *
+ * `willNotFire` (#7026) is the second caller-supplied degrade, and takes the
+ * same shape for the same reason. The tag answers "how did the last run GO?",
+ * never "will this task FIRE?" — the blockers for the latter (a closed global
+ * gate / an unarmed engine, a provider the engine refuses) are ambient state
+ * this module cannot see from a task record. Left to itself the mapping
+ * therefore styles a task green while nothing on the host is firing at all, so
+ * a caller that KNOWS the task cannot fire says so and the tone degrades out of
+ * `ok`. It only ever degrades: a `bad` tag stays `bad`.
  */
 export declare function deriveScheduledTaskHealth(task: ScheduledTaskHealthInput | null | undefined, options?: {
     readonly quarantined?: boolean;
+    readonly willNotFire?: boolean;
 }): ScheduledTaskHealth;

--- a/packages/protocol/dist/scheduled-task-health.js
+++ b/packages/protocol/dist/scheduled-task-health.js
@@ -105,14 +105,25 @@ export function scheduledTaskHealthTone(tag) {
  * task can never present as healthy even if its stored `lastRun` still says
  * `success` (the engine's best-effort quarantine write may not have landed —
  * the usual reason to quarantine is that the store is failing).
+ *
+ * `willNotFire` (#7026) is the second caller-supplied degrade, and takes the
+ * same shape for the same reason. The tag answers "how did the last run GO?",
+ * never "will this task FIRE?" — the blockers for the latter (a closed global
+ * gate / an unarmed engine, a provider the engine refuses) are ambient state
+ * this module cannot see from a task record. Left to itself the mapping
+ * therefore styles a task green while nothing on the host is firing at all, so
+ * a caller that KNOWS the task cannot fire says so and the tone degrades out of
+ * `ok`. It only ever degrades: a `bad` tag stays `bad`.
  */
 export function deriveScheduledTaskHealth(task, options = {}) {
     const tag = deriveScheduledTaskHealthTag(task);
     const quarantined = options.quarantined === true;
+    const willNotFire = options.willNotFire === true;
+    const tone = quarantined ? 'bad' : scheduledTaskHealthTone(tag);
     return {
         tag,
-        tone: quarantined ? 'bad' : scheduledTaskHealthTone(tag),
+        tone: willNotFire && tone === 'ok' ? 'warn' : tone,
         quarantined,
-        isHealthy: tag === 'OK' && !quarantined,
+        isHealthy: tag === 'OK' && !quarantined && !willNotFire,
     };
 }

--- a/packages/protocol/src/scheduled-task-health.ts
+++ b/packages/protocol/src/scheduled-task-health.ts
@@ -76,7 +76,8 @@ export interface ScheduledTaskHealth {
   readonly quarantined: boolean
   /**
    * The ONLY flag a surface may treat as "this schedule is fine". True only for
-   * a successful last run on a task that is neither paused nor quarantined.
+   * a successful last run on a task that is neither paused nor quarantined, and
+   * that the caller has not reported as unable to fire (see `willNotFire`).
    */
   readonly isHealthy: boolean
 }
@@ -140,17 +141,28 @@ export function scheduledTaskHealthTone(tag: ScheduledTaskHealthTag): ScheduledT
  * task can never present as healthy even if its stored `lastRun` still says
  * `success` (the engine's best-effort quarantine write may not have landed —
  * the usual reason to quarantine is that the store is failing).
+ *
+ * `willNotFire` (#7026) is the second caller-supplied degrade, and takes the
+ * same shape for the same reason. The tag answers "how did the last run GO?",
+ * never "will this task FIRE?" — the blockers for the latter (a closed global
+ * gate / an unarmed engine, a provider the engine refuses) are ambient state
+ * this module cannot see from a task record. Left to itself the mapping
+ * therefore styles a task green while nothing on the host is firing at all, so
+ * a caller that KNOWS the task cannot fire says so and the tone degrades out of
+ * `ok`. It only ever degrades: a `bad` tag stays `bad`.
  */
 export function deriveScheduledTaskHealth(
   task: ScheduledTaskHealthInput | null | undefined,
-  options: { readonly quarantined?: boolean } = {},
+  options: { readonly quarantined?: boolean; readonly willNotFire?: boolean } = {},
 ): ScheduledTaskHealth {
   const tag = deriveScheduledTaskHealthTag(task)
   const quarantined = options.quarantined === true
+  const willNotFire = options.willNotFire === true
+  const tone = quarantined ? 'bad' : scheduledTaskHealthTone(tag)
   return {
     tag,
-    tone: quarantined ? 'bad' : scheduledTaskHealthTone(tag),
+    tone: willNotFire && tone === 'ok' ? 'warn' : tone,
     quarantined,
-    isHealthy: tag === 'OK' && !quarantined,
+    isHealthy: tag === 'OK' && !quarantined && !willNotFire,
   }
 }

--- a/packages/server/src/handlers/scheduler-handlers.js
+++ b/packages/server/src/handlers/scheduler-handlers.js
@@ -175,7 +175,23 @@ function effectiveProvider(task, ctx) {
  * long engine error in `lastRun.error`) made the WHOLE snapshot fail the
  * dashboard's `safeParse`, so every task vanished and the tab hung on
  * "Loading…". A snapshot the contract cannot represent is worse than a
- * shortened display string, and the store keeps the full value either way.
+ * shortened display string.
+ *
+ * ── The clamp is display-only, but ONLY if every writer cooperates (#7049) ────
+ * This block used to end "and the store keeps the full value either way", which
+ * was true of the READ and false of the write-back. A surface that seeds an EDIT
+ * FORM from this projection and sends the fields back on save persists the
+ * SHORTENED value, permanently — and nothing here can prevent it, because
+ * `ScheduledTaskInputSchema`'s caps are the SAME numbers, so an over-cap value
+ * cannot be sent back even deliberately. The only thing that keeps it is not
+ * sending the field.
+ *
+ * So the dashboard's task form sends PATCH semantics on `update` — only the
+ * fields the operator actually changed (ScheduledTasksSection.tsx `submit()`) —
+ * and any NEW writer of `scheduled_task_action:update` must do the same. The
+ * store's `update()` also replaces `target` WHOLESALE, so the same rule is what
+ * keeps a `target.permissionMode` (which no form field owns) from being erased
+ * by an unrelated save.
  */
 function clampWire(value, max) {
   if (typeof value !== 'string') return value


### PR DESCRIPTION
Closes #7026. Closes #7049.

Both issues rewrite `packages/dashboard/src/components/ScheduledTasksSection.tsx` and share its test file, so they ship as one PR — separately they would guarantee a rebase conflict.

---

## #7026 — a green `OK` chip and a live next-run time render while the task cannot fire

### Defect

`deriveScheduledTaskHealth` describes **how the last run went**, not **whether the task will fire**. It has no notion of the global gate or of a per-task provider refusal, and the panel passed neither:

- `HealthChip` called `deriveScheduledTaskHealth(task, { quarantined })` only, and `lastRun.status === 'success'` maps to `OK` → tone `ok` unconditionally.
- The next-run cell (`sched-row-next-*` and `sched-detail-next`) was `task.enabled ? formatEpoch(task.nextRun) : '— (paused)'` — `!enabled` was the *only* non-firing case handled.

Scheduled execution is OFF by default, so the default state of a freshly-created task that has run once is `OK` + `next: 09:00 tomorrow` for something that will never fire. The red gate banner above was the only contradicting signal.

### Fix

A new `whyTaskWillNotFire(task, gate)` returns `'paused' | 'refused' | 'engine-not-armed' | null`. Both render sites consume it:

- the chip passes `willNotFire` into the shared helper, which degrades `tone` out of `ok` and clears `isHealthy` — **the CLI-identical `tag` is untouched**, exactly the shape `quarantined` already uses;
- the next-run cell renders `— (paused)` / `— (will not fire)` / `— (scheduler not running)`, mirroring the existing paused treatment.

**The gate half keys on `engineArmed`, not on the persisted `enabled` flag.** That distinction is the same one the banner makes (#6871 C2) and it is load-bearing in both directions:

| gate | engine | next-run cell | why |
|---|---|---|---|
| saved OFF | **armed** | live timestamp | the tasks really are about to run unattended — blanking the time would understate the one state that endangers the operator |
| saved ON | not armed | `— (scheduler not running)` | nothing fires until a daemon restart; a live time is as false as with the flag off |
| saved OFF | not armed | `— (scheduler not running)` | |
| `null` (UNKNOWN) | — | live timestamp | we have not read the daemon; asserting "not running" would be the same zero-data claim the banner's UNKNOWN branch refuses to make |

The wording is deliberately "scheduler not running" rather than the issue's suggested "scheduler disabled", because it also has to be true of row 2, where the flag *is* enabled.

---

## #7049 — the edit form wipes `target.permissionMode` and writes back a truncated name

### Defect

`TaskFormModal.submit()` always built a **complete** payload and sent it for `update` as well as `create`. Two silent losses fell out of that:

1. **`permissionMode` erased.** The bag always contained `target: { provider?, model?, cwd? }` and never `permissionMode` (there is no input for it), while `scheduled-task-store.js` replaces the target **wholesale**:
   ```js
   if ('target' in patch) next.target = normalizeTarget(patch.target)
   ```
   So opening a task and saving **any** unrelated change destroyed a stored `target.permissionMode`. The direction is a de-escalation to the unattended floor, not an escalation — but it is an operator choice discarded with no warning and no way to see it happened.
2. **Clamped values written back truncated.** Every field is seeded from the CLAMPED wire projection (`clampWire`), so re-sending an untouched `name` / `provider` / `model` / `cwd` persisted the shortened value permanently. Nothing server-side can prevent this: `ScheduledTaskInputSchema`'s caps are the **same numbers** as the inputs' `maxLength`, so an over-cap value cannot be sent back even deliberately. The only thing that keeps it is not sending the field.

### Fix

`update` now sends **PATCH semantics**: only the fields whose input differs from the value it was **seeded** with. `create` is unchanged and still composes the whole task.

- Untouched `name` / `prompt` / `cadence` / `target` are omitted → the store keeps whatever it has, at full length.
- When `target` *is* sent, every sub-field the form does not own is carried through. `unownedTarget` is computed by **exclusion** (`OWNED_TARGET_KEYS`), so a target field added later is preserved by default rather than silently dropped the first time someone saves the form.
- An interval cadence's `anchor` — another field with no input — is preserved for the same reason.
- An empty patch is still **sent**: the mutation is not optimistic, so the server's echoed snapshot is what closes the modal.

"Changed" is measured against the seed values, **not** by re-deriving a payload and diffing it against the task. That matters for `once`: its instant round-trips through a `datetime-local` string, so a re-derived `at` can differ from the stored one with nothing touched. (The display half of that round-trip — the field is seeded with a UTC wall clock and read back as local — is a separate pre-existing defect, filed as a follow-on; patch semantics neutralises its *corrupting* half here, since an untouched `once` field is now never re-sent.)

**No `permissionMode` input was added** — whether that mode gets a control is #6761's call, and this PR only preserves what is stored.

### Also in scope

`clampWire`'s doc block claimed the clamp was harmless because "the store keeps the full value either way". True of the read, false of the write-back. It now states the actual contract: the clamp is display-only *only if every writer sends patch semantics*, and names the store's wholesale `target` replace as the second reason.

---

## Verification

TDD, red first. 21 new assertions across two `describe` blocks in `ScheduledTasksSection.test.tsx`.

**RED (before the fix):** `Tests 10 failed | 63 passed (73)` — e.g.

```
× does not style a successful task green while no engine is armed
  → expected 'ok' not to be 'ok'
× replaces the next-run timestamp with a reason in BOTH the row and the detail
  → sched-row-next-task-1: expected 'next: 3/17/2030, 10:46:40 AM' not to contain '3/17/2030, 10:46:40 AM'
× omits `target` entirely on an unrelated save, so a stored permissionMode survives
  → expected true to be false
× POSITIVE CONTROL: editing a target field DOES send target, carrying permissionMode through
  → { model: 'opus', provider: 'claude-sdk' }  (permissionMode absent)
```

**Positive controls** (these PASS on unmodified source, proving the fixtures take effect rather than the negatives passing for free):

- `POSITIVE CONTROL: with the engine armed the same task is green with a live next-run time` — same task, `engineArmed: true` → `data-accent="ok"` **and** the real timestamp.
- `KEEPS the live next-run time when the gate is saved OFF but the engine is STILL FIRING`.
- `claims nothing about firing when the gate is UNKNOWN`.
- `POSITIVE CONTROL: an edited name IS sent` / `an edited cadence IS sent`.
- `CREATE is unaffected — it still sends the complete payload it composed`.

**GREEN:** `Tests 73 passed (73)`.

**Mutation testing** — three one-line mutations, each reverted after:

| mutation | result |
|---|---|
| `gate.engineArmed` → `gate.enabled` in `whyTaskWillNotFire` | 2 failed — precisely the two four-state guards (`SAVED ON but no engine armed`, `saved OFF but STILL FIRING`) |
| `unownedTarget` → `{}` | 2 failed — the permissionMode carry-through control and `clearing a target field still clears it` |
| drop the `willNotFire && tone === 'ok' ? 'warn'` degrade in `@chroxy/protocol` | 3 failed — every chip-tone assertion |

Component verified byte-identical to its pre-mutation state afterwards.

**Suites / gates run**

- `packages/dashboard`: full vitest suite — **292 files, 5072 tests, all green**
- `packages/dashboard`: `tsc --noEmit` — clean
- `packages/dashboard`: `vite build` — clean
- `packages/protocol`: `npm test` — 388 pass; `npm run build` committed (`dist/scheduled-task-health.{js,d.ts}` are tracked, and CI gates dist drift)
- `packages/server`: `scheduler-handlers` + `scheduled-task-store` + `scheduler` + `schedule-cli` + `config-scheduler-gate` — 213 pass; `scheduled-task-health-parity` — 11 pass (the shared-helper option does not perturb CLI parity)
- **CI Server Lint** — all five `packages/server/scripts/lint-*.sh` green; `eslint src/` on the touched handler clean

## Rebase note for #7038

`packages/protocol/src/scheduled-task-health.ts` is touched deliberately minimally — one added option on `deriveScheduledTaskHealth` at the bottom of the file. #7038's fifth status literal lands in `SCHEDULED_TASK_LAST_RUN_STATUSES` / `deriveScheduledTaskHealthTag` near the top and should rebase cleanly behind this.
