### PR TITLE
feat(ci): gate the compiled skill artifacts against their sources

### DIFF
--- a/.claude/commands/skill.md
+++ b/.claude/commands/skill.md
@@ -40,10 +40,11 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`,
-  `pi` → `~/.pi/agent/skills/<name>/SKILL.md`. The first three are repo-tracked; **`pi` is the one
-  user-global target** — Pi has no repo-local discovery, so its artifact lands in the user's home
-  dir and is opt-in rather than a safe default. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`,
+  `pi` → `~/.pi/agent/skills/<name>/SKILL.md`. The first TWO are repo-tracked; **`codex` and `pi`
+  are both user-global** — neither has a repo-local discovery path, so their artifacts land in the
+  user's home dir and both are opt-in rather than safe defaults. Only the repo-tracked pair is
+  gated by `compile-skill-targets.mjs --check` (#7253); a home dir is not part of any commit. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -228,11 +229,11 @@ note in the report that hashes may be stale. Record which source you used.
    offer to record the choice in the profile (the compiler falls back to `claude` if unset). Then
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
-   any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
-   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
-   `~/.codex/skills`, or used by runners that support repo-local Codex skills. **`pi` writes outside
-   the repo** (`~/.pi/agent/skills/`), so only add it when the user actually drives this repo with
-   Pi — never volunteer it into a committed `targets:` line on their behalf. The compiler prints a
+   any emit failure — treat that as a hard gate: fix and re-run before locking. **`codex` and `pi`
+   both write OUTSIDE the repo** (`~/.codex/prompts/<name>.md`, invoked `/prompts:<name>`; and
+   `~/.pi/agent/skills/`), so add either only when the user actually drives this repo with that
+   agent — never volunteer one into a committed `targets:` line on their behalf, and never expect
+   their output in a diff. The compiler prints a
    hint if it sees `~/.pi` on the machine but `pi` is unselected; that hint is advisory and never
    adds the target itself. Keep the list of `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
@@ -279,11 +280,12 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `.codex/skills/<name>/` (dir), `pi` → `~/.pi/agent/skills/<name>/` (dir, **outside the
-repo** — remove it only when `pi` is in the lock entry's `targets`, and say so in the report since
-the user may not expect a repo command to touch their home dir). If the lock entry has no `targets`
-(an older install), fall back to removing whichever of the three **repo-local** artifacts exist —
-never probe `~/.pi` on a guess, because an unrelated Pi skill of the same name could live there.
+`codex` → `~/.codex/prompts/<name>.md` (file), `pi` → `~/.pi/agent/skills/<name>/` (dir). The last
+two are **outside the repo** — remove either only when it is in the lock entry's `targets`, and say
+so in the report, since the user may not expect a repo command to touch their home dir. If the lock
+entry has no `targets` (an older install), fall back to removing whichever of the two **repo-local**
+artifacts exist — never probe `~/.codex` or `~/.pi` on a guess, because an unrelated skill of the
+same name could live there.
 Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -32,8 +32,9 @@ The neutral arg token is `$ARGUMENTS`; emitters map it per agent. Two Gemini cav
 compiler handles automatically: positional `$1`/`$2` have no Gemini equivalent (it warns),
 and a body containing active template sequences (`{{…}}`, `!{…}`, `@{…}` — e.g. an HTML
 template's `{{TITLE}}` or `{{CUSTOMIZE}}` docs) is **skipped** for Gemini rather than emitted
-corrupt (currently: visual-brief, decompose-issue, create-issue, skill — Claude/Codex still
-get them). After editing a skill's generic source by hand, recompile:
+corrupt (Claude/Codex still get them). The compiler logs which skills those are on every run,
+and `--check` reports the count — this used to name them inline and had already gone stale by
+one, which is why it no longer does. After editing a skill's generic source by hand, recompile:
 `node scripts/compile-skill-targets.mjs --name <name>`.
 
 ## Cost Circuit Breaker (marathon skills: prime-directive, tackle-issues, autonomous-dev-flow)

--- a/.claude/skills/agent-review/SKILL.md
+++ b/.claude/skills/agent-review/SKILL.md
@@ -66,6 +66,8 @@ The agent reviews against these standards:
 
 ### 3. Generate Review
 
+**Deciding vs escalating.** A finding is not automatically a question for the user. If the code, the git history, the issue thread or the docs answer it, answer it in the review; if the call is cheap and reversible, state it, note the assumption, and move on. Escalate to the user only when the answers lead to materially different work, or the action is irreversible or outward-facing — and when you do, escalate through `/decide` (the `AskUserQuestion` tool, 2-4 concrete options, your recommendation first with its costs named), never as prose buried in the review body. Keep reviewing the rest of the diff while the question is open.
+
 Create a comprehensive review:
 
 ```markdown

--- a/.claude/skills/batch-merge/SKILL.md
+++ b/.claude/skills/batch-merge/SKILL.md
@@ -56,8 +56,12 @@ gh pr checks ${PR_NUM} --json name,state \
   --jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length'
 
 # Copilot review presence
+# DISMISSED is excluded on purpose: after `dismiss_stale_reviews` fires, a
+# superseded review is still returned by this endpoint, so counting it reports
+# the gate as satisfied by a review of code that no longer exists.
 gh api repos/${REPO}/pulls/${PR_NUM}/reviews \
-  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length'
+  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")
+             | select(.state != "DISMISSED")] | length'
 ```
 
 Update the progress table with pre-flight results. This is informational — does not block the loop.
@@ -84,7 +88,8 @@ All required checks must be `SUCCESS` or `SKIPPED`. If any are failing or pendin
 
 ```bash
 COPILOT_STATUS=$(gh api repos/${REPO}/pulls/${PR_NUM}/reviews \
-  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] |
+  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")
+             | select(.state != "DISMISSED")] |
     if length == 0 then "NOT_FOUND"
     elif any(.[]; .state == "PENDING") then "IN_PROGRESS"
     else "COMPLETED" end')
