### PR TITLE
fix(ci): fail on a FOURTH hand-rolled entry-point guard, not just on drift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,9 @@
 packages/server/node_modules
 packages/server/tests
 packages/server/coverage
+# Dev-only lints. They are never run in the image, and lint-entry-point-guard.mjs
+# imports repo-root scripts/lib/, which the image does not copy — so shipping
+# them would put a module with an unresolvable import inside the container
+# (inert, but pointless). fix-node-pty-helper.js is the one the build needs.
+packages/server/scripts/lint-*
+packages/server/scripts/lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,40 @@ jobs:
             exit 1
           fi
 
+      - name: Check no hand-rolled entry-point guard exists (whole repo, JS/TS only)
+        run: |
+          # Issue #7235 — #7198 was one guard hand-rolled in four files, three
+          # of them wrong, and its failure mode is SILENCE: the guard reads
+          # false, main() never runs, the process exits 0. #7222 added a drift
+          # gate keeping the three surviving copies identical, but that gate
+          # iterates a hardcoded three-element list, so a FOURTH copy is
+          # invisible to it. This lint is the other half: it walks the repo and
+          # fails on any entry-point determination outside the sanctioned set.
+          #
+          # Deliberately REPO-WIDE and not packages/server: two of the three
+          # sanctioned copies live outside it, and so could a fourth. The step
+          # name says what is actually covered — .js/.mjs/.cjs/.ts/.tsx/.jsx.
+          # Shell is NOT walked (docker-entrypoint.sh's `node -e` uses the same
+          # argv slot for a config path), and neither is generated dist/.
+          #
+          # Exit 2 means the lint could not do its job (bad flags, a sanctioned
+          # path that vanished, or it walked fewer files than its floor) and is
+          # reported separately from exit 1 — "the guard broke" must never be
+          # shown as "the guard passed", nor as "the code is dirty".
+          set +e
+          scripts/lint-entry-point-guard.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "OK — entry-point-ness is decided in the sanctioned files only"
+          elif [ "$rc" -eq 2 ]; then
+            echo "::error::lint-entry-point-guard could not run (bad flags, a stale allowlist entry, or it walked fewer files than --min-files). The GUARD is broken, not necessarily the code. See packages/server/scripts/lint-entry-point-guard.mjs."
+            exit 1
+          else
+            echo "::error::A file decides 'was this module run directly?' by hand, or a sanctioned-copy allowlist entry is stale. Import isEntryPoint instead. See packages/server/scripts/lint-entry-point-guard.sh."
+            exit 1
+          fi
+
   dashboard-tests:
     name: Dashboard Tests
     needs: runner-target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,21 +421,24 @@ jobs:
             exit 1
           fi
 
-      - name: Check no hand-rolled entry-point guard exists (whole repo, JS/TS only)
+      - name: Check no hand-rolled entry-point guard exists (JS/TS sources, excluding generated dist/)
         run: |
-          # Issue #7235 — #7198 was one guard hand-rolled in four files, three
-          # of them wrong, and its failure mode is SILENCE: the guard reads
-          # false, main() never runs, the process exits 0. #7222 added a drift
-          # gate keeping the three surviving copies identical, but that gate
-          # iterates a hardcoded three-element list, so a FOURTH copy is
-          # invisible to it. This lint is the other half: it walks the repo and
-          # fails on any entry-point determination outside the sanctioned set.
+          # Issue #7235 — #7198 and the #7213 sweep found one guard hand-rolled
+          # in four files, and ALL FOUR were wrong. Its failure mode is SILENCE:
+          # the guard reads false, main() never runs, the process exits 0. #7222
+          # added a drift gate keeping the three surviving copies identical, but
+          # that gate iterates a hardcoded three-element list, so a FOURTH copy
+          # is invisible to it. This lint is the other half: it walks the tree
+          # and fails on any entry-point determination outside the sanctioned
+          # set.
           #
-          # Deliberately REPO-WIDE and not packages/server: two of the three
+          # Deliberately not scoped to packages/server: two of the three
           # sanctioned copies live outside it, and so could a fourth. The step
-          # name says what is actually covered — .js/.mjs/.cjs/.ts/.tsx/.jsx.
-          # Shell is NOT walked (docker-entrypoint.sh's `node -e` uses the same
-          # argv slot for a config path), and neither is generated dist/.
+          # name says what is actually covered, because a gate that overclaims
+          # in its own title is #7239 — walked are
+          # .js/.mjs/.cjs/.ts/.mts/.cts/.tsx/.jsx; NOT walked are shell
+          # (docker-entrypoint.sh's `node -e` uses the same argv slot for a
+          # config path) and the 65 committed files under generated dist/.
           #
           # Exit 2 means the lint could not do its job (bad flags, a sanctioned
           # path that vanished, or it walked fewer files than its floor) and is

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -242,6 +242,8 @@ was checked against `--help` on the pinned version for exactly this reason.
   (`scripts/lib/entry-point-guard-copies.mjs` is the list, and says why), and
   two gates hold it: `scripts/__tests__/is-entry-point.test.mjs` fails if the
   three diverge (`#7222`), and
-  `packages/server/scripts/lint-entry-point-guard.mjs` walks the repo and fails
-  if a fourth appears (`#7235`). Both copies are unit-tested; the server's own
-  suite is `packages/server/tests/is-entry-point.test.js`.
+  `packages/server/scripts/lint-entry-point-guard.mjs` walks the tree and fails
+  if a fourth appears (`#7235`). The two importable copies each have their own
+  suite — `packages/server/tests/is-entry-point.test.js` and
+  `scripts/__tests__/is-entry-point.test.mjs`; the sidecar's inline third copy
+  is held only by the drift gate, since it cannot be imported to be tested.

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -188,6 +188,17 @@ fixes.
 targets from the config, flows from the runner's own inventory. A hardcoded
 list is correct exactly once (`#7192`, `#7197`).
 
+**When the set genuinely cannot be derived, invert the list instead.** Some sets
+have no manifest to read — the entry-point guard exists in three files that
+cannot import one another, and nothing in the repo declares that. A list of
+things to CHECK fails silently when it falls behind; a list of things EXEMPT
+from a walk over everything fails loudly, because the walk hits the missing
+entry and complains. Same data structure, opposite failure direction. `#7222`
+kept its three copies identical by iterating a hardcoded list, and `#7235` added
+the walk that says there are only three — the second is what makes the first's
+list safe to hardcode, and both now read the same list so they cannot disagree
+about which files they mean.
+
 **Not-checkable must be an error, not a skip.** "I cannot verify this shape" and
 "there is nothing to verify" are different outcomes. Conflating them is how
 `#7195`, `#7210`, and `#7198` all read as success. Throw, and name what could
@@ -226,7 +237,11 @@ was checked against `--help` on the pinned version for exactly this reason.
 - `scripts/verify-publish-artifacts.mjs` — packs, installs, and runs; derives
   its entry points from the published manifests
 - `scripts/check-release-pr-subject.mjs` — content-triggered, fails closed
