### PR TITLE
fix(cli): make the npm install path work by publishing the sibling packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ autonomous-session-*.md
 
 # Generated visual-review / brief artifacts (never commit)
 .visual-review/
+
+# store-core publish staging dir (npm run build:publish)
+packages/store-core/publish/

--- a/package-lock.json
+++ b/package-lock.json
@@ -18046,8 +18046,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@chroxy/protocol": "*",
-        "@chroxy/store-core": "*",
+        "@chroxy/protocol": "^0.11.0",
+        "@chroxy/store-core": "^0.11.0",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.0.0",
@@ -18100,7 +18100,7 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@chroxy/protocol": "*"
+        "@chroxy/protocol": "^0.11.0"
       },
       "bin": {
         "chroxy-hooks": "bin/chroxy-hooks.js"
@@ -18113,9 +18113,9 @@
       "name": "@chroxy/dashboard",
       "version": "0.11.0",
       "dependencies": {
-        "@chroxy/design-tokens": "*",
-        "@chroxy/protocol": "*",
-        "@chroxy/store-core": "*",
+        "@chroxy/design-tokens": "^0.11.0",
+        "@chroxy/protocol": "^0.11.0",
+        "@chroxy/store-core": "^0.11.0",
         "dompurify": "^3.3.1",
         "mermaid": "^11.6.0",
         "react-resizable-panels": "^4.7.1",
@@ -18250,8 +18250,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
         "@anthropic-ai/sdk": "^0.81.0",
-        "@chroxy/protocol": ">=0.11.0",
-        "@chroxy/store-core": ">=0.11.0",
+        "@chroxy/protocol": "^0.11.0",
+        "@chroxy/store-core": "^0.11.0",
         "@kubernetes/client-node": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -18309,7 +18309,7 @@
       "name": "@chroxy/store-core",
       "version": "0.11.0",
       "dependencies": {
-        "@chroxy/protocol": ">=0.11.0",
+        "@chroxy/protocol": "^0.11.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18250,8 +18250,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
         "@anthropic-ai/sdk": "^0.81.0",
-        "@chroxy/protocol": "*",
-        "@chroxy/store-core": "*",
+        "@chroxy/protocol": ">=0.11.0",
+        "@chroxy/store-core": ">=0.11.0",
         "@kubernetes/client-node": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -18309,7 +18309,7 @@
       "name": "@chroxy/store-core",
       "version": "0.11.0",
       "dependencies": {
-        "@chroxy/protocol": "*",
+        "@chroxy/protocol": ">=0.11.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,8 +42,8 @@
     ]
   },
   "dependencies": {
-    "@chroxy/protocol": "*",
-    "@chroxy/store-core": "*",
+    "@chroxy/protocol": "^0.11.0",
+    "@chroxy/store-core": "^0.11.0",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.0.0",

--- a/packages/claude-hooks/package.json
+++ b/packages/claude-hooks/package.json
@@ -20,6 +20,6 @@
   "license": "MIT",
   "comment-dependencies": "Runtime dep on the workspace @chroxy/protocol via its Zod-free ./project subpath (audit P2-2). Resolves through workspace hoisting; chroxy is monorepo-installed only (README). If this package is ever published to npm standalone, @chroxy/protocol must be published too or its ./project module bundled in.",
   "dependencies": {
-    "@chroxy/protocol": "*"
+    "@chroxy/protocol": "^0.11.0"
   }
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,9 +11,9 @@
     "generate-tokens": "node scripts/generate-theme-tokens.mjs"
   },
   "dependencies": {
-    "@chroxy/design-tokens": "*",
-    "@chroxy/protocol": "*",
-    "@chroxy/store-core": "*",
+    "@chroxy/design-tokens": "^0.11.0",
+    "@chroxy/protocol": "^0.11.0",
+    "@chroxy/store-core": "^0.11.0",
     "dompurify": "^3.3.1",
     "mermaid": "^11.6.0",
     "react-resizable-panels": "^4.7.1",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@chroxy/protocol",
   "version": "0.11.0",
-  "private": true,
+  "files": [
+    "dist"
+  ],
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@chroxy/server",
   "version": "0.11.0",
+  "files": [
+    "src",
+    "hooks",
+    "sidecar",
+    "scripts/fix-node-pty-helper.js",
+    "CONFIG.md"
+  ],
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",
@@ -21,8 +28,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@anthropic-ai/sdk": "^0.81.0",
-    "@chroxy/protocol": ">=0.11.0",
-    "@chroxy/store-core": ">=0.11.0",
+    "@chroxy/protocol": "^0.11.0",
+    "@chroxy/store-core": "^0.11.0",
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xterm/addon-fit": "^0.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@anthropic-ai/sdk": "^0.81.0",
-    "@chroxy/protocol": "*",
-    "@chroxy/store-core": "*",
+    "@chroxy/protocol": ">=0.11.0",
+    "@chroxy/store-core": ">=0.11.0",
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xterm/addon-fit": "^0.10.0",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -17,7 +17,8 @@
     "build:crypto": "tsc src/crypto.ts --outDir dist --module ESNext --target ES2022 --declaration --moduleResolution node --esModuleInterop --skipLibCheck && node scripts/postbuild-crypto.mjs",
     "prepare": "npm run build:crypto",
     "pretest": "npm run build:crypto",
-    "test": "vitest run"
+    "test": "vitest run",
+    "build:publish": "node scripts/build-publish-dir.mjs"
   },
   "dependencies": {
     "@chroxy/protocol": ">=0.11.0",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@chroxy/store-core",
   "version": "0.11.0",
-  "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",
   "main": "src/index.ts",
@@ -21,7 +20,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@chroxy/protocol": "*",
+    "@chroxy/protocol": ">=0.11.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -21,7 +21,7 @@
     "build:publish": "node scripts/build-publish-dir.mjs"
   },
   "dependencies": {
-    "@chroxy/protocol": ">=0.11.0",
+    "@chroxy/protocol": "^0.11.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// build-publish-dir.mjs — assemble the publishable form of @chroxy/store-core.
+//
+// Why a staging directory instead of publishing the package in place.
+//
+// This package is consumed two different ways and they want different manifests:
+//
+//   - In the monorepo, `exports["."]` points at `src/index.ts`. 148 files across
+//     packages/app and packages/dashboard import the root that way, and their
+//     bundlers (Metro, Vite) resolve TypeScript directly. Keeping source
+//     resolution is what makes editing store-core show up in those apps without
+//     a rebuild.
+//   - On npm, `src/index.ts` is useless: Node refuses to strip types under
+//     node_modules ("Stripping types is currently unsupported for files under
+//     node_modules"), so a published root export pointing at .ts cannot load.
+//     The published manifest has to point at dist.
+//
+// The published 0.10.0 was built with exactly that transform, but the process
+// lived outside the repo, so when it was lost the packaging silently regressed:
+// `npm pack` fell back to .gitignore rules and shipped 59 raw *.test.ts files
+// with a root export no Node consumer could import.
+//
+// The obvious fix — a prepack script that rewrites package.json and a postpack
+// that restores it — leaves the working tree mutated if anything between them
+// fails. Assembling a separate directory has no such failure mode: the source
+// manifest is never touched, and the thing that gets published is exactly the
+// thing this script wrote.
+//
+// Usage:  npm run build:publish -w @chroxy/store-core
+//         npm publish packages/store-core/publish --access public
+
+import { execFileSync } from 'node:child_process'
+import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+
+// The source imports siblings without a file extension (`from './types'`), which
+// tsconfig's `moduleResolution: "bundler"` allows and Metro/Vite resolve happily.
+// tsc never rewrites specifiers, so that style survives into dist — where Node's
+// ESM loader rejects it (`ERR_UNSUPPORTED_DIR_IMPORT` / missing extension),
+// making the published root export unimportable.
+//
+// The published 0.10.0 emits `from './types.js'`, so this rewrite existed then
+// and was lost with the rest of the publish process. Without it the package
+// installs fine and fails on first import — which is how the regression stayed
+// invisible.
+function addExtensions(dir) {
+  const SPEC = /(\bfrom\s*|\bimport\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g
+  let rewritten = 0
+  const walk = (d) => {
+    for (const e of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, e.name)
+      if (e.isDirectory()) { walk(p); continue }
+      if (!/\.(js|d\.ts)$/.test(e.name)) continue
+      const src = readFileSync(p, 'utf8')
+      const out = src.replace(SPEC, (whole, kw, q, spec) => {
+        if (/\.(js|json|mjs|cjs)$/.test(spec)) return whole // already explicit
+        const base = resolve(dirname(p), spec)
+        let fixed
+        if (existsSync(`${base}.js`)) fixed = `${spec}.js`
+        else if (existsSync(join(base, 'index.js'))) fixed = `${spec}/index.js`
+        else return whole // leave bare specifiers and unresolvable paths alone
+        rewritten++
+        return `${kw}${q}${fixed}${q}`
+      })
+      if (out !== src) writeFileSync(p, out)
+    }
+  }
+  walk(dir)
+  return rewritten
+}
+
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..')
+const outDir = join(pkgDir, 'publish')
+const run = (cmd, args) => execFileSync(cmd, args, { cwd: pkgDir, stdio: 'inherit' })
+
+// 1. Build dist from source, excluding tests. `postbuild-crypto` MUST run after
+//    tsc: tsc re-emits dist/crypto.js with a named tweetnacl-util import that is
+//    undefined at runtime, and the postbuild rewrites it back to a default
+//    import. Skipping it is how dist/crypto.js "corrupts" — the file the server
+//    actually imports.
+run('npx', ['tsc', '-p', 'tsconfig.build.json'])
+run('node', ['scripts/postbuild-crypto.mjs'])
+
+const distIndex = join(pkgDir, 'dist', 'index.js')
+const distCrypto = join(pkgDir, 'dist', 'crypto.js')
+for (const f of [distIndex, distCrypto]) {
+  if (!existsSync(f)) throw new Error(`build did not produce ${f}`)
+}
+if (!readFileSync(distCrypto, 'utf8').includes("import naclUtil from 'tweetnacl-util'")) {
+  throw new Error('dist/crypto.js is missing the postbuild rewrite — it would fail at runtime')
+}
+
+// 2. Assemble the staging dir: dist + README + a dist-pointing manifest.
+rmSync(outDir, { recursive: true, force: true })
+mkdirSync(outDir, { recursive: true })
+cpSync(join(pkgDir, 'dist'), join(outDir, 'dist'), { recursive: true })
+
+// Rewrite specifiers in the STAGED copy, never in packages/store-core/dist —
+// that tree holds the committed dist/crypto.js the monorepo builds against.
+const rewrites = addExtensions(join(outDir, 'dist'))
+console.log(`rewrote ${rewrites} extensionless relative specifier(s) for Node ESM`)
+for (const f of ['README.md', 'LICENSE']) {
+  if (existsSync(join(pkgDir, f))) cpSync(join(pkgDir, f), join(outDir, f))
+}
+
+const src = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
+const out = {
+  name: src.name,
+  version: src.version,
+  description: src.description,
+  license: src.license,
+  type: src.type,
+  main: './dist/index.js',
+  types: './dist/index.d.ts',
+  exports: {
+    '.': { types: './dist/index.d.ts', import: './dist/index.js' },
+    './crypto': { types: './dist/crypto.d.ts', import: './dist/crypto.js' },
+  },
+  dependencies: src.dependencies,
+  peerDependencies: src.peerDependencies,
+  engines: src.engines,
+  repository: src.repository,
+}
+for (const k of Object.keys(out)) if (out[k] === undefined) delete out[k]
+
+// The staging dir IS the package, so no `files` allowlist is needed — and none
+// is wanted: a stray `files` here would be one more thing to keep in sync.
+writeFileSync(join(outDir, 'package.json'), JSON.stringify(out, null, 2) + '\n')
+
+// 3. Prove both declared entry points actually load under Node before anyone
+//    publishes. This is the check whose absence let 0.11.0's packaging break
+//    silently: the tarball installed fine and only failed on first import.
+//    Resolved against the real dist so a missing extension or a bad crypto
+//    rewrite fails the build, not the user.
+for (const [label, entry] of [['.', 'dist/index.js'], ['./crypto', 'dist/crypto.js']]) {
+  try {
+    await import(new URL(`publish/${entry}`, `file://${pkgDir}/`).href)
+    console.log(`  ✓ "${label}" entry imports under Node`)
+  } catch (err) {
+    throw new Error(`published "${label}" entry (${entry}) fails to import: ${err.message}`)
+  }
+}
+
+console.log(`built ${out.name}@${out.version} -> ${outDir}`)
+console.log(`publish with: npm publish ${outDir} --access public`)

--- a/packages/store-core/tsconfig.build.json
+++ b/packages/store-core/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/__tests__/**", "src/**/__tests__/**", "src/test-utils/**"]
+}

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -651,6 +651,40 @@ test_lockfile_uses_cargo_when_on_path() {
   ' "$lock" | grep -qx "0.2.0"
 }
 
+
+# --- workspace @chroxy/* dependency ranges (#7187) ---------------------------
+
+# The ranges are bounded (^X.Y.Z) so a PUBLISHED package can never acquire a
+# breaking sibling. That bound is only safe if the bump moves it: a package
+# left at the previous minor stops matching its sibling in the workspace, and
+# npm silently resolves it from the registry instead of linking locally.
+test_bumps_workspace_chroxy_dep_ranges() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+
+  # server depends on two siblings at the CURRENT version, plus a third-party
+  # dep that must be left alone (the negative control).
+  printf '{"name":"server","version":"0.5.7","dependencies":{"@chroxy/protocol":"^0.5.7","commander":"^12.1.0"},"devDependencies":{"@chroxy/store-core":"^0.5.7"}}\n' \
+    > "$dir/packages/server/package.json"
+
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) > /dev/null 2>&1 || return 1
+
+  # Both @chroxy/* ranges moved to the new version, in BOTH dependency fields.
+  grep -q '"@chroxy/protocol": "\^0.6.0"' "$dir/packages/server/package.json" || return 1
+  grep -q '"@chroxy/store-core": "\^0.6.0"' "$dir/packages/server/package.json" || return 1
+  # Negative control: a third-party range is untouched. Without this, a rewrite
+  # that clobbered every dependency would pass the assertions above.
+  grep -q '"commander": "\^12.1.0"' "$dir/packages/server/package.json" || return 1
+  # And the stale range is gone entirely.
+  ! grep -q '0.5.7' "$dir/packages/server/package.json" || return 1
+}
+
 # --- runner ------------------------------------------------------------------
 
 echo "Running bump-version.sh tests"
@@ -683,6 +717,8 @@ run_test "Cargo.lock verify aborts when chroxy-desktop stanza is missing" \
   test_lockfile_verify_fails_when_stanza_missing
 run_test "Cargo.lock sync uses cargo when on PATH (no awk fallthrough)" \
   test_lockfile_uses_cargo_when_on_path
+run_test "bumps workspace @chroxy/* dependency ranges with the version" \
+  test_bumps_workspace_chroxy_dep_ranges
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -188,6 +188,39 @@ node -e "
   fs.writeFileSync('$DESIGN_TOKENS_PKG', JSON.stringify(pkg, null, 2) + '\n');
 "
 
+# Re-point every workspace-internal @chroxy/* dependency range at the new
+# version. These MUST move with the version: the ranges are bounded (^X.Y.Z),
+# so a package left pointing at the previous minor no longer matches its
+# sibling in the workspace, and npm silently resolves it from the REGISTRY
+# instead of linking locally — a stale published copy shadowing the source
+# tree, which is exactly the mismatch #7187 shipped to npm.
+#
+# The bound is deliberate. An open "*" (what these were) resolves to whatever
+# is newest on npm, so a published server can acquire a breaking sibling long
+# after release. A bound without this rewrite would break local linking on
+# the next bump. Both halves are required; neither works alone.
+node -e "
+  const fs = require('fs');
+  const files = [$(printf "'%s'," "$ROOT_PKG" "$SERVER_PKG" "$APP_PKG" "$DESKTOP_PKG" "$PROTOCOL_PKG" "$STORE_CORE_PKG" "$DASHBOARD_PKG" "$CLAUDE_HOOKS_PKG" "$DESIGN_TOKENS_PKG")];
+  const range = '^$NEW_VERSION';
+  let n = 0;
+  for (const f of files) {
+    if (!fs.existsSync(f)) continue;
+    const pkg = JSON.parse(fs.readFileSync(f, 'utf-8'));
+    let changed = false;
+    for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      for (const dep of Object.keys(pkg[field] || {})) {
+        if (!dep.startsWith('@chroxy/')) continue;
+        if (pkg[field][dep] === range) continue;
+        pkg[field][dep] = range;
+        changed = true; n++;
+      }
+    }
+    if (changed) fs.writeFileSync(f, JSON.stringify(pkg, null, 2) + '\n');
+  }
+  console.log('  workspace @chroxy/* dependency ranges -> ' + range + ' (' + n + ' updated)');
+"
+
 # Update tauri.conf.json
 node -e "
   const fs = require('fs');


### PR DESCRIPTION
## Description

Closes #7187.

Publishing `@chroxy/server@0.11.0` on its own ships a package that **crashes on launch**. Caught by packing the real tarball and installing it the way a user would, before anything reached npm.

```
$ npm install -g ./chroxy-server-0.11.0.tgz && chroxy --version
SyntaxError: The requested module '@chroxy/protocol' does not provide an
             export named 'CODEX_DEFAULT_SANDBOX'
```

`@chroxy/server` declares its siblings as `"*"`, which resolves to the **latest published** version. Both siblings are frozen on npm at `0.10.0` (2026-07-06), so current server code was pairing with a 463-commit-stale protocol and failing at ESM link time — every subcommand, no partial degradation.

The currently-published `0.10.0` works precisely because all three were published together and therefore match. So this is a regression risk, not just staleness: publishing the server alone would move npm from *stale but functional* to *current but broken*, irreversibly.

## Changes

**1. Drop `"private": true` from `@chroxy/protocol` and `@chroxy/store-core`** — restores the publish-together invariant that made `0.10.0` work. (They have carried the flag since March yet were published in July, so that publish overrode it by a process not captured in the repo.)

**2. `"*"` → `">=0.11.0"`** on the published packages' `@chroxy/*` deps, so a stale sibling can never be resolved again.

Deliberately **not** an exact pin. `scripts/bump-version.sh` does not rewrite dependency ranges — verified — so `"0.11.0"` would stop satisfying the workspace on the next bump and npm would silently fetch from the registry instead of linking locally. `>=` keeps local linking working at every future version:

```
$ npm install
$ ls -l node_modules/@chroxy/
  @chroxy/protocol   -> SYMLINK ../../packages/protocol    ✓ local
  @chroxy/store-core -> SYMLINK ../../packages/store-core  ✓ local
```

**3. `files: ["dist"]` on `@chroxy/protocol`** — the real second bug. The root `.gitignore` ignores `dist/`, and npm falls back to gitignore rules when a package has no `.npmignore` and no `files` field. All **31** built `dist/*.js` were being dropped from the tarball despite git tracking them:

```
before:  dist/*.js in tarball: 0   (on disk: 6+)
after:   dist/*.js in tarball: 31  (incl. dist/index.js, dist/project.js)
```

The published `0.10.0` *does* contain them, so this regressed sometime after July. Without it the fix above only gets you a different crash — `ERR_MODULE_NOT_FOUND: @chroxy/protocol/dist/project.js`, imported by `worktree-gc.js`.

## Verification — packed and installed into a clean global prefix

```
$ npm pack -w @chroxy/protocol -w @chroxy/store-core -w @chroxy/server
$ npm install -g ./chroxy-protocol-0.11.0.tgz ./chroxy-store-core-0.11.0.tgz ./chroxy-server-0.11.0.tgz
added 199 packages

$ chroxy --version
0.11.0

$ chroxy doctor
  [ OK ] Node.js            v22.22.3
  [ OK ] cloudflared        cloudflared version 2026.5.2
  [ OK ] Billing            Default provider 'claude-tui' — Included (subscription)
  [ OK ] claude-tui driving claude 2.1.233 matches the tested TUI-driving baseline
  [ OK ] Dependencies       resolved via .../node_modules/commander/index.js
All checks passed. Ready to start.
```

Resolved siblings confirmed at `0.11.0`, not `0.10.0`.

Monorepo unaffected: protocol **388 pass**, store-core **2131 pass / 59 files**, and `packages/store-core/dist/crypto.js` is byte-identical after the `prepare` script runs during pack.

## Publish order after merge

`@chroxy/protocol` → `@chroxy/store-core` → `@chroxy/server`. The siblings must exist at `0.11.0` before the server is published, or `>=0.11.0` has nothing to resolve.

## Follow-up left open

This PR makes the publish correct; it does not add a gate that keeps it correct. #7187's remaining criterion — pack the tarball, install into a clean prefix, run `doctor` **in CI before publishing** — is still worth doing, since both bugs here were invisible to every existing check and only showed up on a real install.