### PR TITLE
docs: stop hardcoding the false-safety guard count, and add the missing causes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,18 +288,32 @@ padding or font size, re-check the resulting box.
 **When you add or change a check, break the thing it protects and confirm it goes
 red.** If you cannot make it fail, it is not a guard.
 
-Eight guards in this repo reported success without checking anything, and all
-eight passed unit tests, lint, typecheck, and CI — for months in some cases.
-Test suites cannot find this class, because the guard's *output* is correct and
-its *coverage* is what is wrong. The recurring causes:
+Every guard in `docs/false-safety-guards.md` reported success without checking
+anything, and every one of them passed unit tests, lint, typecheck, and CI —
+for months in some cases. Test suites cannot find this class, because the
+guard's *output* is correct and its *coverage* is what is wrong.
 
-- a hardcoded list next to a set that grows (`#7192`, `#7197`)
+**Don't put a count here.** This sentence read "eight guards" while the
+catalogue held twelve — a hardcoded number beside a growing set, which is the
+first cause below, and the catalogue says so itself: consult the entries, not a
+tally that is stale the moment one merges. The recurring causes:
+
+- a hardcoded list next to a set that grows (`#7192`, `#7197`, `#7267`) —
+  including one that lived in **CI config**, where no lint, test or code review
+  of the repo could reach it (`#7270`)
 - "cannot check this" silently treated as "nothing to check" (`#7195`, `#7210`)
 - a precondition that is false, so the body never runs and the job is green
   (`#7184`, `#7198`)
 - testing the source tree when the artifact is what ships (`#7189`)
 - a guard wired to only some of its callers, correct for every input it sees
   and never reached by the rest (`#7262`)
+- a check that denies *everything*, so its negative tests pass for the wrong
+  reason and would keep passing with the check deleted outright (`#7273`)
+- a validated value handed on to something that parses it under a different
+  grammar — a pathspec, a revision, a glob, a shell word (`#7281`)
+- a guard whose comment describes a stronger check than its code performs — a
+  character class that admits the flag it claims to block, a substring match
+  standing in for a token match (`#7290`, `#7291`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Restore mutations with `cp` from a backup,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,10 +295,11 @@ inverted: a check so broken it satisfied its own adversarial tests). Test
 suites cannot find this class, because the green is real and the *coverage* is
 what is wrong.
 
-**Don't put a count here.** This sentence read "eight guards" while the
-catalogue held twelve — a hardcoded number beside a growing set, which is the
-first cause below, and the catalogue says so itself: consult the entries, not a
-tally that is stale the moment one merges. The recurring causes:
+**Don't put a count here.** This sentence used to carry one, and the catalogue
+had already grown past it twice before anyone noticed — a hardcoded number
+beside a growing set, which is the first cause below. The catalogue says so
+itself: consult the entries, not a tally that is stale the moment one merges.
+The recurring causes:
 
 - a hardcoded list next to a set that grows (`#7192`, `#7197`, `#7267`) —
   including one that lived in **CI config**, where no lint, test or code review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,10 +288,12 @@ padding or font size, re-check the resulting box.
 **When you add or change a check, break the thing it protects and confirm it goes
 red.** If you cannot make it fail, it is not a guard.
 
-Every guard in `docs/false-safety-guards.md` reported success without checking
-anything, and every one of them passed unit tests, lint, typecheck, and CI —
-for months in some cases. Test suites cannot find this class, because the
-guard's *output* is correct and its *coverage* is what is wrong.
+Every guard in `docs/false-safety-guards.md` passed unit tests, lint, typecheck
+and CI — continuously, for months in some cases — because **success and
+not-checking were the same observable outcome** (entry 11, `#7273`, is that
+inverted: a check so broken it satisfied its own adversarial tests). Test
+suites cannot find this class, because the green is real and the *coverage* is
+what is wrong.
 
 **Don't put a count here.** This sentence read "eight guards" while the
 catalogue held twelve — a hardcoded number beside a growing set, which is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,10 +269,12 @@ padding or font size, re-check the resulting box.
 **When you add or change a check, break the thing it protects and confirm it goes
 red.** If you cannot make it fail, it is not a guard.
 
-Every guard in `docs/false-safety-guards.md` reported success without checking
-anything, and every one of them passed unit tests, lint, typecheck, and CI —
-for months in some cases. Test suites cannot find this class, because the
-guard's *output* is correct and its *coverage* is what is wrong.
+Every guard in `docs/false-safety-guards.md` passed unit tests, lint, typecheck
+and CI — continuously, for months in some cases — because **success and
+not-checking were the same observable outcome** (entry 11, `#7273`, is that
+inverted: a check so broken it satisfied its own adversarial tests). Test
+suites cannot find this class, because the green is real and the *coverage* is
+what is wrong.
 
 **Don't put a count here.** This sentence read "eight guards" while the
 catalogue held twelve — a hardcoded number beside a growing set, which is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,18 +269,32 @@ padding or font size, re-check the resulting box.
 **When you add or change a check, break the thing it protects and confirm it goes
 red.** If you cannot make it fail, it is not a guard.
 
