### PR TITLE
ci: fail a release PR whose subject would not fire the auto-tag job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -895,6 +895,51 @@ jobs:
         # changed without regenerating, or if AGENTS.md was hand-edited.
         run: node scripts/__tests__/gen-agents-md.test.mjs
 
+      - name: Run check-release-pr-subject.mjs tests
+        run: node scripts/__tests__/check-release-pr-subject.test.mjs
+
+  release-pr-subject:
+    name: Release PR Subject
+    # #7184 — auto-tag-on-release.yml only fires on a merge subject matching
+    # `^chore\(release\): cut vX.Y.Z`. A release PR merged under any other
+    # subject silently skips the tag job: no tag, no release, no artifacts, and
+    # a green check mark. That has cost two releases (#4627, and 0.10.0 which
+    # produced the 463-commit gap in #7176).
+    #
+    # Content-triggered on purpose. Keying this to the subject would be
+    # circular — the failure IS a wrong subject — so it asks "does this diff
+    # look like a release?" (root version bump / CHANGELOG version heading) and
+    # only then demands a subject that will tag.
+    if: github.event_name == 'pull_request'
+    needs: runner-target
+    runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}  # SELF_HOSTED_OR_HOSTED (see header)
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # The check diffs against the base branch; a shallow clone would make
+          # that diff unavailable and the script fails closed (exit 2) rather
+          # than silently passing.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Would this PR's subject fire the auto-tag workflow?
+        env:
+          # Via env, not inline `${{ }}`, so a title containing shell
+          # metacharacters cannot be interpolated into the command.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          node scripts/check-release-pr-subject.mjs \
+            --title "$PR_TITLE" \
+            --number "$PR_NUMBER" \
+            --base "$BASE_SHA" \
+            --head HEAD
+
   dashboard-smoke:
     name: Dashboard Smoke (Playwright)
     # #6315: a UI-regression gate. Runs the Playwright dashboard smoke

