### PR TITLE
fix(ci): scope the entry-point walk to the repository, not the filesystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check no hand-rolled entry-point guard exists (JS/TS sources, excluding generated dist/)
+      - name: Check no hand-rolled entry-point guard exists (JS/TS sources in the repository)
         run: |
           # Issue #7235 — #7198 and the #7213 sweep found one guard hand-rolled
           # in four files, and ALL FOUR were wrong. Its failure mode is SILENCE:
@@ -436,9 +436,12 @@ jobs:
           # sanctioned copies live outside it, and so could a fourth. The step
           # name says what is actually covered, because a gate that overclaims
           # in its own title is #7239 — walked are
-          # .js/.mjs/.cjs/.ts/.mts/.cts/.tsx/.jsx; NOT walked are shell
-          # (docker-entrypoint.sh's `node -e` uses the same argv slot for a
-          # config path) and the 65 committed files under generated dist/.
+          # .js/.mjs/.cjs/.ts/.mts/.cts/.tsx/.jsx that git considers part of the
+          # repository. NOT walked: shell (docker-entrypoint.sh's `node -e` uses
+          # the same argv slot for a config path), the 65 committed files under
+          # generated dist/, and anything gitignored — notably
+          # packages/desktop/src-tauri/server-bundle/, a generated copy of the
+          # server that lags its source and still holds pre-#7217 guards.
           #
           # Exit 2 means the lint could not do its job (bad flags, a sanctioned
           # path that vanished, or it walked fewer files than its floor) and is

