### PR TITLE
fix(store-core): assert the self-check resolves inside the staging dir

### DIFF
--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -218,17 +218,26 @@ for (const [label, target] of declared) {
   //   base .../store-core/publish/  + ./dist/index.js -> .../publish/dist/index.js
   //   base .../store-core/publish   + ./dist/index.js -> .../store-core/dist/index.js
   //
-  // That second path is the COMMITTED dist — a real directory of real files,
-  // so existsSync is satisfied and the check proceeds against the wrong tree
-  // entirely.
+  // That second path is packages/store-core/dist — the tree step 1 rebuilds,
+  // mostly gitignored (.gitignore keeps only crypto.js and crypto.d.ts). It is
+  // a real directory of real files, so existsSync is satisfied and the check
+  // proceeds against the wrong tree entirely.
   //
-  // Today it then fails at the import, because addExtensions() rewrites only
-  // the STAGED copy, so the committed dist still carries extensionless
-  // specifiers and Node rejects it with ERR_UNSUPPORTED_DIR_IMPORT. That is
-  // luck, not a guarantee, and the error blames the published entry point
-  // rather than the wrong base URL. Regenerate that dist with extensions and
-  // the same mistake resolves, imports, and goes green having verified nothing
-  // this script produced (#7211).
+  // How loudly that fails depends on WHICH export is checked, which is the
+  // whole problem:
+  //
+  //   "."       throws. addExtensions() rewrites only the STAGED copy, so
+  //             dist/index.js keeps its extensionless specifiers and Node
+  //             rejects it with ERR_UNSUPPORTED_DIR_IMPORT — blaming the
+  //             published entry point rather than the wrong base URL.
+  //   "./crypto" passes. dist/crypto.js has no relative specifiers at all, so
+  //             the staged copy is byte-identical and it imports cleanly.
+  //
+  // So the mistake is caught today only because "." happens to be checked
+  // first and happens to throw. For "./crypto" it is already a silent pass
+  // against the wrong tree. Neither of those is a property of this check —
+  // reorder the exports, or regenerate dist with extensions, and the whole
+  // thing goes green having verified nothing this script produced (#7211).
   const file = new URL(target, pathToFileURL(join(outDir, '/')))
 
   // So assert it rather than trusting the comment. A comment cannot fail; this

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -32,7 +32,7 @@
 import { execFileSync } from 'node:child_process'
 import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join, resolve, sep } from 'node:path'
 
 // The source imports siblings without a file extension (`from './types'`), which
 // tsconfig's `moduleResolution: "bundler"` allows and Metro/Vite resolve happily.
