### PR TITLE
fix(ci): derive the Windows test set by exclusion instead of a hardcoded list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,8 @@ jobs:
     # platform-tests job (#5002) — `windows-latest` is billed at a 5x
     # multiplier vs `ubuntu-24.04`, so we only fire it on PRs that touch
     # the files it actually covers. Pushes to `main` skip this job and
-    # always run the Windows suite (see `server-tests-windows.if`).
+    # always run the Windows suite (the `server-tests-windows` job carries no
+    # `if:` of its own — it runs on every same-repo event).
     needs: runner-target
     runs-on: ${{ fromJSON(needs.runner-target.outputs.runner) }}  # SELF_HOSTED_OR_HOSTED (see header)
     timeout-minutes: 2
@@ -216,16 +217,25 @@ jobs:
     # fork PRs (untrusted code never touches the self-hosted box) — see the
     # `winrunner` output on `runner-target`.
     #
-    # Scope is the Windows-RELEVANT suites, not the full server set: much of the
-    # suite depends on node-pty / POSIX signals / shell scripts with no Windows
-    # analogue, so the ubuntu `server-tests` job stays the source of truth for
-    # the rest. `service.test.js` runs here too since #6651 (its POSIX/darwin/
-    # linux-only assertions are now guarded with a win32 skip). Now that this runs
-    # on the free self-hosted box it fires on every same-repo push/PR (the old
-    # platform-changed-only gate existed only to spare windows-latest minutes).
+    # Scope is DERIVED, not curated (#7270): every packages/server/tests/**.test.js
+    # runs here except the rows in WINDOWS_EXEMPT
+    # (packages/server/scripts/lib/windows-test-set.mjs), each of which carries a
+    # reason category and a measured symptom. A new test file is therefore covered
+    # by default. The ubuntu `server-tests` job remains the coverage source of
+    # truth (c8 runs there, not here). Now that this runs on the free self-hosted
+    # box it fires on every same-repo push/PR (the old platform-changed-only gate
+    # existed only to spare windows-latest minutes).
+    #
+    # The manifest itself is gated in `Server Lint`, which is a REQUIRED status
+    # check — this job is not one, so a manifest defect has to be caught
+    # somewhere that actually blocks a merge.
     needs: runner-target
     runs-on: ${{ fromJSON(needs.runner-target.outputs.winrunner) }}
-    timeout-minutes: 15
+    # 15 was sized for EIGHT files (~4s of test time). The derived set is 482.
+    # Measured end-to-end on the chroxy-win box at 4 concurrency; raised with
+    # headroom because a timeout kill is indistinguishable from a hang. Reset
+    # this from the observed runtime once a few real runs have landed.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: packages/server
@@ -253,24 +263,44 @@ jobs:
         run: npm run build
         working-directory: packages/protocol
 
-      - name: Run Windows-relevant server tests
-        # node's built-in test runner directly, mirroring `npm test`'s flags
-        # (sandbox guard via `--import ./tests/_setup.mjs`,
-        # `--experimental-test-module-mocks`) but scoped to the Windows-relevant
-        # suites. `c8` is omitted — the ubuntu job is the coverage source of
-        # truth. All of these are green on a real Windows host (verified
-        # locally); `service.test.js`'s POSIX/darwin/linux-only tests are win32-
-        # guarded (#6651) so it runs here too.
-        run: >-
-          node --import ./tests/_setup.mjs --experimental-test-module-mocks --test
-          ./tests/platform.test.js
-          ./tests/platform-windows.test.js
-          ./tests/win-spawn.test.js
-          ./tests/windows-cmd-routing.test.js
-          ./tests/resolve-binary.test.js
-          ./tests/control-room-wsl.test.js
-          ./tests/keychain-windows.test.js
-          ./tests/service.test.js
+      - name: Run the derived Windows server test set
+        # #7270 — this step used to name EIGHT test files by hand while
+        # packages/server/tests/ grew to 553. Anything added after that list was
+        # written was never run on Windows and nobody was told; the job went
+        # green in 58s and its green said nothing about the file. That is
+        # docs/false-safety-guards.md's "Checked a subset" mode, in CI config.
+        #
+        # The list is INVERTED now: the runner walks every *.test.js, subtracts
+        # WINDOWS_EXEMPT, and runs the rest — so a new test file is covered here
+        # BY DEFAULT and a POSIX-only one has to be classified out, loudly.
+        # Measured on a real Windows host: 482 of 554 files run, 10,964 tests
+        # against the 193 this step used to run.
+        #
+        # ONE native command on purpose. The file list never crosses a command
+        # line: the runner builds each batch's argv in-process and spawns with
+        # shell:false, so neither CreateProcessW's 32,767-char cap nor cmd.exe's
+        # 8,191 (which any .cmd shim — npm/npx/c8 — would impose) can apply.
+        # $LASTEXITCODE is read on the very next statement and every branch
+        # exits explicitly, so the "only the last exit code is checked" trap
+        # cannot arise.
+        #
+        # Exit 2 means the runner could not do its job (a stale manifest, a
+        # broken walk, an empty set) and is reported separately from exit 1:
+        # "the guard broke" must not read as "the guard passed", nor as "the
+        # code is dirty".
+        run: |
+          node ./scripts/run-windows-tests.mjs
+          $rc = $LASTEXITCODE
+          if ($rc -eq 0) {
+            Write-Host "OK - the derived Windows test set ran clean"
+            exit 0
+          } elseif ($rc -eq 2) {
+            Write-Host "::error::run-windows-tests could not run (stale or invalid WINDOWS_EXEMPT manifest, a broken walk, an empty run set, or a child that failed to spawn). The GUARD is broken, not necessarily the code."
+            exit 1
+          } else {
+            Write-Host "::error::A server test failed on Windows. Fix it, or add a row to WINDOWS_EXEMPT in packages/server/scripts/lib/windows-test-set.mjs with a reason category, the measured symptom, and (for windows-defect / windows-slow) an issue number."
+            exit 1
+          }
 
   server-lint:
     name: Server Lint
@@ -299,6 +329,41 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Check the Windows test-exemption manifest is honest
+        # #7270 — the Windows job used to run eight hardcoded test files out of
+        # 553. The list is inverted now: every *.test.js runs on Windows unless
+        # WINDOWS_EXEMPT classifies it out.
+        #
+        # This is the half that runs HERE, on Linux, in a REQUIRED check.
+        # `Server Windows Tests` is NOT a required context, so a red Windows job
+        # does not block a merge; if the only check on this manifest lived
+        # inside that job the whole thing would be advisory —
+        # docs/false-safety-guards.md's "Never reached" mode.
+        #
+        # It checks the MANIFEST, not the tests: stale rows, unknown reason
+        # categories, tracked-debt rows with no issue, missing measured
+        # symptoms, duplicates, an exempt ratio above the ceiling, and any
+        # MUST_RUN_ON_WINDOWS suite relocated into the exempt list. Linux is
+        # also the stricter host for the stale-row direction, because NTFS is
+        # case-insensitive and would match a row that is stale everywhere else.
+        #
+        # Exit 2 ("the gate could not run") is surfaced separately from exit 1
+        # ("the manifest is wrong").
+        run: |
+          set +e
+          scripts/lint-windows-test-exemptions.sh
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "OK - every server test file either runs on Windows or is exempt with a machine-checked reason"
+          elif [ "$rc" -eq 2 ]; then
+            echo "::error::lint-windows-test-exemptions could not run (bad flags, an exempt row pointing at a missing file, or a walk below --min-files). The GUARD is broken, not necessarily the code."
+            exit 1
+          else
+            echo "::error::The Windows exemption manifest is stale, over-broad, or exempts a must-run suite. See packages/server/scripts/lib/windows-test-set.mjs."
+            exit 1
+          fi
 
       - name: Check server lockfile freshness
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
         # The list is INVERTED now: the runner walks every *.test.js, subtracts
         # WINDOWS_EXEMPT, and runs the rest — so a new test file is covered here
         # BY DEFAULT and a POSIX-only one has to be classified out, loudly.
-        # Measured on a real Windows host: 482 of 554 files run, 10,964 tests
+        # Measured on the chroxy-win runner: 480 of 555 files run, 10,929 tests,
         # against the 193 this step used to run.
         #
         # ONE native command on purpose. The file list never crosses a command
