### PR TITLE
chore(ci): migrate renovate.json off the deprecated manager syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "automerge": false,
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "description": "Track @anthropic-ai/claude-code version pinned in the sidecar Dockerfile ARG",
-      "fileMatch": ["^packages/server/sidecar/Dockerfile$"],
+      "managerFilePatterns": ["/^packages/server/sidecar/Dockerfile$/"],
       "matchStrings": [
         "ARG CLAUDE_CODE_VERSION=(?<currentValue>[^\\s]+)"
       ],


### PR DESCRIPTION
## Description

Part of #7178.

`renovate.json` has never run — the GitHub App was never installed — so it has been sitting on syntax that Renovate now auto-migrates. The official validator on the current file:

```
$ npx --package renovate -- renovate-config-validator renovate.json
 WARN: Config migration necessary
```

Two renames:

| old | new |
|---|---|
| `regexManagers` | `customManagers` (+ `"customType": "regex"`) |
| `fileMatch` | `managerFilePatterns` (delimited regex) |

Renovate would still honour the old spelling, but the **first** thing it does on install is open a Config Migration PR. Landing this now means it starts on dependency work instead of housekeeping.

## Verification

Validator is clean after the change:

```
$ npx --package renovate -- renovate-config-validator renovate.json
 INFO: Config validated successfully
```

The custom manager still does its job — both halves checked against the real file rather than assumed:

```
packages/server/sidecar/Dockerfile:10:ARG CLAUDE_CODE_VERSION=2.1.128

✓ matchString captures currentValue = 2.1.128
✓ managerFilePatterns regex matches packages/server/sidecar/Dockerfile
```

## What this does not do

This does not install the app, which is the actual blocker in #7178 and needs repo-owner authorisation. It only ensures that when the app is installed, the config runs clean.