### PR TITLE
fix(server,protocol): record a deliberate Stop as `interrupted`, not a generic error

### DIFF
--- a/packages/dashboard/src/components/ScheduledTasksSection.test.tsx
+++ b/packages/dashboard/src/components/ScheduledTasksSection.test.tsx
@@ -290,6 +290,10 @@ describe('ScheduledTasksSection — honest per-task status', () => {
     ['refused', { lastRun: { at: 1, status: 'refused' } }, 'REFUSED', 'bad'],
     ['timeout', { lastRun: { at: 1, status: 'timeout' } }, 'TIMEOUT', 'bad'],
     ['skipped', { lastRun: { at: 1, status: 'skipped' } }, 'SKIPPED', 'warn'],
+    // #7038 — a deliberate operator Stop. `warn`, not `bad`: the whole point of
+    // giving it its own status is that it is NOT a crash, and a chip styled
+    // identically to ERROR would say "crash" all over again.
+    ['interrupted', { lastRun: { at: 1, status: 'interrupted' } }, 'INTERRUPTED', 'warn'],
     ['never run', { lastRun: null }, 'NEVER RUN', 'warn'],
     ['paused', { enabled: false }, 'PAUSED', 'warn'],
   ]
@@ -306,7 +310,7 @@ describe('ScheduledTasksSection — honest per-task status', () => {
       seen.add(tag)
       unmount()
     }
-    // Distinctness: 7 cases produced 7 different tags.
+    // Distinctness: every case produced a different tag.
     expect(seen.size).toBe(CASES.length)
   })
 

--- a/packages/dashboard/src/components/ScheduledTasksSection.tsx
+++ b/packages/dashboard/src/components/ScheduledTasksSection.tsx
@@ -15,9 +15,11 @@
  *    helper in @chroxy/protocol — the SAME module the CLI's `healthTag()` uses —
  *    so the two surfaces cannot drift into disagreeing about a task. Exactly one
  *    tag (`OK`) styles as healthy, and it is asserted positively: a task that has
