### PR TITLE
ci(release): gate the npm publish on the artifacts actually running

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,37 @@ jobs:
         run: npm test
         working-directory: packages/app
 
+  # #7189 — the artifact gate. Every other job here tests the SOURCE TREE; this
+  # one packs the tarballs npm would actually receive, installs them into a
+  # throwaway prefix, and runs them. Three defects reached the edge of an
+  # irreversible publish in one day (#7187) while unit tests, lint, typecheck
+  # and CI were all green, because each one only broke the packed artifact:
+  # "*" sibling ranges resolving a stale published protocol, @chroxy/protocol
+  # shipping zero dist/*.js (no `files` field -> npm fell back to .gitignore,
+  # which ignores dist/), and @chroxy/store-core shipping raw *.test.ts with a
+  # root export Node cannot load. All three installed fine and failed on first
+  # import. npm forbids republishing a version, so this runs on the tag, before
+  # any publish, rather than after.
+  verify-artifacts:
+    name: Verify Publish Artifacts
+    needs: test
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pack, install into a clean prefix, and run
+        run: node scripts/verify-publish-artifacts.mjs
+
   docker:
     name: Docker Image
     needs: test
@@ -405,7 +436,11 @@ jobs:
 
   github-release:
     name: GitHub Release
-    needs: [validate, docker, desktop-macos, desktop-windows]
+    # verify-artifacts gates this deliberately: the npm publish is a manual step
+    # that happens AFTER this release exists, so if the packed tarballs are
+    # broken the release should not be declared good and then quietly followed
+    # by an irreversible bad publish (#7189).
+    needs: [validate, docker, desktop-macos, desktop-windows, verify-artifacts]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
     permissions:

