### PR TITLE
docs(changelog): move unreleased 0.9.47 entry back under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ with Claude. Plus device-friendly **persistent pairing tokens** and two claude-t
 reliability fixes.
 
 > This release also ships the previously-unreleased **0.9.47** "model-serving
-> freshness + operator-security" changes (see the [0.9.47] section) — v0.9.47 was
+> freshness + operator-security" changes (folded in below) — v0.9.47 was
 > prepared but never tagged, so everything since v0.9.46 lands here.
 
 ### Added
@@ -54,8 +54,6 @@ reliability fixes.
 - **claude-tui readiness via PTY-output quiescence (#6601).** Detect readiness from
   the PTY output settling instead of the dropped status field, cutting
   first-message readiness from a ~15s degraded wait to ~1s.
-
-## [0.9.47] - 2026-06-25
 
 A **model-serving freshness** release with **operator-security hardening**. The headline: you no longer need to release a new build to **call, add, or re-price a model** the provider's API already exposes — across the whole provider matrix. Alongside that: a **host-local user-shell approval** control, completion of the **#6201 Open/Closed catalog** refactor, an **OpenAI-compatible provider**, a **mobile mission-control** read-only slice, a deep **store-core/protocol contract-typing** wave, and broad reliability/UX polish.
 


### PR DESCRIPTION
## Summary

- CHANGELOG.md contained a `## [0.9.47] - 2026-06-25` entry, but no `v0.9.47` tag or GitHub release exists — the latest tagged release is `v0.9.46`.
- Same problem and same treatment as the phantom `0.10.0` entry fixed in #7149: folded the `[0.9.47]` entry's contents back under the existing `[Unreleased]` heading (per Keep a Changelog convention) so the file no longer implies a release that was never cut.
- Also updated the `[Unreleased]` blockquote that pointed at "the [0.9.47] section" — it now says the changes are folded in below, since that heading no longer exists.
- No code changes, no release cut or tagged — CHANGELOG.md only.

## Test Plan

- [x] Diff reviewed — only the version heading/date line removed and the dangling cross-reference updated; entry content unchanged
