### PR TITLE
docs(cli): document the real npm install path and drop the npx chroxy footgun

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ chroxy start
 
 > **Install the scoped name, not the bare one.** `@chroxy/server` is this project. The unscoped `chroxy` package on npm belongs to someone else and is unrelated — `npm i -g chroxy` or `npx chroxy` **outside a clone of this repo** installs that package, not this one.
 
-Node 22 is the minimum. On macOS with Homebrew's `node@22` not on your default `PATH`:
+Node 22 is the minimum. The `chroxy` binary runs under `#!/usr/bin/env node`, so if Homebrew's `node@22` isn't on your default `PATH`, prefix **every** `chroxy` command — not just `start`:
 
 ```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy init
 PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ export GEMINI_API_KEY=...
 Or pass them inline when starting the server:
 
 ```bash
-OPENAI_API_KEY=sk-... PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+OPENAI_API_KEY=sk-... PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start
 ```
 
 **Running without Claude installed?** The daemon defaults to the `claude-tui` provider, so a bare `chroxy start` expects a `claude` binary. To run a Codex- or Gemini-only machine (no `claude` at all), make a non-Claude provider the default. The cleanest way is to set it in `~/.chroxy/config.json`, because both the daemon **and** `chroxy doctor` read `config.provider`:
@@ -124,42 +124,58 @@ OPENAI_API_KEY=sk-... PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy star
 ```bash
 # Codex-only — no `claude` binary required. doctor honors config.provider too,
 # so it preflights Codex (not claude) and won't complain about a missing binary.
-OPENAI_API_KEY=sk-... npx chroxy start
+OPENAI_API_KEY=sk-... chroxy start
 ```
 
-`CHROXY_PROVIDER=codex npx chroxy start` also works to set the daemon's start-time default, but `chroxy doctor` reads `config.provider` from `~/.chroxy/config.json` rather than the env var — so setting it in the config file is what keeps *both* commands claude-free. Any client can still switch providers per session on session create (`--provider gemini`, or the provider picker in the app/dashboard).
+`CHROXY_PROVIDER=codex chroxy start` also works to set the daemon's start-time default, but `chroxy doctor` reads `config.provider` from `~/.chroxy/config.json` rather than the env var — so setting it in the config file is what keeps *both* commands claude-free. Any client can still switch providers per session on session create (`--provider gemini`, or the provider picker in the app/dashboard).
 
 If you create a session for a provider whose key isn't set, the server returns a clear error (e.g. *"Codex: required credential not set — OPENAI_API_KEY"*). See [docs/providers.md](docs/providers.md) for per-provider capabilities and full env var reference.
 
 ### Server (on your dev machine)
 
-Chroxy is not published to npm yet, so `npx chroxy` resolves from your local clone. Clone the repo and install dependencies first:
+Chroxy is published to npm as **[`@chroxy/server`](https://www.npmjs.com/package/@chroxy/server)**. Install it globally — that puts a `chroxy` command on your `PATH`:
+
+```bash
+npm i -g @chroxy/server
+
+# Install and configure
+chroxy init
+
+# Start the server
+chroxy start
+```
+
+> **Install the scoped name, not the bare one.** `@chroxy/server` is this project. The unscoped `chroxy` package on npm belongs to someone else and is unrelated — `npm i -g chroxy` or `npx chroxy` **outside a clone of this repo** installs that package, not this one.
+
+Node 22 is the minimum. On macOS with Homebrew's `node@22` not on your default `PATH`:
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start
+```
+
+On Windows PowerShell:
+
+```powershell
+npm i -g @chroxy/server
+chroxy init
+chroxy start
+```
+
+<details>
+<summary><b>From a clone instead (contributors)</b></summary>
+
+Inside a clone, `npx chroxy` resolves to the workspace binary, so the bare name is safe there:
 
 ```bash
 git clone https://github.com/blamechris/chroxy.git
 cd chroxy
 npm install
 
-# Install and configure
 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy init
-
-# Start the server
 PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
 ```
 
-On Windows PowerShell:
-
-```powershell
-git clone https://github.com/blamechris/chroxy.git
-cd chroxy
-npm install
-
-# Install and configure
-npx chroxy init
-
-# Start the server
-npx chroxy start
-```
+</details>
 
 The server prints a QR code. Scan it with the Chroxy mobile app, or open the dashboard URL in your browser.
 
