### PR TITLE
fix(server): give claude-cli the live permission-mode sidecar, so Auto stops prompting

### DIFF
--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -79,11 +79,14 @@ Both Docker providers forward only explicitly allowlisted env vars into the cont
 | `CHROXY_PORT` | yes | — | Permission hook HTTP port on host |
 | `CHROXY_HOOK_SECRET` | yes | — | Permission hook auth secret |
 | `CHROXY_PERMISSION_MODE` | yes | — | Permission handling mode |
+| `CHROXY_PERMISSION_MODE_FILE` | **no** (host only) | — | Path to the live permission-mode sidecar. Deliberately NOT forwarded — see below |
 | `CHROXY_HOST` | injected | — | Permission hook hostname (set to `host.docker.internal`) |
 | `HOME` | forwarded from host | hardcoded in container | User home directory |
 | `PATH` | forwarded from host | hardcoded in container | Executable search path |
 
 **Why they differ:** `DockerSession` extends `CliSession`, which runs `claude -p` as a subprocess and uses an external HTTP permission hook to route permission requests back to the host server. This requires `CHROXY_PORT`, `CHROXY_HOOK_SECRET`, and `CHROXY_PERMISSION_MODE` inside the container, plus `CLAUDE_HEADLESS` for stream-json mode. `DockerSdkSession` extends `SdkSession`, which manages the conversation loop and permissions in-process via the Agent SDK — no external hook calls are needed, so those vars are omitted. `HOME` and `PATH` are forwarded from the host env in `DockerSession` but hardcoded by the SDK spawn callback in `DockerSdkSession` (`/home/<user>` and a standard POSIX path). `CHROXY_HOST` is not in the `FORWARDED_ENV_KEYS` array — it is dynamically injected by `DockerSession._spawnPersistentProcess()` when `CHROXY_PORT` is present, set to `host.docker.internal` so the container can reach the host's permission hook endpoint.
