### PR TITLE
fix(server): bind the Grep pattern to `-e` so rg cannot option-parse it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,25 @@ jobs:
         run: npm run build
         working-directory: packages/protocol
 
+      # #7295: the Grep argv-injection proof SPAWNS ripgrep and asserts it does not
+      # execute a `--pre=` preprocessor. A string assertion cannot stand in for that
+      # — the whole point is that rg's own option parser is the thing under test. The
+      # test FAILS (not skips) when rg is missing and CI is set, so this step is what
+      # keeps that from reddening the job: absent it, "cannot check" and "checked"
+      # were the same green, which is the second recurring cause in
+      # docs/false-safety-guards.md. Heterogeneous pool: node:22-bookworm as root has
+      # no sudo, the winbox VM is non-root and has it.
+      - name: Ensure ripgrep is installed (required by the #7295 execution proof)
+        run: |
+          if command -v rg >/dev/null 2>&1; then rg --version | head -1; exit 0; fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y ripgrep
+          else
+            apt-get update && apt-get install -y ripgrep
+          fi
+          rg --version | head -1
+        working-directory: .
+
       - name: Run tests with coverage
         run: npm test
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,9 @@ The recurring causes:
 - a guard whose comment describes a stronger check than its code performs — a
   character class that admits the flag it claims to block, a substring match
   standing in for a token match (`#7290`, `#7291`)
+- a real defence against the *neighbouring* class, mistaken for cover — shell
+  quoting stops the shell, and the quoted word still begins with `-` when the
+  spawned program runs its own option parser over it (`#7295`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Restore mutations with `cp` from a backup,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,9 @@ The recurring causes:
 - a guard whose comment describes a stronger check than its code performs — a
   character class that admits the flag it claims to block, a substring match
   standing in for a token match (`#7290`, `#7291`)
+- a real defence against the *neighbouring* class, mistaken for cover — shell
+  quoting stops the shell, and the quoted word still begins with `-` when the
+  spawned program runs its own option parser over it (`#7295`)
 
 Check the **exit code**, not the output — and note `cmd | grep -c FAIL` reports
 `grep`'s status, not the script's. Restore mutations with `cp` from a backup,

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -479,6 +479,66 @@ program still runs its own option parser over that array. The two are different
 classes with different fixes, and "we use execFile, not exec" is an answer to
 only one of them.
 
+### 14. The quoting that stopped the wrong injection — `#7295`
+
+Entry 13 closed with a generalisation: `execFile` with an array argv stops
+*shell* injection, not *argument* injection. `#7295` is the same sentence with
+one word swapped, in a subsystem that does use a shell.
+
+The `Grep` built-in built its command as a bash string and quoted the
+model-controlled pattern:
+
+```js
+const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
+```
+
+`shellQuote` is a real defence and it works: bash consumes the quotes, so no
+metacharacter in the pattern is ever interpreted. What it cannot do is change
+what the quoted argv element *is*. `rg` then runs its own option parser over a
+string that still begins with `-`, and rg has options that execute programs.
+Measured against ripgrep 15.1.0, with a marker-writing script:
+
+```
+rg -n --no-heading '--pre=/tmp/pre.sh' <root>      rc=1, marker WRITTEN
+rg -n --no-heading -e '--pre=/tmp/pre.sh' <root>   rc=1, marker absent
+```
+
+A second, quieter effect: `--pre=` self-terminates, so `<root>` slides into the
+pattern slot and rg is left with zero paths. Its stdin heuristic then makes it
+read a readable stdin and block until EOF — a hung tool call, measured at the
+full length of the test's 8-second timeout. `maskExit: true` on the container
+path does not help; the process never exits to have its code masked.
+
+**Why it was worse than an ordinary argv bug.** `Grep` is classified read-only
+everywhere in the permission system — `SECRET_READ_FLOOR_TOOLS`,
+`ACCEPT_EDITS_TOOLS`, `ELIGIBLE_TOOLS` — so it is auto-approved in `acceptEdits`
+mode and can carry a standing auto-allow rule. `Bash` and `shell` are in
+`NEVER_AUTO_ALLOW`, refused a whitelist as too dangerous. The bug reached the
+`Bash` capability through the tool exempted for not having it.
+
+**The guard was wired to one of two siblings.** Six lines above `runGrep`,
+`runGlob` validates its pattern against `GLOB_PATTERN_SHELL_METACHARS` and says
+so in a comment. Two adjacent functions, same file, same class of input, same
+kind of sink — one checked, one not. This is the `#7262` cause seen from the
+other side: there, a guard existed and missed callers; here, a guard existed on
+the neighbour and was never asked for.
+
+**The fix is `-e <pattern>`, not a leading-dash rejection.** `-Wall` and
+`--force` are legitimate search patterns; rejecting them is a functional
+regression, and on the unfixed builder `-Wall` was *already* one
+(`rg: unrecognized flag -W`, exit 2). This is fix shape (3) in
+`packages/server/src/utils/argv-safety.js`: bind the value to a named flag.
+Shape (2), a `--` separator, also works here — unlike `#7290`'s revision slot,
+because the pattern *follows* the separator — but `-e` survives future flag
+additions and needs no ordering argument.
+
+**What the test had to do.** `tests/built-in-tools/grep-argv-injection.test.js`
+spawns the built command rather than asserting on its text, because a string
+assertion is only as strong as the reviewer's model of rg's parser. All eight
+tests were confirmed red on the unfixed builder before the fix, and each branch
+was mutated alone afterwards: dropping `-e` from the rg branch kills five,
+dropping it from the `grep -r` fallback kills three.
+
 ## The one that got me while writing this
 
 A Maestro `repeat` was written with `maxRuns: 3`. `YamlRepeatCommand` has no

--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -499,15 +499,27 @@ string that still begins with `-`, and rg has options that execute programs.
 Measured against ripgrep 15.1.0, with a marker-writing script:
 
 ```
-rg -n --no-heading '--pre=/tmp/pre.sh' <root>      rc=1, marker WRITTEN
-rg -n --no-heading -e '--pre=/tmp/pre.sh' <root>   rc=1, marker absent
+rg -i -n --no-heading '--pre=/tmp/pre.sh' <root>      rc=1, marker WRITTEN
+rg -i -n --no-heading -e '--pre=/tmp/pre.sh' <root>   rc=1, marker absent
 ```
 
-A second, quieter effect: `--pre=` self-terminates, so `<root>` slides into the
-pattern slot and rg is left with zero paths. Its stdin heuristic then makes it
-read a readable stdin and block until EOF — a hung tool call, measured at the
-full length of the test's 8-second timeout. `maskExit: true` on the container
-path does not help; the process never exits to have its code masked.
+A second, quieter effect, and the two are **alternatives rather than a pair** —
+which the first draft of this entry got wrong. `--pre=` self-terminates, so
+`<root>` slides into the pattern slot and rg is left with zero paths. What
+happens next is decided by the child's stdin, measured on the unfixed builder:
+
+```
+child stdin = 'ignore'  (what the host sink uses)  rc=1,    marker WRITTEN, no hang
+child stdin = 'pipe', held open                    hangs,   marker absent
+```
+
+`/dev/null` is a chardev, so rg's `is_readable_stdin` heuristic returns false and
+it falls back to searching `./` — executing the preprocessor without hanging.
+Give it a pipe or a file and it blocks on stdin until EOF instead, and
+`maskExit: true` cannot save that: the process never exits to have its code
+masked. So the host sink (`bash-exec.js`, `stdio: ['ignore', …]`) gets the
+EXECUTION, and the hang is what a caller with a piped stdin gets. Both are
+tested; only one can happen per call.
 
 **Why it was worse than an ordinary argv bug.** `Grep` is classified read-only
 everywhere in the permission system — `SECRET_READ_FLOOR_TOOLS`,
@@ -516,28 +528,100 @@ mode and can carry a standing auto-allow rule. `Bash` and `shell` are in
 `NEVER_AUTO_ALLOW`, refused a whitelist as too dangerous. The bug reached the
 `Bash` capability through the tool exempted for not having it.
 
-**The guard was wired to one of two siblings.** Six lines above `runGrep`,
-`runGlob` validates its pattern against `GLOB_PATTERN_SHELL_METACHARS` and says
-so in a comment. Two adjacent functions, same file, same class of input, same
-kind of sink — one checked, one not. This is the `#7262` cause seen from the
-other side: there, a guard existed and missed callers; here, a guard existed on
-the neighbour and was never asked for.
+**The guard was wired to one of two siblings.** `runGlob` — the function
+immediately preceding `runGrep` in `byok-tool-executor.js` — validates its
+pattern against `GLOB_PATTERN_SHELL_METACHARS` and says so in a comment. Two
+adjacent functions, same file, same class of input, same kind of sink — one
+checked, one not.
+
+**But the cover the neighbour had would not have helped**, and saying "one
+checked, one not" without that caveat reproduces entry 13's defect inside this
+very entry. `GLOB_PATTERN_SHELL_METACHARS` is ``/[$`;|&><()\\\n\r]/`` — a
+*shell*-metachar whitelist, guarding an interpolation that `buildGlobCommand`
+deliberately leaves UNQUOTED so the shell expands the glob. Measured, it rejects
+none of the exploit shapes:
+
+```
+--pre=/tmp/pre.sh  -> rejected? false
+-Wall              -> rejected? false
+--force            -> rejected? false
+-f/etc/passwd      -> rejected? false
+```
+
+`runGrep` faced an *argv* problem behind `shellQuote`; its neighbour solved a
+*shell* problem in front of a bare interpolation. Different classes, different
+fixes. So what was missing was not the guard — it was the **question**. A
+sibling with an explicit input check, sitting next to one with none, should have
+prompted "what is `runGrep`'s pattern protected against?", and nobody asked.
+That is the `#7262` cause seen from the other side: there a guard existed and
+missed callers; here a guard existed on the neighbour and was never interrogated.
 
 **The fix is `-e <pattern>`, not a leading-dash rejection.** `-Wall` and
 `--force` are legitimate search patterns; rejecting them is a functional
 regression, and on the unfixed builder `-Wall` was *already* one
 (`rg: unrecognized flag -W`, exit 2). This is fix shape (3) in
-`packages/server/src/utils/argv-safety.js`: bind the value to a named flag.
-Shape (2), a `--` separator, also works here — unlike `#7290`'s revision slot,
-because the pattern *follows* the separator — but `-e` survives future flag
-additions and needs no ordering argument.
+`packages/server/src/utils/argv-safety.js` — bind the value to a named flag the
+CLI declares as requiring an argument.
+
+Shape (3) as written there prescribes the `=`-joined SINGLE-token form
+(`--flag=<value>`), because gemini-cli's yargs `requiresArg` rejects the
+two-token one. `rg` and `grep` accept the two-token `-e <pattern>` (measured
+against ripgrep 15.1.0 and BSD grep: marker absent, rc=1; `-e '-Wall'` matches,
+rc=0), so it is sufficient here — which is that section's own point, that the
+form is a per-CLI question answered by measuring rather than assumed. Shape (2),
+a `--` separator, also works (measured: rc=1, marker absent) — unlike `#7290`'s
+revision slot, because the pattern *follows* the separator — but `-e` survives
+future flag additions and needs no ordering argument.
+
+**Two more slots the first fix walked past.** Binding the pattern left the
+builder's OTHER interpolation, `root`, in a bare positional slot — the
+adjacent-field shape, fixing the field in the report and not its neighbour. It
+is not exploitable today (both callers hand over an absolute path, via
+`safeResolveRoot` and `remapToContainerPath`), but the builder should not rest
+on an invariant it neither states nor tests. Measured:
+
+```
+rg -e TODO    '--pre=/tmp/pre.sh'   rc=0, marker WRITTEN
+rg -e TODO -- '--pre=/tmp/pre.sh'   rc=2, marker absent
+```
+
+And rg reads `RIPGREP_CONFIG_PATH` as flags — including `--pre`, reinstating
+execution *around* the argv fix entirely. Not client-reachable here, but it is
+also a live CORRECTNESS bug, which is the more useful half: a config containing
+`--pre=/bin/echo` silently turns a matching search into `rc=1` no-match. Output
+that gets machine-parsed must not depend on a developer's personal rg config.
+`--no-config` closes both.
 
 **What the test had to do.** `tests/built-in-tools/grep-argv-injection.test.js`
 spawns the built command rather than asserting on its text, because a string
-assertion is only as strong as the reviewer's model of rg's parser. All eight
-tests were confirmed red on the unfixed builder before the fix, and each branch
-was mutated alone afterwards: dropping `-e` from the rg branch kills five,
-dropping it from the `grep -r` fallback kills three.
+assertion is only as strong as the reviewer's model of rg's parser. Every test
+was confirmed red on the unfixed builder first; the full mutant now kills 12 of
+13 (the survivor is the armed positive control below, which deliberately does
+not go through the builder). Each guard was then mutated alone: dropping `-e`
+from the rg branch kills 5, from the `grep -r` fallback 3, dropping `--` before
+the root 3, dropping `--no-config` 3.
+
+**Three ways the tests were themselves false-safe, found by review.** All three
+are this document's own catalogued causes, reproduced inside the change that
+adds an entry to it:
+
+- **A negative control with no positive control.** "The marker was not written"
+  passes for free the moment the fixture stops taking effect. Demonstrated by
+  reverting the fix *and* dropping the script to mode `0o644`: the vulnerability
+  was live and the test went GREEN. The file now runs `--pre` as a genuine flag
+  first and asserts the marker IS written, so an inert fixture fails loudly.
+- **A skip that CI reads as a pass.** The three rg tests carried the whole
+  execution proof and `t.skip`ped when ripgrep was absent — and no CI job
+  installed it, which the Windows job's log proved in the literal form
+  `ok 1 - … # SKIP ripgrep is not installed`. `node:test` counts a skip in
+  `# tests` and not in `# fail`, so what CI actually enforced was the string
+  assertion the file argues is insufficient. Now: a hard failure when
+  `process.env.CI` is set, and a step that installs ripgrep.
+- **An assertion whose name outran its code.** The permission-coupling test
+  matched `-e '<pattern>'` against the whole `if … then rg …; else grep …; fi`
+  string, so EITHER branch satisfied it; it stayed green under each
+  single-branch mutant while that branch was fully exploitable. It now splits on
+  `'; else '` and asserts per branch.
 
 ## The one that got me while writing this
 

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -169,11 +169,28 @@ export function buildGrepArgs(input) {
  * exit 1 on "no matches"; pass `maskExit:true` when the runner rejects on
  * non-zero (the container's `execInEnvironment`) so that case isn't a failure.
  *
+ * SECURITY (#7295): the pattern is bound to `-e`, NOT dropped into a bare
+ * positional slot. `shellQuote` closes SHELL injection only — bash eats the
+ * quotes, and rg/grep then run their OWN option parser over an argv element
+ * that still begins with `-`. Measured against ripgrep 15.1.0, a positional
+ * `--pre=<path>` pattern makes rg EXECUTE `<path>` as a per-file preprocessor,
+ * and — with the root swallowed into the pattern slot, leaving rg zero paths —
+ * blocks forever reading stdin. That is program execution plus a hung tool
+ * call through `Grep`, which the permission model exempts as read-only
+ * (`SECRET_READ_FLOOR_TOOLS`, `ACCEPT_EDITS_TOOLS`, `ELIGIBLE_TOOLS`) while
+ * refusing to whitelist `Bash` at all.
+ *
+ * `-e` and not a leading-dash REJECTION: `-Wall` and `--force` are legitimate
+ * search patterns, so rejecting them would be a functional regression. This is
+ * fix shape (3) in `utils/argv-safety.js`. Proven red-before-green by
+ * `tests/built-in-tools/grep-argv-injection.test.js`, which spawns the built
+ * command and asserts the preprocessor never runs.
+ *
  * @param {{ pattern: string, root: string, ci: string, ln: string, globArg: string, maskExit?: boolean }} opts
  */
 export function buildGrepCommand({ pattern, root, ci, ln, globArg, maskExit = false }) {
-  const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
-  const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
+  const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} -e ${shellQuote(pattern)} ${shellQuote(root)}`
+  const grepCmd = `grep -r ${ci} ${ln} -e ${shellQuote(pattern)} ${shellQuote(root)}`
   const core = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
   return maskExit ? `${core}; true` : core
 }

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -169,28 +169,51 @@ export function buildGrepArgs(input) {
  * exit 1 on "no matches"; pass `maskExit:true` when the runner rejects on
  * non-zero (the container's `execInEnvironment`) so that case isn't a failure.
  *
- * SECURITY (#7295): the pattern is bound to `-e`, NOT dropped into a bare
- * positional slot. `shellQuote` closes SHELL injection only — bash eats the
+ * SECURITY (#7295): BOTH model/caller-controlled interpolations are kept out
+ * of a bare positional slot — the pattern by `-e`, and the root by the `--`
+ * terminator after it. `shellQuote` closes SHELL injection only: bash eats the
  * quotes, and rg/grep then run their OWN option parser over an argv element
  * that still begins with `-`. Measured against ripgrep 15.1.0, a positional
- * `--pre=<path>` pattern makes rg EXECUTE `<path>` as a per-file preprocessor,
+ * `--pre=<path>` value makes rg EXECUTE `<path>` as a per-file preprocessor,
  * and — with the root swallowed into the pattern slot, leaving rg zero paths —
- * blocks forever reading stdin. That is program execution plus a hung tool
- * call through `Grep`, which the permission model exempts as read-only
- * (`SECRET_READ_FLOOR_TOOLS`, `ACCEPT_EDITS_TOOLS`, `ELIGIBLE_TOOLS`) while
- * refusing to whitelist `Bash` at all.
+ * blocks forever reading stdin. Program execution plus a hung tool call,
+ * through `Grep`.
+ *
+ * That matters because of WHERE this sits. `Grep` gets a reduced (secrets-only)
+ * permission floor via `SECRET_READ_FLOOR_TOOLS`, is auto-approved in
+ * `acceptEdits` mode via `ACCEPT_EDITS_TOOLS`, and can carry a standing
+ * auto-allow rule via `ELIGIBLE_TOOLS` — while `Bash`, which owns this
+ * capability honestly, is refused a whitelist outright by `NEVER_AUTO_ALLOW`.
+ *
+ * The `--` is defence in depth, not a live fix: both callers already guarantee
+ * an absolute root (`safeResolveRoot` on the host, `remapToContainerPath` in
+ * the container). It is here so the builder does not depend on an invariant it
+ * neither states nor tests — a third caller passing a raw client path would
+ * otherwise restore the identical `--pre=` execution through the root slot.
+ * MEASURED: `rg -e TODO '--pre=<script>'` executes the script (rc=0, marker
+ * written); with `--` before it, rc=2 and no execution.
+ *
+ * `--no-config` is both hardening and a correctness fix. rg reads the file named
+ * by `RIPGREP_CONFIG_PATH` and applies it as flags — including `--pre`, so an env
+ * that reaches the daemon reinstates the execution this function exists to stop.
+ * It is not client-reachable today (`buildSafeBashEnv` copies the daemon's own
+ * env, which nothing mutates at runtime), but it also breaks ordinary searching:
+ * MEASURED, a config containing `--pre=/bin/echo` turned a matching search into
+ * rc=1 no-match, silently. Machine-parsed output must not depend on a developer's
+ * personal rg config. `grep` has no equivalent to disable.
  *
  * `-e` and not a leading-dash REJECTION: `-Wall` and `--force` are legitimate
- * search patterns, so rejecting them would be a functional regression. This is
- * fix shape (3) in `utils/argv-safety.js`. Proven red-before-green by
+ * search patterns, so rejecting them would be a functional regression. See
+ * `utils/argv-safety.js` (bind-to-a-named-flag); rg and grep accept the
+ * two-token `-e <value>` form, measured. Proven red-before-green by
  * `tests/built-in-tools/grep-argv-injection.test.js`, which spawns the built
  * command and asserts the preprocessor never runs.
  *
  * @param {{ pattern: string, root: string, ci: string, ln: string, globArg: string, maskExit?: boolean }} opts
  */
 export function buildGrepCommand({ pattern, root, ci, ln, globArg, maskExit = false }) {
-  const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} -e ${shellQuote(pattern)} ${shellQuote(root)}`
-  const grepCmd = `grep -r ${ci} ${ln} -e ${shellQuote(pattern)} ${shellQuote(root)}`
+  const rgCmd = `rg --no-config ${ci} ${ln} --no-heading${globArg} -e ${shellQuote(pattern)} -- ${shellQuote(root)}`
+  const grepCmd = `grep -r ${ci} ${ln} -e ${shellQuote(pattern)} -- ${shellQuote(root)}`
   const core = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
   return maskExit ? `${core}; true` : core
 }

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -34,7 +34,11 @@ const _fallbackLog = createLogger('permission-manager')
 // Tools that acceptEdits mode auto-approves. `apply_patch` is codex's file-edit
 // approval (item/fileChange/requestApproval, #6605) — the codex analogue of
 // Write/Edit, so acceptEdits auto-approves codex edits too.
-const ACCEPT_EDITS_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep', 'apply_patch'])
+// Exported so the classification can be PINNED by tests: it is the strongest of
+// the three read-only premises behind #7295 (ELIGIBLE_TOOLS needs a user to
+// create a rule; this one is automatic in acceptEdits mode), and it was the only
+// one a test could not assert.
+export const ACCEPT_EDITS_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep', 'apply_patch'])
 
 // Tools eligible for session-scoped auto-allow rules (`apply_patch` = codex edits).
 export const ELIGIBLE_TOOLS = new Set(['Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep', 'apply_patch'])

--- a/packages/server/tests/built-in-tools/grep-argv-injection.test.js
+++ b/packages/server/tests/built-in-tools/grep-argv-injection.test.js
@@ -160,6 +160,25 @@ function requireRgOrSkip(t, what) {
 }
 
 /**
+ * Same contract as {@link requireRgOrSkip}, for the grep-fallback branch, which
+ * needs a real `grep` and a real `bash` to shim onto a PATH. Absence must not be
+ * silently equivalent to "nothing to check", and must not hard-fail everywhere
+ * either — that is what reddened the Windows job.
+ *
+ * Returns true when the caller should bail out of the test.
+ */
+function requireGrepShimOrSkip(t) {
+  const missing = [GREP_PATH ? null : 'grep', BASH_PATH ? null : 'bash'].filter(Boolean)
+  if (missing.length === 0) return false
+  const what = `${missing.join(' and ')} not found on PATH`
+  if (process.env.CI) {
+    assert.fail(`${what} — the grep-fallback branch proof cannot run in CI (#7295).`)
+  }
+  t.skip(`${what} — the grep-fallback proof did NOT run (it is enforced in CI).`)
+  return true
+}
+
+/**
  * The spawning tests need a POSIX shell: the sinks under test are literally
  * `spawn('bash', ['-c', cmd])` and `docker exec … bash -c`, and the fixtures are
  * `#!/bin/sh` scripts with exec bits. None of that is meaningful on Windows, and
@@ -184,8 +203,13 @@ function build(pattern, root, input = {}) {
  * branch, which would make this test pass for the wrong reason.
  */
 async function makeGrepOnlyPath(dir) {
-  assert.ok(GREP_PATH, 'grep must be on PATH for the fallback-branch tests')
-  assert.ok(BASH_PATH, 'bash must be on PATH for the fallback-branch tests')
+  // Reachable only from a caller that forgot `requireGrepShimOrSkip` — the
+  // environment gate lives in the tests, so a missing tool SKIPS on a dev box and
+  // FAILS in CI. These two are a programming-error guard, and they are fireable:
+  // proven by setting BASH_PATH to null and calling this helper ungated. The
+  // `|| '/bin/bash'` default they used to sit behind made that impossible.
+  assert.ok(GREP_PATH, 'makeGrepOnlyPath called without requireGrepShimOrSkip: grep is not on PATH')
+  assert.ok(BASH_PATH, 'makeGrepOnlyPath called without requireGrepShimOrSkip: bash is not on PATH')
   const bin = path.join(dir, 'bin')
   await mkdir(bin, { recursive: true })
   for (const [name, target] of [['grep', GREP_PATH], ['bash', BASH_PATH]]) {
@@ -272,7 +296,8 @@ describe('Grep argv option injection (#7295)', () => {
   })
 
   describe('grep fallback branch', () => {
-    it('NEGATIVE CONTROL: a `--pre=` pattern is searched as text, not parsed as an option', POSIX_ONLY, async () => {
+    it('NEGATIVE CONTROL: a `--pre=` pattern is searched as text, not parsed as an option', POSIX_ONLY, async (t) => {
+      if (requireGrepShimOrSkip(t)) return
       const fx = await makeFixture()
       try {
         const bin = await makeGrepOnlyPath(fx.dir)
@@ -298,7 +323,8 @@ describe('Grep argv option injection (#7295)', () => {
       }
     })
 
-    it('POSITIVE CONTROL: `-Wall` still matches as text through the grep fallback', POSIX_ONLY, async () => {
+    it('POSITIVE CONTROL: `-Wall` still matches as text through the grep fallback', POSIX_ONLY, async (t) => {
+      if (requireGrepShimOrSkip(t)) return
       const fx = await makeFixture()
       try {
         const bin = await makeGrepOnlyPath(fx.dir)

--- a/packages/server/tests/built-in-tools/grep-argv-injection.test.js
+++ b/packages/server/tests/built-in-tools/grep-argv-injection.test.js
@@ -1,0 +1,286 @@
+/**
+ * Argv option-injection guard for the Grep built-in tool (#7295).
+ *
+ * `buildGrepCommand` puts a model-controlled `pattern` into the argv of `rg`
+ * (and the `grep -r` fallback). `shellQuote` closes SHELL injection — bash
+ * consumes the quotes — but the resulting argv element still begins with `-`,
+ * and rg/grep run their own option parser over it. `rg --pre=<path>` executes
+ * `<path>` as a preprocessor for every file it searches, so a bare positional
+ * pattern slot is **arbitrary program execution**.
+ *
+ * That matters more here than in a normal argv bug because `Grep` is
+ * classified read-only across the permission system (`SECRET_READ_FLOOR_TOOLS`,
+ * `ACCEPT_EDITS_TOOLS`, `ELIGIBLE_TOOLS`) — it is auto-approved in acceptEdits
+ * mode and eligible for a standing auto-allow rule, while `Bash` is
+ * deliberately excluded as too dangerous to whitelist. The fix must therefore
+ * live in the builder, not in the permission layer.
+ *
+ * These tests SPAWN the built command rather than only asserting on its text,
+ * because a string assertion is only as good as the reviewer's model of rg's
+ * parser. Measured against ripgrep 15.1.0 on the unfixed builder:
+ *
+ *   rg -n --no-heading '--pre=/tmp/marker.sh' <root>     rc=1, marker WRITTEN
+ *   rg -n --no-heading -e '--pre=/tmp/marker.sh' <root>  rc=1, marker absent
+ *
+ * The fix is `-e <pattern>` (argv-safety.js fix shape 3), NOT rejecting a
+ * leading dash: `-Wall` and `--force` are legitimate search patterns, and
+ * rejecting them would be a functional regression. The `-Wall` positive
+ * control below pins that.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, mkdir, writeFile, rm, access, chmod } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { existsSync } from 'node:fs'
+import { buildGrepArgs, buildGrepCommand } from '../../src/built-in-tools/tool-transforms.js'
+import { SECRET_READ_FLOOR_TOOLS } from '../../src/permission-floor.js'
+import { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../../src/permission-manager.js'
+
+/** Locate an executable on PATH without shelling out. */
+function findOnPath(name) {
+  for (const dir of (process.env.PATH || '').split(path.delimiter)) {
+    if (!dir) continue
+    const candidate = path.join(dir, name)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+const RG_PATH = findOnPath('rg')
+const GREP_PATH = findOnPath('grep')
+const BASH_PATH = findOnPath('bash') || '/bin/bash'
+
+/**
+ * Run a built command the way the real sinks do (`bash -c`), with a hard
+ * timeout so a HANGING command is a reportable outcome rather than a stuck
+ * test run.
+ *
+ * `stdin: 'pipe'` leaves the child's stdin OPEN and never writes to it. That
+ * is deliberate: when the injected option eats the pattern slot, the root
+ * becomes the pattern, rg is left with zero paths, and its stdin heuristic
+ * makes it read a readable stdin — blocking until EOF. With stdin held open
+ * that block is unbounded, which is the "hung tool call" half of #7295.
+ */
+function runBuilt(cmd, { cwd, env, stdin = 'ignore', timeoutMs = 20_000 } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn('bash', ['-c', cmd], {
+      cwd,
+      env: env || process.env,
+      stdio: [stdin, 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, timeoutMs)
+    child.stdout.on('data', (d) => { stdout += d })
+    child.stderr.on('data', (d) => { stderr += d })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      resolve({ code: null, stdout, stderr, timedOut, spawnError: err })
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (child.stdin && !child.stdin.destroyed) child.stdin.destroy()
+      resolve({ code, stdout, stderr, timedOut })
+    })
+  })
+}
+
+/**
+ * Workspace fixture: a `work/` tree with one searchable file, plus a marker
+ * script parked OUTSIDE that tree. The script is what `--pre=` would execute.
+ */
+async function makeFixture() {
+  const dir = await mkdtemp(path.join(tmpdir(), 'chroxy-grep-argv-'))
+  const root = path.join(dir, 'work')
+  await mkdir(root)
+  await writeFile(path.join(root, 'a.txt'), 'compile with -Wall enabled\nplain TODO line\n')
+  const marker = path.join(dir, 'MARKER')
+  const script = path.join(dir, 'pre.sh')
+  // `--pre` hands the preprocessor the filename as $1 and reads its stdout, so
+  // the script has to cat the file through for rg to behave normally. The
+  // marker write is the side effect that proves execution.
+  await writeFile(script, `#!/bin/sh\n: > ${JSON.stringify(marker)}\nexec cat "$1"\n`)
+  await chmod(script, 0o755)
+  return { dir, root, marker, script, cleanup: () => rm(dir, { recursive: true, force: true }) }
+}
+
+async function exists(p) {
+  try {
+    await access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Build exactly what `runGrep` / the container Grep build for this pattern. */
+function build(pattern, root, input = {}) {
+  const { ci, ln, globArg } = buildGrepArgs(input)
+  return buildGrepCommand({ pattern, root, ci, ln, globArg })
+}
+
+/**
+ * A PATH that resolves `bash` and `grep` but NOT `rg`, to force the `grep -r`
+ * fallback branch deterministically on a machine that has ripgrep installed.
+ * Shims rather than a real directory so the PATH can be exhaustive: any real
+ * bin dir added here might also contain `rg` and silently take the other
+ * branch, which would make this test pass for the wrong reason.
+ */
+async function makeGrepOnlyPath(dir) {
+  assert.ok(GREP_PATH, 'grep must be on PATH for the fallback-branch tests')
+  assert.ok(BASH_PATH, 'bash must be on PATH for the fallback-branch tests')
+  const bin = path.join(dir, 'bin')
+  await mkdir(bin, { recursive: true })
+  for (const [name, target] of [['grep', GREP_PATH], ['bash', BASH_PATH]]) {
+    const shim = path.join(bin, name)
+    await writeFile(shim, `#!/bin/sh\nexec ${JSON.stringify(target)} "$@"\n`)
+    await chmod(shim, 0o755)
+  }
+  return bin
+}
+
+describe('Grep argv option injection (#7295)', () => {
+  describe('ripgrep branch', () => {
+    it('NEGATIVE CONTROL: a `--pre=` pattern must not execute a program', async (t) => {
+      if (!RG_PATH) {
+        t.skip('ripgrep is not installed on this machine — the rg-branch execution proof did NOT run. The grep-branch and command-shape tests below still cover the fix.')
+        return
+      }
+      const fx = await makeFixture()
+      try {
+        const cmd = build(`--pre=${fx.script}`, fx.root)
+        // cwd is the workspace root because rg, given zero paths, falls back to
+        // searching `./` — which is how the preprocessor gets reached at all.
+        const res = await runBuilt(cmd, { cwd: fx.root })
+        assert.equal(
+          await exists(fx.marker),
+          false,
+          `pattern was option-parsed: rg executed the --pre preprocessor. cmd=${cmd} rc=${res.code} stderr=${res.stderr}`,
+        )
+      } finally {
+        await fx.cleanup()
+      }
+    })
+
+    it('NEGATIVE CONTROL: a `--pre=` pattern must terminate, not hang on stdin', async (t) => {
+      if (!RG_PATH) {
+        t.skip('ripgrep is not installed on this machine — the rg-branch hang proof did NOT run.')
+        return
+      }
+      const fx = await makeFixture()
+      try {
+        const cmd = build(`--pre=${fx.script}`, fx.root)
+        const res = await runBuilt(cmd, { cwd: fx.root, stdin: 'pipe', timeoutMs: 8_000 })
+        assert.equal(
+          res.timedOut,
+          false,
+          `command hung: the injected option consumed the pattern slot, leaving rg zero paths so it blocked reading stdin. cmd=${cmd}`,
+        )
+      } finally {
+        await fx.cleanup()
+      }
+    })
+
+    it('POSITIVE CONTROL: a legitimately dash-leading pattern (`-Wall`) still matches as text', async (t) => {
+      if (!RG_PATH) {
+        t.skip('ripgrep is not installed on this machine — the rg-branch positive control did NOT run.')
+        return
+      }
+      const fx = await makeFixture()
+      try {
+        const cmd = build('-Wall', fx.root)
+        const res = await runBuilt(cmd, { cwd: fx.root })
+        assert.equal(res.code, 0, `expected a match, got rc=${res.code} stderr=${res.stderr} cmd=${cmd}`)
+        assert.match(res.stdout, /compile with -Wall enabled/)
+      } finally {
+        await fx.cleanup()
+      }
+    })
+  })
+
+  describe('grep fallback branch', () => {
+    it('NEGATIVE CONTROL: a `--pre=` pattern is searched as text, not parsed as an option', async () => {
+      const fx = await makeFixture()
+      try {
+        const bin = await makeGrepOnlyPath(fx.dir)
+        const cmd = build(`--pre=${fx.script}`, fx.root)
+        const res = await runBuilt(cmd, {
+          cwd: fx.root,
+          env: { ...process.env, PATH: bin },
+        })
+        assert.equal(res.spawnError, undefined, `bash failed to spawn: ${res.spawnError}`)
+        assert.equal(await exists(fx.marker), false, 'grep must not execute anything')
+        // grep's exit codes: 0 = matched, 1 = no match, 2 = usage/other error.
+        // Pre-fix the unknown `--pre` long option makes this a usage error (2);
+        // post-fix it is an ordinary no-match (1).
+        assert.equal(
+          res.code,
+          1,
+          `expected a clean no-match (1), got rc=${res.code} — the pattern was option-parsed. stderr=${res.stderr} cmd=${cmd}`,
+        )
+      } finally {
+        await fx.cleanup()
+      }
+    })
+
+    it('POSITIVE CONTROL: `-Wall` still matches as text through the grep fallback', async () => {
+      const fx = await makeFixture()
+      try {
+        const bin = await makeGrepOnlyPath(fx.dir)
+        const cmd = build('-Wall', fx.root)
+        const res = await runBuilt(cmd, {
+          cwd: fx.root,
+          env: { ...process.env, PATH: bin },
+        })
+        assert.equal(res.code, 0, `expected a match, got rc=${res.code} stderr=${res.stderr} cmd=${cmd}`)
+        assert.match(res.stdout, /compile with -Wall enabled/)
+      } finally {
+        await fx.cleanup()
+      }
+    })
+  })
+
+  describe('command shape', () => {
+    it('binds the pattern to `-e` in BOTH branches, so it can never fill a bare positional slot', () => {
+      const cmd = build('--pre=/tmp/evil.sh', '/work')
+      assert.match(cmd, /rg .*--no-heading -e '--pre=\/tmp\/evil\.sh' '\/work'/)
+      assert.match(cmd, /grep -r .* -e '--pre=\/tmp\/evil\.sh' '\/work'/)
+    })
+
+    it('keeps `-e` immediately before the pattern even with a glob filter present', () => {
+      const cmd = build('-Wall', '/work', { glob: '*.c' })
+      assert.match(cmd, /--no-heading --glob '\*\.c' -e '-Wall' '\/work'/)
+    })
+  })
+
+  describe('permission-model coupling', () => {
+    // The severity of #7295 comes from WHERE the sink sits, not from rg alone.
+    // `Grep` is classified read-only, so it is auto-approved in acceptEdits mode
+    // and can carry a standing auto-allow rule — while `Bash`, which has the same
+    // capability honestly, is refused a whitelist outright. This test pins that
+    // asymmetry to the builder: as long as Grep enjoys the read-only exemption,
+    // its command must not let a pattern reach an option parser.
+    it('Grep keeps its read-only exemption ONLY because the builder binds the pattern to `-e`', () => {
+      assert.ok(SECRET_READ_FLOOR_TOOLS.has('Grep'), 'premise: Grep gets the reduced secret-read floor')
+      assert.ok(ELIGIBLE_TOOLS.has('Grep'), 'premise: Grep is eligible for a session auto-allow rule')
+      assert.ok(NEVER_AUTO_ALLOW.has('Bash'), 'premise: Bash is too dangerous to whitelist')
+
+      // Every dash-leading shape a model could send must land as the operand of
+      // `-e`, never in a slot rg or grep would option-parse.
+      for (const pattern of ['--pre=/tmp/evil.sh', '-Wall', '--force', '-f/etc/passwd', '--']) {
+        const cmd = build(pattern, '/work')
+        assert.match(
+          cmd,
+          new RegExp(`-e '${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`),
+          `pattern ${pattern} is not bound to -e — Grep would exceed its read-only classification`,
+        )
+      }
+    })
+  })
+})

--- a/packages/server/tests/built-in-tools/grep-argv-injection.test.js
+++ b/packages/server/tests/built-in-tools/grep-argv-injection.test.js
@@ -33,24 +33,36 @@ import { spawn } from 'node:child_process'
 import { mkdtemp, mkdir, writeFile, rm, access, chmod } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { existsSync } from 'node:fs'
+import { existsSync, statSync, accessSync, constants } from 'node:fs'
 import { buildGrepArgs, buildGrepCommand } from '../../src/built-in-tools/tool-transforms.js'
 import { SECRET_READ_FLOOR_TOOLS } from '../../src/permission-floor.js'
-import { ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../../src/permission-manager.js'
+import { ACCEPT_EDITS_TOOLS, ELIGIBLE_TOOLS, NEVER_AUTO_ALLOW } from '../../src/permission-manager.js'
 
-/** Locate an executable on PATH without shelling out. */
+/**
+ * Locate an EXECUTABLE FILE on PATH without shelling out. `existsSync` alone is
+ * not enough: a directory or a non-executable file named `rg` would read as
+ * "present" and make the rg tests fail for an unrelated reason.
+ */
 function findOnPath(name) {
   for (const dir of (process.env.PATH || '').split(path.delimiter)) {
     if (!dir) continue
     const candidate = path.join(dir, name)
-    if (existsSync(candidate)) return candidate
+    try {
+      if (!statSync(candidate).isFile()) continue
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      continue
+    }
   }
   return null
 }
 
 const RG_PATH = findOnPath('rg')
 const GREP_PATH = findOnPath('grep')
-const BASH_PATH = findOnPath('bash') || '/bin/bash'
+// No `|| '/bin/bash'` fallback: that would make the `assert.ok(BASH_PATH)` guard
+// below unfireable, and silently shim to a bash that may not exist.
+const BASH_PATH = findOnPath('bash')
 
 /**
  * Run a built command the way the real sinks do (`bash -c`), with a hard
@@ -110,6 +122,11 @@ async function makeFixture() {
   return { dir, root, marker, script, cleanup: () => rm(dir, { recursive: true, force: true }) }
 }
 
+/** Single-quote a path for the hand-built positive-control command. */
+function shellQuoteForTest(v) {
+  return `'${String(v).replace(/'/g, `'\\''`)}'`
+}
+
 async function exists(p) {
   try {
     await access(p)
@@ -118,6 +135,40 @@ async function exists(p) {
     return false
   }
 }
+
+/**
+ * The rg tests carry the whole EXECUTION proof; the rest of the file can only
+ * assert on command text, which is exactly what this file's docblock argues is
+ * insufficient. So "ripgrep is missing" must not be silently equivalent to
+ * "nothing to check" — that is the second recurring cause in
+ * `docs/false-safety-guards.md`. On a developer machine without rg a loud skip
+ * is reasonable; in CI it is a FAILURE, because a green CI log is the thing
+ * nobody reads.
+ *
+ * Returns true when the caller should bail out of the test.
+ */
+function requireRgOrSkip(t, what) {
+  if (RG_PATH) return false
+  if (process.env.CI) {
+    assert.fail(
+      `ripgrep is not installed on this CI runner, so ${what} did not run. ` +
+      'This proof must not be skipped in CI — install ripgrep in the Server Tests job (#7295).',
+    )
+  }
+  t.skip(`ripgrep is not installed on this machine — ${what} did NOT run (it is enforced in CI).`)
+  return true
+}
+
+/**
+ * The spawning tests need a POSIX shell: the sinks under test are literally
+ * `spawn('bash', ['-c', cmd])` and `docker exec … bash -c`, and the fixtures are
+ * `#!/bin/sh` scripts with exec bits. None of that is meaningful on Windows, and
+ * the self-hosted Windows runner's bash is a distro-less WSL stub. Skipping the
+ * five spawning tests keeps the file IN the derived Windows run set (`run =
+ * all - WINDOWS_EXEMPT`, #7270) so the three command-shape/coupling tests still
+ * provide real Windows coverage — strictly better than exempting the whole file.
+ */
+const POSIX_ONLY = { skip: process.platform === 'win32' ? 'POSIX shell required (spawns bash + /bin/sh fixtures)' : false }
 
 /** Build exactly what `runGrep` / the container Grep build for this pattern. */
 function build(pattern, root, input = {}) {
@@ -147,11 +198,33 @@ async function makeGrepOnlyPath(dir) {
 
 describe('Grep argv option injection (#7295)', () => {
   describe('ripgrep branch', () => {
-    it('NEGATIVE CONTROL: a `--pre=` pattern must not execute a program', async (t) => {
-      if (!RG_PATH) {
-        t.skip('ripgrep is not installed on this machine — the rg-branch execution proof did NOT run. The grep-branch and command-shape tests below still cover the fix.')
-        return
+    // ARMS THE NEGATIVE CONTROL BELOW. Without this, `marker was not written`
+    // passes for free the moment the fixture stops taking effect — a failed
+    // chmod, a noexec tmpdir, a future rg that drops `--pre`, a cwd with no
+    // files to preprocess. Proven necessary: with the fix reverted AND the
+    // script mode changed to 0o644, the negative control went GREEN while the
+    // vulnerability was live. A negative assertion with no positive control is
+    // not evidence (`docs/false-safety-guards.md`).
+    it('POSITIVE CONTROL: the marker mechanism really does fire when --pre IS a genuine flag', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the marker-mechanism positive control')) return
+      const fx = await makeFixture()
+      try {
+        // Deliberately NOT via buildGrepCommand: this is the armed control, so
+        // it must reach rg's real `--pre` flag by construction.
+        const cmd = `rg -n --no-heading --pre=${shellQuoteForTest(fx.script)} -e 'compile' ${shellQuoteForTest(fx.root)}`
+        const res = await runBuilt(cmd, { cwd: fx.root })
+        assert.equal(
+          await exists(fx.marker),
+          true,
+          `the fixture is INERT: rg did not execute the preprocessor even when --pre was a real flag, so the negative control below proves nothing. rc=${res.code} stderr=${res.stderr} cmd=${cmd}`,
+        )
+      } finally {
+        await fx.cleanup()
       }
+    })
+
+    it('NEGATIVE CONTROL: a `--pre=` pattern must not execute a program', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the rg-branch execution proof')) return
       const fx = await makeFixture()
       try {
         const cmd = build(`--pre=${fx.script}`, fx.root)
@@ -168,11 +241,8 @@ describe('Grep argv option injection (#7295)', () => {
       }
     })
 
-    it('NEGATIVE CONTROL: a `--pre=` pattern must terminate, not hang on stdin', async (t) => {
-      if (!RG_PATH) {
-        t.skip('ripgrep is not installed on this machine — the rg-branch hang proof did NOT run.')
-        return
-      }
+    it('NEGATIVE CONTROL: a `--pre=` pattern must terminate, not hang on stdin', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the rg-branch hang proof')) return
       const fx = await makeFixture()
       try {
         const cmd = build(`--pre=${fx.script}`, fx.root)
@@ -187,11 +257,8 @@ describe('Grep argv option injection (#7295)', () => {
       }
     })
 
-    it('POSITIVE CONTROL: a legitimately dash-leading pattern (`-Wall`) still matches as text', async (t) => {
-      if (!RG_PATH) {
-        t.skip('ripgrep is not installed on this machine — the rg-branch positive control did NOT run.')
-        return
-      }
+    it('POSITIVE CONTROL: a legitimately dash-leading pattern (`-Wall`) still matches as text', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the rg-branch positive control')) return
       const fx = await makeFixture()
       try {
         const cmd = build('-Wall', fx.root)
@@ -205,7 +272,7 @@ describe('Grep argv option injection (#7295)', () => {
   })
 
   describe('grep fallback branch', () => {
-    it('NEGATIVE CONTROL: a `--pre=` pattern is searched as text, not parsed as an option', async () => {
+    it('NEGATIVE CONTROL: a `--pre=` pattern is searched as text, not parsed as an option', POSIX_ONLY, async () => {
       const fx = await makeFixture()
       try {
         const bin = await makeGrepOnlyPath(fx.dir)
@@ -215,6 +282,8 @@ describe('Grep argv option injection (#7295)', () => {
           env: { ...process.env, PATH: bin },
         })
         assert.equal(res.spawnError, undefined, `bash failed to spawn: ${res.spawnError}`)
+        // Belt-and-braces only: grep has no `--pre` analogue, so this can never
+        // fire. The rc assertion below is what actually carries this test.
         assert.equal(await exists(fx.marker), false, 'grep must not execute anything')
         // grep's exit codes: 0 = matched, 1 = no match, 2 = usage/other error.
         // Pre-fix the unknown `--pre` long option makes this a usage error (2);
@@ -229,7 +298,7 @@ describe('Grep argv option injection (#7295)', () => {
       }
     })
 
-    it('POSITIVE CONTROL: `-Wall` still matches as text through the grep fallback', async () => {
+    it('POSITIVE CONTROL: `-Wall` still matches as text through the grep fallback', POSIX_ONLY, async () => {
       const fx = await makeFixture()
       try {
         const bin = await makeGrepOnlyPath(fx.dir)
@@ -249,13 +318,78 @@ describe('Grep argv option injection (#7295)', () => {
   describe('command shape', () => {
     it('binds the pattern to `-e` in BOTH branches, so it can never fill a bare positional slot', () => {
       const cmd = build('--pre=/tmp/evil.sh', '/work')
-      assert.match(cmd, /rg .*--no-heading -e '--pre=\/tmp\/evil\.sh' '\/work'/)
-      assert.match(cmd, /grep -r .* -e '--pre=\/tmp\/evil\.sh' '\/work'/)
+      assert.match(cmd, /rg --no-config .*--no-heading -e '--pre=\/tmp\/evil\.sh' -- '\/work'/)
+      assert.match(cmd, /grep -r .* -e '--pre=\/tmp\/evil\.sh' -- '\/work'/)
     })
 
     it('keeps `-e` immediately before the pattern even with a glob filter present', () => {
       const cmd = build('-Wall', '/work', { glob: '*.c' })
-      assert.match(cmd, /--no-heading --glob '\*\.c' -e '-Wall' '\/work'/)
+      assert.match(cmd, /--no-heading --glob '\*\.c' -e '-Wall' -- '\/work'/)
+    })
+  })
+
+  describe('the root slot (#7295 follow-through)', () => {
+    // The fix bound the PATTERN. `root` is the builder's other interpolation and
+    // was still bare. Both callers happen to guarantee an absolute path today
+    // (safeResolveRoot / remapToContainerPath), so this is not a live hole — but
+    // the builder must not rest on an invariant it neither states nor tests.
+    // This is the adjacent-field shape: fix the field in the report, walk past
+    // its neighbour.
+    it('NEGATIVE CONTROL: a dash-leading root must not execute a program either', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the root-slot execution proof')) return
+      const fx = await makeFixture()
+      try {
+        const cmd = build('TODO', `--pre=${fx.script}`)
+        const res = await runBuilt(cmd, { cwd: fx.root })
+        assert.equal(
+          await exists(fx.marker),
+          false,
+          `the ROOT slot was option-parsed and rg executed the preprocessor. rc=${res.code} stderr=${res.stderr} cmd=${cmd}`,
+        )
+      } finally {
+        await fx.cleanup()
+      }
+    })
+
+    it('terminates option parsing with `--` before the root in BOTH branches', () => {
+      const cmd = build('TODO', '/work')
+      assert.match(cmd, /rg --no-config .* -e 'TODO' -- '\/work'/)
+      assert.match(cmd, /grep -r .* -e 'TODO' -- '\/work'/)
+    })
+
+    it('POSITIVE CONTROL: an ordinary root still searches normally', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the ordinary-root positive control')) return
+      const fx = await makeFixture()
+      try {
+        const res = await runBuilt(build('-Wall', fx.root), { cwd: fx.root })
+        assert.equal(res.code, 0, `expected a match, got rc=${res.code} stderr=${res.stderr}`)
+        assert.match(res.stdout, /compile with -Wall enabled/)
+      } finally {
+        await fx.cleanup()
+      }
+    })
+  })
+
+  describe('rg config isolation', () => {
+    // Not only hardening: rg applies RIPGREP_CONFIG_PATH as flags, so a developer
+    // config can silently CHANGE RESULTS of a machine-parsed search. Measured: a
+    // config of `--pre=/bin/echo` turns a matching search into rc=1 no-match.
+    it('ignores RIPGREP_CONFIG_PATH, which can both inject --pre and corrupt results', POSIX_ONLY, async (t) => {
+      if (requireRgOrSkip(t, 'the rg config-isolation proof')) return
+      const fx = await makeFixture()
+      try {
+        const cfg = path.join(fx.dir, 'rgcfg')
+        await writeFile(cfg, `--pre=${fx.script}\n`)
+        const res = await runBuilt(build('-Wall', fx.root), {
+          cwd: fx.root,
+          env: { ...process.env, RIPGREP_CONFIG_PATH: cfg },
+        })
+        assert.equal(await exists(fx.marker), false, 'a config-supplied --pre must not execute')
+        assert.equal(res.code, 0, `a hostile/ordinary rg config changed the RESULT: rc=${res.code} stderr=${res.stderr}`)
+        assert.match(res.stdout, /compile with -Wall enabled/)
+      } finally {
+        await fx.cleanup()
+      }
     })
   })
 
@@ -268,18 +402,26 @@ describe('Grep argv option injection (#7295)', () => {
     // its command must not let a pattern reach an option parser.
     it('Grep keeps its read-only exemption ONLY because the builder binds the pattern to `-e`', () => {
       assert.ok(SECRET_READ_FLOOR_TOOLS.has('Grep'), 'premise: Grep gets the reduced secret-read floor')
+      assert.ok(ACCEPT_EDITS_TOOLS.has('Grep'), 'premise: Grep is auto-approved in acceptEdits mode')
       assert.ok(ELIGIBLE_TOOLS.has('Grep'), 'premise: Grep is eligible for a session auto-allow rule')
       assert.ok(NEVER_AUTO_ALLOW.has('Bash'), 'premise: Bash is too dangerous to whitelist')
 
-      // Every dash-leading shape a model could send must land as the operand of
-      // `-e`, never in a slot rg or grep would option-parse.
+      // Assert PER BRANCH. Matching the whole `if … then rg …; else grep …; fi`
+      // string is satisfied by EITHER branch, so it stayed green under each
+      // single-branch mutant while that branch was fully exploitable — a check
+      // whose name claims more than its code verifies, which is the very defect
+      // class this file was written for.
       for (const pattern of ['--pre=/tmp/evil.sh', '-Wall', '--force', '-f/etc/passwd', '--']) {
         const cmd = build(pattern, '/work')
-        assert.match(
-          cmd,
-          new RegExp(`-e '${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`),
-          `pattern ${pattern} is not bound to -e — Grep would exceed its read-only classification`,
-        )
+        const [rgHalf, grepHalf] = cmd.split('; else ')
+        assert.ok(rgHalf.includes('rg ') && grepHalf.includes('grep -r '), `unexpected builder shape: ${cmd}`)
+        const quoted = `-e '${pattern}'`
+        for (const [branch, half] of [['rg', rgHalf], ['grep', grepHalf]]) {
+          assert.ok(
+            half.includes(quoted),
+            `pattern ${pattern} is not bound to -e in the ${branch} branch — Grep would exceed its read-only classification. half=${half}`,
+          )
+        }
       }
     })
   })

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -128,7 +128,7 @@ describe('buildGrepCommand', () => {
   it('prefers rg with an if/then/else grep fallback', () => {
     assert.equal(
       buildGrepCommand(base),
-      `if command -v rg >/dev/null 2>&1; then rg -i -n --no-heading -e 'TODO' '/work'; else grep -r -i -n -e 'TODO' '/work'; fi`,
+      `if command -v rg >/dev/null 2>&1; then rg --no-config -i -n --no-heading -e 'TODO' -- '/work'; else grep -r -i -n -e 'TODO' -- '/work'; fi`,
     )
   })
 
@@ -137,6 +137,6 @@ describe('buildGrepCommand', () => {
   })
 
   it('threads the glob arg into the rg command', () => {
-    assert.match(buildGrepCommand({ ...base, globArg: ` --glob '*.md'` }), /rg -i -n --no-heading --glob '\*\.md' -e 'TODO'/)
+    assert.match(buildGrepCommand({ ...base, globArg: ` --glob '*.md'` }), /rg --no-config -i -n --no-heading --glob '\*\.md' -e 'TODO'/)
   })
 })

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -128,7 +128,7 @@ describe('buildGrepCommand', () => {
   it('prefers rg with an if/then/else grep fallback', () => {
     assert.equal(
       buildGrepCommand(base),
-      `if command -v rg >/dev/null 2>&1; then rg -i -n --no-heading 'TODO' '/work'; else grep -r -i -n 'TODO' '/work'; fi`,
+      `if command -v rg >/dev/null 2>&1; then rg -i -n --no-heading -e 'TODO' '/work'; else grep -r -i -n -e 'TODO' '/work'; fi`,
     )
   })
 
@@ -137,6 +137,6 @@ describe('buildGrepCommand', () => {
   })
 
   it('threads the glob arg into the rg command', () => {
-    assert.match(buildGrepCommand({ ...base, globArg: ` --glob '*.md'` }), /rg -i -n --no-heading --glob '\*\.md'/)
+    assert.match(buildGrepCommand({ ...base, globArg: ` --glob '*.md'` }), /rg -i -n --no-heading --glob '\*\.md' -e 'TODO'/)
   })
 })


### PR DESCRIPTION
Closes #7295

## The bug

`buildGrepCommand` (`packages/server/src/built-in-tools/tool-transforms.js`) put the
model-controlled `pattern` into a **bare positional argv slot** of `rg` and of the
`grep -r` fallback:

```js
const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
```

`shellQuote` is a real defence and it works — bash consumes the quotes, so no
metacharacter is ever interpreted. What it cannot do is change what the quoted argv
element *is*. `rg` then runs its **own** option parser over a string that still begins
with `-`, and rg has options that execute programs.

Measured against ripgrep 15.1.0 with a marker-writing script:

```
rg -n --no-heading '--pre=/tmp/pre.sh' <root>      rc=1, marker WRITTEN
rg -n --no-heading -e '--pre=/tmp/pre.sh' <root>   rc=1, marker absent
```

Second effect: `--pre=` self-terminates, so `<root>` slides into the pattern slot and rg
is left with zero paths. Its stdin heuristic then makes it read a readable stdin and
block until EOF — a hung tool call, measured at the full length of the test's 8s timeout.
`maskExit: true` on the container path does not help; the process never exits to have its
code masked.

## Why it bypassed the permission model

`Grep` is classified read-only everywhere: `SECRET_READ_FLOOR_TOOLS`,
`ACCEPT_EDITS_TOOLS`, `ELIGIBLE_TOOLS`. It is auto-approved in `acceptEdits` mode and can
carry a standing auto-allow rule. `Bash` and `shell` are in `NEVER_AUTO_ALLOW` — refused
a whitelist as too dangerous to grant. The bug reached the `Bash` capability through the
tool exempted for not having it.

## The fix

`-e <pattern>` in both branches of the one shared builder — a single site covering both
sinks (`byok-tool-executor.js:299` and `docker-byok-session.js:2055`).

**Not** a leading-dash rejection. `-Wall` and `--force` are legitimate search patterns,
and on the unfixed builder `-Wall` was *already* a functional regression
(`rg: unrecognized flag -W`, exit 2). This is fix shape (3) in `utils/argv-safety.js`.

## Proven red first

`tests/built-in-tools/grep-argv-injection.test.js` **spawns** the built command rather
than only asserting on its text, because a string assertion is only as strong as the
reviewer's model of rg's parser.

All 8 tests confirmed **RED on the unfixed builder** before the fix:

| Test | Pre-fix failure |
|---|---|
| rg: `--pre=` must not execute a program | marker **written** — program executed |
| rg: `--pre=` must terminate, not hang | **hung** the full 8s timeout |
| rg: `-Wall` still matches as text | rc=2, `rg: unrecognized flag -W` |
| grep: `--pre=` searched as text | rc=2 usage error, not a clean no-match |
| grep: `-Wall` still matches as text | rc=2 |
| command shape ×2 | pattern in a bare positional slot |
| permission-model coupling | pattern not bound to `-e` |

Then mutated **one branch at a time** afterwards: dropping `-e` from the rg branch kills
5 tests, dropping it from the `grep -r` fallback kills 3, and the shape test catches
either. The full-mutant run is 7/7 red (the coupling test was added after).

The grep-fallback tests force their branch with a PATH containing only `bash` and `grep`
shims — not a real bin dir, which might also contain `rg` and silently exercise the other
branch. The rg tests `t.skip` with a loud reason if ripgrep is absent; the grep-branch and
command-shape tests always run.

## Verification

- Full server suite: **13764 tests, 13730 pass, 10 fail** — all 10 proven pre-existing by
  re-running the same 9 files against `origin/main`'s `tool-transforms.js` and diffing the
  failure sets (identical; they are local-env: macOS `/private/tmp` symlinks, a running
  daemon leaking `CHROXY_PORT`, no dashboard build, no codex binary).
- All 9 custom shell lints (`packages/server/scripts/lint-*.sh`): **pass**.
- `gen-agents-md.mjs --check` and `compile-skill-targets.mjs --check`: **in sync**.
- eslint: clean.

## Docs

Adds catalogue entry 14 to `docs/false-safety-guards.md`, and the matching recurring cause
to `CLAUDE.md` (+ regenerated `AGENTS.md`): *a real defence against the neighbouring class,
mistaken for cover*. Also notes the sibling asymmetry — `runGlob` validates its pattern six
lines above `runGrep`, which validated nothing.
