### PR TITLE
fix(server): stage the pathspec that was validated, not the client's string

### DIFF
--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -287,6 +287,69 @@ is also wrong, on both platforms: `'C:\Documents'.startsWith('C:\' + '\')` and
 a separator denies everything. Two of the six copies had already "fixed" it that
 way.
 
+### 12. The guard that validated one language and executed another — `#7281`
+
+`gitStage` resolved the client's string to an absolute path, asked
+`validatePathWithinCwd` whether that path was inside the project, and — having
+been told yes — handed **the client's original string** to `git add`.
+
+The check was correct. The path it checked was never the thing that ran.
+`git add` takes a *pathspec*, not a path, and a pathspec has its own grammar.
+`:/` resolves, as a filesystem path, to a harmless `<cwd>/:` that is plainly
+inside the project; to git it means "from the repository root". From a session
+confined to a subdirectory, one WebSocket message staged files above the
+workspace root, and the server replied `error: null`.
+
+Two grammars, two mechanisms: root-anchoring (`:/`, `:(top)`, `:/*`,
+`:(top,glob)**`) re-bases the pathspec on the repo root, and exclusion-only
+(`:!x`, `:(exclude)x`) means "everything except", resolved repo-wide.
+
+**Why no test caught it.** Every fixture in `ws-file-ops-git-paths.test.js` and
+`git-stage-commit.test.js` used the repo root as the session cwd — the one
+topology in which `:/` has nothing to reach. The suite tested the escape
+mechanism it knew about (`../`, correctly refused) and never asked about the
+one that worked. Fixture *geometry*, not payload, was what made the bug
+invisible; a reviewer scanning six adversarial payloads in a describe block
+named "path validation" would reasonably conclude the surface was covered.
+
+**The fix has two halves and needs both.** `--literal-pathspecs` disables the
+magic; handing git the validated path restores "what is checked is what runs".
+Re-deriving the path alone is *not* sufficient — `relative()` leaves
+`:/etc/shadow` byte-identical.
+
+**Two traps inside the fix**, both found by review after the first cut shipped:
+
+- Deriving the pathspec from the validator's `realPath` stages a symlink's
+  TARGET. Deriving it from the lexical `absPath` can point *out* of the cwd,
+  because containment is decided on `realPath` — so it says yes to a path that
+  merely reaches the cwd through a symlink or an aliased prefix (the ordinary
+  macOS `/var` → `/private/var` case, not an attack). Neither alone is right.
+- Falling back to `realPath` then re-introduces the original sin in miniature:
+  when the fallback yields an empty relative path, answering `'.'` turns a
+  one-path request into a whole-cwd stage. Measured: `['../aliasdir']` staged
+  every file in the cwd, `error: null`.
+
+**And the flag is silent on half the surface.** `git reset` does not error on a
+non-matching pathspec the way `git add` does, so deleting `--literal-pathspecs`
+from the unstage invocation left all 31 tests green. The guard needed its own
+positive control: a file whose name begins with `:` is unstageable *without* the
+flag and unstageable *with* it, so the assertion goes red the moment the flag is
+dropped. The stage half has the mirror control.
+
+**Environment can refuse the fix outright.** git rejects `--literal-pathspecs`
+when the environment also selects another global pathspec mode, so an inherited
+`GIT_GLOB_PATHSPECS=1` or `GIT_ICASE_PATHSPECS=1` would make *every* stage die
+with `fatal: global 'literal' pathspec setting is incompatible with all other
+global pathspec settings`. The daemon inherits the user's shell environment;
+those variables are dropped for our own invocations.
+
+The generalisation is worth more than the instance: **whenever a validated value
+is handed to something that parses it under a different grammar — a pathspec, a
+revision, a glob, a shell word, a URL — the validation proves nothing.** The
+sibling instances that audit turned up are `#7290` (a revision allowlist whose
+comment claims it blocks flags, while `-` is inside its character class) and
+`#7291` (client prompts in positional argv slots with no `--`).
+
 ## The one that got me while writing this
 
 A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -1,4 +1,4 @@
-import { normalize, resolve, join } from 'path'
+import { normalize, resolve, join, relative, sep } from 'path'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { writeFile, unlink } from 'fs/promises'
@@ -114,6 +114,45 @@ function mapGhCreateError(err) {
   }
   const line = firstLine(stderr)
   return { message: line || (err && err.message) || 'Failed to create pull request', existingUrl: null }