+
+**Why `CHROXY_PERMISSION_MODE_FILE` stops at the host (#7337):** on the host, `CliSession` writes the session's current permission mode to a small sidecar file and names it in the child env, because `permission-hook.sh` prefers that file and re-reads it on *every* tool call — so a mid-session mode change reaches even the subprocess that is already running. `CHROXY_PERMISSION_MODE` alone is frozen at spawn and can only be refreshed by a kill-and-respawn, during which the still-live old child keeps resolving the stale mode. The sidecar path is a host tmp path, and `docker exec` cannot add a mount (mounts are fixed at `docker run`), so forwarding the key would name a path that does not exist inside the container. A containerized CLI session therefore still depends on the respawn to pick up a mode change; giving it the live channel needs a bind mount established in `_startContainer()`.
 
 ## App Screens
 

--- a/docs/guides/container-isolation.md
+++ b/docs/guides/container-isolation.md
@@ -150,6 +150,8 @@ Containers receive only an explicit allowlist of environment variables. The full
 **DockerSession** forwards:
 `ANTHROPIC_API_KEY`, `CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING`, `CHROXY_PORT`, `CHROXY_HOOK_SECRET`, `CHROXY_PERMISSION_MODE`, `CLAUDE_HEADLESS`, `HOME`, `PATH`, and conditionally `CHROXY_HOST` (set to `host.docker.internal` when the permission hook port is configured)
 
+It does **not** forward `CHROXY_PERMISSION_MODE_FILE`, which the host-side `CliSession` sets so `permission-hook.sh` can re-read the live permission mode on every tool call (#7337). That path lives in the host's tmpdir and `docker exec` cannot add a mount, so the key would name a path that does not exist in the container. A containerized CLI session consequently still picks up a permission-mode change only on the respawn — see `docs/architecture/reference.md` for the full rationale.
+
 **DockerSdkSession** forwards:
 `ANTHROPIC_API_KEY`, `NODE_ENV`, plus hardcoded overrides: `HOME=/home/<containerUser>` and a fixed `PATH` for the container environment (these are not forwarded from the host)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -102,7 +102,7 @@ If `claude` is reported "Not found", ensure it's in one of the paths listed abov
 |---------|--------------|--------------|--------------|
 | In-process permissions (`canUseTool`) | Yes | No (HTTP hook) | No (HTTP hook) |
 | Live `setModel` | Yes | Yes (restart) | — |
-| Live `setPermissionMode` | Yes | Yes (restart) | Yes (sidecar file, no restart) |
+| Live `setPermissionMode` | Yes | Yes (sidecar file, no restart) | Yes (sidecar file, no restart) |
 | Plan mode | No | **Yes** | No |
 | Resume (`resumeSessionId`) | Yes | Yes (`--resume` on respawn/restore) | Yes (`--resume` on restore) |
 | Thinking level control | Yes | No | No |
@@ -823,7 +823,7 @@ Rows marked **(capability)** come directly from each session class's `static get
 | **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | Yes (HTTP hook) | Yes (channel relay) | — | — | Yes (in-process) | Yes (in-process) | Yes (in-process) |
 | **(capability)** In-process permissions | Yes | — | — | — | — | — | Yes | Yes | Yes |
 | **(capability)** Live model switch | Yes | Yes | — | — | Yes | Yes | Yes | Yes | Yes |
-| **(capability)** Live permission-mode switch | Yes | Yes | Yes (sidecar file) | — | — | — | Yes | Yes | Yes |
+| **(capability)** Live permission-mode switch | Yes | Yes (sidecar file) | Yes (sidecar file) | — | — | — | Yes | Yes | Yes |
 | **(capability)** Plan mode | — | **Yes** | — | — | — | — | — | — | — |
 | **(capability)** Resume (`resumeSessionId`) | Yes | Yes | Yes | — | — | — | — | — | — |
 | **(capability)** Terminal (raw PTY) | — | — | — | — | — | — | — | — | — |
@@ -901,7 +901,8 @@ For capability rows, "—" means the provider's `capabilities` object reports `f
 - **No live model switch, no permission-mode switch, no plan mode, no resume,
   no thinking-level control** — the channel surface does not expose these
   (same gaps as `claude-tui`, except `claude-tui` fakes permission-mode via a
-  sidecar file and resumes across restarts via `--resume`). The channel's wins
+  sidecar file — as `claude-cli` also does since #7337 — and resumes across
+  restarts via `--resume`). The channel's wins
   over `claude-tui` are live streaming and a
   documented first-party permission relay.
 - **Not available on Bedrock / Vertex / Foundry**, and Team/Enterprise orgs

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -51,12 +51,13 @@ case "$HOOK_HOST" in
 esac
 # Permission mode resolution order:
 #   1. CHROXY_PERMISSION_MODE_FILE — if set AND readable AND non-empty.
-#      ClaudeTuiSession writes this sidecar file when setPermissionMode()
-#      is called mid-session, since env vars on a running PTY can't be
-#      mutated from outside (#4013).
-#   2. CHROXY_PERMISSION_MODE env var — the value at session-spawn time.
-#      Used by CliSession (which restarts on mode change) and as the
-#      initial value for TUI sessions.
+#      BOTH hook-routed providers write this sidecar when setPermissionMode()
+#      is called mid-session, since a running subprocess's env can't be mutated
+#      from outside: ClaudeTuiSession since #4013, CliSession since #7337.
+#   2. CHROXY_PERMISSION_MODE env var — the value at session-spawn time, and
+#      the fallback whenever the sidecar is missing or unreadable. Also the
+#      initial value for both providers, and the ONLY channel inside a
+#      container (DockerSession cannot mount the host's sidecar path).
 #   3. "approve" — default if nothing else is set.
 PERM_MODE=""
 if [ -n "$CHROXY_PERMISSION_MODE_FILE" ] && [ -r "$CHROXY_PERMISSION_MODE_FILE" ]; then

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,5 @@
 import { randomBytes, randomUUID } from 'crypto'
-import { mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
+import { mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'fs'
 // #6132 (HOL fix from #5337): the per-turn hook-drain hot path uses async fs so a
 // slow/stuck sink (FUSE/NFS, full disk, tmpwatch race) can't block the shared
 // event loop — which would freeze EVERY claude-tui session (the default provider).
@@ -22,6 +22,8 @@ import { discoverConfiguredMcpServers } from './byok-mcp-config.js'
 import { ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
+import { writePermissionModeSidecarAtomic } from './utils/permission-mode-sidecar.js'
+import { sweepStaleOwnedDirs } from './utils/stale-session-dirs.js'
 import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { createLogger, loggerForSession, redactSensitive, redactSensitivePreservingEscapes } from './logger.js'
@@ -1172,53 +1174,14 @@ export class ClaudeTuiSession extends BaseSession {
    * @returns {{swept:number, kept:number}}
    */
   static sweepStaleSinkDirs(logger = log) {
-    const base = join(tmpdir(), 'chroxy-claude-tui')
-    let entries
-    try { entries = readdirSync(base) } catch { return { swept: 0, kept: 0 } }
-    let swept = 0
-    let kept = 0
-    for (const name of entries) {
-      if (!name.startsWith('s-')) continue
-      const dir = join(base, name)
-      let ownerPid = null
-      try {
-        const n = parseInt(readFileSync(join(dir, 'owner.pid'), 'utf8').trim(), 10)
-        if (Number.isInteger(n) && n > 0) ownerPid = n
-      } catch { /* no/garbage pidfile → orphaned, subject to the grace below */ }
-      if (ownerPid !== null) {
-        let alive
-        try {
-          process.kill(ownerPid, 0) // signal 0 = existence probe
-          alive = true
-        } catch (err) {
-          // ESRCH → dead; EPERM → exists but not ours → still alive, keep it.
-          alive = err && err.code === 'EPERM'
-        }
-        if (alive) { kept++; continue }
-      } else {
-        // #5359 review — a pidfile-less dir might be another process's sink dir
-        // caught BETWEEN its mkdir and its owner.pid write (a cross-process race;
-        // within one process those are synchronous). Give brand-new pidfile-less
-        // dirs a grace window before reaping so we can't delete one mid-creation;
-        // a genuinely orphaned dir is older than the grace and still gets swept.
-        try {
-          // #5332: wall-clock deliberately — compared against the filesystem
-          // mtime (also wall-clock). A monotonic clock would be meaningless here.
-          if (Date.now() - statSync(dir).mtimeMs < ClaudeTuiSession.SINK_SWEEP_GRACE_MS) {
-            kept++
-            continue
-          }
-        } catch { /* stat failed (dir vanished) → fall through to rmSync (no-op) */ }
-      }
-      try {
-        rmSync(dir, { recursive: true, force: true })
-        swept++
-      } catch (err) {
-        logger?.warn?.(`sink-dir sweep: failed to remove ${dir}: ${err.message}`)
-      }
-    }
-    if (swept > 0) logger?.info?.(`Swept ${swept} stale claude-tui sink dir(s) from ${base} (kept ${kept} live)`)
-    return { swept, kept }
+    // #7337: the reaper itself lives in utils/stale-session-dirs.js — CliSession
+    // now has a per-session dir of its own to sweep, and two hand-written copies
+    // of a "delete directories under /tmp" loop is not a drift this repo accepts.
+    return sweepStaleOwnedDirs(join(tmpdir(), 'chroxy-claude-tui'), {
+      graceMs: ClaudeTuiSession.SINK_SWEEP_GRACE_MS,
+      logger,
+      label: 'claude-tui sink',
+    })
   }
 
   // Upper bounds on how long we'll wait for status=idle before falling
@@ -3909,22 +3872,14 @@ export class ClaudeTuiSession extends BaseSession {
    */
   // #5374: BaseSession.setPermissionMode owns the validation + guard and fires
   // this hook after `this.permissionMode` is set, only when the mode changed.
-  // #5334 (IP-6): atomically write the permission-mode sidecar — write a tmp
-  // file then rename(2) over the target. Direct writeFileSync truncates-then-
-  // writes, so a concurrent PreToolUse hook `cat` could observe an empty/partial
-  // value mid-write and fall through to the stale env var. rename(2) is atomic
-  // within the same filesystem, so readers see either the OLD complete value or
-  // the NEW complete value — never an empty/partial one. Throws on failure
-  // (after best-effort tmp cleanup) so each caller applies its own fallback.
+  // #5334 (IP-6): the write is atomic (tmp file + rename(2)) so a concurrent
+  // PreToolUse hook `cat` can never read a truncated value and fall through to
+  // the stale env var. #7337 moved the implementation to utils/ — CliSession
+  // now needs the same channel, and a second hand-written copy of it is the
+  // drift class docs/false-safety-guards.md catalogues. Kept as a thin method
+  // so subclasses and tests can still stub the write.
   _writePermissionModeSidecarAtomic(path, value) {
-    const tmpPath = `${path}.tmp-${randomUUID()}`
-    try {
-      writeFileSync(tmpPath, value)
-      renameSync(tmpPath, path)
-    } catch (err) {
-      try { rmSync(tmpPath, { force: true }) } catch { /* ignore */ }
-      throw err
-    }
+    writePermissionModeSidecarAtomic(path, value)
   }
 
   _onPermissionModeChanged(mode) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -23,7 +23,7 @@ import { ALLOWED_MODEL_IDS } from './models.js'
 import { CLAUDE_FALLBACK_MODELS, claudeModelMetadata } from './claude-model-catalog.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
 import { writePermissionModeSidecarAtomic } from './utils/permission-mode-sidecar.js'
-import { sweepStaleOwnedDirs } from './utils/stale-session-dirs.js'
+import { sweepStaleOwnedDirs, OWNER_PID_FILE } from './utils/stale-session-dirs.js'
 import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { CHROXY_SECRET_DENYLIST } from './utils/spawn-env.js'
 import { createLogger, loggerForSession, redactSensitive, redactSensitivePreservingEscapes } from './logger.js'
@@ -869,7 +869,7 @@ export class ClaudeTuiSession extends BaseSession {
       // so mkdir can create a real directory.
       try { rmSync(this._sinkDir, { recursive: true, force: true }) } catch { /* best effort */ }
       mkdirSync(this._sinkDir, { recursive: true })
-      try { writeFileSync(join(this._sinkDir, 'owner.pid'), String(process.pid)) } catch { /* best effort */ }
+      try { writeFileSync(join(this._sinkDir, OWNER_PID_FILE), String(process.pid)) } catch { /* best effort */ }
       if (this._permissionModeFile) {
         try { this._writePermissionModeSidecarAtomic(this._permissionModeFile, this.permissionMode || 'approve') } catch { /* hook falls back to env var */ }
       }
@@ -1268,7 +1268,7 @@ export class ClaudeTuiSession extends BaseSession {
     // (sweepStaleSinkDirs) can tell a live daemon's sink dir from one orphaned
     // by a prior crash. Best-effort: a missing pidfile just makes the dir
     // sweep-eligible, which is the safe default for an orphan.
-    try { writeFileSync(join(this._sinkDir, 'owner.pid'), String(process.pid)) } catch { /* best effort */ }
+    try { writeFileSync(join(this._sinkDir, OWNER_PID_FILE), String(process.pid)) } catch { /* best effort */ }
 
     // Generate the upstream session uuid here so the JSONL path is
     // predictable + so claude resumes the same conversation across turns.

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -21,7 +21,7 @@ import { prepareSpawn } from './utils/win-spawn.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
 import { writePermissionModeSidecarAtomic } from './utils/permission-mode-sidecar.js'
-import { sweepStaleOwnedDirs, OWNER_PID_FILE } from './utils/stale-session-dirs.js'
+import { sweepStaleOwnedDirs, ensureOwnedBaseDir, OWNER_PID_FILE } from './utils/stale-session-dirs.js'
 import { createLogger, loggerForSession } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { BILLING_CLASSES, isProgrammaticCreditEra } from './billing-class.js'
@@ -525,7 +525,15 @@ export class CliSession extends BaseSession {
       // so a mid-session mode change reaches even the child already running.
       // CHROXY_PERMISSION_MODE above stays as the fallback for a hook that
       // cannot read the file (deleted /tmp entry, container without the mount).
-      ...(this._permissionModeFile ? { CHROXY_PERMISSION_MODE_FILE: this._permissionModeFile } : {}),
+      //
+      // ALWAYS set, never omitted. buildSpawnEnv('claude') is DENYLIST mode, so
+      // the whole parent env passes through — and this daemon may itself have
+      // been launched from inside another chroxy session, whose sidecar path is
+      // then sitting in our env. Omitting the key would let that FOREIGN file
+      // decide this session's permissions, since the hook prefers it over our
+      // own CHROXY_PERMISSION_MODE. Empty string fails the hook's `[ -n ]` guard
+      // and falls through to the env var, which is the documented intent.
+      CHROXY_PERMISSION_MODE_FILE: this._permissionModeFile || '',
       ...(this._port ? { CHROXY_PORT: String(this._port) } : {}),
       // Pass a short-lived per-session secret instead of the primary API token.
       // This limits the blast radius if a tool reads process.env — the hook secret
@@ -1625,24 +1633,53 @@ export class CliSession extends BaseSession {
    * makes at #4013).
    */
   _ensurePermissionModeSidecar() {
-    if (this._permissionModeFile) return
     if (!this._port) return
+    const mode = this.permissionMode || 'approve'
+
+    // Re-seed on EVERY start(), not only the first. The path is kept stable
+    // across a respawn (a still-draining old child holds it in its env), but
+    // the CONTENTS must be re-asserted, because the file outranks the env var
+    // in the hook's resolution order. Without this, a mid-session write that
+    // failed (ENOSPC / EROFS / EIO) left the sidecar holding the OLD mode while
+    // the respawned child carried the NEW one in CHROXY_PERMISSION_MODE — and
+    // the hook read the file. A tighten to `approve` would then keep
+    // auto-allowing for the rest of the session while the daemon, the state
+    // file and the UI all said `approve`. The respawn was documented as the
+    // repair and was not one.
+    if (this._permissionModeFile) {
+      try {
+        writePermissionModeSidecarAtomic(this._permissionModeFile, mode)
+        return
+      } catch (err) {
+        // The existing file is now untrustworthy — and a stale file is WORSE
+        // than none, because it outranks the correct env var. Drop it so the
+        // hook falls back to CHROXY_PERMISSION_MODE, then try a fresh dir below.
+        ;(this._log || log).warn(`permission-mode sidecar re-seed failed (${err.message}) — dropping the stale sidecar so the hook falls back to the env var`)
+        this._cleanupPermissionModeSidecar()
+      }
+    }
+
+    let dir = null
     try {
-      const base = CliSession.PERMISSION_MODE_SIDECAR_BASE
-      mkdirSync(base, { recursive: true })
-      const dir = join(base, `s-${randomUUID()}`)
-      mkdirSync(dir, { recursive: true })
-      // Stamp the owning pid so the boot-time sweep below can tell a live
-      // daemon's dir from one orphaned by a crash. Best-effort: a missing
-      // pidfile just makes the dir sweep-eligible after a grace window, which
-      // is the safe default for an orphan.
+      const base = ensureOwnedBaseDir(CliSession.PERMISSION_MODE_SIDECAR_BASE)
+      dir = join(base, `s-${randomUUID()}`)
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+      // Stamp the owning pid so the boot-time sweep can tell a live daemon's
+      // dir from one orphaned by a crash. Best-effort: a missing pidfile just
+      // makes the dir sweep-eligible after a grace window, which is the safe
+      // default for an orphan.
       try { writeFileSync(join(dir, OWNER_PID_FILE), String(process.pid)) } catch { /* best effort */ }
       const path = join(dir, 'permission-mode')
-      writePermissionModeSidecarAtomic(path, this.permissionMode || 'approve')
+      writePermissionModeSidecarAtomic(path, mode)
       this._permissionModeDir = dir
       this._permissionModeFile = path
     } catch (err) {
-      ;(this._log || log).warn(`initial permission-mode sidecar write failed (${err.message}) — falling back to env-var-only mode; a mid-session permission switch will not reach the running process until it respawns`)
+      // Remove the dir we just created, if we got that far — otherwise a
+      // persistent write failure leaks one dir per respawn, and because
+      // owner.pid names this LIVE daemon the boot sweep keeps every one of
+      // them for the daemon's whole lifetime.
+      if (dir) { try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ } }
+      ;(this._log || log).warn(`permission-mode sidecar unavailable (${err.message}) — falling back to env-var-only mode; a mid-session permission switch will not reach the running process until it respawns`)
       this._permissionModeFile = null
       this._permissionModeDir = null
     }
@@ -1671,11 +1708,14 @@ export class CliSession extends BaseSession {
       try {
         writePermissionModeSidecarAtomic(this._permissionModeFile, mode)
       } catch (err) {
-        // Hook precedence is file -> env var, and the file still holds the
-        // PREVIOUS mode, so the next tool call reads that rather than the env
-        // var. Say so plainly instead of implying an env-var fallback. The
-        // respawn below is still the eventual repair.
-        ;(this._log || log).warn(`failed to write permission-mode sidecar (${err.message}) — tool calls will use the previously written mode until the respawn completes`)
+        // Hook precedence is file -> env var, so a sidecar left holding the
+        // PREVIOUS mode outranks the correct value in CHROXY_PERMISSION_MODE —
+        // and on a TIGHTEN that is fail-open. Remove it rather than leave it:
+        // the hook then falls back to the env var, and start()'s re-seed
+        // rebuilds a fresh sidecar on the respawn below. Leaving it in place
+        // pinned the old mode for the whole session.
+        ;(this._log || log).warn(`failed to write permission-mode sidecar (${err.message}) — removing it so the hook falls back to the spawn env var until the respawn re-seeds`)
+        this._cleanupPermissionModeSidecar()
       }
     }
 
@@ -1934,11 +1974,6 @@ export class CliSession extends BaseSession {
       this._hookManager.destroy()
     }
 
-    // #7337: remove the sidecar dir so long-lived daemons don't leak one
-    // directory per session under /tmp. Nulls `_permissionModeFile` too, so a
-    // setPermissionMode() after destroy() no-ops cleanly.
-    this._cleanupPermissionModeSidecar()
-
     if (this._respawnTimer) {
       clearTimeout(this._respawnTimer)
       this._respawnTimer = null
@@ -1984,6 +2019,18 @@ export class CliSession extends BaseSession {
       child.on('close', () => clearTimeout(forceKillTimer))
       this._child = null
     }
+
+    // #7337: remove the sidecar dir so long-lived daemons don't leak one
+    // directory per session under /tmp. Nulls `_permissionModeFile` too, so a
+    // setPermissionMode() after destroy() no-ops cleanly.
+    //
+    // Deliberately AFTER the kill above, not before it. The child stays alive
+    // for up to the 3s force-kill grace and can fire a PreToolUse hook in that
+    // window; removing the sidecar first makes that hook fall back to the
+    // spawn-frozen CHROXY_PERMISSION_MODE, which is fail-open on a session that
+    // was tightened since spawn (spawned `auto`, switched to `approve`, then
+    // destroyed).
+    this._cleanupPermissionModeSidecar()
 
     // Emit completions for any tracked agents and clear busy state.
     // Must happen before removeAllListeners() so events are delivered.

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1,8 +1,9 @@
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
-import { randomBytes } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
 import { normalizeSdkModelUsage } from './usage-normalize.js'
-import { homedir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { join } from 'path'
 import { createPermissionHookManager } from './permission-hook.js'
 import { guardChildStreams } from './child-stream-guard.js'
@@ -19,6 +20,8 @@ import { labelBinarySpawnFailure } from './utils/verify-binary.js'
 import { prepareSpawn } from './utils/win-spawn.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
+import { writePermissionModeSidecarAtomic } from './utils/permission-mode-sidecar.js'
+import { sweepStaleOwnedDirs, OWNER_PID_FILE } from './utils/stale-session-dirs.js'
 import { createLogger, loggerForSession } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { BILLING_CLASSES, isProgrammaticCreditEra } from './billing-class.js'
@@ -433,6 +436,14 @@ export class CliSession extends BaseSession {
     // Hook manager (shared module)
     this._hookManager = (this._port) ? createPermissionHookManager(this, { settingsPath }) : null
 
+    // #7337: the re-readable permission-mode sidecar. `permission-hook.sh`
+    // prefers this file over CHROXY_PERMISSION_MODE, which is frozen at spawn.
+    // Created on the first start() when permissions are enabled, reused across
+    // respawns, removed on destroy(). Null means "env-var-only" — either
+    // permissions are off (no port) or the initial write failed.
+    this._permissionModeFile = null
+    this._permissionModeDir = null
+
     // Pending-permission bookkeeping for the inactivity timer (#2831).
     // WsServer calls notifyPermissionPending/Resolved when a hook
     // permission belonging to this session is broadcast/resolved.
@@ -470,6 +481,10 @@ export class CliSession extends BaseSession {
       this._hookManager.register()
     }
 
+    // #7337: must run BEFORE _spawnPersistentProcess, which is where
+    // _buildChildEnv() reads `_permissionModeFile` to point the child at it.
+    this._ensurePermissionModeSidecar()
+
     // Skills MVP (#2957) — append shared skills to the Claude CLI system prompt.
     const skillsText = this._buildSystemPrompt()
 
@@ -506,6 +521,11 @@ export class CliSession extends BaseSession {
       CLAUDE_HEADLESS: '1',
       CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1',
       CHROXY_PERMISSION_MODE: this.permissionMode,
+      // #7337: the hook prefers this file and re-reads it on EVERY tool call,
+      // so a mid-session mode change reaches even the child already running.
+      // CHROXY_PERMISSION_MODE above stays as the fallback for a hook that
+      // cannot read the file (deleted /tmp entry, container without the mount).
+      ...(this._permissionModeFile ? { CHROXY_PERMISSION_MODE_FILE: this._permissionModeFile } : {}),
       ...(this._port ? { CHROXY_PORT: String(this._port) } : {}),
       // Pass a short-lived per-session secret instead of the primary API token.
       // This limits the blast radius if a tool reads process.env — the hook secret
@@ -1567,12 +1587,107 @@ export class CliSession extends BaseSession {
     this._killAndRespawn()
   }
 
+  /**
+   * Base dir for the per-session permission-mode sidecar dirs (#7337).
+   * Exposed so the boot sweep and its tests name it once.
+   */
+  static get PERMISSION_MODE_SIDECAR_BASE() { return join(tmpdir(), 'chroxy-claude-cli') }
+
+  /**
+   * #7337: boot-time sweep of sidecar dirs orphaned by a crash. destroy()
+   * removes a session's own dir, but a SIGKILL leaks it, so a long-lived host
+   * accumulates one per crashed session. Same ownership rule as the claude-tui
+   * sink sweep and the same implementation — only dirs whose `owner.pid` is
+   * DEAD are removed, so a live daemon's dirs (including this one's) are kept
+   * and the sweep is safe to run unconditionally at boot.
+   *
+   * @param {object} [logger] - logger with info/warn (defaults to module log)
+   * @returns {{swept:number, kept:number}}
+   */
+  static sweepStaleSidecarDirs(logger = log) {
+    return sweepStaleOwnedDirs(CliSession.PERMISSION_MODE_SIDECAR_BASE, {
+      logger,
+      label: 'claude-cli permission-mode sidecar',
+    })
+  }
+
+  /**
+   * #7337: create the re-readable permission-mode sidecar and seed it with the
+   * session's current mode. Idempotent — a respawn calls start() again and must
+   * keep the SAME path, because the sidecar the still-draining old child holds
+   * in its env has to stay valid until that child is gone.
+   *
+   * Only meaningful when permissions are enabled: with no port there is no hook
+   * endpoint, so `permission-hook.sh` never runs and the mode is moot. A failed
+   * initial write leaves `_permissionModeFile` null and the session falls back
+   * to env-var-only mode — losing the ability to hot-swap the mode is bad, but
+   * failing session start over a /tmp write is worse (same trade ClaudeTuiSession
+   * makes at #4013).
+   */
+  _ensurePermissionModeSidecar() {
+    if (this._permissionModeFile) return
+    if (!this._port) return
+    try {
+      const base = CliSession.PERMISSION_MODE_SIDECAR_BASE
+      mkdirSync(base, { recursive: true })
+      const dir = join(base, `s-${randomUUID()}`)
+      mkdirSync(dir, { recursive: true })
+      // Stamp the owning pid so the boot-time sweep below can tell a live
+      // daemon's dir from one orphaned by a crash. Best-effort: a missing
+      // pidfile just makes the dir sweep-eligible after a grace window, which
+      // is the safe default for an orphan.
+      try { writeFileSync(join(dir, OWNER_PID_FILE), String(process.pid)) } catch { /* best effort */ }
+      const path = join(dir, 'permission-mode')
+      writePermissionModeSidecarAtomic(path, this.permissionMode || 'approve')
+      this._permissionModeDir = dir
+      this._permissionModeFile = path
+    } catch (err) {
+      ;(this._log || log).warn(`initial permission-mode sidecar write failed (${err.message}) — falling back to env-var-only mode; a mid-session permission switch will not reach the running process until it respawns`)
+      this._permissionModeFile = null
+      this._permissionModeDir = null
+    }
+  }
+
+  /** Remove the sidecar dir created by _ensurePermissionModeSidecar. */
+  _cleanupPermissionModeSidecar() {
+    if (this._permissionModeDir) {
+      try { rmSync(this._permissionModeDir, { recursive: true, force: true }) }
+      catch (err) { (this._log || log).warn(`permission-mode sidecar cleanup failed: ${err.message}`) }
+    }
+    this._permissionModeDir = null
+    this._permissionModeFile = null
+  }
+
   _onPermissionModeChanged(mode) {
+    // #7337: publish to the sidecar FIRST. `permission-hook.sh` prefers the
+    // file over CHROXY_PERMISSION_MODE and re-reads it on every tool call, so
+    // this takes effect immediately — including for the child that is still
+    // alive right now. Without it the only channel was the respawn below, which
+    // does not land until the old child's `close` fires (up to the 10s
+    // force-kill grace in _killAndRespawn), and every PreToolUse hook that old
+    // child raises in the meantime resolves the STALE mode. That is #7337: a
+    // Bash approval card on a session whose state file already read `"auto"`.
+    if (this._permissionModeFile) {
+      try {
+        writePermissionModeSidecarAtomic(this._permissionModeFile, mode)
+      } catch (err) {
+        // Hook precedence is file -> env var, and the file still holds the
+        // PREVIOUS mode, so the next tool call reads that rather than the env
+        // var. Say so plainly instead of implying an env-var fallback. The
+        // respawn below is still the eventual repair.
+        ;(this._log || log).warn(`failed to write permission-mode sidecar (${err.message}) — tool calls will use the previously written mode until the respawn completes`)
+      }
+    }
+
     // #3729 panic-button semantics: BaseSession.setPermissionMode lets `'auto'`
     // bypass the `_isBusy` guard, so flipping to auto mid-turn IS destructive —
     // the in-flight `claude -p` process is killed and respawned, dropping the
     // current turn. This is by design (parity with SDK auto-resolve of pending
-    // prompts); see #3735 for the regression test pinning this behavior.
+    // prompts); see #3735 for the regression test pinning this behavior. The
+    // respawn is still required for the OTHER mode channel: `--permission-mode
+    // bypassPermissions` / `plan` is argv, not env, so only a new process picks
+    // it up (buildClaudeCliArgs). The sidecar covers the hook; the respawn
+    // covers claude's own flag.
     // #4828: session-scoped if init has fired.
     ;(this._log || log).info(`Permission mode changed to ${mode}, restarting process`)
     this._killAndRespawn()
@@ -1818,6 +1933,11 @@ export class CliSession extends BaseSession {
     if (this._hookManager) {
       this._hookManager.destroy()
     }
+
+    // #7337: remove the sidecar dir so long-lived daemons don't leak one
+    // directory per session under /tmp. Nulls `_permissionModeFile` too, so a
+    // setPermissionMode() after destroy() no-ops cleanly.
+    this._cleanupPermissionModeSidecar()
 
     if (this._respawnTimer) {
       clearTimeout(this._respawnTimer)

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -92,8 +92,10 @@ const FORWARDED_ENV_KEYS = [
 // The consequence is that a containerized CLI session still needs the respawn
 // to pick up a mode change, exactly as before #7337. Giving it the live channel
 // needs a bind mount established in `_startContainer()`; tracked separately.
-// docker-session.test.js pins the omission (with a CHROXY_PERMISSION_MODE
-// positive control) so it cannot be "fixed" by adding the key alone.
+// tests/cli-permission-mode-sidecar.test.js pins the omission (with a
+// CHROXY_PERMISSION_MODE positive control) so it cannot be "fixed" by adding
+// the key alone. NOT docker-session.test.js — that file drives a hand-written
+// mirror of _spawnPersistentProcess and never reads the real array.
 
 /**
  * DockerSession runs Claude Code inside an isolated Docker container.

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -75,6 +75,26 @@ const FORWARDED_ENV_KEYS = [
   'PATH',
 ]
 
+// #7337: `CHROXY_PERMISSION_MODE_FILE` is DELIBERATELY absent from the list
+// above, and must stay absent until the sidecar is actually reachable from
+// inside the container.
+//
+// CliSession creates the sidecar under the HOST's tmpdir and publishes its
+// path in the child env, so `permission-hook.sh` can re-read the live
+// permission mode on every tool call instead of the spawn-frozen
+// CHROXY_PERMISSION_MODE. A container has its own filesystem and `docker exec`
+// cannot add a mount (mounts are fixed at `docker run`), so forwarding the key
+// would name a host path that does not exist in the container. The hook's
+// `[ -r ... ]` guard makes that fall back to CHROXY_PERMISSION_MODE — correct,
+// but only by accident, and it would read as "containers have the live channel"
+// when they do not.
+//
+// The consequence is that a containerized CLI session still needs the respawn
+// to pick up a mode change, exactly as before #7337. Giving it the live channel
+// needs a bind mount established in `_startContainer()`; tracked separately.
+// docker-session.test.js pins the omission (with a CHROXY_PERMISSION_MODE
+// positive control) so it cannot be "fixed" by adding the key alone.
+
 /**
  * DockerSession runs Claude Code inside an isolated Docker container.
  *

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1437,6 +1437,13 @@ export async function startCliServer(config) {
     .then(({ ClaudeTuiSession }) => ClaudeTuiSession.sweepStaleSinkDirs(log))
     .catch((err) => log.warn(`claude-tui sink-dir sweep failed: ${(err && err.message) || err}`))
 
+  // #7337 — same sweep for claude-cli's per-session permission-mode sidecar
+  // dirs, which leak on a crash for exactly the same reason. Same ownership
+  // rule (only DEAD owners are reaped), same fire-and-forget lazy import.
+  import('./cli-session.js')
+    .then(({ CliSession }) => CliSession.sweepStaleSidecarDirs(log))
+    .catch((err) => log.warn(`claude-cli sidecar-dir sweep failed: ${(err && err.message) || err}`))
+
   console.log('\nPress Ctrl+C to stop.\n')
 
   // Graceful shutdown.

--- a/packages/server/src/utils/permission-mode-sidecar.js
+++ b/packages/server/src/utils/permission-mode-sidecar.js
@@ -1,0 +1,49 @@
+import { writeFileSync, renameSync, rmSync } from 'fs'
+import { randomUUID } from 'crypto'
+
+/**
+ * The permission-mode sidecar: the IPC channel between a live chroxy session
+ * and the `permission-hook.sh` processes its provider subprocess spawns.
+ *
+ * `permission-hook.sh` resolves the mode as
+ *   1. CHROXY_PERMISSION_MODE_FILE — re-read on EVERY tool call
+ *   2. CHROXY_PERMISSION_MODE      — frozen at subprocess spawn
+ *   3. "approve"
+ *
+ * (1) exists because a running subprocess's environment cannot be mutated
+ * from outside. Introduced for the TUI in #4013; extended to `claude-cli`
+ * in #7337, whose only refresh channel had been a destructive kill+respawn
+ * that leaves the OLD child — still firing hooks — reading the stale mode.
+ *
+ * This module is the single implementation. Two hand-written copies of the
+ * same atomic-write dance is the drift class `docs/false-safety-guards.md`
+ * catalogues; both session classes call in here instead.
+ */
+
+/**
+ * Write `value` to `path` atomically: write a tmp file, then rename(2) over
+ * the target.
+ *
+ * A direct `writeFileSync` truncates-then-writes, so a concurrent PreToolUse
+ * hook `cat` can observe an empty or partial value mid-write and silently
+ * fall through to the stale env var (#5334). rename(2) is atomic within a
+ * filesystem, so a reader sees either the OLD complete value or the NEW
+ * complete value — never a torn one.
+ *
+ * Throws on failure (after a best-effort tmp cleanup) so each caller applies
+ * its own fallback rather than inheriting one.
+ *
+ * @param {string} path  Sidecar path. The tmp file is created alongside it,
+ *   so the directory must exist and be on the same filesystem.
+ * @param {string} value The permission mode to publish.
+ */
+export function writePermissionModeSidecarAtomic(path, value) {
+  const tmpPath = `${path}.tmp-${randomUUID()}`
+  try {
+    writeFileSync(tmpPath, value)
+    renameSync(tmpPath, path)
+  } catch (err) {
+    try { rmSync(tmpPath, { force: true }) } catch { /* ignore */ }
+    throw err
+  }
+}

--- a/packages/server/src/utils/permission-mode-sidecar.js
+++ b/packages/server/src/utils/permission-mode-sidecar.js
@@ -1,5 +1,5 @@
-import { writeFileSync, renameSync, rmSync } from 'fs'
 import { randomUUID } from 'crypto'
+import { writeFileRestricted } from '../platform.js'
 
 /**
  * The permission-mode sidecar: the IPC channel between a live chroxy session
@@ -15,35 +15,37 @@ import { randomUUID } from 'crypto'
  * in #7337, whose only refresh channel had been a destructive kill+respawn
  * that leaves the OLD child — still firing hooks — reading the stale mode.
  *
- * This module is the single implementation. Two hand-written copies of the
- * same atomic-write dance is the drift class `docs/false-safety-guards.md`
- * catalogues; both session classes call in here instead.
+ * This module is the single seam both session classes call. It is a thin
+ * wrapper, not a third implementation: the atomic write itself belongs to
+ * `platform.writeFileRestricted`, which #4874 established as the ONE
+ * tmp+rename(2) helper after collapsing the hand-rolled copies in
+ * environment-manager.js and models.js onto it.
  */
 
 /**
- * Write `value` to `path` atomically: write a tmp file, then rename(2) over
- * the target.
+ * Publish `value` to the sidecar at `path`, atomically and owner-only.
  *
- * A direct `writeFileSync` truncates-then-writes, so a concurrent PreToolUse
- * hook `cat` can observe an empty or partial value mid-write and silently
- * fall through to the stale env var (#5334). rename(2) is atomic within a
- * filesystem, so a reader sees either the OLD complete value or the NEW
- * complete value — never a torn one.
+ * Atomic because a direct `writeFileSync` truncates-then-writes, so a
+ * concurrent PreToolUse hook `cat` can observe an empty or partial value and
+ * silently fall through to the stale env var (#5334). rename(2) is atomic
+ * within a filesystem, so a reader sees either the OLD complete value or the
+ * NEW complete value — never a torn one.
  *
- * Throws on failure (after a best-effort tmp cleanup) so each caller applies
- * its own fallback rather than inheriting one.
+ * Owner-only (0600 POSIX / owner DACL on Windows) because this file's contents
+ * decide whether a tool call is prompted. `writeFileRestricted` also carries the
+ * Windows AV-held-handle rename retry, which a hand-rolled copy would not.
  *
- * @param {string} path  Sidecar path. The tmp file is created alongside it,
- *   so the directory must exist and be on the same filesystem.
+ * The tmp suffix is randomised so two writers racing on one sidecar — a respawn
+ * seeding it while a mode change publishes to it — cannot collide on the
+ * intermediate file.
+ *
+ * Throws on failure (after `writeFileRestricted`'s own tmp cleanup) so each
+ * caller applies its own fallback.
+ *
+ * @param {string} path  Sidecar path. The tmp file is created alongside it, so
+ *   the directory must exist.
  * @param {string} value The permission mode to publish.
  */
 export function writePermissionModeSidecarAtomic(path, value) {
-  const tmpPath = `${path}.tmp-${randomUUID()}`
-  try {
-    writeFileSync(tmpPath, value)
-    renameSync(tmpPath, path)
-  } catch (err) {
-    try { rmSync(tmpPath, { force: true }) } catch { /* ignore */ }
-    throw err
-  }
+  writeFileRestricted(path, value, { tmpSuffix: `.tmp-${randomUUID()}` })
 }

--- a/packages/server/src/utils/stale-session-dirs.js
+++ b/packages/server/src/utils/stale-session-dirs.js
@@ -1,0 +1,84 @@
+import { readdirSync, readFileSync, rmSync, statSync } from 'fs'
+
+/**
+ * Boot-time reaper for per-session scratch dirs under the OS tmpdir.
+ *
+ * A session removes its own dir in destroy(), but a CRASH leaks it forever, so
+ * a long-lived host accumulates one dir per crashed session. Introduced for
+ * `claude-tui`'s hook-sink dirs (#5323); generalised in #7337 when `claude-cli`
+ * gained a per-session dir of its own for the permission-mode sidecar. It is
+ * ONE implementation on purpose — a second hand-written copy of a
+ * "delete directories under /tmp" loop is exactly the drift `docs/false-safety-guards.md`
+ * catalogues, and this one deletes things.
+ *
+ * The ownership rule mirrors the worktree reaper's dead-pid-lock logic: each
+ * dir carries an `owner.pid` written at creation, and a dir is removed only
+ * when its owner is DEAD. A live owner — this just-booted daemon, or another
+ * chroxy on the host — keeps its dirs, so the sweep is safe to run
+ * unconditionally at boot: our own pid is alive, so we never delete a dir we
+ * are about to use.
+ */
+
+/** Default grace for a pidfile-less dir. See the race note in sweepStaleOwnedDirs. */
+export const OWNED_DIR_SWEEP_GRACE_MS = 60_000
+
+/** Filename each owner stamps inside its dir so the sweep can probe liveness. */
+export const OWNER_PID_FILE = 'owner.pid'
+
+/**
+ * @param {string} base      Parent dir to scan (e.g. `/tmp/chroxy-claude-tui`).
+ * @param {object} [opts]
+ * @param {string} [opts.prefix='s-']  Only entries with this prefix are considered.
+ * @param {number} [opts.graceMs]      Grace for pidfile-less dirs.
+ * @param {object} [opts.logger]       Logger with info/warn.
+ * @param {string} [opts.label]        Human name for the log line.
+ * @returns {{swept:number, kept:number}}
+ */
+export function sweepStaleOwnedDirs(base, { prefix = 's-', graceMs = OWNED_DIR_SWEEP_GRACE_MS, logger, label = base } = {}) {
+  let entries
+  try { entries = readdirSync(base) } catch { return { swept: 0, kept: 0 } }
+  let swept = 0
+  let kept = 0
+  for (const name of entries) {
+    if (!name.startsWith(prefix)) continue
+    const dir = `${base}/${name}`
+    let ownerPid = null
+    try {
+      const n = parseInt(readFileSync(`${dir}/${OWNER_PID_FILE}`, 'utf8').trim(), 10)
+      if (Number.isInteger(n) && n > 0) ownerPid = n
+    } catch { /* no/garbage pidfile → orphaned, subject to the grace below */ }
+    if (ownerPid !== null) {
+      let alive
+      try {
+        process.kill(ownerPid, 0) // signal 0 = existence probe
+        alive = true
+      } catch (err) {
+        // ESRCH → dead; EPERM → exists but not ours → still alive, keep it.
+        alive = err && err.code === 'EPERM'
+      }
+      if (alive) { kept++; continue }
+    } else {
+      // #5359 review — a pidfile-less dir might be another process's dir caught
+      // BETWEEN its mkdir and its owner.pid write (a cross-process race; within
+      // one process those are synchronous). Give brand-new pidfile-less dirs a
+      // grace window before reaping so we can't delete one mid-creation; a
+      // genuinely orphaned dir is older than the grace and still gets swept.
+      try {
+        // #5332: wall-clock deliberately — compared against the filesystem
+        // mtime (also wall-clock). A monotonic clock would be meaningless here.
+        if (Date.now() - statSync(dir).mtimeMs < graceMs) {
+          kept++
+          continue
+        }
+      } catch { /* stat failed (dir vanished) → fall through to rmSync (no-op) */ }
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true })
+      swept++
+    } catch (err) {
+      logger?.warn?.(`stale-dir sweep: failed to remove ${dir}: ${err.message}`)
+    }
+  }
+  if (swept > 0) logger?.info?.(`Swept ${swept} stale ${label} dir(s) from ${base} (kept ${kept} live)`)
+  return { swept, kept }
+}

--- a/packages/server/src/utils/stale-session-dirs.js
+++ b/packages/server/src/utils/stale-session-dirs.js
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, rmSync, statSync } from 'fs'
+import { chmodSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'fs'
 import { join } from 'path'
 
 /**
@@ -45,8 +45,15 @@ export function sweepStaleOwnedDirs(base, { prefix = 's-', graceMs = OWNED_DIR_S
     const dir = join(base, name)
     let ownerPid = null
     try {
-      const n = parseInt(readFileSync(join(dir, OWNER_PID_FILE), 'utf8').trim(), 10)
-      if (Number.isInteger(n) && n > 0) ownerPid = n
+      // statSync + isFile() BEFORE the read: readFileSync on a FIFO blocks
+      // forever with no timeout, so a planted `owner.pid` fifo would hang the
+      // daemon's boot sweep. A non-regular pidfile is treated as garbage, which
+      // routes to the grace-window branch below — the safe default for an orphan.
+      const pidPath = join(dir, OWNER_PID_FILE)
+      if (statSync(pidPath).isFile()) {
+        const n = parseInt(readFileSync(pidPath, 'utf8').trim(), 10)
+        if (Number.isInteger(n) && n > 0) ownerPid = n
+      }
     } catch { /* no/garbage pidfile → orphaned, subject to the grace below */ }
     if (ownerPid !== null) {
       let alive
@@ -55,7 +62,7 @@ export function sweepStaleOwnedDirs(base, { prefix = 's-', graceMs = OWNED_DIR_S
         alive = true
       } catch (err) {
         // ESRCH → dead; EPERM → exists but not ours → still alive, keep it.
-        alive = false // MUTANT: EPERM (another user's live process) treated as dead
+        alive = err && err.code === 'EPERM'
       }
       if (alive) { kept++; continue }
     } else {
@@ -82,4 +89,46 @@ export function sweepStaleOwnedDirs(base, { prefix = 's-', graceMs = OWNED_DIR_S
   }
   if (swept > 0) logger?.info?.(`Swept ${swept} stale ${label} dir(s) from ${base} (kept ${kept} live)`)
   return { swept, kept }
+}
+
+/**
+ * Create (or adopt) the shared BASE dir that per-session dirs live under, and
+ * refuse to use one an attacker could have prepared.
+ *
+ * `mkdirSync(base, { recursive: true })` returns silently when `base` already
+ * exists — INCLUDING when it is a symlink to a directory — and then creates
+ * children through it. On Linux `os.tmpdir()` is the shared `/tmp`, so another
+ * local user can pre-create `/tmp/chroxy-claude-cli` (or point it elsewhere)
+ * and then substitute a session dir whose `permission-mode` reads `auto`. The
+ * hook re-reads that file on every tool call, so the substitution decides
+ * whether tool calls are prompted. macOS is unaffected — its `$TMPDIR` is a
+ * per-user directory at 0700 — which is exactly why this needs an explicit
+ * check rather than a platform assumption.
+ *
+ * Throws when the base is a symlink, is not ours, or is group/other-writable.
+ * Callers are expected to treat that as "no sidecar" and degrade, not to fail
+ * session start.
+ *
+ * @param {string} base Directory to create or adopt.
+ * @returns {string} `base`, once it is safe to write into.
+ */
+export function ensureOwnedBaseDir(base) {
+  mkdirSync(base, { recursive: true, mode: 0o700 })
+  const st = lstatSync(base)
+  if (st.isSymbolicLink()) {
+    throw new Error(`${base} is a symlink — refusing to write session state through it`)
+  }
+  if (!st.isDirectory()) {
+    throw new Error(`${base} exists and is not a directory`)
+  }
+  // getuid is POSIX-only; on Windows there is no uid and the per-user profile
+  // tmpdir already provides the isolation this check is standing in for.
+  const uid = process.getuid?.()
+  if (uid !== undefined && st.uid !== uid) {
+    throw new Error(`${base} is owned by uid ${st.uid}, not ${uid} — refusing to adopt it`)
+  }
+  // mkdir's mode is masked by umask, and an ADOPTED dir keeps whatever mode it
+  // already had — so re-assert rather than trust the create.
+  if (st.mode & 0o077) chmodSync(base, 0o700)
+  return base
 }

--- a/packages/server/src/utils/stale-session-dirs.js
+++ b/packages/server/src/utils/stale-session-dirs.js
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync, rmSync, statSync } from 'fs'
+import { join } from 'path'
 
 /**
  * Boot-time reaper for per-session scratch dirs under the OS tmpdir.
@@ -41,10 +42,10 @@ export function sweepStaleOwnedDirs(base, { prefix = 's-', graceMs = OWNED_DIR_S
   let kept = 0
   for (const name of entries) {
     if (!name.startsWith(prefix)) continue
-    const dir = `${base}/${name}`
+    const dir = join(base, name)
     let ownerPid = null
     try {
-      const n = parseInt(readFileSync(`${dir}/${OWNER_PID_FILE}`, 'utf8').trim(), 10)
+      const n = parseInt(readFileSync(join(dir, OWNER_PID_FILE), 'utf8').trim(), 10)
       if (Number.isInteger(n) && n > 0) ownerPid = n
     } catch { /* no/garbage pidfile → orphaned, subject to the grace below */ }
     if (ownerPid !== null) {
@@ -54,7 +55,7 @@ export function sweepStaleOwnedDirs(base, { prefix = 's-', graceMs = OWNED_DIR_S
         alive = true
       } catch (err) {
         // ESRCH → dead; EPERM → exists but not ours → still alive, keep it.
-        alive = err && err.code === 'EPERM'
+        alive = false // MUTANT: EPERM (another user's live process) treated as dead
       }
       if (alive) { kept++; continue }
     } else {

--- a/packages/server/src/utils/stale-session-dirs.js
+++ b/packages/server/src/utils/stale-session-dirs.js
@@ -121,10 +121,16 @@ export function ensureOwnedBaseDir(base) {
   if (!st.isDirectory()) {
     throw new Error(`${base} exists and is not a directory`)
   }
-  // getuid is POSIX-only; on Windows there is no uid and the per-user profile
-  // tmpdir already provides the isolation this check is standing in for.
+  // Everything below is POSIX permission semantics. Windows has no uid and its
+  // `mode` bits are a synthetic approximation — `st.mode & 0o077` is non-zero
+  // for essentially every directory there, so this would chmod on every single
+  // start() to no effect. The isolation these checks stand in for is already
+  // provided on Windows by the per-user profile tmpdir that `os.tmpdir()`
+  // returns. The symlink and is-a-directory checks above DO apply everywhere.
   const uid = process.getuid?.()
-  if (uid !== undefined && st.uid !== uid) {
+  if (uid === undefined) return base
+
+  if (st.uid !== uid) {
     throw new Error(`${base} is owned by uid ${st.uid}, not ${uid} — refusing to adopt it`)
   }
   // mkdir's mode is masked by umask, and an ADOPTED dir keeps whatever mode it

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -6,7 +6,7 @@ import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync
 import { join, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import { CliSession } from '../src/cli-session.js'
 
@@ -108,6 +108,15 @@ function createMockChild() {
 // A non-file tool: `Bash` carries no PROTECTED_PATH_INPUT_FIELDS value, so the
 // permission floor can never cover it (permission-floor.js:70-71). In `auto`
 // it must short-circuit to allow; in `approve` it must route to the phone.
+// The three tests that drive the real hook spawn it via `/bin/bash`, which
+// Windows does not have. Guarded PER TEST rather than exempting the whole file
+// in scripts/lib/windows-test-set.mjs — that manifest names per-test skips as
+// the preferred fix and whole-file exemption as the blunt instrument, and the
+// other eight tests here cover the JS side of the fix and run fine on Windows.
+const SKIP_POSIX_SHELL = process.platform === 'win32'
+  ? 'spawns hooks/permission-hook.sh via /bin/bash, which Windows has no analogue for'
+  : false
+
 const BASH_PAYLOAD = JSON.stringify({
   tool_name: 'Bash',
   tool_input: { command: 'git commit -m wip' },
@@ -225,7 +234,7 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
 
   // ---- outcome, through the real hook ----------------------------------
 
-  it('after switching to auto, the real hook allows Bash with NO prompt — using the child\'s frozen env', async () => {
+  it('after switching to auto, the real hook allows Bash with NO prompt — using the child\'s frozen env', { skip: SKIP_POSIX_SHELL }, async () => {
     const mock = await startMockPermissionServer()
     try {
       const session = startedSession({ port: mock.port })
@@ -250,7 +259,7 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     }
   })
 
-  it('POSITIVE CONTROL: in approve mode the same path still raises the prompt', async () => {
+  it('POSITIVE CONTROL: in approve mode the same path still raises the prompt', { skip: SKIP_POSIX_SHELL }, async () => {
     const mock = await startMockPermissionServer({ decision: 'allow' })
     try {
       const session = startedSession({ port: mock.port })
@@ -291,9 +300,13 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     }
 
     it('reaps a dir whose owner pid is dead and keeps one whose owner is alive', () => {
-      // 2^22 is above every real pid_max on macOS/Linux, so it cannot collide
-      // with a live process and be kept for the wrong reason.
-      const orphan = makeSidecarDir(`test-orphan-${process.pid}`, 4194304)
+      // A pid that is definitely dead: run a process to completion and reuse its
+      // pid. A magic large number would be a guess — Windows pids are DWORDs, so
+      // there is no portable "above pid_max" value, and a guess that happened to
+      // be live would keep the dir and pass this test for the WRONG reason.
+      const reaped = spawnSync(process.execPath, ['-e', ''])
+      assert.ok(reaped.pid > 0, 'positive control: the throwaway process must have started')
+      const orphan = makeSidecarDir(`test-orphan-${process.pid}`, reaped.pid)
       const live = makeSidecarDir(`test-live-${process.pid}`, process.pid)
       try {
         assert.ok(existsSync(orphan) && existsSync(live), 'positive control: both dirs exist before the sweep')
@@ -390,7 +403,7 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
       'the sidecar path is a HOST path; `docker exec` cannot mount it, so forwarding the key would name a path that does not exist in the container. Add the bind mount in _startContainer() before adding the key.')
   })
 
-  it('POSITIVE CONTROL: switching back from auto to approve re-raises the prompt', async () => {
+  it('POSITIVE CONTROL: switching back from auto to approve re-raises the prompt', { skip: SKIP_POSIX_SHELL }, async () => {
     const mock = await startMockPermissionServer({ decision: 'deny' })
     try {
       const session = startedSession({ port: mock.port })

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -1,0 +1,417 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { Readable, Writable } from 'node:stream'
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, utimesSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+import { CliSession } from '../src/cli-session.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const hookPath = join(__dirname, '../hooks/permission-hook.sh')
+
+/**
+ * #7337 — `claude-cli` must resolve its permission mode through the SAME
+ * re-readable sidecar file `claude-tui` has had since #4013.
+ *
+ * The defect: `permission-hook.sh` resolves the mode as
+ *   1. CHROXY_PERMISSION_MODE_FILE (re-read on every tool call)
+ *   2. CHROXY_PERMISSION_MODE      (frozen at subprocess spawn)
+ *   3. "approve"
+ *
+ * `CliSession._buildChildEnv()` set only (2). Its ONLY way to refresh the
+ * mode was `_onPermissionModeChanged` -> `_killAndRespawn()`, which does not
+ * take effect until the OLD child has exited (up to a 10s force-kill grace).
+ * Every PreToolUse hook fired by the still-live old child in that window —
+ * and every hook fired at all if the respawn never lands — resolves the
+ * STALE mode. Observed in production as an Allow/Deny card for `Bash` on a
+ * session whose persisted state read `"permissionMode": "auto"`.
+ *
+ * Two layers here, deliberately:
+ *   - the wiring (sidecar exists, env points at it, a mode flip rewrites it
+ *     synchronously, destroy() cleans it up)
+ *   - the OUTCOME, driven through the real `permission-hook.sh` with the
+ *     exact frozen env the running child holds. That is the layer that says
+ *     "no prompt is raised", which is what the user actually reported.
+ *
+ * The `approve` positive controls are load-bearing (docs/false-safety-guards.md):
+ * a "fix" that made the hook allow unconditionally would satisfy every auto
+ * assertion below while deleting the permission system. They fail such a fix,
+ * because they require the prompt to STILL be raised in approve mode through
+ * the very same sidecar channel.
+ */
+
+// ---------------------------------------------------------------- helpers
+
+/** Async spawn of the real hook script. */
+function runHook({ input, env, timeout = 10000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('/bin/bash', [hookPath], { env })
+    let stdout = ''
+    let stderr = ''
+    let timer = null
+    let settled = false
+    const settle = (fn, arg) => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      fn(arg)
+    }
+    child.stdout.on('data', (c) => { stdout += c.toString() })
+    child.stderr.on('data', (c) => { stderr += c.toString() })
+    child.on('error', (err) => settle(reject, err))
+    child.on('close', (status, signal) => settle(resolve, { status, signal, stdout, stderr }))
+    if (timeout) timer = setTimeout(() => { child.kill('SIGKILL') }, timeout)
+    if (input != null) child.stdin.write(input)
+    child.stdin.end()
+  })
+}
+
+/**
+ * Stands in for the daemon's POST /permission endpoint. `count` is the
+ * assertion that matters: >0 means a prompt was raised on the user's device.
+ */
+async function startMockPermissionServer({ decision = 'allow' } = {}) {
+  const received = { count: 0, body: null }
+  const server = createServer((req, res) => {
+    received.count++
+    let body = ''
+    req.on('data', (chunk) => { body += chunk })
+    req.on('end', () => {
+      received.body = body
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ decision }))
+    })
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  return {
+    port: server.address().port,
+    received,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  }
+}
+
+function createMockChild() {
+  const child = new EventEmitter()
+  child.stdin = new Writable({ write(_c, _e, cb) { cb() } })
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
+  child.pid = 12345
+  child.kill = () => true
+  child.killed = false
+  return child
+}
+
+// A non-file tool: `Bash` carries no PROTECTED_PATH_INPUT_FIELDS value, so the
+// permission floor can never cover it (permission-floor.js:70-71). In `auto`
+// it must short-circuit to allow; in `approve` it must route to the phone.
+const BASH_PAYLOAD = JSON.stringify({
+  tool_name: 'Bash',
+  tool_input: { command: 'git commit -m wip' },
+  session_id: 'cli-sidecar-test',
+})
+
+describe('CliSession permission-mode sidecar (#7337)', () => {
+  let tmp
+  const created = []
+  // `claude` is a DENYLIST-mode provider in buildSpawnEnv, so the whole parent
+  // env is forwarded to the child. Running this suite from inside a chroxy
+  // session therefore inherits the OUTER daemon's CHROXY_PERMISSION_MODE_FILE
+  // and every assertion below about "the session did/didn't set it" would be
+  // reading someone else's value. Scrub it for the suite; restore in afterEach
+  // so a failing assertion can't leak the scrubbed state into the next file.
+  let ambientModeFile
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'cli-perm-sidecar-test-'))
+    ambientModeFile = process.env.CHROXY_PERMISSION_MODE_FILE
+    delete process.env.CHROXY_PERMISSION_MODE_FILE
+  })
+
+  afterEach(() => {
+    if (ambientModeFile === undefined) delete process.env.CHROXY_PERMISSION_MODE_FILE
+    else process.env.CHROXY_PERMISSION_MODE_FILE = ambientModeFile
+    for (const s of created) {
+      s._child = null
+      try { const r = s.destroy(); if (r?.catch) r.catch(() => {}) } catch { /* ignore */ }
+    }
+    created.length = 0
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  /**
+   * Real CliSession, real start() — only the subprocess spawn is stubbed, so
+   * every step the entry point takes before spawning (hook registration,
+   * sidecar creation, env construction) runs for real.
+   */
+  function startedSession(opts = {}) {
+    const session = new CliSession({
+      cwd: tmp,
+      port: 9999,
+      settingsPath: join(tmp, 'settings.json'),
+      stateFilePath: join(tmp, 'state.json'),
+      ...opts,
+    })
+    created.push(session)
+    session._spawnPersistentProcess = () => {}
+    session.start()
+    session._child = createMockChild()
+    session._processReady = true
+    return session
+  }
+
+  // ---- wiring ----------------------------------------------------------
+
+  it('start() creates a sidecar holding the initial mode and points the child env at it', () => {
+    const session = startedSession()
+
+    assert.ok(session._permissionModeFile,
+      'CliSession must create a permission-mode sidecar when permissions are enabled')
+    assert.equal(readFileSync(session._permissionModeFile, 'utf8'), 'approve',
+      'sidecar must be seeded with the session\'s initial permission mode')
+
+    const env = session._buildChildEnv()
+    assert.equal(env.CHROXY_PERMISSION_MODE_FILE, session._permissionModeFile,
+      'the child env must name the sidecar so permission-hook.sh reads it first')
+    assert.equal(env.CHROXY_PERMISSION_MODE, 'approve',
+      'the frozen env var stays as the fallback for a hook that cannot read the file')
+  })
+
+  it('setPermissionMode() rewrites the sidecar synchronously, before any respawn lands', () => {
+    const session = startedSession()
+    const sidecar = session._permissionModeFile
+    // Freeze the env exactly as the LIVE child holds it — this is the env the
+    // hook inherits, and it is not mutable from outside the process.
+    const frozenEnv = session._buildChildEnv()
+
+    assert.equal(session.setPermissionMode('auto'), true, 'mode change must be accepted')
+
+    // The old child has NOT closed, so _killAndRespawn's start() has not run.
+    assert.equal(session._respawning, true,
+      'positive control: the respawn is still in flight, so no new env has been built')
+    assert.equal(readFileSync(sidecar, 'utf8'), 'auto',
+      'the sidecar must already hold the new mode — the live child reads it on the next tool call')
+    assert.equal(frozenEnv.CHROXY_PERMISSION_MODE, 'approve',
+      'positive control: the spawn-frozen env var is still stale, which is exactly why the sidecar exists')
+  })
+
+  it('a session without permissions enabled gets no sidecar and no env var', () => {
+    const session = new CliSession({ cwd: tmp, stateFilePath: join(tmp, 'state.json') })
+    created.push(session)
+    session._spawnPersistentProcess = () => {}
+    session.start()
+
+    assert.equal(session._permissionModeFile, null, 'no port -> no sidecar')
+    assert.equal(session._buildChildEnv().CHROXY_PERMISSION_MODE_FILE, undefined,
+      'no sidecar -> the env var must be absent, not an empty string')
+    assert.equal(session.setPermissionMode('auto'), true,
+      'a mode change must still succeed without a sidecar')
+  })
+
+  it('destroy() removes the sidecar and clears the reference', () => {
+    const session = startedSession()
+    const sidecar = session._permissionModeFile
+    assert.ok(existsSync(sidecar), 'positive control: sidecar exists before destroy')
+
+    session._child = null
+    session.destroy()
+
+    assert.equal(session._permissionModeFile, null, 'reference cleared')
+    assert.equal(existsSync(sidecar), false, 'sidecar removed from /tmp')
+  })
+
+  // ---- outcome, through the real hook ----------------------------------
+
+  it('after switching to auto, the real hook allows Bash with NO prompt — using the child\'s frozen env', async () => {
+    const mock = await startMockPermissionServer()
+    try {
+      const session = startedSession({ port: mock.port })
+      // The env the running child was spawned with. Nothing can mutate it.
+      const frozenEnv = session._buildChildEnv()
+
+      session.setPermissionMode('auto')
+
+      const { status, stdout } = await runHook({
+        input: BASH_PAYLOAD,
+        env: { ...process.env, ...frozenEnv },
+      })
+
+      assert.equal(status, 0)
+      const out = JSON.parse(stdout)
+      assert.equal(out.hookSpecificOutput.permissionDecision, 'allow',
+        'auto mode must auto-allow Bash; a prompt here is #7337')
+      assert.equal(mock.received.count, 0,
+        'no POST /permission — the whole point is that the prompt is never raised')
+    } finally {
+      await mock.close()
+    }
+  })
+
+  it('POSITIVE CONTROL: in approve mode the same path still raises the prompt', async () => {
+    const mock = await startMockPermissionServer({ decision: 'allow' })
+    try {
+      const session = startedSession({ port: mock.port })
+      const frozenEnv = session._buildChildEnv()
+
+      // No mode change: the session stays in `approve`.
+      assert.equal(session.permissionMode, 'approve')
+
+      const { status, stdout } = await runHook({
+        input: BASH_PAYLOAD,
+        env: { ...process.env, ...frozenEnv },
+      })
+
+      assert.equal(status, 0)
+      assert.equal(mock.received.count, 1,
+        'approve mode MUST still route to the phone — a fix that allows unconditionally fails here')
+      assert.equal(JSON.parse(stdout).hookSpecificOutput.permissionDecision, 'allow',
+        'the decision comes from the mocked user answer, not from a bypass')
+    } finally {
+      await mock.close()
+    }
+  })
+
+  // ---- crash cleanup ---------------------------------------------------
+
+  /**
+   * destroy() removes a session's own sidecar dir, but a SIGKILL leaks it, so
+   * a long-lived host accumulates one dir per crashed session. Same leak
+   * claude-tui's sink dirs had at #5323 — and, since #7337, the same reaper.
+   */
+  describe('sweepStaleSidecarDirs', () => {
+    function makeSidecarDir(name, pid) {
+      const dir = join(CliSession.PERMISSION_MODE_SIDECAR_BASE, `s-${name}`)
+      mkdirSync(dir, { recursive: true })
+      if (pid !== undefined) writeFileSync(join(dir, 'owner.pid'), String(pid))
+      writeFileSync(join(dir, 'permission-mode'), 'approve')
+      return dir
+    }
+
+    it('reaps a dir whose owner pid is dead and keeps one whose owner is alive', () => {
+      // 2^22 is above every real pid_max on macOS/Linux, so it cannot collide
+      // with a live process and be kept for the wrong reason.
+      const orphan = makeSidecarDir(`test-orphan-${process.pid}`, 4194304)
+      const live = makeSidecarDir(`test-live-${process.pid}`, process.pid)
+      try {
+        assert.ok(existsSync(orphan) && existsSync(live), 'positive control: both dirs exist before the sweep')
+
+        CliSession.sweepStaleSidecarDirs({ info() {}, warn() {} })
+
+        assert.equal(existsSync(orphan), false, 'a dead owner\'s dir must be reaped')
+        assert.equal(existsSync(live), true,
+          'a LIVE owner\'s dir must survive — including the dir this very daemon is about to use')
+      } finally {
+        rmSync(orphan, { recursive: true, force: true })
+        rmSync(live, { recursive: true, force: true })
+      }
+    })
+  })
+
+  /**
+   * The pidfile is what makes a LIVE session's dir survive the reaper. Without
+   * it the dir falls into the pidfile-less branch, which reaps anything older
+   * than the grace window — so a session running for more than a minute would
+   * have its sidecar deleted out from under it on the next daemon boot, and
+   * `permission-hook.sh` would silently fall back to the spawn-frozen env var.
+   * That is #7337 re-created by its own cleanup, so it gets its own test:
+   * asserting the file merely EXISTS would not prove the reaper honours it.
+   */
+  it('a running session\'s sidecar dir survives the sweep even once it is older than the grace window', () => {
+    const session = startedSession()
+    const dir = join(session._permissionModeFile, '..')
+
+    assert.equal(readFileSync(join(dir, 'owner.pid'), 'utf8'), String(process.pid),
+      'the dir must be stamped with THIS process as its owner')
+
+    // Backdate well past the pidfile-less grace so the only thing that can
+    // save the dir is the liveness probe on that pidfile.
+    const longAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    utimesSync(dir, longAgo, longAgo)
+
+    CliSession.sweepStaleSidecarDirs({ info() {}, warn() {} })
+
+    assert.equal(existsSync(session._permissionModeFile), true,
+      'the live session\'s sidecar must survive — reaping it would silently drop the session back to the frozen env var')
+  })
+
+  /**
+   * A reaper nobody calls is dead code that reads as cleanup. Both boot calls
+   * are pinned here, ANCHORED to the `import(` expression that performs them so
+   * the assertion cannot be satisfied by the explanatory comment beside it.
+   */
+  it('server-cli boot sweeps BOTH providers\' stale per-session dirs', () => {
+    const src = readFileSync(join(__dirname, '../src/server-cli.js'), 'utf8')
+
+    for (const [module, method] of [
+      ['./claude-tui-session.js', 'sweepStaleSinkDirs'],
+      ['./cli-session.js', 'sweepStaleSidecarDirs'],
+    ]) {
+      const start = src.indexOf(`import('${module}')`)
+      assert.ok(start !== -1, `positive control: server-cli must lazily import ${module} at boot`)
+      // The `.then(...)` that consumes the import, and nothing after it.
+      const slice = src.slice(start, src.indexOf('.catch(', start))
+      assert.ok(slice.length > 0, `positive control: the ${module} import slice must be non-empty`)
+      assert.ok(slice.includes(`${method}(log)`),
+        `boot must actually call ${method}(log) on the ${module} import — otherwise the reaper never runs and crashed sessions leak a dir each`)
+    }
+  })
+
+  // ---- blast radius: DockerSession extends CliSession -----------------
+
+  /**
+   * `DockerSession` inherits `_buildChildEnv()` — and therefore the new
+   * `CHROXY_PERMISSION_MODE_FILE` — but forwards into the container through
+   * its own `FORWARDED_ENV_KEYS` allowlist. The allowlist is what stopped the
+   * new key from silently reaching a container where the host tmp path does
+   * not exist; this pins that it STAYS out until a bind mount makes the
+   * sidecar readable in there.
+   *
+   * Source-level and ANCHORED: docker-session.test.js drives a hand-written
+   * MIRROR of `_spawnPersistentProcess`, so an argv assertion over that mirror
+   * would keep passing with the real array changed. Slice the real array out
+   * of the real module instead, and assert only within the slice — a file-wide
+   * grep would be satisfiable by the explanatory comment sitting right below
+   * it, which names the key.
+   */
+  it('DockerSession does NOT forward CHROXY_PERMISSION_MODE_FILE into the container', () => {
+    const src = readFileSync(join(__dirname, '../src/docker-session.js'), 'utf8')
+    const start = src.indexOf('const FORWARDED_ENV_KEYS = [')
+    assert.ok(start !== -1, 'positive control: the FORWARDED_ENV_KEYS array must still exist')
+    const end = src.indexOf(']', start)
+    assert.ok(end > start, 'positive control: the array literal must be closed')
+    const arrayLiteral = src.slice(start, end + 1)
+
+    assert.match(arrayLiteral, /'CHROXY_PERMISSION_MODE'/,
+      'positive control: the slice really is the env allowlist, and it does carry the frozen mode var')
+    assert.doesNotMatch(arrayLiteral, /CHROXY_PERMISSION_MODE_FILE/,
+      'the sidecar path is a HOST path; `docker exec` cannot mount it, so forwarding the key would name a path that does not exist in the container. Add the bind mount in _startContainer() before adding the key.')
+  })
+
+  it('POSITIVE CONTROL: switching back from auto to approve re-raises the prompt', async () => {
+    const mock = await startMockPermissionServer({ decision: 'deny' })
+    try {
+      const session = startedSession({ port: mock.port })
+      const frozenEnv = session._buildChildEnv()
+
+      session.setPermissionMode('auto')
+      session._isBusy = false
+      assert.equal(session.setPermissionMode('approve'), true, 'switch back must be accepted')
+
+      const { status, stdout } = await runHook({
+        input: BASH_PAYLOAD,
+        env: { ...process.env, ...frozenEnv },
+      })
+
+      assert.equal(status, 0)
+      assert.equal(mock.received.count, 1,
+        'the sidecar must be able to RE-TIGHTEN the mode, not just loosen it')
+      assert.equal(JSON.parse(stdout).hookSpecificOutput.permissionDecision, 'deny',
+        'the user\'s deny must reach claude')
+    } finally {
+      await mock.close()
+    }
+  })
+})

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -11,6 +11,7 @@ import { createServer } from 'node:http'
 import { CliSession } from '../src/cli-session.js'
 import { ensureOwnedBaseDir } from '../src/utils/stale-session-dirs.js'
 import { writePermissionModeSidecarAtomic } from '../src/utils/permission-mode-sidecar.js'
+import { SKIP_NO_SYMLINK } from './helpers/symlink-support.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const hookPath = join(__dirname, '../hooks/permission-hook.sh')
@@ -438,7 +439,13 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
         'an ADOPTED base keeps whatever mode it had — re-assert rather than trust the create')
     })
 
-    it('refuses a base that is a symlink', () => {
+    // Gated on the PROBED capability, not on `process.platform` (#7273): the
+    // same Windows box answers differently for an interactive developer account
+    // (has SeCreateSymbolicLinkPrivilege) and for the CI service account (does
+    // not) — which is precisely how the platform-inferred version of this guard
+    // passes locally and fails in CI. Only the fixture is unbuildable there; the
+    // symlink branch of ensureOwnedBaseDir is not platform-gated and still runs.
+    it('refuses a base that is a symlink', { skip: SKIP_NO_SYMLINK }, () => {
       const real = join(tmp, 'attacker-owned')
       const link = join(tmp, 'squatted-base')
       mkdirSync(real, { recursive: true })

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -252,7 +252,7 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
       'positive control: the spawn-frozen env var is still stale, which is exactly why the sidecar exists')
   })
 
-  it('a session without permissions enabled gets no sidecar and no env var', () => {
+  it('a session without permissions enabled gets no sidecar, and an EMPTY sidecar env var', () => {
     const session = new CliSession({ cwd: tmp, stateFilePath: join(tmp, 'state.json') })
     created.push(session)
     session._spawnPersistentProcess = () => {}

--- a/packages/server/tests/cli-permission-mode-sidecar.test.js
+++ b/packages/server/tests/cli-permission-mode-sidecar.test.js
@@ -2,13 +2,15 @@ import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { Readable, Writable } from 'node:stream'
-import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, utimesSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, readFileSync, writeFileSync, existsSync, utimesSync, statSync, symlinkSync, chmodSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import { CliSession } from '../src/cli-session.js'
+import { ensureOwnedBaseDir } from '../src/utils/stale-session-dirs.js'
+import { writePermissionModeSidecarAtomic } from '../src/utils/permission-mode-sidecar.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const hookPath = join(__dirname, '../hooks/permission-hook.sh')
@@ -132,17 +134,41 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
   // and every assertion below about "the session did/didn't set it" would be
   // reading someone else's value. Scrub it for the suite; restore in afterEach
   // so a failing assertion can't leak the scrubbed state into the next file.
-  let ambientModeFile
+  //
+  // The hook env is built from `...process.env`, so EVERY CHROXY_ var the hook
+  // reads must be scrubbed — not just the one under test. CHROXY_HOST in
+  // particular redirects the hook's curl target: with it set (as it is inside a
+  // container, or when this suite runs inside a chroxy session) both `approve`
+  // positive controls fail while the auto test stays green, i.e. exactly the
+  // shape where "fix the flake by skipping it" silently unguards the auto path.
+  const AMBIENT_KEYS = [
+    'CHROXY_PERMISSION_MODE_FILE',
+    'CHROXY_PERMISSION_MODE',
+    'CHROXY_HOST',
+    'CHROXY_HOOK_HOST',
+    'CHROXY_HOOK_SECRET',
+    'CHROXY_PORT',
+    'CHROXY_SINK_DIR',
+    'CHROXY_HOOK_UNREACHABLE_DECISION',
+  ]
+  let ambient
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'cli-perm-sidecar-test-'))
-    ambientModeFile = process.env.CHROXY_PERMISSION_MODE_FILE
-    delete process.env.CHROXY_PERMISSION_MODE_FILE
+    ambient = {}
+    for (const k of AMBIENT_KEYS) {
+      ambient[k] = process.env[k]
+      delete process.env[k]
+    }
   })
 
   afterEach(() => {
-    if (ambientModeFile === undefined) delete process.env.CHROXY_PERMISSION_MODE_FILE
-    else process.env.CHROXY_PERMISSION_MODE_FILE = ambientModeFile
+    // Restored FIRST so an assertion throwing mid-test cannot leak the scrub
+    // into the next file.
+    for (const k of AMBIENT_KEYS) {
+      if (ambient?.[k] === undefined) delete process.env[k]
+      else process.env[k] = ambient[k]
+    }
     for (const s of created) {
       s._child = null
       try { const r = s.destroy(); if (r?.catch) r.catch(() => {}) } catch { /* ignore */ }
@@ -165,27 +191,45 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
       ...opts,
     })
     created.push(session)
-    session._spawnPersistentProcess = () => {}
+    // Capture the env AT SPAWN TIME rather than calling _buildChildEnv() again
+    // afterwards. `_ensurePermissionModeSidecar()` must run BEFORE the spawn —
+    // _spawnPersistentProcess reads _buildChildEnv() inline — and a post-hoc
+    // call cannot see that ordering: moving the sidecar creation to AFTER the
+    // spawn leaves the real child with no CHROXY_PERMISSION_MODE_FILE at all
+    // (i.e. #7337 reproduced) while every assertion still passes.
+    session.spawnedEnvs = []
+    session._spawnPersistentProcess = () => {
+      session.spawnedEnvs.push(session._buildChildEnv())
+    }
     session.start()
     session._child = createMockChild()
     session._processReady = true
     return session
   }
 
+  /** The env of the most recent spawn — what the live child actually holds. */
+  const lastSpawnEnv = (session) => session.spawnedEnvs[session.spawnedEnvs.length - 1]
+
   // ---- wiring ----------------------------------------------------------
 
-  it('start() creates a sidecar holding the initial mode and points the child env at it', () => {
-    const session = startedSession()
+  it('start() seeds the sidecar with the session\'s ACTUAL mode and spawns the child pointing at it', () => {
+    // NOT the default: 'approve' is BaseSession's default, so seeding with a
+    // hardcoded 'approve' would satisfy this assertion while breaking every
+    // restored session — `permissionMode` is a real constructor opt, so a
+    // session restored in `acceptEdits` would seed `approve` and prompt on
+    // every tool call until the user toggled the mode.
+    const session = startedSession({ permissionMode: 'acceptEdits' })
 
     assert.ok(session._permissionModeFile,
       'CliSession must create a permission-mode sidecar when permissions are enabled')
-    assert.equal(readFileSync(session._permissionModeFile, 'utf8'), 'approve',
-      'sidecar must be seeded with the session\'s initial permission mode')
+    assert.equal(readFileSync(session._permissionModeFile, 'utf8'), 'acceptEdits',
+      'sidecar must be seeded with the session\'s ACTUAL initial mode, not a hardcoded default')
 
-    const env = session._buildChildEnv()
+    const env = lastSpawnEnv(session)
+    assert.ok(env, 'positive control: the spawn must have happened')
     assert.equal(env.CHROXY_PERMISSION_MODE_FILE, session._permissionModeFile,
-      'the child env must name the sidecar so permission-hook.sh reads it first')
-    assert.equal(env.CHROXY_PERMISSION_MODE, 'approve',
+      'the child must be SPAWNED with the sidecar path — built before the spawn, not after')
+    assert.equal(env.CHROXY_PERMISSION_MODE, 'acceptEdits',
       'the frozen env var stays as the fallback for a hook that cannot read the file')
   })
 
@@ -214,8 +258,8 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     session.start()
 
     assert.equal(session._permissionModeFile, null, 'no port -> no sidecar')
-    assert.equal(session._buildChildEnv().CHROXY_PERMISSION_MODE_FILE, undefined,
-      'no sidecar -> the env var must be absent, not an empty string')
+    assert.equal(session._buildChildEnv().CHROXY_PERMISSION_MODE_FILE, '',
+      'no sidecar -> the key must be SET-BUT-EMPTY, not omitted. buildSpawnEnv(\'claude\') is denylist mode, so omitting it lets an ambient CHROXY_PERMISSION_MODE_FILE inherited from an outer chroxy session decide this session\'s permissions')
     assert.equal(session.setPermissionMode('auto'), true,
       'a mode change must still succeed without a sidecar')
   })
@@ -239,7 +283,7 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     try {
       const session = startedSession({ port: mock.port })
       // The env the running child was spawned with. Nothing can mutate it.
-      const frozenEnv = session._buildChildEnv()
+      const frozenEnv = lastSpawnEnv(session)
 
       session.setPermissionMode('auto')
 
@@ -263,7 +307,7 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     const mock = await startMockPermissionServer({ decision: 'allow' })
     try {
       const session = startedSession({ port: mock.port })
-      const frozenEnv = session._buildChildEnv()
+      const frozenEnv = lastSpawnEnv(session)
 
       // No mode change: the session stays in `approve`.
       assert.equal(session.permissionMode, 'approve')
@@ -283,6 +327,149 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
     }
   })
 
+  // ---- the sidecar outranks the env var, so it must never go stale --------
+
+  /**
+   * THE fail-open this whole mechanism can produce. The hook prefers the file
+   * over CHROXY_PERMISSION_MODE, so a sidecar holding a STALE, more-permissive
+   * mode beats the correct value in the freshly-spawned child's env — silently,
+   * for the rest of the session, while the daemon/state file/UI all disagree.
+   *
+   * The original code early-returned from `_ensurePermissionModeSidecar()` on a
+   * non-null path, so nothing ever re-validated the contents, and the comment
+   * claimed "the respawn below is still the eventual repair". It was not.
+   */
+  it('start() RE-SEEDS an existing sidecar, so a respawn repairs stale contents', () => {
+    const session = startedSession({ permissionMode: 'auto' })
+    const sidecar = session._permissionModeFile
+
+    // Simulate the mid-session write having failed: the session's mode moved on
+    // but the file still holds the old, more permissive value.
+    session.permissionMode = 'approve'
+    writeFileSync(sidecar, 'auto')
+
+    session.start() // the respawn
+
+    assert.equal(session._permissionModeFile, sidecar,
+      'the path must stay stable across a respawn — a still-draining old child holds it in its env')
+    assert.equal(readFileSync(sidecar, 'utf8'), 'approve',
+      'contents must be re-asserted on every start(); a stale sidecar outranks the correct env var')
+  })
+
+  it('a failed mode-change write REMOVES the sidecar rather than leaving it stale', () => {
+    const session = startedSession({ permissionMode: 'auto' })
+    const sidecar = session._permissionModeFile
+    const dir = join(sidecar, '..')
+
+    // Make the atomic write fail the way a full/read-only disk would, without
+    // touching the rest of the filesystem: drop the directory out from under it.
+    rmSync(dir, { recursive: true, force: true })
+
+    assert.equal(session.setPermissionMode('approve'), true, 'the tighten must still be accepted')
+    assert.equal(session._permissionModeFile, null,
+      'the sidecar reference must be dropped so the hook falls back to the env var, not to a stale file')
+  })
+
+  it('_ensurePermissionModeSidecar is idempotent on the path across repeated start()s', () => {
+    const session = startedSession()
+    const first = session._permissionModeFile
+    const firstDir = session._permissionModeDir
+
+    session.start()
+    session.start()
+
+    assert.equal(session._permissionModeFile, first, 'the sidecar path must not move on respawn')
+    assert.equal(session._permissionModeDir, firstDir,
+      'a new dir per respawn would leak every previous one — owner.pid names this LIVE daemon, so the sweep keeps them all')
+    assert.equal(session.spawnedEnvs.length, 3, 'positive control: three spawns really happened')
+    for (const env of session.spawnedEnvs) {
+      assert.equal(env.CHROXY_PERMISSION_MODE_FILE, first, 'every spawn must name the same sidecar')
+    }
+  })
+
+  it('destroy() removes the sidecar only AFTER the child has been killed', () => {
+    const session = startedSession({ permissionMode: 'auto' })
+    const sidecar = session._permissionModeFile
+
+    // The child stays alive for up to the 3s force-kill grace and can fire a
+    // PreToolUse hook in that window. If the sidecar is gone by then the hook
+    // falls back to the spawn-frozen CHROXY_PERMISSION_MODE — which on a
+    // session tightened since spawn (spawned `auto`, switched to `approve`) is
+    // MORE permissive than the user's current setting.
+    let sidecarAliveAtKill = null
+    const child = session._child
+    const realEnd = child.stdin.end.bind(child.stdin)
+    child.stdin.end = (...args) => { sidecarAliveAtKill = existsSync(sidecar); return realEnd(...args) }
+
+    session.destroy()
+
+    assert.equal(sidecarAliveAtKill, true,
+      'the sidecar must still be readable while the child is being killed')
+    assert.equal(existsSync(sidecar), false, 'and removed once destroy() returns')
+  })
+
+  it('the sidecar write goes through the restricted-write helper (owner-only, not a plain write)', { skip: process.platform === 'win32' }, () => {
+    const dir = join(tmp, 'atomic')
+    mkdirSync(dir, { recursive: true })
+    const path = join(dir, 'permission-mode')
+
+    writePermissionModeSidecarAtomic(path, 'auto')
+
+    assert.equal(readFileSync(path, 'utf8'), 'auto')
+    assert.equal(statSync(path).mode & 0o777, 0o600,
+      'this file decides whether a tool call is prompted — a plain writeFileSync would leave it 0644')
+    assert.deepEqual(
+      readdirSync(dir).filter((f) => f.includes('.tmp-')), [],
+      'no intermediate temp file may survive the rename',
+    )
+  })
+
+  // ---- the base dir is attacker-reachable on a shared /tmp ----------------
+
+  describe('ensureOwnedBaseDir', () => {
+    it('creates the base owner-only and re-asserts the mode on an existing dir', { skip: process.platform === 'win32' }, () => {
+      const base = join(tmp, 'base-mode')
+      ensureOwnedBaseDir(base)
+      assert.equal(statSync(base).mode & 0o777, 0o700, 'a fresh base must be 0700, not umask-dependent')
+
+      chmodSync(base, 0o777)
+      ensureOwnedBaseDir(base)
+      assert.equal(statSync(base).mode & 0o777, 0o700,
+        'an ADOPTED base keeps whatever mode it had — re-assert rather than trust the create')
+    })
+
+    it('refuses a base that is a symlink', () => {
+      const real = join(tmp, 'attacker-owned')
+      const link = join(tmp, 'squatted-base')
+      mkdirSync(real, { recursive: true })
+      symlinkSync(real, link)
+      // Positive control: plain mkdirSync would silently accept this and write
+      // straight through the link — that is the whole reason for the check.
+      mkdirSync(link, { recursive: true })
+      assert.equal(existsSync(link), true)
+
+      assert.throws(() => ensureOwnedBaseDir(link), /symlink/i,
+        'a symlinked base lets another local user substitute a permission-mode file that decides every tool call')
+    })
+
+    it('a session whose base is unusable degrades to env-var-only instead of failing start()', () => {
+      const badBase = join(tmp, 'not-a-dir')
+      writeFileSync(badBase, 'i am a file')
+      const original = Object.getOwnPropertyDescriptor(CliSession, 'PERMISSION_MODE_SIDECAR_BASE')
+      Object.defineProperty(CliSession, 'PERMISSION_MODE_SIDECAR_BASE', { get: () => badBase, configurable: true })
+      try {
+        const session = startedSession()
+        assert.equal(session._permissionModeFile, null, 'no sidecar when the base is unusable')
+        assert.equal(lastSpawnEnv(session).CHROXY_PERMISSION_MODE_FILE, '',
+          'and the key must still be set-but-empty so no ambient path leaks in')
+        assert.equal(lastSpawnEnv(session).CHROXY_PERMISSION_MODE, 'approve',
+          'the env var carries the mode instead — degraded, not broken')
+      } finally {
+        Object.defineProperty(CliSession, 'PERMISSION_MODE_SIDECAR_BASE', original)
+      }
+    })
+  })
+
   // ---- crash cleanup ---------------------------------------------------
 
   /**
@@ -298,6 +485,30 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
       writeFileSync(join(dir, 'permission-mode'), 'approve')
       return dir
     }
+
+    /**
+     * EPERM from `process.kill(pid, 0)` means the process EXISTS but belongs to
+     * another user — so it is ALIVE and its dir must be kept. Reading EPERM as
+     * "dead" would make the reaper delete a live session's dir on any host where
+     * two users run chroxy. This branch had no coverage anywhere in the repo,
+     * which is how a mutation of exactly this line survived a 923-test run.
+     */
+    it('treats EPERM (another user\'s LIVE process) as alive, not dead', () => {
+      const dir = makeSidecarDir(`test-eperm-${process.pid}`, 1)
+      const realKill = process.kill
+      process.kill = (pid, sig) => {
+        if (sig === 0 && pid === 1) { const e = new Error('EPERM'); e.code = 'EPERM'; throw e }
+        return realKill.call(process, pid, sig)
+      }
+      try {
+        CliSession.sweepStaleSidecarDirs({ info() {}, warn() {} })
+        assert.equal(existsSync(dir), true,
+          'EPERM means the process exists but is not ours — keeping the dir is the only safe read')
+      } finally {
+        process.kill = realKill
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
 
     it('reaps a dir whose owner pid is dead and keeps one whose owner is alive', () => {
       // A pid that is definitely dead: run a process to completion and reuse its
@@ -406,11 +617,17 @@ describe('CliSession permission-mode sidecar (#7337)', () => {
   it('POSITIVE CONTROL: switching back from auto to approve re-raises the prompt', { skip: SKIP_POSIX_SHELL }, async () => {
     const mock = await startMockPermissionServer({ decision: 'deny' })
     try {
-      const session = startedSession({ port: mock.port })
-      const frozenEnv = session._buildChildEnv()
+      // Spawned in `auto`, so the FROZEN env var says `auto` too. Only the
+      // sidecar can carry the tighten — if the sidecar channel were deleted
+      // entirely this test would auto-allow and fail. Starting from the default
+      // `approve` made it a duplicate of the previous test: the env var alone
+      // satisfied every assertion, so it passed on origin/main (where no
+      // sidecar exists at all) and with the channel mutated out.
+      const session = startedSession({ port: mock.port, permissionMode: 'auto' })
+      const frozenEnv = lastSpawnEnv(session)
+      assert.equal(frozenEnv.CHROXY_PERMISSION_MODE, 'auto',
+        'positive control: the frozen env var must say auto, so only the sidecar can re-tighten')
 
-      session.setPermissionMode('auto')
-      session._isBusy = false
       assert.equal(session.setPermissionMode('approve'), true, 'switch back must be accepted')
 
       const { status, stdout } = await runHook({


### PR DESCRIPTION
## The bug

With a session's permission mode set to **Auto**, a `Bash` tool call still raised an Allow/Deny card on `claude-cli` — while the daemon's persisted state for that session already read `"permissionMode": "auto"`. Not a UI/state desync: the server believed the session was in auto, and the prompt fired anyway.

`permission-hook.sh` resolves the mode in this order:

1. `CHROXY_PERMISSION_MODE_FILE` — a sidecar file, re-read on **every** tool call
2. `CHROXY_PERMISSION_MODE` — **frozen at subprocess spawn**
3. `approve`

Only `claude-tui` ever wrote (1), via the #4013 mechanism. `CliSession` set (2) alone, and its only way to refresh it was `_onPermissionModeChanged` → `_killAndRespawn()` — which does not take effect until the OLD child's `close` event fires, up to a 10s force-kill grace. Every `PreToolUse` hook that still-live child raises in the meantime resolves the **stale** mode. Two providers resolving one setting by two different mechanisms, one live and one frozen, is the defect.

This is the root of the work-loss chain in #7351: Auto mode should suppress these prompts entirely, so the prompt that later expires and silently degrades the turn should never have existed.

## The fix

`CliSession` now creates a per-session sidecar on `start()`, names it in the child env, and publishes to it on every mode change **before** the respawn — so the change reaches even the child that is already running.

The respawn stays. `--permission-mode bypassPermissions` / `plan` is **argv**, not env, so only a new process picks that up: the sidecar covers the hook, the respawn covers claude's own flag. #3729's panic-button semantics are untouched.

Three things came along because they are this change's blast radius, not scope creep:

- **The atomic write moves to `utils/permission-mode-sidecar.js`.** It is tmp-file + `rename(2)` so a concurrent hook `cat` cannot read a torn value (#5334). `ClaudeTuiSession` delegates to it instead of keeping a second hand-written copy.
- **The per-session dir leaks on a crash** — exactly as `claude-tui`'s sink dirs did at #5323. That reaper moves to `utils/stale-session-dirs.js` and both providers now sweep at boot through the one implementation. Dirs carry `owner.pid`; only DEAD owners are reaped, so a live session's sidecar is never deleted out from under it.
- **`DockerSession` deliberately does NOT forward the key.** It extends `CliSession`, so it inherits `_buildChildEnv()` — but the sidecar path is a *host* tmp path and `docker exec` cannot add a mount (mounts are fixed at `docker run`). Forwarding it would name something that does not exist in the container. A containerized CLI session therefore still needs the respawn; giving it the live channel needs a bind mount in `_startContainer()`.

## Verification

Proved red first. Of 7 initial assertions, 5 failed — including the end-to-end one, which drives the **real** `permission-hook.sh` with the exact frozen env a running child holds and asserts no `POST /permission` is made:

```
not ok 5 - after switching to auto, the real hook allows Bash with NO prompt
    no POST /permission — the whole point is that the prompt is never raised
    1 !== 0
```

The two that passed pre-fix are the `approve` **positive controls**, which is correct: they must pass before and after.

Each guard was then mutation-tested, and each goes red for its own reason (`docs/false-safety-guards.md`):

| mutation | fails |
|---|---|
| drop `CHROXY_PERMISSION_MODE_FILE` from the child env | wiring test + the end-to-end outcome test |
| drop the sidecar write in `_onPermissionModeChanged` | the synchronous-rewrite test + the outcome test |
| make the hook ignore the sidecar (`if false`) | the outcome test only — proving it really goes through the file channel |
| force the hook to `auto` (i.e. delete the permission system) | **both `approve` positive controls** |
| remove the boot sweep call | the anchored `server-cli.js` wiring test |
| remove the `owner.pid` stamp | the live-session-survives-the-reaper test |

The last one initially **survived**, which was a real coverage gap — without the stamp a session running longer than the 60s grace would have its sidecar reaped on the next daemon boot, silently dropping it back to the frozen env var and re-creating this very bug. A test was added and the mutant now goes red.

The `DockerSession` guard is source-level and **anchored** to the `FORWARDED_ENV_KEYS` array literal: `docker-session.test.js` drives a hand-written *mirror* of `_spawnPersistentProcess`, so an argv assertion over that mirror would keep passing with the real array changed, and a file-wide grep would be satisfied by the explanatory comment right below it.

## Test results

- New suite: 11/11 pass.
- `claude-tui-session` + `cli-session` + `docker-session` + `base-session` + `permission-hook-sidecar-integration` + `session-manager`: **817/817 pass**.
- All 9 custom server lints pass; `npm run lint` reports 0 errors (10 pre-existing warnings, none in changed files).
- Full local server suite is not a clean signal on this machine: the worktree lives under `~/.chroxy/`, so the `#4633` test sandbox flags unrelated `symlinkSync` calls as writes to the real user-state tree. A control run of pristine `main` in the shared checkout failed *more* tests (16 vs 7), all environmental. CI on Linux is the authoritative gate.

## Docs

`docs/architecture/reference.md` gains a row + rationale for why the key stops at the host; `docs/guides/container-isolation.md` gains the matching note.

Closes #7337