- *    never fired, is paused, was refused, timed out, was skipped, or is
- *    quarantined can never render as healthy, and an unrecognized future status
- *    lands on `ERROR` rather than falling through to something friendlier.
+ *    never fired, is paused, was refused, timed out, was skipped, was
+ *    deliberately interrupted, or is quarantined can never render as healthy, and
+ *    an unrecognized future status lands on `ERROR` rather than falling through
+ *    to something friendlier. Honesty runs the other way too: an `INTERRUPTED`
+ *    run (#7038 — an operator Stop) is warn-toned, not styled like a crash.
  *    A tag describes the last RUN, though, not whether the task will FIRE — so
  *    a task this panel knows cannot fire (paused, refused, quarantined, or no
  *    armed engine) also loses the green tone and its next-run timestamp (#7026,

--- a/packages/protocol/dist/scheduled-task-health.d.ts
+++ b/packages/protocol/dist/scheduled-task-health.d.ts
@@ -30,16 +30,17 @@
  * `healthTag()` return set exactly — adding one here without teaching the CLI
  * (or vice versa) fails the parity test.
  */
-export declare const SCHEDULED_TASK_HEALTH_TAGS: readonly ["OK", "NEVER RUN", "PAUSED", "SKIPPED", "TIMEOUT", "REFUSED", "ERROR"];
+export declare const SCHEDULED_TASK_HEALTH_TAGS: readonly ["OK", "NEVER RUN", "PAUSED", "SKIPPED", "INTERRUPTED", "TIMEOUT", "REFUSED", "ERROR"];
 export type ScheduledTaskHealthTag = (typeof SCHEDULED_TASK_HEALTH_TAGS)[number];
 /**
  * Rendering severity. `ok` is reserved for the single healthy tag; `warn` covers
- * "nothing is broken but nothing ran either" (paused / never fired / slot
- * passed); `bad` covers an actual failure or a refusal to run.
+ * "nothing is broken, but the work did not complete" (paused / never fired /
+ * slot passed / deliberately stopped); `bad` covers an actual failure or a
+ * refusal to run.
  */
 export type ScheduledTaskHealthTone = 'ok' | 'warn' | 'bad';
 /** The `lastRun.status` values the engine can persist (scheduled-task-store.js). */
-export declare const SCHEDULED_TASK_LAST_RUN_STATUSES: readonly ["success", "error", "skipped", "timeout", "refused"];
+export declare const SCHEDULED_TASK_LAST_RUN_STATUSES: readonly ["success", "error", "skipped", "timeout", "refused", "interrupted"];
 export type ScheduledTaskLastRunStatus = (typeof SCHEDULED_TASK_LAST_RUN_STATUSES)[number];
 /** The minimum shape this module needs; the full task carries much more. */
 export interface ScheduledTaskHealthInput {
@@ -73,7 +74,17 @@ export interface ScheduledTaskHealth {
  * ordering prevents.
  */
 export declare function deriveScheduledTaskHealthTag(task: ScheduledTaskHealthInput | null | undefined): ScheduledTaskHealthTag;
-/** Severity for a tag. Only `OK` is `ok`; nothing else can style as healthy. */
+/**
+ * Severity for a tag. Only `OK` is `ok`; nothing else can style as healthy.
+ *
+ * `INTERRUPTED` is `warn`, not `bad`, and that is the point of #7038 rather than
+ * an aesthetic call: the defect was that a deliberate Stop was presented as a
+ * failure. Giving it its own tag but keeping the failure styling would re-merge
+ * it with a crash at the layer an operator actually reads — the colour of the
+ * chip. Nothing is broken and nothing needs fixing; the run simply did not
+ * finish, which is the same class as `SKIPPED`. It is still never healthy:
+ * `isHealthy` is `tag === 'OK'`, so an interrupted run can't read as fine.
+ */
 export declare function scheduledTaskHealthTone(tag: ScheduledTaskHealthTag): ScheduledTaskHealthTone;
 /**
  * Full health readout for a task, including the engine's process-scoped

--- a/packages/protocol/dist/scheduled-task-health.js
+++ b/packages/protocol/dist/scheduled-task-health.js
@@ -35,6 +35,7 @@ export const SCHEDULED_TASK_HEALTH_TAGS = [
     'NEVER RUN',
     'PAUSED',
     'SKIPPED',
+    'INTERRUPTED',
     'TIMEOUT',
     'REFUSED',
     'ERROR',
@@ -46,6 +47,9 @@ export const SCHEDULED_TASK_LAST_RUN_STATUSES = [
     'skipped',
     'timeout',
     'refused',
+    // #7038 — a DELIBERATE stop (operator Stop / orchestration cancel), which the
+    // engine previously recorded as `error`, indistinguishable from a crash.
+    'interrupted',
 ];
 /**
  * Derive the health TAG for a task. Pure, total, and never throws — a malformed
@@ -74,6 +78,8 @@ export function deriveScheduledTaskHealthTag(task) {
             return 'SKIPPED';
         case 'timeout':
             return 'TIMEOUT';
+        case 'interrupted':
+            return 'INTERRUPTED';
         default:
             // `error` AND anything unrecognized. Falling through to the worst
             // plausible tag (never to `OK`) is what keeps a future engine status from
@@ -81,7 +87,17 @@ export function deriveScheduledTaskHealthTag(task) {
             return 'ERROR';
     }
 }
-/** Severity for a tag. Only `OK` is `ok`; nothing else can style as healthy. */
+/**
+ * Severity for a tag. Only `OK` is `ok`; nothing else can style as healthy.
+ *
+ * `INTERRUPTED` is `warn`, not `bad`, and that is the point of #7038 rather than
+ * an aesthetic call: the defect was that a deliberate Stop was presented as a
+ * failure. Giving it its own tag but keeping the failure styling would re-merge
+ * it with a crash at the layer an operator actually reads — the colour of the
+ * chip. Nothing is broken and nothing needs fixing; the run simply did not
+ * finish, which is the same class as `SKIPPED`. It is still never healthy:
+ * `isHealthy` is `tag === 'OK'`, so an interrupted run can't read as fine.
+ */
 export function scheduledTaskHealthTone(tag) {
     switch (tag) {
         case 'OK':
@@ -89,6 +105,7 @@ export function scheduledTaskHealthTone(tag) {
         case 'NEVER RUN':
         case 'PAUSED':
         case 'SKIPPED':
+        case 'INTERRUPTED':
             return 'warn';
         default:
             return 'bad';

--- a/packages/protocol/dist/schemas/server/scheduler.d.ts
+++ b/packages/protocol/dist/schemas/server/scheduler.d.ts
@@ -33,8 +33,17 @@ import { z } from 'zod';
  * `LAST_RUN_STATUSES`). `refused` = the engine declined to start the run at all;
  * distinct from `error` (it ran and failed) and `skipped` (the slot passed), so a
  * reader can tell an operator that NOTHING ran and the definition needs fixing.
+ * `interrupted` (#7038) = the run was deliberately STOPPED (an operator Stop, an
+ * orchestration cancel) rather than failing — also distinct from `error`, so an
+ * operator need not read the free-text message to tell a Stop from a crash.
+ *
+ * KEEP IN SYNC with `SCHEDULED_TASK_LAST_RUN_STATUSES` in
+ * `../../scheduled-task-health.ts`. Both are public exports of this package and
+ * both claim to mirror the engine's gate, so a status added to one and not the
+ * other leaves a stale-but-exported roster for the next consumer to trust.
+ * `packages/server/tests/scheduled-task-health-parity.test.js` pins them equal.
  */
-export declare const SCHEDULED_TASK_LAST_RUN_STATUS_VALUES: readonly ["success", "error", "skipped", "timeout", "refused"];
+export declare const SCHEDULED_TASK_LAST_RUN_STATUS_VALUES: readonly ["success", "error", "skipped", "timeout", "refused", "interrupted"];
 /** Cadence kinds the registry accepts (scheduled-task-store.js's `CADENCE_KINDS`). */
 export declare const SCHEDULED_TASK_CADENCE_KIND_VALUES: readonly ["once", "interval", "cron"];
 /** Mutations the panel can request. `pause`/`resume` are `enabled` flips. */

--- a/packages/protocol/dist/schemas/server/scheduler.js
+++ b/packages/protocol/dist/schemas/server/scheduler.js
@@ -33,6 +33,15 @@ import { z } from 'zod';
  * `LAST_RUN_STATUSES`). `refused` = the engine declined to start the run at all;
  * distinct from `error` (it ran and failed) and `skipped` (the slot passed), so a
  * reader can tell an operator that NOTHING ran and the definition needs fixing.
+ * `interrupted` (#7038) = the run was deliberately STOPPED (an operator Stop, an
+ * orchestration cancel) rather than failing — also distinct from `error`, so an
+ * operator need not read the free-text message to tell a Stop from a crash.
+ *
+ * KEEP IN SYNC with `SCHEDULED_TASK_LAST_RUN_STATUSES` in
+ * `../../scheduled-task-health.ts`. Both are public exports of this package and
+ * both claim to mirror the engine's gate, so a status added to one and not the
+ * other leaves a stale-but-exported roster for the next consumer to trust.
+ * `packages/server/tests/scheduled-task-health-parity.test.js` pins them equal.
  */
 export const SCHEDULED_TASK_LAST_RUN_STATUS_VALUES = [
     'success',
@@ -40,6 +49,7 @@ export const SCHEDULED_TASK_LAST_RUN_STATUS_VALUES = [
     'skipped',
     'timeout',
     'refused',
+    'interrupted',
 ];
 /** Cadence kinds the registry accepts (scheduled-task-store.js's `CADENCE_KINDS`). */
 export const SCHEDULED_TASK_CADENCE_KIND_VALUES = ['once', 'interval', 'cron'];

--- a/packages/protocol/src/scheduled-task-health.ts
+++ b/packages/protocol/src/scheduled-task-health.ts
@@ -36,6 +36,7 @@ export const SCHEDULED_TASK_HEALTH_TAGS = [
   'NEVER RUN',
   'PAUSED',
   'SKIPPED',
+  'INTERRUPTED',
   'TIMEOUT',
   'REFUSED',
   'ERROR',
@@ -45,8 +46,9 @@ export type ScheduledTaskHealthTag = (typeof SCHEDULED_TASK_HEALTH_TAGS)[number]
 
 /**
  * Rendering severity. `ok` is reserved for the single healthy tag; `warn` covers
- * "nothing is broken but nothing ran either" (paused / never fired / slot
- * passed); `bad` covers an actual failure or a refusal to run.
+ * "nothing is broken, but the work did not complete" (paused / never fired /
+ * slot passed / deliberately stopped); `bad` covers an actual failure or a
+ * refusal to run.
  */
 export type ScheduledTaskHealthTone = 'ok' | 'warn' | 'bad'
 
@@ -57,6 +59,9 @@ export const SCHEDULED_TASK_LAST_RUN_STATUSES = [
   'skipped',
   'timeout',
   'refused',
+  // #7038 — a DELIBERATE stop (operator Stop / orchestration cancel), which the
+  // engine previously recorded as `error`, indistinguishable from a crash.
+  'interrupted',
 ] as const
 
 export type ScheduledTaskLastRunStatus = (typeof SCHEDULED_TASK_LAST_RUN_STATUSES)[number]
@@ -108,6 +113,8 @@ export function deriveScheduledTaskHealthTag(
       return 'SKIPPED'
     case 'timeout':
       return 'TIMEOUT'
+    case 'interrupted':
+      return 'INTERRUPTED'
     default:
       // `error` AND anything unrecognized. Falling through to the worst
       // plausible tag (never to `OK`) is what keeps a future engine status from
@@ -116,7 +123,17 @@ export function deriveScheduledTaskHealthTag(
   }
 }
 
-/** Severity for a tag. Only `OK` is `ok`; nothing else can style as healthy. */
+/**
+ * Severity for a tag. Only `OK` is `ok`; nothing else can style as healthy.
+ *
+ * `INTERRUPTED` is `warn`, not `bad`, and that is the point of #7038 rather than
+ * an aesthetic call: the defect was that a deliberate Stop was presented as a
+ * failure. Giving it its own tag but keeping the failure styling would re-merge
+ * it with a crash at the layer an operator actually reads — the colour of the
+ * chip. Nothing is broken and nothing needs fixing; the run simply did not
+ * finish, which is the same class as `SKIPPED`. It is still never healthy:
+ * `isHealthy` is `tag === 'OK'`, so an interrupted run can't read as fine.
+ */
 export function scheduledTaskHealthTone(tag: ScheduledTaskHealthTag): ScheduledTaskHealthTone {
   switch (tag) {
     case 'OK':
@@ -124,6 +141,7 @@ export function scheduledTaskHealthTone(tag: ScheduledTaskHealthTag): ScheduledT
     case 'NEVER RUN':
     case 'PAUSED':
     case 'SKIPPED':
+    case 'INTERRUPTED':
       return 'warn'
     default:
       return 'bad'

--- a/packages/protocol/src/schemas/server/scheduler.ts
+++ b/packages/protocol/src/schemas/server/scheduler.ts
@@ -35,6 +35,15 @@ import { z } from 'zod'
  * `LAST_RUN_STATUSES`). `refused` = the engine declined to start the run at all;
  * distinct from `error` (it ran and failed) and `skipped` (the slot passed), so a
  * reader can tell an operator that NOTHING ran and the definition needs fixing.
+ * `interrupted` (#7038) = the run was deliberately STOPPED (an operator Stop, an
+ * orchestration cancel) rather than failing — also distinct from `error`, so an
+ * operator need not read the free-text message to tell a Stop from a crash.
+ *
+ * KEEP IN SYNC with `SCHEDULED_TASK_LAST_RUN_STATUSES` in
+ * `../../scheduled-task-health.ts`. Both are public exports of this package and
+ * both claim to mirror the engine's gate, so a status added to one and not the
+ * other leaves a stale-but-exported roster for the next consumer to trust.
+ * `packages/server/tests/scheduled-task-health-parity.test.js` pins them equal.
  */
 export const SCHEDULED_TASK_LAST_RUN_STATUS_VALUES = [
   'success',
@@ -42,6 +51,7 @@ export const SCHEDULED_TASK_LAST_RUN_STATUS_VALUES = [
   'skipped',
   'timeout',
   'refused',
+  'interrupted',
 ] as const
 
 /** Cadence kinds the registry accepts (scheduled-task-store.js's `CADENCE_KINDS`). */

--- a/packages/server/src/cli/schedule-cmd.js
+++ b/packages/server/src/cli/schedule-cmd.js
@@ -31,9 +31,11 @@
  *
  * `list` and `last-run` render a task's `lastRun` status verbatim (never
  * papered over): `refused` and a best-effort-persisted quarantine message
- * both show up as an unhealthy `[REFUSED]`/`[ERROR]` tag, and a task that has
- * never fired is always labelled `[NEVER RUN]` rather than left blank —
- * nothing here is allowed to *look* healthy when it isn't.
+ * both show up as an unhealthy `[REFUSED]`/`[ERROR]` tag, a deliberately
+ * stopped run shows `[INTERRUPTED]` rather than borrowing the crash tag
+ * (#7038), and a task that has never fired is always labelled `[NEVER RUN]`
+ * rather than left blank — nothing here is allowed to *look* healthy when it
+ * isn't, and nothing is allowed to look BROKEN when it merely stopped.
  */
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
@@ -171,7 +173,12 @@ function describeCadence(cadence) {
  * `NEVER RUN` — never blank, never mistaken for healthy — and every recorded
  * `lastRun.status` maps to its own tag so `refused` (and a best-effort
  * quarantine write, which persists as `refused`) is never confused with
- * `success`.
+ * `success`, and `interrupted` (#7038 — a deliberate Stop) is never confused
+ * with `error`.
+ *
+ * Kept byte-for-byte in step with `deriveScheduledTaskHealthTag` in
+ * @chroxy/protocol; `tests/scheduled-task-health-parity.test.js` fails if a
+ * status the shared helper tags by name falls through to `default:` here.
  */
 function healthTag(task) {
   if (!task.enabled) return 'PAUSED'
@@ -185,6 +192,8 @@ function healthTag(task) {
       return 'SKIPPED'
     case 'timeout':
       return 'TIMEOUT'
+    case 'interrupted':
+      return 'INTERRUPTED'
     default:
       return 'ERROR'
   }

--- a/packages/server/src/orchestration/orchestration-manager.js
+++ b/packages/server/src/orchestration/orchestration-manager.js
@@ -36,6 +36,7 @@ import {
   buildExecutePrompt, buildResultReviewPrompt, buildSynthesisPrompt,
 } from './role-prompts.js'
 import { createGitOps } from './git-ops.js'
+import { TurnError } from './turn-driver.js'
 import { recordToRunSummary, recordToRunDetail, gateToWire } from './to-wire.js'
 import { buildRunReport, renderReportMarkdown } from './run-report.js'
 
@@ -114,7 +115,13 @@ const IMPLEMENT_ELIGIBLE_PROVIDERS = new Set(['codex'])
 
 // Engine-side subtask states that end scheduling. 'escalated' is deliberately
 // excluded — it awaits a user gate, so it must block synthesis.
-const TERMINAL_SUBTASK_STATES = new Set(['done', 'failed', 'skipped'])
+//
+// 'interrupted' (#7038) IS included: nothing will re-drive a stopped subtask on
+// its own, so leaving it out would park the run forever waiting on a node that
+// can no longer move — a hang, not a status bug. It stays resumable in the
+// transition table (`interrupted -> briefing`, run-model.js); an explicit resume
+// re-enters the loop, which is what makes it different from 'failed'.
+const TERMINAL_SUBTASK_STATES = new Set(['done', 'failed', 'skipped', 'interrupted'])
 function isTerminalSubtaskState(state) { return TERMINAL_SUBTASK_STATES.has(state) }
 
 export class OrchestrationManager extends EventEmitter {
@@ -412,8 +419,17 @@ export class OrchestrationManager extends EventEmitter {
       const st = run.subtasks.get(subtaskId)
       st.state = 'active'
       this._runSubtask(run, subtaskId).catch((err) => {
-        this._log?.warn?.(`subtask ${subtaskId} crashed: ${err?.message || err}`)
-        this._finishSubtask(run, subtaskId, 'failed').catch(() => {})
+        // #7038 — a DELIBERATE stop is not a crash. TurnDriver already gives an
+        // interrupt its own code (TURN_STOPPED, #7009) and run-model already
+        // declares an `interrupted` node state; this arm mapped every thrown
+        // turn to `failed`, so nothing ever wrote it and an operator Stop was
+        // recorded exactly like a worker that blew up. `interrupted` is also the
+        // resumable one (`interrupted -> briefing`), so the mislabel discarded
+        // the only thing that distinguishes the two.
+        const interrupted = err instanceof TurnError && err.code === 'TURN_STOPPED'
+        if (interrupted) this._log?.info?.(`subtask ${subtaskId} interrupted: ${err?.message || err}`)
+        else this._log?.warn?.(`subtask ${subtaskId} crashed: ${err?.message || err}`)
+        this._finishSubtask(run, subtaskId, interrupted ? 'interrupted' : 'failed').catch(() => {})
       })
     }
   }

--- a/packages/server/src/scheduled-task-store.js
+++ b/packages/server/src/scheduled-task-store.js
@@ -112,7 +112,17 @@ const MAX_EPOCH_MS = 8.64e15
 // mode it could not verify. Distinct from `error` (the run happened and failed)
 // and `skipped` (the slot passed) so a reader can tell an operator that NOTHING
 // ran and that the task definition needs fixing.
-const LAST_RUN_STATUSES = new Set(['success', 'error', 'skipped', 'timeout', 'refused'])
+// `interrupted` (#7038) = the run was deliberately STOPPED (an operator Stop, an
+// orchestration cancel) rather than failing. Distinct from `error` for the same
+// reason `refused` is: nothing is broken, so an operator must not have to read
+// the free-text message to tell an intentional interrupt from a crash.
+//
+// This set is a HARD GATE, not documentation: normalizeLastRun() throws on
+// anything outside it, and the engine turns that throw into a QUARANTINE
+// (scheduler.js `_recordRun` — "its run outcome could not be recorded"). An
+// engine status missing here therefore does not just fail to persist; it stops
+// the task firing for the rest of the process.
+const LAST_RUN_STATUSES = new Set(['success', 'error', 'skipped', 'timeout', 'refused', 'interrupted'])
 
 /**
  * Error thrown when a task submitted to add()/update() is malformed. Carries the

--- a/packages/server/src/scheduler.js
+++ b/packages/server/src/scheduler.js
@@ -85,9 +85,11 @@
 //    clamped mode on the session and VERIFIES it by read-back. The invariant is
 //    absolute: a scheduled fire runs at the clamped mode, or it does not run.
 // 7. Every fire attempt — success, error, timeout, permission-blocked, refused,
-//    shed — is recorded into the registry so #6868/#6871 can surface it. A run
-//    the engine refused is recorded `refused` (never `success`), and a run whose
-//    tool calls were blocked is recorded `error`. NOTHING reports `success`
+//    interrupted, shed — is recorded into the registry so #6868/#6871 can surface
+//    it. A run the engine refused is recorded `refused` (never `success`), a run
+//    whose tool calls were blocked is recorded `error`, and a run someone
+//    deliberately STOPPED is recorded `interrupted` (#7038) rather than being
+//    dropped into the same bucket as a provider crash. NOTHING reports `success`
 //    unless the turn actually completed with no permission prompt raised.
 //
 // ── Resource posture (#6933 lesson) ──────────────────────────────────────────
@@ -187,8 +189,32 @@ const SCHEDULED_ALLOWED_PERMISSION_MODES = new Set([SCHEDULED_PERMISSION_MODE, '
  */
 export const REFUSED_STATUS = 'refused'
 
+/**
+ * The `lastRun.status` recorded when a run was DELIBERATELY STOPPED (#7038):
+ * someone pressed Stop on the scheduled session, or an orchestration cancel
+ * interrupted the turn. TurnDriver surfaces that as `TURN_STOPPED` (#7009), and
+ * until now this engine dropped it into the same `error` bucket as a provider
+ * crash — same status, differing only by a free-text message nothing keys on —
+ * so the registry could not distinguish "I stopped this" from "this blew up".
+ *
+ * Named `interrupted` rather than `stopped` for two reasons. It is the word the
+ * rest of the codebase already uses for this exact event — orchestration's
+ * subtask state (`run-model.js` `TERMINAL_NODE_STATUSES`) and the turn-driver's
+ * own message ('turn interrupted before completing') — so one concept keeps one
+ * name across the daemon. And `STOPPED` sitting next to `PAUSED` in a health
+ * chip reads as a statement about the SCHEDULE ("this task is stopped") rather
+ * than about the run, which is precisely the kind of honest-status ambiguity
+ * this vocabulary exists to avoid.
+ *
+ * NOT `success` (the work did not complete) and NOT `error` (nothing is broken;
+ * a human or a cancel did this on purpose). A permission-BLOCKED run that the
+ * engine denied and then interrupted stays `error` — see `_runViaSessionManager`,
+ * where the `runState.blocked` check deliberately precedes this one.
+ */
+export const INTERRUPTED_STATUS = 'interrupted'
+
 /** Statuses `_fire` passes through verbatim; everything else becomes `error`. */
-const PASSTHROUGH_STATUSES = new Set(['success', 'timeout', 'skipped', REFUSED_STATUS])
+const PASSTHROUGH_STATUSES = new Set(['success', 'timeout', 'skipped', REFUSED_STATUS, INTERRUPTED_STATUS])
 
 /**
  * Thrown internally when a run must be refused after the executor was entered
@@ -782,9 +808,22 @@ export class SchedulerEngine extends EventEmitter {
       if (runState.blocked) return this._blockedOutcome(runState, sessionId)
       return { status: 'success', sessionId }
     } catch (err) {
+      // ORDER IS LOAD-BEARING. `runState.blocked` is checked FIRST, ahead of the
+      // TURN_STOPPED arm below, because the engine's own deny path reaches this
+      // catch through exactly the same rejection: it answers `deny`, interrupts
+      // the turn, and TurnDriver rejects TURN_STOPPED (#7009). That run is a real
+      // failure — the agent asked for permission nobody could grant — and must
+      // keep the `error` status it has always had. Only an interrupt with NO
+      // permission activity is the benign operator Stop.
       if (runState.blocked) return this._blockedOutcome(runState, sessionId)
       if (err instanceof TurnError && err.code === 'TURN_TIMEOUT') {
         return { status: 'timeout', sessionId, error: `run exceeded ${ctx.runTimeoutMs}ms` }
+      }
+      if (err instanceof TurnError && err.code === 'TURN_STOPPED') {
+        // #7038 — a deliberate Stop, not a fault. Its own status so an operator
+        // reading the registry (CLI / dashboard chip) can tell it apart from a
+        // provider crash instead of having to parse the error string.
+        return { status: INTERRUPTED_STATUS, sessionId, error: err?.message || 'turn interrupted before completing' }
       }
       return { status: 'error', sessionId, error: err?.message || String(err) }
     } finally {

--- a/packages/server/tests/orchestration-manager.test.js
+++ b/packages/server/tests/orchestration-manager.test.js
@@ -21,6 +21,20 @@ import { TurnDriver } from '../src/orchestration/turn-driver.js'
 
 const KIND_RE = /kind "([a-z_]+)"/
 
+/**
+ * Decider sentinel: model an operator pressing Stop on this turn. The provider
+ * emits `stopped` INSTEAD of a result/error (#4881), which TurnDriver treats as
+ * terminal and rejects as TURN_STOPPED (#7009). Distinct from the `null`
+ * sentinel below, which hangs the turn with no terminal event at all.
+ */
+const STOP_TURN = Symbol('stop-turn')
+
+/**
+ * Decider sentinel: the provider errors out mid-turn → TurnError TURN_ERROR.
+ * The counterfactual to {@link STOP_TURN}: same error class, different code.
+ */
+const ERROR_TURN = Symbol('error-turn')
+
 function fenced(obj) {
   return 'Here is my decision.\n\n```chroxy-decision\n' + JSON.stringify(obj) + '\n```'
 }
@@ -53,6 +67,14 @@ class FakeSession extends EventEmitter {
       if (this.destroyed) return
       const out = this._decide({ role: this.role, kind, prompt: String(prompt), n: this.kindCalls[kind], model: this._model })
       if (out == null) return // sentinel: hang this turn (no result emitted)
+      if (out === STOP_TURN) {
+        this._sm.emit('session_event', { sessionId: this.sessionId, event: 'stopped', data: {} })
+        return
+      }
+      if (out === ERROR_TURN) {
+        this._sm.emit('session_event', { sessionId: this.sessionId, event: 'error', data: { message: 'worker exploded' } })
+        return
+      }
       const text = typeof out === 'string' ? out : fenced(out)
       this._sm.emit('session_event', { sessionId: this.sessionId, event: 'stream_delta', data: { messageId: 'm1', delta: text } })
       this._sm.emit('session_event', {
@@ -336,6 +358,63 @@ test('unrecoverable parse failure fails the subtask', async () => {
     const record = ledger.getRun(rec.runId)
     assert.equal(record.status, 'completed')
     assert.equal(record.subtasks[0].status, 'failed')
+  } finally {
+    cleanup()
+  }
+})
+
+test('an operator Stop mid-subtask lands on `interrupted`, not `failed` (#7038)', async () => {
+  // The orchestration half of #7038. TurnDriver already gives an interrupt its
+  // OWN code (TURN_STOPPED) and run-model already declares an `interrupted`
+  // subtask state — but nothing ever wrote it: the _schedule() catch mapped
+  // EVERY thrown turn to `failed`, so a deliberate Stop was recorded exactly
+  // like a worker that blew up. `interrupted` is resumable (`interrupted ->
+  // briefing` is a legal transition); `failed` is terminal-and-final, so the
+  // mislabel also threw away the one thing that distinguishes them.
+  const decide = (ctx) => {
+    if (ctx.kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'audit' }] }
+    if (ctx.kind === 'plan_of_attack') return STOP_TURN
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    // The run must still REACH synthesis. `interrupted` has to count as a
+    // scheduling-terminal subtask state; if it does not, the run sits forever
+    // waiting on a subtask that will never move and this wait times out — the
+    // exact trap a partial enumeration would leave behind.
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.subtasks[0].status, 'interrupted', 'a Stop is an interrupt, not a failure')
+    assert.notEqual(record.subtasks[0].status, 'failed')
+    assert.equal(record.status, 'completed', 'the run still terminates rather than hanging on the interrupted subtask')
+  } finally {
+    cleanup()
+  }
+})
+
+test('a genuinely CRASHED subtask still lands on `failed` (#7038 positive control)', async () => {
+  // The counterfactual for the test above: only TURN_STOPPED gets the new
+  // state. A worker whose turn ERRORS out rejects with the same TurnError class
+  // and a different code, and must still be a failure — so the interrupt
+  // mapping cannot be a blanket re-label of the catch arm. This one passes on
+  // UNMODIFIED source, which is what makes the red above mean something.
+  const decide = (ctx) => {
+    if (ctx.kind === 'epic_plan') return { kind: 'epic_plan', subtasks: [{ title: 'A', goal: 'g', role: 'audit' }] }
+    if (ctx.kind === 'plan_of_attack') return ERROR_TURN
+    return happyDecider(ctx)
+  }
+  const { ledger, mgr, cleanup } = makeHarness(decide)
+  try {
+    const rec = mgr.createRun({ goal: 'Audit', cwd: '/repo', autoApprovePlan: true })
+    const done = waitFor(mgr, ['run_completed'])
+    await mgr.startRun(rec.runId)
+    await done
+    const record = ledger.getRun(rec.runId)
+    assert.equal(record.subtasks[0].status, 'failed', 'a crash is still a failure')
+    assert.notEqual(record.subtasks[0].status, 'interrupted')
   } finally {
     cleanup()
   }

--- a/packages/server/tests/scheduled-task-health-parity.test.js
+++ b/packages/server/tests/scheduled-task-health-parity.test.js
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path'
 import {
   SCHEDULED_TASK_HEALTH_TAGS,
   SCHEDULED_TASK_LAST_RUN_STATUSES,
+  SCHEDULED_TASK_LAST_RUN_STATUS_VALUES,
   deriveScheduledTaskHealth,
   deriveScheduledTaskHealthTag,
 } from '@chroxy/protocol'
@@ -69,6 +70,32 @@ describe('scheduled-task health — golden mapping', () => {
     assert.deepEqual(
       [...SCHEDULED_TASK_HEALTH_TAGS].sort(),
       ['ERROR', 'INTERRUPTED', 'NEVER RUN', 'OK', 'PAUSED', 'REFUSED', 'SKIPPED', 'TIMEOUT'],
+    )
+  })
+
+  // @chroxy/protocol declares the engine's `lastRun.status` roster TWICE, in two
+  // files, and both are public exports of the package:
+  //
+  //   - `SCHEDULED_TASK_LAST_RUN_STATUSES`      (scheduled-task-health.ts)
+  //   - `SCHEDULED_TASK_LAST_RUN_STATUS_VALUES` (schemas/server/scheduler.ts)
+  //
+  // Both document themselves as mirroring `scheduled-task-store.js`'s
+  // `LAST_RUN_STATUSES`, so at most one of them can be right when they differ.
+  // Nothing imported the second one, which is exactly why it drifted unnoticed
+  // when `interrupted` was added (#7038): a roster with no consumer has no test,
+  // and a stale-but-exported constant is worse than an absent one — the next
+  // consumer to reach for it (a status filter, a `z.enum` built from it) inherits
+  // a set that silently omits a status the engine really does persist.
+  //
+  // Pin them to each other so the NEXT status cannot land in only one half. This
+  // is the same failure mode #7024/#7129 closed for the CLI, one file over.
+  it('both exported lastRun-status rosters declare the same set (#7038)', () => {
+    assert.deepEqual(
+      [...SCHEDULED_TASK_LAST_RUN_STATUS_VALUES].sort(),
+      [...SCHEDULED_TASK_LAST_RUN_STATUSES].sort(),
+      'the two exported status rosters in @chroxy/protocol have drifted — both claim to mirror ' +
+        "scheduled-task-store.js's LAST_RUN_STATUSES, so a status added to one must be added to the other " +
+        '(scheduled-task-health.ts AND schemas/server/scheduler.ts).',
     )
   })
 

--- a/packages/server/tests/scheduled-task-health-parity.test.js
+++ b/packages/server/tests/scheduled-task-health-parity.test.js
@@ -42,6 +42,11 @@ const GOLDEN = [
   [{ enabled: true, lastRun: { status: 'skipped' } }, 'SKIPPED'],
   [{ enabled: true, lastRun: { status: 'timeout' } }, 'TIMEOUT'],
   [{ enabled: true, lastRun: { status: 'refused' } }, 'REFUSED'],
+  // #7038 — a deliberate operator Stop. Its own tag, and deliberately NOT `bad`:
+  // the whole defect was that an intentional interrupt was indistinguishable
+  // from a provider crash, and leaving it styled like ERROR reinstates that at
+  // the tone layer. It is still not healthy — only `OK` ever is.
+  [{ enabled: true, lastRun: { status: 'interrupted' } }, 'INTERRUPTED'],
   [{ enabled: true, lastRun: null }, 'NEVER RUN'],
   // Paused wins over ANY recorded run — a paused task will not fire again.
   [{ enabled: false, lastRun: { status: 'success' } }, 'PAUSED'],
@@ -60,10 +65,22 @@ describe('scheduled-task health — golden mapping', () => {
     }
   })
 
-  it('exports exactly the seven tags the surfaces render', () => {
+  it('exports exactly the eight tags the surfaces render', () => {
     assert.deepEqual(
       [...SCHEDULED_TASK_HEALTH_TAGS].sort(),
-      ['ERROR', 'NEVER RUN', 'OK', 'PAUSED', 'REFUSED', 'SKIPPED', 'TIMEOUT'],
+      ['ERROR', 'INTERRUPTED', 'NEVER RUN', 'OK', 'PAUSED', 'REFUSED', 'SKIPPED', 'TIMEOUT'],
+    )
+  })
+
+  it('an INTERRUPTED run is warn-toned, never `ok` and never styled like a crash (#7038)', () => {
+    const health = deriveScheduledTaskHealth({ enabled: true, lastRun: { status: 'interrupted' } })
+    assert.equal(health.tag, 'INTERRUPTED')
+    assert.equal(health.tone, 'warn', 'a deliberate Stop is not a fault — styling it `bad` re-merges it with a crash')
+    assert.equal(health.isHealthy, false, 'the work did not complete; only OK is healthy')
+    assert.notEqual(
+      deriveScheduledTaskHealthTag({ enabled: true, lastRun: { status: 'error' } }),
+      'INTERRUPTED',
+      'a real error must not borrow the interrupt tag',
     )
   })
 
@@ -319,6 +336,8 @@ describe('scheduled-task health — CLI source parity (#6868 / PR #7013)', () =>
       return 'SKIPPED'
     case 'timeout':
       return 'TIMEOUT'
+    case 'interrupted':
+      return 'INTERRUPTED'
     default:
       return 'ERROR'
   }

--- a/packages/server/tests/scheduled-task-store.test.js
+++ b/packages/server/tests/scheduled-task-store.test.js
@@ -562,6 +562,20 @@ describe('#6862 ScheduledTaskStore', () => {
     assert.throws(() => store.update(t.id, { lastRun: { at: 1, status: 'bogus' } }), ScheduledTaskValidationError)
   })
 
+  it('accepts every status the engine can emit, including `interrupted` (#7038)', () => {
+    // The store is the LAST gate before a run outcome is persisted, and it
+    // throws on an unknown status — which `_recordRun` turns into a QUARANTINE
+    // (scheduler.js: "its run outcome could not be recorded"). So an engine
+    // status the store has not been taught does not merely fail to persist: it
+    // permanently stops the task from firing for the rest of the process.
+    const store = newStore(() => 0)
+    for (const status of ['success', 'error', 'skipped', 'timeout', 'refused', 'interrupted']) {
+      const t = store.add({ prompt: 'p', cadence: { kind: 'interval', everyMs: HOUR } })
+      const updated = store.update(t.id, { lastRun: { at: 1, status } })
+      assert.equal(updated.lastRun.status, status, `${status} must round-trip through the store`)
+    }
+  })
+
   it('remove() deletes and persists; returns false for an unknown id', () => {
     const store = newStore()
     const t = store.add({ prompt: 'p', cadence: { kind: 'once', at: 9999 } })

--- a/packages/server/tests/scheduler.test.js
+++ b/packages/server/tests/scheduler.test.js
@@ -14,6 +14,7 @@ import {
   listSchedulableProviders,
   SCHEDULED_PERMISSION_MODE,
   REFUSED_STATUS,
+  INTERRUPTED_STATUS,
 } from '../src/scheduler.js'
 import { validateCwdAllowed } from '../src/handler-utils.js'
 import { DEFAULT_PROVIDER } from '../src/providers.js'
@@ -820,11 +821,12 @@ describe('#6865 SchedulerEngine', () => {
       assert.match(record.lastRun.error, /permission required/)
     })
 
-    it('only the four real outcomes and `refused` survive; anything else is error', async () => {
+    it('only the four real outcomes, `refused` and `interrupted` survive; anything else is error', async () => {
       const statuses = []
       for (const outcome of [
         { status: 'success' }, { status: 'timeout' }, { status: 'skipped' },
-        { status: REFUSED_STATUS }, { status: 'weird' }, {}, null,
+        { status: REFUSED_STATUS }, { status: INTERRUPTED_STATUS },
+        { status: 'weird' }, {}, null,
       ]) {
         const task = addTask({ prompt: 'p', cadence: { kind: 'once', at: 2000 } })
         const engine = newEngine({ runTask: async () => outcome })
@@ -834,7 +836,7 @@ describe('#6865 SchedulerEngine', () => {
         statuses.push(store.get(task.id).lastRun.status)
         engine.destroy()
       }
-      assert.deepEqual(statuses, ['success', 'timeout', 'skipped', REFUSED_STATUS, 'error', 'error', 'error'])
+      assert.deepEqual(statuses, ['success', 'timeout', 'skipped', REFUSED_STATUS, INTERRUPTED_STATUS, 'error', 'error', 'error'])
     })
   })
 
@@ -879,11 +881,16 @@ describe('#6865 SchedulerEngine', () => {
       assert.equal(record.lastRun.sessionId, 'sess-1')
     })
 
-    it('an operator Stop on a scheduled run is an error, never a success', async () => {
+    it('an operator Stop on a scheduled run records `interrupted`, not a generic error (#7038)', async () => {
       // No permission prompt at all — the turn is simply interrupted (what a Stop
       // from the dashboard does). `runState.blocked` is unset here, so the outcome
       // rides entirely on TurnDriver's TURN_STOPPED rejection. If `stopped` were
       // treated as a normal completion this would read as `success`.
+      //
+      // #7038: it must also not read as `error`. A deliberate Stop and a provider
+      // crash were recorded identically — same status, and the only difference was
+      // a free-text `error` string nothing keys on — so an operator scanning the
+      // registry could not tell "I stopped this" from "this blew up".
       const sm = new FakeSessionManager({ interruptEmitsStopped: true, stopAfterSend: true })
       const task = addTask({ prompt: 'long job', cadence: { kind: 'once', at: 2000 } })
       const engine = newEngine({ sessionManager: sm, runTimeoutMs: 5_000 })
@@ -900,8 +907,38 @@ describe('#6865 SchedulerEngine', () => {
       // Belt-and-braces only (fake clock) — see the previous test.
       assert.ok(elapsedMs < 2_000, `settling must not block on runTimeoutMs (took ${elapsedMs}ms of a 5000ms window)`)
       assert.notEqual(record.lastRun.status, 'success', 'a stopped run did not do the work — never success')
-      assert.equal(record.lastRun.status, 'error')
+      assert.equal(record.lastRun.status, INTERRUPTED_STATUS, 'a deliberate Stop gets its OWN status, not the crash bucket')
+      assert.notEqual(record.lastRun.status, 'error', 'an operator Stop is not a provider failure')
       assert.match(record.lastRun.error, /interrupted/)
+    })
+
+    it('a permission-BLOCKED interrupt stays `error` — only a bare Stop is `interrupted` (#7038)', async () => {
+      // The precedence that must not invert. The engine denies an unattended
+      // permission prompt and THEN interrupts the turn, so the same TURN_STOPPED
+      // rejection arrives on both paths. That one is a real failure: the agent
+      // needed permission nobody could grant and its tool call was refused, which
+      // is the worst-outcome case this engine exists to make visible. Only a Stop
+      // with no permission activity at all (`runState.blocked` unset) is benign.
+      //
+      // If the TURN_STOPPED mapping were placed ABOVE the `runState.blocked`
+      // check, every denied-permission run would quietly re-tag itself from a
+      // `bad` ERROR to a `warn` INTERRUPTED — a strictly worse regression than
+      // the bug #7038 fixes.
+      const sm = new FakeSessionManager({
+        permissionRequest: { requestId: 'req-1', toolName: 'Bash' },
+        interruptEmitsStopped: true,
+      })
+      const task = addTask({ prompt: 'rm things', cadence: { kind: 'once', at: 2000 } })
+      const engine = newEngine({ sessionManager: sm, runTimeoutMs: 5_000 })
+      engine.start()
+      clock = 2000
+      await timers.tick()
+
+      assert.deepEqual(sm.responded, [['req-1', 'deny']])
+      const record = store.get(task.id)
+      assert.equal(record.lastRun.status, 'error', 'a denied permission is a real failure, not a benign stop')
+      assert.notEqual(record.lastRun.status, INTERRUPTED_STATUS)
+      assert.match(record.lastRun.error, /permission required for Bash/)
     })
 
     // ── #7037: the SYMPTOM, not the proxy ────────────────────────────────────


### PR DESCRIPTION
## Defect

A scheduled run someone **stopped on purpose** was recorded identically to a provider crash.

`scheduler.js` `_runViaSessionManager` special-cased only `TURN_TIMEOUT` and let everything else fall to `status: 'error'`. `TurnDriver` has raised a distinct `TURN_STOPPED` since #7009 (turn-driver.js:322, message `turn interrupted before completing`), but nothing downstream keyed on it — so an operator Stop and a blown-up provider both persisted as `error`, differing only by a free-text message no surface keys on.

The same hole existed one layer over in orchestration: `run-model.js` has declared an `interrupted` subtask state since E-1 (`TERMINAL_NODE_STATUSES`), and **nothing ever wrote it** — `_schedule()`'s catch mapped every thrown turn to `failed`. `interrupted` is the resumable one (`interrupted -> briefing` is a legal transition; `failed` is final), so the mislabel discarded the only thing that distinguishes them.

## Two corrections to the issue as filed — both verified on main

1. **"the wire schemas that carry run status would need the new literal" — not true.** `packages/protocol/src/schemas/server/scheduler.ts:110` is `status: z.string().max(64)`, a deliberately un-enumerated bounded string with a doc-block that says exactly why ("an engine that grows a new status must not make the whole snapshot unparseable on an older client"). **No wire schema change was needed** and none was made.
2. **"worth checking against any consecutive-failure/backoff logic keyed on run status" — there is none.** Quarantine (`scheduler.js` `_recordRun` → `_quarantine`) keys on a **persist failure**, never on `lastRun.status`. `grep` for `consecutive|backoff|failureCount|lastRun.status` across `scheduler.js` + `scheduled-task-store.js` returns only the store's own validation gate.

## Choosing the literal: `interrupted`, and what an OLDER daemon does with it

`interrupted` over `stopped` for two reasons:

- It is the word the rest of the daemon **already uses for this exact event** — orchestration's subtask state, and the turn-driver's own message. One concept, one name.
- `STOPPED` sitting next to `PAUSED` in a health chip reads as a claim about the *schedule* ("this task is stopped"), not about the *run*. That is precisely the honest-status ambiguity this vocabulary exists to avoid.

**Forward-compat, stated honestly.** This value is persisted to `~/.chroxy/scheduled-tasks.json`, so it is a commitment. On the **wire** a downgrade is safe: the snapshot schema is a bounded string and `deriveScheduledTaskHealthTag` routes anything unrecognized to `ERROR`, never to `OK`. On **disk** a downgrade is lossy but not destructive: an older daemon's `normalizeLastRun` throws on an unknown status, so `load()` refuses **that task** and routes it to `_preserveUnreadable` — the record stays on disk verbatim and is written back untouched, but the task does not fire until the daemon is upgraded (or its `lastRun` is cleared). That is the same downgrade behaviour `refused` already carries; it is a property of the store's strict status gate, not something this PR introduces.

Tone is `warn`, not `bad`, and that is the point rather than an aesthetic call: the defect is that a deliberate Stop was *presented as a failure*. Giving it its own tag while keeping the failure styling would re-merge it with a crash at the layer an operator actually reads — the colour of the chip. It is still never healthy (`isHealthy` is `tag === 'OK'`).

## Every surface, enumerated before editing and verified after

| # | Surface | State |
|---|---|---|
| 1 | `scheduler.js` `PASSTHROUGH_STATUSES` | added — **without it the whole change is a silent no-op** |
| 2 | `scheduler.js` `_runViaSessionManager` catch | `TURN_STOPPED` arm added, **below** the `runState.blocked` check |
| 3 | `scheduled-task-store.js` `LAST_RUN_STATUSES` | added — this is a hard gate, not documentation |
| 4 | `protocol/scheduled-task-health.ts` `SCHEDULED_TASK_LAST_RUN_STATUSES` | added |
| 5 | `protocol/scheduled-task-health.ts` `deriveScheduledTaskHealthTag` | `case 'interrupted' → 'INTERRUPTED'` |
| 6 | `protocol/scheduled-task-health.ts` `scheduledTaskHealthTone` + `SCHEDULED_TASK_HEALTH_TAGS` | `INTERRUPTED` declared, toned `warn` |
| 7 | `cli/schedule-cmd.js` `healthTag()` | `case 'interrupted'` |
| 8 | `tests/scheduled-task-health-parity.test.js` | GOLDEN row, 8-tag assertion, **and the `COMPLETE` positive-control fixture** |
| 9 | dashboard chip | consumes the shared helper (no per-status branch); its exhaustiveness claim is the `CASES` table in `ScheduledTasksSection.test.tsx` — row added |

**Three more the brief did not list, found by tracing the consumers:**

| # | Surface | Why it matters |
|---|---|---|
| 10 | `orchestration-manager.js` `_schedule()` catch | the orchestration half of the fix — maps `TURN_STOPPED` → `interrupted` |
| 11 | `orchestration-manager.js` `TERMINAL_SUBTASK_STATES` | **a hang, not a status bug**: nothing re-drives a stopped subtask, so omitting it parks the run forever waiting on a node that can never move |
| 12 | doc blocks in `scheduler.js` (posture item 7), `schedule-cmd.js`, `ScheduledTasksSection.tsx` | each enumerates the vocabulary in prose |

Surface 11 in particular is the failure the brief warns about: every test would still have gone green on the *status*, and the run would silently never synthesize.

## Verification

**RED first, on unmodified source:**

```
✖ an operator Stop on a scheduled run records `interrupted`, not a generic error (#7038)
  AssertionError: a deliberate Stop gets its OWN status, not the crash bucket
    actual: 'error',  expected: 'interrupted'

✖ an operator Stop mid-subtask lands on `interrupted`, not `failed` (#7038)
  AssertionError: a Stop is an interrupt, not a failure
    actual: 'failed',  expected: 'interrupted'
```

Plus reds in the parity guard (which named the missing status by itself, exactly as #7129 designed it to), the store, and the dashboard table.

**Positive controls (pass on unmodified source, so the reds mean something):**

- `a permission-BLOCKED interrupt stays 'error'` — the engine's own deny path reaches the *same* `TURN_STOPPED` rejection. Passed before the fix and after, pinning that the new arm sits **below** `runState.blocked`. Inverting that order would quietly re-tag every denied-permission run from a `bad` ERROR to a `warn` INTERRUPTED — strictly worse than the bug being fixed.
- `a genuinely CRASHED subtask still lands on 'failed'` — same `TurnError` class, different code (`TURN_ERROR`). 25/26 orchestration tests passed on the pre-fix run, including this one; only the interrupt test was red.
- The parity guard's own extractor self-test (`the extractor discriminates…`) still discriminates against the drifted fixture.

**Mutation checks — performed, confirmed red, reverted:**

| Mutation | Result |
|---|---|
| drop `INTERRUPTED_STATUS` from `PASSTHROUGH_STATUSES` | RED — and instructively so: `lastRun.status` came back **`refused`**, because the store rejected the unknown status, `_recordRun` threw, and the engine **quarantined the task**. Omitting surface 1 does not merely no-op; it bricks the schedule. |
| drop `interrupted` from `TERMINAL_SUBTASK_STATES` | RED — `Error: timeout waiting for run_completed`. The run hangs, exactly as predicted. |
| drop `case 'interrupted'` from the CLI `healthTag()` | RED — the parity guard names it: *"must declare an explicit case for exactly [interrupted, refused, skipped, success, timeout]"*. No hand-written exemption was added; `CLI_DEFAULT_ARM_STATUSES` stays computed from `deriveScheduledTaskHealthTag`. |

**Tests / lints run (all green):**

- server: `scheduler`, `scheduled-task-store`, `scheduled-task-health-parity`, `schedule-cli`, `schedule-parser`, `scheduler-handlers`, `session-manager-scheduled-task-store`, `cli/schedule-cmd`, and **all 16 `orchestration-*` + orchestrator files** — 356 + 216 + 11 pass, 0 fail
- protocol: `npm run build` (dist rebuilt and committed — the files are tracked) + `npm test` — 388 pass
- dashboard: `ScheduledTasksSection` + `dispatch-scheduled-tasks` — 97 pass; `tsc --noEmit` clean
- **CI Server Lint** (the shell lints, not eslint): all five `packages/server/scripts/lint-*.sh` pass
- repo-root style lints: `lint-no-nul-bytes.sh`, `lint-no-raw-color-literals.sh`, `lint-undefined-css-vars.sh` pass
- `npm run lint` (server): 0 errors, 9 pre-existing warnings, none in the changed files

Closes #7038.
