### PR TITLE
fix(app): let compaction markers reach ChatView on mobile

### DIFF
--- a/packages/app/.maestro/compaction-marker.yaml
+++ b/packages/app/.maestro/compaction-marker.yaml
@@ -58,13 +58,26 @@ name: ChatView compaction marker rendering
 # no-break space) instead of "128,000". `.?` matches any single separator
 # character (or none), while the pinned digit groups still fail the
 # assertion if the wrong NUMBER renders.
+# Wildcards, not an exact match: CompactionMarker nests its segments inside one
+# parent <Text>, and RN flattens an accessible container's children into a
+# single node — the real node reads
+# "Context compacted · 128,000 → 12,000 tokens · 2s · auto", so an exact
+# "Context compacted" can never match it. (Same reason the token assertion
+# below is already wildcarded; this line was simply missed.)
 - assertVisible:
-    text: "Context compacted"
-- assertVisible:
-    id: "compaction-marker-tokens"
+    text: ".*Context compacted.*"
+# The token/duration/trigger segments are nested <Text> inside the marker's
+# single accessible parent, so RN flattens them away — their testIDs are NOT
+# reachable as separate nodes here, only their text is. Those testIDs are
+# already asserted by CompactionMarker.test.tsx via react-test-renderer, where
+# flattening does not apply, so pinning them again here would be both
+# impossible and redundant. What this flow uniquely proves is that the marker
+# reached a real screen with the right CONTENT.
 - assertVisible:
     text: ".*128.?000.*12.?000.*tokens.*"
+# The trigger segment, same flattened node. `auto` is what the mock fixture
+# pins; a manual compaction would render `manual`.
 - assertVisible:
-    id: "compaction-marker-trigger"
+    text: ".*Context compacted.*auto.*"
 
 - takeScreenshot: compaction-marker-inline

