### PR TITLE
fix(ci): realpath both sides of gen-agents-md's entry-point guard

### DIFF
--- a/scripts/__tests__/gen-agents-md.test.mjs
+++ b/scripts/__tests__/gen-agents-md.test.mjs
@@ -11,7 +11,10 @@
  *   node scripts/__tests__/gen-agents-md.test.mjs
  */
 
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -65,6 +68,46 @@ await test('committed AGENTS.md is in sync with CLAUDE.md (drift gate)', async (
     committed === expected,
     'AGENTS.md is stale — run `node scripts/gen-agents-md.mjs` and commit AGENTS.md'
   )
+})
+
+
+// #7198 — the entry-point guard must survive a symlinked invocation path.
+//
+// Node's ESM loader resolves symlinks in `import.meta.url` but leaves
+// `process.argv[1]` as the caller typed it, and `resolve()` does not follow
+// symlinks. On macOS /tmp is a symlink to /private/tmp, so invoking
+// `node /tmp/…/gen-agents-md.mjs` compared '/private/tmp/…' against '/tmp/…',
+// the guard was false, and the script exited 0 having regenerated NOTHING.
+// bump-version.sh calls this and trusts the exit code, so a release could
+// silently skip the regeneration and still report success.
+await test('runs through a symlinked invocation path (#7198)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'genagents-'))
+  try {
+    // Mirror the real layout: the generator resolves CLAUDE.md / AGENTS.md
+    // relative to its own parent directory, i.e. the repo root.
+    const root = join(dir, 'root')
+    const link = join(dir, 'link')
+    mkdirSync(join(root, 'scripts'), { recursive: true })
+    symlinkSync(root, link)
+
+    cpSync(scriptPath, join(root, 'scripts', 'gen-agents-md.mjs'))
+    cpSync(resolve(__dirname, '..', '..', 'CLAUDE.md'), join(root, 'CLAUDE.md'))
+    writeFileSync(join(root, 'AGENTS.md'), 'STALE\n')
+
+    const run = spawnSync(process.execPath, [join(link, 'scripts', 'gen-agents-md.mjs')], { encoding: 'utf8' })
+    assert(run.status === 0, `expected exit 0, got ${run.status}: ${run.stderr}`)
+    assert(
+      readFileSync(join(root, 'AGENTS.md'), 'utf8') !== 'STALE\n',
+      'generator silently no-opped when invoked through a symlinked path'
+    )
+
+    // --check must FAIL on drift through that same path, not pass silently.
+    writeFileSync(join(root, 'AGENTS.md'), 'STALE\n')
+    const checked = spawnSync(process.execPath, [join(link, 'scripts', 'gen-agents-md.mjs'), '--check'], { encoding: 'utf8' })
+    assert(checked.status === 1, `--check should exit 1 on drift, got ${checked.status}`)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 // --- summary --------------------------------------------------------------

--- a/scripts/gen-agents-md.mjs
+++ b/scripts/gen-agents-md.mjs
@@ -12,7 +12,7 @@
 // Keeping CLAUDE.md as the ONE source and generating AGENTS.md means the two can
 // never drift and a convention can never be silently dropped from the mirror.
 
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join, resolve } from 'node:path'
 
@@ -62,9 +62,35 @@ export function readAgentsMd() {
 }
 
 // Only run the CLI side-effects when invoked directly (not when imported by tests).
-// Normalize both sides: process.argv[1] may be relative depending on how node was
-// invoked, while fileURLToPath(import.meta.url) is absolute.
-if (process.argv[1] && resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])) {
+//
+// Both sides are realpath'd, not just `resolve`d. Node's ESM loader resolves
+// symlinks in `import.meta.url`, but `process.argv[1]` is left exactly as the
+// caller typed it, and `resolve()` does not follow symlinks — so on macOS,
+// where /tmp is a symlink to /private/tmp, invoking this as
+// `node /tmp/…/gen-agents-md.mjs` gave '/private/tmp/…' on one side and
+// '/tmp/…' on the other. The guard was false, the CLI branch never ran, and
+// the script exited 0 having done nothing (#7198).
+//
+// That silence is the dangerous part: bump-version.sh calls this and trusts
+// the exit code, so a release could regenerate nothing and still report
+// success — the same shape as every other guard-that-quietly-no-ops fixed
+// this cycle. realpathSync is wrapped because argv[1] need not exist (an
+// `-e` eval, a deleted script); an unresolvable path simply is not this file.
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false
+  const realpathOrNull = (p) => {
+    try {
+      return realpathSync(p)
+    } catch {
+      return null
+    }
+  }
+  const self = realpathOrNull(fileURLToPath(import.meta.url))
+  const argv = realpathOrNull(resolve(process.argv[1]))
+  return self !== null && self === argv
+})()
+
+if (invokedDirectly) {
   const expected = renderAgentsMd(readClaudeMd())
   if (process.argv.includes('--check')) {
     if (readAgentsMd() !== expected) {


### PR DESCRIPTION
## Description

Closes #7198.

`gen-agents-md.mjs` guards its CLI side-effects with:

```js
if (process.argv[1] && resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])) {
```

Node's ESM loader **resolves symlinks** in `import.meta.url`, but leaves `process.argv[1]` exactly as the caller typed it — and `resolve()` does not follow symlinks. On macOS `/tmp` is a symlink to `/private/tmp`:

```
$ node -e "console.log(resolve('/tmp/x.mjs'))"
/tmp/x.mjs          # vs '/private/tmp/x.mjs' from import.meta.url  -> not equal
```

So the guard was false, the CLI branch never ran, and the script **exited 0 having done nothing.**

## Reproduced before fixing

Not inferred from the source — run against a real copy through `/tmp`, with `AGENTS.md` deliberately drifted:

```
$ node /tmp/garepro/scripts/gen-agents-md.mjs
  exit=0
  still drifted? True     <- silently regenerated nothing
```

## Why the silence matters

`bump-version.sh` calls this and trusts the exit code, so **a release could skip the AGENTS.md regeneration and still report success**. And `--check` — the CI drift gate — would pass on a stale file for exactly the same reason, since the branch that performs the check never executes.

That is the same shape as the other guards-that-quietly-no-op addressed this cycle (#7183's skipped pattern, #7197's hardcoded self-check paths): the check reports success by not running.

## Fix

`realpathSync` both sides, wrapped because `argv[1]` need not exist (an `-e` eval, a deleted script) — an unresolvable path simply is not this file.

The import path is deliberately unaffected: the guard must stay false when the module is imported by the test harness, and that is asserted (the suite imports it and the existing three assertions still pass).

## Verification

| scenario | before | after |
|---|---|---|
| run via symlinked `/tmp` path | exit 0, no regeneration | regenerates ✓ |
| `--check` via symlinked path, drifted | would pass silently | **exit 1** ✓ |
| run via real `/private` path | works | works ✓ |
| imported by tests | guard false | guard false ✓ |

Regression test added and **mutation-checked** — restoring the `resolve()`-only guard fails exactly that test and nothing else:

```
  ok   render includes the entire CLAUDE.md body unmodified
  ok   render prepends the auto-generated / do-not-edit header
  ok   committed AGENTS.md is in sync with CLAUDE.md (drift gate)
  FAIL runs through a symlinked invocation path (#7198): generator silently no-opped
  3 passed, 1 failed
```

Scripts suite: **18 pass**.