### PR TITLE
test(app): fix the diff-comment flow's swallowed first tap

### DIFF
--- a/packages/app/.maestro/diff-comment.yaml
+++ b/packages/app/.maestro/diff-comment.yaml
@@ -65,8 +65,35 @@ name: DiffViewer inline comment submit
 - tapOn:
     id: "diff-comment-input"
 - inputText: "prefer a named constant"
-- tapOn:
-    id: "diff-comment-save"
+
+# Tap "Add comment" until the comment is actually queued.
+#
+# This is NOT flake-papering. With the keyboard up, the FIRST tap outside the
+# focused TextInput is consumed by the keyboard dismiss / blur and never
+# reaches the TouchableOpacity — Maestro still reports it COMPLETED, so the
+# failure surfaced two steps later as "diff-submit-comments is not visible"
+# and read like a product bug for a month (#7185). It is not: tapping the same
+# button a second time, on the same state, saves the comment normally.
+#
+# Ruled out first, each on-device: the save button is at y=322-358, well clear
+# of the keyboard, so it is not covered; `diff-action-bar` renders, so
+# showActionBar is true; and a plain wait after inputText does NOT help, so it
+# is a swallowed tap rather than a slow re-render.
+#
+# `repeat` rather than a bare double-tap: once the comment saves the editor
+# closes and `diff-comment-save` no longer exists, so a second unconditional
+# tapOn would fail to find it. This stops as soon as the submit control shows.
+# hideKeyboard would be the direct fix but is broken on the current Maestro
+# CLI (#6089).
+- repeat:
+    maxRuns: 3
+    while:
+      notVisible:
+        id: "diff-submit-comments"
+    commands:
+      - tapOn:
+          id: "diff-comment-save"
+      - waitForAnimationToEnd
 
 # The bottom action bar's Submit control appears once ≥1 comment is queued.
 - extendedWaitUntil:

--- a/packages/app/.maestro/diff-comment.yaml
+++ b/packages/app/.maestro/diff-comment.yaml
@@ -86,7 +86,12 @@ name: DiffViewer inline comment submit
 # hideKeyboard would be the direct fix but is broken on the current Maestro
 # CLI (#6089).
 - repeat:
-    maxRuns: 3
+    # `times`, not `maxRuns`. YamlRepeatCommand exposes times/while/commands/
+    # label/optional and nothing else (javap on maestro-orchestra.jar), and an
+    # unknown key here is silently IGNORED rather than rejected — so `maxRuns`
+    # parsed fine and left the loop bounded only by `while`, i.e. unbounded if
+    # the save genuinely broke. Caught in review on #7202.
+    times: 3
     while:
       notVisible:
         id: "diff-submit-comments"


### PR DESCRIPTION
## Description

Closes #7185.

`diff-comment.yaml` has failed every night since it landed, and it read like a product bug — *"`diff-submit-comments` is not visible"* after saving a comment. **The product is fine.**

With the keyboard up, the **first tap outside the focused `TextInput` is consumed by the keyboard dismiss / blur** and never reaches the `TouchableOpacity`. Maestro reports that tap `COMPLETED` either way, so the failure surfaced two steps later and pointed at the wrong component.

## How it was established, on-device

Reproduced the nightly failure locally first, then dumped the live accessibility hierarchy at the failure point:

```
diff-action-bar:            1    <- showActionBar is true
diff-submit-comments:       0    <- no comment queued
diff-comment-input:         1    <- editor STILL OPEN
diff-comment-save:          1
"prefer a named constant"        <- the text did land
```

The editor still being open means `handleSaveComment` never ran — it ends with `setEditing(null)`. So the tap did not reach the button.

Then the decisive test — tapping that same button, on that same state, with **no code change**:

```
Tap on id: diff-comment-save... COMPLETED
Assert that id: diff-submit-comments is visible... COMPLETED
```

It saves normally. Nothing is broken in `DiffViewer`.

### What was ruled out, each on-device

| hypothesis | result |
|---|---|
| Save button covered by the keyboard | **No** — it sits at y=322–358, well clear |
| `showActionBar` false (no files / loading / error) | **No** — `diff-action-bar` renders |
| Text never reached the input | **No** — the text is in the hierarchy |
| Slow React re-render (pure timing) | **No** — asserting the text *and* adding `waitForAnimationToEnd` both still fail |

That last row is what rules out a timing fix and leaves the swallowed tap.

## The fix

Retry until the comment is actually queued:

```yaml
- repeat:
    maxRuns: 3
    while:
      notVisible:
        id: "diff-submit-comments"
    commands:
      - tapOn:
          id: "diff-comment-save"
      - waitForAnimationToEnd
```

`repeat` rather than an unconditional double-tap: once the save lands the editor closes and `diff-comment-save` no longer exists, so a second bare `tapOn` would fail to find it. This stops as soon as the submit control appears, so it is correct whether the first tap is swallowed or not.

`hideKeyboard` would be the direct fix but is broken on the current Maestro CLI (#6089), which the flow's own header already noted.

## Verification

Three consecutive full runs of the real flow against a booted iPhone 16 Pro:

```
run 1 FAILED steps: 0
run 2 FAILED steps: 0
run 3 FAILED steps: 0
```

## Nightly status after this

`compaction-marker` was a genuine product bug, fixed in #7200. This was the other flow in the nightly's failing set — with both landed, the two known failures are addressed.