### PR TITLE
fix(ci): harden and unit-test store-core's export self-check

### DIFF
--- a/packages/store-core/scripts/__tests__/export-targets.test.mjs
+++ b/packages/store-core/scripts/__tests__/export-targets.test.mjs
@@ -1,0 +1,250 @@
+// export-targets.test.mjs — the coverage #7220 is about.
+//
+// `build-publish-dir.mjs`'s export derivation went through four consecutive PRs
+// (#7197, #7210, #7212, #7225), each fixing a "reports success without actually
+// checking" defect in the same twenty lines, and every one was caught by hand in
+// a PR description rather than by a test. The script is otherwise exercised only
+// by release.yml's verify-artifacts job on a `v*` tag push — i.e. the first time
+// a bad shape is hit for real is during an actual release.
+//
+// So these tests target the shapes rather than the happy path: the null that
+// must NOT throw, the empty object that MUST, and the escape that must be
+// refused. A test that only asserted "./dist/index.js works" would have passed
+// on every one of those four broken versions.
+
+import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import {
+  declaredTargets,
+  exportTargets,
+  needsJsonAttribute,
+  resolveExportTarget,
+} from '../lib/export-targets.mjs'
+
+describe('exportTargets', () => {
+  it('reads a bare string target', () => {
+    expect(exportTargets('./dist/index.js')).toEqual(['./dist/index.js'])
+  })
+
+  // The manifest build-publish-dir actually generates.
+  it('collects both leaves of a flat condition object', () => {
+    expect(exportTargets({ import: './dist/index.js', require: './dist/index.cjs' }))
+      .toEqual(['./dist/index.js', './dist/index.cjs'])
+  })
+
+  // #7210: reading only `.import` meant a require-only entry contributed no
+  // targets and was silently dropped from the check.
+  it('collects a require-only entry', () => {
+    expect(exportTargets({ require: './dist/index.cjs' })).toEqual(['./dist/index.cjs'])
+  })
+
+  // #7212: condition maps nest arbitrarily, and a walker that stopped at depth
+  // one reported success having verified nothing below it.
+  it('descends nested condition objects to arbitrary depth', () => {
+    expect(exportTargets({
+      node: { import: './dist/node.js', require: './dist/node.cjs' },
+      default: './dist/browser.js',
+    })).toEqual(['./dist/node.js', './dist/node.cjs', './dist/browser.js'])
+
+    expect(exportTargets({ a: { b: { c: { d: './deep.js' } } } })).toEqual(['./deep.js'])
+  })
+
+  it('collects every entry of a fallback array', () => {
+    expect(exportTargets(['./a.js', './b.js'])).toEqual(['./a.js', './b.js'])
+  })
+
+  it('skips type-only conditions, which Node never resolves at runtime', () => {
+    expect(exportTargets({ types: './dist/index.d.ts', import: './dist/index.js' }))
+      .toEqual(['./dist/index.js'])
+    expect(exportTargets({ typings: './dist/index.d.ts', import: './dist/index.js' }))
+      .toEqual(['./dist/index.js'])
+  })
+
+  // The negative control for the case above: `types` must be filtered because
+  // it is type-only, not because the walker happens to drop the first key.
+  it('yields nothing for a types-only spec', () => {
+    expect(exportTargets({ types: './dist/index.d.ts' })).toEqual([])
+  })
+
+  it('yields nothing for null or a non-target scalar', () => {
+    expect(exportTargets(null)).toEqual([])
+    expect(exportTargets(undefined)).toEqual([])
+    expect(exportTargets(42)).toEqual([])
+  })
+})
+
+describe('declaredTargets', () => {
+  it('pairs every target with the subpath that declared it', () => {
+    expect(declaredTargets({
+      '.': { types: './dist/index.d.ts', import: './dist/index.js' },
+      './crypto': { types: './dist/crypto.d.ts', import: './dist/crypto.js' },
+    })).toEqual([
+      ['.', './dist/index.js'],
+      ['./crypto', './dist/crypto.js'],
+    ])
+  })
+
+  // `null` blocks a subpath — Node's documented mechanism, not a shape we
+  // failed to read. Throwing here would fail the build on a VALID manifest,
+  // and build:publish runs on every v* tag, so that blocks a release.
+  it('treats a null subpath as blocked, not as an error', () => {
+    expect(declaredTargets({ '.': './dist/index.js', './internal': null }))
+      .toEqual([['.', './dist/index.js']])
+  })
+
+  it('deduplicates a target declared under several conditions', () => {
+    expect(declaredTargets({ '.': { import: './dist/index.js', default: './dist/index.js' } }))
+      .toEqual([['.', './dist/index.js']])
+  })
+
+  // The load-bearing one. "Cannot verify this export" and "there is nothing to
+  // verify" are different answers, and conflating them is how the original bug
+  // read as success — the build exited 0 having never mentioned the export.
+  it('throws on a shape with no resolvable target, naming the shape', () => {
+    expect(() => declaredTargets({ '.': { types: './dist/index.d.ts' } }))
+      .toThrow(/no resolvable target.*index\.d\.ts/s)
+    expect(() => declaredTargets({ '.': {} })).toThrow(/no resolvable target/)
+    expect(() => declaredTargets({ '.': [] })).toThrow(/no resolvable target/)
+  })
+})
+
+describe('resolveExportTarget', () => {
+  const outDir = join(sep === '\\' ? 'C:\\repo' : '/repo', 'pkg', 'publish')
+
+  it('resolves a manifest-relative target inside the staging dir', () => {
+    const url = resolveExportTarget(outDir, '.', './dist/index.js')
+    expect(fileURLToPath(url)).toBe(join(outDir, 'dist', 'index.js'))
+  })
+
+  // #7230 item 2. `join(outDir, '/')` is idempotent, `startsWith(outDir + sep)`
+  // was not — so the two halves of one guard disagreed about outDir's shape and
+  // a trailing separator made the check reject a correctly-resolved target.
+  it('accepts the same target whether or not outDir has a trailing separator', () => {
+    const withSep = resolveExportTarget(outDir + sep, '.', './dist/index.js')
+    expect(fileURLToPath(withSep)).toBe(join(outDir, 'dist', 'index.js'))
+  })
+
+  // #7225's guarantee, and the reason the base URL keeps its trailing slash.
+  // Without it every target resolves one level up, into packages/store-core/dist
+  // — a real directory of real files, so an existence check is satisfied and the
+  // verification proceeds against the wrong tree entirely.
+  it('refuses a target that escapes the staging dir', () => {
+    expect(() => resolveExportTarget(outDir, '.', '../dist/index.js'))
+      .toThrow(/OUTSIDE the staging dir/)
+    expect(() => resolveExportTarget(outDir, '.', '../../etc/passwd'))
+      .toThrow(/OUTSIDE the staging dir/)
+  })
+
+  it('refuses a target that resolves to the staging dir itself', () => {
+    expect(() => resolveExportTarget(outDir, '.', '.')).toThrow(/OUTSIDE the staging dir/)
+  })
+
+  // #7230 item 1. These used to reach fileURLToPath and die there with a bare
+  // Node TypeError and a stack trace — ERR_INVALID_URL_SCHEME /
+  // ERR_INVALID_FILE_URL_HOST. The exit code was right either way; the loss was
+  // the diagnosis, so assert on the message, not just that it throws.
+  it('gives its own error for an absolute non-file: target', () => {
+    expect(() => resolveExportTarget(outDir, '.', 'https://evil.example/x.js'))
+      .toThrow(/does not resolve to a file path/)
+  })
+
+  it('gives its own error for a protocol-relative target', () => {
+    expect(() => resolveExportTarget(outDir, '.', '//host/x.js'))
+      .toThrow(/does not resolve to a file path/)
+  })
+
+  it('does not leak a raw Node TypeError for either shape', () => {
+    for (const target of ['https://evil.example/x.js', '//host/x.js']) {
+      let caught
+      try {
+        resolveExportTarget(outDir, '.', target)
+      } catch (err) {
+        caught = err
+      }
+      expect(caught, `${target} should throw`).toBeDefined()
+      expect(caught.code, `${target} leaked a Node error code`).toBeUndefined()
+      expect(caught.message).toContain('manifest exports')
+    }
+  })
+})
+
+describe('needsJsonAttribute', () => {
+  // #7220 item 2. `"./package.json": "./package.json"` is a common npm idiom
+  // for version detection. It is not in store-core's manifest today, but if it
+  // were, the derivation would produce it as a target and a plain dynamic
+  // import would throw — reporting a broken entry point for a valid one.
+  it('is true for a .json target', () => {
+    expect(needsJsonAttribute('./package.json')).toBe(true)
+  })
+
+  it('is false for JS targets', () => {
+    expect(needsJsonAttribute('./dist/index.js')).toBe(false)
+    expect(needsJsonAttribute('./dist/index.cjs')).toBe(false)
+    expect(needsJsonAttribute('./dist/index.mjs')).toBe(false)
+  })
+
+  // The behaviour that motivates the flag. If a future Node makes the attribute
+  // optional this goes red and the special case can be dropped; until then it
+  // pins WHY the branch exists rather than merely that it does.
+  //
+  // It has to run in a REAL node process. Vitest resolves dynamic imports
+  // through Vite's pipeline, which handles JSON natively and does not require
+  // the attribute at all — asserting in-process measured the test runner's
+  // loader and reported that the import succeeded, which is the opposite of
+  // what build-publish-dir hits when node runs it for real.
+  it('a .json import without the attribute really does throw, under node (control)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-json-'))
+    try {
+      const file = join(dir, 'data.json')
+      writeFileSync(file, '{"ok":true}\n')
+      const href = pathToFileURL(file).href
+      const probe = (attributes) => spawnSync(
+        process.execPath,
+        ['--input-type=module', '-e',
+          `try { const m = await import(${JSON.stringify(href)}${attributes}); ` +
+          "console.log('OK:' + JSON.stringify(m.default)) } catch (e) { console.log('THREW:' + e.message) }"],
+        { encoding: 'utf8' },
+      ).stdout.trim()
+
+      expect(probe('')).toMatch(/^THREW:.*import attribute/)
+      expect(probe(", { with: { type: 'json' } }")).toBe('OK:{"ok":true}')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// The whole point of the extraction: prove the real generated manifest still
+// flows through the derivation unchanged. Everything above tests shapes that
+// cannot occur today; this one tests the shape that does, so a refactor that
+// broke the common case could not hide behind green edge-case tests.
+describe('the manifest build-publish-dir actually generates', () => {
+  it('derives exactly the two dist entry points', () => {
+    const generated = {
+      '.': { types: './dist/index.d.ts', import: './dist/index.js' },
+      './crypto': { types: './dist/crypto.d.ts', import: './dist/crypto.js' },
+    }
+    const declared = declaredTargets(generated)
+    expect(declared).toEqual([
+      ['.', './dist/index.js'],
+      ['./crypto', './dist/crypto.js'],
+    ])
+
+    const staging = mkdtempSync(join(tmpdir(), 'chroxy-publish-'))
+    try {
+      mkdirSync(join(staging, 'dist'), { recursive: true })
+      for (const [label, target] of declared) {
+        const url = resolveExportTarget(staging, label, target)
+        expect(fileURLToPath(url).startsWith(staging)).toBe(true)
+        expect(needsJsonAttribute(target)).toBe(false)
+      }
+    } finally {
+      rmSync(staging, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/store-core/scripts/__tests__/export-targets.test.mjs
+++ b/packages/store-core/scripts/__tests__/export-targets.test.mjs
@@ -19,9 +19,12 @@ import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
+import { posix, win32 } from 'node:path'
+
 import {
   declaredTargets,
   exportTargets,
+  isContained,
   needsJsonAttribute,
   resolveExportTarget,
 } from '../lib/export-targets.mjs'
@@ -144,6 +147,14 @@ describe('resolveExportTarget', () => {
     expect(() => resolveExportTarget(outDir, '.', '.')).toThrow(/OUTSIDE the staging dir/)
   })
 
+  // `relative()` returns exactly '..' for the parent — neither '', nor
+  // '../'-prefixed, nor absolute — so without its own clause the parent
+  // directory reads as CONTAINED. Deleting `rel === '..' ||` used to leave the
+  // whole suite green.
+  it('refuses a target that resolves to the staging dir PARENT', () => {
+    expect(() => resolveExportTarget(outDir, '.', '..')).toThrow(/OUTSIDE the staging dir/)
+  })
+
   // #7230 item 1. These used to reach fileURLToPath and die there with a bare
   // Node TypeError and a stack trace — ERR_INVALID_URL_SCHEME /
   // ERR_INVALID_FILE_URL_HOST. The exit code was right either way; the loss was
@@ -155,6 +166,27 @@ describe('resolveExportTarget', () => {
 
   it('gives its own error for a protocol-relative target', () => {
     expect(() => resolveExportTarget(outDir, '.', '//host/x.js'))
+      .toThrow(/does not resolve to a file path/)
+  })
+
+  // The shapes the enumerate-the-bad-cases approach kept missing. Each of these
+  // has an EMPTY host, so a host check alone lets it through to fileURLToPath
+  // and the raw Node TypeError #7230 is about comes straight back:
+  //
+  //   data:/node:  ERR_INVALID_URL_SCHEME     (non-file scheme, no host)
+  //   %2F          ERR_INVALID_FILE_URL_PATH  (encoded separator)
+  //
+  // 'C:foo' is here because on a POSIX parse it is a drive-relative reference
+  // read as scheme 'c:' — the shape a Windows-authored manifest would carry.
+  it('gives its own error for non-file: shapes with an EMPTY host', () => {
+    for (const target of ['data:text/javascript,export default 1', 'node:fs', 'C:foo']) {
+      expect(() => resolveExportTarget(outDir, '.', target), target)
+        .toThrow(/does not resolve to a file path/)
+    }
+  })
+
+  it('gives its own error for an encoded path separator', () => {
+    expect(() => resolveExportTarget(outDir, '.', './dist%2Findex.js'))
       .toThrow(/does not resolve to a file path/)
   })
 
@@ -173,6 +205,54 @@ describe('resolveExportTarget', () => {
   })
 })
 
+// Store Core Tests runs on Linux only, so without an injectable path module
+// these clauses could never execute — `isAbsolute(rel)` in particular is
+// unreachable on POSIX (relative() never returns an absolute path when both
+// operands share a root) and is the ONLY thing catching a cross-drive escape.
+// The repo runs Windows CI elsewhere, so "unreachable here" is not the same as
+// "unreachable".
+describe('isContained under win32 semantics', () => {
+  it('accepts an ordinary target inside the staging dir', () => {
+    expect(isContained('C:\\repo\\publish', 'C:\\repo\\publish\\dist\\index.js', win32)).toBe(true)
+  })
+
+  // The cross-drive escape. relative() cannot express it as a traversal, so it
+  // returns an absolute path — caught only by the isAbsolute clause.
+  it('refuses a target on a DIFFERENT DRIVE', () => {
+    expect(isContained('C:\\repo\\publish', 'D:\\evil.js', win32)).toBe(false)
+  })
+
+  it('refuses a traversal out of the staging dir', () => {
+    expect(isContained('C:\\repo\\publish', 'C:\\repo\\dist\\index.js', win32)).toBe(false)
+  })
+
+  // A UNC staging dir is a legitimate Windows checkout location. A host-based
+  // rejection tuned to '//host/x.js' failed this — the direction that fails a
+  // VALID release rather than catching a bad one.
+  it('accepts a UNC staging dir with an ordinary target', () => {
+    expect(isContained(
+      '\\\\server\\share\\repo\\publish',
+      '\\\\server\\share\\repo\\publish\\dist\\index.js',
+      win32,
+    )).toBe(true)
+  })
+
+  it('refuses a target on a different UNC share', () => {
+    expect(isContained(
+      '\\\\server\\share\\repo\\publish',
+      '\\\\evil\\share\\x.js',
+      win32,
+    )).toBe(false)
+  })
+
+  // Case-insensitivity is correct on win32 and WRONG on posix; pinning both
+  // directions stops a "simplification" that hardcodes one platform's rules.
+  it('treats case as insignificant on win32 and significant on posix', () => {
+    expect(isContained('C:\\repo\\publish', 'C:\\REPO\\PUBLISH\\dist\\x.js', win32)).toBe(true)
+    expect(isContained('/repo/publish', '/REPO/PUBLISH/dist/x.js', posix)).toBe(false)
+  })
+})
+
 describe('needsJsonAttribute', () => {
   // #7220 item 2. `"./package.json": "./package.json"` is a common npm idiom
   // for version detection. It is not in store-core's manifest today, but if it
@@ -186,6 +266,21 @@ describe('needsJsonAttribute', () => {
     expect(needsJsonAttribute('./dist/index.js')).toBe(false)
     expect(needsJsonAttribute('./dist/index.cjs')).toBe(false)
     expect(needsJsonAttribute('./dist/index.mjs')).toBe(false)
+  })
+
+  // Both of these fail under a plain import — ERR_UNKNOWN_FILE_EXTENSION and
+  // ERR_IMPORT_ATTRIBUTE_MISSING respectively — so a case- or query-sensitive
+  // check reports a valid entry point as broken, the very thing the attribute
+  // exists to prevent.
+  it('is true for an uppercase or query-suffixed .json target', () => {
+    expect(needsJsonAttribute('./B.JSON')).toBe(true)
+    expect(needsJsonAttribute('./q.json?v=1')).toBe(true)
+    expect(needsJsonAttribute('./q.json#frag')).toBe(true)
+  })
+
+  // Not JSON to Node either way, so the attribute would not help.
+  it('is false for .json5', () => {
+    expect(needsJsonAttribute('./tsconfig.json5')).toBe(false)
   })
 
   // The behaviour that motivates the flag. If a future Node makes the attribute

--- a/packages/store-core/scripts/build-publish-dir.mjs
+++ b/packages/store-core/scripts/build-publish-dir.mjs
@@ -31,8 +31,10 @@
 
 import { execFileSync } from 'node:child_process'
 import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
-import { fileURLToPath, pathToFileURL } from 'node:url'
-import { dirname, join, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+
+import { declaredTargets, needsJsonAttribute, resolveExportTarget } from './lib/export-targets.mjs'
 
 // The source imports siblings without a file extension (`from './types'`), which
 // tsconfig's `moduleResolution: "bundler"` allows and Metro/Vite resolve happily.
@@ -140,121 +142,33 @@ writeFileSync(join(outDir, 'package.json'), JSON.stringify(out, null, 2) + '\n')
 //    for the npm consumer, who resolves through `exports` (#7197). Reading the
 //    manifest also means a newly-added export is covered automatically instead
 //    of silently falling outside the check.
+// The derivation lives in ./lib/export-targets.mjs so it can be unit-tested:
+// this file runs tsc at module scope, so importing it to exercise the logic
+// would rebuild the package as a side effect. Four consecutive PRs fixed a
+// "check reports success without actually checking" defect in that derivation
+// (#7197, #7210, #7212, #7225), every one caught by hand in a PR description
+// rather than by a test, which is what #7220 is about.
 const manifest = JSON.parse(readFileSync(join(outDir, 'package.json'), 'utf8'))
-// Collect EVERY string leaf under an export's condition object, not just
-// `.import`. A condition map can nest arbitrarily ({ node: { import: … },
-// default: … }), and reading one known key meant a `require`-only or nested
-// entry contributed no targets and was quietly dropped from `declared` — the
-// same silent-skip this check exists to prevent, one level down (#7210).
-//
-// Not reachable with the manifest this script generates today, which only
-// emits { types, import }. It is guarded anyway because the failure mode is
-// invisible: the build exits 0 and simply never mentions the export.
-// `types` is skipped deliberately: it is a TypeScript-only condition that Node
-// never resolves at runtime. Importing a .d.ts "succeeds" and yields zero
-// exports, so checking it would add a ✓ that means nothing — and a genuinely
-// broken .d.ts would still pass it. Runtime conditions only.
-const TYPE_ONLY_CONDITIONS = new Set(['types', 'typings'])
-
-// Arrays ARE valid here — Node treats them as a fallback list and resolves the
-// first entry whose conditions match (verified against Node 22, both a
-// single-entry array and a condition-fallback array resolve). They fall through
-// to the object branch below via Object.entries, which collects every string
-// leaf.
-//
-// Known over-strictness: for a genuine fallback array, Node needs only ONE
-// entry to resolve, whereas this collects all of them and would fail the build
-// if any were missing. Left as-is deliberately — this script GENERATES the
-// manifest it checks and only ever emits { types, import }, so an array cannot
-// occur without someone editing the generator, at which point the over-strict
-// failure is a loud prompt to revisit this rather than a silent wrong answer.
-function exportTargets(spec) {
-  if (typeof spec === 'string') return [spec]
-  if (spec && typeof spec === 'object') {
-    return Object.entries(spec)
-      .filter(([condition]) => !TYPE_ONLY_CONDITIONS.has(condition))
-      .flatMap(([, value]) => exportTargets(value))
-  }
-  return []
-}
-
-const declared = Object.entries(manifest.exports).flatMap(([label, spec]) => {
-  // `null` is Node's documented way to BLOCK a subpath, not a shape we failed
-  // to read. npm accepts the manifest and Node refuses the path at resolution
-  // (ERR_PACKAGE_PATH_NOT_EXPORTED), so there is genuinely nothing to import
-  // and nothing is wrong. Throwing here would fail the build on a valid
-  // manifest — and `build:publish` runs in release.yml's verify-artifacts job
-  // on every v* tag, so that would block a release rather than catch a bug.
-  if (spec === null) return []
-
-  const targets = [...new Set(exportTargets(spec))]
-  // An export that yields no target at all is a shape this script cannot
-  // check. Throw rather than filter it away — being unable to verify an
-  // export is not the same as there being nothing to verify, and conflating
-  // them is how the original bug read as success.
-  if (!targets.length) {
-    throw new Error(
-      `manifest exports "${label}" in a shape with no resolvable target ` +
-      `(${JSON.stringify(spec)}) — build-publish-dir cannot verify it`,
-    )
-  }
-  return targets.map((target) => [label, target])
-})
+const declared = declaredTargets(manifest.exports)
 
 if (!declared.length) throw new Error('generated manifest declares no exports — nothing to verify')
 
 for (const [label, target] of declared) {
-  // `target` is manifest-relative ('./dist/index.js'), resolved against the
-  // staging dir — the same base a consumer resolves it against. pathToFileURL
-  // rather than a `file://` template: the template mangles Windows paths (drive
-  // letters, backslashes) and anything needing percent-encoding, and this repo
-  // runs Windows CI.
-  //
-  // The `join(outDir, '/')` is load-bearing, not decorative. WHATWG URL
-  // resolution reads a base's trailing slash as the directory/file boundary: a
-  // relative reference APPENDS to a base ending in '/', and REPLACES the last
-  // segment otherwise. Drop it and every target resolves one level up:
-  //
-  //   base .../store-core/publish/  + ./dist/index.js -> .../publish/dist/index.js
-  //   base .../store-core/publish   + ./dist/index.js -> .../store-core/dist/index.js
-  //
-  // That second path is packages/store-core/dist — the tree step 1 rebuilds,
-  // mostly gitignored (.gitignore keeps only crypto.js and crypto.d.ts). It is
-  // a real directory of real files, so existsSync is satisfied and the check
-  // proceeds against the wrong tree entirely.
-  //
-  // How loudly that fails depends on WHICH export is checked, which is the
-  // whole problem:
-  //
-  //   "."       throws. addExtensions() rewrites only the STAGED copy, so
-  //             dist/index.js keeps its extensionless specifiers and Node
-  //             rejects it with ERR_UNSUPPORTED_DIR_IMPORT — blaming the
-  //             published entry point rather than the wrong base URL.
-  //   "./crypto" passes. dist/crypto.js has no relative specifiers at all, so
-  //             the staged copy is byte-identical and it imports cleanly.
-  //
-  // So the mistake is caught today only because "." happens to be checked
-  // first and happens to throw. For "./crypto" it is already a silent pass
-  // against the wrong tree. Neither of those is a property of this check —
-  // reorder the exports, or regenerate dist with extensions, and the whole
-  // thing goes green having verified nothing this script produced (#7211).
-  const file = new URL(target, pathToFileURL(join(outDir, '/')))
-
-  // So assert it rather than trusting the comment. A comment cannot fail; this
-  // turns "simplified the base URL" from a silent wrong answer into a loud one.
-  const filePath = fileURLToPath(file)
-  if (!filePath.startsWith(outDir + sep)) {
-    throw new Error(
-      `manifest exports "${label}" -> ${target} resolved to ${filePath}, which is OUTSIDE the staging dir ` +
-      `(${outDir}). The base URL must keep its trailing separator, or the self-check verifies the wrong files.`,
-    )
-  }
+  // Resolved against the staging dir, the same base a consumer resolves it
+  // against, and refused if it escapes — see resolveExportTarget for why the
+  // base URL's trailing separator is load-bearing (#7211 / #7225 / #7230).
+  const file = resolveExportTarget(outDir, label, target)
 
   if (!existsSync(file)) {
     throw new Error(`manifest exports "${label}" -> ${target}, which does not exist in the package`)
   }
   try {
-    await import(file.href)
+    // A `.json` target needs an import attribute; without one, dynamic import
+    // throws `needs an import attribute of "type: json"` and a perfectly valid
+    // entry point is reported as broken (#7220).
+    await (needsJsonAttribute(target)
+      ? import(file.href, { with: { type: 'json' } })
+      : import(file.href))
     console.log(`  ✓ "${label}" -> ${target} imports under Node`)
   } catch (err) {
     throw new Error(`published "${label}" entry (${target}) fails to import: ${err.message}`)

--- a/packages/store-core/scripts/lib/export-targets.mjs
+++ b/packages/store-core/scripts/lib/export-targets.mjs
@@ -84,6 +84,40 @@ export function declaredTargets(exportsMap) {
 }
 
 /**
+ * True when `filePath` sits strictly inside `outDir`.
+ *
+ * `relative()` rather than `startsWith(outDir + sep)`. The two halves of this
+ * guard have to agree about outDir's shape: `join(outDir, '/')` in the caller is
+ * idempotent — same base whether or not outDir already ends in a separator — but
+ * `startsWith(outDir + sep)` is not, and rejected a correctly-resolved target
+ * whenever outDir carried a trailing separator (#7230). This form tolerates
+ * both, and is case-insensitive on win32 into the bargain (which is correct
+ * here: filePath always inherits outDir's exact case through URL resolution, so
+ * a case-divergent input genuinely IS the same directory on that platform).
+ *
+ * `pathImpl` exists so the win32 branches are reachable from a Linux test run.
+ * Two of the four clauses — `isAbsolute(rel)`, which is what catches a
+ * cross-drive `D:\evil.js`, and the UNC handling — are dead on POSIX and
+ * Store Core Tests is Linux-only, so without an injectable path module they
+ * could only be reasoned about, never executed. Deleting `isAbsolute(rel)` used
+ * to leave the whole suite green.
+ *
+ * @param {string} outDir
+ * @param {string} filePath
+ * @param {{ relative: Function, isAbsolute: Function, sep: string }} [pathImpl]
+ * @returns {boolean}
+ */
+export function isContained(outDir, filePath, pathImpl = { relative, isAbsolute, sep }) {
+  const rel = pathImpl.relative(outDir, filePath)
+  return !(
+    rel === '' ||
+    rel === '..' ||
+    rel.startsWith('..' + pathImpl.sep) ||
+    pathImpl.isAbsolute(rel)
+  )
+}
+
+/**
  * Resolve a manifest-relative target against the staging dir, as a consumer
  * would, and refuse anything that escapes it.
  *
@@ -115,32 +149,32 @@ export function resolveExportTarget(outDir, label, target) {
 
   // A target fileURLToPath cannot convert used to die there with a bare Node
   // TypeError and a stack trace (#7230). The exit code was right either way;
-  // what was lost was the diagnosis, so this refuses it first — and checking
-  // the PROTOCOL alone is not enough, because two different shapes get there:
+  // what was lost was the diagnosis.
+  //
+  // Ask fileURLToPath rather than trying to predict it. Enumerating the bad
+  // shapes was the first attempt here and it kept coming up short — there are
+  // at least three ways in, not the two the issue listed:
   //
   //   'https://evil.example/x.js' -> https://evil.example/x.js -> ERR_INVALID_URL_SCHEME
-  //   '//host/x.js'               -> file://host/x.js         -> ERR_INVALID_FILE_URL_HOST
+  //   '//host/x.js'               -> file://host/x.js          -> ERR_INVALID_FILE_URL_HOST
+  //   './dist%2Findex.js'         -> file:///…/dist%2Findex.js -> ERR_INVALID_FILE_URL_PATH
   //
-  // The second is a protocol-RELATIVE reference: it inherits the base's scheme,
-  // so its protocol IS 'file:' and only the host distinguishes it. A local path
-  // has an empty host; fileURLToPath additionally tolerates 'localhost'.
-  const localHost = file.hostname === '' || file.hostname === 'localhost'
-  if (file.protocol !== 'file:' || !localHost) {
+  // and a host check tuned to the second REJECTS A VALID TARGET when outDir is
+  // itself a UNC path on win32 (base host 'server', so a perfectly ordinary
+  // './dist/index.js' inherits it and looks non-local). Failing a valid release
+  // is the direction declaredTargets' own null-handling argues hardest against.
+  // Catching the conversion covers every shape, present and future, and makes
+  // no assumption about outDir at all.
+  let filePath
+  try {
+    filePath = fileURLToPath(file)
+  } catch (err) {
     throw new Error(
       `manifest exports "${label}" -> ${target} does not resolve to a file path ` +
-      `(${file.href}) — build-publish-dir can only verify local files`,
+      `(${file.href}: ${err.code || err.message}) — build-publish-dir can only verify local files`,
     )
   }
-
-  const filePath = fileURLToPath(file)
-  // `relative()` rather than `startsWith(outDir + sep)`. The two halves of this
-  // guard have to agree about outDir's shape: `join(outDir, '/')` above is
-  // idempotent — same base whether or not outDir already ends in a separator —
-  // but `startsWith(outDir + sep)` is not, and rejected a correctly-resolved
-  // target whenever outDir carried a trailing separator (#7230). This form
-  // tolerates both, and is case-insensitive on win32 into the bargain.
-  const rel = relative(outDir, filePath)
-  if (rel === '' || rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) {
+  if (!isContained(outDir, filePath)) {
     throw new Error(
       `manifest exports "${label}" -> ${target} resolved to ${filePath}, which is OUTSIDE ` +
       `the staging dir (${outDir}). The base URL must keep its trailing separator, or the ` +
@@ -159,7 +193,13 @@ export function resolveExportTarget(outDir, label, target) {
  * `await import()` in the self-check would throw
  * `TypeError: … needs an import attribute of "type: json"` — reporting a broken
  * entry point for a perfectly valid one (#7220).
+ *
+ * The query/fragment strip and the lowercase are not hypothetical tidiness:
+ * `./q.json?v=1` fails with ERR_IMPORT_ATTRIBUTE_MISSING and `./B.JSON` with
+ * ERR_UNKNOWN_FILE_EXTENSION under a plain import, both of which are the same
+ * "valid entry point reported as broken" this exists to prevent. `.json5` is
+ * deliberately NOT matched — it is not JSON to Node either way.
  */
 export function needsJsonAttribute(target) {
-  return target.endsWith('.json')
+  return target.replace(/[?#].*$/, '').toLowerCase().endsWith('.json')
 }

--- a/packages/store-core/scripts/lib/export-targets.mjs
+++ b/packages/store-core/scripts/lib/export-targets.mjs
@@ -1,0 +1,165 @@
+// export-targets.mjs — read a package manifest's `exports` and say which files
+// a consumer could actually import.
+//
+// Extracted from build-publish-dir.mjs (#7220). That script runs `tsc` at module
+// scope, so importing it to test this logic would rebuild the package as a side
+// effect — which is why this derivation went four PRs (#7197, #7210, #7212,
+// #7225) with no test coverage at all, verified only by hand in PR descriptions.
+// Every one of those PRs fixed a "check reports success without actually
+// checking" defect in these same twenty lines. They are here so they can be
+// tested directly.
+//
+// The shapes are Node's, not ours: `exports` values may be strings, condition
+// objects nested arbitrarily deep, fallback arrays, or `null`.
+
+import { isAbsolute, join, relative, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+// `types` is skipped deliberately: it is a TypeScript-only condition that Node
+// never resolves at runtime. Importing a .d.ts "succeeds" and yields zero
+// exports, so checking it would add a ✓ that means nothing — and a genuinely
+// broken .d.ts would still pass it. Runtime conditions only.
+export const TYPE_ONLY_CONDITIONS = new Set(['types', 'typings'])
+
+/**
+ * Every string leaf under an export's spec, in declaration order.
+ *
+ * Collecting EVERY leaf rather than reading a known key is the #7210 fix: a
+ * condition map can nest arbitrarily ({ node: { import: … }, default: … }), and
+ * reading only `.import` meant a `require`-only or nested entry contributed no
+ * targets and was quietly dropped — the same silent skip the self-check exists
+ * to prevent, one level down.
+ *
+ * Arrays ARE valid here — Node treats them as a fallback list and resolves the
+ * first entry whose conditions match. They fall through to the object branch via
+ * Object.entries, which collects every string leaf.
+ *
+ * Known over-strictness: for a genuine fallback array Node needs only ONE entry
+ * to resolve, whereas this collects all of them, so a caller that verifies each
+ * would fail on a manifest Node accepts. Left as-is deliberately —
+ * build-publish-dir GENERATES the manifest it checks and only ever emits
+ * { types, import }, so an array cannot occur without someone editing the
+ * generator, at which point an over-strict failure is a loud prompt to revisit
+ * this rather than a silent wrong answer.
+ */
+export function exportTargets(spec) {
+  if (typeof spec === 'string') return [spec]
+  if (spec && typeof spec === 'object') {
+    return Object.entries(spec)
+      .filter(([condition]) => !TYPE_ONLY_CONDITIONS.has(condition))
+      .flatMap(([, value]) => exportTargets(value))
+  }
+  return []
+}
+
+/**
+ * `[label, target]` pairs for every importable entry point a manifest declares.
+ *
+ * @param {Record<string, unknown>} exportsMap - the manifest's `exports` field
+ * @returns {Array<[string, string]>}
+ */
+export function declaredTargets(exportsMap) {
+  return Object.entries(exportsMap).flatMap(([label, spec]) => {
+    // `null` is Node's documented way to BLOCK a subpath, not a shape we failed
+    // to read. npm accepts the manifest and Node refuses the path at resolution
+    // (ERR_PACKAGE_PATH_NOT_EXPORTED), so there is genuinely nothing to import
+    // and nothing is wrong. Throwing here would fail the build on a valid
+    // manifest — and `build:publish` runs in release.yml's verify-artifacts job
+    // on every v* tag, so that would block a release rather than catch a bug.
+    if (spec === null) return []
+
+    const targets = [...new Set(exportTargets(spec))]
+    // An export that yields no target at all is a shape this cannot check.
+    // Throw rather than filter it away — being unable to verify an export is
+    // not the same as there being nothing to verify, and conflating them is how
+    // the original bug read as success.
+    if (!targets.length) {
+      throw new Error(
+        `manifest exports "${label}" in a shape with no resolvable target ` +
+        `(${JSON.stringify(spec)}) — build-publish-dir cannot verify it`,
+      )
+    }
+    return targets.map((target) => [label, target])
+  })
+}
+
+/**
+ * Resolve a manifest-relative target against the staging dir, as a consumer
+ * would, and refuse anything that escapes it.
+ *
+ * The `join(outDir, '/')` is load-bearing, not decorative. WHATWG URL
+ * resolution reads a base's trailing slash as the directory/file boundary: a
+ * relative reference APPENDS to a base ending in '/', and REPLACES the last
+ * segment otherwise. Drop it and every target resolves one level up:
+ *
+ *   base .../store-core/publish/  + ./dist/index.js -> .../publish/dist/index.js
+ *   base .../store-core/publish   + ./dist/index.js -> .../store-core/dist/index.js
+ *
+ * That second path is packages/store-core/dist — a real directory of real
+ * files, so an existence check is satisfied and the verification proceeds
+ * against the wrong tree entirely (#7211). The containment check below turns
+ * "someone simplified the base URL" from a silent wrong answer into a loud one
+ * (#7225).
+ *
+ * pathToFileURL rather than a `file://` template: the template mangles Windows
+ * paths (drive letters, backslashes) and anything needing percent-encoding, and
+ * this repo runs Windows CI.
+ *
+ * @param {string} outDir - absolute path to the staging directory
+ * @param {string} label - the manifest subpath, for error messages
+ * @param {string} target - the manifest-relative target ('./dist/index.js')
+ * @returns {URL}
+ */
+export function resolveExportTarget(outDir, label, target) {
+  const file = new URL(target, pathToFileURL(join(outDir, '/')))
+
+  // A target fileURLToPath cannot convert used to die there with a bare Node
+  // TypeError and a stack trace (#7230). The exit code was right either way;
+  // what was lost was the diagnosis, so this refuses it first — and checking
+  // the PROTOCOL alone is not enough, because two different shapes get there:
+  //
+  //   'https://evil.example/x.js' -> https://evil.example/x.js -> ERR_INVALID_URL_SCHEME
+  //   '//host/x.js'               -> file://host/x.js         -> ERR_INVALID_FILE_URL_HOST
+  //
+  // The second is a protocol-RELATIVE reference: it inherits the base's scheme,
+  // so its protocol IS 'file:' and only the host distinguishes it. A local path
+  // has an empty host; fileURLToPath additionally tolerates 'localhost'.
+  const localHost = file.hostname === '' || file.hostname === 'localhost'
+  if (file.protocol !== 'file:' || !localHost) {
+    throw new Error(
+      `manifest exports "${label}" -> ${target} does not resolve to a file path ` +
+      `(${file.href}) — build-publish-dir can only verify local files`,
+    )
+  }
+
+  const filePath = fileURLToPath(file)
+  // `relative()` rather than `startsWith(outDir + sep)`. The two halves of this
+  // guard have to agree about outDir's shape: `join(outDir, '/')` above is
+  // idempotent — same base whether or not outDir already ends in a separator —
+  // but `startsWith(outDir + sep)` is not, and rejected a correctly-resolved
+  // target whenever outDir carried a trailing separator (#7230). This form
+  // tolerates both, and is case-insensitive on win32 into the bargain.
+  const rel = relative(outDir, filePath)
+  if (rel === '' || rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) {
+    throw new Error(
+      `manifest exports "${label}" -> ${target} resolved to ${filePath}, which is OUTSIDE ` +
+      `the staging dir (${outDir}). The base URL must keep its trailing separator, or the ` +
+      'self-check verifies the wrong files.',
+    )
+  }
+  return file
+}
+
+/**
+ * True when a target must be imported with `{ with: { type: 'json' } }`.
+ *
+ * `"./package.json": "./package.json"` is a common npm idiom for version
+ * detection. It is not in store-core's manifest today, but if it were added the
+ * derivation above would happily produce it as a target and the plain
+ * `await import()` in the self-check would throw
+ * `TypeError: … needs an import attribute of "type: json"` — reporting a broken
+ * entry point for a perfectly valid one (#7220).
+ */
+export function needsJsonAttribute(target) {
+  return target.endsWith('.json')
+}


### PR DESCRIPTION
Closes #7220, closes #7230.

## Why there were no tests

`build-publish-dir.mjs`'s export derivation has taken **four consecutive PRs** — #7197, #7210, #7212, #7225 — each fixing a *"check reports success without actually checking"* defect in the same twenty lines. Every one was caught by hand in a PR description. It had no test coverage because the script runs `tsc` at module scope: importing it to exercise the logic rebuilds the package.

Extracted to `scripts/lib/export-targets.mjs`, tested directly. Picked up by the existing **Store Core Tests** job via vitest's default glob (verified: `vitest list` collects all 23), so no workflow change.

## #7220 — coverage over the shapes that matter

Not the happy path. A test that only asserted `./dist/index.js works` would have passed on all four broken versions.

| shape | expected | why it matters |
|---|---|---|
| flat `{ import, require }` | both collected | |
| nested `{ node: { import }, default }` | both, arbitrary depth | #7212 |
| `require`-only | collected | #7210 — used to be silently dropped |
| array `["./a.js","./b.js"]` | both collected | |
| `null` | zero targets, **no throw** | Node's subpath-blocking idiom; throwing fails a release on a *valid* manifest |
| `{ types }` only | **throws** | "cannot verify" ≠ "nothing to verify" |
| `{}` / `[]` | **throws**, names the shape | |

## #7230 item 1 — non-`file:` targets

These reached `fileURLToPath` and died with a raw Node `TypeError` instead of the script's own error. **Checking the protocol alone was not enough, and the test written from the issue's table caught that:**

```
'https://evil.example/x.js' -> https://evil.example/x.js -> ERR_INVALID_URL_SCHEME
'//host/x.js'               -> file://host/x.js         -> ERR_INVALID_FILE_URL_HOST
```

The second is protocol-**relative**: it inherits the base's scheme, so its protocol *is* `file:` and only the host distinguishes it. Both shapes now produce a domain error, and a test asserts neither leaks a Node `err.code`.

## #7230 item 2 — containment

`startsWith(outDir + sep)` → the `relative()` form. `join(outDir, '/')` is idempotent and `startsWith` was not, so the two halves of one guard disagreed about `outDir`'s shape and a trailing separator made the check reject a correctly-resolved target.

## #7220 item 2 — `.json` targets

`"./package.json": "./package.json"` is a common npm idiom. Not in store-core's manifest today, but if added, the derivation produces it and a plain `await import()` throws `needs an import attribute of "type: json"` — reporting a valid entry point as broken. Now imported with `{ with: { type: 'json' } }`.

The control for this **must run in a real node subprocess**: vitest resolves dynamic imports through Vite, which handles JSON natively, so the in-process version measured the test runner's loader and cheerfully reported the import succeeding.

## Verification

| mutation | assertion that goes red |
|---|---|
| `join(outDir, '/')` → `outDir` | containment error fires (#7225's guarantee, #7230 AC3) |
| `relative()` → `startsWith(outDir + sep)` | trailing-separator target rejected |
| drop the host check | `//host/x.js` leaks `ERR_INVALID_FILE_URL_HOST` |

23/23 pass; restore green after each. `npm run build:publish` still verifies both real exports (`.` and `./crypto`) and leaves `dist/` untouched.