@@ -96,6 +101,14 @@ Copilot review **must be present** before merge. This is the quality gate.
 - **IN_PROGRESS:** Poll every 30s, max 5 min.
 - **NOT_FOUND + PR < 8 min old:** Poll every 30s, max 8 min. Copilot takes 3-5 min to start.
 - **NOT_FOUND + PR >= 8 min old:** Proceed with warning (Copilot won't come for old PRs).
+
+Compute the age rather than estimating it — the branch above is only reproducible
+if both operators derive it the same way:
+
+```bash
+PR_AGE_MIN=$(gh pr view ${PR_NUM} --json createdAt \
+  --jq '((now - (.createdAt | fromdateiso8601)) / 60) | floor')
+```
 
 #### Step 2c: Address Unaddressed Copilot Comments
 

--- a/.claude/skills/catchup/SKILL.md
+++ b/.claude/skills/catchup/SKILL.md
@@ -1,0 +1,177 @@
+---
+description: "Answer **\"where did we leave off?\"** — a fast, read-only recap of a project's recent activity and current open state."
+---
+
+# /catchup
+
+Answer **"where did we leave off?"** — a fast, read-only recap of a project's recent activity and current open state. Pulls recent commits, CI/deploy health, open PRs (with mergeability), open issues, local git state, and session memory into one scannable summary, ending with a single suggested next step.
+
+Use this at the **start of a session** to re-orient. It is the recap layer: `/recon` explains *what a repo is*, `/start-working` decides *what to do next*, and `/catchup` reports *what just happened and what's open right now*. It never edits, commits, or merges.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional configuration. Space-separated tokens:
+  - First positional: repo slug override (`owner/name`). Defaults to the `origin` remote, then a configured fallback, then inference from the directory name.
+  - `scope=all|issues|prs|recent` — Which sections to include (default: `all`).
+  - `since=N` — Lookback window in days for commits and CI runs (default: 7).
+  - `limit=N` — Max rows per list (default: 20).
+
+Examples:
+```
+/catchup
+/catchup scope=prs
+/catchup owner/repo since=3
+/catchup scope=issues limit=40
+```
+
+## Instructions
+
+### 0. Resolve Target and Mode (gate)
+
+Determine whether there's a local checkout, and which GitHub repo to query. Everything downstream branches on `MODE`.
+
+```bash
+# Is the current directory a git work tree?
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  MODE="local+github"
+  R=$(git remote get-url origin 2>/dev/null | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+else
+  MODE="github-only"   # e.g. a control directory with .claude/ but no clone
+  R=""
+fi
+
+# Fall back to a configured slug, then to the first positional arg.
+R="${ARG_REPO:-$R}"
+R="${R:-blamechris/chroxy}"
+```
+
+If `R` is still empty (no remote, no fallback, no arg), try `gh repo list --limit 50` and match the directory name; if still ambiguous, ask the user for the slug rather than guessing.
+
+State the resolved `R` and `MODE` to the user in one line before continuing. In `github-only` mode, the **Local git state** section is skipped (print "— skipped (no local clone)") — this graceful degradation is the point of the gate, never error out on a missing clone.
+
+Parse `$ARGUMENTS` for `scope` (default `all`), `since` (default 7), and `limit` (default 20).
+
+### 1. Recent Activity — commits + CI/deploy
+
+Run these queries in parallel where possible.
+
+```bash
+# Recent commits on the default branch (works without a local clone)
+gh api "repos/$R/commits" \
+  --jq '.[] | "\(.commit.author.date[0:10])  \(.sha[0:7])  \(.commit.message | split("\n")[0])"' \
+  | head -"$LIMIT"
+
+# Recently merged PRs for "what shipped" context
+gh pr list -R "$R" --state merged --limit 8 \
+  --json number,title,mergedAt -q '.[] | "#\(.number)  \(.mergedAt[0:10])  \(.title)"'
+
+# Latest CI run health
+gh run list -R "$R" --limit 8
+
+# Deploy health on the default branch. Customize the workflow name; if the name is
+# wrong or the repo has no deploy workflow, this simply returns nothing — treat an
+# empty result as "no deploy info" and skip the line, never as an error (graceful
+# degradation, consistent with the rest of the skill).
+gh run list -R "$R" --workflow="Release" --limit 4
+```
+
+Summarize: what shipped recently, whether the latest default-branch run is green, and whether the most recent deploy succeeded. Call out any failing run on the default branch explicitly — that's the "something's on fire" signal.
+
+### 2. Open PRs — with mergeability
+
+```bash
+gh pr list -R "$R" --state open --limit "$LIMIT"
+```
+
+For each open PR, pull the merge/CI rollup so stale or conflicting PRs are obvious. Loop over the **already-capped** list from above so `$PR` is defined and the number of `gh pr view` calls stays bounded by `$LIMIT` (no unbounded N+1 on repos with many open PRs):
+
+```bash
+for PR in $(gh pr list -R "$R" --state open --limit "$LIMIT" --json number -q '.[].number'); do
+  gh pr view "$PR" -R "$R" \
+    --json number,title,mergeable,mergeStateStatus,statusCheckRollup \
+    -q '{num:("#"+(.number|tostring)), title:.title, mergeable:.mergeable, state:.mergeStateStatus,
+         checks:([.statusCheckRollup[]?|.conclusion]|group_by(.)|map("\(.[0]):\(length)")|join(", "))}'
+done
+```
+
+Flag each PR using `mergeStateStatus` + `statusCheckRollup`:
+
+| Signal | Meaning |
+|--------|---------|
+| `BEHIND` | Branch is behind the base — needs a rebase/update before it can merge |
+| `CONFLICTING` / `DIRTY` | Has merge conflicts — needs manual resolution |
+| `FAILURE` in checks | CI is red — may resolve after a rebase, or needs a real fix |
+| `CLEAN` + all `SUCCESS` | Ready to merge |
+
+Note when several stale PRs predate a recent toolchain/dependency change on the default branch — their failures may simply be a missing rebase.
+
+### 3. Open Issues — grouped
+
+```bash
+gh issue list -R "$R" --state open --limit "$LIMIT" \
+  --json number,title,labels,updatedAt \
+  -q '.[] | "#\(.number)  [\([.labels[].name]|join(", "))]  \(.title)"'
+```
+
+Group issues by the repo's label taxonomy so the list reads as themes, not a flat dump:
+
+This repo has no consistent label taxonomy beyond `enhancement` and `from-review` — group by updated date instead of label theme, and flag any `from-review` issues (deferred PR feedback) at the top.
+
+Surface the count, the most recently updated items, and any `bug`/`critical`/`blocked` issues at the top. Do not read every issue body — this is a recap, not triage (`/start-working` does the deep prioritization).
+
+### 4. Local Git State (`local+github` mode only)
+
+Skip this entire section in `github-only` mode (print "— skipped (no local clone)").
+
+```bash
+git status -sb                       # current branch + ahead/behind + dirty files
+git stash list                       # forgotten work-in-progress
+git log --oneline @{u}..HEAD 2>/dev/null   # unpushed local commits, if upstream set
+```
+
+Report the current branch, ahead/behind vs upstream, count of uncommitted/staged files, and any stashes — these are the "you were mid-something" signals.
+
+### 5. Context Layer — memory + repo-memory (best-effort)
+
+Both sources are optional; skip silently if absent.
+
+- **Auto-memory:** if a project/auto memory exists (e.g. `MEMORY.md` or a `memory/` dir), surface any `project`/`feedback` notes relevant to current work — these often record "why we left off here."
+- **repo-memory MCP:** if the `repo-memory` server is enabled, call `get_changed_files` (and `get_project_map` for orientation) to show recently-touched areas. If the server is unavailable, skip without comment.
+
+### 6. Report + Suggested Next Step
+
+Print one scannable summary. Use tables for PRs and issues. Keep it tight.
+
+```markdown
+## Where you left off — {R}
+
+**Mode:** {local+github | github-only}   **Window:** last {since}d
+
+### Recent activity
+{1-3 lines: what shipped, latest CI/deploy state — green or red}
+
+### Open PRs ({N})
+| PR | What | State |
+|----|------|-------|
+| #573 | androidx bump | BEHIND, CI failing |
+| #557 | AGP 9.1.0 | CONFLICTING |
+
+### Open issues ({N})
+{grouped by label theme, 1 line per theme; flag any bug/blocked at top}
+
+### Local state
+{branch · ahead/behind · N uncommitted · M stashed   — or "skipped (no local clone)"}
+
+### Suggested next step
+{ONE concrete action, e.g. "Rebase the 3 BEHIND Dependabot PRs against the new toolchain — likely cheap green wins; handle the conflicting AGP PR separately."}
+```
+
+End on exactly one suggested next step. Do not write any file.
+
+## Critical Rules
+
+1. **Read-only** — `/catchup` never edits files, creates issues/PRs, commits, or merges. It does not merge or rebase anything; it only reports. The user decides what to act on.
+2. **Graceful degradation** — every source is optional. No local clone → `github-only` mode (skip local git state). No `gh` auth, no deploy workflow, no memory, no repo-memory → skip that section and note it in the summary. Never fail the whole run on one missing source.
+3. **Recap, not triage** — this is a fast orientation (target < 90 seconds). Don't read every issue body or trace code. For prioritized work selection use `/start-working`; for repo orientation use `/recon`.
+4. **One next step** — end with a single concrete suggestion, not a menu. The user wanted "where did we leave off," not a backlog.
+5. **No attribution** — never add any AI/agent attribution to output.

--- a/.claude/skills/skill/SKILL.md
+++ b/.claude/skills/skill/SKILL.md
@@ -44,10 +44,10 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`, `pi` →
-  `~/.pi/agent/skills/<name>/`. **This repo's compiler diverges from the registry's**: it adds a
-  fourth `pi` target (#6573) and emits both `codex` and `pi` **user-global** rather than
-  repo-tracked, and both are opt-in. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`,
+  `pi` → `~/.pi/agent/skills/<name>/SKILL.md`. The first three are repo-tracked; **`pi` is the one
+  user-global target** — Pi has no repo-local discovery, so its artifact lands in the user's home
+  dir and is opt-in rather than a safe default. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -228,14 +228,17 @@ note in the report that hashes may be stale. Record which source you used.
    `gh api repos/blamechris/skill-templates/contents/assets/compile-skill-targets.mjs --jq '.content' | base64 -d > scripts/compile-skill-targets.mjs`.
    Write it to `scripts/` and track it in VCS so it travels with the repo. Read the `targets:` line
    from `.claude/skill-profile.md`;
-   if there is none, **ask the user** which agents to compile for (claude / gemini / codex) and
+   if there is none, **ask the user** which agents to compile for (claude / gemini / codex / pi) and
    offer to record the choice in the profile (the compiler falls back to `claude` if unset). Then
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
    any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
-   user-global prompt at `~/.codex/prompts/<name>.md` in this repo — not a repo-tracked
-   folder — so nothing appears in the diff for that target. Same for `pi`. Keep the list of
-   `targets` you compiled with for the next step.
+   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
+   `~/.codex/skills`, or used by runners that support repo-local Codex skills. **`pi` writes outside
+   the repo** (`~/.pi/agent/skills/`), so only add it when the user actually drives this repo with
+   Pi — never volunteer it into a committed `targets:` line on their behalf. The compiler prints a
+   hint if it sees `~/.pi` on the machine but `pi` is unselected; that hint is advisory and never
+   adds the target itself. Keep the list of `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
    (schema below) if absent and upsert `<name>` **atomically** with: the template `hash`; the
    `profileHash` when a `.claude/skill-profile.md` exists (so `update` can tell when the *profile*
@@ -280,9 +283,12 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `~/.codex/prompts/<name>.md`, `pi` → `~/.pi/agent/skills/<name>/` (both user-global
-in this repo). If the lock entry has no `targets` (an older install),
-fall back to removing whichever of those three exist. Report what was removed.
+`codex` → `.codex/skills/<name>/` (dir), `pi` → `~/.pi/agent/skills/<name>/` (dir, **outside the
+repo** — remove it only when `pi` is in the lock entry's `targets`, and say so in the report since
+the user may not expect a repo command to touch their home dir). If the lock entry has no `targets`
+(an older install), fall back to removing whichever of the three **repo-local** artifacts exist —
+never probe `~/.pi` on a guess, because an unrelated Pi skill of the same name could live there.
+Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)
 

--- a/.claude/skills/skill/SKILL.md
+++ b/.claude/skills/skill/SKILL.md
@@ -44,10 +44,11 @@ every skill into every repo, a repo pulls a skill the moment it needs one and th
 - **Targets** — the coding agents a skill is compiled for. `.claude/commands/<name>.md`
   (the customized install) is the provider-NEUTRAL source; `scripts/compile-skill-targets.mjs`
   emits each agent's NATIVE custom-command format: `claude` → `.claude/skills/<name>/SKILL.md`,
-  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `.codex/skills/<name>/SKILL.md`,
-  `pi` → `~/.pi/agent/skills/<name>/SKILL.md`. The first three are repo-tracked; **`pi` is the one
-  user-global target** — Pi has no repo-local discovery, so its artifact lands in the user's home
-  dir and is opt-in rather than a safe default. The active
+  `gemini` → `.gemini/commands/<name>.toml`, `codex` → `~/.codex/prompts/<name>.md`,
+  `pi` → `~/.pi/agent/skills/<name>/SKILL.md`. The first TWO are repo-tracked; **`codex` and `pi`
+  are both user-global** — neither has a repo-local discovery path, so their artifacts land in the
+  user's home dir and both are opt-in rather than safe defaults. Only the repo-tracked pair is
+  gated by `compile-skill-targets.mjs --check` (#7253); a home dir is not part of any commit. The active
   list comes from the `targets:` line in `.claude/skill-profile.md` (prompt the user if absent;
   the compiler falls back to `claude`). This is what makes a skill model-agnostic — author once,
   run under any model. The neutral arg token is `$ARGUMENTS`; the compiler maps it per agent
@@ -232,11 +233,11 @@ note in the report that hashes may be stale. Record which source you used.
    offer to record the choice in the profile (the compiler falls back to `claude` if unset). Then
    run `node scripts/compile-skill-targets.mjs --name <name>` (it reads the profile targets), or
    `--targets <list>` to override. It writes the native artifact per target and exits non-zero on
-   any emit failure — treat that as a hard gate: fix and re-run before locking. Codex emits a
-   repo-tracked skill folder under `.codex/skills/` so it can be reviewed, copied into
-   `~/.codex/skills`, or used by runners that support repo-local Codex skills. **`pi` writes outside
-   the repo** (`~/.pi/agent/skills/`), so only add it when the user actually drives this repo with
-   Pi — never volunteer it into a committed `targets:` line on their behalf. The compiler prints a
+   any emit failure — treat that as a hard gate: fix and re-run before locking. **`codex` and `pi`
+   both write OUTSIDE the repo** (`~/.codex/prompts/<name>.md`, invoked `/prompts:<name>`; and
+   `~/.pi/agent/skills/`), so add either only when the user actually drives this repo with that
+   agent — never volunteer one into a committed `targets:` line on their behalf, and never expect
+   their output in a diff. The compiler prints a
    hint if it sees `~/.pi` on the machine but `pi` is unselected; that hint is advisory and never
    adds the target itself. Keep the list of `targets` you compiled with for the next step.
 8. **Record in the lockfile.** Only after a successful compile, create `.claude/skills.lock`
@@ -283,11 +284,12 @@ note in the report that hashes may be stale. Record which source you used.
 Read the skill's `targets` from its `.claude/skills.lock` entry, then delete
 `.claude/commands/<name>.md`, its lock entry, and exactly the native artifacts for those targets:
 `claude` → `.claude/skills/<name>/` (dir), `gemini` → `.gemini/commands/<name>.toml`,
-`codex` → `.codex/skills/<name>/` (dir), `pi` → `~/.pi/agent/skills/<name>/` (dir, **outside the
-repo** — remove it only when `pi` is in the lock entry's `targets`, and say so in the report since
-the user may not expect a repo command to touch their home dir). If the lock entry has no `targets`
-(an older install), fall back to removing whichever of the three **repo-local** artifacts exist —
-never probe `~/.pi` on a guess, because an unrelated Pi skill of the same name could live there.
+`codex` → `~/.codex/prompts/<name>.md` (file), `pi` → `~/.pi/agent/skills/<name>/` (dir). The last
+two are **outside the repo** — remove either only when it is in the lock entry's `targets`, and say
+so in the report, since the user may not expect a repo command to touch their home dir. If the lock
+entry has no `targets` (an older install), fall back to removing whichever of the two **repo-local**
+artifacts exist — never probe `~/.codex` or `~/.pi` on a guess, because an unrelated skill of the
+same name could live there.
 Report what was removed.
 
 ## Lockfile schema (`.claude/skills.lock`)

--- a/.claude/skills/smoke-form/SKILL.md
+++ b/.claude/skills/smoke-form/SKILL.md
@@ -8,13 +8,19 @@ Generate an interactive, **self-contained HTML smoke-test form** that guides a
 human through a manual verification pass — the hand-driven sibling of
 `/smoke-test` (which runs an automated browser pass). Use it before releases,
 after a feature batch lands, or whenever a change set needs eyes on a real
-device.
+device. With its **wake-on-save loop** (section 6 + `assets/smoke-intake.mjs`),
+the tester's Pass / Pass-with-note / Fail marks **stream live to the driving
+agent**, which triages and files issues in real time — no copy-paste, no waiting.
 
 The output is a single dark-mode `.html` file with inline CSS/JS (no external
 dependencies, no network): collapsible sections per test area, a checkbox +
 result dropdown + notes field per item, progress tracking, localStorage
 persistence (progress survives reloads), and a **Copy Results** button that
-serializes everything the tester entered into paste-ready markdown.
+serializes everything the tester entered into paste-ready markdown. Every command
+in the steps is **click-to-copy**, and each item has **🆘 Need help** / **🖥
+Terminal** buttons that hand the item's context (+ the tester's notes) to an
+assisting agent — so a tester who's mid-task, even playing the app under test,
+gets unblocked in one tap.
 
 ## Arguments
 
@@ -60,6 +66,33 @@ changed:
 - Note per-item **prerequisites** (device, simulator, second machine, network
   conditions) so the tester can batch items by setup:
   Booted iOS simulator + Metro (`npx expo start` from packages/app) + the dev client (`npx expo run:ios` — Expo Go cannot load the app); mock server on :9876 for chat-renderer flows (`bash packages/app/.maestro/scripts/start-mock-server.sh`); a second machine/phone on the same wifi for LAN/pairing items; Node 22 for any server command; Discord webhook configured (keychain `chroxy-discord-webhook` or `CHROXY_DISCORD_WEBHOOK_URL`) for notification items.
+- If the form can only be run after a **deploy/restart** (the app must be at a
+  specific build — e.g. boot-loaded code a page reload won't pick up), make the
+  FIRST item a **build-precondition gate**: the exact redeploy/restart command +
+  how to confirm the live build matches (a `/build` or version check), with a
+  hard "if it doesn't match, STOP". A tester validating a stale build produces
+  false fails that look like real regressions — this trap is worth a dedicated item.
+- **Open with a labeled UI-region map / glossary** whenever the test targets a
+  visual app or overlay. BEFORE the first item, name and locate every on-screen
+  region the checklist will reference — e.g. "top-left status bar = hero name +
+  placement", "prediction modal = the win/tie/loss bar under it", "Reference tabs
+  = Minions / Powers / Comps". An annotated screenshot with callouts is ideal. A
+  tester who doesn't share the codebase's vocabulary cannot run an item that says
+  "check the face-damage chip" — they don't know what that is or where to look.
+  Give them the map first so every later item can simply *point*. (Straight from a
+  live tester: "Assume the tester doesn't know where these things are. Don't just
+  refer to them by name — point out where you expect it, what it looks like.")
+- **Open EVERY section with a "⚙ Before this section — make sure these are running"
+  prereq box.** The region map is global; this is per-section. Before a section's
+  first item, list the exact services/apps/state that must be up to run it — each
+  with its click-to-copy start command — written so a tester with **zero app
+  knowledge** can satisfy them. If the driving agent normally starts something (a
+  server), say so explicitly ("the agent starts this") AND give the manual command
+  as a fallback. (This generalizes the build-precondition gate below from one global
+  gate to per-section preconditions. Straight from a live tester who got stranded on
+  a section because nothing told them an overlay app had to be launched: "list out
+  what needs to be in play before every section — the tester shouldn't need to
+  understand the application; that's the whole goal of this flow.")
 
 Group items into 4–8 sections by surface or setup (not by PR number). Order
 sections so setup flows naturally (e.g. everything needing the same device is
@@ -74,6 +107,36 @@ adjacent). 3–10 items per section; split bigger sections.
 - **Source** — the PR/issue reference(s) this item verifies (rendered as links).
 - **Prereq chip** — if it needs special setup (device, second machine, etc.).
 
+**Atomicity + Steps↔Expected discipline (the QA rigor that makes the form
+trustworthy — a tester runs this deliberately, not by inference):**
+
+- **One observable check per item.** Each item verifies ONE thing with ONE pass
+  condition. Never bundle independent verifications — "launches without a crash"
+  + "no white box" + "a second launch doesn't duplicate" + "a log line appears"
+  are FOUR items, not one. If an item's Expected has multiple "AND" clauses
+  testing unrelated behaviors, split it.
+- **Every Expected clause must trace to a numbered Step.** Expected states the
+  observable result of the listed Steps and nothing else. If verifying something
+  needs an action (e.g. "launch it a second time", "drag the window"), that
+  action IS a numbered Step — never assert in Expected the result of an action
+  the tester was never told to perform.
+- **Make observation explicit.** When a check needs the tester to look at and
+  *report* something rather than judge a clean pass/fail, add an explicit Step —
+  "note what you saw, and where" — with a notes prompt. Never smuggle a "go
+  observe X" requirement into the Expected line; if you need information from the
+  tester, ask for it as a step.
+- **Anchor every UI reference to a named region + what it looks like.** Never
+  refer to an element by an internal/code name alone — say WHERE it is on screen
+  and WHAT it looks like: "the small grey line UNDER the win/tie/loss bar", "the
+  Tier header row reading 'Tier 3 · N'", not "the staleness caveat" or "the tier
+  group". This is the per-item enforcement of the region map above; assume the
+  tester has never seen the code and doesn't know your names for things. An item
+  that names a behavior with no visual anchor leaves the tester guessing what's
+  even being checked.
+
+A tester must be able to execute the Steps top-to-bottom and judge each Expected
+without inferring any hidden action. When in doubt, split the item.
+
 ### 3. Build the HTML — structure and behavior contract
 
 Single file, inline `<style>` and `<script>`, zero external requests. The
@@ -81,13 +144,14 @@ tester may open it weeks later from a different machine — it must work from
 `file://`.
 
 **Theme:** dark mode, system font stack, comfortable line height. Use one
-accent color for interactive elements and result-state colors: pass=green,
-fail=red, blocked=amber, skipped=gray. Respect `prefers-reduced-motion`.
+accent color for interactive elements and result-state colors matching the five
+statuses: pass=green, note=sky-blue, fail=red, skip=gray, need-help=amber.
+Respect `prefers-reduced-motion`.
 
 **Layout, top to bottom:**
 
 1. **Sticky header**: title, scope, generated date, live progress
-   (`N of M checked · X pass / Y fail / Z blocked`), and two buttons:
+   (`N of M checked · X pass / N notes / Y fail / Z need help`), and two buttons:
    - **Copy Results** — serializes the ENTIRE form state to markdown and
      copies to clipboard (see format below). Show a "Copied ✓" flash.
    - **Reset** — clears state after a confirm dialog.
@@ -97,38 +161,104 @@ fail=red, blocked=amber, skipped=gray. Respect `prefers-reduced-motion`.
    section-level progress count in the `<summary>`.
 4. **Items**: each row has —
    - a **checkbox** (tested = touched this item),
-   - a **result `<select>`**: `— / Pass / Fail / Blocked / Skipped`,
+   - a **result control with FIVE statuses** that map to what the agent does with
+     them — this status set is load-bearing (a live tester found the 4-status model
+     forced them to misuse "Fail" or "🆘" for "it works but I have a note"):
+     - **✅ Pass** — works, nothing to say → agent does nothing.
+     - **💡 Pass + note** — *works, but I have feedback* → agent files an
+       **enhancement**. (The bridge from smoke-test to backlog; distinct color, e.g.
+       sky-blue. This is the status most feedback lands on — don't omit it.)
+     - **❌ Fail** — broken / a regression → agent files a **bug** (higher priority).
+     - **⏭ Skip** — not tested / N/A → nothing.
+     - **🆘 Need help** — *I'm blocked right now* → agent helps live (synchronous).
+       Distinct from 💡: 🆘 interrupts, 💡 is async feedback.
    - the title, steps (collapsible if long), expected outcome, source links,
    - a **notes `<input>`/`<textarea>` beside every field** with a
      placeholder hinting what to record ("what you saw, device, repro…").
      Notes are per-item, always visible, never hidden behind a click.
+   - **Per-item agent-assist actions** for a hands-busy tester (e.g. playing the
+     app under test): a **🆘 Need help** button that copies a self-contained help
+     request — the item's title + steps + expected + the tester's per-item AND
+     session/metadata notes + the build under test — to paste straight back to
+     the driving agent; and a **🖥 Terminal** button that copies a single-line
+     `claude "…"` command (quotes/newlines sanitized so it pastes into any shell)
+     seeded with the same context to spin up a fresh session. Both flag the item
+     amber, and reuse the same clipboard fallback as Copy Results.
    - Row border/left-edge tints with the selected result color.
 
 **Behavior:**
 
 - Every input persists to `localStorage` keyed by the file's slug+date
   (restore on load; checkbox auto-checks when a result is chosen).
+- **Per-mark timestamp + "carried over" staleness (the reuse model).** A form is
+  ONE dated pass; reopening it CONTINUES that pass. So a status must record **WHEN**
+  it was set (`at`, set in `setStatus`) and the item must SHOW it — "✓ marked just
+  now / 3h ago". A mark older than a `STALE_MS` threshold (~30 min), **or one with no
+  timestamp** (made before this field existed), renders as **"↩ carried over from an
+  earlier pass — re-confirm?"** with a dashed left-border + an amber tint, and the
+  header shows an "N ↩ carried over" count. This stops a stale Pass from silently
+  reading as a fresh one across sessions/builds — the tester re-confirms it (one click
+  → "just now") or trusts it deliberately. **Make the reuse intentional:** for a NEW
+  change set, generate a NEW form (new slug/date) rather than reopening an old one;
+  reopening is only for continuing an in-progress pass. State this in the form's intro.
 - **Dictation (progressive enhancement):** if `window.SpeechRecognition ||
   window.webkitSpeechRecognition` exists, render a small round 🎤 button beside
   every note field and tester-metadata input. Click → start recognition
-  (`continuous: true`, final results only, `lang` from `navigator.language`),
-  appending each final transcript to the field (space-joined) and persisting;
+  (`continuous: true`, `interimResults: true`, `lang` from `navigator.language`),
+  appending each FINAL transcript to the field (space-joined) and persisting;
   button pulses red while recording, click again (⏹) to stop; only one active
   recorder at a time. Errors (mic permission, offline) surface via the button
   tooltip — never an alert. Where the API is absent the button simply doesn't
   render. Title-hint the privacy caveat: Chromium relays audio to Google's
   speech service; macOS users can always use built-in Dictation instead.
-- Progress counts update live in header and section summaries.
-- **Copy Results markdown format** (exact):
+  **"You are being heard" signal:** show a strong live indicator under the
+  field being dictated into — a `● recording…` label (pulsing dot) + a live
+  **interim-transcript preview** (the not-yet-final text, distinct/dimmed from the
+  committed text, replaced on each event), and outline the active item. Keep the
+  pure split (interim vs final) + append/merge in a testable helper.
+- **Per-item screenshot paste:** the per-item notes accept a pasted
+  (`Ctrl+V`) or dropped image — store it WITH that item's result, show a dark
+  thumbnail frame on the item, and (when the repo customizes an online
+  results-intake mode) include it in the POST to the intake. Guard each image to
+  a sane cap (~2.5 MB decoded); oversize → a visible note, never a silent drop.
+  Intake side: decode the base64 data-URL to a file under
+  `<results>.jsonl.files/` and store a `{file,bytes,mime}` ref in the row
+  (keeps the JSONL small + greppable). Multiple items each carry their own shots.
+- **Click-to-copy commands (essential for a multitasking tester):** every
+  `<code>`/`<pre>` block is click-to-copy — click anywhere on it to copy its
+  text, with a brief flash + toast. Detect terminal commands (text starting
+  `npm `/`node `/`curl `/`git `/`gh `/`cd `/`http`/`<ENV>=`) and render them as
+  prominent, obviously-tappable chips with a `⧉ copy` affordance, so each command
+  is a one-tap target. `stopPropagation` so copying a command inside a
+  collapsible header doesn't also toggle it.
+- Progress counts update live in header and section summaries (count notes
+  separately from fails, e.g. `N notes · M fail · K need-help`).
+- **Live wake-on-save POST (the loop's client half — see section 6):** detect
+  online mode with `const ONLINE = /^https?:$/.test(location.protocol)` (true when
+  served by the intake server, false from `file://`). When ONLINE, `postResult(id)`
+  POSTs `{id, title, section, status, notes, build, ts}` to `/result` (a) on every
+  status change and (b) debounced on note edits for `fail`/`help`/`note` items.
+  **Dedup**: keep a `_lastSent[id]` signature of `status+notes` and skip the POST
+  when unchanged (otherwise focus/toggle re-pings the agent endlessly). Wrap in
+  try/catch — a failure just leaves the answer in localStorage for Export. Show a
+  header badge: **🟢 live — auto-files** (online) vs **💾 offline** (file://). From
+  `file://` the form degrades to localStorage + Copy Results, unchanged.
+- **Copy Results markdown format** (exact) — note the dedicated feedback section so
+  the next agent sees what *worked-but-was-flagged* apart from what *broke*:
 
 ```markdown
 # Smoke test: <scope> — <date>
 Tester: <name> · Build: <build> · Env: <env>
-Result: X pass / Y fail / Z blocked / W skipped / U untested
+Result: X pass / N notes / Y fail / W skipped / Z need help / U untested
 
-## <Section>
-- [x] **<Item title>** — PASS — <note if any>
-- [x] **<Item title>** — FAIL — <note>
+## ⚠️ Needs attention (fail / need-help)
+- ❌ **<Item title>** — <note>
+
+## 💡 Passed with feedback (file as enhancements)
+- 💡 **<Item title>** — <note>
+
+## All results
+- ✅ **<Item title>** — <note if any>
 - [ ] **<Item title>** — (untested)
 ```
 
@@ -153,3 +283,71 @@ Result: X pass / Y fail / Z blocked / W skipped / U untested
 - Anything already covered by green automated tests does not need a manual
   item UNLESS it has a visual/device component automation can't see.
   Server node:test + dashboard/store-core vitest + app jest suites run in CI on every PR; the 20 Maestro flows (`packages/app/.maestro/run-all.yaml`) cover mobile UI on a simulator; `/smoke-test` drives the dashboard headless via Playwright. Manual items should target what those cannot see: real-device feel (latency, scroll, keyboard), multi-machine flows (LAN pairing, tunnel fallback), Discord-side rendering, and anything flagged "needs simulator/device pass" in PR bodies.
+- **LIVE / VISUAL ONLY — never put a purely back-end check in front of a human.**
+  The manual pass is exclusively for what a person at the running app can SEE or
+  DO. CLI output, API routes/status codes, parser or function return shapes,
+  numeric/statistical correctness (scores, percentages, sort orders) — those are
+  UNIT tests, not smoke items. If you catch yourself writing "run `X`, confirm the
+  output is `Y`" with no on-screen component, move it to the test suite and leave
+  it off the checklist entirely. A human's time is for the things automation
+  fundamentally can't observe: layout, rendering, real-device input, "does it
+  feel right." (Build-precondition gates like a redeploy/version check are the one
+  exception — they protect the live pass itself.)
+
+### 6. Live wake-on-save mode (the loop — strongly recommended)
+
+The form alone makes the tester paste a markdown summary back when they finish. The
+**wake-on-save loop** removes that wait entirely: results stream to the driving agent
+as the tester marks them, and the agent files issues **in real time**. Battle-tested
+live; this is the flow to reach for whenever you (the agent) can stay attached.
+
+Three parts:
+
+1. **The form** (this skill) — generated with the section-6 POST wiring above, so each
+   mark hits `/result` when served online.
+2. **The intake server** — `assets/smoke-intake.mjs`. **It is not installed with this
+   skill.** `skill add` / `skill update` write only `.claude/commands/<name>.md`, so
+   the asset has to be fetched the same way `/skill` fetches its own compiler — from a
+   local registry clone if there is one, over the network otherwise:
+
+   ```bash
+   # local clone (preferred; $REG is the resolved registry path)
+   mkdir -p tools && cp "$REG/assets/smoke-intake.mjs" tools/
+
+   # no clone on disk — fetch it, and fail loudly rather than half-fetching
+   set -o pipefail
+   gh api repos/blamechris/skill-templates/contents/assets/smoke-intake.mjs \
+     --jq '.content' | base64 -d > tools/smoke-intake.mjs || exit 1
+   [ -s tools/smoke-intake.mjs ] || { echo "intake server fetch failed" >&2; exit 1; }
+   ```
+
+   Track it in the project once fetched, so it travels with the repo. It serves the
+   form AND appends every result to
+   `<form>.results.jsonl` next to it. Generic + dependency-free:
+   ```bash
+   node tools/smoke-intake.mjs <form.html>   # serves http://127.0.0.1:8770/ , writes <form>.results.jsonl
+   ```
+   The tester opens the served URL (badge reads 🟢 live), not the `file://` path.
+3. **The wake-monitor + triage (agent side)** — the agent tails the results file for
+   actionable statuses and is woken on each, then triages with `/create-issue`:
+   ```bash
+   # arm AFTER the file may already exist; start at end so only NEW marks wake you
+   F="<form>.results.jsonl"; until [ -f "$F" ]; do sleep 2; done
+   tail -n 0 -F "$F" | grep --line-buffered -E '"status":"(fail|help|note)"'
+   ```
+   On each wake: read the FULL note from the JSONL (the wake event truncates), then —
+   **`fail` → file a bug**, **`note` → file an enhancement**, **`help` → answer/assist
+   live**. Use `/create-issue` for the filing (one grouped issue per surface, not one
+   per micro-nit; dedup against issues already filed this session). Notes can grow as
+   the tester edits — re-read before filing; the dedup in the form prevents identical
+   re-pings.
+
+**Setup discipline for the agent:** before telling the tester "go", (a) start every
+service the form's prereq boxes name (or confirm it's their job), (b) start the intake
+server, (c) arm the wake-monitor. Confirm all three are up with one health check.
+Tear down (stop the monitor, kill the intake server) when the tester says the pass is
+done, and back up the `.results.jsonl` (the filed issues are the durable output, but
+keep the raw record).
+
+**Offline fallback is automatic:** opened from `file://` the form still works
+(localStorage + Copy Results) — the loop is a strict enhancement, never a requirement.

--- a/.claude/skills/start-working/SKILL.md
+++ b/.claude/skills/start-working/SKILL.md
@@ -13,7 +13,7 @@ This skill is **read-only** — it never writes files, creates issues, or commit
 - `$ARGUMENTS` - Optional filters. Space-separated tokens:
   - `focus=AREA` — Narrow to a specific area (e.g., `focus=testing`, `focus=security`, `focus=performance`)
   - `limit=N` — Max items to show per source (default: 10)
-  - `include-closed` — Also scan recently closed issues (last 7 days) for context
+  - `include-closed` — Also scan recently closed issues for context
   - If empty, scan everything with defaults
 
 Examples:
@@ -31,7 +31,6 @@ Examples:
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 REPO_NAME=$(basename "$REPO")
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 ```
 
 Parse `$ARGUMENTS` for `focus`, `limit` (default 10), and `include-closed` flag.
@@ -192,7 +191,7 @@ If `focus=AREA` is set, filter to only show items related to that area. Match ag
 
 ### 3. Present Work Queue
 
-Output the primary summary table, then detail sections for each source.
+Output the primary summary table, then detail sections for each source. Cap each detail section to the top `limit` items (default 10) by priority — the queries fetch a wide net so categorization is accurate, but only the most relevant `limit` rows per source are shown. Note any truncation (e.g. "showing top 10 of 23").
 
 #### Primary Output — Work Queue Table
 

--- a/.claude/skills/visual-brief/SKILL.md
+++ b/.claude/skills/visual-brief/SKILL.md
@@ -107,9 +107,36 @@ Use the skeleton below. Rules:
 ```bash
 DIR="${ARG_DIR:-${CLAUDE_BRIEF_DIR:-$HOME/.claude/briefs}}"
 mkdir -p "$DIR"
-# …write the file to "$DIR/<slug>-<date>.html"…
-[ -z "$NO_OPEN" ] && open "$DIR/<slug>-<date>.html"   # macOS; skip with --no-open
+FILE="$DIR/<slug>-<date>.html"
+# …write the file to "$FILE"…
+
+# Launch the browser portably. Opening is a convenience, never a gate: if no
+# launcher exists (headless box, container, CI) we print the path and succeed.
+open_brief() {
+  if [ -n "$NO_OPEN" ]; then return 0; fi          # --no-open
+  for opener in open xdg-open wslview; do          # macOS, Linux, WSL
+    if command -v "$opener" >/dev/null 2>&1; then
+      "$opener" "$1" >/dev/null 2>&1 && return 0
+    fi
+  done
+  if command -v cmd.exe >/dev/null 2>&1; then      # Windows / Git Bash / MSYS
+    cmd.exe /c start "" "$1" >/dev/null 2>&1 && return 0
+  elif command -v start >/dev/null 2>&1; then      # "" is start's window-title arg
+    start "" "$1" >/dev/null 2>&1 && return 0
+  fi
+  # Reached both when no launcher exists and when one exists but failed — the
+  # loop above returns early only on a launcher that actually succeeded.
+  echo "no browser launcher found, or it failed — open the path printed below"
+  return 0                                         # never abort the caller
+}
+open_brief "$FILE"
+echo "$FILE"
 ```
+
+Two things that snippet is deliberately careful about — keep them if you edit it:
+`open_brief` always returns 0, so a missing or failing launcher can't kill a
+caller running under `set -e`; and it ends on `echo`, so the block's exit status
+isn't the short-circuited `--no-open` test.
 
 Report the absolute path so the user can find/link it. If `$CLAUDE_BRIEF_DIR`
 points into an Obsidian vault, mention it's now linkable there.

--- a/.gemini/commands/agent-review.toml
+++ b/.gemini/commands/agent-review.toml
@@ -64,6 +64,8 @@ The agent reviews against these standards:
 
 ### 3. Generate Review
 
+**Deciding vs escalating.** A finding is not automatically a question for the user. If the code, the git history, the issue thread or the docs answer it, answer it in the review; if the call is cheap and reversible, state it, note the assumption, and move on. Escalate to the user only when the answers lead to materially different work, or the action is irreversible or outward-facing — and when you do, escalate through `/decide` (the `AskUserQuestion` tool, 2-4 concrete options, your recommendation first with its costs named), never as prose buried in the review body. Keep reviewing the rest of the diff while the question is open.
+
 Create a comprehensive review:
 
 ```markdown

--- a/.gemini/commands/batch-merge.toml
+++ b/.gemini/commands/batch-merge.toml
@@ -54,8 +54,12 @@ gh pr checks ${PR_NUM} --json name,state \
   --jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length'
 
 # Copilot review presence
+# DISMISSED is excluded on purpose: after `dismiss_stale_reviews` fires, a
+# superseded review is still returned by this endpoint, so counting it reports
+# the gate as satisfied by a review of code that no longer exists.
 gh api repos/${REPO}/pulls/${PR_NUM}/reviews \
-  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length'
+  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")
+             | select(.state != "DISMISSED")] | length'
 ```
 
 Update the progress table with pre-flight results. This is informational — does not block the loop.
@@ -82,7 +86,8 @@ All required checks must be `SUCCESS` or `SKIPPED`. If any are failing or pendin
 
 ```bash
 COPILOT_STATUS=$(gh api repos/${REPO}/pulls/${PR_NUM}/reviews \
-  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] |
+  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")
+             | select(.state != "DISMISSED")] |
     if length == 0 then "NOT_FOUND"
     elif any(.[]; .state == "PENDING") then "IN_PROGRESS"
     else "COMPLETED" end')
