### PR TITLE
fix(ci): widen the config-dir guard to match what its name claimed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check ~/.chroxy resolves through config-dir.js
+      - name: Check ~/.chroxy resolves through config-dir.js (server + claude-hooks JS)
         run: |
           # Issue #7052 — CHROXY_CONFIG_DIR must relocate ALL daemon state. It
           # relocated only half of it, because a `const` freezes at import: 16
@@ -397,8 +397,25 @@ jobs:
           # around that. Both shapes are banned; configDir()/configPath() read
           # the env per call. The lint is ratcheted by file — see
           # scripts/lint-config-dir-baseline.txt, which may shrink, never grow.
-          if scripts/lint-config-dir.sh; then
+          #
+          # #7239 — the step name says what is actually covered. The walk is
+          # packages/server/src + packages/claude-hooks/src, .js/.mjs/.cjs.
+          # Shell resolvers (scripts/docker-entrypoint.sh) and .ts sources are
+          # NOT covered by this gate; the old name implied the whole repo was.
+          #
+          # Exit 2 means the lint could not do its job (bad flags, or it scanned
+          # fewer files than its floor) and is reported separately from exit 1
+          # — "the guard broke" must never be shown as "the code is dirty", and
+          # must never be silently green.
+          set +e
+          scripts/lint-config-dir.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
             echo "OK — ~/.chroxy resolves through src/config-dir.js"
+          elif [ "$rc" -eq 2 ]; then
+            echo "::error::lint-config-dir could not run (bad flags, or it scanned fewer files than --min-files). The GUARD is broken, not necessarily the code. See packages/server/scripts/lint-config-dir.mjs."
+            exit 1
           else
             echo "::error::A file resolves ~/.chroxy outside src/config-dir.js, or a baseline entry is stale. See packages/server/scripts/lint-config-dir.sh."
             exit 1
@@ -950,6 +967,13 @@ jobs:
 
       - name: Run bump-version.sh tests
         run: bash scripts/__tests__/bump-version.test.sh