--- a/docs/release/npm-publish.md
+++ b/docs/release/npm-publish.md
@@ -1,0 +1,117 @@
+# Publishing Chroxy to npm
+
+Three packages go to npm, and they must be published **together, in dependency
+order**. This document is the procedure; `scripts/publish-siblings.sh` is the
+executable form of it.
+
+| package | published from | why |
+|---|---|---|
+| `@chroxy/protocol` | the package dir | shared schemas + wire types |
+| `@chroxy/store-core` | `packages/store-core/publish/` (staging dir) | its in-repo manifest points `.` at `src/index.ts` for the ~148 app/dashboard files that import it as TypeScript; that is not publishable |
+| `@chroxy/server` | the package dir | the daemon + the `chroxy` bin |
+
+`@chroxy/app`, `@chroxy/dashboard`, `@chroxy/desktop`, and `@chroxy/design-tokens`
+are **not** published.
+
+## The rule that matters
+
+`@chroxy/server` depends on its siblings with a bounded range (`^X.Y.Z`), and
+`@chroxy/store-core` depends on `@chroxy/protocol` the same way. A range only
+resolves against what is **already on the registry**, so:
+
+> Publish `protocol` → `store-core` → `server`, and confirm each one is live
+> before publishing the next.
+
+Get this wrong and the failure is loud (`ETARGET`, no matching version) rather
+than silent — that is deliberate, and it is why the ranges are bounded. Under
+the old `"*"` ranges the same mistake resolved a *stale* sibling instead and
+shipped a package that installed cleanly and crashed on first import (#7187).
+
+## Procedure
+
+### 0. Preconditions
+
+- On `main`, clean tree, at the release commit (the `chore(release): cut vX.Y.Z` merge).
+- The `vX.Y.Z` tag exists and `release.yml` is green.
+- Authenticated: `npm whoami` returns your username. If not, `npm login`
+  (browser flow; works with 2FA). npm now restricts 2FA-bypassing tokens, so
+  prefer `npm login` over a long-lived automation token.
+
+### 1. Verify the artifacts — always, before publishing anything
+
+```bash
+node scripts/verify-publish-artifacts.mjs
+```
+
+This packs all three tarballs, installs them into a throwaway prefix with a
+clean `HOME`, and asserts:
+
+- no test files ride along in any tarball (the `files` allowlist has not drifted)
+- `chroxy --version` reports the expected version
+- `chroxy doctor` comes up clean
+- every declared entry point imports from a from-scratch consumer project —
+  `@chroxy/protocol`, `@chroxy/protocol/project`, `@chroxy/store-core`,
+  `@chroxy/store-core/crypto`
+
+Non-zero exit means **do not publish**. npm does not allow republishing a
+version, and unpublishing is barred after 72 hours, so a bad publish is
+permanent.
+
+### 2. Publish
+
+```bash
+bash scripts/publish-siblings.sh
+```
+
+It runs step 1 for you, then publishes in order, waiting for each package to
+appear on the registry before starting the next. Pass `--dry-run` to rehearse.
+
+Doing it by hand is the same three commands:
+
+```bash
+npm publish -w @chroxy/protocol --access public
+npm run build:publish -w @chroxy/store-core && npm publish packages/store-core/publish --access public
+npm publish -w @chroxy/server --access public
+```
+
+Expect an OTP prompt per publish if 2FA is on for writes.
+
+### 3. Confirm
+
+```bash
+npm install -g @chroxy/server --prefer-online && chroxy doctor
+```
+
+`--prefer-online` is not optional here. npm caches registry metadata, so a
+plain `npm install -g @chroxy/server` right after publishing will often install
+the **previous** version and look like the publish failed. Check the version it
+actually resolved before concluding anything.
+
+## Why the verification step exists
+
+Three defects reached the edge of an irreversible publish in a single day, and
+**every one of them was invisible to unit tests, lint, typecheck, and CI**,
+because those test the source tree and none of them test the artifact:
+
+1. `"*"` sibling ranges resolved the two-month-old published protocol against a
+   current server — `SyntaxError: does not provide an export named
+   'CODEX_DEFAULT_SANDBOX'` at ESM link time (#7187).
+2. `@chroxy/protocol` shipped **zero** `dist/*.js`. It had no `files` field and
+   no `.npmignore`, so npm fell back to `.gitignore` — which ignores `dist/` —
+   and dropped 31 built files that git tracks.
+3. `@chroxy/store-core` shipped 59 raw `*.test.ts` files and a root export
+   pointing at `src/index.ts`, which Node refuses to load from `node_modules`
+   ("Stripping types is currently unsupported"). It had also lost the
+   extension-rewrite step its emitted specifiers need, so `dist` was
+   unloadable even once it shipped.
+
+All three installed fine and failed on first import. The only check that finds
+this class is packing the tarball and running it, so that check is now a script
+rather than something remembered.
+
+## Related
+
+- `packages/store-core/scripts/build-publish-dir.mjs` — assembles store-core's
+  publishable form, and self-checks both entry points before finishing.
+- #7187 — the incident.
+- #7189 — this runbook and the verification gate.

--- a/docs/release/npm-publish.md
+++ b/docs/release/npm-publish.md
@@ -49,9 +49,11 @@ clean `HOME`, and asserts:
 - no test files ride along in any tarball (the `files` allowlist has not drifted)
 - `chroxy --version` reports the expected version
 - `chroxy doctor` comes up clean
-- every declared entry point imports from a from-scratch consumer project —
-  `@chroxy/protocol`, `@chroxy/protocol/project`, `@chroxy/store-core`,
-  `@chroxy/store-core/crypto`
+- every declared entry point imports from a from-scratch consumer project.
+  The list is **derived from the published manifests' `exports` maps**, not
+  hardcoded, so adding an export cannot silently fall outside the gate.
+  Currently that resolves to `@chroxy/protocol`, `/schemas`, `/project`,
+  `/handler-coverage`, `@chroxy/store-core`, and `/crypto`.
 
 Non-zero exit means **do not publish**. npm does not allow republishing a
 version, and unpublishing is barred after 72 hours, so a bad publish is

--- a/scripts/publish-siblings.sh
+++ b/scripts/publish-siblings.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# publish-siblings.sh — publish @chroxy/protocol, @chroxy/store-core and
+# @chroxy/server to npm, in dependency order, gated on the artifacts actually
+# working. See docs/release/npm-publish.md.
+#
+# Order is load-bearing. The server depends on its siblings with a bounded
+# range (^X.Y.Z), and a range only resolves against what is ALREADY on the
+# registry — so each package has to be live before the next one goes up. This
+# script waits for that rather than assuming it, because npm's registry is
+# read-through-cached and "just published" is not the same as "resolvable".
+#
+# npm does not allow republishing a version, and unpublish is barred after 72
+# hours, so every check here runs BEFORE anything is sent.
+#
+# Usage:
+#   bash scripts/publish-siblings.sh              # verify, then publish
+#   bash scripts/publish-siblings.sh --dry-run    # verify + rehearse, publish nothing
+#   bash scripts/publish-siblings.sh --skip-verify  # ONLY if verify was just run by hand
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DRY_RUN=0
+SKIP_VERIFY=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --skip-verify) SKIP_VERIFY=1 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Error: unknown flag '$arg'" >&2; exit 1 ;;
+  esac
+done
+
+VERSION=$(node -p "require('./packages/server/package.json').version")
+echo "publish-siblings — version $VERSION"
+[ "$DRY_RUN" = "1" ] && echo "(--dry-run: nothing will be published)"
+
+# --- preconditions -----------------------------------------------------------
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working tree is dirty. Publish from a clean checkout of the release commit." >&2
+  exit 1
+fi
+
+if ! npm whoami >/dev/null 2>&1; then
+  echo "Error: not authenticated to npm. Run 'npm login' first (browser flow, works with 2FA)." >&2
+  exit 1
+fi
+echo "  npm user: $(npm whoami)"
+
+# Refuse to re-publish a version that is already live, rather than letting npm
+# reject it halfway through the sequence and leave the set half-published.
+for pkg in @chroxy/protocol @chroxy/store-core @chroxy/server; do
+  if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
+    echo "Error: $pkg@$VERSION is already published. Bump the version first (scripts/bump-version.sh)." >&2
+    exit 1
+  fi
+done
+echo "  none of the three are published at $VERSION yet"
+
+# --- the gate ----------------------------------------------------------------
+
+if [ "$SKIP_VERIFY" = "1" ]; then
+  echo
+  echo "WARNING: skipping artifact verification (--skip-verify)."
+  echo "         Only safe if you just ran scripts/verify-publish-artifacts.mjs by hand."
+else
+  echo
+  echo "verifying artifacts before publishing..."
+  node scripts/verify-publish-artifacts.mjs
+fi
+
+# --- publish -----------------------------------------------------------------
+
+# Wait for a package to become resolvable. `npm publish` returning 0 does not
+# mean the next `npm view` will see it — the registry is read-through-cached.
+wait_for_registry() {
+  local pkg="$1" want="$2" tries=30
+  echo -n "  waiting for $pkg@$want to be resolvable"
+  while [ "$tries" -gt 0 ]; do
+    if [ "$(npm view "$pkg@$want" version 2>/dev/null || true)" = "$want" ]; then
+      echo " — live"
+      return 0
+    fi
+    echo -n "."
+    sleep 4
+    tries=$((tries - 1))
+  done
+  echo
+  echo "Error: $pkg@$want did not become resolvable within ~2 minutes." >&2
+  echo "       Do NOT publish the next package until it is — the bounded range will not resolve." >&2
+  exit 1
+}
+
+publish() {
+  local label="$1"; shift
+  echo
+  echo "publishing $label"
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  (dry-run) would run: npm publish $*"
+  else
+    npm publish "$@" --access public
+  fi
+}
+
+publish "@chroxy/protocol" -w @chroxy/protocol
+[ "$DRY_RUN" = "1" ] || wait_for_registry "@chroxy/protocol" "$VERSION"
+
+echo
+echo "building @chroxy/store-core's publishable form"
+npm run build:publish -w @chroxy/store-core
+publish "@chroxy/store-core" packages/store-core/publish
+[ "$DRY_RUN" = "1" ] || wait_for_registry "@chroxy/store-core" "$VERSION"
+
+publish "@chroxy/server" -w @chroxy/server
+[ "$DRY_RUN" = "1" ] || wait_for_registry "@chroxy/server" "$VERSION"
+
+echo
+if [ "$DRY_RUN" = "1" ]; then
+  echo "dry run complete — nothing was published."
+else
+  echo "published all three at $VERSION."
+  echo
+  echo "confirm with (--prefer-online matters: npm caches registry metadata and"
+  echo "will otherwise hand you the PREVIOUS version and look like a failed publish):"
+  echo
+  echo "  npm install -g @chroxy/server --prefer-online && chroxy doctor"
+fi

--- a/scripts/verify-publish-artifacts.mjs
+++ b/scripts/verify-publish-artifacts.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// verify-publish-artifacts.mjs — pack the npm-published packages, install them
+// into a throwaway prefix, and prove they actually run before anyone publishes.
+//
+// Why this exists (#7189, after #7187).
+//
+// Three separate defects shipped or nearly shipped through every existing
+// check, because every existing check tests the SOURCE TREE and none of them
+// test the ARTIFACT:
+//
+//   1. @chroxy/server declared its siblings "*", which resolves to the latest
+//      PUBLISHED version — so a current server paired with a two-month-old
+//      protocol and died at ESM link time on a missing export.
+//   2. @chroxy/protocol shipped no dist/*.js at all: it has no `files` field
+//      and no .npmignore, so npm fell back to .gitignore, which ignores dist/.
+//      31 built files were silently dropped from the tarball.
+//   3. @chroxy/store-core shipped 59 raw *.test.ts files and a root export
+//      pointing at src/index.ts, which Node refuses to load from node_modules.
+//
+// Every one of them installed fine and failed on first import. Unit tests,
+// lint, typecheck, and CI were all green throughout. The only thing that
+// catches this class is packing the tarball and running it, which is what this
+// script does.
+//
+// npm publishes are irreversible (no republish of a version, no unpublish
+// after 72h), so this runs BEFORE the publish, not after.
+//
+// Usage:
+//   node scripts/verify-publish-artifacts.mjs           # pack from the working tree
+//   node scripts/verify-publish-artifacts.mjs --keep    # leave the temp dir for inspection
+//
+// Exit code 0 = the artifacts are safe to publish. Non-zero = do not publish.
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const KEEP = process.argv.includes('--keep')
+
+// The three packages that go to npm, in dependency order. store-core publishes
+// from a staging dir (see packages/store-core/scripts/build-publish-dir.mjs):
+// its in-repo manifest points `.` at src/index.ts for the ~148 app/dashboard
+// files that import it as TypeScript, which is not publishable as-is.
+const PACKAGES = [
+  { name: '@chroxy/protocol', packFrom: null },
+  { name: '@chroxy/store-core', packFrom: 'packages/store-core/publish', build: 'build:publish' },
+  { name: '@chroxy/server', packFrom: null },
+]
+
+// Every entry point the published manifests promise. A missing one is the
+// exact shape of failure this script exists to catch, so they are asserted
+// individually rather than inferred from "the CLI started".
+const ENTRY_POINTS = [
+  '@chroxy/protocol',
+  '@chroxy/protocol/project',
+  '@chroxy/store-core',
+  '@chroxy/store-core/crypto',
+]
+
+const log = (m) => console.log(m)
+const run = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { encoding: 'utf8', ...opts })
+
+let failures = 0
+const fail = (msg) => { failures++; console.error(`  FAIL  ${msg}`) }
+const pass = (msg) => log(`  ok    ${msg}`)
+
+const work = mkdtempSync(join(tmpdir(), 'chroxy-publish-verify-'))
+const prefix = join(work, 'prefix')
+const home = join(work, 'home')
+const consumer = join(work, 'consumer')
+for (const d of [prefix, home, consumer]) run('mkdir', ['-p', d])
+
+// A clean HOME matters: `chroxy doctor` reads ~/.chroxy, and a developer's real
+// config can mask a packaging problem by supplying something the tarball failed
+// to ship.
+const env = { ...process.env, npm_config_prefix: prefix, HOME: home }
+
+try {
+  log(`\nverify-publish-artifacts — staging in ${work}\n`)
+
+  log('1. building publishable trees')
+  run('npm', ['run', 'build', '-w', '@chroxy/protocol'], { cwd: ROOT, stdio: 'inherit' })
+  for (const p of PACKAGES.filter((p) => p.build)) {
+    run('npm', ['run', p.build, '-w', p.name], { cwd: ROOT, stdio: 'inherit' })
+  }
+
+  log('\n2. packing tarballs')
+  const tarballs = []
+  for (const p of PACKAGES) {
+    const cwd = p.packFrom ? join(ROOT, p.packFrom) : ROOT
+    const args = p.packFrom ? ['pack', '--pack-destination', work] : ['pack', '-w', p.name, '--pack-destination', work]
+    const out = run('npm', args, { cwd }).trim().split('\n').pop().trim()
+    const tgz = join(work, out)
+    if (!existsSync(tgz)) throw new Error(`npm pack did not produce ${tgz} for ${p.name}`)
+    tarballs.push(tgz)
+    log(`  packed ${p.name} -> ${out}`)
+  }
+
+  // A tarball that ships the test suite is not a break, but it is a signal the
+  // `files` allowlist has drifted — which is how defect (2) above started.
+  log('\n3. tarball hygiene')
+  for (const tgz of tarballs) {
+    const listing = run('tar', ['tzf', tgz]).split('\n')
+    const tests = listing.filter((f) => /\.(test|spec)\.[cm]?[jt]sx?$/.test(f))
+    const name = tgz.split('/').pop()
+    if (tests.length) fail(`${name} ships ${tests.length} test file(s) — check the "files" allowlist`)
+    else pass(`${name} ships no test files (${listing.filter(Boolean).length} files)`)
+  }
+
+  log('\n4. installing into a clean prefix')
+  run('npm', ['install', '-g', ...tarballs], { cwd: work, env, stdio: 'inherit' })
+
+  log('\n5. the CLI runs')
+  const bin = join(prefix, 'bin', 'chroxy')
+  if (!existsSync(bin)) {
+    fail('chroxy binary was not linked into the prefix')
+  } else {
+    try {
+      const v = run(bin, ['--version'], { env }).trim()
+      const expected = JSON.parse(run('node', ['-p', "JSON.stringify(require('./packages/server/package.json'))"], { cwd: ROOT })).version
+      if (v === expected) pass(`chroxy --version reports ${v}`)
+      else fail(`chroxy --version reported "${v}", expected "${expected}"`)
+    } catch (err) {
+      fail(`chroxy --version did not run: ${String(err.stderr || err.message).split('\n')[0]}`)
+    }
+    try {
+      const doc = run(bin, ['doctor'], { env })
+      if (/All checks passed/.test(doc)) pass('chroxy doctor came up clean')
+      else fail(`chroxy doctor did not report success:\n${doc.split('\n').slice(-6).join('\n')}`)
+    } catch (err) {
+      fail(`chroxy doctor did not run: ${String(err.stderr || err.message).split('\n')[0]}`)
+    }
+  }
+
+  // The CLI starting does NOT prove the library entry points resolve — the
+  // server only imports a subset. Defect (3) left @chroxy/store-core's root
+  // export unloadable while `chroxy doctor` passed, so each one is imported
+  // from a from-scratch consumer project.
+  log('\n6. every declared entry point imports')
+  writeFileSync(join(consumer, 'package.json'), JSON.stringify({ name: 'verify-consumer', version: '1.0.0', private: true, type: 'module' }, null, 2))
+  const libs = tarballs.filter((t) => !t.includes('chroxy-server-'))
+  run('npm', ['install', ...libs], { cwd: consumer, env, stdio: 'ignore' })
+  for (const spec of ENTRY_POINTS) {
+    try {
+      const n = run('node', ['--input-type=module', '-e',
+        `import(${JSON.stringify(spec)}).then(m => console.log(Object.keys(m).length))`,
+      ], { cwd: consumer, env }).trim()
+      if (Number(n) > 0) pass(`import("${spec}") → ${n} exports`)
+      else fail(`import("${spec}") resolved but exported nothing`)
+    } catch (err) {
+      fail(`import("${spec}") threw: ${String(err.stderr || err.message).split('\n').find((l) => /Error|error:/.test(l)) || 'unknown'}`)
+    }
+  }
+
+  log('')
+  if (failures) {
+    console.error(`verify-publish-artifacts: ${failures} check(s) FAILED — do not publish\n`)
+    process.exitCode = 1
+  } else {
+    log('verify-publish-artifacts: all checks passed — artifacts are safe to publish\n')
+  }
+} finally {
+  if (KEEP) log(`(--keep) staging left at ${work}`)
+  else rmSync(work, { recursive: true, force: true })
+}

