### PR TITLE
fix(ci): verify AGENTS.md regenerated instead of announcing it

### DIFF
--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -814,6 +814,128 @@ run_test "bump still succeeds when CLAUDE.md is absent" \
 run_test "aborts when CLAUDE.md's version line format changed" \
   test_aborts_when_claude_md_format_changed
 
+# --- AGENTS.md regeneration is VERIFIED, not announced (#7227) ---------------
+#
+# Before this, bump-version.sh printed "AGENTS.md regenerated from CLAUDE.md"
+# on the generator merely having been invoked. `set -euo pipefail` catches a
+# NON-ZERO exit; this whole defect class (#7198 / #7214) is exit ZERO having
+# done nothing, so the release printed a false success and carried a stale
+# AGENTS.md into the CI drift gate.
+#
+# The generator is stubbed rather than copied. What is under test is the
+# CALLER's ability to distinguish "regenerated" from "silently skipped", and a
+# stub can produce the skipped shape on demand — which the real generator, now
+# that #7224 fixed it, no longer can.
+#
+#   healthy — writes AGENTS.md, and --check confirms with the real generator's
+#             wording
+#   quiet   — the authentic #7198 shape: BOTH invocations return without doing
+#             anything, exit 0, print nothing. This is the case an exit-code
+#             check cannot see, because --check is skipped too.
+#   nowrite — the write is skipped but --check still works, so it reports drift
+#             on stderr and exits 1
+install_gen_agents_stub() {
+  local dir="$1" mode="$2"
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/gen-agents-md.mjs" <<STUB
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+const mode = '$mode'
+const check = process.argv.includes('--check')
+// 'quiet' is the silent no-op: no output, exit 0, for BOTH invocations.
+if (mode === 'quiet') process.exit(0)
+if (mode === 'nowrite' && !check) process.exit(0)
+const claude = existsSync('CLAUDE.md') ? readFileSync('CLAUDE.md', 'utf8') : ''
+const want = 'GENERATED\n' + claude
+if (check) {
+  const have = existsSync('AGENTS.md') ? readFileSync('AGENTS.md', 'utf8') : ''
+  if (have !== want) {
+    console.error('::error::AGENTS.md is out of sync with CLAUDE.md.')
+    process.exit(1)
+  }
+  console.log('AGENTS.md is in sync with CLAUDE.md.')
+} else {
+  writeFileSync('AGENTS.md', want)
+}
+STUB
+}
+
+# Shared fixture for the three cases below.
+setup_agents_case() {
+  local dir="$1" mode="$2"
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  install_gen_agents_stub "$dir" "$mode"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+  cat > "$dir/CLAUDE.md" <<'CLAUDEMD'
+# Claude Development Notes
+
+**Current Status (v0.5.7):**
+- stuff works
+
+---
+
+*Last Updated: 2026-01-01*
+*Version: 0.5.7*
+CLAUDEMD
+  printf 'STALE\n' > "$dir/AGENTS.md"
+}
+
+# Positive control. Without it, a check that rejected EVERY generator would
+# pass the two failure cases below and look like a working guard.
+test_agents_md_regeneration_succeeds() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  setup_agents_case "$dir" "healthy"
+
+  local out
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || return 1
+  printf '%s' "$out" | grep -q 'AGENTS.md regenerated from CLAUDE.md' || return 1
+  # ...and it actually wrote, rather than the message being decorative again.
+  grep -q '^GENERATED$' "$dir/AGENTS.md" || return 1
+  ! grep -q '^STALE$' "$dir/AGENTS.md" || return 1
+}
+
+# The authentic #7198 shape, and the one an exit-code-only check misses: the
+# entry-point guard reads false, so the write AND --check are both skipped,
+# both exit 0, and --check prints nothing.
+test_agents_md_silent_noop_fails_the_bump() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  setup_agents_case "$dir" "quiet"
+
+  local out rc=0
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || rc=$?
+  [ "$rc" -ne 0 ] || return 1
+  printf '%s' "$out" | grep -q 'could not confirm AGENTS.md is in sync' || return 1
+  # The false success must NOT also have been printed.
+  ! printf '%s' "$out" | grep -q 'AGENTS.md regenerated from CLAUDE.md' || return 1
+}
+
+# The write is skipped but --check still runs, so it reports drift and exits 1.
+test_agents_md_stale_after_regeneration_fails_the_bump() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  setup_agents_case "$dir" "nowrite"
+
+  local out rc=0
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || rc=$?
+  [ "$rc" -ne 0 ] || return 1
+  printf '%s' "$out" | grep -q 'could not confirm AGENTS.md is in sync' || return 1
+  ! printf '%s' "$out" | grep -q 'AGENTS.md regenerated from CLAUDE.md' || return 1
+}
+
+run_test "AGENTS.md regeneration reports success when it really regenerated" \
+  test_agents_md_regeneration_succeeds
+run_test "a generator that silently no-ops fails the bump (#7198 shape)" \
+  test_agents_md_silent_noop_fails_the_bump
+run_test "a stale AGENTS.md after regeneration fails the bump" \
+  test_agents_md_stale_after_regeneration_fails_the_bump
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -18,7 +18,10 @@
 #
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# -P on both: bash's logical `pwd` retains symlink components, which is the
+# non-canonical-path shape #7198 was about. Canonical here means every path
+# derived from ROOT is canonical too.
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd -P)"
 
 SKIP_CHANGELOG=0
 POSITIONAL=()