+
+      - name: Run docker-entrypoint.sh tests
+        # #7239 — the entrypoint hardcoded $HOME/.chroxy while the daemon
+        # honours CHROXY_CONFIG_DIR, so a relocated container wrote config to
+        # the mounted volume and read state from an unmounted path. Silent,
+        # because the token survived via the exported API_TOKEN.
+        run: bash scripts/__tests__/docker-entrypoint.test.sh
 
       - name: Run flush-and-exit.mjs tests
         run: node scripts/__tests__/flush-and-exit.test.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker: `CHROXY_CONFIG_DIR` is now honoured by the entrypoint (#7239).**
+  `scripts/docker-entrypoint.sh` hardcoded `$HOME/.chroxy` while the daemon
+  honours the override, so `docker run -e CHROXY_CONFIG_DIR=/data` split the
+  container in two — the entrypoint wrote `config.json` to `~/.chroxy` (the
+  mounted `chroxy-data` volume) while the daemon read `/data` for everything
+  else.
+
+  This was silent because the API token survived it by accident: the entrypoint
+  exports `API_TOKEN` and the daemon falls back to that. What actually broke was
+  everything else — `server-identity.json`, `credentials.json`,
+  `session-state.json`, `scheduled-tasks.json` and the trust ledgers landed in an
+  **unmounted** container path and were destroyed on every restart, while the
+  volume sat mounted where nothing wrote to it. A regenerated identity key is the
+  sharp end: pinned clients report it as a possible MITM.
+
+  If you run the container **without** `CHROXY_CONFIG_DIR`, nothing changes.
+
 ### Changed
 
 - **`CHROXY_CONFIG_DIR` now relocates ALL daemon state (#7052).** It previously

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       - CHROXY_TUNNEL_NAME         # for named tunnel
       - CHROXY_TUNNEL_HOSTNAME     # for named tunnel
     volumes:
+      # #7239 — CHROXY_CONFIG_DIR is deliberately NOT passed through above. If
+      # you add it, you MUST move this mount to the same path: the daemon reads
+      # ALL of its state from that root (#7052), so leaving the volume here
+      # sends identity keys, credentials and session state to an unmounted path
+      # that is destroyed on every restart.
       - chroxy-data:/home/chroxy/.chroxy      # config + session state
       - chroxy-claude:/home/chroxy/.claude     # Claude settings
       - ${WORKSPACE_PATH:-.}:/workspace       # project files to work on

--- a/packages/server/scripts/lint-config-dir-baseline.txt
+++ b/packages/server/scripts/lint-config-dir-baseline.txt
@@ -1,4 +1,17 @@
 # Files that still resolve ~/.chroxy without going through src/config-dir.js.
-# Ratchet (#7052): a file may LEAVE this list, never join it.
+# Ratchet (#7052): a file may LEAVE this list, never join it. Since #7239 that
+# is enforced — `--write-baseline` refuses to add an entry without
+# --allow-baseline-growth.
 # Regenerate with: node scripts/lint-config-dir.mjs --write-baseline
+#
+# packages/claude-hooks/src/config.js — a DELIBERATE, permanent exception, not
+# an unmigrated file. claude-hooks is zero-runtime-dep by design (#5885) so that
+# the hook emitters can run inside a plain Claude Code session with nothing
+# installed; it therefore cannot import the server's accessor, and its resolver
+# has to stay hand-rolled. It is correct today (it reads CHROXY_CONFIG_DIR and
+# falls back to ~/.chroxy). It is listed here rather than left unscanned so that
+# a SECOND copy appearing in that package is caught — the whole argument of this
+# lint is that each copy is correct in isolation and each one is a place the
+# convention can drift.
 
+packages/claude-hooks/src/config.js

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -29,26 +29,68 @@
  *     prose while explaining the migration.
  *
  * Allow-list / opt-out:
- *   - `config-dir.js` — the OWNER of the resolution, exempt wholesale.
- *   - the baseline file (`lint-config-dir-baseline.txt`), one repo-relative
- *     path per line, exempts a file that has not been migrated yet. The
- *     ratchet: a file may leave the baseline, never join it. Mirrors
- *     `scripts/no-raw-color-literals-baseline.txt`.
- *   - `// lint-ignore-config-dir` on the line immediately above an offending
- *     line whitelists that one site.
+ *   - the OWNER file(s) (`--owner`, default `packages/server/src/config-dir.js`),
+ *     exempt wholesale.
+ *   - the baseline file (`lint-config-dir-baseline.txt`), one key per line,
+ *     exempts a file that has not been migrated yet. The ratchet: a file may
+ *     leave the baseline, never join it — and since #7239 that is ENFORCED by
+ *     `--write-baseline` rather than left to review (see below).
+ *   - `// lint-ignore-config-dir` in a COMMENT on the line immediately above an
+ *     offending line whitelists that one site.
  *
- * Issue: #7052.
+ * ## Scope (#7239)
+ *
+ * The gate scanned only `packages/server/src`, while its CI step was named
+ * "Check ~/.chroxy resolves through config-dir.js" — which overclaimed, because
+ * live resolvers sit outside that tree. It now scans `packages/claude-hooks/src`
+ * too. That package is deliberately zero-runtime-dep and CANNOT import the
+ * server's accessor, so its one hand-rolled copy is baselined with a note rather
+ * than "fixed"; the point is that a SECOND copy appearing there is now caught.
+ *
+ * Deliberately still out of scope, so the naming does not overclaim again:
+ *   - `scripts/` (repo + package): the linter itself lives there and would scan
+ *     its own pattern definitions. Shell resolvers there are covered by review,
+ *     not by this gate.
+ *   - `.ts` sources: no TypeScript package resolves a chroxy root today. The
+ *     walk already accepts the extension list below, so adding one is a
+ *     one-line change if that stops being true.
+ *
+ * ## Anti-evasion (#7239)
+ *
+ * The rules are line-oriented regexes, and adversarial fixture testing found
+ * several shapes that slipped through. Each is now covered, and each has a
+ * fixture in `tests/lint-config-dir.test.js` proving it is caught:
+ *   - a two-step `const home = homedir()` … `join(home, '.chroxy')`
+ *   - a template literal, `` `${homedir()}/.chroxy/x` ``
+ *   - a combined segment, `join(homedir(), '.chroxy/logs/x')`
+ *   - `process.env.HOME` / `env.HOME` in place of `homedir()`
+ *   - `.mjs` / `.cjs` sources, previously invisible to the walk
+ *   - an ignore marker that merely APPEARS in prose on the previous line
+ *   - an unknown flag (a typo'd `--srcdir`) being ignored, so the lint silently
+ *     scanned the real `src/` and reported OK
+ *   - scanning ZERO files and exiting 0, indistinguishable from a clean tree
+ *
+ * Issue: #7052, #7239.
  *
  * Exit codes:
  *   0 — no un-baselined offenders, and no stale baseline entries
  *   1 — at least one offender, or a baseline entry that is now clean
+ *   2 — the lint could not do its job (bad flags, nothing scanned). Distinct
+ *       from 1 on purpose: "the guard failed" must never read as "the guard
+ *       passed", and it must not read as "the code is dirty" either.
  *
  * Flags:
- *   --src-dir <path>    Override the src directory (used by the golden test
- *                       against fixture trees). Defaults to `../src`.
- *   --baseline <path>   Override the baseline file. Defaults to
- *                       `./lint-config-dir-baseline.txt`.
- *   --write-baseline    Rewrite the baseline from what is currently on disk.
+ *   --src-dir <path>    Directory to scan. REPEATABLE. Defaults to the two
+ *                       roots above.
+ *   --owner <path>      A file exempt wholesale. REPEATABLE. Defaults to
+ *                       `<first --src-dir>/config-dir.js` when --src-dir is
+ *                       given, else the server's config-dir.js.
+ *   --baseline <path>   Override the baseline file.
+ *   --min-files <n>     Fail (exit 2) if fewer than n files were scanned.
+ *                       A FLOOR, not a count — it only ever fails closed.
+ *   --write-baseline    Rewrite the baseline. REFUSES to add a file that is not
+ *                       already listed unless --allow-baseline-growth is given.
+ *   --allow-baseline-growth  Permit --write-baseline to add entries.
  *   --dry-run           Print offenders without failing the exit code.
  */
 
@@ -57,27 +99,63 @@ import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..', '..')
 
-const OWNER = 'config-dir.js'
+const DEFAULT_SRC_DIRS = [
+  join(REPO_ROOT, 'packages', 'server', 'src'),
+  join(REPO_ROOT, 'packages', 'claude-hooks', 'src'),
+]
+const DEFAULT_OWNERS = [join(REPO_ROOT, 'packages', 'server', 'src', 'config-dir.js')]
+
+const SCANNED_EXTENSIONS = ['.js', '.mjs', '.cjs']
 const IGNORE_MARKER = 'lint-ignore-config-dir'
 
+/** Bad usage — the lint could not run. Exit 2, never 0 and never 1. */
+function usageError(message) {
+  console.error(`lint-config-dir: ${message}`)
+  process.exit(2)
+}
+
 function parseArgs(argv) {
-  const out = { srcDir: null, baseline: null, writeBaseline: false, dryRun: false }
+  const out = {
+    srcDirs: [],
+    owners: [],
+    baseline: null,
+    minFiles: null,
+    writeBaseline: false,
+    allowBaselineGrowth: false,
+    dryRun: false,
+  }
+  const needsValue = (flag, value) => {
+    if (value === undefined) usageError(`${flag} requires a value`)
+    return value
+  }
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--src-dir') out.srcDir = argv[++i]
-    else if (argv[i] === '--baseline') out.baseline = argv[++i]
-    else if (argv[i] === '--write-baseline') out.writeBaseline = true
-    else if (argv[i] === '--dry-run') out.dryRun = true
+    const arg = argv[i]
+    if (arg === '--src-dir') out.srcDirs.push(needsValue(arg, argv[++i]))
+    else if (arg === '--owner') out.owners.push(needsValue(arg, argv[++i]))
+    else if (arg === '--baseline') out.baseline = needsValue(arg, argv[++i])
+    else if (arg === '--min-files') out.minFiles = Number(needsValue(arg, argv[++i]))
+    else if (arg === '--write-baseline') out.writeBaseline = true
+    else if (arg === '--allow-baseline-growth') out.allowBaselineGrowth = true
+    else if (arg === '--dry-run') out.dryRun = true
+    // An unknown flag used to be SILENTLY IGNORED, so `--srcdir /tmp/fixture`
+    // (a typo) scanned the real src/ and printed OK — a green run that never
+    // looked at what the caller asked about.
+    else usageError(`unknown argument ${JSON.stringify(arg)}`)
+  }
+  if (out.minFiles !== null && (!Number.isInteger(out.minFiles) || out.minFiles < 0)) {
+    usageError('--min-files requires a non-negative integer')
   }
   return out
 }
 
-function listJsFiles(dir) {
+function listSourceFiles(dir) {
   const out = []
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry)
-    if (statSync(full).isDirectory()) out.push(...listJsFiles(full))
-    else if (entry.endsWith('.js')) out.push(full)
+    if (statSync(full).isDirectory()) out.push(...listSourceFiles(full))
+    else if (SCANNED_EXTENSIONS.some((ext) => entry.endsWith(ext))) out.push(full)
   }
   return out.sort()
 }
@@ -109,9 +187,14 @@ function stripComments(source) {
   return out
 }
 
-// A home-rooted chroxy path: `homedir()` and `.chroxy` on the same statement.
-const RAW_HOME_ROOTED = /homedir\s*\(\s*\)/
-const CHROXY_SEGMENT = /['"`]\.chroxy['"`]/
+// A home-root expression. `process.env.HOME` is the same thing by another
+// spelling (tests/smoke-test.mjs uses it) and evaded a `homedir()`-only rule.
+const HOME_EXPR = /\bhomedir\s*\(\s*\)|\b(?:process\.)?env\.HOME\b/
+
+// `.chroxy` as a path segment. Two spellings, because a quote-delimited rule
+// missed both a combined segment ('.chroxy/logs/x' — the quote does not follow
+// `.chroxy`) and a template literal (`${homedir()}/.chroxy/x` — no quote at all).
+const CHROXY_SEGMENT = /['"`]\.chroxy(?=['"`/])|\/\.chroxy(?=['"`/]|$)/
 
 // A module-scope binding whose initializer calls the accessor. Column-0 means
 // top level: anything inside a function or class body is indented.
@@ -152,48 +235,91 @@ function accessorWrappersIn(codeLines) {
   return names
 }
 
-function findOffenders(srcDir) {
-  const offenders = []
-  for (const file of listJsFiles(srcDir)) {
-    const rel = relative(srcDir, file).split(pathSep).join('/')
-    if (rel === OWNER) continue
-
-    const source = readFileSync(file, 'utf8')
-    const rawLines = source.split('\n')
-    const code = stripComments(source)
-    const wrappers = accessorWrappersIn(code)
-    const callsAccessor = (text) =>
-      CALLS_ACCESSOR_DIRECTLY.test(text)
-      || [...wrappers].some((n) => new RegExp(`\\b${n}\\s*\\(`).test(text))
-      || /\bdefault[A-Z][\w$]*\s*\(/.test(text)
-
-    code.forEach((line, idx) => {
-      const prev = idx > 0 ? rawLines[idx - 1] : ''
-      if (prev.includes(IGNORE_MARKER)) return
-      const push = (kind) =>
-        offenders.push({ file: rel, line: idx + 1, kind, text: rawLines[idx].trim() })
-
-      if (RAW_HOME_ROOTED.test(line) && CHROXY_SEGMENT.test(line)) {
-        // `env.CHROXY_CONFIG_DIR` too, not just `process.env.…` — cli/tokens-cmd.js
-        // destructures `env` from its opts, and it is an inline copy all the same.
-        const inlineResolver = /\benv\.CHROXY_CONFIG_DIR/.test(line)
-        push(inlineResolver ? 'inline-resolver-copy' : 'hardcoded-home-path')
-        return
-      }
-
-      // Calling the accessor is not enough — WHERE you call it decides whether
-      // the env is read at the moment that matters. A module-scope
-      // `const P = configPath('session-state.json')` is exactly as frozen as
-      // the `join(homedir(), …)` it replaced: it evaluates once, at import,
-      // and no later `beforeEach` can move it. The migration would otherwise
-      // look complete while half the defect survived, which is the failure
-      // this whole issue is made of.
-      if (!MODULE_SCOPE_DECL.test(line)) return
-      const initializer = /=\s*$/.test(line.trimEnd()) ? line + (code[idx + 1] ?? '') : line
-      if (callsAccessor(initializer)) push('module-scope-capture')
-    })
+/**
+ * Names bound to a home-root expression anywhere in the file.
+ *
+ * `const home = homedir()` on one line and `join(home, '.chroxy')` on another
+ * is the same defect split across two statements, and the single-line rule could
+ * not see it. The two-step idiom is already live in the tree
+ * (`ws-file-ops/browser.js`, `devcontainer-config.js` — neither is a chroxy path
+ * today, which is exactly why this needed closing before one becomes one).
+ */
+function homeBoundVarsIn(codeLines) {
+  const names = new Set()
+  for (const line of codeLines) {
+    const m = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+)$/.exec(line)
+    if (m && HOME_EXPR.test(m[2])) names.add(m[1])
   }
-  return offenders
+  return names
+}
+
+/**
+ * Is the ignore marker genuinely a directive on this line?
+ *
+ * It used to be a substring test against the raw previous line, so a comment
+ * merely MENTIONING `lint-ignore-config-dir` — this file's own docstring does —
+ * silently exempted whatever followed it.
+ */
+function isIgnoreDirective(rawLine) {
+  return new RegExp(`^\\s*(?://|\\*|/\\*)\\s*${IGNORE_MARKER}\\b`).test(rawLine)
+}
+
+function findOffenders(srcDirs, ownerPaths, keyRoot) {
+  const offenders = []
+  const owners = new Set(ownerPaths.map((p) => resolve(p)))
+  let scanned = 0
+
+  for (const srcDir of srcDirs) {
+    for (const file of listSourceFiles(srcDir)) {
+      // Counted BEFORE the owner filter: this number answers "did the walk find
+      // the tree?", not "how many files survived exemptions". A repo whose only
+      // source file is the owner is legitimately nothing-to-check, and must not
+      // be conflated with a walk that resolved to an empty directory.
+      scanned++
+      if (owners.has(resolve(file))) continue
+      const rel = relative(keyRoot, file).split(pathSep).join('/')
+
+      const source = readFileSync(file, 'utf8')
+      const rawLines = source.split('\n')
+      const code = stripComments(source)
+      const wrappers = accessorWrappersIn(code)
+      const homeVars = homeBoundVarsIn(code)
+      const callsAccessor = (text) =>
+        CALLS_ACCESSOR_DIRECTLY.test(text)
+        || [...wrappers].some((n) => new RegExp(`\\b${n}\\s*\\(`).test(text))
+        || /\bdefault[A-Z][\w$]*\s*\(/.test(text)
+      const isHomeRooted = (text) =>
+        HOME_EXPR.test(text)
+        || [...homeVars].some((n) => new RegExp(`\\b${n}\\b`).test(text))
+
+      code.forEach((line, idx) => {
+        const prev = idx > 0 ? rawLines[idx - 1] : ''
+        if (isIgnoreDirective(prev)) return
+        const push = (kind) =>
+          offenders.push({ file: rel, line: idx + 1, kind, text: rawLines[idx].trim() })
+
+        if (isHomeRooted(line) && CHROXY_SEGMENT.test(line)) {
+          // `env.CHROXY_CONFIG_DIR` too, not just `process.env.…` — cli/tokens-cmd.js
+          // destructures `env` from its opts, and it is an inline copy all the same.
+          const inlineResolver = /\benv\.CHROXY_CONFIG_DIR/.test(line)
+          push(inlineResolver ? 'inline-resolver-copy' : 'hardcoded-home-path')
+          return
+        }
+
+        // Calling the accessor is not enough — WHERE you call it decides whether
+        // the env is read at the moment that matters. A module-scope
+        // `const P = configPath('session-state.json')` is exactly as frozen as
+        // the `join(homedir(), …)` it replaced: it evaluates once, at import,
+        // and no later `beforeEach` can move it. The migration would otherwise
+        // look complete while half the defect survived, which is the failure
+        // this whole issue is made of.
+        if (!MODULE_SCOPE_DECL.test(line)) return
+        const initializer = /=\s*$/.test(line.trimEnd()) ? line + (code[idx + 1] ?? '') : line
+        if (callsAccessor(initializer)) push('module-scope-capture')
+      })
+    }
+  }
+  return { offenders, scanned }
 }
 
 function readBaseline(path) {
@@ -207,13 +333,48 @@ function readBaseline(path) {
 }
 
 const args = parseArgs(process.argv.slice(2))
-const srcDir = resolve(args.srcDir ?? join(__dirname, '..', 'src'))
+const srcDirs = (args.srcDirs.length ? args.srcDirs : DEFAULT_SRC_DIRS).map((d) => resolve(d))
+const owners = args.owners.length
+  ? args.owners
+  : (args.srcDirs.length ? [join(srcDirs[0], 'config-dir.js')] : DEFAULT_OWNERS)
 const baselinePath = resolve(args.baseline ?? join(__dirname, 'lint-config-dir-baseline.txt'))
 
-const offenders = findOffenders(srcDir)
+for (const dir of srcDirs) {
+  if (!existsSync(dir)) usageError(`--src-dir does not exist: ${dir}`)
+}
+
+// Baseline keys are repo-relative for the real run (so a second scan root reads
+// as `packages/claude-hooks/src/config.js`, not `../../claude-hooks/…`), and
+// src-dir-relative when a caller points the lint at a fixture tree.
+const keyRoot = args.srcDirs.length ? srcDirs[0] : REPO_ROOT
+
+const { offenders, scanned } = findOffenders(srcDirs, owners, keyRoot)
 const offendingFiles = new Set(offenders.map((o) => o.file))
 
+// "Scanned zero files" and "scanned 298 clean files" used to be the same
+// observable outcome. An empty or renamed source root exited 0, which is a
+// guard reporting success without having checked anything —
+// docs/false-safety-guards.md names this as the least-solved failure mode.
+if (scanned === 0) {
+  usageError(`scanned 0 files under ${srcDirs.join(', ')} — refusing to report a clean tree`)
+}
+if (args.minFiles !== null && scanned < args.minFiles) {
+  usageError(`scanned only ${scanned} file(s), expected at least ${args.minFiles}. `
+    + 'Either the walk broke or --min-files is stale.')
+}
+
 if (args.writeBaseline) {
+  const existing = readBaseline(baselinePath)
+  const added = [...offendingFiles].filter((f) => !existing.has(f)).sort()
+  // The ratchet used to be a review-time convention, which meant a regenerate
+  // could silently re-add whatever it found. Now it fails closed.
+  if (added.length && !args.allowBaselineGrowth) {
+    console.error('Refusing to grow the baseline (#7052 ratchet: a file may LEAVE, never join):')
+    for (const f of added) console.error(`  + ${f}`)
+    console.error('')
+    console.error('Fix the file, or re-run with --allow-baseline-growth if this is a deliberate, reviewed exception.')
+    process.exit(2)
+  }
   const header = [
     '# Files that still resolve ~/.chroxy without going through src/config-dir.js.',
     '# Ratchet (#7052): a file may LEAVE this list, never join it.',
@@ -237,7 +398,7 @@ for (const o of newOffenders) {
 }
 if (newOffenders.length) {
   console.error('')
-  console.error(`${newOffenders.length} un-baselined site(s) resolve ~/.chroxy outside src/config-dir.js.`)
+  console.error(`${newOffenders.length} un-baselined site(s) resolve ~/.chroxy outside the owner module.`)
   console.error("Use configDir() / configPath(...) from './config-dir.js' — they read CHROXY_CONFIG_DIR per call.")
 }
 
@@ -248,6 +409,6 @@ for (const f of staleBaseline) {
 const failed = newOffenders.length > 0 || staleBaseline.length > 0
 if (!failed) {
   const exempt = baseline.size ? ` (${baseline.size} file(s) still baselined)` : ''
-  console.log(`OK: ~/.chroxy resolves through src/config-dir.js${exempt}.`)
+  console.log(`OK: ${scanned} file(s) scanned; ~/.chroxy resolves through the owner module${exempt}.`)
 }
 process.exit(failed && !args.dryRun ? 1 : 0)

--- a/packages/server/scripts/lint-config-dir.sh
+++ b/packages/server/scripts/lint-config-dir.sh
@@ -3,6 +3,13 @@
 # implementation. Kept as a shell entry point so CI can
 # `run: scripts/lint-config-dir.sh` without worrying about the Node interpreter
 # path on the runner image.
+#
+# `--min-files` is a FLOOR, not a count (#7239). It only ever fails closed: if
+# the walk breaks — a renamed source root, a filter that stops matching, a
+# scan-roots edit that silently resolves to nothing — the lint would otherwise
+# scan few or zero files and report a clean tree, which is indistinguishable
+# from actually being clean. The tree scans ~304 files today; 250 leaves room
+# for ordinary deletions while still catching a collapse.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec node ./scripts/lint-config-dir.mjs "$@"
+exec node ./scripts/lint-config-dir.mjs --min-files 250 "$@"

--- a/packages/server/tests/lint-config-dir.test.js
+++ b/packages/server/tests/lint-config-dir.test.js
@@ -18,7 +18,7 @@
  */
 import { test, describe, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -461,6 +461,271 @@ export function get() { return NAME }
       )
       assert.equal(res.status, 0)
       assert.match(res.stderr, /offender\.js:5/)
+    })
+  })
+
+  /**
+   * #7239 — shapes that EVADED the line-oriented rules.
+   *
+   * Each of these passed the lint before the fix, so each is a fixture proving
+   * a real hole is closed rather than a restatement of an existing rule. The
+   * `CLEAN` counterpart is included where the evasion is a spelling of an
+   * already-banned shape, so a rule that simply matched everything would not
+   * satisfy the pair.
+   */
+  describe('anti-evasion (#7239)', () => {
+    test('two-step: const home = homedir() then join(home, .chroxy)', () => {
+      // The idiom is already live in the tree (ws-file-ops/browser.js,
+      // devcontainer-config.js) — neither is a chroxy path today, which is
+      // exactly why this needed closing before one becomes one.
+      const r = runLint({
+        'two-step.js': `
+import { homedir } from 'os'
+import { join } from 'path'
+const home = homedir()
+export function statePath() {
+  return join(home, '.chroxy', 'session-state.json')
+}
+`,
+      })
+      assert.equal(r.status, 1, r.stdout)
+      assert.match(r.stderr, /two-step\.js:6\s+\[hardcoded-home-path\]/)
+    })
+
+    test('two-step does NOT fire on a home var with no .chroxy segment', () => {
+      // The other half of the pair: `const home = homedir()` is a perfectly
+      // ordinary line, and flagging it everywhere would make the rule useless.
+      const r = runLint({
+        'unrelated-home.js': `
+import { homedir } from 'os'
+import { join } from 'path'
+const home = homedir()
+export function sshDir() {
+  return join(home, '.ssh', 'config')
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+
+    test('template literal: `${homedir()}/.chroxy/x`', () => {
+      const r = runLint({
+        'tpl.js': `
+import { homedir } from 'os'
+export function statePath() {
+  return \`\${homedir()}/.chroxy/session-state.json\`
+}
+`,
+      })
+      assert.equal(r.status, 1, r.stdout)
+      assert.match(r.stderr, /tpl\.js:4\s+\[hardcoded-home-path\]/)
+    })
+
+    test('combined segment: join(homedir(), ".chroxy/logs/x")', () => {
+      const r = runLint({
+        'combined.js': `
+import { homedir } from 'os'
+import { join } from 'path'
+export function logPath() {
+  return join(homedir(), '.chroxy/logs/chroxy.log')
+}
+`,
+      })
+      assert.equal(r.status, 1, r.stdout)
+      assert.match(r.stderr, /combined\.js:5\s+\[hardcoded-home-path\]/)
+    })
+
+    test('process.env.HOME instead of homedir()', () => {
+      const r = runLint({
+        'env-home.js': `
+import { join } from 'path'
+export function statePath() {
+  return join(process.env.HOME, '.chroxy', 'session-state.json')
+}
+`,
+      })
+      assert.equal(r.status, 1, r.stdout)
+      assert.match(r.stderr, /env-home\.js:4\s+\[hardcoded-home-path\]/)
+    })
+
+    test('.mjs and .cjs sources are scanned', () => {
+      // packages/server/scripts/ is entirely .mjs, so a whole class of file was
+      // invisible to a walk that filtered on `.js`.
+      const mjs = runLint({ 'tool.mjs': HARDCODED })
+      assert.equal(mjs.status, 1, mjs.stdout)
+      assert.match(mjs.stderr, /tool\.mjs:5/)
+
+      const cjs = runLint({ 'tool.cjs': HARDCODED })
+      assert.equal(cjs.status, 1, cjs.stdout)
+      assert.match(cjs.stderr, /tool\.cjs:5/)
+    })
+
+    test('a comment merely MENTIONING the marker does not exempt the next line', () => {
+      // The marker was matched as a substring of the raw previous line, so prose
+      // about the lint silently disabled it. This lint's own docstring mentions
+      // the marker several times.
+      const r = runLint({
+        'prose.js': `
+import { homedir } from 'os'
+import { join } from 'path'
+export function statePath() {
+  // Historically this needed a lint-ignore-config-dir directive, but not now.
+  return join(homedir(), '.chroxy', 'session-state.json')
+}
+`,
+      })
+      assert.equal(r.status, 1, r.stdout)
+      assert.match(r.stderr, /prose\.js:6/)
+    })
+
+    test('POSITIVE CONTROL: a real directive on the previous line still exempts', () => {
+      // Proves the test above failed because of the prose/directive distinction,
+      // not because the ignore mechanism was broken outright.
+      const r = runLint({
+        'directive.js': `
+import { homedir } from 'os'
+import { join } from 'path'
+export function statePath() {
+  // lint-ignore-config-dir
+  return join(homedir(), '.chroxy', 'session-state.json')
+}
+`,
+      })
+      assert.equal(r.status, 0, r.stderr)
+    })
+  })
+
+  /**
+   * #7239 — the lint failing to RUN must be distinguishable from the tree being
+   * clean. All of these exit 2: not 0 (a false pass) and not 1 (which would
+   * blame the code for a broken guard).
+   */
+  describe('the guard cannot silently no-op (#7239)', () => {
+    const runRaw = (args) =>
+      spawnSync(process.execPath, [LINT_SCRIPT, ...args], { encoding: 'utf8' })
+
+    const fixtureRoot = (files) => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-configdir-noop-'))
+      tmpRoots.push(root)
+      const srcDir = join(root, 'src')
+      mkdirSync(srcDir, { recursive: true })
+      for (const [rel, source] of Object.entries(files)) {
+        const full = join(srcDir, rel)
+        mkdirSync(dirname(full), { recursive: true })
+        writeFileSync(full, source)
+      }
+      return { root, srcDir, baseline: join(root, 'none.txt') }
+    }
+
+    test('an unknown flag is rejected, not ignored', () => {
+      // `--srcdir` (a typo for --src-dir) used to be dropped on the floor, so
+      // the lint scanned the REAL src/ and reported OK — a green run that never
+      // looked at what the caller asked about.
+      const { srcDir } = fixtureRoot({ 'offender.js': HARDCODED })
+      const res = runRaw(['--srcdir', srcDir])
+      assert.equal(res.status, 2)
+      assert.match(res.stderr, /unknown argument/)
+    })
+
+    test('a flag missing its value is rejected', () => {
+      const res = runRaw(['--src-dir'])
+      assert.equal(res.status, 2)
+      assert.match(res.stderr, /requires a value/)
+    })
+
+    test('scanning zero files fails instead of reporting clean', () => {
+      const { srcDir, baseline } = fixtureRoot({})
+      const res = runRaw(['--src-dir', srcDir, '--baseline', baseline])
+      assert.equal(res.status, 2)
+      assert.match(res.stderr, /scanned 0 files/)
+    })
+
+    test('a nonexistent src dir fails instead of reporting clean', () => {
+      const { root, baseline } = fixtureRoot({})
+      const res = runRaw(['--src-dir', join(root, 'nope'), '--baseline', baseline])
+      assert.equal(res.status, 2)
+      assert.match(res.stderr, /does not exist/)
+    })
+
+    test('--min-files fails when the walk returns fewer files than the floor', () => {
+      const { srcDir, baseline } = fixtureRoot({ 'a.js': CLEAN })
+      const res = runRaw(['--src-dir', srcDir, '--baseline', baseline, '--min-files', '10'])
+      assert.equal(res.status, 2)
+      assert.match(res.stderr, /scanned only 1 file/)
+    })
+
+    test('POSITIVE CONTROL: the same tree passes under a floor it meets', () => {
+      // Proves the failure above came from the floor, not from the fixture
+      // being broken in some other way.
+      const { srcDir, baseline } = fixtureRoot({ 'a.js': CLEAN })
+      const res = runRaw(['--src-dir', srcDir, '--baseline', baseline, '--min-files', '1'])
+      assert.equal(res.status, 0, res.stderr)
+    })
+
+    test('--min-files rejects a non-integer', () => {
+      const { srcDir } = fixtureRoot({ 'a.js': CLEAN })
+      const res = runRaw(['--src-dir', srcDir, '--min-files', 'lots'])
+      assert.equal(res.status, 2)
+    })
+  })
+
+  /**
+   * #7239 — "a file may leave the baseline, never join it" was a review-time
+   * convention, so `--write-baseline` would happily re-add whatever it found.
+   */
+  describe('the ratchet is enforced, not just documented (#7239)', () => {
+    const writeBaselineRun = (extraArgs) => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-configdir-ratchet-'))
+      tmpRoots.push(root)
+      const srcDir = join(root, 'src')
+      mkdirSync(srcDir, { recursive: true })
+      writeFileSync(join(srcDir, 'offender.js'), HARDCODED)
+      const baseline = join(root, 'baseline.txt')
+      writeFileSync(baseline, '# empty\n')
+
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--src-dir', srcDir, '--baseline', baseline, '--write-baseline', ...extraArgs],
+        { encoding: 'utf8' }
+      )
+      return { res, baseline }
+    }
+
+    test('--write-baseline refuses to ADD a file', () => {
+      const { res, baseline } = writeBaselineRun([])
+      assert.equal(res.status, 2)
+      assert.match(res.stderr, /Refusing to grow the baseline/)
+      assert.match(readFileSync(baseline, 'utf8'), /^# empty$/m)
+      assert.doesNotMatch(readFileSync(baseline, 'utf8'), /offender\.js/)
+    })
+
+    test('POSITIVE CONTROL: --allow-baseline-growth permits it', () => {
+      // Proves the refusal is the ratchet and not --write-baseline being broken.
+      const { res, baseline } = writeBaselineRun(['--allow-baseline-growth'])
+      assert.equal(res.status, 0, res.stderr)
+      assert.match(readFileSync(baseline, 'utf8'), /offender\.js/)
+    })
+  })
+
+  describe('multiple scan roots (#7239)', () => {
+    test('every --src-dir is walked, and keys are relative to the first', () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-configdir-multi-'))
+      tmpRoots.push(root)
+      const a = join(root, 'a')
+      const b = join(root, 'b')
+      mkdirSync(a, { recursive: true })
+      mkdirSync(b, { recursive: true })
+      writeFileSync(join(a, 'clean.js'), CLEAN)
+      writeFileSync(join(b, 'offender.js'), HARDCODED)
+
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--src-dir', a, '--src-dir', b, '--baseline', join(root, 'none.txt')],
+        { encoding: 'utf8' }
+      )
+      assert.equal(res.status, 1)
+      // The second root is genuinely walked — this is the whole point of #7239.
+      assert.match(res.stderr, /\.\.\/b\/offender\.js:5/)
     })
   })
 })