+}
+
+/**
+ * #7281 — turn a VALIDATED absolute path into the pathspec git will actually receive.
+ *
+ * `git add` / `git reset` take PATHSPECS, not paths, and a pathspec has its own magic
+ * syntax — so the string the client sent and the path we validated are not written in
+ * the same language. `:/` resolves, as a filesystem path, to a harmless `<cwd>/:` that
+ * passes containment; to git it means "from the repo root", staging the ENTIRE
+ * repository, including files outside the session cwd and outside the workspace root.
+ * The server reported `error: null` while doing it.
+ *
+ * Two changes close it, and only together:
+ *
+ *  - `--literal-pathspecs` on the git invocation, which disables all pathspec magic and
+ *    glob expansion. This is the load-bearing half: re-deriving the path is NOT
+ *    sufficient on its own, because `relative()` leaves a payload such as
+ *    `:/etc/shadow` byte-identical.
+ *  - handing git the path we validated instead of the raw client string, so that what
+ *    is checked is what is executed.
+ *
+ * Derived from `absPath` (lexically resolved), deliberately NOT from the validator's
+ * `realPath` (symlink-resolved): for a symlink inside the repo, `realPath` names its
+ * TARGET, so staging it would record a different object than the one the client asked
+ * for. Containment is still decided on `realPath`; only the pathspec comes from here.
+ *
+ * @param {string} cwdReal - resolved session cwd; the git process's cwd
+ * @param {string} absPath - the absolute path that validatePathWithinCwd approved
+ * @returns {string} a cwd-relative, '/'-separated, magic-free pathspec
+ */
+function toLiteralPathspec(cwdReal, absPath) {
+  const rel = relative(cwdReal, absPath)
+  // absPath === cwdReal. git rejects an empty pathspec outright, and '.' is how the
+  // caller's intent — "everything in the cwd" — is spelled. Callers reject an empty
+  // client string before reaching here, so this only ever stands in for '.' / './'.
+  if (rel === '') return '.'
+  // git pathspecs are '/'-separated on every platform. relative() yields backslashes
+  // on Windows, which git would not match against its own '/'-separated index.
+  return sep === '\\' ? rel.split(sep).join('/') : rel
 }
 
 /**
@@ -305,15 +344,23 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
       // Validate each file path is within session CWD (prevents path traversal)
       const validatedFiles = []
       for (const file of files) {
+        // An empty pathspec is never meaningful, and would otherwise resolve to the
+        // cwd itself and widen to '.' below. git rejects it today; keep that outcome
+        // with a clearer message. (#7281)
+        if (typeof file !== 'string' || file === '') {
+          sendFn(ws, { type: 'git_stage_result', error: 'Invalid file path: empty' })
+          return
+        }
         const absPath = normalize(resolve(cwdReal, file))
         const { valid } = await validatePathWithinCwd(absPath, sessionCwd)
         if (!valid) {
           sendFn(ws, { type: 'git_stage_result', error: `Access denied: path outside project directory — ${file}` })
           return
         }
-        validatedFiles.push(file)
+        // #7281 — what git receives is the path we validated, not the client's string.
+        validatedFiles.push(toLiteralPathspec(cwdReal, absPath))
       }
-      await execFileAsync(GIT, ['add', '--', ...validatedFiles], {
+      await execFileAsync(GIT, ['--literal-pathspecs', 'add', '--', ...validatedFiles], {
         cwd: cwdReal,
         timeout: 10000,
       })
@@ -341,15 +388,23 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
       // Validate each file path is within session CWD (prevents path traversal)
       const validatedFiles = []
       for (const file of files) {
+        // An empty pathspec is never meaningful, and would otherwise resolve to the
+        // cwd itself and widen to '.' below. git rejects it today; keep that outcome
+        // with a clearer message. (#7281)
+        if (typeof file !== 'string' || file === '') {
+          sendFn(ws, { type: 'git_unstage_result', error: 'Invalid file path: empty' })
+          return
+        }
         const absPath = normalize(resolve(cwdReal, file))
         const { valid } = await validatePathWithinCwd(absPath, sessionCwd)
         if (!valid) {
           sendFn(ws, { type: 'git_unstage_result', error: `Access denied: path outside project directory — ${file}` })
           return
         }
-        validatedFiles.push(file)
+        // #7281 — what git receives is the path we validated, not the client's string.
+        validatedFiles.push(toLiteralPathspec(cwdReal, absPath))
       }
-      await execFileAsync(GIT, ['reset', 'HEAD', '--', ...validatedFiles], {
+      await execFileAsync(GIT, ['--literal-pathspecs', 'reset', 'HEAD', '--', ...validatedFiles], {
         cwd: cwdReal,
         timeout: 10000,
       })

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 import { randomBytes } from 'crypto'
 import { GIT } from '../git.js'
 import { validateGitPath } from './common.js'
+import { isPathWithin } from '../utils/path-containment.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -135,17 +136,39 @@ function mapGhCreateError(err) {
  *  - handing git the path we validated instead of the raw client string, so that what
  *    is checked is what is executed.
  *
- * Derived from `absPath` (lexically resolved), deliberately NOT from the validator's
- * `realPath` (symlink-resolved): for a symlink inside the repo, `realPath` names its
- * TARGET, so staging it would record a different object than the one the client asked
- * for. Containment is still decided on `realPath`; only the pathspec comes from here.
+ * Prefers `absPath` (lexically resolved) over the validator's `realPath`
+ * (symlink-resolved): for a symlink INSIDE the cwd, `realPath` names its TARGET, so
+ * staging that would record a different object than the one the client asked for.
+ *
+ * `absPath` is used only when it is lexically inside the cwd, because it is not
+ * always. validatePathWithinCwd decides containment on `realPath`, so it says yes to
+ * a path that merely REACHES the cwd through a symlink or an aliased prefix —
+ * including the entirely ordinary macOS case where the session cwd resolves to
+ * `/private/var/...` while the client names the same file under `/var/...`.
+ * `relative()` then yields a '..' chain pointing out of the cwd, which git refuses
+ * under --literal-pathspecs; and for a symlink ABOVE the cwd it would name a file
+ * outside it. Falling back to `realPath` — which containment has already proved is
+ * inside — gives this function an invariant worth stating plainly: it never returns
+ * a pathspec that leaves the cwd.
+ *
+ * Containment is still decided by validatePathWithinCwd. The isPathWithin call here
+ * is that same root-aware predicate (#7273), not a second implementation of the rule.
  *
  * @param {string} cwdReal - resolved session cwd; the git process's cwd
  * @param {string} absPath - the absolute path that validatePathWithinCwd approved
- * @returns {string} a cwd-relative, '/'-separated, magic-free pathspec
+ * @param {string} realPath - that path with every symlink resolved, from the validator
+ * @returns {string|null} a cwd-relative, '/'-separated, magic-free pathspec, or null
+ *   when neither form stays inside the cwd (the caller then rejects)
  */
