### PR TITLE
fix(dashboard): request notification permission, so native notifications can actually fire

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -74,6 +74,7 @@ import { useTauriMenuWiring } from './hooks/useTauriMenuWiring'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
+import { useNotificationPermission } from './hooks/useNotificationPermission'
 import { useInterventionPing } from './hooks/useInterventionPing'
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { FileOpenPalette } from './components/FileOpenPalette'
@@ -461,7 +462,13 @@ export function App() {
       })),
     [storeMessages],
   )
-  usePermissionNotification(permissionPrompts)
+  // #7351 — own the OS-notification permission lifecycle. `autoRequest` is
+  // gated on a session existing so the first-run prompt lands when
+  // notifications actually become useful, not the instant the app opens. The
+  // request itself is Tauri-only; in a browser it needs a click, which is what
+  // the Settings → Dashboard "Enable notifications" button provides.
+  const notificationPermission = useNotificationPermission({ autoRequest: sessions.length > 0 })
+  usePermissionNotification(permissionPrompts, notificationPermission.permission)
   // #4891 — audible intervention ping enable/mute. Defaults on; persisted
   // per-device in localStorage. Toggled via Settings → Dashboard.
   const [interventionPingEnabled, setInterventionPingEnabled] = useState(() => {
@@ -2397,6 +2404,7 @@ export function App() {
                 setInterventionPingEnabled(enabled)
                 persistInterventionPing(enabled)
               }}
+              notificationPermission={notificationPermission}
             />
           </div>
         )}
@@ -2758,6 +2766,7 @@ export function App() {
         onToggleConsoleTab={(show) => { setShowConsoleTab(show); persistShowConsoleTab(show) }}
         interventionPingEnabled={interventionPingEnabled}
         onToggleInterventionPing={(enabled) => { setInterventionPingEnabled(enabled); persistInterventionPing(enabled) }}
+        notificationPermission={notificationPermission}
         shortcutHelpOpen={shortcutHelpOpen}
         onShortcutHelpClose={() => setShortcutHelpOpen(false)}
         shortcuts={SHORTCUTS}

--- a/packages/dashboard/src/components/AppModals.tsx
+++ b/packages/dashboard/src/components/AppModals.tsx
@@ -1,3 +1,4 @@
+import type { UseNotificationPermissionResult } from '../hooks/useNotificationPermission'
 import type { ComponentProps } from 'react'
 import type { TranscriptViewerState } from '../store/types'
 import { SettingsPanel } from './SettingsPanel'
@@ -34,6 +35,8 @@ export interface AppModalsProps {
   onToggleConsoleTab: (show: boolean) => void
   interventionPingEnabled: boolean
   onToggleInterventionPing: (enabled: boolean) => void
+  // #7351 — OS-notification permission state, forwarded to SettingsPanel.
+  notificationPermission?: UseNotificationPermissionResult
   // Shortcut help
   shortcutHelpOpen: boolean
   onShortcutHelpClose: () => void
@@ -117,6 +120,7 @@ export function AppModals(props: AppModalsProps) {
         onToggleConsoleTab={props.onToggleConsoleTab}
         interventionPingEnabled={props.interventionPingEnabled}
         onToggleInterventionPing={props.onToggleInterventionPing}
+        notificationPermission={props.notificationPermission}
       />
 
       {/* Keyboard shortcut help */}

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -37,6 +37,7 @@
  * added — the smallest refactor that eliminates the per-tab edit cost without
  * churning the tested store internals or the protocol.
  */
+import type { UseNotificationPermissionResult } from '../hooks/useNotificationPermission'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ControlRoomSection, type RepoInvestigateRequest, type RepoOpenSessionRequest } from './ControlRoomSection'
 import { RunnerStatusSection } from './RunnerStatusSection'
@@ -438,6 +439,8 @@ export interface ControlRoomViewProps {
   onToggleConsoleTab?: (show: boolean) => void
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
+  // #7351 — OS-notification permission state, forwarded to the Settings tab.
+  notificationPermission?: UseNotificationPermissionResult
 }
 
 export function ControlRoomView({
@@ -451,6 +454,7 @@ export function ControlRoomView({
   onToggleConsoleTab,
   interventionPingEnabled,
   onToggleInterventionPing,
+  notificationPermission,
 }: ControlRoomViewProps = {}) {
   const [rawTab, setTab] = useState<ControlRoomTab>(() => initialTab ?? loadPersistedTab())
 
@@ -797,6 +801,7 @@ export function ControlRoomView({
             onToggleConsoleTab={onToggleConsoleTab}
             interventionPingEnabled={interventionPingEnabled}
             onToggleInterventionPing={onToggleInterventionPing}
+            notificationPermission={notificationPermission}
           />
         </div>
       )}

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2960,3 +2960,88 @@ describe('SettingsPanel — permission rules + audit history (#6772/#6829)', () 
     ).toBe('Auto-allowed Write ×50 (persisted rule)')
   })
 })
+
+/**
+ * #7351 — the Settings -> Dashboard notification-permission row.
+ *
+ * This row is not cosmetic: on the web backend the button is the ONLY path by
+ * which chroxy can ever obtain notification permission, because browsers
+ * require a user gesture to call `Notification.requestPermission()`. An
+ * untested control here is the same failure the issue is about — a permission
+ * that is never actually requested.
+ */
+describe('SettingsPanel — notification permission row (#7351)', () => {
+  function permissionProp(
+    permission: 'granted' | 'denied' | 'default' | 'unsupported',
+    backend: 'tauri' | 'web' | 'unsupported' = 'web',
+    request = vi.fn().mockResolvedValue(permission),
+  ) {
+    return { backend, permission, request }
+  }
+
+  it('renders nothing when the host does not supply the prop', () => {
+    render(<SettingsPanel isOpen onClose={vi.fn()} />)
+    expect(screen.queryByTestId('notification-permission-field')).not.toBeInTheDocument()
+  })
+
+  it('offers the Enable button while permission is still default', () => {
+    render(<SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('default')} />)
+    expect(screen.getByTestId('notification-permission-field')).toBeInTheDocument()
+    expect(screen.getByTestId('notification-permission-enable')).toBeInTheDocument()
+  })
+
+  it('requests permission when the Enable button is clicked', () => {
+    // The gesture that the whole web path depends on.
+    const request = vi.fn().mockResolvedValue('granted')
+    render(
+      <SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('default', 'web', request)} />,
+    )
+    fireEvent.click(screen.getByTestId('notification-permission-enable'))
+    expect(request).toHaveBeenCalledOnce()
+  })
+
+  it('reports the granted state and stops offering the button', () => {
+    render(<SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('granted')} />)
+    expect(screen.getByTestId('notification-permission-granted')).toBeInTheDocument()
+    expect(screen.queryByTestId('notification-permission-enable')).not.toBeInTheDocument()
+  })
+
+  it('reports the denied state and does not offer a button that cannot work', () => {
+    // Chroxy is not allowed to re-ask after a denial, so an Enable button here
+    // would be a control that silently does nothing.
+    render(<SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('denied')} />)
+    expect(screen.getByTestId('notification-permission-denied')).toBeInTheDocument()
+    expect(screen.queryByTestId('notification-permission-enable')).not.toBeInTheDocument()
+  })
+
+  it('reports the unsupported state — e.g. a LAN http:// dashboard', () => {
+    render(
+      <SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('unsupported', 'unsupported')} />,
+    )
+    expect(screen.getByTestId('notification-permission-unsupported')).toBeInTheDocument()
+    expect(screen.queryByTestId('notification-permission-enable')).not.toBeInTheDocument()
+  })
+
+  it('does not tell desktop users that "your browser" requires a click', () => {
+    // The gesture requirement is a browser rule; under Tauri the request goes
+    // through an OS dialog and the sentence is simply false.
+    render(<SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('default', 'tauri')} />)
+    const field = screen.getByTestId('notification-permission-field')
+    expect(field.textContent).not.toMatch(/your browser/i)
+
+    cleanup()
+
+    // Positive control: on the web backend that sentence IS shown, so the
+    // assertion above is about the backend and not about the copy having been
+    // removed outright.
+    render(<SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('default', 'web')} />)
+    expect(screen.getByTestId('notification-permission-field').textContent).toMatch(/your browser/i)
+  })
+
+  it('does not advise desktop users to "use the desktop app"', () => {
+    render(
+      <SettingsPanel isOpen onClose={vi.fn()} notificationPermission={permissionProp('denied', 'tauri')} />,
+    )
+    expect(screen.getByTestId('notification-permission-denied').textContent).toMatch(/in your OS/i)
+  })
+})

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@
  * Triggered via gear icon in header or Cmd+,. Changes apply instantly
  * and persist to localStorage.
  */
+import type { UseNotificationPermissionResult } from '../hooks/useNotificationPermission'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useConnectionStore, isRuleEligibleProvider } from '../store/connection'
 import type { PermissionRule, PermissionAuditEntry } from '../store/types'
@@ -250,6 +251,10 @@ export interface SettingsContentProps {
   // when the handler is provided.
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
+  // #7351 — OS-notification permission state + the request trigger. Optional
+  // for the same reason as the ping props: call sites and tests that don't
+  // wire it stay valid, and the row simply doesn't render.
+  notificationPermission?: UseNotificationPermissionResult
 }
 
 export interface SettingsPanelProps {
@@ -259,6 +264,7 @@ export interface SettingsPanelProps {
   onToggleConsoleTab?: (show: boolean) => void
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
+  notificationPermission?: UseNotificationPermissionResult
 }
 
 /**
@@ -720,7 +726,7 @@ function ThemeSwatches({ theme }: { theme: ThemeDefinition }) {
   )
 }
 
-export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing }: SettingsContentProps) {
+export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing, notificationPermission }: SettingsContentProps) {
   // #5544: alias retained so the body's many `isOpen` reads (effect gates,
   // refresh-on-open) keep their original meaning — true while this surface
   // is the visible one (modal open, or Control Room Settings tab active).
@@ -2042,7 +2048,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
             )}
           </section>
 
-          {(onToggleConsoleTab || onToggleInterventionPing) && (
+          {(onToggleConsoleTab || onToggleInterventionPing || notificationPermission) && (
             <section className="settings-section" data-testid="dashboard-section">
               <h3>Dashboard</h3>
               {onToggleConsoleTab && (
@@ -2080,6 +2086,58 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
                     request are deduped, and bursts across multiple sessions
                     are throttled into a single ping.
                   </p>
+                </div>
+              )}
+              {/* #7351 — OS-notification permission. Before this, chroxy never
+                  called requestPermission() at all, so the notification path
+                  was unreachable and *silent about it*. This row is the
+                  "surface the ungranted state" half: it always says which of
+                  the four states we are in, and it is the only way the web
+                  backend can ever be granted (the browser requires a user
+                  gesture, so the click below is the request). */}
+              {notificationPermission && (
+                <div className="settings-field settings-field-notifications" data-testid="notification-permission-field">
+                  <label>Desktop notifications</label>
+                  {notificationPermission.permission === 'granted' && (
+                    <p className="settings-hint" data-testid="notification-permission-granted">
+                      On — chroxy will notify you when a session needs your
+                      attention and this window is not focused.
+                    </p>
+                  )}
+                  {notificationPermission.permission === 'default' && (
+                    <>
+                      <button
+                        type="button"
+                        className="btn-secondary settings-notification-enable"
+                        data-testid="notification-permission-enable"
+                        onClick={() => { void notificationPermission.request() }}
+                      >
+                        Enable notifications
+                      </button>
+                      <p className="settings-hint">
+                        Off — chroxy cannot notify you when a session needs
+                        your attention. Your browser only allows this to be
+                        requested from a click, so nothing is asked until you
+                        press the button.
+                      </p>
+                    </>
+                  )}
+                  {notificationPermission.permission === 'denied' && (
+                    <p className="settings-hint" data-testid="notification-permission-denied">
+                      Blocked. Chroxy is not allowed to ask again — re-enable
+                      notifications for this site in your browser or OS
+                      settings, then reload.
+                    </p>
+                  )}
+                  {notificationPermission.permission === 'unsupported' && (
+                    <p className="settings-hint" data-testid="notification-permission-unsupported">
+                      Unavailable in this window. Browsers only expose
+                      notifications on a secure context, so a dashboard opened
+                      over the LAN at an <code>http://</code> address cannot
+                      use them — open it at <code>localhost</code>, or use the
+                      desktop app.
+                    </p>
+                  )}
                 </div>
               )}
             </section>
