### PR TITLE
fix(server): arm the test write sandbox for named and namespace fs imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,8 +288,8 @@ padding or font size, re-check the resulting box.
 **When you add or change a check, break the thing it protects and confirm it goes
 red.** If you cannot make it fail, it is not a guard.
 
-Seven guards in this repo reported success without checking anything, and all
-seven passed unit tests, lint, typecheck, and CI — for months in some cases.
+Eight guards in this repo reported success without checking anything, and all
+eight passed unit tests, lint, typecheck, and CI — for months in some cases.
 Test suites cannot find this class, because the guard's *output* is correct and
 its *coverage* is what is wrong. The recurring causes:
 
@@ -298,6 +298,8 @@ its *coverage* is what is wrong. The recurring causes:
 - a precondition that is false, so the body never runs and the job is green
   (`#7184`, `#7198`)
 - testing the source tree when the artifact is what ships (`#7189`)
+- a guard wired to only some of its callers, correct for every input it sees
+  and never reached by the rest (`#7262`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Restore mutations with `cp` from a backup,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,8 +269,8 @@ padding or font size, re-check the resulting box.
 **When you add or change a check, break the thing it protects and confirm it goes
 red.** If you cannot make it fail, it is not a guard.
 
-Seven guards in this repo reported success without checking anything, and all
-seven passed unit tests, lint, typecheck, and CI — for months in some cases.
+Eight guards in this repo reported success without checking anything, and all
+eight passed unit tests, lint, typecheck, and CI — for months in some cases.
 Test suites cannot find this class, because the guard's *output* is correct and
 its *coverage* is what is wrong. The recurring causes:
 
@@ -279,6 +279,8 @@ its *coverage* is what is wrong. The recurring causes:
 - a precondition that is false, so the body never runs and the job is green
   (`#7184`, `#7198`)
 - testing the source tree when the artifact is what ships (`#7189`)
+- a guard wired to only some of its callers, correct for every input it sees
+  and never reached by the rest (`#7262`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Restore mutations with `cp` from a backup,

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -17,7 +17,7 @@ The pattern recurs faster than it gets recognised, so it is written down.
 ## The shape
 
 A guard exhibits false safety when **success and not-checking are the same
-observable outcome**. Four ways that happens:
+observable outcome**. Five ways that happens:
 
 | mode | what it looks like |
 |---|---|
@@ -124,7 +124,7 @@ exports off `module.exports` at the first ESM import of it. `_setup.mjs` opened
 with `import { mkdtempSync } from 'node:fs'` — and ESM imports evaluate before
 the module body, so that one line took the snapshot from the unpatched object
 before the body could patch anything. **The guard disarmed itself, in its own
-first line, for the 41 modules under `src/` that import a write-side `fs`
+first line, for the 45 modules under `src/` that import a write-side `fs`
 function by name.**
 
 Nothing could see it. The guard still fired correctly for every caller that

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -3,10 +3,10 @@
 > A guard that cannot fail is worse than no guard. No guard leaves you cautious;
 > a green one that never checks anything makes you confident and wrong.
 
-Seven of these were found in a single day (2026-08-15). Every one had passed
-unit tests, lint, typecheck, and CI continuously — in some cases for months —
-because **the defect is invisible to any check that only asks "did it report
-success?"**
+Seven of these were found in a single day (2026-08-15), and the catalogue has
+kept growing since. Every one had passed unit tests, lint, typecheck, and CI
+continuously — in some cases for months — because **the defect is invisible to
+any check that only asks "did it report success?"**
 
 Each entry below cites its issue, and the fix is the PR that closes it; consult
 those rather than a tally here, which would be stale the moment one merges.
@@ -25,11 +25,16 @@ observable outcome**. Four ways that happens:
 | **Checked the wrong thing** | It verifies something already known good, not the artifact that can break. |
 | **Checked a subset** | It iterates a hardcoded list while the real set grows past it. |
 | **Silently skipped an input** | An unrecognised shape is filtered out instead of raising. |
+| **Never reached** | The guard is correct, but only some callers route through it. It passes every input it sees, and never sees the rest. |
 
-In all four, the check *emits* success. Nothing distinguishes "verified" from
+In all five, the check *emits* success. Nothing distinguishes "verified" from
 "declined to verify".
 
-## The seven
+The fifth is the hardest to see, because the guard itself is not wrong — you can
+read it line by line and find no defect. What is wrong is the wiring between it
+and the callers it is supposed to cover, which is not visible from either end.
+
+## The catalogue
 
 ### 1. The gate that never ran — `#7184`
 
@@ -99,6 +104,50 @@ Run through macOS's `/tmp` → `/private/tmp` symlink and the guard reads false,
 across three spellings — including the `pathToFileURL` form, which *looks* more
 careful than the others and is equally broken.
 
+### 8. The sandbox that guarded two of four import forms — `#7262`
+
+`packages/server/tests/_setup.mjs` patches the write-side of `node:fs` so a test
+that forgets a temp path fails loudly instead of clobbering the developer's real
+`~/.chroxy` (`#4633`). It patches the live CJS `module.exports`, and a comment
+asserted that named importers therefore see the patch too. Measured under the
+real harness, they did not:
+
+```
+CJS require        : patchedWriteFileSync
+ESM default import : patchedWriteFileSync
+ESM namespace      : writeFileSync      <-- UNPATCHED
+ESM named import   : writeFileSync      <-- UNPATCHED
+```
+
+Node builds the `node:fs` synthetic ESM module lazily, snapshotting its named
+exports off `module.exports` at the first ESM import of it. `_setup.mjs` opened
+with `import { mkdtempSync } from 'node:fs'` — and ESM imports evaluate before
+the module body, so that one line took the snapshot from the unpatched object
+before the body could patch anything. **The guard disarmed itself, in its own
+first line, for the 41 modules under `src/` that import a write-side `fs`
+function by name.**
+
+Nothing could see it. The guard still fired correctly for every caller that
+reached it, so its output was right; only its reach was wrong. `node:fs/promises`
+is the control that proves the mechanism — a separate synthetic module,
+never ESM-imported by `_setup.mjs`, and all four of *its* binding forms were
+guarded the whole time.
+
+What the reach was hiding: `tests/http-routes.test.js` renamed the developer's
+real `~/.chroxy/connection.json` aside in a `before` hook and moved it back in
+`after` — so a crash, a test timeout, or a SIGKILL between the two left a
+running daemon's connection info stranded under a `.test-backup` suffix. It had
+also been unnecessary for some time, since `readConnectionInfo()` now resolves
+through the `CHROXY_CONFIG_DIR` redirect that `_setup.mjs` already points at a
+tmp dir. Arming the guard surfaced it on the first run.
+
+Two lessons specific to this mode. **A binding is not a value**: patching an
+object only reaches consumers who read through that object, and in ESM the
+consumer's import form decides that — invisibly, at link time, from a different
+file. And **the probe must use the same binding form as the code it vouches
+for**: the first check of this sandbox during `#7254` used a default import,
+reported the guard working, and was right about the only form it tested.
+
 ## The one that got me while writing this
 
 A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no
@@ -151,7 +200,7 @@ match.
 
 ## Detection: mutation testing is the only reliable method
 
-**Every one of the seven passed all existing tests.** Test suites, lint,
+**Every one of these passed all existing tests.** Test suites, lint,
 typecheck, and CI cannot find this class, because the guard's output is correct
 — it is the guard's *coverage* that is wrong.
 

--- a/packages/claude-hooks/tests/_setup.mjs
+++ b/packages/claude-hooks/tests/_setup.mjs
@@ -11,11 +11,36 @@
  *      braces against env leaking out of a spawned process)
  */
 
-import fs from 'node:fs'
-import { mkdtempSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { tmpdir, homedir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+// #7262: reach `node:fs` through `createRequire`, NEVER an ESM import.
+//
+// This file previously opened with `import fs from 'node:fs'` plus
+// `import { mkdtempSync } from 'node:fs'`. Both are ESM imports, and ESM
+// imports are evaluated before the module body — which links the `node:fs`
+// synthetic module and snapshots its named exports off the UNPATCHED
+// `module.exports`. The patches below then landed on an object that named and
+// namespace importers no longer read, so the guard covered exactly two of the
+// four binding forms:
+//
+//   require / default import  -> guarded      namespace / named import -> NOT
+//
+// Measured on this package before the fix, writing to the real
+// `~/.chroxy`: cjs GUARDED, default GUARDED, namespace ENOENT, named ENOENT.
+// The default import was the patch TARGET and still did not save the other
+// two, because linking is what does the damage, not which form you patch.
+//
+// `createRequire` gives the live CJS `module.exports` without linking the
+// synthetic module, so the snapshot is taken later, already patched. The
+// server's sandbox carries the same rule and the reasoning in full
+// (`packages/server/tests/_setup.mjs`), pinned there by
+// `tests/setup-sandbox-binding-forms.test.js`.
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const { mkdtempSync } = fs
 
 const REAL_HOME = homedir()
 const GUARDED_ROOTS = [join(REAL_HOME, '.chroxy'), join(REAL_HOME, '.claude')]

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -11,11 +11,27 @@
  * trees, so the next forgetter fails LOUDLY at the offending call site
  * instead of silently corrupting the developer's live state 76 days later.
  *
- * The guard monkey-patches the write-side of `fs` (sync + promises): any
- * call whose resolved path falls under the real `~/.chroxy/` or `~/.claude/`
- * throws `CHROXY_TEST_SANDBOX` with a stack trace pointing at the caller.
- * Read-side fs calls are untouched, so tests that legitimately *read* the
- * developer's real config (e.g. provider detection in
+ * The guard monkey-patches a NAMED LIST of `fs` functions: any call whose
+ * resolved path falls under the real `~/.chroxy/` or `~/.claude/` throws
+ * `CHROXY_TEST_SANDBOX` with a stack trace pointing at the caller. The list is
+ *
+ *   sync      writeFileSync appendFileSync renameSync mkdirSync
+ *             createWriteStream openSync
+ *   promises  writeFile appendFile rename mkdir open
+ *
+ * and it is a LIST, not a category. Saying "the write-side of fs" — as this
+ * comment used to — reads as a guarantee the code does not make. Measured
+ * under this harness, these reach the real tree unimpeded: `unlinkSync`,
+ * `rmSync`, `rmdirSync`, `cpSync`, `copyFileSync`, `symlinkSync`, `linkSync`,
+ * `chmodSync`, and the `promises` forms of the same. Two of them are not even
+ * destructive-only — `cpSync` and `copyFileSync` were observed CREATING a real
+ * file inside the developer's live `~/.chroxy`. `truncateSync` is covered, but
+ * only incidentally, because it opens with `r+` and trips `openSync`.
+ * Closing that gap is #7267; until it lands, do not read this guard as
+ * covering deletes or copies.
+ *
+ * Read-side fs calls are untouched by design, so tests that legitimately
+ * *read* the developer's real config (e.g. provider detection in
  * `providers.test.js`) keep working.
  *
  * We deliberately do NOT override `process.env.HOME` globally. Several
@@ -68,15 +84,26 @@ import { fileURLToPath } from 'node:url'
 // sees the guard. Node's `--import` flag orders this file ahead of the test's
 // own graph, which is what makes that hold.
 //
-// #7262: THIS FILE MUST NEVER `import` FROM `node:fs`. ESM imports are
-// evaluated before the module body, so a single `import { mkdtempSync } from
-// 'node:fs'` up top links the synthetic module against the UNPATCHED exports —
-// and named/namespace consumers (41 modules under `src/` at the time of
-// writing) silently bypass the sandbox while it still reports success for CJS
-// and default importers. That line lived here for months. Take what you need
-// off the `fs` object below instead, as `mkdtempSync` now does.
-// `tests/setup-sandbox-binding-forms.test.js` pins all four binding forms and
-// fails if this is undone.
+// #7262: NOTHING EVALUATED BEFORE THIS FILE'S BODY MAY ESM-IMPORT `node:fs`.
+// In practice that means this file must not import it — but the condition is
+// wider than this file, and stating it as "never import fs here" would be too
+// narrow: a transitive import through any module this file pulls in, or an
+// earlier `--import` hook, disarms the guard identically. This file has no
+// local imports, which is what keeps the wider condition satisfied; adding one
+// re-opens the question.
+//
+// ESM imports are evaluated before the module body, so a single
+// `import { mkdtempSync } from 'node:fs'` up top links the synthetic module
+// against the UNPATCHED exports — and named/namespace consumers (45 modules
+// under `src/` at the time of writing) silently bypass the sandbox while it
+// still reports success for CJS and default importers. That line lived here
+// for months. Take what you need off the `fs` object below instead, as
+// `mkdtempSync` now does. The same applies to `node:fs/promises`: it is a
+// separate synthetic module with the same lazy-link behaviour, and importing
+// it here disarms the promises half (measured).
+//
+// `tests/setup-sandbox-binding-forms.test.js` pins every binding form
+// behaviourally and fails if any of this is undone.
 const require = createRequire(import.meta.url)
 const fs = require('node:fs')
 const { mkdtempSync } = fs

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -48,7 +48,6 @@
  */
 
 import { createRequire } from 'node:module'
-import { mkdtempSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -56,15 +55,31 @@ import { fileURLToPath } from 'node:url'
 // CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,
 // NOT via an ESM default import. ESM `import fs from 'node:fs'` returns a
 // Module Namespace Exotic Object whose property writes do NOT propagate to
-// later `import { writeFileSync } from 'node:fs'` consumers — those bindings
-// are snapshotted at link-time from the CJS module's original exports.
-// `createRequire('node:fs')` gives us the live CJS `module.exports`; any
-// production code that does `import { writeFileSync } from 'fs'` then sees
-// our patched value because the ESM named exports are derived from this same
-// object at link time. This must run BEFORE any other module imports `node:fs`
-// — Node's `--import` flag in `package.json` enforces that ordering.
+// later `import { writeFileSync } from 'node:fs'` consumers.
+// `createRequire('node:fs')` gives us the live CJS `module.exports` — the
+// object the default import also resolves to, so patching it covers both.
+//
+// Named and namespace importers (`import { writeFileSync } from 'fs'`,
+// `import * as fs from 'fs'`) are covered for a DIFFERENT and more fragile
+// reason: Node builds the `node:fs` synthetic ESM module LAZILY, snapshotting
+// its named exports off `module.exports` the first time some ESM module
+// imports it. As long as that first link happens AFTER this file's body runs,
+// the snapshot is taken from the already-patched object and every binding form
+// sees the guard. Node's `--import` flag orders this file ahead of the test's
+// own graph, which is what makes that hold.
+//
+// #7262: THIS FILE MUST NEVER `import` FROM `node:fs`. ESM imports are
+// evaluated before the module body, so a single `import { mkdtempSync } from
+// 'node:fs'` up top links the synthetic module against the UNPATCHED exports —
+// and named/namespace consumers (41 modules under `src/` at the time of
+// writing) silently bypass the sandbox while it still reports success for CJS
+// and default importers. That line lived here for months. Take what you need
+// off the `fs` object below instead, as `mkdtempSync` now does.
+// `tests/setup-sandbox-binding-forms.test.js` pins all four binding forms and
+// fails if this is undone.
 const require = createRequire(import.meta.url)
 const fs = require('node:fs')
+const { mkdtempSync } = fs
 
 // --- Redirect CHROXY_CONFIG_DIR to a per-process tmp dir ----------------------
 // Production helpers (models.js, connection-info.js, checkpoint-manager.js)

--- a/packages/server/tests/entry-point-call-sites.test.js
+++ b/packages/server/tests/entry-point-call-sites.test.js
@@ -278,10 +278,12 @@ describe('entry-point call site: server-cli-child.js (#7254)', () => {
   // passes process.execArgv through, so the forked daemon boots under the same
   // `--import` guard this process runs under. That is worth knowing but is not
   // worth relying on, for two reasons. It only holds for `fork` (the `spawn`ed
-  // channel-server child above gets no execArgv), and the guard does not cover
-  // named or namespace ESM `fs` imports at all — see #7262, which this work
-  // turned up. Redirecting the roots is the protection; the sandbox is a
-  // backstop that may or may not be armed for a given module.
+  // channel-server child above gets no execArgv), and the sandbox patches a
+  // named list of `fs` functions rather than every way to write — deletes and
+  // copies are outside it (#7267). The binding-form hole this comment used to
+  // cite — named and namespace ESM `fs` imports bypassing the guard entirely —
+  // was #7262 and is fixed. Redirecting the roots is still the protection here;
+  // the sandbox is a backstop.
   const boot = (entry, { cfgDir, home, emptyBin, port }) => {
     const env = {
       ...process.env,

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -1,20 +1,31 @@
-import { describe, it, afterEach, before, after, beforeEach } from 'node:test'
+import { describe, it, afterEach, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
-import { existsSync, renameSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { createHttpHandler, resolveRemoveImage, _resetSnapshotBackendCacheForTests } from '../src/http-routes.js'
 import { registerOAuthCallback, _clearOAuthCallbacksForTests } from '../src/byok-mcp-oauth.js'
 import { PairingManager } from '../src/pairing.js'
 
-// The QR endpoint falls back to reading ~/.chroxy/connection.json from disk.
-// If a Chroxy server is running (or left a stale file), the test gets 200 instead of 503.
-// Temporarily hide the file during this test suite.
-const connInfoPath = join(homedir(), '.chroxy', 'connection.json')
-const connInfoBackup = connInfoPath + '.test-backup'
-let connInfoHidden = false
+// The QR endpoint falls back to reading connection info from disk, and the
+// 503 case below needs that read to come up empty.
+//
+// This suite used to guarantee that by renaming the developer's REAL
+// ~/.chroxy/connection.json aside in `before` and moving it back in `after`
+// (#7262). That was a genuine #4633 hazard — a crash, a `--test-timeout`, or a
+// SIGKILL between the two hooks left the running daemon's connection info
+// stranded under a `.test-backup` suffix — and the sandbox in `tests/_setup.mjs`
+// could not see it, because this file imports `renameSync` by name and named
+// imports bypassed the guard.
+//
+// It was also unnecessary by then. `readConnectionInfo()` resolves through
+// `configPath('connection.json')` (src/connection-info.js), which follows the
+// CHROXY_CONFIG_DIR redirect that `_setup.mjs` points at a per-process tmp dir.
+// The real file is already invisible to this suite; nothing needs to be moved.
+// Same shape as the #7052 note in `_setup.mjs`: a workaround that outlived the
+// path resolution it was written for.
 
 function createMockServer(overrides = {}) {
   return {
@@ -84,20 +95,6 @@ function createMockServer(overrides = {}) {
 describe('http-routes', () => {
   let httpServer
   let port
-
-  before(() => {
-    if (existsSync(connInfoPath)) {
-      renameSync(connInfoPath, connInfoBackup)
-      connInfoHidden = true
-    }
-  })
-
-  after(() => {
-    if (connInfoHidden && existsSync(connInfoBackup)) {
-      renameSync(connInfoBackup, connInfoPath)
-      connInfoHidden = false
-    }
-  })
 
   async function startWith(mockServer) {
     const handler = createHttpHandler(mockServer)

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -321,7 +321,7 @@ describe('http-routes', () => {
       assert.equal(res.status, 403)
     })
 
-    it('GET /connect passes the primary token (404 here since conn info is hidden in this suite)', async () => {
+    it('GET /connect passes the primary token (404 here since the harness config dir has no connection info)', async () => {
       const mock = createMockServer()
       await startWith(mock)
       const res = await globalThis.fetch(`http://127.0.0.1:${port}/connect`, {

--- a/packages/server/tests/setup-sandbox-binding-forms.test.js
+++ b/packages/server/tests/setup-sandbox-binding-forms.test.js
@@ -10,7 +10,7 @@
  *   CJS require          patched      import * as fs from 'fs'     UNPATCHED
  *   import fs from 'fs'  patched      import { writeFileSync }     UNPATCHED
  *
- * 41 modules under `src/` import a write-side `fs` function by name, so for all
+ * 45 modules under `src/` import a write-side `fs` function by name, so for all
  * of them the guard was not armed while still reporting success for everything
  * else — the `docs/false-safety-guards.md` shape exactly.
  *
@@ -25,7 +25,7 @@
  *
  * That makes the fix invisible and trivially reversible: re-adding any innocuous
  * `import { … } from 'node:fs'` to `_setup.mjs` silently disarms the sandbox for
- * 41 modules again, and every other test in this suite still passes. This file
+ * 45 modules again, and every other test in this suite still passes. This file
  * is the only thing standing between that edit and a repeat of #4633.
  *
  * ── How these assertions avoid writing to the real home ────────────────────
@@ -77,6 +77,11 @@ import {
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+// The repo's single comment stripper (#7248). Importing it from `scripts/lib`
+// rather than re-implementing one here is deliberate: #7250 consolidated four
+// hand-rolled strippers into this one after two of them were measured wrong in
+// opposite directions on real files in this repo.
+import { stripComments } from '../scripts/lib/strip-comments.mjs'
 
 const require = createRequire(import.meta.url)
 const fsCjs = require('node:fs')
@@ -101,14 +106,38 @@ function classify(err) {
 
 function probeSync(fn, ...args) {
   try {
-    const ret = fn(...args)
-    // `createWriteStream` does not throw synchronously; it defers to an 'error'
-    // event. Returning a stream here means the guard did not fire.
-    if (ret && typeof ret.destroy === 'function') ret.destroy()
+    fn(...args)
     return classify(null)
   } catch (err) {
     return classify(err)
   }
+}
+
+// `createWriteStream` is the one probe whose BYPASS path is asynchronous: the
+// guard throws synchronously, but a bypassed call returns a live stream and
+// reports ENOENT later on an 'error' event. `probeSync` would classify that as
+// "the call SUCCEEDED" — wrong — and the unhandled 'error' would then surface
+// as an uncaughtException after the test had already ended, turning a clean
+// assertion failure into noise that hides which assertion failed.
+function probeStream(fn, target) {
+  return new Promise((resolve) => {
+    let stream
+    try {
+      stream = fn(target)
+    } catch (err) {
+      resolve(classify(err))
+      return
+    }
+    // No synchronous throw means the guard was bypassed and we are now holding
+    // a real stream aimed at a real path. Attach the handler before yielding.
+    stream.once('error', (err) => resolve(classify(err)))
+    stream.once('open', () => {
+      // It actually opened, so a real file exists under the protected root.
+      stream.destroy()
+      try { namedRmSync(target, { force: true }) } catch { /* best effort */ }
+      resolve(classify(null))
+    })
+  })
 }
 
 async function probeAsync(fn, ...args) {
@@ -170,17 +199,33 @@ describe('write sandbox: all four fs binding forms are guarded (#7262)', () => {
     })
   }
 
-  assert.strictEqual(
-    fsCjs.promises, fspCjs,
-    'node:fs/promises is expected to BE fs.promises — the sandbox patches the ' +
-    'latter and relies on that identity to cover the former.',
-  )
+  // This must be a test(), not a bare assert in the describe() body. A throw
+  // during collection CANCELS the sibling tests rather than failing one, and
+  // node:test reports cancelled subtests with `# fail 0` — a green-looking
+  // summary for a suite that never ran. That is the false-safety shape this
+  // whole file exists to prevent, so it must not appear in the file itself.
+  test('node:fs/promises IS fs.promises, which is why patching the latter covers it', () => {
+    assert.strictEqual(
+      fsCjs.promises, fspCjs,
+      'node:fs/promises is expected to BE fs.promises — the sandbox patches the ' +
+      'latter and relies on that identity to cover the former.',
+    )
+  })
 })
 
 describe('write sandbox: every patched method is armed for named imports', () => {
   // The other axis: each method is a separate monkey-patch in `_setup.mjs` and
   // could individually be missed. Driven through the NAMED form because that is
-  // the form #7262 left unguarded and the one 41 modules under `src/` use.
+  // the form #7262 left unguarded and the one 45 modules under `src/` use.
+  //
+  // KNOWN GAP (#7267): this list is hand-maintained alongside the patch list in
+  // `_setup.mjs`, under a suite titled "every patched method" — a hardcoded list
+  // beside a set that can grow, which is `docs/false-safety-guards.md` cause #1.
+  // It cannot currently claim "every": the sandbox patches no delete or copy
+  // API, so `unlinkSync`, `rmSync`, `cpSync` and friends are absent here because
+  // they are absent there. #7267 closes both halves by deriving the two lists
+  // from one exported array; until then, read this suite as "every method
+  // `_setup.mjs` claims to patch", and check that claim against #7267's table.
   const syncMethods = [
     ['writeFileSync',     () => probeSync(namedWriteFileSync, protectedTarget, 'probe')],
     // NOTE: this one is guarded even when its own binding is stale, so unlike
@@ -199,7 +244,6 @@ describe('write sandbox: every patched method is armed for named imports', () =>
     // Deliberately NOT `{ recursive: true }`: recursive would create real
     // directories under ~/.chroxy if the guard were bypassed.
     ['mkdirSync',         () => probeSync(namedMkdirSync, protectedTarget)],
-    ['createWriteStream', () => probeSync(namedCreateWriteStream, protectedTarget)],
     ['openSync',          () => probeSync(namedOpenSync, protectedTarget, 'w')],
   ]
 
@@ -208,6 +252,14 @@ describe('write sandbox: every patched method is armed for named imports', () =>
       assert.strictEqual(run(), GUARDED, `${label} bypassed the sandbox.`)
     })
   }
+
+  test('createWriteStream is guarded via named import', async () => {
+    assert.strictEqual(
+      await probeStream(namedCreateWriteStream, protectedTarget),
+      GUARDED,
+      'createWriteStream bypassed the sandbox.',
+    )
+  })
 
   const asyncMethods = [
     ['promises.writeFile',   () => probeAsync(namedWriteFile, protectedTarget, 'probe')],
@@ -268,18 +320,46 @@ describe('write sandbox: the cause is pinned structurally too (#7262)', () => {
   test('tests/_setup.mjs contains no ESM import from node:fs', () => {
     const setupPath = fileURLToPath(new URL('./_setup.mjs', import.meta.url))
     const source = namedReadFileSync(setupPath, 'utf8')
-    const offending = source
-      .split('\n')
-      .map((line, i) => [i + 1, line])
-      .filter(([, line]) => /^\s*import\s.*\sfrom\s+['"](node:)?fs(\/promises)?['"]/.test(line))
+
+    // Comments must be blanked first, and with the repo's ONE stripper
+    // (`scripts/lib/strip-comments.mjs`, #7248) rather than a second local
+    // regex. `_setup.mjs` deliberately quotes `import { mkdtempSync } from
+    // 'node:fs'` in its own header to explain the bug, so a check that reads
+    // raw source flags the very comment warning against the thing. Measured:
+    // 1 match raw, 0 stripped. The stripper preserves offsets, so line numbers
+    // computed here are valid against the original file.
+    const blanked = stripComments(source, '_setup.mjs')
+
+    // Deliberately NOT line-anchored on `... from ...`. Three forms disarm the
+    // sandbox and the narrow version caught only the first, which meant the
+    // check that exists to NAME the cause stayed green for two of the three
+    // ways the cause comes back. All three are measured, not assumed:
+    //
+    //   import { mkdtempSync } from 'node:fs'   single line   -> 9 tests fail
+    //   import 'node:fs'                        bare          -> 8 tests fail
+    //   import {\n  mkdtempSync,\n} from 'node:fs'  multi-line
+    //
+    // `node:fs/promises` is included because it is a separate synthetic module
+    // with the same lazy-link behaviour: importing it here snapshots ITS named
+    // exports early and disarms the promises half of the guard (measured: 9
+    // tests fail).
+    const IMPORT_OF_FS = /(^|\n)[ \t]*import\s+(?:[\s\S]*?\sfrom\s+)?['"](node:)?fs(\/promises)?['"]/g
+    const offending = [...blanked.matchAll(IMPORT_OF_FS)].map((m) => {
+      const at = m.index + (m[0].startsWith('\n') ? 1 : 0)
+      return {
+        line: source.slice(0, at).split('\n').length,
+        statement: source.slice(at, at + m[0].length).trim(),
+      }
+    })
 
     assert.deepStrictEqual(
       offending, [],
-      'tests/_setup.mjs must reach node:fs ONLY through createRequire. An ESM ' +
-      'import here is evaluated before the file body and snapshots the ' +
-      'synthetic module\'s named exports from the UNPATCHED object, silently ' +
-      'disarming the sandbox for every named/namespace consumer (#7262). ' +
-      'Destructure what you need off the `fs` object instead.',
+      'tests/_setup.mjs must reach node:fs ONLY through createRequire. Any ESM ' +
+      'import of it here — named, namespace, or bare side-effect — is evaluated ' +
+      'before the file body and snapshots the synthetic module\'s named exports ' +
+      'from the UNPATCHED object, silently disarming the sandbox for every ' +
+      'named/namespace consumer (#7262). Destructure what you need off the ' +
+      '`fs` object instead.',
     )
   })
 })

--- a/packages/server/tests/setup-sandbox-binding-forms.test.js
+++ b/packages/server/tests/setup-sandbox-binding-forms.test.js
@@ -1,0 +1,285 @@
+/**
+ * BINDING-FORM coverage for the write sandbox in `tests/_setup.mjs` (#7262).
+ *
+ * The sandbox patches the write-side of `node:fs` so a test that forgets a temp
+ * path fails loudly instead of clobbering the developer's real `~/.chroxy` /
+ * `~/.claude` (#4633). It patches the live CJS `module.exports` object. Whether
+ * that patch is VISIBLE depends on how the consumer imported `fs`, and for
+ * months it was visible to only two of the four forms:
+ *
+ *   CJS require          patched      import * as fs from 'fs'     UNPATCHED
+ *   import fs from 'fs'  patched      import { writeFileSync }     UNPATCHED
+ *
+ * 41 modules under `src/` import a write-side `fs` function by name, so for all
+ * of them the guard was not armed while still reporting success for everything
+ * else — the `docs/false-safety-guards.md` shape exactly.
+ *
+ * ── Why the fix is one deleted line, and why it needs a test at all ─────────
+ *
+ * Node builds the `node:fs` synthetic ESM module LAZILY, snapshotting its named
+ * exports off `module.exports` at the first ESM import of it. `_setup.mjs` did
+ * `import { mkdtempSync } from 'node:fs'` at the top; ESM imports evaluate
+ * before the module body, so that one line took the snapshot from the UNPATCHED
+ * object before the body could patch anything. Taking `mkdtempSync` off the CJS
+ * object instead lets the snapshot happen later, already patched.
+ *
+ * That makes the fix invisible and trivially reversible: re-adding any innocuous
+ * `import { … } from 'node:fs'` to `_setup.mjs` silently disarms the sandbox for
+ * 41 modules again, and every other test in this suite still passes. This file
+ * is the only thing standing between that edit and a repeat of #4633.
+ *
+ * ── How these assertions avoid writing to the real home ────────────────────
+ *
+ * Every probe targets a path under the protected root whose PARENT DIRECTORY
+ * DOES NOT EXIST. That makes the two outcomes cleanly distinguishable without
+ * risking real state:
+ *
+ *   guard fired      -> throws/rejects `CHROXY_TEST_SANDBOX`  (patched fn ran)
+ *   guard bypassed   -> throws/rejects `ENOENT`               (real fs ran)
+ *
+ * The bypass case reaches the real syscall and is refused by the kernel for the
+ * missing parent, so a FAILING run of this file still creates nothing. Asserting
+ * on a real call's observable outcome — rather than reading `fn.name` — is
+ * deliberate: a name check is a reading, and the sandbox's own first probe in
+ * #7254 read as "working" because it happened to use a default import.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+
+// The four binding forms under test. This file MUST import `node:fs` all four
+// ways — that is the point — and it is safe to do so here because `--import
+// ./tests/_setup.mjs` has already run the patch by the time this file links.
+import * as fsNamespace from 'node:fs'
+import fsDefault from 'node:fs'
+import { createRequire } from 'node:module'
+import {
+  writeFileSync as namedWriteFileSync,
+  appendFileSync as namedAppendFileSync,
+  renameSync as namedRenameSync,
+  mkdirSync as namedMkdirSync,
+  createWriteStream as namedCreateWriteStream,
+  openSync as namedOpenSync,
+  readFileSync as namedReadFileSync,
+  rmSync as namedRmSync,
+} from 'node:fs'
+
+import * as fspNamespace from 'node:fs/promises'
+import fspDefault from 'node:fs/promises'
+import {
+  writeFile as namedWriteFile,
+  appendFile as namedAppendFile,
+  rename as namedRename,
+  mkdir as namedMkdir,
+  open as namedOpen,
+} from 'node:fs/promises'
+
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const fsCjs = require('node:fs')
+const fspCjs = require('node:fs/promises')
+
+// A path under the REAL protected root whose parent does not exist. Never
+// created by any assertion below — see the header.
+const MISSING_DIR = `__chroxy-sandbox-binding-probe-${process.pid}`
+const protectedTarget = join(homedir(), '.chroxy', MISSING_DIR, 'probe.tmp')
+// The control: identically shaped (missing parent) but NOT protected.
+const unprotectedTarget = join(tmpdir(), MISSING_DIR, 'probe.tmp')
+
+const GUARDED = 'guarded'
+const REACHED_REAL_FS = 'reached-real-fs'
+
+function classify(err) {
+  if (!err) return 'no-error: the call SUCCEEDED, which means it wrote to a real path'
+  if (err.code === 'CHROXY_TEST_SANDBOX') return GUARDED
+  if (err.code === 'ENOENT') return REACHED_REAL_FS
+  return `unexpected: ${err.code || err.message}`
+}
+
+function probeSync(fn, ...args) {
+  try {
+    const ret = fn(...args)
+    // `createWriteStream` does not throw synchronously; it defers to an 'error'
+    // event. Returning a stream here means the guard did not fire.
+    if (ret && typeof ret.destroy === 'function') ret.destroy()
+    return classify(null)
+  } catch (err) {
+    return classify(err)
+  }
+}
+
+async function probeAsync(fn, ...args) {
+  try {
+    const handle = await fn(...args)
+    if (handle && typeof handle.close === 'function') await handle.close()
+    return classify(null)
+  } catch (err) {
+    return classify(err)
+  }
+}
+
+describe('write sandbox: all four fs binding forms are guarded (#7262)', () => {
+  // ── The axis that was broken: HOW `fs` was imported ──────────────────────
+  //
+  // `writeFileSync` stands in for the whole write-side here on purpose. The
+  // binding-form defect is not per-method: if the named-export snapshot was
+  // taken before the patch, EVERY method on it is stale together. The
+  // per-method axis is covered separately below.
+  const fsForms = [
+    ['CJS require',          () => fsCjs.writeFileSync],
+    ['ESM default import',   () => fsDefault.writeFileSync],
+    ['ESM namespace import', () => fsNamespace.writeFileSync],
+    ['ESM named import',     () => namedWriteFileSync],
+  ]
+
+  for (const [label, get] of fsForms) {
+    test(`node:fs writeFileSync via ${label} is guarded`, () => {
+      assert.strictEqual(
+        probeSync(get(), protectedTarget, 'probe'),
+        GUARDED,
+        `${label} bypassed the sandbox. If this is the namespace/named form, ` +
+        `something in tests/_setup.mjs is importing 'node:fs' via ESM again — ` +
+        `that snapshots the unpatched exports before the body runs (#7262).`,
+      )
+    })
+  }
+
+  // `node:fs/promises` is the natural CONTROL for the root cause: it is a
+  // separate synthetic module, `_setup.mjs` never ESM-imported it, and all four
+  // of its forms were already guarded while `node:fs` named/namespace were not.
+  // The two differ in exactly one thing — whether `_setup.mjs` links them
+  // early — which is what identifies that import as the cause rather than a
+  // correlate. Pinned here so the control cannot silently rot either.
+  const fspForms = [
+    ['CJS require',          () => fspCjs.writeFile],
+    ['ESM default import',   () => fspDefault.writeFile],
+    ['ESM namespace import', () => fspNamespace.writeFile],
+    ['ESM named import',     () => namedWriteFile],
+  ]
+
+  for (const [label, get] of fspForms) {
+    test(`node:fs/promises writeFile via ${label} is guarded`, async () => {
+      assert.strictEqual(
+        await probeAsync(get(), protectedTarget, 'probe'),
+        GUARDED,
+        `${label} of node:fs/promises bypassed the sandbox.`,
+      )
+    })
+  }
+
+  assert.strictEqual(
+    fsCjs.promises, fspCjs,
+    'node:fs/promises is expected to BE fs.promises — the sandbox patches the ' +
+    'latter and relies on that identity to cover the former.',
+  )
+})
+
+describe('write sandbox: every patched method is armed for named imports', () => {
+  // The other axis: each method is a separate monkey-patch in `_setup.mjs` and
+  // could individually be missed. Driven through the NAMED form because that is
+  // the form #7262 left unguarded and the one 41 modules under `src/` use.
+  const syncMethods = [
+    ['writeFileSync',     () => probeSync(namedWriteFileSync, protectedTarget, 'probe')],
+    // NOTE: this one is guarded even when its own binding is stale, so unlike
+    // its neighbours it survives the #7262 mutant. That is a real property of
+    // Node, not a dead assertion: `appendFileSync` reaches `writeFileSync`
+    // through the module's exports OBJECT, which is the thing `_setup.mjs`
+    // patches — so an unpatched named `appendFileSync` still lands in the
+    // patched `writeFileSync`. Verified by patching only `writeFileSync` on the
+    // CJS object and watching a named `appendFileSync` call trip it. Kept
+    // because it pins the OUTCOME (`appendFileSync` cannot reach the real home)
+    // regardless of which mechanism delivers it; do not read its mutant
+    // survival as this file being insensitive.
+    ['appendFileSync',    () => probeSync(namedAppendFileSync, protectedTarget, 'probe')],
+    ['renameSync (from)', () => probeSync(namedRenameSync, protectedTarget, join(tmpdir(), 'probe-dest.tmp'))],
+    ['renameSync (to)',   () => probeSync(namedRenameSync, join(tmpdir(), MISSING_DIR, 'src.tmp'), protectedTarget)],
+    // Deliberately NOT `{ recursive: true }`: recursive would create real
+    // directories under ~/.chroxy if the guard were bypassed.
+    ['mkdirSync',         () => probeSync(namedMkdirSync, protectedTarget)],
+    ['createWriteStream', () => probeSync(namedCreateWriteStream, protectedTarget)],
+    ['openSync',          () => probeSync(namedOpenSync, protectedTarget, 'w')],
+  ]
+
+  for (const [label, run] of syncMethods) {
+    test(`${label} is guarded via named import`, () => {
+      assert.strictEqual(run(), GUARDED, `${label} bypassed the sandbox.`)
+    })
+  }
+
+  const asyncMethods = [
+    ['promises.writeFile',   () => probeAsync(namedWriteFile, protectedTarget, 'probe')],
+    ['promises.appendFile',  () => probeAsync(namedAppendFile, protectedTarget, 'probe')],
+    ['promises.rename (from)', () => probeAsync(namedRename, protectedTarget, join(tmpdir(), 'probe-dest.tmp'))],
+    ['promises.rename (to)',   () => probeAsync(namedRename, join(tmpdir(), MISSING_DIR, 'src.tmp'), protectedTarget)],
+    ['promises.mkdir',       () => probeAsync(namedMkdir, protectedTarget)],
+    ['promises.open',        () => probeAsync(namedOpen, protectedTarget, 'w')],
+  ]
+
+  for (const [label, run] of asyncMethods) {
+    test(`${label} is guarded via named import`, async () => {
+      assert.strictEqual(await run(), GUARDED, `${label} bypassed the sandbox.`)
+    })
+  }
+})
+
+describe('write sandbox: controls', () => {
+  // POSITIVE CONTROL. Every assertion above passes when the guard throws
+  // CHROXY_TEST_SANDBOX and fails when the call reaches the real fs and gets
+  // ENOENT. That distinction is worthless unless ENOENT is genuinely what the
+  // unguarded path looks like here — otherwise the suite would be green because
+  // nothing ever reaches the syscall, not because the guard is armed.
+  //
+  // Same shape, same missing parent, only the root differs.
+  test('an UNPROTECTED missing-parent path reaches the real fs (ENOENT)', () => {
+    assert.strictEqual(
+      probeSync(namedWriteFileSync, unprotectedTarget, 'probe'),
+      REACHED_REAL_FS,
+      'The control did not reach the real fs, so ENOENT is not a valid ' +
+      'signature for "bypassed" and the guarded assertions above prove nothing.',
+    )
+  })
+
+  test('the guard discriminates by path, not by throwing at everything', () => {
+    // If the patched functions rejected every call, the tests above would pass
+    // for the wrong reason. A legitimate temp write must still succeed —
+    // through the NAMED import specifically, since that binding is the one the
+    // fix changed.
+    const dir = join(tmpdir(), `chroxy-sandbox-binding-ok-${process.pid}`)
+    try {
+      namedMkdirSync(dir, { recursive: true })
+      const file = join(dir, 'legit.txt')
+      namedWriteFileSync(file, 'ok')
+      assert.strictEqual(namedReadFileSync(file, 'utf8'), 'ok')
+    } finally {
+      namedRmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('write sandbox: the cause is pinned structurally too (#7262)', () => {
+  // The behavioural tests above are the real guard — they fail on the OUTCOME
+  // however it is reintroduced. This one adds nothing to coverage; it exists so
+  // the failure NAMES the cause, because the outcome-level failure ("named
+  // import bypassed the sandbox") does not obviously point at an import
+  // statement three files away.
+  test('tests/_setup.mjs contains no ESM import from node:fs', () => {
+    const setupPath = fileURLToPath(new URL('./_setup.mjs', import.meta.url))
+    const source = namedReadFileSync(setupPath, 'utf8')
+    const offending = source
+      .split('\n')
+      .map((line, i) => [i + 1, line])
+      .filter(([, line]) => /^\s*import\s.*\sfrom\s+['"](node:)?fs(\/promises)?['"]/.test(line))
+
+    assert.deepStrictEqual(
+      offending, [],
+      'tests/_setup.mjs must reach node:fs ONLY through createRequire. An ESM ' +
+      'import here is evaluated before the file body and snapshots the ' +
+      'synthetic module\'s named exports from the UNPATCHED object, silently ' +
+      'disarming the sandbox for every named/namespace consumer (#7262). ' +
+      'Destructure what you need off the `fs` object instead.',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`packages/server/tests/_setup.mjs` is the sandbox that stops tests from clobbering the developer's real `~/.chroxy` / `~/.claude` (#4633). It patches the live CJS `module.exports` of `node:fs`, and a comment asserted that named importers therefore see the patch too.

They did not. Measured under the real harness by attempting an actual write through each binding form:

| binding form | before | after |
|---|---|---|
| `require('node:fs')` | blocked | blocked |
| `import fs from 'node:fs'` | blocked | blocked |
| `import * as fs from 'node:fs'` | **WROTE THROUGH** | blocked |
| `import { writeFileSync } from 'node:fs'` | **WROTE THROUGH** | blocked |

**45 modules under `src/` import a write-side `fs` function by name**, so for all of them the sandbox was not armed — while still reporting success for everything else.

## Root cause, with a control

Node builds the `node:fs` synthetic ESM module **lazily**, snapshotting its named exports off `module.exports` at the first ESM import of it. `_setup.mjs` opened with `import { mkdtempSync } from 'node:fs'` — and ESM imports evaluate *before* the module body, so that one line took the snapshot from the **unpatched** object before the body could patch anything. The guard disarmed itself in its own first line.

The control that identifies this as the cause rather than a correlate: **`node:fs/promises` was fully guarded the whole time**, across all four binding forms. It is a separate synthetic module that `_setup.mjs` never ESM-imports. Same patching mechanism, opposite outcome, differing in exactly the one thing.

The fix takes `mkdtempSync` off the CJS object `_setup.mjs` already builds, so the snapshot happens later, against the patched object.

## The bug this was hiding

Arming the guard surfaced one real #4633 violation on the first run. `tests/http-routes.test.js` renamed the developer's **real `~/.chroxy/connection.json`** aside in `before` and moved it back in `after` — so a crash, a `--test-timeout`, or a SIGKILL between the two hooks left a *running daemon's* connection info stranded under a `.test-backup` suffix. The sandbox could not see it because that file imports `renameSync` by name.

It was also unnecessary: `readConnectionInfo()` resolves through `configPath('connection.json')`, which follows the `CHROXY_CONFIG_DIR` redirect `_setup.mjs` already points at a tmp dir. Same shape as the #7052 note already in `_setup.mjs` — a workaround that outlived the path resolution it was written for. Removed; the suite is 64/64 with 0 cancelled.

## The sibling guard had it too

`packages/claude-hooks/tests/_setup.mjs` carried the identical defect. Measured before: `cjs GUARDED, default GUARDED, namespace ENOENT, named ENOENT`. It used a *default* import as its patch target, which is a correct target and still did not save the other two forms — **linking is what does the damage, not which form you patch.** Fixed the same way; 97/97 green.

## Proving it goes red

`tests/setup-sandbox-binding-forms.test.js` (25 tests) pins this. Every form that disarms the sandbox is measured, not assumed, and each takes it from 25 pass / 0 fail to 9 failures — caught by both the behavioural assertions and the structural check:

| mutation | behavioural | structural |
|---|---|---|
| `import { mkdtempSync } from 'node:fs'` (the original) | 9 fail | caught |
| `import 'node:fs'` (bare side-effect) | 9 fail | caught |
| multi-line named import | 9 fail | caught |
| `import { mkdtemp } from 'node:fs/promises'` | 9 fail | caught |

Design notes:
- **Every probe targets a protected path whose parent does not exist**, so the outcomes are cleanly distinguishable — `CHROXY_TEST_SANDBOX` (patched fn ran) vs `ENOENT` (reached the real fs) — and a *failing* run still creates nothing under the real home.
- Assertions are on a real call's outcome, never on `fn.name`. A name check is a reading; the first check of this sandbox during #7254 used a default import and reported the guard working.
- A **positive control** asserts an unprotected missing-parent path really does yield `ENOENT`, so the guarded assertions cannot pass by nothing reaching the syscall; a second asserts legitimate temp writes still succeed through the named binding.
- `appendFileSync` survives the mutant, and the file says why: Node routes it through the exports-object `writeFileSync`, so it is guarded transitively regardless of binding form. Verified by patching only `writeFileSync` and watching a named `appendFileSync` call trip it.

## What the review round changed

A five-lens adversarial review found this PR committing, in miniature, several faults it documents. All measured:

- **The count was wrong by its own blind spot.** "41 modules" came from a single-line-anchored grep, which misses multi-line import blocks like `src/logger.js`'s. It is **45**. Corrected in all five places.
- **The structural check saw one of four reintroduction forms.** It now blanks comments with the repo's single stripper (`scripts/lib/strip-comments.mjs`, #7248) rather than a second local regex — `_setup.mjs` quotes the offending import in its own header, so a raw read flags the comment warning against the thing (1 match raw, 0 stripped).
- **An assertion sat in a `describe()` body.** A throw during collection cancels siblings rather than failing one, and node:test reports that as `# fail 0` — a green summary for a suite that never ran. Moved into a `test()`.
- **`createWriteStream` was misclassified** — its bypass path is async, so a bypass read as "SUCCEEDED" and leaked an uncaughtException after the test ended. It has its own probe.
- **The header overclaimed the guard's reach**, in a PR about a guard that overclaimed its reach. "The write-side of `fs`" is a list, not a category: `unlinkSync`, `rmSync`, `cpSync`, `copyFileSync`, `symlinkSync`, `linkSync`, `chmodSync` all reach the real tree, and `cpSync`/`copyFileSync` were observed **creating a real file inside the live `~/.chroxy`**. Now named exactly, pointing at #7267.
- **`docs/false-safety-guards.md` said "Four ways that happens:" two lines above "In all five"** — the adjacent-field miss, in the doc about missing things.

## Full-suite fallout

Run on this branch and on `main` in the same environment, since this machine is locally red for unrelated reasons (a live daemon on :8765, a real `~/.codex/auth.json`):

| | tests | fail | cancelled | sandbox trips |
|---|---|---|---|---|
| `main` baseline | 13437 | 4 | 0 | 0 |
| this branch | 13462 | 4 | 0 | 0 |

Identical top-level failures on both (`runDoctorChecks`, `Codex spawn-and-assert`, `service`) — all environmental. A later local run added `TunnelManager Integration`, which reproduces on `main` (Cloudflare `error code: 1015`, quick-tunnel rate limiting). **CI's Server Tests job is green on this branch**, which is the authoritative signal. All 7 server shell lints, eslint, the AGENTS.md gate and the compiled-skill-artifact gate pass.

## Docs

`docs/false-safety-guards.md` gains this as entry 8, plus a **fifth failure mode**: *"never reached"* — the guard is correct and passes every input it sees, but only some callers route through it. It is the hardest of the five to spot, because reading the guard finds no defect; the wiring is what is wrong. The "the seven" heading is retired — the doc already warns a tally goes stale, and it was the tally that needed editing.

## Follow-ons filed

- #7267 — the sandbox patches no delete or copy API; `cpSync` writes into the real `~/.chroxy`
- #7268 — claude-hooks guard patches a narrower list and its errors carry no `code`
- #7269 — spawned provider binaries write to the real `~/.claude` / `~/.gemini`
- #7270 — `Server Windows Tests` runs a hardcoded file list, so new cross-platform tests silently never run
- #7271 — `_setup.mjs` leaks one `CHROXY_CONFIG_DIR` temp dir per test process

Closes #7262