### PR TITLE
chore(docs): bump CLAUDE.md's version references with the release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ chroxy/
 └── scripts/         # Install helpers
 ```
 
-**Current Status (v0.10.0):**
+**Current Status (v0.11.0):**
 - Server works: CLI headless mode, multi-provider registry (Claude SDK/CLI/TUI, BYOK, Gemini, Codex — **app-server driver is now the default (#6616): approvals surfaced in Chroxy's permission pipeline + permission-mode switching + image vision + intra-session memory; `CHROXY_CODEX_APPSERVER=0` falls back to legacy `codex exec`** — DeepSeek, Ollama, config-driven Anthropic-compatible + OpenAI-compatible endpoints), WebSocket protocol, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications + Discord status-embed sink, external-session event ingest (`POST /api/events` + ingest secret), session management, model switching, plan mode detection, background agent tracking, container environments (Docker Compose, DevContainer, snapshots), container/worktree isolation, K8s/Rancher backends (config-driven selection; experimental — live-cluster validation pending #6275), embedded user-shell terminal, daemon identity-key rotation (`chroxy identity rotate`), Control Room env/runtime management, queue-while-processing (mid-turn send + auto-flush), permission rule engine, persistent pairing tokens with a configurable sliding TTL (#6598), encrypted credentials at rest (macOS Keychain / Linux libsecret / Windows DPAPI — #6644), opt-in IDE navigation surface (`features.ide` / `CHROXY_ENABLE_IDE=1` — VSCode-style collapsible file-tree navigator, symbol side-panel, go-to-definition, find-references, find-in-project, Cmd+P quick-open, syntax-highlit viewer; epic #6469 P1+P2 complete), extensible provider/handler system
 - Desktop works: Tauri tray app, multi-host LAN client (server picker, mDNS discovery, shared-session join), web dashboard with syntax highlighting, xterm.js terminal, Control Room, notifications, session tabs, voice-to-text (macOS), console page, environment management panel, startup-failure surfacing with retry
 - App works: QR code scanning, connection flow with health checks and retries, ConnectionPhase state machine for resilient reconnection, markdown rendering, dual-view chat/terminal, xterm.js terminal emulation (WebView), plan approval UI, agent monitoring, settings screen, voice-to-text input, session rules UI, worktree toggle
@@ -478,4 +478,4 @@ For detailed component tables, WebSocket protocol messages, file listings, and s
 ---
 
 *Last Updated: 2026-07-02*
-*Version: 0.9.47*
+*Version: 0.11.0*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ chroxy/
 └── scripts/         # Install helpers
 ```
 
