### PR TITLE
fix(server): stop client strings being parsed as CLI options

### DIFF
--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -348,7 +348,88 @@ is handed to something that parses it under a different grammar — a pathspec, 
 revision, a glob, a shell word, a URL — the validation proves nothing.** The
 sibling instances that audit turned up are `#7290` (a revision allowlist whose
 comment claims it blocks flags, while `-` is inside its character class) and
-`#7291` (client prompts in positional argv slots with no `--`).
+`#7291` (client prompts in positional argv slots with no `--`) — both
+now catalogued as entry 13.
+
+### 13. The allowlist that permitted what its comment forbade — `#7290`, `#7291`
+
+Entry 12 predicted these two as its siblings. Both are the same shape: a guard
+whose *comment* describes a stronger check than its *code* performs.
+
+`getDiff` validated a client-controlled revision with
+
+```js
+// Validate ref name to prevent git flag injection
+const diffBase = /^[a-zA-Z0-9._\-\/~^@{}:]+$/.test(rawBase) ? rawBase : 'HEAD'
+```
+
+`-` is inside the character class, so it is a permitted *character*, and the
+regex has nothing to say about *position*. Measured against git 2.54.0, every
+single-token option passed and was then parsed as an option: `--stat`, `-p`,
+`--raw`, `--exit-code`, `--ext-diff`, `--word-diff`, `-U99999`, `-O<path>`.
+Only forms containing `=` were blocked, and only because `=` is absent from the
+class — an accident, not a defence.
+
+**The impact was larger than "git errors out".** `git diff -O<file>` reads
+`<file>` as a diff orderfile, and `getDiff` forwards raw git stderr to the
+client (`error: err.message`). So `-O` is a file existence/readability oracle
+over the entire filesystem, as the daemon user, escaping the session cwd
+completely, with the answer returned on the wire:
+
+```
+-O/etc/passwd                 -> (silent: readable)
+-O/etc/shadow                 -> fatal: failed to read orderfile … No such file or directory
+-O~/.ssh                      -> fatal: … Is a directory
+-O~/.chroxy/config.json       -> (silent: readable — outside the workspace)
+```
+
+The field is unconstrained on the wire: `ClientGetDiffSchema` is
+`z.object({ type: z.literal('get_diff') }).passthrough()`, so nothing upstream
+narrows it either.
+
+**The obvious fix does not work, and the issue itself proposed it.** Appending
+a `--` separator — `['diff', diffBase, '--']` — is ineffective, because `--`
+ends option parsing at *its own position* and `diffBase` precedes it:
+
+```
+git diff --stat --        still applies --stat
+git diff --exit-code --   still exits 1
+git diff -O/etc/nope --   still reads the orderfile
+```
+
+`--literal-pathspecs` (entry 12's fix) does not help either: it constrains the
+*pathspec* language, and a revision is not a pathspec. Rejecting the leading
+dash is the only thing that works here.
+
+**Which fix applies is decided by whether a leading `-` is legitimate**, and
+this is the part that is easy to get backwards. A git revision can never begin
+with `-`, so rejection is right. A user's chat message legitimately can
+("- first point"), so rejecting a prompt would break normal use — there, the
+`--` separator *is* the fix, with every flag moved before it. `#7291`'s
+`_spawnRemoteTask` needed the second treatment, not the first.
+
+**And the gate that was supposed to keep the prompt out of that argv reported
+success without checking.** Feature detection was `help.includes('--remote')`,
+a substring match. Measured against the installed CLI, whose help text carries
+`--remote-control` and `--remote-control-session-name-prefix` and no `--remote`
+at all:
+
+```
+help.includes('--remote')      -> true    (gate opens)
+/--remote(?![\w-])/.test(help) -> false   (correct)
+```
+
+The existing test for this gate fed a help text containing no `--remote`
+substring *at all*, so the naive check already answered it correctly. It passed
+before and after the fix — the recurring test shape in this document: a case
+the guard already handles proves nothing about the case it does not.
+
+**The generalisation.** `execFile` with an array argv stops *shell* injection —
+no shell ever sees the string — and it is easy to write a comment claiming that
+covers injection generally. It does not stop *argument* injection: the spawned
+program still runs its own option parser over that array. The two are different
+classes with different fixes, and "we use execFile, not exec" is an answer to
+only one of them.
 
 ## The one that got me while writing this
 

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -351,7 +351,13 @@ comment claims it blocks flags, while `-` is inside its character class) and
 `#7291` (client prompts in positional argv slots with no `--`) — both
 now catalogued as entry 13.
 
-### 13. The allowlist that permitted what its comment forbade — `#7290`, `#7291`
+### 13. The allowlist that permitted what its comment forbade — `#7290`, `#7291` (partial)
+
+`#7290` is closed. `#7291` is **not** — its `codex-session.js` half is still
+open, because fixing it needs an argv reorder around a documented
+`--sandbox`-before-`resume` invariant that only the repo's spawn-and-assert
+clap harness can verify, and that harness needs a working codex binary. This
+entry describes the half that landed; do not read it as closing `#7291`.
 
 Entry 12 predicted these two as its siblings. Both are the same shape: a guard
 whose *comment* describes a stronger check than its *code* performs.
@@ -377,15 +383,38 @@ over the entire filesystem, as the daemon user, escaping the session cwd
 completely, with the answer returned on the wire:
 
 ```
--O/etc/passwd                 -> (silent: readable)
--O/etc/shadow                 -> fatal: failed to read orderfile … No such file or directory
--O~/.ssh                      -> fatal: … Is a directory
--O~/.chroxy/config.json       -> (silent: readable — outside the workspace)
+-O/etc/passwd                        -> (silent: readable)
+-O/etc/shadow                        -> fatal: failed to read orderfile … No such file or directory
+-O/Users/<you>/.ssh                  -> fatal: … Is a directory
+-O/Users/<you>/.chroxy/config.json   -> (silent: readable — outside the workspace)
 ```
 
-The field is unconstrained on the wire: `ClientGetDiffSchema` is
+Absolute paths, deliberately. git receives these as one argv element with no
+shell anywhere on the path, so a `~` is never expanded — `-O~/.ssh` only ever
+reports "No such file". A tilde in a table like this turns a reproducible
+measurement into a claim nobody can re-run, which is the failure mode this
+document is about.
+
+The field is unconstrained on the wire: `GetDiffSchema` is
 `z.object({ type: z.literal('get_diff') }).passthrough()`, so nothing upstream
 narrows it either.
+
+**The fix closes the leading-dash route and only that.** Said plainly because
+the first draft of this entry did not: `:` and `/` are both in the charset
+allowlist, and git's stderr is still forwarded verbatim, so a path oracle
+needing no dash at all survives —
+
+```
+base='HEAD:/etc/passwd'  -> fatal: path '/etc/passwd' exists on disk, but not in 'HEAD'
+base='HEAD:absent'       -> fatal: path 'absent' does not exist in 'HEAD'
+base='/etc/passwd'       -> fatal: '/etc/passwd' is outside repository
+base='/no/such/file'     -> fatal: ambiguous argument …
+```
+
+— which is pre-existing, tracked separately, and needs `rev-parse --verify`
+plus not forwarding raw git stderr. A guard entry that overstates its own
+reach is the same defect in miniature, which is why it is corrected here
+rather than left to read as sealed.
 
 **The obvious fix does not work, and the issue itself proposed it.** Appending
 a `--` separator — `['diff', diffBase, '--']` — is ineffective, because `--`
@@ -404,9 +433,28 @@ dash is the only thing that works here.
 **Which fix applies is decided by whether a leading `-` is legitimate**, and
 this is the part that is easy to get backwards. A git revision can never begin
 with `-`, so rejection is right. A user's chat message legitimately can
-("- first point"), so rejecting a prompt would break normal use — there, the
-`--` separator *is* the fix, with every flag moved before it. `#7291`'s
+("- first point"), so rejecting a prompt would break normal use — there, a
+`--` separator is the fix, with every flag moved before it. `#7291`'s
 `_spawnRemoteTask` needed the second treatment, not the first.
+
+**But "use `--`" is not a rule either — it depends on the flag's arity, and
+against a required-argument flag it is worse than doing nothing.** Measured
+against commander 12.1.0 with a prompt of `--dangerously-skip-permissions`:
+
+| `--remote` declared as | `['--remote', prompt]` | `['--remote', '--', prompt]` |
+|---|---|---|
+| boolean | **injects** | safe |
+| `[name]` optional | **injects** | safe |
+| `<name>` **required** | safe — swallowed as the flag's value | **injects** |
+
+For a required-argument flag the `--` becomes the flag's own value, which frees
+the prompt to be option-parsed. No single argv is correct under both arities,
+so the caller must know which it faces: `detectFeatures` reads the advertised
+arity and refuses the feature when it cannot use a separator safely. gemini-cli
+is the third variant again — its `requiresArg` flags reject `--` outright, and
+need `--flag=value`. The generalisation is that **the fix shape is a property
+of the target CLI's parser and has to be measured per CLI**; a repo-wide "add
+`--` everywhere" sweep would have broken two of the three.
 
 **And the gate that was supposed to keep the prompt out of that argv reported
 success without checking.** Feature detection was `help.includes('--remote')`,