--- a/scripts/verify-publish-artifacts.mjs
+++ b/scripts/verify-publish-artifacts.mjs
@@ -32,7 +32,7 @@
 // Exit code 0 = the artifacts are safe to publish. Non-zero = do not publish.
 
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -50,15 +50,26 @@ const PACKAGES = [
   { name: '@chroxy/server', packFrom: null },
 ]
 
-// Every entry point the published manifests promise. A missing one is the
-// exact shape of failure this script exists to catch, so they are asserted
-// individually rather than inferred from "the CLI started".
-const ENTRY_POINTS = [
-  '@chroxy/protocol',
-  '@chroxy/protocol/project',
-  '@chroxy/store-core',
-  '@chroxy/store-core/crypto',
-]
+// Every entry point the published manifests promise, DERIVED from the manifests
+// rather than listed here. A hardcoded list is the same defect class this script
+// exists to catch: it silently stops covering an export the moment someone adds
+// one, so the gate keeps reporting full coverage it no longer has. (The first
+// draft of this file hardcoded four and missed @chroxy/protocol/schemas and
+// /handler-coverage — caught in review, hence this.)
+//
+// `packFrom` matters here: store-core's PUBLISHED manifest lives in its staging
+// dir and differs from the in-repo one, so the exports are read from whichever
+// manifest actually ships.
+function entryPointsFor(pkg) {
+  const manifestDir = pkg.packFrom ? join(ROOT, pkg.packFrom) : join(ROOT, 'packages', pkg.name.split('/')[1])
+  const manifest = JSON.parse(readFileSync(join(manifestDir, 'package.json'), 'utf8'))
+  const exportsField = manifest.exports
+  // No exports map means the single `main` entry, addressed by bare name.
+  if (!exportsField || typeof exportsField === 'string') return [pkg.name]
+  return Object.keys(exportsField)
+    .filter((k) => k.startsWith('.'))
+    .map((k) => (k === '.' ? pkg.name : `${pkg.name}/${k.replace(/^\.\//, '')}`))
+}
 
 const log = (m) => console.log(m)
 const run = (cmd, args, opts = {}) =>
