### PR TITLE
test(app): pin the compaction-marker invariants behaviourally

### DIFF
--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -176,16 +176,20 @@ describe('SessionScreen component structure', () => {
       // handed — filtered a list that could never contain a system message.
       // The marker was unreachable on mobile entirely.
       //
-      // Asserted as source text because this predicate is a plain filter inside
-      // a useMemo with no exported seam; the behavioural proof is the
-      // compaction-marker.yaml Maestro flow, which fails at
-      // `compaction-marker is visible` when this line reverts to `return false`.
-      // The predicate itself now lives in selectChatMessages.ts and is covered
-      // behaviourally by selectChatMessages.test.ts (#7201). All this file
-      // should assert is that SessionScreen still delegates to it rather than
-      // reintroducing an inline copy.
+      // The predicate now lives in selectChatMessages.ts and is covered
+      // behaviourally by selectChatMessages.test.ts (#7201). The only thing
+      // left for THIS file to assert is that SessionScreen still delegates
+      // rather than growing an inline copy back — which the import below plus
+      // the call-site assertion above both catch.
+      //
+      // There used to be a `not.toMatch(/if \(m\.type === 'system'\) return
+      // false;/)` here. It was inert: the predicate moved out of this file, so
+      // that string can no longer appear in `src` under any edit, and a
+      // reverting mutation failed zero assertions in this file (#7228). Nor can
+      // it be widened — `m.type === 'system'` legitimately appears twice in
+      // SessionScreen.tsx, deriving the System tab, so a broader negative would
+      // fail on correct code. Removed rather than left looking like cover.
       expect(src).toMatch(/from '\.\/selectChatMessages'/)
-      expect(src).not.toMatch(/if \(m\.type === 'system'\) return false;/)
     })
   })
 })

--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -146,7 +146,9 @@ describe('SessionScreen component structure', () => {
         /chatFilterCompact\s*&&\s*isHiddenInCompactMode\(m\.type\)/,
       )
       // SessionScreen must delegate rather than keep its own copy.
-      expect(src).toMatch(/selectChatMessages\(allMessages, \{ chatFilterCompact, isHiddenInCompactMode \}\)/)
+      expect(src).toMatch(
+        /selectChatMessages\(\s*allMessages\s*,\s*\{\s*chatFilterCompact\s*,\s*isHiddenInCompactMode\s*,?\s*\}\s*,?\s*\)/,
+      )
       expect(src).not.toMatch(/chatFilterCompact\s*&&\s*isHiddenInCompactMode/)
       // The old hard-coded duplicate must be gone — this is the exact string
       // #6882 was filed to remove (drift risk vs. the store-core predicate).
@@ -158,10 +160,14 @@ describe('SessionScreen component structure', () => {
       )
     })
 