@@ -94,6 +99,14 @@ Copilot review **must be present** before merge. This is the quality gate.
 - **IN_PROGRESS:** Poll every 30s, max 5 min.
 - **NOT_FOUND + PR < 8 min old:** Poll every 30s, max 8 min. Copilot takes 3-5 min to start.
 - **NOT_FOUND + PR >= 8 min old:** Proceed with warning (Copilot won't come for old PRs).
+
+Compute the age rather than estimating it — the branch above is only reproducible
+if both operators derive it the same way:
+
+```bash
+PR_AGE_MIN=$(gh pr view ${PR_NUM} --json createdAt \
+  --jq '((now - (.createdAt | fromdateiso8601)) / 60) | floor')
+```
 
 #### Step 2c: Address Unaddressed Copilot Comments
 

--- a/.gemini/commands/smoke-form.toml
+++ b/.gemini/commands/smoke-form.toml
@@ -6,13 +6,19 @@ Generate an interactive, **self-contained HTML smoke-test form** that guides a
 human through a manual verification pass — the hand-driven sibling of
 `/smoke-test` (which runs an automated browser pass). Use it before releases,
 after a feature batch lands, or whenever a change set needs eyes on a real
-device.
+device. With its **wake-on-save loop** (section 6 + `assets/smoke-intake.mjs`),
+the tester's Pass / Pass-with-note / Fail marks **stream live to the driving
+agent**, which triages and files issues in real time — no copy-paste, no waiting.
 
 The output is a single dark-mode `.html` file with inline CSS/JS (no external
 dependencies, no network): collapsible sections per test area, a checkbox +
 result dropdown + notes field per item, progress tracking, localStorage
 persistence (progress survives reloads), and a **Copy Results** button that
-serializes everything the tester entered into paste-ready markdown.
+serializes everything the tester entered into paste-ready markdown. Every command
+in the steps is **click-to-copy**, and each item has **🆘 Need help** / **🖥
+Terminal** buttons that hand the item's context (+ the tester's notes) to an
+assisting agent — so a tester who's mid-task, even playing the app under test,
+gets unblocked in one tap.
 
 ## Arguments
 
@@ -58,6 +64,33 @@ changed:
 - Note per-item **prerequisites** (device, simulator, second machine, network
   conditions) so the tester can batch items by setup:
   Booted iOS simulator + Metro (`npx expo start` from packages/app) + the dev client (`npx expo run:ios` — Expo Go cannot load the app); mock server on :9876 for chat-renderer flows (`bash packages/app/.maestro/scripts/start-mock-server.sh`); a second machine/phone on the same wifi for LAN/pairing items; Node 22 for any server command; Discord webhook configured (keychain `chroxy-discord-webhook` or `CHROXY_DISCORD_WEBHOOK_URL`) for notification items.
