### PR TITLE
docs: write up the false-safety guard pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,26 @@ padding or font size, re-check the resulting box.
 
 ## Testing Conventions
 
+### Every guard must be proven to fail — see [`docs/false-safety-guards.md`](docs/false-safety-guards.md)
+
+**When you add or change a check, break the thing it protects and confirm it goes
+red.** If you cannot make it fail, it is not a guard.
+
+Seven guards in this repo reported success without checking anything, and all
+seven passed unit tests, lint, typecheck, and CI — for months in some cases.
+Test suites cannot find this class, because the guard's *output* is correct and
+its *coverage* is what is wrong. The recurring causes:
+
+- a hardcoded list next to a set that grows (`#7192`, `#7197`)
+- "cannot check this" silently treated as "nothing to check" (`#7195`, `#7210`)
+- a precondition that is false, so the body never runs and the job is green
+  (`#7184`, `#7198`)
+- testing the source tree when the artifact is what ships (`#7189`)
+
+Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
+`grep`'s status, not the script's. Restore mutations with `cp` from a backup,
+never `git checkout --`, which eats unrelated uncommitted work.
+
 ### Server tests must not touch real user state (#4633)
 
 Every test that constructs a `SessionManager` **must** pass `stateFilePath` pointing at a temp file. Otherwise the manager defaults to `~/.chroxy/session-state.json` and the test silently clobbers your live state (this happened on 2026-05-30 — see `feedback_test_state_contamination.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,26 @@ padding or font size, re-check the resulting box.
 
 ## Testing Conventions
 
+### Every guard must be proven to fail — see [`docs/false-safety-guards.md`](docs/false-safety-guards.md)
+
+**When you add or change a check, break the thing it protects and confirm it goes
+red.** If you cannot make it fail, it is not a guard.
+
+Seven guards in this repo reported success without checking anything, and all
+seven passed unit tests, lint, typecheck, and CI — for months in some cases.
+Test suites cannot find this class, because the guard's *output* is correct and
+its *coverage* is what is wrong. The recurring causes:
+
+- a hardcoded list next to a set that grows (`#7192`, `#7197`)
+- "cannot check this" silently treated as "nothing to check" (`#7195`, `#7210`)
+- a precondition that is false, so the body never runs and the job is green
+  (`#7184`, `#7198`)
+- testing the source tree when the artifact is what ships (`#7189`)
+
+Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
+`grep`'s status, not the script's. Restore mutations with `cp` from a backup,
+never `git checkout --`, which eats unrelated uncommitted work.
+
 ### Server tests must not touch real user state (#4633)
 
 Every test that constructs a `SessionManager` **must** pass `stateFilePath` pointing at a temp file. Otherwise the manager defaults to `~/.chroxy/session-state.json` and the test silently clobbers your live state (this happened on 2026-05-30 — see `feedback_test_state_contamination.md`).

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -63,10 +63,10 @@ outside the gate, and the gate reported full coverage.
 
 ### 4. The rewrite that skipped what it could not find — `#7195`
 
-`bump-version.sh` rewrote two version references in `CLAUDE.md`, and `continue`d
-past any pattern that did not match. Reword either line and the rewrite becomes
-a no-op that still exits 0 — a fail-open on precisely the drift it was added to
-prevent.
+`bump-version.sh` rewrote two version references in `CLAUDE.md`, and used
+`continue` to skip past any pattern that did not match. Reword either line and
+the rewrite becomes a no-op that still exits 0 — a fail-open on precisely the
+drift it was added to prevent.
 
 ### 5. The self-check that imported known-good paths — `#7197`
 

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -3,13 +3,13 @@
 > A guard that cannot fail is worse than no guard. No guard leaves you cautious;
 > a green one that never checks anything makes you confident and wrong.
 
-Seven of these were found in a single day (2026-08-15). **Five are fixed and
-merged; two are not** — entry 6 (`#7210`, fix in PR `#7212`) and the sweep in
-entry 7 (`#7213`, fix in PR `#7217`) still have their fixes in open PRs, so
-those two bugs are live on `main` as this is written. Every one of the seven had
-passed unit tests, lint, typecheck, and CI continuously — in some cases for
-months — because **the defect is invisible to any check that only asks "did it
-report success?"**
+Seven of these were found in a single day (2026-08-15). Every one had passed
+unit tests, lint, typecheck, and CI continuously — in some cases for months —
+because **the defect is invisible to any check that only asks "did it report
+success?"**
+
+Each entry below cites its issue, and the fix is the PR that closes it; consult
+those rather than a tally here, which would be stale the moment one merges.
 
 This document exists because the seventh was found inside the fix for the sixth.
 The pattern recurs faster than it gets recognised, so it is written down.
@@ -226,6 +226,7 @@ was checked against `--help` on the pinned version for exactly this reason.
 - `scripts/verify-publish-artifacts.mjs` — packs, installs, and runs; derives
   its entry points from the published manifests
 - `scripts/check-release-pr-subject.mjs` — content-triggered, fails closed
-- `packages/server/src/utils/is-entry-point.js` — the one implementation of the
-  entry-point guard (lands with `#7217`; until then the four call sites still
-  carry their own copies)
+- `packages/server/src/utils/is-entry-point.js` — the entry-point guard, and
+  the only copy of it that is unit-tested (`packages/server/tests/is-entry-point.test.js`).
+  Sites outside that package cannot import it and carry their own copies;
+  `#7222` tracks collapsing them onto one implementation.

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -1,0 +1,191 @@
+# False-Safety Guards
+
+> A guard that cannot fail is worse than no guard. No guard leaves you cautious;
+> a green one that never checks anything makes you confident and wrong.
+
+Seven of these were found and fixed in a single day (2026-08-15). Every one had
+passed unit tests, lint, typecheck, and CI continuously — in some cases for
+months — because **the defect is invisible to any check that only asks "did it
+report success?"**
+
+This document exists because the seventh was found inside the fix for the sixth.
+The pattern recurs faster than it gets recognised, so it is written down.
+
+## The shape
+
+A guard exhibits false safety when **success and not-checking are the same
+observable outcome**. Four ways that happens:
+
+| mode | what it looks like |
+|---|---|
+| **Never ran** | The guard's precondition is false, so its body is skipped. Exit 0. |
+| **Checked the wrong thing** | It verifies something already known good, not the artifact that can break. |
+| **Checked a subset** | It iterates a hardcoded list while the real set grows past it. |
+| **Silently skipped an input** | An unrecognised shape is filtered out instead of raising. |
+
+In all four, the check *emits* success. Nothing distinguishes "verified" from
+"declined to verify".
+
+## The seven
+
+### 1. The gate that never ran — `#7184`
+
+`auto-tag-on-release.yml` fires only on a merge subject matching
+`^chore\(release\): cut vX.Y.Z`. Merge a release PR under any other subject and
+the job's `if:` is false, the job never runs, **and the PR is green**. A
+workflow that did not run is indistinguishable from one that passed.
+
+Cost: two missed releases. `#4627` (v0.9.13–v0.9.19), then `0.10.0` merged as
+`chore(release): 0.10.0 — codex controllable like Claude by default` — no
+`cut v`, no tag, and a 463-commit untagged gap that went unnoticed for two
+months. `#7156` is the general form: a non-required workflow can be dead for its
+entire life and produce the same signal as a healthy repo.
+
+### 2. The check that tested the source tree, never the artifact — `#7189`
+
+Every check in the repo validated the working tree. None packed a tarball and
+ran it. Three packaging defects reached the edge of an irreversible npm publish
+with all of CI green, because each one only broke the *packed artifact*:
+sibling ranges resolving a stale published version, `@chroxy/protocol` shipping
+zero `dist/*.js` (no `files` field → npm fell back to `.gitignore`, which
+ignores `dist/`), and `@chroxy/store-core` shipping raw `*.test.ts` with a root
+export Node refuses to load. All three installed cleanly and failed on first
+import.
+
+### 3. The list that stopped growing — `#7192`
+
+The fix for (2) verified a **hardcoded** list of four entry points. The
+manifest declared six. `@chroxy/protocol/schemas` and `/handler-coverage` were
+outside the gate, and the gate reported full coverage.
+
+### 4. The rewrite that skipped what it could not find — `#7195`
+
+`bump-version.sh` rewrote two version references in `CLAUDE.md`, and `continue`d
+past any pattern that did not match. Reword either line and the rewrite becomes
+a no-op that still exits 0 — a fail-open on precisely the drift it was added to
+prevent.
+
+### 5. The self-check that imported known-good paths — `#7197`
+
+`build-publish-dir.mjs` proved its entry points load by importing a **hardcoded
+literal list**, not the `exports` map it had just written. Point `exports` at a
+typo and the check imports the correct file anyway, prints `✓`, and the break
+surfaces only for the npm consumer resolving through `exports`.
+
+### 6. The derivation that read one key — `#7210`
+
+The fix for (5) read only `.import`. A `require`-only or nested-condition export
+yielded no target, was dropped by a `.filter`, and never appeared in the output.
+**Found inside the fix for the previous entry**, which had claimed "a
+newly-added export is covered automatically".
+
+### 7. The guard defeated by a symlink — `#7198`, `#7213`
+
+Node's ESM loader resolves symlinks in `import.meta.url`; `process.argv[1]` is
+whatever the caller typed. Neither `resolve()` nor `pathToFileURL()` follows
+symlinks:
+
+```
+import.meta.url        : file:///private/tmp/x/probe.mjs
+pathToFileURL(argv[1]) : file:///tmp/x/probe.mjs
+guard would be         : false
+```
+
+Run through macOS's `/tmp` → `/private/tmp` symlink and the guard reads false,
+`main()` never runs, and the process exits 0 having done nothing. Four files
+across three spellings — including the `pathToFileURL` form, which *looks* more
+careful than the others and is equally broken.
+
+## Near-miss: the key that was silently ignored
+
+Not one of the seven, but the same family. A Maestro `repeat` was written with
+`maxRuns: 3`. `YamlRepeatCommand` has no such field — `javap` shows
+`times`/`while`/`commands`/`label`/`optional`. The expectation was a parse
+error. **Unknown keys are silently ignored**, so the flow ran, passed three
+verification runs, and was bounded only by `while` — an unbounded retry that
+looked exactly like a bounded one. A parse error would have been the safer
+outcome.
+
+The lesson generalises: *"it would have failed loudly"* is an assumption, not a
+finding. Check.
+
+## Detection: mutation testing is the only reliable method
+
+**Every one of the seven passed all existing tests.** Test suites, lint,
+typecheck, and CI cannot find this class, because the guard's output is correct
+— it is the guard's *coverage* that is wrong.
+
+The check that works is one question:
+
+> **Break the thing this guard protects. Does it go red?**
+
+If you cannot make it fail, it is not a guard.
+
+```bash
+# 1. Baseline — the guard passes on good input
+node scripts/verify-publish-artifacts.mjs; echo "exit=$?"   # want 0
+
+# 2. Break the protected property (cp a backup first, never `git checkout --`,
+#    which eats unrelated uncommitted work)
+cp packages/protocol/package.json /tmp/backup.json
+# …remove the `files` field…
+
+# 3. The guard MUST fail, and the message must name the real problem
+node scripts/verify-publish-artifacts.mjs; echo "exit=$?"   # want non-zero
+
+# 4. Restore from the backup and confirm baseline again
+cp /tmp/backup.json packages/protocol/package.json
+```
+
+Check the **exit code**, not just the output. A script that prints `FAIL` and
+exits 0 is still a false-safety guard, and `cmd | grep -c FAIL` reports `grep`'s
+status, not the script's — that mistake was made twice while writing these
+fixes.
+
+## Writing guards that cannot lie
+
+**Derive the set; never hardcode it.** Read entry points from the manifest,
+targets from the config, flows from the runner's own inventory. A hardcoded
+list is correct exactly once (`#7192`, `#7197`).
+
+**Not-checkable must be an error, not a skip.** "I cannot verify this shape" and
+"there is nothing to verify" are different outcomes. Conflating them is how
+`#7195`, `#7210`, and `#7198` all read as success. Throw, and name what could
+not be checked.
+
+**Test the artifact, not the source.** Pack the tarball, install it into a
+throwaway prefix, run it. The source tree resolves siblings through workspace
+symlinks and never sees what a consumer sees (`#7189`).
+
+**Prefer failing closed.** An unreachable base ref, an unresolvable path, a
+missing argument — exit non-zero. `scripts/check-release-pr-subject.mjs` exits
+`2` rather than passing when it cannot diff.
+
+**Make "did not run" visibly different from "passed."** This is the hardest one
+and the least solved here. `#7156` and `#7199`/`#7216` are open precisely
+because a skipped job and a green job still look alike.
+
+**Verify the mechanism you are relying on.** Before trusting an unknown flag,
+an unfamiliar config key, or "this would fail loudly", confirm it — `--strict`
+was checked against `--help` on the pinned version for exactly this reason.
+
+## When reviewing a guard
+
+1. Ask what it would take to make this pass while the protected property is
+   broken. If there is an answer, that is the bug.
+2. Look for hardcoded lists next to a set that can grow.
+3. Look for `continue`, `.filter(Boolean)`, and `if (!x) return` on a path that
+   means "could not check".
+4. Ask whether it tests the source tree or the artifact that ships.
+5. Ask what happens when its precondition is false — skip, or fail?
+
+## Related
+
+- `docs/release/npm-publish.md` — the publish runbook, and why the artifact
+  gate exists
+- `scripts/verify-publish-artifacts.mjs` — packs, installs, and runs; derives
+  its entry points from the published manifests
+- `scripts/check-release-pr-subject.mjs` — content-triggered, fails closed
+- `packages/server/src/utils/is-entry-point.js` — the one implementation of the
+  entry-point guard (lands with `#7217`; until then the four call sites still
+  carry their own copies)

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -3,7 +3,10 @@
 > A guard that cannot fail is worse than no guard. No guard leaves you cautious;
 > a green one that never checks anything makes you confident and wrong.
 
-Seven of these were found and fixed in a single day (2026-08-15). Every one had
+Seven of these were found in a single day (2026-08-15). **Five are fixed and
+merged; two are not** — entry 6 (`#7210`, fix in PR `#7212`) and the sweep in
+entry 7 (`#7213`, fix in PR `#7217`) still have their fixes in open PRs, so
+those two bugs are live on `main` as this is written. Every one of the seven had
 passed unit tests, lint, typecheck, and CI continuously — in some cases for
 months — because **the defect is invisible to any check that only asks "did it
 report success?"**
@@ -96,18 +99,55 @@ Run through macOS's `/tmp` → `/private/tmp` symlink and the guard reads false,
 across three spellings — including the `pathToFileURL` form, which *looks* more
 careful than the others and is equally broken.
 
-## Near-miss: the key that was silently ignored
+## The one that got me while writing this
 
-Not one of the seven, but the same family. A Maestro `repeat` was written with
-`maxRuns: 3`. `YamlRepeatCommand` has no such field — `javap` shows
-`times`/`while`/`commands`/`label`/`optional`. The expectation was a parse
-error. **Unknown keys are silently ignored**, so the flow ran, passed three
-verification runs, and was bounded only by `while` — an unbounded retry that
-looked exactly like a bounded one. A parse error would have been the safer
-outcome.
+A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no
+such field — `javap` shows `times`/`while`/`commands`/`label`/`optional`. The
+flow was then run three times to verify the fix, each checked with:
 
-The lesson generalises: *"it would have failed loudly"* is an assumption, not a
-finding. Check.
+```bash
+maestro test … diff-comment.yaml 2>&1 | grep -c "FAILED"
+# 0
+```
+
+Zero failures, three times. Except the flow never ran at all:
+
+```
+$ maestro test … /tmp/mr.yaml; echo "exit=$?"
+Unknown Property: maxRuns at /tmp/mr.yaml:11:1
+exit=1
+$ maestro test … /tmp/mr.yaml 2>&1 | grep -c FAILED
+0
+```
+
+Maestro **rejects** the unknown key and exits 1. But a parse error emits no
+per-step `FAILED` lines, so `grep -c FAILED` reports `0` — indistinguishable
+from a clean run. The verification was itself a false-safety guard: it could
+report success while the thing it verified had not executed.
+
+This is the highest-value entry in this document, for three reasons.
+
+**The tool was not at fault.** Maestro did exactly the right thing — failed
+loudly, at parse time, with the offending key and its line number. Every layer
+worked except the one checking it.
+
+**It happened to someone who had just written the rest of this page.** The rule
+"check the exit code, not the output" is stated below and was still violated,
+in the act of verifying a fix for this exact class. Knowing the pattern is not
+protection.
+
+**The wrong conclusion survived review.** From "the flow passed three times",
+the mechanism was inferred to be *"unknown keys are silently ignored, so the
+loop was unbounded"* — plausible, internally consistent, and wrong. It was
+written into a PR description, a commit message that is now in `main`'s
+history, and an earlier draft of this page, before a reviewer reproduced it and
+found the opposite. A false-safety guard does not just hide a bug; it
+manufactures a confident explanation for the wrong thing.
+
+The generalisable rule: **`grep` on output is not a test result.** `grep`'s exit
+status is its own, and absence of a failure string is not evidence of success —
+a crash, a parse error, or a tool that never started all produce the same empty
+match.
 
 ## Detection: mutation testing is the only reliable method
 


### PR DESCRIPTION
## Description

Seven guards in this repo reported success without checking anything. All were found and fixed on 2026-08-15, and **every one had passed unit tests, lint, typecheck and CI** — in some cases for months.

The seventh was found *inside the fix for the sixth*. That is why this is a document rather than seven closed issues.

## Why test suites cannot catch this class

The guard's **output is correct**. Its **coverage** is what is wrong. Nothing that only asks "did the check report success?" can distinguish a guard that verified something from one that declined to.

The recurring causes turn out to be few and recognisable:

| cause | instances |
|---|---|
| hardcoded list beside a set that grows | #7192, #7197 |
| "cannot check this" silently treated as "nothing to check" | #7195, #7210 |
| precondition false → body never runs → job green | #7184, #7198 |
| testing the source tree when the artifact is what ships | #7189 |

## What's in it

`docs/false-safety-guards.md`:

- **The four modes** — never ran, checked the wrong thing, checked a subset, silently skipped an input. In all four, success and not-checking are the same observable outcome.
- **The seven**, each with its mechanism and what it actually cost — including the two missed releases behind #7184 and the 463-commit untagged gap.
- **The near-miss**: a Maestro `repeat` written with `maxRuns`, expecting a parse error. Unknown keys are *silently ignored*, so it passed three verification runs while being an unbounded retry. The generalisable lesson: *"it would have failed loudly"* is an assumption, not a finding.
- **Mutation testing as the only reliable detection**, with a runnable recipe.
- **Five rules for writing guards that cannot lie** — derive the set, make not-checkable an error, test the artifact, fail closed, make "did not run" visibly different from "passed".
- **A five-question review checklist.**

`CLAUDE.md` gets a short pointer, since that is the file every session actually loads — the document is useless if nobody reads it before writing the eighth instance.

## Two operational notes, included because both were got wrong while fixing these

- **Check the exit code, not the output.** `cmd | grep -c FAIL` reports `grep`'s status, not the script's. That mistake was made twice.
- **Restore mutations with `cp` from a backup**, never `git checkout --`, which eats unrelated uncommitted work.

## Verification

Every issue and PR number cited was checked against the tracker before writing — `#7184`, `#7189`, `#7192`, `#7195`, `#7197`, `#7198`, `#7205`, `#7208`, `#7210`, `#7212`, `#7213`, `#7217`, `#7156`.

Every relative link was resolved. That check caught one dead reference: `packages/server/src/utils/is-entry-point.js` lands with #7217 and does not exist on `main` yet, so it is marked as a forward reference rather than left broken.

`AGENTS.md` regenerated from `CLAUDE.md`; the drift gate passes (4/4).

## Honest scope

This documents a pattern; it does not fix the hardest instance. **#7156, #7199 and #7216 remain open** precisely because "did not run" and "passed" still look identical in GitHub's UI — that is a branch-protection and required-checks problem, not something a convention can close.

Closes #7221.