--- a/scripts/__tests__/docker-entrypoint.test.sh
+++ b/scripts/__tests__/docker-entrypoint.test.sh
@@ -130,8 +130,18 @@ tmp="$(mktemp -d)"
   export CHROXY_CONFIG_DIR="$tmp/relocated"
   bash "$ENTRYPOINT" start >/dev/null 2>&1
 )
-mode="$(stat -f '%Lp' "$tmp/relocated/config.json" 2>/dev/null \
-     || stat -c '%a' "$tmp/relocated/config.json" 2>/dev/null)"
+# GNU and BSD stat disagree, and the obvious `stat -f … || stat -c …` is WRONG
+# on Linux: GNU's `-f` is --file-system, so it does not fail — it prints a
+# filesystem block, and the fallback then appends the real mode to it. Probe
+# with the flag itself, discarding output, and only then read the value.
+file_mode() {
+  if stat -c '%a' "$1" >/dev/null 2>&1; then
+    stat -c '%a' "$1"        # GNU coreutils
+  else
+    stat -f '%Lp' "$1"       # BSD / macOS
+  fi
+}
+mode="$(file_mode "$tmp/relocated/config.json" 2>/dev/null)"
 if [ "$mode" = "600" ]; then
   pass "the relocated config.json is chmod 600"
 else