--- a/packages/server/scripts/lint-entry-point-guard.mjs
+++ b/packages/server/scripts/lint-entry-point-guard.mjs
@@ -65,7 +65,9 @@
  *     entirely. Shell is not scanned and this file's name does not claim it is
  *     (#7239's lesson: a gate must not overclaim in its own title).
  *   - Anything git does not consider part of the repository — gitignored build
- *     output, local scratch files. A guard has to be COMMITTED to matter, and
+ *     output and ignored local scratch files. An untracked file that is NOT
+ *     ignored is still scanned, deliberately: it is on its way to being
+ *     committed. A guard has to be COMMITTED to matter, and
  *     `packages/desktop/src-tauri/server-bundle/` is a generated copy of the
  *     whole server that lags the source by however long since it was last built.
  *     See `gitKnownFiles`.
@@ -245,8 +247,35 @@ function gitKnownFiles(root) {
     ['-C', root, 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
     { encoding: 'utf8', maxBuffer: 128 * 1024 * 1024 },
   )
-  if (res.error || res.status !== 0) return null
-  return new Set(res.stdout.split('\0').filter(Boolean))
+  if (res.error || res.status !== 0) {
+    // Fail-open, but never SILENTLY. Without this line the only difference
+    // between "filtered" and "git could not answer" is a file count the reader
+    // has no baseline for — and on a checkout git refuses to read (the
+    // "dubious ownership" safe.directory error is the common one on self-hosted
+    // runners and in containers) the developer gets the exact #7247 red back
+    // with nothing pointing at the cause.
+    console.error(
+      'lint-entry-point-guard: git could not list the repository '
+      + `(${res.error ? res.error.message : `exit ${res.status}`}); `
+      + 'scanning the whole walk unfiltered, so generated output may be reported.',
+    )
+    return null
+  }
+  // Normalised to NFC because the two sides are produced by different things.
+  // macOS git defaults to core.precomposeunicode=true and emits NFC, while
+  // readdirSync returns the on-disk bytes, which for a file created in NFD stay
+  // NFD. A raw === between them fails, the file is dropped, and a hand-rolled
+  // guard inside it goes UNREPORTED — the silently-skipped-an-input mode this
+  // file's header rejects the cheap prefilter for. Linux git does not
+  // precompose, so this divergence is macOS-only and CI would never show it.
+  //
+  // Case is NOT folded. On a case-insensitive filesystem an unrecorded
+  // case-only rename (plain `mv Thing.js thing.js`, which leaves `git status`
+  // clean) still drops the file locally. Folding case would be wrong on the
+  // case-sensitive filesystems CI runs on, where two such paths are genuinely
+  // different files, so the divergence is left to CI — which is case-sensitive
+  // and does catch it.
+  return new Set(res.stdout.split('\0').filter(Boolean).map((f) => f.normalize('NFC')))
 }
 
 function walk(dir, out = []) {
@@ -450,7 +479,7 @@ try {
 // filtered, which only ever widens coverage.
 const known = gitKnownFiles(root)
 if (known) {
-  files = files.filter((f) => known.has(relative(root, f).split(pathSep).join('/')))
+  files = files.filter((f) => known.has(relative(root, f).split(pathSep).join('/').normalize('NFC')))
 }
 
 // "Walked zero files" and "walked 1963 clean files" must not be the same

--- a/packages/server/scripts/lint-entry-point-guard.mjs
+++ b/packages/server/scripts/lint-entry-point-guard.mjs
@@ -64,6 +64,11 @@
  *     first argument to `node -e`, where argv index 1 means something else
  *     entirely. Shell is not scanned and this file's name does not claim it is
  *     (#7239's lesson: a gate must not overclaim in its own title).
+ *   - Anything git does not consider part of the repository — gitignored build
+ *     output, local scratch files. A guard has to be COMMITTED to matter, and
+ *     `packages/desktop/src-tauri/server-bundle/` is a generated copy of the
+ *     whole server that lags the source by however long since it was last built.
+ *     See `gitKnownFiles`.
  *   - Anything inside a `//` or block comment. This matters — every copy of the
  *     guard, and this file, discuss the banned shapes in prose.
  *
@@ -116,13 +121,16 @@
  *                       equal-site-count check. REPEATABLE. Defaults to
  *                       GUARD_COPIES; empty when --allow is given alone.
  *   --min-files <n>     Exit 2 if fewer than n files were walked. A FLOOR, not a
- *                       count — it only ever fails closed.
+ *                       count — it only ever fails closed. Counted AFTER the
+ *                       gitignore filter, so it tracks what was actually checked.
  *   --dry-run           Print offenders without failing the exit code.
  *
- * Issue: #7235. Background: #7198, #7213, #7222, #7226.
+ * Issue: #7235, and #7247's review + post-merge fix. Background: #7198, #7213,
+ * #7222, #7226.
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -207,6 +215,38 @@ function parseArgs(argv) {
     usageError('--min-files requires a non-negative integer')
   }
   return out
+}
+
+/**
+ * The set of repo-relative paths git considers part of the repository —
+ * tracked, plus untracked files that are not ignored.
+ *
+ * The walk alone is not the right set. `packages/desktop/src-tauri/server-bundle/`
+ * is GENERATED (gitignored at .gitignore:60) and holds a stale, pre-#7217 copy
+ * of the whole server — including two of the original buggy guards. A fresh CI
+ * checkout has no bundle, so CI stayed green while every developer who had built
+ * the desktop app got a red Server Lint from files they never wrote. That is a
+ * false positive in a required check, coming from output that cannot contain a
+ * fourth guard in any meaningful sense: a guard has to be COMMITTED to matter.
+ *
+ * A name in SKIP_DIRS would have fixed this one directory and left the next
+ * generated tree to rediscover it — the hardcoded-list failure this whole lint
+ * exists to prevent. Asking git is the actual rule.
+ *
+ * Returns null when git cannot answer (not a repository, git absent), in which
+ * case nothing is filtered. That direction is deliberate: no filter means
+ * scanning MORE files, never fewer, so an unavailable git cannot hide a guard.
+ * It is also what lets the tests point --repo-root at a plain fixture tree and
+ * still exercise this exact code path.
+ */
+function gitKnownFiles(root) {
+  const res = spawnSync(
+    'git',
+    ['-C', root, 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+    { encoding: 'utf8', maxBuffer: 128 * 1024 * 1024 },
+  )
+  if (res.error || res.status !== 0) return null
+  return new Set(res.stdout.split('\0').filter(Boolean))
 }
 
 function walk(dir, out = []) {
@@ -403,6 +443,14 @@ try {
   files = walk(root).sort()
 } catch (err) {
   usageError(`cannot walk ${root}: ${err.message}`)
+}
+
+// Drop generated output git does not consider part of the repository. See
+// gitKnownFiles: a null return means git could not answer, and nothing is
+// filtered, which only ever widens coverage.
+const known = gitKnownFiles(root)
+if (known) {
+  files = files.filter((f) => known.has(relative(root, f).split(pathSep).join('/')))
 }
 
 // "Walked zero files" and "walked 1963 clean files" must not be the same

--- a/packages/server/scripts/lint-entry-point-guard.sh
+++ b/packages/server/scripts/lint-entry-point-guard.sh
@@ -12,9 +12,11 @@
 # breaks — a skip-list entry that swallows a real directory, a checkout that
 # resolved to nothing — the lint would otherwise walk few or zero files and
 # report a clean tree, which is indistinguishable from actually being clean.
-# The tree walks 1902 files in CI (1903 locally, where one gitignored generated
-# file is present); 1500 leaves room for ordinary deletions while still catching
-# a collapse — losing all of packages/dashboard or packages/server would trip it.
+# The tree checks 1903 files, in CI and in a local checkout alike — the walk is
+# filtered to what git considers part of the repository, so build artifacts no
+# longer make the two diverge. 1500 leaves room for ordinary deletions while
+# still catching a collapse — losing all of packages/dashboard or
+# packages/server would trip it.
 #
 # The number below is asserted against this file by
 # tests/lint-entry-point-guard.test.js, which parses it out rather than

--- a/packages/server/tests/lint-entry-point-guard.test.js
+++ b/packages/server/tests/lint-entry-point-guard.test.js
@@ -673,6 +673,57 @@ describe('lint-entry-point-guard', () => {
       assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`)
     })
 
+    // The floor must count what was actually CHECKED, not what was walked.
+    // The header claims this, the code does it, and nothing pinned it: moving
+    // the filter below the floor check left all 60 tests green. It is
+    // load-bearing — a tree with a lot of generated output could clear the floor
+    // on ignored files while the scanned set had collapsed, which is the exact
+    // failure --min-files exists to prevent.
+    test('--min-files counts the filtered set, not the raw walk', () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-floor-'))
+      tmpRoots.push(root)
+      const run = (...a) => spawnSync('git', ['-C', root, ...a], { encoding: 'utf8' })
+      run('init', '-q')
+      run('config', 'gc.auto', '0')
+      writeFileSync(join(root, '.gitignore'), 'generated/\n')
+      mkdirSync(join(root, 'lib'), { recursive: true })
+      writeFileSync(join(root, 'lib', 'guard.mjs'), SANCTIONED_GUARD)
+      mkdirSync(join(root, 'generated'), { recursive: true })
+      for (let i = 0; i < 5; i++) writeFileSync(join(root, 'generated', `g${i}.js`), 'export const x = 1\n')
+      // Walked: 6. Checked after filtering: 1. A floor of 3 must fail.
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--repo-root', root, '--allow', 'lib/guard.mjs', '--min-files', '3'],
+        { encoding: 'utf8' },
+      )
+      assert.equal(res.status, 2, `${res.stdout}\n${res.stderr}`)
+      assert.match(res.stderr, /walked only 1 file/)
+    })
+
+    // macOS git precomposes to NFC while readdirSync returns the on-disk bytes,
+    // so a file created in NFD compares unequal and is dropped — a guard inside
+    // it goes unreported. Linux git does not precompose, so CI cannot show this.
+    test('a guard in an NFD-named file is still reported', () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-nfd-'))
+      tmpRoots.push(root)
+      const run = (...a) => spawnSync('git', ['-C', root, ...a], { encoding: 'utf8' })
+      run('init', '-q')
+      run('config', 'gc.auto', '0')
+      mkdirSync(join(root, 'lib'), { recursive: true })
+      writeFileSync(join(root, 'lib', 'guard.mjs'), SANCTIONED_GUARD)
+      // "café.js" with a COMBINING acute — decomposed on disk.
+      const nfd = 'café.js'
+      writeFileSync(join(root, nfd), GUARD)
+      run('add', '-A')
+      run('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'x')
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--repo-root', root, '--allow', 'lib/guard.mjs'],
+        { encoding: 'utf8' },
+      )
+      assert.equal(res.status, 1, `a committed guard in an NFD path went unreported:\n${res.stdout}\n${res.stderr}`)
+    })
+
     // Every other test in this file points --repo-root at a plain temp dir that
     // is NOT a repo. They all pass, which is this assertion's real proof: when
     // git cannot answer, nothing is filtered and coverage only widens. Stated

--- a/packages/server/tests/lint-entry-point-guard.test.js
+++ b/packages/server/tests/lint-entry-point-guard.test.js
@@ -597,4 +597,90 @@ describe('lint-entry-point-guard', () => {
     })
   })
 
+
+  // --- #7247 post-merge: generated output is not the repository ------------
+  //
+  // The first version walked the filesystem, which is not the same set as "the
+  // repository". `packages/desktop/src-tauri/server-bundle/` is GENERATED and
+  // gitignored, and it holds a stale pre-#7217 copy of the whole server — two of
+  // the original buggy guards included. A fresh CI checkout has no bundle, so CI
+  // stayed green while anyone who had built the desktop app got a red Server
+  // Lint from files they never wrote.
+  //
+  // A name in SKIP_DIRS would have fixed that one directory and left the next
+  // generated tree to rediscover it, which is the hardcoded-list failure this
+  // lint exists to prevent. Asking git is the actual rule.
+  describe('gitignored output is not walked', () => {
+    /** A fixture tree that is a real git repo, so the ignore rules are real. */
+    function gitFixture(files, gitignore) {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-git-'))
+      tmpRoots.push(root)
+      const run = (...a) => spawnSync('git', ['-C', root, ...a], { encoding: 'utf8' })
+      run('init', '-q')
+      // Auto-gc racing the teardown is a known source of ENOTEMPTY flakes here.
+      run('config', 'gc.auto', '0')
+      writeFileSync(join(root, '.gitignore'), gitignore)
+      mkdirSync(join(root, 'lib'), { recursive: true })
+      writeFileSync(join(root, 'lib', 'guard.mjs'), SANCTIONED_GUARD)
+      for (const [rel, source] of Object.entries(files)) {
+        const full = join(root, rel)
+        mkdirSync(dirname(full), { recursive: true })
+        writeFileSync(full, source)
+      }
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--repo-root', root, '--allow', 'lib/guard.mjs'],
+        { encoding: 'utf8' },
+      )
+      return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '' }
+    }
+
+    const GUARD = 'if (process.argv[1] === __filename) main()\n'
+
+    test('a guard inside gitignored output is not reported', () => {
+      const { status } = gitFixture({ 'generated/bundle/thing.js': GUARD }, 'generated/\n')
+      assert.equal(status, 0)
+    })
+
+    // Positive control, and the one that matters: the exemption must come from
+    // the ignore rule, not from the path being generated-looking or the walk
+    // quietly missing it.
+    test('positive control: the same file NOT ignored is reported', () => {
+      const { status, stderr } = gitFixture({ 'generated/bundle/thing.js': GUARD }, 'something-else/\n')
+      assert.equal(status, 1)
+      assert.match(stderr, /generated\/bundle\/thing\.js/)
+    })
+
+    // A committed file always counts, even if a broad ignore rule would match
+    // it — `git ls-files --cached` lists it regardless.
+    test('a TRACKED file matching an ignore rule is still reported', () => {
+      const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-entrypoint-tracked-'))
+      tmpRoots.push(root)
+      const run = (...a) => spawnSync('git', ['-C', root, ...a], { encoding: 'utf8' })
+      run('init', '-q')
+      run('config', 'gc.auto', '0')
+      mkdirSync(join(root, 'lib'), { recursive: true })
+      writeFileSync(join(root, 'lib', 'guard.mjs'), SANCTIONED_GUARD)
+      mkdirSync(join(root, 'generated'), { recursive: true })
+      writeFileSync(join(root, 'generated', 'thing.js'), GUARD)
+      writeFileSync(join(root, '.gitignore'), 'generated/\n')
+      run('add', '-f', 'generated/thing.js')
+      const res = spawnSync(
+        process.execPath,
+        [LINT_SCRIPT, '--repo-root', root, '--allow', 'lib/guard.mjs'],
+        { encoding: 'utf8' },
+      )
+      assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`)
+    })
+
+    // Every other test in this file points --repo-root at a plain temp dir that
+    // is NOT a repo. They all pass, which is this assertion's real proof: when
+    // git cannot answer, nothing is filtered and coverage only widens. Stated
+    // explicitly so the fallback is not mistaken for an accident.
+    test('a non-repo root filters nothing rather than dropping everything', () => {
+      const { status } = runLint({ 'src/thing.js': GUARD })
+      assert.equal(status, 1)
+    })
+  })
+
 })