@@ -2270,7 +2328,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
  * still open a dismissable panel. The primary entry points (gear / Cmd+,)
  * now redirect to the Control Room Settings tab instead — see App.tsx.
  */
-export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing }: SettingsPanelProps) {
+export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing, notificationPermission }: SettingsPanelProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -2306,6 +2364,7 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
           onToggleConsoleTab={onToggleConsoleTab}
           interventionPingEnabled={interventionPingEnabled}
           onToggleInterventionPing={onToggleInterventionPing}
+          notificationPermission={notificationPermission}
         />
       </div>
     </>

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -2108,7 +2108,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
                     <>
                       <button
                         type="button"
-                        className="btn-secondary settings-notification-enable"
+                        className="settings-secondary-button settings-notification-enable"
                         data-testid="notification-permission-enable"
                         onClick={() => { void notificationPermission.request() }}
                       >
@@ -2116,17 +2116,19 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
                       </button>
                       <p className="settings-hint">
                         Off — chroxy cannot notify you when a session needs
-                        your attention. Your browser only allows this to be
-                        requested from a click, so nothing is asked until you
-                        press the button.
+                        your attention.
+                        {notificationPermission.backend === 'web'
+                          ? ' Your browser only allows this to be requested from a click, so nothing is asked until you press the button.'
+                          : ' Press the button to allow them.'}
                       </p>
                     </>
                   )}
                   {notificationPermission.permission === 'denied' && (
                     <p className="settings-hint" data-testid="notification-permission-denied">
                       Blocked. Chroxy is not allowed to ask again — re-enable
-                      notifications for this site in your browser or OS
-                      settings, then reload.
+                      notifications for
+                      {notificationPermission.backend === 'web' ? ' this site in your browser' : ' Chroxy in your OS'}
+                      {' '}settings, then reload.
                     </p>
                   )}
                   {notificationPermission.permission === 'unsupported' && (
@@ -2135,7 +2137,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
                       notifications on a secure context, so a dashboard opened
                       over the LAN at an <code>http://</code> address cannot
                       use them — open it at <code>localhost</code>, or use the
-                      desktop app.
+                      desktop app instead.
                     </p>
                   )}
                 </div>

--- a/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
+++ b/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
@@ -23,7 +23,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const SRC = path.resolve(__dirname, '..')
-const appSource = fs.readFileSync(path.join(SRC, 'App.tsx'), 'utf-8')
+// Comment-stripped, like every other scan in this file: a guard whose whole
+// purpose is to catch the wiring going missing must not be satisfiable by
+// commenting the wiring out.
+const appSource = stripCommentLines(fs.readFileSync(path.join(SRC, 'App.tsx'), 'utf-8'))
 
 /**
  * Drop comment-ONLY lines (JSDoc bodies, `//` lines) before scanning.
@@ -62,6 +65,13 @@ function sourceFiles(dir: string, acc: string[] = []): string[] {
 }
 
 describe('App wires the notification-permission lifecycle', () => {
+  it('still has App source left after comment-stripping', () => {
+    // Positive control: if stripCommentLines ever ate the file, every
+    // assertion below would fail loudly rather than silently checking ''.
+    expect(appSource.length).toBeGreaterThan(1000)
+    expect(appSource).toContain('function App')
+  })
+
   it('imports useNotificationPermission', () => {
     expect(appSource).toContain("from './hooks/useNotificationPermission'")
   })
@@ -121,9 +131,37 @@ describe('native-notifications is the only Notification call site', () => {
   })
 })
 
+describe('the Enable-notifications button only uses classes that exist', () => {
+  it('has every class on the button defined in components.css', () => {
+    // Caught in review: the button shipped with `btn-secondary`, which is
+    // defined in no stylesheet in the repo — so it rendered with native OS
+    // chrome inside the themed panel. TypeScript cannot catch a class name
+    // that resolves to nothing, and neither can a render test that only
+    // queries by testid.
+    const panel = fs.readFileSync(path.join(SRC, 'components', 'SettingsPanel.tsx'), 'utf-8')
+    const css = fs.readFileSync(path.join(SRC, 'theme', 'components.css'), 'utf-8')
+
+    const match = panel.match(/className="([^"]*settings-notification-enable[^"]*)"/)
+    expect(match?.[1]).toBeTruthy()
+
+    const classes = (match?.[1] ?? '').split(/\s+/).filter(Boolean)
+    // Positive control: the button really does carry more than the one class
+    // this scan is named for, so an empty/one-item list means the regex broke.
+    expect(classes.length).toBeGreaterThan(1)
+
+    const undefinedClasses = classes.filter(c => !new RegExp(`\\.${c}\\b`).test(css))
+    expect(undefinedClasses).toEqual([])
+  })
+})
+
 describe('the Enable-notifications button meets the tap-target floor', () => {
   it('declares a 44px minimum, per the repo-wide rule', () => {
-    const css = fs.readFileSync(path.join(SRC, 'theme', 'components.css'), 'utf-8')
+    // Block comments removed first — the rule is documented with a /* */
+    // comment directly above it, and a commented-OUT rule must not count as
+    // the rule being present.
+    const css = fs
+      .readFileSync(path.join(SRC, 'theme', 'components.css'), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
     const rule = css.match(/\.settings-notification-enable\s*\{[^}]*\}/)
     expect(rule).not.toBeNull()
     expect(rule![0]).toMatch(/min-height:\s*44px/)