--- a/scripts/__tests__/docker-entrypoint.test.sh
+++ b/scripts/__tests__/docker-entrypoint.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# docker-entrypoint.test.sh — tests for scripts/docker-entrypoint.sh (#7239).
+#
+# The entrypoint hardcoded `CONFIG_DIR="$HOME/.chroxy"` while the daemon honours
+# CHROXY_CONFIG_DIR, so `docker run -e CHROXY_CONFIG_DIR=/data` split the
+# container in two: the entrypoint wrote config.json to the mounted volume at
+# ~/.chroxy, and the daemon read /data — an unmounted, ephemeral path — for
+# everything else. The token survived by accident (the entrypoint exports
+# API_TOKEN and server-cli falls back to it), which is exactly why the split was
+# silent: the daemon started fine while every piece of persistent state was
+# being destroyed on each restart.
+#
+# Strategy: run `prepare_config` for real, then assert WHICH directory the
+# config landed in. The entrypoint's final `exec node /app/...` fails in this
+# harness (that path does not exist outside the image) and that is fine — it
+# happens strictly after prepare_config has written the file we assert on.
+#
+# No external test framework — same zero-dep convention as bump-version.test.sh.
+#
+# Run from repo root:
+#   bash scripts/__tests__/docker-entrypoint.test.sh
+#
+# Exit status: 0 if all tests pass, 1 otherwise.
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ENTRYPOINT="$REPO_ROOT/scripts/docker-entrypoint.sh"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+pass() { PASS=$((PASS + 1)); echo "  ok   - $1"; }
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILED_TESTS+=("$1")
+  echo "  FAIL - $1"
+  [ -n "${2:-}" ] && echo "         $2"
+}
+
+# Each case runs the entrypoint's `start` path in a subshell with an isolated
+# HOME. CHROXY_CONFIG_DIR is set or unset EXPLICITLY every time — an inherited
+# value from the developer's shell would make these assertions vacuous, which is
+# the exact way a control stops controlling.
+#
+# The trailing `exec node /app/...` fails here (that path exists only in the
+# image); it runs strictly after prepare_config has written the file asserted on.
+
+echo "docker-entrypoint.sh (#7239)"
+
+# --- 1. The bug: an override must be honoured ------------------------------
+tmp="$(mktemp -d)"
+(
+  export HOME="$tmp/home"
+  mkdir -p "$HOME"
+  export ANTHROPIC_API_KEY="sk-ant-test"
+  export CHROXY_CONFIG_DIR="$tmp/relocated"
+  bash "$ENTRYPOINT" start >/dev/null 2>&1
+)
+if [ -f "$tmp/relocated/config.json" ]; then
+  pass "CHROXY_CONFIG_DIR is honoured — config lands in the relocated root"
+else
+  fail "CHROXY_CONFIG_DIR is honoured — config lands in the relocated root" \
+       "expected $tmp/relocated/config.json to exist"
+fi
+
+if [ ! -f "$tmp/home/.chroxy/config.json" ]; then
+  pass "config does NOT also land in \$HOME/.chroxy (the split-brain)"
+else
+  fail "config does NOT also land in \$HOME/.chroxy (the split-brain)" \
+       "entrypoint wrote to \$HOME/.chroxy while the daemon reads CHROXY_CONFIG_DIR"
+fi
+rm -rf "$tmp"
+
+# --- 2. POSITIVE CONTROL: the default is unchanged -------------------------
+# Proves the assertions above come from the override being honoured, not from
+# the entrypoint having stopped writing config at all.
+tmp="$(mktemp -d)"
+(
+  export HOME="$tmp/home"
+  mkdir -p "$HOME"
+  export ANTHROPIC_API_KEY="sk-ant-test"
+  unset CHROXY_CONFIG_DIR
+  bash "$ENTRYPOINT" start >/dev/null 2>&1
+)
+if [ -f "$tmp/home/.chroxy/config.json" ]; then
+  pass "POSITIVE CONTROL: with no override, config still lands in \$HOME/.chroxy"
+else
+  fail "POSITIVE CONTROL: with no override, config still lands in \$HOME/.chroxy" \
+       "expected $tmp/home/.chroxy/config.json to exist"
+fi
+rm -rf "$tmp"
+
+# --- 3. Token preservation across restarts, in the relocated root ----------
+# The entrypoint preserves an existing apiToken so a restart does not re-pair
+# every device. That has to keep working at the relocated path, not just at the
+# default one.
+tmp="$(mktemp -d)"
+(
+  export HOME="$tmp/home"
+  mkdir -p "$HOME"
+  export ANTHROPIC_API_KEY="sk-ant-test"
+  export CHROXY_CONFIG_DIR="$tmp/relocated"
+  bash "$ENTRYPOINT" start >/dev/null 2>&1
+)
+first="$(node -e "process.stdout.write(require('$tmp/relocated/config.json').apiToken||'')" 2>/dev/null)"
+(
+  export HOME="$tmp/home"
+  export ANTHROPIC_API_KEY="sk-ant-test"
+  export CHROXY_CONFIG_DIR="$tmp/relocated"
+  bash "$ENTRYPOINT" start >/dev/null 2>&1
+)
+second="$(node -e "process.stdout.write(require('$tmp/relocated/config.json').apiToken||'')" 2>/dev/null)"
+if [ -n "$first" ] && [ "$first" = "$second" ]; then
+  pass "the apiToken survives a restart in the relocated root"
+else
+  fail "the apiToken survives a restart in the relocated root" \
+       "first='$first' second='$second'"
+fi
+rm -rf "$tmp"
+
+# --- 4. Mode: the config file holds a token and must not be world-readable --
+tmp="$(mktemp -d)"
+(
+  export HOME="$tmp/home"
+  mkdir -p "$HOME"
+  export ANTHROPIC_API_KEY="sk-ant-test"
+  export CHROXY_CONFIG_DIR="$tmp/relocated"
+  bash "$ENTRYPOINT" start >/dev/null 2>&1
+)
+mode="$(stat -f '%Lp' "$tmp/relocated/config.json" 2>/dev/null \
+     || stat -c '%a' "$tmp/relocated/config.json" 2>/dev/null)"
+if [ "$mode" = "600" ]; then
+  pass "the relocated config.json is chmod 600"
+else
+  fail "the relocated config.json is chmod 600" "got mode '$mode'"
+fi
+rm -rf "$tmp"
+
+echo ""
+echo "passed: $PASS  failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  for t in "${FAILED_TESTS[@]}"; do echo "  - $t"; done
+  exit 1
+fi
+exit 0

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONFIG_DIR="$HOME/.chroxy"
+# #7239 — honour the override the daemon itself honours. This was
+# `CONFIG_DIR="$HOME/.chroxy"`, so `docker run -e CHROXY_CONFIG_DIR=/data` split
+# the container in two: the entrypoint wrote config.json to ~/.chroxy (the
+# mounted `chroxy-data` volume) while the daemon read /data for everything.
+#
+# The token survived that split by accident — the entrypoint exports API_TOKEN
+# and server-cli falls back to it — so the failure looked like nothing was
+# wrong. What actually broke is everything else: server-identity.json,
+# credentials.json, session-state.json, scheduled-tasks.json and the trust
+# ledgers all landed in an UNMOUNTED container path and were destroyed on every
+# restart, while the volume sat mounted where nothing wrote to it. A regenerated
+# identity key is the sharp end of that — pinned clients report it as a possible
+# MITM.
+CONFIG_DIR="${CHROXY_CONFIG_DIR:-$HOME/.chroxy}"
 CONFIG_FILE="$CONFIG_DIR/config.json"
 
 # --- Helper: prepare config for server start ---