-function toLiteralPathspec(cwdReal, absPath) {
-  const rel = relative(cwdReal, absPath)
+function toLiteralPathspec(cwdReal, absPath, realPath) {
+  const rel = isPathWithin(absPath, cwdReal)
+    ? relative(cwdReal, absPath)
+    : relative(cwdReal, realPath)
+  // Defensive: `valid === true` already means realPath is inside, so this is
+  // unreachable today. It stays because a pathspec that leaves the cwd must never
+  // reach git, and a future caller that stops checking `valid` should fail closed
+  // rather than silently widen.
+  if (rel !== '' && !isPathWithin(resolve(cwdReal, rel), cwdReal)) return null
   // absPath === cwdReal. git rejects an empty pathspec outright, and '.' is how the
   // caller's intent — "everything in the cwd" — is spelled. Callers reject an empty
   // client string before reaching here, so this only ever stands in for '.' / './'.
@@ -352,13 +375,14 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
           return
         }
         const absPath = normalize(resolve(cwdReal, file))
-        const { valid } = await validatePathWithinCwd(absPath, sessionCwd)
-        if (!valid) {
+        const { valid, realPath } = await validatePathWithinCwd(absPath, sessionCwd)
+        const pathspec = valid ? toLiteralPathspec(cwdReal, absPath, realPath) : null
+        if (!valid || pathspec === null) {
           sendFn(ws, { type: 'git_stage_result', error: `Access denied: path outside project directory — ${file}` })
           return
         }
         // #7281 — what git receives is the path we validated, not the client's string.
-        validatedFiles.push(toLiteralPathspec(cwdReal, absPath))
+        validatedFiles.push(pathspec)
       }
       await execFileAsync(GIT, ['--literal-pathspecs', 'add', '--', ...validatedFiles], {
         cwd: cwdReal,
@@ -396,13 +420,14 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
           return
         }
         const absPath = normalize(resolve(cwdReal, file))
-        const { valid } = await validatePathWithinCwd(absPath, sessionCwd)
-        if (!valid) {
+        const { valid, realPath } = await validatePathWithinCwd(absPath, sessionCwd)
+        const pathspec = valid ? toLiteralPathspec(cwdReal, absPath, realPath) : null
+        if (!valid || pathspec === null) {
           sendFn(ws, { type: 'git_unstage_result', error: `Access denied: path outside project directory — ${file}` })
           return
         }
         // #7281 — what git receives is the path we validated, not the client's string.
-        validatedFiles.push(toLiteralPathspec(cwdReal, absPath))
+        validatedFiles.push(pathspec)
       }
       await execFileAsync(GIT, ['--literal-pathspecs', 'reset', 'HEAD', '--', ...validatedFiles], {
         cwd: cwdReal,

--- a/packages/server/src/ws-file-ops/git.js
+++ b/packages/server/src/ws-file-ops/git.js
@@ -10,6 +10,27 @@ import { isPathWithin } from '../utils/path-containment.js'
 
 const execFileAsync = promisify(execFileCb)
 
+// #7281 — git REFUSES `--literal-pathspecs` when the environment also selects another
+// global pathspec mode: with GIT_GLOB_PATHSPECS=1 or GIT_ICASE_PATHSPECS=1 inherited from
+// the daemon's environment, every stage/unstage dies with `fatal: global 'literal'
+// pathspec setting is incompatible with all other global pathspec settings` (measured,
+// git 2.54.0). GIT_NOGLOB_PATHSPECS happens to be tolerated today; it is dropped anyway
+// rather than depending on that. The daemon inherits the user's shell environment, so
+// these are theirs to set and not ours to assume absent — drop the family for our own
+// invocations and let the flag decide pathspec semantics by itself.
+const PATHSPEC_ENV_VARS = [
+  'GIT_LITERAL_PATHSPECS',
+  'GIT_GLOB_PATHSPECS',
+  'GIT_NOGLOB_PATHSPECS',
+  'GIT_ICASE_PATHSPECS',
+]
+
+function gitEnvWithoutPathspecModes() {
+  const env = { ...process.env }
+  for (const key of PATHSPEC_ENV_VARS) delete env[key]
+  return env
+}
+
 // #6876 — result sender for the git_create_pr flow. Every field is always
 // present (present-and-nullable) so the wire payload satisfies
 // ServerGitCreatePrResultSchema on every path. #6938 — `existingUrl` is a
@@ -161,18 +182,26 @@ function mapGhCreateError(err) {
  *   when neither form stays inside the cwd (the caller then rejects)
  */
 function toLiteralPathspec(cwdReal, absPath, realPath) {
-  const rel = isPathWithin(absPath, cwdReal)
-    ? relative(cwdReal, absPath)
-    : relative(cwdReal, realPath)
+  const lexicallyInside = isPathWithin(absPath, cwdReal)
+  const rel = lexicallyInside ? relative(cwdReal, absPath) : relative(cwdReal, realPath)
+  if (rel === '') {
+    // The path denotes the cwd DIRECTORY itself, and the two ways of getting here mean
+    // opposite things:
+    //  - lexically inside: the client literally named the cwd ('.', './'). git rejects an
+    //    empty pathspec, and '.' is how "everything in the cwd" is spelled — which is
+    //    exactly what was asked for.
+    //  - via the realPath fallback: the client named something OUTSIDE the cwd that
+    //    RESOLVES to it (a symlink pointing at the cwd). Answering '.' there turns a
+    //    one-path request into a whole-cwd stage, touching files the client never named,
+    //    and replies `error: null` — the same false-success class this change exists to
+    //    remove. Reject instead.
+    return lexicallyInside ? '.' : null
+  }
   // Defensive: `valid === true` already means realPath is inside, so this is
   // unreachable today. It stays because a pathspec that leaves the cwd must never
   // reach git, and a future caller that stops checking `valid` should fail closed
   // rather than silently widen.
-  if (rel !== '' && !isPathWithin(resolve(cwdReal, rel), cwdReal)) return null
-  // absPath === cwdReal. git rejects an empty pathspec outright, and '.' is how the
-  // caller's intent — "everything in the cwd" — is spelled. Callers reject an empty
-  // client string before reaching here, so this only ever stands in for '.' / './'.
-  if (rel === '') return '.'
+  if (!isPathWithin(resolve(cwdReal, rel), cwdReal)) return null
   // git pathspecs are '/'-separated on every platform. relative() yields backslashes
   // on Windows, which git would not match against its own '/'-separated index.
   return sep === '\\' ? rel.split(sep).join('/') : rel
@@ -371,7 +400,7 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
         // cwd itself and widen to '.' below. git rejects it today; keep that outcome
         // with a clearer message. (#7281)
         if (typeof file !== 'string' || file === '') {
-          sendFn(ws, { type: 'git_stage_result', error: 'Invalid file path: empty' })
+          sendFn(ws, { type: 'git_stage_result', error: `Invalid file path: ${typeof file !== 'string' ? 'not a string' : 'empty'}` })
           return
         }
         const absPath = normalize(resolve(cwdReal, file))
@@ -387,6 +416,7 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
       await execFileAsync(GIT, ['--literal-pathspecs', 'add', '--', ...validatedFiles], {
         cwd: cwdReal,
         timeout: 10000,
+        env: gitEnvWithoutPathspecModes(),
       })
       sendFn(ws, { type: 'git_stage_result', error: null })
     } catch (err) {
@@ -416,7 +446,7 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
         // cwd itself and widen to '.' below. git rejects it today; keep that outcome
         // with a clearer message. (#7281)
         if (typeof file !== 'string' || file === '') {
-          sendFn(ws, { type: 'git_unstage_result', error: 'Invalid file path: empty' })
+          sendFn(ws, { type: 'git_unstage_result', error: `Invalid file path: ${typeof file !== 'string' ? 'not a string' : 'empty'}` })
           return
         }
         const absPath = normalize(resolve(cwdReal, file))
@@ -432,6 +462,7 @@ export function createGitOps(sendFn, resolveSessionCwd, validatePathWithinCwd, w
       await execFileAsync(GIT, ['--literal-pathspecs', 'reset', 'HEAD', '--', ...validatedFiles], {
         cwd: cwdReal,
         timeout: 10000,
+        env: gitEnvWithoutPathspecModes(),
       })
       sendFn(ws, { type: 'git_unstage_result', error: null })
     } catch (err) {

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -282,3 +282,174 @@ describe('git ops workspace root validation (#2690)', () => {
     )
   })
 })
+
+describe('gitStage/gitUnstage pathspec magic (#7281)', () => {
+  // `git add` takes a PATHSPEC, not a path. gitStage validated a RESOLVED absolute
+  // path and then handed git the RAW client string — two different languages. `:/`
+  // resolves, as a filesystem path, to a harmless `<cwd>/:` that passes containment;
+  // to git it means "from the repo root". Measured pre-fix: every payload below
+  // returned `error: null` AND staged a file outside the session cwd *and* outside
+  // the workspace root, from a single WebSocket message.
+  //
+  // Topology matters: the escape needs the session cwd to be a STRICT SUBDIRECTORY
+  // of the git repo. Every pre-existing test in this file uses the repo root as the
+  // session cwd, where `:/` has nothing to reach — which is why none of them failed.
+  let repoDir      // the git repo root — NOT reachable by the session
+  let subDir       // session cwd AND workspace root
+  let fileOps
+  let lastMessage
+
+  const mockSend = (_ws, msg) => { lastMessage = msg }
+  const ws = {}
+
+  const OUTSIDE = 'OUTSIDE-THE-WORKSPACE.txt'
+
+  /** Index contents, as repo-root-relative paths. */
+  async function stagedPaths() {
+    const { stdout } = await execFileAsync('git', ['diff', '--cached', '--name-only'], { cwd: repoDir })
+    return stdout.split('\n').map(s => s.trim()).filter(Boolean)
+  }
+
+  /** Anything staged that is not under the session cwd is an escape. */
+  async function escapedPaths() {
+    return (await stagedPaths()).filter(p => !p.startsWith('sub/'))
+  }
+
+  async function resetIndex() {
+    await execFileAsync('git', ['reset', 'HEAD', '--', '.'], { cwd: repoDir }).catch(() => {})
+  }
+
+  before(async () => {
+    repoDir = await mkdtemp(join(tmpdir(), 'chroxy-pathspec-'))
+    subDir = join(repoDir, 'sub')
+    await mkdir(subDir, { recursive: true })
+    await execFileAsync('git', ['init'], { cwd: repoDir })
+    await execFileAsync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir })
+    await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: repoDir })
+    await writeFile(join(subDir, 'inside.txt'), 'original')
+    await writeFile(join(repoDir, OUTSIDE), 'original')
+    await execFileAsync('git', ['add', '-A'], { cwd: repoDir })
+    await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repoDir })
+    // Dirty both, so `git add` has something to stage on either side of the boundary.
+    await writeFile(join(subDir, 'inside.txt'), 'modified')
+    await writeFile(join(repoDir, OUTSIDE), 'modified')
+
+    // workspaceRoot === subDir: the repo root is outside the workspace entirely.
+    fileOps = createFileOps(mockSend, subDir)
+  })
+
+  after(async () => {
+    if (repoDir) await rmDirRobustAsync(repoDir)
+  })
+
+  // POSITIVE CONTROL. Without this, every assertion below would also pass if the
+  // implementation simply denied everything — the exact false-green this repo has
+  // been bitten by (docs/false-safety-guards.md).
+  it('POSITIVE CONTROL: stages an ordinary file inside the session cwd', async () => {
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, ['inside.txt'], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.equal(lastMessage.error, null, `ordinary staging must still work, got: ${lastMessage.error}`)
+    assert.deepEqual(await stagedPaths(), ['sub/inside.txt'])
+  })
+
+  // Every payload here was MEASURED to escape pre-fix. Two distinct mechanisms:
+  //   - root-anchoring  (':/', ':(top)', ':/*', ':/<file>', ':(top,glob)**') re-bases the
+  //     pathspec on the REPO root, which sits above the workspace root here;
+  //   - exclusion-only  (':!<file>', ':(exclude)<file>') means "everything except", and
+  //     that "everything" is resolved repo-wide, not cwd-wide.
+  // ':(glob)**' is deliberately NOT in this list: it stays cwd-relative and does not
+  // escape, so it would be a test that cannot fail.
+  for (const payload of [':/', ':(top)', ':/*', `:/${OUTSIDE}`, ':(top,glob)**', ':!inside.txt', ':(exclude)nothing']) {
+    it(`does not stage outside the workspace root via pathspec magic ${JSON.stringify(payload)}`, async () => {
+      await resetIndex()
+      lastMessage = null
+      await fileOps.gitStage(ws, [payload], subDir)
+      assert.ok(lastMessage, 'should send a response')
+      assert.equal(lastMessage.type, 'git_stage_result')
+      // The invariant, asserted on the filesystem rather than on the reply: whatever
+      // the server chose to report, nothing outside the session cwd may be staged.
+      assert.deepEqual(
+        await escapedPaths(), [],
+        `pathspec ${JSON.stringify(payload)} escaped the workspace root and staged files above it`
+      )
+    })
+  }
+
+  it('gitUnstage does not reach outside the workspace root via pathspec magic', async () => {
+    await resetIndex()
+    // Stage the outside file directly, so a successful escape would be VISIBLE as an
+    // unstage. Without this the assertion could pass simply because nothing was staged.
+    await execFileAsync('git', ['add', '--', OUTSIDE], { cwd: repoDir })
+    assert.deepEqual(await stagedPaths(), [OUTSIDE], 'fixture precondition')
+
+    lastMessage = null
+    await fileOps.gitUnstage(ws, [':/'], subDir)
+    assert.equal(lastMessage.type, 'git_unstage_result')
+    assert.deepEqual(
+      await stagedPaths(), [OUTSIDE],
+      'gitUnstage reached outside the workspace root and unstaged a file above it'
+    )
+    await resetIndex()
+  })
+
+  // POSITIVE CONTROL that --literal-pathspecs is actually ARMED, rather than the
+  // escape merely being blocked by something else. A filename beginning with ':' is
+  // UNSTAGEABLE without the flag (git reads it as magic and errors) and stageable
+  // with it, so this assertion fails if the flag is ever dropped.
+  //
+  // POSIX-only: NTFS forbids ':' in a filename (it is the alternate-data-stream
+  // separator), so the fixture cannot be created on Windows at all.
+  it('POSITIVE CONTROL: stages a file whose name begins with ":" (proves --literal-pathspecs is armed)', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('NTFS forbids ":" in filenames — the fixture cannot exist on Windows')
+      return
+    }
+    const weird = ':weird.txt'
+    await writeFile(join(subDir, weird), 'colon')
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, [weird], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.equal(lastMessage.error, null, `expected the colon-named file to stage, got: ${lastMessage.error}`)
+    assert.deepEqual(await stagedPaths(), [`sub/${weird}`])
+    await resetIndex()
+  })
+
+  // Guards the OTHER wrong fix: deriving the pathspec from the validator's
+  // symlink-resolved `realPath` rather than the lexically-resolved `absPath`. For a
+  // symlink inside the repo, realPath names its TARGET, so staging it would record a
+  // different object than the client asked for.
+  it('stages a symlink itself, not the file it points at', async (t) => {
+    const linkPath = join(subDir, 'link.txt')
+    try {
+      await symlink('inside.txt', linkPath)
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOTSUP') {
+        // The Windows CI runner is NETWORK SERVICE and lacks SeCreateSymbolicLinkPrivilege.
+        t.skip(`symlinks not supported in this environment: ${err.code}`)
+        return
+      }
+      if (err.code !== 'EEXIST') throw err
+    }
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, ['link.txt'], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.equal(lastMessage.error, null, `expected the symlink to stage, got: ${lastMessage.error}`)
+    assert.deepEqual(await stagedPaths(), ['sub/link.txt'], 'must stage the link, not its target')
+    const { stdout } = await execFileAsync('git', ['ls-files', '-s', 'sub/link.txt'], { cwd: repoDir })
+    assert.ok(stdout.startsWith('120000'), `expected symlink mode 120000, got: ${stdout.trim()}`)
+    await resetIndex()
+  })
+
+  it('rejects an empty pathspec rather than widening it to the whole cwd', async () => {
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, [''], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.ok(lastMessage.error, 'an empty pathspec must be an error')
+    assert.deepEqual(await stagedPaths(), [], 'an empty pathspec must not stage anything')
+  })
+})

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -444,6 +444,92 @@ describe('gitStage/gitUnstage pathspec magic (#7281)', () => {
     await resetIndex()
   })
 
