### PR TITLE
test(server): cover the two server isEntryPoint call sites

### DIFF
--- a/packages/server/tests/entry-point-call-sites.test.js
+++ b/packages/server/tests/entry-point-call-sites.test.js
@@ -38,14 +38,20 @@
  * file that touches the modules only through `fork`/`spawn` is what lets the
  * stuck-TRUE direction fail as a NAMED assertion instead.
  *
- * ── Why nothing here asserts on exit status ────────────────────────────────
+ * ── Why exit status is never the primary evidence ──────────────────────────
  *
  * The failure this whole area exists to catch (#7198) is a guard that reads
  * false: the module body never runs, so the process exits 0 having done
- * nothing. Exit 0 is what the bug looks like AND what success looks like. Every
- * assertion below is therefore an OBSERVABLE SIDE EFFECT — a bound port, an IPC
- * frame, a JSON-RPC notification on stdout — each of which is absent when the
- * body did not run.
+ * nothing. Exit 0 is what the bug looks like AND what success looks like, so on
+ * its own it distinguishes nothing. What each test below turns on is therefore
+ * an OBSERVABLE SIDE EFFECT — a bound port, an IPC frame, a JSON-RPC
+ * notification on stdout — each of which is absent when the body did not run.
+ *
+ * Exit status is asserted too, but always as a bounded secondary check and
+ * never as the thing that decides a test. In the stuck-TRUE direction it is
+ * genuinely informative rather than redundant: an importer that started a
+ * server never exits, so a clean exit within a deadline is a third independent
+ * symptom alongside "nothing bound" and "no ready frame".
  *
  * ── Why each negative assertion is paired with a positive control ──────────
  *

--- a/packages/server/tests/entry-point-call-sites.test.js
+++ b/packages/server/tests/entry-point-call-sites.test.js
@@ -1,0 +1,387 @@
+/**
+ * CALL-SITE coverage for the two server modules that decide whether to run
+ * `main()` with the shared `isEntryPoint()` guard (#7254).
+ *
+ *   src/server-cli-child.js            const isModuleEntryPoint = isEntryPoint(import.meta.url)
+ *   src/channels/chroxy-channel-server.js   const isDirectRun = isEntryPoint(import.meta.url)
+ *
+ * The guard itself is thoroughly covered — three un-mergeable copies, a drift
+ * gate (scripts/__tests__/is-entry-point.test.mjs), a lint that forbids a
+ * fourth (scripts/lint-entry-point-guard.mjs) and unit tests
+ * (tests/is-entry-point.test.js). What had no coverage was the CALL SITES:
+ * whether `node server-cli-child.js` actually starts the child, and whether
+ * importing it actually stays quiet. Both modules have test files, and both
+ * only ever import the module and exercise its exports — the exact asymmetry
+ * #7236 was filed about, closed there for the two `scripts/` call sites and
+ * here for the two server ones.
+ *
+ * ── Why this is a SEPARATE FILE, and the one rule it lives by ──────────────
+ *
+ * NOTHING HERE MAY IMPORT EITHER MODULE UNDER TEST AT MODULE SCOPE.
+ *
+ * That is not tidiness. One of the two failure directions is "the guard reads
+ * TRUE when the module was merely imported", and its symptom is that importing
+ * the module runs `main()`. A test file that imports the module is therefore
+ * disabled by the very bug it is trying to detect, and it fails in a way that
+ * names nothing:
+ *
+ *   - hardwiring server-cli-child's guard true makes tests/server-cli-child.test.js
+ *     die during its own top-level import (main() runs, finds no API token, and
+ *     calls process.exit(1)). The runner reports `tests/server-cli-child.test.js
+ *     failed` — one anonymous failure, no assertion, no clue.
+ *   - hardwiring chroxy-channel-server's guard true makes
+ *     tests/chroxy-channel-server.test.js bind 8788 and HANG forever at import,
+ *     because the server suite has run without `--test-force-exit` since #6042.
+ *     A hang is a CI timeout, not a test failure.
+ *
+ * Verified: both of those are what actually happens. Keeping these tests in a
+ * file that touches the modules only through `fork`/`spawn` is what lets the
+ * stuck-TRUE direction fail as a NAMED assertion instead.
+ *
+ * ── Why nothing here asserts on exit status ────────────────────────────────
+ *
+ * The failure this whole area exists to catch (#7198) is a guard that reads
+ * false: the module body never runs, so the process exits 0 having done
+ * nothing. Exit 0 is what the bug looks like AND what success looks like. Every
+ * assertion below is therefore an OBSERVABLE SIDE EFFECT — a bound port, an IPC
+ * frame, a JSON-RPC notification on stdout — each of which is absent when the
+ * body did not run.
+ *
+ * ── Why each negative assertion is paired with a positive control ──────────
+ *
+ * "The port stayed closed" and "no ready frame arrived" pass just as happily
+ * when the staged file failed to import, when the path was wrong, or when the
+ * child died on startup. Each stuck-TRUE test below therefore proves its own
+ * observation can see the effect when it IS present, before it is allowed to
+ * report absence.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { fork, spawn } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  allocatePort,
+  attach,
+  exitCodeWithin,
+  expectNeverListening,
+  makeTempDir,
+  removeTempDir,
+  terminate,
+  waitForListening,
+  waitForOutput,
+  waitUntil,
+} from './helpers/entry-point-call-site.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CHANNEL_SERVER = resolve(__dirname, '..', 'src', 'channels', 'chroxy-channel-server.js')
+const SUPERVISED_CHILD = resolve(__dirname, '..', 'src', 'server-cli-child.js')
+
+// Spelled out rather than imported from the module, for the reason in the
+// header. tests/chroxy-channel-server.test.js already pins the module's own
+// constant to this same literal, so the two cannot drift apart silently.
+const CHANNEL_NOTIFICATION_METHOD = 'notifications/claude/channel'
+
+const tempDirs = []
+after(() => { for (const d of tempDirs) removeTempDir(d) })
+
+const stageDir = (prefix) => {
+  const dir = makeTempDir(prefix)
+  tempDirs.push(dir)
+  return dir
+}
+
+// A staged file, never `node -e`. Under `-e` there is no argv[1] at all, so
+// isEntryPoint returns false on its very first line and never reaches the path
+// comparison that actually decides this — the test would pass without
+// exercising the branch it exists to cover (#7236).
+const stageScript = (dir, name, source) => {
+  const file = join(dir, name)
+  writeFileSync(file, source)
+  return file
+}
+
+/** The module under test, as a specifier a staged script can `import()`. */
+const moduleUrl = (target) => JSON.stringify(pathToFileURL(target).href)
+
+describe('entry-point call site: chroxy-channel-server.js (#7254)', () => {
+  const launch = (entry, port) => attach(spawn(process.execPath, [entry], {
+    // stdin stays an open pipe: StdioServerTransport reads it, and closing it
+    // would tear the child down before the assertions run.
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CHROXY_CHANNEL_PORT: String(port) },
+  }))
+
+  it('running the module directly binds the control surface and forwards a POST onto the channel', async () => {
+    const port = await allocatePort()
+    const { child, stdout, stderr } = launch(CHANNEL_SERVER, port)
+    try {
+      const bound = await waitForListening(port)
+      // A guard stuck false lands exactly here: child alive, idle and silent.
+      assert.ok(
+        bound,
+        `nothing bound 127.0.0.1:${port} — main() never ran, so the entry-point guard read false.\n` +
+        `stderr: ${JSON.stringify(stderr())}\nstdout: ${JSON.stringify(stdout())}`,
+      )
+
+      const res = await fetch(`http://127.0.0.1:${port}/probe`, { method: 'POST', body: 'call-site-probe' })
+      assert.equal(res.status, 200)
+      assert.equal(await res.text(), 'ok')
+
+      // Stronger than "a port is open": the POST has to come back out of the
+      // MCP stdio transport as a channel notification, which proves main() ran
+      // all three of its steps — createChannelServer(), mcp.connect(stdio) and
+      // startHttpControlSurface() — not merely that something is listening.
+      const forwarded = await waitForOutput(stdout, (t) => t.includes(CHANNEL_NOTIFICATION_METHOD))
+      assert.ok(forwarded, `no channel notification reached stdout:\n${JSON.stringify(stdout())}`)
+      const line = stdout().trim().split('\n').find((l) => l.includes(CHANNEL_NOTIFICATION_METHOD))
+      const frame = JSON.parse(line)
+      assert.equal(frame.method, CHANNEL_NOTIFICATION_METHOD)
+      assert.equal(frame.params.content, 'call-site-probe')
+      assert.equal(frame.params.meta.path, '/probe')
+    } finally {
+      await terminate(child)
+    }
+  })
+
+  // POSITIVE CONTROL for the test after it, and the reason that test means
+  // anything. It runs the SAME harness — same staged-file shape, same env, same
+  // port observation — differing only in that it calls main() itself. If this
+  // ever fails, the test below proves nothing and should be read as broken
+  // rather than green.
+  it('positive control: the same staged-importer harness DOES bind when main() is called', async () => {
+    const dir = stageDir('chroxy-channel-ctl-')
+    const port = await allocatePort()
+    // Deliberately calls main() itself. `main` is exported by this module, so
+    // the control invokes exactly what the guard would have invoked.
+    const control = stageScript(
+      dir,
+      'control.mjs',
+      `const m = await import(${moduleUrl(CHANNEL_SERVER)})\nawait m.main()\n`,
+    )
+    const { child, stdout, stderr } = launch(control, port)
+    try {
+      assert.ok(
+        await waitForListening(port),
+        `the control did not bind 127.0.0.1:${port}, so the import test below cannot distinguish anything.\n` +
+        `stderr: ${JSON.stringify(stderr())}\nstdout: ${JSON.stringify(stdout())}`,
+      )
+    } finally {
+      await terminate(child)
+    }
+  })
+
+  it('importing the module does NOT run main() (the stuck-TRUE direction)', async () => {
+    const dir = stageDir('chroxy-channel-import-')
+    const port = await allocatePort()
+    const importer = stageScript(
+      dir,
+      'importer.mjs',
+      `await import(${moduleUrl(CHANNEL_SERVER)})\nconsole.log('IMPORTED-OK')\n`,
+    )
+
+    const { child, stdout, stderr, exited } = launch(importer, port)
+    try {
+      assert.ok(
+        await expectNeverListening(port),
+        'importing the module bound the control surface — the guard reads true when it is not the entry ' +
+        'point, so merely running the unit suite would start a server and a stdio transport.\n' +
+        `stderr: ${JSON.stringify(stderr())}`,
+      )
+      assert.ok(
+        !stderr().includes('HTTP control surface listening'),
+        `main() announced itself on import:\n${JSON.stringify(stderr())}`,
+      )
+      assert.ok(
+        !stdout().includes(CHANNEL_NOTIFICATION_METHOD),
+        `the module connected a channel transport on import:\n${JSON.stringify(stdout())}`,
+      )
+      // Positive control for all three assertions above: they are only evidence
+      // of quiet behaviour if the import actually happened. Printed AFTER the
+      // import resolves, so a typo'd URL or a module that threw on load cannot
+      // masquerade as "imported it and it stayed quiet".
+      assert.ok(
+        stdout().includes('IMPORTED-OK'),
+        `the importer never got past its import, so the assertions above prove nothing:\n${JSON.stringify(stderr())}`,
+      )
+      // Bounded, and captured at spawn time. A guard stuck true turns this
+      // importer into a live server that never exits, and an unbounded await
+      // would hang the suite instead of failing it.
+      assert.equal(
+        await exitCodeWithin(exited),
+        0,
+        `the importer did not exit cleanly — importing started something that keeps the process alive: ${stderr()}`,
+      )
+    } finally {
+      await terminate(child)
+    }
+  })
+})
+
+describe('entry-point call site: server-cli-child.js (#7254)', () => {
+  // This module IS the daemon's child process, which is why its call site
+  // matters more than any other. When the guard reads false the module body
+  // never runs: no supervisor IPC handler is registered, main() is never
+  // called, no server starts — and the process exits 0 with no diagnostic. The
+  // supervisor sees a child that started and stopped cleanly.
+  //
+  // The child boots against the `ollama` provider in a throwaway config dir.
+  // That is not arbitrary: it is the cheapest provider that reaches `ready`.
+  // The default (claude-tui) spawns a real `claude` TUI subprocess, and an
+  // API-key provider such as deepseek aborts with ProviderCredentialMissingError
+  // before main() finishes. `noAuth` plus a loopback `host` additionally keep
+  // the child from advertising itself over mDNS on the developer's LAN
+  // (maybeAdvertiseMdns declines on both counts). Measured: ready in ~285ms,
+  // with no provider process and no PTY.
+  const stage = async () => {
+    const dir = stageDir('chroxy-child-callsite-')
+    const cfgDir = join(dir, 'config')
+    const home = join(dir, 'home')
+    const emptyBin = join(dir, 'bin')
+    mkdirSync(cfgDir)
+    mkdirSync(home)
+    mkdirSync(emptyBin)
+    const port = await allocatePort()
+    writeFileSync(
+      join(cfgDir, 'config.json'),
+      JSON.stringify({ provider: 'ollama', host: '127.0.0.1', port, noAuth: true, tunnel: 'none', cwd: home }),
+    )
+    return { dir, cfgDir, home, emptyBin, port }
+  }
+
+  // HOME is redirected as well as CHROXY_CONFIG_DIR, and the redirection —
+  // not the sandbox — is what protects the developer's real ~/.chroxy and
+  // ~/.claude here (#4633). The child does inherit tests/_setup.mjs: fork()
+  // passes process.execArgv through, so the forked daemon boots under the same
+  // `--import` guard this process runs under. That is worth knowing but is not
+  // worth relying on, for two reasons. It only holds for `fork` (the `spawn`ed
+  // channel-server child above gets no execArgv), and the guard does not cover
+  // named or namespace ESM `fs` imports at all — see #7262, which this work
+  // turned up. Redirecting the roots is the protection; the sandbox is a
+  // backstop that may or may not be armed for a given module.
+  const boot = (entry, { cfgDir, home, emptyBin, port }) => {
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      CHROXY_CONFIG_DIR: cfgDir,
+      PORT: String(port),
+      CHROXY_NO_FILE_LOGGING: '1',
+      // Keychain access is a real, prompting side effect on macOS; both stores
+      // honour their own switch, so neither is consulted here.
+      CHROXY_DISABLE_KEYCHAIN: '1',
+      CHROXY_CRED_DISABLE_KEYCHAIN: '1',
+      // PATH points at an EMPTY directory, which is the only way to suppress
+      // the one subprocess this startup path still makes: wsServer.start() runs
+      // `claude --help` unconditionally for feature detection, with no config
+      // knob. Verified by putting a recording shim named `claude` on PATH and
+      // watching it log `--help`; with PATH empty, nothing is recorded and the
+      // child still reaches ready. The ollama provider needs no external binary,
+      // so nothing else on this path wants PATH.
+      PATH: emptyBin,
+      // Point the ollama client at a dead port. Nothing on the startup path
+      // makes a request, but a developer running a real Ollama on the default
+      // port should not be able to change what this test observes.
+      CHROXY_OLLAMA_BASE_URL: 'http://127.0.0.1:1',
+    }
+    // An inherited API_TOKEN would change the auth branch the child takes; the
+    // config file is the only thing that should decide that here.
+    delete env.API_TOKEN
+    // NOTE: deliberately no `cwd` option. `fork()` inherits process.execArgv,
+    // which under this suite is ['--import', './tests/_setup.mjs'] — a RELATIVE
+    // specifier. Giving the child a different cwd makes it unresolvable and the
+    // child dies at boot with ERR_MODULE_NOT_FOUND, which looks exactly like
+    // "the guard read false". The session's working directory is set through
+    // config.json's `cwd` key instead.
+    return attach(fork(entry, [], {
+      // The 'ipc' slot is the point: {type:'ready'} is this module's contract
+      // with the supervisor, and it exists only over a fork channel.
+      stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+      env,
+    }))
+  }
+
+  const sawReady = (messages) => messages.some((m) => m && m.type === 'ready')
+
+  it('forking the module directly starts the server and sends {type:"ready"} to the supervisor', async () => {
+    const staged = await stage()
+    const { child, messages, stdout, stderr, exited } = boot(SUPERVISED_CHILD, staged)
+    try {
+      const ready = await waitUntil(() => sawReady(messages), { timeoutMs: 30000 })
+      assert.ok(
+        ready,
+        'no {type:"ready"} IPC frame — main() never ran, so the entry-point guard read false and the ' +
+        'supervised daemon started and did nothing.\n' +
+        `stdout: ${JSON.stringify(stdout().slice(-2000))}\nstderr: ${JSON.stringify(stderr().slice(-2000))}`,
+      )
+
+      // Second, independent observation of the same fact: the IPC frame proves
+      // main() reached its last line, the bound port proves startCliServer
+      // genuinely brought a server up.
+      assert.ok(
+        await waitForListening(staged.port),
+        `ready was announced but nothing is listening on 127.0.0.1:${staged.port}`,
+      )
+
+      // The guarded block registers the supervisor IPC handler as well as
+      // calling main(), so exercise that half too — `shutdown` is the
+      // supervisor's stop path and is handled ONLY inside the guard.
+      child.send({ type: 'shutdown' })
+      const [code] = await exited
+      assert.equal(code, 0, `graceful shutdown should exit 0, got ${code}: ${stderr().slice(-2000)}`)
+    } finally {
+      await terminate(child)
+    }
+  })
+
+  it('importing the module does NOT start a server (the stuck-TRUE direction)', async () => {
+    const staged = await stage()
+    const importer = stageScript(
+      staged.dir,
+      'importer.mjs',
+      `await import(${moduleUrl(SUPERVISED_CHILD)})\nconsole.log('IMPORTED-OK')\n`,
+    )
+
+    const { child, messages, stdout, stderr, exited } = boot(importer, staged)
+    try {
+      // ORDER MATTERS, and the ordering is the fix for a defect this test had
+      // in draft. Waiting on the child's exit FIRST hangs forever under the very
+      // mutation this test exists to catch: a guard stuck true turns the
+      // importer into a running daemon, so it never exits. With no default
+      // per-test timeout and no --test-force-exit, that is a silent CI job
+      // timeout rather than a failure. Every wait below is bounded, and the
+      // assertions that name the problem run before the one about exiting.
+
+      // Positive control first: without it, a typo'd import URL, a module that
+      // threw on load, or a child that died early all produce exactly the same
+      // "no server started" observation as correct behaviour does.
+      assert.ok(
+        await waitForOutput(stdout, (t) => t.includes('IMPORTED-OK'), { timeoutMs: 30000 }),
+        'the importer never got past its import, so "no server started" below would prove nothing.\n' +
+        `stdout: ${JSON.stringify(stdout().slice(-2000))}\nstderr: ${JSON.stringify(stderr().slice(-2000))}`,
+      )
+
+      // The port window comes before the IPC check because it WAITS: `ready` is
+      // sent ~250ms after startup, so sampling messages the instant the import
+      // resolves would miss it and report a false all-clear.
+      assert.ok(
+        await expectNeverListening(staged.port),
+        `importing the module bound 127.0.0.1:${staged.port} — merely running the unit suite would start a server.`,
+      )
+      assert.ok(
+        !sawReady(messages),
+        'importing the module announced {type:"ready"} — the guard reads true when it is not the entry ' +
+        'point, so any test that imports this module boots a daemon as a side effect.',
+      )
+      assert.equal(
+        await exitCodeWithin(exited),
+        0,
+        'the importer did not exit cleanly — importing the module started something that keeps the process ' +
+        `alive: ${stderr().slice(-2000)}`,
+      )
+    } finally {
+      await terminate(child)
+    }
+  })
+})

