### PR TITLE
chore(ci): Cap repo-relay notify job and clarify bot-skip comment

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -26,13 +26,18 @@ concurrency:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # Cap hung runs: the concurrency group serializes runs, so an unbounded
+    # hang would queue later notifications behind it for up to the 6h default
+    timeout-minutes: 10
     # Least-privilege token: piggyback review detection reads the pulls and
     # issues APIs; an explicit block zeroes every unlisted scope
     permissions:
       contents: read
       pull-requests: read
       issues: read
-    # Skip bots (prevent cascades) and fork PRs (no secrets access)
+    # Skip this workflow's own actor (prevent self-trigger cascades) and
+    # fork PRs (no secrets access). Other bots (dependabot, Copilot) relay
+    # on purpose — their activity belongs in the channel.
     if: >-
       github.actor != 'github-actions[bot]' &&
       (github.event_name != 'pull_request' ||


### PR DESCRIPTION
## Summary

Propagates the two fixes from the canonical repo-relay workflow rollout (already merged in stock-keep, skill-templates, carebridge, and duskwright) to this repo's copy, which predates them:

- **`timeout-minutes: 10` on the notify job** — the `concurrency` group serializes runs, so a hung run would queue later notifications behind it for up to the 6-hour default.
- **Reworded bot-skip comment** — the old "Skip bots (prevent cascades)" wording overstated the filter. Only this workflow's own actor (`github-actions[bot]`) is skipped, to prevent self-trigger cascades; other bots (dependabot, Copilot) relay on purpose because their activity belongs in the channel.

No behavioral change beyond the timeout cap — the `if` condition itself is untouched.

## Testing

- YAML parses; `jobs.notify.timeout-minutes == 10` verified.