--- a/packages/server/src/orchestration/git-ops.js
+++ b/packages/server/src/orchestration/git-ops.js
@@ -30,7 +30,7 @@ import { join, resolve, sep } from 'node:path'
 import { rmSync, mkdirSync, existsSync } from 'node:fs'
 import { GIT } from '../git.js'
 import { configDir } from '../config-dir.js'
-import { isSafeArgvValue } from '../utils/argv-safety.js'
+import { assertSafeArgvValue } from '../utils/argv-safety.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -46,15 +46,18 @@ const DIFF_MAX_BUFFER = 64 * 1024 * 1024
 // name into a git flag. execFile already blocks SHELL injection; this blocks
 // ARGUMENT injection.
 //
-// #7290: the PREDICATE now lives in utils/argv-safety.js and is shared with
-// ws-file-ops/reader.js. This wrapper survives only to keep throwing
-// GitOpsError (and to keep the 'empty` vs `unsafe` message split that
-// orchestration-git-ops.test.js pins). Do not re-inline the check here — this
-// module used to be the only copy, and #7290 was filed because a SECOND,
-// weaker spelling had grown in reader.js.
+// #7290: the CHECK now lives in utils/argv-safety.js and is shared with
+// ws-file-ops/reader.js. This wrapper exists only to translate its Error into
+// a GitOpsError; the messages (`empty <kind>` / `unsafe <kind>: <json>`) are
+// produced there and are pinned by orchestration-git-ops.test.js. Do not
+// re-inline the check here — this module used to be the only copy, and #7290
+// was filed because a SECOND, weaker spelling had grown in reader.js.
 function assertSafeRef(name, kind = 'ref') {
-  if (typeof name !== 'string' || name.length === 0) throw new GitOpsError(`empty ${kind}`)
-  if (!isSafeArgvValue(name)) throw new GitOpsError(`unsafe ${kind}: ${JSON.stringify(name)}`)
+  try {
+    assertSafeArgvValue(name, kind)
+  } catch (err) {
+    throw new GitOpsError(err.message)
+  }
 }
 
 // Byte-accurate UTF-8 truncation that drops an incomplete trailing multibyte

--- a/packages/server/src/orchestration/git-ops.js
+++ b/packages/server/src/orchestration/git-ops.js
@@ -30,6 +30,7 @@ import { join, resolve, sep } from 'node:path'
 import { rmSync, mkdirSync, existsSync } from 'node:fs'
 import { GIT } from '../git.js'
 import { configDir } from '../config-dir.js'
+import { isSafeArgvValue } from '../utils/argv-safety.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -44,9 +45,16 @@ const DIFF_MAX_BUFFER = 64 * 1024 * 1024
 // carries a NUL/newline — defense-in-depth so a caller can never turn a branch
 // name into a git flag. execFile already blocks SHELL injection; this blocks
 // ARGUMENT injection.
+//
+// #7290: the PREDICATE now lives in utils/argv-safety.js and is shared with
+// ws-file-ops/reader.js. This wrapper survives only to keep throwing
+// GitOpsError (and to keep the 'empty` vs `unsafe` message split that
+// orchestration-git-ops.test.js pins). Do not re-inline the check here — this
+// module used to be the only copy, and #7290 was filed because a SECOND,
+// weaker spelling had grown in reader.js.
 function assertSafeRef(name, kind = 'ref') {
   if (typeof name !== 'string' || name.length === 0) throw new GitOpsError(`empty ${kind}`)
-  if (name.startsWith('-') || /[\0\n\r]/.test(name)) throw new GitOpsError(`unsafe ${kind}: ${JSON.stringify(name)}`)
+  if (!isSafeArgvValue(name)) throw new GitOpsError(`unsafe ${kind}: ${JSON.stringify(name)}`)
 }
 
 // Byte-accurate UTF-8 truncation that drops an incomplete trailing multibyte

--- a/packages/server/src/orchestration/git-ops.js
+++ b/packages/server/src/orchestration/git-ops.js
@@ -48,15 +48,24 @@ const DIFF_MAX_BUFFER = 64 * 1024 * 1024
 //
 // #7290: the CHECK now lives in utils/argv-safety.js and is shared with
 // ws-file-ops/reader.js. This wrapper exists only to translate its Error into
-// a GitOpsError; the messages (`empty <kind>` / `unsafe <kind>: <json>`) are
-// produced there and are pinned by orchestration-git-ops.test.js. Do not
-// re-inline the check here — this module used to be the only copy, and #7290
-// was filed because a SECOND, weaker spelling had grown in reader.js.
+// a GitOpsError; both messages (`empty <kind>` / `unsafe <kind>: <json>`) are
+// produced there, and orchestration-git-ops.test.js pins the `unsafe` half.
+// Do not re-inline the check here — #7290 was filed because a SECOND, weaker
+// spelling had grown in reader.js. A THIRD is still live and NOT folded in:
+// `rejectGitOptionLike` in environments/backends/k8s.js, scoped to gitRepo
+// fields.
 function assertSafeRef(name, kind = 'ref') {
   try {
     assertSafeArgvValue(name, kind)
   } catch (err) {
-    throw new GitOpsError(err.message)
+    // Only validation errors are expected here. Anything else would be a bug
+    // inside the shared guard, so keep the original rather than silently
+    // relabelling it as an unsafe ref. GitOpsError's constructor takes
+    // { args, stderr } and does not forward `cause` to super(), so it is set
+    // here rather than passed in — passing it would be dropped on the floor.
+    const wrapped = new GitOpsError(err.message)
+    wrapped.cause = err
+    throw wrapped
   }
 }
 

--- a/packages/server/src/utils/argv-safety.js
+++ b/packages/server/src/utils/argv-safety.js
@@ -7,15 +7,34 @@
  * begins with `-` is read as an OPTION rather than as the datum it was meant
  * to be. That is a distinct class, and it needs a distinct guard.
  *
- * There are exactly two correct fixes, and which one applies is decided by
- * whether a leading `-` is LEGITIMATE for that datum:
+ * There are three correct fixes. Which one applies is decided by whether a
+ * leading `-` is LEGITIMATE for that datum, and by how the target CLI parses
+ * the slot — so it is a per-CLI question, answered by MEASURING, not assumed:
  *
  *   1. The value can never legitimately start with `-` (a git ref, a branch,
  *      a container name) → REJECT it. `isSafeArgvValue` / `assertSafeArgvValue`.
  *
