### PR TITLE
refactor(ci): consolidate scripts/ entry-point guards, warn when undecidable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,6 +941,11 @@ jobs:
       - name: Run compile-skill-targets.mjs tests
         run: node scripts/__tests__/compile-skill-targets.test.mjs
 
+      - name: Run is-entry-point.mjs tests
+        # Also the drift gate for the guard's three un-shareable copies
+        # (scripts/lib, packages/server/src/utils, sidecar/agent.js) — #7222.
+        run: node scripts/__tests__/is-entry-point.test.mjs
+
       - name: Run lint-no-raw-color-literals golden test
         run: bash scripts/__tests__/lint-no-raw-color-literals.test.sh
 

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -15,7 +15,7 @@ import { spawn as nodeSpawn } from 'node:child_process'
 import { timingSafeEqual, randomUUID } from 'node:crypto'
 import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { Transform } from 'node:stream'
 import { WebSocketServer } from 'ws'
 
@@ -1279,7 +1279,11 @@ export class PodAgent {
 // comparison also breaks on any relative invocation (`node ./agent.js`).
 // This is a standalone in-pod bundle with its own package.json, so it cannot
 // import packages/server/src/utils/is-entry-point.js — duplicated on purpose
-// (#7213).
+// (#7213). The body below runs the same code as that file and as
+// scripts/lib/is-entry-point.mjs — inlined as an IIFE, so it reads
+// `import.meta.url` directly rather than taking it as a parameter. The drift
+// gate in scripts/__tests__/is-entry-point.test.mjs compares all three with
+// comments stripped and fails if they diverge; change one, change all (#7222).
 const invokedDirectly = (() => {
   if (!process.argv[1]) return false
   // The plain comparison runs first and is conclusive on its own: identical
@@ -1292,16 +1296,35 @@ const invokedDirectly = (() => {
   const self = fileURLToPath(import.meta.url)
   const invoked = resolve(process.argv[1])
   if (self === invoked) return true
+  const failures = []
   const real = (p) => {
     try {
       return realpathSync(p)
-    } catch {
+    } catch (err) {
+      failures.push({ path: p, code: err.code || err.message })
       return null
     }
   }
   const realSelf = real(self)
   const realInvoked = real(invoked)
-  return realSelf !== null && realSelf === realInvoked
+  if (realSelf !== null && realInvoked !== null) return realSelf === realInvoked
+
+  // Undecidable, but not silent (#7226): in a pod, an agent that starts and
+  // does nothing is indistinguishable from one that is merely idle, so the
+  // reason has to reach the container log. Only the genuinely UNKNOWN case
+  // warrants it — see the twin in packages/server/src/utils/is-entry-point.js
+  // for why `self` and `invoked` are not symmetric here.
+  const unknowable = realSelf === null ||
+    failures.some(({ code }) => code !== 'ENOENT' && code !== 'ENOTDIR')
+  if (unknowable) {
+    const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
+    console.warn(
+      `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
+      `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
+      'behaviour did NOT run. If you invoked it directly, it did nothing.',
+    )
+  }
+  return false
 })()
 
 if (invokedDirectly) {

--- a/packages/server/sidecar/agent.js
+++ b/packages/server/sidecar/agent.js
@@ -1311,19 +1311,15 @@ const invokedDirectly = (() => {
 
   // Undecidable, but not silent (#7226): in a pod, an agent that starts and
   // does nothing is indistinguishable from one that is merely idle, so the
-  // reason has to reach the container log. Only the genuinely UNKNOWN case
-  // warrants it — see the twin in packages/server/src/utils/is-entry-point.js
-  // for why `self` and `invoked` are not symmetric here.
-  const unknowable = realSelf === null ||
-    failures.some(({ code }) => code !== 'ENOENT' && code !== 'ENOTDIR')
-  if (unknowable) {
-    const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
-    console.warn(
-      `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
-      `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
-      'behaviour did NOT run. If you invoked it directly, it did nothing.',
-    )
-  }
+  // reason has to reach the container log. See the twin in
+  // packages/server/src/utils/is-entry-point.js for why this warns on ANY
+  // realpath failure rather than carving out ENOENT.
+  const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
+  console.warn(
+    `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
+    `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
+    'behaviour did NOT run. If you invoked it directly, it did nothing.',
+  )
   return false
 })()
 

--- a/packages/server/src/utils/is-entry-point.js
+++ b/packages/server/src/utils/is-entry-point.js
@@ -112,34 +112,26 @@ export function isEntryPoint(importMetaUrl) {
   const realInvoked = real(invoked)
   if (realSelf !== null && realInvoked !== null) return realSelf === realInvoked
 
-  // At least one side would not resolve, so the answer is `false` either way.
-  // Whether that `false` is DECIDED or merely UNKNOWN is a different question,
-  // and only the unknown one is worth a diagnostic (#7226). The two sides are
-  // not symmetric:
+  // Reaching here means realpath could not answer for at least one side, so
+  // whether a symlink still joins the two paths is unknowable and `false` is
+  // the only defensible return. It is not, however, an excuse for silence —
+  // that combination is what made #7198 and #7214 expensive (#7226).
   //
-  //   `self`    node LOADED this module, so its path resolved moments ago. If
-  //             it does not resolve now the ground moved underneath us — a
-  //             symlinked invocation whose target was unlinked, a directory
-  //             that lost its permissions — and whether a symlink still joins
-  //             the two paths is genuinely unknowable. Always warn.
-  //   `invoked` just a string the caller supplied. ENOENT/ENOTDIR means it
-  //             definitively does not exist, and a path that does not exist
-  //             cannot be the file we were loaded from — that is a DECIDED
-  //             false. Warning on it would fire on ordinary imports, where
-  //             argv[1] is some other script entirely, and a warning that
-  //             cries wolf on every import is worse than no warning at all.
-  //             Any other errno (EACCES, ELOOP, …) means the filesystem
-  //             refused to answer rather than answered "no", so it could still
-  //             be an inaccessible symlink to this very file: unknown, warn.
-  const unknowable = realSelf === null ||
-    failures.some(({ code }) => code !== 'ENOENT' && code !== 'ENOTDIR')
-  if (unknowable) {
-    const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
-    console.warn(
-      `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
-      `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
-      'behaviour did NOT run. If you invoked it directly, it did nothing.',
-    )
-  }
+  // An earlier version of this warned only when the errno was something other
+  // than ENOENT, on the theory that a non-existent argv[1] was a DECIDED false
+  // and warning on it would cry wolf during ordinary imports. Both halves were
+  // wrong. An ordinary import never reaches this line at all — argv[1] is the
+  // script node is running, so it exists, both realpaths succeed, and the
+  // comparison above returns. And ENOENT is not decided: argv[1] existed at
+  // exec time by construction, so ENOENT means it was REMOVED SINCE. Swap a
+  // `current -> releases-v1` symlink mid-run and you get exactly that — self
+  // resolves, invoked is ENOENT, and the module genuinely IS the entry point.
+  // The carve-out bought nothing and hid that case.
+  const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
+  console.warn(
+    `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
+    `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
+    'behaviour did NOT run. If you invoked it directly, it did nothing.',
+  )
   return false
 }

--- a/packages/server/tests/is-entry-point.test.js
+++ b/packages/server/tests/is-entry-point.test.js
@@ -21,6 +21,7 @@ let dir
 let realDir
 let linkDir
 let realScript
+let siblingScript
 let linkedScript
 
 before(() => {
@@ -33,6 +34,13 @@ before(() => {
   mkdirSync(realDir)
   realScript = join(realDir, 'probe.js')
   writeFileSync(realScript, 'export const x = 1\n')
+  // A real, EXISTING sibling. argv[1] pointing at a path that was never created
+  // looks like "some other script" but behaves nothing like one: realpath fails
+  // and the case short-circuits before the guard's main comparison. That gap let
+  // `return realSelf === realInvoked` be hardwired to `return true` — every
+  // ordinary import running main() — with the whole suite still green.
+  siblingScript = join(realDir, 'sibling.js')
+  writeFileSync(siblingScript, 'export const y = 2\n')
   symlinkSync(realDir, linkDir, 'dir')
   linkedScript = join(linkDir, 'probe.js')
 })
@@ -74,9 +82,20 @@ describe('isEntryPoint', () => {
   })
 
   it('is false when the module is merely imported', () => {
-    withArgv1(join(realDir, 'other.js'), () => {
+    withArgv1(siblingScript, () => {
       assert.equal(isEntryPoint(pathToFileURL(realScript).href), false)
     })
+  })
+
+  // The negative control for the guard's MAIN comparison: both paths exist and
+  // realpath cleanly, so the answer comes from `realSelf === realInvoked`
+  // rather than from a short-circuit. Without it, hardwiring that line to
+  // `return true` passed every test in this file.
+  it('is false when argv[1] is a DIFFERENT file that EXISTS', () => {
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(siblingScript, () => isEntryPoint(pathToFileURL(realScript).href)))
+    assert.equal(value, false, 'an ordinary import must not be treated as the entry point')
+    assert.deepEqual(lines, [], 'ordinary imports must stay silent')
   })
 
   // The original bug (#7198). Node's ESM loader resolves symlinks in
@@ -115,9 +134,10 @@ describe('isEntryPoint', () => {
   // become a blanket "true", or the assertion above would pass for the wrong
   // reason.
   it('is false for DIFFERING paths that cannot be realpath\'d', () => {
-    withArgv1(join(dir, 'nowhere', 'a.js'), () => {
-      assert.equal(isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href), false)
-    })
+    const { value } = capturingWarnings(() =>
+      withArgv1(join(dir, 'nowhere', 'a.js'), () =>
+        isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href)))
+    assert.equal(value, false)
   })
 
   it('is false when there is no invoked script (node -e, REPL)', () => {
@@ -152,8 +172,9 @@ describe('isEntryPoint', () => {
           isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href)))
       assert.equal(value, false, 'undecidable must still answer false')
       assert.equal(lines.length, 1, `expected exactly one warning, got ${JSON.stringify(lines)}`)
-      assert.match(lines[0], /\[is-entry-point]/)
-      assert.match(lines[0], /b\.js/)
+      // Anchored to the PREFIX: the path list in the reason also contains
+      // 'b.js', so a bare /b\.js/ passed even with basename(self) emptied.
+      assert.match(lines[0], /^\[is-entry-point] b\.js:/)
       // The reason, not just the fact: a bare "could not determine" sends the
       // reader back to reproducing it; the errno says which path broke and how.
       assert.match(lines[0], /ENOENT|EACCES/)
@@ -167,8 +188,7 @@ describe('isEntryPoint', () => {
     // the suite and the real signal would stop being read.
     it('stays silent for the ordinary imported-not-run false', () => {
       const { value, lines } = capturingWarnings(() =>
-        withArgv1(join(realDir, 'other.js'), () =>
-          isEntryPoint(pathToFileURL(realScript).href)))
+        withArgv1(siblingScript, () => isEntryPoint(pathToFileURL(realScript).href)))
       assert.equal(value, false)
       assert.deepEqual(lines, [], 'an imported module must not warn')
     })

--- a/packages/server/tests/is-entry-point.test.js
+++ b/packages/server/tests/is-entry-point.test.js
@@ -10,7 +10,7 @@
 // restores it afterwards.
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -48,6 +48,21 @@ const withArgv1 = (value, fn) => {
     return fn()
   } finally {
     process.argv[1] = saved
+  }
+}
+
+// The #7226 warning is captured rather than left to scroll past: a test that
+// only checked the boolean would pass identically whether the diagnostic was
+// printed or not, which is the same "assert the observable, not the intent"
+// reasoning as the rest of this file.
+const capturingWarnings = (fn) => {
+  const saved = console.warn
+  const lines = []
+  console.warn = (...args) => lines.push(args.join(' '))
+  try {
+    return { value: fn(), lines }
+  } finally {
+    console.warn = saved
   }
 }
 
@@ -121,5 +136,80 @@ describe('isEntryPoint', () => {
     } finally {
       process.chdir(saved)
     }
+  })
+
+  // --- #7226: undecidable must not also mean silent -------------------------
+  //
+  // `false` stays the right answer when the paths differ and cannot be
+  // resolved — but returning it without a word is the property that made #7198
+  // and #7214 expensive to find. These cases mirror
+  // scripts/__tests__/is-entry-point.test.mjs, which pins the scripts/ copy of
+  // this same guard; keep the two tables in step (#7222).
+  describe('the undecidable case warns (#7226)', () => {
+    it('warns when it returns false because realpath failed', () => {
+      const { value, lines } = capturingWarnings(() =>
+        withArgv1(join(dir, 'nowhere', 'a.js'), () =>
+          isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href)))
+      assert.equal(value, false, 'undecidable must still answer false')
+      assert.equal(lines.length, 1, `expected exactly one warning, got ${JSON.stringify(lines)}`)
+      assert.match(lines[0], /\[is-entry-point]/)
+      assert.match(lines[0], /b\.js/)
+      // The reason, not just the fact: a bare "could not determine" sends the
+      // reader back to reproducing it; the errno says which path broke and how.
+      assert.match(lines[0], /ENOENT|EACCES/)
+    })
+
+    // The other half of the acceptance criteria, and the one that keeps this
+    // from becoming noise. `self` and `invoked` are not symmetric: argv[1]
+    // pointing at a file that does not exist is a DECIDED false (it cannot be
+    // the module we were loaded from), and it is also what every ordinary
+    // import looks like. Warning there would fire on every guarded import in
+    // the suite and the real signal would stop being read.
+    it('stays silent for the ordinary imported-not-run false', () => {
+      const { value, lines } = capturingWarnings(() =>
+        withArgv1(join(realDir, 'other.js'), () =>
+          isEntryPoint(pathToFileURL(realScript).href)))
+      assert.equal(value, false)
+      assert.deepEqual(lines, [], 'an imported module must not warn')
+    })
+
+    it('stays silent when there is no invoked script (node -e, REPL)', () => {
+      const { value, lines } = capturingWarnings(() =>
+        withArgv1(undefined, () => isEntryPoint(pathToFileURL(realScript).href)))
+      assert.equal(value, false)
+      assert.deepEqual(lines, [])
+    })
+
+    it('stays silent on the happy path', () => {
+      const { value, lines } = capturingWarnings(() =>
+        withArgv1(realScript, () => isEntryPoint(pathToFileURL(realScript).href)))
+      assert.equal(value, true)
+      assert.deepEqual(lines, [])
+    })
+
+    // The boundary between the two cases above, and the only one that tells
+    // "argv[1] is absent" apart from "the filesystem refused to say". Both
+    // answer false; only this one is unknowable, because an unreadable path
+    // could still be a symlink to this very module. Without it, collapsing the
+    // rule back to "warn on any realpath failure" would pass every other test.
+    //
+    // chmod 0000 does not deny root, so this would exercise nothing as root.
+    const asRoot = typeof process.getuid === 'function' && process.getuid() === 0
+    it('warns when argv[1] is UNREADABLE rather than absent', { skip: asRoot && 'running as root' }, () => {
+      const locked = join(dir, 'locked')
+      mkdirSync(locked, { recursive: true })
+      writeFileSync(join(locked, 'entry.js'), '\n')
+      chmodSync(locked, 0o000)
+      try {
+        const { value, lines } = capturingWarnings(() =>
+          withArgv1(join(locked, 'entry.js'), () =>
+            isEntryPoint(pathToFileURL(realScript).href)))
+        assert.equal(value, false)
+        assert.equal(lines.length, 1, `EACCES is unknowable, not decided: ${JSON.stringify(lines)}`)
+        assert.match(lines[0], /EACCES/)
+      } finally {
+        chmodSync(locked, 0o755)
+      }
+    })
   })
 })

--- a/scripts/__tests__/gen-agents-md.test.mjs
+++ b/scripts/__tests__/gen-agents-md.test.mjs
@@ -155,6 +155,14 @@ export async function load (url, context, nextLoad) {
   // BREAK_ON is the last module the entry script pulls in, so every import has
   // resolved by the time this fires; BREAK_DIR is passed in rather than derived
   // from the module path, so the hook does not encode the staged layout.
+  // Unset, endsWith(undefined) coerces to the literal "undefined", the hook
+  // never fires, realpath is never broken — and --check then legitimately
+  // detects the stale AGENTS.md and prints the drift message, so the assertion
+  // cannot tell the difference. Deleting the env line left 8/8 green. Fail
+  // loudly instead of testing nothing.
+  if (!process.env.CHROXY_BREAK_ON) {
+    throw new Error('CHROXY_BREAK_ON is unset — the break would never fire and the test would pass vacuously')
+  }
   if (url.endsWith(process.env.CHROXY_BREAK_ON)) {
     if (process.env.CHROXY_BREAK === 'unlink') unlinkSync(process.env.CHROXY_BREAK_FILE)
     else if (process.env.CHROXY_BREAK === 'eacces') chmodSync(process.env.CHROXY_BREAK_DIR, 0o000)

--- a/scripts/__tests__/gen-agents-md.test.mjs
+++ b/scripts/__tests__/gen-agents-md.test.mjs
@@ -20,8 +20,22 @@ import { fileURLToPath } from 'node:url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const scriptPath = resolve(__dirname, '..', 'gen-agents-md.mjs')
+const libDir = resolve(__dirname, '..', 'lib')
 
 const { renderAgentsMd, readClaudeMd, readAgentsMd } = await import(scriptPath)
+
+// The subprocess fixtures below run the generator out of a temp tree, so they
+// have to stage everything it imports, not just the file itself. Copying the
+// whole scripts/lib directory rather than naming is-entry-point.mjs means the
+// next sibling helper is staged automatically — when the entry-point guard was
+// extracted there (#7222), a fixture that copied only gen-agents-md.mjs failed
+// with ERR_MODULE_NOT_FOUND, and a fixture that hardcodes one filename would
+// fail the same way on the next extraction.
+const stageGenerator = (scriptsDir) => {
+  mkdirSync(scriptsDir, { recursive: true })
+  cpSync(scriptPath, join(scriptsDir, 'gen-agents-md.mjs'))
+  cpSync(libDir, join(scriptsDir, 'lib'), { recursive: true })
+}
 
 let pass = 0
 let fail = 0
@@ -87,10 +101,9 @@ await test('runs through a symlinked invocation path (#7198)', async () => {
     // relative to its own parent directory, i.e. the repo root.
     const root = join(dir, 'root')
     const link = join(dir, 'link')
-    mkdirSync(join(root, 'scripts'), { recursive: true })
+    stageGenerator(join(root, 'scripts'))
     symlinkSync(root, link)
 
-    cpSync(scriptPath, join(root, 'scripts', 'gen-agents-md.mjs'))
     cpSync(resolve(__dirname, '..', '..', 'CLAUDE.md'), join(root, 'CLAUDE.md'))
     writeFileSync(join(root, 'AGENTS.md'), 'STALE\n')
 
@@ -121,16 +134,30 @@ await test('runs through a symlinked invocation path (#7198)', async () => {
 // read the script and BEFORE the module body evaluates, which is where the
 // guard runs. A `module.register` load hook sits exactly in that window: node
 // only has to LOAD the file, not keep it readable afterwards.
+//
+// "After node has read the script" means after it has read the WHOLE GRAPH,
+// not just the entry file — and that distinction became load-bearing when the
+// guard moved to scripts/lib/is-entry-point.mjs (#7222). Node links the graph
+// before evaluating any of it, so a hook that chmods the scripts directory on
+// the load of gen-agents-md.mjs fires while its `./lib/…` import is still
+// unresolved: the import then dies with EACCES and node exits 1 on the
+// uncaught error. That still satisfied a bare `status === 1`, so this test
+// went on passing while testing nothing — the vacuous-pass shape the positive
+// control below exists to catch, arriving through a door the control did not
+// cover. Hence both changes here: break on the LAST module in the graph, and
+// assert the drift MESSAGE rather than just the exit code, so a crash can
+// never again be mistaken for a detection.
 const HOOKS = `
 import { unlinkSync, chmodSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname } from 'node:path'
 export async function load (url, context, nextLoad) {
   const result = await nextLoad(url, context)
-  if (url.endsWith('/gen-agents-md.mjs')) {
-    const p = fileURLToPath(url)
-    if (process.env.CHROXY_BREAK === 'unlink') unlinkSync(p)
-    else if (process.env.CHROXY_BREAK === 'eacces') chmodSync(dirname(p), 0o000)
+  // BREAK_ON is the last module the entry script pulls in, so every import has
+  // resolved by the time this fires; BREAK_DIR is passed in rather than derived
+  // from the module path, so the hook does not encode the staged layout.
+  if (url.endsWith(process.env.CHROXY_BREAK_ON)) {
+    if (process.env.CHROXY_BREAK === 'unlink') unlinkSync(process.env.CHROXY_BREAK_FILE)
+    else if (process.env.CHROXY_BREAK === 'eacces') chmodSync(process.env.CHROXY_BREAK_DIR, 0o000)
   }
   return result
 }
@@ -148,8 +175,7 @@ const withBrokenRealpath = (breakMode, fn) => {
   const dir = mkdtempSync(join(realpathSync(tmpdir()), 'genagents-7214-'))
   const scriptsDir = join(dir, 'root', 'scripts')
   try {
-    mkdirSync(scriptsDir, { recursive: true })
-    cpSync(scriptPath, join(scriptsDir, 'gen-agents-md.mjs'))
+    stageGenerator(scriptsDir)
     cpSync(resolve(__dirname, '..', '..', 'CLAUDE.md'), join(dir, 'root', 'CLAUDE.md'))
     writeFileSync(join(dir, 'root', 'AGENTS.md'), 'STALE\n')
     writeFileSync(join(dir, 'hooks.mjs'), HOOKS)
@@ -157,12 +183,37 @@ const withBrokenRealpath = (breakMode, fn) => {
     fn(spawnSync(
       process.execPath,
       ['--import', join(dir, 'register.mjs'), join(scriptsDir, 'gen-agents-md.mjs'), '--check'],
-      { encoding: 'utf8', env: { ...process.env, CHROXY_BREAK: breakMode } },
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          CHROXY_BREAK: breakMode,
+          CHROXY_BREAK_ON: '/lib/is-entry-point.mjs',
+          CHROXY_BREAK_FILE: join(scriptsDir, 'gen-agents-md.mjs'),
+          CHROXY_BREAK_DIR: scriptsDir,
+        },
+      },
     ))
   } finally {
     chmodSync(scriptsDir, 0o755)
     rmSync(dir, { recursive: true, force: true })
   }
+}
+
+// Both #7214 cases assert on this, not on the exit code alone. `node` exits 1
+// for an uncaught module-load error too, so `status === 1` cannot distinguish
+// "the guard held and --check reported drift" from "the script never ran".
+// Requiring the generator's own message means only the first satisfies it.
+const DRIFT_MESSAGE = '::error::AGENTS.md is out of sync with CLAUDE.md'
+const assertDetectedDrift = (run) => {
+  assert(
+    run.status === 1,
+    `--check must exit 1 on drift; got ${run.status} (0 = the silent no-op this guards)\n${run.stderr}`,
+  )
+  assert(
+    run.stderr.includes(DRIFT_MESSAGE),
+    `exit 1 came from something other than drift detection — the generator never ran.\n${run.stderr}`,
+  )
 }
 
 // Positive control for the two tests below. If the hook does NOT actually break
@@ -177,11 +228,17 @@ await test('the load hook genuinely breaks realpath (positive control)', async (
   try {
     const probe = join(dir, 'probe.mjs')
     writeFileSync(probe, 'process.exit(0)\n')
-    writeFileSync(join(dir, 'hooks.mjs'), HOOKS.replace(/gen-agents-md\.mjs/g, 'probe.mjs'))
+    writeFileSync(join(dir, 'hooks.mjs'), HOOKS)
     writeFileSync(join(dir, 'register.mjs'), REGISTER)
     spawnSync(process.execPath, ['--import', join(dir, 'register.mjs'), probe], {
       encoding: 'utf8',
-      env: { ...process.env, CHROXY_BREAK: 'unlink' },
+      env: {
+        ...process.env,
+        CHROXY_BREAK: 'unlink',
+        CHROXY_BREAK_ON: '/probe.mjs',
+        CHROXY_BREAK_FILE: probe,
+        CHROXY_BREAK_DIR: dir,
+      },
     })
     let threw = false
     try {
@@ -196,8 +253,7 @@ await test('the load hook genuinely breaks realpath (positive control)', async (
 })
 
 await test('--check detects drift when the script is unlinked after launch (#7214)', async () => {
-  withBrokenRealpath('unlink', (run) =>
-    assert(run.status === 1, `--check must exit 1 on drift; got ${run.status} (0 = the silent no-op this guards)`))
+  withBrokenRealpath('unlink', assertDetectedDrift)
 })
 
 // chmod 0000 does not deny root, so as root realpath would succeed and this
@@ -207,8 +263,81 @@ if (typeof process.getuid === 'function' && process.getuid() === 0) {
   process.stdout.write('  skip --check detects drift when realpath fails with EACCES (#7214): running as root\n')
 } else {
   await test('--check detects drift when realpath fails with EACCES (#7214)', async () => {
-    withBrokenRealpath('eacces', (run) =>
-      assert(run.status === 1, `--check must exit 1 on drift; got ${run.status} (0 = the silent no-op this guards)`))
+    withBrokenRealpath('eacces', assertDetectedDrift)
+  })
+}
+
+// --- #7226: the residual undecidable case must say so ----------------------
+//
+// Everything above pins a case the guard can DECIDE. This is the one it
+// cannot: a direct invocation through a symlink whose realpath ALSO fails.
+// #7224 named it honestly as the residual, and `false` remains the only
+// defensible answer — whether a symlink still joins the two paths is not
+// knowable without the call that just failed.
+//
+// What was wrong was that it was also SILENT. The generator exited 0, wrote
+// nothing, and printed nothing; bump-version.sh calls this during a release and
+// could not tell that apart from success. So this test asserts the shape that
+// remains — still exit 0, still no regeneration — AND that the reason now
+// reaches stderr. It is the only test here that expects a no-op, which is
+// exactly why it has to prove the no-op announced itself.
+if (typeof process.getuid === 'function' && process.getuid() === 0) {
+  process.stdout.write('  skip the undecidable case warns instead of silently no-opping (#7226): running as root\n')
+} else {
+  await test('the undecidable case warns instead of silently no-opping (#7226)', async () => {
+    const dir = mkdtempSync(join(realpathSync(tmpdir()), 'genagents-7226-'))
+    const root = join(dir, 'root')
+    const scriptsDir = join(root, 'scripts')
+    const link = join(dir, 'link')
+    try {
+      stageGenerator(scriptsDir)
+      cpSync(resolve(__dirname, '..', '..', 'CLAUDE.md'), join(root, 'CLAUDE.md'))
+      writeFileSync(join(root, 'AGENTS.md'), 'STALE\n')
+      writeFileSync(join(dir, 'hooks.mjs'), HOOKS)
+      writeFileSync(join(dir, 'register.mjs'), REGISTER)
+      // Both triggers at once, which is what makes the case undecidable:
+      // invoked through the symlink so the paths differ (#7198's shape), with
+      // realpath broken so neither side can be resolved (#7214's shape).
+      symlinkSync(root, link)
+
+      const run = spawnSync(
+        process.execPath,
+        ['--import', join(dir, 'register.mjs'), join(link, 'scripts', 'gen-agents-md.mjs')],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            CHROXY_BREAK: 'eacces',
+            CHROXY_BREAK_ON: '/lib/is-entry-point.mjs',
+            CHROXY_BREAK_FILE: join(scriptsDir, 'gen-agents-md.mjs'),
+            CHROXY_BREAK_DIR: scriptsDir,
+          },
+        },
+      )
+
+      // The answer is still false, so the generator still declines to run.
+      // That part is correct and is NOT what this test is complaining about.
+      assert(run.status === 0, `expected the undecidable case to exit 0, got ${run.status}: ${run.stderr}`)
+      chmodSync(scriptsDir, 0o755)
+      assert(
+        readFileSync(join(root, 'AGENTS.md'), 'utf8') === 'STALE\n',
+        'the undecidable case must not regenerate — it cannot know it is the entry point',
+      )
+
+      // ...but it must no longer do that silently. Without this assertion the
+      // test above is satisfied by the exact bug #7226 was filed about.
+      assert(
+        run.stderr.includes('[is-entry-point]'),
+        `the guard declined silently — nothing on stderr explains the no-op:\n${JSON.stringify(run.stderr)}`,
+      )
+      assert(
+        /EACCES/.test(run.stderr),
+        `the warning must carry the reason, not just the fact:\n${run.stderr}`,
+      )
+    } finally {
+      chmodSync(scriptsDir, 0o755)
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 }
 

--- a/scripts/__tests__/is-entry-point.test.mjs
+++ b/scripts/__tests__/is-entry-point.test.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * is-entry-point.test.mjs — pins scripts/lib/is-entry-point.mjs (#7222, #7226).
+ *
+ * The guard's failure mode is SILENCE: it returns false, the CLI branch never
+ * runs, and the process exits 0. Nothing observable distinguishes that from a
+ * clean no-op, which is how the bug survived in four files (#7198, #7213,
+ * #7214). So every case here asserts the boolean directly rather than any
+ * downstream side effect.
+ *
+ * The case table below is deliberately the same one as
+ * packages/server/tests/is-entry-point.test.js. That file cannot be shared —
+ * `scripts/` is outside every workspace package and imports nothing from
+ * `packages/*​/src` — so the two copies of the guard are held equal by testing
+ * both against equivalent tables rather than by a single import. If you add a
+ * case to one, add it to the other.
+ *
+ * `process.argv[1]` is read at call time, which is what makes these tests
+ * possible in-process: each one points argv[1] at a path it controls and
+ * restores it afterwards.
+ *
+ * No external test framework. Run from repo root:
+ *   node scripts/__tests__/is-entry-point.test.mjs
+ */
+
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { isEntryPoint } from '../lib/is-entry-point.mjs'
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+let pass = 0
+let fail = 0
+const failures = []
+
+const test = (name, fn) => {
+  try {
+    fn()
+    pass++
+    process.stdout.write(`  ok ${name}\n`)
+  } catch (err) {
+    fail++
+    failures.push({ name, err })
+    process.stdout.write(`  FAIL ${name}: ${err.message}\n`)
+  }
+}
+
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg || 'assertion failed')
+}
+
+// The base is deliberately NOT realpath'd. On macOS os.tmpdir() is under /var,
+// itself a symlink to /private/var — so these paths carry a real unresolved
+// symlink, the same shape as the /tmp case that started this.
+const dir = mkdtempSync(join(tmpdir(), 'chroxy-entry-'))
+const realDir = join(dir, 'real')
+const linkDir = join(dir, 'link')
+mkdirSync(realDir)
+const realScript = join(realDir, 'probe.js')
+writeFileSync(realScript, 'export const x = 1\n')
+symlinkSync(realDir, linkDir, 'dir')
+const linkedScript = join(linkDir, 'probe.js')
+
+const withArgv1 = (value, fn) => {
+  const saved = process.argv[1]
+  process.argv[1] = value
+  try {
+    return fn()
+  } finally {
+    process.argv[1] = saved
+  }
+}
+
+// The warning is the whole point of #7226, so it is captured rather than left
+// to scroll past: a test that only checked the boolean would pass identically
+// whether the diagnostic was printed or not.
+const capturingWarnings = (fn) => {
+  const saved = console.warn
+  const lines = []
+  console.warn = (...args) => lines.push(args.join(' '))
+  try {
+    return { value: fn(), lines }
+  } finally {
+    console.warn = saved
+  }
+}
+
+try {
+  test('is true when the module IS the invoked script', () => {
+    withArgv1(realScript, () => {
+      assert(isEntryPoint(pathToFileURL(realScript).href) === true)
+    })
+  })
+
+  test('is false when the module is merely imported', () => {
+    withArgv1(join(realDir, 'other.js'), () => {
+      assert(isEntryPoint(pathToFileURL(realScript).href) === false)
+    })
+  })
+
+  // The original bug (#7198). Node's ESM loader resolves symlinks in
+  // import.meta.url; argv[1] is whatever the caller typed. Every hand-rolled
+  // guard compared one against the other and read false.
+  test('is true when invoked through a symlinked directory', () => {
+    withArgv1(linkedScript, () => {
+      assert(isEntryPoint(pathToFileURL(realScript).href) === true)
+    })
+  })
+
+  test('is true when import.meta.url is the symlinked side', () => {
+    withArgv1(realScript, () => {
+      assert(isEntryPoint(pathToFileURL(linkedScript).href) === true)
+    })
+  })
+
+  // The #7217 review finding, and the reason the plain comparison runs first.
+  // A path that cannot be realpath'd stands in for the EACCES / unlinked-script
+  // cases that are not portable to construct: ENOENT takes the identical branch.
+  //
+  // Mutation check: put the realpath comparison back in front of the plain one
+  // and this is the assertion that goes red.
+  test("is true for identical paths even when they cannot be realpath'd", () => {
+    const ghost = join(dir, 'does-not-exist', 'probe.js')
+    withArgv1(ghost, () => {
+      assert(isEntryPoint(pathToFileURL(ghost).href) === true)
+    })
+  })
+
+  // Negative control for the case above: the un-realpath-able path must not
+  // become a blanket "true", or the assertion above would pass for the wrong
+  // reason.
+  test("is false for DIFFERING paths that cannot be realpath'd", () => {
+    withArgv1(join(dir, 'nowhere', 'a.js'), () => {
+      assert(isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href) === false)
+    })
+  })
+
+  test('is false when there is no invoked script (node -e, REPL)', () => {
+    withArgv1(undefined, () => {
+      assert(isEntryPoint(pathToFileURL(realScript).href) === false)
+    })
+  })
+
+  test('resolves a relative argv[1] before comparing', () => {
+    const saved = process.cwd()
+    process.chdir(realDir)
+    try {
+      withArgv1('./probe.js', () => {
+        assert(isEntryPoint(pathToFileURL(realScript).href) === true)
+      })
+    } finally {
+      process.chdir(saved)
+    }
+  })
+
+  // --- #7226: undecidable must not also mean silent ------------------------
+  //
+  // "Undecidable" is the honest answer for differing paths that cannot be
+  // realpath'd, and `false` stays the right return. What was wrong was that
+  // nothing was printed: a human running the script directly saw an exit-0
+  // no-op with no output, which is the property that made #7198 and #7214
+  // expensive to find.
+  test('warns when it returns false because realpath FAILED (#7226)', () => {
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(join(dir, 'nowhere', 'a.js'), () =>
+        isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href)))
+    assert(value === false, 'undecidable must still answer false')
+    assert(lines.length === 1, `expected exactly one warning, got ${lines.length}: ${JSON.stringify(lines)}`)
+    assert(lines[0].includes('[is-entry-point]'), 'warning must be attributable to this guard')
+    assert(lines[0].includes('b.js'), "warning must name the module that could not decide")
+    // The reason, not just the fact. A bare "could not determine" sends the
+    // reader back to reproducing it; the errno says which path broke and how.
+    assert(/ENOENT|EACCES/.test(lines[0]), `warning must carry the realpath errno: ${lines[0]}`)
+  })
+
+  // The other half of the acceptance criteria, and the one that keeps this
+  // from becoming noise: the ORDINARY false — "this module was imported" —
+  // must stay quiet, or every test run that imports a guarded module prints a
+  // spurious warning and the real one stops being noticed.
+  test('stays SILENT for the ordinary imported-not-run false (#7226)', () => {
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(join(realDir, 'other.js'), () =>
+        isEntryPoint(pathToFileURL(realScript).href)))
+    assert(value === false)
+    assert(lines.length === 0, `imported-module case must not warn, got: ${JSON.stringify(lines)}`)
+  })
+
+  // The boundary of the rule above, and the only case that distinguishes
+  // "argv[1] does not exist" from "the filesystem refused to say". Both make
+  // realpath return null and both answer false; only this one is UNKNOWABLE,
+  // because an unreadable path could still be a symlink to this very module.
+  // Without this case the ENOENT/EACCES split is asserted in only one
+  // direction, and collapsing it back to "warn on any failure" would go
+  // undetected by every other test here.
+  //
+  // chmod 0000 does not deny root, so as root this would exercise nothing.
+  // Skipped rather than silently weakened.
+  if (typeof process.getuid === 'function' && process.getuid() === 0) {
+    process.stdout.write('  skip warns when argv[1] is unreadable rather than absent (#7226): running as root\n')
+  } else {
+    test('warns when argv[1] is UNREADABLE rather than absent (#7226)', () => {
+      const locked = join(dir, 'locked')
+      mkdirSync(locked)
+      writeFileSync(join(locked, 'entry.js'), '\n')
+      chmodSync(locked, 0o000)
+      try {
+        const { value, lines } = capturingWarnings(() =>
+          withArgv1(join(locked, 'entry.js'), () =>
+            isEntryPoint(pathToFileURL(realScript).href)))
+        assert(value === false)
+        assert(lines.length === 1, `EACCES on argv[1] is unknowable, not decided: ${JSON.stringify(lines)}`)
+        assert(/EACCES/.test(lines[0]), `warning must carry the errno: ${lines[0]}`)
+      } finally {
+        chmodSync(locked, 0o755)
+      }
+    })
+  }
+
+  test('stays SILENT when there is no invoked script at all (#7226)', () => {
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(undefined, () => isEntryPoint(pathToFileURL(realScript).href)))
+    assert(value === false)
+    assert(lines.length === 0, `node -e / REPL must not warn, got: ${JSON.stringify(lines)}`)
+  })
+
+  test('stays SILENT on the happy path (#7226)', () => {
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(realScript, () => isEntryPoint(pathToFileURL(realScript).href)))
+    assert(value === true)
+    assert(lines.length === 0, `direct invocation must not warn, got: ${JSON.stringify(lines)}`)
+  })
+
+  // --- #7222: the drift gate ------------------------------------------------
+  //
+  // This guard exists in three places and cannot be reduced to one. `scripts/`
+  // imports nothing from `packages/*​/src`, and sidecar/agent.js ships as a
+  // standalone in-pod bundle whose Dockerfile COPYs only agent.js and its
+  // package.json — so neither can import the other.
+  //
+  // "Keep them in sync by hand" is exactly the arrangement that produced #7198:
+  // one guard was fixed, three were not, and nothing said so because the
+  // failure mode is silence. Comments asking the next person to remember do not
+  // fail a build. This does.
+  //
+  // Comments are stripped before comparing because they legitimately differ —
+  // the sidecar's talk about pods — and `import.meta.url` is normalised to the
+  // parameter name because the sidecar is an inline IIFE rather than a function
+  // taking the URL as an argument. Everything else must match exactly.
+  const GUARD_COPIES = [
+    'scripts/lib/is-entry-point.mjs',
+    'packages/server/src/utils/is-entry-point.js',
+    'packages/server/sidecar/agent.js',
+  ]
+
+  const extractGuard = (relPath) => {
+    const lines = readFileSync(join(REPO, relPath), 'utf8').split('\n')
+    const start = lines.findIndex((l) => l.includes('if (!process.argv[1]) return false'))
+    if (start === -1) throw new Error(`${relPath}: could not find the start of the guard`)
+    const end = lines.indexOf('  return false', start)
+    if (end === -1) throw new Error(`${relPath}: could not find the end of the guard`)
+    return lines
+      .slice(start, end + 1)
+      .map((l) => l.replace(/\s+$/, ''))
+      .filter((l) => l.trim() !== '' && !l.trim().startsWith('//'))
+      .join('\n')
+      .replace(/import\.meta\.url/g, 'importMetaUrl')
+  }
+
+  // Positive control. Every assertion below compares extracted text, so an
+  // extraction that silently returned '' — a renamed variable, a reformatted
+  // line, a moved guard — would make all three compare equal and the gate would
+  // report success having compared nothing. That is the same vacuous-pass shape
+  // the rest of this file is written against, so prove the extraction found
+  // real code before trusting any comparison of it.
+  test('the guard extraction finds real code in every copy (positive control)', () => {
+    for (const relPath of GUARD_COPIES) {
+      const body = extractGuard(relPath)
+      const count = body.split('\n').length
+      assert(count >= 20, `${relPath}: extracted only ${count} line(s) — the gate below would be vacuous`)
+      assert(body.includes('realpathSync'), `${relPath}: extract is missing the realpath call`)
+      assert(body.includes('unknowable'), `${relPath}: extract is missing the #7226 decision`)
+    }
+  })
+
+  test('all three copies of the guard are identical (#7222 drift gate)', () => {
+    const [reference, ...rest] = GUARD_COPIES.map((p) => [p, extractGuard(p)])
+    for (const [relPath, body] of rest) {
+      assert(
+        body === reference[1],
+        `${relPath} has drifted from ${reference[0]}.\n` +
+        'These three copies must stay in step — see the header of scripts/lib/is-entry-point.mjs.\n' +
+        `--- ${reference[0]}\n${reference[1]}\n--- ${relPath}\n${body}`,
+      )
+    }
+  })
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
+if (fail > 0) {
+  for (const f of failures) {
+    process.stderr.write(`\n[FAIL] ${f.name}\n${f.err.stack || f.err.message}\n`)
+  }
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/__tests__/is-entry-point.test.mjs
+++ b/scripts/__tests__/is-entry-point.test.mjs
@@ -23,7 +23,7 @@
  *   node scripts/__tests__/is-entry-point.test.mjs
  */
 
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -32,8 +32,14 @@ import { isEntryPoint } from '../lib/is-entry-point.mjs'
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
+// Every case in this file, including the ones that skip themselves. Bump it
+// when you add one — that is the point: a case that vanishes should break the
+// run rather than quietly shrink it.
+const MIN_CASES = 18
+
 let pass = 0
 let fail = 0
+let skipped = 0
 const failures = []
 
 const test = (name, fn) => {
@@ -61,6 +67,14 @@ const linkDir = join(dir, 'link')
 mkdirSync(realDir)
 const realScript = join(realDir, 'probe.js')
 writeFileSync(realScript, 'export const x = 1\n')
+// A real, EXISTING sibling. Pointing argv[1] at a path that was never created
+// looks like "some other script" but behaves nothing like one: realpath fails,
+// so every such case short-circuits before the guard's main comparison is ever
+// reached. That fixture gap let `return realSelf === realInvoked` be hardwired
+// to `return true` — every ordinary import running main() — with all three
+// suites still green.
+const siblingScript = join(realDir, 'sibling.js')
+writeFileSync(siblingScript, 'export const y = 2\n')
 symlinkSync(realDir, linkDir, 'dir')
 const linkedScript = join(linkDir, 'probe.js')
 
@@ -96,9 +110,20 @@ try {
   })
 
   test('is false when the module is merely imported', () => {
-    withArgv1(join(realDir, 'other.js'), () => {
+    withArgv1(siblingScript, () => {
       assert(isEntryPoint(pathToFileURL(realScript).href) === false)
     })
+  })
+
+  // The negative control for the guard's MAIN comparison, and the one the
+  // suite was missing: both paths exist and realpath cleanly, so the answer
+  // comes from `realSelf === realInvoked` rather than from a short-circuit.
+  // Without it, hardwiring that line to `return true` passed every test here.
+  test('is false when argv[1] is a DIFFERENT file that EXISTS', () => {
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(siblingScript, () => isEntryPoint(pathToFileURL(realScript).href)))
+    assert(value === false, 'an ordinary import must not be treated as the entry point')
+    assert(lines.length === 0, `ordinary imports must stay silent, got: ${JSON.stringify(lines)}`)
   })
 
   // The original bug (#7198). Node's ESM loader resolves symlinks in
@@ -120,22 +145,27 @@ try {
   // A path that cannot be realpath'd stands in for the EACCES / unlinked-script
   // cases that are not portable to construct: ENOENT takes the identical branch.
   //
-  // Mutation check: put the realpath comparison back in front of the plain one
-  // and this is the assertion that goes red.
+  // Mutation check: DELETING the plain comparison reddens this. Note that
+  // merely REORDERING it after the realpath decision does not — the answer
+  // stays true via realpath — which is why the silence assertion is here too.
+  // A reordered guard warns on a successful direct run whose path cannot be
+  // realpath'd: the cry-wolf failure #7226's own rationale argues against.
   test("is true for identical paths even when they cannot be realpath'd", () => {
     const ghost = join(dir, 'does-not-exist', 'probe.js')
-    withArgv1(ghost, () => {
-      assert(isEntryPoint(pathToFileURL(ghost).href) === true)
-    })
+    const { value, lines } = capturingWarnings(() =>
+      withArgv1(ghost, () => isEntryPoint(pathToFileURL(ghost).href)))
+    assert(value === true)
+    assert(lines.length === 0, `a decided TRUE must not warn, got: ${JSON.stringify(lines)}`)
   })
 
   // Negative control for the case above: the un-realpath-able path must not
   // become a blanket "true", or the assertion above would pass for the wrong
   // reason.
   test("is false for DIFFERING paths that cannot be realpath'd", () => {
-    withArgv1(join(dir, 'nowhere', 'a.js'), () => {
-      assert(isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href) === false)
-    })
+    const { value } = capturingWarnings(() =>
+      withArgv1(join(dir, 'nowhere', 'a.js'), () =>
+        isEntryPoint(pathToFileURL(join(dir, 'nowhere', 'b.js')).href)))
+    assert(value === false)
   })
 
   test('is false when there is no invoked script (node -e, REPL)', () => {
@@ -156,6 +186,30 @@ try {
     }
   })
 
+  // The case above passes even without resolve(), because realpathSync ALSO
+  // resolves a relative path against cwd — so it drops through to the realpath
+  // fallback and still answers true. What actually needs resolve() is the
+  // FILESYSTEM-FREE fast path the sidecar's comment cites (`node ./agent.js`):
+  // with a path that cannot be realpath'd, only resolve() can still decide.
+  test('resolves a relative argv[1] WITHOUT touching the filesystem', () => {
+    const saved = process.cwd()
+    // Canonical, unlike the other fixtures here. process.cwd() reports a
+    // realpath'd path, so chdir'ing into the symlinked /var form would make
+    // resolve() and `self` disagree for a reason that has nothing to do with
+    // this test — it would fall through to realpath and prove nothing.
+    const canonicalDir = realpathSync(realDir)
+    process.chdir(canonicalDir)
+    try {
+      const ghost = join(canonicalDir, 'ghost.js')
+      const { value, lines } = capturingWarnings(() =>
+        withArgv1('./ghost.js', () => isEntryPoint(pathToFileURL(ghost).href)))
+      assert(value === true, 'a relative direct invocation must decide without realpath')
+      assert(lines.length === 0, `the fast path must not warn, got: ${JSON.stringify(lines)}`)
+    } finally {
+      process.chdir(saved)
+    }
+  })
+
   // --- #7226: undecidable must not also mean silent ------------------------
   //
   // "Undecidable" is the honest answer for differing paths that cannot be
@@ -170,7 +224,11 @@ try {
     assert(value === false, 'undecidable must still answer false')
     assert(lines.length === 1, `expected exactly one warning, got ${lines.length}: ${JSON.stringify(lines)}`)
     assert(lines[0].includes('[is-entry-point]'), 'warning must be attributable to this guard')
-    assert(lines[0].includes('b.js'), "warning must name the module that could not decide")
+    // Anchored to the PREFIX, not just "contains b.js": the path list in the
+    // reason also contains 'b.js', so a `contains` check passed even with
+    // `${basename(self)}` replaced by the empty string.
+    assert(/^\[is-entry-point] b\.js:/.test(lines[0]),
+      `warning must lead with the module that could not decide: ${lines[0]}`)
     // The reason, not just the fact. A bare "could not determine" sends the
     // reader back to reproducing it; the errno says which path broke and how.
     assert(/ENOENT|EACCES/.test(lines[0]), `warning must carry the realpath errno: ${lines[0]}`)
@@ -182,8 +240,7 @@ try {
   // spurious warning and the real one stops being noticed.
   test('stays SILENT for the ordinary imported-not-run false (#7226)', () => {
     const { value, lines } = capturingWarnings(() =>
-      withArgv1(join(realDir, 'other.js'), () =>
-        isEntryPoint(pathToFileURL(realScript).href)))
+      withArgv1(siblingScript, () => isEntryPoint(pathToFileURL(realScript).href)))
     assert(value === false)
     assert(lines.length === 0, `imported-module case must not warn, got: ${JSON.stringify(lines)}`)
   })
@@ -199,6 +256,7 @@ try {
   // chmod 0000 does not deny root, so as root this would exercise nothing.
   // Skipped rather than silently weakened.
   if (typeof process.getuid === 'function' && process.getuid() === 0) {
+    skipped++
     process.stdout.write('  skip warns when argv[1] is unreadable rather than absent (#7226): running as root\n')
   } else {
     test('warns when argv[1] is UNREADABLE rather than absent (#7226)', () => {
@@ -281,7 +339,31 @@ try {
       const count = body.split('\n').length
       assert(count >= 20, `${relPath}: extracted only ${count} line(s) — the gate below would be vacuous`)
       assert(body.includes('realpathSync'), `${relPath}: extract is missing the realpath call`)
-      assert(body.includes('unknowable'), `${relPath}: extract is missing the #7226 decision`)
+      assert(body.includes('console.warn'), `${relPath}: extract is missing the #7226 diagnostic`)
+      assert(body.includes('realSelf'), `${relPath}: extract is missing the realpath comparison`)
+    }
+  })
+
+  // The extraction starts at the argv[1] line, so the import statements sit
+  // OUTSIDE the compared region — and `basename` is used only inside the warn
+  // branch. Dropping it from any one copy left the gate green while making that
+  // copy throw ReferenceError the moment the branch fired. In the sidecar that
+  // means the pod dies at startup, in the one branch whose entire job is to
+  // explain a problem: strictly worse than the silent no-op it replaced.
+  test('every copy imports the bindings its guard body uses (#7222)', () => {
+    const NEEDED = ['realpathSync', 'basename', 'resolve', 'fileURLToPath']
+    for (const relPath of GUARD_COPIES) {
+      const src = readFileSync(join(REPO, relPath), 'utf8')
+      const imports = src.split('\n').filter((l) => l.trimStart().startsWith('import '))
+      assert(imports.length, `${relPath}: no import statements found — extraction is wrong`)
+      const bound = imports.join('\n')
+      for (const name of NEEDED) {
+        assert(
+          new RegExp(`\\b${name}\\b`).test(bound),
+          `${relPath} uses ${name} in the guard but never imports it — ` +
+          'the drift gate cannot see this because imports are outside the compared region',
+        )
+      }
     }
   })
 
@@ -300,7 +382,20 @@ try {
   rmSync(dir, { recursive: true, force: true })
 }
 
-process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
+// A count floor. Several cases skip themselves as root (chmod 0000 does not
+// deny root), and the self-hosted Linux pool has root container members — so
+// without this, a run there prints "14 passed, 0 failed", exits 0, and looks
+// identical to a healthy run. Scripts Tests has no coverage threshold to catch
+// it either. Assert the shape of the run, not just that nothing failed.
+const EXPECTED = pass + fail + skipped
+if (EXPECTED < MIN_CASES) {
+  process.stderr.write(
+    `\nERROR: only ${EXPECTED} case(s) accounted for, expected at least ${MIN_CASES}. ` +
+    'Cases went missing rather than failing — check the root/platform skips.\n',
+  )
+  process.exit(1)
+}
+process.stdout.write(`\n${pass} passed, ${fail} failed${skipped ? `, ${skipped} skipped` : ''}\n`)
 if (fail > 0) {
   for (const f of failures) {
     process.stderr.write(`\n[FAIL] ${f.name}\n${f.err.stack || f.err.message}\n`)

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -20,10 +20,11 @@
 //        [--repo <root>] [--dry-run]
 //
 // Exit non-zero on emit failure so /skill and CI can gate on it.
-import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, realpathSync } from 'node:fs'
-import { join, dirname, resolve } from 'node:path'
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
-import { fileURLToPath } from 'node:url'
+
+import { isEntryPoint } from './lib/is-entry-point.mjs'
 
 export const ALL_TARGETS = ['claude', 'gemini', 'codex', 'pi']
 
@@ -347,39 +348,13 @@ function main() {
 
 // Run the CLI only when invoked directly (`node compile-skill-targets.mjs`), not
 // when a test imports this module for unit coverage of deriveDescription().
-// Both sides realpath'd. Node's ESM loader resolves symlinks in
-// `import.meta.url` but leaves argv[1] as typed, and `resolve()` does not
-// follow symlinks — so on macOS, where /tmp is a symlink to /private/tmp,
-// this compared '/private/tmp/…' against '/tmp/…', read false, and the script
-// exited 0 having compiled nothing (#7213, same bug as #7198).
 //
-// packages/server/src/utils/is-entry-point.js is the shared implementation;
-// scripts/ is outside that package's scope, so the logic is duplicated here
-// deliberately rather than reaching across packages for six lines.
-const invokedDirectly = (() => {
-  if (!process.argv[1]) return false
-  // The plain comparison runs first and is conclusive on its own: identical
-  // paths mean this IS the entry point, decided without touching the
-  // filesystem. Consulting realpath first and reading a failure as false lets
-  // an EACCES on a parent directory (or a script unlinked after launch) turn a
-  // direct run into a silent exit-0 no-op — the exact class this guard exists
-  // to remove (#7217 review). Realpath is only needed when the paths differ,
-  // where a symlink is the sole thing that can still make them one file.
-  const self = fileURLToPath(import.meta.url)
-  const invoked = resolve(process.argv[1])
-  if (self === invoked) return true
-  const real = (p) => {
-    try {
-      return realpathSync(p)
-    } catch {
-      return null
-    }
-  }
-  const realSelf = real(self)
-  const realInvoked = real(invoked)
-  return realSelf !== null && realSelf === realInvoked
-})()
-
-if (invokedDirectly) {
+// The guard lives in scripts/lib/is-entry-point.mjs. It used to be inlined
+// here AND in gen-agents-md.mjs — two hand-maintained copies of the same
+// fifteen lines, which is the duplication #7213 was filed to remove, recreated
+// one directory down (#7222). Without it, invoking this through a symlinked
+// path on macOS read false and the script exited 0 having compiled nothing
+// (#7198 / #7213).
+if (isEntryPoint(import.meta.url)) {
   main()
 }

--- a/scripts/gen-agents-md.mjs
+++ b/scripts/gen-agents-md.mjs
@@ -12,9 +12,11 @@
 // Keeping CLAUDE.md as the ONE source and generating AGENTS.md means the two can
 // never drift and a convention can never be silently dropped from the mirror.
 
-import { readFileSync, writeFileSync, realpathSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
+
+import { isEntryPoint } from './lib/is-entry-point.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const CLAUDE_PATH = join(ROOT, 'CLAUDE.md')
@@ -63,46 +65,18 @@ export function readAgentsMd() {
 
 // Only run the CLI side-effects when invoked directly (not when imported by tests).
 //
-// Both sides are realpath'd, not just `resolve`d. Node's ESM loader resolves
-// symlinks in `import.meta.url`, but `process.argv[1]` is left exactly as the
-// caller typed it, and `resolve()` does not follow symlinks — so on macOS,
-// where /tmp is a symlink to /private/tmp, invoking this as
-// `node /tmp/…/gen-agents-md.mjs` gave '/private/tmp/…' on one side and
-// '/tmp/…' on the other. The guard was false, the CLI branch never ran, and
-// the script exited 0 having done nothing (#7198).
+// The guard lives in scripts/lib/is-entry-point.mjs — this file used to carry
+// its own copy of the same realpath comparison, and so did
+// compile-skill-targets.mjs, which is the "one bug, N copies" shape #7213 was
+// filed to remove, recreated one directory down (#7222).
 //
-// That silence is the dangerous part: bump-version.sh calls this and trusts
-// the exit code, so a release could regenerate nothing and still report
-// success — the same shape as every other guard-that-quietly-no-ops fixed
-// this cycle. realpathSync is wrapped because argv[1] need not exist (an
-// `-e` eval, a deleted script); an unresolvable path simply is not this file.
-const invokedDirectly = (() => {
-  if (!process.argv[1]) return false
-  // The plain comparison runs first and is conclusive on its own: identical
-  // paths mean this IS the entry point, decided without touching the
-  // filesystem. Consulting realpath first and reading a failure as false let an
-  // EACCES on a parent directory (or a script unlinked after launch) turn a
-  // direct run into a silent exit-0 no-op — the same shape as #7198, reached
-  // through a different trigger (#7214). Realpath is only needed once the paths
-  // differ, where a symlink is the only thing that still makes them one file —
-  // the same wording as the canonical copy in
-  // packages/server/src/utils/is-entry-point.js, deliberately.
-  const self = fileURLToPath(import.meta.url)
-  const argv = resolve(process.argv[1])
-  if (self === argv) return true
-  const realpathOrNull = (p) => {
-    try {
-      return realpathSync(p)
-    } catch {
-      return null
-    }
-  }
-  const realSelf = realpathOrNull(self)
-  const realArgv = realpathOrNull(argv)
-  return realSelf !== null && realSelf === realArgv
-})()
-
-if (invokedDirectly) {
+// Why the guard is not a one-liner, in short: Node's ESM loader resolves
+// symlinks in `import.meta.url` but leaves argv[1] as the caller typed it, so
+// invoking this through /tmp on macOS compared '/private/tmp/…' against
+// '/tmp/…', read false, and exited 0 having regenerated NOTHING (#7198). That
+// silence is the dangerous part — bump-version.sh calls this during a release
+// and cannot see the difference between "in sync" and "never ran".
+if (isEntryPoint(import.meta.url)) {
   const expected = renderAgentsMd(readClaudeMd())
   if (process.argv.includes('--check')) {
     if (readAgentsMd() !== expected) {

--- a/scripts/lib/is-entry-point.mjs
+++ b/scripts/lib/is-entry-point.mjs
@@ -1,55 +1,38 @@
-// is-entry-point.js — "was this module run directly, or imported?"
+// is-entry-point.mjs — "was this module run directly, or imported?"
 //
-// Every hand-rolled version of this check in the repo was wrong the same way,
-// so there is one implementation per reachable scope now (#7213, after #7198).
-// Two other copies exist and cannot import this one:
+// The one implementation for `scripts/`. It is a deliberate second copy of
+// packages/server/src/utils/is-entry-point.js: `scripts/` sits outside every
+// workspace package, and no script in this directory reaches into
+// `packages/*/src` for anything (#7217). A third copy is inlined in
+// packages/server/sidecar/agent.js, which ships as a standalone in-pod bundle
+// and cannot import either of the other two.
 //
-//   scripts/lib/is-entry-point.mjs  — `scripts/` is outside every workspace
-//                                     package and reaches into none of them
-//   packages/server/sidecar/agent.js — a standalone in-pod bundle; the
-//                                     Dockerfile COPYs only agent.js and its
-//                                     package.json, so src/ is unreachable
+// Three copies of one guard is the shape #7213 was filed to remove, so the
+// thing that keeps them honest is not a convention but a test: the drift gate
+// in scripts/__tests__/is-entry-point.test.mjs extracts the guard from all
+// three files, strips comments, and fails if any has diverged. Change one,
+// change the others — and if you forget, that test says which (#7222).
 //
-// This file and scripts/lib/is-entry-point.mjs are byte-identical from the
-// `if (!process.argv[1])` line down. sidecar/agent.js runs the same code as an
-// inline IIFE, so it reads `import.meta.url` directly instead of taking it as a
-// parameter and its comments are pod-specific — everything else matches.
+// Why this is not `import.meta.main` (#7222). Node 22.18.0 shipped that as a
+// native, symlink-correct replacement for the whole comparison below, and it
+// would delete every copy of this. It is unusable here: the declared floor is
+// `"node": ">=22"`, and on Node 22.0–22.17 `import.meta.main` is plain
+// `undefined`. A falsy guard on an older-but-supported runtime is exactly the
+// silent exit-0 no-op this module exists to prevent, reintroduced as a version
+// skew that no CI job pinned to `node-version: 22` would ever show. Revisit
+// when the engines floor moves to >=22.18.
 //
-// That is not a convention anyone has to remember: the drift gate in
-// scripts/__tests__/is-entry-point.test.mjs extracts the guard from all three
-// files, strips comments, and fails if they diverge. Change one, change the
-// others, and the test will tell you if you missed one (#7222).
-//
-// Why this is not `import.meta.main`. Node 22.18.0 shipped that as a native,
-// symlink-correct replacement that would delete all three copies. It is
-// unusable here: the declared floor is `"node": ">=22"`, and on Node
-// 22.0–22.17 `import.meta.main` is plain `undefined`. A falsy guard on an
-// older-but-supported runtime is exactly the silent exit-0 no-op this module
-// exists to prevent, reintroduced as a version skew no CI job pinned to
-// `node-version: 22` would ever show. Revisit when the floor moves to >=22.18.
-//
-// The trap: Node's ESM loader RESOLVES SYMLINKS in `import.meta.url`, but
-// `process.argv[1]` is whatever the caller typed. Neither `resolve()` nor
-// `pathToFileURL()` follows symlinks, so every one of these compares a
-// realpath against a non-realpath:
-//
-//   resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])
-//   import.meta.url === pathToFileURL(process.argv[1]).href
-//   process.argv[1] === fileURLToPath(import.meta.url)
-//
-// On macOS /tmp is a symlink to /private/tmp, so running a script by a /tmp
-// path gives 'file:///private/tmp/x.mjs' on one side and 'file:///tmp/x.mjs'
-// on the other. The guard reads false, main() never runs, and the process
-// exits 0 having done nothing — the failure is silence, which is why it
-// survived in four separate files.
-//
-// Demonstrated:
-//   import.meta.url        : file:///private/tmp/ptfu/probe.mjs
-//   pathToFileURL(argv[1]) : file:///tmp/ptfu/probe.mjs
-//   guard would be         : false
+// The trap this replaces: Node's ESM loader RESOLVES SYMLINKS in
+// `import.meta.url`, but `process.argv[1]` is whatever the caller typed, and
+// neither `resolve()` nor `pathToFileURL()` follows symlinks. On macOS /tmp is
+// a symlink to /private/tmp, so running a script by a /tmp path gives
+// 'file:///private/tmp/x.mjs' on one side and 'file:///tmp/x.mjs' on the other.
+// The guard reads false, main() never runs, and the process exits 0 having done
+// nothing — the failure is silence, which is why it survived in four files
+// (#7198, #7213).
 //
 // Usage:
-//   import { isEntryPoint } from './utils/is-entry-point.js'
+//   import { isEntryPoint } from './lib/is-entry-point.mjs'
 //   if (isEntryPoint(import.meta.url)) { main() }
 
 import { realpathSync } from 'node:fs'
@@ -71,18 +54,16 @@ import { fileURLToPath } from 'node:url'
  * exists to remove: an `EACCES` on some parent directory, or a script
  * unlinked after launch, would make a direct `node foo.js` evaluate false,
  * `main()` would never run, and the process would exit 0 having done nothing
- * (#7217 review). Doing the cheap comparison first means no filesystem error
- * can reach the common case at all.
+ * (#7214). Doing the cheap comparison first means no filesystem error can
+ * reach the common case at all.
  *
  * The one genuinely undecidable case is left: paths that differ AND cannot be
  * realpath'd. Whether a symlink joins them is unknowable without the
- * filesystem call that just failed, and `false` is the only defensible answer
- * — it is also strictly better than the pre-#7213 behaviour, which got that
- * case wrong even when realpath would have succeeded. Undecidable does not
- * have to mean quiet, though — that combination is what made #7198 and #7214
- * expensive to find — so that branch warns on stderr before returning (#7226).
- * The ordinary "this module was imported" answer stays silent; only the branch
- * that could not tell says anything.
+ * filesystem call that just failed, and `false` is the only defensible answer.
+ * Undecidable does not have to mean quiet, though — that combination is what
+ * made #7198 and #7214 expensive to find — so that branch warns on stderr
+ * before returning (#7226). The ordinary "this module was imported" answer
+ * stays silent; only the branch that could not tell says anything.
  *
  * argv[1] absent (an `-e` eval, a REPL) means there is no invoked script, so
  * nothing can be the entry point.

--- a/scripts/lib/is-entry-point.mjs
+++ b/scripts/lib/is-entry-point.mjs
@@ -93,34 +93,26 @@ export function isEntryPoint(importMetaUrl) {
   const realInvoked = real(invoked)
   if (realSelf !== null && realInvoked !== null) return realSelf === realInvoked
 
-  // At least one side would not resolve, so the answer is `false` either way.
-  // Whether that `false` is DECIDED or merely UNKNOWN is a different question,
-  // and only the unknown one is worth a diagnostic (#7226). The two sides are
-  // not symmetric:
+  // Reaching here means realpath could not answer for at least one side, so
+  // whether a symlink still joins the two paths is unknowable and `false` is
+  // the only defensible return. It is not, however, an excuse for silence —
+  // that combination is what made #7198 and #7214 expensive (#7226).
   //
-  //   `self`    node LOADED this module, so its path resolved moments ago. If
-  //             it does not resolve now the ground moved underneath us — a
-  //             symlinked invocation whose target was unlinked, a directory
-  //             that lost its permissions — and whether a symlink still joins
-  //             the two paths is genuinely unknowable. Always warn.
-  //   `invoked` just a string the caller supplied. ENOENT/ENOTDIR means it
-  //             definitively does not exist, and a path that does not exist
-  //             cannot be the file we were loaded from — that is a DECIDED
-  //             false. Warning on it would fire on ordinary imports, where
-  //             argv[1] is some other script entirely, and a warning that
-  //             cries wolf on every import is worse than no warning at all.
-  //             Any other errno (EACCES, ELOOP, …) means the filesystem
-  //             refused to answer rather than answered "no", so it could still
-  //             be an inaccessible symlink to this very file: unknown, warn.
-  const unknowable = realSelf === null ||
-    failures.some(({ code }) => code !== 'ENOENT' && code !== 'ENOTDIR')
-  if (unknowable) {
-    const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
-    console.warn(
-      `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
-      `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
-      'behaviour did NOT run. If you invoked it directly, it did nothing.',
-    )
-  }
+  // An earlier version of this warned only when the errno was something other
+  // than ENOENT, on the theory that a non-existent argv[1] was a DECIDED false
+  // and warning on it would cry wolf during ordinary imports. Both halves were
+  // wrong. An ordinary import never reaches this line at all — argv[1] is the
+  // script node is running, so it exists, both realpaths succeed, and the
+  // comparison above returns. And ENOENT is not decided: argv[1] existed at
+  // exec time by construction, so ENOENT means it was REMOVED SINCE. Swap a
+  // `current -> releases-v1` symlink mid-run and you get exactly that — self
+  // resolves, invoked is ENOENT, and the module genuinely IS the entry point.
+  // The carve-out bought nothing and hid that case.
+  const why = failures.map(({ path, code }) => `${path}: ${code}`).join('; ')
+  console.warn(
+    `[is-entry-point] ${basename(self)}: cannot determine whether this module was run ` +
+    `directly — realpath failed (${why}). Assuming it was imported, so its command-line ` +
+    'behaviour did NOT run. If you invoked it directly, it did nothing.',
+  )
   return false
 }


### PR DESCRIPTION
Closes #7222, closes #7226.

## #7222 — consolidation

`scripts/` carried **two** hand-maintained copies of the entry-point guard: `gen-agents-md.mjs` (from #7208) and `compile-skill-targets.mjs` (from #7217). That is the "one bug, N copies" shape #7213 exists to remove, recreated one directory down. Both now import `scripts/lib/is-entry-point.mjs`.

**`import.meta.main` was the better option on paper and is not usable.** It needs Node ≥ 22.18; the declared floor is `"node": ">=22"`, and on 22.0–22.17 it evaluates to plain `undefined`. A falsy guard on a *supported* runtime is precisely the silent exit-0 no-op this guard exists to prevent — and no CI job pinned to `node-version: 22` would ever surface it. Documented in the helper header; revisit when the floor moves.

**Three copies remain and cannot be reduced further:**

| copy | why it can't import the others |
|---|---|
| `scripts/lib/is-entry-point.mjs` | `scripts/` is outside every workspace package and imports nothing from `packages/*/src` |
| `packages/server/src/utils/is-entry-point.js` | the server package's own |
| `packages/server/sidecar/agent.js` | standalone in-pod bundle; the Dockerfile COPYs only `agent.js` + its `package.json` |

A comment asking the next person to keep them in step does not fail a build, so there is a **drift gate** instead: the test extracts the guard from all three files, strips comments, and fails if any diverged.

## #7226 — undecidable, but no longer silent

The undecidable branch now writes one line to stderr instead of returning a bare `false`. `false` is still the answer — what was wrong was the silence.

The first cut of this warned on *every ordinary import*, and the test caught it. `self` and `invoked` are not symmetric:

- **`self`** — node LOADED this module, so its path resolved moments ago. If it no longer does, the ground moved underneath us: **unknowable, warn.**
- **`invoked`** — a caller-supplied string. `ENOENT`/`ENOTDIR` means it does not exist, so it cannot be the file we were loaded from — a **decided** `false`, and also what every ordinary import looks like. Any other errno (`EACCES`, `ELOOP`) is the filesystem *refusing to answer*: **unknowable, warn.**

## Also: a false green this refactor exposed

`gen-agents-md.test.mjs` asserted only `status === 1` for the #7214 cases. `node` exits 1 on an uncaught module-load error too — so once the guard moved to a `./lib` sibling, the EACCES hook fired mid-link, the import died, and **the test went on passing while testing nothing.** The break now fires on the last module in the graph, and both cases assert the generator's own drift message rather than the exit code alone.

## Verification

All three new behaviours were mutation-tested — each mutation turns the matching assertion red, and restore returns green:

| mutation | assertion that goes red |
|---|---|
| break trigger back to the entry module | `--check detects drift … EACCES` |
| diverge the sidecar's guard copy | `all three copies … are identical` |
| `if (unknowable)` → `if (false)` | `the undecidable case warns …` |

Suites: `scripts/__tests__/is-entry-point.test.mjs` 15/15 · `gen-agents-md.test.mjs` 8/8 · `compile-skill-targets.test.mjs` 18/18 · server `is-entry-point` + `chroxy-channel-server` + `server-cli-child` + `sidecar/agent` 143/143 · all 5 server shell lints pass. Both CLIs verified to still fire directly.