### PR DESCRIPTION
Follow-up to #7247, which I found broken **after** merging it — by running the shipped gate against the main checkout rather than my worktree.

## The bug

#7247's lint walks the filesystem. That is not the same set as "the repository".

`packages/desktop/src-tauri/server-bundle/` is generated and gitignored (`.gitignore:60`). It contains a stale copy of the entire server, from before #7217 removed the hand-rolled guards — so it still has two of the original #7198 ones:

```
packages/desktop/src-tauri/server-bundle/src/server-cli-child.js:165
packages/desktop/src-tauri/server-bundle/src/channels/chroxy-channel-server.js:241
  const isEntryPoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
```

A fresh CI checkout has no bundle, so all 22 checks passed on #7247 while the gate was **already failing in every working copy that had built the desktop app** — reporting guards the developer never wrote, in files they cannot fix.

### Why nothing caught it

Worth recording, because it is the interesting part. My worktree *has* `server-bundle`, but empty — so the lint passed there, the 36 fixture tests passed, and all three in-situ mutation runs passed. Every check I ran was against a tree that happened not to contain the failing input. It surfaced only when I ran the merged gate against `~/Projects/chroxy` as a post-merge verification.

## The fix

Adding `server-bundle` to `SKIP_DIRS` would have fixed this one directory and left the next generated tree to rediscover it — the hardcoded-list failure this lint exists to prevent. So the rule is the real one:

