### PR TITLE
docs(changelog): move unreleased 0.10.0 entry back under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.0] - 2026-07-05
-
 The **Codex-controllable-like-Claude** release. Codex now flows through Chroxy's
 permission pipeline **by default** — you approve/deny its commands and file edits,
 switch permission modes, and send it image attachments, exactly the way you do


### PR DESCRIPTION
## Summary

- CHANGELOG.md's newest entry was `## [0.10.0] - 2026-07-05`, but no `v0.10.0` tag or GitHub release exists — the latest tagged release is `v0.9.46`.
- Folded the `[0.10.0]` entry's contents back under the existing `[Unreleased]` heading (per Keep a Changelog convention) so the file no longer implies a release that was never cut.
- No code changes, no release cut or tagged — CHANGELOG.md only.

## Test Plan

- [x] Diff reviewed — only the version heading/date line removed, entry content unchanged