-- `packages/server/src/utils/is-entry-point.js` — the entry-point guard, and
-  the only copy of it that is unit-tested (`packages/server/tests/is-entry-point.test.js`).
-  Sites outside that package cannot import it and carry their own copies;
-  `#7222` tracks collapsing them onto one implementation.
+- `packages/server/src/utils/is-entry-point.js` — the entry-point guard. It
+  exists in three files that cannot import one another
+  (`scripts/lib/entry-point-guard-copies.mjs` is the list, and says why), and
+  two gates hold it: `scripts/__tests__/is-entry-point.test.mjs` fails if the
+  three diverge (`#7222`), and
+  `packages/server/scripts/lint-entry-point-guard.mjs` walks the repo and fails
+  if a fourth appears (`#7235`). Both copies are unit-tested; the server's own
+  suite is `packages/server/tests/is-entry-point.test.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18273,7 +18273,8 @@
       "devDependencies": {
         "c8": "^11.0.0",
         "eslint": "^9.39.3",
-        "playwright": "^1.58.2"
+        "playwright": "^1.58.2",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=22"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "c8": "^11.0.0",
     "eslint": "^9.39.3",
-    "playwright": "^1.58.2"
+    "playwright": "^1.58.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/server/scripts/lib/strip-comments.mjs
+++ b/packages/server/scripts/lib/strip-comments.mjs
@@ -1,0 +1,58 @@
+/**
+ * strip-comments.mjs — blank out JS comments, preserving every offset.
+ *
+ * Extracted verbatim from `lint-claude-family-explicit.mjs` (#5891) when
+ * `lint-entry-point-guard.mjs` (#7235) needed the same thing, rather than
+ * writing a fourth copy of it in the very PR whose subject is "stop the fourth
+ * hand-rolled copy of a thing".
+ *
+ * Two other lints still carry their own: `lint-config-dir.mjs` returns an ARRAY
+ * of stripped lines and is not string-aware, and `lint-session-opt-forwarding.mjs`
+ * drops line-comment text entirely rather than blanking it. Neither is a drop-in
+ * for this signature, so migrating them is real work with its own review — it is
+ * filed rather than smuggled in here.
+ *
+ * String literals are deliberately LEFT INTACT. Every consumer so far wants that:
+ * a lint fixture embedded in a template literal is text the lint should still be
+ * able to see, and a construct written inside a string is not a real occurrence
+ * of it either way. A consumer that needs strings blanked too should say so
+ * explicitly rather than assume it.
+ */
+
+/**
+ * Replace `//` line comments and block comments with spaces, keeping newlines,
+ * so every character index and line number in the result matches the input.
+ *
+ * @param {string} src
+ * @returns {string} the same length as `src`, with comment spans blanked
+ */
+export function stripComments(src) {
+  let out = ''
+  let i = 0
+  const n = src.length
+  let inStr = null
+  while (i < n) {
+    const ch = src[i]
+    if (inStr) {
+      out += ch
+      if (ch === '\\' && i + 1 < n) { out += src[i + 1]; i += 2; continue }
+      if (ch === inStr) inStr = null
+      i++
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; out += ch; i++; continue }
+    if (ch === '/' && src[i + 1] === '/') {
+      while (i < n && src[i] !== '\n') { out += ' '; i++ }
+      continue
+    }
+    if (ch === '/' && src[i + 1] === '*') {
+      out += '  '; i += 2
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) { out += src[i] === '\n' ? '\n' : ' '; i++ }
+      if (i < n) { out += '  '; i += 2 }
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}

--- a/packages/server/scripts/lib/strip-comments.mjs
+++ b/packages/server/scripts/lib/strip-comments.mjs
@@ -1,58 +1,138 @@
 /**
- * strip-comments.mjs — blank out JS comments, preserving every offset.
+ * strip-comments.mjs — blank out JS/TS comments, preserving every offset.
  *
- * Extracted verbatim from `lint-claude-family-explicit.mjs` (#5891) when
- * `lint-entry-point-guard.mjs` (#7235) needed the same thing, rather than
- * writing a fourth copy of it in the very PR whose subject is "stop the fourth
- * hand-rolled copy of a thing".
+ * ## Why this is a parser and not a regex loop
  *
- * Two other lints still carry their own: `lint-config-dir.mjs` returns an ARRAY
- * of stripped lines and is not string-aware, and `lint-session-opt-forwarding.mjs`
- * drops line-comment text entirely rather than blanking it. Neither is a drop-in
- * for this signature, so migrating them is real work with its own review — it is
- * filed rather than smuggled in here.
+ * This started life as a hand-written character scanner, extracted from
+ * `lint-claude-family-explicit.mjs` (#5891) when `lint-entry-point-guard.mjs`
+ * (#7235) needed the same thing. Review of #7247 proved that scanner unsound in
+ * BOTH directions, on real files in this repo, because it could not tell a
+ * regex literal from a comment delimiter:
  *
- * String literals are deliberately LEFT INTACT. Every consumer so far wants that:
- * a lint fixture embedded in a template literal is text the lint should still be
- * able to see, and a construct written inside a string is not a real occurrence
- * of it either way. A consumer that needs strings blanked too should say so
- * explicitly rather than assume it.
+ *   - `u.replace(/\/*$/, '')` — the `\/` leaves a `/`, the next char is `*`, and
+ *     the scanner reads `/*` as a BLOCK COMMENT OPEN. Everything to the next
+ *     `*​/` or EOF is blanked, so any code after it is invisible to the caller.
+ *     That is a silent false negative: a guard hidden behind an ordinary
+ *     trailing-slash trim would never be found.
+ *   - `/(["])/g` — the `"` inside the character class put the scanner into a
+ *     phantom STRING state, so it stopped blanking comments for the rest of the
+ *     file. That is a false positive: ordinary prose then reads as code.
+ *
+ * Measured across the 1903 files the entry-point lint walks: 83 files differed
+ * from the truth, 40 of them hiding real code and 51 leaking comment text. Both
+ * numbers are the false-safety class `docs/false-safety-guards.md` is about, in
+ * a module whose entire job is to let a guard read source correctly.
+ *
+ * Distinguishing `/` as regex-start from `/` as division cannot be done by
+ * scanning characters — it needs the grammar. So this asks a real parser.
+ * TypeScript's is used rather than acorn's because the callers walk `.ts`/`.tsx`
+ * as well as `.js`, and acorn cannot parse those. Over those same 1903 files it
+ * produces zero parse failures and takes ~2.4s.
+ *
+ * ## Contract
+ *
+ * The result is the SAME LENGTH as the input, with comment spans replaced by
+ * spaces and newlines preserved, so every index and line number a caller
+ * computes on the result is valid on the original. That invariant is asserted,
+ * not assumed: a violation throws rather than returning subtly-shifted text,
+ * because a caller reporting `file:line` off a shifted offset is wrong in a way
+ * nothing downstream can detect.
+ *
+ * String and template literals are deliberately LEFT INTACT. Every caller wants
+ * that: a lint fixture embedded in a template literal is text the lint should
+ * still see. A caller that needs strings blanked too should say so explicitly
+ * rather than assume it.
+ *
+ * `lint-config-dir.mjs` and `lint-session-opt-forwarding.mjs` still carry their
+ * own hand-written strippers, with different signatures and the same regex
+ * blindness. Migrating them is #7248.
  */
 
+import ts from 'typescript'
+
+const SCRIPT_KIND_BY_EXT = [
+  ['.tsx', ts.ScriptKind.TSX],
+  ['.jsx', ts.ScriptKind.JSX],
+  ['.mts', ts.ScriptKind.TS],
+  ['.cts', ts.ScriptKind.TS],
+  ['.ts', ts.ScriptKind.TS],
+]
+
+/** TSX and JSX parse differently from plain TS/JS, so the extension matters. */
+function scriptKindFor(fileName) {
+  for (const [ext, kind] of SCRIPT_KIND_BY_EXT) {
+    if (fileName.endsWith(ext)) return kind
+  }
+  return ts.ScriptKind.JS
+}
+
 /**
- * Replace `//` line comments and block comments with spaces, keeping newlines,
- * so every character index and line number in the result matches the input.
+ * Every comment range in `text`.
+ *
+ * Comments are trivia, so they hang off token positions rather than appearing
+ * in the tree. Walking `getChildren()` reaches every TOKEN, not just every
+ * node — `forEachChild` skips punctuation, and a comment can sit in front of a
+ * closing brace — and both the leading and trailing side of each position are
+ * collected, because a same-line `// like this` after an expression is trailing
+ * trivia of the thing before it, not leading trivia of the thing after.
+ */
+function commentRanges(text, fileName) {
+  const sourceFile = ts.createSourceFile(
+    fileName, text, ts.ScriptTarget.Latest, /* setParentNodes */ true, scriptKindFor(fileName),
+  )
+  const seen = new Set()
+  const ranges = []
+  const collect = (pos) => {
+    const found = [
+      ...(ts.getLeadingCommentRanges(text, pos) || []),
+      ...(ts.getTrailingCommentRanges(text, pos) || []),
+    ]
+    for (const range of found) {
+      const key = `${range.pos}:${range.end}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      ranges.push(range)
+    }
+  }
+  const walk = (node) => {
+    collect(node.getFullStart())
+    collect(node.getEnd())
+    for (const child of node.getChildren(sourceFile)) walk(child)
+  }
+  walk(sourceFile)
+  return ranges.sort((a, b) => a.pos - b.pos)
+}
+
+/**
+ * Replace comment spans with spaces, keeping newlines, so the result lines up
+ * with the input character for character.
  *
  * @param {string} src
+ * @param {string} [fileName] - used only to pick the parser's script kind
  * @returns {string} the same length as `src`, with comment spans blanked
+ * @throws if the parser produced ranges that would change the text's length
  */
-export function stripComments(src) {
+export function stripComments(src, fileName = 'input.js') {
   let out = ''
-  let i = 0
-  const n = src.length
-  let inStr = null
-  while (i < n) {
-    const ch = src[i]
-    if (inStr) {
-      out += ch
-      if (ch === '\\' && i + 1 < n) { out += src[i + 1]; i += 2; continue }
-      if (ch === inStr) inStr = null
-      i++
-      continue
-    }
-    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; out += ch; i++; continue }
-    if (ch === '/' && src[i + 1] === '/') {
-      while (i < n && src[i] !== '\n') { out += ' '; i++ }
-      continue
-    }
-    if (ch === '/' && src[i + 1] === '*') {
-      out += '  '; i += 2
-      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) { out += src[i] === '\n' ? '\n' : ' '; i++ }
-      if (i < n) { out += '  '; i += 2 }
-      continue
-    }
-    out += ch
-    i++
+  let cursor = 0
+  for (const range of commentRanges(src, fileName)) {
+    // Ranges can nest or repeat across the leading/trailing collection above;
+    // anything already consumed is skipped rather than double-counted.
+    if (range.pos < cursor) continue
+    out += src.slice(cursor, range.pos)
+    // Built by slicing, never from a code-point array: `[...src]` splits by code
+    // point while the parser's offsets are UTF-16, so a single emoji anywhere
+    // above a comment would shift every subsequent index.
+    out += src.slice(range.pos, range.end).replace(/[^\n]/g, ' ')
+    cursor = range.end
+  }
+  out += src.slice(cursor)
+
+  if (out.length !== src.length) {
+    throw new Error(
+      `strip-comments: blanking ${fileName} changed its length (${src.length} -> ${out.length}). `
+      + 'Offsets would be wrong, so every line number derived from this is wrong.',
+    )
   }
   return out
 }

--- a/packages/server/scripts/lint-claude-family-explicit.mjs
+++ b/packages/server/scripts/lint-claude-family-explicit.mjs
@@ -33,7 +33,16 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { stripComments } from './lib/strip-comments.mjs'
+// Dynamic, so a missing/unloadable stripper exits 2 ("the lint could not run")
+// rather than crashing out as 1 ("a subclass is missing the flag"). A static
+// import cannot be caught, and an uncaught ESM resolution error exits 1.
+let stripComments
+try {
+  ({ stripComments } = await import('./lib/strip-comments.mjs'))
+} catch (err) {
+  console.error(`lint-claude-family-explicit: cannot load the comment stripper: ${err.message}`)
+  process.exit(2)
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -127,7 +136,7 @@ function main() {
     // Scan comment-stripped text (indices preserved) so a subclass declaration
     // inside a comment isn't matched. `static claudeFamily = …` is real code and
     // survives stripping intact.
-    const src = stripComments(raw)
+    const src = stripComments(raw, file)
     SUBCLASS_RE.lastIndex = 0
     let m
     while ((m = SUBCLASS_RE.exec(src)) !== null) {

--- a/packages/server/scripts/lint-claude-family-explicit.mjs
+++ b/packages/server/scripts/lint-claude-family-explicit.mjs
@@ -33,6 +33,8 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { stripComments } from './lib/strip-comments.mjs'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function parseFlags(argv) {
@@ -80,42 +82,11 @@ function findMatchingBrace(src, openIdx) {
   return -1
 }
 
-// Blank out `//` line and `/* */` block comments, preserving every character
-// position and newline so downstream index/line math stays valid. Run the
-// subclass scan on the stripped text so a `class X extends ClaudeByokSession {`
-// written inside a comment is never matched as a real subclass (PR #5925
-// review). String literals are left intact — like the repo's other lints, we
-// don't strip strings (a class declaration inside a string is not a real case).
-function stripComments(src) {
-  let out = ''
-  let i = 0
-  const n = src.length
-  let inStr = null
-  while (i < n) {
-    const ch = src[i]
-    if (inStr) {
-      out += ch
-      if (ch === '\\' && i + 1 < n) { out += src[i + 1]; i += 2; continue }
-      if (ch === inStr) inStr = null
-      i++
-      continue
-    }
-    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; out += ch; i++; continue }
-    if (ch === '/' && src[i + 1] === '/') {
-      while (i < n && src[i] !== '\n') { out += ' '; i++ }
-      continue
-    }
-    if (ch === '/' && src[i + 1] === '*') {
-      out += '  '; i += 2
-      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) { out += src[i] === '\n' ? '\n' : ' '; i++ }
-      if (i < n) { out += '  '; i += 2 }
-      continue
-    }
-    out += ch
-    i++
-  }
-  return out
-}
+// The subclass scan runs on comment-stripped text (see ./lib/strip-comments.mjs,
+// which preserves every character position) so a `class X extends
+// ClaudeByokSession {` written inside a comment is never matched as a real
+// subclass (PR #5925 review). String literals are left intact — a class
+// declaration inside a string is not a real case either way.
 
 function listJsFiles(dir) {
   const out = []

--- a/packages/server/scripts/lint-entry-point-guard.mjs
+++ b/packages/server/scripts/lint-entry-point-guard.mjs
@@ -5,8 +5,10 @@
  *
  * ## Why this exists
  *
- * #7198 was the same guard hand-rolled in four files, three of which were
- * WRONG. Its failure mode is silence: the guard reads false, `main()` never
+ * #7198 and the #7213 sweep found the same guard hand-rolled in four files,
+ * across three spellings, and ALL FOUR were wrong the same way — including the
+ * `pathToFileURL` form, which looks more careful than the others and is equally
+ * broken. Its failure mode is silence: the guard reads false, `main()` never
  * runs, the process exits 0, and nothing distinguishes that from a clean no-op.
  * #7213 removed the copies; #7222 added a drift gate
  * (`scripts/__tests__/is-entry-point.test.mjs`) keeping the three that cannot be
@@ -110,6 +112,9 @@
  *                       it at a fixture tree so production and test run the
  *                       SAME walk rather than two implementations of one.
  *   --allow <relpath>   Replace the sanctioned allowlist. REPEATABLE.
+ *   --guard-copy <rel>  Which sanctioned files are guard COPIES, subject to the
+ *                       equal-site-count check. REPEATABLE. Defaults to
+ *                       GUARD_COPIES; empty when --allow is given alone.
  *   --min-files <n>     Exit 2 if fewer than n files were walked. A FLOOR, not a
  *                       count — it only ever fails closed.
  *   --dry-run           Print offenders without failing the exit code.
@@ -121,7 +126,6 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { stripComments } from './lib/strip-comments.mjs'
 // The repo-root module, not a local copy: the drift gate in
 // scripts/__tests__/is-entry-point.test.mjs imports the same list, so the two
 // gates cannot end up talking about different sets of files. See its header.
@@ -130,7 +134,7 @@ import { GUARD_COPIES } from '../../../scripts/lib/entry-point-guard-copies.mjs'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..', '..')
 
-const SCANNED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx']
+const SCANNED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.tsx', '.jsx']
 const IGNORE_MARKER = 'lint-ignore-entry-point-guard'
 
 // Directories the walk never descends into. Over-denying is caught by
@@ -170,8 +174,19 @@ function usageError(message) {
   process.exit(2)
 }
 
+// Dynamic, so an unloadable stripper exits 2 ("the guard broke") rather than
+// crashing out as 1 ("a hand-rolled guard was found"). A static import cannot be
+// caught, and an uncaught ESM resolution error exits 1 — which the CI step would
+// report as dirty code.
+let stripComments
+try {
+  ({ stripComments } = await import('./lib/strip-comments.mjs'))
+} catch (err) {
+  usageError(`cannot load the comment stripper: ${err.message}`)
+}
+
 function parseArgs(argv) {
-  const out = { repoRoot: null, allow: [], minFiles: null, dryRun: false }
+  const out = { repoRoot: null, allow: [], guardCopies: [], minFiles: null, dryRun: false }
   const needsValue = (flag, value) => {
     if (value === undefined) usageError(`${flag} requires a value`)
     return value
@@ -180,6 +195,7 @@ function parseArgs(argv) {
     const arg = argv[i]
     if (arg === '--repo-root') out.repoRoot = needsValue(arg, argv[++i])
     else if (arg === '--allow') out.allow.push(needsValue(arg, argv[++i]))
+    else if (arg === '--guard-copy') out.guardCopies.push(needsValue(arg, argv[++i]))
     else if (arg === '--min-files') out.minFiles = Number(needsValue(arg, argv[++i]))
     else if (arg === '--dry-run') out.dryRun = true
     // An unknown flag must never be silently ignored: a typo'd --repo-root would
@@ -212,33 +228,63 @@ function walk(dir, out = []) {
 // without the substring while the stripped text still matches a rule, so the
 // file is skipped and the lint reports clean. That is "silently skipped an
 // input", the fourth false-safety mode in docs/false-safety-guards.md. It bought
-// 260ms on a 1900-file walk (0.14s vs 0.40s), which is not a price worth paying
-// for a gate that runs once per push. Strip everything, match everything.
+// 260ms on a 1900-file walk, which is not a price worth paying for a gate that
+// runs once per push. Strip everything, match everything.
 
-// Every rule matches against comment-stripped source, and `\s*` spans newlines,
-// so a shape broken across lines is caught the same as a one-liner.
+// Every rule anchors on the IDENTIFIER `argv`, never on `process.argv`.
+//
+// The first draft required the literal `process` before it, and #7247's review
+// proved that hole live: `import { argv } from 'node:process'` is Node's own
+// documented named-export idiom, and TWO scripts in this repo already use it
+// (scripts/merge-updater-feeds.mjs, packages/server/scripts/spike-mcp-elicitation-shim.mjs).
+// Both are executable and guard-less today, so the next guard written in either
+// one would have been written as `argv[1]` — invisible to a `process.`-anchored
+// rule, and wrong in the #7198 way. Anchoring on `argv` also picks up
+// `globalThis.process.argv[1]`, `process?.argv[1]`, and any aliased holder for
+// free, because none of them change the identifier.
+//
+// `\s*` spans newlines, so a shape broken across lines is caught the same as a
+// one-liner. `(?:\?\.)?` covers the optional-chaining spellings.
 const RULES = [
   {
     kind: 'argv1-index',
-    re: /\bprocess\s*\.\s*argv\s*\[\s*1\s*\]/g,
+    re: /\bargv\s*(?:\?\.)?\s*\[\s*1\s*\]/g,
     hint: 'reads the script slot directly',
   },
   {
     kind: 'argv1-at',
-    re: /\bprocess\s*\.\s*argv\s*\.\s*at\s*\(\s*1\s*\)/g,
+    re: /\bargv\s*\??\s*\.\s*at\s*\(\s*1\s*\)/g,
     hint: 'reads the script slot via .at(1)',
   },
   {
     kind: 'import-meta-main',
-    re: /\bimport\s*\.\s*meta\s*\.\s*main\b/g,
+    re: /\bimport\s*\.\s*meta\s*\??\.\s*main\b/g,
     hint: 'is `undefined` on Node 22.0-22.17, which this package still supports',
   },
 ]
 
 // `const [, script] = process.argv` binds the script slot without naming an
 // index, so no amount of index-matching finds it. Captured as the bracket body
-// and decided by position below.
-const DESTRUCTURE_RE = /\b(?:const|let|var)\s*\[([^\]]*)\]\s*=\s*process\s*\.\s*argv\b/g
+// and decided by position below. The optional `<holder>.` covers `= process.argv`
+// and `= argv` alike.
+const DESTRUCTURE_RE = /\b(?:const|let|var)\s*\[([^\]]*)\]\s*=\s*(?:[\w$]+\s*\??\.\s*)*\bargv\b/g
+
+// Names bound to the argv array, so `const a = process.argv` … `a[1]` is caught
+// too. This mirrors `homeBoundVarsIn` in lint-config-dir.mjs, which exists
+// because the same two-statement split defeated a single-line rule there.
+const ARGV_ALIAS_RE = /\b(?:const|let|var)\s+([\w$]+)\s*=\s*(?:[\w$]+\s*\??\.\s*)*\bargv\b\s*(?![.[])/g
+const ARGV_IMPORT_ALIAS_RE = /\bargv\s+as\s+([\w$]+)/g
+
+/** Local names that hold the argv array itself. */
+function argvAliasesIn(code) {
+  const names = new Set()
+  for (const re of [ARGV_ALIAS_RE, ARGV_IMPORT_ALIAS_RE]) {
+    re.lastIndex = 0
+    let m
+    while ((m = re.exec(code)) !== null) names.add(m[1])
+  }
+  return names
+}
 
 /**
  * Does an array-destructuring pattern bind position 1 to a plain name?
@@ -253,9 +299,18 @@ function bindsScriptSlot(bracketBody) {
   return atOne !== '' && !atOne.startsWith('...')
 }
 
-/** Is the marker a real directive on this line, rather than prose mentioning it? */
-function isIgnoreDirective(rawLine) {
-  return new RegExp(`^\\s*(?://|\\*|/\\*)\\s*${IGNORE_MARKER}\\b`).test(rawLine)
+/**
+ * Is the marker a real directive on this line, rather than prose mentioning it?
+ *
+ * Two conditions, and the second is not redundant. The regex alone reads the RAW
+ * line, so the marker written as ordinary text inside a template literal —
+ * `` `// lint-ignore-entry-point-guard` `` on its own line — satisfies it while
+ * being a string, not a comment. Requiring the stripper to have blanked that
+ * line proves it really was one.
+ */
+function isIgnoreDirective(rawLine, codeLine) {
+  if (!new RegExp(`^\\s*(?://|\\*|/\\*)\\s*${IGNORE_MARKER}\\b`).test(rawLine)) return false
+  return codeLine !== undefined && codeLine.trim() === ''
 }
 
 /** 1-based line number of `index` within `text`. */
@@ -266,16 +321,37 @@ function lineOf(text, index) {
 }
 
 function findInFile(file, rel) {
-  const raw = readFileSync(file, 'utf8')
-  const code = stripComments(raw)
+  let raw
+  try {
+    raw = readFileSync(file, 'utf8')
+  } catch (err) {
+    // An unreadable file is "could not check", never "nothing to check". Without
+    // this the EACCES escapes uncaught, node exits 1, and the CI step reports it
+    // as a hand-rolled guard that does not exist.
+    usageError(`cannot read ${rel}: ${err.message}`)
+  }
+
+  let code
+  try {
+    code = stripComments(raw, file)
+  } catch (err) {
+    usageError(`cannot strip comments from ${rel}: ${err.message}`)
+  }
+
   const rawLines = raw.split('\n')
+  const codeLines = code.split('\n')
   const hits = []
+  const seenIndex = new Set()
 
   const record = (kind, index, hint) => {
+    // Several rules can match the same site (an alias whose name is `argv`, say).
+    // Report it once.
+    if (seenIndex.has(index)) return
+    seenIndex.add(index)
     const line = lineOf(code, index)
     // The marker sits on the line ABOVE the offending site, matching the
     // convention the other lints use.
-    if (line > 1 && isIgnoreDirective(rawLines[line - 2])) return
+    if (line > 1 && isIgnoreDirective(rawLines[line - 2], codeLines[line - 2])) return
     hits.push({ file: rel, line, kind, hint, text: (rawLines[line - 1] || '').trim() })
   }
 
@@ -290,6 +366,16 @@ function findInFile(file, rel) {
   while ((d = DESTRUCTURE_RE.exec(code)) !== null) {
     if (bindsScriptSlot(d[1])) {
       record('argv1-destructure', d.index, 'binds the script slot by position')
+    }
+  }
+
+  // `const a = process.argv` … `a[1]`, which no rule above can see because the
+  // read never names `argv`.
+  for (const alias of argvAliasesIn(code)) {
+    const aliasRe = new RegExp(`\\b${alias}\\s*(?:\\?\\.)?\\s*\\[\\s*1\\s*\\]`, 'g')
+    let a
+    while ((a = aliasRe.exec(code)) !== null) {
+      record('argv1-alias', a.index, `\`${alias}\` holds the argv array`)
     }
   }
 
@@ -333,6 +419,16 @@ if (args.minFiles !== null && files.length < args.minFiles) {
 const exempt = new Set(sanctioned)
 const offenders = []
 const guardedSanctioned = new Set()
+const hitCountByGuardCopy = new Map()
+// Which of the sanctioned files are guard COPIES (subject to the count check
+// below) rather than tests. Explicit rather than "the first N of --allow", so a
+// caller pointing the lint at a fixture tree says what it means.
+const guardCopySet = new Set(
+  args.guardCopies.length ? args.guardCopies : (args.allow.length ? [] : GUARD_COPIES),
+)
+for (const rel of guardCopySet) {
+  if (!exempt.has(rel)) usageError(`--guard-copy ${rel} is not in the sanctioned set`)
+}
 
 for (const file of files) {
   const rel = relative(root, file).split(pathSep).join('/')
@@ -340,10 +436,26 @@ for (const file of files) {
   if (!hits.length) continue
   if (exempt.has(rel)) {
     guardedSanctioned.add(rel)
+    if (guardCopySet.has(rel)) hitCountByGuardCopy.set(rel, hits.length)
     continue
   }
   offenders.push(...hits)
 }
+
+// The exemption above is WHOLE-FILE, which #7247's review showed is a hole:
+// sidecar/agent.js is 1339 lines of in-pod application that merely CONTAINS the
+// guard, and a second, hand-rolled guard added anywhere else in it would be
+// exempt from this walk and invisible to the drift gate, which only extracts the
+// one body. So the three guard copies are held to the same COUNT.
+//
+// No hardcoded number is needed, which is the point: the drift gate already
+// proves the three bodies are character-for-character identical, so they must
+// contain the same number of sites. If one grows an extra, it stops matching its
+// siblings — and if the guard itself changes, all three move together and this
+// stays quiet. A ratchet that maintains itself.
+const guardCounts = [...hitCountByGuardCopy.entries()]
+const countMismatch = guardCounts.length > 1
+  && new Set(guardCounts.map(([, n]) => n)).size > 1
 
 // The other direction of the ratchet: an exemption nothing needs is an
 // exemption the next regression hides behind.
@@ -356,15 +468,15 @@ if (offenders.length) {
   console.error('')
   console.error(`${offenders.length} hand-rolled entry-point determination(s) outside the ${sanctioned.length} sanctioned file(s).`)
   console.error('')
-  console.error('Deciding "was this module run directly?" by hand is #7198: three of the four')
-  console.error('copies were wrong, and the failure is SILENT — the guard reads false, main()')
-  console.error('never runs, and the process exits 0. Import the shared guard instead:')
+  console.error('Deciding "was this module run directly?" by hand is #7198: it was written in')
+  console.error('four files, ALL FOUR were wrong, and the failure is SILENT — the guard reads')
+  console.error('false, main() never runs, and the process exits 0. Import the shared guard:')
   console.error('')
   console.error("  server sources:  import { isEntryPoint } from './utils/is-entry-point.js'")
   console.error("  repo scripts:    import { isEntryPoint } from './lib/is-entry-point.mjs'")
   console.error('')
-  console.error(`If a site genuinely needs argv[1] for something else, put a \`// ${IGNORE_MARKER}\``)
-  console.error('comment on the line above it and say why.')
+  console.error(`If a site genuinely needs the interpreter's script path for something else,`)
+  console.error(`put a \`// ${IGNORE_MARKER}\` comment on the line above it and say why.`)
 }
 
 for (const rel of staleAllowlist) {
@@ -377,7 +489,17 @@ if (staleAllowlist.length) {
   console.error('lands in that file next.')
 }
 
-const failed = offenders.length > 0 || staleAllowlist.length > 0
+if (countMismatch) {
+  console.error('')
+  for (const [rel, n] of guardCounts) console.error(`  ${rel}: ${n} site(s)`)
+  console.error('')
+  console.error('The sanctioned guard copies disagree on how many sites they contain, but the')
+  console.error('drift gate holds their bodies identical — so the copy with more has picked up')
+  console.error('a SECOND, hand-rolled determination outside the shared body. The whole-file')
+  console.error('exemption would otherwise hide it. Remove the extra site.')
+}
+
+const failed = offenders.length > 0 || staleAllowlist.length > 0 || countMismatch
 if (!failed) {
   console.log(`OK: ${files.length} file(s) walked; entry-point-ness is decided in ${sanctioned.length} sanctioned file(s) only.`)
 }

--- a/packages/server/scripts/lint-entry-point-guard.mjs
+++ b/packages/server/scripts/lint-entry-point-guard.mjs
@@ -1,0 +1,384 @@
+#!/usr/bin/env node
+/**
+ * Lint: "was this module run directly?" has exactly three implementations, and
+ * no file outside them may answer that question by hand (#7235).
+ *
+ * ## Why this exists
+ *
+ * #7198 was the same guard hand-rolled in four files, three of which were
+ * WRONG. Its failure mode is silence: the guard reads false, `main()` never
+ * runs, the process exits 0, and nothing distinguishes that from a clean no-op.
+ * #7213 removed the copies; #7222 added a drift gate
+ * (`scripts/__tests__/is-entry-point.test.mjs`) keeping the three that cannot be
+ * merged identical to each other.
+ *
+ * That closed the INSTANCE, not the FAILURE MODE. The drift gate iterates a
+ * hardcoded three-element `GUARD_COPIES` list, so a FOURTH copy appearing
+ * anywhere is invisible to it — "the list that stopped growing", which
+ * docs/false-safety-guards.md names as its own recurring defect (#7192, #7197).
+ * This lint is the half the drift gate cannot cover: it looks at the whole
+ * repo and fails on any entry-point determination that is not one of the three.
+ *
+ * The two gates are complements, not duplicates. The drift gate says "the three
+ * agree"; this one says "there are only three".
+ *
+ * ## What is banned
+ *
+ * Reading the interpreter's script slot — argv index 1 — in any of these
+ * spellings, on comment-stripped source:
+ *
+ *   1. `argv1-index`       — the index read. The shape all four #7198 copies had.
+ *   2. `argv1-at`          — the same read spelled `.at(1)`.
+ *   3. `argv1-destructure` — `const [, script] = process.argv`, which binds the
+ *                            same slot without ever naming the index.
+ *   4. `import-meta-main`  — Node's native answer, and unusable here. It landed
+ *                            in 22.18.0; the declared engines floor is
+ *                            `"node": ">=22"`, so on 22.0–22.17 it is plain
+ *                            `undefined` — a falsy guard on a SUPPORTED runtime,
+ *                            which is exactly the silent exit-0 no-op above,
+ *                            reintroduced as a version skew no CI job pinned to
+ *                            `node-version: 22` would ever show. See the header
+ *                            of scripts/lib/is-entry-point.mjs; when the floor
+ *                            moves to >=22.18 this rule is what should be
+ *                            deleted first.
+ *
+ * The fix for any of them is the same: import `isEntryPoint` from
+ * `src/utils/is-entry-point.js` (server) or `scripts/lib/is-entry-point.mjs`
+ * (repo scripts).
+ *
+ * ## NOT matched, deliberately
+ *
+ *   - `require.main === module`. The CommonJS idiom compares module objects, so
+ *     the symlink trap that produced #7198 cannot reach it. It is correct; there
+ *     is nothing to ban.
+ *   - `process.argv.slice(2)` and friends. Ordinary argument parsing never
+ *     touches the script slot.
+ *   - A rest element in the first position — `const [, ...rest] = process.argv`.
+ *     It reaches the slot, but as argument collection rather than as an identity
+ *     comparison, and flagging it would cost a false positive in a REQUIRED
+ *     check for a shape no guard has ever been written in. A guard hiding there
+ *     would still have to compare `rest[0]` against something, which review sees.
+ *   - `.sh` sources. `scripts/docker-entrypoint.sh` passes a config path as the
+ *     first argument to `node -e`, where argv index 1 means something else
+ *     entirely. Shell is not scanned and this file's name does not claim it is
+ *     (#7239's lesson: a gate must not overclaim in its own title).
+ *   - Anything inside a `//` or block comment. This matters — every copy of the
+ *     guard, and this file, discuss the banned shapes in prose.
+ *
+ * ## Exemptions
+ *
+ * `SANCTIONED` is the three guard copies — imported from
+ * `scripts/lib/entry-point-guard-copies.mjs`, the SAME list the drift gate
+ * iterates, so the two gates cannot end up disagreeing about which files they
+ * are talking about — plus the tests that must drive argv[1] to assert anything.
+ *
+ * It is checked in BOTH directions: an entry whose file has no guard left in it
+ * FAILS as stale, the same ratchet `lint-config-dir.mjs` applies to its
+ * baseline. An allowlist that keeps granting an exemption nothing needs is how
+ * the next regression lands unnoticed.
+ *
+ * Note the asymmetry that makes a hardcoded list safe HERE and unsafe in the
+ * drift gate: this list is the set of things EXEMPT from a repo-wide walk. If it
+ * falls behind, a sanctioned file starts failing — loudly, in a required check.
+ * The drift gate's list was the set of things CHECKED, so falling behind made it
+ * quieter. Same data structure, opposite failure direction. Sharing the list
+ * means the safe direction now covers the unsafe one.
+ *
+ * A single site can also be exempted with `// lint-ignore-entry-point-guard` in
+ * a comment on the line immediately above it.
+ *
+ * ## A note on this file's own text
+ *
+ * Comments are stripped before matching but STRING LITERALS ARE NOT, so no
+ * message or regex below may spell the banned shapes literally in a string, or
+ * the lint fails itself. The rule patterns are regex literals (escaped, so they
+ * do not match themselves) and the diagnostics say "argv[1]" without the
+ * `process.` prefix. That is load-bearing, not styling.
+ *
+ * ## Exit codes
+ *
+ *   0 — no hand-rolled guard outside the sanctioned set
+ *   1 — at least one offender, or a stale allowlist entry
+ *   2 — the lint could not do its job (bad flags, missing root, a sanctioned
+ *       path that does not exist, or too few files walked). Distinct from 1 on
+ *       purpose: "the guard broke" must never read as "the guard passed", and
+ *       must not read as "the code is dirty" either.
+ *
+ * ## Flags
+ *
+ *   --repo-root <path>  Tree to walk. Defaults to the repo root. The tests point
+ *                       it at a fixture tree so production and test run the
+ *                       SAME walk rather than two implementations of one.
+ *   --allow <relpath>   Replace the sanctioned allowlist. REPEATABLE.
+ *   --min-files <n>     Exit 2 if fewer than n files were walked. A FLOOR, not a
+ *                       count — it only ever fails closed.
+ *   --dry-run           Print offenders without failing the exit code.
+ *
+ * Issue: #7235. Background: #7198, #7213, #7222, #7226.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { stripComments } from './lib/strip-comments.mjs'
+// The repo-root module, not a local copy: the drift gate in
+// scripts/__tests__/is-entry-point.test.mjs imports the same list, so the two
+// gates cannot end up talking about different sets of files. See its header.
+import { GUARD_COPIES } from '../../../scripts/lib/entry-point-guard-copies.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..', '..')
+
+const SCANNED_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx']
+const IGNORE_MARKER = 'lint-ignore-entry-point-guard'
+
+// Directories the walk never descends into. Over-denying is caught by
+// --min-files; under-denying only costs time, so this errs toward small.
+// `.claude` is here for a specific reason: the main checkout keeps live git
+// worktrees under `.claude/worktrees/`, and walking those would scan several
+// entire copies of the repo.
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', '.claude', 'dist', 'build', 'coverage',
+  '.next', '.expo', '.turbo', 'target', 'Pods', '.venv', 'venv',
+])
+
+/**
+ * Tests that must drive argv[1] to have anything to assert.
+ *
+ * The first two pin the guard itself. `lint-entry-point-guard.test.js` carries
+ * the offending shapes as fixture text and proves THIS lint against them by
+ * running it as a child process — that exemption is the one hole in the walk,
+ * and it is listed here rather than hidden so a reader can see how narrow it is.
+ *
+ * Kept separate from GUARD_COPIES because these are not guards: adding a file
+ * here exempts it from the walk, while adding one there also opts it into the
+ * drift gate's character-for-character comparison.
+ */
+const TEST_EXEMPTIONS = [
+  'scripts/__tests__/is-entry-point.test.mjs',
+  'packages/server/tests/is-entry-point.test.js',
+  'packages/server/tests/lint-entry-point-guard.test.js',
+]
+
+/** The complete set of files allowed to determine entry-point-ness by hand. */
+const SANCTIONED = [...GUARD_COPIES, ...TEST_EXEMPTIONS]
+
+/** Bad usage, or a broken walk — the lint could not run. Exit 2, never 0 or 1. */
+function usageError(message) {
+  console.error(`lint-entry-point-guard: ${message}`)
+  process.exit(2)
+}
+
+function parseArgs(argv) {
+  const out = { repoRoot: null, allow: [], minFiles: null, dryRun: false }
+  const needsValue = (flag, value) => {
+    if (value === undefined) usageError(`${flag} requires a value`)
+    return value
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--repo-root') out.repoRoot = needsValue(arg, argv[++i])
+    else if (arg === '--allow') out.allow.push(needsValue(arg, argv[++i]))
+    else if (arg === '--min-files') out.minFiles = Number(needsValue(arg, argv[++i]))
+    else if (arg === '--dry-run') out.dryRun = true
+    // An unknown flag must never be silently ignored: a typo'd --repo-root would
+    // otherwise walk the REAL repo and report on something the caller never
+    // asked about, green (#7239).
+    else usageError(`unknown argument ${JSON.stringify(arg)}`)
+  }
+  if (out.minFiles !== null && (!Number.isInteger(out.minFiles) || out.minFiles < 0)) {
+    usageError('--min-files requires a non-negative integer')
+  }
+  return out
+}
+
+function walk(dir, out = []) {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    if (ent.isDirectory()) {
+      if (SKIP_DIRS.has(ent.name)) continue
+      walk(join(dir, ent.name), out)
+    } else if (ent.isFile() && SCANNED_EXTENSIONS.some((ext) => ent.name.endsWith(ext))) {
+      out.push(join(dir, ent.name))
+    }
+  }
+  return out
+}
+
+// There is deliberately NO cheap prefilter over the raw text here. One was
+// written — skip any file whose raw source contains neither `argv` nor
+// `import.meta.main` — and it is unsound in the one direction that matters: a
+// comment INSIDE the expression (`import.me/* */ta.main`) leaves the raw text
+// without the substring while the stripped text still matches a rule, so the
+// file is skipped and the lint reports clean. That is "silently skipped an
+// input", the fourth false-safety mode in docs/false-safety-guards.md. It bought
+// 260ms on a 1900-file walk (0.14s vs 0.40s), which is not a price worth paying
+// for a gate that runs once per push. Strip everything, match everything.
+
+// Every rule matches against comment-stripped source, and `\s*` spans newlines,
+// so a shape broken across lines is caught the same as a one-liner.
+const RULES = [
+  {
+    kind: 'argv1-index',
+    re: /\bprocess\s*\.\s*argv\s*\[\s*1\s*\]/g,
+    hint: 'reads the script slot directly',
+  },
+  {
+    kind: 'argv1-at',
+    re: /\bprocess\s*\.\s*argv\s*\.\s*at\s*\(\s*1\s*\)/g,
+    hint: 'reads the script slot via .at(1)',
+  },
+  {
+    kind: 'import-meta-main',
+    re: /\bimport\s*\.\s*meta\s*\.\s*main\b/g,
+    hint: 'is `undefined` on Node 22.0-22.17, which this package still supports',
+  },
+]
+
+// `const [, script] = process.argv` binds the script slot without naming an
+// index, so no amount of index-matching finds it. Captured as the bracket body
+// and decided by position below.
+const DESTRUCTURE_RE = /\b(?:const|let|var)\s*\[([^\]]*)\]\s*=\s*process\s*\.\s*argv\b/g
+
+/**
+ * Does an array-destructuring pattern bind position 1 to a plain name?
+ *
+ * `[, script]` and `[node, script]` do. `[,, cmd]` (a hole at 1) and
+ * `[, ...rest]` (documented above as out of scope) do not.
+ */
+function bindsScriptSlot(bracketBody) {
+  const elements = bracketBody.split(',')
+  if (elements.length < 2) return false
+  const atOne = elements[1].trim()
+  return atOne !== '' && !atOne.startsWith('...')
+}
+
+/** Is the marker a real directive on this line, rather than prose mentioning it? */
+function isIgnoreDirective(rawLine) {
+  return new RegExp(`^\\s*(?://|\\*|/\\*)\\s*${IGNORE_MARKER}\\b`).test(rawLine)
+}
+
+/** 1-based line number of `index` within `text`. */
+function lineOf(text, index) {
+  let line = 1
+  for (let i = 0; i < index; i++) if (text[i] === '\n') line++
+  return line
+}
+
+function findInFile(file, rel) {
+  const raw = readFileSync(file, 'utf8')
+  const code = stripComments(raw)
+  const rawLines = raw.split('\n')
+  const hits = []
+
+  const record = (kind, index, hint) => {
+    const line = lineOf(code, index)
+    // The marker sits on the line ABOVE the offending site, matching the
+    // convention the other lints use.
+    if (line > 1 && isIgnoreDirective(rawLines[line - 2])) return
+    hits.push({ file: rel, line, kind, hint, text: (rawLines[line - 1] || '').trim() })
+  }
+
+  for (const { kind, re, hint } of RULES) {
+    re.lastIndex = 0
+    let m
+    while ((m = re.exec(code)) !== null) record(kind, m.index, hint)
+  }
+
+  DESTRUCTURE_RE.lastIndex = 0
+  let d
+  while ((d = DESTRUCTURE_RE.exec(code)) !== null) {
+    if (bindsScriptSlot(d[1])) {
+      record('argv1-destructure', d.index, 'binds the script slot by position')
+    }
+  }
+
+  return hits
+}
+
+const args = parseArgs(process.argv.slice(2))
+const root = resolve(args.repoRoot ?? REPO_ROOT)
+const sanctioned = args.allow.length ? args.allow : SANCTIONED
+
+if (!existsSync(root)) usageError(`--repo-root does not exist: ${root}`)
+
+// A sanctioned path that no longer exists means the allowlist is describing a
+// tree that is gone. Exit 2 rather than 1: nothing about the CODE is wrong, the
+// GUARD's premises are.
+for (const rel of sanctioned) {
+  if (!existsSync(join(root, rel))) {
+    usageError(`sanctioned path does not exist under ${root}: ${rel}. `
+      + 'The allowlist is stale — fix it before trusting this run.')
+  }
+}
+
+let files
+try {
+  files = walk(root).sort()
+} catch (err) {
+  usageError(`cannot walk ${root}: ${err.message}`)
+}
+
+// "Walked zero files" and "walked 1963 clean files" must not be the same
+// observable outcome — docs/false-safety-guards.md calls that the least-solved
+// failure mode in this repo.
+if (files.length === 0) {
+  usageError(`walked 0 files under ${root} — refusing to report a clean tree`)
+}
+if (args.minFiles !== null && files.length < args.minFiles) {
+  usageError(`walked only ${files.length} file(s), expected at least ${args.minFiles}. `
+    + 'Either the walk broke or --min-files is stale.')
+}
+
+const exempt = new Set(sanctioned)
+const offenders = []
+const guardedSanctioned = new Set()
+
+for (const file of files) {
+  const rel = relative(root, file).split(pathSep).join('/')
+  const hits = findInFile(file, rel)
+  if (!hits.length) continue
+  if (exempt.has(rel)) {
+    guardedSanctioned.add(rel)
+    continue
+  }
+  offenders.push(...hits)
+}
+
+// The other direction of the ratchet: an exemption nothing needs is an
+// exemption the next regression hides behind.
+const staleAllowlist = sanctioned.filter((rel) => !guardedSanctioned.has(rel))
+
+for (const o of offenders) {
+  console.error(`${o.file}:${o.line}  [${o.kind}]  ${o.text}`)
+}
+if (offenders.length) {
+  console.error('')
+  console.error(`${offenders.length} hand-rolled entry-point determination(s) outside the ${sanctioned.length} sanctioned file(s).`)
+  console.error('')
+  console.error('Deciding "was this module run directly?" by hand is #7198: three of the four')
+  console.error('copies were wrong, and the failure is SILENT — the guard reads false, main()')
+  console.error('never runs, and the process exits 0. Import the shared guard instead:')
+  console.error('')
+  console.error("  server sources:  import { isEntryPoint } from './utils/is-entry-point.js'")
+  console.error("  repo scripts:    import { isEntryPoint } from './lib/is-entry-point.mjs'")
+  console.error('')
+  console.error(`If a site genuinely needs argv[1] for something else, put a \`// ${IGNORE_MARKER}\``)
+  console.error('comment on the line above it and say why.')
+}
+
+for (const rel of staleAllowlist) {
+  console.error(`${rel}: allowlisted as a sanctioned guard but contains none — remove the entry.`)
+}
+if (staleAllowlist.length) {
+  console.error('')
+  console.error('A sanctioned copy that lost its guard is either a bug or a deletion nobody')
+  console.error('updated the allowlist for. Either way the exemption now shields whatever')
+  console.error('lands in that file next.')
+}
+
+const failed = offenders.length > 0 || staleAllowlist.length > 0
+if (!failed) {
+  console.log(`OK: ${files.length} file(s) walked; entry-point-ness is decided in ${sanctioned.length} sanctioned file(s) only.`)
+}
+process.exit(failed && !args.dryRun ? 1 : 0)

--- a/packages/server/scripts/lint-entry-point-guard.sh
+++ b/packages/server/scripts/lint-entry-point-guard.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-entry-point-guard.mjs` for the
+# actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-entry-point-guard.sh` without worrying about the Node
+# interpreter path on the runner image.
+#
+# The walk is REPO-WIDE, not packages/server — a fourth hand-rolled guard is
+# just as likely to appear in `scripts/` or another package, and two of the
+# three sanctioned copies are outside `src/` already (#7235).
+#
+# `--min-files` is a FLOOR, not a count. It only ever fails closed: if the walk
+# breaks — a skip-list entry that swallows a real directory, a checkout that
+# resolved to nothing — the lint would otherwise walk few or zero files and
+# report a clean tree, which is indistinguishable from actually being clean.
+# The tree walks ~1970 files today; 1500 leaves room for ordinary deletions
+# while still catching a collapse.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-entry-point-guard.mjs --min-files 1500 "$@"

--- a/packages/server/scripts/lint-entry-point-guard.sh
+++ b/packages/server/scripts/lint-entry-point-guard.sh
@@ -12,8 +12,13 @@
 # breaks — a skip-list entry that swallows a real directory, a checkout that
 # resolved to nothing — the lint would otherwise walk few or zero files and
 # report a clean tree, which is indistinguishable from actually being clean.
-# The tree walks ~1970 files today; 1500 leaves room for ordinary deletions
-# while still catching a collapse.
+# The tree walks 1902 files in CI (1903 locally, where one gitignored generated
+# file is present); 1500 leaves room for ordinary deletions while still catching
+# a collapse — losing all of packages/dashboard or packages/server would trip it.
+#
+# The number below is asserted against this file by
+# tests/lint-entry-point-guard.test.js, which parses it out rather than
+# hardcoding a second copy.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec node ./scripts/lint-entry-point-guard.mjs --min-files 1500 "$@"

--- a/packages/server/tests/lint-entry-point-guard.test.js
+++ b/packages/server/tests/lint-entry-point-guard.test.js
@@ -27,7 +27,7 @@
  */
 import { test, describe, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -417,13 +417,184 @@ describe('lint-entry-point-guard', () => {
 
     // The floor the CI wrapper passes must actually be clearable, or Server Lint
     // fails on exit 2 for a reason that has nothing to do with the code.
-    test('the wrapper\'s --min-files floor is not stale', () => {
-      const res = spawnSync(
-        process.execPath,
-        [LINT_SCRIPT, '--min-files', '1500'],
-        { encoding: 'utf8' },
-      )
-      assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`)
+    //
+    // The floor is PARSED OUT of the wrapper rather than repeated here. The
+    // first version hardcoded '1500', and mutation proved it blind: setting the
+    // wrapper to `--min-files 99999` made the real CI step exit 2 while this
+    // test stayed green. Two hardcoded copies of one value is this file's own
+    // subject matter, one level down.
+    test("the wrapper's --min-files floor is clearable by the real walk", () => {
+      const wrapper = readFileSync(resolve(__dirname, '..', 'scripts', 'lint-entry-point-guard.sh'), 'utf8')
+      const m = /--min-files\s+(\d+)/.exec(wrapper)
+      assert.ok(m, 'could not find --min-files in the wrapper — this test is checking nothing')
+      const res = spawnSync(process.execPath, [LINT_SCRIPT, '--min-files', m[1]], { encoding: 'utf8' })
+      assert.equal(res.status, 0, `floor ${m[1]} from the wrapper is not clearable:\n${res.stdout}\n${res.stderr}`)
     })
   })
+
+  // --- #7247 review: the identifier, not the `process.` prefix ---------------
+  //
+  // The first version of every rule required the literal `process` before
+  // `.argv`. Review proved that hole live: `import { argv } from 'node:process'`
+  // is Node's own documented idiom and TWO scripts in this repo already use it
+  // (scripts/merge-updater-feeds.mjs,
+  // packages/server/scripts/spike-mcp-elicitation-shim.mjs), both executable and
+  // guard-less. The next guard written in either would have been spelled
+  // `argv[1]` and been invisible.
+  describe('spellings that never name `process`', () => {
+    const CAUGHT = {
+      'bare argv from node:process': "import { argv } from 'node:process'\nif (argv[1] === __filename) main()\n",
+      'destructured from process': 'const { argv } = process\nif (argv[1] === __filename) main()\n',
+      'aliased holder': 'const a = process.argv\nif (a[1] === __filename) main()\n',
+      'renamed import': "import { argv as av } from 'node:process'\nif (av[1] === __filename) main()\n",
+      'optional chain on the index': 'if (process.argv?.[1] === __filename) main()\n',
+      'optional chain on process': 'if (process?.argv[1] === __filename) main()\n',
+      'globalThis reach': 'if (globalThis.process.argv[1] === __filename) main()\n',
+      'bare argv .at(1)': "import { argv } from 'node:process'\nif (argv.at(1) === __filename) main()\n",
+      'optional import.meta?.main': 'if (import.meta?.main) main()\n',
+    }
+    for (const [name, source] of Object.entries(CAUGHT)) {
+      test(`catches ${name}`, () => {
+        assert.equal(runLint({ 'src/thing.js': source }).status, 1)
+      })
+    }
+
+    // The boundary: `argv` is only banned when index 1 is actually read. A yargs
+    // -style parsed object called `argv` is ordinary code, and flagging it would
+    // put a false positive in a required check.
+    test('leaves a parsed `argv` object alone when index 1 is never read', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const argv = parse(process.argv.slice(2))\nconsole.log(argv.verbose, argv[0], argv.at(2))\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same file reading index 1 does fail', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const argv = parse(process.argv.slice(2))\nconsole.log(argv[1])\n',
+      })
+      assert.equal(status, 1)
+    })
+  })
+
+  // --- #7247 review: the stripper must not be fooled by a regex literal ------
+  //
+  // The hand-written stripper this lint shipped with could not tell a regex
+  // literal from a comment delimiter, and was unsound in BOTH directions on real
+  // files. Measured over the 1903 files this lint walks: 83 differed from the
+  // truth, 40 hiding real code and 51 leaking comment text. These two tests are
+  // one of each; either regresses the moment the stripper stops using a parser.
+  describe('regex literals do not desync the comment stripper', () => {
+    // `\/` leaves a `/`, the next char is `*`, and a character scanner reads
+    // `/*` as a BLOCK COMMENT OPEN — blanking the guard below it into silence.
+    test('a guard below a trailing-slash regex is still found', () => {
+      const { status } = runLint({
+        'src/thing.js': "export function n (u) { return u.replace(/\\/*$/, '') }\n"
+          + 'if (import.meta.url === p(process.argv[1]).href) main()\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    // The mirror image: a quote inside a character class put the scanner into a
+    // phantom STRING state, so it stopped blanking comments and ordinary prose
+    // read as code — a spurious red in a required check.
+    test('prose below a quote-bearing regex is still a comment', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const M = /(["])/g\n'
+          + '// prose mentioning process.argv[1] in an ordinary comment\n'
+          + 'export const x = 1\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same prose as CODE still fails', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const M = /(["])/g\nconst me = process.argv[1]\n',
+      })
+      assert.equal(status, 1)
+    })
+  })
+
+  describe('the sanctioned files are exempt, but not unconditionally', () => {
+    // The whole-file exemption is a hole: sidecar/agent.js is 1339 lines of
+    // in-pod application that merely CONTAINS the guard, so a SECOND hand-rolled
+    // guard anywhere else in it would be exempt here and invisible to the drift
+    // gate, which only extracts the one body. The three copies are therefore
+    // held to the same site COUNT — no hardcoded number, because the drift gate
+    // already proves the bodies identical.
+    test('a second guard inside a sanctioned copy breaks the count', () => {
+      const extra = SANCTIONED_GUARD + '\nif (process.argv[1] === __filename) diagnostics()\n'
+      const { status, stderr } = runLint(
+        { 'lib/a.mjs': SANCTIONED_GUARD, 'lib/b.mjs': extra },
+        {
+          withGuard: false,
+          allow: ['lib/a.mjs', 'lib/b.mjs'],
+          extraArgs: ['--guard-copy', 'lib/a.mjs', '--guard-copy', 'lib/b.mjs'],
+        },
+      )
+      assert.equal(status, 1)
+      assert.match(stderr, /disagree on how many sites/)
+    })
+
+    test('positive control: identical copies pass the count check', () => {
+      const { status } = runLint(
+        { 'lib/a.mjs': SANCTIONED_GUARD, 'lib/b.mjs': SANCTIONED_GUARD },
+        {
+          withGuard: false,
+          allow: ['lib/a.mjs', 'lib/b.mjs'],
+          extraArgs: ['--guard-copy', 'lib/a.mjs', '--guard-copy', 'lib/b.mjs'],
+        },
+      )
+      assert.equal(status, 0)
+    })
+
+    test('a --guard-copy outside the sanctioned set exits 2', () => {
+      const { status } = runLint({}, { extraArgs: ['--guard-copy', 'lib/nope.mjs'] })
+      assert.equal(status, 2)
+    })
+  })
+
+  describe('more ways to fail closed', () => {
+    // The marker must be a real comment, not text that merely looks like one.
+    // Written inside a template literal it satisfies the raw-line regex while
+    // being a string, so the stripper has to confirm the line was blanked.
+    test('a marker faked inside a template literal does not exempt', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const s = `\n// lint-ignore-entry-point-guard\n${process.argv[1]}`\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    // An unreadable file is "could not check", never "nothing to check". Before
+    // this the EACCES escaped uncaught, node exited 1, and the CI step reported
+    // a hand-rolled guard that did not exist.
+    test('an unreadable file exits 2, not 1', { skip: process.getuid?.() === 0 && 'running as root' }, () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-eacces-'))
+      tmpRoots.push(root)
+      mkdirSync(join(root, 'lib'), { recursive: true })
+      writeFileSync(join(root, 'lib', 'guard.mjs'), SANCTIONED_GUARD)
+      const locked = join(root, 'src', 'locked.js')
+      mkdirSync(join(root, 'src'), { recursive: true })
+      writeFileSync(locked, 'export const x = 1\n')
+      chmodSync(locked, 0o000)
+      try {
+        const res = spawnSync(
+          process.execPath,
+          [LINT_SCRIPT, '--repo-root', root, '--allow', 'lib/guard.mjs'],
+          { encoding: 'utf8' },
+        )
+        assert.equal(res.status, 2, `${res.stdout}\n${res.stderr}`)
+      } finally {
+        chmodSync(locked, 0o644)
+      }
+    })
+
+    test('.mts and .cts are walked', () => {
+      for (const rel of ['src/tool.mts', 'src/tool.cts']) {
+        const { status } = runLint({ [rel]: 'if (process.argv[1]) main()\n' })
+        assert.equal(status, 1, `not walked: ${rel}`)
+      }
+    })
+  })
+
 })

--- a/packages/server/tests/lint-entry-point-guard.test.js
+++ b/packages/server/tests/lint-entry-point-guard.test.js
@@ -1,0 +1,429 @@
+/**
+ * Tests for scripts/lint-entry-point-guard.mjs (#7235).
+ *
+ * The lint enforces "there are only three": entry-point-ness is decided in the
+ * three un-mergeable copies of the guard and nowhere else. Its companion, the
+ * drift gate in scripts/__tests__/is-entry-point.test.mjs, enforces "the three
+ * agree" — and iterates a hardcoded list, which is exactly why this exists.
+ *
+ * Strategy: build a temp fixture tree, run the lint against it as a child
+ * process with `--repo-root`, and assert the EXIT CODE. Never the output — a
+ * `grep -c` over stdout reports grep's status, not the lint's
+ * (docs/false-safety-guards.md).
+ *
+ * `--repo-root` points the SAME walk at a fixture tree rather than adding a
+ * second enumeration path, so what these tests exercise is what CI runs.
+ *
+ * Every exemption below carries a POSITIVE CONTROL — the same fixture WITHOUT
+ * the thing that is supposed to exempt it, proving the case would have failed
+ * and that the exemption is what saved it. "This passes" passes just as happily
+ * against a lint that detects nothing.
+ *
+ * NOTE: this file is itself allowlisted in the lint's SANCTIONED set, because
+ * the fixture sources below spell the banned shapes literally and the lint's
+ * walk is repo-wide. That exemption is the one hole in the walk; it is listed
+ * where a reader will see it, and the lint's stale-allowlist check fails if this
+ * file ever stops containing them.
+ */
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-entry-point-guard.mjs')
+
+const tmpRoots = []
+after(() => {
+  for (const d of tmpRoots) {
+    try { rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+// A real guard body, used as the fixture's sanctioned copy so the allowlist is
+// never stale for the wrong reason. Trimmed from scripts/lib/is-entry-point.mjs.
+const SANCTIONED_GUARD = `
+import { realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function isEntryPoint (importMetaUrl) {
+  if (!process.argv[1]) return false
+  const self = fileURLToPath(importMetaUrl)
+  const invoked = resolve(process.argv[1])
+  if (self === invoked) return true
+  try {
+    return realpathSync(self) === realpathSync(invoked)
+  } catch {
+    return false
+  }
+}
+`
+
+/**
+ * Build a fixture tree and run the lint against it.
+ *
+ * `lib/guard.mjs` is always written and always allowlisted, so the
+ * stale-allowlist rule is satisfied unless a test deliberately breaks it.
+ *
+ * @param {Record<string,string>} files repo-relative path -> source
+ * @param {{allow?: string[], extraArgs?: string[], withGuard?: boolean}} [opts]
+ */
+function runLint(files, opts = {}) {
+  const { allow = ['lib/guard.mjs'], extraArgs = [], withGuard = true } = opts
+  const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-'))
+  tmpRoots.push(root)
+
+  const all = withGuard ? { 'lib/guard.mjs': SANCTIONED_GUARD, ...files } : { ...files }
+  for (const [rel, source] of Object.entries(all)) {
+    const full = join(root, rel)
+    mkdirSync(dirname(full), { recursive: true })
+    writeFileSync(full, source)
+  }
+
+  const args = ['--repo-root', root]
+  for (const a of allow) args.push('--allow', a)
+  args.push(...extraArgs)
+
+  const res = spawnSync(process.execPath, [LINT_SCRIPT, ...args], { encoding: 'utf8' })
+  return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '', root }
+}
+
+describe('lint-entry-point-guard', () => {
+  describe('the banned shapes', () => {
+    // The shape all four #7198 copies had, and the one a fourth copy is most
+    // likely to be pasted from.
+    test('catches the index read', () => {
+      const { status } = runLint({
+        'src/thing.js': `
+          import { pathToFileURL } from 'node:url'
+          if (import.meta.url === pathToFileURL(process.argv[1]).href) main()
+        `,
+      })
+      assert.equal(status, 1)
+    })
+
+    test('catches the .at(1) spelling', () => {
+      const { status } = runLint({
+        'src/thing.js': `
+          import { fileURLToPath } from 'node:url'
+          if (fileURLToPath(import.meta.url) === process.argv.at(1)) main()
+        `,
+      })
+      assert.equal(status, 1)
+    })
+
+    // Binds the script slot without ever naming an index, so index-matching
+    // alone would walk straight past it.
+    test('catches positional destructuring of the script slot', () => {
+      const { status } = runLint({
+        'src/thing.js': `
+          const [, invokedScript] = process.argv
+          if (invokedScript === __filename) main()
+        `,
+      })
+      assert.equal(status, 1)
+    })
+
+    test('catches import.meta.main', () => {
+      const { status } = runLint({
+        'src/thing.js': 'if (import.meta.main) main()\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    // `\\s*` spans newlines in every rule, so a prettier-wrapped or hand-broken
+    // guard is not a hole. A line-oriented lint would miss all three of these.
+    test('catches shapes broken across lines', () => {
+      for (const source of [
+        'if (process.argv\n  [1] === __filename) main()\n',
+        'if (process\n  .argv\n  .at(1) === __filename) main()\n',
+        'const [\n  ,\n  script,\n] = process.argv\n',
+      ]) {
+        const { status } = runLint({ 'src/thing.js': source })
+        assert.equal(status, 1, `not caught: ${JSON.stringify(source)}`)
+      }
+    })
+
+    // The fourth copy would not necessarily be in packages/server. Two of the
+    // three sanctioned copies already are not.
+    test('catches a guard anywhere in the tree, not just under src/', () => {
+      for (const rel of [
+        'scripts/tool.mjs',
+        'packages/dashboard/scripts/build.js',
+        'packages/store-core/src/cli.ts',
+        'packages/app/.maestro/mock-server.mjs',
+      ]) {
+        const { status } = runLint({ [rel]: 'if (process.argv[1]) main()\n' })
+        assert.equal(status, 1, `not caught at ${rel}`)
+      }
+    })
+
+    // The case that killed the raw-text prefilter. A comment INSIDE the
+    // expression leaves the raw source without the substring the prefilter
+    // looked for, while the stripped source still matches — so the file was
+    // skipped and the tree reported clean. Contrived as a hand-written shape,
+    // but "skipped an input" is a false-safety mode this repo has shipped
+    // three times, and the prefilter only bought 260ms.
+    test('catches a shape whose raw text is broken up by an inline comment', () => {
+      for (const source of [
+        'if (process./* which */argv[1] === __filename) main()\n',
+        'if (import./* native */meta.main) main()\n',
+      ]) {
+        const { status } = runLint({ 'src/thing.js': source })
+        assert.equal(status, 1, `not caught: ${JSON.stringify(source)}`)
+      }
+    })
+
+    test('reports the offending file and line', () => {
+      const { status, stderr } = runLint({
+        'src/thing.js': '\n\nif (process.argv[1] === __filename) main()\n',
+      })
+      assert.equal(status, 1)
+      assert.match(stderr, /src\/thing\.js:3\s+\[argv1-index]/)
+    })
+  })
+
+  describe('what it deliberately leaves alone', () => {
+    // Each of these needs its negative asserted AND a positive control, or the
+    // assertion passes identically against a lint that detects nothing.
+    test('a clean tree passes', () => {
+      const { status } = runLint({
+        'src/thing.js': "import { isEntryPoint } from './guard.mjs'\nif (isEntryPoint(import.meta.url)) main()\n",
+      })
+      assert.equal(status, 0)
+    })
+
+    test('require.main === module is fine (CJS compares module objects)', () => {
+      const { status } = runLint({
+        'src/thing.cjs': 'if (require.main === module) main()\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same file reading the script slot DOES fail', () => {
+      const { status } = runLint({
+        'src/thing.cjs': 'if (require.main === module) main()\nconst me = process.argv[1]\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    test('ordinary argument parsing is fine', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const args = process.argv.slice(2)\nconst [,, cmd] = process.argv\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: moving the binding to position 1 DOES fail', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const args = process.argv.slice(2)\nconst [, cmd] = process.argv\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    test('a rest element at position 1 is out of scope (documented boundary)', () => {
+      const { status } = runLint({
+        'src/thing.js': 'const [, ...rest] = process.argv\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    // Every copy of the guard, and the lint itself, discuss the banned shapes
+    // in prose. Without this the lint would be unusable on its own repo.
+    test('prose in comments is not code', () => {
+      const { status } = runLint({
+        'src/thing.js': `
+          // Never compare import.meta.url against process.argv[1] by hand.
+          /* The old code did: if (process.argv[1] === __filename) main() */
+          export const x = 1
+        `,
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same text UNCOMMENTED does fail', () => {
+      const { status } = runLint({
+        'src/thing.js': 'if (process.argv[1] === __filename) main()\nexport const x = 1\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    // .sh is not walked: docker-entrypoint.sh passes a config path as the first
+    // argument to `node -e`, where the slot means something else entirely.
+    test('shell sources are not walked', () => {
+      const { status } = runLint({
+        'scripts/entry.sh': 'node -e "console.log(process.argv[1])" "$CONFIG"\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same content in a .mjs IS walked', () => {
+      const { status } = runLint({
+        'scripts/entry.mjs': 'console.log(process.argv[1])\n',
+      })
+      assert.equal(status, 1)
+    })
+  })
+
+  describe('exemptions', () => {
+    test('a sanctioned copy is exempt', () => {
+      const { status } = runLint(
+        { 'src/utils/is-entry-point.js': SANCTIONED_GUARD },
+        { allow: ['lib/guard.mjs', 'src/utils/is-entry-point.js'] },
+      )
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same file un-allowlisted fails', () => {
+      const { status } = runLint({ 'src/utils/is-entry-point.js': SANCTIONED_GUARD })
+      assert.equal(status, 1)
+    })
+
+    test('the ignore marker exempts one site', () => {
+      const { status } = runLint({
+        'src/thing.js': '// lint-ignore-entry-point-guard: prints its own usage line\nconsole.log(process.argv[1])\n',
+      })
+      assert.equal(status, 0)
+    })
+
+    test('positive control: the same line without the marker fails', () => {
+      const { status } = runLint({
+        'src/thing.js': '// prints its own usage line\nconsole.log(process.argv[1])\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    // The marker must be a DIRECTIVE, not a mention. lint-config-dir.mjs shipped
+    // with the substring bug and its own docstring silently exempted whatever
+    // followed it.
+    test('the marker merely MENTIONED in prose does not exempt', () => {
+      const { status } = runLint({
+        'src/thing.js': '// You could add lint-ignore-entry-point-guard here, but do not.\nconsole.log(process.argv[1])\n',
+      })
+      assert.equal(status, 1)
+    })
+
+    test('the marker only covers the line below it, not the whole file', () => {
+      const { status } = runLint({
+        'src/thing.js': [
+          '// lint-ignore-entry-point-guard: usage line',
+          'console.log(process.argv[1])',
+          'if (process.argv[1] === __filename) main()',
+        ].join('\n') + '\n',
+      })
+      assert.equal(status, 1)
+    })
+  })
+
+  describe('the allowlist ratchet', () => {
+    // An exemption nothing needs is an exemption the next regression hides
+    // behind — the same rule lint-config-dir.mjs applies to its baseline.
+    test('an allowlisted file with no guard left in it is stale, and fails', () => {
+      const { status, stderr } = runLint(
+        { 'src/former-guard.js': 'export const x = 1\n' },
+        { allow: ['lib/guard.mjs', 'src/former-guard.js'] },
+      )
+      assert.equal(status, 1)
+      assert.match(stderr, /former-guard\.js: allowlisted .* but contains none/)
+    })
+
+    test('an allowlisted path that does not exist is a broken guard, not dirty code', () => {
+      const { status } = runLint({}, { allow: ['lib/guard.mjs', 'src/gone.js'] })
+      assert.equal(status, 2)
+    })
+  })
+
+  describe('failing closed', () => {
+    // "The guard broke" must never be shown as "the guard passed", and must not
+    // be shown as "the code is dirty" either — hence 2, distinct from 1.
+    test('an unknown flag exits 2 rather than silently walking the real repo', () => {
+      const { status } = runLint({}, { extraArgs: ['--reporoot', '/tmp/typo'] })
+      assert.equal(status, 2)
+    })
+
+    test('a flag missing its value exits 2', () => {
+      const { status } = runLint({}, { extraArgs: ['--min-files'] })
+      assert.equal(status, 2)
+    })
+
+    test('a non-integer --min-files exits 2', () => {
+      const { status } = runLint({}, { extraArgs: ['--min-files', 'lots'] })
+      assert.equal(status, 2)
+    })
+
+    test('a --repo-root that does not exist exits 2', () => {
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--repo-root', join(tmpdir(), 'chroxy-no-such-root-7235')],
+        { encoding: 'utf8' },
+      )
+      assert.equal(res.status, 2)
+    })
+
+    // Walking zero files and walking a clean tree used to be the same
+    // observable outcome in this repo's lints, three separate times.
+    test('walking zero files exits 2 rather than reporting a clean tree', () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-empty-'))
+      tmpRoots.push(root)
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--repo-root', root, '--allow', 'nothing.js'],
+        { encoding: 'utf8' },
+      )
+      assert.equal(res.status, 2)
+    })
+
+    test('a --min-files floor above the walk exits 2', () => {
+      const { status } = runLint(
+        { 'src/thing.js': 'export const x = 1\n' },
+        { extraArgs: ['--min-files', '500'] },
+      )
+      assert.equal(status, 2)
+    })
+
+    test('positive control: a floor the walk clears does not', () => {
+      const { status } = runLint(
+        { 'src/thing.js': 'export const x = 1\n' },
+        { extraArgs: ['--min-files', '2'] },
+      )
+      assert.equal(status, 0)
+    })
+  })
+
+  describe('--dry-run', () => {
+    test('reports offenders without failing', () => {
+      const { status, stderr } = runLint(
+        { 'src/thing.js': 'if (process.argv[1] === __filename) main()\n' },
+        { extraArgs: ['--dry-run'] },
+      )
+      assert.equal(status, 0)
+      assert.match(stderr, /argv1-index/)
+    })
+  })
+
+  describe('against the real repository', () => {
+    // The end-to-end case: default flags, default allowlist, the actual tree.
+    // If SANCTIONED drifts from reality — a guard copy renamed, a fourth one
+    // landed — this is what says so.
+    test('the repo is clean under the shipped defaults', () => {
+      const res = spawnSync(process.execPath, [LINT_SCRIPT], { encoding: 'utf8' })
+      assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`)
+      assert.match(res.stdout, /^OK: \d+ file\(s\) walked/)
+    })
+
+    // The floor the CI wrapper passes must actually be clearable, or Server Lint
+    // fails on exit 2 for a reason that has nothing to do with the code.
+    test('the wrapper\'s --min-files floor is not stale', () => {
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--min-files', '1500'],
+        { encoding: 'utf8' },
+      )
+      assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`)
+    })
+  })
+})

--- a/packages/server/tests/strip-comments.test.js
+++ b/packages/server/tests/strip-comments.test.js
@@ -1,0 +1,127 @@
+/**
+ * Tests for scripts/lib/strip-comments.mjs (#7247).
+ *
+ * The module blanks comments so a lint can tell prose from code. It is shared by
+ * lint-claude-family-explicit.mjs and lint-entry-point-guard.mjs, so a bug here
+ * is a bug in two gates at once — and its failure mode is the false-safety class
+ * docs/false-safety-guards.md is about, in both directions:
+ *
+ *   - blanking too MUCH hides real code from the caller (silent false negative)
+ *   - blanking too LITTLE lets prose read as code (spurious failure)
+ *
+ * The hand-written character scanner this replaced did both, because it could
+ * not tell a regex literal from a comment delimiter. Every case below that names
+ * a regex is a regression test for a shape measured on real files in this repo.
+ *
+ * NOTE: the needle here is deliberately NOT an entry-point-guard shape. This
+ * file is not on lint-entry-point-guard's allowlist, and using its banned tokens
+ * as fixture text would make that lint flag this file.
+ */
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { stripComments } from '../scripts/lib/strip-comments.mjs'
+
+const NEEDLE = 'NEEDLE_TOKEN'
+const sees = (src, file = 'input.js') => stripComments(src, file).includes(NEEDLE)
+
+describe('stripComments', () => {
+  describe('the contract', () => {
+    test('preserves length exactly', () => {
+      const src = '// a comment\nconst x = 1 /* block */\n'
+      assert.equal(stripComments(src).length, src.length)
+    })
+
+    test('preserves line numbers across a multi-line block comment', () => {
+      const src = `/*\n\n\n*/\nconst x = ${JSON.stringify(NEEDLE)}\n`
+      const out = stripComments(src)
+      assert.equal(out.split('\n').length, src.split('\n').length)
+      assert.equal(out.split('\n').findIndex((l) => l.includes(NEEDLE)), 4)
+    })
+
+    // The offsets the parser reports are UTF-16. An earlier draft blanked via
+    // `[...src]`, which splits by CODE POINT, so a single emoji above a comment
+    // shifted every index after it and the caller reported the wrong line.
+    test('stays aligned after an astral character', () => {
+      const src = `const flag = '\u{1F600}\u{1F680}'\n// ${NEEDLE} in a comment\nconst y = 2\n`
+      const out = stripComments(src)
+      assert.equal(out.length, src.length)
+      assert.ok(!out.includes(NEEDLE), 'the comment was not blanked — offsets drifted')
+      assert.ok(out.includes("'\u{1F600}\u{1F680}'"), 'the string literal was damaged')
+    })
+  })
+
+  describe('what it blanks', () => {
+    test('line comments', () => assert.equal(sees(`// ${NEEDLE}\n`), false))
+    test('block comments', () => assert.equal(sees(`/* ${NEEDLE} */\n`), false))
+    test('trailing comments after code', () => assert.equal(sees(`const x = 1 // ${NEEDLE}\n`), false))
+    test('JSDoc bodies', () => assert.equal(sees(`/**\n * ${NEEDLE}\n */\nconst x = 1\n`), false))
+    test('a comment before a closing brace', () =>
+      assert.equal(sees(`function f () {\n  g()\n  // ${NEEDLE}\n}\n`), false))
+    test('a comment at end of file', () => assert.equal(sees(`const x = 1\n// ${NEEDLE}\n`), false))
+  })
+
+  describe('what it leaves alone', () => {
+    test('code', () => assert.equal(sees(`const ${NEEDLE} = 1\n`), true))
+
+    // Callers rely on this: a lint fixture embedded in a template literal is
+    // text the lint should still be able to see.
+    test('string literals', () => assert.equal(sees(`const s = '${NEEDLE}'\n`), true))
+    test('template literals', () => assert.equal(sees(`const s = \`${NEEDLE}\`\n`), true))
+    test('a // sequence inside a string', () =>
+      assert.equal(sees(`const u = 'https://x/${NEEDLE}'\n`), true))
+  })
+
+  // The whole reason this module is a parser and not a character loop. Each of
+  // these was measured failing on real files in this repo.
+  describe('regex literals', () => {
+    // `\/` leaves a `/`, the next character is `*`, and a scanner reads `/*` as
+    // a block-comment open — blanking everything after it, code included.
+    test('a trailing-slash regex does not open a phantom block comment', () => {
+      assert.equal(sees(`const t = (u) => u.replace(/\\/*$/, '')\nconst ${NEEDLE} = 1\n`), true)
+    })
+
+    // A regex ending in an escaped slash looks like a `//` line comment.
+    test('a regex ending in an escaped slash does not eat the line', () => {
+      assert.equal(sees(`const w = /^wss:\\/\\// \nconst ${NEEDLE} = 1\n`), true)
+    })
+
+    // A quote inside a character class put the scanner into a phantom string
+    // state, so it stopped blanking comments for the rest of the file.
+    test('a quote inside a character class does not start a string', () => {
+      assert.equal(sees(`const M = /(["])/g\n// ${NEEDLE}\n`), false)
+    })
+
+    test("a single quote inside a character class likewise", () => {
+      assert.equal(sees(`const M = /(['])/g\n// ${NEEDLE}\n`), false)
+    })
+
+    test('a backtick inside a character class likewise', () => {
+      assert.equal(sees('const M = /([`])/g\n// ' + NEEDLE + '\n'), false)
+    })
+
+    // Division must not be mistaken for a regex either — the mirror error.
+    test('division is not a regex', () => {
+      assert.equal(sees(`const r = a / b / c\n// ${NEEDLE}\n`), false)
+      assert.equal(sees(`const r = a / b / c\nconst ${NEEDLE} = 1\n`), true)
+    })
+  })
+
+  describe('TypeScript and JSX', () => {
+    test('parses .ts generics without losing the rest of the file', () => {
+      const src = `const f = new Promise<Response>(() => {})\n// ${NEEDLE}\nconst y: number = 1\n`
+      assert.equal(sees(src, 'x.ts'), false)
+      assert.ok(stripComments(src, 'x.ts').includes('Promise<Response>'))
+    })
+
+    test('parses .tsx without treating a tag as a comparison', () => {
+      const src = `const el = <div className="a">{x}</div>\n// ${NEEDLE}\n`
+      assert.equal(sees(src, 'x.tsx'), false)
+    })
+
+    test('.mts and .cts are treated as TypeScript', () => {
+      const src = `const y: number = 1\n// ${NEEDLE}\n`
+      for (const f of ['x.mts', 'x.cts']) assert.equal(sees(src, f), false, f)
+    })
+  })
+})

--- a/scripts/__tests__/is-entry-point.test.mjs
+++ b/scripts/__tests__/is-entry-point.test.mjs
@@ -29,6 +29,7 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { isEntryPoint } from '../lib/is-entry-point.mjs'
+import { GUARD_COPIES } from '../lib/entry-point-guard-copies.mjs'
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -307,11 +308,12 @@ try {
   // the sidecar's talk about pods — and `import.meta.url` is normalised to the
   // parameter name because the sidecar is an inline IIFE rather than a function
   // taking the URL as an argument. Everything else must match exactly.
-  const GUARD_COPIES = [
-    'scripts/lib/is-entry-point.mjs',
-    'packages/server/src/utils/is-entry-point.js',
-    'packages/server/sidecar/agent.js',
-  ]
+  //
+  // This gate keeps the copies EQUAL; it cannot see a FOURTH one appear, because
+  // it iterates a list (#7235). That half is lint-entry-point-guard.mjs, which
+  // walks the repo and fails on anything outside the same list — imported from
+  // ../lib/entry-point-guard-copies.mjs so the two gates cannot disagree about
+  // which files they are talking about.
 
   const extractGuard = (relPath) => {
     const lines = readFileSync(join(REPO, relPath), 'utf8').split('\n')

--- a/scripts/lib/entry-point-guard-copies.mjs
+++ b/scripts/lib/entry-point-guard-copies.mjs
@@ -26,8 +26,9 @@
 //   packages/server/src/utils/is-entry-point.js — the server's copy, the one
 //     ordinary server modules import.
 //   packages/server/sidecar/agent.js           — ships as a standalone in-pod
-//     bundle whose Dockerfile COPYs only agent.js and its package.json, so it
-//     can import neither of the others.
+//     bundle. Its Dockerfile copies in only `package.json package-lock.json`
+//     and `agent.js`; neither packages/server/src nor scripts/lib is ever in
+//     the image, so it can import neither of the others.
 //
 // If you are here because you want a fourth: check first whether the file can
 // import one of the three. That has been the answer every time so far.

--- a/scripts/lib/entry-point-guard-copies.mjs
+++ b/scripts/lib/entry-point-guard-copies.mjs
@@ -1,0 +1,42 @@
+// entry-point-guard-copies.mjs — the three files allowed to answer "was this
+// module run directly?" by hand.
+//
+// There are exactly two gates on that guard, and before #7235 each carried its
+// own copy of this list:
+//
+//   - the DRIFT gate (scripts/__tests__/is-entry-point.test.mjs) says
+//     "the three agree" — it extracts the guard body from each and fails on
+//     divergence (#7222).
+//   - the WALK (packages/server/scripts/lint-entry-point-guard.mjs) says
+//     "there are only three" — it walks the repo and fails on any entry-point
+//     determination outside this set (#7235).
+//
+// Two lists of the same three files is the defect #7235 is about, one level up:
+// add a fourth copy to the walk's allowlist and forget the drift gate, and the
+// new copy is exempt from BOTH — nothing compares it to anything, and nothing
+// objects. So there is one list, here, imported by both.
+//
+// Adding an entry is a real decision, not bookkeeping. It says a file cannot
+// import either existing copy, and it opts that file into the drift gate, which
+// will then require its guard body to match the others character for character
+// (comments excepted). Today's three are:
+//
+//   scripts/lib/is-entry-point.mjs             — `scripts/` sits outside every
+//     workspace package and imports nothing from `packages/*​/src` (#7217).
+//   packages/server/src/utils/is-entry-point.js — the server's copy, the one
+//     ordinary server modules import.
+//   packages/server/sidecar/agent.js           — ships as a standalone in-pod
+//     bundle whose Dockerfile COPYs only agent.js and its package.json, so it
+//     can import neither of the others.
+//
+// If you are here because you want a fourth: check first whether the file can
+// import one of the three. That has been the answer every time so far.
+//
+// Paths are repo-relative and POSIX-separated. Both consumers join them onto
+// their own root.
+
+export const GUARD_COPIES = [
+  'scripts/lib/is-entry-point.mjs',
+  'packages/server/src/utils/is-entry-point.js',
+  'packages/server/sidecar/agent.js',
+]


### PR DESCRIPTION
Closes #7235.

## The gap

#7222 added a drift gate keeping the three surviving copies of the entry-point guard identical. It iterates `GUARD_COPIES`, a **hardcoded three-element list**, so it is silent when a *fourth* copy appears — which is exactly how #7198 happened (the same guard hand-rolled in four files, **all four wrong**, failing silently: the guard reads false, `main()` never runs, the process exits 0).

That closed the instance, not the failure mode. `docs/false-safety-guards.md` calls this "the list that stopped growing" and cites #7192 and #7197 for the same shape.

## What this adds

`packages/server/scripts/lint-entry-point-guard.mjs` — a **repo-wide** walk (~1900 JS/TS files, 0.4s) that fails on any entry-point determination outside the sanctioned set. Wired into **Server Lint**, which is a required check.

Deliberately repo-wide, not `packages/server`: two of the three sanctioned copies already live outside it, and so could a fourth. The step name says exactly what is covered (#7239's lesson about a gate overclaiming in its own title).

Four shapes are banned, matched on comment-stripped source with `\s*` spanning newlines:

| kind | why |
|---|---|
| `argv1-index` | the shape all four #7198 copies had |
| `argv1-at` | the same read spelled `.at(1)` |
| `argv1-destructure` | `const [, script] = process.argv` binds the slot without naming an index |
| `import-meta-main` | `undefined` on Node 22.0–22.17; the declared floor is `>=22`, so it is a falsy guard on a supported runtime — the same silent no-op, as a version skew no `node-version: 22` job would show |

Documented non-matches, each with a test and a positive control: `require.main === module` (CJS compares module objects, no symlink trap), ordinary `slice(2)` parsing, a rest element at position 1, `.sh` sources (`docker-entrypoint.sh` uses the same slot for a config path), and prose in comments.

## The two gates now read one list

Two hardcoded lists of the same three files is this bug one level up: add a fourth copy to the walk's allowlist, forget the drift gate, and the new copy is exempt from **both**. `scripts/lib/entry-point-guard-copies.mjs` is now the single list, imported by the drift gate and the walk.

The asymmetry that makes hardcoding safe *here*: the walk's list is the set **exempt**, so falling behind fails loudly. The drift gate's was the set **checked**, so falling behind was quiet. Same structure, opposite failure direction — sharing it means the safe direction covers the unsafe one. The allowlist is ratcheted both ways: an entry whose file no longer contains a guard fails as stale, and a sanctioned path that has vanished exits 2.

Exit 2 is distinct from 1 throughout — a bad flag, a missing sanctioned path, or a walk below its `--min-files` floor means the **guard** broke, and must not be reported as "clean" or as "dirty".

## Proven red before being trusted

Not "the tests pass" — the CI step's own shell body, run against real mutants in the real tree, checking **exit codes**:

| mutant | step exit |
|---|---|
| clean tree | 0 |
| 4th guard in `scripts/` (the #7198 `pathToFileURL` shape) | **1** |
| 4th guard in `packages/dashboard/` (the *fixed* realpath shape, copy-pasted) | **1** |
| `import.meta.main` in a `.ts` under `packages/store-core/` | **1** |
| a sanctioned copy renamed (lint exits 2) | **1** |

36 unit tests drive the same walk against fixture trees via `--repo-root`, so there is no second enumeration path that only tests exercise. Every exemption carries a positive control.

### One removal worth naming

A raw-text prefilter (skip files whose raw source has neither `argv` nor `import.meta.main`) was written and then removed. It is unsound in the one direction that matters: a comment *inside* the expression — `import./* */meta.main` — leaves the raw text without the substring while the stripped text still matches, so the file is skipped and the tree reports clean. That is "silently skipped an input", the fourth false-safety mode. It bought 260ms (0.14s vs 0.40s). The test for that case **fails against the prefilter and passes without it**, verified by re-adding it.

## Also in this PR, deliberately

- **`packages/server/scripts/lib/strip-comments.mjs`** — extracted verbatim from `lint-claude-family-explicit.mjs`, which now imports it. Writing a fourth copy of a comment stripper in the PR whose subject is "stop the fourth hand-rolled copy" seemed like poor form. The two other lints carry divergent versions (different signatures and string-awareness); migrating them is real work and is filed separately rather than smuggled in here.
- **`docs/false-safety-guards.md`** — its "Derive the set; never hardcode it" rule gains the complement this PR is an instance of (when the set cannot be derived, invert the list and walk everything). Its `is-entry-point.js` bullet was stale: it says #7222 is open and that the server's copy is the only unit-tested one. Both were true when written on 2026-08-16 and superseded by #7232 the same day.

## Verification

- `scripts/lint-entry-point-guard.sh` — OK, 1903 files walked
- all 7 custom server shell lints — pass
- `packages/server`: `lint-entry-point-guard` (36) + `lint-claude-family-explicit` + `lint-config-dir` + `is-entry-point` — 107 pass / 0 fail
- `scripts/__tests__/is-entry-point.test.mjs` (the drift gate, now importing the shared list) — 18 pass / 0 fail
- `npm run lint` (eslint) — 0 errors