--- a/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
+++ b/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Notification-permission wiring guards (#7351).
+ *
+ * Unit tests prove each piece works in isolation; #7351 was a bug in which
+ * every piece worked and nothing CALLED them. `usePermissionNotification` was
+ * correct, its tests passed, and the feature was dead — because
+ * `Notification.requestPermission()` had no call site anywhere in the product
+ * and the permission never left `'default'`.
+ *
+ * A behavioural test of a hook cannot witness that. These are source-level
+ * guards on the two properties that no in-hook assertion can express:
+ *
+ *   1. App.tsx actually mounts the permission lifecycle and feeds it to the
+ *      notifier. Delete that wiring and every other test in this package still
+ *      passes — which is precisely how the original defect survived.
+ *   2. `utils/native-notifications` stays the ONLY place that touches the raw
+ *      Notification global. The moment a second call site reaches for
+ *      `new Notification(...)` again, it is outside the permission lifecycle
+ *      and the bug is back in a new location.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SRC = path.resolve(__dirname, '..')
+const appSource = fs.readFileSync(path.join(SRC, 'App.tsx'), 'utf-8')
+
+/**
+ * Drop comment-ONLY lines (JSDoc bodies, `//` lines) before scanning.
+ *
+ * Needed because the modules that legitimately discuss this bug describe
+ * `Notification.requestPermission()` in prose, and a guard that cannot tell
+ * code from commentary reports its own documentation as a violation.
+ *
+ * Deliberately conservative: it removes whole lines that are nothing but a
+ * comment, and never truncates a line at a mid-line `//`. Truncating would
+ * let a real offender hide behind a trailing comment (or behind a `'http://'`
+ * literal), which is a strictly worse failure than the false positive it
+ * would fix.
+ */
+function stripCommentLines(src: string): string {
+  return src
+    .split('\n')
+    .filter(line => {
+      const t = line.trim()
+      return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'))
+    })
+    .join('\n')
+}
+
+/** Every non-test .ts/.tsx file under src/, recursively. */
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      sourceFiles(full, acc)
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      acc.push(full)
+    }
+  }
+  return acc
+}
+
+describe('App wires the notification-permission lifecycle', () => {
+  it('imports useNotificationPermission', () => {
+    expect(appSource).toContain("from './hooks/useNotificationPermission'")
+  })
+
+  it('mounts useNotificationPermission', () => {
+    expect(appSource).toMatch(/useNotificationPermission\(\s*\{/)
+  })
+
+  it('feeds the live permission into usePermissionNotification', () => {
+    // Without the second argument a mid-session grant would not reach a
+    // prompt that is already pending.
+    expect(appSource).toMatch(/usePermissionNotification\(\s*permissionPrompts\s*,\s*notificationPermission\.permission\s*\)/)
+  })
+})
+
+describe('native-notifications is the only Notification call site', () => {
+  const files = sourceFiles(SRC)
+
+  it('finds a non-trivial number of source files to scan', () => {
+    // Positive control: a traversal bug that returned [] would make every
+    // assertion below pass vacuously — the exact shape of the bug this file
+    // exists to prevent.
+    expect(files.length).toBeGreaterThan(50)
+    expect(files).toContain(path.join(SRC, 'utils', 'native-notifications.ts'))
+  })
+
+  it('has no `new Notification(` outside the backend module', () => {
+    const offenders = files.filter(f => {
+      if (f === path.join(SRC, 'utils', 'native-notifications.ts')) return false
+      return /\bnew\s+Notification\s*\(/.test(stripCommentLines(fs.readFileSync(f, 'utf-8')))
+    })
+    expect(offenders.map(f => path.relative(SRC, f))).toEqual([])
+  })
+
+  it('has no direct `Notification.permission` / `Notification.requestPermission` read outside the backend module', () => {
+    const offenders = files.filter(f => {
+      if (f === path.join(SRC, 'utils', 'native-notifications.ts')) return false
+      const src = stripCommentLines(fs.readFileSync(f, 'utf-8'))
+      return /(?<![.\w])Notification\s*\.\s*(permission|requestPermission)\b/.test(src)
+    })
+    expect(offenders.map(f => path.relative(SRC, f))).toEqual([])
+  })
+
+  it('the backend module itself really does contain the patterns being guarded', () => {
+    // Positive control for the two assertions above: if the regexes were wrong
+    // (or the Notification API were renamed) they would report "no offenders"
+    // for the wrong reason, and keep passing with the guard deleted.
+    const backend = stripCommentLines(
+      fs.readFileSync(path.join(SRC, 'utils', 'native-notifications.ts'), 'utf-8'),
+    )
+    // The stripper must not have eaten the file wholesale — otherwise both
+    // assertions below would fail loudly, but the two scans above would pass
+    // vacuously for every file in the tree.
+    expect(backend).toContain('export function sendNativeNotification')
+    expect(/\bnew\s+\w+\s*\(\s*title/.test(backend)).toBe(true)
+    expect(/(?<![.\w])Notification\s*\.\s*requestPermission\b/.test(backend)).toBe(true)
+  })
+})
+
+describe('the Enable-notifications button meets the tap-target floor', () => {
+  it('declares a 44px minimum, per the repo-wide rule', () => {
+    const css = fs.readFileSync(path.join(SRC, 'theme', 'components.css'), 'utf-8')
+    const rule = css.match(/\.settings-notification-enable\s*\{[^}]*\}/)
+    expect(rule).not.toBeNull()
+    expect(rule![0]).toMatch(/min-height:\s*44px/)
+    expect(rule![0]).toMatch(/min-width:\s*44px/)
+  })
+})

--- a/packages/dashboard/src/hooks/useNotificationPermission.test.ts
+++ b/packages/dashboard/src/hooks/useNotificationPermission.test.ts
@@ -1,0 +1,184 @@
+/**
+ * useNotificationPermission tests (#7351).
+ *
+ * These are the tests that would have caught the original bug. The defect was
+ * that `Notification.requestPermission()` was never called ANYWHERE in chroxy,
+ * so `Notification.permission` stayed `'default'` forever and the dashboard's
+ * only `new Notification` call was unreachable. The pre-existing suite could
+ * not catch it, because it hand-set `Notification.permission = 'granted'` in
+ * `beforeEach` — establishing by fiat the precondition production never met.
+ *
+ * So the central case below starts from `'default'` — the real production
+ * state — and asserts that the app ASKS. Everything else here is a positive
+ * control on not-asking, because a fix that prompts too eagerly is its own bug
+ * (browsers permanently block origins that spam the notification prompt).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useNotificationPermission } from './useNotificationPermission'
+import { resetNativeNotificationStateForTests } from '../utils/native-notifications'
+
+const originalNotification = Object.getOwnPropertyDescriptor(globalThis, 'Notification')
+const originalTauri = Object.getOwnPropertyDescriptor(window, '__TAURI__')
+
+function installTauriBackend(opts: { granted?: boolean; requestResult?: string } = {}) {
+  const api = {
+    isPermissionGranted: vi.fn().mockResolvedValue(opts.granted ?? false),
+    requestPermission: vi.fn().mockResolvedValue(opts.requestResult ?? 'granted'),
+    sendNotification: vi.fn(),
+  }
+  // @ts-expect-error — test double
+  window.__TAURI__ = { notification: api }
+  return api
+}
+
+function installWebBackend(permission: 'default' | 'granted' | 'denied') {
+  const ctor = vi.fn()
+  // @ts-expect-error — test double
+  ctor.permission = permission
+  // @ts-expect-error — test double
+  ctor.requestPermission = vi.fn().mockResolvedValue('granted')
+  // @ts-expect-error — test double
+  globalThis.Notification = ctor
+  return ctor as unknown as ReturnType<typeof vi.fn> & { requestPermission: ReturnType<typeof vi.fn> }
+}
+
+const ASKED_KEY = 'chroxy_persist_notification_permission_asked'
+
+beforeEach(() => {
+  resetNativeNotificationStateForTests()
+  localStorage.clear()
+  // @ts-expect-error — clearing the global
+  delete globalThis.Notification
+  // @ts-expect-error — clearing the global
+  delete window.__TAURI__
+})
+
+afterEach(() => {
+  if (originalNotification) Object.defineProperty(globalThis, 'Notification', originalNotification)
+  // @ts-expect-error — clearing the global
+  else delete globalThis.Notification
+  if (originalTauri) Object.defineProperty(window, '__TAURI__', originalTauri)
+  // @ts-expect-error — clearing the global
+  else delete window.__TAURI__
+  localStorage.clear()
+})
+
+describe('useNotificationPermission — the request that never happened', () => {
+  it('REQUESTS permission when the state is the production default and a session exists', async () => {
+    // The regression test for #7351. Before the fix nothing in chroxy called
+    // requestPermission() at all; with permission stuck at 'default' the whole
+    // notification feature was unreachable. Asking here is the entire point.
+    const api = installTauriBackend({ granted: false, requestResult: 'granted' })
+
+    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+
+    await waitFor(() => expect(api.requestPermission).toHaveBeenCalledOnce())
+    await waitFor(() => expect(result.current.permission).toBe('granted'))
+    // And the ask is recorded, so a reload does not re-prompt.
+    expect(localStorage.getItem(ASKED_KEY)).toBe('true')
+  })
+
+  it('asks only once even as the hook re-renders', async () => {
+    const api = installTauriBackend({ granted: false, requestResult: 'default' })
+
+    const { rerender } = renderHook(
+      ({ auto }) => useNotificationPermission({ autoRequest: auto }),
+      { initialProps: { auto: true } },
+    )
+    await waitFor(() => expect(api.requestPermission).toHaveBeenCalledOnce())
+
+    // Permission is STILL 'default' (user dismissed the dialog without
+    // choosing) — the exact state that would otherwise loop forever.
+    rerender({ auto: true })
+    rerender({ auto: true })
+    expect(api.requestPermission).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useNotificationPermission — positive controls on NOT asking', () => {
+  it('does not ask before a session exists', async () => {
+    const api = installTauriBackend({ granted: false })
+    renderHook(() => useNotificationPermission({ autoRequest: false }))
+    await waitFor(() => expect(api.isPermissionGranted).toHaveBeenCalled())
+    expect(api.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('does not ask when permission is already granted', async () => {
+    const api = installTauriBackend({ granted: true })
+    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+    await waitFor(() => expect(result.current.permission).toBe('granted'))
+    expect(api.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('does not re-ask after a denial — no prompt spam', async () => {
+    const api = installTauriBackend({ granted: false, requestResult: 'denied' })
+    const { rerender, result } = renderHook(
+      ({ auto }) => useNotificationPermission({ autoRequest: auto }),
+      { initialProps: { auto: true } },
+    )
+    await waitFor(() => expect(result.current.permission).toBe('denied'))
+
+    rerender({ auto: true })
+    rerender({ auto: true })
+    expect(api.requestPermission).toHaveBeenCalledOnce()
+  })
+
+  it('does not ask again on a later page load once this device has been asked', async () => {
+    // Simulates a reload: the module cache is fresh, the permission is back to
+    // 'default' (user dismissed), but localStorage remembers the ask.
+    localStorage.setItem(ASKED_KEY, 'true')
+    const api = installTauriBackend({ granted: false })
+
+    renderHook(() => useNotificationPermission({ autoRequest: true }))
+    await waitFor(() => expect(api.isPermissionGranted).toHaveBeenCalled())
+    expect(api.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('never auto-requests on the web backend — browsers require a user gesture', async () => {
+    // Auto-requesting here does not just fail, it wastes the origin's one
+    // chance to ask: Chrome rejects a gesture-less request outright.
+    const ctor = installWebBackend('default')
+    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+    await waitFor(() => expect(result.current.backend).toBe('web'))
+    expect(ctor.requestPermission).not.toHaveBeenCalled()
+    expect(result.current.permission).toBe('default')
+  })
+})
+
+describe('useNotificationPermission — the explicit Settings request', () => {
+  it('requests on the web backend when the user clicks, and reports the result', async () => {
+    const ctor = installWebBackend('default')
+    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+    await waitFor(() => expect(result.current.backend).toBe('web'))
+
+    await act(async () => {
+      await result.current.request()
+    })
+
+    expect(ctor.requestPermission).toHaveBeenCalledOnce()
+    expect(result.current.permission).toBe('granted')
+  })
+
+  it('honours an explicit click even after this device was already asked', async () => {
+    // The "asked" flag suppresses the AUTOMATIC prompt only. A user who
+    // deliberately clicks Enable must be able to ask again.
+    localStorage.setItem(ASKED_KEY, 'true')
+    const ctor = installWebBackend('default')
+    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+    await waitFor(() => expect(result.current.backend).toBe('web'))
+
+    await act(async () => {
+      await result.current.request()
+    })
+    expect(ctor.requestPermission).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useNotificationPermission — no backend', () => {
+  it("reports 'unsupported' without crashing or asking", async () => {
+    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+    await waitFor(() => expect(result.current.permission).toBe('unsupported'))
+    expect(result.current.backend).toBe('unsupported')
+  })
+})

--- a/packages/dashboard/src/hooks/useNotificationPermission.test.ts
+++ b/packages/dashboard/src/hooks/useNotificationPermission.test.ts
@@ -12,9 +12,27 @@
  * state — and asserts that the app ASKS. Everything else here is a positive
  * control on not-asking, because a fix that prompts too eagerly is its own bug
  * (browsers permanently block origins that spam the notification prompt).
+ *
+ * ## Two harness rules this file has to hold
+ *
+ * **Unmount every render.** This package sets `globals: false` and its
+ * `test-setup.ts` does not call `cleanup()`, so React Testing Library's
+ * automatic teardown is NOT registered. A hook left mounted keeps its pending
+ * probe promise alive; that promise then resolves during a LATER test, against
+ * that test's freshly-installed mocks, and fails it perhaps one run in seven.
+ * `afterEach(cleanup)` below plus explicit `unmount()` is what keeps this file
+ * deterministic.
+ *
+ * **Settle before asserting "did not ask".** `waitFor(isPermissionGranted was
+ * called)` is satisfied synchronously — the call happens in the mount effect,
+ * long before the probe resolves and `probed` flips. Asserting non-request at
+ * that point passes no matter what the gate does, which is the same
+ * never-ran-and-called-it-success shape as the original bug. `renderSettled`
+ * drains the microtask queue first, and each negative case is paired with a
+ * positive control that DOES ask under the same harness.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react'
 import { useNotificationPermission } from './useNotificationPermission'
 import { resetNativeNotificationStateForTests } from '../utils/native-notifications'
 
@@ -40,7 +58,21 @@ function installWebBackend(permission: 'default' | 'granted' | 'denied') {
   ctor.requestPermission = vi.fn().mockResolvedValue('granted')
   // @ts-expect-error — test double
   globalThis.Notification = ctor
-  return ctor as unknown as ReturnType<typeof vi.fn> & { requestPermission: ReturnType<typeof vi.fn> }
+  return ctor as unknown as ReturnType<typeof vi.fn> & { requestPermission: ReturnType<typeof vi.fn>; permission: string }
+}
+
+/**
+ * Render the hook and wait until the initial async probe has fully settled —
+ * i.e. `probed` has flipped and the auto-request effect has had its chance to
+ * run. Anything asserting that the hook did NOT ask must go through this, or
+ * it asserts against a moment before the gate was ever reached.
+ */
+async function renderSettled(autoRequest: boolean) {
+  const view = renderHook(() => useNotificationPermission({ autoRequest }))
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+  return view
 }
 
 const ASKED_KEY = 'chroxy_persist_notification_permission_asked'
@@ -55,6 +87,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   if (originalNotification) Object.defineProperty(globalThis, 'Notification', originalNotification)
   // @ts-expect-error — clearing the global
   else delete globalThis.Notification
@@ -71,7 +104,7 @@ describe('useNotificationPermission — the request that never happened', () => 
     // notification feature was unreachable. Asking here is the entire point.
     const api = installTauriBackend({ granted: false, requestResult: 'granted' })
 
-    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
+    const { result } = await renderSettled(true)
 
     await waitFor(() => expect(api.requestPermission).toHaveBeenCalledOnce())
     await waitFor(() => expect(result.current.permission).toBe('granted'))
@@ -82,7 +115,7 @@ describe('useNotificationPermission — the request that never happened', () => 
   it('asks only once even as the hook re-renders', async () => {
     const api = installTauriBackend({ granted: false, requestResult: 'default' })
 
-    const { rerender } = renderHook(
+    const { rerender, unmount } = renderHook(
       ({ auto }) => useNotificationPermission({ autoRequest: auto }),
       { initialProps: { auto: true } },
     )
@@ -93,27 +126,38 @@ describe('useNotificationPermission — the request that never happened', () => 
     rerender({ auto: true })
     rerender({ auto: true })
     expect(api.requestPermission).toHaveBeenCalledOnce()
+    unmount()
   })
 })
 
 describe('useNotificationPermission — positive controls on NOT asking', () => {
   it('does not ask before a session exists', async () => {
     const api = installTauriBackend({ granted: false })
-    renderHook(() => useNotificationPermission({ autoRequest: false }))
-    await waitFor(() => expect(api.isPermissionGranted).toHaveBeenCalled())
+
+    const view = await renderSettled(false)
+    expect(api.isPermissionGranted).toHaveBeenCalled()
     expect(api.requestPermission).not.toHaveBeenCalled()
+    view.unmount()
+
+    // Positive control: same backend, same settled harness, autoRequest true —
+    // proves the negative above is about `autoRequest` and not about the test
+    // never reaching the gate.
+    const view2 = await renderSettled(true)
+    await waitFor(() => expect(api.requestPermission).toHaveBeenCalledOnce())
+    view2.unmount()
   })
 
   it('does not ask when permission is already granted', async () => {
     const api = installTauriBackend({ granted: true })
-    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
-    await waitFor(() => expect(result.current.permission).toBe('granted'))
+    const { result, unmount } = await renderSettled(true)
+    expect(result.current.permission).toBe('granted')
     expect(api.requestPermission).not.toHaveBeenCalled()
+    unmount()
   })
 
   it('does not re-ask after a denial — no prompt spam', async () => {
     const api = installTauriBackend({ granted: false, requestResult: 'denied' })
-    const { rerender, result } = renderHook(
+    const { rerender, result, unmount } = renderHook(
       ({ auto }) => useNotificationPermission({ autoRequest: auto }),
       { initialProps: { auto: true } },
     )
@@ -122,6 +166,7 @@ describe('useNotificationPermission — positive controls on NOT asking', () => 
     rerender({ auto: true })
     rerender({ auto: true })
     expect(api.requestPermission).toHaveBeenCalledOnce()
+    unmount()
   })
 
   it('does not ask again on a later page load once this device has been asked', async () => {
@@ -130,27 +175,46 @@ describe('useNotificationPermission — positive controls on NOT asking', () => 
     localStorage.setItem(ASKED_KEY, 'true')
     const api = installTauriBackend({ granted: false })
 
-    renderHook(() => useNotificationPermission({ autoRequest: true }))
-    await waitFor(() => expect(api.isPermissionGranted).toHaveBeenCalled())
+    const view = await renderSettled(true)
+    expect(api.isPermissionGranted).toHaveBeenCalled()
     expect(api.requestPermission).not.toHaveBeenCalled()
+    view.unmount()
+
+    // Positive control: clear the flag and nothing else, and the very same
+    // settled harness DOES ask. Without this, deleting the
+    // loadNotificationPermissionAsked() gate would leave the test green.
+    localStorage.clear()
+    resetNativeNotificationStateForTests()
+    const view2 = await renderSettled(true)
+    await waitFor(() => expect(api.requestPermission).toHaveBeenCalledOnce())
+    view2.unmount()
   })
 
   it('never auto-requests on the web backend — browsers require a user gesture', async () => {
     // Auto-requesting here does not just fail, it wastes the origin's one
     // chance to ask: Chrome rejects a gesture-less request outright.
     const ctor = installWebBackend('default')
-    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
-    await waitFor(() => expect(result.current.backend).toBe('web'))
+    const { result, unmount } = await renderSettled(true)
+    expect(result.current.backend).toBe('web')
     expect(ctor.requestPermission).not.toHaveBeenCalled()
     expect(result.current.permission).toBe('default')
+    unmount()
+
+    // Positive control: the same settled harness on the TAURI backend does
+    // ask, so the negative above is about the backend, not about the harness.
+    resetNativeNotificationStateForTests()
+    const api = installTauriBackend({ granted: false })
+    const view2 = await renderSettled(true)
+    await waitFor(() => expect(api.requestPermission).toHaveBeenCalledOnce())
+    view2.unmount()
   })
 })
 
 describe('useNotificationPermission — the explicit Settings request', () => {
   it('requests on the web backend when the user clicks, and reports the result', async () => {
     const ctor = installWebBackend('default')
-    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
-    await waitFor(() => expect(result.current.backend).toBe('web'))
+    const { result, unmount } = await renderSettled(true)
+    expect(result.current.backend).toBe('web')
 
     await act(async () => {
       await result.current.request()
@@ -158,6 +222,7 @@ describe('useNotificationPermission — the explicit Settings request', () => {
 
     expect(ctor.requestPermission).toHaveBeenCalledOnce()
     expect(result.current.permission).toBe('granted')
+    unmount()
   })
 
   it('honours an explicit click even after this device was already asked', async () => {
@@ -165,20 +230,66 @@ describe('useNotificationPermission — the explicit Settings request', () => {
     // deliberately clicks Enable must be able to ask again.
     localStorage.setItem(ASKED_KEY, 'true')
     const ctor = installWebBackend('default')
-    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
-    await waitFor(() => expect(result.current.backend).toBe('web'))
+    const { result, unmount } = await renderSettled(true)
+    expect(result.current.backend).toBe('web')
 
     await act(async () => {
       await result.current.request()
     })
     expect(ctor.requestPermission).toHaveBeenCalledOnce()
+    unmount()
+  })
+})
+
+describe('useNotificationPermission — picks up an out-of-band grant', () => {
+  it('re-probes when the window loses focus, so a grant made in site settings is seen', async () => {
+    // The user grants in Chrome's site-settings panel while the tab is
+    // focused, then switches away — which is exactly when notifications start
+    // mattering. Probing only once per page load would leave React state at
+    // 'default' for the life of the page and silently drop every notification.
+    const ctor = installWebBackend('default')
+    const { result, unmount } = await renderSettled(true)
+    expect(result.current.permission).toBe('default')
+
+    ctor.permission = 'granted'
+    await act(async () => {
+      window.dispatchEvent(new Event('blur'))
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.permission).toBe('granted')
+    unmount()
+  })
+
+  it('re-probes on focus and on visibilitychange too', async () => {
+    const api = installTauriBackend({ granted: false })
+    const { result, unmount } = await renderSettled(false)
+    expect(result.current.permission).toBe('default')
+
+    api.isPermissionGranted.mockResolvedValue(true)
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(result.current.permission).toBe('granted')
+
+    api.isPermissionGranted.mockResolvedValue(false)
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    // A Tauri probe reporting "not granted" cannot distinguish default from
+    // denied, so it settles on 'default' — never a stale 'granted'.
+    expect(result.current.permission).toBe('default')
+    unmount()
   })
 })
 
 describe('useNotificationPermission — no backend', () => {
   it("reports 'unsupported' without crashing or asking", async () => {
-    const { result } = renderHook(() => useNotificationPermission({ autoRequest: true }))
-    await waitFor(() => expect(result.current.permission).toBe('unsupported'))
+    const { result, unmount } = await renderSettled(true)
+    expect(result.current.permission).toBe('unsupported')
     expect(result.current.backend).toBe('unsupported')
+    unmount()
   })
 })

--- a/packages/dashboard/src/hooks/useNotificationPermission.ts
+++ b/packages/dashboard/src/hooks/useNotificationPermission.ts
@@ -1,0 +1,134 @@
+/**
+ * useNotificationPermission (#7351) — own the OS-notification permission
+ * lifecycle: probe it, request it once, and expose the result so the UI can
+ * say out loud when notifications are off.
+ *
+ * ## The bug this closes
+ *
+ * `usePermissionNotification` guarded on `Notification.permission === 'granted'`
+ * while **nothing in chroxy ever called `Notification.requestPermission()`**.
+ * The permission stayed `'default'`, the guard returned every time, and the
+ * dashboard's only `new Notification` call was unreachable in production. See
+ * `utils/native-notifications.ts` for the full write-up.
+ *
+ * ## Why the automatic request is Tauri-only
+ *
+ * Requesting is not symmetrical between the two backends:
+ *
+ * - **Tauri** — `requestPermission()` raises an OS dialog. There is no user-
+ *   gesture requirement, so a first-run request is both possible and the
+ *   normal thing a desktop app does.
+ * - **Browser** — every current browser requires transient activation.
+ *   Requesting on mount does not merely fail, it fails *badly*: Chrome rejects
+ *   the promise, and a rejected/ignored prompt is remembered against the
+ *   origin, which can burn the one chance to ask. So on the web backend the
+ *   request is made only from a real click — the "Enable notifications" button
+ *   in Settings → Dashboard, which passes through `request()` below.
+ *
+ * The alternative (auto-request everywhere) is what makes notification
+ * permission prompts the most-blocked permission on the web; it would also be
+ * the third time this feature shipped in a state that cannot work.
+ *
+ * ## Asking once, and only once
+ *
+ * The auto-request fires when the backend is Tauri, the permission is still
+ * `'default'`, `autoRequest` is true, and this device has not been asked
+ * before (`loadNotificationPermissionAsked()`). The persisted flag is what
+ * covers the case neither backend can report: a user who dismissed the prompt
+ * without choosing leaves the state at `'default'` forever, and without the
+ * flag we would re-prompt on every page load. `hasRequestedRef` covers the
+ * same thing within a single page lifetime, before the async request resolves.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  getNotificationBackend,
+  getNotificationPermission,
+  refreshNotificationPermission,
+  requestNativeNotificationPermission,
+  type NativeNotificationBackend,
+  type NativeNotificationPermission,
+} from '../utils/native-notifications'
+import {
+  loadNotificationPermissionAsked,
+  persistNotificationPermissionAsked,
+} from '../store/persistence'
+
+export interface UseNotificationPermissionOptions {
+  /**
+   * Whether there is now something worth notifying about — the caller passes
+   * "a session exists". Gating on this rather than on mount means we ask at
+   * the moment the permission becomes useful, instead of interrupting someone
+   * who opened the app to change a setting.
+   */
+  autoRequest: boolean
+}
+
+export interface UseNotificationPermissionResult {
+  backend: NativeNotificationBackend
+  permission: NativeNotificationPermission
+  /**
+   * Prompt the user. **Must be called from a user gesture** on the web
+   * backend. Always prompts when invoked — an explicit click is a deliberate
+   * ask, so it ignores the "already asked" flag.
+   */
+  request: () => Promise<NativeNotificationPermission>
+}
+
+export function useNotificationPermission(
+  { autoRequest }: UseNotificationPermissionOptions,
+): UseNotificationPermissionResult {
+  const [backend] = useState<NativeNotificationBackend>(() => getNotificationBackend())
+  const [permission, setPermission] = useState<NativeNotificationPermission>(() =>
+    getNotificationPermission(),
+  )
+  const hasRequestedRef = useRef(false)
+  /**
+   * Whether the initial permission probe has completed.
+   *
+   * Load-bearing for the Tauri backend, whose `isPermissionGranted()` is
+   * async: until it resolves, `getNotificationPermission()` reports
+   * `'default'` (it fails closed by design). Auto-requesting off that
+   * provisional value would re-prompt on every launch of an install where the
+   * user ALREADY granted permission — and would spend the persisted
+   * "asked" flag doing it. So the request waits for a real answer.
+   */
+  const [probed, setProbed] = useState(false)
+
+  // Prime the cached Tauri permission (its probe is async) and pick up a
+  // grant/denial made outside this tab.
+  useEffect(() => {
+    let cancelled = false
+    refreshNotificationPermission().then(next => {
+      if (cancelled) return
+      setPermission(next)
+      setProbed(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const request = useCallback(async (): Promise<NativeNotificationPermission> => {
+    hasRequestedRef.current = true
+    persistNotificationPermissionAsked()
+    const next = await requestNativeNotificationPermission()
+    setPermission(next)
+    return next
+  }, [])
+
+  useEffect(() => {
+    if (!autoRequest) return
+    // Web: no automatic request — see the header. The Settings button is the
+    // only path, because only a click carries the transient activation the
+    // browser demands.
+    if (backend !== 'tauri') return
+    // Never ask off the pre-probe placeholder — see `probed`.
+    if (!probed) return
+    if (permission !== 'default') return
+    if (hasRequestedRef.current) return
+    if (loadNotificationPermissionAsked()) return
+    void request()
+  }, [autoRequest, backend, probed, permission, request])
+
+  return { backend, permission, request }
+}

--- a/packages/dashboard/src/hooks/useNotificationPermission.ts
+++ b/packages/dashboard/src/hooks/useNotificationPermission.ts
@@ -108,6 +108,40 @@ export function useNotificationPermission(
     }
   }, [])
 
+  /**
+   * Re-probe when the window's focus/visibility changes.
+   *
+   * Without this the permission is read exactly once per page load, and a
+   * grant made OUT OF BAND — Chrome's site-settings panel, macOS
+   * Notifications preferences — would never reach React state, leaving
+   * notifications silently off for the life of the page. That would be a
+   * regression against the pre-#7351 code, which re-read the live
+   * `Notification.permission` on every effect run.
+   *
+   * Blur and visibility-hide are listened to as well as focus, because the
+   * moment the user leaves is precisely the moment notifications start
+   * mattering: a grant made while the tab was focused has to be picked up
+   * BEFORE the window loses focus, not after it comes back.
+   */
+  useEffect(() => {
+    if (backend === 'unsupported') return
+    let cancelled = false
+    const reprobe = () => {
+      refreshNotificationPermission().then(next => {
+        if (!cancelled) setPermission(next)
+      })
+    }
+    window.addEventListener('focus', reprobe)
+    window.addEventListener('blur', reprobe)
+    document.addEventListener('visibilitychange', reprobe)
+    return () => {
+      cancelled = true
+      window.removeEventListener('focus', reprobe)
+      window.removeEventListener('blur', reprobe)
+      document.removeEventListener('visibilitychange', reprobe)
+    }
+  }, [backend])
+
   const request = useCallback(async (): Promise<NativeNotificationPermission> => {
     hasRequestedRef.current = true
     persistNotificationPermissionAsked()

--- a/packages/dashboard/src/hooks/usePermissionNotification.test.ts
+++ b/packages/dashboard/src/hooks/usePermissionNotification.test.ts
@@ -28,7 +28,7 @@
  * Nothing here can pass by pretending a permission was granted, because
  * nothing here touches the global permission at all.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { usePermissionNotification } from './usePermissionNotification'
 import { sendNativeNotification } from '../utils/native-notifications'
@@ -46,9 +46,17 @@ beforeEach(() => {
   mockSend.mockClear()
   // Default: window not focused (notifications should fire)
   document.hasFocus = () => false
-  return () => {
-    document.hasFocus = originalHasFocus
-  }
+})
+
+// Restored in an explicit afterEach rather than by returning a teardown from
+// beforeEach. Vitest DOES honour a returned teardown — verified, not assumed:
+// a probe asserting the exact order ran `before:0, cleanup:1, before:1,
+// cleanup:2, before:2`. But Jest does not, and that is the rule most readers
+// (and at least one review bot) carry, so the returned-function form reads as
+// a leak even when it is not. The explicit form costs nothing and is not
+// ambiguous.
+afterEach(() => {
+  document.hasFocus = originalHasFocus
 })
 
 function makePrompt(overrides: Partial<{ id: string; requestId: string; tool: string; description: string; expiresAt: number; answered: string | undefined }> = {}) {

--- a/packages/dashboard/src/hooks/usePermissionNotification.test.ts
+++ b/packages/dashboard/src/hooks/usePermissionNotification.test.ts
@@ -1,34 +1,54 @@
 /**
- * usePermissionNotification tests (#1114, #1565, #1566)
+ * usePermissionNotification tests (#1114, #1565, #1566, #7351)
  *
- * Tests that native notifications fire for permission requests when the window is not focused.
- * Uses document.hasFocus() (#1566) and prunes stale notifiedRef entries (#1565).
+ * Tests that native notifications fire for permission requests when the window
+ * is not focused. Uses document.hasFocus() (#1566) and prunes stale notifiedRef
+ * entries (#1565).
+ *
+ * ## #7351 — what changed here, and why
+ *
+ * This suite used to open with:
+ *
+ *     globalThis.Notification = mockNotification
+ *     globalThis.Notification.permission = 'granted'
+ *     globalThis.Notification.requestPermission = vi.fn()...
+ *
+ * Those three lines were the bug's camouflage. Production never granted the
+ * permission — nothing in chroxy called `requestPermission()` at all — so the
+ * hook's `permission === 'granted'` guard returned on every real invocation
+ * and `new Notification` was unreachable. The suite passed continuously
+ * because it hand-established the precondition, and stubbed the very function
+ * whose absence was the defect. Success and never-running were the same
+ * observable outcome.
+ *
+ * They are gone. The permission is now an explicit INPUT to the hook, supplied
+ * by `useNotificationPermission` (which is what actually asks the user, and is
+ * tested separately), and dispatch goes through `sendNativeNotification` —
+ * whose own permission gate is covered in `utils/native-notifications.test.ts`.
+ * Nothing here can pass by pretending a permission was granted, because
+ * nothing here touches the global permission at all.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { usePermissionNotification } from './usePermissionNotification'
+import { sendNativeNotification } from '../utils/native-notifications'
 
-// Mock Notification API
-const mockNotification = vi.fn()
-let originalNotification: typeof globalThis.Notification
+vi.mock('../utils/native-notifications', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils/native-notifications')>()
+  return { ...actual, sendNativeNotification: vi.fn(() => true) }
+})
+
+const mockSend = vi.mocked(sendNativeNotification)
 let originalHasFocus: typeof document.hasFocus
 
 beforeEach(() => {
-  originalNotification = globalThis.Notification
   originalHasFocus = document.hasFocus
-  // @ts-expect-error — mock
-  globalThis.Notification = mockNotification
-  // @ts-expect-error — mock
-  globalThis.Notification.permission = 'granted'
-  globalThis.Notification.requestPermission = vi.fn().mockResolvedValue('granted')
-  mockNotification.mockClear()
+  mockSend.mockClear()
   // Default: window not focused (notifications should fire)
   document.hasFocus = () => false
-})
-
-afterEach(() => {
-  globalThis.Notification = originalNotification
-  document.hasFocus = originalHasFocus
+  return () => {
+    document.hasFocus = originalHasFocus
+  }
 })
 
 function makePrompt(overrides: Partial<{ id: string; requestId: string; tool: string; description: string; expiresAt: number; answered: string | undefined }> = {}) {
@@ -45,10 +65,10 @@ function makePrompt(overrides: Partial<{ id: string; requestId: string; tool: st
 
 describe('usePermissionNotification', () => {
   it('fires notification when window is not focused and permission request appears', () => {
-    renderHook(() => usePermissionNotification([makePrompt()]))
+    renderHook(() => usePermissionNotification([makePrompt()], 'granted'))
 
-    expect(mockNotification).toHaveBeenCalledOnce()
-    expect(mockNotification).toHaveBeenCalledWith(
+    expect(mockSend).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledWith(
       'Chroxy: Permission Requested',
       expect.objectContaining({ body: 'Run: npm install' })
     )
@@ -57,60 +77,90 @@ describe('usePermissionNotification', () => {
   it('does not fire notification when window is focused', () => {
     document.hasFocus = () => true
 
-    renderHook(() => usePermissionNotification([makePrompt()]))
+    renderHook(() => usePermissionNotification([makePrompt()], 'granted'))
 
-    expect(mockNotification).not.toHaveBeenCalled()
+    expect(mockSend).not.toHaveBeenCalled()
   })
 
   it('does not fire notification for already-answered prompts', () => {
-    renderHook(() => usePermissionNotification([makePrompt({ answered: 'allow' })]))
+    renderHook(() => usePermissionNotification([makePrompt({ answered: 'allow' })], 'granted'))
 
-    expect(mockNotification).not.toHaveBeenCalled()
+    expect(mockSend).not.toHaveBeenCalled()
   })
 
   it('does not fire notification for expired prompts', () => {
-    renderHook(() => usePermissionNotification([makePrompt({ expiresAt: Date.now() - 1000 })]))
+    renderHook(() => usePermissionNotification([makePrompt({ expiresAt: Date.now() - 1000 })], 'granted'))
 
-    expect(mockNotification).not.toHaveBeenCalled()
+    expect(mockSend).not.toHaveBeenCalled()
   })
 
   it('does not fire duplicate notification for the same request', () => {
     const { rerender } = renderHook(
-      ({ p }) => usePermissionNotification(p),
+      ({ p }) => usePermissionNotification(p, 'granted'),
       { initialProps: { p: [makePrompt()] } }
     )
 
-    expect(mockNotification).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledOnce()
 
     // New array instance with same requestId — effect reruns but should not re-notify
     rerender({ p: [makePrompt()] })
-    expect(mockNotification).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledOnce()
+  })
+
+  it('does not fire when permission is still default — the real production state', () => {
+    // #7351: this is the state every browser profile is actually in until
+    // something calls requestPermission(). The pre-fix suite could not express
+    // this case, because its setup hand-set the permission to 'granted'.
+    renderHook(() => usePermissionNotification([makePrompt()], 'default'))
+
+    expect(mockSend).not.toHaveBeenCalled()
   })
 
   it('does not fire when Notification permission is denied', () => {
-    // @ts-expect-error — mock
-    globalThis.Notification.permission = 'denied'
+    renderHook(() => usePermissionNotification([makePrompt()], 'denied'))
 
-    renderHook(() => usePermissionNotification([makePrompt()]))
+    expect(mockSend).not.toHaveBeenCalled()
+  })
 
-    expect(mockNotification).not.toHaveBeenCalled()
+  it('does not fire when no notification backend exists at all', () => {
+    // Dashboard opened over the LAN at an http:// address: not a secure
+    // context, so the browser exposes no Notification API to gate on.
+    renderHook(() => usePermissionNotification([makePrompt()], 'unsupported'))
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('fires for a still-pending prompt as soon as permission is granted mid-session', () => {
+    // #7351: the grant arrives from useNotificationPermission, not from a
+    // change to `prompts`. Passing the permission as a dependency is what
+    // makes the pending prompt notify immediately instead of waiting for the
+    // next unrelated prompt-list change.
+    const prompts = [makePrompt()]
+    const { rerender } = renderHook(
+      ({ perm }) => usePermissionNotification(prompts, perm),
+      { initialProps: { perm: 'default' as const } }
+    )
+    expect(mockSend).not.toHaveBeenCalled()
+
+    rerender({ perm: 'granted' as unknown as 'default' })
+    expect(mockSend).toHaveBeenCalledOnce()
   })
 
   it('prunes stale IDs when prompts are removed, allowing re-notification', () => {
     const prompt1 = makePrompt({ requestId: 'req-1' })
 
     const { rerender } = renderHook(
-      ({ p }) => usePermissionNotification(p),
+      ({ p }) => usePermissionNotification(p, 'granted'),
       { initialProps: { p: [prompt1] } }
     )
 
-    expect(mockNotification).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledOnce()
 
     // Prompt removed (answered/expired) — stale ID should be pruned
     rerender({ p: [] })
 
     // Same requestId reappears (e.g. re-requested) — should fire again
     rerender({ p: [makePrompt({ requestId: 'req-1' })] })
-    expect(mockNotification).toHaveBeenCalledTimes(2)
+    expect(mockSend).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/dashboard/src/hooks/usePermissionNotification.ts
+++ b/packages/dashboard/src/hooks/usePermissionNotification.ts
@@ -2,9 +2,21 @@
  * usePermissionNotification — fire native notifications for permission requests
  * when the browser/Tauri window is not focused.
  *
- * Uses the Web Notification API (supported in both browsers and Tauri WKWebView).
+ * Sends through `utils/native-notifications`, which picks the Tauri plugin
+ * when available and the Web Notification API otherwise. It does NOT touch
+ * `window.Notification` directly: before #7351 it did, behind a
+ * `Notification.permission === 'granted'` guard that nothing ever satisfied,
+ * because `Notification.requestPermission()` was never called anywhere in
+ * chroxy. The permission lifecycle now lives in `useNotificationPermission`,
+ * and dispatch lives in the backend module — this hook only decides *which*
+ * prompts deserve a notification.
  */
 import { useRef, useEffect } from 'react'
+import {
+  getNotificationPermission,
+  sendNativeNotification,
+  type NativeNotificationPermission,
+} from '../utils/native-notifications'
 
 export interface PermissionPromptInfo {
   id: string
@@ -15,11 +27,23 @@ export interface PermissionPromptInfo {
   answered: string | undefined
 }
 
-export function usePermissionNotification(prompts: PermissionPromptInfo[]) {
+/**
+ * @param prompts     Active permission prompts, newest state each render.
+ * @param permission  Live permission state from `useNotificationPermission`.
+ *   Passing it makes a mid-session grant take effect immediately for prompts
+ *   that are still pending, instead of waiting for the next change to
+ *   `prompts` to re-run the effect. Omitted (tests, other call sites) it is
+ *   read from the backend at effect time.
+ */
+export function usePermissionNotification(
+  prompts: PermissionPromptInfo[],
+  permission?: NativeNotificationPermission,
+) {
   const notifiedRef = useRef(new Set<string>())
 
   useEffect(() => {
-    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return
+    const current = permission ?? getNotificationPermission()
+    if (current !== 'granted') return
 
     // Prune stale IDs no longer in the active prompts list
     const activeIds = new Set(prompts.map(p => p.requestId))
@@ -42,12 +66,14 @@ export function usePermissionNotification(prompts: PermissionPromptInfo[]) {
       // Only notify when window is not focused
       if (document.hasFocus()) continue
 
+      // Marked before dispatch, and regardless of whether dispatch succeeds:
+      // a backend that throws must not be retried on every subsequent render.
       notifiedRef.current.add(prompt.requestId)
 
-      new Notification('Chroxy: Permission Requested', {
+      sendNativeNotification('Chroxy: Permission Requested', {
         body: prompt.description,
         tag: `chroxy-perm-${prompt.requestId}`,
       })
     }
-  }, [prompts])
+  }, [prompts, permission])
 }

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -24,6 +24,13 @@ const KEY_SHOW_CONSOLE_TAB = `${KEY_PREFIX}show_console_tab`;
 // #4891 — audible intervention ping. Defaults on; persisted per-device so a
 // muted browser tab stays muted across reload + Tauri restart.
 const KEY_INTERVENTION_PING = `${KEY_PREFIX}intervention_ping`;
+// #7351 — whether we have already prompted for OS-notification permission on
+// this device. Needed because neither backend can report "asked and dismissed"
+// as distinct from "never asked": the Web API leaves `Notification.permission`
+// at 'default' when the user closes the prompt without choosing, and Tauri's
+// `isPermissionGranted()` is a bare boolean. Without this flag the first-run
+// request would re-fire on every single page load for anyone who dismissed it.
+const KEY_NOTIFICATION_PERMISSION_ASKED = `${KEY_PREFIX}notification_permission_asked`;
 // #6799 — global "compact" chat filter (hide tool calls + thinking, mobile
 // parity). Defaults off; persisted per-device so the choice survives reload.
 const KEY_COMPACT_CHAT_FILTER = `${KEY_PREFIX}compact_chat_filter`;
@@ -485,6 +492,37 @@ export function persistInterventionPing(enabled: boolean): void {
 export function loadPersistedInterventionPing(): boolean {
   try {
     return localStorage.getItem(KEY_INTERVENTION_PING) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Record that we have prompted for OS-notification permission (#7351).
+ *
+ * Written once, when the automatic first-run request is made. An explicit
+ * click on "Enable notifications" in Settings deliberately does NOT consult
+ * this flag — the user asked for the prompt, so they get it.
+ */
+export function persistNotificationPermissionAsked(): void {
+  try {
+    localStorage.setItem(KEY_NOTIFICATION_PERMISSION_ASKED, 'true');
+  } catch {
+    // Storage not available
+  }
+}
+
+/**
+ * Whether the automatic notification-permission request has already been made
+ * on this device (#7351).
+ *
+ * Falls back to `true` when storage is unavailable: if we cannot remember
+ * having asked, the safe failure is to *not* ask automatically (the Settings
+ * button still works) rather than to re-prompt on every load.
+ */
+export function loadNotificationPermissionAsked(): boolean {
+  try {
+    return localStorage.getItem(KEY_NOTIFICATION_PERMISSION_ASKED) === 'true';
   } catch {
     return true;
   }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8358,6 +8358,23 @@ button.sidebar-token-view-session-row:hover {
   margin-bottom: 0;
 }
 
+/* #7351 — "Enable notifications" button in Settings -> Dashboard. This is the
+   ONLY path by which the web backend can ever be granted notification
+   permission (browsers require a user gesture to call
+   Notification.requestPermission), so it must be comfortably hittable: 44px
+   is the tap-target floor this repo holds on every surface (Apple HIG /
+   WCAG 2.1 SC 2.5.5). */
+.settings-notification-enable {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0 16px;
+  margin-bottom: 8px;
+}
+
+.settings-field-notifications .settings-hint {
+  margin-bottom: 0;
+}
+
 /* #4563: per-device "Mute on this device" row inside each notification
    category <li>. The row is logically subordinate to the global per-category
    toggle (which lives on the same <li>), so it needs visible hierarchy:

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8358,19 +8358,6 @@ button.sidebar-token-view-session-row:hover {
   margin-bottom: 0;
 }
 
-/* #7351 — "Enable notifications" button in Settings -> Dashboard. This is the
-   ONLY path by which the web backend can ever be granted notification
-   permission (browsers require a user gesture to call
-   Notification.requestPermission), so it must be comfortably hittable: 44px
-   is the tap-target floor this repo holds on every surface (Apple HIG /
-   WCAG 2.1 SC 2.5.5). */
-.settings-notification-enable {
-  min-height: 44px;
-  min-width: 44px;
-  padding: 0 16px;
-  margin-bottom: 8px;
-}
-
 .settings-field-notifications .settings-hint {
   margin-bottom: 0;
 }
@@ -11823,6 +11810,23 @@ button.sidebar-token-view-session-row:hover {
 .settings-secondary-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* #7351 — "Enable notifications" button in Settings -> Dashboard. This is the
+   ONLY path by which the web backend can ever be granted notification
+   permission (browsers require a user gesture to call
+   Notification.requestPermission), so it must be comfortably hittable: 44px
+   is the tap-target floor this repo holds on every surface (Apple HIG /
+   WCAG 2.1 SC 2.5.5).
+
+   Declared AFTER .settings-secondary-button deliberately: both are single-
+   class selectors, so at equal specificity source order decides, and that
+   rule's `padding: 2px 8px` would otherwise override the padding here. */
+.settings-notification-enable {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 4px 16px;
+  margin-bottom: 8px;
 }
 
 /* #6772/#6829 — Session Rules viewer + Permission history layout. Pure layout;

--- a/packages/dashboard/src/utils/native-notifications.test.ts
+++ b/packages/dashboard/src/utils/native-notifications.test.ts
@@ -1,0 +1,215 @@
+/**
+ * native-notifications tests (#7351).
+ *
+ * The defect these cover: chroxy's only `new Notification` call sat behind a
+ * `permission === 'granted'` guard that nothing ever satisfied, because
+ * `Notification.requestPermission()` was never called anywhere in the product.
+ * The old suite hid this by hand-setting `Notification.permission = 'granted'`
+ * in `beforeEach` — the precondition production never established.
+ *
+ * So these tests deliberately start from the REAL production state
+ * (`permission === 'default'`, or no backend at all) and assert what the
+ * module does from there, rather than from a world where someone already
+ * granted it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  getNotificationBackend,
+  getNotificationPermission,
+  refreshNotificationPermission,
+  requestNativeNotificationPermission,
+  sendNativeNotification,
+  resetNativeNotificationStateForTests,
+} from './native-notifications'
+
+const originalNotification = Object.getOwnPropertyDescriptor(globalThis, 'Notification')
+const originalTauri = Object.getOwnPropertyDescriptor(window, '__TAURI__')
+
+/** Install a fake Web Notification API at the given permission state. */
+function installWebBackend(permission: 'default' | 'granted' | 'denied', requestResult: unknown = 'granted') {
+  const ctor = vi.fn()
+  // @ts-expect-error — test double
+  ctor.permission = permission
+  // @ts-expect-error — test double
+  ctor.requestPermission = vi.fn().mockResolvedValue(requestResult)
+  // @ts-expect-error — test double
+  globalThis.Notification = ctor
+  return ctor as unknown as ReturnType<typeof vi.fn> & {
+    permission: string
+    requestPermission: ReturnType<typeof vi.fn>
+  }
+}
+
+/** Install a fake Tauri notification plugin. */
+function installTauriBackend(opts: { granted?: boolean; requestResult?: unknown } = {}) {
+  const api = {
+    isPermissionGranted: vi.fn().mockResolvedValue(opts.granted ?? false),
+    requestPermission: vi.fn().mockResolvedValue(opts.requestResult ?? 'granted'),
+    sendNotification: vi.fn(),
+  }
+  // @ts-expect-error — test double
+  window.__TAURI__ = { notification: api }
+  return api
+}
+
+beforeEach(() => {
+  resetNativeNotificationStateForTests()
+  // Start every case with NO backend, i.e. jsdom's real state. Each test
+  // installs exactly the backend it means to exercise.
+  // @ts-expect-error — clearing the global
+  delete globalThis.Notification
+  // @ts-expect-error — clearing the global
+  delete window.__TAURI__
+})
+
+afterEach(() => {
+  if (originalNotification) Object.defineProperty(globalThis, 'Notification', originalNotification)
+  // @ts-expect-error — clearing the global
+  else delete globalThis.Notification
+  if (originalTauri) Object.defineProperty(window, '__TAURI__', originalTauri)
+  // @ts-expect-error — clearing the global
+  else delete window.__TAURI__
+})
+
+describe('getNotificationBackend', () => {
+  it('reports unsupported when neither backend is present', () => {
+    // This is the state of a dashboard opened over the LAN at an http:// address
+    // — not a secure context, so the browser does not expose Notification at all.
+    expect(getNotificationBackend()).toBe('unsupported')
+    expect(getNotificationPermission()).toBe('unsupported')
+  })
+
+  it('reports web when only the Web Notification API is present', () => {
+    installWebBackend('default')
+    expect(getNotificationBackend()).toBe('web')
+  })
+
+  it('prefers the Tauri plugin over the Web API when both are present', () => {
+    installWebBackend('granted')
+    installTauriBackend({ granted: false })
+    expect(getNotificationBackend()).toBe('tauri')
+  })
+
+  it('falls back to web when the Tauri namespace is present but incomplete', () => {
+    installWebBackend('default')
+    // A partially-injected plugin API must not be treated as a usable backend,
+    // or every call site throws inside an effect where nothing surfaces it.
+    // @ts-expect-error — deliberately missing sendNotification/requestPermission
+    window.__TAURI__ = { notification: { isPermissionGranted: vi.fn() } }
+    expect(getNotificationBackend()).toBe('web')
+  })
+})
+
+describe('getNotificationPermission (web)', () => {
+  it.each(['default', 'granted', 'denied'] as const)('mirrors Notification.permission === %s', state => {
+    installWebBackend(state)
+    expect(getNotificationPermission()).toBe(state)
+  })
+})
+
+describe('getNotificationPermission (tauri)', () => {
+  it("reports 'default' before the async probe has resolved", () => {
+    installTauriBackend({ granted: true })
+    // isPermissionGranted() is async but the notification guard is synchronous,
+    // so the pre-probe answer must fail CLOSED — never an optimistic 'granted'.
+    expect(getNotificationPermission()).toBe('default')
+  })
+
+  it("reports 'granted' after refresh resolves true", async () => {
+    installTauriBackend({ granted: true })
+    await refreshNotificationPermission()
+    expect(getNotificationPermission()).toBe('granted')
+  })
+
+  it("does not downgrade a recorded 'denied' back to 'default' on refresh", async () => {
+    // The plugin's isPermissionGranted() is a bare boolean and cannot express
+    // "asked and refused". If a refresh reset that to 'default', the auto-request
+    // gate would re-prompt a user who already said no, on every probe.
+    const api = installTauriBackend({ granted: false, requestResult: 'denied' })
+    expect(await requestNativeNotificationPermission()).toBe('denied')
+    expect(await refreshNotificationPermission()).toBe('denied')
+    expect(api.isPermissionGranted).toHaveBeenCalled()
+  })
+
+  it("recovers to 'granted' if the user grants after an earlier denial", async () => {
+    const api = installTauriBackend({ granted: false, requestResult: 'denied' })
+    await requestNativeNotificationPermission()
+    expect(getNotificationPermission()).toBe('denied')
+    api.isPermissionGranted.mockResolvedValue(true)
+    expect(await refreshNotificationPermission()).toBe('granted')
+  })
+})
+
+describe('requestNativeNotificationPermission', () => {
+  it('delegates to the Web API and returns its result', async () => {
+    const ctor = installWebBackend('default', 'granted')
+    expect(await requestNativeNotificationPermission()).toBe('granted')
+    expect(ctor.requestPermission).toHaveBeenCalledOnce()
+  })
+
+  it('delegates to the Tauri plugin and caches the result', async () => {
+    const api = installTauriBackend({ requestResult: 'granted' })
+    expect(await requestNativeNotificationPermission()).toBe('granted')
+    expect(api.requestPermission).toHaveBeenCalledOnce()
+    expect(getNotificationPermission()).toBe('granted')
+  })
+
+  it('returns unsupported when there is no backend to ask', async () => {
+    expect(await requestNativeNotificationPermission()).toBe('unsupported')
+  })
+
+  it('never reports a grant for an unrecognised result', async () => {
+    // A shim resolving with undefined must not be read as permission.
+    // NB: set on the mock rather than through installWebBackend's parameter —
+    // passing `undefined` there hits the default argument and silently installs
+    // 'granted', so the test would pass while exercising nothing.
+    const ctor = installWebBackend('default')
+    ctor.requestPermission.mockResolvedValue(undefined)
+    expect(await requestNativeNotificationPermission()).toBe('default')
+  })
+
+  it('survives a rejected Web request (Chrome rejects without a user gesture)', async () => {
+    const ctor = installWebBackend('default')
+    ctor.requestPermission.mockRejectedValue(new Error('requires a user gesture'))
+    expect(await requestNativeNotificationPermission()).toBe('default')
+  })
+})
+
+describe('sendNativeNotification', () => {
+  it('does NOT send when permission is still default — the real production state', () => {
+    const ctor = installWebBackend('default')
+    expect(sendNativeNotification('t', { body: 'b' })).toBe(false)
+    expect(ctor).not.toHaveBeenCalled()
+  })
+
+  it('does NOT send when permission is denied', () => {
+    const ctor = installWebBackend('denied')
+    expect(sendNativeNotification('t', { body: 'b' })).toBe(false)
+    expect(ctor).not.toHaveBeenCalled()
+  })
+
+  it('does NOT send when there is no backend', () => {
+    expect(sendNativeNotification('t')).toBe(false)
+  })
+
+  it('sends through the Web API once granted', () => {
+    const ctor = installWebBackend('granted')
+    expect(sendNativeNotification('Title', { body: 'Body', tag: 'tag-1' })).toBe(true)
+    expect(ctor).toHaveBeenCalledWith('Title', { body: 'Body', tag: 'tag-1' })
+  })
+
+  it('sends through the Tauri plugin once granted', async () => {
+    const api = installTauriBackend({ granted: true })
+    await refreshNotificationPermission()
+    expect(sendNativeNotification('Title', { body: 'Body' })).toBe(true)
+    expect(api.sendNotification).toHaveBeenCalledWith({ title: 'Title', body: 'Body' })
+  })
+
+  it('reports false rather than throwing when the backend throws', () => {
+    const ctor = installWebBackend('granted')
+    ctor.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(sendNativeNotification('t')).toBe(false)
+  })
+})

--- a/packages/dashboard/src/utils/native-notifications.ts
+++ b/packages/dashboard/src/utils/native-notifications.ts
@@ -1,0 +1,256 @@
+/**
+ * native-notifications — the dashboard's single backend for OS-level
+ * notifications (#7351).
+ *
+ * ## Why this module exists
+ *
+ * Before #7351 the dashboard called `new Notification(...)` directly from
+ * `usePermissionNotification`, behind a `Notification.permission !== 'granted'`
+ * guard — and **nothing in chroxy ever called `Notification.requestPermission()`**.
+ * `Notification.permission` therefore stayed `'default'` forever, the guard
+ * returned on every invocation, and the single `new Notification` call site was
+ * unreachable in production. The feature was dead code that passed its tests,
+ * because the suite hand-granted the permission the app never requested.
+ *
+ * That is the `docs/false-safety-guards.md` shape — *"a precondition that is
+ * false, so the body never runs and the job is green"*. The fix is not just to
+ * add a `requestPermission()` call; it is to put every native-notification
+ * concern (support detection, permission state, requesting, sending) behind one
+ * module so a future call site cannot reintroduce the same gap by reaching for
+ * the raw Web API again.
+ *
+ * ## Two backends, and why the Tauri one is preferred
+ *
+ * - **`tauri`** — `window.__TAURI__.notification`, exposed because
+ *   `tauri.conf.json` sets `withGlobalTauri: true` and `capabilities/default.json`
+ *   already grants `notification:default` (which covers
+ *   `is-permission-granted` / `request-permission` / `notify`). The Rust side
+ *   has used this plugin for server-lifecycle notifications since long before
+ *   this change; the dashboard simply never reached it from JS.
+ * - **`web`** — the standard Web Notification API, for the dashboard opened in
+ *   a real browser.
+ *
+ * Tauri is preferred whenever present. The old code's header claimed the Web
+ * API is *"supported in both browsers and Tauri WKWebView"*; that is not
+ * something we should rely on — macOS WKWebView does not reliably expose
+ * `window.Notification`, and if it does not, the web path is permanently dead
+ * in exactly the surface (the desktop app) where turn-complete notifications
+ * matter most. Preferring the plugin makes the desktop app correct regardless
+ * of what WKWebView happens to expose.
+ *
+ * ## Secure-context caveat (do not "fix" this by falling back)
+ *
+ * The Web Notification API is gated on a secure context. `http://127.0.0.1` and
+ * `http://localhost` qualify, so the locally-served dashboard is fine — but the
+ * dashboard reached over the LAN at `http://192.168.x.x:8765` is **not** a
+ * secure context and `Notification` is simply `undefined` there. That is a
+ * browser rule we cannot work around, which is why `'unsupported'` is a
+ * first-class permission state that the UI surfaces honestly rather than a case
+ * we silently swallow.
+ */
+
+/**
+ * Permission state, unified across both backends.
+ *
+ * `'unsupported'` means no backend is available at all (non-secure-context
+ * browser, or a runtime with neither the plugin nor the Web API) — distinct
+ * from `'denied'`, which means a backend exists and the user said no.
+ */
+export type NativeNotificationPermission = 'granted' | 'denied' | 'default' | 'unsupported'
+
+export type NativeNotificationBackend = 'tauri' | 'web' | 'unsupported'
+
+interface TauriNotificationApi {
+  isPermissionGranted: () => Promise<boolean>
+  requestPermission: () => Promise<string>
+  sendNotification: (options: { title: string; body?: string }) => void
+}
+
+/**
+ * Resolve `window.__TAURI__.notification`, or null when it is absent or
+ * incomplete.
+ *
+ * Every method is checked individually rather than trusting the namespace to
+ * exist: a partially-injected plugin API would otherwise throw at the call
+ * site, inside an effect, where the failure is invisible.
+ */
+function getTauriNotificationApi(): TauriNotificationApi | null {
+  if (typeof window === 'undefined') return null
+  const w = window as unknown as Record<string, unknown>
+  const tauri = w.__TAURI__ as Record<string, unknown> | undefined
+  const api = tauri?.notification as Partial<TauriNotificationApi> | undefined
+  if (
+    !api ||
+    typeof api.isPermissionGranted !== 'function' ||
+    typeof api.requestPermission !== 'function' ||
+    typeof api.sendNotification !== 'function'
+  ) {
+    return null
+  }
+  return api as TauriNotificationApi
+}
+
+function getWebNotificationApi(): typeof Notification | null {
+  if (typeof Notification === 'undefined') return null
+  if (typeof Notification.requestPermission !== 'function') return null
+  return Notification
+}
+
+export function getNotificationBackend(): NativeNotificationBackend {
+  if (getTauriNotificationApi()) return 'tauri'
+  if (getWebNotificationApi()) return 'web'
+  return 'unsupported'
+}
+
+/**
+ * Last known Tauri permission state.
+ *
+ * The plugin's `isPermissionGranted()` is **async**, but the notification
+ * guard in `usePermissionNotification` runs inside a synchronous effect body.
+ * So the async answer is cached here and read synchronously by
+ * `getNotificationPermission()`. `useNotificationPermission` primes it on
+ * mount via `refreshNotificationPermission()`.
+ *
+ * `null` means "not yet probed". It is deliberately NOT initialised to
+ * `'default'`: `null` lets `getNotificationPermission()` report `'default'`
+ * (nothing granted yet, correctly refusing to send) while
+ * `refreshNotificationPermission()` can still tell "never asked" from "asked
+ * and got a real answer".
+ */
+let tauriPermission: NativeNotificationPermission | null = null
+
+/** Test seam — clears the cached Tauri permission between cases. */
+export function resetNativeNotificationStateForTests(): void {
+  tauriPermission = null
+}
+
+/**
+ * Synchronous permission read, safe to call from an effect body.
+ *
+ * For the Tauri backend this returns the cached value from the last
+ * `refreshNotificationPermission()` / `requestNativeNotificationPermission()`,
+ * defaulting to `'default'` before the first probe resolves — i.e. it fails
+ * *closed* (no notification sent) rather than optimistically assuming a grant.
+ */
+export function getNotificationPermission(): NativeNotificationPermission {
+  const backend = getNotificationBackend()
+  if (backend === 'tauri') return tauriPermission ?? 'default'
+  if (backend === 'web') {
+    const api = getWebNotificationApi()!
+    return api.permission as NativeNotificationPermission
+  }
+  return 'unsupported'
+}
+
+/**
+ * Probe the current permission without prompting the user.
+ *
+ * Note the asymmetry: the Tauri plugin's `isPermissionGranted()` returns a
+ * *boolean*, so it cannot distinguish `'default'` (never asked) from
+ * `'denied'` (asked and refused). A previously-recorded `'denied'` is
+ * therefore preserved rather than being downgraded back to `'default'` — which
+ * would otherwise make the app re-prompt a user who already said no on every
+ * probe. Across reloads, the "have we asked?" flag in `persistence.ts` is what
+ * keeps that promise; this cache only covers the current page lifetime.
+ */
+export async function refreshNotificationPermission(): Promise<NativeNotificationPermission> {
+  const tauriApi = getTauriNotificationApi()
+  if (tauriApi) {
+    try {
+      const granted = await tauriApi.isPermissionGranted()
+      if (granted) tauriPermission = 'granted'
+      else if (tauriPermission !== 'denied') tauriPermission = 'default'
+    } catch {
+      // A throwing plugin call means we genuinely do not know. Leave any
+      // previously-recorded answer intact rather than inventing one.
+      if (tauriPermission === null) tauriPermission = 'default'
+    }
+    return tauriPermission
+  }
+  return getNotificationPermission()
+}
+
+/**
+ * Normalise whatever a backend returns into our four-state union.
+ *
+ * Both backends are specified to resolve with `'granted' | 'denied' |
+ * 'default'`, but a shimmed or older implementation can resolve with something
+ * else entirely (or `undefined`). Anything unrecognised is treated as
+ * `'default'` — not as a grant.
+ */
+function normalisePermissionResult(value: unknown): NativeNotificationPermission {
+  if (value === 'granted' || value === 'denied' || value === 'default') return value
+  return 'default'
+}
+
+/**
+ * Prompt the user for notification permission.
+ *
+ * **Caller responsibility — user gesture.** On the `web` backend every current
+ * browser requires transient activation for this call: Chrome rejects the
+ * promise outright ("Notification prompting can only be done from a user
+ * gesture") when it is made on page load. So the automatic first-run request
+ * is restricted to the `tauri` backend (where the prompt is an OS dialog with
+ * no such rule), and in a browser the request is only ever made from a click —
+ * the "Enable notifications" button in Settings. See
+ * `useNotificationPermission`.
+ */
+export async function requestNativeNotificationPermission(): Promise<NativeNotificationPermission> {
+  const tauriApi = getTauriNotificationApi()
+  if (tauriApi) {
+    try {
+      tauriPermission = normalisePermissionResult(await tauriApi.requestPermission())
+    } catch {
+      tauriPermission = 'default'
+    }
+    return tauriPermission
+  }
+
+  const webApi = getWebNotificationApi()
+  if (!webApi) return 'unsupported'
+  try {
+    return normalisePermissionResult(await webApi.requestPermission())
+  } catch {
+    // Chrome rejects rather than resolving when there is no user gesture.
+    // Report the state we can still observe instead of crashing the caller.
+    return webApi.permission as NativeNotificationPermission
+  }
+}
+
+export interface NativeNotificationOptions {
+  body?: string
+  /** Collapse key — replaces an earlier notification with the same tag. */
+  tag?: string
+}
+
+/**
+ * Send a native notification. Returns whether it was actually dispatched.
+ *
+ * Callers must not pre-check the permission themselves; this is the one place
+ * that decides, so a new call site cannot forget the guard the way the
+ * pre-#7351 code did. A `false` return means "not sent" for any reason
+ * (unsupported, not granted, backend threw).
+ */
+export function sendNativeNotification(title: string, options: NativeNotificationOptions = {}): boolean {
+  if (getNotificationPermission() !== 'granted') return false
+
+  const tauriApi = getTauriNotificationApi()
+  if (tauriApi) {
+    try {
+      // The plugin has no `tag` equivalent; collapsing is the OS's business.
+      tauriApi.sendNotification({ title, body: options.body })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const webApi = getWebNotificationApi()
+  if (!webApi) return false
+  try {
+    new webApi(title, { body: options.body, tag: options.tag })
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

`packages/dashboard/src/hooks/usePermissionNotification.ts` held the dashboard's **only** `new Notification` call, behind this guard:

```ts
if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return
```

and **nothing in chroxy ever called `Notification.requestPermission()`**. Verified against `288634e98`: the Web API call appears nowhere in source — the only occurrence in the whole repo is `usePermissionNotification.test.ts:23`, as a mock. Every other `requestPermission` hit is chroxy's unrelated `requestPermissionInput` WS action or React Native's `requestPermissionsAsync` in the mobile app.

So `Notification.permission` stayed `'default'` forever, the guard returned every time, and chroxy had **no working native notifications at all** — and no indication anywhere that they were off.

### Why no test caught it

The suite established by fiat the precondition production never met:

```ts
globalThis.Notification.permission = 'granted'                                   // line 22
globalThis.Notification.requestPermission = vi.fn().mockResolvedValue('granted') // line 23
```

It hand-granted the permission the app never requested, and stubbed the very function whose absence *was* the defect. Success and never-running were the same observable outcome — the `docs/false-safety-guards.md` shape *"a precondition that is false, so the body never runs and the job is green."* Those lines are **removed**, not adjusted.

## What changed

**`utils/native-notifications.ts` (new)** — one backend for support detection, permission state, requesting, and dispatch. Callers never touch the raw global, so a new call site cannot reintroduce the gap.

It prefers the **Tauri plugin** (`window.__TAURI__.notification`) over the Web API. The old header claimed the Web API is *"supported in both browsers and Tauri WKWebView"*; that is not safe to rely on — macOS WKWebView does not reliably expose `window.Notification`, which would leave the path permanently dead in exactly the surface where this matters. The plugin needs no new wiring: `withGlobalTauri: true` is already set, `capabilities/default.json` already grants `notification:default`, and `tauri-plugin-notification = "2"` is already a dependency.

**`useNotificationPermission` (new)** — owns the lifecycle. The automatic request is deliberately narrow:

- **Tauri only.** Browsers require transient activation; Chrome *rejects* a gesture-less request, and a spammed prompt can burn the origin's one chance to ask. In a browser the request comes from an explicit click instead.
- **Only once a session exists**, so the prompt lands when notifications become useful rather than the instant the app opens.
- **Only after the async probe resolves.** The plugin's `isPermissionGranted()` is async while the notification guard is synchronous; requesting off the provisional `'default'` would re-prompt an install that had *already* granted permission. (A test caught this — it was a real bug in the first cut.)
- **Only once per device.** Neither backend can distinguish "asked and dismissed" from "never asked" — the Web API leaves `'default'` on dismissal and Tauri's probe is a bare boolean — so a persisted flag is what stops the prompt re-firing on every page load. An explicit Settings click ignores the flag, since that is a deliberate ask.

**Settings → Dashboard** now states which of the four states applies, including `'unsupported'`: a dashboard opened over the LAN at an `http://` address is not a secure context and cannot use notifications at all. The Enable button carries the repo's 44px tap-target floor.

## Verification

Full dashboard suite: **295 files / 5119 tests green**, typecheck clean, build clean.

Every new guard was broken and confirmed red — not just asserted green:

| mutation | result |
|---|---|
| M1 auto-request deleted (reproduces the #7351 defect exactly) | RED |
| M2 probe gate removed (re-prompts an already-granted install) | RED |
| M3 Tauri `'denied'` downgraded to `'default'` on refresh (prompt spam) | RED |
| M4 send permission gate removed (notifies without consent) | RED |
| M5 unknown request result treated as a grant | RED |
| M6 App stops mounting the permission lifecycle | RED |
| M7 a raw `new Notification` reappears outside the backend module | RED |
| M8 the 44px tap-target floor dropped | RED |

M6 and M7 are the ones that matter for this defect *class*: unit tests prove each piece works, and #7351 was a bug in which every piece worked and nothing called them. A behavioural test of a hook cannot witness a missing call site, so `notificationPermissionWiring.test.ts` asserts at source level that App mounts the lifecycle and that the backend module stays the sole `Notification` call site. Both scans carry positive controls (file-count floor, and a check that the patterns really do match the backend), so a broken traversal or regex fails loudly instead of passing vacuously.

## Scope note — Defect 2 is not in this PR

#7351 also raises the silently-degraded turn (a permission expires, the agent continues without the tool). The in-transcript marker for that **already exists** — `PermissionPrompt.tsx:374` renders *"Permission expired — Claude will continue without this tool"*, which is verbatim the text quoted in the issue. What is missing is an end-of-turn *summary* aggregating dropped tool calls, which is a separate surface with a different blast radius. Filed as a follow-on rather than folded in; the reason the user never saw the existing marker is Defect 1, which this PR closes.

## Not verified here

The Tauri plugin path is covered by tests against a mocked `window.__TAURI__.notification`, but has not been exercised in a running desktop build. If the plugin global turns out not to be injected, the code falls back to the Web API and — failing that — reports `'unsupported'` in Settings, so the failure is surfaced rather than silent. Worth a dogfood check on the next desktop build.

Closes #7351
Related to #7347 (turn-complete notification — this was its blocking prerequisite), #7337, #7340