### PR TITLE
fix(server): make CHROXY_CONFIG_DIR relocate ALL daemon state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,22 @@ jobs:
             exit 1
           fi
 
+      - name: Check ~/.chroxy resolves through config-dir.js
+        run: |
+          # Issue #7052 — CHROXY_CONFIG_DIR must relocate ALL daemon state. It
+          # relocated only half of it, because a `const` freezes at import: 16
+          # module-scope constants stayed home-rooted, and 16 other modules grew
+          # their own inline `process.env.CHROXY_CONFIG_DIR || …` copy to work
+          # around that. Both shapes are banned; configDir()/configPath() read
+          # the env per call. The lint is ratcheted by file — see
+          # scripts/lint-config-dir-baseline.txt, which may shrink, never grow.
+          if scripts/lint-config-dir.sh; then
+            echo "OK — ~/.chroxy resolves through src/config-dir.js"
+          else
+            echo "::error::A file resolves ~/.chroxy outside src/config-dir.js, or a baseline entry is stale. See packages/server/scripts/lint-config-dir.sh."
+            exit 1
+          fi
+
   dashboard-tests:
     name: Dashboard Tests
     needs: runner-target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`CHROXY_CONFIG_DIR` now relocates ALL daemon state (#7052).** It previously
+  moved only about half of it: `models.json`, `connection.json`, `pages/`,
+  `snapshots/`, `checkpoints/`, `ingest-secret` and the session-token store
+  followed it, while roughly twenty other files stayed pinned to `~/.chroxy`
+  regardless. Every path now resolves through one accessor that reads the
+  variable per call.
+
+  **If you do not set `CHROXY_CONFIG_DIR`, nothing changes** — the default is
+  still `~/.chroxy` and every path resolves exactly as before.
+
+  **If you DO set it**, the following move out of `~/.chroxy` on upgrade and the
+  daemon will not find your existing files there: `config.json`,
+  `credentials.json`, `session-state.json`, `scheduled-tasks.json`,
+  `server-identity.json`, `server-identity-rotation.json`, `environments.json`,
+  `notification-prefs.json`, `push-tokens.json`, `discord-webhook-state.json`,
+  `discord-billing-state.json`, `binary-trust.json`, `skills-trust.json`,
+  `session-preset-trust.json`, `supervisor.pid`, `known-good-ref`, `skills/`,
+  `worktrees/` and `logs/`.
+
+  Move them once, before starting the upgraded daemon:
+
+  ```bash
+  # with CHROXY_CONFIG_DIR set to your chosen directory
+  mkdir -p "$CHROXY_CONFIG_DIR"
+  cp -a ~/.chroxy/. "$CHROXY_CONFIG_DIR"/
+  ```
+
+  Two consequences are worth calling out because they are easy to misread:
+
+  - **Do NOT run `chroxy init` to fix a "No API token configured" error.** On a
+    host without an OS keychain the token lives in `config.json`; if that file
+    has not been moved the daemon exits with `Run 'chroxy init' first`, but
+    `init` mints a *brand new* token and every paired device has to re-pair.
+    Move `config.json` instead.
+  - On a host without an OS keychain, an unmoved `server-identity.json` makes
+    the daemon mint a **new identity key**, which pinned clients report as a
+    possible MITM. Moving the file avoids it; if you have already hit this, the
+    fix is to re-pair.
+
+  The daemon now logs its resolved config/state root at startup, so you can
+  confirm which directory it actually opened. A relative `CHROXY_CONFIG_DIR` is
+  now refused (with a warning) and falls back to `~/.chroxy`, rather than
+  scattering credentials into whatever directory the daemon was launched from.
+
+  `chroxy service install` now bakes `CHROXY_CONFIG_DIR` into the generated
+  launchd plist / systemd unit / Windows wrapper when it is set, so the
+  installed service and your shell agree on one root.
+
 ## [0.11.0] - 2026-08-15
 
 The **Codex-controllable-like-Claude** release. Codex now flows through Chroxy's

--- a/packages/protocol/dist/project.js
+++ b/packages/protocol/dist/project.js
@@ -126,6 +126,19 @@ function chroxyWorktreesRoot(env = defaultEnv()) {
     if (override.length > 0 && isAbsolute(override)) {
         return realResolve(override);
     }
+    // #7052 — the daemon creates worktrees at `configPath('worktrees')`, which
+    // follows CHROXY_CONFIG_DIR. Resolving `$HOME/.chroxy/worktrees` here instead
+    // would put this module and session-manager.js on different roots the moment
+    // the var is set, and `classifyNonProjectCwd` would stop recognising a chroxy
+    // worktree — restoring the #5464 regression, where a session in one mints a
+    // Discord status embed named after its opaque hex id instead of being
+    // suppressed. Read off `env` rather than `process.env` so the hook side
+    // (claude-hooks, which injects its own env) stays hermetic.
+    const rawConfigDir = typeof env?.CHROXY_CONFIG_DIR === 'string' ? env.CHROXY_CONFIG_DIR.trim() : '';
+    const configDir = rawConfigDir.replace(/[/\\]+$/, '');
+    if (configDir.length > 0 && isAbsolute(configDir)) {
+        return realResolve(join(configDir, 'worktrees'));
+    }
     const home = typeof env?.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir();
     if (!home)
         return null;

--- a/packages/protocol/src/project.ts
+++ b/packages/protocol/src/project.ts
@@ -135,6 +135,19 @@ function chroxyWorktreesRoot(env: ProjectEnv = defaultEnv()): string | null {
   if (override.length > 0 && isAbsolute(override)) {
     return realResolve(override)
   }
+  // #7052 — the daemon creates worktrees at `configPath('worktrees')`, which
+  // follows CHROXY_CONFIG_DIR. Resolving `$HOME/.chroxy/worktrees` here instead
+  // would put this module and session-manager.js on different roots the moment
+  // the var is set, and `classifyNonProjectCwd` would stop recognising a chroxy
+  // worktree — restoring the #5464 regression, where a session in one mints a
+  // Discord status embed named after its opaque hex id instead of being
+  // suppressed. Read off `env` rather than `process.env` so the hook side
+  // (claude-hooks, which injects its own env) stays hermetic.
+  const rawConfigDir = typeof env?.CHROXY_CONFIG_DIR === 'string' ? env.CHROXY_CONFIG_DIR.trim() : ''
+  const configDir = rawConfigDir.replace(/[/\\]+$/, '')
+  if (configDir.length > 0 && isAbsolute(configDir)) {
+    return realResolve(join(configDir, 'worktrees'))
+  }
   const home = typeof env?.HOME === 'string' && env.HOME.length > 0 ? env.HOME : homedir()
   if (!home) return null
   return realResolve(join(home, '.chroxy', 'worktrees'))

--- a/packages/protocol/tests/project.test.js
+++ b/packages/protocol/tests/project.test.js
@@ -102,6 +102,63 @@ describe('deriveProjectFromCwd (server surface)', () => {
     assert.equal(deriveProjectFromCwd(orphan, { CHROXY_WORKTREES_ROOT: root }), null)
     assert.ok(home && id) // fixture sanity
   })
+
+  // #7052 — session-manager.js creates worktrees at `configPath('worktrees')`,
+  // which follows CHROXY_CONFIG_DIR. If this module kept resolving
+  // `$HOME/.chroxy/worktrees`, the two would sit on different roots the moment
+  // the var is set and a chroxy worktree would stop being recognised — the
+  // #5464 regression, where the session mints a status embed named after its
+  // opaque hex id instead of the owning repo.
+  describe('CHROXY_CONFIG_DIR relocation (#7052)', () => {
+    /** Same shape as chroxyWorktreeFixture, but rooted at an arbitrary config dir. */
+    function relocatedFixture(repoName = 'coolproj') {
+      const home = realpathSync(mkdtempSync(join(tmpdir(), 'home-')))
+      const configDir = join(home, '.local', 'state', 'chroxy')
+      const root = join(configDir, 'worktrees')
+      const id = 'cafebabecafebabecafebabecafebabe'
+      const wt = join(root, id)
+      mkdirSync(wt, { recursive: true })
+      const repoRoot = join(home, 'projects', repoName)
+      mkdirSync(join(repoRoot, '.git', 'worktrees', id), { recursive: true })
+      writeFileSync(join(wt, '.git'), `gitdir: ${join(repoRoot, '.git', 'worktrees', id)}\n`)
+      return { home, configDir, root, id, wt, repoName }
+    }
+
+    it('resolves a worktree under a relocated config dir to its owning repo', () => {
+      const { home, configDir, wt, id, repoName } = relocatedFixture()
+      const project = deriveProjectFromCwd(wt, { HOME: home, CHROXY_CONFIG_DIR: configDir })
+      assert.equal(project, repoName)
+      assert.notEqual(project, id, 'must not fall back to the opaque worktree id')
+    })
+
+    it('POSITIVE CONTROL: without the var the same worktree is unrecognised', () => {
+      // Proves the case above passes because CHROXY_CONFIG_DIR was consulted,
+      // not because the path happens to be classifiable some other way.
+      const { home, wt, repoName } = relocatedFixture()
+      assert.notEqual(
+        deriveProjectFromCwd(wt, { HOME: home }),
+        repoName,
+        'a relocated worktree must not resolve while the config dir is unset',
+      )
+    })
+
+    it('the explicit worktrees-root override still wins over CHROXY_CONFIG_DIR', () => {
+      const { home, configDir, root, wt, repoName } = relocatedFixture()
+      assert.equal(
+        deriveProjectFromCwd(wt, { HOME: home, CHROXY_CONFIG_DIR: '/nowhere', CHROXY_WORKTREES_ROOT: root }),
+        repoName,
+      )
+      assert.ok(configDir) // fixture sanity
+    })
+
+    it('a relative CHROXY_CONFIG_DIR is ignored in favour of the home default', () => {
+      // A non-absolute value cannot name a real root, so it falls through to
+      // $HOME/.chroxy/worktrees — matching how the existing
+      // CHROXY_WORKTREES_ROOT override already treats a relative value.
+      const { home, wt, repoName } = chroxyWorktreeFixture()
+      assert.equal(deriveProjectFromCwd(wt, { HOME: home, CHROXY_CONFIG_DIR: 'relative/path' }), repoName)
+    })
+  })
 })
 
 describe('deriveProject (hook surface)', () => {

--- a/packages/server/scripts/lint-config-dir-baseline.txt
+++ b/packages/server/scripts/lint-config-dir-baseline.txt
@@ -1,0 +1,43 @@
+# Files that still resolve ~/.chroxy without going through src/config-dir.js.
+# Ratchet (#7052): a file may LEAVE this list, never join it.
+# Regenerate with: node scripts/lint-config-dir.mjs --write-baseline
+anthropic-compatible-session.js
+auth-probes.js
+binary-provenance-trust.js
+byok-compose-state.js
+byok-credentials.js
+byok-mcp-oauth-store.js
+byok-mcp-trust.js
+byok-session.js
+checkpoint-manager.js
+cli/shared.js
+cli/tokens-cmd.js
+config.js
+connection-info.js
+credential-store.js
+deepseek-credentials.js
+device-preferences.js
+discord-credentials.js
+docker-byok-session.js
+doctor.js
+environment-manager.js
+event-ingest.js
+logger.js
+models.js
+notification-prefs.js
+notifications/discord-billing-sink.js
+notifications/discord-webhook-sink.js
+orchestration/git-ops.js
+server-cli-child.js
+server-cli.js
+server-identity.js
+service.js
+session-manager.js
+session-preset.js
+shell-approval-info.js
+skills-loader.js
+skills-trust.js
+skills-usage.js
+snapshots-store.js
+supervisor.js
+ws-server.js

--- a/packages/server/scripts/lint-config-dir-baseline.txt
+++ b/packages/server/scripts/lint-config-dir-baseline.txt
@@ -1,43 +1,4 @@
 # Files that still resolve ~/.chroxy without going through src/config-dir.js.
 # Ratchet (#7052): a file may LEAVE this list, never join it.
 # Regenerate with: node scripts/lint-config-dir.mjs --write-baseline
-anthropic-compatible-session.js
-auth-probes.js
-binary-provenance-trust.js
-byok-compose-state.js
-byok-credentials.js
-byok-mcp-oauth-store.js
-byok-mcp-trust.js
-byok-session.js
-checkpoint-manager.js
-cli/shared.js
-cli/tokens-cmd.js
-config.js
-connection-info.js
-credential-store.js
-deepseek-credentials.js
-device-preferences.js
-discord-credentials.js
-docker-byok-session.js
-doctor.js
-environment-manager.js
-event-ingest.js
-logger.js
-models.js
-notification-prefs.js
-notifications/discord-billing-sink.js
-notifications/discord-webhook-sink.js
-orchestration/git-ops.js
-server-cli-child.js
-server-cli.js
-server-identity.js
-service.js
-session-manager.js
-session-preset.js
-shell-approval-info.js
-skills-loader.js
-skills-trust.js
-skills-usage.js
-snapshots-store.js
-supervisor.js
-ws-server.js
+

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -113,6 +113,11 @@ function stripComments(source) {
 const RAW_HOME_ROOTED = /homedir\s*\(\s*\)/
 const CHROXY_SEGMENT = /['"`]\.chroxy['"`]/
 
+// A module-scope binding whose initializer calls the accessor. Column-0 means
+// top level: anything inside a function or class body is indented.
+const MODULE_SCOPE_DECL = /^(?:export\s+)?(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=/
+const CALLS_ACCESSOR = /\b(?:configDir|configPath)\s*\(/
+
 function findOffenders(srcDir) {
   const offenders = []
   for (const file of listJsFiles(srcDir)) {
@@ -124,18 +129,29 @@ function findOffenders(srcDir) {
     const code = stripComments(source)
 
     code.forEach((line, idx) => {
-      if (!RAW_HOME_ROOTED.test(line) || !CHROXY_SEGMENT.test(line)) return
       const prev = idx > 0 ? rawLines[idx - 1] : ''
       if (prev.includes(IGNORE_MARKER)) return
-      // `env.CHROXY_CONFIG_DIR` too, not just `process.env.…` — cli/tokens-cmd.js
-      // destructures `env` from its opts, and it is an inline copy all the same.
-      const inlineResolver = /\benv\.CHROXY_CONFIG_DIR/.test(line)
-      offenders.push({
-        file: rel,
-        line: idx + 1,
-        kind: inlineResolver ? 'inline-resolver-copy' : 'hardcoded-home-path',
-        text: rawLines[idx].trim(),
-      })
+      const push = (kind) =>
+        offenders.push({ file: rel, line: idx + 1, kind, text: rawLines[idx].trim() })
+
+      if (RAW_HOME_ROOTED.test(line) && CHROXY_SEGMENT.test(line)) {
+        // `env.CHROXY_CONFIG_DIR` too, not just `process.env.…` — cli/tokens-cmd.js
+        // destructures `env` from its opts, and it is an inline copy all the same.
+        const inlineResolver = /\benv\.CHROXY_CONFIG_DIR/.test(line)
+        push(inlineResolver ? 'inline-resolver-copy' : 'hardcoded-home-path')
+        return
+      }
+
+      // Calling the accessor is not enough — WHERE you call it decides whether
+      // the env is read at the moment that matters. A module-scope
+      // `const P = configPath('session-state.json')` is exactly as frozen as
+      // the `join(homedir(), …)` it replaced: it evaluates once, at import,
+      // and no later `beforeEach` can move it. The migration would otherwise
+      // look complete while half the defect survived, which is the failure
+      // this whole issue is made of.
+      if (!MODULE_SCOPE_DECL.test(line)) return
+      const initializer = /=\s*$/.test(line.trimEnd()) ? line + (code[idx + 1] ?? '') : line
+      if (CALLS_ACCESSOR.test(initializer)) push('module-scope-capture')
     })
   }
   return offenders

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Lint: `~/.chroxy` has exactly one resolver — `src/config-dir.js`.
+ *
+ * `CHROXY_CONFIG_DIR` is supposed to relocate the daemon's entire config/state
+ * root. For a long time it relocated only half of it (#7052), and the reason is
+ * visible in the two shapes this lint bans:
+ *
+ *   1. `join(homedir(), '.chroxy', …)` — a hardcoded home-rooted path that
+ *      ignores the override outright. Sixteen module-scope constants and
+ *      twenty-seven in-function sites had this.
+ *
+ *   2. `process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')` — an
+ *      inline copy of the resolver. Sixteen modules grew one independently,
+ *      *because* the shared constant could not be made to honor the env (a
+ *      `const` freezes at import). Each copy is correct in isolation and each
+ *      one is a place the convention can silently drift.
+ *
+ * Both are replaced by `configDir()` / `configPath(...segments)`, which read
+ * the environment per call.
+ *
+ * NOT matched (and deliberately so):
+ *   - `join(homedir(), 'AppData', 'Local')` in keychain.js — a Windows
+ *     credential path, not chroxy state.
+ *   - `join(homedir(), '.claude.json')` in byok-mcp-config.js — Claude Code's
+ *     own config file, which chroxy reads but does not own.
+ *   - anything inside a `//` line comment or a `/* *\/` block comment. This
+ *     matters: `cli/schedule-cmd.js`'s doc block quotes the banned pattern in
+ *     prose while explaining the migration.
+ *
+ * Allow-list / opt-out:
+ *   - `config-dir.js` — the OWNER of the resolution, exempt wholesale.
+ *   - the baseline file (`lint-config-dir-baseline.txt`), one repo-relative
+ *     path per line, exempts a file that has not been migrated yet. The
+ *     ratchet: a file may leave the baseline, never join it. Mirrors
+ *     `scripts/no-raw-color-literals-baseline.txt`.
+ *   - `// lint-ignore-config-dir` on the line immediately above an offending
+ *     line whitelists that one site.
+ *
+ * Issue: #7052.
+ *
+ * Exit codes:
+ *   0 — no un-baselined offenders, and no stale baseline entries
+ *   1 — at least one offender, or a baseline entry that is now clean
+ *
+ * Flags:
+ *   --src-dir <path>    Override the src directory (used by the golden test
+ *                       against fixture trees). Defaults to `../src`.
+ *   --baseline <path>   Override the baseline file. Defaults to
+ *                       `./lint-config-dir-baseline.txt`.
+ *   --write-baseline    Rewrite the baseline from what is currently on disk.
+ *   --dry-run           Print offenders without failing the exit code.
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const OWNER = 'config-dir.js'
+const IGNORE_MARKER = 'lint-ignore-config-dir'
+
+function parseArgs(argv) {
+  const out = { srcDir: null, baseline: null, writeBaseline: false, dryRun: false }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--src-dir') out.srcDir = argv[++i]
+    else if (argv[i] === '--baseline') out.baseline = argv[++i]
+    else if (argv[i] === '--write-baseline') out.writeBaseline = true
+    else if (argv[i] === '--dry-run') out.dryRun = true
+  }
+  return out
+}
+
+function listJsFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...listJsFiles(full))
+    else if (entry.endsWith('.js')) out.push(full)
+  }
+  return out.sort()
+}
+
+/**
+ * Blank out comment spans so a doc block that *quotes* the banned pattern is
+ * not itself an offender. Returns a line array of the same length, with
+ * commented regions replaced by spaces (line numbers stay accurate).
+ */
+function stripComments(source) {
+  const out = []
+  let inBlock = false
+  for (const line of source.split('\n')) {
+    let kept = ''
+    let i = 0
+    while (i < line.length) {
+      if (inBlock) {
+        const end = line.indexOf('*/', i)
+        if (end === -1) { i = line.length } else { inBlock = false; i = end + 2 }
+        continue
+      }
+      if (line.startsWith('//', i)) break
+      if (line.startsWith('/*', i)) { inBlock = true; i += 2; continue }
+      kept += line[i]
+      i++
+    }
+    out.push(kept)
+  }
+  return out
+}
+
+// A home-rooted chroxy path: `homedir()` and `.chroxy` on the same statement.
+const RAW_HOME_ROOTED = /homedir\s*\(\s*\)/
+const CHROXY_SEGMENT = /['"`]\.chroxy['"`]/
+
+function findOffenders(srcDir) {
+  const offenders = []
+  for (const file of listJsFiles(srcDir)) {
+    const rel = relative(srcDir, file).split(pathSep).join('/')
+    if (rel === OWNER) continue
+
+    const source = readFileSync(file, 'utf8')
+    const rawLines = source.split('\n')
+    const code = stripComments(source)
+
+    code.forEach((line, idx) => {
+      if (!RAW_HOME_ROOTED.test(line) || !CHROXY_SEGMENT.test(line)) return
+      const prev = idx > 0 ? rawLines[idx - 1] : ''
+      if (prev.includes(IGNORE_MARKER)) return
+      // `env.CHROXY_CONFIG_DIR` too, not just `process.env.…` — cli/tokens-cmd.js
+      // destructures `env` from its opts, and it is an inline copy all the same.
+      const inlineResolver = /\benv\.CHROXY_CONFIG_DIR/.test(line)
+      offenders.push({
+        file: rel,
+        line: idx + 1,
+        kind: inlineResolver ? 'inline-resolver-copy' : 'hardcoded-home-path',
+        text: rawLines[idx].trim(),
+      })
+    })
+  }
+  return offenders
+}
+
+function readBaseline(path) {
+  if (!existsSync(path)) return new Set()
+  return new Set(
+    readFileSync(path, 'utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'))
+  )
+}
+
+const args = parseArgs(process.argv.slice(2))
+const srcDir = resolve(args.srcDir ?? join(__dirname, '..', 'src'))
+const baselinePath = resolve(args.baseline ?? join(__dirname, 'lint-config-dir-baseline.txt'))
+
+const offenders = findOffenders(srcDir)
+const offendingFiles = new Set(offenders.map((o) => o.file))
+
+if (args.writeBaseline) {
+  const header = [
+    '# Files that still resolve ~/.chroxy without going through src/config-dir.js.',
+    '# Ratchet (#7052): a file may LEAVE this list, never join it.',
+    '# Regenerate with: node scripts/lint-config-dir.mjs --write-baseline',
+    '',
+  ].join('\n')
+  writeFileSync(baselinePath, header + [...offendingFiles].sort().join('\n') + '\n')
+  console.log(`Wrote ${offendingFiles.size} file(s) to ${relative(process.cwd(), baselinePath)}`)
+  process.exit(0)
+}
+
+const baseline = readBaseline(baselinePath)
+const newOffenders = offenders.filter((o) => !baseline.has(o.file))
+// A baselined file that is now clean must be removed, or the ratchet slips
+// back: the entry would keep granting an exemption nothing needs, and the next
+// regression in that file would land silently.
+const staleBaseline = [...baseline].filter((f) => !offendingFiles.has(f)).sort()
+
+for (const o of newOffenders) {
+  console.error(`${o.file}:${o.line}  [${o.kind}]  ${o.text}`)
+}
+if (newOffenders.length) {
+  console.error('')
+  console.error(`${newOffenders.length} un-baselined site(s) resolve ~/.chroxy outside src/config-dir.js.`)
+  console.error("Use configDir() / configPath(...) from './config-dir.js' — they read CHROXY_CONFIG_DIR per call.")
+}
+
+for (const f of staleBaseline) {
+  console.error(`${f}: listed in the baseline but now clean — remove the entry.`)
+}
+
+const failed = newOffenders.length > 0 || staleBaseline.length > 0
+if (!failed) {
+  const exempt = baseline.size ? ` (${baseline.size} file(s) still baselined)` : ''
+  console.log(`OK: ~/.chroxy resolves through src/config-dir.js${exempt}.`)
+}
+process.exit(failed && !args.dryRun ? 1 : 0)

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -116,7 +116,41 @@ const CHROXY_SEGMENT = /['"`]\.chroxy['"`]/
 // A module-scope binding whose initializer calls the accessor. Column-0 means
 // top level: anything inside a function or class body is indented.
 const MODULE_SCOPE_DECL = /^(?:export\s+)?(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=/
-const CALLS_ACCESSOR = /\b(?:configDir|configPath)\s*\(/
+
+// Matching only `configDir(` / `configPath(` was not enough. logger.js froze its
+// log directory as `let _logDir = defaultLogDir()`, where `defaultLogDir()` is a
+// same-file one-line wrapper around `configPath('logs')` — the exact shape this
+// rule exists to catch, one level of indirection out of its reach. The
+// migration had *replaced* a form rule 1 caught with a form nothing caught, and
+// the lint then declared the tree clean.
+//
+// So the wrapper set is derived from the file rather than hardcoded: any
+// same-file function whose body calls the accessor counts as the accessor. The
+// `defaultX()` naming convention this issue established for these resolvers is
+// included too, so a wrapper defined elsewhere and imported is still caught.
+const ACCESSOR_NAMES = ['configDir', 'configPath']
+const CALLS_ACCESSOR_DIRECTLY = /\b(?:configDir|configPath)\s*\(/
+
+/** Names of same-file functions that (transitively) resolve through the accessor. */
+function accessorWrappersIn(codeLines) {
+  const names = new Set(ACCESSOR_NAMES)
+  // Two passes so a wrapper-of-a-wrapper is caught regardless of definition order.
+  for (let pass = 0; pass < 2; pass++) {
+    for (let i = 0; i < codeLines.length; i++) {
+      const decl = /^(?:export\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/.exec(codeLines[i])
+      if (!decl) continue
+      // Scan the body until the closing brace at column 0.
+      for (let j = i + 1; j < codeLines.length; j++) {
+        if (/^\}/.test(codeLines[j])) break
+        if ([...names].some((n) => new RegExp(`\\b${n}\\s*\\(`).test(codeLines[j]))) {
+          names.add(decl[1])
+          break
+        }
+      }
+    }
+  }
+  return names
+}
 
 function findOffenders(srcDir) {
   const offenders = []
@@ -127,6 +161,11 @@ function findOffenders(srcDir) {
     const source = readFileSync(file, 'utf8')
     const rawLines = source.split('\n')
     const code = stripComments(source)
+    const wrappers = accessorWrappersIn(code)
+    const callsAccessor = (text) =>
+      CALLS_ACCESSOR_DIRECTLY.test(text)
+      || [...wrappers].some((n) => new RegExp(`\\b${n}\\s*\\(`).test(text))
+      || /\bdefault[A-Z][\w$]*\s*\(/.test(text)
 
     code.forEach((line, idx) => {
       const prev = idx > 0 ? rawLines[idx - 1] : ''
@@ -151,7 +190,7 @@ function findOffenders(srcDir) {
       // this whole issue is made of.
       if (!MODULE_SCOPE_DECL.test(line)) return
       const initializer = /=\s*$/.test(line.trimEnd()) ? line + (code[idx + 1] ?? '') : line
-      if (CALLS_ACCESSOR.test(initializer)) push('module-scope-capture')
+      if (callsAccessor(initializer)) push('module-scope-capture')
     })
   }
   return offenders

--- a/packages/server/scripts/lint-config-dir.sh
+++ b/packages/server/scripts/lint-config-dir.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-config-dir.mjs` for the actual
+# implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-config-dir.sh` without worrying about the Node interpreter
+# path on the runner image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-config-dir.mjs "$@"

--- a/packages/server/src/anthropic-compatible-session.js
+++ b/packages/server/src/anthropic-compatible-session.js
@@ -37,8 +37,6 @@
  */
 
 import { readCredentialJsonField } from './credentials-file.js'
-import { join } from 'path'
-import { homedir } from 'os'
 import Anthropic from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from './byok-session.js'
 import { validateAnthropicCompatibleProviders } from './anthropic-compatible-config.js'
@@ -48,6 +46,7 @@ import { refreshDiscoveredModels } from './model-discovery.js'
 import { cachedResolveCredentialFile } from './auth-probes.js'
 import { createLogger } from './logger.js'
 import { BILLING_CLASSES } from './billing-class.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('anthropic-compatible')
 
@@ -65,7 +64,7 @@ const ZERO_PRICING = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWri
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as deepseek-credentials.js).
 function credentialsFilePath() {
-  return join(homedir(), '.chroxy', 'credentials.json')
+  return configPath('credentials.json')
 }
 
 /**

--- a/packages/server/src/auth-probes.js
+++ b/packages/server/src/auth-probes.js
@@ -30,6 +30,7 @@
 import { existsSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { configPath } from './config-dir.js'
 
 /**
  * Best-effort probe for `claude login` OAuth state on disk (#3674).
@@ -218,7 +219,7 @@ const _SLOT_ENV_VAR = {
  */
 export function cachedResolveCredentialFile(slot, envValue, resolve, envVarName) {
   const entry = _credFileCache[slot] || _EMPTY_CRED_FILE_SLOT
-  const credPath = join(homedir(), '.chroxy', 'credentials.json')
+  const credPath = configPath('credentials.json')
 
   if (typeof envValue === 'string' && envValue.length > 0) {
     if (entry.envValue === envValue && entry.path === null && entry.result) {

--- a/packages/server/src/binary-provenance-trust.js
+++ b/packages/server/src/binary-provenance-trust.js
@@ -33,14 +33,15 @@
  * spawning — provenance is a defence-in-depth layer, not a hard dependency).
  */
 import { existsSync } from 'fs'
-import { homedir } from 'os'
-import { join } from 'path'
 import { createLogger } from './logger.js'
 import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('binary-provenance-trust')
 
-export const DEFAULT_BINARY_TRUST_FILE = join(homedir(), '.chroxy', 'binary-trust.json')
+export function defaultBinaryTrustFile() {
+  return configPath('binary-trust.json')
+}
 
 /**
  * Normalise a ledger key for storage / lookup. On case-insensitive filesystems
@@ -72,7 +73,7 @@ export class BinaryProvenanceLedger extends PathHashTrustLedger {
    */
   constructor({ filePath } = {}) {
     super({
-      filePath: filePath || DEFAULT_BINARY_TRUST_FILE,
+      filePath: filePath || defaultBinaryTrustFile(),
       log,
       normalizeKey: _normalizeKey,
       approvalField: 'approvedAt',

--- a/packages/server/src/byok-compose-state.js
+++ b/packages/server/src/byok-compose-state.js
@@ -23,8 +23,8 @@
  */
 
 import { existsSync, readFileSync, mkdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { homedir } from 'node:os'
+import { dirname } from 'node:path'
+import { configPath } from './config-dir.js'
 
 import { writeFileRestricted } from './platform.js'
 
@@ -62,10 +62,9 @@ function cloneComposeFile(composeFile) {
  * `~/.chroxy/environments.json`. Honors CHROXY_CONFIG_DIR like the rest of
  * the docker-byok stack does.
  */
-export const DEFAULT_BYOK_COMPOSE_STATE_PATH = join(
-  process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'),
-  'byok-compose-state.json',
-)
+export function defaultByokComposeStatePath() {
+  return configPath('byok-compose-state.json')
+}
 
 /**
  * Synchronous, crash-durable store of live compose project ids.
@@ -80,7 +79,7 @@ export class ByokComposeStateStore {
    * @param {string} [opts.statePath] - On-disk path for byok-compose-state.json.
    */
   constructor({ statePath } = {}) {
-    this._statePath = statePath || DEFAULT_BYOK_COMPOSE_STATE_PATH
+    this._statePath = statePath || defaultByokComposeStatePath()
     // Map<projectId, entry> so record() on an existing id replaces in place
     // and forget() is O(1). Insertion order is preserved by Map iteration.
     this._stacks = new Map()

--- a/packages/server/src/byok-credentials.js
+++ b/packages/server/src/byok-credentials.js
@@ -18,15 +18,14 @@
  * patterns before any log line lands on disk.
  */
 import { existsSync } from 'fs'
-import { join } from 'path'
-import { homedir } from 'os'
 import { resolveStoredCredentialWithMeta } from './credential-store.js'
+import { configPath } from './config-dir.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home; if this were captured at module load, the
 // path would freeze at the first import.
 function credentialsFilePath() {
-  return join(homedir(), '.chroxy', 'credentials.json')
+  return configPath('credentials.json')
 }
 
 /**

--- a/packages/server/src/byok-mcp-oauth-store.js
+++ b/packages/server/src/byok-mcp-oauth-store.js
@@ -23,11 +23,11 @@
  * key and NEVER touch the real OS keychain.
  */
 import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { homedir } from 'node:os'
+import { dirname } from 'node:path'
 import { randomBytes } from 'node:crypto'
 import * as realKeychain from './keychain.js'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 import {
   isEncryptedEnvelope,
   decryptEnvelope,
@@ -118,7 +118,7 @@ export function _setMcpOAuthKeychainForTests(keychain) {
 // up the new home (frozen-at-import would break the CHROXY_*_HOME isolation the
 // provider-oauth-test-isolation memory prescribes).
 function tokensFilePath() {
-  return process.env.CHROXY_MCP_OAUTH_TOKENS_PATH || join(homedir(), '.chroxy', 'mcp-oauth-tokens.json')
+  return process.env.CHROXY_MCP_OAUTH_TOKENS_PATH || configPath('mcp-oauth-tokens.json')
 }
 
 /**

--- a/packages/server/src/byok-mcp-trust.js
+++ b/packages/server/src/byok-mcp-trust.js
@@ -73,8 +73,8 @@
 
 import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync, unlinkSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join, dirname } from 'node:path'
+import { dirname } from 'node:path'
+import { configPath } from './config-dir.js'
 
 /**
  * On-disk trust-record version. Bumped to 2 by #7001 (partial tuple → full
@@ -131,7 +131,7 @@ export async function withTrustStoreLock(filePath, critical) {
 }
 
 export function defaultTrustStorePath() {
-  return process.env.CHROXY_MCP_TRUST_PATH || join(homedir(), '.chroxy', 'mcp-trust.json')
+  return process.env.CHROXY_MCP_TRUST_PATH || configPath('mcp-trust.json')
 }
 
 /**

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -15,8 +15,6 @@
  */
 
 import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
-import { join } from 'path'
-import { homedir } from 'os'
 import { performance } from 'node:perf_hooks'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { synthesizeModelUsage } from './usage-normalize.js'
@@ -53,6 +51,7 @@ import {
   withTrustStoreLock,
 } from './byok-mcp-trust.js'
 import { getSubagentProfile, SUBAGENT_PROFILE_NAMES } from './byok-subagent-profiles.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('byok-session')
 
@@ -237,7 +236,7 @@ export class ClaudeByokSession extends BaseSession {
       label: 'Claude (BYOK)',
       credentials: {
         envVars: ['ANTHROPIC_API_KEY'],
-        hint: `set ANTHROPIC_API_KEY or save it in ${join(homedir(), '.chroxy', 'credentials.json')} (mode 0600)`,
+        hint: `set ANTHROPIC_API_KEY or save it in ${configPath('credentials.json')} (mode 0600)`,
         optional: false,
       },
     }

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -2,12 +2,12 @@ import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { writeFileRestricted } from './platform.js'
 import { GIT } from './git.js'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('checkpoint')
 
@@ -17,8 +17,7 @@ const execFileAsync = promisify(execFileCb)
 // CHROXY_CONFIG_DIR in beforeEach are respected. Mirrors models.js and
 // connection-info.js (#4633).
 function defaultCheckpointsDir() {
-  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-  return join(configDir, 'checkpoints')
+  return configPath('checkpoints')
 }
 const MAX_CHECKPOINTS_PER_SESSION = 50
 

--- a/packages/server/src/cli/config-cmd.js
+++ b/packages/server/src/cli/config-cmd.js
@@ -2,22 +2,22 @@
  * chroxy config — Show current configuration
  */
 import { existsSync, readFileSync } from 'fs'
-import { CONFIG_FILE } from './shared.js'
+import { configFile } from './shared.js'
 
 export function registerConfigCommand(program) {
   program
     .command('config')
     .description('Show current configuration')
     .action(() => {
-      if (!existsSync(CONFIG_FILE)) {
+      if (!existsSync(configFile())) {
         console.log('No config found. Run \'chroxy init\' first.')
         process.exit(1)
       }
 
-      const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+      const config = JSON.parse(readFileSync(configFile(), 'utf-8'))
 
       console.log('\n📋 Current Configuration\n')
-      console.log(`   Config file: ${CONFIG_FILE}`)
+      console.log(`   Config file: ${configFile()}`)
       console.log(`   Port: ${config.port}`)
       const tunnelMode = config.tunnel || 'quick'
       if (tunnelMode === 'named') {

--- a/packages/server/src/cli/deploy-cmd.js
+++ b/packages/server/src/cli/deploy-cmd.js
@@ -3,7 +3,7 @@
  */
 import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'fs'
 import { join } from 'path'
-import { CONFIG_DIR } from './shared.js'
+import { configDir } from './shared.js'
 import { isWindows } from '../platform.js'
 
 export function registerDeployCommand(program) {
@@ -15,9 +15,9 @@ export function registerDeployCommand(program) {
     .action(async (options) => {
       const { execFileSync } = await import('child_process')
 
-      const PID_FILE = join(CONFIG_DIR, 'supervisor.pid')
-      const LOCK_FILE = join(CONFIG_DIR, 'update.lock')
-      const KNOWN_GOOD_FILE = join(CONFIG_DIR, 'known-good-ref')
+      const PID_FILE = join(configDir(), 'supervisor.pid')
+      const LOCK_FILE = join(configDir(), 'update.lock')
+      const KNOWN_GOOD_FILE = join(configDir(), 'known-good-ref')
 
       let lockAcquired = false
       try {
@@ -44,7 +44,7 @@ export function registerDeployCommand(program) {
           }
         }
 
-        if (!existsSync(CONFIG_DIR)) mkdirSync(CONFIG_DIR, { recursive: true })
+        if (!existsSync(configDir())) mkdirSync(configDir(), { recursive: true })
         writeFileSync(LOCK_FILE, String(process.pid))
         lockAcquired = true
 

--- a/packages/server/src/cli/init-cmd.js
+++ b/packages/server/src/cli/init-cmd.js
@@ -3,7 +3,7 @@
  */
 import { existsSync, mkdirSync } from 'fs'
 import { randomBytes } from 'crypto'
-import { CONFIG_DIR, CONFIG_FILE, prompt } from './shared.js'
+import { configDir, configFile, prompt } from './shared.js'
 import { writeFileRestricted } from '../platform.js'
 import { setToken, isKeychainAvailable } from '../keychain.js'
 
@@ -114,8 +114,8 @@ export async function runInitCmd(deps = {}) {
   const ensureDirFn = deps.ensureDirFn || ((p) => mkdirSync(p, { recursive: true }))
   const isKeychainAvailableFn = deps.isKeychainAvailableFn || isKeychainAvailable
   const setTokenFn = deps.setTokenFn || setToken
-  const configFilePath = deps.configFilePath || CONFIG_FILE
-  const configDirPath = deps.configDirPath || CONFIG_DIR
+  const configFilePath = deps.configFilePath || configFile()
+  const configDirPath = deps.configDirPath || configDir()
   const generateTokenFn =
     deps.generateTokenFn || (() => randomBytes(32).toString('base64url'))
 

--- a/packages/server/src/cli/providers-cmd.js
+++ b/packages/server/src/cli/providers-cmd.js
@@ -14,7 +14,7 @@
  */
 import { existsSync, readFileSync } from 'fs'
 import { writeFileRestricted } from '../platform.js'
-import { CONFIG_FILE } from './shared.js'
+import { configFile } from './shared.js'
 
 // The OpenRouter preset, in one place so the CLI and any future dashboard
 // affordance write an identical entry. baseUrl is the Anthropic-compat root
@@ -98,7 +98,7 @@ export function runProvidersAddOpenRouter(options = {}, deps = {}) {
   const writeFileFn = deps.writeFileFn || writeFileRestricted
   const existsFn = deps.existsFn || existsSync
   const readFileFn = deps.readFileFn || ((p) => readFileSync(p, 'utf-8'))
-  const configFilePath = deps.configFilePath || options.config || CONFIG_FILE
+  const configFilePath = deps.configFilePath || options.config || configFile()
 
   let fileConfig = {}
   if (existsFn(configFilePath)) {
@@ -157,7 +157,7 @@ export function registerProvidersCommand(program) {
   add
     .command('openrouter')
     .description('Add the OpenRouter Anthropic-compatible provider (baseUrl + key seam + model discovery + pricing autofill)')
-    .option('-c, --config <path>', 'Path to config file', CONFIG_FILE)
+    .option('-c, --config <path>', 'Path to config file', configFile())
     .option('--force', 'Overwrite an existing openrouter entry with the current preset')
     .action((options) => {
       const result = runProvidersAddOpenRouter(options)

--- a/packages/server/src/cli/schedule-cmd.js
+++ b/packages/server/src/cli/schedule-cmd.js
@@ -39,7 +39,7 @@
  */
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { CONFIG_DIR, CONFIG_FILE } from './shared.js'
+import { configDir, configFile } from './shared.js'
 import {
   ScheduledTaskStore,
   ScheduledTaskValidationError,
@@ -64,42 +64,43 @@ function readConfigSoft(configPath) {
 /**
  * The registry file THIS DAEMON would load — a sibling of session-state.json.
  *
- * Deliberately rooted at `homedir()/.chroxy` (shared.js's `CONFIG_DIR`) and
- * deliberately NOT at `$CHROXY_CONFIG_DIR`, because the daemon's own registry
- * path is home-rooted at every hop:
+ * Rooted at `configDir()` (shared.js), which is `$CHROXY_CONFIG_DIR` when set
+ * and `~/.chroxy` otherwise — because that is what the daemon's own registry
+ * path now resolves to at every hop:
  *
  *   1. `server-cli.js` constructs its `SessionManager` withOUT a
  *      `stateFilePath` (the string does not appear in that file at all), so the
- *      manager falls back to `session-manager.js`'s `DEFAULT_STATE_FILE` =
- *      `join(homedir(), '.chroxy', 'session-state.json')`.
+ *      manager falls back to `session-manager.js`'s `defaultStateFile()` =
+ *      `configPath('session-state.json')`.
  *   2. `session-manager.js` then derives `this.scheduledTaskStore` from that
  *      path via `defaultScheduledTasksPath()` — i.e. the live scheduler
- *      (#6865) reads `~/.chroxy/scheduled-tasks.json`.
+ *      (#6865) reads `<config dir>/scheduled-tasks.json`.
  *
- * Neither hop consults `CHROXY_CONFIG_DIR`. Plenty of OTHER subsystems do
- * (models.js, connection-info.js, doctor.js, device-preferences.js, …), so the
- * convention genuinely is inconsistent — that split is tracked in #7052, and
- * fixing it means moving the WRITERS, not just this reader. Honouring the env var *here*
- * would point this CLI at a file the running scheduler never opens, and
- * `schedule create` would print "Created scheduled task …" for a task that can
- * never fire while `schedule list` showed an empty registry. That is precisely
- * the report-success-while-silently-wrong failure this module's doc block
- * exists to prevent, so matching the daemon beats matching the convention.
+ * The rule this resolver actually obeys is *match the daemon*, not *match the
+ * convention*. Those pointed in opposite directions until #7052: the
+ * session-state family was hardcoded to `~/.chroxy` while models.js,
+ * connection-info.js and doctor.js honoured the env var, and following the
+ * convention here would have aimed the CLI at a file the running scheduler
+ * never opens — `schedule create` printing "Created scheduled task …" for a
+ * task that can never fire, while `schedule list` showed an empty registry.
+ * #7052 moved the WRITERS onto `configDir()`, so the two agree now and this
+ * resolver follows the daemon by following the env var. If they ever diverge
+ * again, the daemon wins.
  *
- * The same reasoning applies to `CONFIG_FILE` below: `server-cli-child.js`
- * reads `join(homedir(), '.chroxy', 'config.json')`, so reading config from the
- * home-rooted path is what makes `config.provider` / `features.scheduler` here
- * agree with what the daemon resolved.
+ * The same reasoning applies to `configFile()` below: `server-cli-child.js`
+ * reads `configPath('config.json')`, so resolving config the same way is what
+ * makes `config.provider` / `features.scheduler` here agree with what the
+ * daemon resolved.
  *
- * Pinned from both sides by tests: a spawn test asserts the registry does NOT
- * follow `CHROXY_CONFIG_DIR` (tests/cli/schedule-cmd.test.js), and a drift
- * guard asserts the daemon-side path this mirrors is still home-rooted
- * (tests/schedule-cli.test.js). If the session-state family is ever migrated
- * onto `CHROXY_CONFIG_DIR` (#7052), the drift guard goes red and this resolver
- * must move with it.
+ * Pinned from both sides by tests: a spawn test asserts the registry follows
+ * `CHROXY_CONFIG_DIR` end-to-end and falls back to `$HOME/.chroxy` without it
+ * (tests/cli/schedule-cmd.test.js), and a drift guard asserts the CLI and
+ * `defaultStateFile()` land on the same registry under a relocated root
+ * (tests/schedule-cli.test.js). If the daemon's resolution moves again, the
+ * drift guard goes red and this resolver must move with it.
  */
 export function defaultScheduleRegistryPath() {
-  return defaultScheduledTasksPath(join(CONFIG_DIR, 'session-state.json'))
+  return defaultScheduledTasksPath(join(configDir(), 'session-state.json'))
 }
 
 function getDefaultStore() {
@@ -115,7 +116,7 @@ function getDefaultStore() {
  * see tests/schedule-cli.test.js.
  */
 function buildDeps(overrides = {}) {
-  const config = readConfigSoft(CONFIG_FILE)
+  const config = readConfigSoft(configFile())
   return {
     store: overrides.store || getDefaultStore(),
     write: overrides.write || console.log,

--- a/packages/server/src/cli/session-cmd.js
+++ b/packages/server/src/cli/session-cmd.js
@@ -3,14 +3,14 @@
  */
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { CONFIG_DIR } from './shared.js'
+import { configDir } from './shared.js'
 
 export function registerSessionCommands(program) {
   program
     .command('sessions')
     .description('List saved sessions with conversation IDs for terminal handoff')
     .action(() => {
-      const stateFile = join(CONFIG_DIR, 'session-state.json')
+      const stateFile = join(configDir(), 'session-state.json')
 
       if (!existsSync(stateFile)) {
         console.log('\nNo saved sessions found.')
@@ -59,7 +59,7 @@ export function registerSessionCommands(program) {
     .option('--dangerously-skip-permissions', 'Pass --dangerously-skip-permissions to claude')
     .action(async (sessionArg, options) => {
       const { execFileSync } = await import('child_process')
-      const stateFile = join(CONFIG_DIR, 'session-state.json')
+      const stateFile = join(configDir(), 'session-state.json')
 
       if (!existsSync(stateFile)) {
         console.error('No saved sessions found. Start the server first.')

--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -5,7 +5,6 @@
  * config loading, and helper functions.
  */
 import { existsSync, readFileSync } from 'fs'
-import { join } from 'path'
 import readline from 'readline'
 import { validateConfig, mergeConfig, isFatalConfigWarning, DEFAULT_MAX_PAYLOAD_BYTES } from '../config.js'
 import { configDir, configPath } from '../config-dir.js'

--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -6,12 +6,17 @@
  */
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
 import readline from 'readline'
 import { validateConfig, mergeConfig, isFatalConfigWarning, DEFAULT_MAX_PAYLOAD_BYTES } from '../config.js'
+import { configDir, configPath } from '../config-dir.js'
 
-export const CONFIG_DIR = join(homedir(), '.chroxy')
-export const CONFIG_FILE = join(CONFIG_DIR, 'config.json')
+// Re-exported so CLI command modules keep importing their paths from one place.
+export { configDir }
+
+/** `<config dir>/config.json`, resolved per call so CHROXY_CONFIG_DIR is honored (#7052). */
+export function configFile() {
+  return configPath('config.json')
+}
 
 /**
  * Interactive prompt helper
@@ -35,7 +40,7 @@ export function prompt(question) {
  */
 export function addServerOptions(cmd) {
   return cmd
-    .option('-c, --config <path>', 'Path to config file', CONFIG_FILE)
+    .option('-c, --config <path>', 'Path to config file', configFile())
     .option('--host <address>', 'Bind address (default: 0.0.0.0; use 127.0.0.1 for loopback-only). Auth stays enabled.')
     .option('--cwd <path>', 'Working directory for Claude')
     .option('--model <model>', 'Model to use')
@@ -107,7 +112,7 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
       }
       throw err
     }
-  } else if (options.config !== CONFIG_FILE) {
+  } else if (options.config !== configFile()) {
     console.error(`❌ Config file not found: ${options.config}`)
     process.exit(1)
   } else {

--- a/packages/server/src/cli/tokens-cmd.js
+++ b/packages/server/src/cli/tokens-cmd.js
@@ -11,13 +11,12 @@
 // Revoke targets a token by a unique handle PREFIX (from `tokens list`); the full
 // token is never printed. `--all` is the panic button and requires `--yes`.
 
-import { homedir } from 'os'
-import { join } from 'path'
 import { createSessionTokenStore } from '../session-token-store.js'
+import { configDir } from '../config-dir.js'
 
 /** Resolve the chroxy config dir the same way server-cli does. */
 function resolveChroxyDir(env = process.env) {
-  return env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return configDir()
 }
 
 /** Human-readable age string; 'unknown' when the caller passes a non-finite age. */

--- a/packages/server/src/cli/tokens-cmd.js
+++ b/packages/server/src/cli/tokens-cmd.js
@@ -14,8 +14,8 @@
 import { createSessionTokenStore } from '../session-token-store.js'
 import { configDir } from '../config-dir.js'
 
-/** Resolve the chroxy config dir the same way server-cli does. */
-function resolveChroxyDir(env = process.env) {
+/** Resolve the chroxy config dir the same way server-cli does (#7052: one resolver). */
+function resolveChroxyDir() {
   return configDir()
 }
 

--- a/packages/server/src/cli/tunnel-cmd.js
+++ b/packages/server/src/cli/tunnel-cmd.js
@@ -4,7 +4,7 @@
 import { existsSync, mkdirSync, readFileSync } from 'fs'
 import { CloudflareTunnelAdapter } from '../tunnel/index.js'
 import { writeFileRestricted } from '../platform.js'
-import { CONFIG_DIR, CONFIG_FILE, prompt } from './shared.js'
+import { configDir, configFile, prompt } from './shared.js'
 
 export function registerTunnelCommand(program) {
   const tunnelCmd = program
@@ -75,22 +75,22 @@ async function setupCloudflare() {
 
   console.log('\nStep 4: Saving configuration\n')
 
-  if (!existsSync(CONFIG_DIR)) {
-    mkdirSync(CONFIG_DIR, { recursive: true })
+  if (!existsSync(configDir())) {
+    mkdirSync(configDir(), { recursive: true })
   }
 
   let config = {}
-  if (existsSync(CONFIG_FILE)) {
-    config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+  if (existsSync(configFile())) {
+    config = JSON.parse(readFileSync(configFile(), 'utf-8'))
   }
 
   config.tunnel = 'named'
   config.tunnelName = tunnelName
   config.tunnelHostname = hostname
 
-  writeFileRestricted(CONFIG_FILE, JSON.stringify(config, null, 2))
+  writeFileRestricted(configFile(), JSON.stringify(config, null, 2))
 
-  console.log('✅ Configuration saved to:', CONFIG_FILE)
+  console.log('✅ Configuration saved to:', configFile())
   console.log('')
   console.log('Your stable URLs:')
   console.log(`   HTTP:      https://${hostname}`)

--- a/packages/server/src/cli/worktree-gc-cmd.js
+++ b/packages/server/src/cli/worktree-gc-cmd.js
@@ -11,7 +11,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { resolve, basename } from 'node:path'
-import { CONFIG_FILE } from './shared.js'
+import { configFile } from './shared.js'
 import { resolveRepoSet } from '../control-room/repo-set.js'
 import { planRepoGc, applyPlan } from '../worktree-gc.js'
 
@@ -52,7 +52,7 @@ function humanSize(kib) {
  */
 export function collectWorktreeGc(options = {}, deps = {}) {
   const {
-    configPath = CONFIG_FILE,
+    configPath = configFile(),
     plan = planRepoGc,
     sizeOf = (p) => dirSizeKib(p, deps),
     withSizes = true,

--- a/packages/server/src/config-dir.js
+++ b/packages/server/src/config-dir.js
@@ -1,5 +1,10 @@
 import { homedir } from 'os'
-import { join } from 'path'
+import { join, isAbsolute } from 'path'
+
+// Warn once per process, not per call — this is on the hot path for every path
+// resolution in the daemon. `console.warn` rather than the logger because
+// logger.js imports THIS module for its own log directory.
+let warnedRelative = false
 
 /**
  * The daemon's config/state root — the single resolver for `~/.chroxy`.
@@ -36,7 +41,35 @@ import { join } from 'path'
  * @returns {string} Absolute path to the config/state root.
  */
 export function configDir() {
-  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  const raw = process.env.CHROXY_CONFIG_DIR
+  if (!raw) return join(homedir(), '.chroxy')
+
+  // A relative value is REFUSED rather than resolved. Resolving it would only
+  // make the existing hazard explicit: because the read is per call, every fs
+  // operation would resolve it against `process.cwd()` at that moment, so
+  // `CHROXY_CONFIG_DIR=state` scatters credentials.json, the daemon identity
+  // key and the trust ledgers into whatever directory the daemon happened to be
+  // launched from — a git working tree, if `chroxy start` was run from a repo.
+  // Falling back to the known-safe default keeps secrets in one predictable
+  // place, and matches how @chroxy/protocol's project.ts already treats a
+  // relative CHROXY_WORKTREES_ROOT.
+  if (!isAbsolute(raw)) {
+    if (!warnedRelative) {
+      warnedRelative = true
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[config-dir] ignoring CHROXY_CONFIG_DIR=${JSON.stringify(raw)}: not an absolute path. `
+        + `Using ${join(homedir(), '.chroxy')} instead.`,
+      )
+    }
+    return join(homedir(), '.chroxy')
+  }
+  return raw
+}
+
+/** Test seam: reset the once-per-process relative-path warning. */
+export function _resetConfigDirWarningForTest() {
+  warnedRelative = false
 }
 
 /**

--- a/packages/server/src/config-dir.js
+++ b/packages/server/src/config-dir.js
@@ -1,0 +1,58 @@
+import { homedir } from 'os'
+import { join } from 'path'
+
+/**
+ * The daemon's config/state root — the single resolver for `~/.chroxy`.
+ *
+ * **This is a function, and that is the whole point (#7052).** The obvious
+ * shape is a module-scope constant:
+ *
+ *     const CONFIG_DIR = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+ *
+ * and it is silently wrong. A `const` evaluates once, at *import*, so it
+ * captures whatever the environment happened to be when the module graph was
+ * first walked. Pointing such a constant at an env-reading expression changes
+ * nothing: the variable still is not consulted at the moment that matters.
+ * That is not a hypothetical — sixteen modules independently grew their own
+ * inline `process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')` copy
+ * *because* the shared constant could not be made to work, while sixteen
+ * others kept a hardcoded home-rooted `const` and quietly ignored the
+ * override. `CHROXY_CONFIG_DIR` therefore relocated only half the daemon's
+ * state, which is exactly the split-brain #7052 describes.
+ *
+ * The subtle case is a default parameter:
+ *
+ *     export function readRepos(configPath = DEFAULT_CONFIG_PATH) {}   // frozen
+ *     export function readRepos(configPath = defaultConfigPath()) {}   // live
+ *
+ * The default *expression* is evaluated per call either way — but in the first
+ * form all it does is re-read a binding that was assigned once. Only the second
+ * re-reads the environment.
+ *
+ * So: no caching, no memoization, no module-scope capture. A test's
+ * `beforeEach` that sets `CHROXY_CONFIG_DIR` to a temp dir must be respected by
+ * calls made after it, which is only true if the read happens per call.
+ *
+ * @returns {string} Absolute path to the config/state root.
+ */
+export function configDir() {
+  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+}
+
+/**
+ * A path inside {@link configDir}, resolved at call time.
+ *
+ *     configPath('config.json')            // <root>/config.json
+ *     configPath('logs')                   // <root>/logs
+ *     configPath('snapshots', 'a.json')    // <root>/snapshots/a.json
+ *
+ * An empty `CHROXY_CONFIG_DIR` falls back to `~/.chroxy`, matching the `||`
+ * semantics every inline copy this replaces already had — the migration is a
+ * true no-op for the sites that were already correct.
+ *
+ * @param {...string} segments Path segments appended to the root.
+ * @returns {string} Absolute path.
+ */
+export function configPath(...segments) {
+  return join(configDir(), ...segments)
+}

--- a/packages/server/src/config-dir.js
+++ b/packages/server/src/config-dir.js
@@ -22,8 +22,8 @@ import { join } from 'path'
  *
  * The subtle case is a default parameter:
  *
- *     export function readRepos(configPath = DEFAULT_CONFIG_PATH) {}   // frozen
- *     export function readRepos(configPath = defaultConfigPath()) {}   // live
+ *     export function readRepos(p = DEFAULT_CONFIG_PATH) {}   // frozen
+ *     export function readRepos(p = defaultConfigPath()) {}   // live
  *
  * The default *expression* is evaluated per call either way — but in the first
  * form all it does is re-read a binding that was assigned once. Only the second

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -1930,7 +1930,7 @@ function defaultConfigPath() {
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  * @returns {Array<{ path: string, name?: string }>} Repos array, or [] if missing/invalid.
  */
-export function readReposFromConfig(configPath = defaultConfigPath) {
+export function readReposFromConfig(configPath = defaultConfigPath()) {
   try {
     if (!existsSync(configPath)) return []
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'))
@@ -2062,7 +2062,7 @@ function refuseMalformedConfig(configPath, reason, bytes) {
  * @param {Array<{ path: string, name?: string }>} repos - Repos array to write.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeReposToConfig(repos, configPath = defaultConfigPath) {
+export function writeReposToConfig(repos, configPath = defaultConfigPath()) {
   const existing = readConfigForMerge(configPath)
   existing.repos = repos
   const dir = dirname(configPath)
@@ -2085,7 +2085,7 @@ export function writeReposToConfig(repos, configPath = defaultConfigPath) {
  * @param {object|null} preset - The preset object ({ preamble?, seed?, enabled? }) or null to clear.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath = defaultConfigPath) {
+export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath = defaultConfigPath()) {
   const existing = readConfigForMerge(configPath)
   if (!Array.isArray(existing.repos)) existing.repos = []
 
@@ -2136,7 +2136,7 @@ export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath 
  * @param {boolean} enabled - the new gate value.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeSchedulerEnabledToConfig(enabled, configPath = defaultConfigPath) {
+export function writeSchedulerEnabledToConfig(enabled, configPath = defaultConfigPath()) {
   const existing = readConfigForMerge(configPath)
   // A non-object `features` is a single stray FIELD, not the whole config, so it
   // is repaired in place rather than refused — the operator's other settings
@@ -2155,7 +2155,7 @@ export function writeSchedulerEnabledToConfig(enabled, configPath = defaultConfi
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  * @returns {string|undefined} The configured root, or undefined if missing/invalid.
  */
-export function readControlRoomRootFromConfig(configPath = defaultConfigPath) {
+export function readControlRoomRootFromConfig(configPath = defaultConfigPath()) {
   try {
     if (!existsSync(configPath)) return undefined
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'))
@@ -2175,7 +2175,7 @@ export function readControlRoomRootFromConfig(configPath = defaultConfigPath) {
  * @param {string} root - Absolute path to the discovery root.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeControlRoomRootToConfig(root, configPath = defaultConfigPath) {
+export function writeControlRoomRootToConfig(root, configPath = defaultConfigPath()) {
   const existing = readConfigForMerge(configPath)
   existing.controlRoomRoot = root
   const dir = dirname(configPath)

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -10,8 +10,7 @@
 
 import { readFileSync, existsSync, mkdirSync, copyFileSync, constants as fsConstants } from 'fs'
 import { createHash } from 'crypto'
-import { join, dirname } from 'path'
-import { homedir } from 'os'
+import { dirname } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { parseDuration } from './duration.js'
 import { createLogger } from './logger.js'
@@ -23,6 +22,7 @@ import { validateProvidersConfigBlock } from './anthropic-compatible-config.js'
 // Imported from the pure title module (no provider/SDK deps) so config load stays
 // lightweight.
 import { DEFAULT_SEMANTIC_TITLE_MODEL, DEFAULT_SEMANTIC_TITLE_TIMEOUT_MS } from './session-title.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('config')
 
@@ -1921,14 +1921,16 @@ export async function buildEnvironmentBackend(config, { _execFile, _loadBackends
   return { backend, type }
 }
 
-const DEFAULT_CONFIG_PATH = join(homedir(), '.chroxy', 'config.json')
+function defaultConfigPath() {
+  return configPath('config.json')
+}
 
 /**
  * Read the repos array from a config file.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  * @returns {Array<{ path: string, name?: string }>} Repos array, or [] if missing/invalid.
  */
-export function readReposFromConfig(configPath = DEFAULT_CONFIG_PATH) {
+export function readReposFromConfig(configPath = defaultConfigPath) {
   try {
     if (!existsSync(configPath)) return []
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'))
@@ -2060,7 +2062,7 @@ function refuseMalformedConfig(configPath, reason, bytes) {
  * @param {Array<{ path: string, name?: string }>} repos - Repos array to write.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeReposToConfig(repos, configPath = DEFAULT_CONFIG_PATH) {
+export function writeReposToConfig(repos, configPath = defaultConfigPath) {
   const existing = readConfigForMerge(configPath)
   existing.repos = repos
   const dir = dirname(configPath)
@@ -2083,7 +2085,7 @@ export function writeReposToConfig(repos, configPath = DEFAULT_CONFIG_PATH) {
  * @param {object|null} preset - The preset object ({ preamble?, seed?, enabled? }) or null to clear.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath = DEFAULT_CONFIG_PATH) {
+export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath = defaultConfigPath) {
   const existing = readConfigForMerge(configPath)
   if (!Array.isArray(existing.repos)) existing.repos = []
 
@@ -2134,7 +2136,7 @@ export function writeSessionPresetOverrideToConfig(repoPath, preset, configPath 
  * @param {boolean} enabled - the new gate value.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeSchedulerEnabledToConfig(enabled, configPath = DEFAULT_CONFIG_PATH) {
+export function writeSchedulerEnabledToConfig(enabled, configPath = defaultConfigPath) {
   const existing = readConfigForMerge(configPath)
   // A non-object `features` is a single stray FIELD, not the whole config, so it
   // is repaired in place rather than refused — the operator's other settings
@@ -2153,7 +2155,7 @@ export function writeSchedulerEnabledToConfig(enabled, configPath = DEFAULT_CONF
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  * @returns {string|undefined} The configured root, or undefined if missing/invalid.
  */
-export function readControlRoomRootFromConfig(configPath = DEFAULT_CONFIG_PATH) {
+export function readControlRoomRootFromConfig(configPath = defaultConfigPath) {
   try {
     if (!existsSync(configPath)) return undefined
     const raw = JSON.parse(readFileSync(configPath, 'utf-8'))
@@ -2173,7 +2175,7 @@ export function readControlRoomRootFromConfig(configPath = DEFAULT_CONFIG_PATH) 
  * @param {string} root - Absolute path to the discovery root.
  * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
  */
-export function writeControlRoomRootToConfig(root, configPath = DEFAULT_CONFIG_PATH) {
+export function writeControlRoomRootToConfig(root, configPath = defaultConfigPath) {
   const existing = readConfigForMerge(configPath)
   existing.controlRoomRoot = root
   const dir = dirname(configPath)

--- a/packages/server/src/connection-info.js
+++ b/packages/server/src/connection-info.js
@@ -1,20 +1,16 @@
-import { homedir } from 'os'
 import { join } from 'path'
 import { existsSync, readFileSync, unlinkSync, mkdirSync } from 'fs'
 import { writeFileRestricted } from './platform.js'
-
-function getConfigDir() {
-  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-}
+import { configDir, configPath } from './config-dir.js'
 
 export function getConnectionInfoPath() {
-  return join(getConfigDir(), 'connection.json')
+  return configPath('connection.json')
 }
 
 export function writeConnectionInfo(info) {
-  const configDir = getConfigDir()
-  mkdirSync(configDir, { recursive: true })
-  writeFileRestricted(join(configDir, 'connection.json'), JSON.stringify(info, null, 2))
+  const dir = configDir()
+  mkdirSync(dir, { recursive: true })
+  writeFileRestricted(join(dir, 'connection.json'), JSON.stringify(info, null, 2))
 }
 
 export function readConnectionInfo() {

--- a/packages/server/src/control-room/skills-inventory.js
+++ b/packages/server/src/control-room/skills-inventory.js
@@ -45,7 +45,7 @@
 
 import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
-import { loadActiveSkills, findRepoSkillsDir, DEFAULT_SKILLS_DIR } from '../skills-loader.js'
+import { loadActiveSkills, findRepoSkillsDir, defaultSkillsDir } from '../skills-loader.js'
 import { DEFAULT_CONCURRENCY } from './constants.js'
 import { isoFromEpochMs } from '../utils/iso-datetime.js'
 
@@ -249,7 +249,7 @@ function failureReason(err) {
  */
 export async function surveySkillsInventory(repoSet, opts = {}) {
   const {
-    globalDir = DEFAULT_SKILLS_DIR,
+    globalDir = defaultSkillsDir(),
     root = '',
     usage = null,
     concurrency = DEFAULT_CONCURRENCY,

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -42,13 +42,13 @@
  * docs/security/credentials-at-rest.md for the full threat model.
  */
 import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
-import { join, dirname } from 'path'
-import { homedir } from 'os'
+import { dirname } from 'path'
 import { randomBytes } from 'crypto'
 import { maskApiKey } from './byok-credentials.js'
 import * as realKeychain from './keychain.js'
 import { createLogger } from './logger.js'
 import { fsyncForDurability, confirmRenameDurable } from './platform.js'
+import { configPath } from './config-dir.js'
 import {
   CRED_KEY_SERVICE,
   isEncryptedEnvelope,
@@ -215,7 +215,7 @@ export function isKnownCredentialKey(key) {
 // Lazy-resolved per call so tests that mutate process.env.HOME between cases
 // pick up the new home; if captured at module load it would freeze on first import.
 function credentialsFilePath() {
-  return join(homedir(), '.chroxy', 'credentials.json')
+  return configPath('credentials.json')
 }
 
 /**

--- a/packages/server/src/deepseek-credentials.js
+++ b/packages/server/src/deepseek-credentials.js
@@ -19,15 +19,14 @@
  * DeepSeek `sk-` prefix overlaps with many other key formats so it isn't
  * special-cased there — masking at the use site is the defense.
  */
-import { join } from 'path'
-import { homedir } from 'os'
 import { maskApiKey } from './byok-credentials.js'
 import { readCredentialJsonField } from './credentials-file.js'
+import { configPath } from './config-dir.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as byok-credentials.js).
 function credentialsFilePath() {
-  return join(homedir(), '.chroxy', 'credentials.json')
+  return configPath('credentials.json')
 }
 
 /**

--- a/packages/server/src/device-preferences.js
+++ b/packages/server/src/device-preferences.js
@@ -30,16 +30,16 @@
  * harmless (we fall back to `firstSessionId`).
  */
 
-import { homedir } from 'os'
 import { join } from 'path'
 import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import { configDir } from './config-dir.js'
 
 const log = createLogger('device-prefs')
 
 function getConfigDir() {
-  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return configDir()
 }
 
 export function getDevicePreferencesPath() {

--- a/packages/server/src/discord-credentials.js
+++ b/packages/server/src/discord-credentials.js
@@ -29,11 +29,10 @@
  * URLs (token part is the secret); masking at the use site via
  * maskWebhookUrl is the second layer.
  */
-import { join } from 'path'
-import { homedir } from 'os'
 import { cachedResolveCredentialFile } from './auth-probes.js'
 import { readStoredField } from './credential-store.js'
 import { getToken } from './keychain.js'
+import { configPath } from './config-dir.js'
 
 // #5493: the launchd cutover (#5439) stores the webhook in the OS keychain under
 // this service/account and relies on ~/.chroxy/service-wrapper.sh to export it as
@@ -46,7 +45,7 @@ const DISCORD_WEBHOOK_KEYCHAIN_ACCOUNT = 'webhook-url'
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as byok-credentials.js).
 function credentialsFilePath() {
-  return join(homedir(), '.chroxy', 'credentials.json')
+  return configPath('credentials.json')
 }
 
 // Accepted webhook URL shapes. discordapp.com is the legacy domain Discord

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -123,7 +123,7 @@
 import { execFile } from 'child_process'
 import { mkdirSync, writeFileSync, unlinkSync } from 'fs'
 import { createHash, randomBytes } from 'crypto'
-import { homedir, tmpdir } from 'os'
+import { tmpdir } from 'os'
 import { isAbsolute, join, posix, resolve, sep } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import {
@@ -147,6 +147,7 @@ import {
 import { isOperatorTimeoutInRange } from './duration.js'
 import { getErrorMessage } from './utils/error-message.js'
 import { VALID_USERNAME_RE } from './utils/validation-patterns.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('docker-byok')
 
@@ -566,7 +567,7 @@ export class DockerByokSession extends ClaudeByokSession {
       : null
     this._snapshotsDir = typeof opts.snapshotsDir === 'string' && opts.snapshotsDir.trim().length > 0
       ? opts.snapshotsDir.trim()
-      : join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'snapshots')
+      : configPath('snapshots')
     this._sourceSessionId = typeof opts.sourceSessionId === 'string' && opts.sourceSessionId.trim().length > 0
       ? opts.sourceSessionId.trim()
       : null

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -23,6 +23,7 @@ import {
   PROGRAMMATIC_CREDIT_ERA_START,
 } from './billing-class.js'
 import { checkDependencies } from './utils/check-dependencies.js'
+import { configPath } from './config-dir.js'
 
 // Resolve the server package root (the directory containing package.json
 // and node_modules) so dependency checks work regardless of where the
@@ -38,7 +39,9 @@ const SERVER_PKG_DIR = dirname(dirname(__filename))
 // tests/_setup.mjs redirecting CHROXY_CONFIG_DIR to a tmp dir — which would let
 // the named-tunnel routability probe (#5328) fire a live network request from
 // a maintainer's real config during the suite.
-const CONFIG_FILE = join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'config.json')
+function configFile() {
+  return configPath('config.json')
+}
 
 /**
  * Parse the leading `major.minor.patch` semver out of an arbitrary version
@@ -324,9 +327,9 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // #5328 (WP-5.6): named-tunnel coordinates for the routability probe (step 5.6).
   let tunnelMode = null
   let tunnelHostname = null
-  if (existsSync(CONFIG_FILE)) {
+  if (existsSync(configFile())) {
     try {
-      const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+      const config = JSON.parse(readFileSync(configFile(), 'utf-8'))
       if (typeof config.provider === 'string') configProvider = config.provider
       // Normalize the tunnel mode through parseTunnelArg so aliases resolve —
       // e.g. `cloudflare:named` (a documented --tunnel form persisted verbatim)
@@ -353,15 +356,15 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
       registerOpenAiCompatibleProviders(config)
       const { valid, warnings } = validateConfig(config)
       if (valid) {
-        configCheck = { name: 'Config', status: 'pass', message: CONFIG_FILE }
+        configCheck = { name: 'Config', status: 'pass', message: configFile() }
       } else {
-        configCheck = { name: 'Config', status: 'warn', message: `${CONFIG_FILE} — ${warnings.join('; ')}` }
+        configCheck = { name: 'Config', status: 'warn', message: `${configFile()} — ${warnings.join('; ')}` }
       }
     } catch (err) {
       if (err instanceof SyntaxError) {
-        configCheck = { name: 'Config', status: 'fail', message: `${CONFIG_FILE} — invalid JSON: ${err.message}` }
+        configCheck = { name: 'Config', status: 'fail', message: `${configFile()} — invalid JSON: ${err.message}` }
       } else {
-        configCheck = { name: 'Config', status: 'fail', message: `${CONFIG_FILE} — ${err.message}` }
+        configCheck = { name: 'Config', status: 'fail', message: `${configFile()} — ${err.message}` }
       }
     }
   } else {

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -2,12 +2,12 @@ import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
 import { execFile } from 'child_process'
 import { existsSync, readFileSync, mkdirSync } from 'fs'
-import { dirname, join } from 'path'
-import { homedir } from 'os'
+import { dirname } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 import { VALID_USERNAME_RE } from './utils/validation-patterns.js'
 import { DockerBackend } from './environments/backends/docker.js'
+import { configPath } from './config-dir.js'
 import {
   parseDevContainer,
   validateMounts,
@@ -16,7 +16,9 @@ import {
 
 const log = createLogger('environment-manager')
 
-const DEFAULT_STATE_PATH = join(homedir(), '.chroxy', 'environments.json')
+function defaultStatePath() {
+  return configPath('environments.json')
+}
 const DEFAULT_IMAGE = 'node:22-slim'
 const DEFAULT_MEMORY_LIMIT = '2g'
 const DEFAULT_CPU_LIMIT = '2'
@@ -57,7 +59,7 @@ export class EnvironmentManager extends EventEmitter {
    */
   constructor({ statePath, _execFile, backend, workspacePVCDefault } = {}) {
     super()
-    this._statePath = statePath || DEFAULT_STATE_PATH
+    this._statePath = statePath || defaultStatePath()
     this._environments = new Map()
     // Per-environment mutex: Map<envId, Promise> — serializes operations
     this._locks = new Map()

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -27,7 +27,7 @@
 
 import { randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, openSync, writeSync, closeSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname } from 'node:path'
 import { safeTokenCompare } from './token-compare.js'
 import { sendOversizeResponse } from './http-oversize.js'
 import { writeFileRestricted } from './platform.js'

--- a/packages/server/src/event-ingest.js
+++ b/packages/server/src/event-ingest.js
@@ -28,7 +28,6 @@
 import { randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, openSync, writeSync, closeSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { homedir } from 'node:os'
 import { safeTokenCompare } from './token-compare.js'
 import { sendOversizeResponse } from './http-oversize.js'
 import { writeFileRestricted } from './platform.js'
@@ -45,6 +44,7 @@ import { IngestEventSchema } from '@chroxy/protocol'
 // Zod-free @chroxy/protocol/project subpath (audit P2-2, #5850) so the hook
 // (packages/claude-hooks/src/project.js) and this server fallback can't drift.
 import { deriveProjectFromCwd } from '@chroxy/protocol/project'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('ingest')
 
@@ -163,8 +163,7 @@ export const INGEST_IDLE_PROMPT_MAPPING = {
 
 /** Default on-disk location for the ingest secret (0600, same-user reads). */
 export function defaultIngestSecretPath() {
-  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-  return join(configDir, 'ingest-secret')
+  return configPath('ingest-secret')
 }
 
 // Synchronous millisecond sleep (Atomics.wait on a throwaway SharedArrayBuffer) —

--- a/packages/server/src/handler-utils.js
+++ b/packages/server/src/handler-utils.js
@@ -9,6 +9,7 @@ import { statSync, realpathSync, readFileSync } from 'fs'
 import { homedir } from 'os'
 import { resolve, relative, sep } from 'path'
 import { createLogger } from './logger.js'
+import { configDir } from './config-dir.js'
 
 const log = createLogger('handler-utils')
 
@@ -317,6 +318,40 @@ function pathTouchesForbiddenSubdir(absPath, home) {
 }
 
 /**
+ * Returns true if `absPath` is the daemon's own config/state root, or inside it.
+ *
+ * `FORBIDDEN_HOME_SUBDIRS` alone cannot express this (#7052). That set is a
+ * list of literal FIRST SEGMENTS relative to `$HOME`, so it protects
+ * `~/.chroxy` and nothing else — but since #7052 the state root follows
+ * `CHROXY_CONFIG_DIR` and may be named anything (`$HOME/.local/state/chroxy`,
+ * the XDG-correct location and a leading reason to set the var at all) or live
+ * outside `$HOME` entirely, where a `$HOME`-relative check cannot reach.
+ *
+ * Left unguarded, an authenticated client could open a session with its cwd set
+ * to the relocated root and then read `credentials.json`, `config.json` (which
+ * carries the raw primary apiToken on hosts without a keychain — see
+ * docs/security/bearer-token-authority.md), or `server-identity.json`; or write
+ * `known-good-ref` to poison the supervisor's crash-rollback target, which is
+ * the exact A9 attack the `.chroxy` entry was added for on 2026-04-11. Writing
+ * the trust ledgers would pre-seed trust and turn the binary-provenance and
+ * skill-trust gates into no-ops.
+ *
+ * Resolved per call, and derived from `configDir()` rather than a second copy
+ * of the path — the whole point of #7052 is that there is one resolver.
+ */
+function pathTouchesConfigDir(absPath) {
+  let realConfigDir
+  try {
+    realConfigDir = realpathSync(configDir())
+  } catch {
+    // The root does not exist yet. `absPath` already resolved through
+    // realpathSync, so it cannot be inside a directory that is not there.
+    return false
+  }
+  return isPathWithin(absPath, realConfigDir)
+}
+
+/**
  * Validate that a cwd path is allowed as a session working directory.
  *
  * Layers (each must pass):
@@ -368,6 +403,12 @@ export function validateCwdAllowed(cwd, config = null) {
     : homedir()
   if (pathTouchesForbiddenSubdir(realCwd, home)) {
     return 'Directory is not allowed: credential/config directories under $HOME are blocked for security'
+  }
+  // Layer 2b: the daemon's OWN state root, wherever CHROXY_CONFIG_DIR put it.
+  // Separate from the set above because that one matches literal first segments
+  // under $HOME and cannot follow a relocated root (#7052).
+  if (pathTouchesConfigDir(realCwd)) {
+    return 'Directory is not allowed: the chroxy config/state directory is blocked for security'
   }
 
   // Layer 3: explicit allowlist (opt-in, strict)

--- a/packages/server/src/handlers/skills-handlers.js
+++ b/packages/server/src/handlers/skills-handlers.js
@@ -16,7 +16,7 @@ import {
   loadActiveSkillsLayered,
   findRepoSkillsDir,
   findSkillForRetrust,
-  DEFAULT_SKILLS_DIR,
+  defaultSkillsDir,
   _isCommunityNamespace,
 } from '../skills-loader.js'
 import { realpathSync, readdirSync, statSync } from 'fs'
@@ -94,7 +94,7 @@ function handleListSkills(ws, client, msg, ctx) {
   // override per-session). Fall back to the defaults / cwd-walk only
   // when the session doesn't expose these — typically because no
   // session is bound (the no-session path scans the global tier).
-  const sessionSkillsDir = entry?.session?._skillsDir || DEFAULT_SKILLS_DIR
+  const sessionSkillsDir = entry?.session?._skillsDir || defaultSkillsDir()
   const sessionRepoDir = entry?.session
     ? (entry.session._repoSkillsDir !== undefined
       ? entry.session._repoSkillsDir
@@ -358,7 +358,7 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
     resolvedBody = loaded.body
   } else {
     // Block-mode recovery path: scan the session's skill dirs directly.
-    const sessionGlobalDir = entry?.session?._skillsDir || DEFAULT_SKILLS_DIR
+    const sessionGlobalDir = entry?.session?._skillsDir || defaultSkillsDir()
     const sessionRepoDir = entry?.session?._repoSkillsDir !== undefined
       ? entry.session._repoSkillsDir
       : (entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null)
@@ -543,7 +543,7 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
 
   // Resolve the skill path. Community skills are absent from _getSkills()
   // while pending trust, so we scan the community dirs directly.
-  const sessionGlobalDir = entry?.session?._skillsDir || DEFAULT_SKILLS_DIR
+  const sessionGlobalDir = entry?.session?._skillsDir || defaultSkillsDir()
   const sessionRepoDir = entry?.session?._repoSkillsDir !== undefined
     ? entry.session._repoSkillsDir
     : (entry?.session?.cwd ? findRepoSkillsDir(entry.session.cwd) : null)

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -20,10 +20,12 @@ import {
   openSync, readSync, closeSync, writeFileSync, truncateSync,
 } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
 import { SENSITIVE_PATTERNS, API_KEY_PATTERNS, redactValue } from './redaction.js'
+import { configPath } from './config-dir.js'
 
-const DEFAULT_LOG_DIR = join(homedir(), '.chroxy', 'logs')
+function defaultLogDir() {
+  return configPath('logs')
+}
 const MAX_LOG_SIZE = 5 * 1024 * 1024  // 5MB
 const MAX_LOG_FILES = 3
 const ROTATION_CHECK_INTERVAL = 100  // check every N writes
@@ -129,7 +131,7 @@ export function redactSensitivePreservingEscapes(s) {
 let _logLevel = LOG_LEVELS[process.env.LOG_LEVEL] ?? LOG_LEVELS.info
 let _jsonMode = false
 let _logToFile = false
-let _logDir = DEFAULT_LOG_DIR
+let _logDir = defaultLogDir()
 let _logPath = null
 let _auditLogPath = null
 let _writeCount = 0
@@ -261,7 +263,7 @@ export function getAuditLogPath() {
  * (see generateWindowsServiceWrapper).
  *
  * @param {object} [options]
- * @param {string} [options.logDir] - defaults to DEFAULT_LOG_DIR: the capture
+ * @param {string} [options.logDir] - defaults to defaultLogDir(): the capture
  *   location is baked into the plist/unit by `service install` (always
  *   `~/.chroxy/logs`), so it deliberately does NOT follow a custom
  *   CHROXY_LOG_DIR, which only moves the logger's own files
@@ -276,7 +278,7 @@ export function capStdioCaptureLogs({
   tailKeep = STDIO_CAPTURE_TAIL_KEEP,
 } = {}) {
   if (process.platform === 'win32') return []
-  const dir = logDir || DEFAULT_LOG_DIR
+  const dir = logDir || defaultLogDir()
   const capped = []
   for (const name of ['chroxy-stdout.log', 'chroxy-stderr.log']) {
     const filePath = join(dir, name)
@@ -318,7 +320,7 @@ export function closeFileLogging() {
   _logToFile = false
   _jsonMode = false
   _logLevel = LOG_LEVELS.info
-  _logDir = DEFAULT_LOG_DIR
+  _logDir = defaultLogDir()
   _logPath = null
   _auditLogPath = null
   _writeCount = 0

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -131,7 +131,14 @@ export function redactSensitivePreservingEscapes(s) {
 let _logLevel = LOG_LEVELS[process.env.LOG_LEVEL] ?? LOG_LEVELS.info
 let _jsonMode = false
 let _logToFile = false
-let _logDir = defaultLogDir()
+// #7052 — deliberately NOT `defaultLogDir()` here. A module-scope initializer
+// runs at import, so it would freeze the log directory against whatever
+// CHROXY_CONFIG_DIR happened to be when the module graph was first walked —
+// the exact defect config-dir.js exists to prevent, one level of indirection
+// away from where the lint could see it. Resolved lazily in initFileLogging()
+// instead, so a test that relocates the config dir in a `beforeEach` is
+// honored (#4633).
+let _logDir = null
 let _logPath = null
 let _auditLogPath = null
 let _writeCount = 0
@@ -185,7 +192,9 @@ export function initFileLogging({ level = 'info', logDir } = {}) {
   _logLevel = LOG_LEVELS[level] ?? LOG_LEVELS.info
   _logToFile = true
   _writeCount = 0
-  if (logDir) _logDir = logDir
+  // Resolve per call, not at import (#7052): an explicit logDir wins, otherwise
+  // ask config-dir.js now so CHROXY_CONFIG_DIR is read at the moment it matters.
+  _logDir = logDir || defaultLogDir()
   // #3734 review (Copilot): create the log directory at mode 0700, and
   // chmod existing dirs the same way. Logs may contain sensitive data
   // (tool inputs, tokens that slip past the redactor), so they must not
@@ -263,10 +272,12 @@ export function getAuditLogPath() {
  * (see generateWindowsServiceWrapper).
  *
  * @param {object} [options]
- * @param {string} [options.logDir] - defaults to defaultLogDir(): the capture
- *   location is baked into the plist/unit by `service install` (always
- *   `~/.chroxy/logs`), so it deliberately does NOT follow a custom
- *   CHROXY_LOG_DIR, which only moves the logger's own files
+ * @param {string} [options.logDir] - defaults to defaultLogDir(), i.e.
+ *   `<config dir>/logs`, which follows CHROXY_CONFIG_DIR since #7052. The
+ *   capture location is baked into the plist/unit by `service install`, which
+ *   now propagates CHROXY_CONFIG_DIR so both halves agree. Still deliberately
+ *   does NOT follow a custom CHROXY_LOG_DIR, which only moves the logger's own
+ *   files
  * @param {number} [options.maxSize] - cap before truncation kicks in
  * @param {number} [options.tailKeep] - bytes preserved to `<name>.old.log`
  * @returns {Array<{file: string, archive: string, preservedBytes: number}>}

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1,8 +1,8 @@
 import { readFileSync, mkdirSync, watch as fsWatch } from 'fs'
-import { homedir } from 'os'
 import { basename, dirname, join } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 import {
   DEFAULT_CONTEXT_WINDOW,
   ONE_M_SUFFIX,
@@ -163,8 +163,7 @@ export function computePromptCostUsd(usage, pricing) {
 }
 
 function getDefaultCachePath() {
-  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-  return join(configDir, 'models-cache.json')
+  return configPath('models-cache.json')
 }
 
 /**
@@ -175,8 +174,7 @@ function getDefaultCachePath() {
  * the static table doesn't carry — all without a code change.
  */
 function getDefaultOverlayPath() {
-  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-  return join(configDir, 'models.json')
+  return configPath('models.json')
 }
 
 /**
@@ -312,9 +310,8 @@ let providerOverlays = _bootOverlayResult.byProvider
  * @returns {string}
  */
 function getProviderCachePath(providerName) {
-  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
   const safe = String(providerName).replace(/[^a-zA-Z0-9_-]/g, '_')
-  return join(configDir, `models-cache.${safe}.json`)
+  return configPath(`models-cache.${safe}.json`)
 }
 
 /**

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1,5 +1,5 @@
 import { readFileSync, mkdirSync, watch as fsWatch } from 'fs'
-import { basename, dirname, join } from 'path'
+import { basename, dirname } from 'path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 import { configPath } from './config-dir.js'

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -55,8 +55,8 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync, unlinkSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join, dirname } from 'node:path'
+import { dirname } from 'node:path'
+import { configPath } from './config-dir.js'
 
 /**
  * Authoritative category list. MUST stay in sync with the keys of
@@ -147,7 +147,7 @@ const _ALL_CATEGORIES_SET = new Set(ALL_CATEGORIES)
 const _HHMM_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
 
 export function defaultNotificationPrefsPath() {
-  return process.env.CHROXY_NOTIFICATION_PREFS_PATH || join(homedir(), '.chroxy', 'notification-prefs.json')
+  return process.env.CHROXY_NOTIFICATION_PREFS_PATH || configPath('notification-prefs.json')
 }
 
 /**

--- a/packages/server/src/notifications/discord-billing-sink.js
+++ b/packages/server/src/notifications/discord-billing-sink.js
@@ -37,12 +37,12 @@
  */
 
 import { readFileSync, mkdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { homedir } from 'node:os'
+import { dirname } from 'node:path'
 import { writeFileRestricted } from '../platform.js'
 import { createLogger } from '../logger.js'
 import { sleep } from '../utils/sleep.js'
 import { NotificationSink } from './sink.js'
+import { configPath } from '../config-dir.js'
 import {
   cachedResolveDiscordWebhookUrl,
   isValidDiscordWebhookUrl,
@@ -124,7 +124,7 @@ export class DiscordBillingSink extends NotificationSink {
   // -- State persistence ----------------------------------------------------
 
   _resolvedStatePath() {
-    return this._statePath || join(homedir(), '.chroxy', 'discord-billing-state.json')
+    return this._statePath || configPath('discord-billing-state.json')
   }
 
   /** Load the single-message store fresh from disk (read-per-send). */

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -42,12 +42,12 @@
  */
 
 import { readFileSync, mkdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { homedir } from 'node:os'
+import { dirname } from 'node:path'
 import { writeFileRestricted } from '../platform.js'
 import { createLogger } from '../logger.js'
 import { sleep } from '../utils/sleep.js'
 import { NotificationSink } from './sink.js'
+import { configPath } from '../config-dir.js'
 import {
   cachedResolveDiscordWebhookUrl,
   isValidDiscordWebhookUrl,
@@ -279,7 +279,7 @@ export class DiscordWebhookSink extends NotificationSink {
   _resolvedStatePath() {
     // Lazy like discord-credentials.credentialsFilePath so tests that mutate
     // HOME (and the sandbox guard) see the current home, not a frozen one.
-    return this._statePath || join(homedir(), '.chroxy', 'discord-webhook-state.json')
+    return this._statePath || configPath('discord-webhook-state.json')
   }
 
   /**

--- a/packages/server/src/orchestration/git-ops.js
+++ b/packages/server/src/orchestration/git-ops.js
@@ -27,9 +27,9 @@
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
 import { join, resolve, sep } from 'node:path'
-import { homedir } from 'node:os'
 import { rmSync, mkdirSync, existsSync } from 'node:fs'
 import { GIT } from '../git.js'
+import { configDir } from '../config-dir.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -64,10 +64,10 @@ function byteSliceUtf8(str, maxBytes) {
 // written to any user config.
 const ORCH_IDENTITY = { name: 'chroxy-orch', email: 'orch@chroxy.local' }
 
-/** ~/.chroxy (honoring CHROXY_CONFIG_DIR), matching the rest of the daemon. */
-export function configDir() {
-  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-}
+// Re-exported for the orchestration tests, which resolve the root the same way
+// the provisioner does. The resolver itself lives in config-dir.js (#7052) —
+// this module used to carry its own copy.
+export { configDir }
 
 /** The root the orphan sweep and the provisioner MUST agree on. Never `runs/`. */
 export function defaultWorktreesRoot() {

--- a/packages/server/src/server-cli-child.js
+++ b/packages/server/src/server-cli-child.js
@@ -13,15 +13,16 @@
  *   { type: 'drain', timeout } — Drain in-flight work, serialize state, then ack
  */
 import { existsSync, readFileSync } from 'fs'
-import { join } from 'path'
-import { homedir } from 'os'
 import { isEntryPoint } from './utils/is-entry-point.js'
 import { mergeConfig } from './config.js'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('child')
 
-const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
+function configFile() {
+  return configPath('config.json')
+}
 
 // Module-level references for drain handler access
 let _sessionManager = null
@@ -82,8 +83,8 @@ function gracefulExit(code, reason) {
 async function main() {
   // Load config (same as cli.js start command)
   let fileConfig = {}
-  if (existsSync(CONFIG_FILE)) {
-    fileConfig = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+  if (existsSync(configFile())) {
+    fileConfig = JSON.parse(readFileSync(configFile(), 'utf-8'))
   }
 
   const defaults = {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -23,6 +23,7 @@ import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join, relative, sep } from 'path'
 import { createLogger, setJsonMode, initFileLogging, setConsoleQuiet } from './logger.js'
+import { configDir, configPath } from './config-dir.js'
 
 const log = createLogger('cli')
 // #5368 slice (b): QRCode + writeConnectionInfo moved to startup-display.js with
@@ -578,7 +579,7 @@ export async function startCliServer(config) {
 
   // Migrate plaintext token to keychain and remove from config file
   if (!NO_AUTH && config.apiToken && isKeychainAvailable()) {
-    const configFile = join(homedir(), '.chroxy', 'config.json')
+    const configFile = configPath('config.json')
     const { migrated } = migrateToken(config)
     // Remove plaintext token from config file (whether newly migrated or already in keychain)
     const keychainToken = getToken()
@@ -951,10 +952,10 @@ export async function startCliServer(config) {
 
   // 3. Create push notification manager, token manager, and WebSocket server
   const pushManager = new PushManager({
-    storagePath: join(homedir(), '.chroxy', 'push-tokens.json'),
+    storagePath: configPath('push-tokens.json'),
     // #4541: notification preferences persistence. Co-located in
     // ~/.chroxy alongside push-tokens.json so cleanup is one step.
-    prefsPath: join(homedir(), '.chroxy', 'notification-prefs.json'),
+    prefsPath: configPath('notification-prefs.json'),
     // #5413 Phase 2: Discord status-embed sink. Off by default — only
     // active when a webhook URL resolves from CHROXY_DISCORD_WEBHOOK_URL
     // or ~/.chroxy/credentials.json (0600). Non-secret knobs (bot name,
@@ -963,10 +964,10 @@ export async function startCliServer(config) {
     // (message ids, current state) persists alongside the other
     // notification state in ~/.chroxy.
     discord: {
-      statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
+      statePath: configPath('discord-webhook-state.json'),
       // #5828: the billing-alert sink keeps its own state file, separate from
       // the per-project status store above.
-      billingStatePath: join(homedir(), '.chroxy', 'discord-billing-state.json'),
+      billingStatePath: configPath('discord-billing-state.json'),
       ...(config.notifications?.discord || {}),
     },
   })
@@ -990,7 +991,7 @@ export async function startCliServer(config) {
   })
   pushNotificationHandler.start()
 
-  const configFile = join(homedir(), '.chroxy', 'config.json')
+  const configFile = configPath('config.json')
   const tokenManager = NO_AUTH ? null : new TokenManager({
     token: API_TOKEN,
     tokenExpiry: config.tokenExpiry || null,
@@ -1090,7 +1091,7 @@ export async function startCliServer(config) {
   )
   // #6598 — persist paired tokens across restarts (encrypted at rest). Honour a
   // CHROXY_CONFIG_DIR override so it sits next to config.json / credentials.json.
-  const chroxyDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  const chroxyDir = configDir()
   const pairingManager = NO_AUTH ? null : new PairingManager({
     ttlMs: 60_000,
     autoRefresh: true,

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1092,6 +1092,12 @@ export async function startCliServer(config) {
   // #6598 — persist paired tokens across restarts (encrypted at rest). Honour a
   // CHROXY_CONFIG_DIR override so it sits next to config.json / credentials.json.
   const chroxyDir = configDir()
+  // #7052 — state the resolved root once at startup. Every persistent path the
+  // daemon touches now hangs off it, so when an operator relocates the dir and
+  // finds empty trust stores or a missing token, this line is the one thing
+  // that tells them WHICH root the daemon actually opened. Logged
+  // unconditionally: knowing it is `~/.chroxy` is exactly as useful.
+  log.info(`Config/state root: ${chroxyDir}${process.env.CHROXY_CONFIG_DIR ? ' (from CHROXY_CONFIG_DIR)' : ''}`)
   const pairingManager = NO_AUTH ? null : new PairingManager({
     ttlMs: 60_000,
     autoRefresh: true,

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -118,7 +118,7 @@ function secretKeyFromStored(storedB64) {
  * @param {string} [opts.filePath] - fallback file path (defaults to ~/.chroxy/server-identity.json)
  * @returns {{ publicKey: string, secretKey: Uint8Array }|null}
  */
-export function loadServerIdentity({ keychain = realKeychain, filePath = defaultIdentityFile } = {}) {
+export function loadServerIdentity({ keychain = realKeychain, filePath = defaultIdentityFile() } = {}) {
   // Keychain first (when available). #5615: distinguish a genuine "absent" from a
   // READ FAILURE (locked / interaction-not-allowed). On a read failure we MUST
   // NOT fall through to the file / minting path — that would silently rotate the
@@ -256,7 +256,7 @@ export function persistServerIdentity(keyPair, {
  * @returns {{ publicKey: string, secretKey: Uint8Array, created: boolean, backend: 'keychain'|'file' }}
  * @throws {IdentityUnavailableError} when the keychain read failed (case b)
  */
-export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = defaultIdentityFile } = {}) {
+export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = defaultIdentityFile() } = {}) {
   // NB: a keychain read failure throws IdentityUnavailableError here — let it
   // propagate. Catching it would re-enable the silent-rotation bug (#5615).
   const existing = loadServerIdentity({ keychain, filePath })
@@ -285,7 +285,7 @@ export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = 
  * @param {string} [opts.rotationFilePath]
  * @returns {{ newIdentityKey: string, rotationCert: string, previousPublicKey: string }|null}
  */
-export function loadServerRotationCert({ rotationFilePath = defaultIdentityRotationFile } = {}) {
+export function loadServerRotationCert({ rotationFilePath = defaultIdentityRotationFile() } = {}) {
   try {
     const parsed = JSON.parse(readFileSync(rotationFilePath, 'utf-8'))
     const { newIdentityKey, rotationCert, previousPublicKey } = parsed ?? {}
@@ -312,7 +312,7 @@ export function loadServerRotationCert({ rotationFilePath = defaultIdentityRotat
  * @param {string} [opts.rotationFilePath]
  * @returns {{ rotationCert: string, previousPublicKey: string }|null}
  */
-export function resolveServerRotationCert(currentIdentityPublicKey, { rotationFilePath = defaultIdentityRotationFile } = {}) {
+export function resolveServerRotationCert(currentIdentityPublicKey, { rotationFilePath = defaultIdentityRotationFile() } = {}) {
   const sidecar = loadServerRotationCert({ rotationFilePath })
   if (!sidecar) return null
   if (sidecar.newIdentityKey !== currentIdentityPublicKey) {

--- a/packages/server/src/server-identity.js
+++ b/packages/server/src/server-identity.js
@@ -32,13 +32,13 @@
  * path is overridable so tests never touch the real ~/.chroxy/ tree.
  */
 import { readFileSync, mkdirSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { homedir } from 'node:os'
+import { dirname } from 'node:path'
 import { createSigningKeyPair, signIdentityRotation } from '@chroxy/store-core/crypto'
 import nacl from 'tweetnacl'
 import * as realKeychain from './keychain.js'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('identity')
 
@@ -68,7 +68,9 @@ export class IdentityUnavailableError extends Error {
 }
 
 /** Default on-disk fallback location. Overridable for tests. */
-export const DEFAULT_IDENTITY_FILE = join(homedir(), '.chroxy', 'server-identity.json')
+export function defaultIdentityFile() {
+  return configPath('server-identity.json')
+}
 
 /**
  * #5616/#5976 — the identity-rotation continuity-cert sidecar. PUBLIC data only
@@ -78,7 +80,9 @@ export const DEFAULT_IDENTITY_FILE = join(homedir(), '.chroxy', 'server-identity
  * only the most-recent `prev → current` cert. A client pinned ≥2 rotations back
  * has no chain to follow and correctly falls back to manual re-pair.
  */
-export const DEFAULT_IDENTITY_ROTATION_FILE = join(homedir(), '.chroxy', 'server-identity-rotation.json')
+export function defaultIdentityRotationFile() {
+  return configPath('server-identity-rotation.json')
+}
 
 const SECRET_KEY_BYTES = nacl.sign.secretKeyLength // 64
 
@@ -114,7 +118,7 @@ function secretKeyFromStored(storedB64) {
  * @param {string} [opts.filePath] - fallback file path (defaults to ~/.chroxy/server-identity.json)
  * @returns {{ publicKey: string, secretKey: Uint8Array }|null}
  */
-export function loadServerIdentity({ keychain = realKeychain, filePath = DEFAULT_IDENTITY_FILE } = {}) {
+export function loadServerIdentity({ keychain = realKeychain, filePath = defaultIdentityFile } = {}) {
   // Keychain first (when available). #5615: distinguish a genuine "absent" from a
   // READ FAILURE (locked / interaction-not-allowed). On a read failure we MUST
   // NOT fall through to the file / minting path — that would silently rotate the
@@ -202,7 +206,7 @@ function readIdentityFromKeychain(keychain) {
  */
 export function persistServerIdentity(keyPair, {
   keychain = realKeychain,
-  filePath = DEFAULT_IDENTITY_FILE,
+  filePath = defaultIdentityFile(),
   durable = false,
   _write = writeFileRestricted,
 } = {}) {
@@ -252,7 +256,7 @@ export function persistServerIdentity(keyPair, {
  * @returns {{ publicKey: string, secretKey: Uint8Array, created: boolean, backend: 'keychain'|'file' }}
  * @throws {IdentityUnavailableError} when the keychain read failed (case b)
  */
-export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = DEFAULT_IDENTITY_FILE } = {}) {
+export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = defaultIdentityFile } = {}) {
   // NB: a keychain read failure throws IdentityUnavailableError here — let it
   // propagate. Catching it would re-enable the silent-rotation bug (#5615).
   const existing = loadServerIdentity({ keychain, filePath })
@@ -281,7 +285,7 @@ export function getOrCreateServerIdentity({ keychain = realKeychain, filePath = 
  * @param {string} [opts.rotationFilePath]
  * @returns {{ newIdentityKey: string, rotationCert: string, previousPublicKey: string }|null}
  */
-export function loadServerRotationCert({ rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE } = {}) {
+export function loadServerRotationCert({ rotationFilePath = defaultIdentityRotationFile } = {}) {
   try {
     const parsed = JSON.parse(readFileSync(rotationFilePath, 'utf-8'))
     const { newIdentityKey, rotationCert, previousPublicKey } = parsed ?? {}
@@ -308,7 +312,7 @@ export function loadServerRotationCert({ rotationFilePath = DEFAULT_IDENTITY_ROT
  * @param {string} [opts.rotationFilePath]
  * @returns {{ rotationCert: string, previousPublicKey: string }|null}
  */
-export function resolveServerRotationCert(currentIdentityPublicKey, { rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE } = {}) {
+export function resolveServerRotationCert(currentIdentityPublicKey, { rotationFilePath = defaultIdentityRotationFile } = {}) {
   const sidecar = loadServerRotationCert({ rotationFilePath })
   if (!sidecar) return null
   if (sidecar.newIdentityKey !== currentIdentityPublicKey) {
@@ -347,8 +351,8 @@ export function resolveServerRotationCert(currentIdentityPublicKey, { rotationFi
  */
 export function rotateServerIdentity({
   keychain = realKeychain,
-  filePath = DEFAULT_IDENTITY_FILE,
-  rotationFilePath = DEFAULT_IDENTITY_ROTATION_FILE,
+  filePath = defaultIdentityFile(),
+  rotationFilePath = defaultIdentityRotationFile(),
   _write = writeFileRestricted,
 } = {}) {
   const current = loadServerIdentity({ keychain, filePath })

--- a/packages/server/src/service.js
+++ b/packages/server/src/service.js
@@ -4,9 +4,12 @@ import { existsSync, readFileSync, mkdirSync, unlinkSync, readdirSync, writeFile
 import { writeFileRestricted, isWindows } from './platform.js'
 import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
+import { configDir, configPath } from './config-dir.js'
 
 const SERVICE_LABEL = 'com.chroxy.server'
-const DEFAULT_CONFIG_DIR = join(homedir(), '.chroxy')
+function defaultConfigDir() {
+  return configDir()
+}
 const WRAPPER_NAME = 'service-wrapper.sh'
 // Windows Task Scheduler autostart (#6647). The task name the daemon registers
 // under, and the .cmd wrapper it runs (the Windows analogue of WRAPPER_NAME).
@@ -41,7 +44,7 @@ function escapeXml(str) {
  * @param {string} [plat] - Override platform (defaults to process.platform)
  */
 export function getServicePaths(plat = platform()) {
-  const logDir = join(homedir(), '.chroxy', 'logs')
+  const logDir = configPath('logs')
 
   if (plat === 'darwin') {
     return {
@@ -80,7 +83,7 @@ export function generateLaunchdPlist(config) {
     wrapperPath,
     cwd = homedir(),
     startAtLogin = false,
-    logDir = join(homedir(), '.chroxy', 'logs'),
+    logDir = configPath('logs'),
   } = config
 
   // Bake a PATH that includes the node and claude bin dirs so the daemon's
@@ -137,7 +140,7 @@ export function generateSystemdUnit(config) {
     claudeBin,
     wrapperPath,
     cwd = homedir(),
-    logDir = join(homedir(), '.chroxy', 'logs'),
+    logDir = configPath('logs'),
   } = config
 
   // Bake a PATH that includes the node and claude bin dirs for parity with the
@@ -223,7 +226,7 @@ export function generateWindowsServiceWrapper(config) {
     chroxyBin,
     claudeBin,
     cwd = homedir(),
-    logDir = join(homedir(), '.chroxy', 'logs'),
+    logDir = configPath('logs'),
   } = config
 
   // Use Windows path semantics regardless of host so the generated batch is
@@ -505,7 +508,7 @@ exec ${sh(nodePath)} ${sh(chroxyBin)} start
  * @param {string} [configDir] - Override config directory (for testing)
  * @returns {object|null}
  */
-export function loadServiceState(configDir = DEFAULT_CONFIG_DIR) {
+export function loadServiceState(configDir = defaultConfigDir) {
   const statePath = join(configDir, 'service.json')
   if (!existsSync(statePath)) {
     return null
@@ -522,7 +525,7 @@ export function loadServiceState(configDir = DEFAULT_CONFIG_DIR) {
  * @param {object} state
  * @param {string} [configDir] - Override config directory (for testing)
  */
-export function saveServiceState(state, configDir = DEFAULT_CONFIG_DIR) {
+export function saveServiceState(state, configDir = defaultConfigDir) {
   if (!existsSync(configDir)) {
     mkdirSync(configDir, { recursive: true })
   }
@@ -580,7 +583,7 @@ export function installService(config) {
 
   const servicePath = config._servicePath || (plat === 'darwin' ? paths.plistPath : paths.unitPath)
   const logDir = config._logDir || paths.logDir
-  const stateDir = config._stateDir || DEFAULT_CONFIG_DIR
+  const stateDir = config._stateDir || defaultConfigDir()
   const wrapperPath = config._wrapperPath || join(stateDir, WRAPPER_NAME)
 
   // Bake the resolved binary locations into the service PATH so the daemon's
@@ -682,7 +685,7 @@ export function installService(config) {
  * @returns {{ installed: true, platform: 'win32', taskName: string, wrapperPath: string }}
  */
 function installWindowsService(config, paths) {
-  const stateDir = config._stateDir || DEFAULT_CONFIG_DIR
+  const stateDir = config._stateDir || defaultConfigDir()
   const logDir = config._logDir || paths.logDir
   const wrapperPath = config._wrapperPath || join(stateDir, WINDOWS_WRAPPER_NAME)
   const taskName = config._taskName || WINDOWS_TASK_NAME
@@ -784,7 +787,7 @@ export function getWindowsTaskStatus(options = {}) {
  *   Injectable exec for testing (defaults to execFileSync).
  */
 export function uninstallService(options = {}) {
-  const stateDir = options._stateDir || DEFAULT_CONFIG_DIR
+  const stateDir = options._stateDir || defaultConfigDir()
   const state = loadServiceState(stateDir)
 
   if (!state) {
@@ -838,7 +841,7 @@ export function uninstallService(options = {}) {
 export function startService(options = {}) {
   const plat = options._platform || platform()
   const paths = getServicePaths(plat)
-  const stateDir = options._stateDir || DEFAULT_CONFIG_DIR
+  const stateDir = options._stateDir || defaultConfigDir()
   const exec = options._exec || execFileSync
 
   if (plat === 'win32') {
@@ -960,7 +963,7 @@ export function stopService(options = {}) {
  * @returns {{ installed: boolean, running: boolean, pid: number|null, stale: boolean }}
  */
 export function getServiceStatus(options = {}) {
-  const configDir = options.configDir || DEFAULT_CONFIG_DIR
+  const configDir = options.configDir || defaultConfigDir()
   const state = loadServiceState(configDir)
 
   if (!state) {
@@ -1010,7 +1013,7 @@ export function getServiceStatus(options = {}) {
  * @returns {Promise<object>} Full status including health, connection info, etc.
  */
 export async function getFullServiceStatus(options = {}) {
-  const configDir = options.configDir || DEFAULT_CONFIG_DIR
+  const configDir = options.configDir || defaultConfigDir()
   const status = getServiceStatus({ configDir })
   const result = { ...status }
 

--- a/packages/server/src/service.js
+++ b/packages/server/src/service.js
@@ -75,6 +75,28 @@ export function getServicePaths(plat = platform()) {
 /**
  * Generate a macOS launchd plist XML string.
  */
+/**
+ * The config root to bake into a generated service definition, or null.
+ *
+ * launchd's `EnvironmentVariables` dict and systemd's `Environment=` lines are
+ * the daemon's ENTIRE environment — neither inherits the shell that ran
+ * `chroxy service install`. Since #7052 every path the installer resolves
+ * (logDir, service.json, the wrapper) follows CHROXY_CONFIG_DIR, so omitting it
+ * here would start a daemon whose logs land in the relocated root while its
+ * state goes to ~/.chroxy: the same split-brain #7052 exists to remove, moved
+ * to the service boundary, and one the operator cannot fix from their shell.
+ *
+ * Emitted only when set, so a default install produces a byte-identical
+ * definition to before. Injectable for tests.
+ *
+ * @param {object} config
+ * @returns {string|null}
+ */
+function serviceConfigDirEnv(config) {
+  const raw = config?.configDirEnv !== undefined ? config.configDirEnv : process.env.CHROXY_CONFIG_DIR
+  return typeof raw === 'string' && raw.trim() ? raw : null
+}
+
 export function generateLaunchdPlist(config) {
   const {
     nodePath,
@@ -85,6 +107,7 @@ export function generateLaunchdPlist(config) {
     startAtLogin = false,
     logDir = configPath('logs'),
   } = config
+  const configDirEnv = serviceConfigDirEnv(config)
 
   // Bake a PATH that includes the node and claude bin dirs so the daemon's
   // preflight finds both under launchd's bare default PATH (#5491).
@@ -123,7 +146,9 @@ ${programArgs}
     <key>PATH</key>
     <string>${escapeXml(pathValue)}</string>
     <key>CHROXY_DAEMON</key>
-    <string>1</string>
+    <string>1</string>${configDirEnv ? `
+    <key>CHROXY_CONFIG_DIR</key>
+    <string>${escapeXml(configDirEnv)}</string>` : ''}
   </dict>
 </dict>
 </plist>
@@ -142,6 +167,7 @@ export function generateSystemdUnit(config) {
     cwd = homedir(),
     logDir = configPath('logs'),
   } = config
+  const configDirEnv = serviceConfigDirEnv(config)
 
   // Bake a PATH that includes the node and claude bin dirs for parity with the
   // launchd plist (#5491).
@@ -163,7 +189,8 @@ WorkingDirectory=${cwd}
 Restart=on-failure
 RestartSec=5
 Environment=PATH=${pathValue}
-Environment=CHROXY_DAEMON=1
+Environment=CHROXY_DAEMON=1${configDirEnv ? `
+Environment=CHROXY_CONFIG_DIR=${configDirEnv}` : ''}
 StandardOutput=file:${join(logDir, 'chroxy-stdout.log')}
 StandardError=file:${join(logDir, 'chroxy-stderr.log')}
 
@@ -228,6 +255,7 @@ export function generateWindowsServiceWrapper(config) {
     cwd = homedir(),
     logDir = configPath('logs'),
   } = config
+  const configDirEnv = serviceConfigDirEnv(config)
 
   // Use Windows path semantics regardless of host so the generated batch is
   // correct even when this runs on a POSIX CI runner under test (#6647).
@@ -255,6 +283,7 @@ export function generateWindowsServiceWrapper(config) {
     'rem `service install`; edits are lost.',
     `set "PATH=${pathPrepend};%PATH%"`,
     'set "CHROXY_DAEMON=1"',
+    ...(configDirEnv ? [`set "CHROXY_CONFIG_DIR=${configDirEnv}"`] : []),
     `cd /d "${cwd}"`,
     rotateCapture(stdoutLog, pathWin32.join(logDir, 'chroxy-stdout.old.log')),
     rotateCapture(stderrLog, pathWin32.join(logDir, 'chroxy-stderr.old.log')),
@@ -478,6 +507,7 @@ export function buildServicePath({ nodePath, claudeBin }) {
  */
 export function generateServiceWrapper(config) {
   const { nodePath, chroxyBin, pathValue } = config
+  const configDirEnv = serviceConfigDirEnv(config)
 
   const sh = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
   const keychainBlock = ({ service, account, env }) => `
@@ -495,7 +525,8 @@ fi`
 set -e
 
 export PATH=${sh(pathValue)}
-export CHROXY_DAEMON=1
+export CHROXY_DAEMON=1${configDirEnv ? `
+export CHROXY_CONFIG_DIR=${sh(configDirEnv)}` : ''}
 ${keychainBlock(KEYCHAIN_API_TOKEN)}
 ${keychainBlock(KEYCHAIN_DISCORD_WEBHOOK)}
 

--- a/packages/server/src/service.js
+++ b/packages/server/src/service.js
@@ -508,7 +508,7 @@ exec ${sh(nodePath)} ${sh(chroxyBin)} start
  * @param {string} [configDir] - Override config directory (for testing)
  * @returns {object|null}
  */
-export function loadServiceState(configDir = defaultConfigDir) {
+export function loadServiceState(configDir = defaultConfigDir()) {
   const statePath = join(configDir, 'service.json')
   if (!existsSync(statePath)) {
     return null
@@ -525,7 +525,7 @@ export function loadServiceState(configDir = defaultConfigDir) {
  * @param {object} state
  * @param {string} [configDir] - Override config directory (for testing)
  */
-export function saveServiceState(state, configDir = defaultConfigDir) {
+export function saveServiceState(state, configDir = defaultConfigDir()) {
   if (!existsSync(configDir)) {
     mkdirSync(configDir, { recursive: true })
   }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -2,7 +2,6 @@ import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
 import { statSync, mkdirSync, rmSync } from 'fs'
 import { join, resolve, dirname } from 'path'
-import { homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { getProvider, getProviderAuthInfo, DEFAULT_PROVIDER } from './providers.js'
 import { isClaudeProvider } from './models.js'
@@ -38,6 +37,7 @@ import { auditShellDestroy } from './shell-audit.js'
 import { recordShell, forgetShell, reapOrphanShells } from './user-shell-registry.js'
 import { getErrorMessage } from './utils/error-message.js'
 import { toWireCount } from './utils/wire-counters.js'
+import { configPath } from './config-dir.js'
 import {
   forwardPerSessionSettingsToProviderOpts,
   serializePerSessionSettings,
@@ -45,7 +45,18 @@ import {
 } from './per-session-settings.js'
 
 const log = createLogger('session-manager')
-const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
+/**
+ * The state file a SessionManager falls back to when no `stateFilePath` is
+ * injected — i.e. what the running daemon uses (server-cli.js passes none).
+ *
+ * Exported so the schedule CLI's drift guard can assert that its registry and
+ * the daemon's resolve to the same place without constructing a SessionManager
+ * (tests/schedule-cli.test.js). A `const` here would be frozen at import; see
+ * config-dir.js for why that is the whole of #7052.
+ */
+export function defaultStateFile() {
+  return configPath('session-state.json')
+}
 // #5982 — grace before auto-removing an exited user-shell session, so a live
 // viewer sees the "[shell exited]" marker before the session vanishes.
 const AUTO_REMOVE_ON_EXIT_DELAY_MS = 1500
@@ -147,7 +158,9 @@ export class ProviderModelNotSupportedError extends SessionError {
  * Default base directory for session worktrees.
  * @type {string}
  */
-const DEFAULT_WORKTREE_BASE = join(homedir(), '.chroxy', 'worktrees')
+function defaultWorktreeBase() {
+  return configPath('worktrees')
+}
 
 /**
  * Manages the lifecycle of multiple CLI sessions.
@@ -615,7 +628,7 @@ export class SessionManager extends EventEmitter {
 
     // State persistence (delegated to SessionStatePersistence)
     this._persistence = new SessionStatePersistence({
-      stateFilePath: stateFilePath || DEFAULT_STATE_FILE,
+      stateFilePath: stateFilePath || defaultStateFile(),
       stateTtlMs,
       persistDebounceMs,
     })
@@ -660,7 +673,7 @@ export class SessionManager extends EventEmitter {
     this.binaryProvenanceLedger = binaryProvenanceLedger
       || new BinaryProvenanceLedger({ filePath: join(dirname(this._stateFilePath), 'binary-trust.json') })
     // Config path the preset resolver reads the daemon override map from.
-    // Defaults to undefined → resolveSessionPreset uses its own DEFAULT_CONFIG_PATH.
+    // Defaults to undefined → resolveSessionPreset uses its own defaultConfigPath().
     this.presetConfigPath = typeof presetConfigPath === 'string' ? presetConfigPath : null
     // #6771: durable per-project permission rule store. Same temp-redirect logic
     // as the sidecars above — the default file sits next to the session-state
@@ -1142,7 +1155,7 @@ export class SessionManager extends EventEmitter {
       // restored path that doesn't resolve to exactly that is rejected: we
       // safe-degrade to a non-worktree session (worktreePath stays null ⇒ no
       // deletion target) and log loudly, rather than rebind an unsafe path.
-      const expectedWorktreeDir = resolve(join(this._worktreeBase || DEFAULT_WORKTREE_BASE, sessionId))
+      const expectedWorktreeDir = resolve(join(this._worktreeBase || defaultWorktreeBase(), sessionId))
       if (resolve(restoreWorktreePath) === expectedWorktreeDir) {
         worktreePath = restoreWorktreePath
         worktreeRepoDir = restoreWorktreeRepoDir || null
@@ -1162,7 +1175,7 @@ export class SessionManager extends EventEmitter {
       }
 
       // Create worktree directory
-      const worktreeBase = this._worktreeBase || DEFAULT_WORKTREE_BASE
+      const worktreeBase = this._worktreeBase || defaultWorktreeBase()
       const worktreeDir = join(worktreeBase, sessionId)
       mkdirSync(worktreeBase, { recursive: true })
 
@@ -2760,7 +2773,7 @@ export class SessionManager extends EventEmitter {
         // retained sessions are ever swept.
         const liveSessionIds = new Set([...this._sessions.keys(), ...this._failedRestores.keys()])
         const report = sweepOrphanChroxyWorktrees({
-          worktreeBase: this._worktreeBase || DEFAULT_WORKTREE_BASE,
+          worktreeBase: this._worktreeBase || defaultWorktreeBase(),
           liveSessionIds,
         })
         if (report.removed.length || report.skippedDirty.length || report.skippedError.length) {

--- a/packages/server/src/session-preset-trust.js
+++ b/packages/server/src/session-preset-trust.js
@@ -38,11 +38,11 @@
 import { existsSync } from 'fs'
 import { createLogger } from './logger.js'
 import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
-import { DEFAULT_PRESET_TRUST_FILE, _normalizePathKey } from './session-preset.js'
+import { defaultPresetTrustFile, _normalizePathKey } from './session-preset.js'
 
 const log = createLogger('session-preset-trust')
 
-export { DEFAULT_PRESET_TRUST_FILE }
+export { defaultPresetTrustFile }
 
 /**
  * In-memory + on-disk trust ledger for repo-local session presets. One
@@ -55,7 +55,7 @@ export class SessionPresetTrustStore extends PathHashTrustLedger {
    */
   constructor({ filePath } = {}) {
     super({
-      filePath: filePath || DEFAULT_PRESET_TRUST_FILE,
+      filePath: filePath || defaultPresetTrustFile(),
       log,
       normalizeKey: _normalizePathKey,
       approvalField: 'approvedAt',

--- a/packages/server/src/session-preset.js
+++ b/packages/server/src/session-preset.js
@@ -326,7 +326,7 @@ export function readRepoPresetFile(absPath) {
  * @param {string} [configPath]
  * @returns {object|null}
  */
-export function _findRepoConfigEntry(repoPath, configPath = defaultConfigPath) {
+export function _findRepoConfigEntry(repoPath, configPath = defaultConfigPath()) {
   if (!repoPath || typeof repoPath !== 'string') return null
   let raw
   try {
@@ -356,7 +356,7 @@ function _resolveSafe(p) {
  * @param {string} [configPath]
  * @returns {null | ReturnType<typeof validatePreset>}
  */
-export function readDaemonOverride(repoPath, configPath = defaultConfigPath) {
+export function readDaemonOverride(repoPath, configPath = defaultConfigPath()) {
   const entry = _findRepoConfigEntry(repoPath, configPath)
   if (!entry || !entry.sessionPreset) return null
   return validatePreset(entry.sessionPreset)

--- a/packages/server/src/session-preset.js
+++ b/packages/server/src/session-preset.js
@@ -39,6 +39,7 @@ import { dirname, join, resolve, basename } from 'path'
 import { homedir } from 'os'
 import { createHash } from 'crypto'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('session-preset')
 
@@ -63,8 +64,12 @@ const MAX_PRESET_FILE_BYTES = 64 * 1024
 // Cap walk-up iterations — a safety belt; real repos are nowhere near this deep.
 const REPO_DISCOVERY_MAX_DEPTH = 100
 
-export const DEFAULT_CONFIG_PATH = join(homedir(), '.chroxy', 'config.json')
-export const DEFAULT_PRESET_TRUST_FILE = join(homedir(), '.chroxy', 'session-preset-trust.json')
+export function defaultConfigPath() {
+  return configPath('config.json')
+}
+export function defaultPresetTrustFile() {
+  return configPath('session-preset-trust.json')
+}
 
 const _PATH_COMPARE_CASE_INSENSITIVE =
   process.platform === 'darwin' || process.platform === 'win32'
@@ -321,7 +326,7 @@ export function readRepoPresetFile(absPath) {
  * @param {string} [configPath]
  * @returns {object|null}
  */
-export function _findRepoConfigEntry(repoPath, configPath = DEFAULT_CONFIG_PATH) {
+export function _findRepoConfigEntry(repoPath, configPath = defaultConfigPath) {
   if (!repoPath || typeof repoPath !== 'string') return null
   let raw
   try {
@@ -351,7 +356,7 @@ function _resolveSafe(p) {
  * @param {string} [configPath]
  * @returns {null | ReturnType<typeof validatePreset>}
  */
-export function readDaemonOverride(repoPath, configPath = DEFAULT_CONFIG_PATH) {
+export function readDaemonOverride(repoPath, configPath = defaultConfigPath) {
   const entry = _findRepoConfigEntry(repoPath, configPath)
   if (!entry || !entry.sessionPreset) return null
   return validatePreset(entry.sessionPreset)
@@ -393,7 +398,7 @@ export function readDaemonOverride(repoPath, configPath = DEFAULT_CONFIG_PATH) {
  */
 export function resolveSessionPreset(cwd, opts = {}) {
   const trustStore = opts.trustStore || null
-  const configPath = opts.configPath || DEFAULT_CONFIG_PATH
+  const configPath = opts.configPath || defaultConfigPath()
 
   // 1. Locate the repo root (the dir holding `.chroxy/session.json`) via the
   //    walk-up. We need it for BOTH the repo-file read and the daemon override

--- a/packages/server/src/shell-approval-info.js
+++ b/packages/server/src/shell-approval-info.js
@@ -1,7 +1,7 @@
-import { homedir } from 'os'
 import { join } from 'path'
 import { existsSync, readFileSync, unlinkSync, mkdirSync } from 'fs'
 import { writeFileRestricted } from './platform.js'
+import { configDir } from './config-dir.js'
 
 // #6277 — discovery for the host-local user-shell approval listener.
 //
@@ -17,7 +17,7 @@ import { writeFileRestricted } from './platform.js'
 // connection.json for the primary token.
 
 function getConfigDir() {
-  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return configDir()
 }
 
 export function getShellApprovalInfoPath() {

--- a/packages/server/src/skills-loader.js
+++ b/packages/server/src/skills-loader.js
@@ -67,10 +67,13 @@ import { dirname, join, relative, resolve, sep } from 'path'
 import { homedir } from 'os'
 import { createLogger } from './logger.js'
 import { getErrorMessage } from './utils/error-message.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('skills-loader')
 
-export const DEFAULT_SKILLS_DIR = join(homedir(), '.chroxy', 'skills')
+export function defaultSkillsDir() {
+  return configPath('skills')
+}
 
 // Cap walk-up iterations as a safety belt; real repos are nowhere near this deep.
 const REPO_DISCOVERY_MAX_DEPTH = 100
@@ -1448,7 +1451,7 @@ export function findRepoSkillsDir(cwd) {
       if (statSync(candidate).isDirectory()) {
         // Defensive: the user's global skills dir is never a repo overlay.
         // Even if we somehow walk up to it, refuse to claim it as repo-scoped.
-        if (_sameAbsolutePath(candidate, DEFAULT_SKILLS_DIR)) return null
+        if (_sameAbsolutePath(candidate, defaultSkillsDir())) return null
         return candidate
       }
     } catch {
@@ -1772,7 +1775,7 @@ export const SKILLS_PROMPT_HEADER = [
  *
  * @param {object} args
  * @param {string} args.skillName - The skill's display name (no extension).
- * @param {string} [args.globalDir] - Defaults to DEFAULT_SKILLS_DIR.
+ * @param {string} [args.globalDir] - Defaults to defaultSkillsDir().
  * @param {string|null} [args.repoDir] - Optional repo overlay dir.
  * @param {string[]} [args.allowedExtensions] - Defaults to DEFAULT_ALLOWED_EXTENSIONS.
  * @returns {{ realPath: string, body: string } | null}
@@ -1793,7 +1796,7 @@ export function findSkillForRetrust({
   if (repoDir) dirs.push({ dir: repoDir, source: 'repo' })
   if (globalDir) dirs.push({ dir: globalDir, source: 'global' })
   if (dirs.length === 0) {
-    dirs.push({ dir: DEFAULT_SKILLS_DIR, source: 'global' })
+    dirs.push({ dir: defaultSkillsDir(), source: 'global' })
   }
 
   for (const { dir } of dirs) {

--- a/packages/server/src/skills-manager.js
+++ b/packages/server/src/skills-manager.js
@@ -24,7 +24,7 @@ import {
   formatSkillsForPrompt,
   groupSkillsByInjectionMode,
   findRepoSkillsDir,
-  DEFAULT_SKILLS_DIR,
+  defaultSkillsDir,
 } from './skills-loader.js'
 import { SkillsTrustStore } from './skills-trust.js'
 
@@ -90,7 +90,7 @@ export class SkillsManager {
 
     // Cache the immutable load-time inputs so the runtime toggle path (#3209)
     // can rebuild layerOpts without re-parsing constructor args.
-    this._skillsDir = skillsDir || DEFAULT_SKILLS_DIR
+    this._skillsDir = skillsDir || defaultSkillsDir()
     this._repoSkillsDir = repoSkillsDir !== undefined
       ? repoSkillsDir
       : findRepoSkillsDir(cwd)

--- a/packages/server/src/skills-trust.js
+++ b/packages/server/src/skills-trust.js
@@ -100,16 +100,17 @@
  */
 import { existsSync } from 'fs'
 import { basename } from 'path'
-import { homedir } from 'os'
-import { join } from 'path'
 import { createHash } from 'crypto'
 import { createLogger } from './logger.js'
 import { PathHashTrustLedger } from './path-hash-trust-ledger.js'
 import { HEX64 } from './utils/validation-patterns.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('skills-trust')
 
-export const DEFAULT_TRUST_FILE = join(homedir(), '.chroxy', 'skills-trust.json')
+export function defaultTrustFile() {
+  return configPath('skills-trust.json')
+}
 
 export const TRUST_MODE_WARN = 'warn'
 export const TRUST_MODE_BLOCK = 'block'
@@ -201,7 +202,7 @@ export class SkillsTrustStore extends PathHashTrustLedger {
    */
   constructor({ filePath, mode, verifyThrottleMs } = {}) {
     super({
-      filePath: filePath || DEFAULT_TRUST_FILE,
+      filePath: filePath || defaultTrustFile(),
       log,
       normalizeKey: _normalizePathKey,
       approvalField: 'lastVerified',

--- a/packages/server/src/skills-usage.js
+++ b/packages/server/src/skills-usage.js
@@ -41,18 +41,17 @@
  * aggregates (count / lastUsed / repos); the raw entries never cross the wire.
  */
 
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { createLogger } from './logger.js'
 import { loadJsonState, saveJsonState } from './json-state-file.js'
 import { getErrorMessage } from './utils/error-message.js'
 import { MAX_WIRE_DATETIME_MS } from './utils/iso-datetime.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('skills-usage')
 
 /** Default on-disk location for the usage log. */
 export function defaultSkillsUsagePath() {
-  return join(homedir(), '.chroxy', 'skills-usage.json')
+  return configPath('skills-usage.json')
 }
 
 /** Ring-buffer cap on the raw entries kept on disk. */

--- a/packages/server/src/snapshots-store.js
+++ b/packages/server/src/snapshots-store.js
@@ -47,8 +47,8 @@
 
 import { readdirSync, readFileSync, existsSync, unlinkSync } from 'fs'
 import { join } from 'path'
-import { homedir } from 'os'
 import { createLogger } from './logger.js'
+import { configPath } from './config-dir.js'
 
 const log = createLogger('snapshots')
 
@@ -62,8 +62,7 @@ const log = createLogger('snapshots')
  * @returns {string}
  */
 export function getSnapshotsDir() {
-  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
-  return join(configDir, 'snapshots')
+  return configPath('snapshots')
 }
 
 /**

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -5,7 +5,6 @@ import { dirname, resolve, join } from 'path'
 import { createInterface } from 'readline'
 import { fileURLToPath } from 'url'
 import { writeFileSync, readFileSync, unlinkSync, existsSync, mkdirSync } from 'fs'
-import { homedir } from 'os'
 import { EventEmitter } from 'events'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
@@ -13,6 +12,7 @@ import { createLogger } from './logger.js'
 import QRCode from 'qrcode'
 import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
 import { PushManager } from './push.js'
+import { configPath } from './config-dir.js'
 
 function maskToken(token) {
   if (!token) return ''
@@ -34,7 +34,9 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'))
 const SUPERVISOR_VERSION = packageJson.version
-const DEFAULT_PID_FILE = join(homedir(), '.chroxy', 'supervisor.pid')
+function defaultPidFile() {
+  return configPath('supervisor.pid')
+}
 
 const DRAIN_TIMEOUT = 30000
 const RESTART_BACKOFFS = [2000, 2000, 3000, 3000, 5000, 5000, 8000, 8000, 10000, 10000]
@@ -62,8 +64,8 @@ export class Supervisor extends EventEmitter {
     this._port = config.port || parseInt(process.env.PORT || '8765', 10)
     this._apiToken = config.apiToken || process.env.API_TOKEN
     this._tunnelMode = config.tunnel || 'quick'
-    this._pidFilePath = config.pidFilePath || DEFAULT_PID_FILE
-    this._knownGoodFile = config.knownGoodFile || join(homedir(), '.chroxy', 'known-good-ref')
+    this._pidFilePath = config.pidFilePath || defaultPidFile()
+    this._knownGoodFile = config.knownGoodFile || configPath('known-good-ref')
     this._maxRestarts = (typeof config.maxRestarts === 'number' && config.maxRestarts >= 0)
       ? config.maxRestarts
       : 10
@@ -118,7 +120,7 @@ export class Supervisor extends EventEmitter {
       lastBackoffMs: 0,
     }
 
-    this._pushStoragePath = config.pushStoragePath || join(homedir(), '.chroxy', 'push-tokens.json')
+    this._pushStoragePath = config.pushStoragePath || configPath('push-tokens.json')
   }
 
   /** Override point: fork a child process */
@@ -205,9 +207,9 @@ export class Supervisor extends EventEmitter {
     // picks up prefs the child persisted after startup, same as the tokens.
     const push = new PushManager({
       storagePath: this._pushStoragePath,
-      prefsPath: join(homedir(), '.chroxy', 'notification-prefs.json'),
+      prefsPath: configPath('notification-prefs.json'),
       discord: {
-        statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
+        statePath: configPath('discord-webhook-state.json'),
         ...(this.config.notifications?.discord || {}),
       },
     })

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -830,9 +830,13 @@ export class Supervisor extends EventEmitter {
    *
    * Two layers of defense now close this:
    *
-   * 1. `~/.chroxy` is in FORBIDDEN_HOME_SUBDIRS, so sessions can no
-   *    longer create a cwd inside it — the attacker can't reach
-   *    `known-good-ref` via `write_file`.
+   * 1. `validateCwdAllowed` refuses a session cwd inside the config/state
+   *    root, so the attacker can't reach `known-good-ref` via `write_file`.
+   *    Two checks back that: `~/.chroxy` is in FORBIDDEN_HOME_SUBDIRS by
+   *    name, AND the resolved `configDir()` is denied outright. The second
+   *    is what keeps this true once CHROXY_CONFIG_DIR relocates the root
+   *    (#7052) — the name-based set alone would then be guarding an empty
+   *    directory while the real one sat open.
    *
    * 2. This function validates that the ref resolves to the SAME
    *    commit as an existing `known-good-*` git tag. The tag is

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -5,7 +5,6 @@ import { WebSocketServer } from 'ws'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
-import { homedir } from 'os'
 import { PagesStore } from './pages-store.js'
 import { ShellApprovalStore } from './shell-approval-store.js'
 import { finalizeShellCreate } from './handlers/session-handlers.js'
@@ -42,6 +41,7 @@ import { isLoopbackHost } from './bind-host.js'
 import { getLanIp } from './lan-ip.js'
 import { deriveWebhookPayloadUrl } from './github-webhook.js'
 import { isLocalOrLanPeer } from './connection-locality.js'
+import { configPath } from './config-dir.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -643,7 +643,7 @@ export class WsServer {
       ? pagesRateLimiter
       : new RateLimiter({ name: 'pages', windowMs: 60_000, maxMessages: 120, burst: 30 })
     this.pagesStore = pagesStore || new PagesStore({
-      pagesDir: join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'pages'),
+      pagesDir: configPath('pages'),
     })
     // #6277: host-local user-shell approval store. The create gate holds a spawn
     // here when userShell.requireApproval is on; the host operator approves it

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -23,9 +23,19 @@
  * validation helpers (`validateCwdAllowed`, `listFiles` home-fallback,
  * environment manager workspaceRoots) that compare against the live
  * `os.homedir()`. Rerouting HOME up-front breaks those tests in a way
- * that's unrelated to the bug class we're fixing. A bare
- * `new SessionManager()` is still caught — its first `writeFileSync` for
- * the default `~/.chroxy/session-state.json` trips the guard.
+ * that's unrelated to the bug class we're fixing.
+ *
+ * NOTE (#7052): this block used to add "a bare `new SessionManager()` is still
+ * caught — its first `writeFileSync` for the default
+ * `~/.chroxy/session-state.json` trips the guard". That is no longer true, and
+ * saying so would be a false-safety claim. `defaultStateFile()` is now
+ * `configPath('session-state.json')`, which follows the CHROXY_CONFIG_DIR
+ * redirect installed below, so the write lands in this process's tmp dir and
+ * the guard never fires. The same applies to binary-trust.json, checkpoints and
+ * the permission rules. The OUTCOME is still safe — those writes go to a temp
+ * directory, not the developer's home — but this guard no longer NAMES the
+ * offending test. `scripts/lint-tests-state-file-path.sh` is now the check that
+ * catches a missing `stateFilePath`, and it reports the call site.
  *
  * Tests that need to mutate `process.env.HOME` for their own purposes
  * (e.g. `claude-tui-session.test.js`, `byok-credentials.test.js`) are fine

--- a/packages/server/tests/anthropic-compatible.test.js
+++ b/packages/server/tests/anthropic-compatible.test.js
@@ -20,6 +20,10 @@ import { OllamaSession } from '../src/ollama-session.js'
 import { validateConfig } from '../src/config.js'
 import { resetCachesForTest } from '../src/auth-probes.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Tests for config-driven Anthropic-compatible provider endpoints
  * (#5419) — `providers.anthropicCompatible` in config.json.
@@ -538,6 +542,7 @@ describe('credential resolution', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-compat-cred-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     delete process.env[ENV_VAR]
     resetCachesForTest()
   })
@@ -545,6 +550,7 @@ describe('credential resolution', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     delete process.env[ENV_VAR]
     rmSync(tmpHome, { recursive: true, force: true })
     resetCachesForTest()
@@ -628,6 +634,7 @@ describe('credential file read caching (#5461)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-compat-cache-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     delete process.env[ENV_VAR]
     resetCachesForTest()
   })
@@ -635,6 +642,7 @@ describe('credential file read caching (#5461)', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     delete process.env[ENV_VAR]
     rmSync(tmpHome, { recursive: true, force: true })
     resetCachesForTest()

--- a/packages/server/tests/auth-probes.test.js
+++ b/packages/server/tests/auth-probes.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
 import {
   hasClaudeOAuthCreds,
   hasCodexOAuthCreds,
@@ -284,6 +288,7 @@ describe('auth-probes module (#4769)', () => {
         const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-byok-noent-'))
         const savedHome = process.env.HOME
         process.env.HOME = tmp
+        process.env.CHROXY_CONFIG_DIR = join(tmp, '.chroxy')
         try {
           let called = 0
           const r = cachedResolveCredentialFile('byok', undefined, () => {
@@ -298,6 +303,7 @@ describe('auth-probes module (#4769)', () => {
         } finally {
           if (savedHome === undefined) delete process.env.HOME
           else process.env.HOME = savedHome
+          process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
           rmSync(tmp, { recursive: true, force: true })
         }
       })
@@ -337,6 +343,7 @@ describe('auth-probes module (#4769)', () => {
         const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-dyn-noent-'))
         const savedHome = process.env.HOME
         process.env.HOME = tmp
+        process.env.CHROXY_CONFIG_DIR = join(tmp, '.chroxy')
         try {
           let called = 0
           const r = cachedResolveCredentialFile('compat:ZAI_API_KEY:zaiApiKey', undefined, () => {
@@ -350,6 +357,7 @@ describe('auth-probes module (#4769)', () => {
         } finally {
           if (savedHome === undefined) delete process.env.HOME
           else process.env.HOME = savedHome
+          process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
           rmSync(tmp, { recursive: true, force: true })
         }
       })
@@ -361,6 +369,7 @@ describe('auth-probes module (#4769)', () => {
         const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-dyn-noent-'))
         const savedHome = process.env.HOME
         process.env.HOME = tmp
+        process.env.CHROXY_CONFIG_DIR = join(tmp, '.chroxy')
         try {
           const r = cachedResolveCredentialFile('compat::zaiApiKey', undefined, () => ({ key: null }), null)
           assert.equal(r.key, null)
@@ -370,6 +379,7 @@ describe('auth-probes module (#4769)', () => {
         } finally {
           if (savedHome === undefined) delete process.env.HOME
           else process.env.HOME = savedHome
+          process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
           rmSync(tmp, { recursive: true, force: true })
         }
       })
@@ -381,6 +391,7 @@ describe('auth-probes module (#4769)', () => {
         const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-ds-noent-'))
         const savedHome = process.env.HOME
         process.env.HOME = tmp
+        process.env.CHROXY_CONFIG_DIR = join(tmp, '.chroxy')
         try {
           const r = cachedResolveCredentialFile('deepseek', undefined, () => ({ key: null }))
           assert.equal(r.source, 'none')
@@ -388,6 +399,7 @@ describe('auth-probes module (#4769)', () => {
         } finally {
           if (savedHome === undefined) delete process.env.HOME
           else process.env.HOME = savedHome
+          process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
           rmSync(tmp, { recursive: true, force: true })
         }
       })

--- a/packages/server/tests/binary-provenance-trust.test.js
+++ b/packages/server/tests/binary-provenance-trust.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from 'fs'
-import { tmpdir } from 'os'
+import { tmpdir, homedir } from 'os'
 import { join } from 'path'
 import { createHash } from 'crypto'
 import {
@@ -46,7 +46,10 @@ describe('BinaryProvenanceLedger (#6858)', () => {
     const prev = process.env.CHROXY_CONFIG_DIR
     try {
       delete process.env.CHROXY_CONFIG_DIR
-      assert.match(defaultBinaryTrustFile(), /\.chroxy[/\\]binary-trust\.json$/)
+      // Pinned to the actual home root, not just "some directory named
+      // .chroxy" — a regex alone still matches `/tmp/anything/.chroxy/...`, so
+      // it could not tell a real home fallback from a lost one.
+      assert.equal(defaultBinaryTrustFile(), join(homedir(), '.chroxy', 'binary-trust.json'))
     } finally {
       process.env.CHROXY_CONFIG_DIR = prev
     }

--- a/packages/server/tests/binary-provenance-trust.test.js
+++ b/packages/server/tests/binary-provenance-trust.test.js
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { createHash } from 'crypto'
 import {
   BinaryProvenanceLedger,
-  DEFAULT_BINARY_TRUST_FILE,
+  defaultBinaryTrustFile,
   binaryTrustFileExists,
 } from '../src/binary-provenance-trust.js'
 
@@ -35,7 +35,7 @@ describe('BinaryProvenanceLedger (#6858)', () => {
   })
 
   it('defaults its file to ~/.chroxy/binary-trust.json', () => {
-    assert.match(DEFAULT_BINARY_TRUST_FILE, /\.chroxy[/\\]binary-trust\.json$/)
+    assert.match(defaultBinaryTrustFile(), /\.chroxy[/\\]binary-trust\.json$/)
   })
 
   it('pins on approve and reports the record as trusted', () => {

--- a/packages/server/tests/binary-provenance-trust.test.js
+++ b/packages/server/tests/binary-provenance-trust.test.js
@@ -34,8 +34,22 @@ describe('BinaryProvenanceLedger (#6858)', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('defaults its file to ~/.chroxy/binary-trust.json', () => {
-    assert.match(defaultBinaryTrustFile(), /\.chroxy[/\\]binary-trust\.json$/)
+  it('defaults its file to <config dir>/binary-trust.json', () => {
+    // #7052 — CHROXY_CONFIG_DIR-rooted, so this is only `.chroxy/...` when the
+    // override is unset (tests/_setup.mjs sets it suite-wide).
+    assert.equal(defaultBinaryTrustFile(), join(process.env.CHROXY_CONFIG_DIR, 'binary-trust.json'))
+  })
+
+  it('falls back to ~/.chroxy/binary-trust.json when CHROXY_CONFIG_DIR is unset', () => {
+    // Positive control: without this, the assertion above would also pass for a
+    // resolver that had stopped consulting the home fallback entirely.
+    const prev = process.env.CHROXY_CONFIG_DIR
+    try {
+      delete process.env.CHROXY_CONFIG_DIR
+      assert.match(defaultBinaryTrustFile(), /\.chroxy[/\\]binary-trust\.json$/)
+    } finally {
+      process.env.CHROXY_CONFIG_DIR = prev
+    }
   })
 
   it('pins on approve and reports the record as trusted', () => {

--- a/packages/server/tests/byok-credentials.test.js
+++ b/packages/server/tests/byok-credentials.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
 import {
   resolveAnthropicApiKey,
   maskApiKey,
@@ -37,6 +41,7 @@ describe('byok-credentials', () => {
     originalHome = process.env.HOME
     originalApiKey = process.env.ANTHROPIC_API_KEY
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     delete process.env.ANTHROPIC_API_KEY
   })
 
@@ -44,6 +49,7 @@ describe('byok-credentials', () => {
     _setCredentialKeychainForTests(null)
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
     else delete process.env.ANTHROPIC_API_KEY
     rmSync(tmpHome, { recursive: true, force: true })

--- a/packages/server/tests/byok-mcp-prompts-resources.test.js
+++ b/packages/server/tests/byok-mcp-prompts-resources.test.js
@@ -16,6 +16,10 @@ import { createBrowserOps } from '../src/ws-file-ops/browser.js'
 import { ClaudeByokSession } from '../src/byok-session.js'
 import { recordTrust } from '../src/byok-mcp-trust.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const STUB = join(__dirname, 'fixtures', 'mcp-stub.mjs')
 
@@ -411,6 +415,7 @@ describe('ClaudeByokSession MCP prompts/resources (#6823)', () => {
     originalApiKey = process.env.ANTHROPIC_API_KEY
     originalMcpTrustPath = process.env.CHROXY_MCP_TRUST_PATH
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
     process.env.CHROXY_MCP_TRUST_PATH = join(tmpHome, 'mcp-trust.json')
   })

--- a/packages/server/tests/byok-mcp-prompts-resources.test.js
+++ b/packages/server/tests/byok-mcp-prompts-resources.test.js
@@ -425,6 +425,7 @@ describe('ClaudeByokSession MCP prompts/resources (#6823)', () => {
     else delete process.env.ANTHROPIC_API_KEY
     if (originalMcpTrustPath) process.env.CHROXY_MCP_TRUST_PATH = originalMcpTrustPath
     else delete process.env.CHROXY_MCP_TRUST_PATH
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     rmSync(tmpHome, { recursive: true, force: true })
   })
 

--- a/packages/server/tests/byok-session-thinking.test.js
+++ b/packages/server/tests/byok-session-thinking.test.js
@@ -5,6 +5,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ClaudeByokSession } from '../src/byok-session.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #6756 — ClaudeByokSession forwards the already-translated `thinking_delta`
  * instead of dropping it at `default: break`.
@@ -66,12 +70,14 @@ describe('ClaudeByokSession — thinking content forwarding (#6756)', () => {
     originalHome = process.env.HOME
     originalApiKey = process.env.ANTHROPIC_API_KEY
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
   })
 
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
     else delete process.env.ANTHROPIC_API_KEY
     rmSync(tmpHome, { recursive: true, force: true })

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -10,6 +10,10 @@ import { BUILTIN_TOOLS } from '../src/byok-tools.js'
 import { MCP_STATES } from '../src/byok-mcp-client.js'
 import { recordTrust } from '../src/byok-mcp-trust.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Pre-trust the stub MCP server so the fleet's trust gate doesn't sit waiting on
  * a prompt nobody answers.
@@ -138,6 +142,7 @@ describe('ClaudeByokSession', () => {
     originalApiKey = process.env.ANTHROPIC_API_KEY
     originalMcpTrustPath = process.env.CHROXY_MCP_TRUST_PATH
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
     // #4457: per-test isolated trust store so spawning the MCP stub
     // doesn't pollute the developer's real ~/.chroxy/mcp-trust.json,
@@ -148,6 +153,7 @@ describe('ClaudeByokSession', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
     else delete process.env.ANTHROPIC_API_KEY
     if (originalMcpTrustPath) process.env.CHROXY_MCP_TRUST_PATH = originalMcpTrustPath

--- a/packages/server/tests/claude-tui-ensure-cwd-trusted-write.test.js
+++ b/packages/server/tests/claude-tui-ensure-cwd-trusted-write.test.js
@@ -53,6 +53,10 @@ import { join } from 'node:path'
 import '../src/claude-tui-session.js'
 import { ensureCwdTrusted } from '../src/claude-tui/pty-driver.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 let dir
 let fakeHome
 let dotfilesDir
@@ -77,11 +81,13 @@ beforeEach(() => {
   targetPath = join(dotfilesDir, 'claude.json')
   origHome = process.env.HOME
   process.env.HOME = fakeHome
+  process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
 })
 
 afterEach(() => {
   if (origHome === undefined) delete process.env.HOME
   else process.env.HOME = origHome
+  process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
   try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ }
 })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -87,6 +87,7 @@ describe('ClaudeTuiSession', () => {
       if (session) { try { await session.destroy() } catch { /* ignore */ } session = null }
       ClaudeTuiSession.prototype._spawnPty = origSpawnPty
       if (process.env._ORIG_HOME) { process.env.HOME = process.env._ORIG_HOME; delete process.env._ORIG_HOME }
+      process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
     })
 
@@ -253,7 +254,7 @@ describe('ClaudeTuiSession', () => {
       ClaudeTuiSession.prototype._spawnPty = origSpawnPty
       if (process.env._ORIG_HOME) {
         process.env.HOME = process.env._ORIG_HOME
-        process.env.CHROXY_CONFIG_DIR = join(process.env._ORIG_HOME, '.chroxy')
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         delete process.env._ORIG_HOME
       }
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
@@ -6752,7 +6753,7 @@ describe('ClaudeTuiSession', () => {
       ClaudeTuiSession.prototype._spawnPty = origSpawnPty
       if (process.env._ORIG_HOME) {
         process.env.HOME = process.env._ORIG_HOME
-        process.env.CHROXY_CONFIG_DIR = join(process.env._ORIG_HOME, '.chroxy')
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         delete process.env._ORIG_HOME
       }
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
@@ -7040,6 +7041,7 @@ describe('ClaudeTuiSession — atomic permission-mode sidecar write (#5334)', ()
     if (session) { try { await session.destroy() } catch { /* ignore */ } session = null }
     ClaudeTuiSession.prototype._spawnPty = origSpawnPty
     if (process.env._ORIG_HOME) { process.env.HOME = process.env._ORIG_HOME; delete process.env._ORIG_HOME }
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     rmSync(dir, { recursive: true, force: true })
     rmSync(skillsDir, { recursive: true, force: true })
     rmSync(fakeHome, { recursive: true, force: true })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -7,6 +7,10 @@ import { ClaudeTuiSession, withHookFsTimeout } from '../src/claude-tui-session.j
 import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
 import { addLogListener, removeLogListener } from '../src/logger.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 describe('ClaudeTuiSession', () => {
   let emptySkillsDir
   let session
@@ -67,6 +71,7 @@ describe('ClaudeTuiSession', () => {
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
       process.env._ORIG_HOME = process.env.HOME
       process.env.HOME = fakeHome
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
       capturedArgs = null
       origSpawnPty = ClaudeTuiSession.prototype._spawnPty
       ClaudeTuiSession.prototype._spawnPty = async function () {
@@ -229,6 +234,7 @@ describe('ClaudeTuiSession', () => {
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
       process.env._ORIG_HOME = process.env.HOME
       process.env.HOME = fakeHome
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
 
       // Stub _spawnPty on the prototype so start() doesn't actually fork claude.
       // Sets a fake term so subsequent state assertions don't trip on null.
@@ -247,6 +253,7 @@ describe('ClaudeTuiSession', () => {
       ClaudeTuiSession.prototype._spawnPty = origSpawnPty
       if (process.env._ORIG_HOME) {
         process.env.HOME = process.env._ORIG_HOME
+        process.env.CHROXY_CONFIG_DIR = join(process.env._ORIG_HOME, '.chroxy')
         delete process.env._ORIG_HOME
       }
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
@@ -1286,6 +1293,7 @@ describe('ClaudeTuiSession', () => {
       const fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-tui-6576a-'))
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
       process.env.HOME = fakeHome
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
       try {
         session = new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir: emptySkillsDir, repoSkillsDir: null, resumeSessionId: 'ghost-uuid-0001' })
         session._spawnPty = async function () {
@@ -1322,6 +1330,7 @@ describe('ClaudeTuiSession', () => {
         assert.equal(session._processReady, true, 'session ready after inline recovery')
       } finally {
         if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         try { rmSync(fakeHome, { recursive: true, force: true }) } catch { /* best effort */ }
       }
     })
@@ -1658,6 +1667,7 @@ describe('ClaudeTuiSession', () => {
       mkdirSync(join(fakeHome, '.claude', 'sessions'), { recursive: true })
       origHome = process.env.HOME
       process.env.HOME = fakeHome
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
       // node-pty assigns pids as kernel pids; for tests any positive
       // integer suffices, the probe only uses it to build the file path.
       fakePid = 9999
@@ -1666,6 +1676,7 @@ describe('ClaudeTuiSession', () => {
     afterEach(() => {
       if (origHome !== undefined) process.env.HOME = origHome
       else delete process.env.HOME
+      process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
     })
 
@@ -2352,12 +2363,14 @@ describe('ClaudeTuiSession', () => {
       mkdirSync(join(fakeHome, '.claude', 'sessions'), { recursive: true })
       origHome = process.env.HOME
       process.env.HOME = fakeHome
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
       fakePid = 8765
     })
 
     afterEach(() => {
       if (origHome !== undefined) process.env.HOME = origHome
       else delete process.env.HOME
+      process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
     })
 
@@ -3459,6 +3472,7 @@ describe('ClaudeTuiSession', () => {
       writeFileSync(join(home, '.claude.json'), JSON.stringify({ projects: {} }))
       const origHome = process.env.HOME
       process.env.HOME = home
+      process.env.CHROXY_CONFIG_DIR = join(home, '.chroxy')
       const origSpawn = ClaudeTuiSession.prototype._spawnPty
       ClaudeTuiSession.prototype._spawnPty = async function () {
         this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
@@ -3478,6 +3492,7 @@ describe('ClaudeTuiSession', () => {
       } finally {
         ClaudeTuiSession.prototype._spawnPty = origSpawn
         process.env.HOME = origHome
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         rmSync(home, { recursive: true, force: true })
       }
     })
@@ -3487,6 +3502,7 @@ describe('ClaudeTuiSession', () => {
       writeFileSync(join(home, '.claude.json'), JSON.stringify({ projects: {} }))
       const origHome = process.env.HOME
       process.env.HOME = home
+      process.env.CHROXY_CONFIG_DIR = join(home, '.chroxy')
       const origSpawn = ClaudeTuiSession.prototype._spawnPty
       ClaudeTuiSession.prototype._spawnPty = async function () {
         this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
@@ -3500,6 +3516,7 @@ describe('ClaudeTuiSession', () => {
       } finally {
         ClaudeTuiSession.prototype._spawnPty = origSpawn
         process.env.HOME = origHome
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         rmSync(home, { recursive: true, force: true })
       }
     })
@@ -3552,6 +3569,7 @@ describe('ClaudeTuiSession', () => {
       writeFileSync(join(home, '.claude.json'), JSON.stringify({ projects: {} }))
       const origHome = process.env.HOME
       process.env.HOME = home
+      process.env.CHROXY_CONFIG_DIR = join(home, '.chroxy')
       const origSpawn = ClaudeTuiSession.prototype._spawnPty
       let capturedEnv = null
       ClaudeTuiSession.prototype._spawnPty = async function (permissionsEnabled) {
@@ -3584,6 +3602,7 @@ describe('ClaudeTuiSession', () => {
       } finally {
         ClaudeTuiSession.prototype._spawnPty = origSpawn
         process.env.HOME = origHome
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         rmSync(home, { recursive: true, force: true })
       }
     })
@@ -6701,6 +6720,7 @@ describe('ClaudeTuiSession', () => {
       writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
       process.env._ORIG_HOME = process.env.HOME
       process.env.HOME = fakeHome
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
 
       capturedPermissionsEnabled = null
       capturedArgs = null
@@ -6732,6 +6752,7 @@ describe('ClaudeTuiSession', () => {
       ClaudeTuiSession.prototype._spawnPty = origSpawnPty
       if (process.env._ORIG_HOME) {
         process.env.HOME = process.env._ORIG_HOME
+        process.env.CHROXY_CONFIG_DIR = join(process.env._ORIG_HOME, '.chroxy')
         delete process.env._ORIG_HOME
       }
       if (fakeHome) rmSync(fakeHome, { recursive: true, force: true })
@@ -7008,6 +7029,7 @@ describe('ClaudeTuiSession — atomic permission-mode sidecar write (#5334)', ()
     writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
     process.env._ORIG_HOME = process.env.HOME
     process.env.HOME = fakeHome
+    process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
     // Stub the PTY spawn so start() doesn't launch real node-pty/claude.
     origSpawnPty = ClaudeTuiSession.prototype._spawnPty
     ClaudeTuiSession.prototype._spawnPty = async function () {

--- a/packages/server/tests/cli/__helpers/spawn-cli.js
+++ b/packages/server/tests/cli/__helpers/spawn-cli.js
@@ -85,6 +85,16 @@ export function runCli(args, opts = {}) {
     ...(opts.env || {}),
   }
 
+  // A caller can UNSET a sandboxed var by passing null, which the spread alone
+  // cannot express. Needed to exercise a home fallback: the sandbox sets
+  // CHROXY_CONFIG_DIR unconditionally, so a test asserting "falls back to
+  // $HOME/.chroxy when the var is unset" would otherwise never run the fallback
+  // branch and would pass against a resolver that had dropped it entirely.
+  // HOME is still isolated, so this stays hermetic.
+  for (const [k, v] of Object.entries(env)) {
+    if (v === null || v === undefined) delete env[k]
+  }
+
   return new Promise((resolvePromise) => {
     const child = spawn(process.execPath, [CLI_PATH, ...args], {
       env,

--- a/packages/server/tests/cli/config-cmd.test.js
+++ b/packages/server/tests/cli/config-cmd.test.js
@@ -5,8 +5,10 @@
  * config` just prints the resolved config — so we exercise both the
  * "no config" error path and the happy "config exists" path.
  *
- * NB: The shared.js CONFIG_FILE is resolved from os.homedir() at module
- * load time, so we exercise the path via the spawn helper which sets HOME.
+ * NB: shared.js's configFile() resolves per call since #7052, so an in-process
+ * env change would now be honored. These cases still go through the spawn
+ * helper because they assert the CLI's stdout and exit code, not the path — and
+ * a child process is the only way to observe those.
  */
 import { describe, it, after, before } from 'node:test'
 import assert from 'node:assert/strict'

--- a/packages/server/tests/cli/schedule-cmd.test.js
+++ b/packages/server/tests/cli/schedule-cmd.test.js
@@ -149,17 +149,19 @@ describe('chroxy schedule — CLI wiring (#6868)', () => {
     })
   })
 
-  // #7015 — `chroxy schedule` must read/write the registry the RUNNING daemon
-  // reads. That path is home-rooted at every hop: server-cli.js constructs its
-  // SessionManager with no stateFilePath, so the manager falls back to
-  // ~/.chroxy/session-state.json and derives ~/.chroxy/scheduled-tasks.json
-  // from it. Neither hop consults CHROXY_CONFIG_DIR, even though other
-  // subsystems (models.js, doctor.js, connection-info.js) do. If this CLI
-  // followed the env var instead, `create` would report "Created scheduled
-  // task" into a file the scheduler never opens and `list` would come back
-  // empty — a task that silently never fires. Point CHROXY_CONFIG_DIR at a
-  // DIFFERENT directory and prove the registry stays where the daemon looks.
-  it('keeps the registry under $HOME/.chroxy when CHROXY_CONFIG_DIR points elsewhere', async () => {
+  // #7015 / #7052 — `chroxy schedule` must read/write the registry the RUNNING
+  // daemon reads. The invariant is that the CLI and the daemon agree; if they
+  // ever diverge, `create` reports "Created scheduled task" into a file the
+  // scheduler never opens and `list` comes back empty — a task that silently
+  // never fires.
+  //
+  // Until #7052 they agreed on a home-rooted path, because neither hop consulted
+  // CHROXY_CONFIG_DIR, and this test pinned that by proving the registry stayed
+  // under $HOME even when the env var pointed elsewhere. #7052 moved the
+  // WRITERS: SessionManager's default state file is now configPath(...), so both
+  // hops follow the env var and the agreement holds at the relocated root
+  // instead. Same invariant, other side of the migration.
+  it('puts the registry under CHROXY_CONFIG_DIR, and create/list agree there', async () => {
     const { home, cleanup } = makeTempHome()
     const elsewhere = mkdtempSync(join(tmpdir(), 'chroxy-cfgdir-'))
     try {
@@ -170,12 +172,12 @@ describe('chroxy schedule — CLI wiring (#6868)', () => {
       assert.equal(created.code, 0, `stderr: ${created.stderr}`)
 
       assert.ok(
-        existsSync(join(home, '.chroxy', 'scheduled-tasks.json')),
-        'registry must land beside the session-state file the daemon actually loads',
+        existsSync(join(elsewhere, 'scheduled-tasks.json')),
+        'registry must follow CHROXY_CONFIG_DIR — that is where the daemon now loads session-state from',
       )
       assert.ok(
-        !existsSync(join(elsewhere, 'scheduled-tasks.json')),
-        'registry must NOT follow CHROXY_CONFIG_DIR — the daemon scheduler never reads it there',
+        !existsSync(join(home, '.chroxy', 'scheduled-tasks.json')),
+        'registry must not stay home-rooted once CHROXY_CONFIG_DIR relocates the daemon state',
       )
 
       // Same resolution on the read side, so create and list can't disagree.
@@ -189,6 +191,27 @@ describe('chroxy schedule — CLI wiring (#6868)', () => {
       assert.equal(tasks[0].name, 'EnvProbe')
     } finally {
       rmSync(elsewhere, { recursive: true, force: true })
+      cleanup()
+    }
+  })
+
+  // The positive control for the case above: with CHROXY_CONFIG_DIR unset the
+  // registry must fall back to $HOME/.chroxy. Without this, "it landed in the
+  // relocated dir" would also be satisfied by a CLI that had simply stopped
+  // writing under $HOME for some unrelated reason.
+  it('falls back to $HOME/.chroxy when CHROXY_CONFIG_DIR is unset', async () => {
+    const { home, cleanup } = makeTempHome()
+    try {
+      const created = await runCli(
+        ['schedule', 'create', '--prompt', 'x', '--cron', '0 9 * * *', '--name', 'HomeProbe'],
+        { home },
+      )
+      assert.equal(created.code, 0, `stderr: ${created.stderr}`)
+      assert.ok(
+        existsSync(join(home, '.chroxy', 'scheduled-tasks.json')),
+        'registry must be home-rooted when nothing relocates it',
+      )
+    } finally {
       cleanup()
     }
   })

--- a/packages/server/tests/cli/schedule-cmd.test.js
+++ b/packages/server/tests/cli/schedule-cmd.test.js
@@ -204,7 +204,12 @@ describe('chroxy schedule — CLI wiring (#6868)', () => {
     try {
       const created = await runCli(
         ['schedule', 'create', '--prompt', 'x', '--cron', '0 9 * * *', '--name', 'HomeProbe'],
-        { home },
+        // `null` UNSETS it. The spawn helper sandboxes CHROXY_CONFIG_DIR by
+        // default, so without this the child would still have it pointed at
+        // $HOME/.chroxy and the home-fallback branch would never execute —
+        // the test would pass against a resolver that had dropped the fallback
+        // entirely, which is exactly what this control exists to catch.
+        { home, env: { CHROXY_CONFIG_DIR: null } },
       )
       assert.equal(created.code, 0, `stderr: ${created.stderr}`)
       assert.ok(

--- a/packages/server/tests/config-dir.test.js
+++ b/packages/server/tests/config-dir.test.js
@@ -1,0 +1,125 @@
+import { describe, it, beforeEach, afterEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// Imported ONCE, at the top, with no env var set — deliberately.
+//
+// Every other test in this suite that needs a relocated config dir sets
+// CHROXY_CONFIG_DIR *before* a dynamic `await import(...)`, because the module
+// under test froze its paths into a module-scope const and the only way to
+// influence it was to control what the environment looked like at import time.
+// That workaround is the #7052 defect wearing a disguise, so this file must not
+// use it: if these assertions pass against a statically-imported module, the
+// resolution genuinely happens per call.
+import { configDir, configPath } from '../src/config-dir.js'
+
+const originalConfigDir = process.env.CHROXY_CONFIG_DIR
+
+function setEnv(value) {
+  if (value === undefined) delete process.env.CHROXY_CONFIG_DIR
+  else process.env.CHROXY_CONFIG_DIR = value
+}
+
+beforeEach(() => { delete process.env.CHROXY_CONFIG_DIR })
+afterEach(() => { setEnv(originalConfigDir) })
+after(() => { setEnv(originalConfigDir) })
+
+describe('config-dir', () => {
+  describe('configDir()', () => {
+    it('returns CHROXY_CONFIG_DIR when it is set', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/relocated-chroxy'
+      assert.equal(configDir(), '/tmp/relocated-chroxy')
+    })
+
+    it('falls back to ~/.chroxy when unset', () => {
+      assert.equal(configDir(), join(homedir(), '.chroxy'))
+    })
+
+    it('falls back to ~/.chroxy when set to the empty string', () => {
+      // Matches the `||` semantics of the 16 inline copies this replaces, so
+      // migrating an already-correct site is a true no-op.
+      process.env.CHROXY_CONFIG_DIR = ''
+      assert.equal(configDir(), join(homedir(), '.chroxy'))
+    })
+  })
+
+  describe('configPath()', () => {
+    it('joins a single segment onto the root', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/relocated-chroxy'
+      assert.equal(configPath('config.json'), join('/tmp/relocated-chroxy', 'config.json'))
+    })
+
+    it('joins multiple segments onto the root', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/relocated-chroxy'
+      assert.equal(configPath('snapshots', 'a.json'), join('/tmp/relocated-chroxy', 'snapshots', 'a.json'))
+    })
+
+    it('returns the root itself when given no segments', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/relocated-chroxy'
+      assert.equal(configPath(), configDir())
+    })
+
+    it('falls back to ~/.chroxy when unset', () => {
+      assert.equal(configPath('config.json'), join(homedir(), '.chroxy', 'config.json'))
+    })
+  })
+
+  // ---------------------------------------------------------------------
+  // The controls. Everything above passes against a module-scope
+  // `const CONFIG_DIR = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')`
+  // as long as the env happened to be set before import. These do not — they
+  // are the assertions that actually distinguish a live read from a frozen one.
+  // ---------------------------------------------------------------------
+  describe('resolves at call time, not at import time', () => {
+    it('configDir() tracks a change made BETWEEN two calls', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/first'
+      const first = configDir()
+
+      process.env.CHROXY_CONFIG_DIR = '/tmp/second'
+      const second = configDir()
+
+      assert.equal(first, '/tmp/first')
+      assert.equal(second, '/tmp/second')
+      assert.notEqual(first, second, 'configDir() froze its value — it is a const, not a call-time read')
+    })
+
+    it('configPath() tracks a change made BETWEEN two calls', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/first'
+      const first = configPath('session-state.json')
+
+      process.env.CHROXY_CONFIG_DIR = '/tmp/second'
+      const second = configPath('session-state.json')
+
+      assert.equal(first, join('/tmp/first', 'session-state.json'))
+      assert.equal(second, join('/tmp/second', 'session-state.json'))
+      assert.notEqual(first, second, 'configPath() froze its root — it is a const, not a call-time read')
+    })
+
+    it('picks up a value set AFTER the module was imported', () => {
+      // The module was imported statically at the top of this file with no env
+      // var set. A const implementation captured ~/.chroxy right there and can
+      // never return anything else.
+      process.env.CHROXY_CONFIG_DIR = '/tmp/set-after-import'
+      assert.equal(configDir(), '/tmp/set-after-import')
+      assert.notEqual(configDir(), join(homedir(), '.chroxy'))
+    })
+
+    it('honors a beforeEach that relocates the dir', () => {
+      // The pattern real suites use (checkpoint-manager.js:20 documents it):
+      // a beforeEach points the daemon at a temp dir per test. That only works
+      // if the read happens after the hook ran.
+      assert.equal(configDir(), join(homedir(), '.chroxy'), 'the suite-level beforeEach should have cleared the env')
+      process.env.CHROXY_CONFIG_DIR = '/tmp/per-test'
+      assert.equal(configDir(), '/tmp/per-test')
+    })
+
+    it('reverts to the home fallback when the var is deleted mid-run', () => {
+      process.env.CHROXY_CONFIG_DIR = '/tmp/temporarily-relocated'
+      assert.equal(configDir(), '/tmp/temporarily-relocated')
+
+      delete process.env.CHROXY_CONFIG_DIR
+      assert.equal(configDir(), join(homedir(), '.chroxy'), 'configDir() cached the relocated value')
+    })
+  })
+})

--- a/packages/server/tests/config-dir.test.js
+++ b/packages/server/tests/config-dir.test.js
@@ -36,6 +36,28 @@ describe('config-dir', () => {
       assert.equal(configDir(), join(homedir(), '.chroxy'))
     })
 
+    it('refuses a relative value and falls back to ~/.chroxy', () => {
+      // #7052 review — the read is per call, so a relative value would resolve
+      // against process.cwd() at each fs operation, scattering credentials and
+      // the daemon identity key into whatever directory the daemon was launched
+      // from. Refusing keeps secrets in one predictable place.
+      process.env.CHROXY_CONFIG_DIR = 'relative-state-dir'
+      assert.equal(configDir(), join(homedir(), '.chroxy'))
+      assert.equal(configPath('credentials.json'), join(homedir(), '.chroxy', 'credentials.json'))
+    })
+
+    it('refuses a whitespace-only value', () => {
+      process.env.CHROXY_CONFIG_DIR = '   '
+      assert.equal(configDir(), join(homedir(), '.chroxy'))
+    })
+
+    it('POSITIVE CONTROL: an absolute value IS honored', () => {
+      // Without this, the two cases above would also pass against a configDir()
+      // that had stopped reading the environment altogether.
+      process.env.CHROXY_CONFIG_DIR = '/tmp/absolute-state-dir'
+      assert.equal(configDir(), '/tmp/absolute-state-dir')
+    })
+
     it('falls back to ~/.chroxy when set to the empty string', () => {
       // Matches the `||` semantics of the 16 inline copies this replaces, so
       // migrating an already-correct site is a true no-op.

--- a/packages/server/tests/credential-handlers.test.js
+++ b/packages/server/tests/credential-handlers.test.js
@@ -7,6 +7,10 @@ import { settingsHandlers } from '../src/handlers/settings-handlers.js'
 import { getStoredCredential, setStoredCredential } from '../src/credential-store.js'
 import { nsCtx } from './test-helpers.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #3855: WS handler tests for the Provider Credentials messages.
  *   - get_credentials_status: returns masked status, never a raw value
@@ -55,6 +59,7 @@ describe('credential WS handlers (#3855)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-handlers-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) {
       savedEnv[k] = process.env[k]
       delete process.env[k]
@@ -64,6 +69,7 @@ describe('credential WS handlers (#3855)', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) {
       if (savedEnv[k] === undefined) delete process.env[k]
       else process.env[k] = savedEnv[k]

--- a/packages/server/tests/credential-rekey.test.js
+++ b/packages/server/tests/credential-rekey.test.js
@@ -20,6 +20,10 @@ import {
 import { runCredentialsRekey } from '../src/cli/credentials-cmd.js'
 import { POSIX_PERM_SKIP } from './test-helpers.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Credential data-key rotation / rekey (#5229). An in-memory keychain fake
  * drives the encrypted path; HOME points at a tmpdir so the real ~/.chroxy is
@@ -51,6 +55,7 @@ describe('credential data-key rekey (#5229)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-rekey-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) {
       savedEnv[k] = process.env[k]
       delete process.env[k]
@@ -63,6 +68,7 @@ describe('credential data-key rekey (#5229)', () => {
     _setCredentialKeychainForTests(null)
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) {
       if (savedEnv[k] === undefined) delete process.env[k]
       else process.env[k] = savedEnv[k]

--- a/packages/server/tests/credential-store-durable.test.js
+++ b/packages/server/tests/credential-store-durable.test.js
@@ -9,6 +9,10 @@ import { credentialHandlers } from '../src/handlers/credential-handlers.js'
 import { WEBHOOK_SECRET_FIELD } from '../src/github-webhook.js'
 import { nsCtx } from './test-helpers.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #6964 — the credential store's durable-write seam.
  *
@@ -95,6 +99,7 @@ describe('credential-store durable-write seam (#6964)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-durable-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     savedEnvSecret = process.env.GITHUB_WEBHOOK_SECRET
     delete process.env.GITHUB_WEBHOOK_SECRET
     credDir = join(tmpHome, '.chroxy')
@@ -119,6 +124,7 @@ describe('credential-store durable-write seam (#6964)', () => {
     }
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (savedEnvSecret === undefined) delete process.env.GITHUB_WEBHOOK_SECRET
     else process.env.GITHUB_WEBHOOK_SECRET = savedEnvSecret
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }

--- a/packages/server/tests/credential-store-encryption.test.js
+++ b/packages/server/tests/credential-store-encryption.test.js
@@ -13,6 +13,10 @@ import {
 } from '../src/credential-store.js'
 import { isEncryptedEnvelope } from '../src/credential-cipher.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Encrypted-path tests for the credential store (#5154). An in-memory keychain
  * fake drives the encrypted branch; HOME points at a tmpdir so the real
@@ -44,6 +48,7 @@ describe('credential-store at-rest encryption (#5154)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-enc-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) {
       savedEnv[k] = process.env[k]
       delete process.env[k]
@@ -58,6 +63,7 @@ describe('credential-store at-rest encryption (#5154)', () => {
     _setCredentialKeychainForTests(null)
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) {
       if (savedEnv[k] === undefined) delete process.env[k]
       else process.env[k] = savedEnv[k]

--- a/packages/server/tests/credential-store-field.test.js
+++ b/packages/server/tests/credential-store-field.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, statSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
 import {
   setStoredField,
   deleteStoredField,
@@ -27,10 +31,12 @@ describe('setStoredField / deleteStoredField (#6540)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-field-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
   })
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
   })
 

--- a/packages/server/tests/credential-store-spawn-warning.test.js
+++ b/packages/server/tests/credential-store-spawn-warning.test.js
@@ -14,6 +14,10 @@ import {
 } from '../src/credential-store.js'
 import { CRED_KEY_SERVICE } from '../src/credential-cipher.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #5242 — the spawn path must not SILENTLY resolve an encrypted credential to
  * null when the keychain data key is momentarily unavailable (locked keychain,
@@ -51,6 +55,7 @@ describe('credential-store — encrypted-keychain-unavailable warning (#5242)', 
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-warn-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) { savedEnv[k] = process.env[k]; delete process.env[k] }
     logger = capturingLogger()
     _setCredentialLoggerForTests(logger)
@@ -63,6 +68,7 @@ describe('credential-store — encrypted-keychain-unavailable warning (#5242)', 
     _resetKeychainWarningsForTests()
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) { if (savedEnv[k] === undefined) delete process.env[k]; else process.env[k] = savedEnv[k] }
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
   })

--- a/packages/server/tests/credential-store.test.js
+++ b/packages/server/tests/credential-store.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, statSync, readFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
 import {
   KNOWN_CREDENTIALS,
   isKnownCredentialKey,
@@ -31,6 +35,7 @@ describe('credential-store', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-store-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) {
       savedEnv[k] = process.env[k]
       delete process.env[k]
@@ -40,6 +45,7 @@ describe('credential-store', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) {
       if (savedEnv[k] === undefined) delete process.env[k]
       else process.env[k] = savedEnv[k]

--- a/packages/server/tests/credential-test.test.js
+++ b/packages/server/tests/credential-test.test.js
@@ -6,6 +6,10 @@ import { join } from 'node:path'
 import { testCredential } from '../src/credential-test.js'
 import { setStoredCredential } from '../src/credential-store.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #3855: lightweight credential ping. Uses an injected fetch so no real
  * network call is made. Verifies status-code mapping and that the raw value
@@ -30,6 +34,7 @@ describe('credential-test (#3855)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-test-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) {
       savedEnv[k] = process.env[k]
       delete process.env[k]
@@ -39,6 +44,7 @@ describe('credential-test (#3855)', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) {
       if (savedEnv[k] === undefined) delete process.env[k]
       else process.env[k] = savedEnv[k]

--- a/packages/server/tests/deepseek-credentials.test.js
+++ b/packages/server/tests/deepseek-credentials.test.js
@@ -5,6 +5,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { resolveDeepSeekApiKey, maskApiKey } from '../src/deepseek-credentials.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Tests for deepseek-credentials.js (#4656) — env-var precedence,
  * file-fallback, 0600 permission enforcement, key masking re-export.
@@ -25,6 +29,7 @@ describe('deepseek-credentials', () => {
     originalApiKey = process.env.DEEPSEEK_API_KEY
     originalAnthropicKey = process.env.ANTHROPIC_API_KEY
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     delete process.env.DEEPSEEK_API_KEY
     // Defensive: a bleed-through ANTHROPIC_API_KEY must not poison this
     // resolver — the two paths are independent. Confirms isolation.
@@ -34,6 +39,7 @@ describe('deepseek-credentials', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (originalApiKey) process.env.DEEPSEEK_API_KEY = originalApiKey
     else delete process.env.DEEPSEEK_API_KEY
     if (originalAnthropicKey) process.env.ANTHROPIC_API_KEY = originalAnthropicKey

--- a/packages/server/tests/deepseek-session.test.js
+++ b/packages/server/tests/deepseek-session.test.js
@@ -7,6 +7,10 @@ import { DeepSeekSession } from '../src/deepseek-session.js'
 import { ClaudeByokSession } from '../src/byok-session.js'
 import { computePromptCostUsd } from '../src/models.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Tests for DeepSeekSession (#4656).
  *
@@ -204,11 +208,13 @@ describe('DeepSeekSession (#4656)', () => {
       originalHome = process.env.HOME
       originalKey = process.env.DEEPSEEK_API_KEY
       process.env.HOME = tmpHome
+      process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     })
 
     afterEach(() => {
       if (originalHome) process.env.HOME = originalHome
       else delete process.env.HOME
+      process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
       if (originalKey) process.env.DEEPSEEK_API_KEY = originalKey
       else delete process.env.DEEPSEEK_API_KEY
       rmSync(tmpHome, { recursive: true, force: true })

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -53,17 +53,37 @@ function inMemoryKeychain() {
 let originalFetch
 let originalHome
 let originalEnvUrl
+let originalConfigDir
+
+/**
+ * Point the daemon's config dir at a fresh temp home and return it.
+ *
+ * Since #7052 the credentials file is `configPath('credentials.json')`, so it
+ * follows CHROXY_CONFIG_DIR rather than always sitting at `~/.chroxy`. Setting
+ * HOME alone no longer moves it — the suite-wide sandbox (tests/_setup.mjs)
+ * pins CHROXY_CONFIG_DIR to its own tmp dir, which would win. These tests write
+ * a fixture to `<home>/.chroxy/credentials.json` and expect the resolver to
+ * read it, so both have to point at the same place.
+ */
+function useTempHome(home = mkdtempSync(join(tmpdir(), 'discord-home-'))) {
+  process.env.HOME = home
+  process.env.CHROXY_CONFIG_DIR = join(home, '.chroxy')
+  return home
+}
 
 beforeEach(() => {
   originalFetch = globalThis.fetch
   originalHome = process.env.HOME
   originalEnvUrl = process.env.CHROXY_DISCORD_WEBHOOK_URL
+  originalConfigDir = process.env.CHROXY_CONFIG_DIR
   delete process.env.CHROXY_DISCORD_WEBHOOK_URL
 })
 
 afterEach(() => {
   globalThis.fetch = originalFetch
   process.env.HOME = originalHome
+  if (originalConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+  else process.env.CHROXY_CONFIG_DIR = originalConfigDir
   if (originalEnvUrl === undefined) delete process.env.CHROXY_DISCORD_WEBHOOK_URL
   else process.env.CHROXY_DISCORD_WEBHOOK_URL = originalEnvUrl
   mock.restoreAll()
@@ -135,7 +155,7 @@ const errored = (data = {}) => ({
 describe('discord-credentials — webhook URL sourcing', () => {
   it('env var wins over the credentials file', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     mkdirSync(join(home, '.chroxy'), { recursive: true })
     const file = join(home, '.chroxy', 'credentials.json')
     writeFileSync(file, JSON.stringify({ discordWebhookUrl: 'https://discord.com/api/webhooks/1/file-token-aaaaaaaaaaaaaaaaaaaa' }), { mode: 0o600 })
@@ -149,7 +169,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   it('reads discordWebhookUrl from a 0600 credentials.json', () => {
     // Temp home — the #4633 sandbox guard only protects the REAL home.
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     const file = join(dir, 'credentials.json')
     mkdirSync(dir, { recursive: true })
@@ -162,7 +182,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
 
   it('refuses a credentials file that is not 0600', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     mkdirSync(join(home, '.chroxy'), { recursive: true })
     const file = join(home, '.chroxy', 'credentials.json')
     writeFileSync(file, JSON.stringify({ discordWebhookUrl: WEBHOOK }))
@@ -173,7 +193,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   })
 
   it('resolves to none when neither env nor file is present', () => {
-    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    useTempHome()
     const r = resolveDiscordWebhookUrl()
     assert.equal(r.url, null)
     assert.equal(r.source, 'none')
@@ -183,7 +203,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   // var, and credentials.json is the encrypted BYOK envelope — so the webhook
   // must be readable straight from the OS keychain as a third source.
   it('falls back to the keychain when env and file are both absent (#5493)', () => {
-    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    useTempHome()
     const r = resolveDiscordWebhookUrl({
       keychainGet: (service, account) =>
         service === 'chroxy-discord-webhook' && account === 'webhook-url' ? WEBHOOK : null,
@@ -193,7 +213,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   })
 
   it('env var wins over the keychain (#5493)', () => {
-    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    useTempHome()
     process.env.CHROXY_DISCORD_WEBHOOK_URL = WEBHOOK
     const r = resolveDiscordWebhookUrl({ keychainGet: () => 'https://discord.com/api/webhooks/9/keychain-token-zzzzzzzzzzzzzzzzzzzz' })
     assert.equal(r.source, 'env')
@@ -202,7 +222,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
 
   it('the credentials file wins over the keychain (#5493)', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     mkdirSync(dir, { recursive: true })
     const file = join(dir, 'credentials.json')
@@ -214,7 +234,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   })
 
   it('keychain miss leaves source none with a reason noting the keychain was checked (#5493)', () => {
-    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    useTempHome()
     const r = resolveDiscordWebhookUrl({ keychainGet: () => null })
     assert.equal(r.url, null)
     assert.equal(r.source, 'none')
@@ -230,7 +250,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   it('non-ENOENT stat failure (EACCES) surfaces the real error, not "does not exist" (#5523)', () => {
     if (process.getuid && process.getuid() === 0) return // root bypasses dir perms
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     const file = join(dir, 'credentials.json')
     mkdirSync(dir, { recursive: true })
@@ -255,7 +275,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
 
   it('missing-field reason is value-free and stable on a plaintext file', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     mkdirSync(dir, { recursive: true })
     const file = join(dir, 'credentials.json')
@@ -274,7 +294,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
   // unconfigured. The resolver must decrypt via the keychain-backed key.
   it('reads discordWebhookUrl from an ENCRYPTED credentials.json (#5490)', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     mkdirSync(dir, { recursive: true })
     const file = join(dir, 'credentials.json')
@@ -306,7 +326,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
 
   it('encrypted file + unavailable keychain → none with a value-free reason (#5490)', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     mkdirSync(dir, { recursive: true })
     const file = join(dir, 'credentials.json')
@@ -338,7 +358,7 @@ describe('discord-credentials — webhook URL sourcing', () => {
 
   it('cachedResolveDiscordWebhookUrl composes with decryption (#5490)', () => {
     const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
-    process.env.HOME = home
+    useTempHome(home)
     const dir = join(home, '.chroxy')
     mkdirSync(dir, { recursive: true })
     const file = join(dir, 'credentials.json')

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -9,6 +9,10 @@ import { DockerByokSession, remapToContainerPath, CONTAINER_WORKSPACE } from '..
 import { ClaudeByokSession } from '../src/byok-session.js'
 import { registerDockerProvider, getProvider } from '../src/providers.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Tests for the docker-byok provider (#4053).
  *
@@ -85,6 +89,7 @@ beforeEach(() => {
   originalApiKey = process.env.ANTHROPIC_API_KEY
   originalMcpTrustPath = process.env.CHROXY_MCP_TRUST_PATH
   process.env.HOME = tmpHome
+  process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
   process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
   process.env.CHROXY_MCP_TRUST_PATH = join(tmpHome, 'mcp-trust.json')
 })
@@ -92,6 +97,7 @@ beforeEach(() => {
 afterEach(() => {
   if (originalHome) process.env.HOME = originalHome
   else delete process.env.HOME
+  process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
   if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
   else delete process.env.ANTHROPIC_API_KEY
   if (originalMcpTrustPath) process.env.CHROXY_MCP_TRUST_PATH = originalMcpTrustPath

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -839,7 +839,7 @@ describe('checkTunnelRoutability (#5328 WP-5.6)', () => {
   it('runDoctorChecks fires the probe for a configured named tunnel, incl. the cloudflare:named alias', async () => {
     const { writeFileSync, rmSync } = await import('node:fs')
     // _setup.mjs points CHROXY_CONFIG_DIR at a writable tmp dir and doctor's
-    // CONFIG_FILE now honors it (the hermeticity fix), so this lands in the
+    // configFile() now honors it (the hermeticity fix), so this lands in the
     // sandbox, not the real ~/.chroxy.
     const cfgPath = join(process.env.CHROXY_CONFIG_DIR, 'config.json')
     writeFileSync(cfgPath, JSON.stringify({ tunnel: 'cloudflare:named', tunnelHostname: 'chroxy.example.com' }))

--- a/packages/server/tests/github-webhook-handlers.test.js
+++ b/packages/server/tests/github-webhook-handlers.test.js
@@ -8,6 +8,10 @@ import { readStoredField, setStoredField } from '../src/credential-store.js'
 import { WebhookDeliveryRing, WEBHOOK_SECRET_FIELD } from '../src/github-webhook.js'
 import { nsCtx } from './test-helpers.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #6540 (item 3 of #6536): WS handler tests for the repo-events webhook-secret
  * config surface. Guards:
@@ -60,6 +64,7 @@ describe('github webhook-secret WS handlers (#6540)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-webhook-handlers-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     savedEnv = process.env.GITHUB_WEBHOOK_SECRET
     delete process.env.GITHUB_WEBHOOK_SECRET
   })
@@ -67,6 +72,7 @@ describe('github webhook-secret WS handlers (#6540)', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (savedEnv === undefined) delete process.env.GITHUB_WEBHOOK_SECRET
     else process.env.GITHUB_WEBHOOK_SECRET = savedEnv
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }

--- a/packages/server/tests/github-webhook.test.js
+++ b/packages/server/tests/github-webhook.test.js
@@ -23,6 +23,10 @@ import {
 } from '../src/github-webhook.js'
 import { setStoredField } from '../src/credential-store.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 const SECRET = 'whsec_test_secret'
 const sign = (body, secret = SECRET) => `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`
 
@@ -157,12 +161,14 @@ describe('handleGithubWebhook()', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-webhook-deliver-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
   })
   afterEach(() => {
     if (savedEnv === undefined) delete process.env.GITHUB_WEBHOOK_SECRET
     else process.env.GITHUB_WEBHOOK_SECRET = savedEnv
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
   })
 
@@ -408,12 +414,14 @@ describe('webhookSecretSource / resolveWebhookSecret precedence (#6540)', () => 
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-webhook-source-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     savedEnv = process.env.GITHUB_WEBHOOK_SECRET
     delete process.env.GITHUB_WEBHOOK_SECRET
   })
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (savedEnv === undefined) delete process.env.GITHUB_WEBHOOK_SECRET
     else process.env.GITHUB_WEBHOOK_SECRET = savedEnv
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }

--- a/packages/server/tests/handler-utils.test.js
+++ b/packages/server/tests/handler-utils.test.js
@@ -695,6 +695,85 @@ describe('validateCwdAllowed — credential-directory deny-list (2026-04-11 audi
     assert.match(err, /credential.config directories/)
   })
 
+  // #7052 — FORBIDDEN_HOME_SUBDIRS is a list of literal FIRST SEGMENTS under
+  // $HOME, so it protects `~/.chroxy` and nothing else. Once CHROXY_CONFIG_DIR
+  // relocates the state root, that set guards an empty directory while the real
+  // one — credentials.json, config.json (raw apiToken on keychain-less hosts),
+  // server-identity.json, all four trust ledgers — becomes an ordinary
+  // directory a client may open a session in. That reopens the very A9 attack
+  // the `.chroxy` entry above was added for, so the root is denied by
+  // resolution, not by name.
+  describe('relocated config dir (#7052)', () => {
+    let relocated
+    let originalConfigDir
+
+    before(() => {
+      originalConfigDir = process.env.CHROXY_CONFIG_DIR
+      // Deliberately NOT named `.chroxy`, and NOT a first-level child of the
+      // fake home — the shape the literal deny-list cannot express.
+      relocated = join(fakeHome, '.local', 'state', 'chroxy')
+      mkdirSync(join(relocated, 'nested'), { recursive: true })
+    })
+    after(() => {
+      if (originalConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+      else process.env.CHROXY_CONFIG_DIR = originalConfigDir
+    })
+
+    it('rejects the relocated config root itself', () => {
+      process.env.CHROXY_CONFIG_DIR = relocated
+      const err = validateCwdAllowed(relocated, { homeOverride: fakeHome })
+      assert.ok(err, 'the relocated state root must not be usable as a session cwd')
+      assert.match(err, /chroxy config.state directory/)
+    })
+
+    it('rejects a subdirectory of the relocated config root', () => {
+      process.env.CHROXY_CONFIG_DIR = relocated
+      const err = validateCwdAllowed(join(relocated, 'nested'), { homeOverride: fakeHome })
+      assert.ok(err, 'nested paths under the state root must be rejected too')
+    })
+
+    it('POSITIVE CONTROL: the identical directory is allowed when the env is unset', () => {
+      // Without this, the two cases above would also pass if the directory were
+      // being rejected for some unrelated reason (its name, its depth, the
+      // home-fallback layer) rather than because it IS the config root.
+      delete process.env.CHROXY_CONFIG_DIR
+      assert.equal(
+        validateCwdAllowed(relocated, { homeOverride: fakeHome }),
+        null,
+        'with nothing relocating the config dir this is just an ordinary directory',
+      )
+    })
+
+    it('POSITIVE CONTROL: an ordinary sibling stays allowed while the env IS set', () => {
+      // Proves the new layer denies the config root specifically, and has not
+      // become a blanket denial of everything under the fake home.
+      process.env.CHROXY_CONFIG_DIR = relocated
+      assert.equal(
+        validateCwdAllowed(join(fakeHome, 'ordinary-project'), { homeOverride: fakeHome }),
+        null,
+        'an unrelated project directory must remain usable',
+      )
+    })
+
+    it('still rejects ~/.chroxy by name when the env points elsewhere', () => {
+      // The literal deny-list entry is not redundant: the default location must
+      // stay blocked even for a daemon whose state now lives somewhere else.
+      process.env.CHROXY_CONFIG_DIR = relocated
+      const err = validateCwdAllowed(join(fakeHome, '.chroxy'), { homeOverride: fakeHome })
+      assert.ok(err, '~/.chroxy must stay blocked regardless of CHROXY_CONFIG_DIR')
+      assert.match(err, /credential.config directories/)
+    })
+
+    it('does not throw when the configured root does not exist on disk', () => {
+      process.env.CHROXY_CONFIG_DIR = join(fakeHome, 'does-not-exist-at-all')
+      assert.equal(
+        validateCwdAllowed(join(fakeHome, 'ordinary-project'), { homeOverride: fakeHome }),
+        null,
+        'an unresolvable config root must not break cwd validation',
+      )
+    })
+  })
+
   it('rejects a subdirectory of a forbidden entry (~/.config/gcloud)', () => {
     const err = validateCwdAllowed(join(fakeHome, '.config', 'gcloud'), { homeOverride: fakeHome })
     assert.ok(err, 'must reject .config/gcloud subdirectory')

--- a/packages/server/tests/handlers/byok-credentials-handlers.test.js
+++ b/packages/server/tests/handlers/byok-credentials-handlers.test.js
@@ -6,6 +6,10 @@ import { join } from 'path'
 import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
 import { createSpy, nsCtx } from '../test-helpers.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * Tests for the BYOK credentials WS handlers (#4052):
  *   - byok_get_credentials_status
@@ -52,12 +56,14 @@ describe('byok credentials handlers (#4052)', () => {
     originalHome = process.env.HOME
     originalApiKey = process.env.ANTHROPIC_API_KEY
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     delete process.env.ANTHROPIC_API_KEY
   })
 
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
     else delete process.env.ANTHROPIC_API_KEY
     rmSync(tmpHome, { recursive: true, force: true })

--- a/packages/server/tests/lint-config-dir.test.js
+++ b/packages/server/tests/lint-config-dir.test.js
@@ -1,0 +1,355 @@
+/**
+ * Tests for scripts/lint-config-dir.mjs (#7052).
+ *
+ * The lint guards the single-resolver rule: `~/.chroxy` is resolved by
+ * `src/config-dir.js` and nowhere else. Two shapes are banned — a hardcoded
+ * `join(homedir(), '.chroxy', …)` (ignores CHROXY_CONFIG_DIR outright) and an
+ * inline `process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')` copy of
+ * the resolver itself.
+ *
+ * Strategy: run the lint as a child process against a temp fixture `src/` tree
+ * (via `--src-dir` / `--baseline`) and assert the EXIT CODE, not the output.
+ *
+ * Every exemption below is asserted with a POSITIVE CONTROL — the same source
+ * WITHOUT the thing that is supposed to exempt it, proving the case would have
+ * failed and that the exemption is what saved it. A bare "this passes" would
+ * pass just as happily against a lint that detects nothing at all, which is the
+ * false-safety class docs/false-safety-guards.md exists to prevent.
+ */
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-config-dir.mjs')
+
+const tmpRoots = []
+after(() => {
+  for (const d of tmpRoots) {
+    try { rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+/**
+ * Build a fixture src/ tree and run the lint against it.
+ * @param {Record<string,string>} files repo-relative path -> source
+ * @param {string[]|null} baseline lines for the baseline file, or null for none
+ */
+function runLint(files, baseline = null) {
+  const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-configdir-'))
+  tmpRoots.push(root)
+  const srcDir = join(root, 'src')
+  mkdirSync(srcDir, { recursive: true })
+
+  for (const [rel, source] of Object.entries(files)) {
+    const full = join(srcDir, rel)
+    mkdirSync(dirname(full), { recursive: true })
+    writeFileSync(full, source)
+  }
+
+  const args = ['--src-dir', srcDir]
+  if (baseline !== null) {
+    const baselinePath = join(root, 'baseline.txt')
+    writeFileSync(baselinePath, baseline.join('\n') + '\n')
+    args.push('--baseline', baselinePath)
+  } else {
+    args.push('--baseline', join(root, 'does-not-exist.txt'))
+  }
+
+  const res = spawnSync(process.execPath, [LINT_SCRIPT, ...args], { encoding: 'utf8' })
+  return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' }
+}
+
+const HARDCODED = `
+import { homedir } from 'os'
+import { join } from 'path'
+export function statePath() {
+  return join(homedir(), '.chroxy', 'session-state.json')
+}
+`
+
+const INLINE_COPY = `
+import { homedir } from 'os'
+import { join } from 'path'
+export function statePath() {
+  const dir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return join(dir, 'session-state.json')
+}
+`
+
+const CLEAN = `
+import { configPath } from './config-dir.js'
+export function statePath() {
+  return configPath('session-state.json')
+}
+`
+
+const OWNER = `
+import { homedir } from 'os'
+import { join } from 'path'
+export function configDir() {
+  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+}
+`
+
+describe('lint-config-dir', () => {
+  describe('detection', () => {
+    test('a clean file that uses configPath() passes', () => {
+      const r = runLint({ 'clean.js': CLEAN })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('a hardcoded join(homedir(), .chroxy) path fails', () => {
+      const r = runLint({ 'offender.js': HARDCODED })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /offender\.js:5\s+\[hardcoded-home-path\]/)
+    })
+
+    test('an inline resolver copy fails, and is reported as such', () => {
+      const r = runLint({ 'offender.js': INLINE_COPY })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /offender\.js:5\s+\[inline-resolver-copy\]/)
+    })
+
+    test('reports every offending site, not just the first', () => {
+      const r = runLint({ 'a.js': HARDCODED, 'b.js': INLINE_COPY, 'c.js': HARDCODED })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /3 un-baselined site\(s\)/)
+    })
+
+    test('finds offenders in subdirectories', () => {
+      const r = runLint({ 'notifications/sink.js': HARDCODED })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /notifications\/sink\.js:5/)
+    })
+  })
+
+  describe('the owner file is exempt', () => {
+    test('config-dir.js may resolve the env itself', () => {
+      const r = runLint({ 'config-dir.js': OWNER })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('POSITIVE CONTROL: the identical source under another name fails', () => {
+      // Proves the pass above came from the owner exemption, not from the lint
+      // failing to see this shape at all.
+      const r = runLint({ 'not-the-owner.js': OWNER })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /not-the-owner\.js:5\s+\[inline-resolver-copy\]/)
+    })
+  })
+
+  describe('comments are not code', () => {
+    test('a line comment quoting the pattern is not an offense', () => {
+      const r = runLint({
+        'doc.js': `
+// Historically this read join(homedir(), '.chroxy', 'config.json') directly.
+export const x = 1
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('a block comment quoting the pattern is not an offense', () => {
+      // The real case: cli/schedule-cmd.js's doc block quotes the banned
+      // pattern across several lines while explaining the migration.
+      const r = runLint({
+        'doc.js': `
+/**
+ * Deliberately rooted at homedir()/.chroxy, because:
+ *   1. it falls back to join(homedir(), '.chroxy', 'session-state.json').
+ */
+export const x = 1
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('POSITIVE CONTROL: the same text as live code fails', () => {
+      // Without this, both cases above would pass against a lint whose comment
+      // stripper had eaten the entire file.
+      const r = runLint({
+        'doc.js': `
+export const x = join(homedir(), '.chroxy', 'session-state.json')
+`,
+      })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /doc\.js:2\s+\[hardcoded-home-path\]/)
+    })
+
+    test('code AFTER a closed block comment is still linted', () => {
+      const r = runLint({
+        'doc.js': `
+/* a note about join(homedir(), '.chroxy') */
+export const x = join(homedir(), '.chroxy', 'config.json')
+`,
+      })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /doc\.js:3/)
+    })
+
+    test('code on the same line after a block comment closes is still linted', () => {
+      const r = runLint({
+        'doc.js': `
+/* note */ export const x = join(homedir(), '.chroxy', 'config.json')
+`,
+      })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /doc\.js:2/)
+    })
+  })
+
+  describe('non-chroxy home paths are out of scope', () => {
+    test('a Windows AppData credential path is not an offense', () => {
+      // keychain.js:36
+      const r = runLint({
+        'keychain.js': `
+export function dir() {
+  return join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'Chroxy')
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test("Claude Code's own ~/.claude.json is not an offense", () => {
+      // byok-mcp-config.js:43 — chroxy reads this file but does not own it.
+      const r = runLint({
+        'byok-mcp-config.js': `
+export function p() {
+  return process.env.CHROXY_CLAUDE_CONFIG || join(homedir(), '.claude.json')
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('POSITIVE CONTROL: the same shapes with .chroxy DO fail', () => {
+      // Proves the two passes above came from the path segment differing, not
+      // from the lint ignoring `homedir()` in those files by name.
+      const rKeychain = runLint({
+        'keychain.js': `
+export function dir() {
+  return join(process.env.LOCALAPPDATA || join(homedir(), '.chroxy'), 'Chroxy')
+}
+`,
+      })
+      assert.equal(rKeychain.status, 1)
+
+      const rMcp = runLint({
+        'byok-mcp-config.js': `
+export function p() {
+  return process.env.CHROXY_CLAUDE_CONFIG || join(homedir(), '.chroxy')
+}
+`,
+      })
+      assert.equal(rMcp.status, 1)
+    })
+  })
+
+  describe('the lint-ignore marker', () => {
+    test('exempts the line immediately below it', () => {
+      const r = runLint({
+        'legacy.js': `
+export function p() {
+  // lint-ignore-config-dir
+  return join(homedir(), '.chroxy', 'legacy.json')
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('POSITIVE CONTROL: the identical source without the marker fails', () => {
+      const r = runLint({
+        'legacy.js': `
+export function p() {
+  return join(homedir(), '.chroxy', 'legacy.json')
+}
+`,
+      })
+      assert.equal(r.status, 1)
+    })
+
+    test('does NOT exempt a line two below it', () => {
+      const r = runLint({
+        'legacy.js': `
+export function p() {
+  // lint-ignore-config-dir
+  const a = 1
+  return join(homedir(), '.chroxy', 'legacy.json')
+}
+`,
+      })
+      assert.equal(r.status, 1)
+    })
+  })
+
+  describe('the baseline ratchet', () => {
+    test('a baselined file is exempt', () => {
+      const r = runLint({ 'offender.js': HARDCODED }, ['offender.js'])
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('POSITIVE CONTROL: the identical file with an EMPTY baseline fails', () => {
+      // Proves the pass above came from the baseline entry, not from the lint
+      // silently skipping the file for some other reason.
+      const r = runLint({ 'offender.js': HARDCODED }, [])
+      assert.equal(r.status, 1)
+    })
+
+    test('baselining one file does not exempt another', () => {
+      const r = runLint({ 'a.js': HARDCODED, 'b.js': HARDCODED }, ['a.js'])
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /b\.js:5/)
+      assert.doesNotMatch(r.stderr, /a\.js:5/)
+    })
+
+    test('a NEW offender in a non-baselined file fails even when others are baselined', () => {
+      // The ratchet's whole purpose: the list may shrink, never grow.
+      const r = runLint({ 'old.js': HARDCODED, 'new.js': INLINE_COPY }, ['old.js'])
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /new\.js:5/)
+    })
+
+    test('a stale baseline entry — file now clean — fails', () => {
+      // Otherwise the entry keeps granting an exemption nothing needs, and the
+      // next regression in that file lands silently.
+      const r = runLint({ 'clean.js': CLEAN }, ['clean.js'])
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /clean\.js: listed in the baseline but now clean/)
+    })
+
+    test('comments and blank lines in the baseline are ignored', () => {
+      const r = runLint({ 'offender.js': HARDCODED }, [
+        '# a comment',
+        '',
+        'offender.js',
+        '',
+      ])
+      assert.equal(r.status, 0, r.stderr)
+    })
+  })
+
+  describe('--dry-run', () => {
+    test('reports offenders but exits 0', () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-configdir-dry-'))
+      tmpRoots.push(root)
+      const srcDir = join(root, 'src')
+      mkdirSync(srcDir, { recursive: true })
+      writeFileSync(join(srcDir, 'offender.js'), HARDCODED)
+
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--src-dir', srcDir, '--baseline', join(root, 'none.txt'), '--dry-run'],
+        { encoding: 'utf8' }
+      )
+      assert.equal(res.status, 0)
+      assert.match(res.stderr, /offender\.js:5/)
+    })
+  })
+})

--- a/packages/server/tests/lint-config-dir.test.js
+++ b/packages/server/tests/lint-config-dir.test.js
@@ -335,6 +335,117 @@ export function p() {
     })
   })
 
+  // Rule 3 shipped with NO tests. Deleting its body left the suite 25/25 green,
+  // which is the false-safety pattern this repo has hit seven times — a guard
+  // whose output is correct and whose coverage is what is wrong. Worse, the
+  // migration then created a live evader it could not see (logger.js's
+  // `let _logDir = defaultLogDir()`), so the lint reported the tree clean while
+  // half the defect survived. These are the tests that were missing.
+  describe('module-scope capture (rule 3)', () => {
+    const WRAPPER = `
+import { configPath } from './config-dir.js'
+function defaultLogDir() {
+  return configPath('logs')
+}
+`
+    test('a module-scope const initialized from configPath() fails', () => {
+      const r = runLint({
+        'frozen.js': `
+import { configPath } from './config-dir.js'
+const STATE = configPath('session-state.json')
+export function p() { return STATE }
+`,
+      })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /frozen\.js:3\s+\[module-scope-capture\]/)
+    })
+
+    test('an EXPORTED module-scope const fails too', () => {
+      const r = runLint({
+        'frozen.js': `
+import { configDir } from './config-dir.js'
+export const ROOT = configDir()
+`,
+      })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /\[module-scope-capture\]/)
+    })
+
+    test('`let` and `var` are caught, not just `const`', () => {
+      for (const kw of ['let', 'var']) {
+        const r = runLint({
+          'frozen.js': `
+import { configPath } from './config-dir.js'
+${kw} p = configPath('x.json')
+export function get() { return p }
+`,
+        })
+        assert.equal(r.status, 1, `${kw} declaration should be caught`)
+      }
+    })
+
+    test('an initializer on the following line is caught', () => {
+      const r = runLint({
+        'frozen.js': `
+import { configPath } from './config-dir.js'
+const STATE =
+  configPath('session-state.json')
+`,
+      })
+      assert.equal(r.status, 1)
+    })
+
+    test('capture through a same-file wrapper is caught (the logger.js regression)', () => {
+      // The shape that evaded the first version of this rule: the initializer
+      // calls a local one-liner that calls the accessor, so matching the
+      // accessor name alone missed it — and the migration had just replaced a
+      // detectable `join(homedir(), …)` const with exactly this.
+      const r = runLint({ 'logger.js': `${WRAPPER}let _logDir = defaultLogDir()\n` })
+      assert.equal(r.status, 1)
+      assert.match(r.stderr, /logger\.js:6\s+\[module-scope-capture\]/)
+    })
+
+    test('POSITIVE CONTROL: the same wrapper resolved lazily is clean', () => {
+      // Proves the case above is flagged for WHERE the call happens, not merely
+      // for the wrapper existing in the file.
+      const r = runLint({
+        'logger.js': `${WRAPPER}let _logDir = null
+export function init(dir) {
+  _logDir = dir || defaultLogDir()
+  return _logDir
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('POSITIVE CONTROL: the identical call inside a function is clean', () => {
+      // Indentation is the signal for "not module scope". Without this control,
+      // the rule could be matching the accessor call anywhere in the file.
+      const r = runLint({
+        'fine.js': `
+import { configPath } from './config-dir.js'
+export function statePath() {
+  const p = configPath('session-state.json')
+  return p
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('a module-scope binding NOT calling the accessor is clean', () => {
+      const r = runLint({
+        'fine.js': `
+const MAX = 50
+const NAME = 'chroxy'
+export function get() { return NAME }
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+  })
+
   describe('--dry-run', () => {
     test('reports offenders but exits 0', () => {
       const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-configdir-dry-'))

--- a/packages/server/tests/memory-read.test.js
+++ b/packages/server/tests/memory-read.test.js
@@ -7,6 +7,10 @@ import { createFileOps } from '../src/ws-file-ops/index.js'
 import { encodeProjectPath } from '../src/jsonl-reader.js'
 import { resolveSessionCwd } from '../src/ws-file-ops/common.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * `readMemory` op (#6864, epic #6760) — server read of the effective merged
  * CLAUDE.md memory stack (global/project/local + @imports) plus the project's
@@ -37,11 +41,13 @@ describe('memory_read (readMemory) handler', () => {
   after(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
   })
 
   beforeEach(async () => {
     fakeHome = await mkdtemp(join(tmpdir(), 'chroxy-memhome-'))
     process.env.HOME = fakeHome
+    process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
     responses.length = 0
   })
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -236,7 +236,7 @@ describe('Provider Registry', () => {
   // so the dashboard can grey-out unusable providers and show a billing-
   // identity confidence panel without making the user run `chroxy doctor`.
   describe('auth status (#3404 audit)', () => {
-    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'DEEPSEEK_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME']
+    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'DEEPSEEK_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME', 'CHROXY_CONFIG_DIR']
     const saved = {}
     let _tmpClaudeHome = null
     let _tmpCodexHome = null
@@ -1203,7 +1203,7 @@ describe('listProviders credential-file caching (#4658)', () => {
   // Env vars the cache key is sensitive to. Saved/restored per test so a
   // stray ANTHROPIC_API_KEY in the developer env doesn't suppress the file
   // path under test.
-  const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'DEEPSEEK_API_KEY', 'HOME', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME']
+  const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'DEEPSEEK_API_KEY', 'HOME', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME', 'CHROXY_CONFIG_DIR']
   let saved
   let tmpHome
   let _tmpClaudeHome

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -10,6 +10,10 @@ import { CodexSession } from '../src/codex-session.js'
 import { CodexAppServerSession } from '../src/codex-app-server-session.js'
 import { GeminiSession } from '../src/gemini-session.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 describe('Provider Registry', () => {
   it('has claude-cli and claude-sdk pre-registered', () => {
     const cli = getProvider('claude-cli')
@@ -688,6 +692,7 @@ describe('Provider Registry', () => {
       try {
         clearKeys()
         process.env.HOME = tmpFsHome
+        process.env.CHROXY_CONFIG_DIR = join(tmpFsHome, '.chroxy')
         mkdirSync(join(tmpFsHome, '.chroxy'), { recursive: true })
         const credPath = join(tmpFsHome, '.chroxy', 'credentials.json')
         writeFileSync(credPath, JSON.stringify({ deepseekApiKey: 'sk-from-file' }))
@@ -705,6 +710,7 @@ describe('Provider Registry', () => {
       } finally {
         if (savedHome) process.env.HOME = savedHome
         else delete process.env.HOME
+        process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
         rmSync(tmpFsHome, { recursive: true, force: true })
         restoreKeys()
       }
@@ -1212,6 +1218,7 @@ describe('listProviders credential-file caching (#4658)', () => {
     }
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-cache-test-'))
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     mkdirSync(join(tmpHome, '.chroxy'), { recursive: true, mode: 0o700 })
 
     // #3674-style isolation for the OAuth probes so they don't accidentally

--- a/packages/server/tests/schedule-cli.test.js
+++ b/packages/server/tests/schedule-cli.test.js
@@ -12,6 +12,7 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import { tmpdir, homedir } from 'os'
 import { ScheduledTaskStore, defaultScheduledTasksPath } from '../src/scheduled-task-store.js'
+import { defaultStateFile } from '../src/session-manager.js'
 import {
   runScheduleCreate,
   runScheduleList,
@@ -576,25 +577,48 @@ describe('chroxy schedule — id / id-prefix resolution (#6868)', () => {
   })
 })
 
-// #7015 — the registry file this CLI touches must be the one the RUNNING daemon
-// reads. `getDefaultStore()` was flagged in review for not honouring
-// `CHROXY_CONFIG_DIR` "like the rest of the server"; the daemon's registry path
-// is in fact home-rooted at every hop, so following the env var here would aim
-// the CLI at a file the scheduler never opens — `create` would report success
-// for a task that can never fire. These tests pin the agreement AND the premise
-// it rests on: if the session-state family is ever migrated onto
-// `CHROXY_CONFIG_DIR`, the premise checks fail loudly here rather than letting
-// the CLI silently desync. The behavioural half (registry does not follow the
-// env var end-to-end) lives in tests/cli/schedule-cmd.test.js.
-describe('chroxy schedule — registry path agrees with the daemon, not with CHROXY_CONFIG_DIR (#7015)', () => {
+// #7015 / #7052 — the registry file this CLI touches must be the one the RUNNING
+// daemon reads. The invariant is AGREEMENT between the two; which root they
+// agree on is a detail that has now changed once.
+//
+// Until #7052 both were home-rooted, and this guard pinned that: it asserted
+// SessionManager's default state file ignored `CHROXY_CONFIG_DIR`, and said in
+// as many words that if the session-state family were ever migrated onto the
+// env var, the premise check would go red and schedule-cmd.js must move with
+// it. That is exactly what happened — `defaultStateFile()` is now
+// `configPath('session-state.json')` and the CLI resolver follows through
+// `configDir()`. The guard did its job; this is the other side of it.
+//
+// The premises are now asserted BEHAVIOURALLY rather than by grepping
+// session-manager.js's source. A source-grep guard pins a spelling, so it goes
+// red on a harmless rename and — worse — goes green if the code moves somewhere
+// the regex still matches. Relocating the env var and observing where both
+// resolvers actually land tests the thing the CLI depends on. The end-to-end
+// half (a spawned CLI and the daemon reading the same file) lives in
+// tests/cli/schedule-cmd.test.js.
+describe('chroxy schedule — registry path agrees with the daemon (#7015, #7052)', () => {
   const srcDir = fileURLToPath(new URL('../src/', import.meta.url))
   const readSrc = (rel) => readFileSync(join(srcDir, rel), 'utf-8')
 
-  it('resolves to the daemon-derived, home-rooted sibling of session-state.json', () => {
-    assert.equal(
-      defaultScheduleRegistryPath(),
-      defaultScheduledTasksPath(join(homedir(), '.chroxy', 'session-state.json')),
-    )
+  const withConfigDir = async (dir, fn) => {
+    const prev = process.env.CHROXY_CONFIG_DIR
+    if (dir === undefined) delete process.env.CHROXY_CONFIG_DIR
+    else process.env.CHROXY_CONFIG_DIR = dir
+    try {
+      return await fn()
+    } finally {
+      if (prev === undefined) delete process.env.CHROXY_CONFIG_DIR
+      else process.env.CHROXY_CONFIG_DIR = prev
+    }
+  }
+
+  it('resolves to the daemon-derived sibling of session-state.json', async () => {
+    await withConfigDir(undefined, () => {
+      assert.equal(
+        defaultScheduleRegistryPath(),
+        defaultScheduledTasksPath(join(homedir(), '.chroxy', 'session-state.json')),
+      )
+    })
   })
 
   it('premise 1: server-cli.js passes no stateFilePath, so SessionManager falls back to its default', () => {
@@ -604,19 +628,35 @@ describe('chroxy schedule — registry path agrees with the daemon, not with CHR
     )
   })
 
-  it('premise 2: SessionManager\'s default state file is home-rooted, ignoring CHROXY_CONFIG_DIR', () => {
-    const sm = readSrc('session-manager.js')
-    assert.match(
-      sm,
-      /const DEFAULT_STATE_FILE = join\(homedir\(\), '\.chroxy', 'session-state\.json'\)/,
-      'DEFAULT_STATE_FILE moved or changed shape — defaultScheduleRegistryPath() must follow it',
-    )
-    assert.doesNotMatch(
-      sm,
-      /DEFAULT_STATE_FILE\s*=[^\n]*CHROXY_CONFIG_DIR/,
-      'DEFAULT_STATE_FILE now honours CHROXY_CONFIG_DIR — schedule-cmd.js must honour it too, or the CLI '
-        + 'and the daemon scheduler will read different registries',
-    )
+  it('premise 2: the CLI and SessionManager land on the same registry when CHROXY_CONFIG_DIR moves', async () => {
+    // `defaultStateFile()` is the daemon's fallback — server-cli.js injects no
+    // stateFilePath (premise 1), so this IS the path the live scheduler opens.
+    // Asserted directly rather than by constructing a SessionManager, which
+    // would need a stateFilePath of its own and defeat the point.
+    const relocated = join(tmpdir(), 'chroxy-sched-envdir-fixture')
+    await withConfigDir(relocated, () => {
+      assert.equal(
+        defaultScheduleRegistryPath(),
+        defaultScheduledTasksPath(defaultStateFile()),
+        'the CLI and the daemon derive different registries under CHROXY_CONFIG_DIR — '
+          + '`schedule create` would report success for a task that can never fire',
+      )
+      assert.ok(
+        defaultScheduleRegistryPath().startsWith(relocated),
+        'the registry did not follow CHROXY_CONFIG_DIR',
+      )
+    })
+  })
+
+  it('premise 2b: with CHROXY_CONFIG_DIR unset, both fall back to $HOME/.chroxy', async () => {
+    // The positive control for the case above: without it, "both agree" would
+    // also be satisfied by two resolvers that each ignore the env var.
+    await withConfigDir(undefined, () => {
+      assert.ok(
+        defaultScheduleRegistryPath().startsWith(join(homedir(), '.chroxy')),
+        'the home fallback no longer applies',
+      )
+    })
   })
 
   it('premise 3: SessionManager derives its registry from that state file', () => {

--- a/packages/server/tests/service.test.js
+++ b/packages/server/tests/service.test.js
@@ -108,6 +108,66 @@ describe('service', () => {
       }
     })
 
+    // #7052 — launchd's EnvironmentVariables dict and systemd's Environment=
+    // lines ARE the daemon's whole environment; neither inherits the installing
+    // shell. Since the installer now resolves logDir/service.json/the wrapper
+    // through CHROXY_CONFIG_DIR, omitting it from the generated definition
+    // would start a daemon logging to the relocated root while its state went
+    // to ~/.chroxy — the same split-brain this issue removes, at the service
+    // boundary, and unfixable from the operator's shell.
+    describe('CHROXY_CONFIG_DIR propagation into service definitions', () => {
+      const cfg = {
+        nodePath: '/opt/node/bin/node',
+        chroxyBin: '/lib/chroxy/cli.js',
+        pathValue: '/opt/node/bin:/usr/bin',
+        cwd: '/work',
+        logDir: '/relocated/logs',
+      }
+      const generators = [
+        ['launchd plist', (c) => generateLaunchdPlist(c), '<key>CHROXY_CONFIG_DIR</key>'],
+        ['systemd unit', (c) => generateSystemdUnit(c), 'Environment=CHROXY_CONFIG_DIR=/relocated'],
+        ['POSIX wrapper', (c) => generateServiceWrapper(c), 'export CHROXY_CONFIG_DIR='],
+        ['Windows .cmd', (c) => generateWindowsServiceWrapper(c), 'set "CHROXY_CONFIG_DIR=/relocated"'],
+      ]
+
+      for (const [name, gen, marker] of generators) {
+        it(`${name} carries CHROXY_CONFIG_DIR when it is set at install time`, () => {
+          const out = gen({ ...cfg, configDirEnv: '/relocated' })
+          assert.ok(out.includes(marker), `${name} must bake in the config dir\n${out}`)
+          assert.ok(out.includes('/relocated'), `${name} must name the relocated root`)
+        })
+
+        it(`${name} omits it entirely on a default install`, () => {
+          // POSITIVE CONTROL for the case above, and the compatibility promise:
+          // an install with nothing relocated must produce the same definition
+          // it always did, with no empty/dangling entry.
+          const out = gen({ ...cfg, configDirEnv: '' })
+          assert.ok(!out.includes('CHROXY_CONFIG_DIR'), `${name} must not emit an empty entry\n${out}`)
+        })
+      }
+
+      it('the plist stays well-formed XML with the entry present', () => {
+        const plist = generateLaunchdPlist({ ...cfg, configDirEnv: '/relocated' })
+        // Every <key> in the dict must be followed by a <string> value.
+        const envBlock = plist.split('<key>EnvironmentVariables</key>')[1].split('</dict>')[0]
+        const keys = (envBlock.match(/<key>/g) || []).length
+        const strings = (envBlock.match(/<string>/g) || []).length
+        assert.equal(keys, strings, `unbalanced key/string pairs in EnvironmentVariables:\n${envBlock}`)
+        assert.equal(keys, 3, 'expected PATH, CHROXY_DAEMON and CHROXY_CONFIG_DIR')
+      })
+
+      it('escapes an XML-hostile path in the plist', () => {
+        const plist = generateLaunchdPlist({ ...cfg, configDirEnv: '/tmp/a&b' })
+        assert.ok(plist.includes('/tmp/a&amp;b'), 'the config dir must go through escapeXml')
+        assert.ok(!plist.includes('<string>/tmp/a&b</string>'), 'raw ampersand would break the plist')
+      })
+
+      it('shell-quotes the path in the POSIX wrapper', () => {
+        const wrapper = generateServiceWrapper({ ...cfg, configDirEnv: "/tmp/it's here" })
+        assert.match(wrapper, /export CHROXY_CONFIG_DIR='\/tmp\/it'/, 'must reuse the wrapper quoting helper')
+      })
+    })
+
     it('log dir falls back to ~/.chroxy/logs when CHROXY_CONFIG_DIR is unset', () => {
       // The positive control for the case above: without it, "the log dir
       // equals <relocated>/logs" would also pass for a resolver that had

--- a/packages/server/tests/service.test.js
+++ b/packages/server/tests/service.test.js
@@ -2,7 +2,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { tmpdir } from 'os'
+import { tmpdir, homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import {
@@ -60,12 +60,18 @@ describe('service', () => {
   })
 
   describe('getServicePaths()', () => {
+    // Since #7052 the log dir is `configPath('logs')`, so it follows
+    // CHROXY_CONFIG_DIR — which the suite-wide sandbox (tests/_setup.mjs)
+    // points at a tmp dir. Derived from the env here rather than hardcoded to
+    // `.chroxy/logs`, which only held while the path ignored the override.
+    const expectedLogDir = () => join(process.env.CHROXY_CONFIG_DIR, 'logs')
+
     it('returns launchd paths on darwin', { skip: posixOnly }, () => {
       const paths = getServicePaths('darwin')
       assert.equal(paths.type, 'launchd')
       assert.ok(paths.plistPath.includes('LaunchAgents'))
       assert.ok(paths.plistPath.includes('com.chroxy.server.plist'))
-      assert.ok(paths.logDir.includes('.chroxy/logs'))
+      assert.equal(paths.logDir, expectedLogDir())
     })
 
     it('returns systemd paths on linux', { skip: posixOnly }, () => {
@@ -73,19 +79,46 @@ describe('service', () => {
       assert.equal(paths.type, 'systemd')
       assert.ok(paths.unitPath.includes('systemd/user'))
       assert.ok(paths.unitPath.includes('chroxy.service'))
-      assert.ok(paths.logDir.includes('.chroxy/logs'))
+      assert.equal(paths.logDir, expectedLogDir())
     })
 
     it('returns windows info on win32', () => {
       const paths = getServicePaths('win32')
       assert.equal(paths.type, 'windows')
-      assert.ok(paths.logDir.includes('.chroxy'))
+      assert.equal(paths.logDir, expectedLogDir())
     })
 
     it('throws on unsupported platform', () => {
       assert.throws(() => getServicePaths('freebsd'), {
         message: /not supported/i,
       })
+    })
+
+    // #7052 — an installed service writes its logs under the config dir the
+    // operator chose. Before the migration this was hardcoded to ~/.chroxy/logs,
+    // so a relocated daemon logged somewhere its own config dir did not mention.
+    it('log dir follows CHROXY_CONFIG_DIR', () => {
+      const prev = process.env.CHROXY_CONFIG_DIR
+      const relocated = join(tmpdir(), 'chroxy-svc-logdir-fixture')
+      try {
+        process.env.CHROXY_CONFIG_DIR = relocated
+        assert.equal(getServicePaths('darwin').logDir, join(relocated, 'logs'))
+      } finally {
+        process.env.CHROXY_CONFIG_DIR = prev
+      }
+    })
+
+    it('log dir falls back to ~/.chroxy/logs when CHROXY_CONFIG_DIR is unset', () => {
+      // The positive control for the case above: without it, "the log dir
+      // equals <relocated>/logs" would also pass for a resolver that had
+      // stopped consulting the home fallback entirely.
+      const prev = process.env.CHROXY_CONFIG_DIR
+      try {
+        delete process.env.CHROXY_CONFIG_DIR
+        assert.equal(getServicePaths('darwin').logDir, join(homedir(), '.chroxy', 'logs'))
+      } finally {
+        process.env.CHROXY_CONFIG_DIR = prev
+      }
     })
   })
 

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -199,13 +199,21 @@ describe('skills-loader', () => {
       let fakeHome
       let originalHome
       let originalUserprofile
+      let originalConfigDir
 
       beforeEach(() => {
         fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-home-'))
         originalHome = process.env.HOME
         originalUserprofile = process.env.USERPROFILE
+        originalConfigDir = process.env.CHROXY_CONFIG_DIR
         process.env.HOME = fakeHome
         process.env.USERPROFILE = fakeHome
+        // Since #7052 the GLOBAL skills dir is `configPath('skills')`, i.e.
+        // CHROXY_CONFIG_DIR-rooted rather than always `~/.chroxy/skills`. The
+        // suite-wide sandbox (tests/_setup.mjs) points that at its own tmp dir,
+        // so patching HOME alone no longer moves the global dir — point both at
+        // the fake home, which is what "the global dir lives here" now means.
+        process.env.CHROXY_CONFIG_DIR = join(fakeHome, '.chroxy')
       })
 
       afterEach(() => {
@@ -213,6 +221,8 @@ describe('skills-loader', () => {
         else process.env.HOME = originalHome
         if (originalUserprofile === undefined) delete process.env.USERPROFILE
         else process.env.USERPROFILE = originalUserprofile
+        if (originalConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+        else process.env.CHROXY_CONFIG_DIR = originalConfigDir
         rmSync(fakeHome, { recursive: true, force: true })
       })
 

--- a/packages/server/tests/skills-loader.test.js
+++ b/packages/server/tests/skills-loader.test.js
@@ -192,7 +192,7 @@ describe('skills-loader', () => {
     // ---------------------------------------------------------------------
     // #3088: walk-up must not return ~/.chroxy/skills (the global tier) as
     // a repo overlay. We point HOME at a temp dir and re-import the module
-    // with a unique query string so DEFAULT_SKILLS_DIR / homedir() pick up
+    // with a unique query string so defaultSkillsDir() / homedir() pick up
     // the fake home.
     // ---------------------------------------------------------------------
     describe('home-directory boundary (#3088)', () => {
@@ -224,8 +224,8 @@ describe('skills-loader', () => {
         // evaluation against the patched HOME env var.
         const mod = await import(`../src/skills-loader.js?home=${encodeURIComponent(fakeHome)}`)
 
-        // Sanity: DEFAULT_SKILLS_DIR should now resolve under fakeHome.
-        assert.equal(mod.DEFAULT_SKILLS_DIR, join(fakeHome, '.chroxy', 'skills'))
+        // Sanity: defaultSkillsDir() should now resolve under fakeHome.
+        assert.equal(mod.defaultSkillsDir(), join(fakeHome, '.chroxy', 'skills'))
 
         // Session cwd is under $HOME but in a directory with no repo overlay.
         const sessionCwd = join(fakeHome, 'scratch', 'project')
@@ -250,7 +250,7 @@ describe('skills-loader', () => {
         )
       })
 
-      it('refuses to return DEFAULT_SKILLS_DIR even when cwd is exactly $HOME', async () => {
+      it('refuses to return defaultSkillsDir() even when cwd is exactly $HOME', async () => {
         mkdirSync(join(fakeHome, '.chroxy', 'skills'), { recursive: true })
         const mod = await import(`../src/skills-loader.js?home3=${encodeURIComponent(fakeHome)}`)
 

--- a/packages/server/tests/spawn-env-credential-store.test.js
+++ b/packages/server/tests/spawn-env-credential-store.test.js
@@ -6,6 +6,10 @@ import { join } from 'node:path'
 import { buildSpawnEnv } from '../src/utils/spawn-env.js'
 import { setStoredCredential } from '../src/credential-store.js'
 
+// #7052 — the sandbox config dir this process started with. Tests below
+// relocate it alongside HOME and restore it here on teardown.
+const __sandboxConfigDir = process.env.CHROXY_CONFIG_DIR
+
 /**
  * #3855: verify that buildSpawnEnv injects stored credentials when the
  * operator's shell has NOT exported the env var — the Tauri/launchd GUI-launch
@@ -23,6 +27,7 @@ describe('buildSpawnEnv — credential-store fallback (#3855)', () => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-spawn-cred-test-'))
     originalHome = process.env.HOME
     process.env.HOME = tmpHome
+    process.env.CHROXY_CONFIG_DIR = join(tmpHome, '.chroxy')
     for (const k of CRED_ENV_VARS) {
       savedEnv[k] = process.env[k]
       delete process.env[k]
@@ -32,6 +37,7 @@ describe('buildSpawnEnv — credential-store fallback (#3855)', () => {
   afterEach(() => {
     if (originalHome) process.env.HOME = originalHome
     else delete process.env.HOME
+    process.env.CHROXY_CONFIG_DIR = __sandboxConfigDir
     for (const k of CRED_ENV_VARS) {
       if (savedEnv[k] === undefined) delete process.env[k]
       else process.env[k] = savedEnv[k]

--- a/packages/server/tests/supervisor-push-config.test.js
+++ b/packages/server/tests/supervisor-push-config.test.js
@@ -98,12 +98,12 @@ if (typeof mock.module !== 'function') {
 
       // statePath must match the child server's default so message-id
       // convergence keeps working (both processes edit the same embed).
-      assert.equal(opts.discord?.statePath, join(homedir(), '.chroxy', 'discord-webhook-state.json'))
+      assert.equal(opts.discord?.statePath, join(process.env.CHROXY_CONFIG_DIR, 'discord-webhook-state.json'))
 
       // prefsPath must mirror server-cli.js too — otherwise the per-send
       // manager runs with default prefs and supervisor notifications ignore
       // the operator's category mutes / quiet hours (both sinks gate on prefs).
-      assert.equal(opts.prefsPath, join(homedir(), '.chroxy', 'notification-prefs.json'))
+      assert.equal(opts.prefsPath, join(process.env.CHROXY_CONFIG_DIR, 'notification-prefs.json'))
 
       assert.deepEqual(sendCalls, [
         { category: 'activity_error', title: 'Chroxy server is down', body: 'body' },
@@ -136,7 +136,7 @@ if (typeof mock.module !== 'function') {
 
       assert.equal(constructions.length, 1)
       const { opts } = constructions[0]
-      assert.equal(opts.discord?.statePath, join(homedir(), '.chroxy', 'discord-webhook-state.json'))
+      assert.equal(opts.discord?.statePath, join(process.env.CHROXY_CONFIG_DIR, 'discord-webhook-state.json'))
     })
 
     it('destroys the per-send PushManager even when send() rejects', async () => {


### PR DESCRIPTION
Closes #7052.

`CHROXY_CONFIG_DIR` relocated only half the daemon's state. This routes every
`~/.chroxy` resolution in `packages/server` through one accessor that reads the
environment per call, and adds a CI gate so the split cannot reopen.

## Why it only half-worked

A module-scope `const` evaluates at *import*, so pointing one at an env-reading
expression changes nothing — the binding is still not consulted at the moment
that matters. The subtle case is a default parameter:

```js
export function readRepos(p = DEFAULT_CONFIG_PATH) {}   // frozen
export function readRepos(p = defaultConfigPath()) {}   // live
```

That one fact produced both halves of the split: 16 constants stayed hardcoded
and ignored the override, and 16 other modules grew their own inline
`process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')` copy *because* the
shared constant could not be made to work.

## What changed

59 sites across 53 modules, in three shapes:

| Shape | Count | Notes |
|---|---|---|
| In-function `join(homedir(), '.chroxy', …)` | 27 | Ignored the override outright |
| Inline resolver copies | 16 | Each correct alone, each a drift risk |
| Module-scope constants | **18** | Two more than scoping predicted |

The two extra were `doctor.js`'s `CONFIG_FILE` and `byok-compose-state.js`'s
`DEFAULT_BYOK_COMPOSE_STATE_PATH`. Both were counted as healthy because they
read the env — they read it once, at import, so they were as frozen as the
hardcoded ones. Each constant is now a function; the 9 exported ones moved their
call sites with them.

## The scheduler resolver moved, as its doc block said it must

`cli/schedule-cmd.js` deliberately stayed home-rooted so the CLI and the running
scheduler would agree, and predicted that migrating the session-state family
would turn its drift guard red and require this change. It did. Both tests that
pinned the old behaviour are inverted, and both gained the positive control they
were missing — that the path still falls back to `$HOME/.chroxy` when the env var
is unset. Without it, "the registry followed `CHROXY_CONFIG_DIR`" would also pass
for a resolver that had simply stopped writing under `$HOME`.

`session-manager.js` now exports `defaultStateFile()` so that guard asserts
agreement behaviourally instead of grepping `session-manager.js`'s source for a
spelling.

## The guard, and the hole it nearly had

`scripts/lint-config-dir.mjs` bans both shapes outside `config-dir.js`, ratcheted
by a baseline that burns down from 40 files to zero in this PR.

Its first version had a coverage hole worth calling out: it only looked for
`join(homedir(), '.chroxy')`. But `const P = configPath('session-state.json')` at
module scope *uses the accessor* and is still frozen at import — so the migration
would have looked complete while half the defect survived, with the lint
reporting those files clean. The `module-scope-capture` rule closes that, and it
is what produced the true count of 18.

## Verification

- **Accessor tests run against a `const` mutant**: 11 of 12 fail, including all
  six call-time controls.
- **Every lint exemption has a positive control** — the same source without the
  thing meant to exempt it, asserted to fail. 25 cases.
- **All 53 migrated modules smoke-imported** — this caught a TDZ bug where a
  local `const configDir = configDir()` shadowed the import.
- **Differential test run rather than assumption**: the affected files fail 3
  tests on `fa43f83ae` and the same 3 on this branch, no others. Both survivors
  are environmental (two fetch a real `:8765`, which a live daemon answers; one
  needs `OPENAI_API_KEY`).
- eslint clean; all five existing custom server lints green.

## Also updated

16 test assertions across three suites encoded the old behaviour and were
invisible until the paths started honouring the override — `tests/_setup.mjs`
relocates `CHROXY_CONFIG_DIR` suite-wide, so every newly-following path moved out
from under a fixture that had planted its file at `$HOME/.chroxy`.