### PR TITLE
fix(ci): decide the entry point before touching the filesystem

### DIFF
--- a/scripts/__tests__/gen-agents-md.test.mjs
+++ b/scripts/__tests__/gen-agents-md.test.mjs
@@ -12,7 +12,7 @@
  */
 
 import { dirname, join, resolve } from 'node:path'
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
@@ -109,6 +109,108 @@ await test('runs through a symlinked invocation path (#7198)', async () => {
     rmSync(dir, { recursive: true, force: true })
   }
 })
+
+// --- #7214: realpath failing must not silently skip the run -----------------
+//
+// The guard decides "am I the entry point?" from process.argv[1]. When it
+// consulted realpath FIRST, any throw was read as "not the entry point", so a
+// direct run exited 0 having done nothing — no regeneration, no --check, no
+// diagnostic. Same silent no-op as #7198, different trigger.
+//
+// Reproducing that needs the filesystem to break in the window AFTER node has
+// read the script and BEFORE the module body evaluates, which is where the
+// guard runs. A `module.register` load hook sits exactly in that window: node
+// only has to LOAD the file, not keep it readable afterwards.
+const HOOKS = `
+import { unlinkSync, chmodSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+export async function load (url, context, nextLoad) {
+  const result = await nextLoad(url, context)
+  if (url.endsWith('/gen-agents-md.mjs')) {
+    const p = fileURLToPath(url)
+    if (process.env.CHROXY_BREAK === 'unlink') unlinkSync(p)
+    else if (process.env.CHROXY_BREAK === 'eacces') chmodSync(dirname(p), 0o000)
+  }
+  return result
+}
+`
+const REGISTER = `
+import { register } from 'node:module'
+register('./hooks.mjs', import.meta.url)
+`
+
+const withBrokenRealpath = (breakMode, fn) => {
+  // realpathSync the tmpdir: on macOS os.tmpdir() is /var/..., a symlink to
+  // /private/var. Leaving it symlinked would ALSO trip #7198's non-canonical
+  // path case, and the two triggers together are the residual this fix does
+  // not claim to cover. Canonicalising isolates #7214.
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), 'genagents-7214-'))
+  const scriptsDir = join(dir, 'root', 'scripts')
+  try {
+    mkdirSync(scriptsDir, { recursive: true })
+    cpSync(scriptPath, join(scriptsDir, 'gen-agents-md.mjs'))
+    cpSync(resolve(__dirname, '..', '..', 'CLAUDE.md'), join(dir, 'root', 'CLAUDE.md'))
+    writeFileSync(join(dir, 'root', 'AGENTS.md'), 'STALE\n')
+    writeFileSync(join(dir, 'hooks.mjs'), HOOKS)
+    writeFileSync(join(dir, 'register.mjs'), REGISTER)
+    fn(spawnSync(
+      process.execPath,
+      ['--import', join(dir, 'register.mjs'), join(scriptsDir, 'gen-agents-md.mjs'), '--check'],
+      { encoding: 'utf8', env: { ...process.env, CHROXY_BREAK: breakMode } },
+    ))
+  } finally {
+    chmodSync(scriptsDir, 0o755)
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+// Positive control for the two tests below. If the hook does NOT actually break
+// realpath, both assertions pass for the wrong reason: the guard works normally,
+// --check sees the stale AGENTS.md, and exits 1 either way. That is the vacuous
+// pass this whole file exists to distrust, so prove the trigger fires first.
+await test('the load hook genuinely breaks realpath (positive control)', async () => {
+  withBrokenRealpath('unlink', (run) => {
+    assert(run.status !== null, `child did not run at all: ${run.error && run.error.message}`)
+  })
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), 'genagents-ctl-'))
+  try {
+    const probe = join(dir, 'probe.mjs')
+    writeFileSync(probe, 'process.exit(0)\n')
+    writeFileSync(join(dir, 'hooks.mjs'), HOOKS.replace(/gen-agents-md\.mjs/g, 'probe.mjs'))
+    writeFileSync(join(dir, 'register.mjs'), REGISTER)
+    spawnSync(process.execPath, ['--import', join(dir, 'register.mjs'), probe], {
+      encoding: 'utf8',
+      env: { ...process.env, CHROXY_BREAK: 'unlink' },
+    })
+    let threw = false
+    try {
+      realpathSync(probe)
+    } catch {
+      threw = true
+    }
+    assert(threw, 'the unlink hook did not make realpathSync throw — the tests below would pass vacuously')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+await test('--check detects drift when the script is unlinked after launch (#7214)', async () => {
+  withBrokenRealpath('unlink', (run) =>
+    assert(run.status === 1, `--check must exit 1 on drift; got ${run.status} (0 = the silent no-op this guards)`))
+})
+
+// chmod 0000 does not deny root, so as root realpath would succeed and this
+// would pass without exercising the EACCES path at all — vacuously. Skipped
+// rather than silently weakened.
+if (typeof process.getuid === 'function' && process.getuid() === 0) {
+  process.stdout.write('  skip --check detects drift when realpath fails with EACCES (#7214): running as root\n')
+} else {
+  await test('--check detects drift when realpath fails with EACCES (#7214)', async () => {
+    withBrokenRealpath('eacces', (run) =>
+      assert(run.status === 1, `--check must exit 1 on drift; got ${run.status} (0 = the silent no-op this guards)`))
+  })
+}
 
 // --- summary --------------------------------------------------------------
 process.stdout.write(`\n${pass} passed, ${fail} failed\n`)

--- a/scripts/gen-agents-md.mjs
+++ b/scripts/gen-agents-md.mjs
@@ -78,6 +78,16 @@ export function readAgentsMd() {
 // `-e` eval, a deleted script); an unresolvable path simply is not this file.
 const invokedDirectly = (() => {
   if (!process.argv[1]) return false
+  // The plain comparison runs first and is conclusive on its own: identical
+  // paths mean this IS the entry point, decided without touching the
+  // filesystem. Consulting realpath first and reading a failure as false let an
+  // EACCES on a parent directory (or a script unlinked after launch) turn a
+  // direct run into a silent exit-0 no-op — the same shape as #7198, reached
+  // through a different trigger (#7214). Realpath is only needed once the paths
+  // differ, where a symlink is the sole thing that can still make them one file.
+  const self = fileURLToPath(import.meta.url)
+  const argv = resolve(process.argv[1])
+  if (self === argv) return true
   const realpathOrNull = (p) => {
     try {
       return realpathSync(p)
@@ -85,9 +95,9 @@ const invokedDirectly = (() => {
       return null
     }
   }
-  const self = realpathOrNull(fileURLToPath(import.meta.url))
-  const argv = realpathOrNull(resolve(process.argv[1]))
-  return self !== null && self === argv
+  const realSelf = realpathOrNull(self)
+  const realArgv = realpathOrNull(argv)
+  return realSelf !== null && realSelf === realArgv
 })()
 
 if (invokedDirectly) {

--- a/scripts/gen-agents-md.mjs
+++ b/scripts/gen-agents-md.mjs
@@ -84,7 +84,8 @@ const invokedDirectly = (() => {
   // EACCES on a parent directory (or a script unlinked after launch) turn a
   // direct run into a silent exit-0 no-op — the same shape as #7198, reached
   // through a different trigger (#7214). Realpath is only needed once the paths
-  // differ, where a symlink is the sole thing that can still make them one file.
+  // differ — via a symlink, or via case normalisation on a case-insensitive
+  // filesystem (default APFS/NTFS), both of which it resolves.
   const self = fileURLToPath(import.meta.url)
   const argv = resolve(process.argv[1])
   if (self === argv) return true

--- a/scripts/gen-agents-md.mjs
+++ b/scripts/gen-agents-md.mjs
@@ -84,8 +84,9 @@ const invokedDirectly = (() => {
   // EACCES on a parent directory (or a script unlinked after launch) turn a
   // direct run into a silent exit-0 no-op — the same shape as #7198, reached
   // through a different trigger (#7214). Realpath is only needed once the paths
-  // differ — via a symlink, or via case normalisation on a case-insensitive
-  // filesystem (default APFS/NTFS), both of which it resolves.
+  // differ, where a symlink is the only thing that still makes them one file —
+  // the same wording as the canonical copy in
+  // packages/server/src/utils/is-entry-point.js, deliberately.
   const self = fileURLToPath(import.meta.url)
   const argv = resolve(process.argv[1])
   if (self === argv) return true


### PR DESCRIPTION
`scripts/gen-agents-md.mjs`'s entry-point guard resolved `realpath` for both sides first and returned `false` whenever either call threw:

```js
const self = realpathOrNull(fileURLToPath(import.meta.url))
const argv = realpathOrNull(resolve(process.argv[1]))
return self !== null && self === argv
```

An `EACCES` on a parent directory, or a script unlinked after launch, therefore made a direct `node scripts/gen-agents-md.mjs` evaluate `false` — AGENTS.md never regenerated, `--check` never checked, exit 0. The same silent no-op as #7198, reached through a different trigger.

## The fix

The plain comparison is conclusive on its own: identical paths mean this **is** the entry point. Running it first settles the common case with no filesystem access, so no fs error can reach it.

```js
const self = fileURLToPath(import.meta.url)
const argv = resolve(process.argv[1])
if (self === argv) return true
// only now is realpath needed: differing paths can still be one file via a
// symlink, or via case normalisation on a case-insensitive filesystem
```

The #7198 symlink fix is untouched — realpath still runs for exactly the case it was added for. The residual is a direct invocation through a symlink whose realpath *also* fails, which is genuinely undecidable without the call that just failed.

## Coverage

The guard is pinned directly, in `scripts/__tests__/gen-agents-md.test.mjs`. A `module.register` load hook breaks the filesystem in the window between node reading the source and the module body evaluating — which is where the guard runs — under two triggers, `unlink` and `chmod 0000`.

Mutation-verified:

| variant | exit | result |
|---|---|---|
| this PR | 0 | 7 passed, 0 failed |
| realpath-first restored | 1 | both #7214 tests FAIL — `got 0 (0 = the silent no-op this guards)` |
| restored again | 0 | 7 passed, 0 failed |

The suite carries a **positive control**: without it, both tests pass for the wrong reason, since a hook that fails to break realpath leaves the guard working normally and `--check` exits 1 on the stale AGENTS.md either way. The control asserts `realpathSync` actually throws afterwards.

The EACCES case is **skipped as root** — `chmod 0000` does not deny root, so it would otherwise pass without exercising the path at all.

## Verification

Every step the `Scripts Tests` job runs, locally on Node 22:

```
bump-version.test.sh                 exit=0
flush-and-exit.test.mjs              exit=0
compile-skill-targets.test.mjs       exit=0
lint-no-raw-color-literals.test.sh   exit=0
lint-no-nul-bytes.test.sh            exit=0
gen-agents-md.test.mjs               exit=0
check-release-pr-subject.test.mjs    exit=0
```

Plus the guard end-to-end: `node scripts/gen-agents-md.mjs --check` and the same through a symlinked path both exit 0 and report in sync.

## Corrections to this PR's earlier claims

Two statements in the original body were wrong and are replaced above, both caught in review:

1. **"the identical logic is pinned in `packages/server/tests/is-entry-point.test.js`"** — that file covers the shared helper, a *different copy*. Reverting this file's reordering left the whole repo suite exiting 0. The change was unpinned; it is now pinned by the tests above.
2. **"the EACCES trigger is not reproducible in a subprocess"** — false, and the load-hook test is the counterexample. Node only has to *load* the script, not keep it readable through evaluation.

The original body also said "every test the Scripts Tests job runs" while listing five of seven; the full seven are above.

This is the same reordering applied to the other three guards in #7217.

Closes #7214.