- *   2. The value legitimately can (a user's chat message — "- first point")
- *      → do not reject; terminate option parsing with a `--` separator placed
- *      BEFORE the value, and put every flag the command needs BEFORE the `--`.
+ *   2. The value legitimately can (a user's chat message — "- first point"),
+ *      and it sits in a POSITIONAL slot → do not reject; terminate option
+ *      parsing with a `--` separator placed BEFORE the value, and put every
+ *      flag the command needs BEFORE the `--`. This is what the `claude`
+ *      web-task argv does.
+ *
+ *   3. The value legitimately can, and it is the ARGUMENT TO A NAMED FLAG that
+ *      the CLI declares as requiring one → `=`-join the long form,
+ *      `--flag=<value>`, binding the value to the flag in a single token.
+ *      Neither (1) nor (2) works here. Measured against gemini-cli 0.45.2,
+ *      whose `-p/--prompt` and `-m/--model` use yargs `requiresArg`:
+ *
+ *          gemini -p "- first bullet"       usage error, exit 1
+ *          gemini -p -- --list-extensions   usage error, exit 1  (`--` BREAKS it)
+ *          gemini --prompt="- first bullet" parses, value taken literally
+ *
+ *      So a blanket "add `--` everywhere" sweep would be a REGRESSION on such
+ *      a CLI. Beware short-circuiting flags when probing: `gemini -p --version`
+ *      prints a version because yargs handles `--version` before it validates
+ *      `requiresArg`, which makes it look like injection when it is not. Probe
+ *      with a flag that does not short-circuit.
  *
  * `--` is NOT interchangeable with (1). It ends option parsing at ITS OWN
  * position, so it cannot retroactively protect a value that precedes it.

--- a/packages/server/src/utils/argv-safety.js
+++ b/packages/server/src/utils/argv-safety.js
@@ -1,0 +1,93 @@
+/**
+ * Argv option-injection guards (#7290, #7291).
+ *
+ * `execFile`/`spawn` with an array argv already stops SHELL injection — no
+ * shell ever sees the string. It does NOT stop ARGUMENT injection: the spawned
+ * program still runs its own option parser over that array, so a value that
+ * begins with `-` is read as an OPTION rather than as the datum it was meant
+ * to be. That is a distinct class, and it needs a distinct guard.
+ *
+ * There are exactly two correct fixes, and which one applies is decided by
+ * whether a leading `-` is LEGITIMATE for that datum:
+ *
+ *   1. The value can never legitimately start with `-` (a git ref, a branch,
+ *      a container name) → REJECT it. `isSafeArgvValue` / `assertSafeArgvValue`.
+ *
+ *   2. The value legitimately can (a user's chat message — "- first point")
+ *      → do not reject; terminate option parsing with a `--` separator placed
+ *      BEFORE the value, and put every flag the command needs BEFORE the `--`.
+ *
+ * `--` is NOT interchangeable with (1). It ends option parsing at ITS OWN
+ * position, so it cannot retroactively protect a value that precedes it.
+ * Measured against git 2.54.0 while fixing #7290:
+ *
+ *     git diff --stat --        still applies --stat
+ *     git diff --exit-code --   still exits 1
+ *     git diff -O/etc/nope --   still reads the orderfile
+ *
+ * so `['diff', base, '--']` is not a fix for a dash-leading `base`, and
+ * `--literal-pathspecs` (#7281/#7289) does not help either — that constrains
+ * the PATHSPEC language, and a revision is not a pathspec.
+ */
+
+/**
+ * True when `value` is safe to place in an argv slot whose contents would
+ * otherwise be option-parsed.
+ *
+ * Rejects, in order: a non-string, the empty string, a leading `-`, and any
+ * NUL / CR / LF. The control characters matter because several CLIs (and git's
+ * own `--stdin` modes) treat a newline as a record separator, so an embedded
+ * one can smuggle a second argument into a single slot.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isSafeArgvValue(value) {
+  return typeof value === 'string' &&
+    value.length > 0 &&
+    !value.startsWith('-') &&
+    !/[\0\n\r]/.test(value)
+}
+
+/**
+ * Throwing form of {@link isSafeArgvValue}, for call sites that must refuse
+ * rather than fall back.
+ *
+ * @param {unknown} value
+ * @param {string} [kind] - noun for the error message, e.g. 'branch', 'ref'.
+ * @throws {Error} when `value` would be option-parsed.
+ */
+export function assertSafeArgvValue(value, kind = 'value') {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`empty ${kind}`)
+  }
+  if (!isSafeArgvValue(value)) {
+    throw new Error(`unsafe ${kind}: ${JSON.stringify(value)}`)
+  }
+}
+
+/**
+ * Does a CLI's `--help` output advertise `flag` as a flag in its OWN right?
+ *
+ * A bare `help.includes('--remote')` is a false-safety guard: it reports
+ * success without checking, because it also matches `--remote-control`. That
+ * is not hypothetical — measured against the installed Claude Code CLI while
+ * fixing #7291, whose help text carries `--remote-control` and
+ * `--remote-control-session-name-prefix` and NO `--remote`:
+ *
+ *     help.includes('--remote')   -> true    (wrong: opens the gate)
+ *     cliHelpAdvertisesFlag(...)  -> false   (right)
+ *
+ * The trailing `(?![\w-])` is the whole point — the flag must not be followed
+ * by another word character or a hyphen, which is what distinguishes a flag
+ * from a longer flag that merely starts the same way.
+ *
+ * @param {unknown} helpText - captured stdout of `<cli> --help`.
+ * @param {string} flag - the exact flag, including leading dashes, e.g. '--remote'.
+ * @returns {boolean}
+ */
+export function cliHelpAdvertisesFlag(helpText, flag) {
+  if (typeof helpText !== 'string' || typeof flag !== 'string' || !flag) return false
+  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`${escaped}(?![\\w-])`).test(helpText)
+}