+- If the form can only be run after a **deploy/restart** (the app must be at a
+  specific build — e.g. boot-loaded code a page reload won't pick up), make the
+  FIRST item a **build-precondition gate**: the exact redeploy/restart command +
+  how to confirm the live build matches (a `/build` or version check), with a
+  hard "if it doesn't match, STOP". A tester validating a stale build produces
+  false fails that look like real regressions — this trap is worth a dedicated item.
+- **Open with a labeled UI-region map / glossary** whenever the test targets a
+  visual app or overlay. BEFORE the first item, name and locate every on-screen
+  region the checklist will reference — e.g. "top-left status bar = hero name +
+  placement", "prediction modal = the win/tie/loss bar under it", "Reference tabs
+  = Minions / Powers / Comps". An annotated screenshot with callouts is ideal. A
+  tester who doesn't share the codebase's vocabulary cannot run an item that says
+  "check the face-damage chip" — they don't know what that is or where to look.
+  Give them the map first so every later item can simply *point*. (Straight from a
+  live tester: "Assume the tester doesn't know where these things are. Don't just
+  refer to them by name — point out where you expect it, what it looks like.")
+- **Open EVERY section with a "⚙ Before this section — make sure these are running"
+  prereq box.** The region map is global; this is per-section. Before a section's
+  first item, list the exact services/apps/state that must be up to run it — each
+  with its click-to-copy start command — written so a tester with **zero app
+  knowledge** can satisfy them. If the driving agent normally starts something (a
+  server), say so explicitly ("the agent starts this") AND give the manual command
+  as a fallback. (This generalizes the build-precondition gate below from one global
+  gate to per-section preconditions. Straight from a live tester who got stranded on
+  a section because nothing told them an overlay app had to be launched: "list out
+  what needs to be in play before every section — the tester shouldn't need to
+  understand the application; that's the whole goal of this flow.")
 
 Group items into 4–8 sections by surface or setup (not by PR number). Order
 sections so setup flows naturally (e.g. everything needing the same device is
@@ -72,6 +105,36 @@ adjacent). 3–10 items per section; split bigger sections.
 - **Source** — the PR/issue reference(s) this item verifies (rendered as links).
 - **Prereq chip** — if it needs special setup (device, second machine, etc.).
 
+**Atomicity + Steps↔Expected discipline (the QA rigor that makes the form
+trustworthy — a tester runs this deliberately, not by inference):**
+
+- **One observable check per item.** Each item verifies ONE thing with ONE pass
+  condition. Never bundle independent verifications — "launches without a crash"
+  + "no white box" + "a second launch doesn't duplicate" + "a log line appears"
+  are FOUR items, not one. If an item's Expected has multiple "AND" clauses
+  testing unrelated behaviors, split it.
+- **Every Expected clause must trace to a numbered Step.** Expected states the
+  observable result of the listed Steps and nothing else. If verifying something
+  needs an action (e.g. "launch it a second time", "drag the window"), that
+  action IS a numbered Step — never assert in Expected the result of an action
+  the tester was never told to perform.
+- **Make observation explicit.** When a check needs the tester to look at and
+  *report* something rather than judge a clean pass/fail, add an explicit Step —
+  "note what you saw, and where" — with a notes prompt. Never smuggle a "go
+  observe X" requirement into the Expected line; if you need information from the
+  tester, ask for it as a step.
+- **Anchor every UI reference to a named region + what it looks like.** Never
+  refer to an element by an internal/code name alone — say WHERE it is on screen
+  and WHAT it looks like: "the small grey line UNDER the win/tie/loss bar", "the
+  Tier header row reading 'Tier 3 · N'", not "the staleness caveat" or "the tier
+  group". This is the per-item enforcement of the region map above; assume the
+  tester has never seen the code and doesn't know your names for things. An item
+  that names a behavior with no visual anchor leaves the tester guessing what's
+  even being checked.
+
+A tester must be able to execute the Steps top-to-bottom and judge each Expected
+without inferring any hidden action. When in doubt, split the item.
+
 ### 3. Build the HTML — structure and behavior contract
 
 Single file, inline `<style>` and `<script>`, zero external requests. The
@@ -79,13 +142,14 @@ tester may open it weeks later from a different machine — it must work from
 `file://`.
 
 **Theme:** dark mode, system font stack, comfortable line height. Use one
-accent color for interactive elements and result-state colors: pass=green,
-fail=red, blocked=amber, skipped=gray. Respect `prefers-reduced-motion`.
+accent color for interactive elements and result-state colors matching the five
+statuses: pass=green, note=sky-blue, fail=red, skip=gray, need-help=amber.
+Respect `prefers-reduced-motion`.
 
 **Layout, top to bottom:**
 
 1. **Sticky header**: title, scope, generated date, live progress
-   (`N of M checked · X pass / Y fail / Z blocked`), and two buttons:
+   (`N of M checked · X pass / N notes / Y fail / Z need help`), and two buttons:
    - **Copy Results** — serializes the ENTIRE form state to markdown and
      copies to clipboard (see format below). Show a "Copied ✓" flash.
    - **Reset** — clears state after a confirm dialog.
@@ -95,38 +159,104 @@ fail=red, blocked=amber, skipped=gray. Respect `prefers-reduced-motion`.
    section-level progress count in the `<summary>`.
 4. **Items**: each row has —
    - a **checkbox** (tested = touched this item),
-   - a **result `<select>`**: `— / Pass / Fail / Blocked / Skipped`,
+   - a **result control with FIVE statuses** that map to what the agent does with
+     them — this status set is load-bearing (a live tester found the 4-status model
+     forced them to misuse "Fail" or "🆘" for "it works but I have a note"):
+     - **✅ Pass** — works, nothing to say → agent does nothing.
+     - **💡 Pass + note** — *works, but I have feedback* → agent files an
+       **enhancement**. (The bridge from smoke-test to backlog; distinct color, e.g.
+       sky-blue. This is the status most feedback lands on — don't omit it.)
+     - **❌ Fail** — broken / a regression → agent files a **bug** (higher priority).
+     - **⏭ Skip** — not tested / N/A → nothing.
+     - **🆘 Need help** — *I'm blocked right now* → agent helps live (synchronous).
+       Distinct from 💡: 🆘 interrupts, 💡 is async feedback.
    - the title, steps (collapsible if long), expected outcome, source links,
    - a **notes `<input>`/`<textarea>` beside every field** with a
      placeholder hinting what to record ("what you saw, device, repro…").
      Notes are per-item, always visible, never hidden behind a click.
+   - **Per-item agent-assist actions** for a hands-busy tester (e.g. playing the
+     app under test): a **🆘 Need help** button that copies a self-contained help
+     request — the item's title + steps + expected + the tester's per-item AND
+     session/metadata notes + the build under test — to paste straight back to
+     the driving agent; and a **🖥 Terminal** button that copies a single-line
+     `claude "…"` command (quotes/newlines sanitized so it pastes into any shell)
+     seeded with the same context to spin up a fresh session. Both flag the item
+     amber, and reuse the same clipboard fallback as Copy Results.
    - Row border/left-edge tints with the selected result color.
 
 **Behavior:**
 
 - Every input persists to `localStorage` keyed by the file's slug+date
   (restore on load; checkbox auto-checks when a result is chosen).
+- **Per-mark timestamp + "carried over" staleness (the reuse model).** A form is
+  ONE dated pass; reopening it CONTINUES that pass. So a status must record **WHEN**
+  it was set (`at`, set in `setStatus`) and the item must SHOW it — "✓ marked just
+  now / 3h ago". A mark older than a `STALE_MS` threshold (~30 min), **or one with no
+  timestamp** (made before this field existed), renders as **"↩ carried over from an
+  earlier pass — re-confirm?"** with a dashed left-border + an amber tint, and the
+  header shows an "N ↩ carried over" count. This stops a stale Pass from silently
+  reading as a fresh one across sessions/builds — the tester re-confirms it (one click
+  → "just now") or trusts it deliberately. **Make the reuse intentional:** for a NEW
+  change set, generate a NEW form (new slug/date) rather than reopening an old one;
+  reopening is only for continuing an in-progress pass. State this in the form's intro.
 - **Dictation (progressive enhancement):** if `window.SpeechRecognition ||
   window.webkitSpeechRecognition` exists, render a small round 🎤 button beside
   every note field and tester-metadata input. Click → start recognition
-  (`continuous: true`, final results only, `lang` from `navigator.language`),
-  appending each final transcript to the field (space-joined) and persisting;
+  (`continuous: true`, `interimResults: true`, `lang` from `navigator.language`),
+  appending each FINAL transcript to the field (space-joined) and persisting;
   button pulses red while recording, click again (⏹) to stop; only one active
   recorder at a time. Errors (mic permission, offline) surface via the button
   tooltip — never an alert. Where the API is absent the button simply doesn't
   render. Title-hint the privacy caveat: Chromium relays audio to Google's
   speech service; macOS users can always use built-in Dictation instead.
-- Progress counts update live in header and section summaries.
-- **Copy Results markdown format** (exact):
+  **"You are being heard" signal:** show a strong live indicator under the
+  field being dictated into — a `● recording…` label (pulsing dot) + a live
+  **interim-transcript preview** (the not-yet-final text, distinct/dimmed from the
+  committed text, replaced on each event), and outline the active item. Keep the
+  pure split (interim vs final) + append/merge in a testable helper.
+- **Per-item screenshot paste:** the per-item notes accept a pasted
+  (`Ctrl+V`) or dropped image — store it WITH that item's result, show a dark
+  thumbnail frame on the item, and (when the repo customizes an online
+  results-intake mode) include it in the POST to the intake. Guard each image to
+  a sane cap (~2.5 MB decoded); oversize → a visible note, never a silent drop.
+  Intake side: decode the base64 data-URL to a file under
+  `<results>.jsonl.files/` and store a `{file,bytes,mime}` ref in the row
+  (keeps the JSONL small + greppable). Multiple items each carry their own shots.
+- **Click-to-copy commands (essential for a multitasking tester):** every
+  `<code>`/`<pre>` block is click-to-copy — click anywhere on it to copy its
+  text, with a brief flash + toast. Detect terminal commands (text starting
+  `npm `/`node `/`curl `/`git `/`gh `/`cd `/`http`/`<ENV>=`) and render them as
+  prominent, obviously-tappable chips with a `⧉ copy` affordance, so each command
+  is a one-tap target. `stopPropagation` so copying a command inside a
+  collapsible header doesn't also toggle it.
+- Progress counts update live in header and section summaries (count notes
+  separately from fails, e.g. `N notes · M fail · K need-help`).
+- **Live wake-on-save POST (the loop's client half — see section 6):** detect
+  online mode with `const ONLINE = /^https?:$/.test(location.protocol)` (true when
+  served by the intake server, false from `file://`). When ONLINE, `postResult(id)`
+  POSTs `{id, title, section, status, notes, build, ts}` to `/result` (a) on every
+  status change and (b) debounced on note edits for `fail`/`help`/`note` items.
+  **Dedup**: keep a `_lastSent[id]` signature of `status+notes` and skip the POST
+  when unchanged (otherwise focus/toggle re-pings the agent endlessly). Wrap in
+  try/catch — a failure just leaves the answer in localStorage for Export. Show a
+  header badge: **🟢 live — auto-files** (online) vs **💾 offline** (file://). From
+  `file://` the form degrades to localStorage + Copy Results, unchanged.
+- **Copy Results markdown format** (exact) — note the dedicated feedback section so
+  the next agent sees what *worked-but-was-flagged* apart from what *broke*:
 
 ```markdown
 # Smoke test: <scope> — <date>
 Tester: <name> · Build: <build> · Env: <env>
-Result: X pass / Y fail / Z blocked / W skipped / U untested
+Result: X pass / N notes / Y fail / W skipped / Z need help / U untested
 
-## <Section>
-- [x] **<Item title>** — PASS — <note if any>
-- [x] **<Item title>** — FAIL — <note>
+## ⚠️ Needs attention (fail / need-help)
+- ❌ **<Item title>** — <note>
+
+## 💡 Passed with feedback (file as enhancements)
+- 💡 **<Item title>** — <note>
+
+## All results
+- ✅ **<Item title>** — <note if any>
 - [ ] **<Item title>** — (untested)
 ```
 
@@ -151,4 +281,72 @@ Result: X pass / Y fail / Z blocked / W skipped / U untested
 - Anything already covered by green automated tests does not need a manual
   item UNLESS it has a visual/device component automation can't see.
   Server node:test + dashboard/store-core vitest + app jest suites run in CI on every PR; the 20 Maestro flows (`packages/app/.maestro/run-all.yaml`) cover mobile UI on a simulator; `/smoke-test` drives the dashboard headless via Playwright. Manual items should target what those cannot see: real-device feel (latency, scroll, keyboard), multi-machine flows (LAN pairing, tunnel fallback), Discord-side rendering, and anything flagged "needs simulator/device pass" in PR bodies.
+- **LIVE / VISUAL ONLY — never put a purely back-end check in front of a human.**
+  The manual pass is exclusively for what a person at the running app can SEE or
+  DO. CLI output, API routes/status codes, parser or function return shapes,
+  numeric/statistical correctness (scores, percentages, sort orders) — those are
+  UNIT tests, not smoke items. If you catch yourself writing "run `X`, confirm the
+  output is `Y`" with no on-screen component, move it to the test suite and leave
+  it off the checklist entirely. A human's time is for the things automation
+  fundamentally can't observe: layout, rendering, real-device input, "does it
+  feel right." (Build-precondition gates like a redeploy/version check are the one
+  exception — they protect the live pass itself.)
+
+### 6. Live wake-on-save mode (the loop — strongly recommended)
+
+The form alone makes the tester paste a markdown summary back when they finish. The
+**wake-on-save loop** removes that wait entirely: results stream to the driving agent
+as the tester marks them, and the agent files issues **in real time**. Battle-tested
+live; this is the flow to reach for whenever you (the agent) can stay attached.
+
+Three parts:
+
+1. **The form** (this skill) — generated with the section-6 POST wiring above, so each
+   mark hits `/result` when served online.
+2. **The intake server** — `assets/smoke-intake.mjs`. **It is not installed with this
+   skill.** `skill add` / `skill update` write only `.claude/commands/<name>.md`, so
+   the asset has to be fetched the same way `/skill` fetches its own compiler — from a
+   local registry clone if there is one, over the network otherwise:
+
+   ```bash
+   # local clone (preferred; $REG is the resolved registry path)
+   mkdir -p tools && cp "$REG/assets/smoke-intake.mjs" tools/
+
+   # no clone on disk — fetch it, and fail loudly rather than half-fetching
+   set -o pipefail
+   gh api repos/blamechris/skill-templates/contents/assets/smoke-intake.mjs \
+     --jq '.content' | base64 -d > tools/smoke-intake.mjs || exit 1
+   [ -s tools/smoke-intake.mjs ] || { echo "intake server fetch failed" >&2; exit 1; }
+   ```
+
+   Track it in the project once fetched, so it travels with the repo. It serves the
+   form AND appends every result to
+   `<form>.results.jsonl` next to it. Generic + dependency-free:
+   ```bash
+   node tools/smoke-intake.mjs <form.html>   # serves http://127.0.0.1:8770/ , writes <form>.results.jsonl
+   ```
+   The tester opens the served URL (badge reads 🟢 live), not the `file://` path.
+3. **The wake-monitor + triage (agent side)** — the agent tails the results file for
+   actionable statuses and is woken on each, then triages with `/create-issue`:
+   ```bash
+   # arm AFTER the file may already exist; start at end so only NEW marks wake you
+   F="<form>.results.jsonl"; until [ -f "$F" ]; do sleep 2; done
+   tail -n 0 -F "$F" | grep --line-buffered -E '"status":"(fail|help|note)"'
+   ```
+   On each wake: read the FULL note from the JSONL (the wake event truncates), then —
+   **`fail` → file a bug**, **`note` → file an enhancement**, **`help` → answer/assist
+   live**. Use `/create-issue` for the filing (one grouped issue per surface, not one
+   per micro-nit; dedup against issues already filed this session). Notes can grow as
+   the tester edits — re-read before filing; the dedup in the form prevents identical
+   re-pings.
+
+**Setup discipline for the agent:** before telling the tester "go", (a) start every
+service the form's prereq boxes name (or confirm it's their job), (b) start the intake
+server, (c) arm the wake-monitor. Confirm all three are up with one health check.
+Tear down (stop the monitor, kill the intake server) when the tester says the pass is
+done, and back up the `.results.jsonl` (the filed issues are the durable output, but
+keep the raw record).
+
+**Offline fallback is automatic:** opened from `file://` the form still works
+(localStorage + Copy Results) — the loop is a strict enhancement, never a requirement.
 '''

--- a/.gemini/commands/start-working.toml
+++ b/.gemini/commands/start-working.toml
@@ -11,7 +11,7 @@ This skill is **read-only** — it never writes files, creates issues, or commit
 - `{{args}}` - Optional filters. Space-separated tokens:
   - `focus=AREA` — Narrow to a specific area (e.g., `focus=testing`, `focus=security`, `focus=performance`)
   - `limit=N` — Max items to show per source (default: 10)
-  - `include-closed` — Also scan recently closed issues (last 7 days) for context
+  - `include-closed` — Also scan recently closed issues for context
   - If empty, scan everything with defaults
 
 Examples:
@@ -29,7 +29,6 @@ Examples:
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 REPO_NAME=$(basename "$REPO")
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 ```
 
 Parse `{{args}}` for `focus`, `limit` (default 10), and `include-closed` flag.
@@ -190,7 +189,7 @@ If `focus=AREA` is set, filter to only show items related to that area. Match ag
 
 ### 3. Present Work Queue
 
-Output the primary summary table, then detail sections for each source.
+Output the primary summary table, then detail sections for each source. Cap each detail section to the top `limit` items (default 10) by priority — the queries fetch a wide net so categorization is accurate, but only the most relevant `limit` rows per source are shown. Note any truncation (e.g. "showing top 10 of 23").
 
 #### Primary Output — Work Queue Table
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1045,6 +1045,20 @@ jobs:
       - name: Run lint-no-nul-bytes golden test
         run: bash scripts/__tests__/lint-no-nul-bytes.test.sh
 
+      - name: Check compiled skill artifacts are in sync with .claude/commands
+        # #7253 — .claude/commands/<name>.md is the neutral source, but
+        # .claude/skills/<name>/SKILL.md is what Claude actually LOADS (the
+        # legacy .claude/commands/ discovery is broken — anthropics/claude-code#31846)
+        # and .gemini/commands/<name>.toml is Gemini's. A stale artifact means the
+        # skill you edited is not the skill that runs. Nothing gated that, and 11
+        # had drifted on main while `catchup` had never been compiled at all.
+        #
+        # The script resolves its targets from .claude/skill-profile.md and gates
+        # only the repo-local ones. codex and pi compile into ~/.codex and ~/.pi:
+        # per-machine, opt-in, not version-controlled, and never touched by CI.
+        # --check is read-only and refuses those targets outright.
+        run: node scripts/compile-skill-targets.mjs --check
+
       - name: Check AGENTS.md is in sync with CLAUDE.md
         # AGENTS.md is generated from CLAUDE.md (the single source of truth) so
         # non-Claude agents get the same guidance. This gate fails if CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,17 @@ unaware machine's `~/.codex` or `~/.pi`). With no `targets:` line the compiler f
 `claude` only and `/skill` prompts you. After editing a skill's generic source by hand, recompile:
 `node scripts/compile-skill-targets.mjs --name <name>` (`--dry-run` to preview).
 
+**Forgetting to recompile is a CI failure, not a silent one (#7253).** `Scripts Tests` runs
+`node scripts/compile-skill-targets.mjs --check`, which compiles the repo-local targets in memory
+and compares them against what is committed — the same shape as the AGENTS.md gate. It fails on an
+artifact whose bytes differ from its source, one that was never compiled, one left behind for a
+target that now skips the skill, one whose source was deleted, and on a repo-local target that has
+committed artifacts but is not being checked. It writes nothing, and it refuses `codex`/`pi`
+outright: those compile into `~/.codex` and `~/.pi`, which are per-machine and must never be
+touched by CI. This matters more than the AGENTS.md mirror does — `.claude/skills/<name>/SKILL.md`
+is what Claude actually *loads*, so a stale artifact means the skill you edited is not the skill
+that runs.
+
 This repo carries `.claude/skill-profile.md` (the customization profile + `targets:`) and
 `.claude/skills.lock` (what's installed, at which template hash). Maintainers edit templates in
 the registry's `generic/` and run its `scripts/build-index.sh`; consumers pick changes up on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,17 @@ unaware machine's `~/.codex` or `~/.pi`). With no `targets:` line the compiler f
 `claude` only and `/skill` prompts you. After editing a skill's generic source by hand, recompile:
 `node scripts/compile-skill-targets.mjs --name <name>` (`--dry-run` to preview).
 
+**Forgetting to recompile is a CI failure, not a silent one (#7253).** `Scripts Tests` runs
+`node scripts/compile-skill-targets.mjs --check`, which compiles the repo-local targets in memory
+and compares them against what is committed — the same shape as the AGENTS.md gate. It fails on an
+artifact whose bytes differ from its source, one that was never compiled, one left behind for a
+target that now skips the skill, one whose source was deleted, and on a repo-local target that has
+committed artifacts but is not being checked. It writes nothing, and it refuses `codex`/`pi`
+outright: those compile into `~/.codex` and `~/.pi`, which are per-machine and must never be
+touched by CI. This matters more than the AGENTS.md mirror does — `.claude/skills/<name>/SKILL.md`
+is what Claude actually *loads*, so a stale artifact means the skill you edited is not the skill
+that runs.
+
 This repo carries `.claude/skill-profile.md` (the customization profile + `targets:`) and
 `.claude/skills.lock` (what's installed, at which template hash). Maintainers edit templates in
 the registry's `generic/` and run its `scripts/build-index.sh`; consumers pick changes up on the

--- a/docs/dev-workflow-skills.md
+++ b/docs/dev-workflow-skills.md
@@ -51,6 +51,26 @@ Codex reads these from `~/.codex/prompts/` and you invoke them as `/prompts:<nam
 
 With no `targets:` line the compiler falls back to `claude` only. After editing a skill's neutral source by hand, recompile: `node scripts/compile-skill-targets.mjs --name <name>` (`--dry-run` to preview).
 
+### The drift gate (`--check`)
+
+Forgetting that recompile used to be invisible: on `origin/main` 11 compiled artifacts differed from their sources, and `catchup` had a source with no artifact at all — so it was not loadable (#7253). `.claude/skills/<name>/SKILL.md` is what Claude actually **loads**, so a stale artifact means the skill you edited is not the skill that runs.
+
+```bash
+node scripts/compile-skill-targets.mjs --check
+```
+
+Compiles the repo-local targets in memory and compares them against what is committed, exiting 1 and naming every offender. `Scripts Tests` runs it on every PR. It reports five conditions, because "do the bytes match?" alone would have passed `catchup`:
+
+| | |
+|---|---|
+| `STALE` | the artifact differs from its source — recompile |
+| `MISSING` | the source was never compiled |
+| `UNEXPECTED` | an artifact exists for a target that now **skips** this skill (the compile path deletes these; `--check` only reports) |
+| `ORPHAN` | an artifact whose `.claude/commands/<name>.md` is gone — it still loads as a skill |
+| `UNGATED` | a repo-local target has committed artifacts but is not among the checked targets (a mangled `targets:` line degrades to `claude`, which would leave every `.gemini/commands/*.toml` unchecked) |
+
+`--check` is strictly read-only, is a repo-wide gate (so it refuses `--name`), and refuses `codex`/`pi` outright: those compile into `~/.codex` and `~/.pi`, which are per-machine, opt-in, and deliberately not version-controlled, so there is no committed state to compare against and CI must never touch them.
+
 ### Discoverability hint
 
 When you compile, `compile-skill-targets.mjs` prints a one-line hint if it detects an agent's home directory (`~/.codex`, `~/.gemini`) whose target you did **not** select — a nudge so a Codex or Gemini user doesn't silently miss the skills. It never adds the target for you (that would write to a home dir you didn't ask about); it just tells you the flag to pass.

--- a/docs/dev-workflow-skills.md
+++ b/docs/dev-workflow-skills.md
@@ -53,7 +53,7 @@ With no `targets:` line the compiler falls back to `claude` only. After editing 
 
 ### The drift gate (`--check`)
 
-Forgetting that recompile used to be invisible: on `origin/main` 11 compiled artifacts differed from their sources, and `catchup` had a source with no artifact at all — so it was not loadable (#7253). `.claude/skills/<name>/SKILL.md` is what Claude actually **loads**, so a stale artifact means the skill you edited is not the skill that runs.
+Forgetting that recompile used to be invisible: on `origin/main` the gate reported 11 problems — 10 artifacts whose bytes differed from their sources, plus `catchup`, which had a source and no compiled artifact at all, so that skill was not loadable (#7253). `.claude/skills/<name>/SKILL.md` is what Claude actually **loads**, so a stale artifact means the skill you edited is not the skill that runs.
 
 ```bash
 node scripts/compile-skill-targets.mjs --check
@@ -69,7 +69,9 @@ Compiles the repo-local targets in memory and compares them against what is comm
 | `ORPHAN` | an artifact whose `.claude/commands/<name>.md` is gone — it still loads as a skill |
 | `UNGATED` | a repo-local target has committed artifacts but is not among the checked targets (a mangled `targets:` line degrades to `claude`, which would leave every `.gemini/commands/*.toml` unchecked) |
 
-`--check` is strictly read-only, is a repo-wide gate (so it refuses `--name`), and refuses `codex`/`pi` outright: those compile into `~/.codex` and `~/.pi`, which are per-machine, opt-in, and deliberately not version-controlled, so there is no committed state to compare against and CI must never touch them.
+`--check` is strictly read-only and is a repo-wide gate, so it refuses `--name` (under which every artifact for a non-selected skill would read as an `ORPHAN`). It also refuses an unrecognised argument rather than ignoring it — a typo'd `--chekc` used to fall through to the **compile** path, rewriting every artifact and exiting 0.
+
+It never touches `codex`/`pi`, which compile into `~/.codex` and `~/.pi`: per-machine, opt-in, and deliberately not version-controlled, so there is no committed state to compare against. Naming one in `--targets` is an **error**; inheriting one from the profile's `targets:` line **drops it with a logged note**, and if that leaves no repo-local target at all the gate refuses rather than reporting "in sync" over nothing.
 
 ### Discoverability hint
 

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -27,7 +27,8 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const helperPath = resolve(__dirname, '..', 'compile-skill-targets.mjs')
 
-const { deriveDescription, detectUncompiledAgents, emitPi, ALL_TARGETS } = await import(helperPath)
+const { deriveDescription, detectUncompiledAgents, emitPi, ALL_TARGETS, REPO_LOCAL_TARGETS, checkDrift } =
+  await import(helperPath)
 
 let pass = 0
 let fail = 0
@@ -272,7 +273,7 @@ await test('detectUncompiledAgents flags an installed-but-unselected pi (~/.pi)'
 // from "never ran": both are 0. The sibling coverage for the other consumer of
 // the shared guard is in gen-agents-md.test.mjs.
 
-import { existsSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { stageScript } from './helpers/stage-script.mjs'
@@ -501,6 +502,346 @@ await test('importing the module does NOT run its CLI (the other direction, #723
       'importing the module compiled a skill — any test that imports it would rewrite the real repo',
     )
   })
+})
+
+// --- #7253: the drift gate -------------------------------------------------
+//
+// `.claude/commands/<name>.md` is the neutral SOURCE; `.claude/skills/<name>/SKILL.md`
+// is what Claude actually LOADS (the legacy `.claude/commands/` discovery is
+// broken — anthropics/claude-code#31846) and `.gemini/commands/<name>.toml` is
+// Gemini's. A stale artifact therefore means the skill you edited is not the
+// skill that runs. Nothing gated that: on pristine main 11 artifacts differed
+// from what the compiler produces, and `catchup` had a source with no compiled
+// artifact at all, so that skill was not loadable.
+//
+// AGENTS.md — a generated mirror of the same class, and strictly less
+// load-bearing since it changes no agent's behaviour — has had this gate since
+// #7198. These are its counterpart.
+//
+// Four of the tests below cover a way an artifact can be wrong that a naive
+// "do the bytes match?" check passes silently: an artifact that does not exist
+// (`catchup`), one that should not exist, one whose source is gone, and a whole
+// target that is not being checked at all.
+
+// A source Gemini CANNOT take: `{{` is an active sequence in its prompt engine,
+// so emitGemini refuses and the compiler emits no .toml. It is the only way to
+// reach the "an artifact exists that SHOULD NOT" branch, and it is not a
+// hypothetical shape — 5 of the repo's 31 real sources sit in exactly this
+// position.
+const GEMINI_UNSAFE_BODY = '# Unsafe skill\n\nCarries a literal {{TEMPLATE}} token that Gemini would interpret.\n'
+const KEEPER_BODY = '# Keeper skill\n\nA second source so a test can delete the first one.\n'
+
+// The fixture ships ONE source, which is not enough here: deleting it to make an
+// orphan also empties .claude/commands, and the "checked nothing" refusal then
+// fires before the orphan report. A second source keeps each test to ONE
+// condition.
+const addSource = (root, name, body) =>
+  writeFileSync(pjoin(root, '.claude', 'commands', `${name}.md`), body)
+
+const runCheck = (script, args, home, cwd) => runCompiler(script, ['--check', ...args], home, cwd)
+
+// A content-addressed snapshot of a tree: every path, plus every file's bytes.
+// Deliberately NOT mtime-based — its granularity is coarse enough that a
+// same-second rewrite reads as unchanged, which is the one thing a "wrote
+// nothing" assertion must never miss.
+const snapshot = (dir) => {
+  const out = []
+  const walk = (d, rel) => {
+    for (const e of readdirSync(d, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? -1 : 1))) {
+      const r = rel ? `${rel}/${e.name}` : e.name
+      if (e.isDirectory()) {
+        out.push(`d ${r}`)
+        walk(pjoin(d, e.name), r)
+      } else if (e.isFile()) {
+        out.push(`f ${r}\n${readFileSync(pjoin(d, e.name), 'utf8')}`)
+      } else {
+        out.push(`? ${r}`)
+      }
+    }
+  }
+  walk(dir, '')
+  return out.join('\n ')
+}
+
+// Compile the fixture and assert the gate is GREEN on the result. Every drift
+// test below mutates from this state, so a fixture that was already red would
+// make all of them pass for the wrong reason.
+const compileThenCheck = (ctx, targets = 'claude,gemini') => {
+  const built = runCompiler(ctx.script, ['--repo', ctx.root, '--targets', targets], ctx.home, ctx.dir)
+  assert(built.status === 0, `fixture compile failed (${built.status}): ${built.stderr}`)
+  const clean = runCheck(ctx.script, ['--repo', ctx.root, '--targets', targets], ctx.home, ctx.dir)
+  assert(
+    clean.status === 0,
+    `--check must be green on a freshly compiled tree, got ${clean.status}:\n${clean.stdout}${clean.stderr}`,
+  )
+  return clean
+}
+
+// Every drift test asserts the MESSAGE, never the exit code alone. `node` exits
+// 1 for an uncaught module-load error too, and a guard reading false exits 0
+// having done nothing — so a bare status check cannot tell "the gate detected
+// drift" from "the gate never ran". Same reasoning as gen-agents-md.test.mjs's
+// assertDetectedDrift, arrived at the same way (#7214).
+const assertDetected = (run, kind, file) => {
+  assert(
+    run.status === 1,
+    `--check must exit 1 on drift, got ${run.status} (0 = the gate never ran)\n${run.stdout}${run.stderr}`,
+  )
+  assert(
+    run.stderr.includes('::error::Compiled skill artifacts are out of sync'),
+    `exit 1 came from something other than drift detection:\n${run.stderr}`,
+  )
+  const line = run.stderr.split('\n').find((l) => l.includes(file))
+  assert(line, `nothing in the report mentions ${file}:\n${run.stderr}`)
+  assert(line.includes(kind), `${file} was reported, but not as ${kind}:\n${line}`)
+}
+
+// --- the real repo ---------------------------------------------------------
+await test('committed skill artifacts are in sync with .claude/commands (drift gate, #7253)', () => {
+  const repoRoot = resolve(__dirname, '..', '..')
+  const { names, compared, problems } = checkDrift(repoRoot, REPO_LOCAL_TARGETS)
+  // Both counters are the same refusal the CLI applies, asserted here so this
+  // test cannot go vacuous if the source directory is ever moved out from under
+  // it: with no sources there is nothing to compare and `problems` is empty,
+  // which would otherwise read as a pass.
+  assert(names.length > 0, `no skill sources under ${repoRoot}/.claude/commands — this test checked NOTHING`)
+  assert(
+    compared === names.length * REPO_LOCAL_TARGETS.length,
+    `compared ${compared} artifact(s) for ${names.length} source(s) x ${REPO_LOCAL_TARGETS.length} target(s) — the target loop did not run to completion`,
+  )
+  assert(
+    problems.length === 0,
+    'compiled skill artifacts are stale — run `node scripts/compile-skill-targets.mjs --targets ' +
+      `${REPO_LOCAL_TARGETS.join(',')}\` and commit the result:\n` +
+      problems.map((p) => `  ${p.kind.toUpperCase()} [${p.target}] ${p.file}`).join('\n'),
+  )
+})
+
+// --- the gate, end to end --------------------------------------------------
+await test('--check is green on a freshly compiled tree, and says what it checked (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    const clean = compileThenCheck(ctx)
+    // "in sync" with a zero count is the vacuous pass this gate must never
+    // report, so pin the count rather than the word.
+    assert(
+      /in sync: 2 skill\(s\) x 2 target\(s\)/.test(clean.stdout),
+      `the gate must report how much it actually compared:\n${clean.stdout}`,
+    )
+  })
+})
+
+await test('--check goes red when a source is edited without recompiling (#7253)', () => {
+  withFixture((ctx) => {
+    compileThenCheck(ctx)
+    // The exact mistake the gate exists to catch, and the one that drifted 11
+    // artifacts on main: edit the neutral source, ship without recompiling.
+    writeFileSync(
+      pjoin(ctx.root, '.claude', 'commands', 'demo.md'),
+      `${SKILL_BODY}\nA line the committed artifacts do not carry.\n`,
+    )
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assertDetected(run, 'STALE', '.claude/skills/demo/SKILL.md')
+    // Both targets, so a gate that stopped after the first one is red too.
+    assertDetected(run, 'STALE', '.gemini/commands/demo.toml')
+  })
+})
+
+await test('--check goes red when a source was never compiled at all (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    compileThenCheck(ctx)
+    // `catchup` on main: a source with no artifact whatsoever. A gate that only
+    // diffed the files it FOUND would pass this, which is why it is its own case.
+    rmSync(pjoin(ctx.root, '.claude', 'skills', 'demo', 'SKILL.md'))
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assertDetected(run, 'MISSING', '.claude/skills/demo/SKILL.md')
+  })
+})
+
+await test('--check goes red when a source is deleted but its artifacts remain (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    compileThenCheck(ctx)
+    // A half-run `/skill remove`. The artifact keeps LOADING as a skill, with no
+    // source left to review it against — the most invisible of the four.
+    rmSync(pjoin(ctx.root, '.claude', 'commands', 'demo.md'))
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assertDetected(run, 'ORPHAN', '.claude/skills/demo/SKILL.md')
+    assertDetected(run, 'ORPHAN', '.gemini/commands/demo.toml')
+  })
+})
+
+await test('--check goes red on a leftover artifact for a target that skips the skill (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'unsafe', GEMINI_UNSAFE_BODY)
+    compileThenCheck(ctx)
+    const leftover = pjoin(ctx.root, '.gemini', 'commands', 'unsafe.toml')
+    // Positive control for the fixture itself: if the compiler DID emit a Gemini
+    // artifact here, the file written below would be legitimate output and the
+    // test would be asserting on a condition it manufactured.
+    assert(!existsSync(leftover), 'the compiler emitted a Gemini artifact for a body Gemini cannot take')
+    // The compile path DELETES this on its next run (compileOne's removeStale);
+    // --check writes nothing, so it has to REPORT it or the leftover keeps
+    // loading forever.
+    writeFileSync(leftover, "description = 'stale'\nprompt = '''\nleft over from before the skill became unsafe\n'''\n")
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assertDetected(run, 'UNEXPECTED', '.gemini/commands/unsafe.toml')
+  })
+})
+
+await test('--check goes red when a repo-local target has committed artifacts but is not checked (#7253)', () => {
+  withFixture((ctx) => {
+    compileThenCheck(ctx)
+    // targetsFromProfile() returns null for ANY `targets:` line it fails to
+    // match, and main() then falls back to ['claude'] — so one mangled character
+    // in .claude/skill-profile.md would leave every committed
+    // .gemini/commands/*.toml unchecked while the gate still exited 0. "Cannot
+    // check this" must not read as "there was nothing to check".
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude'], ctx.home, ctx.dir)
+    assertDetected(run, 'UNGATED', '.gemini/commands')
+  })
+})
+
+await test('--check detects drift through a symlinked invocation path (#7198 at this call site)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    compileThenCheck(ctx)
+    writeFileSync(pjoin(ctx.root, '.claude', 'commands', 'demo.md'), `${SKILL_BODY}\ndrifted\n`)
+    // node realpaths import.meta.url but leaves argv[1] as typed, so through a
+    // symlink the two differ. Before #7213 that read false and the process
+    // exited 0 — here that means a CI gate reporting "in sync" having compared
+    // nothing, which is strictly worse than the compile path's no-op.
+    const link = pjoin(ctx.dir, 'link')
+    symlinkSync(ctx.root, link)
+    const run = runCheck(
+      pjoin(link, 'scripts', 'compile-skill-targets.mjs'),
+      ['--repo', ctx.root, '--targets', 'claude,gemini'],
+      ctx.home,
+      ctx.dir,
+    )
+    assertDetected(run, 'STALE', '.claude/skills/demo/SKILL.md')
+  })
+})
+
+// --- the gate's own refusals -----------------------------------------------
+await test('--check refuses an empty .claude/commands rather than reporting success (#7253)', () => {
+  withFixture((ctx) => {
+    rmSync(pjoin(ctx.root, '.claude', 'commands', 'demo.md'))
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assert(run.status === 1, `a gate with nothing to check must not exit 0, got ${run.status}:\n${run.stdout}`)
+    assert(
+      /found no skill sources/.test(run.stderr),
+      `exit 1 must name the reason, not just happen:\n${run.stderr}`,
+    )
+  })
+})
+
+await test('--check refuses --name, which would report every other artifact as an orphan (#7253)', () => {
+  withFixture((ctx) => {
+    const run = runCheck(
+      ctx.script,
+      ['--repo', ctx.root, '--targets', 'claude', '--name', 'demo'],
+      ctx.home,
+      ctx.dir,
+    )
+    assert(run.status === 1, `--check --name must be refused, got ${run.status}:\n${run.stdout}`)
+    assert(/repo-wide gate/.test(run.stderr), `the refusal must say why:\n${run.stderr}`)
+  })
+})
+
+await test('--check refuses every non-repo-local target and creates no agent home dir (#7253)', () => {
+  withFixture((ctx) => {
+    const userGlobal = ALL_TARGETS.filter((t) => !REPO_LOCAL_TARGETS.includes(t))
+    // Derived, not listed: a target added to the table is covered here the day
+    // it lands, which a hardcoded ['codex', 'pi'] would not be.
+    assert(userGlobal.length > 0, 'precondition: there is at least one user-global target to refuse')
+    for (const target of userGlobal) {
+      const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', target], ctx.home, ctx.dir)
+      assert(run.status === 1, `--check --targets ${target} must be refused, got ${run.status}:\n${run.stdout}`)
+      assert(
+        /applies only to the repo-local targets/.test(run.stderr),
+        `the refusal must say why:\n${run.stderr}`,
+      )
+    }
+    assert(
+      readdirSync(ctx.home).length === 0,
+      `--check wrote into a user-global agent home dir: ${readdirSync(ctx.home).join(', ')}`,
+    )
+  })
+})
+
+await test('--check never writes — not to the repo, not to a home dir (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    compileThenCheck(ctx)
+    writeFileSync(pjoin(ctx.root, '.claude', 'commands', 'demo.md'), `${SKILL_BODY}\ndrifted\n`)
+    const before = snapshot(ctx.root)
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    // The drifted state matters: it is the reporting path, where the compile
+    // path would rewrite artifacts and delete leftovers. A green run proves
+    // nothing about whether the gate writes.
+    assert(run.status === 1, `precondition: the tree must be drifted so the gate takes its reporting path (${run.status})`)
+    assert(
+      snapshot(ctx.root) === before,
+      '--check modified the repo — it is a gate, and a gate that fixes the thing it measures can never fail',
+    )
+    assert(
+      readdirSync(ctx.home).length === 0,
+      `--check wrote into the home dir: ${readdirSync(ctx.home).join(', ')} — codex/pi artifacts are per-machine and CI must never touch them`,
+    )
+  })
+})
+
+await test('every target is classified, and the classification matches where the compiler writes (#7253)', () => {
+  withFixture((ctx) => {
+    // --check gates the repo-local targets and refuses the rest, so this
+    // classification decides both what is protected and what CI may touch. A
+    // table that said "repo-local" about a target writing into $HOME would point
+    // the gate at a path it must never read; one that said "user-global" about a
+    // committed target would leave those artifacts silently ungated. Assert it
+    // against where the compiler ACTUALLY writes rather than trusting the flag.
+    assert(ALL_TARGETS.length > 0 && REPO_LOCAL_TARGETS.length > 0, 'precondition: both target lists are non-empty')
+    for (const target of ALL_TARGETS) {
+      const home = pjoin(ctx.dir, `home-${target}`)
+      mkdirSync(home, { recursive: true })
+      const repoBefore = snapshot(ctx.root)
+      const run = runCompiler(ctx.script, ['--repo', ctx.root, '--targets', target], home, ctx.dir)
+      assert(run.status === 0, `compiling --targets ${target} failed (${run.status}): ${run.stderr}`)
+      const repoChanged = snapshot(ctx.root) !== repoBefore
+      const wroteHome = readdirSync(home).length > 0
+      if (REPO_LOCAL_TARGETS.includes(target)) {
+        assert(repoChanged, `${target} is classified repo-local but wrote nothing into the repo`)
+        assert(!wroteHome, `${target} is classified repo-local but wrote into $HOME — --check would reach a path CI must never touch`)
+      } else {
+        assert(wroteHome, `${target} is classified user-global but wrote nothing into $HOME`)
+        assert(!repoChanged, `${target} is classified user-global but wrote into the repo — those artifacts are committed and --check skips them`)
+      }
+    }
+  })
+})
+
+await test('checkDrift throws on a non-repo-local target rather than reaching into $HOME (#7253)', () => {
+  // main() refuses these, but checkDrift is EXPORTED: a caller passing ['codex']
+  // would have emitCodex resolve real ~/.codex paths inside a function whose
+  // contract says it never touches a home dir. Derived from the table, so a new
+  // user-global target is covered the day it lands.
+  const repoRoot = resolve(__dirname, '..', '..')
+  const userGlobal = ALL_TARGETS.filter((t) => !REPO_LOCAL_TARGETS.includes(t))
+  assert(userGlobal.length > 0, 'precondition: there is at least one user-global target')
+  for (const target of [...userGlobal, 'not-a-target']) {
+    let threw = null
+    try {
+      checkDrift(repoRoot, [target])
+    } catch (err) {
+      threw = err
+    }
+    assert(threw, `checkDrift accepted ${target} — it would resolve paths outside the repo`)
+    assert(
+      /not a repo-local target/.test(threw.message),
+      `checkDrift(${target}) threw for the wrong reason: ${threw.message}`,
+    )
+  }
 })
 
 // --- summary --------------------------------------------------------------

--- a/scripts/__tests__/compile-skill-targets.test.mjs
+++ b/scripts/__tests__/compile-skill-targets.test.mjs
@@ -27,7 +27,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const helperPath = resolve(__dirname, '..', 'compile-skill-targets.mjs')
 
-const { deriveDescription, detectUncompiledAgents, emitPi, ALL_TARGETS, REPO_LOCAL_TARGETS, checkDrift } =
+const { deriveDescription, detectUncompiledAgents, emitPi, ALL_TARGETS, REPO_LOCAL_TARGETS, checkDrift, listArtifacts } =
   await import(helperPath)
 
 let pass = 0
@@ -516,7 +516,7 @@ await test('importing the module does NOT run its CLI (the other direction, #723
 //
 // AGENTS.md — a generated mirror of the same class, and strictly less
 // load-bearing since it changes no agent's behaviour — has had this gate since
-// #7198. These are its counterpart.
+// #6491. These are its counterpart.
 //
 // Four of the tests below cover a way an artifact can be wrong that a naive
 // "do the bytes match?" check passes silently: an artifact that does not exist
@@ -599,16 +599,26 @@ const assertDetected = (run, kind, file) => {
 // --- the real repo ---------------------------------------------------------
 await test('committed skill artifacts are in sync with .claude/commands (drift gate, #7253)', () => {
   const repoRoot = resolve(__dirname, '..', '..')
-  const { names, compared, problems } = checkDrift(repoRoot, REPO_LOCAL_TARGETS)
+  const { names, compared, skipped, problems } = checkDrift(repoRoot, REPO_LOCAL_TARGETS)
   // Both counters are the same refusal the CLI applies, asserted here so this
   // test cannot go vacuous if the source directory is ever moved out from under
   // it: with no sources there is nothing to compare and `problems` is empty,
   // which would otherwise read as a pass.
   assert(names.length > 0, `no skill sources under ${repoRoot}/.claude/commands — this test checked NOTHING`)
+  // Every (source, target) pair must be accounted for as either byte-compared or
+  // explicitly skipped. Asserting `compared === names x targets` instead would be
+  // WRONG the moment a target legitimately skips a skill — and it was: the gemini
+  // emitter refuses 5 of the 31 real sources, so the equality only held because
+  // `compared` was counting skips it had never compared, overstating the gate's own
+  // coverage self-report by exactly those 5.
   assert(
-    compared === names.length * REPO_LOCAL_TARGETS.length,
-    `compared ${compared} artifact(s) for ${names.length} source(s) x ${REPO_LOCAL_TARGETS.length} target(s) — the target loop did not run to completion`,
+    compared + skipped === names.length * REPO_LOCAL_TARGETS.length,
+    `${compared} compared + ${skipped} skipped != ${names.length} source(s) x ${REPO_LOCAL_TARGETS.length} target(s) — the target loop did not run to completion`,
   )
+  // Pin that the skip path is genuinely exercised by the real repo, so the sum
+  // above cannot silently degenerate into the old equality.
+  assert(skipped > 0, 'no source was skipped for any target — the skip accounting is untested by the real repo')
+  assert(compared > 0, 'nothing was byte-compared — the gate would be vacuous')
   assert(
     problems.length === 0,
     'compiled skill artifacts are stale — run `node scripts/compile-skill-targets.mjs --targets ' +
@@ -618,15 +628,26 @@ await test('committed skill artifacts are in sync with .claude/commands (drift g
 })
 
 // --- the gate, end to end --------------------------------------------------
-await test('--check is green on a freshly compiled tree, and says what it checked (#7253)', () => {
+await test('--check is green on a freshly compiled tree, and its accounting adds up (#7253)', () => {
   withFixture((ctx) => {
     addSource(ctx.root, 'keeper', KEEPER_BODY)
+    addSource(ctx.root, 'unsafe', GEMINI_UNSAFE_BODY)
     const clean = compileThenCheck(ctx)
     // "in sync" with a zero count is the vacuous pass this gate must never
-    // report, so pin the count rather than the word.
+    // report, so pin the NUMBERS, not the word — and pin them end to end through
+    // the CLI, which is the only place the arithmetic is visible to a human.
+    //
+    // 3 sources x 2 targets = 6 pairs. gemini refuses `unsafe`, so exactly 5 were
+    // byte-compared and 1 was skipped (and verified absent). Counting the skip as
+    // a comparison — which it was, until the review — overstates the gate's own
+    // coverage, which is the one number a gate must not inflate.
     assert(
-      /in sync: 2 skill\(s\) x 2 target\(s\)/.test(clean.stdout),
-      `the gate must report how much it actually compared:\n${clean.stdout}`,
+      /in sync: 3 skill\(s\) x 2 target\(s\)/.test(clean.stdout),
+      `the gate must report the breadth it checked:\n${clean.stdout}`,
+    )
+    assert(
+      /5 artifact\(s\) compared, 1 not emittable/.test(clean.stdout),
+      `compared/skipped must be reported separately and add to 6:\n${clean.stdout}`,
     )
   })
 })
@@ -844,7 +865,128 @@ await test('checkDrift throws on a non-repo-local target rather than reaching in
   }
 })
 
+await test('--check sees a SYMLINKED orphan, which a dirent-typed scan drops (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    compileThenCheck(ctx)
+    // git stores symlinks (mode 120000), so this state is committable, and
+    // Claude's loader follows the link — the skill LOADS. But a readdirSync
+    // Dirent describes the link itself, so isDirectory()/isFile() are both false
+    // and an entry filtered on those vanishes from the orphan scan while the gate
+    // reports full sync. The `ungated` backstop calls the same enumeration, so it
+    // went blind too: the guard that exists to stop "cannot check this" reading as
+    // "nothing to check" fell to that exact shape.
+    symlinkSync(pjoin(ctx.root, '.claude', 'skills', 'demo'), pjoin(ctx.root, '.claude', 'skills', 'sym-orphan'))
+    symlinkSync(pjoin(ctx.root, '.gemini', 'commands', 'demo.toml'), pjoin(ctx.root, '.gemini', 'commands', 'sym-orphan.toml'))
+    // Positive control: the loader really can reach a SKILL.md through the link,
+    // so this is a skill that runs — not an inert file the gate may ignore.
+    assert(
+      existsSync(pjoin(ctx.root, '.claude', 'skills', 'sym-orphan', 'SKILL.md')),
+      'precondition: the symlinked skill must be loadable, or this tests nothing',
+    )
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assertDetected(run, 'ORPHAN', '.claude/skills/sym-orphan/SKILL.md')
+    assertDetected(run, 'ORPHAN', '.gemini/commands/sym-orphan.toml')
+  })
+})
+
+await test('--check with no --targets reads the profile — the way CI invokes it (#7253)', () => {
+  withFixture((ctx) => {
+    writeFileSync(pjoin(ctx.root, '.claude', 'skill-profile.md'), 'targets: claude, gemini\n')
+    const built = runCompiler(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assert(built.status === 0, `fixture compile failed: ${built.stderr}`)
+    // Every other test here passes --targets explicitly. Without this one,
+    // targetsFromProfile is executed by NO test at all — and it is the only thing
+    // that decides what the CI step actually checks (ci.yml runs `--check` bare).
+    const run = runCheck(ctx.script, ['--repo', ctx.root], ctx.home, ctx.dir)
+    assert(run.status === 0, `expected 0, got ${run.status}:\n${run.stdout}${run.stderr}`)
+    assert(
+      /2 target\(s\) \[claude, gemini\]/.test(run.stdout),
+      `the profile's targets must be the ones checked:\n${run.stdout}`,
+    )
+  })
+})
+
+await test('--check refuses when the profile leaves no repo-local target to check (#7253)', () => {
+  withFixture((ctx) => {
+    writeFileSync(pjoin(ctx.root, '.claude', 'skill-profile.md'), 'targets: codex, pi\n')
+    // Both are dropped as user-global, leaving an EMPTY target list. Without the
+    // refusal the gate prints "in sync — 0 artifact(s) compared" and exits 0: the
+    // vacuous pass in its purest form, on the exact bare-`--check` path CI takes.
+    const run = runCheck(ctx.script, ['--repo', ctx.root], ctx.home, ctx.dir)
+    assert(run.status === 1, `expected a refusal, got ${run.status}:\n${run.stdout}`)
+    assert(
+      /no repo-local targets to check/.test(run.stderr),
+      `exit 1 must name the reason:\n${run.stderr}`,
+    )
+    assert(readdirSync(ctx.home).length === 0, 'refusing still created a user-global agent dir')
+  })
+})
+
+await test('an unrecognised argument is fatal and compiles nothing (#7253)', () => {
+  withFixture((ctx) => {
+    const before = snapshot(ctx.root)
+    // Silently ignoring it meant one fat-fingered flag changed what the program
+    // DOES: `--chekc` fell through to the COMPILE path, rewrote every artifact in
+    // the checked-out tree, printed "Done." and exited 0 — a CI step that verified
+    // nothing, mutated the workspace, and reported success.
+    const run = runCompiler(ctx.script, ['--repo', ctx.root, '--targets', 'claude', '--chekc'], ctx.home, ctx.dir)
+    assert(run.status === 1, `an unknown argument must be fatal, got ${run.status}:\n${run.stdout}`)
+    assert(/Unknown argument: --chekc/.test(run.stderr), `the refusal must name the argument:\n${run.stderr}`)
+    assert(!/Compiling/.test(run.stdout), `it took the COMPILE path anyway:\n${run.stdout}`)
+    assert(snapshot(ctx.root) === before, 'a run refused for an unknown argument still mutated the repo')
+  })
+})
+
+await test('the remediation printed matches the problem kind (#7253)', () => {
+  withFixture((ctx) => {
+    addSource(ctx.root, 'keeper', KEEPER_BODY)
+    compileThenCheck(ctx)
+    rmSync(pjoin(ctx.root, '.claude', 'commands', 'demo.md'))
+    const run = runCheck(ctx.script, ['--repo', ctx.root, '--targets', 'claude,gemini'], ctx.home, ctx.dir)
+    assertDetected(run, 'ORPHAN', '.claude/skills/demo/SKILL.md')
+    // Recompiling cannot clear an ORPHAN — there is no source left to compile
+    // from. A remediation that does not remediate reads as "the gate is broken"
+    // rather than "here is the fix", which is how a real gate gets disabled.
+    const fix = run.stderr.split('\n').find((l) => l.trim().startsWith('ORPHAN:'))
+    assert(fix, `no ORPHAN remediation line:\n${run.stderr}`)
+    assert(/Delete the artifact/.test(fix), `the ORPHAN fix must say delete, not recompile: ${fix}`)
+    assert(!/--targets/.test(fix), `the ORPHAN fix names a recompile that cannot help: ${fix}`)
+  })
+})
+
+await test('listArtifacts refuses a target it cannot enumerate instead of returning [] (#7253)', () => {
+  // The ORPHAN scan and the UNGATED backstop are both built on this enumeration.
+  // Returning [] for a target with no layout would switch BOTH off for that target
+  // while its STALE/MISSING checks kept passing — half-gated, and indistinguishable
+  // from fully gated. "Cannot enumerate this" must not read as "there was nothing
+  // to enumerate" (docs/false-safety-guards.md).
+  //
+  // Reached without mutating the target table: codex and pi are real entries that
+  // carry no layout, because their artifacts live outside the repo entirely.
+  const repoRoot = resolve(__dirname, '..', '..')
+  const noLayout = ALL_TARGETS.filter((t) => !REPO_LOCAL_TARGETS.includes(t))
+  assert(noLayout.length > 0, 'precondition: at least one target has no repo-local layout')
+  for (const target of noLayout) {
+    let threw = null
+    try {
+      listArtifacts(repoRoot, target)
+    } catch (err) {
+      threw = err
+    }
+    assert(threw, `listArtifacts('${target}') returned instead of refusing — orphan detection would silently do nothing`)
+    assert(/has no layout/.test(threw.message), `refused for the wrong reason: ${threw.message}`)
+  }
+  // Positive control: the same call DOES enumerate for a target that has a layout,
+  // so the assertions above cannot be satisfied by a function that always throws.
+  for (const target of REPO_LOCAL_TARGETS) {
+    const found = listArtifacts(repoRoot, target)
+    assert(found.length > 0, `listArtifacts('${target}') found no artifacts in the real repo — the enumeration is broken`)
+  }
+})
+
 // --- summary --------------------------------------------------------------
+
 process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
 if (fail > 0) {
   for (const f of failures) {

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -22,7 +22,7 @@
 //                                                        # artifact is stale (CI gate)
 //
 // Exit non-zero on emit failure so /skill and CI can gate on it.
-import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, statSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { homedir } from 'node:os'
 
@@ -71,6 +71,16 @@ function parseArgs(argv) {
     else if (a === '--repo') out.repo = need(i++, a)
     else if (a === '--dry-run') out.dryRun = true
     else if (a === '--check') out.check = true
+    // An UNRECOGNISED argument is fatal, not ignorable. Ignoring it meant one
+    // fat-fingered flag silently changed what the program does: `--chekc` fell
+    // through to the COMPILE path, rewrote every artifact in the checked-out
+    // tree, printed "Done." and exited 0 — a CI step that verified nothing,
+    // mutated the workspace, and reported success. "Never ran" must not be
+    // indistinguishable from "passed" (docs/false-safety-guards.md).
+    else {
+      console.error(`Unknown argument: ${a}. Known: --name <name>, --targets <list>, --repo <root>, --dry-run, --check.`)
+      process.exit(1)
+    }
   }
   return out
 }
@@ -167,17 +177,24 @@ function yamlDq(s) {
 // `dir` is the artifact root, repo-relative. `artifact` maps a skill name to its
 // repo-relative path; `nameOf` is the inverse over a direct child of `dir`,
 // returning null for anything that is not one of this target's artifacts.
+// `nameOf` takes the entry name and its RESOLVED kind ('dir' | 'file' | null),
+// resolved through symlinks by the caller. It must not re-derive the kind from a
+// readdirSync Dirent: a Dirent reports the link itself, so a committed symlink
+// (git mode 120000) is neither isFile() nor isDirectory() and an entry filtered
+// on those reads as "not an artifact" — while Claude's loader follows it happily.
+// A symlinked orphan therefore loaded as a skill with the gate reporting full
+// sync, and the UNGATED backstop inherited the same blindness.
 const CLAUDE_LAYOUT = {
   dir: '.claude/skills',
   artifact: (name) => join('.claude/skills', name, 'SKILL.md'),
   // A skill is a DIRECTORY here; a dir with no SKILL.md is separately reported
   // as MISSING when it has a source, and as an ORPHAN when it does not.
-  nameOf: (entry) => (entry.isDirectory() ? entry.name : null),
+  nameOf: (name, kind) => (kind === 'dir' ? name : null),
 }
 const GEMINI_LAYOUT = {
   dir: '.gemini/commands',
   artifact: (name) => join('.gemini/commands', `${name}.toml`),
-  nameOf: (entry) => (entry.isFile() && entry.name.endsWith('.toml') ? entry.name.slice(0, -'.toml'.length) : null),
+  nameOf: (name, kind) => (kind === 'file' && name.endsWith('.toml') ? name.slice(0, -'.toml'.length) : null),
 }
 
 // ---- emitters: (name, body, description, repo) -> { path, content } ----
@@ -339,15 +356,32 @@ export function listSkillNames(cmdDir) {
 // Every artifact currently on disk for a repo-local target, as { name, file }
 // (file is repo-relative). Uses the target's own layout, so it stays the inverse
 // of what the emitter writes.
-function listArtifacts(repo, target) {
+export function listArtifacts(repo, target) {
   const { layout } = TARGETS[target]
-  if (!layout) return []
+  // A repo-local target with no layout would silently return [], switching OFF
+  // both the ORPHAN scan and the UNGATED backstop for it while its STALE/MISSING
+  // checks kept passing — half-gated, and looking fully gated. Refuse instead:
+  // "cannot enumerate this" must never read as "there was nothing to enumerate".
+  if (!layout) {
+    throw new Error(`listArtifacts: repo-local target "${target}" has no layout, so its artifacts cannot be enumerated. Every repo-local target needs one.`)
+  }
   const dir = join(repo, layout.dir)
   if (!existsSync(dir)) return []
   const out = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const name = layout.nameOf(entry)
-    if (name) out.push({ name, file: layout.artifact(name) })
+  for (const name of readdirSync(dir)) {
+    // statSync FOLLOWS symlinks; a readdirSync Dirent describes the link itself.
+    // Resolving here is what lets a symlinked artifact be seen at all (see the
+    // layout comments). A broken link or an unreadable entry resolves to null and
+    // is skipped — it cannot load as a skill either, so it is not drift.
+    let kind = null
+    try {
+      const st = statSync(join(dir, name))
+      kind = st.isDirectory() ? 'dir' : st.isFile() ? 'file' : null
+    } catch {
+      kind = null
+    }
+    const artifactName = layout.nameOf(name, kind)
+    if (artifactName) out.push({ name: artifactName, file: layout.artifact(artifactName) })
   }
   return out
 }
@@ -369,7 +403,7 @@ function listArtifacts(repo, target) {
  * only the obvious one (the bytes differ) is how a gate of this shape would
  * still have missed `catchup`, which had a source and no artifact whatsoever.
  *
- * @returns {{names: string[], targets: string[], compared: number, problems: object[]}}
+ * @returns {{names: string[], targets: string[], compared: number, skipped: number, problems: object[]}}
  */
 export function checkDrift(repo, targets) {
   const rejected = targets.filter((t) => !TARGETS[t] || !TARGETS[t].repoLocal)
@@ -381,6 +415,7 @@ export function checkDrift(repo, targets) {
   const known = new Set(names)
   const problems = []
   let compared = 0
+  let skipped = 0
 
   for (const name of names) {
     const body = stripStamp(readFileSync(join(cmdDir, `${name}.md`), 'utf8'))
@@ -388,8 +423,11 @@ export function checkDrift(repo, targets) {
     for (const target of targets) {
       const { path, content, skip } = TARGETS[target].emit(name, body, description, repo)
       const file = relative(repo, path)
-      compared++
       if (skip) {
+        // Counted separately: this pair was never byte-compared, and folding it
+        // into `compared` overstated the gate's own coverage self-report by
+        // exactly the 5 Gemini-unsafe skills.
+        skipped++
         // The compile path DELETES a leftover artifact here (compileOne's
         // removeStale). --check writes nothing, so it has to report the same
         // condition instead — otherwise an artifact from before the skill became
@@ -397,6 +435,7 @@ export function checkDrift(repo, targets) {
         if (existsSync(path)) problems.push({ kind: 'unexpected', target, name, file, detail: skip })
         continue
       }
+      compared++
       if (!existsSync(path)) {
         problems.push({ kind: 'missing', target, name, file })
         continue
@@ -428,7 +467,7 @@ export function checkDrift(repo, targets) {
     }
   }
 
-  return { names, targets, compared, problems }
+  return { names, targets, compared, skipped, problems }
 }
 
 const PROBLEM_DETAIL = {
@@ -439,6 +478,19 @@ const PROBLEM_DETAIL = {
   ungated: (p) => `${p.count} committed artifact(s) present but "${p.target}" is not in the checked targets`,
 }
 
+// What the developer should DO, per kind. One generic "recompile and commit"
+// line is a no-op for three of the five: recompiling cannot clear an ORPHAN
+// (there is no source to compile), and it cannot clear an UNGATED (the cause is
+// the target list, not the artifacts). A remediation that does not remediate is
+// worse than none — it reads as "the gate is broken" rather than "here is the fix".
+const PROBLEM_FIX = {
+  missing: (targets) => `Run \`node scripts/compile-skill-targets.mjs --targets ${targets.join(',')}\` and commit the result.`,
+  stale: (targets) => `Run \`node scripts/compile-skill-targets.mjs --targets ${targets.join(',')}\` and commit the result.`,
+  unexpected: (targets) => `Delete the leftover artifact(s) above — or run \`node scripts/compile-skill-targets.mjs --targets ${targets.join(',')}\`, which removes them.`,
+  orphan: () => 'Delete the artifact(s) above, or restore the deleted .claude/commands/<name>.md.',
+  ungated: () => 'Fix the `targets:` line in .claude/skill-profile.md so the target is checked — or, if it is genuinely retired, delete its committed artifacts.',
+}
+
 // Run the gate and report. Returns the process exit code (0 in sync, 1 on drift
 // or on a condition that would make the gate vacuous).
 function runCheck(repo, targets) {
@@ -446,7 +498,7 @@ function runCheck(repo, targets) {
     console.error('::error::--check: no repo-local targets to check. Nothing would be verified.')
     return 1
   }
-  const { names, compared, problems } = checkDrift(repo, targets)
+  const { names, compared, skipped, problems } = checkDrift(repo, targets)
   // A gate that checked nothing must never report success. An empty
   // .claude/commands/ makes every loop below a no-op and every artifact an
   // ORPHAN, so say so plainly rather than emitting a wall of orphans.
@@ -454,15 +506,28 @@ function runCheck(repo, targets) {
     console.error(`::error::--check found no skill sources in ${join(repo, '.claude/commands')} — the gate would pass without checking anything.`)
     return 1
   }
+  // The gate's own accounting, checked. Every (source, target) pair must have
+  // been either byte-compared or explicitly skipped; anything else means a loop
+  // exited early and the "in sync" below would cover fewer artifacts than it
+  // claims. This is the one arithmetic the gate cannot get wrong silently.
+  const expected = names.length * targets.length
+  if (compared + skipped !== expected) {
+    console.error(`::error::--check accounting is wrong: ${compared} compared + ${skipped} skipped != ${expected} expected (${names.length} skill(s) x ${targets.length} target(s)). The target loop did not run to completion.`)
+    return 1
+  }
   if (problems.length) {
     console.error(`::error::Compiled skill artifacts are out of sync with .claude/commands/ (${problems.length} problem(s)).`)
     for (const p of problems) {
       console.error(`  ${p.kind.toUpperCase().padEnd(10)} [${p.target}] ${p.file} — ${PROBLEM_DETAIL[p.kind](p)}`)
     }
-    console.error(`\nRun \`node scripts/compile-skill-targets.mjs --targets ${targets.join(',')}\` and commit the result (deleting any ORPHAN/leftover artifact by hand).`)
+    // One line per kind PRESENT, so the fix shown is one that actually applies.
+    console.error('')
+    for (const kind of [...new Set(problems.map((p) => p.kind))]) {
+      console.error(`  ${kind.toUpperCase()}: ${PROBLEM_FIX[kind](targets)}`)
+    }
     return 1
   }
-  console.log(`Compiled skill artifacts are in sync: ${names.length} skill(s) x ${targets.length} target(s) [${targets.join(', ')}] — ${compared} artifact(s) compared.`)
+  console.log(`Compiled skill artifacts are in sync: ${names.length} skill(s) x ${targets.length} target(s) [${targets.join(', ')}] — ${compared} artifact(s) compared${skipped ? `, ${skipped} not emittable for their target (verified absent)` : ''}.`)
   return 0
 }
 

--- a/scripts/compile-skill-targets.mjs
+++ b/scripts/compile-skill-targets.mjs
@@ -18,15 +18,15 @@
 // Usage:
 //   node scripts/compile-skill-targets.mjs [--name <name>] [--targets claude,gemini]
 //        [--repo <root>] [--dry-run]
+//   node scripts/compile-skill-targets.mjs --check       # exit 1 if a committed
+//                                                        # artifact is stale (CI gate)
 //
 // Exit non-zero on emit failure so /skill and CI can gate on it.
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
-import { join, dirname } from 'node:path'
+import { join, dirname, relative } from 'node:path'
 import { homedir } from 'node:os'
 
 import { isEntryPoint } from './lib/is-entry-point.mjs'
-
-export const ALL_TARGETS = ['claude', 'gemini', 'codex', 'pi']
 
 // #6571 — home-dir marker(s) for coding agents whose skills are USER-GLOBAL and
 // OPT-IN. `codex` (`~/.codex/prompts/`) and `pi` (`~/.pi/agent/skills/`, #6573)
@@ -70,6 +70,7 @@ function parseArgs(argv) {
     else if (a === '--targets') out.targets = need(i++, a).split(',').map((s) => s.trim()).filter(Boolean)
     else if (a === '--repo') out.repo = need(i++, a)
     else if (a === '--dry-run') out.dryRun = true
+    else if (a === '--check') out.check = true
   }
   return out
 }
@@ -153,11 +154,37 @@ function yamlDq(s) {
   return '"' + dqEscape(s) + '"'
 }
 
+// ---- repo-local artifact layout ------------------------------------------
+//
+// ONE encoding of where each REPO-LOCAL target's artifact lives, shared by the
+// emitter (which writes it) and by --check (which has to enumerate what is on
+// disk to spot an ORPHAN — an artifact whose source was deleted, which keeps
+// loading as a skill). A second, hand-maintained copy of these paths beside the
+// emitters is exactly the "hardcoded list next to a set that grows" shape that
+// docs/false-safety-guards.md names as this repo's recurring cause of guards
+// that silently check nothing (#7192, #7197).
+//
+// `dir` is the artifact root, repo-relative. `artifact` maps a skill name to its
+// repo-relative path; `nameOf` is the inverse over a direct child of `dir`,
+// returning null for anything that is not one of this target's artifacts.
+const CLAUDE_LAYOUT = {
+  dir: '.claude/skills',
+  artifact: (name) => join('.claude/skills', name, 'SKILL.md'),
+  // A skill is a DIRECTORY here; a dir with no SKILL.md is separately reported
+  // as MISSING when it has a source, and as an ORPHAN when it does not.
+  nameOf: (entry) => (entry.isDirectory() ? entry.name : null),
+}
+const GEMINI_LAYOUT = {
+  dir: '.gemini/commands',
+  artifact: (name) => join('.gemini/commands', `${name}.toml`),
+  nameOf: (entry) => (entry.isFile() && entry.name.endsWith('.toml') ? entry.name.slice(0, -'.toml'.length) : null),
+}
+
 // ---- emitters: (name, body, description, repo) -> { path, content } ----
 
 function emitClaude(name, body, description, repo) {
   return {
-    path: join(repo, '.claude/skills', name, 'SKILL.md'),
+    path: join(repo, CLAUDE_LAYOUT.artifact(name)),
     content: `---\ndescription: ${yamlDq(description)}\n---\n\n${body}`,
   }
 }
@@ -165,7 +192,7 @@ function emitClaude(name, body, description, repo) {
 function emitGemini(name, body, description, repo) {
   // Always report the path (even on skip) so the caller can clean up a stale
   // artifact from a previous compile.
-  const path = join(repo, '.gemini/commands', `${name}.toml`)
+  const path = join(repo, GEMINI_LAYOUT.artifact(name))
   // $ARGUMENTS is the neutral arg token; Gemini uses {{args}}.
   const prompt = body.replace(/\$ARGUMENTS\b/g, '{{args}}')
   // Gemini's prompt engine is active: it interprets {{...}}, !{...} (shell), and
@@ -244,7 +271,28 @@ export function emitPi(name, body, description) {
   }
 }
 
-const EMITTERS = { claude: emitClaude, gemini: emitGemini, codex: emitCodex, pi: emitPi }
+// ---- the target table ----------------------------------------------------
+//
+// The ONE place a target is declared. `repoLocal` says whether the target's
+// artifacts are version-controlled inside the repo (claude, gemini) or written
+// into a per-machine, opt-in home dir (codex -> ~/.codex, pi -> ~/.pi). --check
+// gates only the repo-local ones and must never so much as look at the others:
+// a home dir is not part of the commit, so "drift" there is meaningless, and CI
+// touching it would be a bug in its own right.
+//
+// ALL_TARGETS and REPO_LOCAL_TARGETS are DERIVED from this table rather than
+// written out again, so adding a target cannot leave a stale list behind.
+const TARGETS = {
+  claude: { emit: emitClaude, repoLocal: true, layout: CLAUDE_LAYOUT },
+  gemini: { emit: emitGemini, repoLocal: true, layout: GEMINI_LAYOUT },
+  codex: { emit: emitCodex, repoLocal: false },
+  pi: { emit: emitPi, repoLocal: false },
+}
+
+export const ALL_TARGETS = Object.keys(TARGETS)
+export const REPO_LOCAL_TARGETS = ALL_TARGETS.filter((t) => TARGETS[t].repoLocal)
+
+const EMITTERS = Object.fromEntries(ALL_TARGETS.map((t) => [t, TARGETS[t].emit]))
 
 function compileOne(name, srcPath, targets, repo, dryRun) {
   const raw = readFileSync(srcPath, 'utf8')
@@ -278,6 +326,146 @@ function compileOne(name, srcPath, targets, repo, dryRun) {
   return { name, description, results }
 }
 
+// The skill sources, from the ONE directory that defines them. Shared by the
+// compile path and by --check so the two can never disagree about what a source
+// is (a `--check` that enumerated sources differently would report phantom
+// ORPHANs, or miss a source entirely and pass).
+export function listSkillNames(cmdDir) {
+  return readdirSync(cmdDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, ''))
+}
+
+// Every artifact currently on disk for a repo-local target, as { name, file }
+// (file is repo-relative). Uses the target's own layout, so it stays the inverse
+// of what the emitter writes.
+function listArtifacts(repo, target) {
+  const { layout } = TARGETS[target]
+  if (!layout) return []
+  const dir = join(repo, layout.dir)
+  if (!existsSync(dir)) return []
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const name = layout.nameOf(entry)
+    if (name) out.push({ name, file: layout.artifact(name) })
+  }
+  return out
+}
+
+/**
+ * #7253 — the drift gate. Compare the COMMITTED artifacts of the repo-local
+ * targets against what this compiler produces from `.claude/commands/`.
+ *
+ * Strictly READ-ONLY: it never writes, never removes a stale artifact, and never
+ * resolves a path under `homedir()`. That is not incidental tidiness — codex and
+ * pi compile into `~/.codex` and `~/.pi`, which are per-machine, opt-in and not
+ * version-controlled, so CI must not touch them at all. It is also why a
+ * non-repo-local target is a THROW rather than a filter: main() already refuses
+ * one, but this is exported, and a caller that passed `['codex']` would have
+ * emitCodex resolve real `~/.codex` paths behind a function documented never to.
+ *
+ * Reports four ways an ARTIFACT can be wrong — stale, missing, should-not-exist,
+ * source-deleted — plus one way the GATE itself can be, in `ungated`. Checking
+ * only the obvious one (the bytes differ) is how a gate of this shape would
+ * still have missed `catchup`, which had a source and no artifact whatsoever.
+ *
+ * @returns {{names: string[], targets: string[], compared: number, problems: object[]}}
+ */
+export function checkDrift(repo, targets) {
+  const rejected = targets.filter((t) => !TARGETS[t] || !TARGETS[t].repoLocal)
+  if (rejected.length) {
+    throw new Error(`checkDrift: not a repo-local target: ${rejected.join(', ')}. Known repo-local targets: ${REPO_LOCAL_TARGETS.join(', ')}.`)
+  }
+  const cmdDir = join(repo, '.claude/commands')
+  const names = listSkillNames(cmdDir)
+  const known = new Set(names)
+  const problems = []
+  let compared = 0
+
+  for (const name of names) {
+    const body = stripStamp(readFileSync(join(cmdDir, `${name}.md`), 'utf8'))
+    const description = deriveDescription(body, name)
+    for (const target of targets) {
+      const { path, content, skip } = TARGETS[target].emit(name, body, description, repo)
+      const file = relative(repo, path)
+      compared++
+      if (skip) {
+        // The compile path DELETES a leftover artifact here (compileOne's
+        // removeStale). --check writes nothing, so it has to report the same
+        // condition instead — otherwise an artifact from before the skill became
+        // un-emittable keeps loading forever, and the gate says everything is fine.
+        if (existsSync(path)) problems.push({ kind: 'unexpected', target, name, file, detail: skip })
+        continue
+      }
+      if (!existsSync(path)) {
+        problems.push({ kind: 'missing', target, name, file })
+        continue
+      }
+      if (readFileSync(path, 'utf8') !== content) problems.push({ kind: 'stale', target, name, file })
+    }
+  }
+
+  // An artifact whose source is gone still loads as a skill. `/skill remove`
+  // deletes both, so this is a half-run removal or a hand-deleted source.
+  for (const target of targets) {
+    for (const { name, file } of listArtifacts(repo, target)) {
+      if (!known.has(name)) problems.push({ kind: 'orphan', target, name, file })
+    }
+  }
+
+  // A repo-local target that is NOT being checked but DOES have committed
+  // artifacts is a hole in the gate, not a non-event. `targetsFromProfile`
+  // returns null whenever the `targets:` line fails to match, and main() then
+  // falls back to ['claude'] — so a mangled profile line would leave every
+  // committed .gemini/commands/*.toml ungated while --check still exited 0.
+  // "Cannot check this" must not read as "there was nothing to check"
+  // (docs/false-safety-guards.md).
+  for (const target of REPO_LOCAL_TARGETS) {
+    if (targets.includes(target)) continue
+    const present = listArtifacts(repo, target)
+    if (present.length) {
+      problems.push({ kind: 'ungated', target, count: present.length, file: TARGETS[target].layout.dir })
+    }
+  }
+
+  return { names, targets, compared, problems }
+}
+
+const PROBLEM_DETAIL = {
+  missing: (p) => `never compiled from .claude/commands/${p.name}.md`,
+  stale: (p) => `differs from .claude/commands/${p.name}.md`,
+  unexpected: (p) => `not emittable for this target (${p.detail}) — the artifact is a leftover and must be deleted`,
+  orphan: (p) => `no .claude/commands/${p.name}.md — delete the artifact or restore the source`,
+  ungated: (p) => `${p.count} committed artifact(s) present but "${p.target}" is not in the checked targets`,
+}
+
+// Run the gate and report. Returns the process exit code (0 in sync, 1 on drift
+// or on a condition that would make the gate vacuous).
+function runCheck(repo, targets) {
+  if (!targets.length) {
+    console.error('::error::--check: no repo-local targets to check. Nothing would be verified.')
+    return 1
+  }
+  const { names, compared, problems } = checkDrift(repo, targets)
+  // A gate that checked nothing must never report success. An empty
+  // .claude/commands/ makes every loop below a no-op and every artifact an
+  // ORPHAN, so say so plainly rather than emitting a wall of orphans.
+  if (!names.length) {
+    console.error(`::error::--check found no skill sources in ${join(repo, '.claude/commands')} — the gate would pass without checking anything.`)
+    return 1
+  }
+  if (problems.length) {
+    console.error(`::error::Compiled skill artifacts are out of sync with .claude/commands/ (${problems.length} problem(s)).`)
+    for (const p of problems) {
+      console.error(`  ${p.kind.toUpperCase().padEnd(10)} [${p.target}] ${p.file} — ${PROBLEM_DETAIL[p.kind](p)}`)
+    }
+    console.error(`\nRun \`node scripts/compile-skill-targets.mjs --targets ${targets.join(',')}\` and commit the result (deleting any ORPHAN/leftover artifact by hand).`)
+    return 1
+  }
+  console.log(`Compiled skill artifacts are in sync: ${names.length} skill(s) x ${targets.length} target(s) [${targets.join(', ')}] — ${compared} artifact(s) compared.`)
+  return 0
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2))
   const repo = args.repo
@@ -293,6 +481,31 @@ function main() {
     process.exit(1)
   }
 
+  // #7253 — the drift gate. It answers a different question from the compile
+  // path ("does the commit already contain what the compiler produces?"), so it
+  // returns here rather than falling through into the writing loop below.
+  if (args.check) {
+    // --check is a repo-WIDE gate: it has to see every source to tell an orphan
+    // artifact from one whose source simply was not selected. Under --name every
+    // other committed artifact would be reported as an orphan.
+    if (args.name) {
+      console.error('::error::--check is a repo-wide gate and cannot be combined with --name.')
+      process.exit(1)
+    }
+    const nonLocal = targets.filter((t) => !TARGETS[t].repoLocal)
+    // Asked for explicitly -> refuse. codex/pi artifacts live in ~/.codex and
+    // ~/.pi: per-machine, opt-in, and deliberately not version-controlled, so
+    // there is no committed state for a gate to compare against.
+    if (args.targets && nonLocal.length) {
+      console.error(`::error::--check applies only to the repo-local targets (${REPO_LOCAL_TARGETS.join(', ')}). ${nonLocal.map((t) => `${t} -> ${AGENT_SKILL_DIRS[t]}`).join(', ')} — user-global, per-machine opt-in, and not version-controlled, so there is no committed state to compare against.`)
+      process.exit(1)
+    }
+    // Inherited from the profile -> drop them, but say so. Silence here would be
+    // indistinguishable from having checked them.
+    if (nonLocal.length) console.log(`--check: skipping ${nonLocal.join(', ')} (user-global, not version-controlled).`)
+    process.exit(runCheck(repo, targets.filter((t) => TARGETS[t].repoLocal)))
+  }
+
   // #6571 — nudge if a coding agent is installed but its target isn't selected.
   const uncompiled = detectUncompiledAgents(targets)
   if (uncompiled.length) {
@@ -304,7 +517,7 @@ function main() {
     console.log(`Hint: ${dirs} present but ${uncompiled.join(', ')} not a selected target — pass --targets ${[...targets, ...uncompiled].join(',')} to also compile into ${skillDirs} (see docs/dev-workflow-skills.md).`)
   }
 
-  const names = args.name ? [args.name] : readdirSync(cmdDir).filter((f) => f.endsWith('.md')).map((f) => f.replace(/\.md$/, ''))
+  const names = args.name ? [args.name] : listSkillNames(cmdDir)
   // `--name` is user-facing; a name with a path separator or `..` would let the
   // emitters write outside the intended dirs (incl. ~/.codex). Reject up front.
   const unsafe = names.filter((n) => /[/\\]/.test(n) || n.split(/[/\\]/).includes('..') || n.includes('..'))


### PR DESCRIPTION
Closes #7253.

`.claude/commands/<name>.md` is the neutral **source**; `.claude/skills/<name>/SKILL.md` is what Claude actually **loads** (the legacy `.claude/commands/` discovery is broken — anthropics/claude-code#31846), and `.gemini/commands/<name>.toml` is Gemini's. A stale artifact therefore means *the skill you edited is not the skill that runs*.

`AGENTS.md` has had a drift gate since #7198. These artifacts — same class of generator, sources in the same repo, and strictly more load-bearing since they change agent behaviour — had none. On pristine `origin/main`, 11 had drifted.

## What was wrong

| | |
|---|---|
| 6 × `.claude/skills/*/SKILL.md` + 4 × `.gemini/commands/*.toml` | real content drift, 508 inserted lines — `.gemini/commands/agent-review.toml` was missing a whole "Deciding vs escalating" paragraph its source carries |
| `catchup` | had a source and **no compiled artifact at all**, so the skill was not loadable |

## The gate

`node scripts/compile-skill-targets.mjs --check` compiles the repo-local targets in memory and diffs against what is committed. Five conditions, because "do the bytes match?" alone would have passed `catchup`:

| kind | |
|---|---|
| `STALE` | the artifact differs from its source |
| `MISSING` | the source was never compiled |
| `UNEXPECTED` | an artifact exists for a target that now **skips** the skill (the compile path deletes these; a read-only gate can only report them) |
| `ORPHAN` | an artifact whose source is gone — it still loads as a skill |
| `UNGATED` | a repo-local target has committed artifacts but is not among the checked targets |

`UNGATED` closes a hole the gate would otherwise have had *in itself*: `targetsFromProfile()` returns `null` for **any** `targets:` line it fails to match, and `main()` then falls back to `['claude']` — so one mangled character in `.claude/skill-profile.md` would leave every committed `.gemini/commands/*.toml` unchecked while `--check` still exited 0. Verified against a profile with the key misspelled.

## Scope and safety

- **Strictly read-only.** Asserted by snapshotting the entire fixture tree (content-addressed, not mtime) across a run that had drift to report — the reporting path, where the compile path would rewrite artifacts and delete leftovers.
- **`codex`/`pi` are never touched.** They compile into `~/.codex` and `~/.pi`: per-machine, opt-in, not version-controlled. `--check` refuses them, and `checkDrift()` **throws** rather than filtering, because it is exported and a caller passing `['codex']` would have `emitCodex` resolve real home-dir paths behind a function documented never to.
- The repo-local/user-global split now lives on the **target table**, with `ALL_TARGETS` and `REPO_LOCAL_TARGETS` derived from it. A hardcoded second list beside a growing set is the shape [`docs/false-safety-guards.md`](docs/false-safety-guards.md) names as this repo's recurring cause (#7192, #7197).
- `--check` refuses `--name` (every other artifact would read as an orphan) and refuses an empty `.claude/commands` rather than reporting success.

## Proof it fails

Per `docs/false-safety-guards.md`, a gate that has not been seen to fail is not a gate.

**14 new tests, 37 total** (was 23). A 13-mutation battery breaks one behaviour per run and requires the suite to go red **via the test that owns it** — each report branch removed in turn, the entry-point guard hardwired `false` (the #7198/#7236 silent no-op), `codex` misclassified as repo-local, `checkDrift`'s refusal removed, the `compared` counter frozen. **13/13 detected**, restore green.

Two of those deserve calling out:

- Every drift test asserts the **message**, never the exit code alone — `node` exits 1 for an uncaught module-load error too, so a bare status check cannot tell "the gate detected drift" from "the gate never ran" (#7214's lesson).
- The classification test asserts against **where the compiler actually writes**, not against the flag, and derives its user-global cases from the table so a new target is covered the day it lands.

Verified in the **committed** tree (`git archive <rev> | tar -x`), not the working tree, for both commits independently — each is green on its own.

## Note on enforcement

`Scripts Tests` is still not a required status context (#7199 / #7216, owner-only), so this gate **runs** on every PR but does not yet **block** merge. That is the same limitation every test added in #7251 has, and it is the one thing here that is not fixable from a PR.
