### PR TITLE
fix(dashboard): notify natively when a session finishes and is waiting on you

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -76,6 +76,7 @@ import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
 import { useNotificationPermission } from './hooks/useNotificationPermission'
 import { useInterventionPing } from './hooks/useInterventionPing'
+import { useTurnCompleteNotification, type TurnCompleteSession } from './hooks/useTurnCompleteNotification'
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { FileOpenPalette } from './components/FileOpenPalette'
 import { SymbolSearchPalette } from './components/SymbolSearchPalette'
@@ -90,7 +91,7 @@ import { useMessageRenderer } from './hooks/useMessageRenderer'
 import { SplitPane } from './components/SplitPane'
 import { ViewSwitcher } from './components/ViewSwitcher'
 import { DEFAULT_PROVIDER, USER_SHELL_PROVIDER } from '@chroxy/protocol'
-import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, persistCompactChatFilter, loadPersistedCompactChatFilter, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
+import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, persistTurnCompleteNotification, loadPersistedTurnCompleteNotification, persistCompactChatFilter, loadPersistedCompactChatFilter, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
 import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import { AgentMonitorPanel } from './components/AgentMonitorPanel'
@@ -480,6 +481,13 @@ export function App() {
   // dedupes by requestId and throttles bursts; `enabled` honors the operator
   // mute toggle (Settings → Dashboard, persisted per-device).
   useInterventionPing(permissionPrompts, { enabled: interventionPingEnabled })
+  // #7347 — turn-complete OS-notification enable/mute. Defaults on; persisted
+  // per-device. Separate from the intervention ping and from the OS permission
+  // itself so muting "the session finished" does not also mute "the session
+  // needs permission" — the hook is wired further down, next to `isConnected`.
+  const [turnCompleteNotificationEnabled, setTurnCompleteNotificationEnabled] = useState(() => {
+    return loadPersistedTurnCompleteNotification()
+  })
 
   // #3698 — derive the user-message history for the InputBar's terminal-
   // style Up/Down navigation. Oldest-first (matches the natural arrival
@@ -2097,6 +2105,42 @@ export function App() {
   // available). Extracted to `useTunnelReady` (#5560).
   const tunnelReady = useTunnelReady(isConnected)
 
+  // #7347 — native notification when a session finishes its turn and is left
+  // waiting on the user. Sits here rather than beside the other notification
+  // hooks (~L470) because it needs `isConnected`, declared just above; the
+  // call is unconditional, so hook order stays stable.
+  //
+  // `busy` comes from the per-session server-authoritative `isIdle` (#4639) in
+  // `sessionStates`, which `session_activity` maintains for EVERY session
+  // (broadcast on stream_start and on result). Two nearby signals are wrong
+  // here and both are easy to reach for: `sessions[].isBusy` is only a
+  // `session_list` snapshot and is not rebroadcast on a turn boundary, and the
+  // top-level flat `isIdle` mirrors the ACTIVE session only. Shallow-equal so
+  // the record keeps its identity — and the hook's effect stays put — unless a
+  // session's busy state actually flips.
+  const sessionBusyById = useConnectionStore(
+    useShallow((s) => {
+      const out: Record<string, boolean> = {}
+      for (const id in s.sessionStates) out[id] = s.sessionStates[id]!.isIdle === false
+      return out
+    }),
+  )
+  const turnCompleteSessions = useMemo<TurnCompleteSession[]>(
+    () =>
+      sessions.map(s => ({
+        sessionId: s.sessionId,
+        name: s.name,
+        busy: sessionBusyById[s.sessionId] ?? false,
+        awaitingPermission: (pendingPermissionCounts[s.sessionId] ?? 0) > 0,
+      })),
+    [sessions, sessionBusyById, pendingPermissionCounts],
+  )
+  useTurnCompleteNotification(turnCompleteSessions, {
+    enabled: turnCompleteNotificationEnabled,
+    connected: isConnected,
+    onNotificationClick: handleSwitchSession,
+  })
+
   // Fetch conversation history when welcome screen is shown
   useEffect(() => {
     if (showWelcome) fetchConversationHistory()
@@ -2403,6 +2447,11 @@ export function App() {
               onToggleInterventionPing={(enabled) => {
                 setInterventionPingEnabled(enabled)
                 persistInterventionPing(enabled)
+              }}
+              turnCompleteNotificationEnabled={turnCompleteNotificationEnabled}
+              onToggleTurnCompleteNotification={(enabled) => {
+                setTurnCompleteNotificationEnabled(enabled)
+                persistTurnCompleteNotification(enabled)
               }}
               notificationPermission={notificationPermission}
             />
@@ -2766,6 +2815,8 @@ export function App() {
         onToggleConsoleTab={(show) => { setShowConsoleTab(show); persistShowConsoleTab(show) }}
         interventionPingEnabled={interventionPingEnabled}
         onToggleInterventionPing={(enabled) => { setInterventionPingEnabled(enabled); persistInterventionPing(enabled) }}
+        turnCompleteNotificationEnabled={turnCompleteNotificationEnabled}
+        onToggleTurnCompleteNotification={(enabled) => { setTurnCompleteNotificationEnabled(enabled); persistTurnCompleteNotification(enabled) }}
         notificationPermission={notificationPermission}
         shortcutHelpOpen={shortcutHelpOpen}
         onShortcutHelpClose={() => setShortcutHelpOpen(false)}

--- a/packages/dashboard/src/components/AppModals.tsx
+++ b/packages/dashboard/src/components/AppModals.tsx
@@ -35,6 +35,9 @@ export interface AppModalsProps {
   onToggleConsoleTab: (show: boolean) => void
   interventionPingEnabled: boolean
   onToggleInterventionPing: (enabled: boolean) => void
+  // #7347 — turn-complete OS-notification mute, forwarded to SettingsPanel.
+  turnCompleteNotificationEnabled: boolean
+  onToggleTurnCompleteNotification: (enabled: boolean) => void
   // #7351 — OS-notification permission state, forwarded to SettingsPanel.
   notificationPermission?: UseNotificationPermissionResult
   // Shortcut help
@@ -120,6 +123,8 @@ export function AppModals(props: AppModalsProps) {
         onToggleConsoleTab={props.onToggleConsoleTab}
         interventionPingEnabled={props.interventionPingEnabled}
         onToggleInterventionPing={props.onToggleInterventionPing}
+        turnCompleteNotificationEnabled={props.turnCompleteNotificationEnabled}
+        onToggleTurnCompleteNotification={props.onToggleTurnCompleteNotification}
         notificationPermission={props.notificationPermission}
       />
 

--- a/packages/dashboard/src/components/ControlRoomView.tsx
+++ b/packages/dashboard/src/components/ControlRoomView.tsx
@@ -439,6 +439,9 @@ export interface ControlRoomViewProps {
   onToggleConsoleTab?: (show: boolean) => void
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
+  // #7347 — turn-complete OS-notification mute, forwarded to SettingsContent.
+  turnCompleteNotificationEnabled?: boolean
+  onToggleTurnCompleteNotification?: (enabled: boolean) => void
   // #7351 — OS-notification permission state, forwarded to the Settings tab.
   notificationPermission?: UseNotificationPermissionResult
 }
@@ -454,6 +457,8 @@ export function ControlRoomView({
   onToggleConsoleTab,
   interventionPingEnabled,
   onToggleInterventionPing,
+  turnCompleteNotificationEnabled,
+  onToggleTurnCompleteNotification,
   notificationPermission,
 }: ControlRoomViewProps = {}) {
   const [rawTab, setTab] = useState<ControlRoomTab>(() => initialTab ?? loadPersistedTab())
@@ -801,6 +806,8 @@ export function ControlRoomView({
             onToggleConsoleTab={onToggleConsoleTab}
             interventionPingEnabled={interventionPingEnabled}
             onToggleInterventionPing={onToggleInterventionPing}
+            turnCompleteNotificationEnabled={turnCompleteNotificationEnabled}
+            onToggleTurnCompleteNotification={onToggleTurnCompleteNotification}
             notificationPermission={notificationPermission}
           />
         </div>

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -251,6 +251,10 @@ export interface SettingsContentProps {
   // when the handler is provided.
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
+  // #7347 — turn-complete OS-notification enable/mute. Optional on the same
+  // terms as the ping props.
+  turnCompleteNotificationEnabled?: boolean
+  onToggleTurnCompleteNotification?: (enabled: boolean) => void
   // #7351 — OS-notification permission state + the request trigger. Optional
   // for the same reason as the ping props: call sites and tests that don't
   // wire it stay valid, and the row simply doesn't render.
@@ -264,6 +268,8 @@ export interface SettingsPanelProps {
   onToggleConsoleTab?: (show: boolean) => void
   interventionPingEnabled?: boolean
   onToggleInterventionPing?: (enabled: boolean) => void
+  turnCompleteNotificationEnabled?: boolean
+  onToggleTurnCompleteNotification?: (enabled: boolean) => void
   notificationPermission?: UseNotificationPermissionResult
 }
 
@@ -726,7 +732,7 @@ function ThemeSwatches({ theme }: { theme: ThemeDefinition }) {
   )
 }
 
-export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing, notificationPermission }: SettingsContentProps) {
+export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing, turnCompleteNotificationEnabled, onToggleTurnCompleteNotification, notificationPermission }: SettingsContentProps) {
   // #5544: alias retained so the body's many `isOpen` reads (effect gates,
   // refresh-on-open) keep their original meaning — true while this surface
   // is the visible one (modal open, or Control Room Settings tab active).
@@ -2048,7 +2054,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
             )}
           </section>
 
-          {(onToggleConsoleTab || onToggleInterventionPing || notificationPermission) && (
+          {(onToggleConsoleTab || onToggleInterventionPing || onToggleTurnCompleteNotification || notificationPermission) && (
             <section className="settings-section" data-testid="dashboard-section">
               <h3>Dashboard</h3>
               {onToggleConsoleTab && (
@@ -2085,6 +2091,36 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
                     Applies to this device only. Repeat alerts for the same
                     request are deduped, and bursts across multiple sessions
                     are throttled into a single ping.
+                  </p>
+                </div>
+              )}
+              {/* #7347 — turn-complete OS notification. The session that has
+                  FINISHED and is waiting on you is the one you cannot spot
+                  in-app (#7340) — it looks exactly like a session nobody
+                  asked to do anything. Muted per-device and separately from
+                  the permission notification, so an operator who finds this
+                  one chatty does not answer by revoking OS notifications
+                  outright and losing the permission alerts too. */}
+              {onToggleTurnCompleteNotification && (
+                <div className="settings-field settings-field-checkbox">
+                  <label htmlFor="turn-complete-notification-toggle">
+                    <input
+                      id="turn-complete-notification-toggle"
+                      type="checkbox"
+                      checked={turnCompleteNotificationEnabled ?? true}
+                      onChange={(e) => onToggleTurnCompleteNotification(e.target.checked)}
+                      data-testid="turn-complete-notification-toggle"
+                    />
+                    Notify me when a session finishes
+                  </label>
+                  <p className="settings-hint">
+                    Raises a desktop notification when a session completes its
+                    turn and is left waiting on you — but only while this
+                    window is not focused, so it never fires for a turn you
+                    watched finish. A session that stops on a permission
+                    request is covered by the permission notification instead,
+                    not announced twice. Applies to this device only, and needs
+                    desktop notifications allowed below.
                   </p>
                 </div>
               )}
@@ -2330,7 +2366,7 @@ export function SettingsContent({ active, showConsoleTab, onToggleConsoleTab, in
  * still open a dismissable panel. The primary entry points (gear / Cmd+,)
  * now redirect to the Control Room Settings tab instead — see App.tsx.
  */
-export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing, notificationPermission }: SettingsPanelProps) {
+export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing, turnCompleteNotificationEnabled, onToggleTurnCompleteNotification, notificationPermission }: SettingsPanelProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -2366,6 +2402,8 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
           onToggleConsoleTab={onToggleConsoleTab}
           interventionPingEnabled={interventionPingEnabled}
           onToggleInterventionPing={onToggleInterventionPing}
+          turnCompleteNotificationEnabled={turnCompleteNotificationEnabled}
+          onToggleTurnCompleteNotification={onToggleTurnCompleteNotification}
           notificationPermission={notificationPermission}
         />
       </div>

--- a/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
+++ b/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
@@ -87,6 +87,40 @@ describe('App wires the notification-permission lifecycle', () => {
   })
 })
 
+describe('App wires the turn-complete notification (#7347)', () => {
+  // Same class of guard, same reason: `useTurnCompleteNotification` is fully
+  // covered by its own behavioural suite, and every one of those tests would
+  // still pass with the call deleted from App.tsx — leaving the exact state
+  // #7347 was filed about (a trigger that exists and never runs).
+
+  it('imports and mounts useTurnCompleteNotification', () => {
+    expect(appSource).toContain("from './hooks/useTurnCompleteNotification'")
+    expect(appSource).toMatch(/useTurnCompleteNotification\(\s*turnCompleteSessions\s*,/)
+  })
+
+  it('feeds it the live connection state, not a hardcoded true', () => {
+    // `connected: false` is what discards tracking across a socket drop. Wire
+    // a literal here and a reconnect manufactures a completed turn out of a
+    // re-seeded session_list snapshot.
+    expect(appSource).toMatch(/connected:\s*isConnected\s*,/)
+  })
+
+  it('derives busy from the per-session isIdle flag, not from sessions[].isBusy', () => {
+    // `sessions[].isBusy` is only a session_list snapshot and is NOT
+    // rebroadcast on a turn boundary — reading it here would mean the
+    // notification fires on session create/destroy and never on a completed
+    // turn. `session_activity` maintains `sessionStates[id].isIdle` instead.
+    expect(appSource).toMatch(/sessionStates\[id\]!\.isIdle === false/)
+    expect(appSource).toMatch(/busy:\s*sessionBusyById\[/)
+  })
+
+  it('suppresses the alert for a session that stopped on a permission prompt', () => {
+    // Otherwise the same moment produces two cards: this one and
+    // usePermissionNotification's.
+    expect(appSource).toMatch(/awaitingPermission:\s*\(pendingPermissionCounts\[/)
+  })
+})
+
 describe('native-notifications is the only Notification call site', () => {
   const files = sourceFiles(SRC)
 
@@ -151,6 +185,34 @@ describe('the Enable-notifications button only uses classes that exist', () => {
 
     const undefinedClasses = classes.filter(c => !new RegExp(`\\.${c}\\b`).test(css))
     expect(undefinedClasses).toEqual([])
+  })
+})
+
+describe('the Dashboard-section toggles meet the tap-target floor', () => {
+  it('gives .settings-field-checkbox label a 44px minimum', () => {
+    // The label is the control (clicking the text toggles the checkbox), so
+    // the 44pt floor applies to it and not to the native checkbox glyph. This
+    // is asserted on the SHARED class deliberately: the turn-complete toggle
+    // (#7347), the intervention ping and the console-tab switch all use it, so
+    // one rule covers the whole section and a fourth toggle inherits it.
+    const css = fs
+      .readFileSync(path.join(SRC, 'theme', 'components.css'), 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+    const rule = css.match(/\.settings-field-checkbox\s+label\s*\{[^}]*\}/)
+    expect(rule).not.toBeNull()
+    expect(rule![0]).toMatch(/min-height:\s*44px/)
+  })
+
+  it('renders the turn-complete toggle inside a .settings-field-checkbox row', () => {
+    // Positive control for the CSS assertion above: the rule only protects
+    // this toggle if the toggle actually carries the class.
+    const panel = stripCommentLines(
+      fs.readFileSync(path.join(SRC, 'components', 'SettingsPanel.tsx'), 'utf-8'),
+    )
+    const row = panel.match(
+      /className="settings-field settings-field-checkbox"[\s\S]{0,600}?turn-complete-notification-toggle/,
+    )
+    expect(row).not.toBeNull()
   })
 })
 

--- a/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
+++ b/packages/dashboard/src/hooks/notificationPermissionWiring.test.ts
@@ -92,32 +92,63 @@ describe('App wires the turn-complete notification (#7347)', () => {
   // covered by its own behavioural suite, and every one of those tests would
   // still pass with the call deleted from App.tsx — leaving the exact state
   // #7347 was filed about (a trigger that exists and never runs).
+  //
+  // The two regions are sliced out and asserted WITHIN, rather than scanned
+  // for loosely across the whole file. A bare `expect(appSource).toMatch(
+  // /connected: isConnected/)` would keep passing the day some unrelated
+  // component picks up an identically-named prop — the guard would then be
+  // satisfied by a line that has nothing to do with this hook.
+  const CALL_ANCHOR = 'useTurnCompleteNotification(turnCompleteSessions'
+  const MEMO_ANCHOR = 'const turnCompleteSessions = useMemo'
+
+  const memoStart = appSource.indexOf(MEMO_ANCHOR)
+  const callStart = appSource.indexOf(CALL_ANCHOR)
+  const memoSource = memoStart >= 0 && callStart > memoStart ? appSource.slice(memoStart, callStart) : ''
+  const callSource = callStart >= 0 ? appSource.slice(callStart, appSource.indexOf('})', callStart) + 2) : ''
 
   it('imports and mounts useTurnCompleteNotification', () => {
     expect(appSource).toContain("from './hooks/useTurnCompleteNotification'")
-    expect(appSource).toMatch(/useTurnCompleteNotification\(\s*turnCompleteSessions\s*,/)
+    expect(callStart).toBeGreaterThan(-1)
+  })
+
+  it('sliced out both regions — positive control for the assertions below', () => {
+    // Without this, an anchor that stopped matching would leave both slices
+    // empty and every `not.toMatch` below would pass vacuously.
+    expect(memoSource.length).toBeGreaterThan(100)
+    expect(callSource.length).toBeGreaterThan(50)
+    expect(memoSource).toContain('sessions.map')
   })
 
   it('feeds it the live connection state, not a hardcoded true', () => {
     // `connected: false` is what discards tracking across a socket drop. Wire
     // a literal here and a reconnect manufactures a completed turn out of a
     // re-seeded session_list snapshot.
-    expect(appSource).toMatch(/connected:\s*isConnected\s*,/)
+    expect(callSource).toMatch(/connected:\s*isConnected\b/)
+  })
+
+  it('feeds it the live mute toggle, not a hardcoded true', () => {
+    expect(callSource).toMatch(/enabled:\s*turnCompleteNotificationEnabled\b/)
+  })
+
+  it('wires the click through to a session switch', () => {
+    expect(callSource).toMatch(/onNotificationClick:\s*handleSwitchSession\b/)
   })
 
   it('derives busy from the per-session isIdle flag, not from sessions[].isBusy', () => {
     // `sessions[].isBusy` is only a session_list snapshot and is NOT
-    // rebroadcast on a turn boundary — reading it here would mean the
-    // notification fires on session create/destroy and never on a completed
-    // turn. `session_activity` maintains `sessionStates[id].isIdle` instead.
+    // rebroadcast on a turn boundary; the top-level flat `isIdle` mirrors the
+    // ACTIVE session alone. `session_activity` maintains
+    // `sessionStates[id].isIdle` for every session, which is the one that
+    // moves on a turn boundary.
+    expect(memoSource).toMatch(/busy:\s*sessionBusyById\[/)
+    expect(memoSource).not.toMatch(/busy:\s*s\.isBusy\b/)
     expect(appSource).toMatch(/sessionStates\[id\]!\.isIdle === false/)
-    expect(appSource).toMatch(/busy:\s*sessionBusyById\[/)
   })
 
   it('suppresses the alert for a session that stopped on a permission prompt', () => {
     // Otherwise the same moment produces two cards: this one and
     // usePermissionNotification's.
-    expect(appSource).toMatch(/awaitingPermission:\s*\(pendingPermissionCounts\[/)
+    expect(memoSource).toMatch(/awaitingPermission:\s*\(pendingPermissionCounts\[/)
   })
 })
 

--- a/packages/dashboard/src/hooks/useTurnCompleteNotification.test.ts
+++ b/packages/dashboard/src/hooks/useTurnCompleteNotification.test.ts
@@ -11,11 +11,17 @@
  * effect cannot pass as a suppression. Each guard was additionally verified by
  * deleting it from the hook and confirming the matching test goes red:
  *
- *   - `if (document.hasFocus()) return`         → "does not notify while focused"
- *   - `if (!enabled) return`                    → "does not notify while muted"
- *   - `if (session.awaitingPermission) continue`→ "does not double-notify"
- *   - `if (!connected) { clear; return }`       → "does not notify across a reconnect"
- *   - `observedBusy &&` (edge → state)          → "does not notify for a session that was never busy"
+ *   - `if (document.hasFocus()) return`   → does not notify while the window is focused
+ *   - `if (!enabled) return`              → does not notify while muted
+ *   - `if (session.awaitingPermission)`   → does not double-notify a session that stopped on a permission prompt
+ *   - `if (!connected) { clear; return }` → does not notify across a reconnect that re-seeds the session as idle
+ *   - `observedBusy &&` (edge → state)    → does not notify for a session that was never busy
+ *   - the stale-session prune             → forgets a session that disappears mid-turn
+ *   - `clickRef` (captured closure)       → uses the latest click handler
+ *
+ * The harness asserted each replacement actually landed (one match, bytes
+ * changed) before trusting a red, and that the NAMED test was among the
+ * failures rather than just "something failed".
  *
  * ## Harness notes
  *
@@ -29,6 +35,7 @@
  * `waitFor` that could pass before the thing it guards had a chance to happen.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { StrictMode } from 'react'
 import { renderHook, cleanup } from '@testing-library/react'
 import {
   useTurnCompleteNotification,
@@ -298,6 +305,44 @@ describe('useTurnCompleteNotification — multiple sessions', () => {
     rerender({ sessions: [session({ sessionId: 's1', busy: false })], options: DEFAULTS })
 
     expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+})
+
+describe('useTurnCompleteNotification — under StrictMode', () => {
+  // `src/main.tsx` renders the app inside <StrictMode>, which double-invokes
+  // effects on mount. The hook keeps its busy set in a ref and has no cleanup
+  // function, so the second invocation sees the bookkeeping the first one
+  // already did. Verified rather than reasoned about: a hook that tracks an
+  // edge in a ref is exactly the shape StrictMode catches out, and getting it
+  // wrong is silent — either a duplicate alert or a swallowed one.
+  const strict = { wrapper: StrictMode }
+
+  function mountStrict(sessions: TurnCompleteSession[]) {
+    return renderHook(
+      ({ sessions: s }: { sessions: TurnCompleteSession[] }) =>
+        useTurnCompleteNotification(s, DEFAULTS),
+      { initialProps: { sessions }, ...strict },
+    )
+  }
+
+  it('does not fire on the double-invoked mount of an already-busy session', () => {
+    const { unmount } = mountStrict([session({ busy: true })])
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('does not fire on the double-invoked mount of an already-idle session', () => {
+    const { unmount } = mountStrict([session({ busy: false })])
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('still fires exactly once for a turn that completes after mount', () => {
+    const { rerender, unmount } = mountStrict([session({ busy: true })])
+    rerender({ sessions: [session({ busy: false })] })
+
+    expect(mockSend).toHaveBeenCalledOnce()
     unmount()
   })
 })

--- a/packages/dashboard/src/hooks/useTurnCompleteNotification.test.ts
+++ b/packages/dashboard/src/hooks/useTurnCompleteNotification.test.ts
@@ -1,0 +1,364 @@
+/**
+ * useTurnCompleteNotification tests (#7347).
+ *
+ * ## What "prove it red" means for this suite
+ *
+ * On main the hook does not exist, so the headline case is red by absence —
+ * which proves nothing about the GUARDS, and the guards are where this feature
+ * either works or becomes noise nobody keeps switched on. Every negative
+ * assertion below is therefore paired with a positive control that fires under
+ * the same harness, one field apart, so a fixture that silently failed to take
+ * effect cannot pass as a suppression. Each guard was additionally verified by
+ * deleting it from the hook and confirming the matching test goes red:
+ *
+ *   - `if (document.hasFocus()) return`         → "does not notify while focused"
+ *   - `if (!enabled) return`                    → "does not notify while muted"
+ *   - `if (session.awaitingPermission) continue`→ "does not double-notify"
+ *   - `if (!connected) { clear; return }`       → "does not notify across a reconnect"
+ *   - `observedBusy &&` (edge → state)          → "does not notify for a session that was never busy"
+ *
+ * ## Harness notes
+ *
+ * `document.hasFocus` is stubbed per-case and restored in an explicit
+ * `afterEach`. `cleanup()` runs there too: this package registers no RTL
+ * auto-cleanup (`globals: false`, and `src/test-setup.ts` never calls it), so
+ * a hook left mounted stays mounted into the next file.
+ *
+ * Nothing here is async. The hook's whole effect body runs synchronously
+ * inside `render`/`rerender`, so there is no settle to wait for and no
+ * `waitFor` that could pass before the thing it guards had a chance to happen.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, cleanup } from '@testing-library/react'
+import {
+  useTurnCompleteNotification,
+  type TurnCompleteSession,
+  type UseTurnCompleteNotificationOptions,
+} from './useTurnCompleteNotification'
+import { sendNativeNotification } from '../utils/native-notifications'
+
+vi.mock('../utils/native-notifications', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils/native-notifications')>()
+  return { ...actual, sendNativeNotification: vi.fn(() => true) }
+})
+
+const mockSend = vi.mocked(sendNativeNotification)
+let originalHasFocus: typeof document.hasFocus
+
+beforeEach(() => {
+  originalHasFocus = document.hasFocus
+  mockSend.mockClear()
+  // Default: window NOT focused, i.e. the state in which the feature is
+  // supposed to fire. Cases that test the focus gate opt in explicitly.
+  document.hasFocus = () => false
+})
+
+afterEach(() => {
+  document.hasFocus = originalHasFocus
+  cleanup()
+})
+
+function session(overrides: Partial<TurnCompleteSession> = {}): TurnCompleteSession {
+  return {
+    sessionId: 's1',
+    name: 'chroxy',
+    busy: false,
+    awaitingPermission: false,
+    ...overrides,
+  }
+}
+
+const DEFAULTS: UseTurnCompleteNotificationOptions = { enabled: true, connected: true }
+
+/**
+ * Mount the hook over a mutable (sessions, options) pair so a case can drive
+ * the busy → idle transition the same way React does — one rerender per state
+ * change, with the hook's own ref surviving between them.
+ */
+function mount(
+  initialSessions: TurnCompleteSession[],
+  initialOptions: UseTurnCompleteNotificationOptions = DEFAULTS,
+) {
+  return renderHook(
+    ({ sessions, options }: { sessions: TurnCompleteSession[]; options: UseTurnCompleteNotificationOptions }) =>
+      useTurnCompleteNotification(sessions, options),
+    { initialProps: { sessions: initialSessions, options: initialOptions } },
+  )
+}
+
+describe('useTurnCompleteNotification — the turn-complete edge', () => {
+  it('notifies when a busy session goes idle while the window is unfocused', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    expect(mockSend).not.toHaveBeenCalled()
+
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledWith('Chroxy: chroxy', {
+      body: 'Finished — awaiting your input.',
+      tag: 'chroxy-turn-s1',
+      onClick: expect.any(Function),
+    })
+    unmount()
+  })
+
+  it('does not notify for a session that was never busy — idle is not "awaiting you"', () => {
+    // The positive control is the case above: identical harness, identical
+    // final state, and it fires. The ONLY difference here is that the session
+    // never passed through `busy: true`, so there is no edge to notify about.
+    const { rerender, unmount } = mount([session({ busy: false })])
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('does not notify while a session is still busy', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: true, name: 'renamed' })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('notifies once per completed turn, not once per render', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('notifies again for a second turn on the same session', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: true })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).toHaveBeenCalledTimes(2)
+    unmount()
+  })
+})
+
+describe('useTurnCompleteNotification — gates', () => {
+  it('does not notify while the window is focused', () => {
+    document.hasFocus = () => true
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('consumes the edge while focused, so blurring later does not fire a stale alert', () => {
+    // The bookkeeping has to run even when dispatch is suppressed. Otherwise
+    // the session stays recorded as busy, and the next pass after the window
+    // blurs re-detects a "completed turn" that finished while the user was
+    // watching it.
+    document.hasFocus = () => true
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    document.hasFocus = () => false
+    rerender({ sessions: [session({ busy: false, name: 'nudge' })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('does not notify while muted', () => {
+    const muted = { ...DEFAULTS, enabled: false }
+    const { rerender, unmount } = mount([session({ busy: true })], muted)
+    rerender({ sessions: [session({ busy: false })], options: muted })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('consumes the edge while muted, so unmuting later does not fire a stale alert', () => {
+    const muted = { ...DEFAULTS, enabled: false }
+    const { rerender, unmount } = mount([session({ busy: true })], muted)
+    rerender({ sessions: [session({ busy: false })], options: muted })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('does not double-notify a session that stopped on a permission prompt', () => {
+    // usePermissionNotification owns that moment and fires for the prompt
+    // itself; two cards for one event is just duplication.
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({
+      sessions: [session({ busy: false, awaitingPermission: true })],
+      options: DEFAULTS,
+    })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('notifies the same edge when no prompt is pending — control for the case above', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({
+      sessions: [session({ busy: false, awaitingPermission: false })],
+      options: DEFAULTS,
+    })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    unmount()
+  })
+})
+
+describe('useTurnCompleteNotification — connection lifecycle', () => {
+  it('does not notify across a reconnect that re-seeds the session as idle', () => {
+    // A dropped socket clears transient per-session state and a reconnect
+    // re-seeds `isIdle` from the session_list snapshot. Neither is a completed
+    // turn, and the turn may well still be running on the server.
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: true })], options: { ...DEFAULTS, connected: false } })
+    // Reconnect: the snapshot says idle.
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('notifies the same busy → idle sequence when the socket never dropped — control', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: true })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('starts notifying again for turns that complete after the reconnect', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: true })], options: { ...DEFAULTS, connected: false } })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+    // A genuine new turn, fully observed on the live socket.
+    rerender({ sessions: [session({ busy: true })], options: DEFAULTS })
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    unmount()
+  })
+})
+
+describe('useTurnCompleteNotification — multiple sessions', () => {
+  it('notifies only the session that finished', () => {
+    const busyPair = [
+      session({ sessionId: 's1', name: 'api', busy: true }),
+      session({ sessionId: 's2', name: 'web', busy: true }),
+    ]
+    const { rerender, unmount } = mount(busyPair)
+    rerender({
+      sessions: [
+        session({ sessionId: 's1', name: 'api', busy: false }),
+        session({ sessionId: 's2', name: 'web', busy: true }),
+      ],
+      options: DEFAULTS,
+    })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledWith('Chroxy: api', expect.objectContaining({ tag: 'chroxy-turn-s1' }))
+    unmount()
+  })
+
+  it('notifies a background session — the turn boundary is not the active tab', () => {
+    // The whole point of #7347: `session_activity` carries every session's
+    // busy/idle, so a session the user is not looking at still gets its
+    // completion announced.
+    const { rerender, unmount } = mount([
+      session({ sessionId: 's1', name: 'api', busy: false }),
+      session({ sessionId: 's2', name: 'web', busy: true }),
+    ])
+    rerender({
+      sessions: [
+        session({ sessionId: 's1', name: 'api', busy: false }),
+        session({ sessionId: 's2', name: 'web', busy: false }),
+      ],
+      options: DEFAULTS,
+    })
+
+    expect(mockSend).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledWith('Chroxy: web', expect.objectContaining({ tag: 'chroxy-turn-s2' }))
+    unmount()
+  })
+
+  it('forgets a session that disappears mid-turn, so a reused id does not inherit its edge', () => {
+    const { rerender, unmount } = mount([session({ sessionId: 's1', busy: true })])
+    // Server drops it while still busy (destroyed session).
+    rerender({ sessions: [], options: DEFAULTS })
+    // A new session lands on the same id, idle.
+    rerender({ sessions: [session({ sessionId: 's1', busy: false })], options: DEFAULTS })
+
+    expect(mockSend).not.toHaveBeenCalled()
+    unmount()
+  })
+})
+
+describe('useTurnCompleteNotification — click-to-focus', () => {
+  it('routes the click to the session that finished', () => {
+    const onNotificationClick = vi.fn()
+    const options = { ...DEFAULTS, onNotificationClick }
+    const { rerender, unmount } = mount(
+      [
+        session({ sessionId: 's1', name: 'api', busy: true }),
+        session({ sessionId: 's2', name: 'web', busy: true }),
+      ],
+      options,
+    )
+    rerender({
+      sessions: [
+        session({ sessionId: 's1', name: 'api', busy: true }),
+        session({ sessionId: 's2', name: 'web', busy: false }),
+      ],
+      options,
+    })
+
+    expect(onNotificationClick).not.toHaveBeenCalled()
+    const sent = mockSend.mock.calls[0]![1]!
+    sent.onClick!()
+    expect(onNotificationClick).toHaveBeenCalledWith('s2')
+    unmount()
+  })
+
+  it('uses the latest click handler, not the one captured when the notification was sent', () => {
+    // The handler is held in a ref precisely so a re-rendered parent callback
+    // does not re-run the effect. That is only safe if the ref is what the
+    // notification calls — a stale closure here would switch to a session the
+    // user asked for several renders ago.
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender, unmount } = mount([session({ busy: true })], {
+      ...DEFAULTS,
+      onNotificationClick: first,
+    })
+    rerender({
+      sessions: [session({ busy: false })],
+      options: { ...DEFAULTS, onNotificationClick: first },
+    })
+    rerender({
+      sessions: [session({ busy: false })],
+      options: { ...DEFAULTS, onNotificationClick: second },
+    })
+
+    mockSend.mock.calls[0]![1]!.onClick!()
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledWith('s1')
+    unmount()
+  })
+
+  it('does not throw when no click handler is wired', () => {
+    const { rerender, unmount } = mount([session({ busy: true })])
+    rerender({ sessions: [session({ busy: false })], options: DEFAULTS })
+
+    expect(() => mockSend.mock.calls[0]![1]!.onClick!()).not.toThrow()
+    unmount()
+  })
+})

--- a/packages/dashboard/src/hooks/useTurnCompleteNotification.ts
+++ b/packages/dashboard/src/hooks/useTurnCompleteNotification.ts
@@ -1,0 +1,157 @@
+/**
+ * useTurnCompleteNotification (#7347) — fire a native notification when a
+ * session finishes its turn and is left waiting on the user, while the chroxy
+ * window is not focused.
+ *
+ * ## The gap this closes
+ *
+ * Before this, `usePermissionNotification` was the dashboard's ONLY native
+ * notification trigger. A permission request notified; a completed turn did
+ * not. That is backwards: a pending permission leaves the session *visibly*
+ * blocked (the ⚠ badge, the Allow/Deny card), whereas a finished turn awaiting
+ * a decision is visually indistinguishable from a session that was idle all
+ * along (#7340). The silent case is precisely the one that needs an
+ * out-of-app signal, and a long autonomous run finishing and sitting unnoticed
+ * is what filed the issue.
+ *
+ * (Note the trigger only became reachable at all with #7351, which added the
+ * `Notification.requestPermission()` call chroxy had never made. A trigger
+ * added before that would have been just as dead as the permission one.)
+ *
+ * ## Why the EDGE, not the state
+ *
+ * The hook fires on the busy → not-busy **transition**, never on "is idle".
+ * A session that is merely idle is not awaiting anybody — it is a session
+ * nobody has asked to do anything. Keying on the state instead of the edge
+ * would notify for every session on the list the moment the window blurred,
+ * which is both wrong and unmutable-in-practice.
+ *
+ * `busy` is fed from the server-authoritative per-session `isIdle` flag
+ * (#4639), which `session_activity` maintains for EVERY session — the server
+ * broadcasts it on `stream_start` (busy) and on `result` (idle), so a
+ * background session's turn boundary reaches us without the session being
+ * active. The optimistic `streamingMessageId` sentinel is deliberately NOT
+ * folded in: it only ever covers the active session's own sends, and
+ * `handleDisconnected` clears it, which would manufacture a busy → idle edge
+ * out of a dropped socket.
+ *
+ * ## Why a dropped socket resets everything
+ *
+ * A disconnect is not a completed turn. `handleDisconnected` clears transient
+ * per-session state, and a reconnect re-seeds `isIdle` from the `session_list`
+ * snapshot — either of which can look exactly like busy → idle for a turn that
+ * is in fact still running on the server. So `connected === false` drops all
+ * tracking, and the first observation after the socket returns only re-seeds.
+ *
+ * ## Gates
+ *
+ * - **Window focus** — same rule as `usePermissionNotification`. If the user
+ *   is looking at chroxy they do not need to be told. Skipping this is how the
+ *   feature becomes noise on every turn, and the way users answer noise is by
+ *   switching OS notifications off wholesale — which takes the permission
+ *   notifications with it.
+ * - **Already-pending prompt** — a session that stopped ON a permission
+ *   request is already covered by `usePermissionNotification`. Firing here too
+ *   is a duplicate alert for one moment.
+ * - **Operator mute** — Settings → Dashboard, persisted per-device.
+ * - **OS permission** — NOT checked here. `sendNativeNotification` owns that
+ *   decision; see its contract. Pre-checking is what let the pre-#7351 code
+ *   scatter a guard nothing satisfied.
+ *
+ * The gates suppress the *dispatch* only. Busy-state bookkeeping runs
+ * unconditionally on every pass (short of a disconnect), so a mute toggled
+ * mid-turn, or a window focused mid-turn, does not leave stale state that
+ * fires a phantom notification later.
+ */
+import { useEffect, useRef } from 'react'
+import { sendNativeNotification } from '../utils/native-notifications'
+
+export interface TurnCompleteSession {
+  sessionId: string
+  /** Display name, used verbatim in the notification title. */
+  name: string
+  /**
+   * Whether a turn is currently in flight. Derived from the session's
+   * server-authoritative `isIdle` flag — see the header.
+   */
+  busy: boolean
+  /**
+   * Whether this session currently has a live, unanswered permission prompt.
+   * When true the turn-complete notification is suppressed because
+   * `usePermissionNotification` already covers that moment.
+   */
+  awaitingPermission: boolean
+}
+
+export interface UseTurnCompleteNotificationOptions {
+  /** Operator toggle (Settings → Dashboard). False mutes dispatch only. */
+  enabled: boolean
+  /** Whether the WebSocket is currently connected — see the header. */
+  connected: boolean
+  /**
+   * Called when the user clicks the notification, so the app can bring the
+   * finished session to the front. Web backend only — the Tauri plugin has no
+   * click callback on desktop (see `NativeNotificationOptions.onClick`).
+   */
+  onNotificationClick?: (sessionId: string) => void
+}
+
+export function useTurnCompleteNotification(
+  sessions: TurnCompleteSession[],
+  { enabled, connected, onNotificationClick }: UseTurnCompleteNotificationOptions,
+): void {
+  /** Session ids observed busy on the previous pass. */
+  const busyRef = useRef(new Set<string>())
+
+  // Held in a ref so a fresh click handler from the parent's render does not
+  // re-run the effect. Re-running is not merely wasteful here: the effect is
+  // edge-triggered off `busyRef`, and an extra pass with unchanged sessions is
+  // a no-op, but keeping the dep array to genuine state keeps that guarantee
+  // obvious rather than incidental.
+  const clickRef = useRef(onNotificationClick)
+  useEffect(() => {
+    clickRef.current = onNotificationClick
+  }, [onNotificationClick])
+
+  useEffect(() => {
+    const wasBusy = busyRef.current
+
+    if (!connected) {
+      wasBusy.clear()
+      return
+    }
+
+    const liveIds = new Set<string>()
+    const finished: TurnCompleteSession[] = []
+
+    for (const session of sessions) {
+      liveIds.add(session.sessionId)
+      const observedBusy = wasBusy.has(session.sessionId)
+      if (session.busy) wasBusy.add(session.sessionId)
+      else wasBusy.delete(session.sessionId)
+      if (observedBusy && !session.busy) finished.push(session)
+    }
+
+    // Drop sessions the server no longer lists, so the set stays bounded and a
+    // reused id starts from "never observed busy" rather than inheriting a
+    // stale edge from a destroyed session.
+    for (const id of wasBusy) {
+      if (!liveIds.has(id)) wasBusy.delete(id)
+    }
+
+    if (finished.length === 0) return
+    if (!enabled) return
+    if (document.hasFocus()) return
+
+    for (const session of finished) {
+      if (session.awaitingPermission) continue
+      sendNativeNotification(`Chroxy: ${session.name}`, {
+        body: 'Finished — awaiting your input.',
+        // Collapse repeat completions of the same session into one card
+        // instead of stacking one per turn.
+        tag: `chroxy-turn-${session.sessionId}`,
+        onClick: () => clickRef.current?.(session.sessionId),
+      })
+    }
+  }, [sessions, enabled, connected])
+}

--- a/packages/dashboard/src/store/persistence-notifications.test.ts
+++ b/packages/dashboard/src/store/persistence-notifications.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-device notification preferences (#7347, #7351).
+ *
+ * Two things are covered here, and the second is the interesting one:
+ *
+ * 1. The turn-complete mute toggle defaults ON, mutes only on an explicit
+ *    `'false'`, and survives the storage being unavailable.
+ * 2. Both notification keys survive an **unscoped** `clearPersistedState()` —
+ *    the server-switch path. `KEY_NOTIFICATION_PERMISSION_ASKED` shipped in
+ *    #7351 without being added to `isGlobalKey`, so switching servers deleted
+ *    the "we already asked" flag and re-armed the automatic OS-permission
+ *    prompt for someone who had dismissed one. That is the exact re-prompt
+ *    loop the flag exists to stop; it was simply hidden behind an action
+ *    nobody performs in a unit test.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  setServerScope,
+  clearPersistedState,
+  persistActiveSession,
+  persistTurnCompleteNotification,
+  loadPersistedTurnCompleteNotification,
+  persistNotificationPermissionAsked,
+  loadNotificationPermissionAsked,
+  persistInterventionPing,
+  loadPersistedInterventionPing,
+  _resetForTesting,
+} from './persistence'
+
+beforeEach(() => {
+  localStorage.clear()
+  _resetForTesting()
+  setServerScope(null)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('turn-complete notification preference (#7347)', () => {
+  it('defaults to ON when nothing is stored', () => {
+    expect(loadPersistedTurnCompleteNotification()).toBe(true)
+  })
+
+  it('round-trips an explicit mute and un-mute', () => {
+    persistTurnCompleteNotification(false)
+    expect(loadPersistedTurnCompleteNotification()).toBe(false)
+
+    persistTurnCompleteNotification(true)
+    expect(loadPersistedTurnCompleteNotification()).toBe(true)
+  })
+
+  it('treats any non-"false" stored value as ON', () => {
+    localStorage.setItem('chroxy_persist_turn_complete_notification', 'garbage')
+    expect(loadPersistedTurnCompleteNotification()).toBe(true)
+  })
+
+  it('falls back to ON when storage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    expect(loadPersistedTurnCompleteNotification()).toBe(true)
+  })
+
+  it('does not throw when storage refuses the write', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    expect(() => persistTurnCompleteNotification(false)).not.toThrow()
+  })
+
+  it('is independent of the intervention-ping mute', () => {
+    // The two alerts fire on different events and must be mutable separately —
+    // muting "the session finished" cannot silence "the session needs you".
+    persistTurnCompleteNotification(false)
+    expect(loadPersistedInterventionPing()).toBe(true)
+
+    persistInterventionPing(false)
+    persistTurnCompleteNotification(true)
+    expect(loadPersistedInterventionPing()).toBe(false)
+    expect(loadPersistedTurnCompleteNotification()).toBe(true)
+  })
+})
+
+describe('notification prefs survive an unscoped clear (server switch)', () => {
+  it('keeps the turn-complete mute', () => {
+    persistTurnCompleteNotification(false)
+    persistActiveSession('session-1')
+
+    clearPersistedState()
+
+    // Control: genuinely server-scoped state IS cleared, so this test is not
+    // passing because clearPersistedState quietly did nothing.
+    expect(localStorage.getItem('chroxy_persist_active_session_id')).toBeNull()
+    expect(loadPersistedTurnCompleteNotification()).toBe(false)
+  })
+
+  it('keeps the "already asked for OS permission" flag (#7351 regression)', () => {
+    persistNotificationPermissionAsked()
+    persistActiveSession('session-1')
+    expect(loadNotificationPermissionAsked()).toBe(true)
+
+    clearPersistedState()
+
+    expect(localStorage.getItem('chroxy_persist_active_session_id')).toBeNull()
+    // Before this was added to isGlobalKey the flag was wiped here, and the
+    // next page load re-prompted a user who had already said "not now".
+    expect(loadNotificationPermissionAsked()).toBe(true)
+  })
+})

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -31,6 +31,13 @@ const KEY_INTERVENTION_PING = `${KEY_PREFIX}intervention_ping`;
 // `isPermissionGranted()` is a bare boolean. Without this flag the first-run
 // request would re-fire on every single page load for anyone who dismissed it.
 const KEY_NOTIFICATION_PERMISSION_ASKED = `${KEY_PREFIX}notification_permission_asked`;
+// #7347 — native notification when a session's turn completes and it is
+// waiting on the user. Defaults on; persisted per-device so a muted device
+// stays muted. Separate from the permission-request notification on purpose:
+// the two fire on different events, and an operator who finds turn-complete
+// alerts noisy must be able to mute THEM without switching OS notifications
+// off wholesale, which would take the permission ones with it.
+const KEY_TURN_COMPLETE_NOTIFICATION = `${KEY_PREFIX}turn_complete_notification`;
 // #6799 — global "compact" chat filter (hide tool calls + thinking, mobile
 // parity). Defaults off; persisted per-device so the choice survives reload.
 const KEY_COMPACT_CHAT_FILTER = `${KEY_PREFIX}compact_chat_filter`;
@@ -528,6 +535,33 @@ export function loadNotificationPermissionAsked(): boolean {
   }
 }
 
+/** Persist the turn-complete native-notification enable/mute preference (#7347) */
+export function persistTurnCompleteNotification(enabled: boolean): void {
+  try {
+    localStorage.setItem(KEY_TURN_COMPLETE_NOTIFICATION, String(enabled));
+  } catch {
+    // Storage not available
+  }
+}
+
+/**
+ * Load the persisted turn-complete native-notification preference (#7347).
+ *
+ * Defaults to ON (returns true) when unset, and falls back to ON when storage
+ * is unavailable — same contract as `loadPersistedInterventionPing`. Only an
+ * explicit `'false'` mutes it. The whole point of #7347 is that a finished
+ * session is otherwise indistinguishable from an idle one, so the alert has to
+ * ship enabled to be worth anything; the OS permission gate and the
+ * window-focus gate are what keep it from being noisy.
+ */
+export function loadPersistedTurnCompleteNotification(): boolean {
+  try {
+    return localStorage.getItem(KEY_TURN_COMPLETE_NOTIFICATION) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Persist the compact-chat-filter preference (#6799 — hide tool calls +
  * thinking across the whole transcript, mirroring the mobile app's coarse
@@ -757,6 +791,17 @@ export function clearPersistedState(): void {
  * server-scoped repo/session/tab ordering below), so they belong in the same
  * survive-clear class as the #6915 device prefs. Pre-existing asymmetry from
  * #4304 — this was never intentional exclusion.
+ *
+ * #7347 adds the two OS-notification keys, which are device-level for the same
+ * reason `theme` is — an OS permission grant and a per-device mute have
+ * nothing to do with which chroxy server you are pointed at:
+ *
+ * - `KEY_TURN_COMPLETE_NOTIFICATION` — the new mute toggle.
+ * - `KEY_NOTIFICATION_PERMISSION_ASKED` — shipped in #7351 and never added
+ *   here, so an unscoped `clearPersistedState()` (server switch) deleted it
+ *   and re-armed the automatic first-run permission prompt for a user who had
+ *   already dismissed one. That is exactly the re-prompt-forever behaviour the
+ *   flag was introduced to prevent, just gated behind a server switch.
  */
 function isGlobalKey(key: string): boolean {
   return key === KEY_VIEW_MODE
@@ -766,6 +811,8 @@ function isGlobalKey(key: string): boolean {
     || key === KEY_THEME
     || key === KEY_SHOW_CONSOLE_TAB
     || key === KEY_INTERVENTION_PING
+    || key === KEY_NOTIFICATION_PERMISSION_ASKED
+    || key === KEY_TURN_COMPLETE_NOTIFICATION
     || key === KEY_COMPACT_CHAT_FILTER
     || key === KEY_SIDEBAR_PANEL_HEIGHT
     || key === KEY_SIDEBAR_PANEL_VIEW

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8341,6 +8341,13 @@ button.sidebar-token-view-session-row:hover {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  /* Tap-target floor (#3751 family): the LABEL is the control here — clicking
+     the text toggles the checkbox — so it is the box that has to clear 44px,
+     not the 13px native checkbox glyph inside it. At 14px text the row was
+     ~20px tall, well under the floor, for every toggle in this section. Grown
+     on the shared class rather than per-row so a new toggle inherits a
+     compliant target instead of having to remember one (#7347). */
+  min-height: 44px;
   margin-bottom: 6px;
   font-size: 14px;
   color: var(--text-primary);

--- a/packages/dashboard/src/utils/native-notifications.test.ts
+++ b/packages/dashboard/src/utils/native-notifications.test.ts
@@ -63,6 +63,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // #7347: the onClick cases spy on `window.focus`. Restoring here rather than
+  // only at the end of each case means a failing assertion cannot leak a
+  // throwing focus stub into the next test and turn one red into several.
+  vi.restoreAllMocks()
   if (originalNotification) Object.defineProperty(globalThis, 'Notification', originalNotification)
   // @ts-expect-error — clearing the global
   else delete globalThis.Notification

--- a/packages/dashboard/src/utils/native-notifications.test.ts
+++ b/packages/dashboard/src/utils/native-notifications.test.ts
@@ -213,3 +213,89 @@ describe('sendNativeNotification', () => {
     expect(sendNativeNotification('t')).toBe(false)
   })
 })
+
+/**
+ * #7347 — click-to-focus.
+ *
+ * The turn-complete notification names a session, so clicking it has to be
+ * able to bring that session to the front. These pin BOTH halves of what the
+ * module actually does: the web backend wires the click, and the Tauri backend
+ * demonstrably does not. The second half is the point — desktop click-to-focus
+ * needs a Rust-side notification, and a test that only covered the web path
+ * would leave "does the desktop app do this?" answerable only by guessing.
+ */
+describe('sendNativeNotification — onClick (#7347)', () => {
+  /**
+   * Web backend whose constructor produces an instance with a real `close`,
+   * so the click handler can be invoked the way a browser would invoke it.
+   */
+  function installClickableWebBackend() {
+    const instances: Array<{ onclick: (() => void) | null; close: ReturnType<typeof vi.fn> }> = []
+    const ctor = installWebBackend('granted')
+    ctor.mockImplementation(function (this: { onclick: (() => void) | null; close: ReturnType<typeof vi.fn> }) {
+      this.onclick = null
+      this.close = vi.fn()
+      instances.push(this)
+    })
+    return { ctor, instances }
+  }
+
+  it('wires the click handler on the web backend, focusing the window and closing the card', () => {
+    const { instances } = installClickableWebBackend()
+    const onClick = vi.fn()
+    const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {})
+
+    expect(sendNativeNotification('Chroxy: api', { body: 'Finished', onClick })).toBe(true)
+    expect(instances).toHaveLength(1)
+    const instance = instances[0]!
+    // Not yet — only the click may fire it.
+    expect(onClick).not.toHaveBeenCalled()
+
+    expect(typeof instance.onclick).toBe('function')
+    instance.onclick!()
+
+    expect(focusSpy).toHaveBeenCalled()
+    expect(instance.close).toHaveBeenCalled()
+    expect(onClick).toHaveBeenCalledOnce()
+    focusSpy.mockRestore()
+  })
+
+  it('still calls back when window.focus() is refused', () => {
+    const { instances } = installClickableWebBackend()
+    const onClick = vi.fn()
+    const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {
+      throw new Error('blocked by window-management policy')
+    })
+
+    sendNativeNotification('Chroxy: api', { onClick })
+    instances[0]!.onclick!()
+
+    // The in-app navigation is worth doing even when the window cannot be
+    // raised — otherwise a focus policy silently eats the whole interaction.
+    expect(onClick).toHaveBeenCalledOnce()
+    focusSpy.mockRestore()
+  })
+
+  it('leaves onclick unset when the caller passes no handler', () => {
+    const { instances } = installClickableWebBackend()
+    sendNativeNotification('Chroxy: api', { body: 'Finished' })
+    expect(instances[0]!.onclick).toBeNull()
+  })
+
+  it('sends but does NOT invoke onClick on the Tauri backend — the documented desktop gap', async () => {
+    const api = installTauriBackend({ granted: true })
+    await refreshNotificationPermission()
+    const onClick = vi.fn()
+
+    // The notification itself still goes out; only the click wiring is absent.
+    expect(sendNativeNotification('Chroxy: api', { body: 'Finished', onClick })).toBe(true)
+    expect(api.sendNotification).toHaveBeenCalledWith({ title: 'Chroxy: api', body: 'Finished' })
+    // The plugin's sendNotification returns void and takes no click callback,
+    // so there is nowhere for `onClick` to be attached. If a future plugin
+    // version gains one, THIS assertion is the thing that should be updated —
+    // deliberately, rather than the gap being discovered by a user clicking a
+    // notification and nothing happening.
+    expect(onClick).not.toHaveBeenCalled()
+    expect(api.sendNotification.mock.calls[0]![0]).not.toHaveProperty('onClick')
+  })
+})

--- a/packages/dashboard/src/utils/native-notifications.ts
+++ b/packages/dashboard/src/utils/native-notifications.ts
@@ -221,6 +221,28 @@ export interface NativeNotificationOptions {
   body?: string
   /** Collapse key — replaces an earlier notification with the same tag. */
   tag?: string
+  /**
+   * Invoked when the user clicks the notification, **after** the backend has
+   * done whatever raising the window means for it. Use it for what happens
+   * *inside* the app (select a session, open a view) — never for the window
+   * itself, which differs per backend and is handled below.
+   *
+   * ## Web backend only — and that is a real gap, not an oversight
+   *
+   * `Notification.onclick` is standard and reliable in a browser, so the web
+   * dashboard gets click-to-focus. **The Tauri backend silently ignores this
+   * callback.** `window.__TAURI__.notification.sendNotification()` returns
+   * `void` and exposes no click handler on desktop; the plugin's `onAction`
+   * surface is built around `registerActionTypes`, which is an Android/iOS
+   * concept. Wiring desktop click-to-focus properly means a Rust-side
+   * notification that can call `window::show_window` — a separate,
+   * platform-specific change (tracked as a follow-on to #7347).
+   *
+   * This is deliberately NOT papered over with a fallback: silently doing
+   * nothing where the caller asked for a click action is the honest state, and
+   * `native-notifications.test.ts` pins it so nobody later assumes it works.
+   */
+  onClick?: () => void
 }
 
 /**
@@ -238,6 +260,7 @@ export function sendNativeNotification(title: string, options: NativeNotificatio
   if (tauriApi) {
     try {
       // The plugin has no `tag` equivalent; collapsing is the OS's business.
+      // `options.onClick` is dropped here — see its doc comment.
       tauriApi.sendNotification({ title, body: options.body })
       return true
     } catch {
@@ -248,7 +271,31 @@ export function sendNativeNotification(title: string, options: NativeNotificatio
   const webApi = getWebNotificationApi()
   if (!webApi) return false
   try {
-    new webApi(title, { body: options.body, tag: options.tag })
+    const notification = new webApi(title, { body: options.body, tag: options.tag })
+    const onClick = options.onClick
+    if (onClick) {
+      notification.onclick = () => {
+        // Raising the window is the backend's job, not the caller's: a click
+        // on a notification means "take me there", and what "there" is
+        // depends on which backend sent it. Best-effort — popup blockers and
+        // some window-management policies reject `focus()`, and the in-app
+        // navigation below is still worth doing when they do.
+        try {
+          window.focus()
+        } catch {
+          // Not focusable — fall through and navigate anyway.
+        }
+        // Chrome leaves a clicked notification on screen until it is closed
+        // explicitly; without this the tray keeps a stale "awaiting you" card
+        // for a session the user has already come back to.
+        try {
+          notification.close()
+        } catch {
+          // Already dismissed.
+        }
+        onClick()
+      }
+    }
     return true
   } catch {
     return false


### PR DESCRIPTION
Closes #7347

## The gap

The dashboard had exactly **one** native-notification trigger — `usePermissionNotification`, for permission requests. A completed turn had none.

That is backwards, and #7347 says why: a pending permission leaves the session *visibly* blocked (the pending badge, the Allow/Deny card), while a finished turn awaiting a decision is indistinguishable in-app from a session nobody ever asked to do anything (#7340). The silent case is precisely the one that needs an out-of-app signal. A long autonomous run finishing and sitting unnoticed is what filed the issue.

(The trigger only became reachable at all with #7351, which added the `Notification.requestPermission()` call chroxy had never made. Added before that, it would have been just as dead as the permission one.)

## The edge, not the state

`useTurnCompleteNotification` fires on the busy → **not**-busy transition. A session that is merely idle is not awaiting anybody; keying on the state would notify for every session on the list the moment the window blurred.

`busy` is read from the per-session server-authoritative `isIdle` in `sessionStates`, which `session_activity` maintains for **every** session (broadcast on `stream_start` and on `result`) — so a background session's completion is announced too, not just the active tab's. Both nearby signals are wrong here and both are easy to reach for:

| signal | why not |
|---|---|
| `sessions[].isBusy` | only a `session_list` snapshot; not rebroadcast on a turn boundary |
| top-level flat `isIdle` | mirrors the **active** session alone |

A source-level guard in `notificationPermissionWiring.test.ts` pins the correct one.

## Gates

Every one of these was verified by **deleting it and confirming a named test goes red** — see below.

- **Window focus**, the same rule `usePermissionNotification` uses. Notifying while the user is looking is how this becomes noise on every turn, and the way users answer noise is by revoking OS notifications wholesale — which takes the permission notifications with it.
- **A session that stopped ON a permission prompt** — already covered by `usePermissionNotification`. One moment, one card.
- **A per-device mute** (Settings → Dashboard), separate from the intervention ping and from the OS permission, for the same reason as above.
- **A dropped socket** — `handleDisconnected` clears transient state and a reconnect re-seeds `isIdle` from the `session_list` snapshot. Neither is a completed turn, and the turn may still be running on the server.

The gates suppress **dispatch only**. Busy bookkeeping runs on every pass, so a mute toggled or a window focused mid-turn cannot leave stale state that fires a phantom notification later — two tests cover exactly that.

## Click-to-focus — and the half that is not here

Wired on the **web** backend via `Notification.onclick` → `window.focus()` + switch to that session.

**Not wired on Tauri.** The plugin's `sendNotification()` returns `void` and exposes no click callback on desktop; `onAction` is built around `registerActionTypes`, an Android/iOS concept. Doing this properly on desktop means a Rust-side notification that can call `window::show_window` — a separate, platform-specific change, filed as a follow-on.

Deliberately not papered over with a fallback. A test pins the gap (`sends but does NOT invoke onClick on the Tauri backend`) so it is discovered by reading the suite rather than by clicking a notification and getting nothing.

## Also here — both in the same feature area

- **`KEY_NOTIFICATION_PERMISSION_ASKED` was never added to `isGlobalKey`** (#7351). An unscoped `clearPersistedState()` — the server-switch path — deleted it, re-arming the automatic OS-permission prompt for a user who had already dismissed one. That is the exact re-prompt loop the flag exists to stop, just hidden behind an action no unit test performed. Regression test included, and proven red without the fix.
- **`.settings-field-checkbox label` was ~20px tall** against the repo's 44pt floor (#3751 family). The label *is* the control here — clicking the text toggles the checkbox — so it is the box that has to clear 44px, not the native glyph. Fixed on the shared class so every toggle in the section clears it and a fourth inherits a compliant target.

## Testing

`297 files / 5169 tests` green, stable across three consecutive full runs (this package has a known leaked-hook flake class, so repeats were the point). `tsc --noEmit` clean; `vite build` clean.

**13 mutants, each killed by its named test.** Restores were byte copies, never `git checkout --`; the harness asserted the replacement landed (`count == 1` + bytes changed) before trusting a red, and asserted the *specific* named test failed rather than just "something failed".

Behavioural guards (`useTurnCompleteNotification.ts`):

| mutant | killed by |
|---|---|
| drop `if (document.hasFocus()) return` | does not notify while the window is focused |
| drop `if (!enabled) return` | does not notify while muted |
| drop `if (session.awaitingPermission) continue` | does not double-notify a session that stopped on a permission prompt |
| drop the `!connected` reset | does not notify across a reconnect that re-seeds the session as idle |
| edge → state (`observedBusy &&` removed) | does not notify for a session that was never busy |
| drop the stale-session prune | forgets a session that disappears mid-turn |
| capture `onNotificationClick` instead of the ref | uses the latest click handler |

Wiring guards (`App.tsx`, CSS, `SettingsPanel.tsx`):

| mutant | killed by |
|---|---|
| delete the hook call from App | imports and mounts useTurnCompleteNotification |
| hardcode `connected: true` | feeds it the live connection state |
| read `sessions[].isBusy` instead of `isIdle` | derives busy from the per-session isIdle flag |
| drop the `awaitingPermission` input | suppresses the alert for a session that stopped on a permission prompt |
| drop the 44px floor | gives .settings-field-checkbox label a 44px minimum |
| drop the checkbox class from the toggle row | renders the turn-complete toggle inside a .settings-field-checkbox row |

Plus the persistence regression: removing the two `isGlobalKey` lines turns both survive-a-server-switch tests red, and each carries a positive control asserting genuinely-scoped state *was* cleared, so neither can pass by `clearPersistedState()` quietly doing nothing.

Every negative assertion in the hook suite is paired with a positive control that fires under the same harness one field apart. Nothing here is async — the effect body runs synchronously inside `render`/`rerender`, so there is no `waitFor` that could pass before the guarded thing had a chance to happen.

## Not verified

The **Tauri plugin path is still unverified against a running desktop build** — inherited from #7351, unchanged by this PR. It is tested against a mocked `window.__TAURI__.notification`. If the global is not injected, the code falls back to the Web API and reports `unsupported` in Settings, so it surfaces rather than hides. Worth a dogfood check.