### PR TITLE
fix(server,protocol): surface session-pool starvation instead of wedging a run in executing

### DIFF
--- a/docs/design/orchestration/README.md
+++ b/docs/design/orchestration/README.md
@@ -31,10 +31,12 @@ split the synthesized map" note still applies to whichever future PR adds the ov
 
 1. **Enums** — protocol (`schemas/server/orchestration.ts`) is the single source; the engine
    imports them. Run states: `created, planning, plan_review, executing, paused, budget_paused,
-   synthesizing, cancelling, suspended, completed, failed, cancelled` (`paused` = user-requested
-   pause via `orchestration_run_action`; distinct from `budget_paused` so the UI can render the
-   cause — without it, reconciliation 10's `resume`-from-`paused` would be unserializable in the
-   strict wire enum). Subtask states: `pending,
+   resource_paused, synthesizing, cancelling, suspended, completed, failed, cancelled` (`paused` =
+   user-requested pause via `orchestration_run_action`; distinct from `budget_paused` so the UI can
+   render the cause — without it, reconciliation 10's `resume`-from-`paused` would be unserializable
+   in the strict wire enum. `resource_paused` (#6733) = the daemon's session pool is full so the run
+   cannot spawn its next worker and has nothing in flight; engine-cleared, not user-resumed).
+   Subtask states: `pending,
    spawning, briefing, poa_review, executing, result_review, respawning, merging, conflict_fixup,
    escalated, done, skipped, failed, cancelled, interrupted`. Committee verdicts:
    `approve | revise | redelegate | escalate` (engine's `accept` renamed). (F1, F2, F10)

--- a/docs/design/orchestration/engine.md
+++ b/docs/design/orchestration/engine.md
@@ -134,11 +134,18 @@ created ──start──▶ planning ──plan parsed──▶ plan_review ─
    └────────────────────────── any state ──cancelRun──▶ cancelling ──▶ cancelled
                                any active state ──daemon restart──▶ suspended ──resume──▶ (prior state)
                                executing ──budget cap hit──▶ budget_paused ──user: raise/synthesize/cancel──▶ ...
+                               executing ──pool full, 0 workers──▶ resource_paused ──slot freed──▶ executing
                                planning/executing/synthesizing ──unrecoverable──▶ failed
 ```
 
 - `plan_review` is skipped (auto-approved, `approvedBy:'auto'`) when `mode.autoApprovePlan`. **The v1 user gate sits here — after the architect's (cheap, single-session) planning turn, before any worker spend.** A second implicit user surface exists at `escalated` subtasks and permission-gate escalations; no other approvals block auto flow.
 - `budget_paused` (§11): in-flight turns complete; no new spawns/committee turns start.
+- `resource_paused` (#6733): entered ONLY when all three hold — pending subtasks remain, ZERO
+  workers are in flight, and `_sessionHeadroom()` is false. Saturation with a worker still running
+  is *progress*, not a stall, and must not set it. Because a stalled run has nothing in flight, no
+  internal event re-drives it: the engine subscribes to `sessionManager`'s `session_destroyed` and
+  re-enters the scheduler, which clears the state as soon as it can actually spawn. Engine-cleared,
+  never user-resumed — the dashboard renders the chip but offers no Resume button.
 - Terminal states: `completed`, `failed`, `cancelled`. `suspended` is non-terminal, persisted.
 
 ### 3.3 Subtask state machine (committee gates)
@@ -333,6 +340,7 @@ Policy per role:
 | Cancel run | `cancelRun(runId, {reason})` | state `cancelling`: stop scheduler; `interrupt()` every in-flight owned session; wait ≤10s for `result`/quiesce; **auto-commit dirty implement worktrees**; `destroySession` all owned sessions (worktrees removed, branches survive); integration worktree removed; run `cancelled`, `flushSync()` |
 | Orphaned sessions/worktrees | boot reconcile | Owned sessions whose run is terminal/unknown → destroy. `~/.chroxy/orchestration/<runId>/` dirs with no active run → remove. Complements existing worktree GC (`sweepOrphanChroxyWorktrees`) which already covers `~/.chroxy/worktrees/<sessionId>`. |
 | Budget cap crossed | §11 | `budget_paused`, no kills |
+| Session pool full, nothing in flight | `_sessionHeadroom()` false with pending subtasks and 0 active workers | `resource_paused` + `run_resource_paused` (#6733). Cleared by the scheduler on the next `session_destroyed`; never wedges silently in `executing` |
 | Store corruption | run-store load error | Runs unrecoverable → log + start empty; orphan sweep still runs off session-name prefix `orch:` as best-effort hint (name prefix is a debugging aid; the persisted owned-session map is the authority) |
 
 ## 10. Concurrency policy

--- a/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.test.tsx
@@ -280,6 +280,25 @@ describe('OrchestrationRunsSection (#6691 S-3b)', () => {
     expect(screen.queryByTestId('orch-run-controls')).toBeNull()
   })
 
+  it('#6733: a resource_paused run renders a warn chip and NO Resume button', () => {
+    resetStore({
+      orchestrationRuns: snapshot([runSummary({ status: 'resource_paused' })]),
+      selectedRunId: 'run_1',
+      orchestrationRunDetails: { run_1: { detail: runDetail({ status: 'resource_paused' }), seq: 3 } },
+    })
+    render(<OrchestrationRunsSection />)
+    const chip = screen.getAllByTestId('orch-run-status')[0] as HTMLElement
+    // POSITIVE CONTROL: the row really rendered this status, so the accent
+    // assertion below is reading the right chip.
+    expect(chip.textContent).toBe('resource paused')
+    // a stall the operator must notice — not the neutral in-flight accent
+    expect(chip.getAttribute('data-accent')).toBe('warn')
+    // the engine clears this itself when a slot frees; a Resume button would
+    // either no-op or race it
+    expect(screen.queryByTestId('orch-action-resume')).toBeNull()
+    expect(screen.getByTestId('orch-action-cancel')).toBeTruthy()
+  })
+
   it('AnnotateForm: submits baseline + verdict quality at terminal state', () => {
     resetStore({
       orchestrationRuns: snapshot([runSummary({ status: 'completed' })]),

--- a/packages/dashboard/src/components/OrchestrationRunsSection.tsx
+++ b/packages/dashboard/src/components/OrchestrationRunsSection.tsx
@@ -40,7 +40,10 @@ const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled'])
 function statusAccent(status: string): string {
   if (status === 'completed') return 'ok'
   if (status === 'failed' || status === 'cancelled') return 'bad'
-  if (status === 'plan_review' || status === 'budget_paused' || status === 'paused' || status === 'suspended') return 'warn'
+  if (
+    status === 'plan_review' || status === 'budget_paused' || status === 'resource_paused'
+    || status === 'paused' || status === 'suspended'
+  ) return 'warn'
   return 'neutral'
 }
 
@@ -302,6 +305,10 @@ function RunControls({ run }: { run: RunDetail }) {
     if (id) setReqId(id)
   }
   const canPause = run.status === 'executing'
+  // `resource_paused` (#6733) is deliberately absent: the engine clears that
+  // stall itself the moment a session slot frees, so a Resume button would
+  // either no-op or race the engine. The warn-accented chip is the whole
+  // affordance — the operator's lever is closing a session, not this control.
   const canResume = run.status === 'paused' || run.status === 'budget_paused' || run.status === 'suspended'
   return (
     <div className="cr-orch-run-controls" data-testid="orch-run-controls">

--- a/packages/protocol/dist/schemas/server/orchestration.d.ts
+++ b/packages/protocol/dist/schemas/server/orchestration.d.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
  * dashboard message-handler and moves them to DASHBOARD_ONLY. Mobile parity is
  * a later fast-follow.
  */
-export declare const RUN_STATUS_VALUES: readonly ["created", "planning", "plan_review", "executing", "paused", "budget_paused", "synthesizing", "cancelling", "suspended", "completed", "failed", "cancelled"];
+export declare const RUN_STATUS_VALUES: readonly ["created", "planning", "plan_review", "executing", "paused", "budget_paused", "resource_paused", "synthesizing", "cancelling", "suspended", "completed", "failed", "cancelled"];
 export declare const RUN_NODE_STATUS_VALUES: readonly ["pending", "spawning", "briefing", "poa_review", "executing", "result_review", "respawning", "merging", "conflict_fixup", "escalated", "done", "skipped", "failed", "cancelled", "interrupted"];
 export declare const RUN_GATE_KIND_VALUES: readonly ["epic_plan", "escalation", "bash_permission", "budget_overrun"];
 export declare const RUN_GATE_STATUS_VALUES: readonly ["pending", "approved", "rejected", "revise_requested", "skipped", "expired"];
@@ -178,6 +178,7 @@ export declare const RunSummarySchema: z.ZodObject<{
         executing: "executing";
         paused: "paused";
         budget_paused: "budget_paused";
+        resource_paused: "resource_paused";
         synthesizing: "synthesizing";
         cancelling: "cancelling";
         suspended: "suspended";
@@ -231,6 +232,7 @@ export declare const RunDetailSchema: z.ZodObject<{
         executing: "executing";
         paused: "paused";
         budget_paused: "budget_paused";
+        resource_paused: "resource_paused";
         synthesizing: "synthesizing";
         cancelling: "cancelling";
         suspended: "suspended";
@@ -416,6 +418,7 @@ export declare const ServerOrchestrationRunsSnapshotSchema: z.ZodObject<{
             executing: "executing";
             paused: "paused";
             budget_paused: "budget_paused";
+            resource_paused: "resource_paused";
             synthesizing: "synthesizing";
             cancelling: "cancelling";
             suspended: "suspended";
@@ -479,6 +482,7 @@ export declare const ServerOrchestrationRunSnapshotSchema: z.ZodObject<{
             executing: "executing";
             paused: "paused";
             budget_paused: "budget_paused";
+            resource_paused: "resource_paused";
             synthesizing: "synthesizing";
             cancelling: "cancelling";
             suspended: "suspended";
@@ -670,6 +674,7 @@ export declare const ServerOrchestrationRunDeltaSchema: z.ZodObject<{
             executing: "executing";
             paused: "paused";
             budget_paused: "budget_paused";
+            resource_paused: "resource_paused";
             synthesizing: "synthesizing";
             cancelling: "cancelling";
             suspended: "suspended";

--- a/packages/protocol/dist/schemas/server/orchestration.js
+++ b/packages/protocol/dist/schemas/server/orchestration.js
@@ -18,11 +18,14 @@ import { z } from 'zod';
  */
 // --- canonical enums (engine imports these) --------------------------------
 // Run lifecycle. `paused` = user-requested pause (orchestration_run_action),
-// distinct from `budget_paused` so the UI can render the cause; `suspended` =
-// interrupted by a daemon restart and not yet resumed.
+// distinct from `budget_paused` so the UI can render the cause; `resource_paused`
+// (#6733) = the daemon's session pool is full, so the run cannot spawn its next
+// worker and has NOTHING in flight — it clears itself the moment a slot frees;
+// `suspended` = interrupted by a daemon restart and not yet resumed.
 export const RUN_STATUS_VALUES = [
     'created', 'planning', 'plan_review', 'executing', 'paused', 'budget_paused',
-    'synthesizing', 'cancelling', 'suspended', 'completed', 'failed', 'cancelled',
+    'resource_paused', 'synthesizing', 'cancelling', 'suspended', 'completed',
+    'failed', 'cancelled',
 ];
 // Subtask ("node") lifecycle incl. the committee gates.
 export const RUN_NODE_STATUS_VALUES = [

--- a/packages/protocol/src/schemas/server/orchestration.ts
+++ b/packages/protocol/src/schemas/server/orchestration.ts
@@ -21,11 +21,14 @@ import { z } from 'zod'
 // --- canonical enums (engine imports these) --------------------------------
 
 // Run lifecycle. `paused` = user-requested pause (orchestration_run_action),
-// distinct from `budget_paused` so the UI can render the cause; `suspended` =
-// interrupted by a daemon restart and not yet resumed.
+// distinct from `budget_paused` so the UI can render the cause; `resource_paused`
+// (#6733) = the daemon's session pool is full, so the run cannot spawn its next
+// worker and has NOTHING in flight — it clears itself the moment a slot frees;
+// `suspended` = interrupted by a daemon restart and not yet resumed.
 export const RUN_STATUS_VALUES = [
   'created', 'planning', 'plan_review', 'executing', 'paused', 'budget_paused',
-  'synthesizing', 'cancelling', 'suspended', 'completed', 'failed', 'cancelled',
+  'resource_paused', 'synthesizing', 'cancelling', 'suspended', 'completed',
+  'failed', 'cancelled',
 ] as const
 
 // Subtask ("node") lifecycle incl. the committee gates.

--- a/packages/protocol/tests/orchestration-schema.test.js
+++ b/packages/protocol/tests/orchestration-schema.test.js
@@ -16,6 +16,9 @@ describe('orchestration canonical enums', () => {
   it('expose the run/subtask/gate/verdict value arrays the engine imports', () => {
     assert.ok(RUN_STATUS_VALUES.includes('paused'))
     assert.ok(RUN_STATUS_VALUES.includes('budget_paused'))
+    // #6733 — RunSummarySchema.status is a strict z.enum, so a status the engine
+    // can journal but the enum omits makes safeParse DROP the whole summary.
+    assert.ok(RUN_STATUS_VALUES.includes('resource_paused'))
     assert.ok(RUN_STATUS_VALUES.includes('suspended'))
     assert.ok(RUN_NODE_STATUS_VALUES.includes('escalated'))
     assert.ok(RUN_NODE_STATUS_VALUES.includes('conflict_fixup'))

--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -14,6 +14,7 @@ export default [
         clearInterval: 'readonly',
         setImmediate: 'readonly',
         clearImmediate: 'readonly',
+        queueMicrotask: 'readonly',
         URL: 'readonly',
         Buffer: 'readonly',
         AbortController: 'readonly',

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -155,6 +155,15 @@ export class OrchestrationManager extends EventEmitter {
     this._maxCompletedSnapshots = 32
     this._maxSessions = Number.isFinite(config.maxSessions) ? config.maxSessions : 5
 
+    // #6733: a run stalled on session capacity has NOTHING in flight, so no
+    // internal event will ever re-drive its scheduler. Subscribe unconditionally
+    // (rather than arming on the first stall and disarming on recovery) — the
+    // handler is a no-op walk of `_runs` when nothing is stalled, and arm/disarm
+    // bookkeeping is exactly how a stall state latches. Removed in dispose().
+    this._disposed = false
+    this._onSessionFreed = () => this._onSessionCapacityFreed()
+    if (typeof sessionManager.on === 'function') sessionManager.on('session_destroyed', this._onSessionFreed)
+
     // Owned-session registry drives the permission gate (answers ONLY our sessions).
     if (permissionGateFactory) {
       this._gate = permissionGateFactory({
@@ -169,6 +178,9 @@ export class OrchestrationManager extends EventEmitter {
   }
 
   dispose() {
+    this._disposed = true
+    if (this._onSessionFreed && typeof this._sm.off === 'function') this._sm.off('session_destroyed', this._onSessionFreed)
+    this._onSessionFreed = null
     this._gate?.dispose?.()
   }
 
@@ -364,7 +376,13 @@ export class OrchestrationManager extends EventEmitter {
   // --- scheduler -----------------------------------------------------------
 
   _schedule(run) {
-    if (run.cancelled || run.phase !== 'executing') return
+    if (run.cancelled) return
+    // `resource_paused` (#6733) is a STALL, not a stop — the scheduler MUST be
+    // able to re-enter it, both when a freed session slot re-arms it and when a
+    // gate resolution retires the last pending subtask while it is stalled.
+    // Early-returning on it instead would latch the pause: with zero workers in
+    // flight there is no other event that ever re-drives this run.
+    if (run.phase !== 'executing' && run.phase !== 'resource_paused') return
     const all = [...run.subtasks.values()]
     // Ready to synthesize only when EVERY subtask is terminal. 'escalated' is
     // NOT terminal — it blocks synthesis until the user resolves its gate, so a
@@ -376,7 +394,19 @@ export class OrchestrationManager extends EventEmitter {
     const pending = [...run.subtasks.entries()].filter(([, s]) => s.state === 'pending')
     for (const [subtaskId] of pending) {
       if (this._activeWorkerCount(run) >= this._cfg.maxParallelWorkers) break
-      if (!this._sessionHeadroom()) break
+      if (!this._sessionHeadroom()) {
+        // #6733 — a stall needs ALL THREE: pending work (we are inside the
+        // pending loop, and this subtask is still `pending`), ZERO workers in
+        // flight, and no headroom. With a worker still running this is ordinary
+        // saturation — its completion re-enters _schedule — and pausing there
+        // would fire on most runs and train the operator to ignore the state.
+        if (this._activeWorkerCount(run) === 0) this._pauseForResources(run)
+        break
+      }
+      // Headroom is back, so the stall condition no longer holds. Clear it
+      // BEFORE any other pause/spawn decision so the state never lies and the
+      // next status write (a budget pause, say) starts from `executing`.
+      this._clearResourcePause(run)
       const budget = this._ledger.evaluateBudget(run.runId, { role: 'worker.audit' })
       if (budget && budget.ok === false) { this._pauseForBudget(run); break }
       const st = run.subtasks.get(subtaskId)
@@ -788,6 +818,62 @@ export class OrchestrationManager extends EventEmitter {
     this._emitRunDelta(run)
   }
 
+  // --- #6733: session-pool starvation --------------------------------------
+  //
+  // `_sessionHeadroom()` counts the daemon's TOTAL live sessions, not this run's
+  // own, so unrelated interactive sessions can leave a run unable to spawn ANY
+  // worker. Before this, `_schedule` just `break`ed: the run stayed in
+  // `executing` with pending subtasks, zero workers, and no gate — healthy-
+  // looking and permanently stuck. It now reports the stall, and — because
+  // nothing internal will ever re-drive a run with no work in flight — it
+  // re-checks on the only signal that capacity came back: a session going away.
+
+  /** Enter the stall. Callers must have established all three conditions. */
+  _pauseForResources(run) {
+    // No self-loop: a second pause while already stalled is not a state change
+    // (and `resource_paused -> resource_paused` is illegal by design).
+    if (run.phase === 'resource_paused') return
+    const live = this._liveSessionCount()
+    const detail = `${live}/${this._maxSessions} daemon sessions live (${this._cfg.reserveSessions} reserved) — no slot for the next worker`
+    this._setRunStatus(run, 'resource_paused', 'SESSION_POOL_EXHAUSTED')
+    this._appendTimeline(run, { kind: 'resource_paused', summary: 'waiting for session capacity', detail })
+    this.emit('run_resource_paused', {
+      runId: run.runId,
+      liveSessions: live,
+      maxSessions: this._maxSessions,
+      reserveSessions: this._cfg.reserveSessions,
+    })
+    this._emitRunDelta(run)
+  }
+
+  /** Leave the stall. No-op unless the run is actually stalled. */
+  _clearResourcePause(run) {
+    if (run.phase !== 'resource_paused') return
+    this._setRunStatus(run, 'executing')
+    this._appendTimeline(run, { kind: 'resource_resumed', summary: 'session capacity available — resuming' })
+    this.emit('run_resource_resumed', { runId: run.runId, liveSessions: this._liveSessionCount() })
+    this._emitRunDelta(run)
+  }
+
+  // A session — anyone's — went away, so the pool may have room again. Re-drive
+  // every stalled run's scheduler; `_schedule` re-checks headroom itself and
+  // clears the pause only if it can actually spawn.
+  //
+  // Deferred to a microtask because `session_destroyed` is emitted from INSIDE
+  // SessionManager.destroySession: scheduling synchronously would call
+  // createSession from within a teardown that has not finished its own
+  // bookkeeping. The defer also means the headroom read sees the completed
+  // destroy, never a half-torn-down pool.
+  _onSessionCapacityFreed() {
+    queueMicrotask(() => {
+      if (this._disposed) return
+      for (const run of [...this._runs.values()]) {
+        if (run.cancelled || run.phase !== 'resource_paused') continue
+        this._schedule(run)
+      }
+    })
+  }
+
   _onPermissionEscalation(info) {
     const run = this._runForSession(info.sessionId)
     if (!run) return
@@ -879,8 +965,15 @@ export class OrchestrationManager extends EventEmitter {
     for (const s of run.subtasks.values()) if (s.state === 'active') n += 1
     return n
   }
+  _liveSessionCount() {
+    return typeof this._sm.listSessions === 'function' ? this._sm.listSessions().length : this._sm._sessions?.size ?? 0
+  }
   _sessionHeadroom() {
-    const size = typeof this._sm.listSessions === 'function' ? this._sm.listSessions().length : this._sm._sessions?.size ?? 0
+    // NOTE: this is the daemon's TOTAL live session count, not the run's own —
+    // unrelated sessions can starve a run, which is why #6733 exists. Reserving
+    // orchestration capacity up front (counting only owned sessions) is the other
+    // half of that issue and is deliberately not done here.
+    const size = this._liveSessionCount()
     // Room to spawn ONE more session while still leaving reserveSessions slots
     // free — strict, so the reserve is preserved AFTER the new session exists.
     return size + 1 <= this._maxSessions - this._cfg.reserveSessions

--- a/packages/server/src/orchestration/run-model.js
+++ b/packages/server/src/orchestration/run-model.js
@@ -40,11 +40,17 @@ const RUN_TRANSITIONS = {
   created: ['planning'],
   planning: ['plan_review', 'executing', 'failed'], // executing when autoApprovePlan skips the gate
   plan_review: ['executing', 'cancelled'],
-  executing: ['plan_review', 'paused', 'budget_paused', 'synthesizing', 'executing', 'failed'],
+  executing: ['plan_review', 'paused', 'budget_paused', 'resource_paused', 'synthesizing', 'executing', 'failed'],
   paused: ['executing', 'cancelling'],
   budget_paused: ['executing', 'synthesizing', 'cancelling'],
+  // #6733 — session-pool starvation. Shaped exactly like budget_paused: the run
+  // resumes into `executing` when a slot frees, or goes straight to
+  // `synthesizing` if a gate resolution retired the last pending subtask while it
+  // was stalled. It is NOT self-looping: the engine no-ops a re-pause, so a
+  // resource_paused -> resource_paused write is a real bug and stays illegal.
+  resource_paused: ['executing', 'synthesizing', 'cancelling'],
   synthesizing: ['completed', 'failed'],
-  suspended: ['planning', 'plan_review', 'executing', 'budget_paused', 'paused', 'synthesizing', 'cancelled', 'failed'],
+  suspended: ['planning', 'plan_review', 'executing', 'budget_paused', 'resource_paused', 'paused', 'synthesizing', 'cancelled', 'failed'],
   cancelling: ['cancelled'],
   completed: [],
   failed: [],

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { EventEmitter } from 'node:events'
 
+import { RunSummarySchema } from '@chroxy/protocol'
 import { OrchestrationManager } from '../src/orchestration/orchestration-manager.js'
 import { OrchestrationPermissionGate } from '../src/orchestration/permission-gate.js'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
@@ -574,6 +575,121 @@ test('repo-audit preset supplies the goal and forces audit role', async () => {
     assert.equal(record.subtasks[0].role, 'worker.audit', 'implement coerced to audit')
     // the run was created with no explicit goal — the preset supplied it
     assert.equal(record.preset, 'repo-audit')
+  } finally {
+    cleanup()
+  }
+})
+
+// --- #6733: session-headroom starvation --------------------------------------
+
+// Settle the microtask + timer queues so a fully synchronous scheduler pass (and
+// anything it kicked off) has run before we assert.
+const settle = () => new Promise((r) => setTimeout(r, 20))
+
+// maxSessions 3 with a reserve of 1 means the scheduler only spawns a worker
+// while `liveSessions + 1 <= 2` — i.e. room for the architect plus exactly ONE
+// worker. Adding a single unrelated (non-run) session therefore starves the run
+// completely, which is the production shape of #6733: a busy daemon's own
+// interactive sessions occupy the pool the orchestrator counts against.
+const STARVED = { maxSessions: 3, reserveSessions: 1 }
+
+const workerSessions = (sm) => sm.created.filter((c) => String(c.opts.metadata?.orchestrationRole ?? '').startsWith('worker'))
+
+test('#6733: session-pool starvation surfaces resource_paused instead of a silent executing hang', async () => {
+  const { sm, ledger, mgr, cleanup } = makeHarness(happyDecider, { config: STARVED })
+  const stalls = []
+  const deltas = []
+  mgr.on('run_resource_paused', (p) => stalls.push(p))
+  mgr.on('run_delta', (d) => deltas.push(d))
+  try {
+    // An unrelated interactive session already holds a slot before the run starts.
+    sm.createSession({ metadata: {} })
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    await mgr.startRun(rec.runId)
+    await settle()
+
+    // POSITIVE CONTROL (passes on UNMODIFIED source): the fixture really starves
+    // the scheduler — the architect planned, but no worker was ever spawned and
+    // no subtask left `pending`. Without this the stall assertions below could
+    // pass for the wrong reason.
+    const record = ledger.getRun(rec.runId)
+    assert.equal(workerSessions(sm).length, 0, 'starvation fixture must block every worker spawn')
+    assert.ok(record.subtasks.length > 0, 'the architect must have produced subtasks to starve')
+    assert.ok(record.subtasks.every((s) => s.status === 'pending'), 'every subtask must still be pending')
+
+    // THE DEFECT: pre-fix the run sits in `executing` forever with no gate and no
+    // event. It must report the stall instead.
+    assert.equal(record.status, 'resource_paused', 'a run that cannot spawn any worker must not look healthy')
+    assert.equal(stalls.length, 1, 'exactly one run_resource_paused event')
+    assert.equal(stalls[0].runId, rec.runId)
+
+    // The stall must SURVIVE the wire, not just the ledger: RunSummarySchema.status
+    // is a strict z.enum, so a status missing from RUN_STATUS_VALUES makes the
+    // dashboard's safeParse drop the whole run header — the run would look frozen
+    // at its last valid status, which is the very failure this issue is about.
+    const stallDelta = deltas.at(-1)
+    assert.equal(stallDelta.run.status, 'resource_paused', 'the stall reached the wire projection')
+    const parsed = RunSummarySchema.safeParse(stallDelta.run)
+    assert.equal(parsed.success, true, `stalled RunSummary must validate: ${JSON.stringify(parsed.error?.issues ?? [])}`)
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6733: freeing a session slot clears resource_paused and the run runs to completion', async () => {
+  const { sm, ledger, mgr, cleanup } = makeHarness(happyDecider, { config: STARVED })
+  const resumes = []
+  mgr.on('run_resource_resumed', (p) => resumes.push(p))
+  try {
+    const interactive = sm.createSession({ metadata: {} })
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const stalled = waitFor(mgr, ['run_resource_paused'])
+    await mgr.startRun(rec.runId)
+    await stalled
+    assert.equal(ledger.getRun(rec.runId).status, 'resource_paused')
+
+    // The user closes their unrelated session → capacity is back. A stall that
+    // latches is worse than none, so this must self-clear with no user action.
+    const done = waitFor(mgr, ['run_completed'], { timeoutMs: 8000 })
+    sm.destroySession(interactive)
+    await done
+
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.status, 'completed')
+    assert.ok(record.subtasks.every((s) => s.status === 'done'), 'every subtask completed after the stall cleared')
+    assert.equal(resumes.length, 1, 'exactly one run_resource_resumed event')
+    assert.equal(resumes[0].runId, rec.runId)
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6733: ordinary saturation with a worker still in flight does NOT report a stall', async () => {
+  // No unrelated session: the architect + one worker exactly fill the pool, so
+  // the second subtask hits `!headroom` on every pass while the first worker
+  // runs. That is progress, not a stall — pausing here would fire on most runs
+  // and train the operator to ignore the state.
+  const { sm, ledger, mgr, cleanup } = makeHarness(happyDecider, { config: STARVED })
+  const stalls = []
+  mgr.on('run_resource_paused', (p) => stalls.push(p))
+  let peakLive = 0
+  const origCreate = sm.createSession.bind(sm)
+  sm.createSession = (opts) => {
+    const id = origCreate(opts)
+    peakLive = Math.max(peakLive, sm.listSessions().length)
+    return id
+  }
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+
+    // POSITIVE CONTROL: the headroom gate really engaged — with maxParallelWorkers
+    // defaulting to 2, an ungated scheduler would have had 3 sessions live at once.
+    assert.equal(peakLive, 2, 'the headroom gate must have serialized the two workers')
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
+    assert.equal(stalls.length, 0, 'a saturated but progressing run must not report a stall')
   } finally {
     cleanup()
   }

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -582,10 +582,6 @@ test('repo-audit preset supplies the goal and forces audit role', async () => {
 
 // --- #6733: session-headroom starvation --------------------------------------
 
-// Settle the microtask + timer queues so a fully synchronous scheduler pass (and
-// anything it kicked off) has run before we assert.
-const settle = () => new Promise((r) => setTimeout(r, 20))
-
 // maxSessions 3 with a reserve of 1 means the scheduler only spawns a worker
 // while `liveSessions + 1 <= 2` — i.e. room for the architect plus exactly ONE
 // worker. Adding a single unrelated (non-run) session therefore starves the run
@@ -605,8 +601,14 @@ test('#6733: session-pool starvation surfaces resource_paused instead of a silen
     // An unrelated interactive session already holds a slot before the run starts.
     sm.createSession({ metadata: {} })
     const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const stalled = waitFor(mgr, ['run_resource_paused'])
     await mgr.startRun(rec.runId)
-    await settle()
+    // Wait on the ACTUAL stall event, never a fixed sleep — a loaded CI runner
+    // can outlast any hard-coded settle time. The swallowed rejection is
+    // deliberate: on a regressed source this must still fall through to the
+    // positive controls and the status assertion below, which name WHY it
+    // failed, instead of dying on a bare `timeout waiting for ...`.
+    await stalled.catch(() => {})
 
     // POSITIVE CONTROL (passes on UNMODIFIED source): the fixture really starves
     // the scheduler — the architect planned, but no worker was ever spawned and
@@ -660,6 +662,53 @@ test('#6733: freeing a session slot clears resource_paused and the run runs to c
     assert.equal(resumes.length, 1, 'exactly one run_resource_resumed event')
     assert.equal(resumes[0].runId, rec.runId)
   } finally {
+    cleanup()
+  }
+})
+
+test('#6733: a destroy that does NOT restore headroom re-drives without re-pausing', async () => {
+  // Two unrelated sessions. Freeing ONE still leaves the run starved, so the
+  // session_destroyed re-drive lands on an already-stalled run. That re-entry is
+  // the crash path the engine's own no-op guard covers: `resource_paused ->
+  // resource_paused` is illegal by design, and _onSessionCapacityFreed schedules
+  // from inside a queueMicrotask, so a TransitionError there is an UNCAUGHT
+  // exception that takes the daemon down — not a caught, logged failure.
+  const { sm, ledger, mgr, cleanup } = makeHarness(happyDecider, { config: STARVED })
+  const stalls = []
+  const resumes = []
+  mgr.on('run_resource_paused', (p) => stalls.push(p))
+  mgr.on('run_resource_resumed', (p) => resumes.push(p))
+  const uncaught = []
+  const onUncaught = (err) => uncaught.push(err)
+  process.on('uncaughtException', onUncaught)
+  try {
+    const first = sm.createSession({ metadata: {} })
+    const second = sm.createSession({ metadata: {} })
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const stalled = waitFor(mgr, ['run_resource_paused'])
+    await mgr.startRun(rec.runId)
+    await stalled
+
+    // POSITIVE CONTROL (passes on UNMODIFIED source): freeing the FIRST slot
+    // really does leave the run starved — architect + `second` still fill the
+    // pool — so the re-drive below genuinely re-enters a stalled run rather
+    // than finding headroom and taking the ordinary clear path.
+    const settled = waitFor(mgr, ['run_resource_resumed'], { timeoutMs: 250 }).catch(() => null)
+    sm.destroySession(first)
+    await settled
+    assert.equal(ledger.getRun(rec.runId).status, 'resource_paused', 'still starved after the first slot frees')
+    assert.equal(resumes.length, 0, 'a re-drive with no headroom must not claim the stall cleared')
+    assert.equal(stalls.length, 1, 'and must not re-emit the stall it is already in')
+    assert.deepEqual(uncaught, [], 'the microtask re-drive must not throw an illegal self-transition')
+
+    // ...and the run is still live, not wedged: the NEXT free completes it.
+    const done = waitFor(mgr, ['run_completed'], { timeoutMs: 8000 })
+    sm.destroySession(second)
+    await done
+    assert.equal(ledger.getRun(rec.runId).status, 'completed')
+    assert.equal(resumes.length, 1, 'exactly one clear, on the free that actually restored headroom')
+  } finally {
+    process.off('uncaughtException', onUncaught)
     cleanup()
   }
 })