-**Current Status (v0.10.0):**
+**Current Status (v0.11.0):**
 - Server works: CLI headless mode, multi-provider registry (Claude SDK/CLI/TUI, BYOK, Gemini, Codex — **app-server driver is now the default (#6616): approvals surfaced in Chroxy's permission pipeline + permission-mode switching + image vision + intra-session memory; `CHROXY_CODEX_APPSERVER=0` falls back to legacy `codex exec`** — DeepSeek, Ollama, config-driven Anthropic-compatible + OpenAI-compatible endpoints), WebSocket protocol, Cloudflare tunnel (Quick + Named), supervisor auto-restart, push notifications + Discord status-embed sink, external-session event ingest (`POST /api/events` + ingest secret), session management, model switching, plan mode detection, background agent tracking, container environments (Docker Compose, DevContainer, snapshots), container/worktree isolation, K8s/Rancher backends (config-driven selection; experimental — live-cluster validation pending #6275), embedded user-shell terminal, daemon identity-key rotation (`chroxy identity rotate`), Control Room env/runtime management, queue-while-processing (mid-turn send + auto-flush), permission rule engine, persistent pairing tokens with a configurable sliding TTL (#6598), encrypted credentials at rest (macOS Keychain / Linux libsecret / Windows DPAPI — #6644), opt-in IDE navigation surface (`features.ide` / `CHROXY_ENABLE_IDE=1` — VSCode-style collapsible file-tree navigator, symbol side-panel, go-to-definition, find-references, find-in-project, Cmd+P quick-open, syntax-highlit viewer; epic #6469 P1+P2 complete), extensible provider/handler system
 - Desktop works: Tauri tray app, multi-host LAN client (server picker, mDNS discovery, shared-session join), web dashboard with syntax highlighting, xterm.js terminal, Control Room, notifications, session tabs, voice-to-text (macOS), console page, environment management panel, startup-failure surfacing with retry
 - App works: QR code scanning, connection flow with health checks and retries, ConnectionPhase state machine for resilient reconnection, markdown rendering, dual-view chat/terminal, xterm.js terminal emulation (WebView), plan approval UI, agent monitoring, settings screen, voice-to-text input, session rules UI, worktree toggle
@@ -459,4 +459,4 @@ For detailed component tables, WebSocket protocol messages, file listings, and s
 ---
 
 *Last Updated: 2026-07-02*
-*Version: 0.9.47*
+*Version: 0.11.0*

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -685,6 +685,61 @@ test_bumps_workspace_chroxy_dep_ranges() {
   ! grep -q '0.5.7' "$dir/packages/server/package.json" || return 1
 }
 
+
+# --- CLAUDE.md / AGENTS.md version references (#7183) ------------------------
+
+# These two lines are the first thing a session reads about "what version is
+# this". Nothing rewrote them, so at the 0.10.0 -> 0.11.0 bump the header still
+# said v0.10.0 and the footer still said 0.9.47 — two releases stale.
+test_bumps_claude_md_version_references() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+
+  cat > "$dir/CLAUDE.md" <<'CLAUDEMD'
+# Claude Development Notes
+
+**Current Status (v0.5.7):**
+- stuff works
+
+---
+
+*Last Updated: 2026-01-01*
+*Version: 0.5.7*
+CLAUDEMD
+
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) > /dev/null 2>&1 || return 1
+
+  grep -q '^\*\*Current Status (v0.6.0):\*\*' "$dir/CLAUDE.md" || return 1
+  grep -q '^\*Version: 0.6.0\*$' "$dir/CLAUDE.md" || return 1
+  # Negative control: an unrelated version-shaped line is untouched. Without
+  # this, a rewrite that clobbered every semver in the file would pass above.
+  grep -q '^\*Last Updated: 2026-01-01\*$' "$dir/CLAUDE.md" || return 1
+  ! grep -q '0\.5\.7' "$dir/CLAUDE.md" || return 1
+}
+
+# The script must still run against a tree with no CLAUDE.md — the other
+# fixtures build exactly that, and a hard failure here would break them all.
+test_bump_survives_missing_claude_md() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+  rm -f "$dir/CLAUDE.md"
+
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) > /dev/null 2>&1 || return 1
+  grep -qE '"version":\s*"0.6.0"' "$dir/packages/server/package.json" || return 1
+}
+
 # --- runner ------------------------------------------------------------------
 
 echo "Running bump-version.sh tests"
@@ -719,6 +774,10 @@ run_test "Cargo.lock sync uses cargo when on PATH (no awk fallthrough)" \
   test_lockfile_uses_cargo_when_on_path
 run_test "bumps workspace @chroxy/* dependency ranges with the version" \
   test_bumps_workspace_chroxy_dep_ranges
+run_test "bumps the version references in CLAUDE.md" \
+  test_bumps_claude_md_version_references
+run_test "bump still succeeds when CLAUDE.md is absent" \
+  test_bump_survives_missing_claude_md
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -740,6 +740,39 @@ test_bump_survives_missing_claude_md() {
   grep -qE '"version":\s*"0.6.0"' "$dir/packages/server/package.json" || return 1
 }
 
+
+# A reworded CLAUDE.md must ABORT, not silently skip. Skipping is a fail-open
+# on the exact drift this closes: the rewrite does nothing, the script reports
+# success, and the version goes stale again unnoticed.
+test_aborts_when_claude_md_format_changed() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+
+  # Both markers reworded — the format drift the guard must catch.
+  cat > "$dir/CLAUDE.md" <<'CLAUDEMD'
+# Claude Development Notes
+
+**Status as of v0.5.7:**
+- stuff works
+
+*Release: 0.5.7*
+CLAUDEMD
+
+  # Must fail...
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) > /dev/null 2>&1 && return 1
+  # ...and say why.
+  local out
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 || true )
+  echo "$out" | grep -q "does not contain the expected version reference" || return 1
+  return 0
+}
+
 # --- runner ------------------------------------------------------------------
 
 echo "Running bump-version.sh tests"
