### PR TITLE
fix(cli): walk every export condition, and fail on shapes we cannot check

### DIFF
--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -167,6 +167,14 @@ function exportTargets(spec) {
 }
 
 const declared = Object.entries(manifest.exports).flatMap(([label, spec]) => {
+  // `null` is Node's documented way to BLOCK a subpath, not a shape we failed
+  // to read. npm accepts the manifest and Node refuses the path at resolution
+  // (ERR_PACKAGE_PATH_NOT_EXPORTED), so there is genuinely nothing to import
+  // and nothing is wrong. Throwing here would fail the build on a valid
+  // manifest — and `build:publish` runs in release.yml's verify-artifacts job
+  // on every v* tag, so that would block a release rather than catch a bug.
+  if (spec === null) return []
+
   const targets = [...new Set(exportTargets(spec))]
   // An export that yields no target at all is a shape this script cannot
   // check. Throw rather than filter it away — being unable to verify an

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -156,6 +156,18 @@ const manifest = JSON.parse(readFileSync(join(outDir, 'package.json'), 'utf8'))
 // broken .d.ts would still pass it. Runtime conditions only.
 const TYPE_ONLY_CONDITIONS = new Set(['types', 'typings'])
 
+// Arrays ARE valid here — Node treats them as a fallback list and resolves the
+// first entry whose conditions match (verified against Node 22, both a
+// single-entry array and a condition-fallback array resolve). They fall through
+// to the object branch below via Object.entries, which collects every string
+// leaf.
+//
+// Known over-strictness: for a genuine fallback array, Node needs only ONE
+// entry to resolve, whereas this collects all of them and would fail the build
+// if any were missing. Left as-is deliberately — this script GENERATES the
+// manifest it checks and only ever emits { types, import }, so an array cannot
+// occur without someone editing the generator, at which point the over-strict
+// failure is a loud prompt to revisit this rather than a silent wrong answer.
 function exportTargets(spec) {
   if (typeof spec === 'string') return [spec]
   if (spec && typeof spec === 'object') {

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -141,9 +141,45 @@ writeFileSync(join(outDir, 'package.json'), JSON.stringify(out, null, 2) + '\n')
 //    manifest also means a newly-added export is covered automatically instead
 //    of silently falling outside the check.
 const manifest = JSON.parse(readFileSync(join(outDir, 'package.json'), 'utf8'))
-const declared = Object.entries(manifest.exports)
-  .map(([label, spec]) => [label, typeof spec === 'string' ? spec : spec.import])
-  .filter(([, target]) => target)
+// Collect EVERY string leaf under an export's condition object, not just
+// `.import`. A condition map can nest arbitrarily ({ node: { import: … },
+// default: … }), and reading one known key meant a `require`-only or nested
+// entry contributed no targets and was quietly dropped from `declared` — the
+// same silent-skip this check exists to prevent, one level down (#7210).
+//
+// Not reachable with the manifest this script generates today, which only
+// emits { types, import }. It is guarded anyway because the failure mode is
+// invisible: the build exits 0 and simply never mentions the export.
+// `types` is skipped deliberately: it is a TypeScript-only condition that Node
+// never resolves at runtime. Importing a .d.ts "succeeds" and yields zero
+// exports, so checking it would add a ✓ that means nothing — and a genuinely
+// broken .d.ts would still pass it. Runtime conditions only.
+const TYPE_ONLY_CONDITIONS = new Set(['types', 'typings'])
+
+function exportTargets(spec) {
+  if (typeof spec === 'string') return [spec]
+  if (spec && typeof spec === 'object') {
+    return Object.entries(spec)
+      .filter(([condition]) => !TYPE_ONLY_CONDITIONS.has(condition))
+      .flatMap(([, value]) => exportTargets(value))
+  }
+  return []
+}
+
+const declared = Object.entries(manifest.exports).flatMap(([label, spec]) => {
+  const targets = [...new Set(exportTargets(spec))]
+  // An export that yields no target at all is a shape this script cannot
+  // check. Throw rather than filter it away — being unable to verify an
+  // export is not the same as there being nothing to verify, and conflating
+  // them is how the original bug read as success.
+  if (!targets.length) {
+    throw new Error(
+      `manifest exports "${label}" in a shape with no resolvable target ` +
+      `(${JSON.stringify(spec)}) — build-publish-dir cannot verify it`,
+    )
+  }
+  return targets.map((target) => [label, target])
+})
 
 if (!declared.length) throw new Error('generated manifest declares no exports — nothing to verify')
 


### PR DESCRIPTION
## Description

Closes #7210.

Review of #7205 found the **same silent-skip one level down, inside the fix for it**. The derivation read only `.import`:

```js
.map(([label, spec]) => [label, typeof spec === 'string' ? spec : spec.import])
.filter(([, target]) => target)
```

So a `require`-only or nested-condition export contributed no target, was quietly dropped by the `.filter`, and the build exited 0 **without ever mentioning it** — exactly the failure mode this check exists to prevent. My own PR's claim that "a newly-added export is covered automatically" did not hold for those shapes: newly added, not covered, and nothing said so.

## Changes

**Walk every string leaf** under the condition object, however nested.

**Throw when an export yields no target at all.** Being unable to verify an export is not the same as there being nothing to verify — conflating those is precisely how the original bug read as success. The error names the offending shape.

**Skip `types` / `typings` deliberately.** They are TypeScript-only conditions Node never resolves at runtime. Verified concretely rather than assumed:

```
$ node -e "import('./publish/dist/crypto.d.ts').then(m => console.log(Object.keys(m).length))"
0
```

Importing a `.d.ts` "succeeds" and yields zero exports — so checking one adds a `✓` that means nothing, and a genuinely broken `.d.ts` would still pass it. A first cut of this patch included them and produced exactly that noise.

## Verification

Against the two shapes the review proved were skipped, plus a new edge case:

| manifest shape | before | after |
|---|---|---|
| `'./cjs-only': { require: './dist/nope.cjs' }` | exit 0, silently skipped | **exit 1** ✓ |
| `'./nested': { node: { import: … }, default: … }` | exit 0, silently skipped | **exit 1** ✓ |
| `'./types-only': { types: './x.d.ts' }` (no runtime target) | exit 0 | **exit 1**, names the shape ✓ |
| healthy manifest | exit 0 | exit 0, runtime entries only ✓ |

```
  ✓ "." -> ./dist/index.js imports under Node
  ✓ "./crypto" -> ./dist/crypto.js imports under Node
```

store-core: **2131 tests pass**. Committed `packages/store-core/dist/` byte-identical.

## Note

This is the fifth instance this session of one pattern: a guard that reports success without checking. Worth a written convention once the queue drains, since every instance passed all existing tests.