@@ -274,7 +277,20 @@ if [ -f "$CLAUDE_MD" ]; then
   # so regenerating here is not optional.
   if [ -f "$ROOT/scripts/gen-agents-md.mjs" ]; then
     node "$ROOT/scripts/gen-agents-md.mjs" >/dev/null
-    echo "  AGENTS.md regenerated from CLAUDE.md"
+    # Verify the postcondition instead of announcing it. `set -euo pipefail`
+    # only catches a NON-ZERO exit, and the defect class this regeneration
+    # exists to survive (#7198, #7214) is exit ZERO having done nothing — so in
+    # precisely the failure mode worth worrying about, an unconditional echo
+    # prints a success that is false and the release ships a stale AGENTS.md.
+    # --check re-derives from CLAUDE.md and exits 1 on drift, so it cannot be
+    # satisfied by the generator having skipped itself.
+    if node "$ROOT/scripts/gen-agents-md.mjs" --check >/dev/null 2>&1; then
+      echo "  AGENTS.md regenerated from CLAUDE.md"
+    else
+      echo "  ERROR: AGENTS.md is still out of sync with CLAUDE.md after regeneration" >&2
+      echo "  (the generator exited 0 without writing — see #7198 / #7214)" >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -278,19 +278,38 @@ if [ -f "$CLAUDE_MD" ]; then
   if [ -f "$ROOT/scripts/gen-agents-md.mjs" ]; then
     node "$ROOT/scripts/gen-agents-md.mjs" >/dev/null
     # Verify the postcondition instead of announcing it. `set -euo pipefail`
-    # only catches a NON-ZERO exit, and the defect class this regeneration
+    # catches only a NON-ZERO exit, and the defect class this regeneration
     # exists to survive (#7198, #7214) is exit ZERO having done nothing — so in
     # precisely the failure mode worth worrying about, an unconditional echo
     # prints a success that is false and the release ships a stale AGENTS.md.
-    # --check re-derives from CLAUDE.md and exits 1 on drift, so it cannot be
-    # satisfied by the generator having skipped itself.
-    if node "$ROOT/scripts/gen-agents-md.mjs" --check >/dev/null 2>&1; then
-      echo "  AGENTS.md regenerated from CLAUDE.md"
-    else
-      echo "  ERROR: AGENTS.md is still out of sync with CLAUDE.md after regeneration" >&2
-      echo "  (the generator exited 0 without writing — see #7198 / #7214)" >&2
-      exit 1
-    fi
+    #
+    # --check's EXIT CODE is not sufficient on its own, and assuming it was is
+    # how the first version of this check missed the very defect it names.
+    # --check exits 0 in two unrelated situations:
+    #
+    #   in sync           -> prints "AGENTS.md is in sync with CLAUDE.md."
+    #   never ran at all  -> prints NOTHING
+    #
+    # The second is the authentic #7198 shape: the entry-point guard reads
+    # false and skips this invocation exactly as it skipped the write above.
+    # Both exit 0, so only the confirmation LINE tells them apart. Requiring
+    # the line means a generator that silently declines to run cannot satisfy
+    # this check by staying quiet.
+    agents_check_out="$(node "$ROOT/scripts/gen-agents-md.mjs" --check 2>&1)" || true
+    case "$agents_check_out" in
+      *"is in sync with CLAUDE.md"*)
+        echo "  AGENTS.md regenerated from CLAUDE.md"
+        ;;
+      *)
+        echo "  ERROR: could not confirm AGENTS.md is in sync with CLAUDE.md" >&2
+        if [ -n "$agents_check_out" ]; then
+          echo "  generator said: $agents_check_out" >&2
+        else
+          echo "  the generator produced no output — it exited 0 without running (#7198 / #7214)" >&2
+        fi
+        exit 1
+        ;;
+    esac
   fi
 fi
 