```
git ls-files --cached --others --exclude-standard
```

A guard has to be **committed** to matter. A tracked file still counts even if a broad ignore rule would match it (`--cached` lists it regardless), so `git add -f`'d output is not a hole.

**When git cannot answer** — not a repository, git absent — nothing is filtered. That direction is deliberate: no filter means scanning MORE files, never fewer, so an unavailable git can never hide a guard. It is also what lets the existing tests point `--repo-root` at a plain fixture tree and still exercise this exact code path; that fallback is now asserted rather than left implicit.

`--min-files` is counted after the filter, so it tracks what was actually checked.

## Verification

Against the main checkout, which is where the bug reproduces:

| | exit |
|---|---|
| shipped lint (#7247) on the main checkout | **1** ← the bug |
| this lint on the main checkout | **0** |
| this lint + a real fourth guard there | **1** |
| this lint + a guard planted inside the ignored bundle | **0** |

Four new tests build **real git repos** (`git init`, `gc.auto 0` against the known ENOTEMPTY teardown race) rather than faking ignore rules: ignored guard not reported; positive control with the ignore rule pointed elsewhere; a tracked-but-ignore-matching file still reported; and a non-repo root filtering nothing. The first fails against a filter-disabled mutant.

60 tests in the suite, 102 across all affected server test files, drift gate 18/18, 7/7 custom server lints, eslint clean.