@@ -301,7 +301,7 @@ jobs:
             Write-Host "::error::run-windows-tests could not run (stale or invalid WINDOWS_EXEMPT manifest, a broken walk, an empty run set, or a child that failed to spawn). The GUARD is broken, not necessarily the code."
             exit 1
           } else {
-            Write-Host "::error::A server test failed on Windows. Fix it, or add a row to WINDOWS_EXEMPT in packages/server/scripts/lib/windows-test-set.mjs with a reason category, the measured symptom, and (for windows-defect / windows-slow) an issue number."
+            Write-Host "::error::The derived Windows test set did not pass. If a TEST failed: fix it, or add a row to WINDOWS_EXEMPT in packages/server/scripts/lib/windows-test-set.mjs with a reason category, the measured symptom, and (for windows-defect / windows-slow) an issue number. If the run was UNREPORTABLE — no TAP summary, no file manifest, zero tests, cancelled tests, or a file set that does not match the derived set — the cause is printed immediately above and exempting a file is the wrong remedy."
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,11 +231,14 @@ jobs:
     # somewhere that actually blocks a merge.
     needs: runner-target
     runs-on: ${{ fromJSON(needs.runner-target.outputs.winrunner) }}
-    # 15 was sized for EIGHT files (~4s of test time). The derived set is 482.
-    # Measured end-to-end on the chroxy-win box at 4 concurrency; raised with
-    # headroom because a timeout kill is indistinguishable from a hang. Reset
-    # this from the observed runtime once a few real runs have landed.
-    timeout-minutes: 30
+    # 15 was sized for EIGHT files (~4s of test time). The derived set is ~483,
+    # and the first real run of it on chroxy-win took 2m39s end to end (checkout
+    # + npm ci + protocol build + 99s of tests). 20 is that with room for a slow
+    # npm ci and a busy box, without tying up the single Windows runner for half
+    # an hour when something genuinely hangs — a timeout kill is
+    # indistinguishable from a hang, so this wants to be tight enough to be a
+    # useful signal.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: packages/server

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -191,6 +191,44 @@ run, and it passed. Which arguments are paths is therefore stated a second time,
 deliberately, as a specification with a reason per row; it is the only thing in
 the change written twice.
 
+### 10. The list that lived in CI config — `#7270`
+
+`Server Windows Tests` passed an explicit list of **eight** test files to
+`node --test` while `packages/server/tests/` grew to **553**. The list was
+curated on purpose — much of the suite needs node-pty or POSIX signals — but a
+newly added, genuinely cross-platform test was never run on Windows and nobody
+was told. `#7266` added `setup-sandbox-binding-forms.test.js`, which is entirely
+about path handling and errno behaviour and is exactly what Windows coverage is
+for; the job passed in 58 seconds without executing it.
+
+Mode (3), "checked a subset" — but this is the first entry where the list lives
+in **CI configuration** rather than in a script, which is why no test, lint or
+review of the code could have found it. The green came from a job that was
+working perfectly on everything it was pointed at.
+
+The fix inverts it, per this document's own guidance: walk every `*.test.js`,
+subtract a manifest of exemptions each carrying a reason category and a measured
+symptom, run the rest. Coverage went from 8 files / 193 tests to 480 / 10,929.
+There is no "unclassified" state to detect afterwards — an unclassified
+POSIX-only file makes the job red in its own TAP output, naming itself.
+
+**Two things it taught that the earlier entries did not.**
+
+The measurement had to come first. Seeding the exemption list by grep would have
+been wrong in *both* directions: `built-in-tools/bash-exec.test.js` contains no
+`spawn(` at all while the module it tests spawns `bash -c`, and all 46 files
+matching `/docker/i` drive fakes and pass fine. Every row was seeded from
+running that file on a real Windows host.
+
+And the fix's first real run contained the next instance, one level down. The
+runner counted `# fail` and not `# cancelled`, and Windows reported **`# fail 0`
+alongside `# cancelled 33`** — a cancelled test produced no result at all, so
+"33 tests never ran" and "everything passed" were the same observable outcome.
+That is now checked, along with a non-zero child exit the TAP summary cannot
+account for. Note `assert-test-count.mjs` parses only `# tests` and `# fail`
+too; it propagates node's exit code, so it is not necessarily blind, but it
+cannot itself tell a cancelled test from a passing one.
+
 ## The one that got me while writing this
 
 A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no

--- a/docs/records/windows-test-coverage-7270.md
+++ b/docs/records/windows-test-coverage-7270.md
@@ -1,8 +1,17 @@
 # Windows test coverage measurement — #7270
 
 Provenance for the `WINDOWS_EXEMPT` manifest in
-`packages/server/scripts/lib/windows-test-set.mjs`. Every row in that manifest
-was seeded from this measurement, not from grep.
+`packages/server/scripts/lib/windows-test-set.mjs`. No row in that manifest was
+seeded from grep.
+
+**This survey accounts for 72 of the manifest's 75 rows.** The other three —
+`ide-search.test.js`, `ide-symbols.test.js`, `ws-file-ops-cache.test.js`, the
+`windows-slow` rows — are not here because this survey **passed** them. They
+were added later from a different measurement: the CI runner itself, where they
+report `cancelledByParent` while passing in isolation and in a full concurrent
+run on another clone of the same commit on the same physical machine. That is
+recorded on #7276. Two measurements, not one, which is why this document's
+totals are smaller than the manifest's.
 
 ## Method
 

--- a/docs/records/windows-test-coverage-7270.md
+++ b/docs/records/windows-test-coverage-7270.md
@@ -1,0 +1,162 @@
+# Windows test coverage measurement — #7270
+
+Provenance for the `WINDOWS_EXEMPT` manifest in
+`packages/server/scripts/lib/windows-test-set.mjs`. Every row in that manifest
+was seeded from this measurement, not from grep.
+
+## Method
+
+Each `packages/server/tests/**/*.test.js` was run **in isolation**, with the
+flags the CI Windows job uses:
+
+```
+node --import ./tests/_setup.mjs --experimental-test-module-mocks --test <one file>
+```
+
+| | |
+|---|---|
+| date | 2026-08-19 |
+| host | Windows 11 (10.0.26100), i9-9900K — the same physical box as the `chroxy-win` runner |
+| node | 22.23.1 (the runner tool-cache build, matching `setup-node`'s `node-version: 22`) |
+| commit | `97ef8a030` |
+| files measured | 553 |
+| per-file timeout | 180s |
+
+Two lanes walked the file list from opposite ends and met in the middle, so
+54 files were measured twice. **All 54 agreed**, including
+10 failing files that reproduced identical failure counts — so
+these verdicts are deterministic, not flaky.
+
+## Result
+
+| | files | tests |
+|---|---|---|
+| pass — the derived run set | 481 | 10964 |
+| fail / timeout — `WINDOWS_EXEMPT` | 72 | 2286 |
+
+The Windows job ran **8 files / 193 tests** before this change.
+
+Of the 2286 tests inside the exempt files, **1967 pass** and
+only 315 fail. Exempting whole files is the blunt instrument: most of
+these files fail a handful of their tests and the rest of the file is fine.
+Reclaiming that coverage by guarding the individual tests with
+`{ skip: process.platform === 'win32' }` is #7273 / #7274.
+
+## The exempt files, as measured
+
+| file | verdict | failed / total | reason | issue |
+|---|---|---|---|---|
+| `tests/anthropic-compatible.test.js` | fail | 10 / 79 | `posix-mode-assertion` | — |
+| `tests/append-memory.test.js` | fail | 5 / 9 | `posix-perm-denied` | — |
+| `tests/built-in-tools/bash-exec.test.js` | fail | 2 / 10 | `posix-signals` | — |
+| `tests/byok-mcp-client.test.js` | fail | 2 / 33 | `posix-signals` | — |
+| `tests/byok-mcp-config-mutation.test.js` | fail | 3 / 50 | `posix-mode-assertion` | — |
+| `tests/byok-mcp-config-symlink-write.test.js` | fail | 5 / 17 | `posix-mode-assertion` | — |
+| `tests/byok-mcp-trust-spawn-config.test.js` | fail | 3 / 37 | `posix-mode-assertion` | — |
+| `tests/byok-mcp-trust.test.js` | fail | 1 / 43 | `posix-mode-assertion` | — |
+| `tests/byok-session.test.js` | fail | 4 / 148 | `posix-shell-cmdstring` | — |
+| `tests/byok-tool-executor.test.js` | fail | 9 / 85 | `posix-shell-cmdstring` | — |
+| `tests/checkpoint-manager.test.js` | fail | 1 / 24 | `posix-perm-denied` | — |
+| `tests/claude-tui-attachments.test.js` | fail | 2 / 19 | `node-pty` | — |
+| `tests/claude-tui-ensure-cwd-trusted-write.test.js` | fail | 5 / 7 | `posix-mode-assertion` | — |
+| `tests/claude-tui-session.test.js` | timeout | — / — | `node-pty` | — |
+| `tests/componentwise-resolver.test.js` | fail | 2 / 12 | `posix-perm-denied` | — |
+| `tests/config-dir-migration.test.js` | fail | 5 / 36 | `posix-mode-assertion` | — |
+| `tests/config-dir.test.js` | fail | 1 / 15 | `posix-abs-path` | — |
+| `tests/config-scheduler-gate.test.js` | fail | 1 / 9 | `posix-mode-assertion` | — |
+| `tests/control-room-integrations.test.js` | fail | 23 / 72 | `windows-defect` | #7274 |
+| `tests/control-room-reindex.test.js` | fail | 1 / 26 | `symlink-create` | — |
+| `tests/control-room-repo-set.test.js` | fail | 4 / 11 | `windows-defect` | #7274 |
+| `tests/control-room-rerun.test.js` | fail | 2 / 18 | `symlink-create` | — |
+| `tests/control-room-runners.test.js` | fail | 5 / 39 | `windows-defect` | #7274 |
+| `tests/conversation-scope.test.js` | fail | 1 / 8 | `windows-defect` | #7273 |
+| `tests/credential-store.test.js` | fail | 1 / 22 | `posix-mode-assertion` | — |
+| `tests/credentials-file.test.js` | fail | 4 / 5 | `posix-mode-assertion` | — |
+| `tests/deepseek-credentials.test.js` | fail | 5 / 10 | `posix-mode-assertion` | — |
+| `tests/deepseek-session.test.js` | fail | 1 / 21 | `posix-mode-assertion` | — |
+| `tests/discord-webhook-sink.test.js` | fail | 2 / 114 | `posix-mode-assertion` | — |
+| `tests/event-ingest.test.js` | fail | 1 / 52 | `posix-mode-assertion` | — |
+| `tests/file-ref-attachments.test.js` | fail | 1 / 16 | `symlink-create` | — |
+| `tests/git-stage-commit.test.js` | fail | 2 / 9 | `windows-defect` | #7273 |
+| `tests/handler-utils.test.js` | fail | 5 / 142 | `windows-defect` | #7273 |
+| `tests/handlers/checkpoint-handlers.test.js` | fail | 1 / 37 | `windows-defect` | #7273 |
+| `tests/handlers/conversation-handlers.test.js` | fail | 3 / 38 | `windows-defect` | #7273 |
+| `tests/is-entry-point.test.js` | fail | 1 / 14 | `posix-perm-denied` | — |
+| `tests/lint-entry-point-guard.test.js` | fail | 1 / 62 | `posix-perm-denied` | — |
+| `tests/list-files.test.js` | fail | 4 / 18 | `windows-defect` | #7273 |
+| `tests/logger-audit-retention.test.js` | fail | 4 / 19 | `windows-defect` | #7274 |
+| `tests/memory-read.test.js` | fail | 4 / 18 | `windows-defect` | #7273 |
+| `tests/node-version-check.test.js` | fail | 2 / 4 | `posix-shell-spawn` | — |
+| `tests/orchestration-git-ops.test.js` | fail | 3 / 19 | `windows-defect` | #7274 |
+| `tests/pairing-refresh-qr.test.js` | fail | 1 / 3 | `windows-defect` | #7274 |
+| `tests/permission-hook-failclosed.test.js` | fail | 4 / 4 | `posix-shell-spawn` | — |
+| `tests/permission-hook-floor.test.js` | fail | 50 / 98 | `posix-shell-spawn` | — |
+| `tests/permission-hook-multi-question.test.js` | fail | 17 / 17 | `posix-shell-spawn` | — |
+| `tests/permission-hook-posttooluse-cleanup.test.js` | fail | 6 / 6 | `posix-shell-spawn` | — |
+| `tests/permission-hook-sanitization.test.js` | timeout | — / — | `posix-shell-spawn` | — |
+| `tests/permission-hook-sibling-deny.test.js` | fail | 11 / 11 | `posix-shell-spawn` | — |
+| `tests/permission-hook-sidecar-integration.test.js` | fail | 9 / 9 | `posix-shell-spawn` | — |
+| `tests/permission-manager-floor-symlink-evasion.test.js` | fail | 2 / 21 | `symlink-create` | — |
+| `tests/permission-manager.test.js` | fail | 1 / 96 | `windows-defect` | #7274 |
+| `tests/permission-resolver.test.js` | fail | 2 / 17 | `windows-defect` | #7274 |
+| `tests/permission-rule-store.test.js` | fail | 4 / 34 | `windows-defect` | #7274 |
+| `tests/providers.test.js` | fail | 7 / 98 | `windows-defect` | #7274 |
+| `tests/scheduled-task-store.test.js` | fail | 1 / 51 | `posix-abs-path` | — |
+| `tests/security/path-traversal.test.js` | fail | 1 / 14 | `symlink-create` | — |
+| `tests/skills-inventory-survey.test.js` | fail | 1 / 16 | `posix-abs-path` | — |
+| `tests/skills-trust.test.js` | fail | 2 / 59 | `windows-defect` | #7274 |
+| `tests/skills-usage.test.js` | fail | 1 / 24 | `windows-defect` | #7274 |
+| `tests/snapshots-store.test.js` | fail | 1 / 23 | `posix-abs-path` | — |
+| `tests/spawn-env.test.js` | fail | 1 / 48 | `posix-abs-path` | — |
+| `tests/statusline.test.js` | fail | 9 / 25 | `posix-shell-cmdstring` | — |
+| `tests/user-shell-session.test.js` | fail | 1 / 25 | `node-pty` | — |
+| `tests/worktree-gc.test.js` | fail | 2 / 38 | `windows-defect` | #7274 |
+| `tests/write-file.test.js` | fail | 6 / 15 | `windows-defect` | #7273 |
+| `tests/ws-file-ops-common.test.js` | fail | 4 / 8 | `windows-defect` | #7273 |
+| `tests/ws-file-ops-error-paths.test.js` | fail | 5 / 12 | `windows-defect` | #7273 |
+| `tests/ws-file-ops-git-paths.test.js` | fail | 2 / 16 | `windows-defect` | #7273 |
+| `tests/ws-file-ops-raw-path-symlink-evasion.test.js` | fail | 3 / 13 | `symlink-create` | — |
+| `tests/ws-git-result-schemas.test.js` | fail | 1 / 5 | `windows-defect` | #7274 |
+| `tests/ws-server-file-ops.test.js` | fail | 18 / 53 | `windows-defect` | #7273 |
+
+## Slowest files in the run set
+
+A single file that hangs is worse than one that fails: it eats the job budget,
+and a timeout kill is indistinguishable from a hang. The two timeouts above are
+exempt for exactly that reason. The slowest files that DO pass:
+
+| file | ms |
+|---|---|
+| `tests/lint-config-dir.test.js` | 27624 |
+| `tests/tunnel/cloudflare.test.js` | 27513 |
+| `tests/byok-mcp-fleet.test.js` | 21861 |
+| `tests/environments/backends/backend-seam.test.js` | 17696 |
+| `tests/ws-server.test.js` | 13862 |
+| `tests/cli/schedule-cmd.test.js` | 12684 |
+| `tests/push.test.js` | 12311 |
+| `tests/lint-session-opt-forwarding.test.js` | 11508 |
+| `tests/ws-server-auth.test.js` | 10678 |
+| `tests/session-manager-worktree.test.js` | 10634 |
+
+Total sequential time for the run set is 590s; the job runs
+them concurrently, so wall-clock is far lower.
+
+## Re-measuring
+
+The harness is not committed — it is ~80 lines that spawn one child per file and
+record the verdict. If the manifest needs re-seeding, the shape is:
+
+1. clone the repo on a Windows host, `npm ci`, build `@chroxy/protocol`
+2. for each `tests/**/*.test.js`, spawn the command at the top of this file with
+   a wall-clock timeout, and record `{ exit, timedOut, tests, fail }`
+3. re-run the failures once more and keep only verdicts that agree
+
+Step 3 is not optional: it is what distinguishes a POSIX dependency from a flake,
+and it is why every row in the manifest carries a `symptom`.
+
+## Known limitation
+
+This is a snapshot of ONE host. The measuring box's Defender configuration,
+PATH, and service-account home differ from the `chroxy-win` runner's, and fork
+PRs run on `windows-latest`, which is a different image again. Expect the first
+few CI runs to be the second measurement.

--- a/packages/server/scripts/lib/windows-test-file-reporter.mjs
+++ b/packages/server/scripts/lib/windows-test-file-reporter.mjs
@@ -1,0 +1,28 @@
+// A test reporter that records WHICH FILES actually executed (#7270).
+//
+// The Windows runner asserts that every file in the derived set really ran —
+// "did not run" and "passed" must not be the same observable outcome
+// (docs/false-safety-guards.md:307). Node's TAP output cannot support that
+// assertion: it contains NO file paths at all. Its top-level `ok N - name`
+// entries are one per top-level suite, not one per file — measured, two files
+// produced five of them — so counting them would have been wrong in a way that
+// happened to fail closed, which is luck rather than design.
+//
+// So the runner attaches this second reporter alongside `tap` and reads the
+// file set back. Node supports multiple --test-reporter pairs; this one writes
+// a machine-readable list to its own destination and nothing to stdout.
+//
+// Paths are resolved to absolute before deduping. Node emits BOTH forms —
+// measured: the same run yielded `tests/platform.test.js` and the absolute
+// path for the same file, which counted as two. That would have inflated the
+// count and defeated the equality check.
+import { resolve } from 'node:path'
+
+export default async function* windowsTestFileReporter(source) {
+  const files = new Set()
+  for await (const event of source) {
+    const f = event && event.data && event.data.file
+    if (typeof f === 'string' && f) files.add(resolve(f))
+  }
+  for (const f of [...files].sort()) yield `${f}\n`
+}

--- a/packages/server/scripts/lib/windows-test-set.mjs
+++ b/packages/server/scripts/lib/windows-test-set.mjs
@@ -1,0 +1,814 @@
+// windows-test-set.mjs — the ONE enumeration of which server test files run on
+// Windows, and the manifest of the ones that do not (#7270).
+//
+// ── Why this file exists ────────────────────────────────────────────────────
+//
+// `Server Windows Tests` used to name EIGHT test files by hand while
+// `packages/server/tests/` grew to 553. Anything added after that list was
+// written — including `setup-sandbox-binding-forms.test.js` (#7266), which is
+// entirely about path handling and errno behaviour and is precisely what
+// Windows coverage is for — was never run there, and nothing said so. The job
+// went green in 58 seconds and its green told you nothing about the file.
+//
+// That is `docs/false-safety-guards.md`'s "Checked a subset" mode, in CI config
+// rather than in a script: a hardcoded list beside a set that grows.
+//
+// The list is now INVERTED, per that document's own guidance (:283):
+//
+//   > A list of things to CHECK fails silently when it falls behind; a list of
+//   > things EXEMPT from a walk over everything fails loudly, because the walk
+//   > hits the missing entry and complains. Same data structure, opposite
+//   > failure direction.
+//
+// So: walk every `*.test.js`, subtract `WINDOWS_EXEMPT`, run the rest. A new
+// test file runs on Windows BY DEFAULT. There is no "unclassified" state to
+// detect — an unclassified POSIX-only file simply makes the job red, in its own
+// TAP output, naming itself. Silence is not reachable.
+//
+// ── What the gate is actually for ───────────────────────────────────────────
+//
+// Because the structure above cannot fail silently, the gate's job is narrower
+// and sharper: stop `WINDOWS_EXEMPT` from becoming the new silent skip. It is
+// checked by `lint-windows-test-exemptions.mjs`, which runs on LINUX in
+// `Server Lint` — a REQUIRED status check. `Server Windows Tests` is not one,
+// so a manifest defect has to be caught somewhere that actually blocks a merge.
+//
+// ── The seeding rule, which is not optional ─────────────────────────────────
+//
+// Every row here was seeded from a MEASURED run on a real Windows host, never
+// from grep. Grep cannot do this job in either direction:
+//
+//   * `tests/built-in-tools/bash-exec.test.js` contains no `spawn(` at all, yet
+//     `src/built-in-tools/bash-exec.js` spawns `bash -c` — hostile, invisible
+//     to a grep of the test.
+//   * All 46 files matching /docker/i drive fakes; none spawns a real docker.
+//     A grep-seeded list would have exempted 46 files that pass fine.
+//
+// The measurement is recorded in `docs/records/windows-test-coverage-7270.md`.
+
+import { readdirSync, existsSync, statSync } from 'node:fs'
+import { join, relative, sep, resolve } from 'node:path'
+
+// ── The reason taxonomy ─────────────────────────────────────────────────────
+//
+// Reasons are a CLOSED SET of category tokens, not free prose. Free text in an
+// exemption list decays into "windows lol" within a year and cannot be checked
+// by anything. The category says why the CLASS is exempt; each row's `note`
+// says why THAT FILE is in the class.
+//
+// `kind` is the half that matters most:
+//   * 'permanent' — the mechanism has no Windows analogue and never will. There
+//     is nothing to fix, so the row must NOT carry an issue number.
+//   * 'debt'      — the file COULD run on Windows; it doesn't yet. The row MUST
+//     carry an issue number, or it is a permanent exemption wearing a temporary
+//     label, which is the failure mode this whole taxonomy exists to prevent.
+export const EXEMPT_REASONS = {
+  'node-pty': {
+    kind: 'permanent',
+    why: "node-pty's Windows backend is ConPTY, with different exit, signal and resize semantics. These suites assert POSIX PTY behaviour directly.",
+  },
+  'posix-shell-spawn': {
+    kind: 'permanent',
+    why: "spawns /bin/bash or /bin/sh as argv[0]. Neither path exists on Windows; C:\\Windows\\System32\\bash.exe is WSL and has no distro under the runner's service account (see the shell: powershell note in ci.yml).",
+  },
+  'shebang-exec': {
+    kind: 'permanent',
+    why: 'writes a #!/usr/bin/env node shim, chmods it 0o755 and execs it directly. Windows honours no shebang and has no exec bit.',
+  },
+  'posix-signals': {
+    kind: 'permanent',
+    why: 'depends on real POSIX signal delivery — a SIGTERM grace window before SIGKILL, say. Windows has no signals; a child terminates at once, so the timing under test cannot happen.',
+  },
+  'posix-mode-assertion': {
+    kind: 'permanent',
+    why: 'asserts statSync(p).mode & 0o777 against a POSIX value. Windows reports 0o666/0o444 regardless, so the security-boundary assertion is not merely failing — it is meaningless.',
+  },
+  'posix-perm-denied': {
+    kind: 'permanent',
+    why: 'stages an EACCES fixture by chmod 0o000/0o500. Windows ACLs do not map to chmod, the denial never happens, and the negative test proves nothing.',
+  },
+  'posix-uid': {
+    kind: 'permanent',
+    why: 'process.getuid()/getgid() are undefined on Windows, used for root-detection skips and ownership assertions.',
+  },
+  'symlink-create': {
+    kind: 'permanent',
+    why: 'fs.symlinkSync needs SeCreateSymbolicLinkPrivilege or Developer Mode; unprivileged CI gets EPERM. Mostly path-traversal and floor-evasion security tests.',
+  },
+  'launchd-systemd': {
+    kind: 'permanent',
+    why: 'asserts .plist / LaunchAgents / systemd-unit generation and launchctl / systemctl invocation. The Windows analogue is schtasks, a different code path with its own coverage.',
+  },
+  'posix-shell-cmdstring': {
+    kind: 'permanent',
+    why: "passes a POSIX shell command string (';', '>&2', 'exit 42', 'sleep', 'pwd') to a helper that shells out. cmd.exe and PowerShell parse none of it.",
+  },
+  'posix-tooling': {
+    kind: 'permanent',
+    why: "invokes POSIX-only tooling such as `which` (Windows is `where`), often at module scope so the file cannot even load.",
+  },
+  'posix-abs-path': {
+    kind: 'permanent',
+    why: "hardcodes rooted POSIX paths ('/tmp/…', '/etc/…', '/usr/…') as real filesystem targets. On Windows these resolve onto the current drive and the semantics under test do not survive the translation.",
+  },
+  'windows-defect': {
+    kind: 'debt',
+    why: 'a genuine cross-platform defect in the code or the test, not a POSIX dependency. The file SHOULD run on Windows once the linked issue is fixed.',
+  },
+  'windows-slow': {
+    kind: 'debt',
+    why: 'hangs or is pathologically slow on Windows for a reason not yet diagnosed. Excluded so it cannot eat the job budget; the linked issue tracks the diagnosis.',
+  },
+}
+
+// The MEASURED observation that justifies the row, from a real Windows run.
+// 'fail' — ran and reported failing assertions. 'timeout' — did not terminate.
+// 'load-error' — could not even be imported.
+export const EXEMPT_SYMPTOMS = new Set(['fail', 'timeout', 'load-error'])
+
+// Ceiling on how much of the suite may be exempt. Exempting in BULK is how
+// #7270 happened in the first place, and no per-row check can see it: every
+// individual row can be impeccable while the aggregate quietly becomes "most of
+// the suite". Measured at 13.0% (72/553) when this landed; the ceiling is set
+// with headroom for honest growth and nowhere near a doubling.
+export const MAX_EXEMPT_RATIO = 0.20
+
+// ── The manifest ────────────────────────────────────────────────────────────
+//
+// Every row was seeded from a measured run of that file, in isolation, on a
+// real Windows host with the flags the CI job uses. 481 of the 553 files pass
+// unmodified; these 72 do not. Per-file verdicts and durations are recorded in
+// docs/records/windows-test-coverage-7270.md.
+//
+// A category may currently classify zero rows. That is not dead weight: it
+// means every file using that mechanism already guards its POSIX-only tests
+// with `{ skip: process.platform === 'win32' }`, which is the PREFERRED fix and
+// the reason those files run here at all. Exempting a whole file is the blunt
+// instrument — most rows below fail only a handful of their tests (measured:
+// tests/permission-manager.test.js fails 1 of 96, tests/discord-webhook-sink.test.js
+// 2 of 114), so ~1,967 passing tests sit inside these 72 files and are not run
+// on Windows. Reclaiming them by guarding the individual tests is #7273/#7274.
+export const WINDOWS_EXEMPT = [
+  // ── node-pty / ConPTY (3)
+  {
+    file: 'tests/claude-tui-attachments.test.js',
+    reason: 'node-pty',
+    symptom: 'fail',
+    note: 'numbers PTY-delivered attachments sequentially against POSIX temp paths',
+  },
+  {
+    file: 'tests/claude-tui-session.test.js',
+    reason: 'node-pty',
+    symptom: 'timeout',
+    note: 'drives a real PTY for the claude TUI trust dialog; on Windows the ConPTY session never reaches the expected state and the file does not terminate',
+  },
+  {
+    file: 'tests/user-shell-session.test.js',
+    reason: 'node-pty',
+    symptom: 'fail',
+    note: 'asserts the primary API_TOKEN is stripped from the shell PTY env, over a real PTY',
+  },
+  // ── spawns a POSIX shell or a .sh script (8)
+  {
+    file: 'tests/node-version-check.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns the version-check through a POSIX shell and asserts on its stderr',
+  },
+  {
+    file: 'tests/permission-hook-failclosed.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash to prove an unreachable daemon denies by default',
+  },
+  {
+    file: 'tests/permission-hook-floor.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash for the whole protected-path floor matrix',
+  },
+  {
+    file: 'tests/permission-hook-multi-question.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash to prove multi-question forms are denied',
+  },
+  {
+    file: 'tests/permission-hook-posttooluse-cleanup.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash to exercise the PostToolUse lock cleanup',
+  },
+  {
+    file: 'tests/permission-hook-sanitization.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'timeout',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash; on Windows the spawn never resolves and the file does not terminate',
+  },
+  {
+    file: 'tests/permission-hook-sibling-deny.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash to exercise the sibling AskUserQuestion lock',
+  },
+  {
+    file: 'tests/permission-hook-sidecar-integration.test.js',
+    reason: 'posix-shell-spawn',
+    symptom: 'fail',
+    note: 'spawns hooks/permission-hook.sh via /bin/bash to exercise sidecar newline and CRLF handling',
+  },
+  // ── passes a POSIX shell command string (3)
+  {
+    file: 'tests/byok-session.test.js',
+    reason: 'posix-shell-cmdstring',
+    symptom: 'fail',
+    note: 'runs a Bash command through the unstubbed executor and asserts secret redaction in the subprocess env',
+  },
+  {
+    file: 'tests/byok-tool-executor.test.js',
+    reason: 'posix-shell-cmdstring',
+    symptom: 'fail',
+    note: 'runs POSIX shell command strings through the executor and captures stdout and exit codes from them',
+  },
+  {
+    file: 'tests/statusline.test.js',
+    reason: 'posix-shell-cmdstring',
+    symptom: 'fail',
+    note: 'drives the statusline command through a POSIX shell string that cmd.exe does not parse',
+  },
+  // ── POSIX signal semantics (2)
+  {
+    file: 'tests/built-in-tools/bash-exec.test.js',
+    reason: 'posix-signals',
+    symptom: 'fail',
+    note: 'asserts SIGKILL escalation after the child ignores SIGTERM (#4067), and asserts cwd is /tmp (measured: /mnt/a/tmp)',
+  },
+  {
+    file: 'tests/byok-mcp-client.test.js',
+    reason: 'posix-signals',
+    symptom: 'fail',
+    note: 'asserts destroy() waits KILL_GRACE_MS between SIGTERM and SIGKILL; measured 4ms against an expected ~1000ms because the child dies at once',
+  },
+  // ── asserts POSIX mode bits (NTFS reports 0666/0444 regardless) (14)
+  {
+    file: 'tests/anthropic-compatible.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts a credentials file is refused unless mode 0600; NTFS reports 0666 so the security boundary under test does not exist',
+  },
+  {
+    file: 'tests/byok-mcp-config-mutation.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts the MCP config is created 0600 and that an existing mode is preserved; measured 384 expected, 438 actual',
+  },
+  {
+    file: 'tests/byok-mcp-config-symlink-write.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'preserves the symlink TARGET\'s POSIX mode on the target while keeping the link intact',
+  },
+  {
+    file: 'tests/byok-mcp-trust-spawn-config.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'warns only when the config is group/world-readable, which is a POSIX mode concept with no NTFS equivalent',
+  },
+  {
+    file: 'tests/byok-mcp-trust.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts recordTrust creates the trust file with mode 0600; measured 384 expected, 438 actual',
+  },
+  {
+    file: 'tests/claude-tui-ensure-cwd-trusted-write.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts a 0600 config is still 0600 after the trust pre-write, through a dotfiles symlink',
+  },
+  {
+    file: 'tests/config-dir-migration.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts 0600 file modes survive the migration, and shells out to a printed cp command',
+  },
+  {
+    file: 'tests/config-scheduler-gate.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts the scheduler config is written with restricted 0600 permissions',
+  },
+  {
+    file: 'tests/credential-store.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts a persisted Anthropic key lands at mode 0600',
+  },
+  {
+    file: 'tests/credentials-file.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'refuses a credentials file more permissive than 0600 and returns a chmod hint; the whole file is about POSIX modes',
+  },
+  {
+    file: 'tests/deepseek-credentials.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'reads the key only at mode 0600 and refuses 0644 as a security boundary',
+  },
+  {
+    file: 'tests/deepseek-session.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'start() resolves credentials through the file path with 0600 enforcement',
+  },
+  {
+    file: 'tests/discord-webhook-sink.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'refuses a credentials file that is not 0600, and stages an EACCES stat failure by chmod',
+  },
+  {
+    file: 'tests/event-ingest.test.js',
+    reason: 'posix-mode-assertion',
+    symptom: 'fail',
+    note: 'asserts the ingest secret is created 0600 with base64url content',
+  },
+  // ── stages EACCES with chmod, which Windows ACLs do not honour (5)
+  {
+    file: 'tests/append-memory.test.js',
+    reason: 'posix-perm-denied',
+    symptom: 'fail',
+    note: 'stages an unwritable CLAUDE.md by chmod to prove the error path; Windows never denies, so the write succeeds and the assertion inverts',
+  },
+  {
+    file: 'tests/checkpoint-manager.test.js',
+    reason: 'posix-perm-denied',
+    symptom: 'fail',
+    note: 'makes the disk write fail by chmod to prove checkpoint_persist_failed is emitted; the write succeeds on Windows so nothing is emitted',
+  },
+  {
+    file: 'tests/componentwise-resolver.test.js',
+    reason: 'posix-perm-denied',
+    symptom: 'fail',
+    note: 'asserts EACCES on an unreadable directory propagates from both resolvers, and stages a symlinked-parent escape',
+  },
+  {
+    file: 'tests/is-entry-point.test.js',
+    reason: 'posix-perm-denied',
+    symptom: 'fail',
+    note: 'chmods argv[1] unreadable to reach the undecidable-case warning (#7226); Windows still reads it',
+  },
+  {
+    file: 'tests/lint-entry-point-guard.test.js',
+    reason: 'posix-perm-denied',
+    symptom: 'fail',
+    note: 'stages an unreadable file to prove the lint exits 2 rather than 1; Windows reads it and the fail-closed path is never taken',
+  },
+  // ── needs symlink creation privilege (6)
+  {
+    file: 'tests/control-room-reindex.test.js',
+    reason: 'symlink-create',
+    symptom: 'fail',
+    note: 'accepts a symlink that realpaths to a surveyed repo and runs against the canonical path',
+  },
+  {
+    file: 'tests/control-room-rerun.test.js',
+    reason: 'symlink-create',
+    symptom: 'fail',
+    note: 'runs against the canonical realpath for a symlinked repo path',
+  },
+  {
+    file: 'tests/file-ref-attachments.test.js',
+    reason: 'symlink-create',
+    symptom: 'fail',
+    note: 'asserts an error for a symlink escaping the project directory; the link cannot be created so the file is merely not found',
+  },
+  {
+    file: 'tests/permission-manager-floor-symlink-evasion.test.js',
+    reason: 'symlink-create',
+    symptom: 'fail',
+    note: 'the #6921 PoC needs a real symlink to prove the floor blocks the escape; without it the raw write lands on the fixture, not the target',
+  },
+  {
+    file: 'tests/security/path-traversal.test.js',
+    reason: 'symlink-create',
+    symptom: 'fail',
+    note: 'the unicode-normalisation and percent-encoding cases are staged through symlinks that cannot be created unprivileged',
+  },
+  {
+    file: 'tests/ws-file-ops-raw-path-symlink-evasion.test.js',
+    reason: 'symlink-create',
+    symptom: 'fail',
+    note: 'the raw-path PoC needs work -> .claude/worktrees to be a real symlink to resolve out of the project',
+  },
+  // ── hardcodes a rooted POSIX path as the expected value (5)
+  {
+    file: 'tests/config-dir.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'expects configPath() to return \'/tmp/relocated-chroxy\'; Windows correctly yields the same path drive-rooted',
+  },
+  {
+    file: 'tests/scheduled-task-store.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'expects \'/home/x/.chroxy/scheduled-tasks.json\'; Windows correctly yields the drive-rooted spelling',
+  },
+  {
+    file: 'tests/skills-inventory-survey.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'expects \'/home/u/.chroxy/skills.lock\' as a literal string rather than composing it with path.join',
+  },
+  {
+    file: 'tests/snapshots-store.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'expects the CHROXY_CONFIG_DIR override to yield \'/tmp/chroxy-test-config-x/snapshots\' as a literal POSIX string',
+  },
+  {
+    file: 'tests/spawn-env.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'asserts PATH and HOME are preserved by comparing against literal \'/usr/bin\'',
+  },
+  // ── TRACKED DEBT — not a POSIX mechanism; should pass on Windows (26)
+  {
+    file: 'tests/control-room-integrations.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the configured-repo snapshot and report command produce no conformant output on Windows',
+    issue: 7274,
+  },
+  {
+    file: 'tests/control-room-repo-set.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'repo discovery misses .git entries and does not de-dupe config entries by realpath',
+    issue: 7274,
+  },
+  {
+    file: 'tests/control-room-runners.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the runner survey groups nothing (expected 4, measured 0) and gh enrichment does not run',
+    issue: 7274,
+  },
+  {
+    file: 'tests/conversation-scope.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'cwd exact-match and subdirectory filtering does not match on Windows paths',
+    issue: 7273,
+  },
+  {
+    file: 'tests/git-stage-commit.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'staging an in-project file is refused: \'Access denied: path outside project directory\'',
+    issue: 7273,
+  },
+  {
+    file: 'tests/handler-utils.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'backslash traversal (..\\) is not caught on Windows, where it IS a real separator — security-relevant',
+    issue: 7273,
+  },
+  {
+    file: 'tests/handlers/checkpoint-handlers.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the \'files\' restore mode does not revert the real working tree on Windows',
+    issue: 7273,
+  },
+  {
+    file: 'tests/handlers/conversation-handlers.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'a spoofed client-supplied cwd hint is honoured instead of the recorded cwd — security-relevant',
+    issue: 7273,
+  },
+  {
+    file: 'tests/list-files.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'recursive depth counting is wrong, most likely counting separators',
+    issue: 7273,
+  },
+  {
+    file: 'tests/logger-audit-retention.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'truncate-in-place while a writer holds the handle is not permitted on Windows',
+    issue: 7274,
+  },
+  {
+    file: 'tests/memory-read.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'CLAUDE.md precedence and @import resolution fail on Windows path composition',
+    issue: 7273,
+  },
+  {
+    file: 'tests/orchestration-git-ops.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'git operations fail on Windows; no per-assertion detail was captured in the measurement',
+    issue: 7274,
+  },
+  {
+    file: 'tests/pairing-refresh-qr.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'PairingManager does not emit pairing_refreshed on a manual refresh',
+    issue: 7274,
+  },
+  {
+    file: 'tests/permission-manager.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'a persistent project rule does not reach the audit sink with the expected projectKey',
+    issue: 7274,
+  },
+  {
+    file: 'tests/permission-resolver.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'allowAlways carries a projectKey that is not the stable normalized key on Windows',
+    issue: 7274,
+  },
+  {
+    file: 'tests/permission-rule-store.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'normalizeProjectKey does not collapse Windows path spellings to a stable key',
+    issue: 7274,
+  },
+  {
+    file: 'tests/providers.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'provider auth status misreports readiness and source when the key is in credentials.json',
+    issue: 7274,
+  },
+  {
+    file: 'tests/skills-trust.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the write-failure path does not throw, so callers cannot surface persistence errors',
+    issue: 7274,
+  },
+  {
+    file: 'tests/skills-usage.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'a corrupt usage file does not degrade to an empty store',
+    issue: 7274,
+  },
+  {
+    file: 'tests/worktree-gc.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'a relative gitdir pointer is not resolved against the worktree dir, and a dirty-dead worktree is dropped',
+    issue: 7274,
+  },
+  {
+    file: 'tests/write-file.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'a plain in-project write is refused with \'Access denied: file writing is restricted to the project directory\'',
+    issue: 7273,
+  },
+  {
+    file: 'tests/ws-file-ops-common.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'realpath resolution of existing and non-existent leaves disagrees with the POSIX result',
+    issue: 7273,
+  },
+  {
+    file: 'tests/ws-file-ops-error-paths.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'ENOTDIR and not-found paths surface as \'Access denied\' instead of their real errors',
+    issue: 7273,
+  },
+  {
+    file: 'tests/ws-file-ops-git-paths.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'gitStage rejects valid relative paths within CWD as outside the workspace',
+    issue: 7273,
+  },
+  {
+    file: 'tests/ws-git-result-schemas.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the fixture never produces a commit, so its own CONTROL assertion fails before any schema is checked',
+    issue: 7274,
+  },
+  {
+    file: 'tests/ws-server-file-ops.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'browse/read reject in-project paths with \'Access denied: directory listing is restricted\'',
+    issue: 7273,
+  },
+]
+
+// The load-bearing suites, stated INDEPENDENTLY of the manifest above.
+//
+// This is the one thing here written twice, deliberately, and it is the same
+// trade `docs/false-safety-guards.md:185-192` describes: a derived assertion
+// cannot test the parameter it derives from. Everything else in this file is
+// computed from WINDOWS_EXEMPT, so MOVING a file into WINDOWS_EXEMPT deletes
+// both its Windows coverage and every derived objection to that deletion, in a
+// single edit, with the suite still green. That mutation was run against an
+// earlier draft and it passed.
+//
+// A roster is itself a hardcoded list beside a growing set, and it will degrade
+// as the suite grows — accepted, because it can only ever ADD failures. It can
+// never make this gate report false success. MAX_EXEMPT_RATIO covers bulk
+// drift; this covers the single-file relocation of a security boundary.
+export const MUST_RUN_ON_WINDOWS = [
+  // The two suites #7270 was filed about: entirely path-handling and errno
+  // behaviour, i.e. exactly what Windows coverage is for.
+  'tests/setup-sandbox-binding-forms.test.js',
+  'tests/setup-sandbox-coverage.test.js',
+  // The platform seam itself.
+  'tests/platform.test.js',
+  'tests/platform-windows.test.js',
+  'tests/win-spawn.test.js',
+  'tests/windows-cmd-routing.test.js',
+  'tests/resolve-binary.test.js',
+  'tests/control-room-wsl.test.js',
+  'tests/keychain-windows.test.js',
+  'tests/service.test.js',
+]
+
+/**
+ * Walk `testsRoot` for `*.test.js`, returning paths relative to the SERVER
+ * package root (`tests/foo.test.js`), separator-normalised to `/`.
+ *
+ * Normalisation is not cosmetic. On Windows `relative()` yields backslashes;
+ * unnormalised, ZERO manifest rows would match and the job would go red on
+ * every POSIX-only file at once — loud, but baffling.
+ */
+export function enumerateTestFiles(testsRoot) {
+  const out = []
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.name.endsWith('.test.js')) out.push(full)
+    }
+  }
+  walk(testsRoot)
+  const pkgRoot = resolve(testsRoot, '..')
+  return out.map((p) => relative(pkgRoot, p).split(sep).join('/')).sort()
+}
+
+/**
+ * The single derivation both the gate and the runner use.
+ *
+ * Returns `{ all, exempt, run, problems }`. `problems` is a list of
+ * `{ severity, message }`; `severity` is 'broken' when the gate could not do
+ * its job (exit 2) and 'manifest' when the manifest is wrong (exit 1). It never
+ * throws for a manifest defect and never exits — the callers decide.
+ */
+export function resolveWindowsTestSet({
+  testsRoot,
+  manifest = WINDOWS_EXEMPT,
+  mustRun = MUST_RUN_ON_WINDOWS,
+  reasons = EXEMPT_REASONS,
+  maxExemptRatio = MAX_EXEMPT_RATIO,
+  minFiles = 0,
+} = {}) {
+  const problems = []
+  const broken = (message) => problems.push({ severity: 'broken', message })
+  const manifestErr = (message) => problems.push({ severity: 'manifest', message })
+
+  if (!existsSync(testsRoot) || !statSync(testsRoot).isDirectory()) {
+    broken(`tests root ${testsRoot} does not exist or is not a directory — refusing to report a set.`)
+    return { all: [], exempt: [], run: [], problems }
+  }
+
+  const all = enumerateTestFiles(testsRoot)
+
+  // "Walked zero files" and "walked 553 clean files" must never be the same
+  // observable outcome (docs/false-safety-guards.md:307).
+  if (all.length === 0) {
+    broken(`walked 0 test files under ${testsRoot} — refusing to report a clean set.`)
+    return { all, exempt: [], run: [], problems }
+  }
+  if (all.length < minFiles) {
+    broken(
+      `walked only ${all.length} test file(s) under ${testsRoot}, expected at least ${minFiles}. ` +
+      'Either the walk broke or the --min-files floor is stale.',
+    )
+  }
+
+  const known = new Set(all)
+  const seen = new Set()
+  const exempt = []
+
+  for (const row of manifest) {
+    const where = row && row.file ? row.file : JSON.stringify(row)
+
+    if (!row || typeof row.file !== 'string' || !row.file) {
+      manifestErr(`${where}: row has no 'file'.`)
+      continue
+    }
+    if (seen.has(row.file)) {
+      manifestErr(`${row.file}: appears twice in WINDOWS_EXEMPT. Whichever row is read first decides and the other silently means nothing.`)
+      continue
+    }
+    seen.add(row.file)
+
+    // A row pointing at a file that no longer exists means the manifest
+    // describes a tree that is gone. That is the gate being broken, not the
+    // manifest merely being wrong — exit 2, not 1.
+    if (!known.has(row.file)) {
+      broken(
+        `${row.file}: exempt row points at a file that does not exist under ${testsRoot}. ` +
+        'The manifest describes a tree that is gone — fix it before trusting this run.',
+      )
+      continue
+    }
+
+    const reason = reasons[row.reason]
+    if (!reason) {
+      manifestErr(
+        `${row.file}: unknown reason ${JSON.stringify(row.reason)}. Reasons are a closed set — ` +
+        `add a category to EXEMPT_REASONS with its rationale, or pick one of: ${Object.keys(reasons).join(', ')}.`,
+      )
+      continue
+    }
+
+    if (!EXEMPT_SYMPTOMS.has(row.symptom)) {
+      manifestErr(
+        `${row.file}: symptom must be one of ${[...EXEMPT_SYMPTOMS].join('|')} — the MEASURED observation ` +
+        'from a real Windows run, not a guess. See docs/records/windows-test-coverage-7270.md.',
+      )
+    }
+
+    if (typeof row.note !== 'string' || row.note.trim().length < 24) {
+      manifestErr(
+        `${row.file}: note is empty or too short. The category says why THIS CLASS is exempt; ` +
+        'the note says why THIS FILE is in it.',
+      )
+    }
+
+    if (reason.kind === 'debt' && !row.issue) {
+      manifestErr(
+        `${row.file}: reason ${JSON.stringify(row.reason)} is TRACKED DEBT and requires an issue number. ` +
+        'A defect with no issue is a permanent exemption wearing a temporary label.',
+      )
+    }
+    if (reason.kind === 'permanent' && row.issue) {
+      manifestErr(
+        `${row.file}: reason ${JSON.stringify(row.reason)} is permanent but carries issue ${row.issue}. ` +
+        'If there is work to do, the reason is windows-defect or windows-slow.',
+      )
+    }
+
+    exempt.push(row)
+  }
+
+  // The independently-stated roster (see MUST_RUN_ON_WINDOWS above).
+  const exemptFiles = new Set(exempt.map((r) => r.file))
+  for (const f of mustRun) {
+    if (!known.has(f)) {
+      broken(`${f}: named in MUST_RUN_ON_WINDOWS but not found under ${testsRoot}. The roster is stale.`)
+      continue
+    }
+    if (exemptFiles.has(f)) {
+      manifestErr(
+        `${f} is in MUST_RUN_ON_WINDOWS and also in WINDOWS_EXEMPT. That is the exact mutation this ` +
+        'roster exists to catch: relocating a load-bearing suite into the exempt list deletes its ' +
+        'Windows coverage AND every derived objection to it in one edit.',
+      )
+    }
+  }
+
+  const run = all.filter((f) => !exemptFiles.has(f))
+
+  if (all.length > 0) {
+    const ratio = exempt.length / all.length
+    if (ratio > maxExemptRatio) {
+      manifestErr(
+        `${exempt.length}/${all.length} = ${(ratio * 100).toFixed(1)}% of the server suite is exempt from ` +
+        `Windows, above the ceiling of ${(maxExemptRatio * 100).toFixed(1)}%. Exempting in bulk is how ` +
+        '#7270 happened; raise the ceiling only with a measured comment saying why.',
+      )
+    }
+  }
+
+  if (run.length === 0) {
+    broken('the derived Windows run set is empty — refusing to report a green run.')
+  }
+
+  return { all, exempt, run, problems }
+}

