### PR TITLE
docs: document the 44pt tap-target convention and fix two dangling CLAUDE.md citations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,8 +251,9 @@ When `gh pr merge` fails with "not mergeable" or "base branch policy prohibits t
 
 Every interactive control (button, toggle, tab, tappable row or badge) must present at least a
 **44×44 pt** hit area. This is the Apple HIG minimum for iOS and WCAG 2.1 SC 2.5.5 (Target Size,
-AAA) for the web dashboard — WCAG 2.2's AA floor is only 24×24, but we hold the stricter 44
-everywhere so one number covers both surfaces.
+AAA) for the web dashboard — WCAG 2.2's AA floor is only 24×24, but we hold the stricter 44 as
+the floor on every surface. Android is stricter still: Material's minimum is 48dp, so prefer 48
+in `packages/app` wherever the layout allows.
 
 Two ways to satisfy it, in order of preference:
 
@@ -262,8 +263,8 @@ Two ways to satisfy it, in order of preference:
    #5634 for the permission Approve/Deny buttons.
 2. **`hitSlop`** — for compact, information-dense rows where growing the visible element would
    break the layout (#4876's session-header badges, #3914's CheckInChip). Mobile app only:
-   `hitSlop` is a React Native
-   prop and does **not** exist in the dashboard, which must use padding or spacing instead.
+   `hitSlop` is a React Native prop and does **not** exist in the dashboard, which must use
+   padding or spacing instead.
 
 A control whose visible box is smaller than 44pt and which has no `hitSlop` is a bug, not a style
 preference — all five issues above were filed and fixed as such. When you shrink a control's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,28 @@ When `gh pr merge` fails with "not mergeable" or "base branch policy prohibits t
 - Zustand for state management
 - React Navigation for routing
 
+### Tap targets — 44pt minimum (#3751 / #3914 / #4876 / #4893 / #5634)
+
+Every interactive control (button, toggle, tab, tappable row or badge) must present at least a
+**44×44 pt** hit area. This is the Apple HIG minimum for iOS and WCAG 2.1 SC 2.5.5 (Target Size,
+AAA) for the web dashboard — WCAG 2.2's AA floor is only 24×24, but we hold the stricter 44
+everywhere so one number covers both surfaces.
+
+Two ways to satisfy it, in order of preference:
+
+1. **Grow the visible control** — `minHeight: 44` / `minWidth: 44` (RN), `min-height: 44px` /
+   `min-width: 44px` (dashboard CSS). Prefer this whenever the layout has the room; the target
+   then matches what the user sees. This is what #4893 did for `conversationIdRow` (32 → 44) and
+   #5634 for the permission Approve/Deny buttons.
+2. **`hitSlop`** — for compact, information-dense rows where growing the visible element would
+   break the layout (#4876's session-header badges, #3914's CheckInChip). Mobile app only:
+   `hitSlop` is a React Native
+   prop and does **not** exist in the dashboard, which must use padding or spacing instead.
+
+A control whose visible box is smaller than 44pt and which has no `hitSlop` is a bug, not a style
+preference — all five issues above were filed and fixed as such. When you shrink a control's
+padding or font size, re-check the resulting box.
+
 ## Testing Conventions
 
 ### Server tests must not touch real user state (#4633)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,8 +232,9 @@ When `gh pr merge` fails with "not mergeable" or "base branch policy prohibits t
 
 Every interactive control (button, toggle, tab, tappable row or badge) must present at least a
 **44×44 pt** hit area. This is the Apple HIG minimum for iOS and WCAG 2.1 SC 2.5.5 (Target Size,
-AAA) for the web dashboard — WCAG 2.2's AA floor is only 24×24, but we hold the stricter 44
-everywhere so one number covers both surfaces.
+AAA) for the web dashboard — WCAG 2.2's AA floor is only 24×24, but we hold the stricter 44 as
+the floor on every surface. Android is stricter still: Material's minimum is 48dp, so prefer 48
+in `packages/app` wherever the layout allows.
 
 Two ways to satisfy it, in order of preference:
 
@@ -243,8 +244,8 @@ Two ways to satisfy it, in order of preference:
    #5634 for the permission Approve/Deny buttons.
 2. **`hitSlop`** — for compact, information-dense rows where growing the visible element would
    break the layout (#4876's session-header badges, #3914's CheckInChip). Mobile app only:
-   `hitSlop` is a React Native
-   prop and does **not** exist in the dashboard, which must use padding or spacing instead.
+   `hitSlop` is a React Native prop and does **not** exist in the dashboard, which must use
+   padding or spacing instead.
 
 A control whose visible box is smaller than 44pt and which has no `hitSlop` is a bug, not a style
 preference — all five issues above were filed and fixed as such. When you shrink a control's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,28 @@ When `gh pr merge` fails with "not mergeable" or "base branch policy prohibits t
 - Zustand for state management
 - React Navigation for routing
 
+### Tap targets — 44pt minimum (#3751 / #3914 / #4876 / #4893 / #5634)
+
+Every interactive control (button, toggle, tab, tappable row or badge) must present at least a
+**44×44 pt** hit area. This is the Apple HIG minimum for iOS and WCAG 2.1 SC 2.5.5 (Target Size,
+AAA) for the web dashboard — WCAG 2.2's AA floor is only 24×24, but we hold the stricter 44
+everywhere so one number covers both surfaces.
+
+Two ways to satisfy it, in order of preference:
+
+1. **Grow the visible control** — `minHeight: 44` / `minWidth: 44` (RN), `min-height: 44px` /
+   `min-width: 44px` (dashboard CSS). Prefer this whenever the layout has the room; the target
+   then matches what the user sees. This is what #4893 did for `conversationIdRow` (32 → 44) and
+   #5634 for the permission Approve/Deny buttons.
+2. **`hitSlop`** — for compact, information-dense rows where growing the visible element would
+   break the layout (#4876's session-header badges, #3914's CheckInChip). Mobile app only:
+   `hitSlop` is a React Native
+   prop and does **not** exist in the dashboard, which must use padding or spacing instead.
+
+A control whose visible box is smaller than 44pt and which has no `hitSlop` is a bug, not a style
+preference — all five issues above were filed and fixed as such. When you shrink a control's
+padding or font size, re-check the resulting box.
+
 ## Testing Conventions
 
 ### Server tests must not touch real user state (#4633)

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1373,7 +1373,8 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   // #4893 — bump minHeight from 32 → 44 so the copy-to-clipboard row clears
-  // the Apple HIG / CLAUDE.md 44pt minimum tappable target. Sibling fix to
+  // the 44pt minimum tappable target (Apple HIG; CLAUDE.md "Tap targets"
+  // under Code Style, which documents the repo-wide rule). Sibling fix to
   // #4892 (which used hitSlop for the compact header badges); here the row
   // already has horizontal whitespace in the expanded panel, so growing the
   // visible row by 12pt is preferable to a hitSlop hack.

--- a/packages/desktop/docs/quit-orphan-repro.md
+++ b/packages/desktop/docs/quit-orphan-repro.md
@@ -73,8 +73,7 @@ Repeat step 5 above for every quit path. The expected behaviour:
 The Node server registers a SIGTERM handler that flushes
 `session-state.json` to disk before exiting. SIGKILL bypasses that
 handler and wipes the state file, losing the user's open sessions on
-the next launch (see CLAUDE.md memory note "SIGTERM not SIGKILL for
-Chroxy"). `ServerManager::kill_child()` enforces this:
+the next launch. `ServerManager::kill_child()` enforces this:
 
 1. Send SIGTERM (`libc::kill(pid, SIGTERM)`).
 2. Poll `try_wait()` every 100ms for up to 5 seconds.

--- a/packages/desktop/docs/quit-orphan-repro.md
+++ b/packages/desktop/docs/quit-orphan-repro.md
@@ -72,8 +72,14 @@ Repeat step 5 above for every quit path. The expected behaviour:
 
 The Node server registers a SIGTERM handler that flushes
 `session-state.json` to disk before exiting. SIGKILL bypasses that
-handler and wipes the state file, losing the user's open sessions on
-the next launch. `ServerManager::kill_child()` enforces this:
+handler, costing up to `persistDebounceMs` (2000ms,
+`session-manager.js:343`) of un-flushed session changes. It does not
+wipe the state file: `session-state-persistence.js` rotates the live
+file to `.bak` before each write and writes the new generation via an
+atomic temp+rename, and `restoreState` falls back to `.bak` when the
+main file is missing or unparseable — so one good generation always
+survives. The loss is bounded, not total, but it is still the user's
+newest state, so `ServerManager::kill_child()` prefers SIGTERM:
 
 1. Send SIGTERM (`libc::kill(pid, SIGTERM)`).
 2. Poll `try_wait()` every 100ms for up to 5 seconds.


### PR DESCRIPTION
SettingsBar's conversationIdRow comment cited "the Apple HIG / CLAUDE.md 44pt
minimum tappable target", but CLAUDE.md documented no such rule — grepping it
for 44pt/tappable/tap target returned nothing against a passing positive
control. Same dangling-pointer class as #6993.

The convention itself is real and enforced, just never written down: 75 sites
in packages/app/src pin minHeight/minWidth to 44, 21 files use hitSlop, and
five issues (#3751, #3914, #4876, #4893, #5634) were filed and fixed
specifically to hold the line. So rather than drop the citation, document what
the code already does.

- Add "Tap targets — 44pt minimum" under Code Style, covering both surfaces:
  Apple HIG for iOS and WCAG 2.1 SC 2.5.5 for the dashboard, the grow-the-
  control vs hitSlop preference order, and the fact that hitSlop is RN-only
  and unavailable in the dashboard (which uses CSS min-height/min-width).
- Point the SettingsBar comment at that section by name.
- Regenerate AGENTS.md (drift gate in Scripts Tests).

Per the issue's third acceptance criterion, re-ran the audit across the whole
tree (`git grep -n "CLAUDE\.md" -- packages`, 134 hits) rather than the three
sites listed there. That surfaced one more genuine dangling pointer the
narrower sweep missed:

- packages/desktop/docs/quit-orphan-repro.md cited a CLAUDE.md memory note
  "SIGTERM not SIGKILL for Chroxy". CLAUDE.md's only SIGTERM mention is an
  example commit message; that rule lives in personal memory, not the repo
  doc. The surrounding prose already states the rule in full, so the false
  pointer is simply dropped.

The remaining hits all resolve or are not citations: "UI Verification with
Maestro" (DeviceRuntimesSection, server/control-room/simulators.js) and the
Maestro "pre-flight" reference (protocol device-runtimes → "Prerequisites")
resolve; the server tests' "Test state contamination" lands on the documented
rule at CLAUDE.md's "Server tests must not touch real user state (#4633)";
everything else references CLAUDE.md as data for the memory-panel and
note-append features. docs/ARCH.md in RepoPresetDrawer is placeholder text in
a UI input, not a repo doc reference.

Closes #7124