### PR TITLE
fix(ci): re-pin helm/kind-action to a resolvable SHA (v1.14.0)

### DIFF
--- a/.github/workflows/nightly-k8s-integration.yml
+++ b/.github/workflows/nightly-k8s-integration.yml
@@ -39,7 +39,7 @@ jobs:
       # action cluster is never actually used — we only need the kind binary.
       # Pinned to the most recent stable tag; bump when kind itself requires it.
       - name: Install kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70563a3c # v1.10.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           install_only: true
 


### PR DESCRIPTION
Closes #7133.

One line changed:

```diff
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70563a3c # v1.10.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
```

## The root cause is not the one the issue assumed

The issue reasons that "a pinned SHA disappearing upstream means either the ref was force-pushed/GC'd or
the tag was re-pointed." Neither happened. `v1.10.0` still exists, is a lightweight tag, and still points
at `0025e74a8c7512023d06dc019c617aa3cf561fde` — it has never moved.

The dead SHA shares a **34-of-40 character prefix** with the v1.12.0 commit:

```
a1b0e391336a6ee6713a0583f8c6240d70563a3c   the pin (no such object)
a1b0e391336a6ee6713a0583f8c6240d70863de3   helm/kind-action v1.12.0
                                  ^^^^^^   only the last six differ
```

A 34-character prefix collision is not reachable by chance. This was a corrupted transcription that never
pointed at a real commit, so **the job has been failing at action resolution since the line was first
written** — it did not degrade at some later upstream event. The trailing `# v1.10.0` comment was
independently wrong too: it shares a zero-character prefix with the real v1.10.0 commit.

That matters for acceptance criterion 4 more than the pin itself does. A gate that was broken on arrival
and stayed silently red for its entire life is the strongest argument available that resolution failures
in non-required workflows need to surface somewhere.

## Two factual corrections to the issue

- **"Both K8s workflows" / "K8s Sidecar Integration ... runs on pushes to `main`"** — there is only one
  workflow. `K8s Sidecar Integration` is the *job* name (`nightly-k8s-integration.yml:20-21`); the
  workflow's `name:` is `Nightly K8s Integration`. One file, one job, one `uses:` line. Confirmed three
  ways: only one file references kind-action, `git log --all --diff-filter=A/D -- .github/workflows/`
  shows no sibling K8s workflow was ever added or deleted, and the Actions API lists no such workflow.
- **No `push` trigger exists.** The `on:` block is `schedule` + `workflow_dispatch` only, and the cited
  check id `437161880` returns 404. Nothing here fires per-push — which itself compounds the invisibility
  the issue is complaining about.

## Compatibility

`install_only` is the only input this workflow passes, and it is still declared at v1.14.0 under the same
name and semantics. The argument shape changed internally — v1.10.0's `main.sh` did `args+=(--install-only)`
as a bare flag, v1.14.0 does `args+=(--install-only "${INPUT_INSTALL_ONLY}")` — and `kind.sh:188` handles
both forms, so `install_only: true` still resolves to `install_only="true"` and cluster creation is still
skipped. `cluster_name`, which the surrounding comment reasons about, also still exists with the same
default, so that comment stays accurate.

The action's runtime moved `node20` → `node24`; the job's `runs-on: ubuntu-24.04` GitHub-hosted runner
provides it.

**Worth watching on the first nightly:** defaults move kind `v0.22.0` → `v0.31.0` and kubectl/k8s
`v1.29.3` → `v1.35.0`, and the workflow pins neither. The integration test creates its own cluster with
that binary, so it now boots a much newer kind/node image. This is intentional per the file's existing
"bump when kind itself requires it" comment, but it is unproven until a run happens. v1.14.0's cleanup
also gained an unconditional `docker rm -f <registry_name>` before `kind delete cluster`; on Docker 23.0+
that exits 0 for a nonexistent container and ubuntu-24.04 ships far newer, so the post step should stay
green with `install_only: true` and no registry configured.

## Acceptance criterion 3 — the full pin audit

Audited **every** SHA-pinned action in `.github/workflows/`: **74 `uses:` lines across 7 workflow files**,
resolving to **17 distinct `owner/repo@sha` pairs — 16 third-party plus 1 first-party**
(`blamechris/repo-relay`). All 16 third-party pins were checked individually against
`gh api repos/<owner>/<repo>/commits/<sha>` — exhaustively, not sampled — asserting the API echoes the
pinned SHA back.

**15 of 16 resolve. Exactly 1 was stale: `helm/kind-action`, the subject of this issue.** The first-party
pin resolves too. No other pin was touched — healthy pins were deliberately left alone rather than
opportunistically bumped.

Scope is complete: the repo has no composite actions (`.github/actions/` does not exist, no
`action.yml`/`action.yaml` anywhere in the tree) and no reusable-workflow references (`uses: ./…` returns
zero hits), so those 7 files are the entire surface.

**Floating refs — an observation, not a change made here: there are none.** All 74 `uses:` lines carry a
full 40-hex SHA (`grep -rn "uses:" .github/ | grep -vE "@[0-9a-f]{40}"` returns nothing), including the
first-party action. The convention is applied without exception.

One adjacent nit, also observation only: `dtolnay/rust-toolchain`'s trailing comment reads `# stable` — a
moving branch name rather than a release tag, so there is no way to tell how far the pin has drifted or
what to re-pin it to. The pin itself is a proper SHA and resolves, so this is comment hygiene rather than
supply-chain exposure. That action publishes no version tags; a date or the rustc version would be the
useful comment.

## Acceptance criteria

- [x] Re-pinned to a currently resolvable commit SHA for a known release tag, with the tag in a trailing
      comment. SHA-pinning convention kept.
- [x] Audited every other SHA-pinned third-party action — 16 checked, 1 stale (this one).
- [ ] Dispatch `Nightly K8s Integration` and confirm it gets past action resolution — done after this
      branch is pushed; result reported in a comment below.
- [ ] **Not addressed here, needs its own issue:** whether a resolution failure in a non-required workflow
      should surface somewhere. That is a design question covering this and #7113, and folding a
      notification mechanism into a one-line pin fix would blow the scope.

## Verification

The SHA was independently re-resolved by a second reviewer: `v1.14.0` dereferences to
`ef37e7f390d99f746eb8b610417061a60e82a6cc`, the tag object is type `commit` (lightweight), the commit is
an ancestor of `main` (ahead 5, behind 0), and the release is neither draft nor prerelease. `actionlint`
exits 0 on the edited file, and a full YAML load round-trips
`jobs.k8s-sidecar-integration.steps[2].uses` to the new value with `with: {install_only: true}` intact.

`git show --numstat` is `1 1 .github/workflows/nightly-k8s-integration.yml`, and a diff restricted to the
other six workflow files produces zero lines.
