### PR TITLE
fix(ci): move the K8s test timeout guard off NODE_OPTIONS

### DIFF
--- a/.github/workflows/nightly-k8s-integration.yml
+++ b/.github/workflows/nightly-k8s-integration.yml
@@ -53,10 +53,11 @@ jobs:
       # RUN_K8S_INTEGRATION=1 is the opt-in gate checked by the test file.
       # The script also probes for `kind` on PATH before registering any tests,
       # so a missing binary produces a clean skip rather than a crash.
-      # NODE_OPTIONS timeout guard is set to 14 min (just under the job ceiling)
-      # to guarantee a clean exit with a diagnostic rather than a hard runner kill.
+      # The 14-minute timeout guard (just under the 15-minute job ceiling above,
+      # so we exit with a diagnostic rather than take a hard runner kill) lives on
+      # the `test:integration:k8s` script itself, because Node rejects
+      # --test-timeout in NODE_OPTIONS and refuses to start at all.
       - name: Run K8s sidecar integration test
         run: npm run test:integration:k8s -w packages/server
         env:
           RUN_K8S_INTEGRATION: '1'
-          NODE_OPTIONS: '--test-timeout=840000'

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "test:raw": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
     "test:coverage": "c8 --reporter=text --reporter=html node --import ./tests/_setup.mjs --experimental-test-module-mocks --test './tests/**/*.test.js'",
     "test:integration": "node --import ./tests/_setup.mjs --test ./tests/*.integration.test.js",
-    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
+    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test-timeout=840000 --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
     "lint": "eslint src/",
     "postinstall": "node scripts/fix-node-pty-helper.js"
   },


### PR DESCRIPTION
Closes #7155. **Stacked on #7154** — based on `fix/7133-repin-kind-action`, so this diff shows only the
timeout change. GitHub will retarget it to `main` when #7154 merges.

Two lines:

```diff
-      # NODE_OPTIONS timeout guard is set to 14 min (just under the job ceiling)
-      # to guarantee a clean exit with a diagnostic rather than a hard runner kill.
+      # The 14-minute timeout guard (just under the 15-minute job ceiling above,
+      # so we exit with a diagnostic rather than take a hard runner kill) lives on
+      # the `test:integration:k8s` script itself, because Node rejects
+      # --test-timeout in NODE_OPTIONS and refuses to start at all.
       - name: Run K8s sidecar integration test
         run: npm run test:integration:k8s -w packages/server
         env:
           RUN_K8S_INTEGRATION: '1'
-          NODE_OPTIONS: '--test-timeout=840000'
```

```diff
-    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
+    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test-timeout=840000 --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
```

## What was broken

Node refuses `--test-timeout` in `NODE_OPTIONS` — it is not on the permitted subset — so the process exited
9 before running anything:

```
node: --test-timeout= is not allowed in NODE_OPTIONS
##[error]Process completed with exit code 9.
```

~20ms, well before `kind` was contacted. This was invisible until #7133 was fixed, because the job
previously died even earlier, at action resolution. Both defects arrived in this workflow's founding commit
`1fa1c8647`, so **the K8s gate has never once executed its test**.

## Why the position is load-bearing, not cosmetic

The obvious fix — appending through npm —

```yaml
run: npm run test:integration:k8s -w packages/server -- --test-timeout=840000
```

is wrong, and wrong in the worst possible way: it produces a **green** run with no guard at all. `npm run
… --` appends to the end of the script's command, which puts the flag after the test-file positional, and
Node parses its own options ahead of positionals.

Measured on a 3-second test with a 500ms timeout:

| flag position | result |
|---|---|
| before `--test` (this PR) | `'test timed out after 500ms'` — guard fires |
| after the file positional (`npm run … --`) | passes in 3001.9ms, exit 0 |
| no flag at all (control) | passes in 3002.1ms, exit 0 |

The second and third rows are indistinguishable. That is exactly the vacuous-gate failure class #7156 is
about, so it would have re-created the bug while looking fixed.

## Why the script and not a direct `node` call in the workflow

The other candidate was to drop the `npm run` indirection and inline the full `node` invocation in the
workflow, keeping the 14-minute value next to the comment explaining it. That duplicates the command in two
places, and the next edit to `test:integration:k8s` silently desynchronises CI from local. One source of
truth was worth more than comment adjacency, so the value moved and the comment now points at where it
lives and why it cannot be an env var.

The 14-minute value itself is unchanged and still correct: `timeout-minutes: 15` on the job, so 840000ms
leaves a minute for a clean diagnostic exit ahead of a hard runner kill.

Local dev now inherits the same 14-minute ceiling. That is a deliberate acceptance — it is a ceiling, not a
delay, and an integration test that hangs indefinitely locally is not better than one that gives up with a
diagnostic.

## Validation

- `package.json` parses; `actionlint` exits 0 on the workflow; a full YAML load round-trips the step with
  `env: {"RUN_K8S_INTEGRATION" => "1"}` and `NODE_OPTIONS` gone.
- `RUN_K8S_INTEGRATION: '1'` is untouched — it is a plain env var and was never the problem.
- Verified by dispatching the workflow on this branch; result reported in a comment below.