### PR DESCRIPTION
`scripts/bump-version.sh` printed its success line unconditionally:

```sh
node "$ROOT/scripts/gen-agents-md.mjs" >/dev/null
echo "  AGENTS.md regenerated from CLAUDE.md"
```

`set -euo pipefail` catches only a **non-zero** exit, and the entire #7198/#7214 defect class is exit **zero** having done nothing. So in precisely the failure mode this regeneration exists to survive, the release printed a success that was false and carried a stale `AGENTS.md` into the CI drift gate.

## The change

Run `--check` afterwards and gate the message on it. `--check` re-derives from `CLAUDE.md`, so it cannot be satisfied by the generator having skipped itself.

```sh
if node "$ROOT/scripts/gen-agents-md.mjs" --check >/dev/null 2>&1; then
  echo "  AGENTS.md regenerated from CLAUDE.md"
else
  echo "  ERROR: AGENTS.md is still out of sync with CLAUDE.md after regeneration" >&2
  exit 1
fi
```

#7224 removes the current trigger for that no-op, but the caller was structurally unable to tell "regenerated" from "silently skipped" — and that is the half which does not depend on getting the guard right forever.

Also switches `ROOT` to `cd -P … && pwd -P`. Bash's logical `pwd` retains symlink components, which is the non-canonical-path shape #7198 was about, and every path in the script derives from `ROOT`.

## Verification

The first version of this fix did not work, and the mutation used to justify it was tailored to the fix rather than to the defect — review caught both. `--check` exits 0 in two unrelated situations:

```
$ node scripts/gen-agents-md.mjs --check          # in sync
AGENTS.md is in sync with CLAUDE.md.
exit=0

$ node scripts/gen-agents-md.mjs --check          # entry-point guard false
exit=0
output: ''
```

The second is the authentic #7198 shape: the guard skips the `--check` invocation exactly as it skips the write. So an exit-code-only check printed success anyway — identical to the unconditional `echo` it replaced. The confirmation **line** is the discriminator, and the check now requires it.

The suite also never entered this branch: `build_fake_repo` does not create `gen-agents-md.mjs`, so the file guard was always false and the original "18/18" was the pre-existing count. Three fixtures now stub the generator — `healthy`, `quiet` (both invocations no-op), `nowrite` (write skipped, `--check` real):

| bump-version.sh under test | exit | result |
|---|---|---|
| this PR | 0 | 21 passed, 0 failed |
| `origin/main` | **1** | **both** failure tests FAIL |
| the exit-code-only first attempt | **1** | `quiet` FAILS on behaviour; `nowrite` also fails, on asserted message wording |

The middle row proves the fixtures reach the branch at all; the last reproduces the review finding as a standing test. (Re-verification corrected this row: two tests fail against the first attempt, not one — `quiet` on the behaviour that matters, `nowrite` only because it asserts the new message wording.) `healthy` is a positive control — without it, a check that rejected every generator would pass both failure cases and look correct.

`bash -n` clean.

## On ROOT

`cd -P` + `pwd -P` turned out to be the load-bearing half. Reviewed against the real pre-#7217 guard, invoked through a `/tmp` symlink: `main` leaves AGENTS.md **stale** (the original #7198, reproduced), this branch leaves it **fresh** — canonicalising ROOT canonicalises `argv[1]`, so the guard's two sides agree. No consumer depends on the logical path.

## Known residual

#7231 tracks a separate gap found in review: the generator derives its own root from `import.meta.url`, so `--check` reports on the generator's tree rather than $ROOT. Coincident in normal use, divergent if the script is invoked from elsewhere. Left for its own change.

Closes #7227.
