### PR TITLE
test(server): skip the ledger EACCES fixture as root

### DIFF
--- a/packages/server/tests/orchestration-run-ledger.test.js
+++ b/packages/server/tests/orchestration-run-ledger.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { RunLedger } from '../src/orchestration/run-ledger.js'
 import { makeRunRecord, applyEvent, makeUsageCell } from '../src/orchestration/run-record.js'
+import { POSIX_PERM_SKIP } from './test-helpers.js'
 
 // #6691 M-2 — the durable run store. Every test uses a temp baseDir (the same
 // sandbox discipline as stateFilePath); nothing touches the real ~/.chroxy.
@@ -259,7 +260,11 @@ describe('RunLedger journal-append failure durability (#6720)', () => {
   // path never marks the run dirty in the first place, a flush that ALSO fails
   // used to leave the fold with no retry at all — strictly worse than the
   // pre-#6720 _scheduleSave, which at least got another attempt at shutdown.
-  it('still retries at shutdown when BOTH the journal append and the forced snapshot fail', () => {
+  // Skipped as root: the EACCES half of this fixture is staged with
+  // `chmodSync(runDir, 0o500)`, and root bypasses Unix mode bits, so the
+  // forced snapshot succeeds and the positive control below fires instead
+  // (`the forced snapshot did not land`, 0.4 !== 0). See #6075.
+  it('still retries at shutdown when BOTH the journal append and the forced snapshot fail', { skip: POSIX_PERM_SKIP }, () => {
     const led = mkLedger({ saveDebounceMs: 60_000 })
     const run = led.createRun({ title: 'x' })
     led.createSubtask(run.runId, { subtaskId: 'st1', role: 'a' }) // lifecycle → flushed

--- a/packages/server/tests/orchestration-run-ledger.test.js
+++ b/packages/server/tests/orchestration-run-ledger.test.js
@@ -260,10 +260,12 @@ describe('RunLedger journal-append failure durability (#6720)', () => {
   // path never marks the run dirty in the first place, a flush that ALSO fails
   // used to leave the fold with no retry at all — strictly worse than the
   // pre-#6720 _scheduleSave, which at least got another attempt at shutdown.
-  // Skipped as root: the EACCES half of this fixture is staged with
-  // `chmodSync(runDir, 0o500)`, and root bypasses Unix mode bits, so the
-  // forced snapshot succeeds and the positive control below fires instead
-  // (`the forced snapshot did not land`, 0.4 !== 0). See #6075.
+  // Skipped wherever POSIX mode bits can't deny a write — as root, which
+  // bypasses them, and on Windows, whose ACLs don't map to chmod at all.
+  // The EACCES half of this fixture is staged with `chmodSync(runDir, 0o500)`,
+  // so in both environments the forced snapshot succeeds and the positive
+  // control below fires instead (`the forced snapshot did not land`,
+  // 0.4 !== 0). POSIX_PERM_SKIP carries the reason string for each. See #6075.
   it('still retries at shutdown when BOTH the journal append and the forced snapshot fail', { skip: POSIX_PERM_SKIP }, () => {
     const led = mkLedger({ saveDebounceMs: 60_000 })
     const run = led.createRun({ title: 'x' })


### PR DESCRIPTION
## Description

Closes #7179.

`packages/server/tests/orchestration-run-ledger.test.js:262` — *"still retries at shutdown when BOTH the journal append and the forced snapshot fail"* — cannot pass as **root**.

The test stages the EACCES half of its fixture by making the run directory read-only:

```js
chmodSync(runDir, 0o500)
```

Root bypasses POSIX mode bits, so the snapshot write succeeds, the failure the test is staging never happens, and its **positive control** fires instead:

```
not ok 2 - still retries at shutdown when BOTH the journal append and the forced snapshot fail
  location: 'tests/orchestration-run-ledger.test.js:262:3'
  error: 'the forced snapshot did not land\n\n0.4 !== 0'
  expected: 0
  actual: 0.4
```

This is a **test-environment defect, not a product bug** — CI runs on a non-root runner and is green. It blocks clean runs in root devcontainers, Docker images, and cloud agent sandboxes.

## Fix

Reuse the existing `POSIX_PERM_SKIP` helper from `tests/test-helpers.js`, added by #6075 for exactly this, rather than adding bespoke root detection. Eight other permission fixtures already guard themselves this way (`credential-store-durable.test.js:409/474`, `checkpoint-manager.test.js:98`, `discord-webhook-sink.test.js:231`, `componentwise-resolver.test.js:131`, …) — this file was the lone straggler.

## Verification

Same file, same command, `node:22-alpine`, only the uid varies:

| | before | after |
|---|---|---|
| **uid 0 (root)** | 17 tests, 16 pass, **1 fail** | 17 tests, 16 pass, **0 fail, 1 skipped** |
| **uid 1000** | 17 tests, 17 pass, 0 fail | 17 tests, **17 pass, 0 fail, 0 skipped** |

The non-root row is the important one: the test still **runs and still passes** where it can observe a permission denial. It is skipped only where it structurally cannot.

## Scope — this is the only affected test

All ten restrictive-`chmod` seams in `tests/` were run at uid 0 and uid 1000 in the same container. After this change, no file differs by a failure between the two uids:

| File | uid 0 | uid 1000 |
|---|---|---|
| `orchestration-run-ledger` | 16 pass, 0 fail, **1 skipped** | 17 pass, 0 fail |
| `models-factory` | 45 pass, 0 fail, 2 skipped | 47 pass, 0 fail |
| `componentwise-resolver` | 11 pass, 0 fail, 1 skipped | 12 pass, 0 fail |
| `ws-file-ops-error-paths` | already guarded | already guarded |
| `checkpoint-manager` | 24 pass, 0 fail | 24 pass, 0 fail |

Two caveats on that container run, recorded so the numbers aren't over-read:

- `checkpoint-manager` and `permission-hook-sidecar-integration` fail in `node:22-alpine` at **both** uids — `spawnSync git ENOENT`, because the alpine image has no git. Under `node:22` (which has git) `checkpoint-manager` passes 24/24 at both uids. Unrelated to root.
- Four files (`ws-file-ops-error-paths`, `credential-store-durable`, `discord-webhook-sink`, `credential-rekey`) fail identically at both uids with `ERR_MODULE_NOT_FOUND: Cannot find package 'tweetnacl'` — the test worktree has no `node_modules`. Also unrelated to root, and not introduced here.