@@ -180,14 +196,14 @@ Or connect manually:
    Dashboard: https://<random>.trycloudflare.com/dashboard (use --show-token to see full URL)
 ```
 
-If something looks off, `npx chroxy doctor` reports which dependencies are missing or misconfigured.
+If something looks off, `chroxy doctor` reports which dependencies are missing or misconfigured.
 
 ### Development mode
 
 Use `chroxy dev` when iterating on Chroxy itself. It forces supervisor mode (auto-restart on crash) and requires a tunnel (quick or named):
 
 ```bash
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy dev
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy dev
 ```
 
 ### Local WiFi (same network)
@@ -195,13 +211,13 @@ PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy dev
 If your phone and dev machine are on the same WiFi, connect directly without the tunnel. Start the server with `--tunnel none` to skip the tunnel entirely:
 
 ```bash
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start --tunnel none
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start --tunnel none
 ```
 
 On Windows PowerShell:
 
 ```powershell
-npx chroxy start --tunnel none
+chroxy start --tunnel none
 ```
 
 Then:
@@ -230,7 +246,7 @@ Then:
 | Named Tunnel | `--tunnel named` | Stable URL that survives restarts. Requires Cloudflare account + domain. |
 | No Tunnel | `--tunnel none` | Local only. Use with `--no-auth` for development. |
 
-> **Quick Tunnel security note.** The tunnel URL is randomized, but anyone with both your tunnel URL *and* your API token can connect. The token is the actual secret — protect it, rotate it if leaked (`npx chroxy init` regenerates), and prefer a Named Tunnel + IP allowlist for anything production-shaped.
+> **Quick Tunnel security note.** The tunnel URL is randomized, but anyone with both your tunnel URL *and* your API token can connect. The token is the actual secret — protect it, rotate it if leaked (`chroxy init` regenerates), and prefer a Named Tunnel + IP allowlist for anything production-shaped.
 
 ### Mobile App
 
@@ -305,9 +321,9 @@ winget install Git.Git
 git clone https://github.com/blamechris/chroxy
 cd chroxy
 npm install          # no Visual Studio / node-gyp needed — node-pty ships prebuilt Windows binaries
-npx chroxy doctor    # verify Node, cloudflared, and the port are ready
-npx chroxy init
-npx chroxy start
+chroxy doctor    # verify Node, cloudflared, and the port are ready
+chroxy init
+chroxy start
 ```
 
 Same QR-code / manual-entry connection flow as macOS. All session features (model switching, files, git, plan mode, agents) work identically.