@@ -209,7 +209,30 @@ for (const [label, target] of declared) {
   // rather than a `file://` template: the template mangles Windows paths (drive
   // letters, backslashes) and anything needing percent-encoding, and this repo
   // runs Windows CI.
+  //
+  // The `join(outDir, '/')` is load-bearing, not decorative. WHATWG URL
+  // resolution reads a base's trailing slash as the directory/file boundary: a
+  // relative reference APPENDS to a base ending in '/', and REPLACES the last
+  // segment otherwise. Drop it and every target resolves one level up:
+  //
+  //   base .../store-core/publish/  + ./dist/index.js -> .../publish/dist/index.js
+  //   base .../store-core/publish   + ./dist/index.js -> .../store-core/dist/index.js
+  //
+  // That second path is the COMMITTED dist — it exists, it imports, and the
+  // self-check goes green having verified the wrong artifact entirely, which is
+  // the same false-safety bug #7205 removed wearing a different hat (#7211).
   const file = new URL(target, pathToFileURL(join(outDir, '/')))
+
+  // So assert it rather than trusting the comment. A comment cannot fail; this
+  // turns "simplified the base URL" from a silent wrong answer into a loud one.
+  const filePath = fileURLToPath(file)
+  if (!filePath.startsWith(outDir + sep)) {
+    throw new Error(
+      `manifest exports "${label}" -> ${target} resolved to ${filePath}, which is OUTSIDE the staging dir ` +
+      `(${outDir}). The base URL must keep its trailing separator, or the self-check verifies the wrong files.`,
+    )
+  }
+
   if (!existsSync(file)) {
     throw new Error(`manifest exports "${label}" -> ${target}, which does not exist in the package`)
   }

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -218,9 +218,17 @@ for (const [label, target] of declared) {
   //   base .../store-core/publish/  + ./dist/index.js -> .../publish/dist/index.js
   //   base .../store-core/publish   + ./dist/index.js -> .../store-core/dist/index.js
   //
-  // That second path is the COMMITTED dist — it exists, it imports, and the
-  // self-check goes green having verified the wrong artifact entirely, which is
-  // the same false-safety bug #7205 removed wearing a different hat (#7211).
+  // That second path is the COMMITTED dist — a real directory of real files,
+  // so existsSync is satisfied and the check proceeds against the wrong tree
+  // entirely.
+  //
+  // Today it then fails at the import, because addExtensions() rewrites only
+  // the STAGED copy, so the committed dist still carries extensionless
+  // specifiers and Node rejects it with ERR_UNSUPPORTED_DIR_IMPORT. That is
+  // luck, not a guarantee, and the error blames the published entry point
+  // rather than the wrong base URL. Regenerate that dist with extensions and
+  // the same mistake resolves, imports, and goes green having verified nothing
+  // this script produced (#7211).
   const file = new URL(target, pathToFileURL(join(outDir, '/')))
 
   // So assert it rather than trusting the comment. A comment cannot fail; this


### PR DESCRIPTION
The base URL's trailing separator in `build-publish-dir.mjs`'s self-check is load-bearing. WHATWG URL resolution reads it as the directory/file boundary — a relative reference **appends** to a base ending in `/`, and **replaces** the last segment otherwise:

```
base .../store-core/publish/  + ./dist/index.js  ->  .../publish/dist/index.js
base .../store-core/publish   + ./dist/index.js  ->  .../store-core/dist/index.js
```

So "simplifying" `join(outDir, '/')` to a bare `outDir` — the slash reads as redundant sitting next to the path itself — silently repoints the self-check at the **committed** dist instead of the staged tree the script just assembled and rewrote.

## Correcting the issue's premise

#7211 assumed the committed dist "exists and imports fine today", which would make the mutation a silent pass. That is not the case, and the difference changes what this PR is for.

The committed dist does **not** import:

```
$ node -e "import('packages/store-core/dist/index.js')"
committed dist FAILS to import: ERR_UNSUPPORTED_DIR_IMPORT
```

It carries extensionless specifiers (`export { … } from './types'`) because `addExtensions()` only rewrites the **staged** copy. So the mutation does fail today — at the import step, blaming the published entry point, for a reason unrelated to the actual mistake.

That loudness is an accident of the committed dist's contents, not a property of the check. Regenerate that dist with extensions and the same mutation becomes precisely the silent pass the issue described.

## The change

An assertion that fires **before** the import, so the wrong-directory case is caught regardless of whether the wrong directory happens to be importable:

```js
const filePath = fileURLToPath(file)
if (!filePath.startsWith(outDir + sep)) {
  throw new Error(`… resolved to ${filePath}, which is OUTSIDE the staging dir (${outDir}). …`)
}
```

A comment alone was the other option, and a comment cannot fail.

## Verification (mutation, in order)

| variant | exit | message |
|---|---|---|
| `main` + mutation | 1 | `published "." entry (./dist/index.js) fails to import: Directory import … is not supported` |
| this PR + mutation | 1 | `resolved to …/store-core/dist/index.js, which is OUTSIDE the staging dir (…/publish)` |
| this PR, unmutated | 0 | `✓ "." -> ./dist/index.js` · `✓ "./crypto" -> ./dist/crypto.js` |

Resolution was also checked directly for nested targets — `./dist/sub/deep.js` stays under the staging dir with the correct base and escapes with the mutated one.

Related to #7211. (Leaving the issue open: it also asks for a regression test, which wants the unit-test harness #7220 tracks — this script has none today.)