### PR TITLE
feat(server): detect state stranded by a CHROXY_CONFIG_DIR relocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   ```bash
   # with CHROXY_CONFIG_DIR set to your chosen directory
+  chroxy config-dir migrate --yes
+  ```
+
+  or by hand, which does the same thing:
+
+  ```bash
   mkdir -p "$CHROXY_CONFIG_DIR"
   cp -a ~/.chroxy/. "$CHROXY_CONFIG_DIR"/
   ```
@@ -56,6 +62,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `chroxy service install` now bakes `CHROXY_CONFIG_DIR` into the generated
   launchd plist / systemd unit / Windows wrapper when it is set, so the
   installed service and your shell agree on one root.
+
+### Added
+
+- **Stranded state is now detected and reported, and `chroxy config-dir`
+  migrates it (#7240).** The relocation above is silent by construction: the
+  daemon simply reads a different directory and finds nothing. Three things now
+  surface it.
+
+  The daemon **warns at startup**, naming every entry still at `~/.chroxy` and
+  the remedy. The warning is emitted before the token check, which matters: with
+  a stranded `config.json` on a keychain-less host the daemon exits at that check,
+  and the "config/state root" line added in #7052 comes later in startup — so the
+  operator previously saw `Run 'chroxy init' first` with no indication that a
+  relocation caused it. That message now names the real cause and, in this case,
+  explicitly says not to run `chroxy init`.
+
+  **`chroxy doctor`** gains a `Config/state root` check reporting the resolved
+  root and anything stranded. Its `Config` check no longer answers a missing
+  `config.json` with "run `chroxy init` to create" when the file is merely
+  stranded — that advice mints a fresh token and forces every device to re-pair.
+
+  **`chroxy config-dir status`** lists what is stranded; **`chroxy config-dir
+  migrate --yes`** copies it forward, preserving `0600` file and `0700` directory
+  modes, never overwriting anything already in the destination, and leaving the
+  originals in place.
+
+  The migration is **opt-in rather than automatic, deliberately.** The daemon
+  cannot distinguish "operator just relocated and wants their state" from
+  "operator pointed at a deliberately clean root" — a container, a per-project
+  directory — and copying an identity key and credentials into a directory that
+  may be shared, synced or bind-mounted is the operator's security decision to
+  make, not a side effect of an upgrade.
+
+  What is reported as stranded is **computed** — every entry present at
+  `~/.chroxy` and absent at the resolved root — rather than compared against a
+  list of known state files, so a state file added later is covered without
+  anything to update. Runtime-ephemeral entries (`supervisor.pid`,
+  `update.lock`) are excluded from both the report and the copy.
 
 ## [0.11.0] - 2026-08-15
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,6 +149,26 @@ Or set the token manually in `~/.chroxy/config.json`:
 { "apiToken": "your-token-here" }
 ```
 
+**First, check whether you set `CHROXY_CONFIG_DIR`.** If you did, `chroxy init`
+is the wrong fix and will cost you every paired device: it mints a *brand new*
+token, and the old one is what your devices are paired with. Since #7052 the
+variable relocates all daemon state, so a `config.json` still sitting at
+`~/.chroxy` is simply not read, and on a host without an OS keychain that reads
+as "no token configured".
+
+The daemon names this case explicitly in the error, and `chroxy doctor` reports
+it as a `Config/state root` warning. To confirm and fix:
+
+```bash
+chroxy config-dir status         # what is stranded, and where
+chroxy config-dir migrate --yes  # copy it forward (never overwrites)
+```
+
+The same relocation silently strands `server-identity.json`. On a keychain-less
+host that makes the daemon mint a **new identity key**, which pinned clients
+report as a possible MITM — migrating before first start avoids it; if you have
+already hit it, re-pair.
+
 ## 2. App can't connect (timeout or "connection failed")
 
 **Diagnostic steps:**

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -12,6 +12,7 @@ import { createRequire } from 'module'
 import { registerInitCommand } from './cli/init-cmd.js'
 import { registerServerCommands } from './cli/server-cmd.js'
 import { registerConfigCommand } from './cli/config-cmd.js'
+import { registerConfigDirCommand } from './cli/config-dir-cmd.js'
 import { registerTunnelCommand } from './cli/tunnel-cmd.js'
 import { registerDoctorCommand } from './cli/doctor-cmd.js'
 import { registerDeployCommand } from './cli/deploy-cmd.js'
@@ -43,6 +44,7 @@ program
 registerInitCommand(program)
 registerServerCommands(program)
 registerConfigCommand(program)
+registerConfigDirCommand(program)
 registerTunnelCommand(program)
 registerDoctorCommand(program)
 registerDeployCommand(program)

--- a/packages/server/src/cli/config-dir-cmd.js
+++ b/packages/server/src/cli/config-dir-cmd.js
@@ -1,0 +1,154 @@
+// `chroxy config-dir` — inspect and migrate the daemon's config/state root (#7240).
+//
+// #7052 made CHROXY_CONFIG_DIR relocate ALL daemon state. Anyone who already set
+// it has ~20 files silently stranded at ~/.chroxy on upgrade. The daemon warns
+// at startup and `chroxy doctor` reports it, but neither moves anything: copying
+// an identity key and credentials into a directory the operator may have pointed
+// at a shared, synced or bind-mounted volume is the operator's security decision,
+// and the daemon cannot tell a fresh relocation from a deliberately clean root.
+// So the copy lives here, behind an explicit command.
+
+import { detectStrandedState, migrateStrandedState } from '../config-dir-migration.js'
+
+/**
+ * `chroxy config-dir status` — report the resolved root and anything stranded.
+ *
+ * @param {object} [deps] Injected seams: `write`, `detect`.
+ * @returns {{ relocated: boolean, stranded: string[] }}
+ */
+export function runConfigDirStatus(deps = {}) {
+  const out = deps.write || console.log
+  const detect = deps.detect || detectStrandedState
+  const d = detect()
+
+  out(`Config/state root: ${d.target}${d.relocated ? ' (from CHROXY_CONFIG_DIR)' : ''}`)
+
+  if (!d.relocated) {
+    out('Not relocated — nothing can be stranded.')
+    return { relocated: false, stranded: [] }
+  }
+  if (d.unreadable) {
+    out(`Could not check ${d.source} for stranded state: ${d.unreadable}`)
+    return { relocated: true, stranded: [] }
+  }
+  if (d.stranded.length === 0) {
+    out(`No state stranded at ${d.source}.`)
+    return { relocated: true, stranded: [] }
+  }
+
+  out('')
+  out(`${d.stranded.length} state ${d.stranded.length === 1 ? 'entry is' : 'entries are'} still at ${d.source}:`)
+  for (const name of d.stranded) {
+    out(`  ${name}${d.highConsequence.includes(name) ? '   <- high consequence' : ''}`)
+  }
+  out('')
+  out('Copy them forward with:  chroxy config-dir migrate --yes')
+  return { relocated: true, stranded: d.stranded }
+}
+
+/**
+ * `chroxy config-dir migrate` — copy stranded entries into the resolved root.
+ *
+ * Consequential (it moves secrets across a directory boundary the operator drew),
+ * so it requires an explicit `--yes`; without it the command only explains.
+ * Never overwrites: only entries absent from the target are copied.
+ *
+ * @param {{ yes?: boolean }} options
+ * @param {object} [deps] Injected seams: `write`, `detect`, `migrate`.
+ * @returns {{ migrated: boolean, result: object|null }}
+ */
+export function runConfigDirMigrate(options = {}, deps = {}) {
+  const out = deps.write || console.log
+  const detect = deps.detect || detectStrandedState
+  const migrate = deps.migrate || migrateStrandedState
+  const d = detect()
+
+  if (!d.relocated) {
+    out(`Config/state root is ${d.target} — not relocated, so nothing can be stranded.`)
+    return { migrated: false, result: null }
+  }
+  if (d.unreadable) {
+    out(`Could not read ${d.source}: ${d.unreadable}`)
+    return { migrated: false, result: null }
+  }
+  if (d.stranded.length === 0) {
+    out(`No state stranded at ${d.source} — ${d.target} is already up to date.`)
+    return { migrated: false, result: null }
+  }
+
+  if (!options.yes) {
+    out(
+      [
+        'chroxy config-dir migrate — copy stranded daemon state into the relocated root.',
+        '',
+        `  from: ${d.source}`,
+        `  to:   ${d.target}`,
+        '',
+        `Would copy ${d.stranded.length} ${d.stranded.length === 1 ? 'entry' : 'entries'}:`,
+        ...d.stranded.map((n) => `  ${n}${d.highConsequence.includes(n) ? '   <- high consequence' : ''}`),
+        '',
+        'Nothing already present in the destination is overwritten, and the source is',
+        'left in place — this copies, it does not move.',
+        '',
+        'Note this copies secrets (identity key, credentials, API token) into the',
+        'destination. If that directory is shared, synced or bind-mounted into a',
+        'container, decide whether you want them there before proceeding.',
+        '',
+        'Re-run with --yes to proceed:',
+        '  chroxy config-dir migrate --yes',
+      ].join('\n'),
+    )
+    return { migrated: false, result: null }
+  }
+
+  const result = migrate({ detection: d })
+
+  if (result.copied.length > 0) {
+    out(`Copied ${result.copied.length} ${result.copied.length === 1 ? 'entry' : 'entries'} to ${result.target}:`)
+    for (const name of result.copied) out(`  ${name}`)
+  }
+  if (result.failed.length > 0) {
+    out('')
+    out(`${result.failed.length} ${result.failed.length === 1 ? 'entry' : 'entries'} could NOT be copied:`)
+    for (const f of result.failed) out(`  ${f.name}: ${f.error}`)
+  }
+  out('')
+  out(`The original files are still at ${result.source} — remove them once the daemon`)
+  out('has restarted successfully against the new root.')
+
+  return { migrated: result.copied.length > 0, result }
+}
+
+export function registerConfigDirCommand(program) {
+  const configDirCmd = program
+    .command('config-dir')
+    .description('Inspect and migrate the daemon\'s config/state root (CHROXY_CONFIG_DIR)')
+
+  configDirCmd
+    .command('status')
+    .description('Show the resolved config/state root and any state stranded at ~/.chroxy')
+    .action(() => {
+      try {
+        runConfigDirStatus()
+      } catch (err) {
+        console.error(`config-dir status failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  configDirCmd
+    .command('migrate')
+    .description('Copy state stranded at ~/.chroxy into the relocated root (never overwrites)')
+    .option('--yes', 'Confirm the copy (without this, the command only explains what it would do)')
+    .action((options) => {
+      try {
+        const { result } = runConfigDirMigrate(options)
+        // A partial copy is a failure the caller must be able to see — a script
+        // that ignores it would report a migration that only half happened.
+        if (result?.failed.length > 0) process.exitCode = 1
+      } catch (err) {
+        console.error(`config-dir migrate failed: ${err.message}`)
+        process.exitCode = 1
+      }
+    })
+}