--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -151,7 +151,21 @@ describe('SessionScreen component structure', () => {
     test('system messages are still filtered inline, separately from the compact predicate', () => {
       // #6882: system filtering stays inline — isHiddenInCompactMode is
       // specifically the compact-hide rule, not a catch-all message filter.
-      expect(src).toMatch(/if \(m\.type === 'system'\) return false;/)
+      expect(src).toMatch(/if \(m\.type === 'system'\) return m\.compactMetadata != null;/)
+    })
+
+    test('compaction markers survive the system filter so ChatView can reinsert them (#7186)', () => {
+      // The system filter used to be a flat `return false`, which meant
+      // ChatView's insertCompactionMarkers — which reads the SAME array it is
+      // handed — filtered a list that could never contain a system message.
+      // The marker was unreachable on mobile entirely.
+      //
+      // Asserted as source text because this predicate is a plain filter inside
+      // a useMemo with no exported seam; the behavioural proof is the
+      // compaction-marker.yaml Maestro flow, which fails at
+      // `compaction-marker is visible` when this line reverts to `return false`.
+      expect(src).toMatch(/m\.compactMetadata != null/)
+      expect(src).not.toMatch(/if \(m\.type === 'system'\) return false;/)
     })
   })
 })

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -349,11 +349,17 @@ export function ChatView({
     [messages, streamingMessageId],
   );
 
-  // #6972 — mobile parity: buildChatViewMessages filters `type: 'system'`
-  // off the Chat tab entirely (they're meant for the dashboard's System
-  // tab, which mobile has no equivalent of). Reinsert only the
-  // `compactMetadata`-carrying subset inline, in timestamp order, so the
-  // "Context compacted" marker is reachable at all on mobile. See
+  // #6972 — mobile parity: buildChatViewMessages filters `type: 'system'` off
+  // the Chat tab entirely (they belong on the System tab, which mobile DOES
+  // have — SessionScreen's `viewMode === 'system'`; an earlier version of this
+  // comment claimed otherwise). Compaction boundaries still have to be
+  // reinserted here because they are positional: "context was dropped HERE",
+  // between these two turns. On the System tab, separated from the messages it
+  // sits between, the marker conveys nothing.
+  //
+  // Reinsert only the `compactMetadata`-carrying subset, in timestamp order.
+  // This reads the same `messages` array the component is handed, so SessionScreen
+  // must let those through its own filter for any of it to run (#7186). See
   // insertCompactionMarkers's doc comment for the full placement rationale.
   const displayGroups = useMemo(
     () => insertCompactionMarkers(baseDisplayGroups, messages),

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -187,15 +187,23 @@ export function SessionScreen() {
   // the shared #6880 predicate hides (tool_use/thinking today). `system` stays a
   // separate inline check — isHiddenInCompactMode is specifically the compact-hide rule.
   //
-  // EXCEPT compaction markers (#6972). ChatView reinserts `compactMetadata`-
-  // carrying system messages inline via insertCompactionMarkers, because mobile
-  // has no System tab to send them to. That reinsertion reads the SAME
-  // `messages` array it is handed, so dropping them here left it filtering a
-  // list that could never contain one — dead code, and the marker was
-  // unreachable on mobile entirely. They still never reach the rendered groups
-  // through the normal path: buildChatViewMessages filters `type: 'system'`
-  // (buildChatViewMessages.ts:258) exactly as before, so this only makes them
-  // available to the reinsertion step.
+  // EXCEPT compaction markers (#6972). A compaction boundary is positional —
+  // it means "context was dropped HERE", between these two turns — so it has
+  // to sit inline in the chat flow. Reaching it on the System tab (which mobile
+  // does have, `viewMode === 'system'` below) is not equivalent: the marker
+  // separated from the messages it sits between conveys nothing.
+  //
+  // ChatView reinserts the `compactMetadata`-carrying subset via
+  // insertCompactionMarkers, and that reinsertion reads the SAME `messages`
+  // array it is handed — so dropping them here left it filtering a list that
+  // could never contain one. Dead code, and the marker was unreachable in the
+  // chat flow entirely (#7186).
+  //
+  // They still never reach the rendered groups through the normal path:
+  // buildChatViewMessages filters `type: 'system'` (buildChatViewMessages.ts:258)
+  // exactly as before, so this only makes them available to the reinsertion
+  // step. `systemMessages` below is unchanged, so they also still appear on the
+  // System tab.
   const chatMessages = useMemo(
     () => allMessages.filter((m) => {
       if (m.type === 'system') return m.compactMetadata != null;

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -186,9 +186,19 @@ export function SessionScreen() {
   // Filter messages: exclude system (separate tab) and, in compact mode, whatever
   // the shared #6880 predicate hides (tool_use/thinking today). `system` stays a
   // separate inline check — isHiddenInCompactMode is specifically the compact-hide rule.
+  //
+  // EXCEPT compaction markers (#6972). ChatView reinserts `compactMetadata`-
+  // carrying system messages inline via insertCompactionMarkers, because mobile
+  // has no System tab to send them to. That reinsertion reads the SAME
+  // `messages` array it is handed, so dropping them here left it filtering a
+  // list that could never contain one — dead code, and the marker was
+  // unreachable on mobile entirely. They still never reach the rendered groups
+  // through the normal path: buildChatViewMessages filters `type: 'system'`
+  // (buildChatViewMessages.ts:258) exactly as before, so this only makes them
+  // available to the reinsertion step.
   const chatMessages = useMemo(
     () => allMessages.filter((m) => {
-      if (m.type === 'system') return false;
+      if (m.type === 'system') return m.compactMetadata != null;
       if (chatFilterCompact && isHiddenInCompactMode(m.type)) return false;
       return true;
     }),


### PR DESCRIPTION
## Description

Closes #7186.

**The "Context compacted" marker has never rendered on mobile.** Not a flaky E2E flow — a real product bug that the flow was correctly reporting.

#6972 built the reinsertion right: `buildChatViewMessages` strips `type: 'system'` from the rendered groups, and `ChatView`'s `insertCompactionMarkers` puts the `compactMetadata`-carrying subset back inline, because mobile has no System tab to send them to.

But `SessionScreen` filtered every system message out **one layer above**, before `ChatView` saw anything:

```js
// SessionScreen.tsx:190 (before)
const chatMessages = useMemo(
  () => allMessages.filter((m) => {
    if (m.type === 'system') return false;   // ← markers die here
```

`insertCompactionMarkers` reads the *same* `messages` array it is handed:

```js
const markers = messages.filter((m) => m.type === 'system' && m.compactMetadata != null);
if (markers.length === 0) return displayGroups;
```

…so it was filtering a list that could never contain a system message. Dead code since it shipped.

## The fix

```js
if (m.type === 'system') return m.compactMetadata != null;
```

Markers still never reach the rendered groups by the normal path — `buildChatViewMessages.ts:258` drops `type: 'system'` exactly as before — so this only makes them **available to the reinsertion step**. The System tab and its unread badge read `systemMessages` off `allMessages` and are untouched.

## Verified on a real device, not just unit tests

Booted iPhone 16 Pro, the real Maestro flow, mock server + Metro:

| | result |
|---|---|
| before the fix | `Assert that id: compaction-marker is visible... FAILED` |
| after the fix | flow passes end to end, **0 failed steps** |
| fix reverted, assertions left fixed | `compaction-marker is visible... FAILED` again |

That last row is the one that matters — it proves the product change is what fixed it, not the assertion edits below.

## The flow also had two impossible assertions

`CompactionMarker` nests its segments inside a single accessible parent `<Text>`, and RN flattens those children into one node. Dumped the live hierarchy:

```
Context compacted · 128,000 → 12,000 tokens · 2s · auto
```

So an exact `text: "Context compacted"` and the nested `testID`s (`compaction-marker-tokens`, `compaction-marker-trigger`) are **not matchable there** — the documented gotcha in CLAUDE.md ("accessible containers flatten children so exact text matches need `.*wildcards.*`"). The token assertion beside them was already wildcarded; these were simply missed.

Those testIDs are already asserted by `CompactionMarker.test.tsx` via react-test-renderer, where flattening does not apply, so pinning them here would be both impossible and redundant. What this flow uniquely proves is that the marker **reached a real screen with the right content** — which is now what it asserts.

## Tests

`SessionScreen.test.ts` pinned the old `return false;` as source text; updated, plus a new assertion for the exception. App suite: **2328 pass**. Mutation-checked — reverting the fix fails exactly those two assertions and nothing else.

## Note on #7185

The sibling flow (`diff-comment.yaml`) is a separate defect and is not touched here.