### PR DESCRIPTION
Closes #7239

## The real bug it exposed

`scripts/docker-entrypoint.sh` hardcoded `$HOME/.chroxy` while the daemon honours `CHROXY_CONFIG_DIR`. So `docker run -e CHROXY_CONFIG_DIR=/data` split the container in two: the entrypoint wrote `config.json` to the mounted `chroxy-data` volume at `~/.chroxy`, while the daemon read `/data` for everything else.

**I have to correct the issue on the consequence.** #7239 predicted a fresh token minted on every restart. The token is the one thing that *did* survive — the entrypoint `export`s `API_TOKEN` and `server-cli`'s precedence is `config.apiToken || getToken() || process.env.API_TOKEN`. That accident is exactly why this was silent: the daemon booted and looked healthy.

What actually broke is worse. `server-identity.json`, `credentials.json`, `session-state.json`, `scheduled-tasks.json` and the four trust ledgers all landed in an **unmounted** container path, destroyed on every restart, while the volume sat mounted where nothing wrote to it. A regenerated identity key is the sharp end — pinned clients report it as a possible MITM.

Fix is one line, plus a note in `docker-compose.yml` where someone would add the passthrough (it is deliberately absent today, so the default is safe).

## Scope decisions

The gate scanned only `packages/server/src` while its CI step was named "Check ~/.chroxy resolves through config-dir.js".

