### PR TITLE
test(ci): cover compile-skill-targets.mjs's entry-point call site

### DIFF
--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -45,7 +45,11 @@ const test = async (name, fn) => {
   }
 }
 
+// Counted, so withFixture below can prove its callback actually checked
+// something rather than trusting that it was called.
+let assertions = 0
 const assert = (cond, msg) => {
+  assertions++
   if (!cond) throw new Error(msg || 'assertion failed')
 }
 
@@ -270,6 +274,7 @@ await test('detectUncompiledAgents flags an installed-but-unselected pi (~/.pi)'
 
 import { existsSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
 import { stageScript } from './lib/stage-script.mjs'
 
 const SKILL_BODY = '# Demo skill\n\nCompiles a demo skill for the entry-point fixture.\n'
@@ -285,6 +290,7 @@ const SKILL_BODY = '# Demo skill\n\nCompiles a demo skill for the entry-point fi
  */
 const withFixture = (fn) => {
   const dir = mkdtempSync(pjoin(realpathSync(tmpdir()), 'compile-skill-'))
+  const before = assertions
   try {
     const root = pjoin(dir, 'root')
     const home = pjoin(dir, 'home')
@@ -295,6 +301,22 @@ const withFixture = (fn) => {
     fn({ dir, root, home, script })
   } finally {
     rmSync(dir, { recursive: true, force: true })
+  }
+  // Proof of WORK, not proof of call. Every assertion in this section lives
+  // inside `fn`, and the harness counts a test as `ok` whenever it does not
+  // throw — so a `withFixture` that quietly failed to call `fn` would report
+  // every test here as passing having checked nothing. That is the same
+  // false-safety shape this whole section exists to catch, one level up in the
+  // scaffolding.
+  //
+  // A `ran = true` after the call does NOT close it: the obvious mutation makes
+  // the CALL conditional and still falls through to the flag, which is exactly
+  // how the first version of this line passed a mutant that skipped `fn`
+  // entirely. Counting assertions cannot be dodged that way, and it also
+  // catches the weaker case of a callback that runs but checks nothing.
+  // Unreachable when `fn` throws, since the exception propagates past it.
+  if (assertions === before) {
+    throw new Error('withFixture: the callback made no assertions — this test checked NOTHING')
   }
 }
 
@@ -310,16 +332,24 @@ const withFixture = (fn) => {
  * Determinism second: main()'s "installed but not selected" hint fires off
  * `homedir()`, so on a machine with ~/.codex present the child's stdout would
  * differ from CI's.
+ *
+ * `cwd` is pinned to the fixture for the same reason. Every call passes --repo
+ * explicitly, so it should never matter — but `repo` DEFAULTS to
+ * `process.cwd()`, and the suite is normally invoked from the repo root. If
+ * --repo handling ever regressed, an unpinned child would compile the real
+ * checkout and rewrite its committed artifacts instead of failing. Pointing it
+ * at a directory with no .claude/commands turns that regression red.
  */
-const runCompiler = (scriptPath, args, home) =>
+const runCompiler = (scriptPath, args, home, cwd) =>
   spawnSync(process.execPath, [scriptPath, ...args], {
     encoding: 'utf8',
+    cwd,
     env: { ...process.env, HOME: home, USERPROFILE: home },
   })
 
 await test('invoked directly, it compiles a real skill and writes every target artifact (#7236)', () => {
-  withFixture(({ root, home, script }) => {
-    const run = runCompiler(script, ['--repo', root, '--targets', 'claude,gemini'], home)
+  withFixture(({ dir, root, home, script }) => {
+    const run = runCompiler(script, ['--repo', root, '--targets', 'claude,gemini'], home, dir)
     assert(run.status === 0, `expected exit 0, got ${run.status}: ${run.stderr}`)
 
     const skillMd = pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')
@@ -355,6 +385,7 @@ await test('invoked through a symlinked path, it still compiles (#7198 at this c
       pjoin(link, 'scripts', 'compile-skill-targets.mjs'),
       ['--repo', root, '--targets', 'claude'],
       home,
+      dir,
     )
     assert(run.status === 0, `expected exit 0, got ${run.status}: ${run.stderr}`)
     assert(
@@ -365,10 +396,10 @@ await test('invoked through a symlinked path, it still compiles (#7198 at this c
 })
 
 await test('--dry-run emits nothing, and the identical run without it does (#7236)', () => {
-  withFixture(({ root, home, script }) => {
+  withFixture(({ dir, root, home, script }) => {
     const skillMd = pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')
 
-    const dry = runCompiler(script, ['--repo', root, '--targets', 'claude', '--dry-run'], home)
+    const dry = runCompiler(script, ['--repo', root, '--targets', 'claude', '--dry-run'], home, dir)
     assert(dry.status === 0, `--dry-run should exit 0, got ${dry.status}: ${dry.stderr}`)
     assert(!existsSync(skillMd), '--dry-run wrote an artifact')
 
@@ -376,7 +407,7 @@ await test('--dry-run emits nothing, and the identical run without it does (#723
     // file" is equally what a guard that never fired produces, so the assertion
     // above proves nothing on its own. Same fixture, same flags minus
     // --dry-run, must now write.
-    const wet = runCompiler(script, ['--repo', root, '--targets', 'claude'], home)
+    const wet = runCompiler(script, ['--repo', root, '--targets', 'claude'], home, dir)
     assert(wet.status === 0, `expected exit 0, got ${wet.status}: ${wet.stderr}`)
     assert(existsSync(skillMd), 'the control run emitted nothing either — the no-op above was vacuous')
   })
@@ -386,7 +417,7 @@ await test('exits 1 with a diagnostic when the repo has no .claude/commands (#72
   withFixture(({ dir, home, script }) => {
     const empty = pjoin(dir, 'empty')
     mkdirSync(empty, { recursive: true })
-    const run = runCompiler(script, ['--repo', empty, '--targets', 'claude'], home)
+    const run = runCompiler(script, ['--repo', empty, '--targets', 'claude'], home, dir)
     // A detector for the same mutation that does not depend on a file: with the
     // entry-point guard hardwired false, main() never runs, so the process exits
     // 0 with an empty stderr where it owes a 1 and a reason.
@@ -394,6 +425,38 @@ await test('exits 1 with a diagnostic when the repo has no .claude/commands (#72
     assert(
       /No \.claude\/commands/.test(run.stderr),
       `exit 1 came from something other than the missing-commands check:\n${JSON.stringify(run.stderr)}`,
+    )
+  })
+})
+
+await test('importing the module does NOT run its CLI (the other direction, #7236)', () => {
+  withFixture(({ root, home, script }) => {
+    // Everything above faces one way: a guard stuck FALSE compiles nothing.
+    // Stuck TRUE is the other failure, and it is invisible from that side -
+    // hardwiring the guard to `true` leaves all of the above at 22/22 green,
+    // because main() then runs during THIS FILE's own `await import(...)` at
+    // the top, quietly compiling whatever repo the suite was invoked from and
+    // rewriting its committed artifacts. Testing only the direction the bug
+    // arrived from is how #7250's stripper shipped a worse hole than the one
+    // it fixed, so this faces the other way.
+    //
+    // `-e` leaves argv[1] undefined, which is a legitimate "there is no invoked
+    // script" case the guard must answer false for; the fixture root supplies a
+    // real .claude/commands, so a guard that answered true would have something
+    // to compile and would visibly do it.
+    const run = spawnSync(
+      process.execPath,
+      ['--input-type=module', '-e', `await import(${JSON.stringify(pathToFileURL(script).href)})`],
+      { encoding: 'utf8', cwd: root, env: { ...process.env, HOME: home, USERPROFILE: home } },
+    )
+    assert(run.status === 0, `importing the module should exit 0, got ${run.status}: ${run.stderr}`)
+    assert(
+      !/Compiling/.test(run.stdout),
+      `main() ran on import - the guard reads true when it is not the entry point:\n${run.stdout}`,
+    )
+    assert(
+      !existsSync(pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')),
+      'importing the module compiled a skill - any test that imports it would rewrite the real repo',
     )
   })
 })

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 /**
- * compile-skill-targets.test.mjs — node test harness for deriveDescription()
- * in scripts/compile-skill-targets.mjs.
+ * compile-skill-targets.test.mjs — node test harness for
+ * scripts/compile-skill-targets.mjs.
+ *
+ * Two layers, and both are needed. The unit tests import the module and call
+ * its exported pieces (deriveDescription, detectUncompiledAgents, emitPi). The
+ * subprocess tests at the bottom run the script for real and assert on what it
+ * WROTE, because importing a module proves nothing about whether its CLI still
+ * runs — #7236, where hardwiring the entry-point guard to false left this file
+ * fully green while the script compiled nothing.
  *
  * No external test framework. Each `test()` block runs in series and pushes
  * pass/fail into a counter. Exit status is 0 if all pass, 1 otherwise.
@@ -245,6 +252,150 @@ await test('detectUncompiledAgents flags an installed-but-unselected pi (~/.pi)'
   } finally {
     rmSync(home, { recursive: true, force: true })
   }
+})
+
+// --- entry-point call site (#7236) -----------------------------------------
+//
+// Every test above IMPORTS this module and calls an exported function, which
+// says nothing about whether `node scripts/compile-skill-targets.mjs` still
+// compiles anything. Hardwiring the module's `if (isEntryPoint(import.meta.url))`
+// to `false` left this file at 18/18 green: the script would exit 0 having
+// emitted nothing — the same silent no-op class as #7198/#7214, and the reason
+// that bug survived in four files at once. The failure is SILENCE, not a crash.
+//
+// So the tests below run the script for real, out of a temp fixture, and assert
+// on the ARTIFACT it wrote. Exit status alone cannot tell "compiled everything"
+// from "never ran": both are 0. The sibling coverage for the other consumer of
+// the shared guard is in gen-agents-md.test.mjs.
+
+import { existsSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { stageScript } from './lib/stage-script.mjs'
+
+const SKILL_BODY = '# Demo skill\n\nCompiles a demo skill for the entry-point fixture.\n'
+
+/**
+ * A fixture repo holding the staged compiler plus one source skill.
+ *
+ * The tmpdir is realpath'd first. On macOS `os.tmpdir()` is /var/folders/…, a
+ * symlink to /private/var/…, so a fixture built on the raw path would put every
+ * run through a symlinked prefix — the direct-invocation test would silently
+ * become a second copy of the symlink test, and only on macOS. Canonicalising
+ * here means the only symlink in play is the one a test creates on purpose.
+ */
+const withFixture = (fn) => {
+  const dir = mkdtempSync(pjoin(realpathSync(tmpdir()), 'compile-skill-'))
+  try {
+    const root = pjoin(dir, 'root')
+    const home = pjoin(dir, 'home')
+    mkdirSync(home, { recursive: true })
+    const script = stageScript(helperPath, pjoin(root, 'scripts'))
+    mkdirSync(pjoin(root, '.claude', 'commands'), { recursive: true })
+    writeFileSync(pjoin(root, '.claude', 'commands', 'demo.md'), SKILL_BODY)
+    fn({ dir, root, home, script })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Run the staged compiler with a throwaway HOME.
+ *
+ * Safety first: the `codex` and `pi` emitters write into ~/.codex and ~/.pi, so
+ * a fixture that ever reached them would write to the developer's real home.
+ * That is also why every run below passes --targets explicitly instead of
+ * trusting the profile fallback — the fallback is `['claude']` today, and a
+ * test should not be the thing that notices if that changes.
+ *
+ * Determinism second: main()'s "installed but not selected" hint fires off
+ * `homedir()`, so on a machine with ~/.codex present the child's stdout would
+ * differ from CI's.
+ */
+const runCompiler = (scriptPath, args, home) =>
+  spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  })
+
+await test('invoked directly, it compiles a real skill and writes every target artifact (#7236)', () => {
+  withFixture(({ root, home, script }) => {
+    const run = runCompiler(script, ['--repo', root, '--targets', 'claude,gemini'], home)
+    assert(run.status === 0, `expected exit 0, got ${run.status}: ${run.stderr}`)
+
+    const skillMd = pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')
+    assert(
+      existsSync(skillMd),
+      'the compiler exited 0 having emitted NOTHING — the entry-point guard read false ' +
+      `and main() never ran (#7198/#7236). stdout: ${JSON.stringify(run.stdout)}`,
+    )
+    const emitted = readFileSync(skillMd, 'utf8')
+    assert(emitted.startsWith('---\ndescription: "'), `missing description frontmatter:\n${emitted}`)
+    assert(emitted.includes(SKILL_BODY.trimEnd()), `the source body must pass through verbatim:\n${emitted}`)
+
+    // A second target, so the assertion covers the emitter LOOP rather than one
+    // lucky write: a main() that emitted only its first target would pass above.
+    const geminiToml = pjoin(root, '.gemini', 'commands', 'demo.toml')
+    assert(existsSync(geminiToml), 'the second target was not emitted — the emitter loop stopped after one')
+    assert(
+      readFileSync(geminiToml, 'utf8').includes('# Demo skill'),
+      'the gemini artifact must carry the skill body',
+    )
+  })
+})
+
+await test('invoked through a symlinked path, it still compiles (#7198 at this call site)', () => {
+  withFixture(({ dir, root, home }) => {
+    const link = pjoin(dir, 'link')
+    symlinkSync(root, link)
+    // Through the symlink, node realpaths `import.meta.url` to …/root/… while
+    // `process.argv[1]` stays …/link/… as typed. Comparing those two directly —
+    // which is what this script did before #7213 — reads false, so main() never
+    // runs and the process exits 0 having compiled nothing.
+    const run = runCompiler(
+      pjoin(link, 'scripts', 'compile-skill-targets.mjs'),
+      ['--repo', root, '--targets', 'claude'],
+      home,
+    )
+    assert(run.status === 0, `expected exit 0, got ${run.status}: ${run.stderr}`)
+    assert(
+      existsSync(pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')),
+      'compiled nothing through a symlinked invocation path — the #7198 silent no-op',
+    )
+  })
+})
+
+await test('--dry-run emits nothing, and the identical run without it does (#7236)', () => {
+  withFixture(({ root, home, script }) => {
+    const skillMd = pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')
+
+    const dry = runCompiler(script, ['--repo', root, '--targets', 'claude', '--dry-run'], home)
+    assert(dry.status === 0, `--dry-run should exit 0, got ${dry.status}: ${dry.stderr}`)
+    assert(!existsSync(skillMd), '--dry-run wrote an artifact')
+
+    // The positive control, and the reason this is one test and not two: "no
+    // file" is equally what a guard that never fired produces, so the assertion
+    // above proves nothing on its own. Same fixture, same flags minus
+    // --dry-run, must now write.
+    const wet = runCompiler(script, ['--repo', root, '--targets', 'claude'], home)
+    assert(wet.status === 0, `expected exit 0, got ${wet.status}: ${wet.stderr}`)
+    assert(existsSync(skillMd), 'the control run emitted nothing either — the no-op above was vacuous')
+  })
+})
+
+await test('exits 1 with a diagnostic when the repo has no .claude/commands (#7236)', () => {
+  withFixture(({ dir, home, script }) => {
+    const empty = pjoin(dir, 'empty')
+    mkdirSync(empty, { recursive: true })
+    const run = runCompiler(script, ['--repo', empty, '--targets', 'claude'], home)
+    // A detector for the same mutation that does not depend on a file: with the
+    // entry-point guard hardwired false, main() never runs, so the process exits
+    // 0 with an empty stderr where it owes a 1 and a reason.
+    assert(run.status === 1, `expected exit 1, got ${run.status} (0 = main() never ran)`)
+    assert(
+      /No \.claude\/commands/.test(run.stderr),
+      `exit 1 came from something other than the missing-commands check:\n${JSON.stringify(run.stderr)}`,
+    )
+  })
 })
 
 // --- summary --------------------------------------------------------------

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -275,9 +275,17 @@ await test('detectUncompiledAgents flags an installed-but-unselected pi (~/.pi)'
 import { existsSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
-import { stageScript } from './lib/stage-script.mjs'
+import { stageScript } from './helpers/stage-script.mjs'
 
-const SKILL_BODY = '# Demo skill\n\nCompiles a demo skill for the entry-point fixture.\n'
+// Carries a registry stamp and an arg token on purpose. A bare heading plus one
+// sentence exercises none of the emitter transformations, and `stripStamp`,
+// `emitClaude` and `emitGemini` are NOT exported — these subprocess tests are
+// their only coverage anywhere in the repo, so the fixture has to be rich enough
+// to catch a mutation in them. 28 of the 31 real sources in .claude/commands/
+// carry a stamp, so a stripStamp regression would ship install metadata as skill
+// content in almost every artifact.
+const SKILL_STAMP = '<!-- skill-templates: demo@1.2.3 -->'
+const SKILL_BODY = `${SKILL_STAMP}\n# Demo skill\n\nCompiles a demo skill for the entry-point fixture. Takes $ARGUMENTS.\n`
 
 /**
  * A fixture repo holding the staged compiler plus one source skill.
@@ -298,7 +306,19 @@ const withFixture = (fn) => {
     const script = stageScript(helperPath, pjoin(root, 'scripts'))
     mkdirSync(pjoin(root, '.claude', 'commands'), { recursive: true })
     writeFileSync(pjoin(root, '.claude', 'commands', 'demo.md'), SKILL_BODY)
-    fn({ dir, root, home, script })
+    const returned = fn({ dir, root, home, script })
+    // Sync-only, and said out loud. An async callback returns a pending promise
+    // that nothing awaits: the `finally` below removes the fixture out from
+    // under it, everything after the first `await` runs against a deleted tree,
+    // and the assertion counter is already satisfied by the synchronous prefix —
+    // so the test reports `ok` having skipped the rest of its body. Verified:
+    // making the --dry-run callback async and awaiting once before its positive
+    // control left the suite 23/23 green with the control never executed. The
+    // 18 unit tests above all use async callbacks that the harness awaits, so
+    // async is this file's ambient habit and only these callbacks are not.
+    if (returned && typeof returned.then === 'function') {
+      throw new Error('withFixture: the callback must be synchronous — the fixture is removed before an async body finishes')
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -359,16 +379,32 @@ await test('invoked directly, it compiles a real skill and writes every target a
       `and main() never ran (#7198/#7236). stdout: ${JSON.stringify(run.stdout)}`,
     )
     const emitted = readFileSync(skillMd, 'utf8')
-    assert(emitted.startsWith('---\ndescription: "'), `missing description frontmatter:\n${emitted}`)
-    assert(emitted.includes(SKILL_BODY.trimEnd()), `the source body must pass through verbatim:\n${emitted}`)
+    // Pin the WHOLE frontmatter block, not just its opening. A `startsWith`
+    // check still passes on output whose closing `---` was dropped, which
+    // Claude cannot parse; this also pins that the description is non-empty and
+    // really derived rather than defaulted.
+    assert(
+      /^---\ndescription: "[^\n]+"\n---\n\n/.test(emitted),
+      `frontmatter is not a complete, non-empty block:\n${emitted}`,
+    )
+    assert(emitted.includes('# Demo skill'), `the source body must pass through:\n${emitted}`)
+    assert(
+      !emitted.includes('skill-templates:'),
+      `the registry stamp is install metadata, not skill content — stripStamp did not run:\n${emitted}`,
+    )
 
     // A second target, so the assertion covers the emitter LOOP rather than one
     // lucky write: a main() that emitted only its first target would pass above.
     const geminiToml = pjoin(root, '.gemini', 'commands', 'demo.toml')
     assert(existsSync(geminiToml), 'the second target was not emitted — the emitter loop stopped after one')
+    const gemini = readFileSync(geminiToml, 'utf8')
+    assert(gemini.includes('# Demo skill'), `the gemini artifact must carry the skill body:\n${gemini}`)
+    // $ARGUMENTS is the neutral arg token; Gemini's is {{args}}. Without this,
+    // deleting the substitution silently strips argument passing from every
+    // compiled Gemini command and nothing notices.
     assert(
-      readFileSync(geminiToml, 'utf8').includes('# Demo skill'),
-      'the gemini artifact must carry the skill body',
+      gemini.includes('{{args}}') && !gemini.includes('$ARGUMENTS'),
+      `gemini must rewrite $ARGUMENTS to {{args}}:\n${gemini}`,
     )
   })
 })
@@ -432,31 +468,37 @@ await test('exits 1 with a diagnostic when the repo has no .claude/commands (#72
 await test('importing the module does NOT run its CLI (the other direction, #7236)', () => {
   withFixture(({ root, home, script }) => {
     // Everything above faces one way: a guard stuck FALSE compiles nothing.
-    // Stuck TRUE is the other failure, and it is invisible from that side -
-    // hardwiring the guard to `true` leaves all of the above at 22/22 green,
-    // because main() then runs during THIS FILE's own `await import(...)` at
-    // the top, quietly compiling whatever repo the suite was invoked from and
-    // rewriting its committed artifacts. Testing only the direction the bug
-    // arrived from is how #7250's stripper shipped a worse hole than the one
-    // it fixed, so this faces the other way.
+    // Stuck TRUE is the other failure, and it is invisible from that side —
+    // hardwiring the guard to `true` leaves all of the above green, because
+    // main() then runs during THIS FILE's own `await import(...)` at the top,
+    // compiling whatever repo the suite was invoked from and rewriting its
+    // committed artifacts. Testing only the direction the bug arrived from is
+    // how #7250 shipped a worse hole than the one it fixed, so this faces the
+    // other way.
     //
-    // `-e` leaves argv[1] undefined, which is a legitimate "there is no invoked
-    // script" case the guard must answer false for; the fixture root supplies a
-    // real .claude/commands, so a guard that answered true would have something
-    // to compile and would visibly do it.
-    const run = spawnSync(
-      process.execPath,
-      ['--input-type=module', '-e', `await import(${JSON.stringify(pathToFileURL(script).href)})`],
-      { encoding: 'utf8', cwd: root, env: { ...process.env, HOME: home, USERPROFILE: home } },
-    )
+    // The importer is a STAGED FILE, not `node -e`. Under `-e` there is no
+    // argv[1], so isEntryPoint returns at its first line and never reaches the
+    // path comparison — the test would pass without exercising the branch that
+    // actually decides this. Verified: inverting `self === invoked` to `!==` in
+    // the guard left an `-e` version of this test at 23/23 green while the
+    // suite's own import wrote 12 files into the invoking checkout. A real
+    // argv[1] that is a DIFFERENT existing file is the configuration this suite
+    // genuinely imports under when CI runs it.
+    const importer = pjoin(root, 'importer.mjs')
+    writeFileSync(importer, `await import(${JSON.stringify(pathToFileURL(script).href)})\n`)
+    const run = spawnSync(process.execPath, [importer], {
+      encoding: 'utf8',
+      cwd: root,
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+    })
     assert(run.status === 0, `importing the module should exit 0, got ${run.status}: ${run.stderr}`)
     assert(
       !/Compiling/.test(run.stdout),
-      `main() ran on import - the guard reads true when it is not the entry point:\n${run.stdout}`,
+      `main() ran on import — the guard reads true when it is not the entry point:\n${run.stdout}`,
     )
     assert(
       !existsSync(pjoin(root, '.claude', 'skills', 'demo', 'SKILL.md')),
-      'importing the module compiled a skill - any test that imports it would rewrite the real repo',
+      'importing the module compiled a skill — any test that imports it would rewrite the real repo',
     )
   })
 })

--- a/scripts/__tests__/gen-agents-md.test.mjs
+++ b/scripts/__tests__/gen-agents-md.test.mjs
@@ -12,30 +12,25 @@
  */
 
 import { dirname, join, resolve } from 'node:path'
-import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, cpSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
+import { stageScript } from './lib/stage-script.mjs'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const scriptPath = resolve(__dirname, '..', 'gen-agents-md.mjs')
-const libDir = resolve(__dirname, '..', 'lib')
 
 const { renderAgentsMd, readClaudeMd, readAgentsMd } = await import(scriptPath)
 
 // The subprocess fixtures below run the generator out of a temp tree, so they
-// have to stage everything it imports, not just the file itself. Copying the
-// whole scripts/lib directory rather than naming is-entry-point.mjs means the
-// next sibling helper is staged automatically — when the entry-point guard was
-// extracted there (#7222), a fixture that copied only gen-agents-md.mjs failed
-// with ERR_MODULE_NOT_FOUND, and a fixture that hardcodes one filename would
-// fail the same way on the next extraction.
-const stageGenerator = (scriptsDir) => {
-  mkdirSync(scriptsDir, { recursive: true })
-  cpSync(scriptPath, join(scriptsDir, 'gen-agents-md.mjs'))
-  cpSync(libDir, join(scriptsDir, 'lib'), { recursive: true })
-}
+// have to stage everything it imports, not just the file itself. stageScript
+// copies the whole sibling scripts/lib directory — see its header for why
+// naming individual helpers breaks on the next extraction. It is shared with
+// compile-skill-targets.test.mjs, which needed the identical staging (#7236).
+const stageGenerator = (scriptsDir) => stageScript(scriptPath, scriptsDir)
 
 let pass = 0
 let fail = 0

--- a/scripts/__tests__/gen-agents-md.test.mjs
+++ b/scripts/__tests__/gen-agents-md.test.mjs
@@ -17,7 +17,7 @@ import { tmpdir } from 'node:os'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { stageScript } from './lib/stage-script.mjs'
+import { stageScript } from './helpers/stage-script.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/scripts/__tests__/helpers/stage-script.mjs
+++ b/scripts/__tests__/helpers/stage-script.mjs
@@ -9,10 +9,18 @@
 // single filename would die the same way on the next helper to be extracted.
 // Copying the whole directory stages the next sibling automatically.
 //
-// This is the ONE implementation. gen-agents-md.test.mjs grew it first and
-// compile-skill-targets.test.mjs needed the identical thing (#7236); a second
-// hand-maintained copy of it is the shape #7213/#7222 were filed to remove,
-// recreated one directory down.
+// This is the one implementation FOR THE .mjs TEST FILES. gen-agents-md.test.mjs
+// grew it first and compile-skill-targets.test.mjs needed the identical thing
+// (#7236); a second hand-maintained copy of it is the shape #7213/#7222 were
+// filed to remove, recreated one directory down.
+//
+// It is deliberately not the only one in this directory: bump-version.test.sh's
+// `install_agents_generator()` stages the same script from shell and cannot
+// import this module. That copy also DISAGREES about the missing-lib case — it
+// skips the copy when scripts/lib is absent, where this one refuses — which is
+// the "'cannot check this' treated as 'nothing to check'" shape from
+// docs/false-safety-guards.md. Reconciling them is tracked separately rather
+// than smuggled into a test-coverage change.
 
 import { cpSync, existsSync, mkdirSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'

--- a/scripts/__tests__/lib/stage-script.mjs
+++ b/scripts/__tests__/lib/stage-script.mjs
@@ -1,0 +1,47 @@
+// stage-script.mjs — copy a repo script into a temp fixture along with the
+// sibling `lib/` directory it imports from.
+//
+// Subprocess tests run a script out of a temp tree, so they have to stage
+// everything it imports, not just the file itself. Naming the individual
+// helpers would break on the next extraction: when the entry-point guard moved
+// to scripts/lib/is-entry-point.mjs (#7222), a fixture that copied only
+// gen-agents-md.mjs died with ERR_MODULE_NOT_FOUND, and one that hardcoded that
+// single filename would die the same way on the next helper to be extracted.
+// Copying the whole directory stages the next sibling automatically.
+//
+// This is the ONE implementation. gen-agents-md.test.mjs grew it first and
+// compile-skill-targets.test.mjs needed the identical thing (#7236); a second
+// hand-maintained copy of it is the shape #7213/#7222 were filed to remove,
+// recreated one directory down.
+
+import { cpSync, existsSync, mkdirSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+
+/**
+ * Stage `scriptPath` and its sibling `lib/` into `destScriptsDir`.
+ *
+ * A missing sibling `lib/` throws rather than staging less than asked. Both
+ * current callers import from it, so its absence means either the wrong path
+ * was passed or the helpers moved — and the alternative is a child process
+ * dying with an ERR_MODULE_NOT_FOUND that names a temp path and not the cause.
+ * "Could not stage it" is not the same as "there was nothing to stage".
+ *
+ * @param {string} scriptPath - absolute path to the script under test
+ * @param {string} destScriptsDir - fixture directory to stage into
+ * @returns {string} the staged script's path
+ */
+export function stageScript(scriptPath, destScriptsDir) {
+  const libDir = join(dirname(scriptPath), 'lib')
+  if (!existsSync(libDir)) {
+    throw new Error(
+      `stageScript: no lib/ beside ${scriptPath} — the fixture would be staged ` +
+      'without the helpers the script imports, and the child would fail with a ' +
+      'bare ERR_MODULE_NOT_FOUND naming a temp path.',
+    )
+  }
+  mkdirSync(destScriptsDir, { recursive: true })
+  const staged = join(destScriptsDir, basename(scriptPath))
+  cpSync(scriptPath, staged)
+  cpSync(libDir, join(destScriptsDir, 'lib'), { recursive: true })
+  return staged
+}

--- a/scripts/__tests__/lib/stage-script.mjs
+++ b/scripts/__tests__/lib/stage-script.mjs
@@ -31,6 +31,12 @@ import { basename, dirname, join } from 'node:path'
  * @returns {string} the staged script's path
  */
 export function stageScript(scriptPath, destScriptsDir) {
+  // mkdir FIRST, before anything that can throw. Callers wrap this in a
+  // try/finally that chmods and removes the fixture dir, so throwing before the
+  // directory exists makes their `chmodSync(scriptsDir)` fail with ENOENT — which
+  // masks the diagnostic below AND skips the rmSync, leaking the temp tree. The
+  // check reads more naturally above this line and is deliberately not there.
+  mkdirSync(destScriptsDir, { recursive: true })
   const libDir = join(dirname(scriptPath), 'lib')
   if (!existsSync(libDir)) {
     throw new Error(
@@ -39,7 +45,6 @@ export function stageScript(scriptPath, destScriptsDir) {
       'bare ERR_MODULE_NOT_FOUND naming a temp path.',
     )
   }
-  mkdirSync(destScriptsDir, { recursive: true })
   const staged = join(destScriptsDir, basename(scriptPath))
   cpSync(scriptPath, staged)
   cpSync(libDir, join(destScriptsDir, 'lib'), { recursive: true })


### PR DESCRIPTION
## Problem

Every test in `scripts/__tests__/compile-skill-targets.test.mjs` imported the module and
called an exported function. That says nothing about whether `node
scripts/compile-skill-targets.mjs` still compiles anything.

Hardwiring the script's `if (isEntryPoint(import.meta.url))` to `false` left the file at
**18/18 green** while the script compiled nothing and exited 0 — the same silent no-op
class as #7198/#7214, on the other consumer of the shared guard. `gen-agents-md.mjs`'s
equivalent call site was already covered; this one was the asymmetry #7232 made visible.

## What changed

Four subprocess tests that run the script for real out of a temp fixture and assert on the
**artifact it wrote**. Exit status alone cannot tell "compiled everything" from "never
ran" — both are 0.

| test | what it pins |
|---|---|
| direct invocation | every selected target's artifact is written, so the emitter **loop** is covered, not one lucky write |
| symlinked invocation path | #7198's actual shape at this call site |
| `--dry-run` writes nothing | with the identical run **without** it as an inline positive control |
| no `.claude/commands` → exit 1 | a detector for the same mutation that does not depend on a file |

Staging is extracted to `scripts/__tests__/lib/stage-script.mjs` and shared with
`gen-agents-md.test.mjs`, which grew it first. A second hand-maintained copy is the shape
#7213/#7222 were filed to remove, recreated one directory down.

## Proof it goes red

Restores were `cp` from an absolute-path backup (never `git checkout --`), and every
mutant was grepped for after application to prove it landed — a find/replace that matches
nothing exits 0 and the test then "passes" against a mutant that never existed.

| mutation | new suite | which test caught it |
|---|---|---|
| **A** — guard → `if (false)` (the acceptance criterion) | **exit 1**, 18 passed / 4 failed | all four |
| **A** against the *pre-change* test file | exit 0, **18/18 green** | none — the issue reproduced exactly |
| **B** — `for (const t of targets)` → `targets.slice(0, 1)` | exit 1, 21/1 | direct-invocation (second target absent) |
| **C** — guard reverted to the naive pre-#7213 comparison | exit 1, 21/1 | **symlink only** — proving it is not a duplicate of the direct-run test |
| **D** — `if (!dryRun)` → `if (true)` | exit 1, 21/1 | dry-run |

Each mutation is caught by exactly its intended assertion, and mutation A's failure
messages name the real failure mode rather than a bare boolean.

## Controls validated, not just asserted

- **The injected `HOME` really reaches `homedir()`.** Differential probe: a temp home
  *with* `.codex` produced the "installed but not selected" hint, one *without* did not.
  So the child cannot see the developer's real home. The real `~/.codex/prompts` was
  confirmed untouched.
- **`stageScript` throws** when the sibling `lib/` is absent, rather than silently staging
  an incomplete fixture — verified by calling it with a lone script.
- **The fixture tmpdir is realpath'd.** On macOS `os.tmpdir()` is a symlink, so a fixture
  on the raw path would put every run through a symlinked prefix and quietly turn the
  direct-invocation test into a second copy of the symlink test, on macOS only.

## Safety

Every run passes `--targets` explicitly rather than trusting the profile fallback, and the
child gets a throwaway `HOME`. The `codex` and `pi` emitters write into `~/.codex` and
`~/.pi`, so a fixture that ever reached them would write to the developer's real home.

## Verification

- `compile-skill-targets.test.mjs` 22/22 (was 18/18), Node 22 and Node 26
- `gen-agents-md` 8/8, `is-entry-point` 18/18 (incl. the three-copy drift gate),
  `flush-and-exit` 5/5, `check-release-pr-subject` exit 0 — all on Node 22

Closes #7236