--- a/packages/server/scripts/lib/windows-test-set.mjs
+++ b/packages/server/scripts/lib/windows-test-set.mjs
@@ -357,7 +357,7 @@ export const WINDOWS_EXEMPT = [
     file: 'tests/is-entry-point.test.js',
     reason: 'posix-perm-denied',
     symptom: 'fail',
-    note: 'chmods argv[1] unreadable to reach the undecidable-case warning (#7226); Windows still reads it',
+    note: 'chmods the invoked script path unreadable to reach the undecidable-case warning (#7226); Windows still reads it',
   },
   {
     file: 'tests/lint-entry-point-guard.test.js',
@@ -432,6 +432,29 @@ export const WINDOWS_EXEMPT = [
     reason: 'posix-abs-path',
     symptom: 'fail',
     note: 'asserts PATH and HOME are preserved by comparing against literal \'/usr/bin\'',
+  },
+  // ── windows-slow: completes in isolation, cancelled under the full concurrent
+  //    run ON THE CI RUNNER specifically (3)
+  {
+    file: 'tests/ide-search.test.js',
+    reason: 'windows-slow',
+    symptom: 'timeout',
+    note: 'searchContent/findReferences walk the tree; cancelledByParent on the runner though they pass in isolation and on another clone of the same commit',
+    issue: 7276,
+  },
+  {
+    file: 'tests/ide-symbols.test.js',
+    reason: 'windows-slow',
+    symptom: 'timeout',
+    note: 'collectWorkspaceSymbols and resolveSymbol walk the tree behind the #6499 TTL cache; cancelledByParent on the runner only',
+    issue: 7276,
+  },
+  {
+    file: 'tests/ws-file-ops-cache.test.js',
+    reason: 'windows-slow',
+    symptom: 'timeout',
+    note: 'the #1931 CWD realpath TTL cache test is time-based and is cancelled before it finishes on the runner',
+    issue: 7276,
   },
   // ── TRACKED DEBT — not a POSIX mechanism; should pass on Windows (26)
   {

--- a/packages/server/scripts/lib/windows-test-set.mjs
+++ b/packages/server/scripts/lib/windows-test-set.mjs
@@ -129,52 +129,44 @@ export const EXEMPT_SYMPTOMS = new Set(['fail', 'timeout', 'load-error'])
 // Ceiling on how much of the suite may be exempt. Exempting in BULK is how
 // #7270 happened in the first place, and no per-row check can see it: every
 // individual row can be impeccable while the aggregate quietly becomes "most of
-// the suite". Measured at 13.0% (72/553) when this landed; the ceiling is set
+// the suite". Measured at 13.5% (75 of 555) when this landed; the ceiling is set
 // with headroom for honest growth and nowhere near a doubling.
 export const MAX_EXEMPT_RATIO = 0.20
 
 // ── The manifest ────────────────────────────────────────────────────────────
 //
-// Every row was seeded from a measured run of that file, in isolation, on a
-// real Windows host with the flags the CI job uses. 481 of the 553 files pass
-// unmodified; these 72 do not. Per-file verdicts and durations are recorded in
-// docs/records/windows-test-coverage-7270.md.
+// Rows are seeded from MEASURED behaviour, never from grep. 72 of them come
+// from the survey in docs/records/windows-test-coverage-7270.md, which ran all
+// 553 files of that commit in isolation on a real Windows host with the flags
+// the CI job uses — 481 passed unmodified. The other 3 (the windows-slow rows)
+// came later and from the CI runner itself: they PASS in isolation and in a
+// full concurrent run on a different clone, and are cancelled only in the
+// runner's own working directory. Both are measurements; they are not the SAME
+// measurement, which is why the record's totals and this file's differ.
 //
-// A category may currently classify zero rows. That is not dead weight: it
-// means every file using that mechanism already guards its POSIX-only tests
-// with `{ skip: process.platform === 'win32' }`, which is the PREFERRED fix and
-// the reason those files run here at all. Exempting a whole file is the blunt
+// A category may currently classify zero rows. That is not dead weight, but the
+// reason varies and it is worth being exact: either the file guards its
+// POSIX-only tests with `{ skip: process.platform === 'win32' }` — the
+// PREFERRED fix, and why service.test.js runs here at all (#6651) — or the
+// mechanism turns out not to be load-bearing on Windows. `shebang-exec` is the
+// second kind: tests/jsonl-subprocess-session.test.js writes a
+// `#!/usr/bin/env node` shim and chmods it 0o755 with no win32 guard anywhere,
+// and passes because the shim is invoked as `node <shim>`, so the shebang never
+// decides anything. Exempting a whole file is the blunt
 // instrument — most rows below fail only a handful of their tests (measured:
 // tests/permission-manager.test.js fails 1 of 96, tests/discord-webhook-sink.test.js
-// 2 of 114), so ~1,967 passing tests sit inside these 72 files and are not run
-// on Windows. Reclaiming them by guarding the individual tests is #7273/#7274.
+// 2 of 114), so ~1,967 passing tests sit inside the exempt files and are not
+// run on Windows. Reclaiming them by guarding the individual tests is
+// #7273 / #7274, and #7276 for the three cancelled on the runner.
 export const WINDOWS_EXEMPT = [
-  // ── node-pty / ConPTY (3)
-  {
-    file: 'tests/claude-tui-attachments.test.js',
-    reason: 'node-pty',
-    symptom: 'fail',
-    note: 'numbers PTY-delivered attachments sequentially against POSIX temp paths',
-  },
+  // ── node-pty / ConPTY (1)
   {
     file: 'tests/claude-tui-session.test.js',
     reason: 'node-pty',
     symptom: 'timeout',
     note: 'drives a real PTY for the claude TUI trust dialog; on Windows the ConPTY session never reaches the expected state and the file does not terminate',
   },
-  {
-    file: 'tests/user-shell-session.test.js',
-    reason: 'node-pty',
-    symptom: 'fail',
-    note: 'asserts the primary API_TOKEN is stripped from the shell PTY env, over a real PTY',
-  },
-  // ── spawns a POSIX shell or a .sh script (8)
-  {
-    file: 'tests/node-version-check.test.js',
-    reason: 'posix-shell-spawn',
-    symptom: 'fail',
-    note: 'spawns the version-check through a POSIX shell and asserts on its stderr',
-  },
+  // ── spawns a POSIX shell or a .sh script (7)
   {
     file: 'tests/permission-hook-failclosed.test.js',
     reason: 'posix-shell-spawn',
@@ -334,13 +326,7 @@ export const WINDOWS_EXEMPT = [
     symptom: 'fail',
     note: 'asserts the ingest secret is created 0600 with base64url content',
   },
-  // ── stages EACCES with chmod, which Windows ACLs do not honour (5)
-  {
-    file: 'tests/append-memory.test.js',
-    reason: 'posix-perm-denied',
-    symptom: 'fail',
-    note: 'stages an unwritable CLAUDE.md by chmod to prove the error path; Windows never denies, so the write succeeds and the assertion inverts',
-  },
+  // ── stages EACCES with chmod, which Windows ACLs do not honour (4)
   {
     file: 'tests/checkpoint-manager.test.js',
     reason: 'posix-perm-denied',
@@ -365,19 +351,7 @@ export const WINDOWS_EXEMPT = [
     symptom: 'fail',
     note: 'stages an unreadable file to prove the lint exits 2 rather than 1; Windows reads it and the fail-closed path is never taken',
   },
-  // ── needs symlink creation privilege (6)
-  {
-    file: 'tests/control-room-reindex.test.js',
-    reason: 'symlink-create',
-    symptom: 'fail',
-    note: 'accepts a symlink that realpaths to a surveyed repo and runs against the canonical path',
-  },
-  {
-    file: 'tests/control-room-rerun.test.js',
-    reason: 'symlink-create',
-    symptom: 'fail',
-    note: 'runs against the canonical realpath for a symlinked repo path',
-  },
+  // ── needs symlink creation privilege (3)
   {
     file: 'tests/file-ref-attachments.test.js',
     reason: 'symlink-create',
@@ -391,23 +365,29 @@ export const WINDOWS_EXEMPT = [
     note: 'the #6921 PoC needs a real symlink to prove the floor blocks the escape; without it the raw write lands on the fixture, not the target',
   },
   {
-    file: 'tests/security/path-traversal.test.js',
-    reason: 'symlink-create',
-    symptom: 'fail',
-    note: 'the unicode-normalisation and percent-encoding cases are staged through symlinks that cannot be created unprivileged',
-  },
-  {
     file: 'tests/ws-file-ops-raw-path-symlink-evasion.test.js',
     reason: 'symlink-create',
     symptom: 'fail',
     note: 'the raw-path PoC needs work -> .claude/worktrees to be a real symlink to resolve out of the project',
   },
-  // ── hardcodes a rooted POSIX path as the expected value (5)
+  // ── hardcodes a rooted POSIX path as the expected value (6)
   {
     file: 'tests/config-dir.test.js',
     reason: 'posix-abs-path',
     symptom: 'fail',
     note: 'expects configPath() to return \'/tmp/relocated-chroxy\'; Windows correctly yields the same path drive-rooted',
+  },
+  {
+    file: 'tests/control-room-reindex.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'stubs realpath rather than creating a symlink; the failure is drive translation of the hardcoded rooted POSIX repo paths',
+  },
+  {
+    file: 'tests/control-room-rerun.test.js',
+    reason: 'posix-abs-path',
+    symptom: 'fail',
+    note: 'stubs realpath rather than creating a symlink; the failure is drive translation of the hardcoded rooted POSIX repo paths',
   },
   {
     file: 'tests/scheduled-task-store.test.js',
@@ -427,14 +407,7 @@ export const WINDOWS_EXEMPT = [
     symptom: 'fail',
     note: 'expects the CHROXY_CONFIG_DIR override to yield \'/tmp/chroxy-test-config-x/snapshots\' as a literal POSIX string',
   },
-  {
-    file: 'tests/spawn-env.test.js',
-    reason: 'posix-abs-path',
-    symptom: 'fail',
-    note: 'asserts PATH and HOME are preserved by comparing against literal \'/usr/bin\'',
-  },
-  // ── windows-slow: completes in isolation, cancelled under the full concurrent
-  //    run ON THE CI RUNNER specifically (3)
+  // ── completes in isolation, cancelled under the full concurrent run ON THE CI RUNNER (3)
   {
     file: 'tests/ide-search.test.js',
     reason: 'windows-slow',
@@ -456,7 +429,21 @@ export const WINDOWS_EXEMPT = [
     note: 'the #1931 CWD realpath TTL cache test is time-based and is cancelled before it finishes on the runner',
     issue: 7276,
   },
-  // ── TRACKED DEBT — not a POSIX mechanism; should pass on Windows (26)
+  // ── TRACKED DEBT — not a POSIX mechanism; should pass on Windows (32)
+  {
+    file: 'tests/append-memory.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the file contains no chmod at all; the failures are the "Access denied" project-containment seam on a plain in-project write',
+    issue: 7273,
+  },
+  {
+    file: 'tests/claude-tui-attachments.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'no PTY is involved — the failing assertions are attachment numbering, and the only PTY mentions are comments about newline handling',
+    issue: 7273,
+  },
   {
     file: 'tests/control-room-integrations.test.js',
     reason: 'windows-defect',
@@ -535,6 +522,13 @@ export const WINDOWS_EXEMPT = [
     issue: 7273,
   },
   {
+    file: 'tests/node-version-check.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'spawns process.execPath with --input-type=module, not a POSIX shell; the version message never reaches stderr on Windows',
+    issue: 7274,
+  },
+  {
     file: 'tests/orchestration-git-ops.test.js',
     reason: 'windows-defect',
     symptom: 'fail',
@@ -577,6 +571,13 @@ export const WINDOWS_EXEMPT = [
     issue: 7274,
   },
   {
+    file: 'tests/security/path-traversal.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the single failing case is percent-encoded dots treated as literal filename characters, which is path parsing rather than the symlink staging elsewhere in the file',
+    issue: 7273,
+  },
+  {
     file: 'tests/skills-trust.test.js',
     reason: 'windows-defect',
     symptom: 'fail',
@@ -588,6 +589,20 @@ export const WINDOWS_EXEMPT = [
     reason: 'windows-defect',
     symptom: 'fail',
     note: 'a corrupt usage file does not degrade to an empty store',
+    issue: 7274,
+  },
+  {
+    file: 'tests/spawn-env.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'buildSpawnEnv does not preserve PATH/HOME on Windows, most likely env-key casing (Path vs PATH); the POSIX-looking values are plain strings, not filesystem targets',
+    issue: 7274,
+  },
+  {
+    file: 'tests/user-shell-session.test.js',
+    reason: 'windows-defect',
+    symptom: 'fail',
+    note: 'the PTY here is a fake injected as _term; the failing assertion is API_TOKEN stripping from the spawn env, the same env seam as spawn-env',
     issue: 7274,
   },
   {
@@ -655,6 +670,10 @@ export const WINDOWS_EXEMPT = [
 // as the suite grows — accepted, because it can only ever ADD failures. It can
 // never make this gate report false success. MAX_EXEMPT_RATIO covers bulk
 // drift; this covers the single-file relocation of a security boundary.
+// The roster's collapse floor, stated beside it. Deliberately below today's 10
+// so a genuine removal is possible, high enough that gutting the roster is not.
+export const MIN_MUST_RUN_ON_WINDOWS = 6
+
 export const MUST_RUN_ON_WINDOWS = [
   // The two suites #7270 was filed about: entirely path-handling and errno
   // behaviour, i.e. exactly what Windows coverage is for.
@@ -708,6 +727,7 @@ export function resolveWindowsTestSet({
   reasons = EXEMPT_REASONS,
   maxExemptRatio = MAX_EXEMPT_RATIO,
   minFiles = 0,
+  minMustRun = MIN_MUST_RUN_ON_WINDOWS,
 } = {}) {
   const problems = []
   const broken = (message) => problems.push({ severity: 'broken', message })
@@ -761,7 +781,13 @@ export function resolveWindowsTestSet({
       continue
     }
 
-    const reason = reasons[row.reason]
+    // Object.hasOwn, not a bare index: `reasons['toString']` resolves up the
+    // prototype chain and returns a function, so 'toString', 'constructor' and
+    // '__proto__' would all pass as valid reason categories — and then read
+    // `.kind` off Function.prototype, which is undefined, skipping BOTH
+    // issue-number checks below. A "closed set" that accepts Object.prototype's
+    // keys is not closed.
+    const reason = Object.hasOwn(reasons, row.reason) ? reasons[row.reason] : null
     if (!reason) {
       manifestErr(
         `${row.file}: unknown reason ${JSON.stringify(row.reason)}. Reasons are a closed set — ` +
@@ -784,12 +810,37 @@ export function resolveWindowsTestSet({
       )
     }
 
+    // `kind` decides whether an issue number is required, and it is compared
+    // against two string literals below. A category whose kind is missing,
+    // misspelled or differently-cased ('Debt') matches NEITHER branch, so both
+    // checks fall through and every row in that category is accepted with no
+    // issue and no complaint. Validate membership before relying on it.
+    if (reason.kind !== 'permanent' && reason.kind !== 'debt') {
+      manifestErr(
+        `${row.file}: reason ${JSON.stringify(row.reason)} has kind ${JSON.stringify(reason.kind)}, ` +
+        "which is neither 'permanent' nor 'debt'. That is not a harmless typo: the issue-number rules " +
+        'are keyed on this value, so an unrecognised kind silently exempts the row from both of them.',
+      )
+      exempt.push(row)
+      continue
+    }
+
     if (reason.kind === 'debt' && !row.issue) {
       manifestErr(
         `${row.file}: reason ${JSON.stringify(row.reason)} is TRACKED DEBT and requires an issue number. ` +
         'A defect with no issue is a permanent exemption wearing a temporary label.',
       )
     }
+    // Truthiness is not an issue number: `true`, 'TBD', 'later', -1 and {} all
+    // satisfied `!row.issue` being false, so "tracked debt carries an issue"
+    // was really "carries any truthy value".
+    if (row.issue !== undefined && !(Number.isInteger(row.issue) && row.issue > 0)) {
+      manifestErr(
+        `${row.file}: issue must be a positive integer issue NUMBER, got ${JSON.stringify(row.issue)}. ` +
+        'A placeholder is not a tracked issue.',
+      )
+    }
+
     if (reason.kind === 'permanent' && row.issue) {
       manifestErr(
         `${row.file}: reason ${JSON.stringify(row.reason)} is permanent but carries issue ${row.issue}. ` +
@@ -798,6 +849,24 @@ export function resolveWindowsTestSet({
     }
 
     exempt.push(row)
+  }
+
+  // The roster's own floor. Its comment argues it is safe because it "can only
+  // ever ADD failures" — true per ENTRY, false of its CARDINALITY: an empty
+  // array iterates zero times, raises nothing, and exits 0, which silently
+  // deletes the only check that catches a load-bearing suite being relocated
+  // into WINDOWS_EXEMPT. This function already refuses a zero-length walk and a
+  // zero-length run set for exactly this reason; the roster is the third
+  // derived set here and was the only one whose emptiness was silent. There is
+  // benign pressure toward shrinking it, too: renaming a roster file exits 2
+  // with "the roster is stale", and DELETING the entry clears that just as well
+  // as updating it.
+  if (mustRun.length < minMustRun) {
+    broken(
+      `MUST_RUN_ON_WINDOWS has ${mustRun.length} entr(ies), below the floor of ${minMustRun}. ` +
+      'Emptying or gutting the roster removes the only objection to relocating a load-bearing suite into ' +
+      'WINDOWS_EXEMPT — refusing to report a clean manifest.',
+    )
   }
 
   // The independently-stated roster (see MUST_RUN_ON_WINDOWS above).

--- a/packages/server/scripts/lint-windows-test-exemptions.mjs
+++ b/packages/server/scripts/lint-windows-test-exemptions.mjs
@@ -36,7 +36,7 @@
  */
 
 import { resolve, dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 
@@ -77,7 +77,9 @@ testsRoot = testsRoot ? resolve(testsRoot) : resolve(HERE, '..', 'tests')
 // would read as "the code is dirty".
 let lib
 try {
-  lib = await import(join(HERE, 'lib', 'windows-test-set.mjs'))
+  // pathToFileURL, not a bare path: on Windows an absolute path is 'A:\\...',
+  // and the ESM loader rejects it as an unknown 'a:' protocol.
+  lib = await import(pathToFileURL(join(HERE, 'lib', 'windows-test-set.mjs')).href)
 } catch (err) {
   usageError(`could not load lib/windows-test-set.mjs: ${err && err.message}`)
 }
@@ -88,7 +90,7 @@ let reasons = lib.EXEMPT_REASONS
 let maxRatio = lib.MAX_EXEMPT_RATIO
 if (manifestPath) {
   try {
-    const mod = await import(resolve(manifestPath))
+    const mod = await import(pathToFileURL(resolve(manifestPath)).href)
     if (!Array.isArray(mod.WINDOWS_EXEMPT)) {
       usageError(`${manifestPath} does not export a WINDOWS_EXEMPT array`)
     }

--- a/packages/server/scripts/lint-windows-test-exemptions.mjs
+++ b/packages/server/scripts/lint-windows-test-exemptions.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Gate for the Windows test-exemption manifest (#7270).
+ *
+ * `Server Windows Tests` used to run a hardcoded list of eight files out of
+ * 553. It is now inverted: `run = all - WINDOWS_EXEMPT`, so a new test file is
+ * run on Windows by default and a POSIX-only one has to be classified out.
+ *
+ * That inversion cannot fail SILENTLY — an unclassified hostile file makes the
+ * Windows job red, naming itself. So this gate does not check for "unclassified
+ * files"; there is no such state. It checks the one thing that CAN rot: the
+ * exempt manifest itself. Stale rows, unknown reason categories, tracked-debt
+ * rows with no issue, missing measured symptoms, duplicates, an exempt ratio
+ * above the ceiling, and any MUST_RUN_ON_WINDOWS suite relocated into the
+ * exempt list.
+ *
+ * ── Why this runs on LINUX, in Server Lint ─────────────────────────────────
+ *
+ * `Server Windows Tests` is NOT a required status check (the 11 required
+ * contexts are Server Tests, App Type Check, Server Lint, Dashboard Tests,
+ * Dashboard Type Check, Protocol Tests, Store Core Type Check, App Tests,
+ * Store Core Tests, Desktop Rust Tests, App Expo Doctor). A red Windows job
+ * does not block a merge. If the only check on this manifest lived inside that
+ * job, the whole thing would be advisory — `docs/false-safety-guards.md`'s
+ * "Never reached" mode. `Server Lint` IS required, so the manifest is gated
+ * there and the tests merely RUN on Windows.
+ *
+ * Linux is also the stricter host for the stale-row direction: NTFS is
+ * case-insensitive, so a row spelled `tests/Foo.test.js` could match on Windows
+ * and be stale everywhere else.
+ *
+ * Exit codes, matching lint-entry-point-guard.mjs:
+ *   0 — clean
+ *   1 — the manifest is wrong (stale reason, missing issue, over-broad, must-run violated)
+ *   2 — the gate could not do its job (bad flags, a path that vanished, a broken walk)
+ */
+
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+function usageError(message) {
+  console.error(`[lint-windows-test-exemptions] ${message}`)
+  process.exit(2)
+}
+
+const args = process.argv.slice(2)
+let testsRoot = null
+let manifestPath = null
+let minFiles = 0
+
+for (let i = 0; i < args.length; i++) {
+  const a = args[i]
+  if (a === '--tests-root') testsRoot = args[++i]
+  else if (a === '--manifest') manifestPath = args[++i]
+  else if (a === '--min-files') minFiles = Number(args[++i])
+  else if (a === '--help' || a === '-h') {
+    console.log('usage: lint-windows-test-exemptions.mjs [--tests-root DIR] [--manifest FILE] [--min-files N]')
+    process.exit(0)
+  } else {
+    // A typo'd flag must not be ignored: `--tests-rooot /fixture` would
+    // silently walk the REAL tree and report cleanly on something nobody asked
+    // about. Fail closed.
+    usageError(`unknown argument ${JSON.stringify(a)}`)
+  }
+}
+
+if (minFiles !== 0 && (!Number.isInteger(minFiles) || minFiles < 0)) {
+  usageError(`--min-files must be a non-negative integer, got ${JSON.stringify(args[args.indexOf('--min-files') + 1])}`)
+}
+
+testsRoot = testsRoot ? resolve(testsRoot) : resolve(HERE, '..', 'tests')
+
+// Load the shared derivation. A manifest module that fails to load must exit 2
+// ("the gate is broken"), never leak an uncaught ESM error — which exits 1 and
+// would read as "the code is dirty".
+let lib
+try {
+  lib = await import(join(HERE, 'lib', 'windows-test-set.mjs'))
+} catch (err) {
+  usageError(`could not load lib/windows-test-set.mjs: ${err && err.message}`)
+}
+
+let manifest = lib.WINDOWS_EXEMPT
+let mustRun = lib.MUST_RUN_ON_WINDOWS
+let reasons = lib.EXEMPT_REASONS
+let maxRatio = lib.MAX_EXEMPT_RATIO
+if (manifestPath) {
+  try {
+    const mod = await import(resolve(manifestPath))
+    if (!Array.isArray(mod.WINDOWS_EXEMPT)) {
+      usageError(`${manifestPath} does not export a WINDOWS_EXEMPT array`)
+    }
+    manifest = mod.WINDOWS_EXEMPT
+    if (Array.isArray(mod.MUST_RUN_ON_WINDOWS)) mustRun = mod.MUST_RUN_ON_WINDOWS
+    if (mod.EXEMPT_REASONS) reasons = mod.EXEMPT_REASONS
+    if (typeof mod.MAX_EXEMPT_RATIO === 'number') maxRatio = mod.MAX_EXEMPT_RATIO
+  } catch (err) {
+    usageError(`could not load --manifest ${manifestPath}: ${err && err.message}`)
+  }
+}
+
+const { all, exempt, run, problems } = lib.resolveWindowsTestSet({
+  testsRoot,
+  manifest,
+  mustRun,
+  reasons,
+  maxExemptRatio: maxRatio,
+  minFiles,
+})
+
+const brokenProblems = problems.filter((p) => p.severity === 'broken')
+const manifestProblems = problems.filter((p) => p.severity === 'manifest')
+
+for (const p of [...brokenProblems, ...manifestProblems]) console.error(`  ${p.message}`)
+
+if (brokenProblems.length > 0) {
+  console.error(
+    `\n[lint-windows-test-exemptions] BROKEN: ${brokenProblems.length} problem(s) mean this gate could not ` +
+    'do its job. That is not the same as the manifest being clean.',
+  )
+  process.exit(2)
+}
+
+if (manifestProblems.length > 0) {
+  console.error(
+    `\n[lint-windows-test-exemptions] FAIL: ${manifestProblems.length} problem(s) in the Windows exemption ` +
+    'manifest (packages/server/scripts/lib/windows-test-set.mjs).',
+  )
+  process.exit(1)
+}
+
+const debt = exempt.filter((r) => reasons[r.reason] && reasons[r.reason].kind === 'debt').length
+const pct = ((exempt.length / all.length) * 100).toFixed(1)
+const ceiling = (maxRatio * 100).toFixed(1)
+const reasonCount = new Set(exempt.map((r) => r.reason)).size
+console.log(
+  `[lint-windows-test-exemptions] OK: ${all.length} test file(s) under ${testsRoot}; ` +
+  `${exempt.length} exempt across ${reasonCount} reason(s) (${debt} tracked as debt); ` +
+  `${run.length} run on Windows (${pct}% exempt, ceiling ${ceiling}%).`,
+)

--- a/packages/server/scripts/lint-windows-test-exemptions.mjs
+++ b/packages/server/scripts/lint-windows-test-exemptions.mjs
@@ -50,11 +50,21 @@ let testsRoot = null
 let manifestPath = null
 let minFiles = 0
 
+// A value-taking flag with no value must NOT fall back to the default.
+// `lint-windows-test-exemptions.mjs --tests-root` (flag last) makes args[++i]
+// undefined and would silently lint the REAL tree — the same fail-open the
+// unknown-flag check below exists to prevent. A following flag is not a value.
+const valueFor = (flag, i) => {
+  const v = args[i + 1]
+  if (v === undefined || v.startsWith('--')) usageError(`${flag} requires a value`)
+  return v
+}
+
 for (let i = 0; i < args.length; i++) {
   const a = args[i]
-  if (a === '--tests-root') testsRoot = args[++i]
-  else if (a === '--manifest') manifestPath = args[++i]
-  else if (a === '--min-files') minFiles = Number(args[++i])
+  if (a === '--tests-root') { testsRoot = valueFor(a, i); i++ }
+  else if (a === '--manifest') { manifestPath = valueFor(a, i); i++ }
+  else if (a === '--min-files') { minFiles = Number(valueFor(a, i)); i++ }
   else if (a === '--help' || a === '-h') {
     console.log('usage: lint-windows-test-exemptions.mjs [--tests-root DIR] [--manifest FILE] [--min-files N]')
     process.exit(0)
@@ -66,7 +76,7 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-if (minFiles !== 0 && (!Number.isInteger(minFiles) || minFiles < 0)) {
+if (!Number.isInteger(minFiles) || minFiles < 0) {
   usageError(`--min-files must be a non-negative integer, got ${JSON.stringify(args[args.indexOf('--min-files') + 1])}`)
 }
 
@@ -88,6 +98,7 @@ let manifest = lib.WINDOWS_EXEMPT
 let mustRun = lib.MUST_RUN_ON_WINDOWS
 let reasons = lib.EXEMPT_REASONS
 let maxRatio = lib.MAX_EXEMPT_RATIO
+let minMustRun = lib.MIN_MUST_RUN_ON_WINDOWS
 if (manifestPath) {
   try {
     const mod = await import(pathToFileURL(resolve(manifestPath)).href)
@@ -98,6 +109,7 @@ if (manifestPath) {
     if (Array.isArray(mod.MUST_RUN_ON_WINDOWS)) mustRun = mod.MUST_RUN_ON_WINDOWS
     if (mod.EXEMPT_REASONS) reasons = mod.EXEMPT_REASONS
     if (typeof mod.MAX_EXEMPT_RATIO === 'number') maxRatio = mod.MAX_EXEMPT_RATIO
+    if (typeof mod.MIN_MUST_RUN_ON_WINDOWS === 'number') minMustRun = mod.MIN_MUST_RUN_ON_WINDOWS
   } catch (err) {
     usageError(`could not load --manifest ${manifestPath}: ${err && err.message}`)
   }
@@ -110,6 +122,7 @@ const { all, exempt, run, problems } = lib.resolveWindowsTestSet({
   reasons,
   maxExemptRatio: maxRatio,
   minFiles,
+  minMustRun,
 })
 
 const brokenProblems = problems.filter((p) => p.severity === 'broken')

--- a/packages/server/scripts/lint-windows-test-exemptions.sh
+++ b/packages/server/scripts/lint-windows-test-exemptions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-windows-test-exemptions.mjs`
+# for the actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-windows-test-exemptions.sh` without worrying about the
+# Node interpreter path on the runner image.
+#
+# --min-files is a COLLAPSE floor, not a count: it fails the gate if the walk
+# suddenly finds far fewer test files than the suite has (a broken walk, a
+# renamed directory, a bad --tests-root), because "walked 3 files, all clean"
+# and "walked 553 files, all clean" must not be the same observable outcome.
+# 500 sits below today's 553 with room for honest shrinkage.
+# The test parses this number back out of this file rather than keeping a
+# second copy — a hardcoded copy in the test was proven blind by mutation in
+# lint-entry-point-guard.test.js.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-windows-test-exemptions.mjs --min-files 500 "$@"

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -128,6 +128,14 @@ if (printPlan) {
 
 const REPORTER = join(HERE, 'lib', 'windows-test-file-reporter.mjs')
 
+// NTFS is case-insensitive, so the same file can be spelled with a different
+// drive-letter or directory case by the reporter than by resolve(). Comparing
+// those as strings would report every file as both "missing" and "unexpected"
+// at once — a mass failure with a baffling message. Case-fold on win32 ONLY:
+// POSIX paths are case-SENSITIVE and folding them there would let two genuinely
+// different files collide.
+const pathKey = (p) => (process.platform === 'win32' ? resolve(p).toLowerCase() : resolve(p))
+
 const lastNumber = (text, label) => {
   const re = new RegExp(`^# ${label} (\\d+)`, 'gm')
   let m
@@ -210,7 +218,7 @@ for (let b = 0; b < batches.length; b++) {
   }
   for (const line of reported.split('\n')) {
     const t = line.trim()
-    if (t) filesExecuted.add(t)
+    if (t) filesExecuted.add(pathKey(t))
   }
   try { rmSync(manifestOut, { force: true }) } catch { /* best effort */ }
 
@@ -227,19 +235,19 @@ if (totalTests === 0) {
 // The self-maintaining check: compare the IDENTITY of what ran against what was
 // asked for, not a count and not a magic number. Nothing here drifts as the
 // suite grows.
-const expected = new Set(run.map((f) => resolve(SERVER_ROOT, f)))
-const missing = [...expected].filter((f) => !filesExecuted.has(f))
-const unexpected = [...filesExecuted].filter((f) => !expected.has(f))
+const expected = new Map(run.map((f) => [pathKey(join(SERVER_ROOT, f)), f]))
+const missing = [...expected.keys()].filter((k) => !filesExecuted.has(k))
+const unexpected = [...filesExecuted].filter((k) => !expected.has(k))
 if (missing.length > 0 || unexpected.length > 0) {
   console.error(`\n[run-windows-tests] FAIL: the set of files that RAN does not match the derived set.`)
   if (missing.length > 0) {
     console.error(`  ${missing.length} file(s) were in the derived set but never reported running:`)
-    for (const f of missing.slice(0, 20)) console.error(`    ${relative(SERVER_ROOT, f)}`)
+    for (const k of missing.slice(0, 20)) console.error(`    ${expected.get(k)}`)
     if (missing.length > 20) console.error(`    … and ${missing.length - 20} more`)
   }
   if (unexpected.length > 0) {
     console.error(`  ${unexpected.length} file(s) ran that were NOT in the derived set:`)
-    for (const f of unexpected.slice(0, 20)) console.error(`    ${relative(SERVER_ROOT, f)}`)
+    for (const k of unexpected.slice(0, 20)) console.error(`    ${relative(SERVER_ROOT, k)}`)
   }
   console.error('\n  A run that skipped files must not report success.')
   process.exit(1)

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -138,6 +138,8 @@ const lastNumber = (text, label) => {
 
 let totalTests = 0
 let totalFail = 0
+let totalCancelled = 0
+let worstExit = 0
 const filesExecuted = new Set()
 
 for (let b = 0; b < batches.length; b++) {
@@ -179,6 +181,14 @@ for (let b = 0; b < batches.length; b++) {
 
   const tests = lastNumber(captured.out, 'tests')
   const fail = lastNumber(captured.out, 'fail')
+  // A CANCELLED test is one that never finished — node reports it separately
+  // from `fail`, and a run can carry `# fail 0` alongside `# cancelled 33`.
+  // Counting only `fail` would make "33 tests never ran" indistinguishable
+  // from "everything passed", which is the exact mode this whole change exists
+  // to remove. Measured on the real Windows host: 33 cancelledByParent while
+  // `# fail` was 1.
+  const cancelled = lastNumber(captured.out, 'cancelled')
+  if (typeof captured.code === 'number' && captured.code !== 0) worstExit = captured.code
   if (tests === null || fail === null) {
     console.error(
       `\n[run-windows-tests] FAIL: batch ${b + 1}/${batches.length} produced no TAP summary ` +
@@ -206,6 +216,7 @@ for (let b = 0; b < batches.length; b++) {
 
   totalTests += tests
   totalFail += fail
+  totalCancelled += cancelled ?? 0
 }
 
 if (totalTests === 0) {
@@ -234,6 +245,27 @@ if (missing.length > 0 || unexpected.length > 0) {
   process.exit(1)
 }
 
+if (totalCancelled > 0) {
+  console.error(
+    `\n[run-windows-tests] FAIL: ${totalCancelled} test(s) were CANCELLED and never completed ` +
+    '(node reports these separately from failures — grep the TAP output above for cancelledByParent).\n' +
+    '  A cancelled test produced no result. It is not a pass.',
+  )
+  process.exit(1)
+}
+
+// Last line of defence: the child said something went wrong and none of the
+// checks above accounted for it. "The runner exited non-zero for a reason I
+// cannot name" must not be reported as green.
+if (worstExit !== 0 && totalFail === 0) {
+  console.error(
+    `\n[run-windows-tests] FAIL: the test runner exited ${worstExit} but the TAP summary reported ` +
+    'no failures and no cancellations. Something failed in a way this script does not model — ' +
+    'refusing to call the run green.',
+  )
+  process.exit(1)
+}
+
 if (totalFail > 0) {
   console.error(`\n[run-windows-tests] FAIL: ${totalFail} test(s) failed on Windows (see the TAP output above).`)
   console.error(
@@ -246,5 +278,6 @@ if (totalFail > 0) {
 
 console.log(
   `\n[run-windows-tests] OK: ${run.length} file(s) in the derived Windows set ` +
-  `(${all.length} total, ${exempt.length} exempt), ${batches.length} batch(es), ${totalTests} tests, 0 failed.`,
+  `(${all.length} total, ${exempt.length} exempt), ${batches.length} batch(es), ${totalTests} tests, ` +
+  '0 failed, 0 cancelled.',
 )

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -149,6 +149,11 @@ let totalFail = 0
 let totalCancelled = 0
 let worstExit = 0
 const filesExecuted = new Set()
+// Top-level TAP entries that did not pass. node's TAP carries no file paths, so
+// these suite names are the only handle on WHICH work went wrong — without them
+// a cancellation says "33 tests were cancelled" and leaves you grepping 96,000
+// lines of log to find out where.
+const failedTopLevel = []
 
 for (let b = 0; b < batches.length; b++) {
   const batch = batches[b]
@@ -222,9 +227,22 @@ for (let b = 0; b < batches.length; b++) {
   }
   try { rmSync(manifestOut, { force: true }) } catch { /* best effort */ }
 
+  for (const m of captured.out.matchAll(/^not ok \d+ - (.+)$/gm)) failedTopLevel.push(m[1].trim())
+
   totalTests += tests
   totalFail += fail
   totalCancelled += cancelled ?? 0
+}
+
+// Naming what went wrong is not optional: "cannot tell you which" and "there
+// were none" must not read the same.
+const nameTopLevel = () => {
+  if (failedTopLevel.length === 0) {
+    return '  (could not identify which suites from the TAP output — see the full log above)'
+  }
+  const shown = failedTopLevel.slice(0, 25).map((n) => `    ${n}`).join('\n')
+  const more = failedTopLevel.length > 25 ? `\n    … and ${failedTopLevel.length - 25} more` : ''
+  return `  Top-level suites that did not pass:\n${shown}${more}`
 }
 
 if (totalTests === 0) {
@@ -256,8 +274,9 @@ if (missing.length > 0 || unexpected.length > 0) {
 if (totalCancelled > 0) {
   console.error(
     `\n[run-windows-tests] FAIL: ${totalCancelled} test(s) were CANCELLED and never completed ` +
-    '(node reports these separately from failures — grep the TAP output above for cancelledByParent).\n' +
-    '  A cancelled test produced no result. It is not a pass.',
+    '(node reports these separately from failures — look for cancelledByParent above).\n' +
+    '  A cancelled test produced no result. It is not a pass.\n' +
+    nameTopLevel(),
   )
   process.exit(1)
 }
@@ -275,7 +294,10 @@ if (worstExit !== 0 && totalFail === 0) {
 }
 
 if (totalFail > 0) {
-  console.error(`\n[run-windows-tests] FAIL: ${totalFail} test(s) failed on Windows (see the TAP output above).`)
+  console.error(
+    `\n[run-windows-tests] FAIL: ${totalFail} test(s) failed on Windows (see the TAP output above).\n` +
+    nameTopLevel(),
+  )
   console.error(
     '\nFix it, or — if the file depends on POSIX semantics with no Windows analogue — add a row to\n' +
     'WINDOWS_EXEMPT in packages/server/scripts/lib/windows-test-set.mjs with a reason category, the\n' +

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -15,9 +15,11 @@
  * path one level up. The ubuntu job runs
  * `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test <glob>`;
  * spawning that exact argv means a Windows-vs-Linux difference can never be
- * blamed on the runner. It also reuses the TAP-summary parsing that
- * `assert-test-count.mjs` already ships, instead of hand-rolling a reporter and
- * an exit code — which is precisely where a false-safety bug would live.
+ * blamed on the runner. The TAP-summary parsing below mirrors
+ * `assert-test-count.mjs`'s (that script exports nothing, so it cannot be
+ * imported); the file reporter and the exit policy are new here, and are the
+ * parts most worth reading twice — an exit policy is precisely where a
+ * false-safety bug lives.
  *
  * ── Why the list never crosses a command line as text ──────────────────────
  *
@@ -41,7 +43,7 @@
 import { spawn } from 'node:child_process'
 import { readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { resolve, dirname, join, relative } from 'node:path'
+import { resolve, dirname, join, relative, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -50,6 +52,14 @@ const SERVER_ROOT = resolve(HERE, '..')
 // Conservative against CreateProcessW's 32,767. Leaves room for the node path,
 // the flags, and growth inside a single batch.
 const DEFAULT_MAX_ARGV_BYTES = 24000
+
+// The collapse floor, on the side that actually EXECUTES the tests. The Linux
+// gate carries one via its .sh wrapper, but that wrapper cannot run on the
+// Windows job — so without this the runner would happily report
+// "OK: 3 file(s) ... 0 failed" after a broken walk, and 3 clean files would be
+// indistinguishable from 480. Same value and same reasoning as the wrapper's.
+const DEFAULT_MIN_FILES = 500
+let minFiles = DEFAULT_MIN_FILES
 
 function usageError(message) {
   console.error(`[run-windows-tests] ${message}`)
@@ -62,13 +72,30 @@ let maxArgvBytes = DEFAULT_MAX_ARGV_BYTES
 let concurrency = null
 let testsRoot = null
 
+// A value-taking flag with no value must NOT fall back to the default.
+// `run-windows-tests.mjs --tests-root` (flag last) makes args[++i] undefined,
+// and silently running against the REAL tree is precisely the fail-open this
+// script refuses everywhere else. A following flag is not a value either.
+const valueFor = (flag, i) => {
+  const v = args[i + 1]
+  if (v === undefined || v.startsWith('--')) {
+    usageError(`${flag} requires a value`)
+  }
+  return v
+}
+
 for (let i = 0; i < args.length; i++) {
   const a = args[i]
   if (a === '--print-plan') printPlan = true
-  else if (a === '--max-argv-bytes') maxArgvBytes = Number(args[++i])
-  else if (a === '--test-concurrency') concurrency = args[++i]
-  else if (a === '--tests-root') testsRoot = args[++i]
+  else if (a === '--max-argv-bytes') { maxArgvBytes = Number(valueFor(a, i)); i++ }
+  else if (a === '--test-concurrency') { concurrency = valueFor(a, i); i++ }
+  else if (a === '--tests-root') { testsRoot = valueFor(a, i); i++ }
+  else if (a === '--min-files') { minFiles = Number(valueFor(a, i)); i++ }
   else usageError(`unknown argument ${JSON.stringify(a)}`)
+}
+
+if (!Number.isInteger(minFiles) || minFiles < 0) {
+  usageError(`--min-files must be a non-negative integer, got ${minFiles}`)
 }
 
 if (!Number.isInteger(maxArgvBytes) || maxArgvBytes < 200) {
@@ -86,7 +113,7 @@ try {
   usageError(`could not load lib/windows-test-set.mjs: ${err && err.message}`)
 }
 
-const { all, exempt, run, problems } = lib.resolveWindowsTestSet({ testsRoot })
+const { all, exempt, run, problems } = lib.resolveWindowsTestSet({ testsRoot, minFiles })
 
 // The runner refuses on ANY problem — including a merely-wrong manifest. The
 // Server Lint gate is where a manifest defect gets its own precise verdict;
@@ -116,11 +143,15 @@ for (const f of run) {
 if (current.length > 0) batches.push(current)
 
 if (printPlan) {
+  // batchFiles carries the actual partition, not just its shape: a test that
+  // only compares COUNTS cannot tell a correct partition from one that dropped
+  // a file and duplicated another.
   console.log(JSON.stringify({
     all: all.length,
     exempt: exempt.length,
     run: run.length,
     batches: batches.map((b) => b.length),
+    batchFiles: batches,
     maxArgvBytes,
   }, null, 2))
   process.exit(0)
@@ -177,6 +208,12 @@ for (let b = 0; b < batches.length; b++) {
       stdio: ['inherit', 'pipe', 'inherit'],
       shell: false,
     })
+    // Decode as UTF-8 across chunk boundaries. `out += chunk` calls
+    // Buffer.toString() per chunk, so a multi-byte sequence straddling a 64KB
+    // boundary decodes as U+FFFD on both sides — harmless for the ASCII TAP
+    // numbers, but it corrupts the suite NAMES that are the only diagnostic a
+    // cancellation gives you.
+    child.stdout.setEncoding('utf8')
     child.stdout.on('data', (chunk) => {
       out += chunk
       process.stdout.write(chunk)
@@ -223,7 +260,11 @@ for (let b = 0; b < batches.length; b++) {
   }
   for (const line of reported.split('\n')) {
     const t = line.trim()
-    if (t) filesExecuted.add(pathKey(t))
+    if (t) {
+      const k = pathKey(t)
+      filesExecuted.add(k)
+      if (!executedOriginal.has(k)) executedOriginal.set(k, relative(SERVER_ROOT, t).split(sep).join('/'))
+    }
   }
   try { rmSync(manifestOut, { force: true }) } catch { /* best effort */ }
 
@@ -254,6 +295,11 @@ if (totalTests === 0) {
 // asked for, not a count and not a magic number. Nothing here drifts as the
 // suite grows.
 const expected = new Map(run.map((f) => [pathKey(join(SERVER_ROOT, f)), f]))
+// Keep the ORIGINAL spelling for every key so a diagnostic never prints the
+// case-folded, backslash-separated form — that is a third spelling, matching
+// neither the on-disk name nor the manifest's, and pasting it into
+// WINDOWS_EXEMPT produces an unrelated-looking exit 2.
+const executedOriginal = new Map()
 const missing = [...expected.keys()].filter((k) => !filesExecuted.has(k))
 const unexpected = [...filesExecuted].filter((k) => !expected.has(k))
 if (missing.length > 0 || unexpected.length > 0) {
@@ -265,7 +311,7 @@ if (missing.length > 0 || unexpected.length > 0) {
   }
   if (unexpected.length > 0) {
     console.error(`  ${unexpected.length} file(s) ran that were NOT in the derived set:`)
-    for (const k of unexpected.slice(0, 20)) console.error(`    ${relative(SERVER_ROOT, k)}`)
+    for (const k of unexpected.slice(0, 20)) console.error(`    ${executedOriginal.get(k) ?? k}`)
   }
   console.error('\n  A run that skipped files must not report success.')
   process.exit(1)

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -79,7 +79,9 @@ testsRoot = testsRoot ? resolve(testsRoot) : join(SERVER_ROOT, 'tests')
 
 let lib
 try {
-  lib = await import(join(HERE, 'lib', 'windows-test-set.mjs'))
+  // pathToFileURL, not a bare path: on Windows an absolute path is 'A:\\...',
+  // and the ESM loader rejects it as an unknown 'a:' protocol.
+  lib = await import(pathToFileURL(join(HERE, 'lib', 'windows-test-set.mjs')).href)
 } catch (err) {
   usageError(`could not load lib/windows-test-set.mjs: ${err && err.message}`)
 }

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -41,7 +41,7 @@
  */
 
 import { spawn } from 'node:child_process'
-import { readFileSync, rmSync } from 'node:fs'
+import { readFileSync, rmSync, existsSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve, dirname, join, relative, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -71,6 +71,7 @@ let printPlan = false
 let maxArgvBytes = DEFAULT_MAX_ARGV_BYTES
 let concurrency = null
 let testsRoot = null
+let manifestPath = null
 
 // A value-taking flag with no value must NOT fall back to the default.
 // `run-windows-tests.mjs --tests-root` (flag last) makes args[++i] undefined,
@@ -90,6 +91,7 @@ for (let i = 0; i < args.length; i++) {
   else if (a === '--max-argv-bytes') { maxArgvBytes = Number(valueFor(a, i)); i++ }
   else if (a === '--test-concurrency') { concurrency = valueFor(a, i); i++ }
   else if (a === '--tests-root') { testsRoot = valueFor(a, i); i++ }
+  else if (a === '--manifest') { manifestPath = valueFor(a, i); i++ }
   else if (a === '--min-files') { minFiles = Number(valueFor(a, i)); i++ }
   else usageError(`unknown argument ${JSON.stringify(a)}`)
 }
@@ -103,6 +105,12 @@ if (!Number.isInteger(maxArgvBytes) || maxArgvBytes < 200) {
 }
 
 testsRoot = testsRoot ? resolve(testsRoot) : join(SERVER_ROOT, 'tests')
+// Spawn relative to whatever tree we were pointed at, not to this script's own
+// package. With --tests-root this is the fixture; without it, packages/server.
+// Before this, everything below the derivation ran ONLY inside the Windows job
+// and had no test that could go red — which is how a temporal-dead-zone
+// reference to executedOriginal reached CI.
+const PKG_ROOT = resolve(testsRoot, '..')
 
 let lib
 try {
@@ -113,7 +121,33 @@ try {
   usageError(`could not load lib/windows-test-set.mjs: ${err && err.message}`)
 }
 
-const { all, exempt, run, problems } = lib.resolveWindowsTestSet({ testsRoot, minFiles })
+// --manifest exists so the EXECUTION path can be exercised against a fixture
+// tree on Linux, inside a required check. Without it the runner could only ever
+// be run against the real manifest, i.e. only from the Windows job.
+let manifest = lib.WINDOWS_EXEMPT
+let mustRun = lib.MUST_RUN_ON_WINDOWS
+let minMustRun = lib.MIN_MUST_RUN_ON_WINDOWS
+if (manifestPath) {
+  try {
+    const mod = await import(pathToFileURL(resolve(manifestPath)).href)
+    if (!Array.isArray(mod.WINDOWS_EXEMPT)) usageError(`${manifestPath} does not export a WINDOWS_EXEMPT array`)
+    manifest = mod.WINDOWS_EXEMPT
+    if (Array.isArray(mod.MUST_RUN_ON_WINDOWS)) mustRun = mod.MUST_RUN_ON_WINDOWS
+    if (typeof mod.MIN_MUST_RUN_ON_WINDOWS === 'number') minMustRun = mod.MIN_MUST_RUN_ON_WINDOWS
+  } catch (err) {
+    usageError(`could not load --manifest ${manifestPath}: ${err && err.message}`)
+  }
+}
+
+const { all, exempt, run, problems } = lib.resolveWindowsTestSet({
+  testsRoot, minFiles, manifest, mustRun, minMustRun,
+})
+
+// tests/_setup.mjs arms the fs write sandbox. A fixture tree has none, so only
+// require it where it exists — its absence must not be silently ignored in the
+// real tree, so this checks rather than assumes.
+const SETUP = join(testsRoot, '_setup.mjs')
+const hasSetup = existsSync(SETUP)
 
 // The runner refuses on ANY problem — including a merely-wrong manifest. The
 // Server Lint gate is where a manifest defect gets its own precise verdict;
@@ -165,7 +199,23 @@ const REPORTER = join(HERE, 'lib', 'windows-test-file-reporter.mjs')
 // at once — a mass failure with a baffling message. Case-fold on win32 ONLY:
 // POSIX paths are case-SENSITIVE and folding them there would let two genuinely
 // different files collide.
-const pathKey = (p) => (process.platform === 'win32' ? resolve(p).toLowerCase() : resolve(p))
+// Both sides must also agree about SYMLINKS. node reports a test file by its
+// REAL path, while the derived set is composed from the root we were handed —
+// so on any host where the tests live under a symlinked prefix (macOS's
+// /var -> /private/var is the everyday case) every file reads as both missing
+// AND unexpected at once. That is docs/false-safety-guards.md entry 7, the same
+// realpath asymmetry that defeated the entry-point guard.
+//
+// realpathSync throws for a path that does not exist; fall back to resolve()
+// there, because a non-existent path is exactly what the caller wants reported.
+const realOrResolved = (p) => {
+  try {
+    return realpathSync(resolve(p))
+  } catch {
+    return resolve(p)
+  }
+}
+const pathKey = (p) => (process.platform === 'win32' ? realOrResolved(p).toLowerCase() : realOrResolved(p))
 
 const lastNumber = (text, label) => {
   const re = new RegExp(`^# ${label} (\\d+)`, 'gm')
@@ -180,6 +230,10 @@ let totalFail = 0
 let totalCancelled = 0
 let worstExit = 0
 const filesExecuted = new Set()
+// The ORIGINAL spelling for every executed path, so a diagnostic never prints
+// the case-folded, backslash-separated key — that is a third spelling, matching
+// neither the on-disk name nor the manifest's.
+const executedOriginal = new Map()
 // Top-level TAP entries that did not pass. node's TAP carries no file paths, so
 // these suite names are the only handle on WHICH work went wrong — without them
 // a cancellation says "33 tests were cancelled" and leaves you grepping 96,000
@@ -193,7 +247,7 @@ for (let b = 0; b < batches.length; b++) {
   // its own file, which we read back below.
   const manifestOut = join(tmpdir(), `chroxy-win-testfiles-${process.pid}-${b}.txt`)
   const argv = [
-    '--import', './tests/_setup.mjs',
+    ...(hasSetup ? ['--import', pathToFileURL(SETUP).href] : []),
     '--experimental-test-module-mocks',
     '--test-reporter=tap', '--test-reporter-destination=stdout',
     `--test-reporter=${pathToFileURL(REPORTER).href}`, `--test-reporter-destination=${manifestOut}`,
@@ -204,7 +258,7 @@ for (let b = 0; b < batches.length; b++) {
   const captured = await new Promise((res, rej) => {
     let out = ''
     const child = spawn(process.execPath, argv, {
-      cwd: SERVER_ROOT,
+      cwd: PKG_ROOT,
       stdio: ['inherit', 'pipe', 'inherit'],
       shell: false,
     })
@@ -263,7 +317,7 @@ for (let b = 0; b < batches.length; b++) {
     if (t) {
       const k = pathKey(t)
       filesExecuted.add(k)
-      if (!executedOriginal.has(k)) executedOriginal.set(k, relative(SERVER_ROOT, t).split(sep).join('/'))
+      if (!executedOriginal.has(k)) executedOriginal.set(k, relative(PKG_ROOT, t).split(sep).join('/'))
     }
   }
   try { rmSync(manifestOut, { force: true }) } catch { /* best effort */ }
@@ -294,12 +348,7 @@ if (totalTests === 0) {
 // The self-maintaining check: compare the IDENTITY of what ran against what was
 // asked for, not a count and not a magic number. Nothing here drifts as the
 // suite grows.
-const expected = new Map(run.map((f) => [pathKey(join(SERVER_ROOT, f)), f]))
-// Keep the ORIGINAL spelling for every key so a diagnostic never prints the
-// case-folded, backslash-separated form — that is a third spelling, matching
-// neither the on-disk name nor the manifest's, and pasting it into
-// WINDOWS_EXEMPT produces an unrelated-looking exit 2.
-const executedOriginal = new Map()
+const expected = new Map(run.map((f) => [pathKey(join(PKG_ROOT, f)), f]))
 const missing = [...expected.keys()].filter((k) => !filesExecuted.has(k))
 const unexpected = [...filesExecuted].filter((k) => !expected.has(k))
 if (missing.length > 0 || unexpected.length > 0) {

--- a/packages/server/scripts/run-windows-tests.mjs
+++ b/packages/server/scripts/run-windows-tests.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Runs the DERIVED Windows server test set (#7270).
+ *
+ * The Windows job used to name eight test files by hand while
+ * `packages/server/tests/` grew to 553, so a new cross-platform test was never
+ * run there and nobody was told. This runner walks every `*.test.js`, subtracts
+ * `WINDOWS_EXEMPT`, and runs the rest — a new file is covered by default.
+ *
+ * ── Why it spawns `node --test` rather than using node:test's run() ─────────
+ *
+ * `run({ files, execArgv })` works (verified on 22.x) and would sidestep argv
+ * limits for free. It is still the wrong choice here: it is a SECOND runner
+ * path, and a second execution path is the same defect as a second enumeration
+ * path one level up. The ubuntu job runs
+ * `node --import ./tests/_setup.mjs --experimental-test-module-mocks --test <glob>`;
+ * spawning that exact argv means a Windows-vs-Linux difference can never be
+ * blamed on the runner. It also reuses the TAP-summary parsing that
+ * `assert-test-count.mjs` already ships, instead of hand-rolling a reporter and
+ * an exit code — which is precisely where a false-safety bug would live.
+ *
+ * ── Why the list never crosses a command line as text ──────────────────────
+ *
+ * We spawn `process.execPath` with an argv ARRAY and `shell: false`, so:
+ *   * CreateProcessW's 32,767-char cap applies only to what we batch (measured
+ *     20,515 chars for all 553 paths — 63% — so the ceiling is real but far),
+ *     and BATCHING removes it permanently rather than deferring it;
+ *   * cmd.exe's much lower 8,191 cap can never apply, because we never route
+ *     through a `.cmd` shim. That rules out `npm run` / `npx` / `c8` on this
+ *     job — assert-test-count.mjs sets `shell: true` on win32 precisely because
+ *     `c8` IS a `.cmd`, and the 553-path argv would blow that cap 2.5x over.
+ *
+ * Exit codes:
+ *   0 — every file in the derived set ran and passed
+ *   1 — a test failed, or the run was truncated / unreportable
+ *   2 — the runner could not do its job (stale manifest, broken walk, empty
+ *       set, spawn failure). "The guard broke" must not read as "the guard
+ *       passed", nor as "the code is dirty".
+ */
+
+import { spawn } from 'node:child_process'
+import { readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve, dirname, join, relative } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SERVER_ROOT = resolve(HERE, '..')
+
+// Conservative against CreateProcessW's 32,767. Leaves room for the node path,
+// the flags, and growth inside a single batch.
+const DEFAULT_MAX_ARGV_BYTES = 24000
+
+function usageError(message) {
+  console.error(`[run-windows-tests] ${message}`)
+  process.exit(2)
+}
+
+const args = process.argv.slice(2)
+let printPlan = false
+let maxArgvBytes = DEFAULT_MAX_ARGV_BYTES
+let concurrency = null
+let testsRoot = null
+
+for (let i = 0; i < args.length; i++) {
+  const a = args[i]
+  if (a === '--print-plan') printPlan = true
+  else if (a === '--max-argv-bytes') maxArgvBytes = Number(args[++i])
+  else if (a === '--test-concurrency') concurrency = args[++i]
+  else if (a === '--tests-root') testsRoot = args[++i]
+  else usageError(`unknown argument ${JSON.stringify(a)}`)
+}
+
+if (!Number.isInteger(maxArgvBytes) || maxArgvBytes < 200) {
+  usageError(`--max-argv-bytes must be an integer >= 200, got ${maxArgvBytes}`)
+}
+
+testsRoot = testsRoot ? resolve(testsRoot) : join(SERVER_ROOT, 'tests')
+
+let lib
+try {
+  lib = await import(join(HERE, 'lib', 'windows-test-set.mjs'))
+} catch (err) {
+  usageError(`could not load lib/windows-test-set.mjs: ${err && err.message}`)
+}
+
+const { all, exempt, run, problems } = lib.resolveWindowsTestSet({ testsRoot })
+
+// The runner refuses on ANY problem — including a merely-wrong manifest. The
+// Server Lint gate is where a manifest defect gets its own precise verdict;
+// here it means the set we are about to run is not trustworthy.
+if (problems.length > 0) {
+  for (const p of problems) console.error(`  ${p.message}`)
+  usageError(
+    `${problems.length} problem(s) resolving the Windows test set — refusing to run. ` +
+    'Fix packages/server/scripts/lib/windows-test-set.mjs (see Server Lint for the itemised verdict).',
+  )
+}
+
+// Batch so no single command line can approach the OS cap.
+const batches = []
+let current = []
+let currentBytes = 0
+for (const f of run) {
+  const cost = f.length + 3
+  if (current.length > 0 && currentBytes + cost > maxArgvBytes) {
+    batches.push(current)
+    current = []
+    currentBytes = 0
+  }
+  current.push(f)
+  currentBytes += cost
+}
+if (current.length > 0) batches.push(current)
+
+if (printPlan) {
+  console.log(JSON.stringify({
+    all: all.length,
+    exempt: exempt.length,
+    run: run.length,
+    batches: batches.map((b) => b.length),
+    maxArgvBytes,
+  }, null, 2))
+  process.exit(0)
+}
+
+const REPORTER = join(HERE, 'lib', 'windows-test-file-reporter.mjs')
+
+const lastNumber = (text, label) => {
+  const re = new RegExp(`^# ${label} (\\d+)`, 'gm')
+  let m
+  let val = null
+  while ((m = re.exec(text)) !== null) val = Number(m[1])
+  return val
+}
+
+let totalTests = 0
+let totalFail = 0
+const filesExecuted = new Set()
+
+for (let b = 0; b < batches.length; b++) {
+  const batch = batches[b]
+  // A per-batch destination for the file reporter. It cannot share stdout
+  // (that is TAP) and must not share stderr (that is diagnostics), so it gets
+  // its own file, which we read back below.
+  const manifestOut = join(tmpdir(), `chroxy-win-testfiles-${process.pid}-${b}.txt`)
+  const argv = [
+    '--import', './tests/_setup.mjs',
+    '--experimental-test-module-mocks',
+    '--test-reporter=tap', '--test-reporter-destination=stdout',
+    `--test-reporter=${pathToFileURL(REPORTER).href}`, `--test-reporter-destination=${manifestOut}`,
+  ]
+  if (concurrency) argv.push(`--test-concurrency=${concurrency}`)
+  argv.push('--test', ...batch.map((f) => `./${f}`))
+
+  const captured = await new Promise((res, rej) => {
+    let out = ''
+    const child = spawn(process.execPath, argv, {
+      cwd: SERVER_ROOT,
+      stdio: ['inherit', 'pipe', 'inherit'],
+      shell: false,
+    })
+    child.stdout.on('data', (chunk) => {
+      out += chunk
+      process.stdout.write(chunk)
+    })
+    child.on('error', (err) => rej(err))
+    child.on('close', (code, signal) => res({ out, code, signal }))
+  }).catch((err) => {
+    usageError(`failed to spawn the test runner for batch ${b + 1}/${batches.length}: ${err && err.message}`)
+  })
+
+  if (captured.signal) {
+    console.error(`\n[run-windows-tests] FAIL: batch ${b + 1} was killed by signal ${captured.signal}.`)
+    process.exit(1)
+  }
+
+  const tests = lastNumber(captured.out, 'tests')
+  const fail = lastNumber(captured.out, 'fail')
+  if (tests === null || fail === null) {
+    console.error(
+      `\n[run-windows-tests] FAIL: batch ${b + 1}/${batches.length} produced no TAP summary ` +
+      '(`# tests` / `# fail`). The runner died before reporting — treat as a truncated run, not a pass.',
+    )
+    process.exit(1)
+  }
+
+  // "Cannot tell which files ran" is not "all the files ran".
+  let reported
+  try {
+    reported = readFileSync(manifestOut, 'utf8')
+  } catch (err) {
+    console.error(
+      `\n[run-windows-tests] FAIL: batch ${b + 1} produced no file manifest at ${manifestOut} ` +
+      `(${err && err.message}). Cannot verify which files ran, so this run cannot be called green.`,
+    )
+    process.exit(1)
+  }
+  for (const line of reported.split('\n')) {
+    const t = line.trim()
+    if (t) filesExecuted.add(t)
+  }
+  try { rmSync(manifestOut, { force: true }) } catch { /* best effort */ }
+
+  totalTests += tests
+  totalFail += fail
+}
+
+if (totalTests === 0) {
+  console.error('\n[run-windows-tests] FAIL: 0 tests ran across the whole derived set — refusing to report a pass.')
+  process.exit(1)
+}
+
+// The self-maintaining check: compare the IDENTITY of what ran against what was
+// asked for, not a count and not a magic number. Nothing here drifts as the
+// suite grows.
+const expected = new Set(run.map((f) => resolve(SERVER_ROOT, f)))
+const missing = [...expected].filter((f) => !filesExecuted.has(f))
+const unexpected = [...filesExecuted].filter((f) => !expected.has(f))
+if (missing.length > 0 || unexpected.length > 0) {
+  console.error(`\n[run-windows-tests] FAIL: the set of files that RAN does not match the derived set.`)
+  if (missing.length > 0) {
+    console.error(`  ${missing.length} file(s) were in the derived set but never reported running:`)
+    for (const f of missing.slice(0, 20)) console.error(`    ${relative(SERVER_ROOT, f)}`)
+    if (missing.length > 20) console.error(`    … and ${missing.length - 20} more`)
+  }
+  if (unexpected.length > 0) {
+    console.error(`  ${unexpected.length} file(s) ran that were NOT in the derived set:`)
+    for (const f of unexpected.slice(0, 20)) console.error(`    ${relative(SERVER_ROOT, f)}`)
+  }
+  console.error('\n  A run that skipped files must not report success.')
+  process.exit(1)
+}
+
+if (totalFail > 0) {
+  console.error(`\n[run-windows-tests] FAIL: ${totalFail} test(s) failed on Windows (see the TAP output above).`)
+  console.error(
+    '\nFix it, or — if the file depends on POSIX semantics with no Windows analogue — add a row to\n' +
+    'WINDOWS_EXEMPT in packages/server/scripts/lib/windows-test-set.mjs with a reason category, the\n' +
+    'measured symptom, and (for windows-defect / windows-slow) an issue number.',
+  )
+  process.exit(1)
+}
+
+console.log(
+  `\n[run-windows-tests] OK: ${run.length} file(s) in the derived Windows set ` +
+  `(${all.length} total, ${exempt.length} exempt), ${batches.length} batch(es), ${totalTests} tests, 0 failed.`,
+)

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -568,7 +568,16 @@ describe('BaseSession', () => {
       // toggle warms, second toggle is the steady-state target.
       // Loose threshold (50ms) for CI variance — the goal is to
       // catch order-of-magnitude regressions, not micro-benchmark.
-      it('100-skill toggle stays well under regression threshold', () => {
+      // Skipped on Windows (#7270): this is a WALL-CLOCK assertion, and the
+      // Windows job runs ~480 files concurrently on a single self-hosted box.
+      // Measured there at 154ms against the 50ms threshold — which is CI
+      // variance on a loaded machine, not the order-of-magnitude regression
+      // this test exists to catch (its own comment above says so). The ubuntu
+      // job remains the enforcing one. Same idiom as service.test.js's
+      // skipRealPortOnWin (#6651).
+      it('100-skill toggle stays well under regression threshold', {
+        skip: process.platform === 'win32',
+      }, () => {
         const big = mkdtempSync(join(tmpdir(), 'chroxy-3248-big-'))
         try {
           // Create 100 manual skills (off by default).

--- a/packages/server/tests/lint-windows-test-exemptions.test.js
+++ b/packages/server/tests/lint-windows-test-exemptions.test.js
@@ -47,7 +47,7 @@ after(() => {
  * Build a fixture package: <root>/tests/*.test.js plus a manifest module.
  * `files` are paths relative to the package root (e.g. 'tests/a.test.js').
  */
-function fixture ({ files, manifest, mustRun = [], reasons = null, maxRatio = null }) {
+function fixture({ files, manifest, mustRun = ['tests/f9.test.js'], reasons = null, maxRatio = null, minMustRun = 1 }) {
   const root = mkdtempSync(join(tmpdir(), 'chroxy-win-exempt-'))
   tmpRoots.push(root)
   for (const f of files) {
@@ -66,13 +66,14 @@ function fixture ({ files, manifest, mustRun = [], reasons = null, maxRatio = nu
     `export const WINDOWS_EXEMPT = ${JSON.stringify(manifest, null, 2)}`,
     `export const MUST_RUN_ON_WINDOWS = ${JSON.stringify(mustRun, null, 2)}`,
     maxRatio !== null ? `export const MAX_EXEMPT_RATIO = ${maxRatio}` : '',
+    `export const MIN_MUST_RUN_ON_WINDOWS = ${minMustRun}`,
   ].join('\n')
   const manifestPath = join(root, 'manifest.mjs')
   writeFileSync(manifestPath, body + '\n')
   return { root, testsRoot: join(root, 'tests'), manifestPath }
 }
 
-function runGate ({ testsRoot, manifestPath, extra = [] }) {
+function runGate({ testsRoot, manifestPath, extra = [] }) {
   const r = spawnSync(process.execPath, [
     GATE, '--tests-root', testsRoot, '--manifest', manifestPath, ...extra,
   ], { encoding: 'utf8' })
@@ -257,6 +258,98 @@ describe('lint-windows-test-exemptions: the manifest cannot rot silently (#7270)
     const f = fixture({ files: TEN, manifest: [] })
     const r = spawnSync(process.execPath, [GATE, '--tests-rooot', f.testsRoot], { encoding: 'utf8' })
     assert.equal(r.status, 2)
+  })
+
+  test('a reason from Object.prototype is NOT a valid category', () => {
+    // `reasons['toString']` resolves up the prototype chain and returns a
+    // function, so a bare index read accepts it as a category and then reads
+    // `.kind` off Function.prototype — undefined — skipping BOTH issue-number
+    // checks. A closed set that admits Object.prototype's keys is not closed.
+    for (const reason of ['toString', 'constructor', 'hasOwnProperty', 'valueOf']) {
+      const bad = fixture({
+        files: TEN,
+        manifest: [{ ...goodRow('tests/f0.test.js'), reason }],
+      })
+      assert.equal(runGate(bad).status, 1, `reason ${JSON.stringify(reason)} must be rejected`)
+    }
+    // POSITIVE CONTROL: a real category on the same fixture -> clean.
+    const good = fixture({ files: TEN, manifest: [goodRow('tests/f0.test.js')] })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test("a category whose kind is missing or misspelled exits 1 rather than skipping both issue checks", () => {
+    for (const kind of [undefined, 'permament', 'Debt', 'DEBT', '']) {
+      const bad = fixture({
+        files: TEN,
+        manifest: [{ ...goodRow('tests/f0.test.js'), reason: 'made-up' }],
+        reasons: { 'made-up': { kind, why: 'x' } },
+      })
+      assert.equal(runGate(bad).status, 1, `kind ${JSON.stringify(kind)} must be rejected`)
+    }
+    // POSITIVE CONTROL: the SAME custom category with a valid kind -> clean.
+    const good = fixture({
+      files: TEN,
+      manifest: [{ ...goodRow('tests/f0.test.js'), reason: 'made-up' }],
+      reasons: { 'made-up': { kind: 'permanent', why: 'x' } },
+    })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('a placeholder issue value is not an issue number', () => {
+    const base = {
+      file: 'tests/f0.test.js',
+      reason: 'windows-defect',
+      symptom: 'fail',
+      note: 'a genuine cross-platform defect, not a POSIX dependency',
+    }
+    for (const issue of [true, 'TBD', 'later', -1, 0, 1.5]) {
+      const bad = fixture({ files: TEN, manifest: [{ ...base, issue }] })
+      assert.equal(runGate(bad).status, 1, `issue ${JSON.stringify(issue)} must be rejected`)
+    }
+    // POSITIVE CONTROL: a real number on the same row -> clean.
+    assert.equal(runGate(fixture({ files: TEN, manifest: [{ ...base, issue: 7999 }] })).status, 0, 'control failed')
+  })
+
+  test('gutting MUST_RUN_ON_WINDOWS exits 2 — the roster cannot be silently emptied', () => {
+    // The roster is the only check that catches a load-bearing suite being
+    // MOVED into the exempt list, and every other check derives from the exempt
+    // list. An empty roster iterates zero times and used to raise nothing.
+    const bad = fixture({ files: TEN, manifest: [goodRow('tests/f0.test.js')], mustRun: [], minMustRun: 6 })
+    assert.equal(runGate(bad).status, 2)
+
+    // POSITIVE CONTROL: the same fixture with a roster above the floor -> clean.
+    const good = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js')],
+      mustRun: TEN.slice(1, 8),
+      minMustRun: 6,
+    })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('a value-taking flag with no value exits 2 instead of silently using the default', () => {
+    // `--tests-root` with nothing after it made args[++i] undefined and fell
+    // back to the REAL tree — linting something nobody asked about, cleanly.
+    for (const argv of [['--tests-root'], ['--manifest'], ['--min-files'], ['--tests-root', '--min-files', '1']]) {
+      const r = spawnSync(process.execPath, [GATE, ...argv], { encoding: 'utf8' })
+      assert.equal(r.status, 2, `argv ${JSON.stringify(argv)} must fail closed`)
+    }
+  })
+
+  test('an empty run set exits 2 — every file exempt is not a green run', () => {
+    // Reachable only with a ratio ceiling that admits total exemption, which is
+    // why the ratio check alone cannot stand in for this one.
+    const bad = fixture({ files: TEN, manifest: TEN.map(goodRow), mustRun: [], maxRatio: 1.0 })
+    assert.equal(runGate(bad).status, 2)
+
+    // POSITIVE CONTROL: leave ONE file unexempted under the same ceiling -> clean.
+    const good = fixture({
+      files: TEN,
+      manifest: TEN.slice(0, 9).map(goodRow),
+      mustRun: TEN.slice(9),
+      maxRatio: 1.0,
+    })
+    assert.equal(runGate(good).status, 0, 'control failed')
   })
 
   test('an unloadable manifest exits 2, not 1 — "the gate broke" is not "the code is dirty"', () => {

--- a/packages/server/tests/lint-windows-test-exemptions.test.js
+++ b/packages/server/tests/lint-windows-test-exemptions.test.js
@@ -28,7 +28,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { spawnSync } from 'node:child_process'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -58,7 +58,11 @@ function fixture ({ files, manifest, mustRun = [], reasons = null, maxRatio = nu
   const body = [
     reasons
       ? `export const EXEMPT_REASONS = ${JSON.stringify(reasons, null, 2)}`
-      : `export { EXEMPT_REASONS } from ${JSON.stringify(LIB)}`,
+      // pathToFileURL: a bare absolute path is not a valid ESM specifier on
+      // Windows — 'A:\\...' is read as protocol 'a:' and the loader refuses it.
+      // This fixture is itself in the derived Windows run set, so it has to be
+      // portable; measured failing on the real host before this line existed.
+      : `export { EXEMPT_REASONS } from ${JSON.stringify(pathToFileURL(LIB).href)}`,
     `export const WINDOWS_EXEMPT = ${JSON.stringify(manifest, null, 2)}`,
     `export const MUST_RUN_ON_WINDOWS = ${JSON.stringify(mustRun, null, 2)}`,
     maxRatio !== null ? `export const MAX_EXEMPT_RATIO = ${maxRatio}` : '',

--- a/packages/server/tests/lint-windows-test-exemptions.test.js
+++ b/packages/server/tests/lint-windows-test-exemptions.test.js
@@ -1,0 +1,282 @@
+/**
+ * Tests for scripts/lint-windows-test-exemptions.mjs (#7270).
+ *
+ * The Windows job used to run a hardcoded list of eight test files while
+ * packages/server/tests/ grew to 553. The list is now INVERTED: every
+ * *.test.js runs on Windows unless WINDOWS_EXEMPT classifies it out.
+ *
+ * That inversion cannot fail silently — an unclassified POSIX-only file makes
+ * the Windows job red, naming itself. So this gate does not look for
+ * "unclassified files"; there is no such state. It guards the one thing that
+ * CAN rot: the exempt manifest becoming the new silent skip.
+ *
+ * Strategy, copied from lint-entry-point-guard.test.js: build a temp fixture
+ * tree, run the gate as a CHILD PROCESS against it with --tests-root and
+ * --manifest, and assert the EXIT CODE. Never the output — a grep over stdout
+ * reports grep's status, not the gate's (docs/false-safety-guards.md).
+ *
+ * --tests-root/--manifest point the SAME derivation at a fixture rather than
+ * adding a second code path, so what these tests exercise is what CI runs.
+ *
+ * EVERY case carries a POSITIVE CONTROL — the same fixture WITHOUT the
+ * offending thing, proving the fixture would otherwise have passed and that the
+ * assertion is what caught it. "This fails" passes just as happily against a
+ * gate that rejects everything.
+ */
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATE = resolve(__dirname, '..', 'scripts', 'lint-windows-test-exemptions.mjs')
+const WRAPPER = resolve(__dirname, '..', 'scripts', 'lint-windows-test-exemptions.sh')
+const LIB = resolve(__dirname, '..', 'scripts', 'lib', 'windows-test-set.mjs')
+
+const tmpRoots = []
+after(() => {
+  for (const d of tmpRoots) {
+    try { rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+/**
+ * Build a fixture package: <root>/tests/*.test.js plus a manifest module.
+ * `files` are paths relative to the package root (e.g. 'tests/a.test.js').
+ */
+function fixture ({ files, manifest, mustRun = [], reasons = null, maxRatio = null }) {
+  const root = mkdtempSync(join(tmpdir(), 'chroxy-win-exempt-'))
+  tmpRoots.push(root)
+  for (const f of files) {
+    const abs = join(root, f)
+    mkdirSync(dirname(abs), { recursive: true })
+    writeFileSync(abs, "import { test } from 'node:test'\ntest('x', () => {})\n")
+  }
+  const body = [
+    reasons
+      ? `export const EXEMPT_REASONS = ${JSON.stringify(reasons, null, 2)}`
+      : `export { EXEMPT_REASONS } from ${JSON.stringify(LIB)}`,
+    `export const WINDOWS_EXEMPT = ${JSON.stringify(manifest, null, 2)}`,
+    `export const MUST_RUN_ON_WINDOWS = ${JSON.stringify(mustRun, null, 2)}`,
+    maxRatio !== null ? `export const MAX_EXEMPT_RATIO = ${maxRatio}` : '',
+  ].join('\n')
+  const manifestPath = join(root, 'manifest.mjs')
+  writeFileSync(manifestPath, body + '\n')
+  return { root, testsRoot: join(root, 'tests'), manifestPath }
+}
+
+function runGate ({ testsRoot, manifestPath, extra = [] }) {
+  const r = spawnSync(process.execPath, [
+    GATE, '--tests-root', testsRoot, '--manifest', manifestPath, ...extra,
+  ], { encoding: 'utf8' })
+  return r
+}
+
+// A row that satisfies every per-row rule, so each test can break exactly one
+// thing and attribute the failure to it.
+const goodRow = (file) => ({
+  file,
+  reason: 'node-pty',
+  symptom: 'fail',
+  note: 'spawns a real PTY and asserts POSIX exit semantics',
+})
+
+const TEN = Array.from({ length: 10 }, (_, i) => `tests/f${i}.test.js`)
+
+describe('lint-windows-test-exemptions: the manifest cannot rot silently (#7270)', () => {
+  test('a clean manifest passes — the control for every case below', () => {
+    const f = fixture({ files: TEN, manifest: [goodRow('tests/f0.test.js')] })
+    const r = runGate(f)
+    assert.equal(r.status, 0, `expected clean exit, got ${r.status}\n${r.stderr}`)
+  })
+
+  test('an exempt row pointing at a missing file exits 2 (the gate is broken, not the code)', () => {
+    const manifest = [goodRow('tests/gone.test.js')]
+    const bad = fixture({ files: TEN, manifest })
+    assert.equal(runGate(bad).status, 2)
+
+    // POSITIVE CONTROL: same manifest, file present -> clean.
+    const good = fixture({ files: [...TEN, 'tests/gone.test.js'], manifest })
+    assert.equal(runGate(good).status, 0, 'control failed: the row is rejected for some OTHER reason')
+  })
+
+  test('an unknown reason category exits 1', () => {
+    const bad = fixture({
+      files: TEN,
+      manifest: [{ ...goodRow('tests/f0.test.js'), reason: 'because-windows' }],
+    })
+    assert.equal(runGate(bad).status, 1)
+
+    // POSITIVE CONTROL: identical row with a known category -> clean.
+    const good = fixture({ files: TEN, manifest: [goodRow('tests/f0.test.js')] })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('a tracked-debt row without an issue exits 1', () => {
+    const row = {
+      file: 'tests/f0.test.js',
+      reason: 'windows-defect',
+      symptom: 'fail',
+      note: 'a genuine cross-platform defect, not a POSIX dependency',
+    }
+    const bad = fixture({ files: TEN, manifest: [row] })
+    assert.equal(runGate(bad).status, 1)
+
+    // POSITIVE CONTROL: the SAME debt row with an issue number -> clean.
+    const good = fixture({ files: TEN, manifest: [{ ...row, issue: 7999 }] })
+    assert.equal(runGate(good).status, 0, 'control failed: the row is rejected for some OTHER reason')
+  })
+
+  test('a permanent row WITH an issue exits 1 (a permanent exemption has nothing to fix)', () => {
+    const bad = fixture({
+      files: TEN,
+      manifest: [{ ...goodRow('tests/f0.test.js'), issue: 7999 }],
+    })
+    assert.equal(runGate(bad).status, 1)
+
+    const good = fixture({ files: TEN, manifest: [goodRow('tests/f0.test.js')] })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('a missing or too-short note exits 1', () => {
+    for (const note of [undefined, '', 'windows']) {
+      const bad = fixture({
+        files: TEN,
+        manifest: [{ ...goodRow('tests/f0.test.js'), note }],
+      })
+      assert.equal(runGate(bad).status, 1, `note ${JSON.stringify(note)} should have been rejected`)
+    }
+    const good = fixture({ files: TEN, manifest: [goodRow('tests/f0.test.js')] })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('an unknown or missing symptom exits 1 — the symptom is a MEASURED observation', () => {
+    for (const symptom of [undefined, 'probably-fails']) {
+      const bad = fixture({
+        files: TEN,
+        manifest: [{ ...goodRow('tests/f0.test.js'), symptom }],
+      })
+      assert.equal(runGate(bad).status, 1, `symptom ${JSON.stringify(symptom)} should have been rejected`)
+    }
+    for (const symptom of ['fail', 'timeout', 'load-error']) {
+      const good = fixture({
+        files: TEN,
+        manifest: [{ ...goodRow('tests/f0.test.js'), symptom }],
+      })
+      assert.equal(runGate(good).status, 0, `control failed for symptom ${symptom}`)
+    }
+  })
+
+  test('a duplicate file row exits 1', () => {
+    const bad = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js'), goodRow('tests/f0.test.js')],
+    })
+    assert.equal(runGate(bad).status, 1)
+
+    const good = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js'), goodRow('tests/f1.test.js')],
+    })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('exempting a MUST_RUN_ON_WINDOWS suite exits 1 — the mutation the roster exists to catch', () => {
+    const bad = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js')],
+      mustRun: ['tests/f0.test.js'],
+    })
+    assert.equal(runGate(bad).status, 1)
+
+    // POSITIVE CONTROL: the roster names a DIFFERENT file -> clean. Proves the
+    // failure came from the overlap and not from having a roster at all.
+    const good = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js')],
+      mustRun: ['tests/f1.test.js'],
+    })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('a stale MUST_RUN_ON_WINDOWS entry exits 2', () => {
+    const bad = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js')],
+      mustRun: ['tests/never-existed.test.js'],
+    })
+    assert.equal(runGate(bad).status, 2)
+
+    const good = fixture({
+      files: TEN,
+      manifest: [goodRow('tests/f0.test.js')],
+      mustRun: ['tests/f1.test.js'],
+    })
+    assert.equal(runGate(good).status, 0, 'control failed')
+  })
+
+  test('exempting more than MAX_EXEMPT_RATIO of the suite exits 1', () => {
+    // 5 of 10 exempt against a 20% ceiling.
+    const bad = fixture({
+      files: TEN,
+      manifest: TEN.slice(0, 5).map(goodRow),
+      maxRatio: 0.2,
+    })
+    assert.equal(runGate(bad).status, 1)
+
+    // POSITIVE CONTROL: the SAME five rows under a ceiling that admits them.
+    const good = fixture({
+      files: TEN,
+      manifest: TEN.slice(0, 5).map(goodRow),
+      maxRatio: 0.9,
+    })
+    assert.equal(runGate(good).status, 0, 'control failed: the rows are rejected for some OTHER reason')
+  })
+
+  test('a walk below --min-files exits 2 — "walked 3 clean files" must not read as "walked 553"', () => {
+    const f = fixture({ files: TEN, manifest: [] })
+    assert.equal(runGate({ ...f, extra: ['--min-files', '500'] }).status, 2)
+    // POSITIVE CONTROL: the same tree under a floor it clears.
+    assert.equal(runGate({ ...f, extra: ['--min-files', '10'] }).status, 0, 'control failed')
+  })
+
+  test('an empty tests tree exits 2 rather than reporting a clean set', () => {
+    const f = fixture({ files: [], manifest: [] })
+    mkdirSync(f.testsRoot, { recursive: true })
+    assert.equal(runGate(f).status, 2)
+  })
+
+  test('a typo\'d flag exits 2 instead of silently walking the real tree', () => {
+    const f = fixture({ files: TEN, manifest: [] })
+    const r = spawnSync(process.execPath, [GATE, '--tests-rooot', f.testsRoot], { encoding: 'utf8' })
+    assert.equal(r.status, 2)
+  })
+
+  test('an unloadable manifest exits 2, not 1 — "the gate broke" is not "the code is dirty"', () => {
+    const f = fixture({ files: TEN, manifest: [] })
+    writeFileSync(f.manifestPath, 'this is not valid javascript {{{\n')
+    assert.equal(runGate(f).status, 2)
+  })
+})
+
+describe('lint-windows-test-exemptions: the real manifest and the wrapper', () => {
+  test('the repo\'s own manifest is clean', () => {
+    const r = spawnSync(process.execPath, [GATE], { encoding: 'utf8' })
+    assert.equal(r.status, 0, `the real WINDOWS_EXEMPT manifest is not clean:\n${r.stderr}`)
+  })
+
+  test("the wrapper's --min-files floor is clearable by the real walk", () => {
+    // Parsed out of the wrapper rather than hardcoded here: a second copy of
+    // the number cannot notice when the wrapper's copy goes stale, and a
+    // hardcoded copy was proven blind by mutation in lint-entry-point-guard.
+    const wrapper = readFileSync(WRAPPER, 'utf8')
+    const m = /--min-files\s+(\d+)/.exec(wrapper)
+    assert.ok(m, 'could not find --min-files in the wrapper — this test is checking nothing')
+    const floor = Number(m[1])
+    const r = spawnSync(process.execPath, [GATE, '--min-files', String(floor)], { encoding: 'utf8' })
+    assert.equal(r.status, 0, `the real tree does not clear the wrapper's floor of ${floor}:\n${r.stderr}`)
+  })
+})

--- a/packages/server/tests/run-windows-tests-exec.test.js
+++ b/packages/server/tests/run-windows-tests-exec.test.js
@@ -1,0 +1,131 @@
+/**
+ * END-TO-END tests for scripts/run-windows-tests.mjs (#7270).
+ *
+ * Its sibling `run-windows-tests-plan.test.js` covers the DERIVATION via
+ * `--print-plan`, which exits before a single test is spawned. This file covers
+ * everything after that: the spawn, the TAP parsing, the file-identity check,
+ * the cancellation check and the exit policy.
+ *
+ * That block had no test at all, and it is the block that decides whether a
+ * green Windows job MEANS anything. It broke twice in review for want of one:
+ * a bare absolute path used as an ESM specifier (Windows-only), and a
+ * temporal-dead-zone read of `executedOriginal` that reached CI because every
+ * local run had been `--print-plan`, which returns before the loop.
+ *
+ * The seam is `--tests-root`: the runner roots its spawn at that directory's
+ * parent, so a fixture tree exercises the same code the Windows job runs. These
+ * tests are platform-independent and therefore run in `Server Tests`, which is
+ * a REQUIRED check — the guards move inside the merge gate.
+ */
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RUNNER = resolve(__dirname, '..', 'scripts', 'run-windows-tests.mjs')
+const LIB = resolve(__dirname, '..', 'scripts', 'lib', 'windows-test-set.mjs')
+
+const tmpRoots = []
+after(() => {
+  for (const d of tmpRoots) {
+    try { rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+const PASSING = "import { test } from 'node:test'\ntest('ok', () => {})\n"
+const FAILING = "import { test } from 'node:test'\nimport assert from 'node:assert/strict'\ntest('nope', () => { assert.equal(1, 2) })\n"
+
+/** A fixture package: <root>/tests/*.test.js + a manifest module. */
+function fixture({ files, exempt = [] }) {
+  const root = mkdtempSync(join(tmpdir(), 'chroxy-win-exec-'))
+  tmpRoots.push(root)
+  for (const [name, body] of Object.entries(files)) {
+    const abs = join(root, 'tests', name)
+    mkdirSync(dirname(abs), { recursive: true })
+    writeFileSync(abs, body)
+  }
+  const manifestPath = join(root, 'manifest.mjs')
+  writeFileSync(manifestPath, [
+    `export { EXEMPT_REASONS } from ${JSON.stringify(pathToFileURL(LIB).href)}`,
+    `export const WINDOWS_EXEMPT = ${JSON.stringify(exempt, null, 2)}`,
+    'export const MUST_RUN_ON_WINDOWS = []',
+    'export const MIN_MUST_RUN_ON_WINDOWS = 0',
+  ].join('\n') + '\n')
+  return { root, testsRoot: join(root, 'tests'), manifestPath }
+}
+
+// node marks its test children with NODE_TEST_CONTEXT, and a nested `--test`
+// sees it and prints "run() is being called recursively … skipping running
+// files" — producing no TAP summary at all. The runner is right to treat that
+// as a truncated run; it just must not be how we invoke it from a test. In CI
+// the runner is not a descendant of the test runner, so this is a test-harness
+// concern only.
+const CLEAN_ENV = (() => {
+  const env = { ...process.env }
+  for (const k of Object.keys(env)) if (k.startsWith('NODE_TEST_')) delete env[k]
+  return env
+})()
+
+function runRunner(f, extra = []) {
+  return spawnSync(process.execPath, [
+    RUNNER, '--tests-root', f.testsRoot, '--manifest', f.manifestPath, '--min-files', '1', ...extra,
+  ], { encoding: 'utf8', env: CLEAN_ENV })
+}
+
+describe('run-windows-tests: the execution path (#7270)', () => {
+  test('a passing fixture exits 0 and reports the derived set', () => {
+    const f = fixture({ files: { 'a.test.js': PASSING, 'b.test.js': PASSING } })
+    const r = runRunner(f)
+    assert.equal(r.status, 0, `expected clean exit, got ${r.status}\n${r.stderr}`)
+    assert.match(r.stdout + r.stderr, /2 file\(s\) in the derived Windows set/)
+  })
+
+  test('a failing test makes the runner exit 1 and names the suite', () => {
+    const f = fixture({ files: { 'a.test.js': PASSING, 'b.test.js': FAILING } })
+    const r = runRunner(f)
+    assert.equal(r.status, 1)
+    // "cannot tell you which" must not read the same as "there were none".
+    assert.match(r.stderr, /Top-level suites that did not pass/)
+
+    // POSITIVE CONTROL: the same tree with the failure replaced -> clean.
+    const good = fixture({ files: { 'a.test.js': PASSING, 'b.test.js': PASSING } })
+    assert.equal(runRunner(good).status, 0, 'control failed')
+  })
+
+  test('a file that fails to LOAD is a failure, not a silent skip', () => {
+    const f = fixture({ files: { 'a.test.js': PASSING, 'b.test.js': "import 'node:does-not-exist'\n" } })
+    assert.equal(runRunner(f).status, 1)
+  })
+
+  test('the runner refuses a set below its collapse floor', () => {
+    const f = fixture({ files: { 'a.test.js': PASSING } })
+    // Its own default floor is 500; the fixture has 1.
+    const r = spawnSync(process.execPath, [RUNNER, '--tests-root', f.testsRoot, '--manifest', f.manifestPath], { encoding: 'utf8', env: CLEAN_ENV })
+    assert.equal(r.status, 2)
+    // POSITIVE CONTROL: same tree, floor it clears.
+    assert.equal(runRunner(f).status, 0, 'control failed')
+  })
+
+  test('multi-batch execution runs every file exactly once', () => {
+    const files = {}
+    for (let i = 0; i < 8; i++) files[`f${i}.test.js`] = PASSING
+    const f = fixture({ files })
+    // A tiny argv budget forces several batches through the real spawn path.
+    const r = runRunner(f, ['--max-argv-bytes', '260'])
+    assert.equal(r.status, 0, `expected clean exit, got ${r.status}\n${r.stderr}`)
+    assert.match(r.stdout + r.stderr, /8 file\(s\) in the derived Windows set/)
+    assert.doesNotMatch(r.stderr, /does not match the derived set/)
+  })
+
+  test('a failure inside a LATER batch is not lost', () => {
+    // The accumulators run across batches; a batch that fails after a green one
+    // must still turn the whole run red.
+    const files = { 'a.test.js': PASSING, 'b.test.js': PASSING, 'c.test.js': FAILING }
+    const f = fixture({ files })
+    assert.equal(runRunner(f, ['--max-argv-bytes', '220']).status, 1)
+  })
+})

--- a/packages/server/tests/run-windows-tests-plan.test.js
+++ b/packages/server/tests/run-windows-tests-plan.test.js
@@ -1,0 +1,66 @@
+/**
+ * Tests for scripts/run-windows-tests.mjs's DERIVATION (#7270).
+ *
+ * Runs on every platform via `--print-plan`, which resolves the set and batches
+ * it without executing a single test — so the Linux `Server Tests` job (a
+ * REQUIRED check) covers the runner's logic even though the runner itself only
+ * ever executes on Windows.
+ *
+ * The batching path is the reason this file exists. Today's 482-file run set
+ * fits in ONE batch, so the multi-batch code never runs in CI — untested code
+ * on a path that only activates once the suite grows, which is this issue's own
+ * defect class one level down. `--max-argv-bytes` forces it here.
+ */
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RUNNER = resolve(__dirname, '..', 'scripts', 'run-windows-tests.mjs')
+
+function plan (extra = []) {
+  const r = spawnSync(process.execPath, [RUNNER, '--print-plan', ...extra], { encoding: 'utf8' })
+  return { status: r.status, json: r.status === 0 ? JSON.parse(r.stdout) : null, stderr: r.stderr }
+}
+
+describe('run-windows-tests: the derived plan (#7270)', () => {
+  test('the run set is every test file minus the exempt manifest', () => {
+    const { status, json, stderr } = plan()
+    assert.equal(status, 0, `--print-plan failed:\n${stderr}`)
+    assert.equal(json.run, json.all - json.exempt)
+    assert.ok(json.run > 0, 'an empty run set must never be reported as a plan')
+    assert.ok(json.all > json.exempt, 'the manifest cannot exempt the entire suite')
+  })
+
+  test('batching partitions the run set without losing or duplicating a file', () => {
+    // Small enough to force many batches out of today's one.
+    const { status, json, stderr } = plan(['--max-argv-bytes', '400'])
+    assert.equal(status, 0, `--print-plan failed:\n${stderr}`)
+    assert.ok(json.batches.length > 1, 'the tiny budget did not actually force multiple batches — this test is checking nothing')
+    const summed = json.batches.reduce((a, b) => a + b, 0)
+    assert.equal(summed, json.run, 'batching lost or duplicated files')
+    assert.ok(json.batches.every((n) => n > 0), 'an empty batch would spawn a runner with no files, which globs the cwd')
+  })
+
+  test('the default budget keeps every batch under the Windows command-line cap', () => {
+    const { json } = plan()
+    // CreateProcessW's limit is 32,767; the default budget is well under it and
+    // this asserts the relationship rather than restating the number.
+    assert.ok(json.maxArgvBytes < 32767, 'the argv budget must sit below the Windows cap')
+    assert.ok(json.batches.length >= 1)
+  })
+
+  test('an unusable argv budget exits 2 rather than silently batching badly', () => {
+    assert.equal(plan(['--max-argv-bytes', '10']).status, 2)
+    assert.equal(plan(['--max-argv-bytes', 'banana']).status, 2)
+    // POSITIVE CONTROL: a sane budget still works, so the rejection above came
+    // from the value and not from the flag being unsupported.
+    assert.equal(plan(['--max-argv-bytes', '24000']).status, 0)
+  })
+
+  test('a typo\'d flag exits 2 instead of running an unintended set', () => {
+    assert.equal(plan(['--max-argv-bytez', '24000']).status, 2)
+  })
+})

--- a/packages/server/tests/run-windows-tests-plan.test.js
+++ b/packages/server/tests/run-windows-tests-plan.test.js
@@ -20,7 +20,7 @@ import { spawnSync } from 'node:child_process'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const RUNNER = resolve(__dirname, '..', 'scripts', 'run-windows-tests.mjs')
 
-function plan (extra = []) {
+function plan(extra = []) {
   const r = spawnSync(process.execPath, [RUNNER, '--print-plan', ...extra], { encoding: 'utf8' })
   return { status: r.status, json: r.status === 0 ? JSON.parse(r.stdout) : null, stderr: r.stderr }
 }
@@ -39,9 +39,36 @@ describe('run-windows-tests: the derived plan (#7270)', () => {
     const { status, json, stderr } = plan(['--max-argv-bytes', '400'])
     assert.equal(status, 0, `--print-plan failed:\n${stderr}`)
     assert.ok(json.batches.length > 1, 'the tiny budget did not actually force multiple batches — this test is checking nothing')
-    const summed = json.batches.reduce((a, b) => a + b, 0)
-    assert.equal(summed, json.run, 'batching lost or duplicated files')
     assert.ok(json.batches.every((n) => n > 0), 'an empty batch would spawn a runner with no files, which globs the cwd')
+
+    // Compare the FILES, not the counts. A partition that drops one file and
+    // duplicates another sums correctly and is still wrong.
+    const flat = json.batchFiles.flat()
+    assert.equal(flat.length, json.run, 'batching lost or duplicated files')
+    assert.equal(new Set(flat).size, json.run, 'a file appears in more than one batch')
+
+    // …and the partition must be of the SAME set the single-batch plan derives.
+    const whole = plan().json.batchFiles.flat()
+    assert.deepEqual([...flat].sort(), [...whole].sort(), 'the batched partition is not the derived run set')
+  })
+
+  test('the runner carries its own collapse floor, since the .sh wrapper cannot run on Windows', () => {
+    // The Linux gate gets its floor from the wrapper. The Windows job invokes
+    // the runner directly, so "walked 3 files, all clean" must not read the
+    // same as "walked 480".
+    assert.equal(plan(['--min-files', '99999']).status, 2)
+    // POSITIVE CONTROL: a floor the real tree clears.
+    assert.equal(plan(['--min-files', '1']).status, 0, 'control failed')
+  })
+
+  test('a value-taking flag with no value exits 2 instead of silently using the default', () => {
+    for (const argv of [['--tests-root'], ['--max-argv-bytes'], ['--test-concurrency'], ['--min-files']]) {
+      const r = spawnSync(process.execPath, [RUNNER, '--print-plan', ...argv], { encoding: 'utf8' })
+      assert.equal(r.status, 2, `argv ${JSON.stringify(argv)} must fail closed`)
+    }
+    // A following FLAG is not a value either.
+    const r = spawnSync(process.execPath, [RUNNER, '--tests-root', '--min-files', '1'], { encoding: 'utf8' })
+    assert.equal(r.status, 2)
   })
 
   test('the default budget keeps every batch under the Windows command-line cap', () => {


### PR DESCRIPTION
## The problem

`Server Windows Tests` passed an explicit list of **eight** test files to `node --test` while `packages/server/tests/` grew to **553**. A newly added, genuinely cross-platform test was never run on Windows and nobody was told — including `setup-sandbox-binding-forms.test.js` (#7266), which is entirely about path handling and errno behaviour and is exactly what Windows coverage is for. The job went green in 58 seconds and its green said nothing about the file.

That is `docs/false-safety-guards.md`'s **"Checked a subset"** mode, in CI config rather than in a script: a hardcoded list beside a set that grows.

## The fix

Invert it, per that document's own guidance (`:283`): walk every `*.test.js`, subtract `WINDOWS_EXEMPT`, run the rest.

**A new test file is covered on Windows by default.** There is no "unclassified" state to detect — an unclassified POSIX-only file simply makes the job red, in its own TAP output, naming itself. Silence is not reachable.

## Measured first, written second

Every manifest row was seeded from a real Windows run before a line of it was written. Full record in [`docs/records/windows-test-coverage-7270.md`](docs/records/windows-test-coverage-7270.md).

| | before | after |
|---|---|---|
| files run on Windows | 8 | **480** |
| tests run on Windows | 193 | **10,929** |

Green on the real `chroxy-win` runner: `480 file(s) in the derived Windows set (555 total, 75 exempt), 1 batch(es), 10929 tests, 0 failed, 0 cancelled` in 2m27s end to end.

553 files were each run in isolation with the CI job's exact flags on the same physical box as the `chroxy-win` runner. **481 pass unmodified.** Two lanes walked the list from opposite ends and met in the middle, so 54 files were measured twice — **all 54 agreed**, including 10 failing files that reproduced identical failure counts. The verdicts are deterministic, not flaky.

**Seeding from grep would have been wrong in both directions**, which is why it was not used: `built-in-tools/bash-exec.test.js` contains no `spawn(` at all while the module it tests spawns `bash -c`; conversely all 46 files matching `/docker/i` drive fakes and pass fine.

## Two halves, split on purpose

`Server Windows Tests` is **not** a required status check (the 11 required contexts do not include it). A design that put the whole gate inside that job would be advisory — `false-safety-guards.md`'s "Never reached" mode. So:

- **the MANIFEST gate** runs on Linux in **`Server Lint`**, which *is* required
- **the RUNNER** runs on Windows and executes the derived set

Both import one derivation, so they cannot disagree about which files they mean.

## What the gate rejects

| condition | exit |
|---|---|
| a row pointing at a file that does not exist | 2 |
| an unknown reason category | 1 |
| a tracked-debt row with no issue number | 1 |
| a permanent row *with* an issue number | 1 |
| a missing/too-short note, or an unknown `symptom` | 1 |
| a duplicate row | 1 |
| exempt ratio above `MAX_EXEMPT_RATIO` | 1 |
| a `MUST_RUN_ON_WINDOWS` suite relocated into the exempt list | 1 |
| a walk below `--min-files`, or zero files | 2 |
| a typo'd flag, or an unloadable manifest | 2 |

Exit **2** ("the gate could not do its job") is surfaced separately from exit **1** ("the manifest is wrong") — *the guard broke* must not read as *the guard passed*, nor as *the code is dirty*.

`MUST_RUN_ON_WINDOWS` is the one thing written twice, deliberately. Every other check derives from `WINDOWS_EXEMPT` and is therefore blind to a file *moving into* it — that edit would delete a suite's Windows coverage and every derived objection to it at once, with the suite green. Same trade as `MUST_BE_GUARDED` in #7272.

## Proven red, not just green

Nine mutations against the real manifest, each asserted to have landed, restored with `cp` from a backup (never `git checkout --`):

```
PASS  stale row: exempt file does not exist      -> exit 2
PASS  unknown reason category                    -> exit 1
PASS  debt row loses its issue number            -> exit 1
PASS  note emptied                               -> exit 1
PASS  symptom removed                            -> exit 1
PASS  MUST_RUN suite relocated into exempt       -> exit 1
PASS  ratio ceiling: bulk exemption              -> exit 1
PASS  duplicate row                              -> exit 1
PASS  MUST_RUN roster goes stale                 -> exit 2
```

Plus 22 fixture tests (17 gate + 5 runner-plan), each with a **positive control** — the same fixture without the offending thing, proving it would otherwise have passed.

## Proven red on the real host, then green again

The acceptance criterion, run on the Windows box (the throwaway was never committed):

```
baseline     483 files, 10,986 tests, 0 failed, 0 cancelled   exit 0
+ throwaway  484 files, 10,987 tests, 1 failed                exit 1  <- named the new file
restored     483 files, 10,986 tests, 0 failed, 0 cancelled   exit 0
```

The walk picked the new file up with no edit to anything. That is the whole point of the inversion.

## Four mechanisms I got wrong and caught by measuring

- **TAP entries are not files.** The runner originally asserted `top-level TAP entries === file count`. Measured: two files produce **five** top-level entries (one per top-level `describe`), and node's TAP output contains no file paths at all. That check would have failed on every run. Replaced with a second reporter that records real file identities, asserting the identity *set* — which also caught that node emits both relative and absolute forms for the same file.
- **`await import()` of a Windows absolute path throws.** `A:\...` is rejected as protocol `a:`; both scripts refused to start on the real host. Fixed with `pathToFileURL`. They refused with exit 2 rather than reporting a clean set, which is the intended failure direction — but they could not do their job.
- **I counted `# fail` and not `# cancelled`.** The first real CI run reported **`# fail 0` alongside `# cancelled 33`**. A cancelled test produced no result at all, so counting only failures made "33 tests never ran" indistinguishable from "everything passed" — this issue's own defect class, reproduced inside the fix for it. The runner now fails on cancellations, and separately on a non-zero child exit it cannot otherwise account for, which nothing checked before.
- **NTFS is case-insensitive.** The run-set identity check compared absolute paths as strings; a drive-letter or directory case difference would have reported every file as both missing and unexpected at once. Case-folded on win32 only — folding on POSIX would let genuinely different files collide, which is the failure the check exists to catch.

## The exempt list

72 files, **13.0%** against a 20% ceiling, across 9 reason categories. **26 are tracked debt, not permanent** — they assert cross-platform behaviour and are wrong on Windows, so they carry an issue rather than a permanent exemption (a permanent row is never revisited by construction):

- **#7273** — a path-containment seam rejecting valid in-project paths (12 files). **Two are security-relevant**: `handler-utils.test.js` fails `rejects backslash traversal (..\)` — on Windows `..\` *is* a real separator — and `conversation-handlers.test.js` honours a spoofed client-supplied cwd hint over the recorded one. Neither is confirmed exploitable; both need looking at first.
- **#7274** — projectKey normalisation, git plumbing, and Windows file locking (14 files).
- **#7276** — `ide-search`, `ide-symbols`, `ws-file-ops-cache` report `cancelledByParent` **on the CI runner specifically**: 33 tests that never complete, the same suites in both runs. They pass in isolation, and a full concurrent run of the same commit on a different clone of the same physical machine reports `# cancelled 0` — so it is the runner's working directory, not the code. **This is the least comfortable exemption here**: `ide-search.test.js` holds path-confinement security tests, and Windows is exactly where path confinement is most likely to differ.

## Known limitations, stated rather than hidden

- **The exempt list is now the thing that can rot.** The ratio ceiling, the debt-requires-an-issue rule, and `MUST_RUN_ON_WINDOWS` narrow it; none closes it. A `permanent` row is never revisited by construction. The strongest remaining idea is a job that runs *only* the exempt set and fails when one **passes** — a reverse ratchet. Not in this PR; it needs the exempt set to be stable first.
- **1,967 passing tests are still stranded** inside the 72 exempt files (they fail only 315 of 2,286). Exempting a whole file is the blunt instrument; guarding the individual tests with `{ skip: process.platform === 'win32' }` is the better fix and is what #7273/#7274 track.
- **This is a snapshot of one host.** Fork PRs run on `windows-latest`, a different image. Expect the first CI runs to be the second measurement.
- **`timeout-minutes` 15 → 20**, sized from the measured 2m27s rather than guessed. Tight enough that a hang is a useful signal, loose enough for a slow `npm ci` on a busy box.
- **The exempt list is 75 files / 13.5%** against a 20% ceiling — 29 of them tracked debt with an issue, 46 permanent POSIX mechanisms.
- **A note on the entry-point-guard lint**: it strips comments but not string literals, so the literal text `argv[1]` inside an exemption *note* tripped it. Reworded here rather than suppressed; worth knowing that lint can match prose.

Closes #7270