| Surface | Decision |
|---|---|
| `packages/claude-hooks/src` | **Now scanned.** Zero-runtime-dep by design (#5885), so it cannot import the server's accessor — its one resolver is **baselined with a note**, not "fixed". The point is that a *second* copy there is now caught. |
| `scripts/` (repo + package) | **Out of scope, stated.** The linter lives there and would scan its own pattern definitions. |
| `.ts` | **Out of scope, stated.** No TS package resolves a chroxy root today; the extension list makes it a one-line change if that changes. |
| `.mjs` / `.cjs` | **Now scanned** — `packages/server/scripts/` is entirely `.mjs`, so a whole class of file was invisible. |

The CI step name now says what is covered rather than implying the whole repo.

## Anti-evasion — each with a fixture

All were live holes: a two-step `const home = homedir()` … `join(home, '.chroxy')` (**this idiom already exists in the tree** at `ws-file-ops/browser.js` and `devcontainer-config.js` — neither is a chroxy path *today*, which is why it needed closing first); a template literal; a combined `'.chroxy/logs/x'` segment; `process.env.HOME`; `.mjs`/`.cjs`; and an ignore marker that merely **appears in prose** on the previous line — this linter's own docstring mentions it several times.

## The guard can no longer silently no-op

`docs/false-safety-guards.md` names "scanned zero files == scanned 298 clean files" as the least-solved failure mode. **Exit 2** — deliberately distinct from 1, so "the guard broke" never reads as "the code is dirty" and never reads as green — now covers: zero files scanned, falling below `--min-files` (a floor, not a count; it only fails closed), an **unknown flag** (a typo'd `--srcdir` used to be ignored, so the lint scanned the real `src/` and printed OK), a flag missing its value, and a nonexistent `--src-dir`.

The "may leave, never join" ratchet is now enforced by `--write-baseline` rather than left to review.

## Verification — differential, not just green

Green on its own would prove nothing here, so every new fixture was run against **`origin/main`'s linter**:

- **14 of 18 fail** against the old linter. The 4 that pass are exactly the permissive controls — `two-step does NOT fire without a .chroxy segment`, `a real directive still exempts`, and the two `--allow`/floor-met controls — which by design should pass under both.
- The entrypoint test **fails 4/5 against the old entrypoint**, passing only its positive control (default behaviour unchanged).

Also: 51/51 lint tests, 25/25 `bump-version.sh` tests still green, all six custom server lints green, `ci.yml` parses and the new step is in the right job. Full server suite 13289 tests, **4 failures identical to `origin/main`'s** (verified by name): one needs `OPENAI_API_KEY`, two hit a live local daemon on `:8765`, one is a Rust/clap harness check.

## Note

Stacked conceptually on #7242 (#7240) but branched from `main` and touches disjoint files — either can merge first.