### PR TITLE
fix(ci): one comment stripper, and lint-config-dir stops hiding real offenders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,8 +334,21 @@ jobs:
           # feedback_jsonl_subprocess_middle_layer.md has bitten three times
           # (#3224, #3231, #4790). This lint blocks the next recurrence at
           # PR time instead of catching it in production.
-          if scripts/lint-session-opt-forwarding.sh; then
+          #
+          # Exit 2 is reported separately from 1, matching the config-dir step
+          # below: the lint uses 2 for "could not run" (a stripper that will not
+          # load, a file it cannot read, BASE_SESSION_OPT_KEYS drift) and 1 for
+          # "a subclass drops an opt". Collapsing them told the operator to go
+          # looking for an opt-drop that does not exist (#7248 review).
+          set +e
+          scripts/lint-session-opt-forwarding.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
             echo "OK — every session subclass forwards every BaseSession opt"
+          elif [ "$rc" -eq 2 ]; then
+            echo "::error::lint-session-opt-forwarding could not run (the comment stripper failed to load or read a file, or BASE_SESSION_OPT_KEYS has drifted from the BaseSession ctor). The GUARD is broken, not necessarily the code. See packages/server/scripts/lint-session-opt-forwarding.mjs."
+            exit 1
           else
             echo "::error::A provider session class drops a BaseSession opt on its way to super(). See packages/server/scripts/lint-session-opt-forwarding.sh."
             exit 1

--- a/packages/server/scripts/lib/strip-comments.mjs
+++ b/packages/server/scripts/lib/strip-comments.mjs
@@ -43,9 +43,12 @@
  * still see. A caller that needs strings blanked too should say so explicitly
  * rather than assume it.
  *
