### PR TITLE
fix(server): guard the whole fs mutation surface in the test sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,7 +311,9 @@ Every test that constructs a `SessionManager` **must** pass `stateFilePath` poin
 
 Two layers of defence are wired up:
 
-1. **Sandbox guard** (`packages/server/tests/_setup.mjs`, loaded via `node --import`) — monkey-patches `fs.writeFileSync`/`promises.writeFile`/`renameSync`/`mkdirSync`/`createWriteStream`/`openSync(w*)` to throw `CHROXY_TEST_SANDBOX` if any test writes to the real `~/.chroxy/` or `~/.claude/` tree. The error includes the call site, so the next bare `new SessionManager()` fails loudly at the offending test.
+1. **Sandbox guard** (`packages/server/tests/_setup.mjs`, loaded via `node --import`) — monkey-patches every `fs` function that takes a path and mutates the filesystem, across the sync, callback and `promises` surfaces, so any test write to the real `~/.chroxy/` or `~/.claude/` tree throws `CHROXY_TEST_SANDBOX`. The error includes the call site, so the next bare `new SessionManager()` fails loudly at the offending test.
+
+   The method list is NOT written here, and not written in `_setup.mjs` either: it expands from the one table in `scripts/lib/test-fs-sandbox.mjs`, which `packages/claude-hooks/tests/_setup.mjs` installs from too (the two guards were separate hand-written lists that had drifted in both directions — #7267, #7268). Adding a row there installs the guard AND its proof; `tests/setup-sandbox-coverage.test.js` fails if `GUARDED ∪ EXEMPT` stops covering the live `fs` surface, so a Node upgrade that adds a path-taking mutator goes red rather than quietly widening the hole. Reads are deliberately untouched — tests legitimately read the developer's real config.
 2. **CI lint** (`packages/server/scripts/lint-tests-state-file-path.sh`) — fails the build if any `new SessionManager(...)` in `tests/` is missing `stateFilePath`. Run locally with `cd packages/server && ./scripts/lint-tests-state-file-path.sh`.
 
 If you need to write to the real home for a legitimate reason (no current test does), set `process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'` scoped to the test and restore it after. The sandbox guard MUST stay enabled in `package.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,9 @@ Every test that constructs a `SessionManager` **must** pass `stateFilePath` poin
 
 Two layers of defence are wired up:
 
-1. **Sandbox guard** (`packages/server/tests/_setup.mjs`, loaded via `node --import`) — monkey-patches `fs.writeFileSync`/`promises.writeFile`/`renameSync`/`mkdirSync`/`createWriteStream`/`openSync(w*)` to throw `CHROXY_TEST_SANDBOX` if any test writes to the real `~/.chroxy/` or `~/.claude/` tree. The error includes the call site, so the next bare `new SessionManager()` fails loudly at the offending test.
+1. **Sandbox guard** (`packages/server/tests/_setup.mjs`, loaded via `node --import`) — monkey-patches every `fs` function that takes a path and mutates the filesystem, across the sync, callback and `promises` surfaces, so any test write to the real `~/.chroxy/` or `~/.claude/` tree throws `CHROXY_TEST_SANDBOX`. The error includes the call site, so the next bare `new SessionManager()` fails loudly at the offending test.
+
+   The method list is NOT written here, and not written in `_setup.mjs` either: it expands from the one table in `scripts/lib/test-fs-sandbox.mjs`, which `packages/claude-hooks/tests/_setup.mjs` installs from too (the two guards were separate hand-written lists that had drifted in both directions — #7267, #7268). Adding a row there installs the guard AND its proof; `tests/setup-sandbox-coverage.test.js` fails if `GUARDED ∪ EXEMPT` stops covering the live `fs` surface, so a Node upgrade that adds a path-taking mutator goes red rather than quietly widening the hole. Reads are deliberately untouched — tests legitimately read the developer's real config.
 2. **CI lint** (`packages/server/scripts/lint-tests-state-file-path.sh`) — fails the build if any `new SessionManager(...)` in `tests/` is missing `stateFilePath`. Run locally with `cd packages/server && ./scripts/lint-tests-state-file-path.sh`.
 
 If you need to write to the real home for a legitimate reason (no current test does), set `process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'` scoped to the test and restore it after. The sandbox guard MUST stay enabled in `package.json`.

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -133,6 +133,50 @@ is the control that proves the mechanism — a separate synthetic module,
 never ESM-imported by `_setup.mjs`, and all four of *its* binding forms were
 guarded the whole time.
 
+### 9. The sandbox that guarded a named list, not a category — `#7267`
+
+Found inside the fix for the eighth, which is how this document started.
+
+Making the guard visible to named importers (`#7262`) turned its *reach* into
+its only remaining problem — and its reach was a hand-written list of twelve
+method names. Everything that deletes, copies, links or changes a mode was
+outside it. Measured under the real harness, against the developer's live
+`~/.chroxy`:
+
+```
+writeFileSync mkdirSync openSync   GUARDED
+truncateSync                       GUARDED — but only because it opens 'r+'
+                                             and trips openSync
+unlinkSync rmSync rmdirSync        unguarded   (52 unlinkSync call sites in src/,
+chmodSync symlinkSync linkSync     unguarded    more than openSync has)
+cpSync copyFileSync                unguarded — and these CREATE
+fs.writeFile(path, data, cb)       unguarded — the whole callback surface
+```
+
+`cpSync` is the one worth remembering. A probe aimed at a path whose parent
+directory did **not** exist — chosen precisely so a failing measurement could
+create nothing — left a real directory tree inside the developer's live
+`~/.chroxy`, because `cpSync` creates the destination's parents before it fails.
+The safety argument was sound for every other API and wrong for that one, and
+nothing in the guard, the suite, lint or CI said a word.
+
+The fix is one exported array (`scripts/lib/test-fs-sandbox.mjs`) that expands
+to the patch list *and* to the probes asserting each patch fires, plus a
+complement (`FS_EXEMPTIONS`) that classifies every remaining `fs` function with
+a reason — so `GUARDED ∪ EXEMPT` must cover the live surface exactly, and a Node
+release that adds a path-taking mutator turns the suite red instead of widening
+the hole.
+
+**The part that is not obvious: a derived assertion cannot test the parameter it
+derives from.** Both lists expand from rows like `{ base: 'rename', paths: 2 }`,
+so narrowing one to `paths: 1` deletes the guard on the second argument *and*
+the probe that would have caught it — and the suite stays green while
+`rename(tmp, '~/.chroxy/session-state.json')` walks through. That mutation was
+run, and it passed. Which arguments are paths is therefore stated a second time,
+deliberately, as a specification with a reason per row; it is the only thing in
+the change written twice.
+
+
 What the reach was hiding: `tests/http-routes.test.js` renamed the developer's
 real `~/.chroxy/connection.json` aside in a `before` hook and moved it back in
 `after` — so a crash, a test timeout, or a SIGKILL between the two left a

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -133,6 +133,21 @@ is the control that proves the mechanism — a separate synthetic module,
 never ESM-imported by `_setup.mjs`, and all four of *its* binding forms were
 guarded the whole time.
 
+What the reach was hiding: `tests/http-routes.test.js` renamed the developer's
+real `~/.chroxy/connection.json` aside in a `before` hook and moved it back in
+`after` — so a crash, a test timeout, or a SIGKILL between the two left a
+running daemon's connection info stranded under a `.test-backup` suffix. It had
+also been unnecessary for some time, since `readConnectionInfo()` now resolves
+through the `CHROXY_CONFIG_DIR` redirect that `_setup.mjs` already points at a
+tmp dir. Arming the guard surfaced it on the first run.
+
+Two lessons specific to this mode. **A binding is not a value**: patching an
+object only reaches consumers who read through that object, and in ESM the
+consumer's import form decides that — invisibly, at link time, from a different
+file. And **the probe must use the same binding form as the code it vouches
+for**: the first check of this sandbox during `#7254` used a default import,
+reported the guard working, and was right about the only form it tested.
+
 ### 9. The sandbox that guarded a named list, not a category — `#7267`
 
 Found inside the fix for the eighth, which is how this document started.
@@ -147,8 +162,8 @@ outside it. Measured under the real harness, against the developer's live
 writeFileSync mkdirSync openSync   GUARDED
 truncateSync                       GUARDED — but only because it opens 'r+'
                                              and trips openSync
-unlinkSync rmSync rmdirSync        unguarded   (52 unlinkSync call sites in src/,
-chmodSync symlinkSync linkSync     unguarded    more than openSync has)
+unlinkSync rmSync rmdirSync        unguarded   (34 unlinkSync call sites in src/,
+chmodSync symlinkSync linkSync     unguarded    more than openSync's 14)
 cpSync copyFileSync                unguarded — and these CREATE
 fs.writeFile(path, data, cb)       unguarded — the whole callback surface
 ```
@@ -175,22 +190,6 @@ the probe that would have caught it — and the suite stays green while
 run, and it passed. Which arguments are paths is therefore stated a second time,
 deliberately, as a specification with a reason per row; it is the only thing in
 the change written twice.
-
-
-What the reach was hiding: `tests/http-routes.test.js` renamed the developer's
-real `~/.chroxy/connection.json` aside in a `before` hook and moved it back in
-`after` — so a crash, a test timeout, or a SIGKILL between the two left a
-running daemon's connection info stranded under a `.test-backup` suffix. It had
-also been unnecessary for some time, since `readConnectionInfo()` now resolves
-through the `CHROXY_CONFIG_DIR` redirect that `_setup.mjs` already points at a
-tmp dir. Arming the guard surfaced it on the first run.
-
-Two lessons specific to this mode. **A binding is not a value**: patching an
-object only reaches consumers who read through that object, and in ESM the
-consumer's import form decides that — invisibly, at link time, from a different
-file. And **the probe must use the same binding form as the code it vouches
-for**: the first check of this sandbox during `#7254` used a default import,
-reported the guard working, and was right about the only form it tested.
 
 ## The one that got me while writing this
 

--- a/packages/claude-hooks/tests/_setup.mjs
+++ b/packages/claude-hooks/tests/_setup.mjs
@@ -6,98 +6,77 @@
  * Two layers:
  *   1. temp HOME — `os.homedir()` follows $HOME, so default-path code
  *      (defaultSettingsPath, configDir) resolves into a throwaway dir
- *   2. write guard — fs write primitives throw CHROXY_TEST_SANDBOX if
- *      anything still targets the REAL home's .chroxy/.claude (belt and
+ *   2. write guard — every path-taking `fs` mutator throws CHROXY_TEST_SANDBOX
+ *      if anything still targets the REAL home's .chroxy/.claude (belt and
  *      braces against env leaking out of a spawned process)
+ *
+ * ── #7268: this used to be a SECOND, narrower guard ─────────────────────────
+ *
+ * Layer 2 was a hand-written list here and a different hand-written list in the
+ * server's `_setup.mjs`, and they drifted in both directions. This file patched
+ * `rmSync`/`unlinkSync` that the server did not; the server patched
+ * `openSync`, `appendFileSync` and four `promises` methods that this file did
+ * not. `openSync` was the load-bearing omission: `installer.js` writes
+ * atomically as `openSync -> writeSync -> fsyncSync -> renameSync`, so only the
+ * final `renameSync` was intercepted and a partial write that never reached the
+ * rename went straight to the real `~/.claude`. The errors also carried no
+ * `code`, only a message prefix, so a caller matching `err.code` — including a
+ * probe written against the server's convention — read a FIRED guard as an
+ * unrelated failure.
+ *
+ * Both halves are gone: the list, the installer and the error shape all come
+ * from `scripts/lib/test-fs-sandbox.mjs` now, which is the same code the server
+ * installs. Divergence is no longer something anyone has to remember.
+ *
+ * ── #7262: reach `node:fs` through `createRequire`, NEVER an ESM import ─────
+ *
+ * This file previously opened with `import fs from 'node:fs'` plus
+ * `import { mkdtempSync } from 'node:fs'`. Both are ESM imports, and ESM
+ * imports are evaluated before the module body — which links the `node:fs`
+ * synthetic module and snapshots its named exports off the UNPATCHED
+ * `module.exports`. The patches then landed on an object that named and
+ * namespace importers no longer read, so the guard covered exactly two of the
+ * four binding forms:
+ *
+ *   require / default import  -> guarded      namespace / named import -> NOT
+ *
+ * Measured on this package before the fix, writing to the real `~/.chroxy`:
+ * cjs GUARDED, default GUARDED, namespace ENOENT, named ENOENT. The default
+ * import was the patch TARGET and still did not save the other two, because
+ * linking is what does the damage, not which form you patch.
+ *
+ * The rule now covers `scripts/lib/test-fs-sandbox.mjs` too — it is linked as
+ * part of this file's graph, so an ESM `node:fs` import there would disarm the
+ * guard identically. It uses `createRequire` for that reason, and
+ * `tests/sandbox.test.js` walks the graph rather than trusting this comment.
  */
 
-import { createRequire } from 'node:module'
 import { tmpdir, homedir } from 'node:os'
-import { join, resolve, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
+import { createRequire } from 'node:module'
 
-// #7262: reach `node:fs` through `createRequire`, NEVER an ESM import.
-//
-// This file previously opened with `import fs from 'node:fs'` plus
-// `import { mkdtempSync } from 'node:fs'`. Both are ESM imports, and ESM
-// imports are evaluated before the module body — which links the `node:fs`
-// synthetic module and snapshots its named exports off the UNPATCHED
-// `module.exports`. The patches below then landed on an object that named and
-// namespace importers no longer read, so the guard covered exactly two of the
-// four binding forms:
-//
-//   require / default import  -> guarded      namespace / named import -> NOT
-//
-// Measured on this package before the fix, writing to the real
-// `~/.chroxy`: cjs GUARDED, default GUARDED, namespace ENOENT, named ENOENT.
-// The default import was the patch TARGET and still did not save the other
-// two, because linking is what does the damage, not which form you patch.
-//
-// `createRequire` gives the live CJS `module.exports` without linking the
-// synthetic module, so the snapshot is taken later, already patched. The
-// server's sandbox carries the same rule and the reasoning in full
-// (`packages/server/tests/_setup.mjs`), pinned there by
-// `tests/setup-sandbox-binding-forms.test.js`.
+import { installFsWriteSandbox } from '../../../scripts/lib/test-fs-sandbox.mjs'
+
 const require = createRequire(import.meta.url)
 const fs = require('node:fs')
-const { mkdtempSync } = fs
 
+// Captured BEFORE layer 1 relocates HOME — the guard must lock onto the
+// developer's actual home, not the throwaway one.
 const REAL_HOME = homedir()
-const GUARDED_ROOTS = [join(REAL_HOME, '.chroxy'), join(REAL_HOME, '.claude')]
+
+export const { installed: SANDBOX_INSTALLED, skipped: SANDBOX_SKIPPED } = installFsWriteSandbox({
+  protectedRoots: [resolve(REAL_HOME, '.chroxy'), resolve(REAL_HOME, '.claude')],
+  protectedFiles: [resolve(REAL_HOME, '.claude.json')],
+  // Same opt-out name the server uses, so one escape hatch is documented once.
+  // Nothing in this package's suite needs it except its own probe cleanup,
+  // which has to delete under the protected root to prove nothing leaked.
+  allowEnv: 'CHROXY_TEST_ALLOW_REAL_HOME_WRITES',
+  message: (method, target) =>
+    `CHROXY_TEST_SANDBOX: ${method} to real user state blocked: ${target}\n` +
+    `Tests must use temp paths (env overrides) — see tests/_setup.mjs`,
+})
 
 // Layer 1: relocate HOME before any test module resolves default paths.
-const SANDBOX_HOME = mkdtempSync(join(tmpdir(), 'chroxy-hooks-home-'))
+const SANDBOX_HOME = fs.mkdtempSync(join(tmpdir(), 'chroxy-hooks-home-'))
 process.env.HOME = SANDBOX_HOME
 process.env.USERPROFILE = SANDBOX_HOME
-
-function isGuardedPath(target) {
-  if (typeof target !== 'string' && !(target instanceof URL)) return false
-  let abs
-  try {
-    // `fileURLToPath` (not `.pathname`) for URL targets — it percent-decodes
-    // and handles the Windows `file:///C:/...` leading-slash quirk, same as
-    // packages/server/tests/_setup.mjs.
-    abs = resolve(target instanceof URL ? fileURLToPath(target) : target)
-  } catch {
-    return false
-  }
-  return GUARDED_ROOTS.some((root) => abs === root || abs.startsWith(root + sep))
-}
-
-function guard(original, name) {
-  return function guarded(target, ...args) {
-    if (isGuardedPath(target)) {
-      throw new Error(
-        `CHROXY_TEST_SANDBOX: ${name} to real user state blocked: ${target}\n` +
-        `Tests must use temp paths (env overrides) — see tests/_setup.mjs`
-      )
-    }
-    return original.call(this, target, ...args)
-  }
-}
-
-fs.writeFileSync = guard(fs.writeFileSync, 'writeFileSync')
-fs.mkdirSync = guard(fs.mkdirSync, 'mkdirSync')
-// renameSync checks BOTH paths: renaming real state OUT of the tree and
-// renaming a temp file INTO it are equally destructive (same as
-// packages/server/tests/_setup.mjs).
-const realRenameSync = fs.renameSync
-fs.renameSync = function guardedRenameSync(oldPath, newPath) {
-  if (isGuardedPath(oldPath) || isGuardedPath(newPath)) {
-    throw new Error(
-      `CHROXY_TEST_SANDBOX: renameSync touching real user state blocked: ${String(oldPath)} -> ${String(newPath)}\n` +
-      `Tests must use temp paths (env overrides) — see tests/_setup.mjs`
-    )
-  }
-  return realRenameSync.call(this, oldPath, newPath)
-}
-fs.rmSync = guard(fs.rmSync, 'rmSync')
-fs.unlinkSync = guard(fs.unlinkSync, 'unlinkSync')
-fs.createWriteStream = guard(fs.createWriteStream, 'createWriteStream')
-const realPromisesWriteFile = fs.promises.writeFile
-fs.promises.writeFile = async function guardedWriteFile(target, ...args) {
-  if (isGuardedPath(target)) {
-    throw new Error(`CHROXY_TEST_SANDBOX: promises.writeFile to real user state blocked: ${target}`)
-  }
-  return realPromisesWriteFile.call(this, target, ...args)
-}

--- a/packages/claude-hooks/tests/_setup.mjs
+++ b/packages/claude-hooks/tests/_setup.mjs
@@ -14,15 +14,26 @@
  *
  * Layer 2 was a hand-written list here and a different hand-written list in the
  * server's `_setup.mjs`, and they drifted in both directions. This file patched
- * `rmSync`/`unlinkSync` that the server did not; the server patched
- * `openSync`, `appendFileSync` and four `promises` methods that this file did
- * not. `openSync` was the load-bearing omission: `installer.js` writes
- * atomically as `openSync -> writeSync -> fsyncSync -> renameSync`, so only the
- * final `renameSync` was intercepted and a partial write that never reached the
- * rename went straight to the real `~/.claude`. The errors also carried no
- * `code`, only a message prefix, so a caller matching `err.code` — including a
- * probe written against the server's convention — read a FIRED guard as an
- * unrelated failure.
+ * `rmSync`/`unlinkSync` that the server did not; the server patched `openSync`,
+ * `appendFileSync`, `chmodSync` and four `promises` methods that this file did
+ * not.
+ *
+ * The `openSync` gap was LATENT, not reachable through `installHooks` — and the
+ * distinction matters, because #7268 originally claimed otherwise and the claim
+ * was wrong. `installer.js` writes atomically as
+ * `mkdirSync -> openSync -> writeSync -> fsyncSync -> chmodSync -> renameSync`,
+ * and `mkdirSync` WAS on this file's list, so the sequence aborted at step one.
+ * Measured against a fake protected home with exactly the old list installed:
+ * the guard fired once, on `mkdirSync`, and no directory, temp file or partial
+ * write was produced. `openSync` was covered the way `truncateSync` was covered
+ * on the server side — by accident, through a neighbour — which is precisely the
+ * kind of coverage #7267 replaces with the deliberate kind.
+ *
+ * The error shape was the half that HAD already cost something: these threw a
+ * plain `Error` with the token only in the message and no `code`, so a caller
+ * matching `err.code` — including a probe written against the server's
+ * convention — read a FIRED guard as an unrelated failure. That produced a
+ * false "unguarded" reading during the #7266 review.
  *
  * Both halves are gone: the list, the installer and the error shape all come
  * from `scripts/lib/test-fs-sandbox.mjs` now, which is the same code the server
@@ -47,8 +58,16 @@
  *
  * The rule now covers `scripts/lib/test-fs-sandbox.mjs` too — it is linked as
  * part of this file's graph, so an ESM `node:fs` import there would disarm the
- * guard identically. It uses `createRequire` for that reason, and
- * `tests/sandbox.test.js` walks the graph rather than trusting this comment.
+ * guard identically. It uses `createRequire` for that reason.
+ *
+ * The STRUCTURAL check on that rule lives only in the server package
+ * (`setup-sandbox-binding-forms.test.js`), which walks the shared module — the
+ * file both packages depend on. There is deliberately none here, and this file
+ * is therefore the one residual edge: reaching the server's comment stripper
+ * from this package would couple two packages' test trees to buy a better error
+ * message. What catches a regression here instead is behavioural — every probe
+ * in `tests/sandbox.test.js` fails at once — and that suite's failure message
+ * names this cause explicitly.
  */
 
 import { tmpdir, homedir } from 'node:os'
@@ -64,7 +83,11 @@ const fs = require('node:fs')
 // developer's actual home, not the throwaway one.
 const REAL_HOME = homedir()
 
-export const { installed: SANDBOX_INSTALLED, skipped: SANDBOX_SKIPPED } = installFsWriteSandbox({
+export const {
+  installed: SANDBOX_INSTALLED,
+  skipped: SANDBOX_SKIPPED,
+  isProtected: SANDBOX_IS_PROTECTED,
+} = installFsWriteSandbox({
   protectedRoots: [resolve(REAL_HOME, '.chroxy'), resolve(REAL_HOME, '.claude')],
   protectedFiles: [resolve(REAL_HOME, '.claude.json')],
   // Same opt-out name the server uses, so one escape hatch is documented once.

--- a/packages/claude-hooks/tests/sandbox.test.js
+++ b/packages/claude-hooks/tests/sandbox.test.js
@@ -1,0 +1,259 @@
+/**
+ * Write-sandbox coverage for @chroxy/claude-hooks (#7268).
+ *
+ * This package's `tests/_setup.mjs` is the sibling of the server's. Until
+ * #7267/#7268 the two were separate hand-written patch lists that had drifted
+ * in both directions, and this one was the narrower: it patched `writeFileSync`,
+ * `mkdirSync`, `renameSync`, `rmSync`, `unlinkSync`, `createWriteStream` and
+ * `promises.writeFile`, and nothing else.
+ *
+ * `openSync` was the load-bearing omission. `installer.js` writes settings
+ * atomically as `mkdirSync -> openSync -> writeSync -> fsyncSync -> chmodSync
+ * -> renameSync`, and only the first and last of those were guarded — so a
+ * partial write that never reached the rename went to the real `~/.claude`
+ * unopposed. `chmodSync` was missing too, on a file the installer deliberately
+ * mode-preserves.
+ *
+ * The errors were the second half of the bug: a plain `Error` whose MESSAGE
+ * began `CHROXY_TEST_SANDBOX:`, with no `code`. Any caller matching on
+ * `err.code` — including a probe written against the server's convention —
+ * read a FIRED guard as an unrelated failure, which cost a false reading during
+ * the #7266 review.
+ *
+ * Both halves are fixed by there being one implementation
+ * (`scripts/lib/test-fs-sandbox.mjs`), so the assertions here are mostly about
+ * proving THIS package installed it and that its own code cannot slip past.
+ *
+ * Deliberate asymmetry with the server suite: there is no import-graph walk
+ * here. The server's `setup-sandbox-binding-forms.test.js` walks the shared
+ * module — the file both packages depend on — and the only residual is this
+ * package's own `_setup.mjs`, whose behavioural probes below go red instantly
+ * if an ESM `node:fs` import is reintroduced. Reaching the server's comment
+ * stripper from this package would couple two packages' test trees to save an
+ * error message, so it is not done; the probe failure message names the cause
+ * instead.
+ */
+
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert'
+
+import * as fsNamespace from 'node:fs'
+import * as fspNamespace from 'node:fs/promises'
+import { readFileSync as namedReadFileSync, existsSync as namedExistsSync, rmSync as namedRmSync } from 'node:fs'
+import { homedir, tmpdir, userInfo } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { SANDBOX_INSTALLED, SANDBOX_SKIPPED } from './_setup.mjs'
+import {
+  FS_EXEMPTIONS,
+  SANDBOX_ERROR_CODE,
+  SANDBOX_MARKER,
+  guardedMethodNames,
+} from '../../../scripts/lib/test-fs-sandbox.mjs'
+import { probePlans, runProbe, GUARDED, REACHED_REAL_FS } from '../../../scripts/lib/test-fs-sandbox-probes.mjs'
+import { installHooks } from '../src/installer.js'
+
+// `_setup.mjs` relocates HOME to a throwaway dir, so `homedir()` here is the
+// SANDBOX home, not the developer's. The guard locks onto the REAL one, which
+// has to be recovered a way that survives layer 1: `os.userInfo()` reads the
+// passwd entry (SID on Windows) and ignores $HOME, so it still points at the
+// home the guard is defending. Aiming a probe at `homedir()` instead would
+// target the temp dir and every assertion below would pass for free.
+const PASSWD_HOME = userInfo().homedir
+
+const PROBE_ROOT = join(PASSWD_HOME, '.chroxy', `__chroxy-hooks-sandbox-${process.pid}`)
+const protectedPath = join(PROBE_ROOT, 'd', 'probe.tmp')
+const spare = join(tmpdir(), `chroxy-hooks-sandbox-${process.pid}`, 'spare.tmp')
+const absentSource = join(tmpdir(), `chroxy-hooks-sandbox-absent-${process.pid}`)
+
+function removeProbeRoot () {
+  const prev = process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
+  process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'
+  try { namedRmSync(PROBE_ROOT, { recursive: true, force: true }) } finally {
+    if (prev === undefined) delete process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
+    else process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = prev
+  }
+}
+
+after(() => {
+  removeProbeRoot()
+  namedRmSync(join(tmpdir(), `chroxy-hooks-sandbox-${process.pid}`), { recursive: true, force: true })
+})
+
+describe('claude-hooks write sandbox: the real home is refused (#7268)', () => {
+  test('layer 1 relocated HOME, and the guard still points at the REAL home', () => {
+    assert.notStrictEqual(
+      homedir(), PASSWD_HOME,
+      'tests/_setup.mjs must relocate HOME; without layer 1 the default-path code ' +
+      'under test resolves straight into the developer\'s real ~/.claude.',
+    )
+    assert.ok(PROBE_ROOT.startsWith(PASSWD_HOME), 'the probe must aim at the real home, or it proves nothing')
+  })
+
+  for (const plan of probePlans({ protectedPath, spare, absentSource })) {
+    test(`${plan.label} is guarded`, async () => {
+      const verdict = await runProbe(plan, {
+        fs: fsNamespace,
+        promises: fspNamespace,
+        cleanup: removeProbeRoot,
+      })
+      assert.strictEqual(
+        verdict, GUARDED,
+        `${plan.label} reached the real filesystem. If EVERY probe in this file ` +
+        `failed at once, something in tests/_setup.mjs is ESM-importing 'node:fs' ` +
+        `again — that snapshots the unpatched exports before the body runs and ` +
+        `disarms the guard for named and namespace consumers (#7262).`,
+      )
+    })
+  }
+})
+
+describe('claude-hooks write sandbox: the error shape matches the server (#7268)', () => {
+  test('the guard error carries code CHROXY_TEST_SANDBOX, not just a message prefix', () => {
+    let caught = null
+    try { fsNamespace.writeFileSync(protectedPath, 'probe') } catch (err) { caught = err }
+    assert.ok(caught, 'the guard did not fire at all')
+    assert.strictEqual(
+      caught.code, SANDBOX_ERROR_CODE,
+      'This guard used to throw a bare Error with the token only in its message, so ' +
+      'a caller matching on `err.code` classified a FIRED guard as an unrelated ' +
+      'failure (#7268). The code is the contract; the message is for humans.',
+    )
+    assert.match(caught.message, /CHROXY_TEST_SANDBOX/, 'the human-readable token is still expected in the message')
+  })
+
+  test('the same guard is installed here as in the server package', () => {
+    const { sync, callback, promises } = guardedMethodNames()
+    const expected = [...sync, ...callback.map((m) => `${m} (callback)`), ...promises.map((m) => `promises.${m}`)]
+    const missing = expected.filter((m) => !SANDBOX_INSTALLED.includes(m))
+    assert.deepStrictEqual(
+      missing, [],
+      'This package installs fewer guards than the shared module defines. The two ' +
+      'sandboxes drifted apart once (#7268) and converged on one list precisely so ' +
+      'this cannot happen silently again.',
+    )
+    for (const { reason } of SANDBOX_SKIPPED) {
+      assert.strictEqual(reason, 'absent', 'the only legitimate reason to skip is that the platform lacks the method')
+    }
+  })
+
+  test('the live fs objects carry exactly the guards that were reported installed', () => {
+    const marked = []
+    for (const host of [fsNamespace, fspNamespace]) {
+      for (const key of Object.keys(host)) {
+        const fn = host[key]
+        if (typeof fn === 'function' && fn[SANDBOX_MARKER]) marked.push(fn[SANDBOX_MARKER])
+      }
+    }
+    assert.deepStrictEqual(marked.sort(), [...SANDBOX_INSTALLED].sort())
+  })
+})
+
+describe('claude-hooks write sandbox: installer.js cannot reach the real ~/.claude (#7268)', () => {
+  // `writeSettingsAtomic` is `mkdirSync -> openSync -> writeSync -> fsyncSync ->
+  // chmodSync -> renameSync`. Before #7268 only `mkdirSync` and `renameSync`
+  // were guarded here, so the OPEN — the step that actually creates the temp
+  // file — was unopposed.
+  test('installHooks against the real settings path is blocked', () => {
+    const realSettings = join(PASSWD_HOME, '.claude', 'settings.json')
+    let caught = null
+    try { installHooks({ settingsPath: realSettings }) } catch (err) { caught = err }
+    assert.ok(caught, 'installHooks wrote to the developer\'s real ~/.claude/settings.json')
+    assert.strictEqual(caught.code, SANDBOX_ERROR_CODE, `blocked for the wrong reason: ${caught.message}`)
+  })
+
+  test('the temp file the atomic write opens is itself protected', () => {
+    // The temp path is a SIBLING of the resolved settings path
+    // (`<settings>.chroxy-hooks-<pid>.tmp`), so it lands under ~/.claude too.
+    // Proven by calling the exact step that opens it rather than by asserting
+    // the filename shape, which would be a copy of installer.js's format string
+    // living in a test — a hardcoded list beside a thing that changes.
+    const sibling = join(PASSWD_HOME, '.claude', `settings.json.chroxy-hooks-${process.pid}.tmp`)
+    let caught = null
+    try { fsNamespace.openSync(sibling, 'w') } catch (err) { caught = err }
+    assert.ok(caught && caught.code === SANDBOX_ERROR_CODE, 'openSync on the atomic-write temp path was not guarded')
+  })
+
+  test('every node:fs function this package imports is guarded or exempt with a reason', () => {
+    // The drift-proof half: rather than naming installer.js's four write steps
+    // (a list beside a set that grows), read what the source ACTUALLY imports
+    // and require every one of them to be classified. A new `unlinkSync` in
+    // emit.js is then covered the day it is written.
+    //
+    // The scan runs on raw source, so an `import { … } from 'node:fs'` quoted
+    // inside a comment would be counted. That direction is safe: it can only
+    // over-report and fail loudly, never under-report and pass.
+    const { sync, callback } = guardedMethodNames()
+    const guarded = new Set([...sync, ...callback])
+    const srcDir = fileURLToPath(new URL('../src/', import.meta.url))
+    const unclassified = []
+    let importsSeen = 0
+    for (const file of fsNamespace.readdirSync(srcDir).filter((f) => f.endsWith('.js'))) {
+      const source = namedReadFileSync(join(srcDir, file), 'utf8')
+      // Multi-line import blocks included on purpose: a line-anchored pattern
+      // undercounts them, which is how #7266's own module count came out 41
+      // instead of 45.
+      for (const m of source.matchAll(/import\s*\{([\s\S]*?)\}\s*from\s*['"](?:node:)?fs['"]/g)) {
+        for (const raw of m[1].split(',')) {
+          const name = raw.trim().split(/\s+as\s+/)[0].trim()
+          if (!name) continue
+          importsSeen++
+          if (!guarded.has(name) && !(name in FS_EXEMPTIONS)) unclassified.push(`${file}: ${name}`)
+        }
+      }
+    }
+    assert.ok(importsSeen > 0, 'the scan found no node:fs imports at all, so it proved nothing about this package')
+    assert.deepStrictEqual(
+      unclassified, [],
+      'These fs functions are used by claude-hooks but the sandbox neither guards ' +
+      'nor exempts them. Classify each in scripts/lib/test-fs-sandbox.mjs.',
+    )
+  })
+})
+
+describe('claude-hooks write sandbox: controls (#7268)', () => {
+  test('an UNPROTECTED missing-parent path reaches the real fs (ENOENT)', async () => {
+    const control = probePlans({
+      protectedPath: join(tmpdir(), `chroxy-hooks-control-${process.pid}`, 'probe.tmp'),
+      spare,
+      absentSource,
+    })
+    for (const label of ['writeFileSync', 'unlink (callback)', 'promises.rm']) {
+      const plan = control.find((p) => p.label === label)
+      assert.strictEqual(
+        await runProbe(plan, { fs: fsNamespace, promises: fspNamespace }),
+        REACHED_REAL_FS,
+        `The control (${label}) did not reach the real fs, so ENOENT is not a valid ` +
+        `signature for "bypassed" and every assertion above proves nothing.`,
+      )
+    }
+  })
+
+  test('the sandbox HOME is writable — the guard discriminates by path', () => {
+    const file = join(homedir(), '.claude', 'settings.json')
+    fsNamespace.mkdirSync(join(homedir(), '.claude'), { recursive: true })
+    fsNamespace.writeFileSync(file, '{}')
+    assert.strictEqual(namedReadFileSync(file, 'utf8'), '{}')
+    // Same relative path, real home: refused.
+    assert.throws(
+      () => fsNamespace.writeFileSync(join(PASSWD_HOME, '.claude', 'settings.json'), '{}'),
+      (err) => err.code === SANDBOX_ERROR_CODE,
+    )
+  })
+
+  test('installHooks into the sandbox HOME still works end to end', () => {
+    const settingsPath = join(homedir(), '.claude', 'install-probe.json')
+    assert.strictEqual(installHooks({ settingsPath }), settingsPath)
+    const written = JSON.parse(namedReadFileSync(settingsPath, 'utf8'))
+    assert.ok(written.hooks, 'installHooks wrote no hooks — the guard may be blocking legitimate writes')
+  })
+})
+
+describe('claude-hooks write sandbox: the probes created nothing under the real home (#7268)', () => {
+  test('no probe root exists under the real ~/.chroxy', () => {
+    const leaked = namedExistsSync(PROBE_ROOT)
+    if (leaked) removeProbeRoot()
+    assert.strictEqual(leaked, false, `A probe created real state at ${PROBE_ROOT}.`)
+  })
+})

--- a/packages/claude-hooks/tests/sandbox.test.js
+++ b/packages/claude-hooks/tests/sandbox.test.js
@@ -7,18 +7,22 @@
  * `mkdirSync`, `renameSync`, `rmSync`, `unlinkSync`, `createWriteStream` and
  * `promises.writeFile`, and nothing else.
  *
- * `openSync` was the load-bearing omission. `installer.js` writes settings
- * atomically as `mkdirSync -> openSync -> writeSync -> fsyncSync -> chmodSync
- * -> renameSync`, and only the first and last of those were guarded — so a
- * partial write that never reached the rename went to the real `~/.claude`
- * unopposed. `chmodSync` was missing too, on a file the installer deliberately
- * mode-preserves.
+ * `openSync` and `chmodSync` were missing, but NOT exploitable through
+ * `installHooks`, and #7268 was wrong to say they were. `installer.js` writes
+ * settings atomically as `mkdirSync -> openSync -> writeSync -> fsyncSync ->
+ * chmodSync -> renameSync`, and `mkdirSync` was guarded — so the sequence
+ * aborted at step one. Measured against a fake protected home with exactly the
+ * old list installed: one guard fired (`mkdirSync`), and no directory, temp
+ * file or partial write appeared. That is accidental coverage through a
+ * neighbour, the same shape as `truncateSync` being covered only via
+ * `openSync`; it is why the tests below assert each step is guarded ON ITS OWN
+ * rather than asserting that `installHooks` throws and calling it proven.
  *
- * The errors were the second half of the bug: a plain `Error` whose MESSAGE
- * began `CHROXY_TEST_SANDBOX:`, with no `code`. Any caller matching on
- * `err.code` — including a probe written against the server's convention —
- * read a FIRED guard as an unrelated failure, which cost a false reading during
- * the #7266 review.
+ * The error shape is the half that had already cost something: a plain `Error`
+ * whose MESSAGE began `CHROXY_TEST_SANDBOX:`, with no `code`. Any caller
+ * matching on `err.code` — including a probe written against the server's
+ * convention — read a FIRED guard as an unrelated failure, which produced a
+ * false "unguarded" reading during the #7266 review.
  *
  * Both halves are fixed by there being one implementation
  * (`scripts/lib/test-fs-sandbox.mjs`), so the assertions here are mostly about
@@ -44,14 +48,17 @@ import { homedir, tmpdir, userInfo } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { SANDBOX_INSTALLED, SANDBOX_SKIPPED } from './_setup.mjs'
+import { SANDBOX_INSTALLED, SANDBOX_SKIPPED, SANDBOX_IS_PROTECTED } from './_setup.mjs'
 import {
   FS_EXEMPTIONS,
   SANDBOX_ERROR_CODE,
   SANDBOX_MARKER,
   guardedMethodNames,
 } from '../../../scripts/lib/test-fs-sandbox.mjs'
-import { probePlans, runProbe, GUARDED, REACHED_REAL_FS } from '../../../scripts/lib/test-fs-sandbox-probes.mjs'
+import {
+  probePlans, runProbe, partitionByAvailability, planLabel,
+  GUARDED, REACHED_REAL_FS,
+} from '../../../scripts/lib/test-fs-sandbox-probes.mjs'
 import { installHooks } from '../src/installer.js'
 
 // `_setup.mjs` relocates HOME to a throwaway dir, so `homedir()` here is the
@@ -63,6 +70,9 @@ import { installHooks } from '../src/installer.js'
 const PASSWD_HOME = userInfo().homedir
 
 const PROBE_ROOT = join(PASSWD_HOME, '.chroxy', `__chroxy-hooks-sandbox-${process.pid}`)
+// The other protected root. installer.js writes into ~/.claude, so the
+// installer probes need a target there — with a parent that does not exist.
+const REAL_CLAUDE_PROBE = join(PASSWD_HOME, '.claude', `__chroxy-hooks-sandbox-${process.pid}`)
 const protectedPath = join(PROBE_ROOT, 'd', 'probe.tmp')
 const spare = join(tmpdir(), `chroxy-hooks-sandbox-${process.pid}`, 'spare.tmp')
 const absentSource = join(tmpdir(), `chroxy-hooks-sandbox-absent-${process.pid}`)
@@ -70,7 +80,10 @@ const absentSource = join(tmpdir(), `chroxy-hooks-sandbox-absent-${process.pid}`
 function removeProbeRoot () {
   const prev = process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
   process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'
-  try { namedRmSync(PROBE_ROOT, { recursive: true, force: true }) } finally {
+  try {
+    namedRmSync(PROBE_ROOT, { recursive: true, force: true })
+    namedRmSync(REAL_CLAUDE_PROBE, { recursive: true, force: true })
+  } finally {
     if (prev === undefined) delete process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
     else process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = prev
   }
@@ -81,6 +94,15 @@ after(() => {
   namedRmSync(join(tmpdir(), `chroxy-hooks-sandbox-${process.pid}`), { recursive: true, force: true })
 })
 
+// Only what this platform has. `lchmod`/`lchmodSync` are macOS-only, and probing
+// them on Linux calls `undefined` — a test defect that says nothing about the
+// guard. Dropped plans are corroborated below against the installer's own skip
+// record, so "cannot run this" never becomes "nothing to check".
+const { runnable, unavailable } = partitionByAvailability(
+  probePlans({ protectedPath, spare, absentSource }),
+  { fs: fsNamespace, promises: fspNamespace },
+)
+
 describe('claude-hooks write sandbox: the real home is refused (#7268)', () => {
   test('layer 1 relocated HOME, and the guard still points at the REAL home', () => {
     assert.notStrictEqual(
@@ -88,10 +110,21 @@ describe('claude-hooks write sandbox: the real home is refused (#7268)', () => {
       'tests/_setup.mjs must relocate HOME; without layer 1 the default-path code ' +
       'under test resolves straight into the developer\'s real ~/.claude.',
     )
-    assert.ok(PROBE_ROOT.startsWith(PASSWD_HOME), 'the probe must aim at the real home, or it proves nothing')
+    // Not `PROBE_ROOT.startsWith(PASSWD_HOME)` — that is built from PASSWD_HOME
+    // two lines up and can never fail. The property that matters is that the
+    // GUARD considers this path protected: the guard locked onto `os.homedir()`
+    // (which follows $HOME) while the probe uses the passwd entry, and a
+    // container job that sets HOME=/github/home makes those different. Then
+    // every probe below would aim at an unprotected path and fail with a
+    // message blaming #7262.
+    assert.ok(
+      SANDBOX_IS_PROTECTED(PROBE_ROOT),
+      `The guard does not consider ${PROBE_ROOT} protected, so no probe here ` +
+      `proves anything. $HOME and the passwd home have diverged.`,
+    )
   })
 
-  for (const plan of probePlans({ protectedPath, spare, absentSource })) {
+  for (const plan of runnable) {
     test(`${plan.label} is guarded`, async () => {
       const verdict = await runProbe(plan, {
         fs: fsNamespace,
@@ -125,7 +158,14 @@ describe('claude-hooks write sandbox: the error shape matches the server (#7268)
 
   test('the same guard is installed here as in the server package', () => {
     const { sync, callback, promises } = guardedMethodNames()
-    const expected = [...sync, ...callback.map((m) => `${m} (callback)`), ...promises.map((m) => `promises.${m}`)]
+    // Platform-aware: a method Node does not define here cannot be guarded, and
+    // the skip is corroborated by the loop below requiring reason 'absent'.
+    const exists = (label, method, host) => typeof host[method] === 'function'
+    const expected = [
+      ...sync.filter((m) => exists(m, m, fsNamespace)),
+      ...callback.filter((m) => exists(m, m, fsNamespace)).map((m) => `${m} (callback)`),
+      ...promises.filter((m) => exists(m, m, fspNamespace)).map((m) => `promises.${m}`),
+    ]
     const missing = expected.filter((m) => !SANDBOX_INSTALLED.includes(m))
     assert.deepStrictEqual(
       missing, [],
@@ -136,6 +176,12 @@ describe('claude-hooks write sandbox: the error shape matches the server (#7268)
     for (const { reason } of SANDBOX_SKIPPED) {
       assert.strictEqual(reason, 'absent', 'the only legitimate reason to skip is that the platform lacks the method')
     }
+    const skipped = new Set(SANDBOX_SKIPPED.map((s) => s.name))
+    assert.deepStrictEqual(
+      unavailable.map(planLabel).filter((l) => !skipped.has(l)), [],
+      'A probe was dropped as unavailable while the installer guarded the method ' +
+      'anyway — the method exists and nothing proves its guard fires.',
+    )
   })
 
   test('the live fs objects carry exactly the guards that were reported installed', () => {
@@ -153,13 +199,22 @@ describe('claude-hooks write sandbox: the error shape matches the server (#7268)
 describe('claude-hooks write sandbox: installer.js cannot reach the real ~/.claude (#7268)', () => {
   // `writeSettingsAtomic` is `mkdirSync -> openSync -> writeSync -> fsyncSync ->
   // chmodSync -> renameSync`. Before #7268 only `mkdirSync` and `renameSync`
-  // were guarded here, so the OPEN — the step that actually creates the temp
-  // file — was unopposed.
-  test('installHooks against the real settings path is blocked', () => {
-    const realSettings = join(PASSWD_HOME, '.claude', 'settings.json')
+  // were guarded — which happened to be enough to stop THIS caller, because the
+  // mkdir is first. That is exactly why the integration assertion below is not
+  // sufficient on its own: it would pass against the old, narrower guard too.
+  // Each step is therefore also asserted individually.
+  test('installHooks against a real-home settings path is blocked', () => {
+    // NOT `~/.claude/settings.json` itself. That file exists, is 0600, and holds
+    // the developer's live hook configuration — and `installHooks` MERGES and
+    // rewrites it. Aiming a probe there means that the moment this suite's
+    // premise fails (the guard regressed), the test destroys the very thing the
+    // guard exists to protect. Every other probe in this repo targets a path
+    // with a MISSING PARENT so a failing run is inert; this one now does too,
+    // and it is still under the protected root, which is all the guard reads.
+    const settingsPath = join(REAL_CLAUDE_PROBE, 'settings.json')
     let caught = null
-    try { installHooks({ settingsPath: realSettings }) } catch (err) { caught = err }
-    assert.ok(caught, 'installHooks wrote to the developer\'s real ~/.claude/settings.json')
+    try { installHooks({ settingsPath }) } catch (err) { caught = err }
+    assert.ok(caught, 'installHooks reached the real ~/.claude tree')
     assert.strictEqual(caught.code, SANDBOX_ERROR_CODE, `blocked for the wrong reason: ${caught.message}`)
   })
 
@@ -169,41 +224,80 @@ describe('claude-hooks write sandbox: installer.js cannot reach the real ~/.clau
     // Proven by calling the exact step that opens it rather than by asserting
     // the filename shape, which would be a copy of installer.js's format string
     // living in a test — a hardcoded list beside a thing that changes.
-    const sibling = join(PASSWD_HOME, '.claude', `settings.json.chroxy-hooks-${process.pid}.tmp`)
+    const sibling = join(REAL_CLAUDE_PROBE, `settings.json.chroxy-hooks-${process.pid}.tmp`)
+    let fd = null
     let caught = null
-    try { fsNamespace.openSync(sibling, 'w') } catch (err) { caught = err }
+    try { fd = fsNamespace.openSync(sibling, 'w') } catch (err) { caught = err }
+    // A bypass would return a live fd, not just create a file — close it rather
+    // than leaking it into the rest of the run.
+    if (fd !== null) { try { fsNamespace.closeSync(fd) } catch { /* best effort */ } }
     assert.ok(caught && caught.code === SANDBOX_ERROR_CODE, 'openSync on the atomic-write temp path was not guarded')
   })
 
   test('every node:fs function this package imports is guarded or exempt with a reason', () => {
-    // The drift-proof half: rather than naming installer.js's four write steps
-    // (a list beside a set that grows), read what the source ACTUALLY imports
-    // and require every one of them to be classified. A new `unlinkSync` in
-    // emit.js is then covered the day it is written.
+    // The drift-proof half: rather than naming installer.js's write steps (a
+    // list beside a set that grows), read what the source ACTUALLY imports and
+    // require every name to be classified. A new `unlinkSync` in emit.js is
+    // then covered the day it is written.
     //
-    // The scan runs on raw source, so an `import { … } from 'node:fs'` quoted
-    // inside a comment would be counted. That direction is safe: it can only
-    // over-report and fail loudly, never under-report and pass.
-    const { sync, callback } = guardedMethodNames()
-    const guarded = new Set([...sync, ...callback])
-    const srcDir = fileURLToPath(new URL('../src/', import.meta.url))
+    // Recursive, and it covers `bin/` as well as `src/` — the first version
+    // walked one flat directory and would have missed a subdirectory silently.
+    // It reads `node:fs` AND `node:fs/promises`, because a promise-side name is
+    // classified by a different table.
+    //
+    // The scan runs on raw source, so an import quoted inside a comment is
+    // counted. That direction is safe: it can only over-report and fail loudly.
+    const { sync, callback, promises } = guardedMethodNames()
+    const syncSide = new Set([...sync, ...callback])
+    const promiseSide = new Set(promises)
+
+    const roots = [
+      fileURLToPath(new URL('../src/', import.meta.url)),
+      fileURLToPath(new URL('../bin/', import.meta.url)),
+    ]
+    const files = []
+    const walk = (dir) => {
+      for (const entry of fsNamespace.readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) walk(full)
+        else if (/\.(js|mjs)$/.test(entry.name)) files.push(full)
+      }
+    }
+    for (const root of roots) if (fsNamespace.existsSync(root)) walk(root)
+
     const unclassified = []
+    const unverifiable = []
     let importsSeen = 0
-    for (const file of fsNamespace.readdirSync(srcDir).filter((f) => f.endsWith('.js'))) {
-      const source = namedReadFileSync(join(srcDir, file), 'utf8')
+    for (const file of files) {
+      const source = namedReadFileSync(file, 'utf8')
+      const rel = file.slice(file.indexOf('/claude-hooks/') + 1)
       // Multi-line import blocks included on purpose: a line-anchored pattern
       // undercounts them, which is how #7266's own module count came out 41
       // instead of 45.
-      for (const m of source.matchAll(/import\s*\{([\s\S]*?)\}\s*from\s*['"](?:node:)?fs['"]/g)) {
+      for (const m of source.matchAll(/import\s*\{([\s\S]*?)\}\s*from\s*['"](?:node:)?fs(\/promises)?['"]/g)) {
+        const table = m[2] ? promiseSide : syncSide
         for (const raw of m[1].split(',')) {
           const name = raw.trim().split(/\s+as\s+/)[0].trim()
           if (!name) continue
           importsSeen++
-          if (!guarded.has(name) && !(name in FS_EXEMPTIONS)) unclassified.push(`${file}: ${name}`)
+          if (!table.has(name) && !(name in FS_EXEMPTIONS)) unclassified.push(`${rel}: ${name}`)
         }
       }
+      // A default or namespace import exposes the WHOLE module, so no list of
+      // names can be extracted and this check cannot speak for the file. Say so
+      // instead of scanning it and reporting nothing found.
+      for (const m of source.matchAll(/import\s+(?:\*\s+as\s+)?[\w$]+\s*(?:,\s*\{[\s\S]*?\}\s*)?from\s*['"](?:node:)?fs(?:\/promises)?['"]/g)) {
+        unverifiable.push(`${rel}: ${m[0].trim()}`)
+      }
     }
+    assert.ok(files.length > 0, 'the scan walked no files at all, so it proved nothing')
     assert.ok(importsSeen > 0, 'the scan found no node:fs imports at all, so it proved nothing about this package')
+    assert.deepStrictEqual(
+      unverifiable, [],
+      'A default or namespace `fs` import means this check cannot enumerate what ' +
+      'the file uses. Switch it to named imports, or this scan silently vouches ' +
+      'for a file it never examined.',
+    )
     assert.deepStrictEqual(
       unclassified, [],
       'These fs functions are used by claude-hooks but the sandbox neither guards ' +
@@ -230,14 +324,34 @@ describe('claude-hooks write sandbox: controls (#7268)', () => {
     }
   })
 
+  test('the bare protected FILE ~/.claude.json is guarded, and only that exact path', () => {
+    // Same mechanism, same gap: `protectedFiles` is checked separately from the
+    // roots, and nothing here proved it until a mutation removed the entry and
+    // the suite stayed green.
+    // `renameSync(<absent source>, target)`: ~/.claude.json's parent is $HOME and
+    // EXISTS, so a write probe would overwrite the developer's real file the
+    // moment the guard regressed. With a missing source a bypass fails before
+    // touching the destination.
+    const attempt = (target) => {
+      try { fsNamespace.renameSync(absentSource, target); return 'no-error' } catch (err) { return err.code }
+    }
+    assert.strictEqual(attempt(join(PASSWD_HOME, '.claude.json')), SANDBOX_ERROR_CODE)
+    assert.strictEqual(
+      attempt(join(tmpdir(), '.claude.json')), 'ENOENT',
+      'The guard matched on the file NAME rather than the full path.',
+    )
+  })
+
   test('the sandbox HOME is writable — the guard discriminates by path', () => {
     const file = join(homedir(), '.claude', 'settings.json')
     fsNamespace.mkdirSync(join(homedir(), '.claude'), { recursive: true })
     fsNamespace.writeFileSync(file, '{}')
     assert.strictEqual(namedReadFileSync(file, 'utf8'), '{}')
-    // Same relative path, real home: refused.
+    // Same relative shape under the REAL home: refused. Aimed inside the
+    // missing-parent probe dir rather than at the live settings.json, so a
+    // regression fails the assertion instead of truncating real config.
     assert.throws(
-      () => fsNamespace.writeFileSync(join(PASSWD_HOME, '.claude', 'settings.json'), '{}'),
+      () => fsNamespace.writeFileSync(join(REAL_CLAUDE_PROBE, 'settings.json'), '{}'),
       (err) => err.code === SANDBOX_ERROR_CODE,
     )
   })
@@ -251,9 +365,9 @@ describe('claude-hooks write sandbox: controls (#7268)', () => {
 })
 
 describe('claude-hooks write sandbox: the probes created nothing under the real home (#7268)', () => {
-  test('no probe root exists under the real ~/.chroxy', () => {
-    const leaked = namedExistsSync(PROBE_ROOT)
-    if (leaked) removeProbeRoot()
-    assert.strictEqual(leaked, false, `A probe created real state at ${PROBE_ROOT}.`)
+  test('no probe root exists under the real ~/.chroxy or ~/.claude', () => {
+    const leaked = [PROBE_ROOT, REAL_CLAUDE_PROBE].filter((p) => namedExistsSync(p))
+    if (leaked.length > 0) removeProbeRoot()
+    assert.deepStrictEqual(leaked, [], 'A probe created real state under the developer\'s home.')
   })
 })

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -21,7 +21,7 @@
  *
  * It was a hand-written list until #7267, and the list was the bug. Measured
  * under this harness before that change, these reached the real tree
- * unimpeded: `unlinkSync` (52 call sites under `src/`, more than `openSync`),
+ * unimpeded: `unlinkSync` (34 call sites under `src/`, more than `openSync`),
  * `rmSync`, `rmdirSync`, `cpSync`, `copyFileSync`, `symlinkSync`, `linkSync`,
  * `chmodSync`, the whole `promises` half of the same, and — worst — the entire
  * CALLBACK surface including plain `fs.writeFile(path, data, cb)`. `cpSync`
@@ -32,8 +32,8 @@
  *
  * "Category" is enforced, not asserted: `FS_EXEMPTIONS` in the shared module
  * classifies every remaining `fs` function with a reason, and
- * `tests/setup-sandbox-binding-forms.test.js` fails if their union stops
- * covering the live `fs` surface. A Node upgrade that adds a path-taking
+ * `tests/setup-sandbox-coverage.test.js` fails if their union stops covering
+ * the live `fs` surface. A Node upgrade that adds a path-taking
  * mutator turns the suite red instead of quietly widening the hole.
  *
  * Read-side fs calls are untouched by design, so tests that legitimately
@@ -131,7 +131,11 @@ const fs = require('node:fs')
 // `byok-credentials.test.js`) neither widen nor narrow it.
 const REAL_HOME = homedir()
 
-export const { installed: SANDBOX_INSTALLED, skipped: SANDBOX_SKIPPED } = installFsWriteSandbox({
+export const {
+  installed: SANDBOX_INSTALLED,
+  skipped: SANDBOX_SKIPPED,
+  isProtected: SANDBOX_IS_PROTECTED,
+} = installFsWriteSandbox({
   protectedRoots: [resolve(REAL_HOME, '.chroxy'), resolve(REAL_HOME, '.claude')],
   // Bare files that live NEXT TO the protected dirs (`~/.claude.json` from
   // byok-mcp-config) rather than inside them.

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -11,24 +11,30 @@
  * trees, so the next forgetter fails LOUDLY at the offending call site
  * instead of silently corrupting the developer's live state 76 days later.
  *
- * The guard monkey-patches a NAMED LIST of `fs` functions: any call whose
- * resolved path falls under the real `~/.chroxy/` or `~/.claude/` throws
- * `CHROXY_TEST_SANDBOX` with a stack trace pointing at the caller. The list is
+ * The guard monkey-patches every `fs` function that takes a PATH and mutates
+ * the filesystem: any call whose resolved path falls under the real
+ * `~/.chroxy/` or `~/.claude/` throws `CHROXY_TEST_SANDBOX` with a stack trace
+ * pointing at the caller. It is a CATEGORY now, not a list (#7267) — 61 methods
+ * across the sync, callback and `promises` surfaces, all expanded from the one
+ * table in `scripts/lib/test-fs-sandbox.mjs`, which
+ * `packages/claude-hooks/tests/_setup.mjs` installs from too.
  *
- *   sync      writeFileSync appendFileSync renameSync mkdirSync
- *             createWriteStream openSync
- *   promises  writeFile appendFile rename mkdir open
- *
- * and it is a LIST, not a category. Saying "the write-side of fs" — as this
- * comment used to — reads as a guarantee the code does not make. Measured
- * under this harness, these reach the real tree unimpeded: `unlinkSync`,
+ * It was a hand-written list until #7267, and the list was the bug. Measured
+ * under this harness before that change, these reached the real tree
+ * unimpeded: `unlinkSync` (52 call sites under `src/`, more than `openSync`),
  * `rmSync`, `rmdirSync`, `cpSync`, `copyFileSync`, `symlinkSync`, `linkSync`,
- * `chmodSync`, and the `promises` forms of the same. Two of them are not even
- * destructive-only — `cpSync` and `copyFileSync` were observed CREATING a real
- * file inside the developer's live `~/.chroxy`. `truncateSync` is covered, but
- * only incidentally, because it opens with `r+` and trips `openSync`.
- * Closing that gap is #7267; until it lands, do not read this guard as
- * covering deletes or copies.
+ * `chmodSync`, the whole `promises` half of the same, and — worst — the entire
+ * CALLBACK surface including plain `fs.writeFile(path, data, cb)`. `cpSync`
+ * does not merely bypass the guard: it creates the destination's parent
+ * directories, so a probe aimed at a NON-EXISTENT path under `~/.chroxy` left a
+ * real directory in the developer's live config dir. `truncateSync` read as
+ * covered, but only incidentally — it opens with `r+` and tripped `openSync`.
+ *
+ * "Category" is enforced, not asserted: `FS_EXEMPTIONS` in the shared module
+ * classifies every remaining `fs` function with a reason, and
+ * `tests/setup-sandbox-binding-forms.test.js` fails if their union stops
+ * covering the live `fs` surface. A Node upgrade that adds a path-taking
+ * mutator turns the suite red instead of quietly widening the hole.
  *
  * Read-side fs calls are untouched by design, so tests that legitimately
  * *read* the developer's real config (e.g. provider detection in
@@ -65,8 +71,9 @@
 
 import { createRequire } from 'node:module'
 import { homedir, tmpdir } from 'node:os'
-import { join, resolve, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
+
+import { installFsWriteSandbox } from '../../../scripts/lib/test-fs-sandbox.mjs'
 
 // CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,
 // NOT via an ESM default import. ESM `import fs from 'node:fs'` returns a
@@ -88,25 +95,55 @@ import { fileURLToPath } from 'node:url'
 // In practice that means this file must not import it — but the condition is
 // wider than this file, and stating it as "never import fs here" would be too
 // narrow: a transitive import through any module this file pulls in, or an
-// earlier `--import` hook, disarms the guard identically. This file has no
-// local imports, which is what keeps the wider condition satisfied; adding one
-// re-opens the question.
+// earlier `--import` hook, disarms the guard identically. This file's ONE local
+// import — `scripts/lib/test-fs-sandbox.mjs` — is held to the same rule and
+// reaches `fs` through its own `createRequire`; every further import added here
+// inherits the obligation, transitively.
 //
 // ESM imports are evaluated before the module body, so a single
 // `import { mkdtempSync } from 'node:fs'` up top links the synthetic module
 // against the UNPATCHED exports — and named/namespace consumers (45 modules
 // under `src/` at the time of writing) silently bypass the sandbox while it
 // still reports success for CJS and default importers. That line lived here
-// for months. Take what you need off the `fs` object below instead, as
-// `mkdtempSync` now does. The same applies to `node:fs/promises`: it is a
+// for months. Take what you need off the `fs` object below instead — the tmp
+// config dir is created with `fs.mkdtempSync` for exactly this reason. The same
+// applies to `node:fs/promises`: it is a
 // separate synthetic module with the same lazy-link behaviour, and importing
 // it here disarms the promises half (measured).
+//
+// The rule extends to `scripts/lib/test-fs-sandbox.mjs`, imported below: it is
+// linked as part of THIS file's graph, so an ESM `node:fs` import there would
+// disarm the sandbox identically. It reaches `fs` through its own
+// `createRequire` for that reason, and the structural check in
+// `tests/setup-sandbox-binding-forms.test.js` walks the graph rather than
+// trusting either comment.
 //
 // `tests/setup-sandbox-binding-forms.test.js` pins every binding form
 // behaviourally and fails if any of this is undone.
 const require = createRequire(import.meta.url)
 const fs = require('node:fs')
-const { mkdtempSync } = fs
+
+// --- Capture the real home and arm the guard ---------------------------------
+// Order matters: the guard is installed BEFORE the tmp config dir is created,
+// so even this bootstrap's own `mkdtempSync` runs through it. `homedir()` is
+// read here, at process startup, and the guard locks onto THAT — tests that
+// mutate `process.env.HOME` for their own purposes (`claude-tui-session.test.js`,
+// `byok-credentials.test.js`) neither widen nor narrow it.
+const REAL_HOME = homedir()
+
+export const { installed: SANDBOX_INSTALLED, skipped: SANDBOX_SKIPPED } = installFsWriteSandbox({
+  protectedRoots: [resolve(REAL_HOME, '.chroxy'), resolve(REAL_HOME, '.claude')],
+  // Bare files that live NEXT TO the protected dirs (`~/.claude.json` from
+  // byok-mcp-config) rather than inside them.
+  protectedFiles: [resolve(REAL_HOME, '.claude.json')],
+  allowEnv: 'CHROXY_TEST_ALLOW_REAL_HOME_WRITES',
+  message: (method, target) =>
+    `[chroxy-test-sandbox] BLOCKED ${method} to real user-state path: ${target}\n` +
+    `  This test attempted to write to (or move from/to) the developer's actual ~/.chroxy or ~/.claude tree.\n` +
+    `  Pass a temp path explicitly (e.g. stateFilePath: tmpStateFile()) or set\n` +
+    `  process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1' if the write is intentional.\n` +
+    `  See packages/server/tests/_setup.mjs and issue #4633.`,
+})
 
 // --- Redirect CHROXY_CONFIG_DIR to a per-process tmp dir ----------------------
 // Production helpers (models.js, connection-info.js, checkpoint-manager.js)
@@ -117,152 +154,7 @@ const { mkdtempSync } = fs
 // still set it in their own beforeEach and restore in afterEach — Node's
 // env reads are dynamic.
 if (!process.env.CHROXY_CONFIG_DIR) {
-  process.env.CHROXY_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'chroxy-test-cfg-'))
-}
-
-// --- Capture the real home for the guard --------------------------------------
-const REAL_HOME = homedir()
-const PROTECTED_ROOTS = [
-  resolve(REAL_HOME, '.chroxy') + sep,
-  resolve(REAL_HOME, '.claude') + sep,
-]
-// Also guard the bare files (e.g. `~/.claude.json` from byok-mcp-config)
-// because they live next to the dirs we protect.
-const PROTECTED_FILES = new Set([
-  resolve(REAL_HOME, '.claude.json'),
-])
-
-// --- Sandbox guard ------------------------------------------------------------
-function isProtected(rawPath) {
-  if (process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES === '1') return false
-  if (typeof rawPath !== 'string' && !(rawPath instanceof URL) && !(rawPath instanceof Buffer)) {
-    return false
-  }
-  let p
-  try {
-    // `fileURLToPath` handles cross-platform quirks (Windows `file:///C:/...`
-    // yields `C:\...`, percent-encoded segments are decoded). Falling back to
-    // `.pathname` would leave a leading slash on Windows and break comparison
-    // against `os.homedir()`-derived paths.
-    if (rawPath instanceof URL) p = fileURLToPath(rawPath)
-    else if (rawPath instanceof Buffer) p = rawPath.toString('utf8')
-    else p = rawPath
-    p = resolve(p)
-  } catch {
-    return false
-  }
-  if (PROTECTED_FILES.has(p)) return true
-  for (const root of PROTECTED_ROOTS) {
-    if (p === root.slice(0, -1) || p.startsWith(root)) return true
-  }
-  return false
-}
-
-function makeGuardError(method, target) {
-  const err = new Error(
-    `[chroxy-test-sandbox] BLOCKED ${method} to real user-state path: ${target}\n` +
-    `  This test attempted to write to (or move from/to) the developer's actual ~/.chroxy or ~/.claude tree.\n` +
-    `  Pass a temp path explicitly (e.g. stateFilePath: tmpStateFile()) or set\n` +
-    `  process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1' if the write is intentional.\n` +
-    `  See packages/server/tests/_setup.mjs and issue #4633.`,
-  )
-  err.code = 'CHROXY_TEST_SANDBOX'
-  return err
-}
-
-const origWriteFileSync = fs.writeFileSync
-fs.writeFileSync = function patchedWriteFileSync(target, ...rest) {
-  if (isProtected(target)) throw makeGuardError('writeFileSync', String(target))
-  return origWriteFileSync.call(this, target, ...rest)
-}
-
-const origAppendFileSync = fs.appendFileSync
-fs.appendFileSync = function patchedAppendFileSync(target, ...rest) {
-  if (isProtected(target)) throw makeGuardError('appendFileSync', String(target))
-  return origAppendFileSync.call(this, target, ...rest)
-}
-
-const origRenameSync = fs.renameSync
-fs.renameSync = function patchedRenameSync(oldPath, newPath) {
-  // Check BOTH paths: a `renameSync('~/.chroxy/session-state.json', '/tmp/x')`
-  // would silently relocate real user state without tripping a newPath-only
-  // guard. The whole point of the sandbox is to prevent that.
-  if (isProtected(oldPath) || isProtected(newPath)) {
-    throw makeGuardError('renameSync', `${String(oldPath)} -> ${String(newPath)}`)
-  }
-  return origRenameSync.call(this, oldPath, newPath)
-}
-
-const origMkdirSync = fs.mkdirSync
-fs.mkdirSync = function patchedMkdirSync(target, ...rest) {
-  // Blocks any new directory under the real ~/.chroxy or ~/.claude. The
-  // top-level dirs themselves (PROTECTED_ROOTS) already exist, so a
-  // `mkdirSync('~/.chroxy', { recursive: true })` no-ops in practice —
-  // but we still flag it to surface unexpected callers in tests.
-  if (isProtected(target)) throw makeGuardError('mkdirSync', String(target))
-  return origMkdirSync.call(this, target, ...rest)
-}
-
-const origCreateWriteStream = fs.createWriteStream
-fs.createWriteStream = function patchedCreateWriteStream(target, ...rest) {
-  if (isProtected(target)) throw makeGuardError('createWriteStream', String(target))
-  return origCreateWriteStream.call(this, target, ...rest)
-}
-
-const origOpenSync = fs.openSync
-fs.openSync = function patchedOpenSync(target, flags, ...rest) {
-  // `flags` can be a string ('w', 'a', 'wx', 'w+', 'a+', 'ax') or a number
-  // (constants OR'd together: O_WRONLY=1, O_RDWR=2, O_CREAT=64, O_APPEND=1024…).
-  // We only block when the open is for writing; pure reads are fine.
-  let isWrite = false
-  if (typeof flags === 'string') {
-    isWrite = /[wa+]/.test(flags)
-  } else if (typeof flags === 'number') {
-    // O_WRONLY = 1, O_RDWR = 2, O_CREAT = 64, O_APPEND = 1024, O_TRUNC = 512
-    isWrite = (flags & 1) !== 0 || (flags & 2) !== 0 || (flags & 64) !== 0
-  }
-  if (isWrite && isProtected(target)) throw makeGuardError('openSync', String(target))
-  return origOpenSync.call(this, target, flags, ...rest)
-}
-
-if (fs.promises) {
-  const origWriteFile = fs.promises.writeFile
-  fs.promises.writeFile = function patchedWriteFile(target, ...rest) {
-    if (isProtected(target)) return Promise.reject(makeGuardError('promises.writeFile', String(target)))
-    return origWriteFile.call(this, target, ...rest)
-  }
-
-  const origAppendFile = fs.promises.appendFile
-  fs.promises.appendFile = function patchedAppendFile(target, ...rest) {
-    if (isProtected(target)) return Promise.reject(makeGuardError('promises.appendFile', String(target)))
-    return origAppendFile.call(this, target, ...rest)
-  }
-
-  const origRename = fs.promises.rename
-  fs.promises.rename = function patchedRename(oldPath, newPath) {
-    // Mirror the sync guard: a rename OUT of ~/.chroxy is still data loss.
-    if (isProtected(oldPath) || isProtected(newPath)) {
-      return Promise.reject(makeGuardError('promises.rename', `${String(oldPath)} -> ${String(newPath)}`))
-    }
-    return origRename.call(this, oldPath, newPath)
-  }
-
-  const origMkdir = fs.promises.mkdir
-  fs.promises.mkdir = function patchedMkdir(target, ...rest) {
-    if (isProtected(target)) return Promise.reject(makeGuardError('promises.mkdir', String(target)))
-    return origMkdir.call(this, target, ...rest)
-  }
-
-  const origOpen = fs.promises.open
-  fs.promises.open = function patchedOpen(target, flags, ...rest) {
-    let isWrite = false
-    if (typeof flags === 'string') isWrite = /[wa+]/.test(flags)
-    else if (typeof flags === 'number') isWrite = (flags & 1) !== 0 || (flags & 2) !== 0 || (flags & 64) !== 0
-    if (isWrite && isProtected(target)) {
-      return Promise.reject(makeGuardError('promises.open', String(target)))
-    }
-    return origOpen.call(this, target, flags, ...rest)
-  }
+  process.env.CHROXY_CONFIG_DIR = fs.mkdtempSync(join(tmpdir(), 'chroxy-test-cfg-'))
 }
 
 // --- Default the credential-store to "no keychain" ----------------------------

--- a/packages/server/tests/setup-sandbox-binding-forms.test.js
+++ b/packages/server/tests/setup-sandbox-binding-forms.test.js
@@ -10,9 +10,12 @@
  *   CJS require          patched      import * as fs from 'fs'     UNPATCHED
  *   import fs from 'fs'  patched      import { writeFileSync }     UNPATCHED
  *
- * 45 modules under `src/` import a write-side `fs` function by name, so for all
- * of them the guard was not armed while still reporting success for everything
- * else — the `docs/false-safety-guards.md` shape exactly.
+ * 45 modules under `src/` import, BY NAME, one of the six write-side `fs`
+ * functions the guard named at the time — so for all of them it was not armed
+ * while still reporting success for everything else, the
+ * `docs/false-safety-guards.md` shape exactly. (That figure is specific to the
+ * old, narrow list, which is what makes it the right measure of what #7262
+ * exposed. Against the surface #7267 now guards it is 53.)
  *
  * This file owns ONE axis: is the patch VISIBLE, whichever way `fs` was
  * imported. Whether it is WIDE ENOUGH — which methods are patched at all — is
@@ -233,7 +236,17 @@ describe('write sandbox: the cause is pinned structurally too (#7262)', () => {
   // header of `_setup.mjs` always stated the wider condition; this now checks
   // it instead of asking the next reader to remember it.
 
-  const ESM_IMPORT = /(^|\n)[ \t]*(?:import|export)\s+(?:[\s\S]*?\sfrom\s+)?['"]([^'"]+)['"]/g
+  // Static `import`/`export … from`, including the no-space form (`}from'x'`),
+  // which the first version of this pattern let through.
+  const ESM_IMPORT = /(^|\n)[ \t]*(?:import|export)\s+(?:[\s\S]*?\bfrom\s*)?['"]([^'"]+)['"]/g
+  // `import('x')` is an edge too. A top-level `await import('node:fs')` disarms
+  // the guard exactly as a static import does — it links the synthetic module —
+  // and the static pattern above produces NO match for it, so the check that
+  // exists to name the cause reported the cause absent.
+  const DYNAMIC_IMPORT_LITERAL = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g
+  // A dynamic import whose specifier is NOT a literal cannot be followed at
+  // all, and must be reported rather than skipped.
+  const DYNAMIC_IMPORT_ANY = /\bimport\s*\(/g
   const IS_FS = /^(node:)?fs(\/promises)?$/
 
   function scan (fileUrl) {
@@ -248,13 +261,21 @@ describe('write sandbox: the cause is pinned structurally too (#7262)', () => {
     // computed here stay valid against the original file.
     const blanked = stripComments(source, path)
     const found = []
-    for (const m of blanked.matchAll(ESM_IMPORT)) {
-      const at = m.index + (m[0].startsWith('\n') ? 1 : 0)
+    const record = (index, length, specifier) => {
+      const at = index + (source.slice(index, index + 1) === '\n' ? 1 : 0)
       found.push({
-        specifier: m[2],
+        specifier,
         line: source.slice(0, at).split('\n').length,
-        statement: source.slice(at, at + m[0].length).trim(),
+        statement: source.slice(at, at + length).trim(),
       })
+    }
+    for (const m of blanked.matchAll(ESM_IMPORT)) record(m.index, m[0].length, m[2])
+    for (const m of blanked.matchAll(DYNAMIC_IMPORT_LITERAL)) record(m.index, m[0].length, m[1])
+
+    const literalDynamic = [...blanked.matchAll(DYNAMIC_IMPORT_LITERAL)].length
+    const allDynamic = [...blanked.matchAll(DYNAMIC_IMPORT_ANY)].length
+    for (let i = 0; i < allDynamic - literalDynamic; i++) {
+      found.push({ specifier: '<computed dynamic import>', line: 0, statement: 'import(<expression>)' })
     }
     return found
   }
@@ -277,7 +298,7 @@ describe('write sandbox: the cause is pinned structurally too (#7262)', () => {
           queue.push(new URL(imp.specifier, url).href)
         } else if (!imp.specifier.startsWith('node:')) {
           // "Cannot check this" must never be recorded as "nothing to check" —
-          // that is `docs/false-safety-guards.md` cause #2, and it is how a
+          // that is `docs/false-safety-guards.md` the "Silently skipped an input" mode, and it is how a
           // guard reports success over a file it never opened. A bare package
           // specifier is unresolvable here, so it FAILS rather than being
           // skipped: whatever it pulls in is exactly the transitive `node:fs`

--- a/packages/server/tests/setup-sandbox-binding-forms.test.js
+++ b/packages/server/tests/setup-sandbox-binding-forms.test.js
@@ -14,6 +14,14 @@
  * of them the guard was not armed while still reporting success for everything
  * else — the `docs/false-safety-guards.md` shape exactly.
  *
+ * This file owns ONE axis: is the patch VISIBLE, whichever way `fs` was
+ * imported. Whether it is WIDE ENOUGH — which methods are patched at all — is
+ * `setup-sandbox-coverage.test.js` (#7267). It used to be both, via a
+ * hand-written per-method list sitting beside the patch list in `_setup.mjs`;
+ * that list is deleted, because a second hardcoded list beside a set that grows
+ * is the same defect one level up. Both now expand from the one array in
+ * `scripts/lib/test-fs-sandbox.mjs`.
+ *
  * ── Why the fix is one deleted line, and why it needs a test at all ─────────
  *
  * Node builds the `node:fs` synthetic ESM module LAZILY, snapshotting its named
@@ -55,24 +63,14 @@ import fsDefault from 'node:fs'
 import { createRequire } from 'node:module'
 import {
   writeFileSync as namedWriteFileSync,
-  appendFileSync as namedAppendFileSync,
-  renameSync as namedRenameSync,
   mkdirSync as namedMkdirSync,
-  createWriteStream as namedCreateWriteStream,
-  openSync as namedOpenSync,
   readFileSync as namedReadFileSync,
   rmSync as namedRmSync,
 } from 'node:fs'
 
 import * as fspNamespace from 'node:fs/promises'
 import fspDefault from 'node:fs/promises'
-import {
-  writeFile as namedWriteFile,
-  appendFile as namedAppendFile,
-  rename as namedRename,
-  mkdir as namedMkdir,
-  open as namedOpen,
-} from 'node:fs/promises'
+import { writeFile as namedWriteFile } from 'node:fs/promises'
 
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -111,33 +109,6 @@ function probeSync(fn, ...args) {
   } catch (err) {
     return classify(err)
   }
-}
-
-// `createWriteStream` is the one probe whose BYPASS path is asynchronous: the
-// guard throws synchronously, but a bypassed call returns a live stream and
-// reports ENOENT later on an 'error' event. `probeSync` would classify that as
-// "the call SUCCEEDED" — wrong — and the unhandled 'error' would then surface
-// as an uncaughtException after the test had already ended, turning a clean
-// assertion failure into noise that hides which assertion failed.
-function probeStream(fn, target) {
-  return new Promise((resolve) => {
-    let stream
-    try {
-      stream = fn(target)
-    } catch (err) {
-      resolve(classify(err))
-      return
-    }
-    // No synchronous throw means the guard was bypassed and we are now holding
-    // a real stream aimed at a real path. Attach the handler before yielding.
-    stream.once('error', (err) => resolve(classify(err)))
-    stream.once('open', () => {
-      // It actually opened, so a real file exists under the protected root.
-      stream.destroy()
-      try { namedRmSync(target, { force: true }) } catch { /* best effort */ }
-      resolve(classify(null))
-    })
-  })
 }
 
 async function probeAsync(fn, ...args) {
@@ -213,70 +184,6 @@ describe('write sandbox: all four fs binding forms are guarded (#7262)', () => {
   })
 })
 
-describe('write sandbox: every patched method is armed for named imports', () => {
-  // The other axis: each method is a separate monkey-patch in `_setup.mjs` and
-  // could individually be missed. Driven through the NAMED form because that is
-  // the form #7262 left unguarded and the one 45 modules under `src/` use.
-  //
-  // KNOWN GAP (#7267): this list is hand-maintained alongside the patch list in
-  // `_setup.mjs`, under a suite titled "every patched method" — a hardcoded list
-  // beside a set that can grow, which is `docs/false-safety-guards.md` cause #1.
-  // It cannot currently claim "every": the sandbox patches no delete or copy
-  // API, so `unlinkSync`, `rmSync`, `cpSync` and friends are absent here because
-  // they are absent there. #7267 closes both halves by deriving the two lists
-  // from one exported array; until then, read this suite as "every method
-  // `_setup.mjs` claims to patch", and check that claim against #7267's table.
-  const syncMethods = [
-    ['writeFileSync',     () => probeSync(namedWriteFileSync, protectedTarget, 'probe')],
-    // NOTE: this one is guarded even when its own binding is stale, so unlike
-    // its neighbours it survives the #7262 mutant. That is a real property of
-    // Node, not a dead assertion: `appendFileSync` reaches `writeFileSync`
-    // through the module's exports OBJECT, which is the thing `_setup.mjs`
-    // patches — so an unpatched named `appendFileSync` still lands in the
-    // patched `writeFileSync`. Verified by patching only `writeFileSync` on the
-    // CJS object and watching a named `appendFileSync` call trip it. Kept
-    // because it pins the OUTCOME (`appendFileSync` cannot reach the real home)
-    // regardless of which mechanism delivers it; do not read its mutant
-    // survival as this file being insensitive.
-    ['appendFileSync',    () => probeSync(namedAppendFileSync, protectedTarget, 'probe')],
-    ['renameSync (from)', () => probeSync(namedRenameSync, protectedTarget, join(tmpdir(), 'probe-dest.tmp'))],
-    ['renameSync (to)',   () => probeSync(namedRenameSync, join(tmpdir(), MISSING_DIR, 'src.tmp'), protectedTarget)],
-    // Deliberately NOT `{ recursive: true }`: recursive would create real
-    // directories under ~/.chroxy if the guard were bypassed.
-    ['mkdirSync',         () => probeSync(namedMkdirSync, protectedTarget)],
-    ['openSync',          () => probeSync(namedOpenSync, protectedTarget, 'w')],
-  ]
-
-  for (const [label, run] of syncMethods) {
-    test(`${label} is guarded via named import`, () => {
-      assert.strictEqual(run(), GUARDED, `${label} bypassed the sandbox.`)
-    })
-  }
-
-  test('createWriteStream is guarded via named import', async () => {
-    assert.strictEqual(
-      await probeStream(namedCreateWriteStream, protectedTarget),
-      GUARDED,
-      'createWriteStream bypassed the sandbox.',
-    )
-  })
-
-  const asyncMethods = [
-    ['promises.writeFile',   () => probeAsync(namedWriteFile, protectedTarget, 'probe')],
-    ['promises.appendFile',  () => probeAsync(namedAppendFile, protectedTarget, 'probe')],
-    ['promises.rename (from)', () => probeAsync(namedRename, protectedTarget, join(tmpdir(), 'probe-dest.tmp'))],
-    ['promises.rename (to)',   () => probeAsync(namedRename, join(tmpdir(), MISSING_DIR, 'src.tmp'), protectedTarget)],
-    ['promises.mkdir',       () => probeAsync(namedMkdir, protectedTarget)],
-    ['promises.open',        () => probeAsync(namedOpen, protectedTarget, 'w')],
-  ]
-
-  for (const [label, run] of asyncMethods) {
-    test(`${label} is guarded via named import`, async () => {
-      assert.strictEqual(await run(), GUARDED, `${label} bypassed the sandbox.`)
-    })
-  }
-})
-
 describe('write sandbox: controls', () => {
   // POSITIVE CONTROL. Every assertion above passes when the guard throws
   // CHROXY_TEST_SANDBOX and fails when the call reaches the real fs and gets
@@ -317,49 +224,91 @@ describe('write sandbox: the cause is pinned structurally too (#7262)', () => {
   // the failure NAMES the cause, because the outcome-level failure ("named
   // import bypassed the sandbox") does not obviously point at an import
   // statement three files away.
-  test('tests/_setup.mjs contains no ESM import from node:fs', () => {
-    const setupPath = fileURLToPath(new URL('./_setup.mjs', import.meta.url))
-    const source = namedReadFileSync(setupPath, 'utf8')
+  //
+  // It walks the whole GRAPH, not just `_setup.mjs`. The file-local version was
+  // correct only while `_setup.mjs` imported nothing local, and that stopped
+  // being true when #7267 moved the guard into
+  // `scripts/lib/test-fs-sandbox.mjs`: an ESM `node:fs` import THERE is linked
+  // as part of `_setup.mjs`'s graph and disarms the sandbox identically. The
+  // header of `_setup.mjs` always stated the wider condition; this now checks
+  // it instead of asking the next reader to remember it.
 
+  const ESM_IMPORT = /(^|\n)[ \t]*(?:import|export)\s+(?:[\s\S]*?\sfrom\s+)?['"]([^'"]+)['"]/g
+  const IS_FS = /^(node:)?fs(\/promises)?$/
+
+  function scan (fileUrl) {
+    const path = fileURLToPath(fileUrl)
+    const source = namedReadFileSync(path, 'utf8')
     // Comments must be blanked first, and with the repo's ONE stripper
     // (`scripts/lib/strip-comments.mjs`, #7248) rather than a second local
-    // regex. `_setup.mjs` deliberately quotes `import { mkdtempSync } from
-    // 'node:fs'` in its own header to explain the bug, so a check that reads
-    // raw source flags the very comment warning against the thing. Measured:
-    // 1 match raw, 0 stripped. The stripper preserves offsets, so line numbers
-    // computed here are valid against the original file.
-    const blanked = stripComments(source, '_setup.mjs')
-
-    // Deliberately NOT line-anchored on `... from ...`. Three forms disarm the
-    // sandbox and the narrow version caught only the first, which meant the
-    // check that exists to NAME the cause stayed green for two of the three
-    // ways the cause comes back. All three are measured, not assumed:
-    //
-    //   import { mkdtempSync } from 'node:fs'   single line   -> 9 tests fail
-    //   import 'node:fs'                        bare          -> 8 tests fail
-    //   import {\n  mkdtempSync,\n} from 'node:fs'  multi-line
-    //
-    // `node:fs/promises` is included because it is a separate synthetic module
-    // with the same lazy-link behaviour: importing it here snapshots ITS named
-    // exports early and disarms the promises half of the guard (measured: 9
-    // tests fail).
-    const IMPORT_OF_FS = /(^|\n)[ \t]*import\s+(?:[\s\S]*?\sfrom\s+)?['"](node:)?fs(\/promises)?['"]/g
-    const offending = [...blanked.matchAll(IMPORT_OF_FS)].map((m) => {
+    // regex. Both `_setup.mjs` and the shared module deliberately QUOTE
+    // `import { mkdtempSync } from 'node:fs'` in their headers to explain the
+    // bug, so a check that reads raw source flags the very comment warning
+    // against the thing. The stripper preserves offsets, so line numbers
+    // computed here stay valid against the original file.
+    const blanked = stripComments(source, path)
+    const found = []
+    for (const m of blanked.matchAll(ESM_IMPORT)) {
       const at = m.index + (m[0].startsWith('\n') ? 1 : 0)
-      return {
+      found.push({
+        specifier: m[2],
         line: source.slice(0, at).split('\n').length,
         statement: source.slice(at, at + m[0].length).trim(),
+      })
+    }
+    return found
+  }
+
+  test('nothing in tests/_setup.mjs\'s import graph ESM-imports node:fs', () => {
+    const entry = new URL('./_setup.mjs', import.meta.url).href
+    const seen = new Set()
+    const queue = [entry]
+    const offending = []
+    const unwalkable = []
+
+    while (queue.length > 0) {
+      const url = queue.shift()
+      if (seen.has(url)) continue
+      seen.add(url)
+      for (const imp of scan(url)) {
+        if (IS_FS.test(imp.specifier)) {
+          offending.push({ file: fileURLToPath(url).split('/chroxy/').pop(), line: imp.line, statement: imp.statement })
+        } else if (imp.specifier.startsWith('.')) {
+          queue.push(new URL(imp.specifier, url).href)
+        } else if (!imp.specifier.startsWith('node:')) {
+          // "Cannot check this" must never be recorded as "nothing to check" —
+          // that is `docs/false-safety-guards.md` cause #2, and it is how a
+          // guard reports success over a file it never opened. A bare package
+          // specifier is unresolvable here, so it FAILS rather than being
+          // skipped: whatever it pulls in is exactly the transitive `node:fs`
+          // import this test exists to find.
+          unwalkable.push({ file: fileURLToPath(url).split('/chroxy/').pop(), specifier: imp.specifier })
+        }
       }
-    })
+    }
 
     assert.deepStrictEqual(
+      unwalkable, [],
+      'A module in the sandbox bootstrap\'s graph imports a package this check ' +
+      'cannot follow. Remove it, or make it resolvable — an unwalked edge is an ' +
+      'unchecked one.',
+    )
+    assert.deepStrictEqual(
       offending, [],
-      'tests/_setup.mjs must reach node:fs ONLY through createRequire. Any ESM ' +
-      'import of it here — named, namespace, or bare side-effect — is evaluated ' +
-      'before the file body and snapshots the synthetic module\'s named exports ' +
-      'from the UNPATCHED object, silently disarming the sandbox for every ' +
-      'named/namespace consumer (#7262). Destructure what you need off the ' +
-      '`fs` object instead.',
+      'The sandbox bootstrap and everything it imports must reach node:fs ONLY ' +
+      'through createRequire. Any ESM import of it — named, namespace, bare ' +
+      'side-effect, or a re-export — is evaluated before the file bodies run and ' +
+      'snapshots the synthetic module\'s named exports from the UNPATCHED object, ' +
+      'silently disarming the sandbox for every named/namespace consumer (#7262). ' +
+      'Destructure what you need off the `fs` object instead.',
+    )
+
+    // The walk is only worth anything if it actually reached the shared module;
+    // a resolution change that quietly emptied the queue would pass otherwise.
+    assert.ok(
+      [...seen].some((u) => u.endsWith('/scripts/lib/test-fs-sandbox.mjs')),
+      `The walk never reached scripts/lib/test-fs-sandbox.mjs (visited ${seen.size} ` +
+      `file(s)), so it proved nothing about the module that installs the guard.`,
     )
   })
 })

--- a/packages/server/tests/setup-sandbox-coverage.test.js
+++ b/packages/server/tests/setup-sandbox-coverage.test.js
@@ -5,11 +5,12 @@
  * VISIBLE?" — the #7262 axis, how `fs` was imported. This file answers the
  * other question: "is the patch WIDE ENOUGH?"
  *
- * Until #7267 the answer was no, and the shape was `docs/false-safety-guards.md`
- * cause #1 — a hardcoded list next to a set that grows. The sandbox named seven
+ * Until #7267 the answer was no, and the shape was the
+ * "Checked a subset" mode in `docs/false-safety-guards.md` — a hardcoded list
+ * next to a set that grows. The sandbox named seven
  * sync methods and five `promises` methods, so everything that deletes, copies,
  * links or chmods reached the developer's real `~/.chroxy` unimpeded, including
- * `unlinkSync` (52 call sites under `src/`, more than `openSync` has) and the
+ * `unlinkSync` (34 call sites under `src/`, more than `openSync`'s 14) and the
  * whole CALLBACK surface down to plain `fs.writeFile(path, data, cb)`. The
  * guard reported success the entire time, because every method it did name
  * worked perfectly.
@@ -40,9 +41,17 @@ import assert from 'node:assert'
 
 import * as fsNamespace from 'node:fs'
 import * as fspNamespace from 'node:fs/promises'
-import { writeFileSync as namedWriteFileSync, existsSync as namedExistsSync, rmSync as namedRmSync } from 'node:fs'
+import {
+  writeFileSync as namedWriteFileSync,
+  existsSync as namedExistsSync,
+  rmSync as namedRmSync,
+  renameSync as namedRenameSync,
+  openSync as namedOpenSync,
+  constants as fsConstants,
+} from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { join, sep } from 'node:path'
 
 // The guard's own record of what it installed — read from the SAME module the
 // harness ran, not re-derived. `--import ./tests/_setup.mjs` has already
@@ -57,13 +66,20 @@ import {
   SANDBOX_MARKER,
   guardedMethodNames,
 } from '../../../scripts/lib/test-fs-sandbox.mjs'
-import { probePlans, runProbe, PROBE_EXTRA_ARGS, GUARDED, REACHED_REAL_FS } from '../../../scripts/lib/test-fs-sandbox-probes.mjs'
+import {
+  probePlans, runProbe, partitionByAvailability, planLabel,
+  PROBE_EXTRA_ARGS, GUARDED, REACHED_REAL_FS,
+} from '../../../scripts/lib/test-fs-sandbox-probes.mjs'
 
 // A dedicated root under the REAL protected tree. Nothing below it is ever
 // created by a PASSING run — the guard throws before the syscall — and the last
 // suite asserts that a failing one created nothing either.
 const PROBE_ROOT = join(homedir(), '.chroxy', `__chroxy-sandbox-coverage-${process.pid}`)
 const protectedPath = join(PROBE_ROOT, 'd', 'probe.tmp')
+// The OTHER protected root. `_setup.mjs` hands the guard both, and until this
+// existed every probe aimed at `.chroxy` — so shrinking `protectedRoots` to one
+// entry was an unobserved change.
+const claudeProbe = join(homedir(), '.claude', `__chroxy-sandbox-coverage-${process.pid}`, 'probe.tmp')
 const spare = join(tmpdir(), `chroxy-sandbox-coverage-${process.pid}`, 'spare.tmp')
 const absentSource = join(tmpdir(), `chroxy-sandbox-coverage-absent-${process.pid}`)
 
@@ -74,7 +90,10 @@ const absentSource = join(tmpdir(), `chroxy-sandbox-coverage-absent-${process.pi
 function removeProbeRoot () {
   const prev = process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
   process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'
-  try { namedRmSync(PROBE_ROOT, { recursive: true, force: true }) } finally {
+  try {
+    namedRmSync(PROBE_ROOT, { recursive: true, force: true })
+    namedRmSync(join(homedir(), '.claude', `__chroxy-sandbox-coverage-${process.pid}`), { recursive: true, force: true })
+  } finally {
     if (prev === undefined) delete process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
     else process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = prev
   }
@@ -85,7 +104,21 @@ after(() => {
   namedRmSync(join(tmpdir(), `chroxy-sandbox-coverage-${process.pid}`), { recursive: true, force: true })
 })
 
-const plans = probePlans({ protectedPath, spare, absentSource })
+// Probe what this platform actually has. `lchmod`/`lchmodSync` are macOS-only,
+// and probing them on Linux calls `undefined` — a test defect that says nothing
+// about the guard. The dropped plans are NOT forgotten: the suite below requires
+// the installer to have skipped the same methods for the same reason, so
+// "cannot run this" cannot quietly become "nothing to check".
+// Returns the error code a call produced, or 'no-error' if it succeeded.
+function probeSyncLocal (fn) {
+  try { fn(); return 'no-error' } catch (err) { return err.code || err.message }
+}
+
+const allPlans = probePlans({ protectedPath, spare, absentSource })
+const { runnable: plans, unavailable } = partitionByAvailability(allPlans, {
+  fs: fsNamespace,
+  promises: fspNamespace,
+})
 
 describe('write sandbox: every guarded fs method refuses the real home (#7267)', () => {
   for (const plan of plans) {
@@ -118,11 +151,7 @@ describe('write sandbox: every guarded fs method refuses the real home (#7267)',
 })
 
 describe('write sandbox: the probe list and the patch list cannot drift (#7267)', () => {
-  const probed = new Set(plans.map((p) => {
-    if (p.surface === 'promises') return `promises.${p.method}`
-    if (p.surface === 'callback') return `${p.method} (callback)`
-    return p.method
-  }))
+  const probed = new Set(plans.map(planLabel))
 
   test('every method the guard installed is probed', () => {
     const unprobed = SANDBOX_INSTALLED.filter((name) => !probed.has(name))
@@ -140,6 +169,28 @@ describe('write sandbox: the probe list and the patch list cannot drift (#7267)'
       missing, [],
       'These probes target methods the sandbox did not install, so they can only ' +
       'be passing for some other reason.',
+    )
+  })
+
+  test('every probe this platform cannot run was skipped by the installer too', () => {
+    // The dangerous direction. A plan dropped here is a method nobody proves,
+    // so it must be corroborated INDEPENDENTLY — by the installer having
+    // recorded the same method as absent. Two separate readings of the same
+    // platform fact, from two different code paths.
+    const skipped = new Set(SANDBOX_SKIPPED.map((s) => s.name))
+    const uncorroborated = unavailable
+      .map(planLabel)
+      .filter((label) => !skipped.has(label))
+    assert.deepStrictEqual(
+      uncorroborated, [],
+      'These probes were dropped as "the platform lacks this method", but the ' +
+      'sandbox installed a guard for them anyway — so the method exists and the ' +
+      'probe was skipped for the wrong reason. That is a silently unproven guard.',
+    )
+    assert.ok(
+      plans.length > unavailable.length,
+      `Only ${plans.length} of ${allPlans.length} probes ran. A filter that drops ` +
+      `most of the suite is a broken filter, not a platform difference.`,
     )
   })
 
@@ -220,7 +271,9 @@ describe('write sandbox: two-path operations guard BOTH paths (#7267)', () => {
     ]) {
       for (const surface of ['sync', 'callback', 'promises']) {
         const method = surface === 'sync' ? `${base}Sync` : base
-        const label = surface === 'promises' ? `promises.${base}` : surface === 'callback' ? `${base} (callback)` : `${base}Sync`
+        const label = planLabel({ surface, method })
+        const host = surface === 'promises' ? fspNamespace : fsNamespace
+        if (typeof host[method] !== 'function') continue
         test(`${label} guards its ${position} path argument`, async () => {
           const verdict = await runProbe(
             { base, surface, method, args, extra: PROBE_EXTRA_ARGS[base]() },
@@ -271,7 +324,10 @@ describe('write sandbox: the guard is a category, not a list (#7267)', () => {
   })
 
   test('the exemptions are not a dumping ground — every reason is one of the known kinds', () => {
-    const KNOWN = new Set(['read', 'fd', 'class', 'class-known-residual', 'internal'])
+    const KNOWN = new Set([
+      'read', 'fd', 'fd-metadata-known-residual',
+      'class', 'class-known-residual', 'internal',
+    ])
     const odd = Object.entries({ ...FS_EXEMPTIONS, ...FS_PROMISES_EXEMPTIONS })
       .filter(([, reason]) => !KNOWN.has(reason))
     assert.deepStrictEqual(odd, [], 'Unknown exemption reason — see the header of test-fs-sandbox.mjs.')
@@ -285,6 +341,143 @@ describe('write sandbox: the guard is a category, not a list (#7267)', () => {
     )
     const streams = FS_STREAM_MUTATORS.map((m) => m.name)
     assert.deepStrictEqual(streams.filter((s, i) => streams.indexOf(s) !== i), [])
+  })
+})
+
+describe('write sandbox: the mutator table is complete (#7267)', () => {
+  // S2's axis. Every FIELD of a spec row is pinned — arity by
+  // TWO_PATH_OPERATIONS, a deleted row by the category check, a silent install
+  // skip by probed<->installed. What was NOT pinned is whether a row belongs in
+  // the table at all: MOVING one into FS_EXEMPTIONS deletes the guard AND its
+  // probe AND satisfies the category check, all at once. Measured: relocating
+  // `rmdir` that way left the suite green while `rmdirSync` removed a real
+  // directory under the protected root.
+  //
+  // So the roster is stated independently. It is the answer to "which fs
+  // operations mutate a path", which is a fact about Node, not about this code.
+  const MUST_BE_GUARDED = [
+    'appendFile', 'chmod', 'chown', 'copyFile', 'cp', 'lchmod', 'lchown', 'link',
+    'lutimes', 'mkdir', 'mkdtemp', 'open', 'rename', 'rm', 'rmdir', 'symlink',
+    'truncate', 'unlink', 'utimes', 'writeFile',
+  ]
+
+  test('every path-mutating fs operation is in the table, and nothing else is', () => {
+    assert.deepStrictEqual(
+      FS_PATH_MUTATORS.map((m) => m.base).sort(), [...MUST_BE_GUARDED].sort(),
+      'The mutator table and the roster disagree. If Node gained or lost an ' +
+      'operation, update BOTH — the point of the second list is that moving a ' +
+      'row into FS_EXEMPTIONS can otherwise delete a guard, its probe, and the ' +
+      'category check\'s objection to it in one edit.',
+    )
+    assert.deepStrictEqual(FS_STREAM_MUTATORS.map((m) => m.name), ['createWriteStream'])
+  })
+})
+
+describe('write sandbox: open is gated by write intent, both directions (#7267)', () => {
+  // `open` is the only row whose decision is not purely path-based, which makes
+  // it the one carrying the most logic and — until this suite — the least
+  // coverage. Its numeric branch was measurably wrong: the mask was written as
+  // literals from Linux, where O_CREAT is 64, while on darwin it is 512 and on
+  // Windows 256. `openSync(protected, O_TRUNC)` emptied a real file through an
+  // armed sandbox.
+  const NUMERIC_WRITE_FLAGS = ['O_WRONLY', 'O_RDWR', 'O_CREAT', 'O_TRUNC', 'O_APPEND']
+
+  for (const flag of NUMERIC_WRITE_FLAGS) {
+    test(`openSync with numeric ${flag} is guarded`, () => {
+      assert.strictEqual(
+        probeSyncLocal(() => namedOpenSync(protectedPath, fsConstants[flag])),
+        'CHROXY_TEST_SANDBOX',
+        `A numeric ${flag} (${fsConstants[flag]} on ${process.platform}) was read as a ` +
+        `non-write open. Derive the mask from fs.constants, never from literals.`,
+      )
+    })
+  }
+
+  // The ALLOW direction, which no assertion covered: `isWriteIntent -> true`
+  // left the suite fully green, and would have started throwing inside
+  // skills-loader.js and jsonl-reader.js — which openSync(path, 'r') the
+  // developer's real config on purpose — with nothing naming the cause.
+  test('a READ open of a protected path is allowed through', () => {
+    assert.strictEqual(
+      probeSyncLocal(() => namedOpenSync(protectedPath, 'r')), 'ENOENT',
+      'Reads of the real home are deliberately permitted (providers.test.js and ' +
+      'skills-loader depend on it). A guarded read means isWriteIntent is ' +
+      'answering true for everything.',
+    )
+    assert.strictEqual(probeSyncLocal(() => namedOpenSync(protectedPath, fsConstants.O_RDONLY)), 'ENOENT')
+  })
+})
+
+describe('write sandbox: every path TYPE Node accepts is checked (#7267)', () => {
+  // `isProtected` decodes three shapes and used to return false — unprotected —
+  // for anything else. Node also accepts a bare Uint8Array as a path, and a
+  // Uint8Array is not `instanceof Buffer`, so one went through unexamined.
+  // "Unrecognised shape filtered out instead of raising" is a false-safety mode
+  // in its own right, so unknown shapes now fail CLOSED.
+  const shapes = [
+    ['string', () => protectedPath],
+    ['URL', () => pathToFileURL(protectedPath)],
+    ['Buffer', () => Buffer.from(protectedPath)],
+    ['Uint8Array', () => new Uint8Array(Buffer.from(protectedPath))],
+  ]
+  for (const [label, build] of shapes) {
+    test(`a protected path passed as a ${label} is guarded`, () => {
+      assert.strictEqual(
+        probeSyncLocal(() => namedWriteFileSync(build(), 'probe')), 'CHROXY_TEST_SANDBOX',
+        `A ${label} path bypassed the guard.`,
+      )
+    })
+  }
+
+  test('a case-variant of the protected root is guarded where the fs is case-insensitive', () => {
+    // On APFS and NTFS `~/.Chroxy/x` IS `~/.chroxy/x`. A case-sensitive compare
+    // does not match it, so the guard would wave through a path that resolves to
+    // real user state. Both platforms this repo's CI runs on are affected.
+    const variant = protectedPath.replace(`${sep}.chroxy${sep}`, `${sep}.Chroxy${sep}`)
+    assert.notStrictEqual(variant, protectedPath, 'the probe did not actually change case')
+    const expected = (process.platform === 'darwin' || process.platform === 'win32')
+      ? 'CHROXY_TEST_SANDBOX'
+      : 'ENOENT'
+    assert.strictEqual(
+      probeSyncLocal(() => namedWriteFileSync(variant, 'probe')), expected,
+      process.platform === 'linux'
+        ? 'On a case-sensitive fs .Chroxy is a genuinely different directory and must NOT be guarded.'
+        : 'A case-variant of the protected root reached the real filesystem.',
+    )
+  })
+
+  test('an unrecognised path shape fails CLOSED', () => {
+    assert.strictEqual(
+      probeSyncLocal(() => namedWriteFileSync({ toString: () => protectedPath }, 'probe')),
+      'CHROXY_TEST_SANDBOX',
+      'A shape the guard cannot decode must be refused, not waved through. A ' +
+      'false positive here is a loud failure with the value in hand; a false ' +
+      'negative is #4633.',
+    )
+  })
+
+  test('the same shapes are NOT guarded when the path is unprotected', () => {
+    // Otherwise the four assertions above would pass for a guard that refuses
+    // every non-string argument.
+    //
+    // The control path is built as a STRING and then encoded — never by
+    // `.toString()`-ing the shape. A Uint8Array stringifies to its decimal bytes
+    // ("47,85,115,…"), which is a RELATIVE path: the first version of this test
+    // wrote three junk files into packages/server/ instead of tmpdir.
+    const controlPath = join(tmpdir(), `chroxy-shape-${process.pid}`, 'probe.tmp')
+    const encode = {
+      string: (str) => str,
+      URL: (str) => pathToFileURL(str),
+      Buffer: (str) => Buffer.from(str),
+      Uint8Array: (str) => new Uint8Array(Buffer.from(str)),
+    }
+    for (const [label] of shapes) {
+      assert.strictEqual(
+        probeSyncLocal(() => namedWriteFileSync(encode[label](controlPath), 'probe')),
+        'ENOENT',
+        `${label} control: an unprotected path of this shape must reach the real fs.`,
+      )
+    }
   })
 })
 
@@ -328,12 +521,54 @@ describe('write sandbox: controls (#7267)', () => {
     }
   })
 
+  test('the bare protected FILE ~/.claude.json is guarded, and only that exact path', () => {
+    // `protectedFiles` is a separate mechanism from `protectedRoots`: ~/.claude.json
+    // sits NEXT TO the protected dirs, not inside them, so the root prefix check
+    // never sees it. Nothing proved it until a mutation removed the entry and the
+    // whole suite stayed green — the #7267 defect, in the #7267 fix.
+    // `renameSync(<absent source>, target)`, NOT writeFileSync. ~/.claude.json's
+    // parent is $HOME, which EXISTS — so a plain write probe would overwrite the
+    // developer's real 168KB file the moment the guard regressed, which is the
+    // one scenario this assertion is for. With an absent source, a bypass fails
+    // on the source before it touches the destination (measured), so a failing
+    // run is inert.
+    assert.strictEqual(
+      probeSyncLocal(() => namedRenameSync(absentSource, join(homedir(), '.claude.json'))),
+      'CHROXY_TEST_SANDBOX',
+      'byok-mcp-config writes ~/.claude.json; the guard must refuse it.',
+    )
+    // Discrimination: the guard matches that exact path, not the basename.
+    assert.strictEqual(
+      probeSyncLocal(() => namedRenameSync(absentSource, join(tmpdir(), '.claude.json'))),
+      'ENOENT',
+      'The guard matched on the file NAME rather than the full path.',
+    )
+  })
+
+  test('the OTHER protected root, ~/.claude, is guarded too', () => {
+    assert.strictEqual(
+      probeSyncLocal(() => namedWriteFileSync(claudeProbe, 'probe')), 'CHROXY_TEST_SANDBOX',
+      '_setup.mjs passes both ~/.chroxy and ~/.claude as protected roots; every ' +
+      'other probe here aims at the first, so the second was unobserved.',
+    )
+  })
+
   test('reads of the real home are still allowed', () => {
     // Deliberate: `providers.test.js` and friends legitimately read the
     // developer's real config. A guard that blocked reads would be "safer" and
     // would break the suite, so the exemption is pinned, not assumed.
-    assert.doesNotThrow(() => fsNamespace.existsSync(join(homedir(), '.chroxy')))
-    assert.doesNotThrow(() => fsNamespace.readdirSync(homedir()))
+    //
+    // These are PATCHED functions asked to do a read-shaped thing. `existsSync`
+    // and `readdirSync` used to stand here and could not fail: both are in
+    // FS_EXEMPTIONS, so the guard never wrapped them and the test observed
+    // nothing. `openSync(..., 'r')` goes through the wrapper and out the other
+    // side, which is the property that actually matters.
+    assert.strictEqual(probeSyncLocal(() => namedOpenSync(protectedPath, 'r')), 'ENOENT')
+    // A read that reaches the real fs and is refused BY THE KERNEL, not by us.
+    assert.strictEqual(
+      probeSyncLocal(() => fsNamespace.readFileSync(join(homedir(), '.chroxy', 'no-such-file'), 'utf8')),
+      'ENOENT',
+    )
   })
 })
 
@@ -343,8 +578,9 @@ describe('write sandbox: the probes created nothing under the real home (#7267)'
   // fails, so a probe aimed at a NON-EXISTENT path under ~/.chroxy left a real
   // directory there — through an armed sandbox — while every other probe in
   // this file is safe by construction. This assertion runs last on purpose.
-  test('no probe root exists under ~/.chroxy', () => {
-    const leaked = namedExistsSync(PROBE_ROOT)
+  test('no probe root exists under ~/.chroxy or ~/.claude', () => {
+    const roots = [PROBE_ROOT, join(homedir(), '.claude', `__chroxy-sandbox-coverage-${process.pid}`)]
+    const leaked = roots.some((r) => namedExistsSync(r))
     if (leaked) removeProbeRoot()
     assert.strictEqual(
       leaked, false,

--- a/packages/server/tests/setup-sandbox-coverage.test.js
+++ b/packages/server/tests/setup-sandbox-coverage.test.js
@@ -1,0 +1,355 @@
+/**
+ * CATEGORY coverage for the write sandbox in `tests/_setup.mjs` (#7267).
+ *
+ * Its sibling `setup-sandbox-binding-forms.test.js` answers "is the patch
+ * VISIBLE?" — the #7262 axis, how `fs` was imported. This file answers the
+ * other question: "is the patch WIDE ENOUGH?"
+ *
+ * Until #7267 the answer was no, and the shape was `docs/false-safety-guards.md`
+ * cause #1 — a hardcoded list next to a set that grows. The sandbox named seven
+ * sync methods and five `promises` methods, so everything that deletes, copies,
+ * links or chmods reached the developer's real `~/.chroxy` unimpeded, including
+ * `unlinkSync` (52 call sites under `src/`, more than `openSync` has) and the
+ * whole CALLBACK surface down to plain `fs.writeFile(path, data, cb)`. The
+ * guard reported success the entire time, because every method it did name
+ * worked perfectly.
+ *
+ * ── Why this file cannot drift from the guard ───────────────────────────────
+ *
+ * There is ONE array. `FS_PATH_MUTATORS` in `scripts/lib/test-fs-sandbox.mjs`
+ * expands to the methods the sandbox patches AND to the probes asserted here,
+ * so a row added there is automatically installed and automatically proven. The
+ * old per-method suite in the binding-forms file kept a second, hand-written
+ * list beside the first — the same defect one level up, and it is deleted.
+ *
+ * Three assertions keep that honest, because "derived from one array" only
+ * moves the question to whether the array is complete:
+ *
+ *   1. every method the guard ACTUALLY installed is probed  (installed -> probed)
+ *   2. every method probed was actually installed           (probed -> installed)
+ *   3. GUARDED union EXEMPT covers the live `fs` surface exactly, with a
+ *      recorded reason for each exemption   (the category, not a list)
+ *
+ * (3) is the one that survives a Node upgrade: when `fs` gains a path-taking
+ * mutator, this suite goes red and someone has to classify it, instead of the
+ * hole widening in silence.
+ */
+
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert'
+
+import * as fsNamespace from 'node:fs'
+import * as fspNamespace from 'node:fs/promises'
+import { writeFileSync as namedWriteFileSync, existsSync as namedExistsSync, rmSync as namedRmSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The guard's own record of what it installed — read from the SAME module the
+// harness ran, not re-derived. `--import ./tests/_setup.mjs` has already
+// evaluated it, so this import is a registry cache hit and installs nothing a
+// second time (proven below: a re-run would report `already-guarded` skips).
+import { SANDBOX_INSTALLED, SANDBOX_SKIPPED } from './_setup.mjs'
+import {
+  FS_PATH_MUTATORS,
+  FS_STREAM_MUTATORS,
+  FS_EXEMPTIONS,
+  FS_PROMISES_EXEMPTIONS,
+  SANDBOX_MARKER,
+  guardedMethodNames,
+} from '../../../scripts/lib/test-fs-sandbox.mjs'
+import { probePlans, runProbe, PROBE_EXTRA_ARGS, GUARDED, REACHED_REAL_FS } from '../../../scripts/lib/test-fs-sandbox-probes.mjs'
+
+// A dedicated root under the REAL protected tree. Nothing below it is ever
+// created by a PASSING run — the guard throws before the syscall — and the last
+// suite asserts that a failing one created nothing either.
+const PROBE_ROOT = join(homedir(), '.chroxy', `__chroxy-sandbox-coverage-${process.pid}`)
+const protectedPath = join(PROBE_ROOT, 'd', 'probe.tmp')
+const spare = join(tmpdir(), `chroxy-sandbox-coverage-${process.pid}`, 'spare.tmp')
+const absentSource = join(tmpdir(), `chroxy-sandbox-coverage-absent-${process.pid}`)
+
+// Removing anything under the protected root needs the documented opt-out —
+// the guard blocks the cleanup too, which is itself a small proof that it is
+// armed. Scoped to the call and restored immediately; node:test runs top-level
+// tests in a file sequentially, so no concurrent probe sees the flag.
+function removeProbeRoot () {
+  const prev = process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
+  process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'
+  try { namedRmSync(PROBE_ROOT, { recursive: true, force: true }) } finally {
+    if (prev === undefined) delete process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES
+    else process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = prev
+  }
+}
+
+after(() => {
+  removeProbeRoot()
+  namedRmSync(join(tmpdir(), `chroxy-sandbox-coverage-${process.pid}`), { recursive: true, force: true })
+})
+
+const plans = probePlans({ protectedPath, spare, absentSource })
+
+describe('write sandbox: every guarded fs method refuses the real home (#7267)', () => {
+  for (const plan of plans) {
+    test(`${plan.label} is guarded`, async () => {
+      const verdict = await runProbe(plan, {
+        fs: fsNamespace,
+        promises: fspNamespace,
+        cleanup: removeProbeRoot,
+      })
+      assert.strictEqual(
+        verdict, GUARDED,
+        `${plan.label} reached the real filesystem. The sandbox must refuse every ` +
+        `path-taking fs mutator aimed at ~/.chroxy or ~/.claude (#4633, #7267).`,
+      )
+    })
+  }
+
+  // The sweep above drives the NAMESPACE binding. That is only equivalent to
+  // the named form — the one 45 modules under `src/` use, and the one #7262
+  // left unguarded — because both read the same synthetic-module snapshot.
+  // Pinned rather than assumed, so the whole sweep cannot quietly become a test
+  // of a binding form nobody ships.
+  test('the namespace binding IS the named binding, which is what the sweep rides on', () => {
+    assert.strictEqual(
+      fsNamespace.writeFileSync, namedWriteFileSync,
+      'node:fs namespace and named imports must resolve to the same binding; if ' +
+      'they diverge, the sweep above no longer says anything about named imports.',
+    )
+  })
+})
+
+describe('write sandbox: the probe list and the patch list cannot drift (#7267)', () => {
+  const probed = new Set(plans.map((p) => {
+    if (p.surface === 'promises') return `promises.${p.method}`
+    if (p.surface === 'callback') return `${p.method} (callback)`
+    return p.method
+  }))
+
+  test('every method the guard installed is probed', () => {
+    const unprobed = SANDBOX_INSTALLED.filter((name) => !probed.has(name))
+    assert.deepStrictEqual(
+      unprobed, [],
+      'These methods are patched by the sandbox but nothing here proves the patch ' +
+      'fires. A guard that is never made to fail is not a guard ' +
+      '(docs/false-safety-guards.md).',
+    )
+  })
+
+  test('every method probed was actually installed', () => {
+    const missing = [...probed].filter((name) => !SANDBOX_INSTALLED.includes(name))
+    assert.deepStrictEqual(
+      missing, [],
+      'These probes target methods the sandbox did not install, so they can only ' +
+      'be passing for some other reason.',
+    )
+  })
+
+  test('the only reason to skip a method is that this platform lacks it', () => {
+    // `lchmod`/`lchmodSync` are macOS-only, so a skip is legitimate — but ONLY
+    // for that reason. An `already-guarded` skip would mean `_setup.mjs` ran
+    // twice, which would leave the second (correct) root unenforced.
+    for (const { name, reason } of SANDBOX_SKIPPED) {
+      assert.strictEqual(reason, 'absent', `${name} was skipped for an unexpected reason: ${reason}`)
+      const base = name.replace(/ \(callback\)$/, '').replace(/^promises\./, '')
+      const host = name.startsWith('promises.') ? fspNamespace : fsNamespace
+      assert.strictEqual(
+        typeof host[base], 'undefined',
+        `${name} was skipped as "absent" but it exists on this platform.`,
+      )
+    }
+  })
+
+  test('the installed set matches the functions actually carrying the guard marker', () => {
+    // Read back off the live objects rather than trusting the return value:
+    // a patch that was installed and then overwritten by a later import would
+    // still be listed as installed.
+    // The marker already carries the label the sandbox reported installing
+    // (`promises.rm`, `rm (callback)`, `rmSync`), so it is read verbatim — a
+    // prefix rebuilt here would be a second naming scheme to keep in step.
+    const marked = []
+    for (const host of [fsNamespace, fspNamespace]) {
+      for (const key of Object.keys(host)) {
+        const fn = host[key]
+        if (typeof fn === 'function' && fn[SANDBOX_MARKER]) marked.push(fn[SANDBOX_MARKER])
+      }
+    }
+    assert.deepStrictEqual(
+      marked.sort(), [...SANDBOX_INSTALLED].sort(),
+      'The live fs objects do not carry exactly the guards the sandbox reports ' +
+      'installing — something re-assigned an fs method after the patch.',
+    )
+  })
+})
+
+describe('write sandbox: two-path operations guard BOTH paths (#7267)', () => {
+  // The one property the derived list cannot pin about itself.
+  //
+  // `probePlans` reads the same `paths` field the installer reads, so narrowing
+  // a row from `paths: 2` to `paths: 1` removes the guard on the second
+  // argument AND the probe that would have caught it — the suite stays green
+  // while `rename(tmp, '~/.chroxy/session-state.json')` walks straight through.
+  // Measured: that exact mutation passed every other assertion in this file.
+  //
+  // So this table is stated INDEPENDENTLY, on purpose, and it is the only thing
+  // in the change deliberately written twice. It is a specification, not a copy
+  // of the implementation: each row says why the argument nobody thinks about
+  // is dangerous.
+  const TWO_PATH_OPERATIONS = [
+    ['rename', 'moving real state OUT is data loss, not only moving something IN'],
+    ['cp', 'dest creates (and creates its parents); src reads real user state into a fixture'],
+    ['copyFile', 'the single-file form of the same'],
+    ['link', 'newPath creates a hard link; existingPath is the inode being aliased'],
+    ['symlink', 'path creates — and a link whose TARGET is the real tree defeats this ' +
+                'guard wholesale, because path.resolve() does not follow links: writes ' +
+                'through the alias never look like ~/.chroxy at all'],
+  ]
+
+  test('the table covers exactly the operations declared to take two paths', () => {
+    assert.deepStrictEqual(
+      TWO_PATH_OPERATIONS.map(([op]) => op).sort(),
+      FS_PATH_MUTATORS.filter((m) => m.paths === 2).map((m) => m.base).sort(),
+      'A two-path operation exists that this suite does not probe in both ' +
+      'positions, or vice versa. Add it here WITH the reason its second path ' +
+      'matters — that reason is the whole content of this table.',
+    )
+  })
+
+  for (const [base, why] of TWO_PATH_OPERATIONS) {
+    for (const [position, args] of [
+      ['first', [protectedPath, spare]],
+      ['second', [absentSource, protectedPath]],
+    ]) {
+      for (const surface of ['sync', 'callback', 'promises']) {
+        const method = surface === 'sync' ? `${base}Sync` : base
+        const label = surface === 'promises' ? `promises.${base}` : surface === 'callback' ? `${base} (callback)` : `${base}Sync`
+        test(`${label} guards its ${position} path argument`, async () => {
+          const verdict = await runProbe(
+            { base, surface, method, args, extra: PROBE_EXTRA_ARGS[base]() },
+            { fs: fsNamespace, promises: fspNamespace, cleanup: removeProbeRoot },
+          )
+          assert.strictEqual(verdict, GUARDED, `${label} ignored its ${position} path argument — ${why}`)
+        })
+      }
+    }
+  }
+})
+
+describe('write sandbox: the guard is a category, not a list (#7267)', () => {
+  const { sync, callback, promises } = guardedMethodNames()
+
+  test('every function on node:fs is either guarded or exempt with a reason', () => {
+    const guarded = new Set([...sync, ...callback])
+    const unclassified = Object.keys(fsNamespace)
+      .filter((k) => typeof fsNamespace[k] === 'function')
+      .filter((k) => !guarded.has(k) && !(k in FS_EXEMPTIONS))
+    assert.deepStrictEqual(
+      unclassified, [],
+      'This Node build exposes fs functions the sandbox neither guards nor exempts. ' +
+      'Classify each one in scripts/lib/test-fs-sandbox.mjs: add it to ' +
+      'FS_PATH_MUTATORS if it takes a path and mutates the filesystem, or to ' +
+      'FS_EXEMPTIONS with the reason it cannot corrupt user state.',
+    )
+  })
+
+  test('every function on fs.promises is either guarded or exempt with a reason', () => {
+    const guarded = new Set(promises)
+    const unclassified = Object.keys(fspNamespace)
+      .filter((k) => typeof fspNamespace[k] === 'function')
+      .filter((k) => !guarded.has(k) && !(k in FS_PROMISES_EXEMPTIONS))
+    assert.deepStrictEqual(unclassified, [], 'Classify these in FS_PROMISES_EXEMPTIONS or FS_PATH_MUTATORS.')
+  })
+
+  test('nothing is both guarded and exempt', () => {
+    const guarded = new Set([...sync, ...callback])
+    assert.deepStrictEqual(
+      Object.keys(FS_EXEMPTIONS).filter((k) => guarded.has(k)), [],
+      'An exemption for a guarded method is a contradiction: whichever list is ' +
+      'read first decides, and the other silently means nothing.',
+    )
+    assert.deepStrictEqual(
+      Object.keys(FS_PROMISES_EXEMPTIONS).filter((k) => new Set(promises).has(k)), [],
+    )
+  })
+
+  test('the exemptions are not a dumping ground — every reason is one of the known kinds', () => {
+    const KNOWN = new Set(['read', 'fd', 'class', 'class-known-residual', 'internal'])
+    const odd = Object.entries({ ...FS_EXEMPTIONS, ...FS_PROMISES_EXEMPTIONS })
+      .filter(([, reason]) => !KNOWN.has(reason))
+    assert.deepStrictEqual(odd, [], 'Unknown exemption reason — see the header of test-fs-sandbox.mjs.')
+  })
+
+  test('the mutator table has no duplicate rows', () => {
+    const bases = FS_PATH_MUTATORS.map((m) => m.base)
+    assert.deepStrictEqual(
+      bases.filter((b, i) => bases.indexOf(b) !== i), [],
+      'A duplicated base would install one guard over another and report both.',
+    )
+    const streams = FS_STREAM_MUTATORS.map((m) => m.name)
+    assert.deepStrictEqual(streams.filter((s, i) => streams.indexOf(s) !== i), [])
+  })
+})
+
+describe('write sandbox: controls (#7267)', () => {
+  // POSITIVE CONTROL. Every assertion above passes on CHROXY_TEST_SANDBOX and
+  // fails on ENOENT. That distinction is worthless unless ENOENT is genuinely
+  // what a bypass looks like here — otherwise the suite would be green because
+  // nothing ever reaches the syscall, not because the guard is armed. Same
+  // shape, same missing parent, only the root differs.
+  test('an UNPROTECTED missing-parent path reaches the real fs (ENOENT)', async () => {
+    const control = probePlans({
+      protectedPath: join(tmpdir(), `chroxy-sandbox-control-${process.pid}`, 'probe.tmp'),
+      spare,
+      absentSource,
+    })
+    const write = control.find((p) => p.label === 'writeFileSync')
+    const unlink = control.find((p) => p.label === 'unlink (callback)')
+    const rm = control.find((p) => p.label === 'promises.rm')
+    for (const plan of [write, unlink, rm]) {
+      assert.strictEqual(
+        await runProbe(plan, { fs: fsNamespace, promises: fspNamespace }),
+        REACHED_REAL_FS,
+        `The control (${plan.label}) did not reach the real fs, so ENOENT is not a ` +
+        `valid signature for "bypassed" and the assertions above prove nothing.`,
+      )
+    }
+  })
+
+  test('the guard discriminates by path, not by throwing at everything', () => {
+    const dir = join(tmpdir(), `chroxy-sandbox-coverage-ok-${process.pid}`)
+    try {
+      fsNamespace.mkdirSync(dir, { recursive: true })
+      const file = join(dir, 'legit.txt')
+      namedWriteFileSync(file, 'ok')
+      fsNamespace.chmodSync(file, 0o600)
+      fsNamespace.copyFileSync(file, join(dir, 'copy.txt'))
+      fsNamespace.unlinkSync(join(dir, 'copy.txt'))
+      assert.strictEqual(fsNamespace.readFileSync(file, 'utf8'), 'ok')
+    } finally {
+      namedRmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('reads of the real home are still allowed', () => {
+    // Deliberate: `providers.test.js` and friends legitimately read the
+    // developer's real config. A guard that blocked reads would be "safer" and
+    // would break the suite, so the exemption is pinned, not assumed.
+    assert.doesNotThrow(() => fsNamespace.existsSync(join(homedir(), '.chroxy')))
+    assert.doesNotThrow(() => fsNamespace.readdirSync(homedir()))
+  })
+})
+
+describe('write sandbox: the probes created nothing under the real home (#7267)', () => {
+  // The acceptance criterion #7267 was filed on. `cpSync` is why it is asserted
+  // rather than reasoned: it creates the destination's parent chain before it
+  // fails, so a probe aimed at a NON-EXISTENT path under ~/.chroxy left a real
+  // directory there — through an armed sandbox — while every other probe in
+  // this file is safe by construction. This assertion runs last on purpose.
+  test('no probe root exists under ~/.chroxy', () => {
+    const leaked = namedExistsSync(PROBE_ROOT)
+    if (leaked) removeProbeRoot()
+    assert.strictEqual(
+      leaked, false,
+      `A probe created real state at ${PROBE_ROOT}. It has been removed, but the ` +
+      `sandbox let a write through — that is the #4633 bug, live.`,
+    )
+  })
+})

--- a/scripts/lib/test-fs-sandbox-probes.mjs
+++ b/scripts/lib/test-fs-sandbox-probes.mjs
@@ -1,0 +1,170 @@
+// test-fs-sandbox-probes.mjs — the probe harness both packages use to prove
+// their write sandbox actually fires (#7267, #7268).
+//
+// `docs/false-safety-guards.md`: "when you add or change a check, break the
+// thing it protects and confirm it goes red. If you cannot make it fail, it is
+// not a guard." Every guarded method is therefore CALLED against a protected
+// path here, and the assertion is on the call's observable outcome — never on
+// `fn.name`, never on a marker property. A name check is a reading, and the
+// sandbox's own first probe in #7254 read as "working" because it happened to
+// use a default import.
+//
+// ── How a probe avoids writing to the real home ────────────────────────────
+//
+// Every target is a path under the protected root WHOSE PARENT DIRECTORY DOES
+// NOT EXIST, which makes the two outcomes cleanly distinguishable at no risk:
+//
+//   guard fired    -> CHROXY_TEST_SANDBOX   (the patched wrapper ran)
+//   guard bypassed -> ENOENT                (the real syscall ran, and the
+//                                            kernel refused it)
+//
+// so a FAILING run still creates nothing. That property is not free, and it is
+// not uniform: `cpSync` CREATES the destination's parent chain before it fails.
+// Measured on Node 22.22.3 — a `cpSync` probe at a non-existent path under
+// `~/.chroxy` left a real directory in the developer's live config dir, through
+// an armed sandbox. Every two-path probe therefore puts an ABSENT source in
+// argument 0 when the protected path is argument 1, because `cp` checks the
+// source before it creates anything (measured: ENOENT, nothing created). The
+// leak assertion in the suite is the backstop for that reasoning, not a
+// substitute for it.
+//
+// This module is deliberately NOT in `_setup.mjs`'s import graph — only
+// `test-fs-sandbox.mjs` is, and that one carries the #7262 obligation never to
+// ESM-import `node:fs`.
+import { FS_PATH_MUTATORS, FS_STREAM_MUTATORS, SANDBOX_ERROR_CODE } from './test-fs-sandbox.mjs'
+
+export const GUARDED = 'guarded'
+export const REACHED_REAL_FS = 'reached-real-fs'
+
+export function classify (err) {
+  if (!err) return 'no-error: the call SUCCEEDED, which means it reached a real path'
+  if (err.code === SANDBOX_ERROR_CODE) return GUARDED
+  if (err.code === 'ENOENT') return REACHED_REAL_FS
+  return `unexpected: ${err.code || err.message}`
+}
+
+/**
+ * Arguments each operation needs AFTER its path argument(s). Keyed by the
+ * `base` in `FS_PATH_MUTATORS`, so a mutator added there without a recipe here
+ * fails the suite with "no probe recipe" instead of being silently unprobed.
+ */
+export const PROBE_EXTRA_ARGS = {
+  writeFile: () => ['probe'],
+  appendFile: () => ['probe'],
+  // Deliberately NOT `{ recursive: true }`: recursive would create real
+  // directories under the protected root if the guard were bypassed.
+  mkdir: () => [],
+  mkdtemp: () => [],
+  rm: () => [],
+  rmdir: () => [],
+  unlink: () => [],
+  truncate: () => [0],
+  chmod: () => [0o600],
+  lchmod: () => [0o600],
+  chown: () => [process.getuid?.() ?? 0, process.getgid?.() ?? 0],
+  lchown: () => [process.getuid?.() ?? 0, process.getgid?.() ?? 0],
+  utimes: () => [new Date(), new Date()],
+  lutimes: () => [new Date(), new Date()],
+  rename: () => [],
+  cp: () => [],
+  copyFile: () => [],
+  symlink: () => [],
+  link: () => [],
+  open: () => ['w'],
+  createWriteStream: () => [],
+}
+
+/**
+ * Build one probe plan per (method, protected-argument-position).
+ *
+ * @param {object} paths
+ * @param {string} paths.protectedPath  Under the protected root, parent missing.
+ * @param {string} paths.spare          Unprotected, parent missing — a safe
+ *   partner for the argument the probe is not aiming at.
+ * @param {string} paths.absentSource   Unprotected and NON-EXISTENT — used as
+ *   argument 0 whenever the protected path is argument 1, so `cp` and friends
+ *   fail on the missing source before creating the destination's parents.
+ * @returns {Array<{label: string, method: string, surface: 'sync'|'callback'|'promises'|'stream', args: any[]}>}
+ */
+export function probePlans ({ protectedPath, spare, absentSource }) {
+  const plans = []
+
+  const positions = (paths) => (paths === 1
+    ? [{ suffix: '', args: [protectedPath] }]
+    : [
+        { suffix: ' (from)', args: [protectedPath, spare] },
+        { suffix: ' (to)', args: [absentSource, protectedPath] },
+      ])
+
+  for (const { base, paths } of FS_PATH_MUTATORS) {
+    const recipe = PROBE_EXTRA_ARGS[base]
+    for (const { suffix, args } of positions(paths)) {
+      const extra = recipe ? recipe() : null
+      plans.push({ base, surface: 'sync', method: `${base}Sync`, label: `${base}Sync${suffix}`, args, extra })
+      plans.push({ base, surface: 'callback', method: base, label: `${base} (callback)${suffix}`, args, extra })
+      plans.push({ base, surface: 'promises', method: base, label: `promises.${base}${suffix}`, args, extra })
+    }
+  }
+
+  for (const { name, paths } of FS_STREAM_MUTATORS) {
+    const recipe = PROBE_EXTRA_ARGS[name]
+    for (const { suffix, args } of positions(paths)) {
+      plans.push({ base: name, surface: 'stream', method: name, label: `${name}${suffix}`, args, extra: recipe ? recipe() : null })
+    }
+  }
+
+  return plans
+}
+
+export function probeSync (fn, args) {
+  try { fn(...args); return classify(null) } catch (err) { return classify(err) }
+}
+
+export async function probePromise (fn, args) {
+  try {
+    const handle = await fn(...args)
+    // `promises.open` resolves a FileHandle; leaking it would keep a real fd.
+    if (handle && typeof handle.close === 'function') await handle.close()
+    return classify(null)
+  } catch (err) { return classify(err) }
+}
+
+// The callback form's guard throws SYNCHRONOUSLY by design (see
+// `installFsWriteSandbox`), so both delivery paths have to be classified.
+export function probeCallback (fn, args) {
+  return new Promise((resolve) => {
+    try { fn(...args, (err) => resolve(classify(err))) } catch (err) { resolve(classify(err)) }
+  })
+}
+
+// `createWriteStream` is the one probe whose BYPASS path is asynchronous: the
+// guard throws synchronously, but a bypassed call returns a live stream and
+// reports ENOENT later on an 'error' event. Treating that as "the call
+// succeeded" would be wrong, and the unhandled 'error' would surface as an
+// uncaughtException after the test had ended — noise that hides which
+// assertion failed.
+export function probeStream (fn, args, cleanup) {
+  return new Promise((resolve) => {
+    let stream
+    try { stream = fn(...args) } catch (err) { return resolve(classify(err)) }
+    stream.once('error', (err) => resolve(classify(err)))
+    stream.once('open', () => {
+      // It actually opened, so a real file exists under the protected root.
+      stream.destroy()
+      try { cleanup?.() } catch { /* best effort — the leak assertion reports it */ }
+      resolve(classify(null))
+    })
+  })
+}
+
+/** Run one plan against the given `fs` / `fs.promises` binding objects. */
+export function runProbe (plan, { fs, promises, cleanup }) {
+  const args = plan.extra ? [...plan.args, ...plan.extra] : plan.args
+  switch (plan.surface) {
+    case 'sync': return probeSync(fs[plan.method], args)
+    case 'callback': return probeCallback(fs[plan.method], args)
+    case 'promises': return probePromise(promises[plan.method], args)
+    case 'stream': return probeStream(fs[plan.method], args, cleanup)
+    default: throw new Error(`unknown probe surface: ${plan.surface}`)
+  }
+}

--- a/scripts/lib/test-fs-sandbox-probes.mjs
+++ b/scripts/lib/test-fs-sandbox-probes.mjs
@@ -89,6 +89,22 @@ export const PROBE_EXTRA_ARGS = {
 export function probePlans ({ protectedPath, spare, absentSource }) {
   const plans = []
 
+  // A mutator row with no recipe here must FAIL, not silently produce an
+  // unprobed guard. The comment above used to promise this without any code
+  // behind it, which is the shape this whole change is about.
+  function requireRecipe (base) {
+    const recipe = PROBE_EXTRA_ARGS[base]
+    if (typeof recipe !== 'function') {
+      throw new Error(
+        `no probe recipe for '${base}'. Every row in FS_PATH_MUTATORS / ` +
+        `FS_STREAM_MUTATORS needs an entry in PROBE_EXTRA_ARGS giving the ` +
+        `arguments that follow its path argument(s), or its guard is installed ` +
+        `and never proven.`,
+      )
+    }
+    return recipe
+  }
+
   const positions = (paths) => (paths === 1
     ? [{ suffix: '', args: [protectedPath] }]
     : [
@@ -97,9 +113,9 @@ export function probePlans ({ protectedPath, spare, absentSource }) {
       ])
 
   for (const { base, paths } of FS_PATH_MUTATORS) {
-    const recipe = PROBE_EXTRA_ARGS[base]
+    const recipe = requireRecipe(base)
     for (const { suffix, args } of positions(paths)) {
-      const extra = recipe ? recipe() : null
+      const extra = recipe()
       plans.push({ base, surface: 'sync', method: `${base}Sync`, label: `${base}Sync${suffix}`, args, extra })
       plans.push({ base, surface: 'callback', method: base, label: `${base} (callback)${suffix}`, args, extra })
       plans.push({ base, surface: 'promises', method: base, label: `promises.${base}${suffix}`, args, extra })
@@ -107,13 +123,48 @@ export function probePlans ({ protectedPath, spare, absentSource }) {
   }
 
   for (const { name, paths } of FS_STREAM_MUTATORS) {
-    const recipe = PROBE_EXTRA_ARGS[name]
+    const recipe = requireRecipe(name)
     for (const { suffix, args } of positions(paths)) {
-      plans.push({ base: name, surface: 'stream', method: name, label: `${name}${suffix}`, args, extra: recipe ? recipe() : null })
+      plans.push({ base: name, surface: 'stream', method: name, label: `${name}${suffix}`, args, extra: recipe() })
     }
   }
 
   return plans
+}
+
+/**
+ * Split plans into the ones this platform can actually run and the ones whose
+ * method does not exist here.
+ *
+ * `lchmod`/`lchmodSync` are macOS-only — Node does not define them on Linux, so
+ * a probe built from the table alone calls `undefined` and reports
+ * "fn is not a function". That is a test defect, not a guard failure, and it is
+ * exactly what CI caught: the whole table was probed on a platform that lacks
+ * two of its entries.
+ *
+ * Dropping a probe is the dangerous half of this, because "cannot run this"
+ * must never quietly become "nothing to check" (docs/false-safety-guards.md
+ * the "Silently skipped an input" mode). So this only PARTITIONS — the caller is expected to assert that
+ * every unavailable plan is corroborated by the installer having skipped the
+ * same method for the same reason, and the category-completeness test remains
+ * the backstop: it enumerates the LIVE `fs` object, so a method missing from
+ * this platform is a method with nothing to guard.
+ */
+export function partitionByAvailability (plans, { fs, promises }) {
+  const runnable = []
+  const unavailable = []
+  for (const plan of plans) {
+    const host = plan.surface === 'promises' ? promises : fs
+    ;(typeof host[plan.method] === 'function' ? runnable : unavailable).push(plan)
+  }
+  return { runnable, unavailable }
+}
+
+/** The guard label the installer would report for a plan. */
+export function planLabel (plan) {
+  if (plan.surface === 'promises') return `promises.${plan.method}`
+  if (plan.surface === 'callback') return `${plan.method} (callback)`
+  return plan.method
 }
 
 export function probeSync (fn, args) {

--- a/scripts/lib/test-fs-sandbox.mjs
+++ b/scripts/lib/test-fs-sandbox.mjs
@@ -1,0 +1,321 @@
+// test-fs-sandbox.mjs — the ONE write sandbox both test harnesses install.
+//
+// #4633: a test that forgets a temp path must fail LOUDLY instead of silently
+// clobbering the developer's live `~/.chroxy` / `~/.claude`. Two packages need
+// that guard — `packages/server/tests/_setup.mjs` and
+// `packages/claude-hooks/tests/_setup.mjs` — and until #7267/#7268 each carried
+// its own hand-written patch list. They drifted in BOTH directions: the server
+// patched `openSync`/`appendFileSync`/four `promises` methods that claude-hooks
+// did not, claude-hooks patched `rmSync`/`unlinkSync` that the server did not,
+// and neither patched anything that copies, links, or changes a mode. So there
+// is one list, here, imported by both — the same reasoning
+// `scripts/lib/entry-point-guard-copies.mjs` records for its own list.
+//
+// ── #7262: this module MUST NOT ESM-import `node:fs` ────────────────────────
+//
+// Node builds the `node:fs` synthetic ESM module LAZILY, snapshotting its named
+// exports off `module.exports` the first time some ESM module imports it. Every
+// `import { … } from 'node:fs'` — named, namespace, or bare side-effect — takes
+// that snapshot at LINK time, before any module body runs. A single such import
+// anywhere in the graph a `_setup.mjs` pulls in therefore freezes the UNPATCHED
+// exports, and every `import { writeFileSync } from 'node:fs'` consumer (45
+// modules under `packages/server/src` at the time of writing) bypasses the
+// sandbox while it still reports success for CJS and default importers.
+//
+// That is not hypothetical: `import { mkdtempSync } from 'node:fs'` sat at the
+// top of the server's `_setup.mjs` for months and did exactly this.
+// `createRequire` reaches the live CJS `module.exports` WITHOUT linking the
+// synthetic module, so the snapshot is taken later, already patched.
+//
+// Because this module is imported BY the setup files, the rule now extends to
+// it and to anything it imports. `node:module`, `node:path` and `node:url` are
+// safe — importing them does not link `node:fs`'s synthetic module — and the
+// structural test walks the whole graph rather than trusting this comment.
+import { createRequire } from 'node:module'
+import { resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+
+/**
+ * Every `fs` API that takes a PATH and mutates the filesystem, as one row per
+ * operation. Each row expands to up to three real methods — `<base>Sync`,
+ * `<base>` (callback form) and `fs.promises.<base>` — so a new operation cannot
+ * be added to the sync surface while its promise twin is forgotten, which is
+ * how the two sandboxes drifted apart in the first place.
+ *
+ * `paths` is how many LEADING arguments are paths, and every one of them is
+ * checked. For the two-path operations that is deliberate in both directions:
+ *
+ *   rename(old, new)      moving real state OUT is data loss, same as writing in
+ *   cp/copyFile(src,dest) dest CREATES; src reads real user state into a fixture
+ *   link(existing, new)   new CREATES; existing is the thing being aliased
+ *   symlink(target, path) path CREATES — and a symlink whose TARGET is the real
+ *                         tree is a bypass of this very guard, because
+ *                         `path.resolve` does not follow links: write through
+ *                         the alias and `isProtected` never sees `~/.chroxy`
+ *
+ * `writeIntentArg` marks an operation whose second argument is an open mode;
+ * only write-intent opens are blocked, so tests that legitimately READ the
+ * developer's real config (provider detection, for one) keep working.
+ */
+export const FS_PATH_MUTATORS = [
+  { base: 'writeFile', paths: 1 },
+  { base: 'appendFile', paths: 1 },
+  { base: 'mkdir', paths: 1 },
+  { base: 'mkdtemp', paths: 1 },
+  { base: 'rm', paths: 1 },
+  { base: 'rmdir', paths: 1 },
+  { base: 'unlink', paths: 1 },
+  { base: 'truncate', paths: 1 },
+  { base: 'chmod', paths: 1 },
+  { base: 'lchmod', paths: 1 },
+  { base: 'chown', paths: 1 },
+  { base: 'lchown', paths: 1 },
+  { base: 'utimes', paths: 1 },
+  { base: 'lutimes', paths: 1 },
+  { base: 'rename', paths: 2 },
+  { base: 'cp', paths: 2 },
+  { base: 'copyFile', paths: 2 },
+  { base: 'symlink', paths: 2 },
+  { base: 'link', paths: 2 },
+  { base: 'open', paths: 1, writeIntentArg: 1 },
+]
+
+/**
+ * `createWriteStream` has no `Sync`/promise twins, so it does not fit the table
+ * above. It is the only member of its shape.
+ */
+export const FS_STREAM_MUTATORS = [{ name: 'createWriteStream', paths: 1 }]
+
+/**
+ * The COMPLEMENT: every remaining function on `node:fs` / `fs.promises`, with
+ * the reason it needs no guard.
+ *
+ * This exists so the guard is a CATEGORY and not a list. `docs/false-safety-guards.md`
+ * cause #1 is "a hardcoded list next to a set that grows" — and `fs` grows. A
+ * test asserts that GUARDED ∪ EXEMPT covers the live `fs` surface exactly, so a
+ * Node upgrade that adds a path-taking mutator turns the suite RED and forces a
+ * classification, instead of quietly widening the hole.
+ *
+ * Two reasons appear repeatedly and both are load-bearing:
+ *
+ *   'read'  — reads cannot corrupt user state, and tests legitimately read the
+ *             developer's real config. Guarding these would break them.
+ *   'fd'    — takes a file descriptor, not a path. An fd that can WRITE to a
+ *             protected path can only have come from `open`/`openSync`, which
+ *             IS guarded for write-intent flags, so the check happens one step
+ *             earlier and this surface needs no path check of its own.
+ */
+export const FS_EXEMPTIONS = {
+  // Constructors. `createWriteStream` is the documented entry point and is
+  // guarded; `new fs.WriteStream(path)` would sidestep it. Measured: zero call
+  // sites anywhere in this repo. Named here rather than left silent so the
+  // residual is on the record.
+  Dir: 'class', Dirent: 'class', Stats: 'class',
+  ReadStream: 'class', WriteStream: 'class-known-residual',
+  FileReadStream: 'class', FileWriteStream: 'class-known-residual',
+
+  access: 'read', accessSync: 'read',
+  exists: 'read', existsSync: 'read',
+  glob: 'read', globSync: 'read',
+  lstat: 'read', lstatSync: 'read',
+  openAsBlob: 'read',
+  opendir: 'read', opendirSync: 'read',
+  read: 'read', readSync: 'read',
+  readFile: 'read', readFileSync: 'read',
+  readdir: 'read', readdirSync: 'read',
+  readlink: 'read', readlinkSync: 'read',
+  readv: 'read', readvSync: 'read',
+  realpath: 'read', realpathSync: 'read',
+  stat: 'read', statSync: 'read',
+  statfs: 'read', statfsSync: 'read',
+  watch: 'read', watchFile: 'read', unwatchFile: 'read',
+  createReadStream: 'read',
+
+  close: 'fd', closeSync: 'fd',
+  fchmod: 'fd', fchmodSync: 'fd',
+  fchown: 'fd', fchownSync: 'fd',
+  fdatasync: 'fd', fdatasyncSync: 'fd',
+  fstat: 'fd', fstatSync: 'fd',
+  fsync: 'fd', fsyncSync: 'fd',
+  ftruncate: 'fd', ftruncateSync: 'fd',
+  futimes: 'fd', futimesSync: 'fd',
+  write: 'fd', writeSync: 'fd',
+  writev: 'fd', writevSync: 'fd',
+
+  _toUnixTimestamp: 'internal',
+}
+
+/** The `fs.promises` complement. Same reasons. */
+export const FS_PROMISES_EXEMPTIONS = {
+  access: 'read', glob: 'read', lstat: 'read', opendir: 'read',
+  readFile: 'read', readdir: 'read', readlink: 'read', realpath: 'read',
+  stat: 'read', statfs: 'read', watch: 'read',
+}
+
+export const SANDBOX_ERROR_CODE = 'CHROXY_TEST_SANDBOX'
+
+/** Marks a patched function so a test can enumerate what was ACTUALLY installed. */
+export const SANDBOX_MARKER = Symbol.for('chroxy.testFsSandbox')
+
+/**
+ * `true` when `flags` requests write access. `flags` is a string ('w', 'a',
+ * 'r+', 'wx'…) or a number of OR'd O_* constants.
+ */
+export function isWriteIntent (flags) {
+  if (typeof flags === 'string') return /[wa+]/.test(flags)
+  if (typeof flags === 'number') {
+    // O_WRONLY = 1, O_RDWR = 2, O_CREAT = 64
+    return (flags & 1) !== 0 || (flags & 2) !== 0 || (flags & 64) !== 0
+  }
+  // `undefined` defaults to 'r' — a read.
+  return false
+}
+
+/** Every method name this module would patch, in install order. */
+export function guardedMethodNames () {
+  const sync = []
+  const callback = []
+  const promises = []
+  for (const { base } of FS_PATH_MUTATORS) {
+    sync.push(`${base}Sync`)
+    callback.push(base)
+    promises.push(base)
+  }
+  for (const { name } of FS_STREAM_MUTATORS) sync.push(name)
+  return { sync, callback, promises }
+}
+
+/**
+ * Install the sandbox on the live `node:fs` CJS exports object.
+ *
+ * @param {object} opts
+ * @param {string[]} opts.protectedRoots  Absolute dirs; the dir itself and
+ *   everything under it is protected.
+ * @param {string[]} [opts.protectedFiles] Absolute files protected on their own
+ *   (e.g. `~/.claude.json`, which sits NEXT TO the protected dirs).
+ * @param {string} [opts.allowEnv] Name of an env var whose value `'1'` disables
+ *   the guard for a test that genuinely must write to the real home.
+ * @param {(method: string, target: string) => string} [opts.message] Builds the
+ *   error message body. The `code` is always `CHROXY_TEST_SANDBOX`.
+ * @returns {{installed: string[], skipped: Array<{name: string, reason: string}>, isProtected: Function}}
+ */
+export function installFsWriteSandbox ({ protectedRoots, protectedFiles = [], allowEnv, message }) {
+  const fs = require('node:fs')
+
+  const roots = protectedRoots.map((r) => resolve(r))
+  const files = new Set(protectedFiles.map((f) => resolve(f)))
+
+  function isProtected (rawPath) {
+    if (allowEnv && process.env[allowEnv] === '1') return false
+    if (typeof rawPath !== 'string' && !(rawPath instanceof URL) && !(rawPath instanceof Buffer)) {
+      return false
+    }
+    let p
+    try {
+      // `fileURLToPath` (not `.pathname`) handles the cross-platform quirks:
+      // Windows `file:///C:/…` yields `C:\…`, and percent-encoded segments are
+      // decoded. `.pathname` would leave a leading slash on Windows and never
+      // match an `os.homedir()`-derived path.
+      if (rawPath instanceof URL) p = fileURLToPath(rawPath)
+      else if (rawPath instanceof Buffer) p = rawPath.toString('utf8')
+      else p = rawPath
+      p = resolve(p)
+    } catch {
+      return false
+    }
+    if (files.has(p)) return true
+    for (const root of roots) {
+      if (p === root || p.startsWith(root + sep)) return true
+    }
+    return false
+  }
+
+  const body = message || ((method, target) =>
+    `[chroxy-test-sandbox] BLOCKED ${method} to real user-state path: ${target}`)
+
+  function makeGuardError (method, target) {
+    const err = new Error(body(method, target))
+    err.code = SANDBOX_ERROR_CODE
+    return err
+  }
+
+  // Which of the leading `paths` arguments is protected, rendered for the
+  // message. Returns null when none of them is.
+  function offender (args, paths) {
+    const hits = []
+    for (let i = 0; i < paths; i++) if (isProtected(args[i])) hits.push(String(args[i]))
+    if (hits.length === 0) return null
+    return paths === 1 ? hits[0] : args.slice(0, paths).map(String).join(' -> ')
+  }
+
+  const installed = []
+  const skipped = []
+
+  function patch (host, name, label, wrap) {
+    const original = host[name]
+    if (typeof original !== 'function') {
+      // `lchmod`/`lchmodSync` exist only on macOS, and `fs.promises` gains
+      // methods across Node releases. An absent method is skipped rather than
+      // assumed present; the test asserts absence is the ONLY reason.
+      skipped.push({ name: label, reason: 'absent' })
+      return
+    }
+    if (original[SANDBOX_MARKER]) {
+      skipped.push({ name: label, reason: 'already-guarded' })
+      return
+    }
+    const patched = wrap(original)
+    patched[SANDBOX_MARKER] = label
+    host[name] = patched
+    installed.push(label)
+  }
+
+  for (const spec of FS_PATH_MUTATORS) {
+    const { base, paths, writeIntentArg } = spec
+
+    const blocked = (args) => {
+      if (writeIntentArg !== undefined && !isWriteIntent(args[writeIntentArg])) return null
+      return offender(args, paths)
+    }
+
+    patch(fs, `${base}Sync`, `${base}Sync`, (orig) => function guardedSync (...args) {
+      const hit = blocked(args)
+      if (hit !== null) throw makeGuardError(`${base}Sync`, hit)
+      return orig.apply(this, args)
+    })
+
+    // The CALLBACK form throws SYNCHRONOUSLY rather than handing the error to
+    // the callback, and that is deliberate. `fs.unlink(p, () => {})` is a
+    // common fire-and-forget idiom; delivering a sandbox breach into a callback
+    // that ignores its argument would make the guard silent — the exact failure
+    // this file exists to prevent. Node itself throws synchronously from these
+    // functions for invalid input, so a sync throw is not a novel contract.
+    // Measured: zero callback-form `fs` call sites under `packages/*/src`, so
+    // nothing in production code can be surprised by it.
+    patch(fs, base, `${base} (callback)`, (orig) => function guardedCallback (...args) {
+      const hit = blocked(args)
+      if (hit !== null) throw makeGuardError(`${base} (callback)`, hit)
+      return orig.apply(this, args)
+    })
+
+    if (fs.promises) {
+      patch(fs.promises, base, `promises.${base}`, (orig) => function guardedPromise (...args) {
+        const hit = blocked(args)
+        if (hit !== null) return Promise.reject(makeGuardError(`promises.${base}`, hit))
+        return orig.apply(this, args)
+      })
+    }
+  }
+
+  for (const { name, paths } of FS_STREAM_MUTATORS) {
+    patch(fs, name, name, (orig) => function guardedStream (...args) {
+      const hit = offender(args, paths)
+      if (hit !== null) throw makeGuardError(name, hit)
+      return orig.apply(this, args)
+    })
+  }
+
+  return { installed, skipped, isProtected }
+}

--- a/scripts/lib/test-fs-sandbox.mjs
+++ b/scripts/lib/test-fs-sandbox.mjs
@@ -93,7 +93,7 @@ export const FS_STREAM_MUTATORS = [{ name: 'createWriteStream', paths: 1 }]
  * the reason it needs no guard.
  *
  * This exists so the guard is a CATEGORY and not a list. `docs/false-safety-guards.md`
- * cause #1 is "a hardcoded list next to a set that grows" — and `fs` grows. A
+ * the "Checked a subset" mode is "a hardcoded list next to a set that grows" — and `fs` grows. A
  * test asserts that GUARDED ∪ EXEMPT covers the live `fs` surface exactly, so a
  * Node upgrade that adds a path-taking mutator turns the suite RED and forces a
  * classification, instead of quietly widening the hole.
@@ -106,6 +106,19 @@ export const FS_STREAM_MUTATORS = [{ name: 'createWriteStream', paths: 1 }]
  *             protected path can only have come from `open`/`openSync`, which
  *             IS guarded for write-intent flags, so the check happens one step
  *             earlier and this surface needs no path check of its own.
+ *             Measured, not assumed: on a read-only fd `writeSync` gives EBADF
+ *             and `ftruncateSync` gives EINVAL.
+ *   'fd-metadata-known-residual'
+ *           — the same, EXCEPT that these gate on OWNERSHIP rather than write
+ *             access, so they succeed on the read-only fd the guard
+ *             deliberately allows. Measured on darwin: `openSync(cred, 'r')`
+ *             then `fchmodSync(fd, 0)` changed a real file's mode 600 -> 0, and
+ *             `futimesSync` reset its mtime. A path-based guard cannot see this
+ *             — by the time the fd exists there is no path to check — so
+ *             closing it needs fd bookkeeping in the sandbox. It is named here
+ *             rather than hidden under 'fd', because the 'fd' rationale would
+ *             otherwise be a guarantee this code does not make. Tracked
+ *             separately; no call site in this repo does it.
  */
 export const FS_EXEMPTIONS = {
   // Constructors. `createWriteStream` is the documented entry point and is
@@ -134,13 +147,13 @@ export const FS_EXEMPTIONS = {
   createReadStream: 'read',
 
   close: 'fd', closeSync: 'fd',
-  fchmod: 'fd', fchmodSync: 'fd',
-  fchown: 'fd', fchownSync: 'fd',
+  fchmod: 'fd-metadata-known-residual', fchmodSync: 'fd-metadata-known-residual',
+  fchown: 'fd-metadata-known-residual', fchownSync: 'fd-metadata-known-residual',
   fdatasync: 'fd', fdatasyncSync: 'fd',
   fstat: 'fd', fstatSync: 'fd',
   fsync: 'fd', fsyncSync: 'fd',
   ftruncate: 'fd', ftruncateSync: 'fd',
-  futimes: 'fd', futimesSync: 'fd',
+  futimes: 'fd-metadata-known-residual', futimesSync: 'fd-metadata-known-residual',
   write: 'fd', writeSync: 'fd',
   writev: 'fd', writevSync: 'fd',
 
@@ -159,17 +172,28 @@ export const SANDBOX_ERROR_CODE = 'CHROXY_TEST_SANDBOX'
 /** Marks a patched function so a test can enumerate what was ACTUALLY installed. */
 export const SANDBOX_MARKER = Symbol.for('chroxy.testFsSandbox')
 
+// The write-intent mask, taken from THIS runtime's `fs.constants` rather than
+// written down. The literals are not portable and the old ones were Linux's:
+// `O_CREAT` is 64 on Linux but 512 on macOS and 256 on Windows, so a hardcoded
+// `flags & 64` classified `openSync(p, O_CREAT)` as a READ on every platform
+// this repo actually develops on. `O_TRUNC` was not in the mask at all.
+// Measured on darwin before the fix: `openSync('<protected>/state.json',
+// O_TRUNC)` emptied a real file with the sandbox armed and silent.
+const WRITE_INTENT_MASK =
+  require('node:fs').constants.O_WRONLY |
+  require('node:fs').constants.O_RDWR |
+  require('node:fs').constants.O_CREAT |
+  require('node:fs').constants.O_TRUNC |
+  require('node:fs').constants.O_APPEND
+
 /**
  * `true` when `flags` requests write access. `flags` is a string ('w', 'a',
  * 'r+', 'wx'…) or a number of OR'd O_* constants.
  */
 export function isWriteIntent (flags) {
   if (typeof flags === 'string') return /[wa+]/.test(flags)
-  if (typeof flags === 'number') {
-    // O_WRONLY = 1, O_RDWR = 2, O_CREAT = 64
-    return (flags & 1) !== 0 || (flags & 2) !== 0 || (flags & 64) !== 0
-  }
-  // `undefined` defaults to 'r' — a read.
+  if (typeof flags === 'number') return (flags & WRITE_INTENT_MASK) !== 0
+  // `undefined` defaults to 'r' — a read, which is allowed by design.
   return false
 }
 
@@ -204,14 +228,32 @@ export function guardedMethodNames () {
 export function installFsWriteSandbox ({ protectedRoots, protectedFiles = [], allowEnv, message }) {
   const fs = require('node:fs')
 
-  const roots = protectedRoots.map((r) => resolve(r))
-  const files = new Set(protectedFiles.map((f) => resolve(f)))
+  // macOS (APFS/HFS+ by default) and Windows resolve paths case-insensitively,
+  // so `~/.Chroxy/session-state.json` addresses the same real file as
+  // `~/.chroxy/...` — and a case-sensitive comparison does not match it. Both
+  // platforms run this sandbox in CI. Folding case there can only ever produce
+  // a false POSITIVE (a loud refusal on a path that differs from the real home
+  // by case alone), which is the safe direction for a guard.
+  const FOLD_CASE = process.platform === 'darwin' || process.platform === 'win32'
+  const norm = (p) => (FOLD_CASE ? p.toLowerCase() : p)
+
+  const roots = protectedRoots.map((r) => norm(resolve(r)))
+  const files = new Set(protectedFiles.map((f) => norm(resolve(f))))
 
   function isProtected (rawPath) {
     if (allowEnv && process.env[allowEnv] === '1') return false
-    if (typeof rawPath !== 'string' && !(rawPath instanceof URL) && !(rawPath instanceof Buffer)) {
-      return false
-    }
+    // `createWriteStream(null, { fd })` and `open`'s fd forms pass no path.
+    if (rawPath === null || rawPath === undefined) return false
+    // Node accepts a bare Uint8Array as a path and it is NOT `instanceof
+    // Buffer`, so the old type test let one through unexamined.
+    const isPathLike = typeof rawPath === 'string' ||
+      rawPath instanceof URL ||
+      rawPath instanceof Uint8Array
+    // FAIL CLOSED. Returning `false` for a shape we do not recognise is
+    // "silently skipped an input" — a guard reporting success over something it
+    // declined to look at. A false positive here is a loud test failure with
+    // the value in hand; a false negative is #4633.
+    if (!isPathLike) return true
     let p
     try {
       // `fileURLToPath` (not `.pathname`) handles the cross-platform quirks:
@@ -219,11 +261,12 @@ export function installFsWriteSandbox ({ protectedRoots, protectedFiles = [], al
       // decoded. `.pathname` would leave a leading slash on Windows and never
       // match an `os.homedir()`-derived path.
       if (rawPath instanceof URL) p = fileURLToPath(rawPath)
-      else if (rawPath instanceof Buffer) p = rawPath.toString('utf8')
+      else if (rawPath instanceof Uint8Array) p = Buffer.from(rawPath).toString('utf8')
       else p = rawPath
-      p = resolve(p)
+      p = norm(resolve(p))
     } catch {
-      return false
+      // Undecodable: fail closed for the same reason as above.
+      return true
     }
     if (files.has(p)) return true
     for (const root of roots) {


### PR DESCRIPTION
## Summary

The `#4633` write sandbox patched a **named list** of eleven `fs` methods, not a category. Everything that deletes, copies, links or changes a mode reached the developer's real `~/.chroxy` while the guard went on reporting success — the "Checked a subset" mode in `docs/false-safety-guards.md` — a hardcoded list next to a set that grows.

Found inside the fix for `#7262`, which is this document's own thesis: making the guard *visible* to named importers left its *reach* as the only remaining problem, and the reach was the list.

## Measured, under the real harness, against the live `~/.chroxy`

| API | before |
|---|---|
| `writeFileSync` `mkdirSync` `openSync` | GUARDED |
| `truncateSync` | GUARDED — only incidentally, it opens `r+` and trips `openSync` |
| `unlinkSync` `rmSync` `rmdirSync` | **unguarded** — 34 `unlinkSync` call sites in `src/`, more than `openSync`'s 14 |
| `chmodSync` `symlinkSync` `linkSync` | **unguarded** |
| `cpSync` `copyFileSync` | **unguarded — and these CREATE** |
| `fs.writeFile(path, data, cb)` and the whole callback surface | **unguarded** |

`cpSync` is the one worth remembering. A probe aimed at a path whose **parent directory did not exist** — chosen precisely so a failing measurement could create nothing — left a real directory tree inside the live `~/.chroxy`, because `cpSync` creates the destination's parents before it fails. The safety argument was sound for every other API and wrong for that one, and nothing said a word.

## What changed

**One table, in `scripts/lib/test-fs-sandbox.mjs`.** It expands to 61 guards across the sync, callback and `promises` surfaces, and to the probes that prove each one fires. A row cannot be guarded without being proven, or proven without being guarded. That retires the hand-maintained list `setup-sandbox-binding-forms.test.js` carried as a `KNOWN GAP (#7267)` — deleted, not kept in step.

**The guard is now a category, enforced.** `FS_EXEMPTIONS` classifies every remaining `fs` function with a reason (`read`, `fd`, `class`, `internal`), and `GUARDED ∪ EXEMPT` must cover the live `fs` surface exactly. A Node release that adds a path-taking mutator turns the suite red instead of quietly widening the hole. On Node 22.22.3 that is 100 `fs` functions and 31 `fs.promises` functions, zero unclassified, zero overlap.

**Both packages install the same module** (closes `#7268`). They were separate hand-written lists that had drifted in *both* directions — claude-hooks patched `rmSync`/`unlinkSync` the server did not, the server patched `openSync` and four `promises` methods claude-hooks did not. The `openSync` gap was **latent, not reachable through `installHooks`** — issue #7268 claimed otherwise and was wrong, and I have corrected it there. `installer.js`'s atomic write is `mkdirSync → openSync → writeSync → fsyncSync → chmodSync → renameSync`, and `mkdirSync` *was* on the old list, so the sequence aborted at step one (measured against a fake protected home with exactly the old guard installed: one guard fired, nothing created). `openSync` was covered there the way `truncateSync` was covered on the server side — by accident, through a neighbour — which is the kind of coverage this change replaces with the deliberate kind. Its errors also carried no `code`, so a caller matching `err.code` read a **fired** guard as an unrelated failure — that cost a false reading during the `#7266` review.

**The callback guard throws synchronously**, on purpose: `fs.unlink(p, () => {})` is a common fire-and-forget idiom, and a callback-delivered breach would be silent — the exact failure the sandbox exists to prevent. Zero callback-form `fs` call sites exist under `packages/*/src`, so nothing in production code can be surprised by it.

**The `#7262` rule now covers the graph, not one file.** The guard lives one import away from `_setup.mjs`, so an ESM `node:fs` import in the shared module would disarm it identically. The structural check walks the whole import graph, and an import it *cannot* follow is a failure rather than a skip — "cannot check this" must never read as "nothing to check".

## The part that is not obvious

**A derived assertion cannot test the parameter it derives from.** Both lists expand from rows like `{ base: 'rename', paths: 2 }`, so narrowing one to `paths: 1` deletes the guard on the second argument *and* the probe that would have caught it. That mutation was run and it **passed every other assertion in the suite** — `rename(tmp, '~/.chroxy/session-state.json')` would have walked straight through. Which arguments are paths is therefore stated a second time, deliberately, as a specification with a reason per row. It is the only thing here written twice.

## Every guard proven to fail

Thirteen mutations, each restored from a `cp` backup rather than `git checkout --`, each turning the suites red:

| | mutation | caught by |
|---|---|---|
| M1 | the original `#7262` ESM `fs` import, re-applied to the fixed file | binding forms (51 failing) |
| M2 | an ESM `fs` import in the new shared module | binding forms + graph walk |
| M3 / M4 | drop the `unlink` / `cp` row (the `#7267` defect itself) | category completeness |
| M5b / M5c | `rename` / `symlink` narrowed to one path | two-path pin |
| M6 | `isWriteIntent` always false | the three `open` probes |
| M7 | `cpSync` silently skipped at install | per-method probe + probed→installed |
| M9 | the guard error loses its `code` (the `#7268` defect) | error-shape test |
| M10 | an unwalkable import edge in the bootstrap graph | graph walk |
| M11 | claude-hooks guarding the wrong root | all 84 hooks probes |
| M13–M25 | see the review-round comment | 13 more, added after the panel |
| M12 | a two-path row without a stated reason | the specification table |

M5 was a **green miss on the first run** — the two-path pin was added because of it.

## Verification

- **Full server suite: 13,570 tests, 4 failures — every one of them also fails on `main` in the same environment** (live daemon on `:8765`, real `~/.codex/auth.json`). `main` in fact fails 5. No new failures.
- **Zero sandbox breaches surfaced** across the whole suite, matching the issue's prediction that this is latent, not live.
- claude-hooks: 184/184. New sandbox suites: 133/133 server, 87/87 hooks.
- All 14 server custom lints, all 10 `Scripts Tests` steps, and the AGENTS.md gate pass locally.
- The real `~/.chroxy` is clean afterwards — asserted by the suites themselves, not just checked by hand.

Closes #7267
Closes #7268



---

## Review round (`14e9d3376`)

A six-lens dimension panel with three-lens adversarial verification found **three genuine holes in the change itself**, all now fixed and each with a mutation proving the guard fails without it:

- **The write-intent mask was Linux's literals.** `O_CREAT` is 64 on Linux but **512 on macOS**, and `O_TRUNC` was not in the mask at all — `openSync('<protected>/state.json', O_TRUNC)` emptied a real file through an armed sandbox. Now derived from `fs.constants`. The *allow* direction was unpinned too.
- **Three claude-hooks probes could destroy live config.** They targeted real-home paths whose parent exists, so a regression would rewrite and truncate the developer's `~/.claude/settings.json` — the same class as the `cpSync` discovery above, in a file written for this PR.
- **Platform-blind probes** — the CI failure. `lchmod` is macOS-only; plans are now partitioned by availability, with every dropped plan corroborated against the installer's own skip record.

Plus fail-closed path handling, `Uint8Array` paths, case-folding on darwin/win32, an independent mutator roster, `~/.claude` and `~/.claude.json` probes, dynamic-import detection in the structural walk, and corrections to several of my own claims — including that **#7268's `openSync` premise was wrong** (corrected on the issue). Full detail in the [review-round comment](https://github.com/blamechris/chroxy/pull/7272#issuecomment-5337839555).

**28 mutations, every one red.** Full server suite 13,586 tests / 4 failures, all four also failing on `main` in this environment. claude-hooks 185/185. Both suites also green under a simulated Linux fs surface with `lchmod` removed.