-Eight guards in this repo reported success without checking anything, and all
-eight passed unit tests, lint, typecheck, and CI — for months in some cases.
-Test suites cannot find this class, because the guard's *output* is correct and
-its *coverage* is what is wrong. The recurring causes:
+Every guard in `docs/false-safety-guards.md` reported success without checking
+anything, and every one of them passed unit tests, lint, typecheck, and CI —
+for months in some cases. Test suites cannot find this class, because the
+guard's *output* is correct and its *coverage* is what is wrong.
 
-- a hardcoded list next to a set that grows (`#7192`, `#7197`)
+**Don't put a count here.** This sentence read "eight guards" while the
+catalogue held twelve — a hardcoded number beside a growing set, which is the
+first cause below, and the catalogue says so itself: consult the entries, not a
+tally that is stale the moment one merges. The recurring causes:
+
+- a hardcoded list next to a set that grows (`#7192`, `#7197`, `#7267`) —
+  including one that lived in **CI config**, where no lint, test or code review
+  of the repo could reach it (`#7270`)
 - "cannot check this" silently treated as "nothing to check" (`#7195`, `#7210`)
 - a precondition that is false, so the body never runs and the job is green
   (`#7184`, `#7198`)
 - testing the source tree when the artifact is what ships (`#7189`)
 - a guard wired to only some of its callers, correct for every input it sees
   and never reached by the rest (`#7262`)
+- a check that denies *everything*, so its negative tests pass for the wrong
+  reason and would keep passing with the check deleted outright (`#7273`)
+- a validated value handed on to something that parses it under a different
+  grammar — a pathspec, a revision, a glob, a shell word (`#7281`)
+- a guard whose comment describes a stronger check than its code performs — a
+  character class that admits the flag it claims to block, a substring match
+  standing in for a token match (`#7290`, `#7291`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Restore mutations with `cp` from a backup,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,10 +276,11 @@ inverted: a check so broken it satisfied its own adversarial tests). Test
 suites cannot find this class, because the green is real and the *coverage* is
 what is wrong.
 
-**Don't put a count here.** This sentence read "eight guards" while the
-catalogue held twelve — a hardcoded number beside a growing set, which is the
-first cause below, and the catalogue says so itself: consult the entries, not a
-tally that is stale the moment one merges. The recurring causes:
+**Don't put a count here.** This sentence used to carry one, and the catalogue
+had already grown past it twice before anyone noticed — a hardcoded number
+beside a growing set, which is the first cause below. The catalogue says so
+itself: consult the entries, not a tally that is stale the moment one merges.
+The recurring causes:
 
 - a hardcoded list next to a set that grows (`#7192`, `#7197`, `#7267`) —
   including one that lived in **CI config**, where no lint, test or code review


### PR DESCRIPTION
## Problem

`CLAUDE.md:272` (and its generated `AGENTS.md` mirror) said:

> Eight guards in this repo reported success without checking anything, and all
> eight passed unit tests, lint, typecheck, and CI

That tally stopped tracking `docs/false-safety-guards.md`. The catalogue holds
**twelve** entries on `main` today and gains a **thirteenth** when #7294 lands.
So the number was already wrong twice over, and would go wrong again at entry 14.

The catalogue itself already says not to keep this number:

> Each entry below cites its issue, and the fix is the PR that closes it; consult
> those rather than a tally here, which would be stale the moment one merges.

The doctrine file was keeping a second copy of exactly the fact the catalogue
tells you not to copy — **a hardcoded number beside a growing set**, which is the
first recurring cause listed in the very same paragraph.

## Decision

Phrased as a **live reference, not a count**. Hardcoding "thirteen" would be wrong
on `main` until #7294 merges, and stale again at entry 14. A short note now says
why there is no number, so a future edit doesn't helpfully restore one.

## Also: the causes list was missing entries 9–13

The bullet list enumerating recurring causes stopped at #7262. Added the causes
that entries 9–13 introduced:

| Cause | Entry | Issues |
|---|---|---|
| a check that denies *everything*, so its negative tests pass for the wrong reason and would survive the check being deleted | 11 | #7273 |
| a validated value re-parsed downstream under a different grammar — pathspec, revision, glob, shell word | 12 | #7281 |
| a guard whose comment describes a stronger check than its code performs | 13 | #7290, #7291 |

and extended the existing "hardcoded list" bullet with #7267, plus entry 10's
distinct variant — the same list living in **CI config**, where no lint, test or
code review of the repo could reach it (#7270).

Entry 13's issues (#7290/#7291) are safe to cite regardless of #7294's merge
order: entry 12 on `main` already names them as its siblings.

## Verification

`AGENTS.md` regenerated with `node scripts/gen-agents-md.mjs` and committed in
this PR (CI gate on the mirror).

The gate was **mutation-proved** rather than assumed green — per the doctrine this
PR edits:

```
mutant (one new bullet removed from AGENTS.md)  -> exit 1  ::error:: out of sync
restored (cp from backup, not git checkout --)  -> exit 0  in sync
```

That confirms the gate is actually covering these lines, and that the new bullets
reached the mirror.

Docs-only change; no code paths touched.

Related to #7290, #7291.