### PR TITLE
fix(ci): verify AGENTS.md from bump-version.sh's own $ROOT

### DIFF
--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -175,6 +175,38 @@ STUB
   echo "$stubdir"
 }
 
+# Copy the real gen-agents-md.mjs into a fake repo, plus anything it imports.
+#
+# Copying scripts/lib wholesale rather than naming a file: the generator's
+# entry-point guard was extracted to scripts/lib/is-entry-point.mjs (#7222), and
+# a fixture that stages only gen-agents-md.mjs dies with ERR_MODULE_NOT_FOUND
+# the moment it gains a sibling import. This way the next extraction is staged
+# automatically instead of breaking the fixture.
+install_agents_generator() {
+  local dir="$1"
+  mkdir -p "$dir/scripts"
+  cp "$REPO_ROOT/scripts/gen-agents-md.mjs" "$dir/scripts/gen-agents-md.mjs"
+  if [ -d "$REPO_ROOT/scripts/lib" ]; then
+    cp -R "$REPO_ROOT/scripts/lib" "$dir/scripts/lib"
+  fi
+}
+
+# A CLAUDE.md carrying both version markers the bump rewrites. Without them the
+# bump aborts before it ever reaches the AGENTS.md block (#7183).
+write_claude_md() {
+  cat > "$1" <<CLAUDEMD
+# Claude Development Notes
+
+**Current Status (v$2):**
+- stuff works
+
+---
+
+*Last Updated: 2026-01-01*
+*Version: $2*
+CLAUDEMD
+}
+
 # Write a minimal CHANGELOG.md (header + one prior section).
 write_changelog() {
   local file="$1"
@@ -773,6 +805,112 @@ CLAUDEMD
   return 0
 }
 
+# --- AGENTS.md verified in the caller's frame (#7231) ------------------------
+#
+# bump-version.sh regenerates AGENTS.md and then has to prove it worked. It used
+# to prove it by re-invoking the same program whose reliability is in question
+# — and that program resolves its own paths from import.meta.url, so `--check`
+# graded THE GENERATOR'S AGENTS.md, never "$ROOT/AGENTS.md". Write and check
+# were self-consistent by construction and agreed with each other whether or not
+# the caller's mirror was ever touched.
+#
+# The three cases below are one positive control and two independent routes to
+# the same false success. Without the control, both failure tests would pass on
+# a fixture where the bump aborts for some unrelated reason.
+
+# POSITIVE CONTROL. With the real generator and a well-formed tree, the bump
+# must SUCCEED and $ROOT/AGENTS.md must actually be the render of the
+# POST-bump CLAUDE.md — not the pre-bump one, which is what a check running
+# before the version rewrite would accept.
+test_agents_md_regenerated_and_verified_in_root_frame() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  install_agents_generator "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+  write_claude_md "$dir/CLAUDE.md" "0.5.7"
+  printf 'STALE\n' > "$dir/AGENTS.md"
+
+  local out
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || return 1
+  echo "$out" | grep -q "AGENTS.md regenerated from CLAUDE.md" || return 1
+
+  # The mirror really moved...
+  ! grep -q '^STALE$' "$dir/AGENTS.md" || return 1
+  # ...and carries the BUMPED version, so the regeneration happened after the
+  # CLAUDE.md rewrite rather than before it.
+  grep -q '^\*Version: 0.6.0\*$' "$dir/AGENTS.md" || return 1
+  grep -q 'AUTO-GENERATED FROM CLAUDE.md' "$dir/AGENTS.md" || return 1
+}
+
+# The #7231 case proper — the generator resolves to a DIFFERENT TREE. $ROOT/scripts/
+# gen-agents-md.mjs is a symlink, so node resolves import.meta.url to the other
+# tree and the CLI writes THAT tree's AGENTS.md. Under the old check the bump
+# printed its success line and exited 0 with $ROOT/AGENTS.md untouched.
+test_agents_md_fails_when_generator_writes_to_another_tree() {
+  local dir other
+  dir=$(mktemp -d)
+  other=$(mktemp -d)
+  trap "rm -rf '$dir' '$other'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+  write_claude_md "$dir/CLAUDE.md" "0.5.7"
+  printf 'STALE\n' > "$dir/AGENTS.md"
+
+  # The other tree is a complete, self-consistent repo root: it has its own
+  # CLAUDE.md, so the generator running in ITS frame succeeds and exits 0.
+  install_agents_generator "$other"
+  write_claude_md "$other/CLAUDE.md" "9.9.9"
+  mkdir -p "$dir/scripts"
+  ln -sf "$other/scripts/gen-agents-md.mjs" "$dir/scripts/gen-agents-md.mjs"
+
+  # Must fail...
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) > /dev/null 2>&1 && return 1
+  # ...and say which tree it is complaining about.
+  local out
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 || true )
+  echo "$out" | grep -q "not in sync" || return 1
+
+  # The evidence the old check could not see: the caller's mirror is still
+  # stale, while the generator's own tree was regenerated quite happily.
+  grep -q '^STALE$' "$dir/AGENTS.md" || return 1
+  [ -f "$other/AGENTS.md" ] || return 1
+  return 0
+}
+
+# A missing mirror is a distinct failure from a stale one, and reading ENOENT as
+# "nothing to compare" would fail open on a tree that never generated AGENTS.md
+# at all.
+test_agents_md_fails_when_mirror_is_absent() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+  write_claude_md "$dir/CLAUDE.md" "0.5.7"
+
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/gen-agents-md.mjs" <<'STUB'
+export function renderAgentsMd (claudeContents) {
+  return "<!-- AUTO-GENERATED FROM CLAUDE.md -->\n\n" + claudeContents
+}
+STUB
+
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) > /dev/null 2>&1 && return 1
+  [ ! -f "$dir/AGENTS.md" ] || return 1
+  return 0
+}
+
 # --- runner ------------------------------------------------------------------
 
 echo "Running bump-version.sh tests"
