### PR TITLE
chore(release): cut v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-15
+
 The **Codex-controllable-like-Claude** release. Codex now flows through Chroxy's
 permission pipeline **by default** — you approve/deny its commands and file edits,
 switch permission modes, and send it image attachments, exactly the way you do
@@ -16,6 +18,15 @@ reliability fixes.
 > This release also ships the previously-unreleased **0.9.47** "model-serving
 > freshness + operator-security" changes (folded in below) — v0.9.47 was
 > prepared but never tagged, so everything since v0.9.46 lands here.
+>
+> **Why 0.11.0 and not 0.10.0.** The packages carried a `0.10.0` version for
+> two months without a matching tag, and a `@chroxy/server@0.10.0` was
+> published to npm on 2026-07-06 from a build ~463 commits behind this one.
+> npm does not permit republishing a version, so `0.10.0` is unusable as a
+> release number. This release takes the next clean version instead, so the
+> git tag, the package versions, and the npm artifact agree from here on.
+> There is no `0.10.0` entry in this changelog because no `0.10.0` release
+> was ever cut.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -18042,7 +18042,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18097,7 +18097,7 @@
     },
     "packages/claude-hooks": {
       "name": "@chroxy/claude-hooks",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@chroxy/protocol": "*"
@@ -18111,7 +18111,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@chroxy/design-tokens": "*",
         "@chroxy/protocol": "*",
@@ -18223,16 +18223,16 @@
     },
     "packages/design-tokens": {
       "name": "@chroxy/design-tokens",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT"
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.10.0"
+      "version": "0.11.0"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -18244,7 +18244,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18307,7 +18307,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/claude-hooks",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Stateless Claude Code hook emitters for chroxy's POST /api/events ingest",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/design-tokens",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Canonical Chroxy design tokens — single source for the dashboard theme (and, later, mobile). The dashboard theme.css + tokens.ts are generated from here.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Description

Closes #7176.

`main` is **463 commits past `v0.9.46`** (2026-06-21) with no tag in between — the Codex app-server epic (#6605/#6616), persistent pairing tokens (#6598), and encrypted credentials at rest (#6644) are all currently unreachable from any release. The packages have declared `0.10.0` since June without a matching tag, and `CHANGELOG.md` already documents that `v0.9.47` was prepared and never tagged, so this is the second missed release compounding on the first.

## Why 0.11.0 and not 0.10.0

`@chroxy/server@0.10.0` was published to npm on **2026-07-06** from a build ~463 commits behind HEAD, and npm does not permit republishing a version:

```
$ curl -s https://registry.npmjs.org/@chroxy%2Fserver | ...
dist-tags: {'latest': '0.10.0'}
time: {'0.10.0': '2026-07-06T03:31:54.057Z'}
```

So `0.10.0` is unusable as a release number — tagging it would produce a git tag whose contents do not match the npm artifact of the same name, permanently. Taking the next clean version keeps the tag, the package versions, and npm in agreement going forward. The changelog records this so the absent `0.10.0` entry is not a mystery later.

## Changes

- `scripts/bump-version.sh 0.11.0 --no-changelog` — all 8 packages plus `app.json`, `tauri.conf.json`, `Cargo.toml`, and the three lockfiles
- `CHANGELOG.md`: the already-written `[Unreleased]` section promoted to `## [0.11.0] - 2026-08-15`, with a fresh empty `[Unreleased]` above it

`--no-changelog` is deliberate: the release notes were already written, so this promotes them rather than scaffolding a `TODO` placeholder over them.

## Verification

```
$ bash scripts/__tests__/bump-version.test.sh
Results: 14 passed, 0 failed

$ for s in packages/server/scripts/lint-*.sh; do bash $s; done
lint-claude-family-explicit.sh    PASS
lint-logger-session-scoping.sh    PASS
lint-session-opt-forwarding.sh    PASS
lint-tests-state-file-path.sh     PASS
lint-ws-index-mutations.sh        PASS
```

All 11 version-bearing files verified consistent at `0.11.0`.

## Follow-up (not in this PR)

Tag, GitHub release, and the npm publish happen after this merges. The npm publish requires credentials and is the repo owner's step.