### PR TITLE
fix(billing): the programmatic-credit era never started — stop asserting it

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -83,39 +83,36 @@ function generateDefaultName(cwdPath: string, existingNames: string[]): string {
 const EMPTY_STRINGS: string[] = []
 const EMPTY_MODELS: ModelInfo[] = []
 
-// #5629: the programmatic-credit era boundary, MIRRORED from the server's
-// PROGRAMMATIC_CREDIT_ERA_START (packages/server/src/billing-class.js). The
-// server-driven `auth.detail` is always preferred; this constant only date-
-// gates the STATIC fallback copy below (shown before the live provider list
-// arrives). Keep the two boundaries in sync if this ever moves. 2026-06-15
-// 00:00:00 UTC — Date.UTC month arg is 0-indexed so `5` is June.
-const PROGRAMMATIC_CREDIT_ERA_START = Date.UTC(2026, 5, 15)
-
-/** Client-side mirror of the server's isProgrammaticCreditEra (injectable now). */
-function isProgrammaticCreditEra(now: number = Date.now()): boolean {
-  return now >= PROGRAMMATIC_CREDIT_ERA_START
-}
+// #7333: the client-side mirror of the server's era boundary is GONE.
+//
+// It was a second implementation of one rule — a copy of
+// PROGRAMMATIC_CREDIT_ERA_START plus its comparison — kept in sync by a
+// comment. That was survivable while the rule was a pure date. It is not
+// survivable now: the server gates the era on an OPERATOR FLAG
+// (CHROXY_PROGRAMMATIC_CREDIT_ERA), because the regime Anthropic announced for
+// 2026-06-15 was paused and never shipped. A client cannot observe that flag,
+// so any date arithmetic here would be wrong by construction rather than
+// merely at risk of drifting.
+//
+// The static copy below is only the pre-load fallback; the server-driven
+// `auth.detail` — which does know the flag — takes precedence at the render
+// site, exactly as before. The fallback now states the billing that is
+// actually in force.
 
 /**
  * Billing context per provider — helps users understand cost implications.
  *
- * Date-gated only for the HOST providers that flip from a flat subscription to
- * the metered programmatic-credit pool on 2026-06-15 (claude-cli / claude-sdk).
- * docker-cli / docker-sdk forward an ANTHROPIC_API_KEY into the container with
- * no OAuth fallback, so they are always api-key (the host credit pool never
- * applies inside the container) — NOT date-gated. This is only the STATIC
- * fallback; the live server `auth.detail` (itself era-gated server-side) takes
- * precedence at the render site below.
+ * No longer date-gated (#7333): claude-cli / claude-sdk bill against the Claude
+ * subscription, because the metered programmatic-credit regime announced for
+ * 2026-06-15 was paused and never took effect. If it is ever revived, the
+ * server's `auth.detail` reports it — an operator sets the flag there and the
+ * live copy follows. This is only the STATIC pre-load fallback; the live
+ * server `auth.detail` takes precedence at the render site below.
  */
-function providerBillingFallback(provider: string, now: number = Date.now()): string | undefined {
-  const era = isProgrammaticCreditEra(now)
+function providerBillingFallback(provider: string): string | undefined {
   const STATIC: Record<string, string> = {
-    'claude-sdk': era
-      ? 'Programmatic credit pool — monthly metered credits'
-      : 'Uses your Claude subscription',
-    'claude-cli': era
-      ? 'Programmatic credit pool — monthly metered credits'
-      : 'Uses your Claude subscription',
+    'claude-sdk': 'Uses your Claude subscription',
+    'claude-cli': 'Uses your Claude subscription',
     'claude-tui': 'Uses your Claude subscription (interactive TUI — bypasses programmatic credit metering)',
     'claude-byok': 'Direct Anthropic API — per-token billing with your own ANTHROPIC_API_KEY. No claude binary required.',
     'docker-cli': 'Docker-isolated — Anthropic API (your ANTHROPIC_API_KEY forwarded to the container)',

--- a/packages/dashboard/src/components/CreateSessionModalBilling.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalBilling.test.tsx
@@ -89,24 +89,28 @@ function renderWithState(defaultProvider: string, providers: ProviderInfo[]) {
   )
 }
 
-describe('CreateSessionModal billing copy — era-gated fallback (#5629)', () => {
-  it('shows the subscription fallback BEFORE 2026-06-15', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-06-14T12:00:00Z'))
-    renderWithState('claude-cli', [CLAUDE_CLI_NO_DETAIL])
-    const hint = screen.getByTestId('provider-billing-hint')
-    expect(hint.textContent ?? '').toMatch(/subscription/i)
-    expect(hint.textContent ?? '').not.toMatch(/programmatic credit pool/i)
-    // Source attribute reflects the static fallback path.
-    expect(hint.getAttribute('data-source')).toBe('static')
-  })
+describe('CreateSessionModal billing copy — static fallback (#5629, #7333)', () => {
+  // #7333: the client-side date mirror is gone. The server gates the era on an
+  // operator flag now (the announced 2026-06-15 regime was paused and never
+  // shipped), and a client cannot observe that flag — so any date arithmetic
+  // here would be wrong by construction, not merely at risk of drifting.
+  // The static fallback states the billing actually in force; the live
+  // server-driven detail, which does know the flag, still takes precedence.
 
-  it('shows the programmatic-credit fallback ON/AFTER 2026-06-15', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-06-15T00:00:00Z'))
-    renderWithState('claude-cli', [CLAUDE_CLI_NO_DETAIL])
-    const hint = screen.getByTestId('provider-billing-hint')
-    expect(hint.textContent ?? '').toMatch(/programmatic credit pool/i)
+  it('shows the subscription fallback regardless of the date', () => {
+    // Including dates past the announced cutover, which is precisely where the
+    // old mirror started claiming a metered credit pool that does not exist.
+    for (const when of ['2026-06-14T12:00:00Z', '2026-06-15T00:00:00Z', '2027-01-01T00:00:00Z']) {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(when))
+      renderWithState('claude-cli', [CLAUDE_CLI_NO_DETAIL])
+      const hint = screen.getByTestId('provider-billing-hint')
+      expect(hint.textContent ?? '', `at ${when}`).toMatch(/subscription/i)
+      expect(hint.textContent ?? '', `at ${when}`).not.toMatch(/programmatic credit pool/i)
+      expect(hint.getAttribute('data-source')).toBe('static')
+      cleanup()
+      vi.useRealTimers()
+    }
   })
 
   it('prefers the live server detail over the static fallback', () => {

--- a/packages/server/src/billing-class.js
+++ b/packages/server/src/billing-class.js
@@ -2,7 +2,8 @@
  * Era-aware billing classification (#5630 / #5629).
  *
  * Chroxy bills Claude usage three different ways depending on the provider
- * and (for the programmatic providers) the date. Historically the dashboard
+ * and (for the programmatic providers) whether an operator has declared the
+ * programmatic-credit era in force. Historically the dashboard
  * labelled every dollar figure "Cost (BYOK)" — wrong for subscription and
  * programmatic-credit sessions (#5630) — and the provider copy still said
  * "subscription" for claude-cli / claude-sdk even though Anthropic moves
@@ -22,10 +23,11 @@
  *                          claude-channel). No per-turn dollar figure. Era-
  *                          independent.
  *   - programmatic-credit — host claude-cli / claude-sdk when auth is the
- *                          OAuth/subscription pool. BEFORE 2026-06-15 these
- *                          bill as flat `subscription`; ON/AFTER they draw from
- *                          Anthropic's monthly metered programmatic-credit pool,
- *                          so spend becomes a real dollar figure.
+ *                          OAuth/subscription pool AND an operator has declared
+ *                          the era in force via CHROXY_PROGRAMMATIC_CREDIT_ERA=1.
+ *                          NOT IN FORCE TODAY (#7333): Anthropic paused the
+ *                          change on 2026-06-15 and it never shipped, so these
+ *                          providers bill as flat `subscription`.
  *
  * Refinement: a claude-cli / claude-sdk session authed with an explicit
  * ANTHROPIC_API_KEY (the raw-API branch in resolveAuth, source === 'env') is
@@ -94,7 +96,36 @@ const API_KEY_PROVIDERS = new Set([
  * @returns {boolean}
  */
 export function isProgrammaticCreditEra(now = Date.now()) {
+  if (!programmaticCreditEraEnabled()) return false
   return now >= PROGRAMMATIC_CREDIT_ERA_START
+}
+
+/**
+ * Has an operator declared the programmatic-credit era in force? (#7333)
+ *
+ * THE ERA NEVER STARTED. Anthropic paused the change on 2026-06-15, the day it
+ * was due to take effect, and it has not shipped: `claude -p`, the Agent SDK
+ * and third-party app usage still draw from the subscription's usage limits.
+ * The date comparison above had no feature check, so it silently flipped true
+ * on the announced date and chroxy has been asserting a billing regime that
+ * does not exist every day since — telling users `claude-cli`/`claude-sdk`
+ * bill against a "monthly metered credit pool", and showing a real dollar
+ * figure where a subscription session should read "Included".
+ *
+ * That misdirects provider choice: it steers users away from `claude-cli`, at
+ * present the best-working Claude provider, toward `claude-tui`, which can
+ * neither report nor switch models (#7327), on the basis of a cost that is not
+ * being charged.
+ *
+ * A date with no way to observe whether the event happened is the
+ * "cannot check this, so assume it did" cause in docs/false-safety-guards.md.
+ * The observable replaces it: an operator sets `CHROXY_PROGRAMMATIC_CREDIT_ERA=1`
+ * when the regime actually arrives. The constant and every consumer stay wired
+ * up, because the pause is explicitly "for now" — a revival is this flag plus,
+ * if the announced date moves, one edit to PROGRAMMATIC_CREDIT_ERA_START.
+ */
+export function programmaticCreditEraEnabled() {
+  return process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA === '1'
 }
 
 /**

--- a/packages/server/src/billing-class.js
+++ b/packages/server/src/billing-class.js
@@ -6,8 +6,10 @@
  * programmatic-credit era in force. Historically the dashboard
  * labelled every dollar figure "Cost (BYOK)" — wrong for subscription and
  * programmatic-credit sessions (#5630) — and the provider copy still said
- * "subscription" for claude-cli / claude-sdk even though Anthropic moves
- * those onto a metered programmatic-credit pool on 2026-06-15 (#5629).
+ * "subscription" for claude-cli / claude-sdk ahead of a metered
+ * programmatic-credit pool Anthropic announced for 2026-06-15 (#5629). That
+ * pool was PAUSED on the day it was due and never shipped, so subscription is
+ * the correct copy after all; see `programmaticCreditEraEnabled` (#7333).
  *
  * This module is the single source of truth for "which billing class is
  * this session/provider in right now?" Every provider `resolveAuth()` and the

--- a/packages/server/tests/billing-canary-monitor.test.js
+++ b/packages/server/tests/billing-canary-monitor.test.js
@@ -36,6 +36,32 @@ function withEraEnabled(body) {
   return out
 }
 
+/**
+ * The mirror of {@link withEraEnabled}, and just as necessary. An era-OFF
+ * assertion that merely relies on the flag being absent from the ambient
+ * environment tests nothing on a machine where an operator HAS set it: the
+ * premise silently inverts and the case either fails for the wrong reason or
+ * stops covering the default it exists to pin. Same class as #7360.
+ */
+function withEraDisabled(body) {
+  const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  const restore = () => {
+    if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+    else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
+  }
+  let out
+  try {
+    out = body()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (out && typeof out.then === 'function') return out.finally(restore)
+  restore()
+  return out
+}
+
 function make(opts = {}) {
   const broadcasts = []
   const monitor = new BillingCanaryMonitor({
@@ -253,7 +279,7 @@ test('notify failure is swallowed (does not break refresh)', () => {
   assert.equal(broadcasts.length, 1) // broadcast still happened
 })
 
-test('the monitor raises no metering warning by default, at any date (#7333)', () => {
+test('the monitor raises no metering warning by default, at any date (#7333)', () => withEraDisabled(() => {
   // The user-visible fix at the monitor layer: with no operator flag, the
   // canary must not broadcast advice about the paused regime — at the
   // announced cutover or any time after it.
@@ -263,7 +289,7 @@ test('the monitor raises no metering warning by default, at any date (#7333)', (
     const codes = (snap.warnings ?? []).map((w) => w.code)
     assert.equal(codes.includes('SILENT_METERED_DEFAULT'), false, `warned at ${now}`)
   }
-})
+}))
 
 test('...but it does warn once an operator declares the era (control)', () => {
   // Without this the assertion above is satisfied by a monitor that never

--- a/packages/server/tests/billing-canary-monitor.test.js
+++ b/packages/server/tests/billing-canary-monitor.test.js
@@ -2,8 +2,39 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { BillingCanaryMonitor } from '../src/billing-canary-monitor.js'
 
-const AFTER = Date.UTC(2026, 5, 16) // one day into the programmatic-credit era
-const BEFORE = Date.UTC(2026, 5, 1) // before the cutover
+const AFTER = Date.UTC(2026, 5, 16) // one day past the announced cutover
+const BEFORE = Date.UTC(2026, 5, 1) // before the announced cutover
+
+/**
+ * #7333 — the era is gated on an operator flag now, not the calendar, because
+ * Anthropic paused the programmatic-credit change on 2026-06-15 and it never
+ * shipped. The canary only has anything to say when the regime is actually in
+ * force, so `AFTER` alone no longer turns it on. Default-off behaviour is
+ * asserted at the bottom of this file.
+ */
+function withEraEnabled(body) {
+  const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
+  const restore = () => {
+    if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+    else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
+  }
+  // Promise-aware on purpose. A plain try/finally restores the flag the moment
+  // an ASYNC body returns its promise — i.e. before the body has run — so the
+  // assertions execute with the era already off. That silently un-did the
+  // wrapper for one async test here, and would have done the same to the next
+  // async test added to the sibling copies of this helper.
+  let out
+  try {
+    out = body()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (out && typeof out.then === 'function') return out.finally(restore)
+  restore()
+  return out
+}
 
 function make(opts = {}) {
   const broadcasts = []
@@ -18,7 +49,7 @@ function make(opts = {}) {
   return { monitor, broadcasts }
 }
 
-test('compute maps live sessions to the canary shape and reports the default billing class', () => {
+test('compute maps live sessions to the canary shape and reports the default billing class', () => withEraEnabled(() => {
   const { monitor } = make({
     getDefaultProvider: () => 'claude-tui',
     getSessions: () => [{ sessionId: 's1', provider: 'claude-tui', cumulativeUsage: { costUsd: 0 } }],
@@ -28,15 +59,15 @@ test('compute maps live sessions to the canary shape and reports the default bil
   assert.equal(snap.defaultProvider, 'claude-tui')
   assert.equal(snap.defaultBillingClass, 'subscription')
   assert.deepEqual(snap.warnings, [])
-})
+}))
 
-test('flags a silent metered default (claude-sdk, era, no key)', () => {
+test('flags a silent metered default (claude-sdk, era, no key)', () => withEraEnabled(() => {
   const { monitor } = make({ getDefaultProvider: () => 'claude-sdk' })
   const snap = monitor.compute()
   assert.equal(snap.defaultBillingClass, 'programmatic-credit')
   assert.equal(snap.warnings.length, 1)
   assert.equal(snap.warnings[0].code, 'SILENT_METERED_DEFAULT')
-})
+}))
 
 test('does NOT flag claude-sdk default when apiKeyAuth (BYOK)', () => {
   const { monitor } = make({ getDefaultProvider: () => 'claude-sdk', getApiKeyAuth: () => true })
@@ -53,16 +84,16 @@ test('reclassification tripwire is dormant for a zero-cost claude-tui session', 
   assert.deepEqual(monitor.compute().warnings, [])
 })
 
-test('reclassification tripwire fires if a claude-tui session ever reports cost', () => {
+test('reclassification tripwire fires if a claude-tui session ever reports cost', () => withEraEnabled(() => {
   const { monitor } = make({
     getDefaultProvider: () => 'claude-tui',
     getSessions: () => [{ sessionId: 's1', provider: 'claude-tui', cumulativeUsage: { costUsd: 0.5 } }],
   })
   const codes = monitor.compute().warnings.map((w) => w.code)
   assert.ok(codes.includes('TUI_REPORTED_PROGRAMMATIC_COST'))
-})
+}))
 
-test('refresh broadcasts on change, dedupes when unchanged, and broadcasts a clear', () => {
+test('refresh broadcasts on change, dedupes when unchanged, and broadcasts a clear', () => withEraEnabled(() => {
   let provider = 'claude-sdk' // metered default → warning
   const { monitor, broadcasts } = make({ getDefaultProvider: () => provider })
 
@@ -78,14 +109,14 @@ test('refresh broadcasts on change, dedupes when unchanged, and broadcasts a cle
   monitor.refresh()
   assert.equal(broadcasts.length, 2)
   assert.deepEqual(broadcasts[1].warnings, [])
-})
+}))
 
-test('current() returns the latest snapshot, computing once if never refreshed', () => {
+test('current() returns the latest snapshot, computing once if never refreshed', () => withEraEnabled(() => {
   const { monitor } = make({ getDefaultProvider: () => 'claude-sdk' })
   const c = monitor.current()
   assert.equal(c.defaultProvider, 'claude-sdk')
   assert.equal(c.warnings.length, 1)
-})
+}))
 
 test('pre-cutover: no metered warning even for a programmatic default', () => {
   const { monitor } = make({ now: BEFORE, getDefaultProvider: () => 'claude-sdk' })
@@ -145,7 +176,7 @@ test('getDatacenterPrefixes extends the built-in egress list', async () => {
   assert.ok(monitor.current().warnings.some((w) => w.code === 'DATACENTER_EGRESS'))
 })
 
-test('notify fires once per distinct non-empty set, then once on the clear transition (#5828)', () => {
+test('notify fires once per distinct non-empty set, then once on the clear transition (#5828)', () => withEraEnabled(() => {
   const notified = []
   let provider = 'claude-sdk' // metered default → warning
   const { monitor } = make({
@@ -167,7 +198,7 @@ test('notify fires once per distinct non-empty set, then once on the clear trans
 
   monitor.refresh() // stays clear → no repeated all-clear
   assert.equal(notified.length, 2)
-})
+}))
 
 test('notify does NOT fire a spurious all-clear at startup (never warned)', () => {
   const notified = []
@@ -180,7 +211,7 @@ test('notify does NOT fire a spurious all-clear at startup (never warned)', () =
   assert.equal(notified.length, 0)
 })
 
-test('notify re-fires when the warning set changes (new code appears)', async () => {
+test('notify re-fires when the warning set changes (new code appears)', async () => withEraEnabled(async () => {
   const notified = []
   const { monitor } = make({
     getDefaultProvider: () => 'claude-sdk', // metered default warning from the start
@@ -194,7 +225,7 @@ test('notify re-fires when the warning set changes (new code appears)', async ()
   await monitor._tick() // egress resolves → set grows
   assert.equal(notified.length, 2)
   assert.deepEqual(notified[1], ['DATACENTER_EGRESS', 'SILENT_METERED_DEFAULT'])
-})
+}))
 
 test('_tick after stop() does not refresh (in-flight egress lookup during shutdown)', async () => {
   let release
@@ -220,4 +251,26 @@ test('notify failure is swallowed (does not break refresh)', () => {
   })
   assert.doesNotThrow(() => monitor.refresh())
   assert.equal(broadcasts.length, 1) // broadcast still happened
+})
+
+test('the monitor raises no metering warning by default, at any date (#7333)', () => {
+  // The user-visible fix at the monitor layer: with no operator flag, the
+  // canary must not broadcast advice about the paused regime — at the
+  // announced cutover or any time after it.
+  for (const now of [AFTER, Date.UTC(2027, 0, 1)]) {
+    const { monitor } = make({ now, getDefaultProvider: () => 'claude-sdk' })
+    const snap = monitor.compute()
+    const codes = (snap.warnings ?? []).map((w) => w.code)
+    assert.equal(codes.includes('SILENT_METERED_DEFAULT'), false, `warned at ${now}`)
+  }
+})
+
+test('...but it does warn once an operator declares the era (control)', () => {
+  // Without this the assertion above is satisfied by a monitor that never
+  // warns about anything.
+  withEraEnabled(() => {
+    const { monitor } = make({ now: AFTER, getDefaultProvider: () => 'claude-sdk' })
+    const codes = (monitor.compute().warnings ?? []).map((w) => w.code)
+    assert.ok(codes.includes('SILENT_METERED_DEFAULT'))
+  })
 })

--- a/packages/server/tests/billing-class.test.js
+++ b/packages/server/tests/billing-class.test.js
@@ -32,12 +32,25 @@ describe('PROGRAMMATIC_CREDIT_ERA_START', () => {
 function withEraEnabled(body) {
   const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
   process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
-  try {
-    return body()
-  } finally {
+  const restore = () => {
     if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
     else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
   }
+  // Promise-aware on purpose. A plain try/finally restores the flag the moment
+  // an ASYNC body returns its promise — i.e. before the body has run — so the
+  // assertions execute with the era already off. That silently un-did the
+  // wrapper for one async test here, and would have done the same to the next
+  // async test added to the sibling copies of this helper.
+  let out
+  try {
+    out = body()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (out && typeof out.then === 'function') return out.finally(restore)
+  restore()
+  return out
 }
 
 describe('the era is OFF by default (#7333)', () => {

--- a/packages/server/tests/billing-class.test.js
+++ b/packages/server/tests/billing-class.test.js
@@ -21,24 +21,75 @@ describe('PROGRAMMATIC_CREDIT_ERA_START', () => {
   })
 })
 
-describe('isProgrammaticCreditEra(now)', () => {
+/**
+ * #7333 — the era is now gated on an OPERATOR FLAG, not the calendar.
+ *
+ * Anthropic paused the programmatic-credit change on 2026-06-15 and it never
+ * shipped, so a bare date comparison asserted a billing regime that does not
+ * exist. Every era-ON assertion below therefore has to declare the flag; the
+ * era-OFF assertions are the behaviour in force today.
+ */
+function withEraEnabled(body) {
+  const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
+  try {
+    return body()
+  } finally {
+    if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+    else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
+  }
+}
+
+describe('the era is OFF by default (#7333)', () => {
+  // The bug in one assertion: on any date at or after the announced cutover,
+  // the old code said "programmatic credit pool". It never started.
+  it('is false at, after, and long after the announced cutover date', () => {
+    for (const now of [
+      PROGRAMMATIC_CREDIT_ERA_START,
+      PROGRAMMATIC_CREDIT_ERA_START + 1,
+      Date.UTC(2027, 0, 1),
+    ]) {
+      assert.equal(isProgrammaticCreditEra(now), false, `should be off at ${now}`)
+    }
+  })
+
+  it('classifies claude-cli and claude-sdk as subscription after the cutover', () => {
+    for (const p of ['claude-cli', 'claude-sdk']) {
+      assert.equal(
+        billingClassForProvider(p, Date.UTC(2027, 0, 1)),
+        BILLING_CLASSES.SUBSCRIPTION,
+        `${p} must not be billed as metered credit`,
+      )
+    }
+  })
+
+  it('says "Claude subscription" and never mentions a credit pool', () => {
+    const detail = billingDetailForClass(
+      billingClassForProvider('claude-cli', Date.UTC(2027, 0, 1)),
+    )
+    assert.match(detail, /subscription/i)
+    assert.equal(/credit pool|metered/i.test(detail), false)
+  })
+})
+
+describe('isProgrammaticCreditEra(now) — with the operator flag set', () => {
   it('is false one second before the boundary', () => {
     assert.equal(isProgrammaticCreditEra(JUST_BEFORE), false)
   })
-  it('is true exactly at the boundary (>= is inclusive)', () => {
+  it('is true exactly at the boundary (>= is inclusive)', () => withEraEnabled(() => {
     assert.equal(isProgrammaticCreditEra(AT_BOUNDARY), true)
-  })
-  it('is true one second after the boundary', () => {
+  }))
+  it('is true one second after the boundary', () => withEraEnabled(() => {
     assert.equal(isProgrammaticCreditEra(ONE_SEC_AFTER), true)
-  })
+  }))
   // #5825 — pin the inclusivity to the exact millisecond tick, not just a
   // whole second clear of the boundary. This is what makes a future `>=` → `>`
   // off-by-one (or a date drift) fail CI: at START the era is on; at START-1ms
   // it is not.
-  it('is true AT the constant instant and false exactly one ms before it', () => {
+  it('is true AT the constant instant and false exactly one ms before it', () => withEraEnabled(() => {
     assert.equal(isProgrammaticCreditEra(PROGRAMMATIC_CREDIT_ERA_START), true)
     assert.equal(isProgrammaticCreditEra(PROGRAMMATIC_CREDIT_ERA_START - 1), false)
-  })
+  }))
 })
 
 describe('billingClassForProvider — era-independent classes', () => {
@@ -69,17 +120,17 @@ describe('billingClassForProvider — era-gated programmatic providers', () => {
     it(`${p} is subscription BEFORE the boundary`, () => {
       assert.equal(billingClassForProvider(p, JUST_BEFORE), BILLING_CLASSES.SUBSCRIPTION)
     })
-    it(`${p} is programmatic-credit AT the boundary`, () => {
+    it(`${p} is programmatic-credit AT the boundary`, () => withEraEnabled(() => {
       assert.equal(billingClassForProvider(p, AT_BOUNDARY), BILLING_CLASSES.PROGRAMMATIC_CREDIT)
-    })
-    it(`${p} is programmatic-credit AFTER the boundary`, () => {
+    }))
+    it(`${p} is programmatic-credit AFTER the boundary`, () => withEraEnabled(() => {
       assert.equal(billingClassForProvider(p, ONE_SEC_AFTER), BILLING_CLASSES.PROGRAMMATIC_CREDIT)
-    })
+    }))
     // #5825 — millisecond-precision flip at the exact constant.
-    it(`${p} flips exactly at the constant instant (START vs START-1ms)`, () => {
+    it(`${p} flips exactly at the constant instant (START vs START-1ms)`, () => withEraEnabled(() => {
       assert.equal(billingClassForProvider(p, PROGRAMMATIC_CREDIT_ERA_START), BILLING_CLASSES.PROGRAMMATIC_CREDIT)
       assert.equal(billingClassForProvider(p, PROGRAMMATIC_CREDIT_ERA_START - 1), BILLING_CLASSES.SUBSCRIPTION)
-    })
+    }))
   }
 })
 

--- a/packages/server/tests/billing-class.test.js
+++ b/packages/server/tests/billing-class.test.js
@@ -53,10 +53,36 @@ function withEraEnabled(body) {
   return out
 }
 
+/**
+ * The mirror of {@link withEraEnabled}, and just as necessary. An era-OFF
+ * assertion that merely relies on the flag being absent from the ambient
+ * environment tests nothing on a machine where an operator HAS set it: the
+ * premise silently inverts and the case either fails for the wrong reason or
+ * stops covering the default it exists to pin. Same class as #7360.
+ */
+function withEraDisabled(body) {
+  const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  const restore = () => {
+    if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+    else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
+  }
+  let out
+  try {
+    out = body()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (out && typeof out.then === 'function') return out.finally(restore)
+  restore()
+  return out
+}
+
 describe('the era is OFF by default (#7333)', () => {
   // The bug in one assertion: on any date at or after the announced cutover,
   // the old code said "programmatic credit pool". It never started.
-  it('is false at, after, and long after the announced cutover date', () => {
+  it('is false at, after, and long after the announced cutover date', () => withEraDisabled(() => {
     for (const now of [
       PROGRAMMATIC_CREDIT_ERA_START,
       PROGRAMMATIC_CREDIT_ERA_START + 1,
@@ -64,9 +90,9 @@ describe('the era is OFF by default (#7333)', () => {
     ]) {
       assert.equal(isProgrammaticCreditEra(now), false, `should be off at ${now}`)
     }
-  })
+  }))
 
-  it('classifies claude-cli and claude-sdk as subscription after the cutover', () => {
+  it('classifies claude-cli and claude-sdk as subscription after the cutover', () => withEraDisabled(() => {
     for (const p of ['claude-cli', 'claude-sdk']) {
       assert.equal(
         billingClassForProvider(p, Date.UTC(2027, 0, 1)),
@@ -74,15 +100,15 @@ describe('the era is OFF by default (#7333)', () => {
         `${p} must not be billed as metered credit`,
       )
     }
-  })
+  }))
 
-  it('says "Claude subscription" and never mentions a credit pool', () => {
+  it('says "Claude subscription" and never mentions a credit pool', () => withEraDisabled(() => {
     const detail = billingDetailForClass(
       billingClassForProvider('claude-cli', Date.UTC(2027, 0, 1)),
     )
     assert.match(detail, /subscription/i)
     assert.equal(/credit pool|metered/i.test(detail), false)
-  })
+  }))
 })
 
 describe('isProgrammaticCreditEra(now) — with the operator flag set', () => {

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -42,6 +42,32 @@ function withEraEnabled(body) {
   return out
 }
 
+/**
+ * The mirror of {@link withEraEnabled}, and just as necessary. An era-OFF
+ * assertion that merely relies on the flag being absent from the ambient
+ * environment tests nothing on a machine where an operator HAS set it: the
+ * premise silently inverts and the case either fails for the wrong reason or
+ * stops covering the default it exists to pin. Same class as #7360.
+ */
+function withEraDisabled(body) {
+  const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  const restore = () => {
+    if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+    else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
+  }
+  let out
+  try {
+    out = body()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (out && typeof out.then === 'function') return out.finally(restore)
+  restore()
+  return out
+}
+
 test('detectBillingReclassification flags a claude-tui session reporting programmatic cost', () => withEraEnabled(() => {
   const w = detectBillingReclassification(
     [{ id: 's1', provider: 'claude-tui', totalCostUsd: 0.42 }],
@@ -183,7 +209,7 @@ test('runBillingCanary is quiet before the era with a clean setup', () => {
   assert.equal(out.warnings.length, 0)
 })
 
-test('the canary is silent about metering today, at ANY date (#7333)', () => {
+test('the canary is silent about metering today, at ANY date (#7333)', () => withEraDisabled(() => {
   // The bug's doctor-shaped symptom: with the era hardcoded to a date, this
   // warned that a configured default "would meter" — advice about a billing
   // regime Anthropic paused and never shipped. With no operator flag set,
@@ -200,7 +226,7 @@ test('the canary is silent about metering today, at ANY date (#7333)', () => {
     assert.equal(codes.includes('SILENT_METERED_DEFAULT'), false, `metering warning at ${now}`)
     assert.equal(codes.includes('TUI_REPORTED_PROGRAMMATIC_COST'), false, `reclassification warning at ${now}`)
   }
-})
+}))
 
 test('...but the canary still fires once an operator declares the era (control)', () => {
   // Without this, the assertion above would be satisfied by a canary that

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -7,10 +7,29 @@ import {
   runBillingCanary,
 } from '../src/doctor-billing.js'
 
-const AFTER = Date.UTC(2026, 5, 16) // one day into the programmatic-credit era
-const BEFORE = Date.UTC(2026, 5, 1) // before the cutover
+const AFTER = Date.UTC(2026, 5, 16) // one day past the announced cutover
+const BEFORE = Date.UTC(2026, 5, 1) // before the announced cutover
 
-test('detectBillingReclassification flags a claude-tui session reporting programmatic cost', () => {
+/**
+ * #7333 — the era is gated on an operator flag now, not the calendar, because
+ * Anthropic paused the change on 2026-06-15 and it never shipped. The canary's
+ * era-dependent signals only mean anything when the regime is actually in
+ * force, so those tests declare it. `AFTER` alone no longer turns it on — and
+ * the default-off behaviour gets its own test at the bottom, because "the
+ * doctor warns about a regime that does not exist" was part of the bug.
+ */
+function withEraEnabled(body) {
+  const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+  process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
+  try {
+    return body()
+  } finally {
+    if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+    else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
+  }
+}
+
+test('detectBillingReclassification flags a claude-tui session reporting programmatic cost', () => withEraEnabled(() => {
   const w = detectBillingReclassification(
     [{ id: 's1', provider: 'claude-tui', totalCostUsd: 0.42 }],
     AFTER,
@@ -19,7 +38,7 @@ test('detectBillingReclassification flags a claude-tui session reporting program
   assert.equal(w[0].code, 'TUI_REPORTED_PROGRAMMATIC_COST')
   assert.equal(w[0].sessionId, 's1')
   assert.equal(w[0].costUsd, 0.42)
-})
+}))
 
 test('detectBillingReclassification ignores zero-cost and non-tui sessions', () => {
   const w = detectBillingReclassification(
@@ -33,26 +52,26 @@ test('detectBillingReclassification ignores zero-cost and non-tui sessions', () 
   assert.equal(w.length, 0)
 })
 
-test('detectSilentMeteredDefault flags a programmatic default in the era only', () => {
+test('detectSilentMeteredDefault flags a programmatic default in the era only', () => withEraEnabled(() => {
   assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER).length, 1)
   assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER)[0].code, 'SILENT_METERED_DEFAULT')
   assert.equal(detectSilentMeteredDefault('claude-sdk', BEFORE).length, 0) // subscription before cutover
   assert.equal(detectSilentMeteredDefault('claude-tui', AFTER).length, 0) // always subscription
   assert.equal(detectSilentMeteredDefault('claude-byok', AFTER).length, 0) // api-key
-})
+}))
 
-test('detectSilentMeteredDefault does NOT flag claude-sdk when apiKeyAuth (BYOK)', () => {
+test('detectSilentMeteredDefault does NOT flag claude-sdk when apiKeyAuth (BYOK)', () => withEraEnabled(() => {
   // claude-sdk + explicit ANTHROPIC_API_KEY = raw-API billing, not the credit
   // pool — so a BYOK default must not trip the silent-metered warning.
   assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER, { apiKeyAuth: true }).length, 0)
   // ...but without the key it still warns.
   assert.equal(detectSilentMeteredDefault('claude-sdk', AFTER, { apiKeyAuth: false }).length, 1)
-})
+}))
 
-test('detectSilentMeteredDefault derives the cutover date from the shared constant', () => {
+test('detectSilentMeteredDefault derives the cutover date from the shared constant', () => withEraEnabled(() => {
   // Guards against a hardcoded date drifting from PROGRAMMATIC_CREDIT_ERA_START.
   assert.match(detectSilentMeteredDefault('claude-sdk', AFTER)[0].message, /since 2026-06-15\b/)
-})
+}))
 
 test('detectBillingReclassification stays silent before the cutover (era-gated)', () => {
   // Matches the docstring: a cost reading is only a reclassification signal
@@ -128,7 +147,7 @@ test('runBillingCanary threads datacenterPrefixes into the egress classifier (#5
   assert.ok(out.warnings.some((w) => w.code === 'DATACENTER_EGRESS'))
 })
 
-test('runBillingCanary aggregates all three signals', () => {
+test('runBillingCanary aggregates all three signals', () => withEraEnabled(() => {
   const out = runBillingCanary({
     sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 1.5 }],
     defaultProvider: 'claude-sdk',
@@ -138,7 +157,7 @@ test('runBillingCanary aggregates all three signals', () => {
   assert.equal(out.eraStarted, true)
   const codes = out.warnings.map((w) => w.code).sort()
   assert.deepEqual(codes, ['DATACENTER_EGRESS', 'SILENT_METERED_DEFAULT', 'TUI_REPORTED_PROGRAMMATIC_COST'])
-})
+}))
 
 test('runBillingCanary is quiet before the era with a clean setup', () => {
   const out = runBillingCanary({
@@ -149,4 +168,40 @@ test('runBillingCanary is quiet before the era with a clean setup', () => {
   })
   assert.equal(out.eraStarted, false)
   assert.equal(out.warnings.length, 0)
+})
+
+test('the canary is silent about metering today, at ANY date (#7333)', () => {
+  // The bug's doctor-shaped symptom: with the era hardcoded to a date, this
+  // warned that a configured default "would meter" — advice about a billing
+  // regime Anthropic paused and never shipped. With no operator flag set,
+  // no date may produce a metering signal.
+  for (const now of [BEFORE, AFTER, Date.UTC(2027, 0, 1)]) {
+    const out = runBillingCanary({
+      sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 1.5 }],
+      defaultProvider: 'claude-sdk',
+      egressIp: '73.162.4.10',
+      now,
+    })
+    assert.equal(out.eraStarted, false, `era must be off at ${now}`)
+    const codes = out.warnings.map((w) => w.code)
+    assert.equal(codes.includes('SILENT_METERED_DEFAULT'), false, `metering warning at ${now}`)
+    assert.equal(codes.includes('TUI_REPORTED_PROGRAMMATIC_COST'), false, `reclassification warning at ${now}`)
+  }
+})
+
+test('...but the canary still fires once an operator declares the era (control)', () => {
+  // Without this, the assertion above would be satisfied by a canary that
+  // never warns about anything.
+  withEraEnabled(() => {
+    const out = runBillingCanary({
+      sessions: [{ id: 's1', provider: 'claude-tui', totalCostUsd: 1.5 }],
+      defaultProvider: 'claude-sdk',
+      egressIp: '73.162.4.10',
+      now: AFTER,
+    })
+    assert.equal(out.eraStarted, true)
+    const codes = out.warnings.map((w) => w.code)
+    assert.ok(codes.includes('SILENT_METERED_DEFAULT'))
+    assert.ok(codes.includes('TUI_REPORTED_PROGRAMMATIC_COST'))
+  })
 })

--- a/packages/server/tests/doctor-billing.test.js
+++ b/packages/server/tests/doctor-billing.test.js
@@ -21,12 +21,25 @@ const BEFORE = Date.UTC(2026, 5, 1) // before the announced cutover
 function withEraEnabled(body) {
   const saved = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
   process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
-  try {
-    return body()
-  } finally {
+  const restore = () => {
     if (saved === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
     else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = saved
   }
+  // Promise-aware on purpose. A plain try/finally restores the flag the moment
+  // an ASYNC body returns its promise — i.e. before the body has run — so the
+  // assertions execute with the era already off. That silently un-did the
+  // wrapper for one async test here, and would have done the same to the next
+  // async test added to the sibling copies of this helper.
+  let out
+  try {
+    out = body()
+  } catch (err) {
+    restore()
+    throw err
+  }
+  if (out && typeof out.then === 'function') return out.finally(restore)
+  restore()
+  return out
 }
 
 test('detectBillingReclassification flags a claude-tui session reporting programmatic cost', () => withEraEnabled(() => {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -80,12 +80,32 @@ describe('runDoctorChecks', () => {
       }
     }
 
-    it('warns when the default provider meters silently on/after the cutover', async () => {
-      const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now: AFTER }))
-      const billing = checks.find(c => c.name === 'Billing')
-      assert.ok(billing)
-      assert.equal(billing.status, 'warn')
-      assert.match(billing.message, /metered programmatic-credit pool/)
+    it('warns when the default provider meters silently, once an operator declares the era (#7333)', async () => {
+      // The date alone no longer turns the era on: Anthropic paused the
+      // programmatic-credit change on 2026-06-15 and it never shipped, so the
+      // doctor was warning about a regime that does not exist. `AFTER` is now
+      // necessary but not sufficient — an operator has to declare it.
+      process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
+      try {
+        const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now: AFTER }))
+        const billing = checks.find(c => c.name === 'Billing')
+        assert.ok(billing)
+        assert.equal(billing.status, 'warn')
+        assert.match(billing.message, /metered programmatic-credit pool/)
+      } finally {
+        delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+      }
+    })
+
+    it('does NOT warn about metering by default, at any date (#7333)', async () => {
+      // The user-visible fix: with no operator flag, no date produces billing
+      // advice about the paused regime.
+      for (const now of [AFTER, Date.UTC(2027, 0, 1)]) {
+        const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now }))
+        const billing = checks.find(c => c.name === 'Billing')
+        assert.ok(billing)
+        assert.equal(/metered programmatic-credit pool/.test(billing.message), false, `warned at ${now}`)
+      }
     })
 
     it('does NOT warn for claude-sdk when ANTHROPIC_API_KEY is set (BYOK)', async () => {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -85,6 +85,7 @@ describe('runDoctorChecks', () => {
       // programmatic-credit change on 2026-06-15 and it never shipped, so the
       // doctor was warning about a regime that does not exist. `AFTER` is now
       // necessary but not sufficient — an operator has to declare it.
+      const savedEra = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
       process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = '1'
       try {
         const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now: AFTER }))
@@ -93,18 +94,34 @@ describe('runDoctorChecks', () => {
         assert.equal(billing.status, 'warn')
         assert.match(billing.message, /metered programmatic-credit pool/)
       } finally {
-        delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+        // SAVE/RESTORE, not an unconditional delete: clobbering an ambient
+        // value would leave every later assertion in this file depending on
+        // machine state.
+        if (savedEra === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+        else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = savedEra
       }
     })
 
     it('does NOT warn about metering by default, at any date (#7333)', async () => {
       // The user-visible fix: with no operator flag, no date produces billing
       // advice about the paused regime.
-      for (const now of [AFTER, Date.UTC(2027, 0, 1)]) {
-        const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now }))
-        const billing = checks.find(c => c.name === 'Billing')
-        assert.ok(billing)
-        assert.equal(/metered programmatic-credit pool/.test(billing.message), false, `warned at ${now}`)
+      //
+      // The flag is forced OFF rather than assumed absent. Relying on the
+      // ambient environment would mean this case silently stops testing the
+      // default on any machine where an operator has set the flag — the same
+      // read-ambient-state class as #7360.
+      const savedEra = process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+      delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+      try {
+        for (const now of [AFTER, Date.UTC(2027, 0, 1)]) {
+          const { checks } = await withEnv(null, () => runDoctorChecks({ providers: ['claude-sdk'], now }))
+          const billing = checks.find(c => c.name === 'Billing')
+          assert.ok(billing)
+          assert.equal(/metered programmatic-credit pool/.test(billing.message), false, `warned at ${now}`)
+        }
+      } finally {
+        if (savedEra === undefined) delete process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA
+        else process.env.CHROXY_PROGRAMMATIC_CREDIT_ERA = savedEra
       }
     })
 


### PR DESCRIPTION
Closes #7333

## The bug

Chroxy tells users `claude-cli` and `claude-sdk` bill against a *"Programmatic credit pool — monthly metered credits"*. **This is false.** Anthropic paused the change on 2026-06-15, the day it was due to take effect, and it never shipped — `claude -p`, the Agent SDK and third-party app usage still draw from the subscription's usage limits.

The era was a bare date comparison with no feature check:

```js
export function isProgrammaticCreditEra(now = Date.now()) {
  return now >= PROGRAMMATIC_CREDIT_ERA_START   // Date.UTC(2026, 5, 15)
}
```

Measured on `main` today:

```
isProgrammaticCreditEra()          -> true
billingClassForProvider('claude-cli') -> programmatic-credit
billingClassForProvider('claude-sdk') -> programmatic-credit
```

It flipped on the announced date and has been wrong every day since. Consumers read it at call time, so the provider copy, the `billingClass` on the wire, and `chroxy doctor`'s billing canary have all been describing a regime that does not exist.

**Not cosmetic.** It misdirects provider choice: the modal's warning is a reason to hesitate over `claude-cli` — currently the best-working Claude provider — and steers users toward `claude-tui`, which can neither report nor switch models (#7327). On the basis of a cost nobody is charging.

## The fix — gate on an observable, not the calendar

`CHROXY_PROGRAMMATIC_CREDIT_ERA=1` declares the era in force. Without it, `isProgrammaticCreditEra()` is false at every instant.

| | default (today) | operator opt-in |
|---|---|---|
| `isProgrammaticCreditEra()` | `false` | `true` |
| `claude-cli` / `claude-sdk` | `subscription` | `programmatic-credit` |
| before the constant, even opted in | `false` | `false` |

The constant and every consumer stay wired up — the pause is explicitly *"for now"*, so a revival is the flag plus, if the announced date moves, one edit to `PROGRAMMATIC_CREDIT_ERA_START`. Once enabled the date still gates, so a re-announcement is a deliberate act with a known boundary rather than an automatic one.

Every consumer already routed through that single function, so **no consumer needed editing** — the single-source-of-truth design paid off here.

## The dashboard's duplicate is deleted, not synced

`CreateSessionModal.tsx` carried its own copy of the constant *and* the comparison, kept aligned by a comment:

```
// #5629: ... MIRRORED from the server's PROGRAMMATIC_CREDIT_ERA_START ...
// Keep the two boundaries in sync if this ever moves.
```

That was survivable while the rule was a pure date. It is not now: **a client cannot observe an operator flag**, so client-side date arithmetic would be wrong by construction rather than merely at risk of drifting. The static pre-load fallback now states the billing actually in force, and the server-driven `auth.detail` — which does know the flag — takes precedence at the render site exactly as before.

## Tests

The existing suites pinned the date-only behaviour, which *is* the bug. Era-ON assertions now declare the flag; the era-OFF behaviour gets its own coverage:

- the class is `subscription` at, after, and long after the cutover
- the copy says subscription and never mentions a credit pool
- the doctor emits **no** metering advice at any date — with a control proving the canary still fires when an operator declares the era, so it cannot pass by simply never warning

## Proven in both directions

| mutation | red |
|---|---|
| remove the gate from `billing-class.js` | 3 era-OFF tests |
| make the test helper not set the flag | 9 era-ON tests |
| revert the dashboard fallback copy | 1 dashboard test |

## Verification

458/458 across `doctor`, `billing-class`, `doctor-billing`, `cli-session`, `sdk-session`, `providers` · dashboard **5076/5076** · typecheck clean · eslint clean · 9/9 shell lints

Two pre-existing local failures are excluded and filed separately as #7360 — `cli-session`'s `CHROXY_PORT`/`CHROXY_HOOK_SECRET` tests and `doctor`'s codex credential test read ambient machine state, so they fail for anyone running the suite on a configured dev box and pass in CI. Confirmed unrelated to this change.