+  // A SECOND over-stage vector --literal-pathspecs closes, independent of the escape
+  // above: glob expansion. A client that selects one file whose NAME contains glob
+  // metacharacters gets every file matching the pattern staged. Measured on main:
+  // selecting 'a[bc].txt' stages a[bc].txt, ab.txt AND ac.txt, and reports success —
+  // two files the user never selected. '[' and ']' are legal on NTFS as well as
+  // POSIX, so this runs on every platform.
+  it('stages only the selected file when its name contains glob metacharacters', async () => {
+    await writeFile(join(subDir, 'a[bc].txt'), 'literal')
+    await writeFile(join(subDir, 'ab.txt'), 'decoy')
+    await writeFile(join(subDir, 'ac.txt'), 'decoy')
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, ['a[bc].txt'], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.equal(lastMessage.error, null, `expected the literal file to stage, got: ${lastMessage.error}`)
+    assert.deepEqual(
+      await stagedPaths(), ['sub/a[bc].txt'],
+      'glob expansion staged files the client never selected',
+    )
+    await resetIndex()
+    await rm(join(subDir, 'a[bc].txt'), { force: true })
+    await rm(join(subDir, 'ab.txt'), { force: true })
+    await rm(join(subDir, 'ac.txt'), { force: true })
+  })
+
+  // Pins the realPath fallback in toLiteralPathspec. validatePathWithinCwd decides
+  // containment on the SYMLINK-RESOLVED path, so it approves an absolute path that
+  // merely REACHES the cwd through a symlinked prefix. Deriving the pathspec from the
+  // lexical path alone then yields a '..' chain pointing out of the cwd, which git
+  // refuses under --literal-pathspecs.
+  //
+  // Two forms of the same case, measured, which behave OPPOSITELY on main — hence the
+  // fallback rather than a plain reject:
+  //   - this fixture (a symlinked directory INSIDE the repo): main errors with
+  //     "beyond a symbolic link"; the fallback makes it work. An improvement.
+  //   - the same path shape via a symlinked TMPDIR — the ordinary macOS case where the
+  //     cwd resolves to /private/var/... and the client names /var/... — succeeds on
+  //     main, and a relative()-only fix REGRESSES it to a hard git failure. That form
+  //     cannot be a portable fixture, since it depends on the host's tmpdir being a
+  //     symlink, so it is recorded here rather than asserted.
+  it('accepts an absolute path that reaches the cwd through a symlinked prefix', async (t) => {
+    const alias = join(repoDir, 'alias')
+    try {
+      await symlink(subDir, alias)
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOTSUP') {
+        t.skip(`symlinks not supported in this environment: ${err.code}`)
+        return
+      }
+      if (err.code !== 'EEXIST') throw err
+    }
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, [join(alias, 'inside.txt')], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.equal(lastMessage.error, null, `an aliased absolute path must still stage, got: ${lastMessage.error}`)
+    assert.deepEqual(await stagedPaths(), ['sub/inside.txt'])
+    await resetIndex()
+  })
+
+  // The mirror case, and a genuine escape that was open on main: a symlink ABOVE the
+  // cwd pointing back INTO it. Containment approves it (the real target is inside),
+  // but the lexical path names a file outside the cwd — pre-fix that staged
+  // `lure.txt`, above the workspace root, with error: null.
+  it('does not stage outside the cwd via a symlink above it that points back in', async (t) => {
+    const lure = join(repoDir, 'lure.txt')
+    try {
+      await symlink(join(subDir, 'inside.txt'), lure)
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOTSUP') {
+        t.skip(`symlinks not supported in this environment: ${err.code}`)
+        return
+      }
+      if (err.code !== 'EEXIST') throw err
+    }
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, ['../lure.txt'], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.deepEqual(
+      await escapedPaths(), [],
+      'a symlink above the cwd staged a path outside the workspace root',
+    )
+    await resetIndex()
+  })
+
   it('rejects an empty pathspec rather than widening it to the whole cwd', async () => {
     await resetIndex()
     lastMessage = null

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 import { createFileOps } from '../src/ws-file-ops/index.js'
-import { rmDirRobustAsync } from './test-helpers.js'
+import { disableRepoAutoGc, rmDirRobustAsync } from './test-helpers.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -324,6 +324,9 @@ describe('gitStage/gitUnstage pathspec magic (#7281)', () => {
     subDir = join(repoDir, 'sub')
     await mkdir(subDir, { recursive: true })
     await execFileAsync('git', ['init'], { cwd: repoDir })
+    // #6098 — this block is the only one in this file that COMMITS, so it is the only
+    // one that can trip background gc racing the teardown rm (ENOTEMPTY).
+    disableRepoAutoGc(repoDir)
     await execFileAsync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir })
     await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: repoDir })
     await writeFile(join(subDir, 'inside.txt'), 'original')

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -533,6 +533,89 @@ describe('gitStage/gitUnstage pathspec magic (#7281)', () => {
     await resetIndex()
   })
 