@@ -840,21 +978,40 @@ install_gen_agents_stub() {
   cat > "$dir/scripts/gen-agents-md.mjs" <<STUB
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 const mode = '$mode'
-const check = process.argv.includes('--check')
-// 'quiet' is the silent no-op: no output, exit 0, for BOTH invocations.
-if (mode === 'quiet') process.exit(0)
-if (mode === 'nowrite' && !check) process.exit(0)
-const claude = existsSync('CLAUDE.md') ? readFileSync('CLAUDE.md', 'utf8') : ''
-const want = 'GENERATED\n' + claude
-if (check) {
-  const have = existsSync('AGENTS.md') ? readFileSync('AGENTS.md', 'utf8') : ''
-  if (have !== want) {
-    console.error('::error::AGENTS.md is out of sync with CLAUDE.md.')
-    process.exit(1)
+
+// The pure renderer, exported the way the real generator exports it. Since
+// #7231 this is what bump-version.sh imports to verify in its OWN frame, so it
+// has to be reachable WITHOUT running the CLI.
+export function renderAgentsMd (claudeContents) {
+  return 'GENERATED\n' + claudeContents
+}
+
+// Stands in for the real entry-point guard, and the reason the module-scope
+// \`process.exit(0)\` these stubs used to open with had to go: that exit fired
+// during the verifier's \`await import()\` too, killing the verifying process
+// with status 0 — which the shell would have read as a PASS. A generator whose
+// guard reads false does not exit, it simply declines to run, and a stub that
+// models it any other way tests the stub instead of the script.
+const invokedDirectly = Boolean(process.argv[1] && process.argv[1].endsWith('gen-agents-md.mjs'))
+if (invokedDirectly) {
+  const check = process.argv.includes('--check')
+  // 'quiet' is the silent no-op: no output, exit 0, for BOTH invocations.
+  // 'nowrite' skips only the write, so a --check invocation still reports drift.
+  const skip = mode === 'quiet' || (mode === 'nowrite' && !check)
+  if (!skip) {
+    const claude = existsSync('CLAUDE.md') ? readFileSync('CLAUDE.md', 'utf8') : ''
+    const want = renderAgentsMd(claude)
+    if (check) {
+      const have = existsSync('AGENTS.md') ? readFileSync('AGENTS.md', 'utf8') : ''
+      if (have !== want) {
+        console.error('::error::AGENTS.md is out of sync with CLAUDE.md.')
+        process.exit(1)
+      }
+      console.log('AGENTS.md is in sync with CLAUDE.md.')
+    } else {
+      writeFileSync('AGENTS.md', want)
+    }
   }
-  console.log('AGENTS.md is in sync with CLAUDE.md.')
-} else {
-  writeFileSync('AGENTS.md', want)
 }
 STUB
 }
@@ -868,17 +1025,7 @@ setup_agents_case() {
   write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
 
 - A real fix (#42)"
-  cat > "$dir/CLAUDE.md" <<'CLAUDEMD'
-# Claude Development Notes
-
-**Current Status (v0.5.7):**
-- stuff works
-
----
-
-*Last Updated: 2026-01-01*
-*Version: 0.5.7*
-CLAUDEMD
+  write_claude_md "$dir/CLAUDE.md" "0.5.7"
   printf 'STALE\n' > "$dir/AGENTS.md"
 }
 
@@ -910,7 +1057,7 @@ test_agents_md_silent_noop_fails_the_bump() {
   local out rc=0
   out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || rc=$?
   [ "$rc" -ne 0 ] || return 1
-  printf '%s' "$out" | grep -q 'could not confirm AGENTS.md is in sync' || return 1
+  printf '%s' "$out" | grep -q 'is not in sync with' || return 1
   # The false success must NOT also have been printed.
   ! printf '%s' "$out" | grep -q 'AGENTS.md regenerated from CLAUDE.md' || return 1
 }
@@ -925,7 +1072,7 @@ test_agents_md_stale_after_regeneration_fails_the_bump() {
   local out rc=0
   out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || rc=$?
   [ "$rc" -ne 0 ] || return 1
-  printf '%s' "$out" | grep -q 'could not confirm AGENTS.md is in sync' || return 1
+  printf '%s' "$out" | grep -q 'is not in sync with' || return 1
   ! printf '%s' "$out" | grep -q 'AGENTS.md regenerated from CLAUDE.md' || return 1
 }
 
@@ -935,6 +1082,12 @@ run_test "a generator that silently no-ops fails the bump (#7198 shape)" \
   test_agents_md_silent_noop_fails_the_bump
 run_test "a stale AGENTS.md after regeneration fails the bump" \
   test_agents_md_stale_after_regeneration_fails_the_bump
+run_test "AGENTS.md is verified against \$ROOT, with the real generator (#7231)" \
+  test_agents_md_regenerated_and_verified_in_root_frame
+run_test "a generator writing to ANOTHER tree fails the bump (#7231)" \
+  test_agents_md_fails_when_generator_writes_to_another_tree
+run_test "an absent AGENTS.md fails the bump rather than reading as nothing-to-compare" \
+  test_agents_md_fails_when_mirror_is_absent
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -177,11 +177,12 @@ STUB
 
 # Copy the real gen-agents-md.mjs into a fake repo, plus anything it imports.
 #
-# Copying scripts/lib wholesale rather than naming a file: the generator's
-# entry-point guard was extracted to scripts/lib/is-entry-point.mjs (#7222), and
-# a fixture that stages only gen-agents-md.mjs dies with ERR_MODULE_NOT_FOUND
-# the moment it gains a sibling import. This way the next extraction is staged
-# automatically instead of breaking the fixture.
+# Copying scripts/lib wholesale rather than naming a file. The directory does
+# not exist on this branch; #7222 proposes extracting the entry-point guard
+# there, and a fixture that stages only gen-agents-md.mjs dies with
+# ERR_MODULE_NOT_FOUND the moment the generator gains a sibling import. The
+# `[ -d ]` guard below means this works either way, before or after that lands,
+# and stages the NEXT extraction automatically too.
 install_agents_generator() {
   local dir="$1"
   mkdir -p "$dir/scripts"
@@ -885,6 +886,55 @@ test_agents_md_fails_when_generator_writes_to_another_tree() {
   return 0
 }
 
+# The regression the first cut of #7231 introduced, and the reason the check is
+# gated on a sentinel LINE rather than on node's exit code.
+#
+# The verifier imports the generator into its own process. A generator that
+# declines to run via a MODULE-SCOPE `process.exit(0)` therefore ends the
+# VERIFIER with status 0 — `if node …; then` takes the success branch, the
+# reassuring line prints, and the mirror is left stale. `origin/main` caught this
+# because it required --check's confirmation line; the exit-code-only version did
+# not, which made it strictly weaker than what it replaced against the very
+# defect class it exists to close.
+#
+# `if (!invokedDirectly) process.exit(0)` is not a contrived stub — it is a
+# plausible way to write the guard, and #7222 is currently rewriting exactly that
+# guard.
+test_agents_md_fails_when_generator_exits_during_import() {
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.5.7"
+  install_bump_script "$dir"
+  write_changelog "$dir/CHANGELOG.md" "0.5.7" "### Fixed
+
+- A real fix (#42)"
+  write_claude_md "$dir/CLAUDE.md" "0.5.7"
+  printf 'STALE\n' > "$dir/AGENTS.md"
+
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/gen-agents-md.mjs" <<'STUB'
+// Declines at MODULE SCOPE rather than by guarding a block. Running this as a
+// CLI is a clean exit-0 no-op; IMPORTING it terminates the importing process.
+const invokedDirectly = Boolean(process.argv[1] && process.argv[1].endsWith('gen-agents-md.mjs'))
+if (!invokedDirectly) process.exit(0)
+export function renderAgentsMd (claudeContents) {
+  return '<!-- AUTO-GENERATED FROM CLAUDE.md -->\n\n' + claudeContents
+}
+STUB
+
+  # Must fail...
+  local out rc=0
+  out=$( (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.6.0) 2>&1 ) || rc=$?
+  [ "$rc" -ne 0 ] || return 1
+  # ...must NOT have printed the false success...
+  ! printf '%s' "$out" | grep -q 'AGENTS.md regenerated from CLAUDE.md' || return 1
+  # ...and must name the actual cause rather than blaming drift.
+  printf '%s' "$out" | grep -q 'produced no output at all' || return 1
+  grep -q '^STALE$' "$dir/AGENTS.md" || return 1
+  return 0
+}
+
 # A missing mirror is a distinct failure from a stale one, and reading ENOENT as
 # "nothing to compare" would fail open on a tree that never generated AGENTS.md
 # at all.
@@ -1088,6 +1138,8 @@ run_test "a generator writing to ANOTHER tree fails the bump (#7231)" \
   test_agents_md_fails_when_generator_writes_to_another_tree
 run_test "an absent AGENTS.md fails the bump rather than reading as nothing-to-compare" \
   test_agents_md_fails_when_mirror_is_absent
+run_test "a generator that exits during IMPORT fails the bump (#7231 regression)" \
+  test_agents_md_fails_when_generator_exits_during_import
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -177,12 +177,13 @@ STUB
 
 # Copy the real gen-agents-md.mjs into a fake repo, plus anything it imports.
 #
-# Copying scripts/lib wholesale rather than naming a file. The directory does
-# not exist on this branch; #7222 proposes extracting the entry-point guard
-# there, and a fixture that stages only gen-agents-md.mjs dies with
-# ERR_MODULE_NOT_FOUND the moment the generator gains a sibling import. The
-# `[ -d ]` guard below means this works either way, before or after that lands,
-# and stages the NEXT extraction automatically too.
+# Copying scripts/lib wholesale rather than naming a file. #7222 extracted the
+# entry-point guard to scripts/lib/is-entry-point.mjs, and a fixture that stages
+# only gen-agents-md.mjs dies with ERR_MODULE_NOT_FOUND the moment the generator
+# gains a sibling import — which is exactly what happened when that extraction
+# landed. Copying the directory means the NEXT sibling helper is staged
+# automatically; the `[ -d ]` guard keeps it working against a tree that has no
+# scripts/lib at all.
 install_agents_generator() {
   local dir="$1"
   mkdir -p "$dir/scripts"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -277,39 +277,69 @@ if [ -f "$CLAUDE_MD" ]; then
   # so regenerating here is not optional.
   if [ -f "$ROOT/scripts/gen-agents-md.mjs" ]; then
     node "$ROOT/scripts/gen-agents-md.mjs" >/dev/null
-    # Verify the postcondition instead of announcing it. `set -euo pipefail`
-    # catches only a NON-ZERO exit, and the defect class this regeneration
-    # exists to survive (#7198, #7214) is exit ZERO having done nothing — so in
-    # precisely the failure mode worth worrying about, an unconditional echo
-    # prints a success that is false and the release ships a stale AGENTS.md.
+    # Verify the postcondition instead of announcing it, and verify it in THIS
+    # script's frame of reference.
     #
-    # --check's EXIT CODE is not sufficient on its own, and assuming it was is
-    # how the first version of this check missed the very defect it names.
-    # --check exits 0 in two unrelated situations:
+    # `set -euo pipefail` catches only a NON-ZERO exit, and the defect class
+    # this regeneration exists to survive (#7198, #7214) is exit ZERO having
+    # done nothing — so in precisely the failure mode worth worrying about, an
+    # unconditional echo prints a success that is false and the release ships a
+    # stale AGENTS.md.
     #
-    #   in sync           -> prints "AGENTS.md is in sync with CLAUDE.md."
-    #   never ran at all  -> prints NOTHING
+    # Re-running the generator with --check does not close that, and believing
+    # it did is #7231. The generator derives its own ROOT from import.meta.url,
+    # not from anything this script passes, so --check reports on THE
+    # GENERATOR'S AGENTS.md — never "$ROOT/AGENTS.md", the file this script
+    # actually cares about. Write and check are then self-consistent by
+    # construction: they agree with each other whether or not the caller's
+    # mirror was touched. Demonstrated with the generator resolving to a
+    # different tree than $ROOT, the bump rewrote that tree's mirror, printed
+    # the success line, and exited 0 with $ROOT/AGENTS.md still stale.
     #
-    # The second is the authentic #7198 shape: the entry-point guard reads
-    # false and skips this invocation exactly as it skipped the write above.
-    # Both exit 0, so only the confirmation LINE tells them apart. Requiring
-    # the line means a generator that silently declines to run cannot satisfy
-    # this check by staying quiet.
-    agents_check_out="$(node "$ROOT/scripts/gen-agents-md.mjs" --check 2>&1)" || true
-    case "$agents_check_out" in
-      *"is in sync with CLAUDE.md"*)
-        echo "  AGENTS.md regenerated from CLAUDE.md"
-        ;;
-      *)
-        echo "  ERROR: could not confirm AGENTS.md is in sync with CLAUDE.md" >&2
-        if [ -n "$agents_check_out" ]; then
-          echo "  generator said: $agents_check_out" >&2
-        else
-          echo "  the generator produced no output — it exited 0 without running (#7198 / #7214)" >&2
-        fi
-        exit 1
-        ;;
-    esac
+    # So compare here rather than asking the generator to grade itself: import
+    # the pure renderer, read BOTH files by absolute path under $ROOT, and diff
+    # them. Importing a module never runs its CLI branch, so the entry-point
+    # guard is not consulted at all — this cannot be defeated by that guard
+    # reading false, which is why it SUBSUMES the old exit-code/output check
+    # rather than stacking on it.
+    #
+    # $ROOT reaches node through the environment and is never interpolated into
+    # the -e source: a path containing a quote or a backslash would otherwise be
+    # spliced into the program text.
+    if CHROXY_BUMP_ROOT="$ROOT" node --input-type=module -e '
+      import { readFileSync } from "node:fs"
+      import { join } from "node:path"
+      import { pathToFileURL } from "node:url"
+      const root = process.env.CHROXY_BUMP_ROOT
+      const claudePath = join(root, "CLAUDE.md")
+      const agentsPath = join(root, "AGENTS.md")
+      const generator = pathToFileURL(join(root, "scripts", "gen-agents-md.mjs")).href
+      const { renderAgentsMd } = await import(generator)
+      if (typeof renderAgentsMd !== "function") {
+        console.error("gen-agents-md.mjs does not export renderAgentsMd")
+        process.exit(1)
+      }
+      const expected = renderAgentsMd(readFileSync(claudePath, "utf8"))
+      let actual
+      try {
+        actual = readFileSync(agentsPath, "utf8")
+      } catch (err) {
+        console.error(agentsPath + ": " + (err.code || err.message))
+        process.exit(1)
+      }
+      if (actual !== expected) {
+        console.error(agentsPath + " is not the render of " + claudePath)
+        process.exit(1)
+      }
+    '; then
+      echo "  AGENTS.md regenerated from CLAUDE.md"
+    else
+      echo "  ERROR: $ROOT/AGENTS.md is not in sync with $ROOT/CLAUDE.md" >&2
+      echo "  The generator exited 0, but THIS tree's mirror did not end up" >&2
+      echo "  regenerated (#7198 / #7214 / #7231). Run:" >&2
+      echo "    node $ROOT/scripts/gen-agents-md.mjs" >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -330,6 +330,17 @@ if [ -f "$CLAUDE_MD" ]; then
       import { join } from "node:path"
       import { pathToFileURL } from "node:url"
       const root = process.env.CHROXY_BUMP_ROOT
+      // Not reachable from this script, which always sets it on the command
+      // itself — but every failure in here is a DIAGNOSTIC, and join(undefined)
+      // throws a TypeError that says nothing about what went wrong. The three
+      // defensive branches in this program (this, the renderAgentsMd typeof
+      // check, and the ENOENT catch) are all message quality rather than
+      // safety: the sentinel gate below means anything that ends the program
+      // early prints no AGENTS_IN_SYNC and therefore already fails closed.
+      if (!root) {
+        console.error("CHROXY_BUMP_ROOT is unset — the verifier has no tree to check")
+        process.exit(1)
+      }
       const claudePath = join(root, "CLAUDE.md")
       const agentsPath = join(root, "AGENTS.md")
       const generator = pathToFileURL(join(root, "scripts", "gen-agents-md.mjs")).href

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -306,7 +306,26 @@ if [ -f "$CLAUDE_MD" ]; then
     # $ROOT reaches node through the environment and is never interpolated into
     # the -e source: a path containing a quote or a backslash would otherwise be
     # spliced into the program text.
-    if CHROXY_BUMP_ROOT="$ROOT" node --input-type=module -e '
+    #
+    # The verification is gated on a SENTINEL LINE, not on the exit code, and
+    # that is not belt-and-braces — it is the only thing that makes this
+    # genuinely subsume the --check it replaced.
+    #
+    # The verifier `await import()`s the generator INTO ITS OWN PROCESS. A
+    # generator that declines to run via a module-scope `process.exit(0)` —
+    # `if (!isEntryPoint(import.meta.url)) process.exit(0)` is a perfectly
+    # plausible way to write the guard — therefore terminates THE VERIFIER with
+    # status 0. `if node …; then` takes the success branch, the reassuring line
+    # prints, and $ROOT/AGENTS.md is left stale: the exact false success this
+    # block exists to prevent, arriving through the import that was supposed to
+    # make it impossible.
+    #
+    # Requiring output the program can only produce by reaching its own last
+    # line closes it, because a process that exited early printed nothing. This
+    # is the same discriminator #7229 established for --check, kept rather than
+    # discarded — the first version of this fix dropped it, and #7234's review
+    # demonstrated the regression end-to-end against main.
+    agents_verify_out="$(CHROXY_BUMP_ROOT="$ROOT" node --input-type=module -e '
       import { readFileSync } from "node:fs"
       import { join } from "node:path"
       import { pathToFileURL } from "node:url"
@@ -331,15 +350,30 @@ if [ -f "$CLAUDE_MD" ]; then
         console.error(agentsPath + " is not the render of " + claudePath)
         process.exit(1)
       }
-    '; then
-      echo "  AGENTS.md regenerated from CLAUDE.md"
-    else
-      echo "  ERROR: $ROOT/AGENTS.md is not in sync with $ROOT/CLAUDE.md" >&2
-      echo "  The generator exited 0, but THIS tree's mirror did not end up" >&2
-      echo "  regenerated (#7198 / #7214 / #7231). Run:" >&2
-      echo "    node $ROOT/scripts/gen-agents-md.mjs" >&2
-      exit 1
-    fi
+      console.log("AGENTS_IN_SYNC")
+    ' 2>&1)" || true
+    case "$agents_verify_out" in
+      *AGENTS_IN_SYNC*)
+        echo "  AGENTS.md regenerated from CLAUDE.md"
+        ;;
+      *)
+        echo "  ERROR: $ROOT/AGENTS.md is not in sync with $ROOT/CLAUDE.md" >&2
+        # Distinguish the three ways to get here, because they need different
+        # fixes and the previous wording blamed drift for all of them — a node
+        # syntax error, a missing module and an OOM all printed "the mirror did
+        # not end up regenerated".
+        if [ -z "$agents_verify_out" ]; then
+          echo "  The verifier produced no output at all — the generator ended the" >&2
+          echo "  process during import (a module-scope exit), so nothing was" >&2
+          echo "  compared (#7198 / #7214 / #7231)." >&2
+        else
+          echo "  verifier said: $agents_verify_out" >&2
+        fi
+        echo "  Regenerate with:" >&2
+        echo "    node $ROOT/scripts/gen-agents-md.mjs" >&2
+        exit 1
+        ;;
+    esac
   fi
 fi
 


### PR DESCRIPTION
Closes #7231.

## The defect

`bump-version.sh` regenerated AGENTS.md and then proved it worked by **re-invoking the same program whose reliability was in question**:

```sh
node "$ROOT/scripts/gen-agents-md.mjs" >/dev/null
agents_check_out="$(node "$ROOT/scripts/gen-agents-md.mjs" --check 2>&1)" || true
```

`gen-agents-md.mjs` derives its `ROOT` from `import.meta.url`, not from anything the caller passes. So `--check` graded **the generator's** AGENTS.md and never read `$ROOT/AGENTS.md` — the file the script actually cares about. Write and check are self-consistent by construction: they agree with each other whether or not the caller's mirror was ever touched.

#7229's `cd -P` / `pwd -P` change narrowed the gap between `$ROOT` and the generator's self-derived root, which was the right instinct, but nothing ever compared the two.

## The fix

Verify in **this script's** frame: import the pure renderer, read both files by absolute path under `$ROOT`, diff them.

Importing a module never runs its CLI branch, so the entry-point guard is not consulted at all — this **subsumes** the old exit-code/output check rather than stacking on it. `$ROOT` reaches node through the environment and is never interpolated into the `-e` source, so a path containing a quote or backslash cannot be spliced into the program text.

## A load-bearing change to #7229's stubs

The stubs opened with a module-scope `process.exit(0)` to model a false entry-point guard. **That exit fires during the verifier's `await import()` too** — killing the verifying process with status 0, which the shell reads as a PASS. A generator whose guard reads false does not exit, it declines to run; the stubs now model that, and export `renderAgentsMd` the way the real generator does.

## Verification

Ran the new tests against **main's** `bump-version.sh`:

```
FAIL  a generator writing to ANOTHER tree fails the bump (#7231)   <- the defect
PASS  AGENTS.md is verified against $ROOT, with the real generator (#7231)
PASS  an absent AGENTS.md fails the bump ...
```

The different-tree case fails pre-fix and passes here — #7231 reproduced and closed. Being straight about the other two: the positive control and the absent-mirror case pass either way; the first is a control (without it, a check that rejected *every* generator would look like a working guard) and the second is a regression guard. Only the different-tree test discriminates.

New cases:

| test | what it pins |
|---|---|
| verified against `$ROOT` with the **real** generator | the mirror really moved, and carries the **post-bump** version — so regeneration happened after the CLAUDE.md rewrite, not before |
| generator writes to another tree | `$ROOT/scripts/gen-agents-md.mjs` is a symlink into a second complete repo root; the CLI succeeds there, `$ROOT/AGENTS.md` stays stale, bump must fail |
| absent mirror | ENOENT must not read as "nothing to compare" |

24/24 in `bump-version.test.sh`. `gen-agents-md`, `compile-skill-targets` and `check-release-pr-subject` suites unaffected. `bump-version.sh` is shellcheck-clean.