-    test('system messages are still filtered inline, separately from the compact predicate', () => {
-      // #6882: system filtering stays inline — isHiddenInCompactMode is
-      // specifically the compact-hide rule, not a catch-all message filter.
-      expect(src).toMatch(/selectChatMessages\(allMessages, \{ chatFilterCompact, isHiddenInCompactMode \}\)/)
+    test('system filtering is delegated to selectChatMessages, not the compact predicate', () => {
+      // #6882: system filtering is its own rule — isHiddenInCompactMode is
+      // specifically the compact-hide predicate, not a catch-all message
+      // filter. It moved out of SessionScreen into selectChatMessages (#7201);
+      // what matters is that the two stay separate, not where they live.
+      expect(src).toMatch(
+        /selectChatMessages\(\s*allMessages\s*,\s*\{\s*chatFilterCompact\s*,\s*isHiddenInCompactMode\s*,?\s*\}\s*,?\s*\)/,
+      )
     })
 
     test('compaction markers survive the system filter so ChatView can reinsert them (#7186)', () => {

--- a/packages/app/__tests__/SessionScreen.test.ts
+++ b/packages/app/__tests__/SessionScreen.test.ts
@@ -135,15 +135,25 @@ describe('SessionScreen component structure', () => {
     })
 
     test('the compact filter calls the shared predicate, not a hand-rolled duplicate', () => {
-      expect(src).toMatch(
+      // #7201 moved the predicate into src/screens/selectChatMessages.ts so its
+      // invariants could be tested behaviourally. #6882's rule is unchanged —
+      // it just applies there now, so this reads that file.
+      const selector = fs.readFileSync(
+        path.resolve(__dirname, '../src/screens/selectChatMessages.ts'),
+        'utf-8',
+      )
+      expect(selector).toMatch(
         /chatFilterCompact\s*&&\s*isHiddenInCompactMode\(m\.type\)/,
       )
+      // SessionScreen must delegate rather than keep its own copy.
+      expect(src).toMatch(/selectChatMessages\(allMessages, \{ chatFilterCompact, isHiddenInCompactMode \}\)/)
+      expect(src).not.toMatch(/chatFilterCompact\s*&&\s*isHiddenInCompactMode/)
       // The old hard-coded duplicate must be gone — this is the exact string
       // #6882 was filed to remove (drift risk vs. the store-core predicate).
       // Whitespace-tolerant: catches the duplicate regardless of spacing
       // around `===`/`||` (e.g. `m.type==='tool_use'`), without matching the
       // legitimate isHiddenInCompactMode(m.type) call.
-      expect(src).not.toMatch(
+      expect(selector).not.toMatch(
         /chatFilterCompact\s*&&\s*\(\s*m\.type\s*===\s*'tool_use'\s*\|\|\s*m\.type\s*===\s*'thinking'\s*\)/,
       )
     })
@@ -151,7 +161,7 @@ describe('SessionScreen component structure', () => {
     test('system messages are still filtered inline, separately from the compact predicate', () => {
       // #6882: system filtering stays inline — isHiddenInCompactMode is
       // specifically the compact-hide rule, not a catch-all message filter.
-      expect(src).toMatch(/if \(m\.type === 'system'\) return m\.compactMetadata != null;/)
+      expect(src).toMatch(/selectChatMessages\(allMessages, \{ chatFilterCompact, isHiddenInCompactMode \}\)/)
     })
 
     test('compaction markers survive the system filter so ChatView can reinsert them (#7186)', () => {
@@ -164,7 +174,11 @@ describe('SessionScreen component structure', () => {
       // a useMemo with no exported seam; the behavioural proof is the
       // compaction-marker.yaml Maestro flow, which fails at
       // `compaction-marker is visible` when this line reverts to `return false`.
-      expect(src).toMatch(/m\.compactMetadata != null/)
+      // The predicate itself now lives in selectChatMessages.ts and is covered
+      // behaviourally by selectChatMessages.test.ts (#7201). All this file
+      // should assert is that SessionScreen still delegates to it rather than
+      // reintroducing an inline copy.
+      expect(src).toMatch(/from '\.\/selectChatMessages'/)
       expect(src).not.toMatch(/if \(m\.type === 'system'\) return false;/)
     })
   })

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -70,6 +70,7 @@ import { runQueuedEdit } from '../utils/edit-queued';
 import { formatPasteMarker, expandPasteMarkers, parseMemoryAppend } from '@chroxy/store-core';
 import { PastedTextModal } from '../components/PastedTextModal';
 import { disconnectWithQueueGuard } from '../store/disconnectWithQueueGuard';
+import { selectChatMessages } from './selectChatMessages';
 
 
 // Stable empty arrays to avoid new-reference-per-render in Zustand selectors
@@ -183,33 +184,12 @@ export function SessionScreen() {
     closeGitView,
   } = useSessionViewState({ activeSessionId });
 
-  // Filter messages: exclude system (separate tab) and, in compact mode, whatever
-  // the shared #6880 predicate hides (tool_use/thinking today). `system` stays a
-  // separate inline check — isHiddenInCompactMode is specifically the compact-hide rule.
-  //
-  // EXCEPT compaction markers (#6972). A compaction boundary is positional —
-  // it means "context was dropped HERE", between these two turns — so it has
-  // to sit inline in the chat flow. Reaching it on the System tab (which mobile
-  // does have, `viewMode === 'system'` below) is not equivalent: the marker
-  // separated from the messages it sits between conveys nothing.
-  //
-  // ChatView reinserts the `compactMetadata`-carrying subset via
-  // insertCompactionMarkers, and that reinsertion reads the SAME `messages`
-  // array it is handed — so dropping them here left it filtering a list that
-  // could never contain one. Dead code, and the marker was unreachable in the
-  // chat flow entirely (#7186).
-  //
-  // They still never reach the rendered groups through the normal path:
-  // buildChatViewMessages filters `type: 'system'` (buildChatViewMessages.ts:258)
-  // exactly as before, so this only makes them available to the reinsertion
-  // step. `systemMessages` below is unchanged, so they also still appear on the
-  // System tab.
+  // Which messages reach the Chat tab. The predicate and the two invariants it
+  // upholds (compaction markers survive compact mode; every other system event
+  // goes to the System tab) live in selectChatMessages.ts with their tests —
+  // deliberately NOT restated here, so there is one description to keep true.
   const chatMessages = useMemo(
-    () => allMessages.filter((m) => {
-      if (m.type === 'system') return m.compactMetadata != null;
-      if (chatFilterCompact && isHiddenInCompactMode(m.type)) return false;
-      return true;
-    }),
+    () => selectChatMessages(allMessages, { chatFilterCompact, isHiddenInCompactMode }),
     [allMessages, chatFilterCompact, isHiddenInCompactMode],
   );
   const systemMessages = useMemo(

--- a/packages/app/src/screens/__tests__/selectChatMessages.test.ts
+++ b/packages/app/src/screens/__tests__/selectChatMessages.test.ts
@@ -1,0 +1,116 @@
+/**
+ * selectChatMessages tests (#7201).
+ *
+ * These pin two invariants that were previously verified only by hand on a
+ * booted simulator — which does not survive a refactor, and is exactly how
+ * #7186 (the marker never rendering on mobile) went unnoticed for a month.
+ */
+import { selectChatMessages, shouldShowInChat } from '../selectChatMessages';
+import type { ChatMessage } from '../../store/connection';
+
+// The real shared predicate, not a stand-in: if compact mode ever widens to
+// include more types, this test should feel it.
+import { isHiddenInCompactMode } from '@chroxy/store-core';
+
+const msg = (over: Partial<ChatMessage> & Pick<ChatMessage, 'id' | 'type'>): ChatMessage =>
+  ({ content: '', timestamp: 1, ...over }) as ChatMessage;
+
+const marker = (id = 'compact1'): ChatMessage =>
+  msg({
+    id,
+    type: 'system',
+    content: 'Context compacted (auto): 128,000 → 12,000 tokens',
+    compactMetadata: { trigger: 'auto', preTokens: 128_000, postTokens: 12_000, durationMs: 2_500 },
+  } as Partial<ChatMessage> & Pick<ChatMessage, 'id' | 'type'>);
+
+const opts = (chatFilterCompact: boolean) => ({ chatFilterCompact, isHiddenInCompactMode });
+
+describe('selectChatMessages', () => {
+  describe('INVARIANT 1 — compaction markers survive, compact mode included', () => {
+    it('keeps a compaction marker with compact mode OFF', () => {
+      expect(shouldShowInChat(marker(), opts(false))).toBe(true);
+    });
+
+    // The regression this guards: the `system` branch returning BEFORE the
+    // compact check. Reorder them and markers vanish whenever compact is on.
+    it('keeps a compaction marker with compact mode ON', () => {
+      expect(shouldShowInChat(marker(), opts(true))).toBe(true);
+    });
+
+    it('keeps the marker in a realistic conversation, compact ON', () => {
+      const messages = [
+        msg({ id: 'u1', type: 'user_input', content: 'hi' }),
+        msg({ id: 't1', type: 'tool_use', content: 'ls' }),
+        marker(),
+        msg({ id: 'r1', type: 'response', content: 'hello' }),
+      ];
+      // tool_use is hidden by compact mode; the marker is not.
+      expect(selectChatMessages(messages, opts(true)).map((m) => m.id)).toEqual([
+        'u1',
+        'compact1',
+        'r1',
+      ]);
+    });
+
+    // The ordering itself, isolated from today's isHiddenInCompactMode.
+    //
+    // Reordering the two checks is harmless RIGHT NOW only because
+    // isHiddenInCompactMode never returns true for 'system' — a mutation test
+    // against the real predicate passes either way and proves nothing (it did).
+    // Injecting a predicate that DOES hide 'system' makes the ordering the only
+    // thing keeping the marker alive, which is the invariant actually guarded:
+    // if compact mode ever widens to cover system events, markers must survive.
+    it('keeps the marker even if compact mode is widened to hide system events', () => {
+      const hidesSystemToo = (type: ChatMessage['type']) =>
+        type === 'tool_use' || type === 'thinking' || type === 'system';
+      const widened = { chatFilterCompact: true, isHiddenInCompactMode: hidesSystemToo };
+
+      expect(shouldShowInChat(marker(), widened)).toBe(true);
+      // …and a plain system event is still excluded under that same predicate,
+      // so the assertion above is about the marker, not a blanket pass.
+      expect(
+        shouldShowInChat(msg({ id: 's1', type: 'system', content: 'connected' }), widened),
+      ).toBe(false);
+    });
+  });
+
+  describe('INVARIANT 2 — every other system message is excluded', () => {
+    it('drops a plain system event', () => {
+      expect(shouldShowInChat(msg({ id: 's1', type: 'system', content: 'connected' }), opts(false))).toBe(false);
+    });
+
+    it('drops a system event whose compactMetadata is explicitly null', () => {
+      const m = msg({ id: 's2', type: 'system', content: 'x' });
+      (m as { compactMetadata?: unknown }).compactMetadata = null;
+      expect(shouldShowInChat(m, opts(false))).toBe(false);
+    });
+
+    it('drops plain system events but keeps markers, in one pass', () => {
+      const messages = [
+        msg({ id: 's1', type: 'system', content: 'connected' }),
+        marker(),
+        msg({ id: 's2', type: 'system', content: 'resumed' }),
+      ];
+      expect(selectChatMessages(messages, opts(false)).map((m) => m.id)).toEqual(['compact1']);
+    });
+  });
+
+  describe('compact mode still hides what it is supposed to', () => {
+    it.each(['tool_use', 'thinking'] as const)('hides %s when compact is ON', (type) => {
+      expect(shouldShowInChat(msg({ id: 'x', type }), opts(true))).toBe(false);
+    });
+
+    it.each(['tool_use', 'thinking'] as const)('shows %s when compact is OFF', (type) => {
+      expect(shouldShowInChat(msg({ id: 'x', type }), opts(false))).toBe(true);
+    });
+
+    // Negative control: without this, a predicate that hid everything in
+    // compact mode would pass every assertion above.
+    it.each(['user_input', 'response', 'error', 'prompt'] as const)(
+      'never hides %s, compact ON',
+      (type) => {
+        expect(shouldShowInChat(msg({ id: 'x', type }), opts(true))).toBe(true);
+      },
+    );
+  });
+});

--- a/packages/app/src/screens/selectChatMessages.ts
+++ b/packages/app/src/screens/selectChatMessages.ts
@@ -1,0 +1,58 @@
+/**
+ * selectChatMessages — which messages reach the Chat tab.
+ *
+ * Extracted from SessionScreen's inline `useMemo` (#7201) so the two invariants
+ * below are pinned by behavioural tests rather than by reading the source. Both
+ * were previously verified only by hand on a booted simulator, which does not
+ * survive a refactor.
+ *
+ * INVARIANT 1 — compaction markers survive, compact mode included.
+ *
+ *   A compaction boundary is positional: it means "context was dropped HERE",
+ *   between these two turns. ChatView reinserts the compactMetadata-carrying
+ *   subset inline via insertCompactionMarkers, and that reinsertion reads the
+ *   same array this function returns — so dropping markers here makes the
+ *   reinsertion dead code and the marker unreachable in the chat flow (#7186,
+ *   which is exactly what happened).
+ *
+ *   The `system` branch returns BEFORE the compact-mode check on purpose.
+ *   Compact mode hides tool_use/thinking only (isHiddenInCompactMode is the
+ *   shared definition, buildChatViewMessages.ts), and a compaction boundary is
+ *   neither. Reordering these two checks would silently start hiding markers
+ *   whenever compact mode is on.
+ *
+ * INVARIANT 2 — every other `system` message is excluded.
+ *
+ *   They belong on the System tab, which mobile does have
+ *   (SessionScreen's `viewMode === 'system'`). `systemMessages` is derived
+ *   separately from the unfiltered list, so markers appear there too.
+ */
+import type { ChatMessage } from '../store/connection';
+
+export interface SelectChatMessagesOptions {
+  /** Compact-mode toggle state. */
+  chatFilterCompact: boolean;
+  /** Shared predicate for what compact mode hides (tool_use / thinking). */
+  isHiddenInCompactMode: (type: ChatMessage['type']) => boolean;
+}
+
+/** True when `m` belongs on the Chat tab. */
+export function shouldShowInChat(
+  m: ChatMessage,
+  { chatFilterCompact, isHiddenInCompactMode }: SelectChatMessagesOptions,
+): boolean {
+  // Markers pass regardless of compact mode; every other system event is the
+  // System tab's. This branch MUST stay above the compact check — see
+  // INVARIANT 1.
+  if (m.type === 'system') return m.compactMetadata != null;
+  if (chatFilterCompact && isHiddenInCompactMode(m.type)) return false;
+  return true;
+}
+
+/** Filter a session's messages down to the Chat tab's set. */
+export function selectChatMessages(
+  messages: ChatMessage[],
+  options: SelectChatMessagesOptions,
+): ChatMessage[] {
+  return messages.filter((m) => shouldShowInChat(m, options));
+}

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -55,6 +55,41 @@ describe('buildChatViewMessages', () => {
     expect(groupIds).toEqual(['u1', 'r1'])
   })
 
+  // #7201 — the system filter must stay UNCONDITIONAL, including for messages
+  // carrying compactMetadata.
+  //
+  // Mobile reinserts compaction markers inline via ChatView's
+  // insertCompactionMarkers, because a compaction boundary is positional. The
+  // dashboard runs this same pipeline across both its Chat and System tabs. If
+  // this filter ever gained a compactMetadata exemption — e.g.
+  // `if (m.type === 'system' && m.compactMetadata == null) return false` — the
+  // marker would reach chatMessages/displayGroups directly AND be reinserted,
+  // double-rendering on the dashboard.
+  //
+  // The pre-existing system-filter test above uses a fixture with no
+  // compactMetadata, so it cannot catch that regression. This one can.
+  it('filters out `system` events even when they carry compactMetadata (#7201)', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'hi' }),
+      msg({
+        id: 'compact1',
+        type: 'system',
+        content: 'Context compacted (auto): 128,000 → 12,000 tokens',
+        compactMetadata: { trigger: 'auto', preTokens: 128_000, postTokens: 12_000, durationMs: 2_500 },
+      }),
+      msg({ id: 'r1', type: 'response', content: 'hello' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+
+    expect(out.chatMessages.map(m => m.id)).toEqual(['u1', 'r1'])
+    const groupIds = out.displayGroups.flatMap(g =>
+      g.type === 'single' ? [g.message.id] : g.messages.map(m => m.id),
+    )
+    expect(groupIds).toEqual(['u1', 'r1'])
+    // Explicit: the marker must not appear by ANY route through this pipeline.
+    expect(groupIds).not.toContain('compact1')
+  })
+
   it('passes singleton tool_use through as `tool_use`, not collapsed', () => {
     const messages = [
       msg({ id: 'u1', type: 'user_input', content: 'do a thing' }),


### PR DESCRIPTION
## Description

Closes #7201.

Both invariants #7200 relies on were proven only by hand on a booted simulator — which does not survive a refactor. That is the same gap that let #7186 (the marker never rendering on mobile) sit unnoticed for a month.

## Gap 2 — the system filter must stay unconditional

`buildChatViewMessages`' `if (m.type === 'system') return false` is deliberately unconditional, *including* for `compactMetadata`-carrying messages, so the dashboard never double-renders the marker (once via the normal pipeline, once via `insertCompactionMarkers`).

The existing system-filter test used a fixture with **no** `compactMetadata`, so it could not catch a regression like `if (m.type === 'system' && m.compactMetadata == null) return false`. The new test can — verified by making exactly that mutation:

```
Tests  1 failed | 44 passed (45)
```

## Gap 1 — needed a seam, and my first attempt at it didn't work

The predicate was inline in a `useMemo`, and the only coverage was source-text matching, which pins the *spelling* rather than the behaviour. Extracted to `src/screens/selectChatMessages.ts` — the same move #6972 made for `insertCompactionMarkers` — and tested directly.

**The first version of the test was worthless, and mutation testing is what showed it.** It asserted that markers survive compact mode. That passes whether or not the two checks are in the right order, because `isHiddenInCompactMode` never returns `true` for `'system'` today:

```
=== MUTANT A: reorder so compact-mode check runs first ===
Tests:       14 passed, 14 total     ← proved nothing about ordering
```

The test now injects a predicate that **does** hide `'system'`, which makes the ordering the only thing keeping the marker alive — the invariant genuinely at risk if compact mode ever widens. Same mutation now:

```
Tests:       1 failed, 14 passed, 15 total
```

It also asserts a plain system event is *still* excluded under that widened predicate, so the marker assertion isn't a blanket pass.

## Knock-on changes

Two source-text assertions in `SessionScreen.test.ts` targeted the moved code. #6882's rule — use the shared predicate, never a hand-rolled duplicate — is unchanged, so they now read `selectChatMessages.ts`, plus a new assertion that `SessionScreen` **delegates** rather than keeping its own copy.

The long explanatory comment moved with the code rather than being duplicated in both places, since a second copy is exactly what drifts.

## Suites

`app` **2343 pass** (181 suites) · `store-core` **2132 pass** · `tsc --noEmit` clean.