### PR TITLE
fix: sweep every entry-point guard for the symlink mismatch

### DIFF
--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -1282,6 +1282,16 @@ export class PodAgent {
 // (#7213).
 const invokedDirectly = (() => {
   if (!process.argv[1]) return false
+  // The plain comparison runs first and is conclusive on its own: identical
+  // paths mean this IS the entry point, decided without touching the
+  // filesystem. Consulting realpath first and reading a failure as false lets
+  // an EACCES on a parent directory (or a script unlinked after launch) turn a
+  // direct run into a silent exit-0 no-op — the exact class this guard exists
+  // to remove (#7217 review). Realpath is only needed when the paths differ,
+  // where a symlink is the sole thing that can still make them one file.
+  const self = fileURLToPath(import.meta.url)
+  const invoked = resolve(process.argv[1])
+  if (self === invoked) return true
   const real = (p) => {
     try {
       return realpathSync(p)
@@ -1289,9 +1299,9 @@ const invokedDirectly = (() => {
       return null
     }
   }
-  const self = real(fileURLToPath(import.meta.url))
-  const invoked = real(resolve(process.argv[1]))
-  return self !== null && self === invoked
+  const realSelf = real(self)
+  const realInvoked = real(invoked)
+  return realSelf !== null && realSelf === realInvoked
 })()
 
 if (invokedDirectly) {

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -13,9 +13,9 @@ import { createServer } from 'node:http'
 import { createInterface } from 'node:readline'
 import { spawn as nodeSpawn } from 'node:child_process'
 import { timingSafeEqual, randomUUID } from 'node:crypto'
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { Transform } from 'node:stream'
 import { WebSocketServer } from 'ws'
 
@@ -1274,7 +1274,27 @@ export class PodAgent {
 // Entrypoint — only runs when executed directly, not when imported in tests.
 // ---------------------------------------------------------------------------
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+// Realpath both sides. Node's ESM loader resolves symlinks in
+// `import.meta.url` while argv[1] is whatever the caller typed, so a raw
+// comparison also breaks on any relative invocation (`node ./agent.js`).
+// This is a standalone in-pod bundle with its own package.json, so it cannot
+// import packages/server/src/utils/is-entry-point.js — duplicated on purpose
+// (#7213).
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false
+  const real = (p) => {
+    try {
+      return realpathSync(p)
+    } catch {
+      return null
+    }
+  }
+  const self = real(fileURLToPath(import.meta.url))
+  const invoked = real(resolve(process.argv[1]))
+  return self !== null && self === invoked
+})()
+
+if (invokedDirectly) {
   const agent = new PodAgent()
   agent.listen(PORT).catch((err) => {
     console.error('[chroxy-pod-agent] Failed to start:', err)

--- a/packages/server/src/channels/chroxy-channel-server.js
+++ b/packages/server/src/channels/chroxy-channel-server.js
@@ -31,7 +31,7 @@
  * bridge (#3954) replaces this with a Unix socket driven solely by the session.
  */
 import { createServer } from 'http'
-import { pathToFileURL } from 'url'
+import { isEntryPoint } from '../utils/is-entry-point.js'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
@@ -238,8 +238,7 @@ export async function main() {
 // against pathToFileURL(process.argv[1]) — argv[1] can be a RELATIVE path (e.g.
 // `node ./chroxy-channel-server.js`), so a naive `file://${argv[1]}` would never
 // match the absolute `import.meta.url` and main() would silently never run.
-const isDirectRun = process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
+const isDirectRun = isEntryPoint(import.meta.url)
 if (isDirectRun) {
   main().catch(err => {
     console.error('[chroxy-channel] fatal:', err)

--- a/packages/server/src/server-cli-child.js
+++ b/packages/server/src/server-cli-child.js
@@ -15,7 +15,7 @@
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { pathToFileURL } from 'url'
+import { isEntryPoint } from './utils/is-entry-point.js'
 import { mergeConfig } from './config.js'
 import { createLogger } from './logger.js'
 
@@ -162,9 +162,11 @@ async function handleDrain(timeout) {
 // entry point. When imported (e.g. unit tests of flushAndDestroy) these side
 // effects must NOT fire — registering crash handlers or starting the server on
 // import would corrupt the test runner. #5308 / WP-0.2.
-const isEntryPoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+// Shared helper: a symlinked invocation path made every hand-rolled
+// version of this comparison read false (#7213).
+const isModuleEntryPoint = isEntryPoint(import.meta.url)
 
-if (isEntryPoint) {
+if (isModuleEntryPoint) {
   // Listen for IPC messages from supervisor
   if (process.send) {
     process.on('message', async (msg) => {

--- a/packages/server/src/utils/is-entry-point.js
+++ b/packages/server/src/utils/is-entry-point.js
@@ -34,19 +34,42 @@ import { fileURLToPath } from 'node:url'
 /**
  * True when `importMetaUrl`'s module is the script node was invoked with.
  *
- * Both sides are realpath'd so a symlinked invocation path still matches.
- * Anything that cannot be resolved to a real file — argv[1] absent (an `-e`
- * eval, a REPL), a deleted script, a path we lack permission to stat — is
- * simply not this module, so the guard is false and the caller behaves as if
- * imported. That is the safe direction: a missed CLI run is loud (nothing
- * happens and the user notices), whereas side effects firing during an import
- * would corrupt a test run.
+ * Order matters. The plain (non-realpath) comparison runs FIRST and is
+ * conclusive on its own: if the two paths are already identical, this module
+ * is the entry point and no filesystem access is needed to say so. Only when
+ * they differ is realpath consulted, because the sole reason they can differ
+ * while still naming the same file is a symlink somewhere in the invocation
+ * path.
+ *
+ * That ordering is the point, not an optimisation. Reaching for realpath
+ * first and treating a failure as `false` recreates the very bug this module
+ * exists to remove: an `EACCES` on some parent directory, or a script
+ * unlinked after launch, would make a direct `node foo.js` evaluate false,
+ * `main()` would never run, and the process would exit 0 having done nothing
+ * (#7217 review). Doing the cheap comparison first means no filesystem error
+ * can reach the common case at all.
+ *
+ * The one genuinely undecidable case is left: paths that differ AND cannot be
+ * realpath'd. Whether a symlink joins them is unknowable without the
+ * filesystem call that just failed, and `false` is the only defensible answer
+ * — it is also strictly better than the pre-#7213 behaviour, which got that
+ * case wrong even when realpath would have succeeded.
+ *
+ * argv[1] absent (an `-e` eval, a REPL) means there is no invoked script, so
+ * nothing can be the entry point.
  *
  * @param {string} importMetaUrl - the calling module's `import.meta.url`
  * @returns {boolean}
  */
 export function isEntryPoint(importMetaUrl) {
   if (!process.argv[1]) return false
+
+  const self = fileURLToPath(importMetaUrl)
+  const invoked = resolve(process.argv[1])
+  if (self === invoked) return true
+
+  // Paths differ — a symlink is the only thing that still makes them the same
+  // file, so this is where realpath earns its keep.
   const real = (p) => {
     try {
       return realpathSync(p)
@@ -54,7 +77,7 @@ export function isEntryPoint(importMetaUrl) {
       return null
     }
   }
-  const self = real(fileURLToPath(importMetaUrl))
-  const invoked = real(resolve(process.argv[1]))
-  return self !== null && self === invoked
+  const realSelf = real(self)
+  const realInvoked = real(invoked)
+  return realSelf !== null && realSelf === realInvoked
 }

--- a/packages/server/src/utils/is-entry-point.js
+++ b/packages/server/src/utils/is-entry-point.js
@@ -1,0 +1,60 @@
+// is-entry-point.js — "was this module run directly, or imported?"
+//
+// Every hand-rolled version of this check in the repo was wrong the same way,
+// so there is one implementation now (#7213, after #7198).
+//
+// The trap: Node's ESM loader RESOLVES SYMLINKS in `import.meta.url`, but
+// `process.argv[1]` is whatever the caller typed. Neither `resolve()` nor
+// `pathToFileURL()` follows symlinks, so every one of these compares a
+// realpath against a non-realpath:
+//
+//   resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])
+//   import.meta.url === pathToFileURL(process.argv[1]).href
+//   process.argv[1] === fileURLToPath(import.meta.url)
+//
+// On macOS /tmp is a symlink to /private/tmp, so running a script by a /tmp
+// path gives 'file:///private/tmp/x.mjs' on one side and 'file:///tmp/x.mjs'
+// on the other. The guard reads false, main() never runs, and the process
+// exits 0 having done nothing — the failure is silence, which is why it
+// survived in four separate files.
+//
+// Demonstrated:
+//   import.meta.url        : file:///private/tmp/ptfu/probe.mjs
+//   pathToFileURL(argv[1]) : file:///tmp/ptfu/probe.mjs
+//   guard would be         : false
+//
+// Usage:
+//   import { isEntryPoint } from './utils/is-entry-point.js'
+//   if (isEntryPoint(import.meta.url)) { main() }
+
+import { realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * True when `importMetaUrl`'s module is the script node was invoked with.
+ *
+ * Both sides are realpath'd so a symlinked invocation path still matches.
+ * Anything that cannot be resolved to a real file — argv[1] absent (an `-e`
+ * eval, a REPL), a deleted script, a path we lack permission to stat — is
+ * simply not this module, so the guard is false and the caller behaves as if
+ * imported. That is the safe direction: a missed CLI run is loud (nothing
+ * happens and the user notices), whereas side effects firing during an import
+ * would corrupt a test run.
+ *
+ * @param {string} importMetaUrl - the calling module's `import.meta.url`
+ * @returns {boolean}
+ */
+export function isEntryPoint(importMetaUrl) {
+  if (!process.argv[1]) return false
+  const real = (p) => {
+    try {
+      return realpathSync(p)
+    } catch {
+      return null
+    }
+  }
+  const self = real(fileURLToPath(importMetaUrl))
+  const invoked = real(resolve(process.argv[1]))
+  return self !== null && self === invoked
+}

--- a/packages/server/tests/is-entry-point.test.js
+++ b/packages/server/tests/is-entry-point.test.js
@@ -1,0 +1,125 @@
+// is-entry-point.test.js — pins the one entry-point guard (#7213, #7217).
+//
+// The guard's failure mode is SILENCE: it returns false, main() never runs,
+// and the process exits 0. Nothing observable distinguishes that from a clean
+// no-op, which is how the bug survived in four files. So every case here
+// asserts the boolean directly rather than any downstream side effect.
+//
+// `process.argv[1]` is read at call time, which is what makes these tests
+// possible in-process: each one points argv[1] at a path it controls and
+// restores it afterwards.
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { isEntryPoint } from '../src/utils/is-entry-point.js'
+
+let dir
+let realDir
+let linkDir
+let realScript
+let linkedScript
+
+before(() => {
+  // The base is deliberately NOT realpath'd. On macOS os.tmpdir() is under
+  // /var, itself a symlink to /private/var — so these paths carry a real
+  // unresolved symlink, the same shape as the /tmp case that started this.
+  dir = mkdtempSync(join(tmpdir(), 'chroxy-entry-'))
+  realDir = join(dir, 'real')
+  linkDir = join(dir, 'link')
+  mkdirSync(realDir)
+  realScript = join(realDir, 'probe.js')
+  writeFileSync(realScript, 'export const x = 1\n')
+  symlinkSync(realDir, linkDir, 'dir')
+  linkedScript = join(linkDir, 'probe.js')
+})
+
+after(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const withArgv1 = (value, fn) => {
+  const saved = process.argv[1]
+  process.argv[1] = value
+  try {
+    return fn()
+  } finally {
+    process.argv[1] = saved
+  }
+}
+
+describe('isEntryPoint', () => {
+  it('is true when the module IS the invoked script', () => {
+    withArgv1(realScript, () => {
+      assert.equal(isEntryPoint(pathToFileURL(realScript).href), true)
+    })
+  })
+
+  it('is false when the module is merely imported', () => {
+    withArgv1(join(realDir, 'other.js'), () => {
+      assert.equal(isEntryPoint(pathToFileURL(realScript).href), false)
+    })
+  })
+
+  // The original bug (#7198). Node's ESM loader resolves symlinks in
+  // import.meta.url; argv[1] is whatever the caller typed. Every hand-rolled
+  // guard compared one against the other and read false.
+  it('is true when invoked through a symlinked directory', () => {
+    withArgv1(linkedScript, () => {
+      assert.equal(isEntryPoint(pathToFileURL(realScript).href), true)
+    })
+  })
+
+  it('is true when import.meta.url is the symlinked side', () => {
+    withArgv1(realScript, () => {
+      assert.equal(isEntryPoint(pathToFileURL(linkedScript).href), true)
+    })
+  })
+
+  // The #7217 review finding, and the reason the plain comparison runs first.
+  //
+  // A path that cannot be realpath'd stands in for the EACCES / unlinked-script
+  // cases that are not portable to construct: ENOENT takes the identical branch
+  // in the guard. With realpath consulted FIRST, this returns false — a direct
+  // `node foo.js` that silently does nothing, which is precisely the class the
+  // module was written to eliminate.
+  //
+  // Mutation check: put the realpath comparison back in front of the plain one
+  // and this is the assertion that goes red.
+  it('is true for identical paths even when they cannot be realpath\'d', () => {
+    const ghost = join(dir, 'does-not-exist', 'probe.js')
+    withArgv1(ghost, () => {
+      assert.equal(isEntryPoint(pathToFileURL(ghost).href), true)
+    })
+  })
+
+  // Negative control for the case above: the un-realpath-able path must not
+  // become a blanket "true", or the assertion above would pass for the wrong
+  // reason.
+  it('is false for DIFFERING paths that cannot be realpath\'d', () => {
+    withArgv1(join(dir, 'nowhere', 'a.js'), () => {
+      assert.equal(isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href), false)
+    })
+  })
+
+  it('is false when there is no invoked script (node -e, REPL)', () => {
+    withArgv1(undefined, () => {
+      assert.equal(isEntryPoint(pathToFileURL(realScript).href), false)
+    })
+  })
+
+  it('resolves a relative argv[1] before comparing', () => {
+    const saved = process.cwd()
+    process.chdir(realDir)
+    try {
+      withArgv1('./probe.js', () => {
+        assert.equal(isEntryPoint(pathToFileURL(realScript).href), true)
+      })
+    } finally {
+      process.chdir(saved)
+    }
+  })
+})

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -20,7 +20,7 @@
 //        [--repo <root>] [--dry-run]
 //
 // Exit non-zero on emit failure so /skill and CI can gate on it.
-import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, realpathSync } from 'node:fs'
 import { join, dirname, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -347,6 +347,29 @@ function main() {
 
 // Run the CLI only when invoked directly (`node compile-skill-targets.mjs`), not
 // when a test imports this module for unit coverage of deriveDescription().
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+// Both sides realpath'd. Node's ESM loader resolves symlinks in
+// `import.meta.url` but leaves argv[1] as typed, and `resolve()` does not
+// follow symlinks — so on macOS, where /tmp is a symlink to /private/tmp,
+// this compared '/private/tmp/…' against '/tmp/…', read false, and the script
+// exited 0 having compiled nothing (#7213, same bug as #7198).
+//
+// packages/server/src/utils/is-entry-point.js is the shared implementation;
+// scripts/ is outside that package's scope, so the logic is duplicated here
+// deliberately rather than reaching across packages for six lines.
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false
+  const real = (p) => {
+    try {
+      return realpathSync(p)
+    } catch {
+      return null
+    }
+  }
+  const self = real(fileURLToPath(import.meta.url))
+  const invoked = real(resolve(process.argv[1]))
+  return self !== null && self === invoked
+})()
+
+if (invokedDirectly) {
   main()
 }

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -358,6 +358,16 @@ function main() {
 // deliberately rather than reaching across packages for six lines.
 const invokedDirectly = (() => {
   if (!process.argv[1]) return false
+  // The plain comparison runs first and is conclusive on its own: identical
+  // paths mean this IS the entry point, decided without touching the
+  // filesystem. Consulting realpath first and reading a failure as false lets
+  // an EACCES on a parent directory (or a script unlinked after launch) turn a
+  // direct run into a silent exit-0 no-op — the exact class this guard exists
+  // to remove (#7217 review). Realpath is only needed when the paths differ,
+  // where a symlink is the sole thing that can still make them one file.
+  const self = fileURLToPath(import.meta.url)
+  const invoked = resolve(process.argv[1])
+  if (self === invoked) return true
   const real = (p) => {
     try {
       return realpathSync(p)
@@ -365,9 +375,9 @@ const invokedDirectly = (() => {
       return null
     }
   }
-  const self = real(fileURLToPath(import.meta.url))
-  const invoked = real(resolve(process.argv[1]))
-  return self !== null && self === invoked
+  const realSelf = real(self)
+  const realInvoked = real(invoked)
+  return realSelf !== null && realSelf === realInvoked
 })()
 
 if (invokedDirectly) {


### PR DESCRIPTION
## Description

Closes #7213.

#7208 fixed one of these. Review then found the identical bug **live** in `compile-skill-targets.mjs`, so I swept for the rest rather than patching that one and waiting for the next report. **There were four**, across three different spellings — all wrong the same way:

| file | spelling |
|---|---|
| `scripts/compile-skill-targets.mjs` | `resolve(argv[1]) === fileURLToPath(import.meta.url)` |
| `packages/server/src/server-cli-child.js` | `import.meta.url === pathToFileURL(argv[1]).href` |
| `packages/server/src/channels/chroxy-channel-server.js` | `import.meta.url === pathToFileURL(argv[1]).href` |
| `packages/server/sidecar/agent.js` | `argv[1] === fileURLToPath(import.meta.url)` (breaks on relative paths too) |

## The mechanism

Node's ESM loader **resolves symlinks** in `import.meta.url`. `process.argv[1]` is whatever the caller typed, and **neither `resolve()` nor `pathToFileURL()` follows symlinks**. Demonstrated rather than argued:

```
$ node /tmp/ptfu/probe.mjs
  import.meta.url        : file:///private/tmp/ptfu/probe.mjs
  pathToFileURL(argv[1]) : file:///tmp/ptfu/probe.mjs
  guard would be         : false
```

The guard reads false, `main()` never runs, the process exits **0** having done nothing. That silence is why it survived in four separate files and why the `pathToFileURL` spelling — which *looks* more careful than the others — is equally broken.

## Changes

`packages/server/src/utils/is-entry-point.js` is now the one implementation for the server package. `scripts/` and `sidecar/` sit outside that package's scope (the sidecar is a standalone in-pod bundle with its own `package.json`), so the six lines are duplicated there **deliberately**, each with a comment pointing at the canonical copy — reaching across packages for six lines would be worse.

One thing worth flagging: rewriting `server-cli-child.js` I briefly renamed the const and left the usage site reading `if (isEntryPoint)` — testing the *function*, always truthy, which would have fired CLI side effects on every import. Caught before pushing; mentioning it because it is exactly the failure this guard exists to prevent.

## Verification

| invocation | result |
|---|---|
| through a `/tmp` symlink | `true` ✓ |
| via the real path | `true` ✓ |
| **when imported** | **`false`** ✓ |

That last row is load-bearing — these guards exist to keep CLI side effects from firing during tests (`#5308` / WP-0.2 for `server-cli-child`).

Confirmed `compile-skill-targets` now actually compiles through a symlinked path (`Compiling 31 skill(s) -> [claude, gemini] (dry-run)`) instead of silently no-opping.

**Suites:** server **13170 pass / 4 fail** — byte-identical to the pre-change baseline on this machine (2 need the `codex` binary, 2 collide with a live daemon on `:8765`, both confirmed pre-existing). All five custom server lints pass, eslint clean on the touched files, scripts suite 18 pass, gen-agents-md 4 pass, chroxy-channel-server 22 pass.

## Related

#7214 (`realpathOrNull` swallowing `EACCES`) applies to the shared helper too and is worth folding in next; #7215 notes that "Scripts Tests" never runs on Windows CI, so nothing would catch a Windows regression in this area.