@@ -144,7 +155,11 @@ try {
   writeFileSync(join(consumer, 'package.json'), JSON.stringify({ name: 'verify-consumer', version: '1.0.0', private: true, type: 'module' }, null, 2))
   const libs = tarballs.filter((t) => !t.includes('chroxy-server-'))
   run('npm', ['install', ...libs], { cwd: consumer, env, stdio: 'ignore' })
-  for (const spec of ENTRY_POINTS) {
+  const entryPoints = PACKAGES
+    .filter((p) => p.name !== '@chroxy/server') // a bin, not a library — covered by step 5
+    .flatMap(entryPointsFor)
+  log(`  (derived from the published manifests: ${entryPoints.join(', ')})`)
+  for (const spec of entryPoints) {
     try {
       const n = run('node', ['--input-type=module', '-e',
         `import(${JSON.stringify(spec)}).then(m => console.log(Object.keys(m).length))`,


### PR DESCRIPTION
## Description

Closes #7189.

#7188 fixed the two symptoms behind #7187. This adds the check that would have caught them — and would catch the next one.

Every check this repo had tests the **source tree**. None tested the **artifact**. Three defects reached the edge of an irreversible publish in a single day while unit tests, lint, typecheck and CI were all green, because each one only broke the packed tarball:

| defect | why nothing caught it |
|---|---|
| `"*"` sibling ranges resolved the 2-month-old published protocol against a current server | source tree resolves siblings via workspace symlinks, so it never sees the registry version |
| `@chroxy/protocol` shipped **zero** `dist/*.js` | no `files` field + no `.npmignore` → npm falls back to `.gitignore`, which ignores `dist/`. The files exist on disk and in git |
| `@chroxy/store-core` shipped 59 raw `*.test.ts` and a root export pointing at `src/index.ts` | Node refuses to strip types under `node_modules`; in-repo bundlers resolve it fine |

All three **installed cleanly and failed on first import**. npm forbids republishing a version and bars unpublish after 72h, so the check has to run before the publish, not after.

## What lands

**`scripts/verify-publish-artifacts.mjs`** — packs all three packages, installs them into a throwaway prefix with a clean `HOME`, and asserts:

- no test files ride along in any tarball (the `files` allowlist has not drifted)
- `chroxy --version` matches the repo version
- `chroxy doctor` comes up clean
- **all four declared entry points import from a from-scratch consumer project**

That last one is not redundant with the CLI starting. `@chroxy/server` imports only a subset of `store-core`, which is exactly how store-core's root export stayed broken while `chroxy doctor` reported success.

**`scripts/publish-siblings.sh`** — runs the gate, then publishes `protocol → store-core → server`, waiting for each to become *resolvable* before the next. A bounded range only resolves against what is already on the registry, and `npm publish` returning 0 is not the same as `npm view` seeing it. Refuses on a dirty tree, missing auth, or an already-published version.

**`docs/release/npm-publish.md`** — the runbook, including why `--prefer-online` is mandatory when confirming (npm's cached metadata otherwise serves the *previous* version and reads as a failed publish — which happened during the 0.11.0 publish).

**`release.yml`** — a `verify-artifacts` job, with `github-release` now depending on it, so a tag cannot be declared released when the tarballs it implies are broken.

## Verification — mutation-tested, not assumed

A gate that cannot go red is worse than no gate, so each direction was proven:

```
# good artifacts
$ node scripts/verify-publish-artifacts.mjs ; echo $?
  ok    chroxy --version reports 0.11.0
  ok    chroxy doctor came up clean
  ok    import("@chroxy/protocol") → 421 exports
  ok    import("@chroxy/protocol/project") → 7 exports
  ok    import("@chroxy/store-core") → 327 exports
  ok    import("@chroxy/store-core/crypto") → 17 exports
verify-publish-artifacts: all checks passed
0

# mutant: drop @chroxy/protocol's `files` field (the real bug)
$ node scripts/verify-publish-artifacts.mjs ; echo $?
  FAIL  chroxy-protocol-0.11.0.tgz ships 10 test file(s) — check the "files" allowlist
  FAIL  chroxy --version did not run
  FAIL  chroxy doctor did not run
  FAIL  import("@chroxy/protocol/project") threw: ERR_MODULE_NOT_FOUND … dist/project.js
1
```

That `ERR_MODULE_NOT_FOUND` on `dist/project.js` is the exact failure from the live incident.

Both `publish-siblings.sh` guards were confirmed against the real registry — dirty tree refuses, and `@chroxy/protocol@0.11.0 is already published` exits 1.

`actionlint` findings are unchanged from `main` (12 before, 12 after, neither inside the added lines — baseline re-run through a proper `.github/workflows/` path, since linting it from `/tmp` silently reports zero).