### PR TITLE
fix(cli): self-check store-core's entry points through the manifest it wrote

### DIFF
--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -128,17 +128,37 @@ for (const k of Object.keys(out)) if (out[k] === undefined) delete out[k]
 // is wanted: a stray `files` here would be one more thing to keep in sync.
 writeFileSync(join(outDir, 'package.json'), JSON.stringify(out, null, 2) + '\n')
 
-// 3. Prove both declared entry points actually load under Node before anyone
-//    publishes. This is the check whose absence let 0.11.0's packaging break
-//    silently: the tarball installed fine and only failed on first import.
-//    Resolved against the real dist so a missing extension or a bad crypto
-//    rewrite fails the build, not the user.
-for (const [label, entry] of [['.', 'dist/index.js'], ['./crypto', 'dist/crypto.js']]) {
+// 3. Prove every entry point the generated manifest DECLARES actually loads
+//    under Node before anyone publishes. This is the check whose absence let
+//    0.11.0's packaging break silently: the tarball installed fine and only
+//    failed on first import.
+//
+//    The targets are read back OUT of the manifest just written, not listed
+//    here. A hardcoded literal list would import the known-good file directly
+//    and print ✓ even when `exports` points somewhere wrong — so a typo or a
+//    stale path after a refactor would sail through this check and fail only
+//    for the npm consumer, who resolves through `exports` (#7197). Reading the
+//    manifest also means a newly-added export is covered automatically instead
+//    of silently falling outside the check.
+const manifest = JSON.parse(readFileSync(join(outDir, 'package.json'), 'utf8'))
+const declared = Object.entries(manifest.exports)
+  .map(([label, spec]) => [label, typeof spec === 'string' ? spec : spec.import])
+  .filter(([, target]) => target)
+
+if (!declared.length) throw new Error('generated manifest declares no exports — nothing to verify')
+
+for (const [label, target] of declared) {
+  // `target` is manifest-relative ('./dist/index.js'), resolved against the
+  // staging dir — the same base a consumer resolves it against.
+  const file = new URL(target, `file://${outDir}/`)
+  if (!existsSync(file)) {
+    throw new Error(`manifest exports "${label}" -> ${target}, which does not exist in the package`)
+  }
   try {
-    await import(new URL(`publish/${entry}`, `file://${pkgDir}/`).href)
-    console.log(`  ✓ "${label}" entry imports under Node`)
+    await import(file.href)
+    console.log(`  ✓ "${label}" -> ${target} imports under Node`)
   } catch (err) {
-    throw new Error(`published "${label}" entry (${entry}) fails to import: ${err.message}`)
+    throw new Error(`published "${label}" entry (${target}) fails to import: ${err.message}`)
   }
 }
 

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -31,7 +31,7 @@
 
 import { execFileSync } from 'node:child_process'
 import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, join, resolve } from 'node:path'
 
 // The source imports siblings without a file extension (`from './types'`), which
@@ -149,8 +149,11 @@ if (!declared.length) throw new Error('generated manifest declares no exports �
 
 for (const [label, target] of declared) {
   // `target` is manifest-relative ('./dist/index.js'), resolved against the
-  // staging dir — the same base a consumer resolves it against.
-  const file = new URL(target, `file://${outDir}/`)
+  // staging dir — the same base a consumer resolves it against. pathToFileURL
+  // rather than a `file://` template: the template mangles Windows paths (drive
+  // letters, backslashes) and anything needing percent-encoding, and this repo
+  // runs Windows CI.
+  const file = new URL(target, pathToFileURL(join(outDir, '/')))
   if (!existsSync(file)) {
     throw new Error(`manifest exports "${label}" -> ${target}, which does not exist in the package`)
   }


### PR DESCRIPTION
## Description

Closes #7197.

`build-publish-dir.mjs` ends by proving both entry points load under Node — but it imported a **hardcoded literal list** of paths rather than the targets in the `exports` object it had just generated:

```js
for (const [label, entry] of [['.', 'dist/index.js'], ['./crypto', 'dist/crypto.js']]) {
```

So if the manifest ever pointed somewhere wrong — a typo, a stale path after a refactor — the check imported the *known-good* file directly, printed `✓`, and the break surfaced only for the npm consumer, who resolves through `exports`.

That is the same false-safety shape the check exists to catch. It was verifying files it already knew were fine, not the contract it had just written.

## Change

Read the targets back out of the generated manifest, assert each exists, then import it. Two consequences beyond the reported bug:

- a bad path fails with a message naming the export **and** its target
- a newly-added export is covered **automatically** instead of silently falling outside the check — the same reasoning that took #7192's verifier from 4 hardcoded entry points to 6 derived ones

## Verification

Using the exact reproduction from #7197 — pointing `exports['.']` at `./dist/index-typo.js`:

| | behaviour |
|---|---|
| **before** | prints `✓`, exits **0** |
| **after** | `Error: manifest exports "." -> ./dist/index-typo.js, which does not exist in the package`, exits **1** |

Healthy build still exits 0, and now names what it actually checked:

```
  ✓ "." -> ./dist/index.js imports under Node
  ✓ "./crypto" -> ./dist/crypto.js imports under Node
```

store-core: **2131 tests pass**. Committed `packages/store-core/dist/` untouched (`git status --porcelain` clean), which matters here because this script runs `tsc` and the postbuild rewrite.