### PR TITLE
fix(server): probe the macOS Keychain for Claude creds, and accept `oauthAccount`

### DIFF
--- a/packages/server/src/auth-probes.js
+++ b/packages/server/src/auth-probes.js
@@ -28,6 +28,7 @@
  * file-by-file rationale.
  */
 import { existsSync, readFileSync, statSync } from 'fs'
+import { spawnSync } from 'child_process'
 import { join } from 'path'
 import { homedir } from 'os'
 import { configPath } from './config-dir.js'
@@ -42,16 +43,43 @@ import { configPath } from './config-dir.js'
  *   1. `~/.claude/auth.json`            — current SDK auth file
  *   2. `~/.claude/.credentials.json`    — older Claude Code CLI keystore
  *   3. `~/.claude.json`                 — global config; contains a
- *                                          `claudeAiOauth` block when the
- *                                          user has logged in via subscription
+ *                                          `claudeAiOauth` block (older) or an
+ *                                          `oauthAccount` block (current) when
+ *                                          the user has logged in
+ *   4. macOS Keychain                   — the generic-password item
+ *                                          `Claude Code-credentials`, which is
+ *                                          where current Claude Code actually
+ *                                          stores the credential on darwin
+ *
+ * #7331: checks 1-3 were file-only and keyed on `claudeAiOauth`, so on a
+ * FULLY AUTHENTICATED current macOS install the probe returned false — both
+ * files absent, `~/.claude.json` carrying `oauthAccount` instead, and the real
+ * credential sitting in the Keychain the probe never looked at. That is not a
+ * cosmetic label: `CreateSessionModal` disables the Create button on
+ * `auth.ready === false`, so a correctly-logged-in user could not start an SDK
+ * session at all, and was silently pushed onto `claude-tui` — the provider that
+ * can neither report nor switch models (#7327).
+ *
+ * The Keychain check tests EXISTENCE ONLY. It never passes `-w`, so the secret
+ * is never printed, and stdout/stderr are discarded rather than captured: the
+ * daemon has no reason to hold the user's credential in its own memory, and
+ * the question being asked is only "is there one".
  *
  * Override paths for tests / atypical installs:
- *   - `CHROXY_CLAUDE_HOME`   — overrides the directory for the first two
- *                              file checks AND the default location of
- *                              `.claude.json` (one level up from this dir).
- *   - `CHROXY_CLAUDE_CONFIG` — overrides the global `.claude.json` path
- *                              directly. Wins over the `CHROXY_CLAUDE_HOME`-
- *                              derived default when both are set.
+ *   - `CHROXY_CLAUDE_HOME`     — overrides the directory for the first two
+ *                                file checks AND the default location of
+ *                                `.claude.json` (one level up from this dir).
+ *   - `CHROXY_CLAUDE_CONFIG`   — overrides the global `.claude.json` path
+ *                                directly. Wins over the `CHROXY_CLAUDE_HOME`-
+ *                                derived default when both are set.
+ *   - `CHROXY_CLAUDE_KEYCHAIN` — `0` forces the Keychain probe to report
+ *                                absent, `1` forces present. A test cannot
+ *                                delete the developer's real Keychain item, so
+ *                                without this the logged-OUT direction could
+ *                                not be proven on a developer machine — and a
+ *                                probe only ever proven in the `true`
+ *                                direction is exactly as broken as the one
+ *                                this replaces (docs/false-safety-guards.md).
  */
 function probeClaudeOAuthCreds() {
   try {
@@ -65,17 +93,90 @@ function probeClaudeOAuthCreds() {
     if (existsSync(globalConfig)) {
       try {
         const parsed = JSON.parse(readFileSync(globalConfig, 'utf-8'))
-        if (parsed && typeof parsed === 'object' && parsed.claudeAiOauth) {
+        // `claudeAiOauth` is the older shape; current Claude Code writes
+        // `oauthAccount` here instead (#7331). Accept either.
+        if (parsed && typeof parsed === 'object' && (parsed.claudeAiOauth || parsed.oauthAccount)) {
           return true
         }
       } catch {
         // Malformed JSON — treat as absent.
       }
     }
+    if (probeClaudeKeychainCreds()) return true
   } catch {
     // Any unexpected fs error → behave as if no creds.
   }
   return false
+}
+
+/** The macOS Keychain generic-password service Claude Code stores its creds under. */
+const CLAUDE_KEYCHAIN_SERVICE = 'Claude Code-credentials'
+
+/**
+ * Does the macOS Keychain hold a Claude Code credential? EXISTENCE ONLY.
+ *
+ * Deliberately never passes `-w` (which would print the secret) and discards
+ * all output — the daemon has no reason to hold the user's credential, and the
+ * exit code alone answers the question. Non-darwin returns false without
+ * spawning anything.
+ *
+ * A spawn failure (no `security` binary, sandbox denial, a locked Keychain)
+ * counts as ABSENT. That is the honest reading: we could not observe a
+ * credential, so we must not claim one. It also keeps the failure mode the
+ * same as it was before this probe existed.
+ */
+function probeClaudeKeychainCreds() {
+  const override = process.env.CHROXY_CLAUDE_KEYCHAIN
+  if (override === '0') return false
+  if (override === '1') return true
+  return keychainItemExists(CLAUDE_KEYCHAIN_SERVICE)
+}
+
+/**
+ * The argv for the existence check, exported so a test can assert what this
+ * module is about to hand to `security`.
+ *
+ * The absent flag is the point: `-w` makes `security` PRINT the password to
+ * stdout. Nothing in a readiness probe should be able to do that, and a
+ * source-level guard is the only thing standing between "we ask whether a
+ * credential exists" and "we pipe the user's credential into the daemon". The
+ * override that keeps the unit tests hermetic also means the spawn itself is
+ * rarely executed under test, so this shape is pinned directly rather than
+ * inferred from behaviour.
+ */
+export function claudeKeychainProbeArgv() {
+  return ['find-generic-password', '-s', CLAUDE_KEYCHAIN_SERVICE]
+}
+
+/**
+ * Does a macOS Keychain generic-password item exist for `service`?
+ * EXISTENCE ONLY — output is discarded, the secret is never requested.
+ *
+ * Non-darwin returns false without spawning — an optimisation, not a
+ * correctness guard: on a host with no `security` binary the spawn below
+ * reports absent anyway.
+ *
+ * Every failure counts as ABSENT — we could not observe a credential, so we
+ * must not claim one. Note WHERE that is enforced, because the obvious reading
+ * is wrong: `spawnSync` does NOT throw for a missing binary. MEASURED, it
+ * returns `{ status: null, error: ENOENT }`, so it is the `status === 0`
+ * comparison that rejects it, not the `catch`. The `catch` is an unreachable
+ * backstop kept for a genuinely thrown error; it has no test because nothing
+ * observable reaches it, and claiming otherwise would be the exact
+ * comment-stronger-than-code shape catalogued in docs/false-safety-guards.md.
+ */
+export function keychainItemExists(service) {
+  if (process.platform !== 'darwin') return false
+  try {
+    const result = spawnSync(
+      'security',
+      ['find-generic-password', '-s', service],
+      { stdio: 'ignore', timeout: 5_000 },
+    )
+    return result.status === 0
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -154,7 +255,11 @@ function _cachedProbe(slot, key, probe) {
 }
 
 export function hasClaudeOAuthCreds() {
+  // The Keychain override is part of the key: without it a test that flips
+  // CHROXY_CLAUDE_KEYCHAIN inside the 5s TTL would silently read the previous
+  // verdict, and the logged-out assertion would pass for the wrong reason.
   const key = `${process.env.CHROXY_CLAUDE_HOME ?? ''}|${process.env.CHROXY_CLAUDE_CONFIG ?? ''}`
+    + `|${process.env.CHROXY_CLAUDE_KEYCHAIN ?? ''}`
   return _cachedProbe('claude', key, probeClaudeOAuthCreds)
 }
 

--- a/packages/server/tests/auth-probes.test.js
+++ b/packages/server/tests/auth-probes.test.js
@@ -13,6 +13,8 @@ import {
   hasGeminiOAuthCreds,
   cachedResolveCredentialFile,
   resetCachesForTest,
+  claudeKeychainProbeArgv,
+  keychainItemExists,
 } from '../src/auth-probes.js'
 
 // Boundary tests for the auth-probes module extracted from providers.js as
@@ -25,16 +27,29 @@ import {
 const ENV_KEYS = [
   'CHROXY_CLAUDE_HOME',
   'CHROXY_CLAUDE_CONFIG',
+  'CHROXY_CLAUDE_KEYCHAIN',
   'CHROXY_CODEX_HOME',
   'CHROXY_GEMINI_HOME',
 ]
 
+/**
+ * Run `body` with every override cleared — and with the macOS Keychain probe
+ * (#7331) forced ABSENT unless the test says otherwise.
+ *
+ * That default is not a convenience, it is what makes these tests mean
+ * anything. The probe consults the real Keychain on darwin, so without it the
+ * "returns false when no creds exist" cases pass or fail depending on whether
+ * the developer running them happens to be logged into Claude Code — four of
+ * them flipped to failing the moment the Keychain check landed. A credential
+ * probe whose tests read ambient machine state is not testing the probe.
+ */
 function withSavedEnv(body) {
   const saved = {}
   for (const k of ENV_KEYS) {
     saved[k] = process.env[k]
     delete process.env[k]
   }
+  process.env.CHROXY_CLAUDE_KEYCHAIN = '0'
   try {
     return body()
   } finally {
@@ -121,6 +136,133 @@ describe('auth-probes module (#4769)', () => {
           rmSync(tmp, { recursive: true, force: true })
         }
       })
+    })
+  })
+
+  describe('hasClaudeOAuthCreds — macOS Keychain + oauthAccount (#7331)', () => {
+    // The bug: on a fully authenticated CURRENT macOS install the probe
+    // returned false — `~/.claude/auth.json` and `.credentials.json` both
+    // absent, `~/.claude.json` carrying `oauthAccount` rather than
+    // `claudeAiOauth`, and the real credential in the Keychain the probe never
+    // consulted. `CreateSessionModal` disables Create on `ready === false`, so
+    // a logged-in user could not start an SDK session at all.
+
+    it('accepts `oauthAccount` in ~/.claude.json, not just `claudeAiOauth`', () => {
+      withSavedEnv(() => {
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-claude-'))
+        try {
+          process.env.CHROXY_CLAUDE_HOME = join(tmp, '.claude')
+          const cfg = join(tmp, '.claude.json')
+          process.env.CHROXY_CLAUDE_CONFIG = cfg
+          writeFileSync(cfg, JSON.stringify({ oauthAccount: { emailAddress: 'x@example.com' } }))
+          resetCachesForTest()
+          assert.equal(hasClaudeOAuthCreds(), true)
+        } finally {
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+
+    it('finds creds in the Keychain when NO file on disk has them', () => {
+      // The exact shape of the reported machine: every file check misses and
+      // the Keychain is the only thing that knows.
+      withSavedEnv(() => {
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-claude-'))
+        try {
+          process.env.CHROXY_CLAUDE_HOME = join(tmp, '.claude')
+          process.env.CHROXY_CLAUDE_CONFIG = join(tmp, '.claude.json')
+          process.env.CHROXY_CLAUDE_KEYCHAIN = '1'
+          resetCachesForTest()
+          assert.equal(hasClaudeOAuthCreds(), true)
+        } finally {
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+
+    it('returns FALSE when the Keychain is empty and no file has creds', () => {
+      // The direction that matters. A probe returning true unconditionally
+      // would satisfy the bug report and be just as broken as the original;
+      // this is the assertion that separates the two.
+      withSavedEnv(() => {
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-claude-'))
+        try {
+          process.env.CHROXY_CLAUDE_HOME = join(tmp, '.claude')
+          process.env.CHROXY_CLAUDE_CONFIG = join(tmp, '.claude.json')
+          process.env.CHROXY_CLAUDE_KEYCHAIN = '0'
+          resetCachesForTest()
+          assert.equal(hasClaudeOAuthCreds(), false)
+        } finally {
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+
+    it('a config with neither oauth key is still not creds', () => {
+      // Guards the `oauthAccount` widening from becoming "any object passes".
+      withSavedEnv(() => {
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-claude-'))
+        try {
+          process.env.CHROXY_CLAUDE_HOME = join(tmp, '.claude')
+          const cfg = join(tmp, '.claude.json')
+          process.env.CHROXY_CLAUDE_CONFIG = cfg
+          writeFileSync(cfg, JSON.stringify({ numStartups: 12, theme: 'dark' }))
+          resetCachesForTest()
+          assert.equal(hasClaudeOAuthCreds(), false)
+        } finally {
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+
+    it('the Keychain verdict is part of the cache key, not smeared across the TTL', () => {
+      // The probe is cached for 5s. If the override were absent from the key,
+      // flipping it inside that window would return the stale verdict and the
+      // logged-out assertion above would pass for the wrong reason.
+      withSavedEnv(() => {
+        const tmp = mkdtempSync(join(tmpdir(), 'auth-probes-claude-'))
+        try {
+          process.env.CHROXY_CLAUDE_HOME = join(tmp, '.claude')
+          process.env.CHROXY_CLAUDE_CONFIG = join(tmp, '.claude.json')
+          resetCachesForTest()
+          process.env.CHROXY_CLAUDE_KEYCHAIN = '1'
+          assert.equal(hasClaudeOAuthCreds(), true)
+          process.env.CHROXY_CLAUDE_KEYCHAIN = '0'   // no resetCachesForTest()
+          assert.equal(hasClaudeOAuthCreds(), false, 'the flip must not read a cached verdict')
+        } finally {
+          rmSync(tmp, { recursive: true, force: true })
+        }
+      })
+    })
+  })
+
+  describe('the Keychain probe itself (#7331)', () => {
+    // The CHROXY_CLAUDE_KEYCHAIN override that keeps the tests above hermetic
+    // also short-circuits before the real code — so without this block the
+    // spawn, the exit-code handling and the argv had NO coverage at all, and
+    // mutations to all three passed green. These exercise the real thing.
+
+    it('never asks `security` to print the secret', () => {
+      // `-w` makes `security` write the password to stdout. A readiness probe
+      // must never be able to; this is the guard, and it is deliberately a
+      // source-shape assertion because the spawn is rarely reached under test.
+      const argv = claudeKeychainProbeArgv()
+      assert.equal(argv.includes('-w'), false, '-w would print the credential')
+      assert.equal(argv.includes('-g'), false, '-g would print the credential')
+      assert.ok(argv.includes('-s'), 'must query by service name')
+      assert.ok(argv.includes('Claude Code-credentials'))
+    })
+
+    it('reports absent for a service that does not exist (real spawn)', () => {
+      // Runs the actual `security` binary on darwin — the only test that
+      // exercises spawn + non-zero exit. Uses a service name nothing owns, so
+      // it does not depend on whether the developer is logged in.
+      assert.equal(keychainItemExists('chroxy-nonexistent-service-7331'), false)
+    })
+
+    it('reports absent without spawning on non-darwin', function () {
+      if (process.platform === 'darwin') return   // covered by the CI Linux job
+      assert.equal(keychainItemExists('Claude Code-credentials'), false)
     })
   })
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -236,7 +236,7 @@ describe('Provider Registry', () => {
   // so the dashboard can grey-out unusable providers and show a billing-
   // identity confidence panel without making the user run `chroxy doctor`.
   describe('auth status (#3404 audit)', () => {
-    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'DEEPSEEK_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME', 'CHROXY_CONFIG_DIR']
+    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'DEEPSEEK_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CLAUDE_KEYCHAIN', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME', 'CHROXY_CONFIG_DIR']
     const saved = {}
     let _tmpClaudeHome = null
     let _tmpCodexHome = null
@@ -254,6 +254,12 @@ describe('Provider Registry', () => {
       _tmpClaudeHome = mkdtempSync(join(tmpdir(), 'chroxy-claude-home-'))
       process.env.CHROXY_CLAUDE_HOME = _tmpClaudeHome
       process.env.CHROXY_CLAUDE_CONFIG = join(_tmpClaudeHome, '.claude.json')
+      // #7331: the probe now also consults the macOS Keychain, which an empty
+      // tmpdir cannot isolate — on a logged-in developer machine three
+      // `ready=false` assertions below started reading the real credential and
+      // failing. Same intent as the two lines above, extended to the one
+      // credential source that is not a file.
+      process.env.CHROXY_CLAUDE_KEYCHAIN = '0'
       // #4301: same isolation pattern for the new codex/gemini OAuth probes —
       // point them at empty tmpdirs so neither the developer's real ~/.codex
       // or ~/.gemini state nor any prior test leftover leaks in.
@@ -1203,7 +1209,7 @@ describe('listProviders credential-file caching (#4658)', () => {
   // Env vars the cache key is sensitive to. Saved/restored per test so a
   // stray ANTHROPIC_API_KEY in the developer env doesn't suppress the file
   // path under test.
-  const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'DEEPSEEK_API_KEY', 'HOME', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME', 'CHROXY_CONFIG_DIR']
+  const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'DEEPSEEK_API_KEY', 'HOME', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CLAUDE_KEYCHAIN', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME', 'CHROXY_CONFIG_DIR']
   let saved
   let tmpHome
   let _tmpClaudeHome
@@ -1228,6 +1234,8 @@ describe('listProviders credential-file caching (#4658)', () => {
     _tmpClaudeHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-cache-claude-'))
     process.env.CHROXY_CLAUDE_HOME = _tmpClaudeHome
     process.env.CHROXY_CLAUDE_CONFIG = join(_tmpClaudeHome, '.claude.json')
+    // #7331: Keychain isolation — see the note in the block above.
+    process.env.CHROXY_CLAUDE_KEYCHAIN = '0'
     _tmpCodexHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-cache-codex-'))
     process.env.CHROXY_CODEX_HOME = _tmpCodexHome
     _tmpGeminiHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-cache-gemini-'))


### PR DESCRIPTION
Closes #7331

## The bug

On a fully authenticated current macOS install, `claude-sdk` reports `ready: false`, and `CreateSessionModal` **disables the Create button** on that flag. A correctly-logged-in user cannot start an SDK session at all — and is silently pushed onto `claude-tui`, the provider that can neither report nor switch models (#7327).

Reproduced on this machine, with a working `claude-tui` session running against the same auth:

```
MISSING  ~/.claude/auth.json
MISSING  ~/.claude/.credentials.json
EXISTS   ~/.claude.json      ->  claudeAiOauth: false   oauthAccount: TRUE
EXISTS   Keychain item "Claude Code-credentials"

hasClaudeOAuthCreds()  ->  false        <-- on an authed machine
```

Two gaps: the global config carries **`oauthAccount`** where the probe only knew `claudeAiOauth`, and the real credential lives in the **macOS Keychain**, which `auth-probes.js` had no awareness of whatsoever.

## The fix

Accept either config key, and add a Keychain check — **existence only**:

- never passes `-w` (which makes `security` print the password) or `-g`
- `stdio: 'ignore'` — the daemon has no reason to hold the user's credential
- non-darwin returns false without spawning
- a missing binary or locked Keychain counts as **absent**: we could not observe a credential, so we must not claim one

| | before | after |
|---|---|---|
| authed machine | `false` **(bug)** | `true` |
| logged out (empty home + no Keychain item) | `false` | `false` |
| Keychain only, no files | `false` **(bug)** | `true` |

## Proven in both directions, deliberately

A probe returning `true` unconditionally would satisfy the bug report and be **exactly as broken** as the one it replaces. A developer machine cannot have its real Keychain item deleted for a test, so `CHROXY_CLAUDE_KEYCHAIN` (`0` forces absent, `1` forces present) exists to make the logged-out direction assertable. It is part of the 5s cache key — flipping it inside the TTL must not return a stale verdict, and there is a test for that.

## The override had to be threaded through two existing harnesses

Adding a credential source that **is not a file** broke isolation those harnesses were explicitly built for. Four tests in `auth-probes.test.js` and three in `providers.test.js` began asserting `ready=false` while consulting the developer's *real* Keychain — so their result depended on whether whoever ran them happened to be logged into Claude Code. Both now force the probe absent by default, which is what their existing `#3674` comments already say they are for:

> *"point the OAuth probe at an empty tmpdir so neither the developer's actual `~/.claude` state nor a previous test's leftover can satisfy `_hasClaudeOAuthCreds()`"*

## Mutations — each asserted to land

| mutation | red |
|---|---|
| Keychain never consulted | 2 |
| `oauthAccount` not accepted | 1 |
| override dropped from the cache key | 1 |
| `-w` added (would print the credential) | 1 |
| exit-code check inverted | 1 |
| probe returns true unconditionally (#7273 shape) | 7 |

**Two survive, and are documented rather than papered over.** Removing the non-darwin early return is an *equivalent* mutant — the spawn reports absent on a host with no `security` anyway, so the guard is an optimisation, not correctness. And the `catch` is unreachable: **measured**, `spawnSync` does not throw for a missing binary, it returns `{status: null, error: ENOENT}`, so `status === 0` is what rejects it. The JSDoc claimed the `catch` handled that case — that is the comment-stronger-than-code shape from `docs/false-safety-guards.md` entry 15, so the comment now describes what the code does.

## Not in scope

The issue notes `CliSession.resolveAuth()` is hardcoded `ready: true` and probes nothing, so `claude-cli` never checks while `claude-sdk` checked wrongly. Making the two consistent is a real follow-up but a behaviour change for a second provider; kept out of a fix whose job is to stop blocking authenticated users.

## Verification

312/312 across `auth-probes`, `providers`, `credential-store`, `sdk-session` · 9/9 shell lints · eslint clean