--- a/packages/server/src/config-dir-migration.js
+++ b/packages/server/src/config-dir-migration.js
@@ -1,0 +1,261 @@
+import { chmodSync, cpSync, existsSync, lstatSync, mkdirSync, readdirSync, statSync } from 'fs'
+import { join, resolve } from 'path'
+import { configDir, defaultConfigDir } from './config-dir.js'
+
+/**
+ * #7240 — daemon state left behind at `~/.chroxy` when `CHROXY_CONFIG_DIR`
+ * points somewhere else.
+ *
+ * #7052 made the variable relocate ALL daemon state. For anyone who already set
+ * it, that means roughly twenty files stop being read on upgrade — and none of
+ * them announce it. Two are sharp: an unmoved `server-identity.json` on a
+ * keychain-less host makes the daemon mint a NEW identity key (pinned clients
+ * report a possible MITM, and #5615's fail-safe cannot fire because
+ * absent-everywhere is indistinguishable from first run), and an unmoved
+ * `config.json` loses the apiToken, after which `chroxy init` mints a fresh one
+ * and every paired device has to re-pair.
+ *
+ * **The stranded set is derived, never enumerated.** The obvious shape is a
+ * const array of the ~20 known state filenames, and it is the repo's documented
+ * false-safety pattern (`docs/false-safety-guards.md`): a hardcoded list next to
+ * a set that grows. The next module to add a state file would not be in it, and
+ * the check would report a clean tree while silently missing that file — the
+ * exact failure that #7192/#7197 were filed for. So the set is computed instead:
+ * every entry present under the default root and absent under the resolved one.
+ * A new state file is covered the day it is written, with no list to update.
+ *
+ * The one list here is {@link EPHEMERAL_ENTRIES}, and it is deliberately safe to
+ * get wrong: both detection and migration consult it, so they can never disagree,
+ * and a missing name means a lock file gets reported and copied — not that state
+ * goes silently unmigrated.
+ *
+ * Policy (decided for #7240): **warn loudly, copy on explicit request.** The
+ * daemon cannot distinguish "operator just relocated and wants their state" from
+ * "operator pointed at a deliberately clean root" — a container, a per-project
+ * dir — and copying an identity key and credentials into a directory that may be
+ * shared, synced or bind-mounted is the operator's security decision to make.
+ * The cited precedents (`maybeEncryptCredentialsAtRest`, `migrateToken`) upgrade
+ * a file in place at a path the daemon already owns; this crosses a boundary the
+ * operator explicitly drew. `chroxy config-dir migrate` performs the copy.
+ */
+
+/**
+ * Runtime-ephemeral entries: never reported as stranded, never copied.
+ *
+ * `supervisor.pid` and `update.lock` describe a process that ran against the
+ * OLD root. Copying either forward hands the new root a PID/lock it does not
+ * own; leaving them out of detection is what stops the startup warning
+ * becoming permanent noise once everything real has been migrated.
+ */
+export const EPHEMERAL_ENTRIES = new Set(['supervisor.pid', 'update.lock'])
+
+/**
+ * The two entries whose absence is actively destructive rather than merely
+ * inconvenient, plus the credential store.
+ *
+ * Used ONLY to order and emphasise the warning — never to gate detection or the
+ * copy. If this drifts, the message is less pointed; nothing goes unreported.
+ */
+export const HIGH_CONSEQUENCE_ENTRIES = ['config.json', 'server-identity.json', 'credentials.json']
+
+/**
+ * Do two paths name the same directory?
+ *
+ * Compared by device + inode, not by string. A string compare has to get
+ * symlinks, bind mounts, case-insensitive filesystems, trailing slashes and
+ * `..` spellings all right at once, and the repo has been bitten by exactly
+ * that class before (#6928's separator handling, and a case-insensitive
+ * `~/Projects` path that compared unequal to its own realpath). dev+ino is
+ * true identity and sidesteps every one of them.
+ *
+ * Windows reports `ino` as 0 on some filesystems, so fall back to a normalized
+ * (case-insensitive there) path compare when either inode is unusable.
+ */
+function sameDir(a, b) {
+  try {
+    const sa = statSync(a)
+    const sb = statSync(b)
+    if (sa.ino && sb.ino) return sa.dev === sb.dev && sa.ino === sb.ino
+  } catch {
+    // One side is missing or unreadable — fall through to the path compare,
+    // which correctly reports two different paths as different.
+  }
+  const na = resolve(a)
+  const nb = resolve(b)
+  return process.platform === 'win32' ? na.toLowerCase() === nb.toLowerCase() : na === nb
+}
+
+/**
+ * @typedef {object} StrandedState
+ * @property {boolean} relocated  The resolved root differs from `~/.chroxy`.
+ * @property {string}  source     The default root that may hold stranded state.
+ * @property {string}  target     The root the daemon actually reads.
+ * @property {string[]} stranded  Entry names present in source, absent in target (sorted).
+ * @property {string[]} highConsequence  The subset of `stranded` that is destructive to lose.
+ * @property {string|null} unreadable  Why the source could not be listed, if it could not be.
+ */
+
+/**
+ * Detect state stranded at the default root.
+ *
+ * Never throws: an unreadable source is reported via `unreadable` so callers on
+ * the boot path can degrade rather than fail.
+ *
+ * @param {{ source?: string, target?: string }} [opts] Injection seams for tests.
+ * @returns {StrandedState}
+ */
+export function detectStrandedState({ source = defaultConfigDir(), target = configDir() } = {}) {
+  const result = {
+    relocated: false,
+    source,
+    target,
+    stranded: [],
+    highConsequence: [],
+    unreadable: null,
+  }
+
+  // Covers every not-relocated case at once: the variable unset, set empty, set
+  // to a relative path (config-dir.js refuses those back to the default), or set
+  // to `~/.chroxy` itself by a different spelling or through a symlink.
+  if (sameDir(source, target)) return result
+  result.relocated = true
+
+  if (!existsSync(source)) return result
+
+  let entries
+  try {
+    entries = readdirSync(source)
+  } catch (err) {
+    result.unreadable = err.message
+    return result
+  }
+
+  for (const name of entries) {
+    if (EPHEMERAL_ENTRIES.has(name)) continue
+    if (!existsSync(join(target, name))) result.stranded.push(name)
+  }
+  result.stranded.sort()
+  result.highConsequence = HIGH_CONSEQUENCE_ENTRIES.filter((n) => result.stranded.includes(n))
+  return result
+}
+
+/**
+ * Build the startup / doctor warning for a detection result.
+ *
+ * @param {StrandedState} detection
+ * @returns {string[]} Lines, or empty when there is nothing to say.
+ */
+export function formatStrandedWarning(detection) {
+  if (!detection.relocated) return []
+  if (detection.unreadable) {
+    return [`Could not check ${detection.source} for stranded state: ${detection.unreadable}`]
+  }
+  if (detection.stranded.length === 0) return []
+
+  const { stranded, source, target } = detection
+  const lines = [
+    `CHROXY_CONFIG_DIR is set, but ${stranded.length} state `
+      + `${stranded.length === 1 ? 'entry is' : 'entries are'} still at ${source}:`,
+  ]
+  // Three per line keeps the longest names readable in a terminal.
+  for (let i = 0; i < stranded.length; i += 3) {
+    lines.push(`  ${stranded.slice(i, i + 3).join('  ')}`)
+  }
+  lines.push('')
+  lines.push(`The daemon is reading ${target} and will NOT find them.`)
+
+  if (detection.highConsequence.includes('config.json')) {
+    lines.push('Do NOT run \'chroxy init\' — it mints a fresh token and forces every device to re-pair.')
+  }
+  if (detection.highConsequence.includes('server-identity.json')) {
+    lines.push('An unmoved server-identity.json makes the daemon mint a new identity key,')
+    lines.push('which pinned clients report as a possible MITM.')
+  }
+
+  lines.push('')
+  lines.push('Copy them once:  chroxy config-dir migrate')
+  lines.push(`             or: cp -a ${source}/. ${target}/`)
+  return lines
+}
+
+/**
+ * Mirror source directory modes onto a freshly copied tree.
+ *
+ * `cpSync` preserves FILE modes (a 0600 credentials.json lands 0600) but creates
+ * directories at the default 0755 — so `skills/` at 0700 would widen on copy.
+ * Verified, not assumed: the behaviour is asserted in
+ * `tests/config-dir-migration.test.js`.
+ *
+ * Symlinks are skipped rather than followed: `cpSync` copies them as symlinks,
+ * and `chmodSync` follows them, which would otherwise re-mode a file outside the
+ * tree entirely.
+ */
+function mirrorDirectoryModes(srcPath, destPath) {
+  let st
+  try {
+    st = lstatSync(srcPath)
+  } catch {
+    return
+  }
+  if (!st.isDirectory()) return
+  try {
+    chmodSync(destPath, st.mode & 0o777)
+  } catch {
+    // Best-effort: a mode we cannot set is not a reason to abort a copy that
+    // otherwise succeeded. The copied content is already in place.
+  }
+  let entries
+  try {
+    entries = readdirSync(srcPath)
+  } catch {
+    return
+  }
+  for (const name of entries) mirrorDirectoryModes(join(srcPath, name), join(destPath, name))
+}
+
+/**
+ * Copy stranded entries from the default root into the resolved one.
+ *
+ * **Never overwrites.** Only entries absent from the target are copied, which is
+ * what {@link detectStrandedState} already computes, so a partially-migrated
+ * root converges instead of clobbering.
+ *
+ * @param {{ source?: string, target?: string, detection?: StrandedState }} [opts]
+ * @returns {{ relocated: boolean, copied: string[], failed: Array<{ name: string, error: string }>, source: string, target: string, reason?: string }}
+ */
+export function migrateStrandedState({ source, target, detection } = {}) {
+  const det = detection ?? detectStrandedState({
+    ...(source === undefined ? {} : { source }),
+    ...(target === undefined ? {} : { target }),
+  })
+  const out = { relocated: det.relocated, copied: [], failed: [], source: det.source, target: det.target }
+
+  if (!det.relocated) return { ...out, reason: 'not-relocated' }
+  if (det.unreadable) return { ...out, reason: `source-unreadable: ${det.unreadable}` }
+  if (det.stranded.length === 0) return { ...out, reason: 'nothing-stranded' }
+
+  // mkdir's `mode` is masked by the umask, so chmod explicitly afterwards —
+  // the same belt-and-braces logger.js uses for the log directory.
+  try {
+    mkdirSync(det.target, { recursive: true, mode: 0o700 })
+    chmodSync(det.target, 0o700)
+  } catch (err) {
+    return { ...out, reason: `target-unwritable: ${err.message}` }
+  }
+
+  for (const name of det.stranded) {
+    const from = join(det.source, name)
+    const to = join(det.target, name)
+    try {
+      // errorOnExist + force:false is a second lock on "never overwrite": the
+      // detection already excluded anything present in the target, but the two
+      // reads are not atomic and the copy must lose that race, not win it.
+      cpSync(from, to, { recursive: true, preserveTimestamps: true, errorOnExist: true, force: false })
+      mirrorDirectoryModes(from, to)
+      out.copied.push(name)
+    } catch (err) {
+      out.failed.push({ name, error: err.message })
+    }
+  }
+  return out
+}