+  // The realPath fallback has a second empty-relative case, and it is NOT the client
+  // asking for '.': a path OUTSIDE the cwd that RESOLVES to the cwd directory. Answering
+  // '.' there turns a one-path request into a whole-cwd stage. Measured on the first cut
+  // of this fix: gitStage(['../aliasdir']) replied error:null and staged all three files
+  // in the cwd. Same false-success class as the escape itself.
+  it('does not widen a one-path request into the whole cwd via a symlink to the cwd', async (t) => {
+    const aliasDir = join(repoDir, 'aliasdir')
+    try {
+      await symlink(subDir, aliasDir)
+    } catch (err) {
+      if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOTSUP') {
+        t.skip(`symlinks not supported in this environment: ${err.code}`)
+        return
+      }
+      if (err.code !== 'EEXIST') throw err
+    }
+    await writeFile(join(subDir, 'second.txt'), 'other')
+    await resetIndex()
+    lastMessage = null
+    await fileOps.gitStage(ws, ['../aliasdir'], subDir)
+    assert.equal(lastMessage.type, 'git_stage_result')
+    assert.deepEqual(
+      await stagedPaths(), [],
+      'a single-path request was widened into a whole-cwd stage',
+    )
+    await resetIndex()
+    await rm(join(subDir, 'second.txt'), { force: true })
+  })
+
+  // POSITIVE CONTROL for --literal-pathspecs on the UNSTAGE invocation specifically.
+  // Without it the review showed every other test here stays green: `git reset` does not
+  // error on a non-matching pathspec the way `git add` does, so a dropped flag is silent.
+  // A ':'-prefixed filename is unstageable without the flag and unstageable-able with it,
+  // so this goes red the moment it is removed from the reset argv.
+  //
+  // POSIX-only: NTFS forbids ':' in a filename.
+  it('POSITIVE CONTROL: gitUnstage unstages a file whose name begins with ":" (proves --literal-pathspecs on reset)', async (t) => {
+    if (process.platform === 'win32') {
+      t.skip('NTFS forbids ":" in filenames — the fixture cannot exist on Windows')
+      return
+    }
+    const weird = ':unstage-me.txt'
+    await writeFile(join(subDir, weird), 'colon')
+    await resetIndex()
+    await execFileAsync('git', ['--literal-pathspecs', 'add', '--', `sub/${weird}`], { cwd: repoDir })
+    assert.deepEqual(await stagedPaths(), [`sub/${weird}`], 'fixture precondition: it is staged')
+
+    lastMessage = null
+    await fileOps.gitUnstage(ws, [weird], subDir)
+    assert.equal(lastMessage.type, 'git_unstage_result')
+    assert.equal(lastMessage.error, null, `expected the colon-named file to unstage, got: ${lastMessage.error}`)
+    assert.deepEqual(await stagedPaths(), [], 'the colon-named file was not actually unstaged')
+    await resetIndex()
+    await rm(join(subDir, weird), { force: true })
+  })
+
+  // git REFUSES --literal-pathspecs when the environment selects another global pathspec
+  // mode, so an inherited GIT_GLOB_PATHSPECS/GIT_ICASE_PATHSPECS would make EVERY stage
+  // die with `fatal: global 'literal' pathspec setting is incompatible ...`. The daemon
+  // inherits the user's shell environment, so this is reachable without any attacker.
+  for (const varName of ['GIT_GLOB_PATHSPECS', 'GIT_ICASE_PATHSPECS']) {
+    it(`stages normally when the daemon environment has ${varName} set`, async () => {
+      const had = Object.prototype.hasOwnProperty.call(process.env, varName)
+      const prev = process.env[varName]
+      process.env[varName] = '1'
+      try {
+        await resetIndex()
+        lastMessage = null
+        await fileOps.gitStage(ws, ['inside.txt'], subDir)
+        assert.equal(lastMessage.type, 'git_stage_result')
+        assert.equal(
+          lastMessage.error, null,
+          `an inherited ${varName} broke ordinary staging: ${lastMessage.error}`,
+        )
+        assert.deepEqual(await stagedPaths(), ['sub/inside.txt'])
+      } finally {
+        if (had) process.env[varName] = prev
+        else delete process.env[varName]
+        await resetIndex()
+      }
+    })
+  }
+
   it('rejects an empty pathspec rather than widening it to the whole cwd', async () => {
     await resetIndex()
     lastMessage = null

--- a/packages/server/tests/ws-file-ops-git-paths.test.js
+++ b/packages/server/tests/ws-file-ops-git-paths.test.js
@@ -530,6 +530,12 @@ describe('gitStage/gitUnstage pathspec magic (#7281)', () => {
       await escapedPaths(), [],
       'a symlink above the cwd staged a path outside the workspace root',
     )
+    // And state what it DOES do, rather than leaving it to be discovered. Containment
+    // approved the link's TARGET, so that is what gets staged — a substitution, but a
+    // contained one, and strictly safer than main (which staged `lure.txt` itself, above
+    // the workspace root, replying error:null). Asserted so the behaviour is pinned
+    // rather than incidental; if it ever changes, this is the test that says so.
+    assert.deepEqual(await stagedPaths(), ['sub/inside.txt'])
     await resetIndex()
   })
 
@@ -613,6 +619,41 @@ describe('gitStage/gitUnstage pathspec magic (#7281)', () => {
         else delete process.env[varName]
         await resetIndex()
       }
+    })
+  }
+
+  // COVERAGE for the pathspec DERIVATION, not just the flag. Every other path in this
+  // file (and in every pre-existing gitStage/gitUnstage test) is a SINGLE component, so
+  // toLiteralPathspec could return only the last component and all 89 tests across the
+  // five git/file-ops suites stayed green — measured by mutation. A multi-component path
+  // is what makes `relative()` observable at all.
+  for (const op of ['gitStage', 'gitUnstage']) {
+    it(`${op} preserves every component of a nested path`, async () => {
+      await mkdir(join(subDir, 'nested', 'deep'), { recursive: true })
+      await writeFile(join(subDir, 'nested', 'deep', 'file.txt'), 'nested')
+      // A decoy of the same basename at the cwd root: if the pathspec is ever truncated
+      // to its last component, THIS is what git would match instead.
+      await writeFile(join(subDir, 'file.txt'), 'decoy')
+      const nested = 'sub/nested/deep/file.txt'
+      await resetIndex()
+
+      if (op === 'gitUnstage') {
+        await execFileAsync('git', ['add', '--', nested, 'sub/file.txt'], { cwd: repoDir })
+        assert.deepEqual(await stagedPaths(), ['sub/file.txt', nested], 'fixture precondition')
+      }
+
+      lastMessage = null
+      await fileOps[op](ws, [join('nested', 'deep', 'file.txt')], subDir)
+      assert.equal(lastMessage.error, null, `${op} failed on a nested path: ${lastMessage.error}`)
+      assert.deepEqual(
+        await stagedPaths(),
+        op === 'gitStage' ? [nested] : ['sub/file.txt'],
+        `${op} acted on the wrong path — the pathspec lost or gained a component`,
+      )
+
+      await resetIndex()
+      await rm(join(subDir, 'nested'), { recursive: true, force: true })
+      await rm(join(subDir, 'file.txt'), { force: true })
     })
   }
 