@@ -778,6 +811,8 @@ run_test "bumps the version references in CLAUDE.md" \
   test_bumps_claude_md_version_references
 run_test "bump still succeeds when CLAUDE.md is absent" \
   test_bump_survives_missing_claude_md
+run_test "aborts when CLAUDE.md's version line format changed" \
+  test_aborts_when_claude_md_format_changed
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -240,28 +240,34 @@ if [ -f "$CLAUDE_MD" ]; then
     let src = fs.readFileSync(file, 'utf-8');
     const edits = [
       // '**Current Status (v0.11.0):**' in the Project Overview
-      [/(\*\*Current Status \(v)\d+\.\d+\.\d+(\):\*\*)/, version],
+      [/(\*\*Current Status \(v)\d+\.\d+\.\d+(\):\*\*)/, version, 'the Current Status header'],
       // '*Version: 0.11.0*' in the footer
-      [/(^\*Version: )\d+\.\d+\.\d+(\*\$)/m, version],
+      [/(^\*Version: )\d+\.\d+\.\d+(\*\$)/m, version, 'the Version footer'],
     ];
-    let changed = 0;
-    for (const [re, v] of edits) {
-      if (!re.test(src)) continue;
-      src = src.replace(re, (_m, a, b) => a + v + b);
-      changed++;
+    // A pattern that matches NOTHING must fail, not be skipped. Skipping is a
+    // fail-open on the exact scenario this guards: if CLAUDE.md's line format
+    // is reworded, the rewrite quietly does nothing, the script reports
+    // success, and the version silently drifts again — which is how these two
+    // lines got two releases stale in the first place.
+    const missing = edits.filter(([re]) => !re.test(src)).map(([, , label]) => label);
+    if (missing.length) {
+      console.error('Error: ' + file + ' does not contain the expected version reference(s): ' + missing.join(', '));
+      console.error('       The line format changed. Update the patterns in scripts/bump-version.sh');
+      console.error('       rather than letting the version drift silently (#7183).');
+      process.exit(1);
     }
+    for (const [re, v] of edits) src = src.replace(re, (_m, a, b) => a + v + b);
     fs.writeFileSync(file, src);
-    // Verify after write, mirroring the Cargo.toml handling: a silently-missed
-    // rewrite here is exactly the drift this closes.
+    // Verify after write, mirroring the Cargo.toml handling.
     const after = fs.readFileSync(file, 'utf-8');
-    for (const [re] of edits) {
+    for (const [re, , label] of edits) {
       const m = after.match(re);
-      if (m && !m[0].includes(version)) {
-        console.error('Error: failed to update a version reference in ' + file);
+      if (!m || !m[0].includes(version)) {
+        console.error('Error: failed to update ' + label + ' in ' + file);
         process.exit(1);
       }
     }
-    console.log('  CLAUDE.md version references -> ' + version + ' (' + changed + ' line(s))');
+    console.log('  CLAUDE.md version references -> ' + version + ' (' + edits.length + ' line(s))');
   "
 
   # AGENTS.md is generated from CLAUDE.md and CI (Scripts Tests) fails on drift,

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -55,6 +55,7 @@ STORE_CORE_PKG="$ROOT/packages/store-core/package.json"
 DASHBOARD_PKG="$ROOT/packages/dashboard/package.json"
 CLAUDE_HOOKS_PKG="$ROOT/packages/claude-hooks/package.json"
 DESIGN_TOKENS_PKG="$ROOT/packages/design-tokens/package.json"
+CLAUDE_MD="$ROOT/CLAUDE.md"
 TAURI_CONF="$ROOT/packages/desktop/src-tauri/tauri.conf.json"
 CARGO_TOML="$ROOT/packages/desktop/src-tauri/Cargo.toml"
 ROOT_LOCK="$ROOT/package-lock.json"
@@ -220,6 +221,56 @@ node -e "
   }
   console.log('  workspace @chroxy/* dependency ranges -> ' + range + ' (' + n + ' updated)');
 "
+
+# Update the two version references in CLAUDE.md's prose, then regenerate
+# AGENTS.md from it (#7183).
+#
+# These are the first thing a session reads about "what version is this", and
+# they were wrong immediately after every release: at the 0.10.0 -> 0.11.0 bump
+# the header still said v0.10.0 and the footer still said 0.9.47 — two releases
+# stale, drifting silently because nothing rewrote them.
+#
+# Only touched when the file is present, so the script still runs against a
+# minimal tree (the bump-version test fixtures build one).
+if [ -f "$CLAUDE_MD" ]; then
+  node -e "
+    const fs = require('fs');
+    const file = '$CLAUDE_MD';
+    const version = '$NEW_VERSION';
+    let src = fs.readFileSync(file, 'utf-8');
+    const edits = [
+      // '**Current Status (v0.11.0):**' in the Project Overview
+      [/(\*\*Current Status \(v)\d+\.\d+\.\d+(\):\*\*)/, version],
+      // '*Version: 0.11.0*' in the footer
+      [/(^\*Version: )\d+\.\d+\.\d+(\*\$)/m, version],
+    ];
+    let changed = 0;
+    for (const [re, v] of edits) {
+      if (!re.test(src)) continue;
+      src = src.replace(re, (_m, a, b) => a + v + b);
+      changed++;
+    }
+    fs.writeFileSync(file, src);
+    // Verify after write, mirroring the Cargo.toml handling: a silently-missed
+    // rewrite here is exactly the drift this closes.
+    const after = fs.readFileSync(file, 'utf-8');
+    for (const [re] of edits) {
+      const m = after.match(re);
+      if (m && !m[0].includes(version)) {
+        console.error('Error: failed to update a version reference in ' + file);
+        process.exit(1);
+      }
+    }
+    console.log('  CLAUDE.md version references -> ' + version + ' (' + changed + ' line(s))');
+  "
+
+  # AGENTS.md is generated from CLAUDE.md and CI (Scripts Tests) fails on drift,
+  # so regenerating here is not optional.
+  if [ -f "$ROOT/scripts/gen-agents-md.mjs" ]; then
+    node "$ROOT/scripts/gen-agents-md.mjs" >/dev/null
+    echo "  AGENTS.md regenerated from CLAUDE.md"
+  fi
+fi
 
 # Update tauri.conf.json
 node -e "


### PR DESCRIPTION
## Description

Closes #7183.

`CLAUDE.md` states the current release version in two places, and `scripts/bump-version.sh` never touched either:

- `**Current Status (vX.Y.Z):**` in the Project Overview
- `*Version: X.Y.Z*` in the footer

They are the first thing a session — human or agent — reads about what version this is, and they were wrong immediately after every release. At the 0.10.0 → 0.11.0 cut the header still read `v0.10.0` and the footer still read `0.9.47` — **already two releases stale before that bump**, so this had been drifting quietly across several releases, not just one.

## Changes

`bump-version.sh` now rewrites both lines and then regenerates `AGENTS.md` (generated from `CLAUDE.md`; its CI drift gate would otherwise fail the next release).

Two details worth calling out:

- **Verified after write**, mirroring the existing `Cargo.toml` handling. A silently-missed rewrite is precisely the drift being closed, so the script fails rather than reporting success.
- **Anchored to those two lines**, not "any semver in the file". The test's negative control is an unrelated `*Last Updated: …*` line that must survive untouched — without it, a rewrite that clobbered every version-shaped string in the file would pass.

It also skips cleanly when `CLAUDE.md` is absent, since the existing test fixtures build exactly such a tree.

This PR also brings both files to `0.11.0`, which they should have said since the release cut.

## Verification

```
$ bash scripts/__tests__/bump-version.test.sh
  …
  PASS  bumps workspace @chroxy/* dependency ranges with the version
  PASS  bumps the version references in CLAUDE.md
  PASS  bump still succeeds when CLAUDE.md is absent

Results: 17 passed, 0 failed

$ node scripts/__tests__/gen-agents-md.test.mjs
  ok committed AGENTS.md is in sync with CLAUDE.md (drift gate)
  3 passed, 0 failed
```

Mutation-checked rather than assumed — disabling the rewrite (`if false; then`) fails **exactly** the new CLAUDE.md test and nothing else:

```
Results: 16 passed, 1 failed
Failed tests:
  - bumps the version references in CLAUDE.md
```