--- a/packages/server/tests/orchestration-run-model.test.js
+++ b/packages/server/tests/orchestration-run-model.test.js
@@ -28,6 +28,18 @@ describe('run transitions', () => {
     assert.equal(assertRunTransition('executing', 'cancelling'), true)
     assert.equal(assertRunTransition('planning', 'suspended'), true)
   })
+  it('#6733: allows the resource_paused stall to be entered, cleared and cancelled', () => {
+    // The guards are FAIL-CLOSED since #6732, so a state the engine can journal
+    // but the table omits throws at runtime and wedges a live run.
+    assert.equal(assertRunTransition('executing', 'resource_paused'), true)
+    assert.equal(assertRunTransition('resource_paused', 'executing'), true)
+    // a gate resolution can retire the last pending subtask while stalled
+    assert.equal(assertRunTransition('resource_paused', 'synthesizing'), true)
+    assert.equal(assertRunTransition('resource_paused', 'cancelling'), true)
+    assert.equal(assertRunTransition('suspended', 'resource_paused'), true)
+    // ...but re-pausing an already-stalled run is a bug, not a state change
+    assert.throws(() => assertRunTransition('resource_paused', 'resource_paused'), TransitionError)
+  })
   it('rejects illegal + terminal-source transitions', () => {
     assert.throws(() => assertRunTransition('created', 'completed'), TransitionError)
     assert.throws(() => assertRunTransition('completed', 'executing'), TransitionError)


### PR DESCRIPTION
## Defect

`OrchestrationManager._sessionHeadroom()` gates worker spawns on the daemon's **total** live
session count, not the count owned by the run:

```js
return size + 1 <= this._maxSessions - this._cfg.reserveSessions   // size = ALL live sessions
```

So a couple of unrelated interactive sessions can leave a run unable to spawn *any* worker. The
scheduler's entire response to that was a bare `break`:

```js
if (!this._sessionHeadroom()) break
```

No else-branch, no event, no status change. The run then holds pending subtasks, runs zero workers,
opens no gate — and stays in `executing` looking perfectly healthy, indefinitely. `grep resource_paused`
over the file returned zero hits before this PR: no stall state existed at all.

## Fix

A `resource_paused` run state, shaped after the existing `budget_paused` pause rather than invented
fresh.

**Entry requires all three conditions**, not just "no headroom": pending subtasks remain **and**
zero workers are in flight **and** there is no headroom. Saturation with a worker still running is
*progress* — its completion re-enters `_schedule` — and pausing there would fire on most runs and
train the operator to ignore the state.

**It cannot latch.** Two mechanisms:

1. A stalled run has nothing in flight, so no internal event would ever re-drive it. The engine
   subscribes to `sessionManager`'s `session_destroyed` — the only signal that capacity returned —
   and re-enters `_schedule`, which re-checks headroom itself and clears the state as soon as it can
   actually spawn. The re-entry is deferred to a microtask because `session_destroyed` is emitted
   from *inside* `SessionManager.destroySession`; scheduling synchronously would call `createSession`
   from within a teardown that has not finished its own bookkeeping.
2. `_schedule` no longer early-returns on the paused phase. It previously bailed on
   `run.phase !== 'executing'`, which meant a gate resolution that retired the *last* pending subtask
   while stalled could never reach synthesis — the pause would latch with no pending work left.

The stall is cleared *before* any other pause/spawn decision in the loop, so the state never lies and
the next status write (a budget pause, say) starts from `executing`.

`_sessionHeadroom()` still counts total sessions — the other half of #6733 (reserving orchestration
capacity up front and counting only owned sessions) is deliberately **not** done here, and the
function now carries a comment saying so.

## Adjacent-field enumeration

`resource_paused` is a new run-state literal. Every surface it has to reach:

| Surface | File | Done |
|---|---|---|
| Wire enum (`RunSummarySchema.status` is a strict `z.enum` — a missing value makes `safeParse` drop the whole run header) | `packages/protocol/src/schemas/server/orchestration.ts` | ✅ + rebuilt `dist` |
| Run transition table (fail-closed since #6732 — an unlisted target **throws at runtime**) | `packages/server/src/orchestration/run-model.js` — `executing` row, new `resource_paused` row, `suspended` row | ✅ |
| Engine status writes | `orchestration-manager.js` | ✅ |
| Dashboard status-chip accent (`warn`) | `OrchestrationRunsSection.tsx` | ✅ |
| Dashboard resume control | `OrchestrationRunsSection.tsx` | ✅ **deliberately NOT added** — the engine clears this itself, so a Resume button would no-op or race it. The chip is the whole affordance. |
| Persisted ledger record | `run-ledger.js` / `run-record.js` store `status` as an opaque string; `isTerminalStatus` correctly excludes it (non-terminal) | ✅ no change needed |
| Wire projection | `to-wire.js` passes `record.status` straight through | ✅ no change needed |
| Mobile app | orchestration is dashboard-only in v1; `budget_paused` has zero hits under `packages/app` | ✅ n/a |
| Design docs | `docs/design/orchestration/{README,engine}.md` | ✅ |

`docs/design/orchestration/surface.md`'s `RUN_STATUSES` block is **intentionally left stale** — it is
the superseded original proposal (still listing invented states like `awaiting_gate`/`delegating`),
and README's reconciliation F1 explicitly supersedes it.

## Verification

**RED first** — three new engine tests, run before the fix:

```
not ok 1 - #6733: session-pool starvation surfaces resource_paused instead of a silent executing hang
  error: |-
    a run that cannot spawn any worker must not look healthy
    + actual - expected
    + 'executing'
    - 'resource_paused'
not ok 2 - #6733: freeing a session slot clears resource_paused and the run runs to completion
  error: 'timeout waiting for run_resource_paused'
ok 3 - #6733: ordinary saturation with a worker still in flight does NOT report a stall
# tests 3 / pass 1 / fail 2
```

**Positive controls** (all pass on unmodified source, proving the fixtures take effect):

- entry test: `workerSessions(sm).length === 0`, subtasks exist, and every one is still `pending` —
  the `maxSessions: 3, reserveSessions: 1` + one unrelated session fixture really does starve the
  scheduler, so the state assertion is failing for the right reason;
- no-cry-wolf test: `peakLive === 2` — with `maxParallelWorkers` defaulting to 2, an ungated
  scheduler would have had 3 sessions live at once, so the headroom `break` genuinely engaged;
- dashboard test: the chip's text is `resource paused`, so the accent assertion reads the right chip.

**Mutation checks** (each reverted after):

| Mutation | Result |
|---|---|
| Drop the `session_destroyed` subscription | recovery test RED (`timeout waiting for run_completed`), entry test still green — the recovery path is independently covered, not riding on entry |
| Drop the `activeWorkerCount === 0` condition (pause on no-headroom alone) | no-cry-wolf test RED **and** the recovery test RED — the three-condition guard is load-bearing in two places |
| Remove `resource_paused` from the `executing` transition row | `illegal run transition: executing -> resource_paused` — the #6732 fail-closed guard rejects it at runtime; entry + recovery + the new run-model test all RED |
| Remove `resource_paused` from `RUN_STATUS_VALUES` (+ rebuild dist) | entry + recovery RED on the `RunSummarySchema.safeParse` assertion — the wire enum really is required, not decorative |

**Suites** (Node 22):

- `packages/server` orchestration set (`orchestration-*.test.js`, `server-orchestrator`,
  `session-manager-orchestration-badges`) — 213 pass, 0 fail
- `packages/protocol` — 388 pass, 0 fail
- `packages/store-core` — 2131 pass, 0 fail (+ typecheck clean)
- `packages/dashboard` — 5056 pass across 292 files, 0 fail; `npm run typecheck` clean
- protocol `dist` rebuilt and committed (CI's "protocol dist is in sync with src" gate)

**Lints:**

- server eslint: 0 errors (9 pre-existing warnings, none in touched files)
- all five custom shell lints (`lint-tests-state-file-path`, `lint-session-opt-forwarding`,
  `lint-logger-session-scoping`, `lint-claude-family-explicit`, `lint-ws-index-mutations`): OK

## Not in scope

- #7132 (`cancelRun` lost idempotence under the #6732 guard) — filed separately, untouched here.
- The "reserve orchestration capacity up front / count only owned sessions" alternative from the
  issue. This PR takes the visibility half; the accounting half would change spawn behaviour for
  every run and belongs in its own change.

Closes #6733.