--- a/packages/server/src/utils/argv-safety.js
+++ b/packages/server/src/utils/argv-safety.js
@@ -97,9 +97,12 @@ export function assertSafeArgvValue(value, kind = 'value') {
  *     help.includes('--remote')   -> true    (wrong: opens the gate)
  *     cliHelpAdvertisesFlag(...)  -> false   (right)
  *
- * The trailing `(?![\w-])` is the whole point — the flag must not be followed
- * by another word character or a hyphen, which is what distinguishes a flag
- * from a longer flag that merely starts the same way.
+ * The boundaries are the whole point — the flag must be delimited on BOTH
+ * sides by something that is not a word character or a hyphen, which is what
+ * distinguishes a flag from a longer flag sharing its prefix or its suffix.
+ * A trailing-only test still returns true for `x--remote`, for `---remote`,
+ * and — the exact mirror of the defect this function exists to prevent — for
+ * a `-O` probe against a help line advertising `--O <file>`.
  *
  * @param {unknown} helpText - captured stdout of `<cli> --help`.
  * @param {string} flag - the exact flag, including leading dashes, e.g. '--remote'.
@@ -107,6 +110,50 @@ export function assertSafeArgvValue(value, kind = 'value') {
  */
 export function cliHelpAdvertisesFlag(helpText, flag) {
   if (typeof helpText !== 'string' || typeof flag !== 'string' || !flag) return false
-  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`${escaped}(?![\\w-])`).test(helpText)
+  return new RegExp(`(?<![\\w-])${escapeForRegExp(flag)}(?![\\w-])`).test(helpText)
+}
+
+/** Escape a flag so it can be interpolated into a RegExp body. */
+function escapeForRegExp(flag) {
+  return flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * How does a CLI's `--help` say `flag` is called — specifically, does it take
+ * a REQUIRED argument?
+ *
+ * This decides whether fix shape (2), the `--` separator, is safe, and the
+ * distinction is not cosmetic. Measured against the repo's commander 12.1.0
+ * with a client prompt of `--dangerously-skip-permissions`:
+ *
+ *     declared as       ['--remote', prompt]   ['--remote', '--', prompt]
+ *     --remote          INJECTS                safe
+ *     --remote [name]   INJECTS                safe
+ *     --remote <name>   safe — swallowed as    INJECTS — the `--` becomes the
+ *                       the flag's own value   flag's value, freeing the
+ *                                              prompt to be option-parsed
+ *
+ * So against a required-argument flag the separator is not merely useless, it
+ * is strictly WORSE than omitting it. No single argv shape is correct under
+ * both arities, so a caller must know which it faces and fail closed when it
+ * cannot tell.
+ *
+ * @param {unknown} helpText - captured stdout of `<cli> --help`.
+ * @param {string} flag - the exact flag, e.g. '--remote'.
+ * @returns {'absent'|'boolean'|'optional'|'required'}
+ */
+export function cliHelpFlagArity(helpText, flag) {
+  if (!cliHelpAdvertisesFlag(helpText, flag)) return 'absent'
+  // Inspect what follows the flag on its own help line, skipping any alias
+  // list (`--remote, -r <name>`).
+  const re = new RegExp(`(?<![\\w-])${escapeForRegExp(flag)}(?![\\w-])((?:,\\s*-[\\w-]+)*)([^\\n]*)`)
+  const m = re.exec(helpText)
+  if (!m) return 'boolean'
+  // Only a metavar BEFORE the description column counts. Two spaces or a tab
+  // start the description in every help format we target, so a `<file>` in
+  // prose ("same as --output <file>") is not mistaken for this flag's own.
+  const head = m[2].split(/ {2,}|\t/)[0]
+  if (/^[ =]*<[^>]+>/.test(head)) return 'required'
+  if (/^[ =]*\[[^\]]+\]/.test(head)) return 'optional'
+  return 'boolean'
 }

--- a/packages/server/src/web-task-manager.js
+++ b/packages/server/src/web-task-manager.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { execFile } from 'child_process'
 import { randomUUID } from 'crypto'
+import { cliHelpAdvertisesFlag } from './utils/argv-safety.js'
 
 /**
  * Manages Claude Code Web tasks (cloud sandbox delegation).
@@ -64,8 +65,16 @@ export class WebTaskManager extends EventEmitter {
     const exec = deps.exec || execFileAsync
     try {
       const stdout = await exec('claude', ['--help'])
-      this._remoteAvailable = stdout.includes('--remote')
-      this._teleportAvailable = stdout.includes('--teleport')
+      // #7291: this was `stdout.includes('--remote')`, a SUBSTRING match, which
+      // is satisfied by the LONGER flag `--remote-control`. The installed CLI
+      // advertises `--remote-control` and `--remote-control-session-name-prefix`
+      // and has NO `--remote` at all, so the gate reported the feature
+      // available on a CLI that cannot accept it — a check that reports success
+      // without checking (docs/false-safety-guards.md), and the very thing that
+      // was supposed to keep a client prompt out of the argv in
+      // _spawnRemoteTask below.
+      this._remoteAvailable = cliHelpAdvertisesFlag(stdout, '--remote')
+      this._teleportAvailable = cliHelpAdvertisesFlag(stdout, '--teleport')
     } catch {
       this._remoteAvailable = false
       this._teleportAvailable = false
@@ -190,7 +199,7 @@ export class WebTaskManager extends EventEmitter {
    */
   _spawnRemoteTask(task) {
     // Use execFile with args array to prevent command injection
-    const child = execFile('claude', ['--remote', task.prompt], { cwd: task.cwd, timeout: 300_000 }, (err, stdout, stderr) => {
+    const child = execFile('claude', buildRemoteTaskArgs(task.prompt), { cwd: task.cwd, timeout: 300_000 }, (err, stdout, stderr) => {
       this._childProcesses.delete(child)
 
       if (err) {
@@ -367,6 +376,36 @@ export class WebTaskUnavailableError extends Error {
     this.name = 'WebTaskUnavailableError'
     this.code = 'WEB_TASK_UNAVAILABLE'
   }
+}
+
+/**
+ * Build the argv for a remote web task (#7291).
+ *
+ * `prompt` is the highest-trust-boundary string here — it comes straight from
+ * the client. It used to sit in a bare positional slot (`['--remote', prompt]`),
+ * so a prompt beginning with `-` was parsed by the CLI as an OPTION rather
+ * than as the task text.
+ *
+ * A prompt legitimately CAN begin with a dash ("- first point", "-- aside"),
+ * so REJECTING one would break normal use. The correct fix for a
+ * legitimately-dash-leading value is a `--` end-of-options separator with
+ * every flag placed BEFORE it — see utils/argv-safety.js.
+ *
+ * Verification note: the currently-shipping Claude Code CLI has no `--remote`
+ * flag at all (it has `--remote-control`), so this argv cannot be exercised
+ * against a live binary today — and after the detectFeatures fix above, the
+ * gate correctly keeps this path closed on such a CLI. The shape is asserted
+ * against the CLI's documented grammar, `claude [options] [command] [prompt]`,
+ * in which the prompt is positional and `--` therefore protects it. That `--`
+ * is honoured was measured directly against the installed binary:
+ * `claude --nonexistent-flag-xyz` errors "unknown option", while
+ * `claude -- --nonexistent-flag-xyz` does not.
+ *
+ * @param {string} prompt - client-supplied task text.
+ * @returns {string[]}
+ */
+export function buildRemoteTaskArgs(prompt) {
+  return ['--remote', '--', prompt]
 }
 
 /**

--- a/packages/server/src/web-task-manager.js
+++ b/packages/server/src/web-task-manager.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { execFile } from 'child_process'
 import { randomUUID } from 'crypto'
-import { cliHelpAdvertisesFlag } from './utils/argv-safety.js'
+import { cliHelpAdvertisesFlag, cliHelpFlagArity } from './utils/argv-safety.js'
 
 /**
  * Manages Claude Code Web tasks (cloud sandbox delegation).
@@ -73,7 +73,18 @@ export class WebTaskManager extends EventEmitter {
       // without checking (docs/false-safety-guards.md), and the very thing that
       // was supposed to keep a client prompt out of the argv in
       // _spawnRemoteTask below.
-      this._remoteAvailable = cliHelpAdvertisesFlag(stdout, '--remote')
+      //
+      // The arity check is the second half, and it is load-bearing:
+      // buildRemoteTaskArgs protects the prompt with a `--` separator, and a
+      // separator is only correct when `--remote` is boolean or takes an
+      // OPTIONAL argument. Against a REQUIRED-argument `--remote <name>` the
+      // `--` is consumed as the flag's value and the prompt is freed to be
+      // option-parsed — strictly worse than no separator at all (measured
+      // against commander 12.1.0; the table is in utils/argv-safety.js). We
+      // cannot make one argv correct under both arities, so when the help
+      // advertises a required argument we refuse the feature instead.
+      const remoteArity = cliHelpFlagArity(stdout, '--remote')
+      this._remoteAvailable = remoteArity === 'boolean' || remoteArity === 'optional'
       this._teleportAvailable = cliHelpAdvertisesFlag(stdout, '--teleport')
     } catch {
       this._remoteAvailable = false

--- a/packages/server/src/ws-file-ops/reader.js
+++ b/packages/server/src/ws-file-ops/reader.js
@@ -562,15 +562,13 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
 
       const rawBase = (typeof base === 'string' && base.trim()) ? base.trim() : 'HEAD'
       // #7290: `base` is client-controlled and UNVALIDATED on the wire —
-      // ClientGetDiffSchema is `z.object({ type }).passthrough()` — and it lands
-      // in the REVISION slot of `git diff <base>`. The charset allowlist below
+      // GetDiffSchema is `z.object({ type }).passthrough()` — and it lands in
+      // the REVISION slot of `git diff <base>`. The charset allowlist below
       // used to be the only check, and it put `-` INSIDE its character class,
       // so every single-token option passed it: `--stat`, `-p`, `--exit-code`,
       // `--ext-diff`, and `-O<path>` — which makes git read <path> as a diff
       // orderfile and report whether it could, straight back to the client via
-      // the `error: err.message` branches below. That is a filesystem
-      // existence/readability oracle over the whole disk, as the daemon user,
-      // escaping the session cwd entirely.
+      // the `error: err.message` branches below.
       //
       // isSafeArgvValue is the load-bearing half (it rejects the leading dash);
       // the allowlist stays as a charset narrowing. A `--` separator canNOT
@@ -578,6 +576,22 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       // A git revision can never legitimately begin with `-`, so REJECTING is
       // correct here; falling back to 'HEAD' preserves the pre-existing
       // contract for any unusable base.
+      //
+      // SCOPE — this closes the LEADING-DASH route and only that. A path
+      // oracle survives here that needs no dash at all, because `:` and `/`
+      // are both in the charset and git's stderr is forwarded verbatim:
+      //
+      //     base='HEAD:/etc/passwd' -> fatal: path '/etc/passwd' exists on
+      //                                disk, but not in 'HEAD'
+      //     base='HEAD:absent'      -> fatal: path 'absent' does not exist in 'HEAD'
+      //     base='/etc/passwd'      -> fatal: '/etc/passwd' is outside repository
+      //     base='/no/such/file'    -> fatal: ambiguous argument ...
+      //
+      // That is pre-existing (charset and stderr-forwarding are both unchanged
+      // by #7290) and is tracked separately; closing it means resolving the
+      // base with `rev-parse --verify` and not forwarding raw git stderr,
+      // which is a wider contract change than this fix. Do not read the guard
+      // below as sealing the oracle — it seals one route into it.
       const diffBase = (isSafeArgvValue(rawBase) && /^[a-zA-Z0-9._\-\/~^@{}:]+$/.test(rawBase))
         ? rawBase
         : 'HEAD'

--- a/packages/server/src/ws-file-ops/reader.js
+++ b/packages/server/src/ws-file-ops/reader.js
@@ -6,6 +6,7 @@ import { promisify } from 'util'
 import { parseDiff } from '../diff-parser.js'
 import { GIT } from '../git.js'
 import { isPathWithin } from '../utils/path-containment.js'
+import { isSafeArgvValue } from '../utils/argv-safety.js'
 
 const execFileAsync = promisify(execFileCb)
 
@@ -560,8 +561,26 @@ export function createReaderOps(sendFn, resolveSessionCwd, validatePathWithinCwd
       }
 
       const rawBase = (typeof base === 'string' && base.trim()) ? base.trim() : 'HEAD'
-      // Validate ref name to prevent git flag injection
-      const diffBase = /^[a-zA-Z0-9._\-\/~^@{}:]+$/.test(rawBase) ? rawBase : 'HEAD'
+      // #7290: `base` is client-controlled and UNVALIDATED on the wire —
+      // ClientGetDiffSchema is `z.object({ type }).passthrough()` — and it lands
+      // in the REVISION slot of `git diff <base>`. The charset allowlist below
+      // used to be the only check, and it put `-` INSIDE its character class,
+      // so every single-token option passed it: `--stat`, `-p`, `--exit-code`,
+      // `--ext-diff`, and `-O<path>` — which makes git read <path> as a diff
+      // orderfile and report whether it could, straight back to the client via
+      // the `error: err.message` branches below. That is a filesystem
+      // existence/readability oracle over the whole disk, as the daemon user,
+      // escaping the session cwd entirely.
+      //
+      // isSafeArgvValue is the load-bearing half (it rejects the leading dash);
+      // the allowlist stays as a charset narrowing. A `--` separator canNOT
+      // substitute for either — see utils/argv-safety.js for the measurements.
+      // A git revision can never legitimately begin with `-`, so REJECTING is
+      // correct here; falling back to 'HEAD' preserves the pre-existing
+      // contract for any unusable base.
+      const diffBase = (isSafeArgvValue(rawBase) && /^[a-zA-Z0-9._\-\/~^@{}:]+$/.test(rawBase))
+        ? rawBase
+        : 'HEAD'
 
       let diffOutput = ''
       try {

--- a/packages/server/tests/argv-safety.test.js
+++ b/packages/server/tests/argv-safety.test.js
@@ -1,0 +1,138 @@
+/**
+ * Tests for the shared argv option-injection guards (#7290, #7291).
+ *
+ * Every case here is a NEGATIVE CONTROL in the sense of
+ * docs/false-safety-guards.md: it asserts a value the guard must REFUSE (or a
+ * flag it must NOT claim), so weakening the guard turns it red. Cases that
+ * assert acceptance are labelled as positive controls — without them a guard
+ * that simply refused everything would pass the whole file.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isSafeArgvValue,
+  assertSafeArgvValue,
+  cliHelpAdvertisesFlag,
+} from '../src/utils/argv-safety.js'
+
+describe('isSafeArgvValue', () => {
+  it('refuses every leading-dash form git/CLIs parse as an option', () => {
+    // Measured against git 2.54.0 while fixing #7290: each of these was
+    // accepted by the old `/^[a-zA-Z0-9._\-\/~^@{}:]+$/` allowlist (which put
+    // `-` INSIDE the character class) and then option-parsed by git.
+    for (const v of [
+      '--stat', '-p', '--raw', '--exit-code', '--ext-diff', '--word-diff',
+      '-U99999', '-O/etc/passwd', '--no-index', '-', '--',
+      '--dangerously-skip-permissions', '--print',
+    ]) {
+      assert.equal(isSafeArgvValue(v), false, `must refuse ${JSON.stringify(v)}`)
+    }
+  })
+
+  it('refuses NUL / CR / LF, which can smuggle a second argument', () => {
+    for (const v of ['a\0b', 'a\nb', 'a\r\nb', 'main\n--upload-pack=x', '\n']) {
+      assert.equal(isSafeArgvValue(v), false, `must refuse ${JSON.stringify(v)}`)
+    }
+  })
+
+  it('refuses non-strings and the empty string', () => {
+    for (const v of [null, undefined, 0, 42, {}, [], true, '']) {
+      assert.equal(isSafeArgvValue(v), false, `must refuse ${JSON.stringify(v)}`)
+    }
+  })
+
+  // POSITIVE CONTROL — a guard that refused everything would pass all of the
+  // above. These are the values real callers depend on.
+  it('accepts legitimate refs, branches and names (positive control)', () => {
+    for (const v of [
+      'HEAD', 'HEAD~1', 'HEAD^', 'main', 'origin/main', 'feature/argv-fix',
+      'v1.2.3', 'a1b2c3d', 'refs/heads/main', '@', 'HEAD@{1}',
+      'release-2026', 'my-branch', 'x',
+    ]) {
+      assert.equal(isSafeArgvValue(v), true, `must accept ${JSON.stringify(v)}`)
+    }
+  })
+
+  it('accepts a dash that is not leading', () => {
+    // The check is about POSITION, not about the character.
+    assert.equal(isSafeArgvValue('my-branch'), true)
+    assert.equal(isSafeArgvValue('a--b'), true)
+    assert.equal(isSafeArgvValue('-a'), false)
+  })
+})
+
+describe('assertSafeArgvValue', () => {
+  it('throws on a dash-leading value, naming the kind', () => {
+    assert.throws(() => assertSafeArgvValue('--stat', 'ref'), /unsafe ref/)
+    assert.throws(() => assertSafeArgvValue('-x', 'branch'), /unsafe branch/)
+  })
+
+  it('distinguishes empty from unsafe', () => {
+    // orchestration/git-ops.js pins this split — its callers surface the two
+    // as different GitOpsError messages.
+    assert.throws(() => assertSafeArgvValue('', 'ref'), /empty ref/)
+    assert.throws(() => assertSafeArgvValue(null, 'ref'), /empty ref/)
+    assert.throws(() => assertSafeArgvValue('-x', 'ref'), /unsafe ref/)
+  })
+
+  it('does not throw for a legitimate value (positive control)', () => {
+    assert.doesNotThrow(() => assertSafeArgvValue('main', 'branch'))
+  })
+})
+
+describe('cliHelpAdvertisesFlag', () => {
+  // The #7291 defect, verbatim. The installed Claude Code CLI advertises
+  // --remote-control and --remote-control-session-name-prefix, and has NO
+  // --remote — yet `help.includes('--remote')` returns true.
+  const REAL_HELP = [
+    'Usage: claude [options] [command] [prompt]',
+    '  --remote-control                       Enable remote control',
+    '  --remote-control-session-name-prefix <prefix>  Prefix',
+    '  --teleport                             Teleport a task',
+    '  --print                                Non-interactive output',
+  ].join('\n')
+
+  it('does not let a LONGER flag satisfy a shorter probe', () => {
+    assert.equal(cliHelpAdvertisesFlag(REAL_HELP, '--remote'), false)
+    // The bug this replaces, asserted explicitly so the contrast is pinned:
+    assert.equal(REAL_HELP.includes('--remote'), true,
+      'the naive substring check really does say true — that is the defect')
+  })
+
+  it('detects a flag that IS advertised (positive control)', () => {
+    assert.equal(cliHelpAdvertisesFlag(REAL_HELP, '--teleport'), true)
+    assert.equal(cliHelpAdvertisesFlag(REAL_HELP, '--print'), true)
+    assert.equal(cliHelpAdvertisesFlag(REAL_HELP, '--remote-control'), true)
+  })
+
+  it('accepts a flag at any legitimate boundary', () => {
+    assert.equal(cliHelpAdvertisesFlag('  --remote\n', '--remote'), true, 'newline')
+    assert.equal(cliHelpAdvertisesFlag('  --remote', '--remote'), true, 'end of string')
+    assert.equal(cliHelpAdvertisesFlag('  --remote  Launch', '--remote'), true, 'space')
+    assert.equal(cliHelpAdvertisesFlag('  --remote=<url>', '--remote'), true, 'equals')
+    assert.equal(cliHelpAdvertisesFlag('  --remote, -r', '--remote'), true, 'comma')
+  })
+
+  it('rejects a flag only ever seen as a longer one', () => {
+    assert.equal(cliHelpAdvertisesFlag('--remotely', '--remote'), false)
+    assert.equal(cliHelpAdvertisesFlag('--remote_control', '--remote'), false)
+    assert.equal(cliHelpAdvertisesFlag('--remote-control', '--remote'), false)
+  })
+
+  it('treats a missing or non-string help text as "not advertised"', () => {
+    // "cannot check this" must never be read as "nothing to check" — the
+    // #7195 / #7210 shape. Failing closed is the only safe answer.
+    for (const h of [undefined, null, 0, {}, '']) {
+      assert.equal(cliHelpAdvertisesFlag(h, '--remote'), false)
+    }
+    assert.equal(cliHelpAdvertisesFlag('--remote', ''), false, 'empty flag')
+  })
+
+  it('does not let a regex metacharacter in the flag change the match', () => {
+    // The flag is interpolated into a RegExp, so it must be escaped.
+    assert.equal(cliHelpAdvertisesFlag('--a.c', '--a.c'), true)
+    assert.equal(cliHelpAdvertisesFlag('--abc', '--a.c'), false,
+      'an unescaped "." would match "b" here')
+  })
+})

--- a/packages/server/tests/argv-safety.test.js
+++ b/packages/server/tests/argv-safety.test.js
@@ -14,6 +14,7 @@ import {
   isSafeArgvValue,
   assertSafeArgvValue,
   cliHelpAdvertisesFlag,
+  cliHelpFlagArity,
 } from '../src/utils/argv-safety.js'
 
 describe('isSafeArgvValue', () => {
@@ -134,5 +135,58 @@ describe('cliHelpAdvertisesFlag', () => {
     assert.equal(cliHelpAdvertisesFlag('--a.c', '--a.c'), true)
     assert.equal(cliHelpAdvertisesFlag('--abc', '--a.c'), false,
       'an unescaped "." would match "b" here')
+  })
+})
+
+describe('cliHelpAdvertisesFlag — boundaries on BOTH sides', () => {
+  // A trailing-only lookahead (the first cut of this guard) returned true for
+  // all three of these. The third is the exact mirror of the #7291 defect the
+  // function exists to prevent: a SHORTER probe satisfied by a LONGER flag.
+  it('refuses a match that is not left-delimited', () => {
+    assert.equal(cliHelpAdvertisesFlag('x--remote', '--remote'), false)
+    assert.equal(cliHelpAdvertisesFlag('---remote', '--remote'), false)
+    assert.equal(cliHelpAdvertisesFlag('  --O <file>   Order file', '-O'), false)
+  })
+
+  it('still accepts a genuinely advertised flag (positive control)', () => {
+    assert.equal(cliHelpAdvertisesFlag('  --remote', '--remote'), true)
+    assert.equal(cliHelpAdvertisesFlag('  --remote, -r   Go', '--remote'), true)
+    assert.equal(cliHelpAdvertisesFlag('Usage: x [--remote]', '--remote'), true)
+  })
+})
+
+describe('cliHelpFlagArity', () => {
+  // Which fix shape is safe depends on this. Against a REQUIRED-argument flag
+  // a `--` separator is consumed as the flag's value and frees the client
+  // string to be option-parsed — strictly worse than no separator.
+  it('reads the metavar that follows the flag', () => {
+    assert.equal(cliHelpFlagArity('  --remote            Launch', '--remote'), 'boolean')
+    assert.equal(cliHelpFlagArity('  --remote <name>     Launch', '--remote'), 'required')
+    assert.equal(cliHelpFlagArity('  --remote [name]     Launch', '--remote'), 'optional')
+    assert.equal(cliHelpFlagArity('  --remote=<url>      Launch', '--remote'), 'required')
+  })
+
+  it('skips an alias list before the metavar', () => {
+    assert.equal(cliHelpFlagArity('  --remote, -r        Launch', '--remote'), 'boolean')
+    assert.equal(cliHelpFlagArity('  --remote, -r <n>    Launch', '--remote'), 'required')
+  })
+
+  it('does not read a metavar out of the DESCRIPTION column', () => {
+    // Two spaces start the description, so `<file>` there belongs to the prose,
+    // not to this flag. Without that rule the arity would be misread and the
+    // caller would refuse a perfectly usable boolean flag.
+    assert.equal(cliHelpFlagArity('  --remote    Same as --output <file>', '--remote'), 'boolean')
+  })
+
+  it('returns absent for a flag that is not advertised', () => {
+    assert.equal(cliHelpFlagArity('  --remote-control  Enable', '--remote'), 'absent')
+    assert.equal(cliHelpFlagArity('nothing here', '--remote'), 'absent')
+  })
+
+  it('errs toward "required" — the fail-closed direction — when a flag appears only in prose', () => {
+    // Known limitation: an unanchored match can pick up a flag named in prose.
+    // It resolves to 'required', which makes the caller REFUSE the feature.
+    // Documented deliberately: the wrong answer here is the safe one.
+    assert.equal(cliHelpFlagArity('  --local   Opposite of --remote <x>', '--remote'), 'required')
   })
 })

--- a/packages/server/tests/argv-safety.test.js
+++ b/packages/server/tests/argv-safety.test.js
@@ -130,6 +130,19 @@ describe('cliHelpAdvertisesFlag', () => {
     assert.equal(cliHelpAdvertisesFlag('--remote', ''), false, 'empty flag')
   })
 
+  it('the non-string guard is load-bearing, not decoration', () => {
+    // The fixtures above are NOT a control for the `typeof helpText` check:
+    // every one of them coerces to a string that does not contain the flag, so
+    // RegExp.test() answers false by itself and the assertion passes with the
+    // type guard deleted. Review caught that. These two do not have that
+    // property — both coerce to a string that DOES contain the flag, so
+    // without the type guard they would report it as advertised.
+    assert.equal(cliHelpAdvertisesFlag(['--remote'], '--remote'), false,
+      'an array coercing to "--remote" must not satisfy the probe')
+    assert.equal(cliHelpAdvertisesFlag({ toString: () => '  --remote' }, '--remote'), false,
+      'an object coercing to help text must not satisfy the probe')
+  })
+
   it('does not let a regex metacharacter in the flag change the match', () => {
     // The flag is interpolated into a RegExp, so it must be escaped.
     assert.equal(cliHelpAdvertisesFlag('--a.c', '--a.c'), true)

--- a/packages/server/tests/web-task-manager.test.js
+++ b/packages/server/tests/web-task-manager.test.js
@@ -468,9 +468,22 @@ describe('WebTaskManager', () => {
         assert.ok(sep !== -1 && sep < args.length - 1,
           `no separator protects ${prompt}`)
         assert.equal(args[args.length - 1], prompt, 'prompt must survive verbatim')
-        assert.ok(args.indexOf(prompt) > sep,
-          `${prompt} must appear only AFTER the separator`)
+        // Assert by POSITION, not by searching for the value. `indexOf(prompt)`
+        // returns the separator's own index when the prompt is exactly '--',
+        // so it would fail against a CORRECT implementation.
+        assert.equal(sep, args.length - 2,
+          `the separator must sit immediately before ${JSON.stringify(prompt)}`)
       }
+    })
+
+    it('protects a prompt that is exactly the separator', () => {
+      // The degenerate input the assertion above used to get wrong. '--' is a
+      // legitimate thing for a user to type and must arrive as TEXT.
+      const args = buildRemoteTaskArgs('--')
+      assert.equal(args[args.length - 1], '--', 'the prompt survives verbatim')
+      assert.equal(args.indexOf('--'), args.length - 2,
+        'the FIRST -- is the separator; the second is the prompt')
+      assert.equal(args.filter(a => a === '--').length, 2)
     })
   })
 

--- a/packages/server/tests/web-task-manager.test.js
+++ b/packages/server/tests/web-task-manager.test.js
@@ -474,4 +474,66 @@ describe('WebTaskManager', () => {
     })
   })
 
+
+  describe('#7291 --remote arity gate', () => {
+    // buildRemoteTaskArgs protects the prompt with a `--`, and a separator is
+    // only correct for a boolean or optional-arg flag. Against a REQUIRED-arg
+    // `--remote <name>` the `--` becomes the flag's value and the prompt is
+    // freed to be option-parsed — strictly WORSE than no separator (measured
+    // against commander 12.1.0). Since no argv is correct under both arities,
+    // the gate must refuse rather than guess.
+    const withRemote = (decl) => `Usage: claude [options]\n  ${decl}   Launch a web task\n  --teleport <id>   Teleport\n`
+
+    it('refuses the feature when --remote takes a REQUIRED argument', async () => {
+      manager = new WebTaskManager()
+      const features = await manager.detectFeatures({ exec: async () => withRemote('--remote <name>') })
+      assert.equal(features.remote, false,
+        'a required-arg --remote cannot be protected by a -- separator, so it must be refused')
+      assert.equal(manager.isAvailable, false)
+      // Positive control in the same fixture: --teleport is unaffected.
+      assert.equal(features.teleport, true)
+    })
+
+    it('allows boolean and optional-arg --remote (positive control)', async () => {
+      for (const decl of ['--remote', '--remote [name]']) {
+        const m = new WebTaskManager()
+        const features = await m.detectFeatures({ exec: async () => withRemote(decl) })
+        assert.equal(features.remote, true, `${decl} must remain available`)
+        m.destroy()
+      }
+    })
+  })
+
+  describe('#7291 the production call site is wired to the builder', () => {
+    // buildRemoteTaskArgs is covered as a pure function above, but EVERY other
+    // test in this file stubs `_spawnRemoteTask` to avoid spawning a real
+    // process — so nothing observes that the real one actually CALLS the
+    // builder. Someone could inline `['--remote', prompt]` back into
+    // _spawnRemoteTask and the whole suite would stay green: the guard would
+    // be wired to none of its callers.
+    //
+    // execFile is a module-scope import with no injection seam, and
+    // mock.module of a global leaks across the parallel test runner, so this
+    // asserts on the SOURCE instead. It is deliberately narrow: it checks the
+    // call site names the builder and does not build an argv literal itself.
+    it('_spawnRemoteTask passes buildRemoteTaskArgs(...) to execFile, not a literal argv', async () => {
+      const { readFileSync } = await import('node:fs')
+      const { fileURLToPath } = await import('node:url')
+      const { join, dirname } = await import('node:path')
+      const src = readFileSync(
+        join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'web-task-manager.js'),
+        'utf8',
+      )
+      // Anchor on the METHOD DEFINITION, not the call in launchTask.
+      const defIdx = src.indexOf('_spawnRemoteTask(task) {')
+      assert.ok(defIdx !== -1, '_spawnRemoteTask definition not found')
+      const callSite = src.slice(defIdx, src.indexOf('\n  }', defIdx))
+
+      assert.match(callSite, /execFile\('claude', buildRemoteTaskArgs\(task\.prompt\)/,
+        '_spawnRemoteTask must delegate its argv to buildRemoteTaskArgs')
+      assert.ok(!/\[\s*'--remote'\s*,/.test(callSite),
+        '_spawnRemoteTask must not construct an argv literal of its own')
+    })
+  })
+
 })

--- a/packages/server/tests/web-task-manager.test.js
+++ b/packages/server/tests/web-task-manager.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { WebTaskManager, WebTaskUnavailableError } from '../src/web-task-manager.js'
+import { WebTaskManager, WebTaskUnavailableError, buildRemoteTaskArgs } from '../src/web-task-manager.js'
 
 describe('WebTaskManager', () => {
   let manager
@@ -35,6 +35,49 @@ describe('WebTaskManager', () => {
       const features = await manager.detectFeatures({ exec: async () => 'Usage:\n  --remote\n  --teleport\n' })
       assert.equal(manager.isAvailable, true)
       assert.equal(manager.teleportAvailable, true)
+      assert.deepEqual(features, { remote: true, teleport: true })
+    })
+
+    // ── #7291: the availability gate is a substring match ─────────────────
+    //
+    // The test above ('...lacks --remote') feeds a help text containing no
+    // '--remote' substring AT ALL, so a naive `.includes('--remote')` already
+    // answers it correctly. It passes before and after this fix and proves
+    // nothing — the textbook false-safety test shape from
+    // docs/false-safety-guards.md.
+    //
+    // The control that actually bites is a help text carrying a LONGER flag
+    // that merely starts the same way. This is the real installed CLI's shape:
+    // it advertises --remote-control and --remote-control-session-name-prefix
+    // and has no --remote at all, so the old gate reported the flag available
+    // on a CLI that cannot accept it, opening the argv in _spawnRemoteTask.
+    it('#7291: --remote-control in --help must NOT be read as --remote', async () => {
+      manager = new WebTaskManager()
+      // Verbatim shape of the installed Claude Code CLI's help text.
+      const help = [
+        'Usage: claude [options] [command] [prompt]',
+        '  --remote-control                      Enable remote control',
+        '  --remote-control-session-name-prefix <prefix>',
+        '  --teleport                            Teleport a task',
+      ].join('\n')
+
+      const features = await manager.detectFeatures({ exec: async () => help })
+
+      assert.equal(features.remote, false,
+        '--remote-control must not satisfy a --remote probe')
+      assert.equal(manager.isAvailable, false)
+      // POSITIVE CONTROL in the same fixture: --teleport IS genuinely present,
+      // so a guard that simply answered "false" to everything would fail here.
+      assert.equal(features.teleport, true, '--teleport is really advertised')
+    })
+
+    it('#7291: an exactly-matching flag is still detected (positive control)', async () => {
+      manager = new WebTaskManager()
+      // --remote at end-of-line, and --teleport followed by whitespace: both
+      // are genuine advertisements and must still register.
+      const features = await manager.detectFeatures({
+        exec: async () => 'Usage:\n  --remote\n  --teleport <id>   Teleport\n',
+      })
       assert.deepEqual(features, { remote: true, teleport: true })
     })
 
@@ -403,4 +446,32 @@ describe('WebTaskManager', () => {
       assert.ok(err.message.includes('--remote'))
     })
   })
+
+  describe('#7291 remote task argv', () => {
+    it('puts a -- separator before the client prompt', () => {
+      const args = buildRemoteTaskArgs('do the thing')
+      const sep = args.indexOf('--')
+      assert.ok(sep !== -1, 'argv must carry an end-of-options separator')
+      assert.equal(args[sep + 1], 'do the thing', 'the prompt must sit AFTER the --')
+      // Every flag must precede the separator, or it becomes positional text.
+      for (const a of args.slice(sep + 2)) {
+        assert.ok(!a.startsWith('-'), `flag ${a} must not follow the --`)
+      }
+    })
+
+    it('keeps a dash-leading prompt as TEXT rather than rejecting it', () => {
+      // A prompt legitimately can start with a dash. The fix must not refuse
+      // it — it must stop it being OPTION-PARSED while preserving it verbatim.
+      for (const prompt of ['--print', '--dangerously-skip-permissions', '-p', '- a bullet']) {
+        const args = buildRemoteTaskArgs(prompt)
+        const sep = args.indexOf('--')
+        assert.ok(sep !== -1 && sep < args.length - 1,
+          `no separator protects ${prompt}`)
+        assert.equal(args[args.length - 1], prompt, 'prompt must survive verbatim')
+        assert.ok(args.indexOf(prompt) > sep,
+          `${prompt} must appear only AFTER the separator`)
+      }
+    })
+  })
+
 })

--- a/packages/server/tests/ws-server-file-ops.test.js
+++ b/packages/server/tests/ws-server-file-ops.test.js
@@ -1300,6 +1300,108 @@ describe('get_diff handler', () => {
       rmSync(nonGitDir, { recursive: true, force: true })
     }
   })
+
+  // ── #7290: the `base` revision must never reach git as an OPTION ──────────
+  //
+  // `base` arrives from the wire unvalidated — ClientGetDiffSchema is
+  // `z.object({ type: z.literal('get_diff') }).passthrough()`, so the field is
+  // not constrained at all — and lands in the REVISION slot of
+  // `git diff <base>`. The old allowlist put `-` INSIDE its character class,
+  // so every single-token option passed it.
+  //
+  // These are NEGATIVE CONTROLS, per docs/false-safety-guards.md: each one
+  // observes a git behaviour that is only reachable when the option was
+  // actually parsed. Delete the leading-dash rejection and they go red.
+  //
+  // NOTE `['diff', base, '--']` does NOT fix this and these tests prove it:
+  // `--` ends option parsing at ITS position, and `base` precedes it.
+
+  it('#7290: -O<path> does not become a git orderfile read (filesystem oracle)', async () => {
+    // `git diff -O<file>` reads <file> as a diff order file. git reports
+    // whether it could read it, and getDiff forwards raw git stderr to the
+    // client (reader.js `error: err.message`) — so an unguarded `-O` is a
+    // file existence/readability oracle over the WHOLE filesystem, as the
+    // daemon user, escaping the session cwd entirely.
+    writeFileSync(join(tempDir, 'file.txt'), 'modified content\n')
+    const { ws, messages } = await createDiffTestServer()
+
+    send(ws, { type: 'get_diff', base: '-O/chroxy-7290-no-such-orderfile' })
+    const result = await waitForMessage(messages, 'diff_result', 5000)
+
+    // The oracle's tell. Present iff git parsed `-O` as an option.
+    assert.ok(
+      !/orderfile/i.test(result.error || ''),
+      `git must never see -O as an option; got error: ${result.error}`
+    )
+    // And it must still behave like an unrecognised base: fall back to HEAD.
+    assert.equal(result.error, null)
+    assert.equal(result.files.length, 1)
+
+    ws.close()
+  })
+
+  it('#7290: --exit-code does not become a git option', async () => {
+    // `git diff --exit-code` exits 1 when there are changes, which execFile
+    // surfaces as a rejection — so an unguarded `--exit-code` turns a healthy
+    // diff into a wire error.
+    writeFileSync(join(tempDir, 'file.txt'), 'modified content\n')
+    const { ws, messages } = await createDiffTestServer()
+
+    send(ws, { type: 'get_diff', base: '--exit-code' })
+    const result = await waitForMessage(messages, 'diff_result', 5000)
+
+    assert.equal(result.error, null, 'a dash-leading base must not reach git')
+    assert.equal(result.files.length, 1)
+
+    ws.close()
+  })
+
+  it('#7290: --stat does not become a git option', async () => {
+    // `git diff --stat` emits a summary, not a unified diff, so parseDiff
+    // yields ZERO files. An unguarded `--stat` silently empties the diff view.
+    writeFileSync(join(tempDir, 'file.txt'), 'modified content\n')
+    const { ws, messages } = await createDiffTestServer()
+
+    send(ws, { type: 'get_diff', base: '--stat' })
+    const result = await waitForMessage(messages, 'diff_result', 5000)
+
+    assert.equal(result.error, null)
+    assert.equal(result.files.length, 1, '--stat must not replace the unified diff')
+    assert.ok(result.files[0].hunks.length > 0, 'hunks are lost when --stat is parsed')
+
+    ws.close()
+  })
+
+  // POSITIVE CONTROL — the guard must not be vacuous. A legitimate revision
+  // still reaches git and still selects a real base. Without this, a guard
+  // that rejected EVERYTHING would pass all three tests above.
+  it('#7290: a legitimate revision is still honoured (positive control)', async () => {
+    // Second commit, so HEAD~1 names a base that differs from HEAD and the
+    // choice of base is observable in the output.
+    writeFileSync(join(tempDir, 'file.txt'), 'second content\n')
+    execFileSync(GIT, ['add', 'file.txt'], { cwd: tempDir, stdio: 'pipe' })
+    execFileSync(GIT, ['commit', '-m', 'second'], { cwd: tempDir, stdio: 'pipe' })
+
+    const { ws, messages } = await createDiffTestServer()
+
+    // vs HEAD: the tree is clean, so no files.
+    send(ws, { type: 'get_diff', base: 'HEAD' })
+    const clean = await waitForMessage(messages, 'diff_result', 5000)
+    assert.equal(clean.error, null)
+    assert.deepEqual(clean.files, [], 'HEAD must compare against the last commit')
+
+    // vs HEAD~1: the second commit shows up. Proves the base was really used.
+    // waitForMessage() scans an ACCUMULATING array with .find(), so it would
+    // re-read the reply above. Clear it before the second round-trip.
+    messages.length = 0
+    send(ws, { type: 'get_diff', base: 'HEAD~1' })
+    const prev = await waitForMessage(messages, 'diff_result', 5000)
+    assert.equal(prev.error, null)
+    assert.equal(prev.files.length, 1, 'HEAD~1 must reach git as a real revision')
+    assert.equal(prev.files[0].path, 'file.txt')
+
+    ws.close()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/server/tests/ws-server-file-ops.test.js
+++ b/packages/server/tests/ws-server-file-ops.test.js
@@ -1303,7 +1303,7 @@ describe('get_diff handler', () => {
 
   // ── #7290: the `base` revision must never reach git as an OPTION ──────────
   //
-  // `base` arrives from the wire unvalidated — ClientGetDiffSchema is
+  // `base` arrives from the wire unvalidated — GetDiffSchema is
   // `z.object({ type: z.literal('get_diff') }).passthrough()`, so the field is
   // not constrained at all — and lands in the REVISION slot of
   // `git diff <base>`. The old allowlist put `-` INSIDE its character class,


### PR DESCRIPTION
## What

`execFile` with an array argv blocks **shell** injection — no shell ever sees the string.
It does not block **argument** injection: the spawned program still runs its own option
parser over that array, so a client-controlled value beginning with `-` is read as an
option. Three sites got that wrong, in two different ways, and the guards that were
supposed to stop it described stronger checks than they performed.

Closes #7290. Partially addresses #7291 — see *Deliberately left out* below.

## The `getDiff` revision allowlist (#7290)

```js
// Validate ref name to prevent git flag injection
const diffBase = /^[a-zA-Z0-9._\-\/~^@{}:]+$/.test(rawBase) ? rawBase : 'HEAD'
```

`-` is inside the character class, so it is a permitted *character*, and the regex says
nothing about *position*. Measured against git 2.54.0, every single-token option passed
and was then parsed as an option: `--stat`, `-p`, `--raw`, `--exit-code`, `--ext-diff`,
`--word-diff`, `-U99999`, `-O<path>`. Only forms containing `=` were blocked, and only
because `=` is absent from the class — an accident, not a defence.

`base` is unconstrained on the wire: `ClientGetDiffSchema` is
`z.object({ type: z.literal('get_diff') }).passthrough()`, and `handleGetDiff` passes
`msg.base` straight through. One hop, no guard.

**The impact is larger than the issue estimated.** `git diff -O<file>` reads `<file>` as a
diff orderfile, and `getDiff` forwards raw git stderr to the client
(`error: err.message`). That makes `-O` a **file existence/readability oracle over the
entire filesystem, as the daemon user, escaping the session cwd**, with the answer
returned on the wire:

```
-O/etc/passwd            -> (silent: readable)
-O/etc/shadow            -> fatal: failed to read orderfile … No such file or directory
-O~/.ssh                 -> fatal: … Is a directory
-O~/.chroxy/config.json  -> (silent: readable — outside the workspace)
```

### The issue's own suggested fix does not work

#7290 suggests `['diff', diffBase, '--']`. Measured — it does not help, because `--` ends
option parsing at **its own position** and `diffBase` precedes it:

```
git diff --stat --        still applies --stat
git diff --exit-code --   still exits 1
git diff -O/etc/nope --   still reads the orderfile
```

`--literal-pathspecs` (#7281/#7289) does not help either — that constrains the *pathspec*
language, and a revision is not a pathspec. Rejecting the leading dash is the only thing
that works here, so that is what this does. The pre-existing silent fallback to `HEAD` is
kept, so the wire contract for an unusable base is unchanged.

## The `--remote` availability gate (#7291)

`this._remoteAvailable = stdout.includes('--remote')` is a substring match, satisfied by
the longer `--remote-control`. Measured against the **installed** CLI, which advertises
`--remote-control` and `--remote-control-session-name-prefix` and has no `--remote` at all:

```
help.includes('--remote')      -> true    (gate opens)
/--remote(?![\w-])/.test(help) -> false   (correct)
```

So the gate reported the feature available on a CLI that cannot accept it — a check that
reports success without checking, and the thing that was supposed to keep a client prompt
out of the argv in `_spawnRemoteTask`.

The existing test for this gate fed a help text containing **no `--remote` substring at
all**, so the naive check already answered it correctly. It passed before and after this
fix and proved nothing. Replaced by a control that carries `--remote-control` and asserts
`remote === false` while `--teleport` (genuinely present in the same fixture) stays `true`.

## Reject vs `--`: which fix applies

This is the part that is easy to get backwards, so it is stated once in
`utils/argv-safety.js` and referenced from each site:

- A value that **can never legitimately begin with `-`** (a git revision, a branch) →
  **reject**. `getDiff`, `assertSafeRef`.
- A value that **legitimately can** (a user's chat message — `- first point`) → **do not
  reject**; terminate option parsing with `--`, with every flag placed *before* it.
  `_spawnRemoteTask`. Rejecting there would break ordinary prompts.

That `claude` honours `--` was measured directly, with a positive control:

```
claude --nonexistent-flag-xyz     -> error: unknown option   (option-parsed)
claude -- --nonexistent-flag-xyz  -> no such error           (treated as the prompt)
```

## One spelling, not three

#7290 asks for the existing `assertSafeRef` to be reused rather than a third spelling
written. The predicate now lives in `packages/server/src/utils/argv-safety.js` and is
shared by `ws-file-ops/reader.js` and `orchestration/git-ops.js`. `assertSafeRef` survives
only as a thin wrapper that keeps throwing `GitOpsError` and preserves the `empty` vs
`unsafe` message split that `orchestration-git-ops.test.js` pins.

## Verification

Every guard is **mutation-tested** — reverting each one turns its own tests red, and each
has a **positive control** so a guard that refused everything could not pass:

| mutation | result |
|---|---|
| drop `isSafeArgvValue` from `getDiff`, keep the allowlist | **3 red**, positive control green |
| revert the gate to `stdout.includes('--remote')` | **1 red** |
| revert the argv to `['--remote', prompt]` | **2 red** |
| all restored | 29/29 green |

The `getDiff` tests were written **red first** against unfixed code, and each observes a
git behaviour only reachable when the option was actually parsed (the orderfile fatal,
`--exit-code`'s rc=1, `--stat` collapsing the unified diff to zero files) rather than
asserting on the argv array.

- **215/215** across every affected suite: `argv-safety`, `web-task-manager`,
  `web-task-handlers`, `orchestration-git-ops`, `ws-server-file-ops`, `file-handlers`,
  `ws-file-ops-git-paths`, `git-stage-commit`.
- All **8** custom server lints OK. eslint: 0 errors, and no new warnings in any touched
  file.

Catalogued as `docs/false-safety-guards.md` entry 13, which entry 12 already predicted.

## Deliberately left out

- **#7291's `codex-session.js` site** stays open. The fix there is not a one-token
  insertion: the flags come *after* the positional prompt, so adding `--` requires
  **reordering** the argv, and `buildCodexArgs` carries a documented hard-won invariant
  (`--sandbox` must precede the `resume` subcommand). The repo's own spawn-and-assert clap
  harness (`tests/integration/codex-spawn-argv.integration.test.js`) is the only honest
  proof for that change, and it self-skips here because this host's codex install is broken
  (`vendored binary ENOENT`). Shipping an unverified argv reorder against a fragile
  ordering invariant is not worth it; filed as a follow-on instead.
- **`buildRemoteTaskArgs` cannot be exercised against a live binary**, because the shipping
  CLI has no `--remote` at all — and after the gate fix, that path is correctly closed on
  such a CLI. The shape is asserted against the CLI's documented grammar,
  `claude [options] [command] [prompt]`, in which the prompt is positional. Stated
  explicitly in the function's doc comment rather than left implied.