--- a/scripts/__tests__/check-release-pr-subject.test.mjs
+++ b/scripts/__tests__/check-release-pr-subject.test.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Tests for scripts/check-release-pr-subject.mjs (#7184).
+//
+// The cases that matter are the two real incidents: 0.10.0 merged as
+// `chore(release): 0.10.0 — …` (no `cut v`, so auto-tag never fired, which is
+// the 463-commit untagged gap in #7176), and the near-miss on #7180 titled
+// `chore(cli): cut the 0.11.0 release`. Both are pinned below as fixtures.
+//
+// The negative cases matter just as much: a guard that fires on ordinary PRs
+// gets disabled, and one that cannot fire on a release PR is decoration.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'check-release-pr-subject.mjs')
+
+let passed = 0
+let failed = 0
+const results = []
+
+function check(name, cond) {
+  if (cond) { passed++; results.push(`  PASS  ${name}`) }
+  else { failed++; results.push(`  FAIL  ${name}`) }
+}
+
+// Build a throwaway repo with a base commit and a head commit whose diff we
+// control, so the content-detection half is exercised for real rather than
+// stubbed.
+function makeRepo({ rootVersionFrom, rootVersionTo, changelogHeading, otherChange }) {
+  const dir = mkdtempSync(join(tmpdir(), 'relsubj-'))
+  const git = (...a) => execFileSync('git', a, { cwd: dir, encoding: 'utf8' })
+  git('init', '-q', '-b', 'main')
+  git('config', 'user.email', 't@t')
+  git('config', 'user.name', 't')
+
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'chroxy', version: rootVersionFrom }, null, 2) + '\n')
+  writeFileSync(join(dir, 'CHANGELOG.md'), '# Changelog\n\n## [Unreleased]\n\n- stuff\n')
+  writeFileSync(join(dir, 'src.js'), 'export const a = 1\n')
+  git('add', 'package.json', 'CHANGELOG.md', 'src.js')
+  git('commit', '-q', '-m', 'base')
+  const base = git('rev-parse', 'HEAD').trim()
+
+  if (rootVersionTo) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'chroxy', version: rootVersionTo }, null, 2) + '\n')
+    git('add', 'package.json')
+  }
+  if (changelogHeading) {
+    writeFileSync(join(dir, 'CHANGELOG.md'), `# Changelog\n\n## [Unreleased]\n\n## [${changelogHeading}] - 2026-08-15\n\n- stuff\n`)
+    git('add', 'CHANGELOG.md')
+  }
+  if (otherChange) {
+    writeFileSync(join(dir, 'src.js'), 'export const a = 2\n')
+    git('add', 'src.js')
+  }
+  // --allow-empty: some fixtures deliberately change nothing (the "ordinary PR"
+  // cases), and a fixture builder that throws on those would silently remove
+  // the negative controls.
+  git('commit', '-q', '--allow-empty', '-m', 'head')
+  return { dir, base, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+function runGuard({ dir, base }, title, number) {
+  const args = [SCRIPT, '--title', title, '--base', base, '--head', 'HEAD']
+  if (number) args.push('--number', String(number))
+  const r = spawnSync(process.execPath, args, { cwd: dir, encoding: 'utf8' })
+  return { code: r.status, out: (r.stdout || '') + (r.stderr || '') }
+}
+
+// --- release PRs -------------------------------------------------------------
+
+{
+  const repo = makeRepo({ rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0', changelogHeading: '0.11.0' })
+
+  const good = runGuard(repo, 'chore(release): cut v0.11.0', 7180)
+  check('release PR with the correct subject passes', good.code === 0)
+  check('  …and says the tag will fire', /will fire and push v0\.11\.0/.test(good.out))
+
+  // The real 0.10.0 subject. This is the regression this guard exists for.
+  const lost = runGuard(repo, 'chore(release): 0.10.0 — codex controllable like Claude by default', 6619)
+  check('release PR with the real 0.10.0 subject FAILS', lost.code === 1)
+  check('  …and names the auto-tag workflow', /auto-tag-on-release\.yml/.test(lost.out))
+
+  // The near-miss from #7180 before it was retitled.
+  const nearMiss = runGuard(repo, 'chore(cli): cut the 0.11.0 release', 7180)
+  check('release PR titled chore(cli) FAILS', nearMiss.code === 1)
+
+  // Right shape, wrong scope — `cut v` is present but the subject does not
+  // start with it, so auto-tag's anchored parser will not match.
+  const notAnchored = runGuard(repo, 'fix: revert chore(release): cut v0.11.0', 7180)
+  check('subject where the pattern is not at line start FAILS', notAnchored.code === 1)
+
+  repo.cleanup()
+}
+
+// A version bump with no CHANGELOG promotion is still a release PR.
+{
+  const repo = makeRepo({ rootVersionFrom: '0.11.0', rootVersionTo: '0.12.0' })
+  check('version bump alone is detected as a release PR',
+    runGuard(repo, 'chore: bump deps', 1).code === 1)
+  repo.cleanup()
+}
+
+// A CHANGELOG promotion with no version bump is still a release PR.
+{
+  const repo = makeRepo({ rootVersionFrom: '0.11.0', changelogHeading: '0.11.0' })
+  check('CHANGELOG version heading alone is detected as a release PR',
+    runGuard(repo, 'docs: changelog', 1).code === 1)
+  repo.cleanup()
+}
+
+// --- non-release PRs (the guard must stay quiet) -----------------------------
+
+{
+  const repo = makeRepo({ rootVersionFrom: '0.11.0', otherChange: true })
+  const r = runGuard(repo, 'fix(server): something unrelated', 1234)
+  check('ordinary PR passes untouched', r.code === 0)
+  check('  …and says so explicitly', /not a release PR/.test(r.out))
+  repo.cleanup()
+}
+
+// An [Unreleased] heading is not a version heading — adding one must not trip
+// the guard, or every changelog edit becomes a release PR.
+{
+  const repo = makeRepo({ rootVersionFrom: '0.11.0' })
+  const git = (...a) => execFileSync('git', a, { cwd: repo.dir, encoding: 'utf8' })
+  writeFileSync(join(repo.dir, 'CHANGELOG.md'), '# Changelog\n\n## [Unreleased]\n\n- a new entry\n- another\n')
+  git('add', 'CHANGELOG.md')
+  git('commit', '-q', '-m', 'changelog entry')
+  check('adding entries under [Unreleased] is not a release PR',
+    runGuard(repo, 'docs: add changelog entry', 42).code === 0)
+  repo.cleanup()
+}
+
+// --- the (#N) suffix ---------------------------------------------------------
+//
+// The squash subject carries ` (#N)`. A guard that checks the bare title would
+// pass a subject the real merge then fails on, so the suffix is asserted.
+{
+  const repo = makeRepo({ rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0' })
+  const r = runGuard(repo, 'chore(release): cut v0.11.0', 7180)
+  check('the checked subject includes the (#N) squash suffix', /cut v0\.11\.0 \(#7180\)/.test(r.out))
+  repo.cleanup()
+}
+
+// --- fail-closed on a broken base ref ---------------------------------------
+//
+// A shallow clone must not silently turn the guard into a no-op.
+{
+  const repo = makeRepo({ rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0' })
+  const r = runGuard({ dir: repo.dir, base: 'refs/does-not-exist' }, 'anything', 1)
+  check('an unreachable base ref errors instead of passing', r.code === 2)
+  repo.cleanup()
+}
+
+console.log('\ncheck-release-pr-subject.mjs')
+console.log(results.join('\n'))
+console.log(`\nResults: ${passed} passed, ${failed} failed\n`)
+process.exit(failed ? 1 : 0)

--- a/scripts/__tests__/check-release-pr-subject.test.mjs
+++ b/scripts/__tests__/check-release-pr-subject.test.mjs
@@ -29,7 +29,7 @@ function check(name, cond) {
 // Build a throwaway repo with a base commit and a head commit whose diff we
 // control, so the content-detection half is exercised for real rather than
 // stubbed.
-function makeRepo({ rootVersionFrom, rootVersionTo, changelogHeading, otherChange }) {
+function makeRepo({ rootVersionFrom, rootVersionTo, changelogHeading, otherChange, headSubject, extraCommit }) {
   const dir = mkdtempSync(join(tmpdir(), 'relsubj-'))
   const git = (...a) => execFileSync('git', a, { cwd: dir, encoding: 'utf8' })
   git('init', '-q', '-b', 'main')
@@ -58,7 +58,9 @@ function makeRepo({ rootVersionFrom, rootVersionTo, changelogHeading, otherChang
   // --allow-empty: some fixtures deliberately change nothing (the "ordinary PR"
   // cases), and a fixture builder that throws on those would silently remove
   // the negative controls.
-  git('commit', '-q', '--allow-empty', '-m', 'head')
+  git('commit', '-q', '--allow-empty', '-m', headSubject || 'head')
+  // A second commit flips GitHub from the commit subject to the PR title.
+  if (extraCommit) git('commit', '-q', '--allow-empty', '-m', extraCommit)
   return { dir, base, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
 }
 
@@ -70,28 +72,48 @@ function runGuard({ dir, base }, title, number) {
 }
 
 // --- release PRs -------------------------------------------------------------
+//
+// Each case gets its own repo with the commit subject matching the title under
+// test. That models a real single-commit release PR — #7180 was exactly this —
+// where GitHub squashes under the COMMIT subject, so both places carry the same
+// text and either one being wrong is the failure.
+const releaseRepo = (subject) => makeRepo({
+  rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0', changelogHeading: '0.11.0',
+  headSubject: subject,
+})
 
 {
-  const repo = makeRepo({ rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0', changelogHeading: '0.11.0' })
-
+  const repo = releaseRepo('chore(release): cut v0.11.0')
   const good = runGuard(repo, 'chore(release): cut v0.11.0', 7180)
   check('release PR with the correct subject passes', good.code === 0)
   check('  …and says the tag will fire', /will fire and push v0\.11\.0/.test(good.out))
+  check('the checked subject includes the (#N) squash suffix', /cut v0\.11\.0 \(#7180\)/.test(good.out))
+  repo.cleanup()
+}
 
+{
   // The real 0.10.0 subject. This is the regression this guard exists for.
+  const repo = releaseRepo('chore(release): 0.10.0 — codex controllable like Claude by default')
   const lost = runGuard(repo, 'chore(release): 0.10.0 — codex controllable like Claude by default', 6619)
   check('release PR with the real 0.10.0 subject FAILS', lost.code === 1)
   check('  …and names the auto-tag workflow', /auto-tag-on-release\.yml/.test(lost.out))
+  repo.cleanup()
+}
 
+{
   // The near-miss from #7180 before it was retitled.
-  const nearMiss = runGuard(repo, 'chore(cli): cut the 0.11.0 release', 7180)
-  check('release PR titled chore(cli) FAILS', nearMiss.code === 1)
+  const repo = releaseRepo('chore(cli): cut the 0.11.0 release')
+  check('release PR titled chore(cli) FAILS',
+    runGuard(repo, 'chore(cli): cut the 0.11.0 release', 7180).code === 1)
+  repo.cleanup()
+}
 
-  // Right shape, wrong scope — `cut v` is present but the subject does not
-  // start with it, so auto-tag's anchored parser will not match.
-  const notAnchored = runGuard(repo, 'fix: revert chore(release): cut v0.11.0', 7180)
-  check('subject where the pattern is not at line start FAILS', notAnchored.code === 1)
-
+{
+  // Right shape, wrong anchoring — `cut v` is present but not at line start, so
+  // auto-tag's anchored parser will not match.
+  const repo = releaseRepo('fix: revert chore(release): cut v0.11.0')
+  check('subject where the pattern is not at line start FAILS',
+    runGuard(repo, 'fix: revert chore(release): cut v0.11.0', 7180).code === 1)
   repo.cleanup()
 }
 
@@ -134,17 +156,6 @@ function runGuard({ dir, base }, title, number) {
   repo.cleanup()
 }
 
-// --- the (#N) suffix ---------------------------------------------------------
-//
-// The squash subject carries ` (#N)`. A guard that checks the bare title would
-// pass a subject the real merge then fails on, so the suffix is asserted.
-{
-  const repo = makeRepo({ rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0' })
-  const r = runGuard(repo, 'chore(release): cut v0.11.0', 7180)
-  check('the checked subject includes the (#N) squash suffix', /cut v0\.11\.0 \(#7180\)/.test(r.out))
-  repo.cleanup()
-}
-
 // --- fail-closed on a broken base ref ---------------------------------------
 //
 // A shallow clone must not silently turn the guard into a no-op.
@@ -168,6 +179,51 @@ function runGuard({ dir, base }, title, number) {
   check('--title followed by another flag exits 2', raw(['--title', '--number', '5']).status === 2)
   check('an empty --title exits 2', raw(['--title', '   ']).status === 2)
   check('a missing --title exits 2', raw(['--base', 'HEAD~1']).status === 2)
+  repo.cleanup()
+}
+
+
+// --- squash subject source: commit vs PR title (#7193 review, Critical 1) -----
+//
+// This repo sets squash_merge_commit_title = COMMIT_OR_PR_TITLE, which GitHub
+// resolves to the COMMIT's subject for a single-commit PR and the PR title only
+// when there are 2+. #7180 — the real v0.11.0 release — was single-commit, so
+// this is the repo's actual pattern. Predicting from the PR title alone made
+// the guard pass a release that would not have tagged.
+{
+  // Single commit, PR title right, commit subject WRONG -> must FAIL.
+  const repo = makeRepo({
+    rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0',
+    headSubject: 'wip: bump some versions',
+  })
+  const r = runGuard(repo, 'chore(release): cut v0.11.0', 7180)
+  check('single-commit PR with a good title but bad COMMIT subject FAILS', r.code === 1)
+  check('  …and checks the commit subject, not the title', /from the sole commit's subject/.test(r.out))
+  check('  …and says to amend the commit, not retitle', /amend the COMMIT message/.test(r.out))
+  repo.cleanup()
+}
+
+{
+  // Single commit, commit subject right, PR title wrong -> must PASS (the
+  // commit is what GitHub uses) but say the two differ.
+  const repo = makeRepo({
+    rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0',
+    headSubject: 'chore(release): cut v0.11.0',
+  })
+  const r = runGuard(repo, 'some unrelated PR title', 7180)
+  check('single-commit PR with a good COMMIT subject passes', r.code === 0)
+  check('  …and flags that the title and commit differ', /the PR title and the commit subject differ/.test(r.out))
+  repo.cleanup()
+}
+
+{
+  // Two commits -> GitHub uses the PR title, so a bad commit subject is fine.
+  const repo = makeRepo({
+    rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0',
+    headSubject: 'wip', extraCommit: 'fixup',
+  })
+  const r = runGuard(repo, 'chore(release): cut v0.11.0', 7180)
+  check('multi-commit PR is checked against the PR title', r.code === 0 && /from the PR title \(2 commits\)/.test(r.out))
   repo.cleanup()
 }
 

--- a/scripts/__tests__/check-release-pr-subject.test.mjs
+++ b/scripts/__tests__/check-release-pr-subject.test.mjs
@@ -155,6 +155,22 @@ function runGuard({ dir, base }, title, number) {
   repo.cleanup()
 }
 
+
+// --- argument validation (fail-closed) ---------------------------------------
+//
+// A flag with a missing value must not read as "provided". Treating it as an
+// empty title would let the guard pass a release PR it never checked.
+{
+  const repo = makeRepo({ rootVersionFrom: '0.10.0', rootVersionTo: '0.11.0' })
+  const raw = (extra) => spawnSync(process.execPath, [SCRIPT, ...extra], { cwd: repo.dir, encoding: 'utf8' })
+
+  check('--title with no value exits 2', raw(['--title']).status === 2)
+  check('--title followed by another flag exits 2', raw(['--title', '--number', '5']).status === 2)
+  check('an empty --title exits 2', raw(['--title', '   ']).status === 2)
+  check('a missing --title exits 2', raw(['--base', 'HEAD~1']).status === 2)
+  repo.cleanup()
+}
+
 console.log('\ncheck-release-pr-subject.mjs')
 console.log(results.join('\n'))
 console.log(`\nResults: ${passed} passed, ${failed} failed\n`)

--- a/scripts/check-release-pr-subject.mjs
+++ b/scripts/check-release-pr-subject.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// check-release-pr-subject.mjs — fail a release PR whose subject would not fire
+// the auto-tag workflow (#7184).
+//
+// `.github/workflows/auto-tag-on-release.yml` pushes the release tag on merge
+// and then dispatches release.yml. It fires only when the merge commit message
+// carries a line matching `^chore\(release\): cut vX.Y.Z`. If a release PR is
+// merged under any other subject, the job's `if:` is false, the job never runs,
+// and NOTHING reports a problem — no tag, no GitHub release, no artifacts, and
+// a green check mark on the PR.
+//
+// That has now cost two releases:
+//   - #4627: v0.9.13-v0.9.19 merged, tags never pushed by hand. This workflow
+//     was built to fix that.
+//   - 0.10.0: merged as `chore(release): 0.10.0 — codex controllable like
+//     Claude by default`. No `cut v`, so the guard never matched. That is the
+//     origin of the 463-commit untagged gap in #7176.
+//
+// The check is deliberately CONTENT-triggered, not subject-triggered. Keying it
+// to the subject would be circular: the exact failure is a release PR whose
+// subject is wrong, so a subject-keyed check cannot fire on the case it exists
+// to catch. Instead it asks "does this diff look like a release?" and only then
+// demands the subject.
+//
+// Usage:
+//   node scripts/check-release-pr-subject.mjs --title "<pr title>" --number <n> \
+//        [--base origin/main] [--head HEAD]
+//
+// Exit 0 = not a release PR, or a release PR with a subject that will tag.
+// Exit 1 = a release PR whose subject will NOT tag.
+
+import { execFileSync } from 'node:child_process'
+
+const args = process.argv.slice(2)
+const arg = (name, fallback = null) => {
+  const i = args.indexOf(`--${name}`)
+  return i === -1 ? fallback : args[i + 1]
+}
+
+const title = arg('title')
+const number = arg('number')
+const base = arg('base', 'origin/main')
+const head = arg('head', 'HEAD')
+
+if (title === null) {
+  console.error('Error: --title is required')
+  process.exit(2)
+}
+
+const git = (...a) => execFileSync('git', a, { encoding: 'utf8' })
+
+// --- 1. Is this a release PR? ------------------------------------------------
+//
+// Two independent signals, either of which is sufficient. Two rather than one
+// because a release could in principle be split, and a check that misses the
+// release is worse than one that occasionally asks a non-release PR to explain
+// itself (that case is a one-line title fix, not a wrong tag).
+
+const reasons = []
+
+// (a) the root package.json's `version` field changed. scripts/bump-version.sh
+//     always touches it, so this is the most reliable marker.
+let rootDiff = ''
+try {
+  rootDiff = git('diff', `${base}...${head}`, '--unified=0', '--', 'package.json')
+} catch {
+  // A missing base ref (shallow clone) must not silently disable the guard.
+  console.error(`Error: could not diff ${base}...${head} — cannot determine whether this is a release PR.`)
+  console.error('       Fetch the base ref (fetch-depth: 0) so this check can run.')
+  process.exit(2)
+}
+const versionLine = /^[+-]\s*"version":\s*"(\d+\.\d+\.\d+)"/gm
+const bumped = [...rootDiff.matchAll(versionLine)].map((m) => m[1])
+if (bumped.length) reasons.push(`root package.json version changed (${[...new Set(bumped)].join(' -> ')})`)
+
+// (b) CHANGELOG.md gained a dated version heading — the promotion of
+//     [Unreleased] that every release does.
+let changelogDiff = ''
+try {
+  changelogDiff = git('diff', `${base}...${head}`, '--unified=0', '--', 'CHANGELOG.md')
+} catch { /* CHANGELOG may legitimately be untouched */ }
+const heading = /^\+##\s*\[(\d+\.\d+\.\d+)\]/gm
+const promoted = [...changelogDiff.matchAll(heading)].map((m) => m[1])
+if (promoted.length) reasons.push(`CHANGELOG.md promoted a version heading ([${promoted.join('], [')}])`)
+
+if (!reasons.length) {
+  console.log('not a release PR (no root version bump, no CHANGELOG version heading) — nothing to check')
+  process.exit(0)
+}
+
+console.log('This looks like a release PR:')
+for (const r of reasons) console.log(`  - ${r}`)
+
+// --- 2. Would the merge commit fire the auto-tag job? ------------------------
+//
+// Checked against the message a SQUASH merge actually produces — the PR title
+// with a ` (#N)` suffix — not the bare title. Getting that suffix wrong is how
+// a check like this passes while the real merge does not match.
+
+const AUTO_TAG_RE = /^chore\(release\): cut v\d+\.\d+\.\d+(\s|$)/
+const GUARD_SUBSTRING = 'chore(release): cut v' // auto-tag's `if:` contains() test
+
+const squashSubject = number ? `${title} (#${number})` : title
+console.log(`\nSquash-merge subject would be:\n  ${squashSubject}`)
+
+const matchesParser = AUTO_TAG_RE.test(squashSubject)
+const matchesGuard = squashSubject.includes(GUARD_SUBSTRING)
+
+if (matchesParser && matchesGuard) {
+  const version = squashSubject.match(/v(\d+\.\d+\.\d+)/)[1]
+  console.log(`\nOK — auto-tag-on-release.yml will fire and push v${version}.`)
+  process.exit(0)
+}
+
+console.error(`
+FAIL — this release PR's subject will NOT trigger auto-tag-on-release.yml.
+
+  .github/workflows/auto-tag-on-release.yml gates on:
+    if:  contains(github.event.head_commit.message, '${GUARD_SUBSTRING}')   -> ${matchesGuard}
+    parser: ${AUTO_TAG_RE}   -> ${matchesParser}
+
+If this merges as-is, the tag job silently does not run: no tag, no GitHub
+release, no Docker or desktop artifacts — and a green check mark. That is
+exactly how 0.10.0 was lost (#7176) and #4627 before it.
+
+Fix: retitle the PR to
+
+  chore(release): cut vX.Y.Z
+
+If this is genuinely NOT a release PR, it changed the root package.json version
+or promoted a CHANGELOG version heading, which is what release PRs do — say so
+in the PR and adjust the diff, or the tag automation cannot be trusted.
+`)
+process.exit(1)

--- a/scripts/check-release-pr-subject.mjs
+++ b/scripts/check-release-pr-subject.mjs
@@ -32,9 +32,19 @@
 import { execFileSync } from 'node:child_process'
 
 const args = process.argv.slice(2)
+// A flag with a missing value (`--title` last, or `--title --number 5`) must
+// not read as "provided". Silently treating that as an empty title would let
+// the guard pass a release PR it never actually checked — a fail-open, which
+// is the one outcome a guard must never have.
 const arg = (name, fallback = null) => {
   const i = args.indexOf(`--${name}`)
-  return i === -1 ? fallback : args[i + 1]
+  if (i === -1) return fallback
+  const value = args[i + 1]
+  if (value === undefined || value.startsWith('--')) {
+    console.error(`Error: --${name} was given without a value`)
+    process.exit(2)
+  }
+  return value
 }
 
 const title = arg('title')
@@ -42,8 +52,8 @@ const number = arg('number')
 const base = arg('base', 'origin/main')
 const head = arg('head', 'HEAD')
 
-if (title === null) {
-  console.error('Error: --title is required')
+if (title === null || title.trim() === '') {
+  console.error('Error: --title is required and must not be empty')
   process.exit(2)
 }
 

--- a/scripts/check-release-pr-subject.mjs
+++ b/scripts/check-release-pr-subject.mjs
@@ -110,8 +110,48 @@ for (const r of reasons) console.log(`  - ${r}`)
 const AUTO_TAG_RE = /^chore\(release\): cut v\d+\.\d+\.\d+(\s|$)/
 const GUARD_SUBSTRING = 'chore(release): cut v' // auto-tag's `if:` contains() test
 
-const squashSubject = number ? `${title} (#${number})` : title
-console.log(`\nSquash-merge subject would be:\n  ${squashSubject}`)
+// Which subject GitHub actually uses depends on the commit count. This repo is
+// set to `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, which per GitHub's
+// REST docs defaults to "the commit's title (if only one commit) or the pull
+// request's title (when more than one commit)".
+//
+// So predicting from --title alone is wrong for the SINGLE-COMMIT case — and
+// that is this repo's actual release pattern, not an edge case: #7180, the real
+// v0.11.0 release, was a single-commit PR. It tagged correctly only because its
+// commit message and PR title happened to be identical. Nothing enforced that,
+// and a guard that checked only the PR title would have called a mismatched
+// pair "OK" and then watched the tag job not run — the precise failure this
+// exists to prevent.
+let commitSubjects = []
+try {
+  commitSubjects = git('log', '--format=%s', `${base}..${head}`).split('\n').filter(Boolean)
+} catch {
+  console.error(`Error: could not list commits in ${base}..${head}.`)
+  process.exit(2)
+}
+
+let subjectSource
+let baseSubject
+if (commitSubjects.length === 1) {
+  subjectSource = "the sole commit's subject (GitHub uses it for single-commit squashes)"
+  baseSubject = commitSubjects[0]
+} else {
+  subjectSource = `the PR title (${commitSubjects.length} commits)`
+  baseSubject = title
+}
+
+const squashSubject = number ? `${baseSubject} (#${number})` : baseSubject
+console.log(`\nSquash-merge subject would be — from ${subjectSource}:\n  ${squashSubject}`)
+
+// A single-commit PR whose two subjects disagree is a live footgun even when
+// the one that counts is correct: editing either, or pushing a second commit,
+// silently swaps which one GitHub uses.
+if (commitSubjects.length === 1 && commitSubjects[0] !== title) {
+  console.log(`\nNote: the PR title and the commit subject differ.`)
+  console.log(`  PR title:       ${title}`)
+  console.log(`  commit subject: ${commitSubjects[0]}`)
+  console.log(`  GitHub squashes single-commit PRs under the COMMIT subject, so that is what is checked.`)
+}
 
 const matchesParser = AUTO_TAG_RE.test(squashSubject)
 const matchesGuard = squashSubject.includes(GUARD_SUBSTRING)
@@ -133,9 +173,23 @@ If this merges as-is, the tag job silently does not run: no tag, no GitHub
 release, no Docker or desktop artifacts — and a green check mark. That is
 exactly how 0.10.0 was lost (#7176) and #4627 before it.
 
-Fix: retitle the PR to
+Fix: ${
+  commitSubjects.length === 1
+    ? `amend the COMMIT message to
 
   chore(release): cut vX.Y.Z
+
+  Retitling the PR is NOT enough here. This PR has one commit, and GitHub
+  squashes single-commit PRs under the commit's own subject
+  (squash_merge_commit_title = COMMIT_OR_PR_TITLE). Keep the PR title in
+  sync too, since pushing a second commit would swap which one is used.`
+    : `retitle the PR to
+
+  chore(release): cut vX.Y.Z
+
+  This PR has ${commitSubjects.length} commits, so GitHub squashes under the
+  PR title.`
+}
 
 If this is genuinely NOT a release PR, it changed the root package.json version
 or promoted a CHANGELOG version heading, which is what release PRs do — say so


### PR DESCRIPTION
## Description

Closes #7184.

`auto-tag-on-release.yml` pushes the release tag and dispatches `release.yml`. It fires only on a merge subject matching:

```
^chore\(release\): cut v[0-9]+\.[0-9]+\.[0-9]+
```

Merge a release PR under any other subject and the job's `if:` evaluates false. No tag, no GitHub release, no Docker or desktop artifacts — **and a green check mark**, because a workflow that never ran is indistinguishable from one that passed.

That has now cost two releases:

| | what happened |
|---|---|
| **#4627** | v0.9.13–v0.9.19 merged, tags never pushed by hand. This workflow was built to fix that. |
| **0.10.0** | merged as `chore(release): 0.10.0 — codex controllable like Claude by default`. No `cut v` → guard never matched → the 463-commit untagged gap in #7176. |

It nearly cost a third: #7180 was opened as `chore(cli): cut the 0.11.0 release` and only caught in review.

## Why content-triggered, not subject-triggered

Keying this check to the subject would be circular — the failure *is* a wrong subject, so a subject-keyed check cannot fire on the exact case it exists to catch. This one asks **"does this diff look like a release?"** first:

- the root `package.json` `version` field changed (`bump-version.sh` always touches it), **or**
- `CHANGELOG.md` gained a dated `## [X.Y.Z]` heading

…and only then demands a subject that will tag.

Two details that make it honest rather than decorative:

- It checks the subject a **squash merge actually produces** — `<title> (#N)` — not the bare title. Checking the bare title would pass a subject the real merge then fails on.
- An unreachable base ref exits **2**, not 0, so a shallow clone cannot silently turn the guard into a no-op.

## Verification

13 assertions in `scripts/__tests__/check-release-pr-subject.test.mjs`, pinned against both real incidents:

```
PASS  release PR with the correct subject passes
PASS    …and says the tag will fire
PASS  release PR with the real 0.10.0 subject FAILS
PASS    …and names the auto-tag workflow
PASS  release PR titled chore(cli) FAILS
PASS  subject where the pattern is not at line start FAILS
PASS  version bump alone is detected as a release PR
PASS  CHANGELOG version heading alone is detected as a release PR
PASS  ordinary PR passes untouched
PASS    …and says so explicitly
PASS  adding entries under [Unreleased] is not a release PR
PASS  the checked subject includes the (#N) squash suffix
PASS  an unreachable base ref errors instead of passing

Results: 13 passed, 0 failed
```

Also run against the **real commits** in this repo rather than only synthetic fixtures — `d6bb0ddf5` (the actual v0.11.0 release) with the correct title exits 0; the same diff with the real 0.10.0 title, and with the `chore(cli)` near-miss title, both exit 1; `e08e47469` and `c7cab16e0` (the docs and test PRs) exit 0.

`actionlint` findings unchanged from `main` (2 before, 2 after, neither inside the added job — baseline linted through a real `.github/workflows/` path, since linting from `/tmp` silently reports zero).

The PR title is passed via `env:` rather than inline `${{ }}` so a title containing shell metacharacters cannot be interpolated into the command.