--- a/packages/server/tests/ws-git-result-schemas.test.js
+++ b/packages/server/tests/ws-git-result-schemas.test.js
@@ -48,8 +48,9 @@ const SCHEMAS = {
  */
 const EXPECTED_EMIT_SITES = {
   git_commit_result: 4,
-  git_stage_result: 5,
-  git_unstage_result: 5,
+  // 6 since #7281 added the empty-pathspec rejection to gitStage and gitUnstage.
+  git_stage_result: 6,
+  git_unstage_result: 6,
 }
 
 /** Every response the handlers produced, so one fixture covers all three types. */
@@ -94,6 +95,10 @@ describe('#7085 git write-op result schemas', () => {
     await fileOps.gitStage(mockWs, ['../outside.txt'], tmpDir)
     await fileOps.gitUnstage(mockWs, ['../outside.txt'], tmpDir)
     await fileOps.gitCommit(mockWs, '   ', tmpDir)
+    // #7281 — the empty-pathspec rejection. A separate branch from the traversal
+    // one above: it fires before containment is consulted at all.
+    await fileOps.gitStage(mockWs, [''], tmpDir)
+    await fileOps.gitUnstage(mockWs, [''], tmpDir)
 
     await rm(join(tmpDir, 'new.txt'), { force: true })
   })


### PR DESCRIPTION
## What

`gitStage`/`gitUnstage` validated a **resolved absolute path** and then handed git the
**raw client string**. git reads that string as a *pathspec*, not a path, and a pathspec
has its own magic syntax — so what was checked and what was executed were written in
different languages.

`:/` resolves, as a filesystem path, to a harmless `<cwd>/:` that passes containment. To
git it means "from the repo root".

## Proven, not argued

Driving the real handlers against a real repo whose session cwd is a subdirectory, with
the workspace root set to that subdirectory:

| payload | server replied | actually staged |
|---|---|---|
| `:/` `:(top)` `:/*` `:(top,glob)**` | `error: null` | a file **above the workspace root** |
| `:/OUTSIDE-THE-WORKSPACE.txt` | `error: null` | that exact file |
| `:!inside.txt` `:(exclude)nothing` | `error: null` | the whole repo |
| `../OUTSIDE-...` | `Access denied` ✅ | nothing |

Two distinct mechanisms: **root-anchoring** re-bases the pathspec on the repo root, and
**exclusion-only** pathspecs mean "everything except", resolved repo-wide. Any
authenticated client could do this in one WebSocket message. Platform-independent — not a
Windows defect, and not covered by #7273.

## The fix

Two halves, and only both together close it:

- **`--literal-pathspecs`** on the invocation, disabling all magic and glob expansion.
  This is the load-bearing half — re-deriving the path is *not* sufficient on its own,
  because `relative()` leaves `:/etc/shadow` byte-identical.
- **handing git the validated path** rather than the client's string.

The pathspec is derived from the lexically-resolved `absPath`, *not* the validator's
symlink-resolved `realPath`: for a symlink inside the cwd, `realPath` names its target, so
staging it would record a different object than the client asked for.

But `absPath` is not always inside the cwd either — containment is decided on `realPath`,
so it approves a path that merely *reaches* the cwd through a symlink or aliased prefix.
The second commit handles that, with `isPathWithin` (the same root-aware predicate from
#7273, not a second implementation), giving a stateable invariant: **the function never
returns a pathspec that leaves the cwd.**

## Bugs this fixes beyond the escape

Found while verifying, each measured on `main`:

- **Glob over-staging.** Selecting the single file `a[bc].txt` stages `a[bc].txt`,
  `ab.txt` **and** `ac.txt` — two files the client never selected, reported as success.
- **A symlink above the cwd pointing back into it** (`../lure.txt`) staged `lure.txt`,
  above the workspace root, replying `error: null`. Open on `main`; closed here.
- **A file whose name begins with `:` is un-stageable today** — git reads it as magic.
  Now stageable.
- **An absolute path through a symlinked directory** errored with "beyond a symbolic
  link"; now works.

## Verification

Red-then-green against `origin/main`, by restoring the original file and re-running:
**12 failures before, 0 after** (exit code checked, not output grepped). The suite carries
positive controls so it cannot pass by denying everything — the failure mode
`docs/false-safety-guards.md` entry 11 names *this exact test file* for:

- ordinary staging still succeeds;
- a `:`-prefixed filename **is** stageable, which fails if `--literal-pathspecs` is ever
  dropped — a positive proof the flag is armed, not merely that something was blocked.

Fixture geometry is what makes the bug observable: every pre-existing test in this file
uses the **repo root** as the session cwd, where `:/` has nothing to reach. That is why
none of them caught it.

184/184 green across the eleven affected suites; all 8 server lints pass. The
`EXPECTED_EMIT_SITES` drift guard in `ws-git-result-schemas.test.js` correctly went red on
the new rejection branch — the new branch is now driven by that file's fixture and the
counts updated, and I verified the bumped guard still fires on a 7th site.

## Not fixed here — filed separately

An adversarial audit of every client-controlled argv reaching a spawned process turned up
neighbours that are **not** this bug and are not fixed by `--literal-pathspecs`. They are
filed as their own issues rather than widened into this PR.

Closes #7281