@@ -315,10 +331,10 @@ Same QR-code / manual-entry connection flow as macOS. All session features (mode
 **Quickest start — local/LAN, no Cloudflare account, no tunnel:**
 
 ```powershell
-npx chroxy start --tunnel none --host 127.0.0.1 --show-token
+chroxy start --tunnel none --host 127.0.0.1 --show-token
 ```
 
-This binds the server locally and prints a **token-gated dashboard URL**. With `--show-token` the printed URL includes the `?token=…`, so you can open it directly in any Windows browser for the full chat/terminal UI — no desktop app needed. (Without the flag the URL and token are masked in the output; add `--show-token`, or append the token yourself.) Drop `--host 127.0.0.1` (the default is `0.0.0.0`) to also reach it from your phone over the LAN. Plain `npx chroxy start` (a Cloudflare Quick Tunnel) works too; if the edge isn't routable yet it degrades to local/LAN instead of aborting — pass `--tunnel named` for a stable remote URL.
+This binds the server locally and prints a **token-gated dashboard URL**. With `--show-token` the printed URL includes the `?token=…`, so you can open it directly in any Windows browser for the full chat/terminal UI — no desktop app needed. (Without the flag the URL and token are masked in the output; add `--show-token`, or append the token yourself.) Drop `--host 127.0.0.1` (the default is `0.0.0.0`) to also reach it from your phone over the LAN. Plain `chroxy start` (a Cloudflare Quick Tunnel) works too; if the edge isn't routable yet it degrades to local/LAN instead of aborting — pass `--tunnel named` for a stable remote URL.
 
 **Run at startup:** native Windows service install is not supported by the CLI. Pick one of:
 - **Task Scheduler** — schedule `node <chroxy-path> start` at logon
@@ -361,11 +377,11 @@ If you want the exact Linux runtime, run the daemon inside WSL2 instead of the n
 # Inside WSL2 (Ubuntu) — clone NATIVELY (not under /mnt/c; see the note below)
 git clone https://github.com/blamechris/chroxy && cd chroxy
 npm install                       # a native Linux install — node-pty needs its Linux prebuild
-npx chroxy start --host 0.0.0.0   # 0.0.0.0 is required to reach it from Windows
+chroxy start --host 0.0.0.0   # 0.0.0.0 is required to reach it from Windows
 ```
 
 - **Reaching it from Windows:** WSL2's localhost-forwarding only forwards to a **`0.0.0.0`-bound** server, so `http://localhost:8765` works from a Windows browser. A `--host 127.0.0.1` bind is **not** forwarded and silently isolates the daemon inside WSL — use `--host 0.0.0.0` (chroxy's default) here.
-- **Phone / remote access:** WSL2 sits behind NAT, so run the Cloudflare tunnel **inside** WSL2 (its outbound connection traverses the NAT cleanly): install `cloudflared` in the distro, then plain `npx chroxy start`. Exposing a WSL2 port inbound instead would need a Windows-side `netsh interface portproxy` rule.
+- **Phone / remote access:** WSL2 sits behind NAT, so run the Cloudflare tunnel **inside** WSL2 (its outbound connection traverses the NAT cleanly): install `cloudflared` in the distro, then plain `chroxy start`. Exposing a WSL2 port inbound instead would need a Windows-side `netsh interface portproxy` rule.
 - **Clone natively, not from `/mnt/c`:** a Windows checkout mounted at `/mnt/c` carries two hazards — node-pty's Windows prebuilds don't load under Linux (hence the native `npm install`), and `.sh` scripts a Windows checkout wrote with `core.autocrlf` have CRLF endings that break `./script.sh` (`bash script.sh` tolerates it). The repo stores every script LF (`.gitattributes`), so a native WSL clone is clean.
 
 ## Features
@@ -450,7 +466,7 @@ cd chroxy
 npm install
 
 # Terminal 1: Start the server (Node 22 required)
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start
 
 # Terminal 2: Start Expo dev server (for mobile hot-reload)
 cd packages/app

--- a/docs/guides/container-isolation.md
+++ b/docs/guides/container-isolation.md
@@ -58,7 +58,7 @@ Docker providers are opt-in. You must enable environments *and* have Docker avai
 **CLI flag:**
 
 ```bash
-npx chroxy start --environments --provider docker-sdk
+chroxy start --environments --provider docker-sdk
 ```
 
 **Config file** (`~/.chroxy/config.json`):
@@ -73,7 +73,7 @@ npx chroxy start --environments --provider docker-sdk
 **Environment variable:**
 
 ```bash
-CHROXY_PROVIDER=docker-sdk npx chroxy start --environments
+CHROXY_PROVIDER=docker-sdk chroxy start --environments
 ```
 
 The `--environments` flag triggers Docker availability detection at startup. If `docker info` fails, the docker providers are silently skipped and the server falls back to the default provider.
@@ -98,7 +98,7 @@ Sandbox settings are passed directly to the Agent SDK. No Docker required.
 **Environment variable:**
 
 ```bash
-CHROXY_SANDBOX='{"type":"container","network":false}' npx chroxy start
+CHROXY_SANDBOX='{"type":"container","network":false}' chroxy start
 ```
 
 ### Per-Session Provider Selection
@@ -193,7 +193,7 @@ You can snapshot a running environment at any point using `docker commit`. Snaps
 
 ```bash
 # Start server with environments enabled
-npx chroxy start --environments --provider docker-sdk
+chroxy start --environments --provider docker-sdk
 ```
 
 ### When to Use

--- a/docs/named-tunnel-guide.md
+++ b/docs/named-tunnel-guide.md
@@ -11,7 +11,7 @@ Named Tunnels give you a **stable URL** that never changes. Scan the QR code onc
 ## Quick Setup (Interactive)
 
 ```bash
-npx chroxy tunnel setup
+chroxy tunnel setup
 ```
 
 This walks you through:
@@ -65,19 +65,19 @@ Edit `~/.chroxy/config.json`:
 Or use CLI flags:
 
 ```bash
-npx chroxy start --tunnel named --tunnel-name chroxy --tunnel-hostname chroxy.example.com
+chroxy start --tunnel named --tunnel-name chroxy --tunnel-hostname chroxy.example.com
 ```
 
 Or environment variables:
 
 ```bash
-CHROXY_TUNNEL=named CHROXY_TUNNEL_NAME=chroxy CHROXY_TUNNEL_HOSTNAME=chroxy.example.com npx chroxy start
+CHROXY_TUNNEL=named CHROXY_TUNNEL_NAME=chroxy CHROXY_TUNNEL_HOSTNAME=chroxy.example.com chroxy start
 ```
 
 ### 5. Start the Server
 
 ```bash
-npx chroxy start
+chroxy start
 ```
 
 The QR code and connection URL will always be the same.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -85,7 +85,7 @@ The SDK provider (`claude-sdk`) does not shell out to the `claude` binary for me
 ### Verify
 
 ```bash
-npx chroxy doctor
+chroxy doctor
 ```
 
 Expected output includes:
@@ -152,7 +152,7 @@ It is read from the **daemon process environment** at request time. Set it where
 the daemon is launched, e.g. exported in the shell that runs `chroxy start`:
 
 ```bash
-CHROXY_TUI_MULTISELECT_REINJECT=1 npx chroxy start --provider claude-tui
+CHROXY_TUI_MULTISELECT_REINJECT=1 chroxy start --provider claude-tui
 ```
 
 or, for a launchd-started daemon, in the plist's `EnvironmentVariables`
@@ -250,7 +250,7 @@ The provider hard-fails at `start()` with `OPENAI_API_KEY environment variable i
 codex exec "hello" --json
 
 # Start Chroxy with the codex provider
-OPENAI_API_KEY=sk-... npx chroxy start --provider codex
+OPENAI_API_KEY=sk-... chroxy start --provider codex
 ```
 
 `chroxy doctor` does **not** currently probe for `codex` or `gemini` binaries — it only checks `node`, `cloudflared`, and `claude`. Verify third-party binaries manually.
@@ -461,7 +461,7 @@ The provider hard-fails at `start()` only if **neither** a key (`GEMINI_API_KEY`
 ```bash
 gemini -p "hello" --output-format stream-json -y
 
-GEMINI_API_KEY=... npx chroxy start --provider gemini
+GEMINI_API_KEY=... chroxy start --provider gemini
 ```
 
 ### Common pitfalls
@@ -486,8 +486,8 @@ ollama --version              # must be >= 0.14.0
 ### Use
 
 ```bash
-npx chroxy start --provider ollama                       # default model: qwen3-coder
-npx chroxy start --provider ollama --model glm-4.7       # any locally pulled model id
+chroxy start --provider ollama                       # default model: qwen3-coder
+chroxy start --provider ollama --model glm-4.7       # any locally pulled model id
 ```
 
 There is **no model allow-list**: whatever `ollama list` shows is valid. The dashboard picker seeds Ollama's recommended coder models (`qwen3-coder`, `glm-4.7`, `minimax-m2.1`); type any other pulled model id freely. An unknown id surfaces as Ollama's own error on the first message.
@@ -497,7 +497,7 @@ There is **no model allow-list**: whatever `ollama list` shows is valid. The das
 Resolution order: `CHROXY_OLLAMA_BASE_URL` (full URL) → `OLLAMA_HOST` (Ollama's own convention; bare `host:port` is normalized to `http://`) → `http://localhost:11434`.
 
 ```bash
-CHROXY_OLLAMA_BASE_URL=http://gpu-box:11434 npx chroxy start --provider ollama
+CHROXY_OLLAMA_BASE_URL=http://gpu-box:11434 chroxy start --provider ollama
 ```
 
 ### Common pitfalls
@@ -575,8 +575,8 @@ For **OpenRouter** — which accepts the Anthropic format for *every* model on t
 ### Use
 
 ```bash
-ZAI_API_KEY=... npx chroxy start --provider zai-glm
-npx chroxy start --provider lm-studio
+ZAI_API_KEY=... chroxy start --provider zai-glm
+chroxy start --provider lm-studio
 ```
 
 ### Caveats
@@ -592,7 +592,7 @@ npx chroxy start --provider lm-studio
 ### Preset
 
 ```bash
-npx chroxy providers add openrouter
+chroxy providers add openrouter
 ```
 
 This writes the `providers.anthropicCompatible` entry for you — `baseUrl https://openrouter.ai/api`, the `OPENROUTER_API_KEY` env seam (or the `openrouterApiKey` field in `~/.chroxy/credentials.json`, mode `0600`), a sensible default model, and the `modelDiscovery` block. It's **idempotent**: re-running leaves an existing entry untouched (`--force` rewrites it to the current preset).
@@ -601,7 +601,7 @@ Then provide your key and start:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...           # or save it as "openrouterApiKey" in ~/.chroxy/credentials.json (0600)
-npx chroxy start --provider openrouter
+chroxy start --provider openrouter
 ```
 
 ### Model discovery
@@ -693,8 +693,8 @@ No `apiKeyEnv` / `credentialsKey` → no credential gate (a placeholder key is s
 ### Use
 
 ```bash
-OPENROUTER_API_KEY=sk-or-... npx chroxy start --provider openrouter-oai
-npx chroxy start --provider lm-studio-oai
+OPENROUTER_API_KEY=sk-or-... chroxy start --provider openrouter-oai
+chroxy start --provider lm-studio-oai
 ```
 
 ### Caveats
@@ -738,15 +738,15 @@ Precedence (highest first): CLI flag > environment variable > config file > defa
 ### CLI flag
 
 ```bash
-npx chroxy start --provider claude-cli
-npx chroxy start --provider gemini
-npx chroxy start --provider codex
+chroxy start --provider claude-cli
+chroxy start --provider gemini
+chroxy start --provider codex
 ```
 
 ### Environment variable
 
 ```bash
-CHROXY_PROVIDER=gemini npx chroxy start
+CHROXY_PROVIDER=gemini chroxy start
 ```
 
 ### Config file

--- a/docs/self-hosting-guide.md
+++ b/docs/self-hosting-guide.md
@@ -187,4 +187,4 @@ Check the server logs for crash reasons. The supervisor backs off from 2s to 10s
 
 - Claude Code not installed or not authenticated (`claude --version`)
 - Permission issues accessing the working directory
-- Missing `~/.chroxy/config.json` (run `npx chroxy init`)
+- Missing `~/.chroxy/config.json` (run `chroxy init`)

--- a/docs/setup-and-smoke-test.md
+++ b/docs/setup-and-smoke-test.md
@@ -275,7 +275,7 @@ If 7a–7c pass but 7d doesn't, it's almost always the **AI CLI**, not chroxy �
 | Symptom | Check |
 |---------|-------|
 | `Port 8765 is available` fails / "address in use" | A daemon is already running. `chroxy status` to confirm. Stop it: **Ctrl+C** if you started it in the foreground; `chroxy service stop` if you installed it as a system daemon; otherwise kill the pid that `chroxy status` printed. |
-| `No API token configured. Run 'npx chroxy init' first.` | You skipped step 3, or the keychain entry was removed. Re-run `chroxy init`. |
+| `No API token configured. Run 'chroxy init' first.` | You skipped step 3, or the keychain entry was removed. Re-run `chroxy init`. |
 | Dashboard 403s | The `?token=` is missing/wrong — re-fetch it (step 6). |
 | Tunnel URL unreachable | `curl https://<tunnel>/health`; wait a few seconds for the route to propagate, or check `cloudflared` in `doctor`. |
 | App can't connect | See [self-hosting-guide.md](self-hosting-guide.md#app-cant-connect). |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,8 +140,8 @@ curl -s -H "Authorization: Bearer $TOKEN" -H "Accept: text/plain" \
 
 **Fix:**
 ```bash
-npx chroxy init     # Interactive setup — generates token and config
-npx chroxy start    # Now starts successfully
+chroxy init     # Interactive setup — generates token and config
+chroxy start    # Now starts successfully
 ```
 
 Or set the token manually in `~/.chroxy/config.json`:
@@ -202,7 +202,7 @@ curl -s https://your-tunnel-url.trycloudflare.com
 ```bash
 node --version                    # Check current version
 brew install node@22              # Install Node 22
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start
 ```
 
 ## 6. App shows "server restarting" loop
@@ -216,7 +216,7 @@ PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
 **Fixes:**
 - Check server terminal for error messages
 - Ensure Claude Code CLI is installed and working: `claude --version`
-- Increase max restarts if needed: `npx chroxy start --max-restarts 20`
+- Increase max restarts if needed: `chroxy start --max-restarts 20`
 
 ## 7. QR code won't scan
 
@@ -227,7 +227,7 @@ PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
 
 **Fixes:**
 - Increase terminal font size for a larger QR code
-- Use `npx chroxy pair-code` to re-print the current pairing code + connection URL for the running daemon (or `npx chroxy status` for the tunnel URL / port / uptime) without restarting
+- Use `chroxy pair-code` to re-print the current pairing code + connection URL for the running daemon (or `chroxy status` for the tunnel URL / port / uptime) without restarting
 
 ## 8. E2E encryption errors ("decrypt failed")
 
@@ -246,7 +246,7 @@ PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
 **Cause:** Either the session-idle timeout fired, or the per-turn `RESULT_TIMEOUT` watchdog (5 min by default) fired.
 
 **Fixes:**
-- For the idle timeout: increase it with `npx chroxy start --session-timeout 4h`, or disable it by not setting `--session-timeout` / `CHROXY_SESSION_TIMEOUT`. The app sends keep-alive pings, but only while it's in the foreground.
+- For the idle timeout: increase it with `chroxy start --session-timeout 4h`, or disable it by not setting `--session-timeout` / `CHROXY_SESSION_TIMEOUT`. The app sends keep-alive pings, but only while it's in the foreground.
 - For the per-turn `RESULT_TIMEOUT`: capture a [`/diagnostics`](#0-diagnostics-endpoint-triaging-stuck-sessions) snapshot **before restarting** so you can see whether the session was wedged on a pending permission, an upstream provider call, or a leaked timer. Restarting wipes every flag.
 
 ## 10. Gemini provider errors (`--provider gemini`)
@@ -258,7 +258,7 @@ See [docs/providers.md](providers.md) for Gemini CLI installation and supported 
 - Or export it before launching Chroxy (an exported env var takes precedence over a stored value):
   ```bash
   export GEMINI_API_KEY=your-key-here
-  npx chroxy start --provider gemini
+  chroxy start --provider gemini
   ```
 
 **Symptom:** `gemini: command not found` / `ENOENT`
@@ -278,7 +278,7 @@ See [docs/providers.md](providers.md) for Codex CLI installation and supported m
 - Or export it before launching Chroxy (an exported env var takes precedence over a stored value):
   ```bash
   export OPENAI_API_KEY=your-key-here
-  npx chroxy start --provider codex
+  chroxy start --provider codex
   ```
 
 **Symptom:** `codex: command not found` / `ENOENT`

--- a/docs/troubleshooting/session-token-mismatch.md
+++ b/docs/troubleshooting/session-token-mismatch.md
@@ -66,14 +66,14 @@ logs clean during auto-accept sessions with heavy permission traffic.
 To enable the full correlation trail, restart the server with
 `LOG_LEVEL=debug`:
 
-**CLI (default `npx chroxy start`):**
+**CLI (default `chroxy start`):**
 ```bash
-LOG_LEVEL=debug PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx chroxy start
+LOG_LEVEL=debug PATH="/opt/homebrew/opt/node@22/bin:$PATH" chroxy start
 ```
 
 **Supervisor mode (`--tunnel named`):**
 ```bash
-LOG_LEVEL=debug npx chroxy start --tunnel named
+LOG_LEVEL=debug chroxy start --tunnel named
 ```
 The supervisor passes its environment through to each child respawn, so
 setting it once on the supervisor process is sufficient.

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -96,11 +96,11 @@ export function parseChroxyUrl(raw: string): ParseResult {
 const QR_ERROR_MESSAGES: Record<string, { title: string; message: string }> = {
   not_chroxy: {
     title: 'Not a Chroxy QR Code',
-    message: 'This QR code is not from Chroxy. Scan the QR code shown by "npx chroxy start" on your computer.',
+    message: 'This QR code is not from Chroxy. Scan the QR code shown by "chroxy start" on your computer.',
   },
   missing_token: {
     title: 'Missing Auth Token',
-    message: 'This Chroxy QR code is missing the authentication token. Try restarting the server with "npx chroxy start".',
+    message: 'This Chroxy QR code is missing the authentication token. Try restarting the server with "chroxy start".',
   },
   invalid_url: {
     title: 'Invalid QR Code',
@@ -483,7 +483,7 @@ export function ConnectScreen() {
         <Icon name="satellite" size={48} color={COLORS.accentBlue} />
         <Text style={styles.title}>Connect to Chroxy</Text>
         <Text style={styles.subtitle}>
-          Run 'npx chroxy start' on your Mac, then scan the QR code
+          Run 'chroxy start' on your Mac, then scan the QR code
         </Text>
       </View>
 

--- a/packages/app/src/screens/OnboardingScreen.tsx
+++ b/packages/app/src/screens/OnboardingScreen.tsx
@@ -9,7 +9,7 @@ const STEPS = [
   },
   {
     title: 'Set Up the Server',
-    body: 'On your dev machine, install and start the Chroxy server:\n\nnpx chroxy start\n\nThis starts a daemon with a secure Cloudflare tunnel and displays a QR code.',
+    body: 'On your dev machine, install and start the Chroxy server:\n\nchroxy start\n\nThis starts a daemon with a secure Cloudflare tunnel and displays a QR code.',
   },
   {
     title: 'Connect',

--- a/packages/dashboard/src/components/ErrorScreen.test.tsx
+++ b/packages/dashboard/src/components/ErrorScreen.test.tsx
@@ -47,11 +47,11 @@ describe('ErrorScreen', () => {
       <ErrorScreen
         title="Error"
         message="Server failed"
-        details="Try starting manually: npx chroxy start"
+        details="Try starting manually: chroxy start"
         onRetry={vi.fn()}
       />,
     )
-    expect(screen.getByText(/npx chroxy start/)).toBeInTheDocument()
+    expect(screen.getByText(/chroxy start/)).toBeInTheDocument()
   })
 
   it('does not render details section when not provided', () => {

--- a/packages/server/src/cli/config-cmd.js
+++ b/packages/server/src/cli/config-cmd.js
@@ -10,7 +10,7 @@ export function registerConfigCommand(program) {
     .description('Show current configuration')
     .action(() => {
       if (!existsSync(CONFIG_FILE)) {
-        console.log('No config found. Run \'npx chroxy init\' first.')
+        console.log('No config found. Run \'chroxy init\' first.')
         process.exit(1)
       }
 
@@ -29,6 +29,6 @@ export function registerConfigCommand(program) {
       }
       console.log(`   API token: ${config.apiToken}`)
       console.log('\nNote: CLI flags and environment variables can override these values.')
-      console.log('Run \'npx chroxy start --verbose\' to see full config resolution.\n')
+      console.log('Run \'chroxy start --verbose\' to see full config resolution.\n')
     })
 }

--- a/packages/server/src/cli/deploy-cmd.js
+++ b/packages/server/src/cli/deploy-cmd.js
@@ -149,7 +149,7 @@ export function registerDeployCommand(program) {
 
         if (isWindows) {
           console.error('[deploy] Deploy restart via SIGUSR2 is not supported on Windows.')
-          console.error('   Restart the server manually: npx chroxy start')
+          console.error('   Restart the server manually: chroxy start')
           process.exitCode = 1
           return
         }

--- a/packages/server/src/cli/init-cmd.js
+++ b/packages/server/src/cli/init-cmd.js
@@ -191,7 +191,7 @@ export async function runInitCmd(deps = {}) {
 
   logFn('\n📱 Your API token (keep this secret):')
   logFn(`   ${apiToken}`)
-  logFn('\n🚀 Run \'npx chroxy start\' to launch the server')
+  logFn('\n🚀 Run \'chroxy start\' to launch the server')
   logFn('')
 
   return { written: true, config, apiToken }

--- a/packages/server/src/cli/providers-cmd.js
+++ b/packages/server/src/cli/providers-cmd.js
@@ -107,11 +107,11 @@ export function runProvidersAddOpenRouter(options = {}, deps = {}) {
     } catch (err) {
       logFn(`❌ Config file contains invalid JSON: ${configFilePath}`)
       logFn(`   ${err.message}`)
-      logFn(`   Fix the file or run 'npx chroxy init' to recreate it.`)
+      logFn(`   Fix the file or run 'chroxy init' to recreate it.`)
       return { status: 'invalid-json', written: false, configFilePath }
     }
   } else {
-    logFn(`❌ No config found at ${configFilePath}. Run 'npx chroxy init' first.`)
+    logFn(`❌ No config found at ${configFilePath}. Run 'chroxy init' first.`)
     return { status: 'no-config', written: false, configFilePath }
   }
 
@@ -137,7 +137,7 @@ export function runProvidersAddOpenRouter(options = {}, deps = {}) {
   logFn(`       export ${OPENROUTER_PRESET.apiKeyEnv}=sk-or-...`)
   logFn(`     or save it as "${OPENROUTER_PRESET.credentialsKey}" in ~/.chroxy/credentials.json (mode 0600)`)
   logFn('  2. Start with OpenRouter as the active provider:')
-  logFn(`       npx chroxy start --provider ${OPENROUTER_PRESET.id}`)
+  logFn(`       chroxy start --provider ${OPENROUTER_PRESET.id}`)
   logFn('')
   logFn('  The model picker fills from OpenRouter\'s live catalog and per-model')
   logFn('  pricing is applied automatically — sessions report real cost.')

--- a/packages/server/src/cli/server-cmd.js
+++ b/packages/server/src/cli/server-cmd.js
@@ -47,7 +47,7 @@ export function registerServerCommands(program) {
           for (const f of failures) {
             console.error(`  ✗ ${f.name}: ${f.message}`)
           }
-          console.error('\nRun `npx chroxy doctor` for details, or `--skip-checks` to bypass.\n')
+          console.error('\nRun `chroxy doctor` for details, or `--skip-checks` to bypass.\n')
           process.exitCode = 1
           return
         }

--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -102,7 +102,7 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
       if (err instanceof SyntaxError) {
         console.error(`❌ Config file contains invalid JSON: ${options.config}`)
         console.error(`   ${err.message}`)
-        console.error(`   Fix the file or delete it and run 'npx chroxy init' to recreate.`)
+        console.error(`   Fix the file or delete it and run 'chroxy init' to recreate.`)
         process.exit(1)
       }
       throw err
@@ -111,7 +111,7 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
     console.error(`❌ Config file not found: ${options.config}`)
     process.exit(1)
   } else {
-    console.error('❌ No config found. Run \'npx chroxy init\' first.')
+    console.error('❌ No config found. Run \'chroxy init\' first.')
     process.exit(1)
   }
 

--- a/packages/server/src/cli/tunnel-cmd.js
+++ b/packages/server/src/cli/tunnel-cmd.js
@@ -96,6 +96,6 @@ async function setupCloudflare() {
   console.log(`   HTTP:      https://${hostname}`)
   console.log(`   WebSocket: wss://${hostname}`)
   console.log('')
-  console.log('Run \'npx chroxy start\' to launch with your Named Tunnel.')
+  console.log('Run \'chroxy start\' to launch with your Named Tunnel.')
   console.log('The QR code will always be the same — scan it once, connect forever.\n')
 }

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -365,7 +365,7 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
       }
     }
   } else {
-    configCheck = { name: 'Config', status: 'warn', message: `Not found — run 'npx chroxy init' to create` }
+    configCheck = { name: 'Config', status: 'warn', message: `Not found — run 'chroxy init' to create` }
   }
 
   // 4. Provider-specific checks. Each configured provider contributes its

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -601,7 +601,7 @@ export async function startCliServer(config) {
   }
 
   if (!NO_AUTH && !API_TOKEN) {
-    console.error('[!] No API token configured. Run \'npx chroxy init\' first.') // intentional user-facing output
+    console.error('[!] No API token configured. Run \'chroxy init\' first.') // intentional user-facing output
     process.exit(1)
   }
 

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -264,7 +264,7 @@ export class Supervisor extends EventEmitter {
 
   async start() {
     if (!this._apiToken) {
-      process.stderr.write('[!] No API token configured. Run \'npx chroxy init\' first.\n')
+      process.stderr.write('[!] No API token configured. Run \'chroxy init\' first.\n')
       this._exit(1)
       return
     }

--- a/packages/server/src/tunnel-check.js
+++ b/packages/server/src/tunnel-check.js
@@ -77,7 +77,7 @@ export async function waitForTunnel(httpUrl, { maxAttempts = 20, initialInterval
     `Tunnel failed to become routable after ${maxAttempts} attempts (${elapsed}s). ` +
     `${lastFailure ? `Last failure: ${lastFailure}. ` : ''}` +
     'This usually means your network is blocking Cloudflare, or DNS has not propagated yet. ' +
-    'Try a named tunnel (--tunnel named) or run `npx chroxy doctor` for diagnostics.'
+    'Try a named tunnel (--tunnel named) or run `chroxy doctor` for diagnostics.'
   )
   err.code = 'TUNNEL_NOT_ROUTABLE'
   throw err


### PR DESCRIPTION
## Description

Closes #7177.

`README.md:136` said:

> Chroxy is not published to npm yet, so `npx chroxy` resolves from your local clone.

That has been false since **2026-07-06**, when `@chroxy/server@0.10.0` was published.

### The footgun

The unscoped `chroxy` name on npm is **someone else's package**:

```
$ curl -s https://registry.npmjs.org/chroxy | ...
name: chroxy      dist-tags: {'latest': '0.0.1'}
desc: > proxy     maintainers: [{'name': 'song940', …}]
```

So `npx chroxy start` is only correct **inside a clone**. Anywhere else it downloads and runs an unrelated package. The working command — `npm i -g @chroxy/server` — appeared nowhere.

This was not just a docs problem. The daemon printed the same instruction at runtime in **21 places**. Reproduced live:

```
$ node src/cli.js start --tunnel none --host 127.0.0.1
❌ No config found. Run 'npx chroxy init' first.
```

A user who installed `@chroxy/server` from npm and followed that hint would install `song940/chroxy` instead — the product routing its own users to the wrong package.

## Changes

**README install section** — leads with the real path. `packages/server/package.json` declares `"bin": {"chroxy": "src/cli.js"}`, so a global install puts a bare `chroxy` on `PATH`:

```bash
npm i -g @chroxy/server
chroxy init
chroxy start
```

…plus an explicit callout warning against the unscoped name, and the clone workflow preserved in a collapsed `<details>` section where `npx chroxy` remains correct.

**Runtime strings** — `npx chroxy` → `chroxy` across 15 server sites, 4 app sites, and 2 in a dashboard test fixture (fixture and assertion updated together).

**Docs** — 75 replacements across 8 files describing daemon usage.

### Deliberately left alone

| Path | Why |
|---|---|
| `docs/setup-and-smoke-test.md`, `docs/self-hosting-guide.md` | These walk the **clone** workflow, where `npx chroxy` is the correct form. Their only change is one quoted error message, mirroring the source string this PR edited. |
| `docs/audit/**`, `docs/reports/**` | Point-in-time historical records; rewriting them would falsify the record. 11 occurrences remain there by design. |

## Verification

```
$ grep -rn "npx chroxy" packages/*/src/ | wc -l
0

$ grep -rn "npx chroxy" README.md docs/ | sed 's/:.*//' | sort | uniq -c
   1 docs/audit/tui-hardening-2026-06-07.md
   3 docs/audit/windows-linux-support-2026-07-14/00-master-assessment.md
   3 docs/audit/windows-linux-support-2026-07-14/04-minimalist.md
   1 docs/audit/windows-linux-support-2026-07-14/07-tunneler.md
   2 docs/reports/chroxy-state-and-roadmap-2026-06-27.html
   1 docs/reports/smoke-test-5769.html
```

Residual occurrences are exactly the two excluded historical trees.

## Sequencing

The npm-facing claim is true today (`@chroxy/server` is published), but the currently-published `0.10.0` is a ~463-commit-stale build. **This should merge after the 0.11.0 publish (#7176 / #7180)** so `npm i -g @chroxy/server` gives users current code rather than a two-month-old daemon.