--- a/packages/server/tests/entry-point-call-sites.test.js
+++ b/packages/server/tests/entry-point-call-sites.test.js
@@ -102,7 +102,7 @@ const stageDir = (prefix) => {
 // isEntryPoint returns false on its very first line and never reaches the path
 // comparison that actually decides this — the test would pass without
 // exercising the branch it exists to cover (#7236).
-const stageScript = (dir, name, source) => {
+const writeStagedScript = (dir, name, source) => {
   const file = join(dir, name)
   writeFileSync(file, source)
   return file
@@ -131,7 +131,13 @@ describe('entry-point call site: chroxy-channel-server.js (#7254)', () => {
         `stderr: ${JSON.stringify(stderr())}\nstdout: ${JSON.stringify(stdout())}`,
       )
 
-      const res = await fetch(`http://127.0.0.1:${port}/probe`, { method: 'POST', body: 'call-site-probe' })
+      // Bounded: a child that binds but wedges before res.end() must fail this
+      // test, not hang the suite.
+      const res = await fetch(`http://127.0.0.1:${port}/probe`, {
+        method: 'POST',
+        body: 'call-site-probe',
+        signal: AbortSignal.timeout(10000),
+      })
       assert.equal(res.status, 200)
       assert.equal(await res.text(), 'ok')
 
@@ -161,17 +167,23 @@ describe('entry-point call site: chroxy-channel-server.js (#7254)', () => {
     const port = await allocatePort()
     // Deliberately calls main() itself. `main` is exported by this module, so
     // the control invokes exactly what the guard would have invoked.
-    const control = stageScript(
+    const control = writeStagedScript(
       dir,
       'control.mjs',
       `const m = await import(${moduleUrl(CHANNEL_SERVER)})\nawait m.main()\n`,
     )
     const { child, stdout, stderr } = launch(control, port)
     try {
+      // Short timeout: this binds in well under a second, and the 15s default
+      // only ever delays a diagnosis. If the guard is stuck TRUE the import
+      // already bound the port and this explicit main() then dies on
+      // EADDRINUSE, so a failure here usually means the stuck-TRUE test below
+      // is the one worth reading.
       assert.ok(
-        await waitForListening(port),
-        `the control did not bind 127.0.0.1:${port}, so the import test below cannot distinguish anything.\n` +
-        `stderr: ${JSON.stringify(stderr())}\nstdout: ${JSON.stringify(stdout())}`,
+        await waitForListening(port, { timeoutMs: 5000 }),
+        `the control did not bind 127.0.0.1:${port}, so the import test below cannot distinguish anything ` +
+        '(or the module auto-ran on import and this second main() hit EADDRINUSE — read the stuck-TRUE ' +
+        `result first).\nstderr: ${JSON.stringify(stderr())}\nstdout: ${JSON.stringify(stdout())}`,
       )
     } finally {
       await terminate(child)
@@ -181,7 +193,7 @@ describe('entry-point call site: chroxy-channel-server.js (#7254)', () => {
   it('importing the module does NOT run main() (the stuck-TRUE direction)', async () => {
     const dir = stageDir('chroxy-channel-import-')
     const port = await allocatePort()
-    const importer = stageScript(
+    const importer = writeStagedScript(
       dir,
       'importer.mjs',
       `await import(${moduleUrl(CHANNEL_SERVER)})\nconsole.log('IMPORTED-OK')\n`,
@@ -189,8 +201,19 @@ describe('entry-point call site: chroxy-channel-server.js (#7254)', () => {
 
     const { child, stdout, stderr, exited } = launch(importer, port)
     try {
+      // Positive control FIRST, for two reasons. The negative assertions are
+      // only evidence of quiet behaviour if the import actually happened — a
+      // typo'd URL or a module that threw on load leaves the port just as
+      // unbound. And waiting for it here means the window below is measured
+      // from AFTER the import resolves, which is the moment main() would have
+      // run, rather than from spawn (node startup plus resolving the MCP SDK
+      // would otherwise eat most of it).
       assert.ok(
-        await expectNeverListening(port),
+        await waitForOutput(stdout, (t) => t.includes('IMPORTED-OK'), { timeoutMs: 30000 }),
+        `the importer never got past its import, so the assertions below prove nothing:\n${JSON.stringify(stderr())}`,
+      )
+      assert.ok(
+        await expectNeverListening(port, { windowMs: 3000 }),
         'importing the module bound the control surface — the guard reads true when it is not the entry ' +
         'point, so merely running the unit suite would start a server and a stdio transport.\n' +
         `stderr: ${JSON.stringify(stderr())}`,
@@ -199,18 +222,11 @@ describe('entry-point call site: chroxy-channel-server.js (#7254)', () => {
         !stderr().includes('HTTP control surface listening'),
         `main() announced itself on import:\n${JSON.stringify(stderr())}`,
       )
-      assert.ok(
-        !stdout().includes(CHANNEL_NOTIFICATION_METHOD),
-        `the module connected a channel transport on import:\n${JSON.stringify(stdout())}`,
-      )
-      // Positive control for all three assertions above: they are only evidence
-      // of quiet behaviour if the import actually happened. Printed AFTER the
-      // import resolves, so a typo'd URL or a module that threw on load cannot
-      // masquerade as "imported it and it stayed quiet".
-      assert.ok(
-        stdout().includes('IMPORTED-OK'),
-        `the importer never got past its import, so the assertions above prove nothing:\n${JSON.stringify(stderr())}`,
-      )
+      // NOTE: there is deliberately no assertion that stdout carries no channel
+      // notification. StdioServerTransport writes nothing on connect() — it only
+      // answers inbound stdin frames — and this test never POSTs, so the child's
+      // stdout is empty whether or not main() ran. Such an assertion cannot
+      // fail, and in a file about vacuous checks that is worse than absent.
       // Bounded, and captured at spawn time. A guard stuck true turns this
       // importer into a live server that never exits, and an unbounded await
       // would hang the suite instead of failing it.
@@ -279,17 +295,26 @@ describe('entry-point call site: server-cli-child.js (#7254)', () => {
       CHROXY_DISABLE_KEYCHAIN: '1',
       CHROXY_CRED_DISABLE_KEYCHAIN: '1',
       // PATH points at an EMPTY directory, which is the only way to suppress
-      // the one subprocess this startup path still makes: wsServer.start() runs
-      // `claude --help` unconditionally for feature detection, with no config
-      // knob. Verified by putting a recording shim named `claude` on PATH and
-      // watching it log `--help`; with PATH empty, nothing is recorded and the
-      // child still reaches ready. The ollama provider needs no external binary,
-      // so nothing else on this path wants PATH.
+      // the subprocesses this startup path makes with no config knob at all:
+      // wsServer.start() runs `claude --help` for feature detection, and the
+      // WsServer constructor runs `git rev-parse` twice via getGitInfo().
+      // Verified by putting a recording shim named `claude` on PATH and
+      // watching it log `--help`; with PATH empty nothing is recorded, the
+      // child has no descendants at all, and it still reaches ready. The
+      // ollama provider needs no external binary, so nothing on this path
+      // legitimately wants PATH.
       PATH: emptyBin,
       // Point the ollama client at a dead port. Nothing on the startup path
       // makes a request, but a developer running a real Ollama on the default
       // port should not be able to change what this test observes.
       CHROXY_OLLAMA_BASE_URL: 'http://127.0.0.1:1',
+      // The WsServer constructor fires a background fetch of
+      // registry.npmjs.org unless NODE_ENV === 'test' (ws-server.js:1281).
+      // Nothing in this harness sets NODE_ENV, so without this the forked
+      // child opens a real outbound HTTPS connection — confirmed with lsof —
+      // and on an egress-restricted runner adds a pending socket and a 5s
+      // timer to a test whose whole point is bounded, hermetic behaviour.
+      NODE_ENV: 'test',
     }
     // An inherited API_TOKEN would change the auth branch the child takes; the
     // config file is the only thing that should decide that here.
@@ -317,8 +342,8 @@ describe('entry-point call site: server-cli-child.js (#7254)', () => {
       const ready = await waitUntil(() => sawReady(messages), { timeoutMs: 30000 })
       assert.ok(
         ready,
-        'no {type:"ready"} IPC frame — main() never ran, so the entry-point guard read false and the ' +
-        'supervised daemon started and did nothing.\n' +
+        'no {type:"ready"} IPC frame — either main() never ran (the entry-point guard read false, and the ' +
+        'supervised daemon started and did nothing), or startup failed. stderr below distinguishes them.\n' +
         `stdout: ${JSON.stringify(stdout().slice(-2000))}\nstderr: ${JSON.stringify(stderr().slice(-2000))}`,
       )
 
@@ -334,8 +359,16 @@ describe('entry-point call site: server-cli-child.js (#7254)', () => {
       // calling main(), so exercise that half too — `shutdown` is the
       // supervisor's stop path and is handled ONLY inside the guard.
       child.send({ type: 'shutdown' })
-      const [code] = await exited
-      assert.equal(code, 0, `graceful shutdown should exit 0, got ${code}: ${stderr().slice(-2000)}`)
+      // Bounded like every other wait here. This one was not, and that was a
+      // real hole: break the shutdown handler and an unbounded await turns a
+      // failing test into a hung job that also orphans the forked daemon,
+      // because `finally` never runs. exitCodeWithin yields 'TIMEOUT', so the
+      // assertion names the hang instead of becoming one.
+      assert.equal(
+        await exitCodeWithin(exited),
+        0,
+        `graceful shutdown should exit 0: ${stderr().slice(-2000)}`,
+      )
     } finally {
       await terminate(child)
     }
@@ -343,7 +376,7 @@ describe('entry-point call site: server-cli-child.js (#7254)', () => {
 
   it('importing the module does NOT start a server (the stuck-TRUE direction)', async () => {
     const staged = await stage()
-    const importer = stageScript(
+    const importer = writeStagedScript(
       staged.dir,
       'importer.mjs',
       `await import(${moduleUrl(SUPERVISED_CHILD)})\nconsole.log('IMPORTED-OK')\n`,
@@ -371,8 +404,14 @@ describe('entry-point call site: server-cli-child.js (#7254)', () => {
       // The port window comes before the IPC check because it WAITS: `ready` is
       // sent ~250ms after startup, so sampling messages the instant the import
       // resolves would miss it and report a false all-clear.
+      // 3000ms, measured from after IMPORTED-OK. A full daemon boot is ~270ms
+      // here, but on a loaded 2-core runner it can be slower, and if the bind
+      // lands outside this window both named assertions pass and the mutation
+      // is caught only by the exitCodeWithin bound below — still red, but with
+      // a worse diagnostic. Widen this before trusting the ordering rationale
+      // above on a slow host.
       assert.ok(
-        await expectNeverListening(staged.port),
+        await expectNeverListening(staged.port, { windowMs: 3000 }),
         `importing the module bound 127.0.0.1:${staged.port} — merely running the unit suite would start a server.`,
       )
       assert.ok(

--- a/packages/server/tests/helpers/entry-point-call-site.js
+++ b/packages/server/tests/helpers/entry-point-call-site.js
@@ -8,13 +8,19 @@
  * really does reach `main()`, and that importing the same module really does
  * not.
  *
- * Why every assertion built on these is about an OBSERVABLE SIDE EFFECT and
- * never about exit status: the failure this area exists to catch (#7198) is a
- * guard that reads false, so the module body never runs and the process exits
- * 0 having done nothing. Exit 0 is what the bug looks like AND what success
- * looks like, so a test that checks it distinguishes nothing. A bound port, an
+ * Why the PRIMARY evidence in every test built on these is an OBSERVABLE SIDE
+ * EFFECT rather than exit status: the failure this area exists to catch (#7198)
+ * is a guard that reads false, so the module body never runs and the process
+ * exits 0 having done nothing. Exit 0 is what the bug looks like AND what
+ * success looks like, so on its own it distinguishes nothing. A bound port, an
  * IPC message, a JSON-RPC frame on stdout — those are absent when the body did
  * not run.
+ *
+ * Exit status IS asserted, but only ever as a bounded SECONDARY check — that is
+ * what {@link exitCodeWithin} is for. In the stuck-TRUE direction it carries
+ * real information rather than restating the side-effect assertions: an
+ * importer that started a server does not exit at all, so "did it exit, and
+ * cleanly, within a deadline?" is a third independent symptom.
  *
  * Both directions need covering, and they fail differently:
  *   - stuck FALSE: `node <module>` does nothing. Caught by waiting for the side

--- a/packages/server/tests/helpers/entry-point-call-site.js
+++ b/packages/server/tests/helpers/entry-point-call-site.js
@@ -1,0 +1,244 @@
+/**
+ * Test helpers for proving an `isEntryPoint()` CALL SITE actually runs (#7254).
+ *
+ * The guard itself is well covered — three copies, a drift gate in
+ * scripts/__tests__/is-entry-point.test.mjs, a lint in
+ * scripts/lint-entry-point-guard.mjs, and tests/is-entry-point.test.js. What
+ * these support is the other half: that at a given call site `node <module>`
+ * really does reach `main()`, and that importing the same module really does
+ * not.
+ *
+ * Why every assertion built on these is about an OBSERVABLE SIDE EFFECT and
+ * never about exit status: the failure this area exists to catch (#7198) is a
+ * guard that reads false, so the module body never runs and the process exits
+ * 0 having done nothing. Exit 0 is what the bug looks like AND what success
+ * looks like, so a test that checks it distinguishes nothing. A bound port, an
+ * IPC message, a JSON-RPC frame on stdout — those are absent when the body did
+ * not run.
+ *
+ * Both directions need covering, and they fail differently:
+ *   - stuck FALSE: `node <module>` does nothing. Caught by waiting for the side
+ *     effect and timing out.
+ *   - stuck TRUE:  importing the module runs `main()` as a side effect of any
+ *     test that imports it. Caught by {@link expectNeverListening} and friends
+ *     — and those are NEGATIVE assertions, so they are worth something only
+ *     next to a positive control proving the same observation can see the
+ *     effect when it IS present (#7251 shipped a hole by covering only the
+ *     direction the bug arrived from).
+ */
+import net from 'node:net'
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const LOOPBACK = '127.0.0.1'
+
+/**
+ * Reserve a free TCP port by binding :0 and immediately releasing it.
+ *
+ * Inherently racy — the port can be taken between the close and the child's
+ * bind — but it is the same race every `listen(0, '127.0.0.1')` test in this
+ * suite already runs, and a fixed port is worse: it collides with a developer's
+ * own running instance every time instead of with a 1-in-60000 stranger.
+ *
+ * Port 0 is deliberately not usable as the CHILD's port. `chroxy-channel-server`
+ * resolves its port as `Number(process.env.CHROXY_CHANNEL_PORT) || DEFAULT_PORT`,
+ * and `0` is falsy — so passing 0 does not mean "pick one for me", it silently
+ * means 8788, the real default, on whatever machine is running the suite.
+ * Allocating a concrete port is what keeps the test off it.
+ *
+ * @returns {Promise<number>}
+ */
+export function allocatePort() {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer()
+    probe.on('error', reject)
+    probe.listen(0, LOOPBACK, () => {
+      const { port } = probe.address()
+      probe.close(() => resolve(port))
+    })
+  })
+}
+
+/** One connect attempt. Resolves true if something accepted, false otherwise. */
+function tryConnect(port, host = LOOPBACK) {
+  return new Promise((resolve) => {
+    const sock = net.connect({ port, host })
+    // Every exit path destroys the socket. The server suite runs WITHOUT
+    // `--test-force-exit` since #6042 — leaked handles do not truncate the run,
+    // they HANG it — so a helper that strands a socket wedges CI rather than
+    // failing it.
+    const done = (answer) => {
+      sock.destroy()
+      resolve(answer)
+    }
+    sock.once('connect', () => done(true))
+    sock.once('error', () => done(false))
+  })
+}
+
+/**
+ * Poll `predicate` until it holds or the deadline passes. This is the one
+ * polling loop in this file; everything else is expressed in terms of it, so
+ * there is a single place where a deadline, an interval or an early return can
+ * be wrong. `predicate` may be async and is awaited each tick.
+ *
+ * @returns {Promise<boolean>} true if it held before the deadline.
+ */
+export async function waitUntil(predicate, { timeoutMs = 15000, intervalMs = 50 } = {}) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (await predicate()) return true
+    if (Date.now() >= deadline) return false
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
+/**
+ * Poll until something is listening on `port`, or the deadline passes.
+ * @returns {Promise<boolean>} true if it bound within the window.
+ */
+export function waitForListening(port, { host = LOOPBACK, ...opts } = {}) {
+  return waitUntil(() => tryConnect(port, host), opts)
+}
+
+/**
+ * Watch `port` for `windowMs` and report whether it stayed unbound throughout.
+ *
+ * A NEGATIVE assertion: on its own it passes for every wrong reason there is —
+ * a module that failed to import, a typo in the staged path, a child that died
+ * on startup all leave the port just as unbound as correct behaviour does.
+ * Pair it with a positive control that reaches the same observation through the
+ * same harness.
+ *
+ * Returns as soon as something DOES bind, so only the passing case waits out
+ * the window.
+ *
+ * @returns {Promise<boolean>} true if nothing ever bound.
+ */
+export async function expectNeverListening(port, { windowMs = 1500, host = LOOPBACK, intervalMs = 50 } = {}) {
+  const bound = await waitUntil(() => tryConnect(port, host), { timeoutMs: windowMs, intervalMs })
+  return !bound
+}
+
+/**
+ * Accumulate a child stream into a string later assertions can read.
+ * Returns a getter rather than a live binding so callers cannot read it stale.
+ * Internal: reached through {@link attach}, which is what tests use.
+ */
+function collect(stream) {
+  let buf = ''
+  if (stream) {
+    stream.setEncoding('utf8')
+    stream.on('data', (chunk) => { buf += chunk })
+  }
+  return () => buf
+}
+
+/**
+ * Wire up output collection, IPC collection and exit tracking on an
+ * already-spawned child.
+ *
+ * Takes a child rather than spawning one because the two call sites under test
+ * need different launchers: the channel server is `spawn`ed, the supervised
+ * child is `fork`ed for its IPC channel.
+ *
+ * `exited` is captured HERE, at attach time, rather than awaited on demand
+ * later. That ordering is the whole reason this exists: a child that has
+ * already exited never emits `exit` again, so an `await once(child, 'exit')`
+ * written after a polling loop waits for an event that already fired, and the
+ * runner reports the unhelpful "Promise resolution is still pending but the
+ * event loop has already resolved". The staged-importer children here exit in
+ * milliseconds while the tests watching them deliberately wait over a second,
+ * so that race is the normal case, not a rare one.
+ *
+ * @param {import('node:child_process').ChildProcess} child
+ */
+export function attach(child) {
+  const messages = []
+  child.on('message', (m) => { messages.push(m) })
+  const exited = new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve([child.exitCode, child.signalCode])
+      return
+    }
+    child.once('exit', (code, signal) => resolve([code, signal]))
+  })
+  return { child, stdout: collect(child.stdout), stderr: collect(child.stderr), messages, exited }
+}
+
+/**
+ * Wait for `predicate(text)` to hold over an accumulating stream, or time out.
+ * @returns {Promise<boolean>}
+ */
+export function waitForOutput(getText, predicate, opts = {}) {
+  return waitUntil(() => predicate(getText()), opts)
+}
+
+/**
+ * The child's exit code, or the string `'TIMEOUT'` if it is still running.
+ *
+ * Every wait on a child's exit in these tests goes through this, and that is
+ * deliberate. The stuck-TRUE failure direction turns an importer into a
+ * long-lived server, so an unbounded `await exited` does not fail — it HANGS,
+ * and the server suite has neither a default per-test timeout (node:test's is
+ * Infinity) nor `--test-force-exit` (retired in #6042). A hang is a CI job
+ * timeout with no assertion and no diagnostic, which is the same "the failure
+ * is silence" shape this whole area exists to eliminate. Bounded, the same
+ * condition reports itself as a named assertion instead.
+ *
+ * The timer is always cleared: a stray one keeps the runner's event loop alive,
+ * and without force-exit that wedges the suite rather than truncating it.
+ *
+ * @param {Promise<[number|null, string|null]>} exited from {@link attach}
+ * @returns {Promise<number|null|'TIMEOUT'>}
+ */
+export async function exitCodeWithin(exited, ms = 10000) {
+  let timer
+  const timeout = new Promise((resolve) => { timer = setTimeout(() => resolve(['TIMEOUT', null]), ms) })
+  try {
+    const [code] = await Promise.race([exited, timeout])
+    return code
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Terminate a spawned child and wait for it to actually go away.
+ *
+ * SIGTERM first, never SIGKILL as the opening move — these modules install
+ * flush-on-shutdown handlers and SIGKILL bypasses them. SIGKILL is only the
+ * fallback after a grace period, so a wedged child cannot hang the suite.
+ *
+ * @param {import('node:child_process').ChildProcess|null} child
+ */
+export async function terminate(child, { graceMs = 2000 } = {}) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return
+  const exited = new Promise((resolve) => child.once('exit', resolve))
+  try { child.kill('SIGTERM') } catch { return }
+  const timer = setTimeout(() => { try { child.kill('SIGKILL') } catch {} }, graceMs)
+  try {
+    await exited
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * A temp directory under the REAL tmpdir, for the caller to clean up.
+ *
+ * `realpathSync` matters: on macOS `os.tmpdir()` resolves through a symlink
+ * (`/var` -> `/private/var`), and staging a script under a non-realpath'd path
+ * is precisely the #7198 shape. A test that means to exercise the ordinary
+ * direct run must not accidentally exercise the symlink case too — when a test
+ * wants that case it should build the symlink deliberately.
+ */
+export function makeTempDir(prefix) {
+  return mkdtempSync(join(realpathSync(tmpdir()), prefix))
+}
+
+/** Best-effort recursive removal, for `after()` hooks. */
+export function removeTempDir(dir) {
+  try { rmSync(dir, { recursive: true, force: true }) } catch {}
+}


### PR DESCRIPTION
Closes #7254.

`isEntryPoint()` decides whether a module runs `main()`. Two production call sites had no test that the guarded code actually runs:

```
packages/server/src/server-cli-child.js:168          const isModuleEntryPoint = isEntryPoint(import.meta.url)
packages/server/src/channels/chroxy-channel-server.js:241   const isDirectRun = isEntryPoint(import.meta.url)
```

Both had test files, and both only imported the module and exercised its exports — the asymmetry #7236 closed for the two `scripts/` call sites. This closes it for the two server ones.

It matters most at `server-cli-child.js`, which **is** the daemon's child process. The #7198 failure mode is silence: the guard reads false, the module body never runs, the process exits 0 having done nothing. On a markdown generator that is an annoyance; on the process that runs a user's session it is the daemon starting and immediately doing nothing, with no diagnostic.

## What is added

`packages/server/tests/entry-point-call-sites.test.js` (5 tests) and a shared helper, `tests/helpers/entry-point-call-site.js`.

| test | direction | observable asserted |
|---|---|---|
| channel server: direct run | stuck FALSE | port bound, `POST` → 200 `ok`, **and the JSON-RPC channel notification on the child's stdout** |
| channel server: positive control | — | the same staged-importer harness DOES bind when it calls `main()` itself |
| channel server: import | stuck TRUE | nothing bound, no listen line, no transport, clean exit |
| supervised child: direct fork | stuck FALSE | `{type:'ready'}` IPC frame, WS port bound, and `{type:'shutdown'}` → exit 0 |
| supervised child: import | stuck TRUE | no ready frame, nothing bound, clean exit |

**Exit status is never the primary evidence.** Exit 0 is what the bug looks like *and* what success looks like, so on its own it distinguishes nothing — what each test turns on is a side effect that is absent when the body did not run. Exit status is asserted as a bounded secondary check (`exitCodeWithin`), where in the stuck-TRUE direction it is a genuinely independent third symptom: an importer that started a server never exits at all.

## Proved red — all five mutations

Judged on the runner's **exit code**, with the unmutated tree confirmed green first, and each source restored from a `cp` backup (never `git checkout --`) and re-verified against `git status`:

| mutant | result |
|---|---|
| `isDirectRun = false` | RED — *channel: running the module directly binds…* |
| `isDirectRun = true` | RED — *channel: importing the module does NOT run main()* |
| `isModuleEntryPoint = false` | RED — *child: forking the module directly starts the server…* |
| `isModuleEntryPoint = true` | RED — *child: importing the module does NOT start a server* |
| shutdown IPC handler disabled | RED in 10.3s — *child: forking the module directly starts the server…* |

The fifth was added during review: it is the mutation that exposed the last unbounded `await`, which hung past 75s and orphaned the forked daemon instead of failing. It now fails at the `exitCodeWithin` bound with the test named.

## Three things the work changed about itself

**These tests live in their own file, and that is load-bearing.** A file that imports the module under test is disabled by the very bug it is testing. Hardwiring the child's guard true makes `tests/server-cli-child.test.js` die during its own top-level import — one anonymous `tests/server-cli-child.test.js failed`, no assertion, no clue. Hardwiring the channel guard true makes `tests/chroxy-channel-server.test.js` bind 8788 and **hang forever**, because the server suite has run without `--test-force-exit` since #6042. Both verified. Reaching the modules only through `fork`/`spawn` is what lets the stuck-TRUE direction fail as a *named* assertion.

**The first draft hung instead of failing.** The child's import test awaited the child's exit first — and under the stuck-TRUE mutation the importer becomes a live daemon that never exits. With no default per-test timeout and no force-exit, that is a CI job timeout with no diagnostic: the same "failure is silence" shape this issue is about, reintroduced inside its own fix. Every wait is now bounded (`exitCodeWithin`), and the assertions that name the problem run before the one about exiting.

**Every negative assertion carries a positive control.** "Nothing bound" passes just as happily when the staged file failed to import or the child died on startup. The channel importer is paired with a control that binds the same port through the same harness; both importers print `IMPORTED-OK` *after* the import resolves, so a typo'd URL cannot masquerade as quiet correct behaviour.

## Cost and hermeticity

5 tests, ~4s. The child boots against `ollama` — the cheapest provider that reaches `ready` (the default `claude-tui` spawns a real TUI; `deepseek` aborts on a missing credential). `noAuth` + a loopback `host` suppress mDNS. `HOME`, `CHROXY_CONFIG_DIR`, both keychain switches and a `cwd` are redirected so the child cannot touch real state. `PATH` points at an empty directory to suppress the subprocesses that have no config knob — `wsServer.start()` runs `claude --help` for feature detection and the `WsServer` constructor runs `git rev-parse` twice; verified with a recording shim named `claude`, which logs `--help` when reachable and nothing when `PATH` is empty, leaving the child with no descendants at all. `NODE_ENV=test` stops the constructor's background fetch of `registry.npmjs.org`, which review caught with `lsof` and which the first version of this list missed.

## Follow-ons filed

- **#7262** — `tests/_setup.mjs`'s write sandbox does not cover named or namespace ESM `fs` imports, and its comment claims it does. 41 modules under `packages/server/src/` are therefore unguarded against the #4633 failure. Found because the forked child here inherits `--import ./tests/_setup.mjs` via `execArgv`, which prompted checking what the sandbox actually covers; root-caused to a single line (`_setup.mjs`'s own ESM `fs` import links the namespace before the body patches it) and verified with a paired control. Left for its own PR: arming the guard changes the blast radius of the entire server suite.
- **#7263** — `assert-test-count.mjs`'s docstring is written around `--test-force-exit`, which #6042 removed. Both of its present-tense premises are false, and it describes the opposite of the current failure mode (without the flag a leaked handle *hangs* the suite rather than truncating it).
- **#7265** — `ws-server.js:1281`'s "skipped in test/CI" version check is never skipped, because nothing sets `NODE_ENV=test`; all 28 test files that construct a `WsServer` fetch `registry.npmjs.org`. The same dead gate was removed from `session-manager.js` in #6952 without sweeping `ws-server.js`.

## Verification

- 5/5 green, ~4s. 108/108 across `entry-point-call-sites`, `chroxy-channel-server`, `server-cli-child`, `is-entry-point` and `lint-entry-point-guard` run together.
- `lint-tests-state-file-path`, `lint-logger-session-scoping`, `lint-session-opt-forwarding`, `lint-ws-index-mutations` all pass; `lint-entry-point-guard` still reports the same 6 sanctioned copies (the new file only mentions the guard, it does not reimplement it).