- * `lint-config-dir.mjs` and `lint-session-opt-forwarding.mjs` still carry their
- * own hand-written strippers, with different signatures and the same regex
- * blindness. Migrating them is #7248.
+ * Every lint in `packages/server/scripts/` uses this one as of #7248 — there is
+ * no other implementation in the repo. Both of the copies this replaced were
+ * regex-blind in the way described above, in opposite directions:
+ * `lint-config-dir.mjs`'s was not string-aware and HID code after a URL literal;
+ * `lint-session-opt-forwarding.mjs`'s desynced on a quote inside a character
+ * class and LEAKED comment text as code.
  */
 
 import ts from 'typescript'

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -279,7 +279,16 @@ function findOffenders(srcDirs, ownerPaths, keyRoot) {
 
       const source = readFileSync(file, 'utf8')
       const rawLines = source.split('\n')
-      const code = stripComments(source, file).split('\n')
+      // A stripper throw is "the lint could not read this file", not "the tree
+      // is dirty" — it must not escape as an uncaught exception, which exits 1
+      // and this file documents 1 as an offender. Same reasoning as the guarded
+      // import above (#7248 review).
+      let code
+      try {
+        code = stripComments(source, file).split('\n')
+      } catch (err) {
+        usageError(`cannot strip comments from ${rel}: ${err.message}`)
+      }
       const wrappers = accessorWrappersIn(code)
       const homeVars = homeBoundVarsIn(code)
       const callsAccessor = (text) =>

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -174,9 +174,11 @@ function listSourceFiles(dir) {
 // Comment stripping lives in ./lib/strip-comments.mjs (#7248). This file used
 // to carry its own line-array version, and it was NOT string-aware: a `//`
 // inside a string literal started a "comment", so everything after it on that
-// line was blanked. Real code was being hidden from this lint on 89 of the 307
-// files it scans — `must use http://` in a template literal truncated the rest
-// of the statement, for one. The shared implementation asks a parser, so a `//`
+// line was blanked. Measured over the 307 files it scans, real code was hidden
+// on 47 of them — `must use http://` in a template literal truncated the rest of
+// the statement, for one. (The stripped output differs on more files than that,
+// but only in whitespace padding; 47 is the count where non-whitespace code went
+// missing, which is the number this sentence is about.) The shared implementation asks a parser, so a `//`
 // inside a string is a string.
 //
 // The old signature returned an ARRAY of lines. That stayed a caller concern

--- a/packages/server/scripts/lint-config-dir.mjs
+++ b/packages/server/scripts/lint-config-dir.mjs
@@ -98,6 +98,17 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from '
 import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+// Dynamic, so an unloadable stripper exits 2 ("the lint could not run") rather
+// than 1 ("the tree is dirty"). A static import cannot be caught, and an
+// uncaught ESM resolution error exits 1.
+let stripComments
+try {
+  ({ stripComments } = await import('./lib/strip-comments.mjs'))
+} catch (err) {
+  console.error(`lint-config-dir: cannot load the comment stripper: ${err.message}`)
+  process.exit(2)
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '..', '..', '..')
 
@@ -160,32 +171,19 @@ function listSourceFiles(dir) {
   return out.sort()
 }
 
-/**
- * Blank out comment spans so a doc block that *quotes* the banned pattern is
- * not itself an offender. Returns a line array of the same length, with
- * commented regions replaced by spaces (line numbers stay accurate).
- */
-function stripComments(source) {
-  const out = []
-  let inBlock = false
-  for (const line of source.split('\n')) {
-    let kept = ''
-    let i = 0
-    while (i < line.length) {
-      if (inBlock) {
-        const end = line.indexOf('*/', i)
-        if (end === -1) { i = line.length } else { inBlock = false; i = end + 2 }
-        continue
-      }
-      if (line.startsWith('//', i)) break
-      if (line.startsWith('/*', i)) { inBlock = true; i += 2; continue }
-      kept += line[i]
-      i++
-    }
-    out.push(kept)
-  }
-  return out
-}
+// Comment stripping lives in ./lib/strip-comments.mjs (#7248). This file used
+// to carry its own line-array version, and it was NOT string-aware: a `//`
+// inside a string literal started a "comment", so everything after it on that
+// line was blanked. Real code was being hidden from this lint on 89 of the 307
+// files it scans — `must use http://` in a template literal truncated the rest
+// of the statement, for one. The shared implementation asks a parser, so a `//`
+// inside a string is a string.
+//
+// The old signature returned an ARRAY of lines. That stayed a caller concern
+// rather than becoming an option on the shared module: the shared stripper
+// preserves offsets and newlines exactly, so `.split('\n')` reproduces the
+// array with identical indices, and an option would have been a second code
+// path to keep honest for no gain.
 
 // A home-root expression. `process.env.HOME` is the same thing by another
 // spelling (tests/smoke-test.mjs uses it) and evaded a `homedir()`-only rule.
@@ -281,7 +279,7 @@ function findOffenders(srcDirs, ownerPaths, keyRoot) {
 
       const source = readFileSync(file, 'utf8')
       const rawLines = source.split('\n')
-      const code = stripComments(source)
+      const code = stripComments(source, file).split('\n')
       const wrappers = accessorWrappersIn(code)
       const homeVars = homeBoundVarsIn(code)
       const callsAccessor = (text) =>

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -66,6 +66,19 @@ try {
   process.exit(2)
 }
 
+// A stripper throw is "the lint could not read this file", not "a subclass drops
+// an opt" — it must not escape as an uncaught exception, which exits 1 and this
+// lint reserves 1 for the latter. Four call sites, so the guard is the wrapper
+// rather than four try/catch blocks (#7248 review).
+function strip(src, fileName) {
+  try {
+    return stripComments(src, fileName)
+  } catch (err) {
+    console.error(`lint-session-opt-forwarding: cannot strip comments from ${fileName}: ${err.message}`)
+    process.exit(2)
+  }
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function parseFlags(argv) {
@@ -195,7 +208,7 @@ function extractObjectKeys(block) {
 
 function parseBaseSessionOpts(baseSessionPath) {
   const src = readFileSync(baseSessionPath, 'utf8')
-  const stripped = stripComments(src, baseSessionPath)
+  const stripped = strip(src, baseSessionPath)
   // Anchor on `export class BaseSession` (the class we care about — the
   // file may export helpers and constants too).
   const classIdx = stripped.indexOf('export class BaseSession')
@@ -231,7 +244,7 @@ function parseBaseSessionOpts(baseSessionPath) {
 // Returns { keys: Set<string>, order: string[] }.
 function parseBaseSessionOptKeysArray(baseSessionPath) {
   const src = readFileSync(baseSessionPath, 'utf8')
-  const stripped = stripComments(src, baseSessionPath)
+  const stripped = strip(src, baseSessionPath)
   const declIdx = stripped.indexOf('BASE_SESSION_OPT_KEYS')
   if (declIdx === -1) {
     throw new Error(`Could not find "BASE_SESSION_OPT_KEYS" in ${baseSessionPath}`)
@@ -523,7 +536,7 @@ function main() {
   // (roots + every transitive subclass → the scan matcher picks up direct AND
   // second-tier subclasses) and the picker-ban set (every transitive descendant
   // of a forbidden ancestor, ancestor itself exempt).
-  const classEdges = collectClassEdges(allFiles.map(f => stripComments(readFileSync(f, 'utf8'), f)))
+  const classEdges = collectClassEdges(allFiles.map(f => strip(readFileSync(f, 'utf8'), f)))
   const sessionBases = descendantClosure(classEdges, ROOT_SESSION_BASES, { includeSeeds: true })
   const pickerForbidden = descendantClosure(classEdges, PICKER_FORBIDDEN_ANCESTORS, { includeSeeds: false })
   const classRe = buildSessionClassRegex(sessionBases)
@@ -536,7 +549,7 @@ function main() {
     const origSrc = readFileSync(file, 'utf8')
     if (!classRe.test(origSrc)) continue
     classRe.lastIndex = 0
-    const strippedSrc = stripComments(origSrc, file)
+    const strippedSrc = strip(origSrc, file)
     let m
     while ((m = classRe.exec(strippedSrc)) !== null) {
       const className = m[1]

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -56,6 +56,16 @@ import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+// Dynamic, so an unloadable stripper exits 2 ("the lint could not run") rather
+// than 1 ("a subclass drops an opt").
+let stripComments
+try {
+  ({ stripComments } = await import('./lib/strip-comments.mjs'))
+} catch (err) {
+  console.error(`lint-session-opt-forwarding: cannot load the comment stripper: ${err.message}`)
+  process.exit(2)
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function parseFlags(argv) {
@@ -108,47 +118,18 @@ function findMatchingBracket(src, openIdx, open, close) {
   return -1
 }
 
-function stripComments(src) {
-  // Strip // line comments and /* block */ comments. Keeps newlines so
-  // line-number math downstream still tracks the original source.
-  let out = ''
-  let i = 0
-  let inStr = null
-  while (i < src.length) {
-    const ch = src[i]
-    const prev = src[i - 1]
-    if (inStr) {
-      out += ch
-      if (ch === inStr && prev !== '\\') inStr = null
-      i++
-      continue
-    }
-    if (ch === '"' || ch === "'" || ch === '`') {
-      inStr = ch
-      out += ch
-      i++
-      continue
-    }
-    if (ch === '/' && src[i + 1] === '/') {
-      const nl = src.indexOf('\n', i)
-      if (nl === -1) { i = src.length; continue }
-      i = nl
-      continue
-    }
-    if (ch === '/' && src[i + 1] === '*') {
-      const end = src.indexOf('*/', i + 2)
-      if (end === -1) { i = src.length; continue }
-      // Preserve newlines so any downstream line-counting stays sane.
-      const block = src.slice(i, end + 2)
-      for (const c of block) if (c === '\n') out += '\n'
-      i = end + 2
-      continue
-    }
-    out += ch
-    i++
-  }
-  return out
-}
+// Comment stripping lives in ./lib/strip-comments.mjs (#7248). This file used to
+// carry its own scanner. It was string-aware but not REGEX-aware, so a regex
+// literal containing a quote — `/(["])/g` — put it into a phantom string state
+// and it stopped stripping: on 24 of the files this lint reads, JSDoc bodies
+// survived as if they were code. That is the false-POSITIVE direction of the
+// same defect #7249 fixed in the entry-point lint, and the reason a character
+// scanner cannot do this job: telling a regex literal from division needs the
+// grammar.
+//
+// The shared implementation blanks comments while preserving every offset, which
+// is strictly stronger than what this file needs — `lineOf` below only requires
+// line numbers to line up.
 
 // Extract the set of destructure keys from a `{ ... }` block. Handles
 // trailing commas, default values (`= foo`), rename (`a: b` — rare here),
@@ -214,7 +195,7 @@ function extractObjectKeys(block) {
 
 function parseBaseSessionOpts(baseSessionPath) {
   const src = readFileSync(baseSessionPath, 'utf8')
-  const stripped = stripComments(src)
+  const stripped = stripComments(src, baseSessionPath)
   // Anchor on `export class BaseSession` (the class we care about — the
   // file may export helpers and constants too).
   const classIdx = stripped.indexOf('export class BaseSession')
@@ -250,7 +231,7 @@ function parseBaseSessionOpts(baseSessionPath) {
 // Returns { keys: Set<string>, order: string[] }.
 function parseBaseSessionOptKeysArray(baseSessionPath) {
   const src = readFileSync(baseSessionPath, 'utf8')
-  const stripped = stripComments(src)
+  const stripped = stripComments(src, baseSessionPath)
   const declIdx = stripped.indexOf('BASE_SESSION_OPT_KEYS')
   if (declIdx === -1) {
     throw new Error(`Could not find "BASE_SESSION_OPT_KEYS" in ${baseSessionPath}`)
@@ -542,7 +523,7 @@ function main() {
   // (roots + every transitive subclass → the scan matcher picks up direct AND
   // second-tier subclasses) and the picker-ban set (every transitive descendant
   // of a forbidden ancestor, ancestor itself exempt).
-  const classEdges = collectClassEdges(allFiles.map(f => stripComments(readFileSync(f, 'utf8'))))
+  const classEdges = collectClassEdges(allFiles.map(f => stripComments(readFileSync(f, 'utf8'), f)))
   const sessionBases = descendantClosure(classEdges, ROOT_SESSION_BASES, { includeSeeds: true })
   const pickerForbidden = descendantClosure(classEdges, PICKER_FORBIDDEN_ANCESTORS, { includeSeeds: false })
   const classRe = buildSessionClassRegex(sessionBases)
@@ -555,7 +536,7 @@ function main() {
     const origSrc = readFileSync(file, 'utf8')
     if (!classRe.test(origSrc)) continue
     classRe.lastIndex = 0
-    const strippedSrc = stripComments(origSrc)
+    const strippedSrc = stripComments(origSrc, file)
     let m
     while ((m = classRe.exec(strippedSrc)) !== null) {
       const className = m[1]

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -134,8 +134,11 @@ function findMatchingBracket(src, openIdx, open, close) {
 // Comment stripping lives in ./lib/strip-comments.mjs (#7248). This file used to
 // carry its own scanner. It was string-aware but not REGEX-aware, so a regex
 // literal containing a quote — `/(["])/g` — put it into a phantom string state
-// and it stopped stripping: on 24 of the files this lint reads, JSDoc bodies
-// survived as if they were code. That is the false-POSITIVE direction of the
+// and it stopped stripping, so comment text survived as if it were code. The
+// other direction is worse and is what the test suite pins: in `/\/*$/` the
+// `\/` leaves a `/` and the next character is `*`, so the scanner reads a BLOCK
+// COMMENT OPEN and blanks to EOF — a real offending subclass below such a line
+// became invisible and this lint reported "0 session subclass(es)". Both are the
 // same defect #7249 fixed in the entry-point lint, and the reason a character
 // scanner cannot do this job: telling a regex literal from division needs the
 // grammar.

--- a/packages/server/tests/lint-config-dir.test.js
+++ b/packages/server/tests/lint-config-dir.test.js
@@ -728,4 +728,50 @@ export function statePath() {
       assert.match(res.stderr, /\.\.\/b\/offender\.js:5/)
     })
   })
+
+  // --- #7248: the stripper was hiding real offenders ----------------------
+  //
+  // This lint used to carry its own comment stripper, and it was not
+  // string-aware: `line.startsWith('//', i)` fired on the `//` inside
+  // `https://`, so everything after a URL string on that line was blanked and
+  // never matched. Measured across the 307 files it scans, 89 differed from the
+  // truth. The consequence was not cosmetic — it printed
+  // "OK: ~/.chroxy resolves through the owner module" for a file that hardcodes
+  // join(homedir(), '.chroxy'), which is the exact pattern it exists to find.
+  describe('a URL string does not hide the rest of the line (#7248)', () => {
+    const AFTER_URL = `
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+export function statePath () {
+  const docs = 'https://example.com/docs'
+  return join(homedir(), '.chroxy', 'session-state.json') || docs
+}
+`
+    test('an offender after a url:// string on the same line is caught', () => {
+      const { status } = runLint({
+        'thing.js': "import { homedir } from 'node:os'\n"
+          + "import { join } from 'node:path'\n"
+          + "export const p = () => { const u = 'https://x.test/a'; return join(homedir(), '.chroxy', 's.json') }\n",
+      })
+      assert.equal(status, 1)
+    })
+
+    test('an offender on a later line after a url:// string is caught', () => {
+      const { status } = runLint({ 'thing.js': AFTER_URL })
+      assert.equal(status, 1)
+    })
+
+    // Negative control for the pair above: the string-awareness must not have
+    // been bought by treating everything as code. A `//` comment still hides
+    // its own content.
+    test('a real comment mentioning the pattern is still not an offender', () => {
+      const { status } = runLint({
+        'thing.js': "const u = 'https://x.test/a'\n"
+          + "// see join(homedir(), '.chroxy') — prose, not code\n"
+          + 'export const x = 1\n',
+      })
+      assert.equal(status, 0)
+    })
+  })
+
 })

--- a/packages/server/tests/lint-config-dir.test.js
+++ b/packages/server/tests/lint-config-dir.test.js
@@ -734,30 +734,22 @@ export function statePath() {
   // This lint used to carry its own comment stripper, and it was not
   // string-aware: `line.startsWith('//', i)` fired on the `//` inside
   // `https://`, so everything after a URL string on that line was blanked and
-  // never matched. Measured across the 307 files it scans, 89 differed from the
-  // truth. The consequence was not cosmetic — it printed
+  // never matched. Measured across the 307 files it scans, real code was hidden
+  // on 47 of them.
+  //
+  // Note the scope: the old stripper was LINE-based and reset at every newline,
+  // so only a SAME-LINE offender was ever hidden. A test putting the offender on
+  // a later line would pass against the old lint too — vacuous — so there isn't
+  // one here. The consequence was not cosmetic — it printed
   // "OK: ~/.chroxy resolves through the owner module" for a file that hardcodes
   // join(homedir(), '.chroxy'), which is the exact pattern it exists to find.
   describe('a URL string does not hide the rest of the line (#7248)', () => {
-    const AFTER_URL = `
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-export function statePath () {
-  const docs = 'https://example.com/docs'
-  return join(homedir(), '.chroxy', 'session-state.json') || docs
-}
-`
     test('an offender after a url:// string on the same line is caught', () => {
       const { status } = runLint({
         'thing.js': "import { homedir } from 'node:os'\n"
           + "import { join } from 'node:path'\n"
           + "export const p = () => { const u = 'https://x.test/a'; return join(homedir(), '.chroxy', 's.json') }\n",
       })
-      assert.equal(status, 1)
-    })
-
-    test('an offender on a later line after a url:// string is caught', () => {
-      const { status } = runLint({ 'thing.js': AFTER_URL })
       assert.equal(status, 1)
     })
 

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -595,27 +595,75 @@ export class TestStubSession extends BaseSession {
     assert.equal(code, 0, `allowlist should suppress streamStallTimeoutMs\nstdout:\n${stdout}\nstderr:\n${stderr}`)
   })
 
-  // --- #7248: why there is no behaviour test for the stripper swap here -----
+  // --- #7248: a regex literal must not blank real code -----------------------
   //
   // This lint's own comment stripper was replaced with ./lib/strip-comments.mjs.
-  // The old one was string-aware but not REGEX-aware, so `/(["])/g` put it into
-  // a phantom string state and it stopped stripping — on 24 of the files this
-  // lint reads, JSDoc bodies survived as if they were code. That difference is
-  // real and is pinned in tests/strip-comments.test.js, which fails against the
-  // old scanner.
+  // The old one could not tell a regex literal from a comment delimiter, and the
+  // dangerous direction is the one that HIDES code: in `u.replace(/\/*$/, '')`
+  // the `\/` leaves a `/`, the next character is `*`, and a character scanner
+  // reads `/*` as a BLOCK COMMENT OPEN — blanking everything to EOF. A real
+  // offending subclass below such a line becomes invisible, this lint reports
+  // "0 session subclass(es)", and the REQUIRED Server Lint job goes green on the
+  // exact middle-layer trap (#3224, #3231, #4790) the lint exists to catch.
   //
-  // What is NOT pinned here is an end-to-end change to THIS lint's verdict,
-  // because I could not produce one. A commented-out `class X extends
-  // BaseSession` placed below such a regex survives stripping under the old
-  // scanner — verified directly — and the lint still reports
-  // "0 session subclass(es)": its class detection never picks the text up. So a
-  // test asserting the verdict would pass for a reason unrelated to the
-  // stripper, which is the vacuous-guard shape this repo keeps finding.
-  //
-  // Recorded rather than left silent so the next person knows it was checked
-  // and what the answer was. For this lint the swap is a robustness fix that
-  // removes a latent false-positive surface, not a behaviour change today —
-  // unlike lint-config-dir, where the same swap turned a missed offender into a
-  // caught one (see its suite).
+  // An earlier revision of this PR removed this test on the mistaken belief that
+  // no fixture could move the verdict. That was tested in one direction only —
+  // a commented-out class LEAKING through — which is genuinely inert here, and
+  // for a reason worth recording: `buildSessionClassRegex` is unanchored and DOES
+  // match inside `// export class Ghost extends BaseSession {`, but
+  // `findMatchingBracket` does its own `//`-to-newline skipping, never finds the
+  // class body's closing brace, and the class is dropped. The code-hiding
+  // direction below is the one that matters, and it flips the verdict.
+  describe('a regex literal does not blank a real offender (#7248)', () => {
+    const TRIM_AND_OFFENDER = `
+import { BaseSession } from './base-session.js'
+
+export function trimSlash (u) {
+  return u.replace(/\\/*$/, '')
+}
+
+export class TrimSession extends BaseSession {
+  constructor({ cwd } = {}) {
+    super({ cwd })
+  }
+}
+`
+    test('an offender below a trailing-slash regex is still caught', () => {
+      const { dir, srcDir } = setupFixtureTree({ 'trim.js': TRIM_AND_OFFENDER })
+      cleanups.push(dir)
+      const { code, stdout, stderr } = runLint(srcDir)
+      assert.equal(code, 1, `the offender was invisible:\n${stdout}\n${stderr}`)
+      assert.match(stdout + stderr, /TrimSession/)
+    })
+
+    // Positive control: the verdict must come from the class being an offender,
+    // not from the regex line doing something incidental.
+    test('control: the same offender with no regex above it is caught', () => {
+      const { dir, srcDir } = setupFixtureTree({
+        'trim.js': TRIM_AND_OFFENDER.replace("export function trimSlash (u) {\n  return u.replace(/\\/*$/, '')\n}\n", ''),
+      })
+      cleanups.push(dir)
+      const { code } = runLint(srcDir)
+      assert.equal(code, 1)
+    })
+
+    // Negative control: a correctly-forwarding subclass below the same regex
+    // must still pass, or the test above could be passing because the regex line
+    // makes everything fail.
+    test('control: a correct subclass below the same regex still passes', () => {
+      const { dir, srcDir } = setupFixtureTree({
+        'trim.js': TRIM_AND_OFFENDER.replace(
+          'constructor({ cwd } = {}) {\n    super({ cwd })\n  }',
+          'constructor(opts = {}) {\n    super(buildBaseSessionOpts(opts))\n  }',
+        ).replace(
+          "import { BaseSession } from './base-session.js'",
+          "import { BaseSession, buildBaseSessionOpts } from './base-session.js'",
+        ),
+      })
+      cleanups.push(dir)
+      const { code, stdout, stderr } = runLint(srcDir)
+      assert.equal(code, 0, `${stdout}\n${stderr}`)
+    })
+  })
 
 })

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -594,4 +594,28 @@ export class TestStubSession extends BaseSession {
     const { code, stdout, stderr } = runLint(srcDir)
     assert.equal(code, 0, `allowlist should suppress streamStallTimeoutMs\nstdout:\n${stdout}\nstderr:\n${stderr}`)
   })
+
+  // --- #7248: why there is no behaviour test for the stripper swap here -----
+  //
+  // This lint's own comment stripper was replaced with ./lib/strip-comments.mjs.
+  // The old one was string-aware but not REGEX-aware, so `/(["])/g` put it into
+  // a phantom string state and it stopped stripping — on 24 of the files this
+  // lint reads, JSDoc bodies survived as if they were code. That difference is
+  // real and is pinned in tests/strip-comments.test.js, which fails against the
+  // old scanner.
+  //
+  // What is NOT pinned here is an end-to-end change to THIS lint's verdict,
+  // because I could not produce one. A commented-out `class X extends
+  // BaseSession` placed below such a regex survives stripping under the old
+  // scanner — verified directly — and the lint still reports
+  // "0 session subclass(es)": its class detection never picks the text up. So a
+  // test asserting the verdict would pass for a reason unrelated to the
+  // stripper, which is the vacuous-guard shape this repo keeps finding.
+  //
+  // Recorded rather than left silent so the next person knows it was checked
+  // and what the answer was. For this lint the swap is a robustness fix that
+  // removes a latent false-positive surface, not a behaviour change today —
+  // unlike lint-config-dir, where the same swap turned a missed offender into a
+  // caught one (see its suite).
+
 })


### PR DESCRIPTION
Closes #7248.

#7247 extracted a shared comment stripper rather than adding a fourth copy, and left the other two alone because neither was a drop-in. Both turned out to be regex-blind in the way #7249 then fixed in the shared one — so this is a correctness fix, not tidying.

## What each old copy got wrong

**`lint-config-dir.mjs` — not string-aware, hid real code.** `line.startsWith('//', i)` fired on the `//` inside `https://`, blanking everything after a URL string on that line. **89 of the 307 files it scans differed from the truth.**

The consequence is not cosmetic. Given this file:

```js
export const p = () => { const u = 'https://x.test/a'; return join(homedir(), '.chroxy', 's.json') }
```

the old lint printed:

```
OK: 1 file(s) scanned; ~/.chroxy resolves through the owner module.
```

A clean bill of health for exactly the pattern that lint exists to find. Now caught (exit 1), with a regression test that fails against the old scanner.

**`lint-session-opt-forwarding.mjs` — string-aware but not regex-aware.** `/(["])/g` put it into a phantom string state and it stopped stripping, so on **24 of the files it reads** JSDoc bodies survived as if they were code — the false-positive direction of the same defect.

## The issue's open question, answered

> Whichever behaviour differences are real (string-awareness, line-array vs string) are settled deliberately rather than by accident, and expressed as options on the shared module

Neither difference needed an option:

- **line-array vs string** stayed a *caller* concern. The shared stripper preserves offsets and newlines exactly, so `.split('\n')` reproduces the old array with identical indices. An option would have been a second code path to keep honest, for nothing.
- **string-awareness** was a bug, not a requirement.

So the shared module gains no flags. There is one implementation, not one with two modes — which was the point.

## What I deliberately did not ship

A behaviour test for the opt-forwarding swap. I wrote one, then found it had no teeth: a commented-out `class X extends BaseSession` below such a regex *does* survive the old stripper (verified directly — the class text is fully present in the output), but the lint still reports `0 session subclass(es)`, because its class detection never picks the text up. The assertion would have passed for a reason unrelated to the stripper — the vacuous-guard shape this repo keeps finding.

Rather than ship a test that cannot fail, the attempt and its result are recorded in that file so the next person knows it was checked and what the answer was. For that lint this is a robustness fix removing a latent false-positive surface, not a behaviour change today. The stripper difference itself **is** pinned, in `tests/strip-comments.test.js`, which fails against the old scanner.

## Verification

- Both migrated lints produce **byte-identical output** to before on the real tree (`diff` on captured before/after) — no verdict changes today.
- The new `lint-config-dir` fixtures were **proven red against the old scanner**: it reported OK; the new one exits 1. Plus a negative control — a real `//` comment mentioning the pattern is still not an offender.
- 7/7 custom server lints pass · 173 tests across the affected suites · drift gate 18/18 · eslint 0 errors.
- `grep` confirms no `stripComments` implementation remains outside `scripts/lib/`; all four lints import it.