### PR TITLE
fix(app): keep taps alive over the diff comment editor's scroll views

### DIFF
--- a/packages/app/src/components/DiffViewer.tsx
+++ b/packages/app/src/components/DiffViewer.tsx
@@ -254,8 +254,21 @@ function FileDiffView({
           </Text>
         </View>
       </View>
-      <ScrollView style={styles.diffScroll} contentContainerStyle={styles.diffScrollContent}>
-        <ScrollView horizontal showsHorizontalScrollIndicator>
+      {/* keyboardShouldPersistTaps on BOTH: the inline comment editor's Save /
+          Cancel buttons live inside these scroll views, and the comment input
+          autofocuses — so with RN's default of 'never', the first tap after
+          typing is consumed by the keyboard dismiss and never reaches the
+          button. The user taps "Add comment", nothing happens, and only a
+          second tap works (#7203; surfaced by the Maestro flow in #7185).
+          The prop is per-ScrollView, so setting it only on the outer one
+          leaves the inner one still swallowing the tap. 'handled' rather than
+          'always' keeps tap-to-dismiss working everywhere else in the diff. */}
+      <ScrollView
+        style={styles.diffScroll}
+        contentContainerStyle={styles.diffScrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <ScrollView horizontal showsHorizontalScrollIndicator keyboardShouldPersistTaps="handled">
           <View>
             {file.hunks.map((hunk, i) => (
               <DiffHunkView key={i} hunk={hunk} filePath={file.path} hunkIndex={i} commentApi={commentApi} />


### PR DESCRIPTION
## Description

Closes #7203.

The inline comment editor's Save / Cancel buttons sit inside two nested `ScrollView`s (`DiffViewer.tsx:257-258`), neither of which sets `keyboardShouldPersistTaps`. React Native's default is `'never'`, [documented](https://reactnative.dev/docs/scrollview#keyboardshouldpersisttaps) as: tapping outside the focused text input while the keyboard is up dismisses the keyboard, and **the children do not receive that tap**.

The comment input autofocuses, so a user who types and taps "Add comment" **once** has that tap eaten and sees nothing happen. A second tap works. That is what #7185's flow had been reporting for a month, and #7202 worked around it at the test layer.

## Change

`keyboardShouldPersistTaps="handled"` on **both** scroll views. The prop is per-`ScrollView`, so setting only the outer one leaves the inner one swallowing the tap. `"handled"` rather than `"always"` keeps tap-to-dismiss working everywhere else in the diff.

This matches the established idiom — `ConnectScreen.tsx:480`, `InputBar.tsx:287/352/397`, and `CreateSessionModal.tsx:219` all already use `"handled"`.

## ⚠️ I could not demonstrate this on-device — read before merging

The swallowed tap **did** reproduce reliably earlier in this session (single tap failed; a second tap on the same state saved the comment). It no longer does, and the reason is not that the bug went away:

```
$ maestro --device 0AD31F77… hierarchy   # editor open, input focused
  Keyboard  : 0
  key-      : 0
  shift     : 0
  space     : 0
```

**There is no software keyboard on screen.** The simulator is running with a hardware keyboard attached, so the keyboard-dismiss path this prop governs is never taken.

A clean A/B is therefore inconclusive — with a proper 25s settle between edits, both arms pass twice:

| | run 1 | run 2 |
|---|---|---|
| **without** the fix | 0 failures | 0 failures |
| **with** the fix | 0 failures | 0 failures |

Neither arm exercises the code path, so that table proves nothing about the fix. I am reporting it rather than quoting the passing runs as verification.

**What this rests on instead:** the RN documentation, the five existing uses of `"handled"` in this repo, and the earlier live reproduction of the exact symptom. Real users always have a software keyboard, so the path they hit is precisely the one this simulator cannot exercise.

**Recommendation:** keep #7202's retry loop until this is confirmed on real hardware or on a simulator with the software keyboard forced on (Cmd+K / `ConnectHardwareKeyboard = false`). The retry is harmless if this fix is correct, and still necessary if it is not.

## Tests

App suite: **2328 pass**. No behavioural unit coverage is added — the prop's effect only manifests in the RN gesture responder with a live keyboard, which is exactly what could not be reproduced here.