--- a/packages/server/src/config-dir-migration.js
+++ b/packages/server/src/config-dir-migration.js
@@ -140,6 +140,19 @@ export function detectStrandedState({ source = defaultConfigDir(), target = conf
 }
 
 /**
+ * POSIX-quote a path for a shell command we print for the operator to paste.
+ *
+ * The `cp -a` hint below is a command a human copies and runs, so an unquoted
+ * path with a space runs a DIFFERENT command — `cp -a /srv/my state/. /dst/`
+ * copies two wrong sources — and one with a shell metacharacter is worse.
+ * Single-quoting is the only form that neutralises everything; an embedded
+ * single quote is closed, escaped and reopened, which is the standard idiom.
+ */
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`
+}
+
+/**
  * Build the startup / doctor warning for a detection result.
  *
  * @param {StrandedState} detection
@@ -174,7 +187,7 @@ export function formatStrandedWarning(detection) {
 
   lines.push('')
   lines.push('Copy them once:  chroxy config-dir migrate')
-  lines.push(`             or: cp -a ${source}/. ${target}/`)
+  lines.push(`             or: cp -a ${shellQuote(`${source}/.`)} ${shellQuote(`${target}/`)}`)
   return lines
 }
 

--- a/packages/server/src/config-dir.js
+++ b/packages/server/src/config-dir.js
@@ -40,9 +40,27 @@ let warnedRelative = false
  *
  * @returns {string} Absolute path to the config/state root.
  */
+/**
+ * The root as it resolves with NO override — always `~/.chroxy`.
+ *
+ * Exported because #7240 needs to compare the resolved root against the default
+ * one to find state stranded by a relocation, and that comparison is the single
+ * legitimate reason to want the un-overridden path. Keeping it here means
+ * `join(homedir(), '.chroxy')` still appears in exactly one module, so
+ * `lint-config-dir.mjs` keeps exempting exactly one file and the ratchet stays
+ * honest — a second exemption is how that guard would start to rot.
+ *
+ * Callers who want the root the daemon actually reads want {@link configDir}.
+ *
+ * @returns {string} Absolute path to the default config/state root.
+ */
+export function defaultConfigDir() {
+  return join(homedir(), '.chroxy')
+}
+
 export function configDir() {
   const raw = process.env.CHROXY_CONFIG_DIR
-  if (!raw) return join(homedir(), '.chroxy')
+  if (!raw) return defaultConfigDir()
 
   // A relative value is REFUSED rather than resolved. Resolving it would only
   // make the existing hazard explicit: because the read is per call, every fs
@@ -59,10 +77,10 @@ export function configDir() {
       // eslint-disable-next-line no-console
       console.warn(
         `[config-dir] ignoring CHROXY_CONFIG_DIR=${JSON.stringify(raw)}: not an absolute path. `
-        + `Using ${join(homedir(), '.chroxy')} instead.`,
+        + `Using ${defaultConfigDir()} instead.`,
       )
     }
-    return join(homedir(), '.chroxy')
+    return defaultConfigDir()
   }
   return raw
 }

--- a/packages/server/src/config-dir.js
+++ b/packages/server/src/config-dir.js
@@ -7,6 +7,24 @@ import { join, isAbsolute } from 'path'
 let warnedRelative = false
 
 /**
+ * The root as it resolves with NO override — always `~/.chroxy`.
+ *
+ * Exported because #7240 needs to compare the resolved root against the default
+ * one to find state stranded by a relocation, and that comparison is the single
+ * legitimate reason to want the un-overridden path. Keeping it here means
+ * `join(homedir(), '.chroxy')` still appears in exactly one module, so
+ * `lint-config-dir.mjs` keeps exempting exactly one file and the ratchet stays
+ * honest — a second exemption is how that guard would start to rot.
+ *
+ * Callers who want the root the daemon actually READS want {@link configDir}.
+ *
+ * @returns {string} Absolute path to the default config/state root.
+ */
+export function defaultConfigDir() {
+  return join(homedir(), '.chroxy')
+}
+
+/**
  * The daemon's config/state root — the single resolver for `~/.chroxy`.
  *
  * **This is a function, and that is the whole point (#7052).** The obvious
@@ -40,24 +58,6 @@ let warnedRelative = false
  *
  * @returns {string} Absolute path to the config/state root.
  */
-/**
- * The root as it resolves with NO override — always `~/.chroxy`.
- *
- * Exported because #7240 needs to compare the resolved root against the default
- * one to find state stranded by a relocation, and that comparison is the single
- * legitimate reason to want the un-overridden path. Keeping it here means
- * `join(homedir(), '.chroxy')` still appears in exactly one module, so
- * `lint-config-dir.mjs` keeps exempting exactly one file and the ratchet stays
- * honest — a second exemption is how that guard would start to rot.
- *
- * Callers who want the root the daemon actually reads want {@link configDir}.
- *
- * @returns {string} Absolute path to the default config/state root.
- */
-export function defaultConfigDir() {
-  return join(homedir(), '.chroxy')
-}
-
 export function configDir() {
   const raw = process.env.CHROXY_CONFIG_DIR
   if (!raw) return defaultConfigDir()

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -23,7 +23,7 @@ import {
   PROGRAMMATIC_CREDIT_ERA_START,
 } from './billing-class.js'
 import { checkDependencies } from './utils/check-dependencies.js'
-import { configPath, configDir } from './config-dir.js'
+import { configPath } from './config-dir.js'
 import { detectStrandedState } from './config-dir-migration.js'
 
 // Resolve the server package root (the directory containing package.json
@@ -415,10 +415,14 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
         }
       }
     } else {
+      // Read the root off the detection, NOT from configDir()/process.env
+      // directly: the detection is injectable, and a branch that bypasses the
+      // seam reports something the caller did not ask about — which also makes
+      // this message the one branch a test cannot pin.
       strandedCheck = {
         name: 'Config/state root',
         status: 'pass',
-        message: `${configDir()}${process.env.CHROXY_CONFIG_DIR ? ' (from CHROXY_CONFIG_DIR)' : ''}`,
+        message: `${stranded.target}${stranded.relocated ? ' (from CHROXY_CONFIG_DIR)' : ''}`,
       }
     }
   } catch (err) {

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -23,7 +23,8 @@ import {
   PROGRAMMATIC_CREDIT_ERA_START,
 } from './billing-class.js'
 import { checkDependencies } from './utils/check-dependencies.js'
-import { configPath } from './config-dir.js'
+import { configPath, configDir } from './config-dir.js'
+import { detectStrandedState } from './config-dir-migration.js'
 
 // Resolve the server package root (the directory containing package.json
 // and node_modules) so dependency checks work regardless of where the
@@ -295,7 +296,7 @@ export async function checkTunnelRoutability(deps = {}) {
  *   tests can point the check at a temp directory without mutating process.cwd().
  * @returns {{ checks: Array<{ name: string, status: 'pass'|'warn'|'fail', message: string, provider?: string }>, passed: boolean, providers: string[] }}
  */
-export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR, now = Date.now(), tunnelProbe } = {}) {
+export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgDir = SERVER_PKG_DIR, now = Date.now(), tunnelProbe, detectStranded = detectStrandedState } = {}) {
   const checks = []
 
   // 1. Node.js version
@@ -371,6 +372,59 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
     configCheck = { name: 'Config', status: 'warn', message: `Not found — run 'chroxy init' to create` }
   }
 
+  // #7240 — state stranded at ~/.chroxy by a CHROXY_CONFIG_DIR relocation.
+  // Computed before the Config check is pushed so the "Not found" branch above
+  // can be corrected: recommending `chroxy init` when the real cause is an
+  // unmoved config.json mints a fresh token and forces every device to re-pair,
+  // which is strictly worse than the problem it purports to fix.
+  let strandedCheck = null
+  try {
+    const stranded = detectStranded()
+    if (stranded.unreadable) {
+      strandedCheck = {
+        name: 'Config/state root',
+        status: 'warn',
+        message: `${stranded.target} — could not check ${stranded.source} for stranded state: ${stranded.unreadable}`,
+      }
+    } else if (stranded.stranded.length > 0) {
+      const sharp = stranded.highConsequence.length > 0
+        ? ` (including ${stranded.highConsequence.join(', ')})`
+        : ''
+      // Bounded: a relocated root can strand an arbitrary number of entries and
+      // doctor output is a single line per check. The high-consequence ones are
+      // named separately above, so the truncated tail never hides the sharp cases.
+      const MAX_NAMED = 8
+      const named = stranded.stranded.slice(0, MAX_NAMED).join(', ')
+      const rest = stranded.stranded.length - MAX_NAMED
+      strandedCheck = {
+        name: 'Config/state root',
+        status: 'warn',
+        message: `${stranded.target} (from CHROXY_CONFIG_DIR) — ${stranded.stranded.length} `
+          + `state ${stranded.stranded.length === 1 ? 'entry is' : 'entries are'} still at `
+          + `${stranded.source}${sharp}: ${named}${rest > 0 ? `, and ${rest} more` : ''} `
+          + `— fix: chroxy config-dir migrate`,
+      }
+      if (stranded.highConsequence.includes('config.json')) {
+        configCheck = {
+          name: 'Config',
+          status: 'fail',
+          message: `Not found at ${configPath('config.json')} — it is still at `
+            + `${join(stranded.source, 'config.json')}. Do NOT run 'chroxy init' `
+            + `(it mints a fresh token and forces every device to re-pair) — `
+            + `run 'chroxy config-dir migrate' instead`,
+        }
+      }
+    } else {
+      strandedCheck = {
+        name: 'Config/state root',
+        status: 'pass',
+        message: `${configDir()}${process.env.CHROXY_CONFIG_DIR ? ' (from CHROXY_CONFIG_DIR)' : ''}`,
+      }
+    }
+  } catch (err) {
+    strandedCheck = { name: 'Config/state root', status: 'warn', message: `Check failed: ${err.message}` }
+  }
+
   // 4. Provider-specific checks. Each configured provider contributes its
   // own binary and credential checks. Providers not in the user's config
   // are skipped entirely — a Gemini-only install does NOT fail because
@@ -384,6 +438,8 @@ export async function runDoctorChecks({ port, providers, verbose: _verbose, pkgD
   // 5. Config check — appended after provider checks so per-provider
   // sections group together in the output report.
   checks.push(configCheck)
+  // #7240 — immediately after Config: the root is the context that explains it.
+  if (strandedCheck) checks.push(strandedCheck)
 
   // Credential storage (#6236). Surface WHERE the API token + credentials
   // actually live and whether the OS keychain is healthy — the #6235 fallback to

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'url'
 import { dirname, join, relative, sep } from 'path'
 import { createLogger, setJsonMode, initFileLogging, setConsoleQuiet } from './logger.js'
 import { configDir, configPath } from './config-dir.js'
+import { detectStrandedState, formatStrandedWarning } from './config-dir-migration.js'
 
 const log = createLogger('cli')
 // #5368 slice (b): QRCode + writeConnectionInfo moved to startup-display.js with
@@ -571,6 +572,26 @@ export async function startCliServer(config) {
   // $CHROXY_HOST_VERSION / _GIT_SHA / _CHANNEL to confirm the exact running build.
   Object.assign(process.env, getChroxyHostEnv())
 
+  // #7240 — state stranded at ~/.chroxy by a CHROXY_CONFIG_DIR relocation.
+  //
+  // This runs HERE, near the top of startCliServer, and the placement is the
+  // point. #7052 logs the resolved root, but that line sits ~500 lines further
+  // down — past the `No API token configured` exit below. In the sharpest
+  // failure (stranded config.json on a keychain-less host) the daemon exits
+  // before it ever says which root it opened, so the operator sees a token
+  // error with no hint that a relocation caused it. Warning first is what makes
+  // the diagnosis reachable.
+  //
+  // Detection only — the copy is opt-in via `chroxy config-dir migrate`.
+  // Best-effort, like maybeEncryptCredentialsAtRest: never blocks boot.
+  let strandedState = null
+  try {
+    strandedState = detectStrandedState()
+    for (const line of formatStrandedWarning(strandedState)) log.warn(line)
+  } catch (err) {
+    log.warn(`Stranded config-dir state check failed: ${err.message}`)
+  }
+
   const PORT = config.port || parseInt(process.env.PORT || '8765', 10)
   const NO_AUTH = !!config.noAuth
 
@@ -602,7 +623,17 @@ export async function startCliServer(config) {
   }
 
   if (!NO_AUTH && !API_TOKEN) {
-    console.error('[!] No API token configured. Run \'chroxy init\' first.') // intentional user-facing output
+    // #7240 — when config.json is sitting at ~/.chroxy and the daemon is reading
+    // a relocated root, `chroxy init` is the WRONG advice: it mints a brand new
+    // token and forces every paired device to re-pair. Name the real cause.
+    if (strandedState?.highConsequence.includes('config.json')) {
+      console.error('[!] No API token configured — but config.json is still at ' // intentional user-facing output
+        + `${strandedState.source} while the daemon is reading ${strandedState.target}.`)
+      console.error('    Do NOT run \'chroxy init\' — it mints a fresh token and forces every device to re-pair.')
+      console.error('    Move your existing state instead:  chroxy config-dir migrate')
+    } else {
+      console.error('[!] No API token configured. Run \'chroxy init\' first.') // intentional user-facing output
+    }
     process.exit(1)
   }
 

--- a/packages/server/tests/cli-config-dir-cmd.test.js
+++ b/packages/server/tests/cli-config-dir-cmd.test.js
@@ -1,0 +1,172 @@
+/**
+ * `chroxy config-dir status` / `chroxy config-dir migrate` CLI (#7240).
+ *
+ * Copies daemon state stranded at `~/.chroxy` into a relocated
+ * `CHROXY_CONFIG_DIR`. Consequential — it moves an identity key and credentials
+ * across a directory boundary the operator drew, possibly onto a shared, synced
+ * or bind-mounted volume — so it requires `--yes`; without it the command only
+ * explains what it would do.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { runConfigDirStatus, runConfigDirMigrate } from '../src/cli/config-dir-cmd.js'
+
+function capture() {
+  const lines = []
+  return { write: (s) => lines.push(String(s)), text: () => lines.join('\n') }
+}
+
+const NOT_RELOCATED = {
+  relocated: false,
+  source: '/home/u/.chroxy',
+  target: '/home/u/.chroxy',
+  stranded: [],
+  highConsequence: [],
+  unreadable: null,
+}
+
+const RELOCATED = (stranded, highConsequence = []) => ({
+  relocated: true,
+  source: '/home/u/.chroxy',
+  target: '/srv/chroxy-state',
+  stranded,
+  highConsequence,
+  unreadable: null,
+})
+
+describe('config-dir status (#7240)', () => {
+  it('reports the root and says nothing can be stranded when not relocated', () => {
+    const out = capture()
+    const res = runConfigDirStatus({ write: out.write, detect: () => NOT_RELOCATED })
+
+    assert.equal(res.relocated, false)
+    assert.match(out.text(), /Not relocated/)
+  })
+
+  it('lists stranded entries and marks the high-consequence ones', () => {
+    const out = capture()
+    const res = runConfigDirStatus({
+      write: out.write,
+      detect: () => RELOCATED(['config.json', 'push-tokens.json'], ['config.json']),
+    })
+
+    assert.deepEqual(res.stranded, ['config.json', 'push-tokens.json'])
+    assert.match(out.text(), /config\.json.*high consequence/)
+    assert.doesNotMatch(out.text(), /push-tokens\.json.*high consequence/)
+    assert.match(out.text(), /chroxy config-dir migrate --yes/)
+  })
+
+  it('surfaces an unreadable source rather than claiming nothing is stranded', () => {
+    const out = capture()
+    runConfigDirStatus({ write: out.write, detect: () => ({ ...RELOCATED([]), unreadable: 'EACCES' }) })
+
+    assert.match(out.text(), /EACCES/)
+    assert.doesNotMatch(out.text(), /No state stranded/)
+  })
+})
+
+describe('config-dir migrate (#7240)', () => {
+  it('explains and does NOT copy without --yes', () => {
+    const out = capture()
+    let migrateCalled = false
+    const res = runConfigDirMigrate({}, {
+      write: out.write,
+      detect: () => RELOCATED(['config.json'], ['config.json']),
+      migrate: () => { migrateCalled = true; return { copied: [], failed: [] } },
+    })
+
+    assert.equal(res.migrated, false)
+    assert.equal(migrateCalled, false, 'the confirmation gate must actually gate the copy')
+    assert.match(out.text(), /Re-run with --yes/)
+  })
+
+  it('warns that the copy moves secrets before asking for confirmation', () => {
+    const out = capture()
+    runConfigDirMigrate({}, {
+      write: out.write,
+      detect: () => RELOCATED(['credentials.json'], ['credentials.json']),
+      migrate: () => ({ copied: [], failed: [] }),
+    })
+
+    // The whole reason this is opt-in rather than automatic: the destination may
+    // be a shared/synced/bind-mounted volume, and that is the operator's call.
+    assert.match(out.text(), /secrets/i)
+    assert.match(out.text(), /shared, synced or bind-mounted/)
+  })
+
+  it('copies with --yes and reports what landed', () => {
+    const out = capture()
+    let passed = null
+    const res = runConfigDirMigrate({ yes: true }, {
+      write: out.write,
+      detect: () => RELOCATED(['config.json', 'skills'], ['config.json']),
+      migrate: (opts) => {
+        passed = opts
+        return { copied: ['config.json', 'skills'], failed: [], source: '/home/u/.chroxy', target: '/srv/chroxy-state' }
+      },
+    })
+
+    assert.equal(res.migrated, true)
+    assert.ok(passed.detection, 'the already-computed detection is reused, not recomputed')
+    assert.match(out.text(), /config\.json/)
+    assert.match(out.text(), /skills/)
+  })
+
+  it('reports per-entry failures', () => {
+    const out = capture()
+    const res = runConfigDirMigrate({ yes: true }, {
+      write: out.write,
+      detect: () => RELOCATED(['a', 'b']),
+      migrate: () => ({
+        copied: ['a'], failed: [{ name: 'b', error: 'EACCES' }],
+        source: '/home/u/.chroxy', target: '/srv/chroxy-state',
+      }),
+    })
+
+    assert.equal(res.result.failed.length, 1)
+    assert.match(out.text(), /could NOT be copied/)
+    assert.match(out.text(), /b: EACCES/)
+  })
+
+  it('does nothing when the root is not relocated', () => {
+    const out = capture()
+    let migrateCalled = false
+    const res = runConfigDirMigrate({ yes: true }, {
+      write: out.write,
+      detect: () => NOT_RELOCATED,
+      migrate: () => { migrateCalled = true; return { copied: [], failed: [] } },
+    })
+
+    assert.equal(res.migrated, false)
+    assert.equal(migrateCalled, false)
+    assert.match(out.text(), /not relocated/)
+  })
+
+  it('does nothing when there is nothing stranded', () => {
+    const out = capture()
+    let migrateCalled = false
+    const res = runConfigDirMigrate({ yes: true }, {
+      write: out.write,
+      detect: () => RELOCATED([]),
+      migrate: () => { migrateCalled = true; return { copied: [], failed: [] } },
+    })
+
+    assert.equal(res.migrated, false)
+    assert.equal(migrateCalled, false)
+    assert.match(out.text(), /already up to date/)
+  })
+
+  it('tells the operator the source is still there afterwards', () => {
+    const out = capture()
+    runConfigDirMigrate({ yes: true }, {
+      write: out.write,
+      detect: () => RELOCATED(['config.json']),
+      migrate: () => ({
+        copied: ['config.json'], failed: [],
+        source: '/home/u/.chroxy', target: '/srv/chroxy-state',
+      }),
+    })
+
+    assert.match(out.text(), /still at \/home\/u\/\.chroxy/)
+  })
+})

--- a/packages/server/tests/config-dir-migration.test.js
+++ b/packages/server/tests/config-dir-migration.test.js
@@ -1,0 +1,431 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  EPHEMERAL_ENTRIES,
+  HIGH_CONSEQUENCE_ENTRIES,
+  detectStrandedState,
+  formatStrandedWarning,
+  migrateStrandedState,
+} from '../src/config-dir-migration.js'
+import { defaultConfigDir } from '../src/config-dir.js'
+
+/**
+ * #7240 — stranded `~/.chroxy` state detection + opt-in migration.
+ *
+ * **Every test injects `source` and `target` explicitly**, at temp paths whose
+ * basenames are NOT `.chroxy`. That is deliberate. #7238's review found two
+ * "positive controls" that did not control, and one of them passed because it
+ * matched any directory *named* `.chroxy` — so a name-based implementation would
+ * have satisfied it while being wrong. Naming the temp dirs `src-*` / `dst-*`
+ * means nothing here can pass by recognising a name.
+ *
+ * The one test that exercises the real `CHROXY_CONFIG_DIR` wiring
+ * ("reads the environment") sets and DELETES the variable itself, because
+ * `tests/_setup.mjs` injects it unconditionally for every server test — the
+ * other half of that same review finding, where a control never unset the
+ * variable it claimed to test.
+ */
+
+let tmpRoot
+let source
+let target
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'chroxy-migr-'))
+  source = join(tmpRoot, 'src-state')
+  target = join(tmpRoot, 'dst-state')
+  mkdirSync(source, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+const write = (dir, name, body = 'x', mode = 0o600) => {
+  mkdirSync(dir, { recursive: true })
+  const p = join(dir, name)
+  writeFileSync(p, body)
+  chmodSync(p, mode)
+  return p
+}
+
+const modeOf = (p) => statSync(p).mode & 0o777
+
+describe('detectStrandedState', () => {
+  it('reports entries present at the source and absent at the target', () => {
+    write(source, 'config.json')
+    write(source, 'session-state.json')
+    mkdirSync(target, { recursive: true })
+    write(target, 'session-state.json')
+
+    const d = detectStrandedState({ source, target })
+
+    assert.equal(d.relocated, true)
+    assert.deepEqual(d.stranded, ['config.json'])
+    assert.equal(d.unreadable, null)
+  })
+
+  it('reports nothing when every entry has already been migrated', () => {
+    write(source, 'config.json')
+    write(source, 'credentials.json')
+    write(target, 'config.json')
+    write(target, 'credentials.json')
+
+    const d = detectStrandedState({ source, target })
+
+    assert.equal(d.relocated, true)
+    assert.deepEqual(d.stranded, [])
+    assert.deepEqual(d.highConsequence, [])
+  })
+
+  it('is a no-op when the root is not relocated (source and target are the same dir)', () => {
+    write(source, 'config.json')
+
+    const d = detectStrandedState({ source, target: source })
+
+    assert.equal(d.relocated, false)
+    assert.deepEqual(d.stranded, [])
+  })
+
+  it('treats a symlink to the source as the same dir, not a relocation', () => {
+    write(source, 'config.json')
+    const link = join(tmpRoot, 'link-to-src')
+    symlinkSync(source, link)
+
+    // A string compare would call these different and report every file as
+    // stranded; dev+ino identity is what makes this correct.
+    const d = detectStrandedState({ source, target: link })
+
+    assert.equal(d.relocated, false, 'a symlinked target is the same directory')
+    assert.deepEqual(d.stranded, [])
+  })
+
+  it('treats a non-canonical spelling of the source as the same dir', () => {
+    write(source, 'config.json')
+    const spelled = join(source, '..', 'src-state')
+
+    const d = detectStrandedState({ source, target: spelled })
+
+    assert.equal(d.relocated, false)
+  })
+
+  it('classifies the destructive entries as high-consequence', () => {
+    for (const name of ['config.json', 'server-identity.json', 'credentials.json', 'push-tokens.json']) {
+      write(source, name)
+    }
+
+    const d = detectStrandedState({ source, target })
+
+    assert.deepEqual(d.highConsequence, ['config.json', 'server-identity.json', 'credentials.json'])
+    assert.ok(d.stranded.includes('push-tokens.json'), 'non-sharp entries are still stranded')
+  })
+
+  it('excludes runtime-ephemeral entries from the stranded set', () => {
+    for (const name of EPHEMERAL_ENTRIES) write(source, name)
+
+    const d = detectStrandedState({ source, target })
+
+    assert.equal(d.relocated, true)
+    assert.deepEqual(d.stranded, [], 'a stale pid/lock is not state worth reporting')
+  })
+
+  it('reports nothing when the source does not exist', () => {
+    rmSync(source, { recursive: true, force: true })
+
+    const d = detectStrandedState({ source, target })
+
+    assert.equal(d.relocated, true)
+    assert.deepEqual(d.stranded, [])
+  })
+
+  it('reports an unreadable source instead of throwing', () => {
+    // A file where a directory is expected — readdir fails, and the boot path
+    // must degrade rather than crash the daemon.
+    const notADir = write(source, 'config.json')
+
+    const d = detectStrandedState({ source: notADir, target })
+
+    assert.equal(d.relocated, true)
+    assert.ok(d.unreadable, 'the readdir failure is surfaced, not swallowed')
+    assert.deepEqual(d.stranded, [])
+  })
+
+  it('detects entries that are directories, not just files', () => {
+    mkdirSync(join(source, 'skills'), { recursive: true })
+
+    const d = detectStrandedState({ source, target })
+
+    assert.deepEqual(d.stranded, ['skills'])
+  })
+
+  it('reads CHROXY_CONFIG_DIR at call time for its default target', () => {
+    // The env seam, exercised end-to-end. _setup.mjs sets CHROXY_CONFIG_DIR for
+    // every server test, so this test owns save/restore — including the DELETE
+    // branch, which is the case a control that only ever sets the variable
+    // silently never reaches.
+    const saved = process.env.CHROXY_CONFIG_DIR
+    try {
+      write(source, 'config.json')
+
+      process.env.CHROXY_CONFIG_DIR = target
+      const relocated = detectStrandedState({ source })
+      assert.equal(relocated.target, target, 'the default target follows the env var')
+      assert.deepEqual(relocated.stranded, ['config.json'])
+
+      delete process.env.CHROXY_CONFIG_DIR
+      const unset = detectStrandedState({ source })
+      assert.equal(unset.target, defaultConfigDir(), 'unset falls back to ~/.chroxy')
+      assert.equal(unset.relocated, true, 'the injected source is not the real home')
+    } finally {
+      if (saved === undefined) delete process.env.CHROXY_CONFIG_DIR
+      else process.env.CHROXY_CONFIG_DIR = saved
+    }
+  })
+
+  it('is not relocated when CHROXY_CONFIG_DIR is relative (config-dir.js refuses it)', () => {
+    const saved = process.env.CHROXY_CONFIG_DIR
+    try {
+      process.env.CHROXY_CONFIG_DIR = 'relative-state'
+      // configDir() refuses a relative value back to ~/.chroxy, so a detection
+      // that used the raw env value would claim a relocation that never happened.
+      const d = detectStrandedState({ source: defaultConfigDir() })
+      assert.equal(d.relocated, false)
+    } finally {
+      if (saved === undefined) delete process.env.CHROXY_CONFIG_DIR
+      else process.env.CHROXY_CONFIG_DIR = saved
+    }
+  })
+})
+
+describe('formatStrandedWarning', () => {
+  it('says nothing when nothing is stranded', () => {
+    write(target, 'config.json')
+    write(source, 'config.json')
+    assert.deepEqual(formatStrandedWarning(detectStrandedState({ source, target })), [])
+  })
+
+  it('says nothing when the root is not relocated', () => {
+    write(source, 'config.json')
+    assert.deepEqual(formatStrandedWarning(detectStrandedState({ source, target: source })), [])
+  })
+
+  it('names the stranded entries, both roots, and the remedy', () => {
+    write(source, 'session-state.json')
+    const text = formatStrandedWarning(detectStrandedState({ source, target })).join('\n')
+
+    assert.match(text, /session-state\.json/)
+    assert.match(text, new RegExp(source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(text, new RegExp(target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(text, /chroxy config-dir migrate/)
+  })
+
+  it('warns against chroxy init only when config.json is the stranded file', () => {
+    write(source, 'config.json')
+    const withConfig = formatStrandedWarning(detectStrandedState({ source, target })).join('\n')
+    assert.match(withConfig, /Do NOT run 'chroxy init'/)
+
+    rmSync(join(source, 'config.json'))
+    write(source, 'push-tokens.json')
+    const without = formatStrandedWarning(detectStrandedState({ source, target })).join('\n')
+    assert.doesNotMatch(without, /chroxy init/, 'init advice is scoped to the case it applies to')
+  })
+
+  it('calls out the identity-key MITM consequence when server-identity.json is stranded', () => {
+    write(source, 'server-identity.json')
+    const text = formatStrandedWarning(detectStrandedState({ source, target })).join('\n')
+    assert.match(text, /MITM/)
+  })
+})
+
+describe('migrateStrandedState', () => {
+  it('copies stranded entries into the target', () => {
+    write(source, 'config.json', '{"apiToken":"t"}')
+    write(source, 'session-state.json', '{}')
+
+    const r = migrateStrandedState({ source, target })
+
+    assert.deepEqual(r.copied.sort(), ['config.json', 'session-state.json'])
+    assert.deepEqual(r.failed, [])
+    assert.equal(readFileSync(join(target, 'config.json'), 'utf-8'), '{"apiToken":"t"}')
+  })
+
+  it('preserves 0600 file modes', () => {
+    write(source, 'credentials.json', 'secret', 0o600)
+
+    migrateStrandedState({ source, target })
+
+    assert.equal(modeOf(join(target, 'credentials.json')), 0o600)
+  })
+
+  it('preserves 0700 directory modes', () => {
+    // cpSync preserves file modes but creates directories at the default 0755 —
+    // verified, not assumed. Without the explicit mode mirror, a 0700 skills/
+    // dir holding runtime prompts widens to world-readable on migration.
+    const skills = join(source, 'skills')
+    mkdirSync(skills, { recursive: true })
+    write(skills, 'a.md', '# skill', 0o600)
+    chmodSync(skills, 0o700)
+
+    migrateStrandedState({ source, target })
+
+    assert.equal(modeOf(join(target, 'skills')), 0o700, 'directory mode must not widen on copy')
+    assert.equal(modeOf(join(target, 'skills', 'a.md')), 0o600)
+  })
+
+  it('preserves modes on nested directories', () => {
+    const nested = join(source, 'worktrees', 'inner')
+    mkdirSync(nested, { recursive: true })
+    write(nested, 'f', 'x', 0o600)
+    chmodSync(nested, 0o700)
+    chmodSync(join(source, 'worktrees'), 0o700)
+
+    migrateStrandedState({ source, target })
+
+    assert.equal(modeOf(join(target, 'worktrees')), 0o700)
+    assert.equal(modeOf(join(target, 'worktrees', 'inner')), 0o700)
+  })
+
+  it('never overwrites an entry already present in the target', () => {
+    write(source, 'config.json', 'FROM-SOURCE')
+    write(target, 'config.json', 'FROM-TARGET')
+
+    const r = migrateStrandedState({ source, target })
+
+    assert.deepEqual(r.copied, [])
+    assert.equal(readFileSync(join(target, 'config.json'), 'utf-8'), 'FROM-TARGET',
+      'the target root is authoritative — migration must never clobber it')
+  })
+
+  it('refuses to overwrite even when detection is stale (the TOCTOU race)', () => {
+    // The detection above filters out anything already in the target, so the
+    // cpSync flags never fire on the happy path — which means a test that only
+    // pre-populates the target proves nothing about them. Feed a DELIBERATELY
+    // STALE detection instead: the state after `detect` ran, then something else
+    // created the file before the copy. That is the only way the second lock is
+    // reachable, and without it `errorOnExist`/`force` are unverified.
+    write(source, 'config.json', 'FROM-SOURCE')
+    write(target, 'config.json', 'WRITTEN-AFTER-DETECTION')
+
+    const stale = {
+      relocated: true,
+      source,
+      target,
+      stranded: ['config.json'],
+      highConsequence: ['config.json'],
+      unreadable: null,
+    }
+    const r = migrateStrandedState({ detection: stale })
+
+    assert.deepEqual(r.copied, [], 'the copy must lose the race, not win it')
+    assert.equal(r.failed.length, 1)
+    assert.equal(readFileSync(join(target, 'config.json'), 'utf-8'), 'WRITTEN-AFTER-DETECTION')
+  })
+
+  it('leaves the source in place (it copies, it does not move)', () => {
+    write(source, 'config.json', 'body')
+
+    migrateStrandedState({ source, target })
+
+    assert.ok(existsSync(join(source, 'config.json')), 'the operator keeps a fallback')
+  })
+
+  it('creates the target at 0700 when it does not exist', () => {
+    write(source, 'config.json')
+    assert.equal(existsSync(target), false)
+
+    migrateStrandedState({ source, target })
+
+    assert.equal(modeOf(target), 0o700)
+  })
+
+  it('does nothing when the root is not relocated', () => {
+    write(source, 'config.json')
+
+    const r = migrateStrandedState({ source, target: source })
+
+    assert.equal(r.reason, 'not-relocated')
+    assert.deepEqual(r.copied, [])
+  })
+
+  it('does nothing when there is nothing stranded', () => {
+    write(source, 'config.json')
+    write(target, 'config.json')
+
+    const r = migrateStrandedState({ source, target })
+
+    assert.equal(r.reason, 'nothing-stranded')
+  })
+
+  it('skips runtime-ephemeral entries', () => {
+    write(source, 'supervisor.pid', '4242')
+    write(source, 'config.json')
+
+    const r = migrateStrandedState({ source, target })
+
+    assert.deepEqual(r.copied, ['config.json'])
+    assert.equal(existsSync(join(target, 'supervisor.pid')), false,
+      'a PID from the previous root must not follow the state forward')
+  })
+
+  it('reports a per-entry failure without abandoning the rest', () => {
+    write(source, 'config.json', 'ok')
+    const dangling = join(source, 'broken-link')
+    symlinkSync(join(tmpRoot, 'does-not-exist'), dangling)
+
+    const r = migrateStrandedState({ source, target })
+
+    assert.ok(r.copied.includes('config.json'), 'a good entry still lands')
+    assert.equal(r.copied.includes('broken-link'), false)
+    assert.equal(r.failed.length, 1)
+    assert.equal(r.failed[0].name, 'broken-link')
+  })
+
+  it('converges when re-run after a partial migration', () => {
+    write(source, 'config.json')
+    write(source, 'credentials.json')
+    write(target, 'config.json')
+
+    const first = migrateStrandedState({ source, target })
+    assert.deepEqual(first.copied, ['credentials.json'])
+
+    const second = migrateStrandedState({ source, target })
+    assert.equal(second.reason, 'nothing-stranded')
+  })
+})
+
+describe('HIGH_CONSEQUENCE_ENTRIES', () => {
+  it('names the entries whose loss is destructive rather than inconvenient', () => {
+    // Pinned so a future edit that drops one has to say so: losing config.json
+    // costs every paired device a re-pair, and losing server-identity.json makes
+    // pinned clients report a MITM.
+    assert.deepEqual(HIGH_CONSEQUENCE_ENTRIES,
+      ['config.json', 'server-identity.json', 'credentials.json'])
+  })
+})
+
+describe('the stranded set is derived, not enumerated', () => {
+  it('flags a state file no list in this repo has ever mentioned', () => {
+    // The guard against docs/false-safety-guards.md's "hardcoded list next to a
+    // set that grows". A future module writing a new state file must be covered
+    // the day it ships, with nothing to update here.
+    write(source, 'a-state-file-invented-by-this-test.json')
+
+    const d = detectStrandedState({ source, target })
+
+    assert.deepEqual(d.stranded, ['a-state-file-invented-by-this-test.json'])
+  })
+
+  it('flags every entry the source holds, not a fixed subset', () => {
+    const names = Array.from({ length: 25 }, (_, i) => `state-${i}.json`)
+    for (const n of names) write(source, n)
+
+    const d = detectStrandedState({ source, target })
+
+    assert.equal(d.stranded.length, 25)
+    assert.deepEqual(new Set(d.stranded), new Set(names))
+    assert.deepEqual(readdirSync(source).sort(), d.stranded, 'nothing is filtered out silently')
+  })
+})

--- a/packages/server/tests/config-dir-migration.test.js
+++ b/packages/server/tests/config-dir-migration.test.js
@@ -1,4 +1,5 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
+import { spawnSync } from 'node:child_process'
 import assert from 'node:assert/strict'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -231,6 +232,55 @@ describe('formatStrandedWarning', () => {
     write(source, 'push-tokens.json')
     const without = formatStrandedWarning(detectStrandedState({ source, target })).join('\n')
     assert.doesNotMatch(without, /chroxy init/, 'init advice is scoped to the case it applies to')
+  })
+
+  it('shell-quotes both paths in the cp hint', () => {
+    // The hint is a command a human copies and runs. Unquoted, a path with a
+    // space becomes a DIFFERENT command — `cp -a /srv/my state/. /dst/` copies
+    // two wrong sources — and a metacharacter is worse than wrong.
+    const spaced = join(tmpRoot, 'dir with spaces')
+    mkdirSync(spaced, { recursive: true })
+    write(spaced, 'config.json')
+
+    const text = formatStrandedWarning(detectStrandedState({ source: spaced, target })).join('\n')
+    const cp = text.split('\n').find((l) => l.includes('cp -a'))
+
+    assert.ok(cp.includes(`'${spaced}/.'`), `source not quoted in: ${cp}`)
+    assert.ok(cp.includes(`'${target}/'`), `target not quoted in: ${cp}`)
+  })
+
+  it('escapes an embedded single quote rather than breaking out of the quoting', () => {
+    const tricky = join(tmpRoot, "o'brien")
+    mkdirSync(tricky, { recursive: true })
+    write(tricky, 'config.json')
+
+    const text = formatStrandedWarning(detectStrandedState({ source: tricky, target })).join('\n')
+    const cp = text.split('\n').find((l) => l.includes('cp -a'))
+
+    // The close-escape-reopen idiom, not a raw quote that would terminate the
+    // string. The opening quote sits at the head of the whole path, not next to
+    // the `o`, so match only the escape itself.
+    assert.match(cp, /o'\\''brien\/\.'/)
+  })
+
+  it('the printed cp command actually runs, for a path with a space and a quote', () => {
+    // Pattern-matching the quoting only proves it looks right. A naive
+    // "quote count must be even" check is itself wrong here — `'a'\''b'` is
+    // valid POSIX with five quotes — so the only honest assertion is to hand
+    // the produced command to a real shell and see what it does.
+    const nasty = join(tmpRoot, "weird 'dir' name")
+    mkdirSync(nasty, { recursive: true })
+    write(nasty, 'config.json', 'PAYLOAD')
+    mkdirSync(target, { recursive: true })
+
+    const text = formatStrandedWarning(detectStrandedState({ source: nasty, target })).join('\n')
+    const cp = text.split('\n').find((l) => l.includes('cp -a')).replace(/^\s*or:\s*/, '').trim()
+
+    const res = spawnSync('sh', ['-c', cp], { encoding: 'utf8' })
+
+    assert.equal(res.status, 0, `command failed: ${cp}\n${res.stderr}`)
+    assert.equal(readFileSync(join(target, 'config.json'), 'utf-8'), 'PAYLOAD',
+      'the copy-pasteable hint must copy the right thing')
   })
 
   it('calls out the identity-key MITM consequence when server-identity.json is stranded', () => {

--- a/packages/server/tests/doctor-config-dir.test.js
+++ b/packages/server/tests/doctor-config-dir.test.js
@@ -45,12 +45,19 @@ const runWith = async (detectStranded) => {
 describe('doctor — Config/state root (#7240)', () => {
   it('passes and names the root when nothing is stranded', async () => {
     const { root } = await runWith(stub())
+
     assert.equal(root.status, 'pass')
+    // Pinned to the INJECTED root. This branch used to read configDir() and
+    // process.env directly, which meant it reported something the caller never
+    // asked about and no test could pin it.
+    assert.equal(root.message, '/home/u/.chroxy')
   })
 
   it('passes when the root is relocated but already fully migrated', async () => {
     const { root } = await runWith(relocatedWith([]))
+
     assert.equal(root.status, 'pass')
+    assert.equal(root.message, '/srv/chroxy-state (from CHROXY_CONFIG_DIR)')
   })
 
   it('warns and names the stranded entries, both roots, and the remedy', async () => {

--- a/packages/server/tests/doctor-config-dir.test.js
+++ b/packages/server/tests/doctor-config-dir.test.js
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { runDoctorChecks } from '../src/doctor.js'
+
+/**
+ * #7240 — doctor's `Config/state root` check.
+ *
+ * The detection is injected via the `detectStranded` seam (the same shape as the
+ * existing `tunnelProbe` seam), so these assertions never depend on whatever the
+ * developer happens to have in their real `~/.chroxy` — the flakiness
+ * doctor.test.js's header already warns about.
+ *
+ * The load-bearing case is the last one: doctor previously answered a missing
+ * config.json with "run 'chroxy init' to create", which — when the real cause is
+ * a CHROXY_CONFIG_DIR relocation — mints a fresh token and forces every paired
+ * device to re-pair. That is worse than the problem it claims to fix.
+ */
+
+const stub = (over = {}) => () => ({
+  relocated: false,
+  source: '/home/u/.chroxy',
+  target: '/home/u/.chroxy',
+  stranded: [],
+  highConsequence: [],
+  unreadable: null,
+  ...over,
+})
+
+const relocatedWith = (stranded, highConsequence = []) => stub({
+  relocated: true,
+  source: '/home/u/.chroxy',
+  target: '/srv/chroxy-state',
+  stranded,
+  highConsequence,
+})
+
+const runWith = async (detectStranded) => {
+  const { checks } = await runDoctorChecks({ providers: ['claude-sdk'], detectStranded })
+  return {
+    root: checks.find((c) => c.name === 'Config/state root'),
+    config: checks.find((c) => c.name === 'Config'),
+  }
+}
+
+describe('doctor — Config/state root (#7240)', () => {
+  it('passes and names the root when nothing is stranded', async () => {
+    const { root } = await runWith(stub())
+    assert.equal(root.status, 'pass')
+  })
+
+  it('passes when the root is relocated but already fully migrated', async () => {
+    const { root } = await runWith(relocatedWith([]))
+    assert.equal(root.status, 'pass')
+  })
+
+  it('warns and names the stranded entries, both roots, and the remedy', async () => {
+    const { root } = await runWith(relocatedWith(['session-state.json', 'push-tokens.json']))
+
+    assert.equal(root.status, 'warn')
+    assert.match(root.message, /session-state\.json/)
+    assert.match(root.message, /push-tokens\.json/)
+    assert.match(root.message, /\/home\/u\/\.chroxy/)
+    assert.match(root.message, /\/srv\/chroxy-state/)
+    assert.match(root.message, /chroxy config-dir migrate/)
+  })
+
+  it('truncates a long stranded list but still names the high-consequence entries', async () => {
+    const many = Array.from({ length: 20 }, (_, i) => `state-${i}.json`).concat('server-identity.json')
+    const { root } = await runWith(relocatedWith(many, ['server-identity.json']))
+
+    assert.match(root.message, /and \d+ more/)
+    assert.match(root.message, /server-identity\.json/,
+      'the sharp entry is named outside the truncated tail')
+  })
+
+  it('warns rather than throwing when the source cannot be read', async () => {
+    const { root } = await runWith(stub({ relocated: true, target: '/srv/x', unreadable: 'EACCES' }))
+    assert.equal(root.status, 'warn')
+    assert.match(root.message, /EACCES/)
+  })
+
+  it('degrades to a warn when detection itself throws', async () => {
+    const { root } = await runWith(() => { throw new Error('boom') })
+    assert.equal(root.status, 'warn')
+    assert.match(root.message, /boom/)
+  })
+
+  it('does NOT recommend chroxy init when a stranded config.json is the real cause', async () => {
+    const { config } = await runWith(relocatedWith(['config.json'], ['config.json']))
+
+    assert.equal(config.status, 'fail')
+    assert.doesNotMatch(config.message, /run 'chroxy init' to create/,
+      'that advice mints a fresh token and forces every device to re-pair')
+    assert.match(config.message, /Do NOT run 'chroxy init'/)
+    assert.match(config.message, /chroxy config-dir migrate/)
+  })
+
+  it('leaves the ordinary missing-config advice alone when there is no relocation', async () => {
+    // Only meaningful when the developer has no real config.json; when they do,
+    // the Config check passes and there is no advice to inspect either way.
+    const { config } = await runWith(stub())
+    if (config.status === 'warn' && /Not found/.test(config.message)) {
+      assert.match(config.message, /run 'chroxy init' to create/)
+    }
+  })
+})


### PR DESCRIPTION
Closes #7240

## What

#7052 made `CHROXY_CONFIG_DIR` relocate all daemon state. For anyone who already set it, that silently strands ~20 files at `~/.chroxy` on upgrade. Two cases are destructive rather than inconvenient:

- unmoved `server-identity.json` on a keychain-less host → daemon mints a **new identity key** → pinned clients report a possible MITM (#5615's fail-safe can't fire: absent-everywhere is indistinguishable from first run)
- unmoved `config.json` → apiToken lost → `chroxy init` mints a **fresh** token, forcing every device to re-pair

This surfaces the whole class in three places and migrates only on request.

## The decision the issue asked for: warn loudly, copy opt-in

Recorded here because #7240 asked for it explicitly.

The daemon cannot distinguish *"operator just relocated and wants their state"* from *"operator pointed at a deliberately clean root"* — a container, a per-project dir. Copying an identity key and credentials into a directory that may be shared, synced or bind-mounted is the operator's security decision, not a side effect of an upgrade.

The precedents the issue cites for a best-effort startup migration — `maybeEncryptCredentialsAtRest` (#5154), `migrateToken` — upgrade a file **in place at a path the daemon already owns**. This would cross a boundary the operator explicitly drew. Different act, different default.

## A sharp detail the issue didn't have

#7052 logs the resolved root at startup, but that line is at `server-cli.js:1100` and the `No API token configured` exit is at `:605`. **In the worst case the daemon exits ~500 lines before it says which root it opened**, so the operator saw a token error with no hint a relocation caused it.

The warning is therefore emitted near the top of `startCliServer`, and the fatal message itself now names the real cause and says *not* to run `chroxy init`.

## Surfaces

| Where | Behaviour |
|---|---|
| Startup | Warns, naming stranded entries + remedy, before the token gate. Best-effort; never blocks boot. |
| `chroxy doctor` | New `Config/state root` check. `Config` no longer answers a stranded `config.json` with "run `chroxy init` to create". |
| `chroxy config-dir status` | Lists what is stranded, marking high-consequence entries. |
| `chroxy config-dir migrate --yes` | Copies forward. Preserves `0600`/`0700` modes, never overwrites, leaves originals in place. |

## The stranded set is computed, not enumerated

The obvious implementation is a const array of the ~20 known state filenames. That is exactly the *"hardcoded list next to a set that grows"* shape [`docs/false-safety-guards.md`](docs/false-safety-guards.md) exists to prevent (#7192/#7197) — the next module to add a state file wouldn't be in it, and the check would report clean while missing it.

So it's derived: **every entry present at `~/.chroxy` and absent at the resolved root**. A state file added later is covered the day it ships. The one list, `EPHEMERAL_ENTRIES` (`supervisor.pid`, `update.lock`), is consulted by both detection and migration so they can't disagree, and getting it wrong means a lock file is reported — not that state goes silently unmigrated.

## Two things testing found rather than assumed

- **`cpSync` preserves file modes but creates directories at 0755.** A `0700 skills/` would have widened on copy. Modes are now mirrored explicitly; asserted in the suite.
- **Directory identity is compared by device+inode, not by string.** A string compare has to get symlinks, non-canonical spellings and case-insensitive filesystems all right at once — the class behind #6928 and the case-insensitive-workdir trap.

`defaultConfigDir()` is exported from `config-dir.js` rather than recomputed, so `join(homedir(), '.chroxy')` still appears in exactly one module and `lint-config-dir.mjs` keeps exempting exactly one file. Adding a new baseline entry would have subverted that ratchet.

## Verification

**All eight guards are mutation-proven** — each broken individually, the corresponding test confirmed red, then restored from a `cp` backup (never `git checkout --`) and the suite confirmed green again:

| Mutant | Result |
|---|---|
| M1 directory modes not mirrored | red |
| M2 stranded set hardcoded instead of derived | red |
| M3 `sameDir` by string compare | red |
| M4 copy allowed to overwrite | red |
| M5 ephemeral entries not excluded | red |
| M6 `chroxy init` advice unconditional | red |
| M7 doctor keeps recommending `init` | red |
| M8 `--yes` gate removed | red |

**M4 initially stayed green**, and that was a real hole in my own test: the "never overwrites" case only exercised the *detection* guard, because detection filters the entry out before the `errorOnExist`/`force` flags are ever reached — so the flags were unverified while the test read as proof. It now feeds a deliberately stale detection to exercise the TOCTOU path those flags actually defend.

- **Full server suite: 13322 tests, 4 failures — the same 4 as `origin/main`**, verified by diffing the failing-test names before and after. All environmental: one needs `OPENAI_API_KEY`, two hit a live local daemon on `:8765`, one is a Rust/clap harness check.
- 51 tests added. eslint clean (0 errors); the one warning in `config-dir.js` is pre-existing on `origin/main`.
- All six custom server lints green, including `lint-config-dir.sh`.

## Not in scope

#7239 (guard scope) and #7241 (docs sweep) remain open. `docs/troubleshooting.md` §1 is updated here because it documents the exact symptom this change fixes.